### PR TITLE
fix(ws): 猫娘切换时旧 WebSocket 泄漏 & onclose 重连风暴

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -135,6 +135,9 @@
         console.log('[猫娘切换] 从', oldCatgirl, '切换到', newCatgirl);
         console.log('[猫娘切换] isSwitchingCatgirl:', S.isSwitchingCatgirl);
         let mmdLoadingSessionId = '';
+        // 保存旧连接引用，finally 中确保关闭（防止 try 中途 throw 导致永久泄露）
+        let _switchOldSocket = null;
+        let _switchOldHeartbeat = null;
 
         if (S.isSwitchingCatgirl) {
             console.log('[猫娘切换] 正在切换中，忽略本次请求');
@@ -151,6 +154,8 @@
         // 确认切换到不同角色后，清空上一任的搜歌任务
         window.invalidatePendingMusicSearch();
         S.isSwitchingCatgirl = true;
+        _switchOldSocket = S.socket;
+        _switchOldHeartbeat = S.heartbeatInterval;
         console.log('[猫娘切换] 设置 isSwitchingCatgirl = true');
 
         try {
@@ -1286,6 +1291,18 @@
             }
             showStatusToast(window.t ? window.t('app.switchCatgirlError', { error: error.message }) : `切换失败: ${error.message}`, 4000);
         } finally {
+            // 安全网：确保旧连接一定被关闭，即使 try 中途 throw
+            // 必须在 isSwitchingCatgirl=false 之前执行，
+            // 否则 onclose 会在 isSwitchingCatgirl=false 时触发 auto-reconnect
+            try {
+                if (_switchOldSocket
+                    && _switchOldSocket.readyState !== WebSocket.CLOSED
+                    && _switchOldSocket.readyState !== WebSocket.CLOSING) {
+                    _switchOldSocket.close();
+                }
+                if (_switchOldHeartbeat) clearInterval(_switchOldHeartbeat);
+            } catch (_e) { /* ignore */ }
+
             S.isSwitchingCatgirl = false;
             // 清理切换标识，取消所有 pending 的 applyLighting 定时器
             window._currentCatgirlSwitchId = null;

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -1290,12 +1290,29 @@
                 window.MMDLoadingOverlay?.fail(mmdLoadingSessionId, { detail: error?.message || String(error) });
             }
             showStatusToast(window.t ? window.t('app.switchCatgirlError', { error: error.message }) : `切换失败: ${error.message}`, 4000);
+
+            // 早期失败回滚：若新 socket 未接管（如 /api/characters fetch 抛错），
+            // try 开头的"紧急制动"已停掉 L2D ticker 和 VRM 动画，此处重启回旧模型的渲染循环，
+            // 否则用户看到的是切换失败 toast + 冻结画面。
+            if (_switchOldSocket && S.socket === _switchOldSocket) {
+                try {
+                    const ticker = window.live2dManager?.pixi_app?.ticker;
+                    if (ticker && !ticker.started) ticker.start();
+                } catch (_e) { /* ignore */ }
+                try {
+                    if (window.vrmManager
+                        && !window.vrmManager._animationFrameId
+                        && typeof window.vrmManager.startAnimation === 'function') {
+                        window.vrmManager.startAnimation();
+                    }
+                } catch (_e) { /* ignore */ }
+            }
         } finally {
-            // 安全网：若新 socket 已接管，确保旧连接一定被关闭（即使 try 中途 throw）
+            // 双重保障：若新 socket 已接管，确保旧连接被关闭（即使 try 中途 throw）。
+            // 真正的 stale-onclose guard 在 app-websocket.js 的 onclose 早退
+            // (S.socket !== _thisSocket)，本层是第二道防线。
             // 门闸 S.socket !== _switchOldSocket：切换早期失败（如 /api/characters fetch 抛错）时
-            // 新 socket 尚未建立，此时保留旧 socket 让用户继续与当前猫娘对话
-            // 必须在 isSwitchingCatgirl=false 之前执行，
-            // 否则 onclose 会在 isSwitchingCatgirl=false 时触发 auto-reconnect
+            // 新 socket 尚未建立，此时保留旧 socket 让用户继续与当前猫娘对话。
             try {
                 if (_switchOldSocket
                     && S.socket !== _switchOldSocket

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -1291,16 +1291,21 @@
             }
             showStatusToast(window.t ? window.t('app.switchCatgirlError', { error: error.message }) : `切换失败: ${error.message}`, 4000);
         } finally {
-            // 安全网：确保旧连接一定被关闭，即使 try 中途 throw
+            // 安全网：若新 socket 已接管，确保旧连接一定被关闭（即使 try 中途 throw）
+            // 门闸 S.socket !== _switchOldSocket：切换早期失败（如 /api/characters fetch 抛错）时
+            // 新 socket 尚未建立，此时保留旧 socket 让用户继续与当前猫娘对话
             // 必须在 isSwitchingCatgirl=false 之前执行，
             // 否则 onclose 会在 isSwitchingCatgirl=false 时触发 auto-reconnect
             try {
                 if (_switchOldSocket
+                    && S.socket !== _switchOldSocket
                     && _switchOldSocket.readyState !== WebSocket.CLOSED
                     && _switchOldSocket.readyState !== WebSocket.CLOSING) {
                     _switchOldSocket.close();
                 }
-                if (_switchOldHeartbeat) clearInterval(_switchOldHeartbeat);
+                if (_switchOldHeartbeat && S.heartbeatInterval !== _switchOldHeartbeat) {
+                    clearInterval(_switchOldHeartbeat);
+                }
             } catch (_e) { /* ignore */ }
 
             S.isSwitchingCatgirl = false;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -397,6 +397,7 @@
         var wsUrl = protocol + '://' + window.location.host + '/ws/' + currentLanlanName;
         console.log(window.t('console.websocketConnecting'), currentLanlanName, window.t('console.websocketUrl'), wsUrl);
         S.socket = new WebSocket(wsUrl);
+        var _thisSocket = S.socket; // 闭包捕获，供 onclose 判断是否已被替换
 
         // ---- onopen ----
         S.socket.onopen = function () {
@@ -1674,8 +1675,10 @@
             if (typeof window.syncFloatingMicButtonState === 'function') window.syncFloatingMicButtonState(false);
             if (typeof window.syncFloatingScreenButtonState === 'function') window.syncFloatingScreenButtonState(false);
 
-            // Auto-reconnect (unless switching catgirl)
-            if (!S.isSwitchingCatgirl) {
+            // Auto-reconnect: skip if switching catgirl OR this socket was already
+            // replaced by a newer connectWebSocket() call (prevents reconnect storm
+            // when the old socket's onclose fires after the switch completes).
+            if (!S.isSwitchingCatgirl && S.socket === _thisSocket) {
                 S.autoReconnectTimeoutId = setTimeout(connectWebSocket, 3000);
             }
         };

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1586,6 +1586,15 @@
 
         // ---- onclose ----
         S.socket.onclose = function () {
+            // Stale onclose guard: background-tab throttling (or async scheduling) can
+            // delay an old socket's onclose until after a replacement connectWebSocket()
+            // has already run onopen and started a new session. In that case the mutations
+            // below (heartbeat clear, recording/session reset, button state, audio queue)
+            // would corrupt the live new session. Skip everything when this socket is stale.
+            if (S.socket !== _thisSocket) {
+                console.log('[WS] stale onclose skipped (socket already replaced)');
+                return;
+            }
             console.log(window.t('console.websocketClosed'));
             clearAssistantLifecycleOnDisconnect('socket_close');
 


### PR DESCRIPTION
## Summary
- **app-character.js**: `handleCatgirlSwitch` 的 `finally` 安全网 — 在 try 开始前捕获旧 socket 引用，即使中途 throw 也确保关闭旧连接，防止旧猫娘 session 永久泄漏
- **app-websocket.js**: `onclose` 增加 `_thisSocket` 闭包检查 — 旧 socket 的 onclose 在 `isSwitchingCatgirl=false` 之后异步触发时，不再错误发起自动重连（防止重连风暴）

## Context
`handleCatgirlSwitch` 在 `S.socket.close()` 之前有 ~290 行异步操作（fetch config、模型检测、资源清理）。如果任一步骤 throw，旧 WebSocket 永远不会关闭，旧猫娘的 session 永久泄漏。此外，旧 socket 的 `onclose` 是异步触发的，可能在 `isSwitchingCatgirl` 已重置为 false 之后才到达，导致误触发自动重连。

Electron 环境下同样有效：两个 fix 都作用于 Pet 窗口的真实 WebSocket；Chat 窗口使用 WSProxy（IPC 代理），天然免疫这些问题。

## Test plan
- [ ] 切换猫娘，验证旧连接被正常关闭（检查 backend WS disconnect 日志）
- [ ] 在 `handleCatgirlSwitch` 中模拟 throw，验证 finally 安全网关闭旧 socket
- [ ] 切换后确认无重连风暴（backend 不出现多次 WS connect 日志）
- [ ] Electron 双窗口模式下切换猫娘，验证 Pet 窗口和 Chat 窗口均正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进切换连接时的回滚与清理流程：在切换失败或异常时能恢复旧会话的心跳与渲染循环，并在条件满足时安全关闭旧连接，避免遗留资源。
  * 强化断连与重连判定：仅由当前有效的活动连接触发断开清理与自动重连，防止旧连接的延迟事件影响新会话。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->