### PR TITLE
fix: resolve voice mode button sync and session state issues on auto mic close

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2515,11 +2515,14 @@ function init_app() {
             clearTimeout(window.sessionTimeoutId);
             window.sessionTimeoutId = null;
         }
+        if (sessionStartedRejecter) {
+            try {
+                sessionStartedRejecter(new Error('Session aborted'));
+            } catch (e) { /* ignore already handled */ }
+            sessionStartedRejecter = null;
+        }
         if (sessionStartedResolver) {
             sessionStartedResolver = null;
-        }
-        if (sessionStartedRejecter) {
-            sessionStartedRejecter = null;
         }
 
         // 停止录音时移除录音状态类
@@ -3007,7 +3010,7 @@ function init_app() {
 
     // 同步浮动麦克风按钮状态的辅助函数
     function syncFloatingMicButtonState(isActive) {
-        // 优先通过 manager 对象访问（更可靠）
+        // 更新所有存在的 manager 的按钮状态
         const managers = [window.live2dManager, window.vrmManager];
 
         for (const manager of managers) {
@@ -3019,7 +3022,6 @@ function init_app() {
                         imgOff.style.opacity = isActive ? '0' : '1';
                         imgOn.style.opacity = isActive ? '1' : '0';
                     }
-                    return;
                 }
             }
         }
@@ -3027,22 +3029,18 @@ function init_app() {
 
     // 同步浮动屏幕分享按钮状态的辅助函数
     function syncFloatingScreenButtonState(isActive) {
-        // 优先通过 manager 对象访问（更可靠）
-        const managers = [
-            { obj: window.live2dManager },
-            { obj: window.vrmManager }
-        ];
+        // 更新所有存在的 manager 的按钮状态
+        const managers = [window.live2dManager, window.vrmManager];
 
-        for (const { obj } of managers) {
-            if (obj && obj._floatingButtons && obj._floatingButtons.screen) {
-                const { button, imgOff, imgOn } = obj._floatingButtons.screen;
+        for (const manager of managers) {
+            if (manager && manager._floatingButtons && manager._floatingButtons.screen) {
+                const { button, imgOff, imgOn } = manager._floatingButtons.screen;
                 if (button) {
                     button.dataset.active = isActive ? 'true' : 'false';
                     if (imgOff && imgOn) {
                         imgOff.style.opacity = isActive ? '0' : '1';
                         imgOn.style.opacity = isActive ? '1' : '0';
                     }
-                    return;
                 }
             }
         }


### PR DESCRIPTION
## 问题描述

当语音模式下麦克风检测不到声音自动关闭后，存在以下问题：
1. 浮动麦克风按钮状态不同步，按钮没有变暗
2. 屏幕中央"语音系统准备中"提示一直滚动不消失
3. 返回文本对话模式后，发送文本猫娘不回复
4. 再次进入语音模式后，后台能检测到语音但前端对话框不显示

## 修复内容

### 1. 修复会话结束信号
- 将 `stopRecording()` 中的 `pause_session` 改为 `end_session`
- 确保后端正确结束会话而不是保持在"准备中"状态

### 2. 完善 `stopMicCapture()` 状态清理
- 添加 `hideVoicePreparingToast()` 隐藏残留的准备提示
- 清理 `sessionStartedResolver` 和 `sessionStartedRejecter`
- 清理 `window.sessionTimeoutId` 超时定时器

### 3. 完善 `stopRecording()` 状态清理
- 重置 AI 回复相关的队列和缓冲区
- 重置 `_realisticGeminiQueue`、`_realisticGeminiBuffer`、`_geminiTurnFullText`
- 递增 `_realisticGeminiVersion` 确保新会话使用新版本
- 重置 `currentTurnGeminiBubbles` 和 `_isProcessingRealisticQueue`

### 4. 简化 `syncFloatingMicButtonState` 和 `syncFloatingScreenButtonState`
- 将 4 种冗余的按钮同步方法简化为统一的循环处理
- 移除不可靠的 DOM 查询方式，只使用 manager 对象引用
- 代码减少 63 行

## 测试

- ✅ 语音模式麦克风自动关闭后按钮正确变暗
- ✅ "语音系统准备中"提示正常消失
- ✅ 返回文本模式后对话正常
- ✅ 再次进入语音模式后对话正常显示


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了麦克风自动关闭时的状态清理和同步，确保按钮状态正确更新
  * 优化了录音停止时的会话清理流程，防止残留状态
  * 增强了不同虚拟形象模型切换时的状态管理和 UI 同步
  
* **改进**
  * 提升了 WebSocket 连接稳定性和会话管理的可靠性，减少重连过程中的竞态条件
  * 支持更好的多管理器协调，确保 VRM 和 Live2D 模型的无缝切换

<!-- end of auto-generated comment: release notes by coderabbit.ai -->