### PR TITLE
fix(proactive): 修退避锁失效 + 跨窗口 IPC + 语音播放中避免自打断

### DIFF
--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -1116,6 +1116,12 @@
 
     // ======================== backoff reset ========================
 
+    /**
+     * 重置主动搭话退避级别 + 语音无回复计数，并 reschedule timer；
+     * 同时通过 BroadcastChannel 广播，让所有窗口（包括 leader）同步 reset。
+     * @param {Object} [opts]
+     * @param {boolean} [opts._fromIpc] 标记本次调用源自 IPC 消息，避免回环广播。
+     */
     function resetProactiveChatBackoff(opts) {
         // 重置退避级别
         S.proactiveChatBackoffLevel = 0;

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -93,6 +93,17 @@
                 } else if (data.type === 'goodbye') {
                     _proactivePeers.delete(data.id);
                     _onProactiveLeadershipMaybeChanged();
+                } else if (data.type === 'user_input_reset') {
+                    // 分发环境（Electron）下 chat.html 承担文本输入，但 proactive 计时器
+                    // 只在 index.html (leader) 运行。chat.html 本地调 resetProactiveChatBackoff
+                    // 对 leader 的 S.proactiveChatBackoffLevel 不可见，因此转成 IPC 转发到
+                    // 所有窗口，由 leader 真正重置退避级别 + 重排 timer。
+                    // { _fromIpc: true } 阻止二次广播，靠 data.id !== SELF_ID 已避免回环。
+                    try {
+                        resetProactiveChatBackoff({ _fromIpc: true });
+                    } catch (e) {
+                        console.warn('[Proactive] 处理 user_input_reset IPC 失败:', e);
+                    }
                 }
             };
         }
@@ -241,6 +252,20 @@
     /**
      * 检查主动搭话前置条件是否满足
      */
+    // AI 是否正在播放语音：proactive timer 到点时如果还在播，就跳过本次 nudge
+    // 并继续按固定间隔 poll（见下面 scheduleProactiveChat 的两处 speaking 分支）。
+    // S.isPlaying：audio chunks 入队到 drain 完这段期间为 true；
+    // S.assistantSpeechActiveTurnId：active turn 有音频在跑时非空。
+    // 两者任一为真都视为在播，避免打断自己。
+    function _isAssistantSpeaking() {
+        try {
+            return !!(S && (S.isPlaying || S.assistantSpeechActiveTurnId));
+        } catch (_) {
+            return false;
+        }
+    }
+    mod._isAssistantSpeaking = _isAssistantSpeaking;
+
     function canTriggerProactively() {
         // 「请她离开」状态下禁止一切主动搭话
         if (isGoodbyeActive()) {
@@ -327,6 +352,17 @@
 
             S.proactiveChatTimer = setTimeout(async function () {
                 if (S.isProactiveChatRunning) return;
+                // 设计说明（by 用户意图）：
+                // 这里不"rearm-after-playback"——那样每句话说完都要严格等满一个固定间隔
+                // 才能接下一句，节奏太死板。改为"继续按固定间隔轮询"：
+                // 轮询到时 AI 还在说 → 跳过本次 nudge，不累加 _voiceProactiveNoResponseCount
+                // （没真发请求就不算无回复），但仍然 scheduleProactiveChat() 推进下一 tick。
+                // 结果：播放完成到下一次 nudge 的等待 ∈ [0, interval)，带随机感，更自然。
+                if (_isAssistantSpeaking()) {
+                    console.log('[ProactiveChat] 语音模式：AI 正在播放语音，本次 nudge 跳过（不计数），继续下一 tick');
+                    scheduleProactiveChat();
+                    return;
+                }
                 S.isProactiveChatRunning = true;
                 try {
                     await triggerProactiveChat();
@@ -346,22 +382,35 @@
             return;
         }
 
-        // 文本模式：指数退避
+        // 文本模式：指数退避（带小幅随机指数浮动，避免节奏过于机械）
         var baseInterval = S.proactiveChatInterval;
 
-        // 计算延迟时间（指数退避，倍率2.5）
-        var delay = (baseInterval * 1000) * Math.pow(2.5, S.proactiveChatBackoffLevel);
+        // 在指数上叠加 ±0.125 的随机漂移 → 实际倍率波动约 [0.89x, 1.12x]，幅度很小但有变化
+        var expJitter = (Math.random() - 0.5) * 0.25;
+        var effectiveExp = S.proactiveChatBackoffLevel + expJitter;
+        var delay = (baseInterval * 1000) * Math.pow(2.5, effectiveExp);
 
         // 首次启动时额外等待5秒，避免程序刚启动就触发音乐推荐
         var startupDelay = S.proactiveChatBackoffLevel === 0 ? 6000 : 0;
         delay += startupDelay;
 
-        console.log('主动搭话：' + (delay / 1000) + '秒后触发（基础间隔：' + S.proactiveChatInterval + '秒，退避级别：' + S.proactiveChatBackoffLevel + '，启动延迟：' + (startupDelay / 1000) + '秒）');
+        console.log('主动搭话：' + (delay / 1000).toFixed(1) + '秒后触发（基础间隔：' + S.proactiveChatInterval + '秒，退避级别：' + S.proactiveChatBackoffLevel + '，指数漂移：' + expJitter.toFixed(2) + '，启动延迟：' + (startupDelay / 1000) + '秒）');
 
         S.proactiveChatTimer = setTimeout(async function () {
             // 双重检查锁：定时器触发时再次检查是否正在执行
             if (S.isProactiveChatRunning) {
                 console.log('主动搭话定时器触发时发现正在执行中，跳过本次');
+                return;
+            }
+
+            // 设计说明（by 用户意图）：
+            // 不 rearm-after-playback —— 那样每句话说完都要等满一个固定间隔，节奏太死。
+            // 改为"继续按间隔轮询"：轮询到时 AI 还在说 → 跳过本次，不累加 backoffLevel
+            // （没真发请求就不算一次尝试），但仍然 scheduleProactiveChat() 推进下一 tick。
+            // 结果：播放完成到下一次 nudge 的等待 ∈ [0, interval)，带随机感，更自然。
+            if (_isAssistantSpeaking()) {
+                console.log('[ProactiveChat] 文本模式：AI 正在播放语音，本次跳过（不累加退避），继续下一 tick');
+                scheduleProactiveChat();
                 return;
             }
 
@@ -374,9 +423,17 @@
                 S.isProactiveChatRunning = false; // 解锁
             }
 
-            // 增加退避级别（最多到约7分钟，即level 3：30s * 2.5^3 = 7.5min）
-            if (S.proactiveChatBackoffLevel < 3) {
+            // 增加退避级别：
+            //   level < 2 时每次必升（30s → 75s → 187s ≈ 3min），快速拉开间隔；
+            //   level ≥ 2 后改为 30% 概率升级，让"长期无人搭理"的情况间隔能继续慢慢变长，
+            //     但大多数轮次仍停在当前档位，避免一次跳太远。
+            //   注：硬上限从原设计的 level 3 降到 2，因为同批改动里去掉了 turn_end reset，
+            //   整体退避会更猛 —— 先降一级做软着陆，让用户不至于突然觉得搭话显著变少。
+            if (S.proactiveChatBackoffLevel < 2) {
                 S.proactiveChatBackoffLevel++;
+            } else if (Math.random() < 0.3) {
+                S.proactiveChatBackoffLevel++;
+                console.log('[ProactiveChat] 高档位概率升级命中，退避级别升至 ' + S.proactiveChatBackoffLevel);
             }
 
             // 安排下一次
@@ -898,6 +955,11 @@
         // 优先通过 React 聊天窗口 API 显示表情包
         var host = window.reactChatWindowHost;
         if (host && typeof host.appendMessage === 'function') {
+            // PR #780 之后 proactive 只在 leader 触发，meme 只会暂存在 leader 的
+            // _proactiveAttachmentBuffer 里，flush 到 host.appendMessage 也只写
+            // 进 leader 的 React chat。用 music_ui 暴露的镜像 helper 同步到
+            // 所有窗口，保证 chat.html（follower）也能看到表情包气泡。
+            var mirrorAppend = window.__nekoMirrorChatAppend;
             for (var i = 0; i < memeLinks.length; i++) {
                 (function (meme) {
                     if (!meme || !meme.safeUrl) return;
@@ -914,7 +976,7 @@
                     if (window.appChatAvatar && typeof window.appChatAvatar.getCurrentAvatarDataUrl === 'function') {
                         avatarUrl = window.appChatAvatar.getCurrentAvatarDataUrl() || '';
                     }
-                    host.appendMessage({
+                    var msg = {
                         id: 'meme-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
                         role: 'assistant',
                         author: assistantName,
@@ -924,7 +986,14 @@
                         avatarUrl: avatarUrl || undefined,
                         blocks: [{ type: 'image', url: proxyUrl, alt: meme.title || 'Meme' }],
                         status: 'sent'
-                    });
+                    };
+                    if (typeof mirrorAppend === 'function') {
+                        // 本地 append + 广播镜像（music_ui.js 已装好监听器）
+                        mirrorAppend(host, msg);
+                    } else {
+                        // 兜底：music_ui.js 未就绪时退化为只在本窗口显示
+                        host.appendMessage(msg);
+                    }
                     console.log('[Meme] 已展示图片气泡 (React):', meme.title);
                 })(memeLinks[i]);
             }
@@ -1035,13 +1104,20 @@
 
     // ======================== backoff reset ========================
 
-    function resetProactiveChatBackoff() {
+    function resetProactiveChatBackoff(opts) {
         // 重置退避级别
         S.proactiveChatBackoffLevel = 0;
         // 语音模式：用户说话了，重置无回复计数
         S._voiceProactiveNoResponseCount = 0;
         // 重新安排定时器
         scheduleProactiveChat();
+        // 跨窗口同步：分发环境下 chat.html 输入只会 reset 它自己这份无用的 state，
+        // proactive 真正的计时器在 index.html (leader)。广播 user_input_reset，
+        // 让所有窗口（包括 leader）本地再跑一次 reset。_fromIpc 表示本次调用源自
+        // IPC 消息，不再回广播，避免回环。
+        if (!opts || !opts._fromIpc) {
+            _proactiveBroadcast('user_input_reset');
+        }
     }
     mod.resetProactiveChatBackoff = resetProactiveChatBackoff;
 

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -390,9 +390,21 @@
         var effectiveExp = S.proactiveChatBackoffLevel + expJitter;
         var delay = (baseInterval * 1000) * Math.pow(2.5, effectiveExp);
 
-        // 首次启动时额外等待5秒，避免程序刚启动就触发音乐推荐
-        var startupDelay = S.proactiveChatBackoffLevel === 0 ? 6000 : 0;
+        // 首次启动时额外等待 6 秒，避免程序刚启动就触发音乐推荐。
+        // 用一次性 flag 而非 backoffLevel === 0 —— 后者在 user_input reset 或
+        // speaking-skip 重排时也会命中，导致每次都重新叠 6s，把 skip 路径期望的
+        // "等待 ∈ [0, interval)" 变成 "interval + 6s"。
+        var startupDelay = 0;
+        if (!S._proactiveStartupDelayApplied) {
+            startupDelay = 6000;
+            S._proactiveStartupDelayApplied = true;
+        }
         delay += startupDelay;
+
+        // Clamp：level 长期上爬后 (level ≥ ~13 @ base=30s) `2.5^level` 会把 delay
+        // 顶到超过 setTimeout 的 int32 上限 0x7fffffff ≈ 24.8 天，实际被截断成
+        // "1ms 后立刻 fire"。加个硬上限保险，实际封顶在 ~24 天，已足够长。
+        delay = Math.min(delay, 0x7fffffff);
 
         console.log('主动搭话：' + (delay / 1000).toFixed(1) + '秒后触发（基础间隔：' + S.proactiveChatInterval + '秒，退避级别：' + S.proactiveChatBackoffLevel + '，指数漂移：' + expJitter.toFixed(2) + '，启动延迟：' + (startupDelay / 1000) + '秒）');
 

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -110,6 +110,7 @@
         _voiceSessionInitialTimer: null,
         isProactiveChatRunning: false,
         _proactiveSchedulerInitialized: false,
+        _proactiveStartupDelayApplied: false,
         proactiveChatInterval: 15,
         proactiveVisionFrameTimer: null,
         proactiveVisionInterval: 10,

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1179,13 +1179,14 @@
                         })();
                     })();
 
-                    // Reset proactive chat backoff after AI turn completes
+                    // AI turn_end 后只 reschedule，不 reset backoff。
+                    // 理由：turn_end 无法区分"用户发话引发的 turn"和"proactive 自己引发的 turn"，
+                    // 如果一律 reset 会让 proactive 自己的 turn 把退避清零 → 指数退避形同虚设。
+                    // 用户真的说话时会由 sendTextPayload / 录音开关等路径单独 reset，
+                    // 不依赖 turn_end。语音模式本来就不退避，只是"从 turn end 开始算下一个间隔"。
                     var hasChatMode = (typeof window.hasAnyChatModeEnabled === 'function') ? window.hasAnyChatModeEnabled() : false;
                     if (S.proactiveChatEnabled && hasChatMode) {
-                        if (!S.isRecording) {
-                            if (typeof window.resetProactiveChatBackoff === 'function') window.resetProactiveChatBackoff();
-                        } else if (typeof window.scheduleProactiveChat === 'function') {
-                            // Voice mode also needs a turn-end fallback rearm in case TTS/playback completion never fires.
+                        if (typeof window.scheduleProactiveChat === 'function') {
                             window.scheduleProactiveChat();
                         }
                     }

--- a/static/music_ui.js
+++ b/static/music_ui.js
@@ -147,6 +147,74 @@
         return remoteMusicSenders.size > 0;
     };
 
+    // --- 跨窗口 React 聊天镜像：把本窗口写入 reactChatWindowHost 的
+    // append/update 动作同步广播给其他窗口，解决 PR #780 之后的问题 ——
+    // proactive 聊天只在 leader（通常是 Pet/index.html）触发，后端下发的
+    // 音乐卡片 / meme 气泡只会出现在 leader 的 React chat 里，chat.html
+    // 作为 follower 不再发 /api/proactive_chat 也就收不到响应，它的 React
+    // chat 里只能看到 WS 推的纯文字消息。通过这里的 mirror 把 leader 的
+    // 卡片/气泡广播到 follower，让 chat.html 也能同步渲染。
+    //
+    // 不走 'neko_music_coord' 是为了职责分离：那个 channel 仅用于
+    // "谁在播音乐/是否占用"的互斥协调，这里是 UI 层消息镜像，语义不同。
+    const CHAT_MIRROR_CHANNEL_NAME = 'neko_chat_ui_mirror';
+    let chatMirrorChannel = null;
+    try {
+        if (typeof BroadcastChannel !== 'undefined') {
+            chatMirrorChannel = new BroadcastChannel(CHAT_MIRROR_CHANNEL_NAME);
+            chatMirrorChannel.onmessage = (event) => {
+                const data = event && event.data;
+                if (!data || typeof data !== 'object') return;
+                if (!data.sender || data.sender === MUSIC_COORD_SENDER_ID) return;
+                const host = window.reactChatWindowHost;
+                if (!host) return;
+                try {
+                    if (data.type === 'append' && typeof host.appendMessage === 'function' && data.message) {
+                        host.appendMessage(data.message);
+                    } else if (data.type === 'update' && typeof host.updateMessage === 'function' && data.messageId) {
+                        host.updateMessage(data.messageId, data.patch || {});
+                    }
+                } catch (e) {
+                    console.warn('[Music UI] 镜像 React chat 消息失败:', e);
+                }
+            };
+            window.addEventListener('beforeunload', () => {
+                try {
+                    if (chatMirrorChannel) { chatMirrorChannel.close(); chatMirrorChannel = null; }
+                } catch (_) { /* ignore */ }
+            });
+        }
+    } catch (e) {
+        console.log('[Music UI] chat mirror channel 不可用:', e);
+    }
+
+    const broadcastChatMirror = (payload) => {
+        if (!chatMirrorChannel) return;
+        try {
+            chatMirrorChannel.postMessage(Object.assign({ sender: MUSIC_COORD_SENDER_ID, ts: Date.now() }, payload));
+        } catch (_) { /* ignore */ }
+    };
+
+    // 对外暴露的"本地 append + 广播镜像"两合一 helper —— 供 app-proactive.js
+    // 等下游在想让一条消息同时落到所有窗口的 React chat 时使用。
+    // 下游不要直接调 reactChatWindowHost.appendMessage，否则就只在本窗口显示。
+    const mirrorHostAppend = (host, message) => {
+        if (!message) return;
+        if (host && typeof host.appendMessage === 'function') {
+            host.appendMessage(message);
+        }
+        broadcastChatMirror({ type: 'append', message: message });
+    };
+    const mirrorHostUpdate = (host, messageId, patch) => {
+        if (!messageId) return;
+        if (host && typeof host.updateMessage === 'function') {
+            host.updateMessage(messageId, patch || {});
+        }
+        broadcastChatMirror({ type: 'update', messageId: messageId, patch: patch || {} });
+    };
+    window.__nekoMirrorChatAppend = mirrorHostAppend;
+    window.__nekoMirrorChatUpdate = mirrorHostUpdate;
+
     // --- 更新 React 聊天窗口音乐卡片 ---
     const updateMusicCard = (state, track) => {
         const host = window.reactChatWindowHost;
@@ -160,7 +228,8 @@
         else if (state === 'error') { prefix = '❌'; text = (window.t && window.t('music.playError')) || '播放失败'; }
         else { prefix = '❓'; text = (window.t && window.t('music.unknownState')) || '未知状态'; }
 
-        host.updateMessage(musicCardMessageId, {
+        // 镜像到所有窗口：leader 本地 update + 广播给 follower
+        mirrorHostUpdate(host, musicCardMessageId, {
             blocks: [{
                 type: 'link',
                 url: track?.url || '#',
@@ -699,9 +768,10 @@
             if (host && typeof host.appendMessage === 'function') {
                 // 切歌时，先把上一首的卡片标记为"已结束"，避免覆盖 musicCardMessageId
                 // 之后旧卡片永远停在"播放中"。注意要用旧 id + 旧 track。
-                if (previousCardId && typeof host.updateMessage === 'function') {
+                if (previousCardId) {
                     try {
-                        host.updateMessage(previousCardId, {
+                        // 镜像到所有窗口：follower 也要把上一首标成已播完
+                        mirrorHostUpdate(host, previousCardId, {
                             blocks: [{
                                 type: 'link',
                                 url: (previousTrackForCard && previousTrackForCard.url) || '#',
@@ -726,7 +796,9 @@
                 const timeStr = now.getHours().toString().padStart(2, '0') + ':' + now.getMinutes().toString().padStart(2, '0');
                 const msgId = 'music-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
                 musicCardMessageId = msgId;
-                host.appendMessage({
+                // 镜像到所有窗口：leader 本地 append + 广播给 follower，
+                // 保证 chat.html 里也能出现音乐卡片（见本文件 chat mirror 段的注释）
+                mirrorHostAppend(host, {
                     id: msgId,
                     role: 'assistant',
                     author: assistantName,


### PR DESCRIPTION
- 语音 / 文本模式 timer fire 时先查 S.isPlaying / assistantSpeechActiveTurnId， 在播就跳过本次 nudge（不累加无回复计数 / 退避级别），继续按固定间隔 poll； 结果：播放完成到下次 nudge 的等待 ∈ [0, interval)，避免自己打断自己。
- 文本模式指数退避加 ±0.125 的随机指数漂移；硬上限从 level 3 降到 level 2， 超过 2 后改为 30% 概率升级，支持无限级但大多数轮次停在当前档位。
- turn_end 不再 reset backoff —— 原先 proactive 自引发的 turn 也会清零， 导致退避形同虚设。用户输入路径 (sendTextPayload / 录音开关等) 仍独立 reset。
- 跨窗口 IPC：resetProactiveChatBackoff 通过 neko_proactive_leader BC 广播 user_input_reset，让 Electron 分发环境下 chat.html 的文本输入能 触发 index.html (leader) 真正重置退避级别 + 重排 timer。
- music_ui / app-proactive 补 meme 气泡跨窗口镜像（沿用 #780 的镜像 helper）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增跨窗口聊天镜像与消息同步，确保多窗口中消息和音乐卡片状态一致。

* **改进**
  * 优化主动聊天调度：在助手发言时不打断并即时重排下一次触发，避免误触发和重复尝试。
  * 优化退避策略：引入随机抖动、启动延迟只应用一次并对超长延迟限幅，调整升级概率以平衡重试频率。
  * 统一在会话结束时触发调度以提升一致性；跨窗口时重置也会广播同步。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->