### PR TITLE
perf(memory): cache entry token_count to skip re-tokenization on every render

### DIFF
--- a/memory/persona.py
+++ b/memory/persona.py
@@ -662,6 +662,16 @@ class PersonaManager:
         - rein_last_signal_at / disp_last_signal_at: 各自独立的衰减时钟
         - sub_zero_days + sub_zero_last_increment_date: archive 倒计时
         - merged_from_ids: LLM merge_into 决策吸收的 reflection id 列表
+
+        Token-count cache fields (derived, cache-only — not event-sourced):
+        - token_count: int | None — cached acount_tokens(text)
+        - token_count_text_sha256: str | None — fingerprint of the text that
+          was tokenized; a mismatch triggers recompute on the next render.
+
+        Zero-migration schema addition: existing on-disk entries without
+        these fields naturally read as None via `.get()`, which counts as a
+        cache miss and triggers a clean recompute on first render. No
+        explicit migration event is needed.
         """
         defaults = {
             'id': '',                   # 唯一标识
@@ -684,6 +694,11 @@ class PersonaManager:
             'user_fact_reinforce_count': 0,
             # 溯源：merge_into 吸收的 reflection id 列表
             'merged_from_ids': [],
+            # Derived token-count cache — populated by the render path
+            # (`_get_cached_token_count` / `_aget_cached_token_count`)
+            # on first render and ride-alongs with normal persona saves.
+            'token_count': None,
+            'token_count_text_sha256': None,
         }
         if isinstance(entry, str):
             d = dict(defaults)
@@ -1122,6 +1137,13 @@ class PersonaManager:
                 target_entry['disp_last_signal_at'] = now_iso
                 target_entry['sub_zero_days'] = 0
                 target_entry['merged_from_ids'] = new_merged_from
+                # Token-count cache is derived from `text`; rewriting text
+                # must drop the cache so the next render recomputes. The
+                # fingerprint check would catch the drift anyway, but
+                # explicit invalidation avoids the tiny window where a
+                # concurrent reader might see new text + stale count and
+                # saves one sha256 compute on the next render.
+                self._invalidate_token_count_cache(target_entry)
 
             # _sync_save: cloudsave gate + write + cache-evict-on-failure
             # (CodeRabbit PR #936 round-5 Major #1). See
@@ -1742,9 +1764,82 @@ class PersonaManager:
     # thread on the async path so the FastAPI event loop doesn't stall on
     # batches of ~100 entries.
 
+    # ── token-count cache helpers ────────────────────────────────────
+    #
+    # Each entry dict may carry two derived fields populated on first
+    # render: `token_count` (int) and `token_count_text_sha256` (str).
+    # Defaults to None in `_normalize_entry` / `_normalize_reflection`.
+    #
+    # Read path: compute sha256(text); if it matches the stored
+    # fingerprint AND the count is populated, use the cached value.
+    # Otherwise compute (sync `count_tokens` / async `acount_tokens`)
+    # and write both fields back to the in-memory entry. The cache is
+    # never written to disk directly — it rides along whenever the
+    # persona/reflection is otherwise saved (add_fact, amerge_into,
+    # asave_persona, etc.). A fresh process boot re-tokenizes on first
+    # render which is an acceptable warm-up cost.
+    #
+    # Red line compliance: the cache is purely derived from `text`, so
+    # event-sourcing it would duplicate the source of truth (see
+    # RFC §3.6.8 + the "derived values shouldn't produce events"
+    # principle). The in-memory update + ride-along-on-save approach
+    # also avoids "view mutations outside an event" — we only ever
+    # invoke a disk write through existing event-sourced or save-
+    # permitted paths.
+
     @staticmethod
+    def _text_fingerprint(text: str) -> str:
+        """sha256 hex digest of `text` used as the cache key. Same
+        encoding as the `rewrite_text_sha256` payload in amerge_into so
+        the two stay consistent if we ever cross-check."""
+        return hashlib.sha256((text or '').encode('utf-8')).hexdigest()
+
+    @classmethod
+    def _get_cached_token_count(cls, entry: dict) -> int:
+        """Sync cache-aware token count. Writes `token_count` +
+        `token_count_text_sha256` back to `entry` on miss."""
+        text = entry.get('text', '') or ''
+        if not text:
+            return 0
+        fp = cls._text_fingerprint(text)
+        cached = entry.get('token_count')
+        if cached is not None and entry.get('token_count_text_sha256') == fp:
+            return int(cached)
+        n = count_tokens(text)
+        entry['token_count'] = int(n)
+        entry['token_count_text_sha256'] = fp
+        return int(n)
+
+    @classmethod
+    async def _aget_cached_token_count(cls, entry: dict) -> int:
+        """Async twin — uses `acount_tokens` (worker-thread tiktoken).
+        Write-back semantics match the sync helper."""
+        text = entry.get('text', '') or ''
+        if not text:
+            return 0
+        fp = cls._text_fingerprint(text)
+        cached = entry.get('token_count')
+        if cached is not None and entry.get('token_count_text_sha256') == fp:
+            return int(cached)
+        n = await acount_tokens(text)
+        entry['token_count'] = int(n)
+        entry['token_count_text_sha256'] = fp
+        return int(n)
+
+    @staticmethod
+    def _invalidate_token_count_cache(entry: dict) -> None:
+        """Explicitly drop the cached count. Called by code paths that
+        rewrite `entry['text']` (e.g. `amerge_into`) to avoid the tiny
+        window where a concurrent reader sees new text + stale count.
+        The fingerprint check would catch it anyway, but explicit
+        invalidation is clearer and saves one sha256 compute on the
+        next render."""
+        entry['token_count'] = None
+        entry['token_count_text_sha256'] = None
+
+    @classmethod
     def _score_trim_entries(
-        entries: list, budget: int, now: datetime,
+        cls, entries: list, budget: int, now: datetime,
     ) -> list:
         """Sync score-trim: sort by (evidence_score, importance) DESC, keep
         entries whose accumulated `count_tokens(text)` ≤ `budget`. Stops at
@@ -1765,16 +1860,16 @@ class PersonaManager:
         kept = []
         total = 0
         for e in sorted_entries:
-            t = count_tokens(e.get('text', '') or '')
+            t = cls._get_cached_token_count(e)
             if total + t > budget:
                 break
             kept.append(e)
             total += t
         return kept
 
-    @staticmethod
+    @classmethod
     async def _ascore_trim_entries(
-        entries: list, budget: int, now: datetime,
+        cls, entries: list, budget: int, now: datetime,
     ) -> list:
         """Async twin of `_score_trim_entries`. Identical math; the only
         difference is `acount_tokens` (worker-thread tiktoken)."""
@@ -1789,7 +1884,7 @@ class PersonaManager:
         kept = []
         total = 0
         for e in sorted_entries:
-            t = await acount_tokens(e.get('text', '') or '')
+            t = await cls._aget_cached_token_count(e)
             if total + t > budget:
                 break
             kept.append(e)

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -41,7 +41,7 @@ from utils.file_utils import (
     robust_json_loads,
 )
 from utils.logger_config import get_module_logger
-from utils.tokenize import acount_tokens, count_tokens
+from utils.tokenize import acount_tokens, count_tokens, tokenizer_identity
 
 logger = get_module_logger(__name__, "Memory")
 
@@ -667,6 +667,11 @@ class PersonaManager:
         - token_count: int | None — cached acount_tokens(text)
         - token_count_text_sha256: str | None — fingerprint of the text that
           was tokenized; a mismatch triggers recompute on the next render.
+        - token_count_tokenizer: str | None — fingerprint of the counter
+          used when `token_count` was written (e.g. `tiktoken:o200k_base`
+          or `heuristic:v1`). A mismatch with the current tokenizer
+          identity also triggers recompute, so a cache warmed under
+          tiktoken doesn't get served to a heuristic-fallback render.
 
         Zero-migration schema addition: existing on-disk entries without
         these fields naturally read as None via `.get()`, which counts as a
@@ -697,8 +702,13 @@ class PersonaManager:
             # Derived token-count cache — populated by the render path
             # (`_get_cached_token_count` / `_aget_cached_token_count`)
             # on first render and ride-alongs with normal persona saves.
+            # Both text-sha and tokenizer-identity must match for a hit,
+            # so a cache warmed under tiktoken can't be served to a
+            # heuristic-fallback render (e.g. packaging without encoding
+            # data file).
             'token_count': None,
             'token_count_text_sha256': None,
+            'token_count_tokenizer': None,
         }
         if isinstance(entry, str):
             d = dict(defaults)
@@ -1766,9 +1776,10 @@ class PersonaManager:
 
     # ── token-count cache helpers ────────────────────────────────────
     #
-    # Each entry dict may carry two derived fields populated on first
-    # render: `token_count` (int) and `token_count_text_sha256` (str).
-    # Defaults to None in `_normalize_entry` / `_normalize_reflection`.
+    # Each entry dict may carry three derived fields populated on first
+    # render: `token_count` (int), `token_count_text_sha256` (str) and
+    # `token_count_tokenizer` (str). All default to None in
+    # `_normalize_entry` / `_normalize_reflection`.
     #
     # Read path: compute sha256(text); if it matches the stored
     # fingerprint AND the count is populated, use the cached value.
@@ -1796,34 +1807,54 @@ class PersonaManager:
 
     @classmethod
     def _get_cached_token_count(cls, entry: dict) -> int:
-        """Sync cache-aware token count. Writes `token_count` +
-        `token_count_text_sha256` back to `entry` on miss."""
+        """Sync cache-aware token count. Writes `token_count`,
+        `token_count_text_sha256` and `token_count_tokenizer` back to
+        `entry` on miss.
+
+        Cache hit requires BOTH fingerprints to match:
+        - text sha256 (catches text mutation)
+        - tokenizer identity (catches tiktoken↔heuristic transition;
+          see `utils.tokenize.tokenizer_identity` docstring for the
+          motivating scenario — packaging without encoding data file).
+        """
         text = entry.get('text', '') or ''
         if not text:
             return 0
         fp = cls._text_fingerprint(text)
+        tid = tokenizer_identity()
         cached = entry.get('token_count')
-        if cached is not None and entry.get('token_count_text_sha256') == fp:
+        if (
+            cached is not None
+            and entry.get('token_count_text_sha256') == fp
+            and entry.get('token_count_tokenizer') == tid
+        ):
             return int(cached)
         n = count_tokens(text)
         entry['token_count'] = int(n)
         entry['token_count_text_sha256'] = fp
+        entry['token_count_tokenizer'] = tid
         return int(n)
 
     @classmethod
     async def _aget_cached_token_count(cls, entry: dict) -> int:
         """Async twin — uses `acount_tokens` (worker-thread tiktoken).
-        Write-back semantics match the sync helper."""
+        Write-back semantics match the sync helper (both fingerprints)."""
         text = entry.get('text', '') or ''
         if not text:
             return 0
         fp = cls._text_fingerprint(text)
+        tid = tokenizer_identity()
         cached = entry.get('token_count')
-        if cached is not None and entry.get('token_count_text_sha256') == fp:
+        if (
+            cached is not None
+            and entry.get('token_count_text_sha256') == fp
+            and entry.get('token_count_tokenizer') == tid
+        ):
             return int(cached)
         n = await acount_tokens(text)
         entry['token_count'] = int(n)
         entry['token_count_text_sha256'] = fp
+        entry['token_count_tokenizer'] = tid
         return int(n)
 
     @staticmethod
@@ -1836,6 +1867,7 @@ class PersonaManager:
         next render."""
         entry['token_count'] = None
         entry['token_count_text_sha256'] = None
+        entry['token_count_tokenizer'] = None
 
     @classmethod
     def _score_trim_entries(

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -510,6 +510,11 @@ class PersonaManager:
                         # 文本变化 → 更新
                         old_text = entry.get('text', '')
                         entry['text'] = text
+                        # token_count 缓存是从 text 派生的；这里原地改写
+                        # text 必须同步失效缓存，否则渲染路径要等到
+                        # fingerprint mismatch 才补算，还会额外浪费一次
+                        # sha256（对偶于 amerge_into 的 _sync_mutate_entry）。
+                        self._invalidate_token_count_cache(entry)
                         modified = True
                         logger.info(f"[Persona] {name}: card 同步更新 [{entity}] \"{old_text[:30]}\" → \"{text[:30]}\"")
                     new_card_entries.append(entry)
@@ -1806,10 +1811,19 @@ class PersonaManager:
         return hashlib.sha256((text or '').encode('utf-8')).hexdigest()
 
     @classmethod
-    def _get_cached_token_count(cls, entry: dict) -> int:
+    def _get_cached_token_count(cls, entry: dict, *, writeback: bool = True) -> int:
         """Sync cache-aware token count. Writes `token_count`,
         `token_count_text_sha256` and `token_count_tokenizer` back to
-        `entry` on miss.
+        `entry` on miss when `writeback=True` (the default, for persona
+        entries that live in the `_personas` in-memory view and therefore
+        benefit from across-render cache reuse).
+
+        Callers should pass `writeback=False` for entries that do not have
+        a process-resident view (currently: reflection entries, which are
+        always loaded fresh from disk via `aload_reflections`). In that
+        mode we still short-circuit on a pre-existing cache hit — that's
+        free — but we never pollute the entry dict with fields that
+        wouldn't survive the next render anyway.
 
         Cache hit requires BOTH fingerprints to match:
         - text sha256 (catches text mutation)
@@ -1830,15 +1844,18 @@ class PersonaManager:
         ):
             return int(cached)
         n = count_tokens(text)
-        entry['token_count'] = int(n)
-        entry['token_count_text_sha256'] = fp
-        entry['token_count_tokenizer'] = tid
+        if writeback:
+            entry['token_count'] = int(n)
+            entry['token_count_text_sha256'] = fp
+            entry['token_count_tokenizer'] = tid
         return int(n)
 
     @classmethod
-    async def _aget_cached_token_count(cls, entry: dict) -> int:
+    async def _aget_cached_token_count(cls, entry: dict, *, writeback: bool = True) -> int:
         """Async twin — uses `acount_tokens` (worker-thread tiktoken).
-        Write-back semantics match the sync helper (both fingerprints)."""
+        Write-back semantics match the sync helper (both fingerprints).
+        See `_get_cached_token_count` for the `writeback=False` contract
+        (used by reflection render path, which has no in-memory view)."""
         text = entry.get('text', '') or ''
         if not text:
             return 0
@@ -1852,9 +1869,10 @@ class PersonaManager:
         ):
             return int(cached)
         n = await acount_tokens(text)
-        entry['token_count'] = int(n)
-        entry['token_count_text_sha256'] = fp
-        entry['token_count_tokenizer'] = tid
+        if writeback:
+            entry['token_count'] = int(n)
+            entry['token_count_text_sha256'] = fp
+            entry['token_count_tokenizer'] = tid
         return int(n)
 
     @staticmethod
@@ -1872,6 +1890,7 @@ class PersonaManager:
     @classmethod
     def _score_trim_entries(
         cls, entries: list, budget: int, now: datetime,
+        *, cache_writeback: bool = True,
     ) -> list:
         """Sync score-trim: sort by (evidence_score, importance) DESC, keep
         entries whose accumulated `count_tokens(text)` ≤ `budget`. Stops at
@@ -1880,6 +1899,13 @@ class PersonaManager:
 
         `entries` is a list of dicts (no entity tagging — caller sorts/keys
         as needed). Returns the kept subset preserving the score-DESC order.
+
+        `cache_writeback`: default True writes `token_count` fields back
+        onto each entry for across-render reuse (persona path — entries
+        live in `_personas`). Pass False for reflection entries, which are
+        loaded fresh from disk every render and would have no persistent
+        view to cache against; writing cache fields there would be
+        misleading and pollute reflection.json on the next save.
         """
         sorted_entries = sorted(
             entries,
@@ -1892,7 +1918,7 @@ class PersonaManager:
         kept = []
         total = 0
         for e in sorted_entries:
-            t = cls._get_cached_token_count(e)
+            t = cls._get_cached_token_count(e, writeback=cache_writeback)
             if total + t > budget:
                 break
             kept.append(e)
@@ -1902,9 +1928,11 @@ class PersonaManager:
     @classmethod
     async def _ascore_trim_entries(
         cls, entries: list, budget: int, now: datetime,
+        *, cache_writeback: bool = True,
     ) -> list:
         """Async twin of `_score_trim_entries`. Identical math; the only
-        difference is `acount_tokens` (worker-thread tiktoken)."""
+        difference is `acount_tokens` (worker-thread tiktoken). See the
+        sync twin for the `cache_writeback` contract."""
         sorted_entries = sorted(
             entries,
             key=lambda e: (
@@ -1916,7 +1944,7 @@ class PersonaManager:
         kept = []
         total = 0
         for e in sorted_entries:
-            t = await cls._aget_cached_token_count(e)
+            t = await cls._aget_cached_token_count(e, writeback=cache_writeback)
             if total + t > budget:
                 break
             kept.append(e)
@@ -2120,6 +2148,11 @@ class PersonaManager:
                 persona, suppressed_text_set,
             ),
             REFLECTION_RENDER_TOKEN_BUDGET, now,
+            # Reflections have no `_personas`-style in-memory view — they're
+            # always loaded fresh from disk. Writing cache fields onto the
+            # transient dicts would be garbage-collected on render exit and
+            # could only pollute reflection.json on the next save.
+            cache_writeback=False,
         )
         # Preserve the score-DESC order produced by _score_trim_entries.
         # The previous implementation filtered the ORIGINAL source lists by
@@ -2216,6 +2249,10 @@ class PersonaManager:
                 persona, suppressed_text_set,
             ),
             REFLECTION_RENDER_TOKEN_BUDGET, now,
+            # See sync twin: reflections have no `_personas`-style
+            # in-memory view, so we compute fresh every render without
+            # writing cache fields back onto the transient dicts.
+            cache_writeback=False,
         )
         # Preserve score-DESC order from _ascore_trim_entries — mirror of
         # the sync path fix in _compose_persona_markdown (CodeRabbit PR

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1781,19 +1781,27 @@ class PersonaManager:
 
     # ── token-count cache helpers ────────────────────────────────────
     #
-    # Each entry dict may carry three derived fields populated on first
-    # render: `token_count` (int), `token_count_text_sha256` (str) and
-    # `token_count_tokenizer` (str). All default to None in
-    # `_normalize_entry` / `_normalize_reflection`.
+    # Each persona entry dict may carry three derived fields populated
+    # on first render: `token_count` (int), `token_count_text_sha256`
+    # (str) and `token_count_tokenizer` (str). `_normalize_entry`
+    # defaults all three to None.
     #
-    # Read path: compute sha256(text); if it matches the stored
-    # fingerprint AND the count is populated, use the cached value.
-    # Otherwise compute (sync `count_tokens` / async `acount_tokens`)
-    # and write both fields back to the in-memory entry. The cache is
-    # never written to disk directly — it rides along whenever the
-    # persona/reflection is otherwise saved (add_fact, amerge_into,
-    # asave_persona, etc.). A fresh process boot re-tokenizes on first
-    # render which is an acceptable warm-up cost.
+    # Reflection entries deliberately do NOT default these fields —
+    # `_normalize_reflection` leaves them absent because reflections
+    # have no process-resident cache (each render re-reads from disk),
+    # so any writeback would be garbage-collected with the transient
+    # list. Reflection renders therefore call the same helpers with
+    # `writeback=False` and never persist cache fields. See the
+    # commentary on `_get_cached_token_count` for the contract.
+    #
+    # Read path (persona): compute sha256(text); if it matches the
+    # stored fingerprint AND the count is populated, use the cached
+    # value. Otherwise compute (sync `count_tokens` / async
+    # `acount_tokens`) and write all three fields back to the in-memory
+    # entry. The cache is never written to disk directly — it rides
+    # along whenever the persona is otherwise saved (add_fact,
+    # amerge_into, asave_persona, etc.). A fresh process boot
+    # re-tokenizes on first render which is an acceptable warm-up cost.
     #
     # Red line compliance: the cache is purely derived from `text`, so
     # event-sourcing it would duplicate the source of truth (see

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1891,8 +1891,9 @@ class PersonaManager:
 
         Returns the non-negative int when `raw` is coercible and sane;
         returns None (→ force a cache miss) when `raw` is missing,
-        non-numeric, a bool (`int(True) == 1` would silently succeed —
-        not what we want for a token count field), or negative.
+        non-numeric, a bool, a non-integer float (1.9 would silently
+        truncate to 1), `inf` / `nan` (`int(inf)` raises
+        `OverflowError`), or negative.
 
         `bool` is a subclass of `int` in Python, so the explicit
         `isinstance(raw, bool)` reject keeps us from accepting `True`/
@@ -1900,9 +1901,15 @@ class PersonaManager:
         edited with boolean-looking garbage."""
         if raw is None or isinstance(raw, bool):
             return None
+        if isinstance(raw, float):
+            if not raw.is_integer():
+                return None
+            if raw < 0:
+                return None
+            return int(raw)
         try:
             value = int(raw)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return None
         if value < 0:
             return None

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1830,19 +1830,27 @@ class PersonaManager:
         - tokenizer identity (catches tiktoken↔heuristic transition;
           see `utils.tokenize.tokenizer_identity` docstring for the
           motivating scenario — packaging without encoding data file).
+
+        Additionally, `token_count` must coerce cleanly to a non-negative
+        int. A hand-edited or corrupted `persona.json` could plant a
+        non-numeric or negative value with fingerprints that still happen
+        to match (or match after someone also hand-rewrote the sha256
+        field) — in which case `int(...)` on the cached value would
+        either raise or return garbage and bomb the render. On coercion
+        failure we treat it as a cache miss and recompute.
         """
         text = entry.get('text', '') or ''
         if not text:
             return 0
         fp = cls._text_fingerprint(text)
         tid = tokenizer_identity()
-        cached = entry.get('token_count')
+        cached_count = cls._coerce_cached_count(entry.get('token_count'))
         if (
-            cached is not None
+            cached_count is not None
             and entry.get('token_count_text_sha256') == fp
             and entry.get('token_count_tokenizer') == tid
         ):
-            return int(cached)
+            return cached_count
         n = count_tokens(text)
         if writeback:
             entry['token_count'] = int(n)
@@ -1855,25 +1863,50 @@ class PersonaManager:
         """Async twin — uses `acount_tokens` (worker-thread tiktoken).
         Write-back semantics match the sync helper (both fingerprints).
         See `_get_cached_token_count` for the `writeback=False` contract
-        (used by reflection render path, which has no in-memory view)."""
+        (used by reflection render path, which has no in-memory view),
+        and for the defensive coercion of poisoned `token_count` values
+        from a hand-edited or corrupted `persona.json`."""
         text = entry.get('text', '') or ''
         if not text:
             return 0
         fp = cls._text_fingerprint(text)
         tid = tokenizer_identity()
-        cached = entry.get('token_count')
+        cached_count = cls._coerce_cached_count(entry.get('token_count'))
         if (
-            cached is not None
+            cached_count is not None
             and entry.get('token_count_text_sha256') == fp
             and entry.get('token_count_tokenizer') == tid
         ):
-            return int(cached)
+            return cached_count
         n = await acount_tokens(text)
         if writeback:
             entry['token_count'] = int(n)
             entry['token_count_text_sha256'] = fp
             entry['token_count_tokenizer'] = tid
         return int(n)
+
+    @staticmethod
+    def _coerce_cached_count(raw) -> int | None:
+        """Validate a `token_count` value loaded from an entry dict.
+
+        Returns the non-negative int when `raw` is coercible and sane;
+        returns None (→ force a cache miss) when `raw` is missing,
+        non-numeric, a bool (`int(True) == 1` would silently succeed —
+        not what we want for a token count field), or negative.
+
+        `bool` is a subclass of `int` in Python, so the explicit
+        `isinstance(raw, bool)` reject keeps us from accepting `True`/
+        `False` as legitimate cached counts if persona.json was hand-
+        edited with boolean-looking garbage."""
+        if raw is None or isinstance(raw, bool):
+            return None
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None
+        if value < 0:
+            return None
+        return value
 
     @staticmethod
     def _invalidate_token_count_cache(entry: dict) -> None:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -191,6 +191,15 @@ class ReflectionEngine:
         Also adds the `recent_mentions` / `suppress` mention抑制 fields so
         confirmed reflections can share persona's 5h-window rate-limit
         machinery (AI 自我克制，不在 5h 内反复提同一条)。
+
+        Token-count cache fields (derived, cache-only — not event-sourced;
+        see `PersonaManager._get_cached_token_count` for semantics):
+        - token_count: int | None
+        - token_count_text_sha256: str | None
+
+        Zero-migration schema addition: legacy on-disk reflections without
+        these fields read as None via `.get()` during `_ascore_trim_entries`,
+        which is a clean cache miss → recompute on first render.
         """
         defaults = {
             # Evidence counters
@@ -212,6 +221,13 @@ class ReflectionEngine:
             'recent_mentions': [],
             'suppress': False,
             'suppressed_at': None,
+            # Derived token-count cache — populated on first render via
+            # PersonaManager._aget_cached_token_count (reflections share the
+            # persona render budget machinery via `_ascore_trim_entries`,
+            # which is entry-schema-agnostic). Rides along on normal
+            # reflection saves; fresh boot recomputes on first render.
+            'token_count': None,
+            'token_count_text_sha256': None,
         }
         for k, v in defaults.items():
             entry.setdefault(k, v)

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -196,6 +196,7 @@ class ReflectionEngine:
         see `PersonaManager._get_cached_token_count` for semantics):
         - token_count: int | None
         - token_count_text_sha256: str | None
+        - token_count_tokenizer: str | None
 
         Zero-migration schema addition: legacy on-disk reflections without
         these fields read as None via `.get()` during `_ascore_trim_entries`,
@@ -226,8 +227,11 @@ class ReflectionEngine:
             # persona render budget machinery via `_ascore_trim_entries`,
             # which is entry-schema-agnostic). Rides along on normal
             # reflection saves; fresh boot recomputes on first render.
+            # `token_count_tokenizer` guards against tiktoken↔heuristic
+            # transitions (see PersonaManager._get_cached_token_count).
             'token_count': None,
             'token_count_text_sha256': None,
+            'token_count_tokenizer': None,
         }
         for k, v in defaults.items():
             entry.setdefault(k, v)

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -192,15 +192,19 @@ class ReflectionEngine:
         confirmed reflections can share persona's 5h-window rate-limit
         machinery (AI 自我克制，不在 5h 内反复提同一条)。
 
-        Token-count cache fields (derived, cache-only — not event-sourced;
-        see `PersonaManager._get_cached_token_count` for semantics):
-        - token_count: int | None
-        - token_count_text_sha256: str | None
-        - token_count_tokenizer: str | None
-
-        Zero-migration schema addition: legacy on-disk reflections without
-        these fields read as None via `.get()` during `_ascore_trim_entries`,
-        which is a clean cache miss → recompute on first render.
+        Note on token-count cache: persona entries carry a
+        `token_count` / `token_count_text_sha256` / `token_count_tokenizer`
+        cache that survives across renders because `PersonaManager._personas`
+        is a process-resident view — render-time cache writes land on the
+        same dict that the next render reads. Reflections do NOT have an
+        equivalent in-memory view; `aload_reflections` /
+        `_aload_reflections_full` always read fresh from disk, so any cache
+        writeback on a reflection entry would be garbage-collected right
+        after the render. We deliberately do NOT add the cache fields to
+        this schema — populating them would be misleading (they'd look like
+        a working cache but every render still tokenizes from scratch).
+        Reflection tokenization stays live; in typical workloads the
+        persona-side cache captures the bulk of render time anyway.
         """
         defaults = {
             # Evidence counters
@@ -222,16 +226,6 @@ class ReflectionEngine:
             'recent_mentions': [],
             'suppress': False,
             'suppressed_at': None,
-            # Derived token-count cache — populated on first render via
-            # PersonaManager._aget_cached_token_count (reflections share the
-            # persona render budget machinery via `_ascore_trim_entries`,
-            # which is entry-schema-agnostic). Rides along on normal
-            # reflection saves; fresh boot recomputes on first render.
-            # `token_count_tokenizer` guards against tiktoken↔heuristic
-            # transitions (see PersonaManager._get_cached_token_count).
-            'token_count': None,
-            'token_count_text_sha256': None,
-            'token_count_tokenizer': None,
         }
         for k, v in defaults.items():
             entry.setdefault(k, v)

--- a/tests/unit/test_evidence_token_cache.py
+++ b/tests/unit/test_evidence_token_cache.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Unit tests for the persona / reflection token-count cache.
+Unit tests for the persona token-count cache.
 
 Covers the design in `memory/persona.py` `_get_cached_token_count` /
 `_aget_cached_token_count`:
@@ -13,15 +13,23 @@ Covers the design in `memory/persona.py` `_get_cached_token_count` /
     on the next render, triggering a clean recompute.
   - Changing the tokenizer identity (e.g. tiktoken→heuristic fallback)
     invalidates via tokenizer-fingerprint mismatch on the next render.
-  - `amerge_into` explicitly invalidates the cache when it rewrites
-    text, so a concurrent reader can't see new-text + stale-count.
-  - Cache rides along on `asave_persona` / `asave_reflections` — a
-    save-then-reload round-trip preserves the fields and the subsequent
-    render is a pure cache hit with zero tokenizer calls.
+  - `amerge_into` and `_apply_character_card_sync` explicitly invalidate
+    the cache when they rewrite text, so a concurrent reader can't see
+    new-text + stale-count.
+  - Cache rides along on `asave_persona` — a save-then-reload round-trip
+    preserves the fields and the subsequent render is a pure cache hit
+    with zero tokenizer calls.
   - Legacy entries without the fingerprint field (or with a corrupted
     fingerprint) get a clean recompute on first render.
   - The JSON round-trip of a cached entry does not KeyError on reload
     and the fields survive disk.
+
+Reflection entries are deliberately NOT cached (see
+`_ascore_trim_entries(..., cache_writeback=False)` call at the reflection
+render site): reflections are always loaded fresh from disk via
+`aload_reflections` / `_aload_reflections_full`, so any writeback would
+be garbage-collected before the next render could reuse it. The tests at
+the bottom of this file lock in that "no pollution" contract.
 """
 from __future__ import annotations
 
@@ -316,6 +324,64 @@ async def test_amerge_into_invalidates_cache(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_character_card_sync_invalidates_cache_on_text_rewrite(tmp_path):
+    """`_apply_character_card_sync` rewrites `entry['text']` in-place when
+    the character card's field value changes (lines 509-513). The cache
+    must be explicitly invalidated alongside the rewrite, mirroring the
+    contract `amerge_into` already holds. Without the invalidator the
+    stale `token_count` would ride on disk until the fingerprint safety
+    net caught the mismatch on the NEXT render — correct, but slower
+    (one extra sha256 per stale entry) and misleading during debug."""
+    from memory.persona import PersonaManager
+
+    pm, _event_log, _cm = _build_pm(str(tmp_path))
+
+    # Set up a card-sourced entry WITH a warmed cache (simulating an
+    # entry that has already survived one render).
+    entity = 'master'
+    field_name = 'nickname'
+    entry_id = PersonaManager._card_entry_id(entity, field_name)
+    card_entry = {
+        'id': entry_id,
+        'text': 'nickname: 原始称呼',
+        'source': 'character_card',
+        'protected': True,
+        'reinforcement': 0.0, 'disputation': 0.0,
+        'rein_last_signal_at': None, 'disp_last_signal_at': None,
+        'sub_zero_days': 0, 'sub_zero_last_increment_date': None,
+        'user_fact_reinforce_count': 0,
+        'merged_from_ids': [],
+        'importance': 0,
+        'suppress': False, 'suppressed_at': None,
+        'recent_mentions': [],
+    }
+    persona = {'master': {'facts': [card_entry]}}
+
+    # Warm the cache.
+    PersonaManager._get_cached_token_count(card_entry)
+    assert card_entry['token_count'] is not None
+    warmed_fp = card_entry['token_count_text_sha256']
+    assert warmed_fp == _sha('nickname: 原始称呼')
+
+    # Drive the sync with a changed card value → in-place text rewrite.
+    changed = pm._apply_character_card_sync(
+        '小天', persona,
+        master_basic_config={field_name: '新的称呼改动比较大的样例文本'},
+        lanlan_basic_config={},
+    )
+    assert changed is True
+    # The mutation happened in place …
+    updated = persona['master']['facts'][0]
+    assert updated is card_entry
+    assert updated['text'] == 'nickname: 新的称呼改动比较大的样例文本'
+    # … and the invalidator ran, so the render path won't serve the
+    # stale tiktoken count for new text.
+    assert updated['token_count'] is None
+    assert updated['token_count_text_sha256'] is None
+    assert updated['token_count_tokenizer'] is None
+
+
+@pytest.mark.asyncio
 async def test_cache_survives_persona_save_reload_roundtrip(tmp_path):
     """Cache fields ride along on `asave_persona`. After eviction from
     `_personas` and a disk reload, the fields come back populated and
@@ -365,9 +431,15 @@ async def test_cache_survives_persona_save_reload_roundtrip(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_cache_survives_reflection_save_reload_roundtrip(tmp_path):
-    """Mirror test for reflections: after `asave_reflections` +
-    eviction + reload, the fields are still there."""
+async def test_reflection_render_does_not_pollute_cache_fields(tmp_path):
+    """Reflections have no `_personas`-style in-memory view — each render
+    reads fresh from disk — so the render path MUST NOT write
+    `token_count*` fields onto reflection dicts. If it did, the fields
+    would ride along on the next `asave_reflections`, making a useless
+    cache look authoritative on disk while every render still tokenizes.
+
+    This test locks in the `cache_writeback=False` contract at the
+    reflection call site in `arender_persona_markdown`."""
     from memory.event_log import EventLog
     from memory.facts import FactStore
     from memory.persona import PersonaManager
@@ -390,7 +462,7 @@ async def test_cache_survives_reflection_save_reload_roundtrip(tmp_path):
     now_iso = datetime.now().isoformat()
     reflections = [
         {
-            'id': 'r1', 'text': 'reflection caching test',
+            'id': 'r1', 'text': 'reflection no-pollution contract',
             'entity': 'master', 'status': 'confirmed',
             'created_at': now_iso, 'importance': 1,
             'reinforcement': 1.0, 'disputation': 0.0,
@@ -406,26 +478,32 @@ async def test_cache_survives_reflection_save_reload_roundtrip(tmp_path):
         },
     ]
 
-    # Warm the cache via the render helper (reflections go through the
-    # same generic `_ascore_trim_entries`).
-    await PersonaManager._ascore_trim_entries(
+    # Run the trim under the reflection-render contract.
+    kept = await PersonaManager._ascore_trim_entries(
         reflections, budget=10_000, now=datetime.now(),
+        cache_writeback=False,
     )
-    assert reflections[0]['token_count'] is not None
+    assert len(kept) == 1
+    # Trim still sorted/kept correctly — the count was computed — but
+    # the fields must NOT be populated on the entry dict.
+    assert 'token_count' not in reflections[0] or (
+        reflections[0].get('token_count') is None
+    )
+    assert 'token_count_text_sha256' not in reflections[0] or (
+        reflections[0].get('token_count_text_sha256') is None
+    )
+    assert 'token_count_tokenizer' not in reflections[0] or (
+        reflections[0].get('token_count_tokenizer') is None
+    )
 
+    # Save + reload to confirm nothing pollution-y hit disk either.
     await re.asave_reflections('小天', reflections)
-
-    # Reload from disk — `aload_reflections` runs `_filter_reflections`
-    # which calls `_normalize_reflection`, so our new default fields
-    # get in-place defaults for any legacy items. Our persisted cache
-    # already has them so nothing gets overwritten.
-    from utils.tokenize import tokenizer_identity
     reloaded = await re.aload_reflections('小天', include_archived=False)
     assert len(reloaded) == 1
     r = reloaded[0]
-    assert isinstance(r['token_count'], int) and r['token_count'] > 0
-    assert r['token_count_text_sha256'] == _sha(r['text'])
-    assert r['token_count_tokenizer'] == tokenizer_identity()
+    assert r.get('token_count') is None
+    assert r.get('token_count_text_sha256') is None
+    assert r.get('token_count_tokenizer') is None
 
 
 def test_normalize_entry_defaults_cache_fields_to_none():
@@ -449,24 +527,40 @@ def test_normalize_entry_defaults_cache_fields_to_none():
     assert d2['token_count_tokenizer'] == 'tiktoken:o200k_base'
 
 
-def test_normalize_reflection_defaults_cache_fields_to_none():
-    """Mirror for reflections."""
+def test_normalize_reflection_does_not_default_cache_fields():
+    """Regression guard: `_normalize_reflection` must NOT inject
+    `token_count*` defaults. Reflections have no in-memory view
+    (`_personas` has no `_reflections` twin), so caching on them would
+    produce fields that look meaningful on disk but never serve a hit.
+
+    If a future refactor ever adds a reflection-side in-memory cache,
+    this test is the intentional signal that the schema can be extended
+    — but it should be extended deliberately, not by default."""
     from memory.reflection import ReflectionEngine
 
     r = ReflectionEngine._normalize_reflection(
         {'id': 'r1', 'text': 'anything'}
     )
-    assert r['token_count'] is None
-    assert r['token_count_text_sha256'] is None
-    assert r['token_count_tokenizer'] is None
-    # Idempotent on a pre-populated dict.
-    r['token_count'] = 7
-    r['token_count_text_sha256'] = 'f' * 64
-    r['token_count_tokenizer'] = 'tiktoken:o200k_base'
-    r2 = ReflectionEngine._normalize_reflection(r)
-    assert r2['token_count'] == 7
-    assert r2['token_count_text_sha256'] == 'f' * 64
-    assert r2['token_count_tokenizer'] == 'tiktoken:o200k_base'
+    assert 'token_count' not in r, (
+        'reflection schema must not default token_count — see '
+        'docstring for rationale'
+    )
+    assert 'token_count_text_sha256' not in r
+    assert 'token_count_tokenizer' not in r
+    # Idempotent: if a legacy reflection somehow already carries the
+    # fields (e.g. from an older build of this PR that cached
+    # reflections), normalize must preserve them byte-for-byte rather
+    # than dropping data — even though we no longer write them.
+    legacy = {
+        'id': 'r2', 'text': 'legacy has fields',
+        'token_count': 7,
+        'token_count_text_sha256': 'f' * 64,
+        'token_count_tokenizer': 'tiktoken:o200k_base',
+    }
+    normalized = ReflectionEngine._normalize_reflection(legacy)
+    assert normalized['token_count'] == 7
+    assert normalized['token_count_text_sha256'] == 'f' * 64
+    assert normalized['token_count_tokenizer'] == 'tiktoken:o200k_base'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_evidence_token_cache.py
+++ b/tests/unit/test_evidence_token_cache.py
@@ -5,11 +5,14 @@ Unit tests for the persona / reflection token-count cache.
 Covers the design in `memory/persona.py` `_get_cached_token_count` /
 `_aget_cached_token_count`:
 
-  - First render computes `token_count` + `token_count_text_sha256` and
-    writes them back onto the entry dict in-memory.
+  - First render computes `token_count` + `token_count_text_sha256` +
+    `token_count_tokenizer` and writes them back onto the entry dict
+    in-memory.
   - Second render reuses the cache — the tokenizer is NOT called again.
-  - Rewriting `entry['text']` invalidates via fingerprint mismatch on
-    the next render, triggering a clean recompute.
+  - Rewriting `entry['text']` invalidates via text-fingerprint mismatch
+    on the next render, triggering a clean recompute.
+  - Changing the tokenizer identity (e.g. tiktoken→heuristic fallback)
+    invalidates via tokenizer-fingerprint mismatch on the next render.
   - `amerge_into` explicitly invalidates the cache when it rewrites
     text, so a concurrent reader can't see new-text + stale-count.
   - Cache rides along on `asave_persona` / `asave_reflections` — a
@@ -89,16 +92,17 @@ def _sha(text: str) -> str:
 
 
 def test_first_call_computes_and_caches_sync():
-    """`_get_cached_token_count` populates both fields on first call and
-    the value matches `count_tokens` directly."""
+    """`_get_cached_token_count` populates all three fields on first
+    call and the value matches `count_tokens` directly."""
     from memory.persona import PersonaManager
-    from utils.tokenize import count_tokens
+    from utils.tokenize import count_tokens, tokenizer_identity
 
     e = _entry('m1', '主人很喜欢猫')
     n = PersonaManager._get_cached_token_count(e)
     assert n == count_tokens('主人很喜欢猫')
     assert e['token_count'] == n
     assert e['token_count_text_sha256'] == _sha('主人很喜欢猫')
+    assert e['token_count_tokenizer'] == tokenizer_identity()
 
 
 def test_second_call_uses_cache_sync():
@@ -144,18 +148,21 @@ def test_missing_fingerprint_field_triggers_recompute_sync():
     """Legacy entries (pre-schema-addition) have no fingerprint field.
     `.get()` returns None; the match check fails; recompute happens."""
     from memory.persona import PersonaManager
+    from utils.tokenize import tokenizer_identity
 
     e = _entry('m1', 'legacy pre-cache entry')
     # Simulate a legacy persona.json: the cache fields simply don't
     # exist on the dict at all.
     e.pop('token_count', None)
     e.pop('token_count_text_sha256', None)
+    e.pop('token_count_tokenizer', None)
     assert 'token_count' not in e
 
     n = PersonaManager._get_cached_token_count(e)
     assert n > 0
     assert e['token_count'] == n
     assert e['token_count_text_sha256'] == _sha('legacy pre-cache entry')
+    assert e['token_count_tokenizer'] == tokenizer_identity()
 
 
 def test_corrupted_fingerprint_triggers_recompute_sync():
@@ -166,6 +173,7 @@ def test_corrupted_fingerprint_triggers_recompute_sync():
     e = _entry('m1', 'real text')
     e['token_count'] = 999_999            # wildly wrong
     e['token_count_text_sha256'] = 'deadbeef' * 8  # bogus sha
+    e['token_count_tokenizer'] = 'tiktoken:o200k_base'  # plausible but stale
 
     recomputed = PersonaManager._get_cached_token_count(e)
     assert recomputed < 999_999, (
@@ -187,6 +195,7 @@ def test_empty_text_short_circuits_without_cache_write():
     # "never rendered" from "rendered as empty".
     assert e.get('token_count') is None
     assert e.get('token_count_text_sha256') is None
+    assert e.get('token_count_tokenizer') is None
 
 
 # ── async helper: same contract via acount_tokens ──────────────────
@@ -203,10 +212,12 @@ async def test_first_render_populates_cache_async():
     kept = await PersonaManager._ascore_trim_entries(
         entries, budget=10_000, now=datetime.now(),
     )
+    from utils.tokenize import tokenizer_identity
     assert len(kept) == 2
     for e in kept:
         assert isinstance(e['token_count'], int) and e['token_count'] > 0
         assert e['token_count_text_sha256'] == _sha(e['text'])
+        assert e['token_count_tokenizer'] == tokenizer_identity()
 
 
 @pytest.mark.asyncio
@@ -286,6 +297,7 @@ async def test_amerge_into_invalidates_cache(tmp_path):
     await PersonaManager._aget_cached_token_count(target)
     assert target['token_count'] is not None
     assert target['token_count_text_sha256'] is not None
+    assert target['token_count_tokenizer'] is not None
 
     # Drive amerge_into — this rewrites text + invalidates cache.
     res = await pm.amerge_into(
@@ -300,6 +312,7 @@ async def test_amerge_into_invalidates_cache(tmp_path):
     # Cache was cleared explicitly — next render will recompute.
     assert target['token_count'] is None
     assert target['token_count_text_sha256'] is None
+    assert target['token_count_tokenizer'] is None
 
 
 @pytest.mark.asyncio
@@ -329,12 +342,14 @@ async def test_cache_survives_persona_save_reload_roundtrip(tmp_path):
     pm._personas.pop('小天', None)
 
     # Reload — `_aensure_persona_locked` re-reads persona.json.
+    from utils.tokenize import tokenizer_identity
     reloaded = await pm.aget_persona('小天')
     reloaded_entries = reloaded['master']['facts']
     assert len(reloaded_entries) == 2
     for e in reloaded_entries:
         assert isinstance(e['token_count'], int) and e['token_count'] > 0
         assert e['token_count_text_sha256'] == _sha(e['text'])
+        assert e['token_count_tokenizer'] == tokenizer_identity()
 
     # Second render: acount_tokens must not be called for these entries.
     async def _boom(*_a, **_kw):
@@ -404,11 +419,13 @@ async def test_cache_survives_reflection_save_reload_roundtrip(tmp_path):
     # which calls `_normalize_reflection`, so our new default fields
     # get in-place defaults for any legacy items. Our persisted cache
     # already has them so nothing gets overwritten.
+    from utils.tokenize import tokenizer_identity
     reloaded = await re.aload_reflections('小天', include_archived=False)
     assert len(reloaded) == 1
     r = reloaded[0]
     assert isinstance(r['token_count'], int) and r['token_count'] > 0
     assert r['token_count_text_sha256'] == _sha(r['text'])
+    assert r['token_count_tokenizer'] == tokenizer_identity()
 
 
 def test_normalize_entry_defaults_cache_fields_to_none():
@@ -420,13 +437,16 @@ def test_normalize_entry_defaults_cache_fields_to_none():
     d = PersonaManager._normalize_entry('plain string fact')
     assert d['token_count'] is None
     assert d['token_count_text_sha256'] is None
+    assert d['token_count_tokenizer'] is None
     # Re-run on a dict that already has the field → idempotent; don't
     # clobber a populated cache.
     d['token_count'] = 42
     d['token_count_text_sha256'] = 'cafebabe' * 8
+    d['token_count_tokenizer'] = 'tiktoken:o200k_base'
     d2 = PersonaManager._normalize_entry(d)
     assert d2['token_count'] == 42
     assert d2['token_count_text_sha256'] == 'cafebabe' * 8
+    assert d2['token_count_tokenizer'] == 'tiktoken:o200k_base'
 
 
 def test_normalize_reflection_defaults_cache_fields_to_none():
@@ -438,12 +458,15 @@ def test_normalize_reflection_defaults_cache_fields_to_none():
     )
     assert r['token_count'] is None
     assert r['token_count_text_sha256'] is None
+    assert r['token_count_tokenizer'] is None
     # Idempotent on a pre-populated dict.
     r['token_count'] = 7
     r['token_count_text_sha256'] = 'f' * 64
+    r['token_count_tokenizer'] = 'tiktoken:o200k_base'
     r2 = ReflectionEngine._normalize_reflection(r)
     assert r2['token_count'] == 7
     assert r2['token_count_text_sha256'] == 'f' * 64
+    assert r2['token_count_tokenizer'] == 'tiktoken:o200k_base'
 
 
 @pytest.mark.asyncio
@@ -465,6 +488,7 @@ async def test_cached_entry_json_roundtrip_no_keyerror(tmp_path):
     disk_entry = raw['master']['facts'][0]
     assert disk_entry['token_count'] == e['token_count']
     assert disk_entry['token_count_text_sha256'] == e['token_count_text_sha256']
+    assert disk_entry['token_count_tokenizer'] == e['token_count_tokenizer']
 
     # Re-run normalize on the disk copy — must not raise and must not
     # wipe the populated cache.
@@ -472,4 +496,157 @@ async def test_cached_entry_json_roundtrip_no_keyerror(tmp_path):
     assert normalized['token_count'] == e['token_count']
     assert normalized['token_count_text_sha256'] == (
         e['token_count_text_sha256']
+    )
+    assert normalized['token_count_tokenizer'] == (
+        e['token_count_tokenizer']
+    )
+
+
+# ── tokenizer-identity guards (PR #939 round-1 review) ─────────────
+#
+# Motivation: the text-sha256 alone isn't enough. `utils.tokenize`
+# silently falls back from tiktoken to a heuristic counter when the
+# tiktoken encoding file is missing (e.g. Nuitka/PyInstaller packaging
+# without the `o200k_base.tiktoken` data file). Counts from the two
+# counters differ by a factor of ~1.5-2×. If a cache was warmed under
+# tiktoken and the next render is in heuristic-fallback mode (different
+# environment, fresh binary rollout), serving the cached count would
+# make the budget trim off by roughly that factor. The
+# `token_count_tokenizer` fingerprint catches this transition.
+
+
+def test_tokenizer_change_invalidates_cache_sync():
+    """Populate the cache under one tokenizer identity, then monkey-
+    patch `tokenizer_identity` (via the `memory.persona` import) to
+    return a different string. The next render must recompute.
+    """
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'identity guard test text')
+    first = PersonaManager._get_cached_token_count(e)
+    assert first > 0
+    stamped_tid = e['token_count_tokenizer']
+    assert stamped_tid  # populated on write
+
+    # Swap the tokenizer identity. The underlying counter
+    # (`count_tokens`) is unchanged so the recomputed value matches
+    # what we already have — but the cache write path must still fire
+    # and re-stamp the entry with the new identity.
+    new_tid = stamped_tid + '-rolled'
+    with patch('memory.persona.tokenizer_identity', return_value=new_tid):
+        count_calls = {'n': 0}
+
+        def _counting_count_tokens(text, *a, **kw):
+            count_calls['n'] += 1
+            return first  # deterministic — just needs to be non-zero
+
+        with patch(
+            'memory.persona.count_tokens',
+            side_effect=_counting_count_tokens,
+        ):
+            second = PersonaManager._get_cached_token_count(e)
+
+    assert count_calls['n'] == 1, (
+        'tokenizer identity mismatch must force a recompute; '
+        f'got {count_calls["n"]} count_tokens calls'
+    )
+    assert second == first
+    assert e['token_count_tokenizer'] == new_tid
+
+
+def test_heuristic_fallback_cached_separately_from_tiktoken_sync():
+    """Simulate the real failure mode: cache warmed under tiktoken,
+    next render in heuristic-fallback mode. Counts differ; the cache
+    must miss and the stored count must update to the heuristic value.
+    """
+    from memory.persona import PersonaManager
+
+    tiktoken_value = 12345
+    heuristic_value = 98765
+    call_log: list[str] = []
+
+    # ── First render: pretend we're on tiktoken ─────────────────────
+    with patch(
+        'memory.persona.tokenizer_identity',
+        return_value='tiktoken:o200k_base',
+    ), patch(
+        'memory.persona.count_tokens',
+        side_effect=lambda *a, **kw: (call_log.append('tt'), tiktoken_value)[1],
+    ):
+        e = _entry('m1', 'packaging transition demo text')
+        first = PersonaManager._get_cached_token_count(e)
+
+    assert first == tiktoken_value
+    assert e['token_count'] == tiktoken_value
+    assert e['token_count_tokenizer'] == 'tiktoken:o200k_base'
+    assert call_log == ['tt']
+
+    # ── Second render: packaging shipped without encoding file; we
+    #    silently fell back to heuristic. Cache must miss.
+    with patch(
+        'memory.persona.tokenizer_identity',
+        return_value='heuristic:v1',
+    ), patch(
+        'memory.persona.count_tokens',
+        side_effect=lambda *a, **kw: (
+            call_log.append('heur'), heuristic_value,
+        )[1],
+    ):
+        second = PersonaManager._get_cached_token_count(e)
+
+    assert second == heuristic_value, (
+        'heuristic-fallback render must recompute, not serve the '
+        'tiktoken-era cached count'
+    )
+    assert call_log == ['tt', 'heur']
+    assert e['token_count'] == heuristic_value
+    assert e['token_count_tokenizer'] == 'heuristic:v1'
+
+
+@pytest.mark.asyncio
+async def test_tokenizer_change_invalidates_cache_async():
+    """Async twin of the sync identity-guard test — covers the render
+    hot path (`_ascore_trim_entries` → `_aget_cached_token_count`)."""
+    from memory.persona import PersonaManager
+
+    entries = [_entry('m1', 'async identity guard entry', rein=3.0)]
+    # Warm the cache.
+    await PersonaManager._ascore_trim_entries(
+        entries, budget=10_000, now=datetime.now(),
+    )
+    warmed_tid = entries[0]['token_count_tokenizer']
+    assert warmed_tid
+
+    # Swap identity → second render must call acount_tokens again.
+    new_tid = warmed_tid + '-rolled'
+    call_count = {'n': 0}
+    from utils.tokenize import acount_tokens as real_acount
+
+    async def _counting_acount(text, *a, **kw):
+        call_count['n'] += 1
+        return await real_acount(text, *a, **kw)
+
+    with patch('memory.persona.tokenizer_identity', return_value=new_tid), \
+         patch('memory.persona.acount_tokens', side_effect=_counting_acount):
+        await PersonaManager._ascore_trim_entries(
+            entries, budget=10_000, now=datetime.now(),
+        )
+
+    assert call_count['n'] == 1, (
+        'tokenizer identity mismatch must force recompute on the '
+        f'async render path; got {call_count["n"]} acount_tokens calls'
+    )
+    assert entries[0]['token_count_tokenizer'] == new_tid
+
+
+def test_tokenizer_identity_helper_shape():
+    """`tokenizer_identity` is the API the cache keys off — lock its
+    output shape so future refactors don't silently break the cache."""
+    from utils.tokenize import tokenizer_identity
+
+    tid = tokenizer_identity()
+    assert isinstance(tid, str) and tid
+    # Must be one of the two bucketed namespaces.
+    assert tid.startswith('tiktoken:') or tid.startswith('heuristic:'), (
+        f'unexpected tokenizer identity shape: {tid!r}'
     )

--- a/tests/unit/test_evidence_token_cache.py
+++ b/tests/unit/test_evidence_token_cache.py
@@ -1,0 +1,475 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the persona / reflection token-count cache.
+
+Covers the design in `memory/persona.py` `_get_cached_token_count` /
+`_aget_cached_token_count`:
+
+  - First render computes `token_count` + `token_count_text_sha256` and
+    writes them back onto the entry dict in-memory.
+  - Second render reuses the cache — the tokenizer is NOT called again.
+  - Rewriting `entry['text']` invalidates via fingerprint mismatch on
+    the next render, triggering a clean recompute.
+  - `amerge_into` explicitly invalidates the cache when it rewrites
+    text, so a concurrent reader can't see new-text + stale-count.
+  - Cache rides along on `asave_persona` / `asave_reflections` — a
+    save-then-reload round-trip preserves the fields and the subsequent
+    render is a pure cache hit with zero tokenizer calls.
+  - Legacy entries without the fingerprint field (or with a corrupted
+    fingerprint) get a clean recompute on first render.
+  - The JSON round-trip of a cached entry does not KeyError on reload
+    and the fields survive disk.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ── helpers (minimal harness, keeps tests focused) ──────────────────
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_config_value.return_value = False
+    return cm
+
+
+def _build_pm(tmpdir: str):
+    """PersonaManager bound to `tmpdir` for disk round-trips.
+    `event_log` injected so `amerge_into` doesn't bail on the null-check."""
+    from memory.event_log import EventLog
+    from memory.persona import PersonaManager
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.persona.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+    return pm, event_log, cm
+
+
+def _entry(eid: str, text: str, *, rein: float = 1.0) -> dict:
+    """Build a persona entry with all schema fields PR-3 cares about.
+    Intentionally omits `token_count` / `token_count_text_sha256` so
+    the render path has to populate them itself."""
+    return {
+        'id': eid, 'text': text,
+        'source': 'manual', 'source_id': None,
+        'reinforcement': rein, 'disputation': 0.0,
+        'rein_last_signal_at': None, 'disp_last_signal_at': None,
+        'sub_zero_days': 0, 'sub_zero_last_increment_date': None,
+        'user_fact_reinforce_count': 0,
+        'merged_from_ids': [],
+        'importance': 0,
+        'protected': False,
+        'suppress': False, 'suppressed_at': None,
+        'recent_mentions': [],
+    }
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256((text or '').encode('utf-8')).hexdigest()
+
+
+# ── sync helper: deterministic cache contract ──────────────────────
+
+
+def test_first_call_computes_and_caches_sync():
+    """`_get_cached_token_count` populates both fields on first call and
+    the value matches `count_tokens` directly."""
+    from memory.persona import PersonaManager
+    from utils.tokenize import count_tokens
+
+    e = _entry('m1', '主人很喜欢猫')
+    n = PersonaManager._get_cached_token_count(e)
+    assert n == count_tokens('主人很喜欢猫')
+    assert e['token_count'] == n
+    assert e['token_count_text_sha256'] == _sha('主人很喜欢猫')
+
+
+def test_second_call_uses_cache_sync():
+    """Second call with `count_tokens` patched to raise still succeeds
+    because the fingerprint matches and we short-circuit."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'stable text')
+    first = PersonaManager._get_cached_token_count(e)
+
+    # Swap count_tokens to an exploder — cache path must not call it.
+    with patch('memory.persona.count_tokens',
+               side_effect=AssertionError(
+                   'cache miss — count_tokens should not be called')):
+        second = PersonaManager._get_cached_token_count(e)
+
+    assert first == second > 0
+
+
+def test_text_mutation_triggers_recompute_sync():
+    """Direct mutation of `entry['text']` invalidates the cache via
+    fingerprint mismatch → recompute fires."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'original text')
+    PersonaManager._get_cached_token_count(e)
+    old_count = e['token_count']
+
+    # Mutate text *after* the cache was populated — simulating a
+    # non-merge codepath that forgot to invalidate explicitly. The
+    # fingerprint check is the safety net.
+    e['text'] = 'completely different and much much much longer text ' * 4
+
+    recomputed = PersonaManager._get_cached_token_count(e)
+    assert recomputed != old_count, (
+        'text changed drastically; token count should change too'
+    )
+    assert e['token_count'] == recomputed
+    assert e['token_count_text_sha256'] == _sha(e['text'])
+
+
+def test_missing_fingerprint_field_triggers_recompute_sync():
+    """Legacy entries (pre-schema-addition) have no fingerprint field.
+    `.get()` returns None; the match check fails; recompute happens."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'legacy pre-cache entry')
+    # Simulate a legacy persona.json: the cache fields simply don't
+    # exist on the dict at all.
+    e.pop('token_count', None)
+    e.pop('token_count_text_sha256', None)
+    assert 'token_count' not in e
+
+    n = PersonaManager._get_cached_token_count(e)
+    assert n > 0
+    assert e['token_count'] == n
+    assert e['token_count_text_sha256'] == _sha('legacy pre-cache entry')
+
+
+def test_corrupted_fingerprint_triggers_recompute_sync():
+    """Fingerprint present but doesn't match text (e.g. someone edited
+    text via another path without running the invalidator) → recompute."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'real text')
+    e['token_count'] = 999_999            # wildly wrong
+    e['token_count_text_sha256'] = 'deadbeef' * 8  # bogus sha
+
+    recomputed = PersonaManager._get_cached_token_count(e)
+    assert recomputed < 999_999, (
+        'mismatched fingerprint must force recompute, not trust stale count'
+    )
+    assert e['token_count'] == recomputed
+    assert e['token_count_text_sha256'] == _sha('real text')
+
+
+def test_empty_text_short_circuits_without_cache_write():
+    """Empty / None text returns 0 without mutating the entry — the
+    cache field default of None is fine (0 render cost anyway)."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', '')
+    assert PersonaManager._get_cached_token_count(e) == 0
+    # We deliberately do NOT cache the 0 — empty is the cheapest
+    # possible case and keeping the cache fields None distinguishes
+    # "never rendered" from "rendered as empty".
+    assert e.get('token_count') is None
+    assert e.get('token_count_text_sha256') is None
+
+
+# ── async helper: same contract via acount_tokens ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_render_populates_cache_async():
+    """End-to-end: after `_ascore_trim_entries` runs once, every kept
+    entry carries populated cache fields."""
+    from memory.persona import PersonaManager
+
+    entries = [_entry('m1', '这是第一条事实' * 3, rein=3.0),
+               _entry('m2', 'another latin fact entry goes here', rein=2.0)]
+    kept = await PersonaManager._ascore_trim_entries(
+        entries, budget=10_000, now=datetime.now(),
+    )
+    assert len(kept) == 2
+    for e in kept:
+        assert isinstance(e['token_count'], int) and e['token_count'] > 0
+        assert e['token_count_text_sha256'] == _sha(e['text'])
+
+
+@pytest.mark.asyncio
+async def test_second_render_uses_cache_async():
+    """Second render with `acount_tokens` patched to blow up must still
+    succeed — the cache path is what keeps us off tiktoken."""
+    from memory.persona import PersonaManager
+
+    entries = [_entry('m1', '缓存测试文本'),
+               _entry('m2', 'cache stability check text')]
+
+    # Warm the cache.
+    await PersonaManager._ascore_trim_entries(
+        entries, budget=10_000, now=datetime.now(),
+    )
+
+    async def _boom(*_args, **_kwargs):
+        raise AssertionError(
+            'cache hit expected; acount_tokens must not be called'
+        )
+
+    with patch('memory.persona.acount_tokens', side_effect=_boom):
+        kept = await PersonaManager._ascore_trim_entries(
+            entries, budget=10_000, now=datetime.now(),
+        )
+
+    assert [e['id'] for e in kept] == ['m1', 'm2']
+
+
+@pytest.mark.asyncio
+async def test_text_change_invalidates_cache_across_renders_async():
+    """Warm cache, mutate text, re-render — the acount_tokens count
+    must increase by exactly 1 (the mutated entry recomputes; the
+    other hits cache)."""
+    from memory.persona import PersonaManager
+
+    entries = [_entry('m1', 'stable text that will not change'),
+               _entry('m2', 'mutated')]
+    await PersonaManager._ascore_trim_entries(
+        entries, budget=10_000, now=datetime.now(),
+    )
+
+    call_count = {'n': 0}
+    from utils.tokenize import acount_tokens as real_acount
+
+    async def _counting_acount(text, *a, **kw):
+        call_count['n'] += 1
+        return await real_acount(text, *a, **kw)
+
+    # Mutate m2's text — m1 stays stable so its fingerprint still matches.
+    entries[1]['text'] = 'mutated and drastically longer than before' * 3
+
+    with patch('memory.persona.acount_tokens', side_effect=_counting_acount):
+        await PersonaManager._ascore_trim_entries(
+            entries, budget=10_000, now=datetime.now(),
+        )
+    assert call_count['n'] == 1, (
+        f'expected exactly one acount_tokens call (the mutated entry); '
+        f'got {call_count["n"]}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_amerge_into_invalidates_cache(tmp_path):
+    """`amerge_into` rewrites `target_entry['text']`; the explicit
+    invalidation in `_sync_mutate_entry` must zero out both cache
+    fields so the next render recomputes against the new text."""
+    from memory.persona import PersonaManager
+
+    pm, _event_log, _cm = _build_pm(str(tmp_path))
+
+    target = _entry('card_target', 'original target text', rein=1.0)
+    persona = {'master': {'facts': [target]}}
+    pm._personas['小天'] = persona
+
+    # Warm the cache on the target entry.
+    await PersonaManager._aget_cached_token_count(target)
+    assert target['token_count'] is not None
+    assert target['token_count_text_sha256'] is not None
+
+    # Drive amerge_into — this rewrites text + invalidates cache.
+    res = await pm.amerge_into(
+        '小天',
+        target_entry_id='card_target',
+        merged_text='brand new merged text after absorption',
+        reflection_evidence={'reinforcement': 2.0, 'disputation': 0.0},
+        source_reflection_id='ref_001',
+    )
+    assert res == 'merged'
+    assert target['text'] == 'brand new merged text after absorption'
+    # Cache was cleared explicitly — next render will recompute.
+    assert target['token_count'] is None
+    assert target['token_count_text_sha256'] is None
+
+
+@pytest.mark.asyncio
+async def test_cache_survives_persona_save_reload_roundtrip(tmp_path):
+    """Cache fields ride along on `asave_persona`. After eviction from
+    `_personas` and a disk reload, the fields come back populated and
+    a subsequent render is a pure cache hit (zero tokenizer calls)."""
+    pm, _event_log, _cm = _build_pm(str(tmp_path))
+
+    e1 = _entry('m1', '第一条持久化事实', rein=3.0)
+    e2 = _entry('m2', 'second persistence fact', rein=2.0)
+    persona = {'master': {'facts': [e1, e2]}}
+    pm._personas['小天'] = persona
+
+    # Warm the cache through the real render helper.
+    from memory.persona import PersonaManager
+    await PersonaManager._ascore_trim_entries(
+        [e1, e2], budget=10_000, now=datetime.now(),
+    )
+    assert e1['token_count'] is not None
+    assert e2['token_count'] is not None
+
+    # Persist — this is the ride-along.
+    await pm.asave_persona('小天', persona)
+
+    # Evict the in-memory cache so a reload happens from disk.
+    pm._personas.pop('小天', None)
+
+    # Reload — `_aensure_persona_locked` re-reads persona.json.
+    reloaded = await pm.aget_persona('小天')
+    reloaded_entries = reloaded['master']['facts']
+    assert len(reloaded_entries) == 2
+    for e in reloaded_entries:
+        assert isinstance(e['token_count'], int) and e['token_count'] > 0
+        assert e['token_count_text_sha256'] == _sha(e['text'])
+
+    # Second render: acount_tokens must not be called for these entries.
+    async def _boom(*_a, **_kw):
+        raise AssertionError(
+            'cache hit expected post-reload; acount_tokens must not be called'
+        )
+
+    with patch('memory.persona.acount_tokens', side_effect=_boom):
+        kept = await PersonaManager._ascore_trim_entries(
+            reloaded_entries, budget=10_000, now=datetime.now(),
+        )
+    assert len(kept) == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_survives_reflection_save_reload_roundtrip(tmp_path):
+    """Mirror test for reflections: after `asave_reflections` +
+    eviction + reload, the fields are still there."""
+    from memory.event_log import EventLog
+    from memory.facts import FactStore
+    from memory.persona import PersonaManager
+    from memory.reflection import ReflectionEngine
+
+    cm = _mock_cm(str(tmp_path))
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.facts.get_config_manager", return_value=cm), \
+         patch("memory.persona.get_config_manager", return_value=cm), \
+         patch("memory.reflection.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        fs = FactStore()
+        fs._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+        re = ReflectionEngine(fs, pm, event_log=event_log)
+        re._config_manager = cm
+
+    now_iso = datetime.now().isoformat()
+    reflections = [
+        {
+            'id': 'r1', 'text': 'reflection caching test',
+            'entity': 'master', 'status': 'confirmed',
+            'created_at': now_iso, 'importance': 1,
+            'reinforcement': 1.0, 'disputation': 0.0,
+            'rein_last_signal_at': None, 'disp_last_signal_at': None,
+            'sub_zero_days': 0, 'sub_zero_last_increment_date': None,
+            'user_fact_reinforce_count': 0,
+            'absorbed_into': None,
+            'last_promote_attempt_at': None,
+            'promote_attempt_count': 0,
+            'promote_blocked_reason': None,
+            'recent_mentions': [],
+            'suppress': False, 'suppressed_at': None,
+        },
+    ]
+
+    # Warm the cache via the render helper (reflections go through the
+    # same generic `_ascore_trim_entries`).
+    await PersonaManager._ascore_trim_entries(
+        reflections, budget=10_000, now=datetime.now(),
+    )
+    assert reflections[0]['token_count'] is not None
+
+    await re.asave_reflections('小天', reflections)
+
+    # Reload from disk — `aload_reflections` runs `_filter_reflections`
+    # which calls `_normalize_reflection`, so our new default fields
+    # get in-place defaults for any legacy items. Our persisted cache
+    # already has them so nothing gets overwritten.
+    reloaded = await re.aload_reflections('小天', include_archived=False)
+    assert len(reloaded) == 1
+    r = reloaded[0]
+    assert isinstance(r['token_count'], int) and r['token_count'] > 0
+    assert r['token_count_text_sha256'] == _sha(r['text'])
+
+
+def test_normalize_entry_defaults_cache_fields_to_none():
+    """`_normalize_entry` is the single source of truth for fact-entry
+    defaults. The cache fields must default to None so first-render
+    logic knows to recompute."""
+    from memory.persona import PersonaManager
+
+    d = PersonaManager._normalize_entry('plain string fact')
+    assert d['token_count'] is None
+    assert d['token_count_text_sha256'] is None
+    # Re-run on a dict that already has the field → idempotent; don't
+    # clobber a populated cache.
+    d['token_count'] = 42
+    d['token_count_text_sha256'] = 'cafebabe' * 8
+    d2 = PersonaManager._normalize_entry(d)
+    assert d2['token_count'] == 42
+    assert d2['token_count_text_sha256'] == 'cafebabe' * 8
+
+
+def test_normalize_reflection_defaults_cache_fields_to_none():
+    """Mirror for reflections."""
+    from memory.reflection import ReflectionEngine
+
+    r = ReflectionEngine._normalize_reflection(
+        {'id': 'r1', 'text': 'anything'}
+    )
+    assert r['token_count'] is None
+    assert r['token_count_text_sha256'] is None
+    # Idempotent on a pre-populated dict.
+    r['token_count'] = 7
+    r['token_count_text_sha256'] = 'f' * 64
+    r2 = ReflectionEngine._normalize_reflection(r)
+    assert r2['token_count'] == 7
+    assert r2['token_count_text_sha256'] == 'f' * 64
+
+
+@pytest.mark.asyncio
+async def test_cached_entry_json_roundtrip_no_keyerror(tmp_path):
+    """Persist an entry with cache fields, reload via plain JSON, and
+    re-run normalize — no KeyError, fields preserved."""
+    from memory.persona import PersonaManager
+
+    pm, _el, _cm = _build_pm(str(tmp_path))
+    e = _entry('m1', 'roundtrip sanity check entry')
+    PersonaManager._get_cached_token_count(e)  # populate cache
+    pm._personas['小天'] = {'master': {'facts': [e]}}
+    await pm.asave_persona('小天')
+
+    # Read the raw JSON ourselves to confirm the fields hit disk.
+    path = pm._persona_path('小天')
+    with open(path, encoding='utf-8') as f:
+        raw = json.load(f)
+    disk_entry = raw['master']['facts'][0]
+    assert disk_entry['token_count'] == e['token_count']
+    assert disk_entry['token_count_text_sha256'] == e['token_count_text_sha256']
+
+    # Re-run normalize on the disk copy — must not raise and must not
+    # wipe the populated cache.
+    normalized = PersonaManager._normalize_entry(disk_entry)
+    assert normalized['token_count'] == e['token_count']
+    assert normalized['token_count_text_sha256'] == (
+        e['token_count_text_sha256']
+    )

--- a/tests/unit/test_evidence_token_cache.py
+++ b/tests/unit/test_evidence_token_cache.py
@@ -744,3 +744,165 @@ def test_tokenizer_identity_helper_shape():
     assert tid.startswith('tiktoken:') or tid.startswith('heuristic:'), (
         f'unexpected tokenizer identity shape: {tid!r}'
     )
+
+
+# ── poisoned-cache defensive guards (PR #939 round-3 review) ───────
+#
+# Motivation: `int(entry['token_count'])` on the hit path trusts the
+# value that came off disk. A hand-edited or storage-corrupted
+# `persona.json` could plant a non-numeric string ("??"), a null, a
+# boolean, or a negative number while the sha256 + tokenizer
+# fingerprints still happen to match. In that case the bare
+# `int(cached)` either raises (bombs the render) or returns
+# meaningless garbage (blows the budget math). The cache path must
+# validate the coerced value and fall back to recompute on anything
+# that isn't a non-negative int.
+
+
+def _sanity_fingerprints(entry: dict) -> None:
+    """Helper: set fingerprints so the match check passes and only
+    the `token_count` validation gate is exercised."""
+    from utils.tokenize import tokenizer_identity
+    entry['token_count_text_sha256'] = _sha(entry['text'])
+    entry['token_count_tokenizer'] = tokenizer_identity()
+
+
+def test_non_numeric_cached_count_triggers_recompute_sync():
+    """A string like `"??"` in `token_count` (hand-edit corruption)
+    must NOT bomb `int(...)` — it must be treated as a cache miss and
+    the entry rewritten with a real count."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'poisoned cache recovery sync')
+    e['token_count'] = '??'
+    _sanity_fingerprints(e)
+
+    n = PersonaManager._get_cached_token_count(e)
+    assert isinstance(n, int) and n > 0, (
+        'non-numeric cached count must force recompute; got non-int result'
+    )
+    # Writeback replaced the garbage with a real int.
+    assert e['token_count'] == n
+    assert isinstance(e['token_count'], int)
+
+
+@pytest.mark.asyncio
+async def test_non_numeric_cached_count_triggers_recompute_async():
+    """Async twin — the render hot path uses `_aget_cached_token_count`
+    and must survive the same corruption without exploding."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'poisoned cache recovery async')
+    e['token_count'] = '??'
+    _sanity_fingerprints(e)
+
+    n = await PersonaManager._aget_cached_token_count(e)
+    assert isinstance(n, int) and n > 0
+    assert e['token_count'] == n
+    assert isinstance(e['token_count'], int)
+
+
+def test_negative_cached_count_triggers_recompute_sync():
+    """A negative `token_count` (e.g. `-5`) is non-sensical — you can't
+    have a negative number of tokens. Treat as corruption and recompute."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'negative cache recovery sync')
+    e['token_count'] = -5
+    _sanity_fingerprints(e)
+
+    n = PersonaManager._get_cached_token_count(e)
+    assert n >= 0
+    # Writeback replaced the negative with the real, non-negative value.
+    assert e['token_count'] == n
+    assert e['token_count'] >= 0
+
+
+@pytest.mark.asyncio
+async def test_negative_cached_count_triggers_recompute_async():
+    """Async twin of the negative-value guard."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'negative cache recovery async')
+    e['token_count'] = -5
+    _sanity_fingerprints(e)
+
+    n = await PersonaManager._aget_cached_token_count(e)
+    assert n >= 0
+    assert e['token_count'] == n
+    assert e['token_count'] >= 0
+
+
+def test_null_cached_count_with_matching_fingerprints_triggers_recompute_sync():
+    """`token_count=None` but fingerprints populated is a near-legacy
+    shape (e.g. someone set the sha256/tokenizer fields manually but
+    left the count NULL). The existing `cached is not None` check
+    already handled this; this test locks it in explicitly as part of
+    the broader poisoned-cache family so the three cases (None, non-
+    numeric, negative) are covered symmetrically."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'null cache recovery sync')
+    e['token_count'] = None
+    _sanity_fingerprints(e)
+
+    n = PersonaManager._get_cached_token_count(e)
+    assert isinstance(n, int) and n > 0
+    assert e['token_count'] == n
+
+
+@pytest.mark.asyncio
+async def test_null_cached_count_with_matching_fingerprints_triggers_recompute_async():
+    """Async symmetric twin of the null-value guard."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'null cache recovery async')
+    e['token_count'] = None
+    _sanity_fingerprints(e)
+
+    n = await PersonaManager._aget_cached_token_count(e)
+    assert isinstance(n, int) and n > 0
+    assert e['token_count'] == n
+
+
+def test_boolean_cached_count_triggers_recompute_sync():
+    """`bool` is an `int` subclass in Python, so a naive
+    `isinstance(x, int)` would accept `True` (= 1) as a valid cached
+    count. That's almost never what we want — it's storage corruption,
+    not a legitimate value. The `_coerce_cached_count` helper rejects
+    booleans explicitly."""
+    from memory.persona import PersonaManager
+
+    e = _entry('m1', 'boolean cache poison sync')
+    e['token_count'] = True  # type: ignore[assignment]
+    _sanity_fingerprints(e)
+
+    n = PersonaManager._get_cached_token_count(e)
+    assert isinstance(n, int) and not isinstance(n, bool)
+    # Writeback coerced through `int(n)` — we're stricter than `True==1`.
+    assert e['token_count'] == n
+    assert e['token_count'] is not True
+    assert e['token_count'] is not False
+
+
+def test_coerce_cached_count_helper_shape():
+    """Direct unit coverage for `_coerce_cached_count`. Locks in the
+    exact coercion contract so future refactors don't silently loosen
+    it (e.g. accepting floats that truncate to negatives)."""
+    from memory.persona import PersonaManager as PM
+
+    # Accept: non-negative ints and int-parseable strings.
+    assert PM._coerce_cached_count(0) == 0
+    assert PM._coerce_cached_count(7) == 7
+    assert PM._coerce_cached_count('42') == 42
+
+    # Reject: None, booleans, non-numeric strings, negative, junk types.
+    assert PM._coerce_cached_count(None) is None
+    assert PM._coerce_cached_count(True) is None
+    assert PM._coerce_cached_count(False) is None
+    assert PM._coerce_cached_count('??') is None
+    assert PM._coerce_cached_count('') is None
+    assert PM._coerce_cached_count(-5) is None
+    assert PM._coerce_cached_count('-3') is None
+    assert PM._coerce_cached_count([1, 2, 3]) is None  # type: ignore[arg-type]
+    assert PM._coerce_cached_count({'nope': 1}) is None  # type: ignore[arg-type]

--- a/tests/unit/test_evidence_token_cache.py
+++ b/tests/unit/test_evidence_token_cache.py
@@ -891,18 +891,29 @@ def test_coerce_cached_count_helper_shape():
     it (e.g. accepting floats that truncate to negatives)."""
     from memory.persona import PersonaManager as PM
 
-    # Accept: non-negative ints and int-parseable strings.
+    # Accept: non-negative ints, int-parseable strings, and int-valued floats
+    # (e.g. 42.0 — json.loads of "42.0" produces a float). `bool` subclass
+    # check MUST run before `float` check so True/False don't slip through.
     assert PM._coerce_cached_count(0) == 0
     assert PM._coerce_cached_count(7) == 7
     assert PM._coerce_cached_count('42') == 42
+    assert PM._coerce_cached_count(42.0) == 42
 
-    # Reject: None, booleans, non-numeric strings, negative, junk types.
+    # Reject: None, booleans, non-numeric strings, negative, junk types,
+    # non-integer floats (1.9 → would silently truncate to 1 under int()),
+    # and float infinities / NaN (int(inf) raises OverflowError).
+    import math
     assert PM._coerce_cached_count(None) is None
     assert PM._coerce_cached_count(True) is None
     assert PM._coerce_cached_count(False) is None
     assert PM._coerce_cached_count('??') is None
     assert PM._coerce_cached_count('') is None
     assert PM._coerce_cached_count(-5) is None
+    assert PM._coerce_cached_count(-3.0) is None
+    assert PM._coerce_cached_count(1.9) is None
+    assert PM._coerce_cached_count(float('inf')) is None
+    assert PM._coerce_cached_count(float('nan')) is None
+    assert math.isnan(float('nan'))  # sanity — nan.is_integer() is False
     assert PM._coerce_cached_count('-3') is None
     assert PM._coerce_cached_count([1, 2, 3]) is None  # type: ignore[arg-type]
     assert PM._coerce_cached_count({'nope': 1}) is None  # type: ignore[arg-type]

--- a/utils/tokenize.py
+++ b/utils/tokenize.py
@@ -35,6 +35,14 @@ _ENCODERS: dict = {}
 # fallback so we don't spam the log on subsequent calls.
 _FALLBACK_WARNED = False
 
+# Bump this string whenever the heuristic formula in
+# `_count_tokens_heuristic` changes — the persona/reflection token-count
+# cache keys off `tokenizer_identity()`, and a formula change must
+# invalidate old heuristic-cached counts. tiktoken identity is keyed by
+# the `tiktoken:<encoding>` pair, which already changes automatically if
+# someone flips PERSONA_RENDER_ENCODING.
+_HEURISTIC_VERSION = "v1"
+
 
 def _get_encoder(encoding: str):
     """Return the cached `tiktoken.Encoding` for `encoding`, or `None`
@@ -118,6 +126,31 @@ async def acount_tokens(
     if not text:
         return 0
     return await asyncio.to_thread(count_tokens, text, encoding)
+
+
+def tokenizer_identity(encoding: str = PERSONA_RENDER_ENCODING) -> str:
+    """Short fingerprint of the counter that `count_tokens` currently
+    uses, for use as part of a cache key.
+
+    Returns:
+        - ``"tiktoken:<encoding>"`` when the real tiktoken encoder is
+          loaded (or can be loaded on first call and cached)
+        - ``"heuristic:<version>"`` when we're running the character-
+          class fallback (tiktoken missing, encoding data file missing,
+          etc. — same conditions as `_get_encoder` returning None)
+
+    The key is bucketed per `encoding` so a deployment that changes
+    ``PERSONA_RENDER_ENCODING`` also invalidates the old cache
+    automatically. The heuristic version string is bumped whenever
+    `_count_tokens_heuristic`'s formula changes.
+
+    Cheap: piggybacks on the `_ENCODERS` cache, so after the first
+    call it's a single dict lookup.
+    """
+    enc = _get_encoder(encoding)
+    if enc is None:
+        return f"heuristic:{_HEURISTIC_VERSION}"
+    return f"tiktoken:{encoding}"
 
 
 def _reset_fallback_warned_for_tests() -> None:


### PR DESCRIPTION
## Summary

Cache `token_count` on persona/reflection entries with a `text_sha256` fingerprint so `_ascore_trim_entries` skips the ~2ms/entry tiktoken call when nothing's changed. Follow-up optimization to [#936](https://github.com/Project-N-E-K-O/N.E.K.O/pull/936) PR-3's render budget. Expected render savings on a warm process: ~200ms for 100 entries → O(single sha256 + dict read).

## Approach

- Add two top-level fields on entries: `token_count: int | null`, `token_count_text_sha256: str | null`. Defaults to None in `_normalize_entry` / `_normalize_reflection`.
- Render computes `sha256(text)` and checks: match + cached value present → use cache; otherwise `acount_tokens(text)` + write back in-memory.
- `amerge_into` explicitly invalidates cache when rewriting text (clarity; fingerprint check would catch it otherwise).
- Persistence: in-memory only. Any regular save ride-along persists it as a side effect. Fresh process boot re-tokenizes on first render (acceptable warm-up).

## Why not event-sourced?

Cache is purely derived from `text`. Event-sourcing it would violate red line 5 ("read-time decay is computation, not state transition") in spirit — the same principle applies: derived values shouldn't produce events. In-memory + ride-along-on-save is the minimum-footprint approach.

## Schema migration

Zero-migration: existing on-disk entries without the fields get `None` defaults on load — either via `_normalize_reflection` (already runs on every reflection load) or via `.get()` returning None in `_get_cached_token_count` for persona entries (persona load path does not run `_normalize_entry`, but `.get()` treats missing-field as miss → clean recompute). First render recomputes either way.

## Test plan

- [x] `uv run pytest tests/unit/test_evidence_token_cache.py -v` — 15 passed
- [x] `uv run pytest tests/unit/` — regression sweep: 946 passed (3 pre-existing failures on origin/main unrelated to this PR)
- [x] `uv run ruff check memory/ utils/tokenize.py tests/unit/test_evidence_token_cache.py` — all checks passed
- [x] `uv run python scripts/check_async_blocking.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 为 persona 渲染添加进程内令牌计数缓存并在文本重写时明确失效；裁剪/渲染辅助改为类方法并支持 cache_writeback 控制，默认避免将短期反思写回持久字段。

* **新功能**
  * 引入分词器身份指纹与启发式版本标记，用于区分分词器实现并使缓存可撤销。

* **文档**
  * 明确反思条目不应持久化令牌计数字段的行为说明。

* **测试**
  * 新增全面单元测试，覆盖同步/异步缓存命中、失效、持久化往返及分词器切换场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->