### PR TITLE
fix: processRealisticQueue finally 块竞态 — 过期实例不再破坏新实例互斥锁

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -510,6 +510,17 @@ class OmniOfflineClient:
                     if attempt < max_retries - 1:
                         wait_time = retry_delays[attempt]
                         logger.warning(f"OmniOfflineClient: LLM调用失败 (尝试 {attempt + 1}/{max_retries})，{wait_time}秒后重试: {e}")
+                        # 如果 attempt 已经向前端吐过 chunk，通知前端清除废气泡，
+                        # 否则 retry 的新流会接在旧气泡后面，产生两段不同内容拼接。
+                        if assistant_message and self.on_response_discarded:
+                            await self._notify_response_discarded(
+                                f"api_error:{error_type}",
+                                attempt + 1,
+                                max_retries,
+                                will_retry=True,
+                                message=None,
+                            )
+                        assistant_message = ""
                         await asyncio.sleep(wait_time)
                         continue
                     else:

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -320,13 +320,16 @@
                 }
             }
         } finally {
-            window._isProcessingRealisticQueue = false;
-            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时才递归消费剩余队列。
-            // version 已变时，新的持有者会自行启动 processRealisticQueue，这里不递归，
-            // 避免两个实例同时 shift 同一个队列导致文本 chunk 交错。
-            if ((window._realisticGeminiVersion || 0) === queueVersion &&
-                window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
-                processRealisticQueue(window._realisticGeminiVersion || 0);
+            // 如果 lock 还是 true，说明没有任何外部路径（discard / audio-capture）
+            // 接管过 —— 无论 version 是否变化，我们都是当前唯一持有者，必须释放锁，
+            // 否则队列会卡死。
+            // 如果 lock 已经是 false，说明外部路径已经重置锁并可能启动了新 processor，
+            // 我们不能再递归也不能再动锁。
+            if (window._isProcessingRealisticQueue) {
+                window._isProcessingRealisticQueue = false;
+                if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
+                    processRealisticQueue(window._realisticGeminiVersion || 0);
+                }
             }
         }
     }

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -320,9 +320,14 @@
                 }
             }
         } finally {
-            window._isProcessingRealisticQueue = false;
-            if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
-                processRealisticQueue(window._realisticGeminiVersion || 0);
+            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时，
+            // 才重置锁并尝试递归。如果 version 已变，说明新的持有者已经
+            // 在管理队列了，这里静默退出，避免破坏新实例的互斥锁。
+            if ((window._realisticGeminiVersion || 0) === queueVersion) {
+                window._isProcessingRealisticQueue = false;
+                if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
+                    processRealisticQueue(window._realisticGeminiVersion || 0);
+                }
             }
         }
     }

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -320,14 +320,13 @@
                 }
             }
         } finally {
-            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时，
-            // 才重置锁并尝试递归。如果 version 已变，说明新的持有者已经
-            // 在管理队列了，这里静默退出，避免破坏新实例的互斥锁。
-            if ((window._realisticGeminiVersion || 0) === queueVersion) {
-                window._isProcessingRealisticQueue = false;
-                if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
-                    processRealisticQueue(window._realisticGeminiVersion || 0);
-                }
+            window._isProcessingRealisticQueue = false;
+            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时才递归消费剩余队列。
+            // version 已变时，新的持有者会自行启动 processRealisticQueue，这里不递归，
+            // 避免两个实例同时 shift 同一个队列导致文本 chunk 交错。
+            if ((window._realisticGeminiVersion || 0) === queueVersion &&
+                window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
+                processRealisticQueue(window._realisticGeminiVersion || 0);
             }
         }
     }

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -415,10 +415,14 @@
                 }
             }
         } finally {
-            window._isProcessingRealisticQueue = false;
-            // 兜底检查：如果在循环结束到重置标志位之间又有新消息进入队列，递归触发
-            if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
-                processRealisticQueue(window._realisticGeminiVersion || 0);
+            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时，
+            // 才重置锁并尝试递归。如果 version 已变，说明新的持有者已经
+            // 在管理队列了，这里静默退出，避免破坏新实例的互斥锁。
+            if ((window._realisticGeminiVersion || 0) === queueVersion) {
+                window._isProcessingRealisticQueue = false;
+                if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
+                    processRealisticQueue(window._realisticGeminiVersion || 0);
+                }
             }
         }
     }

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -415,14 +415,13 @@
                 }
             }
         } finally {
-            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时，
-            // 才重置锁并尝试递归。如果 version 已变，说明新的持有者已经
-            // 在管理队列了，这里静默退出，避免破坏新实例的互斥锁。
-            if ((window._realisticGeminiVersion || 0) === queueVersion) {
-                window._isProcessingRealisticQueue = false;
-                if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
-                    processRealisticQueue(window._realisticGeminiVersion || 0);
-                }
+            window._isProcessingRealisticQueue = false;
+            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时才递归消费剩余队列。
+            // version 已变时，新的持有者会自行启动 processRealisticQueue，这里不递归，
+            // 避免两个实例同时 shift 同一个队列导致文本 chunk 交错。
+            if ((window._realisticGeminiVersion || 0) === queueVersion &&
+                window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
+                processRealisticQueue(window._realisticGeminiVersion || 0);
             }
         }
     }

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -415,13 +415,16 @@
                 }
             }
         } finally {
-            window._isProcessingRealisticQueue = false;
-            // 只有当 version 没变（即没有被 discard/isNewMessage 接管）时才递归消费剩余队列。
-            // version 已变时，新的持有者会自行启动 processRealisticQueue，这里不递归，
-            // 避免两个实例同时 shift 同一个队列导致文本 chunk 交错。
-            if ((window._realisticGeminiVersion || 0) === queueVersion &&
-                window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
-                processRealisticQueue(window._realisticGeminiVersion || 0);
+            // 如果 lock 还是 true，说明没有任何外部路径（discard / audio-capture）
+            // 接管过 —— 无论 version 是否变化，我们都是当前唯一持有者，必须释放锁，
+            // 否则队列会卡死。
+            // 如果 lock 已经是 false，说明外部路径已经重置锁并可能启动了新 processor，
+            // 我们不能再递归也不能再动锁。
+            if (window._isProcessingRealisticQueue) {
+                window._isProcessingRealisticQueue = false;
+                if (window._realisticGeminiQueue && window._realisticGeminiQueue.length > 0) {
+                    processRealisticQueue(window._realisticGeminiVersion || 0);
+                }
             }
         }
     }


### PR DESCRIPTION
当 response_discarded 或 isNewMessage 在 processRealisticQueue 的 2s sleep 期间到达时，旧实例的 finally 块会无条件重置 _isProcessingRealisticQueue=false， 破坏新实例的互斥锁，导致两个实例同时 shift 同一个队列，产生文本 chunk 交错。

修复：finally 块中加 version 守卫，version 不匹配时不碰锁、不递归、静默退出。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化了聊天消息队列的处理：在退出时基于当前锁状态和版本决定是否继续处理，避免不同控制路径并发或重复消费同一队列引发冲突。
  * 在上游出错并重试时，会通知前端丢弃正在生成的回复并清除临时内容，防止重试结果与残留片段拼接。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->