### PR TITLE
fix: restore standalone jukebox header button hit-testing

### DIFF
--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3600,58 +3600,9 @@ window.Jukebox = {
 
     Jukebox.injectStyles();
 
-    // 独立窗口：使用专属拖拽层（.jukebox-drag-overlay）处理原生窗口拖拽，
-    // 所有交互区域显式 no-drag，防止后续样式注入把这些区域重新污染成 drag。
-    // 这里保持 #798 的热区范围：按钮仍然可点，标题文字区域不再被 overlay 强行接管，
-    // 避免 Steam 桌面端在快速拖动时重新命中到不稳定的原生 drag 热区。
-    if (window.__NEKO_JUKEBOX_STANDALONE__) {
-      var _noDragSelector =
-        '.jukebox-header, .jukebox-header-left, .jukebox-header-buttons, ' +
-        '.jukebox-content, .jukebox-controls-row, ' +
-        '.jukebox-calibration-section, .jukebox-notice';
+    // Standalone 点歌台的桌面端拖拽/缩放统一交给 static/jukebox-standalone.js，
+    // 避免在 open() 首帧先写入旧的 app-region 热区，导致标题按钮命中缓存异常。
 
-      // 立即设置：拖拽层 drag，交互区域 no-drag
-      var _applyDragRegions = function() {
-        var overlay = jukeboxContainer.querySelector('.jukebox-drag-overlay');
-        if (overlay && overlay.style.webkitAppRegion !== 'drag') {
-          overlay.style.webkitAppRegion = 'drag';
-        }
-        jukeboxContainer.querySelectorAll(_noDragSelector).forEach(function(el) {
-          if (el.style.webkitAppRegion !== 'no-drag') {
-            el.style.webkitAppRegion = 'no-drag';
-          }
-        });
-      };
-      _applyDragRegions();
-
-      // MutationObserver 守护：如果后续有样式注入把这些交互区重新改成 drag，立即纠正
-      try {
-        var _dragGuard = new MutationObserver(function(mutations) {
-          for (var i = 0; i < mutations.length; i++) {
-            var m = mutations[i];
-            if (m.type !== 'attributes' || m.attributeName !== 'style') continue;
-            var el = m.target;
-            if (el.classList && el.classList.contains('jukebox-drag-overlay')) {
-              if (el.style.webkitAppRegion !== 'drag') {
-                el.style.webkitAppRegion = 'drag';
-              }
-            } else if (el.matches && el.matches(_noDragSelector) &&
-                       el.style.webkitAppRegion !== 'no-drag') {
-              el.style.webkitAppRegion = 'no-drag';
-            }
-          }
-        });
-        _dragGuard.observe(jukeboxContainer, {
-          attributes: true,
-          attributeFilter: ['style'],
-          subtree: true
-        });
-        // 保存引用以便 close/destroy 时断开，避免泄漏
-        Jukebox.State._dragGuard = _dragGuard;
-      } catch (e) {
-        console.warn('[Jukebox] drag guard init failed', e);
-      }
-    }
   },
   
   // 窗口拖拽功能

--- a/static/jukebox-standalone.js
+++ b/static/jukebox-standalone.js
@@ -140,6 +140,8 @@
   function neutralizeLegacyRegions(container) {
     disconnectLegacyStandaloneDrag();
 
+    container.style.webkitAppRegion = 'no-drag';
+
     var overlay = container.querySelector('.jukebox-drag-overlay');
     if (overlay) {
       overlay.style.webkitAppRegion = 'no-drag';

--- a/templates/jukebox.html
+++ b/templates/jukebox.html
@@ -39,6 +39,23 @@
             height: 100% !important;
             border-radius: 0 !important;
             box-sizing: border-box !important;
+            -webkit-app-region: no-drag !important;
+        }
+
+        .jukebox-header,
+        .jukebox-header-left,
+        .jukebox-header h3,
+        .jukebox-header-buttons,
+        .jukebox-header-buttons button,
+        .jukebox-settings,
+        .jukebox-minimize,
+        .jukebox-close,
+        .jukebox-content,
+        .jukebox-controls-row,
+        .jukebox-calibration-section,
+        .jukebox-notice,
+        .sam-panel {
+            -webkit-app-region: no-drag !important;
         }
 
         body.neko-jukebox-standalone-page .jukebox-drag-overlay {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了应用独立模式下的拖拽和窗口调整大小的处理机制，改进了代码组织和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->