### PR TITLE
fix: 聊天消息超过50条后按角色错位排序

### DIFF
--- a/frontend/react-neko-chat/src/SmartTextBlock.tsx
+++ b/frontend/react-neko-chat/src/SmartTextBlock.tsx
@@ -94,10 +94,13 @@ function StreamingText({ text }: { text: string }) {
 }
 
 export default function SmartTextBlock({ text, isStreaming }: { text: string; isStreaming?: boolean }) {
+  // Streaming: always use StreamingText for per-batch fade-in, regardless of
+  // markdown content.  Once streaming ends, fall through to markdown rendering.
+  if (isStreaming) {
+    return <StreamingText text={text} />;
+  }
+
   if (!looksLikeRichText(text)) {
-    if (isStreaming) {
-      return <StreamingText text={text} />;
-    }
     return <div className="message-block message-block-text">{text}</div>;
   }
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -23,6 +23,7 @@
     var minimized = false;
     var savedShellSize = null;
     var savedShellPosition = null; // {left, top} before minimize – used to fly back on expand
+    var _sortKeySeq = 0; // monotonically increasing sortKey counter
 
     var state = {
         viewProps: null,
@@ -820,10 +821,16 @@
     function setMessages(messages) {
         var normalized = Array.isArray(messages)
             ? messages.map(function (message, index) {
-                return normalizeMessage(message, index);
+                return normalizeMessage(message, _sortKeySeq + index);
             }).filter(Boolean)
             : [];
         state.messages = sortMessages(normalized);
+        // Advance counter past all assigned sortKeys
+        if (state.messages.length > 0) {
+            _sortKeySeq = state.messages.reduce(function (max, m) {
+                return (typeof m.sortKey === 'number' && m.sortKey > max) ? m.sortKey : max;
+            }, _sortKeySeq) + 1;
+        }
         if (state.messages.length > MAX_MESSAGES) {
             state.messages = state.messages.slice(-MAX_MESSAGES);
         }
@@ -849,7 +856,7 @@
     var MAX_MESSAGES = 50;
 
     function appendMessage(message) {
-        var normalized = normalizeMessage(message, state.messages.length);
+        var normalized = normalizeMessage(message, _sortKeySeq++);
         if (!normalized) return null;
 
         state.messages = sortMessages(state.messages.concat([normalized]));
@@ -888,6 +895,7 @@
 
     function clearMessages() {
         state.messages = [];
+        _sortKeySeq = 0;
         renderWindow();
     }
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -819,18 +819,22 @@
     }
 
     function setMessages(messages) {
+        // Compute fallback start past any explicit sortKey in incoming batch
+        var maxIncomingSortKey = Array.isArray(messages)
+            ? messages.reduce(function (max, message) {
+                var key = message && typeof message.sortKey === 'number' && Number.isFinite(message.sortKey)
+                    ? message.sortKey : null;
+                return (key !== null && key > max) ? key : max;
+            }, -1)
+            : -1;
+        var nextSortKey = Math.max(_sortKeySeq, maxIncomingSortKey + 1);
         var normalized = Array.isArray(messages)
-            ? messages.map(function (message, index) {
-                return normalizeMessage(message, _sortKeySeq + index);
+            ? messages.map(function (message) {
+                return normalizeMessage(message, nextSortKey++);
             }).filter(Boolean)
             : [];
         state.messages = sortMessages(normalized);
-        // Advance counter past all assigned sortKeys
-        if (state.messages.length > 0) {
-            _sortKeySeq = state.messages.reduce(function (max, m) {
-                return (typeof m.sortKey === 'number' && m.sortKey > max) ? m.sortKey : max;
-            }, _sortKeySeq) + 1;
-        }
+        _sortKeySeq = nextSortKey;
         if (state.messages.length > MAX_MESSAGES) {
             state.messages = state.messages.slice(-MAX_MESSAGES);
         }

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -32,6 +32,8 @@
             background: transparent !important;
         }
         #react-chat-window-backdrop { display: none !important; }
+        /* neko-e-collapsed 是 Electron preload 脚本注入的物理折叠态 class，
+           不在本仓库内；折叠时不应铺满窗口 */
         #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding):not(.neko-e-collapsed) {
             position: fixed !important;
             inset: 20px !important;
@@ -106,7 +108,8 @@
             0%   { background-position: -150% -150%; }
             100% { background-position: 250% 250%; }
         }
-        /* 静态边缘高光层 — 在内容之下 */
+        /* 静态边缘高光层 — 在内容之下
+           neko-e-collapsed: Electron preload 注入，折叠时隐藏光效 */
         #react-chat-window-shell:not(.is-minimized):not(.neko-e-collapsed)::before {
             content: '' !important;
             position: absolute !important;
@@ -131,7 +134,8 @@
             ) !important;
         }
         /* 流动光斑层 — 三色径向渐变缓慢漂移，模拟玻璃折射
-           用 background-image 而非 background 简写，避免 !important 锁死 background-position */
+           用 background-image 而非 background 简写，避免 !important 锁死 background-position
+           neko-e-collapsed: Electron preload 注入，折叠时隐藏光效 */
         #react-chat-window-shell:not(.is-minimized):not(.neko-e-collapsed)::after {
             content: '' !important;
             position: absolute !important;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -32,7 +32,7 @@
             background: transparent !important;
         }
         #react-chat-window-backdrop { display: none !important; }
-        #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
+        #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding):not(.neko-e-collapsed) {
             position: fixed !important;
             inset: 20px !important;
             width: auto !important; height: auto !important;
@@ -107,7 +107,7 @@
             100% { background-position: 250% 250%; }
         }
         /* 静态边缘高光层 — 在内容之下 */
-        #react-chat-window-shell:not(.is-minimized)::before {
+        #react-chat-window-shell:not(.is-minimized):not(.neko-e-collapsed)::before {
             content: '' !important;
             position: absolute !important;
             inset: 0 !important;
@@ -132,7 +132,7 @@
         }
         /* 流动光斑层 — 三色径向渐变缓慢漂移，模拟玻璃折射
            用 background-image 而非 background 简写，避免 !important 锁死 background-position */
-        #react-chat-window-shell:not(.is-minimized)::after {
+        #react-chat-window-shell:not(.is-minimized):not(.neko-e-collapsed)::after {
             content: '' !important;
             position: absolute !important;
             inset: 0 !important;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -32,9 +32,7 @@
             background: transparent !important;
         }
         #react-chat-window-backdrop { display: none !important; }
-        /* neko-e-collapsed 是 Electron preload 脚本注入的物理折叠态 class，
-           不在本仓库内；折叠时不应铺满窗口 */
-        #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding):not(.neko-e-collapsed) {
+        #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
             position: fixed !important;
             inset: 20px !important;
             width: auto !important; height: auto !important;
@@ -108,9 +106,8 @@
             0%   { background-position: -150% -150%; }
             100% { background-position: 250% 250%; }
         }
-        /* 静态边缘高光层 — 在内容之下
-           neko-e-collapsed: Electron preload 注入，折叠时隐藏光效 */
-        #react-chat-window-shell:not(.is-minimized):not(.neko-e-collapsed)::before {
+        /* 静态边缘高光层 — 在内容之下 */
+        #react-chat-window-shell:not(.is-minimized)::before {
             content: '' !important;
             position: absolute !important;
             inset: 0 !important;
@@ -134,9 +131,8 @@
             ) !important;
         }
         /* 流动光斑层 — 三色径向渐变缓慢漂移，模拟玻璃折射
-           用 background-image 而非 background 简写，避免 !important 锁死 background-position
-           neko-e-collapsed: Electron preload 注入，折叠时隐藏光效 */
-        #react-chat-window-shell:not(.is-minimized):not(.neko-e-collapsed)::after {
+           用 background-image 而非 background 简写，避免 !important 锁死 background-position */
+        #react-chat-window-shell:not(.is-minimized)::after {
             content: '' !important;
             position: absolute !important;
             inset: 0 !important;


### PR DESCRIPTION
appendMessage 用 state.messages.length 作为 sortKey，但 MAX_MESSAGES 裁剪后 length 恒为 50，导致后续消息 sortKey 全部相同。tiebreaker
localeCompare(id) 按 "assistant-" < "user-" 字母序排列，使猫娘消息 全部排到用户消息前面。

改为单调递增计数器 _sortKeySeq，不受裁剪影响。同时包含 chat.html
Electron 全屏样式修复和 SmartTextBlock 流式渲染改进。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* 改进流式文本渲染逻辑：流式输出现在始终按流模式处理，呈现更一致可靠的实时文本效果
* 优化消息排序机制：引入全局序列化排序策略，消息顺序更稳定且可预测，清空时会重置序列
* 修复折叠状态样式：折叠时不再显示外边高亮与扩展尺寸，界面表现更合理
<!-- end of auto-generated comment: release notes by coderabbit.ai -->