### PR TITLE
解决VRM的悬浮按钮UI无法显示开关状态的问题

### DIFF
--- a/static/vrm-ui-popup.js
+++ b/static/vrm-ui-popup.js
@@ -994,16 +994,9 @@ VRMManager.prototype._createSettingsToggleItem = function (toggle) {
     toggleItem.setAttribute('role', 'switch');
     toggleItem.setAttribute('tabIndex', '0');
     toggleItem.setAttribute('aria-checked', 'false');
+    toggleItem.setAttribute('aria-label', toggle.label);
     Object.assign(toggleItem.style, {
-        display: 'flex',
-        alignItems: 'center',
-        gap: '8px',
-        padding: '8px 12px',
-        cursor: 'pointer',
-        borderRadius: '6px',
-        transition: 'background 0.2s ease',
-        fontSize: '13px',
-        whiteSpace: 'nowrap'
+        padding: '8px 12px'
     });
 
     const checkbox = document.createElement('input');
@@ -1038,33 +1031,11 @@ VRMManager.prototype._createSettingsToggleItem = function (toggle) {
     indicator.className = 'vrm-toggle-indicator';
     indicator.setAttribute('role', 'presentation');
     indicator.setAttribute('aria-hidden', 'true');
-    Object.assign(indicator.style, {
-        width: '20px',
-        height: '20px',
-        borderRadius: '50%',
-        border: '2px solid var(--neko-popup-indicator-border, #ccc)',
-        backgroundColor: 'transparent',
-        cursor: 'pointer',
-        flexShrink: '0',
-        transition: 'all 0.2s ease',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center'
-    });
 
     const checkmark = document.createElement('div');
     checkmark.className = 'vrm-toggle-checkmark';
     checkmark.setAttribute('aria-hidden', 'true');
     checkmark.innerHTML = '✓';
-    Object.assign(checkmark.style, {
-        color: '#fff',
-        fontSize: '13px',
-        fontWeight: 'bold',
-        opacity: '0',
-        transition: 'opacity 0.2s ease',
-        pointerEvents: 'none',
-        userSelect: 'none'
-    });
     indicator.appendChild(checkmark);
 
     const updateIndicatorStyle = (checked) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 新增弹窗色彩主题变量与切换项样式，完善指示器、悬停与聚焦显示。
  * 为每个切换项添加唯一标识、隐藏输入样式及初始状态加载，统一样式/禁用/标题更新流程。
  * 键盘与鼠标交互经防抖统一走一条路径，增强 aria 与 i18n 支持及无障碍细节（含装饰性元素的 aria-hidden）。
  * 弹窗显示时同步全局设置并稳定保存与相关副作用流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->