### PR TITLE
fix(proactive): guard 的 turn-start 分支加 5s 时间窗兜底

### DIFF
--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -254,16 +254,26 @@
      */
     // AI 是否正在播放语音：proactive timer 到点时如果还在播，就跳过本次 nudge
     // 并继续按固定间隔 poll（见下面 scheduleProactiveChat 的两处 speaking 分支）。
-    // S.isPlaying：audio chunks 入队到 drain 完这段期间为 true；
-    // S.assistantSpeechActiveTurnId：active turn 有音频在跑时非空。
-    // assistantTurnId !== assistantTurnCompletedId：后端已发 turn-start
-    // 但还没发 turn-end —— 覆盖"文字已开始流、首个音频 chunk 还没解码"的空窗，
-    // 防止 proactive 在这段窗口里切入、让猫娘打断自己。
+    //
+    // 分支 1（isPlaying / speechActiveTurnId）：覆盖"首个 PCM chunk 入队 → drain 完"。
+    // 分支 2（turnId !== completedId + 时间窗）：覆盖"text 已开始流、首个音频 chunk
+    //   还没解码"那几百毫秒空窗。PR #839 原本只靠 `turnId !== completedId` 自释放，
+    //   但 drain 完时 clearAssistantTurnCompletion 会把 completedId 清回 null 而
+    //   turnId 仍留着，这条件会一直 TRUE、proactive 永不触发。
+    //   加 `elapsed < PROACTIVE_TURN_STARTUP_GRACE_MS` 作为硬上限：那段空窗通常只有
+    //   几百毫秒，5s 已经是数量级的余裕；超出就让分支 1 的自释放信号接管。
+    var PROACTIVE_TURN_STARTUP_GRACE_MS = 5000;
+
     function _isAssistantSpeaking() {
         try {
             if (!S) return false;
             if (S.isPlaying || S.assistantSpeechActiveTurnId) return true;
-            if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
+            if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) {
+                var startedAt = S.assistantTurnStartedAt || 0;
+                if (startedAt && Date.now() - startedAt < PROACTIVE_TURN_STARTUP_GRACE_MS) {
+                    return true;
+                }
+            }
             return false;
         } catch (_) {
             return false;

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -76,6 +76,7 @@
         sessionStartedResolver: null,
         sessionStartedRejecter: null,
         assistantTurnId: null,
+        assistantTurnStartedAt: 0,
         assistantPendingTurnServerId: null,
         assistantTurnAwaitingBubble: false,
         assistantTurnSeq: 0,

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -159,6 +159,7 @@
         S.assistantTurnId = allocateAssistantTurnId(
             serverTurnId === undefined ? S.assistantPendingTurnServerId : serverTurnId
         );
+        S.assistantTurnStartedAt = Date.now();
         clearPendingAssistantTurnStart();
         emitAssistantLifecycleEvent('neko-assistant-turn-start', {
             turnId: S.assistantTurnId,


### PR DESCRIPTION
## Summary

- **Bug**: PR #839 合并后，一轮对话结束后主动搭话（文本/语音）再也不触发。
- **根因**: PR #839 新 guard 依赖的 invariant 在 drain 完成那一刻被打破。
- **修复**: 保留 PR #839 的 guard 意图，但给新分支加 5s 时间窗兜底，避免它跨 turn 卡死。改动局限在 proactive 自身。

## 根因

PR #839 在 [`_isAssistantSpeaking`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-proactive.js#L262) 加了第三条 guard：

```js
if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
```

设想靠 `turn-end` 事件设 `completedId = turnId` 来自然解除。但是：

1. Turn-end 到 → `completedId = X`，guard FALSE ✓
2. 音频 drain 完 → [`maybeFinalizeAssistantSpeech`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-audio-playback.js#L429) 调 `clearAssistantTurnCompletion()` 把 `completedId` 清回 **null**（见 [:279](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-audio-playback.js#L279)）
3. `S.assistantTurnId` 只在下一条 `gemini_response isNewMessage=true` 到来时才 reset（[app-websocket.js:515](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/static/app-websocket.js#L515)）
4. 稳态 = `turnId = "X", completedId = null` → guard **永远 TRUE**
5. proactive 本该"用户不主动时自动触发"，但 guard 永远 TRUE 意味着必须用户先开口才能解锁——**死锁**

### 用户实测日志

```
收到turn end事件，开始情感分析和翻译        ← turn-end 正常到达
主动搭话：10.3秒后触发                       ← schedule 下一次
[MMD] 口型同步已启动 → 口型同步已停止          ← maybeFinalizeAssistantSpeech 跑完
[ProactiveChat] AI 正在播放语音，本次跳过   ← guard TRUE
主动搭话：10.1秒后触发
[ProactiveChat] AI 正在播放语音，本次跳过   ← 又被挡
主动搭话：9.2秒后触发
[ProactiveChat] AI 正在播放语音，本次跳过   ← 连续被挡
```

## 改动

### 两个分支的含义

| State | 置位时机 | 清零时机 |
|---|---|---|
| `isPlaying` / `speechActiveTurnId` | 首个 PCM chunk 入队 | drain 完 |
| `assistantTurnId` | `ensureAssistantTurnStarted`（首个文本 bubble） | 下一轮 / cancel |

- **分支 1**（旧 guard）：覆盖"音频真的在播"
- **分支 2**（PR #839 加的）：覆盖"文字已开始流、首个音频 chunk 还没解码"那几百毫秒空窗

分支 1 不够的原因：Gemini 一旦 `has_ai_content` 就发 `isNewMessage=true`，这时 `assistantTurnId` 已 set，但音频要晚几百毫秒才来——分支 1 在这段期间是 FALSE，proactive 切进来会触发 `interrupted by user`，猫娘自己打断自己。

### fix

[static/app-proactive.js](static/app-proactive.js) + 一个 state 字段 + turn-start 锚点：

```diff
+var PROACTIVE_TURN_STARTUP_GRACE_MS = 5000;
+
 function _isAssistantSpeaking() {
     if (S.isPlaying || S.assistantSpeechActiveTurnId) return true;
-    if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
+    if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) {
+        var startedAt = S.assistantTurnStartedAt || 0;
+        if (startedAt && Date.now() - startedAt < PROACTIVE_TURN_STARTUP_GRACE_MS) {
+            return true;
+        }
+    }
     return false;
 }
```

在 [`ensureAssistantTurnStarted`](static/app-websocket.js#L159) 分配 id 时锚一个时间戳：

```diff
 S.assistantTurnId = allocateAssistantTurnId(...);
+S.assistantTurnStartedAt = Date.now();
```

### 为什么 5s

PR #839 要覆盖的空窗是 "text 流出 → 首个音频 chunk 解码"，实测只有几百毫秒。5s 是数量级余裕——绝不可能真跨到这么远还没开始播。超出 5s 后，要么分支 1 已经接管（音频开始了），要么就是 turn 已经结束——后一种情况下分支 2 若还 TRUE 是死锁，时间窗兜底让它自动 FALSE。

### scope 评估

- **新增 1 个 state 字段** `assistantTurnStartedAt`：只被 `_isAssistantSpeaking` 读，仅在 `ensureAssistantTurnStarted` 新分配 id 时写。
- **不改动** `assistantTurnId` / `assistantTurnCompletedId` 的生命周期，不影响 `resolveAssistantLifecycleTurnId` / `resolveAssistantAudioTurnId` / `ensureAssistantTurnStarted` 的复用检查等其他 consumer。
- blast radius 限制在 proactive 自身。

## Test plan

- [ ] 文本模式：AI 回复一轮后，等 `proactiveChatInterval` 秒，proactive 正常触发下一轮（不再连续打印 `AI 正在播放语音，本次跳过`）
- [ ] 语音模式：同上
- [ ] 回复过程中（turn-start 后 5s 内且音频未到），proactive 仍被挡住——PR #839 的原场景不回退
- [ ] 回复中段（音频播放期间）proactive 被分支 1 挡住——正常
- [ ] 用户打断 / 切猫娘 / WS 断连，proactive 能恢复触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 改进了助手响应状态的检测逻辑，添加了时间窗口限制以确保在对话转换期间的状态管理更加准确，避免状态异常导致的响应延迟或不稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->