### PR TITLE
fix: 修复 Live2D/VRM 反复切换后再换回 VRM 模型加载不出来的问题

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -518,84 +518,81 @@
 
                 // 确保 VRM 管理器已初始化
                 console.log('[猫娘切换] 检查VRM管理器 - 存在:', !!window.vrmManager, '已初始化:', window.vrmManager?._isInitialized);
-                if (!window.vrmManager || !window.vrmManager._isInitialized) {
-                    console.log('[猫娘切换] VRM管理器需要初始化');
 
-                    // 等待 VRM 模块加载（双保险：事件 + 轮询）
-                    if (typeof window.VRMManager === 'undefined') {
-                        await new Promise((resolve, reject) => {
-                            // 先检查是否已经就绪（事件可能已经发出）
-                            if (window.VRMManager) {
-                                return resolve();
+                // 等待 VRM 模块加载（双保险：事件 + 轮询）
+                if (typeof window.VRMManager === 'undefined') {
+                    await new Promise((resolve, reject) => {
+                        // 先检查是否已经就绪（事件可能已经发出）
+                        if (window.VRMManager) {
+                            return resolve();
+                        }
+
+                        let resolved = false;
+                        const timeoutId = setTimeout(() => {
+                            if (!resolved) {
+                                resolved = true;
+                                reject(new Error('VRM 模块加载超时'));
                             }
+                        }, 5000);
 
-                            let resolved = false;
-                            const timeoutId = setTimeout(() => {
+                        // 方法1：监听事件
+                        const eventHandler = () => {
+                            if (!resolved && window.VRMManager) {
+                                resolved = true;
+                                clearTimeout(timeoutId);
+                                window.removeEventListener('vrm-modules-ready', eventHandler);
+                                resolve();
+                            }
+                        };
+                        window.addEventListener('vrm-modules-ready', eventHandler, { once: true });
+
+                        // 方法2：轮询检查（双保险）
+                        const pollInterval = setInterval(() => {
+                            if (window.VRMManager) {
                                 if (!resolved) {
                                     resolved = true;
-                                    reject(new Error('VRM 模块加载超时'));
-                                }
-                            }, 5000);
-
-                            // 方法1：监听事件
-                            const eventHandler = () => {
-                                if (!resolved && window.VRMManager) {
-                                    resolved = true;
                                     clearTimeout(timeoutId);
+                                    clearInterval(pollInterval);
                                     window.removeEventListener('vrm-modules-ready', eventHandler);
                                     resolve();
                                 }
-                            };
-                            window.addEventListener('vrm-modules-ready', eventHandler, { once: true });
+                            }
+                        }, 100); // 每100ms检查一次
 
-                            // 方法2：轮询检查（双保险）
-                            const pollInterval = setInterval(() => {
-                                if (window.VRMManager) {
-                                    if (!resolved) {
-                                        resolved = true;
-                                        clearTimeout(timeoutId);
-                                        clearInterval(pollInterval);
-                                        window.removeEventListener('vrm-modules-ready', eventHandler);
-                                        resolve();
-                                    }
-                                }
-                            }, 100); // 每100ms检查一次
+                        // 清理轮询（在超时或成功时）
+                        const originalResolve = resolve;
+                        const originalReject = reject;
+                        resolve = (...args) => {
+                            clearInterval(pollInterval);
+                            originalResolve(...args);
+                        };
+                        reject = (...args) => {
+                            clearInterval(pollInterval);
+                            originalReject(...args);
+                        };
+                    });
+                }
 
-                            // 清理轮询（在超时或成功时）
-                            const originalResolve = resolve;
-                            const originalReject = reject;
-                            resolve = (...args) => {
-                                clearInterval(pollInterval);
-                                originalResolve(...args);
-                            };
-                            reject = (...args) => {
-                                clearInterval(pollInterval);
-                                originalReject(...args);
-                            };
-                        });
-                    }
+                if (!window.vrmManager) {
+                    window.vrmManager = new window.VRMManager();
+                }
+                // 每次都清除 goodbyeClicked 标志，确保新模型可以正常显示
+                window.vrmManager._goodbyeClicked = false;
 
-                    if (!window.vrmManager) {
-                        window.vrmManager = new window.VRMManager();
-                        // 初始化时确保 _goodbyeClicked 为 false
-                        window.vrmManager._goodbyeClicked = false;
-                    } else {
-                        // 如果 vrmManager 已存在，也清除 goodbyeClicked 标志，确保新模型可以正常显示
-                        window.vrmManager._goodbyeClicked = false;
-                    }
-
-                    // 确保容器和 canvas 存在
-                    const vrmContainer = document.getElementById('vrm-container');
-                    if (vrmContainer && !vrmContainer.querySelector('canvas')) {
+                // 确保容器和 canvas 存在，并初始化 Three.js 场景。
+                // 即使 vrmManager 已初始化也要调用 initThreeJS：在已初始化时是幂等的，
+                // 但会无条件恢复容器/canvas 可见性——修复在 Live2D/VRM 反复切换后，
+                // 容器/canvas 仍保持 display:none 导致 VRM 模型加载不出来的问题。
+                {
+                    const vrmContainerEl = document.getElementById('vrm-container');
+                    if (vrmContainerEl && !vrmContainerEl.querySelector('canvas')) {
                         const canvas = document.createElement('canvas');
                         canvas.id = 'vrm-canvas';
-                        vrmContainer.appendChild(canvas);
+                        vrmContainerEl.appendChild(canvas);
                     }
-
-                    // 初始化 Three.js 场景，传入光照配置（如果存在）
-                    const lightingConfig = catgirlConfig.lighting || null;
-                    await window.vrmManager.initThreeJS('vrm-canvas', 'vrm-container', lightingConfig);
                 }
+                const lightingConfig = catgirlConfig.lighting || null;
+                await window.vrmManager.initThreeJS('vrm-canvas', 'vrm-container', lightingConfig);
 
                 // 转换路径为 URL（基本格式处理，vrm-core.js 会处理备用路径）
                 // 再次验证 vrmModelPath 的有效性

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -520,10 +520,17 @@
                 console.log('[猫娘切换] 检查VRM管理器 - 存在:', !!window.vrmManager, '已初始化:', window.vrmManager?._isInitialized);
 
                 // 等待 VRM 模块加载（双保险：事件 + 轮询）
-                if (typeof window.VRMManager === 'undefined') {
+                // VRMManager 与 VRMCore 由 vrm-init.js 并行加载，加载顺序不确定；
+                // 只检查 VRMManager 会在 VRMCore 未就绪时放行，导致 initThreeJS
+                // 抛 "VRMCore 尚未加载"。因此就绪条件需同时覆盖两者。
+                const isVRMRuntimeReady = () =>
+                    typeof window.VRMManager !== 'undefined' &&
+                    typeof window.VRMCore !== 'undefined';
+
+                if (!isVRMRuntimeReady()) {
                     await new Promise((resolve, reject) => {
                         // 先检查是否已经就绪（事件可能已经发出）
-                        if (window.VRMManager) {
+                        if (isVRMRuntimeReady()) {
                             return resolve();
                         }
 
@@ -537,7 +544,7 @@
 
                         // 方法1：监听事件
                         const eventHandler = () => {
-                            if (!resolved && window.VRMManager) {
+                            if (!resolved && isVRMRuntimeReady()) {
                                 resolved = true;
                                 clearTimeout(timeoutId);
                                 window.removeEventListener('vrm-modules-ready', eventHandler);
@@ -548,7 +555,7 @@
 
                         // 方法2：轮询检查（双保险）
                         const pollInterval = setInterval(() => {
-                            if (window.VRMManager) {
+                            if (isVRMRuntimeReady()) {
                                 if (!resolved) {
                                     resolved = true;
                                     clearTimeout(timeoutId);

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -574,8 +574,24 @@ class VRMManager {
         }
         this._isDisposed = false;
 
+        // 恢复容器可见性：在 Live2D/VRM 之间反复切换时，cleanup 会把容器隐藏
+        // （display:none + 'hidden' class），若 _isInitialized 为 true，app-character.js
+        // 会跳过整个初始化块，导致下次切回 VRM 时容器仍不可见，新模型"加载不出来"。
+        // 这里无条件恢复，确保每次尝试初始化 VRM 时容器都是可见的。
+        const container = containerId ? document.getElementById(containerId) : null;
+        if (container) {
+            container.style.display = 'block';
+            container.style.visibility = 'visible';
+            container.style.opacity = '1';
+            container.classList.remove('hidden');
+        }
+
         // 检查是否已完全初始化（不仅检查 scene，还要检查 camera 和 renderer）
         if (this.scene && this.camera && this.renderer) {
+            // 恢复 renderer canvas 可见性（切换清理时会把 domElement 设为 display:none）
+            if (this.renderer.domElement) {
+                this.renderer.domElement.style.display = 'block';
+            }
             this._initMouseLookAtTracking();
             this._isInitialized = true;
             return true;


### PR DESCRIPTION
当前角色为 Live2D 时，反复切换其他角色再切换回来、最后把原角色改为 VRM，
VRM 会加载但界面看不见。根因：

- app-character.js 切换清理时把 vrm-container 设为 display:none 并加 hidden class，同时把 renderer.domElement 也设为 display:none，但并不会重置 vrmManager._isInitialized。
- 下次切回 VRM 时，若 _isInitialized 为 true，就会跳过整个 VRM 初始化块， initThreeJS 不被调用，容器与 canvas 仍处于隐藏状态。
- loadModel 内部只切 opacity，display:none 下 opacity 无效，模型看似"加载 不出来"。

修复：
- vrm-manager.js initThreeJS 顶部无条件恢复容器可见性（display/visibility /opacity/移除 hidden class），并在已初始化的早返回路径中恢复 renderer.domElement.style.display。
- app-character.js VRM 分支把 VRMManager 实例化/容器 canvas 准备/initThreeJS 调用搬出 _isInitialized 判断——initThreeJS 对已初始化状态是幂等的，这样 每次切回 VRM 都会走一次可见性恢复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 改进了虚拟形象的就绪检测与重试机制，提升在模块加载延迟或切换时的稳定性（包含超时保护）。
  * 优化了虚拟形象容器和渲染画布的显示逻辑，确保在切换或重新初始化后界面可见且交互可用。
* **其他**
  * 切换时重置了交互相关状态以保证一致的用户体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->