### PR TITLE
为角色设置页添加保存与取消按钮的显示逻辑使有修改后才显示

### DIFF
--- a/templates/chara_manager.html
+++ b/templates/chara_manager.html
@@ -273,7 +273,27 @@ function renderMaster() {
         if (["档案名", "性别", "昵称"].includes(k)) return;
         const row = document.createElement('div');
         row.className = 'field-row custom-row';
-        row.innerHTML = `<label>${k}</label><input type="text" name="${k}" value="${master[k]}"><button type="button" class="btn sm delete" style="margin-left:8px">删除设定</button>`;
+        
+        // 创建label元素
+        const label = document.createElement('label');
+        label.textContent = k;
+        row.appendChild(label);
+        
+        // 创建input元素
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.name = k;
+        input.value = master[k];
+        row.appendChild(input);
+        
+        // 创建删除按钮
+        const deleteBtn = document.createElement('button');
+        deleteBtn.type = 'button';
+        deleteBtn.className = 'btn sm delete';
+        deleteBtn.style.marginLeft = '8px';
+        deleteBtn.textContent = '删除设定';
+        row.appendChild(deleteBtn);
+        
         form.insertBefore(row, form.querySelector('div[style]'));
     });
     
@@ -308,6 +328,9 @@ function renderMaster() {
         const deleteButtons = masterFormEl.querySelectorAll('.btn.delete');
         deleteButtons.forEach(btn => {
             btn.addEventListener('click', showMasterActionButtons);
+            btn.addEventListener('click', function() {
+                deleteMasterField(this);
+            });
         });
         
         // 为新增设定按钮添加点击事件监听


### PR DESCRIPTION
1.修复默认会显示保存与取消按钮的问题
2.修复进阶设定保存或取消设置后会自动收起的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advanced settings now remember whether they're expanded or collapsed between sessions.
  * Save and cancel buttons automatically appear when form changes are made, hiding when not needed.

* **Style**
  * Project title updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->