### PR TITLE
fix(docs): change VitePress base to '/' for custom domain

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -400,11 +400,12 @@ export default defineConfig({
   description: 'Developer documentation for the AI companion metaverse platform',
 
   head: [
-    ['link', { rel: 'icon', href: '/N.E.K.O./favicon.ico' }],
+    ['link', { rel: 'icon', href: '/favicon.ico' }],
   ],
 
-  // Deploy to GitHub Pages at https://project-n-e-k-o.github.io/N.E.K.O/
-  base: '/N.E.K.O/',
+  // Custom domain: project-neko.online → base must be '/'
+  // (was '/N.E.K.O/' for github.io subdirectory, but custom domain serves at root)
+  base: '/',
 
   lastUpdated: true,
   cleanUrls: true,


### PR DESCRIPTION
The site uses custom domain project-neko.online, so base must be '/' instead of '/N.E.K.O/'. The previous '/N.E.K.O/' base caused all CSS/JS assets to 404 since the custom domain serves at root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **配置调整**
  * 更新了网站部署配置，现已全面支持自定义域名部署方式
  * 优化了网站资源加载路径，确保网站图标和页面元素能正确加载
  * 完善了网站基础配置以适应新的部署环境

<!-- end of auto-generated comment: release notes by coderabbit.ai -->