### PR TITLE
fix: VRM 模型发送消息后消失 + Task HUD 轮询冗余清理

### DIFF
--- a/static/app-agent.js
+++ b/static/app-agent.js
@@ -1558,8 +1558,16 @@
     };
 
     window.stopAgentTaskPolling = function () {
-        console.log('[App] \u505c\u6b62 Agent \u4efb\u52a1\u72b6\u6001\u8f6e\u8be2');
-        console.trace('[App] stopAgentTaskPolling caller trace');
+        // 如果轮询已经停止，跳过重复清理
+        if (!agentTaskPollingInterval && !agentTaskTimeUpdateInterval && !window._agentTaskTimeUpdateInterval) {
+            // 仍然确保 HUD 隐藏（幂等操作）
+            if (window.AgentHUD && window.AgentHUD.hideAgentTaskHUD) {
+                window.AgentHUD.hideAgentTaskHUD();
+            }
+            return;
+        }
+
+        console.log('[App] 停止 Agent 任务状态轮询');
 
         if (agentTaskTimeUpdateInterval) {
             clearInterval(agentTaskTimeUpdateInterval);
@@ -1674,7 +1682,7 @@
         }
 
         if (isMasterOn && isChildOn) {
-            console.log('[DEBUG HUD] Starting polling. Master:', isMasterOn, 'Child:', isChildOn, 'DOM:', domMaster, domChild, 'Flag:', flags?.agent_enabled, 'Opt:', optMaster, optChild);
+            console.log('[HUD] Starting polling. Master:', isMasterOn, 'Child:', isChildOn);
             window.startAgentTaskPolling();
         } else {
             const LINGER_MS = 10000;
@@ -1686,9 +1694,8 @@
                     return isTerminal && t.terminal_at && (now - t.terminal_at < LINGER_MS);
                 });
             if (hasActiveTasks) {
-                console.log('[DEBUG HUD] Flags off but active tasks exist, keeping HUD visible. Master:', isMasterOn, 'Child:', isChildOn);
+                // 开关已关但还有活跃任务，保持 HUD 可见
             } else {
-                console.log('[DEBUG HUD] Stopping polling. Master:', isMasterOn, 'Child:', isChildOn, 'DOM:', domMaster, domChild, 'Flag:', flags?.agent_enabled, 'Opt:', optMaster, optChild);
                 window.stopAgentTaskPolling();
             }
         }

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -150,7 +150,13 @@
             const modelType = catgirlConfig.model_type || (catgirlConfig.vrm ? 'vrm' : 'live2d');
 
             // 检测 live3d 子类型：优先使用 live3d_sub_type（后端权威来源）
-            const _sanitize = v => (typeof v === 'string' && v.trim() && v !== 'undefined' && v !== 'null') ? v : '';
+            const _sanitize = (v) => {
+                if (v === undefined || v === null) return '';
+                const s = String(v).trim();
+                const lower = s.toLowerCase();
+                if (!s || lower === 'undefined' || lower === 'null') return '';
+                return s;
+            };
             let mmdPath = '';
             let vrmPath = '';
             let effectiveModelType = modelType;

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -149,26 +149,39 @@
 
             const modelType = catgirlConfig.model_type || (catgirlConfig.vrm ? 'vrm' : 'live2d');
 
-            // 检测 live3d 子类型（优先检查 MMD，与后端 _get_live3d_sub_type 保持一致）
+            // 检测 live3d 子类型：优先使用 live3d_sub_type（后端权威来源）
             const _sanitize = v => (typeof v === 'string' && v.trim() && v !== 'undefined' && v !== 'null') ? v : '';
             let mmdPath = '';
             let vrmPath = '';
             let effectiveModelType = modelType;
             if (modelType === 'live3d') {
-                mmdPath = _sanitize(catgirlConfig.mmd)
-                    || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
-                    || '';
-                vrmPath = _sanitize(catgirlConfig.vrm)
-                    || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
-                    || '';
-                if (mmdPath) {
-                    effectiveModelType = 'mmd';
-                } else if (vrmPath) {
+                const subType = (
+                    catgirlConfig._reserved?.avatar?.live3d_sub_type
+                    || catgirlConfig.live3d_sub_type
+                    || ''
+                ).toString().trim().toLowerCase();
+
+                if (subType === 'vrm') {
                     effectiveModelType = 'vrm';
+                } else if (subType === 'mmd') {
+                    effectiveModelType = 'mmd';
                 } else {
-                    effectiveModelType = 'live2d'; // fallback
+                    // sub_type 缺失时回退到路径探测
+                    mmdPath = _sanitize(catgirlConfig.mmd)
+                        || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
+                        || '';
+                    vrmPath = _sanitize(catgirlConfig.vrm)
+                        || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
+                        || '';
+                    if (mmdPath && !vrmPath) {
+                        effectiveModelType = 'mmd';
+                    } else if (vrmPath) {
+                        effectiveModelType = 'vrm';
+                    } else {
+                        effectiveModelType = 'live2d';
+                    }
                 }
-                console.log('[猫娘切换] live3d 子类型检测:', effectiveModelType, '(mmd:', !!mmdPath, 'vrm:', !!vrmPath, ')');
+                console.log('[猫娘切换] live3d 子类型检测:', effectiveModelType, '(subType:', subType, 'mmd:', !!mmdPath, 'vrm:', !!vrmPath, ')');
             }
             console.log('[猫娘切换] effectiveModelType:', effectiveModelType);
 

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -1061,16 +1061,6 @@
                 }
 
             } else {
-                // 如果当前有 VRM/MMD 模型在运行，不要切换到 Live2D
-                if (isVrmCurrentlyActive) {
-                    console.log('[showCurrentModel] effectiveModelType 为', effectiveModelType, '但 VRM 模型正在运行，保持 VRM');
-                    return;
-                }
-                if (isMmdCurrentlyActive) {
-                    console.log('[showCurrentModel] effectiveModelType 为', effectiveModelType, '但 MMD 模型正在运行，保持 MMD');
-                    return;
-                }
-
                 // 显示 Live2D 模型
                 showLive2d();
 

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -1086,7 +1086,14 @@
             }
         } catch (error) {
             console.error('[showCurrentModel] 失败:', error);
-            showLive2d(); // 出错时默认显示Live2D
+            // 出错时检查是否有 VRM/MMD 正在运行，如果有则保持当前状态
+            const isVrmRunning = window.vrmManager && window.vrmManager.currentModel;
+            const isMmdRunning = window.mmdManager && window.mmdManager.currentModel;
+            if (isVrmRunning || isMmdRunning) {
+                console.log('[showCurrentModel] 保持当前已加载的模型');
+                return;
+            }
+            showLive2d();
         }
     }
 

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -779,7 +779,13 @@
                     effectiveModelType = 'mmd';
                 } else {
                     // sub_type 缺失时回退到路径探测
-                    const _sanitize = v => (typeof v === 'string' && v.trim() && v !== 'undefined' && v !== 'null') ? v : '';
+                    const _sanitize = (v) => {
+                        if (v === undefined || v === null) return '';
+                        const s = String(v).trim();
+                        const lower = s.toLowerCase();
+                        if (!s || lower === 'undefined' || lower === 'null') return '';
+                        return s;
+                    };
                     const mmdPath = _sanitize(catgirlConfig.mmd)
                         || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
                         || '';

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -724,9 +724,18 @@
         }
 
         try {
+            // 运行时检测当前已加载的模型类型，用于 API 失败时的回退
+            const isVrmCurrentlyActive = window.vrmManager && window.vrmManager.currentModel;
+            const isMmdCurrentlyActive = window.mmdManager && window.mmdManager.currentModel;
+
             const charResponse = await fetch('/api/characters');
             if (!charResponse.ok) {
-                console.warn('[showCurrentModel] 无法获取角色配置，默认显示Live2D');
+                console.warn('[showCurrentModel] 无法获取角色配置');
+                // 如果当前已有 VRM/MMD 模型在运行，保持当前状态而非回退到 Live2D
+                if (isVrmCurrentlyActive || isMmdCurrentlyActive) {
+                    console.log('[showCurrentModel] 保持当前已加载的模型');
+                    return;
+                }
                 showLive2d();
                 return;
             }
@@ -736,7 +745,11 @@
             const catgirlConfig = charactersData['猫娘']?.[currentCatgirl];
 
             if (!catgirlConfig) {
-                console.warn('[showCurrentModel] 未找到角色配置，默认显示Live2D');
+                console.warn('[showCurrentModel] 未找到角色配置');
+                if (isVrmCurrentlyActive || isMmdCurrentlyActive) {
+                    console.log('[showCurrentModel] 保持当前已加载的模型');
+                    return;
+                }
                 showLive2d();
                 return;
             }
@@ -757,6 +770,11 @@
                     effectiveModelType = 'mmd';
                 } else if (vrmPath) {
                     effectiveModelType = 'vrm';
+                } else if (isVrmCurrentlyActive) {
+                    // live3d 类型但无法解析出具体子类型时，依据当前运行时状态
+                    effectiveModelType = 'vrm';
+                } else if (isMmdCurrentlyActive) {
+                    effectiveModelType = 'mmd';
                 }
             }
             console.log('[showCurrentModel] 当前角色模型类型:', modelType, '有效类型:', effectiveModelType);
@@ -1021,6 +1039,16 @@
                 }
 
             } else {
+                // 如果当前有 VRM/MMD 模型在运行，不要切换到 Live2D
+                if (isVrmCurrentlyActive) {
+                    console.log('[showCurrentModel] effectiveModelType 为', effectiveModelType, '但 VRM 模型正在运行，保持 VRM');
+                    return;
+                }
+                if (isMmdCurrentlyActive) {
+                    console.log('[showCurrentModel] effectiveModelType 为', effectiveModelType, '但 MMD 模型正在运行，保持 MMD');
+                    return;
+                }
+
                 // 显示 Live2D 模型
                 showLive2d();
 

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -724,9 +724,14 @@
         }
 
         try {
-            // 运行时检测当前已加载的模型类型，用于 API 失败时的回退
-            const isVrmCurrentlyActive = window.vrmManager && window.vrmManager.currentModel;
-            const isMmdCurrentlyActive = window.mmdManager && window.mmdManager.currentModel;
+            // 运行时检测当前已加载且可见的模型，用于 API 失败时的回退
+            // 需同时检查模型引用和容器可见性（goodbye 流程中模型引用存在但容器已隐藏）
+            const _vrmEl = document.getElementById('vrm-container');
+            const _mmdEl = document.getElementById('mmd-container');
+            const isVrmCurrentlyActive = window.vrmManager && window.vrmManager.currentModel
+                && _vrmEl && _vrmEl.style.display !== 'none' && !_vrmEl.classList.contains('hidden');
+            const isMmdCurrentlyActive = window.mmdManager && window.mmdManager.currentModel
+                && _mmdEl && _mmdEl.style.display !== 'none' && !_mmdEl.classList.contains('hidden');
 
             const charResponse = await fetch('/api/characters');
             if (!charResponse.ok) {
@@ -756,25 +761,36 @@
 
             const modelType = catgirlConfig.model_type || (catgirlConfig.vrm ? 'vrm' : 'live2d');
 
-            // 解析 live3d 子类型（与 app-character.js 保持一致）
+            // 解析 live3d 子类型
+            // 优先使用 live3d_sub_type（后端权威来源），与 vrm-init.js / live2d-init.js 保持一致
+            // 旧逻辑仅通过 mmd/vrm 路径字段猜测，当两个字段同时存在时会误判
             let effectiveModelType = modelType;
             if (modelType === 'live3d') {
-                const _sanitize = v => (typeof v === 'string' && v.trim() && v !== 'undefined' && v !== 'null') ? v : '';
-                const mmdPath = _sanitize(catgirlConfig.mmd)
-                    || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
-                    || '';
-                const vrmPath = _sanitize(catgirlConfig.vrm)
-                    || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
-                    || '';
-                if (mmdPath) {
-                    effectiveModelType = 'mmd';
-                } else if (vrmPath) {
+                const subType = (
+                    window.lanlan_config?.live3d_sub_type
+                    || catgirlConfig._reserved?.avatar?.live3d_sub_type
+                    || catgirlConfig.live3d_sub_type
+                    || ''
+                ).toString().trim().toLowerCase();
+
+                if (subType === 'vrm') {
                     effectiveModelType = 'vrm';
-                } else if (isVrmCurrentlyActive) {
-                    // live3d 类型但无法解析出具体子类型时，依据当前运行时状态
-                    effectiveModelType = 'vrm';
-                } else if (isMmdCurrentlyActive) {
+                } else if (subType === 'mmd') {
                     effectiveModelType = 'mmd';
+                } else {
+                    // sub_type 缺失时回退到路径探测
+                    const _sanitize = v => (typeof v === 'string' && v.trim() && v !== 'undefined' && v !== 'null') ? v : '';
+                    const mmdPath = _sanitize(catgirlConfig.mmd)
+                        || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
+                        || '';
+                    const vrmPath = _sanitize(catgirlConfig.vrm)
+                        || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
+                        || '';
+                    if (mmdPath && !vrmPath) {
+                        effectiveModelType = 'mmd';
+                    } else if (vrmPath) {
+                        effectiveModelType = 'vrm';
+                    }
                 }
             }
             console.log('[showCurrentModel] 当前角色模型类型:', modelType, '有效类型:', effectiveModelType);
@@ -1086,9 +1102,13 @@
             }
         } catch (error) {
             console.error('[showCurrentModel] 失败:', error);
-            // 出错时检查是否有 VRM/MMD 正在运行，如果有则保持当前状态
-            const isVrmRunning = window.vrmManager && window.vrmManager.currentModel;
-            const isMmdRunning = window.mmdManager && window.mmdManager.currentModel;
+            // 出错时检查是否有 VRM/MMD 正在运行且可见，如果有则保持当前状态
+            const vrmEl = document.getElementById('vrm-container');
+            const mmdEl = document.getElementById('mmd-container');
+            const isVrmRunning = window.vrmManager && window.vrmManager.currentModel
+                && vrmEl && vrmEl.style.display !== 'none' && !vrmEl.classList.contains('hidden');
+            const isMmdRunning = window.mmdManager && window.mmdManager.currentModel
+                && mmdEl && mmdEl.style.display !== 'none' && !mmdEl.classList.contains('hidden');
             if (isVrmRunning || isMmdRunning) {
                 console.log('[showCurrentModel] 保持当前已加载的模型');
                 return;

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -600,14 +600,18 @@ window.AgentHUD.showAgentTaskHUD = function () {
 
 // 隐藏任务 HUD
 window.AgentHUD.hideAgentTaskHUD = function () {
-    console.log('[AgentHUD] hideAgentTaskHUD called');
-    let hud = document.getElementById('agent-task-hud');
+    const hud = document.getElementById('agent-task-hud');
     if (!hud) {
-        console.log('[AgentHUD] HUD element not found, creating it first to hide it properly');
-        hud = this.createAgentTaskHUD();
+        // HUD 不存在时无需创建再隐藏，直接返回
+        return;
     }
-    
-    console.log('[AgentHUD] HUD element found, starting fade out');
+
+    // 已经处于隐藏状态时跳过重复操作
+    if (hud.style.display === 'none') {
+        return;
+    }
+
+    console.log('[AgentHUD] hideAgentTaskHUD: starting fade out');
     hud.style.opacity = '0';
     const savedPos = localStorage.getItem('agent-task-hud-position');
     if (!savedPos) {
@@ -616,16 +620,13 @@ window.AgentHUD.hideAgentTaskHUD = function () {
 
     // 如果之前有正在等待的隐藏定时器，先清理掉
     if (this._hideTimeout) {
-        console.log('[AgentHUD][TimeoutTrace] hideAgentTaskHUD clearing previous timeout ID:', this._hideTimeout);
         clearTimeout(this._hideTimeout);
     }
 
     this._hideTimeout = setTimeout(() => {
-        console.log('[AgentHUD][TimeoutTrace] HUD element display set to none. Timeout ID was:', this._hideTimeout);
         hud.style.display = 'none';
         this._hideTimeout = null;
     }, 300);
-    console.log('[AgentHUD][TimeoutTrace] hideAgentTaskHUD set new timeout ID:', this._hideTimeout);
 };
 
 // 更新任务 HUD 内容

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -315,10 +315,7 @@
 
 
         if (typeof window.checkAndToggleTaskHUD === 'function') {
-            console.log('[AgentUIv2] Calling checkAndToggleTaskHUD from render()');
             window.checkAndToggleTaskHUD();
-        } else {
-            console.log('[AgentUIv2] checkAndToggleTaskHUD not found during render()');
         }
 
     }

--- a/static/js/chara_manager.js
+++ b/static/js/chara_manager.js
@@ -1985,8 +1985,10 @@ function showCatgirlForm(key, container) {
     const normalizedModelType = modelType === 'vrm' ? 'live3d' : modelType;
     let modelDisplayText = '';
 
-    const mmdPath = validateModelPath(cat['mmd']);
-    const vrmPath = validateModelPath(cat['vrm']);
+    const mmdPath = validateModelPath(cat['mmd'])
+        || validateModelPath(cat['_reserved']?.avatar?.mmd?.model_path);
+    const vrmPath = validateModelPath(cat['vrm'])
+        || validateModelPath(cat['_reserved']?.avatar?.vrm?.model_path);
     const live2dPath = validateModelPath(cat['live2d']);
 
     // 优先使用 live3d_sub_type 判断当前活跃的 3D 模型类型

--- a/static/js/chara_manager.js
+++ b/static/js/chara_manager.js
@@ -1989,8 +1989,18 @@ function showCatgirlForm(key, container) {
     const vrmPath = validateModelPath(cat['vrm']);
     const live2dPath = validateModelPath(cat['live2d']);
 
-    if (normalizedModelType === 'live3d' && mmdPath) {
-        // live3d 模式下 MMD 优先（VRM 是旧字段，可能遗留非空值，与后端 _get_live3d_sub_type 一致）
+    // 优先使用 live3d_sub_type 判断当前活跃的 3D 模型类型
+    const live3dSubType = String(
+        cat['_reserved']?.avatar?.live3d_sub_type || cat['live3d_sub_type'] || ''
+    ).trim().toLowerCase();
+
+    if (normalizedModelType === 'live3d' && live3dSubType === 'mmd' && mmdPath) {
+        const mmdName = (mmdPath.split(/[\\/]/).pop() || mmdPath).replace(/\.(pmx|pmd)$/i, '');
+        modelDisplayText = mmdName;
+    } else if (normalizedModelType === 'live3d' && live3dSubType === 'vrm' && vrmPath) {
+        const vrmName = (vrmPath.split(/[\\/]/).pop() || vrmPath).replace(/\.vrm$/i, '');
+        modelDisplayText = vrmName;
+    } else if (normalizedModelType === 'live3d' && mmdPath && !vrmPath) {
         const mmdName = (mmdPath.split(/[\\/]/).pop() || mmdPath).replace(/\.(pmx|pmd)$/i, '');
         modelDisplayText = mmdName;
     } else if (normalizedModelType === 'live3d' && vrmPath) {

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -7201,7 +7201,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
 
             const hasValidMMDPath = !!(catgirlConfig.mmd && (typeof catgirlConfig.mmd === 'string' ? catgirlConfig.mmd : catgirlConfig.mmd.model_path));
-            const storedLive3dSubType = String(catgirlConfig.live3d_sub_type || '').toLowerCase();
+            // 优先使用 live3d_sub_type（后端权威来源，含 _reserved 迁移路径）
+            const storedLive3dSubType = String(
+                catgirlConfig._reserved?.avatar?.live3d_sub_type
+                || catgirlConfig.live3d_sub_type
+                || ''
+            ).trim().toLowerCase();
 
             // 确定模型类型：优先使用 model_type，如果没有则根据是否有有效的 Live3D 路径判断
             let modelType = catgirlConfig.model_type || ((hasValidVRMPath || hasValidMMDPath) ? 'live3d' : 'live2d');
@@ -7213,10 +7218,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             // 确定 Live3D 子类型（VRM 或 MMD）
             let live3dSubType = '';
             if (modelType === 'live3d') {
-                if ((storedLive3dSubType === 'mmd' && hasValidMMDPath) ||
-                    (storedLive3dSubType === 'vrm' && hasValidVRMPath)) {
+                if (storedLive3dSubType === 'vrm' || storedLive3dSubType === 'mmd') {
                     live3dSubType = storedLive3dSubType;
-                } else if (hasValidMMDPath) {
+                } else if (hasValidMMDPath && !hasValidVRMPath) {
                     live3dSubType = 'mmd';
                 } else if (hasValidVRMPath) {
                     live3dSubType = 'vrm';

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -7211,28 +7211,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
 
             // 检查模型类型
-            // 首先安全地检查 VRM 模型路径是否存在且有效
-            let hasValidVRMPath = false;
-            if (catgirlConfig.vrm !== undefined && catgirlConfig.vrm !== null) {
-                const rawValue = catgirlConfig.vrm;
-                if (typeof rawValue === 'string') {
-                    const trimmed = rawValue.trim();
-                    if (trimmed !== '' &&
-                        trimmed !== 'undefined' &&
-                        trimmed !== 'null' &&
-                        !trimmed.includes('undefined') &&
-                        !trimmed.includes('null')) {
-                        hasValidVRMPath = true;
-                    }
-                } else {
-                    const strValue = String(rawValue);
-                    if (strValue !== 'undefined' && strValue !== 'null' && !strValue.includes('undefined')) {
-                        hasValidVRMPath = true;
-                    }
-                }
-            }
-
-            const hasValidMMDPath = !!(catgirlConfig.mmd && (typeof catgirlConfig.mmd === 'string' ? catgirlConfig.mmd : catgirlConfig.mmd.model_path));
+            // 安全地检查 VRM / MMD 模型路径是否存在且有效（含 _reserved 迁移路径）
+            const _isValidPath = (v) => {
+                if (v === undefined || v === null) return false;
+                const s = String(typeof v === 'object' && v.model_path ? v.model_path : v).trim();
+                const lower = s.toLowerCase();
+                return s !== '' && lower !== 'undefined' && lower !== 'null'
+                    && !s.includes('undefined') && !s.includes('null');
+            };
+            const hasValidVRMPath = _isValidPath(catgirlConfig._reserved?.avatar?.vrm?.model_path)
+                || _isValidPath(catgirlConfig.vrm);
+            const hasValidMMDPath = _isValidPath(catgirlConfig._reserved?.avatar?.mmd?.model_path)
+                || _isValidPath(catgirlConfig.mmd);
             // 优先使用 live3d_sub_type（后端权威来源，含 _reserved 迁移路径）
             const storedLive3dSubType = String(
                 catgirlConfig._reserved?.avatar?.live3d_sub_type

--- a/static/js/steam_workshop_manager.js
+++ b/static/js/steam_workshop_manager.js
@@ -2710,7 +2710,12 @@ function expandCharacterCardSection(card) {
         };
         const vrmPath = normalizeModelPath(rawData['vrm']);
         const mmdPath = normalizeModelPath(rawData['mmd']);
-    const explicitLive3dSubType = String(rawData['live3d_sub_type'] || '').toLowerCase();
+    // 优先使用 live3d_sub_type（后端权威来源，含 _reserved 迁移路径）
+    const explicitLive3dSubType = String(
+        rawData['_reserved']?.avatar?.live3d_sub_type
+        || rawData['live3d_sub_type']
+        || ''
+    ).trim().toLowerCase();
 
     // 判断实际模型类型：优先使用显式 live3d_sub_type，缺失时再根据路径区分 VRM/MMD
     let effectiveModelType = 'live2d';
@@ -2722,7 +2727,7 @@ function expandCharacterCardSection(card) {
         } else if (explicitLive3dSubType === 'vrm') {
             effectiveModelType = 'vrm';
             effectiveModelPath = vrmPath;
-        } else if (mmdPath) {
+        } else if (mmdPath && !vrmPath) {
             effectiveModelType = 'mmd';
             effectiveModelPath = mmdPath;
         } else if (vrmPath) {

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -40,7 +40,9 @@ async function InitializationTouchSet(characterJson) {
     }
 
     const modelType = localStorage.getItem('modelType') || 'live2d';
-    if (modelType !== 'live2d') {
+    const isVRMActive = window.vrmManager && window.vrmManager.currentModel;
+    const isMMDActive = window.mmdManager && window.mmdManager.currentModel;
+    if (modelType !== 'live2d' || isVRMActive || isMMDActive) {
         console.log('[TouchSet] 当前模型类型不是 Live2D，跳过触摸配置初始化');
         return;
     }


### PR DESCRIPTION
## 问题

VRM 模型模式下，用户发送第一条文本消息时模型会消失。

## 根因分析

`sendTextPayload` 在启动文本会话时调用 `showCurrentModel()`，该函数通过 `/api/characters` API 判断当前模型类型。但在以下情况会**盲目回退到 Live2D 并隐藏 VRM 容器**：

1. API 请求失败（网络抖动、服务端繁忙）
2. 角色配置未找到（`lanlan_name` 不匹配）
3. `model_type` 为 `live3d` 但 VRM/MMD 路径字段缺失或为空字符串

回退逻辑执行 `showLive2d()` → `vrmContainer.style.display = 'none'`，VRM 就消失了。

同时发现 Task HUD 相关代码存在冗余问题，虽不直接导致 VRM 消失，但会产生大量无意义的控制台日志和不必要的 DOM 操作。

## 修复内容

### 1. `showCurrentModel()` — 防止误杀 VRM（`app-ui.js`）

在函数入口检测运行时模型状态 (`window.vrmManager.currentModel` / `window.mmdManager.currentModel`)：

- **API 失败 / 配置缺失时**：若 VRM 或 MMD 已在运行，保持当前模型，不回退 Live2D
- **`live3d` 子类型解析失败时**：依据运行时状态推断 `effectiveModelType`
- **`else` 兜底分支**：若 VRM/MMD 正在运行，直接 return 而非切换到 Live2D

### 2. `hideAgentTaskHUD()` — 停止无意义创建（`common-ui-hud.js`）

之前：HUD 不存在时会先 `createAgentTaskHUD()`（带 `backdrop-filter: blur(20px)` + `contain: layout style paint`）再立即隐藏。每次 `agent_status_update` WebSocket 消息都会触发。

现在：
- HUD 不存在 → 直接 return
- HUD 已经 `display: none` → 直接 return（幂等）

### 3. `stopAgentTaskPolling()` — 跳过重复清理（`app-agent.js`）

轮询定时器已经为 null 时跳过 `clearInterval` + 日志输出。移除 `console.trace()` 避免控制台刷屏。

### 4. `checkAndToggleTaskHUD()` — 精简日志（`app-agent.js`）

移除 `[DEBUG HUD]` 前缀的冗长日志（含 6 个变量 dump），仅保留关键状态变更日志。

### 5. `agent_ui_v2.js render()` — 移除每帧冗余日志

移除 `[AgentUIv2] Calling checkAndToggleTaskHUD from render()` 日志，该函数每次 snapshot 更新都会调用。

### 6. `touch-config.js` — VRM 模式下跳过 Live2D 触摸初始化

原有检查仅依赖 `localStorage.getItem('modelType')`，该值可能未及时更新。新增运行时检测 `vrmManager.currentModel` / `mmdManager.currentModel`，消除 VRM 模式下的 `[TouchSet] 模型不存在` 重试噪音。

## 测试计划

- [ ] VRM 模型模式下发送文本消息，模型不消失
- [ ] Live2D 模型模式下发送文本消息，模型正常显示
- [ ] Agent 开关切换时 HUD 正常显示/隐藏
- [ ] 控制台不再刷屏 `[DEBUG HUD]` / `stopAgentTaskPolling caller trace` / `[TouchSet] 模型不存在`
- [ ] 断开 `/api/characters` 接口后发送消息，VRM 模型保持不消失

https://claude.ai/code/session_01FkQTEbf4efRCbFi8FdWV7w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

**Bug Fixes**
* 避免不必要地从 VRM/MMD 切换到 Live2D：新增可见性检查与早退保障。
* 任务 HUD 的显示/隐藏与轮询停止改为幂等：避免重复隐藏、无效超时日志与冗余日志输出。
* 触控配置初始化新增运行时模型检测，避免错误初始化。

**改进**
* 优先使用嵌套的 live3d 子类型配置并统一规范化，改进 VRM/MMD 子类型判定与展示名称选择。
* 精简渲染与调试日志，移除冗余输出。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->