### PR TITLE
feat(proactive): SM 收口 agent_callback / greeting 投递入口

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2673,9 +2673,22 @@ class LLMSessionManager:
     async def _deliver_agent_callbacks_text(self, instruction: str, callbacks_snapshot: list) -> None:
         """Execute prompt_ephemeral on an OmniOfflineClient session inside the
         proactive write lock. Caller holds the SM proactive claim (PHASE1).
+
+        返回 True 当且仅当真正投递。返回 False 的情况：claim 到 lock 之间用户
+        抢占（``mark_user_input_preempt`` 在 ``self.lock`` 内翻起 ``_preempted``
+        且已轮换 ``current_speech_id`` 到新 user sid），此时不能再覆盖。
         """
         async with self._proactive_write_lock:
             async with self.lock:
+                # sticky preempt 复查：与 prepare_proactive_delivery 同样，在持有
+                # self.lock 的临界区内判定。USER_INPUT 路径在本锁段内翻 flag 和
+                # 写 user sid 是原子的，如果此处 preempt==True 说明用户已抢到
+                # 本轮 turn，必须放弃本次 proactive（否则会把用户刚写好的 sid
+                # 再覆盖成 proactive sid，污染 TTS/chunk 分发）。
+                if self.state.is_proactive_preempted():
+                    logger.info("[%s] trigger_agent_callbacks: preempted before sid claim, skipping", self.lanlan_name)
+                    self.pending_agent_callbacks.extend(callbacks_snapshot)
+                    return
                 self.current_speech_id = str(uuid4())
                 self._tts_done_queued_for_turn = False
                 proactive_sid = self.current_speech_id
@@ -2812,6 +2825,12 @@ class LLMSessionManager:
                     logger.info("[%s] trigger_greeting: voice session took over while waiting for write lock, skipping", self.lanlan_name)
                     return
                 async with self.lock:
+                    # sticky preempt 复查：USER_INPUT 路径在本锁段内翻 flag 和写
+                    # user sid 是原子的；若 preempt==True 说明用户已抢到本轮 turn，
+                    # 不能再覆盖 current_speech_id 成 proactive sid。
+                    if self.state.is_proactive_preempted():
+                        logger.info("[%s] trigger_greeting: preempted before sid claim, skipping", self.lanlan_name)
+                        return
                     self.current_speech_id = str(uuid4())
                     self._tts_done_queued_for_turn = False
                     proactive_sid = self.current_speech_id

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -256,8 +256,6 @@ class LLMSessionManager:
         self.pending_extra_replies = []
         # 结构化 agent 任务回调队列（用于按会话类型注入）
         self.pending_agent_callbacks: list[dict] = []
-        # 防止 trigger_agent_callbacks 重入
-        self._agent_delivery_in_progress: bool = False
         # 防止 trigger_agent_callbacks 和 finish_proactive_delivery 并发写 WS/sync_message_queue
         self._proactive_write_lock = asyncio.Lock()
         # 由前端控制的Agent相关开关
@@ -2588,22 +2586,22 @@ class LLMSessionManager:
         """Proactively deliver pending agent task results via LLM rephrase.
 
         Design:
-        - Text mode (OmniOfflineClient): calls session.prompt_ephemeral() so the
-          LLM generates a styled response in the character's voice.
+        - Text mode (OmniOfflineClient): claims proactive turn via
+          ``state.try_start_proactive()`` then calls ``prompt_ephemeral()`` so
+          the LLM generates a styled response in the character's voice.
         - Voice mode (OmniRealtimeClient): defers to hot-swap — callbacks are
-          kept in pending_extra_replies for injection via prime_context().
+          kept in pending_extra_replies for injection via prime_context()；
+          不参与 SM 状态机（hot-swap 有独立生命周期）。
         - On failure or when the session is busy, restores callbacks so the next
           handle_response_complete() call will retry automatically.
-        - Re-entrance guard prevents concurrent deliveries.
+        - 重入与"AI 正在回复"互斥由 SM 的原子 claim 承担；同时与
+          ``/api/proactive_chat`` / ``trigger_greeting`` 互为 mutual exclusion。
         """
         sess_type = type(self.session).__name__ if self.session else "None"
         logger.info(
-            "[%s] trigger_agent_callbacks enter: session=%s delivery_in_progress=%s pending=%d",
-            self.lanlan_name, sess_type, self._agent_delivery_in_progress, len(self.pending_agent_callbacks),
+            "[%s] trigger_agent_callbacks enter: session=%s phase=%s pending=%d",
+            self.lanlan_name, sess_type, self.state.phase.value, len(self.pending_agent_callbacks),
         )
-        if self._agent_delivery_in_progress:
-            logger.debug("[%s] trigger_agent_callbacks: skipped — delivery already in progress", self.lanlan_name)
-            return
         if not self.pending_agent_callbacks:
             return
 
@@ -2628,47 +2626,32 @@ class LLMSessionManager:
             self.pending_extra_replies.clear()
             return
 
+        # Voice mode 走 hot-swap，不进 SM proactive 流水线
+        if isinstance(self.session, OmniRealtimeClient):
+            self.pending_agent_callbacks.clear()
+            logger.debug("[%s] trigger_agent_callbacks: voice mode, deferring to hot-swap", self.lanlan_name)
+            return
+
         _lang = normalize_language_code(self.user_language, format='short')
         instruction = (
             _loc(SYSTEM_NOTIFICATION_TASKS_DONE, _lang).format(name=self.lanlan_name, master=self.master_name)
             + "\n".join(items)
         )
-
         callbacks_snapshot = list(self.pending_agent_callbacks)
 
-        self._agent_delivery_in_progress = True
+        # 原子 check-and-claim：若另一路 proactive（router/greeting）在跑或 AI
+        # 正在为用户回复，SM 拒绝本次投递，callbacks 留在 pending 下轮重试。
+        claim_session = self.session if isinstance(self.session, OmniOfflineClient) else None
+        if not await self.state.try_start_proactive(session=claim_session):
+            logger.debug(
+                "[%s] trigger_agent_callbacks: SM denied claim (phase=%s), re-queuing",
+                self.lanlan_name, self.state.phase.value,
+            )
+            return
+
         try:
-            if isinstance(self.session, OmniRealtimeClient):
-                self.pending_agent_callbacks.clear()
-                logger.debug("[%s] trigger_agent_callbacks: voice mode, deferring to hot-swap", self.lanlan_name)
-
-            elif isinstance(self.session, OmniOfflineClient):
-                if getattr(self.session, "_is_responding", False):
-                    logger.debug("[%s] trigger_agent_callbacks: text session busy (_is_responding=True), re-queuing", self.lanlan_name)
-                    return
-                async with self._proactive_write_lock:
-                    async with self.lock:
-                        self.current_speech_id = str(uuid4())
-                        self._tts_done_queued_for_turn = False
-                        proactive_sid = self.current_speech_id
-                    logger.debug("[%s] trigger_agent_callbacks: text session ready, calling prompt_ephemeral", self.lanlan_name)
-                    # 更新字数限制（可能用户在对话期间修改了设置）
-                    if hasattr(self.session, 'update_max_response_length'):
-                        self.session.update_max_response_length(self._get_text_guard_max_length())
-                    self.pending_agent_callbacks.clear()
-                    # 设置 per-task contextvar，让 prompt_ephemeral 回调链里的
-                    # handle_text_data 能识别本路径 chunk 并在 sid 被用户抢走后丢弃。
-                    _sid_token = _proactive_expected_sid.set(proactive_sid)
-                    try:
-                        delivered = await self.session.prompt_ephemeral(instruction)
-                    finally:
-                        _proactive_expected_sid.reset(_sid_token)
-                    logger.debug("[%s] trigger_agent_callbacks: text session prompt_ephemeral delivered=%s", self.lanlan_name, delivered)
-                    if delivered:
-                        self.pending_extra_replies.clear()
-                    else:
-                        self.pending_agent_callbacks.extend(callbacks_snapshot)
-
+            if isinstance(self.session, OmniOfflineClient):
+                await self._deliver_agent_callbacks_text(instruction, callbacks_snapshot)
             else:
                 ws = self.websocket
                 if ws and hasattr(ws, 'client_state') and ws.client_state == ws.client_state.CONNECTED:
@@ -2677,33 +2660,46 @@ class LLMSessionManager:
                     except Exception as e:
                         logger.warning("[%s] trigger_agent_callbacks: auto start_session failed: %s", self.lanlan_name, e)
                 if isinstance(self.session, OmniOfflineClient):
-                    async with self._proactive_write_lock:
-                        async with self.lock:
-                            self.current_speech_id = str(uuid4())
-                            self._tts_done_queued_for_turn = False
-                            proactive_sid = self.current_speech_id
-                        # 更新字数限制（可能用户在对话期间修改了设置）
-                        if hasattr(self.session, 'update_max_response_length'):
-                            self.session.update_max_response_length(self._get_text_guard_max_length())
-                        self.pending_agent_callbacks.clear()
-                        _sid_token = _proactive_expected_sid.set(proactive_sid)
-                        try:
-                            delivered = await self.session.prompt_ephemeral(instruction)
-                        finally:
-                            _proactive_expected_sid.reset(_sid_token)
-                        if delivered:
-                            self.pending_extra_replies.clear()
-                        else:
-                            self.pending_agent_callbacks.extend(callbacks_snapshot)
-                        logger.debug("[%s] trigger_agent_callbacks: auto text session, delivered=%s", self.lanlan_name, delivered)
+                    await self._deliver_agent_callbacks_text(instruction, callbacks_snapshot)
+                    logger.debug("[%s] trigger_agent_callbacks: auto text session delivered", self.lanlan_name)
                 else:
                     logger.debug("[%s] trigger_agent_callbacks: no websocket/session, keeping for later", self.lanlan_name)
-
         except Exception as e:
             logger.warning("[%s] trigger_agent_callbacks error: %s", self.lanlan_name, e)
             self.pending_agent_callbacks.extend(callbacks_snapshot)
         finally:
-            self._agent_delivery_in_progress = False
+            await self.state.fire(SessionEvent.PROACTIVE_DONE)
+
+    async def _deliver_agent_callbacks_text(self, instruction: str, callbacks_snapshot: list) -> None:
+        """Execute prompt_ephemeral on an OmniOfflineClient session inside the
+        proactive write lock. Caller holds the SM proactive claim (PHASE1).
+        """
+        async with self._proactive_write_lock:
+            async with self.lock:
+                self.current_speech_id = str(uuid4())
+                self._tts_done_queued_for_turn = False
+                proactive_sid = self.current_speech_id
+            # SM：发射 CLAIM（把 proactive_sid 写入 state，供诊断/订阅者观察）
+            # 随后立刻 PHASE2，因 prompt_ephemeral 没有可分离的 phase1/phase2 边界
+            await self.state.fire(SessionEvent.PROACTIVE_CLAIM, sid=proactive_sid)
+            await self.state.fire(SessionEvent.PROACTIVE_PHASE2)
+            logger.debug("[%s] trigger_agent_callbacks: text session ready, calling prompt_ephemeral", self.lanlan_name)
+            # 更新字数限制（可能用户在对话期间修改了设置）
+            if hasattr(self.session, 'update_max_response_length'):
+                self.session.update_max_response_length(self._get_text_guard_max_length())
+            self.pending_agent_callbacks.clear()
+            # per-task contextvar：prompt_ephemeral 回调链里 handle_text_data
+            # 识别本路径 chunk 并在 sid 被用户抢走后丢弃
+            _sid_token = _proactive_expected_sid.set(proactive_sid)
+            try:
+                delivered = await self.session.prompt_ephemeral(instruction)
+            finally:
+                _proactive_expected_sid.reset(_sid_token)
+            logger.debug("[%s] trigger_agent_callbacks: prompt_ephemeral delivered=%s", self.lanlan_name, delivered)
+            if delivered:
+                self.pending_extra_replies.clear()
+            else:
+                self.pending_agent_callbacks.extend(callbacks_snapshot)
 
     def _is_voice_session_active_or_starting(self) -> bool:
         """语音 session 正在启动或已经活跃时返回 True，用于阻止 greeting 干扰语音流。"""
@@ -2800,25 +2796,39 @@ class LLMSessionManager:
             logger.info("[%s] trigger_greeting: voice session took over before delivery, skipping", self.lanlan_name)
             return
 
-        async with self._proactive_write_lock:
-            # 持锁后仍需检查：_proactive_write_lock 等待期间语音可能已启动
-            if self._is_voice_session_active_or_starting():
-                logger.info("[%s] trigger_greeting: voice session took over while waiting for write lock, skipping", self.lanlan_name)
-                return
-            async with self.lock:
-                self.current_speech_id = str(uuid4())
-                self._tts_done_queued_for_turn = False
-                proactive_sid = self.current_speech_id
-            _sid_token = _proactive_expected_sid.set(proactive_sid)
-            try:
-                delivered = await self.session.prompt_ephemeral(instruction)
-            finally:
-                _proactive_expected_sid.reset(_sid_token)
-            logger.info("[%s] trigger_greeting: delivered=%s", self.lanlan_name, delivered)
-            # 投递成功后才真正消费节日/周末预算
-            # commit 内部会 atomic_write_json 消费预算文件，offload 以免阻塞事件循环
-            if delivered and _holiday_token is not None:
-                await asyncio.to_thread(commit_holiday_or_weekend_hint, self.lanlan_name, _holiday_token)
+        # 原子 SM claim：与 trigger_agent_callbacks / /api/proactive_chat 互斥
+        # 并拦截"AI 正在为用户回复"（session._is_responding）的场景
+        if not await self.state.try_start_proactive(session=self.session):
+            logger.info(
+                "[%s] trigger_greeting: SM denied claim (phase=%s), skipping",
+                self.lanlan_name, self.state.phase.value,
+            )
+            return
+
+        try:
+            async with self._proactive_write_lock:
+                # 持锁后仍需检查：_proactive_write_lock 等待期间语音可能已启动
+                if self._is_voice_session_active_or_starting():
+                    logger.info("[%s] trigger_greeting: voice session took over while waiting for write lock, skipping", self.lanlan_name)
+                    return
+                async with self.lock:
+                    self.current_speech_id = str(uuid4())
+                    self._tts_done_queued_for_turn = False
+                    proactive_sid = self.current_speech_id
+                await self.state.fire(SessionEvent.PROACTIVE_CLAIM, sid=proactive_sid)
+                await self.state.fire(SessionEvent.PROACTIVE_PHASE2)
+                _sid_token = _proactive_expected_sid.set(proactive_sid)
+                try:
+                    delivered = await self.session.prompt_ephemeral(instruction)
+                finally:
+                    _proactive_expected_sid.reset(_sid_token)
+                logger.info("[%s] trigger_greeting: delivered=%s", self.lanlan_name, delivered)
+                # 投递成功后才真正消费节日/周末预算
+                # commit 内部会 atomic_write_json 消费预算文件，offload 以免阻塞事件循环
+                if delivered and _holiday_token is not None:
+                    await asyncio.to_thread(commit_holiday_or_weekend_hint, self.lanlan_name, _holiday_token)
+        finally:
+            await self.state.fire(SessionEvent.PROACTIVE_DONE)
 
     def enqueue_agent_callback(self, callback: dict) -> None:
         """Enqueue a structured agent task callback for LLM injection.

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -14,7 +14,6 @@
 import asyncio
 import os
 import sys
-from queue import Queue
 from unittest.mock import AsyncMock, MagicMock
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
@@ -59,7 +58,6 @@ class _FakeOmniOffline(OmniOfflineClient):
 
 
 def _make_mgr(session=None) -> LLMSessionManager:
-    import main_logic.core as core_module
     mgr = LLMSessionManager.__new__(LLMSessionManager)
     mgr.lanlan_name = "Test"
     mgr.master_name = "Master"
@@ -235,7 +233,6 @@ async def test_concurrent_agent_callback_and_router_proactive_one_wins():
 async def test_user_input_during_agent_delivery_sets_preempted():
     """text 投递期间 USER_INPUT 到达：sticky _preempted 翻起，phase 复位后仍可感知。"""
     sess_wait = asyncio.Event()
-    outer_loop = asyncio.get_event_loop()
 
     class _SlowSess(OmniOfflineClient):
         _is_responding = False

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -1,0 +1,279 @@
+"""SM 集成回归测试：``trigger_agent_callbacks`` / ``trigger_greeting`` 接入
+``SessionStateMachine`` 之后的关键行为契约。
+
+覆盖点：
+1. Voice 模式走 hot-swap，**不**触碰 SM（不 fire PROACTIVE_START，清 callbacks）
+2. Text 模式在 SM 被另一路 proactive 占用时拒绝投递，callbacks 保留重试
+3. Text 模式在 ``session._is_responding == True`` 时 SM 拒绝，callbacks 保留
+4. 正常 text 投递：IDLE → PHASE1（claim）→ CLAIM → PHASE2 → DONE 事件序列
+5. ``prompt_ephemeral`` 抛异常也必须 fire ``PROACTIVE_DONE``（finally 保证）
+6. ``trigger_agent_callbacks`` 和 ``trigger_greeting`` / ``/api/proactive_chat``
+   之间的 mutual exclusion：并发只有一路进 phase1
+7. ``trigger_greeting`` 的 voice guard 在 SM claim 后触发：不投递但 fire DONE
+"""
+import asyncio
+import os
+import sys
+from queue import Queue
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+# 为隔离 trigger_agent_callbacks / trigger_greeting 的环境依赖（prompt 资源、
+# _loc、normalize_language_code、httpx 等），测试不直接跑整段函数，而是对
+# SM 的契约做黑盒回归 —— 让一个 minimal mgr 模拟真实 LLMSessionManager 的
+# state/session/lock 结构，然后直接调用 trigger_agent_callbacks 的关键分支。
+from main_logic.core import LLMSessionManager, _proactive_expected_sid
+from main_logic.omni_offline_client import OmniOfflineClient
+from main_logic.session_state import (
+    ProactivePhase,
+    SessionEvent,
+    SessionStateMachine,
+    TurnOwner,
+)
+
+
+class _FakeOmniOffline(OmniOfflineClient):
+    """最小 OmniOfflineClient 替身。``prompt_ephemeral`` 行为由测试注入。
+
+    继承自 ``OmniOfflineClient`` 以通过 ``isinstance(...)`` 分支；跳过父类
+    ``__init__`` 避免拉起真实 LLM 客户端。
+    """
+
+    def __init__(self, delivered: bool = True, is_responding: bool = False,
+                 raise_exc: BaseException | None = None):
+        # 刻意不调用 super().__init__：父类需要一堆 OpenAI/websocket 参数
+        self._delivered = delivered
+        self._is_responding = is_responding
+        self._raise = raise_exc
+        self.called_with: list[str] = []
+
+    async def prompt_ephemeral(self, instruction: str) -> bool:
+        self.called_with.append(instruction)
+        if self._raise is not None:
+            raise self._raise
+        return self._delivered
+
+    def update_max_response_length(self, *_a, **_kw):
+        pass
+
+
+def _make_mgr(session=None) -> LLMSessionManager:
+    import main_logic.core as core_module
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.master_name = "Master"
+    mgr.user_language = "en"
+    mgr.state = SessionStateMachine(lanlan_name="Test")
+    mgr.session = session
+    mgr.websocket = None
+    mgr.lock = asyncio.Lock()
+    mgr._proactive_write_lock = asyncio.Lock()
+    mgr.current_speech_id = None
+    mgr._tts_done_queued_for_turn = False
+    mgr.pending_agent_callbacks = []
+    mgr.pending_extra_replies = []
+    mgr._get_text_guard_max_length = MagicMock(return_value=200)
+    # Patch OmniRealtimeClient / OmniOfflineClient isinstance 判定：
+    # 在测试里我们只关心 OmniOfflineClient 分支，其他分支显式构造。
+    mgr.start_session = AsyncMock()
+    return mgr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# trigger_agent_callbacks
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_voice_mode_does_not_touch_sm():
+    """Voice 模式：清 pending，不 fire SM 任何事件。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            pass  # 跳过父类初始化
+
+    mgr = _make_mgr(session=_VoiceSess())
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "task done"}]
+
+    events: list[SessionEvent] = []
+    mgr.state.subscribe(None, lambda ev, p: events.append(ev))
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    # 异步订阅派发 —— 让 event loop 转一圈
+    await asyncio.sleep(0)
+
+    assert mgr.pending_agent_callbacks == []
+    assert mgr.state.phase is ProactivePhase.IDLE
+    assert events == []  # 未走 SM 任何事件
+
+
+async def test_text_mode_sm_denied_when_phase_active():
+    """另一路 proactive 已占 phase1 时，text 投递不应清 callbacks。"""
+    sess = _FakeOmniOffline()
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "hello"}]
+
+    # 模拟 router 已启动 proactive
+    await mgr.state.fire(SessionEvent.PROACTIVE_START)
+    assert mgr.state.phase is ProactivePhase.PHASE1
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    # SM 拒绝 → prompt_ephemeral 未调用，callbacks 保留
+    assert sess.called_with == []
+    assert mgr.pending_agent_callbacks == [{"status": "completed", "summary": "hello"}]
+    assert mgr.state.phase is ProactivePhase.PHASE1  # 原 proactive 占用未动
+
+
+async def test_text_mode_sm_denied_when_session_responding():
+    """AI 正在回复时 SM 拒绝 text 投递。"""
+    sess = _FakeOmniOffline(is_responding=True)
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "queued"}]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    assert sess.called_with == []
+    # callbacks 保留以便下轮重试
+    assert mgr.pending_agent_callbacks == [{"status": "completed", "summary": "queued"}]
+    assert mgr.state.phase is ProactivePhase.IDLE
+
+
+async def test_text_mode_successful_delivery_fires_full_event_sequence():
+    """happy path：START → CLAIM → PHASE2 → DONE，且 phase 回到 IDLE。"""
+    sess = _FakeOmniOffline(delivered=True)
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "ok"}]
+
+    seen: list[tuple[SessionEvent, dict]] = []
+    mgr.state.subscribe(None, lambda ev, p: seen.append((ev, dict(p))))
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    # 异步派发订阅回调
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    event_names = [ev for ev, _ in seen]
+    assert event_names == [
+        SessionEvent.PROACTIVE_START,
+        SessionEvent.PROACTIVE_CLAIM,
+        SessionEvent.PROACTIVE_PHASE2,
+        SessionEvent.PROACTIVE_DONE,
+    ]
+
+    # CLAIM payload 带着生成的 sid
+    claim_payload = seen[1][1]
+    assert claim_payload["sid"] == mgr.current_speech_id
+
+    # 最终 phase 回 IDLE
+    assert mgr.state.phase is ProactivePhase.IDLE
+    assert mgr.state.proactive_sid is None
+
+    # prompt_ephemeral 被调用，callbacks 已清
+    assert len(sess.called_with) == 1
+    assert mgr.pending_agent_callbacks == []
+
+
+async def test_text_mode_exception_still_fires_done():
+    """prompt_ephemeral 抛异常：callbacks 恢复 + PROACTIVE_DONE 仍必 fire。"""
+    sess = _FakeOmniOffline(raise_exc=RuntimeError("llm boom"))
+    mgr = _make_mgr(session=sess)
+    original = [{"status": "completed", "summary": "retry_me"}]
+    mgr.pending_agent_callbacks = list(original)
+
+    seen_events: list[SessionEvent] = []
+    mgr.state.subscribe(None, lambda ev, p: seen_events.append(ev))
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    assert SessionEvent.PROACTIVE_DONE in seen_events
+    assert mgr.state.phase is ProactivePhase.IDLE
+    # exception 路径下 callbacks 恢复（见 core 的 except 分支）
+    assert mgr.pending_agent_callbacks == original
+
+
+async def test_contextvar_reset_after_delivery():
+    """prompt_ephemeral 调用完后 ``_proactive_expected_sid`` 必须恢复为 None。"""
+    sess = _FakeOmniOffline(delivered=True)
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "ctx"}]
+
+    assert _proactive_expected_sid.get() is None
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    assert _proactive_expected_sid.get() is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# mutual exclusion：text trigger 和 router proactive 之间
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_concurrent_agent_callback_and_router_proactive_one_wins():
+    """trigger_agent_callbacks 和 router try_start_proactive 并发：只有一路进 PHASE1。"""
+    sess = _FakeOmniOffline(delivered=True)
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "race"}]
+
+    router_won = await mgr.state.try_start_proactive(session=sess)
+    assert router_won is True
+
+    # 并发的 agent callback 必须被 SM 挡住 —— router 已占 phase1
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    # router 占用未被干扰
+    assert mgr.state.phase is ProactivePhase.PHASE1
+    assert sess.called_with == []
+    # callbacks 保留
+    assert mgr.pending_agent_callbacks == [{"status": "completed", "summary": "race"}]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# user_input sticky preempt 仍生效
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_user_input_during_agent_delivery_sets_preempted():
+    """text 投递期间 USER_INPUT 到达：sticky _preempted 翻起，phase 复位后仍可感知。"""
+    sess_wait = asyncio.Event()
+    outer_loop = asyncio.get_event_loop()
+
+    class _SlowSess(OmniOfflineClient):
+        _is_responding = False
+
+        def __init__(self):
+            pass  # 跳过父类初始化
+
+        async def prompt_ephemeral(self, instruction):
+            # 模拟 LLM 耗时，期间 user input 抢占
+            await sess_wait.wait()
+            return True
+
+        def update_max_response_length(self, *_a, **_kw):
+            pass
+
+    mgr = _make_mgr(session=_SlowSess())
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "slow"}]
+
+    # 同时跑 agent callback delivery + 异步注入 USER_INPUT
+    task = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
+
+    # 等 state 进入 phase1
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if mgr.state.phase in (ProactivePhase.PHASE1, ProactivePhase.PHASE2):
+            break
+
+    await mgr.state.fire(SessionEvent.USER_INPUT, sid="user_new_sid")
+    # sticky flag 应已翻
+    assert mgr.state._preempted is True
+    assert mgr.state.owner is TurnOwner.USER
+
+    # 放行 prompt_ephemeral
+    sess_wait.set()
+    await task
+
+    # 一旦 PROACTIVE_DONE 触发，phase 回到 IDLE，_preempted 清零；
+    # 但 owner 保留 USER（被抢占情况下 DONE 不覆盖）
+    assert mgr.state.phase is ProactivePhase.IDLE
+    assert mgr.state._preempted is False
+    assert mgr.state.owner is TurnOwner.USER

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -207,8 +207,8 @@ async def test_contextvar_reset_after_delivery():
 # mutual exclusion：text trigger 和 router proactive 之间
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def test_concurrent_agent_callback_and_router_proactive_one_wins():
-    """trigger_agent_callbacks 和 router try_start_proactive 并发：只有一路进 PHASE1。"""
+async def test_already_claimed_denies_agent_callback():
+    """router 已占 phase1 时，后续 agent callback 不能进 prompt_ephemeral。"""
     sess = _FakeOmniOffline(delivered=True)
     mgr = _make_mgr(session=sess)
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "race"}]
@@ -216,14 +216,98 @@ async def test_concurrent_agent_callback_and_router_proactive_one_wins():
     router_won = await mgr.state.try_start_proactive(session=sess)
     assert router_won is True
 
-    # 并发的 agent callback 必须被 SM 挡住 —— router 已占 phase1
     await LLMSessionManager.trigger_agent_callbacks(mgr)
 
-    # router 占用未被干扰
     assert mgr.state.phase is ProactivePhase.PHASE1
     assert sess.called_with == []
-    # callbacks 保留
     assert mgr.pending_agent_callbacks == [{"status": "completed", "summary": "race"}]
+
+
+async def test_concurrent_claim_only_one_winner():
+    """真·并发：两路 contender 用同一个 barrier 放行，
+    原子 check-and-claim 保证只有一个 winner 进入 prompt_ephemeral。"""
+    sess = _FakeOmniOffline(delivered=True)
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "race"}]
+
+    barrier = asyncio.Event()
+    router_won = asyncio.Future()
+
+    async def router_contender():
+        await barrier.wait()
+        router_won.set_result(await mgr.state.try_start_proactive(session=sess))
+
+    async def agent_contender():
+        await barrier.wait()
+        await LLMSessionManager.trigger_agent_callbacks(mgr)
+
+    t1 = asyncio.create_task(router_contender())
+    t2 = asyncio.create_task(agent_contender())
+    # 两个 task 都阻塞在 barrier 上，再一起放行
+    await asyncio.sleep(0)
+    barrier.set()
+    await asyncio.gather(t1, t2)
+
+    # 恰好一个 winner：router_won 为 True → agent 被拒；False → agent 成功
+    if router_won.result() is True:
+        # router winner：agent 不能进 prompt_ephemeral
+        assert sess.called_with == []
+        assert mgr.pending_agent_callbacks == [{"status": "completed", "summary": "race"}]
+        assert mgr.state.phase is ProactivePhase.PHASE1
+    else:
+        # agent winner：router 拒绝，agent 跑完 prompt_ephemeral → phase 回 IDLE
+        assert len(sess.called_with) == 1
+        assert mgr.pending_agent_callbacks == []
+        assert mgr.state.phase is ProactivePhase.IDLE
+
+
+async def test_user_input_between_claim_and_lock_is_detected():
+    """CodeRabbit 关键回归：``try_start_proactive`` 返回 True 到获取 ``self.lock``
+    之间，USER_INPUT 可能 mark_user_input_preempt() 并轮换 user sid。此时
+    ``_deliver_agent_callbacks_text`` 必须在 lock 内复查 sticky preempt，不能
+    把用户刚写好的 sid 再覆盖成 proactive sid。"""
+    sess_wait = asyncio.Event()
+
+    class _SlowSess(OmniOfflineClient):
+        _is_responding = False
+
+        def __init__(self):
+            pass
+
+        async def prompt_ephemeral(self, instruction):
+            await sess_wait.wait()
+            return True
+
+        def update_max_response_length(self, *_a, **_kw):
+            pass
+
+    sess = _SlowSess()
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "slow"}]
+
+    # SM claim 成功（phase → PHASE1）
+    assert await mgr.state.try_start_proactive(session=sess) is True
+
+    # 模拟 claim 后、_deliver 之前用户抢占：在 self.lock 内翻 preempt + 换 sid
+    async with mgr.lock:
+        pre_user_sid = "user_fresh_sid"
+        mgr.current_speech_id = pre_user_sid
+        mgr.state.mark_user_input_preempt()
+    await mgr.state.fire(SessionEvent.USER_INPUT, sid=pre_user_sid)
+
+    # 现在直接调 _deliver_agent_callbacks_text（绕过 trigger_agent_callbacks
+    # 的 claim，因为我们已经手动模拟了 claim + user 抢占）
+    callbacks_snapshot = [{"status": "completed", "summary": "slow"}]
+    await LLMSessionManager._deliver_agent_callbacks_text(mgr, "instr", callbacks_snapshot)
+
+    # 关键断言：current_speech_id 保留为用户的 sid，没被 proactive 覆盖
+    assert mgr.current_speech_id == pre_user_sid
+    # prompt_ephemeral 未调用
+    sess_wait.set()  # defensive：万一被调用也不会无限阻塞
+    # 给它一个 tick 证明 prompt_ephemeral 确实没跑
+    await asyncio.sleep(0)
+    # callbacks_snapshot 被恢复回 pending（bail 路径的语义）
+    assert {"status": "completed", "summary": "slow"} in mgr.pending_agent_callbacks
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -343,6 +343,9 @@ async def test_user_input_during_agent_delivery_sets_preempted():
         await asyncio.sleep(0.01)
         if mgr.state.phase in (ProactivePhase.PHASE1, ProactivePhase.PHASE2):
             break
+    assert mgr.state.phase in (ProactivePhase.PHASE1, ProactivePhase.PHASE2), (
+        "等待 trigger_agent_callbacks 进入 proactive phase 超时"
+    )
 
     await mgr.state.fire(SessionEvent.USER_INPUT, sid="user_new_sid")
     # sticky flag 应已翻


### PR DESCRIPTION
## 背景 / 动机

承接 [PR #867](https://github.com/Project-N-E-K-O/N.E.K.O/pull/867) 引入的 `SessionStateMachine`。#867 把 `/api/proactive_chat`（router proactive）收口进 SM，但**同一会话的另外两个 proactive 入口**仍未接入：

- `trigger_agent_callbacks`（agent 任务完成回调投递）
- `trigger_greeting`（首次/切角色 greeting 投递）

这两处各自维护一套旧 guard：
- `_agent_delivery_in_progress` 本地重入 flag（core.py:2604/2639/2706）
- 直读 `session._is_responding` 判「文本会话忙」（`trigger_agent_callbacks` 和 `trigger_greeting` 各有一处）

结果：三路 proactive（router / agent_callback / greeting）**互相不感知**——agent_callback 和 greeting 可能同时入场，或在 router proactive 跑到一半时插进去，导致 sid 争用。

## 改动

### `trigger_agent_callbacks` / `trigger_greeting` 接入 SM

用 `state.try_start_proactive(session=self.session)` 原子 check-and-claim 替代旧 guard，承担：
1. 重入互斥（旧 `_agent_delivery_in_progress` 被删除）
2. AI 正在为用户回复时直接拒绝（旧 `_is_responding` 直读的语义）
3. **三路 proactive 互为 mutual exclusion**：另一路在 PHASE1/PHASE2/COMMITTING 时本路直接 deny

claim 成功后事件序列：`START → CLAIM(sid=...) → PHASE2 → DONE`（与 router 路径对偶，只是跳过 COMMITTING——`prompt_ephemeral` 没有可分离的 phase1/phase2 边界）。任何退出路径（成功 / 异常 / 锁内 voice guard）都通过 `try/finally` 保证 fire `PROACTIVE_DONE`，SM 幂等复位。

副作用安全：
- SM claim 被拒时 callbacks 保留在 pending，下轮 `handle_response_complete` 自动重试（与旧行为一致）
- `prompt_ephemeral` 抛异常走 `except` 恢复 callbacks，`finally` 仍 fire DONE
- Voice 模式（`OmniRealtimeClient`）仍走 hot-swap `pending_extra_replies`，**不**触碰 SM（hot-swap 有独立生命周期，不应视作 proactive 占用）
- `_proactive_write_lock` 保留（与 `finish_proactive_delivery` 之间的 WS 写序约束不变）
- `_proactive_expected_sid` contextvar 保留（per-task chunk 级 race guard，与 SM 的 turn 级防守互补，PR #867 作者明确不合并）

### 代码布局

- `trigger_agent_callbacks` 文本投递路径抽出 `_deliver_agent_callbacks_text()`，消除 text-session 分支和 auto-start 分支的重复代码块
- 删除 `LLMSessionManager.__init__` 中 `_agent_delivery_in_progress` 字段

## 测试

新增 `tests/unit/test_proactive_sm_integration.py` 共 **8 个用例**：

1. `test_voice_mode_does_not_touch_sm` — voice 清 callbacks，0 个 SM 事件
2. `test_text_mode_sm_denied_when_phase_active` — router proactive 占用 phase1 时本路被拒，callbacks 保留
3. `test_text_mode_sm_denied_when_session_responding` — `_is_responding == True` 时被拒，callbacks 保留
4. `test_text_mode_successful_delivery_fires_full_event_sequence` — happy path 事件序列 `[START, CLAIM, PHASE2, DONE]`，CLAIM 带正确 sid
5. `test_text_mode_exception_still_fires_done` — `prompt_ephemeral` 抛异常：callbacks 恢复 + DONE 必 fire + phase 回 IDLE
6. `test_contextvar_reset_after_delivery` — `_proactive_expected_sid` 正确复位
7. `test_concurrent_agent_callback_and_router_proactive_one_wins` — 三路互斥回归
8. `test_user_input_during_agent_delivery_sets_preempted` — 投递中途 USER_INPUT：sticky `_preempted` 翻起、owner 翻为 USER、DONE 后 phase 回 IDLE 但 owner 保留 USER

全量：`uv run pytest tests/unit/test_session_state.py tests/unit/test_proactive_sid_guard.py tests/unit/test_proactive_sm_integration.py -q` → **66 passed**

## 手动回放

- [ ] **三路互斥**：agent 任务跑完时触发 callback → router proactive 入口命中 409（action=pass）
- [ ] **greeting 被 AI 回复抢占**：切角色瞬间让上一个角色的 AI 正在回复 → greeting 命中 SM deny，静默 skip
- [ ] **正常 happy path**：agent 任务完成 → callbacks 触发 → phase IDLE→PHASE1→PHASE2→IDLE，前端正常显示 agent 总结消息
- [ ] **投递中途打断**：agent callback 的 `prompt_ephemeral` 流到一半从前端发消息 → `_preempted` 翻起、proactive chunk 被 `_proactive_expected_sid` contextvar 丢弃、用户新回复正常

## 不在本 PR 范围

- `_proactive_expected_sid` contextvar 保留（per-task / chunk 级，SM 管不到的维度；PR #867 作者明确非冗余）
- `_is_voice_session_active_or_starting()` / `_starting_session_count` 保留（session 存活度 ≠ turn ownership）
- `current_speech_id` 比较保留（chunk 级 sid guard，与 SM 的 turn 级状态互补）

Related: #867 #862 #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进主动交付的异常与最终化流程，确保在错误或中断时触发完成事件并恢复可重试的回调状态。
  * 修正并发竞态与抢占场景下的回调保留与恢复，避免回调丢失或状态不一致。

* **Refactor**
  * 区分语音与文本交付路径：语音走即时热切换，文本走受保护的主动交付流程并保证事件序列与生命周期一致性。
  * 主动问候流程现通过受保护的声明与事件序列执行，保证互斥与清理。

* **Tests**
  * 新增回归与集成测试，覆盖并发、抢占、事件顺序、错误恢复与重试语义验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->