### PR TITLE
Feat/live2d trigger btn UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,11 @@ __pycache__/
 .DS_Store
 .venv
 .venv_monitor/
+.matplotlib/
+.pyinstaller-config/
 # Playwright browsers cache (used by build_nuitka.bat, not for repo)
 playwright_browsers/
+.playwright-browsers/
 .env
 .env.local
 .env.development.local
@@ -74,6 +77,7 @@ Cargo.lock
 # Node/Front-end temp (if any)
 node_modules/
 *.cache/
+*.tsbuildinfo
 dist/
 build/
 *.tsbuildinfo
@@ -99,6 +103,7 @@ static/ziraitikuwa/*
 static/neko/*
 static/kemomimi/*
 static/yui/*
+static/react/neko-chat/*
 打包说明.txt
 runtime_hook_inflect.py
 backup/

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -387,6 +387,9 @@
                         imgOff.style.opacity = isActive ? '0' : '1';
                         imgOn.style.opacity = isActive ? '1' : '0';
                     }
+                    if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
+                        manager.updateSeparatePopupTriggerIcon('screen');
+                    }
                 }
             }
         }

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -443,6 +443,9 @@
                         imgOff.style.opacity = isActive ? '0' : '1';
                         imgOn.style.opacity = isActive ? '1' : '0';
                     }
+                    if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
+                        manager.updateSeparatePopupTriggerIcon('mic');
+                    }
                 }
             }
         }
@@ -462,6 +465,9 @@
                     if (imgOff && imgOn) {
                         imgOff.style.opacity = isActive ? '0' : '1';
                         imgOn.style.opacity = isActive ? '1' : '0';
+                    }
+                    if (typeof manager.updateSeparatePopupTriggerIcon === 'function') {
+                        manager.updateSeparatePopupTriggerIcon('screen');
                     }
                 }
             }

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -671,6 +671,24 @@ const AvatarButtonMixin = {
         };
 
         /**
+         * 同步独立弹窗触发器（三角形）方向
+         */
+        ManagerPrototype.updateSeparatePopupTriggerIcon = function(buttonId) {
+            if (!buttonId) return;
+
+            const buttonData = this._floatingButtons && this._floatingButtons[buttonId];
+            const triggerIcon = buttonData && buttonData.triggerImg
+                ? buttonData.triggerImg
+                : document.querySelector(`.${this._avatarPrefix}-trigger-icon-${buttonId}`);
+            if (!triggerIcon) return;
+
+            const buttonActive = !!(buttonData && buttonData.button && buttonData.button.dataset.active === 'true');
+            const popup = document.getElementById(`${this._avatarPrefix}-popup-${buttonId}`);
+            const popupVisible = !!(popup && popup.style.display === 'flex' && popup.style.opacity !== '0');
+            triggerIcon.style.transform = (buttonActive || popupVisible) ? 'rotate(180deg)' : 'rotate(0deg)';
+        };
+
+        /**
          * 设置按钮激活状态
          */
         ManagerPrototype.setButtonActive = function(buttonId, active) {
@@ -688,6 +706,8 @@ const AvatarButtonMixin = {
             if (buttonData.imgOn) {
                 buttonData.imgOn.style.opacity = active ? '1' : '0';
             }
+
+            this.updateSeparatePopupTriggerIcon(buttonId);
 
             // 同步静音按钮的显示状态
             if (buttonId === 'mic') {

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -2117,8 +2117,9 @@ const AvatarPopupMixin = {
                 popup.style.opacity = '0';
                 const closingOpensLeft = popup.dataset.opensLeft === 'true';
                 popup.style.transform = closingOpensLeft ? 'translateX(10px)' : 'translateX(-10px)';
-                const triggerIcon = document.querySelector(`.${prefix}-trigger-icon-${buttonId}`);
-                if (triggerIcon) triggerIcon.style.transform = 'rotate(0deg)';
+                if (typeof this.updateSeparatePopupTriggerIcon === 'function') {
+                    this.updateSeparatePopupTriggerIcon(buttonId);
+                }
                 if (buttonId === 'agent') window.dispatchEvent(new CustomEvent('live2d-agent-popup-closed'));
 
                 // 关闭该 popup 所属的所有侧面板
@@ -2188,8 +2189,9 @@ const AvatarPopupMixin = {
                         popup.style.visibility = 'visible';
                         popup.style.opacity = '1';
                         popup.classList.remove('is-positioning');
-                        const triggerIcon = document.querySelector(`.${prefix}-trigger-icon-${buttonId}`);
-                        if (triggerIcon) triggerIcon.style.transform = 'rotate(180deg)';
+                        if (typeof this.updateSeparatePopupTriggerIcon === 'function') {
+                            this.updateSeparatePopupTriggerIcon(buttonId);
+                        }
                         requestAnimationFrame(() => {
                             if (popup._showToken !== showToken || popup.style.display !== 'flex') return;
                             popup.style.transform = 'translateX(0)';
@@ -2230,8 +2232,9 @@ const AvatarPopupMixin = {
                 });
             }
 
-            const triggerIcon = document.querySelector(`.${prefix}-trigger-icon-${buttonId}`);
-            if (triggerIcon) triggerIcon.style.transform = 'rotate(0deg)';
+            if (typeof this.updateSeparatePopupTriggerIcon === 'function') {
+                this.updateSeparatePopupTriggerIcon(buttonId);
+            }
 
             popup._hideTimeoutId = setTimeout(() => {
                 finalizePopupClosedState(popup);

--- a/static/live2d-ui-buttons.js
+++ b/static/live2d-ui-buttons.js
@@ -332,6 +332,8 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
         }
 
         // 处理弹窗
+        let triggerBtn = null;
+        let triggerImg = null;
         if (config.hasPopup && config.separatePopupTrigger) {
             if (isMobileWidth() && config.id === 'mic') {
                 buttonsContainer.appendChild(btnWrapper);
@@ -339,7 +341,9 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
                     button: btn,
                     wrapper: btnWrapper,
                     imgOff: imgOff,
-                    imgOn: imgOn
+                    imgOn: imgOn,
+                    triggerButton: null,
+                    triggerImg: null
                 };
                 return;
             }
@@ -347,9 +351,9 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
             if (!isMobileWidth()) {
                 const popup = this.createPopup(config.id);
 
-                const triggerBtn = document.createElement('div');
+                triggerBtn = document.createElement('div');
                 triggerBtn.className = 'live2d-trigger-btn';
-                const triggerImg = document.createElement('img');
+                triggerImg = document.createElement('img');
                 triggerImg.src = '/static/icons/play_trigger_icon.png' + iconVersion;
                 triggerImg.alt = '▶';
                 triggerImg.className = `live2d-trigger-icon-${config.id}`;
@@ -480,7 +484,9 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
             button: btn,
             wrapper: btnWrapper,
             imgOff: imgOff,
-            imgOn: imgOn
+            imgOn: imgOn,
+            triggerButton: (config.hasPopup && config.separatePopupTrigger && !isMobileWidth()) ? triggerBtn : null,
+            triggerImg: (config.hasPopup && config.separatePopupTrigger && !isMobileWidth()) ? triggerImg : null
         };
         console.log(`[Live2D] 按钮已创建: ${config.id}, hasPopup: ${config.hasPopup}, toggle: ${config.toggle}`);
     });

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -150,20 +150,23 @@ MMDManager.prototype.setupFloatingButtons = function() {
         }
 
         // 处理弹窗
+        let triggerBtn = null;
+        let triggerImg = null;
         if (config.hasPopup && config.separatePopupTrigger) {
             if (window.isMobileWidth && window.isMobileWidth() && config.id === 'mic') {
                 buttonsContainer.appendChild(btnWrapper);
+                this._floatingButtons[config.id] = { button: btn, imgOff, imgOn, triggerButton: null, triggerImg: null };
                 return;
             }
 
             const popup = this.createPopup(config.id);
-            const triggerBtn = document.createElement('button');
+            triggerBtn = document.createElement('button');
             triggerBtn.type = 'button';
             triggerBtn.className = 'mmd-trigger-btn';
             triggerBtn.setAttribute('aria-label', 'Open popup');
 
             const iconVersion = window.APP_VERSION ? `?v=${window.APP_VERSION}` : '?v=1.0.0';
-            const triggerImg = document.createElement('img');
+            triggerImg = document.createElement('img');
             triggerImg.src = '/static/icons/play_trigger_icon.png' + iconVersion;
             triggerImg.alt = '';
             triggerImg.className = `mmd-trigger-icon-${config.id}`;
@@ -242,7 +245,13 @@ MMDManager.prototype.setupFloatingButtons = function() {
         }
 
         buttonsContainer.appendChild(btnWrapper);
-        this._floatingButtons[config.id] = { button: btn, imgOff, imgOn };
+        this._floatingButtons[config.id] = {
+            button: btn,
+            imgOff,
+            imgOn,
+            triggerButton: (config.hasPopup && config.separatePopupTrigger && !(window.isMobileWidth && window.isMobileWidth())) ? triggerBtn : null,
+            triggerImg: (config.hasPopup && config.separatePopupTrigger && !(window.isMobileWidth && window.isMobileWidth())) ? triggerImg : null
+        };
     });
 
     // 处理"请她离开"事件

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -183,21 +183,23 @@ VRMManager.prototype.setupFloatingButtons = function() {
         }
 
         // 处理弹窗
+        let triggerBtn = null;
+        let triggerImg = null;
         if (config.hasPopup && config.separatePopupTrigger) {
             if (window.isMobileWidth() && config.id === 'mic') {
                 buttonsContainer.appendChild(btnWrapper);
-                this._floatingButtons[config.id] = { button: btn, imgOff, imgOn };
+                this._floatingButtons[config.id] = { button: btn, imgOff, imgOn, triggerButton: null, triggerImg: null };
                 return;
             }
 
             const popup = this.createPopup(config.id);
-            const triggerBtn = document.createElement('button');
+            triggerBtn = document.createElement('button');
             triggerBtn.type = 'button';
             triggerBtn.className = 'vrm-trigger-btn';
             triggerBtn.setAttribute('aria-label', 'Open popup');
 
             const iconVersion = window.APP_VERSION ? `?v=${window.APP_VERSION}` : '?v=1.0.0';
-            const triggerImg = document.createElement('img');
+            triggerImg = document.createElement('img');
             triggerImg.src = '/static/icons/play_trigger_icon.png' + iconVersion;
             triggerImg.alt = '';
             triggerImg.className = `vrm-trigger-icon-${config.id}`;
@@ -292,7 +294,13 @@ VRMManager.prototype.setupFloatingButtons = function() {
         }
 
         buttonsContainer.appendChild(btnWrapper);
-        this._floatingButtons[config.id] = { button: btn, imgOff, imgOn };
+        this._floatingButtons[config.id] = {
+            button: btn,
+            imgOff,
+            imgOn,
+            triggerButton: (config.hasPopup && config.separatePopupTrigger && !window.isMobileWidth()) ? triggerBtn : null,
+            triggerImg: (config.hasPopup && config.separatePopupTrigger && !window.isMobileWidth()) ? triggerImg : null
+        };
     });
 
     // 处理"请她离开"事件


### PR DESCRIPTION
修复了头像浮动按钮中，语音模式和屏幕分享激活后，右侧独立小三角未随主按钮状态反转的问题。

主要改动：

为浮动按钮增加统一的独立弹窗触发器方向同步逻辑
将语音按钮 mic 的激活态与右侧小三角方向联动
将屏幕分享按钮 screen 的激活态与右侧小三角方向联动
保留弹窗展开/关闭时的小三角方向切换，并与按钮激活态合并处理
为 Live2D、VRM、MMD 三套浮动按钮实现保存 trigger 图标引用，确保三套角色模式行为一致
修复效果：

启动语音模式后，右侧小三角会反转
开启屏幕分享后，右侧小三角也会反转
关闭对应功能后，小三角恢复默认方向
弹窗单独展开/关闭时，小三角方向仍保持正确
校验情况：

已对相关前端 JS 文件执行 node --check
语法检查通过，无新增语法错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化了浮动按钮（屏幕、麦克风）的视觉状态同步机制
  * 改进了弹出窗口触发图标的状态管理，确保其与按钮状态和弹出窗口可见性保持同步
  * 更新了项目构建和缓存的忽略配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->