### PR TITLE
fix: 为 VRM/MMD 桌宠补齐多屏切换逻辑，对齐 Live2D 行为

### DIFF
--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -280,15 +280,21 @@ class MMDInteraction {
         };
 
         // 鼠标抬起
-        this.mouseUpHandler = () => {
+        this.mouseUpHandler = async () => {
             if (this.isDragging) {
                 this.isDragging = false;
                 this.dragMode = null;
                 canvas.style.cursor = 'default';
                 this._restoreButtonPointerEvents();
 
-                // 拖拽结束后保存位置/旋转/缩放
-                this._savePositionAfterInteraction();
+                // 多屏幕支持：检测模型是否移出当前屏幕并切换到新屏幕
+                // 若发生切屏，_checkAndSwitchDisplay 内部会负责保存位置
+                const displaySwitched = await this._checkAndSwitchDisplay();
+
+                if (!displaySwitched) {
+                    // 拖拽结束后保存位置/旋转/缩放
+                    this._savePositionAfterInteraction();
+                }
             }
         };
 
@@ -386,6 +392,158 @@ class MMDInteraction {
         this.dragMode = null;
         this._orbitPivot = null;
         this._restoreButtonPointerEvents();
+    }
+
+    // ═══════════════════ 多屏幕切换 ═══════════════════
+
+    /**
+     * 检测模型是否移出当前屏幕并切换到新屏幕
+     * 返回 true 表示发生了切屏（内部已保存位置），返回 false 表示未切屏
+     */
+    async _checkAndSwitchDisplay() {
+        // 仅在 Electron 环境下执行
+        if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) {
+            return false;
+        }
+        if (!THREE) return false;
+
+        const mesh = this.manager.currentModel?.mesh;
+        const camera = this.manager.camera;
+        const renderer = this.manager.renderer;
+        if (!mesh || !camera || !renderer) return false;
+
+        try {
+            // 1. 计算模型在当前窗口中的屏幕空间中心点（像素）
+            mesh.updateMatrixWorld(true);
+            const box = new THREE.Box3().setFromObject(mesh);
+            if (!box || !Number.isFinite(box.min.x) || !Number.isFinite(box.max.x)) {
+                return false;
+            }
+
+            const canvasRect = renderer.domElement.getBoundingClientRect();
+            const screenWidth = canvasRect.width;
+            const screenHeight = canvasRect.height;
+            if (!(screenWidth > 0) || !(screenHeight > 0)) return false;
+
+            const corners = [
+                new THREE.Vector3(box.min.x, box.min.y, box.min.z),
+                new THREE.Vector3(box.max.x, box.min.y, box.min.z),
+                new THREE.Vector3(box.min.x, box.max.y, box.min.z),
+                new THREE.Vector3(box.max.x, box.max.y, box.min.z),
+                new THREE.Vector3(box.min.x, box.min.y, box.max.z),
+                new THREE.Vector3(box.max.x, box.min.y, box.max.z),
+                new THREE.Vector3(box.min.x, box.max.y, box.max.z),
+                new THREE.Vector3(box.max.x, box.max.y, box.max.z),
+            ];
+
+            let modelMinX = Infinity, modelMaxX = -Infinity;
+            let modelMinY = Infinity, modelMaxY = -Infinity;
+            for (const corner of corners) {
+                const projected = corner.clone().project(camera);
+                const sx = (projected.x * 0.5 + 0.5) * screenWidth;
+                const sy = (-projected.y * 0.5 + 0.5) * screenHeight;
+                modelMinX = Math.min(modelMinX, sx);
+                modelMaxX = Math.max(modelMaxX, sx);
+                modelMinY = Math.min(modelMinY, sy);
+                modelMaxY = Math.max(modelMaxY, sy);
+            }
+
+            // 模型中心（相对于 canvas 左上角的像素），再偏移 canvas 在窗口中的位置
+            const modelCenterX = (modelMinX + modelMaxX) / 2 + canvasRect.left;
+            const modelCenterY = (modelMinY + modelMaxY) / 2 + canvasRect.top;
+
+            // 2. 多屏幕检查
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!displays || displays.length <= 1) return false;
+
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
+            if (modelCenterX >= 0 && modelCenterX < windowWidth &&
+                modelCenterY >= 0 && modelCenterY < windowHeight) {
+                return false;
+            }
+
+            // 3. 计算模型中心在整个桌面上的绝对坐标
+            const currentDisplay = await window.electronScreen.getCurrentDisplay();
+            if (!currentDisplay) {
+                console.warn('[MMD] 无法获取当前显示器信息');
+                return false;
+            }
+            let currentScreenX = currentDisplay.screenX;
+            let currentScreenY = currentDisplay.screenY;
+            if (!Number.isFinite(currentScreenX) || !Number.isFinite(currentScreenY)) {
+                if (currentDisplay.bounds &&
+                    Number.isFinite(currentDisplay.bounds.x) &&
+                    Number.isFinite(currentDisplay.bounds.y)) {
+                    currentScreenX = currentDisplay.bounds.x;
+                    currentScreenY = currentDisplay.bounds.y;
+                } else {
+                    return false;
+                }
+            }
+
+            const modelScreenX = currentScreenX + modelCenterX;
+            const modelScreenY = currentScreenY + modelCenterY;
+
+            // 4. 查找包含模型中心点的目标显示器
+            let targetDisplay = null;
+            for (const display of displays) {
+                const dx = Number.isFinite(display.screenX) ? display.screenX
+                    : (display.bounds && display.bounds.x);
+                const dy = Number.isFinite(display.screenY) ? display.screenY
+                    : (display.bounds && display.bounds.y);
+                const dw = Number.isFinite(display.width) ? display.width
+                    : (display.bounds && display.bounds.width);
+                const dh = Number.isFinite(display.height) ? display.height
+                    : (display.bounds && display.bounds.height);
+                if (!Number.isFinite(dx) || !Number.isFinite(dy) ||
+                    !Number.isFinite(dw) || !Number.isFinite(dh)) continue;
+                if (modelScreenX >= dx && modelScreenX < dx + dw &&
+                    modelScreenY >= dy && modelScreenY < dy + dh) {
+                    targetDisplay = { ...display, screenX: dx, screenY: dy, width: dw, height: dh };
+                    break;
+                }
+            }
+            if (!targetDisplay) return false;
+
+            console.log('[MMD] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
+
+            const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
+
+            if (!(result && result.success && !result.sameDisplay)) {
+                return false;
+            }
+            console.log('[MMD] 屏幕切换成功:', result);
+
+            // 5. 将模型在世界坐标中偏移，使它在新窗口中仍显示在原本的屏幕绝对位置
+            const deltaPxX = currentScreenX - targetDisplay.screenX;
+            const deltaPxY = currentScreenY - targetDisplay.screenY;
+
+            if (deltaPxX !== 0 || deltaPxY !== 0) {
+                const cameraDistance = camera.position.distanceTo(mesh.position);
+                const fov = camera.fov * (Math.PI / 180);
+                const worldHeight = 2 * Math.tan(fov / 2) * cameraDistance;
+                const worldWidth = worldHeight * (screenWidth / screenHeight);
+                const pixelToWorldX = worldWidth / screenWidth;
+                const pixelToWorldY = worldHeight / screenHeight;
+
+                const right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion);
+                const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
+
+                mesh.position.add(right.clone().multiplyScalar(deltaPxX * pixelToWorldX));
+                mesh.position.add(up.clone().multiplyScalar(-deltaPxY * pixelToWorldY));
+            }
+
+            // 6. 等待一帧让新窗口尺寸生效，再保存位置
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            await this._savePositionAfterInteraction();
+
+            return true;
+        } catch (error) {
+            console.error('[MMD] 检测/切换屏幕时出错:', error);
+            return false;
+        }
     }
 
     // ═══════════════════ 偏好保存 ═══════════════════

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -282,14 +282,19 @@ class MMDInteraction {
         // 鼠标抬起
         this.mouseUpHandler = async () => {
             if (this.isDragging) {
+                // 保留本次拖拽类型再清状态，跨屏切换只对 pan 生效
+                // （orbit 是绕模型中心旋转朝向，不应触发多屏切换）
+                const wasPanDrag = this.dragMode === 'pan';
                 this.isDragging = false;
                 this.dragMode = null;
                 canvas.style.cursor = 'default';
                 this._restoreButtonPointerEvents();
 
-                // 多屏幕支持：检测模型是否移出当前屏幕并切换到新屏幕
+                // 多屏幕支持：仅对平移拖拽检测是否移出当前屏幕并切换到新屏幕
                 // 若发生切屏，_checkAndSwitchDisplay 内部会负责保存位置
-                const displaySwitched = await this._checkAndSwitchDisplay();
+                const displaySwitched = wasPanDrag
+                    ? await this._checkAndSwitchDisplay()
+                    : false;
 
                 if (!displaySwitched) {
                     // 拖拽结束后保存位置/旋转/缩放

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -326,11 +326,17 @@ class VRMInteraction {
                 // 拖拽结束后恢复按钮的 pointer-events
                 this._restoreButtonPointerEvents();
 
-                // 拖拽结束后：若超出屏幕范围，执行回弹
-                await this._snapModelIntoScreen({ animate: true });
+                // 多屏幕支持：检测模型是否移出当前屏幕并切换到新屏幕
+                // 与 Live2D 行为对齐：若发生切屏，_checkAndSwitchDisplay 内部负责回弹和保存
+                const displaySwitched = await this._checkAndSwitchDisplay();
 
-                // 拖动结束后保存位置（包含回弹后的位置）
-                await this._savePositionAfterInteraction();
+                if (!displaySwitched) {
+                    // 拖拽结束后：若超出屏幕范围，执行回弹
+                    await this._snapModelIntoScreen({ animate: true });
+
+                    // 拖动结束后保存位置（包含回弹后的位置）
+                    await this._savePositionAfterInteraction();
+                }
             }
         };
 
@@ -833,6 +839,165 @@ class VRMInteraction {
         }
 
         return await this._animateModelToPosition(startPosition, targetPosition);
+    }
+
+    /**
+     * 多屏幕支持：检测模型是否移出当前屏幕并切换到新屏幕
+     * 返回 true 表示发生了切屏（内部已保存位置），返回 false 表示未切屏
+     */
+    async _checkAndSwitchDisplay() {
+        // 仅在 Electron 环境下执行
+        if (!window.electronScreen || !window.electronScreen.moveWindowToDisplay) {
+            return false;
+        }
+        if (!THREE) return false;
+
+        const scene = this.manager.currentModel?.scene;
+        const vrm = this.manager.currentModel?.vrm;
+        const camera = this.manager.camera;
+        const renderer = this.manager.renderer;
+        if (!scene || !vrm || !camera || !renderer) return false;
+
+        try {
+            // 1. 计算模型在当前窗口中的屏幕空间中心点（像素）
+            vrm.scene.updateMatrixWorld(true);
+            const box = new THREE.Box3().setFromObject(vrm.scene);
+            if (!box || !Number.isFinite(box.min.x) || !Number.isFinite(box.max.x)) {
+                return false;
+            }
+
+            const canvasRect = renderer.domElement.getBoundingClientRect();
+            const screenWidth = canvasRect.width;
+            const screenHeight = canvasRect.height;
+            if (!(screenWidth > 0) || !(screenHeight > 0)) return false;
+
+            const corners = [
+                new THREE.Vector3(box.min.x, box.min.y, box.min.z),
+                new THREE.Vector3(box.max.x, box.min.y, box.min.z),
+                new THREE.Vector3(box.min.x, box.max.y, box.min.z),
+                new THREE.Vector3(box.max.x, box.max.y, box.min.z),
+                new THREE.Vector3(box.min.x, box.min.y, box.max.z),
+                new THREE.Vector3(box.max.x, box.min.y, box.max.z),
+                new THREE.Vector3(box.min.x, box.max.y, box.max.z),
+                new THREE.Vector3(box.max.x, box.max.y, box.max.z),
+            ];
+
+            let modelMinX = Infinity, modelMaxX = -Infinity;
+            let modelMinY = Infinity, modelMaxY = -Infinity;
+            corners.forEach(corner => {
+                const projected = corner.clone().project(camera);
+                const sx = (projected.x * 0.5 + 0.5) * screenWidth;
+                const sy = (-projected.y * 0.5 + 0.5) * screenHeight;
+                modelMinX = Math.min(modelMinX, sx);
+                modelMaxX = Math.max(modelMaxX, sx);
+                modelMinY = Math.min(modelMinY, sy);
+                modelMaxY = Math.max(modelMaxY, sy);
+            });
+
+            // 模型中心（相对于 canvas 左上角的像素），再偏移 canvas 在窗口中的位置
+            const modelCenterX = (modelMinX + modelMaxX) / 2 + canvasRect.left;
+            const modelCenterY = (modelMinY + modelMaxY) / 2 + canvasRect.top;
+
+            // 2. 多屏幕检查
+            const displays = await window.electronScreen.getAllDisplays();
+            if (!displays || displays.length <= 1) return false;
+
+            const windowWidth = window.innerWidth;
+            const windowHeight = window.innerHeight;
+            // 如果模型中心仍在当前窗口内，不切屏
+            if (modelCenterX >= 0 && modelCenterX < windowWidth &&
+                modelCenterY >= 0 && modelCenterY < windowHeight) {
+                return false;
+            }
+
+            // 3. 计算模型中心在整个桌面（screen）上的绝对坐标
+            const currentDisplay = await window.electronScreen.getCurrentDisplay();
+            if (!currentDisplay) {
+                console.warn('[VRM] 无法获取当前显示器信息');
+                return false;
+            }
+            let currentScreenX = currentDisplay.screenX;
+            let currentScreenY = currentDisplay.screenY;
+            if (!Number.isFinite(currentScreenX) || !Number.isFinite(currentScreenY)) {
+                if (currentDisplay.bounds &&
+                    Number.isFinite(currentDisplay.bounds.x) &&
+                    Number.isFinite(currentDisplay.bounds.y)) {
+                    currentScreenX = currentDisplay.bounds.x;
+                    currentScreenY = currentDisplay.bounds.y;
+                } else {
+                    return false;
+                }
+            }
+
+            const modelScreenX = currentScreenX + modelCenterX;
+            const modelScreenY = currentScreenY + modelCenterY;
+
+            // 4. 查找包含模型中心点的目标显示器
+            let targetDisplay = null;
+            for (const display of displays) {
+                const dx = Number.isFinite(display.screenX) ? display.screenX
+                    : (display.bounds && display.bounds.x);
+                const dy = Number.isFinite(display.screenY) ? display.screenY
+                    : (display.bounds && display.bounds.y);
+                const dw = Number.isFinite(display.width) ? display.width
+                    : (display.bounds && display.bounds.width);
+                const dh = Number.isFinite(display.height) ? display.height
+                    : (display.bounds && display.bounds.height);
+                if (!Number.isFinite(dx) || !Number.isFinite(dy) ||
+                    !Number.isFinite(dw) || !Number.isFinite(dh)) continue;
+                if (modelScreenX >= dx && modelScreenX < dx + dw &&
+                    modelScreenY >= dy && modelScreenY < dy + dh) {
+                    targetDisplay = { ...display, screenX: dx, screenY: dy, width: dw, height: dh };
+                    break;
+                }
+            }
+            if (!targetDisplay) return false;
+
+            console.log('[VRM] 检测到模型移出当前屏幕，准备切换到屏幕:', targetDisplay.id);
+
+            const result = await window.electronScreen.moveWindowToDisplay(modelScreenX, modelScreenY);
+
+            if (!(result && result.success && !result.sameDisplay)) {
+                return false;
+            }
+            console.log('[VRM] 屏幕切换成功:', result);
+
+            // 5. 将模型在世界坐标中偏移，使它在新窗口中仍显示在原本的屏幕绝对位置
+            //    新窗口原点假定为 targetDisplay.(screenX, screenY)
+            //    期望的新窗口像素位置 = modelScreen(X,Y) - targetDisplay.(screenX, screenY)
+            //    当前投影后的窗口像素位置 = (modelCenterX, modelCenterY)
+            //    需要在屏幕空间移动的像素 = 期望 - 当前 = currentDisplay.(screenX, screenY) - targetDisplay.(screenX, screenY)
+            const deltaPxX = currentScreenX - targetDisplay.screenX;
+            const deltaPxY = currentScreenY - targetDisplay.screenY;
+
+            if (deltaPxX !== 0 || deltaPxY !== 0) {
+                const modelCenterWorld = scene.position.clone();
+                const cameraDistance = camera.position.distanceTo(modelCenterWorld);
+                const fov = camera.fov * (Math.PI / 180);
+                const worldHeight = 2 * Math.tan(fov / 2) * cameraDistance;
+                const worldWidth = worldHeight * (screenWidth / screenHeight);
+                const pixelToWorldX = worldWidth / screenWidth;
+                const pixelToWorldY = worldHeight / screenHeight;
+
+                const right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion);
+                const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
+
+                // 屏幕像素 -> 世界空间：X 沿 +right，Y 沿 -up（屏幕 Y 向下）
+                scene.position.add(right.clone().multiplyScalar(deltaPxX * pixelToWorldX));
+                scene.position.add(up.clone().multiplyScalar(-deltaPxY * pixelToWorldY));
+            }
+
+            // 6. 等待一帧让新窗口尺寸生效，再执行回弹与保存
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            await this._snapModelIntoScreen({ animate: true });
+            await this._savePositionAfterInteraction();
+
+            return true;
+        } catch (error) {
+            console.error('[VRM] 检测/切换屏幕时出错:', error);
+            return false;
+        }
     }
 
 

--- a/static/vrm-interaction.js
+++ b/static/vrm-interaction.js
@@ -319,6 +319,9 @@ class VRMInteraction {
             if (this.isDragging) {
                 e.preventDefault();
                 e.stopPropagation();
+                // 保留本次拖拽类型再清状态，跨屏切换只对 pan 生效
+                // （orbit 只旋转相机，不应触发多屏切换）
+                const wasPanDrag = this.dragMode === 'pan';
                 this.isDragging = false;
                 this.dragMode = null;
                 canvas.style.cursor = 'default';
@@ -326,9 +329,11 @@ class VRMInteraction {
                 // 拖拽结束后恢复按钮的 pointer-events
                 this._restoreButtonPointerEvents();
 
-                // 多屏幕支持：检测模型是否移出当前屏幕并切换到新屏幕
+                // 多屏幕支持：仅对平移拖拽检测是否移出当前屏幕并切换到新屏幕
                 // 与 Live2D 行为对齐：若发生切屏，_checkAndSwitchDisplay 内部负责回弹和保存
-                const displaySwitched = await this._checkAndSwitchDisplay();
+                const displaySwitched = wasPanDrag
+                    ? await this._checkAndSwitchDisplay()
+                    : false;
 
                 if (!displaySwitched) {
                     // 拖拽结束后：若超出屏幕范围，执行回弹


### PR DESCRIPTION
VRM 和 MMD 的 mouseUpHandler 之前只会把模型吸附回当前窗口，缺少与 Live2D 一致 的跨屏检测，导致在多显示器场景下把模型拖到屏幕边缘松手时无法切换到相邻显示器。

为两者新增 _checkAndSwitchDisplay：
- 取模型包围盒投影到屏幕的中心点，判断是否移出当前窗口
- 通过 electronScreen.getCurrentDisplay/getAllDisplays 找到目标显示器
- 调用 moveWindowToDisplay 移动宿主窗口
- 以相机 FOV/距离将窗口位移换算到世界空间，补偿 scene/mesh 位置， 使模型在切屏后仍保持原本的屏幕绝对坐标
- VRM 切屏后再执行 _snapModelIntoScreen 回弹并保存；MMD 直接保存

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持在多显示器环境中拖拽模型时自动切换应用窗口至目标显示器（仅平移拖拽触发）。
  * 切换显示器后自动微调模型位置以保持视图连贯，并在完成后保存位置。

* **修复**
  * 避免在成功切换显示器时重复保存或重复执行后续收束动作；非平移拖拽仍保持原有收束行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->