### PR TITLE
fix: 待机动作切换冻结物理 + 脖子折角甩动 + 四元数符号归一化

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1007,6 +1007,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const _idleRotationTimers = { vrm: null, mmd: null };
     const _idleRotationLast = { vrm: null, mmd: null };
     const _idleLoopCleanup = { vrm: null, mmd: null };
+    // 待机动作切换期间临时禁用物理，防止头发/裙摆因瞬时姿态跳变而飞甩
+    const _idlePhysicsRestoreTimers = { vrm: null, mmd: null };
+    const _idlePhysicsSavedState = { vrm: null, mmd: null };
 
     // 更新模型类型按钮文字的函数（使用统一管理器）
     function updateModelTypeButtonText() {
@@ -4613,6 +4616,72 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
+    /**
+     * 冻结物理模拟以渡过待机动作切换。
+     * 若用户本来就关闭了物理，或物理系统尚未就绪，则不改变现状（saved=null 表示无需恢复）。
+     */
+    function _freezeIdlePhysics(type) {
+        // 若上次切换的恢复定时器还未执行，先取消它——让冻结一直持续到本次切换完成
+        if (_idlePhysicsRestoreTimers[type]) {
+            clearTimeout(_idlePhysicsRestoreTimers[type]);
+            _idlePhysicsRestoreTimers[type] = null;
+        }
+        if (type === 'vrm') {
+            if (!vrmManager || !vrmManager.currentModel) return;
+            // 只在用户本来启用物理时才记录"需要恢复"；否则保持用户设置
+            if (_idlePhysicsSavedState.vrm === null && vrmManager.enablePhysics) {
+                _idlePhysicsSavedState.vrm = true;
+            }
+            vrmManager.enablePhysics = false;
+        } else {
+            const mmd = window.mmdManager;
+            if (!mmd || !mmd.currentModel) return;
+            if (_idlePhysicsSavedState.mmd === null && mmd.enablePhysics) {
+                _idlePhysicsSavedState.mmd = true;
+            }
+            mmd.enablePhysics = false;
+        }
+    }
+
+    /**
+     * 新动画已落位后调用：把物理初始状态对齐到新姿态，然后恢复物理。
+     * 延迟 ~250ms 让 mixer 把新动画的首帧稳定应用到骨架上。
+     */
+    function _scheduleRestoreIdlePhysics(type) {
+        if (_idlePhysicsRestoreTimers[type]) {
+            clearTimeout(_idlePhysicsRestoreTimers[type]);
+        }
+        _idlePhysicsRestoreTimers[type] = setTimeout(() => {
+            _idlePhysicsRestoreTimers[type] = null;
+            try {
+                if (type === 'vrm') {
+                    const vrm = vrmManager?.currentModel?.vrm;
+                    // 把弹簧骨的初始状态对齐到当前（新动画首帧）的骨架姿态，避免被解释为巨大位移
+                    if (vrm?.springBoneManager && typeof vrm.springBoneManager.setInitState === 'function') {
+                        try { vrm.springBoneManager.setInitState(); } catch (e) { /* noop */ }
+                    }
+                    if (_idlePhysicsSavedState.vrm === true && vrmManager) {
+                        vrmManager.enablePhysics = true;
+                    }
+                    _idlePhysicsSavedState.vrm = null;
+                } else {
+                    const mmd = window.mmdManager;
+                    const model = mmd?.currentModel;
+                    if (model?.physics && typeof model.physics.reset === 'function') {
+                        if (model.mesh) model.mesh.updateMatrixWorld(true);
+                        try { model.physics.reset(); } catch (e) { /* noop */ }
+                    }
+                    if (_idlePhysicsSavedState.mmd === true && mmd) {
+                        mmd.enablePhysics = true;
+                    }
+                    _idlePhysicsSavedState.mmd = null;
+                }
+            } catch (err) {
+                console.warn(`[${type.toUpperCase()} IdleAnimation] 恢复物理失败:`, err);
+            }
+        }, 250);
+    }
+
     /** 停止待机动作轮换 */
     function stopIdleRotation(type) {
         if (_idleRotationTimers[type]) {
@@ -4620,6 +4689,16 @@ document.addEventListener('DOMContentLoaded', async () => {
             _idleRotationTimers[type] = null;
         }
         _cleanupIdleLoopListener(type);
+        // 若物理仍处于冻结状态，立即恢复，避免轮换停掉后物理永远关着
+        if (_idlePhysicsRestoreTimers[type]) {
+            clearTimeout(_idlePhysicsRestoreTimers[type]);
+            _idlePhysicsRestoreTimers[type] = null;
+        }
+        if (_idlePhysicsSavedState[type] === true) {
+            if (type === 'vrm' && vrmManager) vrmManager.enablePhysics = true;
+            else if (type === 'mmd' && window.mmdManager) window.mmdManager.enablePhysics = true;
+        }
+        _idlePhysicsSavedState[type] = null;
         _idleRotationLast[type] = null;
     }
 
@@ -4720,6 +4799,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         // 播放新动画前先清理旧的 loop 监听器
         _cleanupIdleLoopListener(type);
 
+        // 切换窗口期间冻结物理，避免瞬时姿态跳变导致头发/裙摆飞甩
+        _freezeIdlePhysics(type);
+
+        let played = false;
         try {
             if (type === 'vrm') {
                 if (vrmManager && vrmManager.animation && vrmManager.currentModel) {
@@ -4727,6 +4810,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         vrmManager.stopVRMAAnimation();
                     }
                     await vrmManager.playVRMAAnimation(url, { loop: true, immediate: true, isIdle: true });
+                    played = true;
                     console.log('[VRM IdleAnimation] 待机动作已切换:', url.split('/').pop());
 
                     // 注册 loop 事件监听：动画一轮播完时自动切换
@@ -4748,6 +4832,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (window.mmdManager && window.mmdManager.currentModel) {
                     await window.mmdManager.loadAnimation(url);
                     window.mmdManager.playAnimation();
+                    played = true;
                     isMmdIdlePlaying = true;
                     console.log('[MMD IdleAnimation] 待机动作已切换:', url.split('/').pop());
 
@@ -4761,6 +4846,22 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         } catch (err) {
             console.warn(`[${type.toUpperCase()} IdleAnimation] 切换待机动作失败:`, err);
+        } finally {
+            if (played) {
+                // 新动画已启动：等 mixer 把首帧应用到骨架上，再对齐物理初始态并解冻
+                _scheduleRestoreIdlePhysics(type);
+            } else {
+                // 切换未发生（模型未就绪等）：立即解冻，避免物理被永久关闭
+                if (_idlePhysicsRestoreTimers[type]) {
+                    clearTimeout(_idlePhysicsRestoreTimers[type]);
+                    _idlePhysicsRestoreTimers[type] = null;
+                }
+                if (_idlePhysicsSavedState[type] === true) {
+                    if (type === 'vrm' && vrmManager) vrmManager.enablePhysics = true;
+                    else if (type === 'mmd' && window.mmdManager) window.mmdManager.enablePhysics = true;
+                }
+                _idlePhysicsSavedState[type] = null;
+            }
         }
     }
 

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1010,6 +1010,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     // 待机动作切换期间临时禁用物理，防止头发/裙摆因瞬时姿态跳变而飞甩
     const _idlePhysicsRestoreTimers = { vrm: null, mmd: null };
     const _idlePhysicsSavedState = { vrm: null, mmd: null };
+    // VRM crossfade 结束后收尾旧 action 的定时器（防止 fadeOut 后 action 残留占用 binding）
+    const _idleCrossfadeCleanupTimers = { vrm: null };
+    // VRM 待机动作 crossfade 时长（秒）。代替 immediate: true，让 mixer 对每根骨做加权 slerp，
+    // 稀释单帧姿态跳变，避开 LookAtQuaternionProxy Euler 拆分在奇点附近的脖子甩动。
+    const IDLE_VRM_FADE_SEC = 0.15;
 
     // 更新模型类型按钮文字的函数（使用统一管理器）
     function updateModelTypeButtonText() {
@@ -4699,6 +4704,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             else if (type === 'mmd' && window.mmdManager) window.mmdManager.enablePhysics = true;
         }
         _idlePhysicsSavedState[type] = null;
+        // 取消挂起的 crossfade 收尾定时器（若有）
+        if (type === 'vrm' && _idleCrossfadeCleanupTimers.vrm) {
+            clearTimeout(_idleCrossfadeCleanupTimers.vrm);
+            _idleCrossfadeCleanupTimers.vrm = null;
+        }
         _idleRotationLast[type] = null;
     }
 
@@ -4806,22 +4816,46 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
             if (type === 'vrm') {
                 if (vrmManager && vrmManager.animation && vrmManager.currentModel) {
-                    if (vrmManager.vrmaAction) {
-                        vrmManager.stopVRMAAnimation();
-                    }
-                    await vrmManager.playVRMAAnimation(url, { loop: true, immediate: true, isIdle: true });
+                    // 记录切换前的 action：crossfade 结束后需要把它 stop() 掉，否则 fadeOut
+                    // 完成后它会以权重 0 继续持有 binding，长期下来会堆积无效 action
+                    const previousAction = vrmManager.animation.currentAction || null;
+                    // 不再先 stopVRMAAnimation（它会 0.5s fadeOut，过长且是为手动动画设计的），
+                    // 改由 _playAction 的 crossfade 分支直接 fadeOut(old) + fadeIn(new)
+                    await vrmManager.playVRMAAnimation(url, {
+                        loop: true,
+                        immediate: false,
+                        fadeDuration: IDLE_VRM_FADE_SEC,
+                        isIdle: true,
+                    });
                     played = true;
                     console.log('[VRM IdleAnimation] 待机动作已切换:', url.split('/').pop());
 
-                    // 注册 loop 事件监听：动画一轮播完时自动切换
+                    // 注册 loop 事件监听：动画一轮播完时自动切换。
+                    // 仅响应当前 action 的 loop，忽略 fadeOut 中的旧 action（权重 0 也会触发 loop）。
                     const mixer = vrmManager.animation?.vrmaMixer;
                     if (mixer) {
-                        const handler = () => {
+                        const handler = (event) => {
+                            const cur = vrmManager.animation?.currentAction;
+                            if (cur && event.action !== cur) return;
                             console.debug('[VRM IdleAnimation] 动画循环完成，切换下一个');
                             _triggerIdleSwitch('vrm');
                         };
                         mixer.addEventListener('loop', handler);
                         _idleLoopCleanup['vrm'] = () => mixer.removeEventListener('loop', handler);
+                    }
+
+                    // crossfade 完成后把旧 action 彻底 stop()，避免 fadeOut 残留累积
+                    if (previousAction && previousAction !== vrmManager.animation.currentAction) {
+                        if (_idleCrossfadeCleanupTimers.vrm) clearTimeout(_idleCrossfadeCleanupTimers.vrm);
+                        _idleCrossfadeCleanupTimers.vrm = setTimeout(() => {
+                            _idleCrossfadeCleanupTimers.vrm = null;
+                            try {
+                                // 再确认它确实不是"当前" action，防止竞态把新 action 误停
+                                if (previousAction !== vrmManager.animation?.currentAction) {
+                                    previousAction.stop();
+                                }
+                            } catch (e) { /* noop */ }
+                        }, Math.ceil(IDLE_VRM_FADE_SEC * 1000) + 50);
                     }
 
                     // 动画加载成功后再启动回退定时器（从实际播放开始计时）

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1010,8 +1010,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     // 待机动作切换期间临时禁用物理，防止头发/裙摆因瞬时姿态跳变而飞甩
     const _idlePhysicsRestoreTimers = { vrm: null, mmd: null };
     const _idlePhysicsSavedState = { vrm: null, mmd: null };
-    // VRM crossfade 结束后收尾旧 action 的定时器（防止 fadeOut 后 action 残留占用 binding）
-    const _idleCrossfadeCleanupTimers = { vrm: null };
+    // VRM crossfade 结束后收尾旧 action 的定时器集合（防止 fadeOut 后 action 残留占用 binding）。
+    // 用 Set 而不是单一 slot：快速连续切换时每个 previousAction 有独立的定时器，不能被后续切换取消，
+    // 否则中间那些 action 会以权重 0 永远留在 mixer 里。
+    const _idleCrossfadeCleanupTimers = { vrm: new Set() };
     // VRM 待机动作 crossfade 时长（秒）。代替 immediate: true，让 mixer 对每根骨做加权 slerp，
     // 稀释单帧姿态跳变，避开 LookAtQuaternionProxy Euler 拆分在奇点附近的脖子甩动。
     const IDLE_VRM_FADE_SEC = 0.15;
@@ -4704,10 +4706,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             else if (type === 'mmd' && window.mmdManager) window.mmdManager.enablePhysics = true;
         }
         _idlePhysicsSavedState[type] = null;
-        // 取消挂起的 crossfade 收尾定时器（若有）
-        if (type === 'vrm' && _idleCrossfadeCleanupTimers.vrm) {
-            clearTimeout(_idleCrossfadeCleanupTimers.vrm);
-            _idleCrossfadeCleanupTimers.vrm = null;
+        // 取消所有挂起的 crossfade 收尾定时器
+        if (type === 'vrm' && _idleCrossfadeCleanupTimers.vrm.size > 0) {
+            for (const tid of _idleCrossfadeCleanupTimers.vrm) clearTimeout(tid);
+            _idleCrossfadeCleanupTimers.vrm.clear();
         }
         _idleRotationLast[type] = null;
     }
@@ -4844,11 +4846,13 @@ document.addEventListener('DOMContentLoaded', async () => {
                         _idleLoopCleanup['vrm'] = () => mixer.removeEventListener('loop', handler);
                     }
 
-                    // crossfade 完成后把旧 action 彻底 stop()，避免 fadeOut 残留累积
+                    // crossfade 完成后把旧 action 彻底 stop()，避免 fadeOut 残留累积。
+                    // 每个 previousAction 都注册自己的定时器，绝不互相取消——否则快速连续切换时
+                    // 中间那些 action 会丢失 stop() 机会，以权重 0 永驻 mixer。
                     if (previousAction && previousAction !== vrmManager.animation.currentAction) {
-                        if (_idleCrossfadeCleanupTimers.vrm) clearTimeout(_idleCrossfadeCleanupTimers.vrm);
-                        _idleCrossfadeCleanupTimers.vrm = setTimeout(() => {
-                            _idleCrossfadeCleanupTimers.vrm = null;
+                        let tid = null;
+                        tid = setTimeout(() => {
+                            _idleCrossfadeCleanupTimers.vrm.delete(tid);
                             try {
                                 // 再确认它确实不是"当前" action，防止竞态把新 action 误停
                                 if (previousAction !== vrmManager.animation?.currentAction) {
@@ -4856,6 +4860,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                                 }
                             } catch (e) { /* noop */ }
                         }, Math.ceil(IDLE_VRM_FADE_SEC * 1000) + 50);
+                        _idleCrossfadeCleanupTimers.vrm.add(tid);
                     }
 
                     // 动画加载成功后再启动回退定时器（从实际播放开始计时）

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1013,6 +1013,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     // VRM crossfade 结束后收尾旧 action 的定时器集合（防止 fadeOut 后 action 残留占用 binding）。
     // 用 Set 而不是单一 slot：快速连续切换时每个 previousAction 有独立的定时器，不能被后续切换取消，
     // 否则中间那些 action 会以权重 0 永远留在 mixer 里。
+    // 每个条目是 { tid, action }：stopIdleRotation 中断时光 clearTimeout 还不够——
+    // 对应的 action 也要主动 stop()，否则同样会以权重 0 常驻 mixer。
     const _idleCrossfadeCleanupTimers = { vrm: new Set() };
     // VRM 待机动作 crossfade 时长（秒）。代替 immediate: true，让 mixer 对每根骨做加权 slerp，
     // 稀释单帧姿态跳变，避开 LookAtQuaternionProxy Euler 拆分在奇点附近的脖子甩动。
@@ -4711,9 +4713,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             _idlePhysicsRestoreTimers[type] = null;
         }
         _alignAndRestoreIdlePhysics(type);
-        // 取消所有挂起的 crossfade 收尾定时器
+        // 取消所有挂起的 crossfade 收尾定时器，并把对应的旧 action 主动 stop()。
+        // 只 clearTimeout 会漏掉 action：它们已 fadeOut 到 0，但没 stop() 就会以权重 0
+        // 常驻 mixer，绑定也不会释放，和本 patch 想避免的残留是同一个坑。
         if (type === 'vrm' && _idleCrossfadeCleanupTimers.vrm.size > 0) {
-            for (const tid of _idleCrossfadeCleanupTimers.vrm) clearTimeout(tid);
+            const currentAction = vrmManager?.animation?.currentAction || null;
+            for (const entry of _idleCrossfadeCleanupTimers.vrm) {
+                clearTimeout(entry.tid);
+                try {
+                    if (entry.action && entry.action !== currentAction) {
+                        entry.action.stop();
+                    }
+                } catch (e) { /* noop */ }
+            }
             _idleCrossfadeCleanupTimers.vrm.clear();
         }
         _idleRotationLast[type] = null;
@@ -4855,17 +4867,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                     // 每个 previousAction 都注册自己的定时器，绝不互相取消——否则快速连续切换时
                     // 中间那些 action 会丢失 stop() 机会，以权重 0 永驻 mixer。
                     if (previousAction && previousAction !== vrmManager.animation.currentAction) {
-                        let tid = null;
-                        tid = setTimeout(() => {
-                            _idleCrossfadeCleanupTimers.vrm.delete(tid);
+                        const entry = { tid: null, action: previousAction };
+                        entry.tid = setTimeout(() => {
+                            _idleCrossfadeCleanupTimers.vrm.delete(entry);
                             try {
                                 // 再确认它确实不是"当前" action，防止竞态把新 action 误停
-                                if (previousAction !== vrmManager.animation?.currentAction) {
-                                    previousAction.stop();
+                                if (entry.action !== vrmManager.animation?.currentAction) {
+                                    entry.action.stop();
                                 }
                             } catch (e) { /* noop */ }
                         }, Math.ceil(IDLE_VRM_FADE_SEC * 1000) + 50);
-                        _idleCrossfadeCleanupTimers.vrm.add(tid);
+                        _idleCrossfadeCleanupTimers.vrm.add(entry);
                     }
 
                     // 动画加载成功后再启动回退定时器（从实际播放开始计时）

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -4651,8 +4651,41 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     /**
-     * 新动画已落位后调用：把物理初始状态对齐到新姿态，然后恢复物理。
-     * 延迟 ~250ms 让 mixer 把新动画的首帧稳定应用到骨架上。
+     * 把物理初始状态对齐到当前骨架姿态，然后按 savedState 恢复 enablePhysics。
+     * VRM: springBoneManager.setInitState()；MMD: physics.reset()。
+     * 不对齐就恢复的话，物理引擎会用旧模拟状态去撞上新骨架姿态，正是这个 patch 想避免的。
+     */
+    function _alignAndRestoreIdlePhysics(type) {
+        try {
+            if (type === 'vrm') {
+                const vrm = vrmManager?.currentModel?.vrm;
+                if (vrm?.springBoneManager && typeof vrm.springBoneManager.setInitState === 'function') {
+                    try { vrm.springBoneManager.setInitState(); } catch (e) { /* noop */ }
+                }
+                if (_idlePhysicsSavedState.vrm === true && vrmManager) {
+                    vrmManager.enablePhysics = true;
+                }
+                _idlePhysicsSavedState.vrm = null;
+            } else {
+                const mmd = window.mmdManager;
+                const model = mmd?.currentModel;
+                if (model?.physics && typeof model.physics.reset === 'function') {
+                    if (model.mesh) model.mesh.updateMatrixWorld(true);
+                    try { model.physics.reset(); } catch (e) { /* noop */ }
+                }
+                if (_idlePhysicsSavedState.mmd === true && mmd) {
+                    mmd.enablePhysics = true;
+                }
+                _idlePhysicsSavedState.mmd = null;
+            }
+        } catch (err) {
+            console.warn(`[${type.toUpperCase()} IdleAnimation] 恢复物理失败:`, err);
+        }
+    }
+
+    /**
+     * 新动画已落位后调用：延迟 ~250ms 让 mixer 把新动画的首帧稳定应用到骨架上，
+     * 再对齐物理初始态并恢复。
      */
     function _scheduleRestoreIdlePhysics(type) {
         if (_idlePhysicsRestoreTimers[type]) {
@@ -4660,32 +4693,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
         _idlePhysicsRestoreTimers[type] = setTimeout(() => {
             _idlePhysicsRestoreTimers[type] = null;
-            try {
-                if (type === 'vrm') {
-                    const vrm = vrmManager?.currentModel?.vrm;
-                    // 把弹簧骨的初始状态对齐到当前（新动画首帧）的骨架姿态，避免被解释为巨大位移
-                    if (vrm?.springBoneManager && typeof vrm.springBoneManager.setInitState === 'function') {
-                        try { vrm.springBoneManager.setInitState(); } catch (e) { /* noop */ }
-                    }
-                    if (_idlePhysicsSavedState.vrm === true && vrmManager) {
-                        vrmManager.enablePhysics = true;
-                    }
-                    _idlePhysicsSavedState.vrm = null;
-                } else {
-                    const mmd = window.mmdManager;
-                    const model = mmd?.currentModel;
-                    if (model?.physics && typeof model.physics.reset === 'function') {
-                        if (model.mesh) model.mesh.updateMatrixWorld(true);
-                        try { model.physics.reset(); } catch (e) { /* noop */ }
-                    }
-                    if (_idlePhysicsSavedState.mmd === true && mmd) {
-                        mmd.enablePhysics = true;
-                    }
-                    _idlePhysicsSavedState.mmd = null;
-                }
-            } catch (err) {
-                console.warn(`[${type.toUpperCase()} IdleAnimation] 恢复物理失败:`, err);
-            }
+            _alignAndRestoreIdlePhysics(type);
         }, 250);
     }
 
@@ -4696,16 +4704,13 @@ document.addEventListener('DOMContentLoaded', async () => {
             _idleRotationTimers[type] = null;
         }
         _cleanupIdleLoopListener(type);
-        // 若物理仍处于冻结状态，立即恢复，避免轮换停掉后物理永远关着
+        // 若物理仍处于冻结状态，立即走对齐+恢复，避免跳过 setInitState/physics.reset
+        // 直接开物理导致残留的旧模拟状态撞上新骨架姿态
         if (_idlePhysicsRestoreTimers[type]) {
             clearTimeout(_idlePhysicsRestoreTimers[type]);
             _idlePhysicsRestoreTimers[type] = null;
         }
-        if (_idlePhysicsSavedState[type] === true) {
-            if (type === 'vrm' && vrmManager) vrmManager.enablePhysics = true;
-            else if (type === 'mmd' && window.mmdManager) window.mmdManager.enablePhysics = true;
-        }
-        _idlePhysicsSavedState[type] = null;
+        _alignAndRestoreIdlePhysics(type);
         // 取消所有挂起的 crossfade 收尾定时器
         if (type === 'vrm' && _idleCrossfadeCleanupTimers.vrm.size > 0) {
             for (const tid of _idleCrossfadeCleanupTimers.vrm) clearTimeout(tid);
@@ -4890,16 +4895,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                 // 新动画已启动：等 mixer 把首帧应用到骨架上，再对齐物理初始态并解冻
                 _scheduleRestoreIdlePhysics(type);
             } else {
-                // 切换未发生（模型未就绪等）：立即解冻，避免物理被永久关闭
+                // 切换未发生（模型未就绪等）：立即走对齐+解冻。
+                // 姿态没变，setInitState/physics.reset 基本是 no-op，但保持路径一致，
+                // 避免未来加逻辑时漏掉这条分支。
                 if (_idlePhysicsRestoreTimers[type]) {
                     clearTimeout(_idlePhysicsRestoreTimers[type]);
                     _idlePhysicsRestoreTimers[type] = null;
                 }
-                if (_idlePhysicsSavedState[type] === true) {
-                    if (type === 'vrm' && vrmManager) vrmManager.enablePhysics = true;
-                    else if (type === 'mmd' && window.mmdManager) window.mmdManager.enablePhysics = true;
-                }
-                _idlePhysicsSavedState[type] = null;
+                _alignAndRestoreIdlePhysics(type);
             }
         }
     }

--- a/static/mmd-animation.js
+++ b/static/mmd-animation.js
@@ -85,6 +85,9 @@ class MMDAnimation {
 
         // 构建动画 Clip
         const clip = buildAnimation(vmdObject, mmd.mesh);
+        // 防御：把每条四元数轨道的相邻关键帧翻到同半球（dot >= 0），
+        // 避免个别 VMD 在动画切换初始几帧被插值成长路径 / 奇点甩动。
+        this._normalizeQuaternionTrackSigns(clip);
         this.currentClip = clip;
 
         // 创建 AnimationMixer
@@ -155,6 +158,32 @@ class MMDAnimation {
         console.log('[MMD Animation] 动画加载完成:', vmdUrl);
 
         return clip;
+    }
+
+    // ═══════════════════ 轨道防御 ═══════════════════
+
+    _normalizeQuaternionTrackSigns(clip) {
+        const THREE = window.THREE;
+        if (!clip?.tracks || !THREE?.QuaternionKeyframeTrack) return;
+        const stride = 4;
+        for (const track of clip.tracks) {
+            if (!(track instanceof THREE.QuaternionKeyframeTrack)) continue;
+            const v = track.values;
+            if (!v || v.length < stride * 2) continue;
+            for (let i = stride; i < v.length; i += stride) {
+                const dot =
+                    v[i - 4] * v[i] +
+                    v[i - 3] * v[i + 1] +
+                    v[i - 2] * v[i + 2] +
+                    v[i - 1] * v[i + 3];
+                if (dot < 0) {
+                    v[i]     = -v[i];
+                    v[i + 1] = -v[i + 1];
+                    v[i + 2] = -v[i + 2];
+                    v[i + 3] = -v[i + 3];
+                }
+            }
+        }
     }
 
     // ═══════════════════ 骨骼缓存 ═══════════════════

--- a/static/vrm-animation.js
+++ b/static/vrm-animation.js
@@ -278,6 +278,36 @@ class VRMAnimation {
         }
     }
 
+    /**
+     * 把 clip 里每条 QuaternionKeyframeTrack 的相邻关键帧翻到同一半球（dot >= 0）。
+     * slerpFlat 成对处理能自洽，但链式经过 3+ 关键帧或配合 LookAt 的 Euler 拆分时，
+     * 偶尔会被反向四元数骗出长路径 / 奇点甩动（表现为脖子折 90 度甩几圈后自愈）。
+     * 同一旋转的 q 和 -q 在表现上等价，翻符号是无副作用的防御。
+     */
+    _normalizeQuaternionTrackSigns(clip) {
+        const THREE = window.THREE;
+        if (!clip?.tracks || !THREE?.QuaternionKeyframeTrack) return;
+        const stride = 4;
+        for (const track of clip.tracks) {
+            if (!(track instanceof THREE.QuaternionKeyframeTrack)) continue;
+            const v = track.values;
+            if (!v || v.length < stride * 2) continue;
+            for (let i = stride; i < v.length; i += stride) {
+                const dot =
+                    v[i - 4] * v[i] +
+                    v[i - 3] * v[i + 1] +
+                    v[i - 2] * v[i + 2] +
+                    v[i - 1] * v[i + 3];
+                if (dot < 0) {
+                    v[i]     = -v[i];
+                    v[i + 1] = -v[i + 1];
+                    v[i + 2] = -v[i + 2];
+                    v[i + 3] = -v[i + 3];
+                }
+            }
+        }
+    }
+
     _findBestMixerRoot(vrm, clip) {
         let mixerRoot = vrm.scene;
         const sampleTracks = clip.tracks.slice(0, 10);
@@ -489,6 +519,7 @@ class VRMAnimation {
             await this._createLookAtProxy(vrm);
             const clip = await this._createAndValidateAnimationClip(vrmAnimation, vrm);
             this._processTracksForVersion(clip, vrmVersion);
+            this._normalizeQuaternionTrackSigns(clip);
 
             // 判断是否为待机动画（仅在显式传入 isIdle: true 时才视为待机）
             this.isIdleAnimation = !!options.isIdle;


### PR DESCRIPTION
## 背景

VRM/MMD 的待机动作多选轮换机制在切换瞬间有两个可见问题：

1. **头发/裙摆飞甩**：`{ immediate: true }` 让骨架一帧内跳到新动画 t=0 姿态，SpringBone / MMDPhysics 把瞬时大位移当成高速冲击积分出去。
2. **罕见的脖子折 90° 甩动**：只有脖子异常，以根部为轴折约 90° 再急速绕轴甩几圈，数帧后自愈。

另外用户确认了之前的需求"上一个动作播放完再换下一个"——VRM/MMD 均已实现：`mixer.addEventListener('loop', ...)` 监听一轮播完触发切换，20s 兜底定时器应对极长动画。

## 修复 1：切换期间冻结物理（头发飞甩）

`static/js/model_manager.js` `_playIdleAnimation`：

- 切换前 `_freezeIdlePhysics(type)`：`vrmManager.enablePhysics = false` / `mmdManager.enablePhysics = false`。只在用户本来开启物理时记录"需要恢复"，避免覆盖用户关闭物理的选择。
- 新动画落位后 `_scheduleRestoreIdlePhysics(type)`：延迟 250ms 调 `vrm.springBoneManager.setInitState()` / `model.physics.reset()`，把物理初始态对齐到新姿态，再恢复 `enablePhysics`。
- `stopIdleRotation` 同步强制解冻，防止轮换停止后物理被永久关闭。
- 连续快切时新 freeze 会取消旧 restore 定时器，冻结覆盖整个过渡窗口。

## 修复 2：VRM 待机切换脖子折角甩动

### 根因

VRM 脖子链上同时被三路写入：
- 动画轨道写 `Normalized_Neck.quaternion`
- `VRMLookAtQuaternionProxy._applyToLookAt()` 内部把自己 quaternion 做 `setFromQuaternion(…, EULER_ORDER)` 拆分，喂给 `vrmLookAt.yaw/pitch`
- `vrm-cursor-follow.js:867` 的 `bone.quaternion.premultiply(localOffset)`

`immediate: true` 下 mixer 一帧写入新动画 t=0 姿态，**当新 clip 的脖子/LookAt 开头姿态恰好把 proxy 的 Euler 拆分推到 pitch ≈ ±90° 奇点附近时**，yaw 被放大数倍，配合动画的基础弯折，视觉即"折 90° + 甩几圈"。数帧后骨骼脱离奇点区自愈。罕见性来自需要 t=0 恰落奇点邻域。

物理冻结不修这个——脖子是动画驱动，不走物理。

### 修复

1. 待机切换从 `immediate: true` 改成 150ms crossfade（`_playAction` 的非立即分支本就实现了 fadeOut+fadeIn）。mixer 在 ~9 帧里对每根骨做加权 `slerpFlat`（最短路径），单帧跳变被稀释成渐变，LookAt proxy quaternion 随 crossfade 平滑过渡不进入奇点。
2. crossfade 结束 +50ms 后 `stop()` 旧 action，避免 fadeOut 后零权重 action 长期残留占用 PropertyBinding。
3. loop 监听过滤 `event.action === currentAction`，忽略 fadeOut 中旧 action 的 loop 事件误触发下一次切换。
4. `stopIdleRotation` 同步清理 crossfade 收尾定时器，防止停轮换后延迟的 `stop()` 误伤下次新 action。

## 修复 3：四元数轨道符号归一化（防御）

在 clip 落地后，对每条 `QuaternionKeyframeTrack` 把相邻关键帧翻到同半球（`dot >= 0`）。`QuaternionLinearInterpolant` 对成对已经自洽，但链式 3+ 关键帧或配合 cubic 插值时仍可能被反向四元数骗出长路径。`q` 与 `-q` 表示同一旋转，翻符号无视觉副作用。

- `static/vrm-animation.js` `_normalizeQuaternionTrackSigns`，在 `_processTracksForVersion` 之后调用
- `static/mmd-animation.js` `_normalizeQuaternionTrackSigns`，在 `buildAnimation` 之后调用

## 时序

```
T+0       freeze(vrm/mmd physics)
T+0       playVRMAAnimation(crossfade 0.15s) 开始   /  loadAnimation + playAnimation
T+150ms   crossfade 完成（VRM）
T+200ms   stop() 旧 action（VRM）
T+250ms   setInitState()/physics.reset() + unfreeze
```

物理窗口 250ms 覆盖 150ms crossfade + 100ms settle。

## Test plan

- [ ] VRM 多选 ≥2 个待机动画轮换，连续观察若干切换，脖子无异常
- [ ] VRM 切换瞬间头发/裙摆不飞甩
- [ ] MMD 多选 ≥2 个待机动画轮换，切换时物理正常（不飞不卡）
- [ ] 用户关闭物理（`enablePhysics = false`）时，切换不会把物理重新打开
- [ ] 切换期间切换到非 live3d 模式/退出 idle 轮换，物理能正确恢复
- [ ] 连续快速切换（短时间内多次 `_triggerIdleSwitch`）无 action 堆积、无物理卡关状态
- [ ] 单选一个待机动画循环，`loop` 事件触发下一轮切换仅响应当前 action，不被 fadeOut 中旧 action 误触发

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 切换空闲动画时临时冻结物理并在对齐当前姿态后恢复，加入延迟恢复以减少切换瞬间异常（更平滑的物理行为）。
  * VRM 空闲动画过渡采用短时淡入/淡出并在过渡完成后清理旧动作，切换更顺滑且无残留动作影响。

* **Bug 修复**
  * 规范化四元数关键帧符号，减少 VRM/MMD 动画抖动与姿态跳变。
  * 改进快速切换场景下的清理与恢复逻辑，防止物理被意外禁用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->