### PR TITLE
Fix Live2D model switching issue by supporting user document director…

### DIFF
--- a/main_server.py
+++ b/main_server.py
@@ -769,14 +769,14 @@ async def get_current_live2d_model(catgirl_name: str = ""):
         # 如果找到了模型名称，获取模型信息
         if live2d_model_name:
             try:
-                # 检查模型是否存在
-                model_dir = os.path.join(os.path.dirname(__file__), 'static', live2d_model_name)
+                # 使用 find_model_directory 查找模型目录（支持 static 和用户文档目录）
+                model_dir, url_prefix = find_model_directory(live2d_model_name)
                 if os.path.exists(model_dir):
                     # 查找模型配置文件
                     model_files = [f for f in os.listdir(model_dir) if f.endswith('.model3.json')]
                     if model_files:
                         model_file = model_files[0]
-                        model_path = f'/static/{live2d_model_name}/{model_file}'
+                        model_path = f'{url_prefix}/{live2d_model_name}/{model_file}'
                         model_info = {
                             'name': live2d_model_name,
                             'path': model_path

--- a/static/app.js
+++ b/static/app.js
@@ -2690,11 +2690,11 @@ function init_app(){
                     if (modelData.success && modelData.model_name && modelData.model_info) {
                         console.log('[猫娘切换监听] 检测到新猫娘的 Live2D 模型:', modelData.model_name, '路径:', modelData.model_info.path);
                         
-                        // 检查 live2dManager 是否存在
+                        // 检查 live2dManager 是否存在并已初始化
                         if (!window.live2dManager) {
                             console.error('[猫娘切换监听] live2dManager 不存在，无法重新加载模型');
-                        } else if (!window.live2dManager.getCurrentModel) {
-                            console.error('[猫娘切换监听] live2dManager.getCurrentModel 不存在，无法重新加载模型');
+                        } else if (!window.live2dManager.pixi_app) {
+                            console.error('[猫娘切换监听] live2dManager 未初始化，无法重新加载模型');
                         } else {
                             const currentModel = window.live2dManager.getCurrentModel();
                             const currentModelPath = currentModel ? (currentModel.url || '') : '';


### PR DESCRIPTION

- 修复了 get_current_live2d_model API，支持在用户文档目录和 static 目录中查找模型
- 改进了前端错误检查，验证 pixi_app 初始化状态

- Fix get_current_live2d_model API to use find_model_directory for both user document and static directories
- Improve error checking in frontend to verify pixi_app initialization instead of method existence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models can now be loaded from both static directories and user-document directories.

* **Bug Fixes**
  * Improved initialization validation for model loading and reloading to ensure proper system state before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->