### PR TITLE
Fix Live2D idle animation restoration logic in triggerRandomEmotion

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1994,7 +1994,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         if (urlMatch) mmdPath = urlMatch[1];
                     }
                     modelData.mmd = mmdPath;
-                    if (mmdAnimationSelect && mmdAnimationSelect.value) {
+                    if (mmdAnimationSelect && mmdAnimationSelect.value && mmdAnimationSelect.value !== '_no_motion_') {
                         modelData.mmd_animation = mmdAnimationSelect.value;
                     }
                     const mmdIdleUrls = getSelectedIdleAnimations('mmd-idle-animation-multiselect');
@@ -2017,7 +2017,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                         }
                     }
                     modelData.vrm = vrmPath;
-                    if (vrmAnimation) {
+                    if (vrmAnimation && vrmAnimation !== '_no_motion_') {
                         modelData.vrm_animation = vrmAnimation;
                     }
                     const vrmIdleUrls = getSelectedIdleAnimations('vrm-idle-animation-multiselect');
@@ -2037,8 +2037,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 console.log('[Live2D Save] motionSelect.value:', motionSelect ? motionSelect.value : 'null');
                 console.log('[Live2D Save] currentModelFiles.motion_files:', currentModelFiles?.motion_files);
                 if (motionSelect) {
-                    // 【修复】无论是否有值，即使是空字符串（用户点击清空/默认选项），也要显式发送给后端，触发置空逻辑
-                    modelData.live2d_idle_animation = motionSelect.value || "";
+                    const motionVal = motionSelect.value;
+                    modelData.live2d_idle_animation = (motionVal && motionVal !== '_no_motion_') ? motionVal : "";
                     console.log('[Live2D Save] Added live2d_idle_animation to modelData:', modelData.live2d_idle_animation);
                 }
                 console.log('[Live2D Save] Final modelData:', JSON.stringify(modelData, null, 2));
@@ -3423,6 +3423,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             if (vrmAnimationSelect && vrmAnimations.length > 0) {
                 vrmAnimationSelect.innerHTML = `<option value="">${t('live2d.selectMotion', '选择动作')}</option>`;
+                const noMotionOption = document.createElement('option');
+                noMotionOption.value = '_no_motion_';
+                noMotionOption.textContent = t('live2d.noMotion', '无动作');
+                vrmAnimationSelect.appendChild(noMotionOption);
                 vrmAnimations.forEach(anim => {
                     // 确保 animPath 是字符串：优先使用 anim.path，否则使用 anim.url，最后使用 anim 本身（如果是字符串）
                     const animPath = (typeof anim.path === 'string' ? anim.path : null)
@@ -3527,6 +3531,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                 // 重置选择器到第一个选项（保持显示"选择动作"）
                 e.target.value = '';
                 updateVRMAnimationSelectButtonText(); // 更新按钮文字为"选择动作"
+                return;
+            }
+
+            // 无动作选项：停止当前播放的 VRM 动作
+            if (selectedValue === '_no_motion_') {
+                if (vrmManager) {
+                    vrmManager.stopVRMAAnimation();
+                    isVrmAnimationPlaying = false;
+                    updateVRMAnimationPlayButtonIcon();
+                    showStatus(t('live2d.motionStopped', '动作已停止'), 1000);
+                }
+                if (playVrmAnimationBtn) playVrmAnimationBtn.disabled = false;
                 return;
             }
 
@@ -3728,6 +3744,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!mmdAnimationSelect) return;
 
             mmdAnimationSelect.innerHTML = `<option value="">${t('live2d.mmdAnimation.selectAnimation', '选择VMD动画')}</option>`;
+            const noMotionOption = document.createElement('option');
+            noMotionOption.value = '_no_motion_';
+            noMotionOption.textContent = t('live2d.noMotion', '无动作');
+            mmdAnimationSelect.appendChild(noMotionOption);
             if (mmdAnimations.length > 0) {
                 mmdAnimations.forEach(anim => {
                     const animPath = anim.path || anim.url || (typeof anim === 'string' ? anim : null);
@@ -4418,6 +4438,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                 return;
             }
 
+            // 无动作选项：停止当前播放的 MMD 动画
+            if (animPath === '_no_motion_') {
+                if (window.mmdManager) {
+                    window.mmdManager.stopAnimation();
+                    isMmdAnimationPlaying = false;
+                    updateMMDAnimationPlayButtonIcon();
+                    showStatus(t('live2d.motionStopped', '动作已停止'), 1000);
+                }
+                if (playMmdAnimationBtn) playMmdAnimationBtn.disabled = false;
+                return;
+            }
+
             if (!window.mmdManager) return;
 
             try {
@@ -4509,6 +4541,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const expressions = vrmManager.expression.getExpressionList();
 
         vrmExpressionSelect.innerHTML = `<option value="">${t('live2d.selectExpression', '选择表情')}</option>`;
+        const noExpressionOption = document.createElement('option');
+        noExpressionOption.value = '_no_expression_';
+        noExpressionOption.textContent = t('live2d.noExpression', '无表情');
+        vrmExpressionSelect.appendChild(noExpressionOption);
 
         if (expressions.length > 0) {
             expressions.forEach(name => {
@@ -4585,6 +4621,18 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (triggerVrmExpressionBtn) {
                     triggerVrmExpressionBtn.disabled = true;
                 }
+                return;
+            }
+
+            // 无表情选项：清除 VRM 表情
+            if (selectedValue === '_no_expression_') {
+                if (vrmManager && vrmManager.expression) {
+                    vrmManager.expression.resetBaseExpression();
+                    isVrmExpressionPlaying = false;
+                    updateVRMExpressionPlayButtonIcon();
+                    showStatus(t('live2d.expressionCleared', '表情已清除'), 1000);
+                }
+                if (triggerVrmExpressionBtn) triggerVrmExpressionBtn.disabled = false;
                 return;
             }
 

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -579,6 +579,9 @@ function captureSettingsSnapshot() {
         live2dIdleAnimation: document.getElementById('motion-select')?.value ?? '',
         idleAnimation: JSON.stringify(_getSelectedIdleAnimationsGlobal('vrm-idle-animation-multiselect')),
         mmdIdleAnimation: JSON.stringify(_getSelectedIdleAnimationsGlobal('mmd-idle-animation-multiselect')),
+        // VRM/MMD 手动动作选择
+        vrmAnimation: document.getElementById('vrm-animation-select')?.value ?? '',
+        mmdAnimation: document.getElementById('mmd-animation-select')?.value ?? '',
     };
 }
 
@@ -3429,31 +3432,35 @@ document.addEventListener('DOMContentLoaded', async () => {
             const data = await RequestHelper.fetchJson('/api/model/vrm/animations');
             vrmAnimations = (data.success && data.animations) ? data.animations : [];
 
-            if (vrmAnimationSelect && vrmAnimations.length > 0) {
+            if (vrmAnimationSelect) {
+                // 始终保留"无动作"选项，让用户能清空已保存的动作配置
                 vrmAnimationSelect.innerHTML = `<option value="">${t('live2d.selectMotion', '选择动作')}</option>`;
                 const noMotionOption = document.createElement('option');
                 noMotionOption.value = '_no_motion_';
                 noMotionOption.textContent = t('live2d.noMotion', '无动作');
                 vrmAnimationSelect.appendChild(noMotionOption);
-                vrmAnimations.forEach(anim => {
-                    // 确保 animPath 是字符串：优先使用 anim.path，否则使用 anim.url，最后使用 anim 本身（如果是字符串）
-                    const animPath = (typeof anim.path === 'string' ? anim.path : null)
-                        || (typeof anim.url === 'string' ? anim.url : null)
-                        || (typeof anim === 'string' ? anim : null);
-                    if (!animPath) {
-                        console.warn('[VRM] 跳过无效动画项:', anim);
-                        return;
-                    }
 
-                    const option = document.createElement('option');
-                    const finalUrl = ModelPathHelper.vrmToUrl(animPath, 'animation');
+                if (vrmAnimations.length > 0) {
+                    vrmAnimations.forEach(anim => {
+                        // 确保 animPath 是字符串：优先使用 anim.path，否则使用 anim.url，最后使用 anim 本身（如果是字符串）
+                        const animPath = (typeof anim.path === 'string' ? anim.path : null)
+                            || (typeof anim.url === 'string' ? anim.url : null)
+                            || (typeof anim === 'string' ? anim : null);
+                        if (!animPath) {
+                            console.warn('[VRM] 跳过无效动画项:', anim);
+                            return;
+                        }
 
-                    option.value = finalUrl;
-                    option.setAttribute('data-path', animPath);
-                    option.setAttribute('data-filename', anim.name || anim.filename || finalUrl.split('/').pop());
-                    option.textContent = option.getAttribute('data-filename');
-                    vrmAnimationSelect.appendChild(option);
-                });
+                        const option = document.createElement('option');
+                        const finalUrl = ModelPathHelper.vrmToUrl(animPath, 'animation');
+
+                        option.value = finalUrl;
+                        option.setAttribute('data-path', animPath);
+                        option.setAttribute('data-filename', anim.name || anim.filename || finalUrl.split('/').pop());
+                        option.textContent = option.getAttribute('data-filename');
+                        vrmAnimationSelect.appendChild(option);
+                    });
+                }
                 vrmAnimationSelect.disabled = false;
                 if (vrmAnimationSelectBtn) {
                     vrmAnimationSelectBtn.disabled = false;
@@ -3461,10 +3468,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 updateVRMAnimationDropdown();
                 updateVRMAnimationSelectButtonText();
                 showStatus(t('live2d.vrmAnimation.animationListLoaded', '动作列表加载成功'), 2000);
-            } else {
-                vrmAnimationSelect.innerHTML = `<option value="">${t('live2d.vrmAnimation.noAnimations', '未找到动作文件')}</option>`;
-                updateVRMAnimationDropdown();
-                updateVRMAnimationSelectButtonText();
             }
         } catch (error) {
             console.error('加载 VRM 动作列表失败:', error);
@@ -3769,11 +3772,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                     option.textContent = filename;
                     mmdAnimationSelect.appendChild(option);
                 });
-                mmdAnimationSelect.disabled = false;
-                if (mmdAnimationSelectBtn) mmdAnimationSelectBtn.disabled = false;
-            } else {
-                mmdAnimationSelect.innerHTML = `<option value="">${t('live2d.mmdAnimation.noAnimation', '无动画')}</option>`;
             }
+            mmdAnimationSelect.disabled = false;
+            if (mmdAnimationSelectBtn) mmdAnimationSelectBtn.disabled = false;
             updateMMDAnimationDropdown();
             updateMMDAnimationSelectButtonText();
         } catch (error) {
@@ -4447,7 +4448,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 return;
             }
 
-            // 无动作选项：停止当前播放的 MMD 动画
+            // 无动作选项：停止当前播放的 MMD 动画，并重置 idle 状态避免状态污染
+            // stopAnimation() 会停掉当前待机动画，但 isMmdIdlePlaying 仍保持旧值；
+            // 下一次启动 idle rotation 时可能把 stale currentAnimationUrl 当成仍在播放，
+            // 导致跳过首次播放/监听器注册。因此需要同步重置 isMmdIdlePlaying。
             if (animPath === '_no_motion_') {
                 if (window.mmdManager) {
                     window.mmdManager.stopAnimation();
@@ -4456,6 +4460,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     showStatus(t('live2d.motionStopped', '动作已停止'), 1000);
                 }
                 if (playMmdAnimationBtn) playMmdAnimationBtn.disabled = true;
+                isMmdIdlePlaying = false; // 重置 idle 状态，避免下一次 idle 轮换误判
                 stopIdleRotation('mmd');
                 return;
             }

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1994,8 +1994,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                         if (urlMatch) mmdPath = urlMatch[1];
                     }
                     modelData.mmd = mmdPath;
-                    if (mmdAnimationSelect && mmdAnimationSelect.value && mmdAnimationSelect.value !== '_no_motion_') {
-                        modelData.mmd_animation = mmdAnimationSelect.value;
+                    if (mmdAnimationSelect) {
+                        if (mmdAnimationSelect.value === '_no_motion_') {
+                            modelData.mmd_animation = '';
+                        } else if (mmdAnimationSelect.value) {
+                            modelData.mmd_animation = mmdAnimationSelect.value;
+                        }
                     }
                     const mmdIdleUrls = getSelectedIdleAnimations('mmd-idle-animation-multiselect');
                     modelData.mmd_idle_animation = mmdIdleUrls;
@@ -2017,8 +2021,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                         }
                     }
                     modelData.vrm = vrmPath;
-                    if (vrmAnimation && vrmAnimation !== '_no_motion_') {
-                        modelData.vrm_animation = vrmAnimation;
+                    if (vrmAnimationSelect) {
+                        if (vrmAnimationSelect.value === '_no_motion_') {
+                            modelData.vrm_animation = '';
+                        } else if (vrmAnimationSelect.value) {
+                            modelData.vrm_animation = vrmAnimationSelect.value;
+                        }
                     }
                     const vrmIdleUrls = getSelectedIdleAnimations('vrm-idle-animation-multiselect');
                     modelData.idle_animation = vrmIdleUrls;
@@ -3542,7 +3550,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     updateVRMAnimationPlayButtonIcon();
                     showStatus(t('live2d.motionStopped', '动作已停止'), 1000);
                 }
-                if (playVrmAnimationBtn) playVrmAnimationBtn.disabled = false;
+                if (playVrmAnimationBtn) playVrmAnimationBtn.disabled = true;
+                stopIdleRotation('vrm');
                 return;
             }
 
@@ -4446,7 +4455,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     updateMMDAnimationPlayButtonIcon();
                     showStatus(t('live2d.motionStopped', '动作已停止'), 1000);
                 }
-                if (playMmdAnimationBtn) playMmdAnimationBtn.disabled = false;
+                if (playMmdAnimationBtn) playMmdAnimationBtn.disabled = true;
+                stopIdleRotation('mmd');
                 return;
             }
 
@@ -4632,7 +4642,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     updateVRMExpressionPlayButtonIcon();
                     showStatus(t('live2d.expressionCleared', '表情已清除'), 1000);
                 }
-                if (triggerVrmExpressionBtn) triggerVrmExpressionBtn.disabled = false;
+                if (triggerVrmExpressionBtn) triggerVrmExpressionBtn.disabled = true;
                 return;
             }
 

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -2044,14 +2044,15 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                 }
 
                 let backupDefs, backupGroups, backupSettingsMotions, backupJsonMotions, backupJsonFileRefs;
-                    let groupExisted = false;
+                let groupExisted = false;
+                let internalModel, motionManager, json, live2dModel;
 
-                    try {
-                        const internalModel = this.currentModel.internalModel;
-                        const motionManager = internalModel.motionManager;
-                        const json = internalModel.settings.json;
+                try {
+                    internalModel = this.currentModel.internalModel;
+                    motionManager = internalModel.motionManager;
+                    json = internalModel.settings.json;
 
-                        backupDefs = motionManager.definitions?.[groupName];
+                    backupDefs = motionManager.definitions?.[groupName];
                         backupGroups = motionManager.motionGroups?.[groupName];
                         backupSettingsMotions = internalModel.settings.motions?.[groupName];
                         backupJsonMotions = json?.motions?.[groupName];
@@ -2059,7 +2060,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
 
                         groupExisted = backupDefs !== undefined || backupGroups !== undefined;
 
-                        const tempMotionsList = [{ 'File': motion.File }];
+                        let tempMotionsList = [{ 'File': motion.File }];
 
                         if (json) {
                             if (!json.FileReferences) json.FileReferences = {};
@@ -2078,7 +2079,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                         if (!motionManager.motionGroups) motionManager.motionGroups = {};
                         motionManager.motionGroups[groupName] = [];
 
-                        const live2dModel = this.currentModel;
+                        live2dModel = this.currentModel;
                         console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
                         await motionManager.loadMotion(groupName, 0);
 

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -1846,6 +1846,7 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
         
         console.log('[Interaction] 点击效果持续时间结束，平滑恢复到默认状态');
         this._currentClickEffectId = null;
+        // 待机动画恢复函数，等平滑恢复完成后再调用，避免被 smoothReset 停掉刚恢复的待机动画
         const restoreIdleMotion = () => {
             if (typeof window.restoreLive2DIdleAnimationOnMainPage === 'function') {
                 window.restoreLive2DIdleAnimationOnMainPage();
@@ -2034,6 +2035,8 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                                 const motionManager = internalModel.motionManager;
                                 const json = internalModel.settings.json;
 
+                                // 使用完整列表而非稀疏数组，
+                                // 避免 motionManager.definitions[groupName] 变成稀疏数组导致同组其它动作丢失
                                 const motionsList = [{ 'File': motion.File }];
 
                                 if (json) {
@@ -2055,6 +2058,7 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                                 }
                                 motionManager.motionGroups[groupName] = [];
 
+                                // 捕获模型引用，await 后校验是否切换了模型，防止旧请求下发到新模型
                                 const live2dModel = this.currentModel;
                                 console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
                                 await motionManager.loadMotion(groupName, 0);

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -1864,9 +1864,6 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
         } else {
             restoreIdleMotion();
         }
-        if (typeof window.restoreLive2DIdleAnimationOnMainPage === 'function') {
-            window.restoreLive2DIdleAnimationOnMainPage();
-        }
     }, window.live2dManager.CLICK_EFFECT_DURATION);
 };
 
@@ -2046,66 +2043,81 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                     console.warn(`[TouchSet] 无法获取motion持续时间:`, error);
                 }
 
-                try {
-                    const internalModel = this.currentModel.internalModel;
-                    const motionManager = internalModel.motionManager;
-                    const json = internalModel.settings.json;
+                let backupDefs, backupGroups, backupSettingsMotions, backupJsonMotions, backupJsonFileRefs;
+                    let groupExisted = false;
 
-                    const backupDefs = motionManager.definitions?.[groupName];
-                    const backupGroups = motionManager.motionGroups?.[groupName];
-                    const backupSettingsMotions = internalModel.settings.motions?.[groupName];
-                    const backupJsonMotions = json?.motions?.[groupName];
-                    const backupJsonFileRefs = json?.FileReferences?.Motions?.[groupName];
+                    try {
+                        const internalModel = this.currentModel.internalModel;
+                        const motionManager = internalModel.motionManager;
+                        const json = internalModel.settings.json;
 
-                    const tempMotionsList = [{ 'File': motion.File }];
+                        backupDefs = motionManager.definitions?.[groupName];
+                        backupGroups = motionManager.motionGroups?.[groupName];
+                        backupSettingsMotions = internalModel.settings.motions?.[groupName];
+                        backupJsonMotions = json?.motions?.[groupName];
+                        backupJsonFileRefs = json?.FileReferences?.Motions?.[groupName];
 
-                    if (json) {
-                        if (!json.FileReferences) json.FileReferences = {};
-                        if (!json.FileReferences.Motions) json.FileReferences.Motions = {};
-                        json.FileReferences.Motions[groupName] = tempMotionsList;
-                        if (!json.motions) json.motions = {};
-                        json.motions[groupName] = tempMotionsList;
+                        groupExisted = backupDefs !== undefined || backupGroups !== undefined;
+
+                        const tempMotionsList = [{ 'File': motion.File }];
+
+                        if (json) {
+                            if (!json.FileReferences) json.FileReferences = {};
+                            if (!json.FileReferences.Motions) json.FileReferences.Motions = {};
+                            json.FileReferences.Motions[groupName] = tempMotionsList;
+                            if (!json.motions) json.motions = {};
+                            json.motions[groupName] = tempMotionsList;
+                        }
+
+                        if (!internalModel.settings.motions) internalModel.settings.motions = {};
+                        internalModel.settings.motions[groupName] = tempMotionsList;
+
+                        if (!motionManager.definitions) motionManager.definitions = {};
+                        motionManager.definitions[groupName] = tempMotionsList;
+
+                        if (!motionManager.motionGroups) motionManager.motionGroups = {};
+                        motionManager.motionGroups[groupName] = [];
+
+                        const live2dModel = this.currentModel;
+                        console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
+                        await motionManager.loadMotion(groupName, 0);
+
+                        if (live2dModel !== this.currentModel) {
+                            console.log('[TouchSet] 模型已切换，中止动作播放');
+                            return;
+                        }
+
+                        motionManager.stopAllMotions();
+                        const result = await live2dModel.motion(groupName, 0, 3);
+
+                        if (result) {
+                            console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
+                        } else {
+                            console.warn(`[TouchSet] ❌ 动作加载成功但引擎仍拒绝播放: ${groupName}[0]`);
+                        }
+                    } catch (error) {
+                        console.warn(`[TouchSet] 动作播放异常: ${groupName}[0]`, error);
+                    } finally {
+                        if (groupExisted) {
+                            if (backupDefs !== undefined) motionManager.definitions[groupName] = backupDefs;
+                            if (backupGroups !== undefined) motionManager.motionGroups[groupName] = backupGroups;
+                            if (backupSettingsMotions !== undefined) internalModel.settings.motions[groupName] = backupSettingsMotions;
+                            if (backupJsonMotions !== undefined) {
+                                if (json) json.motions[groupName] = backupJsonMotions;
+                            }
+                            if (backupJsonFileRefs !== undefined) {
+                                if (json?.FileReferences?.Motions) json.FileReferences.Motions[groupName] = backupJsonFileRefs;
+                            }
+                        } else {
+                            delete motionManager.definitions?.[groupName];
+                            delete motionManager.motionGroups?.[groupName];
+                            delete internalModel.settings.motions?.[groupName];
+                            if (json) {
+                                delete json.motions?.[groupName];
+                                delete json.FileReferences?.Motions?.[groupName];
+                            }
+                        }
                     }
-
-                    if (!internalModel.settings.motions) internalModel.settings.motions = {};
-                    internalModel.settings.motions[groupName] = tempMotionsList;
-
-                    if (!motionManager.definitions) motionManager.definitions = {};
-                    motionManager.definitions[groupName] = tempMotionsList;
-
-                    if (!motionManager.motionGroups) motionManager.motionGroups = {};
-                    motionManager.motionGroups[groupName] = [];
-
-                    const live2dModel = this.currentModel;
-                    console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
-                    await motionManager.loadMotion(groupName, 0);
-
-                    if (live2dModel !== this.currentModel) {
-                        console.log('[TouchSet] 模型已切换，中止动作播放');
-                        return;
-                    }
-
-                    motionManager.stopAllMotions();
-                    const result = await live2dModel.motion(groupName, 0, 3);
-
-                    if (result) {
-                        console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
-                    } else {
-                        console.warn(`[TouchSet] ❌ 动作加载成功但引擎仍拒绝播放: ${groupName}[0]`);
-                    }
-                } catch (error) {
-                    console.warn(`[TouchSet] 动作播放异常: ${groupName}[0]`, error);
-                } finally {
-                    if (backupDefs !== undefined) motionManager.definitions[groupName] = backupDefs;
-                    if (backupGroups !== undefined) motionManager.motionGroups[groupName] = backupGroups;
-                    if (backupSettingsMotions !== undefined) internalModel.settings.motions[groupName] = backupSettingsMotions;
-                    if (backupJsonMotions !== undefined) {
-                        if (json) json.motions[groupName] = backupJsonMotions;
-                    }
-                    if (backupJsonFileRefs !== undefined) {
-                        if (json?.FileReferences?.Motions) json.FileReferences.Motions[groupName] = backupJsonFileRefs;
-                    }
-                }
             }
         }
 

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -1846,14 +1846,22 @@ Live2DManager.prototype.triggerRandomEmotion = async function() {
         
         console.log('[Interaction] 点击效果持续时间结束，平滑恢复到默认状态');
         this._currentClickEffectId = null;
-        // 使用平滑过渡恢复到常驻表情或默认状态（smoothReset 内部会在快照后停止 motion/expression）
+        const restoreIdleMotion = () => {
+            if (typeof window.restoreLive2DIdleAnimationOnMainPage === 'function') {
+                window.restoreLive2DIdleAnimationOnMainPage();
+            }
+        };
         if (typeof this.smoothResetToInitialState === 'function') {
-            this.smoothResetToInitialState().catch(e => {
+            this.smoothResetToInitialState().then(restoreIdleMotion).catch(e => {
                 console.warn('[Interaction] 平滑恢复失败，回退到即时恢复:', e);
                 if (typeof this.clearExpression === 'function') this.clearExpression();
+                restoreIdleMotion();
             });
         } else if (typeof this.clearExpression === 'function') {
             this.clearExpression();
+            restoreIdleMotion();
+        } else {
+            restoreIdleMotion();
         }
     }, window.live2dManager.CLICK_EFFECT_DURATION);
 };
@@ -2022,14 +2030,50 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                             }
                             
                             try {
-                                const result = await this.currentModel.motion(groupName, index, 2);
+                                const internalModel = this.currentModel.internalModel;
+                                const motionManager = internalModel.motionManager;
+                                const json = internalModel.settings.json;
+
+                                const motionsList = [{ 'File': motion.File }];
+
+                                if (json) {
+                                    json.FileReferences = json.FileReferences || {};
+                                    json.FileReferences.Motions = json.FileReferences.Motions || {};
+                                    json.FileReferences.Motions[groupName] = motionsList;
+                                    json.motions = json.motions || {};
+                                    json.motions[groupName] = motionsList;
+                                }
+
+                                internalModel.settings.motions = internalModel.settings.motions || {};
+                                internalModel.settings.motions[groupName] = motionsList;
+
+                                if (!motionManager.definitions) motionManager.definitions = {};
+                                motionManager.definitions[groupName] = motionsList;
+
+                                if (!motionManager.motionGroups) {
+                                    motionManager.motionGroups = {};
+                                }
+                                motionManager.motionGroups[groupName] = [];
+
+                                const live2dModel = this.currentModel;
+                                console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
+                                await motionManager.loadMotion(groupName, 0);
+
+                                if (live2dModel !== this.currentModel) {
+                                    console.log('[TouchSet] 模型已切换，中止动作播放');
+                                    return;
+                                }
+
+                                motionManager.stopAllMotions();
+                                const result = await live2dModel.motion(groupName, 0, 3);
+
                                 if (result) {
-                                    console.log(`[TouchSet] 成功播放动作: ${groupName}[${index}]`);
+                                    console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
                                 } else {
-                                    console.warn(`[TouchSet] 动作播放返回空值: ${groupName}[${index}]`);
+                                    console.warn(`[TouchSet] ❌ 动作加载成功但引擎仍拒绝播放: ${groupName}[0]`);
                                 }
                             } catch (motionError) {
-                                console.warn(`[TouchSet] 动作播放异常: ${groupName}[${index}]`, motionError);
+                                console.warn(`[TouchSet] 动作播放异常: ${groupName}[0]`, motionError);
                             }
                             break;
                         }

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -2080,16 +2080,6 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                     console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
                     await motionManager.loadMotion(groupName, 0);
 
-                    if (backupDefs !== undefined) motionManager.definitions[groupName] = backupDefs;
-                    if (backupGroups !== undefined) motionManager.motionGroups[groupName] = backupGroups;
-                    if (backupSettingsMotions !== undefined) internalModel.settings.motions[groupName] = backupSettingsMotions;
-                    if (backupJsonMotions !== undefined) {
-                        if (json) json.motions[groupName] = backupJsonMotions;
-                    }
-                    if (backupJsonFileRefs !== undefined) {
-                        if (json?.FileReferences?.Motions) json.FileReferences.Motions[groupName] = backupJsonFileRefs;
-                    }
-
                     if (live2dModel !== this.currentModel) {
                         console.log('[TouchSet] 模型已切换，中止动作播放');
                         return;
@@ -2105,6 +2095,16 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                     }
                 } catch (error) {
                     console.warn(`[TouchSet] 动作播放异常: ${groupName}[0]`, error);
+                } finally {
+                    if (backupDefs !== undefined) motionManager.definitions[groupName] = backupDefs;
+                    if (backupGroups !== undefined) motionManager.motionGroups[groupName] = backupGroups;
+                    if (backupSettingsMotions !== undefined) internalModel.settings.motions[groupName] = backupSettingsMotions;
+                    if (backupJsonMotions !== undefined) {
+                        if (json) json.motions[groupName] = backupJsonMotions;
+                    }
+                    if (backupJsonFileRefs !== undefined) {
+                        if (json?.FileReferences?.Motions) json.FileReferences.Motions[groupName] = backupJsonFileRefs;
+                    }
                 }
             }
         }

--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -1964,44 +1964,46 @@ Live2DManager.prototype.setupHitAreaInteraction = function(model) {
  */
 Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
 
-    // ↓只是debug用
-    // const live2d的touch = window.live2dManager.touchSet
-
-
-    if ( hitAreaId ==null || !this.currentModel) {
+    if (this._isHandlingTouchInteraction) {
+        console.log('[TouchSet] 动作正在加载中，忽略频繁连击防止状态污染');
         return;
     }
-    let faceHoldingTime = window.live2dManager.CLICK_EFFECT_DURATION;
-    let AnimHoldingTime = null;
-    // 获取当前模型的 touchSet 配置
-
-    const modelName = this.modelName;
-    const touchSet = this.touchSet && this.touchSet[modelName];
-    
-    if (!touchSet || !touchSet[hitAreaId]) {
-        console.log(`[TouchSet] 没有找到 ${hitAreaId} 的配置`);
-        return;
-    }
-
-    const config = touchSet[hitAreaId];
-    const { motions = [], expressions = [] } = config;
-
-    console.log(`[TouchSet] 播放 ${hitAreaId} 的动画:`, { motions, expressions });
+    this._isHandlingTouchInteraction = true;
 
     try {
-        // 播放动作
+        if (hitAreaId == null || !this.currentModel) {
+            return;
+        }
+        let faceHoldingTime = window.live2dManager.CLICK_EFFECT_DURATION;
+        let AnimHoldingTime = null;
+        const modelName = this.modelName;
+        const touchSet = this.touchSet && this.touchSet[modelName];
+
+        if (!touchSet || !touchSet[hitAreaId]) {
+            console.log(`[TouchSet] 没有找到 ${hitAreaId} 的配置`);
+            return;
+        }
+
+        const config = touchSet[hitAreaId];
+        const { motions = [], expressions = [] } = config;
+
+        console.log(`[TouchSet] 播放 ${hitAreaId} 的动画:`, { motions, expressions });
+
         if (motions.length > 0) {
             const randomMotion = motions[Math.floor(Math.random() * motions.length)];
-            
-            // 优先使用 motionManager.definitions，回退到 fileReferences.Motions
+
             const motionDefs = this.currentModel.internalModel?.motionManager?.definitions;
             const fileRefs = this.fileReferences?.Motions;
-            
+
             const motionSources = [
                 motionDefs,
                 fileRefs
             ].filter(Boolean);
-            
+
+            let foundMotion = null;
+            let foundGroupName = null;
+
+            outerLoop:
             for (const motionSource of motionSources) {
                 for (const [groupName, motionList] of Object.entries(motionSource)) {
                     if (Array.isArray(motionList)) {
@@ -2011,108 +2013,134 @@ Live2DManager.prototype._playTouchSetAnimation = async function(hitAreaId) {
                             return fileName === randomMotion;
                         });
                         if (motion) {
-                            const index = motionList.indexOf(motion);
-                            console.log(`[TouchSet] 准备播放动作: ${groupName}[${index}], 文件: ${motion.File}`);
-                            
-                            // 获取motion的实际持续时间
-                            try {
-                                let motionPath = motion.File;
-                                if (!motionPath.startsWith('http') && !motionPath.startsWith('/')) {
-                                    motionPath = `${this.modelRootPath}/${motionPath}`;
-                                }
-                                const response = await fetch(motionPath);
-                                if (response.ok) {
-                                    const motionData = await response.json();
-                                    if (motionData.Meta && motionData.Meta.Duration) {
-                                        AnimHoldingTime = motionData.Meta.Duration * 1000;
-                                        faceHoldingTime = AnimHoldingTime;
-                                        console.log(`[TouchSet] 动作持续时间: ${AnimHoldingTime}ms, 表情持续时间将同步`);
-                                    }
-                                }
-                            } catch (error) {
-                                console.warn(`[TouchSet] 无法获取motion持续时间:`, error);
-                            }
-
-                            try {
-                                const internalModel = this.currentModel.internalModel;
-                                const motionManager = internalModel.motionManager;
-                                const json = internalModel.settings.json;
-
-                                // 使用完整列表而非稀疏数组，
-                                // 避免 motionManager.definitions[groupName] 变成稀疏数组导致同组其它动作丢失
-                                const motionsList = [{ 'File': motion.File }];
-
-                                if (json) {
-                                    json.FileReferences = json.FileReferences || {};
-                                    json.FileReferences.Motions = json.FileReferences.Motions || {};
-                                    json.FileReferences.Motions[groupName] = motionsList;
-                                    json.motions = json.motions || {};
-                                    json.motions[groupName] = motionsList;
-                                }
-
-                                internalModel.settings.motions = internalModel.settings.motions || {};
-                                internalModel.settings.motions[groupName] = motionsList;
-
-                                if (!motionManager.definitions) motionManager.definitions = {};
-                                motionManager.definitions[groupName] = motionsList;
-
-                                if (!motionManager.motionGroups) {
-                                    motionManager.motionGroups = {};
-                                }
-                                motionManager.motionGroups[groupName] = [];
-
-                                // 捕获模型引用，await 后校验是否切换了模型，防止旧请求下发到新模型
-                                const live2dModel = this.currentModel;
-                                console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
-                                await motionManager.loadMotion(groupName, 0);
-
-                                if (live2dModel !== this.currentModel) {
-                                    console.log('[TouchSet] 模型已切换，中止动作播放');
-                                    return;
-                                }
-
-                                motionManager.stopAllMotions();
-                                const result = await live2dModel.motion(groupName, 0, 3);
-
-                                if (result) {
-                                    console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
-                                } else {
-                                    console.warn(`[TouchSet] ❌ 动作加载成功但引擎仍拒绝播放: ${groupName}[0]`);
-                                }
-                            } catch (motionError) {
-                                console.warn(`[TouchSet] 动作播放异常: ${groupName}[0]`, motionError);
-                            }
-                            break;
+                            foundMotion = motion;
+                            foundGroupName = groupName;
+                            break outerLoop;
                         }
                     }
                 }
             }
+
+            if (!foundMotion) {
+                console.warn(`[TouchSet] 找不到匹配的动作: ${randomMotion}`);
+            } else {
+                const { motion } = { motion: foundMotion };
+                const groupName = foundGroupName;
+                console.log(`[TouchSet] 准备播放动作: ${groupName}, 文件: ${motion.File}`);
+
+                try {
+                    let motionPath = motion.File;
+                    if (!motionPath.startsWith('http') && !motionPath.startsWith('/')) {
+                        motionPath = `${this.modelRootPath}/${motionPath}`;
+                    }
+                    const response = await fetch(motionPath);
+                    if (response.ok) {
+                        const motionData = await response.json();
+                        if (motionData.Meta && motionData.Meta.Duration) {
+                            AnimHoldingTime = motionData.Meta.Duration * 1000;
+                            faceHoldingTime = AnimHoldingTime;
+                            console.log(`[TouchSet] 动作持续时间: ${AnimHoldingTime}ms, 表情持续时间将同步`);
+                        }
+                    }
+                } catch (error) {
+                    console.warn(`[TouchSet] 无法获取motion持续时间:`, error);
+                }
+
+                try {
+                    const internalModel = this.currentModel.internalModel;
+                    const motionManager = internalModel.motionManager;
+                    const json = internalModel.settings.json;
+
+                    const backupDefs = motionManager.definitions?.[groupName];
+                    const backupGroups = motionManager.motionGroups?.[groupName];
+                    const backupSettingsMotions = internalModel.settings.motions?.[groupName];
+                    const backupJsonMotions = json?.motions?.[groupName];
+                    const backupJsonFileRefs = json?.FileReferences?.Motions?.[groupName];
+
+                    const tempMotionsList = [{ 'File': motion.File }];
+
+                    if (json) {
+                        if (!json.FileReferences) json.FileReferences = {};
+                        if (!json.FileReferences.Motions) json.FileReferences.Motions = {};
+                        json.FileReferences.Motions[groupName] = tempMotionsList;
+                        if (!json.motions) json.motions = {};
+                        json.motions[groupName] = tempMotionsList;
+                    }
+
+                    if (!internalModel.settings.motions) internalModel.settings.motions = {};
+                    internalModel.settings.motions[groupName] = tempMotionsList;
+
+                    if (!motionManager.definitions) motionManager.definitions = {};
+                    motionManager.definitions[groupName] = tempMotionsList;
+
+                    if (!motionManager.motionGroups) motionManager.motionGroups = {};
+                    motionManager.motionGroups[groupName] = [];
+
+                    const live2dModel = this.currentModel;
+                    console.log(`[TouchSet] 正在向引擎注入并加载动作: ${motion.File}`);
+                    await motionManager.loadMotion(groupName, 0);
+
+                    if (backupDefs !== undefined) motionManager.definitions[groupName] = backupDefs;
+                    if (backupGroups !== undefined) motionManager.motionGroups[groupName] = backupGroups;
+                    if (backupSettingsMotions !== undefined) internalModel.settings.motions[groupName] = backupSettingsMotions;
+                    if (backupJsonMotions !== undefined) {
+                        if (json) json.motions[groupName] = backupJsonMotions;
+                    }
+                    if (backupJsonFileRefs !== undefined) {
+                        if (json?.FileReferences?.Motions) json.FileReferences.Motions[groupName] = backupJsonFileRefs;
+                    }
+
+                    if (live2dModel !== this.currentModel) {
+                        console.log('[TouchSet] 模型已切换，中止动作播放');
+                        return;
+                    }
+
+                    motionManager.stopAllMotions();
+                    const result = await live2dModel.motion(groupName, 0, 3);
+
+                    if (result) {
+                        console.log(`[TouchSet] ✅ 成功下发播放指令: ${groupName}[0]`);
+                    } else {
+                        console.warn(`[TouchSet] ❌ 动作加载成功但引擎仍拒绝播放: ${groupName}[0]`);
+                    }
+                } catch (error) {
+                    console.warn(`[TouchSet] 动作播放异常: ${groupName}[0]`, error);
+                }
+            }
         }
 
-        // 播放表情
         if (expressions.length > 0) {
             const randomExpressionName = expressions[Math.floor(Math.random() * expressions.length)];
             const faceInfo = this.fileReferences?.Expressions?.find(e => e.Name === randomExpressionName);
             if (!faceInfo || !faceInfo.File) {
                 console.warn(`[TouchSet] 表情文件不存在: ${randomExpressionName}`);
-                
-            }else {
+            } else {
                 console.log(`[TouchSet] 尝试播放表情: ${faceInfo.File}`);
                 try {
                     await this.playExpression(randomExpressionName, faceInfo.File);
                     console.log(`[TouchSet] 播放表情成功: ${randomExpressionName}, 持续时间: ${faceHoldingTime}ms`);
-                    
+
                     clearTimeout(this.expressionTimer);
+                    const holdingTime = Number.isFinite(faceHoldingTime) && faceHoldingTime > 0 ? faceHoldingTime : 3000;
                     this.expressionTimer = setTimeout(() => {
-                        this.clearExpression?.();
-                    }, faceHoldingTime);
+                        if (typeof this.clearExpression === 'function') {
+                            this.clearExpression();
+                            console.log(`[TouchSet] 临时表情清除，准备恢复常驻状态`);
+                            if (typeof this.applyPersistentExpressionsNative === 'function') {
+                                try {
+                                    this.applyPersistentExpressionsNative(true);
+                                } catch (_) {}
+                            }
+                        }
+                    }, holdingTime);
                 } catch (e) {
                     console.warn(`[TouchSet] 播放表情失败: ${randomExpressionName}`, e);
                 }
             }
-
         }
     } catch (error) {
         console.warn(`[TouchSet] 播放动画失败:`, error);
+    } finally {
+        this._isHandlingTouchInteraction = false;
     }
 };

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "Animation",
         "selectExpression": "Expression",
         "selectPersistentExpression": "Persist. Expr.",
+        "noMotion": "No Motion",
+        "noExpression": "No Expression",
         "noMotionFiles": "No motion files",
         "touchAnim": {
             "title": "Touch Anim Config",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "Animación",
         "selectExpression": "Expresión",
         "selectPersistentExpression": "Persistir. Expr.",
+        "noMotion": "Sin Movimiento",
+        "noExpression": "Sin Expresión",
         "noMotionFiles": "Sin archivos de movimiento",
         "touchAnim": {
             "title": "Toque Configuración de animación",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "モーション",
         "selectExpression": "表情",
         "selectPersistentExpression": "常時表情を選択",
+        "noMotion": "モーションなし",
+        "noExpression": "表情なし",
         "noMotionFiles": "モーションファイルなし",
         "touchAnim": {
             "title": "タッチアニメ設定",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "애니메이션",
         "selectExpression": "표현식",
         "selectPersistentExpression": "지속 표현식 선택",
+        "noMotion": "모션 없음",
+        "noExpression": "표현식 없음",
         "noMotionFiles": "모션 파일 없음",
         "touchAnim": {
             "title": "터치 애니메이션 설정",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "Animação",
         "selectExpression": "Expressão",
         "selectPersistentExpression": "Persistir. Expr.",
+        "noMotion": "Sem Movimento",
+        "noExpression": "Sem Expressão",
         "noMotionFiles": "Nenhum arquivo de movimento",
         "touchAnim": {
             "title": "Toque em Configuração do Anim",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "Анимация",
         "selectExpression": "Выражение",
         "selectPersistentExpression": "Пост. выр.",
+        "noMotion": "Без анимации",
+        "noExpression": "Без выражения",
         "noMotionFiles": "Нет файлов анимации",
         "touchAnim": {
             "title": "Настройка касаний",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "选择动作",
         "selectExpression": "选择表情",
         "selectPersistentExpression": "选择常驻表情",
+        "noMotion": "无动作",
+        "noExpression": "无表情",
         "noMotionFiles": "没有动作文件",
         "touchAnim": {
             "title": "触摸动画配置",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1053,6 +1053,8 @@
         "selectMotion": "選擇動作",
         "selectExpression": "選擇錶情",
         "selectPersistentExpression": "選擇常駐錶情",
+        "noMotion": "無動作",
+        "noExpression": "無錶情",
         "noMotionFiles": "沒有動作文件",
         "touchAnim": {
             "title": "觸摸動畫配置",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进 / Bug 修复**
  * 优化触摸触发流程：防止重复触发，确保在平滑重置成功或失败后均恢复空闲动作；播放中若模型切换则中止并清理临时注入的动作；表情清理时限定时长并在可用时恢复持久表情。
* **新功能**
  * 为 VRM/MMD 动作与 VRM 表情新增“无动作/无表情”选项；选中后停止对应播放并禁用相关播放控件，保存时将占位值映射为空。
* **本地化**
  * 添加多语言 live2d.noMotion 与 live2d.noExpression 文案（中/英/日/韩/西/葡/俄）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->