### PR TITLE
fix: prevent duplicate message sends from rapid Enter key presses

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -97,20 +97,23 @@ export default function App({
     const text = draft.trim();
     if (!text && composerAttachments.length === 0) return;
     submittingRef.current = true;
-    const now = new Date();
-    const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
-      .map(n => String(n).padStart(2, '0')).join(':');
-    if (text) {
-      setPendingDrafts(prev => [...prev, {
-        id: `pending-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-        text,
-        time,
-        lastMsgId: messages.length > 0 ? messages[messages.length - 1].id : null,
-      }]);
+    try {
+      const now = new Date();
+      const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
+        .map(n => String(n).padStart(2, '0')).join(':');
+      if (text) {
+        setPendingDrafts(prev => [...prev, {
+          id: `pending-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+          text,
+          time,
+          lastMsgId: messages.length > 0 ? messages[messages.length - 1].id : null,
+        }]);
+      }
+      onComposerSubmit?.({ text });
+      setDraft('');
+    } finally {
+      requestAnimationFrame(() => { submittingRef.current = false; });
     }
-    onComposerSubmit?.({ text });
-    setDraft('');
-    requestAnimationFrame(() => { submittingRef.current = false; });
   }
 
   return (

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import MessageList from './MessageList';
 import { i18n } from './i18n';
 import {
@@ -53,6 +53,7 @@ export default function App({
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
   const [pendingDrafts, setPendingDrafts] = useState<Array<{ id: string; text: string; time: string; lastMsgId: string | null }>>([]);
+  const submittingRef = useRef(false);
   const canSubmit = draft.trim().length > 0 || composerAttachments.length > 0;
   const resolvedImportImageAriaLabel = importImageButtonAriaLabel || importImageButtonLabel;
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
@@ -92,8 +93,10 @@ export default function App({
   }, [messages, pendingDrafts, lastUserAuthor]);
 
   function submitDraft() {
+    if (submittingRef.current) return;
     const text = draft.trim();
     if (!text && composerAttachments.length === 0) return;
+    submittingRef.current = true;
     const now = new Date();
     const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
       .map(n => String(n).padStart(2, '0')).join(':');
@@ -107,6 +110,7 @@ export default function App({
     }
     onComposerSubmit?.({ text });
     setDraft('');
+    requestAnimationFrame(() => { submittingRef.current = false; });
   }
 
   return (


### PR DESCRIPTION
## Summary
- React `submitDraft()` 中 `setDraft('')` 是异步的（下次渲染才生效），快速连按 Enter 会在 `draft` 清空前多次触发提交，导致同一条用户消息被发送 2-3 次
- 后端 `user_input_cache` 把多次到达的相同文本通过 `+=` 拼接成一条记录，AI 也看到多条重复的 HumanMessage
- 用 `useRef` 做同步互斥锁（ref 立即生效，不等渲染），`requestAnimationFrame` 下一帧释放

## Test plan
- [ ] 在聊天框快速连按 Enter，确认只发送一条消息
- [ ] API 请求慢/失败时连按 Enter，确认不会重复
- [ ] 切换猫娘期间发送消息，确认不会重复
- [ ] 正常聊天不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化了消息提交流程，添加了提交防护以避免快速连续操作导致的重复提交，确保乐观更新、回调与清空草稿的执行更可靠；即使发生错误也能正确恢复提交状态，提升稳定性与用户体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->