### PR TITLE
exe模式吞时间戳与蝴蝶结问题

### DIFF
--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -548,9 +548,19 @@
             // 场景 B: 气泡已存在，执行平滑追加
             else if (window.currentGeminiMessage && window.currentGeminiMessage.isConnected) {
                 var fullText = window._geminiTurnFullText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
-                var timePrefix = window.currentGeminiMessage.textContent.match(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /) || [""];
-                window.currentGeminiMessage.textContent = timePrefix[0] + fullText;
 
+
+                // var timePrefix = window.currentGeminiMessage.textContent.match(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /) || [""];
+                // window.currentGeminiMessage.textContent = timePrefix[0] + fullText;
+                var timePrefix = window.currentGeminiMessage.textContent.match(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /);
+                if (!timePrefix) {
+                    timePrefix = "[" + getCurrentTimeString() + "] \u{1F380} ";
+                } else {
+                    timePrefix = timePrefix[0];
+                }
+                window.currentGeminiMessage.textContent = timePrefix + fullText;
+
+                
                 // 触发字幕检测逻辑（防抖）
                 if (S.subtitleCheckDebounceTimer) {
                     clearTimeout(S.subtitleCheckDebounceTimer);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug修复**
  * 优化聊天消息时间戳显示：当消息追加到已有气泡且原本无时间前缀时，现在会自动使用当前时间（并保留表情）作为前缀，保证追加消息与已有消息的时间前缀显示一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->