### PR TITLE
修复声音克隆自定义前缀未填写时的提示信息

### DIFF
--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -331,16 +331,30 @@ function registerVoice() {
 
     // 根据克隆方式验证输入
     if (currentCloneMethod === 'file') {
-        if (!fileInput.files.length || !prefix) {
-            resultDiv.textContent = window.t ? window.t('voice.pleaseUploadFile') : '请上传音频文件并填写前缀';
+        // 先检查文件
+        if (!fileInput.files.length) {
+            resultDiv.textContent = window.t ? window.t('voice.pleaseUploadFile') : '请选择音频文件';
+            resultDiv.className = 'result error';
+            return;
+        }
+        // 再检查前缀
+        if (!prefix) {
+            resultDiv.textContent = window.t ? window.t('voice.pleaseEnterPrefix') : '请填写自定义前缀';
             resultDiv.className = 'result error';
             return;
         }
     } else {
         // 直链克隆
         const url = directLinkUrl.value.trim();
-        if (!url || !prefix) {
-            resultDiv.textContent = window.t ? window.t('voice.pleaseEnterDirectLink') : '请输入音频直链URL并填写前缀';
+        // 先检查URL
+        if (!url) {
+            resultDiv.textContent = window.t ? window.t('voice.pleaseEnterDirectLink') : '请输入音频直链URL';
+            resultDiv.className = 'result error';
+            return;
+        }
+        // 再检查前缀
+        if (!prefix) {
+            resultDiv.textContent = window.t ? window.t('voice.pleaseEnterPrefix') : '请填写自定义前缀';
             resultDiv.className = 'result error';
             return;
         }

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1184,7 +1184,7 @@
         "directLinkUrl": "Audio Direct Link URL (8 seconds recommended, max 20 seconds, wav/mp3 format)",
         "directLinkPlaceholder": "https://example.com/audio.wav",
         "directLinkHint": "Enter a publicly accessible audio file direct link. The system will skip the upload step and use this link directly to register the voice.",
-        "pleaseEnterDirectLink": "Please enter audio direct link URL and prefix",
+        "pleaseEnterDirectLink": "Please enter audio direct link URL",
         "invalidDirectLink": "Please enter a valid HTTP/HTTPS link",
         "silenceModal": {
             "title": "Smart Silence Detection Results",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1184,7 +1184,7 @@
         "directLinkUrl": "音声直リンクURL（8秒が最適、最大20秒、wav/mp3形式）",
         "directLinkPlaceholder": "https://example.com/audio.wav",
         "directLinkHint": "公開アクセス可能な音声ファイルの直リンクを入力してください。システムはアップロード手順をスキップし、このリンクを直接使用して音声を登録します。",
-        "pleaseEnterDirectLink": "音声直リンクURLとプレフィックスを入力してください",
+        "pleaseEnterDirectLink": "音声直リンクURLを入力してください",
         "invalidDirectLink": "有効なHTTP/HTTPSリンクを入力してください",
         "silenceModal": {
             "title": "スマート無音検出結果",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1184,7 +1184,7 @@
         "directLinkUrl": "오디오 직접 링크 URL (8초 권장, 최대 20초, wav/mp3 형식)",
         "directLinkPlaceholder": "https://example.com/audio.wav",
         "directLinkHint": "공개 접근 가능한 오디오 파일의 직접 링크를 입력하세요. 시스템은 업로드 단계를 건너뛰고 이 링크를 직접 사용하여 음성을 등록합니다.",
-        "pleaseEnterDirectLink": "오디오 직접 링크 URL과 접두사를 입력하세요",
+        "pleaseEnterDirectLink": "오디오 직접 링크 URL을 입력하세요",
         "invalidDirectLink": "유효한 HTTP/HTTPS 링크를 입력하세요",
         "silenceModal": {
             "title": "스마트 무음 감지 결과",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1184,7 +1184,7 @@
         "directLinkUrl": "URL прямой ссылки на аудио (оптимально 8 сек, макс. 20 сек, формат wav/mp3)",
         "directLinkPlaceholder": "https://example.com/audio.wav",
         "directLinkHint": "Введите прямую ссылку на общедоступный аудиофайл. Система пропустит шаг загрузки и напрямую использует эту ссылку для регистрации голоса.",
-        "pleaseEnterDirectLink": "Пожалуйста, введите URL прямой ссылки на аудио и префикс",
+        "pleaseEnterDirectLink": "Пожалуйста, введите URL прямой ссылки на аудио",
         "invalidDirectLink": "Пожалуйста, введите действительную HTTP/HTTPS ссылку",
         "silenceModal": {
             "title": "Результаты обнаружения тишины",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1184,7 +1184,7 @@
         "directLinkUrl": "音频直链URL（8秒最佳，请勿超过20秒，wav/mp3格式）",
         "directLinkPlaceholder": "https://example.com/audio.wav",
         "directLinkHint": "输入可公网访问的音频文件直链，系统将跳过上传步骤直接使用该链接注册音色",
-        "pleaseEnterDirectLink": "请输入音频直链URL并填写前缀",
+        "pleaseEnterDirectLink": "请输入音频直链URL",
         "invalidDirectLink": "请输入有效的HTTP/HTTPS链接",
         "silenceModal": {
             "title": "智能空白音频检测结果",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1184,7 +1184,7 @@
         "directLinkUrl": "音訊直鏈URL（8秒最佳，請勿超過20秒，wav/mp3格式）",
         "directLinkPlaceholder": "https://example.com/audio.wav",
         "directLinkHint": "輸入可公開存取的音訊檔案直鏈，系統將跳過上傳步驟直接使用該連結註冊音色",
-        "pleaseEnterDirectLink": "請輸入音訊直鏈URL並填寫前綴",
+        "pleaseEnterDirectLink": "請輸入音訊直鏈URL",
         "invalidDirectLink": "請輸入有效的HTTP/HTTPS連結",
         "silenceModal": {
             "title": "智慧空白音訊檢測結果",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug修复**
  * 优化声音克隆流程的输入校验，文件上传和直接链接模式分别给出独立且更准确的错误提示。
  * 统一在校验失败时展示错误样式，提升可见性和一致性。

* **本地化**
  * 更新多语言提示文案，直接链接提示不再要求同时说明“前缀”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->