### PR TITLE
feat: add OpenRouter as assist API provider

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -657,6 +657,15 @@ DEFAULT_ASSIST_API_PROFILES = {
         'VISION_MODEL': "claude-sonnet-4-6",
         'AGENT_MODEL': "claude-opus-4-6",
     },
+    'openrouter': {
+        'OPENROUTER_URL': "https://openrouter.ai/api/v1",
+        'CONVERSATION_MODEL': "openai/gpt-4.1",
+        'SUMMARY_MODEL': "openai/gpt-4.1-mini",
+        'CORRECTION_MODEL': "openai/gpt-4.1-mini",
+        'EMOTION_MODEL': "openai/gpt-4.1-nano",
+        'VISION_MODEL': "openai/gpt-4.1",
+        'AGENT_MODEL': "openai/gpt-4.1",
+    },
 }
 
 DEFAULT_ASSIST_API_KEY_FIELDS = {
@@ -670,6 +679,7 @@ DEFAULT_ASSIST_API_KEY_FIELDS = {
     'qwen_intl': 'ASSIST_API_KEY_QWEN_INTL',
     'minimax': 'ASSIST_API_KEY_MINIMAX',
     'claude': 'ASSIST_API_KEY_CLAUDE',
+    'openrouter': 'ASSIST_API_KEY_OPENROUTER',
 }
 
 DEFAULT_CONFIG_DATA = {

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -234,6 +234,18 @@
       "emotion_model": "grok-3-mini-fast",
       "vision_model": "grok-4-1-fast-non-reasoning",
       "agent_model": "grok-4-1-fast-non-reasoning"
+    },
+    "openrouter": {
+      "key": "openrouter",
+      "name": "OpenRouter",
+      "description": "模型聚合平台，支持数百种模型，国内版不支持",
+      "openrouter_url": "https://openrouter.ai/api/v1",
+      "conversation_model": "google/gemini-2.5-flash",
+      "summary_model": "deepseek/deepseek-v3.2",
+      "correction_model": "deepseek/deepseek-v3.2",
+      "emotion_model": "google/gemma-3n-e4b-it:free",
+      "vision_model": "google/gemini-2.5-flash",
+      "agent_model": "google/gemini-3-flash-preview"
     }
   },
   "default_models": {
@@ -265,7 +277,8 @@
     "minimax": "ASSIST_API_KEY_MINIMAX",
     "minimax_intl": "ASSIST_API_KEY_MINIMAX_INTL",
     "claude": "ASSIST_API_KEY_CLAUDE",
-    "grok": "ASSIST_API_KEY_GROK"
+    "grok": "ASSIST_API_KEY_GROK",
+    "openrouter": "ASSIST_API_KEY_OPENROUTER"
   },
   "api_key_registry": {
     "qwen": {
@@ -322,6 +335,10 @@
     },
     "grok": {
       "config_field": "assistApiKeyGrok",
+      "restricted": true
+    },
+    "openrouter": {
+      "config_field": "assistApiKeyOpenrouter",
       "restricted": true
     }
   },

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -243,7 +243,7 @@
       "conversation_model": "google/gemini-2.5-flash",
       "summary_model": "deepseek/deepseek-v3.2",
       "correction_model": "deepseek/deepseek-v3.2",
-      "emotion_model": "google/gemma-3n-e4b-it:free",
+      "emotion_model": "qwen/qwen3.5-9b",
       "vision_model": "google/gemini-2.5-flash",
       "agent_model": "google/gemini-3-flash-preview"
     }

--- a/config/providers.py
+++ b/config/providers.py
@@ -22,6 +22,7 @@ EXTRA_BODY_OPENAI = {"enable_thinking": False}
 EXTRA_BODY_CLAUDE = {"thinking": {"type": "disabled"}}
 EXTRA_BODY_GEMINI = {"extra_body": {"google": {"thinking_config": {"thinking_budget": 0}}}}
 EXTRA_BODY_GEMINI_3 = {"extra_body": {"google": {"thinking_config": {"thinking_level": "low", "include_thoughts": False}}}}
+EXTRA_BODY_OPENROUTER = {"reasoning": {"effort": "none"}}
 
 # Agent 调用统一开关：是否加载 extra_body。
 # 默认开启，配合 MODELS_EXTRA_BODY_MAP 实现默认关闭 thinking。
@@ -59,10 +60,11 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "gemini-2.5-flash": EXTRA_BODY_GEMINI,
     "gemini-2.5-flash-lite": EXTRA_BODY_GEMINI,
     "gemini-3-flash-preview": EXTRA_BODY_GEMINI_3,
-    # OpenRouter 格式（provider/model）— OpenRouter 使用统一的 reasoning 参数
-    "google/gemini-2.5-flash": {"reasoning": {"effort": "none"}},
-    "google/gemini-2.5-flash-lite": {"reasoning": {"effort": "none"}},
-    "google/gemini-3-flash-preview": {"reasoning": {"effort": "none"}},
+    # OpenRouter 格式 (provider/model) — OpenRouter 使用统一的 reasoning 参数
+    "google/gemini-2.5-flash": EXTRA_BODY_OPENROUTER,
+    "google/gemini-2.5-flash-lite": EXTRA_BODY_OPENROUTER,
+    "google/gemini-3-flash-preview": EXTRA_BODY_OPENROUTER,
+    "qwen/qwen3.5-9b": EXTRA_BODY_OPENROUTER,
 }
 
 

--- a/config/providers.py
+++ b/config/providers.py
@@ -59,6 +59,10 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "gemini-2.5-flash": EXTRA_BODY_GEMINI,
     "gemini-2.5-flash-lite": EXTRA_BODY_GEMINI,
     "gemini-3-flash-preview": EXTRA_BODY_GEMINI_3,
+    # OpenRouter 格式（provider/model）— OpenRouter 使用统一的 reasoning 参数
+    "google/gemini-2.5-flash": {"reasoning": {"effort": "none"}},
+    "google/gemini-2.5-flash-lite": {"reasoning": {"effort": "none"}},
+    "google/gemini-3-flash-preview": {"reasoning": {"effort": "none"}},
 }
 
 

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -569,6 +569,7 @@ async def get_core_config_api():
             "assistApiKeyMinimaxIntl": core_cfg.get('assistApiKeyMinimaxIntl', ''),
             "assistApiKeyGrok": core_cfg.get('assistApiKeyGrok', ''),
             "assistApiKeyClaude": core_cfg.get('assistApiKeyClaude', ''),
+            "assistApiKeyOpenrouter": core_cfg.get('assistApiKeyOpenrouter', ''),
             "mcpToken": core_cfg.get('mcpToken', ''),
             "openclawUrl": core_cfg.get('openclawUrl'),
             "openclawTimeout": core_cfg.get('openclawTimeout'),
@@ -657,7 +658,7 @@ async def update_core_config(request: Request):
             'assistApiKeyGlm', 'assistApiKeyStep', 'assistApiKeySilicon',
             'assistApiKeyGemini', 'assistApiKeyKimi', 'assistApiKeyDoubao',
             'assistApiKeyMinimax', 'assistApiKeyMinimaxIntl', 'assistApiKeyGrok',
-            'assistApiKeyClaude',
+            'assistApiKeyClaude', 'assistApiKeyOpenrouter',
         ]
         for field in _api_key_fields:
             if field in data:

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -667,7 +667,12 @@
                     }
 
                     var translatedMessage = window.translateStatusMessage ? window.translateStatusMessage(response.message) : response.message;
-                    if (typeof window.showStatusToast === 'function') window.showStatusToast(translatedMessage, 4000, { important: isCriticalError });
+
+                    // TTS 水印提示需要更长显示时间和更高优先级，避免被后续消息覆盖
+                    var stickyInfoCodes = ['TTS_WATERMARK_DETECTED'];
+                    var isStickyInfo = statusCode && stickyInfoCodes.indexOf(statusCode) !== -1;
+
+                    if (typeof window.showStatusToast === 'function') window.showStatusToast(translatedMessage, isStickyInfo ? 8000 : 4000, { important: isCriticalError, priority: isStickyInfo ? 50 : undefined });
 
                     if (statusCode === 'CHARACTER_DISCONNECTED') {
                         if (S.isRecording === false && !S.isTextSessionActive) {

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -805,7 +805,8 @@
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Intl)",
             "claude": "Claude (Anthropic)",
-            "grok": "Grok (xAI)"
+            "grok": "Grok (xAI)",
+            "openrouter": "OpenRouter (Model Aggregator)"
         },
         "coreApiAutoFillHint": "Key auto-filled from API Key Book, or enter directly",
         "assistApiSelectLabel": "Assist API Provider",
@@ -837,7 +838,8 @@
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Intl)",
             "claude": "Claude (Anthropic)",
-            "grok": "Grok (xAI)"
+            "grok": "Grok (xAI)",
+            "openrouter": "OpenRouter"
         },
         "freeVersionNoApiKey": "Free version does not require API Key",
         "pleaseEnterApiKey": "Please enter your API Key",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -805,7 +805,8 @@
             "minimax": "MiniMax（中国版）",
             "minimax_intl": "MiniMax（国際版）",
             "claude": "Claude（Anthropic）",
-            "grok": "Grok（xAI）"
+            "grok": "Grok（xAI）",
+            "openrouter": "OpenRouter（モデルアグリゲーター）"
         },
         "coreApiAutoFillHint": "API管理簿からキーが自動入力されます。直接入力も可能です",
         "assistApiSelectLabel": "アシストAPIプロバイダー",
@@ -837,7 +838,8 @@
             "minimax": "MiniMax（中国版）",
             "minimax_intl": "MiniMax（国際版）",
             "claude": "Claude（Anthropic）",
-            "grok": "Grok（xAI）"
+            "grok": "Grok（xAI）",
+            "openrouter": "OpenRouter"
         },
         "freeVersionNoApiKey": "無料版はAPIキー不要です",
         "pleaseEnterApiKey": "APIキーを入力してください",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -805,7 +805,8 @@
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax(국제 서버)",
             "claude": "Claude(Anthropic)",
-            "grok": "Grok(xAI)"
+            "grok": "Grok(xAI)",
+            "openrouter": "OpenRouter(모델 통합 플랫폼)"
         },
         "coreApiAutoFillHint": "API 관리 대장에서 키가 자동 입력됩니다. 직접 입력도 가능합니다",
         "assistApiSelectLabel": "보조 API 제공업체",
@@ -837,7 +838,8 @@
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax(국제 서버)",
             "claude": "Claude(Anthropic)",
-            "grok": "Grok(xAI)"
+            "grok": "Grok(xAI)",
+            "openrouter": "OpenRouter"
         },
         "freeVersionNoApiKey": "무료 버전에는 API 키가 필요하지 않습니다.",
         "pleaseEnterApiKey": "API 키를 입력하세요.",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -805,7 +805,8 @@
             "minimax": "MiniMax (Китай)",
             "minimax_intl": "MiniMax (международный)",
             "claude": "Claude (Anthropic)",
-            "grok": "Grok (xAI)"
+            "grok": "Grok (xAI)",
+            "openrouter": "OpenRouter (агрегатор моделей)"
         },
         "coreApiAutoFillHint": "Ключ автоматически заполняется из справочника API, можно ввести вручную",
         "assistApiSelectLabel": "Провайдер вспомогательного API",
@@ -837,7 +838,8 @@
             "minimax": "MiniMax (Китай)",
             "minimax_intl": "MiniMax (международный)",
             "claude": "Claude (Anthropic)",
-            "grok": "Grok (xAI)"
+            "grok": "Grok (xAI)",
+            "openrouter": "OpenRouter"
         },
         "freeVersionNoApiKey": "Бесплатная версия не требует API Key",
         "pleaseEnterApiKey": "Введите ваш API Key",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -805,9 +805,9 @@
             "minimax": "MiniMax（国服）",
             "minimax_intl": "MiniMax（国际服）",
             "claude": "Claude（Anthropic，国内无法使用）",
-            "grok": "Grok（xAI）"
+            "grok": "Grok（xAI）",
+            "openrouter": "OpenRouter（模型聚合，国内无法使用）"
         },
-        "coreApiAutoFillHint": "Key从API管理簿自动填充，也可在此直接输入",
         "assistApiSelectLabel": "辅助API服务商",
         "assistApiKeyLabel": "辅助API Key",
         "assistApiAutoFillHint": "Key从API管理簿自动填充，也可在此直接输入",
@@ -837,7 +837,8 @@
             "minimax": "MiniMax（国服）",
             "minimax_intl": "MiniMax（国际服）",
             "claude": "Claude（Anthropic）",
-            "grok": "Grok（xAI）"
+            "grok": "Grok（xAI）",
+            "openrouter": "OpenRouter"
         },
         "freeVersionNoApiKey": "免费版无需API Key",
         "pleaseEnterApiKey": "请输入您的API Key",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -808,6 +808,7 @@
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（模型聚合，国内无法使用）"
         },
+        "coreApiAutoFillHint": "Key从API管理簿自动填充，也可在此直接输入",
         "assistApiSelectLabel": "辅助API服务商",
         "assistApiKeyLabel": "辅助API Key",
         "assistApiAutoFillHint": "Key从API管理簿自动填充，也可在此直接输入",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -805,7 +805,8 @@
             "minimax": "MiniMax（中國）",
             "minimax_intl": "MiniMax（國際服）",
             "claude": "Claude（Anthropic）",
-            "grok": "Grok（xAI）"
+            "grok": "Grok（xAI）",
+            "openrouter": "OpenRouter（模型聚合，國內無法使用）"
         },
         "coreApiAutoFillHint": "Key從API管理簿自動填充，也可在此直接輸入",
         "assistApiSelectLabel": "輔助API服務商",
@@ -837,7 +838,8 @@
             "minimax": "MiniMax（中國）",
             "minimax_intl": "MiniMax（國際服）",
             "claude": "Claude（Anthropic）",
-            "grok": "Grok（xAI）"
+            "grok": "Grok（xAI）",
+            "openrouter": "OpenRouter"
         },
         "freeVersionNoApiKey": "免費版無需API Key",
         "pleaseEnterApiKey": "請輸入您的API Key",

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1606,6 +1606,7 @@ class ConfigManager:
             'ASSIST_API_KEY_MINIMAX': '',
             'ASSIST_API_KEY_MINIMAX_INTL': '',
             'ASSIST_API_KEY_GROK': DEFAULT_CORE_API_KEY,
+            'ASSIST_API_KEY_OPENROUTER': DEFAULT_CORE_API_KEY,
             'IS_FREE_VERSION': False,
             'VISION_MODEL': DEFAULT_VISION_MODEL,
             'AGENT_MODEL': DEFAULT_AGENT_MODEL,
@@ -1668,6 +1669,7 @@ class ConfigManager:
         config['ASSIST_API_KEY_MINIMAX_INTL'] = core_cfg.get('assistApiKeyMinimaxIntl', '')
         config['ASSIST_API_KEY_GROK'] = core_cfg.get('assistApiKeyGrok', '') or config['CORE_API_KEY']
         config['ASSIST_API_KEY_CLAUDE'] = core_cfg.get('assistApiKeyClaude', '') or config['CORE_API_KEY']
+        config['ASSIST_API_KEY_OPENROUTER'] = core_cfg.get('assistApiKeyOpenrouter', '') or config['CORE_API_KEY']
 
         if core_cfg.get('mcpToken'):
             config['MCP_ROUTER_API_KEY'] = core_cfg['mcpToken']


### PR DESCRIPTION
- Add OpenRouter to api_providers.json (assist_api_providers, assist_api_key_fields, api_key_registry)
- Add OpenRouter fallback profile and key field in config/__init__.py
- Add ASSIST_API_KEY_OPENROUTER loading in config_manager.py
- Add OpenRouter-format model names to MODELS_EXTRA_BODY_MAP in providers.py (google/gemini-2.5-flash, gemini-3-flash-preview use reasoning.effort=none)
- Add i18n translations for all 6 locales (assistProviderNames + keyBook)
- Marked restricted=true (hidden for mainland China users)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 OpenRouter 作为可选的 Assist API 提供商，可选择其多种模型用于对话、摘要、纠正、情感与视觉/代理任务。
  * 在设置中新增 OpenRouter 的 API 密钥项，便于配置与使用。

* **改进**
  * 为 OpenRouter 添加了英文、日文、韩文、俄文、简体与繁体中文本地化显示文案。
  * 调整了状态提示（含 TTS 水印检测）显示时长与优先级，改善重要信息可见性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->