### PR TITLE
chore: set timeout-minutes to 300 for Nuitka build, 180 for Electron

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -87,7 +87,7 @@ jobs:
             output_binary: projectneko_server
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: 300
     steps:
       - name: Checkout backend repo
         uses: actions/checkout@v4
@@ -424,6 +424,7 @@ jobs:
             artifact_name: desktop-linux-x64
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
     steps:
       - name: Checkout Electron frontend
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

此版本不包含面向终端用户的功能更改或改进。进行的修改为内部基础设施优化，不影响应用程序功能或用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->