### PR TITLE
feat: 聊天流式渐显动效 + 消息节流 + 乐观 UI + 滚动条美化

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import MessageList from './MessageList';
 import { i18n } from './i18n';
 import {
@@ -52,14 +52,52 @@ export default function App({
   onTranslateToggle,
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
+  const [pendingDrafts, setPendingDrafts] = useState<Array<{ id: string; text: string; time: string }>>([]);
   const canSubmit = draft.trim().length > 0 || composerAttachments.length > 0;
   const resolvedImportImageAriaLabel = importImageButtonAriaLabel || importImageButtonLabel;
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
   const resolvedTranslateAriaLabel = translateButtonAriaLabel || translateButtonLabel;
 
+  // Clear pending drafts once the host confirms them (appears in messages)
+  useEffect(() => {
+    if (pendingDrafts.length === 0) return;
+    const hostUserTexts = new Set(
+      messages
+        .filter(m => m.role === 'user')
+        .flatMap(m => m.blocks.flatMap(b => b.type === 'text' ? [b.text] : [])),
+    );
+    const remaining = pendingDrafts.filter(d => !hostUserTexts.has(d.text));
+    if (remaining.length < pendingDrafts.length) {
+      setPendingDrafts(remaining);
+    }
+  }, [messages, pendingDrafts]);
+
+  // Merge host messages + optimistic pending drafts
+  const lastUserAuthor = [...messages].reverse().find(m => m.role === 'user')?.author;
+  const allMessages = useMemo(() => {
+    if (pendingDrafts.length === 0) return messages;
+    const optimistic: ChatMessage[] = pendingDrafts.map(d => ({
+      id: d.id,
+      role: 'user' as const,
+      author: lastUserAuthor || 'You',
+      time: d.time,
+      blocks: [{ type: 'text' as const, text: d.text }],
+      status: 'sending' as const,
+    }));
+    return [...messages, ...optimistic];
+  }, [messages, pendingDrafts, lastUserAuthor]);
+
   function submitDraft() {
     const text = draft.trim();
     if (!text && composerAttachments.length === 0) return;
+    const now = new Date();
+    const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
+      .map(n => String(n).padStart(2, '0')).join(':');
+    setPendingDrafts(prev => [...prev, {
+      id: `pending-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      text,
+      time,
+    }]);
     onComposerSubmit?.({ text });
     setDraft('');
   }
@@ -79,7 +117,7 @@ export default function App({
 
         <section className="chat-body">
           <MessageList
-            messages={messages}
+            messages={allMessages}
             ariaLabel={messageListAriaLabel}
             failedStatusLabel={failedStatusLabel}
             onAction={onMessageAction}

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -52,7 +52,7 @@ export default function App({
   onTranslateToggle,
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
-  const [pendingDrafts, setPendingDrafts] = useState<Array<{ id: string; text: string; time: string }>>([]);
+  const [pendingDrafts, setPendingDrafts] = useState<Array<{ id: string; text: string; time: string; msgSnapshot: number }>>([]);
   const canSubmit = draft.trim().length > 0 || composerAttachments.length > 0;
   const resolvedImportImageAriaLabel = importImageButtonAriaLabel || importImageButtonLabel;
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
@@ -61,12 +61,14 @@ export default function App({
   // Clear pending drafts once the host confirms them (appears in messages)
   useEffect(() => {
     if (pendingDrafts.length === 0) return;
-    const hostUserTexts = new Set(
-      messages
-        .filter(m => m.role === 'user')
-        .flatMap(m => m.blocks.flatMap(b => b.type === 'text' ? [b.text] : [])),
-    );
-    const remaining = pendingDrafts.filter(d => !hostUserTexts.has(d.text));
+    const remaining = pendingDrafts.filter(d => {
+      const newUserTexts = new Set(
+        messages.slice(d.msgSnapshot)
+          .filter(m => m.role === 'user')
+          .flatMap(m => m.blocks.flatMap(b => b.type === 'text' ? [b.text] : [])),
+      );
+      return !newUserTexts.has(d.text);
+    });
     if (remaining.length < pendingDrafts.length) {
       setPendingDrafts(remaining);
     }
@@ -93,11 +95,14 @@ export default function App({
     const now = new Date();
     const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
       .map(n => String(n).padStart(2, '0')).join(':');
-    setPendingDrafts(prev => [...prev, {
-      id: `pending-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-      text,
-      time,
-    }]);
+    if (text) {
+      setPendingDrafts(prev => [...prev, {
+        id: `pending-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        text,
+        time,
+        msgSnapshot: messages.length,
+      }]);
+    }
     onComposerSubmit?.({ text });
     setDraft('');
   }

--- a/frontend/react-neko-chat/src/MessageBubble.tsx
+++ b/frontend/react-neko-chat/src/MessageBubble.tsx
@@ -47,14 +47,16 @@ function getAvatarClassName(message: ChatMessage) {
 function MessageBlockView({
   block,
   message,
+  isStreaming,
   onAction,
 }: {
   block: MessageBlock;
   message: ChatMessage;
+  isStreaming?: boolean;
   onAction?: (message: ChatMessage, action: MessageAction) => void;
 }) {
   if (block.type === 'text') {
-    return <SmartTextBlock text={block.text} />;
+    return <SmartTextBlock text={block.text} isStreaming={isStreaming} />;
   }
 
   if (block.type === 'image') {
@@ -155,6 +157,8 @@ export default function MessageBubble({
     );
   }
 
+  const streaming = message.status === 'streaming';
+
   return (
     <article
       className={rowClassName}
@@ -187,6 +191,7 @@ export default function MessageBubble({
               key={`${message.id}-${block.type}-${index}`}
               block={block}
               message={message}
+              isStreaming={streaming}
               onAction={onAction}
             />
           ))}

--- a/frontend/react-neko-chat/src/MessageList.tsx
+++ b/frontend/react-neko-chat/src/MessageList.tsx
@@ -1,7 +1,9 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, useMemo } from 'react';
 import MessageBubble from './MessageBubble';
 import { i18n } from './i18n';
 import { type ChatMessage, type MessageAction } from './message-schema';
+
+const MAX_DISPLAY_MESSAGES = 50;
 
 type MessageListProps = {
   messages: ChatMessage[];
@@ -32,7 +34,14 @@ export default function MessageList({
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldScrollRef = useRef(true);
 
-  const isStreaming = messages.some(m => m.status === 'streaming');
+  const displayMessages = useMemo(
+    () => messages.length > MAX_DISPLAY_MESSAGES
+      ? messages.slice(-MAX_DISPLAY_MESSAGES)
+      : messages,
+    [messages],
+  );
+
+  const isStreaming = displayMessages.some(m => m.status === 'streaming');
 
   const scrollToBottom = useCallback(() => {
     const container = containerRef.current;
@@ -50,7 +59,7 @@ export default function MessageList({
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages, scrollToBottom]);
+  }, [displayMessages, scrollToBottom]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -67,7 +76,7 @@ export default function MessageList({
     }
 
     return () => observer.disconnect();
-  }, [messages.length]);
+  }, [displayMessages.length]);
 
   const handleScroll = () => {
     const container = containerRef.current;
@@ -78,7 +87,7 @@ export default function MessageList({
     shouldScrollRef.current = isNearBottom;
   };
 
-  if (messages.length === 0) {
+  if (displayMessages.length === 0) {
     return (
       <div className="message-list" ref={containerRef} aria-label={ariaLabel}>
       </div>
@@ -87,11 +96,11 @@ export default function MessageList({
 
   return (
     <div className="message-list" ref={containerRef} aria-label={ariaLabel} onScroll={handleScroll}>
-      {messages.map((message, index) => (
+      {displayMessages.map((message, index) => (
         <MessageBubble
           key={message.id}
           message={message}
-          isGroupedWithPrevious={shouldGroupWithPrevious(message, messages[index - 1])}
+          isGroupedWithPrevious={shouldGroupWithPrevious(message, displayMessages[index - 1])}
           failedStatusLabel={failedStatusLabel}
           onAction={onAction}
         />

--- a/frontend/react-neko-chat/src/SmartTextBlock.tsx
+++ b/frontend/react-neko-chat/src/SmartTextBlock.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
@@ -38,8 +39,65 @@ function CodeBlock({ inline, className, children }: {
   );
 }
 
-export default function SmartTextBlock({ text }: { text: string }) {
+/**
+ * Streaming text with chunk-based reveal animation.
+ *
+ * Text is split into "settled" (plain text) and "fresh" (a single <span> with
+ * a CSS fade-in).  Every ~200 ms the current batch settles and a new span
+ * starts, giving a continuous "materialising" cadence similar to ChatGPT /
+ * Claude.ai.
+ *
+ * Key design choices:
+ * - Timer is managed via refs so that incoming streaming updates (text.length
+ *   changes) do NOT cancel an in-flight timer.  The old useEffect-cleanup
+ *   approach reset the 200 ms timer on every token, meaning settledLen never
+ *   advanced during fast streaming.
+ * - When the timer fires it reads textLenRef.current (the LATEST length), so
+ *   each batch captures exactly 200 ms worth of tokens.
+ * - `key={settledLen}` on the span forces React to create a fresh DOM node
+ *   each batch, which re-triggers the CSS animation.
+ */
+function StreamingText({ text }: { text: string }) {
+  const [settledLen, setSettledLen] = useState(0);
+  const textLenRef = useRef(text.length);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  textLenRef.current = text.length;
+
+  // Kick off a 200 ms settle timer whenever fresh text exists and no timer is
+  // already running.  Runs after every render but the guard makes it cheap.
+  useEffect(() => {
+    if (textLenRef.current > settledLen && timerRef.current === null) {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        setSettledLen(textLenRef.current);   // snapshot at fire-time
+      }, 200);
+    }
+  });
+
+  // Clear timer on unmount only
+  useEffect(() => () => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+  }, []);
+
+  const fresh = text.slice(settledLen);
+
+  if (!fresh) {
+    return <div className="message-block message-block-text">{text}</div>;
+  }
+
+  return (
+    <div className="message-block message-block-text">
+      {text.slice(0, settledLen)}
+      <span key={settledLen} className="text-chunk-reveal">{fresh}</span>
+    </div>
+  );
+}
+
+export default function SmartTextBlock({ text, isStreaming }: { text: string; isStreaming?: boolean }) {
   if (!looksLikeRichText(text)) {
+    if (isStreaming) {
+      return <StreamingText text={text} />;
+    }
     return <div className="message-block message-block-text">{text}</div>;
   }
 

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -211,6 +211,26 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* 滚动条：细线 + 半透明，参考 Discord / Slack */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(140, 152, 172, 0.25) transparent;
+}
+
+.message-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.message-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.message-list::-webkit-scrollbar-thumb {
+  background: rgba(140, 152, 172, 0.25);
+  border-radius: 3px;
+}
+
+.message-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(140, 152, 172, 0.45);
 }
 
 .message-empty-state {
@@ -228,12 +248,24 @@ textarea {
   gap: 8px;
 }
 
+/* 消息气泡进场动效 */
+@keyframes slideFromLeft {
+  from { opacity: 0; transform: translateX(-14px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+@keyframes slideFromRight {
+  from { opacity: 0.5; transform: translateX(8px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
 .message-row-user {
   justify-content: flex-end;
+  animation: slideFromRight 0.15s ease-out both;
 }
 
 .message-row-assistant {
   justify-content: flex-start;
+  animation: slideFromLeft 0.25s ease-out both;
 }
 
 .message-row-user .avatar {
@@ -329,6 +361,16 @@ textarea {
 
 .message-block {
   min-width: 0;
+}
+
+/* 流式文字分块渐现 — 每批新文本整体淡入，参考 ChatGPT / Claude.ai */
+@keyframes textChunkReveal {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.text-chunk-reveal {
+  animation: textChunkReveal 0.18s ease-out both;
 }
 
 .message-block-text {
@@ -669,6 +711,7 @@ textarea {
   gap: 4px;
   padding: 6px;
   position: relative;
+  z-index: 15;
   background: rgba(255, 255, 255, 0.91);
 }
 
@@ -733,7 +776,7 @@ textarea {
   padding: 0 16px;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.91);
-  border: 1px solid rgba(127, 144, 170, 0.16);
+  border: 1.5px solid rgba(127, 144, 170, 0.25);
   transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.78),
@@ -779,7 +822,8 @@ textarea {
 }
 
 .composer-input::placeholder {
-  color: #66758d;
+  color: rgba(102, 117, 141, 0.5);
+  font-size: 0.85em;
   line-height: 1.34;
 }
 
@@ -1001,6 +1045,19 @@ textarea {
 
 [data-theme="dark"] .chat-body {
   background: rgba(28, 28, 46, 0.91);
+}
+
+/* --- 消息列表滚动条 --- */
+[data-theme="dark"] .message-list {
+  scrollbar-color: rgba(200, 210, 230, 0.15) transparent;
+}
+
+[data-theme="dark"] .message-list::-webkit-scrollbar-thumb {
+  background: rgba(200, 210, 230, 0.15);
+}
+
+[data-theme="dark"] .message-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(200, 210, 230, 0.3);
 }
 
 /* --- 消息列表 --- */

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -824,6 +824,9 @@
             }).filter(Boolean)
             : [];
         state.messages = sortMessages(normalized);
+        if (state.messages.length > MAX_MESSAGES) {
+            state.messages = state.messages.slice(-MAX_MESSAGES);
+        }
         renderWindow();
         return state.messages;
     }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -843,11 +843,16 @@
         return state.composerAttachments;
     }
 
+    var MAX_MESSAGES = 50;
+
     function appendMessage(message) {
         var normalized = normalizeMessage(message, state.messages.length);
         if (!normalized) return null;
 
         state.messages = sortMessages(state.messages.concat([normalized]));
+        if (state.messages.length > MAX_MESSAGES) {
+            state.messages = state.messages.slice(-MAX_MESSAGES);
+        }
         renderWindow();
         return normalized;
     }

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -177,20 +177,17 @@
             color: rgba(102, 117, 141, 0.5) !important;
             font-size: 0.85em !important;
         }
-        /* 消息气泡进场动效 */
-        @keyframes slideFromLeft {
-            from { opacity: 0; transform: translateX(-20px); }
-            to   { opacity: 1; transform: translateX(0); }
+        /* 消息气泡进场动效 —— 由 neko-chat-window.css 统一定义，此处不重复声明。
+           旧版在此处用 !important 重复声明 @keyframes + animation 规则，会导致浏览器
+           对同名 @keyframes 做二次解析，且 !important 阻止 prefers-reduced-motion
+           等未来覆盖，已移除。 */
+
+        /* Electron 独立窗口始终显示全部工具按钮（覆盖 index.css 768px 媒体查询隐藏） */
+        #react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
+            display: inline-flex !important;
         }
-        @keyframes slideFromRight {
-            from { opacity: 0; transform: translateX(20px); }
-            to   { opacity: 1; transform: translateX(0); }
-        }
-        .message-row-assistant {
-            animation: slideFromLeft 0.3s ease-out both !important;
-        }
-        .message-row-user {
-            animation: slideFromRight 0.3s ease-out both !important;
+        #react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2) {
+            display: inline !important;
         }
         /* 隐藏旧版 chat */
         #chat-container { display: none !important; }


### PR DESCRIPTION
## Summary
- **流式文字渐显**：`StreamingText` 组件每 200ms 一批文字 fade-in，ref 管理计时器防止快速 token 到达时计时器被反复 reset
- **消息节流**：React 展示层 + host 数据层各限 50 条，防止长对话性能退化
- **乐观 UI**：用户按回车后消息立即显示，IPC 确认后自动去重，消除 1s+ 输入延迟
- **滚动条美化**：细线半透明样式，适配暗色模式，参考 Discord/Slack
- **气泡 slide 动效**：assistant 从左滑入，user 从右滑入
- **chat.html 清理**：移除重复 `@keyframes` / `!important` 声明，统一由 `neko-chat-window.css` 管理；覆盖 `max-width: 768px` 媒体查询恢复 Jukebox 按钮

## Test plan
- [ ] 发送消息后立即出现在聊天框（不等 IPC 返回）
- [ ] 流式响应文字分批淡入，长文本不会只闪一下就全部出现
- [ ] 消息超过 50 条时旧消息自动回收
- [ ] chat.html（Electron 独立窗口）Jukebox 按钮可见
- [ ] chat.html 气泡 slide 动效正常
- [ ] 暗色模式下滚动条样式正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加乐观消息草稿，提交后即时显示并在服务器回执到位时自动替换
  * 流式文本动画，逐块/逐字显示接收中的消息

* **样式与设计**
  * 增强消息进出场动效与流式文本显现动画
  * 优化消息列表滚动条（含暗色主题）与输入框视觉细节、提升层级显示

* **性能优化**
  * 限制渲染/缓存的消息数量，改善长会话性能
<!-- end of auto-generated comment: release notes by coderabbit.ai -->