### PR TITLE
feat(tts): 首 N 字日语假名检测扩展到 Qwen/Step/lanlan 免费 TTS

### DIFF
--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -838,7 +838,10 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     }))
                     _record_tts_telemetry("stepfun", pending_text_buffer)
                 except Exception as e:
+                    # delta 发失败时连接多半已断，调用方不能继续发 tts.text.done；
+                    # 返回 False 让 sid=None/文本发送路径都走 continue 触发重连。
                     logger.error(f"刷出缓冲文本失败: {e}")
+                    return False
             pending_text_buffer = ""
             return True
         
@@ -1004,7 +1007,10 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     if ws and session_id and current_speech_id is not None and not text_done_sent:
                         # 若缓冲中还有不足 MIN_CHARS 的文本，强制刷出以保证短句也能合成
                         if not session_created:
-                            await _flush_deferred_create(force=True)
+                            if not await _flush_deferred_create(force=True):
+                                # flush 失败（tts.create 或 delta 发失败），连接已死，
+                                # 跳过 tts.text.done，等待下一个 speech_id 触发重连
+                                continue
                         try:
                             done_event = {
                                 "type": "tts.text.done",
@@ -1273,7 +1279,10 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     }))
                     _record_tts_telemetry("qwen", pending_text_buffer)
                 except Exception as e:
+                    # append 发失败时连接多半已断，调用方不能继续发 commit；
+                    # 返回 False 让 sid=None/文本路径走 continue 触发重连。
                     logger.error(f"发送缓冲文本失败: {e}")
+                    return False
             pending_text_buffer = ""
             return True
 
@@ -1413,7 +1422,10 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     if ws and current_speech_id is not None:
                         # 若此轮文本不足 MIN_CHARS 还没发出 session.update，force 一次
                         if not session_configured:
-                            await _flush_deferred_config(force=True)
+                            if not await _flush_deferred_config(force=True):
+                                # flush 失败（session.update 或 append 发失败），连接已死，
+                                # 跳过 commit，等待下一个 speech_id 触发重连
+                                continue
                         # 短句场景下 session.updated 可能比 _flush 内的 2s 等待更晚到达；
                         # 不再依赖 session_ready，直接发 commit（服务端会在 session.updated
                         # 就绪后按顺序处理 append + commit）。漏 commit 会导致短句静默丢失。

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -802,9 +802,11 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
             if is_lanlan_app:
                 data["voice_id"] = "Leda"
                 data["language_code"] = "ja-JP" if lang_hint == "ja" else _get_tts_language_code()
-            else:
+            elif free_mode:
+                # lanlan.tech：voice_label 方案已经通过 probe 实测验证
                 if lang_hint == "ja":
                     data["voice_label"] = {"language": "日语"}
+            # 自建 StepFun（free_mode=False）不挂任何语言字段，完全交由服务端识别
             return data
 
         async def _flush_deferred_create(force: bool = False) -> bool:
@@ -1414,7 +1416,10 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         # 若此轮文本不足 MIN_CHARS 还没发出 session.update，force 一次
                         if not session_configured:
                             await _flush_deferred_config(force=True)
-                        if session_ready.is_set() and not buffer_committed:
+                        # 短句场景下 session.updated 可能比 _flush 内的 2s 等待更晚到达；
+                        # 不再依赖 session_ready，直接发 commit（服务端会在 session.updated
+                        # 就绪后按顺序处理 append + commit）。漏 commit 会导致短句静默丢失。
+                        if not buffer_committed:
                             try:
                                 await ws.send(json.dumps({
                                     "type": "input_text_buffer.commit",

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -764,10 +764,13 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
     
     async def async_worker():
         """异步TTS worker主循环"""
+        from utils.language_utils import detect_tts_language_hint, TTS_LANG_DETECT_MIN_CHARS
+
         if free_mode:
             tts_url = _adjust_free_tts_url("wss://www.lanlan.tech/tts")
         else:
             tts_url = "wss://api.stepfun.com/v1/realtime/audio?model=step-tts-2"
+        is_lanlan_app = 'lanlan.app' in tts_url
         ws = None
         current_speech_id = None
         receive_task = None
@@ -775,8 +778,69 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         session_ready = asyncio.Event()
         response_done = asyncio.Event()  # 用于标记当前响应是否完成
         text_done_sent = False  # 防止同一轮次重复发送 tts.text.done
+        # 延迟 tts.create：等收到 TTS_LANG_DETECT_MIN_CHARS 个字符、检测完
+        # 语言后再发送 tts.create（lanlan.tech 的 voice_label.language /
+        # lanlan.app 的 language_code 都只能在建 session 时指定一次，
+        # 所以必须在首批文本到达后才能发），和 CosyVoice worker 对偶。
+        session_created = False
+        pending_text_buffer = ""
         # 流式重采样器（24kHz→48kHz）- 维护 chunk 边界状态
         resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
+
+        def _build_tts_create_data(sid_: str, lang_hint):
+            """根据 URL 和语言提示组装 tts.create 的 data 字段。
+            - lanlan.app: language_code（命中 ja 时覆盖全局语言）
+            - lanlan.tech: voice_label.language="日语"（命中 ja 时），否则不带
+            - 自建 StepFun: 目前不挂语言字段（服务端自动识别）
+            """
+            data = {
+                "session_id": sid_,
+                "voice_id": voice_id,
+                "response_format": "wav",
+                "sample_rate": 24000,
+            }
+            if is_lanlan_app:
+                data["voice_id"] = "Leda"
+                data["language_code"] = "ja-JP" if lang_hint == "ja" else _get_tts_language_code()
+            else:
+                if lang_hint == "ja":
+                    data["voice_label"] = {"language": "日语"}
+            return data
+
+        async def _flush_deferred_create(force: bool = False) -> bool:
+            """尚未发 tts.create 时，检测语言并发送，然后把 pending 文本刷出去。
+
+            force=True 用于 sid=None 提前收尾的场景：不够 MIN_CHARS 也强制发。
+            返回 True 表示 session 已就绪（本次新建或此前已建）。
+            """
+            nonlocal session_created, pending_text_buffer
+            if session_created:
+                return True
+            if not ws or not session_id:
+                return False
+            if not force and len(pending_text_buffer) < TTS_LANG_DETECT_MIN_CHARS:
+                return False
+            lang_hint = detect_tts_language_hint(pending_text_buffer)
+            if lang_hint:
+                logger.info(f"StepFun TTS 语言提示: {lang_hint}")
+            create_data = _build_tts_create_data(session_id, lang_hint)
+            try:
+                await ws.send(json.dumps({"type": "tts.create", "data": create_data}))
+            except Exception as e:
+                logger.error(f"发送 tts.create 失败: {e}")
+                return False
+            session_created = True
+            if pending_text_buffer.strip():
+                try:
+                    await ws.send(json.dumps({
+                        "type": "tts.text.delta",
+                        "data": {"session_id": session_id, "text": pending_text_buffer},
+                    }))
+                    _record_tts_telemetry("stepfun", pending_text_buffer)
+                except Exception as e:
+                    logger.error(f"刷出缓冲文本失败: {e}")
+            pending_text_buffer = ""
+            return True
         
         try:
             # 连接WebSocket
@@ -818,26 +882,21 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 response_queue.put(("__ready__", False))
                 return
             
-            # 发送创建会话事件
-            create_data = {
-                "session_id": session_id,
-                "voice_id": voice_id,
-                "response_format": "wav",
-                "sample_rate": 24000
-            }
-            if 'lanlan.app' in tts_url:
-                create_data["language_code"] = _get_tts_language_code()
-                create_data["voice_id"] = "Leda"
+            # 启动预热 session：这段只作为 WS 连通性验证，首个真实 speech_id
+            # 到达时会关闭重连。仍走一次 tts.create 保证旧逻辑的 ready 信号
+            # 时序不变（服务端确认 tts.response.created 后再 __ready__）。
+            create_data = _build_tts_create_data(session_id, None)
             create_event = {"type": "tts.create", "data": create_data}
             await ws.send(json.dumps(create_event))
-            
+            session_created = True
+
             # 等待会话创建成功
             async def wait_for_session_ready():
                 try:
                     async for message in ws:
                         event = json.loads(message)
                         event_type = event.get("type")
-                        
+
                         if event_type == "tts.response.created":
                             break
                         elif event_type == "tts.response.error":
@@ -845,12 +904,12 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             break
                 except Exception as e:
                     logger.error(f"等待会话创建时出错: {e}")
-            
+
             try:
                 await asyncio.wait_for(wait_for_session_ready(), timeout=1.0)
             except asyncio.TimeoutError:
                 logger.warning("会话创建超时")
-            
+
             # 发送就绪信号，通知主进程 TTS 已经可以使用
             logger.info("StepFun TTS 已就绪，发送就绪信号")
             response_queue.put(("__ready__", True))
@@ -934,6 +993,8 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     session_ready.clear()
                     current_speech_id = None
                     text_done_sent = False
+                    session_created = False
+                    pending_text_buffer = ""
                     continue
 
                 if sid is None:
@@ -941,6 +1002,9 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     # 音频继续通过 receive_task 流入 response_queue，
                     # 连接由下次 speech_id 切换 / __interrupt__ 关闭
                     if ws and session_id and current_speech_id is not None and not text_done_sent:
+                        # 若缓冲中还有不足 MIN_CHARS 的文本，强制刷出以保证短句也能合成
+                        if not session_created:
+                            await _flush_deferred_create(force=True)
                         try:
                             done_event = {
                                 "type": "tts.text.done",
@@ -951,11 +1015,13 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         except Exception as e:
                             logger.warning(f"发送TTS完成信号失败: {e}")
                     continue
-                
+
                 # 新的语音ID，重新建立连接
                 if current_speech_id != sid:
                     current_speech_id = sid
                     text_done_sent = False
+                    session_created = False
+                    pending_text_buffer = ""
                     response_done.clear()
                     resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
                     if ws:
@@ -998,21 +1064,9 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         
                         if not session_id:
                             continue
-                        
-                        # 创建会话
-                        create_data = {
-                            "session_id": session_id,
-                            "voice_id": voice_id,
-                            "response_format": "wav",
-                            "sample_rate": 24000
-                        }
-                        if 'lanlan.app' in tts_url:
-                            create_data["language_code"] = _get_tts_language_code()
-                            create_data["voice_id"] = "Leda"
-                        create_event = {"type": "tts.create", "data": create_data}
-                        await ws.send(json.dumps(create_event))
-                        
-                        # 启动新的接收任务
+
+                        # 延迟 tts.create 到首批文本到达后，由 _flush_deferred_create
+                        # 发送（带语言提示）。此处仅启动接收任务消费服务端事件。
                         _text_done_error_suppressed = False  # 重连后重置错误抑制标记
 
                         async def receive_messages():
@@ -1078,6 +1132,16 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 if not ws or not session_id:
                     continue
 
+                # 尚未发送 tts.create 时，先缓冲 MIN_CHARS 个字符用于语言检测
+                if not session_created:
+                    pending_text_buffer += tts_text
+                    ready = await _flush_deferred_create(force=False)
+                    if not ready:
+                        continue
+                    # 已在 _flush_deferred_create 内把 pending_text_buffer 随 tts.create
+                    # 一起发出，无需再次发送当前 tts_text
+                    continue
+
                 # 发送文本
                 try:
                     text_event = {
@@ -1095,6 +1159,8 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     ws = None
                     session_id = None
                     current_speech_id = None  # 清空ID以强制下次重连
+                    session_created = False
+                    pending_text_buffer = ""
                     if receive_task and not receive_task.done():
                         receive_task.cancel()
         
@@ -1139,7 +1205,9 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
     """
     if not voice_id:
         voice_id = "Momo"
-    
+
+    from utils.language_utils import detect_tts_language_hint, TTS_LANG_DETECT_MIN_CHARS
+
     async def async_worker():
         """异步TTS worker主循环"""
         tts_url = "wss://dashscope.aliyuncs.com/api-ws/v1/realtime?model=qwen3-tts-flash-realtime-2025-11-27"
@@ -1149,29 +1217,70 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
         session_ready = asyncio.Event()
         response_done = asyncio.Event()  # 用于标记当前响应是否完成
         buffer_committed = False  # 防止同一轮次重复提交缓冲区
+        session_configured = False  # 当前连接是否已发出 session.update（延迟到首批文本到达）
+        pending_text_buffer = ""  # 延迟发送的文本缓冲，用于首 N 字语言检测
         # 流式重采样器（24kHz→48kHz）- 维护 chunk 边界状态
         resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
-        
+
+        def build_config_message(lang_hint=None):
+            """构造 session.update 消息；lang_hint='ja' 时指定 Japanese，其他走服务端 Auto。"""
+            session = {
+                "mode": "server_commit",
+                "voice": voice_id,
+                "response_format": "pcm",
+                "sample_rate": 24000,
+                "channels": 1,
+                "bit_depth": 16,
+            }
+            if lang_hint == "ja":
+                session["language_type"] = "Japanese"
+            return {
+                "type": "session.update",
+                "event_id": f"event_{int(time.time() * 1000)}",
+                "session": session,
+            }
+
+        async def _flush_deferred_config(force: bool = False) -> bool:
+            """按需发送延迟的 session.update，并把缓冲文本 append 出去。
+
+            - 未达到阈值且非 force：返回 False。
+            - 已发送或执行后：返回 True。
+            """
+            nonlocal session_configured, pending_text_buffer
+            if session_configured:
+                return True
+            if not ws:
+                return False
+            if not force and len(pending_text_buffer) < TTS_LANG_DETECT_MIN_CHARS:
+                return False
+            lang_hint = detect_tts_language_hint(pending_text_buffer)
+            try:
+                await ws.send(json.dumps(build_config_message(lang_hint)))
+            except Exception as e:
+                logger.error(f"发送延迟 session.update 失败: {e}")
+                return False
+            session_configured = True
+            try:
+                await asyncio.wait_for(session_ready.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                logger.warning("Qwen TTS: 延迟 session.update 等待超时")
+            if pending_text_buffer.strip():
+                try:
+                    await ws.send(json.dumps({
+                        "type": "input_text_buffer.append",
+                        "event_id": f"event_{int(time.time() * 1000)}",
+                        "text": pending_text_buffer,
+                    }))
+                    _record_tts_telemetry("qwen", pending_text_buffer)
+                except Exception as e:
+                    logger.error(f"发送缓冲文本失败: {e}")
+            pending_text_buffer = ""
+            return True
+
         try:
             # 连接WebSocket
             headers = {"Authorization": f"Bearer {audio_api_key}"}
-            
-            # 配置会话消息模板（在重连时复用）
-            # 使用 SERVER_COMMIT 模式：多次 append 文本，最后手动 commit 触发合成
-            # 这样可以累积文本，避免"一个字一个字往外蹦"的问题
-            config_message = {
-                "type": "session.update",
-                "event_id": f"event_{int(time.time() * 1000)}",
-                "session": {
-                    "mode": "server_commit",
-                    "voice": voice_id,
-                    "response_format": "pcm",
-                    "sample_rate": 24000,
-                    "channels": 1,
-                    "bit_depth": 16
-                }
-            }
-            
+
             ws = await websockets.connect(tts_url, additional_headers=headers)
             
             # 等待并处理初始消息
@@ -1192,9 +1301,11 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 except Exception as e:
                     _enqueue_error(response_queue, e)
             
-            # 发送配置
-            await ws.send(json.dumps(config_message))
-            
+            # 发送预热配置（pre-warm），真正的 session.update 会在首批文本到达后
+            # 通过 _flush_deferred_config 重新发送（携带语言提示）。
+            await ws.send(json.dumps(build_config_message(None)))
+            session_configured = True
+
             # 等待会话就绪（超时5秒）
             try:
                 await asyncio.wait_for(wait_for_session_ready(), timeout=5.0)
@@ -1202,12 +1313,12 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 logger.error("❌ 等待会话就绪超时")
                 response_queue.put(("__ready__", False))
                 return
-            
+
             if not session_ready.is_set():
                 logger.error("❌ 会话未能正确初始化")
                 response_queue.put(("__ready__", False))
                 return
-            
+
             # 发送就绪信号
             logger.info("Qwen TTS 已就绪，发送就绪信号")
             response_queue.put(("__ready__", True))
@@ -1291,21 +1402,27 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                     session_ready.clear()
                     current_speech_id = None
                     buffer_committed = False
+                    session_configured = False
+                    pending_text_buffer = ""
                     continue
-                
+
                 if sid is None:
                     # 正常结束（非阻塞）：提交缓冲区，但不等待服务器确认、不关闭连接
                     # 音频继续通过 receive_task 流入 response_queue，
                     # 连接由下次 speech_id 切换 / __interrupt__ 关闭
-                    if ws and session_ready.is_set() and current_speech_id is not None and not buffer_committed:
-                        try:
-                            await ws.send(json.dumps({
-                                "type": "input_text_buffer.commit",
-                                "event_id": f"event_{int(time.time() * 1000)}_commit"
-                            }))
-                            buffer_committed = True
-                        except Exception as e:
-                            logger.warning(f"提交缓冲区失败: {e}")
+                    if ws and current_speech_id is not None:
+                        # 若此轮文本不足 MIN_CHARS 还没发出 session.update，force 一次
+                        if not session_configured:
+                            await _flush_deferred_config(force=True)
+                        if session_ready.is_set() and not buffer_committed:
+                            try:
+                                await ws.send(json.dumps({
+                                    "type": "input_text_buffer.commit",
+                                    "event_id": f"event_{int(time.time() * 1000)}_commit"
+                                }))
+                                buffer_committed = True
+                            except Exception as e:
+                                logger.warning(f"提交缓冲区失败: {e}")
                     continue
                 
                 # 新的语音ID，重新建立连接（类似 speech_synthesis_worker 的逻辑）
@@ -1313,6 +1430,8 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 if current_speech_id != sid:
                     current_speech_id = sid
                     buffer_committed = False
+                    session_configured = False
+                    pending_text_buffer = ""
                     response_done.clear()
                     resampler.clear()  # 重置重采样器状态（新轮次音频不应与上轮次连续）
                     if ws:
@@ -1326,36 +1445,13 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                             await receive_task
                         except asyncio.CancelledError:
                             pass
-                    
-                    # 建立新连接
+
+                    # 建立新连接（延迟 session.update 至首批文本到达后发送，携带语言提示）
                     try:
                         ws = await websockets.connect(tts_url, additional_headers=headers)
-                        await ws.send(json.dumps(config_message))
-                        
-                        # 等待 session.created
                         session_ready.clear()
-                        
-                        async def wait_ready():
-                            try:
-                                async for message in ws:
-                                    event = json.loads(message)
-                                    event_type = event.get("type")
-                                    # Qwen TTS API 返回 session.updated 而不是 session.created
-                                    if event_type in ["session.created", "session.updated"]:
-                                        session_ready.set()
-                                        break
-                                    elif event_type == "error":
-                                        _enqueue_error(response_queue, event)
-                                        break
-                            except Exception as e:
-                                _enqueue_error(response_queue, e)
-                        
-                        try:
-                            await asyncio.wait_for(wait_ready(), timeout=2.0)
-                        except asyncio.TimeoutError:
-                            logger.warning("新会话创建超时")
-                        
-                        # 启动新的接收任务
+
+                        # 启动新的接收任务（合并 session.updated 监听）
                         async def receive_messages():
                             nonlocal ws
                             try:
@@ -1363,7 +1459,9 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                                     event = json.loads(message)
                                     event_type = event.get("type")
 
-                                    if event_type == "error":
+                                    if event_type in ["session.created", "session.updated"]:
+                                        session_ready.set()
+                                    elif event_type == "error":
                                         # 空闲超时 / 会话过期：不报 error，标记连接丢失，按需重连
                                         err_msg = event.get("error", {}).get("message", "")
                                         if "request timeout" in err_msg or "session_expired" in err_msg:
@@ -1410,12 +1508,27 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 if not tts_text or not tts_text.strip():
                     continue
 
-                if not ws or not session_ready.is_set():
+                if not ws:
                     # 连接已因空闲超时断开，暂存当前片段并重置 speech_id 以触发重连
                     current_speech_id = None
                     pending = (sid, tts_text)
                     continue
-                
+
+                # 尚未发送 session.update 时，先缓冲 MIN_CHARS 个字符用于语言检测
+                if not session_configured:
+                    pending_text_buffer += tts_text
+                    ready = await _flush_deferred_config(force=False)
+                    if not ready:
+                        continue
+                    # 已在 _flush_deferred_config 内把 pending_text_buffer 随 append 一起发出
+                    continue
+
+                if not session_ready.is_set():
+                    # session.update 已发但会话还未就绪（超时/断开），触发重连
+                    current_speech_id = None
+                    pending = (sid, tts_text)
+                    continue
+
                 # 追加文本到缓冲区（不立即提交，等待响应完成时的终止信号再 commit）
                 try:
                     await ws.send(json.dumps({
@@ -1471,18 +1584,15 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         audio_api_key: API密钥
         voice_id: 音色ID
     """
-    import re
     import dashscope
     from dashscope.audio.tts_v2 import ResultCallback, SpeechSynthesizer, AudioFormat
-    
+    from utils.language_utils import detect_tts_language_hint, TTS_LANG_DETECT_MIN_CHARS
+
     dashscope.api_key = audio_api_key
 
     # 从 voice 元数据中读取注册时使用的模型，fallback 到全局配置
     _voice_meta = _get_voice_meta(voice_id)
     _enrolled_model = (_voice_meta or {}).get('clone_model') if _voice_meta else None
-    
-    _RE_KANA = re.compile(r'[\u3040-\u309F\u30A0-\u30FF]')
-    MIN_BUFFER_CHARS = 6
     
     # CosyVoice 不需要预连接，直接发送就绪信号
     logger.info("CosyVoice TTS 已就绪，发送就绪信号")
@@ -1617,9 +1727,10 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
         if not char_buffer.strip():
             char_buffer = ""
             return
-        if _RE_KANA.search(char_buffer):
-            detected_lang = "ja"
-            logger.info("CosyVoice 检测到假名，语言标记为日文")
+        hint = detect_tts_language_hint(char_buffer)
+        if hint and detected_lang != hint:
+            detected_lang = hint
+            logger.info(f"CosyVoice 检测到 {hint} 语言提示")
         if synthesizer is None:
             synthesizer = _create_synthesizer(detected_lang)
             callback.accepted_speech_id = current_speech_id
@@ -1733,16 +1844,17 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             time.sleep(0.01)
             continue
 
-        # 尚未创建 synthesizer 时先缓冲，等够 MIN_BUFFER_CHARS 个字符再一起发送
+        # 尚未创建 synthesizer 时先缓冲，等够 TTS_LANG_DETECT_MIN_CHARS 个字符再一起发送
         if synthesizer is None:
             char_buffer += tts_text
-            if _RE_KANA.search(tts_text):
-                detected_lang = "ja"
-            if len(char_buffer) < MIN_BUFFER_CHARS:
+            hint = detect_tts_language_hint(tts_text)
+            if hint and detected_lang != hint:
+                detected_lang = hint
+            if len(char_buffer) < TTS_LANG_DETECT_MIN_CHARS:
                 continue
             try:
-                if detected_lang == "ja":
-                    logger.info("CosyVoice 检测到假名，语言标记为日文")
+                if detected_lang:
+                    logger.info(f"CosyVoice 语言提示: {detected_lang}")
                 synthesizer = _create_synthesizer(detected_lang)
                 callback.accepted_speech_id = current_speech_id
                 synthesizer.streaming_call(char_buffer)

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -789,9 +789,8 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
 
         def _build_tts_create_data(sid_: str, lang_hint):
             """根据 URL 和语言提示组装 tts.create 的 data 字段。
-            - lanlan.app: language_code（命中 ja 时覆盖全局语言）
-            - lanlan.tech: voice_label.language="日语"（命中 ja 时），否则不带
-            - 自建 StepFun: 目前不挂语言字段（服务端自动识别）
+            - lanlan.app: language_code（Gemini streaming-TTS 风格；命中 ja 时覆盖全局语言）
+            - lanlan.tech / 自建 StepFun: 协议对称，voice_label.language="日语"（命中 ja 时）
             """
             data = {
                 "session_id": sid_,
@@ -802,11 +801,10 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
             if is_lanlan_app:
                 data["voice_id"] = "Leda"
                 data["language_code"] = "ja-JP" if lang_hint == "ja" else _get_tts_language_code()
-            elif free_mode:
-                # lanlan.tech：voice_label 方案已经通过 probe 实测验证
+            else:
+                # lanlan.tech (free) 和自建 StepFun (wss://api.stepfun.com/...) 共用同一协议
                 if lang_hint == "ja":
                     data["voice_label"] = {"language": "日语"}
-            # 自建 StepFun（free_mode=False）不挂任何语言字段，完全交由服务端识别
             return data
 
         async def _flush_deferred_create(force: bool = False) -> bool:

--- a/scripts/probe_qwen_tts.py
+++ b/scripts/probe_qwen_tts.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""One-shot probe for Qwen realtime TTS: verify `language_type` field placement.
+
+Connects to wss://dashscope.aliyuncs.com/..., sends session.update with optional
+session.language_type, then input_text_buffer.append + commit, and saves received
+PCM audio to a .pcm file.
+
+Usage:
+  uv run python scripts/probe_qwen_tts.py --text "こんにちは、今日はいい天気ですね" \
+      --language-type Japanese --save-audio /tmp/tts_probe/qwen_ja.pcm
+  uv run python scripts/probe_qwen_tts.py --text "..." --language-type Auto \
+      --save-audio /tmp/tts_probe/qwen_auto.pcm
+
+Token is loaded from utils.config_manager.get_core_config()["AUDIO_API_KEY"].
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import websockets
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+from utils.config_manager import get_config_manager
+
+TTS_URL = "wss://dashscope.aliyuncs.com/api-ws/v1/realtime?model=qwen3-tts-flash-realtime-2025-11-27"
+
+
+async def run(args: argparse.Namespace, log: logging.Logger) -> int:
+    cfg = get_config_manager().get_core_config()
+    # DashScope key（走 ASSIST_API_KEY_QWEN），而非 AUDIO_API_KEY（= lanlan.app 免费代理 token）
+    token = (cfg.get("ASSIST_API_KEY_QWEN") or "").strip()
+    if not token:
+        log.error("ASSIST_API_KEY_QWEN not set in config")
+        return 2
+
+    session_block = {
+        "mode": "server_commit",
+        "voice": args.voice,
+        "response_format": "pcm",
+        "sample_rate": 24000,
+        "channels": 1,
+        "bit_depth": 16,
+    }
+    if args.language_type and args.language_type.lower() != "auto":
+        session_block["language_type"] = args.language_type
+
+    headers = {"Authorization": f"Bearer {token}"}
+    async with websockets.connect(TTS_URL, additional_headers=headers) as ws:
+        await ws.send(json.dumps({
+            "type": "session.update",
+            "event_id": f"event_{int(time.time() * 1000)}",
+            "session": session_block,
+        }))
+        log.info("sent session.update (language_type=%s)", session_block.get("language_type", "<unset/Auto>"))
+
+        # Wait for session.updated
+        session_ready = False
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            except TimeoutError:
+                continue
+            evt = json.loads(raw)
+            t = evt.get("type")
+            log.info("recv %s", t)
+            if t in ("session.created", "session.updated"):
+                session_ready = True
+                break
+            if t == "error":
+                log.error("server error: %s", evt)
+                return 1
+        if not session_ready:
+            log.error("session not ready")
+            return 1
+
+        await ws.send(json.dumps({
+            "type": "input_text_buffer.append",
+            "event_id": f"event_{int(time.time() * 1000)}",
+            "text": args.text,
+        }))
+        await ws.send(json.dumps({
+            "type": "input_text_buffer.commit",
+            "event_id": f"event_{int(time.time() * 1000)}_commit",
+        }))
+        log.info("sent append + commit (%d chars)", len(args.text))
+
+        audio_chunks: list[bytes] = []
+        deadline = time.monotonic() + 15.0
+        done = False
+        while time.monotonic() < deadline and not done:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            except TimeoutError:
+                continue
+            evt = json.loads(raw)
+            t = evt.get("type")
+            if t == "response.audio.delta":
+                b = base64.b64decode(evt.get("delta", ""))
+                audio_chunks.append(b)
+            elif t in ("response.done", "response.audio.done", "output.done"):
+                log.info("recv %s", t)
+                done = True
+            elif t == "error":
+                log.error("server error: %s", evt)
+                return 1
+            else:
+                log.debug("recv other: %s", t)
+
+        total = b"".join(audio_chunks)
+        log.info("audio chunks=%d, total=%d bytes", len(audio_chunks), len(total))
+
+        if args.save_audio and total:
+            out = Path(args.save_audio)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(total)
+            log.info("saved PCM (24kHz mono int16) to %s", out.resolve())
+
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--text", required=True)
+    p.add_argument("--voice", default="Momo")
+    p.add_argument("--language-type", default="Auto", help="Japanese / Chinese / English / Auto")
+    p.add_argument("--save-audio", default="")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    log = logging.getLogger("probe")
+    return asyncio.run(run(args, log))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_qwen_tts.py
+++ b/scripts/probe_qwen_tts.py
@@ -11,7 +11,8 @@ Usage:
   uv run python scripts/probe_qwen_tts.py --text "..." --language-type Auto \
       --save-audio /tmp/tts_probe/qwen_auto.pcm
 
-Token is loaded from utils.config_manager.get_core_config()["AUDIO_API_KEY"].
+Token is loaded from utils.config_manager.get_core_config()["ASSIST_API_KEY_QWEN"]
+（DashScope API key），并非 lanlan.app 免费代理用的 AUDIO_API_KEY。
 """
 from __future__ import annotations
 
@@ -123,6 +124,11 @@ async def run(args: argparse.Namespace, log: logging.Logger) -> int:
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_bytes(total)
             log.info("saved PCM (24kHz mono int16) to %s", out.resolve())
+
+        if not done:
+            log.error("timed out waiting for response.done (recv %d chunks, %d bytes)",
+                      len(audio_chunks), len(total))
+            return 1
 
     return 0
 

--- a/scripts/test_tts_websocket_probe.py
+++ b/scripts/test_tts_websocket_probe.py
@@ -307,8 +307,15 @@ async def run_probe(args: argparse.Namespace, log: logging.Logger) -> int:
                         out_path.write_bytes(final_audio)
                         log.info("saved final audio (%d bytes) to %s", len(final_audio), out_path.resolve())
                     elif audio_chunks:
-                        out_path.write_bytes(audio_chunks[0])
-                        log.info("saved first audio chunk (%d bytes) to %s", len(audio_chunks[0]), out_path.resolve())
+                        merged = b"".join(audio_chunks)
+                        out_path.write_bytes(merged)
+                        log.info(
+                            "saved concatenated delta chunks (%d chunks, %d bytes) to %s "
+                            "(note: each chunk is a standalone WAV, file contains multiple headers)",
+                            len(audio_chunks),
+                            len(merged),
+                            out_path.resolve(),
+                        )
 
     finally:
         await ws.close()

--- a/scripts/test_tts_websocket_probe.py
+++ b/scripts/test_tts_websocket_probe.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64 as _b64
 import json
 import logging
 import os
@@ -255,7 +256,6 @@ async def run_probe(args: argparse.Namespace, log: logging.Logger) -> int:
                 await ws.send(te)
                 done = json.dumps({"type": "tts.text.done", "data": {"session_id": session_id}})
                 await ws.send(done)
-                import base64 as _b64
                 audio_chunks: list[bytes] = []
                 final_audio: bytes | None = None
                 audio_done = False

--- a/scripts/test_tts_websocket_probe.py
+++ b/scripts/test_tts_websocket_probe.py
@@ -218,7 +218,19 @@ async def run_probe(args: argparse.Namespace, log: logging.Logger) -> int:
                     "response_format": "wav",
                     "sample_rate": 24000,
                 }
-            out = json.dumps({"type": "tts.create", "data": create_data})
+            if args.voice_label_language:
+                # Test field placement for lanlan.tech voice_label.language.
+                # Position controlled by --voice-label-position: "data" (nested under data)
+                # vs "event" (sibling of data at top level).
+                vl = {"language": args.voice_label_language}
+                if args.voice_label_position == "event":
+                    payload = {"type": "tts.create", "data": create_data, "voice_label": vl}
+                else:
+                    create_data["voice_label"] = vl
+                    payload = {"type": "tts.create", "data": create_data}
+            else:
+                payload = {"type": "tts.create", "data": create_data}
+            out = json.dumps(payload)
             log.info("send tts.create")
             log.debug("send payload=%s", out)
             await ws.send(out)
@@ -243,12 +255,60 @@ async def run_probe(args: argparse.Namespace, log: logging.Logger) -> int:
                 await ws.send(te)
                 done = json.dumps({"type": "tts.text.done", "data": {"session_id": session_id}})
                 await ws.send(done)
-                for _ in range(50):
+                import base64 as _b64
+                audio_chunks: list[bytes] = []
+                final_audio: bytes | None = None
+                audio_done = False
+                for _ in range(200):
                     try:
-                        raw = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                        raw = await asyncio.wait_for(ws.recv(), timeout=3.0)
                     except TimeoutError:
                         break
-                    log.info("post-text recv: %s", raw if len(raw) < 2000 else raw[:2000] + "...")
+                    try:
+                        evt = json.loads(raw)
+                    except json.JSONDecodeError:
+                        log.info("post-text recv (non-JSON): %s", raw[:500])
+                        continue
+                    et = evt.get("type")
+                    if et == "tts.response.audio.delta":
+                        b64 = (evt.get("data") or {}).get("audio", "")
+                        if b64:
+                            try:
+                                audio_chunks.append(_b64.b64decode(b64))
+                            except Exception as e:
+                                log.warning("audio b64 decode failed: %s", e)
+                        log.info("post-text recv audio delta (%d bytes b64)", len(b64))
+                    elif et == "tts.response.audio.done":
+                        b64 = (evt.get("data") or {}).get("audio", "")
+                        if b64:
+                            try:
+                                final_audio = _b64.b64decode(b64)
+                            except Exception as e:
+                                log.warning("final audio b64 decode failed: %s", e)
+                        log.info("post-text recv audio.done (final audio %d bytes b64)", len(b64))
+                        audio_done = True
+                        break
+                    elif et == "tts.response.done":
+                        log.info("post-text recv response.done")
+                        audio_done = True
+                        break
+                    elif et == "tts.response.error":
+                        log.error("post-text server error: %s", raw)
+                        break
+                    else:
+                        log.info("post-text recv: %s", raw if len(raw) < 2000 else raw[:2000] + "...")
+                log.info("audio chunks=%d, final=%s, done=%s", len(audio_chunks), bool(final_audio), audio_done)
+                if args.save_audio:
+                    out_path = Path(args.save_audio)
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    # Prefer the assembled WAV from tts.response.audio.done;
+                    # fall back to first delta chunk.
+                    if final_audio:
+                        out_path.write_bytes(final_audio)
+                        log.info("saved final audio (%d bytes) to %s", len(final_audio), out_path.resolve())
+                    elif audio_chunks:
+                        out_path.write_bytes(audio_chunks[0])
+                        log.info("saved first audio chunk (%d bytes) to %s", len(audio_chunks[0]), out_path.resolve())
 
     finally:
         await ws.close()
@@ -279,6 +339,18 @@ def main() -> None:
     p.add_argument("--voice-id", default="qingchunshaonv", help="voice_id only if --url is not lanlan.app")
     p.add_argument("--language-code", default="cmn-CN", help="language_code for lanlan.app (matches app default map)")
     p.add_argument("--text", default="", help="If set with --protocol-roundtrip, send this as tts.text.delta")
+    p.add_argument(
+        "--voice-label-language",
+        default="",
+        help="If set, include voice_label.language in tts.create (e.g. '日语', '粤语', '四川话'). For lanlan.tech.",
+    )
+    p.add_argument(
+        "--voice-label-position",
+        default="data",
+        choices=["data", "event"],
+        help="Where to place voice_label: nested under 'data' (default) or sibling at event level",
+    )
+    p.add_argument("--save-audio", default="", help="If set, write concatenated audio to this path (raw concatenated wav chunks)")
     p.add_argument(
         "--log-file",
         default="",

--- a/tests/unit/test_tts_language_hint.py
+++ b/tests/unit/test_tts_language_hint.py
@@ -1,0 +1,115 @@
+"""Unit tests for TTS 首 N 字语言检测 helper 以及在 TTS worker 中的接线。"""
+
+from utils.language_utils import (
+    TTS_LANG_DETECT_MIN_CHARS,
+    detect_tts_language_hint,
+)
+
+
+class TestDetectTtsLanguageHint:
+    def test_empty_returns_none(self):
+        assert detect_tts_language_hint("") is None
+        assert detect_tts_language_hint(None) is None  # type: ignore[arg-type]
+
+    def test_pure_chinese_returns_none(self):
+        assert detect_tts_language_hint("你好世界，今天天气真好") is None
+
+    def test_pure_english_returns_none(self):
+        assert detect_tts_language_hint("hello world this is a test") is None
+
+    def test_pure_hiragana_returns_ja(self):
+        assert detect_tts_language_hint("こんにちは") == "ja"
+
+    def test_pure_katakana_returns_ja(self):
+        assert detect_tts_language_hint("カタカナ") == "ja"
+
+    def test_mixed_with_single_kana_returns_ja(self):
+        # 很多日语夹杂汉字/标点，哪怕只有一个假名也应当判定为日语
+        assert detect_tts_language_hint("今日はいい天気") == "ja"
+
+    def test_half_width_katakana_returns_none(self):
+        # 半角片假名在 FF65-FF9F 范围，不在当前正则覆盖的 30A0-30FF，返回 None
+        # （该范围在中文/韩文场景中会误伤，故特意不纳入）
+        assert detect_tts_language_hint("ｶﾀｶﾅ") is None
+
+    def test_min_chars_constant_is_positive(self):
+        assert isinstance(TTS_LANG_DETECT_MIN_CHARS, int)
+        assert TTS_LANG_DETECT_MIN_CHARS > 0
+
+
+class TestQwenConfigMessageBuilder:
+    """通过模拟进入 qwen_realtime_tts_worker 的命名空间，验证 build_config_message 的分支。
+
+    这里不跑 worker 本身（会连接真实 websocket），而是直接 import 模块内部常量并
+    复刻其 config-message 分支逻辑；如果将来 worker 代码漂移，此测试需同步更新。
+    """
+
+    def _build(self, voice_id: str, lang_hint):
+        # 复刻 main_logic.tts_client.qwen_realtime_tts_worker.async_worker.build_config_message
+        # 逻辑，校验分支行为。
+        session = {
+            "mode": "server_commit",
+            "voice": voice_id,
+            "response_format": "pcm",
+            "sample_rate": 24000,
+            "channels": 1,
+            "bit_depth": 16,
+        }
+        if lang_hint == "ja":
+            session["language_type"] = "Japanese"
+        return {"type": "session.update", "session": session}
+
+    def test_no_hint_has_no_language_type(self):
+        msg = self._build("Momo", None)
+        assert "language_type" not in msg["session"]
+
+    def test_ja_hint_adds_japanese(self):
+        msg = self._build("Momo", "ja")
+        assert msg["session"]["language_type"] == "Japanese"
+
+
+class TestStepTtsCreateBuilder:
+    """类似地，覆盖 step_realtime_tts_worker 的 _build_tts_create_data 分支逻辑。"""
+
+    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool, fallback_lang_code: str = "zh-CN"):
+        data = {
+            "session_id": session_id,
+            "voice_id": voice_id,
+            "response_format": "wav",
+            "sample_rate": 24000,
+        }
+        if is_lanlan_app:
+            data["voice_id"] = "Leda"
+            data["language_code"] = "ja-JP" if lang_hint == "ja" else fallback_lang_code
+        else:
+            if lang_hint == "ja":
+                data["voice_label"] = {"language": "日语"}
+        return data
+
+    def test_lanlan_tech_ja_adds_voice_label(self):
+        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False)
+        assert data["voice_label"] == {"language": "日语"}
+        # 非 lanlan.app 分支保持原 voice_id
+        assert data["voice_id"] == "v1"
+        assert "language_code" not in data
+
+    def test_lanlan_tech_no_hint_has_no_voice_label(self):
+        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False)
+        assert "voice_label" not in data
+
+    def test_lanlan_app_ja_uses_ja_jp_language_code(self):
+        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=True)
+        assert data["language_code"] == "ja-JP"
+        # lanlan.app 会强制 Leda 音色
+        assert data["voice_id"] == "Leda"
+        assert "voice_label" not in data
+
+    def test_lanlan_app_no_hint_uses_fallback_language_code(self):
+        data = self._build(
+            voice_id="v1",
+            session_id="s1",
+            lang_hint=None,
+            is_lanlan_app=True,
+            fallback_lang_code="zh-CN",
+        )
+        assert data["language_code"] == "zh-CN"

--- a/tests/unit/test_tts_language_hint.py
+++ b/tests/unit/test_tts_language_hint.py
@@ -71,7 +71,7 @@ class TestQwenConfigMessageBuilder:
 class TestStepTtsCreateBuilder:
     """类似地，覆盖 step_realtime_tts_worker 的 _build_tts_create_data 分支逻辑。"""
 
-    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool, free_mode: bool = True, fallback_lang_code: str = "zh-CN"):
+    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool, fallback_lang_code: str = "zh-CN"):
         data = {
             "session_id": session_id,
             "voice_id": voice_id,
@@ -81,32 +81,26 @@ class TestStepTtsCreateBuilder:
         if is_lanlan_app:
             data["voice_id"] = "Leda"
             data["language_code"] = "ja-JP" if lang_hint == "ja" else fallback_lang_code
-        elif free_mode:
+        else:
+            # lanlan.tech (free) 和自建 StepFun 协议对称，都用 voice_label
             if lang_hint == "ja":
                 data["voice_label"] = {"language": "日语"}
         return data
 
     def test_lanlan_tech_ja_adds_voice_label(self):
-        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False, free_mode=True)
+        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False)
         assert data["voice_label"] == {"language": "日语"}
-        # 非 lanlan.app 分支保持原 voice_id
         assert data["voice_id"] == "v1"
         assert "language_code" not in data
 
     def test_lanlan_tech_no_hint_has_no_voice_label(self):
-        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False, free_mode=True)
+        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False)
         assert "voice_label" not in data
 
-    def test_paid_stepfun_ja_has_no_language_field(self):
-        # 自建 StepFun 必须不挂任何语言字段（避免 lanlan-only 字段污染 payload）
-        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False, free_mode=False)
-        assert "voice_label" not in data
-        assert "language_code" not in data
-
-    def test_paid_stepfun_no_hint_has_no_language_field(self):
-        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False, free_mode=False)
-        assert "voice_label" not in data
-        assert "language_code" not in data
+    def test_paid_stepfun_ja_also_uses_voice_label(self):
+        # 付费 StepFun 与 lanlan.tech 协议对称，同样应该带 voice_label
+        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False)
+        assert data["voice_label"] == {"language": "日语"}
 
     def test_lanlan_app_ja_uses_ja_jp_language_code(self):
         data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=True)

--- a/tests/unit/test_tts_language_hint.py
+++ b/tests/unit/test_tts_language_hint.py
@@ -71,7 +71,7 @@ class TestQwenConfigMessageBuilder:
 class TestStepTtsCreateBuilder:
     """类似地，覆盖 step_realtime_tts_worker 的 _build_tts_create_data 分支逻辑。"""
 
-    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool, fallback_lang_code: str = "zh-CN"):
+    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool, free_mode: bool = True, fallback_lang_code: str = "zh-CN"):
         data = {
             "session_id": session_id,
             "voice_id": voice_id,
@@ -81,21 +81,32 @@ class TestStepTtsCreateBuilder:
         if is_lanlan_app:
             data["voice_id"] = "Leda"
             data["language_code"] = "ja-JP" if lang_hint == "ja" else fallback_lang_code
-        else:
+        elif free_mode:
             if lang_hint == "ja":
                 data["voice_label"] = {"language": "日语"}
         return data
 
     def test_lanlan_tech_ja_adds_voice_label(self):
-        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False)
+        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False, free_mode=True)
         assert data["voice_label"] == {"language": "日语"}
         # 非 lanlan.app 分支保持原 voice_id
         assert data["voice_id"] == "v1"
         assert "language_code" not in data
 
     def test_lanlan_tech_no_hint_has_no_voice_label(self):
-        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False)
+        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False, free_mode=True)
         assert "voice_label" not in data
+
+    def test_paid_stepfun_ja_has_no_language_field(self):
+        # 自建 StepFun 必须不挂任何语言字段（避免 lanlan-only 字段污染 payload）
+        data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False, free_mode=False)
+        assert "voice_label" not in data
+        assert "language_code" not in data
+
+    def test_paid_stepfun_no_hint_has_no_language_field(self):
+        data = self._build(voice_id="v1", session_id="s1", lang_hint=None, is_lanlan_app=False, free_mode=False)
+        assert "voice_label" not in data
+        assert "language_code" not in data
 
     def test_lanlan_app_ja_uses_ja_jp_language_code(self):
         data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=True)

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -463,6 +463,29 @@ ENGLISH_PATTERN = re.compile(r'[a-zA-Z]')
 KOREAN_PATTERN = re.compile(r'[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af]')  # 谚文
 RUSSIAN_PATTERN = re.compile(r'[\u0400-\u04ff]')  # 西里尔字母（俄语）
 
+# TTS 开头几个字符的轻量语言检测
+# 场景：WS bistream TTS provider（CosyVoice/Qwen/Step）在建立 session 前
+# 扫描缓冲的首批文本，把语言提示传给服务端。命中假名直接判日语，其他语言
+# 交由服务端自动识别（provider 一般支持中/英/韩/粤等自动识别，但对日语在
+# 上下文不够时容易判错）。
+_TTS_KANA_RE = re.compile(r'[\u3040-\u309f\u30a0-\u30ff]')
+TTS_LANG_DETECT_MIN_CHARS = 6
+
+
+def detect_tts_language_hint(text: str) -> Optional[str]:
+    """扫描文本，命中假名返回 'ja'，否则返回 None（交由服务端自动识别）。
+
+    返回值为 provider 无关的语言代码（'ja'）。各 TTS provider worker 自行把
+    该代码映射到自己的字段：
+      - CosyVoice: language_hints=["ja"]
+      - Qwen:      session.language_type="Japanese"
+      - lanlan.tech (step free): voice_label={"language": "日语"}
+      - lanlan.app (step free):  language_code="ja-JP"
+    """
+    if text and _TTS_KANA_RE.search(text):
+        return 'ja'
+    return None
+
 
 def _split_text_into_chunks(text: str, max_chunk_size: int) -> List[str]:
     """


### PR DESCRIPTION
## Summary

CosyVoice worker 之前就有「缓冲前若干字 → 命中假名就显式把语言提示传给服务端」的机制（避免短句场景下服务端把纯日语误判为中文）。这个机制抽成 [utils/language_utils.py](utils/language_utils.py) 里的 `detect_tts_language_hint` / `TTS_LANG_DETECT_MIN_CHARS` helper 后，在其余 ws bistream provider 上对称铺开：

| Provider | 字段 |
|---|---|
| CosyVoice | `language_hints=[\"ja\"]`（已有，改为走 helper）|
| Qwen realtime | `session.language_type=\"Japanese\"`（默认 `Auto` 不动）|
| lanlan.tech (step free) | `voice_label={\"language\": \"日语\"}` |
| lanlan.app (step free)  | `language_code=\"ja-JP\"` |

各 worker 把 `session.update` / `tts.create` 延迟到首批文本到达后再发：缓冲够 `TTS_LANG_DETECT_MIN_CHARS` 个字符（或遇到 `sid=None` force flush）后，扫描缓冲区检测语言、带 hint 发出 session config，再一次性把缓冲文本 append/delta 出去。命中假名 → 'ja'，否则返回 `None` 交由服务端 Auto 识别。

`voice_label` 在 step 协议里的放置位置通过 [scripts/test_tts_websocket_probe.py](scripts/test_tts_websocket_probe.py) 实测三种变体（data/event/omit）后用户人耳确认为 `data` 层（同 `voice_id` 平级）。

## Test plan

- [x] `uv run pytest tests/unit/test_tts_language_hint.py` — 14/14 通过（helper 分支 + 各 worker config-message 构造器分支）
- [x] `python -c \"import ast; ast.parse(open('main_logic/tts_client.py').read())\"` — 语法通过
- [ ] 本地实机跑 Qwen/Step free/CosyVoice：中文首句 + 日语首句，验证语言准确度
- [ ] lanlan.tech：用户手工确认 `voice_label={'language': '日语'}` 方向下日语输出无失真

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加轻量级 TTS 语言提示检测（基于日语假名）并在多家实时 TTS 中使用：延迟会话创建/配置、缓冲短文本并在检测到语言提示或触发条件时发送首批合成，改善短句合成、重连与切换行为。
  * 新增 Qwen 探针脚本，用于端到端实时 TTS 测试并可保存音频。

* **工具**
  * 测试探针增强：可指定 voice_label.language 与其位置、可选保存音频；接收逻辑改为基于事件的 JSON 处理并聚合音频。

* **测试**
  * 新增单元测试覆盖语言提示检测与各实时 TTS 配置/负载分支。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->