### PR TITLE
fix: workshop MMD preview missing playAnimation after loadAnimation

### DIFF
--- a/static/js/steam_workshop_manager.js
+++ b/static/js/steam_workshop_manager.js
@@ -4000,6 +4000,7 @@ async function loadMmdPreview(modelPath, rawData) {
             if (idleAnimation && typeof workshopMmdManager.loadAnimation === 'function') {
                 try {
                     await workshopMmdManager.loadAnimation(idleAnimation);
+                    workshopMmdManager.playAnimation();
                 } catch (e) {
                     console.warn('[Workshop MMD] idle 动画加载失败:', e);
                 }


### PR DESCRIPTION
## Summary
- The Steam Workshop management page loads MMD idle animation via `loadAnimation()` but never calls `playAnimation()` afterwards, unlike the model manager and main page which both call it.
- Without `playAnimation()`, the animation mixer never starts (`isPlaying` stays `false`), so `mmd-core.js` falls into the "no animation" branch where IK solvers and physics run without proper keyframe driving — causing erratic leg movement while the upper body stays at the pre-warmed frame-0 pose.
- Added the missing `workshopMmdManager.playAnimation()` call right after `loadAnimation()` succeeds, consistent with model manager and `mmd-init.js`.

## Test plan
- [ ] Open Steam Workshop management page, select a character card with an MMD model and idle animation
- [ ] Verify the model plays the idle animation correctly (legs should not jitter)
- [ ] Compare with Model Manager page — both should display identical animation behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * MMD 模型动画在加载后现在自动播放，无需手动触发

<!-- end of auto-generated comment: release notes by coderabbit.ai -->