### PR TITLE
修复 Live2D 触摸交互时 touchSetFilter 未初始化导致的报错

### DIFF
--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -82,6 +82,8 @@ class Live2DManager {
         this.isLocked = false;
         this.onModelLoaded = null;
         this.onStatusUpdate = null;
+        this.touchSetFilter = {};       // 点击/触摸滤波计数器（touch-config.js 会覆盖）
+        this.touchSetHitEventLock = false; // hit 事件锁（touch-config.js 会覆盖）
         this.modelName = null; // 记录当前模型目录名
         this.modelRootPath = null; // 记录当前模型根路径，如 /static/<modelName>
         this.savedModelParameters = null; // 保存的模型参数（从parameters.json加载），供定时器定期应用

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -384,8 +384,9 @@ Live2DManager.prototype.setupDragAndDrop = function (model) {
                     return;
                 }
                 const UseBlock = "default";
-                
+
                 // 滤波 毫秒
+                window.live2dManager.touchSetFilter = window.live2dManager.touchSetFilter || {};
                 if(!window.live2dManager.touchSetFilter[UseBlock]){
                     window.live2dManager.touchSetFilter[UseBlock]= Date.now();
                 }else{
@@ -1879,6 +1880,7 @@ Live2DManager.prototype.setupHitAreaInteraction = function(model) {
         window.live2dManager.touchSetHitEventLock = true
 
         // 滤波 毫秒
+        window.live2dManager.touchSetFilter = window.live2dManager.touchSetFilter || {};
         if(!window.live2dManager.touchSetFilter[hitAreas]){
             window.live2dManager.touchSetFilter[hitAreas]= Date.now();
         }else{


### PR DESCRIPTION
本次改动修复了点击/触摸猫娘时，前端在 live2d-interaction.js 中抛出 TypeError: Cannot read properties of undefined (reading 'default') 的问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 增强了触摸交互和拖拽操作的稳定性，通过实现防御性状态检查，防止交互元素处理过程中的潜在错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->