### PR TITLE
[React] feat(webapp): add i18n loading and language switch

### DIFF
--- a/frontend/src/web/i18n.ts
+++ b/frontend/src/web/i18n.ts
@@ -1,0 +1,94 @@
+import type { TFunction } from "@project_neko/components";
+
+type SupportedLang = "zh-CN" | "en";
+
+function normalizeLang(raw?: string | null): SupportedLang {
+  if (!raw) return "zh-CN";
+  if (raw === "en") return "en";
+  if (raw === "zh-CN") return "zh-CN";
+  const langCode = raw.split("-")[0];
+  if (langCode === "en") return "en";
+  if (langCode === "zh") return "zh-CN";
+  return "zh-CN";
+}
+
+function getByPath(obj: unknown, keyPath: string): unknown {
+  if (!obj || typeof obj !== "object") return undefined;
+  const parts = keyPath.split(".").filter(Boolean);
+  let cur: any = obj;
+  for (const p of parts) {
+    if (!cur || typeof cur !== "object") return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+function interpolate(template: string, params?: Record<string, unknown>) {
+  if (!params) return template;
+  return template.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_m, key) => {
+    const v = (params as any)[key];
+    if (v === null || v === undefined) return "";
+    return String(v);
+  });
+}
+
+async function fetchLocaleJson(staticBaseUrl: string, lang: SupportedLang): Promise<unknown> {
+  const base = staticBaseUrl.replace(/\/+$/, "");
+  const url = `${base}/static/locales/${lang}.json`;
+  // 语言包是静态资源；跨域时不应携带 cookies，否则会触发 CORS 的 credentials 约束
+  const res = await fetch(url, { credentials: "omit" });
+  if (!res.ok) {
+    throw new Error(`Failed to load locale: ${lang}, status=${res.status}`);
+  }
+  return await res.json();
+}
+
+function createT(resources: unknown): TFunction {
+  return (key: string, params?: Record<string, unknown>) => {
+    try {
+      const v = getByPath(resources, key);
+      if (typeof v === "string") return interpolate(v, params);
+      return key;
+    } catch (_e) {
+      return key;
+    }
+  };
+}
+
+export async function initWebappI18n(staticBaseUrl: string): Promise<{
+  t: TFunction;
+  language: SupportedLang;
+  source: "window.t" | "static-locales" | "fallback";
+}> {
+  // 如果旧页面/宿主已经提供了 window.t，则直接复用（保持一致）
+  try {
+    const w: any = typeof window !== "undefined" ? (window as any) : undefined;
+    if (typeof w?.t === "function") {
+      const lang = normalizeLang(w?.i18n?.language || localStorage.getItem("i18nextLng") || navigator.language);
+      return { t: w.t as TFunction, language: lang, source: "window.t" };
+    }
+  } catch (_e) {
+    // ignore
+  }
+
+  const lang = normalizeLang(
+    (typeof localStorage !== "undefined" ? localStorage.getItem("i18nextLng") : null) ||
+      (typeof navigator !== "undefined" ? navigator.language : null)
+  );
+
+  try {
+    const resources = await fetchLocaleJson(staticBaseUrl, lang);
+    return { t: createT(resources), language: lang, source: "static-locales" };
+  } catch (e) {
+    // 回退到中文
+    try {
+      const resources = await fetchLocaleJson(staticBaseUrl, "zh-CN");
+      return { t: createT(resources), language: "zh-CN", source: "static-locales" };
+    } catch (_e2) {
+      console.warn("[webapp] i18n 加载失败，使用 fallback t()：", e);
+      return { t: (k: string) => k, language: lang, source: "fallback" };
+    }
+  }
+}
+
+

--- a/frontend/src/web/main.tsx
+++ b/frontend/src/web/main.tsx
@@ -1,6 +1,21 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { I18nProvider } from "@project_neko/components";
+import type { TFunction } from "@project_neko/components";
+import { initWebappI18n } from "./i18n";
+
+const trimTrailingSlash = (url?: string) => (url ? url.replace(/\/+$/, "") : "");
+const API_BASE = trimTrailingSlash(
+  (import.meta as any).env?.VITE_API_BASE_URL ||
+    (typeof window !== "undefined" ? (window as any).API_BASE_URL : "") ||
+    "http://localhost:48911"
+);
+const STATIC_BASE = trimTrailingSlash(
+  (import.meta as any).env?.VITE_STATIC_SERVER_URL ||
+    (typeof window !== "undefined" ? (window as any).STATIC_SERVER_URL : "") ||
+    API_BASE
+);
 
 const rootEl = document.getElementById("root");
 
@@ -10,7 +25,61 @@ if (!rootEl) {
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>
 );
+
+function Root() {
+  const [t, setT] = React.useState<TFunction>(() => (key: string) => key);
+  const [language, setLanguage] = React.useState<"zh-CN" | "en">("zh-CN");
+
+  React.useEffect(() => {
+    let cancelled = false;
+    initWebappI18n(STATIC_BASE).then(({ t, language, source }) => {
+      if (cancelled) return;
+      console.log("[webapp] i18n 已就绪:", { language, source, staticBaseUrl: STATIC_BASE });
+      setLanguage(language);
+      setT(() => t);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChangeLanguage = React.useCallback(async (lng: "zh-CN" | "en") => {
+    try {
+      const w: any = typeof window !== "undefined" ? (window as any) : undefined;
+      if (typeof w?.changeLanguage === "function") {
+        await w.changeLanguage(lng);
+      } else if (typeof localStorage !== "undefined") {
+        localStorage.setItem("i18nextLng", lng);
+      }
+    } catch (e) {
+      console.warn("[webapp] 切换语言失败，将继续尝试加载语言包：", e);
+      try {
+        localStorage.setItem("i18nextLng", lng);
+      } catch (_e2) {
+        // ignore
+      }
+    }
+
+    const { t, language, source } = await initWebappI18n(STATIC_BASE);
+    console.log("[webapp] i18n 已切换:", { language, source });
+    setLanguage(language);
+    setT(() => t);
+
+    // 在非 i18next 宿主场景下，也广播一次，方便其它逻辑监听
+    try {
+      window.dispatchEvent(new CustomEvent("localechange"));
+    } catch (_e) {
+      // ignore
+    }
+  }, []);
+
+  return (
+    <I18nProvider t={t}>
+      <App language={language} onChangeLanguage={handleChangeLanguage} />
+    </I18nProvider>
+  );
+}
 

--- a/frontend/src/web/styles.css
+++ b/frontend/src/web/styles.css
@@ -30,6 +30,38 @@ body {
   color: #475569;
 }
 
+.app__headerRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.app__headerText {
+  min-width: 0;
+}
+
+.langSwitch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.langSwitch__label {
+  font-size: 14px;
+  color: #475569;
+}
+
+.langSwitch__select {
+  height: 32px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0 10px;
+  background: #fff;
+  color: #0f172a;
+}
+
 .app__content {
   margin-top: 32px;
 }
@@ -46,5 +78,12 @@ ol {
   margin: 0;
   padding-left: 20px;
   color: #334155;
+}
+
+.card__actions {
+  margin-top: 16px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -25,6 +25,49 @@
     "nextPage": "Next Page",
     "selectFile": "Select File"
   },
+  "webapp": {
+    "header": {
+      "title": "N.E.K.O Web App",
+      "subtitle": "Single-page app, no router / no SSR"
+    },
+    "language": {
+      "label": "Language",
+      "zhCN": "中文",
+      "en": "English"
+    },
+    "card": {
+      "title": "Get started",
+      "step1": "Mount your components or entry points here.",
+      "step2Prefix": "For API calls, build on top of ",
+      "step2Suffix": ".",
+      "step3Prefix": "Build output goes to ",
+      "step3Suffix": " (for dev/debug). Reference it from templates as needed."
+    },
+    "actions": {
+      "requestPageConfig": "Request page_config",
+      "showToast": "Show StatusToast",
+      "modalAlert": "Modal Alert",
+      "modalConfirm": "Modal Confirm",
+      "modalPrompt": "Modal Prompt"
+    },
+    "toast": {
+      "apiSuccess": "API call succeeded (demo toast)",
+      "confirmed": "Confirmed",
+      "hello": "Hi, {{name}}!"
+    },
+    "modal": {
+      "alertTitle": "Notice",
+      "alertMessage": "This is an alert dialog",
+      "confirmTitle": "Confirm",
+      "confirmMessage": "Are you sure you want to proceed?",
+      "promptMessage": "Enter a nickname:",
+      "okText": "OK",
+      "cancelText": "Cancel"
+    },
+    "errors": {
+      "requestFailed": "Request failed"
+    }
+  },
   "steam": {
     "characterCards": "Character Cards",
     "characterCardName": "Nickname",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -25,6 +25,49 @@
     "nextPage": "下一页",
     "selectFile": "选择文件"
   },
+  "webapp": {
+    "header": {
+      "title": "N.E.K.O 前端主页",
+      "subtitle": "单页应用，无路由 / 无 SSR"
+    },
+    "language": {
+      "label": "语言",
+      "zhCN": "中文",
+      "en": "English"
+    },
+    "card": {
+      "title": "开始使用",
+      "step1": "在此处挂载你的组件或业务入口。",
+      "step2Prefix": "如需调用接口，可在 ",
+      "step2Suffix": " 基础上封装请求。",
+      "step3Prefix": "构建产物输出到 ",
+      "step3Suffix": "（用于开发/调试），模板按需引用即可。"
+    },
+    "actions": {
+      "requestPageConfig": "请求 page_config",
+      "showToast": "显示 StatusToast",
+      "modalAlert": "Modal Alert",
+      "modalConfirm": "Modal Confirm",
+      "modalPrompt": "Modal Prompt"
+    },
+    "toast": {
+      "apiSuccess": "接口调用成功（示例 toast）",
+      "confirmed": "确认已执行",
+      "hello": "你好，{{name}}!"
+    },
+    "modal": {
+      "alertTitle": "提示",
+      "alertMessage": "这是一条 Alert 弹窗",
+      "confirmTitle": "确认",
+      "confirmMessage": "确认要执行该操作吗？",
+      "promptMessage": "请输入昵称：",
+      "okText": "好的",
+      "cancelText": "再想想"
+    },
+    "errors": {
+      "requestFailed": "请求失败"
+    }
+  },
   "steam": {
     "characterCards": "角色卡",
     "characterCardName": "昵称",


### PR DESCRIPTION
Load locale JSON from STATIC_BASE, inject I18nProvider, log active language, and add a language dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了国际化支持，应用现可在简体中文和英文之间切换。
  * 在应用头部新增语言切换下拉菜单，用户可快速调整显示语言。
  * 所有界面文本现已支持多语言显示，包括标题、步骤说明和操作按钮。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->