### PR TITLE
fix: prevent greeting from racing with voice session

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2264,7 +2264,7 @@ class LLMSessionManager:
         _lang = normalize_language_code(self.user_language, format='short')
         from config.prompts_proactive import get_greeting_prompt, get_time_of_day_hint
         from utils.time_format import format_elapsed as _format_elapsed
-        from utils.holiday_cache import get_holiday_or_weekend_hint
+        from utils.holiday_cache import preview_holiday_or_weekend_hint, commit_holiday_or_weekend_hint
         template = get_greeting_prompt(gap_seconds, _lang)
         if not template:
             return
@@ -2294,12 +2294,13 @@ class LLMSessionManager:
             logger.warning("[%s] trigger_greeting: session is not text mode after start, aborting", self.lanlan_name)
             return
 
-        # 投递通道已就绪，构建 instruction（此时才消费节日预算）
+        # 投递通道已就绪，构建 instruction（节日预算仅 preview，不消费）
         elapsed = _format_elapsed(_lang, gap_seconds)
         time_hint = get_time_of_day_hint(_lang).format(master=self.master_name)
 
+        _holiday_token = None
         try:
-            holiday_hint_text = await get_holiday_or_weekend_hint(_lang, self.lanlan_name)
+            holiday_hint_text, _holiday_token = await preview_holiday_or_weekend_hint(_lang, self.lanlan_name)
         except Exception as e:
             logger.debug("[%s] trigger_greeting: holiday hint failed: %s", self.lanlan_name, e)
             holiday_hint_text = None
@@ -2327,6 +2328,9 @@ class LLMSessionManager:
                 self._tts_done_queued_for_turn = False
             delivered = await self.session.prompt_ephemeral(instruction)
             logger.info("[%s] trigger_greeting: delivered=%s", self.lanlan_name, delivered)
+            # 投递成功后才真正消费节日/周末预算
+            if delivered and _holiday_token is not None:
+                commit_holiday_or_weekend_hint(self.lanlan_name, _holiday_token)
 
     def enqueue_agent_callback(self, callback: dict) -> None:
         """Enqueue a structured agent task callback for LLM injection.

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2223,11 +2223,24 @@ class LLMSessionManager:
         finally:
             self._agent_delivery_in_progress = False
 
+    def _is_voice_session_active_or_starting(self) -> bool:
+        """语音 session 正在启动或已经活跃时返回 True，用于阻止 greeting 干扰语音流。"""
+        if self.is_starting_session and self.input_mode == 'audio':
+            return True
+        if self.is_active and self.input_mode == 'audio':
+            return True
+        return False
+
     async def trigger_greeting(self) -> None:
         """首次连接或切换角色时，根据距上次对话间隔触发主动搭话。
 
         流程：查询 memory_server 获取间隔 → 构建引导词 → 主动拉起 text session → 投递。
         """
+        # ── 守卫：语音 session 正在启动 / 已活跃时，跳过 greeting ──
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_greeting: voice session active/starting, skipping", self.lanlan_name)
+            return
+
         try:
             async with httpx.AsyncClient(timeout=2.0, proxy=None, trust_env=False) as client:
                 resp = await client.get(f"http://127.0.0.1:{self.memory_server_port}/last_conversation_gap/{self.lanlan_name}")
@@ -2241,6 +2254,11 @@ class LLMSessionManager:
 
         if gap_seconds < 900:  # < 15分钟，不触发
             logger.debug("[%s] trigger_greeting: gap %.0fs < 15min, skipping", self.lanlan_name, gap_seconds)
+            return
+
+        # ── await 归来后再检查一次：memory 查询期间用户可能已点了麦克风 ──
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_greeting: voice session appeared during gap query, skipping", self.lanlan_name)
             return
 
         _lang = normalize_language_code(self.user_language, format='short')
@@ -2257,6 +2275,10 @@ class LLMSessionManager:
             pass
         else:
             # 没有 session 或不是 text session → 主动拉起
+            # ── 拉起前再次检查：避免与即将到来的语音 session 竞争 ──
+            if self._is_voice_session_active_or_starting():
+                logger.info("[%s] trigger_greeting: voice session appeared before text session auto-start, skipping", self.lanlan_name)
+                return
             ws = self.websocket
             if not ws or not hasattr(ws, 'client_state') or ws.client_state != ws.client_state.CONNECTED:
                 logger.warning("[%s] trigger_greeting: no connected websocket, aborting", self.lanlan_name)
@@ -2290,7 +2312,16 @@ class LLMSessionManager:
         print(f"[trigger_greeting] instruction:\n{instruction}")
         logger.info("[%s] trigger_greeting: gap=%.0fs elapsed=%s, delivering", self.lanlan_name, gap_seconds, elapsed)
 
+        # ── 投递前最终检查：构建 instruction 期间（holiday hint 等 await）语音可能已接管 ──
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_greeting: voice session took over before delivery, skipping", self.lanlan_name)
+            return
+
         async with self._proactive_write_lock:
+            # 持锁后仍需检查：_proactive_write_lock 等待期间语音可能已启动
+            if self._is_voice_session_active_or_starting():
+                logger.info("[%s] trigger_greeting: voice session took over while waiting for write lock, skipping", self.lanlan_name)
+                return
             async with self.lock:
                 self.current_speech_id = str(uuid4())
                 self._tts_done_queued_for_turn = False

--- a/utils/holiday_cache.py
+++ b/utils/holiday_cache.py
@@ -603,19 +603,27 @@ async def get_holiday_or_weekend_hint(lang: str, character: str) -> str | None:
 # ── preview / commit (deferred consumption) ────────────────────────
 
 def _has_holiday_budget(character: str, proximity: HolidayProximity) -> bool:
-    """Check whether budget is available WITHOUT consuming it."""
-    period = proximity.period
+    """Check whether budget is available WITHOUT consuming or mutating state."""
+    rec = _consumption_data.get(character)
+    if rec is None:
+        return True  # no record → full budget
+    period_key = proximity.period.start.isoformat()
+    period_rec = rec.get("periods", {}).get(period_key)
+    if period_rec is None:
+        return True  # not initialised → full budget
+
     if not proximity.is_today:
-        return _get_period_bucket(character, period, "period", _BUDGET_PERIOD) > 0
-    today = date.today()
-    if period.is_nominal_day(today):
-        return _get_period_bucket(character, period, "holiday", _BUDGET_HOLIDAY) > 0
-    return _get_period_bucket(character, period, "period", _BUDGET_PERIOD) > 0
+        return period_rec.get("period", _BUDGET_PERIOD) > 0
+    if proximity.period.is_nominal_day(date.today()):
+        return period_rec.get("holiday", _BUDGET_HOLIDAY) > 0
+    return period_rec.get("period", _BUDGET_PERIOD) > 0
 
 
 def _has_weekend_budget(character: str) -> bool:
-    """Check whether weekend budget is available WITHOUT consuming it."""
-    rec = _get_char_record(character)
+    """Check whether weekend budget is available WITHOUT consuming or mutating state."""
+    rec = _consumption_data.get(character)
+    if rec is None:
+        return True  # no record → full budget
     today_iso = date.today().isoformat()
     if rec.get("weekend_date") != today_iso:
         return True  # new day → full budget

--- a/utils/holiday_cache.py
+++ b/utils/holiday_cache.py
@@ -567,6 +567,10 @@ async def get_holiday_or_weekend_hint(lang: str, character: str) -> str | None:
 
     Returns ``None`` if budget exhausted or no event — caller should
     produce **no** placeholder text.
+
+    This is a convenience wrapper that **immediately** consumes the budget.
+    For deferred consumption (e.g. greeting with abort checkpoints), use
+    :func:`preview_holiday_or_weekend_hint` + :func:`commit_holiday_or_weekend_hint`.
     """
     proximity = await get_nearest_holiday(lang)
 
@@ -594,6 +598,88 @@ async def get_holiday_or_weekend_hint(lang: str, character: str) -> str | None:
         return _WEEKEND_HINT.get(lang, _WEEKEND_HINT.get('en', ''))
 
     return None
+
+
+# ── preview / commit (deferred consumption) ────────────────────────
+
+def _has_holiday_budget(character: str, proximity: HolidayProximity) -> bool:
+    """Check whether budget is available WITHOUT consuming it."""
+    period = proximity.period
+    if not proximity.is_today:
+        return _get_period_bucket(character, period, "period", _BUDGET_PERIOD) > 0
+    today = date.today()
+    if period.is_nominal_day(today):
+        return _get_period_bucket(character, period, "holiday", _BUDGET_HOLIDAY) > 0
+    return _get_period_bucket(character, period, "period", _BUDGET_PERIOD) > 0
+
+
+def _has_weekend_budget(character: str) -> bool:
+    """Check whether weekend budget is available WITHOUT consuming it."""
+    rec = _get_char_record(character)
+    today_iso = date.today().isoformat()
+    if rec.get("weekend_date") != today_iso:
+        return True  # new day → full budget
+    return rec.get("weekend", 0) > 0
+
+
+def _build_holiday_hint_text(lang: str, proximity: HolidayProximity) -> str:
+    """Build hint text from a proximity object (no side effects)."""
+    name = proximity.period.display_name
+    lang_key = lang if lang in _HOLIDAY_HINT_TODAY else 'en'
+    if proximity.is_today:
+        tpl = _HOLIDAY_HINT_TODAY.get(lang_key, _HOLIDAY_HINT_TODAY['en'])
+        return tpl.format(name=name)
+    elif proximity.days_away <= 3:
+        tpl = _HOLIDAY_HINT_SOON.get(lang_key, _HOLIDAY_HINT_SOON['en'])
+        return tpl.format(name=name, days=proximity.days_away)
+    else:
+        tpl = _HOLIDAY_HINT_WEEK.get(lang_key, _HOLIDAY_HINT_WEEK['en'])
+        return tpl.format(name=name)
+
+
+# Token: ("holiday", HolidayProximity) | ("weekend",)
+
+async def preview_holiday_or_weekend_hint(
+    lang: str, character: str,
+) -> tuple[str | None, tuple | None]:
+    """Get hint text WITHOUT consuming budget.
+
+    Returns ``(hint_text, token)``.  Pass *token* to
+    :func:`commit_holiday_or_weekend_hint` after successful delivery.
+    ``(None, None)`` when no event or budget exhausted.
+    """
+    proximity = await get_nearest_holiday(lang)
+
+    if proximity is not None:
+        if not _has_holiday_budget(character, proximity):
+            return None, None
+        return _build_holiday_hint_text(lang, proximity), ("holiday", proximity)
+
+    # No holiday → check weekend
+    if datetime.now().weekday() >= 5:
+        if not _has_weekend_budget(character):
+            return None, None
+        text = _WEEKEND_HINT.get(lang, _WEEKEND_HINT.get('en', ''))
+        return text, ("weekend",)
+
+    return None, None
+
+
+def commit_holiday_or_weekend_hint(character: str, token: tuple) -> bool:
+    """Consume budget for a previously previewed hint.
+
+    Returns ``True`` if the budget was successfully decremented.
+    Should be called only once per preview, after the hint was actually
+    delivered to the user.
+    """
+    if not token:
+        return False
+    kind = token[0]
+    if kind == "holiday":
+        return try_consume_holiday(character, token[1])
+    if kind == "weekend":
+        return try_consume_weekend(character)
+    return False
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

- **Greeting 竞争修复**：`trigger_greeting()` 在每个 `await` 边界增加 `_is_voice_session_active_or_starting()` 守卫（共 5 处），语音 session 正在启动或已活跃时立即放弃 greeting，不再自动拉起 text session 与语音流竞争
- **节日预算延迟消费**：新增 `preview_holiday_or_weekend_hint()` / `commit_holiday_or_weekend_hint()` 拆分查询与消费，`trigger_greeting()` 仅在 `prompt_ephemeral()` 投递成功后才真正扣减预算，避免因 voice guard 中途放弃而白扣节日/周末 hint 次数

## 背景

用户报告首次语音对话没声音。日志显示首次 audio session 在连接成功后 ~1 秒被前端终止（`by_server=False`），0 条聊天记录。`greeting_check` 在 WebSocket 连接时异步触发，可能在用户点击麦克风前已自动拉起 text session，与随后的 audio session 产生竞争。

## 改动文件

| 文件 | 改动 |
|------|------|
| `main_logic/core.py` | 新增 `_is_voice_session_active_or_starting()` 方法；`trigger_greeting()` 5 个 await 边界增加 voice guard；holiday hint 改用 preview/commit 模式 |
| `utils/holiday_cache.py` | 新增 `preview_holiday_or_weekend_hint()`、`commit_holiday_or_weekend_hint()` 及内部辅助函数；原 `get_holiday_or_weekend_hint()` 保持不变 |

## Test plan

- [ ] 启动应用，等待 greeting 触发（gap > 15min），确认 text greeting 正常投递且节日 hint 正常显示
- [ ] 连接后立即点击麦克风启动语音，确认 greeting 被跳过（日志应显示 `voice session active/starting, skipping`）
- [ ] 语音会话中确认 greeting 不会干扰（无异常 end_session）
- [ ] 节日/周末期间测试：greeting 被 voice guard 放弃时，确认预算未被消费（重启后再次触发应仍有次数）

https://claude.ai/code/session_015MjM6i9DnT5PAUL4d4Jwks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了问候流程：问候在音频会话启动或自动文本会话前会优先跳过，避免干扰音频模式的启动与激活。

* **Chores**
  * 引入“预览 + 确认”提示流程：假日/周末提示在成功交付后才计入预算，减少误消耗；并改进了相关日志以便追踪跳过与预算提交行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->