### PR TITLE
fix: 统一 LLM JSON 响应容错解析 (robust_json_loads)

### DIFF
--- a/brain/deduper.py
+++ b/brain/deduper.py
@@ -5,6 +5,7 @@ from openai import APIConnectionError, InternalServerError, RateLimitError
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
+from utils.file_utils import robust_json_loads
 import json
 
 logger = get_module_logger(__name__, "Agent")
@@ -69,7 +70,7 @@ class TaskDeduper:
                 try:
                     if text.startswith("```"):
                         text = text.replace("```json", "").replace("```", "").strip()
-                    data = json.loads(text)
+                    data = robust_json_loads(text)
                     # Preferred contract: JSON array [matched_id_or_null, duplicate_boolean]
                     if isinstance(data, list) and len(data) >= 2:
                         matched_id = data[0]

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -22,6 +22,7 @@ from config.prompts_agent import (
     USER_PLUGIN_COARSE_SCREEN_PROMPT,
 )
 from config.prompts_sys import _loc
+from utils.file_utils import robust_json_loads
 from plugin.settings import PLUGIN_EXECUTION_TIMEOUT
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
@@ -637,7 +638,7 @@ class DirectTaskExecutor:
             text = (response.content or "").strip()
             if text.startswith("```"):
                 text = text.replace("```json", "").replace("```", "").strip()
-            ids = json.loads(text)
+            ids = robust_json_loads(text)
             if isinstance(ids, list):
                 return [str(i) for i in ids if isinstance(i, (str, int))]
         except Exception as e:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1430,8 +1430,8 @@ async def emotion_analysis(request: Request):
             return "neutral", 0.5
 
         try:
-            import json
-            result = json.loads(result_text)
+            from utils.file_utils import robust_json_loads
+            result = robust_json_loads(result_text)
             if not isinstance(result, dict):
                 # 有效 JSON 也可能是 null/[]/"text"，此时复用降级启发式处理。
                 emotion, confidence = _apply_degraded_emotion_fallback()

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -21,7 +21,7 @@ from config import SETTING_PROPOSER_MODEL
 from config.prompts_memory import get_fact_extraction_prompt
 from utils.language_utils import get_global_language
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, robust_json_loads
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 
@@ -29,34 +29,6 @@ if TYPE_CHECKING:
     from memory.timeindex import TimeIndexedMemory
 
 logger = get_module_logger(__name__, "Memory")
-
-
-def _sanitize_json(raw: str) -> str:
-    """尝试修复 LLM 输出中常见的 JSON 格式问题。
-
-    处理：双花括号→单花括号、单引号→双引号、尾部逗号、Python 字面值等。
-    仅在标准 json.loads 失败后调用。
-    """
-    # LLM 模仿 prompt 模板中的 {{ }} 转义 → 还原为正常花括号
-    s = raw.replace("{{", "{").replace("}}", "}")
-    # Python 风格 True/False/None → JSON
-    s = s.replace("True", "true").replace("False", "false").replace("None", "null")
-    # 尾部逗号：,] 或 ,}
-    s = re.sub(r',\s*([}\]])', r'\1', s)
-    # 单引号→双引号（简单替换，适用于大多数 LLM 输出）
-    # 只在整个字符串不含双引号 key 时才做替换，避免破坏已正确的 JSON
-    if '"' not in s:
-        s = s.replace("'", '"')
-    else:
-        # 混合引号情况：逐步替换单引号 key/value
-        # 1) key: 'xxx': → "xxx":
-        s = re.sub(r"'([^']*?)'\s*:", r'"\1":', s)
-        # 2) value: : 'xxx' → : "xxx"
-        s = re.sub(r":\s*'([^']*?)'", r': "\1"', s)
-        # 3) 数组内单引号元素: ['a', 'b'] → ["a", "b"]
-        s = re.sub(r"'\s*([,\]\}])", r'"\1', s)
-        s = re.sub(r"([,\[\{])\s*'", r'\1"', s)
-    return s
 
 
 _ARCHIVE_AGE_DAYS = 7          # absorbed 且创建超过此天数的 facts 被归档
@@ -266,12 +238,7 @@ class FactStore:
                         raw = match.group(1).strip()
                     else:
                         raw = raw.replace("```json", "").replace("```", "").strip()
-                try:
-                    extracted = json.loads(raw)
-                except json.JSONDecodeError:
-                    # 尝试修复常见 LLM 格式问题后重新解析
-                    sanitized = _sanitize_json(raw)
-                    extracted = json.loads(sanitized)
+                extracted = robust_json_loads(raw)
                 if not isinstance(extracted, list):
                     logger.warning(f"[FactStore] {lanlan_name}: LLM 返回非数组类型 {type(extracted).__name__}，重试")
                     retries += 1

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta
 
 from config import SETTING_PROPOSER_MODEL
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, robust_json_loads
 from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Memory")
@@ -599,7 +599,7 @@ class PersonaManager:
             raw = resp.content
             if raw.startswith("```"):
                 raw = raw.replace("```json", "").replace("```", "").strip()
-            results = json.loads(raw)
+            results = robust_json_loads(raw)
             if not isinstance(results, list):
                 results = [results]
         except Exception as e:

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -15,7 +15,7 @@ from config.prompts_memory import (
 from utils.language_utils import get_global_language
 
 # Setup logger
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, robust_json_loads
 from utils.logger_config import setup_logging
 logger, log_config = setup_logging(service_name="Memory", log_level=logging.INFO)
 
@@ -207,7 +207,7 @@ class CompressedRecentHistoryManager:
                 match = re.search(r'```(?:json)?\s*([\s\S]*?)```', response_content)
                 if match:
                     response_content = match.group(1).strip()
-                summary_json = json.loads(response_content)
+                summary_json = robust_json_loads(response_content)
                 # 从JSON字典中提取对话摘要，假设摘要存储在名为'key'的键下
                 if '对话摘要' in summary_json:
                     print(f"💗摘要结果：{summary_json['对话摘要']}")
@@ -257,7 +257,7 @@ class CompressedRecentHistoryManager:
                 match = re.search(r'```(?:json)?\s*([\s\S]*?)```', response_content)
                 if match:
                     response_content = match.group(1).strip()
-                summary_json = json.loads(response_content)
+                summary_json = robust_json_loads(response_content)
                 # 从JSON字典中提取对话摘要，假设摘要存储在名为'key'的键下
                 if '对话摘要' in summary_json:
                     print(f"💗第二轮摘要结果：{summary_json['对话摘要']}")
@@ -395,7 +395,7 @@ class CompressedRecentHistoryManager:
                     response_content = match.group(1).strip()
 
                 # 解析JSON响应
-                review_result = json.loads(response_content)
+                review_result = robust_json_loads(response_content)
                 
                 if '修正说明' in review_result and '修正后的对话' in review_result:
                     print(f"记忆整理结果：{review_result['修正说明']}")

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 
 from config import SETTING_PROPOSER_MODEL
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, robust_json_loads
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 from memory.persona import PersonaManager
@@ -206,7 +206,7 @@ class ReflectionEngine:
             raw = resp.content.strip()
             if raw.startswith("```"):
                 raw = raw.replace("```json", "").replace("```", "").strip()
-            result = json.loads(raw)
+            result = robust_json_loads(raw)
             if not isinstance(result, dict):
                 logger.warning(f"[Reflection] LLM 返回非 dict: {type(result)}")
                 return []
@@ -370,7 +370,7 @@ class ReflectionEngine:
             raw = resp.content.strip()
             if raw.startswith("```"):
                 raw = raw.replace("```json", "").replace("```", "").strip()
-            feedbacks = json.loads(raw)
+            feedbacks = robust_json_loads(raw)
             if not isinstance(feedbacks, list):
                 feedbacks = [feedbacks]
         except Exception as e:
@@ -432,7 +432,7 @@ class ReflectionEngine:
             raw = resp.content.strip()
             if raw.startswith("```"):
                 raw = raw.replace("```json", "").replace("```", "").strip()
-            feedbacks = json.loads(raw)
+            feedbacks = robust_json_loads(raw)
             if not isinstance(feedbacks, list):
                 feedbacks = [feedbacks]
             return feedbacks

--- a/memory/settings.py
+++ b/memory/settings.py
@@ -6,7 +6,7 @@ from config import SETTING_PROPOSER_MODEL, SETTING_VERIFIER_MODEL
 from config import CHARACTER_RESERVED_FIELDS
 from utils.config_manager import get_config_manager
 from utils.token_tracker import set_call_type
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, robust_json_loads
 from config.prompts_memory import settings_extractor_prompt, settings_verifier_prompt
 
 
@@ -90,9 +90,9 @@ class ImportantSettingsManager:
                 retries += 1
                 continue
             try:
-                merged_settings = json.loads(result)
+                merged_settings = robust_json_loads(result)
                 return merged_settings
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, ValueError):
                 # 如果解析失败，返回新设定
                 retries += 1
                 print(f"❌ Setting resolver返回值解析失败。返回值：{response.content}")
@@ -144,8 +144,8 @@ class ImportantSettingsManager:
                 result = response.content
                 if result.startswith("```"):
                     result = result .replace("```json", "").replace("```", "").strip()
-                new_settings = json.loads(result)
-            except json.JSONDecodeError:
+                new_settings = robust_json_loads(result)
+            except (json.JSONDecodeError, ValueError):
                 print(f"❌ Setting LLM返回的设定JSON解析失败。返回值：{response.content}")
                 retries += 1
             break

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -2,9 +2,46 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
+
+# ── LLM JSON tolerance ─────────────────────────��────────────────────────
+# LLM 经常返回带有格式瑕疵的 JSON（无引号 key、尾逗号、Python 字面值等）。
+# 先尝试标准解析，失败后逐步修补再试。
+_UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
+
+
+def robust_json_loads(raw: str) -> Any:
+    """json.loads with fallback for common LLM JSON quirks.
+
+    Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
+    single-quoted strings (including mixed-quote scenarios).
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    s = raw
+    # {{ }} → { }  (LLM 模仿 prompt 模板转义)
+    s = s.replace("{{", "{").replace("}}", "}")
+    # Python 字面值 → JSON
+    s = s.replace("True", "true").replace("False", "false").replace("None", "null")
+    # 尾逗号
+    s = re.sub(r',\s*([}\]])', r'\1', s)
+    # 无引号 key:  {key: "v"} → {"key": "v"}
+    s = _UNQUOTED_KEY_RE.sub(r' "\1":', s)
+    # 单引号 → 双引号
+    if '"' not in s:
+        s = s.replace("'", '"')
+    else:
+        # 混合引号：逐步替换单引号 key/value
+        s = re.sub(r"'([^']*?)'\s*:", r'"\1":', s)           # key
+        s = re.sub(r":\s*'([^']*?)'", r': "\1"', s)         # value
+        s = re.sub(r"'\s*([,\]\}])", r'"\1', s)              # 数组尾
+        s = re.sub(r"([,\[\{])\s*'", r'\1"', s)              # 数组头
+    return json.loads(s)
 
 
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:


### PR DESCRIPTION
## Summary

- 从用户日志（2026-04-06）中发现 `memory/reflection` 模块 LLM 返回非标准 JSON（无引号 key `{key: "value"}` 而非 `{"key": "value"}`）导致 `json.loads` 持续失败（20次/天），**所有 reflection 合成全部静默降级**
- 审查全部 `json.loads` 调用点后，识别出 **13 处**解析 LLM 响应的代码存在相同风险
- 新增 `utils/file_utils.robust_json_loads()`：合并已有的 `facts._sanitize_json` + 新增 unquoted key 修复，**先标准解析，失败后逐步修补再试**，不影响正常 JSON 的解析性能
- 协议/文件类 `json.loads`（WebSocket、API request、本地文件）**不动**

## 改动范围

| 文件 | 改动 |
|------|------|
| `utils/file_utils.py` | 新增 `robust_json_loads()` |
| `memory/facts.py` | 移除 `_sanitize_json()`，改用共享函数 |
| `memory/reflection.py` | 移除本地 `_robust_json_loads()`，改用共享函数 (3处) |
| `memory/persona.py` | `json.loads` → `robust_json_loads` (1处) |
| `memory/settings.py` | `json.loads` → `robust_json_loads` (2处) |
| `memory/recent.py` | `json.loads` → `robust_json_loads` (3处) |
| `brain/task_executor.py` | `json.loads` → `robust_json_loads` (1处) |
| `brain/deduper.py` | `json.loads` → `robust_json_loads` (1处) |
| `main_routers/system_router.py` | `json.loads` → `robust_json_loads` (1处) |

## `robust_json_loads` 容错能力

| 问题 | 示例 | 来源 |
|------|------|------|
| 无引号 key | `{key: "value"}` | 新增 |
| 尾逗号 | `{"a": 1,}` | 原 `_sanitize_json` |
| Python 字面值 | `True / False / None` | 原 `_sanitize_json` |
| 模板双花括号 | `{{"key": "value"}}` | 原 `_sanitize_json` |
| 单引号 | `{'key': 'value'}` | 原 `_sanitize_json` |
| 混合引号 | `{'key': "value"}` | 原 `_sanitize_json` |

正常 JSON 走 fast path（第一次 `json.loads` 直接成功），不走修补逻辑，零性能开销。

## Test plan

- [ ] 确认 `robust_json_loads` 对标准 JSON 输入行为与 `json.loads` 一致
- [ ] 确认各种 LLM quirk 输入能正确解析
- [ ] 确认无法修复的输入仍然抛出 `json.JSONDecodeError`
- [ ] 确认协议/文件类 `json.loads` 未被改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了来自大型语言模型响应的 JSON 解析，增强容错能力，更好地处理格式异常的数据，确保各项依赖 LLM 输出的功能（包括去重、情感分析、记忆提取和反思综合等）的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->