### PR TITLE
fix(voice): decouple prime_context from create_response to fix 1007 error

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1117,18 +1117,17 @@ class OmniRealtimeClient:
         """
         if not text or not text.strip():
             logger.info("prime_context: skipping empty content")
-            if self.on_response_done:
-                await self.on_response_done()
             return
 
         if self._is_gemini:
+            # Gemini Live API 没有 session.update 机制，只能通过
+            # send_client_content 注入上下文（会创建 user turn）。
+            # on_response_done 由 _handle_messages_gemini 自然触发。
             await self._create_response_gemini(text)
             return
 
         await self.update_session({"instructions": self.instructions + '\n' + text})
         logger.info("prime_context: updated session instructions")
-        if self.on_response_done:
-            await self.on_response_done()
 
     async def create_response(self, instructions: str, skipped: bool = False) -> None:
         """Inject a persistent user message and trigger an LLM response.
@@ -1149,20 +1148,20 @@ class OmniRealtimeClient:
         ``prompt_ephemeral()`` (fire-and-forget audio nudge) for the other
         two injection channels.
         """
-        if skipped:
-            self._skip_until_next_response = True
-
         # Gemini 使用 send_client_content 发送文本内容
         if self._is_gemini:
+            if skipped:
+                self._skip_until_next_response = True
             await self._create_response_gemini(instructions)
             return
 
         # 跳过空内容的发送，避免触发 API 错误
         if not instructions or not instructions.strip():
             logger.info("Skipping empty content in create_response")
-            if self.on_response_done:
-                await self.on_response_done()
             return
+
+        if skipped:
+            self._skip_until_next_response = True
 
         # 通过 conversation.item.create 添加用户消息，再触发响应
         item_event = {
@@ -1189,13 +1188,9 @@ class OmniRealtimeClient:
             logger.warning("Gemini session not available for create_response")
             return
         
-        # 🔧 修复：跳过空内容的发送，避免预热时污染 Gemini 对话历史
-        # 预热时 instructions 为空字符串，发送空 turn 会导致首轮对话被吞掉
+        # 跳过空内容的发送，避免预热时污染 Gemini 对话历史
         if not instructions or not instructions.strip():
             logger.info("Gemini: skipping empty content (warmup or empty message)")
-            # 直接触发 response_done 回调，让预热逻辑正常完成
-            if self.on_response_done:
-                await self.on_response_done()
             return
         
         try:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1124,8 +1124,9 @@ class OmniRealtimeClient:
         Behaviour varies by provider:
           - **OpenAI**: ``conversation.item.create(role=user)`` +
             ``response.create``
-          - **Qwen**: ``conversation.item.create(role=user)`` +
-            ``response.create`` (also updates session instructions)
+          - **Qwen**: appends to session instructions only (Qwen Realtime
+            不支持 ``conversation.item.create``，且无 user 消息时
+            ``response.create`` 会触发 1007 错误)
           - **Gemini**: ``send_client_content(role=user)``
 
         See ``prime_context()`` (session-start priming) and
@@ -1148,12 +1149,17 @@ class OmniRealtimeClient:
             return
 
         if "qwen" in self._model_lower:
-            # 同时更新 session instructions 以保留上下文
+            # Qwen: 只更新 session instructions 注入上下文，不发送 response.create
+            # DashScope API 要求 response.create 前必须存在 user 消息，
+            # 但预热阶段尚无用户对话，发送 response.create 会导致 1007 错误：
+            # "The input messages do not contain elements with the role of user"
             await self.update_session({"instructions": self.instructions + '\n' + instructions})
+            logger.info("Qwen: updated session instructions (skipped response.create)")
+            if self.on_response_done:
+                await self.on_response_done()
+            return
 
-        # 通过 conversation.item.create 添加用户消息，确保 response.create 前存在 user role 消息
-        # 修复：DashScope (Qwen) API 要求 response.create 前必须存在 user 消息，
-        # 否则返回 1007 "The input messages do not contain elements with the role of user"
+        # 其他提供商：通过 conversation.item.create 添加用户消息，再触发响应
         item_event = {
             "type": "conversation.item.create",
             "item": {

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1084,17 +1084,17 @@ class OmniRealtimeClient:
     # Three distinct channels mirror the OmniOfflineClient interface:
     #
     #   prime_context(text, skipped)
-    #       Session-start context priming.  Delegates to create_response()
-    #       because Realtime APIs have no separate "append to system
-    #       prompt" mechanism.
+    #       Session-start context priming.  通过 session.update 追加到
+    #       系统指令，不创建用户消息，不触发模型响应。
+    #       与 OmniOfflineClient.prime_context 语义一致。
     #       Typical caller: core._perform_final_swap_sequence()
     #
     #   create_response(text, skipped)
     #       Mid-conversation persistent message + trigger LLM response.
+    #       会创建 user 角色消息并触发 response.create。
     #       Behaviour varies by provider:
-    #         OpenAI  → conversation.item.create(role=user) + response.create
-    #         Qwen    → update_session(instructions += text) + response.create
-    #         Gemini  → send_client_content(role=user)
+    #         OpenAI / GLM / Step → conversation.item.create(role=user) + response.create
+    #         Gemini              → send_client_content(role=user)
     #
     #   prompt_ephemeral(instruction, *, language)
     #       Fire-and-forget audio nudge.  Injects a short WAV clip via
@@ -1104,29 +1104,45 @@ class OmniRealtimeClient:
     # ------------------------------------------------------------------
 
     async def prime_context(self, text: str, skipped: bool = False) -> None:
-        """Append context to the session at startup (delegates to create_response).
+        """Append context to session instructions at startup.
 
-        Realtime APIs lack a dedicated "append to system prompt" mechanism,
-        so this simply delegates to ``create_response()``.  Semantically
-        identical to the OmniOfflineClient counterpart — called only at
-        session start during hot-swap to inject incremental conversation
-        cache and task summaries.
+        与 OmniOfflineClient.prime_context 语义一致：仅追加到系统指令，
+        不创建用户消息，不触发模型响应。热切换完成后用户开口说话时，
+        模型自然会基于更新后的 instructions 进行回复。
 
         Args:
             text: Context to inject (incremental cache + summary/ready).
-            skipped: If True, the next response will be silently discarded.
+            skipped: Accepted for interface compatibility; not used here
+                     since no response is triggered.
         """
-        await self.create_response(text, skipped=skipped)
+        if not text or not text.strip():
+            logger.info("prime_context: skipping empty content")
+            if self.on_response_done:
+                await self.on_response_done()
+            return
+
+        if self._is_gemini:
+            await self._create_response_gemini(text)
+            return
+
+        await self.update_session({"instructions": self.instructions + '\n' + text})
+        logger.info("prime_context: updated session instructions")
+        if self.on_response_done:
+            await self.on_response_done()
 
     async def create_response(self, instructions: str, skipped: bool = False) -> None:
-        """Inject a persistent message and trigger an LLM response.
+        """Inject a persistent user message and trigger an LLM response.
+
+        与 ``prime_context`` (追加到系统指令) 不同，此方法会创建一条
+        user 角色的会话消息并触发模型响应。适用于需要模型立即回复的
+        mid-conversation 场景。
+
+        注意：需要会话中已有 user 消息或所用 API 支持
+        ``conversation.item.create``，否则可能触发 1007 错误。
 
         Behaviour varies by provider:
-          - **OpenAI**: ``conversation.item.create(role=user)`` +
-            ``response.create``
-          - **Qwen**: appends to session instructions only (Qwen Realtime
-            不支持 ``conversation.item.create``，且无 user 消息时
-            ``response.create`` 会触发 1007 错误)
+          - **OpenAI / GLM / Step**: ``conversation.item.create(role=user)``
+            + ``response.create``
           - **Gemini**: ``send_client_content(role=user)``
 
         See ``prime_context()`` (session-start priming) and
@@ -1148,18 +1164,7 @@ class OmniRealtimeClient:
                 await self.on_response_done()
             return
 
-        if "qwen" in self._model_lower:
-            # Qwen: 只更新 session instructions 注入上下文，不发送 response.create
-            # DashScope API 要求 response.create 前必须存在 user 消息，
-            # 但预热阶段尚无用户对话，发送 response.create 会导致 1007 错误：
-            # "The input messages do not contain elements with the role of user"
-            await self.update_session({"instructions": self.instructions + '\n' + instructions})
-            logger.info("Qwen: updated session instructions (skipped response.create)")
-            if self.on_response_done:
-                await self.on_response_done()
-            return
-
-        # 其他提供商：通过 conversation.item.create 添加用户消息，再触发响应
+        # 通过 conversation.item.create 添加用户消息，再触发响应
         item_event = {
             "type": "conversation.item.create",
             "item": {

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1104,16 +1104,19 @@ class OmniRealtimeClient:
     # ------------------------------------------------------------------
 
     async def prime_context(self, text: str, skipped: bool = False) -> None:
-        """Append context to session instructions at startup.
+        """Inject context during hot-swap.
 
-        热切换时注入增量上下文。行为取决于 skipped 参数：
+        行为取决于 skipped 参数和提供商：
 
-        - ``skipped=True``：仅追加到系统指令，不触发模型响应。
-          用户下次开口时模型自然基于更新后的 instructions 回复。
-        - ``skipped=False``：追加到系统指令后，额外触发一次模型响应
-          （用于任务结果主动汇报）。对于支持 conversation.item.create
-          的提供商（GPT/GLM/Step）通过 create_response 实现；
-          Qwen 不支持该事件，仅更新 instructions。
+        - ``skipped=True`` (或 Qwen)：通过 ``session.update`` 追加到
+          系统指令，不触发模型响应。
+        - ``skipped=False`` (GPT/GLM/Step)：通过 ``create_response``
+          注入一条一次性 user 消息并触发模型响应（用于任务结果主动
+          汇报）。注意：此路径不写入 session instructions，文本是
+          瞬态的，不要改为持久化到 instructions。
+        - Gemini：无论 skipped 值，均通过 ``send_client_content``
+          注入（SDK 限制，无 session.update 机制）。skipped=True 时
+          通过 ``_skip_until_next_response`` 静默丢弃响应。
 
         Args:
             text: Context to inject (incremental cache + summary/ready).

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1131,15 +1131,15 @@ class OmniRealtimeClient:
             await self._create_response_gemini(text)
             return
 
-        # 所有 WebSocket 提供商：先更新 session instructions
-        await self.update_session({"instructions": self.instructions + '\n' + text})
-        logger.info("prime_context: updated session instructions")
-
-        # skipped=False 时需要触发模型主动响应（任务结果汇报等场景）
         if not skipped and "qwen" not in self._model_lower:
-            # 通过 conversation.item.create + response.create 触发响应
-            # Qwen 不支持 conversation.item.create，跳过
+            # skipped=False：需要模型主动响应（任务结果汇报）
+            # 通过 create_response 注入 user 消息 + 触发响应
+            # Qwen 不支持 conversation.item.create，走下方 update_session
             await self.create_response(text)
+        else:
+            # skipped=True 或 Qwen：仅追加到 session instructions
+            await self.update_session({"instructions": self.instructions + '\n' + text})
+            logger.info("prime_context: updated session instructions")
 
     async def create_response(self, instructions: str, skipped: bool = False) -> None:
         """Inject a persistent user message and trigger an LLM response.

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1150,6 +1150,9 @@ class OmniRealtimeClient:
         """
         # Gemini 使用 send_client_content 发送文本内容
         if self._is_gemini:
+            if not instructions or not instructions.strip():
+                logger.info("Gemini: skipping empty content in create_response")
+                return
             if skipped:
                 self._skip_until_next_response = True
             await self._create_response_gemini(instructions)

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1106,14 +1106,19 @@ class OmniRealtimeClient:
     async def prime_context(self, text: str, skipped: bool = False) -> None:
         """Append context to session instructions at startup.
 
-        与 OmniOfflineClient.prime_context 语义一致：仅追加到系统指令，
-        不创建用户消息，不触发模型响应。热切换完成后用户开口说话时，
-        模型自然会基于更新后的 instructions 进行回复。
+        热切换时注入增量上下文。行为取决于 skipped 参数：
+
+        - ``skipped=True``：仅追加到系统指令，不触发模型响应。
+          用户下次开口时模型自然基于更新后的 instructions 回复。
+        - ``skipped=False``：追加到系统指令后，额外触发一次模型响应
+          （用于任务结果主动汇报）。对于支持 conversation.item.create
+          的提供商（GPT/GLM/Step）通过 create_response 实现；
+          Qwen 不支持该事件，仅更新 instructions。
 
         Args:
             text: Context to inject (incremental cache + summary/ready).
-            skipped: Accepted for interface compatibility; not used here
-                     since no response is triggered.
+            skipped: If True, only update instructions without triggering
+                     a response. If False, also trigger model response.
         """
         if not text or not text.strip():
             logger.info("prime_context: skipping empty content")
@@ -1126,8 +1131,15 @@ class OmniRealtimeClient:
             await self._create_response_gemini(text)
             return
 
+        # 所有 WebSocket 提供商：先更新 session instructions
         await self.update_session({"instructions": self.instructions + '\n' + text})
         logger.info("prime_context: updated session instructions")
+
+        # skipped=False 时需要触发模型主动响应（任务结果汇报等场景）
+        if not skipped and "qwen" not in self._model_lower:
+            # 通过 conversation.item.create + response.create 触发响应
+            # Qwen 不支持 conversation.item.create，跳过
+            await self.create_response(text)
 
     async def create_response(self, instructions: str, skipped: bool = False) -> None:
         """Inject a persistent user message and trigger an LLM response.

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1124,8 +1124,8 @@ class OmniRealtimeClient:
         Behaviour varies by provider:
           - **OpenAI**: ``conversation.item.create(role=user)`` +
             ``response.create``
-          - **Qwen**: appends to session instructions + ``response.create``
-            (Qwen Realtime doesn't support ``conversation.item.create``)
+          - **Qwen**: ``conversation.item.create(role=user)`` +
+            ``response.create`` (also updates session instructions)
           - **Gemini**: ``send_client_content(role=user)``
 
         See ``prime_context()`` (session-start priming) and
@@ -1134,37 +1134,43 @@ class OmniRealtimeClient:
         """
         if skipped:
             self._skip_until_next_response = True
-        
+
         # Gemini 使用 send_client_content 发送文本内容
         if self._is_gemini:
             await self._create_response_gemini(instructions)
             return
 
+        # 跳过空内容的发送，避免触发 API 错误
+        if not instructions or not instructions.strip():
+            logger.info("Skipping empty content in create_response")
+            if self.on_response_done:
+                await self.on_response_done()
+            return
+
         if "qwen" in self._model_lower:
+            # 同时更新 session instructions 以保留上下文
             await self.update_session({"instructions": self.instructions + '\n' + instructions})
 
-            logger.info("Creating response with instructions override")
-            await self.send_event({"type": "response.create"})
-        else:
-            # 先通过 conversation.item.create 添加系统消息（增量）
-            item_event = {
-                "type": "conversation.item.create",
-                "item": {
-                    "type": "message",
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "input_text",
-                            "text": instructions
-                        }
-                    ]
-                }
+        # 通过 conversation.item.create 添加用户消息，确保 response.create 前存在 user role 消息
+        # 修复：DashScope (Qwen) API 要求 response.create 前必须存在 user 消息，
+        # 否则返回 1007 "The input messages do not contain elements with the role of user"
+        item_event = {
+            "type": "conversation.item.create",
+            "item": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": instructions
+                    }
+                ]
             }
-            await self.send_event(item_event)
-            
-            # 然后调用 response.create，不带 instructions（避免替换 session instructions）
-            logger.info("Creating response without instructions override")
-            await self.send_event({"type": "response.create"})
+        }
+        await self.send_event(item_event)
+
+        logger.info("Creating response with user message")
+        await self.send_event({"type": "response.create"})
     
     async def _create_response_gemini(self, instructions: str) -> None:
         """Send text content to Gemini and trigger response."""

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1128,6 +1128,8 @@ class OmniRealtimeClient:
             # Gemini Live API 没有 session.update 机制，只能通过
             # send_client_content 注入上下文（会创建 user turn）。
             # on_response_done 由 _handle_messages_gemini 自然触发。
+            if skipped:
+                self._skip_until_next_response = True
             await self._create_response_gemini(text)
             return
 
@@ -1788,13 +1790,13 @@ class OmniRealtimeClient:
                     if self._gemini_user_transcript and self.on_input_transcript:
                         await self.on_input_transcript(self._gemini_user_transcript)
                         self._gemini_user_transcript = ""  # 清空累积
-                    
+
                     self._is_responding = True
                     self._is_first_text_chunk = True  # 重置第一个 chunk 标记
                     self._gemini_current_transcript = ""  # 清空累积
-                    if self.on_new_message:
+                    if not self._skip_until_next_response and self.on_new_message:
                         await self.on_new_message()
-                
+
                 # 处理输出转录 - 流式发送每个 chunk 到前端
                 # 不参与新 turn 检测；turn_complete 后到达的迟到转录会以 isNewMessage=false
                 # 追加到当前轮次的气泡（正确行为）
@@ -1803,23 +1805,23 @@ class OmniRealtimeClient:
                     if hasattr(output_trans, 'text') and output_trans.text:
                         text = output_trans.text
                         self._gemini_current_transcript += text
-                        if self.on_text_delta:
+                        if not self._skip_until_next_response and self.on_text_delta:
                             await self.on_text_delta(text, self._is_first_text_chunk)
                             self._is_first_text_chunk = False
-                
+
                 # 处理模型输出 (音频)
                 if server_content.model_turn:
                     for part in server_content.model_turn.parts:
                         # 跳过 thinking/thought 部分
                         if hasattr(part, 'thought') and part.thought:
                             continue
-                        
+
                         # 处理音频
                         if hasattr(part, 'inline_data') and part.inline_data:
                             if isinstance(part.inline_data.data, bytes):
-                                if self.on_audio_delta:
+                                if not self._skip_until_next_response and self.on_audio_delta:
                                     await self.on_audio_delta(part.inline_data.data)
-                
+
                 # 检查是否 turn 完成（用 getattr 防止 SDK 无该字段时抛错）
                 if getattr(server_content, 'turn_complete', False):
                     # Gemini Live API 不返回 token 数，仅记录调用次数
@@ -1834,12 +1836,17 @@ class OmniRealtimeClient:
                     except Exception:
                         pass
                     self._is_responding = False
-                    # 不再调用 on_output_transcript（已通过 on_text_delta 流式发送）
-                    if self.on_response_done:
+                    if self._skip_until_next_response:
+                        self._skip_until_next_response = False
+                        logger.info("Gemini: skipped response (prime_context priming)")
+                    elif self.on_response_done:
                         await self.on_response_done()
                 
                 # 检查是否被中断
                 if hasattr(server_content, 'interrupted') and server_content.interrupted:
+                    if self._skip_until_next_response:
+                        self._skip_until_next_response = False
+                        logger.info("Gemini: skipped response interrupted, reset skip flag")
                     self._interrupted = True
                     self._is_responding = False
                     # 被中断时也发送已累积的用户输入


### PR DESCRIPTION
## Summary

- 语音对话热切换时，`OmniRealtimeClient.prime_context()` 错误地委托给 `create_response()`，导致伪造 user 消息 + 发送 `response.create`。DashScope (Qwen) 在无 user 消息时直接返回 1007 错误：`InternalError.Algo.InvalidParameter: The input messages do not contain elements with the role of user`
- 修复：`prime_context()` 不再委托 `create_response()`，统一通过 `session.update` 追加到 instructions，与 `OmniOfflineClient.prime_context` 语义一致——不创建伪用户消息，不触发模型响应
- `create_response()` 保留原有接口，移除 Qwen 特殊分支，仅供真正需要注入 user 消息的 mid-conversation 场景使用（当前无调用者）

## Test plan

- [ ] Qwen 语音对话热切换不再出现 1007 错误
- [ ] GPT / GLM / Step / Free 语音对话热切换正常完成
- [ ] Gemini 语音对话热切换不受影响
- [ ] 热切换后 pending_extra_replies 任务汇报内容正确注入到 instructions

https://claude.ai/code/session_013y91EmrQBEXczzkaEJ6DB8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 对空或仅空白输入更严格地直接返回，避免触发不必要的请求或完成事件。
  * 优化不同模型/服务的分流：调整预置上下文与响应触发逻辑，避免非目标路径上重复或错误发送；非-Gemini 路径统一先创建用户消息再触发响应；仅在确认发送时设置跳过标志。
* **文档更新**
  * 更新内部说明，明确预置上下文与响应创建的路由差异与行为；对外接口保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->