### PR TITLE
fix: 修复模型切换时 VRM 画布缓存问题，优化 MMD 管理器复用逻辑

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -922,7 +922,7 @@
                 if (window.mmdManager && window.mmdManager.scene && window.mmdManager.renderer && !window.mmdManager._isDisposed) {
                     // 复用现有场景：清理旧模型（core._clearModel），保留 renderer/scene/camera
                     if (window.mmdManager.core) {
-                        window.mmdManager.core._clearModel();
+                        try { window.mmdManager.core._clearModel(); } catch (e) { console.warn('[猫娘切换] _clearModel 失败:', e); }
                     }
                     // 重置动画状态
                     if (window.mmdManager.animationModule) {

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -895,6 +895,10 @@
                     vrmCanvasMmd.style.visibility = 'hidden';
                     vrmCanvasMmd.style.pointerEvents = 'none';
                 }
+                // 【修复】清除 VRM canvas 缓存帧，防止在模型切换窗口期透穿显示旧 VRM 模型
+                if (window.vrmManager && window.vrmManager.renderer) {
+                    try { window.vrmManager.renderer.clear(); } catch (_) { /* ignore */ }
+                }
 
                 // 显示 MMD 容器
                 const mmdContainerShow = document.getElementById('mmd-container');
@@ -911,12 +915,31 @@
                     mmdCanvasShow.style.pointerEvents = 'auto';
                 }
 
-                // 初始化 MMD 管理器（MMD→MMD 切换时需要完全重新初始化以避免状态残留）
-                console.log('[猫娘切换] 重新初始化 MMD 管理器');
-                if (typeof window.initMMDModel === 'function') {
-                    await window.initMMDModel();
-                } else if (typeof initMMDModel === 'function') {
-                    await initMMDModel();
+                // 初始化 MMD 管理器
+                // 【优化】如果 MMD 管理器已存在且场景有效，复用现有 renderer/scene，
+                // 仅清理旧模型并加载新模型，避免 dispose+重建导致的画布透明窗口期。
+                console.log('[猫娘切换] 初始化/复用 MMD 管理器');
+                if (window.mmdManager && window.mmdManager.scene && window.mmdManager.renderer && !window.mmdManager._isDisposed) {
+                    // 复用现有场景：清理旧模型（core._clearModel），保留 renderer/scene/camera
+                    if (window.mmdManager.core) {
+                        window.mmdManager.core._clearModel();
+                    }
+                    // 重置动画状态
+                    if (window.mmdManager.animationModule) {
+                        try { window.mmdManager.animationModule.dispose(); } catch (_) {}
+                        // 重新创建动画模块
+                        if (typeof MMDAnimation !== 'undefined') {
+                            window.mmdManager.animationModule = new MMDAnimation(window.mmdManager);
+                        }
+                    }
+                    console.log('[猫娘切换] MMD 管理器已复用');
+                } else {
+                    // 首次初始化或管理器已销毁，执行完整初始化
+                    if (typeof window.initMMDModel === 'function') {
+                        await window.initMMDModel();
+                    } else if (typeof initMMDModel === 'function') {
+                        await initMMDModel();
+                    }
                 }
 
                 // 加载 MMD 模型

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -287,8 +287,29 @@ button * {
     opacity: 1;
     overflow: hidden;
     visibility: visible;
-    transition: all 1s ease-in-out;
+    /* 【修复】仅过渡 opacity 和 transform，排除 visibility 的过渡影响，
+     * 避免 MMD 模式下隐藏 VRM 容器时因 transition: all 导致约 1s 的视觉
+     * 残留窗口，使 VRM canvas 中缓存的旧模型（如 sister1.0）短暂可见。 */
+    transition: opacity 1s ease-in-out, transform 1s ease-in-out;
     /* GPU 合成层隔离：减少窗口级重绘对 canvas 的影响 */
+    will-change: transform;
+    transform: translateZ(0);
+}
+
+/* 看板娘MMD模型判定框-容器 */
+#mmd-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    /* 【修复】z-index 与 vrm-container 一致，防止 VRM 容器层级始终高于 MMD，
+     * 导致 MMD 画布透明窗口期（模型清理/重建期间）穿透显示 VRM 缓存内容。 */
+    z-index: 10;
+    pointer-events: none;
+    background: none;
+    overflow: hidden;
+    /* GPU 合成层隔离 */
     will-change: transform;
     transform: translateZ(0);
 }

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2494,6 +2494,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (vrmManager && typeof vrmManager.pauseRendering === 'function') {
                     try { vrmManager.pauseRendering(); } catch (_) { /* ignore */ }
                 }
+                // 【修复】清除 VRM canvas 缓存帧，防止 canvas 内容在容器短暂可见时被绘制
+                if (vrmManager && vrmManager.renderer) {
+                    try { vrmManager.renderer.clear(); } catch (_) { /* ignore */ }
+                }
                 if (vrmManager && vrmManager.renderer && vrmManager.renderer.domElement) {
                     vrmManager.renderer.domElement.style.display = 'none';
                 }
@@ -2878,9 +2882,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 // 更新 sub_type 并刷新控件可见性
                 stopIdleRotation('vrm');
+                // 【修复】MMD→MMD 同类型切换时跳过冗余的 switchModelDisplay，
+                // 避免触发 loadLive3DModels 等异步操作和 VRM 场景重建，减少切换闪烁窗口期。
+                const wasAlreadyMmd = currentLive3dSubType === 'mmd';
                 currentLive3dSubType = 'mmd';
                 localStorage.setItem('live3dSubType', 'mmd');
-                await switchModelDisplay('live3d', 'mmd');
+                if (!wasAlreadyMmd) {
+                    await switchModelDisplay('live3d', 'mmd');
+                }
 
                 // switchModelDisplay 重建了 vrmModelSelect，需要重新选中当前模型
                 if (vrmModelSelect) {
@@ -4012,6 +4021,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (vrmContainer) {
                 vrmContainer.classList.add('hidden');
                 vrmContainer.style.display = 'none';
+            }
+            // 【修复】清除 VRM canvas 缓存帧，防止旧 VRM 模型在切换窗口期短暂闪现
+            if (window.vrmManager && window.vrmManager.renderer) {
+                try { window.vrmManager.renderer.clear(); } catch (_) { /* ignore */ }
             }
             // 显示 MMD 容器
             if (mmdContainer) {

--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -194,6 +194,8 @@ class MMDCore {
         container.style.top = '0';
         container.style.left = '0';
         container.style.setProperty('pointer-events', 'auto', 'important');
+        // 【修复】确保 z-index 与 vrm-container 一致，作为 CSS 缺失时的后备
+        container.style.zIndex = '10';
 
         this.manager.clock = new THREE.Clock();
         this.manager.scene = new THREE.Scene();

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -577,9 +577,11 @@ class VRMManager {
         // 恢复容器可见性：在 Live2D/VRM 之间反复切换时，cleanup 会把容器隐藏
         // （display:none + 'hidden' class），若 _isInitialized 为 true，app-character.js
         // 会跳过整个初始化块，导致下次切回 VRM 时容器仍不可见，新模型"加载不出来"。
-        // 这里无条件恢复，确保每次尝试初始化 VRM 时容器都是可见的。
+        // 【修复】仅在非 MMD 子类型时恢复容器可见性，防止 MMD 模式下 VRM 容器
+        // 被意外显示（initThreeJS 可能被 loadModel 等间接调用，此时 MMD 正在前台）。
+        const isMmdMode = (window.lanlan_config?.live3d_sub_type || '').toLowerCase() === 'mmd';
         const container = containerId ? document.getElementById(containerId) : null;
-        if (container) {
+        if (container && !isMmdMode) {
             container.style.display = 'block';
             container.style.visibility = 'visible';
             container.style.opacity = '1';
@@ -589,7 +591,8 @@ class VRMManager {
         // 检查是否已完全初始化（不仅检查 scene，还要检查 camera 和 renderer）
         if (this.scene && this.camera && this.renderer) {
             // 恢复 renderer canvas 可见性（切换清理时会把 domElement 设为 display:none）
-            if (this.renderer.domElement) {
+            // 【修复】同样受 MMD 守卫保护
+            if (this.renderer.domElement && !isMmdMode) {
                 this.renderer.domElement.style.display = 'block';
             }
             this._initMouseLookAtTracking();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复模型切换时旧渲染帧短暂闪现的问题，减少视觉残影。
  * 避免在已为 MMD 时触发冗余的切换流程，减少闪烁与重建。

* **Refactor**
  * 改为条件重用已有 MMD 管理器，优化切换性能并降低初始化频率。
  * 重置动画状态而非完全重建以保持稳定性。

* **Style**
  * 为 MMD 层新增固定全屏容器和更精确的过渡规则，改善层级与可见性切换体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->