### PR TITLE
fix: 进入 MMD 子类型时隐藏 VRM 场景节点，消除切回 VRM 时 sister1.0 闪现

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2476,6 +2476,21 @@ document.addEventListener('DOMContentLoaded', async () => {
             } else {
                 // MMD 子类型：暂停 VRM 渲染循环，避免后台仍然绘制已缓存的 VRM 模型
                 // （即使容器 display:none，某些浏览器在过渡/重排时仍可能短暂显示 canvas）
+                //
+                // 【修复 MMD→VRM 切换闪现】额外把当前 VRM 模型节点隐藏：
+                // 仅靠 pauseRendering + canvas display:none 不足以覆盖从 MMD 切回 VRM 的缝隙。
+                // 切回 VRM 时，switchModelDisplay 的 VRM 分支会显式 resumeRendering +
+                // 显示 canvas（见上方"对称恢复"），而真正替换模型的 vrmManager.loadModel
+                // 要等到 switchModelDisplay 之后才被 vrmModelSelect handler 调用。
+                // 期间 loadLive3DModels / loadIdleAnimationOptions / restoreVrmIdleAnimation
+                // 等多处 await 都会让浏览器绘制若干帧，此时旧 sister1.0 仍留在 scene 中
+                // 就会被画出来。把 scene.visible 置 false 后，即便 canvas 可见也画不出内容
+                // （renderer 使用 alpha:true，画面为透明）；新模型加载时 disposeVRM 会清掉
+                // 旧节点，新节点走自己的 visible=false → fadeIn 流水线，不受影响。
+                if (vrmManager && vrmManager.currentModel &&
+                    vrmManager.currentModel.vrm && vrmManager.currentModel.vrm.scene) {
+                    vrmManager.currentModel.vrm.scene.visible = false;
+                }
                 if (vrmManager && typeof vrmManager.pauseRendering === 'function') {
                     try { vrmManager.pauseRendering(); } catch (_) { /* ignore */ }
                 }


### PR DESCRIPTION
## 背景

#756 想修复 Live3D 模式下切换模型时 sister1.0（默认 VRM）短暂闪现的问题，做法是进入 MMD 子类型时 `pauseRendering` + 把 VRM canvas `display:none`，并在切回 VRM 时做"对称恢复"。

但该 PR 没有清理 `vrmManager.scene` 里缓存的旧 VRM 模型节点，因此**每次 MMD → VRM 仍会闪现 sister1.0**（在 `model_manager.html` 能稳定复现）。

## 根因

从 MMD 切回 VRM 的时序：

1. 用户在 `vrmModelSelect` 里点一个 VRM 项 → handler 调 `switchModelDisplay('live3d', 'vrm')`。
2. `switchModelDisplay` VRM 分支执行"对称恢复"：`vrm-container` 显示 + `renderer.domElement.style.display='block'` + `resumeRendering()`。**此时 `vrmManager.currentModel` 还是 sister1.0，渲染循环立刻把它画到可见的 canvas 上。**
3. 紧接着多处 `await`（`loadLive3DModels` / `loadIdleAnimationOptions` / `restoreVrmIdleAnimation` 等），每个 `await` 都让浏览器绘制若干帧 → **闪现**。
4. 回到 handler 才调 `vrmManager.loadModel(newUrl)`，它在 `vrm-manager.js:968-972` 才把 canvas `opacity=0`，在 `vrm-core.js:667` 才 `scene.remove` 旧模型 —— 太晚了。

## 修复

在 `switchModelDisplay` 的 MMD 分支里（`pauseRendering` 之前）追加：

```js
if (vrmManager && vrmManager.currentModel &&
    vrmManager.currentModel.vrm && vrmManager.currentModel.vrm.scene) {
    vrmManager.currentModel.vrm.scene.visible = false;
}
```

这样**进入** MMD 时就把旧 VRM 节点设为不可见。之后切回 VRM 时，即便"对称恢复"让 canvas 可见、渲染循环恢复，场景里也画不出任何东西（renderer 用 `alpha:true`，画面透明）。新模型通过 `loadModel` 进来时 `disposeVRM` 会清掉旧节点，新节点走自己的 `visible=false → showAndFadeIn` 流水线，不受影响。

## 为什么不改 VRM 分支"对称恢复"的逻辑

"对称恢复"是防御性代码，覆盖"切回 VRM 但未触发新 `loadModel`"的理论场景。实际 UI 里切子类型必走 `vrmModelSelect` change，一定会调 `loadModel`；但保留这段不会有副作用，改动范围更小、更容易回退。

## 测试

- [ ] 在 `/model_manager.html` 里进 Live3D 模式，从 VRM 切到任一 MMD 模型，再切回任一 VRM 模型：sister1.0 不再闪现。
- [ ] VRM ↔ VRM 直接切换：加载淡入表现不变。
- [ ] MMD ↔ MMD 切换：不再有 sister1.0 闪现（#756 已修，保持）。
- [ ] 首次进入即 MMD（localStorage 里子类型为 mmd，`vrmManager.currentModel` 还不存在）：新增的 null-guard 走空分支，无回归。

https://claude.ai/code/session_014dNzdSoAh1QEquzD41jtqC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 改进了模型切换期间的渲染逻辑，修复了旧模型在切换过程中可能被意外显示的问题，确保模型切换更流畅清晰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->