### PR TITLE
fix(hotswap): 修复热切换并发 recv() 导致语音会话崩溃

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2833,6 +2833,7 @@ class LLMSessionManager:
                 return
 
         try:
+            new_session = None  # 提前初始化，确保 except 块安全访问（实际赋值在 PERFORM ACTUAL HOT SWAP 段）
             incremental_cache = self.message_cache_for_new_session[self.initial_cache_snapshot_len:]
             # 1. Send incremental cache (or a heartbeat) to PENDING session for its *second* ignored response
             if incremental_cache:
@@ -2905,7 +2906,14 @@ class LLMSessionManager:
                     await asyncio.wait_for(old_main_message_handler_task, timeout=2.0)
                     logger.info("Final Swap Sequence: Old message handler task stopped")
                 except asyncio.TimeoutError:
-                    logger.warning("Final Swap Sequence: Old message handler task cancellation timeout")
+                    # 旧 task 仍占着 recv()，继续往下 close() 会重演并发 recv 冲突。
+                    # 关闭 new_session 防止 ws 泄漏，然后中止 swap。
+                    logger.error("Final Swap Sequence: 旧 listener 取消超时，中止热切换")
+                    try:
+                        await new_session.close()
+                    except Exception:
+                        pass
+                    raise RuntimeError("旧 listener 取消超时，热切换中止")
                 except asyncio.CancelledError:
                     pass
                 except Exception as e:
@@ -2951,22 +2959,34 @@ class LLMSessionManager:
 
         except asyncio.CancelledError:
             logger.info("Final Swap Sequence: Task cancelled.")
-            # If cancelled mid-swap, state could be inconsistent. Prioritize cleaning pending.
-            self.is_hot_swap_imminent = False  # Reset flag immediately
+            self.is_hot_swap_imminent = False
+            # new_session 在 self.pending_session = None 后由局部变量持有。
+            # 若 swap 在 promote 之前被取消，_cleanup_pending_session_resources 不再持有它，
+            # 必须在此手动关闭，防止 ws 泄漏。
+            if new_session is not None and new_session is not self.session:
+                try:
+                    await new_session.close()
+                except Exception:
+                    pass
             await self._cleanup_pending_session_resources()
-            await self._reset_preparation_state(clear_main_cache=True)  # Clear all state for clean restart after cancellation
-            # The old main session listener might have been cancelled, needs robust restart if still active
+            await self._reset_preparation_state(clear_main_cache=True)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
         except Exception as e:
             logger.error(f"💥 Final Swap Sequence: Error: {e}")
-            self.is_hot_swap_imminent = False  # Reset flag immediately
+            self.is_hot_swap_imminent = False
             await self.send_status(json.dumps({"code": "INTERNAL_UPDATE_FAILED", "details": {"error": str(e)}}))
+            # 同上：new_session 若未完成 promote，需手动关闭防 ws 泄漏。
+            if new_session is not None and new_session is not self.session:
+                try:
+                    await new_session.close()
+                except Exception:
+                    pass
             await self._cleanup_pending_session_resources()
-            await self._reset_preparation_state(clear_main_cache=True)  # Clear all state for clean restart after error
-            # 若 self.session 的 ws 已失效（swap 因 ws invalid 失败），清除会话状态；
-            # 否则 is_active=True + ws=None 会让后续输入进入坏会话。
+            await self._reset_preparation_state(clear_main_cache=True)
+            # 若 self.session 的 ws 已失效（promote 后 ws invalid），清除会话状态，
+            # 防止 is_active=True + ws=None 让后续输入进入坏会话。
             if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
                 self.session = None
                 self.is_active = False

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2927,11 +2927,9 @@ class LLMSessionManager:
                     logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
 
             # 验证新session的WebSocket是否仍然有效（可能在swap过程中被服务器断开）
-            if isinstance(self.session, OmniRealtimeClient):
-                if not self.session.ws:
-                    logger.error("💥 Final Swap Sequence: 新session的WebSocket在swap后已失效，热切换失败")
-                    # 不强制回滚，让系统通过现有错误处理机制自动重建session
-                    # 注意：此时旧session已关闭，无法回滚
+            if isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
+                # 旧session已关闭无法回滚，抛出异常让 except 块走 end_session 重建流程
+                raise RuntimeError("新session的WebSocket在swap后已失效，热切换失败")
 
             # 旧资源完全清理后，再启动新session的消息监听
             if self.session and hasattr(self.session, 'handle_messages'):
@@ -2961,6 +2959,11 @@ class LLMSessionManager:
             await self.send_status(json.dumps({"code": "INTERNAL_UPDATE_FAILED", "details": {"error": str(e)}}))
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)  # Clear all state for clean restart after error
+            # 若 self.session 的 ws 已失效（swap 因 ws invalid 失败），清除会话状态；
+            # 否则 is_active=True + ws=None 会让后续输入进入坏会话。
+            if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
+                self.session = None
+                self.is_active = False
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
         finally:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2903,10 +2903,29 @@ class LLMSessionManager:
             # 导致新session的websocket被关闭，引发 'NoneType' object has no attribute 'send' 错误
             self.pending_session = None
 
-            # Start the main listener for the NEWLY PROMOTED self.session
-            if self.session and hasattr(self.session, 'handle_messages'):
-                self.message_handler_task = asyncio.create_task(self.session.handle_messages())
-            
+            # 先取消旧session的消息处理任务，确保旧 WebSocket 上没有 recv() 在运行。
+            # 必须在 old_main_session.close() 之前完成：ws.close() 内部会执行关闭握手（等待服务端 CLOSE 帧），
+            # 这本质上也是一次 recv()。若旧 task 仍在 async for 的 recv() 中，就会产生
+            # "cannot call recv while another coroutine is already running recv" 并发冲突。
+            if old_main_message_handler_task and not old_main_message_handler_task.done():
+                old_main_message_handler_task.cancel()
+                try:
+                    await asyncio.wait_for(old_main_message_handler_task, timeout=2.0)
+                    logger.info("Final Swap Sequence: Old message handler task stopped")
+                except asyncio.TimeoutError:
+                    logger.warning("Final Swap Sequence: Old message handler task cancellation timeout")
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"Final Swap Sequence: Old task exited with error: {e}")
+
+            # 旧 task 已停止，现在安全关闭旧 session（ws.close() 握手时无并发 recv() 竞争）
+            if old_main_session:
+                try:
+                    await old_main_session.close()
+                except Exception as e:
+                    logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
+
             # 验证新session的WebSocket是否仍然有效（可能在swap过程中被服务器断开）
             if isinstance(self.session, OmniRealtimeClient):
                 if not self.session.ws:
@@ -2914,27 +2933,9 @@ class LLMSessionManager:
                     # 不强制回滚，让系统通过现有错误处理机制自动重建session
                     # 注意：此时旧session已关闭，无法回滚
 
-            # 关闭旧session - 必须先关闭WebSocket再取消task
-            # 因为handle_messages使用 async for message in self.ws，只有关闭ws才能让循环退出
-            if old_main_session:
-                try:
-                    # 先关闭WebSocket，让async for循环自然退出
-                    await old_main_session.close()
-                except Exception as e:
-                    logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
-            
-            # 然后取消和等待旧session的消息处理任务完成
-            if old_main_message_handler_task and not old_main_message_handler_task.done():
-                old_main_message_handler_task.cancel()
-                try:
-                    await asyncio.wait_for(old_main_message_handler_task, timeout=2.0)
-                    logger.info("Final Swap Sequence: Old message handler task stopped")
-                except asyncio.TimeoutError:
-                    logger.warning("Final Swap Sequence: Old message handler task cancellation timeout (should not happen now)")
-                except asyncio.CancelledError:
-                    pass
-                except Exception as e:
-                    logger.error(f"💥 Final Swap Sequence: Error during old message handler cleanup: {e}")
+            # 旧资源完全清理后，再启动新session的消息监听
+            if self.session and hasattr(self.session, 'handle_messages'):
+                self.message_handler_task = asyncio.create_task(self.session.handle_messages())
 
         
             # Reset all preparation states and clear the *main* cache now that it's fully transferred
@@ -3381,7 +3382,8 @@ class LLMSessionManager:
             except asyncio.TimeoutError:
                 logger.warning("End Session: Warning: Listener task cancellation timeout.")
             except Exception as e:
-                logger.error(f"💥 End Session: Error during listener task cancellation: {e}")
+                # 任务可能已因并发 recv() 冲突等原因提前退出，此处只是发现既成事实
+                logger.warning(f"End Session: Listener task had prior error: {e}")
             if self.message_handler_task is message_handler_task_ref:
                 self.message_handler_task = None
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2911,8 +2911,8 @@ class LLMSessionManager:
                     logger.error("Final Swap Sequence: 旧 listener 取消超时，中止热切换")
                     try:
                         await new_session.close()
-                    except Exception:
-                        pass
+                    except Exception as _e:
+                        logger.debug(f"Final Swap Sequence: 超时中止时关闭 new_session 失败（可忽略）: {_e}")
                     raise RuntimeError("旧 listener 取消超时，热切换中止")
                 except asyncio.CancelledError:
                     pass
@@ -2966,8 +2966,8 @@ class LLMSessionManager:
             if new_session is not None and new_session is not self.session:
                 try:
                     await new_session.close()
-                except Exception:
-                    pass
+                except Exception as _e:
+                    logger.debug(f"Final Swap Sequence: CancelledError 路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
             if self.is_active and self.session and hasattr(self.session, 'handle_messages') and (not self.message_handler_task or self.message_handler_task.done()):
@@ -2981,8 +2981,8 @@ class LLMSessionManager:
             if new_session is not None and new_session is not self.session:
                 try:
                     await new_session.close()
-                except Exception:
-                    pass
+                except Exception as _e:
+                    logger.debug(f"Final Swap Sequence: 异常路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
             # 若 self.session 的 ws 已失效（promote 后 ws invalid），清除会话状态，

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2834,6 +2834,7 @@ class LLMSessionManager:
 
         try:
             new_session = None  # 提前初始化，确保 except 块安全访问（实际赋值在 PERFORM ACTUAL HOT SWAP 段）
+            old_listener_cancel_timed_out = False  # 旧 listener 取消超时标志，供 except 块做 fail-close 决策
             incremental_cache = self.message_cache_for_new_session[self.initial_cache_snapshot_len:]
             # 1. Send incremental cache (or a heartbeat) to PENDING session for its *second* ignored response
             if incremental_cache:
@@ -2907,7 +2908,8 @@ class LLMSessionManager:
                     logger.info("Final Swap Sequence: Old message handler task stopped")
                 except asyncio.TimeoutError:
                     # 旧 task 仍占着 recv()，继续往下 close() 会重演并发 recv 冲突。
-                    # 关闭 new_session 防止 ws 泄漏，然后中止 swap。
+                    # 关闭 new_session 防止 ws 泄漏，标记超时后中止 swap。
+                    old_listener_cancel_timed_out = True
                     logger.error("Final Swap Sequence: 旧 listener 取消超时，中止热切换")
                     try:
                         await new_session.close()
@@ -2985,6 +2987,14 @@ class LLMSessionManager:
                     logger.debug(f"Final Swap Sequence: 异常路径关闭 new_session 失败（可忽略）: {_e}")
             await self._cleanup_pending_session_resources()
             await self._reset_preparation_state(clear_main_cache=True)
+            if old_listener_cancel_timed_out:
+                # 旧 listener 取消超时：旧 task 可能在本函数返回后才真正退出，
+                # 此时无法安全判断 task.done() 并补建 listener，会留下"活跃但无监听"状态。
+                # 直接 fail-close：清除会话状态让前端重连，优于让后续输入陷入僵局。
+                self.session = None
+                self.message_handler_task = None
+                self.is_active = False
+                return
             # 若 self.session 的 ws 已失效（promote 后 ws invalid），清除会话状态，
             # 防止 is_active=True + ws=None 让后续输入进入坏会话。
             if self.session and isinstance(self.session, OmniRealtimeClient) and not self.session.ws:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2887,25 +2887,17 @@ class LLMSessionManager:
             logger.info("Final Swap Sequence: Starting actual session swap...")
             old_main_session = self.session
             old_main_message_handler_task = self.message_handler_task
-            
-            # 执行session切换
-            # 热切换完成后，立即将缓存的音频数据发送到新session
-            await self._flush_hot_swap_audio_cache()
-            self.session = self.pending_session
-            self.current_speech_id = str(uuid4())
-            self._tts_done_queued_for_turn = False
-            self.session_start_time = datetime.now()
-            self._session_turn_count = 0
-            
-            # !!CRITICAL!! 立即清除pending_session引用，防止异常处理器误关闭新session
-            # 此时self.session和self.pending_session指向同一对象（新session）
-            # 如果在此之后发生异常，_cleanup_pending_session_resources()会关闭pending_session
-            # 导致新session的websocket被关闭，引发 'NoneType' object has no attribute 'send' 错误
+            # 立即用局部变量持有新 session，并清空 self.pending_session。
+            # 必须在任何 await 之前完成：后续 cancel/close 的 await 若触发
+            # CancelledError，异常处理器会调 _cleanup_pending_session_resources()，
+            # 它检查 self.pending_session；若不提前清零，会把新 session 的 ws 关掉。
+            new_session = self.pending_session
             self.pending_session = None
 
-            # 先取消旧session的消息处理任务，确保旧 WebSocket 上没有 recv() 在运行。
-            # 必须在 old_main_session.close() 之前完成：ws.close() 内部会执行关闭握手（等待服务端 CLOSE 帧），
-            # 这本质上也是一次 recv()。若旧 task 仍在 async for 的 recv() 中，就会产生
+            # ── 步骤 1：先停旧 listener ────────────────────────────────────────────
+            # 必须在 old_main_session.close() 之前完成：ws.close() 内部执行关闭握手
+            # （等待服务端 CLOSE 帧），本质上是一次 recv()。若旧 task 仍在
+            # async for 的 recv() 中，就会产生
             # "cannot call recv while another coroutine is already running recv" 并发冲突。
             if old_main_message_handler_task and not old_main_message_handler_task.done():
                 old_main_message_handler_task.cancel()
@@ -2919,21 +2911,35 @@ class LLMSessionManager:
                 except Exception as e:
                     logger.warning(f"Final Swap Sequence: Old task exited with error: {e}")
 
-            # 旧 task 已停止，现在安全关闭旧 session（ws.close() 握手时无并发 recv() 竞争）
+            # ── 步骤 2：旧 task 已停，安全关闭旧 session ─────────────────────────
             if old_main_session:
                 try:
                     await old_main_session.close()
                 except Exception as e:
                     logger.error(f"💥 Final Swap Sequence: Error closing old session: {e}")
 
+            # ── 步骤 3：promote 新 session ────────────────────────────────────────
+            # 旧 listener 已停、旧 session 已关，现在切换 self.session；
+            # 此后旧 task 的任何回调若再执行也已看不到旧 ws。
+            self.session = new_session
+            self.current_speech_id = str(uuid4())
+            self._tts_done_queued_for_turn = False
+            self.session_start_time = datetime.now()
+            self._session_turn_count = 0
+
             # 验证新session的WebSocket是否仍然有效（可能在swap过程中被服务器断开）
             if isinstance(self.session, OmniRealtimeClient) and not self.session.ws:
-                # 旧session已关闭无法回滚，抛出异常让 except 块走 end_session 重建流程
+                # 旧session已关闭无法回滚，抛出异常让 except 块走重建流程
                 raise RuntimeError("新session的WebSocket在swap后已失效，热切换失败")
 
-            # 旧资源完全清理后，再启动新session的消息监听
+            # ── 步骤 4：启动新 listener ───────────────────────────────────────────
             if self.session and hasattr(self.session, 'handle_messages'):
                 self.message_handler_task = asyncio.create_task(self.session.handle_messages())
+
+            # ── 步骤 5：flush 热切换音频缓存到新 session ─────────────────────────
+            # 必须在 promote 之后调用：_flush_hot_swap_audio_cache 使用 self.session
+            # 发送音频，此时 self.session 已是新 session，音频会正确发往新会话。
+            await self._flush_hot_swap_audio_cache()
 
         
             # Reset all preparation states and clear the *main* cache now that it's fully transferred


### PR DESCRIPTION
## 问题

语音对话启动时，热切换（Final Swap Sequence）触发后台报错刷屏，前端停在「正在连接服务器」后失败：

```
cannot call recv while another coroutine is already running recv or recv streaming
End Session: Error during listener task cancellation: cannot call recv...
AudioProcessor state reset (external call)  ← 每秒循环
```

## 根本原因

`_final_swap_sequence` 的原有操作顺序有误：

1. 为新 session 创建 `handle_messages` task
2. `await old_main_session.close()` ← `ws.close()` 内部执行关闭握手，**本质是 `recv()`**
3. `old_main_message_handler_task.cancel()` ← **此时旧 task 仍在旧 WebSocket 的 `recv()` 中**

步骤 2 与旧 task 的 `recv()` 在**同一个 WebSocket** 上并发 → websockets 库抛出 "cannot call recv while another coroutine is already running recv"。

这是级联失败的根源：热切换崩溃 → session 反复重建 → `end_session` 循环 → AudioProcessor 不停重置。

## 修复

调整为正确的清理顺序：

1. `cancel()` + `wait_for()` 旧 task → 中断其 `recv()`，确保旧 WebSocket 上无并发访问
2. `await old_main_session.close()` → 此时无 recv() 竞争，关闭握手安全执行  
3. 启动新 session 的 `handle_messages` task

同时将 `end_session` 中捕获到「task 提前因该错误退出」的日志级别从 ERROR 降为 WARNING（此时只是发现既成事实，非新错误）。

## 稳妥性

- `asyncio.Task.cancel()` 会在 task 当前挂起的 `await`（即 `recv()`）处注入 `CancelledError`，可可靠中断 `async for message in ws` 循环，无需依赖 WebSocket 关闭来退出循环
- `wait_for(task, timeout=2.0)` 配合 `close_timeout=0.5s`（连接时已设），最长等待 2s
- 新 session WebSocket 已预热就绪，短暂延迟启动 `handle_messages` 期间的消息会缓存在 WebSocket 接收缓冲区，不丢失

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 优化会话热切换顺序：先停止并取消旧会话的监听任务，再关闭旧会话，降低竞态和资源泄露风险。
  * 提升前后验证并在验证失败时触发重建/重置，清理不一致会话状态。
  * 将热切换音频缓存刷新移至新会话启动并验证后，确保音频发送到正确会话。
  * 强化取消与异常清理：未被提升的新会话会主动关闭以避免连接泄漏。
  * 调整日志级别：部分监听/取消失败由错误降为警告。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->