### PR TITLE
perf(async): 泛化 internal_http_client + 新增 external_http_client，全局 httpx 审计

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1621,8 +1621,8 @@ class LLMSessionManager:
             async def _fetch_new_dialog():
                 """独立任务：取 /new_dialog 响应。在 gather 之前就 kick off，
                 主动避开 TTS worker 启动时的 GIL 争用窗口。"""
-                from utils.memory_client import get_memory_client
-                _mem_client = get_memory_client()
+                from utils.internal_http_client import get_internal_http_client
+                _mem_client = get_internal_http_client()
                 try:
                     resp = await _mem_client.get(
                         f"http://127.0.0.1:{_dlg_port}/new_dialog/{_dlg_lanlan}",
@@ -1976,33 +1976,36 @@ class LLMSessionManager:
         """Query agent server for active tasks and return a prompt snippet."""
         if not self._is_agent_enabled():
             return ""
-        # per-call AsyncClient: agent mode 才跑，每次 session init 一次，目标是 TOOL_SERVER_PORT
-        # （非 memory_client 覆盖的 host），为此单独开共享 client 收益不值得
+        # 复用 internal_http_client 单例：agent mode session init 走此路径，
+        # TOOL_SERVER_PORT 也是 127.0.0.1 内部服务
         try:
-            async with httpx.AsyncClient(timeout=1.5, proxy=None, trust_env=False) as client:
-                resp = await client.get(f"http://127.0.0.1:{TOOL_SERVER_PORT}/tasks")
-                if resp.status_code != 200:
-                    return ""
-                data = resp.json()
-                tasks = data.get("tasks", [])
-                active = [t for t in tasks if t.get("status") in ("running", "queued")]
-                if not active:
-                    return ""
-                _lang = normalize_language_code(self.user_language, format='short')
-                lines = []
-                for t in active:
-                    params = t.get("params") or {}
-                    desc = params.get("query") or params.get("instruction") or t.get("original_query") or t.get("id", "")[:8]
-                    status = _loc(AGENT_TASK_STATUS_RUNNING, _lang) if t.get("status") == "running" else _loc(AGENT_TASK_STATUS_QUEUED, _lang)
-                    lines.append(f"  - [{status}] {desc}")
-                if len(lines) > 0:
-                    return (
-                        _loc(AGENT_TASKS_HEADER, _lang)
-                        + "\n".join(lines)
-                        + _loc(AGENT_TASKS_NOTICE, _lang)
-                    )
-                else:
-                    return ""
+            from utils.internal_http_client import get_internal_http_client
+            client = get_internal_http_client()
+            resp = await client.get(
+                f"http://127.0.0.1:{TOOL_SERVER_PORT}/tasks", timeout=1.5,
+            )
+            if resp.status_code != 200:
+                return ""
+            data = resp.json()
+            tasks = data.get("tasks", [])
+            active = [t for t in tasks if t.get("status") in ("running", "queued")]
+            if not active:
+                return ""
+            _lang = normalize_language_code(self.user_language, format='short')
+            lines = []
+            for t in active:
+                params = t.get("params") or {}
+                desc = params.get("query") or params.get("instruction") or t.get("original_query") or t.get("id", "")[:8]
+                status = _loc(AGENT_TASK_STATUS_RUNNING, _lang) if t.get("status") == "running" else _loc(AGENT_TASK_STATUS_QUEUED, _lang)
+                lines.append(f"  - [{status}] {desc}")
+            if len(lines) > 0:
+                return (
+                    _loc(AGENT_TASKS_HEADER, _lang)
+                    + "\n".join(lines)
+                    + _loc(AGENT_TASKS_NOTICE, _lang)
+                )
+            else:
+                return ""
         except Exception:
             return ""
 
@@ -2117,8 +2120,8 @@ class LLMSessionManager:
             
             initial_prompt = await self._build_initial_prompt()
             self.initial_cache_snapshot_len = len(self.message_cache_for_new_session)
-            from utils.memory_client import get_memory_client
-            _hs_client = get_memory_client()
+            from utils.internal_http_client import get_internal_http_client
+            _hs_client = get_internal_http_client()
             try:
                 resp = await _hs_client.get(
                     f"http://127.0.0.1:{self.memory_server_port}/new_dialog/{self.lanlan_name}",
@@ -2506,11 +2509,11 @@ class LLMSessionManager:
             logger.info("[%s] trigger_greeting: voice session active/starting, skipping", self.lanlan_name)
             return
 
-        # 复用 memory_client 单例：session 启动路径，避开 AsyncClient 构造开销
-        # （Windows idle 157ms，事件循环压力下可达 1.1s，详见 utils/memory_client.py）
+        # 复用 internal_http_client 单例：session 启动路径，避开 AsyncClient 构造开销
+        # （Windows idle 157ms，事件循环压力下可达 1.1s，详见 utils/internal_http_client.py）
         try:
-            from utils.memory_client import get_memory_client
-            _mem_client = get_memory_client()
+            from utils.internal_http_client import get_internal_http_client
+            _mem_client = get_internal_http_client()
             resp = await _mem_client.get(
                 f"http://127.0.0.1:{self.memory_server_port}/last_conversation_gap/{self.lanlan_name}",
                 timeout=2.0,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1976,6 +1976,8 @@ class LLMSessionManager:
         """Query agent server for active tasks and return a prompt snippet."""
         if not self._is_agent_enabled():
             return ""
+        # per-call AsyncClient: agent mode 才跑，每次 session init 一次，目标是 TOOL_SERVER_PORT
+        # （非 memory_client 覆盖的 host），为此单独开共享 client 收益不值得
         try:
             async with httpx.AsyncClient(timeout=1.5, proxy=None, trust_env=False) as client:
                 resp = await client.get(f"http://127.0.0.1:{TOOL_SERVER_PORT}/tasks")
@@ -2504,13 +2506,19 @@ class LLMSessionManager:
             logger.info("[%s] trigger_greeting: voice session active/starting, skipping", self.lanlan_name)
             return
 
+        # 复用 memory_client 单例：session 启动路径，避开 AsyncClient 构造开销
+        # （Windows idle 157ms，事件循环压力下可达 1.1s，详见 utils/memory_client.py）
         try:
-            async with httpx.AsyncClient(timeout=2.0, proxy=None, trust_env=False) as client:
-                resp = await client.get(f"http://127.0.0.1:{self.memory_server_port}/last_conversation_gap/{self.lanlan_name}")
-                if not resp.is_success:
-                    logger.warning("[%s] trigger_greeting: memory server returned %s", self.lanlan_name, resp.status_code)
-                    return
-                gap_seconds = resp.json().get("gap_seconds", -1)
+            from utils.memory_client import get_memory_client
+            _mem_client = get_memory_client()
+            resp = await _mem_client.get(
+                f"http://127.0.0.1:{self.memory_server_port}/last_conversation_gap/{self.lanlan_name}",
+                timeout=2.0,
+            )
+            if not resp.is_success:
+                logger.warning("[%s] trigger_greeting: memory server returned %s", self.lanlan_name, resp.status_code)
+                return
+            gap_seconds = resp.json().get("gap_seconds", -1)
         except Exception as e:
             logger.warning("[%s] trigger_greeting: failed to query gap: %s", self.lanlan_name, e)
             return

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -2591,6 +2591,7 @@ def minimax_tts_worker(request_queue, response_queue, audio_api_key, voice_id, b
         agg_flush_bytes = 4096
 
         # 连通性探测
+        # per-call AsyncClient: 一次性 probe，紧接着下面会构造 per-worker 持久 client
         async with httpx.AsyncClient(timeout=httpx.Timeout(10, connect=10)) as probe:
             probe_resp = await probe.post(
                 api_url, headers=headers,

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1436,6 +1436,7 @@ async def add_catgirl(request: Request):
     await init_one_catgirl(key, is_new=True)
 
     # 通知记忆服务器重新加载配置
+    # per-call AsyncClient: 用户手动新建猫娘触发，典型冷路径
     try:
             async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
                         resp = await client.post(f"http://127.0.0.1:{MEMORY_SERVER_PORT}/reload", timeout=5.0)
@@ -2321,7 +2322,8 @@ async def voice_clone(
                 'speaker_id': prefix,
                 'prompt_text': f"<|{ref_language}|>" if ref_language != 'ch' else "希望你以后能够做的比我还好呦。"
             }
-            
+
+            # per-call AsyncClient: 用户手动上传音色文件触发，冷路径
             async with httpx.AsyncClient(timeout=60, proxy=None, trust_env=False) as client:
                 resp = await client.post(register_url, data=data, files=files)
                 
@@ -2643,6 +2645,7 @@ async def voice_clone_direct(request: Request):
         provider_label = '阿里云CosyVoice'
 
     # 验证直链是否可访问（HEAD失败时回退到GET）
+    # per-call AsyncClient: 用户粘贴直链触发的一次性克隆流程，冷路径（外部 CDN 主机）
     try:
         async with httpx.AsyncClient(timeout=30, proxy=None, trust_env=False) as client:
             head_resp = await client.head(direct_link, follow_redirects=True)
@@ -2666,7 +2669,8 @@ async def voice_clone_direct(request: Request):
             # 1. 下载音频文件（使用流式读取避免内存问题）
             logger.info(f"开始下载直链音频: {direct_link}")
             MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB限制
-            
+
+            # per-call AsyncClient: 用户一次性直链下载，冷路径
             async with httpx.AsyncClient(timeout=60, proxy=None, trust_env=False) as client:
                 async with client.stream('GET', direct_link, follow_redirects=True) as download_resp:
                     if download_resp.status_code != 200:
@@ -2768,7 +2772,8 @@ async def voice_clone_direct(request: Request):
             # 1. 下载音频文件以计算内容MD5（使用流式读取避免内存问题）
             logger.info(f"开始下载直链音频用于CosyVoice: {direct_link}")
             MAX_FILE_SIZE = 100 * 1024 * 1024  # 100MB限制
-            
+
+            # per-call AsyncClient: 用户一次性直链下载，冷路径
             async with httpx.AsyncClient(timeout=60, proxy=None, trust_env=False) as client:
                 async with client.stream('GET', direct_link, follow_redirects=True) as download_resp:
                     if download_resp.status_code != 200:

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -774,6 +774,7 @@ async def update_core_config(request: Request):
             return {"success": False, "error": f"配置已保存但重新加载失败: {str(reload_error)}"}
         
         # 4. Notify agent_server to rebuild CUA adapter with fresh config
+        # per-call AsyncClient: 用户保存 API key 才触发，冷路径
         try:
             import httpx
             from config import TOOL_SERVER_PORT

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -289,6 +289,7 @@ async def api_get_qr_code(
     try:
         import time
         ts = str(int(time.time() * 1000))
+        # per-call AsyncClient: 用户扫码登录触发，冷路径（且每次访问外部平台 host 不同）
         async with httpx.AsyncClient() as client:
             req_method = config.get("method", "GET").upper()
             raw_get_params = config.get("get_params", {})
@@ -378,11 +379,12 @@ async def api_qr_login_poll(
         raw_poll_params = config.get("poll_params", {"qrcode_key": "{{qrcode_key}}"})
         processed_params = {k: (v.replace("{{qrcode_key}}", qrcode_key).replace("{{timestamp}}", ts) if isinstance(v, str) else v) for k, v in raw_poll_params.items()}
 
+        # per-call AsyncClient: 扫码轮询登录，用户触发冷路径
         async with httpx.AsyncClient() as client:
             if req_method == "POST":
                 response = await client.post(
-                    url=config["login"], 
-                    data=processed_params, 
+                    url=config["login"],
+                    data=processed_params,
                     headers=config["headers"],
                     timeout=10
                 )

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -341,6 +341,7 @@ async def save_recent_file(request: Request):
             # 中断 memory_server 的 review 任务
             import httpx
             from config import MEMORY_SERVER_PORT
+            # per-call AsyncClient: 用户手动保存最近对话触发，冷路径
             try:
                 async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
                     await client.post(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2515,8 +2515,8 @@ async def proactive_chat(request: Request):
         
         raw_memory_context = ""
         try:
-            from utils.memory_client import get_memory_client
-            _pt_client = get_memory_client()
+            from utils.internal_http_client import get_internal_http_client
+            _pt_client = get_internal_http_client()
             resp = await _pt_client.get(
                 f"http://127.0.0.1:{MEMORY_SERVER_PORT}/new_dialog/{lanlan_name}",
                 timeout=5.0,
@@ -2571,11 +2571,11 @@ async def proactive_chat(request: Request):
         # 认知框架：Facts → Reflection(pending) → 主动搭话自然提及 → 用户反馈 → Persona
         followup_topics_prompt = ""
         _surfaced_reflection_ids = []  # 记录本次搭话提及了哪些 pending 反思
-        # 复用 memory_client 单例：proactive_chat 每次主动搭话都走此路径
+        # 复用 internal_http_client 单例：proactive_chat 每次主动搭话都走此路径
         try:
-            from utils.memory_client import get_memory_client
+            from utils.internal_http_client import get_internal_http_client
             _mem_base = f"http://127.0.0.1:{MEMORY_SERVER_PORT}"
-            _mem_client = get_memory_client()
+            _mem_client = get_internal_http_client()
             # 1. 自动状态迁移 + 反思合成（集中在 memory_server 进程内执行）
             _reflect_resp = await _mem_client.post(
                 f"{_mem_base}/reflect/{lanlan_name}", timeout=15.0,
@@ -3490,11 +3490,11 @@ async def proactive_chat(request: Request):
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)
 
-        # 后台长期记忆维护（通过 memory_server API）：复用 memory_client 单例
+        # 后台长期记忆维护（通过 memory_server API）：复用 internal_http_client 单例
         try:
-            from utils.memory_client import get_memory_client
+            from utils.internal_http_client import get_internal_http_client
             _mem_base = f"http://127.0.0.1:{MEMORY_SERVER_PORT}"
-            _mem_client = get_memory_client()
+            _mem_client = get_internal_http_client()
             # 保存本次搭话实际提及的 pending 反思 ID（供下次 /process 做反馈检查）
             if _surfaced_reflection_ids:
                 await _mem_client.post(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2571,33 +2571,35 @@ async def proactive_chat(request: Request):
         # 认知框架：Facts → Reflection(pending) → 主动搭话自然提及 → 用户反馈 → Persona
         followup_topics_prompt = ""
         _surfaced_reflection_ids = []  # 记录本次搭话提及了哪些 pending 反思
+        # 复用 memory_client 单例：proactive_chat 每次主动搭话都走此路径
         try:
+            from utils.memory_client import get_memory_client
             _mem_base = f"http://127.0.0.1:{MEMORY_SERVER_PORT}"
-            async with httpx.AsyncClient(proxy=None, trust_env=False) as _mem_client:
-                # 1. 自动状态迁移 + 反思合成（集中在 memory_server 进程内执行）
-                _reflect_resp = await _mem_client.post(
-                    f"{_mem_base}/reflect/{lanlan_name}", timeout=15.0,
-                )
-                if _reflect_resp.status_code == 200:
-                    _reflect_data = _reflect_resp.json()
-                    if _reflect_data.get('auto_transitions'):
-                        print(f"[{lanlan_name}] 自动迁移 {_reflect_data['auto_transitions']} 条反思状态")
-                    if _reflect_data.get('reflection'):
-                        print(f"[{lanlan_name}] 反思完成(pending): {_reflect_data['reflection']['text'][:50]}...")
+            _mem_client = get_memory_client()
+            # 1. 自动状态迁移 + 反思合成（集中在 memory_server 进程内执行）
+            _reflect_resp = await _mem_client.post(
+                f"{_mem_base}/reflect/{lanlan_name}", timeout=15.0,
+            )
+            if _reflect_resp.status_code == 200:
+                _reflect_data = _reflect_resp.json()
+                if _reflect_data.get('auto_transitions'):
+                    print(f"[{lanlan_name}] 自动迁移 {_reflect_data['auto_transitions']} 条反思状态")
+                if _reflect_data.get('reflection'):
+                    print(f"[{lanlan_name}] 反思完成(pending): {_reflect_data['reflection']['text'][:50]}...")
 
-                # 2. 获取回调话题候选
-                _topics_resp = await _mem_client.get(
-                    f"{_mem_base}/followup_topics/{lanlan_name}", timeout=5.0,
-                )
-                if _topics_resp.status_code == 200:
-                    _followup_topics = _topics_resp.json().get('topics', [])
-                    if _followup_topics:
-                        followup_topics_prompt = _loc(PROACTIVE_FOLLOWUP_HEADER, proactive_lang)
-                        for topic in _followup_topics:
-                            followup_topics_prompt += f"- {topic['text']}\n"
-                            if topic.get('id'):
-                                _surfaced_reflection_ids.append(topic['id'])
-                        print(f"[{lanlan_name}] 回调话题候选: {len(_followup_topics)} 条")
+            # 2. 获取回调话题候选
+            _topics_resp = await _mem_client.get(
+                f"{_mem_base}/followup_topics/{lanlan_name}", timeout=5.0,
+            )
+            if _topics_resp.status_code == 200:
+                _followup_topics = _topics_resp.json().get('topics', [])
+                if _followup_topics:
+                    followup_topics_prompt = _loc(PROACTIVE_FOLLOWUP_HEADER, proactive_lang)
+                    for topic in _followup_topics:
+                        followup_topics_prompt += f"- {topic['text']}\n"
+                        if topic.get('id'):
+                            _surfaced_reflection_ids.append(topic['id'])
+                    print(f"[{lanlan_name}] 回调话题候选: {len(_followup_topics)} 条")
         except Exception as e:
             logger.debug(f"[{lanlan_name}] 反思/回调话题获取失败（不影响主流程）: {e}")
 
@@ -3488,21 +3490,22 @@ async def proactive_chat(request: Request):
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)
 
-        # 后台长期记忆维护（通过 memory_server API）
+        # 后台长期记忆维护（通过 memory_server API）：复用 memory_client 单例
         try:
+            from utils.memory_client import get_memory_client
             _mem_base = f"http://127.0.0.1:{MEMORY_SERVER_PORT}"
-            async with httpx.AsyncClient(proxy=None, trust_env=False) as _mem_client:
-                # 保存本次搭话实际提及的 pending 反思 ID（供下次 /process 做反馈检查）
-                if _surfaced_reflection_ids:
-                    await _mem_client.post(
-                        f"{_mem_base}/record_surfaced/{lanlan_name}",
-                        json={"reflection_ids": _surfaced_reflection_ids},
-                        timeout=5.0,
-                    )
-                    print(f"[{lanlan_name}] 记录 surfaced 反思: {len(_surfaced_reflection_ids)} 条")
+            _mem_client = get_memory_client()
+            # 保存本次搭话实际提及的 pending 反思 ID（供下次 /process 做反馈检查）
+            if _surfaced_reflection_ids:
+                await _mem_client.post(
+                    f"{_mem_base}/record_surfaced/{lanlan_name}",
+                    json={"reflection_ids": _surfaced_reflection_ids},
+                    timeout=5.0,
+                )
+                print(f"[{lanlan_name}] 记录 surfaced 反思: {len(_surfaced_reflection_ids)} 条")
 
-                # 记录 persona 提及次数（疲劳跟踪） — persona 文件由 memory_server 管理
-                # record_mentions 已在 memory_server 的 _extract_facts_and_check_feedback 中调用
+            # 记录 persona 提及次数（疲劳跟踪） — persona 文件由 memory_server 管理
+            # record_mentions 已在 memory_server 的 _extract_facts_and_check_feedback 中调用
         except Exception as e:
             logger.debug(f"[{lanlan_name}] 长期记忆后处理失败（不影响主流程）: {e}")
 

--- a/main_server.py
+++ b/main_server.py
@@ -1036,8 +1036,9 @@ def _sync_preload_modules():
     try:
         import httpx
         import asyncio
-        
+
         async def _warmup_httpx():
+            # per-call AsyncClient: 这就是 SSL warmup 本身，改共享 client 反而没意义
             async with httpx.AsyncClient(timeout=1.0, proxy=None, trust_env=False) as client:
                 # 发送一个简单请求预热 SSL 上下文
                 try:
@@ -1355,6 +1356,8 @@ async def shutdown_server_async():
         try:
             from config import MEMORY_SERVER_PORT
             shutdown_url = f"http://127.0.0.1:{MEMORY_SERVER_PORT}/shutdown"
+            # per-call AsyncClient: 每进程仅一次的 shutdown 路径；memory_client 单例
+            # 紧接着会在 on_shutdown 里被 aclose()，此处直接构造一次更稳妥
             async with httpx.AsyncClient(timeout=1, proxy=None, trust_env=False) as client:
                 response = await client.post(shutdown_url)
                 if response.status_code == 200:

--- a/main_server.py
+++ b/main_server.py
@@ -1258,14 +1258,23 @@ async def on_shutdown():
         except Exception as e:
             logger.debug(f"音乐爬虫清理失败: {e}", exc_info=True)
 
-        # 关闭 memory_server 共享 httpx 连接池
+        # 关闭内部共享 httpx 连接池
         try:
-            from utils.memory_client import aclose_memory_client
-            await asyncio.wait_for(aclose_memory_client(), timeout=1.0)
+            from utils.internal_http_client import aclose_internal_http_client
+            await asyncio.wait_for(aclose_internal_http_client(), timeout=1.0)
         except asyncio.TimeoutError:
-            logger.warning("memory_client 清理超时，已强制跳过。")
+            logger.warning("internal_http_client 清理超时，已强制跳过。")
         except Exception as e:
-            logger.debug(f"memory_client 清理失败: {e}", exc_info=True)
+            logger.debug(f"internal_http_client 清理失败: {e}", exc_info=True)
+
+        # 关闭外部共享 httpx 连接池
+        try:
+            from utils.external_http_client import aclose_external_http_client
+            await asyncio.wait_for(aclose_external_http_client(), timeout=2.0)
+        except asyncio.TimeoutError:
+            logger.warning("external_http_client 清理超时，已强制跳过。")
+        except Exception as e:
+            logger.debug(f"external_http_client 清理失败: {e}", exc_info=True)
 
 # 使用 FastAPI 的 app.state 来管理启动配置
 def get_start_config():
@@ -1356,8 +1365,8 @@ async def shutdown_server_async():
         try:
             from config import MEMORY_SERVER_PORT
             shutdown_url = f"http://127.0.0.1:{MEMORY_SERVER_PORT}/shutdown"
-            # per-call AsyncClient: 每进程仅一次的 shutdown 路径；memory_client 单例
-            # 紧接着会在 on_shutdown 里被 aclose()，此处直接构造一次更稳妥
+            # per-call AsyncClient: 每进程仅一次的 shutdown 路径；internal_http_client
+            # 单例紧接着会在 on_shutdown 里被 aclose()，此处直接构造一次更稳妥
             async with httpx.AsyncClient(timeout=1, proxy=None, trust_env=False) as client:
                 response = await client.post(shutdown_url)
                 if response.status_code == 200:

--- a/utils/external_http_client.py
+++ b/utils/external_http_client.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+外部 HTTPS 专用的共享 httpx.AsyncClient 单例。
+
+为什么需要：
+  每次 `async with httpx.AsyncClient(...)` 构造 SSLContext 初始化开销
+  很高（Windows 冷态 ~150ms，事件循环压力下可达 1.1s）。对 web_scraper /
+  meme_fetcher / holiday_cache 等跑着跑着就高频访问外网的模块，每次请求
+  都重新开 client 既拖慢又把连接池复用的好处全扔了。
+
+覆盖范围：
+  **外部安全 HTTPS**（verify=True），允许读 HTTP_PROXY / HTTPS_PROXY 环境
+  变量（trust_env=True），默认跟随 30x 跳转（follow_redirects=True）。
+  `httpx.AsyncClient` 跨 host 复用安全，连接池按 (scheme, host, port)
+  分桶各自 keep-alive。
+
+不适用：
+  - 内部 127.0.0.1 服务：用 `utils/internal_http_client.py`
+  - 用户一次性大下载（>30MB 或 >30s）：per-call 更直观，避免占用池
+  - 需要特殊 SSL 配置 / 自定义 verify 的场景：per-call
+  - TTS 长连流式：已有 per-worker 专属 client
+
+并发：
+  共享 client **不阻塞并发**。`asyncio.gather(client.get(a), client.get(b))`
+  正常，池内自动开多条 TCP（默认 max_connections=100）。
+
+用法：
+    from utils.external_http_client import get_external_http_client
+    client = get_external_http_client()
+    resp = await client.get("https://example.com/api", timeout=10.0)
+
+进程关闭时需调用 `aclose_external_http_client()`。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_client: Optional[httpx.AsyncClient] = None
+
+# 默认超时：多数 scraper / fetcher 调用在 5-10s 区间。调用方可以用
+# `client.get(url, timeout=...)` 覆盖单次请求。
+_DEFAULT_TIMEOUT = 10.0
+
+
+def get_external_http_client() -> httpx.AsyncClient:
+    """返回进程级共享的外部 HTTPS AsyncClient。首次调用时懒初始化。
+
+    配置：
+      - verify=True（默认）：正常校验 TLS 证书
+      - trust_env=True：读 HTTP(S)_PROXY / NO_PROXY 环境变量
+      - follow_redirects=True：默认跟随 30x 跳转
+      - timeout=10.0：请求超时默认值
+    """
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            timeout=_DEFAULT_TIMEOUT,
+            trust_env=True,
+            follow_redirects=True,
+        )
+        logger.debug("[external_http_client] initialized shared AsyncClient")
+    return _client
+
+
+async def aclose_external_http_client() -> None:
+    """在 FastAPI shutdown 钩子中调用，释放连接池。"""
+    global _client
+    if _client is None:
+        return
+    if not _client.is_closed:
+        try:
+            await _client.aclose()
+            logger.debug("[external_http_client] shared AsyncClient closed")
+        except Exception as e:
+            logger.debug(f"[external_http_client] close failed: {e}")
+    _client = None

--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -18,8 +18,6 @@ import os
 import logging
 import locale
 from datetime import datetime
-from pathlib import Path
-import httpx
 
 
 chinese_char_pattern = re.compile(r'[\u4e00-\u9fff]+')
@@ -403,44 +401,6 @@ def find_models():
             logging.error(f"搜索目录 {search_root_dir} 时出错: {e}")
                 
     return found_models
-
-# --- 工具函数 ---
-async def get_upload_policy(api_key, model_name):
-    url = "https://dashscope.aliyuncs.com/api/v1/uploads"
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json"
-    }
-    params = {
-        "action": "getPolicy",
-        "model": model_name
-    }
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, headers=headers, params=params)
-        if response.status_code != 200:
-            raise Exception(f"获取上传凭证失败: {response.text}")
-        return response.json()['data']
-
-async def upload_file_to_oss(policy_data, file_path):
-    file_name = Path(file_path).name
-    key = f"{policy_data['upload_dir']}/{file_name}"
-    with open(file_path, 'rb') as file:
-        files = {
-            'OSSAccessKeyId': (None, policy_data['oss_access_key_id']),
-            'Signature': (None, policy_data['signature']),
-            'policy': (None, policy_data['policy']),
-            'x-oss-object-acl': (None, policy_data['x_oss_object_acl']),
-            'x-oss-forbid-overwrite': (None, policy_data['x_oss_forbid_overwrite']),
-            'key': (None, key),
-            'success_action_status': (None, '200'),
-            'file': (file_name, file)
-        }
-        async with httpx.AsyncClient() as client:
-            response = await client.post(policy_data['upload_host'], files=files)
-            if response.status_code != 200:
-                raise Exception(f"上传文件失败: {response.text}")
-    return f'oss://{key}'
-
 
 def _is_within(base: str, target: str) -> bool:
     """

--- a/utils/holiday_cache.py
+++ b/utils/holiday_cache.py
@@ -206,6 +206,8 @@ def _build_periods(entries: list[HolidayEntry]) -> list[HolidayPeriod]:
 async def _fetch_nager(country: str, year: int) -> list[HolidayEntry]:
     """Fetch from Nager.Date API (JP / KR / RU / US etc.)."""
     url = f"{_NAGER_API}/PublicHolidays/{year}/{country}"
+    # per-call AsyncClient: 每年每国家只拉一次（lazy warmup），且刻意 trust_env=False
+    # 绕开本地代理 —— 与 external_http_client（trust_env=True）配置不一致
     async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, proxy=None, trust_env=False) as client:
         resp = await client.get(url)
         resp.raise_for_status()
@@ -215,6 +217,7 @@ async def _fetch_nager(country: str, year: int) -> list[HolidayEntry]:
 async def _fetch_cn(year: int) -> list[HolidayEntry]:
     """Fetch from timor.tech API for China — complete with 调休."""
     url = f"{_TIMOR_API}/{year}"
+    # per-call AsyncClient: 同上，每年一次，trust_env=False 绕开代理
     async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT, proxy=None, trust_env=False) as client:
         resp = await client.get(url)
         resp.raise_for_status()

--- a/utils/internal_http_client.py
+++ b/utils/internal_http_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Memory Server 专用的共享 httpx.AsyncClient 单例。
+内部 127.0.0.1 服务专用的共享 httpx.AsyncClient 单例。
 
 为什么需要：
   每次 `async with httpx.AsyncClient(...)` 构造时 httpx 会 eagerly 初始化
@@ -9,16 +9,25 @@ Memory Server 专用的共享 httpx.AsyncClient 单例。
   1.1 秒/次，直接把 `/new_dialog` 的 2 秒 timeout 挤爆，表现为"memory
   server 响应超时"（server 侧其实 ~25ms 就返回了）。
 
+覆盖范围：
+  所有 http://127.0.0.1 的内部服务 —— memory_server / agent_server
+  (tool_server) / user_plugin_server 等。`httpx.AsyncClient` 本身跨 host
+  复用安全，连接池按 (scheme, host, port) 分桶各自 keep-alive，不会互相
+  干扰并发。
+
 解决方案：
   进程级别复用一个 AsyncClient，显式关闭 SSL 验证（127.0.0.1 纯 http
   不需要），连接池自动复用 TCP 连接。后续每次请求只付实际网络开销。
 
 用法：
-    from utils.memory_client import get_memory_client
-    client = get_memory_client()
+    from utils.internal_http_client import get_internal_http_client
+    client = get_internal_http_client()
     resp = await client.get(f"http://127.0.0.1:{PORT}/new_dialog/{name}")
 
-进程关闭时需调用 `aclose_memory_client()` 释放连接池。
+进程关闭时需调用 `aclose_internal_http_client()` 释放连接池。
+
+⚠️ 不得用于外部 HTTPS：`verify=False` 会让中间人随意伪造证书而不报错。
+   外部 HTTPS 请用 `utils/external_http_client.py`。
 """
 from __future__ import annotations
 
@@ -36,7 +45,7 @@ _client: Optional[httpx.AsyncClient] = None
 _DEFAULT_TIMEOUT = 5.0
 
 
-def get_memory_client() -> httpx.AsyncClient:
+def get_internal_http_client() -> httpx.AsyncClient:
     """返回进程级共享的 AsyncClient。首次调用时懒初始化。
 
     必须在事件循环内调用（AsyncClient 构造不依赖 loop，但 transport 第一次
@@ -45,7 +54,7 @@ def get_memory_client() -> httpx.AsyncClient:
     global _client
     if _client is None or _client.is_closed:
         # verify=False 彻底跳过 SSLContext 初始化 —— 我们只用来访问
-        # 127.0.0.1 的 memory_server，纯 http，不经过 TLS。
+        # 127.0.0.1 的内部服务，纯 http，不经过 TLS。
         # trust_env=False 不读 HTTP_PROXY/NO_PROXY 等环境变量。
         transport = httpx.AsyncHTTPTransport(verify=False, retries=0)
         _client = httpx.AsyncClient(
@@ -54,11 +63,11 @@ def get_memory_client() -> httpx.AsyncClient:
             trust_env=False,
             transport=transport,
         )
-        logger.debug("[memory_client] initialized shared AsyncClient (verify=False)")
+        logger.debug("[internal_http_client] initialized shared AsyncClient (verify=False)")
     return _client
 
 
-async def aclose_memory_client() -> None:
+async def aclose_internal_http_client() -> None:
     """在 FastAPI shutdown 钩子中调用，释放连接池。"""
     global _client
     if _client is None:
@@ -66,7 +75,7 @@ async def aclose_memory_client() -> None:
     if not _client.is_closed:
         try:
             await _client.aclose()
-            logger.debug("[memory_client] shared AsyncClient closed")
+            logger.debug("[internal_http_client] shared AsyncClient closed")
         except Exception as e:
-            logger.debug(f"[memory_client] close failed: {e}")
+            logger.debug(f"[internal_http_client] close failed: {e}")
     _client = None

--- a/utils/meme_fetcher.py
+++ b/utils/meme_fetcher.py
@@ -181,9 +181,10 @@ class MemeFetcher:
                     # 使用持久化 Session
                     response = await session.get(url, params=params, headers=headers)
                 else:
-                    # 使用临时 Client
-                    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True, trust_env=True) as client:
-                        response = await client.get(url, params=params, headers=headers)
+                    # fallback：复用外部共享 client（未 open 实例时）
+                    from utils.external_http_client import get_external_http_client
+                    client = get_external_http_client()
+                    response = await client.get(url, params=params, headers=headers, timeout=10.0)
                     
                 if response.status_code == 429:
                     q_val = params.get('q') or params.get('keywords') if params else 'N/A'
@@ -588,8 +589,10 @@ class DoutubFetcher:
                     if self._session:
                         api_resp = await self._session.get(api_url, params=api_params, headers=self._get_headers())
                     else:
-                        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True, trust_env=True) as client:
-                            api_resp = await client.get(api_url, params=api_params, headers=self._get_headers())
+                        # fallback：复用外部共享 client
+                        from utils.external_http_client import get_external_http_client
+                        client = get_external_http_client()
+                        api_resp = await client.get(api_url, params=api_params, headers=self._get_headers(), timeout=10.0)
                     
                     if api_resp.status_code == 200:
                         api_data = api_resp.json()

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -2050,11 +2050,13 @@ async def fetch_bilibili_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         url = "https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/all"
         headers = {"User-Agent": get_random_user_agent(), "Referer": "https://t.bilibili.com/"}
         await asyncio.sleep(random.uniform(0.1, 0.5))
-        
-        client = get_external_http_client()
-        response = await client.get(url, headers=headers, cookies=credential.get_cookies(), timeout=10.0)
-        response.raise_for_status()
-        data = response.json()
+
+        # per-call AsyncClient: 带用户鉴权 cookie —— 不能走共享 client，否则
+        # 响应的 Set-Cookie 会自动提取进共享 jar，跨请求污染（httpx 默认行为）
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers, cookies=credential.get_cookies(), timeout=10.0)
+            response.raise_for_status()
+            data = response.json()
 
         if not isinstance(data, dict) or data.get("code") != 0:
             logger.error(f"获取B站动态失败，API返回: {data}")
@@ -2226,10 +2228,11 @@ async def fetch_douyin_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
 
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        client = get_external_http_client()
-        response = await client.get(url, params=params, headers=headers, cookies=cookies, timeout=10.0)
-        response.raise_for_status()
-        data = response.json()
+        # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.get(url, params=params, headers=headers, cookies=cookies, timeout=10.0)
+            response.raise_for_status()
+            data = response.json()
 
         if data.get("status_code") != 0:
             logger.error(f"抖音API返回异常，可能触发风控: {data}")
@@ -2320,10 +2323,11 @@ async def fetch_kuaishou_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
 
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        client = get_external_http_client()
-        response = await client.post(url, headers=headers, json=payload, cookies=cookies, timeout=10.0)
-        response.raise_for_status()
-        data = response.json()
+        # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.post(url, headers=headers, json=payload, cookies=cookies, timeout=10.0)
+            response.raise_for_status()
+            data = response.json()
 
         if data.get("errors"):
             logger.error(f"快手GraphQL返回异常: {data['errors']}")
@@ -2412,14 +2416,15 @@ async def fetch_weibo_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
         # 4. 移动端 API 非常宽容，直接用普通的 httpx 即可稳定发包
-        client = get_external_http_client()
-        response = await client.get(url, headers=headers, cookies=req_cookies, timeout=10.0)
+        # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.get(url, headers=headers, cookies=req_cookies, timeout=10.0)
 
-        if response.status_code != 200:
-            logger.error(f"❌ 移动端微博接口异常，状态码: {response.status_code}")
-            return {'success': False, 'error': f"API请求失败，状态码: {response.status_code}"}
+            if response.status_code != 200:
+                logger.error(f"❌ 移动端微博接口异常，状态码: {response.status_code}")
+                return {'success': False, 'error': f"API请求失败，状态码: {response.status_code}"}
 
-        data = response.json()
+            data = response.json()
 
         # 移动端如果未登录，通常会返回 ok: 0 或者重定向
         if data.get('ok') != 1:
@@ -2501,9 +2506,10 @@ async def fetch_reddit_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         headers = {'User-Agent': get_random_user_agent(), 'Accept': 'application/json'}
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        client = get_external_http_client()
-        response = await client.get(url, headers=headers, cookies=reddit_cookies, timeout=10.0)
-        data = response.json()
+        # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.get(url, headers=headers, cookies=reddit_cookies, timeout=10.0)
+            data = response.json()
         posts = [
             {
                 'title': pd.get('title', ''), 'subreddit': f"r/{pd.get('subreddit', '')}",
@@ -2527,8 +2533,9 @@ async def _fetch_twitter_personal_web_scraping(limit: int = 10, cookies: Optiona
     try:
         url = "https://twitter.com/home"
         headers = {'User-Agent': get_random_user_agent()}
-        client = get_external_http_client()
-        res = await client.get(url, headers=headers, cookies=cookies, timeout=10.0)
+        # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            res = await client.get(url, headers=headers, cookies=cookies, timeout=10.0)
 
         # 如果被重定向到了登录页，说明 Cookie 彻底失效了
         if "login" in str(res.url) or "logout" in str(res.url):
@@ -2603,16 +2610,17 @@ async def fetch_twitter_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        client = get_external_http_client()
-        response = await client.get(url, headers=headers, cookies=twitter_cookies, timeout=10.0)
+        # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.get(url, headers=headers, cookies=twitter_cookies, timeout=10.0)
 
-        # 状态码非 200 时，平滑降级到备用网页刮削方案
-        if response.status_code != 200: 
-            logger.warning(f"Twitter API 拒绝访问 (状态码: {response.status_code})，回退到网页刮削...")
-            return await _fetch_twitter_personal_web_scraping(limit, twitter_cookies)
+            # 状态码非 200 时，平滑降级到备用网页刮削方案
+            if response.status_code != 200:
+                logger.warning(f"Twitter API 拒绝访问 (状态码: {response.status_code})，回退到网页刮削...")
+                return await _fetch_twitter_personal_web_scraping(limit, twitter_cookies)
 
-        # 真正去解析返回的推文数据，替换掉之前的占位符
-        data = response.json()
+            # 真正去解析返回的推文数据，替换掉之前的占位符
+            data = response.json()
         if not isinstance(data, list):
             return {'success': False, 'error': 'API 返回数据格式异常'}
 

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -7,6 +7,7 @@
 """
 import asyncio
 import httpx
+from utils.external_http_client import get_external_http_client
 import random
 import re
 import platform
@@ -350,51 +351,51 @@ async def fetch_reddit_popular(limit: int = 10) -> Dict[str, Any]:
         
         await asyncio.sleep(random.uniform(0.1, 0.5))
         
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            data = response.json()
-            
-            posts = []
-            children = data.get('data', {}).get('children', [])
-            
-            for item in children[:limit]:
-                post_data = item.get('data', {})
-                
-                # 跳过NSFW内容
-                if post_data.get('over_18'):
-                    continue
-                
-                subreddit = post_data.get('subreddit', '')
-                title = post_data.get('title', '')
-                score = post_data.get('score', 0)
-                num_comments = post_data.get('num_comments', 0)
-                permalink = post_data.get('permalink', '')
-                
-                posts.append({
-                    'title': title,
-                    'subreddit': f"r/{subreddit}",
-                    'score': _format_score(score),
-                    'comments': _format_score(num_comments),
-                })
-                if permalink:
-                    posts[-1]['url'] = f"https://www.reddit.com{permalink}"
-                else:
-                    posts[-1]['url'] = ''
-            
-            if posts:
-                logger.info(f"从Reddit获取到{len(posts)}条热门帖子")
-                return {
-                    'success': True,
-                    'posts': posts
-                }
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+        data = response.json()
+
+        posts = []
+        children = data.get('data', {}).get('children', [])
+
+        for item in children[:limit]:
+            post_data = item.get('data', {})
+
+            # 跳过NSFW内容
+            if post_data.get('over_18'):
+                continue
+
+            subreddit = post_data.get('subreddit', '')
+            title = post_data.get('title', '')
+            score = post_data.get('score', 0)
+            num_comments = post_data.get('num_comments', 0)
+            permalink = post_data.get('permalink', '')
+
+            posts.append({
+                'title': title,
+                'subreddit': f"r/{subreddit}",
+                'score': _format_score(score),
+                'comments': _format_score(num_comments),
+            })
+            if permalink:
+                posts[-1]['url'] = f"https://www.reddit.com{permalink}"
             else:
-                return {
-                    'success': False,
-                    'error': 'Reddit返回空数据',
-                    'posts': []
-                }
-                
+                posts[-1]['url'] = ''
+
+        if posts:
+            logger.info(f"从Reddit获取到{len(posts)}条热门帖子")
+            return {
+                'success': True,
+                'posts': posts
+            }
+        else:
+            return {
+                'success': False,
+                'error': 'Reddit返回空数据',
+                'posts': []
+            }
+
     except httpx.TimeoutException:
         logger.exception("获取Reddit热门超时")
         return {
@@ -452,80 +453,80 @@ async def fetch_weibo_trending(limit: int = 10) -> Dict[str, Any]:
         # 添加随机延迟
         await asyncio.sleep(random.uniform(0.1, 0.5))
         
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            
-            # 检查是否重定向到登录页面
-            if 'passport' in str(response.url):
-                logger.warning("微博Cookie可能已过期，回退到公开API")
-                return await _fetch_weibo_trending_fallback(limit)
-            
-            html = response.text
-            soup = BeautifulSoup(html, 'html.parser')
-            
-            # 解析热搜列表 (td-02 class)
-            td_items = soup.find_all('td', class_='td-02')
-            
-            if not td_items:
-                logger.warning("未找到热搜数据，回退到公开API")
-                return await _fetch_weibo_trending_fallback(limit)
-            
-            trending_list = []
-            for i, td in enumerate(td_items):
-                if len(trending_list) >= limit:
-                    break
-                    
-                a_tag = td.find('a')
-                span = td.find('span')
-                
-                if a_tag:
-                    word = a_tag.get_text(strip=True)
-                    if not word:
-                        continue
-                    
-                    # 获取链接
-                    href = a_tag.get('href', '')
-                    # 构建完整URL（相对链接需要加上域名）
-                    if href and not href.startswith('http'):
-                        href = f"https://s.weibo.com{href}"
-                    
-                    # 解析热度值
-                    if span:
-                        hot_text = span.get_text(strip=True)
-                    else:
-                        hot_text = ''
-                    # 热度可能包含类型标签如"剧集 336075"，需要提取数字
-                    import re
-                    hot_match = re.search(r'(\d+)', hot_text)
-                    if hot_match:
-                        raw_hot = int(hot_match.group(1))
-                    else:
-                        raw_hot = 0
-                    
-                    # 提取标签（如"剧集"、"晚会"等）
-                    if hot_text:
-                        note = re.sub(r'\d+', '', hot_text).strip()
-                    else:
-                        note = ''
-                    
-                    trending_list.append({
-                        'word': word,
-                        'raw_hot': raw_hot,
-                        'note': note,
-                        'rank': i + 1,
-                        'url': href
-                    })
-            
-            if trending_list:
-                logger.info(f"成功从s.weibo.com获取{len(trending_list)}条热搜")
-                return {
-                    'success': True,
-                    'trending': trending_list
-                }
-            else:
-                return await _fetch_weibo_trending_fallback(limit)
-                
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+
+        # 检查是否重定向到登录页面
+        if 'passport' in str(response.url):
+            logger.warning("微博Cookie可能已过期，回退到公开API")
+            return await _fetch_weibo_trending_fallback(limit)
+
+        html = response.text
+        soup = BeautifulSoup(html, 'html.parser')
+
+        # 解析热搜列表 (td-02 class)
+        td_items = soup.find_all('td', class_='td-02')
+
+        if not td_items:
+            logger.warning("未找到热搜数据，回退到公开API")
+            return await _fetch_weibo_trending_fallback(limit)
+
+        trending_list = []
+        for i, td in enumerate(td_items):
+            if len(trending_list) >= limit:
+                break
+
+            a_tag = td.find('a')
+            span = td.find('span')
+
+            if a_tag:
+                word = a_tag.get_text(strip=True)
+                if not word:
+                    continue
+
+                # 获取链接
+                href = a_tag.get('href', '')
+                # 构建完整URL（相对链接需要加上域名）
+                if href and not href.startswith('http'):
+                    href = f"https://s.weibo.com{href}"
+
+                # 解析热度值
+                if span:
+                    hot_text = span.get_text(strip=True)
+                else:
+                    hot_text = ''
+                # 热度可能包含类型标签如"剧集 336075"，需要提取数字
+                import re
+                hot_match = re.search(r'(\d+)', hot_text)
+                if hot_match:
+                    raw_hot = int(hot_match.group(1))
+                else:
+                    raw_hot = 0
+
+                # 提取标签（如"剧集"、"晚会"等）
+                if hot_text:
+                    note = re.sub(r'\d+', '', hot_text).strip()
+                else:
+                    note = ''
+
+                trending_list.append({
+                    'word': word,
+                    'raw_hot': raw_hot,
+                    'note': note,
+                    'rank': i + 1,
+                    'url': href
+                })
+
+        if trending_list:
+            logger.info(f"成功从s.weibo.com获取{len(trending_list)}条热搜")
+            return {
+                'success': True,
+                'trending': trending_list
+            }
+        else:
+            return await _fetch_weibo_trending_fallback(limit)
+
     except Exception as e:
         logger.warning(f"s.weibo.com热搜获取失败: {e}，回退到公开API")
         return await _fetch_weibo_trending_fallback(limit)
@@ -552,45 +553,45 @@ async def _fetch_weibo_trending_fallback(limit: int = 10) -> Dict[str, Any]:
         
         await asyncio.sleep(random.uniform(0.1, 0.5))
         
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            data = response.json()
-            
-            if data.get('ok') == 1:
-                trending_list = []
-                realtime_list = data.get('data', {}).get('realtime', [])
-                
-                for item in realtime_list[:limit]:
-                    if item.get('is_ad'):
-                        continue
-                    
-                    word = item.get('word', '')
-                    # 构建搜索URL
-                    if word:
-                        search_url = f"https://s.weibo.com/weibo?q={quote(word)}"
-                    else:
-                        search_url = ''
-                    
-                    trending_list.append({
-                        'word': word,
-                        'raw_hot': item.get('raw_hot', 0),
-                        'note': item.get('note', ''),
-                        'rank': item.get('rank', 0),
-                        'url': search_url
-                    })
-                
-                return {
-                    'success': True,
-                    'trending': trending_list[:limit]
-                }
-            else:
-                logger.error("微博公开API返回错误")
-                return {
-                    'success': False,
-                    'error': '微博API返回错误'
-                }
-                
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+        data = response.json()
+
+        if data.get('ok') == 1:
+            trending_list = []
+            realtime_list = data.get('data', {}).get('realtime', [])
+
+            for item in realtime_list[:limit]:
+                if item.get('is_ad'):
+                    continue
+
+                word = item.get('word', '')
+                # 构建搜索URL
+                if word:
+                    search_url = f"https://s.weibo.com/weibo?q={quote(word)}"
+                else:
+                    search_url = ''
+
+                trending_list.append({
+                    'word': word,
+                    'raw_hot': item.get('raw_hot', 0),
+                    'note': item.get('note', ''),
+                    'rank': item.get('rank', 0),
+                    'url': search_url
+                })
+
+            return {
+                'success': True,
+                'trending': trending_list[:limit]
+            }
+        else:
+            logger.error("微博公开API返回错误")
+            return {
+                'success': False,
+                'error': '微博API返回错误'
+            }
+
     except httpx.TimeoutException:
         logger.exception("获取微博热议话题超时")
         return {
@@ -631,51 +632,51 @@ async def fetch_twitter_trending(limit: int = 10) -> Dict[str, Any]:
         
         await asyncio.sleep(random.uniform(0.1, 0.5))
         
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            html_content = response.text
-            
-            # 从页面解析热门话题
-            trending_list = []
-            
-            # 尝试从页面的JSON数据中提取热门话题
-            trend_pattern = r'"trend":\{[^}]*"name":"([^"]+)"'
-            tweet_count_pattern = r'"tweetCount":"([^"]+)"'
-            
-            trends = re.findall(trend_pattern, html_content)
-            tweet_counts = re.findall(tweet_count_pattern, html_content)
-            
-            for i, trend in enumerate(trends[:limit]):
-                if trend and not trend.startswith('#'):
-                    if not trend.startswith('@'):
-                        trend = '#' + trend
-                
-                # 构建搜索URL
-                if trend:
-                    search_url = f"https://twitter.com/search?q={quote(trend)}"
-                else:
-                    search_url = ''
-                
-                trending_list.append({
-                    'word': trend,
-                })
-                if i < len(tweet_counts):
-                    trending_list[-1]['tweet_count'] = tweet_counts[i]
-                else:
-                    trending_list[-1]['tweet_count'] = 'N/A'
-                trending_list[-1]['note'] = ''
-                trending_list[-1]['rank'] = i + 1
-                trending_list[-1]['url'] = search_url
-            
-            if trending_list:
-                return {
-                    'success': True,
-                    'trending': trending_list
-                }
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+        html_content = response.text
+
+        # 从页面解析热门话题
+        trending_list = []
+
+        # 尝试从页面的JSON数据中提取热门话题
+        trend_pattern = r'"trend":\{[^}]*"name":"([^"]+)"'
+        tweet_count_pattern = r'"tweetCount":"([^"]+)"'
+
+        trends = re.findall(trend_pattern, html_content)
+        tweet_counts = re.findall(tweet_count_pattern, html_content)
+
+        for i, trend in enumerate(trends[:limit]):
+            if trend and not trend.startswith('#'):
+                if not trend.startswith('@'):
+                    trend = '#' + trend
+
+            # 构建搜索URL
+            if trend:
+                search_url = f"https://twitter.com/search?q={quote(trend)}"
             else:
-                return await _fetch_twitter_trending_fallback(limit)
-                
+                search_url = ''
+
+            trending_list.append({
+                'word': trend,
+            })
+            if i < len(tweet_counts):
+                trending_list[-1]['tweet_count'] = tweet_counts[i]
+            else:
+                trending_list[-1]['tweet_count'] = 'N/A'
+            trending_list[-1]['note'] = ''
+            trending_list[-1]['rank'] = i + 1
+            trending_list[-1]['url'] = search_url
+
+        if trending_list:
+            return {
+                'success': True,
+                'trending': trending_list
+            }
+        else:
+            return await _fetch_twitter_trending_fallback(limit)
+
     except httpx.TimeoutException:
         logger.exception("获取Twitter热门超时")
         return {
@@ -752,20 +753,20 @@ async def _fetch_twitter_trending_fallback(limit: int = 10) -> Dict[str, Any]:
         try:
             await asyncio.sleep(random.uniform(0.1, 0.3))
             
-            async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-                response = await client.get(source['url'], headers=headers)
-                
-                if response.status_code == 200:
-                    soup = BeautifulSoup(response.text, 'html.parser')
-                    trending_list = source['parser'](soup, limit)
-                    
-                    if trending_list:
-                        logger.info(f"从{source['name']}获取到{len(trending_list)}条Twitter热门")
-                        return {
-                            'success': True,
-                            'trending': trending_list,
-                            'source': source['name'].lower().replace(' ', '')
-                        }
+            client = get_external_http_client()
+            response = await client.get(source['url'], headers=headers, timeout=5.0)
+
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.text, 'html.parser')
+                trending_list = source['parser'](soup, limit)
+
+                if trending_list:
+                    logger.info(f"从{source['name']}获取到{len(trending_list)}条Twitter热门")
+                    return {
+                        'success': True,
+                        'trending': trending_list,
+                        'source': source['name'].lower().replace(' ', '')
+                    }
         except Exception as e:
             logger.warning(f"{source['name']}获取失败: {e}")
             continue
@@ -1406,27 +1407,27 @@ async def search_google(query: str, limit: int = 10) -> Dict[str, Any]:
         # 添加随机延迟
         await asyncio.sleep(random.uniform(0.2, 0.5))
         
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            html_content = response.text
-            
-            # 解析搜索结果
-            results = parse_google_results(html_content, limit)
-            
-            if results:
-                return {
-                    'success': True,
-                    'query': query,
-                    'results': results
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': '未能解析到搜索结果',
-                    'query': query
-                }
-                
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+        html_content = response.text
+
+        # 解析搜索结果
+        results = parse_google_results(html_content, limit)
+
+        if results:
+            return {
+                'success': True,
+                'query': query,
+                'results': results
+            }
+        else:
+            return {
+                'success': False,
+                'error': '未能解析到搜索结果',
+                'query': query
+            }
+
     except httpx.TimeoutException:
         logger.exception("Google搜索超时")
         return {
@@ -1560,27 +1561,27 @@ async def search_baidu(query: str, limit: int = 5) -> Dict[str, Any]:
         # 添加随机延迟
         await asyncio.sleep(random.uniform(0.2, 0.5))
         
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            html_content = response.text
-            
-            # 解析搜索结果
-            results = parse_baidu_results(html_content, limit)
-            
-            if results:
-                return {
-                    'success': True,
-                    'query': query,
-                    'results': results
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': '未能解析到搜索结果',
-                    'query': query
-                }
-                
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, timeout=5.0)
+        response.raise_for_status()
+        html_content = response.text
+
+        # 解析搜索结果
+        results = parse_baidu_results(html_content, limit)
+
+        if results:
+            return {
+                'success': True,
+                'query': query,
+                'results': results
+            }
+        else:
+            return {
+                'success': False,
+                'error': '未能解析到搜索结果',
+                'query': query
+            }
+
     except httpx.TimeoutException:
         logger.exception("百度搜索超时")
         return {
@@ -2050,10 +2051,10 @@ async def fetch_bilibili_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         headers = {"User-Agent": get_random_user_agent(), "Referer": "https://t.bilibili.com/"}
         await asyncio.sleep(random.uniform(0.1, 0.5))
         
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, headers=headers, cookies=credential.get_cookies(), timeout=10.0)
-            response.raise_for_status()
-            data = response.json()
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, cookies=credential.get_cookies(), timeout=10.0)
+        response.raise_for_status()
+        data = response.json()
 
         if not isinstance(data, dict) or data.get("code") != 0:
             logger.error(f"获取B站动态失败，API返回: {data}")
@@ -2225,60 +2226,60 @@ async def fetch_douyin_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
 
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.get(url, params=params, headers=headers, cookies=cookies)
-            response.raise_for_status()
-            data = response.json()
+        client = get_external_http_client()
+        response = await client.get(url, params=params, headers=headers, cookies=cookies, timeout=10.0)
+        response.raise_for_status()
+        data = response.json()
 
-            if data.get("status_code") != 0:
-                logger.error(f"抖音API返回异常，可能触发风控: {data}")
-                return {'success': False, 'error': "API请求失败，可能需要更新 Cookie 或补全 X-Bogus 签名"}
+        if data.get("status_code") != 0:
+            logger.error(f"抖音API返回异常，可能触发风控: {data}")
+            return {'success': False, 'error': "API请求失败，可能需要更新 Cookie 或补全 X-Bogus 签名"}
 
-            dynamic_list = []
-            # 兼容不同的数据返回结构，归一化为 list
-            raw_data = data.get("data")
-            if isinstance(raw_data, list):
-                aweme_list = raw_data
-            elif isinstance(raw_data, dict):
-                aweme_list = (
-                    raw_data.get("list")
-                    or raw_data.get("aweme_list")
-                    or raw_data.get("items")
-                    or data.get("aweme_list")
-                    or []
-                )
-            else:
-                aweme_list = data.get("aweme_list") or []
+        dynamic_list = []
+        # 兼容不同的数据返回结构，归一化为 list
+        raw_data = data.get("data")
+        if isinstance(raw_data, list):
+            aweme_list = raw_data
+        elif isinstance(raw_data, dict):
+            aweme_list = (
+                raw_data.get("list")
+                or raw_data.get("aweme_list")
+                or raw_data.get("items")
+                or data.get("aweme_list")
+                or []
+            )
+        else:
+            aweme_list = data.get("aweme_list") or []
 
-            for item in aweme_list[:limit]:
-                try:
-                    if not isinstance(item, dict):
-                        logger.warning(f"抖音动态数据项类型异常: {type(item).__name__}，跳过")
-                        continue
-                    author = item.get("author", {}).get("nickname", "未知博主")
-                    desc = item.get("desc") or "[分享了视频]"
-                    aweme_id = item.get("aweme_id", "")
-                    
-                    clean_desc = desc.replace('\n', ' ').strip()
-                    final_content = f"博主【{author}】: {clean_desc}"
-
-                    dynamic_list.append({
-                        'author': author,
-                        'content': final_content,
-                        'timestamp': item.get("create_time", "刚刚"),
-                    })
-                    if aweme_id:
-                        dynamic_list[-1]['url'] = f"https://www.douyin.com/video/{aweme_id}"
-                    else:
-                        dynamic_list[-1]['url'] = "https://www.douyin.com/"
-                except Exception as item_err:
-                    logger.warning(f"解析抖音动态项失败，跳过: {item_err}")
+        for item in aweme_list[:limit]:
+            try:
+                if not isinstance(item, dict):
+                    logger.warning(f"抖音动态数据项类型异常: {type(item).__name__}，跳过")
                     continue
+                author = item.get("author", {}).get("nickname", "未知博主")
+                desc = item.get("desc") or "[分享了视频]"
+                aweme_id = item.get("aweme_id", "")
 
-            if dynamic_list:
-                logger.info(f"✅ 成功获取到 {len(dynamic_list)} 条抖音关注动态")
-                return {'success': True, 'dynamics': dynamic_list}
-            return {'success': False, 'error': '未解析到抖音动态数据'}
+                clean_desc = desc.replace('\n', ' ').strip()
+                final_content = f"博主【{author}】: {clean_desc}"
+
+                dynamic_list.append({
+                    'author': author,
+                    'content': final_content,
+                    'timestamp': item.get("create_time", "刚刚"),
+                })
+                if aweme_id:
+                    dynamic_list[-1]['url'] = f"https://www.douyin.com/video/{aweme_id}"
+                else:
+                    dynamic_list[-1]['url'] = "https://www.douyin.com/"
+            except Exception as item_err:
+                logger.warning(f"解析抖音动态项失败，跳过: {item_err}")
+                continue
+
+        if dynamic_list:
+            logger.info(f"✅ 成功获取到 {len(dynamic_list)} 条抖音关注动态")
+            return {'success': True, 'dynamics': dynamic_list}
+        return {'success': False, 'error': '未解析到抖音动态数据'}
 
     except Exception as e:
         logger.error(f"获取抖音动态失败: {e}")
@@ -2319,48 +2320,48 @@ async def fetch_kuaishou_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
 
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.post(url, headers=headers, json=payload, cookies=cookies)
-            response.raise_for_status()
-            data = response.json()
+        client = get_external_http_client()
+        response = await client.post(url, headers=headers, json=payload, cookies=cookies, timeout=10.0)
+        response.raise_for_status()
+        data = response.json()
 
-            if data.get("errors"):
-                logger.error(f"快手GraphQL返回异常: {data['errors']}")
-                return {'success': False, 'error': "GraphQL查询报错，可能是 Cookie 失效"}
+        if data.get("errors"):
+            logger.error(f"快手GraphQL返回异常: {data['errors']}")
+            return {'success': False, 'error': "GraphQL查询报错，可能是 Cookie 失效"}
 
-            feeds = data.get("data", {}).get("visionFollowFeed", {}).get("feeds", [])
-            dynamic_list = []
+        feeds = data.get("data", {}).get("visionFollowFeed", {}).get("feeds", [])
+        dynamic_list = []
 
-            for item in feeds[:limit]:
-                try:
-                    if not isinstance(item, dict):
-                        logger.warning(f"快手动态数据项类型异常: {type(item).__name__}，跳过")
-                        continue
-                    author = item.get("author", {}).get("name", "未知老铁")
-                    photo = item.get("photo", {})
-                    caption = photo.get("caption") or "[分享了作品]"
-                    photo_id = photo.get("id", "")
-                    
-                    clean_caption = caption.replace('\n', ' ').strip()
-                    final_content = f"老铁【{author}】: {clean_caption}"
-
-                    dynamic_list.append({
-                        'author': author,
-                        'content': final_content,
-                        'timestamp': photo.get("timestamp", "刚刚"),
-                    })
-                    if photo_id:
-                        dynamic_list[-1]['url'] = f"https://www.kuaishou.com/short-video/{photo_id}"
-                    else:
-                        dynamic_list[-1]['url'] = "https://www.kuaishou.com/"
-                except Exception as item_err:
-                    logger.warning(f"解析快手动态项失败，跳过: {item_err}")
+        for item in feeds[:limit]:
+            try:
+                if not isinstance(item, dict):
+                    logger.warning(f"快手动态数据项类型异常: {type(item).__name__}，跳过")
                     continue
+                author = item.get("author", {}).get("name", "未知老铁")
+                photo = item.get("photo", {})
+                caption = photo.get("caption") or "[分享了作品]"
+                photo_id = photo.get("id", "")
 
-            if dynamic_list:
-                logger.info(f"✅ 成功获取到 {len(dynamic_list)} 条快手关注动态")
-                return {'success': True, 'dynamics': dynamic_list}
-            return {'success': False, 'error': '未解析到快手动态数据'}
+                clean_caption = caption.replace('\n', ' ').strip()
+                final_content = f"老铁【{author}】: {clean_caption}"
+
+                dynamic_list.append({
+                    'author': author,
+                    'content': final_content,
+                    'timestamp': photo.get("timestamp", "刚刚"),
+                })
+                if photo_id:
+                    dynamic_list[-1]['url'] = f"https://www.kuaishou.com/short-video/{photo_id}"
+                else:
+                    dynamic_list[-1]['url'] = "https://www.kuaishou.com/"
+            except Exception as item_err:
+                logger.warning(f"解析快手动态项失败，跳过: {item_err}")
+                continue
+
+        if dynamic_list:
+            logger.info(f"✅ 成功获取到 {len(dynamic_list)} 条快手关注动态")
+            return {'success': True, 'dynamics': dynamic_list}
+        return {'success': False, 'error': '未解析到快手动态数据'}
 
     except Exception as e:
         logger.error(f"获取快手动态失败: {e}")
@@ -2411,79 +2412,79 @@ async def fetch_weibo_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
         # 4. 移动端 API 非常宽容，直接用普通的 httpx 即可稳定发包
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers, cookies=req_cookies)
-            
-            if response.status_code != 200:
-                logger.error(f"❌ 移动端微博接口异常，状态码: {response.status_code}")
-                return {'success': False, 'error': f"API请求失败，状态码: {response.status_code}"}
-                
-            data = response.json()
-            
-            # 移动端如果未登录，通常会返回 ok: 0 或者重定向
-            if data.get('ok') != 1:
-                logger.error("❌ 微博拦截：返回 ok=0，说明你的 SUB 凭证已过期！")
-                return {'success': False, 'error': "微博凭证已过期，请去浏览器重新获取"}
-            
-            cards = data.get('data', {}).get('cards', [])
-            weibo_list = []
-            
-            for card in cards:
-                # card_type == 9 代表这是一条正常的微博博文卡片
-                if card.get('card_type') != 9:
-                    continue
-                    
-                mblog = card.get('mblog')
-                if not mblog:
-                    continue
-                    
-                user = mblog.get('user', {})
-                author = user.get('screen_name') or '未知博主'
-                
-                # 提取正文并清理 HTML 标签
-                text = str(mblog.get('text') or '')
-                clean_text = re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', '', text)).strip()
-                
-                # 兼容并缝合转发内容
-                if mblog.get('retweeted_status'):
-                    retweet = mblog['retweeted_status']
-                    rt_author = retweet.get('user', {}).get('screen_name') or '原博主'
-                    rt_text = str(retweet.get('text') or '')
-                    rt_clean_text = re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', '', rt_text)).strip()
-                    clean_text = f"{clean_text} // [转发动态] @{rt_author}: {rt_clean_text}"
-                
-                if clean_text:
-                    display_text = clean_text
-                else:
-                    display_text = "[分享了图片/动态]"
-                final_content = f"博主【{author}】: {display_text}"
-                mid = mblog.get('mid') or mblog.get('id', '')
-                
-                weibo_list.append({
-                    'author': author,
-                    'content': final_content,
-                    'timestamp': mblog.get('created_at') or '',
-                    'url': f"https://m.weibo.cn/detail/{mid}" # 使用移动端 URL
-                })
-                
-                if len(weibo_list) >= limit:
-                    break
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, cookies=req_cookies, timeout=10.0)
 
-            if weibo_list: 
-                logger.info(f"✅ 成功通过移动端接口获取到 {len(weibo_list)} 条微博个人动态")
-                logger.info("微博动态:")  # 统一对齐 B站 的提示词
-                for i, weibo in enumerate(weibo_list, 1):
-                    content = weibo.get('content', '')
-                    # 稍微放宽一点截断长度，保证显示效果更好
-                    if len(content) > 50:
-                        content = content[:50] + "..."
-                    # 去掉冗余的时间和作者，直接干干净净地打印 content
-                    logger.info(f"  - {content}")
-                
-                return {'success': True, 'statuses': weibo_list}
+        if response.status_code != 200:
+            logger.error(f"❌ 移动端微博接口异常，状态码: {response.status_code}")
+            return {'success': False, 'error': f"API请求失败，状态码: {response.status_code}"}
+
+        data = response.json()
+
+        # 移动端如果未登录，通常会返回 ok: 0 或者重定向
+        if data.get('ok') != 1:
+            logger.error("❌ 微博拦截：返回 ok=0，说明你的 SUB 凭证已过期！")
+            return {'success': False, 'error': "微博凭证已过期，请去浏览器重新获取"}
+
+        cards = data.get('data', {}).get('cards', [])
+        weibo_list = []
+
+        for card in cards:
+            # card_type == 9 代表这是一条正常的微博博文卡片
+            if card.get('card_type') != 9:
+                continue
+
+            mblog = card.get('mblog')
+            if not mblog:
+                continue
+
+            user = mblog.get('user', {})
+            author = user.get('screen_name') or '未知博主'
+
+            # 提取正文并清理 HTML 标签
+            text = str(mblog.get('text') or '')
+            clean_text = re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', '', text)).strip()
+
+            # 兼容并缝合转发内容
+            if mblog.get('retweeted_status'):
+                retweet = mblog['retweeted_status']
+                rt_author = retweet.get('user', {}).get('screen_name') or '原博主'
+                rt_text = str(retweet.get('text') or '')
+                rt_clean_text = re.sub(r'\s+', ' ', re.sub(r'<[^>]+>', '', rt_text)).strip()
+                clean_text = f"{clean_text} // [转发动态] @{rt_author}: {rt_clean_text}"
+
+            if clean_text:
+                display_text = clean_text
             else:
-                return {'success': False, 'error': '未解析到微博内容'}
-                
+                display_text = "[分享了图片/动态]"
+            final_content = f"博主【{author}】: {display_text}"
+            mid = mblog.get('mid') or mblog.get('id', '')
+
+            weibo_list.append({
+                'author': author,
+                'content': final_content,
+                'timestamp': mblog.get('created_at') or '',
+                'url': f"https://m.weibo.cn/detail/{mid}" # 使用移动端 URL
+            })
+
+            if len(weibo_list) >= limit:
+                break
+
+        if weibo_list: 
+            logger.info(f"✅ 成功通过移动端接口获取到 {len(weibo_list)} 条微博个人动态")
+            logger.info("微博动态:")  # 统一对齐 B站 的提示词
+            for i, weibo in enumerate(weibo_list, 1):
+                content = weibo.get('content', '')
+                # 稍微放宽一点截断长度，保证显示效果更好
+                if len(content) > 50:
+                    content = content[:50] + "..."
+                # 去掉冗余的时间和作者，直接干干净净地打印 content
+                logger.info(f"  - {content}")
+
+            return {'success': True, 'statuses': weibo_list}
+        else:
+            return {'success': False, 'error': '未解析到微博内容'}
+
     except Exception as e: 
         logger.error(f"微博动态解析发生错误: {e}")
         return {'success': False, 'error': str(e)}
@@ -2500,21 +2501,21 @@ async def fetch_reddit_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         headers = {'User-Agent': get_random_user_agent(), 'Accept': 'application/json'}
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers, cookies=reddit_cookies)
-            data = response.json()
-            posts = [
-                {
-                    'title': pd.get('title', ''), 'subreddit': f"r/{pd.get('subreddit', '')}",
-                    'score': _format_score(pd.get('score', 0)), 
-                    'url': f"https://www.reddit.com{pd.get('permalink', '')}"
-                }
-                for item in data.get('data', {}).get('children', [])[:limit]
-                if not (pd := item.get('data', {})).get('over_18')
-            ]
-            if posts:
-                logger.info(f"✅ 成功获取到 {len(posts)} 条Reddit订阅帖子")
-            return {'success': True, 'posts': posts}
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, cookies=reddit_cookies, timeout=10.0)
+        data = response.json()
+        posts = [
+            {
+                'title': pd.get('title', ''), 'subreddit': f"r/{pd.get('subreddit', '')}",
+                'score': _format_score(pd.get('score', 0)), 
+                'url': f"https://www.reddit.com{pd.get('permalink', '')}"
+            }
+            for item in data.get('data', {}).get('children', [])[:limit]
+            if not (pd := item.get('data', {})).get('over_18')
+        ]
+        if posts:
+            logger.info(f"✅ 成功获取到 {len(posts)} 条Reddit订阅帖子")
+        return {'success': True, 'posts': posts}
     except Exception as e: 
         return {'success': False, 'error': str(e)}
 
@@ -2526,33 +2527,33 @@ async def _fetch_twitter_personal_web_scraping(limit: int = 10, cookies: Optiona
     try:
         url = "https://twitter.com/home"
         headers = {'User-Agent': get_random_user_agent()}
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            res = await client.get(url, headers=headers, cookies=cookies)
-            
-            # 如果被重定向到了登录页，说明 Cookie 彻底失效了
-            if "login" in str(res.url) or "logout" in str(res.url):
-                return {'success': False, 'error': 'Twitter Cookie 已过期，网页端拒绝访问'}
-                
-            tweets = []
-            tweet_texts = re.findall(r'"tweet":\{[^}]*"full_text":"([^"]+)"', res.text)
-            screen_names = re.findall(r'"screen_name":"([^"]+)"', res.text)
-            
-            for i, text in enumerate(tweet_texts[:limit]):
-                clean_text = re.sub(r'https://t\.co/\w+', '', text).strip()
-                if i < len(screen_names):
-                    author_str = screen_names[i]
-                else:
-                    author_str = 'Unknown'
-                tweets.append({
-                    'author': f"@{author_str}", 
-                    'content': clean_text,
-                    'timestamp': '刚刚'  # 保持与主 API 数据字典格式的统一
-                })
-                
-            if tweets:
-                return {'success': True, 'tweets': tweets}
+        client = get_external_http_client()
+        res = await client.get(url, headers=headers, cookies=cookies, timeout=10.0)
+
+        # 如果被重定向到了登录页，说明 Cookie 彻底失效了
+        if "login" in str(res.url) or "logout" in str(res.url):
+            return {'success': False, 'error': 'Twitter Cookie 已过期，网页端拒绝访问'}
+
+        tweets = []
+        tweet_texts = re.findall(r'"tweet":\{[^}]*"full_text":"([^"]+)"', res.text)
+        screen_names = re.findall(r'"screen_name":"([^"]+)"', res.text)
+
+        for i, text in enumerate(tweet_texts[:limit]):
+            clean_text = re.sub(r'https://t\.co/\w+', '', text).strip()
+            if i < len(screen_names):
+                author_str = screen_names[i]
             else:
-                return {'success': False, 'error': '网页正则抓取失败，页面结构可能已变更'}
+                author_str = 'Unknown'
+            tweets.append({
+                'author': f"@{author_str}", 
+                'content': clean_text,
+                'timestamp': '刚刚'  # 保持与主 API 数据字典格式的统一
+            })
+
+        if tweets:
+            return {'success': True, 'tweets': tweets}
+        else:
+            return {'success': False, 'error': '网页正则抓取失败，页面结构可能已变更'}
     except Exception as e: 
         logger.error(f"Twitter 网页抓取 fallback 失败: {e}")
         return {'success': False, 'error': str(e)}
@@ -2602,48 +2603,48 @@ async def fetch_twitter_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         
         await asyncio.sleep(random.uniform(0.1, 0.5))
 
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.get(url, headers=headers, cookies=twitter_cookies)
-            
-            # 状态码非 200 时，平滑降级到备用网页刮削方案
-            if response.status_code != 200: 
-                logger.warning(f"Twitter API 拒绝访问 (状态码: {response.status_code})，回退到网页刮削...")
-                return await _fetch_twitter_personal_web_scraping(limit, twitter_cookies)
-                
-            # 真正去解析返回的推文数据，替换掉之前的占位符
-            data = response.json()
-            if not isinstance(data, list):
-                return {'success': False, 'error': 'API 返回数据格式异常'}
-                
-            tweets = []
-            for tweet in data[:limit]:
-                user = tweet.get('user', {})
-                author = user.get('screen_name') or 'Unknown'
-                # tweet_mode=extended 时，正文在 full_text 里
-                text = str(tweet.get('full_text') or tweet.get('text') or '')
-                
-                # 清理推文末尾自带的分享短链接 (https://t.co/xxx)
-                clean_text = re.sub(r'https://t\.co/\w+', '', text).strip()
-                
-                # 处理转推 (Retweet) 的前缀拼接
-                if 'retweeted_status' in tweet:
-                    rt_user = tweet['retweeted_status'].get('user', {}).get('screen_name', 'Unknown')
-                    rt_text = str(tweet['retweeted_status'].get('full_text') or '')
-                    rt_clean_text = re.sub(r'https://t\.co/\w+', '', rt_text).strip()
-                    clean_text = f"RT @{rt_user}: {rt_clean_text}"
-                
-                tweets.append({
-                    'author': f"@{author}", 
-                    'content': clean_text,
-                    'timestamp': tweet.get('created_at', '')
-                })
-                
-            if tweets:
-                logger.info(f"✅ 成功获取到 {len(tweets)} 条 Twitter 个人时间线动态")
-                return {'success': True, 'tweets': tweets}
-            else:
-                return {'success': False, 'error': '未解析到推文内容'}
-                
+        client = get_external_http_client()
+        response = await client.get(url, headers=headers, cookies=twitter_cookies, timeout=10.0)
+
+        # 状态码非 200 时，平滑降级到备用网页刮削方案
+        if response.status_code != 200: 
+            logger.warning(f"Twitter API 拒绝访问 (状态码: {response.status_code})，回退到网页刮削...")
+            return await _fetch_twitter_personal_web_scraping(limit, twitter_cookies)
+
+        # 真正去解析返回的推文数据，替换掉之前的占位符
+        data = response.json()
+        if not isinstance(data, list):
+            return {'success': False, 'error': 'API 返回数据格式异常'}
+
+        tweets = []
+        for tweet in data[:limit]:
+            user = tweet.get('user', {})
+            author = user.get('screen_name') or 'Unknown'
+            # tweet_mode=extended 时，正文在 full_text 里
+            text = str(tweet.get('full_text') or tweet.get('text') or '')
+
+            # 清理推文末尾自带的分享短链接 (https://t.co/xxx)
+            clean_text = re.sub(r'https://t\.co/\w+', '', text).strip()
+
+            # 处理转推 (Retweet) 的前缀拼接
+            if 'retweeted_status' in tweet:
+                rt_user = tweet['retweeted_status'].get('user', {}).get('screen_name', 'Unknown')
+                rt_text = str(tweet['retweeted_status'].get('full_text') or '')
+                rt_clean_text = re.sub(r'https://t\.co/\w+', '', rt_text).strip()
+                clean_text = f"RT @{rt_user}: {rt_clean_text}"
+
+            tweets.append({
+                'author': f"@{author}", 
+                'content': clean_text,
+                'timestamp': tweet.get('created_at', '')
+            })
+
+        if tweets:
+            logger.info(f"✅ 成功获取到 {len(tweets)} 条 Twitter 个人时间线动态")
+            return {'success': True, 'tweets': tweets}
+        else:
+            return {'success': False, 'error': '未解析到推文内容'}
+
     except Exception as e: 
         logger.error(f"Twitter API 获取失败: {e}")
         return {'success': False, 'error': str(e)}

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -1893,14 +1893,10 @@ async def fetch_window_context_content(limit: int = 5) -> Dict[str, Any]:
         return {
             'success': True,
             'window_title': sanitized_title,
-            'region': '',
+            'region': 'china' if china_region else 'non-china',
             'search_queries': successful_queries,
             'search_results': unique_results,
         }
-        if china_region:
-            result['region'] = 'china'
-        else:
-            result['region'] = 'non-china'
         
     except Exception as e:
         if is_china_region():
@@ -2509,7 +2505,13 @@ async def fetch_reddit_personal_dynamic(limit: int = 10) -> Dict[str, Any]:
         # per-call AsyncClient: 带用户鉴权 cookie，见 bilibili 同款理由
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
             response = await client.get(url, headers=headers, cookies=reddit_cookies, timeout=10.0)
-            data = response.json()
+            response.raise_for_status()
+            try:
+                data = response.json()
+            except json.JSONDecodeError as e:
+                return {'success': False, 'error': f'Reddit 响应 JSON 解析失败: {e}'}
+        if not isinstance(data, dict):
+            return {'success': False, 'error': 'Reddit API 返回格式异常（非 dict）'}
         posts = [
             {
                 'title': pd.get('title', ''), 'subreddit': f"r/{pd.get('subreddit', '')}",


### PR DESCRIPTION
## Summary

延续 #865 的 AsyncClient 共享策略，全局审计 httpx / aiohttp 使用，完成一次性全面治理：

1. **A · 泛化内部 client**：`utils/memory_client.py` → `utils/internal_http_client.py`，覆盖**所有** 127.0.0.1 内部服务（memory_server / agent_server / user_plugin_server）。补迁一处 `core.py::_fetch_active_agent_tasks_prompt`。
2. **B · 新增外部 client**：`utils/external_http_client.py`（`verify=True, trust_env=True, follow_redirects=True, timeout=10s`），迁 `web_scraper` 15 处 + `meme_fetcher` 2 处 fallback。
3. **C · dead code**：删除 `utils/frontend_utils.py` 两处 DashScope OSS 上传辅助（全仓无 caller）。
4. **D · 泄露审计**：`agent_server.py:2845` streaming proxy、`cross_server.py` 3 处 aiohttp —— 均有正确 close 路径，无 leak。

## 变更总览

| 区域 | 动作 | 文件 |
|---|---|---|
| 内部 client | rename + 泛化 docstring | `utils/memory_client.py` → `utils/internal_http_client.py` |
| 内部 client callers | 改名 | `main_server.py`, `main_logic/core.py` (×4), `main_routers/system_router.py` (×3) |
| 外部 client | 新建 | `utils/external_http_client.py` |
| web_scraper 迁移 | 15 处 async-with → shared | `utils/web_scraper.py` |
| meme_fetcher fallback | 2 处 → shared | `utils/meme_fetcher.py` |
| 冷路径保留 | 加注释 | `utils/holiday_cache.py` (2 处 `trust_env=False` 刻意绕代理) |
| dead code | 删除 | `utils/frontend_utils.py` (get_upload_policy, upload_file_to_oss) |

## 为什么不能全部共用一个 client？

- Profile A（内部 127.0.0.1）：`verify=False, trust_env=False, http 明文`
- Profile B（外部 HTTPS）：`verify=True, trust_env=True, follow_redirects=True`

**A 的 `verify=False` 用于外部 HTTPS 就是中间人任意伪造证书不报错，安全漏洞**，必须分两个。

## 并发与共享

- `httpx.AsyncClient` 和 `aiohttp.ClientSession` 均是**并发安全**对象。
- `asyncio.gather(client.get(a), client.get(b))` 正常，池内自动开多条 TCP（默认 `max_connections=100`）。
- 跨 host 复用：连接池按 `(scheme, host, port)` 分桶各自 keep-alive，互不干扰。

## 保留 per-call 的点（配合 `# per-call AsyncClient: ...` 注释）

| 位置 | 理由 |
|---|---|
| `main_server.py:1041` | SSL warmup 本身 |
| `main_server.py:1358` | shutdown 信号，每进程一次 |
| `main_logic/tts_client.py:2594` | probe 后紧接着开 per-worker 持久 client |
| `main_routers/characters_router.py` (5 处) | 用户手动触发：建猫娘 / 上传音色 / 粘贴直链 |
| `main_routers/config_router.py:780` | 用户存 API key 触发 |
| `main_routers/cookies_login_router.py` (2 处) | 扫码登录用户触发 |
| `main_routers/memory_router.py:345` | 用户存最近对话触发 |
| `utils/holiday_cache.py` (2 处) | `trust_env=False` 刻意绕代理，配置不兼容 external_http_client；每年每国一次 |
| `utils/meme_fetcher.py` 4 个 `_session` | 已 per-instance 长期复用 + 有 seclevel1 自定义 SSL fallback 分支，不适合合到全局 |

## 压测

Linux Py3.11 httpx 0.28.1, N=100：

| 场景 | 构造 p50 | 构造 p95 | shared 复用 p50 |
|---|---|---|---|
| 空闲 | 36.8ms | 41.6ms | ≈0ms |
| 4× CPU 背景压力 | 37.8ms | 44.0ms | ≈0ms |

pressure/idle 仅 1.03×。Linux 上 pressure 影响不显著。Windows 上作者实测构造 p50=157ms（idle）/ #865 声称压力下 1.1s 的共识仍然成立，主要源自 Windows trust store 冷读 + 事件循环压力叠加。

## Test plan

- [x] `ast.parse` 通过 14 个改动 / 新增文件
- [x] `python scripts/check_async_blocking.py` exit 0
- [x] `pytest tests/unit/ --ignore=tests/unit/test_api_config_manager.py` 208 passed
  - pre-existing 失败：`test_restricted_providers`（无关 httpx）、`tests/e2e/test_e2e_full_flow.py`（playwright bundle flake）均在 main 上同样失败
- [x] 两个新 client 模块 smoke：singleton 保持、config distinct（internal 5s timeout, external 10s）、aclose 无异常
- [x] 14 个触碰的 module `import ok`
- [ ] 启动 server 实际走一遍切换猫娘 / proactive_chat / meme 搜索 / 热搜抓取，确认连接池复用 & shutdown 清理正常
- [ ] Windows 环境实测切换猫娘延迟改善（主要受益群体）

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 统一并分离了内部与外部 HTTP 客户端管理，改进请求复用与关闭清理行为，提升稳定性与性能。
* **移除**
  * 删除了前端异步文件上传相关的辅助功能与对应实现。
* **文档**
  * 增补注释，明确不同请求路径（内部、外部、一次性）使用的客户端创建与生命周期，便于维护和排查。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->