### PR TITLE
修复 PC 版头像裁剪遮罩错位问题

### DIFF
--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -524,7 +524,15 @@
             var drag = null;
 
             function initLayout() {
-                var maxW = Math.min(360, window.innerWidth - 64);
+                // 计算可用宽度：需扣除控制面板宽度、弹窗 padding/border
+                // popup max-width: calc(100vw - 24px), padding: 14px×2, border: 1px×2
+                var controlsEl = popup.querySelector('.avatar-cropper-controls');
+                var controlsWidth = controlsEl ? controlsEl.offsetWidth : 0;
+                var areaEl = wrap.parentElement;
+                var areaGap = areaEl ? (parseFloat(getComputedStyle(areaEl).gap) || 0) : 0;
+                var popupContentW = window.innerWidth - 24 - 28 - 2;
+                var maxW = Math.min(360, popupContentW - controlsWidth - areaGap);
+                if (maxW < MIN_SIZE) maxW = MIN_SIZE;
                 var maxH = Math.min(360, window.innerHeight - 180);
                 var aspect = sourceWidth / sourceHeight;
                 if (aspect >= 1) {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1286,6 +1286,7 @@ body.react-chat-window-dragging {
     border-radius: 8px;
     background: #0a0a0a;
     align-self: center;
+    flex-shrink: 0;
 }
 
 .avatar-cropper-source-img {


### PR DESCRIPTION
精确计算可用宽度（扣除控制面板、弹窗内边距等），并禁止画布容器被 flex 压缩，确保遮罩与裁剪框坐标一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了头像裁剪工具的布局自适应能力，确保在不同屏幕尺寸下能正确显示和调整。

* **Style**
  * 优化了裁剪画布的布局表现，防止在空间受限时出现异常缩小。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->