### PR TITLE
fix(tts): 引入独立 shutdown sentinel 修复切换角色/重连时 TTS worker 线程泄漏

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -347,9 +347,10 @@ class LLMSessionManager:
         调用方必须已持有 ``self.tts_cache_lock``（与现有 put 调用点一致）。
         对于 ws_bistream 类 provider（qwen / step / cosyvoice），文本碎片直接
         发给服务端处理，跳过 normalizer 以避免 pending_spaces 延迟和 CJK 边界
-        空格删除干扰服务端合成节奏。控制信号（``__interrupt__`` /
-        ``(None, None)``）请继续用 ``tts_request_queue.put`` 直接发送，
-        并在合适时机调用 ``_reset_tts_stream_normalizer``。
+        空格删除干扰服务端合成节奏。控制信号（``__interrupt__`` 打断 /
+        ``(None, None)`` 本轮 utterance 结束-flush / ``("__shutdown__", None)``
+        worker 退出）请继续用 ``tts_request_queue.put`` 直接发送，并在合适
+        时机调用 ``_reset_tts_stream_normalizer``。
         """
         if self._tts_normalize_enabled:
             if speech_id != self._tts_norm_speech_id:
@@ -1027,7 +1028,9 @@ class LLMSessionManager:
 
         if thread_ref and thread_ref.is_alive():
             try:
-                req_queue_ref.put((None, None))
+                # 使用独立的 shutdown sentinel；(None, None) 在 worker 里是
+                # "本轮 utterance 结束、flush 缓冲区"，并不会让 worker 退出。
+                req_queue_ref.put(("__shutdown__", None))
                 await asyncio.to_thread(thread_ref.join, 2.0)
             except Exception as e:
                 logger.error(f"💥 关闭TTS线程时出错: {e}")
@@ -1378,7 +1381,7 @@ class LLMSessionManager:
         if not self.use_tts and self.tts_thread and self.tts_thread.is_alive():
             logger.info("当前模式不需要TTS，关闭TTS线程")
             try:
-                self.tts_request_queue.put((None, None))  # 通知线程退出
+                self.tts_request_queue.put(("__shutdown__", None))  # 通知线程退出
                 self.tts_thread.join(timeout=1.0)  # 等待线程结束
             except Exception as e:
                 logger.error(f"关闭TTS线程时出错: {e}")

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -2078,8 +2078,8 @@ def openai_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
         while True:
             try:
                 sid, _ = request_queue.get()
-                if sid is None:
-                    continue
+                if sid == TTS_SHUTDOWN_SENTINEL:
+                    break
             except Exception:
                 break
         return

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -22,6 +22,12 @@ from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Main")
 
+# 关闭哨兵：core.py 通过 request_queue.put((TTS_SHUTDOWN_SENTINEL, None))
+# 通知 worker 退出主循环。不能复用 (None, None)，因为它已被用作"本轮 utterance
+# 结束、flush/commit 缓冲区"的信号（见 _non_bistream_tts_main_loop、step/qwen
+# worker 的 sid is None 分支）。两种语义必须分开。
+TTS_SHUTDOWN_SENTINEL = "__shutdown__"
+
 
 def _record_tts_telemetry(model_name: str, text: str):
     """Record TTS usage telemetry via TokenTracker."""
@@ -640,6 +646,9 @@ async def _non_bistream_tts_main_loop(
         except Exception:
             break
 
+        if sid == TTS_SHUTDOWN_SENTINEL:
+            break
+
         if sid == "__interrupt__":
             await _cancel_all()
             sentence_buf.clear()
@@ -903,6 +912,9 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 except Exception:
                     break
 
+                if sid == TTS_SHUTDOWN_SENTINEL:
+                    break
+
                 if sid == "__interrupt__":
                     # 打断：立即关闭连接，不发 tts.text.done、不等服务器确认
                     if ws:
@@ -923,7 +935,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     current_speech_id = None
                     text_done_sent = False
                     continue
-                
+
                 if sid is None:
                     # 正常结束（非阻塞）：发送完成信号，但不等待服务器确认、不关闭连接
                     # 音频继续通过 receive_task 流入 response_queue，
@@ -1257,6 +1269,9 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         sid, tts_text = await loop.run_in_executor(None, request_queue.get)
                     except Exception:
                         break
+
+                if sid == TTS_SHUTDOWN_SENTINEL:
+                    break
 
                 if sid == "__interrupt__":
                     # 打断：立即关闭连接，不发 commit、不等服务器确认
@@ -1656,6 +1671,9 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
 
         sid, tts_text = request_queue.get()
 
+        if sid == TTS_SHUTDOWN_SENTINEL:
+            break
+
         if sid == "__interrupt__":
             # 打断：立即静音回调 → 关闭 synthesizer → 清理状态
             # 先 mute 再 close，确保旧 SDK websocket 线程不再往 response_queue 灌数据
@@ -1769,6 +1787,16 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                     last_streaming_call_time = None
                     callback.accepted_speech_id = None
                     callback.reset_bootstrap_state()
+
+    # 收到 TTS_SHUTDOWN_SENTINEL 退出循环后：静音回调并关闭 synthesizer，
+    # 避免 SDK 内部 WebSocket 线程继续往 response_queue 写数据。
+    callback._muted = True
+    if synthesizer is not None:
+        try:
+            synthesizer.close()
+        except Exception:
+            pass
+        synthesizer = None
 
 
 def cogtts_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
@@ -2277,6 +2305,9 @@ def gptsovits_tts_worker(request_queue, response_queue, audio_api_key, voice_id)
                 except Exception:
                     break
 
+                if sid == TTS_SHUTDOWN_SENTINEL:
+                    break
+
                 if sid == "__interrupt__":
                     # 打断：立即关闭连接，不发 end、不等推理完成
                     if _ws_is_open(ws):
@@ -2609,9 +2640,10 @@ def dummy_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
         try:
             # 持续清空队列以避免阻塞，但不做任何处理
             sid, tts_text = request_queue.get()
-            if sid is None:
+            if sid == TTS_SHUTDOWN_SENTINEL:
                 break
-            if sid == "__interrupt__":
+            # sid is None 是 end-of-utterance 信号，dummy 不做任何处理
+            if sid == "__interrupt__" or sid is None:
                 continue
         except Exception as e:
             logger.error(f"Dummy TTS Worker 错误: {e}")
@@ -2753,8 +2785,8 @@ def local_cosyvoice_worker(request_queue, response_queue, audio_api_key, voice_i
         while True:
             try:
                 sid, _ = request_queue.get()
-                if sid is None:
-                    continue
+                if sid == TTS_SHUTDOWN_SENTINEL:
+                    break
             except Exception:
                 break
         return
@@ -2860,6 +2892,9 @@ def local_cosyvoice_worker(request_queue, response_queue, audio_api_key, voice_i
                 sid, tts_text = await loop.run_in_executor(None, request_queue.get)
             except Exception as e:
                 logger.error(f'队列获取异常: {e}')
+                break
+
+            if sid == TTS_SHUTDOWN_SENTINEL:
                 break
 
             if sid == "__interrupt__":

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -1795,6 +1795,9 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         try:
             synthesizer.close()
         except Exception:
+            # best-effort：关闭路径不 raise，与文件内其他 synthesizer.close()
+            # 块保持一致（L1644 / 1683 / 1718 / 1770）。SDK WS 在关闭时通常
+            # 已被服务端回收，异常既常见又不可恢复，log 只会增噪。
             pass
         synthesizer = None
 

--- a/tests/unit/test_minimax_tts_worker.py
+++ b/tests/unit/test_minimax_tts_worker.py
@@ -512,3 +512,98 @@ def test_minimax_worker_incremental_synthesis_on_punctuation(monkeypatch):
     request_queue.close()
     thread.join(timeout=3.0)
     assert not thread.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# Shutdown sentinel regression tests
+#
+# 历史：多进程时代关 worker 靠 process.terminate()，(None, None) 只是附送的
+# 提示。2025-12 改多线程后 .terminate() 被拿掉，但关闭路径没跟着换哨兵，导致
+# worker 把 (None, None) 当 end-of-utterance 处理，thread.join(2.0) 必然超时，
+# 线程泄漏。把 (None, None) 和 ("__shutdown__", None) 的语义钉死在测试里。
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_shutdown_sentinel_exits_minimax_worker(monkeypatch):
+    """minimax (走 _non_bistream_tts_main_loop) 收到 __shutdown__ 应在 2 秒内退出。"""
+    transport = FakeSSETransport(sse_events=[])
+
+    original_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+    thread = threading.Thread(
+        target=tts_client.minimax_tts_worker,
+        args=(request_queue, response_queue, "test-key", "v", "https://api.minimaxi.com"),
+        daemon=True,
+    )
+    thread.start()
+
+    _wait_for_queue_item(response_queue, lambda item: item == ("__ready__", True))
+
+    request_queue.put((tts_client.TTS_SHUTDOWN_SENTINEL, None))
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "worker 未在 2 秒内响应 __shutdown__ 退出"
+
+
+@pytest.mark.unit
+def test_none_none_does_not_exit_minimax_worker(monkeypatch):
+    """(None, None) 是 end-of-utterance flush，不能让 worker 退出。"""
+    transport = FakeSSETransport(sse_events=[])
+
+    original_async_client = httpx.AsyncClient
+
+    def patched_client(*args, **kwargs):
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+    thread = threading.Thread(
+        target=tts_client.minimax_tts_worker,
+        args=(request_queue, response_queue, "test-key", "v", "https://api.minimaxi.com"),
+        daemon=True,
+    )
+    thread.start()
+
+    _wait_for_queue_item(response_queue, lambda item: item == ("__ready__", True))
+
+    request_queue.put((None, None))
+    thread.join(timeout=1.0)
+    assert thread.is_alive(), "(None, None) 是 flush 信号，不应让 worker 退出"
+
+    request_queue.put((tts_client.TTS_SHUTDOWN_SENTINEL, None))
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+
+
+@pytest.mark.unit
+def test_shutdown_sentinel_exits_dummy_worker():
+    """dummy worker：(None, None) continue；__shutdown__ 才退出。"""
+    request_queue = queue.Queue()
+    response_queue = queue.Queue()
+    thread = threading.Thread(
+        target=tts_client.dummy_tts_worker,
+        args=(request_queue, response_queue, "k", "v"),
+        daemon=True,
+    )
+    thread.start()
+
+    _wait_for_queue_item(response_queue, lambda item: item == ("__ready__", True))
+
+    request_queue.put((None, None))
+    thread.join(timeout=0.5)
+    assert thread.is_alive(), "dummy (None, None) 不应退出"
+
+    request_queue.put((tts_client.TTS_SHUTDOWN_SENTINEL, None))
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary
- `core.py` teardown 用 `(None, None)` 当 shutdown 哨兵，但 7 个 worker 都把它当 end-of-utterance flush 信号 → `continue` 回到阻塞 → `thread.join(2.0)` 必然超时 → 触发 `⚠️ TTS worker 未在超时内退出`，worker 引用被清但线程仍在跑，ws/resampler/http client 一并泄漏
- 历史：2025-12 多进程改多线程时删掉 `process.terminate()`，哨兵成了唯一关闭机制但 worker 端没跟着改，bug 潜伏约 4 个月，直到 2026-04 加了超时警告才可见
- 修：新增 `TTS_SHUTDOWN_SENTINEL = "__shutdown__"`，core.py 两处 teardown 改送它，所有 worker 主循环在 `__interrupt__` 之前识别它并 `break`；`(None, None)` 的 flush 语义完全保留

## 改动范围
- `main_logic/tts_client.py`：新增常量；修改 `_non_bistream_tts_main_loop`（覆盖 cogtts/gemini/openai/minimax）/ `step_realtime` / `qwen_realtime` / `cosyvoice_vc` / `gptsovits` / `dummy` / `local_cosyvoice`（主循环 + URL 无效兜底）；`cosyvoice_vc` 额外补循环后 `synthesizer.close()` 清理（之前没有）
- `main_logic/core.py`：`_teardown_tts_runtime` (L1030) 和 `use_tts=False` 早关路径 (L1381) 发送新哨兵；其他 3 处 `(None, None)` 的 end-of-utterance 不动
- `tests/unit/test_minimax_tts_worker.py`：3 个回归 test 钉死两种信号的语义

## Test plan
- [x] `uv run pytest tests/unit/test_minimax_tts_worker.py tests/unit/test_tts_stream_normalizer.py` → 62 passed
- [x] 新增 3 个回归 test：`__shutdown__` 必须让 worker 在 2s 内退出；`(None, None)` 必须保持 worker 活着（flush 语义）
- [ ] 人工验证切换猫娘、WS 重连时 Main 日志不再出现"TTS worker 未在超时内退出"警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 引入独立的终止标志以区分单次话语的结束与整个 TTS 工作线程的关闭，避免将话语结束误判为线程退出。
  * 优化流式/连接关闭流程：在终止时静默回调并尽量关闭合成器，防止后台线程在关闭后继续入队音频。
  * 调整各类 TTS 工作流对终止信号的处理，使关闭路径更明确可靠。

* **Tests**
  * 新增单元测试，验证“话语结束”与“终止标志”两种信号下的不同线程行为与超时/保活要求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->