### PR TITLE
fix: implement motion file playback with 3-tier fallback and character creation validation

### DIFF
--- a/static/live2d-emotion.js
+++ b/static/live2d-emotion.js
@@ -389,16 +389,26 @@ Live2DManager.prototype.playMotion = async function(emotion) {
                     motionManager.definitions[emotion] = [];
                 }
 
-                // 将MotionSpec注入到motionManager的definitions中（而不是motionData）
-                const injectedIndex = motionManager.definitions[emotion].length;
-                const motionSpec = { File: choice.File };
-                motionManager.definitions[emotion].push(motionSpec);
+                // 检查是否已存在相同File的MotionSpec，避免无限增长
+                let injectedIndex = motionManager.definitions[emotion].findIndex(
+                    spec => spec && spec.File === choice.File
+                );
+
+                if (injectedIndex === -1) {
+                    // 不存在，创建新的MotionSpec并添加
+                    injectedIndex = motionManager.definitions[emotion].length;
+                    const motionSpec = { File: choice.File };
+                    motionManager.definitions[emotion].push(motionSpec);
+                    console.log(`添加新的MotionSpec到definitions: ${choice.File} [index=${injectedIndex}]`);
+                } else {
+                    console.log(`复用已存在的MotionSpec: ${choice.File} [index=${injectedIndex}]`);
+                }
 
                 // 使用 motionManager 的 startMotion 方法，使用注入后的索引
                 if (motionManager.startMotion) {
                     const motion = await motionManager.startMotion(
                         emotion,
-                        injectedIndex, // 使用注入后的索引
+                        injectedIndex, // 使用注入后的索引（可能是新的或复用的）
                         3  // priority (高优先级)
                     );
 


### PR DESCRIPTION
Motion文件播放修复总结
问题
之前的代码只播放简单的参数动画（如点头、摇头），完全忽略了你在情感配置页面精心选择的 motion 文件。

解决方案
重写了 playMotion 函数，实现三层回退机制来播放你配置的 motion 文件：

方法1: motion() API (优先)
使用 Live2D 官方的 model.motion(emotion) 方法
要求 FileReferences.Motions 中有对应配置
最标准的播放方式

方法2: startMotion() API (备用)
直接访问底层的 motionManager.startMotion()
手动加载 motion 文件并播放
更底层但更灵活

方法3: 简单动作 (兜底)
如果前两种方法都失败
播放简单的参数动画（点头、摇头等）
确保至少有动作效果

技术细节
✅ 优先使用 EmotionMapping 配置（你在页面上设置的）
✅ 回退到 FileReferences.Motions（兼容旧版本）
✅ 自动获取 motion 文件的持续时间
✅ 动作结束后自动清理，但保留表情

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进动作播放稳定性，修复并减少因动作选择、验证或加载失败导致的播放中断，保留回退播放以确保连续性。
  * 增强计时器与超时清理，避免旧动作定时器与新动作竞态导致异常。

* **改进**
  * 支持多来源动作随机选择与更严格验证，提升动作多样性与可用性。
  * 引入分阶段播放流程、时长感知计时回退和更详尽的播放日志，便于诊断与恢复。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->