### PR TITLE
fix(proactive): Phase 2 abort 按 speech_id 守卫，避免误伤正常回复 TTS

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2187,11 +2187,19 @@ class LLMSessionManager:
             self._tts_done_queued_for_turn = False
         return True
 
-    async def feed_tts_chunk(self, text: str):
-        """只把文本喂给 TTS 管线，不发送到前端显示。"""
+    async def feed_tts_chunk(self, text: str, expected_speech_id: str | None = None):
+        """只把文本喂给 TTS 管线，不发送到前端显示。
+
+        expected_speech_id: 若不为 None 且与当前 current_speech_id 不匹配（说明
+        调用者所属轮次已被其他路径接管，例如主动搭话流式期间用户打断），丢弃本
+        chunk 并返回。lock 内判定以保证与 enqueue 原子，避免 proactive 文本被错
+        打上新轮次的 speech_id 流入用户正常回复音频。
+        """
         if not self.use_tts:
             return
         async with self.tts_cache_lock:
+            if expected_speech_id is not None and self.current_speech_id != expected_speech_id:
+                return
             if self.tts_ready and self.tts_thread and self.tts_thread.is_alive():
                 try:
                     self._enqueue_tts_text_chunk(self.current_speech_id, text)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3267,6 +3267,12 @@ async def proactive_chat(request: Request):
             nonlocal pipe_count, full_text, aborted
             if not text:
                 return False
+            # sid 已被换掉说明用户已打断并接管本轮，立刻 abort 以停止 LLM stream；
+            # feed_tts_chunk 下面还有 lock 内二次校验兜底，防止 await 期间的 race。
+            if mgr.current_speech_id != proactive_sid:
+                print(f"[{lanlan_name}] Phase 2 检测到 sid 变更（用户已接管），abort")
+                aborted = True
+                return True
             for ch in text:
                 if ch in ('|', '｜'):
                     pipe_count += 1
@@ -3279,7 +3285,7 @@ async def proactive_chat(request: Request):
                 aborted = True
                 return True
             full_text += text
-            await mgr.feed_tts_chunk(text)
+            await mgr.feed_tts_chunk(text, expected_speech_id=proactive_sid)
             return False
         
         try:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3228,6 +3228,10 @@ async def proactive_chat(request: Request):
                 "message": "主动搭话条件未满足（用户近期活跃或语音会话正在进行）"
             })
 
+        # 记录本轮主动搭话起始的 speech_id；abort 时若该 id 已变，说明用户已打断并接管，
+        # 此时再调 handle_new_message() 会把用户正常回复的 TTS 也一起清掉。
+        proactive_sid = mgr.current_speech_id
+
         # --- 构建 LLM + messages (static/dynamic 分离) ---
         phase2_use_vision = bool(screenshot_b64_for_phase2 and has_vision_model)
 
@@ -3366,8 +3370,11 @@ async def proactive_chat(request: Request):
         # --- 结果处理 ---
         print(f"\n[PROACTIVE-DEBUG] Phase 2 STREAM output (aborted={aborted}, tag={source_tag}): {(buffer + full_text)[:300]}\n")
         if aborted or not full_text.strip():
-            await mgr.handle_new_message()
-            logger.debug(f"[{lanlan_name}] Phase 2 abort，已中断 TTS + 前端音频")
+            if mgr.current_speech_id == proactive_sid:
+                await mgr.handle_new_message()
+                logger.debug(f"[{lanlan_name}] Phase 2 abort，已中断 TTS + 前端音频")
+            else:
+                logger.info(f"[{lanlan_name}] Phase 2 abort 但用户已接管 (sid changed)，跳过 TTS 清理避免误伤正常回复")
             return JSONResponse({
                 "success": True,
                 "action": "pass",
@@ -3400,7 +3407,10 @@ async def proactive_chat(request: Request):
         
         # 【加固补齐】如果触发了降级拦截（aborted），立即返回
         if aborted:
-            await mgr.handle_new_message()
+            if mgr.current_speech_id == proactive_sid:
+                await mgr.handle_new_message()
+            else:
+                logger.info(f"[{lanlan_name}] 降级拦截 abort 但用户已接管 (sid changed)，跳过 TTS 清理")
             return JSONResponse({
                 "success": True,
                 "action": "pass",


### PR DESCRIPTION
## Summary

主动搭话 Phase 2 流式中被用户打断时，新回复的 TTS 音频会被误清导致没声音。根因在 [main_routers/system_router.py](main_routers/system_router.py) 两处 abort 分支无条件调 \`handle_new_message()\`。

**race 还原**：
| T | 事件 |
|---|---|
| T0 | Phase 2 \`_emit_safe\` → \`feed_tts_chunk\`，proactive 音频在 queue |
| T1 | 用户发文本 → 触发新 LLM response |
| T2 | 新回复首 chunk → callback 调 \`handle_new_message\`：清 queue（丢 proactive 音频，✅ 预期）+ 设新 speech_id **S1** |
| T3 | 新回复继续流，TTS 合成音频（speech_id=S1）入 queue |
| T4 | Phase 2 因 timeout / 空 text / [PASS] 被判 \`aborted=True\` |
| T5 | **走到第二次 \`handle_new_message\`**：drain queue（丢 T3 的 S1 音频 ❌）+ 换 speech_id S2 |

\`_clear_tts_pipeline\` 的 \`await asyncio.sleep(0.02)\` + 二次 drain（[core.py:392-397](main_logic/core.py:392)）恰好给 T3 的音频落队留了窗口期，把新回复的音频也扫走。

**修法**：在 \`prepare_proactive_delivery\` 后 snapshot \`proactive_sid = mgr.current_speech_id\`，abort 时仅当 \`mgr.current_speech_id == proactive_sid\` 才调 \`handle_new_message()\`。sid 已变 → 用户已接管，proactive 音频早被 T2 的首次 \`handle_new_message\` 清过了，再清就是误伤。

## Test plan

- [ ] 手测：主动搭话 Phase 2 刚开始流就立刻发文本消息，确认新回复语音正常播放
- [ ] 手测：主动搭话独立触发（用户无打断），Phase 2 命中 [PASS] / 空回复 / timeout 三种 abort 路径，确认 TTS 正常被切断（行为不回退）
- [ ] 手测：Phase 2 正常走完（未 abort 未打断），确认 \`finish_proactive_delivery\` 流程未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了系统在向用户播放语音期间的接管处理：当用户中途回复时，系统会停止向前端继续播放不再相关的语音片段，并且仅在当前播放会话仍然匹配时才执行音频清理，避免误清理导致的新回复音频中断或丢失，提升交互连贯性与体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->