### PR TITLE
移除移动端聊天窗口中隐藏点歌台按钮的样式规则

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2136,14 +2136,6 @@ body.react-chat-window-dragging {
         overflow-y: auto;
     }
 
-    /* Mobile: hide the divider between translate and jukebox plus the last tool button (jukebox)
-       to reduce clutter on small screens. If the tool order changes, replace these positional
-       selectors with a dedicated class or data attribute on the affected controls. */
-    #react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
-    #react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
-        display: none;
-    }
-
     #react-chat-window-drag-handle {
         cursor: default;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复了移动设备上聊天窗口工具栏中某些元素被意外隐藏的问题。工具栏分隔符和操作按钮现在在移动设备上正常显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->