### PR TITLE
禁止 ui-popup / react-chat / 各类按钮文本被选中

### DIFF
--- a/frontend/plugin-manager/src/assets/main.css
+++ b/frontend/plugin-manager/src/assets/main.css
@@ -9,6 +9,24 @@
   box-sizing: border-box;
 }
 
+/* 禁止按钮文本被选中，避免误选 */
+button,
+[role="button"],
+.el-button,
+.el-button * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+button * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 html, body {
   width: 100%;
   height: 100%;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -31,6 +31,21 @@ textarea {
   font: inherit;
 }
 
+button,
+[role="button"] {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+button * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 .app-shell {
   width: 100%;
   height: 100%;

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -42,6 +42,10 @@ function injectPopupStyles(prefix) {
             opacity: 0;
             transform: translateX(-10px);
             transition: opacity 0.2s cubic-bezier(0.1, 0.9, 0.2, 1), transform 0.2s cubic-bezier(0.1, 0.9, 0.2, 1);
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
         }
         .${prefix}-popup.is-positioning {
             pointer-events: none !important;
@@ -82,6 +86,10 @@ function injectPopupStyles(prefix) {
             transition: background 0.2s ease;
             font-size: 13px;
             white-space: nowrap;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
         }
         .${prefix}-popup-item:hover {
             background: rgba(68, 183, 254, 0.08);
@@ -99,6 +107,10 @@ function injectPopupStyles(prefix) {
             transition: background 0.2s ease, opacity 0.2s ease;
             font-size: 13px;
             white-space: nowrap;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
         }
         .${prefix}-toggle-item:focus-within {
             outline: 2px solid var(--neko-popup-accent, #44b7fe);
@@ -170,6 +182,10 @@ function injectPopupStyles(prefix) {
             pointer-events: auto !important;
             position: relative;
             z-index: 100002;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
         }
         .${prefix}-settings-menu-item:hover {
             background: var(--neko-popup-hover, rgba(68, 183, 254, 0.1));


### PR DESCRIPTION
## Summary

在拖动或连续点击按钮时，按钮文本常常被意外选中（变高亮），体验很烦人。本次把 `user-select: none` 补到了三处尚未覆盖的前端区域：

- **`frontend/react-neko-chat/src/styles.css`** — 全局 `button, [role="button"]` 以及 `button *` 设置 `user-select: none`，覆盖 `.icon-button` / `.tool-button` / `.topbar-action-btn` / `.message-action-button` / `.send-button-circle` 等所有 React 聊天窗按钮。
- **`frontend/plugin-manager/src/assets/main.css`** — 全局 `button, [role="button"], .el-button, .el-button *` 设置 `user-select: none`；`.el-button *` 是为了覆盖 Element Plus 内部用 span 包裹文字的情况。
- **`static/avatar-ui-popup.js`** — 在 `injectPopupStyles()` 注入的样式里，把 `user-select: none` 加到 `.${prefix}-popup`、`.${prefix}-popup-item`、`.${prefix}-toggle-item`、`.${prefix}-settings-menu-item` 上。之前只有 `.toggle-checkmark` / `.toggle-label` 有，现在菜单项和其他可点文本也不能被选中。

`static/css/index.css` 已经有全局 `button { user-select: none }`，不用改。

## Test plan

- [ ] 打开 React 聊天窗口，尝试拖选/多次点击 topbar / 消息操作 / 发送按钮，文本不应变高亮
- [ ] 打开 plugin-manager，尝试拖选 Element Plus `<el-button>`、标题栏关闭按钮，文本不应变高亮
- [ ] 打开虚拟形象（MMD/VRM/Live2D）侧边弹窗：依次测试 mic / screen / agent / settings 弹窗，鼠标在 popup-item、toggle-item、settings-menu-item 上拖动不应选中文本
- [ ] 确认按钮的 click / hover / focus 行为未被影响

https://claude.ai/code/session_015bE94s6vtg58PR2kBWgHmB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 禁用了交互式按钮元素的文本选择，提升了用户交互体验，确保在点击按钮时文本不会被意外选中。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->