### PR TITLE
fix: isolate music cooldown/dedup from other proactive sources

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1910,7 +1910,7 @@ class LLMSessionManager:
             
             initial_prompt = await self._build_initial_prompt()
             self.initial_cache_snapshot_len = len(self.message_cache_for_new_session)
-            async with httpx.AsyncClient(timeout=2.0, proxy=None, trust_env=False) as client:
+            async with httpx.AsyncClient(timeout=3.0, proxy=None, trust_env=False) as client:
                 resp = await client.get(f"http://127.0.0.1:{self.memory_server_port}/new_dialog/{self.lanlan_name}")
                 if not resp.is_success:
                     raise ConnectionError(f"❌ 记忆服务热切换时返回非2xx状态 {resp.status_code}: {resp.text[:200]}")

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2228,7 +2228,7 @@ def build_proactive_response(source_tag: str, ctx: dict) -> tuple[str, list]:
     
     match source_tag:
         case 'CHAT':
-            primary_channel = 'vision'
+            primary_channel = 'chat'
         case 'WEB':
             # 使用细粒度 web 子通道（news/video/home/personal），fallback 到 'web'
             web_link = ctx.get('selected_web_link')

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2959,6 +2959,7 @@ async def proactive_chat(request: Request):
                     )
                     if _is_recent_topic_used(lanlan_name, music_topic_key):
                         print(f"[{lanlan_name}]- Phase 1 音乐话题去重命中，跳过: {track_name}")
+                        music_content = None  # 彻底清空，防止去重后的残留数据泄漏到 fallback 逻辑
                     else:
                         logger.debug(f"[{lanlan_name}]- Phase 1 音乐话题已添加: {music_topic[:100]}...")
                         selected_music_link = {
@@ -3085,14 +3086,14 @@ async def proactive_chat(request: Request):
         
         music_section = ""
         # 如果正在放歌或处于冷却期，强行屏蔽音乐素材推荐，避免 AI 误触
+        # （冷却期时 music_content 已在上游被清空，music_topic 必为 None，此分支不会命中）
         if music_topic and not is_playing_music and not music_cooldown:
             # 【优化】使用独立的标识符，防止模型将音乐素材误认为普通的外部 WEB 话题
             msh = _loc(MUSIC_SECTION_HEADER, proactive_lang)
             msf = _loc(MUSIC_SECTION_FOOTER, proactive_lang)
             music_section = f"{msh}\n{music_topic}\n{msf}"
-        elif is_playing_music or music_cooldown:
-            reason = "正在播放音乐" if is_playing_music else "音乐冷却期"
-            print(f"[{lanlan_name}] {reason}，已屏蔽音乐推荐素材（仅保留 playing_hint）")
+        elif is_playing_music:
+            print(f"[{lanlan_name}] 正在播放音乐，已屏蔽音乐推荐素材（仅保留 playing_hint）")
             music_section = ""
         
         # 构建表情包段（meme 通道）
@@ -3149,8 +3150,10 @@ async def proactive_chat(request: Request):
             if raw_data.get('best_match', {}).get('status') == 'fuzzy':
                 dynamic_context_for_phase2 += get_proactive_music_failsafe_hint(proactive_lang)
 
-        if is_playing_music or music_cooldown:
+        if is_playing_music:
             dynamic_context_for_phase2 += get_proactive_music_strict_constraint(proactive_lang)
+        # music_cooldown 时不再注入 strict_constraint —— 此时 music 通道已被前端/后端
+        # 完全剔除，不应向模型暴露任何音乐相关指令，以免干扰其他 source 的选择。
         print(f"[{lanlan_name}] Phase 2 prompt 长度: {len(generate_prompt)}, 动态上下文: {len(dynamic_context_for_phase2)} 字符")
 
         # --- 前置检查：用户是否空闲、WebSocket 是否在线、session 是否可用 ---
@@ -3313,16 +3316,23 @@ async def proactive_chat(request: Request):
 
         has_music_topic = 'music' in active_channels
 
-        # 【加固】数据级锁：如果正在同步播放音乐，哪怕 AI 产生了音乐标签，也强制降级/忽略
+        # 【加固】数据级锁：如果正在播放音乐，哪怕 AI 产生了音乐标签，也强制降级/忽略
         is_music_used = has_music_topic and source_tag == 'MUSIC'
         ai_wants_music = source_tag == 'MUSIC'
 
-        if (is_playing_music or music_cooldown) and ai_wants_music:
-            print(f"[{lanlan_name}] 数据级锁触发：{'播放中' if is_playing_music else '冷却期'}尝试推荐新歌，已强制拦截并清空曲目列表")
+        if is_playing_music and ai_wants_music:
+            print(f"[{lanlan_name}] 数据级锁触发：播放中尝试推荐新歌，已强制拦截并清空曲目列表")
             is_music_used = False
             music_content = None
             source_tag = 'PASS'
             aborted = True
+        elif music_cooldown and ai_wants_music:
+            # 冷却期：music 通道本不应出现在上下文中，但模型仍输出了 [MUSIC] 标签。
+            # 降级为普通 CHAT 而非 abort 整轮搭话，避免浪费其他 source 的有效内容。
+            print(f"[{lanlan_name}] 音乐冷却期模型输出 [MUSIC]，降级为 CHAT（不中止搭话）")
+            is_music_used = False
+            music_content = None
+            source_tag = 'CHAT'
         
         # 【加固补齐】如果触发了降级拦截（aborted），立即返回
         if aborted:

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -554,11 +554,17 @@
                 }
             }
 
-            // 音乐搭话
+            // 音乐搭话（正在播放或冷却期内不发送 music 模式，避免后端搜歌浪费 + 污染模型上下文）
             console.log('[ProactiveChat] 检查音乐模式: proactiveMusicEnabled=' + S.proactiveMusicEnabled + ', proactiveChatEnabled=' + S.proactiveChatEnabled);
             if (S.proactiveMusicEnabled && S.proactiveChatEnabled) {
-                console.log('[ProactiveChat] 音乐模式已启用');
-                availableModes.push('music');
+                var musicPlaying = (typeof window.isMusicPlaying === 'function') && window.isMusicPlaying();
+                var musicCooldown = (typeof window.isMusicCooldown === 'function') && window.isMusicCooldown();
+                if (musicPlaying || musicCooldown) {
+                    console.log('[ProactiveChat] 音乐模式跳过: playing=' + musicPlaying + ', cooldown=' + musicCooldown);
+                } else {
+                    console.log('[ProactiveChat] 音乐模式已启用');
+                    availableModes.push('music');
+                }
             }
 
             // Meme搭话
@@ -641,9 +647,13 @@
                 if (S.proactivePersonalChatEnabled && S.proactiveChatEnabled) {
                     latestModes.push('personal');
                 }
-                // 音乐搭话
+                // 音乐搭话（重新检查冷却状态，await 期间可能变化）
                 if (S.proactiveMusicEnabled && S.proactiveChatEnabled) {
-                    latestModes.push('music');
+                    var musicPlayingNow = (typeof window.isMusicPlaying === 'function') && window.isMusicPlaying();
+                    var musicCooldownNow = (typeof window.isMusicCooldown === 'function') && window.isMusicCooldown();
+                    if (!musicPlayingNow && !musicCooldownNow) {
+                        latestModes.push('music');
+                    }
                 }
                 // Meme搭话
                 if (S.proactiveMemeEnabled && S.proactiveChatEnabled) {


### PR DESCRIPTION
- Frontend: skip 'music' mode in enabled_modes when playing/cooldown, preventing unnecessary search requests and context pollution
- Frontend: re-check playing/cooldown in post-await latestModes filter
- Backend: only inject strict_constraint when is_playing_music (not cooldown)
- Backend: downgrade [MUSIC] tag to [CHAT] during cooldown instead of aborting the entire proactive turn
- Backend: clear music_content on topic dedup hit to prevent stale data leaking into fallback logic
- Bump memory client timeout from 2s to 3s in core.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 改进了音乐去重处理，防止过时音乐数据影响后续选择。
  * 调整了播放与冷却期间的交互逻辑，避免在冷却时产生不合适的中断或中止行为。
  * 提高了预热/热切换期间的网络鲁棒性，延长了请求超时以减少连接失败。

* **New Features**
  * 优化了前端主动触发的音乐模式选择，在播放或冷却期间禁用音乐建议并记录跳过原因。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->