### PR TITLE
Feat/ci cross platform build - manually copy playwright_browsers on macOS

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -376,6 +376,12 @@ jobs:
           if [ -d "dist/launcher.dist" ]; then
             mv dist/launcher.dist dist/Xiao8
           fi
+          # macOS: playwright_browsers was excluded from Nuitka (xattr bug with
+          # spaces in .app paths), copy it manually into the output directory
+          if [[ "$RUNNER_OS" == "macOS" && -d "playwright_browsers" ]]; then
+            cp -R playwright_browsers dist/Xiao8/playwright_browsers
+            echo "Copied playwright_browsers into dist/Xiao8/"
+          fi
           echo "=== Build output ==="
           ls -la dist/Xiao8/ || echo "dist/Xiao8 not found!"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了macOS上的构建流程，确保Playwright浏览器相关资源正确包含在输出中。

* **Chores**
  * 优化了跨平台构建配置的条件处理逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->