### PR TITLE
禁用部分浏览器快捷键防止出现意外情况

### DIFF
--- a/static/common_dialogs.js
+++ b/static/common_dialogs.js
@@ -550,22 +550,6 @@
                 return false;
             }
         }
-        
-        // 禁用 Alt+← (后退)
-        if (event.altKey && event.key === 'ArrowLeft') {
-            event.preventDefault();
-            return false;
-        }
-        // 禁用 Alt+→ (前进)
-        if (event.altKey && event.key === 'ArrowRight') {
-            event.preventDefault();
-            return false;
-        }
-        // 禁用 Alt+F (打开菜单)
-        if (event.altKey && (event.key === 'f' || event.key === 'F')) {
-            event.preventDefault();
-            return false;
-        }
     }, { passive: false });
     
     // 禁用 Ctrl + 滚轮缩放


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 扩展了被阻止的浏览器快捷键范围，现包括 Ctrl+P、Ctrl+N、Ctrl+T、Ctrl+W、Ctrl+Tab、Ctrl+L、Ctrl+/、Ctrl- 及 Ctrl+滚轮 等常用组合，降低意外触发浏览器操作的概率。
* **Documentation**
  * 更新了相关提示文案，明确说明已禁用多种浏览器快捷键。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->