### PR TITLE
fix: correct sys.path level for plugin module imports

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1298,7 +1298,9 @@ def load_plugins_from_toml(
     logger.info("Loading plugins from {}", plugin_config_root)
     
     # 设置 Python 路径，确保能够导入插件模块
-    project_root = plugin_config_root.parent.parent.resolve()
+    # plugin_config_root = .../bin/plugin/plugins
+    # 我们需要 .../bin/plugin 作为 sys.path，这样 import plugins.xxx 才能正确解析
+    project_root = plugin_config_root.parent.resolve()
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
         logger.info("Added project root to sys.path: {}", project_root)


### PR DESCRIPTION
Remove an extra .parent call that caused sys.path to point one directory level too high. This fixes the issue where import plugins.xxx could not find the module at plugins/xxx/__init__.py.

Before: plugin_config_root.parent.parent → too high
After:  plugin_config_root.parent → correct level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **Bug 修复**
  * 优化了插件加载路径的解析机制，提升了插件系统的兼容性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->