### PR TITLE
fix:voice disconnect errors recovery in onclose

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -622,4 +622,3 @@ async def list_gptsovits_voices(request: Request):
     except Exception as e:
         logger.error(f"获取 GPT-SoVITS 语音列表失败: {e}")
         return {"success": False, "error": str(e)}
-


### PR DESCRIPTION
1. WebSocket 断开时前端 UI 不恢复
socket.onclose 里新增了完整的状态清理：重置语音录制状态、清理音频资源和 AudioContext、重置 isMicStarting/isSwitchingMode 标志、清理 session Promise 和超时定时器、恢复按钮和文本输入区到可用状态。

end_session 里重置 is_starting_session，防止断网重连后 start_session 被误判为重复请求而忽略。

2. 后端 session 静默死亡时前端无感知
 disconnected_by_server() 在 cleanup() 之前发送 session_ended_by_server 消息给前端。

 新增 send_session_ended_by_server() 方法。

 前端新增 session_ended_by_server 消息处理器，收到后重置 isTextSessionActive 和所有 UI 状态。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加服务器会话终止通知，前端可在服务器主动断开时收到并恢复到空闲状态。

* **改进**
  * 强化断线与会话终止的统一清理流程：会清除挂起的会话承诺、超时、音频队列并停止录音与音频资源（包括音频上下文/工作单元），重置模式标志与界面控件，使 UI 始终回到安全的空闲状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->