### PR TITLE
[Memory] PR-2 time decay + archival (RFC §3.5)

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -827,6 +827,13 @@ EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES = 5           # 或空闲 N 分钟触发
 EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS = 40      # 轮询间隔（与 IDLE_CHECK_INTERVAL 对齐）
 EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS = 200   # Stage-2 prompt 带入的 existing 上限
 
+# §3.5 / §6.5 Gate 4：归档扫描背景循环间隔
+# 1 小时一次：sub_zero_days 计数本身按"自然日"防抖（每天最多 +1），
+# 所以扫描频率 ≥ 一天即可保证不漏；选 1h 是为了让"score 跌穿 0 当天"
+# 也能尽快被抓住而非等到次日 00:00。低频远低于 evidence 信号循环
+# (40s)，对 IO/CPU 影响可以忽略。
+EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS = 3600
+
 # §3.6 render budget（PR-3 使用，此处先占位）
 PERSONA_RENDER_TOKEN_BUDGET = 2000       # 非-protected persona 预算
 REFLECTION_RENDER_TOKEN_BUDGET = 1000    # reflection 渲染预算
@@ -993,6 +1000,7 @@ __all__ = [
     'EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES',
     'EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS',
     'EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS',
+    'EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS',
     'PERSONA_RENDER_TOKEN_BUDGET',
     'REFLECTION_RENDER_TOKEN_BUDGET',
     'PERSONA_RENDER_ENCODING',

--- a/memory/archive_shards.py
+++ b/memory/archive_shards.py
@@ -112,14 +112,33 @@ def _pick_shard_path_for_today(
             return os.path.join(archive_dir, candidate)
 
 
-async def _aread_shard(path: str) -> list[dict]:
-    """Read a shard file's contents, returning [] on missing/corrupt.
+class ShardCorruptError(Exception):
+    """Raised by `_aread_shard` when a shard file exists but is unusable
+    (non-JSON / not a list). Callers MUST catch this and treat the shard
+    as full so the picker doesn't reuse + overwrite the corrupt file
+    (coderabbit PR #934 round-2 Major #1 — corrupt shard isolation).
 
-    A corrupt (non-JSON / non-list) shard is logged but treated as empty
-    — same defensive posture as `reflection.py` / `persona.py` use for
-    their main view files. Caller's fresh entries get appended to a clean
-    list rather than silently lost; the corrupt original is still on disk
-    for manual recovery.
+    The corrupt file is left untouched on disk for manual recovery.
+    """
+
+    def __init__(self, path: str, reason: str):
+        super().__init__(f"shard corrupt at {path}: {reason}")
+        self.path = path
+        self.reason = reason
+
+
+async def _aread_shard(path: str) -> list[dict]:
+    """Read a shard file's contents.
+
+    Returns [] on missing (truly empty / non-existent file). Raises
+    ``ShardCorruptError`` on non-JSON / non-list contents — callers
+    must catch and treat as full so the picker can't reuse the file
+    and `atomic_write_json_async` can't overwrite the corrupt original
+    (coderabbit PR #934 round-2 Major #1).
+
+    Symmetric to the sync twin's `(json.JSONDecodeError, OSError)` →
+    `ARCHIVE_FILE_MAX_ENTRIES` defensive posture in
+    ``append_to_shard_sync`` (lines 277-285).
     """
     if not await asyncio.to_thread(os.path.exists, path):
         return []
@@ -127,11 +146,11 @@ async def _aread_shard(path: str) -> list[dict]:
         data = await read_json_async(path)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(f"[ArchiveShard] 读取分片失败 {path}: {e}")
-        return []
+        raise ShardCorruptError(path, str(e)) from e
     if isinstance(data, list):
         return [item for item in data if isinstance(item, dict)]
     logger.warning(f"[ArchiveShard] 分片不是 list，忽略: {path}")
-    return []
+    raise ShardCorruptError(path, f"top-level is {type(data).__name__}, not list")
 
 
 async def apick_today_shard_path(
@@ -163,6 +182,15 @@ async def apick_today_shard_path(
             try:
                 shard_data = await _aread_shard(shard_path)
                 sizes[fn] = len(shard_data)
+            except ShardCorruptError as e:
+                # Coderabbit PR #934 round-2 Major #1: corrupt shards
+                # are reported as full so the picker can't reuse them
+                # (else atomic_write_json_async would overwrite the
+                # corrupt original and lose any salvageable data).
+                logger.warning(
+                    f"[ArchiveShard] 损坏分片视为已满，跳过复用 {shard_path}: {e}"
+                )
+                sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES
             except Exception as e:
                 logger.warning(f"[ArchiveShard] 探测分片大小失败 {shard_path}: {e}")
                 sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES
@@ -223,6 +251,15 @@ async def aappend_to_shard(
             try:
                 shard_data = await _aread_shard(shard_path)
                 sizes[fn] = len(shard_data)
+            except ShardCorruptError as e:
+                # Coderabbit PR #934 round-2 Major #1: corrupt shards
+                # are reported as full so the picker can't reuse them
+                # (else atomic_write_json_async would overwrite the
+                # corrupt original and lose any salvageable data).
+                logger.warning(
+                    f"[ArchiveShard] 损坏分片视为已满，跳过复用 {shard_path}: {e}"
+                )
+                sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES
             except Exception as e:
                 logger.warning(f"[ArchiveShard] 探测分片大小失败 {shard_path}: {e}")
                 sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES  # treat as full → don't reuse
@@ -231,7 +268,19 @@ async def aappend_to_shard(
     remaining = list(entries)
     while remaining:
         shard_path = _pick_shard_path_for_today(archive_dir, today, sizes)
-        existing = await _aread_shard(shard_path)
+        try:
+            existing = await _aread_shard(shard_path)
+        except ShardCorruptError as e:
+            # The picker just selected a fresh shard or one we already
+            # sized as <max above. Reaching this branch means the
+            # filename we picked turns out to be corrupt on the second
+            # read (e.g. concurrent writer truncated it). Mark full
+            # and re-pick — same defensive posture as the size probe.
+            logger.warning(
+                f"[ArchiveShard] 选中分片读取损坏，标记为已满重新选 {shard_path}: {e}"
+            )
+            sizes[os.path.basename(shard_path)] = ARCHIVE_FILE_MAX_ENTRIES
+            continue
         capacity = ARCHIVE_FILE_MAX_ENTRIES - len(existing)
         if capacity <= 0:
             # Brand-new shard rolled in, but a concurrent writer filled
@@ -310,6 +359,62 @@ def append_to_shard_sync(
         sizes[os.path.basename(shard_path)] = len(merged)
         last_written = shard_path
     return last_written
+
+
+def ensure_entry_in_named_shard_sync(
+    archive_dir: str, shard_basename: str, entry: dict,
+) -> bool:
+    """Idempotent helper: ensure ``entry`` (keyed by ``entry['id']``) is
+    present in the shard file ``<archive_dir>/<shard_basename>``,
+    creating the file if missing.
+
+    Used by reconciler archive handlers (`evidence_handlers.py`) to
+    self-heal a missing shard write. Background: archive flow writes
+    the event log first then appends to a shard; if the process dies
+    between those two steps, the active view loses the entry but the
+    shard never gets it. Replaying the event lets the handler call us
+    here so the entry is reconstructed from the event payload's
+    ``entry_snapshot`` (coderabbit PR #934 round-2 Major #3).
+
+    Returns True if a write happened (entry was missing or shard was
+    absent); False if the entry was already present.
+
+    Corruption posture: if the named shard exists but is corrupt
+    (non-JSON / not list), we leave it untouched (raise nothing — log
+    + return False) rather than overwriting it. Same isolation rule
+    as `_aread_shard` (Major #1). The replay will be retried on the
+    next reconciler boot; an operator can fix the corrupt shard
+    manually in between.
+    """
+    if not isinstance(entry, dict):
+        return False
+    eid = entry.get('id')
+    if not eid:
+        return False
+    os.makedirs(archive_dir, exist_ok=True)
+    shard_path = os.path.join(archive_dir, shard_basename)
+    existing: list[dict] = []
+    if os.path.exists(shard_path):
+        try:
+            with open(shard_path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(
+                f"[ArchiveShard] self-heal 跳过损坏分片 {shard_path}: {e}"
+            )
+            return False
+        if not isinstance(data, list):
+            logger.warning(
+                f"[ArchiveShard] self-heal 跳过非 list 分片 {shard_path}"
+            )
+            return False
+        existing = [x for x in data if isinstance(x, dict)]
+        for e in existing:
+            if e.get('id') == eid:
+                return False  # Already present → idempotent no-op.
+    merged = existing + [dict(entry)]
+    atomic_write_json(shard_path, merged, indent=2, ensure_ascii=False)
+    return True
 
 
 def shard_filename_for(now: datetime) -> str:

--- a/memory/archive_shards.py
+++ b/memory/archive_shards.py
@@ -31,7 +31,7 @@ import os
 import re
 import uuid
 from datetime import datetime
-from typing import Iterable
+from typing import Callable, Iterable
 
 from config import ARCHIVE_FILE_MAX_ENTRIES
 from utils.file_utils import (
@@ -82,20 +82,28 @@ def _pick_shard_path_for_today(
 ) -> str:
     """Decide which shard path to append into for `today`.
 
-    Strategy:
-    - If today's most-recent (lexicographically last) shard exists and has
-      < ARCHIVE_FILE_MAX_ENTRIES entries → reuse it.
-    - Otherwise → create a fresh shard with a new uuid8 (re-roll if it
-      collides with an existing filename).
+    Strategy (chatgpt-codex review #934 — earlier "lexical-last only"
+    strategy was buggy because the uuid8 suffix is RANDOM, so the
+    lexically-last shard is not necessarily the most-recently-written one
+    nor the one with capacity. If lex-last happened to be full but an
+    earlier same-day shard still had room, every append rolled a fresh
+    shard → unbounded shard proliferation):
+
+    - Scan ALL of today's shards in lex order; return the FIRST one with
+      ``current_size < ARCHIVE_FILE_MAX_ENTRIES``. This naturally coalesces
+      same-day appends into earlier shards (a shard fills before the next
+      one is touched) while staying deterministic for the
+      `apick_today_shard_path` predict-then-write contract.
+    - If every same-day shard is full (or there are none) → mint a fresh
+      uuid8 shard, re-rolling on the (vanishingly rare) filename collision.
     """
     todays = [
         (fn, u8) for (fn, d, u8) in _list_shard_files(archive_dir)
         if d == today
     ]
-    if todays:
-        latest_fn, _ = todays[-1]
-        if current_size_by_filename.get(latest_fn, 0) < ARCHIVE_FILE_MAX_ENTRIES:
-            return os.path.join(archive_dir, latest_fn)
+    for fn, _ in todays:
+        if current_size_by_filename.get(fn, 0) < ARCHIVE_FILE_MAX_ENTRIES:
+            return os.path.join(archive_dir, fn)
 
     existing_names = {fn for fn, _, _ in _list_shard_files(archive_dir)}
     while True:
@@ -170,13 +178,24 @@ async def apick_today_shard_path(
 
 
 async def aappend_to_shard(
-    archive_dir: str, entries: list[dict], *, now: datetime | None = None,
+    archive_dir: str, entries: list[dict], *,
+    now: datetime | None = None,
+    stamper: Callable[[list[dict], str], None] | None = None,
 ) -> str:
     """Append `entries` into today's shard (creating new ones as needed).
 
     Returns the absolute path of the LAST shard written to. If the entries
     overflow `ARCHIVE_FILE_MAX_ENTRIES` for today's currently-open shard,
     they spill into one or more freshly-created shards.
+
+    The optional ``stamper`` callback (chatgpt-codex / coderabbit review
+    #934) is invoked as ``stamper(chunk, shard_basename)`` immediately
+    BEFORE the chunk is serialized to disk — this lets callers attach
+    per-chunk metadata (notably ``archive_shard_path`` so on-disk records
+    carry their own correct shard filename even when overflow spreads
+    one batch across multiple shards). Stamper mutates entries in place;
+    its return value is ignored. Without a stamper the previous
+    "write-only" behavior is preserved.
 
     Atomicity:
       Each shard write goes through `atomic_write_json_async`. The
@@ -221,6 +240,11 @@ async def aappend_to_shard(
             continue
         chunk = remaining[:capacity]
         remaining = remaining[capacity:]
+        if stamper is not None:
+            # Stamp BEFORE merge+write so the on-disk record matches
+            # what consumers see. Per-chunk basename is correct even
+            # under overflow.
+            stamper(chunk, os.path.basename(shard_path))
         merged = existing + chunk
         await atomic_write_json_async(shard_path, merged, indent=2, ensure_ascii=False)
         sizes[os.path.basename(shard_path)] = len(merged)
@@ -229,11 +253,15 @@ async def aappend_to_shard(
 
 
 def append_to_shard_sync(
-    archive_dir: str, entries: list[dict], *, now: datetime | None = None,
+    archive_dir: str, entries: list[dict], *,
+    now: datetime | None = None,
+    stamper: Callable[[list[dict], str], None] | None = None,
 ) -> str:
     """Sync twin of `aappend_to_shard` — symmetry with sync save paths
     (CLAUDE.md). Used by sync test fixtures and by the one-shot migration
     when called from a non-async context.
+
+    See ``aappend_to_shard`` for ``stamper`` semantics.
     """
     if not entries:
         return ""
@@ -275,6 +303,8 @@ def append_to_shard_sync(
             continue
         chunk = remaining[:capacity]
         remaining = remaining[capacity:]
+        if stamper is not None:
+            stamper(chunk, os.path.basename(shard_path))
         merged = existing + chunk
         atomic_write_json(shard_path, merged, indent=2, ensure_ascii=False)
         sizes[os.path.basename(shard_path)] = len(merged)

--- a/memory/archive_shards.py
+++ b/memory/archive_shards.py
@@ -1,0 +1,436 @@
+# -*- coding: utf-8 -*-
+"""
+Sharded archive storage helpers (memory-evidence-rfc §3.5.4).
+
+Both `memory.reflection` and `memory.persona` archive entries into per-day
+shard files under a directory like ``memory/<char>/<kind>_archive/``. To
+keep symmetry (CLAUDE.md "对偶性是硬性要求"), the sharding logic lives in
+this single module — both managers just declare which directory and call
+in.
+
+File naming: ``<YYYY-MM-DD>_<uuid8>.json`` where the date is the archival
+date (local-clock) and ``<uuid8>`` is the first 8 hex chars of a uuid4.
+A new shard is created when today's most recent shard already has
+``ARCHIVE_FILE_MAX_ENTRIES`` entries (RFC §3.5.4).
+
+Migration helper (`migrate_flat_archive_to_shards`) is reused for the
+one-shot migration of legacy ``reflections_archive.json`` (RFC §3.5.5).
+Persona has no legacy flat file but the helper is generic so any future
+consumer can call it.
+
+All public helpers are async-first; callers provide sync paths via
+``asyncio.to_thread`` if they need a sync twin (we don't expose one
+because the only callers — the periodic archive sweep loop and the
+one-shot startup migration — are async).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import uuid
+from datetime import datetime
+from typing import Iterable
+
+from config import ARCHIVE_FILE_MAX_ENTRIES
+from utils.file_utils import (
+    atomic_write_json,
+    atomic_write_json_async,
+    read_json_async,
+)
+from utils.logger_config import get_module_logger
+
+logger = get_module_logger(__name__, "Memory")
+
+# Shard filename: <YYYY-MM-DD>_<uuid8>.json
+# uuid8 captured for migration uniqueness assertions; date captured to
+# group multiple-shard same-day appends.
+_SHARD_RE = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})_(?P<uuid8>[0-9a-f]{8})\.json$")
+
+# Sentinel file written under the archive dir once the legacy flat-file
+# migration has been applied for that character. Lets us short-circuit
+# `migrate_flat_archive_to_shards` on every boot without re-scanning the
+# directory contents.
+MIGRATION_SENTINEL_FILENAME = ".migrated_from_flat"
+
+
+def _new_uuid8() -> str:
+    """First 8 hex chars of a uuid4. Collision risk for our use case
+    (per-day, ≤ tens-of-shards) is negligible; we still re-roll on
+    collision in `_pick_shard_path`."""
+    return uuid.uuid4().hex[:8]
+
+
+def _list_shard_files(archive_dir: str) -> list[tuple[str, str, str]]:
+    """Return [(filename, date_str, uuid8), ...] for valid shards in the
+    directory, sorted by filename. Non-matching files (incl. the migration
+    sentinel) are silently ignored."""
+    if not os.path.isdir(archive_dir):
+        return []
+    entries: list[tuple[str, str, str]] = []
+    for fn in os.listdir(archive_dir):
+        m = _SHARD_RE.match(fn)
+        if m:
+            entries.append((fn, m.group("date"), m.group("uuid8")))
+    entries.sort(key=lambda t: t[0])
+    return entries
+
+
+def _pick_shard_path_for_today(
+    archive_dir: str, today: str, current_size_by_filename: dict[str, int],
+) -> str:
+    """Decide which shard path to append into for `today`.
+
+    Strategy:
+    - If today's most-recent (lexicographically last) shard exists and has
+      < ARCHIVE_FILE_MAX_ENTRIES entries → reuse it.
+    - Otherwise → create a fresh shard with a new uuid8 (re-roll if it
+      collides with an existing filename).
+    """
+    todays = [
+        (fn, u8) for (fn, d, u8) in _list_shard_files(archive_dir)
+        if d == today
+    ]
+    if todays:
+        latest_fn, _ = todays[-1]
+        if current_size_by_filename.get(latest_fn, 0) < ARCHIVE_FILE_MAX_ENTRIES:
+            return os.path.join(archive_dir, latest_fn)
+
+    existing_names = {fn for fn, _, _ in _list_shard_files(archive_dir)}
+    while True:
+        candidate = f"{today}_{_new_uuid8()}.json"
+        if candidate not in existing_names:
+            return os.path.join(archive_dir, candidate)
+
+
+async def _aread_shard(path: str) -> list[dict]:
+    """Read a shard file's contents, returning [] on missing/corrupt.
+
+    A corrupt (non-JSON / non-list) shard is logged but treated as empty
+    — same defensive posture as `reflection.py` / `persona.py` use for
+    their main view files. Caller's fresh entries get appended to a clean
+    list rather than silently lost; the corrupt original is still on disk
+    for manual recovery.
+    """
+    if not await asyncio.to_thread(os.path.exists, path):
+        return []
+    try:
+        data = await read_json_async(path)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"[ArchiveShard] 读取分片失败 {path}: {e}")
+        return []
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    logger.warning(f"[ArchiveShard] 分片不是 list，忽略: {path}")
+    return []
+
+
+async def apick_today_shard_path(
+    archive_dir: str, *, now: datetime | None = None,
+) -> str:
+    """Resolve the path of the shard a single-entry append would land in,
+    materializing it (as an empty list) so a subsequent call sees the
+    same file.
+
+    Used by archive callers that need to stamp `archive_shard_path` into
+    the entry BEFORE persisting it (so the on-disk record matches the
+    value consumers see). The two-step "pick → mutate entry → append"
+    contract requires the picked path to be deterministic across the
+    two reads; we materialize an empty shard here to lock the choice.
+
+    Caller MUST follow this with a single-entry `aappend_to_shard`. For
+    multi-entry appends call `aappend_to_shard` directly — the chunked
+    path can spill across multiple shards which a single "predict" call
+    cannot describe.
+    """
+    await asyncio.to_thread(os.makedirs, archive_dir, exist_ok=True)
+    if now is None:
+        now = datetime.now()
+    today = now.date().isoformat()
+    sizes: dict[str, int] = {}
+    for fn, date_str, _ in _list_shard_files(archive_dir):
+        if date_str == today:
+            shard_path = os.path.join(archive_dir, fn)
+            try:
+                shard_data = await _aread_shard(shard_path)
+                sizes[fn] = len(shard_data)
+            except Exception as e:
+                logger.warning(f"[ArchiveShard] 探测分片大小失败 {shard_path}: {e}")
+                sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES
+    path = _pick_shard_path_for_today(archive_dir, today, sizes)
+    if not await asyncio.to_thread(os.path.exists, path):
+        # Materialize as empty list so subsequent _list_shard_files calls
+        # see this filename and don't roll a different uuid8 on the next
+        # pick. Callers append to this file via `aappend_to_shard` which
+        # reads + extends + atomic-writes — the empty seed is correctly
+        # consumed.
+        await atomic_write_json_async(path, [], indent=2, ensure_ascii=False)
+    return path
+
+
+async def aappend_to_shard(
+    archive_dir: str, entries: list[dict], *, now: datetime | None = None,
+) -> str:
+    """Append `entries` into today's shard (creating new ones as needed).
+
+    Returns the absolute path of the LAST shard written to. If the entries
+    overflow `ARCHIVE_FILE_MAX_ENTRIES` for today's currently-open shard,
+    they spill into one or more freshly-created shards.
+
+    Atomicity:
+      Each shard write goes through `atomic_write_json_async`. The
+      sequence of writes across shards is NOT a single transaction — but
+      since each shard is independent and the caller's mutation
+      (removing the entry from the active view) happens AFTER this call
+      via record_and_save, the worst-case crash window is "entry
+      duplicated in archive but still in active view" → next sweep can
+      observe + retry. Acceptable per RFC §3.11 ("preserved provenance").
+    """
+    if not entries:
+        return ""
+    await asyncio.to_thread(os.makedirs, archive_dir, exist_ok=True)
+    if now is None:
+        now = datetime.now()
+    today = now.date().isoformat()
+
+    # Compute current sizes for all of today's shards in one pass — we
+    # only really need the "latest today" but precomputing keeps the
+    # loop logic uniform when overflow forces us to roll a new shard.
+    sizes: dict[str, int] = {}
+    for fn, date_str, _ in _list_shard_files(archive_dir):
+        if date_str == today:
+            shard_path = os.path.join(archive_dir, fn)
+            try:
+                shard_data = await _aread_shard(shard_path)
+                sizes[fn] = len(shard_data)
+            except Exception as e:
+                logger.warning(f"[ArchiveShard] 探测分片大小失败 {shard_path}: {e}")
+                sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES  # treat as full → don't reuse
+
+    last_written = ""
+    remaining = list(entries)
+    while remaining:
+        shard_path = _pick_shard_path_for_today(archive_dir, today, sizes)
+        existing = await _aread_shard(shard_path)
+        capacity = ARCHIVE_FILE_MAX_ENTRIES - len(existing)
+        if capacity <= 0:
+            # Brand-new shard rolled in, but a concurrent writer filled
+            # it between our list and our read. Mark as full and re-pick.
+            sizes[os.path.basename(shard_path)] = ARCHIVE_FILE_MAX_ENTRIES
+            continue
+        chunk = remaining[:capacity]
+        remaining = remaining[capacity:]
+        merged = existing + chunk
+        await atomic_write_json_async(shard_path, merged, indent=2, ensure_ascii=False)
+        sizes[os.path.basename(shard_path)] = len(merged)
+        last_written = shard_path
+    return last_written
+
+
+def append_to_shard_sync(
+    archive_dir: str, entries: list[dict], *, now: datetime | None = None,
+) -> str:
+    """Sync twin of `aappend_to_shard` — symmetry with sync save paths
+    (CLAUDE.md). Used by sync test fixtures and by the one-shot migration
+    when called from a non-async context.
+    """
+    if not entries:
+        return ""
+    os.makedirs(archive_dir, exist_ok=True)
+    if now is None:
+        now = datetime.now()
+    today = now.date().isoformat()
+
+    sizes: dict[str, int] = {}
+    for fn, date_str, _ in _list_shard_files(archive_dir):
+        if date_str == today:
+            shard_path = os.path.join(archive_dir, fn)
+            try:
+                with open(shard_path, encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, list):
+                    sizes[fn] = len(data)
+                else:
+                    sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES
+            except (json.JSONDecodeError, OSError):
+                sizes[fn] = ARCHIVE_FILE_MAX_ENTRIES
+
+    last_written = ""
+    remaining = list(entries)
+    while remaining:
+        shard_path = _pick_shard_path_for_today(archive_dir, today, sizes)
+        existing: list[dict] = []
+        if os.path.exists(shard_path):
+            try:
+                with open(shard_path, encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, list):
+                    existing = [x for x in data if isinstance(x, dict)]
+            except (json.JSONDecodeError, OSError):
+                existing = []
+        capacity = ARCHIVE_FILE_MAX_ENTRIES - len(existing)
+        if capacity <= 0:
+            sizes[os.path.basename(shard_path)] = ARCHIVE_FILE_MAX_ENTRIES
+            continue
+        chunk = remaining[:capacity]
+        remaining = remaining[capacity:]
+        merged = existing + chunk
+        atomic_write_json(shard_path, merged, indent=2, ensure_ascii=False)
+        sizes[os.path.basename(shard_path)] = len(merged)
+        last_written = shard_path
+    return last_written
+
+
+def shard_filename_for(now: datetime) -> str:
+    """Helper for consumers that need to predict / record a shard
+    filename without doing the IO. Caller should pair with
+    `_new_uuid8()` if it needs a fresh suffix.
+
+    Currently only used by tests / future debug tooling — production
+    code should use `aappend_to_shard` which picks the path internally.
+    """
+    return f"{now.date().isoformat()}_{_new_uuid8()}.json"
+
+
+# ── one-shot migration of legacy flat archive ──────────────────────────
+
+
+def _entries_grouped_by_archived_date(
+    entries: Iterable[dict],
+) -> dict[str, list[dict]]:
+    """Group archive entries by their `archived_at` ISO-date prefix.
+
+    Entries with missing / unparsable `archived_at` fall under today's
+    bucket (best-effort: better to keep the data than drop it).
+    """
+    today_str = datetime.now().date().isoformat()
+    buckets: dict[str, list[dict]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        archived_at = entry.get("archived_at")
+        date_str: str
+        if isinstance(archived_at, str) and archived_at:
+            try:
+                date_str = datetime.fromisoformat(archived_at).date().isoformat()
+            except ValueError:
+                date_str = today_str
+        else:
+            date_str = today_str
+        buckets.setdefault(date_str, []).append(entry)
+    return buckets
+
+
+def _write_shards_for_date(
+    archive_dir: str, date_str: str, entries: list[dict],
+) -> int:
+    """Distribute `entries` into shards under `archive_dir`, all bearing
+    `date_str` as their date prefix. Returns the number of shard files
+    written.
+    """
+    written = 0
+    chunk_idx = 0
+    while chunk_idx < len(entries):
+        chunk = entries[chunk_idx:chunk_idx + ARCHIVE_FILE_MAX_ENTRIES]
+        # Re-roll on collision against existing shards from concurrent
+        # daily writes; very unlikely but cheap.
+        existing_names = {fn for fn, _, _ in _list_shard_files(archive_dir)}
+        while True:
+            candidate = f"{date_str}_{_new_uuid8()}.json"
+            if candidate not in existing_names:
+                break
+        path = os.path.join(archive_dir, candidate)
+        atomic_write_json(path, chunk, indent=2, ensure_ascii=False)
+        written += 1
+        chunk_idx += ARCHIVE_FILE_MAX_ENTRIES
+    return written
+
+
+def migrate_flat_archive_to_shards_sync(
+    flat_path: str, archive_dir: str,
+) -> tuple[bool, int, int]:
+    """Migrate a legacy flat archive file into the sharded directory.
+
+    Returns ``(migrated, entries_count, shards_written)``.
+
+    Idempotency:
+      - If the migration sentinel file already exists in `archive_dir`,
+        returns ``(False, 0, 0)`` immediately.
+      - If `flat_path` does not exist, also returns ``(False, 0, 0)`` —
+        nothing to migrate.
+
+    Failure semantics:
+      If shard writes succeed for some but not all groups (e.g. disk
+      full mid-way), this raises so the caller can leave the flat file
+      intact as fallback (RFC §3.5.5: "迁移失败 → 保留 flat 文件
+      fallback"). Successful writes accumulate; partial state is
+      recoverable on next boot since the flat file remains and the
+      sentinel is only written after success.
+    """
+    sentinel_path = os.path.join(archive_dir, MIGRATION_SENTINEL_FILENAME)
+    if os.path.exists(sentinel_path):
+        return False, 0, 0
+    if not os.path.exists(flat_path):
+        return False, 0, 0
+
+    with open(flat_path, encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(
+                f"[ArchiveShard] 旧 flat 归档 {flat_path} 解析失败，跳过迁移 (保留原文件): {e}"
+            )
+            return False, 0, 0
+
+    if not isinstance(data, list):
+        logger.warning(
+            f"[ArchiveShard] 旧 flat 归档 {flat_path} 不是 list，跳过迁移 (保留原文件)"
+        )
+        return False, 0, 0
+
+    os.makedirs(archive_dir, exist_ok=True)
+    buckets = _entries_grouped_by_archived_date(data)
+    total_entries = sum(len(v) for v in buckets.values())
+    total_shards = 0
+    for date_str, group in sorted(buckets.items()):
+        total_shards += _write_shards_for_date(archive_dir, date_str, group)
+
+    # Write the sentinel BEFORE deleting the flat file: a crash between
+    # the two leaves us with both the sentinel and the original — next
+    # boot's idempotent guard short-circuits, the flat file then becomes
+    # human-deletable cruft. Reverse order would risk losing data.
+    atomic_write_json(sentinel_path, {
+        "migrated_at": datetime.now().isoformat(),
+        "source": os.path.basename(flat_path),
+        "entries": total_entries,
+        "shards": total_shards,
+    })
+
+    try:
+        os.remove(flat_path)
+    except OSError as e:
+        # Sentinel is in place; the leftover flat file is harmless until
+        # an operator removes it manually. Log loud so it's noticed.
+        logger.warning(
+            f"[ArchiveShard] 迁移成功但删除旧 flat 文件 {flat_path} 失败: {e}"
+        )
+
+    logger.info(
+        f"[ArchiveShard] 迁移 {flat_path} → {archive_dir}: "
+        f"{total_entries} 条 → {total_shards} 个分片"
+    )
+    return True, total_entries, total_shards
+
+
+async def amigrate_flat_archive_to_shards(
+    flat_path: str, archive_dir: str,
+) -> tuple[bool, int, int]:
+    """Async twin — see `migrate_flat_archive_to_shards_sync` docstring.
+
+    The migration is one-shot at startup; throughput doesn't justify a
+    truly async implementation, so we just hop to a worker thread.
+    """
+    return await asyncio.to_thread(
+        migrate_flat_archive_to_shards_sync, flat_path, archive_dir,
+    )

--- a/memory/archive_shards.py
+++ b/memory/archive_shards.py
@@ -379,12 +379,19 @@ def ensure_entry_in_named_shard_sync(
     Returns True if a write happened (entry was missing or shard was
     absent); False if the entry was already present.
 
-    Corruption posture: if the named shard exists but is corrupt
-    (non-JSON / not list), we leave it untouched (raise nothing — log
-    + return False) rather than overwriting it. Same isolation rule
-    as `_aread_shard` (Major #1). The replay will be retried on the
-    next reconciler boot; an operator can fix the corrupt shard
-    manually in between.
+    Corruption posture (coderabbit PR #934 round-3 Major): if the named
+    shard exists but is corrupt (non-JSON / not list), we raise
+    ``ShardCorruptError`` rather than returning False. The earlier
+    "log + return False" conflated "already present" with "can't
+    verify"; the archive handler then dropped the entry from the
+    active view even though the shard never received it — pure data
+    loss in the very crash window this self-heal exists to recover.
+    Callers (``make_reflection_archive_handler`` /
+    ``make_persona_archive_handler``) MUST catch ``ShardCorruptError``
+    and skip the active-view removal so the entry remains recoverable
+    until an operator repairs the corrupt shard. Replay will retry on
+    the next reconciler boot. Same isolation rule as ``_aread_shard``
+    (round-2 Major #1).
     """
     if not isinstance(entry, dict):
         return False
@@ -400,14 +407,16 @@ def ensure_entry_in_named_shard_sync(
                 data = json.load(f)
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(
-                f"[ArchiveShard] self-heal 跳过损坏分片 {shard_path}: {e}"
+                f"[ArchiveShard] self-heal 中止：目标分片损坏 {shard_path}: {e}"
             )
-            return False
+            raise ShardCorruptError(shard_path, str(e)) from e
         if not isinstance(data, list):
             logger.warning(
-                f"[ArchiveShard] self-heal 跳过非 list 分片 {shard_path}"
+                f"[ArchiveShard] self-heal 中止：目标分片非 list {shard_path}"
             )
-            return False
+            raise ShardCorruptError(
+                shard_path, f"top-level is {type(data).__name__}, not list"
+            )
         existing = [x for x in data if isinstance(x, dict)]
         for e in existing:
             if e.get('id') == eid:

--- a/memory/evidence_handlers.py
+++ b/memory/evidence_handlers.py
@@ -20,7 +20,9 @@ import os
 from memory.event_log import (
     EVT_PERSONA_ENTRY_UPDATED,
     EVT_PERSONA_EVIDENCE_UPDATED,
+    EVT_PERSONA_FACT_ADDED,
     EVT_REFLECTION_EVIDENCE_UPDATED,
+    EVT_REFLECTION_STATE_CHANGED,
     Reconciler,
 )
 from utils.file_utils import atomic_write_json
@@ -33,6 +35,9 @@ _EVIDENCE_SNAPSHOT_KEYS = (
     'reinforcement', 'disputation',
     'rein_last_signal_at', 'disp_last_signal_at',
     'sub_zero_days',
+    # 防抖字段（archive sweep 写入）：与 sub_zero_days 一对，必须随其
+    # 一起 replay，否则重放后 view 同一天可能再被 +1（破坏防抖语义）。
+    'sub_zero_last_increment_date',
     # user_fact combo counter (RFC §3.1.8) — 必须走 event log 的 replay
     # 路径才能让重放后 view 的 combo 状态一致
     'user_fact_reinforce_count',
@@ -189,12 +194,97 @@ def make_persona_entry_handler(persona_manager):
     return _apply
 
 
+def make_reflection_archive_handler(reflection_engine):
+    """Build the `reflection.state_changed` apply handler.
+
+    PR-2: only the archive transition (to='archived') is wired.
+    Non-archive state_changed events remain view-writer-driven
+    (confirm_promotion / reject_promotion write the view directly and
+    currently do not emit state_changed events). For `to='archived'`:
+    remove the entry from the active view; the shard file was already
+    written before the event was appended (see
+    `ReflectionEngine.aarchive_reflection`). Idempotent if replayed —
+    the `if entry exists` guard makes a second pass a no-op.
+    """
+
+    def _apply(name: str, payload: dict) -> bool:
+        rid = payload.get('reflection_id')
+        to_status = payload.get('to')
+        if not rid or to_status != 'archived':
+            # Forward-compat: unknown state transitions are a no-op in
+            # this handler; PR-3 may add handlers for promoted/denied.
+            return False
+        path = reflection_engine._reflections_path(name)
+        data: list[dict] = []
+        if os.path.exists(path):
+            with open(path, encoding='utf-8') as f:
+                data = json.load(f)
+        if not isinstance(data, list):
+            raise RuntimeError(
+                f"[ArchiveHandler] {path}: 期望 list，实际 "
+                f"{type(data).__name__}；view 结构异常，暂停 replay"
+            )
+        before = len(data)
+        data = [r for r in data if not (isinstance(r, dict) and r.get('id') == rid)]
+        if len(data) == before:
+            return False  # already removed (idempotent replay)
+        atomic_write_json(path, data, indent=2, ensure_ascii=False)
+        return True
+
+    return _apply
+
+
+def make_persona_archive_handler(persona_manager):
+    """Build the `persona.fact_added` apply handler for archive events.
+
+    RFC §3.5.6: persona archive 复用 fact_added 事件，用 payload 里的
+    `archive_shard_path` 字段区分主路径的 fact_added（该路径未来可能由
+    PR-3 emit，但当前代码未使用）。PR-2 handler 只对带 archive_shard_path
+    的 payload 做归档（从主视图移除 entry）。不带该字段的 payload 当前
+    视为 no-op — 正向 fact_added 还没走事件路径。
+    """
+
+    def _apply(name: str, payload: dict) -> bool:
+        if not payload.get('archive_shard_path'):
+            return False  # Not an archive event → no-op for PR-2
+        entity_key = payload.get('entity_key')
+        entry_id = payload.get('entry_id')
+        if not entity_key or not entry_id:
+            return False
+        path = persona_manager._persona_path(name)
+        if not os.path.exists(path):
+            return False
+        with open(path, encoding='utf-8') as f:
+            persona = json.load(f)
+        if not isinstance(persona, dict):
+            raise RuntimeError(
+                f"[ArchiveHandler] {path}: 期望 dict，实际 "
+                f"{type(persona).__name__}；view 结构异常，暂停 replay"
+            )
+        section = persona.get(entity_key)
+        if not isinstance(section, dict):
+            return False
+        facts = section.get('facts', [])
+        before = len(facts)
+        section['facts'] = [
+            e for e in facts
+            if not (isinstance(e, dict) and e.get('id') == entry_id)
+        ]
+        if len(section['facts']) == before:
+            return False
+        persona_manager._personas[name] = persona
+        atomic_write_json(path, persona, indent=2, ensure_ascii=False)
+        return True
+
+    return _apply
+
+
 def register_evidence_handlers(
     reconciler: Reconciler,
     persona_manager,
     reflection_engine,
 ) -> None:
-    """Register all three evidence handlers on a reconciler.
+    """Register all evidence + archive handlers on a reconciler.
 
     Call once per boot (memory_server startup) and per hot-reload — the
     closures capture the current manager instances so reload-swapped
@@ -210,4 +300,13 @@ def register_evidence_handlers(
     reconciler.register(
         EVT_PERSONA_ENTRY_UPDATED,
         make_persona_entry_handler(persona_manager),
+    )
+    # RFC §3.5.6: archive events reuse state_changed / fact_added
+    reconciler.register(
+        EVT_REFLECTION_STATE_CHANGED,
+        make_reflection_archive_handler(reflection_engine),
+    )
+    reconciler.register(
+        EVT_PERSONA_FACT_ADDED,
+        make_persona_archive_handler(persona_manager),
     )

--- a/memory/evidence_handlers.py
+++ b/memory/evidence_handlers.py
@@ -229,15 +229,34 @@ def make_reflection_archive_handler(reflection_engine):
         # Step 1+2: shard self-heal (write entry into the named shard
         # if missing). Skipped if the event lacks the snapshot fields
         # — older logs from round-1 don't carry them.
-        from memory.archive_shards import ensure_entry_in_named_shard_sync
+        #
+        # Coderabbit PR #934 round-3 Major: if the named shard exists
+        # but is corrupt, ``ensure_entry_in_named_shard_sync`` raises
+        # ``ShardCorruptError`` instead of silently returning False.
+        # We MUST NOT proceed to step 3 in that case — removing the
+        # entry from the active view when we couldn't verify the shard
+        # would lose the only remaining copy. Bail with view intact;
+        # the next reconciler boot will retry once the operator has
+        # repaired (or removed) the corrupt shard.
+        from memory.archive_shards import (
+            ShardCorruptError,
+            ensure_entry_in_named_shard_sync,
+        )
         shard_basename = payload.get('archive_shard_path')
         snapshot = payload.get('entry_snapshot')
         shard_changed = False
         if shard_basename and isinstance(snapshot, dict):
             archive_dir = reflection_engine._reflections_archive_dir(name)
-            shard_changed = ensure_entry_in_named_shard_sync(
-                archive_dir, shard_basename, snapshot,
-            )
+            try:
+                shard_changed = ensure_entry_in_named_shard_sync(
+                    archive_dir, shard_basename, snapshot,
+                )
+            except ShardCorruptError as e:
+                logger.warning(
+                    f"[ArchiveHandler] {name}: 目标分片损坏，保留 active view "
+                    f"中的 reflection_id={rid} 待人工修复后重放: {e}"
+                )
+                return False
 
         # Step 3: remove from the active view (the original handler
         # behavior — still idempotent).
@@ -297,14 +316,28 @@ def make_persona_archive_handler(persona_manager):
 
         # Step 1+2: shard self-heal. Skipped if event predates
         # entry_snapshot (round-1 logs).
-        from memory.archive_shards import ensure_entry_in_named_shard_sync
+        #
+        # Coderabbit PR #934 round-3 Major (twin of reflection handler):
+        # corrupt target shard raises ``ShardCorruptError`` — bail with
+        # the persona view untouched so the entry isn't lost.
+        from memory.archive_shards import (
+            ShardCorruptError,
+            ensure_entry_in_named_shard_sync,
+        )
         snapshot = payload.get('entry_snapshot')
         shard_changed = False
         if isinstance(snapshot, dict):
             archive_dir = persona_manager._persona_archive_dir(name)
-            shard_changed = ensure_entry_in_named_shard_sync(
-                archive_dir, shard_basename, snapshot,
-            )
+            try:
+                shard_changed = ensure_entry_in_named_shard_sync(
+                    archive_dir, shard_basename, snapshot,
+                )
+            except ShardCorruptError as e:
+                logger.warning(
+                    f"[ArchiveHandler] {name}: 目标分片损坏，保留 persona "
+                    f"{entity_key}/{entry_id} 待人工修复后重放: {e}"
+                )
+                return False
 
         # Step 3: persona main-view removal.
         path = persona_manager._persona_path(name)

--- a/memory/evidence_handlers.py
+++ b/memory/evidence_handlers.py
@@ -200,11 +200,22 @@ def make_reflection_archive_handler(reflection_engine):
     PR-2: only the archive transition (to='archived') is wired.
     Non-archive state_changed events remain view-writer-driven
     (confirm_promotion / reject_promotion write the view directly and
-    currently do not emit state_changed events). For `to='archived'`:
-    remove the entry from the active view; the shard file was already
-    written before the event was appended (see
-    `ReflectionEngine.aarchive_reflection`). Idempotent if replayed —
-    the `if entry exists` guard makes a second pass a no-op.
+    currently do not emit state_changed events).
+
+    Self-healing semantics (coderabbit PR #934 round-2 Major #3):
+      The archive write path is `record_and_save` (event + active-view
+      removal) FOLLOWED BY shard append. If the process dies between
+      those two steps, the entry is gone from the active view but the
+      shard never received it — pure data loss without a self-heal.
+      So on every replay, this handler:
+        1. Reads `archive_shard_path` + `entry_snapshot` from payload.
+        2. Ensures the named shard contains the snapshot (idempotent;
+           dedup by entry id).
+        3. THEN removes the entry from the active view if still there.
+      Both steps are individually idempotent → N replays leave the
+      same state as one application. Older events lacking
+      `entry_snapshot` (round-1 schema) skip step 2 and behave as the
+      original "view-only" handler.
     """
 
     def _apply(name: str, payload: dict) -> bool:
@@ -214,6 +225,22 @@ def make_reflection_archive_handler(reflection_engine):
             # Forward-compat: unknown state transitions are a no-op in
             # this handler; PR-3 may add handlers for promoted/denied.
             return False
+
+        # Step 1+2: shard self-heal (write entry into the named shard
+        # if missing). Skipped if the event lacks the snapshot fields
+        # — older logs from round-1 don't carry them.
+        from memory.archive_shards import ensure_entry_in_named_shard_sync
+        shard_basename = payload.get('archive_shard_path')
+        snapshot = payload.get('entry_snapshot')
+        shard_changed = False
+        if shard_basename and isinstance(snapshot, dict):
+            archive_dir = reflection_engine._reflections_archive_dir(name)
+            shard_changed = ensure_entry_in_named_shard_sync(
+                archive_dir, shard_basename, snapshot,
+            )
+
+        # Step 3: remove from the active view (the original handler
+        # behavior — still idempotent).
         path = reflection_engine._reflections_path(name)
         data: list[dict] = []
         if os.path.exists(path):
@@ -226,10 +253,10 @@ def make_reflection_archive_handler(reflection_engine):
             )
         before = len(data)
         data = [r for r in data if not (isinstance(r, dict) and r.get('id') == rid)]
-        if len(data) == before:
-            return False  # already removed (idempotent replay)
-        atomic_write_json(path, data, indent=2, ensure_ascii=False)
-        return True
+        view_changed = len(data) != before
+        if view_changed:
+            atomic_write_json(path, data, indent=2, ensure_ascii=False)
+        return view_changed or shard_changed
 
     return _apply
 
@@ -240,20 +267,49 @@ def make_persona_archive_handler(persona_manager):
     RFC §3.5.6: persona archive 复用 fact_added 事件，用 payload 里的
     `archive_shard_path` 字段区分主路径的 fact_added（该路径未来可能由
     PR-3 emit，但当前代码未使用）。PR-2 handler 只对带 archive_shard_path
-    的 payload 做归档（从主视图移除 entry）。不带该字段的 payload 当前
-    视为 no-op — 正向 fact_added 还没走事件路径。
+    的 payload 做归档。不带该字段的 payload 当前视为 no-op — 正向
+    fact_added 还没走事件路径。
+
+    Self-healing semantics (coderabbit PR #934 round-2 Major #3 — twin
+    of `make_reflection_archive_handler`):
+      The archive write path is `record_and_save` (event + view
+      mutation) FOLLOWED BY shard append. A crash between those two
+      steps leaves the entry gone from the persona but never written
+      to the shard. So on every replay, this handler:
+        1. Reads `archive_shard_path` + `entry_snapshot` from payload.
+        2. Ensures the named shard contains the snapshot (idempotent;
+           dedup by entry id).
+        3. THEN removes the entry from the persona main view if still
+           there.
+      Both steps are individually idempotent → N replays = 1 apply.
+      Older events without `entry_snapshot` (round-1 schema) skip
+      step 2 and behave as the original view-only handler.
     """
 
     def _apply(name: str, payload: dict) -> bool:
-        if not payload.get('archive_shard_path'):
+        shard_basename = payload.get('archive_shard_path')
+        if not shard_basename:
             return False  # Not an archive event → no-op for PR-2
         entity_key = payload.get('entity_key')
         entry_id = payload.get('entry_id')
         if not entity_key or not entry_id:
             return False
+
+        # Step 1+2: shard self-heal. Skipped if event predates
+        # entry_snapshot (round-1 logs).
+        from memory.archive_shards import ensure_entry_in_named_shard_sync
+        snapshot = payload.get('entry_snapshot')
+        shard_changed = False
+        if isinstance(snapshot, dict):
+            archive_dir = persona_manager._persona_archive_dir(name)
+            shard_changed = ensure_entry_in_named_shard_sync(
+                archive_dir, shard_basename, snapshot,
+            )
+
+        # Step 3: persona main-view removal.
         path = persona_manager._persona_path(name)
         if not os.path.exists(path):
-            return False
+            return shard_changed
         with open(path, encoding='utf-8') as f:
             persona = json.load(f)
         if not isinstance(persona, dict):
@@ -263,18 +319,18 @@ def make_persona_archive_handler(persona_manager):
             )
         section = persona.get(entity_key)
         if not isinstance(section, dict):
-            return False
+            return shard_changed
         facts = section.get('facts', [])
         before = len(facts)
         section['facts'] = [
             e for e in facts
             if not (isinstance(e, dict) and e.get('id') == entry_id)
         ]
-        if len(section['facts']) == before:
-            return False
-        persona_manager._personas[name] = persona
-        atomic_write_json(path, persona, indent=2, ensure_ascii=False)
-        return True
+        view_changed = len(section['facts']) != before
+        if view_changed:
+            persona_manager._personas[name] = persona
+            atomic_write_json(path, persona, indent=2, ensure_ascii=False)
+        return view_changed or shard_changed
 
     return _apply
 

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -826,11 +826,17 @@ class PersonaManager:
             entry = self._find_entry_in_section(section_facts, entry_id)
             if entry is None:
                 return None
-            if not maybe_mark_sub_zero(entry, now):
+            # Coderabbit PR #934 round-2 Major #2: probe on a staged copy
+            # so the cached entry is NOT mutated until inside the locked
+            # record_and_save critical section. If event append or save
+            # raises, the cache stays clean (no orphan sub_zero_days
+            # increment that never made it to the event log).
+            staged_entry = dict(entry)
+            if not maybe_mark_sub_zero(staged_entry, now):
                 return None
 
-            new_count = int(entry.get('sub_zero_days', 0) or 0)
-            new_date = entry.get('sub_zero_last_increment_date')
+            new_count = int(staged_entry.get('sub_zero_days', 0) or 0)
+            new_date = staged_entry.get('sub_zero_last_increment_date')
 
             payload = {
                 'entity_key': entity_key,
@@ -851,6 +857,9 @@ class PersonaManager:
                 return persona
 
             def _sync_mutate(_view):
+                # Apply the staged values to the cached entry only after
+                # event append has already succeeded (record_and_save
+                # guarantees this ordering).
                 entry['sub_zero_days'] = new_count
                 entry['sub_zero_last_increment_date'] = new_date
 
@@ -941,13 +950,13 @@ class PersonaManager:
                 # reading the shard back from disk.
                 'text': entry.get('text', ''),
                 'source': entry.get('source', 'unknown'),
-                # Full entry snapshot — lets a future reconciler rewrite
-                # the shard if a crash occurs after record_and_save but
-                # before the shard append below. Today the persona archive
-                # handler only mutates the active view (idempotent), so
-                # the shard is the source of truth for archived data; if
-                # we lose the shard write we lose the archived record.
-                # Carrying the snapshot keeps that recoverable.
+                # Full entry snapshot — the persona archive handler in
+                # evidence_handlers.py reads this on every replay and
+                # idempotently recreates the shard if it's missing
+                # (coderabbit PR #934 round-2 Major #3). Recoverable
+                # crash window: any failure between record_and_save
+                # and the shard append below is healed on the next
+                # reconciler boot.
                 'entry_snapshot': archive_entry,
             }
 
@@ -972,16 +981,18 @@ class PersonaManager:
                     self._persona_path(n), view, indent=2, ensure_ascii=False,
                 )
 
-            # ORDER (coderabbit review #934 — reversed from the original
-            # "shard first, then record_and_save"): record_and_save first
-            # commits the event + view mutation atomically; only THEN do
-            # we append to the shard. The crash window shifts from
-            # "entry duplicated in shard + still in active view" (bad —
-            # next sweep re-archives → growing shard duplicates) to
-            # "entry removed from active + event recorded but shard
-            # missing" (acceptable — event log is the source of truth
-            # per RFC §3.11; entry_snapshot in payload makes future
-            # reconciler-driven shard rewrite possible).
+            # ORDER (coderabbit review #934 round-1 + round-2):
+            # 1. record_and_save first — commits event + view mutation
+            #    atomically. Avoids "duplicated shard entry + still
+            #    active in view" (next sweep would re-archive into a
+            #    second shard slot).
+            # 2. aappend_to_shard second. If this raises, the active
+            #    view has already lost the entry but the shard never
+            #    got it. Self-heal: the persona archive handler in
+            #    evidence_handlers.py reads `entry_snapshot` from the
+            #    event payload and re-creates the shard on the next
+            #    reconciler boot — event log is the source of truth
+            #    (RFC §3.11), snapshot makes recovery automatic.
             await self._event_log.arecord_and_save(
                 name, EVT_PERSONA_FACT_ADDED, payload,
                 sync_load_view=_sync_load,

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -921,12 +921,16 @@ class PersonaManager:
             now_iso = now.isoformat()
             from memory.archive_shards import apick_today_shard_path
             archive_dir = self._persona_archive_dir(name)
+            # Pre-pick the shard path BEFORE record_and_save so we can
+            # stamp it into the event payload (and into the archive_entry
+            # we'll write afterward). `apick_today_shard_path` materializes
+            # the file on disk so the choice is stable across the
+            # subsequent shard append.
             shard_path = await apick_today_shard_path(archive_dir, now=now)
             shard_basename = os.path.basename(shard_path)
             archive_entry = dict(entry)
             archive_entry['archived_at'] = now_iso
             archive_entry['archive_shard_path'] = shard_basename
-            await aappend_to_shard(archive_dir, [archive_entry], now=now)
 
             payload = {
                 'entity_key': entity_key,
@@ -937,6 +941,14 @@ class PersonaManager:
                 # reading the shard back from disk.
                 'text': entry.get('text', ''),
                 'source': entry.get('source', 'unknown'),
+                # Full entry snapshot — lets a future reconciler rewrite
+                # the shard if a crash occurs after record_and_save but
+                # before the shard append below. Today the persona archive
+                # handler only mutates the active view (idempotent), so
+                # the shard is the source of truth for archived data; if
+                # we lose the shard write we lose the archived record.
+                # Carrying the snapshot keeps that recoverable.
+                'entry_snapshot': archive_entry,
             }
 
             def _sync_load(_n: str):
@@ -960,12 +972,23 @@ class PersonaManager:
                     self._persona_path(n), view, indent=2, ensure_ascii=False,
                 )
 
+            # ORDER (coderabbit review #934 — reversed from the original
+            # "shard first, then record_and_save"): record_and_save first
+            # commits the event + view mutation atomically; only THEN do
+            # we append to the shard. The crash window shifts from
+            # "entry duplicated in shard + still in active view" (bad —
+            # next sweep re-archives → growing shard duplicates) to
+            # "entry removed from active + event recorded but shard
+            # missing" (acceptable — event log is the source of truth
+            # per RFC §3.11; entry_snapshot in payload makes future
+            # reconciler-driven shard rewrite possible).
             await self._event_log.arecord_and_save(
                 name, EVT_PERSONA_FACT_ADDED, payload,
                 sync_load_view=_sync_load,
                 sync_mutate_view=_sync_mutate,
                 sync_save_view=_sync_save,
             )
+            await aappend_to_shard(archive_dir, [archive_entry], now=now)
             logger.info(
                 f"[Persona] {name}: 归档 entry {entity_key}/{entry_id} "
                 f"→ {shard_basename}"

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -136,6 +136,18 @@ class PersonaManager:
         from memory import ensure_character_dir
         return os.path.join(ensure_character_dir(self._config_manager.memory_dir, name), 'persona_corrections.json')
 
+    def _persona_archive_dir(self, name: str) -> str:
+        """Sharded archive directory for persona entries (RFC §3.5.4).
+
+        New in PR-2 — persona had no archival before this RFC, so there
+        is no legacy flat file to migrate (RFC §3.5.5 末段).
+        """
+        from memory import ensure_character_dir
+        return os.path.join(
+            ensure_character_dir(self._config_manager.memory_dir, name),
+            'persona_archive',
+        )
+
     # ── CRUD ─────────────────────────────────────────────────────────
 
     def _empty_persona(self) -> dict:
@@ -784,6 +796,179 @@ class PersonaManager:
                 sync_load_view=_sync_load,
                 sync_mutate_view=_sync_mutate,
                 sync_save_view=_sync_save,
+            )
+            return True
+
+    # ── score-driven archive (RFC §3.5) ─────────────────────────────
+
+    async def aincrement_sub_zero(
+        self, name: str, entity_key: str, entry_id: str, now: datetime,
+    ) -> int | None:
+        """Increment one persona entry's `sub_zero_days` via EVT_PERSONA_EVIDENCE_UPDATED.
+
+        Symmetric to `ReflectionEngine.aincrement_sub_zero`. Called by
+        the periodic archive sweep loop. Returns the new count or None
+        if no increment happened.
+        """
+        from memory.event_log import EVT_PERSONA_EVIDENCE_UPDATED
+        from memory.evidence import maybe_mark_sub_zero
+        if self._event_log is None:
+            raise RuntimeError(
+                "[Persona.aincrement_sub_zero] event_log 未注入"
+            )
+
+        async with self._get_alock(name):
+            persona = await self._aensure_persona_locked(name)
+            section = persona.get(entity_key)
+            if not isinstance(section, dict):
+                return None
+            section_facts = section.get('facts', [])
+            entry = self._find_entry_in_section(section_facts, entry_id)
+            if entry is None:
+                return None
+            if not maybe_mark_sub_zero(entry, now):
+                return None
+
+            new_count = int(entry.get('sub_zero_days', 0) or 0)
+            new_date = entry.get('sub_zero_last_increment_date')
+
+            payload = {
+                'entity_key': entity_key,
+                'entry_id': entry_id,
+                'reinforcement': float(entry.get('reinforcement', 0.0) or 0.0),
+                'disputation': float(entry.get('disputation', 0.0) or 0.0),
+                'rein_last_signal_at': entry.get('rein_last_signal_at'),
+                'disp_last_signal_at': entry.get('disp_last_signal_at'),
+                'sub_zero_days': new_count,
+                'sub_zero_last_increment_date': new_date,
+                'user_fact_reinforce_count': int(
+                    entry.get('user_fact_reinforce_count', 0) or 0,
+                ),
+                'source': 'archive_sweep',
+            }
+
+            def _sync_load(_n: str):
+                return persona
+
+            def _sync_mutate(_view):
+                entry['sub_zero_days'] = new_count
+                entry['sub_zero_last_increment_date'] = new_date
+
+            def _sync_save(n: str, view):
+                assert_cloudsave_writable(
+                    self._config_manager,
+                    operation="save",
+                    target=f"memory/{n}/persona.json",
+                )
+                self._personas[n] = view
+                atomic_write_json(
+                    self._persona_path(n), view, indent=2, ensure_ascii=False,
+                )
+
+            await self._event_log.arecord_and_save(
+                name, EVT_PERSONA_EVIDENCE_UPDATED, payload,
+                sync_load_view=_sync_load,
+                sync_mutate_view=_sync_mutate,
+                sync_save_view=_sync_save,
+            )
+            return new_count
+
+    async def aarchive_persona_entry(
+        self, name: str, entity_key: str, entry_id: str,
+    ) -> bool:
+        """Move one persona entry from main view to a sharded archive file.
+
+        RFC §3.5.6: archive 复用 ``EVT_PERSONA_FACT_ADDED`` 事件 — payload
+        carries an `archive_shard_path` field so consumers can distinguish
+        the archive flow from a regular fact_added (regular adds have no
+        such field). Mirrors `ReflectionEngine.aarchive_reflection`.
+
+        Returns True if archived; False if not found / protected.
+        """
+        from memory.archive_shards import aappend_to_shard
+        from memory.event_log import EVT_PERSONA_FACT_ADDED
+        if self._event_log is None:
+            raise RuntimeError(
+                "[Persona.aarchive_persona_entry] event_log 未注入；"
+                "PersonaManager() 构造时须传入 event_log"
+            )
+
+        async with self._get_alock(name):
+            persona = await self._aensure_persona_locked(name)
+            section = persona.get(entity_key)
+            if not isinstance(section, dict):
+                logger.warning(
+                    f"[Persona] {name}: aarchive_persona_entry 找不到 "
+                    f"entity_key={entity_key}"
+                )
+                return False
+            section_facts = section.get('facts', [])
+            entry = self._find_entry_in_section(section_facts, entry_id)
+            if entry is None:
+                logger.warning(
+                    f"[Persona] {name}: aarchive_persona_entry 找不到 "
+                    f"entry_id={entry_id}"
+                )
+                return False
+            if entry.get('protected'):
+                logger.debug(
+                    f"[Persona] {name}: aarchive_persona_entry 跳过 protected "
+                    f"entry_id={entry_id}"
+                )
+                return False
+
+            now = datetime.now()
+            now_iso = now.isoformat()
+            from memory.archive_shards import apick_today_shard_path
+            archive_dir = self._persona_archive_dir(name)
+            shard_path = await apick_today_shard_path(archive_dir, now=now)
+            shard_basename = os.path.basename(shard_path)
+            archive_entry = dict(entry)
+            archive_entry['archived_at'] = now_iso
+            archive_entry['archive_shard_path'] = shard_basename
+            await aappend_to_shard(archive_dir, [archive_entry], now=now)
+
+            payload = {
+                'entity_key': entity_key,
+                'entry_id': entry_id,
+                'archive_shard_path': shard_basename,
+                'archived_at': now_iso,
+                # Snapshot the text/source for replayability without
+                # reading the shard back from disk.
+                'text': entry.get('text', ''),
+                'source': entry.get('source', 'unknown'),
+            }
+
+            def _sync_load(_n: str):
+                return persona
+
+            def _sync_mutate(_view):
+                # Drop the archived entry from the entity section.
+                section_facts[:] = [
+                    e for e in section_facts
+                    if not (isinstance(e, dict) and e.get('id') == entry_id)
+                ]
+
+            def _sync_save(n: str, view):
+                assert_cloudsave_writable(
+                    self._config_manager,
+                    operation="save",
+                    target=f"memory/{n}/persona.json",
+                )
+                self._personas[n] = view
+                atomic_write_json(
+                    self._persona_path(n), view, indent=2, ensure_ascii=False,
+                )
+
+            await self._event_log.arecord_and_save(
+                name, EVT_PERSONA_FACT_ADDED, payload,
+                sync_load_view=_sync_load,
+                sync_mutate_view=_sync_mutate,
+                sync_save_view=_sync_save,
+            )
+            logger.info(
+                f"[Persona] {name}: 归档 entry {entity_key}/{entry_id} "
+                f"→ {shard_basename}"
             )
             return True
 

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -301,20 +301,27 @@ class ReflectionEngine:
         return merged, to_archive, keep_in_main
 
     @staticmethod
-    def _stamp_archive_metadata(entries: list[dict], shard_path: str) -> list[dict]:
-        """Add archived_at + archive_shard_path fields to each entry
-        before they go into a shard. RFC §3.5.6: "归档后字段追加：
-        archived_at（ISO8601）和 archive_shard_path（相对路径字符串）"。
+    def _make_archive_stamper(now_iso: str):
+        """Return a ``stamper(chunk, shard_basename)`` callback for
+        ``aappend_to_shard`` / ``append_to_shard_sync``. RFC §3.5.6:
+        "归档后字段追加：archived_at（ISO8601）和 archive_shard_path
+        （相对路径字符串）"。
 
         We store the basename only (relative to the kind-archive dir) —
         keeps logs short and survives memory_dir relocation.
+
+        Why a callback (chatgpt-codex / coderabbit review #934): the
+        previous "stamp after write" path mutated only the in-memory
+        list, so on-disk records lacked both fields; and in the overflow
+        case where one batch spilled into multiple shards, the single
+        returned ``shard_path`` couldn't describe per-entry locations.
+        Per-chunk stamping inside ``aappend_to_shard`` fixes both.
         """
-        now_iso = datetime.now().isoformat()
-        shard_basename = os.path.basename(shard_path) if shard_path else ''
-        for e in entries:
-            e.setdefault('archived_at', now_iso)
-            e['archive_shard_path'] = shard_basename
-        return entries
+        def _stamp(chunk: list[dict], shard_basename: str) -> None:
+            for e in chunk:
+                e.setdefault('archived_at', now_iso)
+                e['archive_shard_path'] = shard_basename
+        return _stamp
 
     def save_reflections(self, name: str, reflections: list[dict]) -> None:
         """Save reflections, archiving stale promoted/denied entries to shards.
@@ -347,8 +354,10 @@ class ReflectionEngine:
         if to_archive:
             archive_dir = self._reflections_archive_dir(name)
             try:
-                shard_path = append_to_shard_sync(archive_dir, list(to_archive))
-                self._stamp_archive_metadata(to_archive, shard_path)
+                stamper = self._make_archive_stamper(datetime.now().isoformat())
+                shard_path = append_to_shard_sync(
+                    archive_dir, list(to_archive), stamper=stamper,
+                )
                 logger.info(
                     f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections → {os.path.basename(shard_path)}"
                 )
@@ -385,8 +394,10 @@ class ReflectionEngine:
         if to_archive:
             archive_dir = self._reflections_archive_dir(name)
             try:
-                shard_path = await aappend_to_shard(archive_dir, list(to_archive))
-                self._stamp_archive_metadata(to_archive, shard_path)
+                stamper = self._make_archive_stamper(datetime.now().isoformat())
+                shard_path = await aappend_to_shard(
+                    archive_dir, list(to_archive), stamper=stamper,
+                )
                 logger.info(
                     f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections → {os.path.basename(shard_path)}"
                 )
@@ -824,7 +835,6 @@ class ReflectionEngine:
             archive_entry['archived_at'] = now_iso
             archive_entry['status'] = 'archived'
             archive_entry['archive_shard_path'] = shard_basename
-            await aappend_to_shard(archive_dir, [archive_entry], now=now)
 
             payload = {
                 'reflection_id': reflection_id,
@@ -832,6 +842,11 @@ class ReflectionEngine:
                 'to': 'archived',
                 'archive_shard_path': shard_basename,
                 'archived_at': now_iso,
+                # Symmetry with aarchive_persona_entry — full entry
+                # snapshot lets a future reconciler rewrite the shard if
+                # a crash occurs between record_and_save and the shard
+                # append below.
+                'entry_snapshot': archive_entry,
             }
 
             def _sync_load(_n: str):
@@ -852,12 +867,19 @@ class ReflectionEngine:
                     self._reflections_path(n), view, indent=2, ensure_ascii=False,
                 )
 
+            # ORDER (coderabbit review #934, mirroring persona fix):
+            # record_and_save first (commits event + view mutation),
+            # THEN append to shard. Avoids the "shard duplicate +
+            # still-active entry" race where a crash between shard write
+            # and view save would let the next sweep re-archive the same
+            # entry into a second shard slot.
             await self._event_log.arecord_and_save(
                 lanlan_name, EVT_REFLECTION_STATE_CHANGED, payload,
                 sync_load_view=_sync_load,
                 sync_mutate_view=_sync_mutate,
                 sync_save_view=_sync_save,
             )
+            await aappend_to_shard(archive_dir, [archive_entry], now=now)
             logger.info(
                 f"[Reflection] {lanlan_name}: 归档 reflection {reflection_id} "
                 f"(score-driven, prev_status={prev_status}) → {shard_basename}"

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -316,10 +316,21 @@ class ReflectionEngine:
         case where one batch spilled into multiple shards, the single
         returned ``shard_path`` couldn't describe per-entry locations.
         Per-chunk stamping inside ``aappend_to_shard`` fixes both.
+
+        Coderabbit PR #934 round-3 Minor: ``archived_at`` uses direct
+        assignment (not ``setdefault``) so cross-day retries restamp
+        with the actual write date. Earlier ``setdefault`` would
+        preserve the first failed attempt's timestamp; if shard write
+        failed and ``save_reflections`` rolled the entries back into
+        main with ``archived_at`` already attached, a next-day retry
+        would update ``archive_shard_path`` to the new day's basename
+        but leave ``archived_at`` pointing at yesterday — the two
+        fields would disagree on the date. Losing the first stamp is
+        fine because the entry never landed in any shard at that point.
         """
         def _stamp(chunk: list[dict], shard_basename: str) -> None:
             for e in chunk:
-                e.setdefault('archived_at', now_iso)
+                e['archived_at'] = now_iso
                 e['archive_shard_path'] = shard_basename
         return _stamp
 

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -144,9 +144,29 @@ class ReflectionEngine:
         from memory import ensure_character_dir
         return os.path.join(ensure_character_dir(self._config_manager.memory_dir, name), 'reflections.json')
 
-    def _reflections_archive_path(self, name: str) -> str:
+    def _reflections_archive_dir(self, name: str) -> str:
+        """Sharded archive directory (RFC §3.5.4).
+
+        Replaces the legacy flat ``reflections_archive.json`` file. The
+        directory is created lazily by `aappend_to_shard` on first
+        archive event so an idle character never carries an empty dir.
+        """
         from memory import ensure_character_dir
-        return os.path.join(ensure_character_dir(self._config_manager.memory_dir, name), 'reflections_archive.json')
+        return os.path.join(
+            ensure_character_dir(self._config_manager.memory_dir, name),
+            'reflection_archive',
+        )
+
+    def _reflections_legacy_archive_path(self, name: str) -> str:
+        """Legacy flat archive path (pre-RFC §3.5.4). Kept for the
+        one-shot migration in `aone_shot_archive_migration` and to keep
+        the migration sentinel test-discoverable. NOT referenced by any
+        write path."""
+        from memory import ensure_character_dir
+        return os.path.join(
+            ensure_character_dir(self._config_manager.memory_dir, name),
+            'reflections_archive.json',
+        )
 
     def _surfaced_path(self, name: str) -> str:
         from memory import ensure_character_dir
@@ -280,11 +300,31 @@ class ReflectionEngine:
         merged = reflections + keep_in_main
         return merged, to_archive, keep_in_main
 
-    def save_reflections(self, name: str, reflections: list[dict]) -> None:
-        """Save reflections, merging with archived entries on disk.
+    @staticmethod
+    def _stamp_archive_metadata(entries: list[dict], shard_path: str) -> list[dict]:
+        """Add archived_at + archive_shard_path fields to each entry
+        before they go into a shard. RFC §3.5.6: "归档后字段追加：
+        archived_at（ISO8601）和 archive_shard_path（相对路径字符串）"。
 
-        promoted/denied 超过 _REFLECTION_ARCHIVE_DAYS 的条目自动移入归档文件。
+        We store the basename only (relative to the kind-archive dir) —
+        keeps logs short and survives memory_dir relocation.
         """
+        now_iso = datetime.now().isoformat()
+        shard_basename = os.path.basename(shard_path) if shard_path else ''
+        for e in entries:
+            e.setdefault('archived_at', now_iso)
+            e['archive_shard_path'] = shard_basename
+        return entries
+
+    def save_reflections(self, name: str, reflections: list[dict]) -> None:
+        """Save reflections, archiving stale promoted/denied entries to shards.
+
+        promoted/denied 超过 _REFLECTION_ARCHIVE_DAYS 的条目自动移入分片归档
+        目录 (RFC §3.5.4)。This path covers the EXISTING age-based archival —
+        score-driven `sub_zero_days >= EVIDENCE_ARCHIVE_DAYS` archival uses
+        the dedicated `aarchive_reflection` event-sourced path instead.
+        """
+        from memory.archive_shards import append_to_shard_sync
         assert_cloudsave_writable(
             self._config_manager,
             operation="save",
@@ -305,26 +345,25 @@ class ReflectionEngine:
         merged, to_archive, _ = self._prepare_save_reflections(name, reflections, all_on_disk)
 
         if to_archive:
-            archive_path = self._reflections_archive_path(name)
-            existing: list[dict] = []
-            if os.path.exists(archive_path):
-                try:
-                    with open(archive_path, encoding='utf-8') as f:
-                        data = json.load(f)
-                    if isinstance(data, list):
-                        existing = data
-                except (json.JSONDecodeError, OSError) as e:
-                    logger.warning(f"[Reflection] {name}: 读取归档文件失败，跳过本次归档: {e}")
-                    merged = merged + to_archive
-                    to_archive = []
-            if to_archive:
-                existing.extend(to_archive)
-                atomic_write_json(archive_path, existing, indent=2, ensure_ascii=False)
-                logger.info(f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections")
+            archive_dir = self._reflections_archive_dir(name)
+            try:
+                shard_path = append_to_shard_sync(archive_dir, list(to_archive))
+                self._stamp_archive_metadata(to_archive, shard_path)
+                logger.info(
+                    f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections → {os.path.basename(shard_path)}"
+                )
+            except OSError as e:
+                # Fall-back: keep the entries in main file rather than lose
+                # them. Same posture as the old flat-file path.
+                logger.warning(
+                    f"[Reflection] {name}: 写归档分片失败，回滚到 main 保留: {e}"
+                )
+                merged = merged + to_archive
 
         atomic_write_json(path, merged, indent=2, ensure_ascii=False)
 
     async def asave_reflections(self, name: str, reflections: list[dict]) -> None:
+        from memory.archive_shards import aappend_to_shard
         assert_cloudsave_writable(
             self._config_manager,
             operation="save",
@@ -344,21 +383,18 @@ class ReflectionEngine:
         merged, to_archive, _ = self._prepare_save_reflections(name, reflections, all_on_disk)
 
         if to_archive:
-            archive_path = self._reflections_archive_path(name)
-            existing: list[dict] = []
-            if await asyncio.to_thread(os.path.exists, archive_path):
-                try:
-                    data = await read_json_async(archive_path)
-                    if isinstance(data, list):
-                        existing = data
-                except (json.JSONDecodeError, OSError) as e:
-                    logger.warning(f"[Reflection] {name}: 读取归档文件失败，跳过本次归档: {e}")
-                    merged = merged + to_archive
-                    to_archive = []
-            if to_archive:
-                existing.extend(to_archive)
-                await atomic_write_json_async(archive_path, existing, indent=2, ensure_ascii=False)
-                logger.info(f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections")
+            archive_dir = self._reflections_archive_dir(name)
+            try:
+                shard_path = await aappend_to_shard(archive_dir, list(to_archive))
+                self._stamp_archive_metadata(to_archive, shard_path)
+                logger.info(
+                    f"[Reflection] {name}: 归档 {len(to_archive)} 条旧 reflections → {os.path.basename(shard_path)}"
+                )
+            except OSError as e:
+                logger.warning(
+                    f"[Reflection] {name}: 写归档分片失败，回滚到 main 保留: {e}"
+                )
+                merged = merged + to_archive
 
         await atomic_write_json_async(path, merged, indent=2, ensure_ascii=False)
 
@@ -645,6 +681,219 @@ class ReflectionEngine:
                 sync_save_view=_sync_save,
             )
             return True
+
+    # ── score-driven archive (RFC §3.5) ─────────────────────────────
+
+    async def aincrement_sub_zero(
+        self, lanlan_name: str, reflection_id: str, now: datetime,
+    ) -> int | None:
+        """Increment one reflection's `sub_zero_days` via EVT_REFLECTION_EVIDENCE_UPDATED.
+
+        Called by the periodic archive sweep (`memory_server._periodic_archive_sweep_loop`).
+        Goes through `arecord_and_save` so the increment is audit-logged
+        and replayable — derived state but worth recording.
+
+        Returns the new `sub_zero_days` value if incremented, or None if
+        no increment happened (entry not found / protected / already
+        incremented today / score >= 0).
+        """
+        from memory.event_log import EVT_REFLECTION_EVIDENCE_UPDATED
+        from memory.evidence import maybe_mark_sub_zero
+        if self._event_log is None:
+            raise RuntimeError(
+                "[Reflection.aincrement_sub_zero] event_log 未注入"
+            )
+
+        async with self._get_alock(lanlan_name):
+            reflections_full = await self._aload_reflections_full(lanlan_name)
+            entry = self._find_reflection_in_list(reflections_full, reflection_id)
+            if entry is None:
+                return None
+            # `maybe_mark_sub_zero` mutates `entry` in place and returns
+            # True iff the counter advanced. We then snapshot the new
+            # value into an EVIDENCE_UPDATED event so reconcile replay
+            # produces the same view.
+            if not maybe_mark_sub_zero(entry, now):
+                return None
+
+            new_count = int(entry.get('sub_zero_days', 0) or 0)
+            new_date = entry.get('sub_zero_last_increment_date')
+
+            payload = {
+                'reflection_id': reflection_id,
+                'reinforcement': float(entry.get('reinforcement', 0.0) or 0.0),
+                'disputation': float(entry.get('disputation', 0.0) or 0.0),
+                'rein_last_signal_at': entry.get('rein_last_signal_at'),
+                'disp_last_signal_at': entry.get('disp_last_signal_at'),
+                'sub_zero_days': new_count,
+                'sub_zero_last_increment_date': new_date,
+                'user_fact_reinforce_count': int(
+                    entry.get('user_fact_reinforce_count', 0) or 0,
+                ),
+                'source': 'archive_sweep',
+            }
+
+            def _sync_load(_n: str):
+                return reflections_full
+
+            def _sync_mutate(_view):
+                # entry is a reference into reflections_full; the in-place
+                # bump from maybe_mark_sub_zero already persisted into
+                # _view, but we still re-write the two fields explicitly
+                # here so the contract "_sync_mutate applies the snapshot"
+                # holds even if a caller bypasses the helper later.
+                entry['sub_zero_days'] = new_count
+                entry['sub_zero_last_increment_date'] = new_date
+
+            def _sync_save(n: str, view):
+                assert_cloudsave_writable(
+                    self._config_manager,
+                    operation="save",
+                    target=f"memory/{n}/reflections.json",
+                )
+                atomic_write_json(
+                    self._reflections_path(n), view, indent=2, ensure_ascii=False,
+                )
+
+            await self._event_log.arecord_and_save(
+                lanlan_name, EVT_REFLECTION_EVIDENCE_UPDATED, payload,
+                sync_load_view=_sync_load,
+                sync_mutate_view=_sync_mutate,
+                sync_save_view=_sync_save,
+            )
+            return new_count
+
+    async def aarchive_reflection(self, lanlan_name: str, reflection_id: str) -> bool:
+        """Move one reflection from main view to a sharded archive file.
+
+        RFC §3.5.6: archive 复用 ``EVT_REFLECTION_STATE_CHANGED`` 事件
+        (no new event types). Payload carries `from`/`to`/`archive_shard_path`
+        so the reconciler can replay the full transition.
+
+        Flow:
+          1. Pre-write the entry into a shard (with `archived_at` +
+             `archive_shard_path` stamps) — this is OUTSIDE the event
+             log. If the sweep crashes here, the entry stays in main and
+             the next sweep re-tries; the duplicated shard entry is
+             tolerable per RFC §3.11.
+          2. Inside record_and_save: remove the entry from main view,
+             persist event + view + sentinel atomically.
+
+        Returns True if archived; False if `reflection_id` not found or
+        the entry is `protected`.
+        """
+        from memory.archive_shards import aappend_to_shard
+        from memory.event_log import EVT_REFLECTION_STATE_CHANGED
+        if self._event_log is None:
+            raise RuntimeError(
+                "[Reflection.aarchive_reflection] event_log 未注入；"
+                "ReflectionEngine() 构造时须传入 event_log"
+            )
+
+        async with self._get_alock(lanlan_name):
+            reflections_full = await self._aload_reflections_full(lanlan_name)
+            entry = self._find_reflection_in_list(reflections_full, reflection_id)
+            if entry is None:
+                logger.warning(
+                    f"[Reflection] {lanlan_name}: aarchive_reflection 找不到 "
+                    f"reflection_id={reflection_id}"
+                )
+                return False
+            if entry.get('protected'):
+                logger.debug(
+                    f"[Reflection] {lanlan_name}: aarchive_reflection 跳过 protected "
+                    f"reflection_id={reflection_id}"
+                )
+                return False
+
+            prev_status = entry.get('status', 'pending')
+            now = datetime.now()
+            now_iso = now.isoformat()
+
+            # Predict shard path BEFORE writing so we can stamp the
+            # entry's own `archive_shard_path` field to match its on-disk
+            # location. We deep-copy the entry so the in-memory original
+            # remains untouched until the event log gates the mutation;
+            # otherwise a crash between shard-write and event-append
+            # would leave `archived_at` on a still-active entry.
+            from memory.archive_shards import apick_today_shard_path
+            archive_dir = self._reflections_archive_dir(lanlan_name)
+            shard_path = await apick_today_shard_path(archive_dir, now=now)
+            shard_basename = os.path.basename(shard_path)
+            archive_entry = dict(entry)
+            archive_entry['archived_at'] = now_iso
+            archive_entry['status'] = 'archived'
+            archive_entry['archive_shard_path'] = shard_basename
+            await aappend_to_shard(archive_dir, [archive_entry], now=now)
+
+            payload = {
+                'reflection_id': reflection_id,
+                'from': prev_status,
+                'to': 'archived',
+                'archive_shard_path': shard_basename,
+                'archived_at': now_iso,
+            }
+
+            def _sync_load(_n: str):
+                return reflections_full
+
+            def _sync_mutate(view):
+                # Drop the archived entry from active list (in-place
+                # mutate, since `view` IS `reflections_full`).
+                view[:] = [r for r in view if r.get('id') != reflection_id]
+
+            def _sync_save(n: str, view):
+                assert_cloudsave_writable(
+                    self._config_manager,
+                    operation="save",
+                    target=f"memory/{n}/reflections.json",
+                )
+                atomic_write_json(
+                    self._reflections_path(n), view, indent=2, ensure_ascii=False,
+                )
+
+            await self._event_log.arecord_and_save(
+                lanlan_name, EVT_REFLECTION_STATE_CHANGED, payload,
+                sync_load_view=_sync_load,
+                sync_mutate_view=_sync_mutate,
+                sync_save_view=_sync_save,
+            )
+            logger.info(
+                f"[Reflection] {lanlan_name}: 归档 reflection {reflection_id} "
+                f"(score-driven, prev_status={prev_status}) → {shard_basename}"
+            )
+            return True
+
+    async def aone_shot_archive_migration(self, lanlan_name: str) -> bool:
+        """Migrate legacy flat ``reflections_archive.json`` → sharded dir.
+
+        RFC §3.5.5: idempotent one-shot, runs at startup. Returns True if
+        a migration actually happened, False if it was a no-op (file
+        absent or sentinel already present).
+
+        Failure logs but does NOT raise — boot must not stall on archive
+        migration. Worst case: the flat file stays in place and the next
+        boot re-tries.
+        """
+        from memory.archive_shards import amigrate_flat_archive_to_shards
+        flat_path = self._reflections_legacy_archive_path(lanlan_name)
+        archive_dir = self._reflections_archive_dir(lanlan_name)
+        try:
+            migrated, n_entries, n_shards = await amigrate_flat_archive_to_shards(
+                flat_path, archive_dir,
+            )
+        except Exception as e:
+            logger.warning(
+                f"[Reflection] {lanlan_name}: 旧 reflections_archive 迁移失败 "
+                f"(保留原文件 fallback): {e}"
+            )
+            return False
+        if migrated:
+            logger.info(
+                f"[Reflection] {lanlan_name}: 旧 reflections_archive 迁移完成 "
+                f"({n_entries} 条 → {n_shards} 分片)"
+            )
+        return migrated
 
     async def _aload_reflections_full(self, name: str) -> list[dict]:
         """Like aload_reflections(include_archived=True) but also keeps

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -720,15 +720,17 @@ class ReflectionEngine:
             entry = self._find_reflection_in_list(reflections_full, reflection_id)
             if entry is None:
                 return None
-            # `maybe_mark_sub_zero` mutates `entry` in place and returns
-            # True iff the counter advanced. We then snapshot the new
-            # value into an EVIDENCE_UPDATED event so reconcile replay
-            # produces the same view.
-            if not maybe_mark_sub_zero(entry, now):
+            # Coderabbit PR #934 round-2 Major #2: probe on a staged copy
+            # so the in-memory list is NOT mutated until inside the
+            # locked record_and_save critical section. If the event
+            # append or save raises, the live entry stays clean (no
+            # orphan sub_zero_days increment lacking an audit-log row).
+            staged_entry = dict(entry)
+            if not maybe_mark_sub_zero(staged_entry, now):
                 return None
 
-            new_count = int(entry.get('sub_zero_days', 0) or 0)
-            new_date = entry.get('sub_zero_last_increment_date')
+            new_count = int(staged_entry.get('sub_zero_days', 0) or 0)
+            new_date = staged_entry.get('sub_zero_last_increment_date')
 
             payload = {
                 'reflection_id': reflection_id,
@@ -748,11 +750,10 @@ class ReflectionEngine:
                 return reflections_full
 
             def _sync_mutate(_view):
-                # entry is a reference into reflections_full; the in-place
-                # bump from maybe_mark_sub_zero already persisted into
-                # _view, but we still re-write the two fields explicitly
-                # here so the contract "_sync_mutate applies the snapshot"
-                # holds even if a caller bypasses the helper later.
+                # Apply staged values to the cached entry only after
+                # event append succeeded (record_and_save orders
+                # append → mutate → save, so a failure earlier never
+                # reaches this callback).
                 entry['sub_zero_days'] = new_count
                 entry['sub_zero_last_increment_date'] = new_date
 
@@ -781,14 +782,18 @@ class ReflectionEngine:
         (no new event types). Payload carries `from`/`to`/`archive_shard_path`
         so the reconciler can replay the full transition.
 
-        Flow:
-          1. Pre-write the entry into a shard (with `archived_at` +
-             `archive_shard_path` stamps) — this is OUTSIDE the event
-             log. If the sweep crashes here, the entry stays in main and
-             the next sweep re-tries; the duplicated shard entry is
-             tolerable per RFC §3.11.
-          2. Inside record_and_save: remove the entry from main view,
-             persist event + view + sentinel atomically.
+        Flow (coderabbit PR #934 round-1 + round-2):
+          1. Pre-pick the shard path (deterministic basename for the
+             event payload).
+          2. record_and_save — atomically removes the entry from the
+             active view + appends the state_changed event whose
+             payload carries `entry_snapshot` so a crash later is
+             recoverable.
+          3. aappend_to_shard — writes the snapshot into the shard
+             file. If this raises, the next reconciler boot's archive
+             handler self-heals by recreating the shard from
+             `entry_snapshot` (idempotent, see
+             `make_reflection_archive_handler`).
 
         Returns True if archived; False if `reflection_id` not found or
         the entry is `protected`.
@@ -842,10 +847,12 @@ class ReflectionEngine:
                 'to': 'archived',
                 'archive_shard_path': shard_basename,
                 'archived_at': now_iso,
-                # Symmetry with aarchive_persona_entry — full entry
-                # snapshot lets a future reconciler rewrite the shard if
-                # a crash occurs between record_and_save and the shard
-                # append below.
+                # Symmetry with aarchive_persona_entry — the reflection
+                # archive handler in evidence_handlers.py reads this on
+                # every replay and idempotently recreates the shard if
+                # it's missing (coderabbit PR #934 round-2 Major #3).
+                # Crash between record_and_save and the shard append
+                # below is healed on the next reconciler boot.
                 'entry_snapshot': archive_entry,
             }
 
@@ -867,12 +874,20 @@ class ReflectionEngine:
                     self._reflections_path(n), view, indent=2, ensure_ascii=False,
                 )
 
-            # ORDER (coderabbit review #934, mirroring persona fix):
-            # record_and_save first (commits event + view mutation),
-            # THEN append to shard. Avoids the "shard duplicate +
-            # still-active entry" race where a crash between shard write
-            # and view save would let the next sweep re-archive the same
-            # entry into a second shard slot.
+            # ORDER (coderabbit review #934 round-1 + round-2):
+            # 1. record_and_save first (commits event + active-view
+            #    removal atomically). Avoids the "shard duplicate +
+            #    still-active entry" race where a crash between shard
+            #    write and view save would let the next sweep
+            #    re-archive into a second shard slot.
+            # 2. aappend_to_shard second. If THIS step crashes (or
+            #    raises), the active view has already lost the entry
+            #    but the shard never got it. Self-heal: the
+            #    state_changed handler in evidence_handlers.py reads
+            #    `entry_snapshot` from the payload and re-creates the
+            #    shard on the next reconciler boot — the event log is
+            #    the source of truth (RFC §3.11) and the snapshot
+            #    keeps the data recoverable.
             await self._event_log.arecord_and_save(
                 lanlan_name, EVT_REFLECTION_STATE_CHANGED, payload,
                 sync_load_view=_sync_load,

--- a/memory_server.py
+++ b/memory_server.py
@@ -26,6 +26,8 @@ import uvicorn
 from utils.llm_client import convert_to_messages
 from uuid import uuid4
 from config import (
+    EVIDENCE_ARCHIVE_DAYS,
+    EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS,
     EVIDENCE_NEGATIVE_TARGET_MODEL_TIER,
     EVIDENCE_SIGNAL_CHECK_ENABLED,
     EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
@@ -979,6 +981,163 @@ async def _aone_shot_migration_if_needed(lanlan_name: str) -> None:
     )
 
 
+# ── memory-evidence-rfc §3.5.5: one-shot archive migration ──────────
+
+
+async def _aone_shot_archive_migration_if_needed(lanlan_name: str) -> None:
+    """Migrate legacy flat ``reflections_archive.json`` → sharded directory.
+
+    Idempotent: a sentinel file inside the new dir guards re-runs.
+    Persona had no flat archive predecessor, so only reflection needs
+    migration here.
+    """
+    try:
+        await reflection_engine.aone_shot_archive_migration(lanlan_name)
+    except Exception as e:
+        # NEVER let archive migration block boot — RFC §3.5.5 explicitly
+        # allows the legacy file to remain as fallback if migration fails.
+        logger.warning(
+            f"[Migration] {lanlan_name}: 旧 reflections_archive 分片迁移失败 (非致命): {e}"
+        )
+
+
+# ── memory-evidence-rfc §3.5: periodic archive sweep ────────────────
+
+
+async def _periodic_archive_sweep_loop():
+    """Periodically scan all non-protected reflection / persona entries
+    and (a) bump `sub_zero_days` for those with `evidence_score < 0`
+    today, (b) move entries with `sub_zero_days >= EVIDENCE_ARCHIVE_DAYS`
+    into a sharded archive file.
+
+    Runs every `EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS`. The
+    `maybe_mark_sub_zero` helper has its own day-based debounce so a
+    sub-day cadence does not over-count (RFC §3.5.3).
+
+    Per-character iteration is parallel (`asyncio.gather`) — each
+    character has independent files + locks; one slow char must not
+    block another.
+    """
+    from memory.evidence import maybe_mark_sub_zero
+    while True:
+        await asyncio.sleep(EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS)
+        try:
+            character_data = await _config_manager.aload_characters()
+            catgirl_names = list(character_data.get('猫娘', {}).keys())
+        except Exception as e:
+            logger.debug(f"[ArchiveSweep] 加载角色列表失败: {e}")
+            continue
+
+        now = datetime.now()
+
+        async def _sweep_one(name: str):
+            """Scan one character's reflections + persona entries.
+
+            For each non-protected entry:
+              1. Snapshot-test `maybe_mark_sub_zero` (mutates a COPY so
+                 we don't dirty the cache; the real increment + event
+                 happen inside `aincrement_sub_zero` under the per-char
+                 lock).
+              2. Call `aincrement_sub_zero` if needed → returns the new
+                 count or None (no-op).
+              3. Determine the effective `sub_zero_days` for the archive
+                 check:
+                    - If we just incremented → use the returned count
+                    - Else → use the on-disk count from step 1's read
+                 Same-tick archival saves an extra sweep cycle for
+                 entries that were already at threshold but missed the
+                 last increment due to debounce.
+              4. If `effective_sz >= EVIDENCE_ARCHIVE_DAYS` → archive.
+
+            All three operations (increment / archive / their event
+            writes) re-read the view under the per-char lock, so this
+            outer scan can use a stale snapshot safely.
+            """
+            try:
+                # ── reflections ──
+                refls = await reflection_engine._aload_reflections_full(name)
+                for r in refls:
+                    if not isinstance(r, dict):
+                        continue
+                    if r.get('protected'):
+                        continue
+                    rid = r.get('id')
+                    if not rid:
+                        continue
+                    pre_sz = int(r.get('sub_zero_days', 0) or 0)
+                    will_increment = maybe_mark_sub_zero(dict(r), now)
+                    new_count: int | None = None
+                    if will_increment:
+                        try:
+                            new_count = await reflection_engine.aincrement_sub_zero(
+                                name, rid, now,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"[ArchiveSweep] {name}: reflection {rid} "
+                                f"sub_zero 增量失败: {e}"
+                            )
+                    effective_sz = new_count if new_count is not None else pre_sz
+                    if effective_sz >= EVIDENCE_ARCHIVE_DAYS:
+                        try:
+                            await reflection_engine.aarchive_reflection(name, rid)
+                        except Exception as e:
+                            logger.warning(
+                                f"[ArchiveSweep] {name}: reflection {rid} 归档失败: {e}"
+                            )
+
+                # ── persona entries ──
+                persona = await persona_manager.aensure_persona(name)
+                # Snapshot (entity_key, entry_id, pre_sz) tuples; mutations
+                # go through aincrement / aarchive which re-load.
+                snapshots: list[tuple[str, str, int, bool]] = []
+                for entity_key, section in list(persona.items()):
+                    if not isinstance(section, dict):
+                        continue
+                    for entry in section.get('facts', []):
+                        if not isinstance(entry, dict):
+                            continue
+                        if entry.get('protected'):
+                            continue
+                        eid = entry.get('id')
+                        if not eid:
+                            continue
+                        pre_sz = int(entry.get('sub_zero_days', 0) or 0)
+                        will_inc = maybe_mark_sub_zero(dict(entry), now)
+                        snapshots.append((entity_key, eid, pre_sz, will_inc))
+
+                for entity_key, eid, pre_sz, will_inc in snapshots:
+                    new_count = None
+                    if will_inc:
+                        try:
+                            new_count = await persona_manager.aincrement_sub_zero(
+                                name, entity_key, eid, now,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"[ArchiveSweep] {name}: persona {entity_key}/{eid} "
+                                f"sub_zero 增量失败: {e}"
+                            )
+                    effective_sz = new_count if new_count is not None else pre_sz
+                    if effective_sz >= EVIDENCE_ARCHIVE_DAYS:
+                        try:
+                            await persona_manager.aarchive_persona_entry(
+                                name, entity_key, eid,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"[ArchiveSweep] {name}: persona {entity_key}/{eid} 归档失败: {e}"
+                            )
+            except Exception as e:
+                logger.debug(f"[ArchiveSweep] {name}: 扫描失败，跳过: {e}")
+
+        if catgirl_names:
+            await asyncio.gather(
+                *(_sweep_one(name) for name in catgirl_names),
+                return_exceptions=True,
+            )
+
+
 # ── memory-evidence-rfc §3.4.3: background signal extraction loop ───
 
 _signal_check_state: dict[str, dict] = {}  # {name: {turns_since, last_check_ts}}
@@ -1407,11 +1566,17 @@ async def startup_event_handler():
     # memory-evidence-rfc §5: 一次性迁移种子 —— 给旧 reflection / persona 补
     # 上 evidence 字段，失败静默（不阻塞 startup）。各角色 marker 独立、
     # 互不依赖，并行。
+    # PR-2 加：同步触发 §3.5.5 的旧 flat reflections_archive.json → 分片
+    # 目录迁移。两个 migration 都自带 idempotent guard，无依赖关系。
     async def _migrate_one(n: str):
         try:
             await _aone_shot_migration_if_needed(n)
         except Exception as e:
             logger.warning(f"[Memory] {n} evidence 迁移失败: {e}")
+        try:
+            await _aone_shot_archive_migration_if_needed(n)
+        except Exception as e:
+            logger.warning(f"[Memory] {n} archive 迁移失败: {e}")
 
     if catgirl_names:
         await asyncio.gather(
@@ -1429,6 +1594,10 @@ async def startup_event_handler():
     # memory-evidence-rfc §3.4.3: 信号抽取后台循环（Stage-1 + Stage-2 + dispatch）
     if EVIDENCE_SIGNAL_CHECK_ENABLED:
         _spawn_background_task(_periodic_signal_extraction_loop())
+
+    # memory-evidence-rfc §3.5: archive 扫描后台循环（sub_zero_days
+    # 增量 + 满阈值归档），独立于 evidence signal 抽取。
+    _spawn_background_task(_periodic_archive_sweep_loop())
 
 
 @app.on_event("shutdown")

--- a/tests/integration/test_archive_sweep.py
+++ b/tests/integration/test_archive_sweep.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""
+Integration test for the archive sweep loop (RFC §3.5 / PR-2).
+
+Boots a real `MemoryServer` fixture (event_log + reflection_engine +
+persona_manager + reconciler wired together — same as production
+startup), populates a reflection with a strongly negative evidence
+score, drives the sub_zero counter to threshold via repeated
+`aincrement_sub_zero` calls (one per simulated day), then verifies
+`aarchive_reflection` lands the entry into a sharded archive file and
+removes it from the active view.
+
+This is the per-loop body of `_periodic_archive_sweep_loop` exercised
+end-to-end without the asyncio.sleep / character-loader / multi-char
+gather wrapper. The wrapper itself is exercised by direct unit tests
+in `test_evidence_archive.py`; this file's value is asserting the full
+view+event+shard+reconcile chain holds across the production wiring
+path (catches "I forgot to register the handler" type regressions).
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config import EVIDENCE_ARCHIVE_DAYS
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    return cm
+
+
+def _boot_real_stack(tmpdir: str):
+    """Mirror `memory_server.startup_event_handler` step 3 (component
+    instantiation) without bringing FastAPI into the picture. Returns
+    the same tuple of (event_log, fact_store, persona_manager,
+    reflection_engine, reconciler, config_manager) that production
+    holds in module-globals."""
+    from memory.event_log import EventLog, Reconciler
+    from memory.evidence_handlers import register_evidence_handlers
+    from memory.facts import FactStore
+    from memory.persona import PersonaManager
+    from memory.reflection import ReflectionEngine
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.facts.get_config_manager", return_value=cm), \
+         patch("memory.persona.get_config_manager", return_value=cm), \
+         patch("memory.reflection.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        fs = FactStore()
+        fs._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+        re = ReflectionEngine(fs, pm, event_log=event_log)
+        re._config_manager = cm
+        rec = Reconciler(event_log)
+        register_evidence_handlers(rec, pm, re)
+    return event_log, fs, pm, re, rec, cm
+
+
+async def test_full_sweep_cycle_archives_negative_reflection(tmp_path):
+    """End-to-end: confirmed reflection with strongly negative evidence
+    → daily ticks for EVIDENCE_ARCHIVE_DAYS → archive shard appears,
+    active view loses the entry, event log carries replay-stable events.
+    """
+    ev, _fs, pm, re, rec, _cm = _boot_real_stack(str(tmp_path))
+    rid = "ref_integration_arch"
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    seed = [{
+        "id": rid, "text": "整合测试", "entity": "master",
+        "status": "confirmed", "source_fact_ids": [],
+        "created_at": base.isoformat(),
+        "feedback": None, "next_eligible_at": base.isoformat(),
+        "reinforcement": 0.0,
+        "disputation": 5.0,
+        "rein_last_signal_at": None,
+        "disp_last_signal_at": base.isoformat(),
+        "sub_zero_days": 0,
+        "sub_zero_last_increment_date": None,
+    }]
+    await re.asave_reflections("小天", seed)
+
+    # Day-by-day increment (same per-day cadence as the periodic sweep)
+    counts: list[int] = []
+    for d in range(EVIDENCE_ARCHIVE_DAYS):
+        # Refresh disp_last_signal_at to keep the score reading negative
+        # under read-time decay — without this, after ~180 days the disp
+        # would drop below rein and the entry would stop registering as
+        # sub-zero. For EVIDENCE_ARCHIVE_DAYS=14 we are well within one
+        # disp half-life (180d) so it's a no-op here, but explicit beats
+        # accidental coupling to half-life value (RFC §6.5 Gate 1
+        # placeholder).
+        c = await re.aincrement_sub_zero("小天", rid, base + timedelta(days=d))
+        counts.append(c)
+    assert counts == list(range(1, EVIDENCE_ARCHIVE_DAYS + 1)), (
+        f"expected monotonic 1..{EVIDENCE_ARCHIVE_DAYS}, got {counts}"
+    )
+
+    # Now archive (sweep loop's archive branch)
+    archived_ok = await re.aarchive_reflection("小天", rid)
+    assert archived_ok is True
+
+    # Active view: gone
+    active = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in active), (
+        f"expected {rid} removed, found in {[r.get('id') for r in active]}"
+    )
+
+    # Shard file: contains the entry with archived_at + path metadata
+    archive_dir = re._reflections_archive_dir("小天")
+    assert os.path.isdir(archive_dir)
+    shard_files = sorted(
+        f for f in os.listdir(archive_dir) if f.endswith(".json")
+    )
+    assert len(shard_files) >= 1
+    found = None
+    for fn in shard_files:
+        with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+            data = json.load(f)
+        for entry in data:
+            if entry.get("id") == rid:
+                found = (fn, entry)
+                break
+        if found:
+            break
+    assert found is not None, f"{rid} not found in any shard"
+    fn, archived = found
+    assert archived["status"] == "archived"
+    assert archived["archived_at"]
+    assert archived["archive_shard_path"] == fn
+
+    # Reconciler replay: starting from sentinel=None and re-applying every
+    # event must NOT reintroduce the archived entry. This catches a
+    # missing-handler regression where the reconciler would pause on
+    # state_changed and silently skip subsequent evidence updates.
+    # Reset the sentinel to None so we replay everything.
+    await ev.aadvance_sentinel("小天", None)
+    applied = await rec.areconcile("小天")
+    # The view is already in its final state (saved by record_and_save),
+    # so the handlers find it consistent → most return False (no change)
+    # but the loop completes and never throws / pauses.
+    assert applied >= 0
+    # Final state still has the entry archived
+    refls = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in refls)
+
+
+async def test_sweep_skips_protected_persona_entry(tmp_path):
+    """Protected persona entry: even with massive disputation and many
+    sub_zero ticks, archive sweep must not remove it (RFC §3.5.7)."""
+    _ev, _fs, pm, _re, _rec, _cm = _boot_real_stack(str(tmp_path))
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    persona = await pm.aensure_persona("小天")
+    persona.setdefault("master", {}).setdefault("facts", []).append({
+        "id": "card_protected_int", "text": "user is 主人",
+        "source": "character_card", "protected": True,
+        "reinforcement": 0.0, "disputation": 100.0,
+        "disp_last_signal_at": base.isoformat(),
+        "sub_zero_days": 0,
+    })
+    await pm.asave_persona("小天", persona)
+
+    # Try ticks for a week — every increment is a no-op because protected
+    for d in range(7):
+        result = await pm.aincrement_sub_zero(
+            "小天", "master", "card_protected_int", base + timedelta(days=d),
+        )
+        assert result is None
+
+    # And explicit archive call is also a no-op
+    archived = await pm.aarchive_persona_entry(
+        "小天", "master", "card_protected_int",
+    )
+    assert archived is False
+    persona = await pm.aensure_persona("小天")
+    facts = persona.get("master", {}).get("facts", [])
+    assert any(f.get("id") == "card_protected_int" for f in facts)

--- a/tests/unit/test_evidence_archive.py
+++ b/tests/unit/test_evidence_archive.py
@@ -30,8 +30,6 @@ import pytest
 from config import (
     ARCHIVE_FILE_MAX_ENTRIES,
     EVIDENCE_ARCHIVE_DAYS,
-    EVIDENCE_DISP_HALF_LIFE_DAYS,
-    EVIDENCE_REIN_HALF_LIFE_DAYS,
 )
 
 
@@ -79,23 +77,29 @@ def _install(tmpdir: str):
 # ── decay math snapshot (parametrized) ──────────────────────────────
 
 
-@pytest.mark.parametrize("age_days,value,half_life,expected", [
-    # Fresh signal — no decay
-    (0.0, 2.0, 30.0, 2.0),
-    # One half-life
-    (30.0, 2.0, 30.0, 1.0),
-    # Two half-lives
-    (60.0, 2.0, 30.0, 0.5),
-    # Disputation slower
-    (180.0, 2.0, 180.0, 1.0),
-    (90.0, 1.0, 180.0, 0.5 ** 0.5),  # ~0.707
+@pytest.mark.parametrize("func,age_days,value,half_life,expected", [
+    # Reinforcement — fresh signal, no decay
+    ("rein", 0.0, 2.0, 30.0, 2.0),
+    # Reinforcement — one half-life
+    ("rein", 30.0, 2.0, 30.0, 1.0),
+    # Reinforcement — two half-lives
+    ("rein", 60.0, 2.0, 30.0, 0.5),
+    # Disputation — one half-life (slower; default 180d)
+    ("disp", 180.0, 2.0, 180.0, 1.0),
+    # Disputation — half a half-life
+    ("disp", 90.0, 1.0, 180.0, 0.5 ** 0.5),  # ~0.707
 ])
-def test_effective_value_decay_snapshots(age_days, value, half_life, expected):
-    """Direct math: 0.5 ** (age/half_life) * value, tolerance 1e-6."""
+def test_effective_value_decay_snapshots(func, age_days, value, half_life, expected):
+    """Direct math: 0.5 ** (age/half_life) * value, tolerance 1e-6.
+
+    `func` ("rein" | "disp") explicitly dispatches to the right helper
+    so the test doesn't rely on numeric-equality probes against the
+    module constants (coderabbit nit, PR #934).
+    """
     fixed_now = datetime(2026, 4, 23, 12, 0, 0)
     past = fixed_now - timedelta(days=age_days)
 
-    if half_life == EVIDENCE_REIN_HALF_LIFE_DAYS or half_life == 30.0:
+    if func == "rein":
         from memory.evidence import effective_reinforcement
         # Patch the module constant to the test's chosen half_life
         with patch("memory.evidence.EVIDENCE_REIN_HALF_LIFE_DAYS", half_life):
@@ -227,6 +231,321 @@ async def test_shard_append_rolls_multiple_shards_for_huge_batch(tmp_path):
         with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
             total += len(json.load(f))
     assert total == n
+
+
+# ── shard selection by capacity (chatgpt-codex review #934) ─────────
+
+
+@pytest.mark.asyncio
+async def test_shard_picker_fills_earlier_same_day_shard_first(tmp_path):
+    """When today already has multiple shards and the lexically-LAST one
+    is full but an earlier one still has room, append must coalesce into
+    the earlier shard rather than rolling a brand-new third shard.
+
+    Regression for chatgpt-codex P1 (PR #934): the old `_pick_shard_path`
+    only checked `todays[-1]`, so a full lex-last + non-full lex-earlier
+    state caused unbounded shard proliferation."""
+    from memory.archive_shards import (
+        _list_shard_files,
+        _pick_shard_path_for_today,
+        aappend_to_shard,
+    )
+
+    archive_dir = str(tmp_path / "reflection_archive")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    today = fixed_now.date().isoformat()
+
+    # Manually craft two same-day shards: "earlier" (lex-smaller uuid8 = "0")
+    # holds a few entries with capacity left; "later" (lex-larger uuid8 = "f")
+    # is full. Real production filenames use random uuid8 — here we force the
+    # lex order so the test is deterministic.
+    os.makedirs(archive_dir, exist_ok=True)
+    earlier_fn = f"{today}_00000000.json"
+    later_fn = f"{today}_ffffffff.json"
+    earlier_entries = [{"id": f"early{i}", "text": "x"} for i in range(3)]
+    later_entries = [
+        {"id": f"late{i}", "text": "x"} for i in range(ARCHIVE_FILE_MAX_ENTRIES)
+    ]
+    with open(os.path.join(archive_dir, earlier_fn), "w", encoding="utf-8") as f:
+        json.dump(earlier_entries, f)
+    with open(os.path.join(archive_dir, later_fn), "w", encoding="utf-8") as f:
+        json.dump(later_entries, f)
+
+    # Direct picker check: must return the earlier (non-full) shard, not
+    # roll a fresh one and not return the full lex-last shard.
+    sizes = {earlier_fn: len(earlier_entries), later_fn: len(later_entries)}
+    picked = _pick_shard_path_for_today(archive_dir, today, sizes)
+    assert os.path.basename(picked) == earlier_fn, (
+        f"expected coalesce into {earlier_fn}, got {os.path.basename(picked)}"
+    )
+
+    # End-to-end: appending one entry should land in the earlier shard;
+    # total shard count stays at 2, no new file created.
+    new_entry = [{"id": "added", "text": "y"}]
+    await aappend_to_shard(archive_dir, new_entry, now=fixed_now)
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 2, (
+        f"expected exactly 2 shards (no proliferation), got "
+        f"{[s[0] for s in shards]}"
+    )
+    with open(os.path.join(archive_dir, earlier_fn), encoding="utf-8") as f:
+        earlier_data = json.load(f)
+    assert any(e.get("id") == "added" for e in earlier_data), (
+        "new entry should have landed in the earlier shard"
+    )
+    with open(os.path.join(archive_dir, later_fn), encoding="utf-8") as f:
+        later_data = json.load(f)
+    assert all(e.get("id") != "added" for e in later_data), (
+        "full lex-last shard must not have been touched"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shard_picker_rolls_new_shard_when_all_today_full(tmp_path):
+    """When every same-day shard is full, picker must mint a fresh
+    uuid8 shard (not return one of the full ones)."""
+    from memory.archive_shards import (
+        _list_shard_files,
+        aappend_to_shard,
+    )
+
+    archive_dir = str(tmp_path / "reflection_archive")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    today = fixed_now.date().isoformat()
+    os.makedirs(archive_dir, exist_ok=True)
+
+    # Two pre-existing same-day shards, both saturated.
+    full_a_fn = f"{today}_00000000.json"
+    full_b_fn = f"{today}_aaaaaaaa.json"
+    saturated = [{"id": f"x{i}"} for i in range(ARCHIVE_FILE_MAX_ENTRIES)]
+    for fn in (full_a_fn, full_b_fn):
+        with open(os.path.join(archive_dir, fn), "w", encoding="utf-8") as f:
+            json.dump(saturated, f)
+
+    await aappend_to_shard(archive_dir, [{"id": "spillover"}], now=fixed_now)
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 3, f"expected 3 shards, got {[s[0] for s in shards]}"
+    new_fn = next(
+        s[0] for s in shards if s[0] not in {full_a_fn, full_b_fn}
+    )
+    with open(os.path.join(archive_dir, new_fn), encoding="utf-8") as f:
+        assert json.load(f) == [{"id": "spillover"}]
+
+
+# ── stamper callback applies metadata pre-write (chatgpt-codex P2) ──
+
+
+@pytest.mark.asyncio
+async def test_aappend_to_shard_stamper_runs_before_write(tmp_path):
+    """The `stamper` callback must mutate each chunk BEFORE serialization
+    so the on-disk record carries the stamped fields. Regression for
+    chatgpt-codex P2 / coderabbit Major (PR #934)."""
+    from memory.archive_shards import aappend_to_shard
+
+    archive_dir = str(tmp_path / "ref_arc")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    entries = [{"id": f"r{i}", "text": "x"} for i in range(3)]
+
+    def _stamp(chunk, basename):
+        for e in chunk:
+            e["archived_at"] = fixed_now.isoformat()
+            e["archive_shard_path"] = basename
+
+    path = await aappend_to_shard(
+        archive_dir, list(entries), now=fixed_now, stamper=_stamp,
+    )
+    with open(path, encoding="utf-8") as f:
+        on_disk = json.load(f)
+    assert len(on_disk) == 3
+    for e in on_disk:
+        assert e["archived_at"] == fixed_now.isoformat()
+        assert e["archive_shard_path"] == os.path.basename(path)
+
+
+@pytest.mark.asyncio
+async def test_aappend_to_shard_stamper_uses_correct_path_per_chunk_on_overflow(
+    tmp_path,
+):
+    """When one batch overflows into multiple shards, each entry's
+    stamped `archive_shard_path` must match the SHARD IT WAS WRITTEN TO,
+    not just the last shard the call touched. Regression for chatgpt-
+    codex P2 (PR #934)."""
+    from memory.archive_shards import _list_shard_files, aappend_to_shard
+
+    archive_dir = str(tmp_path / "ref_arc")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    n = ARCHIVE_FILE_MAX_ENTRIES + 5
+    entries = [{"id": f"r{i}", "text": "x"} for i in range(n)]
+
+    def _stamp(chunk, basename):
+        for e in chunk:
+            e["archive_shard_path"] = basename
+
+    await aappend_to_shard(
+        archive_dir, list(entries), now=fixed_now, stamper=_stamp,
+    )
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 2
+    # Map every on-disk entry to the shard it lives in; verify the stamped
+    # field matches the actual filename (not the "last shard touched").
+    for fn, _, _ in shards:
+        with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+            data = json.load(f)
+        for e in data:
+            assert e["archive_shard_path"] == fn, (
+                f"entry {e.get('id')} stamped with "
+                f"{e['archive_shard_path']!r} but lives in {fn!r}"
+            )
+
+
+def test_append_to_shard_sync_stamper_uses_correct_path_per_chunk_on_overflow(
+    tmp_path,
+):
+    """Sync twin of the async overflow-stamper test — keeps the symmetry
+    invariant (CLAUDE.md "对偶性是硬性要求")."""
+    from memory.archive_shards import _list_shard_files, append_to_shard_sync
+
+    archive_dir = str(tmp_path / "ref_arc")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    n = ARCHIVE_FILE_MAX_ENTRIES + 3
+    entries = [{"id": f"r{i}", "text": "x"} for i in range(n)]
+
+    def _stamp(chunk, basename):
+        for e in chunk:
+            e["archive_shard_path"] = basename
+
+    append_to_shard_sync(
+        archive_dir, list(entries), now=fixed_now, stamper=_stamp,
+    )
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 2
+    for fn, _, _ in shards:
+        with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+            data = json.load(f)
+        for e in data:
+            assert e["archive_shard_path"] == fn
+
+
+@pytest.mark.asyncio
+async def test_age_based_archival_records_have_metadata_on_disk(tmp_path):
+    """End-to-end regression: after `asave_reflections` archives an aged
+    entry into a shard, the ON-DISK shard JSON must include both
+    `archived_at` and `archive_shard_path`. Previously these were only
+    set on the in-memory list AFTER the disk write, so the on-disk record
+    was missing them. Regression for chatgpt-codex P2 + coderabbit
+    Major (PR #934)."""
+    from memory.reflection import _REFLECTION_ARCHIVE_DAYS
+
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    cutoff = datetime.now() - timedelta(days=_REFLECTION_ARCHIVE_DAYS + 1)
+    old = {
+        "id": "ref_meta_old", "text": "x", "entity": "master",
+        "status": "promoted", "source_fact_ids": [],
+        "created_at": cutoff.isoformat(),
+        "promoted_at": cutoff.isoformat(),
+        "feedback": None, "next_eligible_at": cutoff.isoformat(),
+    }
+    refl_path = re._reflections_path("小天")
+    os.makedirs(os.path.dirname(refl_path), exist_ok=True)
+    with open(refl_path, "w", encoding="utf-8") as f:
+        json.dump([old], f)
+
+    await re.asave_reflections("小天", [])
+
+    archive_dir = re._reflections_archive_dir("小天")
+    shard_files = [f for f in os.listdir(archive_dir) if f.endswith(".json")]
+    assert len(shard_files) == 1
+    shard_fn = shard_files[0]
+    with open(os.path.join(archive_dir, shard_fn), encoding="utf-8") as f:
+        data = json.load(f)
+    archived = next(e for e in data if e.get("id") == "ref_meta_old")
+    assert archived.get("archived_at"), (
+        "on-disk record must have archived_at timestamp"
+    )
+    assert archived.get("archive_shard_path") == shard_fn, (
+        "on-disk record must have archive_shard_path matching its own filename"
+    )
+
+
+def test_age_based_archival_records_have_metadata_on_disk_sync(tmp_path):
+    """Sync twin — keeps symmetry between save_reflections /
+    asave_reflections (CLAUDE.md 对偶性)."""
+    from memory.reflection import _REFLECTION_ARCHIVE_DAYS
+
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    cutoff = datetime.now() - timedelta(days=_REFLECTION_ARCHIVE_DAYS + 1)
+    old = {
+        "id": "ref_meta_old_sync", "text": "x", "entity": "master",
+        "status": "denied", "source_fact_ids": [],
+        "created_at": cutoff.isoformat(),
+        "denied_at": cutoff.isoformat(),
+        "feedback": None, "next_eligible_at": cutoff.isoformat(),
+    }
+    refl_path = re._reflections_path("小天")
+    os.makedirs(os.path.dirname(refl_path), exist_ok=True)
+    with open(refl_path, "w", encoding="utf-8") as f:
+        json.dump([old], f)
+
+    re.save_reflections("小天", [])
+
+    archive_dir = re._reflections_archive_dir("小天")
+    shard_files = [f for f in os.listdir(archive_dir) if f.endswith(".json")]
+    assert len(shard_files) == 1
+    shard_fn = shard_files[0]
+    with open(os.path.join(archive_dir, shard_fn), encoding="utf-8") as f:
+        data = json.load(f)
+    archived = next(e for e in data if e.get("id") == "ref_meta_old_sync")
+    assert archived.get("archived_at")
+    assert archived.get("archive_shard_path") == shard_fn
+
+
+@pytest.mark.asyncio
+async def test_age_based_archival_overflow_each_chunk_has_correct_path(
+    tmp_path,
+):
+    """Archive a batch large enough to overflow into 2 shards; every
+    on-disk entry must carry the `archive_shard_path` of the shard it
+    actually lives in (NOT just the last shard touched). Regression for
+    chatgpt-codex P2 (PR #934)."""
+    from memory.reflection import _REFLECTION_ARCHIVE_DAYS
+
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    cutoff = datetime.now() - timedelta(days=_REFLECTION_ARCHIVE_DAYS + 1)
+    n = ARCHIVE_FILE_MAX_ENTRIES + 7
+    olds = [
+        {
+            "id": f"ref_overflow_{i}", "text": "x", "entity": "master",
+            "status": "promoted", "source_fact_ids": [],
+            "created_at": cutoff.isoformat(),
+            "promoted_at": cutoff.isoformat(),
+            "feedback": None, "next_eligible_at": cutoff.isoformat(),
+        }
+        for i in range(n)
+    ]
+    refl_path = re._reflections_path("小天")
+    os.makedirs(os.path.dirname(refl_path), exist_ok=True)
+    with open(refl_path, "w", encoding="utf-8") as f:
+        json.dump(olds, f)
+
+    await re.asave_reflections("小天", [])
+
+    archive_dir = re._reflections_archive_dir("小天")
+    shard_files = sorted(
+        f for f in os.listdir(archive_dir) if f.endswith(".json")
+    )
+    assert len(shard_files) == 2
+    total_seen = 0
+    for fn in shard_files:
+        with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+            data = json.load(f)
+        for e in data:
+            assert e.get("archive_shard_path") == fn, (
+                f"entry {e.get('id')} stamped {e.get('archive_shard_path')!r} "
+                f"but lives in {fn!r}"
+            )
+            assert e.get("archived_at")
+            total_seen += 1
+    assert total_seen == n
 
 
 # ── legacy flat-file migration ──────────────────────────────────────

--- a/tests/unit/test_evidence_archive.py
+++ b/tests/unit/test_evidence_archive.py
@@ -1197,3 +1197,212 @@ async def test_archive_handler_self_heals_missing_shard(tmp_path):
 
     # Idempotent replay
     assert p_handler("小天", p_archive_evt["payload"]) is False
+
+
+# ── PR #934 round-3 regressions ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_archive_handler_corrupt_shard_keeps_active_view(tmp_path):
+    """Round-3 Major: when the named target shard is corrupt, the
+    archive handler MUST NOT remove the entry from the active view.
+
+    Prior bug: ``ensure_entry_in_named_shard_sync`` returned False on
+    corruption (same as "already present"), the handler treated it as
+    "shard ok, skip", and proceeded to drop the entry from the active
+    view. If this replay was the very recovery from a "event committed
+    but shard never written" crash window, the entry would now be
+    gone from BOTH the view AND every shard — pure data loss.
+
+    Fix: the helper raises ``ShardCorruptError``; both reflection and
+    persona handlers catch it, log, leave the active view untouched,
+    and return False. Operator can repair the shard and the next
+    reconciler boot will retry.
+    """
+    from unittest.mock import patch
+    from memory.archive_shards import ShardCorruptError
+    from memory.event_log import (
+        EVT_PERSONA_FACT_ADDED,
+        EVT_REFLECTION_STATE_CHANGED,
+    )
+    from memory.evidence_handlers import (
+        make_persona_archive_handler,
+        make_reflection_archive_handler,
+    )
+
+    # ── reflection half ──────────────────────────────────────────────
+    _ev, _fs, pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_corrupt_target"
+    seed = [{
+        "id": rid, "text": "must-survive", "entity": "master",
+        "status": "confirmed", "source_fact_ids": [],
+        "created_at": "2026-04-22T10:00:00",
+        "feedback": None, "next_eligible_at": "2026-04-22T10:00:00",
+    }]
+    await re.asave_reflections("小天", seed)
+
+    # Crash between record_and_save and the shard append (round-2
+    # setup) — entry leaves the active view, shard never receives it.
+    async def _shard_boom(*a, **kw):
+        raise RuntimeError("simulated shard write failure")
+
+    with patch("memory.archive_shards.aappend_to_shard", _shard_boom):
+        with pytest.raises(RuntimeError, match="simulated shard write failure"):
+            await re.aarchive_reflection("小天", rid)
+
+    # Sanity: entry already removed from active view by record_and_save.
+    remaining = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in remaining)
+
+    # The archive handler reuses the active view as its "view to
+    # mutate" — but the round-3 invariant is about a DIFFERENT replay
+    # path: an entry the handler is about to drop from the view. To
+    # exercise the corrupt-shard-aborts-view-mutation contract we need
+    # an event whose `reflection_id` IS still in the view. Re-seed
+    # that scenario directly: place the entry back in the active view
+    # (simulating an operator recovery / snapshot restore that left
+    # the on-disk state inconsistent), then replay the archive event
+    # against a corrupt named shard.
+    re_seed = list(remaining) + [seed[0]]
+    await re.asave_reflections("小天", re_seed)
+    after_reseed = await re.aload_reflections("小天", include_archived=True)
+    assert any(r.get("id") == rid for r in after_reseed), (
+        "test setup: re-seeded entry must be back in active view"
+    )
+
+    # Plant a corrupt file at the exact basename the event references.
+    events = _ev.read_since("小天", None)
+    archive_evt = next(
+        e for e in events
+        if e["type"] == EVT_REFLECTION_STATE_CHANGED
+        and e["payload"].get("reflection_id") == rid
+    )
+    shard_basename = archive_evt["payload"]["archive_shard_path"]
+    archive_dir = re._reflections_archive_dir("小天")
+    os.makedirs(archive_dir, exist_ok=True)
+    corrupt_shard_path = os.path.join(archive_dir, shard_basename)
+    corrupt_payload = "{ broken json [["
+    with open(corrupt_shard_path, "w", encoding="utf-8") as f:
+        f.write(corrupt_payload)
+
+    # Replay → handler must abort (return False), NOT touch view.
+    handler = make_reflection_archive_handler(re)
+    changed = handler("小天", archive_evt["payload"])
+    assert changed is False, (
+        "handler must report no change when target shard is corrupt"
+    )
+
+    # Active view intact.
+    after_replay = await re.aload_reflections("小天", include_archived=True)
+    assert any(r.get("id") == rid for r in after_replay), (
+        "entry must remain in active view when shard is corrupt "
+        "(round-3 Major regression)"
+    )
+
+    # Corrupt shard untouched on disk.
+    with open(corrupt_shard_path, encoding="utf-8") as f:
+        assert f.read() == corrupt_payload, (
+            "corrupt shard must NOT be overwritten by self-heal"
+        )
+
+    # Direct check: helper raises ShardCorruptError (not returns False).
+    from memory.archive_shards import ensure_entry_in_named_shard_sync
+    snapshot = archive_evt["payload"]["entry_snapshot"]
+    with pytest.raises(ShardCorruptError):
+        ensure_entry_in_named_shard_sync(
+            archive_dir, shard_basename, snapshot,
+        )
+
+    # ── persona half (symmetric) ─────────────────────────────────────
+    persona = await pm.aensure_persona("小天")
+    persona.setdefault("master", {}).setdefault("facts", []).append({
+        "id": "p_corrupt_target", "text": "p-must-survive",
+        "source": "manual", "source_id": None,
+        "protected": False,
+    })
+    await pm.asave_persona("小天", persona)
+
+    with patch("memory.archive_shards.aappend_to_shard", _shard_boom):
+        with pytest.raises(RuntimeError, match="simulated shard write failure"):
+            await pm.aarchive_persona_entry("小天", "master", "p_corrupt_target")
+
+    # Re-seed the persona entry so the handler has something to drop.
+    persona = await pm.aensure_persona("小天")
+    persona.setdefault("master", {}).setdefault("facts", []).append({
+        "id": "p_corrupt_target", "text": "p-must-survive",
+        "source": "manual", "source_id": None,
+        "protected": False,
+    })
+    await pm.asave_persona("小天", persona)
+
+    p_events = _ev.read_since("小天", None)
+    p_archive_evt = next(
+        e for e in p_events
+        if e["type"] == EVT_PERSONA_FACT_ADDED
+        and e["payload"].get("entry_id") == "p_corrupt_target"
+    )
+    p_shard_basename = p_archive_evt["payload"]["archive_shard_path"]
+    p_archive_dir = pm._persona_archive_dir("小天")
+    os.makedirs(p_archive_dir, exist_ok=True)
+    p_corrupt_path = os.path.join(p_archive_dir, p_shard_basename)
+    with open(p_corrupt_path, "w", encoding="utf-8") as f:
+        f.write(corrupt_payload)
+
+    p_handler = make_persona_archive_handler(pm)
+    p_changed = p_handler("小天", p_archive_evt["payload"])
+    assert p_changed is False, (
+        "persona handler must report no change when target shard is corrupt"
+    )
+
+    persona_after = await pm.aensure_persona("小天")
+    facts_after = persona_after.get("master", {}).get("facts", [])
+    assert any(f.get("id") == "p_corrupt_target" for f in facts_after), (
+        "persona entry must remain in active view when shard is corrupt "
+        "(round-3 Major regression)"
+    )
+    with open(p_corrupt_path, encoding="utf-8") as f:
+        assert f.read() == corrupt_payload, (
+            "corrupt persona shard must NOT be overwritten"
+        )
+
+
+def test_archive_stamper_cross_day_retry_realigns_archived_at(tmp_path):
+    """Round-3 Minor: when shard write fails on day-1 and
+    save_reflections rolls the entries back into main, a day-2 retry
+    must restamp BOTH ``archived_at`` and ``archive_shard_path`` with
+    day-2's values. Earlier ``setdefault('archived_at', now_iso)`` left
+    yesterday's timestamp glued to a today's-shard basename — the two
+    fields disagreed on the date.
+
+    This test exercises ``_make_archive_stamper`` directly (the bug is
+    pure stamper semantics; mocking the full save retry across days
+    requires monkeypatching ``datetime.now`` inside both reflection.py
+    and archive_shards.py which is brittle).
+    """
+    from memory.reflection import ReflectionEngine
+
+    day1_iso = "2026-04-22T10:00:00"
+    day2_iso = "2026-04-23T10:00:00"
+    day1_basename = "2026-04-22_aaaa1111.json"
+    day2_basename = "2026-04-23_bbbb2222.json"
+
+    entry = {"id": "e1", "text": "x"}
+
+    # Day-1 stamp (would have been written but shard append "failed";
+    # entry rolled back into main with stamps attached).
+    stamper_day1 = ReflectionEngine._make_archive_stamper(day1_iso)
+    stamper_day1([entry], day1_basename)
+    assert entry["archived_at"] == day1_iso
+    assert entry["archive_shard_path"] == day1_basename
+
+    # Day-2 retry: a NEW stamper restamps the same dict object.
+    stamper_day2 = ReflectionEngine._make_archive_stamper(day2_iso)
+    stamper_day2([entry], day2_basename)
+    assert entry["archived_at"] == day2_iso, (
+        "archived_at must reflect day-2 retry (round-3 Minor regression: "
+        "setdefault stuck at day-1)"
+    )
+    assert entry["archive_shard_path"] == day2_basename
+    # Internal consistency: both fields agree on the date prefix.
+    assert entry["archived_at"].startswith("2026-04-23")
+    assert entry["archive_shard_path"].startswith("2026-04-23")

--- a/tests/unit/test_evidence_archive.py
+++ b/tests/unit/test_evidence_archive.py
@@ -1,0 +1,625 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for memory archive (PR-2 / RFC §3.5).
+
+Coverage:
+- Decay math snapshots (effective_reinforcement / effective_disputation
+  parametrized over age × value × half-life)
+- Sub-zero accumulation: never resets when score recovers (§3.5.3
+  "归档更积极")
+- protected=True exemption: never accumulates / never archives
+- Sharded append: > ARCHIVE_FILE_MAX_ENTRIES rolls a new shard
+- Legacy flat reflections_archive.json migration: per-day bucketing,
+  uuid8 suffix uniqueness, sentinel created, flat file deleted
+- aarchive_reflection: emits EVT_REFLECTION_STATE_CHANGED to=archived;
+  10 replays of the event leave the view consistent
+- aarchive_persona_entry: emits EVT_PERSONA_FACT_ADDED with
+  archive_shard_path; replay-stable
+- Sweep-loop sub_zero increment: drives a reflection's score below 0
+  for EVIDENCE_ARCHIVE_DAYS simulated days → archive happens
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config import (
+    ARCHIVE_FILE_MAX_ENTRIES,
+    EVIDENCE_ARCHIVE_DAYS,
+    EVIDENCE_DISP_HALF_LIFE_DAYS,
+    EVIDENCE_REIN_HALF_LIFE_DAYS,
+)
+
+
+# ── shared fixtures (mirroring tests/unit/test_evidence_apply_signal.py) ──
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    return cm
+
+
+def _install(tmpdir: str):
+    from memory.event_log import EventLog
+    from memory.evidence_handlers import register_evidence_handlers
+    from memory.facts import FactStore
+    from memory.event_log import Reconciler
+    from memory.persona import PersonaManager
+    from memory.reflection import ReflectionEngine
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.facts.get_config_manager", return_value=cm), \
+         patch("memory.persona.get_config_manager", return_value=cm), \
+         patch("memory.reflection.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        fs = FactStore()
+        fs._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+        re = ReflectionEngine(fs, pm, event_log=event_log)
+        re._config_manager = cm
+        rec = Reconciler(event_log)
+        register_evidence_handlers(rec, pm, re)
+    return event_log, fs, pm, re, rec, cm
+
+
+# ── decay math snapshot (parametrized) ──────────────────────────────
+
+
+@pytest.mark.parametrize("age_days,value,half_life,expected", [
+    # Fresh signal — no decay
+    (0.0, 2.0, 30.0, 2.0),
+    # One half-life
+    (30.0, 2.0, 30.0, 1.0),
+    # Two half-lives
+    (60.0, 2.0, 30.0, 0.5),
+    # Disputation slower
+    (180.0, 2.0, 180.0, 1.0),
+    (90.0, 1.0, 180.0, 0.5 ** 0.5),  # ~0.707
+])
+def test_effective_value_decay_snapshots(age_days, value, half_life, expected):
+    """Direct math: 0.5 ** (age/half_life) * value, tolerance 1e-6."""
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    past = fixed_now - timedelta(days=age_days)
+
+    if half_life == EVIDENCE_REIN_HALF_LIFE_DAYS or half_life == 30.0:
+        from memory.evidence import effective_reinforcement
+        # Patch the module constant to the test's chosen half_life
+        with patch("memory.evidence.EVIDENCE_REIN_HALF_LIFE_DAYS", half_life):
+            entry = {
+                "reinforcement": value,
+                "rein_last_signal_at": past.isoformat(),
+            }
+            actual = effective_reinforcement(entry, fixed_now)
+    else:
+        from memory.evidence import effective_disputation
+        with patch("memory.evidence.EVIDENCE_DISP_HALF_LIFE_DAYS", half_life):
+            entry = {
+                "disputation": value,
+                "disp_last_signal_at": past.isoformat(),
+            }
+            actual = effective_disputation(entry, fixed_now)
+    assert actual == pytest.approx(expected, abs=1e-6)
+
+
+# ── sub-zero accumulation semantics ─────────────────────────────────
+
+
+def test_sub_zero_persists_through_score_oscillation():
+    """RFC §3.5.3 "归档更积极": sub_zero_days never resets even when
+    score climbs back to >= 0. Exhaustively walks negative→positive→
+    negative to lock the invariant."""
+    from memory.evidence import maybe_mark_sub_zero
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    entry = {
+        "reinforcement": 0.0,
+        "disputation": 2.0,
+        "rein_last_signal_at": None,
+        "disp_last_signal_at": base.isoformat(),
+        "sub_zero_days": 0,
+        "sub_zero_last_increment_date": None,
+    }
+    # Day 0: score < 0 → +1
+    assert maybe_mark_sub_zero(entry, base) is True
+    assert entry["sub_zero_days"] == 1
+
+    # Day 1: still negative, still bumps
+    day1 = base + timedelta(days=1)
+    entry["disp_last_signal_at"] = day1.isoformat()
+    assert maybe_mark_sub_zero(entry, day1) is True
+    assert entry["sub_zero_days"] == 2
+
+    # Day 2: user reinforces → score positive — NO bump, NO reset
+    day2 = base + timedelta(days=2)
+    entry["reinforcement"] = 5.0
+    entry["rein_last_signal_at"] = day2.isoformat()
+    assert maybe_mark_sub_zero(entry, day2) is False
+    assert entry["sub_zero_days"] == 2  # preserved
+
+    # Day 3: another negative wave — bumps to 3 (resumes from 2, not 0)
+    day3 = base + timedelta(days=3)
+    entry["reinforcement"] = 0.0
+    entry["disputation"] = 5.0
+    entry["disp_last_signal_at"] = day3.isoformat()
+    assert maybe_mark_sub_zero(entry, day3) is True
+    assert entry["sub_zero_days"] == 3
+
+
+def test_sub_zero_protected_never_accumulates():
+    """RFC §3.5.7: protected=True is total exemption. Even with massive
+    disputation and aged-out reinforcement, sub_zero_days stays 0."""
+    from memory.evidence import maybe_mark_sub_zero
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    entry = {
+        "protected": True,
+        "reinforcement": 0.0,
+        "disputation": 100.0,
+        "disp_last_signal_at": base.isoformat(),
+        "sub_zero_days": 0,
+    }
+    for d in range(EVIDENCE_ARCHIVE_DAYS + 5):
+        assert maybe_mark_sub_zero(entry, base + timedelta(days=d)) is False
+    assert entry["sub_zero_days"] == 0
+
+
+# ── shard size cap ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shard_overflow_creates_new_file(tmp_path):
+    """Append > ARCHIVE_FILE_MAX_ENTRIES → second shard file appears."""
+    from memory.archive_shards import aappend_to_shard, _list_shard_files
+
+    archive_dir = str(tmp_path / "reflection_archive")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+
+    # Round 1: fill exactly to the cap → one shard
+    first_batch = [{"id": f"r{i}", "text": "x", "archived_at": fixed_now.isoformat()}
+                   for i in range(ARCHIVE_FILE_MAX_ENTRIES)]
+    path1 = await aappend_to_shard(archive_dir, first_batch, now=fixed_now)
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 1
+    assert os.path.basename(path1) == shards[0][0]
+    with open(path1, encoding="utf-8") as f:
+        assert len(json.load(f)) == ARCHIVE_FILE_MAX_ENTRIES
+
+    # Round 2: one more entry → must spill into a NEW shard
+    overflow_entry = [{"id": "rN", "text": "y", "archived_at": fixed_now.isoformat()}]
+    path2 = await aappend_to_shard(archive_dir, overflow_entry, now=fixed_now)
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 2, f"expected 2 shards, got {[s[0] for s in shards]}"
+    # uuid8 suffixes must differ
+    suffixes = [u for _, _, u in shards]
+    assert len(set(suffixes)) == 2, f"uuid8 collision: {suffixes}"
+    assert path2 != path1
+    with open(path2, encoding="utf-8") as f:
+        assert len(json.load(f)) == 1
+
+
+@pytest.mark.asyncio
+async def test_shard_append_rolls_multiple_shards_for_huge_batch(tmp_path):
+    """A single call with > ARCHIVE_FILE_MAX_ENTRIES entries spills
+    correctly across as many shards as needed (no truncation)."""
+    from memory.archive_shards import aappend_to_shard, _list_shard_files
+
+    archive_dir = str(tmp_path / "reflection_archive")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    n = ARCHIVE_FILE_MAX_ENTRIES * 2 + 7
+    batch = [{"id": f"r{i}", "text": "x"} for i in range(n)]
+    await aappend_to_shard(archive_dir, batch, now=fixed_now)
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 3
+    total = 0
+    for fn, _, _ in shards:
+        with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+            total += len(json.load(f))
+    assert total == n
+
+
+# ── legacy flat-file migration ──────────────────────────────────────
+
+
+def test_legacy_flat_archive_migration_buckets_by_date(tmp_path):
+    """Three different `archived_at` dates → three buckets, distinct
+    uuid8 suffixes, sentinel written, flat file deleted."""
+    from memory.archive_shards import (
+        MIGRATION_SENTINEL_FILENAME,
+        _list_shard_files,
+        migrate_flat_archive_to_shards_sync,
+    )
+
+    flat_path = str(tmp_path / "reflections_archive.json")
+    archive_dir = str(tmp_path / "reflection_archive")
+
+    entries = [
+        {"id": f"r{i}", "text": "old",
+         "archived_at": f"2026-04-{20 + (i % 3):02d}T10:00:00"}
+        for i in range(7)
+    ]
+    with open(flat_path, "w", encoding="utf-8") as f:
+        json.dump(entries, f)
+
+    migrated, n_entries, n_shards = migrate_flat_archive_to_shards_sync(
+        flat_path, archive_dir,
+    )
+    assert migrated is True
+    assert n_entries == 7
+    # 7 entries across 3 dates, well under MAX_ENTRIES → 3 shards
+    assert n_shards == 3
+
+    shards = _list_shard_files(archive_dir)
+    dates = sorted({d for _, d, _ in shards})
+    assert dates == ["2026-04-20", "2026-04-21", "2026-04-22"]
+    # uuid8 uniqueness across all shards
+    uuids = [u for _, _, u in shards]
+    assert len(set(uuids)) == len(uuids), f"uuid8 collision: {uuids}"
+
+    # Sentinel + flat-file deletion
+    assert os.path.exists(os.path.join(archive_dir, MIGRATION_SENTINEL_FILENAME))
+    assert not os.path.exists(flat_path)
+
+
+def test_legacy_flat_archive_migration_idempotent(tmp_path):
+    """Re-running after success is a no-op (sentinel guard)."""
+    from memory.archive_shards import migrate_flat_archive_to_shards_sync
+
+    flat_path = str(tmp_path / "reflections_archive.json")
+    archive_dir = str(tmp_path / "reflection_archive")
+    entries = [{"id": "r0", "text": "x", "archived_at": "2026-04-22T10:00:00"}]
+    with open(flat_path, "w", encoding="utf-8") as f:
+        json.dump(entries, f)
+
+    migrate_flat_archive_to_shards_sync(flat_path, archive_dir)
+    # Recreate the flat file (simulate operator confusion / partial restore);
+    # sentinel still guards us — no migration runs.
+    with open(flat_path, "w", encoding="utf-8") as f:
+        json.dump(entries, f)
+
+    migrated, _, _ = migrate_flat_archive_to_shards_sync(flat_path, archive_dir)
+    assert migrated is False
+
+
+def test_legacy_flat_archive_migration_no_flat_file_is_noop(tmp_path):
+    from memory.archive_shards import migrate_flat_archive_to_shards_sync
+
+    archive_dir = str(tmp_path / "reflection_archive")
+    flat_path = str(tmp_path / "reflections_archive.json")
+    migrated, n_entries, n_shards = migrate_flat_archive_to_shards_sync(
+        flat_path, archive_dir,
+    )
+    assert (migrated, n_entries, n_shards) == (False, 0, 0)
+
+
+def test_legacy_flat_archive_migration_overflow_still_splits(tmp_path):
+    """One date with > MAX_ENTRIES entries → split into multiple shards
+    sharing the same date prefix but distinct uuid8s."""
+    from memory.archive_shards import (
+        _list_shard_files,
+        migrate_flat_archive_to_shards_sync,
+    )
+
+    flat_path = str(tmp_path / "reflections_archive.json")
+    archive_dir = str(tmp_path / "reflection_archive")
+    n = ARCHIVE_FILE_MAX_ENTRIES + 50
+    entries = [
+        {"id": f"r{i}", "text": "x", "archived_at": "2026-04-22T10:00:00"}
+        for i in range(n)
+    ]
+    with open(flat_path, "w", encoding="utf-8") as f:
+        json.dump(entries, f)
+
+    migrated, n_entries, n_shards = migrate_flat_archive_to_shards_sync(
+        flat_path, archive_dir,
+    )
+    assert migrated is True and n_entries == n and n_shards == 2
+    shards = _list_shard_files(archive_dir)
+    dates = {d for _, d, _ in shards}
+    assert dates == {"2026-04-22"}
+    uuids = [u for _, _, u in shards]
+    assert len(set(uuids)) == 2
+
+
+# ── archive emits correct event + replay-stable ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aarchive_reflection_emits_state_changed_to_archived(tmp_path):
+    from memory.event_log import EVT_REFLECTION_STATE_CHANGED
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_arc"
+    seed = [{
+        "id": rid, "text": "test reflection", "entity": "master",
+        "status": "confirmed", "source_fact_ids": [],
+        "created_at": "2026-04-22T10:00:00",
+        "feedback": None, "next_eligible_at": "2026-04-22T10:00:00",
+    }]
+    await re.asave_reflections("小天", seed)
+
+    ok = await re.aarchive_reflection("小天", rid)
+    assert ok is True
+
+    # View: entry removed from main file
+    remaining = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in remaining)
+
+    # Shard exists with the entry + archived_at + archive_shard_path
+    archive_dir = re._reflections_archive_dir("小天")
+    shard_files = [f for f in os.listdir(archive_dir) if f.endswith(".json")]
+    assert len(shard_files) == 1
+    with open(os.path.join(archive_dir, shard_files[0]), encoding="utf-8") as f:
+        shard_data = json.load(f)
+    assert len(shard_data) == 1
+    archived = shard_data[0]
+    assert archived["id"] == rid
+    assert archived["status"] == "archived"
+    assert archived["archived_at"] is not None
+    assert archived["archive_shard_path"] == shard_files[0]
+
+    # Event log: exactly one state_changed event with to='archived'
+    events = _ev.read_since("小天", None)
+    state_evts = [e for e in events if e["type"] == EVT_REFLECTION_STATE_CHANGED]
+    assert len(state_evts) == 1
+    payload = state_evts[0]["payload"]
+    assert payload["reflection_id"] == rid
+    assert payload["from"] == "confirmed"
+    assert payload["to"] == "archived"
+    assert payload["archive_shard_path"] == shard_files[0]
+
+
+@pytest.mark.asyncio
+async def test_aarchive_reflection_protected_skipped(tmp_path):
+    """RFC §3.5.7: protected reflections never archive."""
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_protected"
+    seed = [{
+        "id": rid, "text": "x", "entity": "master", "status": "confirmed",
+        "source_fact_ids": [], "created_at": "2026-04-22T10:00:00",
+        "feedback": None, "next_eligible_at": "2026-04-22T10:00:00",
+        "protected": True,
+    }]
+    await re.asave_reflections("小天", seed)
+    ok = await re.aarchive_reflection("小天", rid)
+    assert ok is False
+    # Nothing written, nothing archived
+    remaining = await re.aload_reflections("小天", include_archived=True)
+    assert any(r.get("id") == rid for r in remaining)
+
+
+@pytest.mark.asyncio
+async def test_aarchive_reflection_replay_stable(tmp_path):
+    """Re-applying the state_changed handler 10 times leaves the view
+    consistent (entry stays out of active list, idempotent)."""
+    from memory.evidence_handlers import make_reflection_archive_handler
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_replay"
+    await re.asave_reflections("小天", [{
+        "id": rid, "text": "x", "entity": "master", "status": "confirmed",
+        "source_fact_ids": [], "created_at": "2026-04-22T10:00:00",
+        "feedback": None, "next_eligible_at": "2026-04-22T10:00:00",
+    }])
+    await re.aarchive_reflection("小天", rid)
+
+    handler = make_reflection_archive_handler(re)
+    payload = {"reflection_id": rid, "from": "confirmed", "to": "archived",
+               "archive_shard_path": "ignored"}
+    # First replay: no-op (already removed by aarchive_reflection's save).
+    # 10 replays must NOT re-introduce the entry.
+    for _ in range(10):
+        changed = handler("小天", payload)
+        assert changed is False
+    remaining = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in remaining)
+
+
+@pytest.mark.asyncio
+async def test_aarchive_persona_entry_emits_fact_added_with_shard_path(tmp_path):
+    from memory.event_log import EVT_PERSONA_FACT_ADDED
+    _ev, _fs, pm, _re, _rec, _cm = _install(str(tmp_path))
+
+    # Bootstrap a persona with one mutable entry under 'master'.
+    persona = await pm.aensure_persona("小天")
+    persona.setdefault("master", {}).setdefault("facts", []).append({
+        "id": "manual_test1", "text": "user likes cats",
+        "source": "manual", "source_id": None,
+        "protected": False,
+    })
+    await pm.asave_persona("小天", persona)
+
+    ok = await pm.aarchive_persona_entry("小天", "master", "manual_test1")
+    assert ok is True
+
+    # View: removed from facts
+    persona = await pm.aensure_persona("小天")
+    facts = persona.get("master", {}).get("facts", [])
+    assert all(f.get("id") != "manual_test1" for f in facts)
+
+    # Shard file with the entry
+    archive_dir = pm._persona_archive_dir("小天")
+    shard_files = [f for f in os.listdir(archive_dir) if f.endswith(".json")]
+    assert len(shard_files) == 1
+    with open(os.path.join(archive_dir, shard_files[0]), encoding="utf-8") as f:
+        shard_data = json.load(f)
+    assert any(e.get("id") == "manual_test1" for e in shard_data)
+    archived = next(e for e in shard_data if e.get("id") == "manual_test1")
+    assert archived["archived_at"] is not None
+    assert archived["archive_shard_path"] == shard_files[0]
+
+    # Event with archive_shard_path
+    events = _ev.read_since("小天", None)
+    pa_evts = [e for e in events if e["type"] == EVT_PERSONA_FACT_ADDED]
+    assert len(pa_evts) == 1
+    payload = pa_evts[0]["payload"]
+    assert payload["entity_key"] == "master"
+    assert payload["entry_id"] == "manual_test1"
+    assert payload["archive_shard_path"] == shard_files[0]
+    assert payload["archived_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_aarchive_persona_entry_protected_skipped(tmp_path):
+    _ev, _fs, pm, _re, _rec, _cm = _install(str(tmp_path))
+    persona = await pm.aensure_persona("小天")
+    persona.setdefault("master", {}).setdefault("facts", []).append({
+        "id": "card_protected", "text": "x",
+        "source": "character_card", "protected": True,
+    })
+    await pm.asave_persona("小天", persona)
+
+    ok = await pm.aarchive_persona_entry("小天", "master", "card_protected")
+    assert ok is False
+    persona = await pm.aensure_persona("小天")
+    assert any(
+        f.get("id") == "card_protected"
+        for f in persona.get("master", {}).get("facts", [])
+    )
+
+
+# ── sweep loop end-to-end ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sub_zero_increment_reaches_archive_threshold(tmp_path):
+    """Drive a reflection's score below 0 for EVIDENCE_ARCHIVE_DAYS
+    simulated days via aincrement_sub_zero, then verify aarchive_reflection
+    moves it. End-to-end stand-in for `_periodic_archive_sweep_loop`
+    minus the asyncio.sleep + per-character iteration boilerplate."""
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_sweep"
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    # Seed with disputation high enough to keep score < 0 indefinitely.
+    seed = [{
+        "id": rid, "text": "test", "entity": "master",
+        "status": "confirmed", "source_fact_ids": [],
+        "created_at": base.isoformat(),
+        "feedback": None, "next_eligible_at": base.isoformat(),
+        "reinforcement": 0.0,
+        "disputation": 5.0,
+        "rein_last_signal_at": None,
+        "disp_last_signal_at": base.isoformat(),
+        "sub_zero_days": 0,
+        "sub_zero_last_increment_date": None,
+    }]
+    await re.asave_reflections("小天", seed)
+
+    # Tick once per simulated day for EVIDENCE_ARCHIVE_DAYS days.
+    for d in range(EVIDENCE_ARCHIVE_DAYS):
+        result = await re.aincrement_sub_zero(
+            "小天", rid, base + timedelta(days=d),
+        )
+        assert result == d + 1, f"day {d}: expected count={d + 1}, got {result}"
+
+    # After EVIDENCE_ARCHIVE_DAYS increments → counter at threshold → archive.
+    refls = await re._aload_reflections_full("小天")
+    target = next(r for r in refls if r["id"] == rid)
+    assert target["sub_zero_days"] == EVIDENCE_ARCHIVE_DAYS
+
+    archived_ok = await re.aarchive_reflection("小天", rid)
+    assert archived_ok is True
+
+    # Active view no longer contains it
+    remaining = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in remaining)
+    # Shard contains it
+    archive_dir = re._reflections_archive_dir("小天")
+    shard_files = [f for f in os.listdir(archive_dir) if f.endswith(".json")]
+    found = False
+    for fn in shard_files:
+        with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+            data = json.load(f)
+        if any(e.get("id") == rid for e in data):
+            found = True
+            break
+    assert found
+
+
+@pytest.mark.asyncio
+async def test_aincrement_sub_zero_debounces_same_day(tmp_path):
+    """Calling aincrement_sub_zero twice on the same day → second call
+    returns None (debounce inside maybe_mark_sub_zero)."""
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_dbnc"
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    await re.asave_reflections("小天", [{
+        "id": rid, "text": "x", "entity": "master", "status": "confirmed",
+        "source_fact_ids": [], "created_at": base.isoformat(),
+        "feedback": None, "next_eligible_at": base.isoformat(),
+        "reinforcement": 0.0, "disputation": 5.0,
+        "disp_last_signal_at": base.isoformat(),
+    }])
+    first = await re.aincrement_sub_zero("小天", rid, base)
+    second = await re.aincrement_sub_zero("小天", rid, base)
+    assert first == 1
+    assert second is None
+
+
+@pytest.mark.asyncio
+async def test_aincrement_sub_zero_protected_returns_none(tmp_path):
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_prot_inc"
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    await re.asave_reflections("小天", [{
+        "id": rid, "text": "x", "entity": "master", "status": "confirmed",
+        "source_fact_ids": [], "created_at": base.isoformat(),
+        "feedback": None, "next_eligible_at": base.isoformat(),
+        "reinforcement": 0.0, "disputation": 100.0,
+        "disp_last_signal_at": base.isoformat(),
+        "protected": True,
+    }])
+    result = await re.aincrement_sub_zero("小天", rid, base)
+    assert result is None
+
+
+# ── integration with sharded save_reflections (age-based archival) ──
+
+
+@pytest.mark.asyncio
+async def test_age_based_archival_writes_to_shards_not_flat_file(tmp_path):
+    """Existing age-based archival path (promoted/denied >30d) now lands
+    in shards, not the legacy flat file. Verifies the refactor of
+    save_reflections / asave_reflections kept the behavior intact."""
+    from memory.reflection import _REFLECTION_ARCHIVE_DAYS
+
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+    cutoff = datetime.now() - timedelta(days=_REFLECTION_ARCHIVE_DAYS + 1)
+    # Seed an old promoted reflection on disk
+    old = {
+        "id": "ref_old", "text": "x", "entity": "master",
+        "status": "promoted", "source_fact_ids": [],
+        "created_at": cutoff.isoformat(),
+        "promoted_at": cutoff.isoformat(),
+        "feedback": None, "next_eligible_at": cutoff.isoformat(),
+    }
+    # Direct file write to simulate persisted history
+    refl_path = re._reflections_path("小天")
+    os.makedirs(os.path.dirname(refl_path), exist_ok=True)
+    with open(refl_path, "w", encoding="utf-8") as f:
+        json.dump([old], f)
+
+    # Save with empty active list → triggers age-based archival path
+    await re.asave_reflections("小天", [])
+
+    # Active view: empty
+    with open(refl_path, encoding="utf-8") as f:
+        assert json.load(f) == []
+    # Legacy flat file should NOT be created
+    assert not os.path.exists(re._reflections_legacy_archive_path("小天"))
+    # Sharded archive dir contains the entry
+    archive_dir = re._reflections_archive_dir("小天")
+    shard_files = [f for f in os.listdir(archive_dir) if f.endswith(".json")]
+    assert len(shard_files) == 1
+    with open(os.path.join(archive_dir, shard_files[0]), encoding="utf-8") as f:
+        data = json.load(f)
+    assert any(e.get("id") == "ref_old" for e in data)

--- a/tests/unit/test_evidence_archive.py
+++ b/tests/unit/test_evidence_archive.py
@@ -942,3 +942,258 @@ async def test_age_based_archival_writes_to_shards_not_flat_file(tmp_path):
     with open(os.path.join(archive_dir, shard_files[0]), encoding="utf-8") as f:
         data = json.load(f)
     assert any(e.get("id") == "ref_old" for e in data)
+
+
+# ── PR #934 round-2 regressions ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aappend_to_shard_corrupt_shard_left_untouched(tmp_path):
+    """Round-2 Major #1: a corrupt same-day shard must NOT be picked +
+    overwritten. Prior bug: `_aread_shard` returned [] on
+    JSONDecodeError → picker saw size=0 → reuse → atomic write replaced
+    the corrupt original, losing salvageable content.
+
+    Fix: `_aread_shard` raises `ShardCorruptError`; both probe + pick
+    paths catch it and treat the shard as full.
+    """
+    from memory.archive_shards import (
+        _list_shard_files,
+        aappend_to_shard,
+    )
+
+    archive_dir = str(tmp_path / "ref_arc")
+    fixed_now = datetime(2026, 4, 23, 12, 0, 0)
+    today = fixed_now.date().isoformat()
+    os.makedirs(archive_dir, exist_ok=True)
+
+    # Plant a non-JSON corrupt shard with today's date prefix.
+    corrupt_fn = f"{today}_dead0001.json"
+    corrupt_path = os.path.join(archive_dir, corrupt_fn)
+    corrupt_payload = "this is not JSON at all { unbalanced ["
+    with open(corrupt_path, "w", encoding="utf-8") as f:
+        f.write(corrupt_payload)
+
+    # Append a new entry → must NOT touch the corrupt file.
+    new_entry = [{"id": "fresh", "text": "y"}]
+    written_path = await aappend_to_shard(
+        archive_dir, new_entry, now=fixed_now,
+    )
+
+    # Corrupt file unchanged on disk
+    with open(corrupt_path, encoding="utf-8") as f:
+        assert f.read() == corrupt_payload, (
+            "corrupt shard must not have been overwritten"
+        )
+
+    # The new entry landed in a DIFFERENT shard
+    assert os.path.basename(written_path) != corrupt_fn
+    with open(written_path, encoding="utf-8") as f:
+        new_shard_data = json.load(f)
+    assert any(e.get("id") == "fresh" for e in new_shard_data)
+
+    # Now there are two shards: the corrupt one + the new one
+    shards = _list_shard_files(archive_dir)
+    assert len(shards) == 2
+    assert any(s[0] == corrupt_fn for s in shards)
+
+
+@pytest.mark.asyncio
+async def test_aincrement_sub_zero_keeps_cache_clean_on_save_failure(tmp_path):
+    """Round-2 Major #2: if `arecord_and_save` (or its inner
+    `assert_cloudsave_writable`) raises, the cached entry must NOT have
+    been mutated by `maybe_mark_sub_zero`. Prior bug mutated in-place
+    BEFORE record_and_save → orphan increment with no event log row.
+
+    Fix: probe on a staged copy; only the `_sync_mutate` callback
+    (which runs inside record_and_save AFTER append succeeds) touches
+    the live cache.
+    """
+    from memory.event_log import EVT_REFLECTION_EVIDENCE_UPDATED
+    _ev, _fs, _pm, re, _rec, _cm = _install(str(tmp_path))
+
+    rid = "ref_cache_safety"
+    base = datetime(2026, 4, 23, 12, 0, 0)
+    seed = [{
+        "id": rid, "text": "x", "entity": "master", "status": "confirmed",
+        "source_fact_ids": [], "created_at": base.isoformat(),
+        "feedback": None, "next_eligible_at": base.isoformat(),
+        "reinforcement": 0.0,
+        "disputation": 5.0,
+        "rein_last_signal_at": None,
+        "disp_last_signal_at": base.isoformat(),
+        "sub_zero_days": 0,
+        "sub_zero_last_increment_date": None,
+    }]
+    await re.asave_reflections("小天", seed)
+
+    # Force record_and_save to raise on the next call by patching the
+    # per-character event-log lock-bound writer. We patch
+    # `EventLog.record_and_save` (the sync core) so the async hop
+    # raises before any save happens.
+    real_record = re._event_log.record_and_save
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated cloudsave failure")
+
+    re._event_log.record_and_save = _boom
+    try:
+        with pytest.raises(RuntimeError, match="simulated cloudsave failure"):
+            await re.aincrement_sub_zero("小天", rid, base)
+    finally:
+        re._event_log.record_and_save = real_record
+
+    # Cached entry must be UNCHANGED — no orphan sub_zero increment.
+    refls = await re._aload_reflections_full("小天")
+    target = next(r for r in refls if r["id"] == rid)
+    assert target["sub_zero_days"] == 0, (
+        "cache leaked an increment despite save failure (round-2 Major #2 regression)"
+    )
+    assert target["sub_zero_last_increment_date"] is None
+
+    # And no EVIDENCE_UPDATED event was recorded for this entry.
+    events = _ev.read_since("小天", None)
+    matching = [
+        e for e in events
+        if e["type"] == EVT_REFLECTION_EVIDENCE_UPDATED
+        and e["payload"].get("reflection_id") == rid
+    ]
+    assert matching == [], (
+        f"unexpected event(s) recorded despite save failure: {matching}"
+    )
+
+    # Sanity: a NEXT call (with the writer restored) must succeed and
+    # advance to 1, proving the entry wasn't somehow already-debounced.
+    new_count = await re.aincrement_sub_zero("小天", rid, base)
+    assert new_count == 1
+
+
+@pytest.mark.asyncio
+async def test_archive_handler_self_heals_missing_shard(tmp_path):
+    """Round-2 Major #3: if `aarchive_reflection`'s shard append raises
+    AFTER record_and_save committed (entry removed from active view),
+    the next reconciler replay must re-create the shard from
+    `entry_snapshot` in the event payload — otherwise the entry is
+    pure data loss.
+
+    Symmetric for persona archive handler.
+    """
+    from unittest.mock import patch
+    from memory.event_log import (
+        EVT_PERSONA_FACT_ADDED,
+        EVT_REFLECTION_STATE_CHANGED,
+    )
+    from memory.evidence_handlers import (
+        make_persona_archive_handler,
+        make_reflection_archive_handler,
+    )
+
+    # ── reflection half ──────────────────────────────────────────────
+    _ev, _fs, pm, re, _rec, _cm = _install(str(tmp_path))
+    rid = "ref_selfheal"
+    seed = [{
+        "id": rid, "text": "lost-then-found", "entity": "master",
+        "status": "confirmed", "source_fact_ids": [],
+        "created_at": "2026-04-22T10:00:00",
+        "feedback": None, "next_eligible_at": "2026-04-22T10:00:00",
+    }]
+    await re.asave_reflections("小天", seed)
+
+    # Patch `aappend_to_shard` at its source module — both
+    # reflection.py and persona.py do a function-local import, so this
+    # is the symbol they actually resolve at call-time. Simulates a
+    # crash between record_and_save and the shard append. Active view
+    # has already lost the entry by the time this raises.
+    async def _shard_boom(*a, **kw):
+        raise RuntimeError("simulated shard write failure")
+
+    with patch("memory.archive_shards.aappend_to_shard", _shard_boom):
+        with pytest.raises(RuntimeError, match="simulated shard write failure"):
+            await re.aarchive_reflection("小天", rid)
+
+    # Active view: entry already removed (record_and_save ran)
+    remaining = await re.aload_reflections("小天", include_archived=True)
+    assert all(r.get("id") != rid for r in remaining)
+    # Shard dir: empty (the append never ran)
+    archive_dir = re._reflections_archive_dir("小天")
+    if os.path.exists(archive_dir):
+        for fn in os.listdir(archive_dir):
+            if fn.endswith(".json"):
+                with open(os.path.join(archive_dir, fn), encoding="utf-8") as f:
+                    data = json.load(f)
+                assert all(e.get("id") != rid for e in data), (
+                    "shard already contains the entry — test setup broken"
+                )
+
+    # Replay the state_changed event via the handler — must self-heal.
+    events = _ev.read_since("小天", None)
+    archive_evt = next(
+        e for e in events
+        if e["type"] == EVT_REFLECTION_STATE_CHANGED
+        and e["payload"].get("reflection_id") == rid
+    )
+    assert archive_evt["payload"].get("entry_snapshot"), (
+        "event payload missing entry_snapshot — handler can't self-heal"
+    )
+
+    handler = make_reflection_archive_handler(re)
+    changed = handler("小天", archive_evt["payload"])
+    assert changed is True, "self-heal must report a change"
+
+    # Shard now contains the entry under the basename from payload
+    shard_basename = archive_evt["payload"]["archive_shard_path"]
+    shard_path = os.path.join(archive_dir, shard_basename)
+    assert os.path.exists(shard_path), "self-healed shard file missing"
+    with open(shard_path, encoding="utf-8") as f:
+        shard_data = json.load(f)
+    assert any(e.get("id") == rid for e in shard_data)
+
+    # Replaying again is a no-op (idempotent)
+    changed2 = handler("小天", archive_evt["payload"])
+    assert changed2 is False
+    with open(shard_path, encoding="utf-8") as f:
+        shard_data2 = json.load(f)
+    assert len(shard_data2) == len(shard_data), (
+        "replay must NOT duplicate the entry"
+    )
+
+    # ── persona half (symmetric) ─────────────────────────────────────
+    persona = await pm.aensure_persona("小天")
+    persona.setdefault("master", {}).setdefault("facts", []).append({
+        "id": "p_selfheal", "text": "p-lost-then-found",
+        "source": "manual", "source_id": None,
+        "protected": False,
+    })
+    await pm.asave_persona("小天", persona)
+
+    with patch("memory.archive_shards.aappend_to_shard", _shard_boom):
+        with pytest.raises(RuntimeError, match="simulated shard write failure"):
+            await pm.aarchive_persona_entry("小天", "master", "p_selfheal")
+
+    persona = await pm.aensure_persona("小天")
+    facts = persona.get("master", {}).get("facts", [])
+    assert all(f.get("id") != "p_selfheal" for f in facts), (
+        "active view should have lost the entry already"
+    )
+
+    p_events = _ev.read_since("小天", None)
+    p_archive_evt = next(
+        e for e in p_events
+        if e["type"] == EVT_PERSONA_FACT_ADDED
+        and e["payload"].get("entry_id") == "p_selfheal"
+    )
+    p_handler = make_persona_archive_handler(pm)
+    p_changed = p_handler("小天", p_archive_evt["payload"])
+    assert p_changed is True
+
+    p_archive_dir = pm._persona_archive_dir("小天")
+    p_shard_path = os.path.join(
+        p_archive_dir, p_archive_evt["payload"]["archive_shard_path"],
+    )
+    assert os.path.exists(p_shard_path)
+    with open(p_shard_path, encoding="utf-8") as f:
+        p_shard_data = json.load(f)
+    assert any(e.get("id") == "p_selfheal" for e in p_shard_data)
+
+    # Idempotent replay
+    assert p_handler("小天", p_archive_evt["payload"]) is False


### PR DESCRIPTION
## Summary

Implements **PR-2** from [memory-evidence-rfc.md §4.2](docs/design/memory-evidence-rfc.md) — time decay sweep + sharded archive storage (`<YYYY-MM-DD>_<uuid8>.json`, max 500 entries/shard) + one-shot migration of legacy `reflections_archive.json` flat file.

PR-3 (render budget + merge-on-promote) and PR-4 (funnel analytics) follow as separate PRs.

## What's in PR-2

- **`config/__init__.py`** — add `EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS = 3600` + register in `__all__` (RFC §6.5 Gate 4 placeholder).
- **`memory/archive_shards.py`** *(new)* — shared sharded-archive helpers used by both reflection and persona archives:
  - `apick_today_shard_path` (predict + materialize so the in-memory entry's `archive_shard_path` matches its on-disk location)
  - `aappend_to_shard` (append-then-extend, rolls a new shard when current one hits `ARCHIVE_FILE_MAX_ENTRIES`)
  - `migrate_flat_archive_to_shards_sync` / `amigrate_flat_archive_to_shards` (one-shot legacy flat-file migration with sentinel guard, idempotent on re-boot, preserves flat file if migration fails)
  - sync twins for symmetry with the existing `save_reflections` / `asave_reflections` pair.
- **`memory/reflection.py`**:
  - `_reflections_archive_path` → `_reflections_archive_dir` (returns `memory/<char>/reflection_archive/`)
  - new `_reflections_legacy_archive_path` for migration entrypoint
  - `save_reflections` / `asave_reflections` now write age-archived entries (promoted/denied >30d) into shards instead of the flat file, fall back to keeping in main on OSError
  - new `aarchive_reflection` — score-driven archive that emits `EVT_REFLECTION_STATE_CHANGED` with `{from, to: 'archived', archive_shard_path, archived_at}` via the 5-step `arecord_and_save` contract; protected entries skipped
  - new `aincrement_sub_zero` — emits `EVT_REFLECTION_EVIDENCE_UPDATED` with `source: 'archive_sweep'` so the increment is replayable
  - new `aone_shot_archive_migration` — non-fatal wrapper around the shared migration helper
- **`memory/persona.py`**:
  - new `_persona_archive_dir` (`memory/<char>/persona_archive/`)
  - symmetric `aarchive_persona_entry` — emits `EVT_PERSONA_FACT_ADDED` with `archive_shard_path` field (consumers distinguish archive flow from main fact_added by presence of this field)
  - symmetric `aincrement_sub_zero`
- **`memory/evidence_handlers.py`**:
  - register `EVT_REFLECTION_STATE_CHANGED` and `EVT_PERSONA_FACT_ADDED` reconciler handlers (both PR-2 only handle the archive transition; non-archive payloads are no-op for forward compat with PR-3 promote/merge)
  - add `sub_zero_last_increment_date` to `_EVIDENCE_SNAPSHOT_KEYS` so the debounce field survives reconciler replay
- **`memory_server.py`**:
  - new `_periodic_archive_sweep_loop` — every 1h, per-character `asyncio.gather`, scans non-protected reflections + persona entries, calls `aincrement_sub_zero` then `aarchive_reflection` / `aarchive_persona_entry` if `sub_zero_days >= EVIDENCE_ARCHIVE_DAYS`. Same-tick archive saves a sweep cycle for entries that were already at threshold but missed today's increment.
  - new `_aone_shot_archive_migration_if_needed` wired into the existing `_migrate_one` (parallel per-character).
  - sweep loop wired into startup alongside the other `_periodic_*_loop`s.

## ⚠️ Pre-merge reviewer gates (RFC §6.5)

- **Gate 4** — `ARCHIVE_FILE_MAX_ENTRIES = 500`, `EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS = 3600` — please sign off

## Test plan

- [x] `tests/unit/test_evidence_archive.py` — 22 tests covering decay-math snapshots, sub_zero accumulation/oscillation, protected exemption, shard size cap, legacy flat-file migration (per-day bucketing + uuid8 uniqueness + idempotency), archive event emission + handler replay-stability, sub_zero increment + same-day debounce, age-based archival writing to shards. **22 passed.**
- [x] `tests/integration/test_archive_sweep.py` — 2 tests booting the real `EventLog` + managers + `Reconciler` + `register_evidence_handlers` chain (mirrors `memory_server.startup_event_handler` step 3) and exercising end-to-end sweep → archive → reconcile-replay path; protected-persona-skip integration check. **2 passed.**
- [x] `uv run pytest tests/unit/ -q` — 842 passed, 14 skipped (pre-existing failures in `test_api_config_manager.py::TestProviderExclusion::test_restricted_providers`, `test_manager_locks.py::test_persona_locks_prevent_corruption_proof`, `test_runtime_test_ports.py::test_initialize_runtime_test_ports_*` were all confirmed failing on `main`, unrelated to PR-2)
- [x] `uv run ruff check memory/ config/ memory_server.py tests/unit/test_evidence_archive.py tests/integration/test_archive_sweep.py` — clean
- [x] `uv run python scripts/check_async_blocking.py` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增可配置的存档扫描间隔并启动定期后台归档循环，按规则自动增量归档过期反思与人物条目并可自愈缺失档案。
  * 引入分片式存档存储与写入策略，支持按日分片、容量溢出切分、原子写入与一次性迁移旧平面档案。
  * 增强事件驱动归档与回放一致性，归档操作变为可重放且幂等。

* **测试**
  * 添加全面单元与集成测试，覆盖分片行为、迁移、受保护条目排除、回放稳定性与故障场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->