### PR TITLE
fix: 启动器子进程读取使用 utf-8 + replace，避免中文 Windows GBK 解码崩溃

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -731,6 +731,8 @@ def get_port_owners(port: int) -> list[int]:
                 ["netstat", "-ano", "-p", "tcp"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=3,
                 check=False,
             )
@@ -750,6 +752,8 @@ def get_port_owners(port: int) -> list[int]:
                 ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=3,
                 check=False,
             )
@@ -1265,6 +1269,8 @@ def _ensure_playwright_browsers():
             env=env,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=300,
         )
 

--- a/utils/port_utils.py
+++ b/utils/port_utils.py
@@ -169,6 +169,8 @@ def get_hyperv_excluded_ranges() -> list[tuple[int, int]]:
             [resolved_netsh, "interface", "ipv4", "show", "excludedportrange", "protocol=tcp"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
             check=False,
         )


### PR DESCRIPTION
netsh / netstat / lsof / playwright install 之前用 text=True 但未指定 encoding， 在中文 Windows 上会回退到 gbk，输出含非 GBK 字节时 _readerthread 抛 UnicodeDecodeError。统一加上 encoding='utf-8', errors='replace'。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了应用执行系统命令时的字符编码处理，确保网络端口检查和浏览器驱动程序初始化等操作能够更可靠地处理文本输出，提升了应用的稳定性和兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->