### PR TITLE
fix: chat.html 从手机端媒体查询剥离 + 手机端最小化改为底部胶囊

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -935,13 +935,15 @@
     function getMinimizedTarget(rect) {
         if (isMobileWidth()) {
             var mobileWidth = Math.max(0, window.innerWidth - MOBILE_CAPSULE_MARGIN * 2);
+            // 胶囊四周保持 MOBILE_CAPSULE_MARGIN 间距（与左右 6px 对称）
+            var mobileBottomTop = Math.max(0, window.innerHeight - MOBILE_CAPSULE_HEIGHT - MOBILE_CAPSULE_MARGIN);
             return {
                 width: mobileWidth,
                 height: MOBILE_CAPSULE_HEIGHT,
                 left: MOBILE_CAPSULE_MARGIN,
                 top: Math.max(0, Math.min(
                     rect.bottom - MOBILE_CAPSULE_HEIGHT,
-                    window.innerHeight - MOBILE_CAPSULE_HEIGHT
+                    mobileBottomTop
                 ))
             };
         }
@@ -1083,7 +1085,20 @@
 
             // 恢复保存的尺寸
             shell.classList.remove('is-minimized');
-            if (savedShellSize) {
+            if (isMobileWidth()) {
+                // 手机端：宽度永远是全宽（由 CSS 对非动画态的 `.is-minimized`/展开态
+                // 双向 !important 覆盖），所以忽略 savedShellSize.width —— 否则旋屏
+                // (portrait→landscape) 后 savedSize.width < curRect.width，
+                // expandedRect 被 savedSize 缩窄，sx2 > 1，动画反向缩小。
+                // 高度按当前视口 50vh 重新 clamp，避免旋屏或视口变短后超出上限。
+                shell.style.width = Math.max(0, window.innerWidth - MOBILE_CAPSULE_MARGIN * 2) + 'px';
+                var maxMobileHeight = Math.max(0, Math.floor(window.innerHeight * MOBILE_MAX_HEIGHT_RATIO));
+                var savedHeightPx = savedShellSize ? parseFloat(savedShellSize.height) : NaN;
+                var restoreHeight = isFinite(savedHeightPx) && savedHeightPx > 0
+                    ? Math.min(savedHeightPx, maxMobileHeight)
+                    : maxMobileHeight;
+                if (restoreHeight > 0) shell.style.height = restoreHeight + 'px';
+            } else if (savedShellSize) {
                 if (savedShellSize.width) shell.style.width = savedShellSize.width;
                 if (savedShellSize.height) shell.style.height = savedShellSize.height;
             }

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -45,6 +45,11 @@
     }
 
     function isMobileWidth() {
+        // chat.html 是 Electron 独立窗口，始终按 PC 行为处理（即使用户把窗口拖窄到 <768px），
+        // 通过 <body class="electron-chat-window"> 从"手机端布局"中排除。
+        if (document.body && document.body.classList.contains('electron-chat-window')) {
+            return false;
+        }
         return window.innerWidth <= 768;
     }
 
@@ -915,9 +920,38 @@
         };
     }
 
-    var MINIMIZED_SIZE = 50;
+    var MINIMIZED_SIZE = 50;            // 桌面：圆球直径
+    var MOBILE_CAPSULE_HEIGHT = 48;     // 手机：底部胶囊高度
+    var MOBILE_CAPSULE_MARGIN = 6;      // 手机：胶囊离屏幕边距
     var isMinimizeTransitioning = false;
     var activeAnimationCleanup = null; // 当前进行中动画的清理函数
+
+    // 返回最小化后 shell 应达到的像素几何。
+    // 桌面：50x50 圆球，锚定在对话框原左下角（clamp 到视口内）。
+    // 手机：全宽底部胶囊，贴屏幕底边（类似移动 App 的底栏收起态）。
+    // 由于 collapse/expand 动画的 transform-origin = 0% 100%（左下角），
+    // target.left 应等于 rect.left 同列，target 底边应与 rect 底边对齐
+    // （即 target.top = rect.bottom - target.height），这样动画过程中底边不漂移。
+    function getMinimizedTarget(rect) {
+        if (isMobileWidth()) {
+            var mobileWidth = Math.max(0, window.innerWidth - MOBILE_CAPSULE_MARGIN * 2);
+            return {
+                width: mobileWidth,
+                height: MOBILE_CAPSULE_HEIGHT,
+                left: MOBILE_CAPSULE_MARGIN,
+                top: Math.max(0, Math.min(
+                    rect.bottom - MOBILE_CAPSULE_HEIGHT,
+                    window.innerHeight - MOBILE_CAPSULE_HEIGHT
+                ))
+            };
+        }
+        return {
+            width: MINIMIZED_SIZE,
+            height: MINIMIZED_SIZE,
+            left: Math.max(0, Math.min(rect.left, window.innerWidth - MINIMIZED_SIZE)),
+            top: Math.max(0, Math.min(rect.bottom - MINIMIZED_SIZE, window.innerHeight - MINIMIZED_SIZE))
+        };
+    }
 
     function cancelActiveAnimation() {
         if (activeAnimationCleanup) {
@@ -982,13 +1016,14 @@
             shell.style.left = rect.left + 'px';
             shell.style.top = rect.top + 'px';
 
-            // 2. 球的目标位置 = 对话框自身的左下角（clamp 到视口内）
-            var targetLeft = Math.max(0, Math.min(rect.left, window.innerWidth - MINIMIZED_SIZE));
-            var targetTop = Math.max(0, Math.min(rect.bottom - MINIMIZED_SIZE, window.innerHeight - MINIMIZED_SIZE));
+            // 2. 最小化后的目标几何：桌面=50px 圆球 / 手机=全宽底部胶囊
+            var target = getMinimizedTarget(rect);
+            var targetLeft = target.left;
+            var targetTop = target.top;
 
             // 3. 计算缩放比（transform-origin 为 0% 100% 即左下角，无需 translate）
-            var sx = rect.width > 0 ? MINIMIZED_SIZE / rect.width : 1;
-            var sy = rect.height > 0 ? MINIMIZED_SIZE / rect.height : 1;
+            var sx = rect.width > 0 ? target.width / rect.width : 1;
+            var sy = rect.height > 0 ? target.height / rect.height : 1;
 
             // 4. 初始 transform = identity，添加过渡类
             shell.style.transform = 'scale(1, 1)';
@@ -1040,9 +1075,10 @@
             };
 
         } else {
-            // ---- 展开动画：从球位置向右上角展开 ----
+            // ---- 展开动画：从最小化态（桌面圆球 / 手机底部胶囊）展开 ----
             var curRect = shell.getBoundingClientRect();
             var ballLeft = curRect.left;
+            // 桌面圆球的 height≈50，手机胶囊的 height≈48；curRect 直接反映真实值
             var ballBottom = curRect.top + (curRect.height || MINIMIZED_SIZE);
 
             // 恢复保存的尺寸
@@ -1094,9 +1130,10 @@
             expandedRect = shell.getBoundingClientRect();
 
             // 计算初始缩放：transform-origin 为左下角 (0% 100%)
-            // 缩放到 MINIMIZED_SIZE 时，视觉上的左下角保持不变
-            var sx2 = MINIMIZED_SIZE / expandedRect.width;
-            var sy2 = MINIMIZED_SIZE / expandedRect.height;
+            // 从当前最小化态的真实尺寸缩回（桌面 50x50 / 手机 full-width x 48），
+            // 视觉上的左下角保持不变。
+            var sx2 = curRect.width > 0 ? curRect.width / expandedRect.width : 1;
+            var sy2 = curRect.height > 0 ? curRect.height / expandedRect.height : 1;
 
             // 设置初始 transform（看起来还是左下角的小圆）
             shell.style.transform = 'scale(' + sx2 + ', ' + sy2 + ')';
@@ -1585,12 +1622,23 @@
             var overlay = getOverlay();
             if (overlay && !overlay.hidden) {
                 if (minimized) {
-                    // 球留在当前位置，只需确保不溢出屏幕
+                    // 最小化态下，根据当前布局（桌面圆球 / 手机胶囊）重新贴到视口内。
+                    // 手机胶囊宽度由 CSS !important 控制（width: calc(100vw - 12px)），
+                    // 这里只需修正左上角坐标，避免旋转屏或拖窗后溢出。
                     var shell = getShell();
                     if (shell) {
                         var r = shell.getBoundingClientRect();
-                        var safeLeft = Math.max(0, Math.min(r.left, window.innerWidth - MINIMIZED_SIZE));
-                        var safeTop = Math.max(0, Math.min(r.top, window.innerHeight - MINIMIZED_SIZE));
+                        var minW = r.width || MINIMIZED_SIZE;
+                        var minH = r.height || MINIMIZED_SIZE;
+                        var safeLeft, safeTop;
+                        if (isMobileWidth()) {
+                            // 胶囊始终贴屏幕底部中心，左右留 6px
+                            safeLeft = MOBILE_CAPSULE_MARGIN;
+                            safeTop = Math.max(0, window.innerHeight - MOBILE_CAPSULE_HEIGHT - MOBILE_CAPSULE_MARGIN);
+                        } else {
+                            safeLeft = Math.max(0, Math.min(r.left, window.innerWidth - minW));
+                            safeTop = Math.max(0, Math.min(r.top, window.innerHeight - minH));
+                        }
                         if (safeLeft !== r.left || safeTop !== r.top) {
                             shell.style.left = safeLeft + 'px';
                             shell.style.top = safeTop + 'px';

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2110,7 +2110,10 @@ body.react-chat-window-dragging {
         background: transparent;
     }
 
-    #react-chat-window-shell {
+    /* React chat window 移动端规则仅作用于 index.html 等真正的浏览器手机端。
+       chat.html 是 Electron 独立窗口（无论拖得多窄都应走 PC 逻辑），
+       在 <body> 加 .electron-chat-window 从此媒体查询中排除。 */
+    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
         width: calc(100vw - 12px);
         height: auto;
         max-height: 50vh;
@@ -2124,14 +2127,14 @@ body.react-chat-window-dragging {
         overflow: hidden;
     }
 
-    #react-chat-window-shell #react-chat-window-root {
+    body:not(.electron-chat-window) #react-chat-window-shell #react-chat-window-root {
         height: 100%;
         flex: 1 1 auto;
         overflow: hidden;
         min-height: 0;
     }
 
-    #react-chat-window-shell .app-shell {
+    body:not(.electron-chat-window) #react-chat-window-shell .app-shell {
         height: 100%;
         display: flex;
         flex-direction: column;
@@ -2141,7 +2144,7 @@ body.react-chat-window-dragging {
     /* 窄屏与桌面统一用 grid 布局：auto(顶栏) 1fr(消息) auto(输入) +
        overflow:hidden 保证输入区不会被消息挤出。shell 尺寸仍由
        syncMobileContentLayout() 写成显式像素（根据内容 50vh 上限）。 */
-    #react-chat-window-shell .chat-window {
+    body:not(.electron-chat-window) #react-chat-window-shell .chat-window {
         height: 100%;
         display: grid;
         grid-template-rows: auto 1fr auto;
@@ -2149,12 +2152,12 @@ body.react-chat-window-dragging {
         overflow: hidden;
     }
 
-    #react-chat-window-shell .chat-body {
+    body:not(.electron-chat-window) #react-chat-window-shell .chat-body {
         min-height: 0;
         overflow: hidden;
     }
 
-    #react-chat-window-shell .message-list {
+    body:not(.electron-chat-window) #react-chat-window-shell .message-list {
         height: 100%;
         min-height: 0;
         overflow-y: auto;
@@ -2163,20 +2166,42 @@ body.react-chat-window-dragging {
 
     /* .is-mobile-content-capped 现在不再影响布局（message-list 始终可滚），
        保留空规则以免其他位置若有依赖时出现样式回退。 */
-    #react-chat-window-shell.is-mobile-content-capped .message-list {
+    body:not(.electron-chat-window) #react-chat-window-shell.is-mobile-content-capped .message-list {
         overflow-y: auto;
     }
 
     /* Mobile: hide the divider between translate and jukebox plus the last tool button (jukebox)
        to reduce clutter on small screens. If the tool order changes, replace these positional
        selectors with a dedicated class or data attribute on the affected controls. */
-    #react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
-    #react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
+    body:not(.electron-chat-window) #react-chat-window-shell .composer-bottom-tools > .composer-tool-divider:nth-last-child(2),
+    body:not(.electron-chat-window) #react-chat-window-shell .composer-bottom-tools > .composer-tool-btn:last-child {
         display: none;
     }
 
-    #react-chat-window-drag-handle {
+    body:not(.electron-chat-window) #react-chat-window-drag-handle {
         cursor: default;
+    }
+
+    /* ---- 手机端最小化：全宽底部胶囊（替代 50px 圆球）----
+       胶囊横跨屏幕底部，点击即展开；比左下角小圆球更符合手机底栏交互习惯。
+       具体最小化尺寸由 JS 通过 transform scale 动画过渡到此 CSS 终态。 */
+    body:not(.electron-chat-window) #react-chat-window-shell.is-minimized {
+        width: calc(100vw - 12px) !important;
+        height: 48px !important;
+        border-radius: 24px;
+    }
+
+    body:not(.electron-chat-window) #react-chat-window-shell.is-minimized #react-chat-window-drag-handle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    body:not(.electron-chat-window) #react-chat-window-shell.is-minimized .react-chat-minimized-icon {
+        width: 28px;
+        height: 28px;
+        /* 居中显示而非填满整条胶囊 */
+        object-fit: contain;
     }
 
     #chat-container.minimized::before {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -343,7 +343,7 @@
         }
     </style>
 </head>
-<body>
+<body class="electron-chat-window">
 
     <div id="status-toast"></div>
 


### PR DESCRIPTION
## 背景 / 承接 #758

PR #758 把窄屏 React 聊天框切到 grid 布局修好了 composer 被挤的 bug，但"影响范围"表格有两处误判，且遗留两个用户可感知问题：

1. **chat.html（Electron 独立窗口）被 `@media (max-width: 768px)` 污染**。#758 声称"顺带修掉同源隐患"，实际 chat.html 本就不应该走手机端布局 —— 用户把 Electron 窗口拖窄到 <768px 时，内部 `.chat-window` / `.message-list` / composer 等 class 被手机规则改写；且 `isMobileWidth()` 把 Electron 窄窗口误判为手机导致 drag / resize 全失效。
2. **手机端 `.is-minimized`（50px 左下角圆球）点击无法恢复**。根因是 `@media ≤768px` 的 `bottom: 6px; left: 6px; display: flex` 与 `.is-minimized { width/height: 50px !important }` 特异性冲突，污染圆球定位与 drag-handle 内部点击区域。

## 修复

### 前置：Electron 隔离

- `templates/chat.html`：`<body>` 加 `class="electron-chat-window"` 作为身份标记
- `app-react-chat-window.js`：`isMobileWidth()` 检查该 class，Electron 一律按 PC 行为
- `index.css`：`@media (max-width: 768px)` 里所有 `#react-chat-window-*` 规则加上 `body:not(.electron-chat-window)` 前缀，保证只对真·手机端（index.html 窄屏）生效

### 手机端最小化改为底部胶囊（bottom-sheet 风）

手机端 `.is-minimized` 从 50px 左下角圆球改成全宽底部胶囊（`calc(100vw - 12px) × 48px`, `border-radius: 24px`），更符合移动 App 底栏交互习惯。

- 新增 `getMinimizedTarget(rect)` 根据 `isMobileWidth()` 返回目标几何：
  - 桌面：50×50 圆球，锚定在对话框原左下角
  - 手机：全宽 48px 胶囊，贴屏幕底边
- `setMinimized()` 的 collapse / expand 动画不再硬编码 `MINIMIZED_SIZE`；`transform-origin` 保持 `0% 100%`（左下角），对两种形态都正确
- `window.resize` handler 在最小化态按布局重新 clamp 位置

## 影响范围

| 场景 | 之前 | 之后 |
|---|---|---|
| chat.html Electron 任意宽度 | 窄时走手机端规则 / drag resize 失效 | 永远 PC 行为 |
| index.html 手机端展开 (≤768px) | composer 可能被挤（#758 修了） | grid 布局稳固（#758 的 fix 仍生效）|
| index.html 手机端最小化 (≤768px) | 左下角 50px 圆球，点击恢复无反应 | 底部全宽胶囊，点击恢复正常 |
| index.html / chat.html PC 宽屏 (>768px) | — | **零改动** |

## Test plan

- [ ] chat.html Electron 宽窗口：drag / resize / 最小化圆球在左下角均正常
- [ ] chat.html Electron 拖到 <768px 窄窗口：仍然是 PC 行为（不再错走手机布局）
- [ ] index.html PC 宽屏 (>768px)：无视觉回归，冒烟核对布局/滚动/输入框与上线前一致
- [ ] index.html 手机/窄屏 (≤768px)：DevTools 切到移动模拟器
  - [ ] 展开态：50vh cap、消息可滚、输入框稳固（#758 的行为保留）
  - [ ] 点最小化按钮：shrink 到底部胶囊，动画平滑
  - [ ] 点胶囊：展开动画平滑，恢复到原高度
  - [ ] 旋转屏 / 窗口尺寸变化：胶囊始终贴底部
- [ ] 暗色模式下以上场景各过一遍

https://claude.ai/code/session_01BEKipEbGLanimtBGeMNYyC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Electron 窗口在窄屏下被误判为移动设备的问题，确保使用桌面布局与缩放逻辑。
  * 优化最小化/还原动画的缩放与定位计算，提升各种尺寸和窗口缩放下的表现。
  * 改进窗口尺寸变化时的最小化重定位，避免溢出或错位。

* **New Features**
  * 在移动端引入全宽底部“胶囊”最小化样式，并居中最小化图标。
  * 在 HTML 根节点添加 Electron 标识类，CSS 针对 Electron 窗口做特殊排除。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->