### PR TITLE
chore: 引入 async def 同步阻塞静态检查 + 修复存量违规

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,0 +1,38 @@
+name: Analyze
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  python-lint:
+    name: Python lint (ruff + async-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install ruff
+        # ruff is the only dev dep we need for the lint job; a full uv sync
+        # pulls heavy native extensions (playwright, numpy, etc.) that are
+        # unnecessary for static checks.
+        run: uv tool install ruff==0.15.4
+
+      - name: ruff check (incl. ASYNC210/220/221/222/251)
+        run: ruff check .
+
+      - name: Forbid blocking calls in async def bodies
+        # Custom AST checker — covers the gaps flake8-async doesn't:
+        # Thread/Process.join, queue.Queue.get, raw socket recv/accept/connect.
+        run: python scripts/check_async_blocking.py

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Static-check job only needs to read the checked-out source.
+permissions:
+  contents: read
+
 jobs:
   python-lint:
     name: Python lint (ruff + async-blocking)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1450,7 +1450,7 @@ class LLMSessionManager:
                 logger.info("当前模式不需要TTS，关闭TTS线程")
                 try:
                     self.tts_request_queue.put(("__shutdown__", None))  # 通知线程退出
-                    self.tts_thread.join(timeout=1.0)  # 等待线程结束
+                    await asyncio.to_thread(self.tts_thread.join, 1.0)  # 等待线程结束
                 except Exception as e:
                     logger.error(f"关闭TTS线程时出错: {e}")
                 finally:

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -13,6 +13,7 @@ import asyncio
 import time
 import pickle
 import aiohttp
+from queue import Empty
 from config import MONITOR_SERVER_PORT, MEMORY_SERVER_PORT, COMMENTER_SERVER_PORT
 from datetime import datetime
 import json
@@ -173,7 +174,7 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
                 while not message_queue.empty():
                     try:
                         message = message_queue.get_nowait()
-                    except Exception:
+                    except Empty:
                         break
 
                     if message["type"] == "json":

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -171,7 +171,10 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
             try:
                 # 检查消息队列
                 while not message_queue.empty():
-                    message = message_queue.get()
+                    try:
+                        message = message_queue.get_nowait()
+                    except Exception:
+                        break
 
                     if message["type"] == "json":
                         # Forward to monitor if enabled

--- a/plugin/plugins/mijia/__init__.py
+++ b/plugin/plugins/mijia/__init__.py
@@ -150,19 +150,24 @@ class MijiaPlugin(NekoPluginBase):
         if sys.platform == "win32":
             try:
                 import subprocess
-                username = subprocess.check_output(
-                    ["cmd", "/c", "echo", "%USERNAME%"], text=True
-                ).strip()
-                path_str = str(self.credential_path)
-                # 先移除所有继承权限，再授权当前用户完全控制
-                result = subprocess.run(
-                    ["icacls", path_str, "/inheritance:r", "/grant:r", f"{username}:F"],
-                    check=False, capture_output=True, text=True
-                )
-                if result.returncode != 0:
+
+                def _apply_windows_acl() -> tuple[int, str]:
+                    username = subprocess.check_output(
+                        ["cmd", "/c", "echo", "%USERNAME%"], text=True
+                    ).strip()
+                    path_str = str(self.credential_path)
+                    # 先移除所有继承权限，再授权当前用户完全控制
+                    result = subprocess.run(
+                        ["icacls", path_str, "/inheritance:r", "/grant:r", f"{username}:F"],
+                        check=False, capture_output=True, text=True
+                    )
+                    return result.returncode, (result.stderr or "").strip()
+
+                returncode, stderr = await asyncio.to_thread(_apply_windows_acl)
+                if returncode != 0:
                     self.logger.warning(
-                        f"设置凭据文件权限失败(Windows): icacls 返回码 {result.returncode}"
-                        + (f", stderr: {result.stderr.strip()}" if result.stderr.strip() else "")
+                        f"设置凭据文件权限失败(Windows): icacls 返回码 {returncode}"
+                        + (f", stderr: {stderr}" if stderr else "")
                     )
                 else:
                     self.logger.debug("凭据文件权限已设置（仅当前用户）")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,27 @@ dev = [
     "ruff>=0.15.4",
 ]
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Ruff: enforce zero-blocking-call policy in async def bodies.
+# Covers: time.sleep / requests / urllib.request / subprocess.* (run, Popen…).
+# Gaps (threading.Thread.join timeout, queue.Queue.get, threading.Event.wait
+# timeout, raw socket.recv/send/accept/connect) are caught by the companion
+# script scripts/check_async_blocking.py which the CI Analyze job also runs.
+# ─────────────────────────────────────────────────────────────────────────────
+[tool.ruff]
+target-version = "py311"
+extend-exclude = [
+  "frontend",
+  "dist",
+  ".venv",
+]
+
+[tool.ruff.lint]
+select = [
+  "ASYNC210",  # blocking HTTP call (requests / urllib / httpx.Client)
+  "ASYNC220",  # create-subprocess (Popen) in async function
+  "ASYNC221",  # subprocess.run / call / check_output / check_call
+  "ASYNC222",  # Popen.wait / Popen.communicate
+  "ASYNC251",  # time.sleep in async function
+]
+

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -45,6 +45,13 @@ DEFAULT_PATHS = [
     "main_routers",
     "utils",
 ]
+# NOTE: ``plugin/`` is intentionally NOT in the default scope. Plugin code uses
+# pyzmq sockets (``sock.connect`` / ``sock.recv`` via async zmq) and
+# ``asyncio.Queue`` heavily, both of which match the tail-name heuristics here
+# and produce a high false-positive rate (``await sock.recv`` on zmq,
+# ``await asyncio.wait_for(q.get(), …)`` on asyncio.Queue). Ruff's ASYNC*
+# rules still cover plugin code via pyproject.toml. A follow-up can
+# type-disambiguate queue/socket kinds and bring plugin into scope.
 
 CODE = "ASYNC_BLOCK"
 NOQA_TOKEN = "noqa: ASYNC_BLOCK"

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Static check: forbid blocking stdlib calls inside ``async def`` bodies.
+
+Complements ruff's ASYNC210/220/221/222/251 rules by catching gaps the
+flake8-async port does not cover:
+
+* ``threading.Thread.join(timeout=...)`` / ``multiprocessing.Process.join(...)``
+* ``queue.Queue.get(...)`` (blocks by default)
+* Raw ``socket.recv`` / ``accept`` / ``connect`` on blocking sockets
+
+Heuristic: the analyzer only inspects statements whose **nearest enclosing
+function is ``async def``**. A nested sync ``def`` (a common pattern for
+thread targets, ``run_in_executor`` callbacks, etc.) masks the outer async
+context — its body is NOT inspected. This matches ruff's behaviour and
+avoids false positives on dedicated worker code.
+
+Receiver matching uses the *tail name* (rightmost component) of the call
+receiver. That lets us tell ``self.q.get()`` (flagged, queue-like) apart
+from ``self.ws.send()`` (not flagged, websocket). Names that are too
+generic (``send``, ``put``, ``wait``) are not checked here — they hit
+httpx / websockets / asyncio.Event far more often than real blocking
+stdlib objects, so the noise is not worth the signal.
+
+Every violation prints as ``path:line:col  CODE  message``. Exit status
+is 1 when any violation is found, 0 otherwise.
+
+Suppress a specific line with ``# noqa: ASYNC_BLOCK`` — please follow it
+with a one-line justification (reviewed manually).
+
+Usage:
+    python scripts/check_async_blocking.py [paths...]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PATHS = [
+    "main_server.py",
+    "main_logic",
+    "main_routers",
+    "utils",
+]
+
+CODE = "ASYNC_BLOCK"
+NOQA_TOKEN = "noqa: ASYNC_BLOCK"
+
+# Receiver tail-name filters. A call matches if the rightmost identifier
+# component of the receiver (see _tail_name) equals one of the EXACT names
+# or ends with one of the SUFFIX tokens. Tight enough to avoid httpx /
+# websockets / zmq-socket false positives while still catching realistic
+# names like ``tts_thread`` / ``request_queue`` / ``tts_sock``.
+QUEUE_EXACT = {"q", "queue", "queues"}
+QUEUE_SUFFIX = ("_q", "_queue")
+
+THREAD_EXACT = {"t", "thread", "worker", "proc", "process"}
+THREAD_SUFFIX = ("_thread", "_process", "_proc", "_worker")
+
+SOCKET_EXACT = {"sock", "socket"}
+SOCKET_SUFFIX = ("_sock", "_socket")
+
+
+def _tail_matches(tail: str, exact: set[str], suffix: tuple[str, ...]) -> bool:
+    if not tail:
+        return False
+    lowered = tail.lower()
+    if lowered in exact:
+        return True
+    return any(lowered.endswith(s) for s in suffix)
+
+
+def _tail_name(node: ast.expr) -> str:
+    """Return the rightmost identifier component of an expression.
+
+    ``x.y.z`` → ``"z"``; ``x`` → ``"x"``; anything more complex → ``""``.
+    """
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Call):
+        return _tail_name(node.func)
+    if isinstance(node, ast.Subscript):
+        return _tail_name(node.value)
+    return ""
+
+
+class AsyncBlockingChecker(ast.NodeVisitor):
+    def __init__(self, path: Path, source: str) -> None:
+        self.path = path
+        self.source_lines = source.splitlines()
+        # Stack of "async" / "sync" — nearest function kind.
+        self._func_stack: list[str] = []
+        self.violations: list[tuple[int, int, str]] = []
+
+    # ── function tracking ────────────────────────────────────────────────
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._func_stack.append("async")
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._func_stack.append("sync")
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._func_stack.append("sync")
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    # ── helpers ─────────────────────────────────────────────────────────
+    def _in_async_context(self) -> bool:
+        return bool(self._func_stack) and self._func_stack[-1] == "async"
+
+    def _line_has_noqa(self, lineno: int) -> bool:
+        if 1 <= lineno <= len(self.source_lines):
+            return NOQA_TOKEN in self.source_lines[lineno - 1]
+        return False
+
+    def _flag(self, node: ast.AST, message: str) -> None:
+        lineno = getattr(node, "lineno", 0)
+        col = getattr(node, "col_offset", 0) + 1
+        if self._line_has_noqa(lineno):
+            return
+        self.violations.append((lineno, col, message))
+
+    # ── the actual checks ────────────────────────────────────────────────
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._in_async_context() and isinstance(node.func, ast.Attribute):
+            self._check_attribute_call(node)
+        self.generic_visit(node)
+
+    def _check_attribute_call(self, call: ast.Call) -> None:
+        attr = call.func.attr  # type: ignore[union-attr]
+        receiver = call.func.value  # type: ignore[union-attr]
+        tail = _tail_name(receiver)
+        if not tail:
+            return
+
+        if attr == "get" and _tail_matches(tail, QUEUE_EXACT, QUEUE_SUFFIX) and self._queue_get_is_blocking(call):
+            self._flag(
+                call,
+                "queue.Queue.get() blocks the event loop; use asyncio.Queue "
+                "or `await asyncio.to_thread(q.get, ...)`.",
+            )
+            return
+
+        if attr == "join" and _tail_matches(tail, THREAD_EXACT, THREAD_SUFFIX):
+            self._flag(
+                call,
+                "Thread/Process.join() blocks the event loop; use "
+                "`await asyncio.to_thread(t.join, timeout)`.",
+            )
+            return
+
+        if _tail_matches(tail, SOCKET_EXACT, SOCKET_SUFFIX):
+            if attr == "recv":
+                self._flag(
+                    call,
+                    "Blocking socket.recv(); use asyncio.open_connection() "
+                    "/ loop.sock_recv() / asyncio.to_thread.",
+                )
+                return
+            if attr == "accept":
+                self._flag(
+                    call,
+                    "Blocking socket.accept(); use asyncio.start_server() "
+                    "or loop.sock_accept().",
+                )
+                return
+            if attr == "connect":
+                self._flag(
+                    call,
+                    "Blocking socket.connect(); use asyncio.open_connection() "
+                    "or loop.sock_connect().",
+                )
+                return
+
+    @staticmethod
+    def _queue_get_is_blocking(call: ast.Call) -> bool:
+        """Signature: ``queue.Queue.get(block=True, timeout=None)``.
+
+        Non-blocking forms (NOT flagged):
+            q.get(False)                  # positional block=False
+            q.get(block=False)
+            q.get(True, 0)                # positional block=True, timeout=0
+            q.get(timeout=0)
+        Everything else (including ``q.get(False, 5)`` or calls we can't
+        statically resolve) is treated as potentially blocking.
+        """
+        block_arg: ast.expr | None = call.args[0] if len(call.args) >= 1 else None
+        timeout_arg: ast.expr | None = call.args[1] if len(call.args) >= 2 else None
+        for kw in call.keywords:
+            if kw.arg == "block":
+                block_arg = kw.value
+            elif kw.arg == "timeout":
+                timeout_arg = kw.value
+
+        if isinstance(block_arg, ast.Constant) and block_arg.value is False:
+            return False
+        if isinstance(timeout_arg, ast.Constant) and timeout_arg.value == 0:
+            return False
+        return True
+
+
+def _iter_python_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if p.is_file() and p.suffix == ".py":
+            yield p
+        elif p.is_dir():
+            yield from sorted(p.rglob("*.py"))
+
+
+def check_file(path: Path) -> list[tuple[int, int, str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped — {e}", file=sys.stderr)
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        print(f"{path}:{e.lineno}: syntax error — {e.msg}", file=sys.stderr)
+        return []
+    checker = AsyncBlockingChecker(path, source)
+    checker.visit(tree)
+    return checker.violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check for blocking calls in async def bodies.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files/directories to scan (default: main event-loop surface)",
+    )
+    args = parser.parse_args(argv)
+
+    raw_paths = args.paths or DEFAULT_PATHS
+    targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
+
+    total = 0
+    for file in _iter_python_files(targets):
+        for lineno, col, msg in check_file(file):
+            rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
+            print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
+            total += 1
+
+    if total:
+        print(
+            f"\n{total} blocking-call violation(s) found inside async def bodies.\n"
+            "Fix by awaiting the async equivalent or wrapping in "
+            "`await asyncio.to_thread(...)`. Add `# noqa: ASYNC_BLOCK — <reason>` "
+            "only when the call genuinely runs off the event loop.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 动机 / Rationale

主进程跑 FastAPI + asyncio 事件循环，心跳和 WebSocket 对事件循环 stall 极其敏感——**25ms 都不能容忍**。近期 `end_session` 清理期间出现过 ~1s 的事件循环阻塞。仅靠人工 grep / review 拦不住同步阻塞调用反复潜入，需要一道**持久化的静态守卫**。

## 选型 / Mechanism

**ruff 原生 ASYNC 规则 + 自定义 AST 脚本**，而不是单独搞一个 flake8 方案：

1. **ruff 的 `flake8-async` 移植** 已覆盖 `time.sleep` / `requests.*` / `urllib.request.*` / `subprocess.run/call/check_output/Popen.wait/Popen.communicate`。启用 5 条精选规则，不打开整个 ASYNC 家族（避免 ASYNC109/110/230/240 等噪音）：

   | 规则       | 覆盖                                       |
   | -------- | ---------------------------------------- |
   | ASYNC210 | requests / urllib / httpx.Client 等 HTTP 阻塞 |
   | ASYNC220 | `Popen(...)` / 创建阻塞子进程                  |
   | ASYNC221 | `subprocess.run/call/check_output/check_call` |
   | ASYNC222 | `Popen.wait/communicate`                  |
   | ASYNC251 | `time.sleep`                              |

2. **自定义脚本** `scripts/check_async_blocking.py`（AST 实现）补齐 ruff 没覆盖的：
   - `Thread/Process.join(timeout=…)`
   - `queue.Queue.get(…)` （阻塞语义，`get_nowait()` / `get(block=False)` / `get(timeout=0)` 不拦）
   - 原生 `socket.recv / accept / connect`

   接收者用 **tail-name 精确/后缀匹配**（`tts_thread` / `request_queue` / `_sock`），避开 httpx / websockets / zmq socket 的海量误报——一开始放宽匹配时误报了 80+ 次。

   嵌套 sync `def` 不被检查（与 ruff 行为一致），这样放进 `to_thread` / `run_in_executor` / `Thread(target=f)` 的 worker 自然不会被误报——不用为每个 worker 手工打 noqa。

3. **CI**：新增 `.github/workflows/analyze.yml`，`Python lint (ruff + async-blocking)` job 在 push/PR 时同时跑两个检查。仓库无 pre-commit 配置，这里未引入；等后续需要时再加。

## noqa 豁免清单 / Exemption justifications

**本 PR 暂未使用任何 `# noqa: ASYNC_BLOCK`。** 已知的线程 worker（`main_logic/agent_event_bus.py` 的 ZMQ recv 线程、`main_logic/tts_client.py` 的 TTS worker）里的 `time.sleep` 都在普通 `def` 里，不在 `async def` 里——按规则天然豁免，无需 noqa。

格式约定：`# noqa: ASYNC_BLOCK — 简述为什么这个阻塞调用实际跑在事件循环外`。脚本会按字符串匹配放行。

## 存量违规修复 / Violations fixed

| 位置                                        | 问题                              | 修复                                            |
| ----------------------------------------- | ------------------------------- | --------------------------------------------- |
| `main_server.py:546`                      | `sync_process[k].join(timeout=0.1)` in `initialize_character_data` (async) | `await asyncio.to_thread(…join, 0.1)`         |
| `main_server.py:596`                      | `sync_process[k].join(timeout=3)` 同上  | `await asyncio.to_thread(…join, 3)`           |
| `main_logic/core.py:1453`                 | `self.tts_thread.join(timeout=1.0)` 在 async 路径上  | `await asyncio.to_thread(…join, 1.0)`         |
| `main_logic/cross_server.py:174`          | `message_queue.get()` 在 `empty()` 之后（竞态）  | 改 `get_nowait()` + `except Empty: break`     |

> ⚠️ **与并行任务的冲突提示**：任务描述提到 `main_server.py:546,596` 由另一个 PR 修复。我们使用的是相同的 fix（`asyncio.to_thread(thread.join, timeout)`），如果那个 PR 先合，此处会自然变成 no-op；如果本 PR 先合，那个 PR rebase 时 diff 为空即可。选择带上是为了让新的 CI Analyze job 在本 PR 上能绿。

## 验证 / Test plan

- [x] `uv run ruff check .` —— `All checks passed!`
- [x] `uv run python scripts/check_async_blocking.py` —— exit 0
- [x] 合成违规（注入 `time.sleep` / `Thread.join(timeout=)` / `Queue.get()` / `sock.recv()` / `requests.get()` / `subprocess.run()` 于一个 `async def` 中）——**全部 6 条被拦截**（3 条 by ruff, 3 条 by 自定义脚本）
- [x] `# noqa: ASYNC_BLOCK — reason` 行抑制正常工作
- [ ] CI `Analyze / Python lint (ruff + async-blocking)` job 绿（等 PR 触发）

🤖 https://claude.ai/code/session_01TC7MP5nYYtXZXMmTMWNQuN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了一个可运行的静态检查命令行工具，用于检测异步函数中可能的阻塞调用。

* **Bug Fixes**
  * 减少了异步流程中的阻塞风险：改进了消息队列处理和语音合成关闭流程以避免在事件循环中阻塞。
  * 改善了 Windows 平台凭据保存时的非阻塞处理与错误记录。

* **Chores**
  * 引入 CI 分析工作流与 Ruff 配置，增强代码静态检查和质量控制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->