### PR TITLE
fix(session): 消除 end_session 路径上 ~1 秒的 event loop 阻塞

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -482,7 +482,10 @@ class OmniRealtimeClient:
         headers = {
             "Authorization": f"Bearer {self.api_key}"
         }
-        self.ws = await websockets.connect(url, additional_headers=headers)
+        # close_timeout=0.5 缩短 close handshake 的等待上限：默认 10s 会把
+        # end_session 协程挂住数百毫秒~数秒（Qwen 回 CLOSE 帧偶尔很慢），
+        # 超时后 websockets 内部会 transport.abort() 强制关闭。
+        self.ws = await websockets.connect(url, additional_headers=headers, close_timeout=0.5)
         # Clear fatal flag so send_event/update_session work on this new
         # connection (flag may be leftover from a previous failed session
         # when the same OmniRealtimeClient instance is reused).
@@ -1690,22 +1693,11 @@ class OmniRealtimeClient:
             return
         
         if self.ws:
-            # 硬性约束 close handshake 的等待时间：默认 close_timeout=10s，
-            # 若远端（Qwen Realtime）晚响应 CLOSE 帧，会让 end_session 阻塞
-            # 数百毫秒~数秒，进而拖慢 message_handler_task 取消后的后续流程。
-            # 超时后直接 transport.abort() 做本地强制关闭（TCP RST），以保证
-            # end_session 快速返回、主事件循环心跳不受影响。
-            ws_ref = self.ws
             try:
-                await asyncio.wait_for(ws_ref.close(), timeout=0.5)
-            except asyncio.TimeoutError:
-                logger.warning("WebSocket close handshake exceeded 0.5s, aborting transport")
-                transport = getattr(ws_ref, 'transport', None)
-                if transport is not None:
-                    try:
-                        transport.abort()
-                    except Exception as e:
-                        logger.error(f"Error aborting websocket transport: {e}")
+                # 连接时已设 close_timeout=0.5s：远端超时未回 CLOSE 帧时，
+                # websockets 内部会自行 abort transport 强制关闭，
+                # 保证 end_session 快速返回、主事件循环心跳不受影响。
+                await self.ws.close()
             except Exception as e:
                 logger.error(f"Error closing websocket: {e}")
             finally:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1690,9 +1690,22 @@ class OmniRealtimeClient:
             return
         
         if self.ws:
+            # 硬性约束 close handshake 的等待时间：默认 close_timeout=10s，
+            # 若远端（Qwen Realtime）晚响应 CLOSE 帧，会让 end_session 阻塞
+            # 数百毫秒~数秒，进而拖慢 message_handler_task 取消后的后续流程。
+            # 超时后直接 transport.abort() 做本地强制关闭（TCP RST），以保证
+            # end_session 快速返回、主事件循环心跳不受影响。
+            ws_ref = self.ws
             try:
-                # 尝试关闭websocket连接
-                await self.ws.close()
+                await asyncio.wait_for(ws_ref.close(), timeout=0.5)
+            except asyncio.TimeoutError:
+                logger.warning("WebSocket close handshake exceeded 0.5s, aborting transport")
+                transport = getattr(ws_ref, 'transport', None)
+                if transport is not None:
+                    try:
+                        transport.abort()
+                    except Exception as e:
+                        logger.error(f"Error aborting websocket transport: {e}")
             except Exception as e:
                 logger.error(f"Error closing websocket: {e}")
             finally:


### PR DESCRIPTION
## 现象（现场日志证据）

一次 voice session 结束时，17 行日志全部被挤进同一秒（04:39:40），其中若干行本应属于前一秒 04:39:39：

```
04:39:39 - OmniRealtimeClient: response.done - '挺好的呀，精神抖擞的。...'
04:39:39 - End Session: Starting cleanup...
04:39:39 - End Session: Closing connection...
04:39:39 - 静默检测任务被取消
04:39:39 - AudioProcessor state reset (external call)
04:39:40 - WebSocket connection closed           ← OmniRealtimeClient 的 Qwen WS
04:39:40 - End Session: Qwen connection closed.
04:39:40 - End Session: Resources cleaned up.
04:39:40 - [喵酱] turn_end analyze check: ...    ← 本应在 04:39:39 由 response.done 触发
04:39:40 - [EventBus] analyze_request dequeued trigger=turn_end
04:39:40 - [AgentAnalyze] skip: analyzer disabled
04:39:40 - [EventBus] analyze_ack latency_ms=3.1
04:39:40 - [MemoryServer] cache: 喵酱 +2 条消息
04:39:40 - [EventBus] analyze_request dequeued trigger=session_end
04:39:40 - [AgentAnalyze] skip: analyzer disabled
04:39:40 - [EventBus] analyze_ack latency_ms=2.7
04:39:40 - analyze_request dispatch success (session_end)
04:39:40 - 会话结束：聊天历史 2 条，增量 0 条
```

ack 本身 `latency_ms=3.1`，说明任务本身极快 —— 延迟是 **event-loop 占用**，不是计算。

## 定位的单点罪魁

对 `end_session` → `OmniRealtimeClient.close()` → `_teardown_tts_runtime()` 三条路径的候选块逐个静态审计，所有其它候选都能在 ≪25ms 内完成：

- `self._silence_check_task.cancel()` + `await` —— 一个已取消任务的协作式回收，微秒级
- `save_debug_audio()` —— `DEBUG_SAVE_AUDIO=False` 时立即 return
- `audio_processor.reset()` + `_denoiser.reset()` —— 纯内存 numpy + GRU 状态复位，微秒级
- `asyncio.wait_for(message_handler_task, timeout=3.0)` —— cancel 立即抛 CancelledError，几乎没耗时
- `_teardown_tts_runtime` 的 `thread_ref.join(2.0)` —— 已包在 `asyncio.to_thread` 里，不占用 loop

**唯一 ~1s 的块是 `await self.ws.close()`**（omni_realtime_client.py:1695），表现在日志上就是 "AudioProcessor state reset (external call)" (04:39:39) → "WebSocket connection closed" (04:39:40) 之间的 1s gap。

根因：`websockets==15.0.1` 的 `ClientConnection.close()` 默认 `close_timeout=10s`，等的是远端回 CLOSE 帧后 `connection_lost_waiter` 完成。Qwen Realtime 端给 CLOSE 帧的延迟是这 1s 的主要成分；更糟的情况下可以直奔 10s 默认值。

## 修复

在 `main_logic/omni_realtime_client.py` 的 close 路径上：

```python
try:
    await asyncio.wait_for(ws_ref.close(), timeout=0.5)
except asyncio.TimeoutError:
    logger.warning("WebSocket close handshake exceeded 0.5s, aborting transport")
    transport = getattr(ws_ref, 'transport', None)
    if transport is not None:
        transport.abort()
```

- 正常路径下（远端及时回 CLOSE 帧）：`ws.close()` 在几十~几百毫秒内返回，行为不变
- 慢路径下（远端迟响应 / 网络卡顿）：0.5s 后放弃等待，`transport.abort()` 发 TCP RST 本地关掉 socket
- 协议影响：放弃"对方确认 CLOSE"这一握手，连接被 RST 关闭。对客户端主动 end_session 场景可接受 —— 我们已经不打算继续用这条连接了，且 Qwen 服务端会自行处理 RST 后的会话回收。

为什么选 0.5s 而不是任务描述里建议的 0.25s：给到一个"远端正常响应但偶尔抖动"的预算，绝大多数会话仍能走优雅关闭路径。

## 校验（静态推理）

无法本地跑完整 voice session，但修复逻辑可直推：

| 路径 | 修复前 | 修复后 |
|---|---|---|
| 远端 CLOSE 帧 < 500ms（常见） | 正常 close（~几十 ms～1s） | 同上（wait_for 未触发） |
| 远端 CLOSE 帧 ≥ 500ms 或丢失 | close 挂到 close_timeout（最多 10s） | 0.5s 触发 TimeoutError → transport.abort()，总耗时 ≈ 0.5s |
| 网络断开 | close 挂到 close_timeout | 0.5s 后强制关闭 |

预期日志差异：`WebSocket connection closed` 与 `AudioProcessor state reset (external call)` 之间的 gap 从 ~1s 回落到 0~500ms，`turn_end` 的 cross_server 处理不再被挤进下一秒。

## 范围自律

- 只改 `OmniRealtimeClient.close()` 的 `await self.ws.close()` 一处
- 未动 `main_server.py` 的 Thread.join、`workshop_router.py` 的 `time.sleep`、broad linter —— 按任务说明全部留给独立 PR
- 未加临时计时日志（因日志证据已足够定位到单点）

https://claude.ai/code/session_012xroRM8jhFkSaEdypyae1R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了实时连接的关闭流程，缩短并界定了关闭等待时长，避免远端关闭延迟阻塞本地会话结束。
  * 使关闭与会话终止的行为更一致，提高了响应速度与资源清理的可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->