### PR TITLE
解决角色管理中API设置入口按钮文本闪烁的问题

### DIFF
--- a/templates/chara_manager.html
+++ b/templates/chara_manager.html
@@ -32,8 +32,8 @@
                     </div>
                 </div>
         
-                <button type="button" class="btn sm api-key-btn" id="api-key-settings-btn" aria-label="API Key 设置">
-                    <img src="/static/icons/key.png" alt="" class="key-icon"> <span data-i18n="character.apiKeySettings">API Key 设置</span>
+                <button type="button" class="btn sm api-key-btn" id="api-key-settings-btn" aria-label="API Key">
+                    <img src="/static/icons/key.png" alt="" class="key-icon"> <span data-i18n="character.apiKeySettings">API Key</span>
                 </button>
             </div>
             <div class="master-card">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 更新了 API Key 按钮的显示文本和无障碍标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->