### PR TITLE
feat: v0.7.4 — i18n 国际化 + 多窗口增强 + 模型/音乐/UI 修复

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -489,7 +489,7 @@ textarea {
 
 .message-block-image {
   margin: 0;
-  width: min(280px, 100%);
+  max-width: 280px;
   overflow: hidden;
   border-radius: 12px;
   background: rgba(220, 228, 240, 0.85);

--- a/launcher.py
+++ b/launcher.py
@@ -15,8 +15,11 @@ if sys.platform == 'win32':
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
     
+# 检测打包环境（PyInstaller 设 sys.frozen，Nuitka 设 __compiled__）
+IS_FROZEN = getattr(sys, 'frozen', False) or '__compiled__' in globals()
+
 # 处理 PyInstaller 和 Nuitka 打包后的路径
-if getattr(sys, 'frozen', False):
+if IS_FROZEN:
     # 运行在打包后的环境
     if hasattr(sys, '_MEIPASS'):
         # PyInstaller
@@ -214,7 +217,7 @@ def report_startup_failure(message: str, show_dialog: bool = True):
     """统一报告启动失败信息：终端 + （可选）弹窗。"""
     print(message, flush=True)
     emit_frontend_event("startup_failure", {"message": message})
-    if show_dialog and getattr(sys, 'frozen', False):
+    if show_dialog and IS_FROZEN:
         _show_error_dialog(message)
 
 
@@ -373,7 +376,7 @@ def run_merged_servers() -> int:
     _reload_runtime_config_from_env()
 
     # frozen 环境通用设置
-    if getattr(sys, 'frozen', False):
+    if IS_FROZEN:
         if hasattr(sys, '_MEIPASS'):
             os.chdir(sys._MEIPASS)
         else:
@@ -496,7 +499,7 @@ def run_memory_server(
     try:
         _reload_runtime_config_from_env()
         # 确保工作目录正确
-        if getattr(sys, 'frozen', False):
+        if IS_FROZEN:
             if hasattr(sys, '_MEIPASS'):
                 # PyInstaller
                 os.chdir(sys._MEIPASS)
@@ -581,7 +584,7 @@ def run_agent_server(
     try:
         _reload_runtime_config_from_env()
         # 确保工作目录正确
-        if getattr(sys, 'frozen', False):
+        if IS_FROZEN:
             if hasattr(sys, '_MEIPASS'):
                 # PyInstaller
                 os.chdir(sys._MEIPASS)
@@ -643,7 +646,7 @@ def run_main_server(
     try:
         _reload_runtime_config_from_env()
         # 确保工作目录正确
-        if getattr(sys, 'frozen', False):
+        if IS_FROZEN:
             if hasattr(sys, '_MEIPASS'):
                 # PyInstaller
                 os.chdir(sys._MEIPASS)
@@ -1239,7 +1242,7 @@ def _ensure_playwright_browsers():
         return
 
     try:
-        if getattr(sys, "frozen", False):
+        if IS_FROZEN:
             if hasattr(sys, "_MEIPASS"):
                 _bundle = sys._MEIPASS
             else:
@@ -1326,7 +1329,7 @@ def main():
         elif _merged_env in ("0", "false", "no"):
             _use_merged = False
         else:
-            _use_merged = getattr(sys, 'frozen', False)
+            _use_merged = IS_FROZEN
 
         if _use_merged:
             print("\n[Launcher] 合并进程模式\n", flush=True)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1466,7 +1466,7 @@ async def emotion_analysis(request: Request):
                 if confidence < 0.2:
                     emotion = "neutral"
                     decision_source = "neutral_fallback"
-        except json.JSONDecodeError:
+        except ValueError:
             emotion, confidence = _apply_degraded_emotion_fallback()
 
         _push_emotion_update(lanlan_name, emotion, confidence)

--- a/static/achievement_manager.js
+++ b/static/achievement_manager.js
@@ -199,7 +199,7 @@
         showAchievementNotification(achievement) {
             // 如果有 showStatusToast 函数，使用它
             if (typeof window.showStatusToast === 'function') {
-                window.showStatusToast(`🏆 成就解锁: ${achievement.description}`, 3000);
+                window.showStatusToast(window.t ? window.t('achievement.unlocked', { description: achievement.description }) : `🏆 成就解锁: ${achievement.description}`, 3000);
             }
 
             // 触发自定义事件，允许其他模块监听

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -1202,7 +1202,7 @@
 
         } catch (error) {
             console.error('[猫娘切换] 失败:', error);
-            showStatusToast(`切换失败: ${error.message}`, 4000);
+            showStatusToast(window.t ? window.t('app.switchCatgirlError', { error: error.message }) : `切换失败: ${error.message}`, 4000);
         } finally {
             S.isSwitchingCatgirl = false;
             // 清理切换标识，取消所有 pending 的 applyLighting 定时器

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -898,7 +898,7 @@
                 if (backendResult.status === 403 && !S.screenRecordingPermissionHintShown) {
                     S.screenRecordingPermissionHintShown = true;
                     if (typeof window.showStatusToast === 'function') {
-                        window.showStatusToast('\u26A0\uFE0F 屏幕录制权限未授权，请在系统设置中允许屏幕录制', 6000);
+                        window.showStatusToast(window.t ? window.t('app.screenRecordingPermissionDenied') : '\u26A0\uFE0F 屏幕录制权限未授权，请在系统设置中允许屏幕录制', 6000);
                     }
                     console.warn('[ProactiveVision] 后端截图返回 403，请在"系统设置 → 隐私与安全性 → 屏幕录制"中授权 N.E.K.O');
                 }

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -452,6 +452,9 @@
         window.updateLive2DDynamicTexts = function () {
             console.warn('[i18n] Fallback updateLive2DDynamicTexts() called - no-op');
         };
+
+        // 通知所有 localechange 监听者（与正常初始化路径一致）
+        window.dispatchEvent(new CustomEvent('localechange'));
     }
 
     /**

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -366,7 +366,7 @@
                     setGlobalBusy(false);
                     fetchSnapshot().catch(() => { });
                     if (typeof window.showStatusToast === 'function') {
-                        window.showStatusToast(`Agent切换失败: ${e.message}`, 2500);
+                        window.showStatusToast(window.t ? window.t('agent.status.toggleFailed', { error: e.message }) : `Agent切换失败: ${e.message}`, 2500);
                     }
                 }
                 return;
@@ -406,7 +406,7 @@
                         setGlobalBusy(false);
                         fetchSnapshot().catch(() => { });
                         if (typeof window.showStatusToast === 'function') {
-                            window.showStatusToast(`${getName(key)}切换失败: ${err.message}`, 2500);
+                            window.showStatusToast(window.t ? window.t('settings.toggles.toggleFailed', { name: getName(key), error: err.message }) : `${getName(key)}切换失败: ${err.message}`, 2500);
                         }
                         return;
                     } finally {
@@ -457,7 +457,7 @@
                     setGlobalBusy(false);
                     fetchSnapshot().catch(() => {});
                     if (typeof window.showStatusToast === 'function') {
-                        window.showStatusToast(`${openclawName}\u5207\u6362\u5931\u8d25: ${err.message}`, 2500);
+                        window.showStatusToast(window.t ? window.t('settings.toggles.toggleFailed', { name: openclawName, error: err.message }) : `${openclawName}切换失败: ${err.message}`, 2500);
                     }
                     return;
                 } finally {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1514,6 +1514,7 @@
         "switchingCatgirl": "Switching to {{name}}...",
         "switchedCatgirl": "Switched to {{name}}",
         "switchCatgirlFailed": "Failed to switch to {{name}}",
+        "switchCatgirlError": "Switch failed: {{error}}",
         "started": "{{name}} started",
         "voiceUpdated": "{{name}}'s voice updated",
         "audioWorkletFailed": "AudioWorklet failed to load",
@@ -1536,6 +1537,7 @@
         "connectingToServer": "Connecting to server...",
         "readyToSpeak": "Ready to speak!",
         "screenShareRequiresVoice": "Screen share is only for audio/video calls",
+        "screenRecordingPermissionDenied": "⚠️ Screen recording permission denied. Please allow screen recording in System Settings",
         "repetitionDetected": "High repetition detected. Suggest ending conversation to let {{name}} rest.",
         "modelSwitched": "Model switched",
         "screenSource": {
@@ -1621,6 +1623,7 @@
             "browserUse": "Browser Control",
             "focusMode": "Allow Interrupt",
             "unavailable": "{{name}} Unavailable",
+            "toggleFailed": "{{name}} toggle failed: {{error}}",
             "checking": "Checking...",
             "serverOffline": "NekoClaw Server Offline",
             "masterRequired": "Please enable NekoClaw Master Switch first",
@@ -1675,7 +1678,8 @@
             "freeModelWarning": "Due to quota limitations, free models are prone to blocking in NekoClaw mode. It is recommended to switch to a paid model.\n\nIf you have already configured a paid API, please try restarting NEKO.",
             "freeModelWarningTitle": "Free Model Notice",
             "connectivityCheck": "NekoClaw LLM connectivity check in progress...",
-            "precheckFailed": "NekoClaw precheck failed: {{reason}}"
+            "precheckFailed": "NekoClaw precheck failed: {{reason}}",
+            "toggleFailed": "Agent toggle failed: {{error}}"
         },
         "precheck": {
             "AGENT_PRECHECK_PENDING": "Connectivity check in progress...",
@@ -2842,5 +2846,8 @@
             "title": "Meme",
             "loadError": "Failed to load meme"
         }
+    },
+    "achievement": {
+        "unlocked": "🏆 Achievement unlocked: {{description}}"
     }
 }

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1514,6 +1514,7 @@
         "switchingCatgirl": "{{name}}に切り替え中...",
         "switchedCatgirl": "{{name}}に切り替えました",
         "switchCatgirlFailed": "{{name}}への切り替えに失敗しました",
+        "switchCatgirlError": "切り替えに失敗しました: {{error}}",
         "started": "{{name}}が起動しました",
         "voiceUpdated": "{{name}}の声が更新されました",
         "audioWorkletFailed": "AudioWorkletの読み込みに失敗しました",
@@ -1536,6 +1537,7 @@
         "connectingToServer": "サーバーに接続中...",
         "readyToSpeak": "話す準備ができました！",
         "screenShareRequiresVoice": "画面共有は音声/ビデオ通話専用です",
+        "screenRecordingPermissionDenied": "⚠️ 画面録画の権限が許可されていません。システム設定で画面録画を許可してください",
         "repetitionDetected": "高い繰り返しが検出されました。{{name}}を休ませるために会話を終了することをお勧めします。",
         "modelSwitched": "モデルを切り替えました",
         "screenSource": {
@@ -1621,6 +1623,7 @@
             "browserUse": "ブラウザ制御",
             "focusMode": "割り込み許可",
             "unavailable": "{{name}}は利用できません",
+            "toggleFailed": "{{name}}の切り替えに失敗しました: {{error}}",
             "checking": "確認中...",
             "serverOffline": "ネコクローサーバーがオフラインです",
             "masterRequired": "先にネコクローマスタースイッチを有効にしてください",
@@ -1675,7 +1678,8 @@
             "freeModelWarning": "クォータの制限により、無料モデルではネコクローモードがブロックされやすくなります。有料モデルへの切り替えをお勧めします。\n\nすでに有料APIを設定済みの場合は、NEKOを再起動してみてください。",
             "freeModelWarningTitle": "無料モデルのお知らせ",
             "connectivityCheck": "ネコクロー LLM 接続チェック中...",
-            "precheckFailed": "ネコクローのプリチェックに失敗しました：{{reason}}"
+            "precheckFailed": "ネコクローのプリチェックに失敗しました：{{reason}}",
+            "toggleFailed": "Agentの切り替えに失敗しました: {{error}}"
         },
         "precheck": {
             "AGENT_PRECHECK_PENDING": "接続チェック中...",
@@ -2842,5 +2846,8 @@
             "title": "ミーム",
             "loadError": "ミームの読み込みに失敗しました"
         }
+    },
+    "achievement": {
+        "unlocked": "🏆 実績解除: {{description}}"
     }
 }

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1514,6 +1514,7 @@
         "switchingCatgirl": "{{name}}(으)로 전환 중...",
         "switchedCatgirl": "{{name}}로 전환됨",
         "switchCatgirlFailed": "{{name}}로 전환하지 못했습니다.",
+        "switchCatgirlError": "전환 실패: {{error}}",
         "started": "{{name}} 시작됨",
         "voiceUpdated": "{{name}}의 음성이 업데이트되었습니다.",
         "audioWorkletFailed": "AudioWorklet을 로드하지 못했습니다.",
@@ -1536,6 +1537,7 @@
         "connectingToServer": "서버에 연결하는 중...",
         "readyToSpeak": "말할 준비가 되었습니다!",
         "screenShareRequiresVoice": "화면 공유는 음성/영상 통화에만 사용됩니다.",
+        "screenRecordingPermissionDenied": "⚠️ 화면 녹화 권한이 승인되지 않았습니다. 시스템 설정에서 화면 녹화를 허용해 주세요",
         "repetitionDetected": "높은 반복이 감지되었습니다. {{name}}이(가) 쉴 수 있도록 대화 종료를 제안하세요.",
         "modelSwitched": "모델 전환",
         "screenSource": {
@@ -1621,6 +1623,7 @@
             "browserUse": "브라우저 제어",
             "focusMode": "인터럽트 허용",
             "unavailable": "{{name}} 사용할 수 없음",
+            "toggleFailed": "{{name}} 전환 실패: {{error}}",
             "checking": "확인 중...",
             "serverOffline": "네코클로 서버 오프라인",
             "masterRequired": "먼저 네코클로 마스터 스위치를 활성화하십시오.",
@@ -1675,7 +1678,8 @@
             "freeModelWarning": "할당량 제한으로 인해 무료 모델은 네코클로 모드에서 차단되기 쉽습니다. 유료 모델로 전환하는 것을 권장합니다.\n\n이미 유료 API를 설정한 경우 NEKO를 재시작해 보세요.",
             "freeModelWarningTitle": "무료 모델 안내",
             "connectivityCheck": "네코클로 LLM 연결 확인 중...",
-            "precheckFailed": "네코클로 사전 검사 실패: {{reason}}"
+            "precheckFailed": "네코클로 사전 검사 실패: {{reason}}",
+            "toggleFailed": "Agent 전환 실패: {{error}}"
         },
         "precheck": {
             "AGENT_PRECHECK_PENDING": "연결 확인 중...",
@@ -2842,5 +2846,8 @@
             "title": "밈",
             "loadError": "밈을 불러오지 못했습니다"
         }
+    },
+    "achievement": {
+        "unlocked": "🏆 업적 달성: {{description}}"
     }
 }

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1514,6 +1514,7 @@
         "switchingCatgirl": "Переключение на {{name}}...",
         "switchedCatgirl": "Переключено на {{name}}",
         "switchCatgirlFailed": "Не удалось переключиться на {{name}}",
+        "switchCatgirlError": "Ошибка переключения: {{error}}",
         "started": "{{name}} запущена",
         "voiceUpdated": "Голос {{name}} обновлён",
         "audioWorkletFailed": "AudioWorklet не загрузился",
@@ -1536,6 +1537,7 @@
         "connectingToServer": "Подключение к серверу...",
         "readyToSpeak": "Готово к разговору!",
         "screenShareRequiresVoice": "Демонстрация экрана только для аудио/видео звонков",
+        "screenRecordingPermissionDenied": "⚠️ Разрешение на запись экрана не предоставлено. Разрешите запись экрана в системных настройках",
         "repetitionDetected": "Обнаружено повторение. Рекомендуем завершить разговор, чтобы {{name}} отдохнула.",
         "modelSwitched": "Модель переключена",
         "screenSource": {
@@ -1621,6 +1623,7 @@
             "browserUse": "Управление браузером",
             "focusMode": "Разрешить прерывание",
             "unavailable": "{{name}} Недоступен",
+            "toggleFailed": "Ошибка переключения {{name}}: {{error}}",
             "checking": "Проверка...",
             "serverOffline": "Сервер Лапки Неко оффлайн",
             "masterRequired": "Сначала включите главный переключатель Лапки Неко",
@@ -1675,7 +1678,8 @@
             "freeModelWarning": "Из-за ограничений квоты использование бесплатной модели в режиме Лапки Неко может вызвать блокировку. Рекомендуется перейти на платную модель.\n\nЕсли вы уже настроили платный API, попробуйте перезапустить NEKO.",
             "freeModelWarningTitle": "Уведомление о бесплатной модели",
             "connectivityCheck": "Проверка подключения LLM Лапки Неко...",
-            "precheckFailed": "Предварительная проверка Лапки Неко не удалась: {{reason}}"
+            "precheckFailed": "Предварительная проверка Лапки Неко не удалась: {{reason}}",
+            "toggleFailed": "Ошибка переключения Agent: {{error}}"
         },
         "precheck": {
             "AGENT_PRECHECK_PENDING": "Проверка подключения...",
@@ -2842,5 +2846,8 @@
             "title": "Мем",
             "loadError": "Не удалось загрузить мем"
         }
+    },
+    "achievement": {
+        "unlocked": "🏆 Достижение разблокировано: {{description}}"
     }
 }

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1514,6 +1514,7 @@
         "switchingCatgirl": "正在切换到 {{name}}...",
         "switchedCatgirl": "已切换到 {{name}}",
         "switchCatgirlFailed": "切换到 {{name}} 失败",
+        "switchCatgirlError": "切换失败: {{error}}",
         "started": "{{name}} 已启动",
         "voiceUpdated": "{{name}} 的语音已更新",
         "audioWorkletFailed": "AudioWorklet加载失败",
@@ -1536,6 +1537,7 @@
         "connectingToServer": "正在连接服务器...",
         "readyToSpeak": "可以说话了！",
         "screenShareRequiresVoice": "屏幕分享仅用于音视频通话",
+        "screenRecordingPermissionDenied": "⚠️ 屏幕录制权限未授权，请在系统设置中允许屏幕录制",
         "repetitionDetected": "检测到高重复度对话。建议您终止对话，让{{name}}休息片刻。",
         "modelSwitched": "模型已切换",
         "screenSource": {
@@ -1621,6 +1623,7 @@
             "browserUse": "浏览器控制",
             "focusMode": "允许打断",
             "unavailable": "{{name}}不可用",
+            "toggleFailed": "{{name}}切换失败: {{error}}",
             "checking": "查询中...",
             "serverOffline": "猫爪服务器未启动",
             "masterRequired": "请先开启猫爪总开关",
@@ -1675,7 +1678,8 @@
             "freeModelWarning": "由于限额问题，免费模型使用猫爪模式容易阻塞，建议您切换至自费模型。\n\n如果您已经配置好自费API，请尝试重启NEKO。",
             "freeModelWarningTitle": "免费模型提示",
             "connectivityCheck": "猫爪 LLM 连接检查中...",
-            "precheckFailed": "猫爪预检失败：{{reason}}"
+            "precheckFailed": "猫爪预检失败：{{reason}}",
+            "toggleFailed": "Agent切换失败: {{error}}"
         },
         "precheck": {
             "AGENT_PRECHECK_PENDING": "连接检查中...",
@@ -2842,5 +2846,8 @@
             "title": "表情包",
             "loadError": "表情包加载失败"
         }
+    },
+    "achievement": {
+        "unlocked": "🏆 成就解锁: {{description}}"
     }
 }

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1514,6 +1514,7 @@
         "switchingCatgirl": "正在切換到 {{name}}...",
         "switchedCatgirl": "已切換到 {{name}}",
         "switchCatgirlFailed": "切換到 {{name}} 失敗",
+        "switchCatgirlError": "切換失敗: {{error}}",
         "started": "{{name}} 已啓動",
         "voiceUpdated": "{{name}} 的語音已更新",
         "audioWorkletFailed": "AudioWorklet加載失敗",
@@ -1536,6 +1537,7 @@
         "connectingToServer": "正在連接服務器...",
         "readyToSpeak": "可以說話瞭！",
         "screenShareRequiresVoice": "屏幕分享僅用於音視頻通話",
+        "screenRecordingPermissionDenied": "⚠️ 螢幕錄製權限未授權，請在系統設定中允許螢幕錄製",
         "repetitionDetected": "檢測到高重復度對話。建議您終止對話，讓{{name}}休息片刻。",
         "modelSwitched": "模型已切換",
         "screenSource": {
@@ -1621,6 +1623,7 @@
             "browserUse": "瀏覽器控制",
             "focusMode": "允許打斷",
             "unavailable": "{{name}}不可用",
+            "toggleFailed": "{{name}}切換失敗: {{error}}",
             "checking": "查詢中...",
             "serverOffline": "貓爪服務器未啓動",
             "masterRequired": "請先開啓貓爪總開關",
@@ -1675,7 +1678,8 @@
             "freeModelWarning": "由於限額問題，免費模型使用貓爪模式容易阻塞，建議您切換至自費模型。\n\n如果您已經配置好自費API，請嘗試重啟NEKO。",
             "freeModelWarningTitle": "免費模型提示",
             "connectivityCheck": "貓爪 LLM 連接檢查中...",
-            "precheckFailed": "貓爪預檢失敗：{{reason}}"
+            "precheckFailed": "貓爪預檢失敗：{{reason}}",
+            "toggleFailed": "Agent切換失敗: {{error}}"
         },
         "precheck": {
             "AGENT_PRECHECK_PENDING": "連接檢查中...",
@@ -2842,5 +2846,8 @@
             "title": "表情包",
             "loadError": "表情包加載失敗"
         }
+    },
+    "achievement": {
+        "unlocked": "🏆 成就解鎖: {{description}}"
     }
 }

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -6,6 +6,8 @@
     <title>N.E.K.O. Toast</title>
     <link rel="stylesheet" href="/static/css/index.css">
     <link rel="stylesheet" href="/static/css/dark-mode.css">
+    <!-- i18next 加载器（复用 index.html 的 i18n 基础设施） -->
+    <script src="/static/i18n-i18next.js"></script>
     <style>
         html, body {
             margin: 0; padding: 0;
@@ -27,6 +29,34 @@
     <script>
     (function() {
         'use strict';
+
+        // ===== i18n 就绪等待机制 =====
+        // i18n-i18next.js 异步初始化，IPC 消息可能在 window.t 就绪前到达。
+        // localechange 在 exportNormalFunctions/exportFallbackFunctions 中 dispatch，
+        // 但由于 localechange 在 window.t 赋值之前同步触发，需要 setTimeout(0)
+        // 推迟到当前调用栈结束后再 flush，确保 window.t 已被设置。
+        var _i18nReady = (typeof window.t === 'function');
+        var _i18nQueue = [];
+
+        function _flushI18nQueue() {
+            if (_i18nReady) return;
+            _i18nReady = true;
+            var q = _i18nQueue;
+            _i18nQueue = [];
+            for (var i = 0; i < q.length; i++) q[i]();
+        }
+
+        if (!_i18nReady) {
+            window.addEventListener('localechange', function onLocale() {
+                window.removeEventListener('localechange', onLocale);
+                setTimeout(_flushI18nQueue, 0);
+            });
+        }
+
+        function whenI18nReady(fn) {
+            if (_i18nReady) fn();
+            else _i18nQueue.push(fn);
+        }
 
         // ===== Toast API（由 preload-toast.js 注入）=====
         var api = window.nekoToastAPI;
@@ -164,7 +194,7 @@
             img.alt = 'ready';
             var span = document.createElement('span');
             span.style.cssText = 'display:flex;align-items:center;';
-            span.textContent = message || 'You can start talking!';
+            span.textContent = message || window.t('app.readyToSpeak');
             toast.appendChild(img);
             toast.appendChild(span);
 
@@ -257,7 +287,7 @@
 
             var hasMore = pnQueue.length > 0;
             var btn = document.createElement('button');
-            btn.textContent = hasMore ? '下一个' : '确认';
+            btn.textContent = hasMore ? window.t('common.next') : window.t('common.confirm');
             btn.style.cssText = [
                 'background:#3b82f6', 'color:#fff', 'border:none',
                 'border-radius:10px', 'padding:10px 48px',
@@ -295,6 +325,7 @@
 
         // ===== IPC 监听（Electron 环境下由 preload-toast.js 注入 API）=====
         if (api) {
+            // status toast / voice preparing：文本由调用方传入，不依赖 i18n
             api.onShowStatusToast(function(data) {
                 showStatusToast(data.message, data.duration);
             });
@@ -304,11 +335,12 @@
             api.onHideVoicePreparing(function() {
                 hideVoicePreparing();
             });
+            // ready-to-speak / prominent notice：需要 window.t()，等待 i18n 就绪
             api.onShowReadyToSpeak(function(data) {
-                showReadyToSpeak(data.message);
+                whenI18nReady(function() { showReadyToSpeak(data.message); });
             });
             api.onShowProminentNotice(function(data) {
-                showProminentNotice(data);
+                whenI18nReady(function() { showProminentNotice(data); });
             });
         }
 


### PR DESCRIPTION
## Summary

v0.7.4 版本合并，包含 42 个提交、112 个文件变更，涵盖国际化、多窗口体系、模型管理、音乐系统和大量 bug 修复。

### ✨ 新功能
- **i18n 国际化**：硬编码文本全面 i18n 化，toast 窗口 i18n 支持，视觉描述 prompt 国际化（6 语言）
- **Jukebox 独立窗口**：点歌台支持独立窗口运行 + React Chat 点歌台按钮
- **Subtitle 独立窗口重构**：自动缩放 + 拖拽交互
- **React Chat 增强**：最小化悬浮球 + 呼吸灯动画、翻译开关按钮、液态玻璃背景效果
- **多窗口头像预览**：多窗口模式下的头像预览功能
- **待机动画轮换**：默认待机动画改为动画组轮换，循环结束时切换避免中途跳变
- **窗口拖拽**：添加窗口拖拽功能并调整样式层级
- **Nuitka 打包兼容**：冻结环境检测兼容 Nuitka 打包

### 🐛 Bug 修复
- Windows 下角色数据库初始化失败（目录缺失 + 反斜杠 URI）
- 独立聊天窗口角色切换误触发 Live2D 模型热切换
- 模型管理页初始化时序问题（VRM 光照控件 / 待机轮换状态）
- VRM 模型发送消息后消失 + Task HUD 轮询冗余
- Live3D 光照设置在模型切换后重置为错误默认值
- MMD 模型路径无效时回退到默认模型
- LLM JSON 响应容错解析（unquoted key / 尾逗号 / Python 字面值）
- LLM/TTS 重试错误上报策略统一
- 自定义 API 设置中普通 TTS 被误判为 GPT-SoVITS
- /chat 独立窗口头像无法加载
- Live2D ↔ VRM/MMD 来回切换后待机动作丢失
- chat 独立窗口不再弹 toast + 禁止路由保留名用作角色名

### ♻️ 重构
- MiniMax TTS WebSocket 连接生命周期重构 + 空闲超时修复
- Music API 路由统一、域名池和代码结构整合
- 设置弹窗 UI 局部优化（avatar-ui-popup / live2d-ui-drag / avatar-ui-drag）

### 🧪 测试
- 新增 API 设置前端测试、角色路由模型设置单元测试、MiniMax TTS Worker 单元测试

## Test plan
- [ ] 验证多语言切换下 toast / 硬编码文本正确显示
- [ ] 测试 Jukebox / Subtitle 独立窗口打开、拖拽、关闭
- [ ] 测试 React Chat 最小化悬浮球、翻译按钮、液态玻璃效果
- [ ] 在 Windows 环境验证角色数据库初始化
- [ ] 测试 Live2D / VRM / MMD 模型切换后待机动作恢复
- [ ] 验证 Nuitka 打包后的运行兼容性

https://claude.ai/code/session_01Ru31mNDignCfHqr6ZaJZqq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 新增多语言本地化支持，错误消息和系统通知现可按用户语言偏好显示
  * 成就解锁通知现支持多语言本地化消息
  * 增强了国际化系统的语言切换识别机制

* **错误修复**
  * 修复了消息块中图像的尺寸显示行为
  * 改进了系统各项操作的错误提示和信息反馈

<!-- end of auto-generated comment: release notes by coderabbit.ai -->