### PR TITLE
feat(react-chat): 为标题栏与输入栏背景添加 Liquid Glass 毛玻璃质感

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -52,8 +52,40 @@ textarea {
   gap: 12px;
   min-height: 54px;
   padding: 10px 14px 8px;
-  border-bottom: 1px solid rgba(111, 129, 158, 0.16);
-  background: rgba(255, 255, 255, 0.95);
+  position: relative;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.5);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.72) 0%,
+      rgba(245, 248, 255, 0.55) 100%
+    );
+  backdrop-filter: blur(28px) saturate(180%);
+  -webkit-backdrop-filter: blur(28px) saturate(180%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -0.5px 0 rgba(255, 255, 255, 0.25),
+    0 1px 4px rgba(100, 120, 160, 0.06);
+}
+
+/* Liquid-glass specular highlight — topbar */
+.window-topbar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      105deg,
+      rgba(255, 255, 255, 0)   0%,
+      rgba(255, 255, 255, 0.35) 35%,
+      rgba(255, 255, 255, 0)   50%,
+      rgba(200, 220, 255, 0.12) 70%,
+      rgba(255, 255, 255, 0)   100%
+    );
+  mask-image: linear-gradient(to bottom, black 0%, transparent 70%);
+  -webkit-mask-image: linear-gradient(to bottom, black 0%, transparent 70%);
 }
 
 .window-title-group {
@@ -669,8 +701,40 @@ textarea {
   display: grid;
   gap: 12px;
   padding: 16px 10px 18px;
-  border-top: 1px solid rgba(111, 129, 158, 0.16);
-  background: rgba(255, 255, 255, 0.85);
+  position: relative;
+  border-top: 1px solid rgba(255, 255, 255, 0.5);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(245, 248, 255, 0.55) 0%,
+      rgba(255, 255, 255, 0.72) 100%
+    );
+  backdrop-filter: blur(28px) saturate(180%);
+  -webkit-backdrop-filter: blur(28px) saturate(180%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.35),
+    0 -1px 4px rgba(100, 120, 160, 0.06);
+}
+
+/* Liquid-glass specular highlight — composer panel */
+.composer-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      105deg,
+      rgba(255, 255, 255, 0)   0%,
+      rgba(255, 255, 255, 0.3)  30%,
+      rgba(255, 255, 255, 0)   48%,
+      rgba(200, 220, 255, 0.1)  68%,
+      rgba(255, 255, 255, 0)   100%
+    );
+  mask-image: linear-gradient(to top, black 0%, transparent 70%);
+  -webkit-mask-image: linear-gradient(to top, black 0%, transparent 70%);
 }
 
 .composer-attachments {
@@ -943,8 +1007,29 @@ textarea {
 }
 
 [data-theme="dark"] .window-topbar {
-  background: rgba(35, 35, 50, 0.95);
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(50, 50, 72, 0.6) 0%,
+      rgba(38, 38, 58, 0.5) 100%
+    );
+  border-bottom-color: rgba(255, 255, 255, 0.12);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -0.5px 0 rgba(255, 255, 255, 0.04),
+    0 1px 4px rgba(0, 0, 0, 0.15);
+}
+
+[data-theme="dark"] .window-topbar::before {
+  background:
+    linear-gradient(
+      105deg,
+      rgba(255, 255, 255, 0)    0%,
+      rgba(255, 255, 255, 0.06) 35%,
+      rgba(255, 255, 255, 0)    50%,
+      rgba(140, 180, 255, 0.04) 70%,
+      rgba(255, 255, 255, 0)    100%
+    );
 }
 
 [data-theme="dark"] .window-title {
@@ -1161,8 +1246,29 @@ textarea {
 
 /* --- 输入区域 --- */
 [data-theme="dark"] .composer-panel {
-  border-top-color: rgba(255, 255, 255, 0.08);
-  background: rgba(30, 30, 42, 0.85);
+  border-top-color: rgba(255, 255, 255, 0.12);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(38, 38, 58, 0.5) 0%,
+      rgba(50, 50, 72, 0.6) 100%
+    );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.05),
+    0 -1px 4px rgba(0, 0, 0, 0.15);
+}
+
+[data-theme="dark"] .composer-panel::before {
+  background:
+    linear-gradient(
+      105deg,
+      rgba(255, 255, 255, 0)    0%,
+      rgba(255, 255, 255, 0.05) 30%,
+      rgba(255, 255, 255, 0)    48%,
+      rgba(140, 180, 255, 0.03) 68%,
+      rgba(255, 255, 255, 0)    100%
+    );
 }
 
 [data-theme="dark"] .composer-attachment-card {


### PR DESCRIPTION
## Summary

- 为 `.window-topbar` 和 `.composer-panel` 的背景添加 **Liquid Glass** 风格：`backdrop-filter` 毛玻璃模糊 + 半透明渐变底色 + specular highlight 伪元素模拟光线折射
- 边框从硬实线改为柔和的半透明白色，配合 `inset box-shadow` 实现玻璃表面的顶部高光与底部柔光
- 亮色 / 暗色模式均已适配，暗色下高光强度大幅降低以保持微妙感
- **未改动**：输入框本身（`.composer-input-shell`）、消息区域（`.chat-body`）、所有布局与间距属性

## 改动范围

仅 `frontend/react-neko-chat/src/styles.css`，纯视觉层面改动，无逻辑变更。

## Test plan

- [ ] 亮色模式下查看标题栏和输入栏背景是否呈现半透明毛玻璃 + 微光折射效果
- [ ] 暗色模式下确认效果存在但更加收敛
- [ ] 滚动消息列表时确认 backdrop-filter 模糊正常透出下方内容
- [ ] 确认输入框本身、消息气泡、布局间距均未受影响

https://claude.ai/code/session_01Jiq9rata7fscZeyNf3VhVM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 优化了窗口顶栏和编辑器面板的视觉效果，采用液体玻璃设计风格，增强了视觉层次感和现代感
  * 为暗黑模式添加了相应的主题适配，确保各种主题下的视觉呈现一致

<!-- end of auto-generated comment: release notes by coderabbit.ai -->