### PR TITLE
fix(chat): 修复 React 聊天窗口用户消息双渐入和 You -> 实际名字闪动

### DIFF
--- a/frontend/react-neko-chat/src/App.test.tsx
+++ b/frontend/react-neko-chat/src/App.test.tsx
@@ -69,6 +69,19 @@ describe('App', () => {
     expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'Test send' });
   });
 
+  it('does not render a local optimistic user bubble before the host echoes messages', () => {
+    const onComposerSubmit = vi.fn();
+    render(<App onComposerSubmit={onComposerSubmit} />);
+
+    const input = screen.getByPlaceholderText('Type a message...');
+    fireEvent.change(input, { target: { value: 'No local optimistic bubble' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(onComposerSubmit).toHaveBeenCalledWith({ text: 'No local optimistic bubble' });
+    expect(screen.queryByText('No local optimistic bubble')).not.toBeInTheDocument();
+    expect(screen.queryByText('You')).not.toBeInTheDocument();
+  });
+
   it('renders composer tool buttons and calls the React callbacks', () => {
     const onComposerImportImage = vi.fn();
     const onComposerScreenshot = vi.fn();

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useRef } from 'react';
 import MessageList from './MessageList';
 import { i18n } from './i18n';
 import {
@@ -53,45 +53,11 @@ export default function App({
   onTranslateToggle,
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
-  const [pendingDrafts, setPendingDrafts] = useState<Array<{ id: string; text: string; time: string; lastMsgId: string | null }>>([]);
   const submittingRef = useRef(false);
   const canSubmit = draft.trim().length > 0 || composerAttachments.length > 0;
   const resolvedImportImageAriaLabel = importImageButtonAriaLabel || importImageButtonLabel;
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
   const resolvedTranslateAriaLabel = translateButtonAriaLabel || translateButtonLabel;
-
-  // Clear pending drafts once the host confirms them (appears in messages)
-  useEffect(() => {
-    if (pendingDrafts.length === 0) return;
-    const remaining = pendingDrafts.filter(d => {
-      const anchor = d.lastMsgId ? messages.findIndex(m => m.id === d.lastMsgId) : -1;
-      const newMsgs = messages.slice(anchor + 1);
-      const newUserTexts = new Set(
-        newMsgs
-          .filter(m => m.role === 'user')
-          .flatMap(m => m.blocks.flatMap(b => b.type === 'text' ? [b.text] : [])),
-      );
-      return !newUserTexts.has(d.text);
-    });
-    if (remaining.length < pendingDrafts.length) {
-      setPendingDrafts(remaining);
-    }
-  }, [messages, pendingDrafts]);
-
-  // Merge host messages + optimistic pending drafts
-  const lastUserAuthor = [...messages].reverse().find(m => m.role === 'user')?.author;
-  const allMessages = useMemo(() => {
-    if (pendingDrafts.length === 0) return messages;
-    const optimistic: ChatMessage[] = pendingDrafts.map(d => ({
-      id: d.id,
-      role: 'user' as const,
-      author: lastUserAuthor || 'You',
-      time: d.time,
-      blocks: [{ type: 'text' as const, text: d.text }],
-      status: 'sending' as const,
-    }));
-    return [...messages, ...optimistic];
-  }, [messages, pendingDrafts, lastUserAuthor]);
 
   function submitDraft() {
     if (submittingRef.current) return;
@@ -99,17 +65,6 @@ export default function App({
     if (!text && composerAttachments.length === 0) return;
     submittingRef.current = true;
     try {
-      const now = new Date();
-      const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
-        .map(n => String(n).padStart(2, '0')).join(':');
-      if (text) {
-        setPendingDrafts(prev => [...prev, {
-          id: `pending-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-          text,
-          time,
-          lastMsgId: messages.length > 0 ? messages[messages.length - 1].id : null,
-        }]);
-      }
       onComposerSubmit?.({ text });
       setDraft('');
     } finally {
@@ -132,7 +87,7 @@ export default function App({
 
         <section className="chat-body">
           <MessageList
-            messages={allMessages}
+            messages={messages}
             ariaLabel={messageListAriaLabel}
             failedStatusLabel={failedStatusLabel}
             onAction={onMessageAction}

--- a/frontend/react-neko-chat/src/test/setup.ts
+++ b/frontend/react-neko-chat/src/test/setup.ts
@@ -1,1 +1,31 @@
 import '@testing-library/jest-dom/vitest';
+
+if (!HTMLElement.prototype.scrollTo) {
+  HTMLElement.prototype.scrollTo = function scrollTo(options?: number | ScrollToOptions, y?: number) {
+    if (typeof options === 'number') {
+      this.scrollLeft = options;
+      this.scrollTop = typeof y === 'number' ? y : this.scrollTop;
+      return;
+    }
+
+    if (options && typeof options.top === 'number') {
+      this.scrollTop = options.top;
+    }
+    if (options && typeof options.left === 'number') {
+      this.scrollLeft = options.left;
+    }
+  };
+}
+
+if (typeof window.ResizeObserver === 'undefined') {
+  class ResizeObserverMock {
+    observe() {}
+
+    unobserve() {}
+
+    disconnect() {}
+  }
+
+  window.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+  globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+}

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -118,10 +118,11 @@
         return Array.from(screenshotsList.children).map(function (item, index) {
             var img = item.querySelector('.screenshot-thumbnail');
             if (!img || !img.src) return null;
+            var translatedAlt = window.t ? window.t('chat.pendingImageAlt', { index: index + 1 }) : '';
             return {
                 id: String(item.dataset.attachmentId || item.dataset.index || ('attachment-' + index)),
                 url: img.src,
-                alt: img.alt || (window.t ? window.t('chat.pendingImageAlt', { index: index + 1 }) : '图片 ' + (index + 1))
+                alt: img.alt || (typeof translatedAlt === 'string' && translatedAlt ? translatedAlt : '图片 ' + (index + 1))
             };
         }).filter(Boolean);
     };
@@ -995,7 +996,7 @@
                     updateReactOptimisticMessageStatus('failed');
                     window.showStatusToast(
                         window.t
-                            ? window.t('app.startFailed', { error: sendError.message })
+                            ? window.t('app.sendFailed', { error: sendError.message })
                             : '\u53D1\u9001\u5931\u8D25: ' + sendError.message,
                         5000
                     );

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -767,12 +767,44 @@
             options = options || {};
             var text = String(typeof rawText === 'string' ? rawText : '').trim();
             var hasScreenshots = screenshotsList.children.length > 0;
+            var isReactWindowSource = options.source === 'react-chat-window';
+            var reactOptimisticMessageId = '';
+            var reactOptimisticMessageAppended = false;
 
             if (!text && !hasScreenshots) return;
 
             // Record user input time and reset proactive chat
             window.lastUserInputTime = Date.now();
             window.resetProactiveChatBackoff();
+
+            if (isReactWindowSource && window.appChat && typeof window.appChat.appendReactUserMessage === 'function') {
+                reactOptimisticMessageId = 'user-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+                reactOptimisticMessageAppended = !!window.appChat.appendReactUserMessage({
+                    id: reactOptimisticMessageId,
+                    time: (typeof window.getCurrentTimeString === 'function')
+                        ? window.getCurrentTimeString()
+                        : new Date().toLocaleTimeString('en-US', {
+                            hour12: false,
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit'
+                        }),
+                    status: 'sending',
+                    text: text,
+                    imageUrls: mod.getPendingComposerAttachments().map(function (attachment) {
+                        return attachment && attachment.url ? String(attachment.url) : '';
+                    }).filter(Boolean)
+                });
+            }
+
+            function updateReactOptimisticMessageStatus(status) {
+                if (!reactOptimisticMessageAppended || !reactOptimisticMessageId) return;
+                if (window.reactChatWindowHost && typeof window.reactChatWindowHost.updateMessage === 'function') {
+                    window.reactChatWindowHost.updateMessage(reactOptimisticMessageId, {
+                        status: status
+                    });
+                }
+            }
 
             // If no active text session, start one first
             if (!S.isTextSessionActive) {
@@ -852,105 +884,124 @@
                     textInputBox.disabled = false;
                     screenshotButton.disabled = false;
 
+                    updateReactOptimisticMessageStatus('failed');
                     return; // Don't send if session start failed
                 }
             }
 
             // Send message
             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
-                var sentImageUrls = [];
+                try {
+                    var sentImageUrls = [];
 
-                // Send screenshots first
-                if (hasScreenshots) {
-                    var screenshotItems = Array.from(screenshotsList.children);
-                    for (var i = 0; i < screenshotItems.length; i++) {
-                        var img = screenshotItems[i].querySelector('.screenshot-thumbnail');
-                        if (img && img.src) {
-                            sentImageUrls.push(img.src);
-                            S.socket.send(JSON.stringify({
-                                action: 'stream_data',
-                                data: img.src,
-                                input_type: U.isMobile() ? 'camera' : 'screen'
-                            }));
+                    // Send screenshots first
+                    if (hasScreenshots) {
+                        var screenshotItems = Array.from(screenshotsList.children);
+                        for (var i = 0; i < screenshotItems.length; i++) {
+                            var img = screenshotItems[i].querySelector('.screenshot-thumbnail');
+                            if (img && img.src) {
+                                sentImageUrls.push(img.src);
+                                S.socket.send(JSON.stringify({
+                                    action: 'stream_data',
+                                    data: img.src,
+                                    input_type: U.isMobile() ? 'camera' : 'screen'
+                                }));
+                            }
+                        }
+
+                        if (!isReactWindowSource) {
+                            var screenshotItemCount = screenshotItems.length;
+                            window.appendMessage('\uD83D\uDCF8 [\u5DF2\u53D1\u9001' + screenshotItemCount + '\u5F20\u622A\u56FE]', 'user', true, {
+                                skipReactSync: true
+                            });
+                        }
+
+                        // Achievement: send image
+                        if (window.unlockAchievement) {
+                            window.unlockAchievement('ACH_SEND_IMAGE').catch(function (err) {
+                                console.error('\u89E3\u9501\u53D1\u9001\u56FE\u7247\u6210\u5C31\u5931\u8D25:', err);
+                            });
+                        }
+
+                        // Clear screenshot list
+                        screenshotsList.innerHTML = '';
+                        screenshotThumbnailContainer.classList.remove('show');
+                        mod.updateScreenshotCount();
+                        mod.syncPendingComposerAttachments();
+                    }
+
+                    // Then send text (if any)
+                    if (text) {
+                        if (!isReactWindowSource && window.appChat && typeof window.appChat.ensureUserDisplayName === 'function') {
+                            try {
+                                await window.appChat.ensureUserDisplayName();
+                            } catch (nameError) {
+                                console.warn('[Chat] preload user display name failed:', nameError);
+                            }
+                        }
+
+                        S.socket.send(JSON.stringify({
+                            action: 'stream_data',
+                            data: text,
+                            input_type: 'text'
+                        }));
+
+                        if (!options.preserveInputValue) {
+                            textInputBox.value = '';
+                        }
+                        if (!isReactWindowSource) {
+                            window.appendMessage(text, 'user', true, {
+                                skipReactSync: sentImageUrls.length > 0
+                            });
+                        }
+
+                        // Achievement: meow detection
+                        if (window.incrementAchievementCounter) {
+                            var meowPattern = /\u55B5|miao|meow|nya[no]?|\u306B\u3083|\uB0E5|\u043C\u044F\u0443/i;
+                            if (meowPattern.test(text)) {
+                                try {
+                                    window.incrementAchievementCounter('meowCount');
+                                } catch (error) {
+                                    console.debug('\u589E\u52A0\u55B5\u55B5\u8BA1\u6570\u5931\u8D25:', error);
+                                }
+                            }
+                        }
+
+                        // First user input check
+                        if (window.appChat && window.appChat.isFirstUserInput()) {
+                            window.appChat.markFirstUserInput();
+                            console.log(window.t('console.userFirstInputDetected'));
+                            window.checkAndUnlockFirstDialogueAchievement();
                         }
                     }
 
-                    var screenshotItemCount = screenshotItems.length;
-                    window.appendMessage('\uD83D\uDCF8 [\u5DF2\u53D1\u9001' + screenshotItemCount + '\u5F20\u622A\u56FE]', 'user', true, {
-                        skipReactSync: true
-                    });
-
-                    // Achievement: send image
-                    if (window.unlockAchievement) {
-                        window.unlockAchievement('ACH_SEND_IMAGE').catch(function (err) {
-                            console.error('\u89E3\u9501\u53D1\u9001\u56FE\u7247\u6210\u5C31\u5931\u8D25:', err);
+                    if (!isReactWindowSource && window.appChat && typeof window.appChat.appendReactUserMessage === 'function' && sentImageUrls.length > 0) {
+                        window.appChat.appendReactUserMessage({
+                            text: text,
+                            imageUrls: sentImageUrls
                         });
                     }
 
-                    // Clear screenshot list
-                    screenshotsList.innerHTML = '';
-                    screenshotThumbnailContainer.classList.remove('show');
-                    mod.updateScreenshotCount();
-                    mod.syncPendingComposerAttachments();
-                }
+                    updateReactOptimisticMessageStatus('sent');
 
-                // Then send text (if any)
-                if (text) {
-                    if (window.appChat && typeof window.appChat.ensureUserDisplayName === 'function') {
-                        try {
-                            await window.appChat.ensureUserDisplayName();
-                        } catch (nameError) {
-                            console.warn('[Chat] preload user display name failed:', nameError);
-                        }
+                    // Reset proactive chat timer
+                    if (S.proactiveChatEnabled && window.hasAnyChatModeEnabled()) {
+                        window.resetProactiveChatBackoff();
                     }
 
-                    S.socket.send(JSON.stringify({
-                        action: 'stream_data',
-                        data: text,
-                        input_type: 'text'
-                    }));
-
-                    if (!options.preserveInputValue) {
-                        textInputBox.value = '';
-                    }
-                    window.appendMessage(text, 'user', true, {
-                        skipReactSync: sentImageUrls.length > 0
-                    });
-
-                    // Achievement: meow detection
-                    if (window.incrementAchievementCounter) {
-                        var meowPattern = /\u55B5|miao|meow|nya[no]?|\u306B\u3083|\uB0E5|\u043C\u044F\u0443/i;
-                        if (meowPattern.test(text)) {
-                            try {
-                                window.incrementAchievementCounter('meowCount');
-                            } catch (error) {
-                                console.debug('\u589E\u52A0\u55B5\u55B5\u8BA1\u6570\u5931\u8D25:', error);
-                            }
-                        }
-                    }
-
-                    // First user input check
-                    if (window.appChat && window.appChat.isFirstUserInput()) {
-                        window.appChat.markFirstUserInput();
-                        console.log(window.t('console.userFirstInputDetected'));
-                        window.checkAndUnlockFirstDialogueAchievement();
-                    }
+                    window.showStatusToast(window.t ? window.t('app.textChattingShort') : '\u6B63\u5728\u6587\u672C\u804A\u5929\u4E2D', 2000);
+                } catch (sendError) {
+                    console.error('[Chat] send text payload failed:', sendError);
+                    updateReactOptimisticMessageStatus('failed');
+                    window.showStatusToast(
+                        window.t
+                            ? window.t('app.startFailed', { error: sendError.message })
+                            : '\u53D1\u9001\u5931\u8D25: ' + sendError.message,
+                        5000
+                    );
                 }
-
-                if (window.appChat && typeof window.appChat.appendReactUserMessage === 'function' && sentImageUrls.length > 0) {
-                    window.appChat.appendReactUserMessage({
-                        text: text,
-                        imageUrls: sentImageUrls
-                    });
-                }
-
-                // Reset proactive chat timer
-                if (S.proactiveChatEnabled && window.hasAnyChatModeEnabled()) {
-                    window.resetProactiveChatBackoff();
-                }
-
-                window.showStatusToast(window.t ? window.t('app.textChattingShort') : '\u6B63\u5728\u6587\u672C\u804A\u5929\u4E2D', 2000);
             } else {
+                updateReactOptimisticMessageStatus('failed');
                 window.showStatusToast(window.t ? window.t('app.websocketNotConnected') : 'WebSocket\u672A\u8FDE\u63A5\uFF01', 4000);
             }
         }

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -770,7 +770,7 @@
             var hasScreenshots = screenshotsList.children.length > 0;
             var isReactWindowSource = options.source === 'react-chat-window';
             var reactOptimisticMessageId = '';
-            var reactOptimisticMessageAppended = false;
+            var reactOptimisticMessageAppended = null;
 
             if (!text && !hasScreenshots) return;
 
@@ -780,7 +780,7 @@
 
             if (isReactWindowSource && window.appChat && typeof window.appChat.appendReactUserMessage === 'function') {
                 reactOptimisticMessageId = 'user-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
-                reactOptimisticMessageAppended = !!window.appChat.appendReactUserMessage({
+                reactOptimisticMessageAppended = window.appChat.appendReactUserMessage({
                     id: reactOptimisticMessageId,
                     time: (typeof window.getCurrentTimeString === 'function')
                         ? window.getCurrentTimeString()
@@ -799,7 +799,7 @@
             }
 
             function updateReactOptimisticMessageStatus(status) {
-                if (!reactOptimisticMessageAppended || !reactOptimisticMessageId) return;
+                if (reactOptimisticMessageAppended === null || !reactOptimisticMessageId) return;
                 if (window.reactChatWindowHost && typeof window.reactChatWindowHost.updateMessage === 'function') {
                     window.reactChatWindowHost.updateMessage(reactOptimisticMessageId, {
                         status: status

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -613,12 +613,12 @@
 
     function appendReactUserMessage(payload) {
         var host = getHost();
-        if (!host || typeof host.appendMessage !== 'function') return;
+        if (!host || typeof host.appendMessage !== 'function') return null;
 
         payload = payload || {};
         var text = String(payload.text || '').trim();
         var imageUrls = Array.isArray(payload.imageUrls) ? payload.imageUrls.filter(Boolean) : [];
-        if (!text && imageUrls.length === 0) return;
+        if (!text && imageUrls.length === 0) return null;
 
         var author = getCurrentUserName();
         var blocks = [];
@@ -635,15 +635,15 @@
             });
         });
 
-        host.appendMessage({
-            id: nextReactMessageId('user'),
+        return host.appendMessage({
+            id: payload.id ? String(payload.id) : nextReactMessageId('user'),
             role: 'user',
             author: author,
-            time: getCurrentTimeString(),
+            time: payload.time ? String(payload.time) : getCurrentTimeString(),
             createdAt: Date.now(),
             avatarLabel: String(author).trim().slice(0, 1).toUpperCase(),
             blocks: blocks,
-            status: 'sent'
+            status: payload.status ? String(payload.status) : 'sent'
         });
     }
 

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -628,10 +628,11 @@
         }
 
         imageUrls.forEach(function (url, index) {
+            var translatedAlt = window.t ? window.t('chat.pendingImageAlt', { index: index + 1 }) : '';
             blocks.push({
                 type: 'image',
                 url: String(url),
-                alt: (window.t ? window.t('chat.pendingImageAlt', { index: index + 1 }) : '\u56FE\u7247 ' + (index + 1))
+                alt: (typeof translatedAlt === 'string' && translatedAlt ? translatedAlt : '\u56FE\u7247 ' + (index + 1))
             });
         });
 

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -217,12 +217,12 @@
 
     function appendReactUserMessage(payload) {
         var host = getReactChatHost();
-        if (!host || typeof host.appendMessage !== 'function') return;
+        if (!host || typeof host.appendMessage !== 'function') return null;
 
         payload = payload || {};
         var text = String(payload.text || '').trim();
         var imageUrls = Array.isArray(payload.imageUrls) ? payload.imageUrls.filter(Boolean) : [];
-        if (!text && imageUrls.length === 0) return;
+        if (!text && imageUrls.length === 0) return null;
 
         var author = getCurrentUserName();
         var blocks = [];
@@ -242,15 +242,15 @@
             });
         });
 
-        host.appendMessage({
-            id: nextReactMessageId('user'),
+        return host.appendMessage({
+            id: payload.id ? String(payload.id) : nextReactMessageId('user'),
             role: 'user',
             author: author,
-            time: getCurrentTimeString(),
+            time: payload.time ? String(payload.time) : getCurrentTimeString(),
             createdAt: Date.now(),
             avatarLabel: String(author).trim().slice(0, 1).toUpperCase(),
             blocks: blocks,
-            status: 'sent'
+            status: payload.status ? String(payload.status) : 'sent'
         });
     }
 

--- a/static/app-chat.js
+++ b/static/app-chat.js
@@ -235,10 +235,11 @@
         }
 
         imageUrls.forEach(function (url, index) {
+            var translatedAlt = window.t ? window.t('chat.pendingImageAlt', { index: index + 1 }) : '';
             blocks.push({
                 type: 'image',
                 url: String(url),
-                alt: (window.t ? window.t('chat.pendingImageAlt', { index: index + 1 }) : '图片 ' + (index + 1))
+                alt: (typeof translatedAlt === 'string' && translatedAlt ? translatedAlt : '图片 ' + (index + 1))
             });
         });
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1244,10 +1244,18 @@
         setMinimized(!minimized);
     }
 
+    function prewarmUserDisplayName() {
+        if (!window.appChat || typeof window.appChat.ensureUserDisplayName !== 'function') return;
+        Promise.resolve(window.appChat.ensureUserDisplayName()).catch(function (error) {
+            console.warn('[ReactChatWindow] preload user display name failed:', error);
+        });
+    }
+
     function openWindow() {
         var overlay = getOverlay();
         if (!overlay) return;
 
+        prewarmUserDisplayName();
         ensureBundleLoaded()
             .then(function () {
                 if (!mountWindow()) {
@@ -1587,6 +1595,7 @@
         var avatarHeaderButton = $('avatarPreviewHeaderButton');
 
         ensureViewProps();
+        prewarmUserDisplayName();
 
         if (trigger) {
             trigger.addEventListener('click', openWindow);

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1561,6 +1561,7 @@
         "initializingVoice": "Initializing voice chat...",
         "initializingMic": "Initializing microphone...",
         "startFailed": "Start failed: {{error}}",
+        "sendFailed": "Send failed: {{error}}",
         "sessionEnded": "Session ended",
         "returning": "{{name}} is back! Reconnecting...",
         "websocketNotConnected": "WebSocket not connected!",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1561,6 +1561,7 @@
         "initializingVoice": "音声チャットを初期化中...",
         "initializingMic": "マイクを初期化中...",
         "startFailed": "起動失敗: {{error}}",
+        "sendFailed": "送信失敗: {{error}}",
         "sessionEnded": "セッション終了",
         "returning": "{{name}}が戻りました！再接続中...",
         "websocketNotConnected": "WebSocket未接続！",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1561,6 +1561,7 @@
         "initializingVoice": "음성 채팅 초기화 중...",
         "initializingMic": "마이크 초기화 중...",
         "startFailed": "시작 실패: {{error}}",
+        "sendFailed": "전송 실패: {{error}}",
         "sessionEnded": "세션이 종료되었습니다.",
         "returning": "{{name}}이 돌아왔습니다! 다시 연결하는 중...",
         "websocketNotConnected": "WebSocket이 연결되지 않았습니다!",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1561,6 +1561,7 @@
         "initializingVoice": "Инициализация голосового чата...",
         "initializingMic": "Инициализация микрофона...",
         "startFailed": "Ошибка запуска: {{error}}",
+        "sendFailed": "Ошибка отправки: {{error}}",
         "sessionEnded": "Сессия завершена",
         "returning": "{{name}} вернулась! Переподключение...",
         "websocketNotConnected": "WebSocket не подключён!",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1561,6 +1561,7 @@
         "initializingVoice": "正在初始化语音对话...",
         "initializingMic": "正在初始化麦克风...",
         "startFailed": "启动失败: {{error}}",
+        "sendFailed": "发送失败: {{error}}",
         "sessionEnded": "会话已结束",
         "returning": "{{name}}回来了！正在重新连接...",
         "websocketNotConnected": "WebSocket未连接！",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1561,6 +1561,7 @@
         "initializingVoice": "正在初始化語音對話...",
         "initializingMic": "正在初始化麥剋風...",
         "startFailed": "啓動失敗: {{error}}",
+        "sendFailed": "發送失敗: {{error}}",
         "sessionEnded": "會話已結束",
         "returning": "{{name}}迴來瞭！正在重新連接...",
         "websocketNotConnected": "WebSocket未連接！",

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -1,0 +1,268 @@
+import pytest
+from playwright.sync_api import Page
+
+
+def _open_react_chat_page(mock_page: Page, running_server: str) -> None:
+    mock_page.add_init_script(
+        "window.localStorage.setItem('neko_tutorial_settings', 'seen')"
+    )
+    mock_page.goto(f"{running_server}/chat", wait_until="domcontentloaded")
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost"
+        " && window.appButtons"
+        " && window.appChat"
+        " && window.appState"
+        " && typeof window.sendTextPayload === 'function'"
+    )
+    mock_page.evaluate("() => window.reactChatWindowHost.openWindow()")
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.isMounted && window.reactChatWindowHost.isMounted()"
+        " && !!document.querySelector('.composer-input')"
+    )
+
+
+def _install_chat_send_harness(
+    mock_page: Page,
+    *,
+    fail_session_start: bool = False,
+    resolve_delay_ms: int = 300,
+) -> None:
+    mock_page.evaluate(
+        """({ failSessionStart, resolveDelayMs }) => {
+            window.master_display_name = 'Alice';
+            window.master_name = 'Alice';
+            window.lanlan_config = window.lanlan_config || {};
+            window.lanlan_config.master_display_name = 'Alice';
+            window.lanlan_config.master_name = 'Alice';
+
+            window.showStatusToast = () => {};
+            window.hideVoicePreparingToast = () => {};
+            window.resetProactiveChatBackoff = () => {};
+            window.hasAnyChatModeEnabled = () => false;
+            window.showCurrentModel = async () => {};
+            window.checkAndUnlockFirstDialogueAchievement = () => {};
+            window.appChat.ensureUserDisplayName = async () => 'Alice';
+
+            window.__chatTest = {
+                failSessionStart,
+                resolveDelayMs,
+                sentPayloads: []
+            };
+
+            window.appState.isTextSessionActive = false;
+            window.appState.proactiveChatEnabled = false;
+            window.appState.sessionStartedResolver = null;
+            window.appState.sessionStartedRejecter = null;
+            window.sessionTimeoutId = null;
+
+            if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearMessages === 'function') {
+                window.reactChatWindowHost.clearMessages();
+            }
+            if (window.reactChatWindowHost && typeof window.reactChatWindowHost.setComposerAttachments === 'function') {
+                window.reactChatWindowHost.setComposerAttachments([]);
+            }
+
+            const socket = {
+                readyState: WebSocket.OPEN,
+                sent: [],
+                send(payload) {
+                    const parsed = JSON.parse(payload);
+                    this.sent.push(parsed);
+                    window.__chatTest.sentPayloads.push(parsed);
+                    if (parsed.action === 'start_session') {
+                        setTimeout(() => {
+                            if (window.__chatTest.failSessionStart) {
+                                if (window.appState.sessionStartedRejecter) {
+                                    const rejecter = window.appState.sessionStartedRejecter;
+                                    window.appState.sessionStartedResolver = null;
+                                    window.appState.sessionStartedRejecter = null;
+                                    rejecter(new Error('session init failed'));
+                                }
+                                return;
+                            }
+                            if (window.appState.sessionStartedResolver) {
+                                const resolver = window.appState.sessionStartedResolver;
+                                window.appState.sessionStartedResolver = null;
+                                window.appState.sessionStartedRejecter = null;
+                                resolver();
+                            }
+                        }, window.__chatTest.resolveDelayMs);
+                    }
+                },
+                close() {
+                    this.readyState = WebSocket.CLOSED;
+                }
+            };
+
+            window.appState.socket = socket;
+            window.ensureWebSocketOpen = async () => {
+                window.appState.socket = socket;
+            };
+        }""",
+        {
+            "failSessionStart": fail_session_start,
+            "resolveDelayMs": resolve_delay_ms,
+        },
+    )
+
+
+@pytest.mark.frontend
+def test_react_composer_text_submit_uses_single_stable_user_message(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    composer = mock_page.locator(".composer-input")
+    composer.fill("Hello from React")
+    composer.press("Enter")
+
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.getState().messages.length === 1"
+    )
+
+    snapshot = mock_page.evaluate(
+        """() => {
+            const state = window.reactChatWindowHost.getState();
+            const message = state.messages[0];
+            return {
+                count: state.messages.length,
+                author: message && message.author,
+                status: message && message.status,
+                text: message && message.blocks && message.blocks[0] && message.blocks[0].text,
+                hasYouAuthor: state.messages.some((entry) => entry.author === 'You'),
+                userDomRows: document.querySelectorAll('article[data-message-role="user"]').length
+            };
+        }"""
+    )
+
+    assert snapshot["count"] == 1
+    assert snapshot["author"] == "Alice"
+    assert snapshot["status"] == "sending"
+    assert snapshot["text"] == "Hello from React"
+    assert snapshot["hasYouAuthor"] is False
+    assert snapshot["userDomRows"] == 1
+
+    mock_page.wait_for_function(
+        "() => {"
+        "  const state = window.reactChatWindowHost.getState();"
+        "  return state.messages.length === 1 && state.messages[0] && state.messages[0].status === 'sent';"
+        "}"
+    )
+
+    after_send = mock_page.evaluate(
+        """() => {
+            const state = window.reactChatWindowHost.getState();
+            return {
+                count: state.messages.length,
+                author: state.messages[0] && state.messages[0].author,
+                status: state.messages[0] && state.messages[0].status,
+                sentPayloadCount: window.__chatTest.sentPayloads.length
+            };
+        }"""
+    )
+
+    assert after_send["count"] == 1
+    assert after_send["author"] == "Alice"
+    assert after_send["status"] == "sent"
+    assert after_send["sentPayloadCount"] == 2
+
+
+@pytest.mark.frontend
+def test_react_composer_text_and_screenshot_submit_keeps_single_combined_message(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    mock_page.evaluate(
+        """() => {
+            window.appButtons.addScreenshotToList(
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII='
+            );
+        }"""
+    )
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.getState().composerAttachments.length === 1"
+    )
+
+    composer = mock_page.locator(".composer-input")
+    composer.fill("Look at this")
+    composer.press("Enter")
+
+    mock_page.wait_for_function(
+        "() => {"
+        "  const state = window.reactChatWindowHost.getState();"
+        "  return state.messages.length === 1 && state.messages[0] && state.messages[0].status === 'sent';"
+        "}"
+    )
+
+    snapshot = mock_page.evaluate(
+        """() => {
+            const state = window.reactChatWindowHost.getState();
+            const message = state.messages[0];
+            return {
+                count: state.messages.length,
+                status: message && message.status,
+                blockTypes: message && Array.isArray(message.blocks)
+                    ? message.blocks.map((block) => block.type)
+                    : [],
+                author: message && message.author,
+                textBlocks: message && Array.isArray(message.blocks)
+                    ? message.blocks.filter((block) => block.type === 'text').map((block) => block.text)
+                    : [],
+                composerAttachmentCount: state.composerAttachments.length,
+                userDomRows: document.querySelectorAll('article[data-message-role="user"]').length
+            };
+        }"""
+    )
+
+    assert snapshot["count"] == 1
+    assert snapshot["status"] == "sent"
+    assert snapshot["author"] == "Alice"
+    assert snapshot["blockTypes"] == ["text", "image"]
+    assert snapshot["textBlocks"] == ["Look at this"]
+    assert snapshot["composerAttachmentCount"] == 0
+    assert snapshot["userDomRows"] == 1
+
+
+@pytest.mark.frontend
+def test_react_composer_send_failure_marks_same_message_failed(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page, fail_session_start=True, resolve_delay_ms=0)
+
+    composer = mock_page.locator(".composer-input")
+    composer.fill("This should fail")
+    composer.press("Enter")
+
+    mock_page.wait_for_function(
+        "() => {"
+        "  const state = window.reactChatWindowHost.getState();"
+        "  return state.messages.length === 1 && state.messages[0] && state.messages[0].status === 'failed';"
+        "}"
+    )
+
+    snapshot = mock_page.evaluate(
+        """() => {
+            const state = window.reactChatWindowHost.getState();
+            const message = state.messages[0];
+            return {
+                count: state.messages.length,
+                author: message && message.author,
+                status: message && message.status,
+                text: message && message.blocks && message.blocks[0] && message.blocks[0].text,
+                userDomRows: document.querySelectorAll('article[data-message-role="user"]').length
+            };
+        }"""
+    )
+
+    assert snapshot["count"] == 1
+    assert snapshot["author"] == "Alice"
+    assert snapshot["status"] == "failed"
+    assert snapshot["text"] == "This should fail"
+    assert snapshot["userDomRows"] == 1

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -46,7 +46,8 @@ def _install_chat_send_harness(
             window.__chatTest = {
                 failSessionStart,
                 resolveDelayMs,
-                sentPayloads: []
+                sentPayloads: [],
+                fireSessionStart: null
             };
 
             window.appState.isTextSessionActive = false;
@@ -70,6 +71,17 @@ def _install_chat_send_harness(
                     this.sent.push(parsed);
                     window.__chatTest.sentPayloads.push(parsed);
                     if (parsed.action === 'start_session') {
+                        if (window.__chatTest.resolveDelayMs < 0) {
+                            window.__chatTest.fireSessionStart = () => {
+                                if (window.appState.sessionStartedResolver) {
+                                    const resolver = window.appState.sessionStartedResolver;
+                                    window.appState.sessionStartedResolver = null;
+                                    window.appState.sessionStartedRejecter = null;
+                                    resolver();
+                                }
+                            };
+                            return;
+                        }
                         setTimeout(() => {
                             if (window.__chatTest.failSessionStart) {
                                 if (window.appState.sessionStartedRejecter) {
@@ -112,7 +124,7 @@ def test_react_composer_text_submit_uses_single_stable_user_message(
     running_server: str,
 ):
     _open_react_chat_page(mock_page, running_server)
-    _install_chat_send_harness(mock_page)
+    _install_chat_send_harness(mock_page, resolve_delay_ms=-1)
 
     composer = mock_page.locator(".composer-input")
     composer.fill("Hello from React")
@@ -145,6 +157,11 @@ def test_react_composer_text_submit_uses_single_stable_user_message(
     assert snapshot["userDomRows"] == 1
 
     mock_page.wait_for_function(
+        "() => window.__chatTest && typeof window.__chatTest.fireSessionStart === 'function'"
+    )
+    mock_page.evaluate("() => window.__chatTest.fireSessionStart()")
+
+    mock_page.wait_for_function(
         "() => {"
         "  const state = window.reactChatWindowHost.getState();"
         "  return state.messages.length === 1 && state.messages[0] && state.messages[0].status === 'sent';"
@@ -158,7 +175,7 @@ def test_react_composer_text_submit_uses_single_stable_user_message(
                 count: state.messages.length,
                 author: state.messages[0] && state.messages[0].author,
                 status: state.messages[0] && state.messages[0].status,
-                sentPayloadCount: window.__chatTest.sentPayloads.length
+                sentPayloads: window.__chatTest.sentPayloads
             };
         }"""
     )
@@ -166,7 +183,13 @@ def test_react_composer_text_submit_uses_single_stable_user_message(
     assert after_send["count"] == 1
     assert after_send["author"] == "Alice"
     assert after_send["status"] == "sent"
-    assert after_send["sentPayloadCount"] == 2
+    assert "start_session" in [payload["action"] for payload in after_send["sentPayloads"]]
+    assert any(
+        payload["action"] == "stream_data"
+        and payload.get("input_type") == "text"
+        and payload.get("data") == "Hello from React"
+        for payload in after_send["sentPayloads"]
+    )
 
 
 @pytest.mark.frontend


### PR DESCRIPTION
## 背景

当前 React 聊天窗口里，同一条用户消息会被渲染两次：

- React composer 会先本地插入一条 optimistic 用户消息
- 宿主发送链路随后又会再追加一条真实用户消息

这会导致：
- 用户气泡渐入两次
- 第一条消息作者名先显示 `You`
- 后续再被真实名字替换，产生闪动

## 变更内容

- 移除 React 侧本地 `pendingDrafts` optimistic 消息逻辑
- `submitDraft()` 仅负责提交文本并清空输入框，不再本地插入用户消息
- 将 React chat window 的用户消息创建统一收敛到宿主 `sendTextPayload()`
- 对 `react-chat-window` 来源：
  - 发送前立即创建一条稳定的 optimistic 用户消息
  - 复用同一 `messageId` 更新 `sending -> sent/failed`
  - 不再追加第二条文本消息
  - 不再追加截图摘要气泡
  - 文本和截图合并到同一条用户消息中
- 扩展内部 `appendReactUserMessage` helper，支持可选 `id/time/status/imageUrls`
- 在 React 聊天窗初始化和打开时预热用户显示名，避免 `You -> 实际名字` 后改
- 新增 React 单测和 `/chat` 页面级前端回归测试

## 预期效果

- 用户发送文本时只出现 1 条右侧用户气泡
- 用户名从首次渲染开始就是稳定值，不再先显示 `You`
- 文本 + 截图时只显示 1 条合并消息
- 发送失败时原消息原地变为 `failed`，不会再新插入一个气泡

## 验证

- `frontend/react-neko-chat: npm test`
- `frontend/react-neko-chat: npm run build`
- `node --check static/app-buttons.js`
- `node --check static/app-chat.js`
- `node --check static/app-chat-adapter.js`
- `node --check static/app-react-chat-window.js`
- `uv run pytest tests/frontend/test_chat_user_message_dedup.py`

## 备注

- 未改动 HTTP / WebSocket 协议
- React 对外 props schema 保持不变
- 本次只修复用户消息重复渲染和作者名闪动，不额外引入新的失败交互


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在前端发送路径中为非 React 窗口增加可见的本地发送状态（正在发送/已发送/失败）。
  * 增加预热用户显示名的调用以改善首次打开体验。

* **错误修复**
  * 统一并修正消息去重与发送状态切换，避免重复或丢失的用户消息。
  * 在 React 窗口里停止生成本地乐观草稿以减少冲突，发送失败时明确标记并显示错误提示。

* **测试**
  * 添加多项端到端与单元测试，覆盖去重、截图+文本合并发送及失败场景。

* **本地化**
  * 新增“发送失败: …”多语言提示字符串。

* **杂项**
  * 测试环境兼容性补丁与小幅性能/稳定性优化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->