### PR TITLE
fix(voice_clone): 解析非 JSON 响应不再抛 "Unexpected token '<'"

### DIFF
--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -51,6 +51,20 @@ function buildNonJsonError(res, text) {
     return `服务端返回了非JSON响应 (HTTP ${res.status})${snippet ? ': ' + snippet : ''}`;
 }
 
+// 把后端错误响应体转成可读消息：
+// 只有在 errors.<code> 翻译确实存在时才使用 i18n，否则回退到响应自带文案，
+// 避免 i18next 的「缺失 key 回退成 key 本身」行为把 "errors.XXX_UNKNOWN" 直接丢给用户。
+function resolveBackendErrorMsg(data, status) {
+    if (data && data.code && window.t) {
+        const i18nKey = 'errors.' + data.code;
+        const translated = window.t(i18nKey, data.details || {});
+        if (translated && translated !== i18nKey) {
+            return translated;
+        }
+    }
+    return (data && (data.detail || data.message || data.error)) || `API returned ${status}`;
+}
+
 function parseVoiceRegisterError(errorObj) {
     const errorCode = errorObj?.code;
     const errorMsg = errorObj?.message || errorObj?.error || errorObj || '';
@@ -478,9 +492,8 @@ function registerVoice() {
             const { data, nonJson, text } = await safeReadResponse(res);
             if (!res.ok) {
                 if (data) {
-                    // 从响应体中提取详细错误信息
-                    const errorMsg = (data.code && window.t) ? window.t('errors.' + data.code, data.details || {}) : (data.error || data.detail || `API returned ${res.status}`);
-                    throw new Error(errorMsg);
+                    // 从响应体中提取详细错误信息（优先已翻译的 errors.<code>，缺失则回退到 message/detail/error）
+                    throw new Error(resolveBackendErrorMsg(data, res.status));
                 }
                 // 后端/网关返回了 HTML（如 404/502/504），构造可读错误而不是 "Unexpected token '<'"
                 throw new Error(buildNonJsonError(res, text));
@@ -588,9 +601,13 @@ function registerVoice() {
                             }
                         }
                     }).catch(e => {
+                        // e 可能携带 safeReadResponse/buildNonJsonError 构造的可读错误
+                        // （含 HTTP 状态和正文摘要），必须拼进最终提示，否则诊断信息被吞。
+                        const saveErrorMsg = e?.message || e?.toString() || (window.t ? window.t('common.unknownError') : '未知错误');
+                        const base = window.t ? window.t('voice.voiceIdSaveRequestError') : 'voice_id自动保存请求出错';
                         const errorSpan = document.createElement('span');
                         errorSpan.className = 'error';
-                        errorSpan.textContent = (window.t ? window.t('voice.voiceIdSaveRequestError') : 'voice_id自动保存请求出错');
+                        errorSpan.textContent = saveErrorMsg ? `${base}: ${saveErrorMsg}` : base;
                         resultDiv.appendChild(document.createElement('br'));
                         resultDiv.appendChild(errorSpan);
                     });
@@ -665,7 +682,7 @@ async function playPreview(voiceId, btn) {
                     // localStorage 可能满了，但我们仍然可以播放这一次生成的音频
                 }
             } else {
-                const _errMsg = (data.code && window.t) ? window.t('errors.' + data.code, data.details || {}) : (data.error || 'Failed to get preview');
+                const _errMsg = resolveBackendErrorMsg(data, response.status) || 'Failed to get preview';
                 throw new Error(_errMsg);
             }
         }

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -12,6 +12,42 @@ function openApiSettings() {
     }
 }
 
+// 安全地解析 fetch 响应：当后端/反向代理返回 HTML（404/502/504/网关错误等）时
+// 不应抛出 "Unexpected token '<', '<html>...' is not valid JSON"，而应返回带状态码的可读错误。
+async function safeReadResponse(res) {
+    const contentType = (res.headers.get('content-type') || '').toLowerCase();
+    if (contentType.includes('application/json')) {
+        try {
+            return { data: await res.json(), nonJson: false, text: '' };
+        } catch (_) {
+            // Content-Type 声明 JSON 但解析失败，落到文本分支
+        }
+    }
+    let text = '';
+    try { text = await res.text(); } catch (_) { text = ''; }
+    return { data: null, nonJson: true, text };
+}
+
+function buildNonJsonError(res, text) {
+    // 去除 HTML 标签并截断，避免把整段 HTML 报告给用户
+    const snippet = text
+        ? text.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120)
+        : '';
+    if (window.t) {
+        if (res.status === 404) {
+            return window.t('voice.serverRouteNotFound', { status: res.status });
+        }
+        return window.t('voice.serverNonJsonError', {
+            status: res.status,
+            snippet: snippet || res.statusText || ''
+        });
+    }
+    if (res.status === 404) {
+        return `接口未找到 (HTTP 404)，请确认服务端已正确部署并重启`;
+    }
+    return `服务端返回了非JSON响应 (HTTP ${res.status})${snippet ? ': ' + snippet : ''}`;
+}
+
 function parseVoiceRegisterError(errorObj) {
     const errorCode = errorObj?.code;
     const errorMsg = errorObj?.message || errorObj?.error || errorObj || '';
@@ -436,11 +472,19 @@ function registerVoice() {
 
     fetch(apiUrl, requestOptions)
         .then(async res => {
-            const data = await res.json();
+            const { data, nonJson, text } = await safeReadResponse(res);
             if (!res.ok) {
-                // 从响应体中提取详细错误信息
-                const errorMsg = (data.code && window.t) ? window.t('errors.' + data.code, data.details || {}) : (data.error || data.detail || `API returned ${res.status}`);
-                throw new Error(errorMsg);
+                if (data) {
+                    // 从响应体中提取详细错误信息
+                    const errorMsg = (data.code && window.t) ? window.t('errors.' + data.code, data.details || {}) : (data.error || data.detail || `API returned ${res.status}`);
+                    throw new Error(errorMsg);
+                }
+                // 后端/网关返回了 HTML（如 404/502/504），构造可读错误而不是 "Unexpected token '<'"
+                throw new Error(buildNonJsonError(res, text));
+            }
+            if (nonJson) {
+                // 状态码 2xx 但响应体不是 JSON——不应发生，但仍优雅处理
+                throw new Error(buildNonJsonError(res, text));
             }
             return data;
         })
@@ -494,11 +538,18 @@ function registerVoice() {
                         method: 'PUT',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ voice_id: data.voice_id })
-                    }).then(resp => {
+                    }).then(async resp => {
+                        const { data: respData, nonJson, text } = await safeReadResponse(resp);
                         if (!resp.ok) {
-                            throw new Error(`API returned ${resp.status}`);
+                            if (respData && (respData.error || respData.detail)) {
+                                throw new Error(respData.error || respData.detail);
+                            }
+                            throw new Error(buildNonJsonError(resp, text));
                         }
-                        return resp.json();
+                        if (nonJson) {
+                            throw new Error(buildNonJsonError(resp, text));
+                        }
+                        return respData;
                     }).then(res => {
                         if (!res.success) {
                             const errorMsg = res.error || (window.t ? window.t('common.unknownError') : '未知错误');
@@ -590,10 +641,16 @@ async function playPreview(voiceId, btn) {
         if (!audioSrc) {
             // 如果本地没有缓存，则从服务器获取
             const response = await fetch(`/api/characters/voice_preview?voice_id=${encodeURIComponent(voiceId)}`);
-            if (response.status === 404) {
-                throw new Error('API route not found (404). Please ensure the server has been restarted.');
+            const { data, nonJson, text } = await safeReadResponse(response);
+            if (!response.ok) {
+                if (data && (data.error || data.detail)) {
+                    throw new Error(data.error || data.detail);
+                }
+                throw new Error(buildNonJsonError(response, text));
             }
-            const data = await response.json();
+            if (nonJson) {
+                throw new Error(buildNonJsonError(response, text));
+            }
 
             if (data.success && data.audio) {
                 audioSrc = `data:${data.mime_type || 'audio/mpeg'};base64,${data.audio}`;
@@ -652,10 +709,16 @@ async function loadVoices() {
 
     try {
         const response = await fetch('/api/characters/voices');
+        const { data, nonJson, text } = await safeReadResponse(response);
         if (!response.ok) {
-            throw new Error(`API returned ${response.status}`);
+            if (data && (data.error || data.detail)) {
+                throw new Error(data.error || data.detail);
+            }
+            throw new Error(buildNonJsonError(response, text));
         }
-        const data = await response.json();
+        if (nonJson) {
+            throw new Error(buildNonJsonError(response, text));
+        }
 
         if ((!data.voices || Object.keys(data.voices).length === 0) &&
             (!data.free_voices || Object.keys(data.free_voices).length === 0)) {
@@ -860,7 +923,15 @@ async function deleteVoice(voiceId, voiceName) {
             headers: { 'Content-Type': 'application/json' }
         });
 
-        const data = await response.json();
+        const { data: parsed, nonJson, text } = await safeReadResponse(response);
+        if (!response.ok && !parsed) {
+            // 后端/网关返回了 HTML（如 404/502），抛出可读错误
+            throw new Error(buildNonJsonError(response, text));
+        }
+        if (nonJson) {
+            throw new Error(buildNonJsonError(response, text));
+        }
+        const data = parsed || {};
 
         if (response.ok && data.success) {
             // 删除本地缓存的预览音频

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -16,7 +16,10 @@ function openApiSettings() {
 // 不应抛出 "Unexpected token '<', '<html>...' is not valid JSON"，而应返回带状态码的可读错误。
 async function safeReadResponse(res) {
     const contentType = (res.headers.get('content-type') || '').toLowerCase();
-    if (contentType.includes('application/json')) {
+    // 识别 application/json 以及 RFC 6839 的结构化后缀（如 application/problem+json,
+    // application/vnd.api+json 等），它们都是合法 JSON。
+    const isJsonContentType = contentType.includes('application/json') || /\+json(\s*;|\s*$)/.test(contentType);
+    if (isJsonContentType) {
         try {
             return { data: await res.json(), nonJson: false, text: '' };
         } catch (_) {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1274,6 +1274,8 @@
         "prefixShouldBeEnglishLetterAndNumber": "Prefix should be English letters and numbers",
         "invalidApiKeyProvided": "Invalid API-key provided",
         "requestError": "Request error: {{error}}",
+        "serverNonJsonError": "Server returned a non-JSON response (HTTP {{status}}): {{snippet}}",
+        "serverRouteNotFound": "API route not found (HTTP {{status}}). Please ensure the server is deployed and restarted.",
         "voiceIdSaveFailed": "Failed to automatically save voice_id: {{error}}",
         "voiceIdSaved": "voice_id has been automatically saved to character",
         "pageWillRefresh": "Current page will automatically refresh to apply new voice",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1274,6 +1274,8 @@
         "prefixShouldBeEnglishLetterAndNumber": "接頭辞は英文字と数字である必要があります",
         "invalidApiKeyProvided": "無効なAPIキーが提供されました",
         "requestError": "リクエストエラー：{{error}}",
+        "serverNonJsonError": "サーバーが非JSONレスポンスを返しました (HTTP {{status}})：{{snippet}}",
+        "serverRouteNotFound": "APIエンドポイントが見つかりません (HTTP {{status}})。サーバーが正しくデプロイされ再起動されていることを確認してください。",
         "voiceIdSaveFailed": "voice_idの自動保存に失敗しました: {{error}}",
         "voiceIdSaved": "voice_idをキャラクターに自動保存しました",
         "pageWillRefresh": "新しいボイスを適用するためにページが自動更新されます",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1274,6 +1274,8 @@
         "prefixShouldBeEnglishLetterAndNumber": "접두사는 영어 문자와 숫자여야 합니다",
         "invalidApiKeyProvided": "제공된 API 키가 유효하지 않습니다",
         "requestError": "요청 오류: {{error}}",
+        "serverNonJsonError": "서버가 JSON이 아닌 응답을 반환했습니다 (HTTP {{status}}): {{snippet}}",
+        "serverRouteNotFound": "API 경로를 찾을 수 없습니다 (HTTP {{status}}). 서버가 올바르게 배포되고 재시작되었는지 확인하세요.",
         "voiceIdSaveFailed": "voice_id를 자동으로 저장하지 못했습니다: {{error}}",
         "voiceIdSaved": "voice_id가 자동으로 캐릭터에 저장되었습니다.",
         "pageWillRefresh": "새 음성을 적용하기 위해 현재 페이지가 자동으로 새로 고쳐집니다.",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1274,6 +1274,8 @@
         "prefixShouldBeEnglishLetterAndNumber": "Префикс должен состоять из английских букв и цифр",
         "invalidApiKeyProvided": "Указан неверный API-ключ",
         "requestError": "Ошибка запроса: {{error}}",
+        "serverNonJsonError": "Сервер вернул не-JSON ответ (HTTP {{status}}): {{snippet}}",
+        "serverRouteNotFound": "Маршрут API не найден (HTTP {{status}}). Убедитесь, что сервер развёрнут и перезапущен.",
         "voiceIdSaveFailed": "Не удалось автоматически сохранить voice_id: {{error}}",
         "voiceIdSaved": "voice_id автоматически сохранён для персонажа",
         "pageWillRefresh": "Текущая страница обновится для применения нового голоса",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1274,6 +1274,8 @@
         "prefixShouldBeEnglishLetterAndNumber": "前缀应为英文字母和数字",
         "invalidApiKeyProvided": "提供的API密钥无效",
         "requestError": "请求出错：{{error}}",
+        "serverNonJsonError": "服务端返回了非JSON响应 (HTTP {{status}})：{{snippet}}",
+        "serverRouteNotFound": "接口未找到 (HTTP {{status}})，请确认服务端已正确部署并重启",
         "voiceIdSaveFailed": "voice_id自动保存失败: {{error}}",
         "voiceIdSaved": "voice_id已自动保存到角色",
         "pageWillRefresh": "当前页面即将自动刷新以应用新语音",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1274,6 +1274,8 @@
         "prefixShouldBeEnglishLetterAndNumber": "前綴應為英文字母和數字",
         "invalidApiKeyProvided": "提供的API密鑰無效",
         "requestError": "請求齣錯：{{error}}",
+        "serverNonJsonError": "服務端返迴瞭非JSON響應 (HTTP {{status}})：{{snippet}}",
+        "serverRouteNotFound": "接口未找到 (HTTP {{status}})，請確認服務端已正確部署並重啓",
         "voiceIdSaveFailed": "voice_id自動保存失敗: {{error}}",
         "voiceIdSaved": "voice_id已自動保存到角色",
         "pageWillRefresh": "當前頁麵即將自動刷新以應用新語音",


### PR DESCRIPTION
## 问题
音色克隆页点「注册音色」后，用户会看到
`请求出错: Unexpected token '<', '<html>...' is not valid JSON`
——这是前端在 `res.ok` 未校验、`Content-Type` 未判断的情况下直接调用
`res.json()` 造成的二次崩溃。只要后端或反向代理返回 HTML（404 路由错配、
502/504 网关、Cloudflare 错误页等），真正的 HTTP 状态就会被这条 token
错误吞掉，用户无从判断原因。

截图里的 bug 定位在 `static/js/voice_clone.js:439`：
```js
const data = await res.json();   // ← 先解析（HTML 会在这里就炸）
if (!res.ok) { ... }             // ← 再判断（根本走不到）
```

## 修复
- 新增 `safeReadResponse` / `buildNonJsonError` 两个小工具：先看
  `Content-Type`，是 JSON 才 `res.json()`，否则按 text 读；把状态码 +
  正文片段（剥掉 HTML 标签）拼成可读错误；404 走单独文案提醒重启服务端。
- 将这套防御应用到 `voice_clone.js` 中全部 5 处同款 bug：
  `registerVoice` 主流程、`voice_id` 自动保存 PUT、`playPreview`、
  `loadVoices`、`deleteVoice`。
- 新增 `voice.serverNonJsonError` / `voice.serverRouteNotFound` 文案，
  覆盖 zh-CN / zh-TW / en / ja / ko / ru 6 种语言。

## 修复后的用户提示
- 502 网关：`请求出错：服务端返回了非JSON响应 (HTTP 502)：Bad Gateway ...`
- 404 路由：`请求出错：接口未找到 (HTTP 404)，请确认服务端已正确部署并重启`

## Test plan
- [ ] 正常路径：本地启动服务，完整跑一遍「注册音色」，确认成功返回
  `voice_id`、自动保存到角色、UI 提示与修复前一致
- [ ] 404 路径：临时把前端 `apiUrl` 改为不存在的路径，确认提示为
  "接口未找到 (HTTP 404)…"，不再是 "Unexpected token '<'"
- [ ] 502 路径：nginx 指向已关停的上游，确认提示包含 HTTP 502 与截断后的
  HTML 片段
- [ ] i18n：切换 zh-CN / zh-TW / en / ja / ko / ru 各触发一次错误，确认
  新增文案都已本地化
- [ ] 旁路：`loadVoices`、`deleteVoice`、`playPreview`、`voice_id` 自动保存
  在后端返回 HTML 时也都不再抛 token 错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了对服务器响应的解析与错误处理：在遇到非 JSON 或 HTML 响应时不会抛异常，前端会展示更明确且包含 HTTP 状态与简短片段的可读错误信息；相关保存、预览、加载与删除流程的错误提示已统一并强化。
* **本地化**
  * 为新的服务器错误提示添加多语言支持（英文、日文、韩文、俄文、简体中文、繁体中文）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->