### PR TITLE
fix(subtitle): 修 turn_end 早停 vs 拟真 bubble 延迟的竞态 + markdown 占位 + 补 adapter 流式链路

### DIFF
--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -425,6 +425,13 @@
                 window._turnIsStructured = false;
                 window.currentTurnGeminiBubbles = [];
                 window.currentTurnGeminiAttachments = [];
+                // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
+                // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
+                // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
+                // 闸门，否则上一轮结束留下的 true 会把本轮首个 chunk 吞掉。
+                if (typeof window.beginSubtitleTurn === 'function') {
+                    window.beginSubtitleTurn();
+                }
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -178,16 +178,11 @@
         return S && S.mergeMessagesEnabled;
     }
 
-    // ======================== 结构化文本检测（从 app-chat.js 复刻） ========================
+    // ======================== 结构化文本检测（委托给共享 util） ========================
 
     function looksLikeStructuredRichText(text) {
-        var s = normalizeGeminiText(text || '');
-        return /```[\s\S]*```/.test(s)
-            || /(?:^|\n)```/.test(s)
-            || /\$\$[\s\S]*\$\$/.test(s)
-            || /(?<!\$)\$(?!\$)[^$\n]+(?<!\$)\$(?!\$)/.test(s)
-            || /(?:^|\n)\s{0,3}(?:#{1,6}\s|[-*+]\s|\d+\.\s|>\s)/.test(s)
-            || /(?:^|\n)\|.+\|.+(?:\n|\r\n)\|(?:[-: ]+\|){1,}/.test(s);
+        // 统一复用 app-chat-text-utils.js 里的唯一实现，避免与 DOM 路径分叉。
+        return window.appChatTextUtils.looksLikeStructuredRichText(text);
     }
 
     // ======================== 音乐指令清洗（从 app-chat.js 复刻） ========================

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -422,11 +422,27 @@
                 window._geminiTurnFullText = '';
                 window._pendingMusicCommand = '';
                 window._structuredGeminiStreaming = false;
+                window._turnIsStructured = false;
                 window.currentTurnGeminiBubbles = [];
                 window.currentTurnGeminiAttachments = [];
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);
+
+            // 常驻字幕流式写入（adapter 是生产常驻路径；PR #777 漏了这段，导致 React
+            // 聊天窗口下字幕只能等 turn_end 才首次出现，视觉上像"一口气显示"）。
+            // 结构化命中时改走 [markdown] 占位，turn_end 跳过翻译。
+            var streamingText = window._geminiTurnFullText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
+            if (!window._turnIsStructured && looksLikeStructuredRichText(streamingText)) {
+                window._turnIsStructured = true;
+            }
+            if (window._turnIsStructured) {
+                if (typeof window.markSubtitleStructured === 'function') {
+                    window.markSubtitleStructured();
+                }
+            } else if (typeof window.updateSubtitleStreamingText === 'function') {
+                window.updateSubtitleStreamingText(streamingText);
+            }
         }
 
         // ---------- gemini + realistic 模式 ----------

--- a/static/app-chat-text-utils.js
+++ b/static/app-chat-text-utils.js
@@ -1,0 +1,41 @@
+/**
+ * app-chat-text-utils.js — 聊天文本共享小工具
+ *
+ * 唯一职责：把 AI 文本的结构化富文本检测集中到一份实现。
+ * 之前 app-chat.js 和 app-chat-adapter.js 各自持有一份字面量一致的
+ * looksLikeStructuredRichText 拷贝（后者注释写着"从 app-chat.js 复刻"），
+ * 任何一边补规则、修误判、调顺序，两条路径（老 DOM 气泡 / React adapter）
+ * 就会对同一段文本给出不同的 window._turnIsStructured，字幕占位和 turn_end
+ * 收尾会从此分叉。（CodeRabbit nitpick on PR #778）
+ *
+ * 加载顺序：必须在 app-chat.js 和 app-chat-adapter.js 之前 include。
+ * 不 import subtitle.js / websocket 任何符号；本文件是叶子，不依赖其它业务模块。
+ */
+(function () {
+    'use strict';
+
+    // 归一化换行：CRLF → LF，保证下方正则在 Windows 输入下也稳定
+    function normalizeGeminiText(s) {
+        return (s || '').replace(/\r\n/g, '\n');
+    }
+
+    // 结构化富文本识别：命中任一则本轮字幕走 [markdown] 占位、turn_end 跳翻译。
+    // 覆盖：
+    //   - 代码块 ``` ... ``` / 行首 ```
+    //   - 块级 LaTeX $$ ... $$ / 行内单 $ ... $
+    //   - markdown 标题 / 列表 / 有序列表 / 引用
+    //   - markdown 表格（至少一行带分隔线 |---|---|）
+    function looksLikeStructuredRichText(text) {
+        var s = normalizeGeminiText(text || '');
+        return /```[\s\S]*```/.test(s)
+            || /(?:^|\n)```/.test(s)
+            || /\$\$[\s\S]*\$\$/.test(s)
+            || /(?<!\$)\$(?!\$)[^$\n]+(?<!\$)\$(?!\$)/.test(s)
+            || /(?:^|\n)\s{0,3}(?:#{1,6}\s|[-*+]\s|\d+\.\s|>\s)/.test(s)
+            || /(?:^|\n)\|.+\|.+(?:\n|\r\n)\|(?:[-: ]+\|){1,}/.test(s);
+    }
+
+    window.appChatTextUtils = window.appChatTextUtils || {};
+    window.appChatTextUtils.normalizeGeminiText = normalizeGeminiText;
+    window.appChatTextUtils.looksLikeStructuredRichText = looksLikeStructuredRichText;
+})();

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -716,13 +716,8 @@
         }
 
         function looksLikeStructuredRichText(text) {
-            var s = normalizeGeminiText(text || '');
-            return /```[\s\S]*```/.test(s)
-                || /(?:^|\n)```/.test(s)
-                || /\$\$[\s\S]*\$\$/.test(s)
-                || /(?<!\$)\$(?!\$)[^$\n]+(?<!\$)\$(?!\$)/.test(s)
-                || /(?:^|\n)\s{0,3}(?:#{1,6}\s|[-*+]\s|\d+\.\s|>\s)/.test(s)
-                || /(?:^|\n)\|.+\|.+(?:\n|\r\n)\|(?:[-: ]+\|){1,}/.test(s);
+            // 统一复用 app-chat-text-utils.js 里的唯一实现，避免与 adapter 路径分叉。
+            return window.appChatTextUtils.looksLikeStructuredRichText(text);
         }
 
         function renderStructuredGeminiMessage(fullText) {

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -788,6 +788,13 @@
                 // ========== 重置本轮气泡追踪 ==========
                 window.currentTurnGeminiBubbles = [];
                 window.currentTurnGeminiAttachments = [];
+                // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
+                // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
+                // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
+                // 闸门，否则上一轮结束留下的 true 会把本轮首个 chunk 吞掉。
+                if (typeof window.beginSubtitleTurn === 'function') {
+                    window.beginSubtitleTurn();
+                }
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -784,6 +784,7 @@
                 window._geminiTurnFullText = '';
                 window._pendingMusicCommand = '';
                 window._structuredGeminiStreaming = false;
+                window._turnIsStructured = false;
                 // ========== 重置本轮气泡追踪 ==========
                 window.currentTurnGeminiBubbles = [];
                 window.currentTurnGeminiAttachments = [];
@@ -791,10 +792,20 @@
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);
 
-            // 把整轮累积的原文流式写入字幕（常驻字幕，跨气泡持续显示）
-            // turn 结束时由 app-websocket.js 调用翻译替换；turn-start 事件清空
-            if (typeof window.updateSubtitleStreamingText === 'function') {
-                var streamingText = window._geminiTurnFullText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
+            // 结构化富文本（markdown / code / table / latex）→ 字幕显示 [markdown] 占位，
+            // 不再流式写原文，turn_end 也跳过翻译。检测命中后幂等，不会往回切。
+            var streamingText = window._geminiTurnFullText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
+            if (!window._turnIsStructured && looksLikeStructuredRichText(streamingText)) {
+                window._turnIsStructured = true;
+            }
+
+            if (window._turnIsStructured) {
+                if (typeof window.markSubtitleStructured === 'function') {
+                    window.markSubtitleStructured();
+                }
+            } else if (typeof window.updateSubtitleStreamingText === 'function') {
+                // 把整轮累积的原文流式写入字幕（常驻字幕，跨气泡持续显示）
+                // turn 结束时由 app-websocket.js 调用翻译替换；turn-start 事件清空
                 window.updateSubtitleStreamingText(streamingText);
             }
         }

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1033,6 +1033,13 @@
                         var fullText = (bufferedFullText && bufferedFullText.trim()) ? bufferedFullText : fallbackFromBubble;
                         fullText = fullText.replace(/\[play_music:[^\]]*(\]|$)/g, '').trim();
                         if (!fullText) return;
+                        // 结构化 turn（markdown/code/table/latex）→ 字幕收尾为 [markdown] 占位，不翻译
+                        if (window._turnIsStructured) {
+                            if (typeof window.finalizeSubtitleAsStructured === 'function') {
+                                try { window.finalizeSubtitleAsStructured(); } catch (_) {}
+                            }
+                            return;
+                        }
                         (async function () {
                             try {
                                 if (typeof window.translateAndShowSubtitle === 'function') {
@@ -1146,7 +1153,14 @@
                         }, 100);
 
                         // Frontend subtitle finalization: subtitle.js 内部根据开关决定是否
-                        // 真正发请求；不需要的语言会保留流式累积的原文，不会清空字幕
+                        // 真正发请求；不需要的语言会保留流式累积的原文，不会清空字幕。
+                        // 结构化 turn 收尾为 [markdown] 占位，跳过翻译链路。
+                        if (window._turnIsStructured) {
+                            if (typeof window.finalizeSubtitleAsStructured === 'function') {
+                                try { window.finalizeSubtitleAsStructured(); } catch (_) {}
+                            }
+                            return;
+                        }
                         (async function () {
                             try {
                                 if (typeof window.translateAndShowSubtitle === 'function') {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1705,7 +1705,8 @@
     "subtitle": {
         "title": "Real-time Subtitles",
         "enable": "Subtitle Translation",
-        "enableAriaLabel": "Toggle subtitle translation"
+        "enableAriaLabel": "Toggle subtitle translation",
+        "markdownPlaceholder": "[formatted content]"
     },
     "viewer": {
         "title": "Viewer - Project N.E.K.O."

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1705,7 +1705,8 @@
     "subtitle": {
         "title": "リアルタイム字幕",
         "enable": "字幕翻訳",
-        "enableAriaLabel": "字幕翻訳の切り替え"
+        "enableAriaLabel": "字幕翻訳の切り替え",
+        "markdownPlaceholder": "[整形済みコンテンツ]"
     },
     "viewer": {
         "title": "ビューアー - Project N.E.K.O."

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1705,7 +1705,8 @@
     "subtitle": {
         "title": "실시간 자막",
         "enable": "자막 번역",
-        "enableAriaLabel": "자막 번역 전환"
+        "enableAriaLabel": "자막 번역 전환",
+        "markdownPlaceholder": "[서식 있는 내용]"
     },
     "viewer": {
         "title": "뷰어 - 프로젝트 N.E.K.O."

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1705,7 +1705,8 @@
     "subtitle": {
         "title": "Субтитры в реальном времени",
         "enable": "Перевод субтитров",
-        "enableAriaLabel": "Переключить перевод субтитров"
+        "enableAriaLabel": "Переключить перевод субтитров",
+        "markdownPlaceholder": "[форматированный контент]"
     },
     "viewer": {
         "title": "Просмотр — Project N.E.K.O."

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1705,7 +1705,8 @@
     "subtitle": {
         "title": "实时字幕",
         "enable": "字幕翻译",
-        "enableAriaLabel": "字幕翻译开关"
+        "enableAriaLabel": "字幕翻译开关",
+        "markdownPlaceholder": "[格式化内容]"
     },
     "viewer": {
         "title": "Viewer - Project N.E.K.O."

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1705,7 +1705,8 @@
     "subtitle": {
         "title": "實時字幕",
         "enable": "字幕翻譯",
-        "enableAriaLabel": "字幕翻譯開關"
+        "enableAriaLabel": "字幕翻譯開關",
+        "markdownPlaceholder": "[格式化內容]"
     },
     "viewer": {
         "title": "Viewer - Project N.E.K.O."

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -101,6 +101,19 @@ let isCurrentTurnFinalized = false;
 // 当前 turn 是否判定为结构化富文本（markdown/code/table/latex 等）。
 // 结构化 turn 的字幕显示 [markdown] 占位符，不做翻译也不回落原文。
 let currentTurnIsStructured = false;
+// 闸门：标记"本轮 turn 边界已在 isNewMessage 路径被提前复位过"。
+// 背景：neko-assistant-turn-start 事件只在首个可见 bubble 创建后才派发，
+// 但 appendMessage 处理首个 chunk 时就已经调了 updateSubtitleStreamingText。
+// 没有这个闸门就会：
+//   a) isNewMessage 路径先调 updateSubtitleStreamingText → 被上一轮残留的
+//      isCurrentTurnFinalized=true 闸门吞掉，首个 chunk / 单 chunk 回复
+//      完全不上屏，直到 turn_end。（Codex P2 / CodeRabbit Major）
+//   b) 若仅在事件里复位，事件到达时已经过了首个 chunk，onAssistantTurnStart
+//      会把刚写好的字幕再 writeSubtitleText('') 抹掉，产生闪烁。
+// 解法：isNewMessage 入口立即 beginSubtitleTurn() 复位状态并拉高此闸门；
+// 稍后到来的 neko-assistant-turn-start 事件看到闸门已拉高，仅同步显示可见性，
+// 不再二次擦除 currentTurnOriginalText / 字幕文本。
+let turnBoundaryLatched = false;
 
 // 结构化/不可朗读内容的字幕占位符
 function getStructuredPlaceholder() {
@@ -208,10 +221,10 @@ function finalizeSubtitleAsStructured() {
 }
 
 /**
- * 新 turn 开始：清空当前字幕和翻译状态。
- * 由 'neko-assistant-turn-start' 事件触发。
+ * 纯状态复位：bump turnId、清空累积文本与闸门、取消在途翻译。
+ * 不动显示文本（调用方自行决定是否 writeSubtitleText('')）。
  */
-function onAssistantTurnStart() {
+function resetSubtitleTurnState() {
     currentTurnId += 1;
     currentTurnOriginalText = '';
     isCurrentTurnFinalized = false;
@@ -220,6 +233,41 @@ function onAssistantTurnStart() {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
     }
+}
+
+/**
+ * 供 app-chat.js / app-chat-adapter.js 在 isNewMessage 分支、首个
+ * updateSubtitleStreamingText 调用之前先行触发的复位入口。
+ *
+ * 为什么不能只靠事件：
+ *   neko-assistant-turn-start 事件要等 ensureAssistantTurnStarted 确认
+ *   首个可见气泡创建后才会派发（app-websocket.js:385），比首个 chunk
+ *   进入 appendMessage 晚一拍。如果只在事件里解锁，上一轮残留的
+ *   isCurrentTurnFinalized=true 会把本轮首个 chunk / 单 chunk 回复的
+ *   流式写入全部吞掉。
+ */
+function beginSubtitleTurn() {
+    resetSubtitleTurnState();
+    turnBoundaryLatched = true;
+}
+
+/**
+ * 'neko-assistant-turn-start' 事件处理：
+ *   - 如果 isNewMessage 路径已经 beginSubtitleTurn 过（闸门为真），只同步
+ *     显示可见性，不再二次抹字幕 —— 否则会把首个 chunk 已经写好的文本擦掉。
+ *   - 反之（事件在没有前置 isNewMessage 的通道上独立到达）走完整复位路径。
+ */
+function onAssistantTurnStart() {
+    if (turnBoundaryLatched) {
+        turnBoundaryLatched = false;
+        if (subtitleEnabled) {
+            ensureSubtitleVisibleIfEnabled();
+        } else {
+            hideSubtitle();
+        }
+        return;
+    }
+    resetSubtitleTurnState();
     // 开关开启时保留显示框（保持空白等待新文本），关闭时连框一起隐藏
     if (subtitleEnabled) {
         writeSubtitleText('');
@@ -556,6 +604,8 @@ window.subtitleBridge = {
         }
         localStorage.setItem('userLanguage', userLanguage);
     },
+    /** 供 app-chat.js / app-chat-adapter.js 在 isNewMessage 分支首个 chunk 前调用 */
+    beginTurn: beginSubtitleTurn,
     /** 供 app-chat.js 在 _geminiTurnFullText 累积时调用 */
     updateStreamingText: updateSubtitleStreamingText,
     /** 供 app-chat.js / app-chat-adapter.js 命中结构化富文本检测时调用 */
@@ -569,6 +619,7 @@ window.subtitleBridge = {
 // 向后兼容：保留全局函数名，但函数体已经精简
 window.translateAndShowSubtitle = translateAndShowSubtitle;
 window.updateSubtitleStreamingText = updateSubtitleStreamingText;
+window.beginSubtitleTurn = beginSubtitleTurn;
 window.markSubtitleStructured = markSubtitleStructured;
 window.finalizeSubtitleAsStructured = finalizeSubtitleAsStructured;
 window.getUserLanguage = getUserLanguage;

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -93,8 +93,25 @@ let currentTranslateAbortController = null;
 let currentTurnId = 0;
 let currentTranslationRequestId = 0;
 // 当前 turn 是否已收到 turn-end（即 translateAndShowSubtitle 被调用过）。
-// 用于 toggle 开启时判断要不要对当前缓存发起翻译；流式途中不会标记 true。
+// 用途：
+//   1. toggle 开启时判断要不要对当前缓存发起翻译；流式途中不会标记 true。
+//   2. 防止"早停的 turn_end 已 finalize → 延迟渲染的拟真 bubble / 迟到 chunk
+//      又回来调 updateSubtitleStreamingText 把字幕刷回原文"的竞态（PR #778 修复）。
 let isCurrentTurnFinalized = false;
+// 当前 turn 是否判定为结构化富文本（markdown/code/table/latex 等）。
+// 结构化 turn 的字幕显示 [markdown] 占位符，不做翻译也不回落原文。
+let currentTurnIsStructured = false;
+
+// 结构化/不可朗读内容的字幕占位符
+function getStructuredPlaceholder() {
+    try {
+        if (typeof window.t === 'function') {
+            const translated = window.t('subtitle.markdownPlaceholder');
+            if (translated && translated !== 'subtitle.markdownPlaceholder') return translated;
+        }
+    } catch (e) { /* i18n 未就绪时静默回落 */ }
+    return '[markdown]';
+}
 
 /**
  * 内部：把字幕显示元素切换到“可见”状态（如果开关开启）
@@ -134,8 +151,16 @@ function writeSubtitleText(text) {
  * 流式更新：本回合 AI 文本累积时调用。
  * 立即把原文显示到字幕里，跨多个气泡持续写入。
  * 仅在字幕开关开启时才上屏，但内部状态始终维护，方便用户中途打开开关时直接补显。
+ *
+ * 竞态保护（PR #778）：
+ *   - 已 finalize（收到 turn_end，翻译已起）后，丢弃后续流式写入，避免
+ *     拟真模式 2s/气泡延迟导致的"迟到 bubble 把已翻译字幕刷回原文"。
+ *   - 已判定为结构化的 turn 不接受原文写入，继续维持 [markdown] 占位。
  */
 function updateSubtitleStreamingText(text) {
+    if (isCurrentTurnFinalized) return;
+    if (currentTurnIsStructured) return;
+
     const cleaned = (text || '').toString();
     currentTurnOriginalText = cleaned;
 
@@ -147,6 +172,42 @@ function updateSubtitleStreamingText(text) {
 }
 
 /**
+ * 把当前 turn 切换成"结构化富文本"显示模式：字幕显示 [markdown] 占位符，
+ * 后续的 updateSubtitleStreamingText 不再覆盖它，turn_end 也会跳过翻译。
+ *
+ * 场景：本回合文本里检测到 markdown/table/code block/latex 等不适合朗读的结构。
+ * 由 app-chat.js / app-chat-adapter.js 在 looksLikeStructuredRichText 命中时调用。
+ */
+function markSubtitleStructured() {
+    if (isCurrentTurnFinalized) return;
+    if (currentTurnIsStructured) return; // 已是结构化，幂等
+    currentTurnIsStructured = true;
+    const placeholder = getStructuredPlaceholder();
+    currentTurnOriginalText = placeholder;
+    if (!subtitleEnabled) return;
+    ensureSubtitleVisibleIfEnabled();
+    writeSubtitleText(placeholder);
+}
+
+/**
+ * turn_end 终态收尾（结构化版）：标记 finalize，只显示 [markdown] 占位，
+ * 不发翻译请求。等价于 translateAndShowSubtitle 的结构化分支。
+ */
+function finalizeSubtitleAsStructured() {
+    isCurrentTurnFinalized = true;
+    currentTurnIsStructured = true;
+    if (currentTranslateAbortController) {
+        currentTranslateAbortController.abort();
+        currentTranslateAbortController = null;
+    }
+    const placeholder = getStructuredPlaceholder();
+    currentTurnOriginalText = placeholder;
+    if (!subtitleEnabled) return;
+    ensureSubtitleVisibleIfEnabled();
+    writeSubtitleText(placeholder);
+}
+
+/**
  * 新 turn 开始：清空当前字幕和翻译状态。
  * 由 'neko-assistant-turn-start' 事件触发。
  */
@@ -154,6 +215,7 @@ function onAssistantTurnStart() {
     currentTurnId += 1;
     currentTurnOriginalText = '';
     isCurrentTurnFinalized = false;
+    currentTurnIsStructured = false;
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
@@ -176,11 +238,18 @@ async function translateAndShowSubtitle(text) {
         return;
     }
 
+    // 结构化 turn 走占位符分支：不翻译，不写原文，避免把大段 markdown/code 送去 LLM
+    if (currentTurnIsStructured) {
+        finalizeSubtitleAsStructured();
+        return;
+    }
+
     // 快照本次请求归属的 turn 与 request 序号。响应回来时必须跟当前值匹配，
     // 否则说明已被新 turn / 新请求抢占（哪怕原文字面量相同也要丢弃）。
     const requestTurnId = currentTurnId;
     const requestId = ++currentTranslationRequestId;
-    // 收到 turn-end 才算当前 turn 已结算
+    // 收到 turn-end 才算当前 turn 已结算；此后 updateSubtitleStreamingText 的
+    // 迟到调用会被丢弃，避免被延迟渲染的拟真 bubble 刷回原文（PR #778 修复）。
     isCurrentTurnFinalized = true;
 
     if (userLanguage === null) {
@@ -489,6 +558,10 @@ window.subtitleBridge = {
     },
     /** 供 app-chat.js 在 _geminiTurnFullText 累积时调用 */
     updateStreamingText: updateSubtitleStreamingText,
+    /** 供 app-chat.js / app-chat-adapter.js 命中结构化富文本检测时调用 */
+    markStructured: markSubtitleStructured,
+    /** 供 app-websocket.js 在结构化 turn 的 turn end 时调用（跳过翻译） */
+    finalizeAsStructured: finalizeSubtitleAsStructured,
     /** 供 app-websocket.js 在 turn end 时调用 */
     finalizeTurnWithTranslation: translateAndShowSubtitle
 };
@@ -496,4 +569,6 @@ window.subtitleBridge = {
 // 向后兼容：保留全局函数名，但函数体已经精简
 window.translateAndShowSubtitle = translateAndShowSubtitle;
 window.updateSubtitleStreamingText = updateSubtitleStreamingText;
+window.markSubtitleStructured = markSubtitleStructured;
+window.finalizeSubtitleAsStructured = finalizeSubtitleAsStructured;
 window.getUserLanguage = getUserLanguage;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -471,6 +471,7 @@
     <!-- app 模块（与 index.html 完全相同的加载顺序）-->
     <script src="/static/app-state.js"></script>
     <script src="/static/app-ui.js"></script>
+    <script src="/static/app-chat-text-utils.js"></script>
     <script src="/static/app-chat.js"></script>
     <script src="/static/app-chat-avatar.js"></script>
     <script src="/static/app-audio-playback.js"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -252,6 +252,7 @@
     <!-- app 解构模块 -->
     <script src="/static/app-state.js"></script>
     <script src="/static/app-ui.js"></script>
+    <script src="/static/app-chat-text-utils.js"></script>
     <script src="/static/app-chat.js"></script>
     <script src="/static/app-chat-avatar.js"></script>
     <script src="/static/app-chat-adapter.js"></script>


### PR DESCRIPTION
延续 #777。经测试定位到字幕的竞态 + 拟真模式流式缺口，一起修。

## 问题（PR #777 遗留）

1. **早停 turn_end vs 延迟 bubble 的竞态**：拟真模式下气泡按 2s/条节流渲染，但服务端 `turn end` 在 AI 文本结束的瞬间就到。`translateAndShowSubtitle` 把字幕替换成译文后，队列里的迟到 bubble 仍在触发 `isNewMessage` / `_flushPendingRealisticQueue`，导致后续的迟到 `updateSubtitleStreamingText` 又把字幕刷回原文（严重时只剩末尾那条孤立 bubble 的片段）。
2. **React 聊天窗口路径没有流式字幕**：React 聊天窗口走 `app-chat-adapter.js`，但 PR #777 的 `updateSubtitleStreamingText` 只加在 `app-chat.js` 里，adapter 路径完全没写。实际生产效果：字幕要等 `turn_end` 才第一次出现，视觉上就是"一口气显示"——和 #777 的目标完全相反。
3. **结构化富文本被当原文翻译**：markdown / code block / table / latex 被原样塞进字幕再送去 `/api/translate`，既乱码又浪费 token。
4. **music / image**：`[play_music:...]` 已有清洗链路；image / link card 走附件通道不进文本流，本身不污染字幕。无需额外动。

## 修复

1. **`subtitle.js` 新增 `isCurrentTurnFinalized` 竞态闸门**：`translateAndShowSubtitle` 入口即置 `true`，之后所有 `updateSubtitleStreamingText` 的迟到调用直接丢弃。`onAssistantTurnStart` 复位。
2. **`subtitle.js` 新增 `currentTurnIsStructured` + `markSubtitleStructured` / `finalizeSubtitleAsStructured`**：结构化 turn 字幕显示 `[markdown]` 占位（i18n key `subtitle.markdownPlaceholder`，6 种语言都补了本地化翻译），`turn_end` 跳过翻译。
3. **`app-chat-adapter.js` 补齐 `updateSubtitleStreamingText` 链路**，与 `app-chat.js` 同源：在 `_geminiTurnFullText` 累加后按 `looksLikeStructuredRichText` 分流（结构化 → `markSubtitleStructured`；否则 → `updateSubtitleStreamingText`）。`_turnIsStructured` 在 `isNewMessage` 时复位，保证新 turn 不继承旧判定。
4. **`app-websocket.js` 两个 turn_end 分支**（`turn end` / `turn_end_agent_callback`）在调 `translateAndShowSubtitle` 前检查 `window._turnIsStructured`，命中则走 `finalizeSubtitleAsStructured` 收尾，不发翻译请求。
5. **`translateAndShowSubtitle` 入口再加一层结构化短路**：即便调用者忘了判，也不会把 markdown 送去 `/api/translate`。

## Test plan

- [ ] 拟真模式（关 mergeMessages）：长回复 + 末尾孤立句子；观察 `turn_end` 译文定稿后，迟到的末句 bubble 渲染不再把字幕刷回原文。
- [ ] React 聊天窗口（adapter 常驻路径）：字幕在流式途中就应按原文滚动出现，而不是等到 `turn_end`。
- [ ] 合并消息模式：原文流式更新 + `turn_end` 译文替换，行为不变。
- [ ] Markdown 回合（代码块 / 表格 / `$latex$` / `#` 标题）：字幕显示 `[格式化内容]` 占位，不会残留原文；`turn_end` 不发翻译请求。
- [ ] 主动搭话 / 热切换回调（`turn end agent_callback`）路径：结构化占位 + 非结构化翻译两条分支都生效。
- [ ] `subtitleBridge.toggle` 流式途中开/关：结构化 turn 开关时显示占位；普通 turn 未 finalize 时跟随流式，已 finalize 时补发翻译——行为同 #777。

https://claude.ai/code/session_01JVUnycxErW27utYNmSP2xb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 实时字幕增强：引入共享文本检测工具，提高对结构化/富文本的识别；检测到结构化内容时改为占位显示并跳过逐字翻译与流式替换，防止被覆写或延迟。
  * 回合控制优化：在回合开始和流式过程中引入回合开启/标记/完成机制，改善首个流式片段的显示稳定性。

* **国际化**
  * 为字幕界面新增“格式化内容”占位文本并更新多语言翻译条目。

* **部署**
  * 客户端新增文本检测脚本并调整加载顺序以确保共用工具可用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->