### PR TITLE
fix: 窄屏 React 聊天框用 grid 布局防止消息挤出输入框

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2111,7 +2111,7 @@ body.react-chat-window-dragging {
 
     /* 窄屏与桌面统一用 grid 布局：auto(顶栏) 1fr(消息) auto(输入) +
        overflow:hidden 保证输入区不会被消息挤出。shell 尺寸仍由
-       syncMobileContentLayout() 写成显式像素（根据内容 50vh 上限）。*/
+       syncMobileContentLayout() 写成显式像素（根据内容 50vh 上限）。 */
     #react-chat-window-shell .chat-window {
         height: 100%;
         display: grid;
@@ -2133,7 +2133,7 @@ body.react-chat-window-dragging {
     }
 
     /* .is-mobile-content-capped 现在不再影响布局（message-list 始终可滚），
-       保留空规则以免其他位置若有依赖时出现样式回退。*/
+       保留空规则以免其他位置若有依赖时出现样式回退。 */
     #react-chat-window-shell.is-mobile-content-capped .message-list {
         overflow-y: auto;
     }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2109,29 +2109,31 @@ body.react-chat-window-dragging {
         min-height: 0;
     }
 
+    /* 窄屏与桌面统一用 grid 布局：auto(顶栏) 1fr(消息) auto(输入) +
+       overflow:hidden 保证输入区不会被消息挤出。shell 尺寸仍由
+       syncMobileContentLayout() 写成显式像素（根据内容 50vh 上限）。*/
     #react-chat-window-shell .chat-window {
         height: 100%;
-        display: flex;
-        flex-direction: column;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
         min-height: 0;
+        overflow: hidden;
     }
 
     #react-chat-window-shell .chat-body {
-        flex: 1 1 auto;
-        min-height: 60px;
-        display: flex;
-        flex-direction: column;
+        min-height: 0;
         overflow: hidden;
     }
 
     #react-chat-window-shell .message-list {
-        flex: 1 1 auto;
-        min-height: 60px;
-        height: auto;
-        overflow-y: hidden;
+        height: 100%;
+        min-height: 0;
+        overflow-y: auto;
         -webkit-overflow-scrolling: touch;
     }
 
+    /* .is-mobile-content-capped 现在不再影响布局（message-list 始终可滚），
+       保留空规则以免其他位置若有依赖时出现样式回退。*/
     #react-chat-window-shell.is-mobile-content-capped .message-list {
         overflow-y: auto;
     }


### PR DESCRIPTION
## 背景

用户反馈：在手机版（窄屏）随着 `appendMessage` 累积的气泡越来越多，React 聊天框里的气泡最终占据整个聊天框，导致输入框消失（被挤到屏幕外面）。

## 根因

`static/css/index.css` 里 `@media (max-width: 768px)` 分支用的是 flex column 布局 + `.message-list { overflow-y: hidden }` 默认值，靠 JS 动态切 `.is-mobile-content-capped` 类才能启用滚动：

- `.message-list { flex: 1 1 auto; height: auto; overflow-y: hidden }` —— 默认不滚动。
- flex column 下 composer 理论上可以被 `flex-shrink` 压缩，能不能守住取决于 `composer-input-shell { min-height: 98px }` 的隐式 min-content 行为，不同浏览器表现不一致。
- JS 侧 `syncMobileContentLayout()` 依赖 rAF 时序，在快速 append 时有单帧错位可能。

此外 **chat.html 独立窗口在 ≤768px 下也命中同一套媒体查询**（shell 的 `inset: 20px !important` 不包含 `display`，所以 flex column 会生效），之前未实测，属于同一个隐患。

## 修复

把窄屏 `.chat-window` 切回与桌面版一致的 **grid 布局**：

```css
#react-chat-window-shell .chat-window {
    display: grid;
    grid-template-rows: auto 1fr auto;  /* auto=顶栏, 1fr=消息, auto=输入 */
    overflow: hidden;
    min-height: 0;
    height: 100%;
}
```

- `auto` 行按自身内容撑开，**结构上**不可能被消息挤压。
- `1fr` 行吃剩余空间，`.message-list` 在其中 `overflow-y: auto` 滚动。
- shell 尺寸仍由 `syncMobileContentLayout()` 显式写像素（根据内容和 50vh 上限），grid 内部能正确解析 `height: 100%`。

## 影响范围

改动严格锁在 `@media only screen and (max-width: 768px)` 块内：

| 场景 | 影响 |
|---|---|
| index.html PC 宽屏 (>768px) | **零改动**（不进媒体查询） |
| index.html 手机/窄屏 (≤768px) | 切到 grid 布局，修复本 bug |
| chat.html Electron 宽窗口 | **零改动** |
| chat.html Electron 窄窗口 (≤768px) | 顺带修掉同源隐患 |

JS 侧零改动。`.is-mobile-content-capped` 空规则保留以兜底，日后可连同 JS 一起清理。

## Test plan

- [ ] PC 宽屏 (>768px) 冒烟：打开 index.html，确认布局/滚动/输入框行为与上线前一致，无视觉回归。
- [ ] 手机/窄屏 (≤768px)：DevTools 切到移动模拟器，在 console 跑：
  ```js
  for (let i = 0; i < 100; i++) {
    window.reactChatWindowHost.appendMessage({
      id: 'test-' + i,
      role: i % 2 ? 'user' : 'assistant',
      blocks: [{ type: 'text', text: '测试 ' + i }]
    });
  }
  ```
  预期：shell 稳定在视口底部 ≤50vh，消息区可滚动，输入框始终可见可点击。
- [ ] chat.html Electron 宽窗口：布局与之前一致。
- [ ] chat.html Electron 拖到 ≤768px 窄窗口：输入框同样稳固，之前未测的路径顺带验证。
- [ ] 暗色模式下上述场景各再过一遍。

https://claude.ai/code/session_019ncRL3urndS9E6tYY8ei1U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 样式优化

* **样式优化**
  * 在移动布局中重构聊天窗口的布局与滚动行为，改为更稳定的容器布局，确保消息列表成为可滚动区域，提升移动端滚动性能与显示一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->