### PR TITLE
refactor(logging): plugin 子进程日志收纳到 logs/plugin/ 子目录

### DIFF
--- a/plugin/core/host.py
+++ b/plugin/core/host.py
@@ -249,6 +249,9 @@ def _setup_plugin_logger(plugin_id: str, project_root: Path) -> Any:
         _bootstrap_setup_logging(
             service_name=f"Plugin_{safe_pid}",
             silent=True,
+            # plugin 子进程日志统一收纳到 logs/plugin/，别跟 PluginServer /
+            # Main / Memory / Agent 等宿主进程日志混在 logs/ 顶层。
+            log_subdir="plugin",
         )
     except Exception:
         # RobustLoggerConfig 自己会做多级 fallback；这里只兜底，不要遮蔽根因。

--- a/plugin/core/plugin_logger.py
+++ b/plugin/core/plugin_logger.py
@@ -91,7 +91,10 @@ class PluginFileLogger:
         """返回当前进程的日志文件路径（由本体 RobustLoggerConfig 决定）。"""
         try:
             from utils.logger_config import RobustLoggerConfig
-            cfg = RobustLoggerConfig(service_name=f"Plugin_{self.plugin_id}")
+            cfg = RobustLoggerConfig(
+                service_name=f"Plugin_{self.plugin_id}",
+                log_subdir="plugin",
+            )
             return Path(cfg.get_log_file_path())
         except Exception:
             return self.plugin_dir / "logs" / f"{self.plugin_id}.log"
@@ -99,7 +102,10 @@ class PluginFileLogger:
     def get_log_directory(self) -> Path:
         try:
             from utils.logger_config import RobustLoggerConfig
-            cfg = RobustLoggerConfig(service_name=f"Plugin_{self.plugin_id}")
+            cfg = RobustLoggerConfig(
+                service_name=f"Plugin_{self.plugin_id}",
+                log_subdir="plugin",
+            )
             return Path(cfg.get_log_directory_path())
         except Exception:
             return self.plugin_dir / "logs"

--- a/plugin/logging_config.py
+++ b/plugin/logging_config.py
@@ -228,11 +228,16 @@ def _ensure_root_logger() -> None:
         # handler。再调一次会触发 RobustLoggerConfig.setup_logger() 的 "幂等重建"
         # （清掉重建），既浪费 IO，又会多打一行 "日志系统已初始化"。
         if not service_logger.handlers:
+            # ``Plugin_<id>`` 子进程 → 收纳到 ``logs/plugin/``；
+            # ``PluginServer`` 宿主进程 → 留在顶层 ``logs/``。
+            # 前缀匹配故意卡 ``Plugin_`` 下划线，避免把 ``PluginServer`` 误路由。
+            log_subdir = "plugin" if service_name.startswith("Plugin_") else None
             try:
                 _bootstrap_setup_logging(
                     service_name=service_name,
                     log_level=_level_to_int(LOG_LEVEL),
                     silent=True,
+                    log_subdir=log_subdir,
                 )
             except Exception:
                 # bootstrap 失败 —— 同样别锁死 flag，下次真正能跑时再重试。

--- a/plugin/server/logs.py
+++ b/plugin/server/logs.py
@@ -83,12 +83,15 @@ def _validate_plugin_id(plugin_id: str) -> None:
         )
 
 
-def _resolve_robust_log_dir(service_name: str) -> Path:
+def _resolve_robust_log_dir(service_name: str, log_subdir: str | None = None) -> Path:
     """通过本体 RobustLoggerConfig 拿落盘目录。
 
     AppImage 打包后 plugin 包在只读 squashfs 下，禁止用 cwd / __file__ 推
     日志路径。RobustLoggerConfig 会按 5 级回退（Documents → AppData → home
     → temp）选择可写目录。
+
+    ``log_subdir`` 与 writer 侧保持一致：plugin 子进程写入 ``logs/plugin/``，
+    server 主进程写入 ``logs/``。
     """
     try:
         from utils.logger_config import RobustLoggerConfig
@@ -103,7 +106,7 @@ def _resolve_robust_log_dir(service_name: str) -> Path:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         RobustLoggerConfig = getattr(mod, "RobustLoggerConfig")
-    config = RobustLoggerConfig(service_name=service_name)
+    config = RobustLoggerConfig(service_name=service_name, log_subdir=log_subdir)
     log_dir = Path(config.get_log_directory_path())
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir
@@ -113,10 +116,11 @@ def get_plugin_log_dir(plugin_id: str) -> Path:
     """
     获取插件的日志目录。
 
-    所有插件 / 服务器日志统一落到本体 RobustLoggerConfig 选中的可写目录
-    （默认 Documents/N.E.K.O/logs/）。文件名由 RobustLoggerConfig 控制：
-      - 服务器日志：N.E.K.O_PluginServer_YYYYMMDD.log
-      - 插件日志：N.E.K.O_Plugin_{plugin_id}_YYYYMMDD.log
+    落盘分层（与 writer 侧 ``plugin/core/host.py`` / ``plugin/logging_config.py``
+    保持对偶）：
+
+      - 服务器日志：``<docs>/N.E.K.O/logs/N.E.K.O_PluginServer_YYYYMMDD.log``
+      - 插件日志：  ``<docs>/N.E.K.O/logs/plugin/N.E.K.O_Plugin_{id}_YYYYMMDD.log``
 
     Args:
         plugin_id: 插件ID（或 SERVER_LOG_ID 表示服务器日志）
@@ -129,9 +133,14 @@ def get_plugin_log_dir(plugin_id: str) -> Path:
     """
     _validate_plugin_id(plugin_id)
 
-    service_name = "PluginServer" if plugin_id == SERVER_LOG_ID else f"Plugin_{plugin_id}"
+    if plugin_id == SERVER_LOG_ID:
+        service_name = "PluginServer"
+        log_subdir: str | None = None
+    else:
+        service_name = f"Plugin_{plugin_id}"
+        log_subdir = "plugin"
     try:
-        return _resolve_robust_log_dir(service_name)
+        return _resolve_robust_log_dir(service_name, log_subdir=log_subdir)
     except HTTPException:
         raise
     except (

--- a/plugin/server/logs.py
+++ b/plugin/server/logs.py
@@ -149,9 +149,14 @@ def get_plugin_log_dir(plugin_id: str) -> Path:
         *_RUNTIME_ERRORS,
     ) as exc:
         # 终极兜底：临时目录。绝不再走 plugin/ 包内目录（squashfs 只读）。
+        # 把 log_subdir 也接到兜底路径上，保持 reader/writer 对偶 —— 否则
+        # writer 正常写 ``.../logs/plugin/``、reader 走到这里去读
+        # ``.../neko/logs/``，前端直接读空。
         logger.warning(f"Failed to resolve robust log dir for {service_name}: {exc}; falling back to temp")
         import tempfile
         fallback_dir = Path(tempfile.gettempdir()) / "neko" / "logs"
+        if log_subdir:
+            fallback_dir = fallback_dir / log_subdir
         fallback_dir.mkdir(parents=True, exist_ok=True)
         return fallback_dir
 

--- a/plugin/tests/unit/test_plugin_logging_landing.py
+++ b/plugin/tests/unit/test_plugin_logging_landing.py
@@ -152,20 +152,35 @@ def test_plugin_server_main_process_unifies_logs_under_pluginserver(
     # and a stray N.E.K.O_Plugin_*.log would exist.
     assert not list(isolated_log_dir.glob("N.E.K.O_Plugin_*.log"))
 
+    # PluginServer 是宿主进程，绝对不能被收纳到 logs/plugin/ —— 否则 Electron
+    # 那侧按顶层路径读 PluginServer 日志时会一片空白。
+    plugin_subdir = isolated_log_dir / "plugin"
+    if plugin_subdir.exists():
+        assert not list(plugin_subdir.glob("N.E.K.O_PluginServer_*.log")), (
+            "PluginServer 宿主日志被误路由到 logs/plugin/ 子目录了。"
+        )
+
 
 def test_plugin_subprocess_logs_to_its_own_service_file(isolated_log_dir, monkeypatch):
     """Simulate _setup_plugin_logger from plugin/core/host.py:
     1. set NEKO_PLUGIN_SERVICE_NAME=Plugin_<safe_pid>
-    2. utils.logger_config.setup_logging(service_name="Plugin_<safe_pid>")
+    2. utils.logger_config.setup_logging(service_name="Plugin_<safe_pid>",
+       log_subdir="plugin")
     3. plugin.logging_config.get_logger(f"plugin.{safe_pid}").bind(plugin_id=...)
 
-    Expectation: logs land in N.E.K.O_Plugin_demo_*.log and nowhere else.
+    Expectation: logs land in ``logs/plugin/N.E.K.O_Plugin_demo_*.log`` — NOT
+    at the ``logs/`` top level where PluginServer / Main / Memory / Agent live.
     """
     monkeypatch.setenv("NEKO_PLUGIN_SERVICE_NAME", "Plugin_demo")
 
     from utils.logger_config import setup_logging as bootstrap_setup_logging
 
-    bootstrap_setup_logging(service_name="Plugin_demo", log_level=logging.INFO, silent=True)
+    bootstrap_setup_logging(
+        service_name="Plugin_demo",
+        log_level=logging.INFO,
+        silent=True,
+        log_subdir="plugin",
+    )
 
     plogging = importlib.import_module("plugin.logging_config")
 
@@ -176,15 +191,23 @@ def test_plugin_subprocess_logs_to_its_own_service_file(isolated_log_dir, monkey
     for h in logging.getLogger("N.E.K.O.Plugin_demo").handlers:
         h.flush()
 
-    text = _read_logs(isolated_log_dir, "Plugin_demo")
+    plugin_subdir = isolated_log_dir / "plugin"
+    text = _read_logs(plugin_subdir, "Plugin_demo")
     assert "hello-from-plugin-demo" in text
     assert "warn-from-plugin-demo" in text
 
     # error log file gets opened on setup; nothing should be written there
     # for INFO/WARNING traffic.
-    error_file = isolated_log_dir / "N.E.K.O_Plugin_demo_error.log"
+    error_file = plugin_subdir / "N.E.K.O_Plugin_demo_error.log"
     if error_file.exists():
         assert "hello-from-plugin-demo" not in error_file.read_text(encoding="utf-8")
+
+    # Plugin_* 子进程日志绝对不能再污染顶层 logs/。顶层是留给 PluginServer /
+    # Main / Memory / Agent 宿主进程的。如果未来又有人忘了传 log_subdir，
+    # 这个反向断言会在 CI 直接报错。
+    assert not list(isolated_log_dir.glob("N.E.K.O_Plugin_demo_*.log")), (
+        "Plugin_demo 子进程日志落到 logs/ 顶层了；应收纳到 logs/plugin/。"
+    )
 
 
 def test_module_level_logger_follows_late_service_name_change(
@@ -216,7 +239,12 @@ def test_module_level_logger_follows_late_service_name_change(
     # Step 3: host belatedly sets env + boots its logger sink.
     monkeypatch.setenv("NEKO_PLUGIN_SERVICE_NAME", "Plugin_lazy")
     from utils.logger_config import setup_logging as bootstrap_setup_logging
-    bootstrap_setup_logging(service_name="Plugin_lazy", log_level=logging.INFO, silent=True)
+    bootstrap_setup_logging(
+        service_name="Plugin_lazy",
+        log_level=logging.INFO,
+        silent=True,
+        log_subdir="plugin",
+    )
 
     # Step 4: emit through the loggers grabbed BEFORE step 3.
     early_logger.info("late-routed-shared")
@@ -226,7 +254,7 @@ def test_module_level_logger_follows_late_service_name_change(
     for h in logging.getLogger("N.E.K.O.Plugin_lazy").handlers:
         h.flush()
 
-    text = _read_logs(isolated_log_dir, "Plugin_lazy")
+    text = _read_logs(isolated_log_dir / "plugin", "Plugin_lazy")
     assert "late-routed-shared" in text, (
         "PluginLoggerAdapter froze its stdlib logger at construction — "
         "subprocess-style late env change no longer routes to the right file."

--- a/utils/logger_config.py
+++ b/utils/logger_config.py
@@ -60,11 +60,11 @@ class RobustLoggerConfig:
     DEFAULT_BACKUP_COUNT = 5  # Keep 5 backup files
     DEFAULT_LOG_RETENTION_DAYS = 30  # Keep logs for 30 days
     
-    def __init__(self, app_name=None, service_name=None, log_level=None, max_bytes=None, 
-                 backup_count=None, retention_days=None):
+    def __init__(self, app_name=None, service_name=None, log_level=None, max_bytes=None,
+                 backup_count=None, retention_days=None, log_subdir=None):
         """
         初始化日志配置
-        
+
         Args:
             app_name: 应用名称，用于创建日志目录，默认使用配置中的 APP_NAME
             service_name: 服务名称，用于区分不同服务的日志文件（如Main、Memory、Agent）
@@ -72,6 +72,11 @@ class RobustLoggerConfig:
             max_bytes: 单个日志文件的最大大小
             backup_count: 保留的备份文件数量
             retention_days: 日志保留天数
+            log_subdir: 日志落到基目录下的哪个子目录（如 "plugin"）。默认 None =
+                直接写到基目录 ``<docs>/N.E.K.O/logs/``。传入 ``"plugin"`` 会把日志
+                路由到 ``<docs>/N.E.K.O/logs/plugin/``，用于把大量 plugin 子进程
+                日志从顶层收纳到一个子目录，避免与 PluginServer / Main / Memory /
+                Agent 等宿主进程日志混在一起。
         """
         self.app_name = app_name if app_name is not None else APP_NAME
         self.service_name = service_name  # 服务名称用于文件名区分
@@ -79,9 +84,15 @@ class RobustLoggerConfig:
         self.max_bytes = max_bytes or self.DEFAULT_MAX_BYTES
         self.backup_count = backup_count or self.DEFAULT_BACKUP_COUNT
         self.retention_days = retention_days or self.DEFAULT_LOG_RETENTION_DAYS
-        
-        # 获取日志目录
+        self.log_subdir = log_subdir
+
+        # 获取日志目录（先拿到基目录，再按 log_subdir 路由到子目录）
         self.log_dir = self._get_log_directory()
+        if log_subdir:
+            # 不让调用方传带 "/" 的路径，避免意外逃出基目录。
+            safe = str(log_subdir).strip().strip("/\\")
+            if safe:
+                self.log_dir = self.log_dir / safe
         
         # 日志文件名：如果有service_name则包含，否则只用app_name
         if self.service_name:
@@ -419,24 +430,34 @@ class EnhancedLogger:
         self._logger.exception(msg, *args, **kwargs)
 
 
-def setup_logging(app_name=None, service_name=None, log_level=None, silent=False):
+def setup_logging(app_name=None, service_name=None, log_level=None, silent=False,
+                  log_subdir=None):
     """
     便捷函数：设置日志配置
-    
+
     Args:
         app_name: 应用名称，默认使用配置中的 APP_NAME（用于确定日志目录）
         service_name: 服务名称，用于区分不同服务的日志文件（如Main、Memory、Agent）
         log_level: 日志级别
         silent: 静默模式，不打印初始化消息（用于子进程避免重复输出）
-        
+        log_subdir: 日志子目录。plugin 子进程传 ``"plugin"`` 即可把
+            ``N.E.K.O_Plugin_<id>_*.log`` 收纳到 ``logs/plugin/`` 下，避免与
+            PluginServer / Main / Memory / Agent 等宿主进程的日志混在顶层。
+            默认 ``None`` = 保持老行为，写到 ``logs/`` 基目录。
+
     Returns:
         tuple: (增强的logger实例, 日志配置对象)
-        
+
     注意：
         返回的logger会自动在error()调用时包含traceback（如果在异常上下文中）
         也可以使用logger.exception()来明确记录异常信息
     """
-    config = RobustLoggerConfig(app_name=app_name, service_name=service_name, log_level=log_level)
+    config = RobustLoggerConfig(
+        app_name=app_name,
+        service_name=service_name,
+        log_level=log_level,
+        log_subdir=log_subdir,
+    )
     # 使用带命名空间的 logger 名（如 N.E.K.O.Agent），
     # 避免与第三方库的同名 logger 冲突（browser_use 内部有名为 "Agent" 的 logger）。
     base_logger = config.setup_logger()


### PR DESCRIPTION
## 动机（#912 的 follow-up）

拆完 loguru 后所有服务都落到 `<docs>/N.E.K.O/logs/` 顶层，几十个插件日后一人一个 `N.E.K.O_Plugin_<id>_YYYYMMDD.log` + `N.E.K.O_Plugin_<id>_error.log` + 轮转后缀，几天下来顶层目录就被淹没，PluginServer / Main / Memory / Agent 宿主进程的日志找不到。

## 落盘布局

```
<docs>/N.E.K.O/logs/
  N.E.K.O_PluginServer_20260421.log   ← 宿主，顶层
  N.E.K.O_PluginServer_error.log
  N.E.K.O_Main_20260421.log
  N.E.K.O_Memory_20260421.log
  N.E.K.O_Agent_20260421.log
  ...
  plugin/                              ← 新增收纳层
    N.E.K.O_Plugin_demo_20260421.log
    N.E.K.O_Plugin_demo_error.log
    N.E.K.O_Plugin_bilibili_danmaku_20260421.log
    ...
```

## 改动点

- **`utils/logger_config.RobustLoggerConfig`** 新增可选 `log_subdir` 参数（同步暴露到 `setup_logging()`）。默认 `None` = 零行为变化，Main / Memory / Agent / PluginServer 落盘位置不动。路径拼接完 strip 掉 `/` `\\` 防止调用方意外逃出基目录。
- **`plugin/core/host.py`** `_setup_plugin_logger` 显式传 `log_subdir="plugin"`。
- **`plugin/logging_config._ensure_root_logger`** 兜底 bootstrap 按 `service_name.startswith("Plugin_")` 判断。故意卡下划线 —— `PluginServer` 没有后置下划线，不会误路由到 `plugin/`。
- **`plugin/server/logs.py`** reader 侧对偶：`get_plugin_log_dir` 对 `Plugin_<id>` 传 `"plugin"`、对 `SERVER_LOG_ID` 不传；`_resolve_robust_log_dir` 接受 `log_subdir` kwarg；`_list_plugin_log_files_for_tail` 和 3 处调用点（API endpoint / `_watch_loop` / `send_initial_logs`）无需改动 —— helper 拿到什么目录就 glob 什么。
- **`plugin/core/plugin_logger.PluginFileLogger`** `get_log_file_path` / `get_log_directory` 同步传 `log_subdir="plugin"`，避免 SDK 侧报的文件路径跟 writer 真实落盘分叉。
- **前端** 无硬编码路径（已搜过整个 `frontend/`）。

## 测试

- `test_plugin_logging_landing.py`：
  - `Plugin_demo` / `Plugin_lazy` 测试改读 `logs/plugin/` 子目录；
  - 新增两条反向断言 —— `PluginServer` 不得出现在 `logs/plugin/`，`Plugin_demo` 不得出现在 `logs/` 顶层。未来若有人忘传 `log_subdir` CI 会直接报错。
- `test_logs_latest_file_filter.py`：helper 签名未变、拿到什么目录读什么，无需改动。
- 本 PR 改动的 10 个日志相关测试全部通过（`test_plugin_logging_landing.py` 6 + `test_logs_latest_file_filter.py` 4）。
- 其余 4 个 preexisting failure 与本 PR 无关（`test_plugin_meta_fields_shape` / `test_core_types_and_dataclasses` / `test_plugin_cli_inspect_and_verify_routes` / `test_plugin_cli_pack_bundle_route_uses_mode_payload`），已在 main 上直接复现。

## 决策说明

1. **旧日志不迁移、不兼容读**（用户决策）。新版本部署时旧的 `N.E.K.O_Plugin_*.log` 孤立在 `logs/` 顶层，retention 到期后自然消亡。
2. **不按 `plugin_id` 再分一层**（`logs/plugin/<id>/N.E.K.O_Plugin_<id>_*.log`）：文件名已编 `plugin_id`，再加一层目录信息冗余；reader 需要扫子目录，复杂度↑；按插件清日志 `rm logs/plugin/*_Plugin_<id>_*` 一样能做到。哪个插件真的日志爆炸再单独分层不迟。
3. **显式 `log_subdir` 参数** vs 基于 `service_name` 前缀自动路由：#912 因 `setdefault` 的隐式行为踩过坑，显式 > 隐式。plugin 侧两个 writer 入口（`plugin/core/host.py` / `plugin/logging_config._ensure_root_logger`）各显式传一次，非 plugin 服务一行都不改。

## Test plan

- [x] `uv run pytest plugin/tests/unit/test_plugin_logging_landing.py plugin/tests/unit/server/test_logs_latest_file_filter.py` 全绿
- [x] `uv run pytest plugin/tests/unit/`（排除 preexisting failure）全绿
- [ ] CI：CodeRabbit review + analyze.yml（`check_no_loguru` 守门）

https://claude.ai/code/session_019XbvPkZGUYSjLMEathSjMi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 插件日志现在写入专属子目录（logs/plugin/），主机与插件日志分离，便于管理与排查。
* **测试**
  * 更新测试以验证插件日志路由到子目录，并确保主机进程日志仍写入顶层日志目录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->