### PR TITLE
refactor(memory-server): 复用内部 HTTP 单例 + startup 兜底 cloudsave bootstrap

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -414,14 +414,18 @@ async def notify_memory_server_reload(*, reason: str = "") -> bool:
 
 async def release_memory_server_character(character_name: str, *, reason: str = "") -> bool:
     from urllib.parse import quote
+    from utils.internal_http_client import get_internal_http_client
 
     try:
         encoded_name = quote(character_name, safe="")
-        async with httpx.AsyncClient(proxy=None, trust_env=False) as client:
-            response = await client.post(
-                f"http://127.0.0.1:{MEMORY_SERVER_PORT}/release_character/{encoded_name}",
-                timeout=5.0,
-            )
+        # 复用进程级单例避免 per-call SSLContext 冷启动（实测 ~1.1s/次）。
+        # 单例在 on_shutdown 末尾由 aclose_internal_http_client 统一关闭，
+        # release/upload 阶段之前都可安全共享；无需 async with。
+        client = get_internal_http_client()
+        response = await client.post(
+            f"http://127.0.0.1:{MEMORY_SERVER_PORT}/release_character/{encoded_name}",
+            timeout=5.0,
+        )
         if response.status_code != 200:
             logger.warning(
                 "⚠️ 释放记忆服务器角色句柄失败，status=%s, character=%s, reason=%s",

--- a/memory_server.py
+++ b/memory_server.py
@@ -76,8 +76,10 @@ def validate_lanlan_name(name: str) -> str:
     return result.normalized
 
 # 初始化组件（迁移必须在实例化之前，否则旧路径文件找不到）
+# bootstrap_local_cloudsave_environment 移到 startup 钩子执行：该函数在磁盘满/
+# 权限不足/只读 FS 等场景会 raise OSError，以前裸调会让整个模块 import 失败，
+# FastAPI 根本起不来；改为 startup 钩子里 try/except 降级为警告日志后继续。
 _config_manager = get_config_manager()
-bootstrap_local_cloudsave_environment(_config_manager)
 try:
     from memory import migrate_to_character_dirs
     _config_manager.ensure_memory_directory()
@@ -586,6 +588,15 @@ async def _periodic_idle_maintenance_loop():
 @app.on_event("startup")
 async def startup_event_handler():
     """应用启动时初始化"""
+    # 先 bootstrap cloudsave 目录结构：磁盘满/只读 FS 等场景会 raise OSError，
+    # 降级为 warning 后继续（对应的 set_root_mode(NORMAL) 只在 bootstrap 成功时写入）
+    bootstrap_ok = False
+    try:
+        bootstrap_local_cloudsave_environment(_config_manager)
+        bootstrap_ok = True
+    except Exception as e:
+        logger.warning(f"[Memory] cloudsave 环境 bootstrap 失败，后续 cloudsave 相关操作可能降级: {e}")
+
     try:
         from utils.token_tracker import TokenTracker, install_hooks
         install_hooks()
@@ -620,16 +631,19 @@ async def startup_event_handler():
     except Exception as e:
         logger.warning(f"[Memory] Persona 迁移检查失败: {e}")
 
-    try:
-        set_root_mode(
-            _config_manager,
-            ROOT_MODE_NORMAL,
-            current_root=str(_config_manager.app_docs_dir),
-            last_known_good_root=str(_config_manager.app_docs_dir),
-            last_successful_boot_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-        )
-    except Exception as e:
-        logger.warning(f"[Memory] 写入启动成功标记失败: {e}")
+    if bootstrap_ok:
+        try:
+            set_root_mode(
+                _config_manager,
+                ROOT_MODE_NORMAL,
+                current_root=str(_config_manager.app_docs_dir),
+                last_known_good_root=str(_config_manager.app_docs_dir),
+                last_successful_boot_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            )
+        except Exception as e:
+            logger.warning(f"[Memory] 写入启动成功标记失败: {e}")
+    else:
+        logger.warning("[Memory] 跳过 ROOT_MODE_NORMAL 写入：cloudsave bootstrap 未成功")
 
     # 启动定期后台任务
     _spawn_background_task(_periodic_rebuttal_loop())

--- a/memory_server.py
+++ b/memory_server.py
@@ -606,7 +606,6 @@ async def startup_event_handler():
         _char_data = await _config_manager.aload_characters()
         _catgirl_names = list(_char_data.get('猫娘', {}).keys())
         await asyncio.to_thread(migrate_to_character_dirs, _config_manager.memory_dir, _catgirl_names)
-        del _char_data, _catgirl_names
     except Exception as _e:
         logger.warning(f"[Memory] 目录迁移失败: {_e}")
 

--- a/memory_server.py
+++ b/memory_server.py
@@ -75,27 +75,23 @@ def validate_lanlan_name(name: str) -> str:
         raise HTTPException(status_code=400, detail="Invalid characters in lanlan_name")
     return result.normalized
 
-# 初始化组件（迁移必须在实例化之前，否则旧路径文件找不到）
-# bootstrap_local_cloudsave_environment 移到 startup 钩子执行：该函数在磁盘满/
-# 权限不足/只读 FS 等场景会 raise OSError，以前裸调会让整个模块 import 失败，
-# FastAPI 根本起不来；改为 startup 钩子里 try/except 降级为警告日志后继续。
+# 所有依赖 cloudsave 目录结构的初始化都推迟到 startup 钩子（见 startup_event_handler）：
+#   1. bootstrap_local_cloudsave_environment 在磁盘满/只读 FS 等场景会 raise OSError，
+#      裸调会让 module import 阶段就崩，FastAPI 根本起不来；
+#   2. bootstrap 内部的 import_legacy_runtime_root_if_needed 可能把 legacy 扁平布局的
+#      memory/{type}_{name}.ext 文件带进 target root，必须在 migrate_to_character_dirs
+#      之前跑（不然 legacy 数据留在扁平布局、components 只认 per-character 布局，数据不可达）；
+#   3. 因此 bootstrap → migrate → 组件实例化 三步必须保持顺序且都放在 startup 里。
+# Components 先声明为 None，startup hook 赋值。FastAPI 在 startup 钩子 await 完成后
+# 才开始接请求，所以 route handler 不会看到 None。
 _config_manager = get_config_manager()
-try:
-    from memory import migrate_to_character_dirs
-    _config_manager.ensure_memory_directory()
-    _char_data = _config_manager.load_characters()
-    _catgirl_names = list(_char_data.get('猫娘', {}).keys())
-    migrate_to_character_dirs(_config_manager.memory_dir, _catgirl_names)
-    del _char_data, _catgirl_names
-except Exception as _e:
-    logger.warning(f"[Memory] 模块级目录迁移失败: {_e}")
 
-recent_history_manager = CompressedRecentHistoryManager()
-settings_manager = ImportantSettingsManager()  # 保留兼容，逐步迁移
-time_manager = TimeIndexedMemory(recent_history_manager)
-fact_store = FactStore(time_indexed_memory=time_manager)
-persona_manager = PersonaManager()
-reflection_engine = ReflectionEngine(fact_store, persona_manager)
+recent_history_manager: CompressedRecentHistoryManager | None = None
+settings_manager: ImportantSettingsManager | None = None
+time_manager: TimeIndexedMemory | None = None
+fact_store: FactStore | None = None
+persona_manager: PersonaManager | None = None
+reflection_engine: ReflectionEngine | None = None
 
 # 用于保护重新加载操作的锁
 _reload_lock = asyncio.Lock()
@@ -588,14 +584,39 @@ async def _periodic_idle_maintenance_loop():
 @app.on_event("startup")
 async def startup_event_handler():
     """应用启动时初始化"""
-    # 先 bootstrap cloudsave 目录结构：磁盘满/只读 FS 等场景会 raise OSError，
-    # 降级为 warning 后继续（对应的 set_root_mode(NORMAL) 只在 bootstrap 成功时写入）
+    global recent_history_manager, settings_manager, time_manager, fact_store, persona_manager, reflection_engine
+
+    # ── 步骤 1：bootstrap cloudsave 目录 ──────────────────────────
+    # 磁盘满/只读 FS 等场景会 raise OSError；降级为 warning 后继续，
+    # set_root_mode(NORMAL) 只在 bootstrap 成功时写入。bootstrap 内部的
+    # import_legacy_runtime_root_if_needed 可能把 legacy 扁平布局文件带进 target root，
+    # 所以 migrate 必须在 bootstrap 之后运行。
     bootstrap_ok = False
     try:
         bootstrap_local_cloudsave_environment(_config_manager)
         bootstrap_ok = True
     except Exception as e:
         logger.warning(f"[Memory] cloudsave 环境 bootstrap 失败，后续 cloudsave 相关操作可能降级: {e}")
+
+    # ── 步骤 2：目录结构迁移 ───────────────────────────────────
+    # 必须在 bootstrap 之后（拿到可能的 legacy 扁平文件）、组件实例化之前（组件只读 per-character 路径）。
+    try:
+        from memory import migrate_to_character_dirs
+        _config_manager.ensure_memory_directory()
+        _char_data = await _config_manager.aload_characters()
+        _catgirl_names = list(_char_data.get('猫娘', {}).keys())
+        await asyncio.to_thread(migrate_to_character_dirs, _config_manager.memory_dir, _catgirl_names)
+        del _char_data, _catgirl_names
+    except Exception as _e:
+        logger.warning(f"[Memory] 目录迁移失败: {_e}")
+
+    # ── 步骤 3：组件实例化 ──────────────────────────────────
+    recent_history_manager = CompressedRecentHistoryManager()
+    settings_manager = ImportantSettingsManager()  # 保留兼容，逐步迁移
+    time_manager = TimeIndexedMemory(recent_history_manager)
+    fact_store = FactStore(time_indexed_memory=time_manager)
+    persona_manager = PersonaManager()
+    reflection_engine = ReflectionEngine(fact_store, persona_manager)
 
     try:
         from utils.token_tracker import TokenTracker, install_hooks
@@ -666,7 +687,8 @@ async def shutdown_event_handler():
     async with _reload_lock:
         managers_to_cleanup.extend(_deferred_time_managers)
         _deferred_time_managers.clear()
-        if all(existing is not time_manager for existing in managers_to_cleanup):
+        # time_manager 在 startup 钩子里才实例化；若启动过程中就触发 shutdown 可能为 None
+        if time_manager is not None and all(existing is not time_manager for existing in managers_to_cleanup):
             managers_to_cleanup.append(time_manager)
     for manager in managers_to_cleanup:
         try:


### PR DESCRIPTION
## Summary

PR #681 的两个 follow-up，合并在同一个 PR 里。

### 1. `release_memory_server_character` 复用 internal_http_client 单例

- 位置：`main_routers/characters_router.py:415`
- 问题：`on_shutdown` 现在会并发 release N 个角色句柄（3s 总预算），原实现每次 `async with httpx.AsyncClient(proxy=None, trust_env=False)` 都会 eager 初始化 SSLContext，冷启动下实测 ~1.1s/次（见 `utils/internal_http_client.py` 模块 docstring），N 个并发创建有把 3s 预算挤爆的风险。
- 修改：改用 `get_internal_http_client()` 进程级单例。单例本身显式 `proxy=None / trust_env=False / verify=False`，安全语义等价（localhost 纯 http，无代理绕行风险）。
- 生命周期：不用 `async with`——单例由 `on_shutdown` 末尾的 `aclose_internal_http_client()` 统一关闭，release/upload 阶段之前都可安全共享。`_request_memory_server_shutdown()` 仍保留 per-call（它和 aclose 之间没别的用户）。

### 2. `bootstrap_local_cloudsave_environment` 从模块顶层移到 `@app.on_event("startup")`

- 位置：`memory_server.py:80`（原裸调点）
- 问题：该函数在磁盘满 / 权限不足 / 只读 FS 等场景会 `raise OSError("failed to ensure cloudsave directory structure")`，原来在模块顶层裸调会让整个 module import 阶段崩溃，FastAPI 根本起不来，用户只看到一坨 traceback。参考 `main_server.py:1233` 已经把同一个 bootstrap 放在了 startup 钩子里。
- 修改：移到 `startup_event_handler` 里 try/except，失败降级为 warning 日志后继续。
- gating：`set_root_mode(ROOT_MODE_NORMAL)` 用局部 `bootstrap_ok` flag 门控。移出模块级后 Python import 语义提供的隐式 gating 消失，需要显式标志，避免把失败冷启动记为"上次成功"。
- 未动：模块级 `migrate_to_character_dirs` 块保留在原位——组件实例化之前必须完成目录迁移（否则旧路径文件找不到，引发数据丢失）这条约束未变。

## Test plan

- [x] `uv run python scripts/check_async_blocking.py` — exit 0，clean
- [x] `uv run pytest tests/unit/test_cloudsave_*.py tests/unit/test_character_memory_regression.py` — 208 passed
- [x] 特别确认：`test_main_server_shutdown_releases_live_sessions_then_uploads_existing_snapshot` mock 了 `release_memory_server_character` 本身，底层改动不影响 mock
- [ ] 手动验证：模拟 `ensure_cloudsave_structure` 失败，确认 memory_server 仍能起来（仅后续 cloudsave 操作报警告）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 版本更新说明

* **Bug Fixes / 改进**
  * 启动流程更具容错性，初始化失败不再阻塞服务启动。
  * 将依赖云存储的初始化延后至启动阶段，按需设置全局管理器实例。
  * 目录迁移改为后台线程执行并记录失败警告，减少阻塞风险。
  * 启用对内部 HTTP 客户端的复用以优化请求资源管理并提高可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->