### PR TITLE
fix(jukebox): i18n 化 bindings 页已选提示

### DIFF
--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -1345,10 +1345,19 @@ window.Jukebox = {
 
       let text = '';
       if (activeTab === 'bindings' && (bindingSongCount > 0 || bindingActionCount > 0)) {
-        text = `绑定页已选 ${bindingSongCount} 首歌曲、${bindingActionCount} 个动画；绑定集合共 ${bindingBundle.songIds.length} 首歌曲、${bindingBundle.actionIds.length} 个动画`;
+        text = window.t('Jukebox.bindingsSelected', {
+          defaultValue: '绑定页已选 {{bindingSongCount}} 首歌曲、{{bindingActionCount}} 个动画；绑定集合共 {{bundleSongCount}} 首歌曲、{{bundleActionCount}} 个动画',
+          bindingSongCount,
+          bindingActionCount,
+          bundleSongCount: bindingBundle.songIds.length,
+          bundleActionCount: bindingBundle.actionIds.length,
+        });
       } else if (songCount > 0 || actionCount > 0) {
-        const template = window.t('Jukebox.selectedInfo', '已选择 {{songCount}} 首歌曲，{{actionCount}} 个动画');
-        text = template.replace('{{songCount}}', songCount).replace('{{actionCount}}', actionCount);
+        text = window.t('Jukebox.selectedInfo', {
+          defaultValue: '已选择 {{songCount}} 首歌曲，{{actionCount}} 个动画',
+          songCount,
+          actionCount,
+        });
       }
 
       infoEl.textContent = text;

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2927,6 +2927,7 @@
         "selectedActions": "{{count}} animations selected",
         "selectedSeparator": ", ",
         "selectedInfo": "{{songCount}} songs and {{actionCount}} animations selected",
+        "bindingsSelected": "Bindings tab: {{bindingSongCount}} songs, {{bindingActionCount}} animations selected; bundle total: {{bundleSongCount}} songs, {{bundleActionCount}} animations",
         "missing": "Missing",
         "unknownError": "Unknown error",
         "calibration": "Calibrate Animation",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2927,6 +2927,7 @@
         "selectedActions": "{{count}}アニメーション選択中",
         "selectedSeparator": "、",
         "selectedInfo": "{{songCount}}曲、{{actionCount}}アニメーション選択中",
+        "bindingsSelected": "バインディングタブで{{bindingSongCount}}曲、{{bindingActionCount}}アニメーション選択中；バンドル合計{{bundleSongCount}}曲、{{bundleActionCount}}アニメーション",
         "missing": "欠落",
         "unknownError": "不明なエラー",
         "calibration": "アニメーションをキャリブレーション",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2927,6 +2927,7 @@
         "selectedActions": "{{count}}개 애니메이션 선택됨",
         "selectedSeparator": ", ",
         "selectedInfo": "{{songCount}}개 노래, {{actionCount}}개 애니메이션 선택됨",
+        "bindingsSelected": "바인딩 탭에서 {{bindingSongCount}}개 노래, {{bindingActionCount}}개 애니메이션 선택됨; 번들 합계 {{bundleSongCount}}개 노래, {{bundleActionCount}}개 애니메이션",
         "missing": "누락",
         "unknownError": "알 수 없는 오류",
         "calibration": "애니메이션 보정",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2927,6 +2927,7 @@
         "selectedActions": "Выбрано {{count}} анимаций",
         "selectedSeparator": ", ",
         "selectedInfo": "Выбрано {{songCount}} песен, {{actionCount}} анимаций",
+        "bindingsSelected": "На вкладке привязок выбрано: {{bindingSongCount}} песен, {{bindingActionCount}} анимаций; всего в наборе: {{bundleSongCount}} песен, {{bundleActionCount}} анимаций",
         "missing": "Отсутствует",
         "unknownError": "Неизвестная ошибка",
         "calibration": "Калибровка анимации",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2927,6 +2927,7 @@
         "selectedActions": "已选择 {{count}} 个动画",
         "selectedSeparator": "，",
         "selectedInfo": "已选择 {{songCount}} 首歌曲，{{actionCount}} 个动画",
+        "bindingsSelected": "绑定页已选 {{bindingSongCount}} 首歌曲、{{bindingActionCount}} 个动画；绑定集合共 {{bundleSongCount}} 首歌曲、{{bundleActionCount}} 个动画",
         "missing": "缺失",
         "unknownError": "未知错误",
         "calibration": "校准动画",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2927,6 +2927,7 @@
         "selectedActions": "已選擇 {{count}} 個動畫",
         "selectedSeparator": "，",
         "selectedInfo": "已選擇 {{songCount}} 首歌曲，{{actionCount}} 個動畫",
+        "bindingsSelected": "綁定頁已選 {{bindingSongCount}} 首歌曲、{{bindingActionCount}} 個動畫；綁定集合共 {{bundleSongCount}} 首歌曲、{{bundleActionCount}} 個動畫",
         "missing": "缺失",
         "unknownError": "未知錯誤",
         "calibration": "校準動畫",

--- a/templates/jukebox.html
+++ b/templates/jukebox.html
@@ -138,8 +138,15 @@
 
             _jbInitDone = true;
             if (typeof window.t !== 'function') {
-                window.t = function(key, fallback) {
-                    return fallback || key;
+                window.t = function(key, opts) {
+                    if (typeof opts === 'string') return opts;
+                    if (opts && typeof opts === 'object') {
+                        var tpl = typeof opts.defaultValue === 'string' ? opts.defaultValue : key;
+                        return tpl.replace(/\{\{(\w+)\}\}/g, function(_, name) {
+                            return opts[name] != null ? opts[name] : '{{' + name + '}}';
+                        });
+                    }
+                    return key;
                 };
             }
             _initJukebox();

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -321,7 +321,16 @@
             if (!_mgrInitDone) {
                 _mgrInitDone = true;
                 if (typeof window.t !== 'function') {
-                    window.t = function(key, fallback) { return typeof fallback === 'string' ? fallback : key; };
+                    window.t = function(key, opts) {
+                        if (typeof opts === 'string') return opts;
+                        if (opts && typeof opts === 'object') {
+                            var tpl = typeof opts.defaultValue === 'string' ? opts.defaultValue : key;
+                            return tpl.replace(/\{\{(\w+)\}\}/g, function(_, name) {
+                                return opts[name] != null ? opts[name] : '{{' + name + '}}';
+                            });
+                        }
+                        return key;
+                    };
                 }
                 _initManager().catch(function(e) { console.error('[JukeboxManager] init failed:', e); });
             }


### PR DESCRIPTION
## Summary
- 绑定页 `updateSelectionInfo()` 里"绑定页已选 N 首歌曲、N 个动画；绑定集合共 ..."原本是硬编码中文字符串，切语言不生效；改成走 `window.t('Jukebox.bindingsSelected', { ... })` 让 i18next 原生插值。
- 顺手把旁边 `selectedInfo` 的 `template.replace(...).replace(...)` 也改成 params 对象，和 `app-agent.js` 里 `window.t('settings.toggles.unavailable', { name })` 的既有用法对齐。
- 6 个 locale (en/ja/ko/ru/zh-CN/zh-TW) 全部同步补齐新 key `Jukebox.bindingsSelected`，占位符 `{{bindingSongCount}} / {{bindingActionCount}} / {{bundleSongCount}} / {{bundleActionCount}}`。

## Test plan
- [ ] 打开 Jukebox 管理器，切到"绑定"页
- [ ] 勾选若干歌曲 + 动画，确认底部信息栏文案正确
- [ ] 切换 6 种语言，各自显示对应翻译
- [ ] 非绑定页（songs / actions）底部信息仍按 `selectedInfo` 模板正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 改进了选择信息显示：绑定选项卡现在同时显示所选项数与对应的捆绑总数，统计更清晰。
  * 扩展了多语言本地化：新增/更新了日文、韩文、俄文、简体中文和繁体中文的对应文案。
* **改进**
  * 优化了国际化文本的占位替换与回退行为，提升多语言显示一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->