### PR TITLE
fix(tests): monkeypatch _TARGET_ROOT alongside _RUNTIME_PLUGINS_ROOT …

### DIFF
--- a/plugin/tests/unit/server/test_plugin_cli_route.py
+++ b/plugin/tests/unit/server/test_plugin_cli_route.py
@@ -64,10 +64,15 @@ def plugin_cli_test_app() -> FastAPI:
 async def test_plugin_cli_inspect_and_verify_routes(
     plugin_cli_test_app: FastAPI,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     plugin_dir = _make_plugin_dir(tmp_path)
     package_path = tmp_path / "route_demo.neko-plugin"
     pack_plugin(plugin_dir, package_path)
+
+    import plugin.server.application.plugin_cli.service as plugin_cli_service_module
+
+    monkeypatch.setattr(plugin_cli_service_module, "_TARGET_ROOT", tmp_path)
 
     transport = ASGITransport(app=plugin_cli_test_app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:
@@ -142,6 +147,7 @@ async def test_plugin_cli_pack_bundle_route_uses_mode_payload(
     import plugin.server.application.plugin_cli.service as plugin_cli_service_module
 
     monkeypatch.setattr(plugin_cli_service_module, "_RUNTIME_PLUGINS_ROOT", tmp_path)
+    monkeypatch.setattr(plugin_cli_service_module, "_TARGET_ROOT", tmp_path)
 
     transport = ASGITransport(app=plugin_cli_test_app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as client:


### PR DESCRIPTION
…in plugin CLI tests

PR #916 added _TARGET_ROOT path restriction to the plugin CLI service so target_dir / package paths must live inside _CLI_ROOT / "target". Two unit tests that operate on tmp_path paths never patched _TARGET_ROOT, so the CLI returned 400 when the request used tmp_path. Add the missing monkeypatch (and a MonkeyPatch fixture param where absent).

https://claude.ai/code/session_019XbvPkZGUYSjLMEathSjMi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新了单元测试以改进测试环境的配置和临时路径的处理，确保测试的稳定性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->