### PR TITLE
fix: 修复 Live3D MMD 模型互相切换时 sister1.0 VRM 模型短暂闪现的问题

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2460,6 +2460,15 @@ document.addEventListener('DOMContentLoaded', async () => {
                     console.log('[模型管理] VRM 场景初始化成功');
                     showStatus(t('live2d.vrmInitialized', 'VRM 管理器初始化成功'));
                 }
+                // 【修复】对称恢复：从 MMD 子类型切回 VRM 时，MMD 分支会把 canvas 隐藏并
+                // 暂停渲染循环。若场景已初始化则 initThreeJS 不会被调用，需要在此显式
+                // 恢复 canvas 可见性并重启渲染循环，避免预览空白或卡在旧帧。
+                if (vrmManager && vrmManager.renderer && vrmManager.renderer.domElement) {
+                    vrmManager.renderer.domElement.style.display = 'block';
+                }
+                if (vrmManager && typeof vrmManager.resumeRendering === 'function') {
+                    try { vrmManager.resumeRendering(); } catch (_) { /* ignore */ }
+                }
             } catch (error) {
                 console.error('VRM 场景初始化失败:', error);
                 showStatus(t('live2d.vrmInitFailed', `VRM 场景初始化失败: ${error.message}`));

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -5202,6 +5202,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // 应用打光值到UI和场景
     function applyLightingValues(lighting) {
+        // 【修复】非 VRM 子类型不应用 VRM 打光配置：
+        // MMD 子类型时 switchModelDisplay 会跳过 VRM 初始化（避免 sister1.0 闪现），
+        // 此时 vrmManager.ambientLight 等永远不存在，若继续执行会陷入每 100ms 的
+        // setTimeout 重试循环，造成后台定时器长期挂起。
+        if (currentModelType !== 'live3d' || currentLive3dSubType === 'mmd') {
+            return;
+        }
         const ui = {
             ambientLightSlider: document.getElementById('ambient-light-slider'),
             mainLightSlider: document.getElementById('main-light-slider'),

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2249,9 +2249,25 @@ document.addEventListener('DOMContentLoaded', async () => {
             // VRM 表情组仅在 VRM 子类型时显示（MMD 子类型时隐藏）
             if (vrmExpressionGroup) vrmExpressionGroup.style.display = (currentLive3dSubType !== 'mmd') ? 'flex' : 'none';
             if (live2dContainer) live2dContainer.style.display = 'none';
+            // 【修复】MMD 子类型时保持 VRM 容器隐藏，避免 VRM 场景中缓存的模型（如 sister1.0）
+            // 在切换过程中被浏览器绘制，导致短暂闪现；同时显示 MMD 容器作为前台画布。
             if (vrmContainer) {
-                vrmContainer.classList.remove('hidden');
-                vrmContainer.style.display = 'block';
+                if (currentLive3dSubType === 'mmd') {
+                    vrmContainer.classList.add('hidden');
+                    vrmContainer.style.display = 'none';
+                } else {
+                    vrmContainer.classList.remove('hidden');
+                    vrmContainer.style.display = 'block';
+                }
+            }
+            if (mmdContainer) {
+                if (currentLive3dSubType === 'mmd') {
+                    mmdContainer.classList.remove('hidden');
+                    mmdContainer.style.display = 'block';
+                } else {
+                    mmdContainer.classList.add('hidden');
+                    mmdContainer.style.display = 'none';
+                }
             }
             // 更新VRM选择器按钮文字
             if (typeof updateVRMAnimationSelectButtonText === 'function') {
@@ -2343,22 +2359,26 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (parameterEditorGroup) parameterEditorGroup.style.display = 'none';
 
             // 初始化 VRM 管理器
+            // 【修复】仅在 VRM 子类型时初始化 VRM 场景。MMD 子类型时若调用 initThreeJS，
+            // 会强制显示 vrm-container（见 vrm-manager.js initThreeJS），导致 VRM 场景中缓存的
+            // 模型（如 sister1.0）被浏览器绘制并短暂闪现。
+            if (currentLive3dSubType !== 'mmd') {
             // 1. 如果 vrmManager 不存在，创建实例
             if (!vrmManager) {
                 try {
                     /**
                      * ===== 代码质量改进：修复 VRM 初始化竞争条件 =====
-                     * 
+                     *
                      * 问题：
                      * - 如果 'vrm-modules-ready' 事件在监听器附加之前触发，会导致无限等待
                      * - 缺少超时机制可能导致用户界面卡死
-                     * 
+                     *
                      * 解决方案：
                      * 1. 首先检查模块是否已加载（window.VRMManager 或 window.vrmModuleLoaded）
                      *    如果已加载，立即 resolve，避免等待已发生的事件
                      * 2. 使用 once: true 确保事件监听器只触发一次
                      * 3. 添加 8 秒超时机制，提供更快的反馈和防止无限等待
-                     * 
+                     *
                      * 使用位置：
                      * - switchModelDisplay() 函数中的 VRM 初始化
                      * - vrmModelSelect change 事件监听器中的 VRM 初始化
@@ -2443,6 +2463,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             } catch (error) {
                 console.error('VRM 场景初始化失败:', error);
                 showStatus(t('live2d.vrmInitFailed', `VRM 场景初始化失败: ${error.message}`));
+            }
+            } else {
+                // MMD 子类型：暂停 VRM 渲染循环，避免后台仍然绘制已缓存的 VRM 模型
+                // （即使容器 display:none，某些浏览器在过渡/重排时仍可能短暂显示 canvas）
+                if (vrmManager && typeof vrmManager.pauseRendering === 'function') {
+                    try { vrmManager.pauseRendering(); } catch (_) { /* ignore */ }
+                }
+                if (vrmManager && vrmManager.renderer && vrmManager.renderer.domElement) {
+                    vrmManager.renderer.domElement.style.display = 'none';
+                }
             }
 
             // 加载模型列表


### PR DESCRIPTION
问题：在 Live3D 模式下，当用户在不同 MMD 模型之间点击切换时，
sister1.0（默认 VRM 模型）会在切换瞬间短暂出现。

根因：model_manager 的 switchModelDisplay 在 live3d 分支中无条件 显示 vrm-container 并调用 vrmManager.initThreeJS。initThreeJS 内部 会再次强制恢复 vrm-container 的可见性（display:block）。由于 VRM
场景仍然保有之前加载的 sister1.0 作为 currentModel，浏览器会在
await 点短暂绘制出 sister1.0，随后才被后续流程隐藏。

修复：
- switchModelDisplay 根据 currentLive3dSubType 条件切换容器可见性： MMD 子类型时隐藏 vrm-container、显示 mmd-container；VRM 子类型 时保持原行为。
- MMD 子类型时完全跳过 VRM 管理器创建和 initThreeJS 调用，并暂停 VRM 渲染循环、将 VRM canvas 设为 display:none，防止缓存的 VRM 模型被继续绘制。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 修复 VRM 与 MMD 切换时预览空白或停留旧帧的问题：切换到 MMD 时暂停并隐藏 VRM 渲染输出，切回 VRM 时恢复显示并尝试重启渲染循环，避免黑屏或停帧。
  * 防止在 MMD 模式下误用 VRM 灯光更新逻辑，避免无效或出错的光照应用与重试。
* **性能优化**
  * 优化初始化与渲染控制：仅在当前子类型需要时进行 VRM 场景初始化与渲染管理，减少切换期间不必要的渲染和计算。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->