### PR TITLE
修复 VRM 模型在屏幕边缘缩放时飞出屏幕的问题

### DIFF
--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -249,7 +249,8 @@ class VRMInteraction {
                 const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
 
                 // 计算新位置：鼠标移动的像素 × 每像素对应的世界空间距离
-                const newPosition = this.manager.currentModel.scene.position.clone();
+                const oldPosition = this.manager.currentModel.scene.position.clone();
+                const newPosition = oldPosition.clone();
                 newPosition.add(right.multiplyScalar(deltaX * pixelToWorldX));
                 newPosition.add(up.multiplyScalar(-deltaY * pixelToWorldY));
 
@@ -258,6 +259,12 @@ class VRMInteraction {
 
                 // 应用位置（按钮和锁图标位置由 _startUIUpdateLoop 自动更新）
                 this.manager.currentModel.scene.position.copy(finalPosition);
+
+                // 同步更新 _cameraTarget，使缩放中心跟随模型移动
+                if (this.manager._cameraTarget) {
+                    const posDelta = finalPosition.clone().sub(oldPosition);
+                    this.manager._cameraTarget.add(posDelta);
+                }
             } else if (this.dragMode === 'orbit' && this.manager.camera && this._orbitCenter) {
                 // 右键拖拽：相机绕模型中心旋转，同时补偿 lookAt 使模型保持在屏幕原位
                 const camera = this.manager.camera;
@@ -840,12 +847,22 @@ class VRMInteraction {
             return false;
         }
 
+        // 计算回弹产生的位移，用于同步更新 _cameraTarget
+        const snapDelta = targetPosition.clone().sub(startPosition);
+
         if (!animate) {
             scene.position.copy(targetPosition);
+            if (this.manager._cameraTarget) {
+                this.manager._cameraTarget.add(snapDelta);
+            }
             return true;
         }
 
-        return await this._animateModelToPosition(startPosition, targetPosition);
+        const result = await this._animateModelToPosition(startPosition, targetPosition);
+        if (result && this.manager._cameraTarget) {
+            this.manager._cameraTarget.add(snapDelta);
+        }
+        return result;
     }
 
 

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -265,6 +265,8 @@ class VRMInteraction {
                     const posDelta = finalPosition.clone().sub(oldPosition);
                     this.manager._cameraTarget.add(posDelta);
                 }
+                // 位置变了，清除缓存的包围盒，下次缩放时重新获取
+                this._cachedBox = null;
             } else if (this.dragMode === 'orbit' && this.manager.camera && this._orbitCenter) {
                 // 右键拖拽：相机绕模型中心旋转，同时补偿 lookAt 使模型保持在屏幕原位
                 const camera = this.manager.camera;

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -158,6 +158,14 @@ class VRMInteraction {
             if (this._snapAnimationFrameId) {
                 cancelAnimationFrame(this._snapAnimationFrameId);
                 this._snapAnimationFrameId = null;
+
+                // 动画被中断，同步 _cameraTarget 到模型实际移动的位移量
+                if (this.manager._cameraTarget && this._snapStartPosition && this.manager.currentModel?.scene) {
+                    const currentDelta = this.manager.currentModel.scene.position.clone().sub(this._snapStartPosition);
+                    this.manager._cameraTarget.add(currentDelta);
+                }
+                this._snapStartPosition = null;
+
                 if (this._snapResolve) {
                     this._snapResolve(false);
                     this._snapResolve = null;
@@ -265,8 +273,10 @@ class VRMInteraction {
                     const posDelta = finalPosition.clone().sub(oldPosition);
                     this.manager._cameraTarget.add(posDelta);
                 }
-                // 位置变了，清除缓存的包围盒，下次缩放时重新获取
+                // 位置变了，清除所有缓存，下次缩放/悬停检测时重新获取
                 this._cachedBox = null;
+                this._cachedCorners = null;
+                this._cachedScreenBounds = null;
             } else if (this.dragMode === 'orbit' && this.manager.camera && this._orbitCenter) {
                 // 右键拖拽：相机绕模型中心旋转，同时补偿 lookAt 使模型保持在屏幕原位
                 const camera = this.manager.camera;
@@ -814,6 +824,7 @@ class VRMInteraction {
         const scene = this.manager.currentModel.scene;
 
         this._isSnappingModel = true;
+        this._snapStartPosition = startPosition.clone();
 
         return new Promise((resolve) => {
             this._snapResolve = resolve;
@@ -835,6 +846,7 @@ class VRMInteraction {
                     this._isSnappingModel = false;
                     this._snapAnimationFrameId = null;
                     this._snapResolve = null;
+                    this._snapStartPosition = null;
                     resolve(true);
                 }
             };

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -403,10 +403,17 @@ class VRMInteraction {
             const zoomFactor = delta > 0 ? (1 + zoomSpeed) : (1 - zoomSpeed);
 
             if (this.manager.currentModel.scene && this.manager.camera) {
-                // 使用统一的 _cameraTarget 作为缩放中心
-                const zoomCenter = this.manager._cameraTarget
-                    ? this.manager._cameraTarget.clone()
-                    : new THREE.Vector3(0, 0, 0);
+                // 使用模型包围盒的实际中心作为缩放中心，确保缩放始终围绕模型正中心
+                const vrm = this.manager.currentModel.vrm;
+                let zoomCenter;
+                if (vrm && vrm.scene) {
+                    const box = new THREE.Box3().setFromObject(vrm.scene);
+                    zoomCenter = box.getCenter(new THREE.Vector3());
+                } else {
+                    zoomCenter = this.manager._cameraTarget
+                        ? this.manager._cameraTarget.clone()
+                        : new THREE.Vector3(0, 0, 0);
+                }
 
                 const oldDistance = this.manager.camera.position.distanceTo(zoomCenter);
                 const minDist = 0.5;
@@ -421,6 +428,9 @@ class VRMInteraction {
 
                 this.manager.camera.position.copy(zoomCenter)
                     .add(direction.multiplyScalar(newDistance));
+
+                // 同步 _cameraTarget 到模型中心
+                this.manager._cameraTarget = zoomCenter.clone();
 
                 if (this.manager.controls && this.manager.controls.update) {
                     this.manager.controls.update();

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -296,25 +296,31 @@ class VRMInteraction {
                 // 更新相机位置
                 camera.position.copy(orbitCenter).add(offset);
 
-                // 先临时看向旋转中心，建立新的相机坐标系
+                // 先临时看向旋转中心（此时模型在屏幕正中心）
                 camera.lookAt(orbitCenter);
 
-                // 用 NDC 坐标补偿，使模型中心保持在原来的屏幕位置
+                // 用精确的四元数旋转补偿，使模型中心保持在原来的屏幕位置
                 const nx = this._orbitNDC.x;
                 const ny = this._orbitNDC.y;
-                const halfHeight = radius * Math.tan(camera.fov * Math.PI / 360);
-                const halfWidth = halfHeight * camera.aspect;
 
-                const right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion);
-                const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
+                if (Math.abs(nx) > 0.001 || Math.abs(ny) > 0.001) {
+                    const tanHalfFov = Math.tan(camera.fov * Math.PI / 360);
+                    // 计算 orbitCenter 需要投影到 NDC (nx, ny) 对应的 camera-local 方向
+                    const desiredDir = new THREE.Vector3(
+                        nx * tanHalfFov * camera.aspect,
+                        ny * tanHalfFov,
+                        -1
+                    ).normalize();
+                    const forward = new THREE.Vector3(0, 0, -1);
+                    // 旋转相机使 orbitCenter 从屏幕中心移到目标 NDC 位置
+                    const compensation = new THREE.Quaternion().setFromUnitVectors(desiredDir, forward);
+                    camera.quaternion.multiply(compensation);
+                }
 
-                // target = 模型中心 - NDC偏移量（使模型投影回原屏幕位置）
-                const newTarget = orbitCenter.clone()
-                    .sub(right.clone().multiplyScalar(nx * halfWidth))
-                    .sub(up.clone().multiplyScalar(ny * halfHeight));
-
-                camera.lookAt(newTarget);
-                this.manager._cameraTarget = newTarget;
+                // 从新朝向重建 _cameraTarget（相机前方与 orbitCenter 同距离处）
+                const dist = camera.position.distanceTo(orbitCenter);
+                const worldForward = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion);
+                this.manager._cameraTarget = camera.position.clone().add(worldForward.multiplyScalar(dist));
             }
 
             this.previousMousePosition = { x: e.clientX, y: e.clientY };
@@ -404,15 +410,20 @@ class VRMInteraction {
 
             if (this.manager.currentModel.scene && this.manager.camera) {
                 // 使用模型包围盒的实际中心作为缩放中心，确保缩放始终围绕模型正中心
-                const vrm = this.manager.currentModel.vrm;
+                // 优先使用已缓存的包围盒（由 updateModelBoundsCache 在动画帧中维护），避免每次 wheel 事件重算
                 let zoomCenter;
-                if (vrm && vrm.scene) {
-                    const box = new THREE.Box3().setFromObject(vrm.scene);
-                    zoomCenter = box.getCenter(new THREE.Vector3());
+                if (this._cachedBox) {
+                    zoomCenter = this._cachedBox.getCenter(new THREE.Vector3());
                 } else {
-                    zoomCenter = this.manager._cameraTarget
-                        ? this.manager._cameraTarget.clone()
-                        : new THREE.Vector3(0, 0, 0);
+                    const vrm = this.manager.currentModel.vrm;
+                    if (vrm && vrm.scene) {
+                        const box = new THREE.Box3().setFromObject(vrm.scene);
+                        zoomCenter = box.getCenter(new THREE.Vector3());
+                    } else {
+                        zoomCenter = this.manager._cameraTarget
+                            ? this.manager._cameraTarget.clone()
+                            : new THREE.Vector3(0, 0, 0);
+                    }
                 }
 
                 const oldDistance = this.manager.camera.position.distanceTo(zoomCenter);
@@ -429,12 +440,8 @@ class VRMInteraction {
                 this.manager.camera.position.copy(zoomCenter)
                     .add(direction.multiplyScalar(newDistance));
 
-                // 同步 _cameraTarget 到模型中心
+                // 仅同步内部状态，不调用 lookAt / controls.target 以保持模型在屏幕上的位置不变
                 this.manager._cameraTarget = zoomCenter.clone();
-
-                if (this.manager.controls && this.manager.controls.update) {
-                    this.manager.controls.update();
-                }
 
                 // 缩放结束后防抖保存位置
                 this._debouncedSavePosition();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了在中断或取消贴入/动画时的相机与模型同步，避免位置不同步或残留偏移。
  * 修复了平移/滚轮缩放时中心点与相机目标不同步的情况，优先使用模型包围盒中心并在必要时重新计算。
  * 在模型位置变化后清理缓存，确保后续交互一致性。

* **Refactor**
  * 重写了环绕拖拽的视角补偿逻辑，提升旋转对齐与交互稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->