### PR TITLE
refactor: consolidate per-catgirl runtime state into RoleState (#857)

### DIFF
--- a/main_routers/shared_state.py
+++ b/main_routers/shared_state.py
@@ -7,19 +7,37 @@ that are initialized in main_server.py but need to be accessed by routers.
 
 Design: Routers import getters from this module, main_server.py sets the state
 after initialization.
+
+History
+-------
+Issue #857 / PR #855 review consolidated 6 parallel per-catgirl module-globals
+in main_server.py (sync_message_queue / sync_shutdown_event / session_id /
+sync_process / websocket_locks / session_manager) into a single
+``role_state: dict[str, RoleState]`` container. To avoid touching dozens of
+consumer call-sites in this PR, the legacy getters
+(``get_sync_message_queue`` etc.) are kept and now return a thin
+``_RoleStateFieldView`` adapter — a ``MutableMapping`` view over one field of
+each ``RoleState`` entry. Consumers see the same dict-like API
+(``[k]`` / ``in`` / ``del`` / ``.keys()`` / ``.items()`` / ``.get()`` / ``.pop()``).
+
+A new ``get_role_state()`` getter exposes the underlying container directly
+for code that wants to migrate off the per-field views.
 """
 
+from collections.abc import MutableMapping
 from typing import Dict
+
 _UNSET = object()
 
 # Global state containers (set by main_server.py)
 _state = {
-    'sync_message_queue': _UNSET,
-    'sync_shutdown_event': _UNSET,
-    'session_manager': _UNSET,
-    'session_id': _UNSET,
-    'sync_process': _UNSET,
-    'websocket_locks': _UNSET,
+    'role_state': _UNSET,            # NEW canonical store (dict[str, RoleState])
+    'sync_message_queue': _UNSET,    # _RoleStateFieldView adapter (legacy API)
+    'sync_shutdown_event': _UNSET,   # _RoleStateFieldView adapter (legacy API)
+    'session_manager': _UNSET,       # _RoleStateFieldView adapter (legacy API)
+    'session_id': _UNSET,            # _RoleStateFieldView adapter (legacy API)
+    'sync_process': _UNSET,          # _RoleStateFieldView adapter (legacy API)
+    'websocket_locks': _UNSET,       # _RoleStateFieldView adapter (legacy API)
     'steamworks': None,
     'templates': _UNSET,
     'config_manager': _UNSET,
@@ -31,13 +49,97 @@ _state = {
 }
 
 
+class _RoleStateFieldView(MutableMapping):
+    """Dict-like view over a single field of every ``RoleState`` entry.
+
+    Backward-compatibility shim for legacy ``get_sync_message_queue()`` /
+    ``get_session_id()`` etc. callers. Holds a reference to the live
+    ``role_state`` dict and a field name; reads/writes proxy to
+    ``role_state[k].<field>``.
+
+    Semantics
+    ---------
+    ``__contains__(k)`` returns True iff ``k in role_state`` AND the field
+    value is not ``None``. This preserves the legacy "the dict has no entry
+    for this catgirl" check used by code like::
+
+        if lanlan_name not in session_id: ...
+        if lanlan in session_manager: ...
+
+    For optional fields (session_id / sync_process / session_manager) this
+    matches the historical "dict had no key" state. For always-present fields
+    (sync_message_queue / sync_shutdown_event / websocket_lock) the values are
+    never ``None`` after ``_ensure_character_slots`` so contains is equivalent
+    to ``k in role_state``.
+
+    ``__delitem__(k)`` clears the field by setting it to ``None``; it does
+    NOT remove the underlying ``role_state`` entry. Removing the whole
+    catgirl goes through ``del role_state[k]`` in
+    ``_cleanup_character_dicts``. This matches the only consumer ``del`` /
+    ``pop`` site we have today (``session_id.pop(lanlan_name, None)`` in
+    ``websocket_router``), which means "this catgirl no longer has a live
+    session" — not "delete the catgirl".
+
+    Note on ``websocket_lock``: external consumers must NEVER assign through
+    this view (would strand any coroutine already waiting on the old Lock).
+    No consumer does today. The view does not actively block writes — it
+    relies on convention + code review.
+    """
+
+    __slots__ = ("_role_state", "_field")
+
+    def __init__(self, role_state: dict, field: str):
+        self._role_state = role_state
+        self._field = field
+
+    def __getitem__(self, key):
+        rs = self._role_state.get(key)
+        if rs is None:
+            raise KeyError(key)
+        value = getattr(rs, self._field)
+        if value is None:
+            raise KeyError(key)
+        return value
+
+    def __setitem__(self, key, value):
+        rs = self._role_state.get(key)
+        if rs is None:
+            raise KeyError(
+                f"role_state[{key!r}] not initialized; "
+                f"call _ensure_character_slots before assigning {self._field!r}"
+            )
+        setattr(rs, self._field, value)
+
+    def __delitem__(self, key):
+        rs = self._role_state.get(key)
+        if rs is None or getattr(rs, self._field) is None:
+            raise KeyError(key)
+        setattr(rs, self._field, None)
+
+    def __contains__(self, key):
+        rs = self._role_state.get(key)
+        return rs is not None and getattr(rs, self._field, None) is not None
+
+    def __iter__(self):
+        field = self._field
+        return (
+            k for k, rs in self._role_state.items()
+            if getattr(rs, field, None) is not None
+        )
+
+    def __len__(self):
+        field = self._field
+        return sum(
+            1 for rs in self._role_state.values()
+            if getattr(rs, field, None) is not None
+        )
+
+    def __repr__(self):
+        return f"_RoleStateFieldView(field={self._field!r}, len={len(self)})"
+
+
 def init_shared_state(
-    sync_message_queue: Dict,
-    sync_shutdown_event: Dict,
-    session_manager: Dict,
-    session_id: Dict,
-    sync_process: Dict,
-    websocket_locks: Dict,
+    role_state: Dict,
     steamworks,
     templates,
     config_manager,
@@ -47,13 +149,14 @@ def init_shared_state(
     init_one_catgirl=None,
     remove_one_catgirl=None,
 ):
-    """Initialize shared state from main_server.py"""
-    _state['sync_message_queue'] = sync_message_queue
-    _state['sync_shutdown_event'] = sync_shutdown_event
-    _state['session_manager'] = session_manager
-    _state['session_id'] = session_id
-    _state['sync_process'] = sync_process
-    _state['websocket_locks'] = websocket_locks
+    """Initialize shared state from main_server.py.
+
+    Builds adapter views over ``role_state`` so legacy getters
+    (``get_sync_message_queue`` etc.) keep their old observable behavior.
+    The adapters hold a live reference to ``role_state`` — future mutations
+    in main_server.py are reflected without a re-init step.
+    """
+    _state['role_state'] = role_state
     _state['steamworks'] = steamworks
     _state['templates'] = templates
     _state['config_manager'] = config_manager
@@ -62,6 +165,17 @@ def init_shared_state(
     _state['switch_current_catgirl_fast'] = switch_current_catgirl_fast
     _state['init_one_catgirl'] = init_one_catgirl
     _state['remove_one_catgirl'] = remove_one_catgirl
+
+    # Pre-build adapter views (legacy API).
+    # Note: legacy dict was named "websocket_locks" (plural) but the consolidated
+    # field is "websocket_lock" (singular, one per role).
+    _state['sync_message_queue'] = _RoleStateFieldView(role_state, 'sync_message_queue')
+    _state['sync_shutdown_event'] = _RoleStateFieldView(role_state, 'sync_shutdown_event')
+    _state['session_manager'] = _RoleStateFieldView(role_state, 'session_manager')
+    _state['session_id'] = _RoleStateFieldView(role_state, 'session_id')
+    _state['sync_process'] = _RoleStateFieldView(role_state, 'sync_process')
+    _state['websocket_locks'] = _RoleStateFieldView(role_state, 'websocket_lock')
+
 
 def _check_initialized(key: str) -> None:
     """Validate that a state key has been initialized via init_shared_state."""
@@ -73,45 +187,61 @@ def _check_initialized(key: str) -> None:
         )
 
 # Getters for all shared state
+def get_role_state() -> Dict:
+    """Get the canonical role_state dict (``dict[str, RoleState]``).
+
+    New code should prefer this over the per-field legacy getters.
+    """
+    _check_initialized('role_state')
+    return _state['role_state']
+
+
 def get_sync_message_queue() -> Dict:
-    """Get the sync_message_queue dictionary."""
+    """Get a dict-like view of per-role sync_message_queue.
+
+    Backed by ``role_state`` via ``_RoleStateFieldView``.
+    """
     _check_initialized('sync_message_queue')
     return _state['sync_message_queue']
 
 
 def get_sync_shutdown_event() -> Dict:
-    """Get the sync_shutdown_event dictionary."""
+    """Get a dict-like view of per-role sync_shutdown_event."""
     _check_initialized('sync_shutdown_event')
     return _state['sync_shutdown_event']
 
 
 def get_session_manager() -> Dict:
-    """Get the session_manager dictionary."""
+    """Get a dict-like view of per-role session_manager."""
     _check_initialized('session_manager')
     return _state['session_manager']
 
 
 def get_session_id() -> Dict:
-    """Get the session_id dictionary."""
+    """Get a dict-like view of per-role session_id."""
     _check_initialized('session_id')
     return _state['session_id']
 
 
 def get_sync_process() -> Dict:
-    """Get the sync_process dictionary."""
+    """Get a dict-like view of per-role sync_process."""
     _check_initialized('sync_process')
     return _state['sync_process']
 
 
 def get_websocket_locks() -> Dict:
-    """Get the websocket_locks dictionary."""
+    """Get a dict-like view of per-role websocket_lock.
+
+    Note: legacy plural name preserved for API compatibility; the underlying
+    field on RoleState is ``websocket_lock`` (singular).
+    """
     _check_initialized('websocket_locks')
     return _state['websocket_locks']
 
 
 def get_steamworks():
     """Get the steamworks instance.
-    
+
     Note: This may return None if Steamworks failed to initialize
     (e.g., Steam client not running). Callers must handle None gracefully.
     We do NOT call _check_initialized here because None is a valid value.

--- a/main_server.py
+++ b/main_server.py
@@ -78,6 +78,8 @@ try:
     from fastapi.templating import Jinja2Templates # noqa
     from threading import Thread, Event as ThreadEvent # noqa
     from queue import Queue, Empty as QueueEmpty # noqa
+    from dataclasses import dataclass # noqa
+    from typing import Any, Optional # noqa
 except Exception as e:
     logger.exception(f"[Main] Module import failed during startup: {e}")
     raise
@@ -161,26 +163,50 @@ _server_loop: asyncio.AbstractEventLoop | None = None
 
 _config_manager = get_config_manager()
 
+@dataclass
+class RoleState:
+    """单个 catgirl 的 per-k 运行态容器。
+
+    把之前 6 张并列 module-global dict（sync_message_queue / sync_shutdown_event /
+    session_id / sync_process / websocket_locks / session_manager）合并成一个
+    record，由 role_state[k] 统一持有，避免半初始化状态 + 维护成本分散。
+    见 issue #857 / PR #855 review。
+
+    不变量：
+    - sync_message_queue / sync_shutdown_event / websocket_lock 在
+      _ensure_character_slots 一次性构造，之后**永不替换**。特别是
+      websocket_lock —— 替换会让已经 ``async with`` 进来的协程阻塞在一把
+      孤立的旧 Lock 上；如果任何逻辑需要整体重建 role_state[k]，必须
+      把旧 lock 原样传过去。
+    - session_id / sync_process / session_manager 初始为 None，分别由
+      websocket_router / _init_character_resources 后续赋值。
+    """
+    sync_message_queue: Queue
+    sync_shutdown_event: ThreadEvent
+    websocket_lock: asyncio.Lock
+    session_id: Optional[str] = None
+    sync_process: Optional[Thread] = None
+    # 用 Any 而非 core.LLMSessionManager：避免 dataclass 运行时求值 annotation
+    # 时踩到 forward-ref / 循环引用边界
+    session_manager: Optional[Any] = None
+
+
+# 角色名 -> RoleState 的主存储；所有 per-k 同步资源都通过它访问
+role_state: dict[str, RoleState] = {}
+
+
 def cleanup():
     """通知所有同步线程停止"""
     logger.info("正在关闭同步线程...")
-    for k in sync_shutdown_event:
+    for rs in role_state.values():
         try:
-            sync_shutdown_event[k].set()
+            rs.sync_shutdown_event.set()
         except Exception:
             pass
 
 # 只在主进程中注册 cleanup 函数，防止子进程退出时执行清理
 if _IS_MAIN_PROCESS:
     atexit.register(cleanup)
-
-sync_message_queue = {}
-sync_shutdown_event = {}
-session_manager = {}
-session_id = {}
-sync_process = {}
-# 每个角色的websocket操作锁，用于防止preserve/restore与cleanup()之间的竞争
-websocket_locks = {}
 # 角色数据全局变量（会在重载时更新）
 master_name = None
 her_name = None
@@ -207,12 +233,29 @@ def _is_websocket_connected(ws) -> bool:
         return False
 
 
+def _iter_session_managers():
+    """Yield (name, session_manager) for every role with a live session_manager.
+
+    Replaces the old ``session_manager.items()`` pattern after the per-k dicts
+    were consolidated into ``role_state``.
+    """
+    for name, rs in role_state.items():
+        if rs.session_manager is not None:
+            yield name, rs.session_manager
+
+
+def _get_session_manager(name):
+    """Return ``role_state[name].session_manager`` or None — dict.get() equivalent."""
+    if not name:
+        return None
+    rs = role_state.get(name)
+    return rs.session_manager if rs is not None else None
+
+
 def _select_fallback_session_manager():
     """Return a single connected session manager as a safe fallback, if unambiguous."""
     connected = []
-    for name, mgr in session_manager.items():
-        if not mgr:
-            continue
+    for name, mgr in _iter_session_managers():
         ws = getattr(mgr, "websocket", None)
         if _is_websocket_connected(ws):
             connected.append((name, mgr))
@@ -225,9 +268,7 @@ async def _broadcast_to_all_connected(event_payload: dict) -> int:
     """Broadcast an event to all connected WebSocket sessions asynchronously."""
     delivered_count = 0
     # Take a snapshot to avoid RuntimeError from concurrent dict mutation
-    for name, mgr in list(session_manager.items()):
-        if not mgr:
-            continue
+    for name, mgr in list(_iter_session_managers()):
         ws = getattr(mgr, "websocket", None)
         if _is_websocket_connected(ws) and hasattr(ws, "send_json"):
             try:
@@ -259,8 +300,9 @@ async def _handle_agent_event(event: dict):
                 "type": "agent_status_update",
                 "snapshot": event.get("snapshot", {}),
             }
-            if lanlan and lanlan in session_manager:
-                mgr = session_manager.get(lanlan)
+            mgr_for_status = _get_session_manager(lanlan)
+            if lanlan and mgr_for_status is not None:
+                mgr = mgr_for_status
                 ws = getattr(mgr, "websocket", None) if mgr else None
                 if _is_websocket_connected(ws):
                     try:
@@ -272,7 +314,7 @@ async def _handle_agent_event(event: dict):
             return
 
         # Resolve target session manager; fallback to broadcast if lanlan is unknown
-        mgr = session_manager.get(lanlan) if lanlan else None
+        mgr = _get_session_manager(lanlan)
         if not mgr and event_type == "task_update":
             # Broadcast task_update to all connected sessions when lanlan is unresolvable
             task_payload = {"type": "agent_task_update", "task": event.get("task", {})}
@@ -284,7 +326,7 @@ async def _handle_agent_event(event: dict):
         # --- Music Global Broadcasts (Must come before early 'if not mgr' returns) ---
         elif event_type == "music_allowlist_add":
             # Music allowlist is a global UI state, broadcast to all active sessions
-            targets = [mgr] if mgr else list(session_manager.values())
+            targets = [mgr] if mgr else [m for _, m in _iter_session_managers()]
             for target_mgr in targets:
                 if target_mgr and target_mgr.websocket and hasattr(target_mgr.websocket, "send_json"):
                     try:
@@ -300,7 +342,7 @@ async def _handle_agent_event(event: dict):
 
         elif event_type == "music_play_url":
             # Music playback is a global UI action, broadcast to all active sessions
-            targets = [mgr] if mgr else list(session_manager.values())
+            targets = [mgr] if mgr else [m for _, m in _iter_session_managers()]
             for target_mgr in targets:
                 if target_mgr and target_mgr.websocket and hasattr(target_mgr.websocket, "send_json"):
                     try:
@@ -332,7 +374,7 @@ async def _handle_agent_event(event: dict):
                     "[EventBus] %s dropped: no target session for lanlan=%s, active_sessions=%s",
                     event_type,
                     lanlan,
-                    list(session_manager.keys()),
+                    [name for name, _ in _iter_session_managers()],
                 )
                 return
         if not mgr:
@@ -446,37 +488,37 @@ async def _refresh_character_globals():
 def _ensure_character_slots(k: str) -> bool:
     """为单个 catgirl 预备 per-k 同步资源槽位。返回是否为新建角色（决定后续要不要强制启动线程）。
 
-    这些 dict 初始化必须在 async 工作前完成，供 _init_character_resources 读取。
-    全部纯内存操作，同步即可。
+    纯内存的原子操作：要么 role_state[k] 已经存在（什么都不做），要么一次性
+    把 queue / shutdown_event / websocket_lock 三件全部填好。避免旧代码里
+    6 张 dict 用两种不同 sentinel（sync_message_queue vs websocket_locks）
+    各自判断 "角色是否已有槽位" 造成的半初始化风险。
     """
-    is_new = False
-    if k not in sync_message_queue:
-        sync_message_queue[k] = Queue()
-        sync_shutdown_event[k] = ThreadEvent()
-        session_id[k] = None
-        sync_process[k] = None
+    if k not in role_state:
+        role_state[k] = RoleState(
+            sync_message_queue=Queue(),
+            sync_shutdown_event=ThreadEvent(),
+            websocket_lock=asyncio.Lock(),
+        )
         logger.info(f"为角色 {k} 初始化新资源")
-        is_new = True
-    if k not in websocket_locks:
-        websocket_locks[k] = asyncio.Lock()
-    if k not in sync_process:
-        sync_process[k] = None
-    return is_new
+        return True
+    return False
 
 
 async def _init_character_resources(k: str, is_new_character: bool):
     """为单个 catgirl 完成 session_manager 更新 + 同步连接器线程检查/重启。
 
     依赖 module globals: master_name, lanlan_prompt, lanlan_basic_config（调用方负责先刷新）。
-    写入 per-k 槽位: session_manager[k], sync_process[k] —— 不同 k 之间不共享状态，可安全并行。
+    写入 per-k 槽位: role_state[k].session_manager / sync_process —— 不同 k 之间
+    不共享状态，可安全并行。
     """
+    rs = role_state[k]  # 调用方必须先 _ensure_character_slots，保证这里可直接索引
     # 更新或创建session manager（使用最新的prompt）
     # 使用锁保护websocket的preserve/restore操作，防止与cleanup()竞争
-    async with websocket_locks[k]:
+    async with rs.websocket_lock:
         # 如果已存在且已有websocket连接，保留websocket引用
         old_websocket = None
-        if k in session_manager and session_manager[k].websocket:
-            old_websocket = session_manager[k].websocket
+        if rs.session_manager is not None and rs.session_manager.websocket:
+            old_websocket = rs.session_manager.websocket
             logger.info(f"保留 {k} 的现有WebSocket连接")
 
         # 注意：不在这里清理旧session，因为：
@@ -486,13 +528,13 @@ async def _init_character_resources(k: str, is_new_character: bool):
         # 如果旧session_manager有活跃session，保留它，只更新配置相关的字段
 
         # 先检查会话状态（在锁内检查避免竞态条件）
-        has_active_session = k in session_manager and session_manager[k].is_active
+        has_active_session = rs.session_manager is not None and rs.session_manager.is_active
 
         if has_active_session:
             # 有活跃session，不重新创建session_manager，只更新配置
             # 这是为了防止重新创建session_manager时破坏正在运行的session
             try:
-                old_mgr = session_manager[k]
+                old_mgr = rs.session_manager
                 # 更新prompt
                 old_mgr.lanlan_prompt = lanlan_prompt[k].replace('{LANLAN_NAME}', k).replace('{MASTER_NAME}', master_name)
                 # 直接读 module global lanlan_basic_config，避免重复 load + deepcopy
@@ -509,31 +551,33 @@ async def _init_character_resources(k: str, is_new_character: bool):
                 # 如果确实需要更新配置，可以考虑在下次session重启时再应用
         else:
             # 没有活跃session，可以安全地重新创建session_manager
-            session_manager[k] = core.LLMSessionManager(
-                sync_message_queue[k],
+            new_mgr = core.LLMSessionManager(
+                rs.sync_message_queue,
                 k,
                 lanlan_prompt[k].replace('{LANLAN_NAME}', k).replace('{MASTER_NAME}', master_name)
             )
 
             # 将websocket锁存储到session manager中，供cleanup()使用
-            session_manager[k].websocket_lock = websocket_locks[k]
+            new_mgr.websocket_lock = rs.websocket_lock
 
             # 恢复websocket引用（如果存在）
             if old_websocket:
-                session_manager[k].websocket = old_websocket
+                new_mgr.websocket = old_websocket
                 logger.info(f"已恢复 {k} 的WebSocket连接")
+
+            rs.session_manager = new_mgr
 
     # 检查并启动同步连接器线程
     # 如果是新角色，或者线程不存在/已停止，需要启动线程
     need_start_thread = False
     if is_new_character:
         need_start_thread = True
-    elif sync_process[k] is None:
+    elif rs.sync_process is None:
         need_start_thread = True
-    elif hasattr(sync_process[k], 'is_alive') and not await asyncio.to_thread(sync_process[k].is_alive):
+    elif hasattr(rs.sync_process, 'is_alive') and not await asyncio.to_thread(rs.sync_process.is_alive):
         need_start_thread = True
         try:
-            await asyncio.to_thread(sync_process[k].join, timeout=0.1)
+            await asyncio.to_thread(rs.sync_process.join, timeout=0.1)
         except Exception:
             # 注意不要写成 bare except：to_thread 是 cancellation point，
             # 如果 catch 了 BaseException 会吞掉 asyncio.CancelledError
@@ -544,7 +588,7 @@ async def _init_character_resources(k: str, is_new_character: bool):
             _char_name = k
             def _make_status_cb(char_name):
                 def _cb(msg):
-                    mgr = session_manager.get(char_name)
+                    mgr = _get_session_manager(char_name)
                     if not mgr:
                         return
                     loop = _server_loop
@@ -558,65 +602,57 @@ async def _init_character_resources(k: str, is_new_character: bool):
                 return _cb
             _status_cb = _make_status_cb(_char_name)
 
-            sync_process[k] = Thread(
+            new_thread = Thread(
                 target=cross_server.sync_connector_process,
-                args=(sync_message_queue[k], sync_shutdown_event[k], k, f"ws://127.0.0.1:{MONITOR_SERVER_PORT}", {'bullet': False, 'monitor': True}, _status_cb),
+                args=(rs.sync_message_queue, rs.sync_shutdown_event, k, f"ws://127.0.0.1:{MONITOR_SERVER_PORT}", {'bullet': False, 'monitor': True}, _status_cb),
                 daemon=True,
                 name=f"SyncConnector-{k}"
             )
-            sync_process[k].start()
-            logger.info(f"✅ 已为角色 {k} 启动同步连接器线程 ({sync_process[k].name})")
+            rs.sync_process = new_thread
+            new_thread.start()
+            logger.info(f"✅ 已为角色 {k} 启动同步连接器线程 ({new_thread.name})")
             await asyncio.sleep(0.1)  # 线程启动更快，减少等待时间
-            # 与上面 L533 的 is_alive 检查保持一致，走 to_thread 避免任何潜在阻塞
-            if not await asyncio.to_thread(sync_process[k].is_alive):
-                logger.error(f"❌ 同步连接器线程 {k} ({sync_process[k].name}) 启动后立即退出！")
+            # 与上面 is_alive 检查保持一致，走 to_thread 避免任何潜在阻塞
+            if not await asyncio.to_thread(new_thread.is_alive):
+                logger.error(f"❌ 同步连接器线程 {k} ({new_thread.name}) 启动后立即退出！")
             else:
-                logger.info(f"✅ 同步连接器线程 {k} ({sync_process[k].name}) 正在运行")
+                logger.info(f"✅ 同步连接器线程 {k} ({new_thread.name}) 正在运行")
         except Exception as e:
             logger.error(f"❌ 启动角色 {k} 的同步连接器线程失败: {e}", exc_info=True)
 
 
 async def _stop_character_thread(k: str):
     """停止单个 catgirl 的同步连接器线程（最多 3s join）。dict 清理留给调用方顺序做。"""
-    if k in sync_process and sync_process[k] is not None:
-        try:
-            logger.info(f"正在停止角色 {k} 的同步连接器线程...")
-            if k in sync_shutdown_event:
-                sync_shutdown_event[k].set()
-            await asyncio.to_thread(sync_process[k].join, timeout=3)  # 等待线程正常结束
-            if await asyncio.to_thread(sync_process[k].is_alive):
-                logger.warning(f"⚠️ 同步连接器线程 {k} 未能在超时内停止，将作为daemon线程自动清理")
-            else:
-                logger.info(f"✅ 已停止角色 {k} 的同步连接器线程")
-        except Exception as e:
-            logger.warning(f"停止角色 {k} 的同步连接器线程时出错: {e}")
+    rs = role_state.get(k)
+    if rs is None or rs.sync_process is None:
+        return
+    try:
+        logger.info(f"正在停止角色 {k} 的同步连接器线程...")
+        rs.sync_shutdown_event.set()
+        await asyncio.to_thread(rs.sync_process.join, timeout=3)  # 等待线程正常结束
+        if await asyncio.to_thread(rs.sync_process.is_alive):
+            logger.warning(f"⚠️ 同步连接器线程 {k} 未能在超时内停止，将作为daemon线程自动清理")
+        else:
+            logger.info(f"✅ 已停止角色 {k} 的同步连接器线程")
+    except Exception as e:
+        logger.warning(f"停止角色 {k} 的同步连接器线程时出错: {e}")
 
 
 def _cleanup_character_dicts(k: str):
-    """同步清理单个 catgirl 的 per-k dict 槽位。调用前确保对应线程已停或超时。"""
+    """同步清理单个 catgirl 的 per-k 槽位。调用前确保对应线程已停或超时。"""
+    rs = role_state.get(k)
+    if rs is None:
+        return
     # 清理队列（queue.Queue 没有 close/join_thread 方法）
-    if k in sync_message_queue:
-        try:
-            while not sync_message_queue[k].empty():
-                sync_message_queue[k].get_nowait()
-        except QueueEmpty:
-            # while empty + get_nowait 本身是 racy idiom：另一线程可能先 drain 掉，
-            # 导致 get_nowait 抛 Empty。这里队列即将被 del 掉，忽略无害。
-            pass
-        del sync_message_queue[k]
-
-    # 清理其他资源
-    if k in sync_shutdown_event:
-        del sync_shutdown_event[k]
-    if k in session_manager:
-        del session_manager[k]
-    if k in session_id:
-        del session_id[k]
-    if k in sync_process:
-        del sync_process[k]
-    # 与 _ensure_character_slots 对称：避免反复增删同名角色时累积 Lock 对象
-    if k in websocket_locks:
-        del websocket_locks[k]
+    try:
+        while not rs.sync_message_queue.empty():
+            rs.sync_message_queue.get_nowait()
+    except QueueEmpty:
+        # while empty + get_nowait 本身是 racy idiom：另一线程可能先 drain 掉，
+        # 导致 get_nowait 抛 Empty。这里 role_state[k] 即将被 del 掉，忽略无害。
+        pass
+    # 一次 del 原子清掉所有 6 个字段 —— 替代旧代码里 6 张 dict 分别 del 的对称清理
+    del role_state[k]
 
 
 async def initialize_character_data():
@@ -625,8 +661,6 @@ async def initialize_character_data():
     冷路径（启动 / 主人名编辑 / 大规模批量导入）。per-catgirl 编辑请走
     init_one_catgirl / remove_one_catgirl / switch_current_catgirl_fast 这些 fast path。
     """
-    global sync_message_queue, sync_shutdown_event, session_manager, session_id, sync_process, websocket_locks
-
     logger.info("正在加载角色配置...")
 
     # 清理无效的voice_id引用；如果发现旧版 CosyVoice 音色，推入通知缓冲池等前端连接后弹出
@@ -653,7 +687,7 @@ async def initialize_character_data():
             logger.error(f"❌ 初始化角色 {k} 失败: {res}", exc_info=res)
 
     # 清理已删除角色的资源
-    removed_names = [k for k in session_manager.keys() if k not in catgirl_names]
+    removed_names = [k for k in role_state.keys() if k not in catgirl_names]
 
     # N 个 join(timeout=3) 串行最坏要 3N 秒；并行化后墙钟 ≈ 3 秒。
     if removed_names:
@@ -825,12 +859,7 @@ from main_routers.shared_state import init_shared_state # noqa
 # 注意：steamworks 会在 startup 事件中初始化后更新
 if _IS_MAIN_PROCESS:
     init_shared_state(
-        sync_message_queue=sync_message_queue,
-        sync_shutdown_event=sync_shutdown_event,
-        session_manager=session_manager,
-        session_id=session_id,
-        sync_process=sync_process,
-        websocket_locks=websocket_locks,
+        role_state=role_state,
         steamworks=None,  # 延迟初始化，会在 startup 事件中设置
         templates=templates,
         config_manager=_config_manager,
@@ -1141,7 +1170,7 @@ async def on_shutdown():
         
         # 释放 soxr ResampleStream（nanobind C 扩展），避免解释器退出时泄漏警告
         try:
-            for mgr in session_manager.values():
+            for _, mgr in _iter_session_managers():
                 if hasattr(mgr, 'audio_resampler'):
                     mgr.audio_resampler = None
         except Exception as e:


### PR DESCRIPTION
## Summary

Closes #857. Consolidates the 6 parallel per-catgirl module-global dicts in `main_server.py` (`sync_message_queue` / `sync_shutdown_event` / `session_id` / `sync_process` / `websocket_locks` / `session_manager`) into a single `@dataclass RoleState` container, addressing the invariant-fragility CodeRabbit raised in [#855](https://github.com/Project-N-E-K-O/N.E.K.O/pull/855)'s review.

- New `RoleState` dataclass + `role_state: dict[str, RoleState]` master store in `main_server.py`.
- `_ensure_character_slots` / `_cleanup_character_dicts` now do single-dict insert / delete — atomic by construction. The old `sync_message_queue` vs `websocket_locks` sentinel mismatch is gone.
- `_init_character_resources` rebuilds `session_manager` via "build → atomic assign", so concurrent readers see either old or fully-built new manager (never half-built).
- `main_routers/shared_state.py`: legacy getters (`get_sync_message_queue` etc.) **kept with unchanged signature + observable behavior**, now backed by `_RoleStateFieldView` — a `MutableMapping` adapter exposing one field of every `RoleState` entry as a dict-like view (`[k]` / `in` / `del` / `.keys()` / `.items()` / `.get()` / `.pop()`).
- New `get_role_state()` getter for new code.

**Out of scope (intentionally narrow):** consumer call sites in `characters_router` / `config_router` / `workshop_router` / `core.py` / `cross_server.py` are NOT migrated. The adapter keeps them working unchanged; full migration is a separate follow-up.

## Critical invariants preserved

- `websocket_lock` is constructed once in `_ensure_character_slots` and **never replaced** — replacing would strand any coroutine already `async with`-ing on the old `Lock`. Verified by smoke test that re-calling `_ensure_character_slots` keeps the same lock object.
- `sync_process` defaults to `None`; the Thread is only started inside `_init_character_resources`, never as part of `RoleState` construction.
- `session_manager` two-branch logic (in-place update for active session vs full rebuild for inactive) preserved verbatim.
- Adapter `__contains__(k)` returns True iff `k in role_state` **and** the field is non-None. For `session_id`/`sync_process`/`session_manager` (nullable) this matches legacy "key not in dict" semantics after `pop`. For `sync_message_queue`/`sync_shutdown_event`/`websocket_lock` (always non-None post-init) it equals `k in role_state`.
- `del view[k]` clears the field to `None`; full catgirl removal still goes through `del role_state[k]` in `_cleanup_character_dicts`. Matches the only consumer `pop` site (`session_id.pop(name, None)` in websocket_router) which means "release this session" not "remove the catgirl".

## Test plan

- [x] `python scripts/check_async_blocking.py` exits 0
- [x] `python -c "import ast; [ast.parse(open(p, encoding='utf-8').read()) for p in ['main_server.py', 'main_routers/shared_state.py']]"` succeeds
- [x] Smoke test: `_ensure_character_slots('alpha')` creates entry, second call returns `False` (idempotent), `websocket_lock` reference stable across re-ensure
- [x] Smoke test: legacy adapters (`get_sync_message_queue` / `get_session_id` etc.) — `[k]`, `in`, `pop`, `len`, `iter` all return the expected values for both always-present and nullable fields
- [x] Smoke test: `_cleanup_character_dicts('alpha')` removes the entry from both `role_state` and every adapter view
- [ ] End-to-end: add new catgirl via UI → session_manager + sync thread spawn correctly
- [ ] End-to-end: edit catgirl prompt while session active → in-place config update path (no thread restart)
- [ ] End-to-end: delete catgirl → thread joined within 3s, role_state entry gone, adapters report absent
- [ ] End-to-end: switch current catgirl (fast path) → no per-k work, globals refreshed
- [ ] No consumer code (characters_router / config_router / workshop_router / core / cross_server) touched in this PR — verify with `git diff --stat`

## Follow-up

Migrate consumer sites off the `_RoleStateFieldView` adapters onto `get_role_state()` directly, then delete the legacy getters. Tracked separately so this PR stays a pure structural consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

**重构**
- 优化了内部状态管理架构，统一整合了多个独立的状态数据结构，改进了代码组织和维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->