### PR TITLE
feat(proactive): 事件驱动 SessionStateMachine + phase1/phase2 中途 preempt

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2547,10 +2547,17 @@ class LLMSessionManager:
                     self.lanlan_name, expected_speech_id, self.current_speech_id,
                 )
                 return False
+            # 冻结 commit 用的 turn_id：current_speech_id 由 self.lock 保护，不在
+            # _proactive_write_lock 范围内，下面 send_lanlan_response 之前若用户经
+            # handle_new_message/stream_text 抢占完成 sid 轮换，再让 send_lanlan_response
+            # 默认从 self.current_speech_id 取值会把这条 proactive 气泡打到用户新
+            # turn 上、前端分组串掉。expected_speech_id 在 phase2 已经一路传到这里
+            # 并且刚校验过，作为冻结快照最稳。
+            commit_sid = expected_speech_id or self.current_speech_id
             # 状态机：进入 COMMITTING 阶段；期间若用户抢占仍会 sticky 到 _preempted，
             # 但本处 lock 内 sid 已校验过，commit 本身安全。
             await self.state.fire(SessionEvent.PROACTIVE_COMMITTING)
-            await self.send_lanlan_response(full_text, is_first_chunk=True)
+            await self.send_lanlan_response(full_text, is_first_chunk=True, turn_id=commit_sid)
 
             from utils.llm_client import AIMessage as _AIMsg
             if self.session and hasattr(self.session, '_conversation_history'):

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1006,6 +1006,10 @@ class LLMSessionManager:
         self.session_start_time = None
         await self._cleanup_pending_session_resources()  # close()后再置None，避免泄漏
         self.is_hot_swap_imminent = False
+        # 状态机是 per-manager 的，跨 start_session/end_session 复用同一实例。
+        # 若上一轮 proactive 在 PHASE1/PHASE2 中途 WS 断开、PROACTIVE_DONE 来不及
+        # fire，phase/_preempted 会泄漏到新会话，堵死 can_start_proactive。
+        await self.state.reset()
 
     def _has_custom_tts(self) -> bool:
         """判断当前会话是否使用自定义 TTS（克隆音色或自定义 TTS URL）。"""

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1013,7 +1013,9 @@ class LLMSessionManager:
         # 状态机是 per-manager 的，跨 start_session/end_session 复用同一实例。
         # 若上一轮 proactive 在 PHASE1/PHASE2 中途 WS 断开、PROACTIVE_DONE 来不及
         # fire，phase/_preempted 会泄漏到新会话，堵死 can_start_proactive。
-        await self.state.reset()
+        # teardown 必须用 force=True：默认 reset() 会在活动 phase 上 no-op（保护
+        # auto-start 不被误清），但 end_session 语义就是整轮收尾，必须强制清场。
+        await self.state.reset(force=True)
 
     def _has_custom_tts(self) -> bool:
         """判断当前会话是否使用自定义 TTS（克隆音色或自定义 TTS URL）。"""
@@ -2451,10 +2453,11 @@ class LLMSessionManager:
 
     async def prepare_proactive_delivery(self, min_idle_secs: float = 30.0) -> bool:
         """Phase 2 流式输出前的前置检查 + speech_id 生成。返回 True 表示可以继续。"""
-        # 早期抢占检查：auto-start 分支会走到 start_session → _init_renew_status，
-        # 其中的 state.reset() 会吹掉 proactive phase（reset 本身已对活动 phase 做
-        # no-op，但我们仍希望在任何 await / sid 改写前快速短路），以及防止用户刚
-        # 在入口之后抢占，后续 self.current_speech_id 写入覆盖用户的 user_sid。
+        # 早期抢占检查：在任何 await / sid 改写前快速短路，防止用户刚在入口之后
+        # 抢占而后续 self.current_speech_id 写入覆盖用户的 user_sid。默认 reset()
+        # 对活动 phase no-op（保护 auto-start 期间偶发并发 reset），但 end_session
+        # 走 force=True 强制清场——这里短路不依赖 reset() 的语义差异，单纯是为
+        # 了更早放弃已被抢占的 proactive 轮次。
         if self.state.is_proactive_preempted():
             logger.info("[%s] prepare_proactive_delivery: preempted before claim", self.lanlan_name)
             return False

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -433,8 +433,12 @@ class LLMSessionManager:
         async with self.lock:
             self.current_speech_id = str(uuid4())
             new_sid = self.current_speech_id
-        # 状态机：USER_INPUT 事件用于让正在跑的 proactive 流水线立刻观察到抢占。
-        # 必须在 sid 已写入后发射，保证订阅者看到的 current_speech_id 是新值。
+            # 必须在 self.lock 内同步翻 _preempted 标记，使新 sid + preempt 对
+            # 同样在 self.lock 内复查 is_proactive_preempted 的 prepare_proactive_delivery
+            # 原子可见；否则 proactive 会插到 lock 释放 ~ fire() 之间把 user sid
+            # 再覆盖成 proactive sid。完整 USER_INPUT 事件仍在锁外 fire，以更新
+            # owner/user_sid 并派发订阅者。
+            self.state.mark_user_input_preempt()
         await self.state.fire(SessionEvent.USER_INPUT, sid=new_sid)
 
     async def handle_text_data(self, text: str, is_first_chunk: bool = False):
@@ -3200,6 +3204,10 @@ class LLMSessionManager:
                         self.current_speech_id = str(uuid4())
                         self._tts_done_queued_for_turn = False
                         new_user_sid = self.current_speech_id
+                        # 与 handle_new_message 同理：sid 写入的同一锁段内同步翻
+                        # _preempted，避免 prepare_proactive_delivery 插到 lock
+                        # 释放 ~ fire() 之间再覆盖新 user sid。
+                        self.state.mark_user_input_preempt()
                     # 状态机：文本模式 stream_text 入口同样需要发射 USER_INPUT。
                     # handle_new_message 只在语音模式走到，这里是文本模式的对偶。
                     await self.state.fire(SessionEvent.USER_INPUT, sid=new_user_sid)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2447,6 +2447,13 @@ class LLMSessionManager:
 
     async def prepare_proactive_delivery(self, min_idle_secs: float = 30.0) -> bool:
         """Phase 2 流式输出前的前置检查 + speech_id 生成。返回 True 表示可以继续。"""
+        # 早期抢占检查：auto-start 分支会走到 start_session → _init_renew_status，
+        # 其中的 state.reset() 会吹掉 proactive phase（reset 本身已对活动 phase 做
+        # no-op，但我们仍希望在任何 await / sid 改写前快速短路），以及防止用户刚
+        # 在入口之后抢占，后续 self.current_speech_id 写入覆盖用户的 user_sid。
+        if self.state.is_proactive_preempted():
+            logger.info("[%s] prepare_proactive_delivery: preempted before claim", self.lanlan_name)
+            return False
         if self.last_user_activity_time is not None:
             if time.time() - self.last_user_activity_time < min_idle_secs:
                 logger.info("[%s] prepare_proactive_delivery: user active recently", self.lanlan_name)
@@ -2470,7 +2477,16 @@ class LLMSessionManager:
                 return False
             if not self.session or not hasattr(self.session, '_conversation_history'):
                 return False
+            # auto-start 期间耗时 await；再次确认 proactive 未被用户抢占
+            if self.state.is_proactive_preempted():
+                logger.info("[%s] prepare_proactive_delivery: preempted during auto-start", self.lanlan_name)
+                return False
         async with self.lock:
+            # lock 内二次复查：USER_INPUT 在 self.lock 内 rotate sid，sticky preempt
+            # flag 先于 sid mutation 翻起；此处若已被抢占则不写 current_speech_id。
+            if self.state.is_proactive_preempted():
+                logger.info("[%s] prepare_proactive_delivery: preempted in claim lock", self.lanlan_name)
+                return False
             self.current_speech_id = str(uuid4())
             self._tts_done_queued_for_turn = False
             claim_sid = self.current_speech_id

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -19,6 +19,7 @@ from utils.screenshot_utils import process_screen_data
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient
 from main_logic.tts_client import get_tts_worker, dummy_tts_worker, TTS_PROVIDER_REGISTRY
+from main_logic.session_state import SessionStateMachine, SessionEvent
 from utils.preferences import load_global_conversation_settings, aload_global_conversation_settings
 from config import MEMORY_SERVER_PORT, TOOL_SERVER_PORT
 from config.prompts_sys import (
@@ -310,6 +311,12 @@ class LLMSessionManager:
         
         # 用户活动时间戳：用于主动搭话检测最近是否有用户输入
         self.last_user_activity_time = None  # float timestamp or None
+
+        # 事件驱动状态机：收口 "谁占用当前 turn" 的所有信号，供 proactive 流水线
+        # 零成本（O(1) 读）频繁询问 is_proactive_preempted。事件发射点分布在
+        # handle_new_message / stream_text 入口 / prepare_proactive_delivery /
+        # finish_proactive_delivery / system_router.proactive_chat 等处。
+        self.state = SessionStateMachine(lanlan_name=lanlan_name)
         
         # 用户语言设置（由 start_session 或前端 set_user_language() 设置，初始为 None）
         self.user_language = None
@@ -425,6 +432,10 @@ class LLMSessionManager:
         # 新回复的 audio_chunk 也不会被错误丢弃
         async with self.lock:
             self.current_speech_id = str(uuid4())
+            new_sid = self.current_speech_id
+        # 状态机：USER_INPUT 事件用于让正在跑的 proactive 流水线立刻观察到抢占。
+        # 必须在 sid 已写入后发射，保证订阅者看到的 current_speech_id 是新值。
+        await self.state.fire(SessionEvent.USER_INPUT, sid=new_sid)
 
     async def handle_text_data(self, text: str, is_first_chunk: bool = False):
         """文本回调：处理文本显示和TTS（用于文本模式）"""
@@ -2458,6 +2469,10 @@ class LLMSessionManager:
         async with self.lock:
             self.current_speech_id = str(uuid4())
             self._tts_done_queued_for_turn = False
+            claim_sid = self.current_speech_id
+        # 状态机：正式 claim turn。订阅者（诊断、frontend sync 等）在此之后
+        # 观察到 proactive_sid 已与 current_speech_id 一致。
+        await self.state.fire(SessionEvent.PROACTIVE_CLAIM, sid=claim_sid)
         return True
 
     async def feed_tts_chunk(self, text: str, expected_speech_id: str | None = None):
@@ -2508,6 +2523,9 @@ class LLMSessionManager:
                     self.lanlan_name, expected_speech_id, self.current_speech_id,
                 )
                 return False
+            # 状态机：进入 COMMITTING 阶段；期间若用户抢占仍会 sticky 到 _preempted，
+            # 但本处 lock 内 sid 已校验过，commit 本身安全。
+            await self.state.fire(SessionEvent.PROACTIVE_COMMITTING)
             await self.send_lanlan_response(full_text, is_first_chunk=True)
 
             from utils.llm_client import AIMessage as _AIMsg
@@ -3161,6 +3179,10 @@ class LLMSessionManager:
                     async with self.lock:
                         self.current_speech_id = str(uuid4())
                         self._tts_done_queued_for_turn = False
+                        new_user_sid = self.current_speech_id
+                    # 状态机：文本模式 stream_text 入口同样需要发射 USER_INPUT。
+                    # handle_new_message 只在语音模式走到，这里是文本模式的对偶。
+                    await self.state.fire(SessionEvent.USER_INPUT, sid=new_user_sid)
 
                     should_handoff, openclaw_messages = await self._should_handoff_text_to_openclaw(data)
                     if should_handoff:

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -24,7 +24,7 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Awaitable, Callable, Iterable, Optional, Union
+from typing import Any, Awaitable, Callable, Optional, Union
 
 
 class TurnOwner(Enum):
@@ -215,7 +215,8 @@ class SessionStateMachine:
         try:
             self._subscribers[key].remove(cb)
         except (KeyError, ValueError):
-            pass
+            # idempotent unsubscribe：重复取消或取消未注册的 cb 视为 no-op
+            return
 
 
 def _swallow_subscriber_exc(task: "asyncio.Task") -> None:
@@ -223,7 +224,9 @@ def _swallow_subscriber_exc(task: "asyncio.Task") -> None:
     try:
         task.result()
     except Exception:
-        pass
+        # 故意吞：避免订阅者异常冒泡污染事件流，也避免 "Task exception was
+        # never retrieved" 刷屏。订阅者自己负责在 callback 内部落日志。
+        return
 
 
 # 不对外导出 —— 内部哨兵，用于 ``subscribe(None, ...)``

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -123,7 +123,7 @@ class SessionStateMachine:
         if self.phase in _PROACTIVE_ACTIVE_PHASES:
             self._preempted = True
 
-    async def reset(self) -> None:
+    async def reset(self, *, force: bool = False) -> None:
         """Teardown hook：把 SM 复位到初始态，清掉可能泄漏的 proactive 残留。
 
         ``LLMSessionManager`` 跨多次 ``start_session()`` / ``end_session()`` 复用
@@ -135,14 +135,18 @@ class SessionStateMachine:
         保留 ``_subscribers`` 和 ``last_user_activity`` —— 前者是应用层注册的
         钩子不该无故吹飞，后者跨会话单调递增有诊断价值。
 
-        注意：当 proactive 流水线正处于活动阶段（PHASE1/PHASE2/COMMITTING）时，
-        本方法是 **no-op**。这是因为 ``prepare_proactive_delivery`` 在没有现成
-        session 时会 auto-start，该路径进入 ``start_session → _init_renew_status``，
-        若此处无脑复位就会把 proactive 刚翻起的 phase/sticky flag 全吹掉，使后续
-        phase1/phase2 的 ``is_proactive_preempted`` 彻底失效。
+        Args:
+            force: 若为 ``False``（默认），在 proactive 活动阶段（PHASE1/PHASE2/
+                COMMITTING）本方法是 **no-op**，由活动中的 proactive 自身负责
+                ``PROACTIVE_DONE`` 清理——这是保护 ``prepare_proactive_delivery``
+                在某些并发场景（例如 auto-start 期间偶发错误回收）下不被误清。
+                若为 ``True``，**强制**复位一切状态，不管当前 phase。真正的会话
+                teardown（WS 断开、``end_session``）必须用 ``force=True``——否则
+                活动中的 proactive 卡死导致的 phase/preempt 泄漏会堵死下一轮
+                ``can_start_proactive``。
         """
         async with self._write_lock:
-            if self.phase in _PROACTIVE_ACTIVE_PHASES:
+            if not force and self.phase in _PROACTIVE_ACTIVE_PHASES:
                 # 活动中的 proactive 自身负责 PROACTIVE_DONE 清理；此处跳过
                 return
             self.owner = TurnOwner.NONE

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -101,6 +101,25 @@ class SessionStateMachine:
                 return True
         return False
 
+    async def reset(self) -> None:
+        """Teardown hook：把 SM 复位到初始态，清掉可能泄漏的 proactive 残留。
+
+        ``LLMSessionManager`` 跨多次 ``start_session()`` / ``end_session()`` 复用
+        同一个 SM 实例。若上一轮 proactive 在 PHASE1/PHASE2 时 WebSocket 意外
+        断开、``PROACTIVE_DONE`` 来不及 fire，``phase`` 和 ``_preempted`` 会
+        粘到下一轮会话，导致 ``can_start_proactive`` 永远返回 False。本方法
+        由 ``_init_renew_status`` 调用，保证新会话拿到干净 SM。
+
+        保留 ``_subscribers`` 和 ``last_user_activity`` —— 前者是应用层注册的
+        钩子不该无故吹飞，后者跨会话单调递增有诊断价值。
+        """
+        async with self._write_lock:
+            self.owner = TurnOwner.NONE
+            self.phase = ProactivePhase.IDLE
+            self.proactive_sid = None
+            self.user_sid = None
+            self._preempted = False
+
     def can_start_proactive(self, session: Any = None) -> bool:
         """能否发起新一轮主动搭话（入口 409 前置判定用）。
 

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -103,6 +103,26 @@ class SessionStateMachine:
                 return True
         return False
 
+    def mark_user_input_preempt(self) -> None:
+        """同步翻起 ``_preempted`` sticky flag（仅当 proactive 处于活动阶段）。
+
+        用于 ``handle_new_message`` / ``stream_text`` 等 sid 轮换路径在持有
+        ``self.lock``（保护 ``current_speech_id`` 的锁）的同一临界区内原子地
+        翻起抢占标记。否则以下 race 成立喵：
+
+        T1 持 self.lock 写新 user sid → 释放 lock → 去 await fire(USER_INPUT) …
+        T2 正好这个窗口里拿到 self.lock（走 prepare_proactive_delivery 的 lock
+           内 preempt 复查），看到 ``_preempted=False`` 继续往下，把刚写好的
+           user sid 再覆盖成 proactive sid，用户这轮回复的 chunk/TTS 全带错 sid。
+
+        本方法不走 ``_write_lock``：同步布尔写 + 只读判定无需跨协程同步；并且允许
+        调用方在 ``self.lock`` 内无 await 完成"写 sid + 翻 flag"两步合一。完整的
+        ``SessionEvent.USER_INPUT`` 仍然需要在锁外 fire，以更新 owner/user_sid/
+        last_user_activity 并派发订阅者。
+        """
+        if self.phase in _PROACTIVE_ACTIVE_PHASES:
+            self._preempted = True
+
     async def reset(self) -> None:
         """Teardown hook：把 SM 复位到初始态，清掉可能泄漏的 proactive 残留。
 
@@ -175,14 +195,7 @@ class SessionStateMachine:
                 self._subscribers.get(_WILDCARD, ())
             )
 
-        for cb in snap_subs:
-            try:
-                res = cb(SessionEvent.PROACTIVE_START, {})
-            except Exception:
-                continue
-            if asyncio.iscoroutine(res):
-                task = asyncio.create_task(res)
-                task.add_done_callback(_swallow_subscriber_exc)
+        _dispatch_subscribers(snap_subs, SessionEvent.PROACTIVE_START, {})
         return True
 
     def snapshot(self) -> dict:
@@ -209,18 +222,7 @@ class SessionStateMachine:
                 self._subscribers.get(_WILDCARD, ())
             )
 
-        for cb in snap_subs:
-            try:
-                res = cb(event, payload)
-            except Exception:
-                # 订阅者异常不能影响事件流（同步路径）
-                continue
-            if asyncio.iscoroutine(res):
-                # 异步订阅者：用 create_task 派发，但挂 done_callback 静默吸收异常
-                # 避免 "Task exception was never retrieved" 刷屏。订阅者自己负责
-                # 在回调里做日志/上报。
-                task = asyncio.create_task(res)
-                task.add_done_callback(_swallow_subscriber_exc)
+        _dispatch_subscribers(snap_subs, event, payload)
 
     def _apply(self, event: SessionEvent, payload: dict) -> None:
         """内部状态转移。调用方已持 ``_write_lock``。"""
@@ -279,6 +281,33 @@ class SessionStateMachine:
         except (KeyError, ValueError):
             # idempotent unsubscribe：重复取消或取消未注册的 cb 视为 no-op
             return
+
+
+def _dispatch_subscribers(
+    subs: "list[Subscriber]",
+    event: SessionEvent,
+    payload: dict,
+) -> None:
+    """统一派发订阅者：同步抛异常静默；返回 awaitable（包括 coroutine、Task、
+    Future、自定义 awaitable）统一 ``ensure_future`` 包装并挂 done-callback，
+    避免 Task/Future 类型的异常绕过吞噬逻辑泄漏到事件循环。
+    """
+    for cb in subs:
+        try:
+            res = cb(event, payload)
+        except Exception:
+            # 订阅者同步异常不能影响事件流；订阅者自行日志/上报
+            continue
+        if res is None:
+            continue
+        if asyncio.iscoroutine(res) or asyncio.isfuture(res) or hasattr(res, "__await__"):
+            # ensure_future 对 coroutine 包成 Task；对 Future 原样返回；对自定义
+            # awaitable 通过 __await__ 包成 Task —— 三类都能挂 done-callback。
+            try:
+                fut = asyncio.ensure_future(res)
+            except Exception:
+                continue
+            fut.add_done_callback(_swallow_subscriber_exc)
 
 
 def _swallow_subscriber_exc(task: "asyncio.Task") -> None:

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -1,0 +1,243 @@
+"""Per-session event-driven state machine.
+
+此模块把散落在 ``LLMSessionManager`` / ``OmniOfflineClient`` 中的若干"谁在占用
+当前轮次"信号（``current_speech_id`` 轮换、``session._is_responding``、
+``_proactive_expected_sid`` contextvar、``last_user_activity_time``）收拢到一个
+单点状态机。目的：
+
+1. 主动搭话（proactive）流水线的 phase1/phase2 可以**零成本**（O(1) 读，无锁）
+   频繁询问 ``is_proactive_preempted(claim_token)`` —— 即使在每个 LLM chunk
+   之间 check，也不会引入可观测开销。
+2. 把 "用户接管" / "AI 开始回复" 等信号以事件形式发布，各消费者（TTS worker、
+   日志、前端 sync）可以订阅而不必直读多个字段。
+3. per-catgirl（未来可扩展为 per-catgirl+user）独立实例，状态互不干扰。
+
+本模块在 Stage 1 引入时作为 facade：事件发射点写在既有的 sid 轮换 / proactive
+生命周期处，旧字段（``current_speech_id`` / ``_is_responding``）继续存在，
+消费者逐步迁移（见 Stage 2）。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Iterable, Optional, Union
+
+
+class TurnOwner(Enum):
+    """谁在占用当前 turn。"""
+
+    NONE = "none"
+    USER = "user"          # 用户输入中 / AI 正在为用户回复
+    PROACTIVE = "proactive"  # 主动搭话流水线持有
+
+
+class ProactivePhase(Enum):
+    """主动搭话流水线当前阶段（text mode；voice fudge 不走这里）。"""
+
+    IDLE = "idle"
+    PHASE1 = "phase1"            # fetch + unified LLM
+    PHASE2 = "phase2"            # astream → TTS
+    COMMITTING = "committing"    # finish_proactive_delivery 内
+
+
+class SessionEvent(Enum):
+    """写路径事件。发射方通过 ``fire()``，读路径只读 state 字段。"""
+
+    USER_INPUT = "user_input"                  # 用户新一轮输入触发的 sid 轮换
+    USER_ACTIVITY = "user_activity"            # 不轮换 sid 的用户活动（transcript 等）
+    PROACTIVE_START = "proactive_start"        # 进入 phase1
+    PROACTIVE_CLAIM = "proactive_claim"        # prepare 生成 sid，正式持有 turn
+    PROACTIVE_PHASE2 = "proactive_phase2"      # 进入流式 TTS
+    PROACTIVE_COMMITTING = "proactive_committing"  # 进入 finish_proactive_delivery
+    PROACTIVE_DONE = "proactive_done"          # 主动搭话退出（成功 / pass / abort）
+
+
+Subscriber = Callable[[SessionEvent, dict], Union[None, Awaitable[None]]]
+
+
+@dataclass
+class SessionStateMachine:
+    """单个 ``(lanlan_name, user)`` 会话的事件驱动状态机。
+
+    写路径（``fire``）持 ``_write_lock``；读路径（``is_proactive_preempted``、
+    ``can_start_proactive``、``snapshot``）只读字段，无锁无 await。发射方可以
+    在任意 async 上下文里 fire，订阅回调会在 apply 之后异步派发，不阻塞事件流。
+    """
+
+    lanlan_name: str
+    owner: TurnOwner = TurnOwner.NONE
+    phase: ProactivePhase = ProactivePhase.IDLE
+    proactive_sid: Optional[str] = None
+    user_sid: Optional[str] = None
+    last_user_activity: float = 0.0
+    _preempted: bool = False
+    _subscribers: dict = field(default_factory=lambda: defaultdict(list))
+    _write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    # ── 读路径（O(1)，热路径）─────────────────────────────────────────
+    def is_proactive_preempted(self, claim_token: Optional[str] = None) -> bool:
+        """主动搭话路径是否应立刻 abort。
+
+        Args:
+            claim_token: 调用段起点 snapshot 的 sid。
+                - phase1 前还没 claim 时传 ``None``，此时仅看 sticky preempt flag。
+                - phase2 起传 ``prepare_proactive_delivery`` 发出的 sid。
+
+        规则：
+            1) ``_preempted`` sticky flag —— 任何 proactive 阶段期间 USER_INPUT
+               事件被记下时立刻翻为 True，直到 ``PROACTIVE_DONE`` 清零。
+            2) ``claim_token`` 非 None 且与当前 ``proactive_sid`` 不一致 ——
+               防御性兜底，正常情况 sticky flag 已先触发。
+        """
+        if self._preempted:
+            return True
+        if claim_token is not None:
+            # proactive_sid 可能为 None（start 但尚未 claim），此时不判 mismatch
+            if self.proactive_sid is not None and self.proactive_sid != claim_token:
+                return True
+        return False
+
+    def can_start_proactive(self, session: Any = None) -> bool:
+        """能否发起新一轮主动搭话（入口 409 前置判定用）。
+
+        Args:
+            session: 可选，当前 session（OmniOfflineClient / OmniRealtimeClient）。
+                若传入且 ``_is_responding == True``，说明 AI 正在为用户回复，
+                应拒绝 proactive。这一步把原来散在 router 里直读 session 字段
+                的检查收拢到 SM。
+
+        返回 False 的三种情况：
+            - owner == USER（用户持有 turn）
+            - phase != IDLE（另一轮 proactive 在跑 / 正在 commit）
+            - session._is_responding == True（AI 正在为用户回复）
+        """
+        if self.owner is TurnOwner.USER:
+            return False
+        if self.phase is not ProactivePhase.IDLE:
+            return False
+        if session is not None and getattr(session, "_is_responding", False):
+            return False
+        return True
+
+    def snapshot(self) -> dict:
+        """供日志 / 诊断使用的一致性快照。"""
+        return {
+            "lanlan_name": self.lanlan_name,
+            "owner": self.owner.value,
+            "phase": self.phase.value,
+            "proactive_sid": self.proactive_sid,
+            "user_sid": self.user_sid,
+            "preempted": self._preempted,
+            "last_user_activity": self.last_user_activity,
+        }
+
+    # ── 写路径 ──────────────────────────────────────────────────────
+    async def fire(self, event: SessionEvent, **payload: Any) -> None:
+        """发射事件；在 ``_write_lock`` 内 apply，随后在锁外异步派发订阅。
+
+        订阅者在 apply 之后观察到的状态必然是"事件生效后"的状态。
+        """
+        async with self._write_lock:
+            self._apply(event, payload)
+            snap_subs = list(self._subscribers.get(event, ())) + list(
+                self._subscribers.get(_WILDCARD, ())
+            )
+
+        for cb in snap_subs:
+            try:
+                res = cb(event, payload)
+            except Exception:
+                # 订阅者异常不能影响事件流（同步路径）
+                continue
+            if asyncio.iscoroutine(res):
+                # 异步订阅者：用 create_task 派发，但挂 done_callback 静默吸收异常
+                # 避免 "Task exception was never retrieved" 刷屏。订阅者自己负责
+                # 在回调里做日志/上报。
+                task = asyncio.create_task(res)
+                task.add_done_callback(_swallow_subscriber_exc)
+
+    def _apply(self, event: SessionEvent, payload: dict) -> None:
+        """内部状态转移。调用方已持 ``_write_lock``。"""
+        if event is SessionEvent.USER_INPUT:
+            # 任何 proactive 阶段遇到 USER_INPUT 都 sticky preempt
+            if self.phase in _PROACTIVE_ACTIVE_PHASES:
+                self._preempted = True
+            self.owner = TurnOwner.USER
+            self.user_sid = payload.get("sid")
+            self.last_user_activity = time.time()
+
+        elif event is SessionEvent.USER_ACTIVITY:
+            self.last_user_activity = time.time()
+            # 不轮换 owner / sid（voice transcript 等静默信号）
+
+        elif event is SessionEvent.PROACTIVE_START:
+            # 进入 phase1：清 sticky flag，owner 翻到 proactive
+            self._preempted = False
+            self.owner = TurnOwner.PROACTIVE
+            self.phase = ProactivePhase.PHASE1
+            self.proactive_sid = None
+
+        elif event is SessionEvent.PROACTIVE_CLAIM:
+            # 只在 proactive 路径存活时 claim sid；否则丢弃（已被抢）
+            sid = payload.get("sid")
+            if self.phase is ProactivePhase.PHASE1 and not self._preempted:
+                self.proactive_sid = sid
+
+        elif event is SessionEvent.PROACTIVE_PHASE2:
+            if self.phase is ProactivePhase.PHASE1:
+                self.phase = ProactivePhase.PHASE2
+
+        elif event is SessionEvent.PROACTIVE_COMMITTING:
+            if self.phase is ProactivePhase.PHASE2:
+                self.phase = ProactivePhase.COMMITTING
+
+        elif event is SessionEvent.PROACTIVE_DONE:
+            # 清 proactive 半边；owner 由最近事件决定 —— 若中途被 USER_INPUT
+            # 抢占，owner 已是 USER，本事件只清 phase，不覆盖 owner。
+            self.phase = ProactivePhase.IDLE
+            self.proactive_sid = None
+            self._preempted = False
+            if self.owner is TurnOwner.PROACTIVE:
+                self.owner = TurnOwner.NONE
+
+    # ── 订阅 ────────────────────────────────────────────────────────
+    def subscribe(self, event: Optional[SessionEvent], cb: Subscriber) -> None:
+        """订阅事件；``event=None`` 表示订阅全部。"""
+        key = _WILDCARD if event is None else event
+        self._subscribers[key].append(cb)
+
+    def unsubscribe(self, event: Optional[SessionEvent], cb: Subscriber) -> None:
+        key = _WILDCARD if event is None else event
+        try:
+            self._subscribers[key].remove(cb)
+        except (KeyError, ValueError):
+            pass
+
+
+def _swallow_subscriber_exc(task: "asyncio.Task") -> None:
+    """异步订阅者抛异常时静默（只取一次结果避免 warning），由订阅者自行负责上报。"""
+    try:
+        task.result()
+    except Exception:
+        pass
+
+
+# 不对外导出 —— 内部哨兵，用于 ``subscribe(None, ...)``
+_WILDCARD = "__wildcard__"
+
+# phase 判定"proactive 正在干活、应被 USER_INPUT 抢占"的集合
+_PROACTIVE_ACTIVE_PHASES = frozenset(
+    {ProactivePhase.PHASE1, ProactivePhase.PHASE2, ProactivePhase.COMMITTING}
+)
+
+
+__all__ = [
+    "ProactivePhase",
+    "SessionEvent",
+    "SessionStateMachine",
+    "TurnOwner",
+]

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -75,7 +75,9 @@ class SessionStateMachine:
     user_sid: Optional[str] = None
     last_user_activity: float = 0.0
     _preempted: bool = False
-    _subscribers: dict = field(default_factory=lambda: defaultdict(list))
+    _subscribers: "dict[Union[SessionEvent, str], list[Subscriber]]" = field(
+        default_factory=lambda: defaultdict(list)
+    )
     _write_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     # ── 读路径（O(1)，热路径）─────────────────────────────────────────

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -114,8 +114,17 @@ class SessionStateMachine:
 
         保留 ``_subscribers`` 和 ``last_user_activity`` —— 前者是应用层注册的
         钩子不该无故吹飞，后者跨会话单调递增有诊断价值。
+
+        注意：当 proactive 流水线正处于活动阶段（PHASE1/PHASE2/COMMITTING）时，
+        本方法是 **no-op**。这是因为 ``prepare_proactive_delivery`` 在没有现成
+        session 时会 auto-start，该路径进入 ``start_session → _init_renew_status``，
+        若此处无脑复位就会把 proactive 刚翻起的 phase/sticky flag 全吹掉，使后续
+        phase1/phase2 的 ``is_proactive_preempted`` 彻底失效。
         """
         async with self._write_lock:
+            if self.phase in _PROACTIVE_ACTIVE_PHASES:
+                # 活动中的 proactive 自身负责 PROACTIVE_DONE 清理；此处跳过
+                return
             self.owner = TurnOwner.NONE
             self.phase = ProactivePhase.IDLE
             self.proactive_sid = None
@@ -144,6 +153,36 @@ class SessionStateMachine:
             return False
         if session is not None and getattr(session, "_is_responding", False):
             return False
+        return True
+
+    async def try_start_proactive(self, session: Any = None) -> bool:
+        """原子地"检查 + 占坑"：仅当 ``can_start_proactive`` 返回 True 时才翻
+        ``IDLE → PHASE1``，避免两次无锁检查之间的 TOCTOU 窗口导致两路并发 proactive
+        同时进入 PHASE1。
+
+        返回 True 表示本次调用抢到了 turn 所有权（已翻 PHASE1，订阅者已收到
+        ``PROACTIVE_START``）；返回 False 表示另一路 proactive 抢先或 AI 正在响应，
+        调用方应直接返回 409（不需要再 fire ``PROACTIVE_DONE``，因为 ``PROACTIVE_START``
+        没发出）。
+        """
+        async with self._write_lock:
+            if self.phase is not ProactivePhase.IDLE:
+                return False
+            if session is not None and getattr(session, "_is_responding", False):
+                return False
+            self._apply(SessionEvent.PROACTIVE_START, {})
+            snap_subs = list(self._subscribers.get(SessionEvent.PROACTIVE_START, ())) + list(
+                self._subscribers.get(_WILDCARD, ())
+            )
+
+        for cb in snap_subs:
+            try:
+                res = cb(SessionEvent.PROACTIVE_START, {})
+            except Exception:
+                continue
+            if asyncio.iscoroutine(res):
+                task = asyncio.create_task(res)
+                task.add_done_callback(_swallow_subscriber_exc)
         return True
 
     def snapshot(self) -> dict:
@@ -243,9 +282,16 @@ class SessionStateMachine:
 
 
 def _swallow_subscriber_exc(task: "asyncio.Task") -> None:
-    """异步订阅者抛异常时静默（只取一次结果避免 warning），由订阅者自行负责上报。"""
+    """异步订阅者抛异常时静默（只取一次结果避免 warning），由订阅者自行负责上报。
+
+    ``asyncio.CancelledError`` 是 ``BaseException`` 子类，不被 ``except Exception``
+    捕获；进程关停 / 任务 cancel 路径下若不单独捕获会绕过 done-callback 继续冒泡
+    触发 "Task exception was never retrieved" warning。
+    """
     try:
         task.result()
+    except asyncio.CancelledError:
+        return
     except Exception:
         # 故意吞：避免订阅者异常冒泡污染事件流，也避免 "Task exception was
         # never retrieved" 刷屏。订阅者自己负责在 callback 内部落日志。

--- a/main_logic/session_state.py
+++ b/main_logic/session_state.py
@@ -110,13 +110,15 @@ class SessionStateMachine:
                 应拒绝 proactive。这一步把原来散在 router 里直读 session 字段
                 的检查收拢到 SM。
 
-        返回 False 的三种情况：
-            - owner == USER（用户持有 turn）
+        返回 False 的两种情况：
             - phase != IDLE（另一轮 proactive 在跑 / 正在 commit）
             - session._is_responding == True（AI 正在为用户回复）
+
+        注意：**不**基于 ``owner == USER`` 判拒。USER_INPUT 事件把 owner 翻到
+        USER 之后没有 AI_RESPONSE_END 事件将其复位（Stage 2 未做该项迁移），
+        若此处卡 owner == USER 会导致用户发第一条消息后所有 proactive 都被
+        永久 409 掉。owner 目前只用于 sticky preempt 的语义，不用于 gating。
         """
-        if self.owner is TurnOwner.USER:
-            return False
         if self.phase is not ProactivePhase.IDLE:
             return False
         if session is not None and getattr(session, "_is_responding", False):

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3310,6 +3310,15 @@ async def proactive_chat(request: Request):
         # 完全剔除，不应向模型暴露任何音乐相关指令，以免干扰其他 source 的选择。
         print(f"[{lanlan_name}] Phase 2 prompt 长度: {len(generate_prompt)}, 动态上下文: {len(dynamic_context_for_phase2)} 字符")
 
+        # Phase 1 preempt check (final)：request_fresh_screenshot 最多 await 3s，
+        # 是 prepare_proactive_delivery 之前唯一剩下的可打断窗口。若此处用户已
+        # 接管，继续走 prepare 会让其内部的 `current_speech_id = uuid4()` 覆盖
+        # 用户轮次的 sid —— 即使 SM 的 PROACTIVE_CLAIM 在 _preempted=True 时不
+        # 回写 proactive_sid，mgr.current_speech_id 已经被物理换掉，用户的
+        # 回复 TTS 会被错贴上一个陌生 sid。
+        if mgr.state.is_proactive_preempted():
+            return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_pre_prepare")))
+
         # --- 前置检查：用户是否空闲、WebSocket 是否在线、session 是否可用 ---
         if not await mgr.prepare_proactive_delivery(min_idle_secs=30.0):
             return await _end_proactive(JSONResponse({

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -76,6 +76,25 @@ from utils.logger_config import get_module_logger
 router = APIRouter(prefix="/api", tags=["system"])
 logger = get_module_logger(__name__, "Main")
 
+
+async def _safe_fire_proactive_done(scope: dict) -> None:
+    """从 proactive_chat 的异常处理路径安全复位状态机。
+
+    异常可能发生在 PROACTIVE_START 之前（mgr 未绑定、_SE 未 import）或之后，
+    这里统一用 locals() dict 查找避免 NameError。状态机 fire 本身 idempotent：
+    状态已经是 IDLE 时 PROACTIVE_DONE 只是空操作。
+    """
+    mgr = scope.get("mgr")
+    se = scope.get("_SE")
+    emitted = scope.get("_proactive_done_emitted", False)
+    if mgr is None or se is None or emitted:
+        return
+    try:
+        await mgr.state.fire(se.PROACTIVE_DONE)
+    except Exception as err:  # 状态机不该抛，但兜底 swallow
+        logger.warning("safe_fire_proactive_done 异常: %s", err)
+
+
 # 统一的表情包图源白名单由 utils.meme_fetcher 维护，本文件仅用于引入
 
 _EMOTION_LABEL_ALIASES = {
@@ -2349,12 +2368,17 @@ async def proactive_chat(request: Request):
         if not mgr:
             return JSONResponse({"success": False, "error": f"角色 {lanlan_name} 不存在"}, status_code=404)
         
-        # 检查是否正在响应中（如果正在说话，不打断）
-        if mgr.is_active and hasattr(mgr.session, '_is_responding') and mgr.session._is_responding:
+        # 检查能否发起新一轮主动搭话：状态机统一把 "AI 正在响应"（_is_responding）、
+        # "用户持有 turn"（owner）、"另一轮 proactive 在跑"（phase != IDLE）三个信号
+        # 收拢到 can_start_proactive 一个 O(1) 判定。mgr.is_active 仅用于判断 session
+        # 是否已实例化，故仍需保留（can_start_proactive 对 session=None 容错）。
+        probe_session = mgr.session if mgr.is_active else None
+        if not mgr.state.can_start_proactive(session=probe_session):
             return JSONResponse({
                 "success": False,
                 "error": "AI正在响应中，无法主动搭话",
-                "message": "请等待当前响应完成"
+                "message": "请等待当前响应完成",
+                "state": mgr.state.snapshot(),
             }, status_code=409)
 
         # ========== Voice mode fast path ==========
@@ -2366,6 +2390,36 @@ async def proactive_chat(request: Request):
                 "action": "chat" if delivered else "pass",
                 "message": "voice proactive triggered" if delivered else "voice proactive skipped (guard)",
             })
+
+        # ========== Text-mode proactive：进入状态机管理 ==========
+        # PROACTIVE_START 让状态机翻到 PHASE1；之后 phase1/phase2 全部走
+        # mgr.state.is_proactive_preempted() 做 O(1) 抢占检查。所有退出路径
+        # 必须经过 _end_proactive() 发出 PROACTIVE_DONE，以复位状态机。
+        from main_logic.session_state import SessionEvent as _SE
+        await mgr.state.fire(_SE.PROACTIVE_START)
+        _proactive_done_emitted = False
+
+        async def _end_proactive(resp: JSONResponse) -> JSONResponse:
+            """包装所有 proactive 正常/短路退出：幂等地 fire PROACTIVE_DONE。"""
+            nonlocal _proactive_done_emitted
+            if not _proactive_done_emitted:
+                _proactive_done_emitted = True
+                try:
+                    await mgr.state.fire(_SE.PROACTIVE_DONE)
+                except Exception as _done_err:
+                    logger.warning("[%s] PROACTIVE_DONE fire 异常: %s", lanlan_name, _done_err)
+            return resp
+
+        def _proactive_preempted_json(where: str) -> dict:
+            logger.info(
+                "[%s] proactive %s preempted by user takeover (state=%s)",
+                lanlan_name, where, mgr.state.snapshot(),
+            )
+            return {
+                "success": True,
+                "action": "pass",
+                "message": f"proactive {where} preempted by user takeover",
+            }
 
         print(f"[{lanlan_name}] 开始主动搭话流程（两阶段架构）...")
         
@@ -2497,12 +2551,16 @@ async def proactive_chat(request: Request):
             sources[mode] = content
         
         if not sources:
-            return JSONResponse({
+            return await _end_proactive(JSONResponse({
                 "success": False,
                 "error": "所有信息源获取失败",
                 "action": "pass"
-            }, status_code=500)
-        
+            }, status_code=500))
+
+        # Phase 1 preempt check：信息源并行 fetch 完，正式进入 LLM 前先瞄一眼
+        if mgr.state.is_proactive_preempted():
+            return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_fetch")))
+
         print(f"[{lanlan_name}] 成功获取 {len(sources)} 个信息源: {list(sources.keys())}")
 
         # ========== 1. 获取记忆上下文 (New Dialog) ==========
@@ -2553,7 +2611,13 @@ async def proactive_chat(request: Request):
             return text, ""
 
         memory_context, inner_thoughts = _parse_new_dialog(raw_memory_context)
-        
+
+        # Phase 1 preempt check：memory_server new_dialog 是 phase1 里首次大 await
+        # （httpx timeout 5s）。用户在这期间打断只能等超时才有下一次 check，
+        # 这里补一刀。
+        if mgr.state.is_proactive_preempted():
+            return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_memory")))
+
         # ========== 2. 选择语言 ==========
         try:
             request_lang = data.get('language') or data.get('lang') or data.get('i18n_language')
@@ -2601,6 +2665,12 @@ async def proactive_chat(request: Request):
         except Exception as e:
             logger.debug(f"[{lanlan_name}] 反思/回调话题获取失败（不影响主流程）: {e}")
 
+        # Phase 1 preempt check：reflection POST(15s) + followup GET(5s) 是又一段
+        # 可能拖很久的 await 串，整段裸跑会让用户打断后继续跑完 LLM 配置和
+        # 后续步骤，再到 pre-LLM check 才识破。这里补一刀。
+        if mgr.state.is_proactive_preempted():
+            return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_reflect")))
+
         # ========== 4. 获取 LLM 配置 ==========
         try:
             correction_config = _config_manager.get_model_api_config('correction')
@@ -2610,11 +2680,11 @@ async def proactive_chat(request: Request):
             
             if not correction_model or not correction_api_key:
                 logger.error("纠错模型配置缺失: model或api_key未设置")
-                return JSONResponse({
+                return await _end_proactive(JSONResponse({
                     "success": False,
                     "error": "纠错模型配置缺失",
                     "detail": "请在设置中配置纠错模型的model和api_key"
-                }, status_code=500)
+                }, status_code=500))
             
             vision_config = _config_manager.get_model_api_config('vision')
             vision_model_name = vision_config.get('model', '')
@@ -2625,12 +2695,12 @@ async def proactive_chat(request: Request):
                 logger.info("Vision 模型未配置，Phase 2 将退回使用 correction 模型")
         except Exception as e:
             logger.error(f"获取模型配置失败: {e}")
-            return JSONResponse({
+            return await _end_proactive(JSONResponse({
                 "success": False,
                 "error": "模型配置异常",
                 "detail": str(e)
-            }, status_code=500)
-        
+            }, status_code=500))
+
         def _make_llm(temperature: float = 1.0, max_tokens: int = 1536,
                       use_vision: bool = False, disable_thinking: bool = True):
             """
@@ -2887,6 +2957,10 @@ async def proactive_chat(request: Request):
             enriched_memory_context = memory_context + "\n" + followup_topics_prompt
 
         if has_web_task or has_music_task or has_meme_task:
+            # Phase 1 preempt check：拨号前最后一次检查。大头 LLM 调用即将开始，
+            # 此后等待期间用户抢占只能靠流结束后的兜底识别。
+            if mgr.state.is_proactive_preempted():
+                return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_pre_llm")))
             try:
                 from config.prompts_proactive import build_unified_phase1_prompt
                 unified_prompt = build_unified_phase1_prompt(
@@ -2992,6 +3066,9 @@ async def proactive_chat(request: Request):
             fetch_labels.append('meme')
 
         if fetch_tasks_p1:
+            # Phase 1 preempt check：unified LLM 刚回，music/meme 后置 fetch 前再瞄
+            if mgr.state.is_proactive_preempted():
+                return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_llm")))
             fetch_results_p1 = await asyncio.gather(*fetch_tasks_p1, return_exceptions=True)
             for label_p1, result_p1 in zip(fetch_labels, fetch_results_p1):
                 if isinstance(result_p1, Exception):
@@ -3088,11 +3165,15 @@ async def proactive_chat(request: Request):
         
         if not phase1_topics and not vision_content:
             print(f"[{lanlan_name}] Phase 1 所有通道均无可用话题")
-            return JSONResponse({
+            return await _end_proactive(JSONResponse({
                 "success": True,
                 "action": "pass",
                 "message": "所有信息源筛选后均不值得搭话"
-            })
+            }))
+
+        # Phase 1 preempt check：topic assembly 完，进入 Phase 2 前最后一次瞄
+        if mgr.state.is_proactive_preempted():
+            return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_pre_phase2")))
         
         # 收集各通道结果
         active_channels = [ch for ch, _ in phase1_topics]
@@ -3231,15 +3312,18 @@ async def proactive_chat(request: Request):
 
         # --- 前置检查：用户是否空闲、WebSocket 是否在线、session 是否可用 ---
         if not await mgr.prepare_proactive_delivery(min_idle_secs=30.0):
-            return JSONResponse({
+            return await _end_proactive(JSONResponse({
                 "success": True,
                 "action": "pass",
                 "message": "主动搭话条件未满足（用户近期活跃或语音会话正在进行）"
-            })
+            }))
 
         # 记录本轮主动搭话起始的 speech_id；abort 时若该 id 已变，说明用户已打断并接管，
         # 此时再调 handle_new_message() 会把用户正常回复的 TTS 也一起清掉。
+        # prepare_proactive_delivery 已经 fire(PROACTIVE_CLAIM, sid=...)；这里把
+        # 状态机翻到 PHASE2，后续 astream 循环的抢占检查基于此阶段。
         proactive_sid = mgr.current_speech_id
+        await mgr.state.fire(_SE.PROACTIVE_PHASE2)
 
         # --- 构建 LLM + messages (static/dynamic 分离) ---
         phase2_use_vision = bool(screenshot_b64_for_phase2 and has_vision_model)
@@ -3276,10 +3360,13 @@ async def proactive_chat(request: Request):
             nonlocal pipe_count, full_text, aborted
             if not text:
                 return False
-            # sid 已被换掉说明用户已打断并接管本轮，立刻 abort 以停止 LLM stream；
-            # feed_tts_chunk 下面还有 lock 内二次校验兜底，防止 await 期间的 race。
-            if mgr.current_speech_id != proactive_sid:
-                print(f"[{lanlan_name}] Phase 2 检测到 sid 变更（用户已接管），abort")
+            # 状态机 preempt check：O(1) 读 sticky flag + sid 比较。用户抢占
+            # （handle_new_message 或 text stream_text 入口）会 fire USER_INPUT，
+            # 在 PHASE2 阶段 sticky 把 _preempted 翻到 True；同时 current_speech_id
+            # 被轮换，proactive_sid != 新 sid 兜底覆盖竞态窗口。
+            # feed_tts_chunk 下面还有 lock 内 expected_speech_id 二次校验。
+            if mgr.state.is_proactive_preempted(proactive_sid):
+                print(f"[{lanlan_name}] Phase 2 检测到用户接管（state 抢占），abort")
                 aborted = True
                 return True
             for ch in text:
@@ -3303,6 +3390,12 @@ async def proactive_chat(request: Request):
                 async with _make_llm(temperature=1.0, max_tokens=1536,
                                     use_vision=phase2_use_vision, disable_thinking=True) as llm:
                     async for chunk in llm.astream(messages):
+                        # Phase 2 preempt check：每 chunk 顶端做 O(1) 状态机读，
+                        # 用户抢占立刻跳出；_emit_safe 里还有一次保险。
+                        if mgr.state.is_proactive_preempted(proactive_sid):
+                            print(f"[{lanlan_name}] Phase 2 astream chunk 前检测到抢占，abort")
+                            aborted = True
+                            break
                         content = chunk.content if hasattr(chunk, 'content') else ''
                         if not content:
                             continue
@@ -3385,16 +3478,19 @@ async def proactive_chat(request: Request):
         # --- 结果处理 ---
         print(f"\n[PROACTIVE-DEBUG] Phase 2 STREAM output (aborted={aborted}, tag={source_tag}): {(buffer + full_text)[:300]}\n")
         if aborted or not full_text.strip():
-            if mgr.current_speech_id == proactive_sid:
+            # 只有当用户没接管时才调 handle_new_message 清 TTS —— 否则会把
+            # 用户正常回复的 TTS 也清掉（PR #862 修的 bug）。状态机的
+            # is_proactive_preempted 是权威信号，sid 比较作为最后一道兜底。
+            if not mgr.state.is_proactive_preempted(proactive_sid):
                 await mgr.handle_new_message()
                 logger.debug(f"[{lanlan_name}] Phase 2 abort，已中断 TTS + 前端音频")
             else:
-                logger.info(f"[{lanlan_name}] Phase 2 abort 但用户已接管 (sid changed)，跳过 TTS 清理避免误伤正常回复")
-            return JSONResponse({
+                logger.info(f"[{lanlan_name}] Phase 2 abort 但用户已接管 (state preempted)，跳过 TTS 清理避免误伤正常回复")
+            return await _end_proactive(JSONResponse({
                 "success": True,
                 "action": "pass",
                 "message": "Phase 2 流式输出被拦截或为空"
-            })
+            }))
         
         response_text = full_text.strip()
         logger.debug(f"[{lanlan_name}] Phase 2 流式完成 (vision={phase2_use_vision}): {response_text[:120]}...")
@@ -3422,15 +3518,15 @@ async def proactive_chat(request: Request):
         
         # 【加固补齐】如果触发了降级拦截（aborted），立即返回
         if aborted:
-            if mgr.current_speech_id == proactive_sid:
+            if not mgr.state.is_proactive_preempted(proactive_sid):
                 await mgr.handle_new_message()
             else:
-                logger.info(f"[{lanlan_name}] 降级拦截 abort 但用户已接管 (sid changed)，跳过 TTS 清理")
-            return JSONResponse({
+                logger.info(f"[{lanlan_name}] 降级拦截 abort 但用户已接管 (state preempted)，跳过 TTS 清理")
+            return await _end_proactive(JSONResponse({
                 "success": True,
                 "action": "pass",
                 "message": f"[{lanlan_name}] 播放中推荐拦截触发，动作已取消"
-            })
+            }))
 
         # 使用纯函数构建响应
         primary_channel, source_links = build_proactive_response(source_tag, {
@@ -3477,13 +3573,13 @@ async def proactive_chat(request: Request):
                 "[%s] 主动搭话被用户接管，短路下游写入（topic/memory/response）",
                 lanlan_name,
             )
-            return JSONResponse({
+            return await _end_proactive(JSONResponse({
                 "success": True,
                 "action": "pass",
                 "message": "proactive delivery skipped: user took over turn",
                 "lanlan_name": lanlan_name,
                 "turn_id": mgr.current_speech_id,
-            })
+            }))
 
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)
@@ -3543,7 +3639,7 @@ async def proactive_chat(request: Request):
             _record_topic_usage(lanlan_name, selected_meme_topic_key)
             print(f"[{lanlan_name}] 已记录表情包话题去重: {selected_meme_topic_key[:60]}")
 
-        return JSONResponse({
+        return await _end_proactive(JSONResponse({
             "success": True,
             "action": "chat",
             "message": "主动搭话已发送",
@@ -3553,16 +3649,18 @@ async def proactive_chat(request: Request):
             "active_channels": active_channels,
             "source_links": source_links,
             "turn_id": mgr.current_speech_id
-        })
-        
+        }))
+
     except asyncio.TimeoutError:
         logger.error("主动搭话超时")
+        await _safe_fire_proactive_done(locals())
         return JSONResponse({
             "success": False,
             "error": "AI处理超时"
         }, status_code=504)
     except Exception as e:
         logger.error(f"主动搭话接口异常: {e}")
+        await _safe_fire_proactive_done(locals())
         return JSONResponse({
             "success": False,
             "error": "服务器内部错误",

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2369,21 +2369,21 @@ async def proactive_chat(request: Request):
             return JSONResponse({"success": False, "error": f"角色 {lanlan_name} 不存在"}, status_code=404)
         
         # 检查能否发起新一轮主动搭话：状态机统一把 "AI 正在响应"（_is_responding）、
-        # "用户持有 turn"（owner）、"另一轮 proactive 在跑"（phase != IDLE）三个信号
-        # 收拢到 can_start_proactive 一个 O(1) 判定。mgr.is_active 仅用于判断 session
-        # 是否已实例化，故仍需保留（can_start_proactive 对 session=None 容错）。
+        # "另一轮 proactive 在跑"（phase != IDLE）两个信号收拢到 O(1) 判定。
+        # mgr.is_active 仅用于判断 session 是否已实例化，故仍需保留。
         probe_session = mgr.session if mgr.is_active else None
-        if not mgr.state.can_start_proactive(session=probe_session):
-            return JSONResponse({
-                "success": False,
-                "error": "AI正在响应中，无法主动搭话",
-                "message": "请等待当前响应完成",
-                "state": mgr.state.snapshot(),
-            }, status_code=409)
 
         # ========== Voice mode fast path ==========
-        # 语音模式下不走 Phase1/Phase2，直接注入预录音频触发 AI 回复
+        # 语音模式下不走 Phase1/Phase2，不占 SM 的 proactive phase；先用只读
+        # can_start_proactive 做 409 判定即可。
         if data.get('voice_mode') and mgr.is_active and isinstance(mgr.session, OmniRealtimeClient):
+            if not mgr.state.can_start_proactive(session=probe_session):
+                return JSONResponse({
+                    "success": False,
+                    "error": "AI正在响应中，无法主动搭话",
+                    "message": "请等待当前响应完成",
+                    "state": mgr.state.snapshot(),
+                }, status_code=409)
             delivered = await mgr.trigger_voice_proactive_nudge()
             return JSONResponse({
                 "success": True,
@@ -2391,12 +2391,18 @@ async def proactive_chat(request: Request):
                 "message": "voice proactive triggered" if delivered else "voice proactive skipped (guard)",
             })
 
-        # ========== Text-mode proactive：进入状态机管理 ==========
-        # PROACTIVE_START 让状态机翻到 PHASE1；之后 phase1/phase2 全部走
-        # mgr.state.is_proactive_preempted() 做 O(1) 抢占检查。所有退出路径
-        # 必须经过 _end_proactive() 发出 PROACTIVE_DONE，以复位状态机。
+        # ========== Text-mode proactive：原子 "检查 + 占坑" ==========
+        # try_start_proactive 在 _write_lock 内完成 can_start_proactive 判定 + 翻
+        # IDLE→PHASE1 + 订阅派发，避免并发请求双双通过 can_start_proactive 后
+        # 各自 fire(PROACTIVE_START) 导致两路 proactive 同时进入 PHASE1。
         from main_logic.session_state import SessionEvent as _SE
-        await mgr.state.fire(_SE.PROACTIVE_START)
+        if not await mgr.state.try_start_proactive(session=probe_session):
+            return JSONResponse({
+                "success": False,
+                "error": "AI正在响应中，无法主动搭话",
+                "message": "请等待当前响应完成",
+                "state": mgr.state.snapshot(),
+            }, status_code=409)
         _proactive_done_emitted = False
 
         async def _end_proactive(resp: JSONResponse) -> JSONResponse:

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
 from main_logic.core import LLMSessionManager, _proactive_expected_sid
+from main_logic.session_state import SessionStateMachine
 
 
 def _make_mgr() -> LLMSessionManager:
@@ -45,6 +46,9 @@ def _make_mgr() -> LLMSessionManager:
     mgr._enqueue_tts_text_chunk = MagicMock()
     mgr._respawn_tts_worker = MagicMock()
     mgr.send_lanlan_response = AsyncMock()
+    # 状态机：finish_proactive_delivery / handle_new_message 会 fire 事件，
+    # 所以测试 mgr 也要有真实 SM 实例（轻量、无外部依赖）。
+    mgr.state = SessionStateMachine(lanlan_name="Test")
     return mgr
 
 

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -162,10 +162,20 @@ async def test_can_start_proactive_false_when_phase1():
     assert sm.can_start_proactive() is False
 
 
-async def test_can_start_proactive_false_when_user_owns():
+async def test_can_start_proactive_true_after_user_turn_completes():
+    """Regression: owner == USER 不能永久阻塞 proactive。
+
+    USER_INPUT 会把 owner 翻到 USER，但没有 AI_RESPONSE_END 事件将其复位
+    （Stage 2 未做该项迁移）。can_start_proactive 若卡 owner == USER，用户
+    发第一条消息后所有后续 proactive 都会被永久 409 掉 —— 这是 Codex review
+    发现的 P1 bug。正确语义：只看 phase 和 session._is_responding。
+    """
     sm = _sm()
     await sm.fire(SessionEvent.USER_INPUT, sid="u")
-    assert sm.can_start_proactive() is False
+    # 用户发完了，AI 也不在响应（session=None），proactive 必须能起
+    assert sm.can_start_proactive(session=None) is True
+    # 即使传 session，只要 _is_responding=False 就能起
+    assert sm.can_start_proactive(session=_FakeSession(is_responding=False)) is True
 
 
 async def test_can_start_proactive_true_after_done():

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -359,6 +359,95 @@ async def test_concurrent_user_input_and_proactive_start_converges():
     assert sm_b._preempted is True
 
 
+async def test_try_start_proactive_atomic_only_one_winner():
+    """并发 try_start_proactive：只有一路拿到 turn 所有权，其余都返回 False。
+
+    这是"检查 + 占坑"合成原子操作的核心保证：若分裂为 can_start_proactive +
+    fire(PROACTIVE_START) 两步，两个请求都能在 IDLE 时通过 can_start，进而各自
+    fire 进 PHASE1，claim/commit 互相踩 turn。
+    """
+    sm = _sm()
+
+    results = await asyncio.gather(
+        sm.try_start_proactive(),
+        sm.try_start_proactive(),
+        sm.try_start_proactive(),
+    )
+    assert results.count(True) == 1
+    assert results.count(False) == 2
+    assert sm.phase is ProactivePhase.PHASE1
+    assert sm.owner is TurnOwner.PROACTIVE
+
+
+async def test_try_start_proactive_refuses_when_session_is_responding():
+    """AI 正在为用户回复时（session._is_responding=True），即使 SM phase=IDLE，
+    try_start_proactive 也必须返回 False（与 can_start_proactive 语义对齐）。
+    """
+    sm = _sm()
+
+    class _Resp:
+        _is_responding = True
+
+    ok = await sm.try_start_proactive(session=_Resp())
+    assert ok is False
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm.owner is TurnOwner.NONE
+
+
+async def test_try_start_proactive_dispatches_subscribers():
+    """try_start_proactive 抢到所有权时也要派发 PROACTIVE_START 订阅者，
+    与直接 fire(PROACTIVE_START) 行为一致。
+    """
+    sm = _sm()
+    hits: list[SessionEvent] = []
+
+    def cb(event, payload):
+        hits.append(event)
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    ok = await sm.try_start_proactive()
+    assert ok is True
+    await asyncio.sleep(0)
+    assert hits == [SessionEvent.PROACTIVE_START]
+
+
+async def test_try_start_proactive_false_does_not_dispatch():
+    """try_start_proactive 败者（第二名）不应误触发 PROACTIVE_START 订阅者，
+    否则订阅者会以为有两轮 proactive 在跑。
+    """
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)  # 先占坑
+    hits: list[SessionEvent] = []
+
+    def cb(event, payload):
+        hits.append(event)
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    ok = await sm.try_start_proactive()
+    assert ok is False
+    await asyncio.sleep(0)
+    assert hits == []
+
+
+async def test_swallow_subscriber_cancelled_error():
+    """异步订阅者被取消时，done-callback 必须吞掉 CancelledError，
+    否则 "Task exception was never retrieved" warning 会刷屏。
+    """
+    from main_logic.session_state import _swallow_subscriber_exc
+
+    async def never_returns():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(never_returns())
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # 直接调用 done-callback；不该抛
+    _swallow_subscriber_exc(task)
+
+
 async def test_fire_is_serialized_by_write_lock():
     """并发 fire 应被 write_lock 串行化，内部状态永远一致。"""
     sm = _sm()
@@ -399,18 +488,17 @@ async def test_user_activity_updates_timestamp_without_owner_flip():
 # reset() —— teardown hook，防止跨 session 状态泄漏
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def test_reset_clears_proactive_leftover_state():
-    """若上一轮 proactive 在 PHASE1/PHASE2 中途 WS 断开，PROACTIVE_DONE 没 fire，
-    phase/_preempted/proactive_sid 会粘着；reset 必须清干净。"""
+async def test_reset_clears_state_after_proactive_done():
+    """PROACTIVE_DONE fire 后，reset 应把所有 per-session 字段回零。"""
     sm = _sm()
     await sm.fire(SessionEvent.PROACTIVE_START)
-    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="orphan_sid")
-    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
-    await sm.fire(SessionEvent.USER_INPUT, sid="user_sid_mid_stream")
-    # 模拟 WS 断开：proactive_chat 协程被取消，PROACTIVE_DONE 没 fire
-    # 此时 SM 卡在 PHASE2 + _preempted=True
-    assert sm.phase is ProactivePhase.PHASE2
-    assert sm._preempted is True
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_x")
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    await sm.fire(SessionEvent.PROACTIVE_DONE)
+
+    # 此刻 owner=USER（被抢占后的正常状态），phase=IDLE
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm.owner is TurnOwner.USER
 
     await sm.reset()
 
@@ -419,8 +507,28 @@ async def test_reset_clears_proactive_leftover_state():
     assert sm.proactive_sid is None
     assert sm.user_sid is None
     assert sm._preempted is False
-    # reset 后 can_start_proactive 必须放行，否则新 session 永远起不了 proactive
     assert sm.can_start_proactive() is True
+
+
+async def test_reset_is_noop_during_active_proactive_phase():
+    """reset 在 PROACTIVE_ACTIVE 阶段必须 no-op：若 ``prepare_proactive_delivery``
+    的 auto-start 子路径通过 ``start_session → end_session → _init_renew_status``
+    间接触发 reset，不能把当前正在跑的 proactive 状态（phase/_preempted）一并吹掉，
+    否则后续 phase1/phase2 的抢占检测会失效。
+    """
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="live_sid")
+    await sm.fire(SessionEvent.USER_INPUT, sid="preempt_sid")
+    assert sm._preempted is True
+
+    await sm.reset()
+
+    # 活动阶段 reset 不生效，phase/_preempted/sids 保持不变
+    assert sm.phase is ProactivePhase.PHASE1
+    assert sm._preempted is True
+    assert sm.proactive_sid == "live_sid"
+    assert sm.user_sid == "preempt_sid"
 
 
 async def test_reset_preserves_subscribers():

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -411,8 +411,8 @@ async def test_async_subscriber_returning_task_with_exception_is_swallowed():
 # 并发
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def test_concurrent_user_input_and_proactive_start_converges():
-    """USER_INPUT 和 PROACTIVE_START 并发 fire：无论谁先，终态都自洽。
+async def test_interleaved_user_input_and_proactive_start_converges():
+    """USER_INPUT 和 PROACTIVE_START 两种交错顺序：无论谁先 fire，终态都自洽。
 
     - USER_INPUT 先：owner=USER，PROACTIVE_START 后 owner 被改成 PROACTIVE，
       phase=PHASE1，此时 is_proactive_preempted=False（因为 sticky 在 START

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -395,6 +395,61 @@ async def test_user_activity_updates_timestamp_without_owner_flip():
 # snapshot
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ─────────────────────────────────────────────────────────────────────────────
+# reset() —— teardown hook，防止跨 session 状态泄漏
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_reset_clears_proactive_leftover_state():
+    """若上一轮 proactive 在 PHASE1/PHASE2 中途 WS 断开，PROACTIVE_DONE 没 fire，
+    phase/_preempted/proactive_sid 会粘着；reset 必须清干净。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="orphan_sid")
+    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+    await sm.fire(SessionEvent.USER_INPUT, sid="user_sid_mid_stream")
+    # 模拟 WS 断开：proactive_chat 协程被取消，PROACTIVE_DONE 没 fire
+    # 此时 SM 卡在 PHASE2 + _preempted=True
+    assert sm.phase is ProactivePhase.PHASE2
+    assert sm._preempted is True
+
+    await sm.reset()
+
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm.owner is TurnOwner.NONE
+    assert sm.proactive_sid is None
+    assert sm.user_sid is None
+    assert sm._preempted is False
+    # reset 后 can_start_proactive 必须放行，否则新 session 永远起不了 proactive
+    assert sm.can_start_proactive() is True
+
+
+async def test_reset_preserves_subscribers():
+    """reset 是 teardown hook，不该把应用层注册的订阅钩子吹掉。"""
+    sm = _sm()
+    hits: list[SessionEvent] = []
+
+    def cb(event, payload):
+        hits.append(event)
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.reset()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await asyncio.sleep(0)
+    # 两次 START 都触发了订阅者
+    assert hits == [SessionEvent.PROACTIVE_START, SessionEvent.PROACTIVE_START]
+
+
+async def test_reset_preserves_last_user_activity():
+    """reset 不该把 last_user_activity 吹回 0：跨 session 的活跃度追踪还要用。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    activity = sm.last_user_activity
+    assert activity > 0
+    await sm.reset()
+    assert sm.last_user_activity == activity
+
+
 async def test_snapshot_fields():
     sm = _sm()
     await sm.fire(SessionEvent.PROACTIVE_START)

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -1,0 +1,397 @@
+"""``SessionStateMachine`` 的单元测试。
+
+覆盖点：
+1. 初始态 / 正常 proactive 生命周期转移
+2. USER_INPUT 在 phase1 / phase2 / committing 的 sticky preempt 行为
+3. ``is_proactive_preempted`` 的零成本读（sticky flag + claim_token 兜底）
+4. ``can_start_proactive`` 在各状态下的返回
+5. ``PROACTIVE_DONE`` 的 owner 复位规则（被抢占时不误覆盖 USER）
+6. 订阅者的派发顺序与状态一致性
+7. 并发 fire 的最终态不依赖调度顺序
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from main_logic.session_state import (
+    ProactivePhase,
+    SessionEvent,
+    SessionStateMachine,
+    TurnOwner,
+)
+
+
+def _sm() -> SessionStateMachine:
+    return SessionStateMachine(lanlan_name="Test")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 初始态 & 正常 proactive 生命周期
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_initial_state_is_idle():
+    sm = _sm()
+    assert sm.owner is TurnOwner.NONE
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm.proactive_sid is None
+    assert sm._preempted is False
+    assert sm.is_proactive_preempted() is False
+    assert sm.can_start_proactive() is True
+
+
+async def test_normal_proactive_lifecycle():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm.phase is ProactivePhase.PHASE1
+    assert sm.owner is TurnOwner.PROACTIVE
+
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_1")
+    assert sm.proactive_sid == "sid_1"
+
+    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+    assert sm.phase is ProactivePhase.PHASE2
+
+    await sm.fire(SessionEvent.PROACTIVE_COMMITTING)
+    assert sm.phase is ProactivePhase.COMMITTING
+
+    await sm.fire(SessionEvent.PROACTIVE_DONE)
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm.owner is TurnOwner.NONE
+    assert sm.proactive_sid is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# USER_INPUT sticky preempt
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_user_input_during_phase1_marks_preempted():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.USER_INPUT, sid="user_sid")
+    assert sm._preempted is True
+    assert sm.owner is TurnOwner.USER
+    assert sm.is_proactive_preempted() is True
+
+
+async def test_user_input_during_phase2_marks_preempted():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_2")
+    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+    await sm.fire(SessionEvent.USER_INPUT, sid="user_sid")
+    assert sm._preempted is True
+    assert sm.is_proactive_preempted(claim_token="sid_2") is True
+
+
+async def test_user_input_during_committing_marks_preempted():
+    """Commit 极短窗口内也得标 preempted —— 后续 _record_proactive_chat 等
+    副作用仍会走 committed=False 路径跳过，但 SM 要如实反映真相。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_3")
+    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+    await sm.fire(SessionEvent.PROACTIVE_COMMITTING)
+    await sm.fire(SessionEvent.USER_INPUT, sid="user_sid")
+    assert sm._preempted is True
+
+
+async def test_user_input_when_idle_does_not_flip_preempted():
+    sm = _sm()
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    assert sm._preempted is False
+    assert sm.owner is TurnOwner.USER
+    assert sm.is_proactive_preempted() is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_proactive_preempted 的 claim_token 兜底
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_is_proactive_preempted_sticky_after_user_input():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_x")
+    # 即使 sid 还没动，sticky flag 已经是 True
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    # claim_token 与 proactive_sid 其实一致，但 sticky 仍然返回 True
+    assert sm.is_proactive_preempted(claim_token="sid_x") is True
+
+
+async def test_is_proactive_preempted_claim_token_mismatch_fallback():
+    """proactive_sid 不等于 claim_token 时也应返回 True —— 防御性兜底，
+    正常情况 sticky flag 已先触发，这里是双保险。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_current")
+    assert sm.is_proactive_preempted(claim_token="sid_stale") is True
+
+
+async def test_is_proactive_preempted_claim_token_matches_not_preempted():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_m")
+    assert sm.is_proactive_preempted(claim_token="sid_m") is False
+
+
+async def test_is_proactive_preempted_phase1_none_token_ok():
+    """phase1 尚未 claim 时 claim_token=None，只看 sticky flag。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm.is_proactive_preempted(claim_token=None) is False
+
+
+async def test_proactive_claim_dropped_if_preempted():
+    """用户在 phase1 抢占后，即使 prepare_proactive_delivery 还是 fire 了
+    CLAIM，proactive_sid 不应被填上 —— 否则 phase2 会误以为自己仍然持有 turn。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="should_not_stick")
+    assert sm.proactive_sid is None
+    assert sm.is_proactive_preempted() is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# can_start_proactive
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_can_start_proactive_false_when_phase1():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm.can_start_proactive() is False
+
+
+async def test_can_start_proactive_false_when_user_owns():
+    sm = _sm()
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    assert sm.can_start_proactive() is False
+
+
+async def test_can_start_proactive_true_after_done():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_DONE)
+    assert sm.can_start_proactive() is True
+
+
+class _FakeSession:
+    """只暴露 `_is_responding` 的最小 session stub。"""
+
+    def __init__(self, is_responding: bool) -> None:
+        self._is_responding = is_responding
+
+
+async def test_can_start_proactive_false_when_session_is_responding():
+    """AI 正在为用户回复 —— 即使 SM 自己看起来 IDLE，也不能起 proactive。
+
+    这一步把原来 router 里直读 session._is_responding 的检查收拢到 SM。
+    """
+    sm = _sm()
+    assert sm.phase is ProactivePhase.IDLE
+    session = _FakeSession(is_responding=True)
+    assert sm.can_start_proactive(session=session) is False
+
+
+async def test_can_start_proactive_true_with_idle_session():
+    sm = _sm()
+    session = _FakeSession(is_responding=False)
+    assert sm.can_start_proactive(session=session) is True
+
+
+async def test_can_start_proactive_none_session_falls_back_to_sm_only():
+    """session=None 时只看 SM 自己的字段，向后兼容单元测试。"""
+    sm = _sm()
+    assert sm.can_start_proactive(session=None) is True
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm.can_start_proactive(session=None) is False
+
+
+async def test_can_start_proactive_session_without_is_responding_attr():
+    """session 没有 `_is_responding` 字段时（老 session 类型）不该抛，当作 False 处理。"""
+    sm = _sm()
+
+    class _BareSession:
+        pass
+
+    assert sm.can_start_proactive(session=_BareSession()) is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PROACTIVE_DONE 对 owner 的处理
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_proactive_done_preserves_user_ownership_after_preempt():
+    """抢占路径下，proactive 最后 fire DONE 时 owner 已经是 USER，
+    DONE 不该把 owner 改成 NONE —— 用户仍然持有 turn。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    assert sm.owner is TurnOwner.USER
+    await sm.fire(SessionEvent.PROACTIVE_DONE)
+    assert sm.owner is TurnOwner.USER
+    # 但 phase 和 sticky flag 确实复位
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm._preempted is False
+
+
+async def test_proactive_done_flips_owner_to_none_on_clean_exit():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="c")
+    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+    await sm.fire(SessionEvent.PROACTIVE_COMMITTING)
+    await sm.fire(SessionEvent.PROACTIVE_DONE)
+    assert sm.owner is TurnOwner.NONE
+
+
+async def test_second_proactive_after_done_starts_fresh():
+    """一轮抢占结束后，下一轮 proactive 应重新归 IDLE → PHASE1，sticky 清零。"""
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.USER_INPUT, sid="u1")
+    await sm.fire(SessionEvent.PROACTIVE_DONE)
+    # USER_INPUT 让 owner 变 USER；下一轮 START 要能重新 claim
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm._preempted is False
+    assert sm.phase is ProactivePhase.PHASE1
+    assert sm.owner is TurnOwner.PROACTIVE
+    assert sm.is_proactive_preempted() is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 订阅
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_subscriber_sees_post_apply_state():
+    """订阅者在回调触发时观察到的状态必然是"事件 apply 后"的状态。"""
+    sm = _sm()
+    observed: list[tuple[ProactivePhase, TurnOwner]] = []
+
+    def cb(event, payload):
+        observed.append((sm.phase, sm.owner))
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    # 订阅者回调是异步 schedule，让一次事件循环
+    await asyncio.sleep(0)
+    assert observed == [(ProactivePhase.PHASE1, TurnOwner.PROACTIVE)]
+
+
+async def test_subscriber_exception_does_not_break_event_flow():
+    sm = _sm()
+
+    def bad(event, payload):
+        raise RuntimeError("subscriber should not break caller")
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, bad)
+    # fire 不应该抛
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm.phase is ProactivePhase.PHASE1
+
+
+async def test_wildcard_subscriber_gets_all_events():
+    sm = _sm()
+    received: list[SessionEvent] = []
+
+    def cb(event, payload):
+        received.append(event)
+
+    sm.subscribe(None, cb)
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.USER_INPUT, sid="u")
+    await asyncio.sleep(0)
+    assert SessionEvent.PROACTIVE_START in received
+    assert SessionEvent.USER_INPUT in received
+
+
+async def test_async_subscriber_coroutine_is_scheduled():
+    sm = _sm()
+    fired = asyncio.Event()
+
+    async def cb(event, payload):
+        fired.set()
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await asyncio.wait_for(fired.wait(), timeout=1.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 并发
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_concurrent_user_input_and_proactive_start_converges():
+    """USER_INPUT 和 PROACTIVE_START 并发 fire：无论谁先，终态都自洽。
+
+    - USER_INPUT 先：owner=USER，PROACTIVE_START 后 owner 被改成 PROACTIVE，
+      phase=PHASE1，此时 is_proactive_preempted=False（因为 sticky 在 START
+      时被清零 —— 这是故意的：START 表示一轮新 proactive，上一轮遗留的
+      sticky flag 不该影响新轮次）。
+    - PROACTIVE_START 先：phase=PHASE1，USER_INPUT 后 _preempted=True、
+      owner=USER，sticky 翻起。
+    这两条路径终态不同是意料之中的 —— 我们只验证各自都"自洽"。
+    """
+    # Case A: USER_INPUT 先
+    sm_a = _sm()
+    await sm_a.fire(SessionEvent.USER_INPUT, sid="u")
+    await sm_a.fire(SessionEvent.PROACTIVE_START)
+    assert sm_a.phase is ProactivePhase.PHASE1
+    assert sm_a.owner is TurnOwner.PROACTIVE
+    assert sm_a._preempted is False
+
+    # Case B: PROACTIVE_START 先
+    sm_b = _sm()
+    await sm_b.fire(SessionEvent.PROACTIVE_START)
+    await sm_b.fire(SessionEvent.USER_INPUT, sid="u")
+    assert sm_b.phase is ProactivePhase.PHASE1  # phase 自己不动，由 DONE 清
+    assert sm_b.owner is TurnOwner.USER
+    assert sm_b._preempted is True
+
+
+async def test_fire_is_serialized_by_write_lock():
+    """并发 fire 应被 write_lock 串行化，内部状态永远一致。"""
+    sm = _sm()
+
+    async def burst():
+        await sm.fire(SessionEvent.PROACTIVE_START)
+        await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="s")
+        await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+        await sm.fire(SessionEvent.PROACTIVE_COMMITTING)
+        await sm.fire(SessionEvent.PROACTIVE_DONE)
+
+    await asyncio.gather(burst(), burst(), burst())
+    # 三轮完整生命周期之后终态必然是 IDLE
+    assert sm.phase is ProactivePhase.IDLE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# USER_ACTIVITY（静默信号，不轮换 sid/owner）
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_user_activity_updates_timestamp_without_owner_flip():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    before_activity = sm.last_user_activity
+    await sm.fire(SessionEvent.USER_ACTIVITY)
+    assert sm.last_user_activity > before_activity
+    # owner 未被改动
+    assert sm.owner is TurnOwner.PROACTIVE
+    # sticky 未被翻（USER_ACTIVITY 不表示抢占）
+    assert sm._preempted is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# snapshot
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_snapshot_fields():
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="sid_snap")
+    snap = sm.snapshot()
+    assert snap["lanlan_name"] == "Test"
+    assert snap["owner"] == TurnOwner.PROACTIVE.value
+    assert snap["phase"] == ProactivePhase.PHASE1.value
+    assert snap["proactive_sid"] == "sid_snap"
+    assert snap["preempted"] is False

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -612,6 +612,29 @@ async def test_reset_is_noop_during_active_proactive_phase():
     assert sm.user_sid == "preempt_sid"
 
 
+async def test_reset_force_clears_state_even_during_active_proactive():
+    """reset(force=True) 是真正的 teardown（WS 断开 / end_session）：即便 proactive
+    还卡在 PHASE1/PHASE2，也必须强制清场，否则 phase/_preempted 会泄漏到下一轮
+    session，彻底堵死 can_start_proactive 的 IDLE 判定。
+    """
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="live_sid")
+    await sm.fire(SessionEvent.USER_INPUT, sid="preempt_sid")
+    assert sm.phase is ProactivePhase.PHASE1
+    assert sm._preempted is True
+
+    await sm.reset(force=True)
+
+    # force=True 绕过活动 phase 保护，全部字段复位
+    assert sm.phase is ProactivePhase.IDLE
+    assert sm._preempted is False
+    assert sm.proactive_sid is None
+    assert sm.user_sid is None
+    assert sm.owner is TurnOwner.NONE
+    assert sm.can_start_proactive() is True
+
+
 async def test_reset_preserves_subscribers():
     """reset 是 teardown hook，不该把应用层注册的订阅钩子吹掉。"""
     sm = _sm()

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -141,6 +141,48 @@ async def test_is_proactive_preempted_phase1_none_token_ok():
     assert sm.is_proactive_preempted(claim_token=None) is False
 
 
+async def test_mark_user_input_preempt_sync_flips_flag_during_active_phase():
+    """``mark_user_input_preempt`` 是 sid 轮换路径在 ``self.lock`` 内同步调用的
+    helper，保证 sid 写入 + preempt 翻起原子可见。活动阶段必须翻，idle 阶段不翻。
+    """
+    sm = _sm()
+    # idle 时 no-op
+    sm.mark_user_input_preempt()
+    assert sm._preempted is False
+
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    assert sm._preempted is False
+    sm.mark_user_input_preempt()
+    assert sm._preempted is True
+
+    # PHASE2 / COMMITTING 同样覆盖
+    sm._preempted = False
+    await sm.fire(SessionEvent.PROACTIVE_PHASE2)
+    sm.mark_user_input_preempt()
+    assert sm._preempted is True
+
+    sm._preempted = False
+    await sm.fire(SessionEvent.PROACTIVE_COMMITTING)
+    sm.mark_user_input_preempt()
+    assert sm._preempted is True
+
+
+async def test_mark_user_input_preempt_atomically_visible_before_full_fire():
+    """回归 race：prepare_proactive_delivery 必须在 ``mark_user_input_preempt``
+    之后、``fire(USER_INPUT)`` 之前，也能从 ``is_proactive_preempted()`` 看到 True。
+    这模拟 core.py 里 sid 轮换的临界区语义。
+    """
+    sm = _sm()
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await sm.fire(SessionEvent.PROACTIVE_CLAIM, sid="claim_sid")
+
+    # 模拟 handle_new_message 持 self.lock 写新 sid + mark 翻 flag 的片段
+    sm.mark_user_input_preempt()
+    # 此刻 fire(USER_INPUT) 还没调用；但并发的 prepare_proactive_delivery 在
+    # 其 lock-held 复查点已能看到抢占，绝不会再误写 current_speech_id。
+    assert sm.is_proactive_preempted(claim_token="claim_sid") is True
+
+
 async def test_proactive_claim_dropped_if_preempted():
     """用户在 phase1 抢占后，即使 prepare_proactive_delivery 还是 fire 了
     CLAIM，proactive_sid 不应被填上 —— 否则 phase2 会误以为自己仍然持有 turn。"""
@@ -325,6 +367,44 @@ async def test_async_subscriber_coroutine_is_scheduled():
     sm.subscribe(SessionEvent.PROACTIVE_START, cb)
     await sm.fire(SessionEvent.PROACTIVE_START)
     await asyncio.wait_for(fired.wait(), timeout=1.0)
+
+
+async def test_async_subscriber_returning_task_is_also_awaited():
+    """订阅者若返回已创建的 Task（而非 coroutine），派发路径也要能接管它，
+    异常/取消才不会绕过 ``_swallow_subscriber_exc`` 泄漏到事件循环。
+    """
+    sm = _sm()
+    inner_fired = asyncio.Event()
+
+    async def inner():
+        inner_fired.set()
+
+    def cb(event, payload):
+        # 返回 Task 而非 coroutine；早先的 iscoroutine 分支会把它漏过去
+        return asyncio.create_task(inner())
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    await asyncio.wait_for(inner_fired.wait(), timeout=1.0)
+
+
+async def test_async_subscriber_returning_task_with_exception_is_swallowed():
+    """返回 Task 的订阅者，其任务抛异常不应产生 "Task exception was never
+    retrieved" warning（由 done-callback 静默吞下）。
+    """
+    sm = _sm()
+
+    async def inner_raises():
+        raise RuntimeError("boom")
+
+    def cb(event, payload):
+        return asyncio.create_task(inner_raises())
+
+    sm.subscribe(SessionEvent.PROACTIVE_START, cb)
+    await sm.fire(SessionEvent.PROACTIVE_START)
+    # 让 inner_raises 任务运行并被 done-callback 吞掉
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_session_state.py
+++ b/tests/unit/test_session_state.py
@@ -443,8 +443,9 @@ async def test_swallow_subscriber_cancelled_error():
     try:
         await task
     except asyncio.CancelledError:
+        # 故意吞：这里只是把 task 驱动到 done 态供下面 _swallow_subscriber_exc
+        # 调用，CancelledError 本身就是测试期望的结果。
         pass
-    # 直接调用 done-callback；不该抛
     _swallow_subscriber_exc(task)
 
 


### PR DESCRIPTION
## 背景 / 动机

text-mode proactive（`/api/proactive_chat` 的 phase1 LLM + phase2 流式 TTS）之前没有中途 preempt 检查，用户在主动搭话中途打断时，后端经常整条跑到尾才在 PR #862 / #863 的末尾 sid guard 里识破，白烧一整条 LLM 调用 + 流式 TTS。

本 PR 引入一个**事件驱动的 per-session 状态机**（`SessionStateMachine`），收口散落在 `LLMSessionManager` / `OmniOfflineClient` 中的"谁占用当前 turn"信号（`current_speech_id` 轮换、`session._is_responding`、proactive 生命周期），让 phase1/phase2 可以在每个大 await 边界 / 每个 chunk 顶端做 **O(1) 无锁无 await** 的抢占检查。

> 关联 PR：#862（Phase 2 abort sid guard，已 merged）、#863（sid guard 全链路硬化，OPEN）

## 设计

### 状态机（`main_logic/session_state.py`）

```
TurnOwner: NONE | USER | PROACTIVE
ProactivePhase: IDLE → PHASE1 → PHASE2 → COMMITTING → IDLE
SessionEvent: USER_INPUT / USER_ACTIVITY / PROACTIVE_START / _CLAIM /
              _PHASE2 / _COMMITTING / _DONE
```

- **写路径**：`fire(event, **payload)`，内部 `_write_lock` 串行化 apply；订阅回调在锁外异步派发，异常静默吸收，不阻塞事件流。
- **读路径**：`is_proactive_preempted(claim_token) -> bool` / `can_start_proactive(session=None) -> bool` 只读字段，无锁无 await，可在热路径随意调用。
- `_preempted` 是 **sticky flag**：PROACTIVE_* 阶段期间一旦有 USER_INPUT 事件立刻翻 True，PROACTIVE_START/DONE 时清零。
- `PROACTIVE_CLAIM` 在 `_preempted` 已起时**不回写 sid**，防止 phase2 误以为自己还持有 turn。
- `PROACTIVE_DONE` 不覆盖 USER owner（用户已接管时保留 USER 态）。

### 事件发射点（`main_logic/core.py`）

| 位置 | 事件 |
|---|---|
| `handle_new_message()` sid 轮换后 | `USER_INPUT(sid=new_sid)` |
| text 模式 stream_text 入口 sid 轮换后 | `USER_INPUT(sid=new_sid)` |
| `prepare_proactive_delivery` 末尾 | `PROACTIVE_CLAIM(sid=new_sid)` |
| `finish_proactive_delivery` 入 write_lock 内 | `PROACTIVE_COMMITTING` |

### 路由层接入（`main_routers/system_router.py`）

- **入口 409** 判定换成 `mgr.state.can_start_proactive(session=mgr.session)`，吸收原先直读 `_is_responding` 的逻辑。
- **Phase 1 preempt check** 共 6 处，覆盖每段大 await：
  - 并行 `_fetch_source` gather 之后
  - memory_server `new_dialog` HTTP GET 之后
  - reflection/followup_topics HTTP 之后
  - unified LLM 调用之前
  - 并行 music/meme post-fetch 之后
  - `prepare_proactive_delivery` 之前
- **Phase 2 preempt check**：`astream` 循环顶端 + `_emit_safe` 入口两处；进入 phase2 时 `fire(PROACTIVE_PHASE2)`。
- **统一退出**：所有 `return JSONResponse` 走 `_end_proactive(resp)` 包装（幂等 fire `PROACTIVE_DONE`）；outer `except` 用 `_safe_fire_proactive_done(locals())` 兜底复位。

### 副作用安全

抢占命中时 `current_speech_id` 已被用户轮走，走既有的 sid 比较 guard（PR #862 / #863）自动跳过：

- `handle_new_message()` 的清 TTS 只在 `not mgr.state.is_proactive_preempted(proactive_sid)` 时触发（避免 PR #862 修的误清 bug）
- `feed_tts_chunk(expected_speech_id=...)` lock 内二次校验
- `finish_proactive_delivery(expected_speech_id=...)` lock 内校验，sid 不符返回 False，路由层短路 `_record_proactive_chat` / topic usage / surfaced reflection

## 不在本 PR 范围

- voice fudge（`trigger_voice_proactive_nudge`，PR #864 已覆盖）
- `handle_text_data` / `handle_output_transcript` 里的 `_proactive_expected_sid` contextvar guard（per-task 隔离，agent_callback / greeting 路径专用，语义与 SM 互补而非冗余）
- `trigger_agent_callbacks` / `trigger_greeting` 尚未接入 SM —— 下 PR 做 mutual exclusion

## 测试

### 单测（`uv run pytest tests/unit/test_session_state.py tests/unit/test_proactive_sid_guard.py -q` → **44 passed**）

新增 `tests/unit/test_session_state.py` 29 个单测覆盖：

- 初始态 + 正常 proactive 生命周期
- USER_INPUT 在 PHASE1 / PHASE2 / COMMITTING 的 sticky preempt
- `is_proactive_preempted` 的 sticky flag + claim_token 兜底
- `can_start_proactive` 在各状态 / 各 session 组合下的返回（含 `session._is_responding` 探测）
- PROACTIVE_DONE 的 owner 复位规则（抢占路径不误覆盖 USER）
- PROACTIVE_CLAIM 在 preempted 状态下不回写 sid
- 订阅者派发时序（apply 后观察到新态）、同步异常隔离、async 订阅 coroutine 派发
- 并发 fire 的最终态自洽（write_lock 串行化）
- `USER_ACTIVITY` 不轮换 owner/sid / snapshot 字段

`tests/unit/test_proactive_sid_guard.py` 的 `_make_mgr()` 加了 `mgr.state = SessionStateMachine(...)` 字段，原 15 个 sid guard 测试继续全绿。

### 手动回放步骤（建议 reviewer 验证）

- [ ] **Phase 1 中途打断**：打开 NEKO，触发 proactive（等 ~30s idle）→ phase1 LLM 调用刚发出 <3s 内从前端发消息。期望：后端日志出现 `proactive phase1_* preempted by user takeover`，HTTP 200 `action=pass`，用户新回复正常，无残留 proactive 气泡。
- [ ] **Phase 2 中途打断**：同上，但等到 phase2 首字已吐出再打断。期望：后端日志 `Phase 2 astream chunk 前检测到抢占, abort` 或 `Phase 2 检测到用户接管（state 抢占），abort`，不调 `handle_new_message`（避免误清用户 TTS），前端不显示半截 proactive 内容。
- [ ] **正常 happy path**：proactive 跑到底无打断。期望：状态机从 IDLE → PHASE1 → PHASE2 → COMMITTING → IDLE，响应 `action=chat`，行为与改动前一致。
- [ ] **入口 409**：AI 正在回复时触发 proactive。期望：`state.can_start_proactive()` 命中 `_is_responding==True` 分支，返回 409，响应体附 `state.snapshot()` 便于诊断。

### Review Pass

改动经独立 subagent review（跑过完整测试、检查了 return 路径覆盖 / 异常边界 / 发射点正确性），reviewer 指出 phase1 里 memory_server 和 reflection 两段 httpx 裸 await 漏检查，已在本 PR 中补齐；另加了订阅者 async 任务异常 swallow 防 "Task exception was never retrieved"。

Related: #862 #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入会话级异步事件驱动状态机，精细协调主动交互阶段、轮次所有权与抢占；在会话续期时重置状态。

* **改进**
  * 在主动交付与用户输入路径统一发出事件与使用快照化交付标识，减少竞态与不一致。

* **Bug 修复**
  * 在多处检查点加强抢占检测与早期短路，确保超时/异常路径能稳妥结束并清理状态。

* **测试**
  * 大幅扩展单元测试，覆盖状态机生命周期、抢占语义、并发竞态、订阅回调与重置行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->