### PR TITLE
修复手机端 React 聊天窗口无法拖动的问题，最小化改为 50px 圆形悬浮球（与桌面端一致），并新增顶部拖拽手柄支持手动调整聊天框高度

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -944,9 +944,7 @@
         };
     }
 
-    var MINIMIZED_SIZE = 50;            // 桌面：圆球直径
-    var MOBILE_CAPSULE_HEIGHT = 48;     // 手机：底部胶囊高度
-    var MOBILE_CAPSULE_MARGIN = 6;      // 手机：胶囊离屏幕边距
+    var MINIMIZED_SIZE = 50;            // 桌面/手机：圆球直径
     var isMinimizeTransitioning = false;
     var activeAnimationCleanup = null; // 当前进行中动画的清理函数
 
@@ -1097,17 +1095,19 @@
             // 恢复保存的尺寸
             shell.classList.remove('is-minimized');
             if (isMobileWidth()) {
-                // 手机端：宽度永远是全宽（由 CSS 对非动画态的 `.is-minimized`/展开态
-                // 双向 !important 覆盖），所以忽略 savedShellSize.width —— 否则旋屏
-                // (portrait→landscape) 后 savedSize.width < curRect.width，
-                // expandedRect 被 savedSize 缩窄，sx2 > 1，动画反向缩小。
-                // 高度按当前视口 50vh 重新 clamp，避免旋屏或视口变短后超出上限。
-                shell.style.width = Math.max(0, window.innerWidth - MOBILE_CAPSULE_MARGIN * 2) + 'px';
-                var maxMobileHeight = Math.max(0, Math.floor(window.innerHeight * MOBILE_MAX_HEIGHT_RATIO));
+                // 手机端：宽度由 CSS calc(100vw - 12px) 控制，清除内联宽度
+                shell.style.removeProperty('width');
+                // 高度：优先使用用户手动设置的高度，否则自动计算上限 85vh
+                var mobileMaxH = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
                 var savedHeightPx = savedShellSize ? parseFloat(savedShellSize.height) : NaN;
-                var restoreHeight = isFinite(savedHeightPx) && savedHeightPx > 0
-                    ? Math.min(savedHeightPx, maxMobileHeight)
-                    : maxMobileHeight;
+                var restoreHeight;
+                if (mobileUserHeight > 0) {
+                    restoreHeight = Math.min(mobileUserHeight, mobileMaxH);
+                } else if (isFinite(savedHeightPx) && savedHeightPx > 0) {
+                    restoreHeight = Math.min(savedHeightPx, mobileMaxH);
+                } else {
+                    restoreHeight = Math.floor(window.innerHeight * MOBILE_MAX_HEIGHT_RATIO);
+                }
                 if (restoreHeight > 0) shell.style.height = restoreHeight + 'px';
             } else if (savedShellSize) {
                 if (savedShellSize.width) shell.style.width = savedShellSize.width;
@@ -1507,9 +1507,13 @@
         newHeight = Math.min(newHeight, window.innerHeight);
 
         if (mobile) {
-            // 手机端仅更新高度，保持 CSS 控制的 bottom/left/width
+            // 手机端：更新高度和 top，保持 CSS 控制的 left/width
             var maxMobileH = Math.floor(window.innerHeight * 0.85);
-            shell.style.height = Math.min(newHeight, maxMobileH) + 'px';
+            var clampedH = Math.min(newHeight, maxMobileH);
+            shell.style.height = clampedH + 'px';
+            // 设置 top 并清除 bottom，使北侧拖拽正确向上扩展
+            shell.style.top = newTop + 'px';
+            shell.style.bottom = 'auto';
         } else {
             shell.style.width = newWidth + 'px';
             shell.style.height = newHeight + 'px';
@@ -1526,8 +1530,10 @@
         if (shell) {
             var rect = shell.getBoundingClientRect();
             if (isMobileWidth()) {
-                // 手机端：保存用户设置的高度
+                // 手机端：保存用户设置的高度，恢复底部锚定
                 mobileUserHeight = Math.round(rect.height);
+                shell.style.removeProperty('top');
+                shell.style.removeProperty('bottom');
                 try {
                     localStorage.setItem(MOBILE_HEIGHT_STORAGE_KEY, String(mobileUserHeight));
                 } catch (_) {}
@@ -1706,9 +1712,9 @@
                         var minH = r.height || MINIMIZED_SIZE;
                         var safeLeft, safeTop;
                         if (isMobileWidth()) {
-                            // 胶囊始终贴屏幕底部中心，左右留 6px
-                            safeLeft = MOBILE_CAPSULE_MARGIN;
-                            safeTop = Math.max(0, window.innerHeight - MOBILE_CAPSULE_HEIGHT - MOBILE_CAPSULE_MARGIN);
+                            // 圆形悬浮球：保持用户拖拽位置，仅 clamp 到视口内
+                            safeLeft = Math.max(0, Math.min(r.left, window.innerWidth - minW));
+                            safeTop = Math.max(0, Math.min(r.top, window.innerHeight - minH));
                         } else {
                             safeLeft = Math.max(0, Math.min(r.left, window.innerWidth - minW));
                             safeTop = Math.max(0, Math.min(r.top, window.innerHeight - minH));

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -39,6 +39,9 @@
 
     var MOBILE_MAX_HEIGHT_RATIO = 0.5;
     var MOBILE_MESSAGE_MIN_HEIGHT = 60;
+    var MOBILE_MIN_HEIGHT = 150;
+    var MOBILE_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.mobileHeight';
+    var mobileUserHeight = 0; // 用户手动设置的手机端高度（0 = 自动）
     var mobileLayoutFrame = 0;
 
     function $(id) {
@@ -113,6 +116,16 @@
         var root = getRoot();
         if (!overlay || overlay.hidden || !shell || !root || minimized || !isMobileWidth()) {
             clearMobileContentCap();
+            return;
+        }
+
+        // 如果用户手动设置了高度，使用用户高度，不自动计算
+        if (mobileUserHeight > 0) {
+            var maxH = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
+            var h = Math.min(mobileUserHeight, maxH);
+            shell.style.height = h + 'px';
+            shell.dataset.mobileAutoHeight = 'false';
+            shell.classList.remove('is-mobile-content-capped');
             return;
         }
 
@@ -521,7 +534,7 @@
 
     function applyPosition(left, top) {
         var shell = getShell();
-        if (!shell || isMobileWidth()) return;
+        if (!shell) return;
 
         var clamped = clampPosition(left, top);
         shell.style.left = clamped.left + 'px';
@@ -944,20 +957,7 @@
     // target.left 应等于 rect.left 同列，target 底边应与 rect 底边对齐
     // （即 target.top = rect.bottom - target.height），这样动画过程中底边不漂移。
     function getMinimizedTarget(rect) {
-        if (isMobileWidth()) {
-            var mobileWidth = Math.max(0, window.innerWidth - MOBILE_CAPSULE_MARGIN * 2);
-            // 胶囊四周保持 MOBILE_CAPSULE_MARGIN 间距（与左右 6px 对称）
-            var mobileBottomTop = Math.max(0, window.innerHeight - MOBILE_CAPSULE_HEIGHT - MOBILE_CAPSULE_MARGIN);
-            return {
-                width: mobileWidth,
-                height: MOBILE_CAPSULE_HEIGHT,
-                left: MOBILE_CAPSULE_MARGIN,
-                top: Math.max(0, Math.min(
-                    rect.bottom - MOBILE_CAPSULE_HEIGHT,
-                    mobileBottomTop
-                ))
-            };
-        }
+        // 桌面端和移动端统一使用 50px 圆形悬浮球
         return {
             width: MINIMIZED_SIZE,
             height: MINIMIZED_SIZE,
@@ -1320,7 +1320,6 @@
     function startDrag(clientX, clientY) {
         var shell = getShell();
         if (!shell) return;
-        if (isMobileWidth() && !minimized) return;
 
         var rect = shell.getBoundingClientRect();
         dragState = {
@@ -1399,7 +1398,8 @@
             if (avatarHeaderBtn && avatarHeaderBtn.contains(event.target)) return;
             if (!event.touches || event.touches.length === 0) return;
             startDrag(event.touches[0].clientX, event.touches[0].clientY);
-        }, { passive: true });
+            event.preventDefault();
+        }, { passive: false });
 
         document.addEventListener('mousemove', function (event) {
             if (!dragState) return;
@@ -1408,8 +1408,9 @@
 
         document.addEventListener('touchmove', function (event) {
             if (!dragState || !event.touches || event.touches.length === 0) return;
+            event.preventDefault();
             updateDrag(event.touches[0].clientX, event.touches[0].clientY);
-        }, { passive: true });
+        }, { passive: false });
 
         document.addEventListener('mouseup', stopDrag);
         document.addEventListener('touchend', stopDrag);
@@ -1434,7 +1435,10 @@
 
     function startResize(clientX, clientY, direction) {
         var shell = getShell();
-        if (!shell || isMobileWidth()) return;
+        if (!shell) return;
+        // 手机端仅允许向上拖动调整高度（北侧边缘）
+        if (isMobileWidth() && direction !== 'n') return;
+        if (minimized) return;
 
         var rect = shell.getBoundingClientRect();
         resizeState = {
@@ -1465,10 +1469,13 @@
         var newWidth = resizeState.origWidth;
         var newHeight = resizeState.origHeight;
 
-        if (dir.indexOf('e') !== -1) {
+        // 手机端仅处理高度变化
+        var mobile = isMobileWidth();
+
+        if (!mobile && dir.indexOf('e') !== -1) {
             newWidth = Math.max(MIN_WIDTH, resizeState.origWidth + dx);
         }
-        if (dir.indexOf('w') !== -1) {
+        if (!mobile && dir.indexOf('w') !== -1) {
             var proposedWidth = resizeState.origWidth - dx;
             if (proposedWidth >= MIN_WIDTH) {
                 newWidth = proposedWidth;
@@ -1478,17 +1485,18 @@
                 newLeft = resizeState.origLeft + resizeState.origWidth - MIN_WIDTH;
             }
         }
-        if (dir.indexOf('s') !== -1) {
+        if (!mobile && dir.indexOf('s') !== -1) {
             newHeight = Math.max(MIN_HEIGHT, resizeState.origHeight + dy);
         }
         if (dir.indexOf('n') !== -1) {
+            var minH = mobile ? MOBILE_MIN_HEIGHT : MIN_HEIGHT;
             var proposedHeight = resizeState.origHeight - dy;
-            if (proposedHeight >= MIN_HEIGHT) {
+            if (proposedHeight >= minH) {
                 newHeight = proposedHeight;
                 newTop = resizeState.origTop + dy;
             } else {
-                newHeight = MIN_HEIGHT;
-                newTop = resizeState.origTop + resizeState.origHeight - MIN_HEIGHT;
+                newHeight = minH;
+                newTop = resizeState.origTop + resizeState.origHeight - minH;
             }
         }
 
@@ -1498,11 +1506,17 @@
         newWidth = Math.min(newWidth, window.innerWidth);
         newHeight = Math.min(newHeight, window.innerHeight);
 
-        shell.style.width = newWidth + 'px';
-        shell.style.height = newHeight + 'px';
-        shell.style.left = newLeft + 'px';
-        shell.style.top = newTop + 'px';
-        shell.style.transform = 'none';
+        if (mobile) {
+            // 手机端仅更新高度，保持 CSS 控制的 bottom/left/width
+            var maxMobileH = Math.floor(window.innerHeight * 0.85);
+            shell.style.height = Math.min(newHeight, maxMobileH) + 'px';
+        } else {
+            shell.style.width = newWidth + 'px';
+            shell.style.height = newHeight + 'px';
+            shell.style.left = newLeft + 'px';
+            shell.style.top = newTop + 'px';
+            shell.style.transform = 'none';
+        }
     }
 
     function stopResize() {
@@ -1511,8 +1525,16 @@
         var shell = getShell();
         if (shell) {
             var rect = shell.getBoundingClientRect();
-            persistPosition(rect.left, rect.top);
-            persistSize(rect.width, rect.height);
+            if (isMobileWidth()) {
+                // 手机端：保存用户设置的高度
+                mobileUserHeight = Math.round(rect.height);
+                try {
+                    localStorage.setItem(MOBILE_HEIGHT_STORAGE_KEY, String(mobileUserHeight));
+                } catch (_) {}
+            } else {
+                persistPosition(rect.left, rect.top);
+                persistSize(rect.width, rect.height);
+            }
         }
 
         resizeState = null;
@@ -1535,7 +1557,8 @@
             if (!target || !target.dataset || !target.dataset.resizeDir) return;
             if (!event.touches || event.touches.length === 0) return;
             startResize(event.touches[0].clientX, event.touches[0].clientY, target.dataset.resizeDir);
-        }, { passive: true });
+            event.preventDefault();
+        }, { passive: false });
 
         document.addEventListener('mousemove', function (event) {
             if (!resizeState) return;
@@ -1544,8 +1567,9 @@
 
         document.addEventListener('touchmove', function (event) {
             if (!resizeState || !event.touches || event.touches.length === 0) return;
+            event.preventDefault();
             updateResize(event.touches[0].clientX, event.touches[0].clientY);
-        }, { passive: true });
+        }, { passive: false });
 
         document.addEventListener('mouseup', stopResize);
         document.addEventListener('touchend', stopResize);
@@ -1631,6 +1655,17 @@
         createResizeEdges();
         bindResizing();
         bindBridgeEvents();
+
+        // 恢复手机端用户设置的高度
+        try {
+            var storedMobileHeight = localStorage.getItem(MOBILE_HEIGHT_STORAGE_KEY);
+            if (storedMobileHeight) {
+                var parsed = Number(storedMobileHeight);
+                if (Number.isFinite(parsed) && parsed >= MOBILE_MIN_HEIGHT) {
+                    mobileUserHeight = parsed;
+                }
+            }
+        } catch (_) {}
 
         // 悬浮球 hover 效果（参考原版 #chat-container 实现）
         var header = getHeader();

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -119,6 +119,9 @@
             return;
         }
 
+        // 正在拖拽调整高度时不覆盖，等 stopResize() 结束后再同步
+        if (resizeState) return;
+
         // 如果用户手动设置了高度，使用用户高度，不自动计算
         if (mobileUserHeight > 0) {
             var maxH = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
@@ -1511,6 +1514,10 @@
             // 手机端：更新高度和 top，保持 CSS 控制的 left/width
             var maxMobileH = Math.floor(window.innerHeight * 0.85);
             var clampedH = Math.min(newHeight, maxMobileH);
+            // 高度被截断时重新计算 top，保持面板底部不动
+            if (clampedH < newHeight) {
+                newTop = window.innerHeight - clampedH;
+            }
             shell.style.height = clampedH + 'px';
             // 设置 top 并清除 bottom，使北侧拖拽正确向上扩展
             shell.style.top = newTop + 'px';

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -52,10 +52,16 @@
         return document.getElementById(id);
     }
 
+    function isElectronChatWindow() {
+        // chat.html 用 <body class="electron-chat-window">；Electron 独立聊天窗口。
+        // 本 PR 的所有移动端改动都必须对它无感，作为显式隔离在全局 touch 处理里用来短路。
+        return !!(document.body && document.body.classList.contains('electron-chat-window'));
+    }
+
     function isMobileWidth() {
         // chat.html 是 Electron 独立窗口，始终按 PC 行为处理（即使用户把窗口拖窄到 <768px），
         // 通过 <body class="electron-chat-window"> 从"手机端布局"中排除。
-        if (document.body && document.body.classList.contains('electron-chat-window')) {
+        if (isElectronChatWindow()) {
             return false;
         }
         return window.innerWidth <= 768;
@@ -1423,7 +1429,8 @@
 
         document.addEventListener('touchmove', function (event) {
             if (!dragState || !event.touches || event.touches.length === 0) return;
-            event.preventDefault();
+            // chat.html 不走 mobile 路径，保留原 passive: true 语义，不吞原生滚动。
+            if (!isElectronChatWindow()) event.preventDefault();
             updateDrag(event.touches[0].clientX, event.touches[0].clientY);
         }, { passive: false });
 
@@ -1582,8 +1589,8 @@
             if (!target || !target.dataset || !target.dataset.resizeDir) return;
             if (!event.touches || event.touches.length === 0) return;
             startResize(event.touches[0].clientX, event.touches[0].clientY, target.dataset.resizeDir);
-            // 只在确实进入 resize 状态后才吞事件（手机端非 n 方向 / 最小化态会 bail out）
-            if (resizeState) event.preventDefault();
+            // chat.html 保留原 passive 语义；只在真正进入 resize（非 chat.html）才吞事件。
+            if (resizeState && !isElectronChatWindow()) event.preventDefault();
         }, { passive: false });
 
         document.addEventListener('mousemove', function (event) {
@@ -1593,7 +1600,7 @@
 
         document.addEventListener('touchmove', function (event) {
             if (!resizeState || !event.touches || event.touches.length === 0) return;
-            event.preventDefault();
+            if (!isElectronChatWindow()) event.preventDefault();
             updateResize(event.touches[0].clientX, event.touches[0].clientY);
         }, { passive: false });
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1582,7 +1582,8 @@
             if (!target || !target.dataset || !target.dataset.resizeDir) return;
             if (!event.touches || event.touches.length === 0) return;
             startResize(event.touches[0].clientX, event.touches[0].clientY, target.dataset.resizeDir);
-            event.preventDefault();
+            // 只在确实进入 resize 状态后才吞事件（手机端非 n 方向 / 最小化态会 bail out）
+            if (resizeState) event.preventDefault();
         }, { passive: false });
 
         document.addEventListener('mousemove', function (event) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -37,12 +37,16 @@
         onComposerSubmit: null
     };
 
-    var MOBILE_MAX_HEIGHT_RATIO = 0.5;
+    var MOBILE_MAX_HEIGHT_RATIO = 0.85;
     var MOBILE_MESSAGE_MIN_HEIGHT = 60;
     var MOBILE_MIN_HEIGHT = 150;
     var MOBILE_HEIGHT_STORAGE_KEY = 'neko.reactChatWindow.mobileHeight';
     var mobileUserHeight = 0; // 用户手动设置的手机端高度（0 = 自动）
     var mobileLayoutFrame = 0;
+
+    function getMobileMaxHeight() {
+        return Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * MOBILE_MAX_HEIGHT_RATIO));
+    }
 
     function $(id) {
         return document.getElementById(id);
@@ -124,8 +128,7 @@
 
         // 如果用户手动设置了高度，使用用户高度，不自动计算
         if (mobileUserHeight > 0) {
-            var maxH = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
-            var h = Math.min(mobileUserHeight, maxH);
+            var h = Math.min(mobileUserHeight, getMobileMaxHeight());
             shell.style.height = h + 'px';
             shell.dataset.mobileAutoHeight = 'false';
             shell.classList.remove('is-mobile-content-capped');
@@ -140,7 +143,7 @@
             return;
         }
 
-        var maxHeight = Math.max(0, Math.floor(window.innerHeight * MOBILE_MAX_HEIGHT_RATIO));
+        var maxHeight = getMobileMaxHeight();
         if (!maxHeight) return;
 
         var desiredMessageHeight = Math.max(MOBILE_MESSAGE_MIN_HEIGHT, messageList.scrollHeight);
@@ -561,14 +564,21 @@
         if (!shell) return;
 
         if (isMobileWidth()) {
-            shell.style.removeProperty('left');
-            shell.style.removeProperty('top');
+            // 宽度由 CSS calc(100vw - 12px) 控制；transform 的 translate 会污染 applyPosition 坐标。
             shell.style.removeProperty('width');
-            // 不清 height：清掉会让 shell 瞬间回到 CSS 的 `height:auto;max-height:50vh`，
+            shell.style.removeProperty('transform');
+            // 不清 height：清掉会让 shell 瞬间回到 CSS 的 `height:auto;max-height:85vh`，
             // grid `auto 1fr auto` 父容器塌缩会把 .message-list 的 clientHeight 挤到几十 px，
             // 浏览器 clamp scrollTop → 0，下一帧 syncMobileContentLayout() 恢复 height 时已经来不及。
             // 保留旧像素值，让紧随其后的 syncMobileContentLayout() 直接覆写，避免中间态。
-            shell.style.removeProperty('transform');
+            // 不清 left/top：手机端允许 expanded 在任意位置飘；只按新视口 clamp 一次，避免旋屏/键盘后溢出。
+            if (shell.style.left || shell.style.top) {
+                var rect = shell.getBoundingClientRect();
+                var clampedLeft = Math.max(0, Math.min(rect.left, window.innerWidth - rect.width));
+                var clampedTop = Math.max(0, Math.min(rect.top, window.innerHeight - rect.height));
+                shell.style.left = clampedLeft + 'px';
+                shell.style.top = clampedTop + 'px';
+            }
             return;
         }
 
@@ -1101,7 +1111,7 @@
                 // 手机端：宽度由 CSS calc(100vw - 12px) 控制，清除内联宽度
                 shell.style.removeProperty('width');
                 // 高度：优先使用用户手动设置的高度，否则自动计算上限 85vh
-                var mobileMaxH = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
+                var mobileMaxH = getMobileMaxHeight();
                 var savedHeightPx = savedShellSize ? parseFloat(savedShellSize.height) : NaN;
                 var restoreHeight;
                 if (mobileUserHeight > 0) {
@@ -1109,7 +1119,7 @@
                 } else if (isFinite(savedHeightPx) && savedHeightPx > 0) {
                     restoreHeight = Math.min(savedHeightPx, mobileMaxH);
                 } else {
-                    restoreHeight = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
+                    restoreHeight = mobileMaxH;
                 }
                 if (restoreHeight > 0) shell.style.height = restoreHeight + 'px';
             } else if (savedShellSize) {
@@ -1393,6 +1403,8 @@
             event.preventDefault();
         });
 
+        // touchstart 不 preventDefault：让浏览器自行决定是滚动还是点击，
+        // 真正进入拖拽后由 touchmove（passive: false）阻止滚动即可。
         header.addEventListener('touchstart', function (event) {
             var closeButton = $('reactChatWindowCloseButton');
             if (closeButton && closeButton.contains(event.target)) return;
@@ -1402,8 +1414,7 @@
             if (avatarHeaderBtn && avatarHeaderBtn.contains(event.target)) return;
             if (!event.touches || event.touches.length === 0) return;
             startDrag(event.touches[0].clientX, event.touches[0].clientY);
-            event.preventDefault();
-        }, { passive: false });
+        }, { passive: true });
 
         document.addEventListener('mousemove', function (event) {
             if (!dragState) return;
@@ -1512,7 +1523,7 @@
 
         if (mobile) {
             // 手机端：更新高度和 top，保持 CSS 控制的 left/width
-            var maxMobileH = Math.floor(window.innerHeight * 0.85);
+            var maxMobileH = getMobileMaxHeight();
             var clampedH = Math.min(newHeight, maxMobileH);
             // 高度被截断时重新计算 top，保持面板底部不动
             if (clampedH < newHeight) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -86,7 +86,7 @@
         if (!shell) return;
 
         shell.classList.remove('is-mobile-content-capped');
-        if (shell.dataset.mobileAutoHeight === 'true') {
+        if (shell.dataset.mobileAutoHeight !== undefined) {
             shell.style.removeProperty('height');
             delete shell.dataset.mobileAutoHeight;
         }
@@ -1106,7 +1106,7 @@
                 } else if (isFinite(savedHeightPx) && savedHeightPx > 0) {
                     restoreHeight = Math.min(savedHeightPx, mobileMaxH);
                 } else {
-                    restoreHeight = Math.floor(window.innerHeight * MOBILE_MAX_HEIGHT_RATIO);
+                    restoreHeight = Math.max(MOBILE_MIN_HEIGHT, Math.floor(window.innerHeight * 0.85));
                 }
                 if (restoreHeight > 0) shell.style.height = restoreHeight + 'px';
             } else if (savedShellSize) {
@@ -1194,7 +1194,7 @@
                     var r = shell.getBoundingClientRect();
                     var clamped = clampPosition(r.left, r.top);
                     applyPosition(clamped.left, clamped.top);
-                    if (!window._chatAdapterActive) {
+                    if (!window._chatAdapterActive && !isMobileWidth()) {
                         persistPosition(clamped.left, clamped.top);
                     }
                 });
@@ -1360,7 +1360,8 @@
             var rect = shell.getBoundingClientRect();
             // 最小化态下不持久化悬浮球坐标到展开态存储，
             // 否则 restorePosition 会把完整窗口放到悬浮球位置
-            if (!minimized) {
+            // 移动端坐标也不持久化，避免污染桌面端保存的位置
+            if (!minimized && !isMobileWidth()) {
                 persistPosition(rect.left, rect.top);
             }
         }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2244,7 +2244,7 @@ body.react-chat-window-dragging {
     body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized):not(.is-collapsing):not(.is-expanding) {
         width: calc(100vw - 12px);
         height: auto;
-        max-height: 50vh;
+        max-height: 85vh;
         top: auto;
         bottom: 6px;
         left: 6px;
@@ -2307,29 +2307,55 @@ body.react-chat-window-dragging {
     }
 
     body:not(.electron-chat-window) #react-chat-window-drag-handle {
-        cursor: default;
+        cursor: grab;
     }
 
-    /* ---- 手机端最小化：全宽底部胶囊（替代 50px 圆球）----
-       胶囊横跨屏幕底部，点击即展开；比左下角小圆球更符合手机底栏交互习惯。
-       具体最小化尺寸由 JS 通过 transform scale 动画过渡到此 CSS 终态。 */
+    /* 手机端：仅显示顶部拖拽边缘用于调整高度，隐藏其余方向 */
+    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-edge {
+        display: none;
+    }
+    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-n {
+        display: block;
+        height: 14px;
+        top: -4px;
+        left: 0;
+        right: 0;
+        cursor: n-resize;
+        /* 可视拖拽指示条 */
+        background: transparent;
+    }
+    body:not(.electron-chat-window) #react-chat-window-shell:not(.is-minimized) .react-chat-resize-n::after {
+        content: '';
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 36px;
+        height: 4px;
+        border-radius: 2px;
+        background: rgba(150, 160, 175, 0.4);
+    }
+
+    /* ---- 手机端最小化：50px 圆形悬浮球（与桌面端一致）----
+       替代原先的全宽底部胶囊，使用圆形小球，可自由拖动 */
     body:not(.electron-chat-window) #react-chat-window-shell.is-minimized {
-        width: calc(100vw - 12px) !important;
-        height: 48px !important;
-        border-radius: 24px;
+        width: 50px !important;
+        height: 50px !important;
+        border-radius: 50%;
     }
 
     body:not(.electron-chat-window) #react-chat-window-shell.is-minimized #react-chat-window-drag-handle {
         display: flex;
         align-items: center;
         justify-content: center;
+        cursor: pointer;
     }
 
     body:not(.electron-chat-window) #react-chat-window-shell.is-minimized .react-chat-minimized-icon {
-        width: 28px;
-        height: 28px;
-        /* 居中显示而非填满整条胶囊 */
+        width: 100%;
+        height: 100%;
         object-fit: contain;
+        pointer-events: none;
     }
 
     #chat-container.minimized::before {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -2271,7 +2271,8 @@ body.react-chat-window-dragging {
 
     /* 窄屏与桌面统一用 grid 布局：auto(顶栏) 1fr(消息) auto(输入) +
        overflow:hidden 保证输入区不会被消息挤出。shell 尺寸仍由
-       syncMobileContentLayout() 写成显式像素（根据内容 50vh 上限）。 */
+       syncMobileContentLayout() 写成显式像素（根据内容，最高 85vh；
+       用户拖过顶部手柄后走 mobileUserHeight 持久化值）。 */
     body:not(.electron-chat-window) #react-chat-window-shell .chat-window {
         height: 100%;
         display: grid;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 移动端支持用户自定义并持久保存窗口高度，恢复时优先使用用户高度并随窗口变化保持锚定。

* **改进**
  * 移动端最大高度提升至屏幕85%。
  * 最小化统一为50×50圆形气泡，图标填充气泡并禁用指针事件；气泡锚点随视口约束，展开时行为更一致。
  * 移动端仅上缘可调整高度、禁止在最小化时调整，触控交互与拖拽手感优化，持久化与自动高度逻辑改进。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->