### PR TITLE
fix: 修复 Windows 下角色数据库初始化失败（目录缺失 + 反斜杠 URI）

### DIFF
--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -34,17 +34,18 @@ class TimeIndexedMemory:
                     logger.info(f"[TimeIndexedMemory] 角色 '{lanlan_name}' 不在配置中，使用默认路径: {db_path}")
 
             # 确保数据库文件的父目录存在（兼容相对文件名路径）
-            db_dir = os.path.dirname(os.path.abspath(db_path))
+            normalized_db_path = os.path.abspath(db_path)
+            db_dir = os.path.dirname(normalized_db_path)
             os.makedirs(db_dir, exist_ok=True)
             # Windows 路径使用反斜杠，SQLite URI 需要正斜杠
-            uri_path = db_path.replace("\\", "/")
+            uri_path = normalized_db_path.replace("\\", "/")
             engine = create_engine(f"sqlite:///{uri_path}")
             connection_string = f"sqlite:///{uri_path}"
             # 先完成所有初始化/迁移，再注册到 self.engines，
             # 避免失败后引擎被标记为"已初始化"而跳过后续修复
             self._ensure_tables_exist_with(engine, connection_string, lanlan_name)
             self._check_and_migrate_schema(engine, lanlan_name)
-            self.db_paths[lanlan_name] = db_path
+            self.db_paths[lanlan_name] = normalized_db_path
             self.engines[lanlan_name] = engine
             return True
         except Exception:

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -33,8 +33,12 @@ class TimeIndexedMemory:
                     db_path = os.path.join(ensure_character_dir(config_mgr.memory_dir, lanlan_name), 'time_indexed.db')
                     logger.info(f"[TimeIndexedMemory] 角色 '{lanlan_name}' 不在配置中，使用默认路径: {db_path}")
 
-            engine = create_engine(f"sqlite:///{db_path}")
-            connection_string = f"sqlite:///{db_path}"
+            # 确保数据库文件的父目录存在
+            os.makedirs(os.path.dirname(db_path), exist_ok=True)
+            # Windows 路径使用反斜杠，SQLite URI 需要正斜杠
+            uri_path = db_path.replace("\\", "/")
+            engine = create_engine(f"sqlite:///{uri_path}")
+            connection_string = f"sqlite:///{uri_path}"
             # 先完成所有初始化/迁移，再注册到 self.engines，
             # 避免失败后引擎被标记为"已初始化"而跳过后续修复
             self._ensure_tables_exist_with(engine, connection_string, lanlan_name)
@@ -108,7 +112,8 @@ class TimeIndexedMemory:
             timestamp = datetime.now()
 
         db_path = self.db_paths[lanlan_name]
-        connection_string = f"sqlite:///{db_path}"
+        uri_path = db_path.replace("\\", "/")
+        connection_string = f"sqlite:///{uri_path}"
         
         original_table = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
         

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -33,8 +33,9 @@ class TimeIndexedMemory:
                     db_path = os.path.join(ensure_character_dir(config_mgr.memory_dir, lanlan_name), 'time_indexed.db')
                     logger.info(f"[TimeIndexedMemory] 角色 '{lanlan_name}' 不在配置中，使用默认路径: {db_path}")
 
-            # 确保数据库文件的父目录存在
-            os.makedirs(os.path.dirname(db_path), exist_ok=True)
+            # 确保数据库文件的父目录存在（兼容相对文件名路径）
+            db_dir = os.path.dirname(os.path.abspath(db_path))
+            os.makedirs(db_dir, exist_ok=True)
             # Windows 路径使用反斜杠，SQLite URI 需要正斜杠
             uri_path = db_path.replace("\\", "/")
             engine = create_engine(f"sqlite:///{uri_path}")


### PR DESCRIPTION
## Summary

- 修复 `_ensure_engine_exists` 在创建 SQLite 引擎前未确保角色专属目录（如 `memory/水水/`）存在的问题，新增 `os.makedirs` 调用
- 修复 Windows 下 `os.path.join` 产生的反斜杠路径直接拼入 `sqlite:///` URI 导致 SQLAlchemy 无法打开数据库文件的问题，统一将路径中的 `\` 替换为 `/`
- 同步修正 `store_conversation` 中的 `connection_string` 构造逻辑

## 复现场景

在 Windows 环境下，角色名为"水水"时初始化数据库引擎报错：
```
sqlite3.OperationalError: unable to open database file
```

根本原因：
1. `config_manager.get_character_data()` 返回的 `time_store` 路径直接传入 `create_engine()`，跳过了 `ensure_character_dir()` 的目录创建逻辑
2. Windows 路径 `C:\...\memory\水水\time_indexed.db` 拼成 `sqlite:///C:\...` 后是无效 URI

## Test plan

- [ ] Windows 环境下新建一个角色（含中文名），验证数据库文件和目录正常创建
- [ ] 验证已有角色的数据库读写不受影响
- [ ] Linux/macOS 下回归测试，确认正斜杠路径无副作用

https://claude.ai/code/session_01PdBuo8r81gEPdMQdAM8oQt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Windows 环境下数据库路径处理问题：将数据库路径规范为绝对路径并统一分隔符，使用正确的 SQLite URI 格式，避免因路径格式导致的连接失败。
  * 自动创建缺失的数据库目录，确保首次写入时能顺利建立数据库连接；构建连接字符串时对已存路径进行分隔符规范化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->