### PR TITLE
fix: 修复 VRM 模型加载时卡在 T-pose 的竞态问题

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -5296,8 +5296,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
 
             // 加载待机动作选项并恢复保存的选择（多选）
+            // 优先读取 snake_case `idle_animation`，这是主保存路径（见 line 1822）实际写入的字段；
+            // 再兼容历史的 `idleAnimations` / `idleAnimation`。与 restoreVrmIdleAnimation 保持一致，
+            // 否则我的 loadModel bootstrap (wait03) 会在此后无法被用户保存的 idle 列表覆盖。
             await loadIdleAnimationOptions();
-            let vrmIdleAnims = charData?.idleAnimations ?? charData?.idleAnimation;
+            let vrmIdleAnims = charData?.idle_animation ?? charData?.idleAnimations ?? charData?.idleAnimation;
             if (vrmIdleAnims != null) {
                 // 向前兼容: string -> array
                 if (typeof vrmIdleAnims === 'string') vrmIdleAnims = vrmIdleAnims ? [vrmIdleAnims] : [];

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -3073,19 +3073,15 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
 
                 // 使用 URL 加载模型，而不是本地文件路径（浏览器不允许加载 file:// 路径）
-                // 传入 { autoPlay: false } 以便在此处统一播放待机动画，避免先露出 T-pose
+                // 把 wait03 交给 loadModel 内部的 autoPlay 流水线，由它保证"先起动画、再淡入"，
+                // 避免外部 await 造成 showAndFadeIn 先于动画播放、让 T-pose 露出的竞态。
+                // 用户保存的 idle 选择由 loadCharacterLighting 恢复后通过 startIdleRotation 覆盖。
                 //增加 addShadow: false
                 // 【注意】朝向会自动从preferences中加载（在vrm-core.js的loadModel中处理）
-                await vrmManager.loadModel(modelUrl, { autoPlay: false, addShadow: false });
-                // 加载后立即播内置 wait03 防 T-pose; 用户保存的 idle 选择
-                // 由 loadCharacterLighting 恢复后通过 startIdleRotation 覆盖
-                if (vrmManager.animation) {
-                    try {
-                        await vrmManager.playVRMAAnimation('/static/vrm/animation/wait03.vrma', { loop: true, immediate: true, isIdle: true });
-                    } catch (e) {
-                        console.warn('[VRM] 播放 wait03 待机动画失败:', e);
-                    }
-                }
+                await vrmManager.loadModel(modelUrl, {
+                    addShadow: false,
+                    idleAnimation: '/static/vrm/animation/wait03.vrma'
+                });
                 // 加载新模型后，重置播放状态
                 isVrmAnimationPlaying = false;
                 updateVRMAnimationPlayButtonIcon();

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -831,6 +831,11 @@ class VRMManager {
         const loadToken = ++this._activeLoadToken;
         this._loadState = 'preparing';
         this._isModelReadyForInteraction = false;
+        // 新一轮加载：取消上一轮可能还在跑的 T-pose 回退重试，避免旧重试打断新模型动画
+        if (this._idleRecoveryTimerId) {
+            clearTimeout(this._idleRecoveryTimerId);
+            this._idleRecoveryTimerId = null;
+        }
         this._initModules();
         if (!this.core) this.core = new window.VRMCore(this);
 
@@ -953,15 +958,19 @@ class VRMManager {
         };
 
         // 加载待机动画（作为 Promise，与场景稳定性并行等待）
-        let animationReady = Promise.resolve();
+        // 返回 true 表示动画成功播放；false 表示模块未就绪或播放失败（需要后续回退重试）。
+        let animationReady = Promise.resolve(true);
+        let animationPlayed = false;
         if (options.autoPlay !== false) {
             animationReady = (async () => {
-                if (!this.currentModel || !this.currentModel.vrm) return;
+                if (!this.currentModel || !this.currentModel.vrm) return false;
 
-                let retries = 10;
+                // 放宽模块加载等待窗口（原 10×100ms = 1s 在慢速网络下会静默跳过，
+                // 导致模型以 T-pose 亮相），改为 30×100ms = 3s
+                let retries = 30;
                 while (retries > 0) {
-                    if (!this._isLoadTokenActive(loadToken)) return;
-                    if (!this.currentModel || !this.currentModel.vrm) return;
+                    if (!this._isLoadTokenActive(loadToken)) return false;
+                    if (!this.currentModel || !this.currentModel.vrm) return false;
 
                     if (!this.animation) this._initModules();
                     if (this.animation) break;
@@ -986,21 +995,24 @@ class VRMManager {
                 }
 
                 if (!this.animation) {
-                    console.warn('[VRM Manager] VRMAnimation 模块未加载，跳过自动播放');
-                    return;
+                    console.warn('[VRM Manager] VRMAnimation 模块未加载，稍后将后台重试以避免卡 T-pose');
+                    return false;
                 }
                 const currentLoadToken = this._activeLoadToken;
-                if (loadToken !== currentLoadToken) return;
+                if (loadToken !== currentLoadToken) return false;
 
                 try {
-                    if (!this._isLoadTokenActive(loadToken)) return;
+                    if (!this._isLoadTokenActive(loadToken)) return false;
                     await this.playVRMAAnimation(DEFAULT_LOOP_ANIMATION, {
                         loop: true,
                         immediate: true,
                         isIdle: true
                     });
+                    animationPlayed = true;
+                    return true;
                 } catch (err) {
-                    console.warn('[VRM Manager] 自动播放失败:', err);
+                    console.warn('[VRM Manager] 自动播放失败，稍后将后台重试以避免卡 T-pose:', err);
+                    return false;
                 }
             })();
         }
@@ -1022,7 +1034,7 @@ class VRMManager {
         const stabilityPromise = (result && result.vrm && result.vrm.scene && this._isLoadTokenActive(loadToken))
             ? this._waitForSceneStability(result.vrm.scene, loadToken)
             : Promise.resolve(false);
-        const [stabilityResult] = await Promise.all([stabilityPromise, animationReady]);
+        const [stabilityResult, animationSucceeded] = await Promise.all([stabilityPromise, animationReady]);
 
         if (this._isLoadTokenActive(loadToken) && stabilityResult === true) {
             this._loadState = 'ready';
@@ -1050,11 +1062,73 @@ class VRMManager {
             }));
 
             showAndFadeIn();
+
+            // T-pose 防卡死回退：autoPlay 未关闭、但首轮动画没播起来时（模块加载超时 / 播放抛错），
+            // 在后台周期性重试，直到成功播放或 loadToken 失效。这样即使 VRMAnimation 模块延迟加载
+            // 或网络抖动，模型最终也会脱离 T-pose 进入待机动画。
+            if (options.autoPlay !== false && animationSucceeded !== true && !animationPlayed) {
+                this._scheduleIdleAnimationRetry(loadToken, DEFAULT_LOOP_ANIMATION);
+            }
         } else if (this._isLoadTokenActive(loadToken)) {
             this._loadState = 'idle';
             this._isModelReadyForInteraction = false;
         }
         return result;
+    }
+
+    /**
+     * 在后台周期性重试待机动画，避免 VRMAnimation 模块加载慢/播放失败时模型卡在 T-pose。
+     * - 只要 loadToken 仍然有效（没有被新的 loadModel 替换），就会一直尝试。
+     * - 一旦 animation 模块就绪并成功触发 playVRMAAnimation，立即停止。
+     * - 用户手动播放了非 idle 动画时（isIdleAnimation=false 且有 currentAction）也会停止，不打扰手动操作。
+     */
+    _scheduleIdleAnimationRetry(loadToken, idleAnimationUrl) {
+        if (this._idleRecoveryTimerId) {
+            clearTimeout(this._idleRecoveryTimerId);
+            this._idleRecoveryTimerId = null;
+        }
+
+        const MAX_ATTEMPTS = 20;      // 最多尝试 20 次
+        const INTERVAL_MS = 500;      // 每次间隔 500ms -> 总计最长约 10s
+        let attempts = 0;
+
+        const attempt = async () => {
+            this._idleRecoveryTimerId = null;
+            // token 失效或已被 dispose：停止
+            if (this._isDisposed || !this._isLoadTokenActive(loadToken)) return;
+            if (!this.currentModel || !this.currentModel.vrm) return;
+
+            // 用户已经手动触发了其他动画（非 idle）：让位，停止重试
+            const anim = this.animation;
+            if (anim && anim.currentAction && anim.isIdleAnimation === false) return;
+            // 当前已经在播 idle：已经脱离 T-pose，停止重试
+            if (anim && anim.currentAction && anim.isIdleAnimation === true) return;
+
+            if (!this.animation) this._initModules();
+
+            if (this.animation) {
+                try {
+                    await this.playVRMAAnimation(idleAnimationUrl, {
+                        loop: true,
+                        immediate: true,
+                        isIdle: true
+                    });
+                    console.log('[VRM Manager] T-pose 回退重试成功，已切入待机动画');
+                    return; // 成功，结束
+                } catch (err) {
+                    console.warn('[VRM Manager] T-pose 回退重试播放失败:', err);
+                }
+            }
+
+            attempts += 1;
+            if (attempts >= MAX_ATTEMPTS) {
+                console.warn('[VRM Manager] T-pose 回退重试已达上限，放弃');
+                return;
+            }
+            this._idleRecoveryTimerId = setTimeout(attempt, INTERVAL_MS);
+        };
+
+        this._idleRecoveryTimerId = setTimeout(attempt, INTERVAL_MS);
     }
 
     async playVRMAAnimation(url, opts) {
@@ -1183,6 +1257,11 @@ class VRMManager {
         if (this._retryTimerId) {
             clearTimeout(this._retryTimerId);
             this._retryTimerId = null;
+        }
+        // 3b. 清理 T-pose 回退重试定时器
+        if (this._idleRecoveryTimerId) {
+            clearTimeout(this._idleRecoveryTimerId);
+            this._idleRecoveryTimerId = null;
         }
 
         // 4. 清理阴影资源

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -976,7 +976,6 @@ class VRMManager {
         // 加载待机动画（作为 Promise，与场景稳定性并行等待）
         // 返回 true 表示动画成功播放；false 表示模块未就绪或播放失败（需要后续回退重试）。
         let animationReady = Promise.resolve(true);
-        let animationPlayed = false;
         if (options.autoPlay !== false) {
             animationReady = (async () => {
                 if (!this.currentModel || !this.currentModel.vrm) return false;
@@ -1024,7 +1023,6 @@ class VRMManager {
                         immediate: true,
                         isIdle: true
                     });
-                    animationPlayed = true;
                     return true;
                 } catch (err) {
                     console.warn('[VRM Manager] 自动播放失败，稍后将后台重试以避免卡 T-pose:', err);
@@ -1082,7 +1080,7 @@ class VRMManager {
             // T-pose 防卡死回退：autoPlay 未关闭、但首轮动画没播起来时（模块加载超时 / 播放抛错），
             // 在后台周期性重试，直到成功播放或 loadToken 失效。这样即使 VRMAnimation 模块延迟加载
             // 或网络抖动，模型最终也会脱离 T-pose 进入待机动画。
-            if (options.autoPlay !== false && animationSucceeded !== true && !animationPlayed) {
+            if (options.autoPlay !== false && !animationSucceeded) {
                 this._scheduleIdleAnimationRetry(loadToken, DEFAULT_LOOP_ANIMATION);
             }
         } else if (this._isLoadTokenActive(loadToken)) {

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -1098,11 +1098,22 @@ class VRMManager {
             if (this._isDisposed || !this._isLoadTokenActive(loadToken)) return;
             if (!this.currentModel || !this.currentModel.vrm) return;
 
-            // 用户已经手动触发了其他动画（非 idle）：让位，停止重试
+            // 仅当动画"真正在运行"时才放弃重试：
+            // 单纯 currentAction 非 null 不能等同于正在播放——stopVRMAAnimation 用 500ms
+            // fadeOut 后才清空 currentAction；单次性 clip 播完后 currentAction 也会悬挂
+            // 指向已停止的 action。此时若提前 return，模型仍会卡在 T-pose。
             const anim = this.animation;
-            if (anim && anim.currentAction && anim.isIdleAnimation === false) return;
-            // 当前已经在播 idle：已经脱离 T-pose，停止重试
-            if (anim && anim.currentAction && anim.isIdleAnimation === true) return;
+            const actionRunning = !!(
+                anim
+                && anim.vrmaIsPlaying
+                && anim.currentAction
+                && typeof anim.currentAction.isRunning === 'function'
+                && anim.currentAction.isRunning()
+            );
+            if (actionRunning) {
+                // 无论是用户手动动画还是已在播的 idle，模型都已脱离 T-pose
+                return;
+            }
 
             if (!this.animation) this._initModules();
 


### PR DESCRIPTION
- model_manager.js 原先以 { autoPlay: false } 加载模型，再在 await 之后 外部调用 playVRMAAnimation 播放 wait03。由于 loadModel 在 autoPlay=false 时会让 animationReady 立即 resolve，场景稳定后 showAndFadeIn 会先于外部 动画播放执行，导致模型以 T-pose 亮相后才切入待机动画。改为把待机动画 路径通过新的 idleAnimation 选项交给 loadModel 内部流水线统一处理。

- vrm-manager.js 的 animationReady IIFE 在 VRMAnimation 模块加载超时 (原 10×100ms = 1s) 时会静默放弃，模型就一直卡在 T-pose 没有任何回退。 现放宽等待到 30×100ms = 3s，并在 showAndFadeIn 后追加一个后台重试 循环 (_scheduleIdleAnimationRetry)：只要模型尚未进入任何动画，就每 500ms 重试一次、最多 20 次，直到成功播放待机动画或被新的 loadModel 接管。dispose 与新一轮 loadModel 均会清理该定时器，避免旧回退打断 新模型。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 简化并稳定了 VRM 模型加载时的空闲动画流程，减少播放失败与重复尝试造成的可见延迟。
  * 引入明确的播放成功/失败判定与后台重试机制，确保空闲动画在可见时刻启动或有可靠重试。
  * 优化模型切换期间的定时器清理，防止先前加载任务干扰新模型的动画与状态。

* **New Features**
  * 优先读取并使用 charData.idle_animation 作为空闲动作来源，兼容旧字段。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->