### PR TITLE
fix(async): 消除 transitive 同步阻塞（compress_screenshot / load_cookies）+ 扩展 async-check 深度 1

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2133,15 +2133,17 @@ class LLMSessionManager:
                 import pyautogui
                 from utils.screenshot_utils import compress_screenshot, COMPRESS_TARGET_HEIGHT, COMPRESS_JPEG_QUALITY
                 import base64 as b64mod
-                shot = await asyncio.to_thread(pyautogui.screenshot)
-                if shot.mode in ('RGBA', 'LA', 'P'):
-                    shot = shot.convert('RGB')
-                jpg_bytes = await asyncio.to_thread(
-                    compress_screenshot,
-                    shot,
-                    target_h=COMPRESS_TARGET_HEIGHT,
-                    quality=COMPRESS_JPEG_QUALITY,
-                )
+                def _capture_and_compress() -> bytes:
+                    shot = pyautogui.screenshot()
+                    if shot.mode in ('RGBA', 'LA', 'P'):
+                        shot = shot.convert('RGB')
+                    return compress_screenshot(
+                        shot,
+                        target_h=COMPRESS_TARGET_HEIGHT,
+                        quality=COMPRESS_JPEG_QUALITY,
+                    )
+
+                jpg_bytes = await asyncio.to_thread(_capture_and_compress)
                 b64_str = b64mod.b64encode(jpg_bytes).decode('utf-8')
                 logger.info("[%s] request_fresh_screenshot: 后端 pyautogui 兜底成功 (%dKB)", self.lanlan_name, len(jpg_bytes) // 1024)
                 return b64_str

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2133,10 +2133,15 @@ class LLMSessionManager:
                 import pyautogui
                 from utils.screenshot_utils import compress_screenshot, COMPRESS_TARGET_HEIGHT, COMPRESS_JPEG_QUALITY
                 import base64 as b64mod
-                shot = pyautogui.screenshot()
+                shot = await asyncio.to_thread(pyautogui.screenshot)
                 if shot.mode in ('RGBA', 'LA', 'P'):
                     shot = shot.convert('RGB')
-                jpg_bytes = compress_screenshot(shot, target_h=COMPRESS_TARGET_HEIGHT, quality=COMPRESS_JPEG_QUALITY)
+                jpg_bytes = await asyncio.to_thread(
+                    compress_screenshot,
+                    shot,
+                    target_h=COMPRESS_TARGET_HEIGHT,
+                    quality=COMPRESS_JPEG_QUALITY,
+                )
                 b64_str = b64mod.b64encode(jpg_bytes).decode('utf-8')
                 logger.info("[%s] request_fresh_screenshot: 后端 pyautogui 兜底成功 (%dKB)", self.lanlan_name, len(jpg_bytes) // 1024)
                 return b64_str

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -3829,9 +3829,9 @@ async def export_catgirl_with_portrait(
 
         try:
             Image.MAX_IMAGE_PIXELS = 100_000_000  # 限制最大像素数防止解压炸弹
-            portrait_img = Image.open(io.BytesIO(portrait_data))
+            portrait_img = Image.open(io.BytesIO(portrait_data))  # noqa: ASYNC_BLOCK — cold path, user-triggered character card export; full PIL chain below should also be off-loaded as a follow-up
             portrait_img.verify()
-            portrait_img = Image.open(io.BytesIO(portrait_data))  # verify()后需要重新打开
+            portrait_img = Image.open(io.BytesIO(portrait_data))  # noqa: ASYNC_BLOCK — cold path, user-triggered character card export; see above
         except Exception as e:
             logger.warning(f"[导出角色卡] 图片验证失败: {e}")
             return JSONResponse({'success': False, 'error': f'无效的图片文件: {str(e)}'}, status_code=400)

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -3683,6 +3683,12 @@ async def import_character_card(zip_file: UploadFile = File(...)):
             await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)
 
 
+class _InvalidPortraitError(ValueError):
+    """Raised by the character-card render helper when the user-supplied
+    portrait fails PIL's verify() check. Caught at the endpoint to map
+    to a 400 response (vs. 500 for genuine render errors)."""
+
+
 @router.post('/catgirl/{name}/export-with-portrait')
 async def export_catgirl_with_portrait(
     name: str,
@@ -3827,113 +3833,101 @@ async def export_catgirl_with_portrait(
 
         logger.info(f"[导出角色卡] 接收到立绘图片，大小: {len(portrait_data)} bytes")
 
+        png_path = temp_path / 'character_card.png'
+
+        # 整段 PIL 渲染链（图片校验 + 卡片合成 + 字体扫描 + PNG 编码）放进 worker
+        # 线程，避免阻塞事件循环。校验失败用专属异常，让外层回 400 而不是 500。
+        def _render_card_png(_portrait_data: bytes, _name: str, _png_path) -> None:
+            try:
+                Image.MAX_IMAGE_PIXELS = 100_000_000  # 限制最大像素数防止解压炸弹
+                portrait_img = Image.open(io.BytesIO(_portrait_data))
+                portrait_img.verify()
+                portrait_img = Image.open(io.BytesIO(_portrait_data))
+            except Exception as exc:
+                raise _InvalidPortraitError(str(exc)) from exc
+
+            logger.info(f"[导出角色卡] 立绘图片尺寸: {portrait_img.size}, 模式: {portrait_img.mode}")
+
+            if portrait_img.mode != 'RGBA':
+                portrait_img = portrait_img.convert('RGBA')
+
+            width, height = 600, 800
+            card_img = Image.new('RGBA', (width, height), color='#E8F4F8')
+            draw = ImageDraw.Draw(card_img)
+
+            header_height = height // 6
+            draw.rectangle([0, 0, width, header_height], fill='#40C5F1')
+
+            font_size = 42
+            font = None
+            font_candidates = [
+                ("msyhbd.ttc", font_size),
+                ("Microsoft YaHei Bold.ttf", font_size),
+                ("simhei.ttf", font_size),
+                ("simsun.ttc", font_size),
+                ("msyh.ttc", font_size),
+                ("Microsoft YaHei.ttf", font_size),
+            ]
+            for font_name, size in font_candidates:
+                try:
+                    font = ImageFont.truetype(font_name, size)
+                    logger.info(f"[导出角色卡] 使用字体: {font_name}")
+                    break
+                except Exception as e:
+                    logger.warning(f"[导出角色卡] 字体加载失败: {font_name}, 错误: {e}")
+                    continue
+            if font is None:
+                font = ImageFont.load_default()
+                logger.warning("[导出角色卡] 使用默认字体")
+
+            bbox = draw.textbbox((0, 0), _name, font=font)
+            text_width = bbox[2] - bbox[0]
+            text_height = bbox[3] - bbox[1]
+            text_x = 40
+            text_y = (header_height - text_height) // 2 - bbox[1]
+
+            shadow_offset = 2
+            draw.text((text_x + shadow_offset, text_y + shadow_offset), _name, fill='#00000040', font=font)
+            draw.text((text_x, text_y), _name, fill='white', font=font)
+
+            portrait_area_x = 20
+            portrait_area_y = header_height + 20
+            portrait_area_width = width - 40
+            portrait_area_height = height - header_height - 40
+            logger.info(f"[导出角色卡] 立绘区域: ({portrait_area_x}, {portrait_area_y}, {portrait_area_width}, {portrait_area_height})")
+
+            portrait_width, portrait_height = portrait_img.size
+            target_aspect = portrait_area_width / portrait_area_height
+            source_aspect = portrait_width / portrait_height
+            logger.info(f"[导出角色卡] 立绘原始尺寸: {portrait_width}x{portrait_height}, 目标比例: {target_aspect:.2f}, 源比例: {source_aspect:.2f}")
+
+            if source_aspect > target_aspect:
+                new_height = portrait_area_height
+                new_width = int(new_height * source_aspect)
+            else:
+                new_width = portrait_area_width
+                new_height = int(new_width / source_aspect)
+
+            portrait_resized = portrait_img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+            logger.info(f"[导出角色卡] 立绘调整后尺寸: {new_width}x{new_height}")
+
+            paste_x = portrait_area_x + (portrait_area_width - new_width) // 2
+            paste_y = portrait_area_y + (portrait_area_height - new_height) // 2
+            logger.info(f"[导出角色卡] 立绘粘贴位置: ({paste_x}, {paste_y})")
+
+            card_img.paste(portrait_resized, (paste_x, paste_y), portrait_resized)
+            logger.info("[导出角色卡] 立绘粘贴完成")
+
+            final_img = Image.new('RGB', (width, height), color='#E8F4F8')
+            final_img.paste(card_img, (0, 0), card_img)
+
+            final_img.save(_png_path, 'PNG')
+
         try:
-            Image.MAX_IMAGE_PIXELS = 100_000_000  # 限制最大像素数防止解压炸弹
-            portrait_img = Image.open(io.BytesIO(portrait_data))  # noqa: ASYNC_BLOCK — cold path, user-triggered character card export; full PIL chain below should also be off-loaded as a follow-up
-            portrait_img.verify()
-            portrait_img = Image.open(io.BytesIO(portrait_data))  # noqa: ASYNC_BLOCK — cold path, user-triggered character card export; see above
-        except Exception as e:
+            await asyncio.to_thread(_render_card_png, portrait_data, name, png_path)
+        except _InvalidPortraitError as e:
             logger.warning(f"[导出角色卡] 图片验证失败: {e}")
             return JSONResponse({'success': False, 'error': f'无效的图片文件: {str(e)}'}, status_code=400)
-
-        logger.info(f"[导出角色卡] 立绘图片尺寸: {portrait_img.size}, 模式: {portrait_img.mode}")
-
-        # 转换为RGBA模式（确保透明通道）
-        if portrait_img.mode != 'RGBA':
-            portrait_img = portrait_img.convert('RGBA')
-
-        # 3. 创建角色卡模板
-        width, height = 600, 800
-        card_img = Image.new('RGBA', (width, height), color='#E8F4F8')
-        draw = ImageDraw.Draw(card_img)
-
-        # 顶部1/6区域使用深蓝色
-        header_height = height // 6
-        draw.rectangle([0, 0, width, header_height], fill='#40C5F1')
-
-        # 在顶部左侧添加角色名称
-        # 尝试使用更美观的字体，并加粗显示
-        font_size = 42  # 增大字体
-        font = None
-
-        # 尝试多种中文字体，按优先级排序
-        font_candidates = [
-            ("msyhbd.ttc", font_size),      # 微软雅黑粗体
-            ("Microsoft YaHei Bold.ttf", font_size),  # 微软雅黑粗体（另一种名称）
-            ("simhei.ttf", font_size),      # 黑体
-            ("simsun.ttc", font_size),      # 宋体
-            ("msyh.ttc", font_size),        # 微软雅黑常规
-            ("Microsoft YaHei.ttf", font_size),  # 微软雅黑（另一种名称）
-        ]
-
-        for font_name, size in font_candidates:
-            try:
-                font = ImageFont.truetype(font_name, size)
-                logger.info(f"[导出角色卡] 使用字体: {font_name}")
-                break
-            except Exception as e:
-                logger.warning(f"[导出角色卡] 字体加载失败: {font_name}, 错误: {e}")
-                continue
-
-        if font is None:
-            font = ImageFont.load_default()
-            logger.warning("[导出角色卡] 使用默认字体")
-
-        text = name
-        bbox = draw.textbbox((0, 0), text, font=font)
-        text_width = bbox[2] - bbox[0]
-        text_height = bbox[3] - bbox[1]
-        text_x = 40  # 稍微增加左边距
-        text_y = (header_height - text_height) // 2 - bbox[1]
-
-        # 添加文字阴影效果增加可读性
-        shadow_offset = 2
-        draw.text((text_x + shadow_offset, text_y + shadow_offset), text, fill='#00000040', font=font)  # 半透明黑色阴影
-        draw.text((text_x, text_y), text, fill='white', font=font)  # 白色文字
-
-        # 4. 合成立绘到角色卡
-        # 立绘区域：顶部蓝色区域下方到卡片底部，左右留边距
-        portrait_area_x = 20
-        portrait_area_y = header_height + 20
-        portrait_area_width = width - 40
-        portrait_area_height = height - header_height - 40
-        logger.info(f"[导出角色卡] 立绘区域: ({portrait_area_x}, {portrait_area_y}, {portrait_area_width}, {portrait_area_height})")
-
-        # 计算缩放比例，保持比例，居中填充
-        portrait_width, portrait_height = portrait_img.size
-        target_aspect = portrait_area_width / portrait_area_height
-        source_aspect = portrait_width / portrait_height
-        logger.info(f"[导出角色卡] 立绘原始尺寸: {portrait_width}x{portrait_height}, 目标比例: {target_aspect:.2f}, 源比例: {source_aspect:.2f}")
-
-        if source_aspect > target_aspect:
-            # 源更宽，以高度为准
-            new_height = portrait_area_height
-            new_width = int(new_height * source_aspect)
-        else:
-            # 源更高，以宽度为准
-            new_width = portrait_area_width
-            new_height = int(new_width / source_aspect)
-
-        # 调整立绘大小
-        portrait_resized = portrait_img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-        logger.info(f"[导出角色卡] 立绘调整后尺寸: {new_width}x{new_height}")
-
-        # 计算居中位置
-        paste_x = portrait_area_x + (portrait_area_width - new_width) // 2
-        paste_y = portrait_area_y + (portrait_area_height - new_height) // 2
-        logger.info(f"[导出角色卡] 立绘粘贴位置: ({paste_x}, {paste_y})")
-
-        # 粘贴立绘（使用alpha通道）
-        card_img.paste(portrait_resized, (paste_x, paste_y), portrait_resized)
-        logger.info("[导出角色卡] 立绘粘贴完成")
-
-        # 转换为RGB模式（PNG不支持RGBA的某些特性）
-        final_img = Image.new('RGB', (width, height), color='#E8F4F8')
-        final_img.paste(card_img, (0, 0), card_img)
-
-        # 5. 保存PNG图片
-        png_path = temp_path / 'character_card.png'
-        final_img.save(png_path, 'PNG')
 
         # 6. 将压缩包数据嵌入 PNG 的 neKo 块（合法 PNG chunk，Electron 可正常预览）
         with open(png_path, 'rb') as f:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -3881,7 +3881,6 @@ async def export_catgirl_with_portrait(
                 logger.warning("[导出角色卡] 使用默认字体")
 
             bbox = draw.textbbox((0, 0), _name, font=font)
-            text_width = bbox[2] - bbox[0]
             text_height = bbox[3] - bbox[1]
             text_x = 40
             text_y = (header_height - text_height) // 2 - bbox[1]

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -3843,6 +3843,7 @@ async def export_catgirl_with_portrait(
                 portrait_img = Image.open(io.BytesIO(_portrait_data))
                 portrait_img.verify()
                 portrait_img = Image.open(io.BytesIO(_portrait_data))
+                portrait_img.load()  # 强制解码：把截断/损坏的像素错误提前到这里，与 _InvalidPortraitError 一起回 400 而不是后续 resize/save 时回 500
             except Exception as exc:
                 raise _InvalidPortraitError(str(exc)) from exc
 

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -163,13 +163,16 @@ async def get_all_cookies_status():
     """返回每个支持平台的 Cookie 存在状态（前端个人动态功能使用）"""
     try:
         platforms = login_manager.get_supported_platforms()
-        result = {}
-        for platform_key in platforms:
-            cookies = load_cookies_from_file(platform_key)
-            result[platform_key] = {
+        loaded = await asyncio.gather(
+            *(asyncio.to_thread(load_cookies_from_file, p) for p in platforms)
+        )
+        result = {
+            platform_key: {
                 "has_cookies": bool(cookies),
                 "cookies_count": len(cookies) if cookies else 0,
             }
+            for platform_key, cookies in zip(platforms, loaded)
+        }
         return {"success": True, "data": result}
     except Exception as e:
         logger.error(f"获取所有 cookie 状态失败: {type(e).__name__}")
@@ -181,7 +184,7 @@ async def get_platform_cookies(platform: str):
     if platform not in supported:
         raise HTTPException(status_code=400, detail="平台无效")
             
-    cookies = load_cookies_from_file(platform)
+    cookies = await asyncio.to_thread(load_cookies_from_file, platform)
     if not cookies:
         return {"success": True, "data": {"platform": platform, "has_cookies": False}}
             

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -1053,7 +1053,7 @@ async def export_config(
         )
     except Exception:
         # 发生异常时清理临时目录
-        cleanup_temp_path(str(temp_dir))
+        await asyncio.to_thread(cleanup_temp_path, str(temp_dir))
         raise
 
 
@@ -1427,5 +1427,5 @@ async def pack_folder(files: List[UploadFile] = File(...)):
         )
     except Exception:
         # 发生异常时清理临时目录
-        cleanup_temp_path(str(temp_dir))
+        await asyncio.to_thread(cleanup_temp_path, str(temp_dir))
         raise

--- a/main_routers/mmd_router.py
+++ b/main_routers/mmd_router.py
@@ -500,11 +500,11 @@ async def upload_mmd_zip(file: UploadFile = File(...)):
                 for n in decoded_names
             ):
                 # ZIP 已含同名目录结构，直接解压到 mmd_dir
-                _extract_zip_with_encoding(zf, mmd_dir, name_map)
+                await asyncio.to_thread(_extract_zip_with_encoding, zf, mmd_dir, name_map)
             else:
                 # 解压到 target_dir
                 target_dir.mkdir(parents=True, exist_ok=True)
-                _extract_zip_with_encoding(zf, target_dir, name_map)
+                await asyncio.to_thread(_extract_zip_with_encoding, zf, target_dir, name_map)
 
         # 找到解压后的 PMX 路径
         pmx_candidates = []

--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -1,5 +1,7 @@
 # 音乐路由
 
+import asyncio
+
 from fastapi import APIRouter, Query
 from fastapi.responses import RedirectResponse, Response, JSONResponse, StreamingResponse
 from cachetools import TTLCache
@@ -340,7 +342,7 @@ async def play_netease_music(song_id: str):
 
     try:
         # 加载 Cookie 并同步到 pyncm_async 会话
-        cookies = load_cookies_from_file('netease')
+        cookies = await asyncio.to_thread(load_cookies_from_file, 'netease')
         if cookies:
             session = pyncm_async.GetCurrentSession()
             # 兼容性处理：pyncm_async 内部使用 httpx，直接注入 cookiejar

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2249,9 +2249,13 @@ async def backend_screenshot(request: Request):
         return JSONResponse({"success": False, "error": "pyautogui not installed"}, status_code=501)
 
     try:
-        shot = await asyncio.to_thread(pyautogui.screenshot)
-        if shot.mode in ('RGBA', 'LA', 'P'):
-            shot = shot.convert('RGB')
+        def _capture_rgb_screenshot():
+            shot = pyautogui.screenshot()
+            if shot.mode in ('RGBA', 'LA', 'P'):
+                shot = shot.convert('RGB')
+            return shot
+
+        shot = await asyncio.to_thread(_capture_rgb_screenshot)
 
         # macOS 黑屏检测：仅在 macOS 上执行——未授权 Screen Recording 时 pyautogui 返回全黑图片
         # 其他平台（Windows/Linux）全黑截图属正常内容，不应拦截
@@ -2266,7 +2270,9 @@ async def backend_screenshot(request: Request):
             except Exception:
                 logger.debug("macOS blank-screen detection failed, skipping check", exc_info=True)
 
-        jpg_bytes = compress_screenshot(shot, target_h=COMPRESS_TARGET_HEIGHT, quality=COMPRESS_JPEG_QUALITY)
+        jpg_bytes = await asyncio.to_thread(
+            compress_screenshot, shot, target_h=COMPRESS_TARGET_HEIGHT, quality=COMPRESS_JPEG_QUALITY,
+        )
         b64 = base64.b64encode(jpg_bytes).decode('utf-8')
         data_url = f"data:image/jpeg;base64,{b64}"
         return JSONResponse({"success": True, "data": data_url, "size": len(jpg_bytes)})

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -55,7 +55,12 @@ from config.prompts_proactive import (
     MUSIC_SEARCH_RESULT_TEXTS,
 )
 from utils.workshop_utils import get_workshop_path
-from utils.screenshot_utils import compress_screenshot, COMPRESS_TARGET_HEIGHT, COMPRESS_JPEG_QUALITY
+from utils.screenshot_utils import (
+    compress_screenshot,
+    decode_and_compress_screenshot_b64,
+    COMPRESS_TARGET_HEIGHT,
+    COMPRESS_JPEG_QUALITY,
+)
 from utils.language_utils import detect_language, translate_text, normalize_language_code, get_global_language
 from utils.web_scraper import (
     fetch_trending_content, format_trending_content,
@@ -2244,7 +2249,7 @@ async def backend_screenshot(request: Request):
         return JSONResponse({"success": False, "error": "pyautogui not installed"}, status_code=501)
 
     try:
-        shot = pyautogui.screenshot()
+        shot = await asyncio.to_thread(pyautogui.screenshot)
         if shot.mode in ('RGBA', 'LA', 'P'):
             shot = shot.convert('RGB')
 
@@ -2390,14 +2395,15 @@ async def proactive_chat(request: Request):
                 # 截图将在 Phase 2 由 vision_model 直接读取原图，这里只做压缩。
                 compressed_b64 = ''
                 try:
-                    from PIL import Image as _PILImage
                     b64_raw = screenshot_data.split(',', 1)[1] if ',' in screenshot_data else screenshot_data
-                    img = _PILImage.open(BytesIO(base64.b64decode(b64_raw)))
-                    if img.mode in ('RGBA', 'LA', 'P'):
-                        img = img.convert('RGB')
-                    jpg_bytes = compress_screenshot(img, target_h=COMPRESS_TARGET_HEIGHT, quality=COMPRESS_JPEG_QUALITY)
-                    compressed_b64 = base64.b64encode(jpg_bytes).decode('utf-8')
-                    print(f"[{lanlan_name}] Vision 通道: 截图压缩完成 {len(jpg_bytes)//1024}KB (Phase 2 将直接分析)")
+                    compressed_b64 = await asyncio.to_thread(
+                        decode_and_compress_screenshot_b64,
+                        b64_raw,
+                        COMPRESS_TARGET_HEIGHT,
+                        COMPRESS_JPEG_QUALITY,
+                    )
+                    jpg_size_kb = len(compressed_b64) * 3 // 4 // 1024
+                    print(f"[{lanlan_name}] Vision 通道: 截图压缩完成 {jpg_size_kb}KB (Phase 2 将直接分析)")
                 except Exception as compress_err:
                     logger.warning(f"[{lanlan_name}] 截图压缩失败（Phase 2 将无法使用截图）: {compress_err}")
                 return (mode, {'window_title': window_title, 'screenshot_b64': compressed_b64})

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -21,6 +21,33 @@ generic (``send``, ``put``, ``wait``) are not checked here — they hit
 httpx / websockets / asyncio.Event far more often than real blocking
 stdlib objects, so the noise is not worth the signal.
 
+Depth-1 transitive check
+------------------------
+A sync helper in this repo, called *directly* from an ``async def``, can
+still block the loop even though ruff and the direct-body pass above see
+nothing wrong (the helper is a plain ``def``; its body is off-loaded in
+our model). A second pass addresses exactly that class:
+
+1. Scan every module-level / class-level ``def`` (not nested inside an
+   ``async def``) and mark it as "risky" when its direct body contains a
+   recognised blocking stdlib call (``PIL.Image.open``, Fernet
+   encrypt/decrypt, ``shutil.*``, ``time.sleep``, ``requests.*``,
+   ``subprocess.run``/``call``/``check_*``, ``urllib.request.urlopen``,
+   plus the queue/thread/socket tail-name heuristics above).
+2. Walk every ``async def`` body again, and for each bare ``foo(...)``
+   or ``obj.foo(...)`` call match the tail name against the risky index.
+   A hit is reported as: *blocking sync helper '<name>' ... called
+   directly from async context; wrap the call in
+   ``await asyncio.to_thread(...)``*.
+
+We deliberately stop at depth 1 — tracing deeper chains needs type
+inference and/or module-level import resolution, and name-based
+heuristics past depth 1 produce more noise than signal. Imports are not
+resolved; a helper re-exported or aliased at import time will slip
+through. That is a known trade-off — easy to add later, hard to make
+quiet today. False positives from name collisions can be silenced per
+line with ``# noqa: ASYNC_BLOCK — <reason>``.
+
 Every violation prints as ``path:line:col  CODE  message``. Exit status
 is 1 when any violation is found, 0 otherwise.
 
@@ -70,6 +97,69 @@ THREAD_SUFFIX = ("_thread", "_process", "_proc", "_worker")
 SOCKET_EXACT = {"sock", "socket"}
 SOCKET_SUFFIX = ("_sock", "_socket")
 
+# ── depth-1 transitive detection ────────────────────────────────────────
+# Specific (receiver_tail, attr) pairs for stdlib blocking operations.
+# These are used to classify a sync ``def`` as "risky" when its body
+# contains such a call, and to describe *why* it is risky. Matching is
+# on the tail (rightmost) identifier of the receiver — ``self.x.y.save``
+# collapses to ``y.save``, which disambiguates ``fernet.encrypt`` vs.
+# ``self.encrypt``. Overly generic pairs are deliberately omitted.
+RISKY_ATTR_PAIRS: dict[tuple[str, str], str] = {
+    # PIL
+    ("Image", "open"): "PIL.Image.open",
+    ("_PILImage", "open"): "PIL.Image.open",
+    ("PIL", "open"): "PIL.Image.open",
+    # pyautogui (screen capture goes through native code, blocks for tens
+    # of ms on each frame)
+    ("pyautogui", "screenshot"): "pyautogui.screenshot",
+    # Fernet
+    ("fernet", "encrypt"): "Fernet.encrypt",
+    ("fernet", "decrypt"): "Fernet.decrypt",
+    ("Fernet", "encrypt"): "Fernet.encrypt",
+    ("Fernet", "decrypt"): "Fernet.decrypt",
+    # requests
+    ("requests", "get"): "requests.get",
+    ("requests", "post"): "requests.post",
+    ("requests", "put"): "requests.put",
+    ("requests", "delete"): "requests.delete",
+    ("requests", "patch"): "requests.patch",
+    ("requests", "head"): "requests.head",
+    ("requests", "options"): "requests.options",
+    ("requests", "request"): "requests.request",
+    # subprocess
+    ("subprocess", "run"): "subprocess.run",
+    ("subprocess", "call"): "subprocess.call",
+    ("subprocess", "check_call"): "subprocess.check_call",
+    ("subprocess", "check_output"): "subprocess.check_output",
+    ("subprocess", "Popen"): "subprocess.Popen",
+    # urllib
+    ("request", "urlopen"): "urllib.request.urlopen",
+    ("urllib", "urlopen"): "urllib.request.urlopen",
+    # time
+    ("time", "sleep"): "time.sleep",
+    # shutil (belt + suspenders: any sync helper wrapping these that is
+    # itself called from async bypasses the direct-body shutil checks)
+    ("shutil", "copy"): "shutil.copy",
+    ("shutil", "copy2"): "shutil.copy2",
+    ("shutil", "copyfile"): "shutil.copyfile",
+    ("shutil", "copyfileobj"): "shutil.copyfileobj",
+    ("shutil", "copytree"): "shutil.copytree",
+    ("shutil", "move"): "shutil.move",
+    ("shutil", "rmtree"): "shutil.rmtree",
+}
+
+# Bare-name (no receiver) function calls that indicate blocking —
+# catches ``from time import sleep``, ``from shutil import rmtree``,
+# ``from urllib.request import urlopen`` etc. Names must be distinctive
+# enough that a collision with a user-defined function of the same name
+# inside the scanned tree is unlikely. ``sleep`` is distinctive;
+# ``copy`` is NOT (too many generic helpers), so we only flag it via
+# attribute form above.
+RISKY_BARE_CALLS: dict[str, str] = {
+    "urlopen": "urllib.request.urlopen",
+    "rmtree": "shutil.rmtree",
+}
+
 
 def _tail_matches(tail: str, exact: set[str], suffix: tuple[str, ...]) -> bool:
     if not tail:
@@ -96,13 +186,103 @@ def _tail_name(node: ast.expr) -> str:
     return ""
 
 
+def _describe_blocking_call(call: ast.Call) -> str | None:
+    """If the call matches a known blocking stdlib operation, return a
+    short human-readable description; otherwise ``None``.
+
+    This is the knowledge used by the depth-1 transitive pass to decide
+    whether a plain ``def`` is risky to call from an async context.
+    """
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        receiver_tail = _tail_name(func.value)
+        attr = func.attr
+        label = RISKY_ATTR_PAIRS.get((receiver_tail, attr))
+        if label is not None:
+            return label
+        # queue.Queue.get / Thread.join / socket.recv forms — also mark a
+        # plain def that calls these as risky, since being wrapped in a
+        # sync helper doesn't make them any less blocking.
+        if attr == "get" and _tail_matches(receiver_tail, QUEUE_EXACT, QUEUE_SUFFIX):
+            return "queue.Queue.get()"
+        if attr == "join" and _tail_matches(receiver_tail, THREAD_EXACT, THREAD_SUFFIX):
+            return "Thread/Process.join()"
+        if _tail_matches(receiver_tail, SOCKET_EXACT, SOCKET_SUFFIX) and attr in {"recv", "accept", "connect"}:
+            return f"blocking socket.{attr}()"
+        return None
+    if isinstance(func, ast.Name):
+        return RISKY_BARE_CALLS.get(func.id)
+    return None
+
+
+class RiskySyncDefIndexer(ast.NodeVisitor):
+    """First pass: find plain ``def`` helpers whose direct body calls a
+    known-blocking stdlib operation. A helper's body is scanned with
+    nested ``def`` / ``async def`` / lambda bodies excluded (they do not
+    execute when the outer helper returns). We only index top-level
+    functions and methods of top-level classes — lambdas, deeply nested
+    defs, and defs inside another ``async def`` cannot escape to an
+    unrelated async-call site.
+    """
+
+    def __init__(self) -> None:
+        # name -> (file-relative-or-absolute path str, lineno, reason)
+        # Filled by module-level driver.
+        self.risky: dict[str, tuple[str, int, str]] = {}
+
+    def index_module(self, tree: ast.Module, path: Path) -> None:
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                self._consider_def(node, path)
+            elif isinstance(node, ast.ClassDef):
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef):
+                        self._consider_def(item, path)
+
+    def _consider_def(self, node: ast.FunctionDef, path: Path) -> None:
+        reason = _sync_body_has_blocking_call(node)
+        if reason is None:
+            return
+        # First-wins: if two helpers share a name, keep the first so the
+        # message points at a real definition. Name collisions are rare
+        # enough in this repo that this is fine.
+        self.risky.setdefault(node.name, (str(path), node.lineno, reason))
+
+
+def _sync_body_has_blocking_call(func: ast.FunctionDef) -> str | None:
+    """Scan ``func``'s body for a known-blocking call, descending into
+    control-flow (if/for/with/try) but NOT into nested functions or
+    lambdas — a nested function's code only runs when invoked, which by
+    definition won't happen just because the outer helper is called.
+    Returns a short reason string, or ``None``.
+    """
+    stack: list[ast.AST] = list(func.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue  # prune nested scope
+        if isinstance(node, ast.Call):
+            reason = _describe_blocking_call(node)
+            if reason is not None:
+                return reason
+        for child in ast.iter_child_nodes(node):
+            stack.append(child)
+    return None
+
+
 class AsyncBlockingChecker(ast.NodeVisitor):
-    def __init__(self, path: Path, source: str) -> None:
+    def __init__(
+        self,
+        path: Path,
+        source: str,
+        risky_helpers: dict[str, tuple[str, int, str]] | None = None,
+    ) -> None:
         self.path = path
         self.source_lines = source.splitlines()
         # Stack of "async" / "sync" — nearest function kind.
         self._func_stack: list[str] = []
         self.violations: list[tuple[int, int, str]] = []
+        self._risky = risky_helpers or {}
 
     # ── function tracking ────────────────────────────────────────────────
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
@@ -138,9 +318,56 @@ class AsyncBlockingChecker(ast.NodeVisitor):
 
     # ── the actual checks ────────────────────────────────────────────────
     def visit_Call(self, node: ast.Call) -> None:
-        if self._in_async_context() and isinstance(node.func, ast.Attribute):
-            self._check_attribute_call(node)
+        if self._in_async_context():
+            if isinstance(node.func, ast.Attribute):
+                self._check_attribute_call(node)
+            self._check_direct_blocking_call(node)
+            self._check_transitive_sync_helper(node)
         self.generic_visit(node)
+
+    def _check_direct_blocking_call(self, call: ast.Call) -> None:
+        """Flag known-blocking stdlib calls (PIL.Image.open, Fernet
+        encrypt/decrypt, time.sleep, shutil.*, requests.*, etc.) that
+        appear inline inside an ``async def`` body. Uses the same
+        recogniser as the depth-1 risky-helper indexer for symmetry —
+        anything blocking-enough to mark a sync helper as risky is also
+        blocking when written inline.
+        """
+        reason = _describe_blocking_call(call)
+        if reason is None:
+            return
+        # Avoid duplicating with the existing queue/thread/socket flags —
+        # those carry richer messages from _check_attribute_call.
+        if reason in ("queue.Queue.get()", "Thread/Process.join()") or reason.startswith(
+            "blocking socket."
+        ):
+            return
+        self._flag(
+            call,
+            f"{reason} blocks the event loop; wrap in await asyncio.to_thread(...).",
+        )
+
+    def _check_transitive_sync_helper(self, call: ast.Call) -> None:
+        """Depth-1: flag ``foo(...)`` or ``obj.foo(...)`` where ``foo``
+        is the name of an indexed risky sync helper. We intentionally
+        match on tail name only — resolving receivers would need import
+        tracking, and in this repo the helper names we care about
+        (``compress_screenshot``, ``load_cookies_from_file``, etc.) are
+        distinctive enough that collisions are rare.
+        """
+        name = _tail_name(call.func)
+        if not name:
+            return
+        hit = self._risky.get(name)
+        if hit is None:
+            return
+        def_path, def_lineno, reason = hit
+        self._flag(
+            call,
+            f"blocking sync helper '{name}' (defined at {def_path}:{def_lineno}, "
+            f"uses {reason}) called directly from async context; wrap the call "
+            f"in await asyncio.to_thread(...).",
+        )
 
     def _check_attribute_call(self, call: ast.Call) -> None:
         attr = call.func.attr  # type: ignore[union-attr]
@@ -223,18 +450,27 @@ def _iter_python_files(paths: Iterable[Path]) -> Iterator[Path]:
             yield from sorted(p.rglob("*.py"))
 
 
-def check_file(path: Path) -> list[tuple[int, int, str]]:
+def _parse_file(path: Path) -> tuple[str, ast.Module] | None:
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
         print(f"{path}: skipped — {e}", file=sys.stderr)
-        return []
+        return None
     try:
         tree = ast.parse(source, filename=str(path))
     except SyntaxError as e:
         print(f"{path}:{e.lineno}: syntax error — {e.msg}", file=sys.stderr)
-        return []
-    checker = AsyncBlockingChecker(path, source)
+        return None
+    return source, tree
+
+
+def check_file(
+    path: Path,
+    source: str,
+    tree: ast.Module,
+    risky_helpers: dict[str, tuple[str, int, str]] | None = None,
+) -> list[tuple[int, int, str]]:
+    checker = AsyncBlockingChecker(path, source, risky_helpers=risky_helpers)
     checker.visit(tree)
     return checker.violations
 
@@ -251,9 +487,27 @@ def main(argv: list[str] | None = None) -> int:
     raw_paths = args.paths or DEFAULT_PATHS
     targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
 
-    total = 0
+    # Pass 1: parse every file once, build the risky-sync-def index.
+    parsed: list[tuple[Path, str, ast.Module]] = []
+    indexer = RiskySyncDefIndexer()
     for file in _iter_python_files(targets):
-        for lineno, col, msg in check_file(file):
+        parsed_file = _parse_file(file)
+        if parsed_file is None:
+            continue
+        source, tree = parsed_file
+        parsed.append((file, source, tree))
+        rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
+        # Re-seed indexer.risky entries with the relative path for nicer
+        # error messages, but preserve first-wins.
+        local_indexer = RiskySyncDefIndexer()
+        local_indexer.index_module(tree, rel)
+        for name, info in local_indexer.risky.items():
+            indexer.risky.setdefault(name, info)
+
+    # Pass 2: walk async bodies for direct blocking + depth-1 transitive.
+    total = 0
+    for file, source, tree in parsed:
+        for lineno, col, msg in check_file(file, source, tree, risky_helpers=indexer.risky):
             rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
             print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
             total += 1

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -158,6 +158,10 @@ RISKY_ATTR_PAIRS: dict[tuple[str, str], str] = {
 RISKY_BARE_CALLS: dict[str, str] = {
     "urlopen": "urllib.request.urlopen",
     "rmtree": "shutil.rmtree",
+    # ``from time import sleep`` — distinctive enough; await asyncio.sleep
+    # is an attribute call (``asyncio.sleep``) so it won't be confused with
+    # this bare ``sleep`` form.
+    "sleep": "time.sleep",
 }
 
 

--- a/utils/cookies_login.py
+++ b/utils/cookies_login.py
@@ -275,7 +275,7 @@ async def get_bilibili_cookies(_method: str = "manual") -> Optional[Dict[str, st
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]") 
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('bilibili', cookies)
+        save_cookies_to_file('bilibili', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 # ==========================================
@@ -288,7 +288,7 @@ async def get_douyin_cookies(_method: str = "manual") -> Optional[Dict[str, str]
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('douyin', cookies)
+        save_cookies_to_file('douyin', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 async def get_kuaishou_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
@@ -298,7 +298,7 @@ async def get_kuaishou_cookies(_method: str = "manual") -> Optional[Dict[str, st
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('kuaishou', cookies)
+        save_cookies_to_file('kuaishou', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 async def get_weibo_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
@@ -308,7 +308,7 @@ async def get_weibo_cookies(_method: str = "manual") -> Optional[Dict[str, str]]
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('weibo', cookies)
+        save_cookies_to_file('weibo', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 async def get_reddit_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
@@ -318,7 +318,7 @@ async def get_reddit_cookies(_method: str = "manual") -> Optional[Dict[str, str]
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('reddit', cookies)
+        save_cookies_to_file('reddit', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 async def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
@@ -328,7 +328,7 @@ async def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('twitter', cookies)
+        save_cookies_to_file('twitter', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 async def get_netease_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
@@ -338,7 +338,7 @@ async def get_netease_cookies(_method: str = "manual") -> Optional[Dict[str, str
     print("\033[F\033[K" + "👉 请粘贴 Cookie: [已接收，已脱敏掩码]")
     cookies = parse_cookie_string(cookie_string)
     if cookies:
-        save_cookies_to_file('netease', cookies)
+        save_cookies_to_file('netease', cookies)  # noqa: ASYNC_BLOCK — CLI-only path; outer fn already blocks on input()
     return cookies
 
 # ==========================================

--- a/utils/screenshot_utils.py
+++ b/utils/screenshot_utils.py
@@ -70,6 +70,24 @@ def compress_screenshot(
     return buf.getvalue()
 
 
+def decode_and_compress_screenshot_b64(
+    b64_raw: str,
+    target_h: int = COMPRESS_TARGET_HEIGHT,
+    quality: int = COMPRESS_JPEG_QUALITY,
+) -> str:
+    """Decode a base64-encoded screenshot, normalize to RGB, and return a
+    base64 JPEG string (without the ``data:`` prefix).
+
+    Entirely synchronous and CPU/IO-bound — callers in async contexts MUST
+    invoke via ``await asyncio.to_thread(...)`` to keep the event loop free.
+    """
+    img = Image.open(BytesIO(base64.b64decode(b64_raw)))
+    if img.mode in ("RGBA", "LA", "P"):
+        img = img.convert("RGB")
+    jpg_bytes = compress_screenshot(img, target_h=target_h, quality=quality)
+    return base64.b64encode(jpg_bytes).decode("utf-8")
+
+
 async def process_screen_data(data: str) -> Optional[str]:
     """
     处理前端发送的屏幕分享数据流
@@ -92,12 +110,12 @@ async def process_screen_data(data: str) -> Optional[str]:
             return None
         
         img_bytes = base64.b64decode(img_b64)
-        
-        image = _validate_image_data(img_bytes)
+
+        image = await asyncio.to_thread(_validate_image_data, img_bytes)
         if image is None:
             logger.error("无效的图片数据")
             return None
-        
+
         w, h = image.size
         logger.debug(f"屏幕数据验证完成: 尺寸 {w}x{h}")
         
@@ -240,16 +258,21 @@ async def analyze_screenshot_from_data_url(data_url: str, window_title: str = ''
         # 验证图片有效性并转换为JPEG
         try:
             image_bytes = base64.b64decode(base64_data)
-            image = _validate_image_data(image_bytes)
+            image = await asyncio.to_thread(_validate_image_data, image_bytes)
             if image is None:
                 logger.error("无效的图片数据")
                 return None
-            
+
             # 统一压缩为 JPEG（含 resize）
             if image.mode in ('RGBA', 'LA', 'P'):
                 image = image.convert('RGB')
             orig_w, orig_h = image.size
-            jpg_bytes = compress_screenshot(image, target_h=COMPRESS_TARGET_HEIGHT, quality=COMPRESS_JPEG_QUALITY)
+            jpg_bytes = await asyncio.to_thread(
+                compress_screenshot,
+                image,
+                target_h=COMPRESS_TARGET_HEIGHT,
+                quality=COMPRESS_JPEG_QUALITY,
+            )
             base64_data = base64.b64encode(jpg_bytes).decode('utf-8')
             new_size = len(jpg_bytes)
             logger.info(f"截图验证成功: {orig_w}x{orig_h} → 压缩后 {new_size//1024}KB")


### PR DESCRIPTION
## 背景

PR #840–#846 已经把 ruff ASYNC 规则 + 自定义 `scripts/check_async_blocking.py` 上线，并修完了所有**直接**违规（time.sleep / subprocess / requests / urllib / Thread.join / queue.get / raw socket）。但这两个工具都不会追踪 `async def foo(): bar()` 中 `bar()` 是本仓库内 sync helper 的情况——而 helper 内部仍然在 PIL/Fernet/shutil 上阻塞事件循环。手动审计找到了 5 处此类残留，本 PR 全部修复，并把这一类违规纳入静态检查。

## Part 1 — 修复 5 处 transitive 同步阻塞

| # | 路径 | async 函数 | 问题 helper | 修复 |
|---|------|-----------|------------|------|
| A | `main_routers/system_router.py:2381` | `proactive_chat._fetch_source('vision')` | `PIL.Image.open` + `compress_screenshot` | 抽出 `decode_and_compress_screenshot_b64` (`utils/screenshot_utils.py`)，整条 PIL 链 `await asyncio.to_thread(...)` |
| B | `main_logic/core.py:2107` | `request_fresh_screenshot`（本机兜底分支） | `pyautogui.screenshot` + `compress_screenshot` | 二者均 `await asyncio.to_thread(...)` |
| C | `main_routers/cookies_login_router.py:160` | `get_all_cookies_status` | `load_cookies_from_file`（× 7 平台，每个含 Fernet 解密 + 文件 IO） | `await asyncio.gather(*(asyncio.to_thread(load_cookies_from_file, p) for p in platforms))` |
| D | `main_routers/cookies_login_router.py:184` | `get_platform_cookies` | `load_cookies_from_file` | `await asyncio.to_thread(load_cookies_from_file, platform)` |

`save_cookies_to_file` 在同文件 ~144 / ~428 已是 `to_thread`，C/D 修完后 load/save 路径对称。

### Before / After 片段（A 站点示例）

```python
# Before — 直接在 async def 体内执行 PIL 全链
img = _PILImage.open(BytesIO(base64.b64decode(b64_raw)))
if img.mode in ('RGBA', 'LA', 'P'):
    img = img.convert('RGB')
jpg_bytes = compress_screenshot(img, target_h=..., quality=...)

# After — 抽 helper + to_thread
compressed_b64 = await asyncio.to_thread(
    decode_and_compress_screenshot_b64,
    b64_raw, COMPRESS_TARGET_HEIGHT, COMPRESS_JPEG_QUALITY,
)
```

## Part 2 — `scripts/check_async_blocking.py` 新增 depth-1 transitive pass

新流程：

1. **Pass 1**: 遍历每个非 async 上下文的 `def`（顶层函数 + 顶层类的方法），扫描其直接 body（剪枝掉嵌套 def / lambda 体——它们不会因为外层 helper 被调用就执行），如果命中已知阻塞操作（PIL.Image.open / Fernet encrypt-decrypt / shutil.* / time.sleep / requests.* / subprocess.* / urlopen / pyautogui.screenshot / 已有的 queue.get / Thread.join / socket.recv-accept-connect 启发式），把函数名记入 risky 索引（`name → (file, lineno, reason)`）。
2. **Pass 2**: 重新遍历每个 `async def`，对每个 `foo(...)` / `obj.foo(...)` 用 `_tail_name` 取尾名，命中 risky 索引就报错，附带原 helper 定义位置 + 阻塞理由。
3. **同时**把 PIL.Image.open / Fernet / shutil / pyautogui.screenshot 等 inline 形式也加进直接体内检测——之前只查 queue/thread/socket。

### 为什么停在 depth-1

- 再深就需要类型推断或 import 解析。
- 名字启发式过 depth 1 噪音 > 信号。
- 当前 4 个目标目录代码量足够小，depth-1 已经能 cover。

### 误报取舍

- 仅匹配尾名（不解析 receiver 类型）。
- 过于通用的名字（`save` / `load` / `process` / `get` / `copy`）不进 risky 索引——CLI 仓里 `compress_screenshot` / `load_cookies_from_file` / `_extract_zip_with_encoding` 这种命名足够特异，碰撞罕见。
- 未追踪 import / alias，`from X import Y as Z` 别名形式会漏过——已知 trade-off。
- 真发生命名碰撞 → 单行 `# noqa: ASYNC_BLOCK — <reason>` 抑制。

## 顺手清扫 — depth-1 新发现的真实阻塞点

新 linter 一开就扫出额外 **真正** 的阻塞点（不是误报）。本 PR 一并修复：

| 路径 | 修复 |
|------|------|
| `main_routers/jukebox_router.py:1056, 1430` | 异常路径 `cleanup_temp_path` (shutil.rmtree) → `to_thread` |
| `main_routers/mmd_router.py:503, 507` | 用户 MMD 上传 `_extract_zip_with_encoding` (shutil.copyfileobj) → `to_thread` |
| `main_routers/music_router.py:343` | 每次播歌 `load_cookies_from_file` → `to_thread`（异步对称） |
| `utils/screenshot_utils.py:114, 261` | 每帧屏幕共享 `_validate_image_data` (PIL.Image.open) → `to_thread` |
| `main_routers/system_router.py:2252` | `backend_screenshot` 内 `pyautogui.screenshot` → `to_thread`（顺带 fix） |

## 主动留作 follow-up（noqa 抑制）

按任务约定，cold-path 不在本 PR 范围。Linter 命中后用 `# noqa: ASYNC_BLOCK — <reason>` 抑制，理由全部写在行尾：

| 路径 | 性质 | 抑制理由 |
|------|------|---------|
| `utils/cookies_login.py:278, 291, 301, 311, 321, 331, 341` | 7 个 async 平台导入 helper（`get_*_cookies`） | 已经在用 `input()` 阻塞 stdin，是 CLI-only 路径，从未由 FastAPI 调用 |
| `main_routers/characters_router.py:3832, 3834` | 角色卡导出端点的 PIL 全链 (`Image.open` + `verify` + `convert` + `resize` + `paste` + `save`) | 用户主动触发的一次性导出，整条链应该在 follow-up 里抽成 sync helper 后整体 `to_thread`（不是单纯包 `Image.open`） |

依然在 "Do NOT fix" 名单内、本 PR **未触碰**：`_get_port_owners` 启动期 subprocess、`_check_non_mainland` 首次调用 urllib、`_try_shrink_image_payload` (omni_realtime_client sync 分支)、`loop.slow_callback_duration` 调试钩子、PR #846 的 T1-T5。

## 验证

- [x] `python -c 'import ast; ast.parse(...)'` 全部 10 个 touch 文件 → OK
- [x] `uv run ruff check .` → All checks passed（关于 `ASYNC_BLOCK` 不是合法 ruff 码的 warning 与 PR #846 之前一致，并不阻断）
- [x] `uv run python scripts/check_async_blocking.py` → exit 0，零违规
- [x] Sanity: 临时回退 Site C，linter 立即报 `blocking sync helper 'load_cookies_from_file' (defined at utils/cookies_login.py:173, uses Fernet.decrypt) called directly from async context`，恢复后 clean

## Test plan

- [ ] 启动 server 后触发 `/proactive_chat` (vision mode) — 确认 Phase 1 截图压缩正常 + 事件循环不被 PIL 长尾占用
- [ ] 触发 `request_fresh_screenshot` 本机兜底 — 确认 pyautogui 截图正常返回
- [ ] `GET /cookies/status` × 7 platforms — 返回数据不变，但延迟分布更平
- [ ] 删/存某平台 cookies + 重新加载 — 解密路径仍然 OK
- [ ] 上传 MMD ZIP — 确认解压正常
- [ ] 播放网易云歌曲 — 确认 cookie 加载路径 OK

https://claude.ai/code/session_01Li2AugCvrK1dAP4jeA356Z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **优化与重构**
  * 多处耗时/阻塞操作改为后台线程执行，减少主事件循环阻塞，提升响应与并发表现。
  * 截图与图像处理流程重构为可在工作线程中完成，压缩与编码更稳健且效率更高。
  * 并行化 Cookie 状态加载，加快批量读取速度。
* **修复**
  * 人像导出接口对无效图片返回明确的 400 错误响应。
* **工具改进**
  * 异步阻塞检测工具增强，改进阻塞调用识别与报告。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->