### PR TITLE
perf(async): 消除主进程事件循环阻塞（5 commits, T1-T5）

### DIFF
--- a/.agent/rules/neko-guide.md
+++ b/.agent/rules/neko-guide.md
@@ -30,3 +30,18 @@ trigger: always_on
 聊天 UI 只有一份实现：`/frontend/react-neko-chat/` 构建出 `neko-chat-window.iife.js`。`index.html` 和 `chat.html` 都挂载同一个 React 组件到 `#react-chat-window-root`，区别仅在于 index.html 里是可收起的浮层，chat.html 里是全屏铺满。
 
 旧的 `#chat-container`（纯 DOM 聊天）已弃用，CSS 强制隐藏。`app-chat-adapter.js` 拦截所有遗留的 `appendMessage()` 调用并统一路由到 React 侧。修改聊天 UI/逻辑时去 `/frontend/react-neko-chat/` 改，不要碰 `#chat-container` 的旧代码。
+
+## 架构：单进程 + 事件循环零阻塞
+
+`main_server` / `memory_server` / `agent_server` 三子系统已合并进同一个 FastAPI 进程，共享事件循环。任何会阻塞事件循环超过数十毫秒的调用都会把另外两个子系统也拖慢，因此在 async 路径（`async def` 函数、FastAPI 路由、`asyncio.create_task` 后台任务、WebSocket handler）里禁止以下操作：
+
+- **同步文件 IO**（`open() + read/write`、`json.load/dump`、`atomic_write_json`）→ 用 `utils.file_utils` 里的 `atomic_write_json_async` / `atomic_write_text_async` / `read_json_async`，或包 `await asyncio.to_thread(...)`。
+- **同步 SQLite**（`engine.connect() + execute`、`session.commit()`）→ 走 `memory/timeindex.py` 的 `a*` 镜像（`astore_conversation` / `asearch_facts` / `aget_last_conversation_time` 等）；若确需 sync，必须 `asyncio.to_thread`。
+- **同步 HTTP**（`httpx.Client`、`requests`、`urllib.request`）→ 用 `httpx.AsyncClient`。唯一刻意保留的例外是 `agent_server._bind_deferred_task`，它走 `run_in_executor`。
+- **CPU 密集循环**（BM25 重排、遍历上千条记录、批量 embedding 归一化）→ `await asyncio.to_thread(...)` offload。例：`brain/plugin_filter.stage1_filter` 已 offload。
+- **`time.sleep(...)`** → `await asyncio.sleep(...)`。
+- **`threading.Lock` 持锁跨 `await`** → 改用 `asyncio.Lock`；仅当整个临界区都是纯内存/CPU 操作、绝不 `await` 时才允许保留 `threading.Lock`。
+
+配置写入遵循对偶模式：`ConfigManager.save_characters` / `JukeboxConfig.save()` 等同步版留给启动期 & sync 迁移；async 路径一律走 `asave_characters` / `asave()` 之类的 `a*` 版本，内部就是 `asyncio.to_thread(self.<sync>, ...)`。新增写磁盘方法时请保持这个对偶。
+
+事件循环上默认 `loop.slow_callback_duration = 0.05`，超过 50ms 的 sync 回调会打 `Executing ... took X seconds` warning。提 PR 前请扫一眼启动日志。

--- a/.agent/rules/neko-guide.md
+++ b/.agent/rules/neko-guide.md
@@ -44,4 +44,4 @@ trigger: always_on
 
 配置写入遵循对偶模式：`ConfigManager.save_characters` / `JukeboxConfig.save()` 等同步版留给启动期 & sync 迁移；async 路径一律走 `asave_characters` / `asave()` 之类的 `a*` 版本，内部就是 `asyncio.to_thread(self.<sync>, ...)`。新增写磁盘方法时请保持这个对偶。
 
-事件循环上默认 `loop.slow_callback_duration = 0.05`，超过 50ms 的 sync 回调会打 `Executing ... took X seconds` warning。提 PR 前请扫一眼启动日志。
+事件循环慢回调检测需要开启 asyncio debug 模式才会触发（设置 `NEKO_DEBUG_ASYNC=1`；`PYTHONASYNCIODEBUG=1` 或 `python -X dev` 也可）。启用后 `main_server.py` 会把 `loop.slow_callback_duration` 收紧到 50ms，超过的 sync 回调会打 `Executing ... took X seconds` warning。提 PR 前请在调试模式下扫一眼启动日志。

--- a/agent_server.py
+++ b/agent_server.py
@@ -108,7 +108,7 @@ class Modules:
 import threading
 _plugin_name_cache: Dict[str, str] = {}
 _plugin_name_cache_time: float = 0.0
-_plugin_name_cache_lock = threading.Lock()
+_plugin_name_cache_lock = asyncio.Lock()
 PLUGIN_NAME_CACHE_TTL: float = 30.0  # 缓存 30 秒
 TASK_REGISTRY_CLEANUP_TTL: float = 300.0  # 已完成任务保留 5 分钟
 DEFERRED_TASK_TIMEOUT: float = 3600.0  # deferred 任务超时 1 小时
@@ -379,30 +379,27 @@ def _bind_deferred_task(plugin_id: str, reminder_id: str, agent_task_id: str) ->
         logger.warning("[Deferred] bind failed: plugin=%s reminder=%s error=%s", plugin_id, reminder_id, e)
 
 
-def _get_plugin_friendly_name(plugin_id: str) -> str | None:
+async def _get_plugin_friendly_name(plugin_id: str) -> str | None:
     """获取插件的友好名称（用于 HUD 显示）
 
     通过 HTTP 调用嵌入式插件服务的 /plugins 端点获取插件列表，
-    并使用缓存减少请求次数。使用线程锁保证多线程安全。
+    并使用缓存减少请求次数。
     """
     global _plugin_name_cache, _plugin_name_cache_time
 
-    # 检查缓存（加锁读取）
     now = time.time()
-    with _plugin_name_cache_lock:
+    async with _plugin_name_cache_lock:
         if _plugin_name_cache and (now - _plugin_name_cache_time) < PLUGIN_NAME_CACHE_TTL:
             return _plugin_name_cache.get(plugin_id)
 
-    # 缓存过期或为空，从嵌入式插件服务获取
     new_cache = {}
     cache_time = now
     try:
-        with httpx.Client(timeout=1.0, proxy=None, trust_env=False) as client:
-            resp = client.get(f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}/plugins")
+        async with httpx.AsyncClient(timeout=1.0, proxy=None, trust_env=False) as client:
+            resp = await client.get(f"http://127.0.0.1:{USER_PLUGIN_SERVER_PORT}/plugins")
             if resp.status_code == 200:
                 data = resp.json()
                 plugins = data.get("plugins", [])
-                # 构建新缓存
                 for p in plugins:
                     if isinstance(p, dict):
                         pid = p.get("id")
@@ -411,8 +408,7 @@ def _get_plugin_friendly_name(plugin_id: str) -> str | None:
                             new_cache[pid] = pname
                         elif pid:
                             new_cache[pid] = pid
-                # 更新全局缓存（加锁写入）
-                with _plugin_name_cache_lock:
+                async with _plugin_name_cache_lock:
                     _plugin_name_cache = new_cache
                     _plugin_name_cache_time = cache_time
                 return new_cache.get(plugin_id)
@@ -852,8 +848,8 @@ def _check_agent_api_gate() -> Dict[str, Any]:
         return {"ready": False, "reasons": [f"Agent API check failed: {e}"], "is_free_version": False}
 
 
-def _get_plugin_display_id(plugin_id: str) -> str:
-    return _get_plugin_friendly_name(plugin_id) or plugin_id
+async def _get_plugin_display_id(plugin_id: str) -> str:
+    return (await _get_plugin_friendly_name(plugin_id)) or plugin_id
 
 
 async def _emit_main_event(event_type: str, lanlan_name: Optional[str], **payload) -> None:
@@ -1350,7 +1346,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 entry_id = result.entry_id
                 up_start = _now_iso()
                 # 获取插件友好名称（用于 HUD 显示）
-                plugin_name = _get_plugin_friendly_name(plugin_id)
+                plugin_name = await _get_plugin_friendly_name(plugin_id)
                 logger.info(
                     "[TaskExecutor] Dispatching UserPlugin: plugin_id=%s, entry_id=%s, plugin_name=%s",
                     plugin_id, entry_id, plugin_name,
@@ -1468,7 +1464,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             logger.info(f"[TaskExecutor] ✅ UserPlugin completed: {plugin_id}")
                             if not _suppress_reply:
                                 _lang = _rp_lang(None)
-                                display_id = _get_plugin_display_id(plugin_id)
+                                display_id = await _get_plugin_display_id(plugin_id)
                                 summary = _rp_phrase('plugin_done_with', _lang, id=display_id, detail=detail) if detail else _rp_phrase('plugin_done', _lang, id=display_id)
                                 try:
                                     await _emit_task_result(
@@ -1492,7 +1488,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             if not _suppress_reply:
                                 _lang = _rp_lang(None)
                                 try:
-                                    display_id = _get_plugin_display_id(plugin_id)
+                                    display_id = await _get_plugin_display_id(plugin_id)
                                     _fail_summary = _rp_phrase('plugin_failed_with', _lang, id=display_id, detail=detail) if detail else _rp_phrase('plugin_failed', _lang, id=display_id)
                                     await _emit_task_result(
                                         lanlan_name,
@@ -2470,7 +2466,7 @@ async def plugin_execute_direct(payload: Dict[str, Any]):
     logger.info(f"[Plugin] Direct execute request: plugin_id={plugin_id}, entry_id={entry_id}, lanlan={lanlan_name}")
 
     # 获取插件友好名称（用于 HUD 显示）
-    plugin_name = _get_plugin_friendly_name(plugin_id)
+    plugin_name = await _get_plugin_friendly_name(plugin_id)
     task_params = {"plugin_id": plugin_id, "entry_id": entry_id, "args": args}
     if plugin_name:
         task_params["plugin_name"] = plugin_name
@@ -2556,7 +2552,7 @@ async def plugin_execute_direct(payload: Dict[str, Any]):
                     if not res.success:
                         info["error"] = (detail or str(res.error or ""))[:500]
                     _lang = _rp_lang(None)
-                    display_id = _get_plugin_display_id(plugin_id)
+                    display_id = await _get_plugin_display_id(plugin_id)
                     if res.success:
                         summary = _rp_phrase('plugin_done_with', _lang, id=display_id, detail=detail) if detail else _rp_phrase('plugin_done', _lang, id=display_id)
                     else:

--- a/agent_server.py
+++ b/agent_server.py
@@ -3258,7 +3258,7 @@ async def set_agent_flags(payload: Dict[str, Any]):
                 asyncio.ensure_future(_fire_agent_llm_connectivity_check())
             else:
                 try:
-                    avail = Modules.computer_use.is_available()
+                    avail = await asyncio.to_thread(Modules.computer_use.is_available)
                     reasons = avail.get('reasons', []) if isinstance(avail, dict) else []
                     _set_capability("computer_use", bool(avail.get("ready")) if isinstance(avail, dict) else False, reasons[0] if reasons else "")
                     if avail.get("ready"):

--- a/agent_server.py
+++ b/agent_server.py
@@ -3030,7 +3030,7 @@ async def openfang_availability():
     """检查 OpenFang 可用性。"""
     if not Modules.openfang:
         return {"enabled": False, "ready": False, "reason": "adapter 未加载"}
-    return Modules.openfang.is_available()
+    return await asyncio.to_thread(Modules.openfang.is_available)
 
 
 @app.get("/openclaw/availability")
@@ -3494,7 +3494,7 @@ async def computer_use_availability():
     if not getattr(Modules.computer_use, "init_ok", False):
         asyncio.ensure_future(_fire_agent_llm_connectivity_check())
 
-    status = Modules.computer_use.is_available()
+    status = await asyncio.to_thread(Modules.computer_use.is_available)
     reasons = status.get("reasons", []) if isinstance(status, dict) else []
     _set_capability("computer_use", bool(status.get("ready")) if isinstance(status, dict) else False, reasons[0] if reasons else "")
     
@@ -3555,7 +3555,7 @@ async def computer_use_run(payload: Dict[str, Any]):
     screenshot = base64.b64decode(screenshot_b64) if isinstance(screenshot_b64, str) else None
     # Preflight readiness check to avoid scheduling tasks that will fail immediately
     try:
-        avail = Modules.computer_use.is_available()
+        avail = await asyncio.to_thread(Modules.computer_use.is_available)
         if not avail.get("ready"):
             return JSONResponse(content={"success": False, "error": "ComputerUse not ready", "reasons": avail.get("reasons", [])}, status_code=503)
     except Exception as e:

--- a/brain/browser_use_adapter.py
+++ b/brain/browser_use_adapter.py
@@ -694,7 +694,7 @@ class BrowserUseAdapter:
 
         from browser_use import Agent
 
-        ok, info = self._config_manager.consume_agent_daily_quota(
+        ok, info = await self._config_manager.aconsume_agent_daily_quota(
             source="browser_use.run_instruction",
             units=1,
         )

--- a/brain/deduper.py
+++ b/brain/deduper.py
@@ -50,7 +50,7 @@ class TaskDeduper:
         
         for attempt in range(max_retries):
             try:
-                ok, info = get_config_manager().consume_agent_daily_quota(
+                ok, info = await get_config_manager().aconsume_agent_daily_quota(
                     source="deduper.judge",
                     units=1,
                 )

--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -8,6 +8,7 @@ going through the user plugin runtime.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import uuid
 from typing import Any, Dict, Optional
@@ -162,7 +163,8 @@ class OpenClawAdapter:
     ) -> Dict[str, Any]:
         self.reload_config()
         sender = sender_id or self.default_sender_id
-        resolved_session_id = session_id or self.get_or_create_persistent_session_id(
+        resolved_session_id = session_id or await asyncio.to_thread(
+            self.get_or_create_persistent_session_id,
             role_name=role_name,
             sender_id=sender,
         )
@@ -218,7 +220,8 @@ class OpenClawAdapter:
     ) -> Dict[str, Any]:
         self.reload_config()
         sender = sender_id or self.default_sender_id
-        resolved_session_id = session_id or self.get_or_create_persistent_session_id(
+        resolved_session_id = session_id or await asyncio.to_thread(
+            self.get_or_create_persistent_session_id,
             role_name=role_name,
             sender_id=sender,
         )

--- a/brain/openfang_adapter.py
+++ b/brain/openfang_adapter.py
@@ -612,10 +612,10 @@ class OpenFangAdapter:
         except Exception as e:
             logger.error("[OpenFang] HTTP config sync failed: %s", e)
 
-        # (3) Write config.toml
+        # (3) Write config.toml（同步文件 IO，offload 到线程）
         file_written = False
         try:
-            self._write_openfang_model_config(api_key, base_url, model)
+            await asyncio.to_thread(self._write_openfang_model_config, api_key, base_url, model)
             file_written = True
         except Exception as e:
             logger.debug("[OpenFang] config.toml write failed (non-fatal): %s", e)
@@ -819,9 +819,9 @@ class OpenFangAdapter:
             f'temperature = 0.3\n'
             f'max_tokens = 4096\n'
         )
-        # 写 .env 供 Electron 下次重启注入 OpenFang 环境
+        # 写 .env 供 Electron 下次重启注入 OpenFang 环境（同步 IO，offload）
         if neko_api_key and api_key_env:
-            self._ensure_openfang_env_var(api_key_env, neko_api_key)
+            await asyncio.to_thread(self._ensure_openfang_env_var, api_key_env, neko_api_key)
         # base_url: proxy URL (需要兼容性修补) 或直连 URL (原生支持的 provider)
         manifest_toml += f'base_url = "{effective_url}"\n'
         print(f"[OpenFang DEBUG] manifest_toml:\n{manifest_toml}")

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -232,7 +232,7 @@ class DirectTaskExecutor:
         try:
             llm = self._get_llm(temperature=0, max_completion_tokens=150)
             for p in to_generate:
-                quota_error = self._check_agent_quota("task_executor.ensure_short_desc")
+                quota_error = await self._check_agent_quota("task_executor.ensure_short_desc")
                 if quota_error:
                     logger.debug("[Agent] Stopping short_description generation: quota exceeded")
                     break
@@ -352,9 +352,9 @@ class DirectTaskExecutor:
         except RuntimeError:
             logger.debug("[Agent] No running event loop, skipping async LLM close")
 
-    def _check_agent_quota(self, source: str) -> Optional[str]:
-        """免费版 Agent 模型每日 300 次本地限流。"""
-        ok, info = self._config_manager.consume_agent_daily_quota(source=source, units=1)
+    async def _check_agent_quota(self, source: str) -> Optional[str]:
+        """免费版 Agent 模型每日 300 次本地限流（async，避免事件循环阻塞）。"""
+        ok, info = await self._config_manager.aconsume_agent_daily_quota(source=source, units=1)
         if ok:
             return None
         return json.dumps({"code": "AGENT_QUOTA_EXCEEDED", "details": {"used": info.get('used', 0), "limit": info.get('limit', 300)}})
@@ -484,7 +484,7 @@ class DirectTaskExecutor:
                     {"role": "user", "content": user_prompt},
                 ]
 
-                quota_error = self._check_agent_quota("task_executor.assess_unified")
+                quota_error = await self._check_agent_quota("task_executor.assess_unified")
                 if quota_error:
                     return UnifiedChannelDecision()
 
@@ -630,7 +630,7 @@ class DirectTaskExecutor:
                 {"role": "user", "content": user_text},
             ]
 
-            quota_error = self._check_agent_quota("task_executor.coarse_screen")
+            quota_error = await self._check_agent_quota("task_executor.coarse_screen")
             if quota_error:
                 return []
 
@@ -706,8 +706,9 @@ class DirectTaskExecutor:
                     len(plugins_desc), len(plugin_list),
                 )
 
-                # BM25 + keyword filter
-                bm25_filtered, _ = stage1_filter(
+                # BM25 + keyword filter（纯 CPU，offload 到线程）
+                bm25_filtered, _ = await asyncio.to_thread(
+                    stage1_filter,
                     user_intent or conversation,
                     plugin_list,
                     bm25_top_k=10,
@@ -765,7 +766,7 @@ class DirectTaskExecutor:
                     {"role": "user", "content": user_prompt},
                 ]
 
-                quota_error = self._check_agent_quota("task_executor.assess_user_plugin")
+                quota_error = await self._check_agent_quota("task_executor.assess_user_plugin")
                 if quota_error:
                     return UserPluginDecision(
                         has_task=False,
@@ -1002,7 +1003,8 @@ class DirectTaskExecutor:
         cu_available = False
         if computer_use_enabled:
             try:
-                cu_available = self.computer_use.is_available().get('ready', False)
+                cu_status = await asyncio.to_thread(self.computer_use.is_available)
+                cu_available = cu_status.get('ready', False) if isinstance(cu_status, dict) else False
                 logger.info("[TaskExecutor] ComputerUse available: %s", cu_available)
             except Exception as e:
                 logger.warning("[TaskExecutor] Failed to check ComputerUse: %s", e)
@@ -1010,7 +1012,8 @@ class DirectTaskExecutor:
         browser_available = False
         if browser_use_enabled:
             try:
-                browser_available = self.browser_use.is_available().get("ready", False)
+                bu_status = await asyncio.to_thread(self.browser_use.is_available)
+                browser_available = bu_status.get("ready", False) if isinstance(bu_status, dict) else False
                 logger.info("[TaskExecutor] BrowserUse available: %s", browser_available)
             except Exception as e:
                 logger.warning("[TaskExecutor] Failed to check BrowserUse: %s", e)
@@ -1026,7 +1029,9 @@ class DirectTaskExecutor:
         copaw_available = False
         if openclaw_enabled and self.openclaw:
             try:
-                copaw_available = self.openclaw.is_available().get("ready", False)
+                # openclaw.is_available 内部走 sync httpx，必须 offload
+                oc_status = await asyncio.to_thread(self.openclaw.is_available)
+                copaw_available = oc_status.get("ready", False) if isinstance(oc_status, dict) else False
                 logger.info("[TaskExecutor] CoPaw available: %s", copaw_available)
             except Exception as e:
                 logger.warning("[TaskExecutor] Failed to check CoPaw: %s", e)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1353,7 +1353,7 @@ class LLMSessionManager:
 
             # 每次启动会话前都清理一次无效 voice_id，避免角色配置残留旧音色导致启动异常
             try:
-                cleaned_count, legacy_names = self._config_manager.cleanup_invalid_voice_ids()
+                cleaned_count, legacy_names = await asyncio.to_thread(self._config_manager.cleanup_invalid_voice_ids)
                 if cleaned_count > 0:
                     logger.info(f"🧹 start_session 前已清理 {cleaned_count} 个无效 voice_id")
                 self._enqueue_voice_migration_notice(legacy_names)
@@ -1927,7 +1927,7 @@ class LLMSessionManager:
             
             # 热切换准备时同样清理无效 voice_id，防止旧版本 voice 残留进入热切换流程
             try:
-                cleaned_count, legacy_names = self._config_manager.cleanup_invalid_voice_ids()
+                cleaned_count, legacy_names = await asyncio.to_thread(self._config_manager.cleanup_invalid_voice_ids)
                 if cleaned_count > 0:
                     logger.info(f"🧹 热切换准备: 已清理 {cleaned_count} 个无效 voice_id")
                 self._enqueue_voice_migration_notice(legacy_names)
@@ -2437,8 +2437,9 @@ class LLMSessionManager:
             delivered = await self.session.prompt_ephemeral(instruction)
             logger.info("[%s] trigger_greeting: delivered=%s", self.lanlan_name, delivered)
             # 投递成功后才真正消费节日/周末预算
+            # commit 内部会 atomic_write_json 消费预算文件，offload 以免阻塞事件循环
             if delivered and _holiday_token is not None:
-                commit_holiday_or_weekend_hint(self.lanlan_name, _holiday_token)
+                await asyncio.to_thread(commit_holiday_or_weekend_hint, self.lanlan_name, _holiday_token)
 
     def enqueue_agent_callback(self, callback: dict) -> None:
         """Enqueue a structured agent task callback for LLM injection.

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1556,17 +1556,16 @@ async def update_catgirl(name: str, request: Request):
 
 @router.delete('/catgirl/{name}')
 async def delete_catgirl(name: str):
-    import shutil
     _config_manager = get_config_manager()
     characters = _config_manager.load_characters()
     if name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
-    
+
     # 检查是否是当前正在使用的猫娘
     current_catgirl = characters.get('当前猫娘', '')
     if name == current_catgirl:
         return JSONResponse({'success': False, 'error': '不能删除当前正在使用的猫娘！请先切换到其他猫娘后再删除。'}, status_code=400)
-    
+
     # 删除对应的记忆文件
     try:
         memory_paths = [_config_manager.memory_dir, _config_manager.project_memory_dir]
@@ -1576,7 +1575,7 @@ async def delete_catgirl(name: str):
             f'settings_{name}.json',    # 设置文件
             f'recent_{name}.json',      # 最近聊天记录文件
         ]
-        
+
         for base_dir in memory_paths:
             for file_name in files_to_delete:
                 file_path = base_dir / file_name
@@ -1585,7 +1584,7 @@ async def delete_catgirl(name: str):
                         if file_path.is_dir():
                             await asyncio.to_thread(shutil.rmtree, file_path)
                         else:
-                            file_path.unlink()
+                            await asyncio.to_thread(file_path.unlink)
                         logger.info(f"已删除: {file_path}")
                     except Exception as e:
                         logger.warning(f"删除失败 {file_path}: {e}")

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1570,10 +1570,11 @@ async def delete_catgirl(name: str):
     try:
         memory_paths = [_config_manager.memory_dir, _config_manager.project_memory_dir]
         files_to_delete = [
-            f'semantic_memory_{name}',  # 语义记忆目录
-            f'time_indexed_{name}',     # 时间索引数据库文件
-            f'settings_{name}.json',    # 设置文件
-            f'recent_{name}.json',      # 最近聊天记录文件
+            f'semantic_memory_{name}',  # 语义记忆目录（旧布局）
+            f'time_indexed_{name}',     # 时间索引数据库文件（旧布局）
+            f'settings_{name}.json',    # 设置文件（旧布局）
+            f'recent_{name}.json',      # 最近聊天记录文件（旧布局）
+            name,                       # 新布局：memory/<name>/{recent,facts,reflections,persona,time_indexed.db,...}
         ]
 
         for base_dir in memory_paths:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -43,7 +43,7 @@ from utils.voice_clone import (
     QwenVoiceCloneError,
     qwen_language_hints,
 )
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json_async
 from utils.frontend_utils import find_models, find_model_directory, is_user_imported_model
 from utils.language_utils import normalize_language_code
 from utils.logger_config import get_module_logger

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -43,7 +43,7 @@ from utils.voice_clone import (
     QwenVoiceCloneError,
     qwen_language_hints,
 )
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.frontend_utils import find_models, find_model_directory, is_user_imported_model
 from utils.language_utils import normalize_language_code
 from utils.logger_config import get_module_logger
@@ -624,7 +624,7 @@ async def update_catgirl_l2d(name: str, request: Request):
                 logger.debug(f"已保存角色 {name} 的模型 {live2d_model}")
         
         # 保存配置
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
         await initialize_character_data()
@@ -705,7 +705,7 @@ async def update_catgirl_touch_set(name: str, request: Request):
         existing_touch_set[model_name] = touch_set_data
         
         set_reserved(characters['猫娘'][name], 'touch_set', existing_touch_set)
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
         
         initialize_character_data = get_initialize_character_data()
         if initialize_character_data:
@@ -822,7 +822,7 @@ async def update_catgirl_lighting(name: str, request: Request):
             get_reserved(characters['猫娘'][name], 'avatar', 'vrm', 'lighting', default=None),
         )
 
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
         
         if apply_runtime:
             initialize_character_data = get_initialize_character_data()
@@ -932,7 +932,7 @@ async def update_catgirl_mmd_settings(name: str, request: Request):
                 cursor_follow['enabled'] = _to_bool(cursor_follow['enabled'])
             set_reserved(characters['猫娘'][name], 'avatar', 'mmd', 'cursor_follow', cursor_follow)
 
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
 
         logger.info("已保存角色 %s 的MMD模型设置", name)
         return JSONResponse(content={
@@ -1025,7 +1025,7 @@ async def update_catgirl_voice_id(name: str, request: Request):
         }, status_code=400)
 
     set_reserved(characters['猫娘'][name], 'voice_id', voice_id)
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
     
     # 如果是当前活跃的猫娘，需要先通知前端，再关闭session
     is_current_catgirl = (name == characters.get('当前猫娘', ''))
@@ -1148,7 +1148,7 @@ async def rename_catgirl(old_name: str, request: Request):
     # 如果当前猫娘是被重命名的猫娘，也需要更新
     if is_current_catgirl:
         characters['当前猫娘'] = new_name
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
     # 自动重新加载配置
     initialize_character_data = get_initialize_character_data()
     await initialize_character_data()
@@ -1173,7 +1173,7 @@ async def unregister_voice(name: str):
         
         # COMPAT(v1->v2): 统一落到 _reserved.voice_id，旧平铺 voice_id 不再写入/删除。
         set_reserved(characters['猫娘'][name], 'voice_id', '')
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
 
         # 如果是当前活跃的猫娘，需要先通知前端，再关闭session
         is_current_catgirl = (name == characters.get('当前猫娘', ''))
@@ -1241,7 +1241,7 @@ async def set_current_catgirl(request: Request):
                     'error': '语音状态下无法切换角色，请先停止语音对话后再切换'
                 }, status_code=400)
     characters['当前猫娘'] = catgirl_name
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
     initialize_character_data = get_initialize_character_data()
     # 自动重新加载配置
     await initialize_character_data()
@@ -1315,7 +1315,7 @@ async def update_master(request: Request):
     initialize_character_data = get_initialize_character_data()
     characters = _config_manager.load_characters()
     characters['主人'] = {k: v for k, v in data.items() if v}
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
     # 自动重新加载配置
     await initialize_character_data()
     return {"success": True}
@@ -1352,7 +1352,7 @@ async def rename_master(old_name: str, request: Request):
             return JSONResponse({'success': False, 'error': '新档案名与已有猫娘名称冲突'}, status_code=400)
 
         characters['主人']['档案名'] = new_name
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
 
     try:
         initialize_character_data = get_initialize_character_data()
@@ -1411,7 +1411,7 @@ async def add_catgirl(request: Request):
                 catgirl_data[k] = v
 
     characters['猫娘'][key] = catgirl_data
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
     initialize_character_data = get_initialize_character_data()
     # 自动重新加载配置
     await initialize_character_data()
@@ -1504,7 +1504,7 @@ async def update_catgirl(name: str, request: Request):
     if model_type_in_payload and requested_model_type:
         set_reserved(characters['猫娘'][name], 'avatar', 'model_type', requested_model_type)
 
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
 
     new_voice_id = get_reserved(characters['猫娘'][name], 'voice_id', default='', legacy_keys=('voice_id',))
     voice_id_changed = voice_id_in_payload and old_voice_id != new_voice_id
@@ -1593,7 +1593,7 @@ async def delete_catgirl(name: str):
     
     # 删除角色配置
     del characters['猫娘'][name]
-    _config_manager.save_characters(characters)
+    await _config_manager.asave_characters(characters)
     initialize_character_data = get_initialize_character_data()
     await initialize_character_data()
     return {"success": True}
@@ -1613,7 +1613,7 @@ async def clear_voice_ids():
                     set_reserved(characters['猫娘'][name], 'voice_id', '')
                     cleared_count += 1
         
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
         await initialize_character_data()
@@ -1698,7 +1698,7 @@ async def set_microphone(request: Request):
         characters_data['当前麦克风'] = microphone_id
         
         # 保存配置
-        _config_manager.save_characters(characters_data)
+        await _config_manager.asave_characters(characters_data)
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
         await initialize_character_data()
@@ -1918,7 +1918,7 @@ async def delete_voice(voice_id: str):
                             affected_active_names.append(name)
             
             if cleaned_count > 0:
-                _config_manager.save_characters(characters)
+                await _config_manager.asave_characters(characters)
                 
                 # 对于受影响的活跃角色，通知并结束 session
                 for name in affected_active_names:
@@ -2925,7 +2925,7 @@ async def save_catgirl_to_model_folder(request: Request):
             
         # 保存角色卡到模型文件夹
         file_path = os.path.join(model_folder_path, safe_name)
-        atomic_write_json(file_path, chara_data, ensure_ascii=False, indent=2)
+        await atomic_write_json_async(file_path, chara_data, ensure_ascii=False, indent=2)
         
         logger.info(f"角色卡已成功保存到模型文件夹: {file_path}")
         return {"success": True, "path": file_path, "modelFolderPath": model_folder_path}
@@ -2975,7 +2975,7 @@ async def save_character_card(request: Request):
         characters['猫娘'][chara_name] = catgirl_data
         
         # 保存到characters.json
-        _config_manager.save_characters(characters)
+        await _config_manager.asave_characters(characters)
         
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
@@ -3657,7 +3657,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
             characters['猫娘'][character_name] = chara_data_to_save
 
             # 保存到文件
-            _config_manager.save_characters(characters)
+            await _config_manager.asave_characters(characters)
 
             # 刷新内存中的角色数据，确保磁盘和内存同步
             initialize_character_data = get_initialize_character_data()

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager, get_steamworks, get_session_manager, get_initialize_character_data
 from .characters_router import get_current_live2d_model
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json_async
 from utils.preferences import load_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, load_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
 from utils.logger_config import get_module_logger
 from utils.config_manager import get_reserved

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -9,6 +9,7 @@ Handles configuration-related API endpoints including:
 - API providers
 """
 
+import asyncio
 import json
 import os
 import threading
@@ -19,7 +20,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager, get_steamworks, get_session_manager, get_initialize_character_data
 from .characters_router import get_current_live2d_model
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.preferences import load_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, load_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
 from utils.logger_config import get_module_logger
 from utils.config_manager import get_reserved
@@ -348,8 +349,12 @@ async def save_preferences(request: Request):
                         width > 0 and height > 0):
                     viewport = None
 
-        # 更新偏好
-        if update_model_preferences(data['model_path'], data['position'], data['scale'], parameters, display, rotation, viewport, camera_position):
+        # 更新偏好（底层 atomic_write_json 会阻塞事件循环，offload 到线程池）
+        ok = await asyncio.to_thread(
+            update_model_preferences,
+            data['model_path'], data['position'], data['scale'], parameters, display, rotation, viewport, camera_position,
+        )
+        if ok:
             return {"success": True, "message": "偏好设置已保存"}
         else:
             return {"success": False, "error": "保存失败"}
@@ -395,7 +400,7 @@ async def save_conversation_settings(request: Request):
         if not isinstance(data, dict):
             return {"success": False, "error": "请求体必须为对象"}
 
-        if not save_global_conversation_settings(data):
+        if not await asyncio.to_thread(save_global_conversation_settings, data):
             return {"success": False, "error": "保存失败"}
 
         if 'noiseReductionEnabled' in data:
@@ -698,8 +703,8 @@ async def update_core_config(request: Request):
         if 'ttsVoiceId' in data:
             core_cfg['ttsVoiceId'] = data['ttsVoiceId']
         
-        atomic_write_json(core_config_path, core_cfg, indent=2, ensure_ascii=False)
-        
+        await atomic_write_json_async(core_config_path, core_cfg, indent=2, ensure_ascii=False)
+
         # API配置更新后，需要先通知所有客户端，再关闭session，最后重新加载配置
         logger.info("API配置已更新，准备通知客户端并重置所有session...")
         

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -6,6 +6,7 @@ Handles authentication-related endpoints with strict validation and
 unified logic for credential management.
 """
 
+import asyncio
 import re
 import io
 import base64
@@ -140,7 +141,7 @@ async def save_cookie(data: CookieSubmit):
         
         # 3. 存储
         encrypt = data.encrypt if data.encrypt is not None else True
-        success = save_cookies_to_file(data.platform, cookies, encrypt=encrypt)
+        success = await asyncio.to_thread(save_cookies_to_file, data.platform, cookies, encrypt=encrypt)
         
         if success:
             return {
@@ -424,7 +425,7 @@ async def api_qr_login_poll(
             if cookies and cookie_fields:
                 filtered_cookies = {k: v for k, v in cookies.items() if k in cookie_fields}
                 if filtered_cookies:
-                    save_ok = save_cookies_to_file(platform, filtered_cookies)
+                    save_ok = await asyncio.to_thread(save_cookies_to_file, platform, filtered_cookies)
                     if save_ok:
                         logger.info(f"✅ {platform} QR 登录凭证已自动持久化")
                     else:

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -339,7 +339,12 @@ class JukeboxConfig:
                 user_data["md5Index"]["actions"][md5_key] = action_id
 
         atomic_write_json(self.config_file, user_data)
-    
+
+    async def asave(self):
+        """异步 save 包装：事件循环上不能直接调用 save()（会阻塞）。"""
+        import asyncio
+        await asyncio.to_thread(self.save)
+
     def get_next_id(self, prefix: str) -> str:
         """获取下一个 ID"""
         existing = self.data.get(f"{prefix}s", {})
@@ -470,7 +475,7 @@ async def upload_songs(
         finally:
             file.file.close()
     
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     # 单首歌曲上传时直接返回结果，批量时返回结果列表
     if len(files) == 1:
@@ -494,7 +499,7 @@ async def delete_song(song_id: str):
         # 删除相关绑定
         if song_id in jukebox_config.data["bindings"]:
             del jukebox_config.data["bindings"][song_id]
-            jukebox_config.save()
+            await jukebox_config.asave()
             logger.info(f"删除内置歌曲的绑定关系: {song_id}")
         return {"success": True, "message": "内置歌曲的绑定关系已删除"}
 
@@ -515,7 +520,7 @@ async def delete_song(song_id: str):
 
     # 删除歌曲记录
     del jukebox_config.data["songs"][song_id]
-    jukebox_config.save()
+    await jukebox_config.asave()
 
     logger.info(f"删除歌曲: {song_id}")
     return {"success": True}
@@ -531,7 +536,7 @@ async def update_song_visibility(song_id: str, visible: bool = Form(...)):
         raise HTTPException(404, "歌曲不存在")
     
     jukebox_config.data["songs"][song_id]["visible"] = visible
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     return {"success": True}
 
@@ -554,7 +559,7 @@ async def update_song_metadata(
     if artist is not None:
         jukebox_config.data["songs"][song_id]["artist"] = artist
     
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     logger.info(f"更新歌曲元数据: {song_id}, name={name}, artist={artist}")
     return {"success": True}
@@ -573,7 +578,7 @@ async def update_action_metadata(
         raise HTTPException(404, "动画不存在")
     
     jukebox_config.data["actions"][action_id]["name"] = name
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     logger.info(f"更新动画元数据: {action_id}, name={name}")
     return {"success": True}
@@ -603,7 +608,7 @@ async def set_song_default_action(
             raise HTTPException(400, "该动画未绑定到此歌曲")
     
     jukebox_config.data["songs"][song_id]["defaultAction"] = action_id
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     logger.info(f"设置歌曲默认动画: {song_id} -> {action_id}")
     return {"success": True, "defaultAction": action_id}
@@ -700,7 +705,7 @@ async def upload_actions(
         finally:
             file.file.close()
     
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     # 单个动画上传时直接返回结果，批量时返回结果列表
     if len(files) == 1:
@@ -733,7 +738,7 @@ async def delete_action(action_id: str):
             # 如果没有绑定了，删除空字典
             if not bindings:
                 del jukebox_config.data["bindings"][song_id]
-        jukebox_config.save()
+        await jukebox_config.asave()
         logger.info(f"删除内置动画的绑定关系: {action_id}")
         return {"success": True, "message": "内置动画的绑定关系已删除"}
 
@@ -763,7 +768,7 @@ async def delete_action(action_id: str):
 
     # 删除动画记录
     del jukebox_config.data["actions"][action_id]
-    jukebox_config.save()
+    await jukebox_config.asave()
 
     logger.info(f"删除动画: {action_id}")
     return {"success": True}
@@ -819,7 +824,7 @@ async def bind_song_action(
         song["defaultAction"] = actionId
         logger.info(f"设置默认动画: {songId} -> {actionId} (首次绑定)")
     
-    jukebox_config.save()
+    await jukebox_config.asave()
     
     logger.info(f"建立绑定: {songId} <-> {actionId}, offset={offset}")
     return {"success": True, "defaultAction": song.get("defaultAction", "")}
@@ -855,7 +860,7 @@ async def unbind_song_action(
                 song["defaultAction"] = ""
                 logger.info(f"清除默认动画: {songId} (解绑了默认动画 {actionId})")
             
-            jukebox_config.save()
+            await jukebox_config.asave()
             logger.info(f"解除绑定: {songId} <-> {actionId}")
             return {"success": True, "defaultAction": song.get("defaultAction", "")}
     
@@ -1372,7 +1377,7 @@ async def import_config(file: UploadFile = File(...)):
                 local_song["defaultAction"] = local_action_id
                 logger.info(f"导入映射默认动画: {local_song_id} -> {local_action_id}")
 
-        jukebox_config.save()
+        await jukebox_config.asave()
         
         logger.info(f"导入完成: {stats}")
         return {"success": True, "stats": stats}

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -342,7 +342,6 @@ class JukeboxConfig:
 
     async def asave(self):
         """异步 save 包装：事件循环上不能直接调用 save()（会阻塞）。"""
-        import asyncio
         await asyncio.to_thread(self.save)
 
     def get_next_id(self, prefix: str) -> str:

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.frontend_utils import find_models, find_model_directory, find_workshop_item_by_id
 from utils.logger_config import get_module_logger
 from utils.url_utils import encode_url_path
@@ -242,8 +242,8 @@ async def update_model_config(model_name: str, request: Request):
         if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
             file_refs['Expressions'] = data['FileReferences']['Expressions']
 
-        atomic_write_json(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
-            
+        await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
+
         return {"success": True, "message": "模型配置已更新"}
     except Exception as e:
         logger.error(f"更新模型配置失败: {e}")
@@ -411,8 +411,8 @@ async def update_emotion_mapping(model_name: str, request: Request):
         config_data['EmotionMapping'] = data
 
         # 保存配置到文件
-        atomic_write_json(model_json_path, config_data, ensure_ascii=False, indent=2)
-        
+        await atomic_write_json_async(model_json_path, config_data, ensure_ascii=False, indent=2)
+
         logger.info(f"模型 {model_name} 的情绪映射配置已更新（已同步到 FileReferences）")
         return {"success": True, "message": "情绪映射配置已保存"}
     except Exception as e:
@@ -576,7 +576,7 @@ async def save_model_parameters(model_name: str, request: Request):
         
         # 保存到parameters.json文件
         parameters_file = os.path.join(model_dir, 'parameters.json')
-        atomic_write_json(parameters_file, parameters, indent=2, ensure_ascii=False)
+        await atomic_write_json_async(parameters_file, parameters, indent=2, ensure_ascii=False)
         
         logger.info(f"已保存模型参数到: {parameters_file}, 参数数量: {len(parameters)}")
         return {"success": True, "message": "参数保存成功"}
@@ -731,8 +731,8 @@ async def update_model_config_by_id(model_id: str, request: Request):
         if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
             file_refs['Expressions'] = data['FileReferences']['Expressions']
 
-        atomic_write_json(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
-            
+        await atomic_write_json_async(model_json_path, current_config, ensure_ascii=False, indent=4)  # 使用 indent=4 保持格式
+
         return {"success": True, "message": "模型配置已更新"}
     except Exception as e:
         logger.error(f"更新模型配置失败: {e}")
@@ -1016,7 +1016,7 @@ async def upload_live2d_model(files: list[UploadFile] = File(...)):
 
                         if modified:
                             try:
-                                atomic_write_json(motion_path, motion_data, ensure_ascii=False, indent=4)
+                                await atomic_write_json_async(motion_path, motion_data, ensure_ascii=False, indent=4)
                                 logger.info(f"已清除口型参数：{motion_path}")
                             except Exception:
                                 # 写入失败则记录但不阻止上传

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request
 from utils.character_name import validate_character_name
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.logger_config import get_module_logger
 from fastapi.responses import JSONResponse
 
@@ -330,7 +330,7 @@ async def save_recent_file(request: Request):
             }
         })
     try:
-        atomic_write_json(resolved_path, arr, ensure_ascii=False, indent=2)
+        await atomic_write_json_async(resolved_path, arr, ensure_ascii=False, indent=2)
         
         if catgirl_name:
             # 中断 memory_server 的 review 任务
@@ -458,7 +458,7 @@ async def update_catgirl_name(request: Request):
                         data['content'] = content
         
         # 保存更新后的内容；写入成功后再删除旧路径，避免改名过程中数据丢失
-        atomic_write_json(new_file_path, file_content, ensure_ascii=False, indent=2)
+        await atomic_write_json_async(new_file_path, file_content, ensure_ascii=False, indent=2)
 
         user_memory_dir = Path(cm.memory_dir).resolve()
         resolved_old_file_path = old_file_path.resolve()
@@ -520,7 +520,7 @@ async def update_review_config(request: Request):
         config_data['recent_memory_auto_review'] = enabled
         
         # 保存配置
-        atomic_write_json(config_path, config_data, ensure_ascii=False, indent=2)
+        await atomic_write_json_async(config_path, config_data, ensure_ascii=False, indent=2)
         
         logger.info(f"记忆整理配置已更新: enabled={enabled}")
         return {"success": True, "enabled": enabled}

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request
 from utils.character_name import validate_character_name
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json_async
 from utils.logger_config import get_module_logger
 from fastapi.responses import JSONResponse
 

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -460,17 +460,20 @@ async def update_catgirl_name(request: Request):
         # 保存更新后的内容；写入成功后再删除旧路径，避免改名过程中数据丢失
         await atomic_write_json_async(new_file_path, file_content, ensure_ascii=False, indent=2)
 
-        user_memory_dir = Path(cm.memory_dir).resolve()
+        allowed_roots = [
+            Path(cm.memory_dir).resolve(),
+            Path(cm.project_memory_dir).resolve(),
+        ]
         resolved_old_file_path = old_file_path.resolve()
         if (
             resolved_old_file_path != new_file_path.resolve()
             and old_file_path.exists()
-            and resolved_old_file_path.is_relative_to(user_memory_dir)
+            and any(resolved_old_file_path.is_relative_to(root) for root in allowed_roots)
         ):
             if old_file_path.is_dir():
                 await asyncio.to_thread(shutil.rmtree, old_file_path)
             else:
-                old_file_path.unlink()
+                await asyncio.to_thread(old_file_path.unlink)
         
         logger.info(f"已更新猫娘名称从 '{old_name}' 到 '{new_name}' 的记忆文件")
         return {"success": True}

--- a/main_routers/mmd_router.py
+++ b/main_routers/mmd_router.py
@@ -24,7 +24,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/model/mmd", tags=["mmd"])
@@ -792,7 +792,7 @@ async def update_emotion_mapping(request: Request):
         if not config_file.resolve().is_relative_to(config_path.resolve()):
             return JSONResponse(status_code=400, content={"success": False, "error": "无效的模型名称"})
 
-        atomic_write_json(config_file, mapping)
+        await atomic_write_json_async(config_file, mapping)
 
         logger.info(f"更新 MMD 情感映射: {safe_name}")
         return JSONResponse(content={"success": True, "message": "情感映射已更新"})

--- a/main_routers/mmd_router.py
+++ b/main_routers/mmd_router.py
@@ -24,7 +24,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json_async
 from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/model/mmd", tags=["mmd"])

--- a/main_routers/vrm_router.py
+++ b/main_routers/vrm_router.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json_async
 from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/model/vrm", tags=["vrm"])

--- a/main_routers/vrm_router.py
+++ b/main_routers/vrm_router.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/model/vrm", tags=["vrm"])
@@ -724,7 +724,7 @@ async def update_emotion_mapping(model_name: str, request: Request):
                 content={"success": False, "error": "无法创建配置目录"}
             )
 
-        atomic_write_json(config_path, normalized_data, ensure_ascii=False, indent=2)
+        await atomic_write_json_async(config_path, normalized_data, ensure_ascii=False, indent=2)
 
         logger.info(f"已保存VRM模型 {model_name} 的情感映射配置")
 

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from .shared_state import get_steamworks, get_config_manager, get_initialize_character_data
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, atomic_write_json_async
 from utils.workshop_utils import (
     ensure_workshop_folder_exists,
     get_workshop_path,
@@ -1329,7 +1329,8 @@ async def unsubscribe_workshop_item(request: Request):
                             logger.info(f"已从characters.json中删除角色卡: {chara_name}")
                     
                     if deleted_count > 0:
-                        # 保存更新后的characters.json
+                        # 保存更新后的characters.json（perform_cleanup 是同步闭包，被
+                        # Steamworks 回调线程调用，这里直接走同步 save_characters）
                         config_mgr.save_characters(characters)
                         logger.info(f"已保存更新后的characters.json，删除了 {deleted_count} 个角色卡")
                         
@@ -2034,7 +2035,7 @@ async def prepare_workshop_upload(request: Request):
         
         # 1. 复制角色卡JSON到临时目录(已验证为安全文件名)喵
         chara_file_path = os.path.join(temp_item_dir, safe_chara_name)
-        atomic_write_json(chara_file_path, chara_data, ensure_ascii=False, indent=2)
+        await atomic_write_json_async(chara_file_path, chara_data, ensure_ascii=False, indent=2)
         logger.info(f"角色卡已复制到临时目录: {chara_file_path}")
         
         # 2. 根据模型类型查找并复制模型文件
@@ -2472,7 +2473,13 @@ async def publish_to_workshop(request: Request):
                     logger.warning(f"读取角色卡数据时出错: {read_error}")
                 
                 # 写入元数据文件（包含快照）
-                write_workshop_meta(character_card_name, published_file_id, content_hash, uploaded_snapshot)
+                await asyncio.to_thread(
+                    write_workshop_meta,
+                    character_card_name,
+                    published_file_id,
+                    content_hash,
+                    uploaded_snapshot,
+                )
                 logger.info(f"已更新角色卡 {character_card_name} 的 .workshop_meta.json（包含快照）")
             except Exception as e:
                 logger.error(f"更新 .workshop_meta.json 失败: {e}")
@@ -2930,7 +2937,7 @@ async def sync_workshop_character_cards() -> dict:
             
             # 4. 保存并重新加载角色配置
             if need_save:
-                config_mgr.save_characters(characters)
+                await config_mgr.asave_characters(characters)
                 logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡")
                 
                 try:

--- a/main_server.py
+++ b/main_server.py
@@ -439,7 +439,8 @@ async def initialize_character_data():
     logger.info("正在加载角色配置...")
     
     # 清理无效的voice_id引用；如果发现旧版 CosyVoice 音色，推入通知缓冲池等前端连接后弹出
-    _cleaned, _legacy_names = _config_manager.cleanup_invalid_voice_ids()
+    # cleanup_invalid_voice_ids 内部涉及同步 IO（load/save characters），offload 以免阻塞事件循环
+    _cleaned, _legacy_names = await asyncio.to_thread(_config_manager.cleanup_invalid_voice_ids)
     if _legacy_names:
         core.enqueue_voice_migration_notice(_legacy_names)
     

--- a/main_server.py
+++ b/main_server.py
@@ -539,7 +539,7 @@ async def initialize_character_data():
         elif sync_process[k] is None:
             # 线程为None，需要启动
             need_start_thread = True
-        elif hasattr(sync_process[k], 'is_alive') and not sync_process[k].is_alive():
+        elif hasattr(sync_process[k], 'is_alive') and not await asyncio.to_thread(sync_process[k].is_alive):
             # 线程已停止，需要重启
             need_start_thread = True
             try:
@@ -596,7 +596,7 @@ async def initialize_character_data():
                 if k in sync_shutdown_event:
                     sync_shutdown_event[k].set()
                 await asyncio.to_thread(sync_process[k].join, timeout=3)  # 等待线程正常结束
-                if sync_process[k].is_alive():
+                if await asyncio.to_thread(sync_process[k].is_alive):
                     logger.warning(f"⚠️ 同步连接器线程 {k} 未能在超时内停止，将作为daemon线程自动清理")
                 else:
                     logger.info(f"✅ 已停止角色 {k} 的同步连接器线程")
@@ -939,6 +939,7 @@ async def on_startup():
     if _IS_MAIN_PROCESS:
         global steamworks, _preload_task, agent_event_bridge, _server_loop
         _server_loop = asyncio.get_running_loop()
+        _server_loop.slow_callback_duration = 0.05
         logger.info("正在初始化 Steamworks...")
         steamworks = initialize_steamworks()
         

--- a/main_server.py
+++ b/main_server.py
@@ -940,7 +940,12 @@ async def on_startup():
     if _IS_MAIN_PROCESS:
         global steamworks, _preload_task, agent_event_bridge, _server_loop
         _server_loop = asyncio.get_running_loop()
-        _server_loop.slow_callback_duration = 0.05
+        # asyncio 的慢回调告警只在 loop debug 模式下输出。默认关闭，
+        # 需要排查事件循环停顿时设 NEKO_DEBUG_ASYNC=1 启用（会略微增加每 callback 开销）。
+        if os.environ.get("NEKO_DEBUG_ASYNC") == "1":
+            _server_loop.set_debug(True)
+            _server_loop.slow_callback_duration = 0.05
+            logger.info("[asyncio] debug mode enabled (slow_callback_duration=0.05s)")
         logger.info("正在初始化 Steamworks...")
         steamworks = initialize_steamworks()
         

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -305,10 +305,7 @@ class FactStore:
 
             # Stage 2: FTS5 semantic dedup (lightweight, no LLM)
             if self._time_indexed is not None:
-                # TODO(T3): timeindex SQLite 改原生 async 后去掉 to_thread 包装
-                similar = await asyncio.to_thread(
-                    self._time_indexed.search_facts, lanlan_name, text, 3,
-                )
+                similar = await self._time_indexed.asearch_facts(lanlan_name, text, 3)
                 is_dup = False
                 for fid, score in similar:
                     if score < -5:
@@ -333,10 +330,7 @@ class FactStore:
 
             # Index in FTS5
             if self._time_indexed is not None:
-                # TODO(T3): timeindex SQLite 改原生 async 后去掉 to_thread 包装
-                await asyncio.to_thread(
-                    self._time_indexed.index_fact, lanlan_name, fact_entry['id'], text,
-                )
+                await self._time_indexed.aindex_fact(lanlan_name, fact_entry['id'], text)
 
         if new_facts:
             await self.asave_facts(lanlan_name)

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -21,7 +21,12 @@ from config import SETTING_PROPOSER_MODEL
 from config.prompts_memory import get_fact_extraction_prompt
 from utils.language_utils import get_global_language
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json, robust_json_loads
+from utils.file_utils import (
+    atomic_write_json,
+    atomic_write_json_async,
+    read_json_async,
+    robust_json_loads,
+)
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 
@@ -85,6 +90,11 @@ class FactStore:
             self._facts[name] = []
             return self._facts[name]
 
+    async def aload_facts(self, name: str) -> list[dict]:
+        if name in self._facts:
+            return self._facts[name]
+        return await asyncio.to_thread(self.load_facts, name)
+
     @classmethod
     def _migrate_v1_entity_values(cls, facts: list[dict]) -> bool:
         """Rename v1 entity values ('user'→'master', 'ai'→'neko') in-place."""
@@ -137,6 +147,9 @@ class FactStore:
                     f.write(datetime.now().isoformat())
             except Exception:
                 pass
+
+    async def asave_facts(self, name: str) -> None:
+        await asyncio.to_thread(self.save_facts, name)
 
     def _facts_archive_path(self, name: str) -> str:
         from memory import ensure_character_dir
@@ -192,7 +205,7 @@ class FactStore:
         from openai import APIConnectionError, InternalServerError, RateLimitError
         from utils.llm_client import create_chat_llm
 
-        _, _, _, _, name_mapping, _, _, _, _ = self._config_manager.get_character_data()
+        _, _, _, _, name_mapping, _, _, _, _ = await self._config_manager.aget_character_data()
         name_mapping['ai'] = lanlan_name
 
         # Build conversation text
@@ -271,7 +284,7 @@ class FactStore:
 
         # Deduplicate and store
         new_facts = []
-        existing_facts = self.load_facts(lanlan_name)
+        existing_facts = await self.aload_facts(lanlan_name)
         existing_hashes = {f.get('hash') for f in existing_facts if f.get('hash')}
 
         for fact in extracted:
@@ -292,7 +305,10 @@ class FactStore:
 
             # Stage 2: FTS5 semantic dedup (lightweight, no LLM)
             if self._time_indexed is not None:
-                similar = self._time_indexed.search_facts(lanlan_name, text, limit=3)
+                # TODO(T3): timeindex SQLite 改原生 async 后去掉 to_thread 包装
+                similar = await asyncio.to_thread(
+                    self._time_indexed.search_facts, lanlan_name, text, 3,
+                )
                 is_dup = False
                 for fid, score in similar:
                     if score < -5:
@@ -317,10 +333,13 @@ class FactStore:
 
             # Index in FTS5
             if self._time_indexed is not None:
-                self._time_indexed.index_fact(lanlan_name, fact_entry['id'], text)
+                # TODO(T3): timeindex SQLite 改原生 async 后去掉 to_thread 包装
+                await asyncio.to_thread(
+                    self._time_indexed.index_fact, lanlan_name, fact_entry['id'], text,
+                )
 
         if new_facts:
-            self.save_facts(lanlan_name)
+            await self.asave_facts(lanlan_name)
             print(f"📝 [FactStore] {lanlan_name}: 提取了 {len(new_facts)} 条新事实")
             for nf in new_facts:
                 print(f"   - [{nf.get('entity','?')}] {nf.get('text','')[:80]}")
@@ -333,6 +352,13 @@ class FactStore:
     def get_unabsorbed_facts(self, name: str, min_importance: int = 5) -> list[dict]:
         """Get facts that haven't been consumed by a reflection yet."""
         facts = self.load_facts(name)
+        return [
+            f for f in facts
+            if not f.get('absorbed') and f.get('importance', 0) >= min_importance
+        ]
+
+    async def aget_unabsorbed_facts(self, name: str, min_importance: int = 5) -> list[dict]:
+        facts = await self.aload_facts(name)
         return [
             f for f in facts
             if not f.get('absorbed') and f.get('importance', 0) >= min_importance
@@ -353,3 +379,6 @@ class FactStore:
                 changed = True
         if changed:
             self.save_facts(name)
+
+    async def amark_absorbed(self, name: str, fact_ids: list[str]) -> None:
+        await asyncio.to_thread(self.mark_absorbed, name, fact_ids)

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -23,8 +23,6 @@ from utils.language_utils import get_global_language
 from utils.config_manager import get_config_manager
 from utils.file_utils import (
     atomic_write_json,
-    atomic_write_json_async,
-    read_json_async,
     robust_json_loads,
 )
 from utils.logger_config import get_module_logger

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -17,6 +17,7 @@ Key features:
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -25,7 +26,12 @@ from datetime import datetime, timedelta
 
 from config import SETTING_PROPOSER_MODEL
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json, robust_json_loads
+from utils.file_utils import (
+    atomic_write_json,
+    atomic_write_json_async,
+    read_json_async,
+    robust_json_loads,
+)
 from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Memory")
@@ -159,6 +165,38 @@ class PersonaManager:
         self.save_persona(name, persona)
         return persona
 
+    async def aensure_persona(self, name: str) -> dict:
+        if name in self._personas:
+            if await self._async_sync_character_card(name, self._personas[name]):
+                await self.asave_persona(name, self._personas[name])
+            return self._personas[name]
+
+        path = self._persona_path(name)
+        if await asyncio.to_thread(os.path.exists, path):
+            try:
+                data = await read_json_async(path)
+                if isinstance(data, dict):
+                    migrated = self._migrate_v1_entity_keys(data)
+                    if self._is_persona_empty(data):
+                        await self._async_migrate_from_settings(name, data)
+                        migrated = True
+                    if await self._async_sync_character_card(name, data):
+                        migrated = True
+                    if migrated:
+                        await self.asave_persona(name, data)
+                    self._personas[name] = data
+                    return data
+                logger.warning(f"[Persona] {name}: persona 文件不是 dict，忽略")
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"[Persona] 加载失败: {e}")
+
+        persona = self._empty_persona()
+        await self._async_migrate_from_settings(name, persona)
+        await self._async_sync_character_card(name, persona)
+        self._personas[name] = persona
+        await self.asave_persona(name, persona)
+        return persona
+
     @staticmethod
     def _migrate_v1_entity_keys(persona: dict) -> bool:
         """One-time migration: rename v1 entity keys and unify inner key to 'facts'.
@@ -193,6 +231,58 @@ class PersonaManager:
         raw = f"{entity}:{field_name}"
         return f"card_{hashlib.sha256(raw.encode()).hexdigest()[:8]}"
 
+    def _resolve_settings_path(self, name: str) -> str | None:
+        from memory import ensure_character_dir
+        char_dir = ensure_character_dir(self._config_manager.memory_dir, name)
+        settings_path = os.path.join(char_dir, 'settings.json')
+        if not os.path.exists(settings_path):
+            old_path = os.path.join(str(self._config_manager.memory_dir), f'settings_{name}.json')
+            if os.path.exists(old_path):
+                return old_path
+            return None
+        return settings_path
+
+    def _apply_settings_migration(
+        self, name: str, persona: dict, master_name: str,
+        name_mapping: dict, old_settings: dict,
+    ) -> int:
+        def _is_migratable(val) -> bool:
+            if val is None:
+                return False
+            if isinstance(val, str):
+                return bool(val.strip())
+            if isinstance(val, (list, dict, set, tuple)):
+                return len(val) > 0
+            return True
+
+        def _existing_texts_for(facts_list):
+            return {e.get('text', '') for e in facts_list if isinstance(e, dict)}
+
+        migrated_count = 0
+        for section_key, facts_dict in old_settings.items():
+            if not isinstance(facts_dict, dict):
+                continue
+            if section_key == master_name or section_key == name_mapping.get('human', ''):
+                target = persona['master']['facts']
+            elif section_key == name:
+                target = persona['neko']['facts']
+            else:
+                target = persona['relationship']['facts']
+
+            seen = _existing_texts_for(target)
+            for k, v in facts_dict.items():
+                if _is_migratable(v):
+                    text = f"{k}: {v}"
+                    if text not in seen:
+                        entry = self._normalize_entry(text)
+                        content_hash = hashlib.sha256(text.encode()).hexdigest()[:8]
+                        entry['id'] = f"legacy_{content_hash}"
+                        entry['source'] = 'settings'
+                        target.append(entry)
+                        seen.add(text)
+                        migrated_count += 1
+        return migrated_count
+
     def _migrate_from_settings(self, name: str, persona: dict) -> None:
         """One-time migration from legacy settings.json to persona format.
 
@@ -200,66 +290,48 @@ class PersonaManager:
         角色卡数据（characters.json）的同步统一由 _sync_character_card() 负责，
         此方法不再处理角色卡，避免两处写入导致重复条目。
         """
-        from memory import ensure_character_dir
-
         _, _, _, _, name_mapping, _, _, _, _ = (
             self._config_manager.get_character_data()
         )
         master_name = name_mapping.get('human', '主人')
-        migrated_count = 0
 
-        # 确保 persona 有核心 entity 结构，防止 KeyError
         for section_key in ('neko', 'master', 'relationship'):
             persona.setdefault(section_key, {}).setdefault('facts', [])
 
-        def _is_migratable(val) -> bool:
-            """仅排除 None、空白字符串、空容器；保留 0/False 等标量假值。"""
-            if val is None:
-                return False
-            if isinstance(val, str):
-                return bool(val.strip())
-            if isinstance(val, (list, dict, set, tuple)):
-                return len(val) > 0
-            return True  # int 0, bool False 等合法标量
-
-        # ── 从 settings.json 迁移（LLM 提取的设定）──
-        char_dir = ensure_character_dir(self._config_manager.memory_dir, name)
-        settings_path = os.path.join(char_dir, 'settings.json')
-        if not os.path.exists(settings_path):
-            old_path = os.path.join(str(self._config_manager.memory_dir), f'settings_{name}.json')
-            if os.path.exists(old_path):
-                settings_path = old_path
-        if os.path.exists(settings_path):
+        settings_path = self._resolve_settings_path(name)
+        migrated_count = 0
+        if settings_path:
             try:
                 with open(settings_path, encoding='utf-8') as f:
                     old_settings = json.load(f)
                 if isinstance(old_settings, dict):
-                    # 按 target section 分别去重，避免跨 section 误去重
-                    def _existing_texts_for(facts_list):
-                        return {e.get('text', '') for e in facts_list if isinstance(e, dict)}
+                    migrated_count = self._apply_settings_migration(
+                        name, persona, master_name, name_mapping, old_settings,
+                    )
+            except Exception as e:
+                logger.warning(f"[Persona] {name}: settings.json 读取失败: {e}")
 
-                    for section_key, facts_dict in old_settings.items():
-                        if not isinstance(facts_dict, dict):
-                            continue
-                        if section_key == master_name or section_key == name_mapping.get('human', ''):
-                            target = persona['master']['facts']
-                        elif section_key == name:
-                            target = persona['neko']['facts']
-                        else:
-                            target = persona['relationship']['facts']
+        if migrated_count:
+            logger.info(f"[Persona] {name}: 迁移了 {migrated_count} 条 persona 数据（settings）")
 
-                        seen = _existing_texts_for(target)
-                        for k, v in facts_dict.items():
-                            if _is_migratable(v):
-                                text = f"{k}: {v}"
-                                if text not in seen:
-                                    entry = self._normalize_entry(text)
-                                    content_hash = hashlib.sha256(text.encode()).hexdigest()[:8]
-                                    entry['id'] = f"legacy_{content_hash}"
-                                    entry['source'] = 'settings'
-                                    target.append(entry)
-                                    seen.add(text)
-                                    migrated_count += 1
+    async def _async_migrate_from_settings(self, name: str, persona: dict) -> None:
+        _, _, _, _, name_mapping, _, _, _, _ = (
+            await self._config_manager.aget_character_data()
+        )
+        master_name = name_mapping.get('human', '主人')
+
+        for section_key in ('neko', 'master', 'relationship'):
+            persona.setdefault(section_key, {}).setdefault('facts', [])
+
+        settings_path = await asyncio.to_thread(self._resolve_settings_path, name)
+        migrated_count = 0
+        if settings_path:
+            try:
+                old_settings = await read_json_async(settings_path)
+                if isinstance(old_settings, dict):
+                    migrated_count = self._apply_settings_migration(
+                        name, persona, master_name, name_mapping, old_settings,
+                    )
             except Exception as e:
                 logger.warning(f"[Persona] {name}: settings.json 读取失败: {e}")
 
@@ -268,27 +340,11 @@ class PersonaManager:
 
     # ── character card 同步 ───────────────────────────────────────────
 
-    def _sync_character_card(self, name: str, persona: dict) -> bool:
-        """同步 character card 条目到 persona 头部，保持顺序与 characters.json 一致。
-
-        规则：
-        1. 读取当前 characters.json 的 neko/master 字段
-        2. 为每个字段生成确定性 ID (card_{entity}_{hash})
-        3. 与 persona 中 source=='character_card' 的条目对比
-        4. 更新文本变化的、新增缺少的、删除 card 中已移除的
-        5. card 条目始终排在 facts 列表头部，顺序与 card 一致
-
-        Returns True if any change was made.
-        """
+    def _apply_character_card_sync(
+        self, name: str, persona: dict,
+        master_basic_config, lanlan_basic_config,
+    ) -> bool:
         from config import CHARACTER_RESERVED_FIELDS
-
-        try:
-            _, _, master_basic_config, lanlan_basic_config, name_mapping, _, _, _, _ = (
-                self._config_manager.get_character_data()
-            )
-        except Exception:
-            return False
-
         excluded_fields = set(CHARACTER_RESERVED_FIELDS)
         changed = False
 
@@ -382,14 +438,56 @@ class PersonaManager:
 
         return changed
 
+    def _sync_character_card(self, name: str, persona: dict) -> bool:
+        """同步 character card 条目到 persona 头部，保持顺序与 characters.json 一致。
+
+        规则：
+        1. 读取当前 characters.json 的 neko/master 字段
+        2. 为每个字段生成确定性 ID (card_{entity}_{hash})
+        3. 与 persona 中 source=='character_card' 的条目对比
+        4. 更新文本变化的、新增缺少的、删除 card 中已移除的
+        5. card 条目始终排在 facts 列表头部，顺序与 card 一致
+
+        Returns True if any change was made.
+        """
+        try:
+            _, _, master_basic_config, lanlan_basic_config, _, _, _, _, _ = (
+                self._config_manager.get_character_data()
+            )
+        except Exception:
+            return False
+        return self._apply_character_card_sync(
+            name, persona, master_basic_config, lanlan_basic_config,
+        )
+
+    async def _async_sync_character_card(self, name: str, persona: dict) -> bool:
+        try:
+            _, _, master_basic_config, lanlan_basic_config, _, _, _, _, _ = (
+                await self._config_manager.aget_character_data()
+            )
+        except Exception:
+            return False
+        return self._apply_character_card_sync(
+            name, persona, master_basic_config, lanlan_basic_config,
+        )
+
     def save_persona(self, name: str, persona: dict | None = None) -> None:
         if persona is None:
             persona = self._personas.get(name, self._empty_persona())
         self._personas[name] = persona
         atomic_write_json(self._persona_path(name), persona, indent=2, ensure_ascii=False)
 
+    async def asave_persona(self, name: str, persona: dict | None = None) -> None:
+        if persona is None:
+            persona = self._personas.get(name, self._empty_persona())
+        self._personas[name] = persona
+        await atomic_write_json_async(self._persona_path(name), persona, indent=2, ensure_ascii=False)
+
     def get_persona(self, name: str) -> dict:
         return self.ensure_persona(name)
+
+    async def aget_persona(self, name: str) -> dict:
+        return await self.aensure_persona(name)
 
     # ── entry normalization ──────────────────────────────────────────
 
@@ -435,6 +533,37 @@ class PersonaManager:
     FACT_REJECTED_CARD = 'rejected_card'      # contradicts character_card → permanent
     FACT_QUEUED_CORRECTION = 'queued'         # contradicts non-card → correction queue
 
+    def _evaluate_fact_contradiction(
+        self, name: str, text: str, section_facts: list, stop_names: list[str],
+    ) -> tuple[str | None, str | None]:
+        """Returns (rejection_code, conflicting_text) or (None, None) if OK."""
+        for existing in section_facts:
+            if isinstance(existing, dict):
+                old_text = existing.get('text', '')
+                is_card = existing.get('source') == 'character_card'
+            else:
+                old_text = str(existing)
+                is_card = False
+            if self._texts_may_contradict(old_text, text, stop_names=stop_names):
+                if is_card:
+                    logger.info(
+                        f"[Persona] {name}: 新条目与角色卡矛盾，无条件拒绝: "
+                        f"card=\"{old_text[:40]}\" vs new=\"{text[:40]}\""
+                    )
+                    return self.FACT_REJECTED_CARD, old_text
+                return self.FACT_QUEUED_CORRECTION, old_text
+        return None, None
+
+    def _build_fact_entry(self, text: str, source: str, source_id: str | None) -> dict:
+        entry = self._normalize_entry(text)
+        if source == 'reflection' and source_id:
+            entry['id'] = f"prom_{source_id}"
+        else:
+            entry['id'] = f"manual_{datetime.now().strftime('%Y%m%d%H%M%S')}_{hashlib.sha256(text.encode()).hexdigest()[:8]}"
+        entry['source'] = source
+        entry['source_id'] = source_id
+        return entry
+
     def add_fact(self, name: str, text: str, entity: str = 'master',
                  source: str = 'manual', source_id: str | None = None) -> str:
         """Add a confirmed fact to persona. Checks for contradictions first.
@@ -452,32 +581,32 @@ class PersonaManager:
         section_facts = self._get_section_facts(persona, entity)
         stop_names = self._get_entity_stop_names()
 
-        for existing in section_facts:
-            if isinstance(existing, dict):
-                old_text = existing.get('text', '')
-                is_card = existing.get('source') == 'character_card'
-            else:
-                old_text = str(existing)
-                is_card = False
-            if self._texts_may_contradict(old_text, text, stop_names=stop_names):
-                if is_card:
-                    logger.info(
-                        f"[Persona] {name}: 新条目与角色卡矛盾，无条件拒绝: "
-                        f"card=\"{old_text[:40]}\" vs new=\"{text[:40]}\""
-                    )
-                    return self.FACT_REJECTED_CARD
-                self._queue_correction(name, old_text, text, entity)
-                return self.FACT_QUEUED_CORRECTION
+        code, old_text = self._evaluate_fact_contradiction(name, text, section_facts, stop_names)
+        if code == self.FACT_REJECTED_CARD:
+            return self.FACT_REJECTED_CARD
+        if code == self.FACT_QUEUED_CORRECTION:
+            self._queue_correction(name, old_text, text, entity)
+            return self.FACT_QUEUED_CORRECTION
 
-        entry = self._normalize_entry(text)
-        if source == 'reflection' and source_id:
-            entry['id'] = f"prom_{source_id}"
-        else:
-            entry['id'] = f"manual_{datetime.now().strftime('%Y%m%d%H%M%S')}_{hashlib.sha256(text.encode()).hexdigest()[:8]}"
-        entry['source'] = source
-        entry['source_id'] = source_id
-        section_facts.append(entry)
+        section_facts.append(self._build_fact_entry(text, source, source_id))
         self.save_persona(name, persona)
+        return self.FACT_ADDED
+
+    async def aadd_fact(self, name: str, text: str, entity: str = 'master',
+                        source: str = 'manual', source_id: str | None = None) -> str:
+        persona = await self.aensure_persona(name)
+        section_facts = self._get_section_facts(persona, entity)
+        stop_names = await self._aget_entity_stop_names()
+
+        code, old_text = self._evaluate_fact_contradiction(name, text, section_facts, stop_names)
+        if code == self.FACT_REJECTED_CARD:
+            return self.FACT_REJECTED_CARD
+        if code == self.FACT_QUEUED_CORRECTION:
+            await self._aqueue_correction(name, old_text, text, entity)
+            return self.FACT_QUEUED_CORRECTION
+
+        section_facts.append(self._build_fact_entry(text, source, source_id))
+        await self.asave_persona(name, persona)
         return self.FACT_ADDED
 
     def _get_section_facts(self, persona: dict, entity: str) -> list:
@@ -488,6 +617,20 @@ class PersonaManager:
         try:
             master_name, her_name, _, _, _, _, _, _, _ = (
                 self._config_manager.get_character_data()
+            )
+            names = []
+            if master_name:
+                names.append(master_name)
+            if her_name:
+                names.append(her_name)
+            return names
+        except Exception:
+            return []
+
+    async def _aget_entity_stop_names(self) -> list[str]:
+        try:
+            master_name, her_name, _, _, _, _, _, _, _ = (
+                await self._config_manager.aget_character_data()
             )
             names = []
             if master_name:
@@ -526,20 +669,38 @@ class PersonaManager:
 
     # ── contradiction queue ──────────────────────────────────────────
 
-    def _queue_correction(self, name: str, old_text: str, new_text: str, entity: str) -> None:
-        corrections = self.load_pending_corrections(name)
+    @staticmethod
+    def _build_correction_list(
+        corrections: list[dict], old_text: str, new_text: str, entity: str,
+    ) -> list[dict] | None:
+        """Returns the modified list or None if duplicate (no change needed)."""
         for existing in corrections:
             if (existing.get('old_text') == old_text
                     and existing.get('new_text') == new_text
                     and existing.get('entity') == entity):
-                return
+                return None
         corrections.append({
             'old_text': old_text,
             'new_text': new_text,
             'entity': entity,
             'created_at': datetime.now().isoformat(),
         })
-        atomic_write_json(self._corrections_path(name), corrections, indent=2, ensure_ascii=False)
+        return corrections
+
+    def _queue_correction(self, name: str, old_text: str, new_text: str, entity: str) -> None:
+        corrections = self.load_pending_corrections(name)
+        updated = self._build_correction_list(corrections, old_text, new_text, entity)
+        if updated is None:
+            return
+        atomic_write_json(self._corrections_path(name), updated, indent=2, ensure_ascii=False)
+        logger.info(f"[Persona] {name}: 发现潜在矛盾，加入审视队列")
+
+    async def _aqueue_correction(self, name: str, old_text: str, new_text: str, entity: str) -> None:
+        corrections = await self.aload_pending_corrections(name)
+        updated = self._build_correction_list(corrections, old_text, new_text, entity)
+        if updated is None:
+            return
+        await atomic_write_json_async(self._corrections_path(name), updated, indent=2, ensure_ascii=False)
         logger.info(f"[Persona] {name}: 发现潜在矛盾，加入审视队列")
 
     def load_pending_corrections(self, name: str) -> list[dict]:
@@ -554,6 +715,18 @@ class PersonaManager:
                 pass
         return []
 
+    async def aload_pending_corrections(self, name: str) -> list[dict]:
+        path = self._corrections_path(name)
+        if not await asyncio.to_thread(os.path.exists, path):
+            return []
+        try:
+            data = await read_json_async(path)
+            if isinstance(data, list):
+                return data
+        except (json.JSONDecodeError, OSError):
+            pass
+        return []
+
     async def resolve_corrections(self, name: str) -> int:
         """用 correction model 批量审视矛盾队列（单次 LLM 调用）。
 
@@ -562,7 +735,7 @@ class PersonaManager:
         """
         from config.prompts_memory import persona_correction_prompt
 
-        corrections = self.load_pending_corrections(name)
+        corrections = await self.aload_pending_corrections(name)
         if not corrections:
             return 0
 
@@ -607,7 +780,7 @@ class PersonaManager:
             return 0
 
         # 应用结果
-        persona = self.ensure_persona(name)
+        persona = await self.aensure_persona(name)
         resolved = 0
         for result in results:
             if not isinstance(result, dict):
@@ -652,7 +825,7 @@ class PersonaManager:
             resolved += 1
 
         if resolved:
-            self.save_persona(name, persona)
+            await self.asave_persona(name, persona)
             # Only remove processed corrections, keep unprocessed ones
             processed_indices: set[int] = set()
             for r in results:
@@ -664,19 +837,14 @@ class PersonaManager:
                 except (ValueError, TypeError):
                     continue
             remaining = [c for i, c in enumerate(corrections) if i not in processed_indices]
-            atomic_write_json(self._corrections_path(name), remaining,
-                              indent=2, ensure_ascii=False)
+            await atomic_write_json_async(self._corrections_path(name), remaining,
+                                          indent=2, ensure_ascii=False)
             logger.info(f"[Persona] {name}: 批量审视完成 {resolved} 条矛盾，剩余 {len(remaining)} 条")
         return resolved
 
     # ── 提及疲劳：记录 + 更新 suppress ───────────────────────────
 
-    def record_mentions(self, name: str, response_text: str) -> None:
-        """主动搭话投递后，扫描 response 中哪些 persona 条目被提及。
-
-        核心逻辑：5小时内提及 > SUPPRESS_MENTION_LIMIT 次 → suppress。
-        """
-        persona = self.ensure_persona(name)
+    def _apply_record_mentions(self, persona: dict, response_text: str) -> bool:
         now_str = datetime.now().isoformat()
         now = datetime.now()
         cutoff = now - timedelta(hours=SUPPRESS_WINDOW_HOURS)
@@ -686,29 +854,36 @@ class PersonaManager:
             if not isinstance(entry, dict):
                 continue
             if entry.get('protected'):
-                continue  # 硬编码条目不参与 suppress 计数
+                continue
             if not _is_mentioned(entry.get('text', ''), response_text):
                 continue
 
-            # 记录本次提及时间
             mentions = entry.get('recent_mentions', [])
             mentions.append(now_str)
-            # 清理窗口外的旧记录
             mentions = [t for t in mentions if self._in_window(t, cutoff)]
             entry['recent_mentions'] = mentions
 
-            # 窗口内超限 → suppress
             if not entry.get('suppress') and len(mentions) > SUPPRESS_MENTION_LIMIT:
                 entry['suppress'] = True
                 entry['suppressed_at'] = now_str
             changed = True
+        return changed
 
-        if changed:
+    def record_mentions(self, name: str, response_text: str) -> None:
+        """主动搭话投递后，扫描 response 中哪些 persona 条目被提及。
+
+        核心逻辑：5小时内提及 > SUPPRESS_MENTION_LIMIT 次 → suppress。
+        """
+        persona = self.ensure_persona(name)
+        if self._apply_record_mentions(persona, response_text):
             self.save_persona(name, persona)
 
-    def update_suppressions(self, name: str) -> None:
-        """刷新 suppress 状态：冷却期过 → 解除；清理窗口外的 recent_mentions。"""
-        persona = self.ensure_persona(name)
+    async def arecord_mentions(self, name: str, response_text: str) -> None:
+        persona = await self.aensure_persona(name)
+        if self._apply_record_mentions(persona, response_text):
+            await self.asave_persona(name, persona)
+
+    def _apply_update_suppressions(self, persona: dict) -> bool:
         now = datetime.now()
         cutoff = now - timedelta(hours=SUPPRESS_WINDOW_HOURS)
         changed = False
@@ -717,14 +892,12 @@ class PersonaManager:
             if not isinstance(entry, dict):
                 continue
 
-            # 清理窗口外的旧记录
             mentions = entry.get('recent_mentions', [])
             cleaned = [t for t in mentions if self._in_window(t, cutoff)]
             if len(cleaned) != len(mentions):
                 entry['recent_mentions'] = cleaned
                 changed = True
 
-            # suppress 冷却检查
             if entry.get('suppress'):
                 suppressed_str = entry.get('suppressed_at')
                 if suppressed_str:
@@ -737,9 +910,18 @@ class PersonaManager:
                             changed = True
                     except (ValueError, TypeError):
                         pass
+        return changed
 
-        if changed:
+    def update_suppressions(self, name: str) -> None:
+        """刷新 suppress 状态：冷却期过 → 解除；清理窗口外的 recent_mentions。"""
+        persona = self.ensure_persona(name)
+        if self._apply_update_suppressions(persona):
             self.save_persona(name, persona)
+
+    async def aupdate_suppressions(self, name: str) -> None:
+        persona = await self.aensure_persona(name)
+        if self._apply_update_suppressions(persona):
+            await self.asave_persona(name, persona)
 
     @staticmethod
     def _in_window(ts_str: str, cutoff: datetime) -> bool:
@@ -759,21 +941,13 @@ class PersonaManager:
 
     # ── rendering ────────────────────────────────────────────────────
 
-    def render_persona_markdown(self, name: str, pending_reflections: list[dict] | None = None,
-                                   confirmed_reflections: list[dict] | None = None) -> str:
-        """Render persona as markdown for LLM context injection.
-
-        Suppressed entries are rendered in a separate "暂不主动提及" section,
-        NOT in their original sections. suppress has highest priority.
-        """
-        # Refresh suppressions before rendering so expired cooldowns are released
-        self.update_suppressions(name)
-        persona = self.ensure_persona(name)
-        _, _, _, _, name_mapping, _, _, _, _ = self._config_manager.get_character_data()
+    def _compose_persona_markdown(
+        self, name: str, persona: dict, name_mapping: dict,
+        pending_reflections: list[dict] | None,
+        confirmed_reflections: list[dict] | None,
+    ) -> str:
         master_name = name_mapping.get('human', '主人')
         ai_name = name
-
-        # Entity key → section header mapping for known entities
         _headers = {
             'master': f"关于{master_name}",
             'neko': f"关于{ai_name}",
@@ -782,7 +956,6 @@ class PersonaManager:
 
         sections = []
 
-        # Collect suppressed items across all sections
         suppressed_lines = []
         for entry in self._collect_all_entries(persona):
             if isinstance(entry, dict) and entry.get('suppress'):
@@ -790,7 +963,6 @@ class PersonaManager:
                 if text:
                     suppressed_lines.append(f"- {text}")
 
-        # Render each entity section dynamically
         for entity_key, section in persona.items():
             if not isinstance(section, dict):
                 continue
@@ -800,7 +972,6 @@ class PersonaManager:
                 header = _headers.get(entity_key, entity_key)
                 sections.append(f"### {header}\n" + "\n".join(lines))
 
-        # Pending reflections (also exclude suppressed)
         if pending_reflections:
             pending_lines = []
             for r in pending_reflections:
@@ -813,7 +984,6 @@ class PersonaManager:
                     + "\n".join(pending_lines)
                 )
 
-        # Confirmed reflections (软 persona：比 pending 更稳固，但仍可修正)
         if confirmed_reflections:
             confirmed_lines = []
             for r in confirmed_reflections:
@@ -826,7 +996,6 @@ class PersonaManager:
                     + "\n".join(confirmed_lines)
                 )
 
-        # Suppressed section (記得但别主动提)
         if suppressed_lines:
             sections.append(
                 f"### 暂不主动提及的内容（{ai_name}记得，但最近提到太多次了，不要再主动提起）\n"
@@ -834,6 +1003,33 @@ class PersonaManager:
             )
 
         return "\n\n".join(sections) if sections else ""
+
+    def render_persona_markdown(self, name: str, pending_reflections: list[dict] | None = None,
+                                   confirmed_reflections: list[dict] | None = None) -> str:
+        """Render persona as markdown for LLM context injection.
+
+        Suppressed entries are rendered in a separate "暂不主动提及" section,
+        NOT in their original sections. suppress has highest priority.
+        """
+        # Refresh suppressions before rendering so expired cooldowns are released
+        self.update_suppressions(name)
+        persona = self.ensure_persona(name)
+        _, _, _, _, name_mapping, _, _, _, _ = self._config_manager.get_character_data()
+        return self._compose_persona_markdown(
+            name, persona, name_mapping, pending_reflections, confirmed_reflections,
+        )
+
+    async def arender_persona_markdown(
+        self, name: str,
+        pending_reflections: list[dict] | None = None,
+        confirmed_reflections: list[dict] | None = None,
+    ) -> str:
+        await self.aupdate_suppressions(name)
+        persona = await self.aensure_persona(name)
+        _, _, _, _, name_mapping, _, _, _, _ = await self._config_manager.aget_character_data()
+        return self._compose_persona_markdown(
+            name, persona, name_mapping, pending_reflections, confirmed_reflections,
+        )
 
     def _is_suppressed_text(self, persona: dict, text: str) -> bool:
         """Check if a given text matches any suppressed entry."""

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -724,6 +724,7 @@ class PersonaManager:
             if isinstance(data, list):
                 return data
         except (json.JSONDecodeError, OSError):
+            # 文件损坏或被并发进程替换：按空队列处理，下次 add_pending_correction 会重建
             pass
         return []
 

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -15,7 +15,12 @@ from config.prompts_memory import (
 from utils.language_utils import get_global_language
 
 # Setup logger
-from utils.file_utils import atomic_write_json, robust_json_loads
+from utils.file_utils import (
+    atomic_write_json,
+    atomic_write_json_async,
+    read_json_async,
+    robust_json_loads,
+)
 from utils.logger_config import setup_logging
 logger, log_config = setup_logging(service_name="Memory", log_level=logging.INFO)
 
@@ -56,6 +61,14 @@ class CompressedRecentHistoryManager:
         except Exception as reset_error:
             logger.error(f"[RecentHistory] 重置 {lanlan_name} 的历史记录文件失败: {reset_error}", exc_info=True)
 
+    async def _areset_history_file(self, file_path, lanlan_name, reason):
+        try:
+            await asyncio.to_thread(os.makedirs, os.path.dirname(file_path), exist_ok=True)
+            await atomic_write_json_async(file_path, [], indent=2, ensure_ascii=False)
+            logger.warning(f"[RecentHistory] {lanlan_name} 的历史记录文件无效（{reason}），已重置为空列表: {file_path}")
+        except Exception as reset_error:
+            logger.error(f"[RecentHistory] 重置 {lanlan_name} 的历史记录文件失败: {reset_error}", exc_info=True)
+
     def _load_history_from_file(self, file_path, lanlan_name):
         """安全读取 recent 文件，遇到空文件或非法 JSON 时自动重置。"""
         try:
@@ -78,6 +91,29 @@ class CompressedRecentHistoryManager:
         except Exception as e:
             logger.warning(f"读取 {lanlan_name} 的历史记录文件失败: {e}，使用空列表")
             return []
+
+    async def _aload_history_from_file(self, file_path, lanlan_name):
+        try:
+            raw_content = await asyncio.to_thread(self._read_text, file_path)
+            if not raw_content.strip():
+                await self._areset_history_file(file_path, lanlan_name, "文件为空")
+                return []
+            file_content = json.loads(raw_content)
+            if not isinstance(file_content, list):
+                await self._areset_history_file(file_path, lanlan_name, "JSON 根节点不是列表")
+                return []
+            return messages_from_dict(file_content)
+        except json.JSONDecodeError as e:
+            await self._areset_history_file(file_path, lanlan_name, f"JSON 解析失败: {e}")
+            return []
+        except Exception as e:
+            logger.warning(f"读取 {lanlan_name} 的历史记录文件失败: {e}，使用空列表")
+            return []
+
+    @staticmethod
+    def _read_text(file_path: str) -> str:
+        with open(file_path, encoding='utf-8') as f:
+            return f.read()
     
     def _get_llm(self):
         """动态获取LLM实例以支持配置热重载"""
@@ -97,38 +133,25 @@ class CompressedRecentHistoryManager:
 
     async def update_history(self, new_messages, lanlan_name, detailed=False, compress=True):
         try:
-            _, _, _, _, _, _, _, _, recent_log = self._config_manager.get_character_data()
+            _, _, _, _, _, _, _, _, recent_log = await self._config_manager.aget_character_data()
             self.log_file_path = recent_log
         except Exception as e:
             logger.error(f"获取角色配置失败: {e}")
 
         self._ensure_path_for_character(lanlan_name)
 
-        # 确保角色在 user_histories 中
         if lanlan_name not in self.user_histories:
             self.user_histories[lanlan_name] = []
-        
-        # 如果文件存在，加载历史记录
-        if lanlan_name in self.log_file_path and os.path.exists(self.log_file_path[lanlan_name]):
-            self.user_histories[lanlan_name] = self._load_history_from_file(
-                self.log_file_path[lanlan_name],
-                lanlan_name
+
+        file_path = self.log_file_path[lanlan_name]
+        if await asyncio.to_thread(os.path.exists, file_path):
+            self.user_histories[lanlan_name] = await self._aload_history_from_file(
+                file_path, lanlan_name,
             )
 
         try:
             self.user_histories[lanlan_name].extend(new_messages)
             logger.debug(f"[RecentHistory] {lanlan_name} 添加了 {len(new_messages)} 条新消息，当前共 {len(self.user_histories[lanlan_name])} 条")
-
-            # 确保文件目录存在
-            file_path = self.log_file_path[lanlan_name]
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-
-            atomic_write_json(
-                file_path,
-                messages_to_dict(self.user_histories[lanlan_name]),
-                indent=2,
-                ensure_ascii=False,
-            )  # Save the updated history to file before compressing
 
             if compress and len(self.user_histories[lanlan_name]) > self.compress_threshold:
                 to_compress = self.user_histories[lanlan_name][:-self.max_history_length+1]
@@ -136,26 +159,12 @@ class CompressedRecentHistoryManager:
                 self.user_histories[lanlan_name] = compressed + self.user_histories[lanlan_name][-self.max_history_length+1:]
         except Exception as e:
             logger.error(f"[RecentHistory] 更新历史记录时出错: {e}", exc_info=True)
-            # 即使出错，也尝试保存当前状态
-            try:
-                file_path = self.log_file_path[lanlan_name]
-                os.makedirs(os.path.dirname(file_path), exist_ok=True)
-                atomic_write_json(
-                    file_path,
-                    messages_to_dict(self.user_histories.get(lanlan_name, [])),
-                    indent=2,
-                    ensure_ascii=False,
-                )
-            except Exception as save_error:
-                logger.error(f"[RecentHistory] 保存历史记录失败: {save_error}", exc_info=True)
 
-        # 统一保存
         try:
-            file_path = self.log_file_path[lanlan_name]
-            os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            atomic_write_json(
+            await asyncio.to_thread(os.makedirs, os.path.dirname(file_path), exist_ok=True)
+            await atomic_write_json_async(
                 file_path,
-                messages_to_dict(self.user_histories[lanlan_name]),
+                messages_to_dict(self.user_histories.get(lanlan_name, [])),
                 indent=2,
                 ensure_ascii=False,
             )
@@ -293,14 +302,34 @@ class CompressedRecentHistoryManager:
         # 确保角色在 user_histories 中
         if lanlan_name not in self.user_histories:
             self.user_histories[lanlan_name] = []
-        
+
         # 如果文件存在，加载历史记录
         if lanlan_name in self.log_file_path and os.path.exists(self.log_file_path[lanlan_name]):
             self.user_histories[lanlan_name] = self._load_history_from_file(
                 self.log_file_path[lanlan_name],
                 lanlan_name
             )
-        
+
+        return self.user_histories.get(lanlan_name, [])
+
+    async def aget_recent_history(self, lanlan_name):
+        try:
+            _, _, _, _, _, _, _, _, recent_log = await self._config_manager.aget_character_data()
+            self.log_file_path = recent_log
+        except Exception as e:
+            logger.error(f"获取角色配置失败: {e}")
+
+        self._ensure_path_for_character(lanlan_name)
+
+        if lanlan_name not in self.user_histories:
+            self.user_histories[lanlan_name] = []
+
+        file_path = self.log_file_path[lanlan_name]
+        if await asyncio.to_thread(os.path.exists, file_path):
+            self.user_histories[lanlan_name] = await self._aload_history_from_file(
+                file_path, lanlan_name,
+            )
+
         return self.user_histories.get(lanlan_name, [])
 
     async def review_history(self, lanlan_name, cancel_event=None):
@@ -319,18 +348,17 @@ class CompressedRecentHistoryManager:
             from utils.config_manager import get_config_manager
             config_manager = get_config_manager()
             config_path = str(config_manager.get_config_path('core_config.json'))
-            if os.path.exists(config_path):
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    config_data = json.load(f)
-                    if 'recent_memory_auto_review' in config_data and not config_data['recent_memory_auto_review']:
-                        print(f"{lanlan_name} 的自动记忆整理已禁用，跳过审阅")
-                        return False
+            if await asyncio.to_thread(os.path.exists, config_path):
+                config_data = await read_json_async(config_path)
+                if 'recent_memory_auto_review' in config_data and not config_data['recent_memory_auto_review']:
+                    print(f"{lanlan_name} 的自动记忆整理已禁用，跳过审阅")
+                    return False
         except Exception as e:
             print(f"读取配置文件失败：{e}，继续执行审阅")
-        
+
         # 获取当前历史记录
-        
-        current_history = self.get_recent_history(lanlan_name)
+
+        current_history = await self.aget_recent_history(lanlan_name)
         
         if not current_history:
             print(f"{lanlan_name} 的历史记录为空，无需审阅")
@@ -419,9 +447,9 @@ class CompressedRecentHistoryManager:
                     
                     # 更新历史记录
                     self.user_histories[lanlan_name] = corrected_messages
-                    
+
                     # 保存到文件
-                    atomic_write_json(
+                    await atomic_write_json_async(
                         self.log_file_path[lanlan_name],
                         messages_to_dict(corrected_messages),
                         indent=2,

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -153,6 +153,17 @@ class CompressedRecentHistoryManager:
             self.user_histories[lanlan_name].extend(new_messages)
             logger.debug(f"[RecentHistory] {lanlan_name} 添加了 {len(new_messages)} 条新消息，当前共 {len(self.user_histories[lanlan_name])} 条")
 
+            # 先把 extend 后的未压缩状态落盘，再进入耗时的 compress_history。
+            # compress_history 会走 LLM，耗时数秒到数十秒，期间进程崩溃或 task 被 cancel
+            # （CancelledError 穿透下面的 except Exception）会导致本批 new_messages 丢失。
+            await asyncio.to_thread(os.makedirs, os.path.dirname(file_path), exist_ok=True)
+            await atomic_write_json_async(
+                file_path,
+                messages_to_dict(self.user_histories[lanlan_name]),
+                indent=2,
+                ensure_ascii=False,
+            )
+
             if compress and len(self.user_histories[lanlan_name]) > self.compress_threshold:
                 to_compress = self.user_histories[lanlan_name][:-self.max_history_length+1]
                 compressed = [(await self.compress_history(to_compress, lanlan_name, detailed))[0]]

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -127,6 +127,7 @@ class ReflectionEngine:
                     to_archive.append(r)
                     continue
             except (ValueError, TypeError):
+                # 时间戳缺失/格式异常：不归档，落回 main 保守保留
                 pass
             keep_in_main.append(r)
         merged = reflections + keep_in_main

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -111,11 +111,8 @@ class ReflectionEngine:
 
     def _prepare_save_reflections(
         self, name: str, reflections: list[dict], all_on_disk: list[dict],
-    ) -> tuple[list[dict] | None, list[dict], list[dict]]:
-        """Pure logic: compute (merged_main, to_archive, existing_archive_after_merge).
-
-        Returns (None, [], []) to signal abort. Reads archive file if needed.
-        """
+    ) -> tuple[list[dict], list[dict], list[dict]]:
+        """Pure logic: compute (merged_main, to_archive, keep_in_main)."""
         active_ids = {r['id'] for r in reflections if 'id' in r}
         finished = [r for r in all_on_disk if r.get('id') not in active_ids
                     and r.get('status') in ('promoted', 'denied')]
@@ -152,8 +149,6 @@ class ReflectionEngine:
                 return
 
         merged, to_archive, _ = self._prepare_save_reflections(name, reflections, all_on_disk)
-        if merged is None:
-            return
 
         if to_archive:
             archive_path = self._reflections_archive_path(name)
@@ -188,8 +183,6 @@ class ReflectionEngine:
                 return
 
         merged, to_archive, _ = self._prepare_save_reflections(name, reflections, all_on_disk)
-        if merged is None:
-            return
 
         if to_archive:
             archive_path = self._reflections_archive_path(name)

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -78,8 +78,9 @@ class ReflectionEngine:
     # ── persistence ──────────────────────────────────────────────────
 
     @staticmethod
-    def _filter_reflections(data, include_archived: bool) -> list[dict]:
+    def _filter_reflections(data, include_archived: bool, path: str) -> list[dict]:
         if not isinstance(data, list):
+            logger.warning(f"[Reflection] reflections 文件不是列表，忽略: {path}")
             return []
         items = [item for item in data if isinstance(item, dict) and 'id' in item]
         if not include_archived:
@@ -92,7 +93,7 @@ class ReflectionEngine:
             try:
                 with open(path, encoding='utf-8') as f:
                     data = json.load(f)
-                return self._filter_reflections(data, include_archived)
+                return self._filter_reflections(data, include_archived, path)
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"[Reflection] 加载失败: {e}")
         return []
@@ -106,7 +107,7 @@ class ReflectionEngine:
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(f"[Reflection] 加载失败: {e}")
             return []
-        return self._filter_reflections(data, include_archived)
+        return self._filter_reflections(data, include_archived, path)
 
     def _prepare_save_reflections(
         self, name: str, reflections: list[dict], all_on_disk: list[dict],

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -18,6 +18,7 @@ automatically promoted to persona.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from datetime import datetime, timedelta
@@ -25,7 +26,12 @@ from typing import TYPE_CHECKING
 
 from config import SETTING_PROPOSER_MODEL
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json, robust_json_loads
+from utils.file_utils import (
+    atomic_write_json,
+    atomic_write_json_async,
+    read_json_async,
+    robust_json_loads,
+)
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 from memory.persona import PersonaManager
@@ -71,49 +77,47 @@ class ReflectionEngine:
 
     # ── persistence ──────────────────────────────────────────────────
 
+    @staticmethod
+    def _filter_reflections(data, include_archived: bool) -> list[dict]:
+        if not isinstance(data, list):
+            return []
+        items = [item for item in data if isinstance(item, dict) and 'id' in item]
+        if not include_archived:
+            items = [r for r in items if r.get('status') not in ('promoted', 'denied')]
+        return items
+
     def load_reflections(self, name: str, include_archived: bool = False) -> list[dict]:
         path = self._reflections_path(name)
         if os.path.exists(path):
             try:
                 with open(path, encoding='utf-8') as f:
                     data = json.load(f)
-                if isinstance(data, list):
-                    items = [item for item in data if isinstance(item, dict) and 'id' in item]
-                    if not include_archived:
-                        # Exclude promoted/denied (archived) from active operations
-                        items = [r for r in items if r.get('status') not in ('promoted', 'denied')]
-                    return items
-                logger.warning(f"[Reflection] reflections 文件不是列表，忽略: {path}")
+                return self._filter_reflections(data, include_archived)
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"[Reflection] 加载失败: {e}")
         return []
 
-    def save_reflections(self, name: str, reflections: list[dict]) -> None:
-        """Save reflections, merging with archived entries on disk.
-
-        promoted/denied 超过 _REFLECTION_ARCHIVE_DAYS 的条目自动移入归档文件。
-        """
+    async def aload_reflections(self, name: str, include_archived: bool = False) -> list[dict]:
         path = self._reflections_path(name)
-        # Load all (including archived) to preserve them
-        all_on_disk = []
-        if os.path.exists(path):
-            try:
-                with open(path, encoding='utf-8') as f:
-                    data = json.load(f)
-                if isinstance(data, list):
-                    all_on_disk = [r for r in data if isinstance(r, dict)]
-            except (json.JSONDecodeError, OSError) as e:
-                # 读取失败 → 中止保存，避免覆盖磁盘上的 promoted/denied 条目
-                logger.warning(f"[Reflection] {name}: 读取现有 reflections 失败，中止保存以保护归档数据: {e}")
-                return
+        if not await asyncio.to_thread(os.path.exists, path):
+            return []
+        try:
+            data = await read_json_async(path)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"[Reflection] 加载失败: {e}")
+            return []
+        return self._filter_reflections(data, include_archived)
 
-        # Build id→entry map from active list
+    def _prepare_save_reflections(
+        self, name: str, reflections: list[dict], all_on_disk: list[dict],
+    ) -> tuple[list[dict] | None, list[dict], list[dict]]:
+        """Pure logic: compute (merged_main, to_archive, existing_archive_after_merge).
+
+        Returns (None, [], []) to signal abort. Reads archive file if needed.
+        """
         active_ids = {r['id'] for r in reflections if 'id' in r}
-        # Keep archived entries that aren't in the active list
         finished = [r for r in all_on_disk if r.get('id') not in active_ids
-                     and r.get('status') in ('promoted', 'denied')]
-
-        # 分离需要归档的旧条目
+                    and r.get('status') in ('promoted', 'denied')]
         cutoff = datetime.now() - timedelta(days=_REFLECTION_ARCHIVE_DAYS)
         keep_in_main, to_archive = [], []
         for r in finished:
@@ -125,8 +129,30 @@ class ReflectionEngine:
             except (ValueError, TypeError):
                 pass
             keep_in_main.append(r)
+        merged = reflections + keep_in_main
+        return merged, to_archive, keep_in_main
 
-        # 归档到独立文件
+    def save_reflections(self, name: str, reflections: list[dict]) -> None:
+        """Save reflections, merging with archived entries on disk.
+
+        promoted/denied 超过 _REFLECTION_ARCHIVE_DAYS 的条目自动移入归档文件。
+        """
+        path = self._reflections_path(name)
+        all_on_disk = []
+        if os.path.exists(path):
+            try:
+                with open(path, encoding='utf-8') as f:
+                    data = json.load(f)
+                if isinstance(data, list):
+                    all_on_disk = [r for r in data if isinstance(r, dict)]
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"[Reflection] {name}: 读取现有 reflections 失败，中止保存以保护归档数据: {e}")
+                return
+
+        merged, to_archive, _ = self._prepare_save_reflections(name, reflections, all_on_disk)
+        if merged is None:
+            return
+
         if to_archive:
             archive_path = self._reflections_archive_path(name)
             existing: list[dict] = []
@@ -137,17 +163,50 @@ class ReflectionEngine:
                     if isinstance(data, list):
                         existing = data
                 except (json.JSONDecodeError, OSError) as e:
-                    # 归档文件损坏 → 放弃本次归档，保留在主文件中，避免覆盖丢数据
                     logger.warning(f"[Reflection] {name}: 读取归档文件失败，跳过本次归档: {e}")
-                    keep_in_main.extend(to_archive)
+                    merged = merged + to_archive
                     to_archive = []
             if to_archive:
                 existing.extend(to_archive)
                 atomic_write_json(archive_path, existing, indent=2, ensure_ascii=False)
                 logger.info(f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections")
 
-        merged = reflections + keep_in_main
         atomic_write_json(path, merged, indent=2, ensure_ascii=False)
+
+    async def asave_reflections(self, name: str, reflections: list[dict]) -> None:
+        path = self._reflections_path(name)
+        all_on_disk = []
+        if await asyncio.to_thread(os.path.exists, path):
+            try:
+                data = await read_json_async(path)
+                if isinstance(data, list):
+                    all_on_disk = [r for r in data if isinstance(r, dict)]
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"[Reflection] {name}: 读取现有 reflections 失败，中止保存以保护归档数据: {e}")
+                return
+
+        merged, to_archive, _ = self._prepare_save_reflections(name, reflections, all_on_disk)
+        if merged is None:
+            return
+
+        if to_archive:
+            archive_path = self._reflections_archive_path(name)
+            existing: list[dict] = []
+            if await asyncio.to_thread(os.path.exists, archive_path):
+                try:
+                    data = await read_json_async(archive_path)
+                    if isinstance(data, list):
+                        existing = data
+                except (json.JSONDecodeError, OSError) as e:
+                    logger.warning(f"[Reflection] {name}: 读取归档文件失败，跳过本次归档: {e}")
+                    merged = merged + to_archive
+                    to_archive = []
+            if to_archive:
+                existing.extend(to_archive)
+                await atomic_write_json_async(archive_path, existing, indent=2, ensure_ascii=False)
+                logger.info(f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections")
+
+        await atomic_write_json_async(path, merged, indent=2, ensure_ascii=False)
 
     def load_surfaced(self, name: str) -> list[dict]:
         """Load the list of reflections that were surfaced in proactive chat."""
@@ -157,15 +216,31 @@ class ReflectionEngine:
                 with open(path, encoding='utf-8') as f:
                     data = json.load(f)
                 if isinstance(data, list):
-                    # Filter to dicts only; drop corrupted entries
                     return [item for item in data if isinstance(item, dict)]
                 logger.warning(f"[Reflection] surfaced 文件不是列表，忽略: {path}")
             except (json.JSONDecodeError, OSError) as e:
                 logger.warning(f"[Reflection] 加载 surfaced 失败: {e}")
         return []
 
+    async def aload_surfaced(self, name: str) -> list[dict]:
+        path = self._surfaced_path(name)
+        if not await asyncio.to_thread(os.path.exists, path):
+            return []
+        try:
+            data = await read_json_async(path)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"[Reflection] 加载 surfaced 失败: {e}")
+            return []
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        logger.warning(f"[Reflection] surfaced 文件不是列表，忽略: {path}")
+        return []
+
     def save_surfaced(self, name: str, surfaced: list[dict]) -> None:
         atomic_write_json(self._surfaced_path(name), surfaced, indent=2, ensure_ascii=False)
+
+    async def asave_surfaced(self, name: str, surfaced: list[dict]) -> None:
+        await atomic_write_json_async(self._surfaced_path(name), surfaced, indent=2, ensure_ascii=False)
 
     # ── synthesis ────────────────────────────────────────────────────
 
@@ -178,11 +253,11 @@ class ReflectionEngine:
         from utils.language_utils import get_global_language
         from utils.llm_client import create_chat_llm
 
-        unabsorbed = self._fact_store.get_unabsorbed_facts(lanlan_name)
+        unabsorbed = await self._fact_store.aget_unabsorbed_facts(lanlan_name)
         if len(unabsorbed) < MIN_FACTS_FOR_REFLECTION:
             return []
 
-        _, _, _, _, name_mapping, _, _, _, _ = self._config_manager.get_character_data()
+        _, _, _, _, name_mapping, _, _, _, _ = await self._config_manager.aget_character_data()
         master_name = name_mapping.get('human', '主人')
 
         facts_text = "\n".join(f"- {f['text']} (importance: {f.get('importance', 5)})" for f in unabsorbed)
@@ -238,12 +313,12 @@ class ReflectionEngine:
             'next_eligible_at': (now + timedelta(minutes=REFLECTION_COOLDOWN_MINUTES)).isoformat(),
         }
 
-        reflections = self.load_reflections(lanlan_name)
+        reflections = await self.aload_reflections(lanlan_name)
         reflections.append(reflection)
-        self.save_reflections(lanlan_name, reflections)
+        await self.asave_reflections(lanlan_name, reflections)
 
         # Mark source facts as absorbed
-        self._fact_store.mark_absorbed(lanlan_name, reflection['source_fact_ids'])
+        await self._fact_store.amark_absorbed(lanlan_name, reflection['source_fact_ids'])
 
         logger.info(f"[Reflection] {lanlan_name}: 合成了新反思: {reflection_text[:50]}...")
         return [reflection]
@@ -261,18 +336,21 @@ class ReflectionEngine:
         reflections = self.load_reflections(lanlan_name)
         return [r for r in reflections if r.get('status') == 'pending']
 
+    async def aget_pending_reflections(self, lanlan_name: str) -> list[dict]:
+        reflections = await self.aload_reflections(lanlan_name)
+        return [r for r in reflections if r.get('status') == 'pending']
+
     def get_confirmed_reflections(self, lanlan_name: str) -> list[dict]:
         """Get all confirmed (soft persona) reflections."""
         reflections = self.load_reflections(lanlan_name)
         return [r for r in reflections if r.get('status') == 'confirmed']
 
-    def get_followup_topics(self, lanlan_name: str) -> list[dict]:
-        """Get pending reflections suitable for natural mention in proactive chat.
+    async def aget_confirmed_reflections(self, lanlan_name: str) -> list[dict]:
+        reflections = await self.aload_reflections(lanlan_name)
+        return [r for r in reflections if r.get('status') == 'confirmed']
 
-        Returns candidates that have passed their cooldown period.
-        Does NOT persist anything — call record_surfaced() after reply is sent.
-        """
-        pending = self.get_pending_reflections(lanlan_name)
+    @staticmethod
+    def _filter_followup_candidates(pending: list[dict]) -> list[dict]:
         if not pending:
             return []
         now = datetime.now()
@@ -282,11 +360,55 @@ class ReflectionEngine:
             if next_eligible:
                 try:
                     if datetime.fromisoformat(next_eligible) > now:
-                        continue  # still in cooldown
+                        continue
                 except (ValueError, TypeError):
                     pass
             eligible.append(r)
         return eligible[:2]
+
+    def get_followup_topics(self, lanlan_name: str) -> list[dict]:
+        """Get pending reflections suitable for natural mention in proactive chat.
+
+        Returns candidates that have passed their cooldown period.
+        Does NOT persist anything — call record_surfaced() after reply is sent.
+        """
+        return self._filter_followup_candidates(self.get_pending_reflections(lanlan_name))
+
+    async def aget_followup_topics(self, lanlan_name: str) -> list[dict]:
+        pending = await self.aget_pending_reflections(lanlan_name)
+        return self._filter_followup_candidates(pending)
+
+    def _apply_record_surfaced(
+        self, reflection_ids: list[str], reflections: list[dict], surfaced: list[dict],
+    ) -> tuple[bool, list[dict]]:
+        now = datetime.now()
+        now_str = now.isoformat()
+        next_eligible = (now + timedelta(minutes=REFLECTION_COOLDOWN_MINUTES)).isoformat()
+
+        id_to_text = {r['id']: r.get('text', '') for r in reflections}
+        cooldown_changed = False
+        for r in reflections:
+            if r.get('id') in reflection_ids:
+                r['next_eligible_at'] = next_eligible
+                cooldown_changed = True
+
+        for rid in reflection_ids:
+            found = False
+            for s in surfaced:
+                if s.get('reflection_id') == rid:
+                    s['surfaced_at'] = now_str
+                    s['text'] = id_to_text.get(rid, s.get('text', ''))
+                    s['feedback'] = None
+                    found = True
+                    break
+            if not found:
+                surfaced.append({
+                    'reflection_id': rid,
+                    'text': id_to_text.get(rid, ''),
+                    'surfaced_at': now_str,
+                    'feedback': None,
+                })
+        return cooldown_changed, surfaced
 
     def record_surfaced(self, lanlan_name: str, reflection_ids: list[str]) -> None:
         """Record which reflections were actually mentioned in proactive chat.
@@ -297,39 +419,25 @@ class ReflectionEngine:
         if not reflection_ids:
             return
         surfaced = self.load_surfaced(lanlan_name)
-        now = datetime.now()
-        now_str = now.isoformat()
-        next_eligible = (now + timedelta(minutes=REFLECTION_COOLDOWN_MINUTES)).isoformat()
-
-        # Load and update reflections (refresh cooldown)
         reflections = self.load_reflections(lanlan_name)
-        id_to_text = {r['id']: r.get('text', '') for r in reflections}
-        cooldown_changed = False
-        for r in reflections:
-            if r.get('id') in reflection_ids:
-                r['next_eligible_at'] = next_eligible
-                cooldown_changed = True
+        cooldown_changed, surfaced = self._apply_record_surfaced(
+            reflection_ids, reflections, surfaced,
+        )
         if cooldown_changed:
             self.save_reflections(lanlan_name, reflections)
-
-        for rid in reflection_ids:
-            # If already surfaced, refresh timestamp and clear feedback for re-check
-            found = False
-            for s in surfaced:
-                if s.get('reflection_id') == rid:
-                    s['surfaced_at'] = now_str
-                    s['text'] = id_to_text.get(rid, s.get('text', ''))
-                    s['feedback'] = None  # re-enable feedback collection
-                    found = True
-                    break
-            if not found:
-                surfaced.append({
-                    'reflection_id': rid,
-                    'text': id_to_text.get(rid, ''),
-                    'surfaced_at': now_str,
-                    'feedback': None,
-                })
         self.save_surfaced(lanlan_name, surfaced)
+
+    async def arecord_surfaced(self, lanlan_name: str, reflection_ids: list[str]) -> None:
+        if not reflection_ids:
+            return
+        surfaced = await self.aload_surfaced(lanlan_name)
+        reflections = await self.aload_reflections(lanlan_name)
+        cooldown_changed, surfaced = self._apply_record_surfaced(
+            reflection_ids, reflections, surfaced,
+        )
+        if cooldown_changed:
+            await self.asave_reflections(lanlan_name, reflections)
+        await self.asave_surfaced(lanlan_name, surfaced)
 
     async def check_feedback(self, lanlan_name: str, user_messages: list[str]) -> list[dict] | None:
         """Check if user's recent messages confirm/deny surfaced reflections.
@@ -340,7 +448,7 @@ class ReflectionEngine:
         from utils.language_utils import get_global_language
         from utils.llm_client import create_chat_llm
 
-        surfaced = self.load_surfaced(lanlan_name)
+        surfaced = await self.aload_surfaced(lanlan_name)
         pending_surfaced = [s for s in surfaced if s.get('feedback') is None]
         if not pending_surfaced:
             return []
@@ -388,7 +496,7 @@ class ReflectionEngine:
                 for s in surfaced:
                     if s.get('reflection_id') == rid:
                         s['feedback'] = feedback
-        self.save_surfaced(lanlan_name, surfaced)
+        await self.asave_surfaced(lanlan_name, surfaced)
 
         return feedbacks
 
@@ -440,6 +548,18 @@ class ReflectionEngine:
             logger.warning(f"[Reflection] 反驳检查失败: {e}")
             return None
 
+    @staticmethod
+    def _apply_promotion_status(
+        reflections: list[dict], reflection_id: str, status: str,
+    ) -> str | None:
+        now_str = datetime.now().isoformat()
+        for r in reflections:
+            if r.get('id') == reflection_id:
+                r['status'] = status
+                r[f'{status}_at'] = now_str
+                return r.get('text', '')
+        return None
+
     def confirm_promotion(self, lanlan_name: str, reflection_id: str) -> None:
         """Mark reflection as confirmed (soft persona). Does NOT write to persona yet.
 
@@ -448,39 +568,62 @@ class ReflectionEngine:
         upgrades them to real persona entries.
         """
         reflections = self.load_reflections(lanlan_name)
-        for r in reflections:
-            if r.get('id') == reflection_id:
-                r['status'] = 'confirmed'
-                r['confirmed_at'] = datetime.now().isoformat()
-                logger.info(f"[Reflection] {lanlan_name}: 反思已确认(软persona): {r['text'][:50]}...")
-                break
+        text = self._apply_promotion_status(reflections, reflection_id, 'confirmed')
+        if text is not None:
+            logger.info(f"[Reflection] {lanlan_name}: 反思已确认(软persona): {text[:50]}...")
         self.save_reflections(lanlan_name, reflections)
         self._mark_surfaced_handled(lanlan_name, reflection_id, 'confirmed')
+
+    async def aconfirm_promotion(self, lanlan_name: str, reflection_id: str) -> None:
+        reflections = await self.aload_reflections(lanlan_name)
+        text = self._apply_promotion_status(reflections, reflection_id, 'confirmed')
+        if text is not None:
+            logger.info(f"[Reflection] {lanlan_name}: 反思已确认(软persona): {text[:50]}...")
+        await self.asave_reflections(lanlan_name, reflections)
+        await self._amark_surfaced_handled(lanlan_name, reflection_id, 'confirmed')
 
     def reject_promotion(self, lanlan_name: str, reflection_id: str) -> None:
         """Mark a reflection as denied — won't be promoted."""
         reflections = self.load_reflections(lanlan_name)
-        for r in reflections:
-            if r.get('id') == reflection_id:
-                r['status'] = 'denied'
-                r['denied_at'] = datetime.now().isoformat()
-                logger.info(f"[Reflection] {lanlan_name}: 反思被否定: {r['text'][:50]}...")
-                break
+        text = self._apply_promotion_status(reflections, reflection_id, 'denied')
+        if text is not None:
+            logger.info(f"[Reflection] {lanlan_name}: 反思被否定: {text[:50]}...")
         self.save_reflections(lanlan_name, reflections)
         self._mark_surfaced_handled(lanlan_name, reflection_id, 'denied')
+
+    async def areject_promotion(self, lanlan_name: str, reflection_id: str) -> None:
+        reflections = await self.aload_reflections(lanlan_name)
+        text = self._apply_promotion_status(reflections, reflection_id, 'denied')
+        if text is not None:
+            logger.info(f"[Reflection] {lanlan_name}: 反思被否定: {text[:50]}...")
+        await self.asave_reflections(lanlan_name, reflections)
+        await self._amark_surfaced_handled(lanlan_name, reflection_id, 'denied')
+
+    @staticmethod
+    def _apply_mark_surfaced_handled(
+        surfaced: list[dict], reflection_id: str, feedback: str,
+    ) -> bool:
+        now_str = datetime.now().isoformat()
+        changed = False
+        for s in surfaced:
+            if s.get('reflection_id') == reflection_id and s.get('feedback') is None:
+                s['feedback'] = feedback
+                s['feedback_at'] = now_str
+                changed = True
+        return changed
 
     def _mark_surfaced_handled(self, lanlan_name: str, reflection_id: str, feedback: str) -> None:
         """Mark surfaced record as handled so check_feedback won't reprocess it."""
         surfaced = self.load_surfaced(lanlan_name)
-        changed = False
-        now = datetime.now().isoformat()
-        for s in surfaced:
-            if s.get('reflection_id') == reflection_id and s.get('feedback') is None:
-                s['feedback'] = feedback
-                s['feedback_at'] = now
-                changed = True
-        if changed:
+        if self._apply_mark_surfaced_handled(surfaced, reflection_id, feedback):
             self.save_surfaced(lanlan_name, surfaced)
+
+    async def _amark_surfaced_handled(
+        self, lanlan_name: str, reflection_id: str, feedback: str,
+    ) -> None:
+        surfaced = await self.aload_surfaced(lanlan_name)
+        if self._apply_mark_surfaced_handled(surfaced, reflection_id, feedback):
+            await self.asave_surfaced(lanlan_name, surfaced)
 
     def auto_promote_stale(self, lanlan_name: str) -> int:
         """Process two automatic state transitions:
@@ -500,7 +643,6 @@ class ReflectionEngine:
             status = r.get('status')
             try:
                 if status == 'pending':
-                    # pending → confirmed after AUTO_CONFIRM_DAYS
                     created = datetime.fromisoformat(r.get('created_at', ''))
                     if (now - created).total_seconds() / 86400 >= AUTO_CONFIRM_DAYS:
                         r['status'] = 'confirmed'
@@ -511,7 +653,6 @@ class ReflectionEngine:
                         logger.info(f"[Reflection] {lanlan_name}: pending→confirmed({AUTO_CONFIRM_DAYS}天): {r['text'][:50]}...")
 
                 elif status == 'confirmed':
-                    # confirmed → promoted after AUTO_PROMOTE_DAYS
                     confirmed_at = datetime.fromisoformat(r.get('confirmed_at', ''))
                     if (now - confirmed_at).total_seconds() / 86400 >= AUTO_PROMOTE_DAYS:
                         result = self._persona_manager.add_fact(
@@ -545,8 +686,75 @@ class ReflectionEngine:
                 self._batch_mark_surfaced_handled(lanlan_name, promoted_ids, 'promoted')
         return transitions
 
+    async def aauto_promote_stale(self, lanlan_name: str) -> int:
+        reflections = await self.aload_reflections(lanlan_name)
+        now = datetime.now()
+        transitions = 0
+        confirmed_ids: list[str] = []
+        promoted_ids: list[str] = []
+
+        for r in reflections:
+            status = r.get('status')
+            try:
+                if status == 'pending':
+                    created = datetime.fromisoformat(r.get('created_at', ''))
+                    if (now - created).total_seconds() / 86400 >= AUTO_CONFIRM_DAYS:
+                        r['status'] = 'confirmed'
+                        r['confirmed_at'] = now.isoformat()
+                        r['auto_confirmed'] = True
+                        confirmed_ids.append(r['id'])
+                        transitions += 1
+                        logger.info(f"[Reflection] {lanlan_name}: pending→confirmed({AUTO_CONFIRM_DAYS}天): {r['text'][:50]}...")
+
+                elif status == 'confirmed':
+                    confirmed_at = datetime.fromisoformat(r.get('confirmed_at', ''))
+                    if (now - confirmed_at).total_seconds() / 86400 >= AUTO_PROMOTE_DAYS:
+                        result = await self._persona_manager.aadd_fact(
+                            lanlan_name, r['text'],
+                            entity=r.get('entity', 'relationship'),
+                            source='reflection',
+                            source_id=r['id'],
+                        )
+                        if result == PersonaManager.FACT_ADDED:
+                            r['status'] = 'promoted'
+                            r['promoted_at'] = now.isoformat()
+                            promoted_ids.append(r['id'])
+                            transitions += 1
+                            logger.info(f"[Reflection] {lanlan_name}: confirmed→persona({AUTO_PROMOTE_DAYS}天): {r['text'][:50]}...")
+                        elif result == PersonaManager.FACT_REJECTED_CARD:
+                            r['status'] = 'denied'
+                            r['denied_at'] = now.isoformat()
+                            r['denied_reason'] = 'contradicts_character_card'
+                            transitions += 1
+                            logger.info(f"[Reflection] {lanlan_name}: confirmed→denied(与角色卡矛盾): {r['text'][:50]}...")
+                        else:
+                            logger.info(f"[Reflection] {lanlan_name}: confirmed→persona 暂缓(进入矛盾审视队列): {r['text'][:50]}...")
+            except (ValueError, TypeError):
+                continue
+
+        if transitions:
+            await self.asave_reflections(lanlan_name, reflections)
+            if confirmed_ids:
+                await self._abatch_mark_surfaced_handled(lanlan_name, confirmed_ids, 'auto_confirmed')
+            if promoted_ids:
+                await self._abatch_mark_surfaced_handled(lanlan_name, promoted_ids, 'promoted')
+        return transitions
+
     # 允许从这些 feedback 状态转换到新状态（用于 promoted 覆盖 confirmed/auto_confirmed）
     _UPGRADABLE_FEEDBACK = {None, 'confirmed', 'auto_confirmed'}
+
+    def _apply_batch_mark(
+        self, surfaced: list[dict], reflection_ids: list[str], feedback: str,
+    ) -> bool:
+        id_set = set(reflection_ids)
+        changed = False
+        now = datetime.now().isoformat()
+        for s in surfaced:
+            if s.get('reflection_id') in id_set and s.get('feedback') in self._UPGRADABLE_FEEDBACK:
+                s['feedback'] = feedback
+                s['feedback_at'] = now
+                changed = True
+        return changed
 
     def _batch_mark_surfaced_handled(
         self, lanlan_name: str, reflection_ids: list[str], feedback: str,
@@ -559,13 +767,14 @@ class ReflectionEngine:
         if not reflection_ids:
             return
         surfaced = self.load_surfaced(lanlan_name)
-        id_set = set(reflection_ids)
-        changed = False
-        now = datetime.now().isoformat()
-        for s in surfaced:
-            if s.get('reflection_id') in id_set and s.get('feedback') in self._UPGRADABLE_FEEDBACK:
-                s['feedback'] = feedback
-                s['feedback_at'] = now
-                changed = True
-        if changed:
+        if self._apply_batch_mark(surfaced, reflection_ids, feedback):
             self.save_surfaced(lanlan_name, surfaced)
+
+    async def _abatch_mark_surfaced_handled(
+        self, lanlan_name: str, reflection_ids: list[str], feedback: str,
+    ) -> None:
+        if not reflection_ids:
+            return
+        surfaced = await self.aload_surfaced(lanlan_name)
+        if self._apply_batch_mark(surfaced, reflection_ids, feedback):
+            await self.asave_surfaced(lanlan_name, surfaced)

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -187,7 +187,9 @@ class TimeIndexedMemory:
         return []
 
     def retrieve_original_by_timeframe(self, lanlan_name, start_time, end_time):
-        if lanlan_name not in self.engines:
+        # 懒加载：首次访问时（例如重启后立刻读取）需要注册 engine，
+        # 否则 rebuttal loop 会静默跳过，直到 store_conversation 才触发建表
+        if not self._ensure_engine_exists(lanlan_name):
             return []
         table_name = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
         # 查询指定时间范围内的对话

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -4,6 +4,7 @@ from config import TIME_ORIGINAL_TABLE_NAME, TIME_COMPRESSED_TABLE_NAME
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
 from datetime import datetime
+import asyncio
 import os
 
 logger = get_module_logger(__name__, "Memory")
@@ -13,9 +14,7 @@ class TimeIndexedMemory:
         self.engines = {}  # 存储 {lanlan_name: engine}
         self.db_paths = {} # 存储 {lanlan_name: db_path}
         self.recent_history_manager = recent_history_manager
-        _, _, _, _, _, _, time_store, _, _ = get_config_manager().get_character_data()
-        for name in time_store:
-            self._ensure_engine_exists(name, time_store[name])
+        # 懒加载：不在构造器里同步初始化每角色 engine，首次访问时按需创建
 
     def _ensure_engine_exists(self, lanlan_name: str, db_path: str | None = None) -> bool:
         """确保指定角色的数据库引擎已初始化喵~"""
@@ -51,6 +50,12 @@ class TimeIndexedMemory:
         except Exception:
             logger.exception(f"初始化角色数据库引擎失败: {lanlan_name}")
             return False
+
+    async def _aensure_engine_exists(self, lanlan_name: str, db_path: str | None = None) -> bool:
+        """异步版本：把阻塞的 engine 创建丢到线程池。"""
+        if lanlan_name in self.engines and lanlan_name in self.db_paths:
+            return True
+        return await asyncio.to_thread(self._ensure_engine_exists, lanlan_name, db_path)
 
     def dispose_engine(self, lanlan_name: str):
         """释放指定角色的数据库引擎资源喵~"""
@@ -104,7 +109,7 @@ class TimeIndexedMemory:
             except Exception:
                 logger.exception(f"[TimeIndexedMemory] 迁移 {lanlan_name} 表 {table} 失败")
 
-    async def store_conversation(self, event_id, messages, lanlan_name, timestamp=None):
+    def store_conversation(self, event_id, messages, lanlan_name, timestamp=None):
         # 确保数据库引擎和路径存在
         if not self._ensure_engine_exists(lanlan_name):
             logger.error(f"严重错误：无法为角色 {lanlan_name} 创建任何数据库连接")
@@ -116,9 +121,9 @@ class TimeIndexedMemory:
         db_path = self.db_paths[lanlan_name]
         uri_path = db_path.replace("\\", "/")
         connection_string = f"sqlite:///{uri_path}"
-        
+
         original_table = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
-        
+
         origin_history = SQLChatMessageHistory(
             connection_string=connection_string,
             session_id=event_id,
@@ -134,6 +139,11 @@ class TimeIndexedMemory:
                 {"timestamp": timestamp, "session_id": event_id}
             )
             conn.commit()
+
+    async def astore_conversation(self, event_id, messages, lanlan_name, timestamp=None):
+        await asyncio.to_thread(
+            self.store_conversation, event_id, messages, lanlan_name, timestamp
+        )
 
     def _validate_table_name(self, table_name: str) -> str:
         """验证表名是否合法，防止 SQL 注入喵~"""
@@ -166,8 +176,14 @@ class TimeIndexedMemory:
             logger.warning(f"[TimeIndexedMemory] 查询最后对话时间失败: {e}")
         return None
 
+    async def aget_last_conversation_time(self, lanlan_name: str) -> datetime | None:
+        return await asyncio.to_thread(self.get_last_conversation_time, lanlan_name)
+
     def retrieve_summary_by_timeframe(self, lanlan_name, start_time, end_time):
         """[已废弃] compressed table 不再写入，fact/reflection 已取代。"""
+        return []
+
+    async def aretrieve_summary_by_timeframe(self, lanlan_name, start_time, end_time):
         return []
 
     def retrieve_original_by_timeframe(self, lanlan_name, start_time, end_time):
@@ -181,6 +197,11 @@ class TimeIndexedMemory:
                 {"start_time": start_time, "end_time": end_time}
             )
             return result.fetchall()
+
+    async def aretrieve_original_by_timeframe(self, lanlan_name, start_time, end_time):
+        return await asyncio.to_thread(
+            self.retrieve_original_by_timeframe, lanlan_name, start_time, end_time
+        )
 
     # ── FTS5 事实索引 ─────────────────────────────────────────────
 
@@ -199,6 +220,9 @@ class TimeIndexedMemory:
                 conn.commit()
         except Exception as e:
             logger.warning(f"[TimeIndexedMemory] 创建 FTS5 表失败: {e}")
+
+    async def a_ensure_fts_table(self, lanlan_name: str) -> None:
+        await asyncio.to_thread(self._ensure_fts_table, lanlan_name)
 
     def index_fact(self, lanlan_name: str, fact_id: str, content: str) -> None:
         """将事实插入 FTS5 索引。"""
@@ -221,6 +245,9 @@ class TimeIndexedMemory:
                 conn.commit()
         except Exception as e:
             logger.warning(f"[TimeIndexedMemory] 索引事实失败: {e}")
+
+    async def aindex_fact(self, lanlan_name: str, fact_id: str, content: str) -> None:
+        await asyncio.to_thread(self.index_fact, lanlan_name, fact_id, content)
 
     def search_facts(self, lanlan_name: str, query: str, limit: int = 10) -> list[tuple[str, float]]:
         """通过 FTS5 BM25 搜索事实。返回 [(fact_id, bm25_score), ...]。
@@ -248,6 +275,9 @@ class TimeIndexedMemory:
             logger.debug(f"[TimeIndexedMemory] FTS5 搜索失败（可能是查询为空或语法）: {e}")
             return []
 
+    async def asearch_facts(self, lanlan_name: str, query: str, limit: int = 10) -> list[tuple[str, float]]:
+        return await asyncio.to_thread(self.search_facts, lanlan_name, query, limit)
+
     def delete_fact_from_index(self, lanlan_name: str, fact_id: str) -> None:
         """从 FTS5 索引中移除事实。"""
         if not self._ensure_engine_exists(lanlan_name):
@@ -262,3 +292,6 @@ class TimeIndexedMemory:
                 conn.commit()
         except Exception as e:
             logger.warning(f"[TimeIndexedMemory] 删除 FTS5 索引失败: {e}")
+
+    async def adelete_fact_from_index(self, lanlan_name: str, fact_id: str) -> None:
+        await asyncio.to_thread(self.delete_fact_from_index, lanlan_name, fact_id)

--- a/memory_server.py
+++ b/memory_server.py
@@ -256,7 +256,7 @@ async def _periodic_rebuttal_loop():
                 start_time = _last_rebuttal_check.get(
                     name, now - _td(hours=1)
                 )
-                rows = time_manager.retrieve_original_by_timeframe(
+                rows = await time_manager.aretrieve_original_by_timeframe(
                     name, start_time, now,
                 )
                 if not rows:
@@ -558,7 +558,7 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
         # 旧模块已禁用（性能不足）：
         # await settings_manager.extract_and_update_settings(input_history, lanlan_name)
         # await semantic_manager.store_conversation(uid, input_history, lanlan_name)
-        await time_manager.store_conversation(uid, input_history, lanlan_name)
+        await time_manager.astore_conversation(uid, input_history, lanlan_name)
 
         # 异步事实提取（不阻塞返回，失败静默跳过）
         _spawn_background_task(_extract_facts_and_check_feedback(input_history, lanlan_name))
@@ -601,7 +601,7 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
         # 首轮摘要带锁：阻塞 /new_dialog 直到摘要+时间戳写入完成
         async with _get_settle_lock(lanlan_name):
             await recent_history_manager.update_history(input_history, lanlan_name, detailed=True)
-            await time_manager.store_conversation(uid, input_history, lanlan_name)
+            await time_manager.astore_conversation(uid, input_history, lanlan_name)
 
         # 以下操作在锁外执行，不阻塞 /new_dialog
         # 异步事实提取
@@ -642,7 +642,7 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
 
         async with _get_settle_lock(lanlan_name):
             if input_history:
-                await time_manager.store_conversation(uid, input_history, lanlan_name)
+                await time_manager.astore_conversation(uid, input_history, lanlan_name)
             await recent_history_manager.update_history([], lanlan_name, detailed=True)
 
         if input_history:
@@ -664,7 +664,7 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
 
 
 @app.get("/get_recent_history/{lanlan_name}")
-def get_recent_history(lanlan_name: str):
+async def get_recent_history(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
     # 检查角色是否存在于配置中
     try:
@@ -676,8 +676,8 @@ def get_recent_history(lanlan_name: str):
     except Exception as e:
         logger.error(f"检查角色配置失败: {e}")
         return "开始聊天前，没有历史记录。\n"
-    
-    history = recent_history_manager.get_recent_history(lanlan_name)
+
+    history = await recent_history_manager.aget_recent_history(lanlan_name)
     _, _, _, _, name_mapping, _, _, _, _ = _config_manager.get_character_data()
     name_mapping['ai'] = lanlan_name
     result = f"开始聊天前，{lanlan_name}又在脑海内整理了近期发生的事情。\n"
@@ -704,7 +704,7 @@ async def get_memory(query: str, lanlan_name: str):
     )
 
 @app.get("/get_settings/{lanlan_name}")
-def get_settings(lanlan_name: str):
+async def get_settings(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
     # 检查角色是否存在于配置中
     try:
@@ -718,23 +718,22 @@ def get_settings(lanlan_name: str):
         return f"{lanlan_name}记得{{}}"
 
     # 优先使用 persona markdown 渲染（与 /new_dialog 保持一致），回退到旧 settings 格式
-    pending_reflections = reflection_engine.get_pending_reflections(lanlan_name)
-    confirmed_reflections = reflection_engine.get_confirmed_reflections(lanlan_name)
-    persona_md = persona_manager.render_persona_markdown(
+    pending_reflections = await reflection_engine.aget_pending_reflections(lanlan_name)
+    confirmed_reflections = await reflection_engine.aget_confirmed_reflections(lanlan_name)
+    persona_md = await persona_manager.arender_persona_markdown(
         lanlan_name, pending_reflections, confirmed_reflections,
     )
     if persona_md:
         return persona_md
     # 兼容回退（自然语言格式）
     return _format_legacy_settings_as_text(settings_manager.get_settings(lanlan_name), lanlan_name)
-    return result
 
 
 @app.get("/get_persona/{lanlan_name}")
-def get_persona(lanlan_name: str):
+async def get_persona(lanlan_name: str):
     """返回完整 persona JSON（供 UI / memory_browser 使用）。"""
     lanlan_name = validate_lanlan_name(lanlan_name)
-    return persona_manager.get_persona(lanlan_name)
+    return await persona_manager.aget_persona(lanlan_name)
 
 @app.post("/reload")
 async def reload_config():
@@ -844,7 +843,7 @@ async def new_dialog(lanlan_name: str):
         # ── 距上次聊天间隔提示（放在最末尾，紧接 CONTEXT_SUMMARY_READY 之前） ──
         try:
             from datetime import datetime as _dt
-            last_time = time_manager.get_last_conversation_time(lanlan_name)
+            last_time = await time_manager.aget_last_conversation_time(lanlan_name)
             if last_time:
                 gap = _dt.now() - last_time
                 gap_seconds = gap.total_seconds()
@@ -877,7 +876,7 @@ async def last_conversation_gap(lanlan_name: str):
     """返回距上次对话的间隔秒数，供主服务判断是否触发主动搭话。"""
     lanlan_name = validate_lanlan_name(lanlan_name)
     try:
-        last_time = time_manager.get_last_conversation_time(lanlan_name)
+        last_time = await time_manager.aget_last_conversation_time(lanlan_name)
         if last_time is None:
             return {"gap_seconds": -1}
         gap = (datetime.now() - last_time).total_seconds()

--- a/memory_server.py
+++ b/memory_server.py
@@ -248,7 +248,7 @@ async def _periodic_rebuttal_loop():
         now = datetime.now()
         for name in catgirl_names:
             try:
-                confirmed = reflection_engine.get_confirmed_reflections(name)
+                confirmed = await reflection_engine.aget_confirmed_reflections(name)
                 if not confirmed:
                     continue
 
@@ -283,7 +283,7 @@ async def _periodic_rebuttal_loop():
                     if isinstance(fb, dict) and fb.get('feedback') == 'denied':
                         rid = fb.get('reflection_id')
                         if rid:
-                            reflection_engine.reject_promotion(name, rid)
+                            await reflection_engine.areject_promotion(name, rid)
                             logger.info(f"[Rebuttal] {name}: confirmed 反思被反驳: {rid}")
             except Exception as e:
                 logger.debug(f"[Rebuttal] {name}: 处理失败，跳过: {e}")
@@ -307,7 +307,7 @@ async def _periodic_auto_promote_loop():
 
         for name in catgirl_names:
             try:
-                transitions = reflection_engine.auto_promote_stale(name)
+                transitions = await reflection_engine.aauto_promote_stale(name)
                 if transitions:
                     logger.info(f"[AutoPromote] {name}: {transitions} 条状态迁移")
             except Exception as e:
@@ -331,7 +331,7 @@ async def startup_event_handler():
         character_data = _config_manager.load_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
         for name in catgirl_names:
-            persona_manager.ensure_persona(name)
+            await persona_manager.aensure_persona(name)
         logger.info(f"[Memory] Persona 迁移检查完成，角色数: {len(catgirl_names)}")
     except Exception as e:
         logger.warning(f"[Memory] Persona 迁移检查失败: {e}")
@@ -423,7 +423,7 @@ async def api_reflect(lanlan_name: str):
     auto_transitions = 0
     reflection_result = None
     try:
-        auto_transitions = reflection_engine.auto_promote_stale(lanlan_name)
+        auto_transitions = await reflection_engine.aauto_promote_stale(lanlan_name)
     except Exception as e:
         logger.debug(f"[ReflectAPI] {lanlan_name}: auto_promote_stale 失败: {e}")
     try:
@@ -441,7 +441,7 @@ async def api_followup_topics(lanlan_name: str):
     """获取回调话题候选（不标记 surfaced，调用方需后续调 /record_surfaced）。"""
     lanlan_name = validate_lanlan_name(lanlan_name)
     try:
-        topics = reflection_engine.get_followup_topics(lanlan_name)
+        topics = await reflection_engine.aget_followup_topics(lanlan_name)
     except Exception as e:
         logger.debug(f"[ReflectAPI] {lanlan_name}: get_followup_topics 失败: {e}")
         topics = []
@@ -457,7 +457,7 @@ async def api_record_surfaced(request: Request, lanlan_name: str):
     if not reflection_ids:
         return {"ok": True}
     try:
-        reflection_engine.record_surfaced(lanlan_name, reflection_ids)
+        await reflection_engine.arecord_surfaced(lanlan_name, reflection_ids)
     except Exception as e:
         logger.debug(f"[ReflectAPI] {lanlan_name}: record_surfaced 失败: {e}")
     return {"ok": True}
@@ -478,13 +478,13 @@ async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
         # 2. 全局复读嗅探：扫描 AI 回复中是否重复提及 persona 条目
         ai_response = _extract_ai_response(messages)
         if ai_response:
-            persona_manager.record_mentions(lanlan_name, ai_response)
+            await persona_manager.arecord_mentions(lanlan_name, ai_response)
     except Exception as e:
         logger.warning(f"[MemoryServer] 复读嗅探失败: {e}")
 
     try:
         # 3. 检查用户对之前 surfaced 反思的反馈（宽松确认）
-        surfaced = reflection_engine.load_surfaced(lanlan_name)
+        surfaced = await reflection_engine.aload_surfaced(lanlan_name)
         pending_surfaced = [s for s in surfaced if s.get('feedback') is None]
         if pending_surfaced:
             user_msgs = _extract_user_messages(messages)
@@ -503,10 +503,10 @@ async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
                     for s in pending_surfaced:
                         rid = s.get('reflection_id')
                         if rid in denied_ids:
-                            reflection_engine.reject_promotion(lanlan_name, rid)
+                            await reflection_engine.areject_promotion(lanlan_name, rid)
                         else:
                             # 宽松确认：用户有回复 + 未被 denied → 自动 confirm
-                            reflection_engine.confirm_promotion(lanlan_name, rid)
+                            await reflection_engine.aconfirm_promotion(lanlan_name, rid)
     except Exception as e:
         logger.warning(f"[MemoryServer] 反馈检查失败: {e}")
 
@@ -814,10 +814,10 @@ async def new_dialog(lanlan_name: str):
 
         # ── [静态前缀] Persona 长期记忆（变化极少 → 最大化 prefix cache） ──
     # pending + confirmed 反思也注入上下文（分区标注）
-        pending_reflections = reflection_engine.get_pending_reflections(lanlan_name)
-        confirmed_reflections = reflection_engine.get_confirmed_reflections(lanlan_name)
+        pending_reflections = await reflection_engine.aget_pending_reflections(lanlan_name)
+        confirmed_reflections = await reflection_engine.aget_confirmed_reflections(lanlan_name)
         result = _loc(PERSONA_HEADER, _lang).format(name=lanlan_name)
-        persona_md = persona_manager.render_persona_markdown(
+        persona_md = await persona_manager.arender_persona_markdown(
             lanlan_name, pending_reflections, confirmed_reflections,
         )
         if persona_md:
@@ -833,7 +833,7 @@ async def new_dialog(lanlan_name: str):
             time=get_timestamp(),
         )
 
-        for i in recent_history_manager.get_recent_history(lanlan_name):
+        for i in await recent_history_manager.aget_recent_history(lanlan_name):
             if isinstance(i.content, str):
                 cleaned_content = brackets_pattern.sub('', i.content).strip()
                 result += f"{name_mapping[i.type]} | {cleaned_content}\n"

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -29,6 +29,9 @@ class DummyConfigManager:
         self.saved_characters = copy.deepcopy(characters)
         self.characters = copy.deepcopy(characters)
 
+    async def asave_characters(self, characters):
+        self.save_characters(characters)
+
 
 def _build_characters_fixture():
     return {

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -25,12 +25,12 @@ class DummyConfigManager:
     def load_characters(self):
         return copy.deepcopy(self.characters)
 
-    def save_characters(self, characters):
+    def save_characters(self, characters, character_json_path=None):
         self.saved_characters = copy.deepcopy(characters)
         self.characters = copy.deepcopy(characters)
 
-    async def asave_characters(self, characters):
-        self.save_characters(characters)
+    async def asave_characters(self, characters, character_json_path=None):
+        self.save_characters(characters, character_json_path)
 
 
 def _build_characters_fixture():

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2115,6 +2115,13 @@ class ConfigManager:
                 "source": source or "",
             }
 
+    async def aconsume_agent_daily_quota(self, source: str = "", units: int = 1) -> tuple[bool, dict]:
+        """Async wrapper of ``consume_agent_daily_quota``.
+
+        事件循环上禁止直接走同步版本（会 open+fsync 阻塞）。
+        """
+        return await asyncio.to_thread(self.consume_agent_daily_quota, source, units)
+
     def load_json_config(self, filename, default_value=None):
         """
         加载JSON配置文件

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -8,6 +8,7 @@ import os
 import json
 import shutil
 import threading
+import asyncio
 import math
 from datetime import date
 from copy import deepcopy
@@ -488,6 +489,12 @@ class ConfigManager:
         self.chara_dir = self.app_docs_dir / "character_cards"
         self._workshop_config_lock = threading.Lock()
         self._workshop_config_cleanup_done = False
+
+        self._characters_cache: dict | None = None
+        self._characters_cache_mtime: float | None = None
+        self._characters_cache_path: str | None = None
+        self._characters_dirty: bool = False
+        self._characters_cache_lock = threading.Lock()
 
         self.project_config_dir = self._get_project_config_directory()
         self.project_memory_dir = self._get_project_memory_directory()
@@ -1008,15 +1015,33 @@ class ConfigManager:
         if character_json_path is None:
             character_json_path = str(self.get_config_path('characters.json'))
 
+        with self._characters_cache_lock:
+            cache = self._characters_cache
+            cache_path = self._characters_cache_path
+            cache_mtime = self._characters_cache_mtime
+        if cache is not None and cache_path == character_json_path:
+            try:
+                current_mtime = os.path.getmtime(character_json_path)
+            except OSError:
+                current_mtime = None
+            if current_mtime is not None and current_mtime == cache_mtime:
+                return deepcopy(cache)
+
         try:
             with open(character_json_path, 'r', encoding='utf-8') as f:
                 character_data = json.load(f)
+            try:
+                loaded_mtime = os.path.getmtime(character_json_path)
+            except OSError:
+                loaded_mtime = None
         except FileNotFoundError:
             logger.info("未找到猫娘配置文件 %s，使用默认配置。", character_json_path)
             character_data = self.get_default_characters()
+            loaded_mtime = None
         except Exception as e:
             logger.error("读取猫娘配置文件出错: %s，使用默认人设。", e)
             character_data = self.get_default_characters()
+            loaded_mtime = None
 
         migrated = False
         if not isinstance(character_data, dict):
@@ -1039,6 +1064,12 @@ class ConfigManager:
                 logger.info("检测到旧版角色保留字段，已自动迁移到 _reserved 结构。")
             except Exception as migrate_err:
                 logger.warning("自动迁移角色保留字段后写回失败: %s", migrate_err)
+        else:
+            with self._characters_cache_lock:
+                self._characters_cache = deepcopy(character_data)
+                self._characters_cache_mtime = loaded_mtime
+                self._characters_cache_path = character_json_path
+                self._characters_dirty = False
         return character_data
 
     def save_characters(self, data, character_json_path=None):
@@ -1050,6 +1081,15 @@ class ConfigManager:
         self.ensure_config_directory()
 
         atomic_write_json(character_json_path, data, ensure_ascii=False, indent=2)
+        try:
+            new_mtime = os.path.getmtime(character_json_path)
+        except OSError:
+            new_mtime = None
+        with self._characters_cache_lock:
+            self._characters_cache = deepcopy(data)
+            self._characters_cache_mtime = new_mtime
+            self._characters_cache_path = character_json_path
+            self._characters_dirty = False
 
     # --- Voice storage helpers ---
 
@@ -1398,7 +1438,10 @@ class ConfigManager:
                     her_name,
                 )
                 character_data['当前猫娘'] = her_name
-                self.save_characters(character_data)
+                with self._characters_cache_lock:
+                    if self._characters_cache is not None:
+                        self._characters_cache['当前猫娘'] = her_name
+                    self._characters_dirty = True
 
         name_mapping = {'human': master_name, 'system': "SYSTEM_MESSAGE"}
         lanlan_prompt_map = {}
@@ -1433,6 +1476,9 @@ class ConfigManager:
             setting_store,
             recent_log,
         )
+
+    async def aget_character_data(self):
+        return await asyncio.to_thread(self.get_character_data)
 
     # --- Core config helpers ---
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1073,7 +1073,7 @@ class ConfigManager:
         return character_data
 
     def save_characters(self, data, character_json_path=None):
-        """保存角色配置"""
+        """保存角色配置（同步版本，会阻塞事件循环；async 路径请用 asave_characters）"""
         if character_json_path is None:
             character_json_path = str(self.get_config_path('characters.json'))
 
@@ -1090,6 +1090,10 @@ class ConfigManager:
             self._characters_cache_mtime = new_mtime
             self._characters_cache_path = character_json_path
             self._characters_dirty = False
+
+    async def asave_characters(self, data, character_json_path=None):
+        """async 包装：事件循环上禁止直接走同步版本（atomic_write_json 会阻塞）。"""
+        return await asyncio.to_thread(self.save_characters, data, character_json_path)
 
     # --- Voice storage helpers ---
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1442,10 +1442,16 @@ class ConfigManager:
                     her_name,
                 )
                 character_data['当前猫娘'] = her_name
-                with self._characters_cache_lock:
-                    if self._characters_cache is not None:
-                        self._characters_cache['当前猫娘'] = her_name
-                    self._characters_dirty = True
+                # 罕见分支（仅配置损坏/删除猫娘后触发），同步落盘以保证重启后修正仍生效。
+                # save_characters 内部会刷新 cache，这里无需再手动同步。
+                try:
+                    self.save_characters(character_data)
+                except Exception as persist_err:
+                    logger.warning("自动纠正当前猫娘后写回失败，将仅保留内存修正: %s", persist_err)
+                    with self._characters_cache_lock:
+                        if self._characters_cache is not None:
+                            self._characters_cache['当前猫娘'] = her_name
+                        self._characters_dirty = True
 
         name_mapping = {'human': master_name, 'system': "SYSTEM_MESSAGE"}
         lanlan_prompt_map = {}

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import re
@@ -86,3 +87,45 @@ def atomic_write_json(
         **json_kwargs,
     )
     atomic_write_text(path, content, encoding=encoding)
+
+
+def read_json(path: str | os.PathLike[str], *, encoding: str = "utf-8") -> Any:
+    with open(path, "r", encoding=encoding) as f:
+        return json.load(f)
+
+
+async def atomic_write_text_async(
+    path: str | os.PathLike[str],
+    content: str,
+    *,
+    encoding: str = "utf-8",
+) -> None:
+    await asyncio.to_thread(atomic_write_text, path, content, encoding=encoding)
+
+
+async def atomic_write_json_async(
+    path: str | os.PathLike[str],
+    data: Any,
+    *,
+    encoding: str = "utf-8",
+    ensure_ascii: bool = False,
+    indent: int | None = 2,
+    **json_kwargs: Any,
+) -> None:
+    await asyncio.to_thread(
+        atomic_write_json,
+        path,
+        data,
+        encoding=encoding,
+        ensure_ascii=ensure_ascii,
+        indent=indent,
+        **json_kwargs,
+    )
+
+
+async def read_json_async(
+    path: str | os.PathLike[str],
+    *,
+    encoding: str = "utf-8",
+) -> Any:
+    return await asyncio.to_thread(read_json, path, encoding=encoding)

--- a/utils/holiday_cache.py
+++ b/utils/holiday_cache.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import TypedDict
@@ -394,6 +395,11 @@ async def get_nearest_holiday(lang: str) -> HolidayProximity | None:
 _CONSUMPTION_FILENAME = "holiday_consumption.json"
 _consumption_data: dict[str, dict] = {}
 _consumption_path: Path | None = None
+# Protects RMW on _consumption_data + atomic_write_json; covers both the
+# immediate-consume (get_holiday_or_weekend_hint) and deferred-commit
+# (commit_holiday_or_weekend_hint via asyncio.to_thread) paths against
+# concurrent writers in worker threads.
+_consumption_lock = threading.Lock()
 
 _BUDGET_HOLIDAY = 3   # statutory day budget (shared across all 假日 days)
 _BUDGET_PERIOD = 3    # 调休 day budget (shared across all 调休 days)
@@ -459,23 +465,24 @@ def _get_period_bucket(character: str, period: HolidayPeriod,
 def _consume_period_bucket(character: str, period: HolidayPeriod,
                            bucket: str, budget: int) -> bool:
     """Try to consume 1 use from a period bucket. Returns True if successful."""
-    rec = _get_char_record(character)
-    period_key = period.start.isoformat()
-    if period_key not in rec["periods"]:
-        rec["periods"][period_key] = {}
-    period_rec = rec["periods"][period_key]
+    with _consumption_lock:
+        rec = _get_char_record(character)
+        period_key = period.start.isoformat()
+        if period_key not in rec["periods"]:
+            rec["periods"][period_key] = {}
+        period_rec = rec["periods"][period_key]
 
-    remaining = period_rec.get(bucket)
-    if remaining is None:
-        # First use → initialise
-        period_rec[bucket] = budget - 1
-        _save_consumption()
-        return True
-    if remaining > 0:
-        period_rec[bucket] = remaining - 1
-        _save_consumption()
-        return True
-    return False
+        remaining = period_rec.get(bucket)
+        if remaining is None:
+            # First use → initialise
+            period_rec[bucket] = budget - 1
+            _save_consumption()
+            return True
+        if remaining > 0:
+            period_rec[bucket] = remaining - 1
+            _save_consumption()
+            return True
+        return False
 
 
 def try_consume_holiday(character: str, proximity: HolidayProximity) -> bool:
@@ -500,22 +507,23 @@ def try_consume_holiday(character: str, proximity: HolidayProximity) -> bool:
 
 def try_consume_weekend(character: str) -> bool:
     """Try to consume 1 use for a weekend hint. Budget 2, resets daily."""
-    rec = _get_char_record(character)
-    today_iso = date.today().isoformat()
+    with _consumption_lock:
+        rec = _get_char_record(character)
+        today_iso = date.today().isoformat()
 
-    if rec.get("weekend_date") != today_iso:
-        # New day → reset
-        rec["weekend_date"] = today_iso
-        rec["weekend"] = _BUDGET_WEEKEND - 1
-        _save_consumption()
-        return True
+        if rec.get("weekend_date") != today_iso:
+            # New day → reset
+            rec["weekend_date"] = today_iso
+            rec["weekend"] = _BUDGET_WEEKEND - 1
+            _save_consumption()
+            return True
 
-    remaining = rec.get("weekend", 0)
-    if remaining > 0:
-        rec["weekend"] = remaining - 1
-        _save_consumption()
-        return True
-    return False
+        remaining = rec.get("weekend", 0)
+        if remaining > 0:
+            rec["weekend"] = remaining - 1
+            _save_consumption()
+            return True
+        return False
 
 
 # Startup: load persisted data


### PR DESCRIPTION
## Summary

三个前独立进程（main / memory / agent）合并成单进程共享 event loop 后，高热路径上的同步阻塞会直接卡心跳和 WebSocket。这个 PR 分 5 步完成从地基到全链路的异步化：

- **T1** 地基+紧急止血：`utils/file_utils.py` 新增 `atomic_write_*_async` / `read_json_async`；`main_server.py` 加 `loop.slow_callback_duration = 0.05`；`config_manager.py` characters 加内存缓存 + mtime check；角色删除走 `to_thread(shutil.rmtree)`；`agent_server.py` plugin name 查询换 `httpx.AsyncClient` + `asyncio.Lock`。
- **T2** memory 模块全链路异步化：`recent.py` / `facts.py` / `reflection.py` / `persona.py` 每个 sync IO 都加 `a*` 镜像；`reflection.save_reflections` 的 4 次 fsync 合为 1 次；`memory_server.py` 全部 handler 切到 async 版本。
- **T3** timeindex 异步镜像 + 懒加载：`memory/timeindex.py` 构造器停用"每个角色初始化时预热 engine"循环，改成 `_aensure_engine_exists` 懒加载；新增 9 个 `a*` 方法（`astore_conversation`、`asearch_facts`、`aindex_fact`…）；清掉 T2 放在 `facts.py` 里的 TODO(T3) 占位。
- **T4** agent 路径：`brain/task_executor.py` quota check 改 async、BM25 `stage1_filter` 走 `to_thread`、三个 adapter 的 `is_available()` offload；`openclaw_adapter` / `openfang_adapter` / `browser_use_adapter` / `deduper` 内部同步 IO 在 async 路径里 offload。
- **T5** 收尾：`characters_router.py` 9 处 `save_characters` → `asave_characters`；`jukebox_router` `JukeboxConfig` 加 `asave()` 并迁移 14 个 call site；`workshop_router.perform_cleanup` 在 Steamworks 回调线程里保留 sync 并加说明注释；`.agent/rules/neko-guide.md` 补了一节「单进程 + 事件循环零阻塞」约束。

## 验证

- `uv run ruff check .` 通过（含 PR #842 的 ASYNC210/220/221/222/251 规则）。
- `uv run scripts/check_async_blocking.py` 通过（Thread.join(timeout=) / queue.Queue.get() / socket.recv 的 AST 兜底）。
- 完整 pytest：292 passed、7 failed，失败全是 Playwright 的 headless 兜底（`test_e2e_full_flow` / `test_api_settings` / `test_chara_settings` / `test_memory_browser` / `test_avatar_reaction_bubble`）+ 一个 `test_restricted_providers`，在 origin/main 上同样失败，非本 PR 引入。
- `tests/unit/test_characters_router_model_settings.py` 6 个用例全部通过（T5 需要把 `DummyConfigManager` 补一个 `asave_characters` 的 await-友好 mock）。

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run scripts/check_async_blocking.py`
- [x] `uv run pytest tests/unit/test_characters_router_model_settings.py`
- [x] `uv run pytest tests/`（baseline failures 已核对）
- [ ] 手动：切换猫娘、删除猫娘、开关 agent、analyze_request —— 确认心跳不掉、WebSocket 不断、event loop 没有 `slow callback` 警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 广泛将阻塞操作移入异步或后台线程：路由、记忆、人格、任务执行、插件与持久化等改为 async/线程卸载，提升并发与响应性；引入配置文件内存缓存并调整并发与删除行为为非阻塞；部分全局消费/计数改为加锁以保证一致性；若干接口增加或提供 async 版本。

* **文档**
  * 新增异步架构指南，明确禁止长时间阻塞事件循环、同步/异步写入配对约定，并建议开启 asyncio 调试与慢回调阈值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->