### PR TITLE
fix(i18n): align locale interpolation placeholders

### DIFF
--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1294,9 +1294,9 @@
         "noVoices": "登録済みボイスはありません",
         "loadError": "読み込み失敗、後でもう一度お試しください",
         "delete": "削除",
-        "confirmDelete": "このボイスを削除しますか？",
+        "confirmDelete": "ボイス「{{name}}」を削除してもよろしいですか？この操作は元に戻せません。",
         "deleting": "削除中...",
-        "deleteSuccess": "削除成功",
+        "deleteSuccess": "ボイス「{{name}}」の削除が完了しました",
         "deleteFailed": "削除失敗",
         "deleteError": "削除失敗：{{error}}",
         "freePresetLabel": "無料プリセット",
@@ -1848,7 +1848,7 @@
             "title": "待機アニメーション",
             "selectHint": "待機モーションを選択",
             "selectedCount": "{{count}} 件選択中",
-            "changed": "待機アニメーションが変更されました: {{name}}",
+            "changed": "待機アニメーションが変更されました",
             "changeFailed": "待機アニメーションの変更に失敗しました"
         }
     },

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -148,7 +148,7 @@
         "subscriptionsUpdated": "订阅列表已更新",
         "unsubscribeFailed": "取消订阅失败: {{error}}",
         "unsubscribeError": "取消订阅时发生错误，请稍后再试",
-        "validatingFolderPath": "正在验证文件夹路径...",
+        "validatingFolderPath": "正在验证文件夹: {{path}}",
         "previewImageMissing": "预览图片文件不存在，请检查路径",
         "uploadReady": "准备上传 {{itemName}}",
         "pageDescription": "通过此页面，您可以浏览、订阅、下载和管理Steam创意工坊中的Live2D模型和声音",


### PR DESCRIPTION
修复多语言文案中的占位符不对齐问题，确保插值参数在各语言中保持一致。\n\n本次调整包括：\n- 移除 ja 的 mmd.idleAnimation.changed 中多余的 {{name}}\n- 补全 zh-CN 的 steam.validatingFolderPath 中缺失的 {{path}}\n- 补全 ja 的 voice.confirmDelete 和 voice.deleteSuccess 中缺失的 {{name}}\n\n这次提交仅修改 static/locales/ja.json 与 static/locales/zh-CN.json，不影响其他分支。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **本地化更新**
  * 改进了日文删除操作的确认和成功提示信息的清晰度和详细程度
  * 优化了动画变更通知的显示文本
  * 增强了中文文件夹验证提示的信息详细度

<!-- end of auto-generated comment: release notes by coderabbit.ai -->