### PR TITLE
fix: cancel manual crop now keeps the original avatar

### DIFF
--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -805,6 +805,7 @@
         isCapturing = true;
         const token = ++activeCaptureToken;
         const cacheKey = getCurrentModelCacheKey();
+        const prevCachedPreview = cachedPreview ? Object.assign({}, cachedPreview) : null;
         if (showCard) {
             setPreviewVisible(true, trigger);
         }
@@ -837,8 +838,17 @@
                     var croppedDataUrl = await cropSourceToAvatar(result.sourceDataUrl, userCrop);
                     applyPreviewResult({ dataUrl: croppedDataUrl, modelType: result.modelType }, cacheKey);
                 } else {
-                    applyPreviewResult(result, cacheKey);
-                    setPreviewNote(translateLabel('chat.avatarPreviewCropCancelled', '已取消手动裁剪，使用自动裁剪结果。'));
+                    if (prevCachedPreview) {
+                        cachedPreview = prevCachedPreview;
+                        setPreviewImage(prevCachedPreview.dataUrl);
+                        setPreviewStatus(
+                            translateLabel('chat.avatarPreviewReady', '头像已更新') + ' · ' + normalizeModelLabel(prevCachedPreview.modelType)
+                        );
+                    } else {
+                        setPreviewImage('');
+                        setPreviewStatus(translateLabel('chat.avatarPreviewCardStatus', '点击上方按钮生成当前模型头像'));
+                    }
+                    setPreviewNote(translateLabel('chat.avatarPreviewCropCancelled', '已取消手动裁剪，保持原头像不变。'));
                 }
             } else {
                 applyPreviewResult(result, cacheKey);

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -586,7 +586,7 @@
         "avatarPreviewFailed": "Failed to generate avatar",
         "avatarCropperTitle": "Adjust avatar crop area",
         "avatarPreviewCropping": "Please adjust the crop area",
-        "avatarPreviewCropCancelled": "Manual crop cancelled, using auto-cropped result.",
+        "avatarPreviewCropCancelled": "Manual crop cancelled, keeping the original avatar.",
         "avatarCropMoveUp": "Move up",
         "avatarCropMoveDown": "Move down",
         "avatarCropMoveLeft": "Move left",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -586,7 +586,7 @@
         "avatarPreviewFailed": "アバターの生成に失敗しました",
         "avatarCropperTitle": "アバターの切り抜き範囲を調整",
         "avatarPreviewCropping": "切り抜き範囲を調整してください",
-        "avatarPreviewCropCancelled": "手動切り抜きをキャンセルしました。自動切り抜き結果を使用します。",
+        "avatarPreviewCropCancelled": "手動切り抜きをキャンセルしました。元のアバターを維持します。",
         "avatarCropMoveUp": "上へ移動",
         "avatarCropMoveDown": "下へ移動",
         "avatarCropMoveLeft": "左へ移動",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -586,7 +586,7 @@
         "avatarPreviewFailed": "아바타 생성 실패",
         "avatarCropperTitle": "아바타 자르기 영역 조정",
         "avatarPreviewCropping": "자르기 영역을 조정하세요",
-        "avatarPreviewCropCancelled": "수동 자르기가 취소되었습니다. 자동 자르기 결과를 사용합니다.",
+        "avatarPreviewCropCancelled": "수동 자르기가 취소되었습니다. 기존 아바타를 유지합니다.",
         "avatarCropMoveUp": "위로 이동",
         "avatarCropMoveDown": "아래로 이동",
         "avatarCropMoveLeft": "왼쪽으로 이동",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -586,7 +586,7 @@
         "avatarPreviewFailed": "Не удалось создать аватар",
         "avatarCropperTitle": "Настройка области обрезки аватара",
         "avatarPreviewCropping": "Настройте область обрезки",
-        "avatarPreviewCropCancelled": "Ручная обрезка отменена. Используется автоматический результат.",
+        "avatarPreviewCropCancelled": "Ручная обрезка отменена. Аватар остаётся прежним.",
         "avatarCropMoveUp": "Вверх",
         "avatarCropMoveDown": "Вниз",
         "avatarCropMoveLeft": "Влево",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -586,7 +586,7 @@
         "avatarPreviewFailed": "生成头像失败",
         "avatarCropperTitle": "调整头像裁剪区域",
         "avatarPreviewCropping": "请调整裁剪区域",
-        "avatarPreviewCropCancelled": "已取消手动裁剪，使用自动裁剪结果。",
+        "avatarPreviewCropCancelled": "已取消手动裁剪，保持原头像不变。",
         "avatarCropMoveUp": "上移",
         "avatarCropMoveDown": "下移",
         "avatarCropMoveLeft": "左移",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -586,7 +586,7 @@
         "avatarPreviewFailed": "生成頭像失敗",
         "avatarCropperTitle": "調整頭像裁剪區域",
         "avatarPreviewCropping": "請調整裁剪區域",
-        "avatarPreviewCropCancelled": "已取消手動裁剪，使用自動裁剪結果。",
+        "avatarPreviewCropCancelled": "已取消手動裁剪，保持原頭像不變。",
         "avatarCropMoveUp": "上移",
         "avatarCropMoveDown": "下移",
         "avatarCropMoveLeft": "左移",


### PR DESCRIPTION
## Summary
- **修复取消裁剪后仍然更新头像的 bug**：点击"取消"按钮后，现在会正确恢复到裁剪前的原始头像，而不是应用自动裁剪结果。

## Changes
- **static/app-chat-avatar.js**:
  - 在 capture 流程开始前保存 `prevCachedPreview` 快照
  - 取消裁剪时恢复 `cachedPreview` 和预览图为之前保存的状态，不再调用 `applyPreviewResult`
  - 若之前无缓存（首次使用），则清空预览并恢复到初始提示
- **static/locales/*.json** (6 files): 更新 `avatarPreviewCropCancelled` 的翻译文案，从"使用自动裁剪结果"改为"保持原头像不变"

## Test plan
- [ ] 打开头像预览 → 点击刷新头像 → 进入裁剪模式 → 点击取消 → 确认头像不变
- [ ] 打开头像预览 → 点击刷新头像 → 进入裁剪模式 → 直接关闭弹窗 → 确认头像不变
- [ ] 打开头像预览 → 点击刷新头像 → 进入裁剪模式 → 点击保存 → 确认头像更新为手动裁剪结果
- [ ] 首次使用（无缓存）→ 点击刷新 → 取消 → 确认回到初始提示状态


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 修复了用户取消手动头像裁剪时的行为，现在正确保留原始头像而不是应用自动裁剪结果
- 更新了英文、日文、韩文、俄文、简体中文和繁体中文的用户提示文本，以准确反映头像裁剪取消后的操作

<!-- end of auto-generated comment: release notes by coderabbit.ai -->