### PR TITLE
fix(async): _force_kill_browser 改 to_thread + 扩展 async-check 到 memory_server / agent_server 全链路

### DIFF
--- a/brain/browser_use_adapter.py
+++ b/brain/browser_use_adapter.py
@@ -990,10 +990,10 @@ class BrowserUseAdapter:
                 await asyncio.wait_for(self._browser_session.stop(), timeout=10)
             except asyncio.TimeoutError:
                 logger.warning("[BrowserUse] _browser_session.stop() timed out after 10s")
-                self._force_kill_browser(browser_pid)
+                await asyncio.to_thread(self._force_kill_browser, browser_pid)
             except Exception as exc:
                 logger.warning("[BrowserUse] _browser_session.stop() raised: %s", exc)
-                self._force_kill_browser(browser_pid)
+                await asyncio.to_thread(self._force_kill_browser, browser_pid)
 
             self._browser_session = None
         self._session_ever_started = False

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -260,6 +260,26 @@ class RiskySyncDefIndexer(ast.NodeVisitor):
         self.risky.setdefault(node.name, (str(path), node.lineno, reason))
 
 
+def _collect_async_def_names(tree: ast.Module) -> set[str]:
+    """Collect top-level + one-level-nested ``async def`` names from a
+    module. Used to disambiguate name collisions: if a name is defined
+    as both a sync helper (risky) and an async method elsewhere in
+    scope, a call site ``await foo(...)`` is ambiguous under name-only
+    matching, so we drop that name from the risky index rather than
+    report false positives on the async side. Symmetric with the sync
+    indexer's scope — top-level defs + methods of top-level classes.
+    """
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef):
+            names.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if isinstance(item, ast.AsyncFunctionDef):
+                    names.add(item.name)
+    return names
+
+
 def _sync_body_has_blocking_call(func: ast.FunctionDef) -> str | None:
     """Scan ``func``'s body for a known-blocking call, descending into
     control-flow (if/for/with/try) but NOT into nested functions or
@@ -295,11 +315,16 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         self.violations: list[tuple[int, int, str]] = []
         self._risky = risky_helpers or {}
         # ids of Call nodes that are the direct target of an ``await`` —
-        # ``await q.get()`` is cooperative regardless of whether the tail
-        # name matches a queue-like heuristic, and ``await adapter.run_X()``
-        # is an async method call even when a sync helper with the same
-        # tail name exists elsewhere in the tree. Indexed by id() to avoid
-        # mutating the AST.
+        # suppresses ONLY the queue/thread/socket tail-name heuristics in
+        # ``_check_attribute_call``. Those heuristics guess at the
+        # receiver's type from its identifier, and an ``await`` in front
+        # proves the receiver is an asyncio object (awaiting a blocking
+        # ``queue.Queue.get()`` is a TypeError at runtime). Direct
+        # blocking stdlib calls and depth-1 transitive sync-helper
+        # checks are *not* suppressed — a sync helper that blocks
+        # synchronously and then returns an awaitable would still run
+        # its blocking body on the event-loop thread before the await.
+        # Indexed by id() to avoid mutating the AST.
         self._awaited_call_ids: set[int] = set()
 
     # ── function tracking ────────────────────────────────────────────────
@@ -335,22 +360,27 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         self.violations.append((lineno, col, message))
 
     def visit_Await(self, node: ast.Await) -> None:
-        # Mark the directly-awaited call so visit_Call skips it. A bare
-        # ``await X(...)`` is definitionally off the event loop — whatever
-        # X refers to must return an awaitable, so tail-name heuristics
-        # that happen to match a sync helper elsewhere are irrelevant.
-        # Arguments inside X(...) are NOT marked — a blocking call passed
-        # as an argument (``await gather(requests.get(...))``) is still
-        # evaluated synchronously before the await.
+        # Mark the directly-awaited call for targeted suppression in
+        # visit_Call (see _awaited_call_ids docstring). Arguments inside
+        # X(...) are NOT marked — a blocking call passed as an argument
+        # (``await gather(requests.get(...))``) is still evaluated
+        # synchronously before the await.
         if isinstance(node.value, ast.Call):
             self._awaited_call_ids.add(id(node.value))
         self.generic_visit(node)
 
     # ── the actual checks ────────────────────────────────────────────────
     def visit_Call(self, node: ast.Call) -> None:
-        if self._in_async_context() and id(node) not in self._awaited_call_ids:
-            if isinstance(node.func, ast.Attribute):
+        if self._in_async_context():
+            awaited = id(node) in self._awaited_call_ids
+            # queue/thread/socket heuristics are name-based type guesses;
+            # an ``await`` proves the receiver is an asyncio object.
+            if isinstance(node.func, ast.Attribute) and not awaited:
                 self._check_attribute_call(node)
+            # Direct blocking stdlib calls (requests.get, shutil.copy, …)
+            # and depth-1 transitive sync-helper dispatch are checked
+            # regardless of await — a sync helper that blocks before
+            # returning an awaitable still blocks the loop thread.
             self._check_direct_blocking_call(node)
             self._check_transitive_sync_helper(node)
         self.generic_visit(node)
@@ -520,6 +550,7 @@ def main(argv: list[str] | None = None) -> int:
     # Pass 1: parse every file once, build the risky-sync-def index.
     parsed: list[tuple[Path, str, ast.Module]] = []
     indexer = RiskySyncDefIndexer()
+    async_names: set[str] = set()
     for file in _iter_python_files(targets):
         parsed_file = _parse_file(file)
         if parsed_file is None:
@@ -533,6 +564,19 @@ def main(argv: list[str] | None = None) -> int:
         local_indexer.index_module(tree, rel)
         for name, info in local_indexer.risky.items():
             indexer.risky.setdefault(name, info)
+        async_names |= _collect_async_def_names(tree)
+
+    # Drop risky names that also exist as an ``async def`` somewhere in
+    # scope. At a call site ``await foo(...)`` we cannot statically tell
+    # which definition the receiver binds to, and real async methods
+    # with the same tail name as an unrelated sync helper (e.g. multiple
+    # agent adapters expose ``async def run_instruction`` while
+    # ``brain/computer_use.py`` defines a sync one) would otherwise
+    # produce a wave of false positives. The cost is we no longer flag
+    # direct calls to the sync variant from async code — a rename is
+    # the right fix if that case arises.
+    for name in async_names:
+        indexer.risky.pop(name, None)
 
     # Pass 2: walk async bodies for direct blocking + depth-1 transitive.
     total = 0

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -307,6 +307,7 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         path: Path,
         source: str,
         risky_helpers: dict[str, tuple[str, int, str]] | None = None,
+        ambiguous_async_names: set[str] | None = None,
     ) -> None:
         self.path = path
         self.source_lines = source.splitlines()
@@ -314,6 +315,15 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         self._func_stack: list[str] = []
         self.violations: list[tuple[int, int, str]] = []
         self._risky = risky_helpers or {}
+        # Names defined as BOTH a risky sync helper and an ``async def``
+        # somewhere in scope. At an ``await foo(...)`` site we cannot
+        # statically tell which one the receiver binds to, so transitive
+        # checks on those sites are skipped — but only when awaited.
+        # A bare ``foo(...)`` (no await) is still checked against the
+        # risky entry, since calling a coroutine without awaiting is a
+        # separate bug and the sync variant is the only one that
+        # runs-and-blocks when called unawaited.
+        self._ambiguous_async_names = ambiguous_async_names or set()
         # ids of Call nodes that are the direct target of an ``await`` —
         # suppresses ONLY the queue/thread/socket tail-name heuristics in
         # ``_check_attribute_call``. Those heuristics guess at the
@@ -382,7 +392,7 @@ class AsyncBlockingChecker(ast.NodeVisitor):
             # regardless of await — a sync helper that blocks before
             # returning an awaitable still blocks the loop thread.
             self._check_direct_blocking_call(node)
-            self._check_transitive_sync_helper(node)
+            self._check_transitive_sync_helper(node, awaited=awaited)
         self.generic_visit(node)
 
     def _check_direct_blocking_call(self, call: ast.Call) -> None:
@@ -407,16 +417,26 @@ class AsyncBlockingChecker(ast.NodeVisitor):
             f"{reason} blocks the event loop; wrap in await asyncio.to_thread(...).",
         )
 
-    def _check_transitive_sync_helper(self, call: ast.Call) -> None:
+    def _check_transitive_sync_helper(self, call: ast.Call, *, awaited: bool) -> None:
         """Depth-1: flag ``foo(...)`` or ``obj.foo(...)`` where ``foo``
         is the name of an indexed risky sync helper. We intentionally
         match on tail name only — resolving receivers would need import
         tracking, and in this repo the helper names we care about
         (``compress_screenshot``, ``load_cookies_from_file``, etc.) are
         distinctive enough that collisions are rare.
+
+        When ``awaited`` is True and the name also exists as an
+        ``async def`` somewhere in scope, we skip — the receiver most
+        likely binds to the async variant (awaiting the sync variant's
+        non-awaitable return is a runtime TypeError). Non-awaited
+        calls are still checked: a bare ``foo(...)`` invocation of a
+        sync blocking helper is exactly the case this pass was
+        designed to catch.
         """
         name = _tail_name(call.func)
         if not name:
+            return
+        if awaited and name in self._ambiguous_async_names:
             return
         hit = self._risky.get(name)
         if hit is None:
@@ -529,8 +549,14 @@ def check_file(
     source: str,
     tree: ast.Module,
     risky_helpers: dict[str, tuple[str, int, str]] | None = None,
+    ambiguous_async_names: set[str] | None = None,
 ) -> list[tuple[int, int, str]]:
-    checker = AsyncBlockingChecker(path, source, risky_helpers=risky_helpers)
+    checker = AsyncBlockingChecker(
+        path,
+        source,
+        risky_helpers=risky_helpers,
+        ambiguous_async_names=ambiguous_async_names,
+    )
     checker.visit(tree)
     return checker.violations
 
@@ -566,22 +592,29 @@ def main(argv: list[str] | None = None) -> int:
             indexer.risky.setdefault(name, info)
         async_names |= _collect_async_def_names(tree)
 
-    # Drop risky names that also exist as an ``async def`` somewhere in
-    # scope. At a call site ``await foo(...)`` we cannot statically tell
-    # which definition the receiver binds to, and real async methods
-    # with the same tail name as an unrelated sync helper (e.g. multiple
-    # agent adapters expose ``async def run_instruction`` while
-    # ``brain/computer_use.py`` defines a sync one) would otherwise
-    # produce a wave of false positives. The cost is we no longer flag
-    # direct calls to the sync variant from async code — a rename is
-    # the right fix if that case arises.
-    for name in async_names:
-        indexer.risky.pop(name, None)
+    # Build the "ambiguous" set — names that exist as BOTH a risky
+    # sync helper and an ``async def`` somewhere in scope. Used by
+    # visit_Call to skip the transitive check only at ``await foo(...)``
+    # sites where the receiver could bind either way. Non-awaited
+    # ``foo(...)`` calls are still checked against the risky entry:
+    # even if there's an async variant somewhere, a bare call that
+    # hits the sync one blocks, and our report should surface it.
+    # Example trigger: ``brain/computer_use.py`` defines a sync
+    # ``run_instruction`` while openclaw/openfang/browser_use adapters
+    # expose ``async def run_instruction`` — ``await adapter.run_X()``
+    # is fine, a hypothetical bare ``run_instruction(...)`` is not.
+    ambiguous_async_names = async_names & set(indexer.risky)
 
     # Pass 2: walk async bodies for direct blocking + depth-1 transitive.
     total = 0
     for file, source, tree in parsed:
-        for lineno, col, msg in check_file(file, source, tree, risky_helpers=indexer.risky):
+        for lineno, col, msg in check_file(
+            file,
+            source,
+            tree,
+            risky_helpers=indexer.risky,
+            ambiguous_async_names=ambiguous_async_names,
+        ):
             rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
             print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
             total += 1

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -71,6 +71,13 @@ DEFAULT_PATHS = [
     "main_logic",
     "main_routers",
     "utils",
+    # memory_server.py + its import chain (memory/ package)
+    "memory_server.py",
+    "memory",
+    # agent_server.py + its import chain (brain/ package; main_logic already
+    # in scope above)
+    "agent_server.py",
+    "brain",
 ]
 # NOTE: ``plugin/`` is intentionally NOT in the default scope. Plugin code uses
 # pyzmq sockets (``sock.connect`` / ``sock.recv`` via async zmq) and
@@ -287,6 +294,13 @@ class AsyncBlockingChecker(ast.NodeVisitor):
         self._func_stack: list[str] = []
         self.violations: list[tuple[int, int, str]] = []
         self._risky = risky_helpers or {}
+        # ids of Call nodes that are the direct target of an ``await`` —
+        # ``await q.get()`` is cooperative regardless of whether the tail
+        # name matches a queue-like heuristic, and ``await adapter.run_X()``
+        # is an async method call even when a sync helper with the same
+        # tail name exists elsewhere in the tree. Indexed by id() to avoid
+        # mutating the AST.
+        self._awaited_call_ids: set[int] = set()
 
     # ── function tracking ────────────────────────────────────────────────
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
@@ -320,9 +334,21 @@ class AsyncBlockingChecker(ast.NodeVisitor):
             return
         self.violations.append((lineno, col, message))
 
+    def visit_Await(self, node: ast.Await) -> None:
+        # Mark the directly-awaited call so visit_Call skips it. A bare
+        # ``await X(...)`` is definitionally off the event loop — whatever
+        # X refers to must return an awaitable, so tail-name heuristics
+        # that happen to match a sync helper elsewhere are irrelevant.
+        # Arguments inside X(...) are NOT marked — a blocking call passed
+        # as an argument (``await gather(requests.get(...))``) is still
+        # evaluated synchronously before the await.
+        if isinstance(node.value, ast.Call):
+            self._awaited_call_ids.add(id(node.value))
+        self.generic_visit(node)
+
     # ── the actual checks ────────────────────────────────────────────────
     def visit_Call(self, node: ast.Call) -> None:
-        if self._in_async_context():
+        if self._in_async_context() and id(node) not in self._awaited_call_ids:
             if isinstance(node.func, ast.Attribute):
                 self._check_attribute_call(node)
             self._check_direct_blocking_call(node)


### PR DESCRIPTION
## Summary
- **Real bug**: `brain/browser_use_adapter.py::_close_browser` 的异常分支里，`self._force_kill_browser(browser_pid)` 是同步调用，内部 `subprocess.run(..., timeout=10)` 最长阻塞 event loop 10s。改为 `await asyncio.to_thread(...)`。
- **Check 扩展**: `scripts/check_async_blocking.py` 的 `DEFAULT_PATHS` 补上 `memory_server.py` / `memory/` 与 `agent_server.py` / `brain/`，覆盖两个服务的完整导入链（`main_logic` / `utils` 已在域内）。
- **Check 修误报**: 新增 `visit_Await`，直接 `await` 的 `Call` 跳过 tail-name 检查。没加这条的话新扩展的域里会误报 7 条：
  - `await asyncio.Queue.get()` — `_queue` 后缀命中 queue 启发式
  - `await adapter.run_instruction(...)` — 和 `brain/computer_use.py::run_instruction`（sync def，含 `pyautogui.screenshot`）撞名，触发 depth-1 transitive

## 验证
- `uv run python scripts/check_async_blocking.py` → exit 0，0 violation
- shutil 全名匹配已在 `RISKY_ATTR_PAIRS`（`copy/copy2/copyfile/copyfileobj/copytree/move/rmtree`），repo 里所有 `shutil` 使用都是 `import shutil` 形式，`(receiver="shutil", attr=X)` 直接命中

## Test plan
- [ ] CI lint/async-check 通过
- [ ] 回归 `_close_browser` 的 timeout/exception 分支仍能强杀浏览器

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化浏览器会话关闭逻辑：改进异常与超时处理以减少阻塞，提升会话终止的可靠性和稳定性。

* **Chores**
  * 增强异步阻塞检测工具：扩大扫描范围并改进对异步调用的识别与判定，降低误报率，提升代码质量检查覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->