### PR TITLE
fix(autostart-prompt): 同步 shell 端 autostart 状态事件到 prompt 缓存

### DIFF
--- a/static/app-autostart-prompt.js
+++ b/static/app-autostart-prompt.js
@@ -241,7 +241,18 @@
             return Promise.resolve(unsupported);
         }
 
+        const requestIssuedAt = Date.now();
         const request = provider.getStatus().then(function (response) {
+            // shell 事件 (neko:autostart-status-changed) 可能在 IPC 期间把
+            // state.autostartStatusUpdatedAt 推进到 requestIssuedAt 之后。
+            // 这时该响应相对 shell 快照已经过期，直接丢弃避免把旧 enabled 回写覆盖新状态。
+            if (requestIssuedAt < state.autostartStatusUpdatedAt) {
+                logFlow('autostart-status', {
+                    source: requestOptions.source || 'unknown',
+                    droppedAsStale: true,
+                });
+                return buildAutostartCapabilitySnapshot();
+            }
             applyAutostartCapabilityState(response);
             logFlow('autostart-status', {
                 source: requestOptions.source || 'unknown',

--- a/static/app-autostart-prompt.js
+++ b/static/app-autostart-prompt.js
@@ -139,6 +139,33 @@
         state.autostartStatusUpdatedAt = Date.now();
     }
 
+    let autostartChangedListenerInstalled = false;
+
+    function handleAutostartStatusChanged(event) {
+        const detail = event && event.detail;
+        if (
+            detail
+            && typeof detail === 'object'
+            && 'enabled' in detail
+            && 'supported' in detail
+            && 'provider' in detail
+        ) {
+            applyAutostartCapabilityState(detail);
+            logFlow('autostart-status', {
+                source: 'shell-event',
+                provider: detail.provider,
+                authoritative: !!detail.authoritative,
+                supported: state.autostartSupported,
+                enabled: state.autostartEnabled,
+                platform: detail.platform,
+                mechanism: detail.mechanism,
+            });
+            return;
+        }
+        // detail 不完整：仅清零时间戳，下一次 ensureAutostartStatusFresh 会重新 poll。
+        state.autostartStatusUpdatedAt = 0;
+    }
+
     async function postDecision(payload) {
         try {
             const response = await requestJson('/api/autostart-prompt/decision', {
@@ -600,6 +627,11 @@
             });
             scheduleFastHeartbeat();
         });
+
+        if (!autostartChangedListenerInstalled) {
+            autostartChangedListenerInstalled = true;
+            window.addEventListener('neko:autostart-status-changed', handleAutostartStatusChanged);
+        }
 
         window.addEventListener('beforeunload', syncForegroundWindow);
     }


### PR DESCRIPTION
## Summary
- lanlan_frd PR #32 起主进程会在托盘切换开机自启后经 preload 广播 `neko:autostart-status-changed`，但 prompt 层（`static/app-autostart-prompt.js`）没订阅，导致 `AUTOSTART_STATUS_MAX_AGE_MS = 15s` 缓存窗口内 `ensureAutostartStatusFresh` 返回旧快照，heartbeat / prompt 判定会跑偏
- 在 `bindEvents` 里挂 listener（模块级哨兵防重复）：`event.detail` 含 `enabled` / `supported` / `provider` 时复用既有 `applyAutostartCapabilityState` 刷新缓存及 `autostartStatusUpdatedAt`，让 `isAutostartStatusFresh` 立刻判定为 fresh；detail 不完整时仅清零时间戳，下一次判定触发 poll
- 保持 `static/app-autostart-provider.js` 不动（PR #684 起 provider 刻意只做薄桥），不新增 `window.nekoAutostart` 引用

## Test plan
- [x] `tests/unit/test_autostart_provider.py` 本地 2 passed
- [ ] 既有 `tests/frontend/test_home_prompt_flow.py::test_desktop_autostart_status_event_syncs_prompt_heartbeat_state` 已覆盖本改动预期行为（dispatch event → 下一次 heartbeat body 含 `autostart_enabled: true` / `autostart_provider: 'neko-pc'` / `autostart_status_authoritative: true`）；本地 playwright 环境在 `TutorialPrompt prompt helpers unavailable` 处 30s 超时，**与本 diff 无关**（stash 后行为相同）—— 需在 CI 上跑
- [ ] 手测：Electron 壳层托盘切换自启动 → prompt 层不再在 15s 窗口里发旧 `autostart_enabled: false` 快照

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 增加对来自系统的自启动状态变更事件的处理，应用可实时采纳外部状态更新，减少轮询。
* **修复**
  * 防止过时响应覆盖已更新的状态：当检测到到达的状态信息已被更新时，会丢弃过时响应并保持当前快照，避免状态回退或闪烁。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->