### PR TITLE
修复切换画质时MMD描边设置被覆盖的问题

### DIFF
--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -77,9 +77,10 @@ class MMDCore {
 
     /**
      * 应用画质设置（模仿 VRM 的画质分级系统）
-     * low:    pixelRatio=0.8, 物理关, 描边关
-     * medium: pixelRatio=1.0, 物理开, 描边关
+     * low:    pixelRatio=0.8, 物理关
+     * medium: pixelRatio=1.0, 物理开
      * high:   pixelRatio=auto, 物理开, 描边开
+     * 注意：描边设置由用户手动控制，画质设置不会覆盖用户的选择
      */
     applyQualitySettings(quality) {
         if (!this.manager.renderer) return;
@@ -89,19 +90,24 @@ class MMDCore {
         if (quality === 'low') {
             this.manager.renderer.setPixelRatio(Math.min(0.8, devicePixelRatio));
             this.manager.enablePhysics = false;
-            this.manager.useOutlineEffect = false;
         } else if (quality === 'medium') {
             this.manager.renderer.setPixelRatio(Math.min(1.0, devicePixelRatio));
             this.manager.enablePhysics = true;
-            this.manager.useOutlineEffect = false;
         } else {
-            // high: 使用性能检测的原始像素比
             this.applyPerformanceSettings();
             this.manager.enablePhysics = true;
-            this.manager.useOutlineEffect = true;
+            if (!this.manager._userForcedOutline) {
+                this.manager.useOutlineEffect = true;
+            }
         }
 
-        console.log(`[MMD] 画质设置: ${quality}, physics=${this.manager.enablePhysics}, outline=${this.manager.useOutlineEffect}`);
+        if (!this.manager._userForcedOutline) {
+            if (quality === 'low' || quality === 'medium') {
+                this.manager.useOutlineEffect = false;
+            }
+        }
+
+        console.log(`[MMD] 画质设置: ${quality}, physics=${this.manager.enablePhysics}, outline=${this.manager.useOutlineEffect}, userForcedOutline=${this.manager._userForcedOutline}`);
     }
 
     // ═══════════════════ 模块动态导入 ═══════════════════

--- a/static/mmd-manager.js
+++ b/static/mmd-manager.js
@@ -14,6 +14,7 @@ class MMDManager {
         this.controls = null;
         this.effect = null; // OutlineEffect
         this.useOutlineEffect = true;
+        this._userForcedOutline = false; // 用户是否手动设置过描边
         this.enablePhysics = true;
         this.physicsStrength = 1.0;
         this._baseGravityY = -98;  // Ammo.js 默认重力 Y 分量
@@ -298,6 +299,7 @@ class MMDManager {
             }
             if (r.outline != null) {
                 this.useOutlineEffect = r.outline;
+                this._userForcedOutline = true; // 用户手动设置描边
             }
         }
         // 物理

--- a/static/mmd-ui-debug.js
+++ b/static/mmd-ui-debug.js
@@ -317,6 +317,7 @@ function applyMMDDebugSetting(key, value) {
             break;
         case 'useOutlineEffect':
             manager.useOutlineEffect = value;
+            manager._userForcedOutline = true;
             break;
         case 'pixelRatio':
             if (manager.renderer) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本说明

* **Bug 修复**
  * 改进了画质设置与轮廓效果的交互逻辑，用户手动设置的轮廓效果偏好现在不会被画质等级自动覆盖。

* **改进**
  * 优化了调试信息记录，包含更详细的渲染设置状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->