### PR TITLE
修复已保存的 VRM 灯光配置在主页面初始加载和模型热重载后不会立即生效的问题。page_config 现在会返回 lighting 配置…

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -218,6 +218,7 @@ async def get_page_config(lanlan_name: str = ""):
             model_type = 'live3d'
         
         model_path = ""
+        lighting = None
         # live3d_sub_type: 前端用于区分 Live3D 模式下加载 VRM 还是 MMD 渲染器
         live3d_sub_type = ""
         
@@ -230,6 +231,16 @@ async def get_page_config(lanlan_name: str = ""):
                 model_path = _resolve_vrm_path(vrm_path, _config_manager, target_name)
             else:
                 logger.warning(f"角色 {target_name} 的VRM模型路径为空")
+            saved_lighting = get_reserved(
+                catgirl_config,
+                'avatar',
+                'vrm',
+                'lighting',
+                default=None,
+                legacy_keys=('lighting',),
+            )
+            if isinstance(saved_lighting, dict):
+                lighting = dict(saved_lighting)
         elif model_type == 'live3d' and _get_live3d_sub_type(catgirl_config) == 'mmd':
             live3d_sub_type = 'mmd'
             # MMD模型：处理路径转换
@@ -270,7 +281,8 @@ async def get_page_config(lanlan_name: str = ""):
             "master_nickname": str(master_basic_config.get('昵称', '') or ''),
             "master_display_name": master_display_name or "",
             "model_path": model_path,
-            "model_type": model_type
+            "model_type": model_type,
+            "lighting": lighting,
         }
         if model_type == 'live3d':
             result["live3d_sub_type"] = live3d_sub_type

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -235,6 +235,12 @@
                 var newModelType = (data.model_type || 'live2d').toLowerCase();
                 var live3dSubType = (data.live3d_sub_type || '').toLowerCase();
                 var oldModelType = window.lanlan_config?.model_type || 'live2d';
+                var nextLighting = (data.lighting && typeof data.lighting === 'object')
+                    ? Object.assign({}, data.lighting)
+                    : null;
+
+                window.lanlan_config = window.lanlan_config || {};
+                window.lanlan_config.lighting = nextLighting;
 
                 console.log('[Model] 模型切换:', {
                     oldType: oldModelType,
@@ -354,9 +360,22 @@
                             }
                         }
 
-                        // Apply lighting config if available
-                        if (window.lanlan_config?.lighting && typeof window.applyVRMLighting === 'function') {
-                            window.applyVRMLighting(window.lanlan_config.lighting, window.vrmManager);
+                        // 重新应用打光/曝光/描边；若角色未保存自定义光照，则回退到默认值，避免沿用上一个角色的灯光状态。
+                        var effectiveLighting = window.lanlan_config?.lighting || window.VRM_DEFAULT_LIGHTING || null;
+                        if (effectiveLighting && typeof window.applyVRMLighting === 'function') {
+                            window.applyVRMLighting(effectiveLighting, window.vrmManager);
+                            if (typeof window.applyVRMOutlineWidth === 'function') {
+                                var currentModelRef = window.vrmManager?.currentModel;
+                                var outlineScale = effectiveLighting.outlineWidthScale;
+                                requestAnimationFrame(function () {
+                                    if (window.vrmManager?.currentModel !== currentModelRef) {
+                                        return;
+                                    }
+                                    if (outlineScale !== undefined) {
+                                        window.applyVRMOutlineWidth(outlineScale, window.vrmManager);
+                                    }
+                                });
+                            }
                         }
                     } else {
                         console.error('[Model] VRM 管理器初始化失败');

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -97,6 +97,9 @@ async function loadPageConfig() {
             lanlan_config.master_profile_name = data.master_profile_name || '';
             lanlan_config.master_nickname = data.master_nickname || '';
             lanlan_config.master_display_name = data.master_display_name || data.master_nickname || data.master_name || '';
+            lanlan_config.lighting = (data.lighting && typeof data.lighting === 'object')
+                ? Object.assign({}, data.lighting)
+                : null;
             window.master_name = lanlan_config.master_name;
             window.master_profile_name = lanlan_config.master_profile_name;
             window.master_nickname = lanlan_config.master_nickname;
@@ -150,6 +153,7 @@ async function loadPageConfig() {
             console.error('获取页面配置失败:', data.error);
             // 使用默认值
             lanlan_config.lanlan_name = "";
+            lanlan_config.lighting = null;
             cubism4Model = "";
             vrmModel = "";
             window.lanlan_config = lanlan_config;
@@ -161,6 +165,7 @@ async function loadPageConfig() {
         console.error('加载页面配置时出错:', error);
         // 使用默认值
         lanlan_config.lanlan_name = "";
+        lanlan_config.lighting = null;
         cubism4Model = "";
         vrmModel = "";
         window.lanlan_config = lanlan_config;
@@ -181,6 +186,9 @@ if (window.__NEKO_MULTI_WINDOW__ && window.location.pathname === '/chat') {
             lanlan_config.lanlan_name = d.lanlan_name || '';
             lanlan_config.model_type = (d.model_type || 'live2d').toLowerCase();
             lanlan_config.live3d_sub_type = (d.live3d_sub_type || '').toLowerCase();
+            lanlan_config.lighting = (d.lighting && typeof d.lighting === 'object')
+                ? Object.assign({}, d.lighting)
+                : null;
             window.lanlan_config = lanlan_config;
             // master 信息
             window.master_name = d.master_name || '';


### PR DESCRIPTION
…，前端会同步更新并重新应用灯光、曝光和描边设置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为VRM虚拟形象添加了灯光配置支持，现可通过后端API配置和管理灯光设置。
  * 改进了页面重新加载时的灯光配置持久化处理，确保设置在切换模型时保持一致。
  * 优化了轮廓宽度的应用逻辑，使其在模型加载期间更加稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->