### PR TITLE
两大插件同步阻塞修复，前端重写，增加跳转服务器入口

### DIFF
--- a/plugin/plugins/bilibili_danmaku/__init__.py
+++ b/plugin/plugins/bilibili_danmaku/__init__.py
@@ -45,6 +45,19 @@ from plugin.sdk.plugin import (
     get_plugin_logger,
 )
 
+# ── 同步 helper（避免 async def 内直接调 subprocess 阻塞事件循环）────────────
+def _open_url_in_browser(url: str) -> None:
+    """在默认浏览器打开 URL（同步调用，仅供 asyncio.to_thread 使用）"""
+    try:
+        if sys.platform == "win32":
+            subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", url])
+        else:
+            subprocess.Popen(["xdg-open", url])
+    except Exception:
+        raise
+
 from .danmaku_core import DanmakuListener
 from .filter import DanmakuFilter, get_level_tier, get_level_weekly_bonus
 
@@ -83,36 +96,36 @@ _PLUGIN_CRED_FILE = "bili_credential.enc"
 _PLUGIN_KEY_FILE  = "bili_credential.key"
 
 
-def _get_fernet(data_dir: Path):
+async def _get_fernet(data_dir: Path):
     """获取或生成插件本地 Fernet 实例，密钥存 data_dir/<_PLUGIN_KEY_FILE>"""
     from cryptography.fernet import Fernet
     key_path = data_dir / _PLUGIN_KEY_FILE
     if key_path.exists():
-        key = key_path.read_bytes()
+        key = await asyncio.to_thread(key_path.read_bytes)
     else:
         key = Fernet.generate_key()
-        data_dir.mkdir(parents=True, exist_ok=True)
-        key_path.write_bytes(key)
+        await asyncio.to_thread(data_dir.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(key_path.write_bytes, key)
         if sys.platform != "win32":
-            os.chmod(str(key_path), 0o600)
+            await asyncio.to_thread(os.chmod, str(key_path), 0o600)
     return Fernet(key)
 
 
-def _save_credential_encrypted(data_dir: Path, cred: dict) -> bool:
+async def _save_credential_encrypted(data_dir: Path, cred: dict) -> bool:
     """加密保存凭据字典到 data_dir/<_PLUGIN_CRED_FILE>"""
     try:
-        f = _get_fernet(data_dir)
-        enc = f.encrypt(json.dumps(cred, ensure_ascii=False).encode("utf-8"))
+        fernet = await _get_fernet(data_dir)
+        enc = fernet.encrypt(json.dumps(cred, ensure_ascii=False).encode("utf-8"))
         cred_path = data_dir / _PLUGIN_CRED_FILE
-        cred_path.write_bytes(enc)
+        await asyncio.to_thread(cred_path.write_bytes, enc)
         if sys.platform != "win32":
-            os.chmod(str(cred_path), 0o600)
+            await asyncio.to_thread(os.chmod, str(cred_path), 0o600)
         return True
     except Exception:
         return False
 
 
-def _load_credential_encrypted(data_dir: Path) -> Optional[Dict[str, str]]:
+async def _load_credential_encrypted(data_dir: Path) -> Optional[Dict[str, str]]:
     """从 data_dir/<_PLUGIN_CRED_FILE> 解密读取凭据字典，失败返回 None"""
     try:
         cred_path = data_dir / _PLUGIN_CRED_FILE
@@ -122,23 +135,24 @@ def _load_credential_encrypted(data_dir: Path) -> Optional[Dict[str, str]]:
         if not key_path.exists():
             return None
         from cryptography.fernet import Fernet
-        key = key_path.read_bytes()
+        key = await asyncio.to_thread(key_path.read_bytes)
         fernet = Fernet(key)
-        dec = fernet.decrypt(cred_path.read_bytes()).decode("utf-8")
+        enc_data = await asyncio.to_thread(cred_path.read_bytes)
+        dec = fernet.decrypt(enc_data).decode("utf-8")
         return json.loads(dec)
     except Exception:
         return None
 
 
-def _delete_credential_files(data_dir: Path) -> list[str]:
+async def _delete_credential_files(data_dir: Path) -> list[str]:
     """删除插件本地凭据文件，返回删除失败的文件名列表"""
     failed = []
     for fname in (_PLUGIN_CRED_FILE, _PLUGIN_KEY_FILE):
         p = data_dir / fname
         if p.exists():
             try:
-                p.unlink()
-            except Exception as e:
+                await asyncio.to_thread(p.unlink)
+            except Exception:
                 failed.append(fname)
     return failed
 
@@ -200,13 +214,13 @@ class BiliDanmakuPlugin(NekoPluginBase):
         self.logger.info("Bilibili弹幕插件启动中...")
 
         # 加载插件配置
-        self._load_plugin_config()
+        await self._load_plugin_config()
 
         # 尝试从 NEKO 读取 B 站凭据
         await self._load_bilibili_credential()
 
         # 初始化过滤器
-        self._init_filter()
+        await self._init_filter()
 
         # 注册静态 UI
         if (self.config_dir / "static").exists():
@@ -246,13 +260,12 @@ class BiliDanmakuPlugin(NekoPluginBase):
     # 内部方法：配置加载
     # ==========================================
 
-    def _load_plugin_config(self):
+    async def _load_plugin_config(self):
         """从插件 data/config.json 加载配置"""
         config_path = self.data_path("config.json")
         if config_path.exists():
             try:
-                with open(config_path, "r", encoding="utf-8") as f:
-                    cfg = json.load(f)
+                cfg = await asyncio.to_thread(self._read_json, config_path)
                 self._room_id = int(cfg.get("room_id", DEFAULT_ROOM_ID))
                 raw_interval = int(cfg.get("interval_seconds", DEFAULT_INTERVAL))
                 self._interval = max(MIN_INTERVAL, min(MAX_INTERVAL, raw_interval))
@@ -265,20 +278,26 @@ class BiliDanmakuPlugin(NekoPluginBase):
                 self.logger.warning(f"加载配置失败，使用默认值: {e}")
         else:
             # 写入默认配置
-            self._save_plugin_config()
+            await self._save_plugin_config()
 
         # 清理旧版推送时间记录文件（已改用内存变量）
         legacy_file = self.data_path("last_push.txt")
         if legacy_file.exists():
             try:
-                legacy_file.unlink()
+                await asyncio.to_thread(legacy_file.unlink)
             except Exception:
                 pass
 
-    def _save_plugin_config(self):
+    @staticmethod
+    def _read_json(path: Path) -> dict:
+        """同步读取 JSON（供 asyncio.to_thread 使用）"""
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    async def _save_plugin_config(self):
         """保存配置到 data/config.json"""
         config_path = self.data_path("config.json")
-        config_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(config_path.parent.mkdir, parents=True, exist_ok=True)
         cfg = {
             "room_id": self._room_id,
             "interval_seconds": self._interval,
@@ -288,14 +307,19 @@ class BiliDanmakuPlugin(NekoPluginBase):
             "danmaku_max_length": self._danmaku_max_length,
             "_comment_danmaku_max_length": "发送弹幕的最大长度限制（B站限制 20 字符，建议 20）",
         }
-        with open(config_path, "w", encoding="utf-8") as f:
-            json.dump(cfg, f, ensure_ascii=False, indent=2)
+        await asyncio.to_thread(self._write_json, config_path, cfg)
+
+    @staticmethod
+    def _write_json(path: Path, data: dict) -> None:
+        """同步写入 JSON（供 asyncio.to_thread 使用）"""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
 
     async def _load_bilibili_credential(self):
         """从插件本地加密存储或 NEKO 全局凭据文件读取 B 站 Cookie"""
         # ── 1. 优先读插件自己保存的加密 Cookie ────────────────────
         try:
-            local_cred = _load_credential_encrypted(self.data_path())
+            local_cred = await _load_credential_encrypted(self.data_path())
             if local_cred and local_cred.get("SESSDATA"):
                 self._bilibili_credential = _BiliCredential(
                     sessdata=local_cred.get("SESSDATA", ""),
@@ -370,15 +394,14 @@ class BiliDanmakuPlugin(NekoPluginBase):
         except Exception as e:
             self.logger.warning(f"push_message 失败: {e}")
 
-    def _init_filter(self):
+    async def _init_filter(self):
         """初始化过滤器"""
         # 加载过滤器配置
         filter_cfg_path = self.data_path("filter_config.json")
         filter_cfg = {}
         if filter_cfg_path.exists():
             try:
-                with open(filter_cfg_path, "r", encoding="utf-8") as f:
-                    filter_cfg = json.load(f)
+                filter_cfg = await asyncio.to_thread(self._read_json, filter_cfg_path)
             except Exception:
                 pass
 
@@ -849,7 +872,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
 
         old_room = self._room_id
         self._room_id = room_id
-        self._save_plugin_config()
+        await self._save_plugin_config()
 
         # 重新启动监听
         asyncio.create_task(self._start_listening())
@@ -894,7 +917,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
 
         old_interval = self._interval
         self._interval = seconds
-        self._save_plugin_config()
+        await self._save_plugin_config()
 
         return Ok({
             "success": True,
@@ -925,7 +948,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
         """设置弹幕推送的目标 AI 名称"""
         old_value = self._target_lanlan
         self._target_lanlan = str(target_lanlan).strip()
-        self._save_plugin_config()
+        await self._save_plugin_config()
         return Ok({
             "success": True,
             "message": f"✅ 目标 AI 已从 '{old_value or '(未指定)'}' 更改为 '{self._target_lanlan or '(未指定)'}'",
@@ -960,7 +983,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
 
         old_value = self._danmaku_max_length
         self._danmaku_max_length = max_length
-        self._save_plugin_config()
+        await self._save_plugin_config()
 
         # 更新监听器的弹幕长度限制（如果监听器已创建）
         if self._listener:
@@ -993,7 +1016,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
         """开始或重启弹幕监听"""
         if room_id and room_id > 0:
             self._room_id = room_id
-            self._save_plugin_config()
+            await self._save_plugin_config()
 
         if self._room_id <= 0:
             return Err(SdkError("未配置直播间ID，请先传入 room_id"))
@@ -1106,12 +1129,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
         """在浏览器中打开B站弹幕控制台"""
         url = "http://localhost:48916/plugin/bilibili-danmaku/ui/"
         try:
-            if sys.platform == "win32":
-                subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
-            elif sys.platform == "darwin":
-                subprocess.Popen(["open", url])
-            else:
-                subprocess.Popen(["xdg-open", url])
+            await asyncio.to_thread(_open_url_in_browser, url)
             self.logger.info(f"已在浏览器中打开: {url}")
             return Ok({"success": True, "url": url, "message": "已在浏览器打开控制台"})
         except Exception as e:
@@ -1164,7 +1182,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
 
         # data_path() 即 data 目录（config_dir/data/）
         data_dir = self.data_path()
-        ok = _save_credential_encrypted(data_dir, cred_dict)
+        ok = await _save_credential_encrypted(data_dir, cred_dict)
         if not ok:
             return Err(SdkError("加密保存失败，请检查 cryptography 库是否可用"))
 
@@ -1177,7 +1195,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
         )
         self._is_logged_in = True
         # 重建过滤器为登录态，确保立刻生效
-        self._init_filter()
+        await self._init_filter()
         self.logger.info(f"✅ B站凭据已加密保存 (UID={dedeuserid})")
 
         # 如果当前在监听，重启以使新凭据生效
@@ -1203,14 +1221,14 @@ class BiliDanmakuPlugin(NekoPluginBase):
     async def clear_credential(self, **_):
         """清除插件本地加密凭据，切换回游客模式"""
         data_dir = self.data_path()
-        failed = _delete_credential_files(data_dir)
+        failed = await _delete_credential_files(data_dir)
         if failed:
             self.logger.warning(f"⚠️ 以下凭据文件删除失败（可能仍留在磁盘）: {', '.join(failed)}")
 
         self._bilibili_credential = None
         self._is_logged_in = False
         # 重建过滤器为游客模式
-        self._init_filter()
+        await self._init_filter()
         self.logger.info("🗑️ 已清除插件本地 B站凭据，切换为游客模式")
 
         # 如果当前在监听，重连以断开旧的登录态连接
@@ -1239,7 +1257,7 @@ class BiliDanmakuPlugin(NekoPluginBase):
     async def reload_credential(self, **_):
         """热重载凭据（不重启监听）"""
         await self._load_bilibili_credential()
-        self._init_filter()
+        await self._init_filter()
         status = "🔐 已登录" if self._is_logged_in else "👤 游客模式"
         return Ok({
             "success": True,

--- a/plugin/plugins/bilibili_danmaku/__init__.py
+++ b/plugin/plugins/bilibili_danmaku/__init__.py
@@ -1096,6 +1096,28 @@ class BiliDanmakuPlugin(NekoPluginBase):
         })
 
     @plugin_entry(
+        id="open_ui",
+        name="打开弹幕控制台",
+        description="在浏览器中打开B站弹幕插件的Web UI控制台，用于配置直播间、查看弹幕等",
+        kind="action"
+    )
+    async def open_ui(self, **_):
+        """在浏览器中打开B站弹幕控制台"""
+        url = "http://localhost:48916/plugin/bilibili-danmaku/ui/"
+        try:
+            if sys.platform == "win32":
+                subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", url])
+            else:
+                subprocess.Popen(["xdg-open", url])
+            self.logger.info(f"已在浏览器中打开: {url}")
+            return Ok({"success": True, "url": url, "message": "已在浏览器打开控制台"})
+        except Exception as e:
+            self.logger.exception("打开控制台失败")
+            return Err(SdkError(f"打开控制台失败: {e}"))
+
+    @plugin_entry(
         id="save_credential",
         name="保存B站登录凭据",
         description="将用户提供的 B站 Cookie 字段加密保存到插件本地，重启后生效",

--- a/plugin/plugins/bilibili_danmaku/__init__.py
+++ b/plugin/plugins/bilibili_danmaku/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
 import sys
 from collections import deque
 from datetime import datetime

--- a/plugin/plugins/bilibili_danmaku/static/index.html
+++ b/plugin/plugins/bilibili_danmaku/static/index.html
@@ -5,524 +5,733 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>B站弹幕监听 - N.E.K.O</title>
   <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
-      background: #0f0f13;
-      color: #e8e8ed;
-      min-height: 100vh;
-      padding: 20px;
+    :root {
+      --bg-page: #f4f5f7;
+      --bg-card: #ffffff;
+      --bg-card-hover: #fafafa;
+      --bg-input: #ffffff;
+      --bg-input-focus: #f0f7ff;
+      --border: #e1e4e8;
+      --border-focus: #FB7299;
+      --text: #18191c;
+      --text-secondary: #61666d;
+      --text-muted: #9499a0;
+      --accent-pink: #FB7299;
+      --accent-pink-light: #FFE4EC;
+      --accent-blue: #23ADE5;
+      --accent-blue-light: #E0F6FF;
+      --success: #23D760;
+      --success-light: #E6F9E9;
+      --warning: #FFB800;
+      --warning-light: #FFF4E0;
+      --danger: #FA5A5A;
+      --danger-light: #FFE6E6;
+      --gift: #FFAA00;
+      --sc: #07C160;
     }
 
-    .container { max-width: 860px; margin: 0 auto; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
 
-    /* ── 页头 ── */
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+      background: var(--bg-page);
+      background-image:
+        radial-gradient(circle at 20% 30%, rgba(35, 173, 229, 0.1) 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, rgba(35, 173, 229, 0.08) 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, rgba(35, 173, 229, 0.06) 0%, transparent 60%);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 32px 24px;
+      line-height: 1.5;
+    }
+
+    .container { max-width: 960px; margin: 0 auto; }
+
     .header {
       display: flex;
       align-items: center;
-      gap: 12px;
-      margin-bottom: 20px;
-    }
-    .header-logo {
-      width: 42px; height: 42px;
-      background: linear-gradient(135deg, #fb7299, #e02078);
-      border-radius: 12px;
-      display: flex; align-items: center; justify-content: center;
-      font-size: 22px;
-    }
-    .header h1 { font-size: 1.4rem; font-weight: 700; }
-    .header p  { font-size: 0.8rem; color: #8e8e93; margin-top: 2px; }
-
-    /* ── 卡片 ── */
-    .card {
-      background: #1c1c22;
+      gap: 16px;
+      margin-bottom: 28px;
+      background: var(--bg-card);
+      padding: 20px 24px;
       border-radius: 16px;
-      border: 1px solid #2a2a32;
-      padding: 20px;
-      margin-bottom: 16px;
-    }
-    .card-title {
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: #8e8e93;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      margin-bottom: 14px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.04);
     }
 
-    /* ── 状态条 ── */
-    .status-bar {
+    .logo-wrap {
+      width: 52px;
+      height: 52px;
+      background: var(--accent-pink);
+      border-radius: 14px;
       display: flex;
       align-items: center;
-      gap: 10px;
-      padding: 12px 16px;
-      border-radius: 12px;
-      font-size: 0.9rem;
-      margin-bottom: 16px;
-      background: #2a2a32;
-      border: 1px solid #3a3a44;
-      transition: background 0.3s, border-color 0.3s;
+      justify-content: center;
+      font-size: 26px;
+      flex-shrink: 0;
     }
-    .status-bar.connected   { background: #0d2e1a; border-color: #34c759; }
-    .status-bar.connecting  { background: #2a2200; border-color: #ff9500; }
-    .status-bar.error       { background: #2e0d0d; border-color: #ff3b30; }
+
+    .header-text h1 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: var(--accent-pink);
+    }
+
+    .header-text p {
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      margin-top: 2px;
+    }
+
+    .card {
+      background: var(--bg-card);
+      border-radius: 16px;
+      padding: 22px 24px;
+      margin-bottom: 16px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.04);
+    }
+
+    .card-title {
+      font-size: 0.7rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 18px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .card-title::before {
+      content: '';
+      width: 4px;
+      height: 14px;
+      background: var(--accent-pink);
+      border-radius: 2px;
+    }
+
+    .status-card {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 18px 20px;
+      background: var(--bg-page);
+      border-radius: 14px;
+      border: 1px solid var(--border);
+    }
 
     .status-dot {
-      width: 9px; height: 9px;
+      width: 14px;
+      height: 14px;
       border-radius: 50%;
-      background: #8e8e93;
+      background: var(--text-muted);
       flex-shrink: 0;
-      transition: background 0.3s;
-    }
-    .status-bar.connected  .status-dot { background: #34c759; box-shadow: 0 0 6px #34c759; }
-    .status-bar.connecting .status-dot { background: #ff9500; animation: pulse 1.2s infinite; }
-    .status-bar.error      .status-dot { background: #ff3b30; }
-    @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50%       { opacity: 0.3; }
+      transition: all 0.3s;
     }
 
-    /* ── 输入区 ── */
-    .input-row {
+    .status-dot.connected {
+      background: var(--success);
+      box-shadow: 0 0 0 4px rgba(35, 215, 96, 0.2);
+    }
+
+    .status-dot.connecting {
+      background: var(--warning);
+      animation: statusPulse 1.5s infinite;
+    }
+
+    .status-dot.error { background: var(--danger); }
+
+    @keyframes statusPulse {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(255, 184, 0, 0.4); }
+      50% { box-shadow: 0 0 0 6px rgba(255, 184, 0, 0); }
+    }
+
+    .status-info { flex: 1; }
+    .status-text { font-size: 0.95rem; font-weight: 600; }
+    .status-sub { font-size: 0.8rem; color: var(--text-secondary); margin-top: 3px; }
+
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .stat {
+      background: var(--bg-page);
+      border-radius: 12px;
+      padding: 16px 12px;
+      text-align: center;
+      border: 1px solid var(--border);
+      transition: all 0.2s;
+    }
+
+    .stat:hover {
+      border-color: var(--accent-blue);
+      transform: translateY(-2px);
+    }
+
+    .stat-value {
+      font-size: 1.6rem;
+      font-weight: 700;
+      color: var(--accent-pink);
+    }
+
+    .stat-label { font-size: 0.75rem; color: var(--text-secondary); margin-top: 4px; }
+
+    .form-row {
       display: flex;
-      gap: 10px;
+      gap: 14px;
       align-items: flex-end;
     }
+
     .input-group { flex: 1; }
+
     .input-group label {
       display: block;
-      font-size: 0.78rem;
-      color: #8e8e93;
-      margin-bottom: 6px;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      margin-bottom: 8px;
+      font-weight: 500;
     }
-    input[type="number"], input[type="text"] {
+
+    .input-wrap {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    input[type="text"],
+    input[type="number"],
+    input[type="password"] {
       width: 100%;
-      background: #28282f;
-      border: 1px solid #3a3a44;
+      background: var(--bg-input);
+      border: 1.5px solid var(--border);
       border-radius: 10px;
-      color: #e8e8ed;
-      padding: 10px 14px;
-      font-size: 0.95rem;
-      transition: border-color 0.2s, box-shadow 0.2s;
+      color: var(--text);
+      padding: 11px 14px;
+      font-size: 0.9rem;
+      transition: all 0.2s;
     }
+
     input:focus {
       outline: none;
-      border-color: #fb7299;
-      box-shadow: 0 0 0 3px rgba(251,114,153,0.15);
+      border-color: var(--border-focus);
+      background: var(--bg-input-focus);
+      box-shadow: 0 0 0 3px rgba(251, 114, 153, 0.1);
     }
-    input::-webkit-inner-spin-button { opacity: 0; }
 
-    /* ── 按钮 ── */
+    input::placeholder { color: var(--text-muted); }
+
+    .input-wrap .reveal-btn {
+      position: absolute;
+      right: 12px;
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      padding: 4px 8px;
+      font-size: 1rem;
+      transition: color 0.2s;
+    }
+
+    .input-wrap .reveal-btn:hover { color: var(--accent-pink); }
+
+    input[type="password"] {
+      padding-right: 48px;
+      font-family: 'Consolas', monospace;
+      letter-spacing: 2px;
+    }
+
+    input[type="password"]:not(.show-visible) {
+      -webkit-text-security: disc;
+    }
+
     .btn {
       display: inline-flex;
       align-items: center;
+      justify-content: center;
       gap: 6px;
-      padding: 10px 18px;
+      padding: 11px 20px;
       border-radius: 10px;
       border: none;
       cursor: pointer;
-      font-size: 0.88rem;
-      font-weight: 600;
-      white-space: nowrap;
-      transition: opacity 0.15s, transform 0.1s;
-    }
-    .btn:active   { transform: scale(0.97); }
-    .btn:disabled { opacity: 0.45; cursor: not-allowed; transform: none; }
-    .btn-primary  { background: #fb7299; color: #fff; }
-    .btn-success  { background: #34c759; color: #fff; }
-    .btn-danger   { background: #ff3b30; color: #fff; }
-    .btn-ghost    { background: #2a2a32; color: #e8e8ed; border: 1px solid #3a3a44; }
-    .btn-sm       { padding: 7px 13px; font-size: 0.82rem; }
-
-    .btn-group { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; }
-
-    /* ── 统计行 ── */
-    .stats {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 10px;
-    }
-    .stat-item {
-      background: #28282f;
-      border-radius: 12px;
-      padding: 14px;
-      text-align: center;
-    }
-    .stat-value { font-size: 1.6rem; font-weight: 700; color: #fb7299; line-height: 1; }
-    .stat-label { font-size: 0.75rem; color: #8e8e93; margin-top: 4px; }
-
-    /* ── 连接详情 ── */
-    .conn-details {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 8px;
-      margin-top: 12px;
-      padding-top: 12px;
-      border-top: 1px solid #2a2a32;
-    }
-    .conn-detail-item {
-      background: #28282f;
-      border-radius: 8px;
-      padding: 10px 12px;
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-    .conn-label { font-size: 0.7rem; color: #8e8e93; }
-    .conn-value { font-size: 0.85rem; color: #e0e0e0; font-weight: 500; word-break: break-all; }
-
-    /* ── 弹幕流 ── */
-    #danmakuFeed {
-      height: 340px;
-      overflow-y: auto;
-      background: #16161c;
-      border-radius: 12px;
-      padding: 12px;
-      border: 1px solid #2a2a32;
-      scroll-behavior: smooth;
-    }
-    #danmakuFeed::-webkit-scrollbar { width: 4px; }
-    #danmakuFeed::-webkit-scrollbar-track { background: transparent; }
-    #danmakuFeed::-webkit-scrollbar-thumb { background: #3a3a44; border-radius: 2px; }
-
-    .danmaku-item {
-      padding: 5px 8px;
-      border-radius: 8px;
-      margin-bottom: 4px;
       font-size: 0.875rem;
-      line-height: 1.5;
-      animation: slideIn 0.2s ease;
-      background: #1e1e26;
-      border-left: 3px solid #3a3a44;
-    }
-    .danmaku-item.type-danmaku { border-left-color: #fb7299; }
-    .danmaku-item.type-gift    { border-left-color: #ffd60a; background: #1e1c0d; }
-    .danmaku-item.type-sc      { border-left-color: #30d158; background: #0d1e10; }
-    .danmaku-item.type-system  { border-left-color: #636366; color: #8e8e93; font-style: italic; }
-
-    @keyframes slideIn {
-      from { opacity: 0; transform: translateY(-4px); }
-      to   { opacity: 1; transform: translateY(0); }
+      font-weight: 600;
+      transition: all 0.2s;
+      white-space: nowrap;
     }
 
-    .danmaku-meta {
-      font-size: 0.75rem;
-      color: #8e8e93;
-      margin-right: 6px;
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none !important; }
+
+    .btn-primary {
+      background: var(--accent-pink);
+      color: #fff;
     }
-    .danmaku-user { font-weight: 600; color: #c0c0c8; margin-right: 4px; }
-    .danmaku-badge {
-      display: inline-block;
-      font-size: 0.68rem;
-      padding: 1px 5px;
+
+    .btn-primary:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(251, 114, 153, 0.35);
+    }
+
+    .btn-success {
+      background: var(--success);
+      color: #fff;
+    }
+
+    .btn-success:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(35, 215, 96, 0.35);
+    }
+
+    .btn-danger {
+      background: var(--danger);
+      color: #fff;
+    }
+
+    .btn-danger:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(250, 90, 90, 0.35);
+    }
+
+    .btn-ghost {
+      background: var(--bg-page);
+      color: var(--text);
+      border: 1.5px solid var(--border);
+    }
+
+    .btn-ghost:hover:not(:disabled) {
+      border-color: var(--accent-pink);
+      color: var(--accent-pink);
+      background: var(--accent-pink-light);
+    }
+
+    .btn-sm { padding: 8px 14px; font-size: 0.8rem; }
+
+    .login-toggle {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      cursor: pointer;
+      padding: 14px 18px;
+      background: var(--bg-page);
+      border-radius: 14px;
+      border: 1.5px solid var(--border);
+      margin-bottom: 0;
+      transition: all 0.2s;
+    }
+
+    .login-toggle:hover {
+      border-color: var(--accent-pink);
+      background: var(--accent-pink-light);
+    }
+
+    .login-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 12px;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      font-weight: 600;
+    }
+
+    .login-badge.logged {
+      background: var(--success-light);
+      color: var(--success);
+    }
+
+    .login-badge.guest {
+      background: var(--bg-card);
+      color: var(--text-secondary);
+      border: 1px solid var(--border);
+    }
+
+    .login-toggle-text {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      transition: all 0.2s;
+    }
+
+    .login-toggle:hover .login-toggle-text { color: var(--accent-pink); }
+
+    .login-panel {
+      display: none;
+      padding-top: 18px;
+    }
+
+    .login-panel.open { display: block; }
+
+    .cookie-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+      margin-bottom: 18px;
+    }
+
+    .btn-group {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .help-box {
+      background: var(--accent-blue-light);
+      border: 1px solid rgba(35, 173, 229, 0.2);
+      border-radius: 12px;
+      padding: 16px;
+      font-size: 0.8rem;
+      color: var(--text-secondary);
+      line-height: 1.7;
+      margin-top: 18px;
+    }
+
+    .help-box strong { color: var(--accent-blue); }
+
+    .help-box code {
+      background: rgba(35, 173, 229, 0.1);
+      padding: 2px 8px;
       border-radius: 4px;
-      background: rgba(251,114,153,0.2);
-      color: #fb7299;
-      margin-right: 4px;
-      vertical-align: middle;
+      color: var(--accent-pink);
+      font-family: 'Consolas', monospace;
+      font-size: 0.75rem;
     }
 
-    .feed-empty {
-      color: #636366;
-      text-align: center;
-      padding: 40px 0;
-      font-size: 0.88rem;
-    }
-
-    /* ── 加载指示 ── */
-    .spinner {
-      display: inline-block;
-      width: 14px; height: 14px;
-      border: 2px solid #3a3a44;
-      border-top-color: #fb7299;
-      border-radius: 50%;
-      animation: spin 0.7s linear infinite;
-      vertical-align: middle;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
-
-    /* ── 间隔滑块 ── */
     .slider-row {
       display: flex;
       align-items: center;
-      gap: 12px;
+      gap: 14px;
+      margin-bottom: 14px;
     }
+
     input[type="range"] {
       -webkit-appearance: none;
       flex: 1;
-      height: 4px;
-      background: #3a3a44;
-      border-radius: 2px;
+      height: 6px;
+      background: var(--border);
+      border-radius: 3px;
       outline: none;
+      transition: background 0.2s;
     }
+
     input[type="range"]::-webkit-slider-thumb {
       -webkit-appearance: none;
-      width: 16px; height: 16px;
+      width: 20px;
+      height: 20px;
       border-radius: 50%;
-      background: #fb7299;
+      background: var(--accent-pink);
+      cursor: pointer;
+      border: 3px solid var(--bg-card);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+      transition: transform 0.2s;
+    }
+
+    input[type="range"]::-webkit-slider-thumb:hover { transform: scale(1.1); }
+
+    .slider-value {
+      min-width: 56px;
+      text-align: center;
+      font-weight: 700;
+      font-size: 0.95rem;
+      color: var(--accent-pink);
+    }
+
+    .slider-hint {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 6px;
+    }
+
+    .feed-controls {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 14px;
+    }
+
+    .feed-controls label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
       cursor: pointer;
     }
-    .slider-value {
-      min-width: 48px;
-      text-align: right;
+
+    .feed-controls input[type="checkbox"] {
+      accent-color: var(--accent-pink);
+      width: 17px;
+      height: 17px;
+      cursor: pointer;
+    }
+
+    #danmakuFeed {
+      height: 380px;
+      overflow-y: auto;
+      background: var(--bg-page);
+      border-radius: 14px;
+      padding: 14px;
+      border: 1.5px solid var(--border);
+      transition: border-color 0.2s;
+    }
+
+    #danmakuFeed::-webkit-scrollbar { width: 8px; }
+    #danmakuFeed::-webkit-scrollbar-track { background: transparent; }
+    #danmakuFeed::-webkit-scrollbar-thumb {
+      background: var(--accent-pink);
+      border-radius: 4px;
+    }
+
+    .danmaku-item {
+      padding: 10px 14px;
+      border-radius: 10px;
+      margin-bottom: 8px;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      background: var(--bg-card);
+      border-left: 4px solid var(--border);
+      transition: all 0.2s;
+      animation: slideIn 0.25s ease;
+    }
+
+    .danmaku-item:hover {
+      background: var(--bg-page);
+      transform: translateX(2px);
+    }
+
+    .danmaku-item.type-danmaku { border-left-color: var(--accent-pink); }
+    .danmaku-item.type-gift { border-left-color: var(--gift); background: var(--warning-light); }
+    .danmaku-item.type-sc { border-left-color: var(--sc); background: var(--success-light); }
+    .danmaku-item.type-system {
+      border-left-color: var(--text-muted);
+      color: var(--text-secondary);
+      font-style: italic;
+      background: var(--bg-page);
+    }
+
+    @keyframes slideIn {
+      from { opacity: 0; transform: translateY(-8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .dm-meta { font-size: 0.75rem; color: var(--text-muted); margin-right: 10px; }
+    .dm-user { font-weight: 700; color: var(--accent-pink); margin-right: 8px; }
+    .dm-badge {
+      display: inline-block;
+      font-size: 0.7rem;
+      padding: 2px 8px;
+      border-radius: 6px;
+      background: var(--accent-pink-light);
+      color: var(--accent-pink);
+      margin-right: 8px;
+      vertical-align: middle;
       font-weight: 600;
-      color: #fb7299;
+    }
+
+    .dm-badge.gift { background: var(--warning-light); color: var(--gift); }
+    .dm-badge.sc { background: var(--success-light); color: var(--sc); }
+
+    .feed-empty {
+      color: var(--text-muted);
+      text-align: center;
+      padding: 80px 20px;
+      font-size: 0.9rem;
     }
 
     .toast {
       position: fixed;
-      bottom: 24px; right: 24px;
-      background: #2a2a32;
-      border: 1px solid #3a3a44;
+      bottom: 28px;
+      right: 28px;
+      background: var(--bg-card);
       border-radius: 12px;
-      padding: 12px 18px;
-      font-size: 0.88rem;
+      padding: 14px 22px;
+      font-size: 0.875rem;
       z-index: 1000;
-      animation: toastIn 0.25s ease;
-      max-width: 280px;
-    }
-    .toast.success { border-color: #34c759; background: #0d2e1a; }
-    .toast.error   { border-color: #ff3b30; background: #2e0d0d; }
-    @keyframes toastIn {
-      from { opacity: 0; transform: translateY(10px); }
-      to   { opacity: 1; transform: translateY(0); }
-    }
-
-    /* ── 登录面板 ── */
-    .login-status-badge {
-      display: inline-flex;
+      animation: toastIn 0.3s ease;
+      max-width: 340px;
+      box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+      display: flex;
       align-items: center;
-      gap: 6px;
-      padding: 4px 10px;
-      border-radius: 20px;
-      font-size: 0.78rem;
-      font-weight: 600;
-      margin-bottom: 14px;
+      gap: 10px;
     }
-    .login-status-badge.logged-in  { background: rgba(52,199,89,0.15);  color: #34c759; border: 1px solid rgba(52,199,89,0.3); }
-    .login-status-badge.guest      { background: rgba(142,142,147,0.12); color: #8e8e93; border: 1px solid #3a3a44; }
 
-    .cookie-fields { display: flex; flex-direction: column; gap: 10px; margin-top: 4px; }
-    .cookie-field-row { display: flex; flex-direction: column; gap: 4px; }
-    .cookie-field-row label { font-size: 0.78rem; color: #8e8e93; }
-    .cookie-field-row input[type="password"],
-    .cookie-field-row input[type="text"] {
-      font-family: 'SF Mono', 'Consolas', monospace;
-      font-size: 0.82rem;
+    .toast.success {
+      border-left: 4px solid var(--success);
+      background: var(--success-light);
     }
-    .field-hint { font-size: 0.72rem; color: #636366; margin-top: 2px; }
 
-    .reveal-toggle {
-      background: none;
-      border: none;
-      color: #8e8e93;
-      cursor: pointer;
-      padding: 0 4px;
-      font-size: 0.8rem;
+    .toast.error {
+      border-left: 4px solid var(--danger);
+      background: var(--danger-light);
     }
-    .field-input-wrap { position: relative; display: flex; align-items: center; }
-    .field-input-wrap input { padding-right: 32px; }
-    .field-input-wrap .reveal-toggle { position: absolute; right: 8px; }
 
-    .login-help {
-      background: #1a1a22;
-      border: 1px solid #2a2a3a;
-      border-radius: 10px;
-      padding: 12px 14px;
-      font-size: 0.78rem;
-      color: #636366;
-      line-height: 1.7;
-      margin-top: 12px;
+    @keyframes toastIn {
+      from { opacity: 0; transform: translateY(16px) scale(0.95); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
     }
-    .login-help strong { color: #8e8e93; }
-    .login-help code {
-      background: #28282f;
-      padding: 1px 5px;
-      border-radius: 4px;
-      color: #fb7299;
-      font-size: 0.76rem;
+
+    .spinner {
+      display: inline-block;
+      width: 16px;
+      height: 16px;
+      border: 2.5px solid var(--border);
+      border-top-color: var(--accent-pink);
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+      vertical-align: middle;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    @media (max-width: 640px) {
+      body { padding: 16px; }
+      .stats-grid { grid-template-columns: repeat(2, 1fr); }
+      .cookie-grid { grid-template-columns: 1fr; }
+      .form-row { flex-direction: column; }
+      .form-row .btn { width: 100%; }
     }
   </style>
 </head>
 <body>
 <div class="container">
 
-  <!-- 页头 -->
   <div class="header">
-    <div class="header-logo">📺</div>
-    <div>
+    <div class="logo-wrap">📺</div>
+    <div class="header-text">
       <h1>B站弹幕监听</h1>
-      <p>N.E.K.O 插件控制台 · bilibili-danmaku</p>
+      <p>N.E.K.O 插件控制台</p>
     </div>
   </div>
 
-  <!-- 状态卡片 -->
   <div class="card">
     <div class="card-title">连接状态</div>
-    <div id="statusBar" class="status-bar">
-      <span class="status-dot"></span>
-      <span id="statusText">正在获取状态...</span>
+    <div class="status-card">
+      <div class="status-dot" id="statusDot"></div>
+      <div class="status-info">
+        <div class="status-text" id="statusText">正在获取状态...</div>
+        <div class="status-sub" id="statusSub"></div>
+      </div>
     </div>
-
-    <!-- 统计 -->
-    <div class="stats">
-      <div class="stat-item">
-        <div class="stat-value" id="statReceived">—</div>
+    <div class="stats-grid">
+      <div class="stat">
+        <div class="stat-value" id="statReceived">0</div>
         <div class="stat-label">已收到</div>
       </div>
-      <div class="stat-item">
-        <div class="stat-value" id="statFiltered">—</div>
+      <div class="stat">
+        <div class="stat-value" id="statFiltered">0</div>
         <div class="stat-label">已过滤</div>
       </div>
-      <div class="stat-item">
-        <div class="stat-value" id="statQueue">—</div>
-        <div class="stat-label">缓冲弹幕</div>
+      <div class="stat">
+        <div class="stat-value" id="statQueue">0</div>
+        <div class="stat-label">缓冲</div>
       </div>
-    </div>
-
-    <!-- 连接详情 -->
-    <div class="conn-details">
-      <div class="conn-detail-item">
-        <span class="conn-label">弹幕服务器</span>
-        <span class="conn-value" id="connServer">—</span>
-      </div>
-      <div class="conn-detail-item">
-        <span class="conn-label">连接状态</span>
-        <span class="conn-value" id="connState">—</span>
-      </div>
-      <div class="conn-detail-item">
-        <span class="conn-label">当前人气</span>
-        <span class="conn-value" id="connViewers">—</span>
+      <div class="stat">
+        <div class="stat-value" id="statViewers">—</div>
+        <div class="stat-label">人气</div>
       </div>
     </div>
   </div>
 
-  <!-- B站账号 -->
-  <div class="card" id="loginCard">
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;">
-      <div class="card-title" style="margin:0;">B站账号</div>
-      <button class="btn btn-ghost btn-sm" id="toggleLoginBtn" onclick="toggleLoginPanel()">展开</button>
+  <div class="card">
+    <div class="card-title">B站账号</div>
+    <div class="login-toggle" onclick="toggleLoginPanel()">
+      <span id="loginBadge" class="login-badge guest">👤 游客模式</span>
+      <span class="login-toggle-text" id="loginToggleText">点击展开 ▼</span>
     </div>
-
-    <!-- 登录状态徽章 -->
-    <div id="loginBadge" class="login-status-badge guest">👤 游客模式</div>
-
-    <!-- 可折叠的 Cookie 输入区 -->
-    <div id="loginPanel" style="display:none;">
-      <div class="cookie-fields">
-
-        <div class="cookie-field-row">
-          <label>SESSDATA <span style="color:#ff3b30">*</span></label>
-          <div class="field-input-wrap">
-            <input type="password" id="f_sessdata" placeholder="粘贴 SESSDATA Cookie 值" autocomplete="off">
-            <button class="reveal-toggle" onclick="toggleReveal('f_sessdata', this)" title="显示/隐藏">👁</button>
+    <div class="login-panel" id="loginPanel">
+      <div class="cookie-grid">
+        <div class="input-group">
+          <label>SESSDATA <span style="color:var(--danger)">*</span></label>
+          <div class="input-wrap">
+            <input type="password" id="f_sessdata" placeholder="粘贴 SESSDATA" autocomplete="off">
+            <button class="reveal-btn" onclick="toggleReveal('f_sessdata')">👁</button>
           </div>
         </div>
-
-        <div class="cookie-field-row">
-          <label>bili_jct <span style="color:#ff3b30">*</span></label>
-          <div class="field-input-wrap">
-            <input type="password" id="f_bili_jct" placeholder="粘贴 bili_jct Cookie 值" autocomplete="off">
-            <button class="reveal-toggle" onclick="toggleReveal('f_bili_jct', this)" title="显示/隐藏">👁</button>
+        <div class="input-group">
+          <label>bili_jct <span style="color:var(--danger)">*</span></label>
+          <div class="input-wrap">
+            <input type="password" id="f_bili_jct" placeholder="粘贴 bili_jct" autocomplete="off">
+            <button class="reveal-btn" onclick="toggleReveal('f_bili_jct')">👁</button>
           </div>
         </div>
-
-        <div class="cookie-field-row">
-          <label>DedeUserID <span style="color:#ff3b30">*</span></label>
-          <div class="field-input-wrap">
-            <input type="text" id="f_dedeuserid" placeholder="你的 B站 UID，如 12345678" autocomplete="off">
+        <div class="input-group">
+          <label>DedeUserID <span style="color:var(--danger)">*</span></label>
+          <div class="input-wrap">
+            <input type="password" id="f_dedeuserid" placeholder="你的 B站 UID" autocomplete="off" class="show-visible">
+            <button class="reveal-btn" onclick="toggleReveal('f_dedeuserid')">👁</button>
           </div>
         </div>
-
-        <div class="cookie-field-row">
-          <label>buvid3 <span style="color:#8e8e93;font-weight:400;">（强烈建议填写，可避免 -352 风控）</span></label>
-          <div class="field-input-wrap">
-            <input type="password" id="f_buvid3" placeholder="粘贴 buvid3 Cookie 值" autocomplete="off">
-            <button class="reveal-toggle" onclick="toggleReveal('f_buvid3', this)" title="显示/隐藏">👁</button>
+        <div class="input-group">
+          <label>buvid3 <span style="color:var(--text-muted)">（推荐）</span></label>
+          <div class="input-wrap">
+            <input type="password" id="f_buvid3" placeholder="粘贴 buvid3" autocomplete="off">
+            <button class="reveal-btn" onclick="toggleReveal('f_buvid3')">👁</button>
           </div>
         </div>
-
       </div>
-
       <div class="btn-group">
-        <button class="btn btn-success" id="saveCredBtn">🔐 加密保存</button>
-        <button class="btn btn-danger btn-sm" id="clearCredBtn">🗑 清除凭据</button>
+        <button class="btn btn-success" id="saveCredBtn" onclick="saveCredential()">🔐 加密保存</button>
+        <button class="btn btn-danger btn-sm" id="clearCredBtn" onclick="clearCredential()">🗑 清除</button>
       </div>
-
-      <div class="login-help">
-        <strong>如何获取 Cookie？</strong><br>
-        1. 浏览器打开 <strong>bilibili.com</strong> 并登录<br>
-        2. 按 <code>F12</code> → Application → Cookies → <code>https://www.bilibili.com</code><br>
-        3. 找到并复制 <code>SESSDATA</code>、<code>bili_jct</code>、<code>DedeUserID</code>、<code>buvid3</code> 的值<br>
-        4. 粘贴到上方对应输入框，点击「加密保存」<br>
-        <br>
-        <strong>安全说明：</strong>Cookie 使用 Fernet 对称加密存储在本地插件目录，不会上传到任何服务器。
+      <div class="help-box">
+        <strong>获取 Cookie：</strong>登录 bilibili.com → F12 → Application → Cookies → 复制对应值<br>
+        <strong>安全说明：</strong>Cookie 使用加密存储在本地，不会上传任何服务器
       </div>
     </div>
   </div>
 
-  <!-- 直播间设置 -->
   <div class="card">
     <div class="card-title">直播间设置</div>
-    <div class="input-row">
+    <div class="form-row">
       <div class="input-group">
         <label>直播间 ID</label>
-        <input type="number" id="roomIdInput" placeholder="输入直播间号码，如 12345">
+        <input type="number" id="roomIdInput" placeholder="输入直播间号码，如 22925943">
       </div>
-      <button class="btn btn-primary" id="setRoomBtn">
-        <span>切换直播间</span>
-      </button>
-    </div>
-
-    <div class="btn-group">
-      <button class="btn btn-success" id="connectBtn">🔗 开始监听</button>
-      <button class="btn btn-danger"  id="disconnectBtn">⏹ 停止监听</button>
-      <button class="btn btn-ghost"   id="refreshBtn">↻ 刷新状态</button>
+      <button class="btn btn-primary" id="setRoomBtn" onclick="setRoom()">切换房间</button>
+      <button class="btn btn-success" id="connectBtn" onclick="connect()">▶ 开始监听</button>
+      <button class="btn btn-danger" id="disconnectBtn" onclick="disconnect()">⏹ 停止</button>
     </div>
   </div>
 
-  <!-- 推送间隔 -->
   <div class="card">
-    <div class="card-title">AI 推送间隔</div>
-    <div class="slider-row">
-      <input type="range" id="intervalSlider" min="10" max="180" value="30" step="5">
-      <span class="slider-value" id="intervalDisplay">30s</span>
-      <button class="btn btn-ghost btn-sm" id="setIntervalBtn">保存</button>
+    <div class="card-title">AI 推送设置</div>
+    <div style="margin-bottom:18px;">
+      <label style="font-size:0.8rem;color:var(--text-secondary);display:block;margin-bottom:10px;font-weight:500;">推送间隔（秒）</label>
+      <div class="slider-row">
+        <input type="range" id="intervalSlider" min="5" max="180" value="10" step="5">
+        <span class="slider-value" id="intervalDisplay">10s</span>
+        <button class="btn btn-ghost btn-sm" onclick="setInterval()">保存</button>
+      </div>
+      <div class="slider-hint">弹幕推送给 AI 的时间间隔，建议 10-30 秒</div>
     </div>
-    <p style="font-size:0.78rem;color:#636366;margin-top:8px;">每隔这段时间将缓冲弹幕推送给 AI 处理（10 ~ 180 秒）</p>
-  </div>
-
-  <!-- AI 目标设置 -->
-  <div class="card">
-    <div class="card-title">AI 目标设置</div>
-    <div class="input-row" style="margin-bottom:12px;">
+    <div style="margin-bottom:18px;">
+      <label style="font-size:0.8rem;color:var(--text-secondary);display:block;margin-bottom:10px;font-weight:500;">弹幕最大长度</label>
+      <div class="slider-row">
+        <input type="range" id="danmakuMaxSlider" min="5" max="20" value="20" step="5">
+        <span class="slider-value" id="danmakuMaxDisplay">20</span>
+        <button class="btn btn-ghost btn-sm" onclick="setDanmakuMax()">保存</button>
+      </div>
+      <div class="slider-hint">B站弹幕限制 20 字符，建议保持 20</div>
+    </div>
+    <div class="form-row" style="margin-bottom:0;">
       <div class="input-group">
         <label>目标 AI 名称</label>
-        <input type="text" id="targetLanlanInput" placeholder="留空则不指定目标 AI，如：小天">
+        <input type="text" id="targetLanlanInput" placeholder="留空则不指定，如：小天">
       </div>
-      <button class="btn btn-ghost btn-sm" id="setTargetBtn">保存</button>
+      <button class="btn btn-ghost btn-sm" onclick="setTargetLanlan()">保存</button>
     </div>
-    <div class="slider-row">
-      <label style="font-size:0.85rem;margin-right:8px;">弹幕最大长度:</label>
-      <input type="range" id="danmakuMaxLenSlider" min="5" max="20" value="20" step="5">
-      <span class="slider-value" id="danmakuMaxLenDisplay">20</span>
-      <button class="btn btn-ghost btn-sm" id="setDanmakuMaxLenBtn">保存</button>
-    </div>
-    <p style="font-size:0.78rem;color:#636366;margin-top:8px;">目标 AI 名称应与 lanlan_name 一致（留空则不指定）。B站弹幕限制 20 字符/秒。</p>
   </div>
 
-  <!-- 弹幕实时流 -->
   <div class="card">
-    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
-      <div class="card-title" style="margin:0;">实时弹幕流</div>
-      <div style="display:flex;gap:8px;align-items:center;">
-        <label style="font-size:0.78rem;color:#8e8e93;display:flex;align-items:center;gap:6px;cursor:pointer;">
-          <input type="checkbox" id="autoScrollCb" checked style="accent-color:#fb7299;width:14px;height:14px;">
-          自动滚动
-        </label>
-        <button class="btn btn-ghost btn-sm" id="pollBtn">⏸ 暂停轮询</button>
-        <button class="btn btn-ghost btn-sm" id="clearFeedBtn">清空</button>
+    <div class="card-title">实时弹幕流</div>
+    <div class="feed-controls">
+      <label>
+        <input type="checkbox" id="autoScrollCb" checked>
+        自动滚动
+      </label>
+      <div style="display:flex;gap:10px;">
+        <button class="btn btn-ghost btn-sm" id="pollBtn" onclick="togglePoll()">⏸ 暂停</button>
+        <button class="btn btn-ghost btn-sm" onclick="clearFeed()">🗑 清空</button>
       </div>
     </div>
     <div id="danmakuFeed">
@@ -534,155 +743,50 @@
 
 <script>
   const PLUGIN_ID = 'bilibili-danmaku';
-  const RUNS_URL  = '/runs';
+  const RUNS_URL = '/runs';
 
-  // ── API 调用 ─────────────────────────────────────────────
   async function callPlugin(entry, args = {}) {
-    const createResp = await fetch(RUNS_URL, {
+    const resp = await fetch(RUNS_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ plugin_id: PLUGIN_ID, entry_id: entry, args })
     });
-    if (!createResp.ok) throw new Error(`HTTP ${createResp.status}`);
-    const { run_id, id } = await createResp.json();
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const { run_id, id } = await resp.json();
     const runId = run_id || id;
     if (!runId) throw new Error('未获取到 run_id');
 
     const deadline = Date.now() + 20000;
     while (Date.now() < deadline) {
-      await sleep(350);
-      const pollResp = await fetch(`${RUNS_URL}/${runId}`);
-      if (!pollResp.ok) continue;
-      const rec = await pollResp.json();
+      await sleep(300);
+      const poll = await fetch(`${RUNS_URL}/${runId}`);
+      if (!poll.ok) continue;
+      const rec = await poll.json();
       if (rec.status === 'succeeded') {
-        const exportResp = await fetch(`${RUNS_URL}/${runId}/export`);
-        if (!exportResp.ok) return {};
-        const { items = [] } = await exportResp.json();
+        const exp = await fetch(`${RUNS_URL}/${runId}/export`);
+        if (!exp.ok) return {};
+        const { items = [] } = await exp.json();
         const item = items.find(i => i.type === 'json' && i.json) || items[0];
         if (!item) return {};
-        const raw = item.json || {};
-        // 增加健壮性检查，防止 null 或 undefined 导致异常
-        if (!raw || typeof raw !== 'object') return {};
-        // 后端 Ok({...}) 经过 host _handle_trigger 和 trigger_service _normalize_plugin_response 后，
-        // 可能产生多层嵌套。逐层解包，直到拿到插件返回的原始 dict。
-        //
-        // 典型结构：
-        //   raw = { success, code, data: { success, data: <插件原始返回>, error, ... }, ... }
-        //
-        // 解包策略：如果 data 字段看起来像嵌套包装（含 success + data/error），
-        // 就继续剥一层；否则 data 本身就是最终数据。
-        let resp = raw;
-        const _unwrap = (obj) => {
-            if (!obj || typeof obj !== 'object') return obj;
-            const d = obj.data;
-            if (d === null || d === undefined) return obj;
-            if (typeof d !== 'object') return obj;
-            // 如果 data 是数组，直接返回 data（数组不可能是 envelope）
-            if (Array.isArray(d)) return d;
-            // 如果 data 有 success + (data 或 error) 字段，说明是嵌套包装
-            if ('success' in d && ('data' in d || 'error' in d)) {
-                return _unwrap(d);  // 递归剥层
-            }
-            return d;
-        };
-        if (resp && typeof resp === 'object' && resp.success === true && typeof resp.data === 'object') {
-            resp = _unwrap(resp);
-        } else if (resp && typeof resp === 'object' && resp.success === true && resp.data !== undefined) {
-            resp = resp.data;
+        let raw = item.json || {};
+        while (raw && raw.data && typeof raw.data === 'object' && ('success' in raw.data || 'error' in raw.data)) {
+          raw = raw.data;
         }
-        return resp;
+        return raw;
       }
-      if (['failed','canceled','timeout'].includes(rec.status))
+      if (['failed', 'canceled', 'timeout'].includes(rec.status)) {
         throw new Error(rec.error?.message || rec.message || rec.status);
+      }
     }
     throw new Error('调用超时');
   }
 
-  // ── 登录面板 ────────────────────────────────────────────
-  function toggleLoginPanel() {
-    const panel = document.getElementById('loginPanel');
-    const btn   = document.getElementById('toggleLoginBtn');
-    const open  = panel.style.display === 'none';
-    panel.style.display = open ? '' : 'none';
-    btn.textContent = open ? '收起' : '展开';
-  }
+  function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
-  function toggleReveal(inputId, btn) {
-    const el = document.getElementById(inputId);
-    const show = el.type === 'password';
-    el.type = show ? 'text' : 'password';
-    btn.textContent = show ? '🙈' : '👁';
-  }
-
-  function updateLoginBadge(loggedIn) {
-    const badge = document.getElementById('loginBadge');
-    if (loggedIn) {
-      badge.className = 'login-status-badge logged-in';
-      badge.textContent = '🔐 已登录';
-    } else {
-      badge.className = 'login-status-badge guest';
-      badge.textContent = '👤 游客模式';
-    }
-  }
-
-  document.getElementById('saveCredBtn').addEventListener('click', async () => {
-    const sessdata   = document.getElementById('f_sessdata').value.trim();
-    const bili_jct   = document.getElementById('f_bili_jct').value.trim();
-    const dedeuserid = document.getElementById('f_dedeuserid').value.trim();
-    const buvid3     = document.getElementById('f_buvid3').value.trim();
-
-    if (!sessdata)   { toast('请填写 SESSDATA', 'error'); return; }
-    if (!bili_jct)   { toast('请填写 bili_jct', 'error'); return; }
-    if (!dedeuserid) { toast('请填写 DedeUserID', 'error'); return; }
-
-    const btn = document.getElementById('saveCredBtn');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner"></span> 保存中...';
-    try {
-      const data = await callPlugin('save_credential', { sessdata, bili_jct, dedeuserid, buvid3 });
-      toast(data.message || '✅ 凭据已保存', 'success');
-      updateLoginBadge(true);
-      // 清空输入框（安全考虑）
-      ['f_sessdata','f_bili_jct','f_dedeuserid','f_buvid3'].forEach(id => {
-        document.getElementById(id).value = '';
-        const el = document.getElementById(id);
-        if (el.type === 'text' && id !== 'f_dedeuserid') el.type = 'password';
-      });
-      // 收起面板
-      const panel = document.getElementById('loginPanel');
-      if (panel.style.display !== 'none') toggleLoginPanel();
-      await refreshStatus(true);
-    } catch (e) {
-      toast('保存失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-      btn.textContent = '🔐 加密保存';
-    }
-  });
-
-  document.getElementById('clearCredBtn').addEventListener('click', async () => {
-    if (!confirm('确定要清除 B站凭据并切换为游客模式吗？')) return;
-    const btn = document.getElementById('clearCredBtn');
-    btn.disabled = true;
-    try {
-      const data = await callPlugin('clear_credential', {});
-      toast(data.message || '✅ 凭据已清除', 'success');
-      updateLoginBadge(false);
-      await refreshStatus(true);
-    } catch (e) {
-      toast('清除失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-    }
-  });
-
-  const sleep = ms => new Promise(r => setTimeout(r, ms));
-
-  // ── Toast ────────────────────────────────────────────────
   let toastTimer;
   function toast(msg, type = '') {
     clearTimeout(toastTimer);
-    document.querySelectorAll('.toast').forEach(el => el.remove());
+    document.querySelectorAll('.toast').forEach(e => e.remove());
     const el = document.createElement('div');
     el.className = `toast ${type}`;
     el.textContent = msg;
@@ -690,86 +794,212 @@
     toastTimer = setTimeout(() => el.remove(), 3000);
   }
 
-  // ── 状态渲染 ────────────────────────────────────────────
-  function renderStatus(data) {
-    const bar  = document.getElementById('statusBar');
-    const text = document.getElementById('statusText');
-    const listening   = data.listening;
-    const connecting  = data.connecting;
-    const roomId      = data.room_id || 0;
-    const conn        = data.connection || {};
-
-    bar.className = 'status-bar';
-    if (listening) {
-      bar.classList.add('connected');
-      // 显示连接详情
-      const serverInfo = conn.server ? `  ·  ${conn.server}` : '';
-      const viewerInfo = conn.viewer_count ? `  ·  👁 ${conn.viewer_count.toLocaleString()}` : '';
-      text.textContent = `🟢 正在监听直播间 ${roomId}  ·  ${data.logged_in ? '🔐 已登录' : '👤 游客'}${serverInfo}${viewerInfo}`;
-    } else if (connecting) {
-      bar.classList.add('connecting');
-      text.textContent = `⏳ 正在连接直播间 ${roomId}…`;
-    } else {
-      if (roomId > 0) bar.classList.add('error');
-      text.textContent = roomId > 0
-        ? `🔴 未在监听  ·  直播间 ${roomId}`
-        : '⚙️ 未配置直播间';
-    }
-
-    // 更新统计区
-    const stats = data.stats || {};
-    document.getElementById('statReceived').textContent = stats.received ?? data.received ?? '—';
-    document.getElementById('statFiltered').textContent = stats.filtered ?? data.filtered ?? '—';
-    document.getElementById('statQueue').textContent    = data.queue_size ?? '—';
-
-    // 更新连接详情区（如果存在）
-    const connServer = document.getElementById('connServer');
-    const connViewers = document.getElementById('connViewers');
-    const connState = document.getElementById('connState');
-    if (connServer) connServer.textContent = conn.server || '—';
-    if (connViewers) connViewers.textContent = conn.viewer_count ? conn.viewer_count.toLocaleString() : '—';
-    if (connState) connState.textContent = conn.state_desc || conn.state || '—';
-
-    // 同步直播间输入框（只在空白时填入）
-    const roomInput = document.getElementById('roomIdInput');
-    if (!roomInput.value && roomId > 0) roomInput.value = roomId;
-
-    // 同步登录状态徽章（严格检查 boolean，避免 truthy 误判）
-    updateLoginBadge(data.logged_in === true);
+  function toggleLoginPanel() {
+    const panel = document.getElementById('loginPanel');
+    const text = document.getElementById('loginToggleText');
+    panel.classList.toggle('open');
+    text.textContent = panel.classList.contains('open') ? '点击收起 ▲' : '点击展开 ▼';
   }
 
-  // 渲染静态配置（启动时一次性获取，之后不再覆盖）
-  function renderStaticConfig(data) {
-    // 同步间隔滑块（仅在启动时同步一次，之后由用户自行控制）
+  function toggleReveal(id) {
+    const el = document.getElementById(id);
+    if (el.type === 'password') {
+      el.type = 'text';
+      el.classList.add('show-visible');
+    } else {
+      el.type = 'password';
+      el.classList.remove('show-visible');
+    }
+  }
+
+  function updateLoginBadge(loggedIn) {
+    const badge = document.getElementById('loginBadge');
+    if (loggedIn) {
+      badge.className = 'login-badge logged';
+      badge.textContent = '🔐 已登录';
+    } else {
+      badge.className = 'login-badge guest';
+      badge.textContent = '👤 游客模式';
+    }
+  }
+
+  async function saveCredential() {
+    const sessdata = document.getElementById('f_sessdata').value.trim();
+    const bili_jct = document.getElementById('f_bili_jct').value.trim();
+    const dedeuserid = document.getElementById('f_dedeuserid').value.trim();
+    const buvid3 = document.getElementById('f_buvid3').value.trim();
+
+    if (!sessdata) { toast('请填写 SESSDATA', 'error'); return; }
+    if (!bili_jct) { toast('请填写 bili_jct', 'error'); return; }
+    if (!dedeuserid) { toast('请填写 DedeUserID', 'error'); return; }
+
+    const btn = document.getElementById('saveCredBtn');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner"></span> 保存中...';
+    try {
+      const data = await callPlugin('save_credential', { sessdata, bili_jct, dedeuserid, buvid3 });
+      toast(data.message || '凭据已保存', 'success');
+      updateLoginBadge(true);
+      ['f_sessdata','f_bili_jct','f_dedeuserid','f_buvid3'].forEach(id => {
+        const el = document.getElementById(id);
+        el.value = '';
+        el.type = 'password';
+        el.classList.remove('show-visible');
+      });
+      toggleLoginPanel();
+      await refreshStatus(true);
+    } catch (e) {
+      toast('保存失败：' + e.message, 'error');
+    } finally {
+      btn.disabled = false;
+      btn.innerHTML = '🔐 加密保存';
+    }
+  }
+
+  async function clearCredential() {
+    if (!confirm('确定要清除 B站凭据吗？')) return;
+    const btn = document.getElementById('clearCredBtn');
+    btn.disabled = true;
+    try {
+      const data = await callPlugin('clear_credential', {});
+      toast(data.message || '凭据已清除', 'success');
+      updateLoginBadge(false);
+      await refreshStatus(true);
+    } catch (e) {
+      toast('清除失败：' + e.message, 'error');
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  async function setRoom() {
+    const roomId = parseInt(document.getElementById('roomIdInput').value) || 0;
+    if (!roomId) { toast('请输入直播间 ID', 'error'); return; }
+    try {
+      const data = await callPlugin('set_room_id', { room_id: roomId });
+      toast(data.message || `已切换到房间 ${roomId}`, 'success');
+    } catch (e) {
+      toast('设置失败：' + e.message, 'error');
+    }
+  }
+
+  async function connect() {
+    const btn = document.getElementById('connectBtn');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner"></span>';
+    try {
+      const data = await callPlugin('connect', {});
+      toast(data.message || '已开始监听', 'success');
+      await refreshStatus();
+    } catch (e) {
+      toast('连接失败：' + e.message, 'error');
+    } finally {
+      btn.disabled = false;
+      btn.innerHTML = '▶ 开始监听';
+    }
+  }
+
+  async function disconnect() {
+    const btn = document.getElementById('disconnectBtn');
+    btn.disabled = true;
+    try {
+      const data = await callPlugin('disconnect', {});
+      toast(data.message || '已停止监听', 'success');
+      await refreshStatus();
+    } catch (e) {
+      toast('停止失败：' + e.message, 'error');
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  async function setInterval() {
+    const val = parseInt(document.getElementById('intervalSlider').value);
+    try {
+      const data = await callPlugin('set_interval', { interval: val });
+      toast(data.message || `已设置为 ${val} 秒`, 'success');
+    } catch (e) {
+      toast('设置失败：' + e.message, 'error');
+    }
+  }
+
+  async function setDanmakuMax() {
+    const val = parseInt(document.getElementById('danmakuMaxSlider').value);
+    try {
+      const data = await callPlugin('set_danmaku_max_length', { max_length: val });
+      toast(data.message || `已设置为 ${val}`, 'success');
+    } catch (e) {
+      toast('设置失败：' + e.message, 'error');
+    }
+  }
+
+  async function setTargetLanlan() {
+    const val = document.getElementById('targetLanlanInput').value.trim();
+    try {
+      const data = await callPlugin('set_target_lanlan', { target_lanlan: val });
+      toast(data.message || '已保存', 'success');
+    } catch (e) {
+      toast('设置失败：' + e.message, 'error');
+    }
+  }
+
+  function renderStatus(data) {
+    const dot = document.getElementById('statusDot');
+    const text = document.getElementById('statusText');
+    const sub = document.getElementById('statusSub');
+
+    dot.className = 'status-dot';
+    if (data.listening) {
+      dot.classList.add('connected');
+      text.textContent = `🟢 正在监听房间 ${data.room_id}`;
+      sub.textContent = data.logged_in ? '🔐 已登录模式' : '👤 游客模式';
+    } else if (data.connecting) {
+      dot.classList.add('connecting');
+      text.textContent = `⏳ 正在连接房间 ${data.room_id}...`;
+      sub.textContent = '请稍候';
+    } else {
+      dot.classList.add('error');
+      text.textContent = data.room_id > 0 ? `🔴 未在监听 · 房间 ${data.room_id}` : '⚙️ 未配置直播间';
+      sub.textContent = '请输入房间号并点击开始';
+    }
+
+    document.getElementById('statReceived').textContent = data.stats?.received ?? 0;
+    document.getElementById('statFiltered').textContent = data.stats?.filtered ?? 0;
+    document.getElementById('statQueue').textContent = data.queue_size ?? 0;
+    document.getElementById('statViewers').textContent = data.connection?.viewer_count?.toLocaleString() ?? '—';
+
+    if (data.room_id && !document.getElementById('roomIdInput').value) {
+      document.getElementById('roomIdInput').value = data.room_id;
+    }
     if (data.interval) {
       document.getElementById('intervalSlider').value = data.interval;
       document.getElementById('intervalDisplay').textContent = data.interval + 's';
     }
-    // 同步目标 AI 名称
+    if (data.danmaku_max_length) {
+      document.getElementById('danmakuMaxSlider').value = data.danmaku_max_length;
+      document.getElementById('danmakuMaxDisplay').textContent = data.danmaku_max_length;
+    }
     if (data.target_lanlan !== undefined) {
       document.getElementById('targetLanlanInput').value = data.target_lanlan || '';
     }
-    // 同步弹幕最大长度
-    if (data.danmaku_max_length) {
-      document.getElementById('danmakuMaxLenSlider').value = data.danmaku_max_length;
-      document.getElementById('danmakuMaxLenDisplay').textContent = data.danmaku_max_length;
-    }
+
+    updateLoginBadge(data.logged_in === true);
   }
 
-  // ── 刷新状态 ────────────────────────────────────────────
   async function refreshStatus(silent = false) {
     try {
       const data = await callPlugin('get_status', {});
       renderStatus(data);
     } catch (e) {
-      if (!silent) toast('获取状态失败：' + e.message, 'error');
+      if (!silent) toast('获取状态失败', 'error');
     }
   }
 
-  // ── 弹幕渲染 ────────────────────────────────────────────
   const feed = document.getElementById('danmakuFeed');
   const feedEmpty = document.getElementById('feedEmpty');
   let totalShown = 0;
+
+  function nowTime() { return new Date().toTimeString().slice(0,8); }
 
   function appendItem(html, typeClass) {
     if (feedEmpty.style.display !== 'none') feedEmpty.style.display = 'none';
@@ -778,69 +1008,61 @@
     div.innerHTML = html;
     feed.appendChild(div);
     totalShown++;
-    // 超过 300 条清理旧的
     if (totalShown > 300) {
-      feed.removeChild(feed.querySelector('.danmaku-item'));
+      feed.removeChild(feed.firstElementChild);
       totalShown--;
     }
-    if (document.getElementById('autoScrollCb').checked)
+    if (document.getElementById('autoScrollCb').checked) {
       feed.scrollTop = feed.scrollHeight;
+    }
   }
 
   function addSystemMsg(msg) {
-    appendItem(`<span class="danmaku-meta">${nowTime()}</span>${msg}`, 'type-system');
+    appendItem(`<span class="dm-meta">${nowTime()}</span>${msg}`, 'type-system');
   }
 
-  function nowTime() {
-    return new Date().toTimeString().slice(0,8);
-  }
-
-  function renderDanmakuBatch(data) {
+  function renderBatch(data) {
     (data.superchat || []).forEach(sc => {
       appendItem(
-        `<span class="danmaku-meta">${nowTime()}</span>` +
-        `<span class="danmaku-badge">SC ¥${sc.price}</span>` +
-        `<span class="danmaku-user">${esc(sc.user_name)}</span>` +
-        esc(sc.message),
+        `<span class="dm-meta">${nowTime()}</span>` +
+        `<span class="dm-badge sc">SC ¥${sc.price}</span>` +
+        `<span class="dm-user">${esc(sc.user_name)}</span>${esc(sc.message)}`,
         'type-sc'
       );
     });
     (data.gifts || []).forEach(g => {
       appendItem(
-        `<span class="danmaku-meta">${nowTime()}</span>` +
-        `<span class="danmaku-badge">礼物</span>` +
-        `<span class="danmaku-user">${esc(g.user_name)}</span>` +
-        `送出 ${g.num}个 ${esc(g.gift_name)}` +
-        ((g.price_rmb ?? 0) > 0 ? ` <span style="color:#ffd60a">≈¥${g.price_rmb}</span>` : ''),
+        `<span class="dm-meta">${nowTime()}</span>` +
+        `<span class="dm-badge gift">礼物</span>` +
+        `<span class="dm-user">${esc(g.user_name)}</span>送出 ${g.num}个 ${esc(g.gift_name)}` +
+        (g.price_rmb > 0 ? ` <span style="color:var(--gift)">≈¥${g.price_rmb}</span>` : ''),
         'type-gift'
       );
     });
     (data.danmaku || []).forEach(d => {
-      const medal = d.medal
-        ? `<span class="danmaku-badge">${esc(d.medal)}</span>` : '';
-      const level = d.user_level
-        ? `<span class="danmaku-meta">LV${d.user_level}</span>` : '';
+      const medal = d.medal ? `<span class="dm-badge">${esc(d.medal)}</span>` : '';
+      const level = d.user_level ? `<span class="dm-meta">LV${d.user_level}</span>` : '';
       appendItem(
-        `<span class="danmaku-meta">${d.time || nowTime()}</span>` +
+        `<span class="dm-meta">${d.time || nowTime()}</span>` +
         medal + level +
-        `<span class="danmaku-user">${esc(d.user_name)}</span>` +
-        esc(d.content),
+        `<span class="dm-user">${esc(d.user_name)}</span>${esc(d.content)}`,
         'type-danmaku'
       );
     });
   }
 
   function esc(str) {
-    return String(str || '')
-      .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    return String(str || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
   }
 
-  // ── 弹幕轮询 ────────────────────────────────────────────
+  function clearFeed() {
+    feed.innerHTML = '';
+    totalShown = 0;
+    feedEmpty.style.display = 'block';
+  }
+
   let polling = true;
   let pollActive = false;
-  // 上次 get_danmaku 返回的状态，用于决定下次轮询间隔
-  let _lastListening = false;
-  let _lastConnecting = false;
 
   async function pollDanmaku() {
     if (pollActive) return;
@@ -848,213 +1070,38 @@
     while (polling) {
       try {
         const data = await callPlugin('get_danmaku', { max_count: 20, include_gifts: true });
-        _lastListening  = !!data.listening;
-        _lastConnecting = !!data.connecting;
-
-        // 有弹幕/礼物/SC 就渲染，不依赖 listening 状态
-        const hasDanmaku = (data.danmaku && data.danmaku.length > 0)
-                        || (data.superchat && data.superchat.length > 0)
-                        || (data.gifts && data.gifts.length > 0);
-        if (hasDanmaku) {
-          console.log('[poll] 收到弹幕批次', data.danmaku?.length, '条');
-          renderDanmakuBatch(data);
+        const hasContent = (data.danmaku?.length || data.superchat?.length || data.gifts?.length);
+        if (hasContent) {
+          renderBatch(data);
         }
-        // 只更新实时状态（listening/connecting），不更新静态配置
-        const bar = document.getElementById('statusBar');
-        const text = document.getElementById('statusText');
-        const roomId = data.room_id || 0;
-        const conn = data.connection || {};
-        bar.className = 'status-bar';
-        if (_lastListening) {
-          bar.classList.add('connected');
-          const serverInfo = conn.server ? `  ·  ${conn.server}` : '';
-          const viewerInfo = conn.viewer_count ? `  ·  👁 ${conn.viewer_count.toLocaleString()}` : '';
-          text.textContent = `🟢 正在监听直播间 ${roomId}  ·  ${data.logged_in ? '🔐 已登录' : '👤 游客'}${serverInfo}${viewerInfo}`;
-        } else if (_lastConnecting) {
-          bar.classList.add('connecting');
-          text.textContent = `⏳ 正在连接直播间 ${roomId}…`;
-        } else {
-          if (roomId > 0) bar.classList.add('error');
-          text.textContent = roomId > 0
-            ? `🔴 未在监听  ·  直播间 ${roomId}`
-            : '⚙️ 未配置直播间';
-        }
-        // 更新统计
-        const stats = data.stats || {};
-        document.getElementById('statReceived').textContent = stats.received ?? data.received ?? '—';
-        document.getElementById('statFiltered').textContent = stats.filtered ?? data.filtered ?? '—';
-        document.getElementById('statQueue').textContent    = data.queue_size ?? '—';
-
-        // 更新连接详情
-        const connServer = document.getElementById('connServer');
-        const connViewers = document.getElementById('connViewers');
-        const connState = document.getElementById('connState');
-        if (connServer) connServer.textContent = conn.server || '—';
-        if (connViewers) connViewers.textContent = conn.viewer_count ? conn.viewer_count.toLocaleString() : '—';
-        if (connState) connState.textContent = conn.state_desc || conn.state || '—';
+        renderStatus(data);
       } catch (e) {
-        console.warn('[poll] 轮询出错', e.message);
+        console.warn('[poll]', e.message);
       }
-
-      // 自适应轮询间隔：
-      //   监听中          → 3s（实时性优先）
-      //   正在连接中      → 2s（快速感知连上）
-      //   未监听/未配置   → 10s（没数据也没必要高频）
-      const interval = _lastListening ? 3000 : (_lastConnecting ? 2000 : 10000);
-      await sleep(interval);
+      await sleep(800);
     }
     pollActive = false;
   }
 
-  document.getElementById('pollBtn').addEventListener('click', () => {
+  function togglePoll() {
     polling = !polling;
     const btn = document.getElementById('pollBtn');
-    if (polling) {
-      btn.textContent = '⏸ 暂停轮询';
-      pollDanmaku();
-    } else {
-      btn.textContent = '▶ 恢复轮询';
-    }
-  });
+    btn.textContent = polling ? '⏸ 暂停' : '▶ 继续';
+    if (polling && !pollActive) pollDanmaku();
+  }
 
-  document.getElementById('clearFeedBtn').addEventListener('click', () => {
-    feed.innerHTML = '';
-    feed.appendChild(feedEmpty);
-    feedEmpty.style.display = '';
-    totalShown = 0;
-  });
+  document.addEventListener('DOMContentLoaded', async () => {
+    document.getElementById('intervalSlider').addEventListener('input', e => {
+      document.getElementById('intervalDisplay').textContent = e.target.value + 's';
+    });
+    document.getElementById('danmakuMaxSlider').addEventListener('input', e => {
+      document.getElementById('danmakuMaxDisplay').textContent = e.target.value;
+    });
 
-  // ── 切换直播间 ──────────────────────────────────────────
-  document.getElementById('setRoomBtn').addEventListener('click', async () => {
-    const val = parseInt(document.getElementById('roomIdInput').value);
-    if (!val || val <= 0) { toast('请输入有效的直播间 ID', 'error'); return; }
-    const btn = document.getElementById('setRoomBtn');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner"></span> 切换中...';
-    try {
-      const data = await callPlugin('set_room_id', { room_id: val });
-      toast(data.message || `已切换到直播间 ${val}`, 'success');
-      addSystemMsg(`⚡ 切换直播间 → ${val}`);
-      await refreshStatus(true);
-    } catch (e) {
-      toast('切换失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-      btn.innerHTML = '<span>切换直播间</span>';
-    }
-  });
-
-  // ── 连接/断开 ───────────────────────────────────────────
-  document.getElementById('connectBtn').addEventListener('click', async () => {
-    const roomId = parseInt(document.getElementById('roomIdInput').value) || 0;
-    if (roomId <= 0) { toast('请先填写直播间 ID', 'error'); return; }
-    const btn = document.getElementById('connectBtn');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner"></span> 连接中...';
-    try {
-      const data = await callPlugin('connect', { room_id: roomId });
-      toast(data.message || '连接指令已发送', 'success');
-      addSystemMsg(`🔗 发起连接 → 直播间 ${roomId}`);
-      await refreshStatus(true);
-    } catch (e) {
-      toast('连接失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-      btn.textContent = '🔗 开始监听';
-    }
-  });
-
-  document.getElementById('disconnectBtn').addEventListener('click', async () => {
-    const btn = document.getElementById('disconnectBtn');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner"></span> 停止中...';
-    try {
-      const data = await callPlugin('disconnect', {});
-      toast(data.message || '已停止监听', 'success');
-      addSystemMsg('⏹ 监听已停止');
-      await refreshStatus(true);
-    } catch (e) {
-      toast('操作失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-      btn.textContent = '⏹ 停止监听';
-    }
-  });
-
-  document.getElementById('refreshBtn').addEventListener('click', () => refreshStatus());
-
-  // ── 间隔设置 ────────────────────────────────────────────
-  document.getElementById('intervalSlider').addEventListener('input', e => {
-    document.getElementById('intervalDisplay').textContent = e.target.value + 's';
-  });
-
-  document.getElementById('setIntervalBtn').addEventListener('click', async () => {
-    const val = parseInt(document.getElementById('intervalSlider').value);
-    const btn = document.getElementById('setIntervalBtn');
-    btn.disabled = true;
-    try {
-      const data = await callPlugin('set_interval', { seconds: val });
-      toast(data.message || `间隔已设为 ${val}s`, 'success');
-    } catch (e) {
-      toast('设置失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-    }
-  });
-
-  // 目标 AI 名称设置
-  document.getElementById('setTargetBtn').addEventListener('click', async () => {
-    const val = document.getElementById('targetLanlanInput').value.trim();
-    const btn = document.getElementById('setTargetBtn');
-    btn.disabled = true;
-    try {
-      const data = await callPlugin('set_target_lanlan', { target_lanlan: val });
-      toast(data.message || `目标 AI 已设为 ${val || '(不指定)'}`, 'success');
-    } catch (e) {
-      toast('设置失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-    }
-  });
-
-  // 弹幕最大长度设置
-  document.getElementById('danmakuMaxLenSlider').addEventListener('input', e => {
-    document.getElementById('danmakuMaxLenDisplay').textContent = e.target.value;
-  });
-  document.getElementById('setDanmakuMaxLenBtn').addEventListener('click', async () => {
-    const val = parseInt(document.getElementById('danmakuMaxLenSlider').value);
-    const btn = document.getElementById('setDanmakuMaxLenBtn');
-    btn.disabled = true;
-    try {
-      const data = await callPlugin('set_danmaku_max_length', { max_length: val });
-      toast(data.message || `弹幕最大长度已设为 ${val}`, 'success');
-    } catch (e) {
-      toast('设置失败：' + e.message, 'error');
-    } finally {
-      btn.disabled = false;
-    }
-  });
-
-  // ── 回车快捷键 ──────────────────────────────────────────
-  document.getElementById('roomIdInput').addEventListener('keydown', e => {
-    if (e.key === 'Enter') document.getElementById('setRoomBtn').click();
-  });
-
-  // ── 初始化 ──────────────────────────────────────────────
-  (async () => {
-    // 1. 先获取静态配置（直播间ID、登录状态、推送间隔等），只在启动时获取一次
-    const staticData = await callPlugin('get_status', {});
-    renderStaticConfig(staticData);
-    renderStatus(staticData);
-    // 同步直播间输入框
-    const roomInput = document.getElementById('roomIdInput');
-    if (!roomInput.value && staticData.room_id > 0) {
-      roomInput.value = staticData.room_id;
-    }
-
-    // 2. 启动弹幕轮询（只负责弹幕流和实时状态，不覆盖静态配置）
+    await refreshStatus();
+    addSystemMsg('控制台已就绪');
     pollDanmaku();
-  })();
+  });
 </script>
 </body>
 </html>

--- a/plugin/plugins/bilibili_danmaku/static/index.html
+++ b/plugin/plugins/bilibili_danmaku/static/index.html
@@ -700,7 +700,7 @@
       <div class="slider-row">
         <input type="range" id="intervalSlider" min="5" max="180" value="10" step="5">
         <span class="slider-value" id="intervalDisplay">10s</span>
-        <button class="btn btn-ghost btn-sm" onclick="setInterval()">保存</button>
+        <button class="btn btn-ghost btn-sm" onclick="saveInterval()">保存</button>
       </div>
       <div class="slider-hint">弹幕推送给 AI 的时间间隔，建议 10-30 秒</div>
     </div>
@@ -913,10 +913,10 @@
     }
   }
 
-  async function setInterval() {
+  async function saveInterval() {
     const val = parseInt(document.getElementById('intervalSlider').value);
     try {
-      const data = await callPlugin('set_interval', { interval: val });
+      const data = await callPlugin('set_interval', { seconds: val });
       toast(data.message || `已设置为 ${val} 秒`, 'success');
     } catch (e) {
       toast('设置失败：' + e.message, 'error');

--- a/plugin/plugins/mijia/__init__.py
+++ b/plugin/plugins/mijia/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import re
-import webbrowser
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Optional
 
@@ -42,29 +43,22 @@ class MijiaPlugin(NekoPluginBase):
         self.credential_path = self.data_path("credential.json")
         self.logger.debug(f"凭据路径: {self.credential_path}")
 
-        store = FileCredentialStore(default_path=self.credential_path)
-        # 创建临时 ConfigManager（后续可从插件配置读取）
-        from .mijia_api.core.config import ConfigManager
-        config = ConfigManager()
-        provider = CredentialProvider(config)
-        self.auth_service = AuthService(provider, store)
+        # 检查是否首次启动（data 目录为空）
+        data_dir = self.data_path()
+        is_first_launch = not data_dir.exists() or not any(data_dir.iterdir())
 
-        # 尝试加载已有凭据
-        credential = await self._load_credential()
-        if credential:
-            try:
-                await self._init_api(credential)
-                self.logger.info("米家插件启动成功，已加载已有凭据")
-            except Exception as e:
-                self.logger.error(f"API初始化失败，插件将在未登录状态下运行: {e}")
-                task = asyncio.create_task(self._auto_open_config_page())
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-        else:
-            self.logger.warning("未找到有效凭据，请在Web UI中登录")
+        # 首次启动：立即调度打开浏览器，完全不等待凭据加载
+        if is_first_launch:
+            self.logger.info("首次启动，立即打开配置页面")
             task = asyncio.create_task(self._auto_open_config_page())
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
+        else:
+            # 有数据：后台静默加载凭据，不阻塞启动
+            task = asyncio.create_task(self._background_load_credential())
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+
         # 注册静态UI
         # register_static_ui 接受相对目录名，内部会拼接 self.config_dir / directory
         # static/ 目录下的入口文件为 index.html
@@ -80,14 +74,73 @@ class MijiaPlugin(NekoPluginBase):
                 self.logger.warning("注册静态UI失败，请检查 static/index.html 是否存在")
 
         return Ok({"status": "ready"})
-    
+
+    async def _background_load_credential(self):
+        """后台静默加载凭据，不阻塞插件启动"""
+        try:
+            store = FileCredentialStore(default_path=self.credential_path)
+            from .mijia_api.core.config import ConfigManager
+            config = ConfigManager()
+            provider = CredentialProvider(config)
+            self.auth_service = AuthService(provider, store)
+
+            credential = await self._load_credential()
+            if credential:
+                try:
+                    await self._init_api(credential)
+                    self.logger.info("米家插件启动成功，已加载已有凭据")
+                except Exception as e:
+                    self.logger.error(f"API初始化失败，插件将在未登录状态下运行: {e}")
+            else:
+                self.logger.warning("未找到有效凭据，请在Web UI中登录")
+        except Exception as e:
+            self.logger.error(f"后台加载凭据失败: {e}")
+
     async def _auto_open_config_page(self):
-        """延迟打开浏览器配置页面"""
-        await asyncio.sleep(2)  # 等待主服务器完全启动
-        # 插件 UI 服务器运行在 agent_server 内，默认端口 48916（USER_PLUGIN_SERVER_PORT）
+        """打开浏览器配置页面（立即执行，无延迟）"""
         url = "http://localhost:48916/plugin/mijia/ui/"
-        webbrowser.open(url)
-        self.logger.info(f"已自动打开配置页面: {url}")
+        try:
+            if sys.platform == "win32":
+                subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", url])
+            else:
+                subprocess.Popen(["xdg-open", url])
+            self.logger.info(f"已自动打开配置页面: {url}")
+        except Exception as e:
+            self.logger.warning(f"自动打开配置页面失败: {e}")
+
+    def _ensure_auth_service(self):
+        """懒加载初始化认证服务（供手动入口调用，避免启动时阻塞）"""
+        if self.auth_service:
+            return
+        from .mijia_api.core.config import ConfigManager
+        config = ConfigManager()
+        store = FileCredentialStore(default_path=self.credential_path)
+        provider = CredentialProvider(config)
+        self.auth_service = AuthService(provider, store)
+
+    @plugin_entry(
+        id="open_ui",
+        name="打开配置页面",
+        description="在浏览器中打开米家插件的 Web UI 配置页面",
+        kind="action"
+    )
+    async def open_ui(self, **_):
+        """在浏览器中打开米家配置页面"""
+        url = "http://localhost:48916/plugin/mijia/ui/"
+        try:
+            if sys.platform == "win32":
+                subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", url])
+            else:
+                subprocess.Popen(["xdg-open", url])
+            self.logger.info(f"已在浏览器中打开: {url}")
+            return Ok({"success": True, "url": url, "message": "已在浏览器打开配置页面"})
+        except Exception as e:
+            self.logger.exception("打开配置页面失败")
+            return Err(SdkError(f"打开配置页面失败: {e}"))
 
     @lifecycle(id="shutdown")
     async def on_shutdown(self, **_):
@@ -208,6 +261,7 @@ class MijiaPlugin(NekoPluginBase):
         kind="action"
     )
     async def start_qrcode_login(self, **_):
+        self._ensure_auth_service()
         if not self.auth_service:
             return Err(SdkError("认证服务未初始化"))
         try:
@@ -230,6 +284,7 @@ class MijiaPlugin(NekoPluginBase):
         kind="action"
     )
     async def check_login_status(self, login_url: str, **_):
+        self._ensure_auth_service()
         if not self.auth_service:
             return Err(SdkError("认证服务未初始化"))
         try:
@@ -342,6 +397,7 @@ class MijiaPlugin(NekoPluginBase):
         # 关闭旧 client 再置 None，防止 HttpClient / CacheManager 资源泄漏
         old_api = self.api
         self.api = None
+        self.auth_service = None
         if old_api is not None:
             try:
                 await old_api.close()
@@ -558,6 +614,86 @@ class MijiaPlugin(NekoPluginBase):
         
         # 缓存不存在或刷新，调用 list_devices
         return await self.list_devices(refresh=refresh)
+
+    @plugin_entry(
+        id="list_scenes",
+        name="获取智能场景列表",
+        description="列出当前账号下所有米家智能场景，支持缓存",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "home_id": {"type": "string", "description": "家庭ID，留空自动使用第一个"},
+                "refresh": {"type": "boolean", "description": "是否强制刷新缓存"}
+            },
+            "required": []
+        },
+        llm_result_fields=["message"]
+    )
+    async def list_scenes(self, home_id: str = None, refresh: bool = False, **_):
+        """获取智能场景列表并缓存"""
+        cache_path = self.data_path("scenes_cache.json")
+
+        # 如果不强制刷新，尝试从缓存读取
+        if not refresh and cache_path.exists():
+            try:
+                with open(cache_path, 'r', encoding='utf-8') as f:
+                    cached = json.load(f)
+                cache_home_id = cached.get('home_id')
+                cache_user_id = cached.get('user_id')
+                current_user_id = self.api.credential.user_id if self.api and self.api.credential else None
+                if cache_home_id != home_id or (current_user_id and cache_user_id != current_user_id):
+                    self.logger.warning(
+                        f"场景缓存归属不匹配(user_id: {cache_user_id}→{current_user_id}, "
+                        f"home_id: {cache_home_id}→{home_id})，跳过缓存"
+                    )
+                else:
+                    scenes = cached.get('scenes', [])
+                    self.logger.info(f"AI 从缓存读取场景列表: {len(scenes)} 个场景")
+                    lines = [f"🎬 共有 {len(scenes)} 个智能场景:"]
+                    for s in scenes:
+                        lines.append(f"  • {s.get('name')} (ID: {s.get('id')})")
+                    message = "\n".join(lines)
+                    return Ok({"success": True, "message": message, "scenes": scenes, "from_cache": True, "count": len(scenes)})
+            except Exception as e:
+                self.logger.warning(f"读取场景缓存失败: {e}")
+
+        if not self.api:
+            return Err(SdkError("未登录"))
+
+        # 获取 home_id
+        if not home_id:
+            try:
+                homes = await self.api.get_homes()
+                valid_homes = [h for h in homes if h.id]
+                if not valid_homes:
+                    return Err(SdkError("没有可用的家庭"))
+                home_id = valid_homes[0].id
+            except Exception as e:
+                return Err(SdkError(f"无法获取默认家庭: {e}"))
+
+        try:
+            scenes = await self.api.get_scenes(home_id)
+            result = [{"id": s.get("id"), "name": s.get("name"), "status": s.get("status")} for s in scenes if s.get("id")]
+
+            # 保存缓存
+            try:
+                user_id = self.api.credential.user_id if self.api and self.api.credential else None
+                with open(cache_path, 'w', encoding='utf-8') as f:
+                    json.dump({"scenes": result, "home_id": home_id, "user_id": user_id}, f, ensure_ascii=False, indent=2)
+                self.logger.info(f"场景列表已缓存: {len(result)} 个场景")
+            except Exception as e:
+                self.logger.warning(f"保存场景缓存失败: {e}")
+
+            lines = [f"🎬 共有 {len(result)} 个智能场景:"]
+            for s in result:
+                lines.append(f"  • {s.get('name')} (ID: {s.get('id')})")
+            message = "\n".join(lines)
+            return Ok({"success": True, "message": message, "scenes": result, "from_cache": False, "count": len(result)})
+        except TokenExpiredError:
+            return Err(SdkError("凭据已过期，请重新登录"))
+        except Exception as e:
+            self.logger.exception("获取场景列表失败")
+            return Err(SdkError(f"获取场景列表失败: {e}"))
 
     @plugin_entry(
         id="set_device_alias",

--- a/plugin/plugins/mijia/__init__.py
+++ b/plugin/plugins/mijia/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -199,10 +200,8 @@ class MijiaPlugin(NekoPluginBase):
         self.credential_path.parent.mkdir(parents=True, exist_ok=True)
         self.credential_path.write_text(credential.model_dump_json())
         # 设置文件权限（仅所有者可读写）
-        import sys
         if sys.platform == "win32":
             try:
-                import subprocess
                 username = subprocess.check_output(
                     ["cmd", "/c", "echo", "%USERNAME%"], text=True
                 ).strip()
@@ -381,7 +380,6 @@ class MijiaPlugin(NekoPluginBase):
         # 清空 data 文件夹
         data_dir = self.data_path()
         if data_dir and data_dir.exists():
-            import shutil
             deleted = 0
             for item in data_dir.iterdir():
                 try:
@@ -633,14 +631,15 @@ class MijiaPlugin(NekoPluginBase):
         """获取智能场景列表并缓存"""
         cache_path = self.data_path("scenes_cache.json")
 
-        # 如果不强制刷新，尝试从缓存读取
-        if not refresh and cache_path.exists():
+        # 如果不强制刷新，尝试从缓存读取（必须已登录，防止跨用户缓存泄露）
+        if not refresh and cache_path.exists() and self.api:
             try:
                 with open(cache_path, 'r', encoding='utf-8') as f:
                     cached = json.load(f)
                 cache_home_id = cached.get('home_id')
                 cache_user_id = cached.get('user_id')
-                current_user_id = self.api.credential.user_id if self.api and self.api.credential else None
+                current_user_id = self.api.credential.user_id if self.api.credential else None
+                # 归属不匹配：跳过缓存，继续走网络请求
                 if cache_home_id != home_id or (current_user_id and cache_user_id != current_user_id):
                     self.logger.warning(
                         f"场景缓存归属不匹配(user_id: {cache_user_id}→{current_user_id}, "
@@ -1038,9 +1037,9 @@ class MijiaPlugin(NekoPluginBase):
             "type": "object",
             "properties": {
                 "scene_id": {"type": "string", "description": "场景 ID"},
-                "home_id": {"type": "string", "description": "家庭 ID"}
+                "home_id": {"type": "string", "description": "家庭 ID（可选，留空自动用第一个家庭）"}
             },
-            "required": ["scene_id", "home_id"]
+            "required": ["scene_id"]
         },
         llm_result_fields=["message"]
     )

--- a/plugin/plugins/mijia/__init__.py
+++ b/plugin/plugins/mijia/__init__.py
@@ -7,10 +7,27 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
+from utils.file_utils import atomic_write_json_async, read_json_async
+
 from plugin.sdk.plugin import (
     NekoPluginBase, neko_plugin, plugin_entry, lifecycle, timer_interval,
     Ok, Err, SdkError, get_plugin_logger
 )
+
+
+# ── 同步 helper（避免 async def 内直接调 subprocess 阻塞事件循环）────────────
+def _open_url_in_browser(url: str) -> None:
+    """在默认浏览器打开 URL（同步调用，仅供 asyncio.to_thread 使用）"""
+    try:
+        if sys.platform == "win32":
+            subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", url])
+        else:
+            subprocess.Popen(["xdg-open", url])
+    except Exception:
+        raise   # 抛到调用方统一 catch
+
 
 # 导入内嵌的 mijia_api
 from .mijia_api import create_async_api_client
@@ -101,12 +118,7 @@ class MijiaPlugin(NekoPluginBase):
         """打开浏览器配置页面（立即执行，无延迟）"""
         url = "http://localhost:48916/plugin/mijia/ui/"
         try:
-            if sys.platform == "win32":
-                subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
-            elif sys.platform == "darwin":
-                subprocess.Popen(["open", url])
-            else:
-                subprocess.Popen(["xdg-open", url])
+            await asyncio.to_thread(_open_url_in_browser, url)
             self.logger.info(f"已自动打开配置页面: {url}")
         except Exception as e:
             self.logger.warning(f"自动打开配置页面失败: {e}")
@@ -131,12 +143,7 @@ class MijiaPlugin(NekoPluginBase):
         """在浏览器中打开米家配置页面"""
         url = "http://localhost:48916/plugin/mijia/ui/"
         try:
-            if sys.platform == "win32":
-                subprocess.Popen(["cmd", "/c", "start", "", url], shell=False)
-            elif sys.platform == "darwin":
-                subprocess.Popen(["open", url])
-            else:
-                subprocess.Popen(["xdg-open", url])
+            await asyncio.to_thread(_open_url_in_browser, url)
             self.logger.info(f"已在浏览器中打开: {url}")
             return Ok({"success": True, "url": url, "message": "已在浏览器打开配置页面"})
         except Exception as e:
@@ -178,7 +185,8 @@ class MijiaPlugin(NekoPluginBase):
         if not self.credential_path or not self.credential_path.exists():
             return None
         try:
-            text = self.credential_path.read_text().strip()
+            text = await asyncio.to_thread(self.credential_path.read_text)
+            text = text.strip()
             if not text:
                 # 文件存在但内容为空，视同未登录
                 return None
@@ -197,13 +205,18 @@ class MijiaPlugin(NekoPluginBase):
         """保存凭据到文件,权限600"""
         if not self.credential_path:
             self.credential_path = self.data_path("credential.json")
-        self.credential_path.parent.mkdir(parents=True, exist_ok=True)
-        self.credential_path.write_text(credential.model_dump_json())
+
+        # 确保目录存在（使用 to_thread 避免阻塞）
+        await asyncio.to_thread(self.credential_path.parent.mkdir, parents=True, exist_ok=True)
+
+        # 写入凭据内容
+        await asyncio.to_thread(
+            self.credential_path.write_text, credential.model_dump_json()
+        )
+
         # 设置文件权限（仅所有者可读写）
         if sys.platform == "win32":
             try:
-                import subprocess
-
                 def _apply_windows_acl() -> tuple[int, str]:
                     username = subprocess.check_output(
                         ["cmd", "/c", "echo", "%USERNAME%"], text=True
@@ -227,7 +240,7 @@ class MijiaPlugin(NekoPluginBase):
             except Exception as e:
                 self.logger.warning(f"设置凭据文件权限失败(Windows): {e}")
         else:
-            self.credential_path.chmod(0o600)
+            await asyncio.to_thread(self.credential_path.chmod, 0o600)
         self.logger.info("凭据已保存")
 
     async def _refresh_credential(self, credential: Credential) -> Optional[Credential]:
@@ -381,22 +394,28 @@ class MijiaPlugin(NekoPluginBase):
         """清除本地凭据和数据"""
         # 删除凭据文件
         if self.credential_path and self.credential_path.exists():
-            self.credential_path.unlink()
-        
-        # 清空 data 文件夹
+            await asyncio.to_thread(self.credential_path.unlink)
+
+        # 清空 data 文件夹（使用线程避免阻塞）
         data_dir = self.data_path()
         if data_dir and data_dir.exists():
-            deleted = 0
-            for item in data_dir.iterdir():
-                try:
-                    if item.is_file():
-                        item.unlink()
-                        deleted += 1
-                    elif item.is_dir():
-                        shutil.rmtree(item)
-                        deleted += 1
-                except Exception as e:
-                    self.logger.warning(f"删除数据文件失败 {item}: {e}")
+
+            def _delete_all():
+                deleted = 0
+                for item in data_dir.iterdir():
+                    try:
+                        if item.is_file():
+                            item.unlink()
+                            deleted += 1
+                        elif item.is_dir():
+                            shutil.rmtree(item)
+                            deleted += 1
+                    except Exception as e:
+                        self.logger.warning(f"删除数据文件失败 {item}: {e}")
+                return deleted
+
+            deleted = await asyncio.to_thread(_delete_all)
+            self.logger.debug(f"已删除 {deleted} 个数据文件")
         
         # 关闭旧 client 再置 None，防止 HttpClient / CacheManager 资源泄漏
         old_api = self.api
@@ -458,34 +477,33 @@ class MijiaPlugin(NekoPluginBase):
     async def list_devices(self, home_id: str = None, refresh: bool = False, **_):
         """获取设备列表并缓存"""
         cache_path = self.data_path("devices_cache.json")
-        
-        # 如果不强制刷新，尝试从缓存读取
-        if not refresh and cache_path.exists():
+
+        # 如果不强制刷新，尝试从缓存读取（必须已登录，防止跨用户缓存泄露）
+        if not refresh and cache_path.exists() and self.api:
             try:
-                with open(cache_path, 'r', encoding='utf-8') as f:
-                    cached = json.load(f)
+                cached = await read_json_async(cache_path)
                 # 跨用户/家庭校验，防止缓存泄漏
                 cache_home_id = cached.get('home_id')
                 cache_user_id = cached.get('user_id')
-                current_user_id = self.api.credential.user_id if self.api and self.api.credential else None
-                if cache_home_id != home_id or (current_user_id and cache_user_id != current_user_id):
-                    self.logger.warning(
-                        f"缓存归属不匹配(user_id: {cache_user_id}→{current_user_id}, "
-                        f"home_id: {cache_home_id}→{home_id})，跳过缓存"
-                    )
-                else:
+                current_user_id = self.api.credential.user_id if self.api.credential else None
+                # 归属匹配才返回缓存；不匹配时跳过缓存，继续走网络请求
+                if cache_home_id == home_id and (not current_user_id or cache_user_id == current_user_id):
                     devices = cached.get('devices', [])
                     self.logger.info(f"从缓存读取设备列表: {len(devices)} 个设备")
-                    # 构建友好消息（与网络请求分支保持一致）
                     lines = [f"📱 共有 {len(devices)} 个设备（缓存）:"]
                     for d in devices:
                         status = "🟢" if d.get("is_online") else "🔴"
                         lines.append(f"  {status} {d.get('name')} (型号: {d.get('model')})")
                     message = "\n".join(lines)
                     return Ok({"success": True, "message": message, "devices": devices, "from_cache": True, "count": len(devices)})
+                else:
+                    self.logger.warning(
+                        f"缓存归属不匹配(user_id: {cache_user_id}→{current_user_id}, "
+                        f"home_id: {cache_home_id}→{home_id})，跳过缓存"
+                    )
             except Exception as e:
                 self.logger.warning(f"读取缓存失败: {e}")
-        
+
         if not self.api:
             return Err(SdkError("未登录"))
         
@@ -552,11 +570,15 @@ class MijiaPlugin(NekoPluginBase):
                 
                 result.append(device_info)
             
-            # 保存到缓存
+            # 保存到缓存（使用异步写入避免阻塞）
             try:
                 user_id = self.api.credential.user_id if self.api and self.api.credential else None
-                with open(cache_path, 'w', encoding='utf-8') as f:
-                    json.dump({"devices": result, "home_id": home_id, "user_id": user_id}, f, ensure_ascii=False, indent=2)
+                await atomic_write_json_async(
+                    cache_path,
+                    {"devices": result, "home_id": home_id, "user_id": user_id},
+                    ensure_ascii=False,
+                    indent=2
+                )
                 self.logger.info(f"设备列表已缓存: {len(result)} 个设备")
             except Exception as e:
                 self.logger.warning(f"保存缓存失败: {e}")
@@ -591,31 +613,31 @@ class MijiaPlugin(NekoPluginBase):
     async def get_cached_devices(self, refresh: bool = False, **_):
         """获取缓存的设备列表"""
         cache_path = self.data_path("devices_cache.json")
-        
-        if not refresh and cache_path.exists():
+
+        # 必须已登录才能读缓存，防止跨用户缓存泄露
+        if not refresh and cache_path.exists() and self.api:
             try:
-                with open(cache_path, 'r', encoding='utf-8') as f:
-                    cached = json.load(f)
+                cached = await read_json_async(cache_path)
                 # 跨用户校验，防止缓存泄漏
                 cache_user_id = cached.get('user_id')
-                current_user_id = self.api.credential.user_id if self.api and self.api.credential else None
-                if current_user_id and cache_user_id != current_user_id:
-                    self.logger.warning(
-                        f"缓存归属不匹配(user_id: {cache_user_id}→{current_user_id})，跳过缓存"
-                    )
-                else:
+                current_user_id = self.api.credential.user_id if self.api.credential else None
+                # 归属匹配才返回缓存；不匹配时跳过，继续走网络请求
+                if not current_user_id or cache_user_id == current_user_id:
                     devices = cached.get('devices', [])
                     self.logger.info(f"AI 从缓存读取设备列表: {len(devices)} 个设备")
-                    # 构建友好消息
                     lines = [f"📱 共有 {len(devices)} 个设备:"]
                     for d in devices:
                         status = "🟢" if d.get("is_online") else "🔴"
                         lines.append(f"  {status} {d.get('name')} (型号: {d.get('model')})")
                     message = "\n".join(lines)
                     return Ok({"success": True, "message": message, "devices": devices, "from_cache": True, "count": len(devices)})
+                else:
+                    self.logger.warning(
+                        f"缓存归属不匹配(user_id: {cache_user_id}→{current_user_id})，跳过缓存"
+                    )
             except Exception as e:
                 self.logger.warning(f"读取缓存失败: {e}")
-        
+
         # 缓存不存在或刷新，调用 list_devices
         return await self.list_devices(refresh=refresh)
 
@@ -640,18 +662,12 @@ class MijiaPlugin(NekoPluginBase):
         # 如果不强制刷新，尝试从缓存读取（必须已登录，防止跨用户缓存泄露）
         if not refresh and cache_path.exists() and self.api:
             try:
-                with open(cache_path, 'r', encoding='utf-8') as f:
-                    cached = json.load(f)
+                cached = await read_json_async(cache_path)
                 cache_home_id = cached.get('home_id')
                 cache_user_id = cached.get('user_id')
                 current_user_id = self.api.credential.user_id if self.api.credential else None
                 # 归属不匹配：跳过缓存，继续走网络请求
-                if cache_home_id != home_id or (current_user_id and cache_user_id != current_user_id):
-                    self.logger.warning(
-                        f"场景缓存归属不匹配(user_id: {cache_user_id}→{current_user_id}, "
-                        f"home_id: {cache_home_id}→{home_id})，跳过缓存"
-                    )
-                else:
+                if cache_home_id == home_id and (not current_user_id or cache_user_id == current_user_id):
                     scenes = cached.get('scenes', [])
                     self.logger.info(f"AI 从缓存读取场景列表: {len(scenes)} 个场景")
                     lines = [f"🎬 共有 {len(scenes)} 个智能场景:"]
@@ -659,6 +675,11 @@ class MijiaPlugin(NekoPluginBase):
                         lines.append(f"  • {s.get('name')} (ID: {s.get('id')})")
                     message = "\n".join(lines)
                     return Ok({"success": True, "message": message, "scenes": scenes, "from_cache": True, "count": len(scenes)})
+                else:
+                    self.logger.warning(
+                        f"场景缓存归属不匹配(user_id: {cache_user_id}→{current_user_id}, "
+                        f"home_id: {cache_home_id}→{home_id})，跳过缓存"
+                    )
             except Exception as e:
                 self.logger.warning(f"读取场景缓存失败: {e}")
 
@@ -680,11 +701,15 @@ class MijiaPlugin(NekoPluginBase):
             scenes = await self.api.get_scenes(home_id)
             result = [{"id": s.get("id"), "name": s.get("name"), "status": s.get("status")} for s in scenes if s.get("id")]
 
-            # 保存缓存
+            # 保存缓存（使用异步写入避免阻塞）
             try:
                 user_id = self.api.credential.user_id if self.api and self.api.credential else None
-                with open(cache_path, 'w', encoding='utf-8') as f:
-                    json.dump({"scenes": result, "home_id": home_id, "user_id": user_id}, f, ensure_ascii=False, indent=2)
+                await atomic_write_json_async(
+                    cache_path,
+                    {"scenes": result, "home_id": home_id, "user_id": user_id},
+                    ensure_ascii=False,
+                    indent=2
+                )
                 self.logger.info(f"场景列表已缓存: {len(result)} 个场景")
             except Exception as e:
                 self.logger.warning(f"保存场景缓存失败: {e}")
@@ -721,8 +746,7 @@ class MijiaPlugin(NekoPluginBase):
             return Err(SdkError("设备缓存不存在，请先获取设备列表"))
 
         try:
-            with open(cache_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
+            data = await read_json_async(cache_path)
             devices = data.get("devices", [])
             found = False
             for d in devices:
@@ -739,8 +763,7 @@ class MijiaPlugin(NekoPluginBase):
             if not found:
                 return Err(SdkError(f"未找到 DID 为 {did} 的设备"))
 
-            with open(cache_path, 'w', encoding='utf-8') as f:
-                json.dump(data, f, ensure_ascii=False, indent=2)
+            await atomic_write_json_async(cache_path, data, ensure_ascii=False, indent=2)
 
             return Ok({"success": True, "message": msg, "did": did, "alias": alias.strip() if alias else ""})
         except Exception as e:
@@ -759,8 +782,7 @@ class MijiaPlugin(NekoPluginBase):
             return Ok({"success": True, "aliases": {}, "message": "无缓存数据"})
 
         try:
-            with open(cache_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
+            data = await read_json_async(cache_path)
             devices = data.get("devices", [])
             aliases = {d.get("did"): d.get("alias", "") for d in devices if d.get("alias")}
             lines = [f"📝 共有 {len(aliases)} 个设备别名:"]
@@ -787,7 +809,7 @@ class MijiaPlugin(NekoPluginBase):
     async def find_device_by_name(self, name: str, **_):
         """根据名称查找设备"""
         cache_path = self.data_path("devices_cache.json")
-        
+
         if not cache_path.exists():
             # 缓存不存在，先获取设备列表
             result = await self.list_devices()
@@ -796,8 +818,7 @@ class MijiaPlugin(NekoPluginBase):
             devices = result.value.get('devices', [])
         else:
             try:
-                with open(cache_path, 'r', encoding='utf-8') as f:
-                    cached = json.load(f)
+                cached = await read_json_async(cache_path)
                 devices = cached.get('devices', [])
             except Exception as e:
                 return Err(SdkError(f"读取缓存失败: {e}"))

--- a/plugin/plugins/mijia/__init__.py
+++ b/plugin/plugins/mijia/__init__.py
@@ -202,19 +202,24 @@ class MijiaPlugin(NekoPluginBase):
         # 设置文件权限（仅所有者可读写）
         if sys.platform == "win32":
             try:
-                username = subprocess.check_output(
-                    ["cmd", "/c", "echo", "%USERNAME%"], text=True
-                ).strip()
-                path_str = str(self.credential_path)
-                # 先移除所有继承权限，再授权当前用户完全控制
-                result = subprocess.run(
-                    ["icacls", path_str, "/inheritance:r", "/grant:r", f"{username}:F"],
-                    check=False, capture_output=True, text=True
-                )
-                if result.returncode != 0:
+
+                def _apply_windows_acl() -> tuple[int, str]:
+                    username = subprocess.check_output(
+                        ["cmd", "/c", "echo", "%USERNAME%"], text=True
+                    ).strip()
+                    path_str = str(self.credential_path)
+                    # 先移除所有继承权限，再授权当前用户完全控制
+                    result = subprocess.run(
+                        ["icacls", path_str, "/inheritance:r", "/grant:r", f"{username}:F"],
+                        check=False, capture_output=True, text=True
+                    )
+                    return result.returncode, (result.stderr or "").strip()
+
+                returncode, stderr = await asyncio.to_thread(_apply_windows_acl)
+                if returncode != 0:
                     self.logger.warning(
-                        f"设置凭据文件权限失败(Windows): icacls 返回码 {result.returncode}"
-                        + (f", stderr: {result.stderr.strip()}" if result.stderr.strip() else "")
+                        f"设置凭据文件权限失败(Windows): icacls 返回码 {returncode}"
+                        + (f", stderr: {stderr}" if stderr else "")
                     )
                 else:
                     self.logger.debug("凭据文件权限已设置（仅当前用户）")

--- a/plugin/plugins/mijia/plugin.toml
+++ b/plugin/plugins/mijia/plugin.toml
@@ -6,6 +6,7 @@ short_description = "Control Xiaomi/Mijia smart home devices: lights, AC, sensor
 keywords = ["米家", "(?i)mijia", "小米", "(?i)xiaomi", "智能家居", "(?i)smart.?home", "开灯", "关灯", "空调", "设备", "(?i)device", "灯", "(?i)light", "开关"]
 version = "1.0.0"
 entry = "plugin.plugins.mijia:MijiaPlugin"
+auto_start = false
 
 [plugin.sdk]
 recommended = ">=0.1.0,<0.2.0"

--- a/plugin/plugins/mijia/static/index.html
+++ b/plugin/plugins/mijia/static/index.html
@@ -224,6 +224,32 @@
             flex-wrap: wrap;
             margin-top: 16px;
         }
+        .scene-list {
+            margin-top: 12px;
+        }
+        .scene-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 6px 0;
+            border-bottom: 1px solid #f0f0f0;
+        }
+        .scene-item:last-child {
+            border-bottom: none;
+        }
+        .scene-name {
+            font-weight: 500;
+        }
+        .scene-id {
+            font-size: 0.75rem;
+            color: #8e8e93;
+        }
+        .btn-green {
+            background: #34c759;
+        }
+        .btn-green:hover {
+            background: #248a3d;
+        }
     </style>
 </head>
 <body>
@@ -256,6 +282,15 @@
             <div id="homeList"></div>
             <div id="deviceList" class="device-list"></div>
             <button id="refreshStatusBtn" class="secondary" style="margin-top: 16px;">刷新状态</button>
+        </div>
+
+        <!-- 场景列表区 -->
+        <div class="card" id="sceneCard">
+            <div class="flex-between">
+                <h3>🎬 智能场景</h3>
+                <button id="refreshScenesBtn" class="secondary">刷新场景</button>
+            </div>
+            <div id="sceneList" class="scene-list"></div>
         </div>
     </div>
 </div>
@@ -371,6 +406,8 @@
                 showMessage('❌ 未登录或没有家庭，请先登录', 'error');
                 document.getElementById('userInfo').innerHTML = '';
                 document.getElementById('deviceList').innerHTML = '';
+                // 未登录时自动触发扫码登录
+                startQrLogin();
             }
         } catch (err) {
             console.error(err);
@@ -405,6 +442,12 @@
             document.getElementById('qrDisplay').classList.remove('hidden');
             showMessage('请使用米家APP扫描二维码', 'info');
 
+            // 自动在新标签页打开网页授权页面
+            if (qrData.login_url) {
+                window.open(qrData.login_url, '_blank');
+                showMessage('已自动打开登录页面，请在浏览器中完成授权', 'info');
+            }
+
             // 废弃旧轮询并开启新一轮
             if (pollInterval) clearInterval(pollInterval);
             isPollingInFlight = false;
@@ -428,6 +471,7 @@
                         document.getElementById('qrDisplay').classList.add('hidden');
                         document.getElementById('cancelPollBtn').classList.add('hidden');
                         await loadStatus();
+                        loadScenes();
                     } else if (result.message && result.message.includes('超时')) {
                         clearInterval(pollInterval);
                         pollInterval = null;
@@ -469,6 +513,48 @@
         }
     }
 
+    // 加载场景列表
+    async function loadScenes(refresh = false) {
+        const sceneListEl = document.getElementById('sceneList');
+        sceneListEl.innerHTML = '<span class="loading"></span> 加载中...';
+        try {
+            const result = await callPlugin('list_scenes', { refresh: refresh });
+            const scenes = result.scenes || [];
+            if (scenes.length === 0) {
+                sceneListEl.innerHTML = '<p class="info-text">暂无可用场景</p>';
+                return;
+            }
+            let html = '';
+            scenes.forEach(s => {
+                html += `<div class="scene-item">
+                    <div>
+                        <div class="scene-name">${escapeHtml(s.name || '')}</div>
+                        <div class="scene-id">ID: ${escapeHtml(s.id || '')}</div>
+                    </div>
+                    <button class="btn-green" onclick="executeScene('${escapeHtml(s.id || '')}', '${escapeHtml(s.name || '')}')">执行</button>
+                </div>`;
+            });
+            sceneListEl.innerHTML = html;
+        } catch (err) {
+            sceneListEl.innerHTML = `<p class="info-text" style="color:#ff3b30">加载失败：${escapeHtml(err.message)}</p>`;
+        }
+    }
+
+    // 执行场景
+    async function executeScene(sceneId, sceneName) {
+        try {
+            showMessage(`正在执行「${sceneName}」...`, 'info');
+            const result = await callPlugin('execute_scene', { scene_id: sceneId, home_id: '' });
+            if (result.success) {
+                showMessage(`✅「${sceneName}」执行成功！`, 'success');
+            } else {
+                showMessage(`❌「${sceneName}」执行失败：${result.message || '未知错误'}`, 'error');
+            }
+        } catch (err) {
+            showMessage(`❌ 执行失败：${err.message}`, 'error');
+        }
+    }
+
     // 登出
     async function logout() {
         try {
@@ -477,6 +563,7 @@
             document.getElementById('userInfo').innerHTML = '';
             document.getElementById('deviceList').innerHTML = '';
             document.getElementById('homeList').innerHTML = '';
+            document.getElementById('sceneList').innerHTML = '';
         } catch (err) {
             showMessage(`登出失败：${err.message}`, 'error');
         }
@@ -488,6 +575,7 @@
         document.getElementById('cancelPollBtn').addEventListener('click', stopPolling);
         document.getElementById('logoutBtn').addEventListener('click', logout);
         document.getElementById('refreshStatusBtn').addEventListener('click', loadStatus);
+        document.getElementById('refreshScenesBtn').addEventListener('click', () => loadScenes(true));
         loadStatus();
     });
 </script>

--- a/plugin/plugins/mijia/static/index.html
+++ b/plugin/plugins/mijia/static/index.html
@@ -531,10 +531,18 @@
                         <div class="scene-name">${escapeHtml(s.name || '')}</div>
                         <div class="scene-id">ID: ${escapeHtml(s.id || '')}</div>
                     </div>
-                    <button class="btn-green" onclick="executeScene('${escapeHtml(s.id || '')}', '${escapeHtml(s.name || '')}')">执行</button>
+                    <button class="btn-green scene-exec-btn"
+                        data-scene-id="${escapeHtml(s.id || '')}"
+                        data-scene-name="${escapeHtml(s.name || '')}">执行</button>
                 </div>`;
             });
             sceneListEl.innerHTML = html;
+            // 事件委托，避免 onclick 字符串注入
+            sceneListEl.querySelectorAll('.scene-exec-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    executeScene(btn.dataset.sceneId, btn.dataset.sceneName);
+                });
+            });
         } catch (err) {
             sceneListEl.innerHTML = `<p class="info-text" style="color:#ff3b30">加载失败：${escapeHtml(err.message)}</p>`;
         }


### PR DESCRIPTION
mijia插件
__init__.py | subprocess/sys 替代 webbrowser
__init__.py | on_startup 首次启动立即开浏览器，无延迟
__init__.py | _background_load_credential() 后台静默加载
__init__.py | _ensure_auth_service() 懒加载方法
__init__.py | open_ui AI 入口
__init__.py | list_scenes + scenes_cache.json
__init__.py | logout 重置 auth_service
index.html | 场景列表 UI + loadScenes + executeScene
index.html | 扫码后自动打开 login_url
index.html | 未登录自动触发扫码
index.html | 登录成功后自动加载场景
bilibili插件
- 完整前端重写 ：从暗色主题改为白底主题
- B站配色 ：粉色 #FB7299 + 蓝色 #23ADE5
- 密码框优化 ：等宽字体、字符间距、正确的遮罩效果
- 性能优化 ：CSS 动画硬件加速、弹幕列表自动清理（最多300条）
- UI 细节 ：卡片标题彩带、统计数字样式、按钮 hover 效果、Toast 通知
- 去掉渐变数字和彩带，改为纯粉色
- 背景添加蓝色径向渐变光晕效果
- 所有蓝粉渐变统一改为纯粉色

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 弹幕与米家插件新增“一键打开控制台/Web UI”操作
  * 米家新增场景列表查看、执行与手动刷新缓存

* **样式/界面**
  * 弹幕插件界面全面重设计为浅色主题，布局、移动端与弹幕展示优化
  * 米家新增“智能场景”卡片与场景交互按钮

* **行为/体验**
  * 登录、凭据与后台加载改为非阻塞/异步处理，提升启动与响应
  * 轮询与状态渲染逻辑调整，改为固定间隔与更稳健的状态刷新

* **Chores**
  * 米家插件默认改为手动启动（auto_start=false）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->