### PR TITLE
fix(subtitle): 字幕改为 turn 级常驻 + 双协议 turn 边界对齐 + 修 google skip flag

### DIFF
--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -285,11 +285,6 @@
             window.ensureAssistantTurnStarted('create_gemini_bubble');
         }
 
-        // 字幕检测
-        if (typeof window.checkAndShowSubtitlePrompt === 'function') {
-            window.checkAndShowSubtitlePrompt(cleanSentence);
-        }
-
         return ref;
     }
 

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -336,9 +336,6 @@
             window.ensureAssistantTurnStarted('create_gemini_bubble');
         }
 
-        // 检测AI消息的语言，如果与用户语言不同，显示字幕提示框
-        checkAndShowSubtitlePrompt(cleanSentence);
-
         // 如果是AI第一次回复，更新状态并检查成就
         if (isFirstAIResponse) {
             isFirstAIResponse = false;
@@ -762,8 +759,6 @@
                 window.currentTurnGeminiBubbles = window.currentTurnGeminiBubbles || [];
                 window.currentTurnGeminiBubbles.push(msgDiv);
 
-                checkAndShowSubtitlePrompt(cleanFullText);
-
                 if (isFirstAIResponse) {
                     isFirstAIResponse = false;
                     console.log(window.t('console.aiFirstReplyDetected'));
@@ -795,6 +790,13 @@
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);
+
+            // 把整轮累积的原文流式写入字幕（常驻字幕，跨气泡持续显示）
+            // turn 结束时由 app-websocket.js 调用翻译替换；turn-start 事件清空
+            if (typeof window.updateSubtitleStreamingText === 'function') {
+                var streamingText = window._geminiTurnFullText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
+                window.updateSubtitleStreamingText(streamingText);
+            }
         }
 
         if (sender === 'gemini' && !isMergeMessagesEnabled()) {
@@ -889,9 +891,6 @@
                 window.currentGeminiMessage = null;
             }
 
-            // 3. 对干净的文本调用字幕检测
-            checkAndShowSubtitlePrompt(cleanNewText);
-
             if (isFirstAIResponse) {
                 isFirstAIResponse = false;
                 console.log(window.t('console.aiFirstReplyDetected'));
@@ -915,8 +914,6 @@
                     window.currentTurnGeminiBubbles = window.currentTurnGeminiBubbles || [];
                     window.currentTurnGeminiBubbles.push(msgDiv);
                     createdVisibleBubble = true;
-
-                    checkAndShowSubtitlePrompt(cleanText);
                 } else {
                     // 仅有指令无文本，继续保持指针为空，直到出现有意义的文本块
                     window.currentGeminiMessage = null;
@@ -926,9 +923,6 @@
             else if (window.currentGeminiMessage && window.currentGeminiMessage.isConnected) {
                 var fullText = window._geminiTurnFullText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
 
-
-                // var timePrefix = window.currentGeminiMessage.textContent.match(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /) || [""];
-                // window.currentGeminiMessage.textContent = timePrefix[0] + fullText;
                 var timePrefix = window.currentGeminiMessage.textContent.match(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /u);
                 if (!timePrefix) {
                     timePrefix = "[" + getCurrentTimeString() + "] \u{1F380} ";
@@ -937,41 +931,6 @@
                 }
                 window.currentGeminiMessage.textContent = timePrefix + fullText;
                 updateReactTextMessage(window.currentGeminiMessage, 'assistant', getCurrentAssistantName(), window.currentGeminiMessage.textContent, 'streaming');
-
-                
-                // 触发字幕检测逻辑（防抖）
-                if (S.subtitleCheckDebounceTimer) {
-                    clearTimeout(S.subtitleCheckDebounceTimer);
-                }
-
-                S.subtitleCheckDebounceTimer = setTimeout(function () {
-                    if (!window.currentGeminiMessage ||
-                        window.currentGeminiMessage.nodeType !== Node.ELEMENT_NODE ||
-                        !window.currentGeminiMessage.isConnected) {
-                        S.subtitleCheckDebounceTimer = null;
-                        return;
-                    }
-
-                    var currentFullText = window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /u, '');
-                    if (currentFullText && currentFullText.trim()) {
-                        if (typeof userLanguage !== 'undefined' && userLanguage === null) {
-                            getUserLanguage().then(function () {
-                                if (window.currentGeminiMessage && window.currentGeminiMessage.isConnected) {
-                                    var detectedLang = detectLanguage(currentFullText);
-                                    if (detectedLang !== 'unknown' && detectedLang !== userLanguage) {
-                                        showSubtitlePrompt();
-                                    }
-                                }
-                            }).catch(function (err) { console.warn('[i18n] Stream error:', err); });
-                        } else {
-                            var detectedLang = detectLanguage(currentFullText);
-                            if (detectedLang !== 'unknown' && typeof userLanguage !== 'undefined' && detectedLang !== userLanguage) {
-                                showSubtitlePrompt();
-                            }
-                        }
-                    }
-                    S.subtitleCheckDebounceTimer = null;
-                }, 300);
             }
         } else {
             // 创建新消息 (user / 其他 sender)
@@ -998,9 +957,6 @@
                 // ========== 追踪本轮气泡 ==========
                 window.currentTurnGeminiBubbles.push(newDiv);
                 createdVisibleBubble = true;
-
-                // 检测AI消息的语言，如果与用户语言不同，显示字幕提示框
-                checkAndShowSubtitlePrompt(cleanedText);
 
                 // 如果是AI第一次回复，更新状态并检查成就
                 if (isFirstAIResponse) {

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -126,7 +126,6 @@
         screenshotCounter: 0,
         statusToastTimeout: null,
         _statusToastPriority: 0,
-        subtitleCheckDebounceTimer: null,
         lastVoiceUserMessage: null,
         lastVoiceUserMessageTime: 0,
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1018,6 +1018,32 @@
                     }
                     clearPendingAssistantTurnStart();
 
+                    // 主动消息 / 热切换回调也产生了 AI 文本（来自 send_lanlan_response），
+                    // 同样需要为字幕翻译。情感分析 / proactive backoff 维持原行为不动。
+                    (function () {
+                        var bufferedFullText = typeof window._geminiTurnFullText === 'string'
+                            ? window._geminiTurnFullText
+                            : '';
+                        var fallbackFromBubble = (window.currentGeminiMessage &&
+                            window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
+                            window.currentGeminiMessage.isConnected &&
+                            typeof window.currentGeminiMessage.textContent === 'string')
+                            ? window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /, '')
+                            : '';
+                        var fullText = (bufferedFullText && bufferedFullText.trim()) ? bufferedFullText : fallbackFromBubble;
+                        fullText = fullText.replace(/\[play_music:[^\]]*(\]|$)/g, '').trim();
+                        if (!fullText) return;
+                        (async function () {
+                            try {
+                                if (typeof window.translateAndShowSubtitle === 'function') {
+                                    await window.translateAndShowSubtitle(fullText);
+                                }
+                            } catch (transError) {
+                                console.error('[Subtitle] agent_callback translate failed:', transError);
+                            }
+                        })();
+                    })();
+
                 // -------- system turn end --------
                 } else if (response.type === 'system' && response.data === 'turn end') {
                     console.log(window.t('console.turnEndReceived'));

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1119,17 +1119,12 @@
                             }
                         }, 100);
 
-                        // Frontend translation
+                        // Frontend subtitle finalization: subtitle.js 内部根据开关决定是否
+                        // 真正发请求；不需要的语言会保留流式累积的原文，不会清空字幕
                         (async function () {
                             try {
-                                if (typeof getUserLanguage === 'function') {
-                                    var _userLanguage = await getUserLanguage();
-                                    // Only translate subtitle when subtitle toggle is on
-                                    if (typeof subtitleEnabled !== 'undefined' && subtitleEnabled) {
-                                        if (typeof translateAndShowSubtitle === 'function') {
-                                            await translateAndShowSubtitle(fullText);
-                                        }
-                                    }
+                                if (typeof window.translateAndShowSubtitle === 'function') {
+                                    await window.translateAndShowSubtitle(fullText);
                                 }
                             } catch (transError) {
                                 console.error(window.t('console.translationProcessFailed'), {

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -300,12 +300,6 @@ html #chat-container {
   border-color: #777;
 }
 
-[data-theme="dark"] .subtitle-prompt-message {
-  background: linear-gradient(135deg, rgba(42, 123, 196, 0.12) 0%, rgba(42, 123, 196, 0.18) 100%);
-  border-color: rgba(74, 163, 223, 0.25);
-  box-shadow: 0 2px 8px rgba(42, 123, 196, 0.15);
-}
-
 /* ===== 暗色模式：字幕显示区域 ===== */
 [data-theme="dark"] #subtitle-display {
   background: linear-gradient(135deg, rgba(42, 123, 196, 0.92) 0%, rgba(42, 123, 196, 0.88) 50%, rgba(60, 145, 220, 0.92) 100%);

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1267,91 +1267,9 @@ body.react-chat-window-dragging {
     cursor: progress;
 }
 
-/* 字幕提示框样式（放在输入框区域中，与输入框对齐） */
-.subtitle-prompt-message {
-    width: 100%;
-    background: linear-gradient(135deg, rgba(68, 183, 254, 0.08) 0%, rgba(68, 183, 254, 0.12) 100%);
-    border: 1px solid rgba(68, 183, 254, 0.2);
-    border-radius: 8px;
-    padding: 0;
-    margin-top: 8px;
-    box-shadow: 0 2px 8px rgba(68, 183, 254, 0.1);
-    box-sizing: border-box;
-    pointer-events: auto;
-    touch-action: manipulation;
-}
-
-.subtitle-prompt-content {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    padding: 8px 16px;
-}
-
-.subtitle-toggle-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    flex-shrink: 0;
-    cursor: pointer;
-}
-
-.subtitle-toggle-indicator {
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    border: 2px solid #ccc;
-    background-color: transparent;
-    cursor: pointer;
-    flex-shrink: 0;
-    transition: all 0.2s ease;
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.subtitle-toggle-indicator::after {
-    content: '✓';
-    color: #fff;
-    font-size: 12px;
-    font-weight: bold;
-    line-height: 1;
-    opacity: 0;
-    transition: opacity 0.2s ease;
-    pointer-events: none;
-    user-select: none;
-}
-
-.subtitle-toggle-indicator.active {
-    border-color: #44b7fe;
-    background-color: #44b7fe;
-}
-
-.subtitle-toggle-indicator.active::after {
-    opacity: 1;
-}
-
-.subtitle-toggle-label {
-    font-size: 15px;
-    color: #333;
-    user-select: none;
-    cursor: pointer;
-    font-weight: 500;
-}
-
-/* 语音模式下的字幕提示框样式（放在 chat-container 底部） */
-.subtitle-prompt-message.voice-mode {
-    width: auto;
-    margin: 8px 12px;
-    pointer-events: auto;
-}
-
-/* 最小化时隐藏字幕提示框 */
-#chat-container.minimized .subtitle-prompt-message {
-    display: none !important;
-}
+/* 旧的 .subtitle-prompt-message 注入式提示已下线：
+ * 字幕翻译开关现在常驻在 React 聊天窗口的 composer 工具栏，
+ * 由 frontend/react-neko-chat 渲染。 */
 
 
 /* 字幕显示区域样式（参考Xiao8项目优化，性能优化版本） */

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -1,8 +1,18 @@
-// 字幕提示框功能
-// 从 app.js 中抽离的字幕子系统模块
+// 字幕（常驻字幕 + 按需翻译）
+//
+// 工作流程
+// ──────────
+//   1. 一个 AI 回合（turn）= 一段连续讲话，可能被切成多个聊天气泡。
+//   2. 字幕跨气泡持久显示，不会被新气泡清空。
+//   3. turn 进行中：流式原文实时写入字幕（updateSubtitleStreamingText）。
+//   4. turn 结束：调用 /api/translate；如果需要翻译则用译文替换原文，
+//      否则保留原文。
+//   5. 下一个 turn-start 才清空字幕，开始下一段。
+//
+// 翻译开关由 React 聊天窗口的 composer 按钮控制，状态走 window.subtitleBridge。
+// 旧的字幕提示气泡（subtitle-prompt-message）已下线，相关 prompt/detect 代码全部移除。
 
-// 归一化语言代码：将 BCP-47 格式（如 'zh-CN', 'en-US'）归一化为简单代码（'zh', 'en', 'ja', 'ko'）
-// 与 detectLanguage() 返回的格式保持一致，避免误判
+// 归一化语言代码：将 BCP-47 格式（如 'zh-CN', 'en-US'）归一化为简单代码（'zh', 'en', 'ja', 'ko', 'ru'）
 function normalizeLanguageCode(lang) {
     if (!lang) return 'zh'; // 默认中文
     const langLower = lang.toLowerCase();
@@ -31,644 +41,220 @@ let subtitleEnabled = (typeof window.appState !== 'undefined' && typeof window.a
 function setUserLanguage(lang) {
     userLanguage = lang;
     localStorage.setItem('userLanguage', userLanguage);
-    // 同步到 appState
     if (typeof window.appState !== 'undefined') {
         window.appState.userLanguage = userLanguage;
     }
-    // 触发统一保存（会同步到服务器）
     if (typeof window.appSettings !== 'undefined' && window.appSettings.saveSettings) {
         window.appSettings.saveSettings();
     }
 }
-// 用户语言（延迟初始化，避免使用 localStorage 旧值）
-// 初始化为 null，确保在使用前从 API 获取最新值
+// 用户语言（懒加载，避免使用 localStorage 旧值）
 let userLanguage = null;
-// Google 翻译失败标记（会话级，页面刷新后重置）
-let googleTranslateFailed = false;
 // 用户语言初始化 Promise（用于确保只初始化一次）
 let userLanguageInitPromise = null;
 
-// 获取用户语言（支持语言代码归一化，延迟初始化）
+// 获取用户语言（支持语言代码归一化，懒加载）
 async function getUserLanguage() {
-    // 如果已经初始化过，直接返回
     if (userLanguage !== null) {
         return userLanguage;
     }
-    
-    // 如果正在初始化，等待初始化完成
     if (userLanguageInitPromise) {
         return await userLanguageInitPromise;
     }
-    
-    // 开始初始化
     userLanguageInitPromise = (async () => {
         try {
-            // 优先从API获取最新值
             const response = await fetch('/api/config/user_language');
             const data = await response.json();
             if (data.success && data.language) {
-                // 归一化语言代码：将 BCP-47 格式（如 'zh-CN', 'en-US'）归一化为简单代码（'zh', 'en', 'ja', 'ko'）
-                // 与 detectLanguage() 返回的格式保持一致，避免误判
                 setUserLanguage(normalizeLanguageCode(data.language));
                 return userLanguage;
             }
         } catch (error) {
             console.warn('从API获取用户语言失败，尝试使用缓存或浏览器语言:', error);
         }
-        
-        // API失败时，尝试从localStorage获取（作为回退）
         const cachedLang = localStorage.getItem('userLanguage');
         if (cachedLang) {
             setUserLanguage(normalizeLanguageCode(cachedLang));
             return userLanguage;
         }
-        
-        // 最后回退到浏览器语言
         const browserLang = navigator.language || navigator.userLanguage;
         setUserLanguage(normalizeLanguageCode(browserLang));
         return userLanguage;
     })();
-    
     return await userLanguageInitPromise;
 }
 
-// 简单的语言检测函数（客户端）
-function detectLanguage(text) {
-    if (!text || !text.trim()) {
-        return 'unknown';
-    }
-    
-    // 中文检测
-    const chinesePattern = /[\u4e00-\u9fff]/g;
-    // 日文检测（平假名、片假名）
-    const japanesePattern = /[\u3040-\u309f\u30a0-\u30ff]/g;
-    // 韩文检测（谚文）
-    const koreanPattern = /[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af]/g;
-    // 俄文检测（西里尔字母）
-    const russianPattern = /[\u0400-\u04ff]/g;
-    // 英文检测
-    const englishPattern = /[a-zA-Z]/g;
-
-    const chineseCount = (text.match(chinesePattern) || []).length;
-    const japaneseCount = (text.match(japanesePattern) || []).length;
-    const koreanCount = (text.match(koreanPattern) || []).length;
-    const russianCount = (text.match(russianPattern) || []).length;
-    const englishCount = (text.match(englishPattern) || []).length;
-
-    // 如果包含日文假名，优先判断为日语
-    if (japaneseCount > 0) {
-        return 'ja';
-    }
-
-    // 如果包含韩文，优先判断为韩语
-    if (koreanCount > 0) {
-        return 'ko';
-    }
-
-    // 如果包含俄文西里尔字母，判断为俄语
-    if (russianCount >= englishCount && russianCount >= chineseCount && russianCount > 0) {
-        return 'ru';
-    }
-
-    // 判断主要语言
-    if (chineseCount > englishCount && chineseCount > 0) {
-        return 'zh';
-    } else if (englishCount > 0) {
-        return 'en';
-    } else {
-        return 'unknown';
-    }
-}
-
-// 字幕显示相关变量
-let subtitleTimeout = null;
+// 当前 turn 的原始（未翻译）累积文本，写在主线程上随时可读
+let currentTurnOriginalText = '';
+// 终态翻译请求的取消器
 let currentTranslateAbortController = null;
-let pendingTranslation = null;
-// 流式输出时字幕语言检测的防抖计时器
-let subtitleCheckDebounceTimer = null;
+// 标记最近一次翻译请求所对应的原文，用于丢弃过期响应
+let pendingTranslationKey = null;
 
-// 翻译消息气泡（如果用户语言不是中文）
-async function translateMessageBubble(text, messageElement) {
-    if (!text || !text.trim() || !messageElement) {
-        return;
+/**
+ * 内部：把字幕显示元素切换到“可见”状态（如果开关开启）
+ */
+function ensureSubtitleVisibleIfEnabled() {
+    const display = document.getElementById('subtitle-display');
+    if (!display) return null;
+    if (subtitleEnabled) {
+        display.classList.remove('hidden');
+        display.classList.add('show');
+        display.style.opacity = '1';
     }
-    
-    if (userLanguage === null) {
-        await getUserLanguage();
-    }
-    
-    if (!userLanguage || userLanguage === 'zh') {
-        return;
-    }
-    
-    try {
-        const response = await fetch('/api/translate', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                text: text,
-                target_lang: (userLanguage !== null ? userLanguage : 'zh'),
-                source_lang: 'zh',
-                skip_google: googleTranslateFailed
-            })
-        });
-        
-        if (!response.ok) {
-            console.warn('翻译消息气泡失败:', response.status);
-            return;
-        }
-        
-        const result = await response.json();
-        
-        if (result.google_failed === true) {
-            googleTranslateFailed = true;
-            console.log('Google 翻译失败，本次会话中将跳过 Google 翻译');
-        }
-        
-        if (result.success && result.translated_text && result.translated_text !== text) {
-            const timestampMatch = messageElement.textContent.match(/^\[(\d{2}:\d{2}:\d{2})\] 🎀 /);
-            if (timestampMatch) {
-                messageElement.textContent = `[${timestampMatch[1]}] 🎀 ${result.translated_text}`;
-                console.log('消息气泡已翻译:', result.translated_text.substring(0, 50) + '...');
-            }
-        }
-    } catch (error) {
-        console.error('翻译消息气泡异常:', error);
-    }
+    return display;
 }
 
-// 检查并显示字幕提示框
-async function checkAndShowSubtitlePrompt(text) {
-    if (userLanguage === null) {
-        await getUserLanguage();
+/**
+ * 把字幕显示元素隐藏并清空文字（开关关闭或手动 hideSubtitle 时使用）
+ */
+function hideSubtitle() {
+    const display = document.getElementById('subtitle-display');
+    if (!display) return;
+    const subtitleText = document.getElementById('subtitle-text');
+    if (subtitleText) subtitleText.textContent = '';
+    display.classList.remove('show');
+    display.classList.add('hidden');
+    display.style.opacity = '0';
+}
+
+/**
+ * 写入字幕文本（不影响显示/隐藏状态）
+ */
+function writeSubtitleText(text) {
+    const subtitleText = document.getElementById('subtitle-text');
+    if (subtitleText) subtitleText.textContent = text || '';
+}
+
+/**
+ * 流式更新：本回合 AI 文本累积时调用。
+ * 立即把原文显示到字幕里，跨多个气泡持续写入。
+ * 仅在字幕开关开启时才上屏，但内部状态始终维护，方便用户中途打开开关时直接补显。
+ */
+function updateSubtitleStreamingText(text) {
+    const cleaned = (text || '').toString();
+    currentTurnOriginalText = cleaned;
+
+    if (!subtitleEnabled) return;
+    if (!cleaned.trim()) return;
+
+    ensureSubtitleVisibleIfEnabled();
+    writeSubtitleText(cleaned);
+}
+
+/**
+ * 新 turn 开始：清空当前字幕和翻译状态。
+ * 由 'neko-assistant-turn-start' 事件触发。
+ */
+function onAssistantTurnStart() {
+    currentTurnOriginalText = '';
+    pendingTranslationKey = null;
+    if (currentTranslateAbortController) {
+        currentTranslateAbortController.abort();
+        currentTranslateAbortController = null;
     }
-    
-    const allGeminiMessages = document.querySelectorAll('.message.gemini');
-    let hasNonUserLanguage = false;
-    let latestNonUserLanguageText = '';
-    
-    if (allGeminiMessages.length > 0) {
-        for (const msg of allGeminiMessages) {
-            const msgText = msg.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] 🎀 /, '');
-            if (msgText && msgText.trim()) {
-                const detectedLang = detectLanguage(msgText);
-                if (detectedLang !== 'unknown' && detectedLang !== userLanguage) {
-                    hasNonUserLanguage = true;
-                    latestNonUserLanguageText = msgText;
-                }
-            }
-        }
-    }
-    
-    if (hasNonUserLanguage) {
-        showSubtitlePrompt();
+    // 开关开启时保留显示框（保持空白等待新文本），关闭时连框一起隐藏
+    if (subtitleEnabled) {
+        writeSubtitleText('');
+        ensureSubtitleVisibleIfEnabled();
     } else {
-        hideSubtitlePrompt();
         hideSubtitle();
     }
 }
 
-// 翻译并显示字幕
+/**
+ * Turn 结束时调用：尝试翻译并替换字幕文本。
+ * 如果不需要翻译（同语言 / 检测失败 / 用户禁用），保留原文。
+ */
 async function translateAndShowSubtitle(text) {
     if (!text || !text.trim()) {
         return;
     }
-    
-    // 即使开关关闭，也需要检测语言来决定是否隐藏提示
+
     if (userLanguage === null) {
         await getUserLanguage();
     }
-    
-    const currentTranslationText = text;
-    pendingTranslation = currentTranslationText;
-    
+
+    // 始终把原文当作字幕基准
+    currentTurnOriginalText = text;
+    if (subtitleEnabled) {
+        ensureSubtitleVisibleIfEnabled();
+        writeSubtitleText(text);
+    }
+
+    if (!subtitleEnabled) {
+        return; // 开关关闭，不发翻译请求
+    }
+
+    pendingTranslationKey = text;
+
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
     }
-    
     currentTranslateAbortController = new AbortController();
-    
-    try {
-        const subtitleDisplay = document.getElementById('subtitle-display');
-        if (!subtitleDisplay) {
-            console.warn('字幕显示元素不存在');
-            return;
-        }
+    const abortController = currentTranslateAbortController;
 
-        // 调用翻译API
+    try {
         const response = await fetch('/api/translate', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 text: text,
-                target_lang: (userLanguage !== null ? userLanguage : 'zh'), // 确保已初始化
-                source_lang: null, // 自动检测
-                skip_google: googleTranslateFailed // 如果 Google 翻译失败过，跳过它
+                target_lang: (userLanguage !== null ? userLanguage : 'zh'),
+                source_lang: null
             }),
-            signal: currentTranslateAbortController.signal
+            signal: abortController.signal
         });
 
         if (!response.ok) {
-            console.warn('翻译请求失败:', response.status);
-            if (pendingTranslation === currentTranslationText) {
-                pendingTranslation = null;
-            }
-            console.error('字幕翻译API请求失败:', {
-                status: response.status,
-                statusText: response.statusText,
-                text: text.substring(0, 50) + '...',
-                userLanguage: userLanguage
-            });
+            console.warn('字幕翻译请求失败:', response.status);
             return;
         }
 
         const result = await response.json();
 
-        if (pendingTranslation !== currentTranslationText) {
-            console.log('检测到更新的翻译请求，忽略旧的翻译结果');
+        // 已经被新一轮翻译/turn 抢占，丢弃过期结果
+        if (pendingTranslationKey !== text) {
             return;
         }
-        pendingTranslation = null;
+        pendingTranslationKey = null;
 
-        if (result.google_failed === true) {
-            googleTranslateFailed = true;
-            console.log('Google 翻译失败，本次会话中将跳过 Google 翻译');
+        if (!subtitleEnabled) {
+            return; // 翻译期间用户关掉了开关
         }
 
-        const frontendDetectedLang = detectLanguage(text);
-        const isNonUserLanguage = frontendDetectedLang !== 'unknown' && frontendDetectedLang !== userLanguage;
-
-        // 异步等待后再次确认元素仍然存在
-        if (!subtitleDisplay.isConnected) {
-            console.warn('字幕显示元素在异步操作后已从DOM移除');
-            return;
+        // 真正发生了翻译才替换；同语言/未知语言/失败保留原文
+        if (result.success && result.translated_text &&
+            result.source_lang && result.target_lang &&
+            result.source_lang !== result.target_lang &&
+            result.source_lang !== 'unknown' &&
+            result.translated_text !== text) {
+            ensureSubtitleVisibleIfEnabled();
+            writeSubtitleText(result.translated_text);
+            console.log('字幕已翻译:', result.translated_text.substring(0, 50));
         }
-
-        const subtitleDisplayAfter = subtitleDisplay;
-        
-        if (result.success && result.translated_text && 
-            result.source_lang && result.target_lang && 
-            result.source_lang !== result.target_lang && 
-            result.source_lang !== 'unknown') {
-            showSubtitlePrompt();
-            
-            if (subtitleEnabled) {
-                const subtitleText = document.getElementById('subtitle-text');
-                if (subtitleText) subtitleText.textContent = result.translated_text;
-                subtitleDisplayAfter.classList.add('show');
-                subtitleDisplayAfter.classList.remove('hidden');
-                subtitleDisplayAfter.style.opacity = '1';
-                console.log('字幕已更新（已翻译）:', result.translated_text.substring(0, 50) + '...');
-
-                // 不自动隐藏，由用户手动关闭
-            } else {
-                const subtitleText = document.getElementById('subtitle-text');
-                if (subtitleText) subtitleText.textContent = '';
-                subtitleDisplayAfter.classList.remove('show');
-                subtitleDisplayAfter.classList.add('hidden');
-                subtitleDisplayAfter.style.opacity = '0';
-                console.log('开关已关闭，不显示字幕');
-            }
-        } else {
-            if (isNonUserLanguage) {
-                showSubtitlePrompt();
-                const subtitleText = document.getElementById('subtitle-text');
-                if (subtitleText) subtitleText.textContent = '';
-                subtitleDisplayAfter.classList.remove('show');
-                subtitleDisplayAfter.classList.add('hidden');
-                subtitleDisplayAfter.style.opacity = '0';
-                console.log('前端检测到非用户语言，显示提示框');
-            } else {
-                hideSubtitlePrompt();
-                const subtitleText = document.getElementById('subtitle-text');
-                if (subtitleText) subtitleText.textContent = '';
-                subtitleDisplayAfter.classList.remove('show');
-                subtitleDisplayAfter.classList.add('hidden');
-                subtitleDisplayAfter.style.opacity = '0';
-                console.log('对话已是用户语言，自动隐藏字幕提示');
-            }
-            if (subtitleTimeout) {
-                clearTimeout(subtitleTimeout);
-                subtitleTimeout = null;
-            }
-        }
+        // else: 不需要翻译，保留刚才写入的原文，什么也不做
     } catch (error) {
         if (error.name === 'AbortError') {
-            if (pendingTranslation === currentTranslationText) {
-                pendingTranslation = null;
-            }
             return;
         }
-        
         console.error('字幕翻译异常:', {
             error: error.message,
-            stack: error.stack,
-            name: error.name,
             text: text.substring(0, 50) + '...',
             userLanguage: userLanguage
         });
-        
-        if (pendingTranslation === currentTranslationText) {
-            pendingTranslation = null;
-        }
-        
-        if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-            console.warn('提示：字幕翻译功能暂时不可用，但对话可以正常进行');
-        }
     } finally {
-        currentTranslateAbortController = null;
+        if (currentTranslateAbortController === abortController) {
+            currentTranslateAbortController = null;
+        }
     }
 }
 
-// 隐藏字幕
-function hideSubtitle() {
-    const subtitleDisplay = document.getElementById('subtitle-display');
-    if (!subtitleDisplay) return;
-    
-    // 清除定时器
-    if (subtitleTimeout) {
-        clearTimeout(subtitleTimeout);
-        subtitleTimeout = null;
-    }
-    
-    subtitleDisplay.classList.remove('show');
-    subtitleDisplay.style.opacity = '0';
-    
-    // 延迟隐藏，让淡出动画完成
-    setTimeout(() => {
-        const subtitleDisplayForTimeout = document.getElementById('subtitle-display');
-        if (subtitleDisplayForTimeout && subtitleDisplayForTimeout.style.opacity === '0') {
-            subtitleDisplayForTimeout.classList.add('hidden');
-        }
-    }, 300);
-}
-
-// 显示字幕提示框（参考Xiao8项目，改为系统消息形式）
-function showSubtitlePrompt() {
-    // 检查是否已经显示过提示（避免重复显示）
-    const existingPrompt = document.getElementById('subtitle-prompt-message');
-    if (existingPrompt) {
-        return;
-    }
-    
-    const textInputArea = document.getElementById('text-input-area');
-    const chatContainer = document.getElementById('chat-container');
-    
-    // 检测是否处于语音模式（text-input-area 被隐藏）
-    const isVoiceMode = textInputArea && textInputArea.classList.contains('hidden');
-    
-    // 确定父容器：语音模式下使用 chat-container，否则使用 text-input-area
-    let parentContainer;
-    if (isVoiceMode) {
-        parentContainer = chatContainer;
-    } else {
-        parentContainer = textInputArea;
-    }
-    
-    if (!parentContainer) {
-        return;
-    }
-    
-    // 创建提示消息（放在输入框区域中）
-    const promptDiv = document.createElement('div');
-    promptDiv.id = 'subtitle-prompt-message';
-    promptDiv.classList.add('subtitle-prompt-message');
-    
-    // 如果是语音模式，添加特殊样式类
-    if (isVoiceMode) {
-        promptDiv.classList.add('voice-mode');
-    }
-    
-    // 创建提示内容
-    const promptContent = document.createElement('div');
-    promptContent.classList.add('subtitle-prompt-content');
-    
-    // 创建开关容器
-    const toggleWrapper = document.createElement('div');
-    toggleWrapper.classList.add('subtitle-toggle-wrapper');
-    
-    // 创建圆形指示器
-    const indicator = document.createElement('div');
-    indicator.classList.add('subtitle-toggle-indicator');
-    if (subtitleEnabled) {
-        indicator.classList.add('active');
-    }
-    
-    // 创建标签文本
-    const labelText = document.createElement('span');
-    labelText.classList.add('subtitle-toggle-label');
-    labelText.setAttribute('data-i18n', 'subtitle.enable');
-    // 使用i18n翻译，如果i18n未加载或翻译不存在则根据浏览器语言提供fallback
-    const browserLang = normalizeLanguageCode(navigator.language);
-    const fallbacks = {
-        'zh': '字幕翻译',
-        'en': 'Subtitle Translation',
-        'ja': '字幕翻訳',
-        'ko': '자막 번역',
-        'ru': 'Перевод субтитров'
-    };
-    if (window.t) {
-        const translated = window.t('subtitle.enable');
-        // 如果翻译返回的是key本身（说明翻译不存在），使用浏览器语言的fallback
-        labelText.textContent = (translated && translated !== 'subtitle.enable') ? translated : (fallbacks[browserLang] || fallbacks['en']);
-    } else {
-        // i18n未加载时，使用浏览器语言的fallback
-        labelText.textContent = fallbacks[browserLang] || fallbacks['en'];
-    }
-    
-    toggleWrapper.appendChild(indicator);
-    toggleWrapper.appendChild(labelText);
-    
-    promptContent.appendChild(toggleWrapper);
-    promptDiv.appendChild(promptContent);
-    
-    // 根据模式插入到不同位置
-    if (isVoiceMode) {
-        // 语音模式：插入到 chat-container 底部（在 text-input-area 之前）
-        if (textInputArea) {
-            chatContainer.insertBefore(promptDiv, textInputArea);
-        } else {
-            chatContainer.appendChild(promptDiv);
-        }
-    } else {
-        // 文本模式：插入到输入框区域的最后（在text-input-row之后）
-        const textInputRow = textInputArea.querySelector('#text-input-row');
-        if (textInputRow && textInputRow.nextSibling) {
-            textInputArea.insertBefore(promptDiv, textInputRow.nextSibling);
-        } else {
-            textInputArea.appendChild(promptDiv);
-        }
-    }
-
-    
-    // 如果i18next已加载，监听语言变化事件
-    if (window.i18next) {
-        window.i18next.on('languageChanged', () => {
-            if (labelText && window.t) {
-                const translated = window.t('subtitle.enable');
-                // 如果翻译返回的是key本身（说明翻译不存在），使用当前语言的fallback
-                if (translated && translated !== 'subtitle.enable') {
-                    labelText.textContent = translated;
-                } else {
-                    // 使用与初始渲染相同的fallback逻辑
-                    const currentLang = normalizeLanguageCode(window.i18next.language || navigator.language);
-                    labelText.textContent = fallbacks[currentLang] || fallbacks['en'];
-                }
-            }
-        });
-    }
-    
-    // 更新指示器状态
-    const updateIndicator = () => {
-        if (subtitleEnabled) {
-            indicator.classList.add('active');
-        } else {
-            indicator.classList.remove('active');
-        }
-    };
-    
-    // 切换开关的函数
-    const handleToggle = (e) => {
-        if (e) {
-            e.preventDefault();
-            e.stopPropagation();
-        }
-        subtitleEnabled = !subtitleEnabled;
-        // 同步到 appState 和 localStorage
-        if (typeof window.appState !== 'undefined') {
-            window.appState.subtitleEnabled = subtitleEnabled;
-        }
-        localStorage.setItem('subtitleEnabled', subtitleEnabled.toString());
-        // 触发统一保存（会同步到服务器）
-        if (typeof window.appSettings !== 'undefined' && window.appSettings.saveSettings) {
-            window.appSettings.saveSettings();
-        }
-        updateIndicator();
-        console.log('字幕开关:', subtitleEnabled ? '开启' : '关闭');
-        
-        if (!subtitleEnabled) {
-            const subtitleDisplay = document.getElementById('subtitle-display');
-            if (subtitleDisplay) {
-                const subtitleText = document.getElementById('subtitle-text');
-                if (subtitleText) subtitleText.textContent = '';
-                subtitleDisplay.classList.remove('show');
-                subtitleDisplay.classList.add('hidden');
-                subtitleDisplay.style.opacity = '0';
-            }
-            if (subtitleTimeout) {
-                clearTimeout(subtitleTimeout);
-                subtitleTimeout = null;
-            }
-        } else {
-            // 如果开启，重新翻译并显示字幕
-            if (currentTranslateAbortController) {
-                currentTranslateAbortController.abort();
-                currentTranslateAbortController = null;
-            }
-            pendingTranslation = null;
-            
-            if (window.currentGeminiMessage && 
-                window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
-                window.currentGeminiMessage.isConnected &&
-                typeof window.currentGeminiMessage.textContent === 'string') {
-                const fullText = window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] 🎀 /, '');
-                if (fullText && fullText.trim()) {
-                    const subtitleDisplay = document.getElementById('subtitle-display');
-                    if (!subtitleDisplay) {
-                        console.error('字幕显示元素不存在，无法显示字幕');
-                        return;
-                    }
-                    subtitleDisplay.classList.remove('hidden');
-                    translateAndShowSubtitle(fullText);
-                }
-            } else {
-                if (window.currentGeminiMessage) {
-                    console.warn('currentGeminiMessage存在但不是有效的DOM元素，无法翻译字幕');
-                }
-            }
-        }
-    };
-    
-    let touchHandled = false;
-    
-    const handleTouchToggle = (e) => {
-        e.preventDefault();
-        touchHandled = true;
-        handleToggle(e);
-    };
-    
-    // 绑定点击事件（桌面端）
-    toggleWrapper.addEventListener('click', (e) => {
-        if (touchHandled) {
-            touchHandled = false;
-            return;
-        }
-        handleToggle(e);
-    });
-    indicator.addEventListener('click', (e) => {
-        if (touchHandled) {
-            touchHandled = false;
-            return;
-        }
-        handleToggle(e);
-    });
-    labelText.addEventListener('click', (e) => {
-        if (touchHandled) {
-            touchHandled = false;
-            return;
-        }
-        handleToggle(e);
-    });
-    
-    // 绑定触摸事件（移动端）
-    toggleWrapper.addEventListener('touchstart', handleTouchToggle, { passive: false });
-    indicator.addEventListener('touchstart', handleTouchToggle, { passive: false });
-    labelText.addEventListener('touchstart', handleTouchToggle, { passive: false });
-}
-
-// 隐藏字幕提示框
-function hideSubtitlePrompt() {
-    const existingPrompt = document.getElementById('subtitle-prompt-message');
-    if (existingPrompt) {
-        existingPrompt.remove();
-        console.log('已隐藏字幕提示消息');
-    }
-}
-
-// 初始化字幕开关（DOM加载完成后）
+// 初始化字幕模块（DOM 就绪后绑定拖拽 & turn 事件）
 document.addEventListener('DOMContentLoaded', async function() {
-    // 拖拽初始化只绑定 DOM 事件，不依赖语言数据，立即执行
     initSubtitleDrag();
-
-    // 初始化用户语言（等待完成，确保使用最新值）
     await getUserLanguage();
-
-    // 检查当前消息中是否有非用户语言
-    // 增强null安全检查：确保currentGeminiMessage是有效的DOM元素
-    if (window.currentGeminiMessage &&
-        window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
-        window.currentGeminiMessage.isConnected &&
-        typeof window.currentGeminiMessage.textContent === 'string') {
-        const fullText = window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] 🎀 /, '');
-        if (fullText && fullText.trim()) {
-            checkAndShowSubtitlePrompt(fullText);
-        }
-    }
-
-    // 初始化通用引导管理器（幂等性保护）
-    if (!window.__universalTutorialManagerInitialized && typeof initUniversalTutorialManager === 'function') {
-        try {
-            initUniversalTutorialManager();
-            window.__universalTutorialManagerInitialized = true;
-            console.log('[App] 通用引导管理器已初始化');
-        } catch (error) {
-            console.error('[App] 通用引导管理器初始化失败:', error);
-        }
-    }
+    window.addEventListener('neko-assistant-turn-start', onAssistantTurnStart);
 });
 
 // 字幕拖拽功能
@@ -676,29 +262,23 @@ function initSubtitleDrag() {
     const subtitleDisplay = document.getElementById('subtitle-display');
     const dragHandle = document.getElementById('subtitle-drag-handle');
 
-    console.log('[Subtitle] 调试 - 找到字幕元素:', !!subtitleDisplay);
-    console.log('[Subtitle] 调试 - 找到拖拽句柄:', !!dragHandle);
-
     if (!subtitleDisplay || !dragHandle) {
         console.warn('[Subtitle] 无法找到字幕元素或拖拽句柄');
         return;
     }
 
     let isDragging = false;
-    let pendingDrag = false; // mousedown 后等待真实拖动
+    let pendingDrag = false;
     let isManualPosition = false;
     let startX, startY;
     let initialX, initialY;
 
-    // 鼠标按下事件
     function handleMouseDown(e) {
-        // 只响应左键拖拽
         if (e.button !== 0) return;
 
         pendingDrag = true;
         document.body.style.userSelect = 'none';
 
-        // 获取并记录当前元素位置（含 transform），在 mousedown 时快照
         const rect = subtitleDisplay.getBoundingClientRect();
         startX = e.clientX;
         startY = e.clientY;
@@ -709,7 +289,6 @@ function initSubtitleDrag() {
         document.addEventListener('mouseup', handleMouseUp);
     }
 
-    // 触摸开始事件
     function handleTouchStart(e) {
         const touch = e.touches[0];
         handleMouseDown({
@@ -734,7 +313,6 @@ function initSubtitleDrag() {
         subtitleDisplay.style.bottom = 'auto';
     }
 
-    // 鼠标移动事件
     function handleMouseMove(e) {
         if (!pendingDrag && !isDragging) return;
 
@@ -752,7 +330,6 @@ function initSubtitleDrag() {
         let newX = initialX + dx;
         let newY = initialY + dy;
 
-        // 限制在窗口范围内
         const maxX = window.innerWidth - subtitleDisplay.offsetWidth;
         const maxY = window.innerHeight - subtitleDisplay.offsetHeight;
 
@@ -763,7 +340,6 @@ function initSubtitleDrag() {
         subtitleDisplay.style.top = newY + 'px';
     }
 
-    // 触摸移动事件
     function handleTouchMove(e) {
         const touch = e.touches[0];
         handleMouseMove({
@@ -773,7 +349,6 @@ function initSubtitleDrag() {
         });
     }
 
-    // 鼠标释放事件
     function handleMouseUp() {
         if (!pendingDrag && !isDragging) return;
 
@@ -784,25 +359,19 @@ function initSubtitleDrag() {
 
         document.removeEventListener('mousemove', handleMouseMove);
         document.removeEventListener('mouseup', handleMouseUp);
-        // 注意：touchmove/touchend 是初始化时全局绑定的，不在这里移除
     }
 
-    // 触摸结束事件
     function handleTouchUp() {
         handleMouseUp();
     }
 
-    // 绑定事件到拖拽句柄
     dragHandle.addEventListener('mousedown', handleMouseDown);
     dragHandle.addEventListener('touchstart', handleTouchStart, { passive: false });
 
-    // 全局绑定移动和结束事件
     document.addEventListener('touchmove', handleTouchMove, { passive: false });
     document.addEventListener('touchend', handleTouchUp);
     document.addEventListener('touchcancel', handleTouchUp);
 
-    // 窗口大小改变时，确保手动定位的字幕不超出边界
-    // CSS 居中定位（left:50% + transform）由浏览器自动处理，无需干预
     window.addEventListener('resize', () => {
         if (!isManualPosition) return;
 
@@ -817,37 +386,33 @@ function initSubtitleDrag() {
             subtitleDisplay.style.top = maxY + 'px';
         }
     });
-
-    console.log('[Subtitle] 字幕拖拽功能已初始化');
 }
 
 // ======================== 外部桥接接口 ========================
-// 供 app-settings.js 等其他模块在合并服务器设置后调用，保持内部状态同步
+// 供 app-settings.js / React 聊天窗口在合并服务器设置或用户点击开关时调用
 window.subtitleBridge = {
+    /** 仅同步状态，不做副作用（用于服务器设置回灌） */
     setSubtitleEnabled: function(enabled) {
-        subtitleEnabled = enabled;
+        subtitleEnabled = !!enabled;
         if (typeof window.appState !== 'undefined') {
             window.appState.subtitleEnabled = subtitleEnabled;
         }
         localStorage.setItem('subtitleEnabled', subtitleEnabled.toString());
 
-        // 立即显示/隐藏字幕框
-        var display = document.getElementById('subtitle-display');
-        if (display) {
-            if (subtitleEnabled) {
-                display.classList.remove('hidden');
-                display.classList.add('show');
-                display.style.opacity = '1';
+        if (subtitleEnabled) {
+            // 重新启用：把当前 turn 已有原文补显到字幕
+            if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
+                ensureSubtitleVisibleIfEnabled();
+                writeSubtitleText(currentTurnOriginalText);
             } else {
-                var text = document.getElementById('subtitle-text');
-                if (text) text.textContent = '';
-                display.classList.remove('show');
-                display.classList.add('hidden');
-                display.style.opacity = '0';
+                ensureSubtitleVisibleIfEnabled();
+                writeSubtitleText('');
             }
+        } else {
+            hideSubtitle();
         }
     },
-    /** 完整切换：翻转开关 + 执行运行时副作用（隐藏/重新翻译字幕） */
+    /** 完整切换：翻转开关 + 执行运行时副作用（隐藏/补显字幕，并在开启时翻译当前文本） */
     toggle: function() {
         subtitleEnabled = !subtitleEnabled;
         if (typeof window.appState !== 'undefined') {
@@ -858,63 +423,31 @@ window.subtitleBridge = {
             window.appSettings.saveSettings();
         }
 
-        // 更新旧版提示框的指示器（如果存在）
-        var indicator = document.querySelector('.subtitle-toggle-indicator');
-        if (indicator) {
-            if (subtitleEnabled) {
-                indicator.classList.add('active');
-            } else {
-                indicator.classList.remove('active');
-            }
-        }
-
         console.log('字幕开关:', subtitleEnabled ? '开启' : '关闭');
 
         if (!subtitleEnabled) {
-            // 关闭：隐藏字幕、清除定时器
-            var display = document.getElementById('subtitle-display');
-            if (display) {
-                var text = document.getElementById('subtitle-text');
-                if (text) text.textContent = '';
-                display.classList.remove('show');
-                display.classList.add('hidden');
-                display.style.opacity = '0';
-            }
-            if (subtitleTimeout) {
-                clearTimeout(subtitleTimeout);
-                subtitleTimeout = null;
-            }
-        } else {
-            // 开启：立即显示字幕框
-            var subtitleDisplay = document.getElementById('subtitle-display');
-            if (subtitleDisplay) {
-                subtitleDisplay.classList.remove('hidden');
-                subtitleDisplay.classList.add('show');
-                subtitleDisplay.style.opacity = '1';
-            }
-
-            // 如果有当前消息，重新翻译
             if (currentTranslateAbortController) {
                 currentTranslateAbortController.abort();
                 currentTranslateAbortController = null;
             }
-            pendingTranslation = null;
-
-            if (window.currentGeminiMessage &&
-                window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
-                window.currentGeminiMessage.isConnected &&
-                typeof window.currentGeminiMessage.textContent === 'string') {
-                var fullText = window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] 🎀 /, '');
-                if (fullText && fullText.trim()) {
-                    translateAndShowSubtitle(fullText);
-                }
+            pendingTranslationKey = null;
+            hideSubtitle();
+        } else {
+            // 立即把当前 turn 已有原文补显
+            if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
+                ensureSubtitleVisibleIfEnabled();
+                writeSubtitleText(currentTurnOriginalText);
+                // 如果当前 turn 已经结束（没有新流入），尝试触发一次翻译替换
+                translateAndShowSubtitle(currentTurnOriginalText);
+            } else {
+                ensureSubtitleVisibleIfEnabled();
+                writeSubtitleText('');
             }
         }
 
         return subtitleEnabled;
     },
     setUserLanguage: function(lang) {
-        // 空值时回退到默认值
         if (!lang || typeof lang !== 'string') {
             lang = 'zh';
         }
@@ -923,5 +456,14 @@ window.subtitleBridge = {
             window.appState.userLanguage = userLanguage;
         }
         localStorage.setItem('userLanguage', userLanguage);
-    }
+    },
+    /** 供 app-chat.js 在 _geminiTurnFullText 累积时调用 */
+    updateStreamingText: updateSubtitleStreamingText,
+    /** 供 app-websocket.js 在 turn end 时调用 */
+    finalizeTurnWithTranslation: translateAndShowSubtitle
 };
+
+// 向后兼容：保留全局函数名，但函数体已经精简
+window.translateAndShowSubtitle = translateAndShowSubtitle;
+window.updateSubtitleStreamingText = updateSubtitleStreamingText;
+window.getUserLanguage = getUserLanguage;

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -101,13 +101,12 @@ let isCurrentTurnFinalized = false;
  */
 function ensureSubtitleVisibleIfEnabled() {
     const display = document.getElementById('subtitle-display');
-    if (!display) return null;
+    if (!display) return;
     if (subtitleEnabled) {
         display.classList.remove('hidden');
         display.classList.add('show');
         display.style.opacity = '1';
     }
-    return display;
 }
 
 /**

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -88,8 +88,13 @@ async function getUserLanguage() {
 let currentTurnOriginalText = '';
 // 终态翻译请求的取消器
 let currentTranslateAbortController = null;
-// 标记最近一次翻译请求所对应的原文，用于丢弃过期响应
-let pendingTranslationKey = null;
+// 单调递增的 turn id / request id，用于丢弃来自旧 turn 或旧请求的响应。
+// 不要用原文做去重键：同一字幕在相邻 turn 有可能字面量相同。
+let currentTurnId = 0;
+let currentTranslationRequestId = 0;
+// 当前 turn 是否已收到 turn-end（即 translateAndShowSubtitle 被调用过）。
+// 用于 toggle 开启时判断要不要对当前缓存发起翻译；流式途中不会标记 true。
+let isCurrentTurnFinalized = false;
 
 /**
  * 内部：把字幕显示元素切换到“可见”状态（如果开关开启）
@@ -147,8 +152,9 @@ function updateSubtitleStreamingText(text) {
  * 由 'neko-assistant-turn-start' 事件触发。
  */
 function onAssistantTurnStart() {
+    currentTurnId += 1;
     currentTurnOriginalText = '';
-    pendingTranslationKey = null;
+    isCurrentTurnFinalized = false;
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
@@ -171,8 +177,20 @@ async function translateAndShowSubtitle(text) {
         return;
     }
 
+    // 快照本次请求归属的 turn 与 request 序号。响应回来时必须跟当前值匹配，
+    // 否则说明已被新 turn / 新请求抢占（哪怕原文字面量相同也要丢弃）。
+    const requestTurnId = currentTurnId;
+    const requestId = ++currentTranslationRequestId;
+    // 收到 turn-end 才算当前 turn 已结算
+    isCurrentTurnFinalized = true;
+
     if (userLanguage === null) {
         await getUserLanguage();
+    }
+
+    // 请求之前再校验一次 — getUserLanguage 本身是 await，可能已经跨 turn
+    if (requestTurnId !== currentTurnId || requestId !== currentTranslationRequestId) {
+        return;
     }
 
     // 始终把原文当作字幕基准
@@ -185,8 +203,6 @@ async function translateAndShowSubtitle(text) {
     if (!subtitleEnabled) {
         return; // 开关关闭，不发翻译请求
     }
-
-    pendingTranslationKey = text;
 
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
@@ -213,11 +229,10 @@ async function translateAndShowSubtitle(text) {
 
         const result = await response.json();
 
-        // 已经被新一轮翻译/turn 抢占，丢弃过期结果
-        if (pendingTranslationKey !== text) {
+        // 已经被新 turn / 新请求抢占，丢弃过期结果（用单调序号判断，不用原文）
+        if (requestTurnId !== currentTurnId || requestId !== currentTranslationRequestId) {
             return;
         }
-        pendingTranslationKey = null;
 
         if (!subtitleEnabled) {
             return; // 翻译期间用户关掉了开关
@@ -255,6 +270,20 @@ document.addEventListener('DOMContentLoaded', async function() {
     initSubtitleDrag();
     await getUserLanguage();
     window.addEventListener('neko-assistant-turn-start', onAssistantTurnStart);
+
+    // 通用引导管理器：index.html / chat.html 都加载 subtitle.js，
+    // 但自身模板没有 init 调用，历史上靠这里兜底（其他子页面模板各自 init）。
+    // 幂等保护防止跨页面重复 init。
+    if (!window.__universalTutorialManagerInitialized &&
+        typeof initUniversalTutorialManager === 'function') {
+        try {
+            initUniversalTutorialManager();
+            window.__universalTutorialManagerInitialized = true;
+            console.log('[App] 通用引导管理器已初始化');
+        } catch (error) {
+            console.error('[App] 通用引导管理器初始化失败:', error);
+        }
+    }
 });
 
 // 字幕拖拽功能
@@ -430,15 +459,17 @@ window.subtitleBridge = {
                 currentTranslateAbortController.abort();
                 currentTranslateAbortController = null;
             }
-            pendingTranslationKey = null;
             hideSubtitle();
         } else {
             // 立即把当前 turn 已有原文补显
             if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText(currentTurnOriginalText);
-                // 如果当前 turn 已经结束（没有新流入），尝试触发一次翻译替换
-                translateAndShowSubtitle(currentTurnOriginalText);
+                // 仅当本 turn 已经收到 turn-end 时，才对缓存原文补发一次翻译；
+                // 流式途中打开开关时，让字幕跟随流式文本更新，避免"半句翻译 → 被后续 chunk 覆盖"的闪烁。
+                if (isCurrentTurnFinalized) {
+                    translateAndShowSubtitle(currentTurnOriginalText);
+                }
             } else {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText('');

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -428,6 +428,34 @@ except Exception as e:
     TRANSLATEPY_AVAILABLE = False
     logger.warning(f"translatepy 导入失败（其他错误）: {e}，将跳过 translatepy 翻译")
 
+# 进程级 Google 翻译失败标记：一旦 Google 在本进程内失败过一次，
+# 后续直接跳过 Google，避免每个请求都等满超时。前端的 skip_google
+# 仅是会话级（刷新即丢），这里补足后端的进程级持久化，跨请求生效。
+_google_translate_failed_flag = False
+_google_translate_failed_lock = threading.Lock()
+
+
+def _is_google_marked_failed() -> bool:
+    with _google_translate_failed_lock:
+        return _google_translate_failed_flag
+
+
+def _mark_google_failed() -> None:
+    global _google_translate_failed_flag
+    with _google_translate_failed_lock:
+        if not _google_translate_failed_flag:
+            _google_translate_failed_flag = True
+            logger.info("⛔ [翻译服务] Google 翻译已被标记为不可用，本进程后续请求将直接跳过")
+
+
+def reset_google_translate_failure_flag() -> None:
+    """重置 Google 翻译失败标记（测试或网络恢复时使用）"""
+    global _google_translate_failed_flag
+    with _google_translate_failed_lock:
+        _google_translate_failed_flag = False
+        logger.info("🔄 [翻译服务] 已清除 Google 翻译失败标记")
+
+
 # 语言检测正则表达式
 CHINESE_PATTERN = re.compile(r'[\u4e00-\u9fff]')
 JAPANESE_PATTERN = re.compile(r'[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff]')  # 平假名、片假名、汉字
@@ -658,51 +686,46 @@ def detect_language(text: str) -> str:
 async def translate_text(text: str, target_lang: str, source_lang: Optional[str] = None, skip_google: bool = False) -> Tuple[str, bool]:
     """
     翻译文本到目标语言
-    
+
     根据系统区域选择不同的翻译服务优先级：
-    - 中文区：Google 翻译（优先尝试，5秒超时，超时后立即降级）-> translatepy -> LLM 翻译
-    - 非中文区：Google 翻译 -> LLM 翻译（简化流程，去掉 translatepy）
-    
-    降级机制说明：
-    - 中文区使用超时机制（5秒）快速判断 Google 翻译是否可用
-    - 如果 Google 翻译在 5 秒内没有响应，立即降级到 translatepy，避免长时间等待
-    - 如果 skip_google=True，直接跳过 Google 翻译（用于会话级失败标记）
-    
+    - 中文区：直接 translatepy → LLM 翻译（不尝试 Google，避免每次等满超时）
+    - 非中文区：Google 翻译 → LLM 翻译（一旦 Google 失败，进程级标记后续请求直接跳过）
+
     Args:
         text: 要翻译的文本
-        target_lang: 目标语言代码 ('zh', 'en', 'ja', 'ko')
-        source_lang: 源语言代码，如果为None则自动检测
-        skip_google: 是否跳过 Google 翻译（会话级失败标记）
-        
+        target_lang: 目标语言代码 ('zh', 'en', 'ja', 'ko', 'ru')
+        source_lang: 源语言代码，如果为 None 则自动检测
+        skip_google: 是否跳过 Google 翻译（兼容旧调用方，与进程级标记取或）
+
     Returns:
-        (翻译后的文本, google_failed): 如果翻译失败则返回原文，google_failed 表示 Google 翻译是否失败
+        (翻译后的文本, google_failed): 翻译失败时返回原文；
+        google_failed 表示本次（或此前）Google 翻译是否被标记为不可用
     """
-    google_failed = False  # 记录 Google 翻译是否失败
-    
     if not text or not text.strip():
-        return text, google_failed
-    
+        return text, _is_google_marked_failed()
+
     # 自动检测源语言
     if source_lang is None:
         source_lang = detect_language(text)
-    
+
     # 如果源语言和目标语言相同，不需要翻译
     if source_lang == target_lang or source_lang == 'unknown':
         logger.debug(f"跳过翻译: 源语言({source_lang}) == 目标语言({target_lang}) 或源语言未知")
-        return text, google_failed
-    
+        return text, _is_google_marked_failed()
+
     # 判断当前区域，决定翻译服务优先级
     try:
         is_china = is_china_region()
     except Exception as e:
         logger.warning(f"获取区域信息失败: {e}，默认使用非中文区优先级")
         is_china = False
-    
-    if is_china:
-        region_str = '中文区'
-    else:
-        region_str = '非中文区'
+
+    region_str = '中文区' if is_china else '非中文区'
     logger.debug(f"🔄 [翻译服务] 开始翻译流程: {source_lang} -> {target_lang}, 文本长度: {len(text)}, 区域: {region_str}")
+
+    # 中文区：完全跳过 Google；非中文区：综合调用方意愿与进程级标记
+    skip_google_effective = is_china or skip_google or _is_google_marked_failed()
+    google_failed = _is_google_marked_failed()
     
     # 语言代码映射：我们的代码 -> Google Translate 代码
     GOOGLE_LANG_MAP = {
@@ -775,26 +798,10 @@ async def translate_text(text: str, target_lang: str, source_lang: Optional[str]
     
     # 根据区域选择不同的优先级
     if is_china:
-        # 中文区：先尝试 Google 翻译（带超时），确认不能用后再降级到 translatepy
-        # 优先级1：尝试使用 Google 翻译（中文区优先尝试，5秒超时，超时后立即降级）
-        # 如果 skip_google=True，直接跳过 Google 翻译
-        if skip_google:
-            logger.debug("⏭️ [翻译服务] 跳过 Google 翻译（会话级失败标记），直接使用 translatepy")
-        elif GOOGLETRANS_AVAILABLE:
-            logger.debug(f"🌐 [翻译服务] 尝试 Google 翻译 (中文区优先，5秒超时): {source_lang} -> {target_lang}")
-            translated_text = await _try_google_translate(timeout=5.0)  # 5秒超时
-            if translated_text:
-                logger.info(f"✅ [翻译服务] Google翻译成功: {source_lang} -> {target_lang}")
-                return translated_text, google_failed
-            else:
-                logger.debug("❌ [翻译服务] Google翻译不可用（超时或失败），立即降级到 translatepy")
-                google_failed = True  # 标记 Google 翻译失败
-        else:
-            logger.debug("⚠️ [翻译服务] Google 翻译不可用（googletrans 未安装），尝试 translatepy")
-        
-        # 优先级2：尝试使用 translatepy（确认 Google 不能用后降级）
+        # 中文区：直接走 translatepy（不再尝试 Google，避免每次都等满超时）
+        logger.debug("⏭️ [翻译服务] 中文区，直接使用 translatepy")
         if TRANSLATEPY_AVAILABLE:
-            logger.debug(f"🌐 [翻译服务] 尝试 translatepy (中文区降级): {source_lang} -> {target_lang}")
+            logger.debug(f"🌐 [翻译服务] 尝试 translatepy (中文区): {source_lang} -> {target_lang}")
             try:
                 translated_text = await translate_with_translatepy(text, source_lang, target_lang)
                 if translated_text:
@@ -808,10 +815,9 @@ async def translate_text(text: str, target_lang: str, source_lang: Optional[str]
             logger.debug("⚠️ [翻译服务] translatepy 不可用（未安装），回退到 LLM 翻译")
     else:
         # 非中文区：Google 翻译 → LLM 翻译（简化流程，去掉 translatepy）
-        # 优先级1：尝试使用 Google 翻译
-        # 如果 skip_google=True，直接跳过 Google 翻译
-        if skip_google:
-            logger.debug("⏭️ [翻译服务] 跳过 Google 翻译（会话级失败标记），直接使用 LLM 翻译")
+        # skip_google_effective 综合了调用方意愿与本进程的失败标记
+        if skip_google_effective:
+            logger.debug("⏭️ [翻译服务] 跳过 Google 翻译（已被标记不可用 / 调用方要求），直接使用 LLM 翻译")
         elif GOOGLETRANS_AVAILABLE:
             logger.debug(f"🌐 [翻译服务] 尝试 Google 翻译 (非中文区): {source_lang} -> {target_lang}")
             translated_text = await _try_google_translate()
@@ -820,7 +826,8 @@ async def translate_text(text: str, target_lang: str, source_lang: Optional[str]
                 return translated_text, google_failed
             else:
                 logger.debug("❌ [翻译服务] Google翻译失败，回退到 LLM 翻译")
-                google_failed = True  # 标记 Google 翻译失败
+                _mark_google_failed()  # 进程级标记，本进程后续请求不再尝试
+                google_failed = True
         else:
             logger.debug("⚠️ [翻译服务] Google 翻译不可用（googletrans 未安装），回退到 LLM 翻译")
     


### PR DESCRIPTION
## 背景

之前字幕翻译有几个长期问题：

1. **每个新气泡清空字幕**：`checkAndShowSubtitlePrompt` 在每个 bubble 上调用，遍历所有 `.message.gemini` 重新检测语言，一旦本句是用户语言就 `hideSubtitle()`，导致 AI 回复被切成多条气泡时字幕反复闪掉。
2. **冗余链路**：React 聊天窗口已经常驻翻译开关（`composer-translate-btn`），但旧的注入式 `.subtitle-prompt-message` 链路（`detectLanguage` / `showSubtitlePrompt` / `checkAndShowSubtitlePrompt` / `translateMessageBubble`）仍然在跑，开关有两套状态。
3. **同语言强行清空**：`translateAndShowSubtitle` 中 `source_lang === target_lang` 的分支会 `hidden` 并清空 `subtitle-text`，把上一句翻译抹掉。
4. **`googleTranslateFailed` 只存前端 session 内存**：刷新即丢，下次请求又要等满 5 秒 Google 超时。
5. **`turn end agent_callback` 跳过翻译**：proactive / 语音热切换回合的字幕停在原文上不动。

## 改动

### 字幕机制：bubble 级 → turn 级常驻
- `static/subtitle.js` 全量重写：监听 `neko-assistant-turn-start` 清空字幕（**只在 turn 开始时**），`updateSubtitleStreamingText()` 跨气泡持续把整轮原文写入字幕，`translateAndShowSubtitle()` 仅在确实拿到不同语种译文时替换文本，否则保留原文不再清空。
- `static/app-chat.js` 在 `_geminiTurnFullText` 累加点喂给字幕（`-58 行`）。
- 删除 `checkAndShowSubtitlePrompt` / `showSubtitlePrompt` / `hideSubtitlePrompt` / `translateMessageBubble` / `detectLanguage` 全套 + 5 处调用 + `subtitleCheckDebounceTimer`。
- 删除 `.subtitle-prompt-message` 及其 dark-mode 变体 CSS。

### 双协议 turn 边界审计
确认 `OmniOfflineClient`（OpenAI 兼容）与 `OmniRealtimeClient`（Gemini Live / OpenAI Realtime）通过同一 `send_lanlan_response → gemini_response` WS 消息走完全对称路径（`isNewMessage` 复位 + `system: turn end` 终态）。前端 `app-websocket.js:367` `gemini_response` handler 无协议分支。

唯一漏网之鱼：`handle_proactive_complete()` 发的是 `system: turn end agent_callback`，前端 handler 此前只 emit `neko-assistant-turn-end` 不调翻译。已在 `app-websocket.js:978` 分支补上等价的字幕 finalization。

### 后端翻译降级链
`utils/language_utils.py`：
- **中文区直接走 `translatepy → LLM`**，不再尝试 Google（按实际可用性优化，避免每次都等满 5s 超时）
- **非中文区**新增进程级 `_google_translate_failed_flag`（线程安全，跨请求生效），Google 失败一次后本进程后续请求自动跳过；提供 `reset_google_translate_failure_flag()` 用于手动重置
- 前端不再需要传 `googleTranslateFailed`

## Test plan

- [ ] 文本模式 + 中文用户 + 英文 AI：单气泡 → 字幕显示原文 → turn end 替换为中文译文
- [ ] 文本模式 + 中文用户 + 英文 AI：多气泡（合并消息关闭，realistic queue 拆句）→ 每个新气泡到来时字幕**不闪不清空**，整轮累积 → turn end 才出译文
- [ ] 中文用户 + 中文 AI：字幕显示原文，**不会被强行清空**（旧 bug：source==target 时清空）
- [ ] 翻译开关 OFF → 字幕框完全隐藏；中途 ON → 当前 turn 已累积的原文立即补显并翻译
- [ ] 下一个 turn-start：字幕清空开始下一段
- [ ] 中文 Windows 系统：检查日志中文区翻译走 translatepy 不走 Google（即不再有 5s 超时等待）
- [ ] 海外网络 Google 失败：第一次失败后 backend 标记，后续请求日志 "已被标记不可用"
- [ ] 主动消息 / agent 任务回调（`task_result direct_reply`）：字幕同样得到翻译
- [ ] 语音模式：subtitle.html 浮窗的字幕跨气泡累积正确
- [ ] React composer 翻译开关按钮状态与 `appState.subtitleEnabled` 同步

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持消息生成过程中的实时流式字幕更新。

* **改进**
  * 将字幕交互从提示式改为持久显示，可通过界面直接控制显隐与翻译。
  * 在对话回合结束时自动触发并展示翻译结果，翻译仅在回合结束时替换原文。
  * 引入回合级翻译状态与请求取消，避免过期或重叠翻译结果。
  * 优化翻译失败处理，进程级别减少重复尝试。

* **样式调整**
  * 移除旧版字幕提示相关样式定义。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->