### PR TITLE
fix: 修复头像比例变形 & 增加手动裁剪功能

### DIFF
--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -535,9 +535,15 @@
                 wrap.style.height = displayH + 'px';
 
                 if (defaultCropRect) {
-                    crop.size = Math.round(Math.min(defaultCropRect.width, defaultCropRect.height) / scaleRatio);
-                    crop.x = Math.round(defaultCropRect.x / scaleRatio);
-                    crop.y = Math.round(defaultCropRect.y / scaleRatio);
+                    var rX = defaultCropRect.x || 0;
+                    var rY = defaultCropRect.y || 0;
+                    var rW = defaultCropRect.width || defaultCropRect.size || 0;
+                    var rH = defaultCropRect.height || defaultCropRect.size || 0;
+                    if (rW > rH) { rX += Math.round((rW - rH) / 2); rW = rH; }
+                    else if (rH > rW) { rY += Math.round((rH - rW) / 2); rH = rW; }
+                    crop.size = Math.round(rW / scaleRatio);
+                    crop.x = Math.round(rX / scaleRatio);
+                    crop.y = Math.round(rY / scaleRatio);
                 } else {
                     crop.size = Math.round(Math.min(displayW, displayH) * 0.7);
                     crop.x = Math.round((displayW - crop.size) / 2);

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -219,6 +219,7 @@
             if (pendingHideHandler) return;
             // 关键：关闭时先取消任何尚未执行的进场 rAF，否则它会把 is-visible 加回来
             cancelPendingShow();
+            closeCropperIfOpen();
 
             card.classList.remove('is-visible');
             clearTriggerActive();
@@ -412,8 +413,8 @@
         });
     }
 
-    async function captureAvatarPreview() {
-        // 优先使用本地 avatarPortrait（index.html）；chat.html 里回退到 IPC。
+    async function captureAvatarPreview(opts) {
+        const extra = opts || {};
         if (window.avatarPortrait && typeof window.avatarPortrait.capture === 'function') {
             return window.avatarPortrait.capture({
                 width: 320,
@@ -422,7 +423,8 @@
                 shape: 'rounded',
                 radius: 40,
                 background: 'rgba(255, 255, 255, 0.96)',
-                includeDataUrl: true
+                includeDataUrl: true,
+                includeSourceDataUrl: !!extra.includeSourceDataUrl
             });
         }
         if (window.__NEKO_MULTI_WINDOW__ && typeof window.__nekoRequestAvatarPreview === 'function') {
@@ -431,11 +433,211 @@
         throw new Error(translateLabel('chat.avatarPreviewUnavailable', '头像预览功能尚未就绪。'));
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // Manual Avatar Cropper (inline in popup)
+    // ═══════════════════════════════════════════════════════════════
+
+    var cropperState = null;
+
+    function openAvatarCropper(sourceDataUrl, defaultCropRect, sourceWidth, sourceHeight) {
+        return new Promise(function (resolve) {
+            var popup = S.dom.chatAvatarPreviewCard;
+            var wrap = document.getElementById('avatar-cropper-wrap');
+            var img = document.getElementById('avatar-cropper-img');
+            var svgMask = document.getElementById('avatar-cropper-mask');
+            var cropBox = document.getElementById('avatar-cropper-box');
+            var cancelBtn = document.getElementById('avatar-cropper-cancel');
+            var saveBtn = document.getElementById('avatar-cropper-save');
+
+            if (!popup || !wrap || !img || !svgMask || !cropBox) {
+                resolve(null);
+                return;
+            }
+
+            var displayW, displayH, scaleRatio;
+            var crop = { x: 0, y: 0, size: 0 };
+            var MIN_SIZE = 40;
+            var settled = false;
+            var drag = null;
+
+            function initLayout() {
+                var maxW = Math.min(360, window.innerWidth - 64);
+                var maxH = Math.min(360, window.innerHeight - 180);
+                var aspect = sourceWidth / sourceHeight;
+                if (aspect >= 1) {
+                    displayW = Math.min(maxW, sourceWidth);
+                    displayH = Math.round(displayW / aspect);
+                    if (displayH > maxH) { displayH = maxH; displayW = Math.round(displayH * aspect); }
+                } else {
+                    displayH = Math.min(maxH, sourceHeight);
+                    displayW = Math.round(displayH * aspect);
+                    if (displayW > maxW) { displayW = maxW; displayH = Math.round(displayW / aspect); }
+                }
+                scaleRatio = sourceWidth / displayW;
+                img.style.width = displayW + 'px';
+                img.style.height = displayH + 'px';
+                wrap.style.width = displayW + 'px';
+                wrap.style.height = displayH + 'px';
+
+                if (defaultCropRect) {
+                    crop.size = Math.round(Math.min(defaultCropRect.width, defaultCropRect.height) / scaleRatio);
+                    crop.x = Math.round(defaultCropRect.x / scaleRatio);
+                    crop.y = Math.round(defaultCropRect.y / scaleRatio);
+                } else {
+                    crop.size = Math.round(Math.min(displayW, displayH) * 0.7);
+                    crop.x = Math.round((displayW - crop.size) / 2);
+                    crop.y = Math.round((displayH - crop.size) / 2);
+                }
+                clampCrop();
+                renderCrop();
+            }
+
+            function clampCrop() {
+                crop.size = Math.max(MIN_SIZE, Math.min(crop.size, displayW, displayH));
+                crop.x = Math.max(0, Math.min(crop.x, displayW - crop.size));
+                crop.y = Math.max(0, Math.min(crop.y, displayH - crop.size));
+            }
+
+            function renderCrop() {
+                cropBox.style.left = crop.x + 'px';
+                cropBox.style.top = crop.y + 'px';
+                cropBox.style.width = crop.size + 'px';
+                cropBox.style.height = crop.size + 'px';
+                var w = displayW, h = displayH;
+                var cx = crop.x, cy = crop.y, cs = crop.size;
+                svgMask.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+                svgMask.innerHTML =
+                    '<defs><mask id="__acm">' +
+                    '<rect width="' + w + '" height="' + h + '" fill="white"/>' +
+                    '<rect x="' + cx + '" y="' + cy + '" width="' + cs + '" height="' + cs + '" fill="black"/>' +
+                    '</mask></defs>' +
+                    '<rect width="' + w + '" height="' + h + '" fill="rgba(0,0,0,0.5)" mask="url(#__acm)"/>';
+            }
+
+            function onPointerDown(e) {
+                var h = e.target.dataset && e.target.dataset.handle;
+                if (h) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    drag = { startX: e.clientX, startY: e.clientY, ox: crop.x, oy: crop.y, osize: crop.size, type: 'resize', handle: h };
+                } else if (cropBox.contains(e.target) || e.target === cropBox) {
+                    e.preventDefault();
+                    drag = { startX: e.clientX, startY: e.clientY, ox: crop.x, oy: crop.y, type: 'move' };
+                }
+            }
+
+            function onPointerMove(e) {
+                if (!drag) return;
+                var dx = e.clientX - drag.startX;
+                var dy = e.clientY - drag.startY;
+                if (drag.type === 'move') {
+                    crop.x = drag.ox + dx;
+                    crop.y = drag.oy + dy;
+                } else {
+                    var hh = drag.handle;
+                    var delta;
+                    if (hh === 'br') { delta = Math.max(dx, dy); crop.size = drag.osize + delta; }
+                    else if (hh === 'tl') { delta = Math.min(dx, dy); crop.size = drag.osize - delta; crop.x = drag.ox + delta; crop.y = drag.oy + delta; }
+                    else if (hh === 'tr') { delta = Math.max(dx, -dy); crop.size = drag.osize + delta; crop.y = drag.oy - delta; }
+                    else if (hh === 'bl') { delta = Math.max(-dx, dy); crop.size = drag.osize + delta; crop.x = drag.ox - delta; }
+                }
+                clampCrop();
+                renderCrop();
+            }
+
+            function onPointerUp() { drag = null; }
+
+            function cleanup() {
+                document.removeEventListener('pointermove', onPointerMove);
+                document.removeEventListener('pointerup', onPointerUp);
+                wrap.removeEventListener('pointerdown', onPointerDown);
+                if (cancelBtn) cancelBtn.removeEventListener('click', onCancel);
+                if (saveBtn) saveBtn.removeEventListener('click', onSave);
+                popup.classList.remove('is-cropping');
+                cropperState = null;
+            }
+
+            function finish(accepted) {
+                if (settled) return;
+                settled = true;
+                cleanup();
+                if (accepted) {
+                    resolve({
+                        x: Math.round(crop.x * scaleRatio),
+                        y: Math.round(crop.y * scaleRatio),
+                        size: Math.round(crop.size * scaleRatio)
+                    });
+                } else {
+                    resolve(null);
+                }
+            }
+
+            function onCancel() { finish(false); }
+            function onSave() { finish(true); }
+
+            img.src = sourceDataUrl;
+            wrap.addEventListener('pointerdown', onPointerDown);
+            document.addEventListener('pointermove', onPointerMove);
+            document.addEventListener('pointerup', onPointerUp);
+            cancelBtn.addEventListener('click', onCancel);
+            saveBtn.addEventListener('click', onSave);
+
+            popup.classList.add('is-cropping');
+            setPreviewStatus(translateLabel('chat.avatarCropperTitle', '调整头像裁剪区域'));
+
+            cropperState = { finish: finish };
+
+            requestAnimationFrame(function () { initLayout(); });
+        });
+    }
+
+    function closeCropperIfOpen() {
+        if (cropperState && cropperState.finish) {
+            cropperState.finish(false);
+        }
+    }
+
+    function cropSourceToAvatar(sourceDataUrl, cropRect) {
+        return new Promise(function (resolve, reject) {
+            var img = new Image();
+            img.onload = function () {
+                try {
+                    var canvas = document.createElement('canvas');
+                    canvas.width = 320;
+                    canvas.height = 320;
+                    var ctx = canvas.getContext('2d');
+                    ctx.beginPath();
+                    var r = 40;
+                    var w = 320, h = 320;
+                    ctx.moveTo(r, 0);
+                    ctx.arcTo(w, 0, w, h, r);
+                    ctx.arcTo(w, h, 0, h, r);
+                    ctx.arcTo(0, h, 0, 0, r);
+                    ctx.arcTo(0, 0, w, 0, r);
+                    ctx.closePath();
+                    ctx.clip();
+                    ctx.fillStyle = 'rgba(255, 255, 255, 0.96)';
+                    ctx.fillRect(0, 0, 320, 320);
+                    ctx.drawImage(img,
+                        cropRect.x, cropRect.y, cropRect.size, cropRect.size,
+                        0, 0, 320, 320
+                    );
+                    resolve(canvas.toDataURL('image/png', 0.92));
+                } catch (err) {
+                    reject(err);
+                }
+            };
+            img.onerror = function () { reject(new Error('Failed to load source image')); };
+            img.src = sourceDataUrl;
+        });
+    }
+
     async function renderAvatarPreview(options = {}) {
         const forceRefresh = options.forceRefresh === true;
         const showCard = options.showCard !== false;
         const silent = options.silent === true;
         const trigger = options.trigger || null;
+        const manualCrop = options.manualCrop === true;
 
         if (isCapturing) {
             if (!showCard && silent) {
@@ -469,10 +671,34 @@
         setPreviewNote(translateLabel('chat.avatarPreviewCardNote', '将基于当前显示中的 Live2D / VRM / MMD 模型生成头像。'));
 
         try {
-            const result = await captureAvatarPreview();
+            const result = await captureAvatarPreview({ includeSourceDataUrl: manualCrop });
             if (token !== activeCaptureToken) return;
 
-            applyPreviewResult(result, cacheKey);
+            if (manualCrop && result.sourceDataUrl) {
+                setLoadingState(false);
+                setPreviewStatus(translateLabel('chat.avatarPreviewCropping', '请调整裁剪区域'));
+
+                var srcDims = await new Promise(function (res) {
+                    var tmp = new Image();
+                    tmp.onload = function () { res({ w: tmp.naturalWidth, h: tmp.naturalHeight }); };
+                    tmp.onerror = function () { res({ w: 640, h: 640 }); };
+                    tmp.src = result.sourceDataUrl;
+                });
+                var defRect = result.cropRectPixels || null;
+
+                var userCrop = await openAvatarCropper(result.sourceDataUrl, defRect, srcDims.w, srcDims.h);
+                if (token !== activeCaptureToken) return;
+
+                if (userCrop) {
+                    var croppedDataUrl = await cropSourceToAvatar(result.sourceDataUrl, userCrop);
+                    applyPreviewResult({ dataUrl: croppedDataUrl, modelType: result.modelType }, cacheKey);
+                } else {
+                    applyPreviewResult(result, cacheKey);
+                    setPreviewNote(translateLabel('chat.avatarPreviewCropCancelled', '已取消手动裁剪，使用自动裁剪结果。'));
+                }
+            } else {
+                applyPreviewResult(result, cacheKey);
+            }
         } catch (error) {
             if (token !== activeCaptureToken) return;
 
@@ -688,7 +914,7 @@
         bindTriggerButton(S.dom.avatarPreviewHeaderButton);
 
         refreshButton.addEventListener('click', function () {
-            renderAvatarPreview({ forceRefresh: true, trigger: activeTrigger });
+            renderAvatarPreview({ forceRefresh: true, trigger: activeTrigger, manualCrop: true });
         });
 
         closeButton.addEventListener('click', function () {

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -535,11 +535,15 @@
                     crop.y = drag.oy + dy;
                 } else {
                     var hh = drag.handle;
-                    var delta;
-                    if (hh === 'br') { delta = Math.max(dx, dy); crop.size = drag.osize + delta; }
-                    else if (hh === 'tl') { delta = Math.min(dx, dy); crop.size = drag.osize - delta; crop.x = drag.ox + delta; crop.y = drag.oy + delta; }
-                    else if (hh === 'tr') { delta = Math.max(dx, -dy); crop.size = drag.osize + delta; crop.y = drag.oy - delta; }
-                    else if (hh === 'bl') { delta = Math.max(-dx, dy); crop.size = drag.osize + delta; crop.x = drag.ox - delta; }
+                    var ldx, ldy;
+                    if (hh === 'br')      { ldx =  dx; ldy =  dy; }
+                    else if (hh === 'tl') { ldx = -dx; ldy = -dy; }
+                    else if (hh === 'tr') { ldx =  dx; ldy = -dy; }
+                    else                  { ldx = -dx; ldy =  dy; }
+                    var delta = Math.max(ldx, ldy);
+                    crop.size = drag.osize + delta;
+                    if (hh === 'tl' || hh === 'bl') { crop.x = drag.ox - delta; }
+                    if (hh === 'tl' || hh === 'tr') { crop.y = drag.oy - delta; }
                 }
                 clampCrop();
                 renderCrop();
@@ -655,7 +659,10 @@
 
             cropperState = { finish: finish, controlsEl: controlsEl, onCtrlAction: onCtrlAction };
 
-            requestAnimationFrame(function () { initLayout(); });
+            requestAnimationFrame(function () {
+                initLayout();
+                positionPopupNearTrigger(popup, activeTrigger);
+            });
         });
     }
 

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -449,7 +449,7 @@
             var cancelBtn = document.getElementById('avatar-cropper-cancel');
             var saveBtn = document.getElementById('avatar-cropper-save');
 
-            if (!popup || !wrap || !img || !svgMask || !cropBox) {
+            if (!popup || !wrap || !img || !svgMask || !cropBox || !cancelBtn || !saveBtn) {
                 resolve(null);
                 return;
             }

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -413,6 +413,55 @@
         });
     }
 
+    /**
+     * 通过 BroadcastChannel 请求 Pet 窗口执行带源数据的截取。
+     */
+    function captureAvatarPreviewViaBroadcast(includeSourceDataUrl) {
+        return new Promise(function (resolve, reject) {
+            var bc = window.appInterpage && window.appInterpage.nekoBroadcastChannel;
+            if (!bc) {
+                reject(new Error('BroadcastChannel unavailable'));
+                return;
+            }
+            var requestId = 'cap_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
+            var finished = false;
+            var timerId = null;
+            function onMessage(event) {
+                if (!event.data || event.data.action !== 'avatar_capture_result') return;
+                if (event.data.requestId !== requestId) return;
+                if (finished) return;
+                finished = true;
+                bc.removeEventListener('message', onMessage);
+                if (timerId) { clearTimeout(timerId); timerId = null; }
+                if (event.data.error) {
+                    reject(new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败')));
+                } else {
+                    var result = {
+                        dataUrl: event.data.dataUrl || '',
+                        modelType: event.data.modelType || ''
+                    };
+                    if (event.data.sourceDataUrl) result.sourceDataUrl = event.data.sourceDataUrl;
+                    if (event.data.cropRectPixels) result.cropRectPixels = event.data.cropRectPixels;
+                    resolve(result);
+                }
+            }
+            bc.addEventListener('message', onMessage);
+            timerId = setTimeout(function () {
+                if (finished) return;
+                finished = true;
+                bc.removeEventListener('message', onMessage);
+                reject(new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败')));
+            }, 15000);
+            bc.postMessage({
+                action: 'request_avatar_capture',
+                requestId: requestId,
+                includeSourceDataUrl: !!includeSourceDataUrl,
+                lanlan_name: (window.lanlan_config && window.lanlan_config.lanlan_name) || '',
+                timestamp: Date.now()
+            });
+        });
+    }
+
     async function captureAvatarPreview(opts) {
         const extra = opts || {};
         if (window.avatarPortrait && typeof window.avatarPortrait.capture === 'function') {
@@ -427,8 +476,14 @@
                 includeSourceDataUrl: !!extra.includeSourceDataUrl
             });
         }
-        if (window.__NEKO_MULTI_WINDOW__ && typeof window.__nekoRequestAvatarPreview === 'function') {
-            return captureAvatarPreviewViaIpc();
+        if (window.__NEKO_MULTI_WINDOW__) {
+            if (extra.includeSourceDataUrl) {
+                return captureAvatarPreviewViaBroadcast(true);
+            }
+            if (typeof window.__nekoRequestAvatarPreview === 'function') {
+                return captureAvatarPreviewViaIpc();
+            }
+            return captureAvatarPreviewViaBroadcast(false);
         }
         throw new Error(translateLabel('chat.avatarPreviewUnavailable', '头像预览功能尚未就绪。'));
     }
@@ -697,7 +752,7 @@
                         cropRect.x, cropRect.y, cropRect.size, cropRect.size,
                         0, 0, 320, 320
                     );
-                    resolve(canvas.toDataURL('image/png', 0.92));
+                    resolve(canvas.toDataURL('image/png'));
                 } catch (err) {
                     reject(err);
                 }

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -478,7 +478,14 @@
         }
         if (window.__NEKO_MULTI_WINDOW__) {
             if (extra.includeSourceDataUrl) {
-                return captureAvatarPreviewViaBroadcast(true);
+                try {
+                    return await captureAvatarPreviewViaBroadcast(true);
+                } catch (_bcErr) {
+                    if (typeof window.__nekoRequestAvatarPreview === 'function') {
+                        return captureAvatarPreviewViaIpc();
+                    }
+                    throw _bcErr;
+                }
             }
             if (typeof window.__nekoRequestAvatarPreview === 'function') {
                 return captureAvatarPreviewViaIpc();

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -547,12 +547,34 @@
 
             function onPointerUp() { drag = null; }
 
+            function onWheel(e) {
+                if (!cropBox.contains(e.target) && e.target !== cropBox) return;
+                e.preventDefault();
+                var step = Math.round(crop.size * 0.08);
+                if (step < 4) step = 4;
+                var delta = e.deltaY > 0 ? -step : step;
+                var oldSize = crop.size;
+                var newSize = Math.max(MIN_SIZE, Math.min(oldSize + delta, displayW, displayH));
+                if (newSize === oldSize) return;
+                var centerX = crop.x + oldSize / 2;
+                var centerY = crop.y + oldSize / 2;
+                crop.size = newSize;
+                crop.x = Math.round(centerX - newSize / 2);
+                crop.y = Math.round(centerY - newSize / 2);
+                clampCrop();
+                renderCrop();
+            }
+
             function cleanup() {
                 document.removeEventListener('pointermove', onPointerMove);
                 document.removeEventListener('pointerup', onPointerUp);
                 wrap.removeEventListener('pointerdown', onPointerDown);
+                wrap.removeEventListener('wheel', onWheel);
                 if (cancelBtn) cancelBtn.removeEventListener('click', onCancel);
                 if (saveBtn) saveBtn.removeEventListener('click', onSave);
+                if (cropperState && cropperState.controlsEl) {
+                    cropperState.controlsEl.removeEventListener('click', cropperState.onCtrlAction);
+                }
                 popup.classList.remove('is-cropping');
                 cropperState = null;
             }
@@ -575,17 +597,63 @@
             function onCancel() { finish(false); }
             function onSave() { finish(true); }
 
+            var MOVE_STEP = 10;
+            var SIZE_STEP_RATIO = 0.1;
+
+            function onCtrlAction(e) {
+                var btn = e.target.closest('[data-crop-action]');
+                if (!btn) return;
+                var action = btn.dataset.cropAction;
+                var sizeStep = Math.max(6, Math.round(crop.size * SIZE_STEP_RATIO));
+                switch (action) {
+                    case 'up':    crop.y -= MOVE_STEP; break;
+                    case 'down':  crop.y += MOVE_STEP; break;
+                    case 'left':  crop.x -= MOVE_STEP; break;
+                    case 'right': crop.x += MOVE_STEP; break;
+                    case 'center':
+                        crop.x = Math.round((displayW - crop.size) / 2);
+                        crop.y = Math.round((displayH - crop.size) / 2);
+                        break;
+                    case 'bigger': {
+                        var oldS = crop.size;
+                        var newS = Math.max(MIN_SIZE, Math.min(oldS + sizeStep, displayW, displayH));
+                        if (newS !== oldS) {
+                            crop.x -= Math.round((newS - oldS) / 2);
+                            crop.y -= Math.round((newS - oldS) / 2);
+                            crop.size = newS;
+                        }
+                        break;
+                    }
+                    case 'smaller': {
+                        var oldS2 = crop.size;
+                        var newS2 = Math.max(MIN_SIZE, Math.min(oldS2 - sizeStep, displayW, displayH));
+                        if (newS2 !== oldS2) {
+                            crop.x += Math.round((oldS2 - newS2) / 2);
+                            crop.y += Math.round((oldS2 - newS2) / 2);
+                            crop.size = newS2;
+                        }
+                        break;
+                    }
+                }
+                clampCrop();
+                renderCrop();
+            }
+
+            var controlsEl = popup.querySelector('.avatar-cropper-controls');
+
             img.src = sourceDataUrl;
             wrap.addEventListener('pointerdown', onPointerDown);
+            wrap.addEventListener('wheel', onWheel, { passive: false });
             document.addEventListener('pointermove', onPointerMove);
             document.addEventListener('pointerup', onPointerUp);
             cancelBtn.addEventListener('click', onCancel);
             saveBtn.addEventListener('click', onSave);
+            if (controlsEl) controlsEl.addEventListener('click', onCtrlAction);
 
             popup.classList.add('is-cropping');
             setPreviewStatus(translateLabel('chat.avatarCropperTitle', '调整头像裁剪区域'));
 
-            cropperState = { finish: finish };
+            cropperState = { finish: finish, controlsEl: controlsEl, onCtrlAction: onCtrlAction };
 
             requestAnimationFrame(function () { initLayout(); });
         });

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -925,6 +925,8 @@
                     }
                     case 'request_avatar_capture': {
                         if (window.location.pathname === '/chat') break;
+                        var captureLanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+                        if (event.data.lanlan_name && (!captureLanlanName || event.data.lanlan_name !== captureLanlanName)) break;
                         var captureRequestId = event.data.requestId || '';
                         var includeSource = !!event.data.includeSourceDataUrl;
                         if (window.avatarPortrait && typeof window.avatarPortrait.capture === 'function') {
@@ -954,6 +956,13 @@
                                     error: true,
                                     timestamp: Date.now()
                                 });
+                            });
+                        } else if (nekoBroadcastChannel) {
+                            nekoBroadcastChannel.postMessage({
+                                action: 'avatar_capture_result',
+                                requestId: captureRequestId,
+                                error: true,
+                                timestamp: Date.now()
                             });
                         }
                         break;

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -923,6 +923,41 @@
                         }
                         break;
                     }
+                    case 'request_avatar_capture': {
+                        if (window.location.pathname === '/chat') break;
+                        var captureRequestId = event.data.requestId || '';
+                        var includeSource = !!event.data.includeSourceDataUrl;
+                        if (window.avatarPortrait && typeof window.avatarPortrait.capture === 'function') {
+                            window.avatarPortrait.capture({
+                                width: 320, height: 320, padding: 0.035,
+                                shape: 'rounded', radius: 40,
+                                background: 'rgba(255, 255, 255, 0.96)',
+                                includeDataUrl: true,
+                                includeSourceDataUrl: includeSource
+                            }).then(function (result) {
+                                if (!nekoBroadcastChannel) return;
+                                nekoBroadcastChannel.postMessage({
+                                    action: 'avatar_capture_result',
+                                    requestId: captureRequestId,
+                                    dataUrl: result.dataUrl || '',
+                                    modelType: result.modelType || '',
+                                    sourceDataUrl: includeSource ? (result.sourceDataUrl || '') : '',
+                                    cropRectPixels: result.cropRectPixels || null,
+                                    timestamp: Date.now()
+                                });
+                            }).catch(function (err) {
+                                console.error('[BroadcastChannel] avatar capture failed:', err);
+                                if (!nekoBroadcastChannel) return;
+                                nekoBroadcastChannel.postMessage({
+                                    action: 'avatar_capture_result',
+                                    requestId: captureRequestId,
+                                    error: true,
+                                    timestamp: Date.now()
+                                });
+                            });
+                        }
+                        break;
+                    }
                 }
             };
         }

--- a/static/avatar-portrait.js
+++ b/static/avatar-portrait.js
@@ -21,6 +21,7 @@
         quality: 0.92,
         includeBlob: false,
         includeDataUrl: false,
+        includeSourceDataUrl: false,
         modelType: null,
         // 新增：裁剪模式
         // 'headshot' - 头像模式（默认，聚焦头部）
@@ -476,6 +477,24 @@
             width,
             height
         };
+    }
+
+    function cropRectToTargetAspect(rect, targetWidth, targetHeight) {
+        const targetAspect = targetWidth / Math.max(targetHeight, 1);
+        const currentAspect = rect.width / Math.max(rect.height, 1);
+        if (Math.abs(currentAspect - targetAspect) < 0.005) return rect;
+
+        const result = { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+        if (currentAspect > targetAspect) {
+            const newWidth = result.height * targetAspect;
+            result.x += (result.width - newWidth) * 0.5;
+            result.width = newWidth;
+        } else {
+            const newHeight = result.width / targetAspect;
+            result.y += (result.height - newHeight) * 0.3;
+            result.height = newHeight;
+        }
+        return result;
     }
 
     function cssRectToPixelRect(rect, metrics) {
@@ -1407,12 +1426,13 @@
                 clipOutputShape(outputCtx, outputCanvas.width, outputCanvas.height, finalOptions);
                 maybeFillBackground(outputCtx, outputCanvas.width, outputCanvas.height, finalOptions.background);
 
-                const sourceCropRect = renderedSource.cropRectPixels || {
+                const sourceCropRectRaw = renderedSource.cropRectPixels || {
                     x: 0,
                     y: 0,
                     width: renderedSource.canvas.width,
                     height: renderedSource.canvas.height
                 };
+                const sourceCropRect = cropRectToTargetAspect(sourceCropRectRaw, outputCanvas.width, outputCanvas.height);
                 outputCtx.drawImage(
                     renderedSource.canvas,
                     sourceCropRect.x,
@@ -1450,6 +1470,9 @@
                 if (finalOptions.includeDataUrl) {
                     result.dataUrl = canvasToDataUrl(outputCanvas, finalOptions.mimeType, finalOptions.quality);
                 }
+                if (finalOptions.includeSourceDataUrl) {
+                    result.sourceDataUrl = canvasToDataUrl(result.sourceCanvas, finalOptions.mimeType, finalOptions.quality);
+                }
 
                 return result;
             }
@@ -1463,7 +1486,8 @@
 
         const sourceMetrics = getCanvasMetrics(sourceCanvas);
         const cssCropRect = adapter.getCropRect(context, finalOptions);
-        const pixelCropRect = cssRectToPixelRect(cssCropRect, sourceMetrics);
+        const pixelCropRectRaw = cssRectToPixelRect(cssCropRect, sourceMetrics);
+        const pixelCropRect = cropRectToTargetAspect(pixelCropRectRaw, finalOptions.width, finalOptions.height);
         const outputCanvas = createOutputCanvas(finalOptions.width, finalOptions.height);
         const outputCtx = outputCanvas.getContext('2d');
 
@@ -1500,6 +1524,14 @@
         }
         if (finalOptions.includeDataUrl) {
             result.dataUrl = canvasToDataUrl(outputCanvas, finalOptions.mimeType, finalOptions.quality);
+        }
+        if (finalOptions.includeSourceDataUrl) {
+            const srcCopy = createOutputCanvas(sourceCanvas.width, sourceCanvas.height);
+            const srcCtx = srcCopy.getContext('2d');
+            if (srcCtx) {
+                srcCtx.drawImage(sourceCanvas, 0, 0);
+                result.sourceDataUrl = canvasToDataUrl(srcCopy, finalOptions.mimeType, finalOptions.quality);
+            }
         }
 
         return result;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1305,13 +1305,14 @@ body.react-chat-window-dragging {
     box-sizing: border-box;
     border: 2px solid rgba(255, 255, 255, 0.85);
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
-    overflow: hidden;
+    overflow: visible;
 }
 
 .avatar-cropper-viewfinder {
     position: absolute;
     inset: 0;
     pointer-events: none;
+    overflow: hidden;
 }
 
 .avatar-cropper-grid-line {
@@ -1331,32 +1332,86 @@ body.react-chat-window-dragging {
     pointer-events: none;
 }
 
+/* 手柄：完全定位在 crop-box 外侧角落 */
 .avatar-cropper-handle {
     position: absolute;
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     z-index: 2;
 }
-.avatar-cropper-handle::before {
+.avatar-cropper-handle::before,
+.avatar-cropper-handle::after {
     content: '';
     position: absolute;
     background: #fff;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.7);
     border-radius: 1px;
 }
-.avatar-cropper-handle.tl { top: -3px; left: -3px; cursor: nwse-resize; }
-.avatar-cropper-handle.tr { top: -3px; right: -3px; cursor: nesw-resize; }
-.avatar-cropper-handle.bl { bottom: -3px; left: -3px; cursor: nesw-resize; }
-.avatar-cropper-handle.br { bottom: -3px; right: -3px; cursor: nwse-resize; }
+.avatar-cropper-handle.tl { top: -26px; left: -26px; cursor: nwse-resize; }
+.avatar-cropper-handle.tr { top: -26px; right: -26px; cursor: nesw-resize; }
+.avatar-cropper-handle.bl { bottom: -26px; left: -26px; cursor: nesw-resize; }
+.avatar-cropper-handle.br { bottom: -26px; right: -26px; cursor: nwse-resize; }
 
-.avatar-cropper-handle.tl::before { top: 0; left: 0; width: 14px; height: 3px; }
-.avatar-cropper-handle.tl::after  { content: ''; position: absolute; top: 0; left: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
-.avatar-cropper-handle.tr::before { top: 0; right: 0; left: auto; width: 14px; height: 3px; }
-.avatar-cropper-handle.tr::after  { content: ''; position: absolute; top: 0; right: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
-.avatar-cropper-handle.bl::before { bottom: 0; top: auto; left: 0; width: 14px; height: 3px; }
-.avatar-cropper-handle.bl::after  { content: ''; position: absolute; bottom: 0; left: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
-.avatar-cropper-handle.br::before { bottom: 0; top: auto; right: 0; left: auto; width: 14px; height: 3px; }
-.avatar-cropper-handle.br::after  { content: ''; position: absolute; bottom: 0; right: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
+.avatar-cropper-handle.tl::before { bottom: 0; right: 0; width: 20px; height: 5px; }
+.avatar-cropper-handle.tl::after  { bottom: 0; right: 0; width: 5px; height: 20px; }
+.avatar-cropper-handle.tr::before { bottom: 0; left: 0; width: 20px; height: 5px; }
+.avatar-cropper-handle.tr::after  { bottom: 0; left: 0; width: 5px; height: 20px; }
+.avatar-cropper-handle.bl::before { top: 0; right: 0; width: 20px; height: 5px; }
+.avatar-cropper-handle.bl::after  { top: 0; right: 0; width: 5px; height: 20px; }
+.avatar-cropper-handle.br::before { top: 0; left: 0; width: 20px; height: 5px; }
+.avatar-cropper-handle.br::after  { top: 0; left: 0; width: 5px; height: 20px; }
+
+/* 右侧控制面板 */
+.avatar-cropper-controls {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    align-self: center;
+    flex-shrink: 0;
+}
+.avatar-cropper-controls-row {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+.avatar-cropper-ctrl-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.35);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+    padding: 0;
+}
+.avatar-cropper-ctrl-btn:hover {
+    background: rgba(68, 183, 254, 0.25);
+    border-color: rgba(68, 183, 254, 0.4);
+}
+.avatar-cropper-ctrl-btn:active {
+    background: rgba(68, 183, 254, 0.4);
+}
+.avatar-cropper-ctrl-btn svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+}
+.avatar-cropper-ctrl-divider {
+    height: 6px;
+}
+
+.avatar-cropper-area {
+    display: flex;
+    gap: 10px;
+    align-items: stretch;
+}
 
 .avatar-cropper-buttons {
     display: flex;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1267,6 +1267,139 @@ body.react-chat-window-dragging {
     cursor: progress;
 }
 
+/* ──── Avatar Cropper (inline in popup) ──── */
+.chat-avatar-preview-crop-body {
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+}
+#chat-avatar-preview-popup.is-cropping .chat-avatar-preview-card-body { display: none; }
+#chat-avatar-preview-popup.is-cropping .chat-avatar-preview-crop-body { display: flex; }
+#chat-avatar-preview-popup.is-cropping { width: auto; max-width: calc(100vw - 24px); }
+
+.avatar-cropper-canvas-wrap {
+    position: relative;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+    overflow: hidden;
+    border-radius: 8px;
+    background: #0a0a0a;
+    align-self: center;
+}
+
+.avatar-cropper-source-img {
+    display: block;
+    pointer-events: none;
+}
+
+.avatar-cropper-mask {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.avatar-cropper-crop-box {
+    position: absolute;
+    cursor: move;
+    box-sizing: border-box;
+    border: 2px solid rgba(255, 255, 255, 0.85);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+}
+
+.avatar-cropper-viewfinder {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.avatar-cropper-grid-line {
+    position: absolute;
+    background: rgba(255, 255, 255, 0.35);
+}
+.avatar-cropper-grid-line.h1 { top: 33.33%; left: 0; right: 0; height: 1px; }
+.avatar-cropper-grid-line.h2 { top: 66.66%; left: 0; right: 0; height: 1px; }
+.avatar-cropper-grid-line.v1 { left: 33.33%; top: 0; bottom: 0; width: 1px; }
+.avatar-cropper-grid-line.v2 { left: 66.66%; top: 0; bottom: 0; width: 1px; }
+
+.avatar-cropper-circle-guide {
+    position: absolute;
+    inset: 4%;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    pointer-events: none;
+}
+
+.avatar-cropper-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    z-index: 2;
+}
+.avatar-cropper-handle::before {
+    content: '';
+    position: absolute;
+    background: #fff;
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
+    border-radius: 1px;
+}
+.avatar-cropper-handle.tl { top: -3px; left: -3px; cursor: nwse-resize; }
+.avatar-cropper-handle.tr { top: -3px; right: -3px; cursor: nesw-resize; }
+.avatar-cropper-handle.bl { bottom: -3px; left: -3px; cursor: nesw-resize; }
+.avatar-cropper-handle.br { bottom: -3px; right: -3px; cursor: nwse-resize; }
+
+.avatar-cropper-handle.tl::before { top: 0; left: 0; width: 14px; height: 3px; }
+.avatar-cropper-handle.tl::after  { content: ''; position: absolute; top: 0; left: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
+.avatar-cropper-handle.tr::before { top: 0; right: 0; left: auto; width: 14px; height: 3px; }
+.avatar-cropper-handle.tr::after  { content: ''; position: absolute; top: 0; right: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
+.avatar-cropper-handle.bl::before { bottom: 0; top: auto; left: 0; width: 14px; height: 3px; }
+.avatar-cropper-handle.bl::after  { content: ''; position: absolute; bottom: 0; left: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
+.avatar-cropper-handle.br::before { bottom: 0; top: auto; right: 0; left: auto; width: 14px; height: 3px; }
+.avatar-cropper-handle.br::after  { content: ''; position: absolute; bottom: 0; right: 0; width: 3px; height: 14px; background: #fff; box-shadow: 0 0 3px rgba(0,0,0,0.5); border-radius: 1px; }
+
+.avatar-cropper-buttons {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.avatar-cropper-btn {
+    padding: 6px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(68, 183, 254, 0.24);
+    background: rgba(68, 183, 254, 0.08);
+    color: #215f90;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+}
+.avatar-cropper-btn:hover {
+    background: rgba(68, 183, 254, 0.14);
+    border-color: rgba(68, 183, 254, 0.38);
+}
+.avatar-cropper-btn.primary {
+    background: rgba(68, 183, 254, 0.22);
+    border-color: rgba(68, 183, 254, 0.4);
+    color: #127dbc;
+}
+.avatar-cropper-btn.primary:hover {
+    background: rgba(68, 183, 254, 0.32);
+}
+[data-theme="dark"] .avatar-cropper-btn {
+    color: #8fd4ff;
+    border-color: rgba(68, 183, 254, 0.22);
+    background: rgba(68, 183, 254, 0.06);
+}
+[data-theme="dark"] .avatar-cropper-btn:hover {
+    background: rgba(68, 183, 254, 0.14);
+}
+[data-theme="dark"] .avatar-cropper-btn.primary {
+    background: rgba(68, 183, 254, 0.18);
+    border-color: rgba(68, 183, 254, 0.38);
+}
+
 /* 旧的 .subtitle-prompt-message 注入式提示已下线：
  * 字幕翻译开关现在常驻在 React 聊天窗口的 composer 工具栏，
  * 由 frontend/react-neko-chat 渲染。 */

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -457,6 +457,29 @@
                 <button id="chatAvatarPreviewRefreshButton" class="chat-avatar-preview-refresh-btn" type="button" data-i18n="chat.avatarPreviewRefresh">刷新头像</button>
             </div>
         </div>
+        <div class="chat-avatar-preview-crop-body">
+            <div id="avatar-cropper-wrap" class="avatar-cropper-canvas-wrap">
+                <img id="avatar-cropper-img" class="avatar-cropper-source-img" alt="">
+                <svg id="avatar-cropper-mask" class="avatar-cropper-mask"></svg>
+                <div id="avatar-cropper-box" class="avatar-cropper-crop-box">
+                    <div class="avatar-cropper-viewfinder">
+                        <div class="avatar-cropper-grid-line h1"></div>
+                        <div class="avatar-cropper-grid-line h2"></div>
+                        <div class="avatar-cropper-grid-line v1"></div>
+                        <div class="avatar-cropper-grid-line v2"></div>
+                        <div class="avatar-cropper-circle-guide"></div>
+                    </div>
+                    <div class="avatar-cropper-handle tl" data-handle="tl"></div>
+                    <div class="avatar-cropper-handle tr" data-handle="tr"></div>
+                    <div class="avatar-cropper-handle bl" data-handle="bl"></div>
+                    <div class="avatar-cropper-handle br" data-handle="br"></div>
+                </div>
+            </div>
+            <div class="avatar-cropper-buttons">
+                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button">取消</button>
+                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button">保存</button>
+            </div>
+        </div>
     </div>
 
     <!-- 跳过：Live2D/VRM/Three.js、common_ui.js(DOM拖拽不兼容)、touch-config、tutorial -->

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -458,21 +458,35 @@
             </div>
         </div>
         <div class="chat-avatar-preview-crop-body">
-            <div id="avatar-cropper-wrap" class="avatar-cropper-canvas-wrap">
-                <img id="avatar-cropper-img" class="avatar-cropper-source-img" alt="">
-                <svg id="avatar-cropper-mask" class="avatar-cropper-mask"></svg>
-                <div id="avatar-cropper-box" class="avatar-cropper-crop-box">
-                    <div class="avatar-cropper-viewfinder">
-                        <div class="avatar-cropper-grid-line h1"></div>
-                        <div class="avatar-cropper-grid-line h2"></div>
-                        <div class="avatar-cropper-grid-line v1"></div>
-                        <div class="avatar-cropper-grid-line v2"></div>
-                        <div class="avatar-cropper-circle-guide"></div>
+            <div class="avatar-cropper-area">
+                <div id="avatar-cropper-wrap" class="avatar-cropper-canvas-wrap">
+                    <img id="avatar-cropper-img" class="avatar-cropper-source-img" alt="">
+                    <svg id="avatar-cropper-mask" class="avatar-cropper-mask"></svg>
+                    <div id="avatar-cropper-box" class="avatar-cropper-crop-box">
+                        <div class="avatar-cropper-viewfinder">
+                            <div class="avatar-cropper-grid-line h1"></div>
+                            <div class="avatar-cropper-grid-line h2"></div>
+                            <div class="avatar-cropper-grid-line v1"></div>
+                            <div class="avatar-cropper-grid-line v2"></div>
+                            <div class="avatar-cropper-circle-guide"></div>
+                        </div>
+                        <div class="avatar-cropper-handle tl" data-handle="tl"></div>
+                        <div class="avatar-cropper-handle tr" data-handle="tr"></div>
+                        <div class="avatar-cropper-handle bl" data-handle="bl"></div>
+                        <div class="avatar-cropper-handle br" data-handle="br"></div>
                     </div>
-                    <div class="avatar-cropper-handle tl" data-handle="tl"></div>
-                    <div class="avatar-cropper-handle tr" data-handle="tr"></div>
-                    <div class="avatar-cropper-handle bl" data-handle="bl"></div>
-                    <div class="avatar-cropper-handle br" data-handle="br"></div>
+                </div>
+                <div class="avatar-cropper-controls">
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="up" title="上移"><svg viewBox="0 0 16 16"><path d="M8 3L2 10h12z"/></svg></button>
+                    <div class="avatar-cropper-controls-row">
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="left" title="左移"><svg viewBox="0 0 16 16"><path d="M3 8l7-6v12z"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="center" title="居中"><svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3"/><path d="M8 1v3M8 12v3M1 8h3M12 8h3" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="right" title="右移"><svg viewBox="0 0 16 16"><path d="M13 8L6 2v12z"/></svg></button>
+                    </div>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="down" title="下移"><svg viewBox="0 0 16 16"><path d="M8 13l6-7H2z"/></svg></button>
+                    <div class="avatar-cropper-ctrl-divider"></div>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="bigger" title="放大"><svg viewBox="0 0 16 16"><path d="M3 8h10M8 3v10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="smaller" title="缩小"><svg viewBox="0 0 16 16"><path d="M3 8h10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
                 </div>
             </div>
             <div class="avatar-cropper-buttons">

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -477,21 +477,21 @@
                     </div>
                 </div>
                 <div class="avatar-cropper-controls">
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="up" title="上移"><svg viewBox="0 0 16 16"><path d="M8 3L2 10h12z"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="up" data-i18n-title="chat.avatarCropMoveUp" title="上移"><svg viewBox="0 0 16 16"><path d="M8 3L2 10h12z"/></svg></button>
                     <div class="avatar-cropper-controls-row">
-                        <button class="avatar-cropper-ctrl-btn" data-crop-action="left" title="左移"><svg viewBox="0 0 16 16"><path d="M3 8l7-6v12z"/></svg></button>
-                        <button class="avatar-cropper-ctrl-btn" data-crop-action="center" title="居中"><svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3"/><path d="M8 1v3M8 12v3M1 8h3M12 8h3" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>
-                        <button class="avatar-cropper-ctrl-btn" data-crop-action="right" title="右移"><svg viewBox="0 0 16 16"><path d="M13 8L6 2v12z"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="left" data-i18n-title="chat.avatarCropMoveLeft" title="左移"><svg viewBox="0 0 16 16"><path d="M3 8l7-6v12z"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="center" data-i18n-title="chat.avatarCropCenter" title="居中"><svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3"/><path d="M8 1v3M8 12v3M1 8h3M12 8h3" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="right" data-i18n-title="chat.avatarCropMoveRight" title="右移"><svg viewBox="0 0 16 16"><path d="M13 8L6 2v12z"/></svg></button>
                     </div>
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="down" title="下移"><svg viewBox="0 0 16 16"><path d="M8 13l6-7H2z"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="down" data-i18n-title="chat.avatarCropMoveDown" title="下移"><svg viewBox="0 0 16 16"><path d="M8 13l6-7H2z"/></svg></button>
                     <div class="avatar-cropper-ctrl-divider"></div>
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="bigger" title="放大"><svg viewBox="0 0 16 16"><path d="M3 8h10M8 3v10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="smaller" title="缩小"><svg viewBox="0 0 16 16"><path d="M3 8h10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="bigger" data-i18n-title="chat.avatarCropZoomIn" title="放大"><svg viewBox="0 0 16 16"><path d="M3 8h10M8 3v10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="smaller" data-i18n-title="chat.avatarCropZoomOut" title="缩小"><svg viewBox="0 0 16 16"><path d="M3 8h10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
                 </div>
             </div>
             <div class="avatar-cropper-buttons">
-                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button">取消</button>
-                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button">保存</button>
+                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropCancel">取消</button>
+                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button" data-i18n="chat.avatarCropSave">保存</button>
             </div>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,21 +181,35 @@
             </div>
         </div>
         <div class="chat-avatar-preview-crop-body">
-            <div id="avatar-cropper-wrap" class="avatar-cropper-canvas-wrap">
-                <img id="avatar-cropper-img" class="avatar-cropper-source-img" alt="">
-                <svg id="avatar-cropper-mask" class="avatar-cropper-mask"></svg>
-                <div id="avatar-cropper-box" class="avatar-cropper-crop-box">
-                    <div class="avatar-cropper-viewfinder">
-                        <div class="avatar-cropper-grid-line h1"></div>
-                        <div class="avatar-cropper-grid-line h2"></div>
-                        <div class="avatar-cropper-grid-line v1"></div>
-                        <div class="avatar-cropper-grid-line v2"></div>
-                        <div class="avatar-cropper-circle-guide"></div>
+            <div class="avatar-cropper-area">
+                <div id="avatar-cropper-wrap" class="avatar-cropper-canvas-wrap">
+                    <img id="avatar-cropper-img" class="avatar-cropper-source-img" alt="">
+                    <svg id="avatar-cropper-mask" class="avatar-cropper-mask"></svg>
+                    <div id="avatar-cropper-box" class="avatar-cropper-crop-box">
+                        <div class="avatar-cropper-viewfinder">
+                            <div class="avatar-cropper-grid-line h1"></div>
+                            <div class="avatar-cropper-grid-line h2"></div>
+                            <div class="avatar-cropper-grid-line v1"></div>
+                            <div class="avatar-cropper-grid-line v2"></div>
+                            <div class="avatar-cropper-circle-guide"></div>
+                        </div>
+                        <div class="avatar-cropper-handle tl" data-handle="tl"></div>
+                        <div class="avatar-cropper-handle tr" data-handle="tr"></div>
+                        <div class="avatar-cropper-handle bl" data-handle="bl"></div>
+                        <div class="avatar-cropper-handle br" data-handle="br"></div>
                     </div>
-                    <div class="avatar-cropper-handle tl" data-handle="tl"></div>
-                    <div class="avatar-cropper-handle tr" data-handle="tr"></div>
-                    <div class="avatar-cropper-handle bl" data-handle="bl"></div>
-                    <div class="avatar-cropper-handle br" data-handle="br"></div>
+                </div>
+                <div class="avatar-cropper-controls">
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="up" title="上移"><svg viewBox="0 0 16 16"><path d="M8 3L2 10h12z"/></svg></button>
+                    <div class="avatar-cropper-controls-row">
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="left" title="左移"><svg viewBox="0 0 16 16"><path d="M3 8l7-6v12z"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="center" title="居中"><svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3"/><path d="M8 1v3M8 12v3M1 8h3M12 8h3" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="right" title="右移"><svg viewBox="0 0 16 16"><path d="M13 8L6 2v12z"/></svg></button>
+                    </div>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="down" title="下移"><svg viewBox="0 0 16 16"><path d="M8 13l6-7H2z"/></svg></button>
+                    <div class="avatar-cropper-ctrl-divider"></div>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="bigger" title="放大"><svg viewBox="0 0 16 16"><path d="M3 8h10M8 3v10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="smaller" title="缩小"><svg viewBox="0 0 16 16"><path d="M3 8h10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
                 </div>
             </div>
             <div class="avatar-cropper-buttons">

--- a/templates/index.html
+++ b/templates/index.html
@@ -180,6 +180,29 @@
                 <button id="chatAvatarPreviewRefreshButton" class="chat-avatar-preview-refresh-btn" type="button" data-i18n="chat.avatarPreviewRefresh">刷新头像</button>
             </div>
         </div>
+        <div class="chat-avatar-preview-crop-body">
+            <div id="avatar-cropper-wrap" class="avatar-cropper-canvas-wrap">
+                <img id="avatar-cropper-img" class="avatar-cropper-source-img" alt="">
+                <svg id="avatar-cropper-mask" class="avatar-cropper-mask"></svg>
+                <div id="avatar-cropper-box" class="avatar-cropper-crop-box">
+                    <div class="avatar-cropper-viewfinder">
+                        <div class="avatar-cropper-grid-line h1"></div>
+                        <div class="avatar-cropper-grid-line h2"></div>
+                        <div class="avatar-cropper-grid-line v1"></div>
+                        <div class="avatar-cropper-grid-line v2"></div>
+                        <div class="avatar-cropper-circle-guide"></div>
+                    </div>
+                    <div class="avatar-cropper-handle tl" data-handle="tl"></div>
+                    <div class="avatar-cropper-handle tr" data-handle="tr"></div>
+                    <div class="avatar-cropper-handle bl" data-handle="bl"></div>
+                    <div class="avatar-cropper-handle br" data-handle="br"></div>
+                </div>
+            </div>
+            <div class="avatar-cropper-buttons">
+                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button">取消</button>
+                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button">保存</button>
+            </div>
+        </div>
     </div>
     <div id="live2d-container">
         <canvas id="live2d-canvas"></canvas>

--- a/templates/index.html
+++ b/templates/index.html
@@ -200,21 +200,21 @@
                     </div>
                 </div>
                 <div class="avatar-cropper-controls">
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="up" title="上移"><svg viewBox="0 0 16 16"><path d="M8 3L2 10h12z"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="up" data-i18n-title="chat.avatarCropMoveUp" title="上移"><svg viewBox="0 0 16 16"><path d="M8 3L2 10h12z"/></svg></button>
                     <div class="avatar-cropper-controls-row">
-                        <button class="avatar-cropper-ctrl-btn" data-crop-action="left" title="左移"><svg viewBox="0 0 16 16"><path d="M3 8l7-6v12z"/></svg></button>
-                        <button class="avatar-cropper-ctrl-btn" data-crop-action="center" title="居中"><svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3"/><path d="M8 1v3M8 12v3M1 8h3M12 8h3" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>
-                        <button class="avatar-cropper-ctrl-btn" data-crop-action="right" title="右移"><svg viewBox="0 0 16 16"><path d="M13 8L6 2v12z"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="left" data-i18n-title="chat.avatarCropMoveLeft" title="左移"><svg viewBox="0 0 16 16"><path d="M3 8l7-6v12z"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="center" data-i18n-title="chat.avatarCropCenter" title="居中"><svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3"/><path d="M8 1v3M8 12v3M1 8h3M12 8h3" stroke="currentColor" stroke-width="1.5" fill="none"/></svg></button>
+                        <button class="avatar-cropper-ctrl-btn" data-crop-action="right" data-i18n-title="chat.avatarCropMoveRight" title="右移"><svg viewBox="0 0 16 16"><path d="M13 8L6 2v12z"/></svg></button>
                     </div>
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="down" title="下移"><svg viewBox="0 0 16 16"><path d="M8 13l6-7H2z"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="down" data-i18n-title="chat.avatarCropMoveDown" title="下移"><svg viewBox="0 0 16 16"><path d="M8 13l6-7H2z"/></svg></button>
                     <div class="avatar-cropper-ctrl-divider"></div>
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="bigger" title="放大"><svg viewBox="0 0 16 16"><path d="M3 8h10M8 3v10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
-                    <button class="avatar-cropper-ctrl-btn" data-crop-action="smaller" title="缩小"><svg viewBox="0 0 16 16"><path d="M3 8h10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="bigger" data-i18n-title="chat.avatarCropZoomIn" title="放大"><svg viewBox="0 0 16 16"><path d="M3 8h10M8 3v10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
+                    <button class="avatar-cropper-ctrl-btn" data-crop-action="smaller" data-i18n-title="chat.avatarCropZoomOut" title="缩小"><svg viewBox="0 0 16 16"><path d="M3 8h10" stroke="currentColor" stroke-width="2" fill="none"/></svg></button>
                 </div>
             </div>
             <div class="avatar-cropper-buttons">
-                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button">取消</button>
-                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button">保存</button>
+                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropCancel">取消</button>
+                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button" data-i18n="chat.avatarCropSave">保存</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- **修复头像比例变形**：avatar-portrait.js 的 capture 在 drawImage 之前引入 cropRectToTargetAspect，确保源矩形被裁剪（而非拉伸）到目标宽高比，解决 Live2D / VRM / MMD 头像预览变形问题。
- **新增手动裁剪功能**：点击「刷新头像」后，在同一个预览弹窗内切换到裁剪模式，用户可通过拖拽/缩放选框、滚轮调整、右侧方向按钮精准控制裁剪区域，保存后生成 320x320 圆角头像。

## Changes
- **static/avatar-portrait.js**: 新增 cropRectToTargetAspect 辅助函数；capture 支持 includeSourceDataUrl 选项导出原始画布数据
- **static/app-chat-avatar.js**: 新增 openAvatarCropper（内嵌裁剪器 UI + 交互）、cropSourceToAvatar（Canvas 裁剪输出）；renderAvatarPreview 集成手动裁剪流程
- **static/css/index.css**: 裁剪器样式：遮罩、选框、九宫格取景线、圆形辅助线、角落手柄、右侧控制按钮面板
- **templates/index.html + chat.html**: 在 popup 内添加裁剪器 DOM 结构

## Test plan
- 加载 VRM 模型 -> 打开头像预览 -> 确认头像不变形（1:1 裁剪而非拉伸）
- 加载 Live2D 模型 -> 同上验证
- 点击刷新头像 -> 弹窗内切换为裁剪模式 -> 拖拽选框移动/角落手柄缩放/滚轮缩放/右侧按钮控制 -> 保存
- 裁剪模式下点击取消或关闭弹窗 -> 回退到自动裁剪结果
- 选框在极限大小时滚轮不会导致位置偏移


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 内置头像手动裁剪界面：拖拽、角点缩放、移动、网格/圆形辅助、取消/保存，导出圆形 320×320 PNG。
  * 预览捕获可选返回原始源图与裁剪信息；支持通过页面间广播通道跨窗口请求并返回捕获结果（含超时与错误处理），并在不可用时回退到页面内捕获。

* **行为变更 / 修复**
  * 刷新按钮现在触发手动裁剪流程；用户取消裁剪将回退至自动结果并标注“裁剪已取消”。
  * 关闭预览弹窗时确保任何打开的裁剪器被正确关闭。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->