### PR TITLE
fix: Improve microphone button state management and prevent duplicate…

### DIFF
--- a/static/live2d.js
+++ b/static/live2d.js
@@ -1576,8 +1576,34 @@ class Live2DManager {
                 
                 btn.addEventListener('click', (e) => {
                     e.stopPropagation();
+                    
+                    // 对于麦克风按钮，在计算状态之前就检查 micButton 的状态
+                    if (config.id === 'mic') {
+                        const micButton = document.getElementById('micButton');
+                        if (micButton && micButton.classList.contains('active')) {
+                            // 检查是否正在录音：如果 isRecording 为 true，说明已经启动成功，允许点击退出
+                            // 如果 isRecording 为 false，说明正在启动过程中，阻止点击
+                            const isRecording = window.isRecording || false; // 从全局获取 isRecording 状态
+                            
+                            if (!isRecording) {
+                                // 正在启动过程中，强制保持激活状态，不切换
+                                // 确保浮动按钮状态与 micButton 同步
+                                if (btn.dataset.active !== 'true') {
+                                    btn.dataset.active = 'true';
+                                    if (imgOff && imgOn) {
+                                        imgOff.style.opacity = '0';
+                                        imgOn.style.opacity = '1';
+                                    }
+                                }
+                                return; // 直接返回，不执行任何状态切换或事件触发
+                            }
+                            // 如果 isRecording 为 true，说明已经启动成功，允许继续执行（可以退出）
+                        }
+                    }
+                    
                     const isActive = btn.dataset.active === 'true';
                     const newActive = !isActive;
+                    
                     btn.dataset.active = newActive.toString();
                     
                     // 更新图标状态


### PR DESCRIPTION
完成目标：
当用户点击麦克风按键时，麦克风按键保持激活状态，在语音模式启动成功或失败之前的所有点击均无效，按键也保持激活状态，等到成功或失败之后，用户才能对麦克风按键进行操作。

1. 修复重复点击问题
- 添加 active 类检查，防止在语音系统启动过程中重复点击麦克风按钮
- 点击后立即禁用按钮，直到连接成功或失败

2. 优化按钮状态同步
- 新增 syncFloatingMicButtonState() 函数，统一管理浮动按钮与主按钮的状态同步
- 确保启动过程中浮动按钮状态与主按钮保持一致
- 启动失败时正确恢复所有按钮状态

3. 完善超时处理逻辑
- 优化连接超时机制，防止超时定时器重复触发
- 超时时间设置为 10 秒
- 确保所有错误路径都能正确清理定时器和状态变量

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved voice recording reliability with enhanced timeout management during session startup.
  * Prevents accidental microphone deactivation during the recording initialization phase.
  * Enhanced error handling during microphone initialization with proper UI state recovery.
  * Improved synchronization between main and floating microphone controls to prevent state mismatches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->