### PR TITLE
fix(拖拽): 禁用弹窗元素的pointer-events避免拖拽冲突

### DIFF
--- a/static/live2d-ui-drag.js
+++ b/static/live2d-ui-drag.js
@@ -45,6 +45,20 @@
             wrapper.setAttribute('data-prev-pointer-events', currentValue);
             wrapper.style.pointerEvents = 'none';
         });
+        
+        // 禁用所有弹窗元素的 pointer-events，避免拖拽时与弹窗冲突
+        const popups = document.querySelectorAll('.live2d-popup, [id^="live2d-popup-"]');
+        popups.forEach(popup => {
+            if (popup) {
+                // 如果已经保存过，说明正在拖拽中，跳过
+                if (popup.hasAttribute('data-prev-pointer-events')) {
+                    return;
+                }
+                const currentValue = popup.style.pointerEvents || '';
+                popup.setAttribute('data-prev-pointer-events', currentValue);
+                popup.style.pointerEvents = 'none';
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
在拖拽时添加对弹窗元素的pointer-events处理，防止与拖拽操作产生冲突

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **修复**
  * 改进了拖拽操作期间弹出窗口元素的交互处理，确保拖拽操作不会被弹出元素干扰。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->