### PR TITLE
fix: MMD model not restored after closing character manager when original model missing

### DIFF
--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -814,6 +814,17 @@
                 window.mmdManager.pauseRendering();
             }
 
+            // 停止 UI 更新循环（独立于渲染循环，pauseRendering 不会停止它们）
+            // 如果不停止，UI 循环每帧会覆盖下面设置的 display: none，导致按钮重新出现
+            if (window.vrmManager && window.vrmManager._uiUpdateLoopId != null) {
+                cancelAnimationFrame(window.vrmManager._uiUpdateLoopId);
+                window.vrmManager._uiUpdateLoopId = null;
+            }
+            if (window.mmdManager && window.mmdManager._uiUpdateLoopId != null) {
+                cancelAnimationFrame(window.mmdManager._uiUpdateLoopId);
+                window.mmdManager._uiUpdateLoopId = null;
+            }
+
             // 隐藏所有悬浮按钮、锁图标和返回按钮（它们挂载在 document.body 上，不随容器隐藏）
             document.querySelectorAll(
                 '#live2d-floating-buttons, #vrm-floating-buttons, #mmd-floating-buttons, ' +
@@ -862,6 +873,11 @@
                 if (window.vrmManager && typeof window.vrmManager.resumeRendering === 'function') {
                     window.vrmManager.resumeRendering();
                 }
+                // 重启 VRM UI 更新循环（被 handleHideMainUI 停止）
+                if (window.vrmManager && window.vrmManager._uiUpdateLoopId == null
+                    && typeof window.vrmManager._startUIUpdateLoop === 'function') {
+                    window.vrmManager._startUIUpdateLoop();
+                }
             } else if (currentModelType === 'live3d') {
                 // Live3D: determine sub-type from config
                 var live3dSubType = (window.lanlan_config && window.lanlan_config.live3d_sub_type || '').toLowerCase();
@@ -873,12 +889,20 @@
                         mmdContainerR.classList.remove('hidden');
                     }
                     var mmdCanvasR = document.getElementById('mmd-canvas');
-                    if (mmdCanvasR && !mmdRequestSessionId) {
+                    var hasActiveLoadingSession = mmdCanvasR && !!mmdCanvasR.dataset.mmdLoadingSessionId;
+                    if (mmdCanvasR && !hasActiveLoadingSession) {
                         mmdCanvasR.style.visibility = 'visible';
                         mmdCanvasR.style.pointerEvents = 'auto';
                     }
                     if (window.mmdManager && typeof window.mmdManager.resumeRendering === 'function') {
                         window.mmdManager.resumeRendering();
+                    }
+                    // 重启 MMD UI 更新循环（被 handleHideMainUI 停止）
+                    // UI 循环会自动管理浮动按钮和锁图标的显示/定位
+                    if (window.mmdManager && window.mmdManager._uiUpdateLoopId == null
+                        && typeof window.mmdManager._startUIUpdateLoop === 'function') {
+                        window.mmdManager._snapUIPosition = true;
+                        window.mmdManager._startUIUpdateLoop();
                     }
                 } else {
                     var vrmContainerR = document.getElementById('vrm-container');
@@ -893,6 +917,10 @@
                     }
                     if (window.vrmManager && typeof window.vrmManager.resumeRendering === 'function') {
                         window.vrmManager.resumeRendering();
+                    }
+                    if (window.vrmManager && window.vrmManager._uiUpdateLoopId == null
+                        && typeof window.vrmManager._startUIUpdateLoop === 'function') {
+                        window.vrmManager._startUIUpdateLoop();
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary

When the configured MMD model file does not exist, the app correctly falls back to the default model. However, if the user then opens and closes the character/model manager without switching models, the fallback model disappears and never comes back. This PR fixes three root causes in `handleShowMainUI` / `handleHideMainUI` (`static/app-interpage.js`):

1. **`ReferenceError: mmdRequestSessionId is not defined`** — `handleShowMainUI` referenced a block-scoped `let` variable (`mmdRequestSessionId`) from `handleModelReload`, causing a silent `ReferenceError` inside a `try` block. This prevented the MMD canvas visibility and rendering from being restored. Fixed by reading `canvas.dataset.mmdLoadingSessionId` instead.

2. **Independent UI update loops not stopped during hide** — `handleHideMainUI` calls `pauseRendering()` which only stops the main render loop (`_animationFrameId`), but VRM and MMD managers have separate `requestAnimationFrame`-based UI update loops (`_uiUpdateLoopId` in `*-ui-buttons.js`) that set `display` on floating buttons every frame. These loops override the `display: none` set by `handleHideMainUI`, causing buttons to reappear at incorrect positions (top-left corner). Fixed by explicitly cancelling `_uiUpdateLoopId` for both managers.

3. **UI update loops not restarted on show** — After resuming rendering in `handleShowMainUI`, the UI update loops were never restarted, leaving floating buttons and lock icons non-functional. Fixed by calling `_startUIUpdateLoop()` for the active manager.

## Reproduction steps (before fix)

1. Set an MMD model path that does not exist → app falls back to default model ✅
2. Open character manager → model and UI disappear (by design) ✅
3. Close character manager without changing model → **model never comes back** ❌

## Test plan

- [ ] Set a nonexistent MMD model path, confirm fallback to default model works
- [ ] Open character manager → verify model and all UI elements disappear
- [ ] Close character manager → verify default MMD model reappears with correct floating buttons
- [ ] Repeat with VRM model type → verify same hide/show behavior works
- [ ] While manager is open, click "请她离开" → close manager → verify only the return button is visible (not the model + buttons)
