### PR TITLE
refactor(cookies): 把 CLI wizard 函数从 async def 改回 sync def

### DIFF
--- a/utils/cookies_login.py
+++ b/utils/cookies_login.py
@@ -10,7 +10,6 @@
 4. 深度环境伪装：增加完整的 Origin/Referer 请求头，防止触发账号环境风控。
 """
 
-import asyncio
 import json
 import os
 import sys
@@ -268,7 +267,7 @@ def parse_cookie_string(cookie_string: str) -> Dict[str, str]:
 
  
 
-async def get_bilibili_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_bilibili_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【B站手动导入】(注意：请勿在此界面外泄露您的 SESSDATA)")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -281,7 +280,7 @@ async def get_bilibili_cookies(_method: str = "manual") -> Optional[Dict[str, st
 # ==========================================
 # 其他平台登录逻辑 (纯手工导入)
 # ==========================================
-async def get_douyin_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_douyin_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【抖音手动导入】(需包含 sessionid 和 ttwid 字段)")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -291,7 +290,7 @@ async def get_douyin_cookies(_method: str = "manual") -> Optional[Dict[str, str]
         save_cookies_to_file('douyin', cookies)
     return cookies
 
-async def get_kuaishou_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_kuaishou_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【快手手动导入】(需包含 kuaishou.server.web_st 字段)")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -301,7 +300,7 @@ async def get_kuaishou_cookies(_method: str = "manual") -> Optional[Dict[str, st
         save_cookies_to_file('kuaishou', cookies)
     return cookies
 
-async def get_weibo_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_weibo_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【微博手动导入】(需包含 SUB 字段)")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -311,7 +310,7 @@ async def get_weibo_cookies(_method: str = "manual") -> Optional[Dict[str, str]]
         save_cookies_to_file('weibo', cookies)
     return cookies
 
-async def get_reddit_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_reddit_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【Reddit 手动导入】")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -321,7 +320,7 @@ async def get_reddit_cookies(_method: str = "manual") -> Optional[Dict[str, str]
         save_cookies_to_file('reddit', cookies)
     return cookies
 
-async def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【Twitter/X 手动导入】")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -331,7 +330,7 @@ async def get_twitter_cookies(_method: str = "manual") -> Optional[Dict[str, str
         save_cookies_to_file('twitter', cookies)
     return cookies
 
-async def get_netease_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
+def get_netease_cookies(_method: str = "manual") -> Optional[Dict[str, str]]:
     print("\n" + "-" * 40)
     print("【网易云音乐手动导入】(需包含 MUSIC_U 字段)")
     cookie_string = input("👉 请粘贴 Cookie: ").strip()
@@ -356,9 +355,9 @@ class PlatformLoginManager:
             'twitter': {'name': 'Twitter/X', 'methods': ['manual'], 'func': get_twitter_cookies}
         }
     
-    async def login_platform(self, platform: str, method: str) -> Optional[Dict[str, str]]:
+    def login_platform(self, platform: str, method: str) -> Optional[Dict[str, str]]:
         if platform in self.platforms:
-            return await self.platforms[platform]['func'](method)
+            return self.platforms[platform]['func'](method)
         return None
     
     def get_supported_platforms(self) -> Dict[str, Dict[str, Any]]:
@@ -375,7 +374,7 @@ class PlatformLoginManager:
                 result[platform]['default_method'] = None
         return result
 
-async def interactive_login():
+def interactive_login():
     manager = PlatformLoginManager()
     platforms = list(manager.platforms.items())
     
@@ -414,7 +413,7 @@ async def interactive_login():
                         pass
                 
                 print(f"\n🚀 正在启动 {p_info['name']} 的 {method} 安全流程...")
-                await manager.login_platform(p_key, method)
+                manager.login_platform(p_key, method)
             else:
                 print("❌ 无效的序号。")
         except ValueError:
@@ -425,9 +424,7 @@ async def interactive_login():
 
 if __name__ == "__main__":
     try:
-        if sys.platform == 'win32':
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        asyncio.run(interactive_login())
+        interactive_login()
     except KeyboardInterrupt:
         print("\n👋 终端已安全关闭。")
         sys.exit(0)


### PR DESCRIPTION
## 背景

`utils/cookies_login.py` 里的 7 个 `get_*_cookies` helper（bilibili / douyin / kuaishou / weibo / reddit / twitter / netease）、`PlatformLoginManager.login_platform`、以及 `interactive_login` 函数体内都用 `input("👉 请粘贴 Cookie: ").strip()` 做同步阻塞 stdin 读——本质是 CLI 交互式 wizard 代码，从来不是 FastAPI 路径调用。`async def` 标记是历史误用。

PR #850 的 depth-1 transitive 静态检查把这几个 helper 标出来后（它们调用 `save_cookies_to_file`，内部走 Fernet 加密 + 文件 IO），正确做法不是加 `# noqa: ASYNC_BLOCK` 或者 `asyncio.to_thread` 包裹，而是改回 `sync def`——因为函数体里 `input(...)` 那一行已经彻底卡死事件循环了，隔靴搔痒地把里面的一个小 helper offload 出去没有意义。

本 PR 独立于 PR #850，直接在 main 上改 `utils/cookies_login.py`，不触碰 PR #850 的 noqa 抑制。

## 改动文件

- `utils/cookies_login.py`:
  - 7 个 `get_*_cookies` helper 从 `async def` 改为 `def`
  - `PlatformLoginManager.login_platform` 从 `async def` 改为 `def`，内部 `await` 一并移除
  - `interactive_login` 从 `async def` 改为 `def`（其中 `manager.login_platform(...)` 移除 `await`）
  - `__main__` 入口从 `asyncio.run(interactive_login())` 改为直接调用 `interactive_login()`，同时移除不再需要的 `asyncio.set_event_loop_policy` 和 `import asyncio`

## 调用方影响面

用 `grep -rn "get_bilibili_cookies\|get_douyin_cookies\|get_kuaishou_cookies\|get_weibo_cookies\|get_reddit_cookies\|get_twitter_cookies\|get_netease_cookies\|login_platform" --include="*.py" .` 扫了全仓：

- 7 个 `get_*_cookies` 唯一引用点是 `utils/cookies_login.py:350-356` 的 `PlatformLoginManager.platforms` 注册表（存函数对象不涉及 await），无外部直接调用
- `login_platform` 唯一调用方是 `utils/cookies_login.py:417` 的 `interactive_login`（同文件 CLI wizard）
- FastAPI 路由 `main_routers/cookies_login_router.py` 虽然 `import PlatformLoginManager` 并实例化为 `login_manager`，但只调用 `login_manager.get_supported_platforms()`（本来就是 sync def），**不**调用 `login_platform` 或 7 个 helper，所以没有 FastAPI 路径受影响

## login_platform 选 A 还是 B

选了 **选项 A**（改成 sync def）。理由：
- 唯一调用方是同文件 CLI wizard `interactive_login`
- FastAPI 路由确认没用到
- 改成 sync def 语义更干净，一眼看出这是同步 CLI 代码

## 验证

- `python -c 'import ast; ast.parse(open("utils/cookies_login.py").read())'` OK
- `uv run python scripts/check_async_blocking.py` exit 0（cookies_login.py 不再是 async def，linter 自然扫不到了）
- `uv run ruff check .` All checks passed
- `grep "await" utils/cookies_login.py` 无 dangling await


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 登录与 Cookie 获取流程已由异步改为同步执行，移除了异步运行依赖。
  * 所有平台的手动登录流程（B站、抖音、快手、微博、Reddit、Twitter、网易）已统一为同步接口，CLI 启动与交互流程简化并更直观。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->