### PR TITLE
解决辅助API无法自由选择模型供应商的问题

### DIFF
--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -866,6 +866,11 @@ function updateAssistApiRecommendation() {
             freeOption.textContent = window.t ? window.t('api.freeVersionOnlyWhenCoreFree') : '免费版（仅核心API为免费版时可用）';
         }
 
+        // 如果辅助API当前是免费版，自动切换为默认的阿里（qwen）
+        if (selectedAssistApi === 'free') {
+            assistApiSelect.value = 'qwen';
+        }
+
         // 启用所有辅助API输入框（统一处理，启用时清理显示为免费版的占位值）
         setAssistApiInputsDisabled(false);
 
@@ -878,35 +883,6 @@ function updateAssistApiRecommendation() {
             'silicon': 'assistApiKeyInputSilicon',
             'gemini': 'assistApiKeyInputGemini'
         };
-
-        // 检查辅助API是否有对应的API Key
-        function hasAssistApiKey(assistApi) {
-            if (assistApi === 'free') return false;
-            const inputId = assistApiKeyInputMap[assistApi];
-            if (!inputId) return false;
-            const input = document.getElementById(inputId);
-            return input && input.value && input.value.trim() !== '';
-        }
-
-        // 如果当前 assist 是免费版或没有对应的 Key，自动跟随 core
-        let newAssistApi = selectedAssistApi;
-        if (selectedAssistApi === 'free' || !hasAssistApiKey(selectedAssistApi)) {
-            // 检查 core API 是否在 assist 选项中可用
-            const coreOption = assistApiSelect.querySelector(`option[value="${selectedCoreApi}"]`);
-            if (coreOption && !coreOption.disabled) {
-                newAssistApi = selectedCoreApi;
-                if (selectedAssistApi !== 'free') {
-                    console.log(`[API Settings] 辅助API ${selectedAssistApi} 没有Key，自动跟随核心API: ${selectedCoreApi}`);
-                }
-            } else {
-                // core 不在 assist 选项中，默认使用 qwen
-                newAssistApi = 'qwen';
-            }
-        }
-        
-        if (newAssistApi !== selectedAssistApi) {
-            assistApiSelect.value = newAssistApi;
-        }
 
         switch (selectedCoreApi) {
             case 'qwen':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 错误修复
  * 当辅助API选为"免费"时，现在会自动切换至"通义千问"

## 功能改进
  * 辅助API选择不再自动跟随核心API的可用状态进行更新
  * 用户选定的辅助API将保持选择，不会因密钥缺失而自动变更

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->