### PR TITLE
fix: 重置 VRM/MMD 模型位置时同步复位相机，使模型稳定回到屏幕中央

### DIFF
--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -970,9 +970,16 @@ class MMDCore {
                 // 让模型在屏幕上占约 45% 高度
                 const distance = (modelHeight / 2) / Math.tan(fov / 2) / targetScreenHeight * screenHeight;
 
-                this.manager.camera.position.set(0, center.y, Math.abs(distance));
+                // 把相机锚定到 bounding box 中心，否则模型几何中心偏离世界原点时，
+                // 实际相机到目标的距离与 `distance` 不一致，复位构图会漂
+                this.manager.camera.position.set(center.x, center.y, center.z + Math.abs(distance));
                 this.manager.camera.lookAt(center.x, center.y, center.z);
                 this.manager.camera.updateProjectionMatrix();
+
+                if (this.manager.controls) {
+                    this.manager.controls.target.set(center.x, center.y, center.z);
+                    this.manager.controls.update();
+                }
             } catch (err) {
                 console.warn('[MMD Core] 重置相机失败，回退到初始机位:', err);
                 this.manager.camera.position.set(0, 10, 70);

--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -942,6 +942,8 @@ class MMDCore {
         const mmd = this.manager.currentModel;
         if (!mmd || !mmd.mesh) return;
 
+        const THREE = window.THREE;
+
         // 禁用物理，防止位置变更期间拉丝
         const hadPhysics = this.manager.enablePhysics;
         this.manager.enablePhysics = false;
@@ -950,6 +952,33 @@ class MMDCore {
         mesh.position.set(0, 0, 0);
         mesh.quaternion.identity();
         mesh.scale.set(1, 1, 1);
+
+        // 复位相机到初始机位，使模型稳定出现在屏幕中央
+        // （MMD 的 orbit 仅旋转 mesh 不动相机，但用户可能通过其他入口改动过相机；
+        //  同时也为将来相机交互做前向兼容）
+        if (THREE && this.manager.camera) {
+            try {
+                mesh.updateMatrixWorld(true);
+                const box = new THREE.Box3().setFromObject(mesh);
+                const center = box.getCenter(new THREE.Vector3());
+                const size = box.getSize(new THREE.Vector3());
+
+                const modelHeight = size.y > 0 ? size.y : 20;
+                const screenHeight = window.innerHeight;
+                const targetScreenHeight = screenHeight * 0.45;
+                const fov = this.manager.camera.fov * (Math.PI / 180);
+                // 让模型在屏幕上占约 45% 高度
+                const distance = (modelHeight / 2) / Math.tan(fov / 2) / targetScreenHeight * screenHeight;
+
+                this.manager.camera.position.set(0, center.y, Math.abs(distance));
+                this.manager.camera.lookAt(center.x, center.y, center.z);
+                this.manager.camera.updateProjectionMatrix();
+            } catch (err) {
+                console.warn('[MMD Core] 重置相机失败，回退到初始机位:', err);
+                this.manager.camera.position.set(0, 10, 70);
+                this.manager.camera.lookAt(0, 10, 0);
+            }
+        }
 
         if (mmd.physics && typeof mmd.physics.reset === 'function') {
             mesh.updateMatrixWorld(true);
@@ -968,6 +997,8 @@ class MMDCore {
                 { x: 0, y: 0, z: 0 }
             );
         }
+
+        console.log('[MMD Core] 模型位置已重置，相机已复位');
     }
 
     // ═══════════════════ 锁定 ═══════════════════

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -872,11 +872,21 @@ class VRMManager {
                 this._cameraTarget = new THREE.Vector3(0, center.y, 0);
                 this.camera.lookAt(this._cameraTarget);
                 this.camera.updateProjectionMatrix();
+
+                // 同步 OrbitControls 的 target，否则下一帧 controls.update() 会用旧 target 覆盖 lookAt
+                if (this.controls) {
+                    this.controls.target.copy(this._cameraTarget);
+                    this.controls.update();
+                }
             } catch (err) {
                 console.warn('[VRM Manager] 重置相机失败，回退到初始机位:', err);
                 this.camera.position.set(0, 1.1, 1.5);
                 this._cameraTarget = new THREE.Vector3(0, 0.9, 0);
                 this.camera.lookAt(this._cameraTarget);
+                if (this.controls) {
+                    this.controls.target.copy(this._cameraTarget);
+                    this.controls.update();
+                }
             }
         }
 

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -834,6 +834,9 @@ class VRMManager {
                     // 使用固定参考距离（而非 camera.position.z，因相机可能已被 orbit 偏移）
                     const targetScreenHeight = screenHeight * 0.45;
                     const fov = this.camera.fov * (Math.PI / 180);
+                    // 5 = vrm-core.js 首次加载计算缩放时所用的默认相机距离
+                    //（见 vrm-core.js 里 `camera.position?.z || 5` 的 fallback）
+                    // 这里沿用同一参考值，保证复位前后缩放口径一致、避免视觉跳变
                     const referenceDistance = 5;
                     const worldHeightAtDistance = 2 * Math.tan(fov / 2) * referenceDistance;
                     const scaleRatio = (targetScreenHeight / screenHeight) * (worldHeightAtDistance / unscaledHeight);

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -775,22 +775,93 @@ class VRMManager {
     }
 
     /**
-     * 重置模型位置/旋转/缩放到默认值（供外部调用，如 N.E.K.O.-PC）
+     * 重置模型位置/旋转/缩放到默认值，并把相机拉回屏幕中心（供外部调用，如 N.E.K.O.-PC）
+     *
+     * 问题背景：之前只重置 scene.position/rotation/scale，但用户如果右键拖拽过（orbit），
+     * 相机已不再看向世界原点，此时仅复位模型位置会使模型继续处于屏幕外。
+     * 因此这里同时复位相机到依据模型包围盒计算的默认机位，使模型稳定回到屏幕中央。
      */
     resetModelPosition() {
         const model = this.currentModel;
         const scene = model?.vrm?.scene ?? model?.scene;
         if (!scene) return;
 
+        const THREE = window.THREE;
         const vrm = model.vrm || model;
 
+        // 1) 先复位模型的位置与旋转
         scene.position.set(0, 0, 0);
         scene.rotation.set(0, 0, 0);
-        this.setModelScaleScalar(1);
 
+        // 2) 应用朝向检测（保持和初次加载一致）
         if (window.VRMOrientationDetector && vrm) {
             const detectedRotation = window.VRMOrientationDetector.detectAndFixOrientation(vrm, null);
             window.VRMOrientationDetector.applyRotation(vrm, detectedRotation);
+        }
+
+        // 3) 根据模型 bounding box 与屏幕大小计算目标缩放，避免硬编码 1 造成视觉过大
+        let targetScale = 1;
+        if (THREE) {
+            try {
+                scene.updateMatrixWorld(true);
+                const preBox = new THREE.Box3().setFromObject(scene);
+                const preSize = preBox.getSize(new THREE.Vector3());
+                const unscaledHeight = preSize.y / (scene.scale.y || 1);
+
+                const screenHeight = window.innerHeight;
+                const screenWidth = window.innerWidth;
+                const isMobile = screenWidth <= 768;
+
+                if (isMobile) {
+                    targetScale = Math.max(0.4, Math.min(0.8, screenHeight / 1800));
+                } else if (unscaledHeight > 0 && Number.isFinite(unscaledHeight) && this.camera && this.camera.fov) {
+                    // 使用固定参考距离（而非 camera.position.z，因相机可能已被 orbit 偏移）
+                    const targetScreenHeight = screenHeight * 0.45;
+                    const fov = this.camera.fov * (Math.PI / 180);
+                    const referenceDistance = 5;
+                    const worldHeightAtDistance = 2 * Math.tan(fov / 2) * referenceDistance;
+                    const scaleRatio = (targetScreenHeight / screenHeight) * (worldHeightAtDistance / unscaledHeight);
+                    targetScale = Math.max(0.5, Math.min(1.2, scaleRatio));
+                } else {
+                    targetScale = Math.max(0.5, Math.min(1.0, screenHeight / 1200));
+                }
+            } catch (err) {
+                console.warn('[VRM Manager] 重置缩放计算失败，使用 1:', err);
+                targetScale = 1;
+            }
+        }
+        this.setModelScaleScalar(targetScale);
+
+        // 4) 根据缩放后的 bounding box 重新放置相机，使模型居中显示
+        if (THREE && this.camera) {
+            try {
+                scene.updateMatrixWorld(true);
+                const box = new THREE.Box3().setFromObject(scene);
+                const center = box.getCenter(new THREE.Vector3());
+                const size = box.getSize(new THREE.Vector3());
+
+                const screenHeight = window.innerHeight;
+                const screenWidth = window.innerWidth;
+                const isMobileDevice = screenWidth <= 768;
+
+                const scaledModelHeight = size.y > 0 ? size.y : 1.5;
+                const targetScreenHeight = screenHeight * 0.45;
+                const fov = this.camera.fov * (Math.PI / 180);
+                const distance = (scaledModelHeight / 2) / Math.tan(fov / 2) / targetScreenHeight * screenHeight;
+
+                const cameraY = center.y + (isMobileDevice ? scaledModelHeight * 0.2 : scaledModelHeight * 0.1);
+                const cameraZ = Math.abs(distance);
+                this.camera.position.set(0, cameraY, cameraZ);
+
+                this._cameraTarget = new THREE.Vector3(0, center.y, 0);
+                this.camera.lookAt(this._cameraTarget);
+                this.camera.updateProjectionMatrix();
+            } catch (err) {
+                console.warn('[VRM Manager] 重置相机失败，回退到初始机位:', err);
+                this.camera.position.set(0, 1.1, 1.5);
+                this._cameraTarget = new THREE.Vector3(0, 0.9, 0);
+                this.camera.lookAt(this._cameraTarget);
+            }
         }
 
         const modelUrl = model.url || '';
@@ -798,12 +869,12 @@ class VRMManager {
             this.core.saveUserPreferences(
                 modelUrl,
                 { x: 0, y: 0, z: 0 },
-                { x: 1, y: 1, z: 1 },
+                { x: targetScale, y: targetScale, z: targetScale },
                 { x: scene.rotation.x, y: scene.rotation.y, z: scene.rotation.z }
             ).catch(err => console.warn('[VRM Manager] 保存重置偏好失败:', err));
         }
 
-        console.log('[VRM Manager] 模型位置已重置');
+        console.log('[VRM Manager] 模型位置已重置，相机已复位，目标缩放:', targetScale.toFixed(3));
     }
 
     /**


### PR DESCRIPTION
之前 VRM/MMD 的 resetModelPosition() 只复位 scene/mesh 的位置、旋转和缩放， 没有重置相机。当用户通过右键 orbit 拖拽改变过相机朝向后，即使把模型位置复位
到世界原点，相机也不再看向原点，模型仍然在屏幕外。

本次改动：
- VRM：按屏幕大小重算合适缩放（避免硬编码 1 过大），再基于包围盒把相机 放到能让模型占屏幕 45% 高度的机位，并刷新 _cameraTarget。
- MMD：在复位 mesh 位置/旋转/缩放后，按包围盒中心重新放置相机并 lookAt。

Live2D 路径保持不变（继续回到右下角）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进模型位置重置：通过包围盒居中模型并同步视点
  * 动态统一缩放：基于包围盒与视口计算并应用合适缩放（含移动端/桌面差异）
  * 相机与控件同步：更新相机朝向、投影矩阵并同步交互控件目标
  * 增强鲁棒性：增加错误处理并回退到固定视角，持久化保存计算后的缩放值并记录日志
<!-- end of auto-generated comment: release notes by coderabbit.ai -->