### PR TITLE
chore: load .env and make server bind/ports configurable

### DIFF
--- a/main_server.py
+++ b/main_server.py
@@ -675,8 +675,8 @@ if __name__ == "__main__":
     logger.info(f"Serving static files from: {os.path.abspath('static')}")
     logger.info(f"Serving index.html from: {os.path.abspath('templates/index.html')}")
     logger.info(f"Server mode: {'DEV' if DEV_MODE else 'PROD'}; bind host: {MAIN_SERVER_HOST}; port: {MAIN_SERVER_PORT}")
-    display_host = "127.0.0.1" if MAIN_SERVER_HOST == "0.0.0.0" else MAIN_SERVER_HOST
-    logger.info(f"Access UI at: http://{display_host}:{MAIN_SERVER_PORT} (or your network IP:{MAIN_SERVER_PORT})")
+    display_host = MAIN_SERVER_HOST if MAIN_SERVER_HOST != "0.0.0.0" else "localhost/your-network-ip"
+    logger.info(f"Access UI at: http://{display_host}:{MAIN_SERVER_PORT}")
     logger.info("-----------------------------")
 
     # 使用统一的速率限制日志过滤器

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "N.E.K.O"
 version = "1.0.0"
 description = "N.E.K.O. Desktop"
 readme = "README.MD"
-requires-python = ">=3.11,<3.12"
+requires-python = ">=3.11,<3.13"
 dependencies = [
   "fastapi~=0.115.9",
   "websockets~=15.0.1",


### PR DESCRIPTION
- load .env without external deps (env vars win)\n- add DEV_MODE + MAIN_SERVER_HOST, env-driven ports\n- uvicorn binds to MAIN_SERVER_HOST; logs reflect mode\n- set requires-python to <3.12 (uv.lock left uncommitted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持通过 .env 文件配置环境变量，无需外部依赖
  * 添加开发/生产模式自动检测，根据环境自动调整服务器行为
  * 服务器主机和端口配置现已动态化，支持环境变量驱动

* **改进**
  * 优化服务器启动日志，现在显示运行模式和绑定地址

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->