### PR TITLE
fix: VRM 待机切换脖子甩动 —— 跨 clip 同半球对齐 + LookAt proxy 永久 no-op

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1012,13 +1012,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     // VRM 侧走 crossfade + 跨 clip 同半球对齐，骨骼每帧位移极小，SpringBone 无冲击，不走这条路径。
     const _idleMmdPhysicsRestoreTimer = { mmd: null };
     const _idleMmdPhysicsSavedState = { mmd: null };
-    // 上一轮 VRM crossfade 的 previousAction：fadeOut(IDLE_VRM_FADE_SEC) 完成后仍以权重 0
-    // 占用 PropertyBinding，长期累积会吃内存。单槽存储即可：下一轮切换时 stop() 它
-    // （idle 轮换间隔 ≫ 0.15s，届时 fadeOut 早已完成）。
-    // 用定时器 Set 反而复杂且容易漏 stop，顺延到下一轮是无副作用的最小方案。
-    const _idlePendingStopAction = { vrm: null };
     // VRM 待机动作 crossfade 时长（秒）。mixer 对每根骨做加权 slerp，把单帧姿态跳变稀释成
     // 逐帧小幅位移，避开 LookAt 奇点 / 四元数跨半球长路径 / 物理飞甩。
+    // previousAction 的延迟 stop 已下沉到 vrm-animation.js `_playAction` 的每次 fadeOut，
+    // 跟 idle/手动切换路径解耦，不在此处维护 pending 槽。
     const IDLE_VRM_FADE_SEC = 0.15;
 
     // 更新模型类型按钮文字的函数（使用统一管理器）
@@ -4691,16 +4688,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 _idleMmdPhysicsRestoreTimer.mmd = null;
             }
             _alignAndRestoreMmdIdlePhysics();
-        } else if (type === 'vrm' && _idlePendingStopAction.vrm) {
-            // 上一轮 crossfade 的 previousAction：此时 fadeOut 早已完成（idle 间隔 ≫ 0.15s）。
-            // stop() 释放 binding，避免权重 0 常驻 mixer。
-            const cur = vrmManager?.animation?.currentAction || null;
-            try {
-                if (_idlePendingStopAction.vrm !== cur) {
-                    _idlePendingStopAction.vrm.stop();
-                }
-            } catch (e) { /* noop */ }
-            _idlePendingStopAction.vrm = null;
         }
         _idleRotationLast[type] = null;
     }
@@ -4815,20 +4802,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
             if (type === 'vrm') {
                 if (vrmManager && vrmManager.animation && vrmManager.currentModel) {
-                    // 上一轮挂起的 previousAction：此时其 fadeOut 早已完成，stop() 释放 binding。
-                    // 必须在本轮 crossfade 启动之前做：否则本轮 previousAction 会覆盖上一轮的槽。
-                    if (_idlePendingStopAction.vrm) {
-                        const curBefore = vrmManager.animation.currentAction || null;
-                        try {
-                            if (_idlePendingStopAction.vrm !== curBefore) {
-                                _idlePendingStopAction.vrm.stop();
-                            }
-                        } catch (e) { /* noop */ }
-                        _idlePendingStopAction.vrm = null;
-                    }
-                    const previousAction = vrmManager.animation.currentAction || null;
                     // 不再先 stopVRMAAnimation（它会 0.5s fadeOut，过长且是为手动动画设计的），
-                    // 改由 _playAction 的 crossfade 分支直接 fadeOut(old) + fadeIn(new)
+                    // 改由 _playAction 的 crossfade 分支直接 fadeOut(old) + fadeIn(new)。
+                    // previousAction 的延迟 stop 在 vrm-animation.js `_playAction` 内部按本次
+                    // fadeDuration schedule，不再依赖 idle 轮换路径来 drain。
                     await vrmManager.playVRMAAnimation(url, {
                         loop: true,
                         immediate: false,
@@ -4850,12 +4827,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                         };
                         mixer.addEventListener('loop', handler);
                         _idleLoopCleanup['vrm'] = () => mixer.removeEventListener('loop', handler);
-                    }
-
-                    // 把本轮 previousAction 挂起到下一轮 crossfade 启动时 stop()。
-                    // 届时其 fadeOut(IDLE_VRM_FADE_SEC) 早已完成，stop 不会打断任何淡出。
-                    if (previousAction && previousAction !== vrmManager.animation.currentAction) {
-                        _idlePendingStopAction.vrm = previousAction;
                     }
 
                     // 动画加载成功后再启动回退定时器（从实际播放开始计时）

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1007,17 +1007,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     const _idleRotationTimers = { vrm: null, mmd: null };
     const _idleRotationLast = { vrm: null, mmd: null };
     const _idleLoopCleanup = { vrm: null, mmd: null };
-    // 待机动作切换期间临时禁用物理，防止头发/裙摆因瞬时姿态跳变而飞甩
-    const _idlePhysicsRestoreTimers = { vrm: null, mmd: null };
-    const _idlePhysicsSavedState = { vrm: null, mmd: null };
-    // VRM crossfade 结束后收尾旧 action 的定时器集合（防止 fadeOut 后 action 残留占用 binding）。
-    // 用 Set 而不是单一 slot：快速连续切换时每个 previousAction 有独立的定时器，不能被后续切换取消，
-    // 否则中间那些 action 会以权重 0 永远留在 mixer 里。
-    // 每个条目是 { tid, action }：stopIdleRotation 中断时光 clearTimeout 还不够——
-    // 对应的 action 也要主动 stop()，否则同样会以权重 0 常驻 mixer。
-    const _idleCrossfadeCleanupTimers = { vrm: new Set() };
-    // VRM 待机动作 crossfade 时长（秒）。代替 immediate: true，让 mixer 对每根骨做加权 slerp，
-    // 稀释单帧姿态跳变，避开 LookAtQuaternionProxy Euler 拆分在奇点附近的脖子甩动。
+    // MMD 待机动作切换期间临时禁用物理，防止头发/裙摆因瞬时姿态跳变而飞甩。
+    // MMD 无 crossfade（loadAnimation 一步落位），骨架会单帧跳变 → MMDPhysics 积分为冲击。
+    // VRM 侧走 crossfade + 跨 clip 同半球对齐，骨骼每帧位移极小，SpringBone 无冲击，不走这条路径。
+    const _idleMmdPhysicsRestoreTimer = { mmd: null };
+    const _idleMmdPhysicsSavedState = { mmd: null };
+    // 上一轮 VRM crossfade 的 previousAction：fadeOut(IDLE_VRM_FADE_SEC) 完成后仍以权重 0
+    // 占用 PropertyBinding，长期累积会吃内存。单槽存储即可：下一轮切换时 stop() 它
+    // （idle 轮换间隔 ≫ 0.15s，届时 fadeOut 早已完成）。
+    // 用定时器 Set 反而复杂且容易漏 stop，顺延到下一轮是无副作用的最小方案。
+    const _idlePendingStopAction = { vrm: null };
+    // VRM 待机动作 crossfade 时长（秒）。mixer 对每根骨做加权 slerp，把单帧姿态跳变稀释成
+    // 逐帧小幅位移，避开 LookAt 奇点 / 四元数跨半球长路径 / 物理飞甩。
     const IDLE_VRM_FADE_SEC = 0.15;
 
     // 更新模型类型按钮文字的函数（使用统一管理器）
@@ -4626,94 +4627,53 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     /**
-     * 冻结物理模拟以渡过待机动作切换。
-     * 若用户本来就关闭了物理，或物理系统尚未就绪，则不改变现状（saved=null 表示无需恢复）。
+     * 冻结 MMD 物理以渡过待机动作切换。MMD 无 crossfade，loadAnimation 一步就把骨架姿态
+     * 推到新动画的 t=0，MMDPhysics 会把单帧大位移积分成高速冲击 → 头发/裙摆飞甩。
+     * 若用户本来就关闭了物理则保持现状（saved=null 表示无需恢复，避免覆盖用户设置）。
      */
-    function _freezeIdlePhysics(type) {
-        // 若上次切换的恢复定时器还未执行，先取消它——让冻结一直持续到本次切换完成
-        if (_idlePhysicsRestoreTimers[type]) {
-            clearTimeout(_idlePhysicsRestoreTimers[type]);
-            _idlePhysicsRestoreTimers[type] = null;
+    function _freezeMmdIdlePhysics() {
+        if (_idleMmdPhysicsRestoreTimer.mmd) {
+            clearTimeout(_idleMmdPhysicsRestoreTimer.mmd);
+            _idleMmdPhysicsRestoreTimer.mmd = null;
         }
-        if (type === 'vrm') {
-            if (!vrmManager || !vrmManager.currentModel) return;
-            // 只在用户本来启用物理时才记录"需要恢复"；否则保持用户设置
-            if (_idlePhysicsSavedState.vrm === null && vrmManager.enablePhysics) {
-                _idlePhysicsSavedState.vrm = true;
-            }
-            vrmManager.enablePhysics = false;
-            // 冻结 LookAt proxy 的 Euler 拆分：crossfade 期间 proxy 的 quaternion 处于
-            // 两个 clip 的混合过渡中，setFromQuaternion → Euler 可能命中 pitch ≈ ±90°
-            // 万向锁，导致 yaw 爆炸 → 脖子折 90° 甩几圈。把 _applyToLookAt 替换为 no-op
-            // 即可阻断拆分；crossfade 窗口结束后 delete 实例属性，原型方法自动恢复。
-            try {
-                const proxy = vrmManager.currentModel.vrm?.scene?.getObjectByName('lookAtQuaternionProxy');
-                if (proxy && typeof proxy._applyToLookAt === 'function' && !proxy.hasOwnProperty('_applyToLookAt')) {
-                    proxy._applyToLookAt = function() {};
-                }
-            } catch (_) { /* noop */ }
-        } else {
-            const mmd = window.mmdManager;
-            if (!mmd || !mmd.currentModel) return;
-            if (_idlePhysicsSavedState.mmd === null && mmd.enablePhysics) {
-                _idlePhysicsSavedState.mmd = true;
-            }
-            mmd.enablePhysics = false;
+        const mmd = window.mmdManager;
+        if (!mmd || !mmd.currentModel) return;
+        if (_idleMmdPhysicsSavedState.mmd === null && mmd.enablePhysics) {
+            _idleMmdPhysicsSavedState.mmd = true;
         }
+        mmd.enablePhysics = false;
     }
 
     /**
-     * 把物理初始状态对齐到当前骨架姿态，然后按 savedState 恢复 enablePhysics。
-     * VRM: springBoneManager.setInitState()；MMD: physics.reset()。
-     * 不对齐就恢复的话，物理引擎会用旧模拟状态去撞上新骨架姿态，正是这个 patch 想避免的。
+     * 把 MMDPhysics 初始态对齐到当前骨架姿态，再按 savedState 恢复 enablePhysics。
+     * 不 reset 直接开物理，旧模拟状态会撞上新骨架姿态（正是这个机制想避免的）。
      */
-    function _alignAndRestoreIdlePhysics(type) {
+    function _alignAndRestoreMmdIdlePhysics() {
         try {
-            if (type === 'vrm') {
-                const vrm = vrmManager?.currentModel?.vrm;
-                if (vrm?.springBoneManager && typeof vrm.springBoneManager.setInitState === 'function') {
-                    try { vrm.springBoneManager.setInitState(); } catch (e) { /* noop */ }
-                }
-                if (_idlePhysicsSavedState.vrm === true && vrmManager) {
-                    vrmManager.enablePhysics = true;
-                }
-                _idlePhysicsSavedState.vrm = null;
-                // 恢复 LookAt proxy：delete 实例 shadow，原型上的 _applyToLookAt 自动生效
-                try {
-                    const proxy = vrm?.scene?.getObjectByName('lookAtQuaternionProxy');
-                    if (proxy?.hasOwnProperty('_applyToLookAt')) {
-                        delete proxy._applyToLookAt;
-                    }
-                } catch (_) { /* noop */ }
-            } else {
-                const mmd = window.mmdManager;
-                const model = mmd?.currentModel;
-                if (model?.physics && typeof model.physics.reset === 'function') {
-                    if (model.mesh) model.mesh.updateMatrixWorld(true);
-                    try { model.physics.reset(); } catch (e) { /* noop */ }
-                }
-                if (_idlePhysicsSavedState.mmd === true && mmd) {
-                    mmd.enablePhysics = true;
-                }
-                _idlePhysicsSavedState.mmd = null;
+            const mmd = window.mmdManager;
+            const model = mmd?.currentModel;
+            if (model?.physics && typeof model.physics.reset === 'function') {
+                if (model.mesh) model.mesh.updateMatrixWorld(true);
+                try { model.physics.reset(); } catch (e) { /* noop */ }
             }
+            if (_idleMmdPhysicsSavedState.mmd === true && mmd) {
+                mmd.enablePhysics = true;
+            }
+            _idleMmdPhysicsSavedState.mmd = null;
         } catch (err) {
-            console.warn(`[${type.toUpperCase()} IdleAnimation] 恢复物理失败:`, err);
+            console.warn('[MMD IdleAnimation] 恢复物理失败:', err);
         }
     }
 
-    /**
-     * 新动画已落位后调用：延迟 500ms 让 mixer 把新动画充分应用到骨架上，
-     * 再对齐物理初始态并恢复。余量留足以兼容低帧率和 GC 卡顿。
-     */
-    function _scheduleRestoreIdlePhysics(type) {
-        if (_idlePhysicsRestoreTimers[type]) {
-            clearTimeout(_idlePhysicsRestoreTimers[type]);
+    /** 延迟 250ms 让 mixer 把新动画首帧应用到骨架，再对齐 MMDPhysics 并解冻。 */
+    function _scheduleRestoreMmdIdlePhysics() {
+        if (_idleMmdPhysicsRestoreTimer.mmd) {
+            clearTimeout(_idleMmdPhysicsRestoreTimer.mmd);
         }
-        _idlePhysicsRestoreTimers[type] = setTimeout(() => {
-            _idlePhysicsRestoreTimers[type] = null;
-            _alignAndRestoreIdlePhysics(type);
-        }, 500);
+        _idleMmdPhysicsRestoreTimer.mmd = setTimeout(() => {
+            _idleMmdPhysicsRestoreTimer.mmd = null;
+            _alignAndRestoreMmdIdlePhysics();
+        }, 250);
     }
 
     /** 停止待机动作轮换 */
@@ -4723,27 +4683,24 @@ document.addEventListener('DOMContentLoaded', async () => {
             _idleRotationTimers[type] = null;
         }
         _cleanupIdleLoopListener(type);
-        // 若物理仍处于冻结状态，立即走对齐+恢复，避免跳过 setInitState/physics.reset
-        // 直接开物理导致残留的旧模拟状态撞上新骨架姿态
-        if (_idlePhysicsRestoreTimers[type]) {
-            clearTimeout(_idlePhysicsRestoreTimers[type]);
-            _idlePhysicsRestoreTimers[type] = null;
-        }
-        _alignAndRestoreIdlePhysics(type);
-        // 取消所有挂起的 crossfade 收尾定时器，并把对应的旧 action 主动 stop()。
-        // 只 clearTimeout 会漏掉 action：它们已 fadeOut 到 0，但没 stop() 就会以权重 0
-        // 常驻 mixer，绑定也不会释放，和本 patch 想避免的残留是同一个坑。
-        if (type === 'vrm' && _idleCrossfadeCleanupTimers.vrm.size > 0) {
-            const currentAction = vrmManager?.animation?.currentAction || null;
-            for (const entry of _idleCrossfadeCleanupTimers.vrm) {
-                clearTimeout(entry.tid);
-                try {
-                    if (entry.action && entry.action !== currentAction) {
-                        entry.action.stop();
-                    }
-                } catch (e) { /* noop */ }
+        if (type === 'mmd') {
+            // 若 MMD 物理仍处于冻结状态，立即对齐+恢复，避免跳过 physics.reset 直接开物理
+            // 让旧模拟状态撞上新骨架姿态
+            if (_idleMmdPhysicsRestoreTimer.mmd) {
+                clearTimeout(_idleMmdPhysicsRestoreTimer.mmd);
+                _idleMmdPhysicsRestoreTimer.mmd = null;
             }
-            _idleCrossfadeCleanupTimers.vrm.clear();
+            _alignAndRestoreMmdIdlePhysics();
+        } else if (type === 'vrm' && _idlePendingStopAction.vrm) {
+            // 上一轮 crossfade 的 previousAction：此时 fadeOut 早已完成（idle 间隔 ≫ 0.15s）。
+            // stop() 释放 binding，避免权重 0 常驻 mixer。
+            const cur = vrmManager?.animation?.currentAction || null;
+            try {
+                if (_idlePendingStopAction.vrm !== cur) {
+                    _idlePendingStopAction.vrm.stop();
+                }
+            } catch (e) { /* noop */ }
+            _idlePendingStopAction.vrm = null;
         }
         _idleRotationLast[type] = null;
     }
@@ -4845,15 +4802,30 @@ document.addEventListener('DOMContentLoaded', async () => {
         // 播放新动画前先清理旧的 loop 监听器
         _cleanupIdleLoopListener(type);
 
-        // 切换窗口期间冻结物理，避免瞬时姿态跳变导致头发/裙摆飞甩
-        _freezeIdlePhysics(type);
+        // VRM 侧：crossfade + 跨 clip 同半球对齐（_alignClipToCurrentPose）已经把骨骼
+        // 逐帧位移稀释到无害范围，SpringBone/LookAt 都不会被单帧跳变激发，无需冻结物理。
+        // MMD 侧：loadAnimation 一步落位，仍需 freeze → reset → unfreeze 以防飞甩。
+        let mmdFrozen = false;
+        if (type === 'mmd') {
+            _freezeMmdIdlePhysics();
+            mmdFrozen = true;
+        }
 
         let played = false;
         try {
             if (type === 'vrm') {
                 if (vrmManager && vrmManager.animation && vrmManager.currentModel) {
-                    // 记录切换前的 action：crossfade 结束后需要把它 stop() 掉，否则 fadeOut
-                    // 完成后它会以权重 0 继续持有 binding，长期下来会堆积无效 action
+                    // 上一轮挂起的 previousAction：此时其 fadeOut 早已完成，stop() 释放 binding。
+                    // 必须在本轮 crossfade 启动之前做：否则本轮 previousAction 会覆盖上一轮的槽。
+                    if (_idlePendingStopAction.vrm) {
+                        const curBefore = vrmManager.animation.currentAction || null;
+                        try {
+                            if (_idlePendingStopAction.vrm !== curBefore) {
+                                _idlePendingStopAction.vrm.stop();
+                            }
+                        } catch (e) { /* noop */ }
+                        _idlePendingStopAction.vrm = null;
+                    }
                     const previousAction = vrmManager.animation.currentAction || null;
                     // 不再先 stopVRMAAnimation（它会 0.5s fadeOut，过长且是为手动动画设计的），
                     // 改由 _playAction 的 crossfade 分支直接 fadeOut(old) + fadeIn(new)
@@ -4880,21 +4852,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                         _idleLoopCleanup['vrm'] = () => mixer.removeEventListener('loop', handler);
                     }
 
-                    // crossfade 完成后把旧 action 彻底 stop()，避免 fadeOut 残留累积。
-                    // 每个 previousAction 都注册自己的定时器，绝不互相取消——否则快速连续切换时
-                    // 中间那些 action 会丢失 stop() 机会，以权重 0 永驻 mixer。
+                    // 把本轮 previousAction 挂起到下一轮 crossfade 启动时 stop()。
+                    // 届时其 fadeOut(IDLE_VRM_FADE_SEC) 早已完成，stop 不会打断任何淡出。
                     if (previousAction && previousAction !== vrmManager.animation.currentAction) {
-                        const entry = { tid: null, action: previousAction };
-                        entry.tid = setTimeout(() => {
-                            _idleCrossfadeCleanupTimers.vrm.delete(entry);
-                            try {
-                                // 再确认它确实不是"当前" action，防止竞态把新 action 误停
-                                if (entry.action !== vrmManager.animation?.currentAction) {
-                                    entry.action.stop();
-                                }
-                            } catch (e) { /* noop */ }
-                        }, Math.ceil(IDLE_VRM_FADE_SEC * 1000) + 50);
-                        _idleCrossfadeCleanupTimers.vrm.add(entry);
+                        _idlePendingStopAction.vrm = previousAction;
                     }
 
                     // 动画加载成功后再启动回退定时器（从实际播放开始计时）
@@ -4920,18 +4881,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         } catch (err) {
             console.warn(`[${type.toUpperCase()} IdleAnimation] 切换待机动作失败:`, err);
         } finally {
-            if (played) {
-                // 新动画已启动：等 mixer 把首帧应用到骨架上，再对齐物理初始态并解冻
-                _scheduleRestoreIdlePhysics(type);
-            } else {
-                // 切换未发生（模型未就绪等）：立即走对齐+解冻。
-                // 姿态没变，setInitState/physics.reset 基本是 no-op，但保持路径一致，
-                // 避免未来加逻辑时漏掉这条分支。
-                if (_idlePhysicsRestoreTimers[type]) {
-                    clearTimeout(_idlePhysicsRestoreTimers[type]);
-                    _idlePhysicsRestoreTimers[type] = null;
+            if (mmdFrozen) {
+                if (played) {
+                    _scheduleRestoreMmdIdlePhysics();
+                } else {
+                    // 切换未发生（模型未就绪等）：立即对齐+解冻，姿态没变则 physics.reset 基本 no-op
+                    if (_idleMmdPhysicsRestoreTimer.mmd) {
+                        clearTimeout(_idleMmdPhysicsRestoreTimer.mmd);
+                        _idleMmdPhysicsRestoreTimer.mmd = null;
+                    }
+                    _alignAndRestoreMmdIdlePhysics();
                 }
-                _alignAndRestoreIdlePhysics(type);
             }
         }
     }

--- a/static/vrm-animation.js
+++ b/static/vrm-animation.js
@@ -235,13 +235,38 @@ class VRMAnimation {
             proxy.name = 'lookAtQuaternionProxy';
             vrm.scene.add(proxy);
         }
-        // 永久屏蔽 proxy 的 Euler 拆分。
-        // 原实现每次 proxy.quaternion 变化都会 setFromQuaternion→Euler(YXZ) 再写 yaw/pitch，
-        // pitch ≈ ±90° 附近命中万向锁 → yaw 爆炸 → 眼球奇点甩动。
-        // 而 cursor-follow 已经通过 vrmLookAt.target 直接驱动眼球（见 vrm-manager.js），
-        // proxy 这条路径既冗余又有害，直接 shadow 成 no-op 一劳永逸。
+        // 用基于前向向量的稳定提取替换 proxy 的 Euler 拆分（shadow 原型方法）。
+        //
+        // 原实现：setFromQuaternion(q, 'YXZ') → Euler → yaw = y, pitch = x。
+        //   pitch ≈ ±π/2 附近 YXZ 拆分退化（Euler 矩阵奇异），yaw 由退化矩阵任意
+        //   输出 → 眼球奇点甩动。
+        //
+        // 新实现：把 proxy.quaternion 作用于本地 -Z（VRM 头部前方），从结果向量
+        //   提取 pitch=asin(fy), yaw=atan2(-fx, -fz)。
+        //   对无 roll 的 LookAt quaternion（authored gaze 的标准形态）与 Euler YXZ
+        //   数学上完全等价——Y 旋转给 yaw，X 旋转给 pitch，Z 旋转(roll)在 YXZ
+        //   里被塞进 euler.z 被 proxy 忽略，forward-vector 提取同样忽略 roll
+        //   （绕前向轴的旋转不改变前向）。
+        //   关键区别：pitch=±π/2 时 asin 域边界稳定返回 π/2，atan2(0,0)=0 给
+        //   出明确的 yaw=0 回退，而不是退化 YXZ 的任意值。
+        //
+        // 不再用 no-op：no-op 会静默丢弃 VRMA 文件里 authored 的 LookAt quaternion
+        // 轨道（createVRMAnimationClip 把它们映射到 proxy.quaternion），影响
+        // 手动播放的带 gaze 动画的正常表现（Project-N-E-K-O/N.E.K.O#772 Codex P1）。
         if (!Object.prototype.hasOwnProperty.call(proxy, '_applyToLookAt')) {
-            proxy._applyToLookAt = function () {};
+            const RAD2DEG = 180 / Math.PI;
+            proxy._applyToLookAt = function () {
+                const q = this.quaternion;
+                const x = q.x, y = q.y, z = q.z, w = q.w;
+                // forward = q * (0,0,-1) * q⁻¹，展开后的分量
+                const fx = -2 * (x * z + w * y);
+                const fy =  2 * (w * x - y * z);
+                const fz =  2 * (x * x + y * y) - 1;
+                // asin 定义域 [-1, 1]，浮点积累可能越界，clamp 防 NaN
+                const cy = fy > 1 ? 1 : (fy < -1 ? -1 : fy);
+                this.vrmLookAt.pitch = Math.asin(cy) * RAD2DEG;
+                this.vrmLookAt.yaw = Math.atan2(-fx, -fz) * RAD2DEG;
+            };
         }
     }
 
@@ -460,7 +485,26 @@ class VRMAnimation {
             if (this.currentAction && this.currentAction !== newAction) {
                 this.vrmaMixer.update(0);
                 if (vrm.scene) vrm.scene.updateMatrixWorld(true);
-                this.currentAction.fadeOut(fadeDuration);
+                // fadeOut 只把 weight 归零，action 本身仍在 mixer 的 _actions 列表里
+                // 以 weight=0 的状态持续 update。如果不 stop，后续每次 _playAction 都
+                // 会让残留 action 越堆越多（idle ↔ manual VRMA 反复切换尤其明显）。
+                // 这里按本次 fadeDuration schedule 一个与 action 绑定的 stop，
+                // 跟调用方（idle/manual）解耦——任何 VRMA 播放路径都能正确收尾
+                // （Project-N-E-K-O/N.E.K.O#772 Codex P2）。
+                const outgoing = this.currentAction;
+                outgoing.fadeOut(fadeDuration);
+                const stopDelayMs = Math.ceil(fadeDuration * 1000) + 50;
+                setTimeout(() => {
+                    try {
+                        // 只有当 outgoing 已经不是当前 action 时才 stop，避免把同一
+                        // action 反复切入/切出时误杀正在 fadeIn 的自己。
+                        if (this.currentAction !== outgoing) {
+                            outgoing.stop();
+                        }
+                    } catch (e) {
+                        // action 可能已被 mixer 清理；stop 幂等，忽略异常
+                    }
+                }, stopDelayMs);
                 newAction.enabled = true;
                 if (options.noReset) {
                     newAction.fadeIn(fadeDuration).play();

--- a/static/vrm-animation.js
+++ b/static/vrm-animation.js
@@ -31,6 +31,10 @@ class VRMAnimation {
         this._loaderPromise = null;
         this._fadeTimer = null;
         this._springBoneRestoreTimer = null;
+        // crossfade 时给每个 outgoing action schedule 的 stop 定时器。Set 允许
+        // 多个 in-flight fadeOut 同时等待 stop，reset() 时统一清干净，防止
+        // 重建 VRMAnimation 实例后残留回调打到旧 action。
+        this._outgoingStopTimers = new Set();
         this.playbackSpeed = 1.0;
         this.skeletonHelper = null;
         this.debug = false;
@@ -504,7 +508,12 @@ class VRMAnimation {
                 const outgoing = this.currentAction;
                 outgoing.fadeOut(fadeDuration);
                 const stopDelayMs = Math.ceil(fadeDuration * 1000) + 50;
-                setTimeout(() => {
+                // 定时器登记到 _outgoingStopTimers，reset() 统一清——防止
+                // 实例 dispose 后回调仍打到已释放的 action（CodeRabbit on PR #772）。
+                let timerId;
+                timerId = setTimeout(() => {
+                    this._outgoingStopTimers.delete(timerId);
+                    if (this._disposed) return;
                     try {
                         // 只有当 outgoing 已经不是当前 action 时才 stop，避免把同一
                         // action 反复切入/切出时误杀正在 fadeIn 的自己。
@@ -515,6 +524,7 @@ class VRMAnimation {
                         // action 可能已被 mixer 清理；stop 幂等，忽略异常
                     }
                 }, stopDelayMs);
+                this._outgoingStopTimers.add(timerId);
                 newAction.enabled = true;
                 if (options.noReset) {
                     newAction.fadeIn(fadeDuration).play();
@@ -818,6 +828,10 @@ class VRMAnimation {
         if (this._springBoneRestoreTimer) {
             clearTimeout(this._springBoneRestoreTimer);
             this._springBoneRestoreTimer = null;
+        }
+        if (this._outgoingStopTimers && this._outgoingStopTimers.size > 0) {
+            for (const id of this._outgoingStopTimers) clearTimeout(id);
+            this._outgoingStopTimers.clear();
         }
 
         this._skinnedMeshes = [];

--- a/static/vrm-animation.js
+++ b/static/vrm-animation.js
@@ -227,13 +227,21 @@ class VRMAnimation {
 
     async _createLookAtProxy(vrm) {
         if (!vrm.lookAt) return;
-        const existingProxy = vrm.scene.getObjectByName('lookAtQuaternionProxy');
-        if (!existingProxy) {
+        let proxy = vrm.scene.getObjectByName('lookAtQuaternionProxy');
+        if (!proxy) {
             const animationModule = await VRMAnimation._getAnimationModule();
             const { VRMLookAtQuaternionProxy } = animationModule;
-            const lookAtQuatProxy = new VRMLookAtQuaternionProxy(vrm.lookAt);
-            lookAtQuatProxy.name = 'lookAtQuaternionProxy';
-            vrm.scene.add(lookAtQuatProxy);
+            proxy = new VRMLookAtQuaternionProxy(vrm.lookAt);
+            proxy.name = 'lookAtQuaternionProxy';
+            vrm.scene.add(proxy);
+        }
+        // 永久屏蔽 proxy 的 Euler 拆分。
+        // 原实现每次 proxy.quaternion 变化都会 setFromQuaternion→Euler(YXZ) 再写 yaw/pitch，
+        // pitch ≈ ±90° 附近命中万向锁 → yaw 爆炸 → 眼球奇点甩动。
+        // 而 cursor-follow 已经通过 vrmLookAt.target 直接驱动眼球（见 vrm-manager.js），
+        // proxy 这条路径既冗余又有害，直接 shadow 成 no-op 一劳永逸。
+        if (!Object.prototype.hasOwnProperty.call(proxy, '_applyToLookAt')) {
+            proxy._applyToLookAt = function () {};
         }
     }
 
@@ -275,6 +283,41 @@ class VRMAnimation {
                     track.name = originalName;
                 }
             });
+        }
+    }
+
+    /**
+     * 把新 clip 每条 QuaternionKeyframeTrack 的关键帧整体翻到当前骨骼姿态的同半球。
+     * crossfade 期间 mixer 在"旧 clip 当前采样"和"新 clip 第 0 帧"之间做加权 slerp；
+     * 若两者 dot < 0，slerp 会取反向长路径——即使两个旋转在 3D 空间里完全相同，
+     * 视觉上就是骨骼绕反向轴甩一大圈再归位（偶发脖子折 90° 甩几圈的根因）。
+     * _normalizeQuaternionTrackSigns 只解决单 clip 内部相邻帧的符号一致性，解决不了跨 clip。
+     * 这里用 "新 clip 首帧 vs 骨骼当前 quaternion" 的 dot 决定是否整条轨道翻号；
+     * 翻号不改变旋转本身（q 与 -q 等价），只改变插值路径。
+     * 必须在 _normalizeQuaternionTrackSigns 之后调用——那一步保证 clip 内部自洽，
+     * 所以整条翻号不会破坏内部相邻帧的同半球关系。
+     */
+    _alignClipToCurrentPose(clip) {
+        const THREE = window.THREE;
+        if (!clip?.tracks || !THREE?.QuaternionKeyframeTrack) return;
+        // 优先用正在运行的 vrmaMixer 的 root，确保查到的 bone.quaternion 反映当前动画姿态
+        const root = this.vrmaMixer?.getRoot?.() || this.manager?.currentModel?.vrm?.scene;
+        if (!root || typeof root.getObjectByName !== 'function') return;
+        const stride = 4;
+        for (const track of clip.tracks) {
+            if (!(track instanceof THREE.QuaternionKeyframeTrack)) continue;
+            const boneName = track.name.split('.')[0];
+            const bone = root.getObjectByName(boneName);
+            const bq = bone?.quaternion;
+            if (!bq) continue;
+            const v = track.values;
+            if (!v || v.length < stride) continue;
+            const dot = bq.x * v[0] + bq.y * v[1] + bq.z * v[2] + bq.w * v[3];
+            if (dot < 0) {
+                for (let i = 0; i < v.length; i++) {
+                    v[i] = -v[i];
+                }
+            }
         }
     }
 
@@ -520,6 +563,10 @@ class VRMAnimation {
             const clip = await this._createAndValidateAnimationClip(vrmAnimation, vrm);
             this._processTracksForVersion(clip, vrmVersion);
             this._normalizeQuaternionTrackSigns(clip);
+            // 跨 clip 同半球对齐：必须在 _normalizeQuaternionTrackSigns 之后、
+            // _createAndConfigureAction 之前。此刻 vrmaMixer 上仍是上一条 action 在跑，
+            // 骨骼 quaternion 反映当前姿态；后续 _playAction 的 crossfade slerp 才能走最短路径。
+            this._alignClipToCurrentPose(clip);
 
             // 判断是否为待机动画（仅在显式传入 isIdle: true 时才视为待机）
             this.isIdleAnimation = !!options.isIdle;

--- a/static/vrm-animation.js
+++ b/static/vrm-animation.js
@@ -325,14 +325,24 @@ class VRMAnimation {
     _alignClipToCurrentPose(clip) {
         const THREE = window.THREE;
         if (!clip?.tracks || !THREE?.QuaternionKeyframeTrack) return;
-        // 优先用正在运行的 vrmaMixer 的 root，确保查到的 bone.quaternion 反映当前动画姿态
+        // 优先用正在运行的 vrmaMixer 的 root（_findBestMixerRoot 通常返回
+        // normalizedRoot——VRM 标准化骨架树），确保查到的 bone.quaternion
+        // 反映当前动画姿态。
+        // 但 `lookAtQuaternionProxy` 是挂在 vrm.scene 直下的 sibling，不在
+        // normalizedRoot 树里——此时回退到 vrm.scene.getObjectByName 才能
+        // 拿到 proxy.quaternion 做同半球对齐，否则 authored LookAt 轨道
+        // 在 crossfade 时仍可能走长路径（CodeRabbit on PR #772）。
         const root = this.vrmaMixer?.getRoot?.() || this.manager?.currentModel?.vrm?.scene;
         if (!root || typeof root.getObjectByName !== 'function') return;
+        const scene = this.manager?.currentModel?.vrm?.scene;
         const stride = 4;
         for (const track of clip.tracks) {
             if (!(track instanceof THREE.QuaternionKeyframeTrack)) continue;
             const boneName = track.name.split('.')[0];
-            const bone = root.getObjectByName(boneName);
+            let bone = root.getObjectByName(boneName);
+            if (!bone && scene && scene !== root) {
+                bone = scene.getObjectByName(boneName);
+            }
             const bq = bone?.quaternion;
             if (!bq) continue;
             const v = track.values;


### PR DESCRIPTION
## 背景

#767 (123e974) + 039c1c0 试图修复 VRM 待机动作切换偶发脖子折 90° 甩动的问题，但用的是"时间窗口内冻结物理 + 临时 no-op LookAt proxy"的 timing 赌博方案：

- 500ms 冻结窗口不够用（低帧率 / GC 卡顿可能让 mixer 在 500ms 内只推进几帧），继续加大同样的问题只会再现
- commit message 里的诊断偏了——`VRMLookAtQuaternionProxy._applyToLookAt` 只写 `vrmLookAt.yaw/pitch`（驱动眼球），根本不直接写 neck 骨骼，所以"proxy 污染脖子"的因果链不成立
- Set + `{ tid, action }` 条目 + 定时器回调 + 竞态判定那一套体操本身就是 timing 模型带来的并发包袱

## 本 PR 换成消除根因的两条，删掉时间窗口那一坨。

### A. `static/vrm-animation.js` — `_createLookAtProxy` 永久 shadow `_applyToLookAt` 为 no-op

原 proxy 在 `quaternion` 变化时做 `setFromQuaternion → Euler(YXZ)` 再写 `vrmLookAt.yaw/pitch`。pitch ≈ ±90° 附近命中万向锁 → yaw 爆炸 → 眼球奇点甩动。

而 cursor-follow 已经通过 `vrmLookAt.target = eyesTarget` 直接驱动眼球（见 `vrm-manager.js:692`），proxy 这条路径**既冗余又有害**。在创建 proxy 之后直接 `proxy._applyToLookAt = function () {}` shadow 掉原型方法，一劳永逸。

### B. `static/vrm-animation.js` — 新增 `_alignClipToCurrentPose(clip)`，crossfade 启动前做"跨 clip 同半球对齐"

已有的 `_normalizeQuaternionTrackSigns` 只保证 **单 clip 内** 相邻关键帧同半球（dot >= 0）。crossfade 时 mixer 在「旧 clip 当前采样」和「新 clip 第 0 帧」之间加权 slerp——若两者 `dot < 0` 会取反向长路径 → 骨骼绕反向轴甩一大圈再归位（脖子偶发折 90° 甩几圈的真正根因）。

新方法对每条 `QuaternionKeyframeTrack`：
1. 从正在运行的 `vrmaMixer.getRoot()` 查对应骨骼的当前 `quaternion`
2. 与 track 第 0 帧做 dot，若 < 0 就把整条 track 的 `values` 取反

整条翻号不改变旋转本身（q 与 -q 等价），只改变插值路径。必须在 `_normalizeQuaternionTrackSigns` 之后、`_createAndConfigureAction` 之前调用。

### 清理 `static/js/model_manager.js`

- 删除 `_idlePhysicsRestoreTimers.vrm` / `_idlePhysicsSavedState.vrm` / VRM 冻结物理 / proxy 临时 no-op 与恢复代码；VRM 侧不再依赖时间窗口
- `_idleCrossfadeCleanupTimers` Set + `{ tid, action }` 条目 + 定时器回调 → 换成单槽 `_idlePendingStopAction.vrm`：下一轮 crossfade 启动时 stop() 上一轮 previousAction（idle 轮换间隔 ≫ 0.15s，届时 fadeOut 早已完成），`stopIdleRotation` 同步清空。等价语义，零定时器
- `_freezeIdlePhysics` / `_alignAndRestoreIdlePhysics` / `_scheduleRestoreIdlePhysics` 的 VRM 分支整条删掉，helper 重命名为 `_freezeMmdIdlePhysics` / `_alignAndRestoreMmdIdlePhysics` / `_scheduleRestoreMmdIdlePhysics`——MMD 无 crossfade，`loadAnimation` 一步落位，保留 freeze → reset → unfreeze 路径防止飞甩

### 保留

- crossfade (`IDLE_VRM_FADE_SEC = 0.15s`)
- `_normalizeQuaternionTrackSigns`（单 clip 内部相邻帧同半球，对手动动画也适用）
- loop 事件过滤旧 action

## Diff

+149 / -142 across 2 files。净增 7 行，但复杂度实际下降：去掉了 Set + 定时器 + 闭包 tid + 竞态判定 + savedState 那一整套并发体操。

## Test plan

- [ ] 长时间（10+ 分钟）挂多个 VRM 待机动画，确认脖子不再偶发折 90° 甩动
- [ ] 低帧率场景（开 DevTools Performance → 6x CPU throttle）触发多次轮换，确认无飞甩、无奇点
- [ ] 物理效果（头发/裙摆）在切换瞬间不再被单帧位移激发
- [ ] cursor-follow 眼球跟随正常（proxy no-op 后不影响 target 路径）
- [ ] 快速连续切换（手动 `_triggerIdleSwitch('vrm')` 触发多次）不泄漏 mixer action
- [ ] MMD 侧轮换行为不回归（freeze/reset/unfreeze 路径保留）

https://claude.ai/code/session_012kBS5fAtHcu5XQTcFMH6dB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fix修复**
  * MMD 模型：引入独立空闲物理处理，切换时冻结并在播放成功后延迟恢复（约250ms），播放失败则立即恢复，空闲旋转停止更可靠。
  * VRM 模型：移除多余的物理冻结，改进视线（LookAt）计算与四元数关键帧对齐；动画混合更平滑，已淡出的动作会按时停止以避免残留影响。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->