### PR TITLE
fix: chat.html 多窗口下 proactive 同时触发 + 音乐播放竞态

### DIFF
--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -433,10 +433,18 @@
     window.dispatchMusicPlay = async function (trackInfo, options) {
         options = options || {};
 
-        // 拦截逻辑：如果是主动搭话触发的切歌，且当前正在放歌，则拦截
-        if (options.source === 'proactive' && typeof window.isMusicPlaying === 'function' && window.isMusicPlaying()) {
-            console.log('[MusicDispatch] 拦截来自主动搭话的切歌请求，保持当前播放');
-            return false;
+        // 拦截逻辑：如果是主动搭话触发的切歌，且本地正在放歌 / 加载中 /
+        // 其他窗口（chat.html 与 index.html 互为兄弟）也在放歌，则拦截。
+        // 单纯的 isMusicPlaying() 在"已 dispatch 但 audio 还没 play"的窗口里
+        // 会返回 false，导致并发的第二次 dispatch 被放行，最终两首歌同时响。
+        if (options.source === 'proactive') {
+            var localPlaying = typeof window.isMusicPlaying === 'function' && window.isMusicPlaying();
+            var localPending = typeof window.isMusicPending === 'function' && window.isMusicPending();
+            var remoteActive = typeof window.isRemoteMusicActive === 'function' && window.isRemoteMusicActive();
+            if (localPlaying || localPending || remoteActive) {
+                console.log('[MusicDispatch] 拦截来自主动搭话的切歌请求 (playing=' + localPlaying + ', pending=' + localPending + ', remote=' + remoteActive + ')');
+                return false;
+            }
         }
 
         if (!trackInfo || !trackInfo.url) {

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -437,6 +437,11 @@
         // 其他窗口（chat.html 与 index.html 互为兄弟）也在放歌，则拦截。
         // 单纯的 isMusicPlaying() 在"已 dispatch 但 audio 还没 play"的窗口里
         // 会返回 false，导致并发的第二次 dispatch 被放行，最终两首歌同时响。
+        //
+        // 注意：这是有意的不对称拦截 —— 仅 source==='proactive'（主动搭话）
+        // 的推荐会被当前播放拦下；用户主动搜索、插件 music_play_url、
+        // [play_music:] 指令等（app-websocket.js 的 dispatchMusicPlay 调用不带
+        // source 字段）仍允许直接切歌。用户/插件意图 > 被动推荐。
         if (options.source === 'proactive') {
             var localPlaying = typeof window.isMusicPlaying === 'function' && window.isMusicPlaying();
             var localPending = typeof window.isMusicPending === 'function' && window.isMusicPending();

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -446,8 +446,9 @@
             var localPlaying = typeof window.isMusicPlaying === 'function' && window.isMusicPlaying();
             var localPending = typeof window.isMusicPending === 'function' && window.isMusicPending();
             var remoteActive = typeof window.isRemoteMusicActive === 'function' && window.isRemoteMusicActive();
-            if (localPlaying || localPending || remoteActive) {
-                console.log('[MusicDispatch] 拦截来自主动搭话的切歌请求 (playing=' + localPlaying + ', pending=' + localPending + ', remote=' + remoteActive + ')');
+            var rateLimited = typeof window.isMusicRecommendRateLimited === 'function' && window.isMusicRecommendRateLimited();
+            if (localPlaying || localPending || remoteActive || rateLimited) {
+                console.log('[MusicDispatch] 拦截来自主动搭话的切歌请求 (playing=' + localPlaying + ', pending=' + localPending + ', remote=' + remoteActive + ', rateLimited=' + rateLimited + ')');
                 return false;
             }
         }
@@ -461,6 +462,10 @@
 
         if (window.sendMusicMessage) {
             var accepted = await window.sendMusicMessage(trackInfo);
+            // proactive 来源成功派发后打上限流时间戳，阻止接下来 18s 内的再次 proactive 推荐
+            if (accepted && options.source === 'proactive' && typeof window.markProactiveMusicRecommended === 'function') {
+                window.markProactiveMusicRecommended();
+            }
             return accepted; // 返回布尔值表示是否成功派发
         } else {
             console.warn('[MusicDispatch] sendMusicMessage \u5C1A\u672A\u5C31\u7EEA\uFF0C\u542F\u52A8\u7B49\u5F85 (ID: ' + currentDispatchId + ')...');

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -147,18 +147,24 @@
         console.log('[Proactive] 主备状态切换：自己现在' + (nowLeader ? '是 leader（开始调度 proactive_chat / vision）' : '是 follower（停止调度，等待 leader 失联）'));
         if (nowLeader) {
             // 接班：立刻安排一次 proactive_chat
-            try { scheduleProactiveChat(); } catch (_) {}
+            try { scheduleProactiveChat(); } catch (e) {
+                console.warn('[Proactive] 接班时调度 proactive_chat 失败:', e);
+            }
             // 接班：如果当前正在录音，启动 vision-during-speech
             try {
                 if (S.isRecording) startProactiveVisionDuringSpeech();
-            } catch (_) {}
+            } catch (e) {
+                console.warn('[Proactive] 接班时启动 vision-during-speech 失败:', e);
+            }
         } else {
             // 让位：清掉本地 proactive 定时器和 vision 心跳
             if (S.proactiveChatTimer) {
                 clearTimeout(S.proactiveChatTimer);
                 S.proactiveChatTimer = null;
             }
-            try { stopProactiveVisionDuringSpeech(); } catch (_) {}
+            try { stopProactiveVisionDuringSpeech(); } catch (e) {
+                console.warn('[Proactive] 让位时停止 vision-during-speech 失败:', e);
+            }
         }
     }
 

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -22,6 +22,172 @@
     const S = window.appState;
     const C = window.appConst;
 
+    // ======================== proactive leader election ========================
+    //
+    // 背景：index.html（Pet 主窗口）和 chat.html（聊天浮窗）共用 app-proactive.js，
+    // 各自跑 setTimeout 调度，会同时发 /api/proactive_chat 请求 / 推屏幕帧。
+    // 后端把它们当两次独立请求处理，结果双倍 LLM 调用、双倍音乐推荐、双倍 vision 帧。
+    //
+    // 约定：Pet (index.html) 为主，chat.html 为从。同时存活时只有 Pet 跑调度；
+    // Pet 关闭后 chat.html 通过 TTL 自动接班。
+    //
+    // 协议：广播 'neko_proactive_leader'。每 5s 心跳，15s TTL。
+    // rank 越小越优先：Pet=0, chat.html=1, 其它页面=99（不参与）。
+    //
+    const PROACTIVE_LEADER_CHANNEL = 'neko_proactive_leader';
+    const PROACTIVE_LEADER_HEARTBEAT_MS = 5000;
+    const PROACTIVE_LEADER_TTL_MS = 15000;
+    const PROACTIVE_LEADER_RECHECK_MS = 8000; // 非 leader 的自检周期
+
+    const PROACTIVE_SELF_ID = (Date.now().toString(36) + Math.random().toString(36).slice(2, 10));
+
+    function _computeSelfRank() {
+        try {
+            const path = (window.location && window.location.pathname) || '';
+            // chat.html 浮窗 → 从节点
+            if (path === '/chat') return 1;
+            // 不参与 proactive 的页面（model_manager / jukebox / subtitle / agenthud / toast / cookies_login 等）
+            // 它们本来就不加载 app-proactive.js，但保险起见显式归类为不参与
+            if (
+                path === '/model_manager' || path === '/l2d' ||
+                path === '/live2d_parameter_editor' || path === '/jukebox' ||
+                path === '/jukebox/manager' || path === '/subtitle' ||
+                path === '/agenthud' || path === '/toast'
+            ) return 99;
+            // 其它（/、/{lanlan_name}）一律视为 Pet 主窗口
+            return 0;
+        } catch (_) {
+            return 0;
+        }
+    }
+    const PROACTIVE_SELF_RANK = _computeSelfRank();
+
+    // peer_id -> { rank, expireAt }
+    const _proactivePeers = new Map();
+    let _proactiveLeaderChannel = null;
+    let _proactiveLeaderHeartbeatTimer = null;
+    let _wasLeaderLastTick = null; // 用于 leader 状态切换时主动 reschedule
+
+    try {
+        if (typeof BroadcastChannel !== 'undefined' && PROACTIVE_SELF_RANK !== 99) {
+            _proactiveLeaderChannel = new BroadcastChannel(PROACTIVE_LEADER_CHANNEL);
+            _proactiveLeaderChannel.onmessage = function (event) {
+                const data = event && event.data;
+                if (!data || typeof data !== 'object') return;
+                if (!data.id || data.id === PROACTIVE_SELF_ID) return;
+                if (data.type === 'announce' || data.type === 'heartbeat') {
+                    const isNewPeer = !_proactivePeers.has(data.id);
+                    _proactivePeers.set(data.id, {
+                        rank: typeof data.rank === 'number' ? data.rank : 99,
+                        expireAt: Date.now() + PROACTIVE_LEADER_TTL_MS
+                    });
+                    // 新 peer 上线：立即回一个 heartbeat，让它在第一次决策前就能感知到我，
+                    // 避免新窗口在 announce 后的"无人响应"窗口里误以为只有自己。
+                    if (data.type === 'announce') {
+                        _proactiveBroadcast('heartbeat');
+                    }
+                    // 拓扑变化（新 peer 或 announce）时重新评估自己的角色
+                    if (isNewPeer || data.type === 'announce') {
+                        _onProactiveLeadershipMaybeChanged();
+                    }
+                } else if (data.type === 'goodbye') {
+                    _proactivePeers.delete(data.id);
+                    _onProactiveLeadershipMaybeChanged();
+                }
+            };
+        }
+    } catch (e) {
+        console.log('[Proactive] BroadcastChannel 不可用，主备协调失效:', e);
+    }
+
+    function _proactiveBroadcast(type) {
+        if (!_proactiveLeaderChannel) return;
+        try {
+            _proactiveLeaderChannel.postMessage({
+                type: type || 'heartbeat',
+                id: PROACTIVE_SELF_ID,
+                rank: PROACTIVE_SELF_RANK,
+                ts: Date.now()
+            });
+        } catch (_) { /* ignore */ }
+    }
+
+    function _purgeStaleProactivePeers() {
+        const now = Date.now();
+        let removed = false;
+        for (const [id, info] of _proactivePeers) {
+            if (now > info.expireAt) {
+                _proactivePeers.delete(id);
+                removed = true;
+            }
+        }
+        return removed;
+    }
+
+    function isProactiveLeader() {
+        if (PROACTIVE_SELF_RANK === 99) return false; // 不参与的页面永远不是
+        _purgeStaleProactivePeers();
+        // 找出存活节点中最优 rank（含自己），同 rank 时 ID 字典序小者胜
+        let bestRank = PROACTIVE_SELF_RANK;
+        let bestId = PROACTIVE_SELF_ID;
+        for (const [id, info] of _proactivePeers) {
+            if (info.rank < bestRank || (info.rank === bestRank && id < bestId)) {
+                bestRank = info.rank;
+                bestId = id;
+            }
+        }
+        return bestId === PROACTIVE_SELF_ID;
+    }
+    mod.isProactiveLeader = isProactiveLeader;
+
+    function _onProactiveLeadershipMaybeChanged() {
+        const nowLeader = isProactiveLeader();
+        if (_wasLeaderLastTick === nowLeader) return;
+        _wasLeaderLastTick = nowLeader;
+        console.log('[Proactive] 主备状态切换：自己现在' + (nowLeader ? '是 leader（开始调度 proactive_chat / vision）' : '是 follower（停止调度，等待 leader 失联）'));
+        if (nowLeader) {
+            // 接班：立刻安排一次 proactive_chat
+            try { scheduleProactiveChat(); } catch (_) {}
+            // 接班：如果当前正在录音，启动 vision-during-speech
+            try {
+                if (S.isRecording && typeof startProactiveVisionDuringSpeech === 'function') {
+                    startProactiveVisionDuringSpeech();
+                }
+            } catch (_) {}
+        } else {
+            // 让位：清掉本地 proactive 定时器和 vision 心跳
+            if (S.proactiveChatTimer) {
+                clearTimeout(S.proactiveChatTimer);
+                S.proactiveChatTimer = null;
+            }
+            try {
+                if (typeof stopProactiveVisionDuringSpeech === 'function') {
+                    stopProactiveVisionDuringSpeech();
+                }
+            } catch (_) {}
+        }
+    }
+
+    // 启动：先 announce 一下，再周期性 heartbeat
+    if (_proactiveLeaderChannel) {
+        _proactiveBroadcast('announce');
+        _proactiveLeaderHeartbeatTimer = setInterval(function () {
+            _proactiveBroadcast('heartbeat');
+            // 心跳节奏顺手扫一下过期 peer，防止 leader 被关掉后 follower 不知情
+            if (_purgeStaleProactivePeers()) {
+                _onProactiveLeadershipMaybeChanged();
+            }
+        }, PROACTIVE_LEADER_HEARTBEAT_MS);
+        // 窗口关闭前广播 goodbye，让对端立即接班
+        window.addEventListener('beforeunload', function () {
+            _proactiveBroadcast('goodbye');
+            if (_proactiveLeaderHeartbeatTimer) {
+                clearInterval(_proactiveLeaderHeartbeatTimer);
+                _proactiveLeaderHeartbeatTimer = null;
+            }
+        });
+    }
+
     // ======================== screen-capture helpers (delegate to app-screen.js) ========================
 
     function captureCanvasFrame(video, jpegQuality, detectBlack) {
@@ -121,6 +287,15 @@
             clearTimeout(S.proactiveChatTimer);
             S.proactiveChatTimer = null;
         }
+
+        // 主备协调：非 leader 不调度，只挂一个轻量的 recheck，
+        // 一旦 leader 失联（peer 过期）就自动接班。
+        if (!isProactiveLeader()) {
+            console.log('[Proactive] 当前不是 leader，跳过调度，等待接班 (rank=' + PROACTIVE_SELF_RANK + ')');
+            S.proactiveChatTimer = setTimeout(scheduleProactiveChat, PROACTIVE_LEADER_RECHECK_MS);
+            return;
+        }
+        _wasLeaderLastTick = true;
 
         // 必须开启主动搭话且选择至少一种搭话方式才启动调度
         if (!S.proactiveChatEnabled || !hasAnyChatModeEnabled()) {
@@ -244,6 +419,12 @@
 
     async function triggerProactiveChat() {
         try {
+            // 主备协调：本窗口非 leader 时不触发，避免和 Pet 主窗口重复发请求。
+            // 这里再 guard 一次是为了防止 leader 切换后旧定时器仍然触发。
+            if (!isProactiveLeader()) {
+                console.log('[ProactiveChat] 当前不是 leader，跳过触发');
+                return;
+            }
             // 「请她离开」状态下不触发
             if (isGoodbyeActive()) {
                 console.log('[ProactiveChat] goodbye 状态，跳过本次触发');
@@ -925,6 +1106,13 @@
             S.proactiveVisionFrameTimer = null;
         }
 
+        // 主备协调：proactive vision 也由 Pet 主窗口负责，chat.html 不参与。
+        // 否则两个窗口都会向后端推屏幕帧，带宽和 LLM 调用翻倍。
+        if (!isProactiveLeader()) {
+            console.log('[ProactiveVision] 当前不是 leader，跳过启动');
+            return;
+        }
+
         // 「请她离开」状态下禁止启动
         if (isGoodbyeActive()) {
             return;
@@ -938,6 +1126,11 @@
         S.proactiveVisionFrameTimer = setInterval(async function () {
             // 在每次执行前再做一次检查，避免竞态
             if (!S.proactiveVisionEnabled || !S.isRecording || isGoodbyeActive()) {
+                stopProactiveVisionDuringSpeech();
+                return;
+            }
+            // leader 切换的兜底：发帧前再核对一次
+            if (!isProactiveLeader()) {
                 stopProactiveVisionDuringSpeech();
                 return;
             }
@@ -1137,6 +1330,7 @@
     window.acquireProactiveVisionStream = acquireProactiveVisionStream;
     window.releaseProactiveVisionStream = releaseProactiveVisionStream;
     window.scheduleProactiveChat = scheduleProactiveChat;
+    window.isProactiveLeader = isProactiveLeader;
     window.captureCanvasFrame = captureCanvasFrame;
     window.fetchBackendScreenshot = fetchBackendScreenshot;
     window.scheduleScreenCaptureIdleCheck = scheduleScreenCaptureIdleCheck;

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -150,9 +150,7 @@
             try { scheduleProactiveChat(); } catch (_) {}
             // 接班：如果当前正在录音，启动 vision-during-speech
             try {
-                if (S.isRecording && typeof startProactiveVisionDuringSpeech === 'function') {
-                    startProactiveVisionDuringSpeech();
-                }
+                if (S.isRecording) startProactiveVisionDuringSpeech();
             } catch (_) {}
         } else {
             // 让位：清掉本地 proactive 定时器和 vision 心跳
@@ -160,11 +158,7 @@
                 clearTimeout(S.proactiveChatTimer);
                 S.proactiveChatTimer = null;
             }
-            try {
-                if (typeof stopProactiveVisionDuringSpeech === 'function') {
-                    stopProactiveVisionDuringSpeech();
-                }
-            } catch (_) {}
+            try { stopProactiveVisionDuringSpeech(); } catch (_) {}
         }
     }
 

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -51,6 +51,85 @@
     let aplayerLoadPromise = null;
     let latestMusicRequestToken = 0;
 
+    // --- 竞态保护：dispatch 入口的"加载中"标记 ---
+    // sendMusicMessage 的 URL 校验/库加载阶段对外暴露，避免并发 dispatch 在
+    // 真正的 audio 还未启动时绕过 isMusicPlaying() 拦截。
+    let musicDispatchPending = false;
+
+    // --- 竞态保护：executePlay 串行化 ---
+    // 两个并发 executePlay 在 await initializeAPlayer 期间会同时把
+    // currentPlayingTrack / musicCardMessageId 覆盖一次，第一个实例还会
+    // 残留一个未受控的 <audio>。用 Promise 链把它们排成单线。
+    let executePlayChain = Promise.resolve();
+
+    // --- 跨窗口协调：当多个窗口（index.html + chat.html）同时开了主动搭话时，
+    // 它们各自的播放器都会响应自己的 proactive_chat 响应。即使本地不在播，
+    // 远程窗口可能正在播；用一个独立 BroadcastChannel 互相通报，
+    // dispatchMusicPlay 在 source==='proactive' 时把远程视作"已占用"。 ---
+    const MUSIC_COORD_SENDER_ID = (Date.now().toString(36) + Math.random().toString(36).slice(2, 10));
+    const REMOTE_MUSIC_TTL_MS = 30 * 1000; // 心跳超时
+    // sender_id -> expireAt
+    const remoteMusicSenders = new Map();
+    let musicCoordChannel = null;
+    try {
+        if (typeof BroadcastChannel !== 'undefined') {
+            musicCoordChannel = new BroadcastChannel('neko_music_coord');
+            musicCoordChannel.onmessage = (event) => {
+                const data = event && event.data;
+                if (!data || typeof data !== 'object') return;
+                const sid = data.sender;
+                if (!sid || sid === MUSIC_COORD_SENDER_ID) return;
+                if (data.type === 'music_started' || data.type === 'music_heartbeat') {
+                    remoteMusicSenders.set(sid, Date.now() + REMOTE_MUSIC_TTL_MS);
+                } else if (data.type === 'music_ended') {
+                    remoteMusicSenders.delete(sid);
+                }
+            };
+        }
+    } catch (e) {
+        console.log('[Music UI] BroadcastChannel 不可用，跨窗口协调失效:', e);
+    }
+
+    const broadcastMusicCoord = (type) => {
+        if (!musicCoordChannel) return;
+        try {
+            musicCoordChannel.postMessage({ type, sender: MUSIC_COORD_SENDER_ID, ts: Date.now() });
+        } catch (_) { /* ignore */ }
+    };
+
+    // 心跳：当本地正在播时定期广播，防止其他窗口误以为对方已退出
+    let musicHeartbeatTimer = null;
+    const startMusicHeartbeat = () => {
+        if (musicHeartbeatTimer) return;
+        musicHeartbeatTimer = setInterval(() => {
+            try {
+                if (localPlayer && localPlayer.audio && !localPlayer.audio.paused) {
+                    broadcastMusicCoord('music_heartbeat');
+                } else {
+                    stopMusicHeartbeat();
+                }
+            } catch (_) {
+                stopMusicHeartbeat();
+            }
+        }, 10 * 1000);
+    };
+    const stopMusicHeartbeat = () => {
+        if (musicHeartbeatTimer) {
+            clearInterval(musicHeartbeatTimer);
+            musicHeartbeatTimer = null;
+        }
+    };
+
+    const isRemoteMusicActive = () => {
+        if (remoteMusicSenders.size === 0) return false;
+        const now = Date.now();
+        // 顺手清理已过期的 sender
+        for (const [sid, exp] of remoteMusicSenders) {
+            if (now > exp) remoteMusicSenders.delete(sid);
+        }
+        return remoteMusicSenders.size > 0;
+    };
+
     // --- 更新 React 聊天窗口音乐卡片 ---
     const updateMusicCard = (state, track) => {
         const host = window.reactChatWindowHost;
@@ -387,6 +466,10 @@
         }
         currentPlayingTrack = null;
         musicCardMessageId = null;
+
+        // 跨窗口协调：通知其他窗口本地音乐已停
+        stopMusicHeartbeat();
+        broadcastMusicCoord('music_ended');
     };
 
     // --- 查找并替换整个 loadAPlayerLibrary 函数 ---
@@ -446,7 +529,19 @@
 
     // --- 5. 播放器挂载逻辑 (支持原地更新与实例复用) ---
     // 核心逻辑：复用 APlayer 实例可以保留浏览器的“音频解锁”状态，极大提高自动播放成功率
-    const executePlay = async (trackInfo, currentToken, shouldAutoPlay = true) => {
+    //
+    // 【串行化】两次并发调用如果同时进入 needsInit 分支，会同时 await initializeAPlayer，
+    // 都拿到自己的实例后写 currentPlayingTrack/musicCardMessageId，第一份卡片
+    // 会被第二份盖掉，被覆盖的实例如果 destroy 不及时还会残留 <audio>。
+    // 用 executePlayChain 把所有 executePlay 排成单线，保证内部 await 不会被抢跑。
+    const executePlay = (trackInfo, currentToken, shouldAutoPlay = true) => {
+        const run = () => executePlayCore(trackInfo, currentToken, shouldAutoPlay);
+        const next = executePlayChain.then(run, run); // 即使前一次 reject 也继续
+        executePlayChain = next.catch(() => { /* 链路自愈，避免 rejection 阻断后续 */ });
+        return next;
+    };
+
+    const executePlayCore = async (trackInfo, currentToken, shouldAutoPlay = true) => {
         if (currentToken !== latestMusicRequestToken) return;
 
         // 清除可能的自动销毁与 DOM 移除定时器
@@ -535,6 +630,11 @@
             }
         }
 
+        // 切歌前，先把上一首卡片标记为"已结束"。必须在 currentPlayingTrack
+        // 被覆盖之前用旧值更新，否则旧卡片会被改写成新曲目信息。
+        const previousTrackForCard = currentPlayingTrack;
+        const previousCardId = musicCardMessageId;
+
         // --- 2. 原地更新 UI 文本/封面 (始终执行) ---
         currentPlayingTrack = trackInfo;
         setMusicBarTitle(musicBar, trackInfo.name || '');
@@ -565,6 +665,22 @@
         {
             const host = window.reactChatWindowHost;
             if (host && typeof host.appendMessage === 'function') {
+                // 切歌时，先把上一首的卡片标记为"已结束"，避免覆盖 musicCardMessageId
+                // 之后旧卡片永远停在"播放中"。注意要用旧 id + 旧 track。
+                if (previousCardId && typeof host.updateMessage === 'function') {
+                    try {
+                        host.updateMessage(previousCardId, {
+                            blocks: [{
+                                type: 'link',
+                                url: (previousTrackForCard && previousTrackForCard.url) || '#',
+                                title: (previousTrackForCard && previousTrackForCard.name) || '未知曲目',
+                                description: (previousTrackForCard && previousTrackForCard.artist) || '未知艺术家',
+                                siteName: '✅ ' + ((window.t && window.t('music.ended')) || '已播完'),
+                                thumbnailUrl: (previousTrackForCard && previousTrackForCard.cover) || undefined
+                            }]
+                        });
+                    } catch (_) { /* ignore */ }
+                }
                 let assistantName = '';
                 if (window.lanlan_config && window.lanlan_config.lanlan_name) assistantName = window.lanlan_config.lanlan_name;
                 else if (window._currentCatgirl) assistantName = window._currentCatgirl;
@@ -655,6 +771,9 @@
                     autoplayBlocked = false;
                     lastPlayPosition = (boundPlayer.audio && boundPlayer.audio.currentTime) || 0;
                     updateMusicCard('playing', currentPlayingTrack);
+                    // 跨窗口协调：本地真正开始放歌后通知其他窗口
+                    broadcastMusicCoord('music_started');
+                    startMusicHeartbeat();
                 });
                 boundPlayer.on('pause', () => {
                     updatePlayBtnState(false);
@@ -1017,6 +1136,10 @@
     window.sendMusicMessage = async function (trackInfo, shouldAutoPlay = true) {
         if (!trackInfo) return false;
 
+        // 进入 dispatch 流水线就立即标记 pending —— 让并发的 dispatchMusicPlay
+        // 能在 isMusicPlaying() 还未变成 true 的"加载中"窗口里也识别到占用。
+        musicDispatchPending = true;
+
         // --- 核心修复：更鲁棒的 URL 预清理 ---
         if (trackInfo.url && typeof trackInfo.url === 'string') {
             try {
@@ -1046,6 +1169,7 @@
         // 5秒去重逻辑
         if (lastPlayedMusicUrl === trackInfo.url && (now - lastMusicPlayTime) < 5000 && isPlayerInDOM()) {
             console.log('[Music UI] 5秒内相同音乐且已在播放中，跳过播发请求:', trackInfo.name);
+            musicDispatchPending = false;
             return true;
         }
 
@@ -1085,6 +1209,7 @@
                 var msg = window.t ? window.t('music.unsafeSource', { domain: domain }) : ('已拦截不安全音源: ' + domain);
                 window.showStatusToast(msg, 5000);
             }
+            musicDispatchPending = false;
             return false;
         }
 
@@ -1101,13 +1226,14 @@
                 player.play();
                 showNowPlayingToast(trackInfo.name);
             }
+            musicDispatchPending = false;
             return true;
         }
 
         showNowPlayingToast(trackInfo.name);
 
         loadAPlayerLibrary().then(function () {
-            executePlay(trackInfo, currentToken, shouldAutoPlay);
+            return executePlay(trackInfo, currentToken, shouldAutoPlay);
         }).catch(function (err) {
             // 库加载失败同样需要校验 token，防止关闭后弹出报错
             if (currentToken === latestMusicRequestToken) {
@@ -1115,6 +1241,12 @@
                 showErrorToast('music.loadError', '音乐播放器加载失败');
             } else {
                 console.log('[Music UI] 库加载失败，但请求已取消，忽略报错');
+            }
+        }).finally(function () {
+            // 仅当本次 dispatch 仍是最新的、且后续未被新的 sendMusicMessage 覆盖时
+            // 才解除 pending；否则交给后来者管理。
+            if (currentToken === latestMusicRequestToken) {
+                musicDispatchPending = false;
             }
         });
 
@@ -1209,6 +1341,11 @@
     window.isMusicCooldown = isInMusicCooldown;
     window.getMusicCurrentTrack = getMusicCurrentTrack;
     window.MusicPluginAPI = MusicPluginAPI;
+
+    // 竞态拦截辅助：dispatch 流水线中（URL 校验/库加载/init）的占位标记
+    window.isMusicPending = () => musicDispatchPending;
+    // 跨窗口协调：其他窗口正在播歌（基于 BroadcastChannel 通报）
+    window.isRemoteMusicActive = isRemoteMusicActive;
 
     // 派发就绪事件，通知提前加载的插件可以开始注册域名了
     window.dispatchEvent(new CustomEvent('music-ui-ready'));

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -169,6 +169,21 @@
         consecutiveSkipsToTrigger: 2,        // 连续秒关 2 次触发冷却
         cooldownDurationMs: 20 * 60 * 1000   // 冷却 20 分钟
     };
+
+    // --- 主动推荐频率限流 ---
+    // 用户反馈"推荐太频繁"，加一层硬性最小间隔：任意一次 proactive 推荐
+    // 成功派发后，接下来 RECOMMEND_COOLDOWN_MS 内不再放行新的 proactive 推荐。
+    // 非 proactive 来源（用户主动点播、插件直推、[play_music:] 指令）不受影响。
+    const RECOMMEND_COOLDOWN_MS = 18000;
+    let lastProactiveRecommendAt = 0;
+
+    const isMusicRecommendRateLimited = () => {
+        if (lastProactiveRecommendAt <= 0) return false;
+        return (Date.now() - lastProactiveRecommendAt) < RECOMMEND_COOLDOWN_MS;
+    };
+    const markProactiveMusicRecommended = () => {
+        lastProactiveRecommendAt = Date.now();
+    };
     let accumulatedPlaySeconds = 0;   // actual playback seconds (from player.currentTime)
     let lastPlayPosition = 0;         // player.currentTime snapshot at last play/resume
     let consecutiveSkipCount = 0;
@@ -1346,6 +1361,9 @@
     window.isMusicPending = () => musicDispatchPending;
     // 跨窗口协调：其他窗口正在播歌（基于 BroadcastChannel 通报）
     window.isRemoteMusicActive = isRemoteMusicActive;
+    // 推荐频率限流：最近是否刚派发过 proactive 推荐
+    window.isMusicRecommendRateLimited = isMusicRecommendRateLimited;
+    window.markProactiveMusicRecommended = markProactiveMusicRecommended;
 
     // 派发就绪事件，通知提前加载的插件可以开始注册域名了
     window.dispatchEvent(new CustomEvent('music-ui-ready'));

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -54,7 +54,10 @@
     // --- 竞态保护：dispatch 入口的"加载中"标记 ---
     // sendMusicMessage 的 URL 校验/库加载阶段对外暴露，避免并发 dispatch 在
     // 真正的 audio 还未启动时绕过 isMusicPlaying() 拦截。
-    let musicDispatchPending = false;
+    //
+    // 用计数器而非 boolean：并发的 sendMusicMessage 调用各自 +1 / -1，
+    // 谁先走早退分支都不会把尚在库加载中的兄弟调用误清为 idle。
+    let musicDispatchPendingCount = 0;
 
     // --- 竞态保护：executePlay 串行化 ---
     // 两个并发 executePlay 在 await initializeAPlayer 期间会同时把
@@ -1165,9 +1168,16 @@
     window.sendMusicMessage = async function (trackInfo, shouldAutoPlay = true) {
         if (!trackInfo) return false;
 
-        // 进入 dispatch 流水线就立即标记 pending —— 让并发的 dispatchMusicPlay
+        // 进入 dispatch 流水线就立即 +1 —— 让并发的 dispatchMusicPlay
         // 能在 isMusicPlaying() 还未变成 true 的"加载中"窗口里也识别到占用。
-        musicDispatchPending = true;
+        // 用本地 pendingReleased 防止重复释放。
+        musicDispatchPendingCount += 1;
+        let pendingReleased = false;
+        const releasePending = () => {
+            if (pendingReleased) return;
+            pendingReleased = true;
+            musicDispatchPendingCount = Math.max(0, musicDispatchPendingCount - 1);
+        };
 
         // --- 核心修复：更鲁棒的 URL 预清理 ---
         if (trackInfo.url && typeof trackInfo.url === 'string') {
@@ -1198,7 +1208,7 @@
         // 5秒去重逻辑
         if (lastPlayedMusicUrl === trackInfo.url && (now - lastMusicPlayTime) < 5000 && isPlayerInDOM()) {
             console.log('[Music UI] 5秒内相同音乐且已在播放中，跳过播发请求:', trackInfo.name);
-            musicDispatchPending = false;
+            releasePending();
             return true;
         }
 
@@ -1238,7 +1248,7 @@
                 var msg = window.t ? window.t('music.unsafeSource', { domain: domain }) : ('已拦截不安全音源: ' + domain);
                 window.showStatusToast(msg, 5000);
             }
-            musicDispatchPending = false;
+            releasePending();
             return false;
         }
 
@@ -1255,7 +1265,7 @@
                 player.play();
                 showNowPlayingToast(trackInfo.name);
             }
-            musicDispatchPending = false;
+            releasePending();
             return true;
         }
 
@@ -1272,11 +1282,8 @@
                 console.log('[Music UI] 库加载失败，但请求已取消，忽略报错');
             }
         }).finally(function () {
-            // 仅当本次 dispatch 仍是最新的、且后续未被新的 sendMusicMessage 覆盖时
-            // 才解除 pending；否则交给后来者管理。
-            if (currentToken === latestMusicRequestToken) {
-                musicDispatchPending = false;
-            }
+            // 每次调用独立释放：不用 token 判断，本次引用计数 -1 就好。
+            releasePending();
         });
 
         return true;
@@ -1372,7 +1379,7 @@
     window.MusicPluginAPI = MusicPluginAPI;
 
     // 竞态拦截辅助：dispatch 流水线中（URL 校验/库加载/init）的占位标记
-    window.isMusicPending = () => musicDispatchPending;
+    window.isMusicPending = () => musicDispatchPendingCount > 0;
     // 跨窗口协调：其他窗口正在播歌（基于 BroadcastChannel 通报）
     window.isRemoteMusicActive = isRemoteMusicActive;
     // 推荐频率限流：最近是否刚派发过 proactive 推荐

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -786,6 +786,10 @@
                         if (latestMusicRequestToken === tokenAtEvent) destroyMusicPlayer(true, true, true);
                     }, MUSIC_CONFIG.timeouts.paused);
                     updateMusicCard('paused', currentPlayingTrack);
+                    // 跨窗口协调：暂停立刻通告，避免对端在 TTL 内以为我还在播而拦截 proactive；
+                    // 若用户点"继续"，play 事件会再次广播 music_started。
+                    stopMusicHeartbeat();
+                    broadcastMusicCoord('music_ended');
                 });
                 boundPlayer.on('ended', () => {
                     updatePlayBtnState(false);
@@ -798,6 +802,9 @@
                         if (latestMusicRequestToken === tokenAtEvent) destroyMusicPlayer(true, true, true);
                     }, MUSIC_CONFIG.timeouts.ended);
                     updateMusicCard('ended', currentPlayingTrack);
+                    // 同上：自然播完时立刻通告，让对端能立即响应新的 proactive 推荐。
+                    stopMusicHeartbeat();
+                    broadcastMusicCoord('music_ended');
                 });
                 boundPlayer.on('error', (err) => {
                     if (boundPlayer._destroying) return;

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -786,10 +786,6 @@
                         if (latestMusicRequestToken === tokenAtEvent) destroyMusicPlayer(true, true, true);
                     }, MUSIC_CONFIG.timeouts.paused);
                     updateMusicCard('paused', currentPlayingTrack);
-                    // 跨窗口协调：暂停立刻通告，避免对端在 TTL 内以为我还在播而拦截 proactive；
-                    // 若用户点"继续"，play 事件会再次广播 music_started。
-                    stopMusicHeartbeat();
-                    broadcastMusicCoord('music_ended');
                 });
                 boundPlayer.on('ended', () => {
                     updatePlayBtnState(false);
@@ -802,9 +798,6 @@
                         if (latestMusicRequestToken === tokenAtEvent) destroyMusicPlayer(true, true, true);
                     }, MUSIC_CONFIG.timeouts.ended);
                     updateMusicCard('ended', currentPlayingTrack);
-                    // 同上：自然播完时立刻通告，让对端能立即响应新的 proactive 推荐。
-                    stopMusicHeartbeat();
-                    broadcastMusicCoord('music_ended');
                 });
                 boundPlayer.on('error', (err) => {
                     if (boundPlayer._destroying) return;

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -85,6 +85,20 @@
                     remoteMusicSenders.delete(sid);
                 }
             };
+            // 窗口关闭时通告一声 music_ended 并关闭 channel，避免对端等 30s TTL 才意识到我退出
+            window.addEventListener('beforeunload', () => {
+                try {
+                    if (musicCoordChannel) {
+                        musicCoordChannel.postMessage({
+                            type: 'music_ended',
+                            sender: MUSIC_COORD_SENDER_ID,
+                            ts: Date.now()
+                        });
+                        musicCoordChannel.close();
+                        musicCoordChannel = null;
+                    }
+                } catch (_) { /* ignore */ }
+            });
         }
     } catch (e) {
         console.log('[Music UI] BroadcastChannel 不可用，跨窗口协调失效:', e);


### PR DESCRIPTION
## 症状

在 chat.html 上观察到：

- 第一次音乐推荐时同时播放两首歌，第一首没有卡片、后台播放、无法暂停
- 上一首还没放完就被下一首抢走
- 日志显示 `/api/proactive_chat` 同一时刻被请求两次，LLM 调用和音乐推荐都翻倍

## 根因

1. **chat.html 与 index.html 各跑各的 proactive 调度器** —— 共用 `app-proactive.js`，同时发请求、同时推 vision 帧。(critical)
2. **`executePlay` 内部 `await initializeAPlayer` 的并发竞态** —— 第二次 dispatch 在第一次 init 期间插入，两个 APlayer 实例并存，`currentPlayingTrack` / `musicCardMessageId` 被覆盖，第一个实例的 audio 残留。
3. **`dispatchMusicPlay` 的 proactive 拦截只看 `isMusicPlaying()`** —— URL 白名单等待 + 库加载 + init 这段窗口里它返回 false，并发的第二次请求被放行。
4. **切歌时 `musicCardMessageId` 直接被新 id 覆盖** —— 旧卡片永远停在"播放中"。

## 修复

### 1. Leader election（app-proactive.js）

约定 **Pet (index.html) 为主，chat.html 为从**。同时存活时只有 Pet 跑调度；Pet 关闭后 chat.html 通过 TTL 自动接班。

- 专用 BroadcastChannel `neko_proactive_leader`，5s heartbeat / 15s TTL / `beforeunload` 广播 `goodbye`。
- rank：`/chat` = 1（从），其它路径 = 0（Pet 主），`model_manager / jukebox / subtitle / agenthud / toast` 等 = 99（不参与）。
- `scheduleProactiveChat` / `triggerProactiveChat` / `startProactiveVisionDuringSpeech` 全部加 `isProactiveLeader()` guard。
- 非 leader 用 8s recheck 兜底；leader 切换时立即 `scheduleProactiveChat()` 接班 / 清定时器让位。
- 新 peer announce 时 leader 立即回一个 heartbeat，消除 discovery race。

### 2. 单窗口内音乐竞态（music_ui.js）

- `executePlayChain` Promise 链把所有 `executePlay` 串行化，避免两次 `await initializeAPlayer` 并发。
- `musicDispatchPending` 标记从 `sendMusicMessage` 入口起就视为占用，所有早 return / `.finally` 正确清除（且校验 token 防止被后续 dispatch 误清）。
- 切歌前用旧 id + 旧 track 把上一张卡片改成 "已播完"，再 `appendMessage` 新卡片。
- 专用 BroadcastChannel `neko_music_coord` + sender_id 做跨窗口音乐协调，本地 `play` 时广播 `music_started` + 10s 心跳；`destroyMusicPlayer` 时广播 `music_ended`。

### 3. dispatch 拦截维度补齐（app-chat.js）

`dispatchMusicPlay` 的 proactive 拦截从 `isMusicPlaying()` 升级为 `isMusicPlaying() || isMusicPending() || isRemoteMusicActive()` 三维判断。

## 行为预期

- **两个窗口都开** → Pet 跑调度，chat.html 静默旁观。
- **chat.html 单开** → 没看到任何 peer，自己升级为 leader。
- **Pet 关闭** → chat.html 收到 goodbye 立刻接班；若 Pet 崩溃无 goodbye，15s TTL 后接班。
- 音乐切歌时旧卡片标记为 "已播完"，不再残留"播放中"。

## Test plan

- [ ] 同时打开 Pet + chat.html，确认 `/api/proactive_chat` 只被请求一次（看后端日志）
- [ ] 音乐推荐只播一首，不再出现"后台无卡片"的残留音频
- [ ] 关闭 Pet 窗口后 chat.html 在 ~15s 内接班，proactive 继续工作
- [ ] 连续切歌时旧音乐卡片正确变成"已播完"

https://claude.ai/code/session_0114MCyTPpVNhDTXJqeWEBiv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 引入跨窗口主导（leader）选举与心跳，只有主窗口安排主动聊天与视觉提示。
  * 增加跨窗口音乐协调（启动/心跳/结束广播）、挂起计数、推荐限流与标记接口（可标记已派发的主动推荐）。

* **改进**
  * 主动派发拦截条件扩展：在源为 proactive 时会检测播放/挂起/远端活跃/推荐限流并拦截。
  * 播放请求串行化，防止并发冲突与残留音频元素；切曲时更准确更新音乐卡片状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->