### PR TITLE
无色调映射时禁用曝光滑块防止误导

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -4389,9 +4389,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             if (s.rendering) {
                 if (mmdTonemappingSelect && s.rendering.toneMapping != null) {
-                    mmdTonemappingSelect.value = s.rendering.toneMapping;
-                    // 根据色调映射设置曝光滑块禁用状态
+                    // 统一使用数值类型，避免字符串和数字混用
                     const toneMappingValue = Number(s.rendering.toneMapping);
+                    mmdTonemappingSelect.value = toneMappingValue.toString();
+                    // 根据色调映射设置曝光滑块禁用状态
                     const isNoToneMapping = toneMappingValue === 0;
                     if (mmdExposureSlider) {
                         mmdExposureSlider.disabled = isNoToneMapping;
@@ -4553,12 +4554,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         }
         if (tonemappingSelect && lighting.toneMapping !== undefined) {
-            tonemappingSelect.value = lighting.toneMapping.toString();
+            // 统一使用数值类型，避免字符串和数字混用
+            const toneMappingValue = Number(lighting.toneMapping);
+            tonemappingSelect.value = toneMappingValue.toString();
             if (vrmManager.renderer) {
-                vrmManager.renderer.toneMapping = lighting.toneMapping;
+                vrmManager.renderer.toneMapping = toneMappingValue;
             }
             // 根据色调映射设置曝光滑块禁用状态
-            const toneMappingValue = Number(lighting.toneMapping);
             const isNoToneMapping = toneMappingValue === 0;
             if (exposureSlider) {
                 exposureSlider.disabled = isNoToneMapping;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复在色调映射为“无”时，曝光滑块与数值未被正确禁用的问题，确保控件不可用时无法交互。
  * 改进禁用状态的视觉反馈：调整控件透明度以明确显示不可用状态。
  * 保证 VRM（Live3D）与 MMD 模式下，切换色调映射、恢复与应用设置时，曝光控件状态即时与当前色调映射保持同步。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->