### PR TITLE
feat: 待机动画在循环结束时切换，避免动作中途跳变

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -4289,10 +4289,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // ===== 待机动作多选：工具函数 =====
 
-    /** 待机动作轮换定时器 */
+    /** 待机动作轮换定时器（回退用，防止动画过长不切换） */
     const _idleRotationTimers = { vrm: null, mmd: null };
     /** 上一次播放的 URL（避免连续播放同一个） */
     const _idleRotationLast = { vrm: null, mmd: null };
+    /** loop 事件监听器清理函数（动画一轮播完时自动切换） */
+    const _idleLoopCleanup = { vrm: null, mmd: null };
 
     /** 从多选容器中获取所有已勾选的动画 URL 列表 */
     function getSelectedIdleAnimations(containerId) {
@@ -4371,12 +4373,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     });
 
+    /** 清理 loop 事件监听器 */
+    function _cleanupIdleLoopListener(type) {
+        if (_idleLoopCleanup[type]) {
+            _idleLoopCleanup[type]();
+            _idleLoopCleanup[type] = null;
+        }
+    }
+
     /** 停止待机动作轮换 */
     function stopIdleRotation(type) {
         if (_idleRotationTimers[type]) {
             clearTimeout(_idleRotationTimers[type]);
             _idleRotationTimers[type] = null;
         }
+        _cleanupIdleLoopListener(type);
         _idleRotationLast[type] = null;
     }
 
@@ -4390,30 +4401,41 @@ document.addEventListener('DOMContentLoaded', async () => {
         _playIdleAnimation(type, firstUrl);
         _idleRotationLast[type] = firstUrl;
 
-        // 多于 1 个才定时轮换
+        // 多于 1 个才轮换（loop 事件 + 回退定时器）
         if (urls.length > 1) {
-            _scheduleNextIdle(type, urls);
+            _scheduleNextIdle(type);
         }
     }
 
-    function _scheduleNextIdle(type, urls) {
+    /** 触发一次待机动作切换（loop 完成或回退定时器都走这里） */
+    function _triggerIdleSwitch(type) {
+        // 清理当前的定时器和 loop 监听器
+        if (_idleRotationTimers[type]) {
+            clearTimeout(_idleRotationTimers[type]);
+            _idleRotationTimers[type] = null;
+        }
+        _cleanupIdleLoopListener(type);
+
+        // 模式不匹配时停止轮换
+        if (!_isIdleTypeActive(type)) return;
+
+        // 重新获取当前已选列表（用户可能在期间改了勾选）
+        const containerId = type === 'vrm' ? 'vrm-idle-animation-multiselect' : 'mmd-idle-animation-multiselect';
+        const currentUrls = getSelectedIdleAnimations(containerId);
+        if (currentUrls.length < 2) return;
+
+        const nextUrl = _pickRandomDifferent(currentUrls, _idleRotationLast[type]);
+        _playIdleAnimation(type, nextUrl); // loop 监听器会在动画加载完成后注册
+        _idleRotationLast[type] = nextUrl;
+        _scheduleNextIdle(type); // 设置回退定时器
+    }
+
+    /** 设置回退定时器（仅当动画过长未触发 loop 事件时强制切换） */
+    function _scheduleNextIdle(type) {
+        if (_idleRotationTimers[type]) clearTimeout(_idleRotationTimers[type]);
         _idleRotationTimers[type] = setTimeout(() => {
-            // 模式不匹配时停止轮换
-            if (!_isIdleTypeActive(type)) {
-                _idleRotationTimers[type] = null;
-                return;
-            }
-            // 重新获取当前已选列表（用户可能在期间改了勾选）
-            const containerId = type === 'vrm' ? 'vrm-idle-animation-multiselect' : 'mmd-idle-animation-multiselect';
-            const currentUrls = getSelectedIdleAnimations(containerId);
-            if (currentUrls.length < 2) {
-                _idleRotationTimers[type] = null;
-                return;
-            }
-            const nextUrl = _pickRandomDifferent(currentUrls, _idleRotationLast[type]);
-            _playIdleAnimation(type, nextUrl);
-            _idleRotationLast[type] = nextUrl;
-            _scheduleNextIdle(type, currentUrls);
+            console.debug(`[${type.toUpperCase()} IdleAnimation] 回退定时器触发，强制切换`);
+            _triggerIdleSwitch(type);
         }, 20000);
     }
 
@@ -4443,6 +4465,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (type === 'vrm' && isVrmAnimationPlaying) return;
         if (type === 'mmd' && isMmdAnimationPlaying) return;
 
+        // 播放新动画前先清理旧的 loop 监听器
+        _cleanupIdleLoopListener(type);
+
         try {
             if (type === 'vrm') {
                 if (vrmManager && vrmManager.animation && vrmManager.currentModel) {
@@ -4451,6 +4476,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                     }
                     await vrmManager.playVRMAAnimation(url, { loop: true, immediate: true, isIdle: true });
                     console.log('[VRM IdleAnimation] 待机动作已切换:', url.split('/').pop());
+
+                    // 注册 loop 事件监听：动画一轮播完时自动切换
+                    const mixer = vrmManager.animation?.vrmaMixer;
+                    if (mixer) {
+                        const handler = () => {
+                            console.debug('[VRM IdleAnimation] 动画循环完成，切换下一个');
+                            _triggerIdleSwitch('vrm');
+                        };
+                        mixer.addEventListener('loop', handler);
+                        _idleLoopCleanup['vrm'] = () => mixer.removeEventListener('loop', handler);
+                    }
                 }
             } else {
                 if (window.mmdManager && window.mmdManager.currentModel) {
@@ -4462,6 +4498,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                     window.mmdManager.playAnimation();
                     isMmdIdlePlaying = true;
                     console.log('[MMD IdleAnimation] 待机动作已切换:', url.split('/').pop());
+
+                    // 注册 loop 事件监听：动画一轮播完时自动切换
+                    const mixer = window.mmdManager.animationModule?.mixer;
+                    if (mixer) {
+                        const handler = () => {
+                            console.debug('[MMD IdleAnimation] 动画循环完成，切换下一个');
+                            _triggerIdleSwitch('mmd');
+                        };
+                        mixer.addEventListener('loop', handler);
+                        _idleLoopCleanup['mmd'] = () => mixer.removeEventListener('loop', handler);
+                    }
                 }
             }
         } catch (err) {

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -4396,15 +4396,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         stopIdleRotation(type);
         if (!urls || urls.length === 0) return;
 
-        // 立即播放一个
+        // 立即播放一个（回退定时器和 loop 监听器在 await 成功后由 _playIdleAnimation 内部注册）
         const firstUrl = urls.length === 1 ? urls[0] : _pickRandomDifferent(urls, _idleRotationLast[type]);
         _playIdleAnimation(type, firstUrl);
         _idleRotationLast[type] = firstUrl;
-
-        // 多于 1 个才轮换（loop 事件 + 回退定时器）
-        if (urls.length > 1) {
-            _scheduleNextIdle(type);
-        }
     }
 
     /** 触发一次待机动作切换（loop 完成或回退定时器都走这里） */
@@ -4425,9 +4420,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (currentUrls.length < 2) return;
 
         const nextUrl = _pickRandomDifferent(currentUrls, _idleRotationLast[type]);
-        _playIdleAnimation(type, nextUrl); // loop 监听器会在动画加载完成后注册
+        _playIdleAnimation(type, nextUrl); // loop 监听器和回退定时器在 await 成功后注册
         _idleRotationLast[type] = nextUrl;
-        _scheduleNextIdle(type); // 设置回退定时器
     }
 
     /** 设置回退定时器（仅当动画过长未触发 loop 事件时强制切换） */
@@ -4487,6 +4481,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                         mixer.addEventListener('loop', handler);
                         _idleLoopCleanup['vrm'] = () => mixer.removeEventListener('loop', handler);
                     }
+
+                    // 动画加载成功后再启动回退定时器（从实际播放开始计时）
+                    const vrmUrls = getSelectedIdleAnimations('vrm-idle-animation-multiselect');
+                    if (vrmUrls.length > 1) _scheduleNextIdle('vrm');
                 }
             } else {
                 if (window.mmdManager && window.mmdManager.currentModel) {
@@ -4509,6 +4507,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                         mixer.addEventListener('loop', handler);
                         _idleLoopCleanup['mmd'] = () => mixer.removeEventListener('loop', handler);
                     }
+
+                    // 动画加载成功后再启动回退定时器（从实际播放开始计时）
+                    const mmdUrls = getSelectedIdleAnimations('mmd-idle-animation-multiselect');
+                    if (mmdUrls.length > 1) _scheduleNextIdle('mmd');
                 }
             }
         } catch (err) {

--- a/static/mmd-init.js
+++ b/static/mmd-init.js
@@ -203,8 +203,22 @@ window.addEventListener('mmd-modules-ready', async () => {
 });
 
 // ── 主页面 MMD 待机动作轮换 ──────────────────────────────
+// 策略：优先在动画一轮播完（loop 事件）时切换，避免动作中途跳变；
+//       20 秒回退定时器仅在动画过长时强制切换。
 let _mmdIdleTimer = null;
 let _mmdIdleLastUrl = null;
+let _mmdIdleLoopCleanup = null;
+
+function _clearMmdIdleSchedule() {
+    if (_mmdIdleTimer) {
+        clearTimeout(_mmdIdleTimer);
+        _mmdIdleTimer = null;
+    }
+    if (_mmdIdleLoopCleanup) {
+        _mmdIdleLoopCleanup();
+        _mmdIdleLoopCleanup = null;
+    }
+}
 
 function _startMmdIdleRotation(urls) {
     _stopMmdIdleRotation();
@@ -215,36 +229,52 @@ function _startMmdIdleRotation(urls) {
         return candidates[Math.floor(Math.random() * candidates.length)] || urls[0];
     }
 
-    function scheduleNext() {
-        _mmdIdleTimer = setTimeout(async () => {
-            const mgr = window.mmdManager;
-            if (!mgr || !mgr.currentModel) {
-                _mmdIdleTimer = null;
-                return;
-            }
-            try {
-                const url = pickRandom();
-                if (url) {
-                    mgr.stopAnimation();
-                    await mgr.loadAnimation(url);
-                    mgr.playAnimation();
-                    _mmdIdleLastUrl = url;
-                    console.debug('[MMD IdleRotation] 切换待机动作:', url.split('/').pop());
+    async function switchToNext() {
+        _clearMmdIdleSchedule();
+
+        const mgr = window.mmdManager;
+        if (!mgr || !mgr.currentModel) return;
+
+        try {
+            const url = pickRandom();
+            if (url) {
+                mgr.stopAnimation();
+                await mgr.loadAnimation(url);
+                mgr.playAnimation();
+                _mmdIdleLastUrl = url;
+                console.debug('[MMD IdleRotation] 切换待机动作:', url.split('/').pop());
+
+                // 注册 loop 事件监听：动画一轮播完时自动切换
+                const mixer = mgr.animationModule?.mixer;
+                if (mixer) {
+                    const handler = () => {
+                        console.debug('[MMD IdleRotation] 动画循环完成，切换下一个');
+                        switchToNext();
+                    };
+                    mixer.addEventListener('loop', handler);
+                    _mmdIdleLoopCleanup = () => mixer.removeEventListener('loop', handler);
                 }
-            } catch (e) {
-                console.warn('[MMD IdleRotation] 切换失败:', e);
             }
-            scheduleNext();
+        } catch (e) {
+            console.warn('[MMD IdleRotation] 切换失败:', e);
+        }
+        scheduleFallback();
+    }
+
+    /** 设置回退定时器 */
+    function scheduleFallback() {
+        if (_mmdIdleTimer) clearTimeout(_mmdIdleTimer);
+        _mmdIdleTimer = setTimeout(() => {
+            console.debug('[MMD IdleRotation] 回退定时器触发，强制切换');
+            switchToNext();
         }, 20000);
     }
-    scheduleNext();
+
+    scheduleFallback();
 }
 
 function _stopMmdIdleRotation() {
-    if (_mmdIdleTimer) {
-        clearTimeout(_mmdIdleTimer);
-        _mmdIdleTimer = null;
-    }
+    _clearMmdIdleSchedule();
     _mmdIdleLastUrl = null;
 }
 

--- a/static/mmd-init.js
+++ b/static/mmd-init.js
@@ -271,6 +271,18 @@ function _startMmdIdleRotation(urls) {
     }
 
     scheduleFallback();
+
+    // 如果动画已经在播放（如 app-interpage.js 预先播放的第一个），
+    // 立即注册 loop 监听器，不必等 20 秒回退定时器
+    const mixer = window.mmdManager?.animationModule?.mixer;
+    if (mixer) {
+        const handler = () => {
+            console.debug('[MMD IdleRotation] 初始动画循环完成，切换下一个');
+            switchToNext();
+        };
+        mixer.addEventListener('loop', handler);
+        _mmdIdleLoopCleanup = () => mixer.removeEventListener('loop', handler);
+    }
 }
 
 function _stopMmdIdleRotation() {

--- a/static/vrm-init.js
+++ b/static/vrm-init.js
@@ -618,8 +618,22 @@ async function initVRMModel() {
 }
 
 // ── 主页面 VRM 待机动作轮换 ──────────────────────────────
+// 策略：优先在动画一轮播完（loop 事件）时切换，避免动作中途跳变；
+//       20 秒回退定时器仅在动画过长时强制切换。
 let _vrmIdleTimer = null;
 let _vrmIdleLastUrl = null;
+let _vrmIdleLoopCleanup = null;
+
+function _clearVrmIdleSchedule() {
+    if (_vrmIdleTimer) {
+        clearTimeout(_vrmIdleTimer);
+        _vrmIdleTimer = null;
+    }
+    if (_vrmIdleLoopCleanup) {
+        _vrmIdleLoopCleanup();
+        _vrmIdleLoopCleanup = null;
+    }
+}
 
 function _startVrmIdleRotation(urls) {
     _stopVrmIdleRotation();
@@ -630,35 +644,51 @@ function _startVrmIdleRotation(urls) {
         return candidates[Math.floor(Math.random() * candidates.length)] || urls[0];
     }
 
-    function scheduleNext() {
-        _vrmIdleTimer = setTimeout(async () => {
-            const mgr = window.vrmManager;
-            if (!mgr || !mgr.currentModel || !mgr.animation) {
-                _vrmIdleTimer = null;
-                return;
-            }
-            try {
-                const url = pickRandom();
-                if (url) {
-                    if (mgr.vrmaAction) mgr.stopVRMAAnimation();
-                    await mgr.playVRMAAnimation(url, { loop: true, immediate: true, isIdle: true });
-                    _vrmIdleLastUrl = url;
-                    console.debug('[VRM IdleRotation] 切换待机动作:', url.split('/').pop());
+    async function switchToNext() {
+        _clearVrmIdleSchedule();
+
+        const mgr = window.vrmManager;
+        if (!mgr || !mgr.currentModel || !mgr.animation) return;
+
+        try {
+            const url = pickRandom();
+            if (url) {
+                if (mgr.vrmaAction) mgr.stopVRMAAnimation();
+                await mgr.playVRMAAnimation(url, { loop: true, immediate: true, isIdle: true });
+                _vrmIdleLastUrl = url;
+                console.debug('[VRM IdleRotation] 切换待机动作:', url.split('/').pop());
+
+                // 注册 loop 事件监听：动画一轮播完时自动切换
+                const mixer = mgr.animation?.vrmaMixer;
+                if (mixer) {
+                    const handler = () => {
+                        console.debug('[VRM IdleRotation] 动画循环完成，切换下一个');
+                        switchToNext();
+                    };
+                    mixer.addEventListener('loop', handler);
+                    _vrmIdleLoopCleanup = () => mixer.removeEventListener('loop', handler);
                 }
-            } catch (e) {
-                console.warn('[VRM IdleRotation] 切换失败:', e);
             }
-            scheduleNext();
+        } catch (e) {
+            console.warn('[VRM IdleRotation] 切换失败:', e);
+        }
+        scheduleFallback();
+    }
+
+    /** 设置回退定时器 */
+    function scheduleFallback() {
+        if (_vrmIdleTimer) clearTimeout(_vrmIdleTimer);
+        _vrmIdleTimer = setTimeout(() => {
+            console.debug('[VRM IdleRotation] 回退定时器触发，强制切换');
+            switchToNext();
         }, 20000);
     }
-    scheduleNext();
+
+    scheduleFallback();
 }
 
 function _stopVrmIdleRotation() {
-    if (_vrmIdleTimer) {
-        clearTimeout(_vrmIdleTimer);
-        _vrmIdleTimer = null;
-    }
+    _clearVrmIdleSchedule();
     _vrmIdleLastUrl = null;
 }
 

--- a/static/vrm-init.js
+++ b/static/vrm-init.js
@@ -685,6 +685,18 @@ function _startVrmIdleRotation(urls) {
     }
 
     scheduleFallback();
+
+    // 如果动画已经在播放（如外部预先播放的第一个待机动作），
+    // 立即注册 loop 监听器，不必等 20 秒回退定时器
+    const mixer = window.vrmManager?.animation?.vrmaMixer;
+    if (mixer) {
+        const handler = () => {
+            console.debug('[VRM IdleRotation] 初始动画循环完成，切换下一个');
+            switchToNext();
+        };
+        mixer.addEventListener('loop', handler);
+        _vrmIdleLoopCleanup = () => mixer.removeEventListener('loop', handler);
+    }
 }
 
 function _stopVrmIdleRotation() {


### PR DESCRIPTION
## Summary

- 待机动画轮换改为监听 `THREE.AnimationMixer` 的 `loop` 事件，在动画自然完成一个循环后再切换到下一个，消除动作中途被打断的跳变感
- 原有的 20 秒定时切换降级为回退机制，仅在单轮动画超过 20 秒时强制切换，防止过长动画卡死轮换
- 三处独立的待机轮换系统（`model_manager.js`、`vrm-init.js`、`mmd-init.js`）均已同步修改

## 实现细节

| 机制 | 触发条件 | 作用 |
|---|---|---|
| `loop` 事件监听 | 动画播完一轮 | 主要切换路径，过渡自然 |
| 20s `setTimeout` | 动画持续超过 20 秒 | 回退保护，防止卡死 |

- `loop` 监听器在 `await playVRMAAnimation()` / `await loadAnimation()` 之后注册，确保 mixer 已就绪
- 每次切换前清理旧监听器再注册新的，防止事件泄漏
- 两种机制互斥：无论谁先触发都会清理对方，避免重复切换

## Test plan

- [ ] VRM 模型：勾选 2+ 个待机动作，观察是否在动画自然播完一轮后切换（而非固定 20 秒）
- [ ] MMD 模型：同上验证
- [ ] 使用时长超过 20 秒的动画，验证回退定时器是否正常强制切换
- [ ] 切换过程中勾选/取消勾选待机动作，验证轮换状态正确更新
- [ ] 仅勾选 1 个待机动作时，验证不会触发轮换逻辑

https://claude.ai/code/session_01XCY2qbcVeD9EFS83kYpuyP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug修复**
  * 优化空闲动画轮换：改为基于动画“loop”事件的驱动并保留20秒回退计时，提升切换时机准确性与流畅性。
  * 强化监听器与定时器清理，避免过期/重复监听导致的资源泄漏与异常。

* **新功能**
  * 切换时实时读取当前多选设置，若空闲模式已关闭则停止轮换。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->