### PR TITLE
perf(async): 并行化启动期两处可独立的 await

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -627,7 +627,7 @@ async def _fire_user_plugin_capability_check() -> None:
 _llm_check_lock = asyncio.Lock()
 
 
-async def _fire_agent_llm_connectivity_check() -> None:
+async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
     """Probe the shared Agent-LLM endpoint in a background thread.
 
     Both ComputerUse and BrowserUse rely on the same ``agent`` model config,
@@ -636,8 +636,17 @@ async def _fire_agent_llm_connectivity_check() -> None:
     *both* computer_use and browser_use.
 
     Uses a lock to prevent concurrent probes from racing.
+
+    ``queue=False`` (default): early-return if another probe is in flight.
+      Right for spammy event-driven callers (UI toggles / flag flips) where a
+      second probe would just duplicate the in-flight one.
+
+    ``queue=True``: wait for the lock and run anyway.  Right when the caller
+      represents a *state change* that must be reflected on capability (e.g.
+      BrowserUse just became available), where early-return would silently
+      drop the refresh.
     """
-    if _llm_check_lock.locked():
+    if not queue and _llm_check_lock.locked():
         return
 
     async with _llm_check_lock:
@@ -2153,7 +2162,11 @@ async def startup():
             logger.info("[Agent] BrowserUseAdapter ready (background init)")
             # fire-and-forget capability 刷新：check_connectivity 可能因网络不稳
             # 走到几十秒级的重试，绝不能把 OpenFang 初始化链 gate 在它上面。
-            _refresh_task = asyncio.create_task(_fire_agent_llm_connectivity_check())
+            # queue=True：这是"BU 刚就绪"这种状态变化触发，不能被启动期 LLM probe
+            # 持锁时的早退路径吞掉，否则 browser_use capability 会停在 PENDING。
+            _refresh_task = asyncio.create_task(
+                _fire_agent_llm_connectivity_check(queue=True)
+            )
             Modules._persistent_tasks.add(_refresh_task)
             _refresh_task.add_done_callback(Modules._persistent_tasks.discard)
         except Exception as exc:

--- a/agent_server.py
+++ b/agent_server.py
@@ -2151,10 +2151,11 @@ async def startup():
             Modules.browser_use = bu
             Modules.task_executor.browser_use = bu
             logger.info("[Agent] BrowserUseAdapter ready (background init)")
-            try:
-                await _fire_agent_llm_connectivity_check()
-            except Exception:
-                logger.debug("[Agent] Post-browser-init capability refresh failed", exc_info=True)
+            # fire-and-forget capability 刷新：check_connectivity 可能因网络不稳
+            # 走到几十秒级的重试，绝不能把 OpenFang 初始化链 gate 在它上面。
+            _refresh_task = asyncio.create_task(_fire_agent_llm_connectivity_check())
+            Modules._persistent_tasks.add(_refresh_task)
+            _refresh_task.add_done_callback(Modules._persistent_tasks.discard)
         except Exception as exc:
             logger.error("[Agent] BrowserUseAdapter background init failed: %s", exc)
 

--- a/agent_server.py
+++ b/agent_server.py
@@ -2158,9 +2158,6 @@ async def startup():
         except Exception as exc:
             logger.error("[Agent] BrowserUseAdapter background init failed: %s", exc)
 
-    _bu_task = asyncio.create_task(_init_browser_use_background())
-    Modules._persistent_tasks.add(_bu_task)
-    _bu_task.add_done_callback(Modules._persistent_tasks.discard)
     try:
         await _start_embedded_user_plugin_server()
     except Exception as e:
@@ -2232,9 +2229,16 @@ async def startup():
             logger.error("[OpenFang] background init failed: %s", exc)
             _set_capability("openfang", False, str(exc))
 
-    _of_task = asyncio.create_task(_init_openfang_background())
-    Modules._persistent_tasks.add(_of_task)
-    _of_task.add_done_callback(Modules._persistent_tasks.discard)
+    # BrowserUse 与 OpenFang 都涉及较重的初始化（CPU 密集模块加载 / 进程连通性轮询），
+    # 放在同一个后台任务里串行执行，避免两者并发时启动期 CPU 双峰。LLM connectivity
+    # probe 是轻量 HTTP，独立 task 与这条串行链并行。
+    async def _init_heavy_adapters_serial():
+        await _init_browser_use_background()
+        await _init_openfang_background()
+
+    _heavy_adapters_task = asyncio.create_task(_init_heavy_adapters_serial())
+    Modules._persistent_tasks.add(_heavy_adapters_task)
+    _heavy_adapters_task.add_done_callback(Modules._persistent_tasks.discard)
 
     # Both CUA and BrowserUse share the agent LLM — default to "not connected"
     # and probe in background.  The single check updates both capability caches.

--- a/memory_server.py
+++ b/memory_server.py
@@ -330,11 +330,20 @@ async def startup_event_handler():
     try:
         character_data = _config_manager.load_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
-        # 各角色的 persona 文件互相独立，并行迁移检查避免 N 倍串行磁盘 IO
+        # 各角色的 persona 文件互相独立，并行迁移检查避免 N 倍串行磁盘 IO。
+        # return_exceptions=True：避免 fail-fast 取消其它角色正在写盘的协程，
+        # 造成 persona 文件半写入；出错的角色单独记日志。
         if catgirl_names:
-            await asyncio.gather(
-                *(persona_manager.aensure_persona(n) for n in catgirl_names)
+            results = await asyncio.gather(
+                *(persona_manager.aensure_persona(n) for n in catgirl_names),
+                return_exceptions=True,
             )
+            for name, result in zip(catgirl_names, results):
+                if isinstance(result, Exception):
+                    logger.warning(
+                        f"[Memory] Persona 迁移检查失败: {name}: {result}",
+                        exc_info=result,
+                    )
         logger.info(f"[Memory] Persona 迁移检查完成，角色数: {len(catgirl_names)}")
     except Exception as e:
         logger.warning(f"[Memory] Persona 迁移检查失败: {e}")

--- a/memory_server.py
+++ b/memory_server.py
@@ -330,8 +330,11 @@ async def startup_event_handler():
     try:
         character_data = _config_manager.load_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
-        for name in catgirl_names:
-            await persona_manager.aensure_persona(name)
+        # 各角色的 persona 文件互相独立，并行迁移检查避免 N 倍串行磁盘 IO
+        if catgirl_names:
+            await asyncio.gather(
+                *(persona_manager.aensure_persona(n) for n in catgirl_names)
+            )
         logger.info(f"[Memory] Persona 迁移检查完成，角色数: {len(catgirl_names)}")
     except Exception as e:
         logger.warning(f"[Memory] Persona 迁移检查失败: {e}")


### PR DESCRIPTION
## Summary

PR #846 清掉同步阻塞之后，启动链路还有两处把独立工作串成串行 `await` 的地方，这 PR 把它们并行化。

### 1. `memory_server` persona 迁移检查
`for name in catgirl_names: await persona_manager.aensure_persona(name)` 改成 `asyncio.gather(...)`。各角色的 persona 文件、\`_personas\` dict key 都独立，gather 安全。N 角色 × disk IO → 一次墙钟。

### 2. `agent_server` 启动期能力探测
原来 3 个 `create_task` 并发（BrowserUse + OpenFang + LLM connectivity probe），BrowserUse 的模块加载（playwright/chromium 导入，CPU 密集）和 OpenFang 的进程连通轮询同时启动会造成启动期 CPU 双峰。改为：

- **BrowserUse → OpenFang**：放在同一个后台 task 里串行 `await`，错开 CPU 峰。
- **LLM connectivity probe**：单独 task 并行（纯 HTTP，轻量，与上面串行链不冲突）。

LLM probe 只依赖 `Modules.computer_use`（在启动前已设好），且函数内有 `_llm_check_lock` 防重入；BU 初始化完成后会 post-refresh capability（仍然走这把锁），串行性得到保持。

## Test plan

- [x] `uv run python scripts/check_async_blocking.py` 零违规
- [x] `uv run pytest tests/unit -q` 219 passed（`test_restricted_providers` 是 main 上已存在的失败，与本 PR 无关）
- [ ] 冷启动墙钟观察：memory server persona 检查日志时间 < 单角色时间 × N；agent server 日志里 BU ready 在 OF ready 之前
- [ ] 手测：启动期 CPU 占用无双峰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 版本发布说明

* **优化改进**
  * 启动后台任务调度重构：将浏览器与适配器初始化合并为单个串行“重载适配器”后台任务，减少相互阻塞并简化跟踪。
  * LLM 连通性探测改为非阻塞的后台触发并支持在初始化后强制排队重试，提升能力刷新及时性。
  * 人物/角色初始化改为并发执行，单个失败仅记录警告，不影响其它初始化，提升鲁棒性与启动效率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->