### PR TITLE
猫娘名称修改时可以同步修改记忆名称；防止猫娘名字中出现“.”符号导致无法保存记忆；优化主人与猫娘档案键值显示

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -56,6 +56,8 @@ def _validate_profile_name(name: str) -> str | None:
         return '档案名为必填项'
     if '/' in name or '\\' in name:
         return '档案名不能包含路径分隔符(/或\\)'
+    if '.' in name:
+        return '档案名不能包含点号(.)'
     if _profile_name_units(name) > PROFILE_NAME_MAX_UNITS:
         return f'档案名长度不能超过{PROFILE_NAME_MAX_UNITS}单位（ASCII=1，其他=2；PROFILE_NAME_MAX_UNITS={PROFILE_NAME_MAX_UNITS}）'
     return None

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -53,6 +53,10 @@ def validate_catgirl_name(name: str) -> tuple[bool, str]:
     if os.path.sep in name or '/' in name or '\\' in name or '..' in name:
         return False, "名称不能包含路径分隔符或目录遍历字符"
     
+    # Reject dots to prevent issues with memory file creation
+    if '.' in name:
+        return False, "名称不能包含点号(.)"
+    
     return True, ""
 
 
@@ -361,6 +365,7 @@ async def update_catgirl_name(request: Request):
                             f"{old_name}:",     # 纯冒号
                             f"{old_name}->",    # 箭头
                             f"[{old_name}]",    # 方括号
+                            f"{old_name} | ",   # 摘要中的角色标识格式
                         ]
                         
                         for pattern in patterns:

--- a/static/css/chara_manager.css
+++ b/static/css/chara_manager.css
@@ -354,13 +354,18 @@ body .container-header {
 .field-row-wrapper label {
     min-width: 110px;
     /* 增加最小宽度以适应英文 */
+    max-width: 160px;
+    /* 最大显示8个中文字符宽度 */
     font-weight: 700;
     color: #40C5F1;
     font-size: 1.2rem;
     flex-shrink: 0;
-    display: flex;
-    align-items: center;
+    display: block;
     line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: default;
 }
 
 .field-row-wrapper label span[style*="color:red"] {

--- a/static/js/chara_manager.js
+++ b/static/js/chara_manager.js
@@ -137,6 +137,16 @@ function getFieldLabel(fieldName) {
     return fieldName;
 }
 
+const FIELD_LABEL_MAX_UNITS = 16;
+
+function setFieldLabelText(labelEl, text) {
+    labelEl.textContent = text;
+    const units = profileNameCountUnits(text);
+    if (units > FIELD_LABEL_MAX_UNITS) {
+        labelEl.title = text;
+    }
+}
+
 function tOrFallback(key, fallback, params) {
     if (window.t && typeof window.t === 'function') {
         try {
@@ -149,11 +159,15 @@ function tOrFallback(key, fallback, params) {
 }
 
 const PROFILE_NAME_CONTAINS_SLASH_KEY = 'character.profileNameContainsSlash';
+const PROFILE_NAME_CONTAINS_DOT_KEY = 'character.profileNameContainsDot';
 
 function translateBackendError(errorMessage) {
     if (!errorMessage || typeof errorMessage !== 'string') return errorMessage;
     if (errorMessage.includes('路径分隔符') || errorMessage.includes('不能包含"/"')) {
         return tOrFallback(PROFILE_NAME_CONTAINS_SLASH_KEY, errorMessage);
+    }
+    if (errorMessage.includes('点号') || errorMessage.includes('不能包含"."')) {
+        return tOrFallback(PROFILE_NAME_CONTAINS_DOT_KEY, errorMessage);
     }
     if (errorMessage.includes('档案名为必填项')) {
         return tOrFallback('character.profileNameRequired', errorMessage);
@@ -204,6 +218,14 @@ function flashProfileNameContainsSlash(inputEl) {
     if (!inputEl) return;
 
     const msg = tOrFallback(PROFILE_NAME_CONTAINS_SLASH_KEY, '档案名不能包含路径分隔符');
+
+    flashProfileNameError(inputEl, msg);
+}
+
+function flashProfileNameContainsDot(inputEl) {
+    if (!inputEl) return;
+
+    const msg = tOrFallback(PROFILE_NAME_CONTAINS_DOT_KEY, '档案名不能包含点号(.)');
 
     flashProfileNameError(inputEl, msg);
 }
@@ -286,6 +308,21 @@ function attachProfileNameLimiter(inputEl) {
                 try { inputEl.setSelectionRange(newPos, newPos); } catch (e) { /* ignore */ }
             }
             flashProfileNameContainsSlash(inputEl);
+            before = inputEl.value;
+        }
+        
+        // 检查是否包含点号，移除并显示警告
+        if (before.includes('.')) {
+            const caret = (typeof inputEl.selectionStart === 'number') ? inputEl.selectionStart : null;
+            inputEl.value = before.replace(/\./g, '');
+            if (caret !== null) {
+                // 计算光标之前被移除的点号数量
+                const beforeCaret = before.substring(0, caret);
+                const removedCount = (beforeCaret.match(/\./g) || []).length;
+                const newPos = Math.max(0, caret - removedCount);
+                try { inputEl.setSelectionRange(newPos, newPos); } catch (e) { /* ignore */ }
+            }
+            flashProfileNameContainsDot(inputEl);
             before = inputEl.value;
         }
         
@@ -686,7 +723,7 @@ function renderMaster() {
 
         // 创建label元素（在wrapper中）
         const label = document.createElement('label');
-        label.textContent = getFieldLabel(k);
+        setFieldLabelText(label, getFieldLabel(k));
         wrapper.appendChild(label);
 
         // 创建field-row（胶囊框）
@@ -790,7 +827,7 @@ function setupMasterFormListeners() {
             wrapper.className = 'field-row-wrapper custom-row';
 
             const labelEl = document.createElement('label');
-            labelEl.textContent = key;
+            setFieldLabelText(labelEl, key);
             wrapper.appendChild(labelEl);
 
             const row = document.createElement('div');
@@ -1387,7 +1424,7 @@ function showCatgirlForm(key, container) {
             const deleteFieldText = (window.t && typeof window.t === 'function') ? `<img src="/static/icons/delete.png" alt="" class="delete-icon"> <span data-i18n="character.deleteField">${window.t('character.deleteField')}</span>` : '<img src="/static/icons/delete.png" alt="" class="delete-icon"> 删除设定';
 
             const labelEl = document.createElement('label');
-            labelEl.textContent = getFieldLabel(k);
+            setFieldLabelText(labelEl, getFieldLabel(k));
             wrapper.appendChild(labelEl);
 
             const fieldRow = document.createElement('div');
@@ -1730,7 +1767,7 @@ function showCatgirlForm(key, container) {
         const deleteFieldText = (window.t && typeof window.t === 'function') ? `<img src="/static/icons/delete.png" alt="" class="delete-icon"> <span data-i18n="character.deleteField">${window.t('character.deleteField')}</span>` : '<img src="/static/icons/delete.png" alt="" class="delete-icon"> 删除设定';
 
         const labelEl = document.createElement('label');
-        labelEl.textContent = key;
+        setFieldLabelText(labelEl, key);
         wrapper.appendChild(labelEl);
 
         const fieldRow = document.createElement('div');
@@ -2145,6 +2182,7 @@ function showCatgirlForm(key, container) {
 window.renameMaster = async function (oldName) {
     let _renameMasterDidOverLimit = false;
     let _renameMasterContainsSlash = false;
+    let _renameMasterContainsDot = false;
     const newName = await showPrompt(
         window.t ? window.t('character.enterNewProfileName') : '请输入新的主人档案名',
         oldName,
@@ -2158,13 +2196,17 @@ window.renameMaster = async function (oldName) {
                 const trimmed = String(v ?? '').trim();
                 _renameMasterDidOverLimit = profileNameCountUnits(trimmed) > PROFILE_NAME_MAX_UNITS;
                 _renameMasterContainsSlash = trimmed.includes('/') || trimmed.includes('\\');
-                return profileNameTrimToMaxUnits(trimmed.replace(/[/\\]/g, ''), PROFILE_NAME_MAX_UNITS);
+                _renameMasterContainsDot = trimmed.includes('.');
+                return profileNameTrimToMaxUnits(trimmed.replace(/[/\\.]/g, ''), PROFILE_NAME_MAX_UNITS);
             },
             validator: (v) => {
                 const trimmed = String(v ?? '').trim();
                 if (!trimmed) return tOrFallback(NEW_PROFILE_NAME_REQUIRED_KEY, '新档案名不能为空');
                 if (profileNameCountUnits(trimmed) > PROFILE_NAME_MAX_UNITS) {
                     return tOrFallback(PROFILE_NAME_TOO_LONG_KEY, '档案名过长');
+                }
+                if (trimmed.includes('.')) {
+                    return tOrFallback(PROFILE_NAME_CONTAINS_DOT_KEY, '档案名不能包含点号(.)');
                 }
                 return '';
             },
@@ -2176,6 +2218,10 @@ window.renameMaster = async function (oldName) {
                 if (_renameMasterContainsSlash) {
                     _renameMasterContainsSlash = false;
                     flashProfileNameContainsSlash(inputEl);
+                }
+                if (_renameMasterContainsDot) {
+                    _renameMasterContainsDot = false;
+                    flashProfileNameContainsDot(inputEl);
                 }
             }
         }
@@ -2219,6 +2265,7 @@ window.renameCatgirl = async function (oldName) {
 
     let _renameCatgirlDidOverLimit = false;
     let _renameCatgirlContainsSlash = false;
+    let _renameCatgirlContainsDot = false;
     const newName = await showPrompt(
         window.t ? window.t('character.enterNewProfileName') : '请输入新的猫娘档案名',
         oldName,
@@ -2232,13 +2279,17 @@ window.renameCatgirl = async function (oldName) {
                 const trimmed = String(v ?? '').trim();
                 _renameCatgirlDidOverLimit = profileNameCountUnits(trimmed) > PROFILE_NAME_MAX_UNITS;
                 _renameCatgirlContainsSlash = trimmed.includes('/') || trimmed.includes('\\');
-                return profileNameTrimToMaxUnits(trimmed.replace(/[/\\]/g, ''), PROFILE_NAME_MAX_UNITS);
+                _renameCatgirlContainsDot = trimmed.includes('.');
+                return profileNameTrimToMaxUnits(trimmed.replace(/[/\\.]/g, ''), PROFILE_NAME_MAX_UNITS);
             },
             validator: (v) => {
                 const trimmed = String(v ?? '').trim();
                 if (!trimmed) return tOrFallback(NEW_PROFILE_NAME_REQUIRED_KEY, '新档案名不能为空');
                 if (profileNameCountUnits(trimmed) > PROFILE_NAME_MAX_UNITS) {
                     return tOrFallback(PROFILE_NAME_TOO_LONG_KEY, '档案名过长');
+                }
+                if (trimmed.includes('.')) {
+                    return tOrFallback(PROFILE_NAME_CONTAINS_DOT_KEY, '档案名不能包含点号(.)');
                 }
                 return '';
             },
@@ -2250,6 +2301,10 @@ window.renameCatgirl = async function (oldName) {
                 if (_renameCatgirlContainsSlash) {
                     _renameCatgirlContainsSlash = false;
                     flashProfileNameContainsSlash(inputEl);
+                }
+                if (_renameCatgirlContainsDot) {
+                    _renameCatgirlContainsDot = false;
+                    flashProfileNameContainsDot(inputEl);
                 }
             }
         }

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1166,6 +1166,7 @@
         "profileNameMaxHint": "Max 20 characters",
         "profileNameTooLong": "Profile name is too long",
         "profileNameContainsSlash": "Profile name cannot contain path separators (/ or \\)",
+        "profileNameContainsDot": "Profile name cannot contain dots (.)",
         "newProfileNameRequired": "New profile name cannot be empty",
         "newProfileNameTooLong": "Profile name is too long",
         "required": "*",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1166,6 +1166,7 @@
         "profileNameMaxHint": "最大20文字",
         "profileNameTooLong": "プロフィール名が長すぎます",
         "profileNameContainsSlash": "プロフィール名にパス区切り文字(/または\\)を含めることはできません",
+        "profileNameContainsDot": "プロフィール名にドット(.)を含めることはできません",
         "newProfileNameRequired": "新しいプロフィール名は空にできません",
         "newProfileNameTooLong": "プロフィール名が長すぎます",
         "required": "*",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1166,6 +1166,7 @@
         "profileNameMaxHint": "최대 20자",
         "profileNameTooLong": "프로필 이름이 너무 깁니다.",
         "profileNameContainsSlash": "프로필 이름에 경로 구분 기호(/ 또는 \\)를 포함할 수 없습니다",
+        "profileNameContainsDot": "프로필 이름에 점(.)을 포함할 수 없습니다",
         "newProfileNameRequired": "새 프로필 이름은 비워둘 수 없습니다.",
         "newProfileNameTooLong": "프로필 이름이 너무 깁니다.",
         "required": "*",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1166,6 +1166,7 @@
         "profileNameMaxHint": "Макс. 20 символов",
         "profileNameTooLong": "Имя профиля слишком длинное",
         "profileNameContainsSlash": "Имя профиля не может содержать разделители пути (/ или \\)",
+        "profileNameContainsDot": "Имя профиля не может содержать точки (.)",
         "newProfileNameRequired": "Новое имя профиля не может быть пустым",
         "newProfileNameTooLong": "Имя профиля слишком длинное",
         "required": "*",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1166,6 +1166,7 @@
         "profileNameMaxHint": "最多20个字符",
         "profileNameTooLong": "档案名过长",
         "profileNameContainsSlash": "档案名不能包含路径分隔符(/或\\)",
+        "profileNameContainsDot": "档案名不能包含点号(.)",
         "newProfileNameRequired": "新档案名不能为空",
         "newProfileNameTooLong": "档案名过长",
         "required": "*",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1166,6 +1166,7 @@
         "profileNameMaxHint": "最多20個字符",
         "profileNameTooLong": "檔案名過長",
         "profileNameContainsSlash": "檔案名不能包含路徑分隔符(/或\\)",
+        "profileNameContainsDot": "檔案名不能包含點號(.)",
         "newProfileNameRequired": "新檔案名不能為空",
         "newProfileNameTooLong": "檔案名過長",
         "required": "*",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 档案名称现已禁止使用点号(.)，防止无效字符输入。
  * 优化了长标签文本的显示，超长内容自动截断并显示为省略号。
  * 增强了档案名称验证提示，用户输入点号时将收到实时警告。

* **本地化**
  * 新增英文、日文、韩文、俄文及繁体中文的点号验证提示消息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->