### PR TITLE
将聊天框内的头像预览卡片改为独立弹窗，共用于 chat.html 和 index.html

### DIFF
--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -578,10 +578,17 @@
         setPreviewVisible(false);
     }
 
+    // 捕获模式下 scroll 会被文档内任意滚动容器触发（聊天消息列表、设置面板等），
+    // 用 rAF 合并到每帧最多一次布局计算，避免频繁 getBoundingClientRect 触发回流。
+    let viewportChangeRaf = null;
     function handleViewportChange() {
-        const card = S.dom.chatAvatarPreviewCard;
-        if (!card || card.hidden || !activeTrigger) return;
-        positionPopupNearTrigger(card, activeTrigger);
+        if (viewportChangeRaf) return;
+        viewportChangeRaf = window.requestAnimationFrame(function () {
+            viewportChangeRaf = null;
+            const card = S.dom.chatAvatarPreviewCard;
+            if (!card || card.hidden || !activeTrigger) return;
+            positionPopupNearTrigger(card, activeTrigger);
+        });
     }
 
     // 已绑定的触发按钮集合（供外点击判断使用）

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -617,9 +617,23 @@
 
         // —— 数据层：不管有无预览 UI 都执行（chat.html 没有预览卡片但仍需头像数据） ——
 
-        // 从 localStorage 恢复当前角色的头像
+        // 头像数据优先级：IPC 刚注入的内存缓存 > localStorage > 空态
+        //   1) 模块加载时 __nekoPendingAvatar 被消费后，cachedPreview 会被预先填好，
+        //      那才是 Pet 窗口当前的实时头像，比 localStorage 里上次会话的数据更新。
+        //   2) 否则退回读取当前角色的持久化头像。
+        //   3) 都没有，则进入等待态。
         var stored = loadFromStorage();
-        if (stored) {
+        if (cachedPreview && cachedPreview.dataUrl) {
+            // 保留内存缓存；刷新 cacheKey 并补写一次 localStorage
+            // （加载时 lanlan_config.lanlan_name 可能尚未就绪，保存会静默失败）。
+            cachedPreview.cacheKey = getCurrentModelCacheKey();
+            saveToStorage(cachedPreview);
+            setPreviewImage(cachedPreview.dataUrl);
+            setPreviewStatus(
+                translateLabel('chat.avatarPreviewReady', '头像已更新') + ' · ' + normalizeModelLabel(cachedPreview.modelType)
+            );
+            setPreviewNote(translateLabel('chat.avatarPreviewReadyHint', '这是从当前模型画布实时提取的头像预览。'));
+        } else if (stored) {
             cachedPreview = {
                 cacheKey: getCurrentModelCacheKey(),
                 dataUrl: stored.dataUrl,

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -161,11 +161,30 @@
         popup.style.transformOrigin = openUpward ? 'bottom right' : 'top right';
     }
 
+    // 退场过渡 fallback（略大于 CSS 里 opacity/transform transition 的最长时长 0.18s）
+    const HIDE_TRANSITION_FALLBACK_MS = 220;
+    let pendingHideTimer = null;
+    let pendingHideHandler = null;
+
+    function cancelPendingHide(card) {
+        if (pendingHideTimer) {
+            clearTimeout(pendingHideTimer);
+            pendingHideTimer = null;
+        }
+        if (card && pendingHideHandler) {
+            card.removeEventListener('transitionend', pendingHideHandler);
+        }
+        pendingHideHandler = null;
+    }
+
     function setPreviewVisible(visible, trigger) {
         const card = S.dom.chatAvatarPreviewCard;
         if (!card) return;
 
         if (visible) {
+            // 进场前把可能残留的退场监听清干净，避免刚打开又被 finalize 为 hidden
+            cancelPendingHide(card);
+
             // 切换触发按钮的激活态
             if (activeTrigger && activeTrigger !== trigger) {
                 activeTrigger.classList.remove('is-active');
@@ -182,9 +201,29 @@
                 card.classList.add('is-visible');
             });
         } else {
+            // 已经隐藏或正在隐藏 → 幂等退出
+            if (card.hidden) return;
+            if (pendingHideHandler) return;
+
             card.classList.remove('is-visible');
-            card.hidden = true;
             clearTriggerActive();
+
+            const finalizeHide = function () {
+                if (pendingHideTimer) {
+                    clearTimeout(pendingHideTimer);
+                    pendingHideTimer = null;
+                }
+                card.removeEventListener('transitionend', finalizeHide);
+                pendingHideHandler = null;
+                // 可能在等待过渡期间又被重新打开；若已重新可见则不要强制 hidden
+                if (!card.classList.contains('is-visible')) {
+                    card.hidden = true;
+                }
+            };
+
+            pendingHideHandler = finalizeHide;
+            card.addEventListener('transitionend', finalizeHide);
+            pendingHideTimer = window.setTimeout(finalizeHide, HIDE_TRANSITION_FALLBACK_MS);
         }
     }
 
@@ -676,6 +715,19 @@
     mod.setExternalAvatar = function setExternalAvatar(dataUrl, modelType) {
         externalAvatarDataUrl = dataUrl || '';
         externalAvatarModelType = modelType || '';
+
+        // 把 IPC 注入的头像合并进 cachedPreview，让 renderAvatarPreview 的快路径直接命中，
+        // 避免弹窗打开时再发一次 IPC（可能超时 → 用户看到失败态）。
+        if (externalAvatarDataUrl) {
+            cachedPreview = {
+                cacheKey: getCurrentModelCacheKey(),
+                dataUrl: externalAvatarDataUrl,
+                modelType: externalAvatarModelType || getCurrentModelType(),
+                capturedAt: Date.now()
+            };
+            saveToStorage(cachedPreview);
+        }
+
         // 如果弹窗已打开且本地没有本窗口可采集的模型，就直接把 IPC 数据显示出来。
         const card = S.dom && S.dom.chatAvatarPreviewCard;
         const hasLocalPortrait = !!(window.avatarPortrait && typeof window.avatarPortrait.capture === 'function');

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -98,21 +98,105 @@
         return 'Live2D';
     }
 
-    function setPreviewVisible(visible) {
+    // 当前打开弹窗的触发按钮（用于定位 + 激活态）
+    let activeTrigger = null;
+
+    function clearTriggerActive() {
+        if (activeTrigger) {
+            activeTrigger.classList.remove('is-active');
+        }
+        activeTrigger = null;
+    }
+
+    /**
+     * 计算并设置弹窗相对触发按钮的位置。
+     * 默认在按钮下方右对齐；空间不足时翻转到上方；始终限制在视口内。
+     */
+    function positionPopupNearTrigger(popup, trigger) {
+        const margin = 8;
+        const viewportW = window.innerWidth;
+        const viewportH = window.innerHeight;
+
+        // 把弹窗移到不可见区域做精准尺寸测量，临时关闭 transform 以便 offsetWidth 反映真实布局尺寸
+        popup.style.left = '-9999px';
+        popup.style.top = '-9999px';
+        popup.style.transform = 'none';
+        popup.style.transformOrigin = '';
+
+        const popupW = popup.offsetWidth || 320;
+        const popupH = popup.offsetHeight || 220;
+
+        // 恢复 transform：is-visible 切换时才播放动画；此时清回空字符串，让 CSS 规则生效
+        popup.style.transform = '';
+
+        let anchorRect = null;
+        if (trigger && typeof trigger.getBoundingClientRect === 'function') {
+            anchorRect = trigger.getBoundingClientRect();
+        }
+
+        // 无触发按钮（例如通过 API 直接调用）：居中显示
+        if (!anchorRect || (anchorRect.width === 0 && anchorRect.height === 0)) {
+            const left = Math.max(margin, Math.round((viewportW - popupW) / 2));
+            const top = Math.max(margin, Math.round((viewportH - popupH) / 2));
+            popup.style.left = left + 'px';
+            popup.style.top = top + 'px';
+            popup.style.transformOrigin = 'center center';
+            return;
+        }
+
+        // 优先：按钮下方右对齐
+        let top = anchorRect.bottom + margin;
+        let openUpward = false;
+        if (top + popupH > viewportH - margin && anchorRect.top - margin - popupH >= margin) {
+            top = anchorRect.top - margin - popupH;
+            openUpward = true;
+        }
+        top = Math.max(margin, Math.min(top, viewportH - popupH - margin));
+
+        let left = anchorRect.right - popupW;
+        left = Math.max(margin, Math.min(left, viewportW - popupW - margin));
+
+        popup.style.left = left + 'px';
+        popup.style.top = top + 'px';
+        popup.style.transformOrigin = openUpward ? 'bottom right' : 'top right';
+    }
+
+    function setPreviewVisible(visible, trigger) {
         const card = S.dom.chatAvatarPreviewCard;
-        const button = S.dom.avatarPreviewButton;
-        if (!card || !button) return;
-        card.hidden = !visible;
-        button.classList.toggle('is-active', visible);
+        if (!card) return;
+
+        if (visible) {
+            // 切换触发按钮的激活态
+            if (activeTrigger && activeTrigger !== trigger) {
+                activeTrigger.classList.remove('is-active');
+            }
+            activeTrigger = trigger || activeTrigger || null;
+            if (activeTrigger) {
+                activeTrigger.classList.add('is-active');
+            }
+
+            card.hidden = false;
+            positionPopupNearTrigger(card, activeTrigger);
+            // 触发进入动画（下一帧应用 is-visible）
+            window.requestAnimationFrame(function () {
+                card.classList.add('is-visible');
+            });
+        } else {
+            card.classList.remove('is-visible');
+            card.hidden = true;
+            clearTriggerActive();
+        }
     }
 
     function setLoadingState(loading) {
-        const button = S.dom.avatarPreviewButton;
+        const legacyButton = S.dom.avatarPreviewButton;
+        const headerButton = S.dom.avatarPreviewHeaderButton;
         const refreshButton = S.dom.chatAvatarPreviewRefreshButton;
-        if (button) {
-            button.classList.toggle('is-loading', loading);
-            button.disabled = loading;
-        }
+        [legacyButton, headerButton].forEach(function (btn) {
+            if (!btn) return;
+            btn.classList.toggle('is-loading', loading);
+            btn.disabled = loading;
+        });
         if (refreshButton) {
             refreshButton.disabled = loading;
         }
@@ -150,11 +234,9 @@
         shell.classList.add('is-empty');
     }
 
+    // 作为独立弹窗后不再要求输入区可见；保留函数以便将来需要判断上下文。
     function isInlinePreviewAvailable() {
-        const textInputArea = S.dom.textInputArea || document.getElementById('text-input-area');
-        if (!textInputArea) return false;
-        if (textInputArea.classList.contains('hidden')) return false;
-        return window.getComputedStyle(textInputArea).display !== 'none';
+        return true;
     }
 
     function getCurrentModelType() {
@@ -235,47 +317,82 @@
         lastScheduledCacheKey = '';
     }
 
-    async function captureAvatarPreview() {
-        if (!window.avatarPortrait || typeof window.avatarPortrait.capture !== 'function') {
-            throw new Error(translateLabel('chat.avatarPreviewUnavailable', '头像预览功能尚未就绪。'));
-        }
-
-        return window.avatarPortrait.capture({
-            width: 320,
-            height: 320,
-            padding: 0.035,
-            shape: 'rounded',
-            radius: 40,
-            background: 'rgba(255, 255, 255, 0.96)',
-            includeDataUrl: true
+    /**
+     * 从 Pet 窗口（Electron 多窗口模式）通过 IPC 请求头像预览。
+     */
+    function captureAvatarPreviewViaIpc() {
+        return new Promise(function (resolve, reject) {
+            var finished = false;
+            var timerId = null;
+            function cleanup() {
+                window.removeEventListener('neko:avatar-preview-ipc-result', onResult);
+                if (timerId) { clearTimeout(timerId); timerId = null; }
+            }
+            function onResult(event) {
+                if (finished) return;
+                finished = true;
+                cleanup();
+                var detail = event && event.detail;
+                if (detail && detail.dataUrl) {
+                    resolve({ dataUrl: detail.dataUrl, modelType: detail.modelType || '' });
+                } else {
+                    reject(new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败')));
+                }
+            }
+            window.addEventListener('neko:avatar-preview-ipc-result', onResult);
+            timerId = setTimeout(function () {
+                if (finished) return;
+                finished = true;
+                cleanup();
+                reject(new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败')));
+            }, 10000);
+            try {
+                window.__nekoRequestAvatarPreview();
+            } catch (err) {
+                if (!finished) {
+                    finished = true;
+                    cleanup();
+                    reject(err);
+                }
+            }
         });
+    }
+
+    async function captureAvatarPreview() {
+        // 优先使用本地 avatarPortrait（index.html）；chat.html 里回退到 IPC。
+        if (window.avatarPortrait && typeof window.avatarPortrait.capture === 'function') {
+            return window.avatarPortrait.capture({
+                width: 320,
+                height: 320,
+                padding: 0.035,
+                shape: 'rounded',
+                radius: 40,
+                background: 'rgba(255, 255, 255, 0.96)',
+                includeDataUrl: true
+            });
+        }
+        if (window.__NEKO_MULTI_WINDOW__ && typeof window.__nekoRequestAvatarPreview === 'function') {
+            return captureAvatarPreviewViaIpc();
+        }
+        throw new Error(translateLabel('chat.avatarPreviewUnavailable', '头像预览功能尚未就绪。'));
     }
 
     async function renderAvatarPreview(options = {}) {
         const forceRefresh = options.forceRefresh === true;
         const showCard = options.showCard !== false;
-        const skipInputCheck = options.skipInputCheck === true;
         const silent = options.silent === true;
+        const trigger = options.trigger || null;
 
         if (isCapturing) {
-            if (skipInputCheck && silent) {
+            if (!showCard && silent) {
                 pendingAutoCapture = true;
-            }
-            return;
-        }
-        if (!skipInputCheck && !isInlinePreviewAvailable()) {
-            if (typeof window.showStatusToast === 'function') {
-                window.showStatusToast(
-                    translateLabel('chat.avatarPreviewInputHidden', '当前输入区已隐藏，请回到文字聊天界面后再查看头像。'),
-                    3500
-                );
             }
             return;
         }
 
         if (!forceRefresh && hasUsableCachedPreview()) {
             if (showCard) {
-                setPreviewVisible(true);
+                setPreviewVisible(true, trigger);
             }
             setPreviewImage(cachedPreview.dataUrl);
             setPreviewStatus(
@@ -289,7 +406,7 @@
         const token = ++activeCaptureToken;
         const cacheKey = getCurrentModelCacheKey();
         if (showCard) {
-            setPreviewVisible(true);
+            setPreviewVisible(true, trigger);
         }
         setLoadingState(true);
         setPreviewStatus(forceRefresh
@@ -354,7 +471,6 @@
                         forceRefresh: true,
                         silent: true,
                         showCard: false,
-                        skipInputCheck: true,
                         reason: reason || 'model-loaded'
                     }).catch(function (error) {
                         console.warn('[app-chat-avatar] 自动缓存头像失败:', error);
@@ -392,17 +508,51 @@
 
     function handleOutsidePointer(event) {
         const card = S.dom.chatAvatarPreviewCard;
-        const button = S.dom.avatarPreviewButton;
         if (!card || card.hidden) return;
-        if (card.contains(event.target) || (button && button.contains(event.target))) {
-            return;
+        if (card.contains(event.target)) return;
+        // 点在任一已注册的触发按钮上 → 由触发按钮自己处理（点击切换）
+        for (const trigger of triggerButtons) {
+            if (trigger && trigger.contains(event.target)) return;
         }
         setPreviewVisible(false);
     }
 
+    function handleEscapeKey(event) {
+        if (event.key !== 'Escape') return;
+        const card = S.dom.chatAvatarPreviewCard;
+        if (!card || card.hidden) return;
+        setPreviewVisible(false);
+    }
+
+    function handleViewportChange() {
+        const card = S.dom.chatAvatarPreviewCard;
+        if (!card || card.hidden || !activeTrigger) return;
+        positionPopupNearTrigger(card, activeTrigger);
+    }
+
+    // 已绑定的触发按钮集合（供外点击判断使用）
+    const triggerButtons = new Set();
+
+    function bindTriggerButton(button) {
+        if (!button || triggerButtons.has(button)) return;
+        triggerButtons.add(button);
+        button.addEventListener('click', function (event) {
+            event.stopPropagation();
+            const card = S.dom.chatAvatarPreviewCard;
+            // 同一触发按钮再次点击 → 关闭弹窗
+            if (card && !card.hidden && activeTrigger === button) {
+                setPreviewVisible(false);
+                return;
+            }
+            renderAvatarPreview({ trigger: button });
+        });
+    }
+
     mod.init = function init() {
         S.dom.avatarPreviewButton = document.getElementById('avatarPreviewButton');
-        S.dom.chatAvatarPreviewCard = document.getElementById('chat-avatar-preview-card');
+        S.dom.avatarPreviewHeaderButton = document.getElementById('avatarPreviewHeaderButton');
+        // 保留旧字段名 chatAvatarPreviewCard 以兼容其他代码；实际指向新弹窗元素。
+        S.dom.chatAvatarPreviewCard = document.getElementById('chat-avatar-preview-popup');
         S.dom.chatAvatarPreviewStatus = document.getElementById('chat-avatar-preview-status');
         S.dom.chatAvatarPreviewNote = document.getElementById('chat-avatar-preview-note');
         S.dom.chatAvatarPreviewImageShell = document.getElementById('chat-avatar-preview-image-shell');
@@ -448,22 +598,22 @@
         // 清理已删除角色的残留头像（不阻塞初始化）
         purgeOrphanedAvatars();
 
-        // —— UI 层：仅在预览卡片存在时绑定（index.html） ——
-
-        const button = S.dom.avatarPreviewButton;
+        // —— UI 层：独立弹窗绑定 ——
+        // 弹窗 DOM 在 chat.html / index.html 中都存在；避免重复绑定。
+        const popup = S.dom.chatAvatarPreviewCard;
         const refreshButton = S.dom.chatAvatarPreviewRefreshButton;
         const closeButton = S.dom.chatAvatarPreviewCloseButton;
 
-        if (!button || !refreshButton || !closeButton) {
+        if (!popup || !refreshButton || !closeButton) {
             return;
         }
 
-        button.addEventListener('click', function () {
-            renderAvatarPreview();
-        });
+        // 触发按钮：老版 index.html 聊天面板内的按钮 + 新版 React 聊天头部按钮
+        bindTriggerButton(S.dom.avatarPreviewButton);
+        bindTriggerButton(S.dom.avatarPreviewHeaderButton);
 
         refreshButton.addEventListener('click', function () {
-            renderAvatarPreview({ forceRefresh: true });
+            renderAvatarPreview({ forceRefresh: true, trigger: activeTrigger });
         });
 
         closeButton.addEventListener('click', function () {
@@ -471,6 +621,30 @@
         });
 
         document.addEventListener('pointerdown', handleOutsidePointer, true);
+        document.addEventListener('keydown', handleEscapeKey);
+        window.addEventListener('resize', handleViewportChange);
+        window.addEventListener('scroll', handleViewportChange, true);
+    };
+
+    /**
+     * 外部 API：允许其他模块（如 React 聊天窗口）手动打开弹窗。
+     * @param {HTMLElement} [trigger] - 触发按钮，用于定位
+     * @param {Object} [options]
+     */
+    mod.showPopup = function showPopup(trigger, options) {
+        const opts = Object.assign({ trigger: trigger || null }, options || {});
+        return renderAvatarPreview(opts);
+    };
+
+    mod.hidePopup = function hidePopup() {
+        setPreviewVisible(false);
+    };
+
+    /**
+     * 外部 API：让其他脚本追加触发按钮（例如动态生成的 DOM）。
+     */
+    mod.registerTrigger = function registerTrigger(button) {
+        bindTriggerButton(button);
     };
 
     mod.getCachedPreview = function getCachedPreview() {
@@ -502,6 +676,16 @@
     mod.setExternalAvatar = function setExternalAvatar(dataUrl, modelType) {
         externalAvatarDataUrl = dataUrl || '';
         externalAvatarModelType = modelType || '';
+        // 如果弹窗已打开且本地没有本窗口可采集的模型，就直接把 IPC 数据显示出来。
+        const card = S.dom && S.dom.chatAvatarPreviewCard;
+        const hasLocalPortrait = !!(window.avatarPortrait && typeof window.avatarPortrait.capture === 'function');
+        if (externalAvatarDataUrl && card && !card.hidden && !hasLocalPortrait) {
+            setPreviewImage(externalAvatarDataUrl);
+            setPreviewStatus(
+                translateLabel('chat.avatarPreviewReady', '头像已更新') + ' · ' + normalizeModelLabel(externalAvatarModelType)
+            );
+            setPreviewNote(translateLabel('chat.avatarPreviewReadyHint', '这是从当前模型画布实时提取的头像预览。'));
+        }
         window.dispatchEvent(new CustomEvent('chat-avatar-preview-updated', {
             detail: { dataUrl: externalAvatarDataUrl, modelType: externalAvatarModelType, source: 'ipc' }
         }));

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -165,6 +165,14 @@
     const HIDE_TRANSITION_FALLBACK_MS = 220;
     let pendingHideTimer = null;
     let pendingHideHandler = null;
+    let pendingShowRaf = null;
+
+    function cancelPendingShow() {
+        if (pendingShowRaf) {
+            window.cancelAnimationFrame(pendingShowRaf);
+            pendingShowRaf = null;
+        }
+    }
 
     function cancelPendingHide(card) {
         if (pendingHideTimer) {
@@ -184,6 +192,8 @@
         if (visible) {
             // 进场前把可能残留的退场监听清干净，避免刚打开又被 finalize 为 hidden
             cancelPendingHide(card);
+            // 也清掉可能排队但尚未执行的进场 rAF，确保 is-visible 只被加一次
+            cancelPendingShow();
 
             // 切换触发按钮的激活态
             if (activeTrigger && activeTrigger !== trigger) {
@@ -197,13 +207,18 @@
             card.hidden = false;
             positionPopupNearTrigger(card, activeTrigger);
             // 触发进入动画（下一帧应用 is-visible）
-            window.requestAnimationFrame(function () {
+            pendingShowRaf = window.requestAnimationFrame(function () {
+                pendingShowRaf = null;
+                // 守卫：如果这一帧之前已被切换到隐藏状态，就不要再加回 is-visible
+                if (card.hidden) return;
                 card.classList.add('is-visible');
             });
         } else {
             // 已经隐藏或正在隐藏 → 幂等退出
             if (card.hidden) return;
             if (pendingHideHandler) return;
+            // 关键：关闭时先取消任何尚未执行的进场 rAF，否则它会把 is-visible 加回来
+            cancelPendingShow();
 
             card.classList.remove('is-visible');
             clearTriggerActive();

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -766,13 +766,15 @@
 
     function handleAvatarGeneratorClick() {
         try {
-            // Prefer legacy button if it exists (index.html); absent in chat.html
-            var legacyBtn = document.getElementById('avatarPreviewButton');
-            if (legacyBtn) {
-                legacyBtn.click();
+            // 统一走独立头像预览弹窗；弹窗模块自行处理缓存与 IPC 回退。
+            if (window.appChatAvatar && typeof window.appChatAvatar.showPopup === 'function') {
+                var anchor = document.getElementById('avatarPreviewHeaderButton')
+                    || document.getElementById('avatarPreviewButton')
+                    || null;
+                window.appChatAvatar.showPopup(anchor);
                 return;
             }
-            // React-first mode or standalone chat window — capture directly
+            // 极端兜底：弹窗模块加载失败时仍保持原有直采逻辑。
             captureAvatarDirect();
         } finally {
             dispatchHostEvent('avatar-generator-click', {});
@@ -1531,14 +1533,12 @@
                 toggleMinimized();
             });
         }
+        // Note: the avatarPreviewHeaderButton click is bound by app-chat-avatar.js
+        // (it owns the standalone avatar preview popup and toggling behavior).
+        // We only fire the host event here for external listeners/analytics.
         if (avatarHeaderButton) {
-            avatarHeaderButton.addEventListener('click', function (event) {
-                event.stopPropagation();
-                // Notify external listeners/analytics/extensions first
+            avatarHeaderButton.addEventListener('click', function () {
                 dispatchHostEvent('avatar-generator-click', {});
-                // Always use direct capture — the legacy avatarPreviewButton opens
-                // the old-chat preview card which is hidden behind the React overlay.
-                captureAvatarDirect();
             });
         }
         if (backdrop) {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1069,22 +1069,51 @@ body.react-chat-window-dragging {
     display: none;
 }
 
-#chat-avatar-preview-card {
+/* 独立头像预览弹窗（chat.html / index.html 共用）
+   作为一个浮动窗口定位在触发按钮附近。 */
+#chat-avatar-preview-popup {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 320px;
+    max-width: calc(100vw - 24px);
     display: flex;
     flex-direction: column;
     gap: 12px;
-    padding: 12px;
+    padding: 14px;
     border-radius: 16px;
-    border: 1px solid rgba(68, 183, 254, 0.18);
+    border: 1px solid rgba(68, 183, 254, 0.22);
     background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(247, 250, 252, 0.92));
+        linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 250, 252, 0.96));
     box-shadow:
-        0 8px 22px rgba(33, 95, 144, 0.08),
+        0 20px 48px rgba(12, 20, 34, 0.24),
+        0 8px 22px rgba(33, 95, 144, 0.12),
         inset 0 1px 0 rgba(255, 255, 255, 0.72);
+    z-index: 100010;
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+    transform-origin: top right;
+    transition: opacity 0.16s ease, transform 0.18s cubic-bezier(0.2, 0, 0, 1);
+    pointer-events: auto;
 }
 
-#chat-avatar-preview-card[hidden] {
+#chat-avatar-preview-popup.is-visible {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+#chat-avatar-preview-popup[hidden] {
     display: none !important;
+}
+
+[data-theme="dark"] #chat-avatar-preview-popup {
+    border-color: rgba(68, 183, 254, 0.28);
+    background:
+        linear-gradient(180deg, rgba(30, 38, 52, 0.96), rgba(22, 28, 40, 0.96));
+    box-shadow:
+        0 20px 48px rgba(0, 0, 0, 0.5),
+        0 8px 22px rgba(0, 0, 0, 0.28),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .chat-avatar-preview-card-header {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -438,6 +438,27 @@
         </div>
     </div>
 
+    <!-- 独立头像预览弹窗（chat.html / index.html 共用）-->
+    <div id="chat-avatar-preview-popup" class="chat-avatar-preview-popup" role="dialog" aria-modal="false" aria-labelledby="chat-avatar-preview-popup-title" hidden>
+        <div class="chat-avatar-preview-card-header">
+            <div class="chat-avatar-preview-card-title-group">
+                <div id="chat-avatar-preview-popup-title" class="chat-avatar-preview-card-title" data-i18n="chat.avatarPreviewCardTitle">当前头像</div>
+                <div id="chat-avatar-preview-status" class="chat-avatar-preview-card-status" data-i18n="chat.avatarPreviewCardStatus">点击上方按钮生成当前模型头像</div>
+            </div>
+            <button id="chatAvatarPreviewCloseButton" class="chat-avatar-preview-card-close" type="button" data-i18n-title="chat.avatarPreviewClose" data-i18n-aria="chat.avatarPreviewClose" aria-label="关闭头像预览">×</button>
+        </div>
+        <div class="chat-avatar-preview-card-body">
+            <div id="chat-avatar-preview-image-shell" class="chat-avatar-preview-image-shell is-empty">
+                <img id="chat-avatar-preview-image" class="chat-avatar-preview-image" data-i18n-alt="chat.avatarPreviewImageAlt" alt="当前头像预览" hidden>
+                <div id="chat-avatar-preview-placeholder" class="chat-avatar-preview-placeholder" data-i18n="chat.avatarPreviewPlaceholder">AVATAR</div>
+            </div>
+            <div class="chat-avatar-preview-card-meta">
+                <div id="chat-avatar-preview-note" class="chat-avatar-preview-card-note" data-i18n="chat.avatarPreviewCardNote">将基于当前显示中的 Live2D / VRM / MMD 模型生成头像。</div>
+                <button id="chatAvatarPreviewRefreshButton" class="chat-avatar-preview-refresh-btn" type="button" data-i18n="chat.avatarPreviewRefresh">刷新头像</button>
+            </div>
+        </div>
+    </div>
+
     <!-- 跳过：Live2D/VRM/Three.js、common_ui.js(DOM拖拽不兼容)、touch-config、tutorial -->
     <script src="/static/libs/ogg-opus-decoder.min.js"></script>
     <script src="/static/music_ui.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,25 +98,6 @@
                     <!-- 截图项将动态添加到这里 -->
                 </div>
             </div>
-            <div id="chat-avatar-preview-card" hidden>
-                <div class="chat-avatar-preview-card-header">
-                    <div class="chat-avatar-preview-card-title-group">
-                        <div class="chat-avatar-preview-card-title" data-i18n="chat.avatarPreviewCardTitle">当前头像</div>
-                        <div id="chat-avatar-preview-status" class="chat-avatar-preview-card-status" data-i18n="chat.avatarPreviewCardStatus">点击上方按钮生成当前模型头像</div>
-                    </div>
-                    <button id="chatAvatarPreviewCloseButton" class="chat-avatar-preview-card-close" type="button" data-i18n-title="chat.avatarPreviewClose" data-i18n-aria="chat.avatarPreviewClose">×</button>
-                </div>
-                <div class="chat-avatar-preview-card-body">
-                    <div id="chat-avatar-preview-image-shell" class="chat-avatar-preview-image-shell is-empty">
-                        <img id="chat-avatar-preview-image" class="chat-avatar-preview-image" data-i18n-alt="chat.avatarPreviewImageAlt" alt="当前头像预览" hidden>
-                        <div id="chat-avatar-preview-placeholder" class="chat-avatar-preview-placeholder" data-i18n="chat.avatarPreviewPlaceholder">AVATAR</div>
-                    </div>
-                    <div class="chat-avatar-preview-card-meta">
-                        <div id="chat-avatar-preview-note" class="chat-avatar-preview-card-note" data-i18n="chat.avatarPreviewCardNote">将基于当前显示中的 Live2D / VRM / MMD 模型生成头像。</div>
-                        <button id="chatAvatarPreviewRefreshButton" class="chat-avatar-preview-refresh-btn" type="button" data-i18n="chat.avatarPreviewRefresh">刷新头像</button>
-                    </div>
-                </div>
-            </div>
             <div id="text-input-row">
                 <textarea id="textInputBox" data-i18n-placeholder="chat.textInputPlaceholder"
                     placeholder="文字聊天模式...回车发送，Shift+回车换行" tabindex="0"></textarea>
@@ -178,6 +159,26 @@
                 <button id="reactChatWindowCloseButton" type="button" data-i18n-aria="chat.reactWindowClose" data-i18n-title="chat.reactWindowClose">×</button>
             </div>
             <div id="react-chat-window-root"></div>
+        </div>
+    </div>
+    <!-- 独立头像预览弹窗（chat.html / index.html 共用）-->
+    <div id="chat-avatar-preview-popup" class="chat-avatar-preview-popup" role="dialog" aria-modal="false" aria-labelledby="chat-avatar-preview-popup-title" hidden>
+        <div class="chat-avatar-preview-card-header">
+            <div class="chat-avatar-preview-card-title-group">
+                <div id="chat-avatar-preview-popup-title" class="chat-avatar-preview-card-title" data-i18n="chat.avatarPreviewCardTitle">当前头像</div>
+                <div id="chat-avatar-preview-status" class="chat-avatar-preview-card-status" data-i18n="chat.avatarPreviewCardStatus">点击上方按钮生成当前模型头像</div>
+            </div>
+            <button id="chatAvatarPreviewCloseButton" class="chat-avatar-preview-card-close" type="button" data-i18n-title="chat.avatarPreviewClose" data-i18n-aria="chat.avatarPreviewClose" aria-label="关闭头像预览">×</button>
+        </div>
+        <div class="chat-avatar-preview-card-body">
+            <div id="chat-avatar-preview-image-shell" class="chat-avatar-preview-image-shell is-empty">
+                <img id="chat-avatar-preview-image" class="chat-avatar-preview-image" data-i18n-alt="chat.avatarPreviewImageAlt" alt="当前头像预览" hidden>
+                <div id="chat-avatar-preview-placeholder" class="chat-avatar-preview-placeholder" data-i18n="chat.avatarPreviewPlaceholder">AVATAR</div>
+            </div>
+            <div class="chat-avatar-preview-card-meta">
+                <div id="chat-avatar-preview-note" class="chat-avatar-preview-card-note" data-i18n="chat.avatarPreviewCardNote">将基于当前显示中的 Live2D / VRM / MMD 模型生成头像。</div>
+                <button id="chatAvatarPreviewRefreshButton" class="chat-avatar-preview-refresh-btn" type="button" data-i18n="chat.avatarPreviewRefresh">刷新头像</button>
+            </div>
         </div>
     </div>
     <div id="live2d-container">


### PR DESCRIPTION
- 把 #chat-avatar-preview-card 从 #chat-container > #text-input-area 移出，重命名为 #chat-avatar-preview-popup，作为顶层浮动面板，z-index 高于 React 聊天窗口
- 在 chat.html 里新增同样的弹窗 DOM，使新版 React 聊天框也能弹出头像预览（截图里的"当前头像"窗口）
- app-chat-avatar.js 重构：新增按触发按钮定位、视口翻转、点击切换、ESC 关闭、窗口 resize/scroll 跟随；暴露 showPopup/hidePopup/registerTrigger 公共 API；captureAvatarPreview 支持 Electron 多窗口 IPC 回退
- app-react-chat-window.js 不再自绑 avatarPreviewHeaderButton 的捕获逻辑，改为委托给独立弹窗模块，仅保留 host event 分发
- 新增弹窗 CSS（含暗色模式），复用原卡片内部样式类

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 头像预览改为独立浮动弹窗，支持外部接口显示/隐藏并可注册触发按钮
  * 支持外部注入头像并合并持久化，弹窗开启时可即时刷新显示

* **改进**
  * 始终可用的内联预览入口；优先本地抓取，跨窗口场景有超时回退
  * 智能定位与翻转，自动约束至视窗并在调整/滚动时实时重定位
  * 改善加载/禁用状态、Escape 关闭与外部点击行为优化，避免显示状态竞争

* **样式**
  * 新版弹窗视觉与深色主题样式，加入淡入/位移动画
<!-- end of auto-generated comment: release notes by coderabbit.ai -->