### PR TITLE
fix/修复切换猫娘后上一位的聊天记录仍残留

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -418,6 +418,11 @@
             // 3. 准备新环境
             showStatusToast(window.t ? window.t('app.switchingCatgirl', { name: newCatgirl }) : `正在切换到 ${newCatgirl}...`, 3000);
 
+            // 先退役旧 socket，让它后续的 onmessage / onclose 在清空会话期间直接走 stale guard。
+            if (_switchOldSocket && S.socket === _switchOldSocket) {
+                S.socket = null;
+            }
+
             // 清空聊天记录和相关全局状态
             const chatContainer = document.getElementById('chatContainer');
             if (chatContainer) {

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -423,6 +423,12 @@
             if (chatContainer) {
                 chatContainer.innerHTML = '';
             }
+            if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearMessages === 'function') {
+                window.reactChatWindowHost.clearMessages();
+            }
+            if (typeof window._resetReactChatSwitchState === 'function') {
+                window._resetReactChatSwitchState();
+            }
             // 重置聊天相关的全局状态
             window.currentGeminiMessage = null;
             window._geminiTurnFullText = '';
@@ -434,9 +440,15 @@
             window._pendingMusicCommand = '';
             window._realisticGeminiTimestamp = null;
             window._realisticGeminiVersion = (window._realisticGeminiVersion || 0) + 1;
+            window._isProcessingRealisticQueue = false;
+            window.realisticGeminiCurrentTurnId = null;
             // 重置语音模式用户转录合并追踪
             S.lastVoiceUserMessage = null;
             S.lastVoiceUserMessageTime = 0;
+            // 丢弃切换前已经入站但尚未消费的旧 TTS 数据
+            S.incomingAudioEpoch += 1;
+            S.incomingAudioBlobQueue = [];
+            S.pendingAudioChunkMetaQueue = [];
 
             // 清理连接与状态
             if (S.autoReconnectTimeoutId) clearTimeout(S.autoReconnectTimeoutId);

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -251,6 +251,14 @@
         });
     }
 
+    function _resetReactChatSwitchState() {
+        _pendingHostMessages = [];
+        if (_pendingFlushTimer) {
+            clearInterval(_pendingFlushTimer);
+            _pendingFlushTimer = null;
+        }
+    }
+
     function createGeminiBubble(sentence) {
         var host = getHost();
         var cleanSentence = (sentence || '').replace(/\[play_music:[^\]]*(\]|$)/g, '');
@@ -661,6 +669,7 @@
     window.setReactMessageStatus = setReactMessageStatus;
     window._tryFlushPendingHostMessages = _tryFlushPendingHostMessages;
     window._clearPendingHostMessagesByIds = _clearPendingHostMessagesByIds;
+    window._resetReactChatSwitchState = _resetReactChatSwitchState;
 
     // 覆盖 appChat 上的方法
     if (window.appChat) {

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -503,6 +503,11 @@
 
         // ---- onmessage ----
         S.socket.onmessage = function (event) {
+            if (S.socket !== _thisSocket) {
+                console.log('[WS] stale onmessage skipped (socket already replaced)');
+                return;
+            }
+
             // Binary audio data
             if (event.data instanceof Blob) {
                 if (window.DEBUG_AUDIO) {

--- a/tests/frontend/test_chat_switch_reset.py
+++ b/tests/frontend/test_chat_switch_reset.py
@@ -12,6 +12,9 @@ def _open_chat_page(mock_page: Page, running_server: str) -> None:
         " && window.connectWebSocket"
         " && window.reactChatWindowHost"
         " && typeof window.appendMessage === 'function'"
+        " && typeof window.createGeminiBubble === 'function'"
+        " && typeof window._tryFlushPendingHostMessages === 'function'"
+        " && typeof window._resetReactChatSwitchState === 'function'"
         " && window.appState"
     )
 
@@ -79,7 +82,17 @@ def test_chat_switch_clears_dom_react_and_pending_adapter_messages(
             window.invalidatePendingMusicSearch = () => {};
 
             window.reactChatWindowHost.clearMessages();
-            window.reactChatWindowHost.appendMessage({
+            window._resetReactChatSwitchState();
+
+            const host = window.reactChatWindowHost;
+            const originalAppendMessage = host.appendMessage;
+            window.__postSwitchForcedFlushAppends = 0;
+            host.appendMessage = (message) => {
+                window.__postSwitchForcedFlushAppends += 1;
+                return originalAppendMessage.call(host, message);
+            };
+
+            host.appendMessage({
                 id: 'old-react-message',
                 role: 'assistant',
                 author: oldCatgirl,
@@ -87,6 +100,7 @@ def test_chat_switch_clears_dom_react_and_pending_adapter_messages(
                 blocks: [{ type: 'text', text: 'old react message' }],
                 status: 'sent'
             });
+            window.__postSwitchForcedFlushAppends = 0;
 
             const chatContainer = document.getElementById('chatContainer');
             if (chatContainer) {
@@ -97,17 +111,26 @@ def test_chat_switch_clears_dom_react_and_pending_adapter_messages(
                 chatContainer.appendChild(oldBubble);
             }
 
-            const host = window.reactChatWindowHost;
-            delete window.reactChatWindowHost;
-            window.appendMessage('queued stale message。', 'gemini', true);
+            window.reactChatWindowHost = null;
+            const queuedRef = window.createGeminiBubble('queued stale message');
             window.reactChatWindowHost = host;
+            const queuedMessageId = queuedRef && queuedRef.dataset
+                ? queuedRef.dataset.reactChatMessageId || ''
+                : '';
+            const preSwitchReactMessages = host.getState().messages.length;
 
             await window.handleCatgirlSwitch(newCatgirl, oldCatgirl);
+            window._tryFlushPendingHostMessages();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            host.appendMessage = originalAppendMessage;
 
             return {
                 oldCatgirl,
                 newCatgirl,
                 currentCatgirl: window.lanlan_config.lanlan_name,
+                queuedMessageId,
+                preSwitchReactMessages,
+                postSwitchForcedFlushAppends: window.__postSwitchForcedFlushAppends,
                 reactMessages: window.reactChatWindowHost.getState().messages.length,
                 domMessages: document.querySelectorAll('#chatContainer .message').length,
                 connectCalls: window.__switchConnectCalls,
@@ -122,6 +145,9 @@ def test_chat_switch_clears_dom_react_and_pending_adapter_messages(
 
     assert "error" not in result, result
     assert result["currentCatgirl"] == result["newCatgirl"]
+    assert result["queuedMessageId"]
+    assert result["preSwitchReactMessages"] == 1
+    assert result["postSwitchForcedFlushAppends"] == 0
     assert result["reactMessages"] == 0
     assert result["domMessages"] == 0
     assert result["connectCalls"] == 1
@@ -233,6 +259,12 @@ def test_stale_socket_onmessage_does_not_replay_old_messages_or_audio(
                     type: 'gemini_response',
                     text: 'live should remain。',
                     isNewMessage: true
+                })
+            });
+            liveSocket.onmessage({
+                data: JSON.stringify({
+                    type: 'system',
+                    data: 'turn end'
                 })
             });
             liveSocket.onmessage({ data: new Blob(['live-audio']) });

--- a/tests/frontend/test_chat_switch_reset.py
+++ b/tests/frontend/test_chat_switch_reset.py
@@ -1,0 +1,266 @@
+import pytest
+from playwright.sync_api import Page
+
+
+def _open_chat_page(mock_page: Page, running_server: str) -> None:
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(f"{running_server}/chat", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.handleCatgirlSwitch"
+        " && window.connectWebSocket"
+        " && window.reactChatWindowHost"
+        " && typeof window.appendMessage === 'function'"
+        " && window.appState"
+    )
+
+
+@pytest.mark.frontend
+def test_chat_switch_clears_dom_react_and_pending_adapter_messages(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_chat_page(mock_page, running_server)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const resp = await fetch('/api/characters');
+            const data = await resp.json();
+            const names = Object.keys((data && data['猫娘']) || {});
+            if (names.length < 2) {
+                return { error: 'not_enough_catgirls', names };
+            }
+
+            const oldCatgirl = names[0];
+            const newCatgirl = names.find((name) => name !== oldCatgirl) || '';
+
+            window.lanlan_config = window.lanlan_config || {};
+            window.lanlan_config.lanlan_name = oldCatgirl;
+            window._currentCatgirl = oldCatgirl;
+            window.currentCatgirl = oldCatgirl;
+
+            if (window.appState.heartbeatInterval) {
+                clearInterval(window.appState.heartbeatInterval);
+                window.appState.heartbeatInterval = null;
+            }
+            if (window.appState.autoReconnectTimeoutId) {
+                clearTimeout(window.appState.autoReconnectTimeoutId);
+                window.appState.autoReconnectTimeoutId = null;
+            }
+            try {
+                if (window.appState.socket && typeof window.appState.socket.close === 'function') {
+                    window.appState.socket.close();
+                }
+            } catch (_) {}
+            window.appState.socket = null;
+            window.appState.isRecording = false;
+            window.appState.isTextSessionActive = true;
+            window.appState.incomingAudioEpoch = 7;
+            window.appState.incomingAudioBlobQueue = [
+                { epoch: 7, speechId: 'old-speech', blob: new Blob(['old-audio']) }
+            ];
+            window.appState.pendingAudioChunkMetaQueue = [
+                { epoch: 7, speechId: 'old-speech' }
+            ];
+
+            window.__switchConnectCalls = 0;
+            window.__switchClearAudioCalls = 0;
+            window.showStatusToast = () => {};
+            window.clearAudioQueue = async () => {
+                window.__switchClearAudioCalls += 1;
+            };
+            window.connectWebSocket = () => {
+                window.__switchConnectCalls += 1;
+            };
+            window.stopRecording = () => {};
+            window.syncFloatingMicButtonState = () => {};
+            window.syncFloatingScreenButtonState = () => {};
+            window.invalidatePendingMusicSearch = () => {};
+
+            window.reactChatWindowHost.clearMessages();
+            window.reactChatWindowHost.appendMessage({
+                id: 'old-react-message',
+                role: 'assistant',
+                author: oldCatgirl,
+                time: '12:00:00',
+                blocks: [{ type: 'text', text: 'old react message' }],
+                status: 'sent'
+            });
+
+            const chatContainer = document.getElementById('chatContainer');
+            if (chatContainer) {
+                chatContainer.innerHTML = '';
+                const oldBubble = document.createElement('div');
+                oldBubble.className = 'message gemini';
+                oldBubble.textContent = 'old dom bubble';
+                chatContainer.appendChild(oldBubble);
+            }
+
+            const host = window.reactChatWindowHost;
+            delete window.reactChatWindowHost;
+            window.appendMessage('queued stale message。', 'gemini', true);
+            window.reactChatWindowHost = host;
+
+            await window.handleCatgirlSwitch(newCatgirl, oldCatgirl);
+
+            return {
+                oldCatgirl,
+                newCatgirl,
+                currentCatgirl: window.lanlan_config.lanlan_name,
+                reactMessages: window.reactChatWindowHost.getState().messages.length,
+                domMessages: document.querySelectorAll('#chatContainer .message').length,
+                connectCalls: window.__switchConnectCalls,
+                clearAudioCalls: window.__switchClearAudioCalls,
+                isTextSessionActive: window.appState.isTextSessionActive,
+                incomingAudioEpoch: window.appState.incomingAudioEpoch,
+                incomingAudioBlobQueue: window.appState.incomingAudioBlobQueue.length,
+                pendingAudioChunkMetaQueue: window.appState.pendingAudioChunkMetaQueue.length
+            };
+        }"""
+    )
+
+    assert "error" not in result, result
+    assert result["currentCatgirl"] == result["newCatgirl"]
+    assert result["reactMessages"] == 0
+    assert result["domMessages"] == 0
+    assert result["connectCalls"] == 1
+    assert result["clearAudioCalls"] == 1
+    assert result["isTextSessionActive"] is False
+    assert result["incomingAudioEpoch"] == 8
+    assert result["incomingAudioBlobQueue"] == 0
+    assert result["pendingAudioChunkMetaQueue"] == 0
+
+    mock_page.wait_for_timeout(350)
+    after_retry = mock_page.evaluate(
+        """() => ({
+            reactMessages: window.reactChatWindowHost.getState().messages.length,
+            domMessages: document.querySelectorAll('#chatContainer .message').length
+        })"""
+    )
+    assert after_retry["reactMessages"] == 0
+    assert after_retry["domMessages"] == 0
+
+
+@pytest.mark.frontend
+def test_stale_socket_onmessage_does_not_replay_old_messages_or_audio(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_chat_page(mock_page, running_server)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const resp = await fetch('/api/characters');
+            const data = await resp.json();
+            const names = Object.keys((data && data['猫娘']) || {});
+            if (names.length < 2) {
+                return { error: 'not_enough_catgirls', names };
+            }
+
+            if (window.appState.heartbeatInterval) {
+                clearInterval(window.appState.heartbeatInterval);
+                window.appState.heartbeatInterval = null;
+            }
+            if (window.appState.autoReconnectTimeoutId) {
+                clearTimeout(window.appState.autoReconnectTimeoutId);
+                window.appState.autoReconnectTimeoutId = null;
+            }
+            try {
+                if (window.appState.socket && typeof window.appState.socket.close === 'function') {
+                    window.appState.socket.close();
+                }
+            } catch (_) {}
+            window.appState.socket = null;
+
+            window.reactChatWindowHost.clearMessages();
+            const chatContainer = document.getElementById('chatContainer');
+            if (chatContainer) {
+                chatContainer.innerHTML = '';
+            }
+
+            window.__audioEnqueueCount = 0;
+            window.enqueueIncomingAudioBlob = () => {
+                window.__audioEnqueueCount += 1;
+            };
+
+            window.__wsInstances = [];
+            function FakeWebSocket(url) {
+                this.url = url;
+                this.readyState = 0;
+                this.sent = [];
+            }
+            FakeWebSocket.prototype.addEventListener = function () {};
+            FakeWebSocket.prototype.send = function (payload) {
+                this.sent.push(payload);
+            };
+            FakeWebSocket.prototype.close = function () {
+                this.readyState = 3;
+            };
+
+            function FakeWebSocketCtor(url) {
+                const ws = new FakeWebSocket(url);
+                window.__wsInstances.push(ws);
+                return ws;
+            }
+            FakeWebSocketCtor.OPEN = 1;
+            FakeWebSocketCtor.CONNECTING = 0;
+            FakeWebSocketCtor.CLOSING = 2;
+            FakeWebSocketCtor.CLOSED = 3;
+            FakeWebSocketCtor.prototype = FakeWebSocket.prototype;
+            window.WebSocket = FakeWebSocketCtor;
+
+            window.lanlan_config = window.lanlan_config || {};
+            window.lanlan_config.lanlan_name = names[0];
+            window.connectWebSocket();
+            const staleSocket = window.__wsInstances[0];
+
+            window.lanlan_config.lanlan_name = names[1];
+            window.connectWebSocket();
+            const liveSocket = window.__wsInstances[1];
+
+            staleSocket.onmessage({
+                data: JSON.stringify({
+                    type: 'gemini_response',
+                    text: 'stale should be ignored。',
+                    isNewMessage: true
+                })
+            });
+            staleSocket.onmessage({ data: new Blob(['stale-audio']) });
+
+            liveSocket.onmessage({
+                data: JSON.stringify({
+                    type: 'gemini_response',
+                    text: 'live should remain。',
+                    isNewMessage: true
+                })
+            });
+            liveSocket.onmessage({ data: new Blob(['live-audio']) });
+
+            const snapshot = window.reactChatWindowHost.getState();
+            const firstMessage = snapshot.messages[0] || null;
+            const firstText = firstMessage && Array.isArray(firstMessage.blocks)
+                ? firstMessage.blocks
+                    .map((block) => block && block.type === 'text' ? block.text : '')
+                    .join('')
+                : '';
+
+            return {
+                instances: window.__wsInstances.length,
+                messageCount: snapshot.messages.length,
+                firstText,
+                audioEnqueueCount: window.__audioEnqueueCount,
+                currentSocketUrl: window.appState.socket && window.appState.socket.url,
+                staleSocketUrl: staleSocket.url,
+                liveSocketUrl: liveSocket.url
+            };
+        }"""
+    )
+
+    assert "error" not in result, result
+    assert result["instances"] == 2
+    assert result["messageCount"] == 1
+    assert result["firstText"] == "live should remain。"
+    assert result["audioEnqueueCount"] == 1
+    assert result["currentSocketUrl"] == result["liveSocketUrl"]
+    assert result["currentSocketUrl"] != result["staleSocketUrl"]


### PR DESCRIPTION
背景
切换当前猫娘时，现有逻辑只清空了旧版 DOM 聊天气泡和部分全局状态，但 React 聊天窗口内部的消息 state 以及 adapter 的待重放队列没有一起清理，导致切换到下一位猫娘后，上一位的聊天记录仍然会显示出来。

此外，切换过程中如果旧 WebSocket 连接还有迟到消息或音频到达，也可能把旧会话内容重新写回新猫娘的会话中。

本次修改
在角色切换流程中补充 React 聊天窗口清理
切换猫娘时调用 reactChatWindowHost.clearMessages()，确保 React 聊天记录被清空
同步清空 adapter 的待重放消息队列，避免旧消息在 host 恢复后被重新 append
在角色切换流程中补充会话残留状态清理
重置 currentGeminiMessage、currentTurnGeminiBubbles、_geminiTurnFullText
清空 realistic queue / buffer，并复位处理锁
丢弃切换前已经入站但尚未消费的旧 TTS blob 和 chunk meta
在 WebSocket 消息处理入口增加 stale-socket guard
如果当前 onmessage 所属 socket 已经不是活跃连接，则直接忽略该消息
防止旧连接的迟到文本/音频污染新猫娘会话
新增前端回归测试
验证切换后 DOM、React state、adapter pending 队列都会被清空
验证旧 socket 的迟到消息和音频不会写回当前会话
影响范围
前端角色切换逻辑
React 聊天窗口 adapter
WebSocket 前端消息消费逻辑
前端回归测试

预期效果
切换到下一位猫娘后，聊天窗口会从空状态开始
上一位猫娘的历史消息不会继续显示
切换过程中旧连接的迟到文本和音频不会回灌到新会话

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 切换角色时增强会话与界面重置，主动清除聊天界面、排队消息和音频队列。

* **Bug 修复**
  * 阻止旧连接/过期会话导致的旧消息或音频被重新处理或回放。

* **测试**
  * 新增前端端到端测试，验证切换后界面与音频/消息队列正确清空并防止过期数据重现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->