### PR TITLE
添加Live2D模型验证和回退机制

### DIFF
--- a/main_helper/omni_realtime_client.py
+++ b/main_helper/omni_realtime_client.py
@@ -1,7 +1,6 @@
 # -- coding: utf-8 --
 
 import asyncio
-from re import T
 import websockets
 import json
 import base64

--- a/templates/chara_manager.html
+++ b/templates/chara_manager.html
@@ -506,6 +506,45 @@ function showCatgirlForm(key, container) {
         }
         if (!data['档案名']) { alert('档案名为必填项'); return; }
         
+        // 验证Live2D模型文件存在性
+        if (data['live2d'] && data['live2d'].trim() !== '') {
+            try {
+                const response = await fetch(`/api/characters/catgirl/l2d/${encodeURIComponent(data['档案名'])}`);
+                const modelInfo = await response.json();
+                
+                if (!modelInfo.valid) {
+                    const confirmFallback = confirm(`猫娘"${data['档案名']}"的Live2D模型文件不存在或已损坏。\n\n当前模型路径: ${data['live2d']}\n\n是否回退到默认模型(mao_pro)？\n\n点击"确定"使用默认模型，点击"取消"保持当前设置。`);
+                    
+                    if (confirmFallback) {
+                        // 回退到默认模型
+                        const fallbackResponse = await fetch(`/api/characters/catgirl/l2d/${encodeURIComponent(data['档案名'])}`, {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({ fallback_to_default: true })
+                        });
+                        const fallbackResult = await fallbackResponse.json();
+                        
+                        if (fallbackResult.success) {
+                            alert(`已回退到默认模型: ${fallbackResult.model_path}`);
+                            // 更新表单中的live2d字段
+                            data['live2d'] = fallbackResult.model_path;
+                        } else {
+                            alert('回退到默认模型失败，请检查模型设置');
+                        }
+                    } else {
+                        // 用户选择保持当前设置，继续保存
+                        console.warn(`用户选择保持无效的Live2D模型设置: ${data['live2d']}`);
+                    }
+                }
+            } catch (error) {
+                console.error('验证Live2D模型失败:', error);
+                const continueSave = confirm(`无法验证Live2D模型文件存在性。\n\n是否继续保存？\n\n点击"确定"继续保存，点击"取消"中止保存。`);
+                if (!continueSave) {
+                    return;
+                }
+            }
+        }
+        
         try {
             console.log('提交数据:', data);
             const response = await fetch('/api/characters/catgirl' + (isNew ? '' : '/' + encodeURIComponent(key)), {
@@ -798,4 +837,4 @@ const masterSaveBtn = document.querySelector('#master-form button[type="submit"]
 if (masterSaveBtn) masterSaveBtn.classList.add('sm');
 </script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
当角色管理对应的模型文件不存在或损坏时，自动回退到默认模型mao_pro
并且应用在 index.html 上，防止主页右侧模型因为角色管理对应的模型文件不存在或损坏而无法显示tatic\live2d.js浮动按钮