### PR TITLE
feat: Add Apple Silicon (arm64) build support

### DIFF
--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -1,6 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 import sys
 import os
+import platform
 from PyInstaller.utils.hooks import collect_all
 from PyInstaller.building.build_main import Tree
 
@@ -57,8 +58,11 @@ def add_data(src, dest):
     if '*' in src:
         # 处理通配符
         files = glob.glob(src_path)
-        for f in files:
-            datas.append((f, dest))
+        if files:
+            for f in files:
+                datas.append((f, dest))
+        else:
+            print(f"[Build] Warning: No files matched pattern '{src}', skipping")
     elif os.path.exists(src_path):
         datas.append((src_path, dest))
     else:
@@ -303,7 +307,7 @@ exe = EXE(
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=True if sys.platform == 'darwin' else False,  # macOS 需要开启
-    target_arch='arm64' if sys.platform == 'darwin' else None,  # Apple Silicon 架构
+    target_arch=platform.machine() if sys.platform == 'darwin' else None,  # 自动检测 macOS 架构 (arm64/x86_64)
     codesign_identity=None,
     entitlements_file=None,
     icon='assets/icon.ico' if sys.platform == 'win32' else None,  # macOS 暂不使用图标

--- a/specs/monitor_build.spec
+++ b/specs/monitor_build.spec
@@ -6,6 +6,7 @@ Monitor 独立打包配置文件
 
 import os
 import sys
+import platform
 from PyInstaller.utils.hooks import collect_data_files
 
 # 获取 spec 文件所在目录和项目根目录
@@ -128,7 +129,7 @@ exe = EXE(
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=True if sys.platform == 'darwin' else False,  # macOS 需要开启
-    target_arch='arm64' if sys.platform == 'darwin' else None,  # Apple Silicon 架构
+    target_arch=platform.machine() if sys.platform == 'darwin' else None,  # 自动检测 macOS 架构 (arm64/x86_64)
     codesign_identity=None,
     entitlements_file=None,
     icon='assets/icon.ico' if sys.platform == 'win32' else None,  # macOS 暂不使用图标


### PR DESCRIPTION
- Update launcher.spec and monitor_build.spec for macOS arm64 architecture
- Add proper path handling for spec files in subdirectories
- Support both macOS (dylib) and Windows (dll) Steam libraries
- Set target_arch to arm64 for Apple Silicon builds
- Enable argv_emulation for macOS compatibility
- Successfully compiled arm64 executable on M5 chip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 构建流程改为以项目根为基准的绝对路径，临时切换并恢复工作目录，增加构建时调试输出。
  * 资源收集改为通配符友好且容错的注册方式，统一收集静态资产与顶层文件。
  * 构建配置平台感知化：在 macOS 启用 argv_emulation 并按架构处理，图标/版本嵌入按平台条件化，移除默认运行时钩子列表。

* **Bug Fixes**
  * 修复跨平台库/二进制选择与路径解析导致的构建不稳定问题。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->