### PR TITLE
fix(tts): 去掉 Gemini Live 输出转录里的中文/中英交界 ASCII 空格

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
 from utils.frontend_utils import contains_chinese, replace_blank, replace_corner_mark, remove_bracket, \
-    is_only_punctuation
+    is_only_punctuation, TtsStreamNormalizer
 from utils.screenshot_utils import process_screen_data
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient
@@ -153,6 +153,11 @@ class LLMSessionManager:
         self.tts_request_queue = Queue()  # TTS request (线程队列)
         self.tts_response_queue = Queue()  # TTS response (线程队列)
         self.tts_thread = None  # TTS线程
+        # 跨 chunk 规范化器：Gemini Live 输出转录会在中文 token 之间插入 ASCII
+        # 空格，让 MiniMax / CosyVoice 等 streaming TTS 把中文读断。normalizer
+        # 按 replace_blank 的语义剔除空格，同时延后处理 chunk 尾部空格以保证边界正确。
+        self._tts_stream_normalizer = TtsStreamNormalizer()
+        self._tts_norm_speech_id: Optional[str] = None
         # 流式音频重采样器（24kHz→48kHz）- 维护内部状态避免 chunk 边界不连续
         self.audio_resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
         self.lock = asyncio.Lock()  # 使用异步锁替代同步锁
@@ -314,6 +319,28 @@ class LLMSessionManager:
         except Exception:
             return 350
 
+    def _enqueue_tts_text_chunk(self, speech_id, text: str) -> None:
+        """通过 stream normalizer 把一段文本 chunk 入 TTS 队列。
+
+        调用方必须已持有 ``self.tts_cache_lock``（与现有 put 调用点一致）。
+        speech_id 变化会触发 normalizer 重置；规范化后若 chunk 为空则不入队，
+        避免给 TTS worker 发无意义的空串。控制信号（``__interrupt__`` /
+        ``(None, None)``）请继续用 ``tts_request_queue.put`` 直接发送，
+        并在合适时机调用 ``_reset_tts_stream_normalizer``。
+        """
+        if speech_id != self._tts_norm_speech_id:
+            self._tts_stream_normalizer.reset()
+            self._tts_norm_speech_id = speech_id
+        normalized = self._tts_stream_normalizer.feed(text)
+        if not normalized:
+            return
+        self.tts_request_queue.put((speech_id, normalized))
+
+    def _reset_tts_stream_normalizer(self) -> None:
+        """清空 normalizer 状态。中断 / 轮次结束 / session 重建时调用。"""
+        self._tts_stream_normalizer.reset()
+        self._tts_norm_speech_id = None
+
     async def _clear_tts_pipeline(self):
         """清空 TTS 请求/响应队列和待处理缓存，停止当前合成。"""
         if self.use_tts and self.tts_thread and self.tts_thread.is_alive():
@@ -326,6 +353,7 @@ class LLMSessionManager:
                 self.tts_request_queue.put(("__interrupt__", None))
             except Exception as e:
                 logger.warning(f"⚠️ 发送TTS中断信号失败: {e}")
+            self._reset_tts_stream_normalizer()
             # 等待 TTS worker 处理 __interrupt__ 并 mute 回调（worker 轮询间隔 ~10ms）
             # 然后再次清空响应队列，确保旧 synthesizer 泄漏的音频全部丢弃
             await asyncio.sleep(0.02)
@@ -378,11 +406,11 @@ class LLMSessionManager:
                 if self.tts_ready and self.tts_thread and self.tts_thread.is_alive():
                     # TTS已就绪，直接发送
                     try:
-                        self.tts_request_queue.put((self.current_speech_id, text))
+                        self._enqueue_tts_text_chunk(self.current_speech_id, text)
                     except Exception as e:
                         logger.warning(f"⚠️ 发送TTS请求失败: {e}")
                 else:
-                    # TTS未就绪，先缓存
+                    # TTS未就绪，先缓存（规范化延迟到 _flush_tts_pending_chunks）
                     self.tts_pending_chunks.append((self.current_speech_id, text))
                     if len(self.tts_pending_chunks) == 1:
                         logger.info("TTS未就绪，开始缓存文本chunk...")
@@ -588,11 +616,11 @@ class LLMSessionManager:
                 if self.tts_ready and self.tts_thread and self.tts_thread.is_alive():
                     # TTS已就绪，直接发送
                     try:
-                        self.tts_request_queue.put((self.current_speech_id, text))
+                        self._enqueue_tts_text_chunk(self.current_speech_id, text)
                     except Exception as e:
                         logger.warning(f"⚠️ 发送TTS请求失败: {e}")
                 else:
-                    # TTS未就绪，先缓存
+                    # TTS未就绪，先缓存（规范化延迟到 _flush_tts_pending_chunks）
                     self.tts_pending_chunks.append((self.current_speech_id, text))
                     if len(self.tts_pending_chunks) == 1:
                         logger.info("TTS未就绪，开始缓存文本chunk...")
@@ -1029,7 +1057,7 @@ class LLMSessionManager:
             if self.tts_thread and self.tts_thread.is_alive():
                 for speech_id, text in self.tts_pending_chunks:
                     try:
-                        self.tts_request_queue.put((speech_id, text))
+                        self._enqueue_tts_text_chunk(speech_id, text)
                     except Exception as e:
                         logger.error(f"💥 发送缓存的TTS请求失败: {e}")
                         break
@@ -2051,7 +2079,7 @@ class LLMSessionManager:
         async with self.tts_cache_lock:
             if self.tts_ready and self.tts_thread and self.tts_thread.is_alive():
                 try:
-                    self.tts_request_queue.put((self.current_speech_id, text))
+                    self._enqueue_tts_text_chunk(self.current_speech_id, text)
                 except Exception as e:
                     logger.warning(f"⚠️ feed_tts_chunk 失败: {e}")
             else:

--- a/tests/unit/test_tts_stream_normalizer.py
+++ b/tests/unit/test_tts_stream_normalizer.py
@@ -11,7 +11,11 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
-from utils.frontend_utils import TtsStreamNormalizer, replace_blank
+from utils.frontend_utils import (
+    TtsStreamNormalizer,
+    drop_cjk_boundary_spaces,
+    replace_blank,
+)
 
 
 # --- replace_blank 基本语义与边界安全性 --------------------------------------
@@ -38,13 +42,55 @@ def test_replace_blank(text, expected):
     assert replace_blank(text) == expected
 
 
-# --- 单次 feed：不跨 chunk 时行为应与 replace_blank 完全一致 ------------------
+# --- drop_cjk_boundary_spaces：只删 CJK 邻接空格，不误伤其他脚本 ------------
 
-def test_feed_single_chunk_matches_replace_blank():
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # CJK 邻接空格应删
+        ("你 好 世 界", "你好世界"),
+        ("hello 你好", "hello你好"),
+        ("你好 world", "你好world"),
+        # Hiragana / Katakana 也按 CJK 处理
+        ("こんにちは 世界", "こんにちは世界"),
+        # Korean (Hangul) 不属于 CJK glue 范围,空格应保留
+        ("안녕하세요 여러분", "안녕하세요 여러분"),
+        # Cyrillic / Arabic / Thai 空格应保留
+        ("Привет мир", "Привет мир"),
+        ("مرحبا بالعالم", "مرحبا بالعالم"),
+        ("สวัสดี ชาวโลก", "สวัสดี ชาวโลก"),
+        # 纯 ASCII 词间空格保留
+        ("hello world", "hello world"),
+        # 边界空格 (没邻居 → 不 CJK → 保留)
+        (" hello", " hello"),
+        ("hello ", "hello "),
+        # 中韩交界:左 CJK → 删(偏保守,Gemini artifact 场景更可能)
+        ("你好 안녕", "你好안녕"),
+        # 空字符串
+        ("", ""),
+    ],
+)
+def test_drop_cjk_boundary_spaces(text, expected):
+    assert drop_cjk_boundary_spaces(text) == expected
+
+
+# --- 单次 feed：不跨 chunk 时 ----------------------------------------------
+
+def test_feed_single_chunk_cjk():
     n = TtsStreamNormalizer()
     assert n.feed("你 好 世 界") == "你好世界"
     n.reset()
     assert n.feed("hello world") == "hello world"
+
+
+def test_feed_single_chunk_preserves_non_cjk_spaces():
+    """Korean / Cyrillic / Arabic 等靠空格分词的脚本不能被动手。"""
+    n = TtsStreamNormalizer()
+    assert n.feed("안녕하세요 여러분") == "안녕하세요 여러분"
+    n.reset()
+    assert n.feed("Привет мир") == "Привет мир"
+    n.reset()
+    assert n.feed("مرحبا بالعالم") == "مرحبا بالعالم"
 
 
 # --- chunk 边界：尾部空格延后决策 ------------------------------------------
@@ -124,12 +170,33 @@ def test_flush_drops_trailing_spaces():
     assert n.flush() == ""
 
 
-def test_reset_clears_state():
+def test_reset_clears_both_pending_and_last_char():
+    """reset 必须同时清空 pending_spaces 和 last_nonspace。"""
     n = TtsStreamNormalizer()
-    n.feed("hello ")
+    n.feed("你好")  # last_nonspace = '好'
     n.reset()
-    # reset 之后，首个 chunk 以空格开头应被视为无左邻居 → 删除
-    assert n.feed(" world") == "world"
+    # last_nonspace 清空后,右邻居 'w' 非 CJK → 保留前导空格
+    assert n.feed(" world") == " world"
+
+    n2 = TtsStreamNormalizer()
+    n2.feed("hello ")  # pending_spaces = " "
+    n2.reset()
+    # pending_spaces 清空后,不应把上轮尾空格带到新轮次
+    assert n2.feed("world") == "world"
+
+
+def test_cross_chunk_korean_keeps_space():
+    """跨 chunk 韩语空格 regression 保护(codex review P1)。"""
+    n = TtsStreamNormalizer()
+    assert n.feed("안녕하세요 ") == "안녕하세요"
+    # 左 '요' 右 '여' 均非 CJK → 保留空格
+    assert n.feed("여러분") == " 여러분"
+
+
+def test_cross_chunk_cyrillic_keeps_space():
+    n = TtsStreamNormalizer()
+    assert n.feed("Привет ") == "Привет"
+    assert n.feed("мир") == " мир"
 
 
 def test_empty_chunk_is_noop():
@@ -174,13 +241,20 @@ def test_speech_id_boundary_via_reset_does_not_leak_across_turns():
         "尾部空格和中文 ",
         "你好     world",
         "a b c 一 二 三",
+        # 多语言 regression 覆盖
+        "안녕하세요 여러분",
+        "Привет мир",
+        "hello 안녕 world",
+        "こんにちは 世界",
     ],
 )
 def test_stream_matches_whole_text_except_trailing(full_text):
     """任意切分方式下，拼接所有 emit 加上 flush 应等于对完整文本调用
-    replace_blank 的结果去掉尾部空格（flush 丢尾空格是 normalizer 的约定）。
+    drop_cjk_boundary_spaces 的结果，再去掉首尾空格（flush 丢尾空格是
+    normalizer 的约定；首位空格若 drop_cjk_boundary_spaces 保留则继续
+    保留，但若整段只剩空格则为空）。
     """
-    expected = replace_blank(full_text).rstrip(" ")
+    expected = drop_cjk_boundary_spaces(full_text).rstrip(" ")
 
     # 在多种切分点下都成立
     for split in range(len(full_text) + 1):

--- a/tests/unit/test_tts_stream_normalizer.py
+++ b/tests/unit/test_tts_stream_normalizer.py
@@ -229,7 +229,7 @@ def test_speech_id_boundary_via_reset_does_not_leak_across_turns():
     assert n.feed("world") == "world"
 
 
-# --- 端到端：拼接全部 emit == 在"完整文本"上跑 replace_blank ------------
+# --- 端到端：拼接全部 emit == 在"完整文本"上跑 drop_cjk_boundary_spaces ----
 
 @pytest.mark.parametrize(
     "full_text",
@@ -250,9 +250,8 @@ def test_speech_id_boundary_via_reset_does_not_leak_across_turns():
 )
 def test_stream_matches_whole_text_except_trailing(full_text):
     """任意切分方式下，拼接所有 emit 加上 flush 应等于对完整文本调用
-    drop_cjk_boundary_spaces 的结果，再去掉首尾空格（flush 丢尾空格是
-    normalizer 的约定；首位空格若 drop_cjk_boundary_spaces 保留则继续
-    保留，但若整段只剩空格则为空）。
+    drop_cjk_boundary_spaces 的结果再去掉**尾部**空格（flush 丢尾空格是
+    normalizer 的约定；首位空格若 drop_cjk_boundary_spaces 保留则继续保留）。
     """
     expected = drop_cjk_boundary_spaces(full_text).rstrip(" ")
 

--- a/tests/unit/test_tts_stream_normalizer.py
+++ b/tests/unit/test_tts_stream_normalizer.py
@@ -1,0 +1,192 @@
+"""TtsStreamNormalizer: 跨 chunk 的 ASCII 空格规范化。
+
+覆盖 Gemini Live 输出转录把中文 token 切开（"你 好 世 界"）的典型场景，
+同时验证 chunk 边界（尾部空格延后决策、跨 chunk 左上下文继承）不会吃字或留字。
+"""
+import os
+import sys
+
+import pytest
+
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from utils.frontend_utils import TtsStreamNormalizer, replace_blank
+
+
+# --- replace_blank 基本语义与边界安全性 --------------------------------------
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # 中文之间 / 中英交界的 ASCII 空格全部丢掉
+        ("你 好 世 界", "你好世界"),
+        ("hello 你好", "hello你好"),
+        ("你好 world", "你好world"),
+        # 纯 ASCII 词间空格保留
+        ("hello world", "hello world"),
+        # 边界空格（没有邻居）一律丢掉，且不能 IndexError / 负索引回绕
+        (" ", ""),
+        (" a", "a"),
+        ("a ", "a"),
+        (" hello ", "hello"),
+        # 空字符串
+        ("", ""),
+    ],
+)
+def test_replace_blank(text, expected):
+    assert replace_blank(text) == expected
+
+
+# --- 单次 feed：不跨 chunk 时行为应与 replace_blank 完全一致 ------------------
+
+def test_feed_single_chunk_matches_replace_blank():
+    n = TtsStreamNormalizer()
+    assert n.feed("你 好 世 界") == "你好世界"
+    n.reset()
+    assert n.feed("hello world") == "hello world"
+
+
+# --- chunk 边界：尾部空格延后决策 ------------------------------------------
+
+def test_trailing_space_dropped_when_next_chunk_starts_with_chinese():
+    """chunk 末尾的 ASCII 空格，若下一 chunk 以中文开头，应删除。
+
+    Gemini Live 常见形态：["你 好", " 世", " 界"] → "你好世界"。
+    """
+    n = TtsStreamNormalizer()
+    assert n.feed("你 好") == "你好"
+    # 空格被暂存，没有立即 emit
+    assert n.feed(" 世") == "世"
+    assert n.feed(" 界") == "界"
+
+
+def test_trailing_space_kept_when_both_sides_ascii_across_chunks():
+    """chunk 边界上的空格若左右都是 ASCII 非空格，应保留。"""
+    n = TtsStreamNormalizer()
+    # 第一个 chunk 以 ASCII 结尾，尾部空格暂存
+    assert n.feed("hello ") == "hello"
+    # 下一个 chunk 以 ASCII 开头 → 空格被保留
+    assert n.feed("world") == " world"
+
+
+def test_leading_space_uses_previous_chunk_last_char_as_left_context():
+    """下一 chunk 以空格开头时，左邻居是上一 chunk emit 的末位非空格字符。"""
+    n = TtsStreamNormalizer()
+    assert n.feed("你好") == "你好"
+    # 左邻居是 '好'（非 ASCII），空格应删
+    assert n.feed(" world") == "world"
+
+    n.reset()
+    assert n.feed("hello") == "hello"
+    # 左邻居是 'o'（ASCII 非空格），右邻居 'w' 也是 → 空格保留
+    assert n.feed(" world") == " world"
+
+    n.reset()
+    assert n.feed("hello") == "hello"
+    # 左邻居 'o' 是 ASCII，右邻居 '你' 非 ASCII → 空格删
+    assert n.feed(" 你好") == "你好"
+
+
+def test_single_char_chunks_chinese():
+    """极端碎片化：Gemini 有时一次就吐一个字符。"""
+    n = TtsStreamNormalizer()
+    out = []
+    for c in "你 好 世 界":
+        out.append(n.feed(c))
+    assert "".join(out) == "你好世界"
+
+
+def test_single_char_chunks_english():
+    n = TtsStreamNormalizer()
+    out = []
+    for c in "hello world":
+        out.append(n.feed(c))
+    assert "".join(out) == "hello world"
+
+
+def test_mixed_chinese_english_fragmented():
+    """中英混排 + 碎片化：常见 Gemini + 英文词汇的情况。"""
+    n = TtsStreamNormalizer()
+    chunks = ["你", "好", " Hello", " world", " 再", "见"]
+    out = "".join(n.feed(c) for c in chunks)
+    # "你好" + " Hello" (左'好' 非ASCII → 删) + " world" (左'o' 右'w' 均ASCII → 留)
+    # + " 再" (左'd' ASCII 右'再' 非ASCII → 删) + "见"
+    assert out == "你好Hello world再见"
+
+
+# --- flush 与轮次切换 ------------------------------------------------------
+
+def test_flush_drops_trailing_spaces():
+    n = TtsStreamNormalizer()
+    assert n.feed("hello ") == "hello"  # 尾部空格暂存
+    # 轮次结束，没有下一 chunk，空格就地丢掉
+    assert n.flush() == ""
+
+
+def test_reset_clears_state():
+    n = TtsStreamNormalizer()
+    n.feed("hello ")
+    n.reset()
+    # reset 之后，首个 chunk 以空格开头应被视为无左邻居 → 删除
+    assert n.feed(" world") == "world"
+
+
+def test_empty_chunk_is_noop():
+    n = TtsStreamNormalizer()
+    assert n.feed("") == ""
+    assert n.feed("你 好") == "你好"
+    assert n.feed("") == ""
+
+
+def test_chunk_of_only_spaces_holds_all_for_later():
+    """整个 chunk 都是空格时应全部暂存，不 emit。"""
+    n = TtsStreamNormalizer()
+    assert n.feed("你好") == "你好"
+    assert n.feed("   ") == ""  # 全部暂存
+    # 下一 chunk 中文开头 → 所有暂存空格都删
+    assert n.feed("世界") == "世界"
+
+
+def test_speech_id_boundary_via_reset_does_not_leak_across_turns():
+    """模拟 _enqueue_tts_text_chunk 在 speech_id 切换时 reset。
+
+    上一轮的尾部空格不应被带到下一轮的首个 chunk 里。
+    """
+    n = TtsStreamNormalizer()
+    n.feed("hello ")  # 上一轮 trailing 暂存
+    # 上一轮的尾部空格在 flush 时丢掉
+    n.flush()
+    # 新轮次模拟 reset
+    n.reset()
+    assert n.feed("world") == "world"
+
+
+# --- 端到端：拼接全部 emit == 在"完整文本"上跑 replace_blank ------------
+
+@pytest.mark.parametrize(
+    "full_text",
+    [
+        "你 好 世 界",
+        "hello world 你好",
+        "hello 你好 world",
+        " 前导空格和中文",
+        "尾部空格和中文 ",
+        "你好     world",
+        "a b c 一 二 三",
+    ],
+)
+def test_stream_matches_whole_text_except_trailing(full_text):
+    """任意切分方式下，拼接所有 emit 加上 flush 应等于对完整文本调用
+    replace_blank 的结果去掉尾部空格（flush 丢尾空格是 normalizer 的约定）。
+    """
+    expected = replace_blank(full_text).rstrip(" ")
+
+    # 在多种切分点下都成立
+    for split in range(len(full_text) + 1):
+        n = TtsStreamNormalizer()
+        out = n.feed(full_text[:split]) + n.feed(full_text[split:])
+        out += n.flush()
+        assert out == expected, (
+            f"split={split} full={full_text!r} got={out!r} expected={expected!r}"
+        )

--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -152,21 +152,78 @@ def replace_blank(text: str):
     return "".join(out_str)
 
 
+# "Glue-to-adjacent" 字符范围：这些脚本里出现的 ASCII 空格几乎一定是 tokenizer
+# artifact（Gemini Live 把中文 token 切开的那种），不是语义分词。
+# 刻意不包含：Hangul（韩语用空格分词）、Cyrillic / Arabic / Thai / Devanagari 等。
+_CJK_GLUE_RANGES = (
+    (0x3040, 0x30FF),  # Hiragana + Katakana
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+)
+
+
+def _is_cjk_glue_char(c: str) -> bool:
+    if not c:
+        return False
+    cp = ord(c)
+    for lo, hi in _CJK_GLUE_RANGES:
+        if lo <= cp <= hi:
+            return True
+    return False
+
+
+def drop_cjk_boundary_spaces(text: str) -> str:
+    """去掉至少一侧是 CJK 汉字 / 日文假名的 ASCII 空格（含连续空格串）。
+
+    专治 Gemini Live 这类 realtime 后端在输出转录里把中文 token 切开
+    （"你 好 世 界"）的 artifact。相比 :func:`replace_blank`：
+
+    - 前者只在两侧均为 ASCII 非空格字符时保留空格，会误伤 Korean /
+      Cyrillic / Arabic / Thai 等"非 ASCII 但靠空格分词"的脚本
+      （"안녕하세요 여러분" → "안녕하세요여러분"）。
+    - 本函数只在 CJK 汉字/假名邻接的情况下删空格，其余场景一律保留。
+
+    判邻居时会**跳过连续空格**找到最近的非空格字符，这样
+    ``"你好   世界"`` 整段 3 个空格都会被删掉，而不是只删掉最外侧两个。
+    """
+    n = len(text)
+    out = []
+    for i, c in enumerate(text):
+        if c == " ":
+            # 向左跳过连续空格找最近非空格
+            j = i - 1
+            while j >= 0 and text[j] == " ":
+                j -= 1
+            left = text[j] if j >= 0 else ""
+            # 向右跳过连续空格找最近非空格
+            j = i + 1
+            while j < n and text[j] == " ":
+                j += 1
+            right = text[j] if j < n else ""
+            if _is_cjk_glue_char(left) or _is_cjk_glue_char(right):
+                continue
+        out.append(c)
+    return "".join(out)
+
+
 class TtsStreamNormalizer:
     """跨 chunk 安全的 TTS 文本规范化器。
 
     Gemini Live 等 realtime 后端的 output transcript 会在中文 token 之间
     插入 ASCII 空格（"你 好 世 界"），MiniMax / CosyVoice 等 streaming
-    TTS 会把这些断开的中文读成顿挫的短片段。该 normalizer 复用
-    :func:`replace_blank` 的语义（只保留两侧均为非空格 ASCII 的空格），
-    但针对 streaming 场景做了两项关键处理：
+    TTS 会把这些断开的中文读成顿挫的短片段。该 normalizer 用
+    :func:`drop_cjk_boundary_spaces` 去除 CJK 邻接的 ASCII 空格，同时
+    针对 streaming 场景做了两项关键处理：
 
     1. 尾部空格**延后决策**：chunk 末尾的 ASCII 空格暂存到下一个 chunk
        出现时，再结合后一个字符判断是否保留。
     2. 左侧上下文**跨 chunk 继承**：用上一次 emit 出的最后一个非空格字符
        作为下个 chunk 首位空格的"左邻居"，避免在 chunk 边界误判。
 
-    每个新的 TTS 轮次（speech_id 切换）必须调用 :meth:`reset`。
+    刻意**不碰**非 CJK 脚本（Korean / Cyrillic / Arabic / Thai 等）的空格，
+    它们靠 ASCII 空格做分词，删掉会让 TTS 彻底读不对。每个新的 TTS 轮次
+    （speech_id 切换）必须调用 :meth:`reset`。
     """
 
     __slots__ = ("_last_nonspace", "_pending_spaces")
@@ -193,10 +250,10 @@ class TtsStreamNormalizer:
         if not stripped:
             return ""
 
-        # 用上次 emit 的末位非空格字符当左邻居；非空格保证 replace_blank
-        # 不会丢掉 prefix 本身，可以用长度精确剥离。
+        # 用上次 emit 的末位非空格字符当左邻居；非空格保证
+        # drop_cjk_boundary_spaces 不会丢掉 prefix 本身，可以用长度精确剥离。
         prefix = self._last_nonspace
-        filtered = replace_blank(prefix + stripped)
+        filtered = drop_cjk_boundary_spaces(prefix + stripped)
         if prefix and filtered.startswith(prefix):
             filtered = filtered[len(prefix):]
 

--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -130,15 +130,88 @@ def split_paragraph(text: str, force_process=False, lang="zh", token_min_n=2.5, 
 
 # remove blank between chinese character
 def replace_blank(text: str):
+    """保留两侧都是"非空格 ASCII 字符"的空格，其余 ASCII 空格一律去掉。
+
+    用于处理 Gemini Live output transcript 之类把中文词中间插入空格、
+    以及中英交界处的 ASCII 空格场景——这些空格会让 TTS 把中文读断。
+
+    边界字符（i==0 或 i==末尾）没有对应侧的邻居，一律按"非 ASCII/空格"处理
+    直接丢弃，避免 Python 负索引或 IndexError。
+    """
+    n = len(text)
     out_str = []
     for i, c in enumerate(text):
         if c == " ":
-            if ((text[i + 1].isascii() and text[i + 1] != " ") and
-                    (text[i - 1].isascii() and text[i - 1] != " ")):
+            left = text[i - 1] if i > 0 else ""
+            right = text[i + 1] if i + 1 < n else ""
+            if (left and left.isascii() and left != " "
+                    and right and right.isascii() and right != " "):
                 out_str.append(c)
         else:
             out_str.append(c)
     return "".join(out_str)
+
+
+class TtsStreamNormalizer:
+    """跨 chunk 安全的 TTS 文本规范化器。
+
+    Gemini Live 等 realtime 后端的 output transcript 会在中文 token 之间
+    插入 ASCII 空格（"你 好 世 界"），MiniMax / CosyVoice 等 streaming
+    TTS 会把这些断开的中文读成顿挫的短片段。该 normalizer 复用
+    :func:`replace_blank` 的语义（只保留两侧均为非空格 ASCII 的空格），
+    但针对 streaming 场景做了两项关键处理：
+
+    1. 尾部空格**延后决策**：chunk 末尾的 ASCII 空格暂存到下一个 chunk
+       出现时，再结合后一个字符判断是否保留。
+    2. 左侧上下文**跨 chunk 继承**：用上一次 emit 出的最后一个非空格字符
+       作为下个 chunk 首位空格的"左邻居"，避免在 chunk 边界误判。
+
+    每个新的 TTS 轮次（speech_id 切换）必须调用 :meth:`reset`。
+    """
+
+    __slots__ = ("_last_nonspace", "_pending_spaces")
+
+    def __init__(self):
+        self._last_nonspace = ""
+        self._pending_spaces = ""
+
+    def reset(self) -> None:
+        """清空状态。新 speech_id 或中断时调用。"""
+        self._last_nonspace = ""
+        self._pending_spaces = ""
+
+    def feed(self, chunk: str) -> str:
+        """输入一个新 chunk，返回当前可安全 emit 的已规范化文本。"""
+        if not chunk:
+            return ""
+
+        work = self._pending_spaces + chunk
+
+        # 尾部 ASCII 空格暂存，等下一个 chunk 的首字符决定去留
+        stripped = work.rstrip(" ")
+        self._pending_spaces = work[len(stripped):]
+        if not stripped:
+            return ""
+
+        # 用上次 emit 的末位非空格字符当左邻居；非空格保证 replace_blank
+        # 不会丢掉 prefix 本身，可以用长度精确剥离。
+        prefix = self._last_nonspace
+        filtered = replace_blank(prefix + stripped)
+        if prefix and filtered.startswith(prefix):
+            filtered = filtered[len(prefix):]
+
+        for c in reversed(filtered):
+            if c != " ":
+                self._last_nonspace = c
+                break
+
+        return filtered
+
+    def flush(self) -> str:
+        """轮次结束收尾：丢弃悬挂的尾部空格并清空状态。"""
+        self._pending_spaces = ""
+        self._last_nonspace = ""
+        return ""
 
 
 def is_only_punctuation(text):


### PR DESCRIPTION
## 背景

Gemini Live API 的 output transcript 会在中文 token 之间插入 ASCII 空格（例如 \`你 好 世 界\`，原因诡异），MiniMax / CosyVoice 等 streaming TTS 会把这些断开的中文读成顿挫的短片段。

\`replace_blank\` 本来就是为"去掉中文/中英交界空格、保留英文词间空格"设计的，只是之前只在 \`cross_server\` 同步历史里用，实时 TTS 链路没接上。

## 变更

### \`utils/frontend_utils.py\`
- 修 \`replace_blank\` 两个边界 bug：
  - \`i==0\` 时 \`text[i-1]\` 走 Python 负索引回绕到末尾
  - \`i==末位\` 时 \`text[i+1]\` IndexError
- 新增 \`TtsStreamNormalizer\`：**跨 chunk 安全**的规范化器
  - 尾部 ASCII 空格**延后决策**：暂存到下次 feed 看到首字符再判断
  - **左上下文跨 chunk 继承**：记住上次 emit 的末位非空格字符作为下个 chunk 首位空格的左邻居
  - \`reset()\` / \`flush()\` 用于轮次切换与中断

### \`main_logic/core.py\`
- 新增 \`_enqueue_tts_text_chunk(speech_id, text)\` helper，4 个入队点统一走它
  - \`handle_text_data\`、\`handle_output_transcript\`、\`_flush_tts_pending_chunks\`、\`feed_tts_chunk\`
- speech_id 切换自动 reset；\`_clear_tts_pipeline\` 在 \`__interrupt__\` 后显式 reset
- 控制信号（\`__interrupt__\` / \`(None, None)\`）保留原始 \`put\`，不过 helper

### \`tests/unit/test_tts_stream_normalizer.py\`
28 用例全绿：
- \`replace_blank\` 中文边界语义 + 边界安全
- 单 chunk 与 \`replace_blank\` 完全一致
- Gemini 碎片流：\`[\"你 好\", \" 世\", \" 界\"]\` → \`\"你好世界\"\`
- 跨 chunk 保留 ASCII 词间空格：\`\"hello \" + \"world\"\` → \`\"hello world\"\`
- 跨 chunk 删中文邻接空格：\`\"hello \" + \" 你好\"\` → \`\"hello你好\"\`
- 单字符极端碎片化 / flush / reset / 空 chunk / 纯空格 chunk
- **参数化端到端**：任意切分点下 \`sum(feed) + flush()\` == \`replace_blank(full_text).rstrip(\" \")\`

### 不动的地方
- \`local_server/cosyvoice_server/CosyVoice/utils/frontend_utils.py\` 是 vendored 上游 Alibaba 代码
- \`cross_server.py\` 的 \`normalize_text\` 走非 streaming 路径，边界修复对它透明兼容

## Test plan

- [x] \`uv run pytest tests/unit/test_tts_stream_normalizer.py\` 28 passed
- [x] \`main_logic.core\` 导入 smoke test
- [ ] 实机验证 Gemini Live + MiniMax：确认不再读断中文
- [ ] 实机验证 Gemini Live + CosyVoice：同上
- [ ] 实机验证文本模式 + TTS：英文词间空格不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复并稳健化流式文本中空格处理与边界判断，避免越界和错误丢失/保留空格的情况。

* **改进**
  * 引入流式 TTS 文本归一化流程，延迟跨块空格判定以防上下文泄漏并确保输出一致性。

* **测试**
  * 新增全面单元测试，覆盖多种脚本、极端分片、reset/flush 行为，验证端到端规范化一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->