### PR TITLE
fix(config): 消除 load_characters 并发重复触发迁移和校验警告

### DIFF
--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -495,6 +495,7 @@ class ConfigManager:
         self._characters_cache_path: str | None = None
         self._characters_dirty: bool = False
         self._characters_cache_lock = threading.Lock()
+        self._characters_reload_lock = threading.Lock()
 
         self.project_config_dir = self._get_project_config_directory()
         self.project_memory_dir = self._get_project_memory_directory()
@@ -1027,50 +1028,68 @@ class ConfigManager:
             if current_mtime is not None and current_mtime == cache_mtime:
                 return deepcopy(cache)
 
-        try:
-            with open(character_json_path, 'r', encoding='utf-8') as f:
-                character_data = json.load(f)
-            try:
-                loaded_mtime = os.path.getmtime(character_json_path)
-            except OSError:
-                loaded_mtime = None
-        except FileNotFoundError:
-            logger.info("未找到猫娘配置文件 %s，使用默认配置。", character_json_path)
-            character_data = self.get_default_characters()
-            loaded_mtime = None
-        except Exception as e:
-            logger.error("读取猫娘配置文件出错: %s，使用默认人设。", e)
-            character_data = self.get_default_characters()
-            loaded_mtime = None
-
-        migrated = False
-        if not isinstance(character_data, dict):
-            logger.warning("角色配置文件结构异常（非 dict），使用默认配置。")
-            character_data = self.get_default_characters()
-        catgirl_map = character_data.get("猫娘")
-        if isinstance(catgirl_map, dict):
-            for name, catgirl_data in catgirl_map.items():
-                if not isinstance(catgirl_data, dict):
-                    logger.warning("角色 '%s' 配置非 dict，跳过迁移。", name)
-                    continue
-                if migrate_catgirl_reserved(catgirl_data):
-                    migrated = True
-                reserved_errors = validate_reserved_schema(catgirl_data.get("_reserved"))
-                if reserved_errors:
-                    logger.warning("检测到角色 _reserved 字段结构异常: %s", "; ".join(reserved_errors))
-        if migrated:
-            try:
-                self.save_characters(character_data, character_json_path=character_json_path)
-                logger.info("检测到旧版角色保留字段，已自动迁移到 _reserved 结构。")
-            except Exception as migrate_err:
-                logger.warning("自动迁移角色保留字段后写回失败: %s", migrate_err)
-        else:
+        # 慢路径：独占锁，防止多个线程同时读文件、重复触发迁移和校验警告。
+        with self._characters_reload_lock:
+            # 双检：进锁后重新核对 mtime，另一个线程可能已经完成了加载。
             with self._characters_cache_lock:
-                self._characters_cache = deepcopy(character_data)
-                self._characters_cache_mtime = loaded_mtime
-                self._characters_cache_path = character_json_path
-                self._characters_dirty = False
-        return character_data
+                cache = self._characters_cache
+                cache_path = self._characters_cache_path
+                cache_mtime = self._characters_cache_mtime
+            if cache is not None and cache_path == character_json_path:
+                try:
+                    current_mtime = os.path.getmtime(character_json_path)
+                except OSError:
+                    current_mtime = None
+                if current_mtime is not None and current_mtime == cache_mtime:
+                    return deepcopy(cache)
+
+            try:
+                with open(character_json_path, 'r', encoding='utf-8') as f:
+                    character_data = json.load(f)
+                try:
+                    loaded_mtime = os.path.getmtime(character_json_path)
+                except OSError:
+                    loaded_mtime = None
+            except FileNotFoundError:
+                logger.info("未找到猫娘配置文件 %s，使用默认配置。", character_json_path)
+                character_data = self.get_default_characters()
+                loaded_mtime = None
+            except Exception as e:
+                logger.error("读取猫娘配置文件出错: %s，使用默认人设。", e)
+                character_data = self.get_default_characters()
+                loaded_mtime = None
+
+            migrated = False
+            if not isinstance(character_data, dict):
+                logger.warning("角色配置文件结构异常（非 dict），使用默认配置。")
+                character_data = self.get_default_characters()
+            catgirl_map = character_data.get("猫娘")
+            if isinstance(catgirl_map, dict):
+                all_schema_errors: list[str] = []
+                for name, catgirl_data in catgirl_map.items():
+                    if not isinstance(catgirl_data, dict):
+                        logger.warning("角色 '%s' 配置非 dict，跳过迁移。", name)
+                        continue
+                    if migrate_catgirl_reserved(catgirl_data):
+                        migrated = True
+                    reserved_errors = validate_reserved_schema(catgirl_data.get("_reserved"))
+                    for err in reserved_errors:
+                        all_schema_errors.append(f"{name}: {err}")
+                if all_schema_errors:
+                    logger.warning("检测到角色 _reserved 字段结构异常: %s", "; ".join(all_schema_errors))
+            if migrated:
+                try:
+                    self.save_characters(character_data, character_json_path=character_json_path)
+                    logger.info("检测到旧版角色保留字段，已自动迁移到 _reserved 结构。")
+                except Exception as migrate_err:
+                    logger.warning("自动迁移角色保留字段后写回失败: %s", migrate_err)
+            else:
+                with self._characters_cache_lock:
+                    self._characters_cache = deepcopy(character_data)
+                    self._characters_cache_mtime = loaded_mtime
+                    self._characters_cache_path = character_json_path
+                    self._characters_dirty = False
+            return character_data
 
     def save_characters(self, data, character_json_path=None):
         """保存角色配置（同步版本，会阻塞事件循环；async 路径请用 asave_characters）"""


### PR DESCRIPTION
## 问题

`load_characters` 在多线程环境下存在竞争窗口：多个并发请求同时发现 `characters.json` 的 mtime 过期时，会各自独立读取文件、运行迁移（`migrate_catgirl_reserved`）和 schema 校验（`validate_reserved_schema`），产生 **N\_并发 × K\_角色** 条重复 WARNING，导致日志刷屏。

## 修复

1. **双检锁**（`_characters_reload_lock`）：进入慢路径（mtime 不匹配）时先拿独占锁，锁内再次核对 mtime；第一个线程完成加载并更新缓存后，后续线程直接命中缓存返回，不再重复执行读文件 / 迁移 / 校验。

2. **合并校验警告**：把所有角色的 `_reserved` schema 错误聚合成一条 WARNING（`角色A: …; 角色B: …`），从原来的每角色一条降到每次加载最多一条。

## 背景

`_reserved.avatar.mmd.idle_animation` 的 schema 在 PR #649 里已从 `str` 修为 `(str, list, type(None))`，理论上不再触发校验警告；但并发竞争导致的多次重复执行在任何 schema 不匹配场景下都会放大日志量，本 PR 从根本上堵住这个问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了角色数据加载的并发处理机制，增强了系统稳定性。
  * 优化了错误处理流程，确保错误信息更加清晰和一致。

* **Refactor**
  * 重构了角色加载逻辑，消除了冗余的数据处理操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->