### PR TITLE
fix: tutorial highlight positioning and popover image loading issues

### DIFF
--- a/static/libs/driver.min.js
+++ b/static/libs/driver.min.js
@@ -330,7 +330,35 @@
             }
 
             // 定位弹窗（传入元素信息以便智能定位）
-            setTimeout(() => this.positionPopover(element), 0);
+            setTimeout(() => {
+                // 等待弹窗内所有图片加载完成后再定位，避免图片异步加载导致高度不准
+                const imgs = this.popover ? Array.from(this.popover.querySelectorAll('img[src]')) : [];
+                const unloaded = imgs.filter(img => !img.complete || img.naturalHeight === 0);
+
+                if (unloaded.length === 0) {
+                    this.positionPopover(element);
+                } else {
+                    console.log(`[Driver] 等待 ${unloaded.length} 张图片加载完成后再定位`);
+                    let loaded = 0;
+                    const onDone = () => {
+                        loaded++;
+                        if (loaded >= unloaded.length) {
+                            this.positionPopover(element);
+                        }
+                    };
+                    unloaded.forEach(img => {
+                        img.addEventListener('load', onDone, { once: true });
+                        img.addEventListener('error', onDone, { once: true });
+                    });
+                    // 兜底：最多等 3 秒，防止图片永远加载不完卡住教程
+                    setTimeout(() => {
+                        if (loaded < unloaded.length) {
+                            console.warn('[Driver] 图片加载超时，强制定位');
+                            this.positionPopover(element);
+                        }
+                    }, 3000);
+                }
+            }, 0);
         }
 
         positionPopover(element) {

--- a/static/libs/driver.min.js
+++ b/static/libs/driver.min.js
@@ -181,54 +181,80 @@
 
         // 滚动到元素并创建高亮框
         scrollToElementAndHighlight(element, popover, stepIndex) {
-            // 检查元素是否在视口内
-            const rect = element.getBoundingClientRect();
-            const isInViewport = (
-                rect.top >= 0 &&
-                rect.left >= 0 &&
-                rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-                rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-            );
+            // 检查元素位置是否有效（非零尺寸且不在原点）
+            const hasValidRect = (el) => {
+                const r = el.getBoundingClientRect();
+                // 尺寸为 0 说明元素不可见（display:none 等）
+                if (r.width === 0 && r.height === 0) return false;
+                // 有固定尺寸但位置在 (0,0) 且没有设置过 left/top，说明位置未初始化
+                if (r.left === 0 && r.top === 0 && el.style.position === 'fixed' && !el.style.left && !el.style.top) return false;
+                return true;
+            };
 
-            if (isInViewport) {
-                // 元素已在视口内，直接创建高亮
-                console.log('[Driver] 元素已在视口内');
-                this.createHighlight(element);
-                this.createPopover(element, popover, stepIndex);
-                this.emit('next');
-            } else {
-                // 元素不在视口内，需要滚动
-                console.log('[Driver] 元素不在视口内，正在滚动...');
+            const proceed = () => {
+                const rect = element.getBoundingClientRect();
+                const isInViewport = (
+                    rect.top >= 0 &&
+                    rect.left >= 0 &&
+                    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+                    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+                );
 
-                // 使用 scrollIntoView 滚动到元素
-                element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-
-                // 监听滚动停止来创建高亮框
-                let scrollTimer = null;
-                let created = false;
-
-                const createAfterScroll = () => {
-                    if (created) return;
-                    created = true;
-                    window.removeEventListener('scroll', onScroll);
-                    console.log('[Driver] 滚动完成，创建高亮框');
+                if (isInViewport) {
+                    console.log('[Driver] 元素已在视口内');
                     this.createHighlight(element);
                     this.createPopover(element, popover, stepIndex);
                     this.emit('next');
+                } else {
+                    console.log('[Driver] 元素不在视口内，正在滚动...');
+                    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+                    let scrollTimer = null;
+                    let created = false;
+
+                    const createAfterScroll = () => {
+                        if (created) return;
+                        created = true;
+                        window.removeEventListener('scroll', onScroll);
+                        console.log('[Driver] 滚动完成，创建高亮框');
+                        this.createHighlight(element);
+                        this.createPopover(element, popover, stepIndex);
+                        this.emit('next');
+                    };
+
+                    const onScroll = () => {
+                        if (scrollTimer) clearTimeout(scrollTimer);
+                        scrollTimer = setTimeout(createAfterScroll, 150);
+                    };
+
+                    window.addEventListener('scroll', onScroll, { passive: true });
+                    setTimeout(() => {
+                        window.removeEventListener('scroll', onScroll);
+                        createAfterScroll();
+                    }, 1200);
+                }
+            };
+
+            // 如果元素位置无效（如 display:none 或位置未初始化），轮询等待
+            if (!hasValidRect(element)) {
+                console.log('[Driver] 元素位置无效，等待位置就绪...');
+                let attempts = 0;
+                const maxAttempts = 100; // 最多等 5 秒（50ms × 100）
+                const poll = () => {
+                    attempts++;
+                    if (hasValidRect(element)) {
+                        console.log(`[Driver] 元素位置就绪（等待了 ${attempts * 50}ms）`);
+                        proceed();
+                    } else if (attempts >= maxAttempts) {
+                        console.warn('[Driver] 元素位置等待超时，跳过此步骤');
+                        this.showStep(stepIndex + 1);
+                    } else {
+                        setTimeout(poll, 50);
+                    }
                 };
-
-                const onScroll = () => {
-                    if (scrollTimer) clearTimeout(scrollTimer);
-                    scrollTimer = setTimeout(createAfterScroll, 150);
-                };
-
-                window.addEventListener('scroll', onScroll, { passive: true });
-
-                // 保底：最多等 1200ms
-                setTimeout(() => {
-                    window.removeEventListener('scroll', onScroll);
-                    createAfterScroll();
-                }, 1200);
+                poll();
+            } else {
+                proceed();
             }
         }
 

--- a/static/live2d-ui-buttons.js
+++ b/static/live2d-ui-buttons.js
@@ -133,7 +133,8 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
     const tick = () => {
         try {
             if (!model || !model.parent) {
-                if (lockIcon) lockIcon.style.display = 'none';
+                // 教程期间不隐藏锁图标，防止高亮框位置被刷到 (0,0)
+                if (lockIcon && !window.isInTutorial) lockIcon.style.display = 'none';
                 return;
             }
             const bounds = model.getBounds();

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -60,6 +60,8 @@ MMDManager.prototype.setupFloatingButtons = function() {
 
     // 锁图标显示逻辑
     const shouldShowLockIcon = () => {
+        // 教程期间始终显示锁图标，防止高亮框位置异常
+        if (window.isInTutorial) return true;
         const isLocked = this.isLocked;
         if (this._isInReturnState) return false;
         if (isLocked) return true;

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -2077,6 +2077,9 @@ class UniversalTutorialManager {
      * 启动引导步骤（内部方法）
      */
     startTutorialSteps(validSteps) {
+        // 预加载所有步骤中的图片，确保走到含图片的步骤时图片已在浏览器缓存中
+        this._preloadStepImages(validSteps);
+
         // 重置步骤 onHighlighted 触发标记（避免重复/跨次引导）
         this._lastOnHighlightedStepIndex = null;
 
@@ -2659,6 +2662,34 @@ class UniversalTutorialManager {
                 resolve();
             }, 600);
         });
+    }
+
+    /**
+     * 预加载所有教程步骤中的图片。
+     * 解析每个步骤的 popover.description HTML，提取 <img src="..."> 中的 URL，
+     * 通过 new Image() 提前下载到浏览器缓存。这样走到含图片的步骤时，
+     * createPopover 插入 DOM 后图片能立即渲染，offsetHeight 计算准确，
+     * 避免图片异步加载导致弹窗定位偏移、按钮被截断。
+     */
+    _preloadStepImages(steps) {
+        if (!steps || steps.length === 0) return;
+        const srcSet = new Set();
+        const imgTagRegex = /<img[^>]+src\s*=\s*["']([^"']+)["'][^>]*>/gi;
+        for (const step of steps) {
+            const desc = step.popover && step.popover.description;
+            if (!desc || typeof desc !== 'string') continue;
+            let match;
+            while ((match = imgTagRegex.exec(desc)) !== null) {
+                srcSet.add(match[1]);
+            }
+            imgTagRegex.lastIndex = 0;
+        }
+        if (srcSet.size === 0) return;
+        console.log(`[Tutorial] 预加载 ${srcSet.size} 张教程图片:`, [...srcSet]);
+        for (const src of srcSet) {
+            const img = new Image();
+            img.src = src;
+        }
     }
 
     /**

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -71,6 +71,8 @@ VRMManager.prototype.setupFloatingButtons = function() {
 
     // 锁图标显示逻辑
     const shouldShowLockIcon = () => {
+        // 教程期间始终显示锁图标，防止高亮框位置异常
+        if (window.isInTutorial) return true;
         const isLocked = this.interaction && this.interaction.checkLocked ? this.interaction.checkLocked() : false;
         if (this._isInReturnState) return false;
         if (isLocked) return true;


### PR DESCRIPTION
## Summary

Fixes two tutorial system issues:

### 1. Tutorial popover buttons clipped when step contains images
- **Root cause**: `createPopover` calls `positionPopover` via `setTimeout(0)`, but the popover description contains an `<img>` tag. If the image hasn't loaded when `positionPopover` runs, `offsetHeight` is calculated without the image, causing the popover to be positioned incorrectly — the description text and navigation buttons overflow below the viewport.
- **Fix**: 
  - Added `_preloadStepImages()` in `UniversalTutorialManager` — scans all step descriptions at tutorial start and preloads images via `new Image()`.
  - Modified `createPopover` in `driver.min.js` to check `img.complete` before positioning; if images are still loading, waits for `onload`/`onerror` (with 3s timeout fallback).

### 2. Lock icon highlight collapses to (0,0)
- **Root cause**: The lock icon is dynamically positioned by a pixi.js ticker based on model bounds, and hidden (`display: none`) when the mouse is not near the model. During the tutorial, the ticker and `shouldShowLockIcon()` logic would override the tutorial's forced `display: block`, causing `getBoundingClientRect()` to return (0,0) during `refresh()` calls.
- **Fix**:
  - Added `window.isInTutorial` guard in Live2D tick function to skip hiding the lock icon during tutorial.
  - Added `window.isInTutorial` guard in VRM/MMD `shouldShowLockIcon()` to always return `true` during tutorial.
  - Added position validity check in `scrollToElementAndHighlight` — polls every 50ms (up to 5s) for the element to have valid dimensions and position before creating the highlight.

## Changed files
- `static/libs/driver.min.js` — image-aware positioning, position validity polling
- `static/universal-tutorial-manager.js` — `_preloadStepImages()` method
- `static/live2d-ui-buttons.js` — tutorial guard in lock icon tick
- `static/vrm-ui-buttons.js` — tutorial guard in `shouldShowLockIcon`
- `static/mmd-ui-buttons.js` — tutorial guard in `shouldShowLockIcon`

## Test plan
- [x] Reproduced image loading issue by deferring image src injection — buttons were clipped. Fix resolves it.
- [x] Verified lock icon fix with Live2D and MMD models — highlight stays at correct position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新说明

* **功能改进**
  - 教程模式下，锁定图标现在保持可见状态

* **性能优化**
  - 优化教程步骤的图片加载性能，在教程启动时预先加载相关图片资源

<!-- end of auto-generated comment: release notes by coderabbit.ai -->