### PR TITLE
docs(memory): 重做 #928 漏合的 vitepress dead-link 修复 (84a99b9e)

### DIFF
--- a/docs/design/memory-evidence-rfc-plan.md
+++ b/docs/design/memory-evidence-rfc-plan.md
@@ -12,7 +12,7 @@
 
 ### 0.1 任务输入
 
-- Handoff spec: [`docs/design/memory-evidence-task.md`](memory-evidence-task.md)（commit `bd2477be`，target branch `claude/review-pr-634-memory-rSsDR`）
+- Handoff spec: `docs/design/memory-evidence-task.md`（commit `bd2477be`，target branch `claude/review-pr-634-memory-rSsDR`）— 已按 RFC 交付后删除
 - Template RFC: [`docs/design/memory-event-log-rfc.md`](memory-event-log-rfc.md)（840 行，结构参考）
 - 上游 PR / Issue：
   - [#849](https://github.com/Project-N-E-K-O/N.E.K.O/issues/849)（**OPEN issue**）条目级 user-driven evidence 提议——本 RFC 是它的设计落地


### PR DESCRIPTION
## Summary

- PR [#928](https://github.com/Project-N-E-K-O/N.E.K.O/pull/928) 合并到 main（aa3aa9a4）时带入了 commit 6bfda767 删除 `docs/design/memory-evidence-task.md`，但 sibling plan 文件 `memory-evidence-rfc-plan.md` 还把它当 markdown 链接 `[...](memory-evidence-task.md)` 引用，vitepress build 会在 docs deploy 里挂掉。
- 原 PR branch 上后来补过 [84a99b9e](https://github.com/Project-N-E-K-O/N.E.K.O/commit/84a99b9e577058e5d295dfbabefae8bd8325d1db) 修这个问题，但 PR 已 squash-merge，fix commit 没跟着进 main。
- 本 PR 在 main 上重做同一个 fix：把 markdown 链接换成纯反引号注释 + "已按 RFC 交付后删除" 说明，因为 task.md 是有意删除的、不再是有效链接目标。

仅 1 行改动，无其他逻辑影响。

## Test plan

- [ ] CI 跑过 vitepress build，不再因 `memory-evidence-rfc-plan.md:15` 的 dead link 失败
- [ ] Grep 确认剩余对 `memory-evidence-task.md` 的引用（`git rm` 命令内 + 正文反引号说明）都不是 markdown 链接形式

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档更新**
  * 更新了设计规划文档，移除了已删除的交接规范文件的链接引用，并添加了状态说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->