### PR TITLE
修复独立聊天窗口在角色切换时误触发本地 Live2D 模型热切换，导致未加载 Live2D 运行时的页面抛出 Live2DManager …

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -73,6 +73,10 @@
         }
     }
 
+    function supportsLocalModelRuntime() {
+        return window.location.pathname !== '/chat';
+    }
+
     function emitAssistantSpeechCancel(source) {
         var turnId = S.assistantTurnId || S.assistantSpeechActiveTurnId || null;
         S.assistantTurnId = null;
@@ -425,7 +429,9 @@
 
             // 4. 根据模型类型加载相应的模型
             console.log('[猫娘切换] 检测到模型类型:', modelType, '有效类型:', effectiveModelType);
-            if (effectiveModelType === 'vrm') {
+            if (!supportsLocalModelRuntime()) {
+                console.log('[猫娘切换] 当前页面不加载本地模型，跳过模型热切换');
+            } else if (effectiveModelType === 'vrm') {
                 // 加载 VRM 模型
                 console.log('[猫娘切换] 进入VRM加载分支');
 

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -74,7 +74,7 @@
     }
 
     function supportsLocalModelRuntime() {
-        return window.location.pathname !== '/chat';
+        return !/^\/chat(?:\/|$)/.test(window.location.pathname || '');
     }
 
     function emitAssistantSpeechCancel(source) {


### PR DESCRIPTION
…unavailable；现在 /chat 页面会跳过本地模型切换，只保留角色与会话状态同步

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了模型切换逻辑：新增页面是否支持本地模型运行的检测，避免在不支持的页面触发特定模型的热切换/加载流程并记录相关信息，从而减少不必要的切换和错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->