### PR TITLE
feat: 增强模型类型检查，防止异步回调导致的按钮创建错误

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -262,6 +262,13 @@
                 var oldLive3dSubType = (window.lanlan_config?.live3d_sub_type || '').toLowerCase();
                 var typeChanged = oldModelType !== newModelType ||
                     (newModelType === 'live3d' && oldLive3dSubType !== live3dSubType);
+
+                // 提前更新 config，防止异步间隙中其他代码基于过时类型重建按钮
+                if (typeChanged && window.lanlan_config) {
+                    window.lanlan_config.model_type = newModelType;
+                    window.lanlan_config.live3d_sub_type = live3dSubType;
+                }
+
                 if (typeChanged) {
                     if (oldModelType === 'live2d') cleanupLive2DOverlayUI();
                     if (oldModelType === 'vrm') cleanupVRMOverlayUI();
@@ -715,6 +722,13 @@
             if (window.mmdManager && typeof window.mmdManager.pauseRendering === 'function') {
                 window.mmdManager.pauseRendering();
             }
+
+            // 隐藏所有悬浮按钮、锁图标和返回按钮（它们挂载在 document.body 上，不随容器隐藏）
+            document.querySelectorAll(
+                '#live2d-floating-buttons, #vrm-floating-buttons, #mmd-floating-buttons, ' +
+                '#live2d-lock-icon, #vrm-lock-icon, #mmd-lock-icon, ' +
+                '#live2d-return-button-container, #vrm-return-button-container, #mmd-return-button-container'
+            ).forEach(function (el) { el.style.display = 'none'; });
         } catch (error) {
             console.error('[UI] 隐藏主界面失败:', error);
         }

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -642,6 +642,12 @@
             }
         } catch (error) {
             console.error('[Model] 模型热切换失败:', error);
+            // 回滚提前写入的 config，防止残留错误的模型类型
+            if (typeChanged && window.lanlan_config) {
+                window.lanlan_config.model_type = oldModelType;
+                window.lanlan_config.live3d_sub_type = oldLive3dSubType || '';
+                console.warn('[Model] 已回滚 config:', { model_type: oldModelType, live3d_sub_type: oldLive3dSubType });
+            }
             window.showStatusToast(
                 window.t ? window.t('app.modelSwitchFailed') : '模型切换失败',
                 3000

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -87,10 +87,7 @@ const AvatarButtonMixin = {
                           : p === 'vrm'    ? window.vrmManager
                           :                   window.mmdManager;
                 if (!mgr) return;
-                if (typeof mgr.cleanupFloatingButtons === 'function') {
-                    try { mgr.cleanupFloatingButtons(); } catch (_) {}
-                } else {
-                    // 回退：手动取消更新循环和清理引用
+                const manualCleanup = () => {
                     if (mgr._uiUpdateLoopId !== null && mgr._uiUpdateLoopId !== undefined) {
                         cancelAnimationFrame(mgr._uiUpdateLoopId);
                         mgr._uiUpdateLoopId = null;
@@ -99,8 +96,19 @@ const AvatarButtonMixin = {
                         try { mgr.pixi_app.ticker.remove(mgr._floatingButtonsTicker); } catch (_) {}
                         mgr._floatingButtonsTicker = null;
                     }
+                    if (mgr._uiWindowHandlers) {
+                        mgr._uiWindowHandlers.forEach(({ event, handler, target, options: opts }) => {
+                            (target || window).removeEventListener(event, handler, opts);
+                        });
+                        mgr._uiWindowHandlers = [];
+                    }
                     mgr._floatingButtonsContainer = null;
                     mgr._returnButtonContainer = null;
+                };
+                if (typeof mgr.cleanupFloatingButtons === 'function') {
+                    try { mgr.cleanupFloatingButtons(); } catch (_) { manualCleanup(); }
+                } else {
+                    manualCleanup();
                 }
             });
 

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -57,7 +57,7 @@ const AvatarButtonMixin = {
                 this._returnButtonDragHandlers = null;
             }
 
-            // 清理旧 DOM
+            // 清理旧 DOM（自身类型）
             document.querySelectorAll(`#${options.containerElementId}, #${options.lockIconId}, #${options.returnContainerId}`)
                 .forEach(el => el.remove());
             if (options.excludeLiveD2Elements && options.excludeLiveD2Elements.length > 0) {
@@ -66,11 +66,49 @@ const AvatarButtonMixin = {
                 });
             }
 
-            // 清理旧的侧边面板（防止画质切换等场景导致重复 UI）
-            document.querySelectorAll(`[data-neko-sidepanel-owner^="${options.popupPrefix}-popup-"]`).forEach(panel => {
-                if (panel._collapseTimeout) { clearTimeout(panel._collapseTimeout); panel._collapseTimeout = null; }
-                if (panel._hoverCollapseTimer) { clearTimeout(panel._hoverCollapseTimer); panel._hoverCollapseTimer = null; }
-                panel.remove();
+            // 清理所有其他模型类型的悬浮按钮 DOM（全类型互斥，防止模型切换后出现多组按钮）
+            const allButtonIds = [
+                'live2d-floating-buttons', 'live2d-lock-icon', 'live2d-return-button-container',
+                'vrm-floating-buttons', 'vrm-lock-icon', 'vrm-return-button-container',
+                'mmd-floating-buttons', 'mmd-lock-icon', 'mmd-return-button-container'
+            ];
+            const selfIds = [options.containerElementId, options.lockIconId, options.returnContainerId];
+            allButtonIds.forEach(id => {
+                if (selfIds.indexOf(id) === -1) {
+                    const el = document.getElementById(id);
+                    if (el) el.remove();
+                }
+            });
+
+            // 取消其他管理器的 UI 更新循环，防止幽灵回调重建按钮
+            const otherPrefixes = ['live2d', 'vrm', 'mmd'].filter(p => p !== prefix);
+            otherPrefixes.forEach(p => {
+                const mgr = p === 'live2d' ? window.live2dManager
+                          : p === 'vrm'    ? window.vrmManager
+                          :                   window.mmdManager;
+                if (!mgr) return;
+                // 取消 RAF 循环（VRM / MMD）
+                if (mgr._uiUpdateLoopId !== null && mgr._uiUpdateLoopId !== undefined) {
+                    cancelAnimationFrame(mgr._uiUpdateLoopId);
+                    mgr._uiUpdateLoopId = null;
+                }
+                // 取消 PIXI ticker（Live2D）
+                if (mgr._floatingButtonsTicker && mgr.pixi_app && mgr.pixi_app.ticker) {
+                    try { mgr.pixi_app.ticker.remove(mgr._floatingButtonsTicker); } catch (_) {}
+                    mgr._floatingButtonsTicker = null;
+                }
+                // 清理引用，防止残留状态
+                mgr._floatingButtonsContainer = null;
+                mgr._returnButtonContainer = null;
+            });
+
+            // 清理所有模型类型的侧边面板
+            ['live2d', 'vrm', 'mmd'].forEach(p => {
+                document.querySelectorAll(`[data-neko-sidepanel-owner^="${p}-popup-"]`).forEach(panel => {
+                    if (panel._collapseTimeout) { clearTimeout(panel._collapseTimeout); panel._collapseTimeout = null; }
+                    if (panel._hoverCollapseTimer) { clearTimeout(panel._hoverCollapseTimer); panel._hoverCollapseTimer = null; }
+                    panel.remove();
+                });
             });
 
             // 创建按钮容器

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -80,26 +80,28 @@ const AvatarButtonMixin = {
                 }
             });
 
-            // 取消其他管理器的 UI 更新循环，防止幽灵回调重建按钮
+            // 调用其他管理器的完整清理 API，防止幽灵回调及残留事件监听
             const otherPrefixes = ['live2d', 'vrm', 'mmd'].filter(p => p !== prefix);
             otherPrefixes.forEach(p => {
                 const mgr = p === 'live2d' ? window.live2dManager
                           : p === 'vrm'    ? window.vrmManager
                           :                   window.mmdManager;
                 if (!mgr) return;
-                // 取消 RAF 循环（VRM / MMD）
-                if (mgr._uiUpdateLoopId !== null && mgr._uiUpdateLoopId !== undefined) {
-                    cancelAnimationFrame(mgr._uiUpdateLoopId);
-                    mgr._uiUpdateLoopId = null;
+                if (typeof mgr.cleanupFloatingButtons === 'function') {
+                    try { mgr.cleanupFloatingButtons(); } catch (_) {}
+                } else {
+                    // 回退：手动取消更新循环和清理引用
+                    if (mgr._uiUpdateLoopId !== null && mgr._uiUpdateLoopId !== undefined) {
+                        cancelAnimationFrame(mgr._uiUpdateLoopId);
+                        mgr._uiUpdateLoopId = null;
+                    }
+                    if (mgr._floatingButtonsTicker && mgr.pixi_app && mgr.pixi_app.ticker) {
+                        try { mgr.pixi_app.ticker.remove(mgr._floatingButtonsTicker); } catch (_) {}
+                        mgr._floatingButtonsTicker = null;
+                    }
+                    mgr._floatingButtonsContainer = null;
+                    mgr._returnButtonContainer = null;
                 }
-                // 取消 PIXI ticker（Live2D）
-                if (mgr._floatingButtonsTicker && mgr.pixi_app && mgr.pixi_app.ticker) {
-                    try { mgr.pixi_app.ticker.remove(mgr._floatingButtonsTicker); } catch (_) {}
-                    mgr._floatingButtonsTicker = null;
-                }
-                // 清理引用，防止残留状态
-                mgr._floatingButtonsContainer = null;
-                mgr._returnButtonContainer = null;
             });
 
             // 清理所有模型类型的侧边面板

--- a/static/live2d-ui-buttons.js
+++ b/static/live2d-ui-buttons.js
@@ -186,6 +186,10 @@ Live2DManager.prototype.setupFloatingButtons = function(model) {
         return;
     }
 
+    // 防御性检查：当前模型类型不是 Live2D 时不创建按钮（防止过时的异步回调）
+    var cfgType = (window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
+    if (cfgType && cfgType !== 'live2d') return;
+
     if (this._floatingButtonsResizeHandler) {
         window.removeEventListener('resize', this._floatingButtonsResizeHandler);
         this._floatingButtonsResizeHandler = null;

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -23,6 +23,12 @@ AvatarButtonMixin.apply(MMDManager.prototype, 'mmd', {
 MMDManager.prototype.setupFloatingButtons = function() {
     if (window.location.pathname.includes('model_manager')) return;
 
+    // 防御性检查：当前模型类型不是 MMD 时不创建按钮（防止过时的异步回调）
+    var cfgType = (window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
+    var cfgSub = (window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
+    if (cfgType && cfgType !== 'live3d') return;  // 非 live3d 模式时 MMD 不应存在
+    if (cfgType === 'live3d' && cfgSub && cfgSub !== 'mmd') return;  // live3d 但子类型不是 mmd
+
     // 基础框架初始化
     const buttonsContainer = this.setupFloatingButtonsBase();
 

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -26,8 +26,7 @@ MMDManager.prototype.setupFloatingButtons = function() {
     // 防御性检查：当前模型类型不是 MMD 时不创建按钮（防止过时的异步回调）
     var cfgType = (window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
     var cfgSub = (window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
-    if (cfgType && cfgType !== 'live3d') return;  // 非 live3d 模式时 MMD 不应存在
-    if (cfgType === 'live3d' && cfgSub && cfgSub !== 'mmd') return;  // live3d 但子类型不是 mmd
+    if (!(cfgType === 'live3d' && cfgSub === 'mmd')) return;  // 仅 live3d + mmd 子类型时才创建 MMD 按钮
 
     // 基础框架初始化
     const buttonsContainer = this.setupFloatingButtonsBase();

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -26,6 +26,12 @@ VRMManager.prototype.setupFloatingButtons = function() {
         return;
     }
 
+    // 防御性检查：当前模型类型不是 VRM 时不创建按钮（防止过时的异步回调）
+    var cfgType = (window.lanlan_config && window.lanlan_config.model_type || '').toLowerCase();
+    var cfgSub = (window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
+    var isVrm = cfgType === 'vrm' || (cfgType === 'live3d' && cfgSub === 'vrm');
+    if (cfgType && !isVrm) return;
+
     // 基础框架初始化
     const buttonsContainer = this.setupFloatingButtonsBase();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 切换模型类型时立即更新配置，减少切换期间不一致的 UI 状态。
  * 在跨类型切换失败时回滚配置并发出回滚警告，避免残留错误配置。
  * 强制将浮动按钮、锁定图标和返回按钮容器设为隐藏，确保挂载于 document.body 的元素也被隐藏。
  * 清理逻辑扩展为跨模型互斥移除旧 UI 元素，避免残留面板或按钮。
  * 新增防御性检查，防止为非目标模型创建或初始化浮动 UI。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->