### PR TITLE
fix: 修复输入框高度、Jukebox 按钮绑定和侧面板 hideMainUI 无恢复问题

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -667,7 +667,7 @@ textarea {
 .composer-panel {
   display: grid;
   gap: 4px;
-  padding: 6px 9px 10px;
+  padding: 6px;
   position: relative;
   background: rgba(255, 255, 255, 0.91);
 }
@@ -729,9 +729,9 @@ textarea {
 .composer-input-shell {
   display: flex;
   flex-direction: column;
-  min-height: 52px;
-  padding: 0 7px 0 13px;
-  border-radius: 12px;
+  min-height: 98px;
+  padding: 0 16px;
+  border-radius: 16px;
   background: rgba(255, 255, 255, 0.91);
   border: 1px solid rgba(127, 144, 170, 0.16);
   transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
@@ -752,7 +752,7 @@ textarea {
 .composer-input {
   display: block;
   width: 100%;
-  min-height: 32px;
+  min-height: 66px;
   max-height: 160px;
   margin: 0;
   resize: none !important;
@@ -764,7 +764,7 @@ textarea {
   -webkit-appearance: none;
   background: transparent;
   color: #1f2329;
-  padding: 8px 0 2px;
+  padding: 12px 0 10px;
   line-height: 1.34;
   vertical-align: top;
   box-shadow: none !important;
@@ -794,7 +794,7 @@ textarea {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1px 0 6px;
+  padding: 6px 0 10px;
 }
 
 .composer-bottom-tools {
@@ -807,8 +807,8 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   padding: 0;
   margin: 0;
   border: 0;
@@ -828,8 +828,8 @@ textarea {
 }
 
 .composer-tool-btn img {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   object-fit: contain;
   pointer-events: none;
 }
@@ -877,8 +877,8 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   padding: 0;
   border: 0;
   border-radius: 50%;
@@ -899,8 +899,8 @@ textarea {
 }
 
 .send-button-circle img {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   object-fit: contain;
   pointer-events: none;
 }

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3228,6 +3228,13 @@ window.Jukebox = {
     const MAX_RETRIES = 20;
     const jukeboxButton = document.getElementById('jukeboxButton');
     if (!jukeboxButton) {
+      // React Chat 模式下按钮由 React 组件渲染，通过 onJukeboxClick 回调直接调用
+      // window.Jukebox.toggle()，无需绑定 DOM 按钮
+      const reactChatRoot = document.getElementById('react-chat-window-root');
+      if (reactChatRoot) {
+        console.log('[Jukebox]', 'React Chat 模式，跳过 DOM 按钮绑定');
+        return;
+      }
       if (retries >= MAX_RETRIES) {
         console.error('[Jukebox]', window.t('Jukebox.btnNotFoundGiveUp', '点歌台按钮在重试后仍未找到，放弃绑定'));
         return;

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -723,13 +723,13 @@ function createSidePanelMenuItem(manager, prefix, item) {
         } else {
             childWin = window.open(url, name, feat);
         }
+        // 弹窗被拦截或打开失败时不隐藏主页，避免无法恢复
+        if (!childWin) return;
         if (typeof window.handleHideMainUI === 'function') {
             window.handleHideMainUI();
         }
-        if (childWin) {
-            _activeManagerWindows.add(childWin);
-            _startManagerWindowWatcher();
-        }
+        _activeManagerWindows.add(childWin);
+        _startManagerWindowWatcher();
     }
 
     menuItem.addEventListener('click', (e) => {

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -635,6 +635,26 @@ function createCharacterSettingsSidePanel(manager, prefix) {
 /**
  * 创建侧边面板菜单项
  */
+// 跟踪所有已打开的模型管理子窗口，只有全部关闭后才恢复主页渲染
+const _activeManagerWindows = new Set();
+let _managerWindowCheckTimer = null;
+
+function _startManagerWindowWatcher() {
+    if (_managerWindowCheckTimer) return;
+    _managerWindowCheckTimer = setInterval(() => {
+        for (const win of _activeManagerWindows) {
+            if (win.closed) _activeManagerWindows.delete(win);
+        }
+        if (_activeManagerWindows.size === 0) {
+            clearInterval(_managerWindowCheckTimer);
+            _managerWindowCheckTimer = null;
+            if (typeof window.handleShowMainUI === 'function') {
+                window.handleShowMainUI();
+            }
+        }
+    }, 1000);
+}
+
 function createSidePanelMenuItem(manager, prefix, item) {
     const menuItem = document.createElement('div');
     menuItem.id = `${prefix}-sidepanel-${item.id}`;
@@ -695,7 +715,7 @@ function createSidePanelMenuItem(manager, prefix, item) {
 
     let isOpening = false;
 
-    // 打开子窗口并暂停主页渲染，子窗口关闭后自动恢复
+    // 打开子窗口并暂停主页渲染，所有管理窗口关闭后自动恢复
     function openAndPauseMainUI(url, name, feat) {
         let childWin;
         if (typeof window.openOrFocusWindow === 'function') {
@@ -706,14 +726,9 @@ function createSidePanelMenuItem(manager, prefix, item) {
         if (typeof window.handleHideMainUI === 'function') {
             window.handleHideMainUI();
         }
-        // 子窗口关闭后恢复主页渲染
-        if (childWin && typeof window.handleShowMainUI === 'function') {
-            const checkClosed = setInterval(() => {
-                if (childWin.closed) {
-                    clearInterval(checkClosed);
-                    window.handleShowMainUI();
-                }
-            }, 1000);
+        if (childWin) {
+            _activeManagerWindows.add(childWin);
+            _startManagerWindowWatcher();
         }
     }
 

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -695,6 +695,28 @@ function createSidePanelMenuItem(manager, prefix, item) {
 
     let isOpening = false;
 
+    // 打开子窗口并暂停主页渲染，子窗口关闭后自动恢复
+    function openAndPauseMainUI(url, name, feat) {
+        let childWin;
+        if (typeof window.openOrFocusWindow === 'function') {
+            childWin = window.openOrFocusWindow(url, name, feat);
+        } else {
+            childWin = window.open(url, name, feat);
+        }
+        if (typeof window.handleHideMainUI === 'function') {
+            window.handleHideMainUI();
+        }
+        // 子窗口关闭后恢复主页渲染
+        if (childWin && typeof window.handleShowMainUI === 'function') {
+            const checkClosed = setInterval(() => {
+                if (childWin.closed) {
+                    clearInterval(checkClosed);
+                    window.handleShowMainUI();
+                }
+            }, 1000);
+        }
+    }
+
     menuItem.addEventListener('click', (e) => {
         e.stopPropagation();
         if (isOpening) return;
@@ -709,12 +731,7 @@ function createSidePanelMenuItem(manager, prefix, item) {
                 finalUrl = `${item.urlBase}?lanlan_name=${encodeURIComponent(lanlanName)}`;
                 isOpening = true;
                 windowName = `neko_${item.id}_${encodeURIComponent(lanlanName || 'default')}`;
-                if (typeof window.openOrFocusWindow === 'function') {
-                    window.openOrFocusWindow(finalUrl, windowName);
-                } else {
-                    window.open(finalUrl, windowName);
-                }
-                if (typeof window.handleHideMainUI === 'function') window.handleHideMainUI();
+                openAndPauseMainUI(finalUrl, windowName);
                 setTimeout(() => { isOpening = false; }, 500);
             } else if (item.id === 'voice-clone' && item.url) {
                 const lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
@@ -734,7 +751,6 @@ function createSidePanelMenuItem(manager, prefix, item) {
                 } else {
                     window.open(finalUrl, windowName, features);
                 }
-                if (typeof window.handleHideMainUI === 'function') window.handleHideMainUI();
                 setTimeout(() => { isOpening = false; }, 500);
             } else if (item.url) {
                 isOpening = true;
@@ -743,7 +759,6 @@ function createSidePanelMenuItem(manager, prefix, item) {
                 } else {
                     window.open(finalUrl, windowName);
                 }
-                if (typeof window.handleHideMainUI === 'function') window.handleHideMainUI();
                 setTimeout(() => { isOpening = false; }, 500);
             }
         }


### PR DESCRIPTION
## Summary

修复 63a9e39 / 0c5e736 引入的三个回归问题：

- **Jukebox 按钮绑定空转**：React Chat 迁移后 `#jukeboxButton` 已不存在于 DOM，`setupButton()` 反复重试 20 次输出警告。现在检测到 `#react-chat-window-root` 后直接跳过，React 按钮通过 `onJukeboxClick` 回调正常工作
- **侧面板 handleHideMainUI 无恢复**：`window.open` 打开子窗口后调用 `handleHideMainUI()` 暂停模型渲染，但子窗口关闭后从未调用 `handleShowMainUI()`，导致模型永久隐藏。现在仅对模型管理页面（live2d/vrm/mmd-manage）暂停，并监听子窗口关闭自动恢复；voice-clone 和通用链接不再暂停主页
- **输入框高度过窄**：还原 `styles.css` 中 composer 区域被过度缩小的 CSS（min-height、padding、按钮尺寸）

## Test plan

- [ ] 打开 index.html，确认控制台不再出现 `[Jukebox] Jukebox button not found` 重复警告
- [ ] 点击 React Chat 中的点歌台按钮，确认功能正常
- [ ] 从侧面板打开模型管理页面，确认主页模型暂停；关闭管理页面后模型自动恢复显示
- [ ] 从侧面板打开 voice-clone 或其他链接，确认主页模型不被隐藏
- [ ] 确认输入框高度恢复正常，不再过窄

https://claude.ai/code/session_01WhvaxRRsoHVvmBmz7hzw8v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **样式**
  * 优化了聊天输入区布局与尺寸：调整输入区域、工具按钮和发送按钮的间距、圆角与大小，提升触控与视觉体验

* **改进**
  * 在 React 聊天模式下更智能地处理缺失按钮的检测，避免不必要的重试
  * 改进侧边面板的子窗口管理，主界面在子窗口打开/关闭时的显示与隐藏更可靠
<!-- end of auto-generated comment: release notes by coderabbit.ai -->