### PR TITLE
refactor: 使用 CSS 原生拖动替代 JS 模拟拖动，修复窗口拖动异常

### DIFF
--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -34,14 +34,34 @@
             box-sizing: border-box !important;
         }
 
-        /* 整个面板可拖拽，内容区域和交互按钮排除 */
+        /* 整个面板走 OS 原生拖动（Chromium `-webkit-app-region: drag` → Windows HTCAPTION）。
+           不再用 JS mousedown + setBounds 模拟，避免和 Windows 边缘 WS_THICKFRAME resize
+           热区并发触发导致"拖一下窗口变大一下"。 */
         .jukebox-sam-panel {
-            -webkit-app-region: no-drag !important;
+            -webkit-app-region: drag !important;
             cursor: grab;
         }
 
-        body.neko-jukebox-manager-standalone-dragging .jukebox-sam-panel {
-            cursor: grabbing;
+        /* 交互元素必须 no-drag，否则点击会被原生拖动吃掉。 */
+        .jukebox-sam-panel button,
+        .jukebox-sam-panel input,
+        .jukebox-sam-panel a,
+        .jukebox-sam-panel select,
+        .jukebox-sam-panel textarea,
+        .jukebox-sam-panel label,
+        .jukebox-sam-panel [contenteditable="true"],
+        .jukebox-sam-panel .sam-tab,
+        .jukebox-sam-panel .sam-close-btn,
+        .jukebox-sam-panel .sam-content,
+        .jukebox-sam-panel .sam-item,
+        .jukebox-sam-panel .sam-binding-item,
+        .jukebox-sam-panel .sam-checkbox,
+        .jukebox-sam-panel .sam-unbind-btn,
+        .jukebox-sam-panel .sam-add-binding-btn,
+        .jukebox-sam-panel .sam-click-add,
+        .jukebox-sam-panel .sam-file-drop-zone,
+        .jukebox-sam-panel .sam-footer {
+            -webkit-app-region: no-drag !important;
         }
     </style>
 </head>
@@ -54,211 +74,9 @@
     <script src="/static/Jukebox.js"></script>
     <script>
         // 管理器独立窗口初始化
-        function _managerReadWindowBounds() {
-            return {
-                x: typeof window.screenX === 'number' ? window.screenX : 0,
-                y: typeof window.screenY === 'number' ? window.screenY : 0,
-                width: typeof window.outerWidth === 'number' ? window.outerWidth : document.documentElement.clientWidth,
-                height: typeof window.outerHeight === 'number' ? window.outerHeight : document.documentElement.clientHeight
-            };
-        }
-
-        function _managerReadWorkArea() {
-            var screenObj = window.screen || {};
-            return {
-                x: typeof screenObj.availLeft === 'number' ? screenObj.availLeft : 0,
-                y: typeof screenObj.availTop === 'number' ? screenObj.availTop : 0,
-                width: typeof screenObj.availWidth === 'number' ? screenObj.availWidth : (screenObj.width || _managerReadWindowBounds().width),
-                height: typeof screenObj.availHeight === 'number' ? screenObj.availHeight : (screenObj.height || _managerReadWindowBounds().height)
-            };
-        }
-
-        function _managerClampBounds(bounds, workArea) {
-            var next = {
-                x: Math.round(bounds.x),
-                y: Math.round(bounds.y),
-                width: Math.round(bounds.width),
-                height: Math.round(bounds.height)
-            };
-
-            if (!workArea) {
-                return next;
-            }
-
-            var maxRight = workArea.x + workArea.width;
-            var maxBottom = workArea.y + workArea.height;
-            next.x = Math.max(workArea.x, Math.min(next.x, maxRight - next.width));
-            next.y = Math.max(workArea.y, Math.min(next.y, maxBottom - next.height));
-            return next;
-        }
-
-        function _managerGetEventScreenPoint(e) {
-            var point = e.touches ? e.touches[0] : e;
-            return {
-                x: typeof point.screenX === 'number' ? point.screenX : point.clientX,
-                y: typeof point.screenY === 'number' ? point.screenY : point.clientY
-            };
-        }
-
-        function _managerSetWindowBounds(bounds) {
-            if (window.nekoJukeboxWindow && typeof window.nekoJukeboxWindow.setBounds === 'function') {
-                window.nekoJukeboxWindow.setBounds(bounds.x, bounds.y, bounds.width, bounds.height);
-                return;
-            }
-
-            if (typeof window.moveTo === 'function') {
-                window.moveTo(bounds.x, bounds.y);
-            }
-        }
-
-        function _managerCreateRafScheduler(flush) {
-            var rafId = 0;
-            return {
-                queue: function() {
-                    if (rafId) return;
-                    rafId = requestAnimationFrame(function() {
-                        rafId = 0;
-                        flush();
-                    });
-                },
-                cancel: function() {
-                    if (!rafId) return;
-                    cancelAnimationFrame(rafId);
-                    rafId = 0;
-                }
-            };
-        }
-
-        function _managerQueueDragBounds(state, point, scheduler) {
-            if (!state) return;
-
-            state.latestPoint = point;
-            if (!state.startBounds) {
-                return;
-            }
-
-            state.pendingBounds = _managerClampBounds({
-                x: state.startBounds.x + (point.x - state.startPointerX),
-                y: state.startBounds.y + (point.y - state.startPointerY),
-                width: state.startBounds.width,
-                height: state.startBounds.height
-            }, state.workArea);
-            scheduler.queue();
-        }
-
-        function _bindManagerStandaloneDrag(panel) {
-            if (!panel || panel.__nekoManagerStandaloneDragBound) return;
-            panel.__nekoManagerStandaloneDragBound = true;
-
-            var state = null;
-            var scheduler = _managerCreateRafScheduler(function() {
-                if (!state || !state.pendingBounds) return;
-                var pending = state.pendingBounds;
-                state.pendingBounds = null;
-                _managerSetWindowBounds(pending);
-            });
-            var interactiveSelector =
-                'button, input, a, select, textarea, label, [contenteditable="true"], ' +
-                '.sam-tab, .sam-close-btn, .sam-item, .sam-binding-item, .sam-checkbox, ' +
-                '.sam-unbind-btn, .sam-add-binding-btn, .sam-click-add, .sam-file-drop-zone';
-
-            function finishDrag() {
-                if (!state) return;
-
-                if (state.mode === 'pending') {
-                    state.released = true;
-                    document.body.classList.remove('neko-jukebox-manager-standalone-dragging');
-                    return;
-                }
-
-                scheduler.cancel();
-
-                if (state.pendingBounds) {
-                    _managerSetWindowBounds(state.pendingBounds);
-                }
-
-                state = null;
-                document.body.classList.remove('neko-jukebox-manager-standalone-dragging');
-            }
-
-            async function onPointerDown(e) {
-                if (typeof e.button === 'number' && e.button !== 0) return;
-                if (e.target.closest(interactiveSelector)) return;
-
-                e.preventDefault();
-                e.stopPropagation();
-
-                document.body.classList.add('neko-jukebox-manager-standalone-dragging');
-
-                var point = _managerGetEventScreenPoint(e);
-                var token = {};
-                state = {
-                    mode: 'pending',
-                    token: token,
-                    startPointerX: point.x,
-                    startPointerY: point.y,
-                    startBounds: null,
-                    workArea: null,
-                    latestPoint: null,
-                    released: false,
-                    pendingBounds: null
-                };
-
-                var startBounds = _managerReadWindowBounds();
-                var workArea = _managerReadWorkArea();
-
-                var pendingReads = [
-                    Promise.resolve(startBounds),
-                    Promise.resolve(workArea)
-                ];
-
-                if (window.nekoJukeboxWindow && typeof window.nekoJukeboxWindow.getBounds === 'function') {
-                    pendingReads[0] = Promise.resolve(window.nekoJukeboxWindow.getBounds()).catch(function() {
-                        return startBounds;
-                    });
-                }
-
-                if (window.nekoJukeboxWindow && typeof window.nekoJukeboxWindow.getWorkArea === 'function') {
-                    pendingReads[1] = Promise.resolve(window.nekoJukeboxWindow.getWorkArea()).catch(function() {
-                        return workArea;
-                    });
-                }
-
-                var resolved = await Promise.all(pendingReads);
-                startBounds = resolved[0] || startBounds;
-                workArea = resolved[1] || workArea;
-
-                if (!state || state.token !== token) {
-                    return;
-                }
-
-                state.mode = 'manual';
-                state.startBounds = startBounds || _managerReadWindowBounds();
-                state.workArea = workArea || _managerReadWorkArea();
-
-                if (state.latestPoint) {
-                    _managerQueueDragBounds(state, state.latestPoint, scheduler);
-                }
-                if (state.released) {
-                    finishDrag();
-                }
-            }
-
-            function onPointerMove(e) {
-                if (!state || state.released) return;
-                e.preventDefault();
-                _managerQueueDragBounds(state, _managerGetEventScreenPoint(e), scheduler);
-            }
-
-            panel.addEventListener('mousedown', onPointerDown);
-            panel.addEventListener('touchstart', onPointerDown, { passive: false });
-            document.addEventListener('mousemove', onPointerMove);
-            document.addEventListener('touchmove', onPointerMove, { passive: false });
-            document.addEventListener('mouseup', finishDrag);
-            document.addEventListener('touchend', finishDrag);
-            document.addEventListener('touchcancel', finishDrag);
-            window.addEventListener('blur', finishDrag);
-        }
+        // 拖动走 CSS `-webkit-app-region: drag`（OS 原生），不再用 JS mousedown 模拟。
+        // 原因：JS 设 setBounds 会和 Windows 边缘 resize 热区并发，看起来"一拖就变大"。
+        // 原生拖动下 Chromium 返回 HTCAPTION，Windows 直接走窗口移动，绕开 resize 逻辑。
 
         async function _initManager() {
             if (!window.Jukebox || !window.Jukebox.SongActionManager) return;
@@ -268,7 +86,7 @@
             // 创建管理器面板 DOM
             var panel = SAM.create();
             document.body.appendChild(panel);
-            _bindManagerStandaloneDrag(panel);
+            // 拖动由 CSS `-webkit-app-region: drag` 原生接管，无需 JS 绑定。
 
             // 注入管理器样式
             var style = document.createElement('style');

--- a/tests/frontend/test_jukebox_manager_standalone.py
+++ b/tests/frontend/test_jukebox_manager_standalone.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,7 @@ from playwright.sync_api import Page
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MANAGER_TEMPLATE = (REPO_ROOT / "templates" / "jukebox_manager.html").read_text(encoding="utf-8")
 JUKEBOX_SCRIPT = (REPO_ROOT / "static" / "Jukebox.js").read_text(encoding="utf-8")
+JUKEBOX_STANDALONE_SCRIPT = (REPO_ROOT / "static" / "jukebox-standalone.js").read_text(encoding="utf-8")
 
 HARNESS_HTML = """
 <!DOCTYPE html>
@@ -31,15 +33,16 @@ def test_jukebox_manager_standalone_uses_native_drag_regions():
 
     改回 JS 驱动拖动会让这个测试失败。
     """
-    # 面板本体必须声明为 drag 区域
-    assert "-webkit-app-region: drag !important;" in MANAGER_TEMPLATE
+    # 面板本体必须声明为 drag 区域（放宽空白容忍 CSS 格式化工具）
+    assert re.search(r"-webkit-app-region:\s*drag\s*!important", MANAGER_TEMPLATE)
     # 交互元素必须声明为 no-drag，否则点击会被原生拖动吃掉
-    assert ".jukebox-sam-panel button," in MANAGER_TEMPLATE
-    assert ".jukebox-sam-panel .sam-close-btn," in MANAGER_TEMPLATE
-    assert "-webkit-app-region: no-drag !important;" in MANAGER_TEMPLATE
-    # 不应再注册 JS mousedown 拖动（旧实现的标志函数）
-    assert "_bindManagerStandaloneDrag" not in MANAGER_TEMPLATE
-    assert "neko-jukebox-manager-standalone-dragging" not in MANAGER_TEMPLATE
+    assert re.search(r"\.jukebox-sam-panel\s+button\b", MANAGER_TEMPLATE)
+    assert re.search(r"\.jukebox-sam-panel\s+\.sam-close-btn\b", MANAGER_TEMPLATE)
+    assert re.search(r"-webkit-app-region:\s*no-drag\s*!important", MANAGER_TEMPLATE)
+    # 不应再注册 JS mousedown 拖动（旧实现的标志函数）——模板和外部 JS 文件都要拦
+    for source in (MANAGER_TEMPLATE, JUKEBOX_STANDALONE_SCRIPT, JUKEBOX_SCRIPT):
+        assert "_bindManagerStandaloneDrag" not in source
+        assert "neko-jukebox-manager-standalone-dragging" not in source
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_jukebox_manager_standalone.py
+++ b/tests/frontend/test_jukebox_manager_standalone.py
@@ -1,5 +1,3 @@
-import re
-import time
 from pathlib import Path
 
 import pytest
@@ -8,10 +6,6 @@ from playwright.sync_api import Page
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MANAGER_TEMPLATE = (REPO_ROOT / "templates" / "jukebox_manager.html").read_text(encoding="utf-8")
-INLINE_SCRIPTS = re.findall(r"<script\b(?![^>]*\bsrc=)[^>]*>(.*?)</script>", MANAGER_TEMPLATE, flags=re.S)
-MANAGER_SCRIPT = next((script for script in INLINE_SCRIPTS if "_bindManagerStandaloneDrag" in script), None)
-if MANAGER_SCRIPT is None:
-    raise RuntimeError("manager template missing inline script containing '_bindManagerStandaloneDrag'")
 JUKEBOX_SCRIPT = (REPO_ROOT / "static" / "Jukebox.js").read_text(encoding="utf-8")
 
 HARNESS_HTML = """
@@ -28,200 +22,24 @@ HARNESS_HTML = """
 """
 
 
-def _bootstrap_manager_page(page: Page) -> None:
-    page.set_viewport_size({"width": 900, "height": 700})
-    page.set_content(HARNESS_HTML)
-    page.evaluate(
-        """
-        () => {
-          window.t = (key, fallback) => typeof fallback === 'string' ? fallback : key;
-          window.i18n = { isInitialized: true };
-          window.__managerLog = [];
-          window.__closeClicks = 0;
-          window.__bounds = { x: 100, y: 120, width: 640, height: 520 };
-          window.nekoJukeboxWindow = {
-            getBounds() {
-              return new Promise((resolve) => {
-                setTimeout(() => resolve({ ...window.__bounds }), 80);
-              });
-            },
-            getWorkArea() {
-              return new Promise((resolve) => {
-                setTimeout(() => resolve({ x: 0, y: 0, width: 1920, height: 1080 }), 80);
-              });
-            },
-            setBounds(x, y, width, height) {
-              window.__bounds = { x, y, width, height };
-              window.__managerLog.push(['setBounds', x, y, width, height]);
-            }
-          };
-
-          window.Jukebox = {
-            SongActionManager: {
-              create() {
-                const panel = document.createElement('div');
-                panel.className = 'jukebox-sam-panel';
-                panel.innerHTML = `
-                  <div class="sam-header">
-                    <div class="sam-title">Manager</div>
-                    <div class="sam-tabs">
-                      <button class="sam-tab active" type="button">Songs</button>
-                    </div>
-                    <button class="sam-close-btn" id="closeBtn" type="button">×</button>
-                  </div>
-                  <div class="sam-content">
-                    <div class="sam-panel active">
-                      <div class="sam-gap" id="contentGap"></div>
-                      <div class="sam-item" id="songItem">
-                        <button id="itemBtn" type="button">Action</button>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="sam-footer">
-                    <span class="sam-selection-info">Info</span>
-                    <span class="sam-click-add" id="clickAdd">+ Add</span>
-                  </div>
-                `;
-
-                panel.querySelector('#closeBtn').addEventListener('click', () => {
-                  window.__closeClicks += 1;
-                });
-
-                this.element = panel;
-                return panel;
-              },
-              getStyles() {
-                return `
-                  .jukebox-sam-panel {
-                    position: fixed;
-                    inset: 0;
-                    display: flex;
-                    flex-direction: column;
-                    box-sizing: border-box;
-                    padding: 16px;
-                    background: rgba(20, 20, 20, 0.96);
-                    color: #fff;
-                  }
-                  .sam-header {
-                    height: 52px;
-                    display: flex;
-                    align-items: center;
-                    gap: 12px;
-                    flex-shrink: 0;
-                  }
-                  .sam-tabs {
-                    flex: 1;
-                    display: flex;
-                    justify-content: center;
-                  }
-                  .sam-content {
-                    flex: 1;
-                    min-height: 0;
-                    padding: 12px 0;
-                  }
-                  .sam-panel.active {
-                    display: block;
-                    height: 100%;
-                  }
-                  .sam-gap {
-                    height: 180px;
-                    margin-bottom: 12px;
-                    border-radius: 8px;
-                    background: rgba(255, 255, 255, 0.06);
-                  }
-                  .sam-item {
-                    padding: 12px;
-                    border-radius: 8px;
-                    background: rgba(255, 255, 255, 0.14);
-                  }
-                  .sam-footer {
-                    height: 60px;
-                    display: flex;
-                    align-items: center;
-                    justify-content: space-between;
-                    flex-shrink: 0;
-                  }
-                `;
-              },
-              hide() {}
-            }
-          };
-        }
-        """
-    )
-    page.add_script_tag(content=MANAGER_SCRIPT)
-    page.evaluate("_tryInitManager()")
-    page.wait_for_selector(".jukebox-sam-panel")
-
-
-def _wait_for_manager_drag_log(page: Page, timeout: float = 1.0, interval: float = 0.02):
-    deadline = time.monotonic() + timeout
-    drag_log = []
-
-    while time.monotonic() < deadline:
-        drag_log = page.evaluate("window.__managerLog")
-        if any(entry[0] == "setBounds" and (entry[1] != 100 or entry[2] != 120) for entry in drag_log):
-            return drag_log
-        time.sleep(interval)
-
-    return drag_log
-
-
 @pytest.mark.frontend
-def test_jukebox_manager_standalone_fast_drag_survives_async_bounds(mock_page: Page):
-    _bootstrap_manager_page(mock_page)
+def test_jukebox_manager_standalone_uses_native_drag_regions():
+    """
+    回归保护：管理器的拖动必须走 CSS `-webkit-app-region: drag`（OS 原生 HTCAPTION），
+    而不是 JS mousedown + setBounds。历史 bug：JS 设 setBounds 会和 Windows 边缘
+    WS_THICKFRAME resize 热区并发触发，表现为"拖一下窗口变大一下"。
 
-    gap = mock_page.locator("#contentGap").bounding_box()
-    assert gap is not None
-
-    mock_page.mouse.move(gap["x"] + 24, gap["y"] + 24)
-    mock_page.mouse.down()
-    mock_page.mouse.move(gap["x"] + 180, gap["y"] + 120)
-    mock_page.mouse.up()
-
-    body_class = mock_page.locator("body").get_attribute("class") or ""
-    assert "neko-jukebox-manager-standalone-dragging" not in body_class
-
-    drag_log = _wait_for_manager_drag_log(mock_page)
-    assert any(entry[0] == "setBounds" and (entry[1] != 100 or entry[2] != 120) for entry in drag_log)
-
-    body_class = mock_page.locator("body").get_attribute("class") or ""
-    assert "neko-jukebox-manager-standalone-dragging" not in body_class
-
-    mock_page.evaluate("window.__managerLog = []")
-    mock_page.click("#closeBtn")
-    assert mock_page.evaluate("window.__closeClicks") == 1
-    assert mock_page.evaluate("window.__managerLog") == []
-
-
-@pytest.mark.frontend
-def test_jukebox_manager_standalone_ignores_post_release_pointer_moves(mock_page: Page):
-    _bootstrap_manager_page(mock_page)
-
-    gap = mock_page.locator("#contentGap").bounding_box()
-    assert gap is not None
-
-    start_x = gap["x"] + 24
-    start_y = gap["y"] + 24
-    release_x = gap["x"] + 180
-    release_y = gap["y"] + 120
-    after_release_x = gap["x"] + 320
-    after_release_y = gap["y"] + 220
-
-    expected_x = 100 + int(release_x - start_x)
-    expected_y = 120 + int(release_y - start_y)
-
-    mock_page.mouse.move(start_x, start_y)
-    mock_page.mouse.down()
-    mock_page.mouse.move(release_x, release_y)
-    mock_page.mouse.up()
-    mock_page.mouse.move(after_release_x, after_release_y)
-
-    _wait_for_manager_drag_log(mock_page)
-
-    final_bounds = mock_page.evaluate("window.__bounds")
-    assert final_bounds["x"] == expected_x
-    assert final_bounds["y"] == expected_y
+    改回 JS 驱动拖动会让这个测试失败。
+    """
+    # 面板本体必须声明为 drag 区域
+    assert "-webkit-app-region: drag !important;" in MANAGER_TEMPLATE
+    # 交互元素必须声明为 no-drag，否则点击会被原生拖动吃掉
+    assert ".jukebox-sam-panel button," in MANAGER_TEMPLATE
+    assert ".jukebox-sam-panel .sam-close-btn," in MANAGER_TEMPLATE
+    assert "-webkit-app-region: no-drag !important;" in MANAGER_TEMPLATE
+    # 不应再注册 JS mousedown 拖动（旧实现的标志函数）
+    assert "_bindManagerStandaloneDrag" not in MANAGER_TEMPLATE
+    assert "neko-jukebox-manager-standalone-dragging" not in MANAGER_TEMPLATE
 
 
 @pytest.mark.frontend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 管理器面板改为使用操作系统原生拖拽，提升拖拽稳定性与响应性；同时确保按钮/输入等交互元素保持可点击。

* **Tests**
  * 移除基于脚本模拟的拖拽行为测试，改为基于模板的静态断言以校验原生拖拽与交互排除规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->