### PR TITLE
fix: jukebox 独立窗口按钮点击失灵 (Chromium drag region 缓存 bug)

### DIFF
--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3458,6 +3458,7 @@ window.Jukebox = {
     jukeboxContainer.className = 'jukebox-container';
     jukeboxContainer.innerHTML = `
       <div class="jukebox-header">
+        <div class="jukebox-drag-overlay"></div>
         <div class="jukebox-header-left">
           <h3>${window.t('Jukebox.title', '点歌台')}</h3>
           <span id="jukebox-status-text" class="jukebox-status-text">${window.t('Jukebox.ready', '准备就绪')}</span>
@@ -3549,6 +3550,57 @@ window.Jukebox = {
     }
     
     Jukebox.injectStyles();
+
+    // 独立窗口：使用专属拖拽层（.jukebox-drag-overlay）处理原生窗口拖拽，
+    // 所有交互区域显式 no-drag，防止 preload 注入 drag 覆盖。
+    // 这种"兄弟层"方案彻底规避 Chromium -webkit-app-region 命中测试缓存 bug：
+    // 拖拽层与按钮不是父子关系，Chromium 不会把按钮区域错误地归入拖拽区域。
+    if (window.__NEKO_JUKEBOX_STANDALONE__) {
+      var _noDragSelector =
+        '.jukebox-header, .jukebox-header-left, .jukebox-header-buttons, ' +
+        '.jukebox-content, .jukebox-controls-row, ' +
+        '.jukebox-calibration-section, .jukebox-notice';
+
+      // 立即设置：拖拽层 drag，交互区域 no-drag
+      var _applyDragRegions = function() {
+        var overlay = jukeboxContainer.querySelector('.jukebox-drag-overlay');
+        if (overlay && overlay.style.webkitAppRegion !== 'drag') {
+          overlay.style.webkitAppRegion = 'drag';
+        }
+        jukeboxContainer.querySelectorAll(_noDragSelector).forEach(function(el) {
+          if (el.style.webkitAppRegion !== 'no-drag') {
+            el.style.webkitAppRegion = 'no-drag';
+          }
+        });
+      };
+      _applyDragRegions();
+
+      // MutationObserver 守护：如果 preload 后续重新注入 drag，立即纠正
+      try {
+        var _guardBusy = false;
+        var _dragGuard = new MutationObserver(function(mutations) {
+          if (_guardBusy) return;
+          for (var i = 0; i < mutations.length; i++) {
+            var m = mutations[i];
+            if (m.type === 'attributes' && m.attributeName === 'style') {
+              var el = m.target;
+              // 保护交互区域不被改为 drag
+              if (el.matches && el.matches(_noDragSelector) &&
+                  el.style.webkitAppRegion !== 'no-drag') {
+                _guardBusy = true;
+                el.style.webkitAppRegion = 'no-drag';
+                _guardBusy = false;
+              }
+            }
+          }
+        });
+        _dragGuard.observe(jukeboxContainer, {
+          attributes: true,
+          attributeFilter: ['style'],
+          subtree: true
+        });
+      } catch (_) {}
+    }
   },
   
   // 窗口拖拽功能
@@ -3770,6 +3822,21 @@ window.Jukebox = {
         cursor: grab;
         user-select: none;
         -webkit-user-select: none;
+        position: relative;
+      }
+
+      /* 专属拖拽层：绝对定位覆盖 header，但 z-index 低于按钮，
+         与按钮是兄弟关系而非父子关系，规避 Chromium -webkit-app-region 缓存 bug */
+      .jukebox-drag-overlay {
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+      }
+
+      .jukebox-header-left,
+      .jukebox-header-buttons {
+        position: relative;
+        z-index: 1;
       }
       
       .jukebox-header:active {

--- a/templates/jukebox.html
+++ b/templates/jukebox.html
@@ -41,6 +41,26 @@
             border-radius: 0 !important;
             box-sizing: border-box !important;
         }
+
+        /* 窗口拖拽 —— Chromium 已知 bug：-webkit-app-region 的命中测试区域
+           会被合成器缓存，子元素的 no-drag 挖洞经常失效（拖拽后恢复、
+           鼠标晃动后又坏、resize 后又好），根本原因是缓存未正确失效。
+           解决方案：不在任何包含交互子元素的容器上设 drag，改用一个
+           绝对定位的专属拖拽层（.jukebox-drag-overlay），它与按钮在
+           DOM 上是兄弟关系而非父子关系，彻底规避缓存 bug。 */
+        .jukebox-drag-overlay {
+            -webkit-app-region: drag;
+        }
+        /* 整个 header 及所有交互区域显式 no-drag，防止 preload 注入污染 */
+        .jukebox-header,
+        .jukebox-header-left,
+        .jukebox-header-buttons,
+        .jukebox-content,
+        .jukebox-controls-row,
+        .jukebox-calibration-section,
+        .jukebox-notice {
+            -webkit-app-region: no-drag !important;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
用专属拖拽层 (.jukebox-drag-overlay) 替代在 .jukebox-header-left 上 设置 -webkit-app-region: drag 的方案。overlay 与按钮是 DOM 兄弟关系 而非父子关系，彻底规避 Chromium 合成器对 drag/no-drag 命中测试区域
缓存失效不正确的已知 bug。

症状：Electron 独立窗口中右上角按钮（关闭/最小化/设置）大多数时候
点不到，拖拽标题栏后短暂恢复，鼠标晃动后再次失灵，resize 后恢复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了窗口拖拽在Electron应用中的可靠性表现
  * 确保界面中的交互元素不会被窗口拖拽操作干扰

<!-- end of auto-generated comment: release notes by coderabbit.ai -->