### PR TITLE
fix(agent_server): fix main_server timeout by moving analyze_ack logic

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -791,13 +791,13 @@ async def _on_session_event(event: Dict[str, Any]) -> None:
         lanlan_name = event.get("lanlan_name")
         event_id = event.get("event_id")
         logger.info("[AgentAnalyze] analyze_request received: trigger=%s lanlan=%s messages=%d", event.get("trigger"), lanlan_name, len(messages) if isinstance(messages, list) else 0)
-        if not Modules.analyzer_enabled:
-            logger.info("[AgentAnalyze] skip: analyzer disabled (master switch off)")
-            return
         if event_id:
             ack_task = asyncio.create_task(_emit_main_event("analyze_ack", lanlan_name, event_id=event_id))
             Modules._background_tasks.add(ack_task)
             ack_task.add_done_callback(Modules._background_tasks.discard)
+        if not Modules.analyzer_enabled:
+            logger.info("[AgentAnalyze] skip: analyzer disabled (master switch off)")
+            return
         if isinstance(messages, list) and messages:
             # Consume only new user turn. Assistant turn_end without new user input should be ignored.
             lanlan_key = _normalize_lanlan_key(lanlan_name)


### PR DESCRIPTION
agent_server.py 中 analyzer_enabled = False 时，代码直接 return ， 没有发送 analyze_ack ，导致 main_server 等待 ack 超时。

### 修复内容
将 ack 发送移到 analyzer_enabled 检查之前

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **重构**
  * 优化了会话事件处理逻辑，确保应答事件得到正确处理和调度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->