### PR TITLE
fix: HTTP 503 错误显示为用户友好的"上游服务器繁忙"提示

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1643,6 +1643,8 @@ class LLMSessionManager:
                     await self.send_status(json.dumps({"code": "API_KEY_REJECTED"}))
                 elif '429' in error_str:
                     await self.send_status(json.dumps({"code": "API_RATE_LIMIT_SESSION"}))
+                elif 'HTTP 503' in error_str:
+                    await self.send_status(json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
                 elif 'All connection attempts failed' in error_str:
                     await self.send_status(json.dumps({"code": "LLM_CONNECTION_FAILED"}))
                 else:
@@ -3166,6 +3168,7 @@ class LLMSessionManager:
                             'API_ARREARS', 'API_QUOTA_TIME', 'API_KEY_REJECTED',
                             'API_RATE_LIMIT', 'API_POLICY_VIOLATION',
                             'API_1008_FALLBACK', 'TTS_CONNECTION_FAILED',
+                            'UPSTREAM_SERVER_BUSY',
                         }
                         _parsed_code = None
                         _keyword_target = error_msg_text  # 非 JSON 错误时回退使用

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -1048,6 +1048,8 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         
                     except Exception as e:
                         logger.error(f"重新建立连接失败: {e}")
+                        if 'HTTP 503' in str(e):
+                            _enqueue_error(response_queue, json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
                         response_queue.put(("__reconnecting__", "TTS_RECONNECTING"))
                         await asyncio.sleep(1.0)
                         continue
@@ -1086,6 +1088,8 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         
         except Exception as e:
             logger.error(f"StepFun实时TTS Worker错误: {e}")
+            if 'HTTP 503' in str(e):
+                _enqueue_error(response_queue, json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
             response_queue.put(("__ready__", False))
         finally:
             # 清理资源
@@ -1381,6 +1385,8 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         
                     except Exception as e:
                         logger.error(f"重新建立连接失败: {e}")
+                        if 'HTTP 503' in str(e):
+                            _enqueue_error(response_queue, json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
                         response_queue.put(("__reconnecting__", "TTS_RECONNECTING"))
                         await asyncio.sleep(1.0)
                         continue
@@ -1414,6 +1420,8 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         
         except Exception as e:
             logger.error(f"Qwen实时TTS Worker错误: {e}")
+            if 'HTTP 503' in str(e):
+                _enqueue_error(response_queue, json.dumps({"code": "UPSTREAM_SERVER_BUSY"}))
             response_queue.put(("__ready__", False))
         finally:
             # 清理资源

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -534,6 +534,7 @@
         "AGENT_CU_AUTO_CLOSED": "Computer Use module not loaded, auto-disabled",
         "AGENT_CU_CAPABILITY_LOST": "Computer Use unavailable: $t(agent.precheck.{{reason_code}})",
         "TTS_CONNECTION_FAILED": "TTS service connection failed: {{msg}}",
+        "UPSTREAM_SERVER_BUSY": "Sorry, the upstream server is busy. Please try again later~",
         "TTS_RECONNECTING": "🔄 TTS service is reconnecting, please wait...",
         "TTS_WATERMARK_DETECTED": "⚠️ CogTTS audio watermark (beep) detected. To disable the watermark, go to the Zhipu console and configure it manually.",
         "TTS_CUSTOM_URL_NOT_CONFIGURED": "GPT-SoVITS API URL not configured. Please enable and configure custom TTS in API settings.",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -534,6 +534,7 @@
         "AGENT_CU_AUTO_CLOSED": "Computer Use モジュール未ロード、自動無効化されました",
         "AGENT_CU_CAPABILITY_LOST": "Computer Use が利用できません：$t(agent.precheck.{{reason_code}})",
         "TTS_CONNECTION_FAILED": "TTSサービス接続失敗: {{msg}}",
+        "UPSTREAM_SERVER_BUSY": "ごめんなさいにゃ、上流サーバーが混雑しています。しばらくしてからもう一度お試しください~",
         "TTS_RECONNECTING": "🔄 音声サービスが自動再接続中です。しばらくお待ちください...",
         "TTS_WATERMARK_DETECTED": "⚠️ CogTTSの音声ウォーターマーク（ビープ音）を検出しました。ウォーターマークを無効にするには、智譜コンソールで手動設定してください。",
         "TTS_CUSTOM_URL_NOT_CONFIGURED": "GPT-SoVITS API URLが設定されていません。API設定でカスタムTTSを有効にして設定してください。",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -534,6 +534,7 @@
         "AGENT_CU_AUTO_CLOSED": "Computer Use 모듈이 로드되지 않아 자동 비활성화되었습니다",
         "AGENT_CU_CAPABILITY_LOST": "Computer Use를 사용할 수 없습니다: $t(agent.precheck.{{reason_code}})",
         "TTS_CONNECTION_FAILED": "TTS 서비스 연결 실패: {{msg}}",
+        "UPSTREAM_SERVER_BUSY": "죄송해요냥, 상위 서버가 바쁩니다. 잠시 후 다시 시도해 주세요~",
         "TTS_RECONNECTING": "🔄 음성 서비스가 자동 재연결 중입니다. 잠시만 기다려주세요...",
         "TTS_WATERMARK_DETECTED": "⚠️ CogTTS 오디오 워터마크(비프음)가 감지되었습니다. 워터마크를 비활성화하려면 Zhipu 콘솔에서 수동으로 설정하세요.",
         "TTS_CUSTOM_URL_NOT_CONFIGURED": "GPT-SoVITS API URL이 설정되지 않았습니다. API 설정에서 커스텀 TTS를 활성화하고 설정하세요.",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -534,6 +534,7 @@
         "AGENT_CU_AUTO_CLOSED": "Модуль Computer Use не загружен, автоматически отключён",
         "AGENT_CU_CAPABILITY_LOST": "Computer Use недоступен: $t(agent.precheck.{{reason_code}})",
         "TTS_CONNECTION_FAILED": "Ошибка подключения к TTS-сервису: {{msg}}",
+        "UPSTREAM_SERVER_BUSY": "Извините, ня, сервер провайдера перегружен. Попробуйте позже~",
         "TTS_RECONNECTING": "🔄 Служба TTS автоматически переподключается, подождите...",
         "TTS_WATERMARK_DETECTED": "⚠️ Обнаружен водяной знак CogTTS (звуковой сигнал). Чтобы отключить водяной знак, настройте это вручную в консоли Zhipu.",
         "TTS_CUSTOM_URL_NOT_CONFIGURED": "URL GPT-SoVITS API не настроен. Включите и настройте пользовательский TTS в настройках API.",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -534,6 +534,7 @@
         "AGENT_CU_AUTO_CLOSED": "Computer Use 模块未加载，已自动关闭",
         "AGENT_CU_CAPABILITY_LOST": "Computer Use 不可用：$t(agent.precheck.{{reason_code}})",
         "TTS_CONNECTION_FAILED": "TTS服务连接失败: {{msg}}",
+        "UPSTREAM_SERVER_BUSY": "抱歉喵，上游运营商服务器繁忙，请稍后重试~",
         "TTS_RECONNECTING": "🔄 语音服务正在自动重连，请稍候...",
         "TTS_WATERMARK_DETECTED": "⚠️ 检测到智谱CogTTS音频水印（滴滴声），如需去除水印请前往智谱控制台手动配置。",
         "TTS_CUSTOM_URL_NOT_CONFIGURED": "未配置 GPT-SoVITS API URL，请先在 API 设置中启用并配置自定义 TTS",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -534,6 +534,7 @@
         "AGENT_CU_AUTO_CLOSED": "Computer Use 模組未載入，已自動關閉",
         "AGENT_CU_CAPABILITY_LOST": "Computer Use 不可用：$t(agent.precheck.{{reason_code}})",
         "TTS_CONNECTION_FAILED": "TTS服務連接失敗: {{msg}}",
+        "UPSTREAM_SERVER_BUSY": "抱歉喵，上游營運商伺服器繁忙，請稍後重試~",
         "TTS_RECONNECTING": "🔄 語音服務正在自動重連，請稍候...",
         "TTS_WATERMARK_DETECTED": "⚠️ 偵測到智譜CogTTS音訊浮水印（嗶嗶聲），如需去除浮水印請前往智譜控制台手動配置。",
         "TTS_CUSTOM_URL_NOT_CONFIGURED": "未配置 GPT-SoVITS API URL，請先在 API 設置中啟用並配置自訂 TTS",


### PR DESCRIPTION
## Summary

- WebSocket HTTP 503 连接拒绝错误（无论来自 TTS 还是语音会话 RealtimeClient）统一转化为 `UPSTREAM_SERVER_BUSY` 错误码，前端 Toast 显示为 **"抱歉喵，上游运营商服务器繁忙，请稍后重试~"**
- 替代原先直接暴露英文异常文本的 `CONNECTION_CLOSED_ABNORMAL` / `TTS_CONNECTION_FAILED`
- `tts.response.error` 事件中的 503（"too long without operation"）不受影响，保持原有行为

### 改动点

| 文件 | 改动 |
|------|------|
| `core.py` | `start_session` 错误分支新增 `HTTP 503` 匹配 → 发送 `UPSTREAM_SERVER_BUSY` |
| `core.py` | TTS 错误分类 `_known_codes` 新增 `UPSTREAM_SERVER_BUSY` |
| `tts_client.py` | StepFun/Qwen worker 初始连接 + 重连失败时检测 HTTP 503 并 enqueue 错误 |
| 6 个 locale 文件 | 新增 `UPSTREAM_SERVER_BUSY` 翻译（zh-CN/zh-TW/en/ja/ko/ru） |

## Test plan

- [ ] 模拟上游服务器返回 HTTP 503，验证前端 Toast 显示对应语言的"上游服务器繁忙"提示
- [ ] 验证 `tts.response.error`（"too long without operation"）仍走原有 `TTS_CONNECTION_FAILED` 路径，不受影响
- [ ] 验证其他错误码（401/429/WinError 等）的匹配逻辑不受影响

https://claude.ai/code/session_013vHWrvCDneMpBLjbhkSMBr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 添加了对上游服务器繁忙状态的检测和处理机制
  * 扩展了错误代码识别集以包含"上游服务器繁忙"错误类型
  * 在六种语言中添加了对应的错误提示信息，当上游服务器繁忙时提示用户稍后重试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->