### PR TITLE
fix(proactive): guard 覆盖 turn-start 到首音频 chunk 的空窗

### DIFF
--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -256,10 +256,15 @@
     // 并继续按固定间隔 poll（见下面 scheduleProactiveChat 的两处 speaking 分支）。
     // S.isPlaying：audio chunks 入队到 drain 完这段期间为 true；
     // S.assistantSpeechActiveTurnId：active turn 有音频在跑时非空。
-    // 两者任一为真都视为在播，避免打断自己。
+    // assistantTurnId !== assistantTurnCompletedId：后端已发 turn-start
+    // 但还没发 turn-end —— 覆盖"文字已开始流、首个音频 chunk 还没解码"的空窗，
+    // 防止 proactive 在这段窗口里切入、让猫娘打断自己。
     function _isAssistantSpeaking() {
         try {
-            return !!(S && (S.isPlaying || S.assistantSpeechActiveTurnId));
+            if (!S) return false;
+            if (S.isPlaying || S.assistantSpeechActiveTurnId) return true;
+            if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
+            return false;
         } catch (_) {
             return false;
         }


### PR DESCRIPTION
## Summary

- 语音会话里有 bug：文本刚开始流、首个音频 chunk 还没解码的几百毫秒空窗里，proactive timer 恰好到点就会切入，模拟用户输入触发 Gemini \`interrupted by user\`，把猫娘自己打断。
- 修复：把 \`_isAssistantSpeaking()\` 扩成三段覆盖，补上"后端发过 turn-start 但还没发 turn-end"这一条。
- 语音 [static/app-proactive.js:361](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/charming-johnson-4aa044/static/app-proactive.js#L361) 和文本 [:471](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/charming-johnson-4aa044/static/app-proactive.js#L471) 两处调用点自动受益。

## 根因分析

原 guard 只看两个信号：
- \`S.isPlaying\` — 首个 PCM chunk 入队时才置 true（[app-audio-playback.js:844](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-audio-playback.js#L844)）
- \`S.assistantSpeechActiveTurnId\` — 首个 source scheduled 时才置值（[:685](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-audio-playback.js#L685)）

但 Gemini 一旦 \`has_ai_content\` 就发 \`isNewMessage=true\` 的 \`gemini_response\`，此时 \`S.assistantTurnId\` 已 set（[app-websocket.js:515-524](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-websocket.js#L515)），但音频 blob 要晚几百毫秒才到。这段空窗里 guard 漏掉。

新增条件 \`assistantTurnId && assistantTurnId !== assistantTurnCompletedId\` 利用已有 state：
- \`assistantTurnCompletedId\` 在后端 \`turn_end\` event 时被置为当前 turnId（[app-audio-playback.js:470](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-audio-playback.js#L470)）
- 两者不等 ⇔ turn 已开始、后端还没发 end，正好是要补的窗口

## Test plan

- [ ] 开语音会话，静候 proactive 自动触发 → 正常 drain、不干扰
- [ ] proactive 触发后猫娘回复期间，确认不会出现自己打断自己的情况（日志不再出现成对的 \`prompt_ephemeral: aborted\` + \`Gemini response was interrupted by user\`）
- [ ] 主动切断（用户说话）打断猫娘的路径依然正常工作
- [ ] 文本模式下 proactive 触发依然能正常走 backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  - 改进了语音助手状态检测逻辑，更准确地识别助手发言时段，包括内部状态过渡期间的情况，确保交互体验更加流畅。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->