### PR TITLE
perf(async): 系统性消除审计发现的同步阻塞 + 串行 await

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -2379,10 +2379,13 @@ async def shutdown():
     if bridge is not None:
         try:
             bridge._stop.set()
-            # 等 recv 线程退出（RCVTIMEO=1s，最多等 2s），避免 close 与 recv 竞态
-            for _t in (getattr(bridge, '_recv_thread', None), getattr(bridge, '_analyze_recv_thread', None)):
-                if _t is not None:
-                    await asyncio.to_thread(_t.join, 2.0)
+            # 等 recv 线程退出（RCVTIMEO=1s，最多等 2s）—— 两个线程并行 join，避免串行 4s
+            _recv_threads = [t for t in (getattr(bridge, '_recv_thread', None), getattr(bridge, '_analyze_recv_thread', None)) if t is not None]
+            if _recv_threads:
+                await asyncio.gather(
+                    *(asyncio.to_thread(_t.join, 2.0) for _t in _recv_threads),
+                    return_exceptions=True,
+                )
             try:
                 import zmq as _zmq
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1386,10 +1386,10 @@ class LLMSessionManager:
         
             # 如果角色没有设置 voice_id，尝试使用自定义API配置的 TTS_VOICE_ID 作为回退
             if not self.voice_id:
-                core_config = await self._config_manager.aget_core_config()
-                tts_voice_id = core_config.get('TTS_VOICE_ID', '')
+                # core_config 在单次 start_session 内不会变（改它走 save_core_api → end_session），复用顶部 snapshot
+                tts_voice_id = core_config_snapshot.get('TTS_VOICE_ID', '')
                 # 过滤掉 GPT-SoVITS 禁用时的占位符（格式: __gptsovits_disabled__|...）
-                if core_config.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
+                if core_config_snapshot.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
                     self.voice_id = tts_voice_id
                     logger.info(f"🔄 使用自定义TTS回退音色: '{self.voice_id}'")
                     self._is_free_preset_voice = False
@@ -1417,11 +1417,10 @@ class LLMSessionManager:
                 # 注意：不清空 pending_input_data，因为可能已有数据在缓存中
         
             # 根据 input_mode 设置 use_tts
-            # 检查是否有自定义 TTS 配置（URL 存在即表示配置了自定义 TTS）
-            core_config = await self._config_manager.aget_core_config()
+            # 检查是否有自定义 TTS 配置（URL 存在即表示配置了自定义 TTS）—— 复用顶部 snapshot
             has_custom_tts_config = (
-                core_config.get('ENABLE_CUSTOM_API') and 
-                core_config.get('TTS_MODEL_URL')
+                core_config_snapshot.get('ENABLE_CUSTOM_API') and
+                core_config_snapshot.get('TTS_MODEL_URL')
             )
         
             if input_mode == 'text':
@@ -1962,10 +1961,10 @@ class LLMSessionManager:
             
             # 如果角色没有设置 voice_id，尝试使用自定义API配置的 TTS_VOICE_ID 作为回退
             if not self.voice_id:
-                core_config = await self._config_manager.aget_core_config()
-                tts_voice_id = core_config.get('TTS_VOICE_ID', '')
+                # 复用本次热切换准备顶部的 snapshot（save_core_api 会 end_session 才能改 core_config）
+                tts_voice_id = core_config_snapshot.get('TTS_VOICE_ID', '')
                 # 过滤掉 GPT-SoVITS 禁用时的占位符（格式: __gptsovits_disabled__|...）
-                if core_config.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
+                if core_config_snapshot.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
                     self.voice_id = tts_voice_id
                     logger.info(f"🔄 热切换准备: 使用自定义TTS回退音色: '{self.voice_id}'")
                     self._is_free_preset_voice = False

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -18,7 +18,7 @@ from utils.screenshot_utils import process_screen_data
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.tts_client import get_tts_worker, dummy_tts_worker, TTS_PROVIDER_REGISTRY
-from utils.preferences import load_global_conversation_settings
+from utils.preferences import load_global_conversation_settings, aload_global_conversation_settings
 from config import MEMORY_SERVER_PORT, TOOL_SERVER_PORT
 from config.prompts_sys import (
     _loc,
@@ -901,11 +901,14 @@ class LLMSessionManager:
         if swap_task_ref and not swap_task_ref.done():
             swap_task_ref.cancel()
             tasks_to_await.append(swap_task_ref)
-        for task in tasks_to_await:
-            try:
-                await asyncio.wait_for(task, timeout=2.0)
-            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
-                pass
+        # 并行 wait：bg 和 swap task 已 cancel，串行最坏 4s 墙钟，gather 后 2s 封顶
+        if tasks_to_await:
+            async def _wait_one(t):
+                try:
+                    await asyncio.wait_for(t, timeout=2.0)
+                except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                    pass
+            await asyncio.gather(*(_wait_one(t) for t in tasks_to_await), return_exceptions=True)
         
         if self.background_preparation_task is bg_task_ref:
             self.background_preparation_task = None
@@ -1348,8 +1351,10 @@ class LLMSessionManager:
             # 重新读取配置以支持热重载
             # core_api_type 从 realtime 配置获取，支持自定义 realtime API 时自动设为 'local'
             realtime_config = self._config_manager.get_model_api_config('realtime')
-            self.core_api_type = realtime_config.get('api_type', '') or self._config_manager.get_core_config().get('CORE_API_TYPE', '')
-            self.audio_api_key = self._config_manager.get_core_config()['AUDIO_API_KEY']
+            # 合并两次同步 IO：core_config 一次 read 即可，avoid 双倍 json.load
+            core_config_snapshot = await self._config_manager.aget_core_config()
+            self.core_api_type = realtime_config.get('api_type', '') or core_config_snapshot.get('CORE_API_TYPE', '')
+            self.audio_api_key = core_config_snapshot['AUDIO_API_KEY']
 
             # 每次启动会话前都清理一次无效 voice_id，避免角色配置残留旧音色导致启动异常
             try:
@@ -1361,7 +1366,7 @@ class LLMSessionManager:
                 logger.warning(f"⚠️ start_session 清理无效 voice_id 失败，继续启动会话: {e}")
 
             # 重新读取角色配置以获取最新的voice_id（支持角色切换后的音色热更新）
-            _, _, _, self.lanlan_basic_config, _, _, _, _, _ = self._config_manager.get_character_data()
+            _, _, _, self.lanlan_basic_config, _, _, _, _, _ = await self._config_manager.aget_character_data()
             old_voice_id = self.voice_id
             raw_voice_id = self._get_voice_id()
             block_free_preset = self._should_block_free_preset_voice(raw_voice_id, realtime_config.get('base_url', ''))
@@ -1377,7 +1382,7 @@ class LLMSessionManager:
         
             # 如果角色没有设置 voice_id，尝试使用自定义API配置的 TTS_VOICE_ID 作为回退
             if not self.voice_id:
-                core_config = self._config_manager.get_core_config()
+                core_config = await self._config_manager.aget_core_config()
                 tts_voice_id = core_config.get('TTS_VOICE_ID', '')
                 # 过滤掉 GPT-SoVITS 禁用时的占位符（格式: __gptsovits_disabled__|...）
                 if core_config.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
@@ -1409,7 +1414,7 @@ class LLMSessionManager:
         
             # 根据 input_mode 设置 use_tts
             # 检查是否有自定义 TTS 配置（URL 存在即表示配置了自定义 TTS）
-            core_config = self._config_manager.get_core_config()
+            core_config = await self._config_manager.aget_core_config()
             has_custom_tts_config = (
                 core_config.get('ENABLE_CUSTOM_API') and 
                 core_config.get('TTS_MODEL_URL')
@@ -1635,7 +1640,7 @@ class LLMSessionManager:
                         api_type=self.core_api_type
                     )
                     # Apply user's noise reduction preference to the AudioProcessor
-                    nr_enabled = load_global_conversation_settings().get('noiseReductionEnabled', True)
+                    nr_enabled = (await aload_global_conversation_settings()).get('noiseReductionEnabled', True)
                     if hasattr(new_session, '_audio_processor') and new_session._audio_processor:
                         new_session._audio_processor.set_enabled(nr_enabled)
 
@@ -1922,9 +1927,11 @@ class LLMSessionManager:
             # 重新读取配置以支持热重载
             # core_api_type 从 realtime 配置获取，支持自定义 realtime API 时自动设为 'local'
             realtime_config = self._config_manager.get_model_api_config('realtime')
-            self.core_api_type = realtime_config.get('api_type', '') or self._config_manager.get_core_config().get('CORE_API_TYPE', '')
-            self.audio_api_key = self._config_manager.get_core_config()['AUDIO_API_KEY']
-            
+            # 合并两次同步 IO：core_config 一次 read 即可
+            core_config_snapshot = await self._config_manager.aget_core_config()
+            self.core_api_type = realtime_config.get('api_type', '') or core_config_snapshot.get('CORE_API_TYPE', '')
+            self.audio_api_key = core_config_snapshot['AUDIO_API_KEY']
+
             # 热切换准备时同样清理无效 voice_id，防止旧版本 voice 残留进入热切换流程
             try:
                 cleaned_count, legacy_names = await asyncio.to_thread(self._config_manager.cleanup_invalid_voice_ids)
@@ -1935,7 +1942,7 @@ class LLMSessionManager:
                 logger.warning(f"⚠️ 热切换准备: 清理无效 voice_id 失败，继续准备会话: {e}")
 
             # 重新读取角色配置以获取最新的voice_id（支持角色切换后的音色热更新）
-            _, _, _, self.lanlan_basic_config, _, _, _, _, _ = self._config_manager.get_character_data()
+            _, _, _, self.lanlan_basic_config, _, _, _, _, _ = await self._config_manager.aget_character_data()
             old_voice_id = self.voice_id
             raw_voice_id = self._get_voice_id()
             block_free_preset = self._should_block_free_preset_voice(raw_voice_id, realtime_config.get('base_url', ''))
@@ -1951,7 +1958,7 @@ class LLMSessionManager:
             
             # 如果角色没有设置 voice_id，尝试使用自定义API配置的 TTS_VOICE_ID 作为回退
             if not self.voice_id:
-                core_config = self._config_manager.get_core_config()
+                core_config = await self._config_manager.aget_core_config()
                 tts_voice_id = core_config.get('TTS_VOICE_ID', '')
                 # 过滤掉 GPT-SoVITS 禁用时的占位符（格式: __gptsovits_disabled__|...）
                 if core_config.get('ENABLE_CUSTOM_API') and tts_voice_id and not tts_voice_id.startswith('__gptsovits_disabled__'):
@@ -2011,7 +2018,7 @@ class LLMSessionManager:
                     api_type=self.core_api_type
                 )
                 # Apply user's noise reduction preference to the AudioProcessor
-                nr_enabled = load_global_conversation_settings().get('noiseReductionEnabled', True)
+                nr_enabled = (await aload_global_conversation_settings()).get('noiseReductionEnabled', True)
                 if hasattr(self.pending_session, '_audio_processor') and self.pending_session._audio_processor:
                     self.pending_session._audio_processor.set_enabled(nr_enabled)
                 logger.info("🔄 热切换准备: 创建语音模式 OmniRealtimeClient")

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -906,8 +906,12 @@ class LLMSessionManager:
             async def _wait_one(t):
                 try:
                     await asyncio.wait_for(t, timeout=2.0)
-                except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    # 清理路径：cancel 后的任务必然抛这两者之一，吞掉即可
                     pass
+                except Exception as e:
+                    # 非预期异常不应阻塞准备状态重置，记 debug 方便排障
+                    logger.debug(f"_wait_one: ignored unexpected exception: {e}")
             await asyncio.gather(*(_wait_one(t) for t in tasks_to_await), return_exceptions=True)
         
         if self.background_preparation_task is bg_task_ref:

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -579,8 +579,9 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
                 return
             try:
                 await target.close()
-            except Exception:
-                pass
+            except Exception as e:
+                # 已进入重连/退出阶段，close 失败不影响后续流程；记 debug 方便排障
+                logger.debug(f"_safe_close: ignored exception during close: {e}")
 
         await asyncio.gather(
             _safe_close(sync_ws), _safe_close(binary_ws), _safe_close(bullet_ws),

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -573,19 +573,20 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
                 bullet_ws = None
                 await asyncio.sleep(0.03)  # 重连前等待
 
-        # 关闭资源
-        for ws in [sync_ws, binary_ws, bullet_ws]:
-            if ws:
-                try:
-                    await ws.close()
-                except Exception:
-                    pass
-        for sess in [sync_session, binary_session, bullet_session]:
-            if sess:
-                try:
-                    await sess.close()
-                except Exception:
-                    pass
+        # 关闭资源（并行：3 个 ws + 3 个 session 互相独立）
+        async def _safe_close(target):
+            if target is None:
+                return
+            try:
+                await target.close()
+            except Exception:
+                pass
+
+        await asyncio.gather(
+            _safe_close(sync_ws), _safe_close(binary_ws), _safe_close(bullet_ws),
+            _safe_close(sync_session), _safe_close(binary_session), _safe_close(bullet_session),
+            return_exceptions=True,
+        )
         for rdr in [sync_reader, binary_reader, bullet_reader]:
             if rdr:
                 try:

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -105,7 +105,7 @@ async def update_agent_flags(request: Request):
         data = await request.json()
         _config_manager = get_config_manager()
         session_manager = get_session_manager()
-        _, her_name_current, _, _, _, _, _, _, _ = _config_manager.get_character_data()
+        _, her_name_current, _, _, _, _, _, _, _ = await _config_manager.aget_character_data()
         lanlan = data.get('lanlan_name') or her_name_current
         flags = data.get('flags') or {}
         mgr = session_manager.get(lanlan)

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2888,30 +2888,33 @@ async def get_character_cards():
         # 确保character_cards目录存在
         config_mgr.ensure_chara_directory()
         
-        character_cards = []
-        
-        # 遍历character_cards目录下的所有.chara.json文件
-        for filename in os.listdir(config_mgr.chara_dir):
-            if filename.endswith('.chara.json'):
-                try:
-                    file_path = os.path.join(config_mgr.chara_dir, filename)
-                    
-                    # 读取文件内容
-                    data = await read_json_async(file_path)
-                    
-                    # 检查是否包含基本信息
-                    if data and data.get('name'):
-                        character_cards.append({
-                            'id': filename[:-11],  # 去掉.chara.json后缀
-                            'name': data['name'],
-                            'description': data.get('description', ''),
-                            'tags': data.get('tags', []),
-                            'rawData': data,
-                            'path': file_path
-                        })
-                except Exception as e:
-                    logger.error(f"读取角色卡文件 {filename} 时出错: {e}")
-        
+        # 遍历 character_cards 目录下的所有 .chara.json 文件，并行读取
+        # （角色卡多时串行 await 会 N 次线程切换 + JSON 解析，整条接口延迟线性增长）
+        candidate_filenames = [f for f in os.listdir(config_mgr.chara_dir) if f.endswith('.chara.json')]
+
+        async def _read_one_card(filename: str):
+            file_path = os.path.join(config_mgr.chara_dir, filename)
+            try:
+                data = await read_json_async(file_path)
+                if data and data.get('name'):
+                    return {
+                        'id': filename[:-11],  # 去掉 .chara.json 后缀
+                        'name': data['name'],
+                        'description': data.get('description', ''),
+                        'tags': data.get('tags', []),
+                        'rawData': data,
+                        'path': file_path,
+                    }
+            except Exception as e:
+                logger.error(f"读取角色卡文件 {filename} 时出错: {e}")
+            return None
+
+        results = await asyncio.gather(
+            *(_read_one_card(fn) for fn in candidate_filenames),
+            return_exceptions=False,
+        )
+        character_cards = [r for r in results if r is not None]
+
         logger.info(f"已加载 {len(character_cards)} 个角色卡")
         return {"success": True, "character_cards": character_cards}
     except Exception as e:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1796,16 +1796,17 @@ async def get_voice_preview(voice_id: str):
         voices = _config_manager.get_voices_for_current_api()
         voice_data = voices.get(voice_id) if isinstance(voices, dict) else None
         provider = (voice_data or {}).get('provider', '')
-        core_config = await _config_manager.aget_core_config()
-        
+
         # 优先尝试从 tts_custom 获取 API Key
         try:
             tts_custom_config = _config_manager.get_model_api_config('tts_custom')
             audio_api_key = tts_custom_config.get('api_key', '')
         except Exception:
             audio_api_key = ''
-            
+
         # 如果没有，则回退到核心配置
+        # Codex review: 原先这里顶上还有一个 `core_config = ...`，从未被读取（死代码）。
+        # 全仓 async 化时把死读也改成了 await，反而白跑一次 IO，删。
         if not audio_api_key:
             core_config = await _config_manager.aget_core_config()
             audio_api_key = core_config.get('AUDIO_API_KEY', '')

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -50,7 +50,7 @@ from utils.voice_clone import (
     QwenVoiceCloneError,
     qwen_language_hints,
 )
-from utils.file_utils import atomic_write_json_async
+from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.frontend_utils import find_models, find_model_directory, is_user_imported_model
 from utils.language_utils import normalize_language_code
 from utils.logger_config import get_module_logger
@@ -160,7 +160,7 @@ async def get_characters(request: Request):
     """获取角色数据，支持根据用户语言自动翻译人设"""
     _config_manager = get_config_manager()
     # 创建深拷贝，避免修改原始配置数据
-    characters_data = copy.deepcopy(_config_manager.load_characters())
+    characters_data = copy.deepcopy(await _config_manager.aload_characters())
     if isinstance(characters_data.get('猫娘'), dict):
         # COMPAT(v1->v2): 前端仍依赖旧平铺字段，接口层按需展开。
         for cat_name, cat_data in list(characters_data['猫娘'].items()):
@@ -225,7 +225,7 @@ async def get_current_live2d_model(catgirl_name: str = "", item_id: str = ""):
     """
     try:
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         
         # 如果没有指定角色名称，使用当前猫娘
         if not catgirl_name:
@@ -504,7 +504,7 @@ async def update_catgirl_l2d(name: str, request: Request):
         
         # 加载当前角色配置
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         
         # 确保猫娘配置存在
         if '猫娘' not in characters:
@@ -696,7 +696,7 @@ async def update_catgirl_touch_set(name: str, request: Request):
             )
         
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         
         if '猫娘' not in characters or name not in characters['猫娘']:
             return JSONResponse(
@@ -753,7 +753,7 @@ async def update_catgirl_lighting(name: str, request: Request):
             apply_runtime = query_params.get('apply_runtime', '').lower() in ('true', '1', 'yes')
 
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
 
         if '猫娘' not in characters or name not in characters['猫娘']:
             return JSONResponse(content={
@@ -873,7 +873,7 @@ async def update_catgirl_mmd_settings(name: str, request: Request):
         data = await request.json()
 
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
 
         if '猫娘' not in characters or name not in characters['猫娘']:
             return JSONResponse(content={
@@ -960,7 +960,7 @@ async def get_catgirl_mmd_settings(name: str):
     """获取指定角色的MMD模型设置"""
     try:
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
 
         if '猫娘' not in characters or name not in characters['猫娘']:
             return JSONResponse(content={
@@ -1005,7 +1005,7 @@ async def update_catgirl_voice_id(name: str, request: Request):
         return {"success": True, "session_restarted": False, "voice_id_changed": False}
     _config_manager = get_config_manager()
     session_manager = get_session_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     if name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
     voice_id = str(data.get('voice_id') or '').strip()
@@ -1071,7 +1071,7 @@ async def get_catgirl_voice_mode_status(name: str):
     """检查指定角色是否在语音模式下"""
     _config_manager = get_config_manager()
     session_manager = get_session_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     is_current = characters.get('当前猫娘') == name
     
     if name not in session_manager:
@@ -1110,7 +1110,7 @@ async def rename_catgirl(old_name: str, request: Request):
     err = _validate_profile_name(new_name)
     if err:
         return JSONResponse({'success': False, 'error': err.replace('档案名', '新档案名')}, status_code=400)
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     if old_name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '原猫娘不存在'}, status_code=404)
     if new_name in characters['猫娘']:
@@ -1169,7 +1169,7 @@ async def unregister_voice(name: str):
     try:
         _config_manager = get_config_manager()
         session_manager = get_session_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         if name not in characters.get('猫娘', {}):
             return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
         
@@ -1213,7 +1213,7 @@ async def unregister_voice(name: str):
 async def get_current_catgirl():
     """获取当前使用的猫娘名称"""
     _config_manager = get_config_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     current_catgirl = characters.get('当前猫娘', '')
     return JSONResponse(content={'current_catgirl': current_catgirl})
 
@@ -1228,7 +1228,7 @@ async def set_current_catgirl(request: Request):
     
     _config_manager = get_config_manager()
     session_manager = get_session_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     if catgirl_name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '指定的猫娘不存在'}, status_code=404)
     
@@ -1265,21 +1265,32 @@ async def set_current_catgirl(request: Request):
         "old_catgirl": old_catgirl
     })
     
-    # 遍历所有session_manager，尝试发送消息
-    for lanlan_name, mgr in list(session_manager.items()):
+    # 并行通知所有 session_manager —— 每个 send_text 独立，per-mgr 失败时只清自己的 ws，
+    # 串行版本里一个慢/卡的 ws 会拖累后面的通知。
+    snapshot = list(session_manager.items())
+    for lanlan_name, mgr in snapshot:
+        logger.info(f"检查 {lanlan_name} 的WebSocket: websocket存在={mgr.websocket is not None}")
+
+    async def _notify_one(lanlan_name, mgr):
         ws = mgr.websocket
-        logger.info(f"检查 {lanlan_name} 的WebSocket: websocket存在={ws is not None}")
-        
-        if ws:
-            try:
-                await ws.send_text(message)
-                notification_count += 1
-                logger.info(f"✅ 已通过WebSocket通知 {lanlan_name} 的连接：猫娘已从 {old_catgirl} 切换到 {catgirl_name}")
-            except Exception as e:
-                logger.warning(f"❌ 通知 {lanlan_name} 的连接失败: {e}")
-                # 如果发送失败，可能是连接已断开，清空websocket引用
-                if mgr.websocket == ws:
-                    mgr.websocket = None
+        if not ws:
+            return False
+        try:
+            await ws.send_text(message)
+            logger.info(f"✅ 已通过WebSocket通知 {lanlan_name} 的连接：猫娘已从 {old_catgirl} 切换到 {catgirl_name}")
+            return True
+        except Exception as e:
+            logger.warning(f"❌ 通知 {lanlan_name} 的连接失败: {e}")
+            # 如果发送失败，可能是连接已断开，清空websocket引用
+            if mgr.websocket == ws:
+                mgr.websocket = None
+            return False
+
+    _notify_results = await asyncio.gather(
+        *(_notify_one(n, m) for n, m in snapshot),
+        return_exceptions=True,
+    )
+    notification_count = sum(1 for r in _notify_results if r is True)
     
     if notification_count > 0:
         logger.info(f"✅ 已通过WebSocket通知 {notification_count} 个连接的客户端：猫娘已从 {old_catgirl} 切换到 {catgirl_name}")
@@ -1321,7 +1332,7 @@ async def update_master(request: Request):
     data['档案名'] = str(profile_name).strip()
     _config_manager = get_config_manager()
     initialize_character_data = get_initialize_character_data()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     characters['主人'] = {k: v for k, v in data.items() if v}
     await _config_manager.asave_characters(characters)
     # 自动重新加载配置
@@ -1348,7 +1359,7 @@ async def rename_master(old_name: str, request: Request):
         return JSONResponse({'success': False, 'error': err.replace('档案名', '新档案名')}, status_code=400)
 
     async with _ugc_sync_lock:
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         if '主人' not in characters or not characters['主人']:
             return JSONResponse({'success': False, 'error': '主人档案不存在'}, status_code=404)
 
@@ -1395,7 +1406,7 @@ async def add_catgirl(request: Request):
     data['档案名'] = str(profile_name).strip()
 
     _config_manager = get_config_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     key = data['档案名']
 
     # 检查是否已存在同名角色，使用 Windows 风格的命名 (x)
@@ -1474,7 +1485,7 @@ async def update_catgirl(name: str, request: Request):
 
     data = _filter_mutable_catgirl_fields(raw_data)
     _config_manager = get_config_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     if name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
 
@@ -1573,7 +1584,7 @@ async def update_catgirl(name: str, request: Request):
 @router.delete('/catgirl/{name}')
 async def delete_catgirl(name: str):
     _config_manager = get_config_manager()
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     if name not in characters.get('猫娘', {}):
         return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
 
@@ -1593,18 +1604,21 @@ async def delete_catgirl(name: str):
             name,                       # 新布局：memory/<name>/{recent,facts,reflections,persona,time_indexed.db,...}
         ]
 
-        for base_dir in memory_paths:
-            for file_name in files_to_delete:
-                file_path = base_dir / file_name
-                if file_path.exists():
-                    try:
-                        if file_path.is_dir():
-                            await asyncio.to_thread(shutil.rmtree, file_path)
-                        else:
-                            await asyncio.to_thread(file_path.unlink)
-                        logger.info(f"已删除: {file_path}")
-                    except Exception as e:
-                        logger.warning(f"删除失败 {file_path}: {e}")
+        # 展平 product 后并行：2 个目录 × 5 个名字 = 10 个独立 IO，串行 to_thread 是 10× round-trip
+        async def _delete_one(file_path):
+            if not file_path.exists():
+                return
+            try:
+                if file_path.is_dir():
+                    await asyncio.to_thread(shutil.rmtree, file_path)
+                else:
+                    await asyncio.to_thread(file_path.unlink)
+                logger.info(f"已删除: {file_path}")
+            except Exception as e:
+                logger.warning(f"删除失败 {file_path}: {e}")
+
+        delete_targets = [base_dir / file_name for base_dir in memory_paths for file_name in files_to_delete]
+        await asyncio.gather(*(_delete_one(p) for p in delete_targets), return_exceptions=True)
     except Exception as e:
         logger.error(f"删除记忆文件时出错: {e}")
     
@@ -1621,7 +1635,7 @@ async def clear_voice_ids():
     """清除所有角色的本地Voice ID记录"""
     try:
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         cleared_count = 0
         
         # 清除所有猫娘的voice_id
@@ -1710,7 +1724,7 @@ async def set_microphone(request: Request):
         
         # 使用标准的load/save函数
         _config_manager = get_config_manager()
-        characters_data = _config_manager.load_characters()
+        characters_data = await _config_manager.aload_characters()
         
         # 添加或更新麦克风选择
         characters_data['当前麦克风'] = microphone_id
@@ -1732,7 +1746,7 @@ async def get_microphone():
     try:
         _config_manager = get_config_manager()
         # 使用配置管理器加载角色配置
-        characters_data = _config_manager.load_characters()
+        characters_data = await _config_manager.aload_characters()
         
         # 获取保存的麦克风选择
         microphone_id = characters_data.get('当前麦克风')
@@ -1749,7 +1763,7 @@ async def get_voices():
     _config_manager = get_config_manager()
     result = {"voices": _config_manager.get_voices_for_current_api()}
     
-    core_config = _config_manager.get_core_config()
+    core_config = await _config_manager.aget_core_config()
     if core_config.get('IS_FREE_VERSION'):
         core_url = core_config.get('CORE_URL', '')
         openrouter_url = core_config.get('OPENROUTER_URL', '')
@@ -1760,7 +1774,7 @@ async def get_voices():
                 result["free_voices"] = free_voices
     
     # 构建 voice_id → 使用该音色的角色名列表，用于前端显示
-    characters = _config_manager.load_characters()
+    characters = await _config_manager.aload_characters()
     voice_owners = {}
     for catgirl_name, catgirl_config in characters.get('猫娘', {}).items():
         if not isinstance(catgirl_config, dict):
@@ -1782,7 +1796,7 @@ async def get_voice_preview(voice_id: str):
         voices = _config_manager.get_voices_for_current_api()
         voice_data = voices.get(voice_id) if isinstance(voices, dict) else None
         provider = (voice_data or {}).get('provider', '')
-        core_config = _config_manager.get_core_config()
+        core_config = await _config_manager.aget_core_config()
         
         # 优先尝试从 tts_custom 获取 API Key
         try:
@@ -1793,7 +1807,7 @@ async def get_voice_preview(voice_id: str):
             
         # 如果没有，则回退到核心配置
         if not audio_api_key:
-            core_config = _config_manager.get_core_config()
+            core_config = await _config_manager.aget_core_config()
             audio_api_key = core_config.get('AUDIO_API_KEY', '')
 
         logger.info(f"正在为音色 {voice_id} 生成预览音频...")
@@ -1921,7 +1935,7 @@ async def delete_voice(voice_id: str):
             # 清理所有角色中使用该音色的引用
             _config_manager = get_config_manager()
             session_manager = get_session_manager()
-            characters = _config_manager.load_characters()
+            characters = await _config_manager.aload_characters()
             cleaned_count = 0
             affected_active_names = []
             
@@ -1938,8 +1952,8 @@ async def delete_voice(voice_id: str):
             if cleaned_count > 0:
                 await _config_manager.asave_characters(characters)
                 
-                # 对于受影响的活跃角色，通知并结束 session
-                for name in affected_active_names:
+                # 对于受影响的活跃角色，并行通知 + 结束 session（每个 end_session ≈ 1s）
+                async def _refresh_one(name):
                     logger.info(f"检测到活跃角色 {name} 的 voice_id 已被删除，准备刷新...")
                     # 1. 发送刷新通知
                     await send_reload_page_notice(session_manager[name], "音色已删除，页面即将刷新")
@@ -1949,6 +1963,12 @@ async def delete_voice(voice_id: str):
                         logger.info(f"已结束受影响角色 {name} 的 session")
                     except Exception as e:
                         logger.error(f"结束受影响角色 {name} 的 session 时出错: {e}")
+
+                if affected_active_names:
+                    await asyncio.gather(
+                        *(_refresh_one(name) for name in affected_active_names),
+                        return_exceptions=True,
+                    )
 
                 # 自动重新加载配置
                 initialize_character_data = get_initialize_character_data()
@@ -2876,8 +2896,7 @@ async def get_character_cards():
                     file_path = os.path.join(config_mgr.chara_dir, filename)
                     
                     # 读取文件内容
-                    with open(file_path, 'r', encoding='utf-8') as f:
-                        data = json.load(f)
+                    data = await read_json_async(file_path)
                     
                     # 检查是否包含基本信息
                     if data and data.get('name'):
@@ -2967,7 +2986,7 @@ async def save_character_card(request: Request):
         _config_manager = get_config_manager()
         
         # 加载现有的characters.json
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
         
         # 确保'猫娘'键存在
         if '猫娘' not in characters:
@@ -3027,7 +3046,7 @@ async def export_catgirl_card(name: str):
 
     try:
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
 
         if name not in characters.get('猫娘', {}):
             return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
@@ -3281,7 +3300,7 @@ async def export_catgirl_settings_only(name: str):
 
     try:
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
 
         if name not in characters.get('猫娘', {}):
             return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)
@@ -3450,8 +3469,7 @@ async def import_character_card(zip_file: UploadFile = File(...)):
             if character_json_path.exists():
                 # 非加密格式
                 try:
-                    with open(character_json_path, 'r', encoding='utf-8') as f:
-                        character_data = json.load(f)
+                    character_data = await read_json_async(character_json_path)
                 except json.JSONDecodeError as e:
                     logger.warning(f"[导入角色卡] 解析 character.json 失败: {e}")
                     return JSONResponse({'success': False, 'error': f'角色卡解析失败: {str(e)}'}, status_code=400)
@@ -3488,15 +3506,14 @@ async def import_character_card(zip_file: UploadFile = File(...)):
             metadata_path = extract_path / 'metadata.json'
             metadata = {}
             if metadata_path.exists():
-                with open(metadata_path, 'r', encoding='utf-8') as f:
-                    metadata = json.load(f)
+                metadata = await read_json_async(metadata_path)
 
         character_name = character_data.get('档案名', '未命名角色')
 
         _config_manager = get_config_manager()
 
         async with _ugc_sync_lock:
-            characters = _config_manager.load_characters()
+            characters = await _config_manager.aload_characters()
 
             # 检查是否已存在同名角色，使用 Windows 风格的命名 (x)
             if character_name in characters.get('猫娘', {}):
@@ -3729,7 +3746,7 @@ async def export_catgirl_with_portrait(
     temp_dir = None
     try:
         _config_manager = get_config_manager()
-        characters = _config_manager.load_characters()
+        characters = await _config_manager.aload_characters()
 
         if name not in characters.get('猫娘', {}):
             return JSONResponse({'success': False, 'error': '猫娘不存在'}, status_code=404)

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -20,8 +20,8 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager, get_steamworks, get_session_manager, get_initialize_character_data
 from .characters_router import get_current_live2d_model
-from utils.file_utils import atomic_write_json_async
-from utils.preferences import load_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, load_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
+from utils.file_utils import atomic_write_json_async, read_json_async
+from utils.preferences import load_user_preferences, aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, load_global_conversation_settings, aload_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
 from utils.logger_config import get_module_logger
 from utils.config_manager import get_reserved
 from config import (
@@ -205,7 +205,7 @@ async def get_page_config(lanlan_name: str = ""):
     try:
         # 获取角色数据
         _config_manager = get_config_manager()
-        master_name, her_name, master_basic_config, lanlan_basic_config, _, _, _, _, _ = _config_manager.get_character_data()
+        master_name, her_name, master_basic_config, lanlan_basic_config, _, _, _, _, _ = await _config_manager.aget_character_data()
         master_display_name = _resolve_master_display_name(master_basic_config, master_name)
         
         # 如果提供了 lanlan_name 参数，使用它；否则使用当前角色
@@ -306,7 +306,7 @@ async def get_page_config(lanlan_name: str = ""):
 @router.get("/preferences")
 async def get_preferences():
     """获取用户偏好设置"""
-    preferences = load_user_preferences()
+    preferences = await aload_user_preferences()
     return preferences
 
 
@@ -385,7 +385,7 @@ async def set_preferred_model(request: Request):
 async def get_conversation_settings():
     """获取全局对话设置（从 user_preferences.json 同步备份中读取）"""
     try:
-        settings = load_global_conversation_settings()
+        settings = await aload_global_conversation_settings()
         return {"success": True, "settings": settings}
     except Exception as e:
         logger.exception(f"获取对话设置失败: {e}")
@@ -545,13 +545,12 @@ async def get_core_config_api():
             from utils.config_manager import get_config_manager
             config_manager = get_config_manager()
             core_config_path = str(config_manager.get_config_path('core_config.json'))
-            with open(core_config_path, 'r', encoding='utf-8') as f:
-                core_cfg = json.load(f)
-                api_key = core_cfg.get('coreApiKey', '')
+            core_cfg = await read_json_async(core_config_path)
+            api_key = core_cfg.get('coreApiKey', '')
         except FileNotFoundError:
             # 如果文件不存在，返回当前配置中的CORE_API_KEY
             _config_manager = get_config_manager()
-            core_config = _config_manager.get_core_config()
+            core_config = await _config_manager.aget_core_config()
             api_key = core_config.get('CORE_API_KEY','')
             # 创建空的配置对象用于返回默认值
             core_cfg = {}
@@ -708,33 +707,48 @@ async def update_core_config(request: Request):
         # API配置更新后，需要先通知所有客户端，再关闭session，最后重新加载配置
         logger.info("API配置已更新，准备通知客户端并重置所有session...")
         
-        # 1. 先通知所有连接的客户端即将刷新（WebSocket还连着）
-        notification_count = 0
+        # 1. 并行通知所有连接的客户端即将刷新（WebSocket还连着）
         session_manager = get_session_manager()
-        for lanlan_name, mgr in session_manager.items():
-            if mgr.is_active and mgr.websocket:
-                try:
-                    await mgr.websocket.send_text(json.dumps({
-                        "type": "reload_page",
-                        "message": "API配置已更新，页面即将刷新"
-                    }))
-                    notification_count += 1
-                    logger.info(f"已通知 {lanlan_name} 的前端刷新页面")
-                except Exception as e:
-                    logger.warning(f"通知 {lanlan_name} 的WebSocket失败: {e}")
-        
+        reload_payload = json.dumps({
+            "type": "reload_page",
+            "message": "API配置已更新，页面即将刷新"
+        })
+
+        async def _notify(lanlan_name, mgr):
+            if not (mgr.is_active and mgr.websocket):
+                return False
+            try:
+                await mgr.websocket.send_text(reload_payload)
+                logger.info(f"已通知 {lanlan_name} 的前端刷新页面")
+                return True
+            except Exception as e:
+                logger.warning(f"通知 {lanlan_name} 的WebSocket失败: {e}")
+                return False
+
+        _notify_results = await asyncio.gather(
+            *(_notify(n, m) for n, m in session_manager.items()),
+            return_exceptions=True,
+        )
+        notification_count = sum(1 for r in _notify_results if r is True)
         logger.info(f"已通知 {notification_count} 个客户端")
-        
-        # 2. 立刻关闭所有活跃的session（这会断开所有WebSocket）
-        sessions_ended = []
-        for lanlan_name, mgr in session_manager.items():
-            if mgr.is_active:
-                try:
-                    await mgr.end_session(by_server=True)
-                    sessions_ended.append(lanlan_name)
-                    logger.info(f"{lanlan_name} 的session已结束")
-                except Exception as e:
-                    logger.error(f"结束 {lanlan_name} 的session时出错: {e}")
+
+        # 2. 并行关闭所有活跃的 session（每个 end_session ≈ 1s，串行 N 秒，gather 后 ≈ 1s）
+        async def _end(lanlan_name, mgr):
+            if not mgr.is_active:
+                return None
+            try:
+                await mgr.end_session(by_server=True)
+                logger.info(f"{lanlan_name} 的session已结束")
+                return lanlan_name
+            except Exception as e:
+                logger.error(f"结束 {lanlan_name} 的session时出错: {e}")
+                return None
+
+        _end_results = await asyncio.gather(
+            *(_end(n, m) for n, m in session_manager.items()),
+            return_exceptions=True,
+        )
+        sessions_ended = [r for r in _end_results if isinstance(r, str)]
         
         # 3. 重新加载配置并重建session manager
         logger.info("正在重新加载配置...")

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -21,7 +21,7 @@ from fastapi.responses import JSONResponse
 from .shared_state import get_config_manager, get_steamworks, get_session_manager, get_initialize_character_data
 from .characters_router import get_current_live2d_model
 from utils.file_utils import atomic_write_json_async, read_json_async
-from utils.preferences import load_user_preferences, aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, load_global_conversation_settings, aload_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
+from utils.preferences import aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, aload_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
 from utils.logger_config import get_module_logger
 from utils.config_manager import get_reserved
 from config import (

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -708,7 +708,10 @@ async def update_core_config(request: Request):
         logger.info("API配置已更新，准备通知客户端并重置所有session...")
         
         # 1. 并行通知所有连接的客户端即将刷新（WebSocket还连着）
+        # 重要：先 snapshot 一份成员列表，让 notify 和 end_session 两阶段操作同一组 mgr。
+        # 否则前端收到 reload_page 后立即重连进来的新 mgr，会被第二阶段误杀（CodeRabbit P1）。
         session_manager = get_session_manager()
+        mgr_snapshot = list(session_manager.items())
         reload_payload = json.dumps({
             "type": "reload_page",
             "message": "API配置已更新，页面即将刷新"
@@ -726,13 +729,14 @@ async def update_core_config(request: Request):
                 return False
 
         _notify_results = await asyncio.gather(
-            *(_notify(n, m) for n, m in session_manager.items()),
+            *(_notify(n, m) for n, m in mgr_snapshot),
             return_exceptions=True,
         )
         notification_count = sum(1 for r in _notify_results if r is True)
         logger.info(f"已通知 {notification_count} 个客户端")
 
         # 2. 并行关闭所有活跃的 session（每个 end_session ≈ 1s，串行 N 秒，gather 后 ≈ 1s）
+        # 复用上一阶段的 snapshot，确保不会误杀新重连进来的 mgr。
         async def _end(lanlan_name, mgr):
             if not mgr.is_active:
                 return None
@@ -745,7 +749,7 @@ async def update_core_config(request: Request):
                 return None
 
         _end_results = await asyncio.gather(
-            *(_end(n, m) for n, m in session_manager.items()),
+            *(_end(n, m) for n, m in mgr_snapshot),
             return_exceptions=True,
         )
         sessions_ended = [r for r in _end_results if isinstance(r, str)]

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -708,10 +708,18 @@ async def update_core_config(request: Request):
         logger.info("API配置已更新，准备通知客户端并重置所有session...")
         
         # 1. 并行通知所有连接的客户端即将刷新（WebSocket还连着）
-        # 重要：先 snapshot 一份成员列表，让 notify 和 end_session 两阶段操作同一组 mgr。
-        # 否则前端收到 reload_page 后立即重连进来的新 mgr，会被第二阶段误杀（CodeRabbit P1）。
+        # 重要：snapshot (name, mgr, session) 三元组，让 notify 和 end_session 两阶段
+        # 操作同一组 mgr **+** 同一份 session：
+        # - mgr 维度防新 mgr 被加入第二阶段误杀
+        # - session 维度防同一 mgr 在两阶段之间已 rotate 到新 session 被误杀
+        #   （前端 reload 后立即重连 → 触发新 session → 第二阶段不应关掉新 session）
+        # end_session 内部已有 expected_session stale guard（core.py:3013/3026），
+        # 这里把 snapshot 时的 session 传下去即可触发该 guard。
         session_manager = get_session_manager()
-        mgr_snapshot = list(session_manager.items())
+        mgr_snapshot = [
+            (name, mgr, getattr(mgr, "session", None))
+            for name, mgr in session_manager.items()
+        ]
         reload_payload = json.dumps({
             "type": "reload_page",
             "message": "API配置已更新，页面即将刷新"
@@ -729,19 +737,20 @@ async def update_core_config(request: Request):
                 return False
 
         _notify_results = await asyncio.gather(
-            *(_notify(n, m) for n, m in mgr_snapshot),
+            *(_notify(n, m) for n, m, _session in mgr_snapshot),
             return_exceptions=True,
         )
         notification_count = sum(1 for r in _notify_results if r is True)
         logger.info(f"已通知 {notification_count} 个客户端")
 
         # 2. 并行关闭所有活跃的 session（每个 end_session ≈ 1s，串行 N 秒，gather 后 ≈ 1s）
-        # 复用上一阶段的 snapshot，确保不会误杀新重连进来的 mgr。
-        async def _end(lanlan_name, mgr):
-            if not mgr.is_active:
+        # 复用上一阶段的 (mgr, session) snapshot，确保不会误杀重连进来的新 mgr，
+        # 也不会误杀同一 mgr 在中途 rotate 出来的新 session。
+        async def _end(lanlan_name, mgr, expected_session):
+            if not mgr.is_active or expected_session is None:
                 return None
             try:
-                await mgr.end_session(by_server=True)
+                await mgr.end_session(by_server=True, expected_session=expected_session)
                 logger.info(f"{lanlan_name} 的session已结束")
                 return lanlan_name
             except Exception as e:
@@ -749,7 +758,7 @@ async def update_core_config(request: Request):
                 return None
 
         _end_results = await asyncio.gather(
-            *(_end(n, m) for n, m in mgr_snapshot),
+            *(_end(n, m, s) for n, m, s in mgr_snapshot),
             return_exceptions=True,
         )
         sessions_ended = [r for r in _end_results if isinstance(r, str)]

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -26,7 +26,7 @@ from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask
 
 from .shared_state import get_config_manager
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, read_json_async
 from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/jukebox", tags=["jukebox"])
@@ -436,7 +436,8 @@ async def upload_songs(
                 await asyncio.to_thread(shutil.copyfileobj, file.file, buffer)
 
             # 计算 MD5
-            file_md5 = calculate_md5(target_path)
+            # 大文件 hash 整文件读取，offload 避免阻塞事件循环
+            file_md5 = await asyncio.to_thread(calculate_md5, target_path)
 
             # 检查重复（基于MD5）
             existing_song_id = jukebox_config.data["md5Index"]["songs"].get(file_md5)
@@ -668,7 +669,8 @@ async def upload_actions(
                 await asyncio.to_thread(shutil.copyfileobj, file.file, buffer)
 
             # 计算 MD5
-            file_md5 = calculate_md5(target_path)
+            # 大文件 hash 整文件读取，offload 避免阻塞事件循环
+            file_md5 = await asyncio.to_thread(calculate_md5, target_path)
 
             # 检查重复（基于MD5）
             existing_action_id = jukebox_config.data["md5Index"]["actions"].get(file_md5)
@@ -1173,8 +1175,7 @@ async def import_config(file: UploadFile = File(...)):
             raise HTTPException(400, "导入包中缺少 config.json")
         
         try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                import_data = json.load(f)
+            import_data = await read_json_async(config_path)
         except json.JSONDecodeError as err:
             raise HTTPException(400, "config.json 不是有效的 JSON") from err
         
@@ -1203,7 +1204,7 @@ async def import_config(file: UploadFile = File(...)):
 
             # 始终从实际文件计算 MD5，不信任配置中的值
             if src_audio.exists():
-                file_md5 = calculate_md5(src_audio)
+                file_md5 = await asyncio.to_thread(calculate_md5, src_audio)
                 song["audioMd5"] = file_md5
             else:
                 file_md5 = song.get("audioMd5", "")
@@ -1270,7 +1271,7 @@ async def import_config(file: UploadFile = File(...)):
 
             # 始终从实际文件计算 MD5，不信任配置中的值
             if src_file.exists():
-                file_md5 = calculate_md5(src_file)
+                file_md5 = await asyncio.to_thread(calculate_md5, src_file)
                 action["fileMd5"] = file_md5
             else:
                 file_md5 = action.get("fileMd5", "")

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json, atomic_write_json_async, read_json_async
 from utils.frontend_utils import find_models, find_model_directory, find_workshop_item_by_id
 from utils.logger_config import get_module_logger
 from utils.url_utils import encode_url_path
@@ -232,9 +232,8 @@ async def update_model_config(model_name: str, request: Request):
             return JSONResponse(status_code=404, content={"success": False, "error": "模型配置文件不存在"})
         
         # 为了安全，只允许修改 Motions 和 Expressions
-        with open(model_json_path, 'r', encoding='utf-8') as f:
-            current_config = json.load(f)
-            
+        current_config = await read_json_async(model_json_path)
+
         file_refs = current_config.setdefault("FileReferences", {})
         if 'FileReferences' in data and 'Motions' in data['FileReferences']:
             file_refs['Motions'] = data['FileReferences']['Motions']
@@ -345,8 +344,7 @@ async def update_emotion_mapping(model_name: str, request: Request):
         if not model_json_path or not os.path.exists(model_json_path):
             return JSONResponse(status_code=404, content={"success": False, "error": "模型配置文件不存在"})
 
-        with open(model_json_path, 'r', encoding='utf-8') as f:
-            config_data = json.load(f)
+        config_data = await read_json_async(model_json_path)
 
         # 统一写入到标准 Cubism 结构（FileReferences.Motions / FileReferences.Expressions）
         file_refs = config_data.setdefault('FileReferences', {})
@@ -721,13 +719,12 @@ async def update_model_config_by_id(model_id: str, request: Request):
             return JSONResponse(status_code=404, content={"success": False, "error": "模型配置文件不存在"})
         
         # 为了安全，只允许修改 Motions 和 Expressions
-        with open(model_json_path, 'r', encoding='utf-8') as f:
-            current_config = json.load(f)
-            
+        current_config = await read_json_async(model_json_path)
+
         file_refs = current_config.setdefault("FileReferences", {})
         if 'FileReferences' in data and 'Motions' in data['FileReferences']:
             file_refs['Motions'] = data['FileReferences']['Motions']
-            
+
         if 'FileReferences' in data and 'Expressions' in data['FileReferences']:
             file_refs['Expressions'] = data['FileReferences']['Expressions']
 

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request
 from utils.character_name import validate_character_name
-from utils.file_utils import atomic_write_json_async
+from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.logger_config import get_module_logger
 from fastapi.responses import JSONResponse
 
@@ -281,9 +281,14 @@ async def get_recent_file(filename: str):
         status_code = path_error_status_code(path_error_code)
         return JSONResponse({"success": False, "error": path_error}, status_code=status_code)
     
-    with open(resolved_path, 'r', encoding='utf-8') as f:
-        content = f.read()
+    # offload 同步 read 到线程池：recent.json 单文件可达数 MB
+    content = await asyncio.to_thread(_read_text_file, resolved_path)
     return {"content": content}
+
+
+def _read_text_file(path: str, encoding: str = 'utf-8') -> str:
+    with open(path, 'r', encoding=encoding) as f:
+        return f.read()
 
 
 @router.post('/recent_file/save')
@@ -409,8 +414,7 @@ async def update_catgirl_name(request: Request):
         new_file_path = Path(new_file_path)
 
         # 2. 先完整读取旧文件，确认可解析后再写入新路径，避免中途失败导致源文件丢失
-        with open(old_file_path, 'r', encoding='utf-8') as f:
-            file_content = json.load(f)
+        file_content = await read_json_async(old_file_path)
         
         # 遍历所有消息，仅在特定字段中更新猫娘名称
         for item in file_content:
@@ -490,10 +494,9 @@ async def get_review_config():
         config_manager = get_config_manager()
         config_path = str(config_manager.get_config_path('core_config.json'))
         if os.path.exists(config_path):
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config_data = json.load(f)
-                # 如果配置中没有这个键，默认返回True（开启）
-                return {"enabled": config_data.get('recent_memory_auto_review', True)}
+            config_data = await read_json_async(config_path)
+            # 如果配置中没有这个键，默认返回True（开启）
+            return {"enabled": config_data.get('recent_memory_auto_review', True)}
         else:
             # 如果配置文件不存在，默认返回True（开启）
             return {"enabled": True}
@@ -516,8 +519,7 @@ async def update_review_config(request: Request):
         
         # 读取现有配置
         if os.path.exists(config_path):
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config_data = json.load(f)
+            config_data = await read_json_async(config_path)
         
         # 更新配置
         config_data['recent_memory_auto_review'] = enabled

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2013,13 +2013,13 @@ async def proxy_meme_image(url: str):
 
 # 辅助函数
 
-@router.get('/steam/proxy-image')
 def _read_binary_file(path: str) -> bytes:
     """同步 binary read，给 asyncio.to_thread 调用。"""
     with open(path, 'rb') as f:
         return f.read()
 
 
+@router.get('/steam/proxy-image')
 async def proxy_image(image_path: str):
     """
     代理访问本地图片文件，支持绝对路径和相对路径，特别是Steam创意工坊目录

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2014,6 +2014,12 @@ async def proxy_meme_image(url: str):
 # 辅助函数
 
 @router.get('/steam/proxy-image')
+def _read_binary_file(path: str) -> bytes:
+    """同步 binary read，给 asyncio.to_thread 调用。"""
+    with open(path, 'rb') as f:
+        return f.read()
+
+
 async def proxy_image(image_path: str):
     """
     代理访问本地图片文件，支持绝对路径和相对路径，特别是Steam创意工坊目录
@@ -2191,14 +2197,13 @@ async def proxy_image(image_path: str):
         
         # 检查文件大小是否超过50MB限制
         MAX_IMAGE_SIZE = 50 * 1024 * 1024  # 50MB
-        file_size = os.path.getsize(final_path)
+        file_size = await asyncio.to_thread(os.path.getsize, final_path)
         if file_size > MAX_IMAGE_SIZE:
             logger.warning(f"图片文件大小超过限制: {final_path} ({file_size / 1024 / 1024:.2f}MB > 50MB)")
             return JSONResponse(content={"success": False, "error": f"图片文件大小超过50MB限制 ({file_size / 1024 / 1024:.2f}MB)"}, status_code=413)
-        
-        # 读取图片文件
-        with open(final_path, 'rb') as f:
-            image_data = f.read()
+
+        # 读取图片文件 —— 最多 50MB，事件循环上同步 read 会卡几十毫秒
+        image_data = await asyncio.to_thread(_read_binary_file, final_path)
         
         # 根据文件扩展名设置MIME类型
         ext = os.path.splitext(final_path)[1].lower()
@@ -2331,7 +2336,7 @@ async def proactive_chat(request: Request):
         _config_manager = get_config_manager()
         session_manager = get_session_manager()
         # 获取当前角色数据（包括完整人设）
-        master_name_current, her_name_current, _, _, _, lanlan_prompt_map, _, _, _ = _config_manager.get_character_data()
+        master_name_current, her_name_current, _, _, _, lanlan_prompt_map, _, _, _ = await _config_manager.aget_character_data()
         
         data = await request.json()
         lanlan_name = data.get('lanlan_name') or her_name_current

--- a/main_routers/vrm_router.py
+++ b/main_routers/vrm_router.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse
 
 from .shared_state import get_config_manager
 from .workshop_router import get_subscribed_workshop_items
-from utils.file_utils import atomic_write_json_async
+from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.logger_config import get_module_logger
 
 router = APIRouter(prefix="/api/model/vrm", tags=["vrm"])
@@ -647,8 +647,7 @@ async def get_emotion_mapping(model_name: str):
             )
 
         if config_path.exists():
-            with open(config_path, 'r', encoding='utf-8') as f:
-                config = json.load(f)
+            config = await read_json_async(config_path)
             return {"success": True, "config": config}
         else:
             # 返回默认配置

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -55,6 +55,12 @@ _ugc_sync_lock = asyncio.Lock()
 _ugc_query_lock = asyncio.Lock()
 
 
+def _read_first_line(path: str, encoding: str = 'utf-8') -> str:
+    """同步读文件首行，供 asyncio.to_thread 调用（README.md / README.txt 元数据回退）。"""
+    with open(path, 'r', encoding=encoding) as f:
+        return f.readline()
+
+
 def _is_item_cache_valid(item_id: int) -> bool:
     """检查单个 UGC 缓存条目是否在有效期内"""
     entry = _ugc_details_cache.get(item_id)
@@ -826,14 +832,14 @@ async def get_subscribed_workshop_items():
                                             item_info["title"] = config_data["title"]
                                         elif "name" in config_data and config_data["name"]:
                                             item_info["title"] = config_data["name"]
-                                            
-                                            if "description" in config_data and config_data["description"]:
-                                                item_info["description"] = config_data["description"]
-                                        else:
-                                            # 对于文本文件，将第一行作为标题
-                                            first_line = f.readline().strip()
-                                            if first_line and item_info['title'].startswith('未知物品_'):
-                                                item_info['title'] = first_line[:100]  # 限制长度
+                                        # description 作为 title/name 的同级分支，不应嵌在 elif name 下
+                                        if "description" in config_data and config_data["description"]:
+                                            item_info["description"] = config_data["description"]
+                                    else:
+                                        # README.md / README.txt：把首行当标题（offload sync IO）
+                                        first_line = (await asyncio.to_thread(_read_first_line, config_path)).strip()
+                                        if first_line and item_info['title'].startswith('未知物品_'):
+                                            item_info['title'] = first_line[:100]  # 限制长度
                                     logger.debug(f"从本地文件 {os.path.basename(config_path)} 成功获取物品 {item_id} 的信息")
                                     break
                                 except Exception as file_error:

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -2516,7 +2516,9 @@ def _publish_workshop_item(steamworks, title, description, content_folder, previ
             item_id = None
             if character_card_name:
                 try:
-                    meta_data = await asyncio.to_thread(read_workshop_meta, character_card_name)
+                    # 注意：_publish_workshop_item 是 sync def，在 worker 线程里跑，不能用 await。
+                    # 其它 async 调用点已全部走 asyncio.to_thread，lint 已覆盖。
+                    meta_data = read_workshop_meta(character_card_name)
                     if meta_data and meta_data.get('workshop_item_id'):
                         item_id = int(meta_data.get('workshop_item_id'))
                         logger.info(f"从 .workshop_meta.json 读取到物品ID: {item_id}")

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from .shared_state import get_steamworks, get_config_manager, get_initialize_character_data
-from utils.file_utils import atomic_write_json, atomic_write_json_async
+from utils.file_utils import atomic_write_json, atomic_write_json_async, read_json_async
 from utils.workshop_utils import (
     ensure_workshop_folder_exists,
     get_workshop_path,
@@ -819,14 +819,13 @@ async def get_subscribed_workshop_items():
                         for config_path in config_files:
                             if os.path.exists(config_path):
                                 try:
-                                    with open(config_path, 'r', encoding='utf-8') as f:
-                                        if config_path.endswith('.json'):
-                                            config_data = json.load(f)
-                                            # 尝试从配置文件中提取标题和描述
-                                            if "title" in config_data and config_data["title"]:
-                                                item_info["title"] = config_data["title"]
-                                            elif "name" in config_data and config_data["name"]:
-                                                item_info["title"] = config_data["name"]
+                                    if config_path.endswith('.json'):
+                                        config_data = await read_json_async(config_path)
+                                        # 尝试从配置文件中提取标题和描述
+                                        if "title" in config_data and config_data["title"]:
+                                            item_info["title"] = config_data["title"]
+                                        elif "name" in config_data and config_data["name"]:
+                                            item_info["title"] = config_data["name"]
                                             
                                             if "description" in config_data and config_data["description"]:
                                                 item_info["description"] = config_data["description"]
@@ -1480,7 +1479,7 @@ async def get_workshop_meta(character_name: str):
         decoded_name = unquote(character_name)
         
         # 读取元数据
-        meta_data = read_workshop_meta(decoded_name)
+        meta_data = await asyncio.to_thread(read_workshop_meta, decoded_name)
         
         if meta_data:
             return JSONResponse(content={
@@ -1512,7 +1511,7 @@ async def get_workshop_meta(character_name: str):
 async def get_workshop_config():
     try:
         from utils.workshop_utils import load_workshop_config
-        workshop_config_data = load_workshop_config()
+        workshop_config_data = await asyncio.to_thread(load_workshop_config)
         return {"success": True, "config": workshop_config_data}
     except Exception as e:
         logger.error(f"获取创意工坊配置失败: {str(e)}")
@@ -1527,7 +1526,7 @@ async def save_workshop_config_api(config_data: dict):
         from utils.workshop_utils import load_workshop_config, save_workshop_config, ensure_workshop_folder_exists
         
         # 先加载现有配置，避免使用全局变量导致的不一致问题
-        workshop_config_data = load_workshop_config() or {}
+        workshop_config_data = await asyncio.to_thread(load_workshop_config) or {}
         
         # 更新配置
         if 'default_workshop_folder' in config_data:
@@ -1561,7 +1560,7 @@ async def scan_local_workshop_items(request: Request):
         
         # 确保配置已加载
         from utils.workshop_utils import load_workshop_config
-        workshop_config_data = load_workshop_config()
+        workshop_config_data = await asyncio.to_thread(load_workshop_config)
         logger.info(f'创意工坊配置已加载: {workshop_config_data}')
         
         data = await request.json()
@@ -2007,7 +2006,7 @@ async def prepare_workshop_upload(request: Request):
 
         # 检查是否已存在workshop_meta.json文件（防止重复上传）
         if character_card_name:
-            meta_data = read_workshop_meta(character_card_name)
+            meta_data = await asyncio.to_thread(read_workshop_meta, character_card_name)
             if meta_data and meta_data.get('workshop_item_id'):
                 workshop_item_id = meta_data.get('workshop_item_id')
 
@@ -2173,7 +2172,7 @@ async def prepare_workshop_upload(request: Request):
         # 读取 .workshop_meta.json（如果存在）
         workshop_item_id = None
         if character_card_name:
-            meta_data = read_workshop_meta(character_card_name)
+            meta_data = await asyncio.to_thread(read_workshop_meta, character_card_name)
             if meta_data and meta_data.get('workshop_item_id'):
                 workshop_item_id = meta_data.get('workshop_item_id')
                 logger.info(f"检测到已存在的 Workshop 物品 ID: {workshop_item_id}")
@@ -2452,9 +2451,8 @@ async def publish_to_workshop(request: Request):
                     import glob
                     chara_files = glob.glob(os.path.join(content_folder, "*.chara.json"))
                     if chara_files:
-                        with open(chara_files[0], 'r', encoding='utf-8') as f:
-                            chara_data = json.load(f)
-                            uploaded_snapshot['character_data'] = chara_data
+                        chara_data = await read_json_async(chara_files[0])
+                        uploaded_snapshot['character_data'] = chara_data
                         logger.info(f"已从临时文件夹读取角色卡数据")
                     
                     # 获取模型名称（从文件夹中查找模型目录）
@@ -2518,7 +2516,7 @@ def _publish_workshop_item(steamworks, title, description, content_folder, previ
             item_id = None
             if character_card_name:
                 try:
-                    meta_data = read_workshop_meta(character_card_name)
+                    meta_data = await asyncio.to_thread(read_workshop_meta, character_card_name)
                     if meta_data and meta_data.get('workshop_item_id'):
                         item_id = int(meta_data.get('workshop_item_id'))
                         logger.info(f"从 .workshop_meta.json 读取到物品ID: {item_id}")
@@ -2861,7 +2859,7 @@ async def sync_workshop_character_cards() -> dict:
         
         # 使用全局锁序列化 load_characters -> save_characters 流程，防止并发覆写
         async with _ugc_sync_lock:
-            characters = config_mgr.load_characters()
+            characters = await config_mgr.aload_characters()
             if '猫娘' not in characters:
                 characters['猫娘'] = {}
             
@@ -2885,8 +2883,7 @@ async def sync_workshop_character_cards() -> dict:
                     
                     for chara_file_path in chara_files:
                         try:
-                            with open(chara_file_path, 'r', encoding='utf-8') as f:
-                                chara_data = json.load(f)
+                            chara_data = await read_json_async(chara_file_path)
                             
                             chara_name = chara_data.get('档案名') or chara_data.get('name')
                             if not chara_name:

--- a/main_server.py
+++ b/main_server.py
@@ -265,18 +265,26 @@ def _select_fallback_session_manager():
 
 
 async def _broadcast_to_all_connected(event_payload: dict) -> int:
-    """Broadcast an event to all connected WebSocket sessions asynchronously."""
-    delivered_count = 0
+    """Broadcast an event to all connected WebSocket sessions in parallel.
+    每秒可能多次（agent status），串行 await 会让一个慢的 ws 拖累其它会话。"""
     # Take a snapshot to avoid RuntimeError from concurrent dict mutation
-    for name, mgr in list(_iter_session_managers()):
-        ws = getattr(mgr, "websocket", None)
-        if _is_websocket_connected(ws) and hasattr(ws, "send_json"):
-            try:
-                await ws.send_json(event_payload)
-                delivered_count += 1
-            except Exception as e:
-                logger.debug("[EventBus] broadcast to %s failed: %s", name, e)
-    return delivered_count
+    targets = [
+        (name, getattr(mgr, "websocket", None))
+        for name, mgr in list(_iter_session_managers())
+        if mgr
+    ]
+    targets = [(n, ws) for n, ws in targets if _is_websocket_connected(ws) and hasattr(ws, "send_json")]
+
+    async def _send_one(name, ws):
+        try:
+            await ws.send_json(event_payload)
+            return True
+        except Exception as e:
+            logger.debug("[EventBus] broadcast to %s failed: %s", name, e)
+            return False
+
+    results = await asyncio.gather(*(_send_one(n, ws) for n, ws in targets), return_exceptions=False)
+    return sum(1 for r in results if r is True)
 
 
 async def _handle_agent_event(event: dict):
@@ -327,15 +335,19 @@ async def _handle_agent_event(event: dict):
         elif event_type == "music_allowlist_add":
             # Music allowlist is a global UI state, broadcast to all active sessions
             targets = [mgr] if mgr else [m for _, m in _iter_session_managers()]
-            for target_mgr in targets:
+            payload = {
+                "type": "music_allowlist_add",
+                "domains": event.get("domains") or event.get("metadata", {}).get("domains", [])
+            }
+
+            async def _send_allowlist(target_mgr):
                 if target_mgr and target_mgr.websocket and hasattr(target_mgr.websocket, "send_json"):
                     try:
-                        await target_mgr.websocket.send_json({
-                            "type": "music_allowlist_add",
-                            "domains": event.get("domains") or event.get("metadata", {}).get("domains", [])
-                        })
+                        await target_mgr.websocket.send_json(payload)
                     except Exception as e:
                         logger.debug("[EventBus] music_allowlist_add broadcast failed: %s", e)
+
+            await asyncio.gather(*(_send_allowlist(t) for t in targets), return_exceptions=True)
             if targets:
                 logger.info("[EventBus] music_allowlist_add broadcasted to %d sessions", len(targets))
             return
@@ -343,17 +355,21 @@ async def _handle_agent_event(event: dict):
         elif event_type == "music_play_url":
             # Music playback is a global UI action, broadcast to all active sessions
             targets = [mgr] if mgr else [m for _, m in _iter_session_managers()]
-            for target_mgr in targets:
+            payload = {
+                "type": "music_play_url",
+                "url": event.get("url"),
+                "name": event.get("name") or "Plugin Music",
+                "artist": event.get("artist") or "External"
+            }
+
+            async def _send_play(target_mgr):
                 if target_mgr and target_mgr.websocket and hasattr(target_mgr.websocket, "send_json"):
                     try:
-                        await target_mgr.websocket.send_json({
-                            "type": "music_play_url",
-                            "url": event.get("url"),
-                            "name": event.get("name") or "Plugin Music",
-                            "artist": event.get("artist") or "External"
-                        })
+                        await target_mgr.websocket.send_json(payload)
                     except Exception as e:
                         logger.debug("[EventBus] music_play_url broadcast failed: %s", e)
+
+            await asyncio.gather(*(_send_play(t) for t in targets), return_exceptions=True)
             if targets:
                 logger.info("[EventBus] music_play_url broadcasted to %d sessions", len(targets))
             return

--- a/memory/settings.py
+++ b/memory/settings.py
@@ -152,9 +152,9 @@ class ImportantSettingsManager:
 
         # 检测并解决矛盾
         if len(new_settings)>0:
-            self.load_settings()
+            await asyncio.to_thread(self.load_settings)
             self.settings[lanlan_name] = await self.detect_and_resolve_contradictions(self.settings[lanlan_name], new_settings, lanlan_name)
-            self.save_settings(lanlan_name)
+            await asyncio.to_thread(self.save_settings, lanlan_name)
 
     def get_settings(self, lanlan_name):
         self.load_settings()

--- a/memory_server.py
+++ b/memory_server.py
@@ -239,18 +239,21 @@ async def _periodic_rebuttal_loop():
     while True:
         await asyncio.sleep(REBUTTAL_CHECK_INTERVAL)
         try:
-            character_data = _config_manager.load_characters()
+            character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
         except Exception as e:
             logger.debug(f"[Rebuttal] 加载角色列表失败: {e}")
             continue
 
         now = datetime.now()
-        for name in catgirl_names:
+
+        async def _check_one_rebuttal(name: str):
+            """单个 catgirl 的反驳检查。各角色互相独立，外层 gather 并行。
+            内部对 feedbacks 仍串行 areject_promotion（同 reflection 不能并发处理）。"""
             try:
                 confirmed = await reflection_engine.aget_confirmed_reflections(name)
                 if not confirmed:
-                    continue
+                    return
 
                 # 确定查询起始时间：上次检查时间 or 1小时前（首次）
                 start_time = _last_rebuttal_check.get(
@@ -261,12 +264,12 @@ async def _periodic_rebuttal_loop():
                 )
                 if not rows:
                     _last_rebuttal_check[name] = now
-                    continue
+                    return
 
                 user_msgs = _extract_user_messages_from_rows(rows)
                 if not user_msgs:
                     _last_rebuttal_check[name] = now
-                    continue
+                    return
 
                 # 复用 check_feedback 判断反驳
                 feedbacks = await reflection_engine.check_feedback_for_confirmed(
@@ -275,7 +278,7 @@ async def _periodic_rebuttal_loop():
                 if feedbacks is None:
                     # LLM 调用失败 → 不推进窗口，下次重试这批消息
                     logger.warning(f"[Rebuttal] {name}: 反驳检查失败，保留窗口待重试")
-                    continue
+                    return
 
                 # 成功才推进窗口
                 _last_rebuttal_check[name] = now
@@ -288,6 +291,12 @@ async def _periodic_rebuttal_loop():
             except Exception as e:
                 logger.debug(f"[Rebuttal] {name}: 处理失败，跳过: {e}")
 
+        if catgirl_names:
+            await asyncio.gather(
+                *(_check_one_rebuttal(name) for name in catgirl_names),
+                return_exceptions=True,
+            )
+
 
 AUTO_PROMOTE_CHECK_INTERVAL = 300  # 5 分钟
 
@@ -299,19 +308,25 @@ async def _periodic_auto_promote_loop():
     while True:
         await asyncio.sleep(AUTO_PROMOTE_CHECK_INTERVAL)
         try:
-            character_data = _config_manager.load_characters()
+            character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
         except Exception as e:
             logger.debug(f"[AutoPromote] 加载角色列表失败: {e}")
             continue
 
-        for name in catgirl_names:
+        async def _promote_one(name: str):
             try:
                 transitions = await reflection_engine.aauto_promote_stale(name)
                 if transitions:
                     logger.info(f"[AutoPromote] {name}: {transitions} 条状态迁移")
             except Exception as e:
                 logger.debug(f"[AutoPromote] {name}: 处理失败: {e}")
+
+        if catgirl_names:
+            await asyncio.gather(
+                *(_promote_one(name) for name in catgirl_names),
+                return_exceptions=True,
+            )
 
 
 @app.on_event("startup")
@@ -328,7 +343,7 @@ async def startup_event_handler():
     # 自动迁移 settings → persona（如 persona 文件不存在）
     # 注：目录结构迁移已在模块级完成（在组件实例化之前）
     try:
-        character_data = _config_manager.load_characters()
+        character_data = await _config_manager.aload_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
         # 各角色的 persona 文件互相独立，并行迁移检查避免 N 倍串行磁盘 IO。
         # return_exceptions=True：避免 fail-fast 取消其它角色正在写盘的协程，
@@ -556,7 +571,7 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
     try:
         # 检查角色是否存在于配置中，如果不存在则记录信息但继续处理（允许新角色）
         try:
-            character_data = _config_manager.load_characters()
+            character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
             if lanlan_name not in catgirl_names:
                 logger.info(f"[MemoryServer] 角色 '{lanlan_name}' 不在配置中，但继续处理（可能是新创建的角色）")
@@ -600,7 +615,7 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
     try:
         # 检查角色是否存在于配置中，如果不存在则记录信息但继续处理（允许新角色）
         try:
-            character_data = _config_manager.load_characters()
+            character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
             if lanlan_name not in catgirl_names:
                 logger.info(f"[MemoryServer] renew: 角色 '{lanlan_name}' 不在配置中，但继续处理（可能是新创建的角色）")
@@ -680,7 +695,7 @@ async def get_recent_history(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
     # 检查角色是否存在于配置中
     try:
-        character_data = _config_manager.load_characters()
+        character_data = await _config_manager.aload_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
         if lanlan_name not in catgirl_names:
             logger.warning(f"角色 '{lanlan_name}' 不在配置中，返回空历史记录")
@@ -690,7 +705,7 @@ async def get_recent_history(lanlan_name: str):
         return "开始聊天前，没有历史记录。\n"
 
     history = await recent_history_manager.aget_recent_history(lanlan_name)
-    _, _, _, _, name_mapping, _, _, _, _ = _config_manager.get_character_data()
+    _, _, _, _, name_mapping, _, _, _, _ = await _config_manager.aget_character_data()
     name_mapping['ai'] = lanlan_name
     result = f"开始聊天前，{lanlan_name}又在脑海内整理了近期发生的事情。\n"
     for i in history:
@@ -720,7 +735,7 @@ async def get_settings(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
     # 检查角色是否存在于配置中
     try:
-        character_data = _config_manager.load_characters()
+        character_data = await _config_manager.aload_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
         if lanlan_name not in catgirl_names:
             logger.warning(f"角色 '{lanlan_name}' 不在配置中，返回空设置")
@@ -738,7 +753,8 @@ async def get_settings(lanlan_name: str):
     if persona_md:
         return persona_md
     # 兼容回退（自然语言格式）
-    return _format_legacy_settings_as_text(settings_manager.get_settings(lanlan_name), lanlan_name)
+    legacy_settings = await asyncio.to_thread(settings_manager.get_settings, lanlan_name)
+    return _format_legacy_settings_as_text(legacy_settings, lanlan_name)
 
 
 @app.get("/get_persona/{lanlan_name}")
@@ -791,7 +807,7 @@ async def new_dialog(lanlan_name: str):
     
     # 检查角色是否存在于配置中
     try:
-        character_data = _config_manager.load_characters()
+        character_data = await _config_manager.aload_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
         if lanlan_name not in catgirl_names:
             logger.warning(f"角色 '{lanlan_name}' 不在配置中，返回空上下文")
@@ -819,7 +835,7 @@ async def new_dialog(lanlan_name: str):
 
         # 正则表达式：删除所有类型括号及其内容（包括[]、()、{}、<>、【】、（）等）
         brackets_pattern = re.compile(r'(\[.*?\]|\(.*?\)|（.*?）|【.*?】|\{.*?\}|<.*?>)')
-        master_name, _, _, _, name_mapping, _, _, _, _ = _config_manager.get_character_data()
+        master_name, _, _, _, name_mapping, _, _, _, _ = await _config_manager.aget_character_data()
         name_mapping['ai'] = lanlan_name
         _lang = get_global_language()
 
@@ -835,7 +851,9 @@ async def new_dialog(lanlan_name: str):
             result += persona_md
         else:
             # 兼容回退：使用旧 settings（自然语言格式）
-            result += _format_legacy_settings_as_text(settings_manager.get_settings(lanlan_name), lanlan_name) + "\n"
+            # get_settings 内部 open() + json.load()，offload 避免阻塞（冷回退路径，但触发时多文件 IO）
+            legacy_settings = await asyncio.to_thread(settings_manager.get_settings, lanlan_name)
+            result += _format_legacy_settings_as_text(legacy_settings, lanlan_name) + "\n"
 
         # ── [动态部分] 内心活动（每次变化） ──
         result += _loc(INNER_THOUGHTS_HEADER, _lang).format(name=lanlan_name)

--- a/monitor.py
+++ b/monitor.py
@@ -16,7 +16,7 @@ import uvicorn
 from fastapi.templating import Jinja2Templates
 from utils.frontend_utils import find_models, find_model_config_file, find_model_directory
 from utils.workshop_utils import get_default_workshop_folder
-from utils.preferences import load_user_preferences, aload_user_preferences
+from utils.preferences import aload_user_preferences
 
 # Setup logger
 from utils.logger_config import setup_logging

--- a/monitor.py
+++ b/monitor.py
@@ -16,7 +16,7 @@ import uvicorn
 from fastapi.templating import Jinja2Templates
 from utils.frontend_utils import find_models, find_model_config_file, find_model_directory
 from utils.workshop_utils import get_default_workshop_folder
-from utils.preferences import load_user_preferences
+from utils.preferences import load_user_preferences, aload_user_preferences
 
 # Setup logger
 from utils.logger_config import setup_logging
@@ -74,7 +74,7 @@ async def get_page_config(lanlan_name: str = ""):
     """获取页面配置（lanlan_name 和 model_path）"""
     try:
         # 获取角色数据
-        _, her_name, _, lanlan_basic_config, _, _, _, _, _ = _config_manager.get_character_data()
+        _, her_name, _, lanlan_basic_config, _, _, _, _, _ = await _config_manager.aget_character_data()
         
         # 如果提供了 lanlan_name 参数，使用它；否则使用当前角色
         target_name = lanlan_name if lanlan_name else her_name
@@ -114,7 +114,7 @@ async def get_page_config(lanlan_name: str = ""):
 @app.get("/api/config/preferences")
 async def get_preferences():
     """获取用户偏好设置（与main_server.py保持一致）"""
-    preferences = load_user_preferences()
+    preferences = await aload_user_preferences()
     return preferences
 
 @app.get('/api/live2d/emotion_mapping/{model_name}')

--- a/scripts/check_async_blocking.py
+++ b/scripts/check_async_blocking.py
@@ -153,6 +153,15 @@ RISKY_ATTR_PAIRS: dict[tuple[str, str], str] = {
     ("shutil", "copytree"): "shutil.copytree",
     ("shutil", "move"): "shutil.move",
     ("shutil", "rmtree"): "shutil.rmtree",
+    # json: load() reads from a file handle (always blocks on read);
+    # loads() is in-memory string parse (NOT blocking, NOT flagged).
+    # NOTE: kept high-signal entries here. We deliberately do NOT add
+    # ``open`` (builtin), ``os.listdir`` / ``os.makedirs`` / ``os.path.getmtime``
+    # / ``os.path.getsize`` / ``Thread.is_alive`` here — they each have
+    # legitimate hot-path patterns (sync file create + offloaded copyfileobj,
+    # microsecond-scale stat / GIL checks) that would force noisy noqas.
+    # Add them later if the FP cost gets cheaper (per-pattern context filter).
+    ("json", "load"): "json.load (reads from file handle)",
 }
 
 # Bare-name (no receiver) function calls that indicate blocking —
@@ -218,6 +227,12 @@ def _describe_blocking_call(call: ast.Call) -> str | None:
             return "queue.Queue.get()"
         if attr == "join" and _tail_matches(receiver_tail, THREAD_EXACT, THREAD_SUFFIX):
             return "Thread/Process.join()"
+        # NOTE: ``is_alive()`` deliberately NOT flagged. It takes the GIL for
+        # microseconds (vs. join() which can block indefinitely). Wrapping in
+        # ``await asyncio.to_thread(t.is_alive)`` adds ~100µs roundtrip
+        # overhead, which is a net regression in the per-audio-chunk TTS
+        # watchdog loop where this pattern dominates. If a future hot loop
+        # needs flagging, narrow the rule to "inside for/while body" only.
         if _tail_matches(receiver_tail, SOCKET_EXACT, SOCKET_SUFFIX) and attr in {"recv", "accept", "connect"}:
             return f"blocking socket.{attr}()"
         return None
@@ -408,9 +423,10 @@ class AsyncBlockingChecker(ast.NodeVisitor):
             return
         # Avoid duplicating with the existing queue/thread/socket flags —
         # those carry richer messages from _check_attribute_call.
-        if reason in ("queue.Queue.get()", "Thread/Process.join()") or reason.startswith(
-            "blocking socket."
-        ):
+        if reason in (
+            "queue.Queue.get()",
+            "Thread/Process.join()",
+        ) or reason.startswith("blocking socket."):
             return
         self._flag(
             call,

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -25,6 +25,9 @@ class DummyConfigManager:
     def load_characters(self):
         return copy.deepcopy(self.characters)
 
+    async def aload_characters(self, character_json_path=None):
+        return copy.deepcopy(self.characters)
+
     def save_characters(self, characters, character_json_path=None):
         self.saved_characters = copy.deepcopy(characters)
         self.characters = copy.deepcopy(characters)

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1490,6 +1490,16 @@ class ConfigManager:
     async def aget_character_data(self):
         return await asyncio.to_thread(self.get_character_data)
 
+    async def aload_characters(self, character_json_path=None):
+        """异步包装 load_characters：cache hit 也要 deepcopy 整个字典，
+        N 个 catgirl 时拷贝可达数 ms，offload 避免阻塞事件循环。"""
+        return await asyncio.to_thread(self.load_characters, character_json_path)
+
+    async def aget_core_config(self):
+        """异步包装 get_core_config：内部 open()+json.load() 读 core_config.json，
+        async endpoint 调用时必须 offload，避免事件循环阻塞。"""
+        return await asyncio.to_thread(self.get_core_config)
+
     # --- Core config helpers ---
 
     # Combined region cache (None = not checked, True = non-mainland, False = mainland)

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -1,8 +1,9 @@
+import asyncio
 import json
 import os
 from typing import Dict, Any, Optional, List
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json
+from utils.file_utils import atomic_write_json, read_json_async
 
 # 初始化配置管理器
 _config_manager = get_config_manager()
@@ -36,6 +37,17 @@ def load_user_preferences() -> List[Dict[str, Any]]:
     except Exception as e:
         print(f"加载用户偏好失败: {e}")
     return []
+
+
+async def aload_user_preferences() -> List[Dict[str, Any]]:
+    """异步版 load_user_preferences：供 async endpoint 调用，避免同步 open()+json.load() 阻塞事件循环。
+
+    共享 load_user_preferences 的 dict→list 兼容处理。
+    """
+    def _sync_load():
+        return load_user_preferences()
+    return await asyncio.to_thread(_sync_load)
+
 
 def save_user_preferences(preferences: List[Dict[str, Any]]) -> bool:
     """
@@ -303,6 +315,11 @@ def load_global_conversation_settings() -> Dict[str, Any]:
     except Exception as e:
         print(f"加载全局对话设置失败: {e}")
     return {}
+
+
+async def aload_global_conversation_settings() -> Dict[str, Any]:
+    """异步版 load_global_conversation_settings：供 async 路径调用，offload sync IO。"""
+    return await asyncio.to_thread(load_global_conversation_settings)
 
 
 def save_global_conversation_settings(settings: Dict[str, Any]) -> bool:

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -3,7 +3,7 @@ import json
 import os
 from typing import Dict, Any, Optional, List
 from utils.config_manager import get_config_manager
-from utils.file_utils import atomic_write_json, read_json_async
+from utils.file_utils import atomic_write_json
 
 # 初始化配置管理器
 _config_manager = get_config_manager()

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -430,7 +430,7 @@ async def fetch_weibo_trending(limit: int = 10) -> Dict[str, Any]:
     """
     try:
         # 动态获取平台 Cookie，拒绝硬编码
-        weibo_cookies = _get_platform_cookies('weibo')
+        weibo_cookies = await asyncio.to_thread(_get_platform_cookies, 'weibo')
         sub_cookie = weibo_cookies.get('SUB') or weibo_cookies.get('sub', '')
         if sub_cookie:
             cookie_header = f"SUB={sub_cookie}"
@@ -2201,7 +2201,7 @@ async def fetch_douyin_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
     try:
         from utils.cookies_login import validate_cookies
         
-        cookies = _get_platform_cookies('douyin')
+        cookies = await asyncio.to_thread(_get_platform_cookies, 'douyin')
         if not cookies:
             return {'success': False, 'error': '未找到抖音 Cookie 配置'}
         
@@ -2293,7 +2293,7 @@ async def fetch_kuaishou_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
     try:
         from utils.cookies_login import validate_cookies
         
-        cookies = _get_platform_cookies('kuaishou')
+        cookies = await asyncio.to_thread(_get_platform_cookies, 'kuaishou')
         if not cookies:
             return {'success': False, 'error': '未找到快手 Cookie 配置'}
         
@@ -2378,7 +2378,7 @@ async def fetch_weibo_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
     try:
         from utils.cookies_login import validate_cookies
         
-        weibo_cookies = _get_platform_cookies('weibo')
+        weibo_cookies = await asyncio.to_thread(_get_platform_cookies, 'weibo')
         if not weibo_cookies:
             return {'success': False, 'error': '未找到 config/weibo_cookies.json'}
         
@@ -2493,7 +2493,7 @@ async def fetch_reddit_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
     获取Reddit推送的动态帖子
     """
     try:
-        reddit_cookies = _get_platform_cookies('reddit')
+        reddit_cookies = await asyncio.to_thread(_get_platform_cookies, 'reddit')
         if not reddit_cookies: 
             return {'success': False, 'error': '未配置 config/reddit_cookies.json'}
         url = f"https://www.reddit.com/hot.json?limit={limit}"
@@ -2565,7 +2565,7 @@ async def fetch_twitter_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
     try:
         from utils.cookies_login import validate_cookies
         
-        twitter_cookies = _get_platform_cookies('twitter')
+        twitter_cookies = await asyncio.to_thread(_get_platform_cookies, 'twitter')
         if not twitter_cookies:
              return {'success': False, 'error': '未配置 config/twitter_cookies.json'}
         


### PR DESCRIPTION
## Summary

接 #846 / #848 / #850 / #853 后的一轮全仓 async 审计 —— 32 项审计发现 + 一轮 lint 扩展级联清理，20 个文件 +371/-253 行。每改一处都先用 awk 定位 enclosing function 验证是 async def，避免误改 sync helper。

### A. 热点 endpoint 同步 config 读取 → async (10 处)
- `memory_server` 三个对话生命周期端点：`new_dialog` / `get_recent_history` / `get_settings` 之前每次同步 deepcopy 整个 characters 字典
- `core.start_session` / `_background_prepare_pending_session` 每次起会话同样问题
- `monitor.{get_page_config,get_preferences}` / `system_router.proactive_chat` / `agent_router.update_agent_flags` / `config_router.{get_page_config,get_preferences}`
- 新增 `aload_characters` / `aget_core_config` / `aload_user_preferences` / `aload_global_conversation_settings` 作为 drop-in async 包装

### B. 同步 `open()+json.load()` → `read_json_async` (10+ 处)
- live2d/vrm/memory/jukebox/characters/config router 的 6 处 async endpoint
- `proxy_image` 50MB binary read 拆出 `_read_binary_file` 并 offload
- jukebox `calculate_md5` 4 处全文件 hash 走 `to_thread`
- `import_character_card` / `get_character_cards` 角色卡导入读盘

### C. 串行 await 循环 → `asyncio.gather` (14 处)
| 位置 | 收益 |
|------|------|
| `main_server._broadcast_to_all_connected` + 2 个 music event 广播 | 慢 ws 不再拖累其它会话 |
| `set_current_catgirl` 切换通知 | per-mgr 失败仍只清自己的 ws |
| `save_core_api` reload_page 通知 + end_session 扫荡 | O(N×1s) → O(1s) |
| `delete_voice` 受影响角色 end_session | 同上 |
| `delete_catgirl` 嵌套删除 (2×5=10 IO) | 展平后 gather |
| `_reset_preparation_state` bg+swap task wait_for(2s) | 最坏墙钟 4s → 2s |
| `cross_server` connector teardown (3 ws + 3 session) | close 全并行 |
| `agent_server` shutdown 2 个 recv 线程 join | 4s → 2s |
| `memory_server` _periodic_rebuttal_loop / _periodic_auto_promote_loop | 按 catgirl 并行 |

### D. lint 扩展 + 级联 sweep (~50 处)
- `scripts/check_async_blocking.py` 的 `RISKY_ATTR_PAIRS` 新增 `("json", "load")`
- 触发后级联扫出大量系统性违规：
  - `characters_router` 28 个 `_config_manager.load_characters()` → `await aload_characters()`
  - `core.py` 多处 `get_core_config()` → `await aget_core_config()`，并合并连续两次 IO 为一次 snapshot
  - `workshop_router` 里 `read_workshop_meta` / `load_workshop_config` 全部 `to_thread` 包裹
  - `web_scraper.py` 6 处 `_get_platform_cookies` 包 `to_thread`
  - `memory/settings.py extract_and_update_settings` 里 `load_settings` / `save_settings` 包 `to_thread`
- 其它 lint 候选项（`builtins.open` / `os.{listdir,makedirs}` / `Thread.is_alive` 等）权衡 FP 后未启用，理由写在 `RISKY_BARE_CALLS` / 相关 attr 段的注释里（如 `is_alive` 微秒级 GIL，wrap 反而引入 100μs 净亏）

## Test plan

- [x] `python scripts/check_async_blocking.py` → exit 0
- [x] 21 个改动文件 `ast.parse` 全 OK
- [ ] 启动 server，触发热点端点（new_dialog / start_session / proactive_chat），确认无回归
- [ ] 切换猫娘 / 编辑/删除 catgirl / 修改 voice_id 走完整流程
- [ ] save_core_api 改一次 API key 看 N 个 session reload 是否仍正常
- [ ] 上传一首大歌曲（~20MB）确认 calculate_md5 不再卡

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 大规模移除阻塞式 I/O：文件/JSON 读取与哈希计算改为异步或后台线程执行，提升界面与接口响应性
  * 并行化关闭/清理、WebSocket 广播、会话终止与文件删除流程，减少停顿与延迟
  * 同步配置/偏好/角色读取提供异步入口并改为 await 使用，改善高并发下的稳定性与吞吐量
<!-- end of auto-generated comment: release notes by coderabbit.ai -->