### PR TITLE
fix: TTS诊断日志区分"跳过(原生语音)"与真正启动

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1366,7 +1366,8 @@ class LLMSessionManager:
             )
             
             logger.info(f"⚡ 并行启动完成 (总用时: {time.time() - start_parallel_time:.2f}秒)")
-            logger.info(f"[语音会话诊断] 并行启动结果: TTS={'异常' if isinstance(tts_result, Exception) else 'OK'}, LLM={'异常' if isinstance(llm_result, Exception) else 'OK'}")
+            tts_status = '异常' if isinstance(tts_result, Exception) else ('跳过(原生语音)' if not self.use_tts else 'OK')
+            logger.info(f"[语音会话诊断] 并行启动结果: TTS={tts_status}, LLM={'异常' if isinstance(llm_result, Exception) else 'OK'}")
             # 检查是否有错误
             if isinstance(tts_result, Exception):
                 logger.error(f"TTS 启动失败: {tts_result}")


### PR DESCRIPTION
use_tts=False 时 start_tts_if_needed() 直接返回 True，
之前统一显示 TTS=OK 产生误导，现在改为 TTS=跳过(原生语音)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了诊断日志中文本到语音（TTS）状态的报告准确性。当未启用TTS时，现在准确显示"跳过"状态，而非错误状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->