### PR TITLE
fix(main_server): 避免 initialize_character_data 里同步 Thread.join 阻塞 event loop

### DIFF
--- a/main_server.py
+++ b/main_server.py
@@ -543,7 +543,7 @@ async def initialize_character_data():
             # 线程已停止，需要重启
             need_start_thread = True
             try:
-                sync_process[k].join(timeout=0.1)
+                await asyncio.to_thread(sync_process[k].join, timeout=0.1)
             except: # noqa: E722
                 pass
         
@@ -593,7 +593,7 @@ async def initialize_character_data():
                 logger.info(f"正在停止已删除角色 {k} 的同步连接器线程...")
                 if k in sync_shutdown_event:
                     sync_shutdown_event[k].set()
-                sync_process[k].join(timeout=3)  # 等待线程正常结束
+                await asyncio.to_thread(sync_process[k].join, timeout=3)  # 等待线程正常结束
                 if sync_process[k].is_alive():
                     logger.warning(f"⚠️ 同步连接器线程 {k} 未能在超时内停止，将作为daemon线程自动清理")
                 else:

--- a/main_server.py
+++ b/main_server.py
@@ -544,7 +544,9 @@ async def initialize_character_data():
             need_start_thread = True
             try:
                 await asyncio.to_thread(sync_process[k].join, timeout=0.1)
-            except: # noqa: E722
+            except Exception:
+                # 注意不要写成 bare except：to_thread 是 cancellation point，
+                # 如果 catch 了 BaseException 会吞掉 asyncio.CancelledError
                 pass
         
         if need_start_thread:


### PR DESCRIPTION
## 背景

主服务跑在 FastAPI + asyncio 单事件循环上，前端通过 WebSocket 心跳监控连通性。**只要 event loop 卡住几百毫秒，心跳就会超时，前端立刻报 "WebSocket not connected"**。因此后端策略是：在 async 路径上**禁止任何阻塞调用，连 25ms 都不行**。

近期日志里抓到一次 `end_session` 清理时 event loop 停顿约 1s（`response.done` → `session_end analyze` 之间 17 行日志被压在同一秒内）。根因排查正在分头进行，本 PR 只处理两处最显眼的同步阻塞。

## 问题

`async def initialize_character_data()` 里有两处对 `threading.Thread` 的同步 `.join(timeout=...)`：

| 位置 | 调用 | 最坏阻塞 | 触发频率 |
| --- | --- | --- | --- |
| `main_server.py:546` | `sync_process[k].join(timeout=0.1)` | 100ms × 死线程数 | 启动 / 改名 / 新增 / 删除 角色时 |
| `main_server.py:596` | `sync_process[k].join(timeout=3)` | **3s × 删除的角色数** | 删除 catgirl 时 |

第二处尤其致命：用户删一个 catgirl，整个 event loop 最长被掐 3 秒，期间 WebSocket 心跳全断。

## 修复

两处都改成

```python
await asyncio.to_thread(sync_process[k].join, timeout=...)
```

把阻塞的 `Thread.join` 扔到默认 executor 线程池里执行，event loop 在等待期间继续转。语义上完全一致：`Thread.join` 本身是线程安全的，只是从调用线程换成 executor 线程而已，超时行为、`is_alive()` 后续判断都不变。

文件中其余 `.join(...)` 都是 `os.path.join`，与本次修复无关。

## Test plan

- [x] `uv run python -c "import ast; ast.parse(open('main_server.py', encoding='utf-8').read())"` 通过
- [x] `uv run ruff check main_server.py` —— 无新增告警（已有的 2 个 F401 在 1294/1295 行，与本 PR 无关，是 main 上既有问题）
- [x] diff 仅 2 行改动，最小变更
- [ ] **手动验证未执行**：当前环境无法启动完整前端 + 后端联调，未能实测"删除 catgirl 时 WebSocket ping-pong 不中断"。建议合并前在本地复现：删除一个 catgirl，观察前端 WebSocket 状态在同步线程退出全过程中保持 connected
- [ ] 角色启动 / 改名 / 新增 / 删除 流程功能性回归（至少各跑一次确认线程仍能正常重启与停止）

## 范围

仅修这两处 `Thread.join`。`main_server.py` 里其他可能阻塞的同步调用按任务说明走单独 PR，不在本 PR 处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在等待线程结束时可能阻塞事件循环的问题：将同步阻塞等待替换为异步非阻塞的等待方式，避免在清理或重启线程时造成应用响应变慢或卡顿，并收窄了异常处理范围以更明确地处理异常与取消情形，从而提升稳定性与性能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->