### PR TITLE
Persist Steam workshop path as startup fallback

### DIFF
--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -347,7 +347,7 @@ def _resolve_workshop_search_dir() -> str:
     """
     获取创意工坊搜索目录
     
-    优先级: user_mod_folder(配置) > Steam运行时路径 > default_workshop_folder(配置) > 默认workshop目录
+    优先级: user_mod_folder(配置) > Steam运行时路径 > user_workshop_folder(缓存文件) > default_workshop_folder(配置) > 默认workshop目录
     """
     from utils.config_manager import get_workshop_path
     workshop_path = get_workshop_path()


### PR DESCRIPTION
Cache the resolved Steam workshop directory from successful Steam discovery so non-Steam startup flows can still resolve workshop assets reliably.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 现在会保存用户选择的 Steam Workshop 文件夹路径，便于后续快速访问

* **改进**
  * 优化了工作室路径的自动解析逻辑，提升识别准确度
  * 增强了配置管理的线程安全性，提高并发场景下的稳定性
  * 调整日志记录级别以改进诊断效率

<!-- end of auto-generated comment: release notes by coderabbit.ai -->