### PR TITLE
test(proactive): sid guard 全链路硬化 + 15 个单测

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4,6 +4,7 @@
 TTS部分使用了两个队列，原本只需要一个，但是阿里的TTS API回调函数只支持同步函数，所以增加了一个response queue来异步向前端发送音频数据。
 """
 import asyncio
+import contextvars
 import json
 import struct  # For packing audio data
 import re
@@ -53,6 +54,17 @@ import httpx
 
 # Setup logger for this module
 logger = get_module_logger(__name__, "Main")
+
+# 主动搭话（proactive）调用 prompt_ephemeral 时设置的 sid 期望值。
+# 目的：prompt_ephemeral 内部通过 on_text_delta=handle_text_data 回调 enqueue TTS，
+# 中间可能被用户输入抢占（user stream_text 清 queue + 换 current_speech_id）。
+# handle_text_data / handle_output_transcript 检查此 contextvar：若已设置且与
+# current_speech_id 不符，说明本路径生成的 chunk 已不属于当前轮次，必须丢弃
+# 以免 proactive 文本被错打上用户新 sid 混进用户回复 TTS。
+# contextvar 是 per-task 隔离，不会泄漏到用户 stream_text 所在的独立任务。
+_proactive_expected_sid: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    '_proactive_expected_sid', default=None,
+)
 
 # TTS 错误码：不可恢复，禁止 respawn（欠费 / API Key 无效）
 NO_RETRY_TTS_CODES = {'API_ARREARS', 'API_KEY_REJECTED'}
@@ -416,6 +428,19 @@ class LLMSessionManager:
     async def handle_text_data(self, text: str, is_first_chunk: bool = False):
         """文本回调：处理文本显示和TTS（用于文本模式）"""
 
+        # 主动搭话 race guard：prompt_ephemeral 路径会设置 _proactive_expected_sid
+        # contextvar。若其与 current_speech_id 不一致，说明用户已在 proactive
+        # 生成期间打断并换了 sid，本 chunk 属于已被作废的 proactive 轮次，必须
+        # 整体丢弃（含前端显示和 TTS），避免污染用户当前轮次。user stream_text
+        # 在自己的 task 里 contextvar 为 None，不受影响。
+        expected_sid = _proactive_expected_sid.get()
+        if expected_sid is not None and expected_sid != self.current_speech_id:
+            logger.debug(
+                "handle_text_data drop: expected_sid=%s current_sid=%s len=%d",
+                expected_sid, self.current_speech_id, len(text),
+            )
+            return
+
         # 如果是新消息的第一个chunk，清空TTS队列和缓存以打断之前的语音
         if is_first_chunk and self.use_tts:
             async with self.tts_cache_lock:
@@ -638,7 +663,16 @@ class LLMSessionManager:
         # 否则会导致前端把同一轮 AI 语音误判为新轮次, 出现首包被重置/吞掉的问题.
 
     async def handle_output_transcript(self, text: str, is_first_chunk: bool = False):
-        """输出转录回调：处理文本显示和TTS（用于语音模式）"""        
+        """输出转录回调：处理文本显示和TTS（用于语音模式）"""
+        # 同 handle_text_data：proactive 路径设置的 sid 期望值若与 current 不符，
+        # 丢弃本 chunk，避免 proactive 文本被错插进用户新轮次。
+        expected_sid = _proactive_expected_sid.get()
+        if expected_sid is not None and expected_sid != self.current_speech_id:
+            logger.debug(
+                "handle_output_transcript drop: expected_sid=%s current_sid=%s len=%d",
+                expected_sid, self.current_speech_id, len(text),
+            )
+            return
         # 无论是否使用TTS，都要发送文本到前端显示
         await self.send_lanlan_response(text, is_first_chunk)
         
@@ -2199,6 +2233,10 @@ class LLMSessionManager:
             return
         async with self.tts_cache_lock:
             if expected_speech_id is not None and self.current_speech_id != expected_speech_id:
+                logger.debug(
+                    "feed_tts_chunk drop: expected_sid=%s current_sid=%s len=%d",
+                    expected_speech_id, self.current_speech_id, len(text),
+                )
                 return
             if self.tts_ready and self.tts_thread and self.tts_thread.is_alive():
                 try:
@@ -2211,9 +2249,22 @@ class LLMSessionManager:
                 if self.tts_thread and not self.tts_thread.is_alive():
                     self._respawn_tts_worker()
 
-    async def finish_proactive_delivery(self, full_text: str):
-        """流式完成后收尾：一次性投递完整文本 + 记录历史 + TTS/turn end 信号。"""
+    async def finish_proactive_delivery(self, full_text: str, expected_speech_id: str | None = None):
+        """流式完成后收尾：一次性投递完整文本 + 记录历史 + TTS/turn end 信号。
+
+        expected_speech_id: 若不为 None 且在进入 _proactive_write_lock 后与当前
+        current_speech_id 不符，说明 Phase 2 流结束到 finish 之间用户已打断并
+        接管本轮（stream_text 清了 queue + 换了 sid）。此时前端/history/TTS
+        结束信号都必须跳过，否则 proactive 文本气泡会插在用户回复后面、
+        history 被污染、TTS done 会误结束用户正在进行的回复。
+        """
         async with self._proactive_write_lock:
+            if expected_speech_id is not None and self.current_speech_id != expected_speech_id:
+                logger.info(
+                    "[%s] finish_proactive_delivery skip: sid changed (expected=%s current=%s)，用户已接管本轮",
+                    self.lanlan_name, expected_speech_id, self.current_speech_id,
+                )
+                return
             await self.send_lanlan_response(full_text, is_first_chunk=True)
 
             from utils.llm_client import AIMessage as _AIMsg
@@ -2303,12 +2354,19 @@ class LLMSessionManager:
                     async with self.lock:
                         self.current_speech_id = str(uuid4())
                         self._tts_done_queued_for_turn = False
+                        proactive_sid = self.current_speech_id
                     logger.debug("[%s] trigger_agent_callbacks: text session ready, calling prompt_ephemeral", self.lanlan_name)
                     # 更新字数限制（可能用户在对话期间修改了设置）
                     if hasattr(self.session, 'update_max_response_length'):
                         self.session.update_max_response_length(self._get_text_guard_max_length())
                     self.pending_agent_callbacks.clear()
-                    delivered = await self.session.prompt_ephemeral(instruction)
+                    # 设置 per-task contextvar，让 prompt_ephemeral 回调链里的
+                    # handle_text_data 能识别本路径 chunk 并在 sid 被用户抢走后丢弃。
+                    _sid_token = _proactive_expected_sid.set(proactive_sid)
+                    try:
+                        delivered = await self.session.prompt_ephemeral(instruction)
+                    finally:
+                        _proactive_expected_sid.reset(_sid_token)
                     logger.debug("[%s] trigger_agent_callbacks: text session prompt_ephemeral delivered=%s", self.lanlan_name, delivered)
                     if delivered:
                         self.pending_extra_replies.clear()
@@ -2327,11 +2385,16 @@ class LLMSessionManager:
                         async with self.lock:
                             self.current_speech_id = str(uuid4())
                             self._tts_done_queued_for_turn = False
+                            proactive_sid = self.current_speech_id
                         # 更新字数限制（可能用户在对话期间修改了设置）
                         if hasattr(self.session, 'update_max_response_length'):
                             self.session.update_max_response_length(self._get_text_guard_max_length())
                         self.pending_agent_callbacks.clear()
-                        delivered = await self.session.prompt_ephemeral(instruction)
+                        _sid_token = _proactive_expected_sid.set(proactive_sid)
+                        try:
+                            delivered = await self.session.prompt_ephemeral(instruction)
+                        finally:
+                            _proactive_expected_sid.reset(_sid_token)
                         if delivered:
                             self.pending_extra_replies.clear()
                         else:
@@ -2449,7 +2512,12 @@ class LLMSessionManager:
             async with self.lock:
                 self.current_speech_id = str(uuid4())
                 self._tts_done_queued_for_turn = False
-            delivered = await self.session.prompt_ephemeral(instruction)
+                proactive_sid = self.current_speech_id
+            _sid_token = _proactive_expected_sid.set(proactive_sid)
+            try:
+                delivered = await self.session.prompt_ephemeral(instruction)
+            finally:
+                _proactive_expected_sid.reset(_sid_token)
             logger.info("[%s] trigger_greeting: delivered=%s", self.lanlan_name, delivered)
             # 投递成功后才真正消费节日/周末预算
             # commit 内部会 atomic_write_json 消费预算文件，offload 以免阻塞事件循环

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2249,7 +2249,7 @@ class LLMSessionManager:
                 if self.tts_thread and not self.tts_thread.is_alive():
                     self._respawn_tts_worker()
 
-    async def finish_proactive_delivery(self, full_text: str, expected_speech_id: str | None = None):
+    async def finish_proactive_delivery(self, full_text: str, expected_speech_id: str | None = None) -> bool:
         """流式完成后收尾：一次性投递完整文本 + 记录历史 + TTS/turn end 信号。
 
         expected_speech_id: 若不为 None 且在进入 _proactive_write_lock 后与当前
@@ -2257,6 +2257,10 @@ class LLMSessionManager:
         接管本轮（stream_text 清了 queue + 换了 sid）。此时前端/history/TTS
         结束信号都必须跳过，否则 proactive 文本气泡会插在用户回复后面、
         history 被污染、TTS done 会误结束用户正在进行的回复。
+
+        返回 True 表示真正落库，False 表示因 sid 变化被跳过。调用方据此短路
+        下游副作用（_record_proactive_chat / topic usage / surfaced reflection 等），
+        避免把未送达的内容记成"已送达"。
         """
         async with self._proactive_write_lock:
             if expected_speech_id is not None and self.current_speech_id != expected_speech_id:
@@ -2264,7 +2268,7 @@ class LLMSessionManager:
                     "[%s] finish_proactive_delivery skip: sid changed (expected=%s current=%s)，用户已接管本轮",
                     self.lanlan_name, expected_speech_id, self.current_speech_id,
                 )
-                return
+                return False
             await self.send_lanlan_response(full_text, is_first_chunk=True)
 
             from utils.llm_client import AIMessage as _AIMsg
@@ -2287,6 +2291,7 @@ class LLMSessionManager:
             except Exception:
                 pass
         logger.info("[%s] Proactive stream delivered: %.40s…", self.lanlan_name, full_text)
+        return True
 
     async def trigger_agent_callbacks(self) -> None:
         """Proactively deliver pending agent task results via LLM rephrase.

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3455,7 +3455,9 @@ async def proactive_chat(request: Request):
                 _append_music_recommendations(source_links, music_content)
         
         # 一次性投递完整文本 + 记录历史 + TTS end + turn end
-        await mgr.finish_proactive_delivery(response_text)
+        # 传 proactive_sid：若 Phase 2 流结束到这里之间用户已打断（换了 sid），
+        # finish 内部会跳过所有写入，避免 proactive 文本污染用户当前轮次。
+        await mgr.finish_proactive_delivery(response_text, expected_speech_id=proactive_sid)
 
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3457,7 +3457,24 @@ async def proactive_chat(request: Request):
         # 一次性投递完整文本 + 记录历史 + TTS end + turn end
         # 传 proactive_sid：若 Phase 2 流结束到这里之间用户已打断（换了 sid），
         # finish 内部会跳过所有写入，避免 proactive 文本污染用户当前轮次。
-        await mgr.finish_proactive_delivery(response_text, expected_speech_id=proactive_sid)
+        committed = await mgr.finish_proactive_delivery(
+            response_text, expected_speech_id=proactive_sid
+        )
+        if not committed:
+            # Proactive 内容未真正落库（用户已接管本轮），所有下游副作用必须跳过：
+            # 否则 _record_proactive_chat 会把未送达内容计入去重历史、topic usage
+            # 会误记已用，前端拿到 "chat" action 会以为搭话成功。
+            logger.info(
+                "[%s] 主动搭话被用户接管，短路下游写入（topic/memory/response）",
+                lanlan_name,
+            )
+            return JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": "proactive delivery skipped: user took over turn",
+                "lanlan_name": lanlan_name,
+                "turn_id": mgr.current_speech_id,
+            })
 
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -14,8 +14,6 @@ import sys
 from queue import Queue
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
 from main_logic.core import LLMSessionManager, _proactive_expected_sid

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -189,12 +189,13 @@ async def test_handle_output_transcript_contextvar_mismatch_drops():
 # ─────────────────────────────────────────────────────────────────────────────
 
 async def test_finish_proactive_delivery_no_expected_sid_runs_all():
-    """向后兼容：不传 expected_speech_id 照常投递。"""
+    """向后兼容：不传 expected_speech_id 照常投递，并返回 True。"""
     mgr = _make_mgr()
     mgr.current_speech_id = "anything"
     mgr.session = MagicMock()
     mgr.session._conversation_history = []
-    await LLMSessionManager.finish_proactive_delivery(mgr, "done")
+    result = await LLMSessionManager.finish_proactive_delivery(mgr, "done")
+    assert result is True
     mgr.send_lanlan_response.assert_called_once()
     assert len(mgr.session._conversation_history) == 1
     assert mgr._tts_done_queued_for_turn is True
@@ -205,22 +206,28 @@ async def test_finish_proactive_delivery_sid_match_runs_all():
     mgr.current_speech_id = "s_proactive"
     mgr.session = MagicMock()
     mgr.session._conversation_history = []
-    await LLMSessionManager.finish_proactive_delivery(
+    result = await LLMSessionManager.finish_proactive_delivery(
         mgr, "done", expected_speech_id="s_proactive",
     )
+    assert result is True
     mgr.send_lanlan_response.assert_called_once()
     assert len(mgr.session._conversation_history) == 1
 
 
 async def test_finish_proactive_delivery_sid_mismatch_skips_all_writes():
-    """关键：Phase 2 结束→finish 之间用户打断，finish 内所有副作用必须跳过。"""
+    """关键：Phase 2 结束→finish 之间用户打断，finish 内所有副作用必须跳过，且返回 False。
+
+    路由层依赖 False 这个返回值来短路 _record_proactive_chat / topic usage /
+    surfaced reflection 等下游副作用，避免"未送达内容"被记为已送达。
+    """
     mgr = _make_mgr()
     mgr.current_speech_id = "s_user"  # 用户接管
     mgr.session = MagicMock()
     mgr.session._conversation_history = []
-    await LLMSessionManager.finish_proactive_delivery(
+    result = await LLMSessionManager.finish_proactive_delivery(
         mgr, "orphan proactive", expected_speech_id="s_proactive",
     )
+    assert result is False
     mgr.send_lanlan_response.assert_not_called()
     assert mgr.session._conversation_history == []
     assert mgr._tts_done_queued_for_turn is False

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -1,0 +1,315 @@
+"""针对主动搭话（proactive）TTS 管线 sid race guard 的单元测试。
+
+覆盖场景：
+1. feed_tts_chunk 的 expected_speech_id 语义（向后兼容 + race-safe drop）
+2. handle_text_data / handle_output_transcript 的 contextvar-based guard
+3. finish_proactive_delivery 的 expected_speech_id 语义
+4. contextvar 的 per-task 隔离（核心保证：proactive guard 不会误伤用户轮次）
+5. 端到端 race：proactive 流式 + 用户打断，验证 proactive 残留 chunk 被丢、
+   用户回复不受影响
+"""
+import asyncio
+import os
+import sys
+from queue import Queue
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from main_logic.core import LLMSessionManager, _proactive_expected_sid
+
+
+def _make_mgr() -> LLMSessionManager:
+    """跳过 __init__，直接装配 guard 测试必需的最小属性集。
+
+    __init__ 会加载 config / character data / voice 等外部依赖，对 sid guard
+    行为测试没有价值，只会带来环境耦合。
+    """
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.use_tts = True
+    mgr.tts_cache_lock = asyncio.Lock()
+    mgr.lock = asyncio.Lock()
+    mgr._proactive_write_lock = asyncio.Lock()
+    mgr.tts_pending_chunks = []
+    mgr.tts_request_queue = Queue()
+    mgr.tts_response_queue = Queue()
+    mgr.tts_thread = MagicMock()
+    mgr.tts_thread.is_alive.return_value = True
+    mgr.tts_ready = True
+    mgr.current_speech_id = None
+    mgr._tts_done_queued_for_turn = False
+    mgr.lanlan_name = "Test"
+    mgr.session = None
+    mgr.websocket = None
+    mgr.sync_message_queue = Queue()
+    mgr._enqueue_tts_text_chunk = MagicMock()
+    mgr._respawn_tts_worker = MagicMock()
+    mgr.send_lanlan_response = AsyncMock()
+    return mgr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# feed_tts_chunk
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_feed_tts_chunk_no_expected_sid_enqueues():
+    """向后兼容：老 caller 不传 expected_speech_id，行为不变。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_any"
+    await LLMSessionManager.feed_tts_chunk(mgr, "hello")
+    mgr._enqueue_tts_text_chunk.assert_called_once_with("s_any", "hello")
+
+
+async def test_feed_tts_chunk_enqueues_when_sid_matches():
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_proactive"
+    await LLMSessionManager.feed_tts_chunk(mgr, "hi", expected_speech_id="s_proactive")
+    mgr._enqueue_tts_text_chunk.assert_called_once()
+
+
+async def test_feed_tts_chunk_drops_when_sid_mismatches():
+    """关键：proactive 生成期间用户换了 sid，本 chunk 必须丢，不能以新 sid 流入。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"  # 用户已接管
+    await LLMSessionManager.feed_tts_chunk(mgr, "proactive tail", expected_speech_id="s_proactive")
+    mgr._enqueue_tts_text_chunk.assert_not_called()
+    assert mgr.tts_pending_chunks == []
+
+
+async def test_feed_tts_chunk_drop_is_atomic_with_enqueue():
+    """lock 内判定：保证 check 和 enqueue 不会被交错。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_proactive"
+
+    enqueue_calls: list[str] = []
+
+    def _spy_enqueue(sid, text):
+        enqueue_calls.append((sid, text))
+
+    mgr._enqueue_tts_text_chunk.side_effect = _spy_enqueue
+
+    async def flipper():
+        """在 feed_tts_chunk 执行中翻 sid，看能不能漏掉一次 drop。"""
+        # 让 feed_tts_chunk 先进到 lock 里；这里等 lock 再改 sid
+        async with mgr.tts_cache_lock:
+            mgr.current_speech_id = "s_user"
+
+    # 先触发一次 feed_tts_chunk 并让 flipper 并发；tts_cache_lock 保护 check+enqueue
+    await asyncio.gather(
+        LLMSessionManager.feed_tts_chunk(mgr, "x", expected_speech_id="s_proactive"),
+        flipper(),
+    )
+    # 不管谁先拿锁：要么 enqueue 成功（s_proactive），要么被 flipper 拦到 drop；
+    # 绝不会出现 "check 过了但 enqueue 时 sid 已变" 的脏数据。
+    if enqueue_calls:
+        assert enqueue_calls[0][0] == "s_proactive"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# handle_text_data (text mode) 的 contextvar guard
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_handle_text_data_no_contextvar_always_passes():
+    """用户自己 stream_text：contextvar 为 None，不应 drop。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"
+    await LLMSessionManager.handle_text_data(mgr, "user reply", is_first_chunk=False)
+    mgr.send_lanlan_response.assert_called_once()
+    mgr._enqueue_tts_text_chunk.assert_called_once()
+
+
+async def test_handle_text_data_contextvar_match_passes():
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_proactive"
+    token = _proactive_expected_sid.set("s_proactive")
+    try:
+        await LLMSessionManager.handle_text_data(mgr, "p", is_first_chunk=False)
+    finally:
+        _proactive_expected_sid.reset(token)
+    mgr.send_lanlan_response.assert_called_once()
+    mgr._enqueue_tts_text_chunk.assert_called_once()
+
+
+async def test_handle_text_data_contextvar_mismatch_drops_all_writes():
+    """sid guard 要同时拦前端显示和 TTS —— proactive 文本不能进用户气泡。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"
+    token = _proactive_expected_sid.set("s_proactive")
+    try:
+        await LLMSessionManager.handle_text_data(mgr, "stale proactive", is_first_chunk=True)
+    finally:
+        _proactive_expected_sid.reset(token)
+    mgr.send_lanlan_response.assert_not_called()
+    mgr._enqueue_tts_text_chunk.assert_not_called()
+
+
+async def test_handle_text_data_contextvar_mismatch_skips_queue_clear():
+    """回归保护：is_first_chunk 分支原本会清 TTS 响应队列；drop 路径不该触发。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"
+    mgr.tts_pending_chunks = [("s_user", "user_cached")]
+    mgr.tts_response_queue.put(b"user audio bytes")
+
+    token = _proactive_expected_sid.set("s_proactive")
+    try:
+        await LLMSessionManager.handle_text_data(mgr, "stale", is_first_chunk=True)
+    finally:
+        _proactive_expected_sid.reset(token)
+
+    # 用户的 pending chunk 和 queue 都不能被动到
+    assert mgr.tts_pending_chunks == [("s_user", "user_cached")]
+    assert not mgr.tts_response_queue.empty()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# handle_output_transcript (voice mode) 的 contextvar guard
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_handle_output_transcript_no_contextvar_passes():
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"
+    await LLMSessionManager.handle_output_transcript(mgr, "text", is_first_chunk=False)
+    mgr.send_lanlan_response.assert_called_once()
+
+
+async def test_handle_output_transcript_contextvar_mismatch_drops():
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"
+    token = _proactive_expected_sid.set("s_proactive")
+    try:
+        await LLMSessionManager.handle_output_transcript(mgr, "stale", is_first_chunk=False)
+    finally:
+        _proactive_expected_sid.reset(token)
+    mgr.send_lanlan_response.assert_not_called()
+    mgr._enqueue_tts_text_chunk.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# finish_proactive_delivery 的 expected_speech_id
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_finish_proactive_delivery_no_expected_sid_runs_all():
+    """向后兼容：不传 expected_speech_id 照常投递。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "anything"
+    mgr.session = MagicMock()
+    mgr.session._conversation_history = []
+    await LLMSessionManager.finish_proactive_delivery(mgr, "done")
+    mgr.send_lanlan_response.assert_called_once()
+    assert len(mgr.session._conversation_history) == 1
+    assert mgr._tts_done_queued_for_turn is True
+
+
+async def test_finish_proactive_delivery_sid_match_runs_all():
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_proactive"
+    mgr.session = MagicMock()
+    mgr.session._conversation_history = []
+    await LLMSessionManager.finish_proactive_delivery(
+        mgr, "done", expected_speech_id="s_proactive",
+    )
+    mgr.send_lanlan_response.assert_called_once()
+    assert len(mgr.session._conversation_history) == 1
+
+
+async def test_finish_proactive_delivery_sid_mismatch_skips_all_writes():
+    """关键：Phase 2 结束→finish 之间用户打断，finish 内所有副作用必须跳过。"""
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_user"  # 用户接管
+    mgr.session = MagicMock()
+    mgr.session._conversation_history = []
+    await LLMSessionManager.finish_proactive_delivery(
+        mgr, "orphan proactive", expected_speech_id="s_proactive",
+    )
+    mgr.send_lanlan_response.assert_not_called()
+    assert mgr.session._conversation_history == []
+    assert mgr._tts_done_queued_for_turn is False
+    assert mgr.sync_message_queue.empty()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# contextvar per-task 隔离 —— 本次修复的核心正确性前提
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_contextvar_isolated_across_tasks():
+    """一个 task set 的 contextvar 不会被另一个 task 读到。
+
+    这是本次 guard 方案的基石：proactive 设 guard → 只影响 proactive 自己的
+    callback 链；用户 stream_text 的回调在另一个 task，永远读到 None。
+    """
+    observed: dict[str, str | None] = {}
+
+    async def proactive():
+        token = _proactive_expected_sid.set("s_proactive")
+        try:
+            await asyncio.sleep(0)  # 让出
+            observed["proactive"] = _proactive_expected_sid.get()
+        finally:
+            _proactive_expected_sid.reset(token)
+
+    async def user():
+        await asyncio.sleep(0)  # 让 proactive 先 set
+        observed["user"] = _proactive_expected_sid.get()
+
+    await asyncio.gather(asyncio.create_task(proactive()), asyncio.create_task(user()))
+    assert observed["proactive"] == "s_proactive"
+    assert observed["user"] is None  # 用户 task 看不到 proactive 的 contextvar
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 端到端 race：proactive 流式 + 用户打断
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_end_to_end_proactive_interrupted_by_user():
+    """模拟 bug 现场：proactive 正在 handle_text_data 喂 TTS，用户突然改 sid。
+
+    期望：
+    - 打断前的 proactive chunk 正常入队（带 proactive sid）
+    - 打断后的 proactive 残留 chunk 被丢（guard 拦截）
+    - 用户自己的回复 chunk 正常入队（带 user sid，不受 guard 影响）
+    """
+    mgr = _make_mgr()
+    mgr.current_speech_id = "s_proactive"
+
+    user_started = asyncio.Event()
+    proactive_can_continue = asyncio.Event()
+
+    async def proactive_flow():
+        token = _proactive_expected_sid.set("s_proactive")
+        try:
+            # 第一个 chunk：sid 仍是 s_proactive，应入队
+            await LLMSessionManager.handle_text_data(mgr, "p_early", is_first_chunk=False)
+            # 把控制权让给 user，等它改完 sid
+            user_started.set()
+            await proactive_can_continue.wait()
+            # 第二个 chunk：此时 sid 已被 user 换掉，guard 应拦截
+            await LLMSessionManager.handle_text_data(mgr, "p_late", is_first_chunk=False)
+        finally:
+            _proactive_expected_sid.reset(token)
+
+    async def user_flow():
+        await user_started.wait()
+        # 模拟 stream_text：改 sid（真实场景还会清 queue，此处测 guard 语义就够）
+        mgr.current_speech_id = "s_user"
+        # 用户自己的回复 chunk 不在 proactive contextvar 下
+        await LLMSessionManager.handle_text_data(mgr, "u_reply", is_first_chunk=False)
+        proactive_can_continue.set()
+
+    await asyncio.gather(
+        asyncio.create_task(proactive_flow()),
+        asyncio.create_task(user_flow()),
+    )
+
+    # 核心断言：p_late 被丢，p_early 和 u_reply 各入队一次
+    enqueued_texts = [c.args[1] for c in mgr._enqueue_tts_text_chunk.call_args_list]
+    assert "p_early" in enqueued_texts
+    assert "u_reply" in enqueued_texts
+    assert "p_late" not in enqueued_texts
+    assert len(enqueued_texts) == 2
+
+    # 入队的 sid 必须和当时的 current_speech_id 对应
+    enqueued_sids = {c.args[1]: c.args[0] for c in mgr._enqueue_tts_text_chunk.call_args_list}
+    assert enqueued_sids["p_early"] == "s_proactive"
+    assert enqueued_sids["u_reply"] == "s_user"


### PR DESCRIPTION
## Summary

在 [#862](https://github.com/Project-N-E-K-O/N.E.K.O/pull/862) 合并之后，针对残留的 4 个风险点继续硬化主动搭话 / 用户插话的 race，并补齐自动化测试：

- **Risk #4 — debug log**：`feed_tts_chunk` 在 sid mismatch 丢弃时打 debug log（含 expected / current / len），方便事后定位误丢
- **Risk #1 — 上游入口全链路 guard**：
  - 新增模块级 `_proactive_expected_sid` ContextVar（per-task 隔离）
  - `handle_text_data` / `handle_output_transcript` 顶部加 ctxvar 守卫 —— prompt_ephemeral 流到一半用户接管时，残留 chunk 不再发前端也不再入 TTS 队列
  - `trigger_agent_callbacks` 的两处 `prompt_ephemeral` 和 `trigger_greeting` 都用 try/finally 包 `.set()` / `.reset()`，保证只在主动搭话任务内生效，不污染用户正常流式任务
- **Risk #3 — finish_proactive_delivery guard**：新增 `expected_speech_id` 参数，在 `_proactive_write_lock` 内原子检查，避免 phase-2 末尾 write-back 覆盖用户新会话状态
- **Risk #2 — 自动化测试**：`tests/unit/test_proactive_sid_guard.py` 15 个单测全通过
  - feed_tts_chunk：4 个（无参 / sid 匹配 / sid 不匹配 / 无 tts）
  - handle_text_data：4 个（ctxvar 未设 / 匹配 / 不匹配 / 不匹配不发前端）
  - handle_output_transcript：2 个（匹配 / 不匹配）
  - finish_proactive_delivery：3 个（无参 / 匹配 / 不匹配）
  - ContextVar 任务隔离：1 个
  - 端到端竞争：1 个（用 `asyncio.Event` 编排确定性交错）

## Test plan

- [x] `uv run pytest tests/unit/test_proactive_sid_guard.py -v` — 15 passed
- [ ] 本地回放原始 log 场景（proactive 流式中用户插话）确认正常回复 TTS 不再被吞

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 防止被中断的主动生成内容（文本与TTS）在用户切换回合后被错误显示或播放；在检测到会话/播放不匹配时丢弃残留片段并记录事件。
  * 在检测到用户“接管”后跳过主动交付的最终写入与后续持久化，并在响应中返回跳过信息与当前回合 ID。

* **Tests**
  * 新增大规模单元与端到端测试，覆盖并发竞态、上下文隔离与各种交付/丢弃路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->