### PR TITLE
fix(main): 把 async def 里的 Thread.join / shutil.* offload 到 to_thread

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1450,7 +1450,7 @@ class LLMSessionManager:
                 logger.info("当前模式不需要TTS，关闭TTS线程")
                 try:
                     self.tts_request_queue.put(("__shutdown__", None))  # 通知线程退出
-                    self.tts_thread.join(timeout=1.0)  # 等待线程结束
+                    await asyncio.to_thread(self.tts_thread.join, 1.0)  # 等待线程结束
                 except Exception as e:
                     logger.error(f"关闭TTS线程时出错: {e}")
                 finally:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1583,7 +1583,7 @@ async def delete_catgirl(name: str):
                 if file_path.exists():
                     try:
                         if file_path.is_dir():
-                            shutil.rmtree(file_path)
+                            await asyncio.to_thread(shutil.rmtree, file_path)
                         else:
                             file_path.unlink()
                         logger.info(f"已删除: {file_path}")
@@ -3424,7 +3424,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
                         dest_path.parent.mkdir(parents=True, exist_ok=True)
                         total_uncompressed_size += member_size
                         with zf.open(member) as src, open(dest_path, 'wb') as dst:
-                            shutil.copyfileobj(src, dst, length=8192)
+                            await asyncio.to_thread(shutil.copyfileobj, src, dst, length=8192)
 
             # 读取角色设定（支持加密和非加密格式）
             character_json_path = extract_path / 'character.json'
@@ -3534,7 +3534,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
                                     counter += 1
 
                                 # 复制整个模型文件夹
-                                shutil.copytree(model_item, target_model_dir)
+                                await asyncio.to_thread(shutil.copytree, model_item, target_model_dir)
                                 logger.info(f'已导入MMD模型文件夹: {original_model_name} -> {model_name}')
 
                                 # 查找文件夹中的主模型文件（.pmx 或 .pmd）
@@ -3569,7 +3569,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
                                     counter += 1
 
                                 # 复制模型文件
-                                shutil.copytree(model_item, target_model_dir)
+                                await asyncio.to_thread(shutil.copytree, model_item, target_model_dir)
                                 logger.info(f'已导入Live2D模型: {original_model_name} -> {model_name}')
 
                                 # 查找复制后的 .model3.json 文件，保留相对路径
@@ -3606,7 +3606,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
                                     target_model_path = _config_manager.vrm_dir / f"{model_name}{model_ext}"
                                     counter += 1
 
-                                shutil.copy2(model_file, target_model_path)
+                                await asyncio.to_thread(shutil.copy2, model_file, target_model_path)
                                 logger.info(f'已导入VRM模型: {original_model_name} -> {model_name}')
 
                                 # 记录导入的模型信息
@@ -3680,7 +3680,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
     finally:
         # 清理临时目录
         if temp_dir and os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)
 
 
 @router.post('/catgirl/{name}/export-with-portrait')
@@ -3971,4 +3971,4 @@ async def export_catgirl_with_portrait(
         return JSONResponse({'success': False, 'error': f'导出失败: {str(e)}'}, status_code=500)
     finally:
         if temp_dir and os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -9,6 +9,7 @@ Handles jukebox-related endpoints including:
 - Configuration import/export
 """
 
+import asyncio
 import io
 import json
 import hashlib
@@ -428,7 +429,7 @@ async def upload_songs(
             target_path = jukebox_config.songs_dir / target_filename
 
             with open(target_path, "wb") as buffer:
-                shutil.copyfileobj(file.file, buffer)
+                await asyncio.to_thread(shutil.copyfileobj, file.file, buffer)
 
             # 计算 MD5
             file_md5 = calculate_md5(target_path)
@@ -660,7 +661,7 @@ async def upload_actions(
             target_path = jukebox_config.actions_dir / target_filename
 
             with open(target_path, "wb") as buffer:
-                shutil.copyfileobj(file.file, buffer)
+                await asyncio.to_thread(shutil.copyfileobj, file.file, buffer)
 
             # 计算 MD5
             file_md5 = calculate_md5(target_path)
@@ -948,7 +949,7 @@ async def export_config(
             if src_path.exists():
                 dst_path = export_dir / song["audio"]
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src_path, dst_path)
+                await asyncio.to_thread(shutil.copy2, src_path, dst_path)
 
         # 导出动画
         for action_id in action_ids_to_export:
@@ -975,7 +976,7 @@ async def export_config(
             if src_path.exists():
                 dst_path = export_dir / action["file"]
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src_path, dst_path)
+                await asyncio.to_thread(shutil.copy2, src_path, dst_path)
 
         # 导出绑定关系（将ID绑定转换为MD5绑定，便于跨系统导入）
         # 本地存储格式: bindings[songId][actionId] = {"offset": 0}
@@ -1129,7 +1130,7 @@ async def import_config(file: UploadFile = File(...)):
         zip_path = temp_path / "import.zip"
 
         with open(zip_path, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
+            await asyncio.to_thread(shutil.copyfileobj, file.file, buffer)
         
         extract_dir = temp_path / "extracted"
         extract_dir.mkdir()
@@ -1161,7 +1162,7 @@ async def import_config(file: UploadFile = File(...)):
                 else:
                     member_path.parent.mkdir(parents=True, exist_ok=True)
                     with zf.open(member) as src, open(member_path, 'wb') as dst:
-                        shutil.copyfileobj(src, dst)
+                        await asyncio.to_thread(shutil.copyfileobj, src, dst)
         
         config_path = extract_dir / "config.json"
         if not config_path.exists():
@@ -1215,7 +1216,7 @@ async def import_config(file: UploadFile = File(...)):
                     target_filename = get_unique_filename(jukebox_config.songs_dir, original_filename)
                     dst_audio = jukebox_config.songs_dir / target_filename
                     dst_audio.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src_audio, dst_audio)
+                    await asyncio.to_thread(shutil.copy2, src_audio, dst_audio)
 
                     new_id = sanitize_filename(target_filename)
                     base_id = new_id
@@ -1282,7 +1283,7 @@ async def import_config(file: UploadFile = File(...)):
                     target_filename = get_unique_filename(jukebox_config.actions_dir, original_filename)
                     dst_file = jukebox_config.actions_dir / target_filename
                     dst_file.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(src_file, dst_file)
+                    await asyncio.to_thread(shutil.copy2, src_file, dst_file)
 
                     new_id = sanitize_filename(target_filename)
                     base_id = new_id
@@ -1402,7 +1403,7 @@ async def pack_folder(files: List[UploadFile] = File(...)):
                 raise HTTPException(400, f"文件名包含非法路径: {file.filename}") from err
             file_path.parent.mkdir(parents=True, exist_ok=True)
             with open(file_path, "wb") as f:
-                shutil.copyfileobj(file.file, f)
+                await asyncio.to_thread(shutil.copyfileobj, file.file, f)
 
         # 创建 ZIP 文件
         zip_path = temp_path / "packed.zip"

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -10,6 +10,7 @@ Handles Live2D model-related endpoints including:
 - Model upload
 """
 
+import asyncio
 import os
 import json
 import pathlib
@@ -922,10 +923,10 @@ async def upload_live2d_model(files: list[UploadFile] = File(...)):
                     })
                 else:
                     logger.info(f"清理残留的无效模型目录: {target_model_dir}")
-                    shutil.rmtree(target_model_dir, ignore_errors=True)
-            
+                    await asyncio.to_thread(shutil.rmtree, target_model_dir, ignore_errors=True)
+
             # 复制模型根目录到用户文档的live2d目录
-            shutil.copytree(model_root_dir, target_model_dir)
+            await asyncio.to_thread(shutil.copytree, model_root_dir, target_model_dir)
 
             # 上传后：遍历模型目录中的所有动作文件（*.motion3.json），
             # 将官方白名单参数及模型自身在 .model3.json 中声明为 LipSync 的参数的 Segments 清空为 []。
@@ -1038,7 +1039,7 @@ async def upload_live2d_model(files: list[UploadFile] = File(...)):
         # 清理可能的残留目录
         try:
             if target_model_dir and target_model_dir.exists():
-                shutil.rmtree(target_model_dir)
+                await asyncio.to_thread(shutil.rmtree, target_model_dir)
                 logger.info(f"已清理导入失败的残留目录: {target_model_dir}")
         except Exception as cleanup_err:
             logger.warning(f"清理导入失败的残留目录时出错: {cleanup_err}")

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -7,6 +7,7 @@ Handles memory-related endpoints including:
 - Memory review configuration
 """
 
+import asyncio
 import os
 import re
 import json
@@ -467,7 +468,7 @@ async def update_catgirl_name(request: Request):
             and resolved_old_file_path.is_relative_to(user_memory_dir)
         ):
             if old_file_path.is_dir():
-                shutil.rmtree(old_file_path)
+                await asyncio.to_thread(shutil.rmtree, old_file_path)
             else:
                 old_file_path.unlink()
         

--- a/main_routers/mmd_router.py
+++ b/main_routers/mmd_router.py
@@ -9,6 +9,7 @@ Handles MMD model-related endpoints including:
 - MMD emotion mapping configuration
 """
 
+import asyncio
 import json
 import os
 import re
@@ -491,7 +492,7 @@ async def upload_mmd_zip(file: UploadFile = File(...)):
                     })
                 else:
                     logger.info(f"清理残留的无效模型目录: {target_dir}")
-                    shutil.rmtree(target_dir, ignore_errors=True)
+                    await asyncio.to_thread(shutil.rmtree, target_dir, ignore_errors=True)
 
             # 使用编码修正后的文件名解压
             if all(
@@ -510,7 +511,7 @@ async def upload_mmd_zip(file: UploadFile = File(...)):
         for ext in ALLOWED_MODEL_EXTENSIONS:
             pmx_candidates.extend(target_dir.rglob(f'*{ext}'))
         if not pmx_candidates:
-            shutil.rmtree(target_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, target_dir, ignore_errors=True)
             return JSONResponse(status_code=500, content={
                 "success": False, "error": "解压后未找到模型文件"
             })
@@ -533,11 +534,11 @@ async def upload_mmd_zip(file: UploadFile = File(...)):
 
     except zipfile.BadZipFile:
         if target_dir and target_dir.exists():
-            shutil.rmtree(target_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, target_dir, ignore_errors=True)
         return JSONResponse(status_code=400, content={"success": False, "error": "ZIP 文件损坏"})
     except Exception as e:
         if target_dir and target_dir.exists():
-            shutil.rmtree(target_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, target_dir, ignore_errors=True)
         logger.error(f"上传 MMD ZIP 包失败: {e}", exc_info=True)
         return JSONResponse(status_code=500, content={"success": False, "error": str(e)})
     finally:
@@ -841,7 +842,7 @@ async def delete_mmd_model(request: Request):
                     })
                 # 残缺目录（无模型文件）：允许删除
                 deleted_files = sum(1 for f in candidate.rglob('*') if f.is_file())
-                shutil.rmtree(candidate)
+                await asyncio.to_thread(shutil.rmtree, candidate)
                 logger.info(f"删除残缺 MMD 模型目录: {candidate}")
                 return JSONResponse(content={
                     "success": True,
@@ -872,7 +873,7 @@ async def delete_mmd_model(request: Request):
             for f in top_subdir.rglob('*'):
                 if f.is_file():
                     deleted_files += 1
-            shutil.rmtree(top_subdir)
+            await asyncio.to_thread(shutil.rmtree, top_subdir)
             logger.info(f"删除 MMD 模型目录: {top_subdir} ({deleted_files} 个文件)")
         else:
             # 模型在顶层：只删除模型文件本身

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -2045,7 +2045,7 @@ async def prepare_workshop_upload(request: Request):
             
             # 安全检查：防止路径穿越
             if '..' in model_name:
-                shutil.rmtree(temp_item_dir, ignore_errors=True)
+                await asyncio.to_thread(shutil.rmtree, temp_item_dir, ignore_errors=True)
                 return JSONResponse({
                     "success": False,
                     "error": "非法模型路径"
@@ -2081,7 +2081,7 @@ async def prepare_workshop_upload(request: Request):
                 
                 if source_file and source_file.exists():
                     vrm_dest = os.path.join(temp_item_dir, vrm_filename)
-                    shutil.copy2(str(source_file), vrm_dest)
+                    await asyncio.to_thread(shutil.copy2, str(source_file), vrm_dest)
                     logger.info(f"VRM模型文件已复制到临时目录: {vrm_dest}")
                     model_copied = True
                     
@@ -2099,7 +2099,7 @@ async def prepare_workshop_upload(request: Request):
                     source_dir = mmd_base / mmd_dir_name
                     if source_dir.exists() and source_dir.is_dir():
                         model_dest_dir = os.path.join(temp_item_dir, mmd_dir_name)
-                        shutil.copytree(str(source_dir), model_dest_dir, dirs_exist_ok=True)
+                        await asyncio.to_thread(shutil.copytree, str(source_dir), model_dest_dir, dirs_exist_ok=True)
                         logger.info(f"MMD模型目录已复制到临时目录: {model_dest_dir}")
                         model_copied = True
                 elif model_name.startswith('/user_mmd/') and len(path_parts) == 2:
@@ -2109,7 +2109,7 @@ async def prepare_workshop_upload(request: Request):
                     source_file = mmd_base / mmd_filename
                     if source_file.exists():
                         mmd_dest = os.path.join(temp_item_dir, mmd_filename)
-                        shutil.copy2(str(source_file), mmd_dest)
+                        await asyncio.to_thread(shutil.copy2, str(source_file), mmd_dest)
                         logger.info(f"MMD模型文件已复制到临时目录: {mmd_dest}")
                         model_copied = True
                 elif model_name.startswith('/static/mmd/'):
@@ -2121,7 +2121,7 @@ async def prepare_workshop_upload(request: Request):
                         source_dir = source_file.parent
                         dest_name = source_dir.name
                         model_dest_dir = os.path.join(temp_item_dir, dest_name)
-                        shutil.copytree(str(source_dir), model_dest_dir, dirs_exist_ok=True)
+                        await asyncio.to_thread(shutil.copytree, str(source_dir), model_dest_dir, dirs_exist_ok=True)
                         logger.info(f"MMD模型目录已复制到临时目录: {model_dest_dir}")
                         model_copied = True
                 elif model_name.startswith('/workshop/'):
@@ -2142,13 +2142,13 @@ async def prepare_workshop_upload(request: Request):
                                             source_dir = source_file.parent
                                             dest_name = source_dir.name
                                             model_dest_dir = os.path.join(temp_item_dir, dest_name)
-                                            shutil.copytree(str(source_dir), model_dest_dir, dirs_exist_ok=True)
+                                            await asyncio.to_thread(shutil.copytree, str(source_dir), model_dest_dir, dirs_exist_ok=True)
                                             logger.info(f"Workshop MMD模型目录已复制到临时目录: {model_dest_dir}")
                                             model_copied = True
                                     break
             
             if not model_copied:
-                shutil.rmtree(temp_item_dir, ignore_errors=True)
+                await asyncio.to_thread(shutil.rmtree, temp_item_dir, ignore_errors=True)
                 return JSONResponse({
                     "success": False,
                     "error": f"模型文件不存在: {model_name}"
@@ -2158,7 +2158,7 @@ async def prepare_workshop_upload(request: Request):
             model_dir, _ = find_model_directory(model_name)
             if not model_dir or not os.path.exists(model_dir):
                 # 清理临时目录
-                shutil.rmtree(temp_item_dir, ignore_errors=True)
+                await asyncio.to_thread(shutil.rmtree, temp_item_dir, ignore_errors=True)
                 return JSONResponse({
                     "success": False,
                     "error": f"模型目录不存在: {model_name}"
@@ -2166,7 +2166,7 @@ async def prepare_workshop_upload(request: Request):
             
             # 复制整个模型目录到临时目录
             model_dest_dir = os.path.join(temp_item_dir, model_name)
-            shutil.copytree(model_dir, model_dest_dir, dirs_exist_ok=True)
+            await asyncio.to_thread(shutil.copytree, model_dir, model_dest_dir, dirs_exist_ok=True)
             logger.info(f"模型文件已复制到临时目录: {model_dest_dir}")
         
         # 读取 .workshop_meta.json（如果存在）
@@ -2234,7 +2234,7 @@ async def cleanup_temp_folder(request: Request):
         
         # 删除临时目录
         if os.path.exists(temp_folder):
-            shutil.rmtree(temp_folder, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, temp_folder, ignore_errors=True)
             logger.info(f"临时目录已删除: {temp_folder}")
             return JSONResponse({
                 "success": True,
@@ -2379,7 +2379,7 @@ async def publish_to_workshop(request: Request):
                 # 复制预览图片到内容文件夹
                 try:
                     import shutil
-                    shutil.copy2(preview_image, new_preview_path)
+                    await asyncio.to_thread(shutil.copy2, preview_image, new_preview_path)
                     logger.info(f'预览图片已复制到内容文件夹并统一命名: {new_preview_path}')
                     # 使用新的统一命名的预览图片路径
                     preview_image = new_preview_path
@@ -2403,7 +2403,7 @@ async def publish_to_workshop(request: Request):
                         new_preview_path = os.path.join(content_folder, f'preview{file_extension}')
                         try:
                             import shutil
-                            shutil.copy2(preview_image, new_preview_path)
+                            await asyncio.to_thread(shutil.copy2, preview_image, new_preview_path)
                             logger.info(f'自动找到的预览图片已统一命名: {new_preview_path}')
                             preview_image = new_preview_path
                         except Exception as e:


### PR DESCRIPTION
## 背景 / Rationale

延续"main FastAPI/asyncio event loop 零阻塞"硬策略（前端 WebSocket 心跳会因 loop 卡顿而断开）。此前已合并的相关修复：

- #840 `main_server.py` Thread.join
- #841 `workshop_router` Steamworks 回调轮询里的 `time.sleep`
- #843 `end_session` close-path 卡顿

最新一轮 AST 审计发现 **39 处新的阻塞调用**（1 P0 + 38 P1），均位于 `async def` handler 里，对大文件（VRM / MMD 模型动辄几百 MB）可一次卡住事件循环数秒。本 PR 把它们全部机械地 offload 到 `asyncio.to_thread`。

## 改动

**纯机械搬运 — 不改逻辑、不改顺序、不新增错误处理**，保持参数顺序与 kwargs 完全一致；原有 `try/except` / `logger.info` / `finally` 结构全部保留。

### P0（1 处）

- `main_logic/core.py:1453` — `start_session` 里切 TTS 模式时的 `self.tts_thread.join(timeout=1.0)` → `await asyncio.to_thread(self.tts_thread.join, 1.0)`

### P1（38 处，全部 `await asyncio.to_thread(shutil.*, …)`）

| 路由 | 处数 | 场景 |
| --- | --- | --- |
| `main_routers/workshop_router.py` | 12 | VRM/MMD 模型打包/卸载、临时目录清理、预览图复制 |
| `main_routers/jukebox_router.py` | 9 | 歌曲/动作上传、导入导出压缩包 |
| `main_routers/characters_router.py` | 7 | 角色卡导入解压、模型文件夹复制 |
| `main_routers/mmd_router.py` | 6 | MMD 模型目录清理 |
| `main_routers/live2d_router.py` | 3 | Live2D 模型上传失败清理 |
| `main_routers/memory_router.py` | 1 | 猫娘重命名时的记忆目录清理 |

### 附带

为 `jukebox_router.py` / `mmd_router.py` / `live2d_router.py` / `memory_router.py` 补齐 `import asyncio`（这些文件有 `async def` 但尚未显式 import asyncio）。

### 范围外（本 PR 不处理）

- `utils/config_manager.py:1458` geo check urllib — 需 transitive 分析
- `utils/token_tracker.py:758` telemetry urllib
- `utils/port_utils.py:168` `netsh` subprocess
- `utils/screenshot_utils.py` / `system_router.py:2395` / `characters_router.py:3832` PIL
- `utils/cookies_login.py` Fernet
- Ruff/CI 规则强制（另一 follow-up task）
- 非 `async def` 里的 `shutil.*`（已经走 FastAPI threadpool，无需改）

## 验证 / Test plan

- [x] 语法：`python -c "import ast; ast.parse(open(...).read())"` 全部 7 文件 OK
- [x] Lint：`uv run ruff check` 对这 7 文件，只剩下与本 PR 无关的既有告警（F401/F541/E402/F841），无新增问题
- [x] grep：所有列出行号的 `shutil.*` / `Thread.join` 均已前缀 `await asyncio.to_thread(`
- [x] 审计计数：39 → 0（P0 0、P1 0）
- [ ] 功能冒烟（本地环境未搭建）：
  - 上传大型 Workshop VRM 模型，期间 WebSocket 心跳持续
  - 导入带大立绘的角色卡，期间 WebSocket 心跳持续

## 备注

审计脚本 `scripts/audit_async_blocking.py` 当前工作树未见；上列"39 → 0"为按 task 描述逐行核对的结果。建议在合入本 PR 后把审计脚本连同 ruff 规则一起补齐，作为下一个 task 的 CI enforcement。

https://claude.ai/code/session_01XzHxKxjgrF9KCZSyWbadHN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了文件系统操作在多个核心模块中的处理机制，增强了应用的并发处理能力和响应速度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->