### PR TITLE
Fix(mmd): reset idle animation for MMD request stage; fix eye jitter on motion switch 

### DIFF
--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -894,6 +894,16 @@ window.Jukebox = {
     }
   },
 
+  _resetToNoneMode: function() {
+    const mesh = window.mmdManager.currentModel?.mesh;
+    if (mesh?.skeleton) {
+      mesh.skeleton.pose();
+    }
+    if (window.mmdManager.cursorFollow) {
+      window.mmdManager.cursorFollow.setAnimationMode('none');
+    }
+  },
+
   restoreIdleAnimation: async function() {
     if (!window.mmdManager) return;
 
@@ -923,13 +933,7 @@ window.Jukebox = {
     if (restoreRequestId !== Jukebox.State.playRequestId) return;
 
     if (!idleUrl) {
-      const mesh = window.mmdManager.currentModel?.mesh;
-      if (mesh?.skeleton) {
-        mesh.skeleton.pose();
-      }
-      if (window.mmdManager.cursorFollow) {
-        window.mmdManager.cursorFollow.setAnimationMode('none');
-      }
+      Jukebox._resetToNoneMode();
       return;
     }
 
@@ -940,13 +944,8 @@ window.Jukebox = {
       console.log('[Jukebox]', window.t('Jukebox.idleRestored', '已恢复待机动画'));
     } catch (error) {
       console.warn('[Jukebox]', window.t('Jukebox.idleRestoreFailed', '恢复待机动画失败'), error);
-      const mesh = window.mmdManager.currentModel?.mesh;
-      if (mesh?.skeleton) {
-        mesh.skeleton.pose();
-      }
-      if (window.mmdManager.cursorFollow) {
-        window.mmdManager.cursorFollow.setAnimationMode('none');
-      }
+      if (restoreRequestId !== Jukebox.State.playRequestId) return;
+      Jukebox._resetToNoneMode();
     }
   },
 

--- a/static/mmd-animation.js
+++ b/static/mmd-animation.js
@@ -10,9 +10,6 @@ class MMDAnimation {
         // 异步加载请求 ID（用于取消过期请求）
         this._loadRequestId = 0;
 
-        // stop() rAF 回调序列 ID（用于取消过时的回调）
-        this._stopRafSeqId = 0;
-
         // 动画状态
         this.mixer = null;
         this.currentAction = null;
@@ -225,7 +222,6 @@ class MMDAnimation {
 
         if (this.manager?.cursorFollow) {
             const cf = this.manager.cursorFollow;
-            const prevTargetWeight = cf._targetWeight;
             cf._appliedLastFrame = false;
             cf._targetWeight = 0;
             cf._trackingWeight = 0;
@@ -236,12 +232,6 @@ class MMDAnimation {
             cf._targetPitch = 0;
             if (cf._neckBone) cf._neckBaseQuat.copy(cf._neckBone.quaternion);
             if (cf._headBone) cf._headBaseQuat.copy(cf._headBone.quaternion);
-            const seqId = ++this._stopRafSeqId || 1;
-            requestAnimationFrame(() => {
-                if (seqId === this._stopRafSeqId) {
-                    cf._targetWeight = prevTargetWeight;
-                }
-            });
         }
 
         this.isPlaying = false;

--- a/static/mmd-manager.js
+++ b/static/mmd-manager.js
@@ -191,9 +191,6 @@ class MMDManager {
             this.animationModule.stop();
         }
         this.currentAnimationUrl = null;
-        if (this.cursorFollow) {
-            this.cursorFollow.setAnimationMode('none');
-        }
     }
 
     // ═══════════════════ 表情/口型 ═══════════════════


### PR DESCRIPTION
- 修复无动作情况下的点歌台问题
-  修读模型管理中，从其他动作切换到无动作导致的眼睛乱晃问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化空闲动画的保存与恢复：避免后续播放覆盖已保存的空闲动画，并忽略来自 /jukebox/song_ 的舞蹈来源。
  * 新增“重置为无模式”行为，恢复/失败时更可靠地重置模型到绑定姿势并清除跟随状态。
  * 加强播放/停止/加载流程中 cursorFollow 的状态与权重重置，减少残留姿态与竞态问题。
  * 停止动画时不再强制切换 cursorFollow 模式为 none。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->