### PR TITLE
fix: 切换猫娘后 session 无法恢复（greeting 静默失败 + WebSocket 双重重连）

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2331,7 +2331,7 @@ class LLMSessionManager:
 
     def _is_voice_session_active_or_starting(self) -> bool:
         """语音 session 正在启动或已经活跃时返回 True，用于阻止 greeting 干扰语音流。"""
-        if self.is_starting_session and self.input_mode == 'audio':
+        if self._starting_session_count > 0 and self.input_mode == 'audio':
             return True
         if self.is_active and self.input_mode == 'audio':
             return True

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -345,6 +345,11 @@
 
             if (S.socket && S.socket.readyState === WebSocket.CONNECTING) {
                 attachOpenListener(S.socket);
+            } else if (S.isSwitchingCatgirl) {
+                // 切换期间 handleCatgirlSwitch 独家负责新建 socket（close → sleep → connect）。
+                // 如果这里也发起 connectWebSocket，会和 handleCatgirlSwitch 的 connect 双重重连：
+                // 前一个新 socket 被后一个覆盖变成孤儿，polling 被迫重绑，5s 超时即报
+                // "WebSocket not connected"。改为仅靠下面的 polling 等新 socket 就位。
             } else {
                 // socket does not exist or CLOSED/CLOSING -> rebuild
                 if (S.autoReconnectTimeoutId) {


### PR DESCRIPTION
## 问题

切换猫娘（`POST /api/current_catgirl`）完成、用户立即点击聊天时，前端报：
- 文本聊天：`WebSocket not connected`
- 语音聊天：`Session failed to start`

排查发现这是两个独立 bug 在同一场景下被连锁触发。

## 两处修复

### 1. 后端：`_is_voice_session_active_or_starting` 引用不存在的属性

[main_logic/core.py:2334](main_logic/core.py#L2334)

```python
# 改前
if self.is_starting_session and self.input_mode == 'audio':
# 改后
if self._starting_session_count > 0 and self.input_mode == 'audio':
```

`LLMSessionManager` 只有 `_starting_session_count`（计数器，见 [core.py:274](main_logic/core.py#L274)），没有 `is_starting_session`（布尔）。这是 guard 从布尔重构成计数器（#811 及后续）时漏改的一处。

**后果**：`trigger_greeting` 在 5 处 await 前后调用这个函数，第一次调用即抛 `AttributeError`，被 `_fire_task` 静默吞掉——greeting 永远发不出，表现为「切换后的自动搭话不触发」。

### 2. 前端：`ensureWebSocketOpen` 在切换期间双重重连

[static/app-websocket.js:346](static/app-websocket.js#L346)

`handleCatgirlSwitch` 的 WebSocket 重建流程（[app-character.js:452-459](static/app-character.js#L452)）：

```js
if (S.socket) S.socket.close();          // 旧 socket → CLOSING
await new Promise(r => setTimeout(r, 100));
connectWebSocket();                       // 100ms 后才建新 socket
```

这 100ms 窗口里若用户点击发送：
1. `ensureWebSocketOpen` 见到 `S.socket` 处于 CLOSING → 自行调 `connectWebSocket()` 建新 socket A
2. `handleCatgirlSwitch` 紧接着又调 `connectWebSocket()` → `S.socket` 被替换成 socket B，socket A 变孤儿
3. `ensureWebSocketOpen` 的 polling 反复重绑到新 `S.socket`，5s 内若 socket B 未完成握手 → 抛 `WebSocket not connected`

**修复**：切换期间（`S.isSwitchingCatgirl === true`）由 `handleCatgirlSwitch` 独家建 socket，`ensureWebSocketOpen` 不再自行 connect，只靠下方 polling 等新 socket 就位。

## 关联但未在本 PR 处理

- **语音聊天 `Session failed to start`**：原先推测是「greeting 自动拉起 text session 抢跑」，但 bug 1 证明 greeting 实际是死的，那条推论不成立。修完本 PR 后需重测复现，再抓后端完整 stack trace 判断根因（memory server 探活？realtime connect？）。不在本 PR 范围。
- #833（并发孤儿 session） / #837（guard 生命周期泄漏）：与本 PR 同一函数但不同修复主题，独立处理。

## Test plan

- [x] `uv run python -c "import ast; ast.parse(open('main_logic/core.py', encoding='utf-8').read())"` 通过
- [x] `uv run ruff check main_logic/core.py` 通过
- [x] `node -c static/app-websocket.js` 通过
- [ ] 手测：切换猫娘后立即点发送，文本聊天不再报 `WebSocket not connected`
- [ ] 手测：切换后等待 ≥15min gap，观察是否触发 greeting（验证 bug 1 修复）
- [ ] 手测：切换后立即点麦 → 观察 `Session failed to start` 是否仍复现，若仍复现则进一步定位

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了语音会话模式的判断逻辑，确保正确识别语音会话状态。
  * 优化了切换操作期间的连接管理，防止不必要的重新连接尝试，提升稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->