### PR TITLE
fix: 模型管理页未保存提示全面化 — 快照比对替代零散 dirty 标记

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -504,7 +504,41 @@ function sendMessageToMainPage(action, payload = {}) {
 // 全局变量：跟踪未保存的更改
 window.hasUnsavedChanges = false;
 
-// 仅当本页确实保存过配置时，才触发主界面重载（避免退出就把主界面模型/位置“复位”）
+// 采集当前所有可保存设置的快照（模型选择 + 打光 + 待机动作）
+function captureSettingsSnapshot() {
+    const modelSelect = document.getElementById('model-select');
+    const vrmModelSelect = document.getElementById('vrm-model-select');
+    return {
+        modelType: typeof currentModelType !== 'undefined' ? currentModelType : '',
+        live2d: modelSelect ? modelSelect.value : '',
+        live3d: vrmModelSelect ? vrmModelSelect.value : '',
+        // VRM 打光
+        ambient: document.getElementById('ambient-light-slider')?.value ?? '',
+        mainLight: document.getElementById('main-light-slider')?.value ?? '',
+        exposure: document.getElementById('exposure-slider')?.value ?? '',
+        toneMapping: document.getElementById('tonemapping-select')?.value ?? '',
+        outlineWidth: document.getElementById('vrm-outline-width-slider')?.value ?? '',
+        // MMD 打光
+        mmdAmbientIntensity: document.getElementById('mmd-ambient-intensity-slider')?.value ?? '',
+        mmdAmbientColor: document.getElementById('mmd-ambient-color-picker')?.value ?? '',
+        mmdDirectionalIntensity: document.getElementById('mmd-directional-intensity-slider')?.value ?? '',
+        mmdDirectionalColor: document.getElementById('mmd-directional-color-picker')?.value ?? '',
+        mmdExposure: document.getElementById('mmd-exposure-slider')?.value ?? '',
+        mmdToneMapping: document.getElementById('mmd-tonemapping-select')?.value ?? '',
+        mmdOutline: String(document.getElementById('mmd-outline-toggle')?.checked ?? false),
+        // 待机动作
+        idleAnimation: document.getElementById('idle-animation-select')?.value ?? '',
+        mmdIdleAnimation: document.getElementById('mmd-idle-animation-select')?.value ?? '',
+    };
+}
+
+// 比较两个快照是否一致
+function snapshotsEqual(a, b) {
+    if (!a || !b) return false;
+    return Object.keys(a).every(k => String(a[k]) === String(b[k]));
+}
+
+// 仅当本页确实保存过配置时，才触发主界面重载（避免退出就把主界面模型/位置”复位”）
 window._modelManagerHasSaved = false;
 window._modelManagerLanlanName = new URLSearchParams(window.location.search).get('lanlan_name') || '';
 /**
@@ -1169,8 +1203,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 textSpanId: 'mmd-animation-select-text',
                 iconClass: 'mmd-animation-select-icon',
                 iconSrc: '/static/icons/motion_select_icon.png?v=1',
-                defaultText: '选择VMD动画',
-                iconAlt: '选择VMD动画',
+                defaultText: t('live2d.mmdAnimation.selectAnimation', '选择VMD动画'),
+                iconAlt: t('live2d.mmdAnimation.selectAnimation', '选择VMD动画'),
                 shouldSkipOption: (option) => {
                     return option.value === '' && (
                         option.textContent.includes('请先加载') ||
@@ -3214,7 +3248,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             mmdAnimations = (data.success && Array.isArray(data.animations)) ? data.animations : [];
             if (!mmdAnimationSelect) return;
 
-            mmdAnimationSelect.innerHTML = '<option value="">选择VMD动画</option>';
+            mmdAnimationSelect.innerHTML = `<option value="">${t('live2d.mmdAnimation.selectAnimation', '选择VMD动画')}</option>`;
             if (mmdAnimations.length > 0) {
                 mmdAnimations.forEach(anim => {
                     const animPath = anim.path || anim.url || (typeof anim === 'string' ? anim : null);
@@ -4080,6 +4114,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (vrmManager && vrmManager.ambientLight) {
                 vrmManager.ambientLight.intensity = value;
             }
+            window.hasUnsavedChanges = true;
         });
     }
 
@@ -4091,6 +4126,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (vrmManager && vrmManager.mainLight) {
                 vrmManager.mainLight.intensity = value;
             }
+            window.hasUnsavedChanges = true;
         });
     }
 
@@ -4146,6 +4182,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (vrmManager && vrmManager.renderer) {
                 vrmManager.renderer.toneMappingExposure = value;
             }
+            window.hasUnsavedChanges = true;
         });
     }
 
@@ -4173,6 +4210,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (exposureValue) {
                 exposureValue.style.opacity = isNoToneMapping ? '0.5' : '1';
             }
+            window.hasUnsavedChanges = true;
         });
     }
 
@@ -4201,6 +4239,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (vrmOutlineWidthSlider) {
         vrmOutlineWidthSlider.addEventListener('input', (e) => {
             applyVrmOutlineWidth(parseFloat(e.target.value));
+            window.hasUnsavedChanges = true;
         });
     }
 
@@ -4209,6 +4248,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         idleAnimationSelect.addEventListener('change', async (e) => {
             const selectedUrl = e.target.value;
             if (!selectedUrl) return;
+            window.hasUnsavedChanges = true;
             // 实时切换待机动作：停止当前动画，播放新的循环动画
             if (vrmManager && vrmManager.animation && vrmManager.currentModel) {
                 try {
@@ -4304,6 +4344,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (mmdIdleAnimationSelect) {
         mmdIdleAnimationSelect.addEventListener('change', async (e) => {
             const selectedUrl = e.target.value;
+            window.hasUnsavedChanges = true;
             // 实时切换MMD待机动作：停止当前动画，播放新的循环动画
             if (window.mmdManager && window.mmdManager.currentModel) {
                 try {
@@ -4462,6 +4503,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const valEl = document.getElementById(valId);
                     if (valEl) valEl.textContent = fmt ? fmt(v) : v;
                     applyMmdSettings();
+                    window.hasUnsavedChanges = true;
                 });
             }
         });
@@ -4476,6 +4518,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const valEl = document.getElementById(valId);
                     if (valEl) valEl.textContent = e.target.value;
                     applyMmdSettings();
+                    window.hasUnsavedChanges = true;
                 });
             }
         });
@@ -4495,6 +4538,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (mmdExposureValue) {
                     mmdExposureValue.style.opacity = isNoToneMapping ? '0.5' : '1';
                 }
+                window.hasUnsavedChanges = true;
             });
         }
 
@@ -4504,6 +4548,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const statusEl = document.getElementById('mmd-outline-status');
                 if (statusEl) statusEl.textContent = e.target.checked ? 'ON' : 'OFF';
                 applyMmdSettings();
+                window.hasUnsavedChanges = true;
             });
         }
 
@@ -5379,11 +5424,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (modelSuccess) {
                 showStatus(t('live2d.settingsSaved', '模型设置保存成功!'), 2000);
                 window.hasUnsavedChanges = false;
-                window._savedModelSnapshot = {
-                    modelType: currentModelType,
-                    live2d: modelSelect ? modelSelect.value : '',
-                    live3d: vrmModelSelect ? vrmModelSelect.value : '',
-                };
+                window._savedModelSnapshot = captureSettingsSnapshot();
                 window._modelManagerHasSaved = true;
             } else {
                 showStatus(t('live2d.saveFailedGeneral', '保存失败!'), 2000);
@@ -5393,11 +5434,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (positionSuccess && modelSuccess) {
                 showStatus(t('live2d.settingsSaved', '位置和模型设置保存成功!'), 2000);
                 window.hasUnsavedChanges = false; // 保存成功后重置标志
-                window._savedModelSnapshot = {
-                    modelType: currentModelType,
-                    live2d: modelSelect ? modelSelect.value : '',
-                    live3d: vrmModelSelect ? vrmModelSelect.value : '',
-                };
+                window._savedModelSnapshot = captureSettingsSnapshot();
                 window._modelManagerHasSaved = true;
                 // 不在保存时立即通知主页，而是在返回主页时通知
                 // sendMessageToMainPage('reload_model');
@@ -5407,6 +5444,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 window._modelManagerHasSaved = true;
             } else if (modelSuccess) {
                 showStatus(t('live2d.modelSavedPositionFailed', '模型设置保存成功，位置保存失败!'), 2000);
+                window._savedModelSnapshot = captureSettingsSnapshot();
                 window._modelManagerHasSaved = true;
                 // 不在保存时立即通知主页，而是在返回主页时通知
                 // sendMessageToMainPage('reload_model');
@@ -5467,14 +5505,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         _earlyBackBtn.removeEventListener('click', _earlyBackHandler);
     }
     backToMainBtn.addEventListener('click', async () => {
-        // 检查是否有未保存的更改：先比对当前模型选择和已保存快照，一致则视为无更改
+        // 退出前：比对当前设置和已保存快照，完全一致则视为无更改
         if (window.hasUnsavedChanges && window._savedModelSnapshot) {
-            const snap = window._savedModelSnapshot;
-            // 只比较当前激活分支的模型选择，隐藏分支的变化不触发未保存提示
-            const branchMatch = currentModelType === 'live2d'
-                ? (modelSelect ? modelSelect.value : '') === snap.live2d
-                : (vrmModelSelect ? vrmModelSelect.value : '') === snap.live3d;
-            if (currentModelType === snap.modelType && branchMatch) {
+            if (snapshotsEqual(window._savedModelSnapshot, captureSettingsSnapshot())) {
                 window.hasUnsavedChanges = false;
             }
         }
@@ -7144,12 +7177,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    // 记录初始化完成时各 select 的已保存值，用于退出前判断模型是否真的被改过
-    window._savedModelSnapshot = {
-        modelType: currentModelType,
-        live2d: modelSelect ? modelSelect.value : '',
-        live3d: vrmModelSelect ? vrmModelSelect.value : '',
-    };
+    // 等待异步设置（打光、待机动作等）加载完成后记录快照
+    setTimeout(() => {
+        window._savedModelSnapshot = captureSettingsSnapshot();
+    }, 500);
   } catch (_fatalError) {
     console.error('[模型管理] DOMContentLoaded 致命错误:', _fatalError);
     const _s = document.getElementById('status-text');


### PR DESCRIPTION
1. 初始化加载角色模型时 dispatchEvent('change') 误触发 hasUnsavedChanges， 导致什么都没改也弹"未保存"提示。
2. 打光、待机动作等设置修改后退出不会触发未保存提示。

改为快照比对机制：初始化完成后记录所有可保存设置的快照，退出前对比当前值
和快照，不一致才弹提示。同时在各打光/待机动作 handler 中追加 dirty 标记，
让 beforeunload 等检查点也能正确拦截。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **功能改进**
  * 增强了未保存更改的检测功能，现已涵盖模型选择、灯光设置和动画配置等多个设置项。
  * 优化了离开页面时的确认提示逻辑，现可更准确地检测所有已修改的内容。

* **国际化**
  * 改进了动画选择相关的文本翻译支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->