### PR TITLE
fix: Fix physics bone stretching during model rotation

### DIFF
--- a/static/libs/three-mmd-physics-ammo.module.js
+++ b/static/libs/three-mmd-physics-ammo.module.js
@@ -1045,6 +1045,8 @@ class MMDPhysics {
     const position = manager.allocThreeVector3();
     const quaternion = manager.allocThreeQuaternion();
     const scale = manager.allocThreeVector3();
+    // Ensure matrixWorld reflects latest mesh.quaternion/position before decompose
+    mesh.updateMatrixWorld(true);
     mesh.matrixWorld.decompose(position, quaternion, scale);
 
     // [终极魔法 1: 局部相对重力 (Local Gravity)]
@@ -1108,11 +1110,8 @@ class MMDPhysics {
 
     // World Rotation Compensation: Sync dynamic rigid bodies when the model rotates.
     if (delta > 0) {
-      mesh.updateMatrixWorld(true);
-      const freshQuat = manager.allocThreeQuaternion();
-      mesh.getWorldQuaternion(freshQuat);
       const deltaQuat = manager.allocThreeQuaternion();
-      deltaQuat.copy(prevMeshQuat).invert().multiply(freshQuat);
+      deltaQuat.copy(prevMeshQuat).invert().multiply(quaternion);
       const rotAngle = 2 * Math.acos(Math.min(1, Math.abs(deltaQuat.w)));
 
       if (rotAngle > 0.001) {
@@ -1167,7 +1166,6 @@ class MMDPhysics {
         manager.freeTransform(tr);
       }
       manager.freeThreeQuaternion(deltaQuat);
-      manager.freeThreeQuaternion(freshQuat);
     }
 
     if (scale.x !== 1 || scale.y !== 1 || scale.z !== 1) {

--- a/static/libs/three-mmd-physics-ammo.module.js
+++ b/static/libs/three-mmd-physics-ammo.module.js
@@ -709,6 +709,21 @@ class RigidBody {
     manager.freeThreeVector3(thV);
     manager.freeTransform(tr);
   }
+  _updateBonePositionSoft() {
+    const manager = this.manager;
+    const tr = this._getWorldTransformForBone();
+    const thV = manager.allocThreeVector3();
+    const o = manager.getOrigin(tr);
+    thV.set(o.x(), o.y(), o.z());
+    if (this.bone.parent)
+      this.bone.parent.worldToLocal(thV);
+    // 动态 alpha：偏差小时快速收敛（减少穿模），偏差大时慢速跟随（避免拉长）
+    const dist = this.bone.position.distanceTo(thV);
+    const alpha = dist < 0.1 ? 0.06 : dist < 0.5 ? 0.02 : 0.005;
+    this.bone.position.lerp(thV, alpha);
+    manager.freeThreeVector3(thV);
+    manager.freeTransform(tr);
+  }
   _updateBoneRotation() {
     const manager = this.manager;
     const tr = this._getWorldTransformForBone();
@@ -746,8 +761,10 @@ class RigidBody {
     if (this.params.physicsMode === 0 || this.params.boneIndex === -1)
       return this;
     this._updateBoneRotation();
+    // 柔性位置同步：不硬覆盖 position（会导致拉长），而是缓慢趋向物理位置
+    // 保持碰撞一致性的同时避免视觉拉伸
     if (this.params.physicsMode === 1)
-      this._updateBonePosition();
+      this._updateBonePositionSoft();
     this.bone.updateMatrixWorld(true);
     if (this.params.physicsMode === 2)
       this._setPositionFromBone();
@@ -1084,6 +1101,71 @@ class MMDPhysics {
       }
       this._lastMeshPos.copy(currentPos);
       manager.freeThreeVector3(displacement);
+    }
+
+    // World Rotation Compensation: Sync dynamic rigid bodies when the model rotates.
+    if (delta > 0) {
+      mesh.updateMatrixWorld(true);
+      const freshQuat = manager.allocThreeQuaternion();
+      mesh.getWorldQuaternion(freshQuat);
+      const deltaQuat = manager.allocThreeQuaternion();
+      deltaQuat.copy(this._lastMeshQuat).invert().multiply(freshQuat);
+      const rotAngle = 2 * Math.acos(Math.min(1, Math.abs(deltaQuat.w)));
+
+      if (rotAngle > 0.001) {
+        const pivot = position;
+        const tr = manager.allocTransform();
+
+        for (let i = 0, il = this.bodies.length; i < il; i++) {
+          const body = this.bodies[i];
+          if (body.params.physicsMode !== 0 && body.body) {
+            const ms = body.body.getMotionState();
+            if (ms) {
+              ms.getWorldTransform(tr);
+              const o = tr.getOrigin();
+
+              // Rotate position around pivot
+              const px = o.x() - pivot.x, py = o.y() - pivot.y, pz = o.z() - pivot.z;
+              const rVec = manager.allocThreeVector3();
+              rVec.set(px, py, pz).applyQuaternion(deltaQuat);
+              o.setValue(rVec.x + pivot.x, rVec.y + pivot.y, rVec.z + pivot.z);
+              manager.freeThreeVector3(rVec);
+
+              // Rotate orientation
+              const bodyQuat = tr.getRotation();
+              const thQ = manager.allocThreeQuaternion();
+              thQ.set(bodyQuat.x(), bodyQuat.y(), bodyQuat.z(), bodyQuat.w());
+              thQ.premultiply(deltaQuat);
+              const ammoQ = manager.allocQuaternion();
+              ammoQ.setValue(thQ.x, thQ.y, thQ.z, thQ.w);
+              tr.setRotation(ammoQ);
+              manager.freeQuaternion(ammoQ);
+              manager.freeThreeQuaternion(thQ);
+
+              body.body.setCenterOfMassTransform(tr);
+              ms.setWorldTransform(tr);
+
+              // Rotate velocities to keep inertia direction consistent
+              const lv = body.body.getLinearVelocity();
+              const av = body.body.getAngularVelocity();
+              const rvl = manager.allocThreeVector3();
+              rvl.set(lv.x(), lv.y(), lv.z()).applyQuaternion(deltaQuat);
+              const rva = manager.allocThreeVector3();
+              rva.set(av.x(), av.y(), av.z()).applyQuaternion(deltaQuat);
+              lv.setValue(rvl.x, rvl.y, rvl.z);
+              av.setValue(rva.x, rva.y, rva.z);
+              body.body.setLinearVelocity(lv);
+              body.body.setAngularVelocity(av);
+              manager.freeThreeVector3(rvl);
+              manager.freeThreeVector3(rva);
+            }
+          }
+        }
+        manager.freeTransform(tr);
+      }
+      this._lastMeshQuat.copy(freshQuat);
+      manager.freeThreeQuaternion(deltaQuat);
+      manager.freeThreeQuaternion(freshQuat);
     }
 
     if (scale.x !== 1 || scale.y !== 1 || scale.z !== 1) {

--- a/static/libs/three-mmd-physics-ammo.module.js
+++ b/static/libs/three-mmd-physics-ammo.module.js
@@ -1038,6 +1038,9 @@ class MMDPhysics {
 
     const manager = this.manager;
     const mesh = this.mesh;
+    // Capture previous-frame quaternion before any updates (used by rotation compensation + spin-lock)
+    const prevMeshQuat = manager.allocThreeQuaternion();
+    prevMeshQuat.copy(this._lastMeshQuat);
     let isNonDefaultScale = false;
     const position = manager.allocThreeVector3();
     const quaternion = manager.allocThreeQuaternion();
@@ -1109,7 +1112,7 @@ class MMDPhysics {
       const freshQuat = manager.allocThreeQuaternion();
       mesh.getWorldQuaternion(freshQuat);
       const deltaQuat = manager.allocThreeQuaternion();
-      deltaQuat.copy(this._lastMeshQuat).invert().multiply(freshQuat);
+      deltaQuat.copy(prevMeshQuat).invert().multiply(freshQuat);
       const rotAngle = 2 * Math.acos(Math.min(1, Math.abs(deltaQuat.w)));
 
       if (rotAngle > 0.001) {
@@ -1163,7 +1166,6 @@ class MMDPhysics {
         }
         manager.freeTransform(tr);
       }
-      this._lastMeshQuat.copy(freshQuat);
       manager.freeThreeQuaternion(deltaQuat);
       manager.freeThreeQuaternion(freshQuat);
     }
@@ -1185,7 +1187,7 @@ class MMDPhysics {
     // Spin-Lock Mechanism (自旋锁防撕裂机制):
     // 检测模型的极限空间自转。如果角速度超过安全阈值（例如高速拖拉/转圈），巨大的离心力会将密集的弹簧直接扯断。
     // 在此时强行剥夺物理引擎算力：清零所有物理动能和惯性，并将裙摆、头发死死锁在默认位置上。
-    const angleDelta = this._lastMeshQuat.angleTo(quaternion);
+    const angleDelta = prevMeshQuat.angleTo(quaternion);
     const angularVelocity = angleDelta / delta;
     if (angularVelocity > 3.0) { // 阈值：> 3.0 rad/s (约 170 度/秒)
       const zeroVel = manager.allocVector3();
@@ -1204,6 +1206,7 @@ class MMDPhysics {
       manager.freeVector3(zeroVel);
     }
     this._lastMeshQuat.copy(quaternion);
+    manager.freeThreeQuaternion(prevMeshQuat);
 
     this._stepSimulation(delta);
     this._dampNearRestBodies();

--- a/static/libs/three-mmd-physics-ammo.module.js
+++ b/static/libs/three-mmd-physics-ammo.module.js
@@ -1183,11 +1183,12 @@ class MMDPhysics {
     this._updateRigidBodies();
 
     // Spin-Lock Mechanism (自旋锁防撕裂机制):
-    // 检测模型的极限空间自转。如果角速度超过安全阈值（例如高速拖拉/转圈），巨大的离心力会将密集的弹簧直接扯断。
-    // 在此时强行剥夺物理引擎算力：清零所有物理动能和惯性，并将裙摆、头发死死锁在默认位置上。
+    // Only trigger if rotation compensation did NOT already handle this frame's rotation.
+    // Also guard against delta <= 0 to avoid Infinity/NaN.
     const angleDelta = prevMeshQuat.angleTo(quaternion);
-    const angularVelocity = angleDelta / delta;
-    if (angularVelocity > 3.0) { // 阈值：> 3.0 rad/s (约 170 度/秒)
+    const angularVelocity = delta > 0 ? angleDelta / delta : 0;
+    const rotationCompensated = delta > 0 && angleDelta > 0.001;
+    if (!rotationCompensated && angularVelocity > 3.0) { // 阈值：> 3.0 rad/s (约 170 度/秒)
       const zeroVel = manager.allocVector3();
       zeroVel.setValue(0, 0, 0);
       for (let i = 0, il = this.bodies.length; i < il; i++) {


### PR DESCRIPTION
## Problem
When rotating an MMD model, dynamic bones (hair, skirt, etc.) visibly "stretch" — kinematic bones follow the rotation instantly while physics-driven bones lag behind at their old world positions, creating a visual elongation effect. Fast rotation also triggers the spin-lock mechanism (>3.0 rad/s threshold) which force-resets all dynamic bones, causing visible stuttering.

## Root Cause
`updateBone()` for Mode 1 bones calls `_updateBonePosition()` which uses `copy()` to directly overwrite `bone.position` from the physics rigid body's world transform. When there is any positional discrepancy between the physics body and the expected bone position during rotation, the position gets set to an incorrect value, causing the bone to appear stretched.

Additionally, the physics `update()` method has position compensation for model translation (World Position Compensation) but lacks equivalent rotation compensation — dynamic rigid bodies are not synchronized when the model rotates.

## Changes
Two changes in `three-mmd-physics-ammo.module.js`:

**1. Soft position sync (`_updateBonePositionSoft`)**

Replaces the hard `copy()` in `_updateBonePosition()` with adaptive `lerp()`. The interpolation alpha adjusts based on deviation magnitude:
- Small deviation (<0.1): alpha 0.06 — fast convergence for better collision accuracy
- Medium deviation (0.1~0.5): alpha 0.02 — balanced
- Large deviation (>0.5): alpha 0.005 — prevents visual stretching

This prevents sudden position jumps that cause stretching while still allowing gradual convergence to maintain physics-visual consistency.

**2. World Rotation Compensation**

Added after the existing World Position Compensation in `update()`. When the model rotates:
- Detects rotation delta via `mesh.getWorldQuaternion()` comparison with previous frame
- For all dynamic rigid bodies (Mode 1/2):
  - Rotates position around model pivot point
  - Rotates body orientation (quaternion)
  - Rotates linear and angular velocities to maintain consistent inertia direction
- Added `mesh.updateMatrixWorld(true)` before decompose to ensure fresh transform data

This keeps dynamic bodies synchronized with model rotation, eliminating the lag that caused stretching.

## Test Plan
- [x] Slow rotation: verified no stretching — dynamic bones follow model rotation smoothly
- [x] Fast back-and-forth rotation: no stretching, no spin-lock stutter, no erratic bone flying
- [x] Cross-validation: switched between fix branch and unmodified main to confirm original exhibits stretching + spin-lock stutter while fix branch does not
- [x] lerp alpha tuning: tested alpha=0.08 (stretching returned), alpha=0.02 (improved), final: adaptive alpha based on deviation magnitude
- [x] Clipping observation: skirt clipping behavior comparable to original, no significant regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 骨骼位置同步由瞬时覆盖改为基于距离的平滑插值，提升物理驱动骨骼过渡的自然度与稳定性。
  * 在模型旋转时引入世界旋转补偿，保持物理刚体的位置、朝向及线/角速度与模型旋转一致，减少错位与抖动。
  * 优化自旋锁相关的角速度计算与帧级四元数处理，加入帧差保护以避免不良除零情况并在已补偿旋转时跳过冗余自旋锁。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->