### PR TITLE
fix: replace 3s setTimeout with LoadingManager.onLoad for MMD texture fallback

### DIFF
--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -394,9 +394,23 @@ class MMDCore {
         // 自定义 LoadingManager: 追踪加载失败的纹理 URL
         const loadManager = new THREE.LoadingManager();
         loadManager._failedUrls = [];
+        loadManager._allResourcesLoaded = false;
         loadManager.onError = (url) => {
             console.warn(`[MMD Core] 资源加载失败: ${url}`);
             loadManager._failedUrls.push(url);
+        };
+        // 所有资源（含失败的）加载完成后，检查并修复缺失纹理
+        loadManager.onLoad = () => {
+            loadManager._allResourcesLoaded = true;
+            console.log('[MMD Core] 所有资源加载完成，检查纹理状态');
+            if (this.manager.currentModel) {
+                // 清除兜底定时器
+                if (this._fixMissingTexturesTimer) {
+                    clearTimeout(this._fixMissingTexturesTimer);
+                    this._fixMissingTexturesTimer = null;
+                }
+                this._fixMissingTextures(this.manager.currentModel);
+            }
         };
         this.manager._loadManager = loadManager;
 
@@ -565,8 +579,16 @@ class MMDCore {
         }
         console.log(`[MMD Core] 材质后处理完成: ${materialCount} 个材质`);
 
-        // 延迟检查纹理加载状态，为加载失败的纹理提供白色 fallback
-        setTimeout(() => this._fixMissingTextures(mmd), 3000);
+        // 兜底：如果 LoadingManager.onLoad 30 秒内未触发，强制检查纹理状态
+        // （正常情况下 onLoad 会在所有资源加载完后触发，此定时器仅防极端情况）
+        this._fixMissingTexturesTimer = setTimeout(() => {
+            this._fixMissingTexturesTimer = null;
+            const loadManager = this.manager._loadManager;
+            if (loadManager && !loadManager._allResourcesLoaded) {
+                console.warn('[MMD Core] 纹理加载兜底超时（30s），强制检查纹理状态');
+                this._fixMissingTextures(mmd);
+            }
+        }, 30000);
     }
 
     /**
@@ -787,6 +809,12 @@ class MMDCore {
     _clearModel() {
         const mmd = this.manager.currentModel;
         if (!mmd) return;
+
+        // 清理纹理修复兜底定时器
+        if (this._fixMissingTexturesTimer) {
+            clearTimeout(this._fixMissingTexturesTimer);
+            this._fixMissingTexturesTimer = null;
+        }
 
         // 停止动画
         if (this.manager.animationModule) {

--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -807,14 +807,14 @@ class MMDCore {
     // ═══════════════════ 模型清理 ═══════════════════
 
     _clearModel() {
-        const mmd = this.manager.currentModel;
-        if (!mmd) return;
-
-        // 清理纹理修复兜底定时器
+        // 清理纹理修复兜底定时器（必须在早退之前，防止 currentModel 被外部提前置空时 timer 泄漏）
         if (this._fixMissingTexturesTimer) {
             clearTimeout(this._fixMissingTexturesTimer);
             this._fixMissingTexturesTimer = null;
         }
+
+        const mmd = this.manager.currentModel;
+        if (!mmd) return;
 
         // 停止动画
         if (this.manager.animationModule) {

--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -400,16 +400,18 @@ class MMDCore {
             loadManager._failedUrls.push(url);
         };
         // 所有资源（含失败的）加载完成后，检查并修复缺失纹理
+        // 使用 _pendingMmd 捕获模型引用，避免 onLoad 在 currentModel 赋值前触发时跳过检查
+        this._pendingMmd = null;
         loadManager.onLoad = () => {
             loadManager._allResourcesLoaded = true;
             console.log('[MMD Core] 所有资源加载完成，检查纹理状态');
-            if (this.manager.currentModel) {
-                // 清除兜底定时器
+            const mmd = this._pendingMmd || this.manager.currentModel;
+            if (mmd) {
                 if (this._fixMissingTexturesTimer) {
                     clearTimeout(this._fixMissingTexturesTimer);
                     this._fixMissingTexturesTimer = null;
                 }
-                this._fixMissingTextures(this.manager.currentModel);
+                this._fixMissingTextures(mmd);
             }
         };
         this.manager._loadManager = loadManager;
@@ -430,7 +432,10 @@ class MMDCore {
             const mmd = await new Promise((resolve, reject) => {
                 loader.load(
                     modelUrl,
-                    (mmd) => resolve(mmd),
+                    (mmd) => {
+                        this._pendingMmd = mmd;
+                        resolve(mmd);
+                    },
                     (progress) => {
                         this._updateLoadingOverlay(
                             loadingSessionId,


### PR DESCRIPTION
## Summary

Replaces the fixed 3-second `setTimeout` in `_fixMissingTextures` with `LoadingManager.onLoad`, which fires after all resources (including failed ones) have finished loading.

### Problem
When textures take longer than 3 seconds to load (slow network, large files), `_fixMissingTextures` runs too early and replaces still-loading textures with white fallback. Once replaced, the original textures never recover even after they finish loading — the model stays permanently white.

### Fix
- Register `loadManager.onLoad` callback at `LoadingManager` creation time (before model loading starts), so it fires regardless of when textures finish loading
- `_fixMissingTextures` now runs only after all resources are done, making `tex.version === 0 && source.data == null` a reliable indicator of actual failure
- 30-second fallback `setTimeout` for extreme edge cases where `onLoad` never fires
- Clean up fallback timer in `_clearModel` to prevent stale timers on model switch

### Why `onLoad` instead of `onError`?
`onError` fires per-texture on 404, but the texture object may not be fully wired into the material at that point. `onLoad` fires after everything is settled, making the existing `_fixMissingTextures` check reliable without needing to correlate `_failedUrls` with material texture references.

## Changed files
- `static/mmd-core.js` — `loadModel` (onLoad registration), `_postProcessMaterials` (3s→30s fallback), `_clearModel` (timer cleanup)

## Test plan
- Reproduced by injecting 5-second delay in `CustomStaticFiles.get_response` for image files
- **Old code (3s setTimeout)**: All 16 textures incorrectly replaced with white fallback at 3s, model stayed permanently white even after textures loaded at 5s
- **New code (onLoad)**: `onLoad` fired correctly after 5s delay, all 16 textures loaded normally, no false positives


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 将缺失纹理的处理改为基于资源加载完成状态，资源就绪后立即修复
  * 在罕见未触发完成事件的情况下新增更长的备用超时以触发回退处理
  * 加强加载时对目标模型的捕获以确保修复在正确模型上执行
  * 模型卸载时立即清除挂起的回退计时器，避免已卸载模型触发延迟处理
<!-- end of auto-generated comment: release notes by coderabbit.ai -->