### PR TITLE
fix(meme): SSL fallback for meme proxy + require gptsovitsEnabled for GSV routing

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -931,8 +931,15 @@ class LLMSessionManager:
     def _has_custom_tts(self) -> bool:
         """判断当前会话是否使用自定义 TTS（克隆音色或自定义 TTS URL）。"""
         core_config = self._config_manager.get_core_config()
-        return (bool(self.voice_id) and not self._is_free_preset_voice) or bool(
-            core_config.get('ENABLE_CUSTOM_API') and core_config.get('TTS_MODEL_URL')
+        # 克隆音色始终走 custom 路径；
+        # ENABLE_CUSTOM_API + TTS_MODEL_URL 仅在 gptsovitsEnabled 开启时才视为 custom，
+        # 否则 caller 会用 tts_custom credentials 启动 default worker，导致鉴权失败。
+        if bool(self.voice_id) and not self._is_free_preset_voice:
+            return True
+        return bool(
+            core_config.get('ENABLE_CUSTOM_API')
+            and core_config.get('TTS_MODEL_URL')
+            and core_config.get('gptsovitsEnabled')
         )
 
     def _start_tts_thread(self):

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -2677,9 +2677,14 @@ def get_tts_worker(core_api_type='qwen', has_custom_voice=False, voice_id=''):
         tts_config = cm.get_model_api_config('tts_custom')
         if tts_config.get('is_custom'):
             base_url = tts_config.get('base_url') or ''
-            if base_url.startswith('http://') or base_url.startswith('https://'):
+            # GPT-SoVITS / local CosyVoice 需要用户显式启用 gptsovitsEnabled 开关，
+            # 仅 enableCustomApi + http URL 不应自动路由到 GPT-SoVITS。
+            core_cfg = cm.get_core_config()
+            gsv_enabled = core_cfg.get('gptsovitsEnabled', False)
+            if gsv_enabled and (base_url.startswith('http://') or base_url.startswith('https://')):
                 return gptsovits_tts_worker, None, 'gptsovits'
-            return local_cosyvoice_worker, None, 'local_cosyvoice'
+            if gsv_enabled and (base_url.startswith('ws://') or base_url.startswith('wss://')):
+                return local_cosyvoice_worker, None, 'local_cosyvoice'
     except Exception as e:
         logger.warning(f'TTS调度器检查报告:{e}')
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1888,8 +1888,8 @@ async def proxy_meme_image(url: str):
                 ctx = ssl.create_default_context()
                 try:
                     ctx.set_ciphers('DEFAULT@SECLEVEL=1')
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("[Meme Proxy] set_ciphers SECLEVEL=1 不可用，使用默认密码套件: %s", e)
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
                 return httpx.AsyncClient(timeout=15.0, follow_redirects=False, verify=ctx)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response
 from openai import APIConnectionError, InternalServerError, RateLimitError
 from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm
+import ssl
 import httpx
 from cachetools import TTLCache
 
@@ -1876,8 +1877,25 @@ async def proxy_meme_image(url: str):
 
         # 使用流式下载以严格控制资源大小，防止内存溢出或大文件攻击
         MAX_IMAGE_SIZE = 10 * 1024 * 1024  # 10MB 限制
-        
-        async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+
+        # 已知 SSL 证书有问题的 CDN 域名（如七牛 CDN hostname mismatch），
+        # 对这些域名首次请求即使用宽松 SSL，避免白白浪费一次超时。
+        _SSL_RELAXED_HOSTS = {'qn.doutub.com'}
+        need_relaxed_ssl = hostname in _SSL_RELAXED_HOSTS
+
+        def _make_client(relaxed: bool = False) -> httpx.AsyncClient:
+            if relaxed:
+                ctx = ssl.create_default_context()
+                try:
+                    ctx.set_ciphers('DEFAULT@SECLEVEL=1')
+                except Exception:
+                    pass
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+                return httpx.AsyncClient(timeout=15.0, follow_redirects=False, verify=ctx)
+            return httpx.AsyncClient(timeout=15.0, follow_redirects=False)
+
+        async with _make_client(relaxed=need_relaxed_ssl) as client:
             current_url = decoded_url
             for _ in range(4):  # 最多跟随 3 次重定向 (4次请求)
                 async with client.stream("GET", current_url, headers=headers) as resp:
@@ -1949,6 +1967,35 @@ async def proxy_meme_image(url: str):
 
     except httpx.TimeoutException:
         return JSONResponse(content={"success": False, "error": "请求超时"}, status_code=504)
+    except (ssl.SSLError, httpx.ConnectError) as e:
+        # SSL 握手失败：对白名单内的表情包域名降级重试（宽松 SSL）
+        is_ssl = isinstance(e, ssl.SSLError) or 'SSL' in str(e) or 'certificate' in str(e).lower()
+        if is_ssl and not need_relaxed_ssl:
+            logger.warning(f"[Meme Proxy] SSL 失败，降级重试: {hostname} ({e})")
+            try:
+                async with _make_client(relaxed=True) as fallback_client:
+                    async with fallback_client.stream("GET", decoded_url, headers=headers) as resp:
+                        resp.raise_for_status()
+                        raw_ct = resp.headers.get('Content-Type', '').lower()
+                        ct = raw_ct.split(';', 1)[0].strip()
+                        allowed_ct = {'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif', 'image/bmp'}
+                        if ct not in allowed_ct:
+                            return JSONResponse(content={"success": False, "error": "格式不支持"}, status_code=403)
+                        body = bytearray()
+                        async for chunk in resp.aiter_bytes():
+                            body.extend(chunk)
+                            if len(body) > MAX_IMAGE_SIZE:
+                                return JSONResponse(content={"success": False, "error": "资源超过大小限制"}, status_code=413)
+                        MEME_PROXY_CACHE[cache_key] = {'body': bytes(body), 'content_type': ct}
+                        return Response(
+                            content=bytes(body), media_type=ct,
+                            headers={'Cache-Control': 'public, max-age=86400', 'X-Cache': 'MISS-SSL-FALLBACK', 'X-Content-Type-Options': 'nosniff'}
+                        )
+            except Exception as fallback_e:
+                logger.error(f"[Meme Proxy] SSL 降级重试也失败: {fallback_e}")
+                return JSONResponse(content={"success": False, "error": str(fallback_e)}, status_code=500)
+        logger.error(f"[Meme Proxy] 代理失败: {str(e)}")
+        return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)
     except Exception as e:
         logger.error(f"[Meme Proxy] 代理失败: {str(e)}")
         return JSONResponse(content={"success": False, "error": str(e)}, status_code=500)

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1258,7 +1258,7 @@ class ConfigManager:
         tts_config = self.get_model_api_config('tts_custom')
         base_url = tts_config.get('base_url', '')
         is_local_tts = tts_config.get('is_custom') and base_url.startswith(('ws://', 'wss://'))
-        
+
         if is_local_tts:
             api_key = '__LOCAL_TTS__'
         else:

--- a/utils/custom_tts_adapter.py
+++ b/utils/custom_tts_adapter.py
@@ -27,6 +27,7 @@ def check_custom_tts_voice_allowed(
     if not suffix:
         return False
 
-    tts_config = get_model_api_config('tts_custom')
-    base_url = tts_config.get('base_url') or ''
-    return bool(tts_config.get('is_custom') and base_url.startswith(('http://', 'https://')))
+    # gsv: 前缀的 voice_id 仅在用户显式启用 GPT-SoVITS 开关时有效
+    from utils.config_manager import get_config_manager
+    core_cfg = get_config_manager().get_core_config()
+    return bool(core_cfg.get('gptsovitsEnabled', False))

--- a/utils/custom_tts_adapter.py
+++ b/utils/custom_tts_adapter.py
@@ -27,7 +27,12 @@ def check_custom_tts_voice_allowed(
     if not suffix:
         return False
 
-    # gsv: 前缀的 voice_id 仅在用户显式启用 GPT-SoVITS 开关时有效
+    # gsv: 前缀的 voice_id 仅在 GPT-SoVITS 开关启用 且 endpoint 为 HTTP 时有效，
+    # ws:// (local CosyVoice) 用 `:` 做速度分隔符，不能接受 gsv: 前缀。
     from utils.config_manager import get_config_manager
-    core_cfg = get_config_manager().get_core_config()
-    return bool(core_cfg.get('gptsovitsEnabled', False))
+    cm = get_config_manager()
+    if not cm.get_core_config().get('gptsovitsEnabled', False):
+        return False
+    tts_config = get_model_api_config('tts_custom')
+    base_url = tts_config.get('base_url') or ''
+    return bool(tts_config.get('is_custom') and base_url.startswith(('http://', 'https://')))


### PR DESCRIPTION
## Summary
- **Meme proxy SSL fallback**: `qn.doutub.com`（斗图吧七牛 CDN）SSL 证书 hostname mismatch 导致所有 doutub 表情包图裂。对已知问题域名首次请求即用宽松 SSL；其他域名 SSL 失败时自动降级重试。成功后正常写入 TTLCache，后续命中缓存不再重复请求。
- **GSV routing guard**: GPT-SoVITS / local CosyVoice TTS worker 现在需要用户显式启用 `gptsovitsEnabled` 开关，仅有 `enableCustomApi` + http URL 不再自动路由到 GPT-SoVITS，避免误触。

## Test plan
- [ ] 启动应用，触发主动搭话带表情包（meme 通道），确认 doutub 来源的图片能正常加载不再报 SSL 错误
- [ ] 确认 imgflip 来源的表情包仍正常（未受影响）
- [ ] 未开启 `gptsovitsEnabled` 时，自定义 TTS 不走 GPT-SoVITS worker
- [ ] 开启 `gptsovitsEnabled` 后，http:// base_url 正常路由到 GPT-SoVITS，ws:// 路由到 local CosyVoice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进图片代理的 SSL 错误处理：对特定主机使用放宽的 TLS 验证并在失败时尝试回退重试，同时保留格式/大小校验与缓存与错误响应逻辑。  
* **改进**
  * 优化自定义 TTS 路由与授权：基于核心配置开关有条件选择本地或远程语音工作器，并以该开关决定某类自定义语音的可用性。  
* **其它**
  * 少量代码清理，不影响对外行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->