### PR TITLE
fix(vision): handle edge cases for macOS getDisplayMedia prompts

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2158,7 +2158,11 @@ function init_app() {
                         }
                     }
                     // 重启主动视觉（如果之前已启用）
+                    // 先检查并重新获取屏幕流（切换麦克风期间流可能已丢失）
                     if (shouldRestartProactiveVision) {
+                        if (typeof acquireProactiveVisionStream === 'function') {
+                            await acquireProactiveVisionStream();
+                        }
                         startProactiveVisionDuringSpeech();
                     }
                 }
@@ -3438,6 +3442,11 @@ function init_app() {
             // 启动语音期间的主动视觉定时（如果已开启主动视觉）
             try {
                 if (proactiveVisionEnabled) {
+                    // 刷新页面后 screenCaptureStream 会丢失，需要在用户手势上下文中重新获取
+                    // 录音按钮点击是一个有效的用户手势上下文
+                    if (typeof acquireProactiveVisionStream === 'function') {
+                        await acquireProactiveVisionStream();
+                    }
                     startProactiveVisionDuringSpeech();
                 }
             } catch (e) {
@@ -8872,9 +8881,16 @@ function init_app() {
                 video.remove();
             }
 
-            // 如果缓存流提取帧失败，或无缓存流，走 captureProactiveChatScreenshot（内含后端兜底）
+            // 如果缓存流提取帧失败，或无缓存流
             if (!dataUrl) {
-                dataUrl = await captureProactiveChatScreenshot();
+                if (isWindowsOS()) {
+                    // Windows 不需要用户手势即可调用 getDisplayMedia，可以走完整的截图流程
+                    dataUrl = await captureProactiveChatScreenshot();
+                } else {
+                    // macOS/Linux: 定时器（非用户手势）上下文中调用 getDisplayMedia 会反复弹窗
+                    // 仅走后端 pyautogui 截图兜底
+                    dataUrl = await fetchBackendScreenshot();
+                }
             }
 
             if (dataUrl && socket && socket.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
- Acquire screen stream before restarting proactive vision on mic switch, preventing getDisplayMedia calls from non-user-gesture context
- Acquire screen stream on record button click after page refresh
- Avoid calling getDisplayMedia in timer context on macOS/Linux; only use backend pyautogui fallback. Windows is unaffected as it doesn't require user gesture for getDisplayMedia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 增强了屏幕捕捉功能在系统重启和初始化时的稳定性
* 针对不同操作系统优化了屏幕截图处理流程
* 改进了麦克风切换后的视觉功能恢复机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->