### PR TITLE
修复 assistApiKey 回退逻辑

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -557,27 +557,36 @@ async def get_core_config_api():
         
         # 旧版本 core_config.json 可能只有 coreApiKey 而没有各 assistApiKey* 字段，
         # 需要与 ConfigManager.get_core_config() 保持一致的回退逻辑，
-        # 以免升级后声音克隆页面误报"没有可用API"。
+        # 但只能回退到与 coreApi / assistApi 匹配的服务商，
+        # 以免将不兼容的 API Key 填充到其他服务商。
         fallback_key = api_key or ''
+        _core_api_provider = core_cfg.get('coreApi', 'qwen')
+        _assist_api_provider = core_cfg.get('assistApi', 'qwen')
+        _fallback_providers = {_core_api_provider, _assist_api_provider}
+
+        def _fb(provider: str) -> str:
+            """仅当 provider 与用户选择的 coreApi/assistApi 一致时才回退到 coreApiKey"""
+            return fallback_key if provider in _fallback_providers else ''
+
         return {
             "api_key": api_key,
-            "coreApi": core_cfg.get('coreApi', 'qwen'),
-            "assistApi": core_cfg.get('assistApi', 'qwen'),
-            "assistApiKeyQwen": core_cfg.get('assistApiKeyQwen', '') or fallback_key,
+            "coreApi": _core_api_provider,
+            "assistApi": _assist_api_provider,
+            "assistApiKeyQwen": core_cfg.get('assistApiKeyQwen', '') or _fb('qwen'),
             "assistApiKeyQwenIntl": core_cfg.get('assistApiKeyQwenIntl', ''),
-            "assistApiKeyOpenai": core_cfg.get('assistApiKeyOpenai', '') or fallback_key,
-            "assistApiKeyGlm": core_cfg.get('assistApiKeyGlm', '') or fallback_key,
-            "assistApiKeyStep": core_cfg.get('assistApiKeyStep', '') or fallback_key,
-            "assistApiKeySilicon": core_cfg.get('assistApiKeySilicon', '') or fallback_key,
-            "assistApiKeyGemini": core_cfg.get('assistApiKeyGemini', '') or fallback_key,
-            "assistApiKeyKimi": core_cfg.get('assistApiKeyKimi', '') or fallback_key,
-            "assistApiKeyDeepseek": core_cfg.get('assistApiKeyDeepseek', '') or fallback_key,
-            "assistApiKeyDoubao": core_cfg.get('assistApiKeyDoubao', '') or fallback_key,
+            "assistApiKeyOpenai": core_cfg.get('assistApiKeyOpenai', '') or _fb('openai'),
+            "assistApiKeyGlm": core_cfg.get('assistApiKeyGlm', '') or _fb('glm'),
+            "assistApiKeyStep": core_cfg.get('assistApiKeyStep', '') or _fb('step'),
+            "assistApiKeySilicon": core_cfg.get('assistApiKeySilicon', '') or _fb('silicon'),
+            "assistApiKeyGemini": core_cfg.get('assistApiKeyGemini', '') or _fb('gemini'),
+            "assistApiKeyKimi": core_cfg.get('assistApiKeyKimi', '') or _fb('kimi'),
+            "assistApiKeyDeepseek": core_cfg.get('assistApiKeyDeepseek', '') or _fb('deepseek'),
+            "assistApiKeyDoubao": core_cfg.get('assistApiKeyDoubao', '') or _fb('doubao'),
             "assistApiKeyMinimax": core_cfg.get('assistApiKeyMinimax', ''),
             "assistApiKeyMinimaxIntl": core_cfg.get('assistApiKeyMinimaxIntl', ''),
-            "assistApiKeyGrok": core_cfg.get('assistApiKeyGrok', '') or fallback_key,
-            "assistApiKeyClaude": core_cfg.get('assistApiKeyClaude', '') or fallback_key,
-            "assistApiKeyOpenrouter": core_cfg.get('assistApiKeyOpenrouter', '') or fallback_key,
+            "assistApiKeyGrok": core_cfg.get('assistApiKeyGrok', '') or _fb('grok'),
+            "assistApiKeyClaude": core_cfg.get('assistApiKeyClaude', '') or _fb('claude'),
+            "assistApiKeyOpenrouter": core_cfg.get('assistApiKeyOpenrouter', '') or _fb('openrouter'),
             "mcpToken": core_cfg.get('mcpToken', ''),
             "openclawUrl": core_cfg.get('openclawUrl'),
             "openclawTimeout": core_cfg.get('openclawTimeout'),

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -560,8 +560,8 @@ async def get_core_config_api():
         # 但只能回退到与 coreApi / assistApi 匹配的服务商，
         # 以免将不兼容的 API Key 填充到其他服务商。
         fallback_key = api_key or ''
-        _core_api_provider = core_cfg.get('coreApi', 'qwen')
-        _assist_api_provider = core_cfg.get('assistApi', 'qwen')
+        _core_api_provider = core_cfg.get('coreApi') or 'qwen'
+        _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
 
         def _fb(provider: str) -> str:

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1717,25 +1717,32 @@ class ConfigManager:
             if not isinstance(core_cfg, dict):
                 core_cfg = deepcopy(DEFAULT_CONFIG_DATA['core_config.json'])
 
-        # API Keys
+        # API Keys — 仅对与 coreApi/assistApi 匹配的服务商回退到 CORE_API_KEY
         if core_cfg.get('coreApiKey'):
             config['CORE_API_KEY'] = core_cfg['coreApiKey']
 
-        config['ASSIST_API_KEY_QWEN'] = core_cfg.get('assistApiKeyQwen', '') or config['CORE_API_KEY']
+        _core_api_provider = core_cfg.get('coreApi', 'qwen')
+        _assist_api_provider = core_cfg.get('assistApi', 'qwen')
+        _fallback_providers = {_core_api_provider, _assist_api_provider}
+
+        def _fb(provider: str) -> str:
+            return config['CORE_API_KEY'] if provider in _fallback_providers else ''
+
+        config['ASSIST_API_KEY_QWEN'] = core_cfg.get('assistApiKeyQwen', '') or _fb('qwen')
         config['ASSIST_API_KEY_QWEN_INTL'] = core_cfg.get('assistApiKeyQwenIntl', '')
-        config['ASSIST_API_KEY_OPENAI'] = core_cfg.get('assistApiKeyOpenai', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_GLM'] = core_cfg.get('assistApiKeyGlm', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_STEP'] = core_cfg.get('assistApiKeyStep', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_SILICON'] = core_cfg.get('assistApiKeySilicon', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_GEMINI'] = core_cfg.get('assistApiKeyGemini', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_KIMI'] = core_cfg.get('assistApiKeyKimi', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_DEEPSEEK'] = core_cfg.get('assistApiKeyDeepseek', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_DOUBAO'] = core_cfg.get('assistApiKeyDoubao', '') or config['CORE_API_KEY']
+        config['ASSIST_API_KEY_OPENAI'] = core_cfg.get('assistApiKeyOpenai', '') or _fb('openai')
+        config['ASSIST_API_KEY_GLM'] = core_cfg.get('assistApiKeyGlm', '') or _fb('glm')
+        config['ASSIST_API_KEY_STEP'] = core_cfg.get('assistApiKeyStep', '') or _fb('step')
+        config['ASSIST_API_KEY_SILICON'] = core_cfg.get('assistApiKeySilicon', '') or _fb('silicon')
+        config['ASSIST_API_KEY_GEMINI'] = core_cfg.get('assistApiKeyGemini', '') or _fb('gemini')
+        config['ASSIST_API_KEY_KIMI'] = core_cfg.get('assistApiKeyKimi', '') or _fb('kimi')
+        config['ASSIST_API_KEY_DEEPSEEK'] = core_cfg.get('assistApiKeyDeepseek', '') or _fb('deepseek')
+        config['ASSIST_API_KEY_DOUBAO'] = core_cfg.get('assistApiKeyDoubao', '') or _fb('doubao')
         config['ASSIST_API_KEY_MINIMAX'] = core_cfg.get('assistApiKeyMinimax', '')
         config['ASSIST_API_KEY_MINIMAX_INTL'] = core_cfg.get('assistApiKeyMinimaxIntl', '')
-        config['ASSIST_API_KEY_GROK'] = core_cfg.get('assistApiKeyGrok', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_CLAUDE'] = core_cfg.get('assistApiKeyClaude', '') or config['CORE_API_KEY']
-        config['ASSIST_API_KEY_OPENROUTER'] = core_cfg.get('assistApiKeyOpenrouter', '') or config['CORE_API_KEY']
+        config['ASSIST_API_KEY_GROK'] = core_cfg.get('assistApiKeyGrok', '') or _fb('grok')
+        config['ASSIST_API_KEY_CLAUDE'] = core_cfg.get('assistApiKeyClaude', '') or _fb('claude')
+        config['ASSIST_API_KEY_OPENROUTER'] = core_cfg.get('assistApiKeyOpenrouter', '') or _fb('openrouter')
 
         if core_cfg.get('mcpToken'):
             config['MCP_ROUTER_API_KEY'] = core_cfg['mcpToken']

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -1721,8 +1721,8 @@ class ConfigManager:
         if core_cfg.get('coreApiKey'):
             config['CORE_API_KEY'] = core_cfg['coreApiKey']
 
-        _core_api_provider = core_cfg.get('coreApi', 'qwen')
-        _assist_api_provider = core_cfg.get('assistApi', 'qwen')
+        _core_api_provider = core_cfg.get('coreApi') or 'qwen'
+        _assist_api_provider = core_cfg.get('assistApi') or 'qwen'
         _fallback_providers = {_core_api_provider, _assist_api_provider}
 
         def _fb(provider: str) -> str:


### PR DESCRIPTION
仅对与用户选择的 coreApi/assistApi 匹配的服务商回退 coreApiKey，避免将不兼容的 API Key 错误填充到所有服务商字段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 改进 API 密钥的回退策略：仅在目标提供商与配置中选择的提供商匹配时才使用通用备用密钥，按提供商有条件回退，提升密钥配置的准确性与安全性；部分特定提供商字段保持原有独立配置，不受通用回退影响。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->