### PR TITLE
fix: VRM 滚轮缩放对齐 MMD，避免角色在屏幕边缘被缩出画面

### DIFF
--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -367,6 +367,8 @@ class VRMInteraction {
         };
 
         // 6. 滚轮缩放
+        // 对齐 MMD 行为：直接缩放 scene.scale，围绕模型自身原点进行，
+        // 避免因 "相机靠近固定 _cameraTarget" 在角色被拖到边缘时把角色甩出屏幕。
         this.wheelHandler = (e) => {
             if (this.checkLocked() || !this.manager.currentModel) return;
 
@@ -386,42 +388,25 @@ class VRMInteraction {
             e.preventDefault();
             e.stopPropagation();
 
-            if (!THREE) {
-                console.error('[VRM Interaction] THREE.js 未加载，无法处理滚轮缩放');
-                return;
+            const scene = this.manager.currentModel.scene;
+            if (!scene) return;
+
+            const scaleFactor = e.deltaY > 0 ? 0.95 : 1.05;
+            // 夹到一个合理范围，避免反复滚轮把模型缩到 0 或爆炸大
+            const minScale = 0.1;
+            const maxScale = 10.0;
+            const currentScale = scene.scale.x || 1;
+            const newScale = Math.max(minScale, Math.min(maxScale, currentScale * scaleFactor));
+
+            // 通过 manager.setModelScaleScalar 统一缩放，同时同步 SpringBone 碰撞体半径
+            if (typeof this.manager.setModelScaleScalar === 'function') {
+                this.manager.setModelScaleScalar(newScale);
+            } else {
+                scene.scale.setScalar(newScale);
             }
 
-            const delta = e.deltaY;
-            const zoomSpeed = 0.05;
-            const zoomFactor = delta > 0 ? (1 + zoomSpeed) : (1 - zoomSpeed);
-
-            if (this.manager.currentModel.scene && this.manager.camera) {
-                // 使用统一的 _cameraTarget 作为缩放中心
-                const zoomCenter = this.manager._cameraTarget
-                    ? this.manager._cameraTarget.clone()
-                    : new THREE.Vector3(0, 0, 0);
-
-                const oldDistance = this.manager.camera.position.distanceTo(zoomCenter);
-                const minDist = 0.5;
-                const maxDist = 20.0;
-
-                let newDistance = oldDistance * zoomFactor;
-                newDistance = Math.max(minDist, Math.min(maxDist, newDistance));
-
-                const direction = new THREE.Vector3()
-                    .subVectors(this.manager.camera.position, zoomCenter)
-                    .normalize();
-
-                this.manager.camera.position.copy(zoomCenter)
-                    .add(direction.multiplyScalar(newDistance));
-
-                if (this.manager.controls && this.manager.controls.update) {
-                    this.manager.controls.update();
-                }
-
-                // 缩放结束后防抖保存位置
-                this._debouncedSavePosition();
-            }
+            // 缩放结束后防抖保存位置
+            this._debouncedSavePosition();
         };
 
         this.auxClickHandler = (e) => {

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -398,12 +398,14 @@ class VRMInteraction {
             const currentScale = scene.scale.x || 1;
             const newScale = Math.max(minScale, Math.min(maxScale, currentScale * scaleFactor));
 
-            // 通过 manager.setModelScaleScalar 统一缩放，同时同步 SpringBone 碰撞体半径
-            if (typeof this.manager.setModelScaleScalar === 'function') {
-                this.manager.setModelScaleScalar(newScale);
-            } else {
-                scene.scale.setScalar(newScale);
+            // 通过 manager.setModelScaleScalar 统一缩放，同时同步 SpringBone 碰撞体半径。
+            // 这里不走 scene.scale.setScalar 的静默回退：那样只会缩视觉 mesh、不同步 collider，
+            // 反而把状态失配藏起来。API 不可用时显式告警并中止，以便尽早暴露问题。
+            if (typeof this.manager.setModelScaleScalar !== 'function') {
+                console.warn('[VRM Interaction] manager.setModelScaleScalar 不可用，跳过缩放以避免 SpringBone 状态失配');
+                return;
             }
+            this.manager.setModelScaleScalar(newScale);
 
             // 缩放结束后防抖保存位置
             this._debouncedSavePosition();

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -394,7 +394,7 @@ class VRMInteraction {
             const scaleFactor = e.deltaY > 0 ? 0.95 : 1.05;
             // 夹到一个合理范围，避免反复滚轮把模型缩到 0 或爆炸大
             const minScale = 0.1;
-            const maxScale = 10.0;
+            const maxScale = 50.0;
             const currentScale = scene.scale.x || 1;
             const newScale = Math.max(minScale, Math.min(maxScale, currentScale * scaleFactor));
 


### PR DESCRIPTION
## 问题

VRM 模型用滚轮缩放时，**如果角色先被拖到屏幕边缘**，继续滚轮会把角色缩到屏幕外面，看上去就像"往屏幕中心缩"。MMD 没有这个问题。

## 根因

`static/vrm-interaction.js` 的 `wheelHandler` 原实现是**移动相机**，把 `camera.position` 沿着指向 `_cameraTarget` 的方向靠近/远离：

```js
const zoomCenter = this.manager._cameraTarget
    ? this.manager._cameraTarget.clone()
    : new THREE.Vector3(0, 0, 0);
// ...
this.manager.camera.position.copy(zoomCenter)
    .add(direction.multiplyScalar(newDistance));
```

而 `_cameraTarget` 在 `vrm-manager.js:875` / `vrm-core.js:980` 都是 `new THREE.Vector3(0, center.y, 0)`——**场景原点上方的角色胸口位置**。pan 拖动 (`vrm-interaction.js:253-260`) 改的是 `scene.position`，**完全不会更新 `_cameraTarget`**。

于是：
1. 用户把角色拖到 `(-3, 0, 0)`，`_cameraTarget` 还留在 `(0, center.y, 0)`
2. 滚轮缩放让相机靠近 `(0, center.y, 0)`
3. 相机距离减半 → 同样的世界横向偏移在屏幕上的角度位置翻倍
4. 原本偏离画面中心的角色被透视"甩"到屏幕外

对比：MMD (`static/mmd-interaction.js:314-315`) 直接 `mesh.scale.multiplyScalar(scaleFactor)`，围绕 mesh 自身原点缩放，相机不动，屏幕位置保持。

## 修复

对齐 MMD 行为：改为直接缩放 `scene.scale`。

```js
const scaleFactor = e.deltaY > 0 ? 0.95 : 1.05;
const newScale = Math.max(0.1, Math.min(50.0, (scene.scale.x || 1) * scaleFactor));
this.manager.setModelScaleScalar(newScale);
this._debouncedSavePosition();
```

- 走 `manager.setModelScaleScalar`（`vrm-manager.js:1321`），同步 SpringBone 碰撞体半径，避免缩放后头发/裙摆抖动异常
- `scene.scale` 本来就被现有的 `_savePositionAfterInteraction` 保存、`vrm-core.js:807` 恢复，持久化链路免费复用
- 夹到 `[0.1, 50.0]` 避免反复滚轮缩到 0 或爆炸大
- orbit（右键拖）仍然负责相机移动，zoom 与 orbit 解耦，不再耦合出奇怪 bug

## 已知小影响

老用户的 `preferences.camera_position` 里可能记录着之前滚轮遗留的"靠很近/很远"的相机距离，下次加载会还原那个相机状态，表现为"画面被裁了但模型是默认大小"。再滚一次滚轮 / 点一次"重置位置"即可恢复正常。是一次性影响。

## 测试计划

- [ ] VRM 模型加载后，角色居中时滚轮，观察缩放围绕角色自身（OK）
- [ ] 把角色 pan 到屏幕最左/最右/最上/最下，滚轮，角色应保持在屏幕原位只是尺寸变化（修复点）
- [ ] 缩放后刷新/切角色/重启，scale 应被正确恢复
- [ ] 缩放后 SpringBone（头发/裙摆）物理表现正常
- [ ] MMD 滚轮缩放行为无变化（未改动 MMD 代码）

https://claude.ai/code/session_01RwwCTk5dnjARWHPmLH9zwx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 重构了鼠标滚轮缩放：改为直接缩放模型场景，缩放行为更稳定自然，不再通过移动摄像机实现
  * 引入基于滚轮方向的倍数缩放并限制在 0.1–50 倍范围，避免过度或过小缩放
  * 缩放后始终保存状态以便恢复
  * 若外部缩放委托不可用，会记录警告并停止缩放以防不一致行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->