### PR TITLE
fix(proactive): voice fudge 三层用户说话守卫（A+B+C）

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1287,7 +1287,13 @@ class OmniRealtimeClient:
             return False
         # A: 现有 _client_vad_active + grace 检查（sustained VAD 信号兜底）。
         # Grace 已从 2s 扩到 6s，覆盖自然停顿。
-        if self._rnnoise_vad_active:
+        # 门控条件：存在可靠 VAD 信号源。
+        #   - server-VAD 后端（Qwen/OpenAI）：server 的 speech_started/stopped 可靠，
+        #     不依赖 RNNoise。特别覆盖 16kHz 移动端长句 >8s 的场景（_user_recent_activity
+        #     在 speech_started 打点后 8s 过期，而用户还在说，需要 _client_vad_active 兜底）。
+        #   - RNNoise 客户端 VAD（48kHz 桌面 + Gemini/lanlan.app+free）
+        # RMS-only 路径（16kHz 无 server-VAD）信号太噪，不信任，依赖 _user_recent_activity。
+        if self._has_server_vad or self._rnnoise_vad_active:
             if self._client_vad_active:
                 logger.debug("prompt_ephemeral: skipped — user speaking (VAD active)")
                 return False

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1600,8 +1600,13 @@ class OmniRealtimeClient:
                     # Priority 1: server VAD → sync to unified _client_vad_active
                     self._client_vad_active = True
                     self._client_vad_last_speech_time = self._last_speech_time
-                    # B: server-VAD 也喂给 _user_recent_activity，保持各 VAD 源对称
-                    self._user_recent_activity_time = self._last_speech_time
+                    # B: server-VAD 也喂给 _user_recent_activity，保持各 VAD 源对称。
+                    # 但 fudge 注入期间 server 会对我们自己 append 的 fudge 音频
+                    # 回 speech_started —— 这不是真用户活动，若打点 prompt_ephemeral
+                    # 循环会检测到 _user_recent_activity_time > _inject_start 而自 abort，
+                    # 并在之后 8s 内阻塞下一次 fudge（入口 guard 一起被污染）。
+                    if not self._proactive_injecting:
+                        self._user_recent_activity_time = self._last_speech_time
                     if self._is_responding:
                         logger.info("Handling interruption")
                         await self.handle_interruption()
@@ -1613,7 +1618,10 @@ class OmniRealtimeClient:
                     # Update timestamp so grace period starts from speech end
                     _now = time.time()
                     self._client_vad_last_speech_time = _now
-                    self._user_recent_activity_time = _now
+                    # 同 speech_started：fudge 自己的音频结束时 server 也会 emit
+                    # speech_stopped，不能当成真用户活动打点。
+                    if not self._proactive_injecting:
+                        self._user_recent_activity_time = _now
                 elif event_type == "conversation.item.input_audio_transcription.completed":
                     self._print_input_transcript = True
                     transcript = event.get("transcript", "")

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -296,11 +296,21 @@ class OmniRealtimeClient:
         # All native-image paths use _client_vad_active to adjust send rate
         self._client_vad_active = False  # 语音活动检测（统一标志）
         self._client_vad_last_speech_time = 0.0  # 上次检测到语音的时间戳
-        self._client_vad_grace_period = 2.0  # 语音结束后保持活跃的宽限期（秒）
+        # Grace 从 2.0 提到 6.0：覆盖用户说话时的自然停顿（换气/思考），
+        # 避免 prompt_ephemeral 在用户两句话中间的静默缝隙误触发。
+        self._client_vad_grace_period = 6.0  # 语音结束后保持活跃的宽限期（秒）
         self._client_vad_threshold = 500  # RMS 能量阈值（int16 范围，fallback用）
         self._speech_detect_start = 0.0  # RNNoise 连续检测到语音的起始时间
         self._speech_sustain_threshold = 0.5  # 需持续 500ms 才算真正说话（防噪音误触）
         self._rnnoise_vad_active = False  # RNNoise VAD 是否正在运行（48kHz + denoiser ok）
+        # Fudge 保护专用信号：与 _client_vad_active 解耦，记录"最近任何一帧 RNNoise
+        # 判定为语音（>0.4，无需 sustain 500ms）或 server-VAD speech_started"的时刻。
+        # 解决两个 _client_vad_active 覆盖不到的窗口：
+        #   1. 用户说话首 500ms 还未达 sustain 阈值时
+        #   2. 句子间停顿 >grace_period 时 _client_vad_active flip False 的瞬间
+        # prompt_ephemeral 在此窗口内直接放弃注入。
+        self._user_recent_activity_time = 0.0
+        self._user_recent_activity_window = 8.0
 
         # 防止log刷屏机制（当websocket关闭后）
         self._last_ws_none_warning_time = 0.0  # 上次websocket为None警告的时间戳
@@ -474,6 +484,7 @@ class OmniRealtimeClient:
         self._client_vad_last_speech_time = 0.0
         self._speech_detect_start = 0.0
         self._rnnoise_vad_active = False
+        self._user_recent_activity_time = 0.0
         if self._audio_processor is not None:
             self._audio_processor.reset()
 
@@ -875,6 +886,10 @@ class OmniRealtimeClient:
             if _rnnoise_vad_live:
                 # Priority 2: RNNoise speech probability with sustained threshold
                 if self._audio_processor.speech_probability > 0.4:
+                    # B: 单帧 RNNoise 判定为语音就立即打点，独立于 sustain。
+                    # _client_vad_active 仍需 500ms sustain，_user_recent_activity
+                    # 只看"最近是否发声"，fudge guard 用它兜住首 500ms 和停顿缝隙。
+                    self._user_recent_activity_time = current_time
                     if self._speech_detect_start == 0.0:
                         self._speech_detect_start = current_time
                     elif current_time - self._speech_detect_start >= self._speech_sustain_threshold:
@@ -890,6 +905,10 @@ class OmniRealtimeClient:
                     if rms > self._client_vad_threshold:
                         self._client_vad_last_speech_time = current_time
                         self._client_vad_active = True
+                        # RMS 噪音率高，但若 RNNoise 不可用（16kHz/移动端），
+                        # RMS 是唯一信号，也喂给 B 兜底。阈值已经是 500（较高），
+                        # 一般环境噪音达不到。
+                        self._user_recent_activity_time = current_time
         
         # Suppress mic → server during proactive nudge injection (VAD above still updates)
         if self._proactive_injecting:
@@ -1255,15 +1274,24 @@ class OmniRealtimeClient:
         if self._is_responding:
             logger.debug("prompt_ephemeral: skipped — already responding")
             return False
-        # Client VAD guard: only when RNNoise VAD is actively processing audio
-        # (48kHz input + denoiser running). For 16kHz/mobile or when RNNoise is
-        # unavailable, VAD falls back to RMS which is too noisy — skip to avoid
-        # permanently blocking proactive.
+        # ── User-speech guards ───────────────────────────────────────
+        # B: 先用独立的 _user_recent_activity_time 判定近期是否有语音帧；
+        # 此信号不依赖 sustain，覆盖用户说话首 500ms 与句间停顿缝隙。
+        # 适用所有 VAD 源（RNNoise / server-VAD / RMS），所以不再门控在
+        # _rnnoise_vad_active 下 —— RMS 阈值 500 已较保守，误触可接受，
+        # 相比"fudge 切断用户说话"的体验损失值得。
+        _now = time.time()
+        if _now - self._user_recent_activity_time < self._user_recent_activity_window:
+            logger.debug("prompt_ephemeral: skipped — user recently active (%.2fs ago)",
+                         _now - self._user_recent_activity_time)
+            return False
+        # A: 现有 _client_vad_active + grace 检查（sustained VAD 信号兜底）。
+        # Grace 已从 2s 扩到 6s，覆盖自然停顿。
         if self._rnnoise_vad_active:
             if self._client_vad_active:
                 logger.debug("prompt_ephemeral: skipped — user speaking (VAD active)")
                 return False
-            if time.time() - self._client_vad_last_speech_time < self._client_vad_grace_period:
+            if _now - self._client_vad_last_speech_time < self._client_vad_grace_period:
                 logger.debug("prompt_ephemeral: skipped — VAD grace period")
                 return False
 
@@ -1327,10 +1355,20 @@ class OmniRealtimeClient:
         image_injected = False
 
         try:
+            _inject_start = time.time()
             for chunk_idx, i in enumerate(range(0, len(pcm_data), chunk_size)):
-                # Abort if AI starts responding, or user speaking (only when RNNoise VAD active)
+                # Abort conditions:
+                #   - AI started responding (self-interrupt protection)
+                #   - _client_vad_active sustained-speech fired (RNNoise only)
+                #   - B: any VAD source detected a new speech frame SINCE injection started
+                #     —— 注入过程中用户突然开口也能丢弃残余 chunk，不至于把用户
+                #     语音与 fudge 音频混在一起喂给模型
                 if self._is_responding or (self._rnnoise_vad_active and self._client_vad_active):
                     logger.info("prompt_ephemeral: aborted — user spoke or response started")
+                    await self.clear_audio_buffer()
+                    return False
+                if self._user_recent_activity_time > _inject_start:
+                    logger.info("prompt_ephemeral: aborted — user started speaking during injection")
                     await self.clear_audio_buffer()
                     return False
 
@@ -1562,6 +1600,8 @@ class OmniRealtimeClient:
                     # Priority 1: server VAD → sync to unified _client_vad_active
                     self._client_vad_active = True
                     self._client_vad_last_speech_time = self._last_speech_time
+                    # B: server-VAD 也喂给 _user_recent_activity，保持各 VAD 源对称
+                    self._user_recent_activity_time = self._last_speech_time
                     if self._is_responding:
                         logger.info("Handling interruption")
                         await self.handle_interruption()
@@ -1571,7 +1611,9 @@ class OmniRealtimeClient:
                         await self.on_new_message()
                     self._audio_in_buffer = False
                     # Update timestamp so grace period starts from speech end
-                    self._client_vad_last_speech_time = time.time()
+                    _now = time.time()
+                    self._client_vad_last_speech_time = _now
+                    self._user_recent_activity_time = _now
                 elif event_type == "conversation.item.input_audio_transcription.completed":
                     self._print_input_transcript = True
                     transcript = event.get("transcript", "")
@@ -1675,6 +1717,7 @@ class OmniRealtimeClient:
         self._client_vad_last_speech_time = 0.0
         self._speech_detect_start = 0.0
         self._rnnoise_vad_active = False
+        self._user_recent_activity_time = 0.0
 
         # 保存 debug 音频（RNNoise 处理前后的对比音频）
         if self._audio_processor is not None:
@@ -1728,6 +1771,7 @@ class OmniRealtimeClient:
                 self._client_vad_last_speech_time = 0.0
                 self._speech_detect_start = 0.0
                 self._rnnoise_vad_active = False
+                self._user_recent_activity_time = 0.0
 
                 # 重置音频处理器状态
                 if self._audio_processor is not None:

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -395,6 +395,12 @@
 
         // 如果音量超过阈值(0.01),认为检测到声音
         if (rms > 0.01) {
+            // C: 为前端 proactive guard 持续打点"最近一次有声音"。
+            // 阈值与下面 hasSoundDetected 共用 0.01；这里每帧都写（~16ms 一次），
+            // 不做去抖，保证 proactive tick 能读到最新值。与后端
+            // _user_recent_activity_time 对称：不等 sustain、不等 VAD 判定，
+            // 只要麦克风真的收到过声音就算"用户可能在说话"。
+            S.userRecentSpeechTime = Date.now();
             if (!S.hasSoundDetected) {
                 S.hasSoundDetected = true;
                 console.log('麦克风静音检测：检测到声音，RMS =', rms);

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -264,6 +264,13 @@
     //   几百毫秒，5s 已经是数量级的余裕；超出就让分支 1 的自释放信号接管。
     var PROACTIVE_TURN_STARTUP_GRACE_MS = 5000;
 
+    // C: 用户最近发声的窗口（ms）。和后端 _user_recent_activity_window (8s) 对齐，
+    // 网络来回有延迟时前端守门先挡住，请求根本不发出去，省一个 round-trip。
+    // `S.userRecentSpeechTime` 由 app-audio-capture.js 里的 monitorInputVolume 持续
+    // 写入（RMS > 0.01 每帧打点），这里用一个稍宽于后端的窗口，保证"前端没挡住但
+    // 后端挡住"的 race 不至于频繁发生（fudge 空跑成本低，但可以省则省）。
+    var USER_RECENT_SPEECH_WINDOW_MS = 8000;
+
     function _isAssistantSpeaking() {
         try {
             if (!S) return false;
@@ -280,6 +287,21 @@
         }
     }
     mod._isAssistantSpeaking = _isAssistantSpeaking;
+
+    // C: 判断用户是否最近在发声。仅在 voice 模式下使用（文本模式没有麦克风打点），
+    // 用来在前端层面拦住 proactive tick，与后端 prompt_ephemeral 的
+    // _user_recent_activity_time 防线形成对称冗余。
+    function _isUserRecentlySpeaking() {
+        try {
+            if (!S || !S.isRecording) return false;
+            var last = S.userRecentSpeechTime || 0;
+            if (!last) return false;
+            return (Date.now() - last) < USER_RECENT_SPEECH_WINDOW_MS;
+        } catch (_) {
+            return false;
+        }
+    }
+    mod._isUserRecentlySpeaking = _isUserRecentlySpeaking;
 
     function canTriggerProactively() {
         // 「请她离开」状态下禁止一切主动搭话
@@ -375,6 +397,15 @@
                 // 结果：播放完成到下一次 nudge 的等待 ∈ [0, interval)，带随机感，更自然。
                 if (_isAssistantSpeaking()) {
                     console.log('[ProactiveChat] 语音模式：AI 正在播放语音，本次 nudge 跳过（不计数），继续下一 tick');
+                    scheduleProactiveChat();
+                    return;
+                }
+                // C: 前端麦克风 RMS 最近 8s 内超过语音阈值 → 用户正在说话或
+                // 刚说完，不发 fudge。与后端 _user_recent_activity_time guard
+                // 对称（8s 窗口），请求根本不出门，省一次 round-trip。
+                // 同 AI-speaking 分支：不计入 no-response 计数，仍推进下一 tick。
+                if (_isUserRecentlySpeaking()) {
+                    console.log('[ProactiveChat] 语音模式：用户最近在发声，本次 nudge 跳过（不计数），继续下一 tick');
                     scheduleProactiveChat();
                     return;
                 }

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -84,6 +84,11 @@
         assistantTurnCompletionSource: null,
         assistantSpeechActiveTurnId: null,
         assistantSpeechStartedTurnId: null,
+        // 最近一次本地麦克风 RMS 超过语音阈值的时间戳（ms epoch）。
+        // 由 app-audio-capture.js 里的 monitorInputVolume 持续写入；
+        // app-proactive.js 在 voice 模式 tick 时用它判断"用户最近是否在发声"，
+        // 与后端 _user_recent_activity_time 形成对称防线。
+        userRecentSpeechTime: 0,
 
         // --- 屏幕共享 ---
         screenCaptureStream: null,


### PR DESCRIPTION
## 背景

Gemini voice 模式下 `prompt_ephemeral`（voice fudge）会在用户说话时注入预录音频，把用户自己的话打断。具体日志场景：AI 刚说完 \"我等你\" → 用户开口说 \"哦 没问题 …… 刚才我正想说这边天气突然好冷啊\" → 中间那个自然停顿超过旧的 2s grace → tick 恰好到点 → fudge 放行 → AI 又回了一句 \"我等你\"。

## 根因

旧的 `prompt_ephemeral` guard 只在以下条件为真时拦截：
- `_rnnoise_vad_active=True`（RNNoise 在跑）**且**
- `_client_vad_active=True`（sustained speech 信号，需要连续 500ms 才置 True）**或** `now - _client_vad_last_speech_time < 2s`

两个覆盖不到的窗口：
1. 用户说话首 500ms 未达 sustain 阈值时
2. 句子间自然停顿 > 2s 时 `_client_vad_active` flip False 的瞬间

而且整个 guard 门控在 `_rnnoise_vad_active` 下 —— 移动端 / 16kHz / 非 RNNoise 路径完全无保护。前端也没有任何 \"用户正在说话\" 的本地信号（`user_transcript` 只在 turn 结束后到达）。

## 三层互补守卫

**A — 后端 grace 窗口**：`_client_vad_grace_period: 2.0 → 6.0` 秒。覆盖换气 / 思考的自然停顿。

**B — 后端独立 \"近期发声\" 信号**：新字段 `_user_recent_activity_time` / `_user_recent_activity_window=8s`。三类 VAD 源全部打点：
- RNNoise 单帧 `speech_probability > 0.4`（**无需 sustain**，兜住首 500ms）
- server-VAD `speech_started` 事件
- RMS fallback（阈值 500，已较保守）

`prompt_ephemeral` 入口与注入循环都查此信号，**不再门控在 `_rnnoise_vad_active` 下** —— Gemini / Qwen / OpenAI / 移动端统一生效。注入过程中 `_user_recent_activity_time > _inject_start` 直接 abort 残余 chunk。

**C — 前端本地打点**：`app-audio-capture.js` 的 `monitorInputVolume` 每帧（RMS > 0.01）写 `S.userRecentSpeechTime`，与现有 `hasSoundDetected` 共用阈值。`app-proactive.js` 新增 `_isUserRecentlySpeaking()` 8s 窗口（略宽于后端，留网络缓冲），voice-mode scheduler tick 里与 `_isAssistantSpeaking()` 对称检查，不计 no-response、仍推进下一 tick。

## 与 #863 的关系

正交。#863 修 text-mode proactive 流式 Phase-2 残留污染用户新 turn；本 PR 修 voice-mode fudge 的 VAD 触发时机。同名 `prompt_ephemeral` 但一个是 `OmniOfflineClient` / 一个是 `OmniRealtimeClient`，代码路径完全分叉，不会冲突。

## Test plan

- [x] `uv run python -c \"import ast; ast.parse(...)\"` 后端语法 OK
- [x] `node --check` 三个 JS 文件语法 OK
- [x] `uv run pytest tests/unit/test_voice_session.py` 3 passed
- [ ] 本地回放原 log 场景（AI 说完 \"我等你\" 后用户说一句带停顿的长句）验证 fudge 不再插话
- [ ] 验证正常 proactive 场景（用户长时间静默）仍能触发 fudge
- [ ] 移动端（16kHz 无 RNNoise）路径验证 B 的 RMS fallback 保护生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 改进了语音活动与注入音频的协调，防止在用户开始说话时混入或叠加自动播放的响应音频，减少误触发和音频冲突。

* **新功能**
  * 引入前端/后端共享的“近期用户说话”检测与追踪，结合多路声音指标更准确判断用户是否刚刚讲话。
  * 调度逻辑在检测到用户近期说话时会跳过自动提示/主动推送，避免打断用户当前交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->