### PR TITLE
fix: sync focusModeEnabled when returning from l2d page

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2059,6 +2059,27 @@ function init_app(){
     window.addEventListener('live2d-settings-click', () => {
         console.log('设置按钮被点击');
         
+        // 每次打开设置弹出框时，同步 window 中的最新值到局部变量
+        if (typeof window.focusModeEnabled !== 'undefined') {
+            focusModeEnabled = window.focusModeEnabled;
+        }
+        if (typeof window.proactiveChatEnabled !== 'undefined') {
+            proactiveChatEnabled = window.proactiveChatEnabled;
+        }
+        
+        // 如果已经初始化过，更新开关状态
+        if (settingsPopupInitialized) {
+            const proactiveChatToggle = document.getElementById('proactive-chat-toggle-l2d');
+            const focusModeToggle = document.getElementById('focus-mode-toggle-l2d');
+            if (proactiveChatToggle) {
+                proactiveChatToggle.checked = proactiveChatEnabled;
+            }
+            if (focusModeToggle) {
+                focusModeToggle.checked = focusModeEnabled;
+            }
+            return; // 已初始化，直接返回
+        }
+        
         // 仅第一次点击时填充内容
         if (!settingsPopupInitialized) {
             const popup = document.getElementById('live2d-popup-settings');
@@ -2162,6 +2183,14 @@ function init_app(){
                 // 设置初始状态
                 const proactiveChatToggle = document.getElementById('proactive-chat-toggle-l2d');
                 const focusModeToggle = document.getElementById('focus-mode-toggle-l2d');
+                
+                // 从 window 同步最新值到局部变量（防止从 l2d 页面返回时值丢失）
+                if (typeof window.proactiveChatEnabled !== 'undefined') {
+                    proactiveChatEnabled = window.proactiveChatEnabled;
+                }
+                if (typeof window.focusModeEnabled !== 'undefined') {
+                    focusModeEnabled = window.focusModeEnabled;
+                }
                 
                 if (proactiveChatToggle) {
                     proactiveChatToggle.checked = proactiveChatEnabled;
@@ -2282,7 +2311,17 @@ function init_app(){
     window.addEventListener('live2d-return-click', () => {
         console.log('[App] 请她回来按钮被点击，开始恢复所有界面');
         
-        // 第一步：清除"请她离开"标志
+        // 第一步：同步 window 中的设置值到局部变量（防止从 l2d 页面返回时值丢失）
+        if (typeof window.focusModeEnabled !== 'undefined') {
+            focusModeEnabled = window.focusModeEnabled;
+            console.log('[App] 同步 focusModeEnabled:', focusModeEnabled);
+        }
+        if (typeof window.proactiveChatEnabled !== 'undefined') {
+            proactiveChatEnabled = window.proactiveChatEnabled;
+            console.log('[App] 同步 proactiveChatEnabled:', proactiveChatEnabled);
+        }
+        
+        // 第二步：清除"请她离开"标志
         if (window.live2dManager) {
             window.live2dManager._goodbyeClicked = false;
         }
@@ -2290,14 +2329,14 @@ function init_app(){
             window.live2d._goodbyeClicked = false;
         }
         
-        // 第二步：隐藏独立的"请她回来"按钮
+        // 第三步：隐藏独立的"请她回来"按钮
         const returnButtonContainer = document.getElementById('live2d-return-button-container');
         if (returnButtonContainer) {
             returnButtonContainer.style.display = 'none';
             returnButtonContainer.style.pointerEvents = 'none';
         }
         
-        // 第三步：恢复live2d容器（移除minimized类）
+        // 第四步：恢复live2d容器（移除minimized类）
         const live2dContainer = document.getElementById('live2d-container');
         if (live2dContainer) {
             console.log('[App] 移除minimized类前，容器类列表:', live2dContainer.classList.toString());
@@ -2314,7 +2353,7 @@ function init_app(){
             live2dContainer.style.removeProperty('opacity');
         }
         
-        // 第四步：恢复锁按钮
+        // 第五步：恢复锁按钮
         const lockIcon = document.getElementById('live2d-lock-icon');
         if (lockIcon) {
             lockIcon.style.display = 'block';
@@ -2322,7 +2361,7 @@ function init_app(){
             lockIcon.style.removeProperty('opacity');
         }
         
-        // 第五步：恢复浮动按钮系统（使用 !important 强制显示，覆盖之前的隐藏样式）
+        // 第六步：恢复浮动按钮系统（使用 !important 强制显示，覆盖之前的隐藏样式）
         const floatingButtons = document.getElementById('live2d-floating-buttons');
         if (floatingButtons) {
             // 先清除所有可能的隐藏样式
@@ -2347,7 +2386,7 @@ function init_app(){
             }
         }
         
-        // 第六步：恢复对话区
+        // 第七步：恢复对话区
         const chatContainerEl = document.getElementById('chat-container');
         const toggleChatBtn = document.getElementById('toggle-chat-btn');
         if (chatContainerEl && chatContainerEl.classList.contains('minimized')) {
@@ -2357,7 +2396,7 @@ function init_app(){
             }
         }
         
-        // 第七步：触发原有的返回逻辑
+        // 第八步：触发原有的返回逻辑
         if (returnSessionButton) {
             setTimeout(() => {
                 console.log('[App] 触发returnSessionButton点击');


### PR DESCRIPTION
fix: sync focusModeEnabled when returning from l2d page

- Sync window.focusModeEnabled and window.proactiveChatEnabled to local variables when initializing settings popup
- Sync values when 'return' button is clicked to prevent value loss
- Update toggle states when settings popup is reopened after initialization"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Live2D settings synchronization to ensure UI toggles accurately reflect the current state of focus mode and proactive chat settings when opening the settings popup.
  * Enhanced settings consistency across page navigations by reinforcing synchronization between settings values and their UI representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->