### PR TITLE
feat: 添加独立的 Jukebox 管理器页面和窗口支持

### DIFF
--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -157,7 +157,7 @@ async def get_jukebox_page(request: Request):
 
 @router.get("/jukebox/manager", response_class=HTMLResponse)
 async def get_jukebox_manager_page(request: Request):
-    """Jukebox 管理器独立窗口页面（从点歌台打开）"""
+    """Jukebox 管理器独立窗口页面 (从点歌台打开)"""
     templates = get_templates()
     return templates.TemplateResponse("templates/jukebox_manager.html", {"request": request})
 

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -155,6 +155,13 @@ async def get_jukebox_page(request: Request):
     return templates.TemplateResponse("templates/jukebox.html", {"request": request})
 
 
+@router.get("/jukebox/manager", response_class=HTMLResponse)
+async def get_jukebox_manager_page(request: Request):
+    """Jukebox 管理器独立窗口页面（从点歌台打开）"""
+    templates = get_templates()
+    return templates.TemplateResponse("templates/jukebox_manager.html", {"request": request})
+
+
 @router.get("/toast", response_class=HTMLResponse)
 async def get_toast_page(request: Request):
     """Toast 通知独立窗口页面（Electron 加载）"""

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3332,13 +3332,15 @@ window.Jukebox = {
 
     // 监听管理器独立窗口的刷新通知（BroadcastChannel 跨窗口通信）
     try {
-      var bc = new BroadcastChannel('neko-jukebox');
-      bc.onmessage = function(e) {
-        if (e.data && e.data.type === 'reload' && Jukebox.State.isOpen) {
-          console.log('[Jukebox] 收到管理器刷新通知，重新加载歌曲');
-          Jukebox.loadSongs();
-        }
-      };
+      if (!Jukebox._broadcastChannel) {
+        Jukebox._broadcastChannel = new BroadcastChannel('neko-jukebox');
+        Jukebox._broadcastChannel.onmessage = function(e) {
+          if (e.data && e.data.type === 'reload' && Jukebox.State.isOpen) {
+            console.log('[Jukebox] 收到管理器刷新通知，重新加载歌曲');
+            Jukebox.loadSongs();
+          }
+        };
+      }
     } catch (e) {}
 
     const jukeboxButton = document.getElementById('jukeboxButton');
@@ -3412,6 +3414,15 @@ window.Jukebox = {
     
     Jukebox.State.isOpen = false;
     Jukebox.State.isHidden = false;
+    
+    // 清理 BroadcastChannel
+    try {
+      if (Jukebox._broadcastChannel) {
+        Jukebox._broadcastChannel.onmessage = null;
+        Jukebox._broadcastChannel.close();
+        Jukebox._broadcastChannel = null;
+      }
+    } catch (e) {}
     
     // 清空歌曲列表和元素映射，确保下次打开时重新渲染
     Jukebox.State.songs = [];

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -453,6 +453,20 @@ window.Jukebox = {
     isVisible: false,
 
     toggle: function() {
+      if (window.__NEKO_JUKEBOX_STANDALONE__) {
+        // 独立模式：打开/关闭管理器独立窗口
+        if (this._managerWindow && !this._managerWindow.closed) {
+          this._managerWindow.close();
+          this._managerWindow = null;
+        } else {
+          this._managerWindow = window.open(
+            '/jukebox/manager', 'neko-jukebox-manager',
+            'width=480,height=600'
+          );
+        }
+        return;
+      }
+      // Web 模式：切换 DOM 面板
       if (this.isVisible) {
         this.hide();
       } else {
@@ -464,11 +478,9 @@ window.Jukebox = {
       if (this.element) {
         this.element.style.display = 'flex';
         this.isVisible = true;
-        // 如果尚未被拖拽过，定位到点歌台左侧
         if (!this.element.style.left) {
           this.positionNextToJukebox();
         }
-        // 刷新数据
         this.load();
       }
     },
@@ -3317,12 +3329,23 @@ window.Jukebox = {
     });
     
     Jukebox.State.isOpen = true;
-    
+
+    // 监听管理器独立窗口的刷新通知（BroadcastChannel 跨窗口通信）
+    try {
+      var bc = new BroadcastChannel('neko-jukebox');
+      bc.onmessage = function(e) {
+        if (e.data && e.data.type === 'reload' && Jukebox.State.isOpen) {
+          console.log('[Jukebox] 收到管理器刷新通知，重新加载歌曲');
+          Jukebox.loadSongs();
+        }
+      };
+    } catch (e) {}
+
     const jukeboxButton = document.getElementById('jukeboxButton');
     if (jukeboxButton) {
       jukeboxButton.classList.add('active');
     }
-    
+
     console.log('[Jukebox] 点歌台已打开');
   },
   
@@ -3529,10 +3552,12 @@ window.Jukebox = {
     document.body.appendChild(sidePanel);
     Jukebox.State.container = wrapper;
     
-    // 绑定窗口拖拽事件
-    Jukebox.bindWindowDrag(wrapper, jukeboxContainer);
-    // 绑定管理器面板拖拽事件
-    Jukebox.bindPanelDrag(sidePanel);
+    // 独立窗口模式由 preload 注入 -webkit-app-region: drag 处理拖拽，
+    // JS 拖拽会因 preventDefault 与原生拖拽冲突，且 inset:0!important 阻止 wrapper 移动
+    if (!window.__NEKO_JUKEBOX_STANDALONE__) {
+      Jukebox.bindWindowDrag(wrapper, jukeboxContainer);
+      Jukebox.bindPanelDrag(sidePanel);
+    }
     
     Jukebox.injectStyles();
   },

--- a/templates/jukebox.html
+++ b/templates/jukebox.html
@@ -22,6 +22,8 @@
             overflow: hidden;
             background: #87CEEB;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            user-select: none;
+            -webkit-user-select: none;
         }
 
         /* Electron 独立窗口：Jukebox 覆盖全窗口 */
@@ -38,15 +40,6 @@
             height: 100% !important;
             border-radius: 0 !important;
             box-sizing: border-box !important;
-        }
-        /* 独立窗口不需要 SongActionManager 侧面板浮动 */
-        .sam-panel {
-            position: fixed !important;
-            right: 0 !important;
-            top: 0 !important;
-            height: 100% !important;
-            border-radius: 0 !important;
-            z-index: 100 !important;
         }
     </style>
 </head>

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -106,7 +106,7 @@
             if (typeof window.t === 'function' && window.i18n && window.i18n.isInitialized === true) {
                 _mgrInitDone = true;
                 clearInterval(_mgrPoll);
-                _initManager();
+                _initManager().catch(function(e) { console.error('[JukeboxManager] init failed:', e); });
             }
         }
         var _mgrPoll = setInterval(function() { _tryInitManager(); }, 100);
@@ -117,7 +117,7 @@
                 if (typeof window.t !== 'function') {
                     window.t = function(key, fallback) { return typeof fallback === 'string' ? fallback : key; };
                 }
-                _initManager();
+                _initManager().catch(function(e) { console.error('[JukeboxManager] init failed:', e); });
             }
         }, 3000);
     </script>

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -115,7 +115,7 @@
             if (!_mgrInitDone) {
                 _mgrInitDone = true;
                 if (typeof window.t !== 'function') {
-                    window.t = function(key, fallback) { return fallback || key; };
+                    window.t = function(key, fallback) { return typeof fallback === 'string' ? fallback : key; };
                 }
                 _initManager();
             }

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8">
+    <title>N.E.K.O. Jukebox Manager</title>
+
+    <!-- i18n -->
+    <script src="/static/i18n-i18next.js"></script>
+    <!-- 暗色模式 -->
+    <link rel="stylesheet" href="/static/css/dark-mode.css">
+    <script src="/static/theme-manager.js"></script>
+
+    <style>
+        html, body {
+            margin: 0; padding: 0;
+            width: 100%; height: 100%;
+            overflow: hidden;
+            background: rgba(0, 0, 0, 0.85);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            user-select: none;
+            -webkit-user-select: none;
+        }
+
+        /* 管理器面板覆盖全窗口 */
+        .jukebox-sam-panel {
+            position: fixed !important;
+            inset: 0 !important;
+            width: 100% !important;
+            height: 100% !important;
+            max-height: 100% !important;
+            border-radius: 0 !important;
+            box-sizing: border-box !important;
+        }
+
+        /* 整个面板可拖拽，内容区域和交互按钮排除 */
+        .jukebox-sam-panel {
+            -webkit-app-region: drag;
+        }
+        .sam-content,
+        .sam-footer,
+        .sam-close-btn,
+        .sam-tab {
+            -webkit-app-region: no-drag;
+        }
+    </style>
+</head>
+<body>
+    <script>
+        // 标记为管理器独立窗口模式
+        window.__NEKO_JUKEBOX_MANAGER_STANDALONE__ = true;
+    </script>
+    <!-- Jukebox.js 包含 SongActionManager 定义 -->
+    <script src="/static/Jukebox.js"></script>
+    <script>
+        // 管理器独立窗口初始化
+        async function _initManager() {
+            if (!window.Jukebox || !window.Jukebox.SongActionManager) return;
+
+            var SAM = Jukebox.SongActionManager;
+
+            // 创建管理器面板 DOM
+            var panel = SAM.create();
+            document.body.appendChild(panel);
+
+            // 注入管理器样式
+            var style = document.createElement('style');
+            style.textContent = SAM.getStyles();
+            document.head.appendChild(style);
+
+            // 覆盖 hide：关闭窗口而非隐藏 DOM
+            SAM.hide = function() {
+                window.close();
+            };
+
+            // 覆盖 Jukebox.loadSongs：通过 BroadcastChannel 通知点歌台窗口刷新
+            Jukebox.loadSongs = function() {
+                try {
+                    new BroadcastChannel('neko-jukebox').postMessage({ type: 'reload' });
+                } catch (e) {}
+            };
+
+            // 显示并加载数据
+            SAM.element.style.display = 'flex';
+            SAM.isVisible = true;
+            SAM.load();
+        }
+
+        // 等待 i18n 就绪
+        var _mgrInitDone = false;
+        function _tryInitManager() {
+            if (_mgrInitDone) return;
+            if (typeof window.t === 'function' && window.i18n && window.i18n.isInitialized !== false) {
+                _mgrInitDone = true;
+                _initManager();
+            }
+        }
+        var _mgrPoll = setInterval(function() { _tryInitManager(); }, 100);
+        setTimeout(function() {
+            clearInterval(_mgrPoll);
+            if (!_mgrInitDone) {
+                _mgrInitDone = true;
+                if (typeof window.t !== 'function') {
+                    window.t = function(key, fallback) { return fallback || key; };
+                }
+                _initManager();
+            }
+        }, 3000);
+    </script>
+</body>
+</html>

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -93,6 +93,7 @@
             if (_mgrInitDone) return;
             if (typeof window.t === 'function' && window.i18n && window.i18n.isInitialized !== false) {
                 _mgrInitDone = true;
+                clearInterval(_mgrPoll);
                 _initManager();
             }
         }

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -70,15 +70,25 @@
             document.head.appendChild(style);
 
             // 覆盖 hide：关闭窗口而非隐藏 DOM
+            var _prevHide = SAM.hide;
             SAM.hide = function() {
-                window.close();
+                try {
+                    window.close();
+                } catch (e) {
+                    if (typeof _prevHide === 'function') _prevHide.call(SAM);
+                }
             };
 
-            // 覆盖 Jukebox.loadSongs：通过 BroadcastChannel 通知点歌台窗口刷新
-            Jukebox.loadSongs = function() {
+            // 覆盖 Jukebox.loadSongs：保留原始行为，完成后通过 BroadcastChannel 通知点歌台窗口刷新
+            var _origLoadSongs = Jukebox.loadSongs;
+            var _jukeboxBC;
+            try { _jukeboxBC = new BroadcastChannel('neko-jukebox'); } catch (e) {}
+            Jukebox.loadSongs = async function() {
+                var result = await _origLoadSongs.apply(Jukebox, arguments);
                 try {
-                    new BroadcastChannel('neko-jukebox').postMessage({ type: 'reload' });
+                    if (_jukeboxBC) _jukeboxBC.postMessage({ type: 'reload' });
                 } catch (e) {}
+                return result;
             };
 
             // 显示并加载数据

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -74,6 +74,9 @@
             SAM.hide = function() {
                 try {
                     window.close();
+                    if (!window.closed && typeof _prevHide === 'function') {
+                        _prevHide.call(SAM);
+                    }
                 } catch (e) {
                     if (typeof _prevHide === 'function') _prevHide.call(SAM);
                 }
@@ -91,10 +94,9 @@
                 return result;
             };
 
-            // 显示并加载数据
+            // 显示管理器（SAM.create() 已调用 load，无需重复加载）
             SAM.element.style.display = 'flex';
             SAM.isVisible = true;
-            SAM.load();
         }
 
         // 等待 i18n 就绪

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -103,7 +103,7 @@
         var _mgrInitDone = false;
         function _tryInitManager() {
             if (_mgrInitDone) return;
-            if (typeof window.t === 'function' && window.i18n && window.i18n.isInitialized !== false) {
+            if (typeof window.t === 'function' && window.i18n && window.i18n.isInitialized === true) {
                 _mgrInitDone = true;
                 clearInterval(_mgrPoll);
                 _initManager();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增独立的 Jukebox 管理器页面（/jukebox/manager），可在单独窗口打开并管理播放列表。
  * 管理器与主界面通过广播通道同步：加载/刷新时会广播 reload 事件以触发其它窗口更新。

* **改进**
  * 独立模式下优化界面与交互：禁用文本选择、设置可拖拽/不可拖拽区域、避免页面内拖拽绑定。
  * 启动更鲁棒：加入国际化就绪检测与超时回退；关闭行为改为尝试关闭窗口并回退原有隐藏逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->