### PR TITLE
fix: OpenFang provider 校验修复 — Ollama 免密放行 + Gemini 工具调用修正

### DIFF
--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -46,7 +46,8 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         host = (parsed.hostname or "").lower()
         path = (parsed.path or "").lower()
         port = parsed.port  # may raise ValueError for malformed ports
-    except Exception:
+    except Exception as exc:
+        logger.debug("[OpenFang] Failed to parse base_url %r: %s", base_url, exc)
         host, path, port = "", "", None
 
     def _host_matches(*domains: str) -> bool:

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -41,13 +41,13 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
     from urllib.parse import urlsplit
 
     model_lower = model.lower()
-    parsed = urlsplit(base_url)
-    host = (parsed.hostname or "").lower()
-    path = (parsed.path or "").lower()
     try:
-        port = parsed.port
-    except ValueError:
-        port = None
+        parsed = urlsplit(base_url)
+        host = (parsed.hostname or "").lower()
+        path = (parsed.path or "").lower()
+        port = parsed.port  # may raise ValueError for malformed ports
+    except Exception:
+        host, path, port = "", "", None
 
     def _host_matches(*domains: str) -> bool:
         """Check if host exactly matches or is a subdomain of any given domain."""
@@ -97,8 +97,8 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
     _is_google_ai = _host_matches("generativelanguage.googleapis.com")
     _normalized_path = path.rstrip("/")
     if _is_google_ai and (
-        _normalized_path.endswith("/openai")
-        or "/openai/" in path
+        _normalized_path == "/v1beta/openai"
+        or _normalized_path.startswith("/v1beta/openai/")
     ):
         # OpenAI 兼容端点, 直连即可, 不需要 Gemini driver
         return {

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -79,7 +79,20 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         }
 
     # Gemini / Google AI
-    if "generativelanguage.googleapis.com" in url_lower or "gemini" in model_lower:
+    # Google 提供两种端点：
+    #   /v1beta/openai/ — OpenAI 兼容（Bearer token + OpenAI tools 格式）→ 用 openai provider
+    #   /v1beta         — 原生 Gemini API（?key= 认证 + functionDeclarations）→ 用 gemini provider
+    _is_google_ai = "generativelanguage.googleapis.com" in url_lower
+    _is_gemini_model = "gemini" in model_lower
+    if _is_google_ai and "/openai" in url_lower:
+        # OpenAI 兼容端点，直连即可，不需要 Gemini driver
+        return {
+            "provider": "openai",
+            "needs_proxy": False,
+            "effective_url": base_url,
+            "api_key_env": "GEMINI_API_KEY",
+        }
+    if _is_google_ai or _is_gemini_model:
         return {
             "provider": "gemini",
             "needs_proxy": False,

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -44,6 +44,10 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
     parsed = urlsplit(base_url)
     host = (parsed.hostname or "").lower()
     path = (parsed.path or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
 
     def _host_matches(*domains: str) -> bool:
         """Check if host exactly matches or is a subdomain of any given domain."""
@@ -130,9 +134,10 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         or any(host.startswith(f"172.{i}.") for i in range(16, 32))
     )
     _is_local = _is_loopback or _is_lan
-    _has_ollama_port = parsed.port == 11434
-    _has_ollama_hint = "ollama" in model_lower or "/ollama" in path
-    if _has_ollama_port or (_is_local and _has_ollama_hint):
+    _has_ollama_port = port == 11434
+    _has_ollama_path = "/ollama" in path
+    _has_ollama_model = "ollama" in model_lower
+    if _has_ollama_port or _has_ollama_path or (_is_local and _has_ollama_model):
         return {
             "provider": "ollama",
             "needs_proxy": False,
@@ -589,8 +594,8 @@ class OpenFangAdapter:
         key_pushed = False
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
-                # (1) Push API key — 本地 provider (Ollama 等) 无需推送 key
-                if api_key:
+                # (1) Push API key — 本地 provider (api_key_env 为空) 跳过
+                if api_key and pinfo.get("api_key_env"):
                     provider_key_url = f"{self.base_url}/api/providers/{provider}/key"
                     for payload in [
                         {"key": api_key},

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -85,12 +85,12 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": "GROQ_API_KEY",
         }
 
-    # Gemini / Google AI
+    # Gemini / Google AI -- 仅通过 hostname 白名单判定, 不用 model name 启发式
+    # (model 名含 "gemini" 但 host 不是 Google 的情况 = OpenAI-compatible 代理, 应走 fallback)
     # Google 提供两种端点:
     #   /v1beta/openai/ -- OpenAI 兼容 (Bearer token + OpenAI tools 格式) -> 用 openai provider
     #   /v1beta         -- 原生 Gemini API (?key= 认证 + functionDeclarations) -> 用 gemini provider
     _is_google_ai = _host_matches("generativelanguage.googleapis.com")
-    _is_gemini_model = "gemini" in model_lower
     if _is_google_ai and "/openai" in path:
         # OpenAI 兼容端点, 直连即可, 不需要 Gemini driver
         return {
@@ -99,7 +99,7 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "effective_url": base_url,
             "api_key_env": "GEMINI_API_KEY",
         }
-    if _is_google_ai or _is_gemini_model:
+    if _is_google_ai:
         return {
             "provider": "gemini",
             "needs_proxy": False,

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -22,6 +22,8 @@ from utils.config_manager import get_config_manager
 # OpenFang LLM proxy — 运行在 agent_server 上，补全 OpenAI 兼容性字段
 _LLM_PROXY_BASE_URL = f"http://127.0.0.1:{TOOL_SERVER_PORT}/openfang-llm-proxy"
 
+logger = logging.getLogger("openfang_adapter")
+
 # ── Provider 检测 ──────────────────────────────────────────
 # OpenFang 原生支持多种 provider: anthropic, openai, groq, gemini, deepseek, ollama 等
 # 根据用户配置的 agent API base_url 推断最合适的 provider 和是否需要 proxy
@@ -160,7 +162,6 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         "api_key_env": "OPENAI_API_KEY",
     }
 
-logger = logging.getLogger("openfang_adapter")
 
 
 # ──────────────────────────────────────────────────────────────

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -627,8 +627,8 @@ class OpenFangAdapter:
                                     key_pushed = True
                                     logger.info("[OpenFang] API key synced to openai fallback")
                                     break
-                            except Exception:
-                                pass
+                            except Exception as ep:
+                                logger.debug("[OpenFang] Fallback key push attempt failed: %s", ep)
 
                     if not key_pushed:
                         logger.warning("[OpenFang] All key push formats failed, relying on config.toml")

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -41,6 +41,16 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
     url_lower = base_url.lower()
     model_lower = model.lower()
 
+    # 已知的 OpenAI-compatible 代理/中转 — 必须走 proxy，跳过后续 model-name 启发式匹配
+    _proxy_hosts = ("openrouter.ai", "lanlan.app", "lanlan.tech")
+    if any(h in url_lower for h in _proxy_hosts):
+        return {
+            "provider": "openai",
+            "needs_proxy": True,
+            "effective_url": _LLM_PROXY_BASE_URL,
+            "api_key_env": "OPENAI_API_KEY",
+        }
+
     # Anthropic 原生 API — OpenFang 直接支持，无需 proxy
     if "anthropic.com" in url_lower or "api.anthropic" in url_lower:
         return {
@@ -86,10 +96,18 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": "DEEPSEEK_API_KEY",
         }
 
-    # Ollama (local) — detect localhost, 127.0.0.1, 0.0.0.0, [::1]
+    # Ollama — detect by:
+    #   1. Loopback/LAN address + default port 11434
+    #   2. Loopback/LAN address + "ollama" in model name
+    #   3. URL path containing "/ollama" (reverse-proxy setups)
+    #   4. Default port 11434 on any host (strong Ollama signal)
     _loopback_hosts = ("localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]")
     _is_loopback = any(h in url_lower for h in _loopback_hosts)
-    if _is_loopback and ("11434" in url_lower or "ollama" in model_lower):
+    _is_lan = any(url_lower.startswith(f"http://{p}") for p in ("10.", "172.", "192.168."))
+    _is_local = _is_loopback or _is_lan
+    _has_ollama_port = ":11434" in url_lower
+    _has_ollama_hint = "ollama" in model_lower or "/ollama" in url_lower
+    if _has_ollama_port or (_is_local and _has_ollama_hint):
         return {
             "provider": "ollama",
             "needs_proxy": False,
@@ -521,13 +539,19 @@ class OpenFangAdapter:
             logger.warning("[OpenFang] Agent model not configured, cannot sync")
             return False
 
-        if not api_key or not base_url:
-            logger.warning("[OpenFang] Agent API 未配置 (key=%s, url=%s), 跳过同步",
-                           "set" if api_key else "empty", "set" if base_url else "empty")
+        if not base_url:
+            logger.warning("[OpenFang] Agent API base_url 未配置, 跳过同步")
             return False
 
-        # 自动检测 provider 和是否需要 proxy
+        # 先检测 provider，再决定是否需要 api_key
+        # Ollama 等本地 provider 不需要 api_key（api_key_env 为空串）
         pinfo = _detect_provider_info(base_url, model)
+        if not api_key and pinfo.get("api_key_env"):
+            # 云端 provider 缺少 api_key，跳过同步
+            logger.warning("[OpenFang] Agent API key 未配置 (provider=%s), 跳过同步",
+                           pinfo["provider"])
+            return False
+
         self._provider_info = pinfo
         provider = pinfo["provider"]
         effective_url = pinfo["effective_url"]
@@ -540,60 +564,65 @@ class OpenFangAdapter:
         key_pushed = False
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
-                # (1) Push API key — 尝试推送到检测到的 provider
-                provider_key_url = f"{self.base_url}/api/providers/{provider}/key"
-                for payload in [
-                    {"key": api_key},
-                    {"api_key": api_key},
-                    {"key": api_key, "base_url": base_url, "model": model},
-                    api_key,  # plain string body
-                ]:
-                    try:
-                        if isinstance(payload, str):
-                            resp = await client.post(
-                                provider_key_url,
-                                content=payload,
-                                headers={**self._auth_headers(), "Content-Type": "text/plain"},
-                            )
-                        else:
-                            resp = await client.post(
-                                provider_key_url,
-                                json=payload,
-                                headers=self._auth_headers(),
-                            )
-                        if resp.status_code == 200:
-                            key_pushed = True
-                            logger.info("[OpenFang] API key synced to %s (format=%s): model=%s",
-                                        provider, type(payload).__name__, model)
-                            break
-                    except Exception as ep:
-                        logger.debug("[OpenFang] Key push attempt failed: %s", ep)
-
-                # 如果检测到的 provider push 失败，也尝试 openai（通用后备）
-                if not key_pushed and provider != "openai":
-                    for payload in [{"key": api_key}, api_key]:
+                # (1) Push API key — 本地 provider (Ollama 等) 无需推送 key
+                if api_key:
+                    provider_key_url = f"{self.base_url}/api/providers/{provider}/key"
+                    for payload in [
+                        {"key": api_key},
+                        {"api_key": api_key},
+                        {"key": api_key, "base_url": base_url, "model": model},
+                        api_key,  # plain string body
+                    ]:
                         try:
                             if isinstance(payload, str):
                                 resp = await client.post(
-                                    f"{self.base_url}/api/providers/openai/key",
+                                    provider_key_url,
                                     content=payload,
                                     headers={**self._auth_headers(), "Content-Type": "text/plain"},
                                 )
                             else:
                                 resp = await client.post(
-                                    f"{self.base_url}/api/providers/openai/key",
+                                    provider_key_url,
                                     json=payload,
                                     headers=self._auth_headers(),
                                 )
                             if resp.status_code == 200:
                                 key_pushed = True
-                                logger.info("[OpenFang] API key synced to openai fallback")
+                                logger.info("[OpenFang] API key synced to %s (format=%s): model=%s",
+                                            provider, type(payload).__name__, model)
                                 break
-                        except Exception:
-                            pass
+                        except Exception as ep:
+                            logger.debug("[OpenFang] Key push attempt failed: %s", ep)
 
-                if not key_pushed:
-                    logger.warning("[OpenFang] All key push formats failed, relying on config.toml")
+                    # 如果检测到的 provider push 失败，也尝试 openai（通用后备）
+                    if not key_pushed and provider != "openai":
+                        for payload in [{"key": api_key}, api_key]:
+                            try:
+                                if isinstance(payload, str):
+                                    resp = await client.post(
+                                        f"{self.base_url}/api/providers/openai/key",
+                                        content=payload,
+                                        headers={**self._auth_headers(), "Content-Type": "text/plain"},
+                                    )
+                                else:
+                                    resp = await client.post(
+                                        f"{self.base_url}/api/providers/openai/key",
+                                        json=payload,
+                                        headers=self._auth_headers(),
+                                    )
+                                if resp.status_code == 200:
+                                    key_pushed = True
+                                    logger.info("[OpenFang] API key synced to openai fallback")
+                                    break
+                            except Exception:
+                                pass
+
+                    if not key_pushed:
+                        logger.warning("[OpenFang] All key push formats failed, relying on config.toml")
+                else:
+                    # 本地 provider 不需要 key，跳过 key push
+                    key_pushed = True
+                    logger.info("[OpenFang] Local provider %s, skipping API key push", provider)
 
                 # (2) Override provider base_url
                 push_url = effective_url  # proxy URL 或直连 URL

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -38,12 +38,19 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": str,       # 环境变量名 (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
         }
     """
-    url_lower = base_url.lower()
-    model_lower = model.lower()
+    from urllib.parse import urlsplit
 
-    # 已知的 OpenAI-compatible 代理/中转 — 必须走 proxy，跳过后续 model-name 启发式匹配
-    _proxy_hosts = ("openrouter.ai",)
-    if any(h in url_lower for h in _proxy_hosts):
+    model_lower = model.lower()
+    parsed = urlsplit(base_url)
+    host = (parsed.hostname or "").lower()
+    path = (parsed.path or "").lower()
+
+    def _host_matches(*domains: str) -> bool:
+        """Check if host exactly matches or is a subdomain of any given domain."""
+        return any(host == d or host.endswith(f".{d}") for d in domains)
+
+    # 已知的 OpenAI-compatible 代理/中转 -- 必须走 proxy, 跳过后续 model-name 启发式匹配
+    if _host_matches("openrouter.ai"):
         return {
             "provider": "openai",
             "needs_proxy": True,
@@ -51,8 +58,8 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": "OPENAI_API_KEY",
         }
 
-    # Anthropic 原生 API — OpenFang 直接支持，无需 proxy
-    if "anthropic.com" in url_lower or "api.anthropic" in url_lower:
+    # Anthropic 原生 API -- OpenFang 直接支持, 无需 proxy
+    if _host_matches("anthropic.com", "api.anthropic.com"):
         return {
             "provider": "anthropic",
             "needs_proxy": False,
@@ -60,8 +67,8 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": "ANTHROPIC_API_KEY",
         }
 
-    # OpenAI 原生 API — OpenFang 直接支持，无需 proxy
-    if "api.openai.com" in url_lower:
+    # OpenAI 原生 API -- OpenFang 直接支持, 无需 proxy
+    if _host_matches("api.openai.com"):
         return {
             "provider": "openai",
             "needs_proxy": False,
@@ -70,7 +77,7 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         }
 
     # Groq
-    if "groq.com" in url_lower or "groq" in model_lower:
+    if _host_matches("groq.com", "api.groq.com") or "groq" in model_lower:
         return {
             "provider": "groq",
             "needs_proxy": False,
@@ -79,13 +86,13 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         }
 
     # Gemini / Google AI
-    # Google 提供两种端点：
-    #   /v1beta/openai/ — OpenAI 兼容（Bearer token + OpenAI tools 格式）→ 用 openai provider
-    #   /v1beta         — 原生 Gemini API（?key= 认证 + functionDeclarations）→ 用 gemini provider
-    _is_google_ai = "generativelanguage.googleapis.com" in url_lower
+    # Google 提供两种端点:
+    #   /v1beta/openai/ -- OpenAI 兼容 (Bearer token + OpenAI tools 格式) -> 用 openai provider
+    #   /v1beta         -- 原生 Gemini API (?key= 认证 + functionDeclarations) -> 用 gemini provider
+    _is_google_ai = _host_matches("generativelanguage.googleapis.com")
     _is_gemini_model = "gemini" in model_lower
-    if _is_google_ai and "/openai" in url_lower:
-        # OpenAI 兼容端点，直连即可，不需要 Gemini driver
+    if _is_google_ai and "/openai" in path:
+        # OpenAI 兼容端点, 直连即可, 不需要 Gemini driver
         return {
             "provider": "openai",
             "needs_proxy": False,
@@ -101,7 +108,7 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
         }
 
     # DeepSeek
-    if "deepseek.com" in url_lower or "deepseek" in model_lower:
+    if _host_matches("deepseek.com", "api.deepseek.com") or "deepseek" in model_lower:
         return {
             "provider": "deepseek",
             "needs_proxy": False,
@@ -109,17 +116,22 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
             "api_key_env": "DEEPSEEK_API_KEY",
         }
 
-    # Ollama — detect by:
+    # Ollama -- detect by:
     #   1. Loopback/LAN address + default port 11434
     #   2. Loopback/LAN address + "ollama" in model name
     #   3. URL path containing "/ollama" (reverse-proxy setups)
     #   4. Default port 11434 on any host (strong Ollama signal)
-    _loopback_hosts = ("localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]")
-    _is_loopback = any(h in url_lower for h in _loopback_hosts)
-    _is_lan = any(url_lower.startswith(f"http://{p}") for p in ("10.", "172.", "192.168."))
+    _loopback_hosts = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+    _is_loopback = host in _loopback_hosts
+    # RFC1918 private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+    _is_lan = (
+        host.startswith("10.")
+        or host.startswith("192.168.")
+        or any(host.startswith(f"172.{i}.") for i in range(16, 32))
+    )
     _is_local = _is_loopback or _is_lan
-    _has_ollama_port = ":11434" in url_lower
-    _has_ollama_hint = "ollama" in model_lower or "/ollama" in url_lower
+    _has_ollama_port = parsed.port == 11434
+    _has_ollama_hint = "ollama" in model_lower or "/ollama" in path
     if _has_ollama_port or (_is_local and _has_ollama_hint):
         return {
             "provider": "ollama",
@@ -633,8 +645,7 @@ class OpenFangAdapter:
                     if not key_pushed:
                         logger.warning("[OpenFang] All key push formats failed, relying on config.toml")
                 else:
-                    # 本地 provider 不需要 key，跳过 key push
-                    key_pushed = True
+                    # 本地 provider 不需要 key, 跳过 key push
                     logger.info("[OpenFang] Local provider %s, skipping API key push", provider)
 
                 # (2) Override provider base_url

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -42,7 +42,7 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
     model_lower = model.lower()
 
     # 已知的 OpenAI-compatible 代理/中转 — 必须走 proxy，跳过后续 model-name 启发式匹配
-    _proxy_hosts = ("openrouter.ai", "lanlan.app", "lanlan.tech")
+    _proxy_hosts = ("openrouter.ai",)
     if any(h in url_lower for h in _proxy_hosts):
         return {
             "provider": "openai",

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -95,7 +95,11 @@ def _detect_provider_info(base_url: str, model: str) -> dict:
     #   /v1beta/openai/ -- OpenAI 兼容 (Bearer token + OpenAI tools 格式) -> 用 openai provider
     #   /v1beta         -- 原生 Gemini API (?key= 认证 + functionDeclarations) -> 用 gemini provider
     _is_google_ai = _host_matches("generativelanguage.googleapis.com")
-    if _is_google_ai and "/openai" in path:
+    _normalized_path = path.rstrip("/")
+    if _is_google_ai and (
+        _normalized_path.endswith("/openai")
+        or "/openai/" in path
+    ):
         # OpenAI 兼容端点, 直连即可, 不需要 Gemini driver
         return {
             "provider": "openai",

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -9,7 +9,6 @@ Covers:
 import os
 import sys
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -1,0 +1,275 @@
+"""
+Unit tests for OpenFang provider detection and config sync.
+
+Covers:
+- _detect_provider_info: all provider types, edge cases, proxy URL early-exit
+- sync_config: key-free provider (Ollama) vs cloud provider validation
+"""
+
+import os
+import sys
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from brain.openfang_adapter import _detect_provider_info, OpenFangAdapter
+
+
+# ── _detect_provider_info ─────────────────────────────────────
+
+
+class TestDetectProviderInfo:
+    """Test _detect_provider_info for all provider types and edge cases."""
+
+    # -- Direct cloud providers --
+
+    def test_anthropic_by_url(self):
+        r = _detect_provider_info("https://api.anthropic.com/v1", "claude-sonnet-4-20250514")
+        assert r["provider"] == "anthropic"
+        assert r["needs_proxy"] is False
+        assert r["api_key_env"] == "ANTHROPIC_API_KEY"
+
+    def test_openai_by_url(self):
+        r = _detect_provider_info("https://api.openai.com/v1", "gpt-4.1")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is False
+        assert r["api_key_env"] == "OPENAI_API_KEY"
+
+    def test_groq_by_url(self):
+        r = _detect_provider_info("https://api.groq.com/openai/v1", "llama-3.3-70b")
+        assert r["provider"] == "groq"
+        assert r["needs_proxy"] is False
+
+    def test_groq_by_model(self):
+        r = _detect_provider_info("https://custom-endpoint.example.com/v1", "groq-llama-70b")
+        assert r["provider"] == "groq"
+
+    def test_gemini_by_url(self):
+        r = _detect_provider_info(
+            "https://generativelanguage.googleapis.com/v1beta", "gemini-2.5-flash"
+        )
+        assert r["provider"] == "gemini"
+        assert r["needs_proxy"] is False
+        assert r["api_key_env"] == "GEMINI_API_KEY"
+
+    def test_gemini_by_model(self):
+        r = _detect_provider_info("https://custom-endpoint.example.com/v1", "gemini-2.5-pro")
+        assert r["provider"] == "gemini"
+        assert r["needs_proxy"] is False
+
+    def test_deepseek_by_url(self):
+        r = _detect_provider_info("https://api.deepseek.com/v1", "deepseek-chat")
+        assert r["provider"] == "deepseek"
+        assert r["needs_proxy"] is False
+
+    def test_deepseek_by_model(self):
+        r = _detect_provider_info("https://custom.example.com/v1", "deepseek-r1")
+        assert r["provider"] == "deepseek"
+
+    # -- Proxy URLs: must always go through proxy, never match by model name --
+
+    def test_openrouter_with_gemini_model(self):
+        """OpenRouter URL + gemini model → must be proxy, NOT direct gemini."""
+        r = _detect_provider_info("https://openrouter.ai/api/v1", "gemini-2.5-flash")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
+
+    def test_openrouter_with_deepseek_model(self):
+        r = _detect_provider_info("https://openrouter.ai/api/v1", "deepseek/deepseek-r1")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
+
+    def test_lanlan_app_with_gemini_model(self):
+        r = _detect_provider_info("https://api.lanlan.app/v1", "gemini-2.5-pro")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
+
+    def test_lanlan_tech_with_any_model(self):
+        r = _detect_provider_info("https://api.lanlan.tech/v1", "qwen-turbo")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
+
+    # -- Ollama: loopback, LAN, non-standard port --
+
+    def test_ollama_localhost_default_port(self):
+        r = _detect_provider_info("http://localhost:11434/v1", "llama3")
+        assert r["provider"] == "ollama"
+        assert r["needs_proxy"] is False
+        assert r["api_key_env"] == ""
+
+    def test_ollama_127_default_port(self):
+        r = _detect_provider_info("http://127.0.0.1:11434/v1", "qwen2.5")
+        assert r["provider"] == "ollama"
+        assert r["api_key_env"] == ""
+
+    def test_ollama_ipv6_default_port(self):
+        r = _detect_provider_info("http://[::1]:11434/v1", "llama3")
+        assert r["provider"] == "ollama"
+
+    def test_ollama_non_standard_port_with_ollama_model(self):
+        """Loopback + 'ollama' in model name → Ollama, even on non-default port."""
+        r = _detect_provider_info("http://localhost:8080/v1", "ollama/llama3")
+        assert r["provider"] == "ollama"
+        assert r["needs_proxy"] is False
+
+    def test_ollama_lan_default_port(self):
+        """LAN IP (192.168.x.x) + default port → Ollama."""
+        r = _detect_provider_info("http://192.168.1.100:11434/v1", "llama3")
+        assert r["provider"] == "ollama"
+        assert r["needs_proxy"] is False
+
+    def test_ollama_lan_10_network(self):
+        """10.x.x.x LAN + default port → Ollama."""
+        r = _detect_provider_info("http://10.0.0.5:11434/v1", "mistral")
+        assert r["provider"] == "ollama"
+
+    def test_ollama_lan_172_network(self):
+        """172.x.x.x LAN + default port → Ollama."""
+        r = _detect_provider_info("http://172.16.0.10:11434/v1", "llama3")
+        assert r["provider"] == "ollama"
+
+    def test_ollama_reverse_proxy_path(self):
+        """URL path containing '/ollama' → Ollama (reverse-proxy setup)."""
+        r = _detect_provider_info("http://192.168.1.1:8080/ollama/v1", "llama3")
+        assert r["provider"] == "ollama"
+
+    def test_ollama_remote_default_port(self):
+        """Remote host (not LAN/loopback) with :11434 → still Ollama (strong signal)."""
+        r = _detect_provider_info("http://my-gpu-server.example.com:11434/v1", "llama3")
+        assert r["provider"] == "ollama"
+        assert r["needs_proxy"] is False
+
+    def test_local_non_ollama_port_non_ollama_model(self):
+        """Loopback + non-Ollama port + non-Ollama model → fallback to proxy."""
+        r = _detect_provider_info("http://localhost:8080/v1", "llama3")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
+
+    # -- Fallback: unknown provider → openai + proxy --
+
+    def test_unknown_provider_fallback(self):
+        r = _detect_provider_info("https://api.custom-llm.example.com/v1", "my-model")
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
+        assert r["api_key_env"] == "OPENAI_API_KEY"
+
+
+# ── sync_config: key-free provider handling ───────────────────
+
+
+class TestSyncConfigKeyFreeProvider:
+    """Test that sync_config allows Ollama (no API key) to proceed."""
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    @patch("brain.openfang_adapter.get_config_manager")
+    def test_ollama_no_key_proceeds(self, mock_get_cm):
+        """Ollama with empty api_key should NOT be blocked by sync_config."""
+        cm = MagicMock()
+        cm.get_model_api_config.return_value = {
+            "model": "llama3",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+        }
+        mock_get_cm.return_value = cm
+
+        adapter = OpenFangAdapter(base_url="http://127.0.0.1:12345")
+
+        # Mock httpx to avoid real HTTP calls — make it raise to short-circuit
+        # but the key point is: we should NOT return False before reaching HTTP
+        with patch("brain.openfang_adapter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            # Config/set and reload endpoints
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "ok"
+            mock_client.post.return_value = mock_resp
+            mock_client.put.return_value = mock_resp
+
+            result = self._run(adapter.sync_config())
+
+        # Should succeed (not blocked by empty key)
+        assert result is True
+        # Provider should be detected as ollama
+        assert adapter._provider_info["provider"] == "ollama"
+
+    @patch("brain.openfang_adapter.get_config_manager")
+    def test_cloud_provider_no_key_blocked(self, mock_get_cm):
+        """Cloud provider (OpenAI) with empty api_key should be blocked."""
+        cm = MagicMock()
+        cm.get_model_api_config.return_value = {
+            "model": "gpt-4.1",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "",
+        }
+        mock_get_cm.return_value = cm
+
+        adapter = OpenFangAdapter()
+        result = self._run(adapter.sync_config())
+
+        assert result is False
+
+    @patch("brain.openfang_adapter.get_config_manager")
+    def test_gemini_with_key_proceeds(self, mock_get_cm):
+        """Gemini with a valid API key should proceed normally."""
+        cm = MagicMock()
+        cm.get_model_api_config.return_value = {
+            "model": "gemini-2.5-flash",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta",
+            "api_key": "AIza-test-key-12345",
+        }
+        mock_get_cm.return_value = cm
+
+        adapter = OpenFangAdapter(base_url="http://127.0.0.1:12345")
+
+        with patch("brain.openfang_adapter.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "ok"
+            mock_client.post.return_value = mock_resp
+            mock_client.put.return_value = mock_resp
+
+            result = self._run(adapter.sync_config())
+
+        assert result is True
+        assert adapter._provider_info["provider"] == "gemini"
+
+    @patch("brain.openfang_adapter.get_config_manager")
+    def test_no_model_returns_false(self, mock_get_cm):
+        """Missing model should return False immediately."""
+        cm = MagicMock()
+        cm.get_model_api_config.return_value = {
+            "model": "",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "",
+        }
+        mock_get_cm.return_value = cm
+
+        adapter = OpenFangAdapter()
+        result = self._run(adapter.sync_config())
+        assert result is False
+
+    @patch("brain.openfang_adapter.get_config_manager")
+    def test_no_base_url_returns_false(self, mock_get_cm):
+        """Missing base_url should return False immediately."""
+        cm = MagicMock()
+        cm.get_model_api_config.return_value = {
+            "model": "llama3",
+            "base_url": "",
+            "api_key": "",
+        }
+        mock_get_cm.return_value = cm
+
+        adapter = OpenFangAdapter()
+        result = self._run(adapter.sync_config())
+        assert result is False

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -85,11 +85,15 @@ class TestDetectProviderInfo:
         r = _detect_provider_info("https://openrouter.ai/api/v1", "gemini-2.5-flash")
         assert r["provider"] == "openai"
         assert r["needs_proxy"] is True
+        assert r["api_key_env"] == "OPENAI_API_KEY"
+        assert r["effective_url"] != "https://openrouter.ai/api/v1"
 
     def test_openrouter_with_deepseek_model(self):
         r = _detect_provider_info("https://openrouter.ai/api/v1", "deepseek/deepseek-r1")
         assert r["provider"] == "openai"
         assert r["needs_proxy"] is True
+        assert r["api_key_env"] == "OPENAI_API_KEY"
+        assert r["effective_url"] != "https://openrouter.ai/api/v1"
 
     # -- Ollama: loopback, LAN, non-standard port --
 

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -201,7 +201,8 @@ class TestSyncConfigKeyFreeProvider:
 
         # Mock httpx to avoid real HTTP calls — make it raise to short-circuit
         # but the key point is: we should NOT return False before reaching HTTP
-        with patch("brain.openfang_adapter.httpx.AsyncClient") as mock_client_cls:
+        with patch("brain.openfang_adapter.httpx.AsyncClient") as mock_client_cls, \
+             patch.object(OpenFangAdapter, "_write_openfang_model_config"):
             mock_client = AsyncMock()
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -249,7 +250,8 @@ class TestSyncConfigKeyFreeProvider:
 
         adapter = OpenFangAdapter(base_url="http://127.0.0.1:12345")
 
-        with patch("brain.openfang_adapter.httpx.AsyncClient") as mock_client_cls:
+        with patch("brain.openfang_adapter.httpx.AsyncClient") as mock_client_cls, \
+             patch.object(OpenFangAdapter, "_write_openfang_model_config"):
             mock_client = AsyncMock()
             mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -220,6 +220,13 @@ class TestSyncConfigKeyFreeProvider:
         assert result is True
         # Provider should be detected as ollama
         assert adapter._provider_info["provider"] == "ollama"
+        # Critical: must NOT push to /api/providers/{provider}/key for local providers
+        for call in mock_client.post.call_args_list:
+            url = call.args[0] if call.args else call.kwargs.get("url", "")
+            assert "/api/providers/ollama/key" not in url, \
+                f"Local provider should not push key, but got POST to {url}"
+            assert "/api/providers/openai/key" not in url, \
+                f"Local provider should not fall back to openai key push, got POST to {url}"
 
     @patch("brain.openfang_adapter.get_config_manager")
     def test_cloud_provider_no_key_blocked(self, mock_get_cm):

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -184,7 +184,7 @@ class TestSyncConfigKeyFreeProvider:
     """Test that sync_config allows Ollama (no API key) to proceed."""
 
     def _run(self, coro):
-        return asyncio.get_event_loop().run_until_complete(coro)
+        return asyncio.run(coro)
 
     @patch("brain.openfang_adapter.get_config_manager")
     def test_ollama_no_key_proceeds(self, mock_get_cm):

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -81,16 +81,6 @@ class TestDetectProviderInfo:
         assert r["provider"] == "openai"
         assert r["needs_proxy"] is True
 
-    def test_lanlan_app_with_gemini_model(self):
-        r = _detect_provider_info("https://api.lanlan.app/v1", "gemini-2.5-pro")
-        assert r["provider"] == "openai"
-        assert r["needs_proxy"] is True
-
-    def test_lanlan_tech_with_any_model(self):
-        r = _detect_provider_info("https://api.lanlan.tech/v1", "qwen-turbo")
-        assert r["provider"] == "openai"
-        assert r["needs_proxy"] is True
-
     # -- Ollama: loopback, LAN, non-standard port --
 
     def test_ollama_localhost_default_port(self):

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -125,8 +125,18 @@ class TestDetectProviderInfo:
         assert r["provider"] == "ollama"
 
     def test_ollama_lan_172_network(self):
-        """172.x.x.x LAN + default port → Ollama."""
+        """172.16-31.x.x (RFC1918) + default port → Ollama."""
         r = _detect_provider_info("http://172.16.0.10:11434/v1", "llama3")
+        assert r["provider"] == "ollama"
+
+    def test_172_non_rfc1918_not_lan(self):
+        """172.15.x.x is NOT RFC1918 private range, should not be detected as LAN Ollama."""
+        r = _detect_provider_info("http://172.15.0.1:8080/v1", "llama3")
+        assert r["provider"] != "ollama"
+
+    def test_ollama_lan_https(self):
+        """HTTPS LAN address + default port → Ollama (not just HTTP)."""
+        r = _detect_provider_info("https://192.168.1.100:11434/v1", "llama3")
         assert r["provider"] == "ollama"
 
     def test_ollama_reverse_proxy_path(self):

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -46,11 +46,21 @@ class TestDetectProviderInfo:
         r = _detect_provider_info("https://custom-endpoint.example.com/v1", "groq-llama-70b")
         assert r["provider"] == "groq"
 
-    def test_gemini_by_url(self):
+    def test_gemini_native_api(self):
+        """Native Gemini API (no /openai/) → provider=gemini for native driver."""
         r = _detect_provider_info(
             "https://generativelanguage.googleapis.com/v1beta", "gemini-2.5-flash"
         )
         assert r["provider"] == "gemini"
+        assert r["needs_proxy"] is False
+        assert r["api_key_env"] == "GEMINI_API_KEY"
+
+    def test_gemini_openai_compat_endpoint(self):
+        """Gemini /openai/ endpoint → provider=openai (Bearer token + OpenAI tools)."""
+        r = _detect_provider_info(
+            "https://generativelanguage.googleapis.com/v1beta/openai/", "gemini-3-flash-preview"
+        )
+        assert r["provider"] == "openai"
         assert r["needs_proxy"] is False
         assert r["api_key_env"] == "GEMINI_API_KEY"
 
@@ -206,12 +216,12 @@ class TestSyncConfigKeyFreeProvider:
         assert result is False
 
     @patch("brain.openfang_adapter.get_config_manager")
-    def test_gemini_with_key_proceeds(self, mock_get_cm):
-        """Gemini with a valid API key should proceed normally."""
+    def test_gemini_openai_compat_with_key_proceeds(self, mock_get_cm):
+        """Gemini OpenAI-compat endpoint with valid API key should proceed as openai provider."""
         cm = MagicMock()
         cm.get_model_api_config.return_value = {
-            "model": "gemini-2.5-flash",
-            "base_url": "https://generativelanguage.googleapis.com/v1beta",
+            "model": "gemini-3-flash-preview",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
             "api_key": "AIza-test-key-12345",
         }
         mock_get_cm.return_value = cm
@@ -232,7 +242,7 @@ class TestSyncConfigKeyFreeProvider:
             result = self._run(adapter.sync_config())
 
         assert result is True
-        assert adapter._provider_info["provider"] == "gemini"
+        assert adapter._provider_info["provider"] == "openai"
 
     @patch("brain.openfang_adapter.get_config_manager")
     def test_no_model_returns_false(self, mock_get_cm):

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -140,10 +140,21 @@ class TestDetectProviderInfo:
         r = _detect_provider_info("https://192.168.1.100:11434/v1", "llama3")
         assert r["provider"] == "ollama"
 
-    def test_ollama_reverse_proxy_path(self):
-        """URL path containing '/ollama' → Ollama (reverse-proxy setup)."""
+    def test_ollama_reverse_proxy_path_local(self):
+        """LAN + URL path containing '/ollama' → Ollama (reverse-proxy setup)."""
         r = _detect_provider_info("http://192.168.1.1:8080/ollama/v1", "llama3")
         assert r["provider"] == "ollama"
+
+    def test_ollama_reverse_proxy_path_remote(self):
+        """Remote host + URL path containing '/ollama' → still Ollama."""
+        r = _detect_provider_info("https://example.com/ollama/v1", "llama3")
+        assert r["provider"] == "ollama"
+        assert r["needs_proxy"] is False
+
+    def test_malformed_port_does_not_crash(self):
+        """Malformed port in URL should not raise, falls to fallback."""
+        r = _detect_provider_info("http://localhost:abc/v1", "llama3")
+        assert r["provider"] == "openai"
 
     def test_ollama_remote_default_port(self):
         """Remote host (not LAN/loopback) with :11434 → still Ollama (strong signal)."""

--- a/tests/unit/test_openfang_provider_detection.py
+++ b/tests/unit/test_openfang_provider_detection.py
@@ -63,10 +63,11 @@ class TestDetectProviderInfo:
         assert r["needs_proxy"] is False
         assert r["api_key_env"] == "GEMINI_API_KEY"
 
-    def test_gemini_by_model(self):
+    def test_gemini_model_on_unknown_host_falls_through(self):
+        """Non-Google host + gemini model name → NOT native Gemini, falls to proxy fallback."""
         r = _detect_provider_info("https://custom-endpoint.example.com/v1", "gemini-2.5-pro")
-        assert r["provider"] == "gemini"
-        assert r["needs_proxy"] is False
+        assert r["provider"] == "openai"
+        assert r["needs_proxy"] is True
 
     def test_deepseek_by_url(self):
         r = _detect_provider_info("https://api.deepseek.com/v1", "deepseek-chat")


### PR DESCRIPTION
## Summary

`_detect_provider_info` 和 `sync_config` 存在三个问题，导致 Ollama 无法用于 OpenFang Agent、Gemini 工具调用协议不匹配：

### 1. Ollama 被 `sync_config` 空 key 前置校验拦死

`sync_config()` 在调用 `_detect_provider_info` **之前**就检查 `if not api_key`，Ollama 等本地 provider 空 key 直接 `return False`，永远无法同步到 OpenFang。

**修复**：将 api_key 校验移到 provider 检测之后，仅对 `api_key_env` 非空的云端 provider 拦截空 key。Ollama 的 `api_key_env=""`，正常放行。同时 key push 逻辑也加了本地 provider 跳过保护。

### 2. Ollama 检测范围过窄

原检测条件：`loopback AND (port 11434 OR "ollama" in model)`，导致以下场景漏检：
- 非标端口（如 `localhost:8080` + model 含 `ollama`）
- LAN 部署（`192.168.x.x:11434`）
- 反向代理（URL 路径含 `/ollama`）

**修复**：
- `:11434` 端口在任何主机上都视为 Ollama（强信号）
- LAN 地址 (`192.168.*`, `10.*`, `172.*`) + Ollama 暗示 → 识别
- URL 路径含 `/ollama` → 识别（反向代理场景）

### 3. Gemini OpenAI 兼容端点被误判为原生 Gemini provider

默认 Gemini assist profile 的 URL 是 `/v1beta/openai/`（OpenAI 兼容端点），但 `_detect_provider_info` 只看域名 `generativelanguage.googleapis.com` → 统一返回 `provider="gemini"` → OpenFang 用 Gemini 原生 driver（`?key=` 认证 + `functionDeclarations`）去打 OpenAI 兼容端点 → **工具调用格式不匹配**。

**修复**：区分两种 Google AI 端点：
- `/v1beta/openai/` → `provider="openai"`（Bearer token + OpenAI tools 格式）
- `/v1beta` → `provider="gemini"`（原生 Gemini driver）

### 4. OpenRouter 代理 URL 被 model name 启发式污染

`openrouter.ai/api/v1` + model=`gemini-2.5-flash` 会被 `"gemini" in model_lower` 匹配为直连 Gemini → OpenFang 用 Gemini driver 打 OpenRouter → 必挂。

**修复**：OpenRouter 等已知代理 URL 在函数最前面就提前返回 proxy 路径。

## Test plan

- [x] 27 个 mock 测试覆盖所有 provider 检测场景 + sync_config 边界条件，全部通过
- [ ] Ollama 本地部署 + OpenFang Agent：配置空 key，确认任务能正常下发
- [ ] Gemini AI Studio key + OpenFang Agent：确认工具调用（function calling）正常工作
- [ ] OpenRouter + Gemini model：确认走 proxy 路径而非直连

https://claude.ai/code/session_01US8ggjgJn75EwrgkSbLtMV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进提供商识别逻辑，基于规范化主机/端口/路径匹配，减少云与本地服务误判与错误代理选择。

* **功能优化**
  * 优先识别特定代理主机并自动启用代理规则；加强本地回环/LAN/端口/路径探测；调整同步配置流程：先判定提供商再决定是否推送 API Key，改进跳过与日志行为。

* **测试**
  * 添加全面单元测试，覆盖提供商推断、代理优先级与配置同步的多种边界情况。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->