### PR TITLE
修复 VRM 模型路径解析错误导致无法加载内置模型的问题

### DIFF
--- a/static/js/chara_manager.js
+++ b/static/js/chara_manager.js
@@ -1807,14 +1807,17 @@ function showCatgirlForm(key, container) {
     modelLink.style.alignItems = 'center';
 
     // 显示当前模型（优先显示Live3D VRM/MMD，如果没有则显示Live2D）
-    // 辅助函数：检查模型路径是否有效（与 model_manager.js 保持一致）
-    function isValidModelPath(path) {
-        if (path === undefined || path === null) return false;
-        const strValue = String(path).trim();
-        if (strValue === '') return false;
-        if (strValue === 'undefined' || strValue === 'null') return false;
-        if (strValue.toLowerCase().includes('undefined') || strValue.toLowerCase().includes('null')) return false;
-        return true;
+    // 辅助函数：检查模型路径是否有效，返回验证后的字符串或空字符串
+    function validateModelPath(path) {
+        if (path === undefined || path === null) return '';
+        if (typeof path !== 'string') {
+            path = String(path);
+        }
+        const strValue = path.trim();
+        if (strValue === '') return '';
+        if (strValue === 'undefined' || strValue === 'null') return '';
+        if (strValue.toLowerCase().includes('undefined') || strValue.toLowerCase().includes('null')) return '';
+        return strValue;
     }
 
     const modelType = cat['model_type'] || 'live2d';
@@ -1822,17 +1825,19 @@ function showCatgirlForm(key, container) {
     const normalizedModelType = modelType === 'vrm' ? 'live3d' : modelType;
     let modelDisplayText = '';
 
-    if (normalizedModelType === 'live3d' && isValidModelPath(cat['mmd'])) {
+    const mmdPath = validateModelPath(cat['mmd']);
+    const vrmPath = validateModelPath(cat['vrm']);
+    const live2dPath = validateModelPath(cat['live2d']);
+
+    if (normalizedModelType === 'live3d' && mmdPath) {
         // live3d 模式下 MMD 优先（VRM 是旧字段，可能遗留非空值，与后端 _get_live3d_sub_type 一致）
-        const mmdPath = cat['mmd'];
         const mmdName = (mmdPath.split(/[\\/]/).pop() || mmdPath).replace(/\.(pmx|pmd)$/i, '');
         modelDisplayText = mmdName;
-    } else if (normalizedModelType === 'live3d' && isValidModelPath(cat['vrm'])) {
-        const vrmPath = cat['vrm'];
+    } else if (normalizedModelType === 'live3d' && vrmPath) {
         const vrmName = (vrmPath.split(/[\\/]/).pop() || vrmPath).replace(/\.vrm$/i, '');
         modelDisplayText = vrmName;
-    } else if (isValidModelPath(cat['live2d'])) {
-        modelDisplayText = cat['live2d'];
+    } else if (live2dPath) {
+        modelDisplayText = live2dPath;
     } else {
         modelDisplayText = window.t ? window.t('character.modelNotSet') : '未设置';
     }

--- a/static/js/chara_manager.js
+++ b/static/js/chara_manager.js
@@ -1807,22 +1807,31 @@ function showCatgirlForm(key, container) {
     modelLink.style.alignItems = 'center';
 
     // 显示当前模型（优先显示Live3D VRM/MMD，如果没有则显示Live2D）
+    // 辅助函数：检查模型路径是否有效（与 model_manager.js 保持一致）
+    function isValidModelPath(path) {
+        if (path === undefined || path === null) return false;
+        const strValue = String(path).trim();
+        if (strValue === '') return false;
+        if (strValue === 'undefined' || strValue === 'null') return false;
+        if (strValue.toLowerCase().includes('undefined') || strValue.toLowerCase().includes('null')) return false;
+        return true;
+    }
+
     const modelType = cat['model_type'] || 'live2d';
+    // 兼容旧配置：'vrm' 统一为 'live3d'
+    const normalizedModelType = modelType === 'vrm' ? 'live3d' : modelType;
     let modelDisplayText = '';
-    if (modelType === 'vrm' && cat['vrm']) {
-        const vrmPath = cat['vrm'];
-        const vrmName = vrmPath ? (vrmPath.split(/[\\/]/).pop() || vrmPath).replace(/\.vrm$/i, '') : '';
-        modelDisplayText = vrmName;
-    } else if (modelType === 'live3d' && cat['mmd']) {
+
+    if (normalizedModelType === 'live3d' && isValidModelPath(cat['mmd'])) {
         // live3d 模式下 MMD 优先（VRM 是旧字段，可能遗留非空值，与后端 _get_live3d_sub_type 一致）
         const mmdPath = cat['mmd'];
-        const mmdName = mmdPath ? (mmdPath.split(/[\\/]/).pop() || mmdPath).replace(/\.(pmx|pmd)$/i, '') : '';
+        const mmdName = (mmdPath.split(/[\\/]/).pop() || mmdPath).replace(/\.(pmx|pmd)$/i, '');
         modelDisplayText = mmdName;
-    } else if (modelType === 'live3d' && cat['vrm']) {
+    } else if (normalizedModelType === 'live3d' && isValidModelPath(cat['vrm'])) {
         const vrmPath = cat['vrm'];
-        const vrmName = vrmPath ? (vrmPath.split(/[\\/]/).pop() || vrmPath).replace(/\.vrm$/i, '') : '';
+        const vrmName = (vrmPath.split(/[\\/]/).pop() || vrmPath).replace(/\.vrm$/i, '');
         modelDisplayText = vrmName;
-    } else if (cat['live2d']) {
+    } else if (isValidModelPath(cat['live2d'])) {
         modelDisplayText = cat['live2d'];
     } else {
         modelDisplayText = window.t ? window.t('character.modelNotSet') : '未设置';

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2415,8 +2415,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 models.forEach(model => {
                     const option = document.createElement('option');
 
-                    // 严格检查 model.path，如果不存在或为字符串 "undefined"，根据 model.filename 构建路径
-                    let modelPath = model.path;
+                    // 严格检查 model.url 或 model.path，后端返回的是 url 字段
+                    let modelPath = model.url || model.path;
                     let isValidPath = modelPath &&
                         modelPath !== 'undefined' &&
                         modelPath !== 'null' &&
@@ -2425,11 +2425,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                         !modelPath.toLowerCase().includes('undefined') &&
                         !modelPath.toLowerCase().includes('null');
 
+                    // 如果 path 无效但有 filename，尝试使用 filename 构建路径
                     if (!isValidPath && model.filename) {
-                        // 使用 ModelPathHelper 标准化路径
                         const filename = model.filename.trim();
                         if (filename && filename !== 'undefined' && filename !== 'null' && !filename.toLowerCase().includes('undefined')) {
-                            modelPath = ModelPathHelper.normalizeModelPath(filename, 'model');
+                            // 优先使用 url，如果没有 url 则根据 location 判断路径前缀
+                            if (model.url) {
+                                modelPath = model.url;
+                            } else if (model.location === 'project') {
+                                modelPath = `/static/vrm/${filename}`;
+                            } else {
+                                modelPath = `/user_vrm/${filename}`;
+                            }
                             isValidPath = true;
                         }
                     }
@@ -3570,7 +3577,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // 添加 VRM 模型
             vrmModels.forEach(model => {
-                let modelPath = model.path;
+                // 后端返回的是 url 字段，不是 path 字段
+                let modelPath = model.url || model.path;
                 let isValidPath = modelPath &&
                     modelPath !== 'undefined' &&
                     modelPath !== 'null' &&
@@ -3579,10 +3587,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                     !modelPath.toLowerCase().includes('undefined') &&
                     !modelPath.toLowerCase().includes('null');
 
+                // 如果 path 无效但有 filename，尝试使用 filename 构建路径
                 if (!isValidPath && model.filename) {
                     const filename = model.filename.trim();
                     if (filename && filename !== 'undefined' && filename !== 'null' && !filename.toLowerCase().includes('undefined')) {
-                        modelPath = ModelPathHelper.normalizeModelPath(filename, 'model');
+                        // 优先使用 url，如果没有 url 则根据 location 判断路径前缀
+                        if (model.url) {
+                            modelPath = model.url;
+                        } else if (model.location === 'project') {
+                            modelPath = `/static/vrm/${filename}`;
+                        } else {
+                            modelPath = `/user_vrm/${filename}`;
+                        }
                         isValidPath = true;
                     }
                 }

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -528,6 +528,58 @@ window._modelManagerLanlanName = new URLSearchParams(window.location.search).get
  */
 const ModelPathHelper = {
     /**
+     * 验证模型路径是否有效
+     * 拒绝 undefined/null 字符串、空值、以及包含 'undefined'/'null' 的字符串
+     * @param {*} path - 原始路径值
+     * @returns {string} 验证后的字符串，无效时返回空字符串
+     */
+    validatePath(path) {
+        if (path === undefined || path === null) return '';
+        if (typeof path !== 'string') {
+            path = String(path);
+        }
+        const trimmed = path.trim();
+        if (trimmed === '') return '';
+        if (trimmed === 'undefined' || trimmed === 'null') return '';
+        if (trimmed.toLowerCase().includes('undefined') || trimmed.toLowerCase().includes('null')) return '';
+        return trimmed;
+    },
+
+    /**
+     * 从模型数据中提取有效的 VRM 路径
+     * @param {Object} model - 模型数据对象
+     * @returns {Object} { path: string, isValid: boolean, filename: string }
+     */
+    extractVrmPath(model) {
+        if (!model || typeof model !== 'object') {
+            return { path: '', isValid: false, filename: '' };
+        }
+
+        // 优先检查 url 字段
+        let validPath = this.validatePath(model.url);
+        if (validPath) {
+            return { path: validPath, isValid: true, filename: model.filename || '' };
+        }
+
+        // 检查 path 字段
+        validPath = this.validatePath(model.path);
+        if (validPath) {
+            return { path: validPath, isValid: true, filename: model.filename || '' };
+        }
+
+        // 如果都没有，但有 filename，根据 location 构建路径
+        const validFilename = this.validatePath(model.filename);
+        if (validFilename) {
+            const builtPath = model.location === 'project'
+                ? `/static/vrm/${validFilename}`
+                : `/user_vrm/${validFilename}`;
+            return { path: builtPath, isValid: true, filename: validFilename };
+        }
+
+        return { path: '', isValid: false, filename: '' };
+    },
+
+    /**
      * 标准化模型路径
      * 处理 Windows 反斜杠、/user_vrm/ 前缀和本地文件路径
      * @param {string} rawPath - 原始路径
@@ -535,10 +587,8 @@ const ModelPathHelper = {
      * @returns {string} 标准化后的路径
      */
     normalizeModelPath(rawPath, type = 'model') {
-        if (!rawPath) return '';
-
-        // 确保 path 是字符串类型
-        let path = String(rawPath).trim();
+        const path = this.validatePath(rawPath);
+        if (!path) return '';
 
         // 如果已经是 URL 格式 (http/https) 或 Web 绝对路径 (/)，直接返回
         if (path.startsWith('http') || path.startsWith('/')) {
@@ -2415,49 +2465,24 @@ document.addEventListener('DOMContentLoaded', async () => {
                 models.forEach(model => {
                     const option = document.createElement('option');
 
-                    // 严格检查 model.url 或 model.path，后端返回的是 url 字段
-                    let modelPath = model.url || model.path;
-                    let isValidPath = modelPath &&
-                        modelPath !== 'undefined' &&
-                        modelPath !== 'null' &&
-                        typeof modelPath === 'string' &&
-                        modelPath.trim() !== '' &&
-                        !modelPath.toLowerCase().includes('undefined') &&
-                        !modelPath.toLowerCase().includes('null');
+                    // 使用 ModelPathHelper 提取有效的 VRM 路径
+                    const { path: modelPath, isValid, filename } = ModelPathHelper.extractVrmPath(model);
 
-                    // 如果 path 无效但有 filename，尝试使用 filename 构建路径
-                    if (!isValidPath && model.filename) {
-                        const filename = model.filename.trim();
-                        if (filename && filename !== 'undefined' && filename !== 'null' && !filename.toLowerCase().includes('undefined')) {
-                            // 优先使用 url，如果没有 url 则根据 location 判断路径前缀
-                            if (model.url) {
-                                modelPath = model.url;
-                            } else if (model.location === 'project') {
-                                modelPath = `/static/vrm/${filename}`;
-                            } else {
-                                modelPath = `/user_vrm/${filename}`;
-                            }
-                            isValidPath = true;
-                        }
-                    }
-
-                    // 如果仍然无效，跳过该模型
-                    if (!isValidPath) {
+                    // 如果无效，跳过该模型
+                    if (!isValid || !modelPath) {
                         console.warn('[模型管理] 跳过无效的 VRM 模型:', model);
                         return;
                     }
 
                     // 使用 ModelPathHelper 确保 data-path 属性永远是有效的 URL
-                    const validPath = modelPath.startsWith('/') || modelPath.startsWith('http')
-                        ? ModelPathHelper.normalizeModelPath(modelPath, 'model')
-                        : ModelPathHelper.normalizeModelPath(model.filename || modelPath.split(/[/\\]/).pop(), 'model');
+                    const validPath = ModelPathHelper.normalizeModelPath(modelPath, 'model');
 
-                    option.value = model.url || validPath;
+                    option.value = validPath;
                     option.setAttribute('data-path', validPath);
-                    if (model.filename) {
-                        option.setAttribute('data-filename', model.filename);
+                    if (filename) {
+                        option.setAttribute('data-filename', filename);
                     }
-                    option.textContent = model.name || model.filename || validPath;
+                    option.textContent = model.name || filename || validPath;
                     vrmModelSelect.appendChild(option);
                 });
                 vrmModelSelect.disabled = false;
@@ -3577,43 +3602,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // 添加 VRM 模型
             vrmModels.forEach(model => {
-                // 后端返回的是 url 字段，不是 path 字段
-                let modelPath = model.url || model.path;
-                let isValidPath = modelPath &&
-                    modelPath !== 'undefined' &&
-                    modelPath !== 'null' &&
-                    typeof modelPath === 'string' &&
-                    modelPath.trim() !== '' &&
-                    !modelPath.toLowerCase().includes('undefined') &&
-                    !modelPath.toLowerCase().includes('null');
+                // 使用 ModelPathHelper 提取有效的 VRM 路径
+                const { path: modelPath, isValid, filename } = ModelPathHelper.extractVrmPath(model);
 
-                // 如果 path 无效但有 filename，尝试使用 filename 构建路径
-                if (!isValidPath && model.filename) {
-                    const filename = model.filename.trim();
-                    if (filename && filename !== 'undefined' && filename !== 'null' && !filename.toLowerCase().includes('undefined')) {
-                        // 优先使用 url，如果没有 url 则根据 location 判断路径前缀
-                        if (model.url) {
-                            modelPath = model.url;
-                        } else if (model.location === 'project') {
-                            modelPath = `/static/vrm/${filename}`;
-                        } else {
-                            modelPath = `/user_vrm/${filename}`;
-                        }
-                        isValidPath = true;
-                    }
-                }
-                if (!isValidPath) return;
+                if (!isValid || !modelPath) return;
 
-                const validPath = modelPath.startsWith('/') || modelPath.startsWith('http')
-                    ? ModelPathHelper.normalizeModelPath(modelPath, 'model')
-                    : ModelPathHelper.normalizeModelPath(model.filename || modelPath.split(/[/\\]/).pop(), 'model');
+                const validPath = ModelPathHelper.normalizeModelPath(modelPath, 'model');
 
                 const option = document.createElement('option');
-                option.value = model.url || validPath;
+                option.value = validPath;
                 option.setAttribute('data-path', validPath);
                 option.setAttribute('data-sub-type', 'vrm');
-                if (model.filename) option.setAttribute('data-filename', model.filename);
-                const baseName = model.name || model.filename || validPath;
+                if (filename) option.setAttribute('data-filename', filename);
+                const baseName = model.name || filename || validPath;
                 option.textContent = baseName;
                 vrmModelSelect.appendChild(option);
             });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进并统一了模型路径验证逻辑，拒绝 undefined/null（含字符串字面量）和空值，避免异常或错误的路径被使用。
  * 新增模型路径提取优先级（url → path → 基于 filename 拼接），跳过不可用项并同步 filename 显示。
  * 规范化模型类型映射（将 legacy vrm 视作 live3d），并调整模型显示选择：live3d 优先 mmd，再退回 vrm；非 live3d 则使用 live2d。
  * 简化了显示路径的名称提取逻辑，移除冗余空值检查。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->