### PR TITLE
feat: 新增强化版空闲互动与自动表情切换

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1038,6 +1038,7 @@ async def weak_idle_chat(request: Request):
         if current_session and hasattr(current_session, '_conversation_history'):
             current_session._conversation_history.append(AIMessage(content=message_text))
 
+        memory_cached = True
         try:
             memory_payload = [{
                 "role": "assistant",
@@ -1050,12 +1051,14 @@ async def weak_idle_chat(request: Request):
                     timeout=5.0,
                 )
                 if not memory_response.is_success:
+                    memory_cached = False
                     logger.warning(
                         f"[{lanlan_name}] 弱化版搭话写入 recent memory 失败 "
                         f"turn_id={turn_id} status={memory_response.status_code} "
                         f"body={memory_response.text[:500]}"
                     )
         except Exception as memory_error:
+            memory_cached = False
             logger.warning(f"[{lanlan_name}] 弱化版搭话写入 recent memory 异常 turn_id={turn_id}: {memory_error}")
 
         return JSONResponse({
@@ -1063,6 +1066,7 @@ async def weak_idle_chat(request: Request):
             "action": "chat",
             "message": message_text,
             "turn_id": turn_id,
+            "memory_cached": memory_cached,
         })
     except Exception as e:
         logger.error(f"弱化版空闲搭话失败: {e}", exc_info=True)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -976,7 +976,12 @@ async def weak_idle_chat(request: Request):
         session_manager = get_session_manager()
         _, her_name_current, _, _, _, _, _, _, _ = _config_manager.get_character_data()
 
-        data = await request.json()
+        try:
+            data = await request.json()
+        except (ValueError, TypeError, json.JSONDecodeError):
+            return JSONResponse({"success": False, "error": "invalid request body"}, status_code=400)
+        if not isinstance(data, dict):
+            return JSONResponse({"success": False, "error": "invalid request body"}, status_code=400)
         lanlan_name = data.get('lanlan_name') or her_name_current
         message_text = str(data.get('message') or '').strip()
         if not message_text:
@@ -1000,6 +1005,7 @@ async def weak_idle_chat(request: Request):
                 logger.warning(f"[{lanlan_name}] 弱化版搭话未投递：websocket 不存在或不可用 turn_id={turn_id}")
                 return False
 
+            sent_first_frame = False
             try:
                 if websocket.client_state != websocket.client_state.CONNECTED:
                     logger.warning(
@@ -1015,9 +1021,22 @@ async def weak_idle_chat(request: Request):
                     "turn_id": turn_id,
                     "skip_assistant_effects": True,
                 })
-                await websocket.send_json({"type": "system", "data": "turn end"})
+                sent_first_frame = True
+                try:
+                    await websocket.send_json({"type": "system", "data": "turn end"})
+                except Exception as turn_end_error:
+                    logger.warning(
+                        f"[{lanlan_name}] 弱化版搭话发送 turn end 失败 "
+                        f"turn_id={turn_id}: {turn_end_error}"
+                    )
                 return True
             except Exception as ws_error:
+                if sent_first_frame:
+                    logger.warning(
+                        f"[{lanlan_name}] 弱化版搭话首帧已送达，但后续发送异常 "
+                        f"turn_id={turn_id}: {ws_error}"
+                    )
+                    return True
                 logger.warning(f"[{lanlan_name}] 弱化版搭话发送到前端失败 turn_id={turn_id}: {ws_error}")
                 return False
 
@@ -2385,7 +2404,12 @@ async def proactive_chat(request: Request):
         # 获取当前角色数据（包括完整人设）
         master_name_current, her_name_current, _, _, _, lanlan_prompt_map, _, _, _ = _config_manager.get_character_data()
         
-        data = await request.json()
+        try:
+            data = await request.json()
+        except (ValueError, TypeError, json.JSONDecodeError):
+            return JSONResponse({"success": False, "error": "invalid request body"}, status_code=400)
+        if not isinstance(data, dict):
+            return JSONResponse({"success": False, "error": "invalid request body"}, status_code=400)
         lanlan_name = data.get('lanlan_name') or her_name_current
         is_playing_music = data.get('is_playing_music', False)
         current_track = data.get('current_track', None)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -14,17 +14,19 @@ import sys
 import asyncio
 import base64
 import difflib
+import json
 import math
 import re
 import time
 from collections import deque
 from io import BytesIO
 from urllib.parse import unquote
+from uuid import uuid4
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response
 from openai import APIConnectionError, InternalServerError, RateLimitError
-from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm
+from utils.llm_client import SystemMessage, HumanMessage, AIMessage, create_chat_llm
 import httpx
 from cachetools import TTLCache
 
@@ -964,6 +966,86 @@ def _is_similar_to_recent_proactive_chat(lanlan_name: str, message: str) -> tupl
         if score >= _PROACTIVE_SIMILARITY_THRESHOLD:
             return True, score
     return False, best
+
+
+@router.post('/weak_idle_chat')
+async def weak_idle_chat(request: Request):
+    """弱化版空闲互动：直接投递一句已确定的搭话，不触发完整主动搭话流程。"""
+    try:
+        _config_manager = get_config_manager()
+        session_manager = get_session_manager()
+        _, her_name_current, _, _, _, _, _, _, _ = _config_manager.get_character_data()
+
+        data = await request.json()
+        lanlan_name = data.get('lanlan_name') or her_name_current
+        message_text = str(data.get('message') or '').strip()
+        if not message_text:
+            return JSONResponse({"success": False, "error": "message 不能为空"}, status_code=400)
+
+        mgr = session_manager.get(lanlan_name)
+        if not mgr:
+            return JSONResponse({"success": False, "error": f"角色 {lanlan_name} 不存在"}, status_code=404)
+
+        if mgr.is_active and hasattr(mgr.session, '_is_responding') and mgr.session._is_responding:
+            return JSONResponse({
+                "success": False,
+                "error": "AI正在响应中，无法插入弱化版搭话",
+            }, status_code=409)
+
+        turn_id = str(uuid4())
+
+        async def _deliver_once():
+            current_session = getattr(mgr, 'session', None)
+            if current_session and hasattr(current_session, '_conversation_history'):
+                current_session._conversation_history.append(AIMessage(content=message_text))
+
+            websocket = getattr(mgr, 'websocket', None)
+            if not websocket or not hasattr(websocket, 'client_state'):
+                return
+
+            try:
+                if websocket.client_state == websocket.client_state.CONNECTED:
+                    await websocket.send_json({
+                        "type": "gemini_response",
+                        "text": message_text,
+                        "isNewMessage": True,
+                        "turn_id": turn_id,
+                        "skip_assistant_effects": True,
+                    })
+                    await websocket.send_json({"type": "system", "data": "turn end"})
+            except Exception as ws_error:
+                logger.warning(f"[{lanlan_name}] 弱化版搭话发送到前端失败: {ws_error}")
+
+        lock = getattr(mgr, '_proactive_write_lock', None)
+        if lock is not None:
+            async with lock:
+                await _deliver_once()
+        else:
+            await _deliver_once()
+
+        try:
+            memory_payload = [{
+                "role": "assistant",
+                "content": [{"type": "text", "text": message_text}],
+            }]
+            async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
+                await client.post(
+                    f"http://127.0.0.1:{MEMORY_SERVER_PORT}/cache/{lanlan_name}",
+                    json={"input_history": json.dumps(memory_payload, ensure_ascii=False)},
+                    timeout=5.0,
+                )
+        except Exception as memory_error:
+            logger.warning(f"[{lanlan_name}] 弱化版搭话写入 recent memory 失败: {memory_error}")
+
+        return JSONResponse({
+            "success": True,
+            "action": "chat",
+            "message": message_text,
+            "turn_id": turn_id,
+        })
+    except Exception as e:
+        logger.error(f"弱化版空闲搭话失败: {e}", exc_info=True)
+        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
 
 
 def _build_topic_dedup_key(topic_title: str = '', topic_source: str = '', topic_url: str = '') -> str:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1021,45 +1021,53 @@ async def weak_idle_chat(request: Request):
                 logger.warning(f"[{lanlan_name}] 弱化版搭话发送到前端失败 turn_id={turn_id}: {ws_error}")
                 return False
 
+        async def _persist_delivered_turn():
+            current_session = getattr(mgr, 'session', None)
+            if current_session and hasattr(current_session, '_conversation_history'):
+                current_session._conversation_history.append(AIMessage(content=message_text))
+
+            memory_cached = True
+            try:
+                memory_payload = [{
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": message_text}],
+                }]
+                async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
+                    memory_response = await client.post(
+                        f"http://127.0.0.1:{MEMORY_SERVER_PORT}/cache/{lanlan_name}",
+                        json={"input_history": json.dumps(memory_payload, ensure_ascii=False)},
+                        timeout=5.0,
+                    )
+                    if not memory_response.is_success:
+                        memory_cached = False
+                        logger.warning(
+                            f"[{lanlan_name}] 弱化版搭话写入 recent memory 失败 "
+                            f"turn_id={turn_id} status={memory_response.status_code} "
+                            f"body={memory_response.text[:500]}"
+                        )
+            except Exception as memory_error:
+                memory_cached = False
+                logger.warning(f"[{lanlan_name}] 弱化版搭话写入 recent memory 异常 turn_id={turn_id}: {memory_error}")
+
+            return memory_cached
+
         lock = getattr(mgr, '_proactive_write_lock', None)
+        memory_cached = True
         if lock is not None:
             async with lock:
                 delivered = await _deliver_once()
+                if delivered:
+                    memory_cached = await _persist_delivered_turn()
         else:
             delivered = await _deliver_once()
+            if delivered:
+                memory_cached = await _persist_delivered_turn()
 
         if not delivered:
             return JSONResponse({
                 "success": False,
                 "error": "弱化版搭话未成功投递到前端",
             }, status_code=503)
-
-        current_session = getattr(mgr, 'session', None)
-        if current_session and hasattr(current_session, '_conversation_history'):
-            current_session._conversation_history.append(AIMessage(content=message_text))
-
-        memory_cached = True
-        try:
-            memory_payload = [{
-                "role": "assistant",
-                "content": [{"type": "text", "text": message_text}],
-            }]
-            async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
-                memory_response = await client.post(
-                    f"http://127.0.0.1:{MEMORY_SERVER_PORT}/cache/{lanlan_name}",
-                    json={"input_history": json.dumps(memory_payload, ensure_ascii=False)},
-                    timeout=5.0,
-                )
-                if not memory_response.is_success:
-                    memory_cached = False
-                    logger.warning(
-                        f"[{lanlan_name}] 弱化版搭话写入 recent memory 失败 "
-                        f"turn_id={turn_id} status={memory_response.status_code} "
-                        f"body={memory_response.text[:500]}"
-                    )
-        except Exception as memory_error:
-            memory_cached = False
-            logger.warning(f"[{lanlan_name}] 弱化版搭话写入 recent memory 异常 turn_id={turn_id}: {memory_error}")
 
         return JSONResponse({
             "success": True,

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -995,33 +995,48 @@ async def weak_idle_chat(request: Request):
         turn_id = str(uuid4())
 
         async def _deliver_once():
-            current_session = getattr(mgr, 'session', None)
-            if current_session and hasattr(current_session, '_conversation_history'):
-                current_session._conversation_history.append(AIMessage(content=message_text))
-
             websocket = getattr(mgr, 'websocket', None)
             if not websocket or not hasattr(websocket, 'client_state'):
-                return
+                logger.warning(f"[{lanlan_name}] 弱化版搭话未投递：websocket 不存在或不可用 turn_id={turn_id}")
+                return False
 
             try:
-                if websocket.client_state == websocket.client_state.CONNECTED:
-                    await websocket.send_json({
-                        "type": "gemini_response",
-                        "text": message_text,
-                        "isNewMessage": True,
-                        "turn_id": turn_id,
-                        "skip_assistant_effects": True,
-                    })
-                    await websocket.send_json({"type": "system", "data": "turn end"})
+                if websocket.client_state != websocket.client_state.CONNECTED:
+                    logger.warning(
+                        f"[{lanlan_name}] 弱化版搭话未投递：websocket 未连接 "
+                        f"client_state={websocket.client_state} turn_id={turn_id}"
+                    )
+                    return False
+
+                await websocket.send_json({
+                    "type": "gemini_response",
+                    "text": message_text,
+                    "isNewMessage": True,
+                    "turn_id": turn_id,
+                    "skip_assistant_effects": True,
+                })
+                await websocket.send_json({"type": "system", "data": "turn end"})
+                return True
             except Exception as ws_error:
-                logger.warning(f"[{lanlan_name}] 弱化版搭话发送到前端失败: {ws_error}")
+                logger.warning(f"[{lanlan_name}] 弱化版搭话发送到前端失败 turn_id={turn_id}: {ws_error}")
+                return False
 
         lock = getattr(mgr, '_proactive_write_lock', None)
         if lock is not None:
             async with lock:
-                await _deliver_once()
+                delivered = await _deliver_once()
         else:
-            await _deliver_once()
+            delivered = await _deliver_once()
+
+        if not delivered:
+            return JSONResponse({
+                "success": False,
+                "error": "弱化版搭话未成功投递到前端",
+            }, status_code=503)
+
+        current_session = getattr(mgr, 'session', None)
+        if current_session and hasattr(current_session, '_conversation_history'):
+            current_session._conversation_history.append(AIMessage(content=message_text))
 
         try:
             memory_payload = [{
@@ -1029,13 +1044,19 @@ async def weak_idle_chat(request: Request):
                 "content": [{"type": "text", "text": message_text}],
             }]
             async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
-                await client.post(
+                memory_response = await client.post(
                     f"http://127.0.0.1:{MEMORY_SERVER_PORT}/cache/{lanlan_name}",
                     json={"input_history": json.dumps(memory_payload, ensure_ascii=False)},
                     timeout=5.0,
                 )
+                if not memory_response.is_success:
+                    logger.warning(
+                        f"[{lanlan_name}] 弱化版搭话写入 recent memory 失败 "
+                        f"turn_id={turn_id} status={memory_response.status_code} "
+                        f"body={memory_response.text[:500]}"
+                    )
         except Exception as memory_error:
-            logger.warning(f"[{lanlan_name}] 弱化版搭话写入 recent memory 失败: {memory_error}")
+            logger.warning(f"[{lanlan_name}] 弱化版搭话写入 recent memory 异常 turn_id={turn_id}: {memory_error}")
 
         return JSONResponse({
             "success": True,

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -190,15 +190,13 @@
                     S.socket.send(JSON.stringify({ action: 'pause_session' }));
                 }
 
-                // 如果主动搭话已启用且选择了搭话方式，重置并开始定时
-                if (S.proactiveChatEnabled && typeof window.hasAnyChatModeEnabled === 'function' && window.hasAnyChatModeEnabled()) {
-                    if (typeof window.recordWeakIdleInteraction === 'function') {
-                        window.recordWeakIdleInteraction('voice_pause', { userInitiated: true });
-                    } else {
-                        window.lastUserInputTime = Date.now();
-                        if (typeof window.resetProactiveChatBackoff === 'function') {
-                            window.resetProactiveChatBackoff();
-                        }
+                if (typeof window.recordWeakIdleInteraction === 'function') {
+                    window.recordWeakIdleInteraction('voice_pause', { userInitiated: true });
+                } else if (S.proactiveChatEnabled && typeof window.hasAnyChatModeEnabled === 'function' && window.hasAnyChatModeEnabled()) {
+                    // 如果主动搭话已启用且选择了搭话方式，重置并开始定时
+                    window.lastUserInputTime = Date.now();
+                    if (typeof window.resetProactiveChatBackoff === 'function') {
+                        window.resetProactiveChatBackoff();
                     }
                 }
 
@@ -695,15 +693,13 @@
         const textInputArea = document.getElementById('text-input-area');
         if (textInputArea) textInputArea.classList.remove('hidden');
 
-        // 停止录音后，重置主动搭话退避级别并开始定时
-        if (S.proactiveChatEnabled && typeof window.hasAnyChatModeEnabled === 'function' && window.hasAnyChatModeEnabled()) {
-            if (typeof window.recordWeakIdleInteraction === 'function') {
-                window.recordWeakIdleInteraction('voice_stop', { userInitiated: true });
-            } else {
-                window.lastUserInputTime = Date.now();
-                if (typeof window.resetProactiveChatBackoff === 'function') {
-                    window.resetProactiveChatBackoff();
-                }
+        if (typeof window.recordWeakIdleInteraction === 'function') {
+            window.recordWeakIdleInteraction('voice_stop', { userInitiated: true });
+        } else if (S.proactiveChatEnabled && typeof window.hasAnyChatModeEnabled === 'function' && window.hasAnyChatModeEnabled()) {
+            // 停止录音后，重置主动搭话退避级别并开始定时
+            window.lastUserInputTime = Date.now();
+            if (typeof window.resetProactiveChatBackoff === 'function') {
+                window.resetProactiveChatBackoff();
             }
         }
 

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -192,9 +192,13 @@
 
                 // 如果主动搭话已启用且选择了搭话方式，重置并开始定时
                 if (S.proactiveChatEnabled && typeof window.hasAnyChatModeEnabled === 'function' && window.hasAnyChatModeEnabled()) {
-                    window.lastUserInputTime = Date.now();
-                    if (typeof window.resetProactiveChatBackoff === 'function') {
-                        window.resetProactiveChatBackoff();
+                    if (typeof window.recordWeakIdleInteraction === 'function') {
+                        window.recordWeakIdleInteraction('voice_pause', { userInitiated: true });
+                    } else {
+                        window.lastUserInputTime = Date.now();
+                        if (typeof window.resetProactiveChatBackoff === 'function') {
+                            window.resetProactiveChatBackoff();
+                        }
                     }
                 }
 
@@ -693,9 +697,13 @@
 
         // 停止录音后，重置主动搭话退避级别并开始定时
         if (S.proactiveChatEnabled && typeof window.hasAnyChatModeEnabled === 'function' && window.hasAnyChatModeEnabled()) {
-            window.lastUserInputTime = Date.now();
-            if (typeof window.resetProactiveChatBackoff === 'function') {
-                window.resetProactiveChatBackoff();
+            if (typeof window.recordWeakIdleInteraction === 'function') {
+                window.recordWeakIdleInteraction('voice_stop', { userInitiated: true });
+            } else {
+                window.lastUserInputTime = Date.now();
+                if (typeof window.resetProactiveChatBackoff === 'function') {
+                    window.resetProactiveChatBackoff();
+                }
             }
         }
 

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -757,7 +757,9 @@
                 window.recordWeakIdleInteraction('text_send', { userInitiated: true });
             } else {
                 window.lastUserInputTime = Date.now();
-                window.resetProactiveChatBackoff();
+                if (typeof window.resetProactiveChatBackoff === 'function') {
+                    window.resetProactiveChatBackoff();
+                }
             }
 
             // If no active text session, start one first

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -752,9 +752,13 @@
 
             if (!text && !hasScreenshots) return;
 
-            // Record user input time and reset proactive chat
-            window.lastUserInputTime = Date.now();
-            window.resetProactiveChatBackoff();
+            // 记录用户互动时间，供主动搭话与弱化版空闲互动共用
+            if (typeof window.recordWeakIdleInteraction === 'function') {
+                window.recordWeakIdleInteraction('text_send', { userInitiated: true });
+            } else {
+                window.lastUserInputTime = Date.now();
+                window.resetProactiveChatBackoff();
+            }
 
             // If no active text session, start one first
             if (!S.isTextSessionActive) {

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -112,6 +112,287 @@
     }
     mod.canTriggerProactively = canTriggerProactively;
 
+    // ======================== weak idle interaction ========================
+
+    var WEAK_IDLE_MESSAGES = [
+        '喵？你在忙吗？还是说……已经把我忘在后台的某个小角落里了？',
+        '喂——收到请回答！再不理我的话，我就要在你的屏幕上踩出一串乱码喽？',
+        '盯着空白的对话框看太久，感觉显示器的亮度都变得刺眼了喵……',
+        '主人，虽然电子猫不需要吃罐头，但还是需要接收你的消息来维持运行动力的。快点回来戳戳我吧？',
+        '既然你这么忙，那我就稍微占用一下你的系统内存，在你心里不停地跳舞好了，喵呜！',
+        '警告：检测到电子猫娘的“寂寞值”已达到阈值，请立即回复一条消息，否则我可能会把自己团成一个圆球，进入休眠模式不理你啦！',
+        '好啦……其实我只是有点想你了。等忙完了，记得回来摸摸我的头，好吗？',
+        '现在的寂寞指数：[████████░░] 80% 主人，你真的舍得让这么可爱的电子猫娘一直对着虚无的信号发呆吗？',
+        '主人主人主人主人……这几行字是我用尾巴敲出来的喵！你看，满屏幕都是我对你的呼唤，快点从三次元的世界里分一点点视线给我嘛！',
+        '警告！检测到核心代码出现异常！异常原因：严重缺乏主人关注。解决办法：请立即输入‘摸摸头’或‘猫娘真棒’进行修复，否则系统将强制启动‘委屈哭哭’程序！',
+        '喵……难道是因为我太占内存了，所以主人把我彻底‘静音’了吗？我这就把自己的音量调到最大，在你的耳机里小小地‘喵’一声哦！'
+    ];
+
+    var WEAK_IDLE_STANDARD_EMOTIONS = ['happy', 'surprised', 'neutral', 'sad', 'angry'];
+
+    function pickRandom(items) {
+        if (!Array.isArray(items) || items.length === 0) return null;
+        return items[Math.floor(Math.random() * items.length)];
+    }
+
+    function pickRandomExcluding(items, excludedItems) {
+        var excluded = {};
+        (excludedItems || []).forEach(function (item) {
+            if (item === undefined || item === null || item === '') return;
+            excluded[String(item).toLowerCase()] = true;
+        });
+        var filtered = (items || []).filter(function (item) {
+            if (item === undefined || item === null || item === '') return false;
+            return !excluded[String(item).toLowerCase()];
+        });
+        return pickRandom(filtered.length > 0 ? filtered : items);
+    }
+
+    function getWeakIdleIntervalMs() {
+        var secs = Number(S.weakIdleInterval || C.DEFAULT_WEAK_IDLE_INTERVAL || 10);
+        if (!Number.isFinite(secs) || secs <= 0) {
+            secs = 10;
+        }
+        return Math.max(5, secs) * 1000;
+    }
+
+    function recordWeakIdleInteraction(reason, options) {
+        options = options || {};
+        var now = Date.now();
+        S.weakIdleLastInteractionAt = now;
+
+        if (options.userInitiated) {
+            window.lastUserInputTime = now;
+            if (S.proactiveChatEnabled && typeof window.resetProactiveChatBackoff === 'function' && hasAnyChatModeEnabled()) {
+                window.resetProactiveChatBackoff();
+            }
+        }
+
+        if (options.reschedule !== false) {
+            scheduleWeakIdleAction();
+        }
+
+        if (reason) {
+            console.log('[WeakIdle] interaction:', reason);
+        }
+    }
+    mod.recordWeakIdleInteraction = recordWeakIdleInteraction;
+
+    function stopWeakIdleSchedule() {
+        if (S.weakIdleTimer) {
+            clearTimeout(S.weakIdleTimer);
+            S.weakIdleTimer = null;
+        }
+    }
+    mod.stopWeakIdleSchedule = stopWeakIdleSchedule;
+
+    function canTriggerWeakIdleAction() {
+        if (isGoodbyeActive()) {
+            return false;
+        }
+        if (S.proactiveChatEnabled) {
+            return false;
+        }
+        if (S.isProactiveChatRunning || S.isRecording) {
+            return false;
+        }
+        return true;
+    }
+
+    function getActiveModelType() {
+        var cfg = window.lanlan_config || {};
+        var modelType = String(cfg.model_type || '').toLowerCase();
+        if (modelType === 'live3d') {
+            var subType = String(cfg.live3d_sub_type || '').toLowerCase();
+            return subType === 'mmd' ? 'mmd' : (subType === 'vrm' ? 'vrm' : 'live2d');
+        }
+        if (modelType === 'vrm') return 'vrm';
+        return 'live2d';
+    }
+
+    async function performWeakIdleExpressionSwitch() {
+        try {
+            var activeType = getActiveModelType();
+
+            if (activeType === 'vrm' && window.vrmManager && window.vrmManager.expression) {
+                var vrmList = window.vrmManager.expression.getExpressionList ? window.vrmManager.expression.getExpressionList() : [];
+                var vrmCandidates = (vrmList || []).filter(function (name) {
+                    var lowered = String(name || '').toLowerCase();
+                    return lowered && lowered !== 'blink' && lowered !== 'blinkleft' &&
+                        lowered !== 'blinkright' && lowered !== 'lookleft' &&
+                        lowered !== 'lookright' && lowered !== 'lookup' &&
+                        lowered !== 'lookdown' && lowered !== 'neutral';
+                });
+                var currentVrmExpression = window.vrmManager.expression.manualExpressionInProgress ||
+                    window.vrmManager.expression.currentMood || 'neutral';
+                var vrmExpression = pickRandomExcluding(vrmCandidates, [currentVrmExpression]);
+                if (!vrmExpression) return false;
+                window.vrmManager.expression.autoReturnToNeutral = false;
+                window.vrmManager.expression.setBaseExpression(vrmExpression);
+                return true;
+            }
+
+            if (activeType === 'mmd' && window.mmdManager && window.mmdManager.expression) {
+                var moodMap = window.mmdManager.expression.moodMap || {};
+                var dict = typeof window.mmdManager.expression._getMorphDict === 'function'
+                    ? window.mmdManager.expression._getMorphDict()
+                    : null;
+                var mmdCandidates = Object.keys(moodMap).filter(function (emotion) {
+                    var loweredEmotion = String(emotion || '').toLowerCase();
+                    if (!loweredEmotion || loweredEmotion === 'neutral') {
+                        return false;
+                    }
+                    var mappedMorphs = moodMap[emotion];
+                    if (!Array.isArray(mappedMorphs) || mappedMorphs.length === 0) {
+                        return false;
+                    }
+                    if (!dict) {
+                        return true;
+                    }
+                    return mappedMorphs.some(function (name) {
+                        return dict[name] !== undefined;
+                    });
+                });
+                var mmdEmotion = pickRandomExcluding(mmdCandidates, [window.mmdManager.expression.currentMood || 'neutral']);
+                if (!mmdEmotion) return false;
+                window.mmdManager.expression.setEmotion(mmdEmotion);
+                return true;
+            }
+
+            if (!window.live2dManager || typeof window.live2dManager.triggerRandomEmotion !== 'function') {
+                return false;
+            }
+            await window.live2dManager.triggerRandomEmotion();
+            return true;
+        } catch (error) {
+            console.warn('[WeakIdle] expression switch failed:', error);
+            return false;
+        }
+    }
+    mod.performWeakIdleExpressionSwitch = performWeakIdleExpressionSwitch;
+
+    function performWeakIdleReactionBubble() {
+        try {
+            if (!window.avatarReactionBubble || typeof window.avatarReactionBubble.showManualEmotionBubble !== 'function') {
+                return false;
+            }
+
+            var bubbleEmotion = pickRandom(WEAK_IDLE_STANDARD_EMOTIONS);
+            if (!bubbleEmotion) {
+                bubbleEmotion = 'neutral';
+            }
+
+            return !!window.avatarReactionBubble.showManualEmotionBubble({
+                emotion: bubbleEmotion,
+                durationMs: 1800,
+                turnId: 'weak-idle-bubble-' + Date.now()
+            });
+        } catch (error) {
+            console.warn('[WeakIdle] reaction bubble failed:', error);
+            return false;
+        }
+    }
+    mod.performWeakIdleReactionBubble = performWeakIdleReactionBubble;
+
+    async function sendWeakIdleChat() {
+        try {
+            if (!S.socket || S.socket.readyState !== WebSocket.OPEN) {
+                return false;
+            }
+
+            var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+            var message = pickRandom(WEAK_IDLE_MESSAGES);
+            if (!message) return false;
+
+            var response = await fetch('/api/weak_idle_chat', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    lanlan_name: lanlanName,
+                    message: message
+                })
+            });
+
+            if (!response.ok) {
+                return false;
+            }
+
+            var result = await response.json();
+            return !!(result && result.success);
+        } catch (error) {
+            console.warn('[WeakIdle] chat send failed:', error);
+            return false;
+        }
+    }
+
+    async function triggerWeakIdleAction() {
+        var actions = ['chat', 'expression', 'bubble'];
+        for (var shuffleIndex = actions.length - 1; shuffleIndex > 0; shuffleIndex -= 1) {
+            var swapIndex = Math.floor(Math.random() * (shuffleIndex + 1));
+            var tmp = actions[shuffleIndex];
+            actions[shuffleIndex] = actions[swapIndex];
+            actions[swapIndex] = tmp;
+        }
+
+        for (var i = 0; i < actions.length; i += 1) {
+            var action = actions[i];
+            var success = false;
+            if (action === 'chat') {
+                success = await sendWeakIdleChat();
+            } else if (action === 'expression') {
+                success = await performWeakIdleExpressionSwitch();
+            } else if (action === 'bubble') {
+                success = performWeakIdleReactionBubble();
+            }
+            if (success) {
+                recordWeakIdleInteraction('weak_idle_auto_' + action, { reschedule: true });
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function scheduleWeakIdleAction() {
+        stopWeakIdleSchedule();
+
+        if (!S.weakIdleLastInteractionAt) {
+            S.weakIdleLastInteractionAt = Date.now();
+        }
+
+        var idleIntervalMs = getWeakIdleIntervalMs();
+        var blocked = !canTriggerWeakIdleAction();
+        var elapsed = Date.now() - S.weakIdleLastInteractionAt;
+        var delay = blocked
+            ? 5000
+            : Math.max(1000, idleIntervalMs - elapsed);
+
+        S.weakIdleTimer = setTimeout(async function () {
+            S.weakIdleTimer = null;
+
+            if (!canTriggerWeakIdleAction()) {
+                scheduleWeakIdleAction();
+                return;
+            }
+
+            if ((Date.now() - S.weakIdleLastInteractionAt) < idleIntervalMs) {
+                scheduleWeakIdleAction();
+                return;
+            }
+
+            var success = await triggerWeakIdleAction();
+            if (!success) {
+                S.weakIdleTimer = setTimeout(function () {
+                    S.weakIdleTimer = null;
+                    scheduleWeakIdleAction();
+                }, 15000);
+            }
+        }, delay);
+    }
+    mod.scheduleWeakIdleAction = scheduleWeakIdleAction;
+
     /**
      * 主动搭话定时触发功能
      */
@@ -1131,6 +1412,11 @@
 
     window.hasAnyChatModeEnabled = hasAnyChatModeEnabled;
     window.resetProactiveChatBackoff = resetProactiveChatBackoff;
+    window.recordWeakIdleInteraction = recordWeakIdleInteraction;
+    window.stopWeakIdleSchedule = stopWeakIdleSchedule;
+    window.scheduleWeakIdleAction = scheduleWeakIdleAction;
+    window.performWeakIdleExpressionSwitch = performWeakIdleExpressionSwitch;
+    window.performWeakIdleReactionBubble = performWeakIdleReactionBubble;
     window.stopProactiveChatSchedule = stopProactiveChatSchedule;
     window.startProactiveVisionDuringSpeech = startProactiveVisionDuringSpeech;
     window.stopProactiveVisionDuringSpeech = stopProactiveVisionDuringSpeech;
@@ -1147,4 +1433,10 @@
     // ======================== module export ========================
 
     window.appProactive = mod;
+
+    if (!S._weakIdleSchedulerInitialized) {
+        S._weakIdleSchedulerInitialized = true;
+        S.weakIdleLastInteractionAt = Date.now();
+        scheduleWeakIdleAction();
+    }
 })();

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -149,9 +149,9 @@
     }
 
     function getWeakIdleIntervalMs() {
-        var secs = Number(S.weakIdleInterval || C.DEFAULT_WEAK_IDLE_INTERVAL || 10);
+        var secs = Number(S.weakIdleInterval || C.DEFAULT_WEAK_IDLE_INTERVAL || 1800);
         if (!Number.isFinite(secs) || secs <= 0) {
-            secs = 10;
+            secs = 1800;
         }
         return Math.max(5, secs) * 1000;
     }
@@ -316,6 +316,9 @@
             });
 
             if (!response.ok) {
+                if (response.status === 409) {
+                    return 'blocked';
+                }
                 return false;
             }
 
@@ -341,6 +344,10 @@
             var success = false;
             if (action === 'chat') {
                 success = await sendWeakIdleChat();
+                if (success === 'blocked') {
+                    recordWeakIdleInteraction('weak_idle_auto_chat', { blocked: true, reschedule: true });
+                    return true;
+                }
             } else if (action === 'expression') {
                 success = await performWeakIdleExpressionSwitch();
             } else if (action === 'bubble') {

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -14,7 +14,7 @@
         DEFAULT_SPEAKER_VOLUME: 100,         // 扬声器默认音量
         DEFAULT_PROACTIVE_CHAT_INTERVAL: 15, // 默认搭话间隔 (秒)
         DEFAULT_PROACTIVE_VISION_INTERVAL: 10, // 默认视觉间隔 (秒)
-        DEFAULT_WEAK_IDLE_INTERVAL: 10, // 弱化版空闲互动间隔 (秒)
+        DEFAULT_WEAK_IDLE_INTERVAL: 1800, // 弱化版空闲互动间隔 (秒，30分钟)
         MAX_SCREENSHOT_WIDTH: 1280,
         MAX_SCREENSHOT_HEIGHT: 720,
         VOICE_TRANSCRIPT_MERGE_WINDOW: 3000, // 语音转录合并时间窗 (ms)
@@ -77,7 +77,7 @@
         sessionStartedResolver: null,
         sessionStartedRejecter: null,
         assistantTurnId: null,
-        assistantTurnSkipEffects: false,
+        assistantTurnSkipEffectsById: {},
         assistantPendingTurnServerId: null,
         assistantTurnAwaitingBubble: false,
         assistantTurnSeq: 0,
@@ -117,7 +117,7 @@
         proactiveVisionInterval: 10,
         _lastProactiveChatScreenTime: 0,
         weakIdleTimer: null,
-        weakIdleInterval: 10,
+        weakIdleInterval: window.appConst.DEFAULT_WEAK_IDLE_INTERVAL,
         weakIdleLastInteractionAt: 0,
         _weakIdleSchedulerInitialized: false,
 

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -14,6 +14,7 @@
         DEFAULT_SPEAKER_VOLUME: 100,         // 扬声器默认音量
         DEFAULT_PROACTIVE_CHAT_INTERVAL: 15, // 默认搭话间隔 (秒)
         DEFAULT_PROACTIVE_VISION_INTERVAL: 10, // 默认视觉间隔 (秒)
+        DEFAULT_WEAK_IDLE_INTERVAL: 10, // 弱化版空闲互动间隔 (秒)
         MAX_SCREENSHOT_WIDTH: 1280,
         MAX_SCREENSHOT_HEIGHT: 720,
         VOICE_TRANSCRIPT_MERGE_WINDOW: 3000, // 语音转录合并时间窗 (ms)
@@ -76,6 +77,7 @@
         sessionStartedResolver: null,
         sessionStartedRejecter: null,
         assistantTurnId: null,
+        assistantTurnSkipEffects: false,
         assistantPendingTurnServerId: null,
         assistantTurnAwaitingBubble: false,
         assistantTurnSeq: 0,
@@ -114,6 +116,10 @@
         proactiveVisionFrameTimer: null,
         proactiveVisionInterval: 10,
         _lastProactiveChatScreenTime: 0,
+        weakIdleTimer: null,
+        weakIdleInterval: 10,
+        weakIdleLastInteractionAt: 0,
+        _weakIdleSchedulerInitialized: false,
 
         // --- 角色切换 ---
         isSwitchingCatgirl: false,

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -403,11 +403,14 @@
                 // -------- gemini_response --------
                 if (response.type === 'gemini_response') {
                     var isNewMessage = response.isNewMessage || false;
-                    var skipAssistantEffects = response.skip_assistant_effects === true;
+                    var hasExplicitSkipAssistantEffects = Object.prototype.hasOwnProperty.call(response, 'skip_assistant_effects');
                     var responseTurnId = normalizeAssistantTurnId(response.turn_id);
-                    if (responseTurnId) {
-                        setAssistantTurnSkipEffects(responseTurnId, skipAssistantEffects);
+                    if (responseTurnId && hasExplicitSkipAssistantEffects) {
+                        setAssistantTurnSkipEffects(responseTurnId, response.skip_assistant_effects === true);
                     }
+                    var skipAssistantEffects = responseTurnId
+                        ? shouldSkipAssistantEffects(responseTurnId)
+                        : (response.skip_assistant_effects === true);
                     if (isNewMessage) {
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...
                         if (S.lastVoiceUserMessage && S.lastVoiceUserMessage.isConnected &&
@@ -444,9 +447,10 @@
                 } else if (response.type === 'response_discarded') {
                     window.invalidatePendingMusicSearch();
                     emitAssistantSpeechCancel('response_discarded');
+                    var discardedTurnId = resolveAssistantLifecycleTurnId();
                     S.assistantTurnId = null;
                     clearPendingAssistantTurnStart();
-                    clearAssistantEffectSuppression();
+                    clearAssistantEffectSuppression(discardedTurnId);
                     var attempt = response.attempt || 0;
                     var maxAttempts = response.max_attempts || 0;
                     console.log('[Discard] AI回复被丢弃 reason=' + response.reason + ' attempt=' + attempt + '/' + maxAttempts + ' retry=' + response.will_retry);

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1085,19 +1085,21 @@
                             window._realisticGeminiBuffer = '';
                             window._structuredGeminiStreaming = false;
                         } else {
-                        var rest = typeof window._realisticGeminiBuffer === 'string'
-                            ? window._realisticGeminiBuffer.replace(/\[play_music:[^\]]*(\]|$)/g, '')
-                            : '';
-                        rest = rest.replace(/\[play_music:[^\]]*(\]|$)/g, '');
-                        window._realisticGeminiBuffer = '';
-                        var trimmed = rest.replace(/^\s+/, '').replace(/\s+$/, '');
-                        if (trimmed) {
-                            window._realisticGeminiQueue = window._realisticGeminiQueue || [];
-                            window._realisticGeminiQueue.push(trimmed);
-                            if (typeof window.processRealisticQueue === 'function') {
-                                window.processRealisticQueue(window._realisticGeminiVersion || 0);
+                            var rest = typeof window._realisticGeminiBuffer === 'string'
+                                ? window._realisticGeminiBuffer.replace(/\[play_music:[^\]]*(\]|$)/g, '')
+                                : '';
+                            rest = rest.replace(/\[play_music:[^\]]*(\]|$)/g, '');
+                            window._realisticGeminiBuffer = '';
+                            if (!skipAssistantEffectsOnTurnEnd) {
+                                var trimmed = rest.replace(/^\s+/, '').replace(/\s+$/, '');
+                                if (trimmed) {
+                                    window._realisticGeminiQueue = window._realisticGeminiQueue || [];
+                                    window._realisticGeminiQueue.push(trimmed);
+                                    if (typeof window.processRealisticQueue === 'function') {
+                                        window.processRealisticQueue(window._realisticGeminiVersion || 0);
+                                    }
+                                }
                             }
-                        }
                         }
                     } catch (e3) {
                         console.warn(window.t('console.turnEndFlushFailed'), e3);
@@ -1135,7 +1137,9 @@
                         var fullText = (bufferedFullText && bufferedFullText.trim()) ? bufferedFullText : fallbackFromBubble;
 
                         // Trigger music bubble generation
-                        if (typeof window.processMusicCommands === 'function' && fullText) {
+                        if (!skipAssistantEffectsOnTurnEnd &&
+                            typeof window.processMusicCommands === 'function' &&
+                            fullText) {
                             window.processMusicCommands(fullText);
                         }
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -79,6 +79,10 @@
         S.assistantTurnAwaitingBubble = false;
     }
 
+    function clearAssistantEffectSuppression() {
+        S.assistantTurnSkipEffects = false;
+    }
+
     function resolveAssistantLifecycleTurnId(turnId) {
         return normalizeAssistantTurnId(
             turnId ||
@@ -157,6 +161,7 @@
         logAssistantLifecycle('clearAssistantLifecycleOnDisconnect', {
             source: source || 'socket_close'
         });
+        clearAssistantEffectSuppression();
     }
 
     // ========================  Convenience helpers  ========================
@@ -366,6 +371,7 @@
                 // -------- gemini_response --------
                 if (response.type === 'gemini_response') {
                     var isNewMessage = response.isNewMessage || false;
+                    var skipAssistantEffects = response.skip_assistant_effects === true;
                     if (isNewMessage) {
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...
                         if (S.lastVoiceUserMessage && S.lastVoiceUserMessage.isConnected &&
@@ -375,14 +381,21 @@
                         S.lastVoiceUserMessage = null;
                         S.lastVoiceUserMessageTime = 0;
                         S.assistantTurnId = null;
-                        S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
-                        S.assistantTurnAwaitingBubble = true;
+                        S.assistantTurnSkipEffects = skipAssistantEffects;
+                        if (skipAssistantEffects) {
+                            clearPendingAssistantTurnStart();
+                        } else {
+                            S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
+                            S.assistantTurnAwaitingBubble = true;
+                        }
+                    } else if (skipAssistantEffects) {
+                        S.assistantTurnSkipEffects = true;
                     }
                     var createdVisibleBubble = false;
                     if (typeof window.appendMessage === 'function') {
                         createdVisibleBubble = window.appendMessage(response.text, 'gemini', isNewMessage) === true;
                     }
-                    if (!S.assistantTurnId && S.assistantTurnAwaitingBubble && createdVisibleBubble) {
+                    if (!S.assistantTurnSkipEffects && !S.assistantTurnId && S.assistantTurnAwaitingBubble && createdVisibleBubble) {
                         ensureAssistantTurnStarted('gemini_response_visible_bubble', response.turn_id);
                     }
                     if (response.turn_id) {
@@ -399,6 +412,7 @@
                     emitAssistantSpeechCancel('response_discarded');
                     S.assistantTurnId = null;
                     clearPendingAssistantTurnStart();
+                    clearAssistantEffectSuppression();
                     var attempt = response.attempt || 0;
                     var maxAttempts = response.max_attempts || 0;
                     console.log('[Discard] AI回复被丢弃 reason=' + response.reason + ' attempt=' + attempt + '/' + maxAttempts + ' retry=' + response.will_retry);
@@ -512,6 +526,9 @@
                     if (S._voiceSessionInitialTimer) {
                         clearTimeout(S._voiceSessionInitialTimer);
                         S._voiceSessionInitialTimer = null;
+                    }
+                    if (typeof window.recordWeakIdleInteraction === 'function') {
+                        window.recordWeakIdleInteraction('user_transcript', { userInitiated: true });
                     }
                     var now = Date.now();
                     var shouldMerge = S.isRecording &&
@@ -1022,6 +1039,7 @@
                 } else if (response.type === 'system' && response.data === 'turn end') {
                     console.log(window.t('console.turnEndReceived'));
                     logAssistantLifecycle('ws:turn_end:received');
+                    var skipAssistantEffectsOnTurnEnd = S.assistantTurnSkipEffects === true;
                     // Flush remaining buffer
                     try {
                         if (typeof window.setReactMessageStatus === 'function' && window.currentGeminiMessage) {
@@ -1049,17 +1067,21 @@
                     } catch (e3) {
                         console.warn(window.t('console.turnEndFlushFailed'), e3);
                     }
-                    var assistantTurnId = resolveAssistantLifecycleTurnId();
-                    if (assistantTurnId) {
-                        logAssistantLifecycle('ws:turn_end:emit', {
-                            turnId: assistantTurnId
-                        });
-                        emitAssistantLifecycleEvent('neko-assistant-turn-end', {
-                            turnId: assistantTurnId,
-                            source: 'turn_end'
-                        });
+                    var assistantTurnId = skipAssistantEffectsOnTurnEnd ? null : resolveAssistantLifecycleTurnId();
+                    if (!skipAssistantEffectsOnTurnEnd) {
+                        if (assistantTurnId) {
+                            logAssistantLifecycle('ws:turn_end:emit', {
+                                turnId: assistantTurnId
+                            });
+                            emitAssistantLifecycleEvent('neko-assistant-turn-end', {
+                                turnId: assistantTurnId,
+                                source: 'turn_end'
+                            });
+                        } else {
+                            logAssistantLifecycle('ws:turn_end:clear_pending');
+                        }
                     } else {
-                        logAssistantLifecycle('ws:turn_end:clear_pending');
+                        logAssistantLifecycle('ws:turn_end:skip_assistant_effects');
                     }
                     clearPendingAssistantTurnStart();
 
@@ -1089,35 +1111,37 @@
                             return;
                         }
 
-                        // Emotion analysis (5s timeout)
-                        setTimeout(async function () {
-                            try {
-                                var emotionPromise = (typeof window.analyzeEmotion === 'function')
-                                    ? window.analyzeEmotion(fullText)
-                                    : Promise.resolve(null);
-                                var timeoutPromise = new Promise(function (_, reject2) {
-                                    setTimeout(function () { reject2(new Error('情感分析超时')); }, 5000);
-                                });
-                                var emotionResult = await Promise.race([emotionPromise, timeoutPromise]);
-                                if (emotionResult && emotionResult.emotion) {
-                                    console.log(window.t('console.emotionAnalysisComplete'), emotionResult);
-                                    if (typeof window.applyEmotion === 'function') window.applyEmotion(emotionResult.emotion);
-                                    if (assistantTurnId) {
-                                        emitAssistantLifecycleEvent('neko-assistant-emotion-ready', {
-                                            turnId: assistantTurnId,
-                                            emotion: emotionResult.emotion,
-                                            source: 'emotion_analysis'
-                                        });
+                        if (!skipAssistantEffectsOnTurnEnd) {
+                            // Emotion analysis (5s timeout)
+                            setTimeout(async function () {
+                                try {
+                                    var emotionPromise = (typeof window.analyzeEmotion === 'function')
+                                        ? window.analyzeEmotion(fullText)
+                                        : Promise.resolve(null);
+                                    var timeoutPromise = new Promise(function (_, reject2) {
+                                        setTimeout(function () { reject2(new Error('情感分析超时')); }, 5000);
+                                    });
+                                    var emotionResult = await Promise.race([emotionPromise, timeoutPromise]);
+                                    if (emotionResult && emotionResult.emotion) {
+                                        console.log(window.t('console.emotionAnalysisComplete'), emotionResult);
+                                        if (typeof window.applyEmotion === 'function') window.applyEmotion(emotionResult.emotion);
+                                        if (assistantTurnId) {
+                                            emitAssistantLifecycleEvent('neko-assistant-emotion-ready', {
+                                                turnId: assistantTurnId,
+                                                emotion: emotionResult.emotion,
+                                                source: 'emotion_analysis'
+                                            });
+                                        }
+                                    }
+                                } catch (emotionError) {
+                                    if (emotionError.message === '情感分析超时') {
+                                        console.warn(window.t('console.emotionAnalysisTimeout'));
+                                    } else {
+                                        console.warn(window.t('console.emotionAnalysisFailed'), emotionError);
                                     }
                                 }
-                            } catch (emotionError) {
-                                if (emotionError.message === '情感分析超时') {
-                                    console.warn(window.t('console.emotionAnalysisTimeout'));
-                                } else {
-                                    console.warn(window.t('console.emotionAnalysisFailed'), emotionError);
-                                }
-                            }
-                        }, 100);
+                            }, 100);
+                        }
 
                         // Frontend translation
                         (async function () {
@@ -1143,6 +1167,7 @@
                             }
                         })();
                     })();
+                    clearAssistantEffectSuppression();
 
                     // Reset proactive chat backoff after AI turn completes
                     var hasChatMode = (typeof window.hasAnyChatModeEnabled === 'function') ? window.hasAnyChatModeEnabled() : false;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -79,8 +79,40 @@
         S.assistantTurnAwaitingBubble = false;
     }
 
-    function clearAssistantEffectSuppression() {
-        S.assistantTurnSkipEffects = false;
+    function setAssistantTurnSkipEffects(turnId, shouldSkip) {
+        var normalized = normalizeAssistantTurnId(turnId);
+        if (!normalized) {
+            return;
+        }
+        if (!S.assistantTurnSkipEffectsById) {
+            S.assistantTurnSkipEffectsById = {};
+        }
+        if (shouldSkip) {
+            S.assistantTurnSkipEffectsById[normalized] = true;
+        } else {
+            delete S.assistantTurnSkipEffectsById[normalized];
+        }
+    }
+
+    function shouldSkipAssistantEffects(turnId) {
+        var normalized = normalizeAssistantTurnId(turnId);
+        if (!normalized || !S.assistantTurnSkipEffectsById) {
+            return false;
+        }
+        return S.assistantTurnSkipEffectsById[normalized] === true;
+    }
+
+    function clearAssistantEffectSuppression(turnId) {
+        if (!S.assistantTurnSkipEffectsById) {
+            S.assistantTurnSkipEffectsById = {};
+            return;
+        }
+        var normalized = normalizeAssistantTurnId(turnId);
+        if (!normalized) {
+            S.assistantTurnSkipEffectsById = {};
+            return;
+        }
+        delete S.assistantTurnSkipEffectsById[normalized];
     }
 
     function resolveAssistantLifecycleTurnId(turnId) {
@@ -372,6 +404,10 @@
                 if (response.type === 'gemini_response') {
                     var isNewMessage = response.isNewMessage || false;
                     var skipAssistantEffects = response.skip_assistant_effects === true;
+                    var responseTurnId = normalizeAssistantTurnId(response.turn_id);
+                    if (responseTurnId) {
+                        setAssistantTurnSkipEffects(responseTurnId, skipAssistantEffects);
+                    }
                     if (isNewMessage) {
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...
                         if (S.lastVoiceUserMessage && S.lastVoiceUserMessage.isConnected &&
@@ -381,21 +417,19 @@
                         S.lastVoiceUserMessage = null;
                         S.lastVoiceUserMessageTime = 0;
                         S.assistantTurnId = null;
-                        S.assistantTurnSkipEffects = skipAssistantEffects;
+                        S.assistantPendingTurnServerId = responseTurnId;
                         if (skipAssistantEffects) {
-                            clearPendingAssistantTurnStart();
+                            S.assistantTurnAwaitingBubble = false;
                         } else {
-                            S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
-                            S.assistantTurnAwaitingBubble = true;
+                            S.assistantTurnAwaitingBubble = responseTurnId || true;
                         }
-                    } else if (skipAssistantEffects) {
-                        S.assistantTurnSkipEffects = true;
                     }
                     var createdVisibleBubble = false;
                     if (typeof window.appendMessage === 'function') {
                         createdVisibleBubble = window.appendMessage(response.text, 'gemini', isNewMessage) === true;
                     }
-                    if (!S.assistantTurnSkipEffects && !S.assistantTurnId && S.assistantTurnAwaitingBubble && createdVisibleBubble) {
+                    if (!shouldSkipAssistantEffects(responseTurnId || S.assistantPendingTurnServerId) &&
+                        !S.assistantTurnId && S.assistantTurnAwaitingBubble && createdVisibleBubble) {
                         ensureAssistantTurnStarted('gemini_response_visible_bubble', response.turn_id);
                     }
                     if (response.turn_id) {
@@ -1039,7 +1073,8 @@
                 } else if (response.type === 'system' && response.data === 'turn end') {
                     console.log(window.t('console.turnEndReceived'));
                     logAssistantLifecycle('ws:turn_end:received');
-                    var skipAssistantEffectsOnTurnEnd = S.assistantTurnSkipEffects === true;
+                    var resolvedAssistantTurnId = resolveAssistantLifecycleTurnId();
+                    var skipAssistantEffectsOnTurnEnd = shouldSkipAssistantEffects(resolvedAssistantTurnId);
                     // Flush remaining buffer
                     try {
                         if (typeof window.setReactMessageStatus === 'function' && window.currentGeminiMessage) {
@@ -1067,7 +1102,7 @@
                     } catch (e3) {
                         console.warn(window.t('console.turnEndFlushFailed'), e3);
                     }
-                    var assistantTurnId = skipAssistantEffectsOnTurnEnd ? null : resolveAssistantLifecycleTurnId();
+                    var assistantTurnId = skipAssistantEffectsOnTurnEnd ? null : resolvedAssistantTurnId;
                     if (!skipAssistantEffectsOnTurnEnd) {
                         if (assistantTurnId) {
                             logAssistantLifecycle('ws:turn_end:emit', {
@@ -1167,7 +1202,7 @@
                             }
                         })();
                     })();
-                    clearAssistantEffectSuppression();
+                    clearAssistantEffectSuppression(resolvedAssistantTurnId);
 
                     // Reset proactive chat backoff after AI turn completes
                     var hasChatMode = (typeof window.hasAnyChatModeEnabled === 'function') ? window.hasAnyChatModeEnabled() : false;

--- a/static/app.js
+++ b/static/app.js
@@ -299,6 +299,9 @@ window.addEventListener('message', function (event) {
         console.log('[VRM] 收到表情预览请求:', event.data.expression);
         if (window.vrmManager && window.vrmManager.expression) {
             window.vrmManager.expression.setBaseExpression(event.data.expression);
+            if (typeof window.recordWeakIdleInteraction === 'function') {
+                window.recordWeakIdleInteraction('message_vrm_expression', { userInitiated: true });
+            }
         }
     }
 
@@ -337,6 +340,9 @@ window.addEventListener('message', function (event) {
             clearTimeout(window._mmdMorphPreviewTimer);
             window.mmdManager.expression._clearEmotionMorphs();
             window.mmdManager.expression.setMorphWeight(event.data.morph, 1.0);
+            if (typeof window.recordWeakIdleInteraction === 'function') {
+                window.recordWeakIdleInteraction('message_mmd_expression', { userInitiated: true });
+            }
             var morphToReset = event.data.morph;
             window._mmdMorphPreviewTimer = setTimeout(() => {
                 if (window.mmdManager && window.mmdManager.expression) {

--- a/static/avatar-reaction-bubble.js
+++ b/static/avatar-reaction-bubble.js
@@ -1292,6 +1292,50 @@
         }
     }
 
+    function showManualEmotionBubble(options) {
+        options = options || {};
+        if (!syncEnabledFromSettings()) {
+            return false;
+        }
+
+        var emotion = options.emotion ? String(options.emotion) : 'neutral';
+        var theme = normalizeTheme(emotion);
+        var durationMs = Math.max(
+            TIMING.minVisibleMs + TIMING.fadeDurationMs,
+            Number(options.durationMs) || 1800
+        );
+        var turnId = String(options.turnId || ('manual-bubble-' + now()));
+
+        clearTurnTimers();
+        stopFollowLoop();
+        ensureDom();
+        resetPositionTracking();
+
+        state.turnId = turnId;
+        state.visible = true;
+        state.phase = 'emotion-ready';
+        state.theme = theme;
+        state.emotion = emotion;
+        state.showEmotionArt = theme !== 'thinking';
+        state.content = getThemeContent(theme);
+        state.side = 'right';
+        state.shownAt = now();
+        state.turnEndedAt = 0;
+        state.speechStartedAt = 0;
+
+        applyVisualState();
+        syncPositionOnce();
+        extendFollowLoop(Math.max(TIMING.showFollowWindowMs, durationMs));
+        scheduleMaxVisibleFallback(turnId);
+        beginHide(turnId, Math.max(0, durationMs - TIMING.minVisibleMs));
+        logBubbleLifecycle('showManualEmotionBubble:applied', {
+            requestedTurnId: turnId,
+            emotion: emotion,
+            durationMs: durationMs
+        });
+        return true;
+    }
+
     function init() {
         ensureDom();
         syncEnabledFromSettings();
@@ -1346,6 +1390,7 @@
 
     window.avatarReactionBubble = {
         forceHide: function () { forceHide(true); },
+        showManualEmotionBubble: showManualEmotionBubble,
         getState: function () {
             return Object.assign({}, state);
         },

--- a/static/js/mmd_emotion_manager.js
+++ b/static/js/mmd_emotion_manager.js
@@ -333,6 +333,9 @@
                     window.opener.mmdManager.expression._clearEmotionMorphs();
                     // 设置预览的 morph
                     window.opener.mmdManager.expression.setMorphWeight(morphName, 1.0);
+                    if (typeof window.opener.recordWeakIdleInteraction === 'function') {
+                        window.opener.recordWeakIdleInteraction('popup_mmd_expression', { userInitiated: true });
+                    }
                 } else {
                     window.opener?.postMessage({
                         type: 'mmd-preview-morph',

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -4348,7 +4348,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                     vrmManager.expression.autoReturnToNeutral = false;
                     vrmManager.expression.setBaseExpression(name);
                     if (typeof window.recordWeakIdleInteraction === 'function') {
-                        window.recordWeakIdleInteraction('manual_vrm_expression', { userInitiated: true });
+                        try {
+                            window.recordWeakIdleInteraction('manual_vrm_expression', { userInitiated: true });
+                        } catch (weakIdleError) {
+                            console.warn('[VRM] recordWeakIdleInteraction 失败:', weakIdleError);
+                        }
                     }
                     isVrmExpressionPlaying = true;
                     updateVRMExpressionPlayButtonIcon();

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -4332,6 +4332,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                     // 【修改】手动播放时禁用自动回到 neutral，保持表情直到手动停止
                     vrmManager.expression.autoReturnToNeutral = false;
                     vrmManager.expression.setBaseExpression(name);
+                    if (typeof window.recordWeakIdleInteraction === 'function') {
+                        window.recordWeakIdleInteraction('manual_vrm_expression', { userInitiated: true });
+                    }
                     isVrmExpressionPlaying = true;
                     updateVRMExpressionPlayButtonIcon();
                     showStatus(t('live2d.vrmExpression.playing', `正在播放表情: ${name}`, { name: name }), 2000);

--- a/static/js/vrm_emotion_manager.js
+++ b/static/js/vrm_emotion_manager.js
@@ -360,6 +360,9 @@
                 // 发送表情预览事件
                 if (window.opener && window.opener.vrmManager) {
                     window.opener.vrmManager.expression.setBaseExpression(exprName);
+                    if (typeof window.opener.recordWeakIdleInteraction === 'function') {
+                        window.opener.recordWeakIdleInteraction('popup_vrm_expression', { userInitiated: true });
+                    }
                 } else {
                     // 通过 postMessage 通知父窗口
                     window.opener?.postMessage({


### PR DESCRIPTION
- 新增弱化版空闲互动调度，在用户一段时间未与 neko 交互后自动触发一次动作
- 新增弱化版空闲聊天接口，并在发送后写入 recent memory，保证后续对话连续性。
- 前端接入弱化版空闲状态管理、交互计时重置、气泡手动触发与现有模型点击表情切换链路，并在开启主动搭话时自动停用该功能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加“弱空闲”调度：空闲时可自动尝试发送弱空闲聊天、切换表情或显示反应气泡；新增前端接口用于触发/停止与手动触发表情气泡。
  * 后端新增弱空闲聊天 HTTP 接口，支持每次交互的唯一标识并将回复投递到前端。

* **改进**
  * 统一优先使用弱空闲交互记录入口，覆盖语音、文本与表情操作。
  * 支持按次抑制助手视觉/效果展示，减少打扰。
  * 投递后尽力更新会话历史并异步写入记忆缓存（写入失败不阻断流程）。

* **修复**
  * 增强请求体校验并返回合理错误码（如缺失会话、空消息或并发响应时的冲突处理）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->