### PR TITLE
修复旧版本升级后声音克隆页面误报"没有可用API"的问题

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -551,25 +551,29 @@ async def get_core_config_api():
             # 创建空的配置对象用于返回默认值
             core_cfg = {}
         
+        # 旧版本 core_config.json 可能只有 coreApiKey 而没有各 assistApiKey* 字段，
+        # 需要与 ConfigManager.get_core_config() 保持一致的回退逻辑，
+        # 以免升级后声音克隆页面误报"没有可用API"。
+        fallback_key = api_key or ''
         return {
             "api_key": api_key,
             "coreApi": core_cfg.get('coreApi', 'qwen'),
             "assistApi": core_cfg.get('assistApi', 'qwen'),
-            "assistApiKeyQwen": core_cfg.get('assistApiKeyQwen', ''),
+            "assistApiKeyQwen": core_cfg.get('assistApiKeyQwen', '') or fallback_key,
             "assistApiKeyQwenIntl": core_cfg.get('assistApiKeyQwenIntl', ''),
-            "assistApiKeyOpenai": core_cfg.get('assistApiKeyOpenai', ''),
-            "assistApiKeyGlm": core_cfg.get('assistApiKeyGlm', ''),
-            "assistApiKeyStep": core_cfg.get('assistApiKeyStep', ''),
-            "assistApiKeySilicon": core_cfg.get('assistApiKeySilicon', ''),
-            "assistApiKeyGemini": core_cfg.get('assistApiKeyGemini', ''),
-            "assistApiKeyKimi": core_cfg.get('assistApiKeyKimi', ''),
-            "assistApiKeyDeepseek": core_cfg.get('assistApiKeyDeepseek', ''),
-            "assistApiKeyDoubao": core_cfg.get('assistApiKeyDoubao', ''),
+            "assistApiKeyOpenai": core_cfg.get('assistApiKeyOpenai', '') or fallback_key,
+            "assistApiKeyGlm": core_cfg.get('assistApiKeyGlm', '') or fallback_key,
+            "assistApiKeyStep": core_cfg.get('assistApiKeyStep', '') or fallback_key,
+            "assistApiKeySilicon": core_cfg.get('assistApiKeySilicon', '') or fallback_key,
+            "assistApiKeyGemini": core_cfg.get('assistApiKeyGemini', '') or fallback_key,
+            "assistApiKeyKimi": core_cfg.get('assistApiKeyKimi', '') or fallback_key,
+            "assistApiKeyDeepseek": core_cfg.get('assistApiKeyDeepseek', '') or fallback_key,
+            "assistApiKeyDoubao": core_cfg.get('assistApiKeyDoubao', '') or fallback_key,
             "assistApiKeyMinimax": core_cfg.get('assistApiKeyMinimax', ''),
             "assistApiKeyMinimaxIntl": core_cfg.get('assistApiKeyMinimaxIntl', ''),
-            "assistApiKeyGrok": core_cfg.get('assistApiKeyGrok', ''),
-            "assistApiKeyClaude": core_cfg.get('assistApiKeyClaude', ''),
-            "assistApiKeyOpenrouter": core_cfg.get('assistApiKeyOpenrouter', ''),
+            "assistApiKeyGrok": core_cfg.get('assistApiKeyGrok', '') or fallback_key,
+            "assistApiKeyClaude": core_cfg.get('assistApiKeyClaude', '') or fallback_key,
+            "assistApiKeyOpenrouter": core_cfg.get('assistApiKeyOpenrouter', '') or fallback_key,
             "mcpToken": core_cfg.get('mcpToken', ''),
             "openclawUrl": core_cfg.get('openclawUrl'),
             "openclawTimeout": core_cfg.get('openclawTimeout'),


### PR DESCRIPTION
旧版 core_config.json 只保存了 coreApiKey，没有各 assistApiKey* 字段，GET /api/config/core_api 端点缺少回退逻辑导致前端检测到空值。现已对齐 ConfigManager.get_core_config() 的回退行为，当 assistApiKey* 为空时自动回退到 coreApiKey

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了多个AI助手API密钥的配置处理机制，当特定API密钥为空时，系统现在会使用备用密钥确保正常运行。

* **改进**
  * 提升了API密钥管理的灵活性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->