### PR TITLE
fix: 统一 LLM/TTS 重试错误上报策略，区分立即上报与延迟上报

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3084,7 +3084,7 @@ class LLMSessionManager:
                     elif data[0] == "__reconnecting__":
                         self._tts_retry_notify_count += 1
                         logger.info(f"🌊 TTS 正在自动重连 (retry {self._tts_retry_notify_count})")
-                        if self._tts_retry_notify_count > 3:
+                        if self._tts_retry_notify_count >= 3:
                             user_msg = json.dumps({"code": "TTS_RECONNECTING", "level": "info"})
                             self._fire_task(self.send_status(user_msg))
                         continue
@@ -3136,10 +3136,10 @@ class LLMSessionManager:
                             else:
                                 user_msg = json.dumps({"code": "TTS_CONNECTION_FAILED", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'TTS_CONNECTION_FAILED'
-                        # 可重试的错误：前3次不通知前端，第3次失败后再发
+                        # 可重试的错误：前2次静默重试，第3次失败时上报前端
                         if self._last_tts_error_code not in NO_RETRY_TTS_CODES:
                             self._tts_retry_notify_count += 1
-                            if self._tts_retry_notify_count <= 3:
+                            if self._tts_retry_notify_count < 3:
                                 logger.info(f"TTS 错误重试 {self._tts_retry_notify_count}/3，暂不通知前端")
                                 continue
                         self._fire_task(self.send_status(user_msg))

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -54,8 +54,8 @@ import httpx
 # Setup logger for this module
 logger = get_module_logger(__name__, "Main")
 
-# TTS 错误码中不应自动重试的类型（欠费 / 配额耗尽）
-NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_QUOTA_TIME'}
+# TTS 错误码中不应自动重试的类型（欠费 / 配额耗尽 / API Key 无效）
+NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_QUOTA_TIME', 'API_KEY_REJECTED'}
 
 # ---------------------------------------------------------------------------
 # 重要通知缓冲池
@@ -725,6 +725,10 @@ class LLMSessionManager:
                 await self.send_status(json.dumps({"code": "API_QUOTA_TIME"}))
             elif '429' in message_text_lower or 'too many' in message_text_lower:
                 await self.send_status(json.dumps({"code": "API_RATE_LIMIT"}))
+            elif ('401' in message_text_lower or 'unauthorized' in message_text_lower
+                    or 'authentication' in message_text_lower
+                    or ('invalid' in message_text_lower and 'key' in message_text_lower)):
+                await self.send_status(json.dumps({"code": "API_KEY_REJECTED"}))
             elif 'policy violation' in message_text_lower:
                 await self.send_status(json.dumps({"code": "API_POLICY_VIOLATION", "details": {"msg": message_text}}))
             elif '1008' in message_text_lower:
@@ -3095,8 +3099,9 @@ class LLMSessionManager:
 
                         # 优先尝试从结构化 JSON 中提取明确的 code 字段
                         _known_codes = {
-                            'API_ARREARS', 'API_QUOTA_TIME', 'API_RATE_LIMIT',
-                            'API_POLICY_VIOLATION', 'API_1008_FALLBACK', 'TTS_CONNECTION_FAILED',
+                            'API_ARREARS', 'API_QUOTA_TIME', 'API_KEY_REJECTED',
+                            'API_RATE_LIMIT', 'API_POLICY_VIOLATION',
+                            'API_1008_FALLBACK', 'TTS_CONNECTION_FAILED',
                         }
                         _parsed_code = None
                         try:
@@ -3133,6 +3138,11 @@ class LLMSessionManager:
                             elif '1008' in error_msg_lower:
                                 user_msg = json.dumps({"code": "API_1008_FALLBACK", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'API_1008_FALLBACK'
+                            elif ('401' in error_msg_lower or 'unauthorized' in error_msg_lower
+                                    or 'authentication' in error_msg_lower
+                                    or ('invalid' in error_msg_lower and 'key' in error_msg_lower)):
+                                user_msg = json.dumps({"code": "API_KEY_REJECTED", "details": {"msg": error_msg_text}})
+                                self._last_tts_error_code = 'API_KEY_REJECTED'
                             else:
                                 user_msg = json.dumps({"code": "TTS_CONNECTION_FAILED", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'TTS_CONNECTION_FAILED'

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -54,8 +54,10 @@ import httpx
 # Setup logger for this module
 logger = get_module_logger(__name__, "Main")
 
-# TTS 错误码中不应自动重试的类型（欠费 / 配额耗尽 / API Key 无效）
-NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_QUOTA_TIME', 'API_KEY_REJECTED'}
+# TTS 错误码：不可恢复，禁止 respawn（欠费 / API Key 无效）
+NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_KEY_REJECTED'}
+# TTS 错误码：立即上报前端，不受"第3次才通知"门槛限制（含配额——仍允许重试）
+IMMEDIATE_REPORT_TTS_CODES = NO_RETRY_TTS_CODES | {'API_QUOTA_TIME'}
 
 # ---------------------------------------------------------------------------
 # 重要通知缓冲池
@@ -1586,7 +1588,9 @@ class LLMSessionManager:
                         await self.send_status(json.dumps({"code": "MEMORY_SERVER_CRASHED", "details": {"port": self.memory_server_port}}))
                     else:
                         await self.send_status(json.dumps({"code": "CONNECTION_REFUSED"}))
-                elif '401' in error_str:
+                elif ('401' in error_str or 'unauthorized' in error_str.lower()
+                        or 'authentication' in error_str.lower()
+                        or ('invalid' in error_str.lower() and 'key' in error_str.lower())):
                     await self.send_status(json.dumps({"code": "API_KEY_REJECTED"}))
                 elif '429' in error_str:
                     await self.send_status(json.dumps({"code": "API_RATE_LIMIT_SESSION"}))
@@ -3147,7 +3151,7 @@ class LLMSessionManager:
                                 user_msg = json.dumps({"code": "TTS_CONNECTION_FAILED", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'TTS_CONNECTION_FAILED'
                         # 可重试的错误：前2次静默重试，第3次失败时上报前端
-                        if self._last_tts_error_code not in NO_RETRY_TTS_CODES:
+                        if self._last_tts_error_code not in IMMEDIATE_REPORT_TTS_CODES:
                             self._tts_retry_notify_count += 1
                             if self._tts_retry_notify_count < 3:
                                 logger.info(f"TTS 错误重试 {self._tts_retry_notify_count}/3，暂不通知前端")

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -483,12 +483,27 @@ class OmniOfflineClient:
                             
                 except (APIConnectionError, InternalServerError, RateLimitError) as e:
                     error_type = type(e).__name__
+                    error_str_lower = str(e).lower()
                     is_internal_error = isinstance(e, InternalServerError)
                     logger.info(f"ℹ️ 捕获到 {error_type} 错误")
+
+                    # 欠费/配额错误立即上报，不重试
+                    if '欠费' in error_str_lower or 'standing' in error_str_lower:
+                        logger.error(f"OmniOfflineClient: 检测到欠费错误，直接上报: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_ARREARS"}))
+                            status_reported = True
+                        break
+                    if 'quota' in error_str_lower or 'time limit' in error_str_lower:
+                        logger.error(f"OmniOfflineClient: 检测到配额错误，直接上报: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_QUOTA_TIME"}))
+                            status_reported = True
+                        break
+
                     if attempt < max_retries - 1:
                         wait_time = retry_delays[attempt]
                         logger.warning(f"OmniOfflineClient: LLM调用失败 (尝试 {attempt + 1}/{max_retries})，{wait_time}秒后重试: {e}")
-                        # 前3次重试不通知前端，仅在最终失败时发送
                         await asyncio.sleep(wait_time)
                         continue
                     else:

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -487,7 +487,7 @@ class OmniOfflineClient:
                     is_internal_error = isinstance(e, InternalServerError)
                     logger.info(f"ℹ️ 捕获到 {error_type} 错误")
 
-                    # 欠费/配额错误立即上报，不重试
+                    # 欠费/配额/API Key 错误立即上报，不重试
                     if '欠费' in error_str_lower or 'standing' in error_str_lower:
                         logger.error(f"OmniOfflineClient: 检测到欠费错误，直接上报: {e}")
                         if self.on_status_message:
@@ -498,6 +498,14 @@ class OmniOfflineClient:
                         logger.error(f"OmniOfflineClient: 检测到配额错误，直接上报: {e}")
                         if self.on_status_message:
                             await self.on_status_message(json.dumps({"code": "API_QUOTA_TIME"}))
+                            status_reported = True
+                        break
+                    if ('401' in error_str_lower or 'unauthorized' in error_str_lower
+                            or 'authentication' in error_str_lower
+                            or ('invalid' in error_str_lower and 'key' in error_str_lower)):
+                        logger.error(f"OmniOfflineClient: 检测到 API Key 错误，直接上报: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_KEY_REJECTED"}))
                             status_reported = True
                         break
 

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -487,7 +487,7 @@ class OmniOfflineClient:
                     is_internal_error = isinstance(e, InternalServerError)
                     logger.info(f"ℹ️ 捕获到 {error_type} 错误")
 
-                    # 欠费/配额/API Key 错误立即上报，不重试
+                    # 欠费/API Key 错误立即上报并终止；配额错误上报但继续重试
                     if '欠费' in error_str_lower or 'standing' in error_str_lower:
                         logger.error(f"OmniOfflineClient: 检测到欠费错误，直接上报: {e}")
                         if self.on_status_message:
@@ -495,11 +495,9 @@ class OmniOfflineClient:
                             status_reported = True
                         break
                     if 'quota' in error_str_lower or 'time limit' in error_str_lower:
-                        logger.error(f"OmniOfflineClient: 检测到配额错误，直接上报: {e}")
+                        logger.warning(f"OmniOfflineClient: 检测到配额错误，上报前端: {e}")
                         if self.on_status_message:
                             await self.on_status_message(json.dumps({"code": "API_QUOTA_TIME"}))
-                            status_reported = True
-                        break
                     if ('401' in error_str_lower or 'unauthorized' in error_str_lower
                             or 'authentication' in error_str_lower
                             or ('invalid' in error_str_lower and 'key' in error_str_lower)):

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -494,11 +494,7 @@ class OmniOfflineClient:
                             await self.on_status_message(json.dumps({"code": "API_ARREARS"}))
                             status_reported = True
                         break
-                    if 'quota' in error_str_lower or 'time limit' in error_str_lower:
-                        logger.warning(f"OmniOfflineClient: 检测到配额错误，上报前端: {e}")
-                        if self.on_status_message:
-                            await self.on_status_message(json.dumps({"code": "API_QUOTA_TIME"}))
-                    if ('401' in error_str_lower or 'unauthorized' in error_str_lower
+                    elif ('401' in error_str_lower or 'unauthorized' in error_str_lower
                             or 'authentication' in error_str_lower
                             or ('invalid' in error_str_lower and 'key' in error_str_lower)):
                         logger.error(f"OmniOfflineClient: 检测到 API Key 错误，直接上报: {e}")
@@ -506,6 +502,10 @@ class OmniOfflineClient:
                             await self.on_status_message(json.dumps({"code": "API_KEY_REJECTED"}))
                             status_reported = True
                         break
+                    elif 'quota' in error_str_lower or 'time limit' in error_str_lower:
+                        logger.warning(f"OmniOfflineClient: 检测到配额错误，上报前端: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_QUOTA_TIME"}))
 
                     if attempt < max_retries - 1:
                         wait_time = retry_delays[attempt]

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -280,6 +280,7 @@ class OmniRealtimeClient:
         self._is_throttled = False  # 503检测后节流状态
         self._throttle_until = 0.0  # 节流结束时间戳
         self._throttle_duration = 2.0  # 节流持续时间（秒）
+        self._server_busy_count: int = 0  # 503 过载计数，第3次起通知前端
         
         # Fatal error detection - 检测到致命错误后立即中断
         self._fatal_error_occurred = False  # 致命错误标志
@@ -1445,8 +1446,10 @@ class OmniRealtimeClient:
                     if '503' in error_msg or 'overloaded' in error_msg.lower():
                         self._is_throttled = True
                         self._throttle_until = time.time() + self._throttle_duration
-                        logger.warning(f"⚡ 503 detected, throttling for {self._throttle_duration}s")
-                        if self.on_status_message:
+                        self._server_busy_count += 1
+                        logger.warning(f"⚡ 503 detected (count={self._server_busy_count}), throttling for {self._throttle_duration}s")
+                        # 前2次静默节流，第3次起通知前端
+                        if self._server_busy_count >= 3 and self.on_status_message:
                             await self.on_status_message(json.dumps({"code": "SERVER_BUSY_THROTTLE"}))
                         continue
                     


### PR DESCRIPTION
## Summary

审计并统一了所有 LLM/TTS 重试路径的前端错误上报策略，解决两个核心问题：

1. **部分瞬态错误（503、TTS 重连）首次就上报前端**，造成不必要的用户干扰
2. **欠费/配额/API Key 等不可恢复错误被重试计数器吞掉**，延迟了用户感知

### 改动原则

| 错误类型 | 策略 |
|---|---|
| 欠费 (`API_ARREARS`) | 立即上报 + 终止重试 |
| API Key 无效 (`API_KEY_REJECTED`) | 立即上报 + 终止重试 |
| 配额 (`API_QUOTA_TIME`) | 立即上报 + **继续重试**（可能是临时限制） |
| 超时 / 503 / 连接失败等瞬态错误 | 第 3 次失败时才上报 |

### 具体改动（3 个文件）

**`omni_realtime_client.py`**
- 新增 `_server_busy_count` 计数器，503/overloaded 前 2 次静默节流，第 3 次起发送 `SERVER_BUSY_THROTTLE`

**`core.py`**
- `NO_RETRY_TTS_CODES` 加入 `API_KEY_REJECTED`，TTS 遇到 API Key 错误不再静默重试
- TTS `__reconnecting__` 阈值 `> 3` → `>= 3`（第 3 次通知，原来第 4 次才通知）
- TTS `__error__` 阈值 `<= 3` → `< 3`（第 3 次上报，原来第 4 次才上报）
- TTS `__error__` 关键词匹配增加 401/unauthorized/authentication/invalid key → `API_KEY_REJECTED`
- TTS `_known_codes` 集合增加 `API_KEY_REJECTED`
- `handle_connection_error` 增加 API Key 错误分类，不再归入 `API_UNKNOWN_ERROR`

**`omni_offline_client.py`**
- 重试循环增加欠费/配额/API Key 关键词检测
- 欠费 & API Key：立即上报 + `break`
- 配额：立即上报但**不 break**，继续重试

### 未改动（无需改动）的重试位置

| 位置 | 原因 |
|---|---|
| `brain/task_executor.py` 两个评估循环 | 不报前端，返回默认值，符合预期 |
| `brain/cua/core/engine.py` 各引擎 backoff | 不报前端，纯重试 |
| `main_routers/system_router.py` `_llm_call_with_retry` | 不报前端，raise 由调用方处理 |

## Test plan

- [ ] 文本模式对话：模拟 InternalServerError，确认第 3 次失败才出现前端提示
- [ ] 文本模式对话：模拟含 "欠费" 的 InternalServerError，确认首次即上报 `API_ARREARS` 并终止
- [ ] 文本模式对话：模拟含 "401" 的错误，确认首次即上报 `API_KEY_REJECTED` 并终止
- [ ] 文本模式对话：模拟含 "quota" 的错误，确认首次即上报 `API_QUOTA_TIME` 但继续重试
- [ ] 语音模式：触发 503 事件，确认前 2 次静默，第 3 次出现 `SERVER_BUSY_THROTTLE`
- [ ] TTS：模拟 TTS worker 错误，确认第 3 次才通知前端
- [ ] TTS：模拟含 "unauthorized" 的 TTS 错误，确认立即通知（不受重试计数器抑制）

https://claude.ai/code/session_01C1ia3We3bw9EGF3ySuwDLE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug修复**
  * 更准确识别并即时报告认证失败/密钥被拒和欠费等错误，避免无效重试
  * 对配额/时限类错误保留重试行为但会报告状态
  * 调整重连提示时机：重新连接提示在重试次数达到3次时触发
  * 服务器繁忙只在连续多次出现时才提醒，减少噪音
<!-- end of auto-generated comment: release notes by coderabbit.ai -->