### PR TITLE
refactor: rename OpenFang display name to 虚拟机 (Virtual Machine) acros…

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -1592,7 +1592,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 await _emit_task_result(
                                     lanlan_name, channel="openfang", task_id=of_task_id,
                                     success=False,
-                                    summary=f'OpenFang 任务 "{result.task_description}" 已取消',
+                                    summary=f'虚拟机任务 "{result.task_description}" 已取消',
                                     error_message=cancel_msg,
                                 )
                             except Exception:
@@ -1617,7 +1617,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 await _emit_task_result(
                                     lanlan_name, channel="openfang", task_id=of_task_id,
                                     success=False,
-                                    summary=f'OpenFang 任务 "{result.task_description}" 执行异常',
+                                    summary=f'虚拟机任务 "{result.task_description}" 执行异常',
                                     error_message=str(e),
                                 )
                             except Exception:
@@ -2533,7 +2533,7 @@ async def openfang_run(payload: Dict[str, Any]):
     if not instruction:
         return JSONResponse({"error": "instruction required"}, status_code=400)
     if not Modules.openfang or not Modules.openfang.init_ok:
-        return JSONResponse({"error": "OpenFang not available"}, status_code=503)
+        return JSONResponse({"error": "VM agent not available"}, status_code=503)
 
     task_id = f"of_{uuid.uuid4().hex[:12]}"
 

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -159,7 +159,7 @@ window.AgentHUD._createAgentPopupContent = function (popup) {
         },
         {
             id: 'agent-openfang',
-            label: window.t ? window.t('settings.toggles.openfang') : 'OpenFang',
+            label: window.t ? window.t('settings.toggles.openfang') : '虚拟机',
             labelKey: 'settings.toggles.openfang',
             initialDisabled: true,
             initialTitle: window.t ? window.t('settings.toggles.checking') : '查询中...'

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -43,7 +43,7 @@
             computer_use_enabled: window.t ? window.t('settings.toggles.keyboardControl') : '键鼠控制',
             browser_use_enabled: window.t ? window.t('settings.toggles.browserUse') : 'Browser Control',
             user_plugin_enabled: window.t ? window.t('settings.toggles.userPlugin') : '用户插件',
-            openfang_enabled: window.t ? window.t('settings.toggles.openfang') : 'OpenFang',
+            openfang_enabled: window.t ? window.t('settings.toggles.openfang') : '虚拟机',
         };
         return map[key] || key;
     };

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1449,7 +1449,7 @@
             "enabled": "{{name}} Enabled",
             "disabled": "{{name}} Disabled",
             "enableFailed": "{{name}} Enable Failed",
-            "openfang": "OpenFang Agent",
+            "openfang": "Virtual Machine",
             "userPluginAdapting": "User Plugin (Developing)",
             "moltbotAdapting": "OpenClaw (Developing)",
             "chatSettings": "Chat Settings",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1449,7 +1449,7 @@
             "enabled": "{{name}}を有効にしました",
             "disabled": "{{name}}を無効にしました",
             "enableFailed": "{{name}}の有効化に失敗しました",
-            "openfang": "OpenFang エージェント",
+            "openfang": "仮想マシン",
             "userPluginAdapting": "ユーザープラグイン（開発中）",
             "moltbotAdapting": "OpenClaw（開発中）",
             "chatSettings": "チャット設定",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1449,7 +1449,7 @@
             "enabled": "{{name}} 활성화됨",
             "disabled": "{{name}} 비활성화됨",
             "enableFailed": "{{name}} 활성화 실패",
-            "openfang": "OpenFang 에이전트",
+            "openfang": "가상 머신",
             "userPluginAdapting": "사용자 플러그인(개발 중)",
             "moltbotAdapting": "OpenClaw (개발 중)",
             "chatSettings": "채팅 설정",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1449,7 +1449,7 @@
             "enabled": "{{name}} Включен",
             "disabled": "{{name}} Отключен",
             "enableFailed": "{{name}} Ошибка включения",
-            "openfang": "OpenFang Агент",
+            "openfang": "Виртуальная машина",
             "userPluginAdapting": "Пользовательский плагин (В разработке)",
             "moltbotAdapting": "OpenClaw (В разработке)",
             "animationSettings": "Настройки анимации",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1449,7 +1449,7 @@
             "enabled": "{{name}}已开启",
             "disabled": "{{name}}已关闭",
             "enableFailed": "{{name}}开启失败",
-            "openfang": "OpenFang 智能体",
+            "openfang": "虚拟机",
             "userPluginAdapting": "用户插件（开发中）",
             "moltbotAdapting": "OpenClaw（开发中）",
             "chatSettings": "对话设置",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1449,7 +1449,7 @@
             "enabled": "{{name}}已開啓",
             "disabled": "{{name}}已關閉",
             "enableFailed": "{{name}}開啓失敗",
-            "openfang": "OpenFang 智能體",
+            "openfang": "虛擬機",
             "userPluginAdapting": "用戶插件（開發中）",
             "moltbotAdapting": "OpenClaw（開發中）",
             "chatSettings": "對話設定",


### PR DESCRIPTION
…s all locales

- Update all 6 i18n locale files (zh-CN, zh-TW, en, ja, ko, ru)
- Update JS fallback strings in agent_ui_v2.js and common-ui-hud.js
- Update user-facing HUD task summaries and API error messages in agent_server.py
- Internal code identifiers, log prefixes, and routing keys left unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **样式**
  * 更新了用户界面标签和错误消息文本，现统一使用"虚拟机"称呼，支持英语、日语、韩语、俄语和中文（简繁）等多个语言版本的显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->