### PR TITLE
feat(memory): fact version chain + reflection ontology constraints

### DIFF
--- a/config/prompts_memory.py
+++ b/config/prompts_memory.py
@@ -1191,8 +1191,16 @@ REFLECTION_PROMPT = {
 - "neko": 主要关于 {LANLAN_NAME} 的自我认知
 - "relationship": 关于两人之间的关系动态
 
+请同时给出该反思的语义类别 relation_type（必须与 entity 匹配）、置信度 confidence (0.0–1.0)，以及时间范围 temporal_scope：
+- master 可用: preference(偏好) | trait(性格) | habit(习惯) | identity(身份) | emotional(情感) | boundary(边界)
+- neko 可用: self_awareness(自我认知) | learned(习得行为) | role_note(角色备注)
+- relationship 可用: dynamic(互动模式) | milestone(里程碑) | tension(摩擦) | shared_memory(共同记忆) | agreement(约定)
+- temporal_scope: current(当前) | past(过去) | ongoing(持续)
+
+要求：单一事实、一句话表达，不混合多个无关信息；confidence 低于 0.5 的条目会被降级为无类别。
+
 请以 JSON 格式返回：
-{{"reflection": "你的反思洞察", "entity": "master/neko/relationship"}}""",
+{{"reflection": "你的反思洞察", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
     'en': """Below are a series of extracted facts about {LANLAN_NAME} and {MASTER_NAME}:
 
 ======以下为事实======
@@ -1207,8 +1215,16 @@ Determine which entity the reflection primarily concerns:
 - "neko": primarily about {LANLAN_NAME}'s self-perception
 - "relationship": about the dynamics between them
 
+Also provide a semantic relation_type (must match the entity), a confidence (0.0–1.0), and a temporal_scope:
+- master: preference | trait | habit | identity | emotional | boundary
+- neko: self_awareness | learned | role_note
+- relationship: dynamic | milestone | tension | shared_memory | agreement
+- temporal_scope: current | past | ongoing
+
+Requirements: express a single fact in one sentence; do not mix unrelated information. Entries with confidence < 0.5 are demoted to uncategorized.
+
 Return in JSON format:
-{{"reflection": "your reflective insight", "entity": "master/neko/relationship"}}""",
+{{"reflection": "your reflective insight", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
     'ja': """以下は {LANLAN_NAME} と {MASTER_NAME} に関する一連の抽出済み事実です：
 
 ======以下为事实======
@@ -1223,8 +1239,16 @@ Return in JSON format:
 - "neko": 主に {LANLAN_NAME} の自己認識について
 - "relationship": 二人の関係の動態について
 
+さらに意味カテゴリ relation_type（entity と整合）、信頼度 confidence (0.0–1.0)、時間範囲 temporal_scope も付けてください：
+- master: preference | trait | habit | identity | emotional | boundary
+- neko: self_awareness | learned | role_note
+- relationship: dynamic | milestone | tension | shared_memory | agreement
+- temporal_scope: current | past | ongoing
+
+要件：一つの事実を一文で表現し、無関係な情報を混ぜない。confidence が 0.5 未満のものは無カテゴリに降格されます。
+
 JSON形式で返してください：
-{{"reflection": "あなたの反省的洞察", "entity": "master/neko/relationship"}}""",
+{{"reflection": "あなたの反省的洞察", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
     'ko': """다음은 {LANLAN_NAME}과 {MASTER_NAME}에 대해 추출된 일련의 사실입니다:
 
 ======以下为事实======
@@ -1239,8 +1263,16 @@ JSON形式で返してください：
 - "neko": 주로 {LANLAN_NAME}의 자기 인식에 대해
 - "relationship": 두 사람 사이의 관계 동태에 대해
 
+또한 의미 범주 relation_type(entity와 일치해야 함), 신뢰도 confidence(0.0–1.0), 시간 범위 temporal_scope를 함께 제공해 주세요:
+- master: preference | trait | habit | identity | emotional | boundary
+- neko: self_awareness | learned | role_note
+- relationship: dynamic | milestone | tension | shared_memory | agreement
+- temporal_scope: current | past | ongoing
+
+요구사항: 단일 사실을 한 문장으로 표현하고 관련 없는 정보를 섞지 마세요. confidence가 0.5 미만이면 무분류로 강등됩니다.
+
 JSON 형식으로 반환해 주세요:
-{{"reflection": "당신의 반성적 통찰", "entity": "master/neko/relationship"}}""",
+{{"reflection": "당신의 반성적 통찰", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
     'ru': """Ниже представлена серия извлечённых фактов о {LANLAN_NAME} и {MASTER_NAME}:
 
 ======以下为事实======
@@ -1255,8 +1287,16 @@ JSON 형식으로 반환해 주세요:
 - "neko": в основном о самовосприятии {LANLAN_NAME}
 - "relationship": о динамике отношений между ними
 
+Также укажите семантическую категорию relation_type (должна соответствовать entity), уверенность confidence (0.0–1.0) и временной охват temporal_scope:
+- master: preference | trait | habit | identity | emotional | boundary
+- neko: self_awareness | learned | role_note
+- relationship: dynamic | milestone | tension | shared_memory | agreement
+- temporal_scope: current | past | ongoing
+
+Требования: один факт в одном предложении, без смешения не связанных сведений. Записи с confidence < 0.5 понижаются до «без категории».
+
 Верните в формате JSON:
-{{"reflection": "ваше рефлексивное наблюдение", "entity": "master/neko/relationship"}}""",
+{{"reflection": "ваше рефлексивное наблюдение", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
 }
 
 

--- a/config/prompts_memory.py
+++ b/config/prompts_memory.py
@@ -1191,16 +1191,16 @@ REFLECTION_PROMPT = {
 - "neko": 主要关于 {LANLAN_NAME} 的自我认知
 - "relationship": 关于两人之间的关系动态
 
-请同时给出该反思的语义类别 relation_type（必须与 entity 匹配）、置信度 confidence (0.0–1.0)，以及时间范围 temporal_scope：
+请同时给出该反思的语义类别 relation_type（必须与 entity 匹配），以及时间范围 temporal_scope：
 - master 可用: preference(偏好) | trait(性格) | habit(习惯) | identity(身份) | emotional(情感) | boundary(边界)
 - neko 可用: self_awareness(自我认知) | learned(习得行为) | role_note(角色备注)
 - relationship 可用: dynamic(互动模式) | milestone(里程碑) | tension(摩擦) | shared_memory(共同记忆) | agreement(约定)
 - temporal_scope: current(当前) | past(过去) | ongoing(持续)
 
-要求：紧扣单一观察或模式，不要把多个无关事实混在一起；长度保持在 2-3 句简短洞察内即可。confidence 低于 0.5 的条目会被降级为无类别。
+要求：紧扣单一观察或模式，不要把多个无关事实混在一起；长度保持在 2-3 句简短洞察内即可。
 
 请以 JSON 格式返回：
-{{"reflection": "你的反思洞察", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
+{{"reflection": "你的反思洞察", "entity": "master/neko/relationship", "relation_type": "preference", "temporal_scope": "current"}}""",
     'en': """Below are a series of extracted facts about {LANLAN_NAME} and {MASTER_NAME}:
 
 ======以下为事实======
@@ -1215,16 +1215,16 @@ Determine which entity the reflection primarily concerns:
 - "neko": primarily about {LANLAN_NAME}'s self-perception
 - "relationship": about the dynamics between them
 
-Also provide a semantic relation_type (must match the entity), a confidence (0.0–1.0), and a temporal_scope:
+Also provide a semantic relation_type (must match the entity) and a temporal_scope:
 - master: preference | trait | habit | identity | emotional | boundary
 - neko: self_awareness | learned | role_note
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-Requirements: stay focused on a single observation or pattern; do not mix unrelated facts. The 2-3-sentence length guidance above still applies. Entries with confidence < 0.5 are demoted to uncategorized.
+Requirements: stay focused on a single observation or pattern; do not mix unrelated facts. The 2-3-sentence length guidance above still applies.
 
 Return in JSON format:
-{{"reflection": "your reflective insight", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
+{{"reflection": "your reflective insight", "entity": "master/neko/relationship", "relation_type": "preference", "temporal_scope": "current"}}""",
     'ja': """以下は {LANLAN_NAME} と {MASTER_NAME} に関する一連の抽出済み事実です：
 
 ======以下为事实======
@@ -1239,16 +1239,16 @@ Return in JSON format:
 - "neko": 主に {LANLAN_NAME} の自己認識について
 - "relationship": 二人の関係の動態について
 
-さらに意味カテゴリ relation_type（entity と整合）、信頼度 confidence (0.0–1.0)、時間範囲 temporal_scope も付けてください：
+さらに意味カテゴリ relation_type（entity と整合）と時間範囲 temporal_scope も付けてください：
 - master: preference | trait | habit | identity | emotional | boundary
 - neko: self_awareness | learned | role_note
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-要件：単一の観察やパターンに集中し、無関係な事実を混ぜないこと。長さは先に示した 2-3 文の範囲を維持。confidence が 0.5 未満のものは無カテゴリに降格されます。
+要件：単一の観察やパターンに集中し、無関係な事実を混ぜないこと。長さは先に示した 2-3 文の範囲を維持。
 
 JSON形式で返してください：
-{{"reflection": "あなたの反省的洞察", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
+{{"reflection": "あなたの反省的洞察", "entity": "master/neko/relationship", "relation_type": "preference", "temporal_scope": "current"}}""",
     'ko': """다음은 {LANLAN_NAME}과 {MASTER_NAME}에 대해 추출된 일련의 사실입니다:
 
 ======以下为事实======
@@ -1263,16 +1263,16 @@ JSON形式で返してください：
 - "neko": 주로 {LANLAN_NAME}의 자기 인식에 대해
 - "relationship": 두 사람 사이의 관계 동태에 대해
 
-또한 의미 범주 relation_type(entity와 일치해야 함), 신뢰도 confidence(0.0–1.0), 시간 범위 temporal_scope를 함께 제공해 주세요:
+또한 의미 범주 relation_type(entity와 일치해야 함)과 시간 범위 temporal_scope를 함께 제공해 주세요:
 - master: preference | trait | habit | identity | emotional | boundary
 - neko: self_awareness | learned | role_note
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-요구사항: 단일 관찰 또는 패턴에 집중하고 관련 없는 사실을 섞지 마세요. 위의 2-3문장 길이 지침은 그대로 유지합니다. confidence가 0.5 미만이면 무분류로 강등됩니다.
+요구사항: 단일 관찰 또는 패턴에 집중하고 관련 없는 사실을 섞지 마세요. 위의 2-3문장 길이 지침은 그대로 유지합니다.
 
 JSON 형식으로 반환해 주세요:
-{{"reflection": "당신의 반성적 통찰", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
+{{"reflection": "당신의 반성적 통찰", "entity": "master/neko/relationship", "relation_type": "preference", "temporal_scope": "current"}}""",
     'ru': """Ниже представлена серия извлечённых фактов о {LANLAN_NAME} и {MASTER_NAME}:
 
 ======以下为事实======
@@ -1287,16 +1287,16 @@ JSON 형식으로 반환해 주세요:
 - "neko": в основном о самовосприятии {LANLAN_NAME}
 - "relationship": о динамике отношений между ними
 
-Также укажите семантическую категорию relation_type (должна соответствовать entity), уверенность confidence (0.0–1.0) и временной охват temporal_scope:
+Также укажите семантическую категорию relation_type (должна соответствовать entity) и временной охват temporal_scope:
 - master: preference | trait | habit | identity | emotional | boundary
 - neko: self_awareness | learned | role_note
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-Требования: сосредоточьтесь на одном наблюдении или паттерне, не смешивайте не связанные факты. Указанная выше длина в 2-3 предложения сохраняется. Записи с confidence < 0.5 понижаются до «без категории».
+Требования: сосредоточьтесь на одном наблюдении или паттерне, не смешивайте не связанные факты. Указанная выше длина в 2-3 предложения сохраняется.
 
 Верните в формате JSON:
-{{"reflection": "ваше рефлексивное наблюдение", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
+{{"reflection": "ваше рефлексивное наблюдение", "entity": "master/neko/relationship", "relation_type": "preference", "temporal_scope": "current"}}""",
 }
 
 

--- a/config/prompts_memory.py
+++ b/config/prompts_memory.py
@@ -1197,7 +1197,7 @@ REFLECTION_PROMPT = {
 - relationship 可用: dynamic(互动模式) | milestone(里程碑) | tension(摩擦) | shared_memory(共同记忆) | agreement(约定)
 - temporal_scope: current(当前) | past(过去) | ongoing(持续)
 
-要求：单一事实、一句话表达，不混合多个无关信息；confidence 低于 0.5 的条目会被降级为无类别。
+要求：紧扣单一观察或模式，不要把多个无关事实混在一起；长度保持在 2-3 句简短洞察内即可。confidence 低于 0.5 的条目会被降级为无类别。
 
 请以 JSON 格式返回：
 {{"reflection": "你的反思洞察", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
@@ -1221,7 +1221,7 @@ Also provide a semantic relation_type (must match the entity), a confidence (0.0
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-Requirements: express a single fact in one sentence; do not mix unrelated information. Entries with confidence < 0.5 are demoted to uncategorized.
+Requirements: stay focused on a single observation or pattern; do not mix unrelated facts. The 2-3-sentence length guidance above still applies. Entries with confidence < 0.5 are demoted to uncategorized.
 
 Return in JSON format:
 {{"reflection": "your reflective insight", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
@@ -1245,7 +1245,7 @@ Return in JSON format:
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-要件：一つの事実を一文で表現し、無関係な情報を混ぜない。confidence が 0.5 未満のものは無カテゴリに降格されます。
+要件：単一の観察やパターンに集中し、無関係な事実を混ぜないこと。長さは先に示した 2-3 文の範囲を維持。confidence が 0.5 未満のものは無カテゴリに降格されます。
 
 JSON形式で返してください：
 {{"reflection": "あなたの反省的洞察", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
@@ -1269,7 +1269,7 @@ JSON形式で返してください：
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-요구사항: 단일 사실을 한 문장으로 표현하고 관련 없는 정보를 섞지 마세요. confidence가 0.5 미만이면 무분류로 강등됩니다.
+요구사항: 단일 관찰 또는 패턴에 집중하고 관련 없는 사실을 섞지 마세요. 위의 2-3문장 길이 지침은 그대로 유지합니다. confidence가 0.5 미만이면 무분류로 강등됩니다.
 
 JSON 형식으로 반환해 주세요:
 {{"reflection": "당신의 반성적 통찰", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",
@@ -1293,7 +1293,7 @@ JSON 형식으로 반환해 주세요:
 - relationship: dynamic | milestone | tension | shared_memory | agreement
 - temporal_scope: current | past | ongoing
 
-Требования: один факт в одном предложении, без смешения не связанных сведений. Записи с confidence < 0.5 понижаются до «без категории».
+Требования: сосредоточьтесь на одном наблюдении или паттерне, не смешивайте не связанные факты. Указанная выше длина в 2-3 предложения сохраняется. Записи с confidence < 0.5 понижаются до «без категории».
 
 Верните в формате JSON:
 {{"reflection": "ваше рефлексивное наблюдение", "entity": "master/neko/relationship", "relation_type": "preference", "confidence": 0.85, "temporal_scope": "current"}}""",

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1615,27 +1615,46 @@ class PersonaManager:
             section_facts = self._get_section_facts(persona, entity)
 
             if action == 'replace':
+                # `replace` means "new observation is an update/correction to
+                # the old memory" — semantically an in-place edit, not a
+                # fresh insertion. We update `text` + extend the version
+                # chain but **preserve** id / source / source_id / evidence
+                # counters (reinforcement, disputation, sub_zero_days) /
+                # recent_mentions / merged_from_ids so confirm/dispute state
+                # and provenance survive the rewrite. Rebuilding via
+                # `_normalize_entry(merged_text)` would wipe all of that,
+                # reducing a confirmed persona entry to a blank slate.
+                history_entry = {
+                    'text': old_text,
+                    'replaced_at': datetime.now().isoformat(),
+                    'reason': 'correction',
+                    # `source_fact_id` stays None: the pending-correction
+                    # record has no upstream fact id today. Follow-up work
+                    # can plumb one through _queue_correction without
+                    # changing this structure.
+                    'source_fact_id': None,
+                }
                 for j, existing in enumerate(section_facts):
                     et = existing.get('text', '') if isinstance(existing, dict) else str(existing)
                     if et == old_text:
-                        new_entry = self._normalize_entry(merged_text)
-                        # Fact version chain (RFC §2): preserve the chain from
-                        # the replaced entry, then record the old text itself.
-                        # `source_fact_id` is None because the pending-correction
-                        # record has no upstream fact id today; future work can
-                        # plumb one through _queue_correction without changing
-                        # this structure.
-                        prior_history = (
-                            existing.get('version_history', []) or []
-                            if isinstance(existing, dict) else []
-                        )
-                        new_entry['version_history'] = list(prior_history) + [{
-                            'text': old_text,
-                            'replaced_at': datetime.now().isoformat(),
-                            'reason': 'correction',
-                            'source_fact_id': None,
-                        }]
-                        section_facts[j] = new_entry
+                        if isinstance(existing, dict):
+                            prior_history = existing.get('version_history', []) or []
+                            existing['text'] = merged_text
+                            existing['version_history'] = list(prior_history) + [history_entry]
+                            # Text changed → invalidate the derived
+                            # token-count cache so the next render recomputes
+                            # against the new text instead of serving a
+                            # stale count tied to old_text's sha.
+                            existing['token_count'] = None
+                            existing['token_count_text_sha256'] = None
+                            existing['token_count_tokenizer'] = None
+                            section_facts[j] = self._normalize_entry(existing)
+                        else:
+                            # Legacy str entry — no metadata to preserve;
+                            # migrate to dict form and seed the chain.
+                            new_entry = self._normalize_entry(merged_text)
+                            new_entry['version_history'] = [history_entry]
+                            section_facts[j] = new_entry
                         break
             elif action == 'keep_new':
                 section_facts[:] = [

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -714,6 +714,11 @@ class PersonaManager:
             'token_count': None,
             'token_count_text_sha256': None,
             'token_count_tokenizer': None,
+            # Fact version chain (RFC memory-enhancements §2). Populated in
+            # resolve_corrections' replace branch so "主人以前住东京，后来搬到
+            # 大阪" stays traceable. Each item: {text, replaced_at, reason,
+            # source_fact_id}. None/empty list means no version history.
+            'version_history': [],
         }
         if isinstance(entry, str):
             d = dict(defaults)
@@ -1613,7 +1618,24 @@ class PersonaManager:
                 for j, existing in enumerate(section_facts):
                     et = existing.get('text', '') if isinstance(existing, dict) else str(existing)
                     if et == old_text:
-                        section_facts[j] = self._normalize_entry(merged_text)
+                        new_entry = self._normalize_entry(merged_text)
+                        # Fact version chain (RFC §2): preserve the chain from
+                        # the replaced entry, then record the old text itself.
+                        # `source_fact_id` is None because the pending-correction
+                        # record has no upstream fact id today; future work can
+                        # plumb one through _queue_correction without changing
+                        # this structure.
+                        prior_history = (
+                            existing.get('version_history', []) or []
+                            if isinstance(existing, dict) else []
+                        )
+                        new_entry['version_history'] = list(prior_history) + [{
+                            'text': old_text,
+                            'replaced_at': datetime.now().isoformat(),
+                            'reason': 'correction',
+                            'source_fact_id': None,
+                        }]
+                        section_facts[j] = new_entry
                         break
             elif action == 'keep_new':
                 section_facts[:] = [

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -71,6 +71,78 @@ REFLECTION_TERMINAL_STATUSES = frozenset({
     'promoted', 'denied', 'archived', 'merged', 'promote_blocked',
 })
 
+# ── Reflection ontology (RFC memory-enhancements §3) ────────────────
+# Constrains the semantic category of each synthesized reflection so
+# same-(entity, relation_type) entries are naturally mergeable and the
+# render path can group by role-of-information instead of flat-listing.
+RELATION_TYPES = {
+    # master — facts about the human user
+    'preference':     '偏好/喜好',
+    'trait':          '性格/特征',
+    'habit':          '习惯/日常',
+    'identity':       '身份/背景',
+    'emotional':      '情感状态',
+    'boundary':       '边界/禁忌',
+    # neko — AI self-model
+    'self_awareness': '自我认知',
+    'learned':        '习得行为',
+    'role_note':      '角色备注',
+    # relationship — the dyad
+    'dynamic':        '互动模式',
+    'milestone':      '关系里程碑',
+    'tension':        '摩擦/冲突',
+    'shared_memory': '共同记忆',
+    'agreement':     '约定/共识',
+}
+
+ENTITY_RELATION_MAP: dict[str, frozenset[str]] = {
+    'master':       frozenset({'preference', 'trait', 'habit', 'identity', 'emotional', 'boundary'}),
+    'neko':         frozenset({'self_awareness', 'learned', 'role_note'}),
+    'relationship': frozenset({'dynamic', 'milestone', 'tension', 'shared_memory', 'agreement'}),
+}
+
+TEMPORAL_SCOPES = frozenset({'current', 'past', 'ongoing'})
+
+# Minimum LLM self-rated confidence to accept a reflection outright.
+# Below this the ontology fields are stripped (degraded to null) but the
+# reflection text itself still lands — RFC §3.3.6 "不把本体约束做成硬失败".
+MIN_REFLECTION_CONFIDENCE = 0.5
+
+# Soft cap on reflection text length. Beyond this, the ontology fields
+# are stripped because the text is likely a compound/multi-fact statement
+# (§3.3.4 validator). The reflection itself still persists unchanged so
+# no information is lost.
+MAX_REFLECTION_TEXT_CHARS = 200
+
+
+def _validate_reflection_ontology(
+    entity: str,
+    relation_type: str | None,
+    confidence: float | None,
+    temporal_scope: str | None,
+    text: str,
+) -> tuple[bool, str]:
+    """Returns (is_valid, reason). Invalid entries keep their text but
+    have relation_type/confidence/temporal_scope stripped — see caller."""
+    if relation_type is not None:
+        if relation_type not in RELATION_TYPES:
+            return False, f'unknown relation_type: {relation_type!r}'
+        allowed = ENTITY_RELATION_MAP.get(entity, frozenset())
+        if relation_type not in allowed:
+            return False, f'{relation_type!r} not valid for entity {entity!r}'
+    if confidence is not None:
+        try:
+            c = float(confidence)
+        except (TypeError, ValueError):
+            return False, f'non-numeric confidence: {confidence!r}'
+        if c < MIN_REFLECTION_CONFIDENCE:
+            return False, f'low confidence: {c}'
+    if temporal_scope is not None and temporal_scope not in TEMPORAL_SCOPES:
+        return False, f'unknown temporal_scope: {temporal_scope!r}'
+    if len(text) > MAX_REFLECTION_TEXT_CHARS:
+        return False, f'text too long: {len(text)} chars (compound risk)'
+    return True, 'ok'
+
 
 def _reflection_id_from_facts(source_fact_ids: list[str]) -> str:
     """根据 source fact ids 生成确定性 reflection id（P1 幂等性核心）。
@@ -226,6 +298,12 @@ class ReflectionEngine:
             'recent_mentions': [],
             'suppress': False,
             'suppressed_at': None,
+            # Ontology fields (RFC memory-enhancements §3). All optional —
+            # legacy entries and validation-stripped entries both read None.
+            'relation_type': None,
+            'confidence': None,
+            'subject': None,
+            'temporal_scope': None,
         }
         for k, v in defaults.items():
             entry.setdefault(k, v)
@@ -567,6 +645,38 @@ class ReflectionEngine:
             reflection_entity = result.get('entity', 'relationship')
             if reflection_entity not in ('master', 'neko', 'relationship'):
                 reflection_entity = 'relationship'
+
+            # Ontology fields (RFC §3). Missing fields are tolerated — we
+            # only enforce consistency when the LLM does fill them in, so
+            # older prompts stay compatible. Validation failure degrades
+            # to null (soft fail per §3.3.6) rather than dropping the whole
+            # reflection.
+            rel_type = result.get('relation_type')
+            if rel_type is not None and not isinstance(rel_type, str):
+                rel_type = None
+            conf_raw = result.get('confidence')
+            try:
+                confidence = float(conf_raw) if conf_raw is not None else None
+            except (TypeError, ValueError):
+                confidence = None
+            temporal = result.get('temporal_scope')
+            if temporal is not None and not isinstance(temporal, str):
+                temporal = None
+            subject = result.get('subject')
+            if subject is not None and not isinstance(subject, str):
+                subject = None
+
+            ok, reason = _validate_reflection_ontology(
+                reflection_entity, rel_type, confidence, temporal, reflection_text,
+            )
+            if not ok:
+                logger.info(
+                    f"[Reflection] ontology 验证不通过({reason})，降级为 null: "
+                    f"entity={reflection_entity} rel_type={rel_type}"
+                )
+                rel_type = None
+                confidence = None
+                temporal = None
         except Exception as e:
             logger.warning(f"[Reflection] 合成失败: {e}")
             return []
@@ -599,6 +709,13 @@ class ReflectionEngine:
             'next_eligible_at': (now + timedelta(minutes=REFLECTION_COOLDOWN_MINUTES)).isoformat(),
             'reinforcement': initial_rein,
             'rein_last_signal_at': now_iso if initial_rein > 0 else None,
+            # Ontology (RFC §3). May be None if the model omitted them or
+            # validation demoted them. Callers that want to filter or group
+            # by relation_type should treat None as "uncategorized".
+            'relation_type': rel_type,
+            'confidence': confidence,
+            'temporal_scope': temporal,
+            'subject': subject,
         })
 
         # 再次 load：LLM 调用期间可能有并发 synth；用最新 list 做 id dedup 追加

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
 import os
 import threading
 from datetime import datetime, timedelta
@@ -135,6 +136,15 @@ def _validate_reflection_ontology(
             c = float(confidence)
         except (TypeError, ValueError):
             return False, f'non-numeric confidence: {confidence!r}'
+        # Reject NaN / ±Inf before range-checking. Non-finite floats would
+        # otherwise be silently kept and, once persisted, emit non-standard
+        # JSON literals (NaN/Infinity) that break strict parsers downstream.
+        if not math.isfinite(c):
+            return False, f'non-finite confidence: {c}'
+        # Prompt contract is 0.0–1.0; clamp out-of-range values to invalid so
+        # a hallucinated "1.7" or "-0.2" doesn't slip through as metadata.
+        if c < 0.0 or c > 1.0:
+            return False, f'confidence out of range [0.0, 1.0]: {c}'
         if c < MIN_REFLECTION_CONFIDENCE:
             return False, f'low confidence: {c}'
     if temporal_scope is not None and temporal_scope not in TEMPORAL_SCOPES:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -684,9 +684,14 @@ class ReflectionEngine:
                     f"[Reflection] ontology 验证不通过({reason})，降级为 null: "
                     f"entity={reflection_entity} rel_type={rel_type}"
                 )
+                # Strip the entire ontology tuple — keeping `subject` while
+                # dropping the rest would leave a half-structured record
+                # (no class but still a subject label), which downstream
+                # grouping/filtering can't interpret consistently.
                 rel_type = None
                 confidence = None
                 temporal = None
+                subject = None
         except Exception as e:
             logger.warning(f"[Reflection] 合成失败: {e}")
             return []

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -75,19 +75,29 @@ REFLECTION_TERMINAL_STATUSES = frozenset({
 # Constrains the semantic category of each synthesized reflection so
 # same-(entity, relation_type) entries are naturally mergeable and the
 # render path can group by role-of-information instead of flat-listing.
+#
+# The schema is **kind-based, not name-based**: every entity gets mapped
+# to one of three kinds (user / character / relationship) and the
+# allowed relation_type set follows from the kind. Today we have one
+# user (`master`) and one character (`neko`) — but for future group-chat
+# extensions, every additional human plays role-kind `user` and reuses
+# the same relation set, every additional AI character plays role-kind
+# `character`, and a single shared `relationship` slot covers the
+# group-as-a-whole. New `entity` names plug in without touching
+# RELATION_TYPES or the prompt enum.
 RELATION_TYPES = {
-    # master — facts about the human user
+    # `user` kind — facts about a human participant
     'preference':     '偏好/喜好',
     'trait':          '性格/特征',
     'habit':          '习惯/日常',
     'identity':       '身份/背景',
     'emotional':      '情感状态',
     'boundary':       '边界/禁忌',
-    # neko — AI self-model
+    # `character` kind — AI self-model
     'self_awareness': '自我认知',
     'learned':        '习得行为',
     'role_note':      '角色备注',
-    # relationship — the dyad
+    # `relationship` kind — the group as a whole (1v1 today, NvM later)
     'dynamic':        '互动模式',
     'milestone':      '关系里程碑',
     'tension':        '摩擦/冲突',
@@ -95,11 +105,41 @@ RELATION_TYPES = {
     'agreement':     '约定/共识',
 }
 
-ENTITY_RELATION_MAP: dict[str, frozenset[str]] = {
-    'master':       frozenset({'preference', 'trait', 'habit', 'identity', 'emotional', 'boundary'}),
-    'neko':         frozenset({'self_awareness', 'learned', 'role_note'}),
+# Entity → kind mapping. New entity names default to `user` kind so that
+# adding "guest_alice" or "groupmate_bob" to the chat just works without
+# a schema migration. Override here only when an entity needs a non-user
+# template (i.e. another AI character, or a relationship aggregate).
+ENTITY_KINDS: dict[str, str] = {
+    'master':       'user',
+    'neko':         'character',
+    'relationship': 'relationship',
+}
+
+# Allowed relation_type set per kind. This is the actual source of truth
+# for validation; ENTITY_KINDS is the indirection that lets us add new
+# entities without expanding this table.
+KIND_RELATION_MAP: dict[str, frozenset[str]] = {
+    'user':         frozenset({'preference', 'trait', 'habit', 'identity', 'emotional', 'boundary'}),
+    'character':    frozenset({'self_awareness', 'learned', 'role_note'}),
     'relationship': frozenset({'dynamic', 'milestone', 'tension', 'shared_memory', 'agreement'}),
 }
+
+
+def _entity_kind(entity: str) -> str:
+    """Resolve an entity name to its ontology kind.
+
+    Unknown entities default to ``user`` — the safest fallback because
+    user-kind has the richest relation set, and future group members are
+    overwhelmingly likely to be additional human participants. Existing
+    callers ignore this default by passing the canonical entity names
+    (master / neko / relationship) we already register above.
+    """
+    return ENTITY_KINDS.get(entity, 'user')
+
+
+def _allowed_relation_types(entity: str) -> frozenset[str]:
+    return KIND_RELATION_MAP.get(_entity_kind(entity), frozenset())
+
 
 TEMPORAL_SCOPES = frozenset({'current', 'past', 'ongoing'})
 
@@ -120,9 +160,13 @@ def _validate_reflection_ontology(
     if relation_type is not None:
         if relation_type not in RELATION_TYPES:
             return False, f'unknown relation_type: {relation_type!r}'
-        allowed = ENTITY_RELATION_MAP.get(entity, frozenset())
+        allowed = _allowed_relation_types(entity)
         if relation_type not in allowed:
-            return False, f'{relation_type!r} not valid for entity {entity!r}'
+            return (
+                False,
+                f'{relation_type!r} not valid for entity {entity!r} '
+                f'(kind={_entity_kind(entity)!r})',
+            )
     if temporal_scope is not None and temporal_scope not in TEMPORAL_SCOPES:
         return False, f'unknown temporal_scope: {temporal_scope!r}'
     if len(text) > MAX_REFLECTION_TEXT_CHARS:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import math
 import os
 import threading
 from datetime import datetime, timedelta
@@ -104,49 +103,26 @@ ENTITY_RELATION_MAP: dict[str, frozenset[str]] = {
 
 TEMPORAL_SCOPES = frozenset({'current', 'past', 'ongoing'})
 
-# Minimum LLM self-rated confidence to accept a reflection outright.
-# Below this the ontology fields are stripped (degraded to null) but the
-# reflection text itself still lands — RFC §3.3.6 "不把本体约束做成硬失败".
-MIN_REFLECTION_CONFIDENCE = 0.5
-
 # Soft cap on reflection text length. Beyond this, the ontology fields
-# are stripped because the text is likely a compound/multi-fact statement
-# (§3.3.4 validator). The reflection itself still persists unchanged so
-# no information is lost.
+# are stripped because the text is likely a compound/multi-fact statement.
+# The reflection itself still persists unchanged so no information is lost.
 MAX_REFLECTION_TEXT_CHARS = 200
 
 
 def _validate_reflection_ontology(
     entity: str,
     relation_type: str | None,
-    confidence: float | None,
     temporal_scope: str | None,
     text: str,
 ) -> tuple[bool, str]:
     """Returns (is_valid, reason). Invalid entries keep their text but
-    have relation_type/confidence/temporal_scope stripped — see caller."""
+    have relation_type/temporal_scope stripped — see caller."""
     if relation_type is not None:
         if relation_type not in RELATION_TYPES:
             return False, f'unknown relation_type: {relation_type!r}'
         allowed = ENTITY_RELATION_MAP.get(entity, frozenset())
         if relation_type not in allowed:
             return False, f'{relation_type!r} not valid for entity {entity!r}'
-    if confidence is not None:
-        try:
-            c = float(confidence)
-        except (TypeError, ValueError):
-            return False, f'non-numeric confidence: {confidence!r}'
-        # Reject NaN / ±Inf before range-checking. Non-finite floats would
-        # otherwise be silently kept and, once persisted, emit non-standard
-        # JSON literals (NaN/Infinity) that break strict parsers downstream.
-        if not math.isfinite(c):
-            return False, f'non-finite confidence: {c}'
-        # Prompt contract is 0.0–1.0; clamp out-of-range values to invalid so
-        # a hallucinated "1.7" or "-0.2" doesn't slip through as metadata.
-        if c < 0.0 or c > 1.0:
-            return False, f'confidence out of range [0.0, 1.0]: {c}'
-        if c < MIN_REFLECTION_CONFIDENCE:
-            return False, f'low confidence: {c}'
     if temporal_scope is not None and temporal_scope not in TEMPORAL_SCOPES:
         return False, f'unknown temporal_scope: {temporal_scope!r}'
     if len(text) > MAX_REFLECTION_TEXT_CHARS:
@@ -311,7 +287,6 @@ class ReflectionEngine:
             # Ontology fields (RFC memory-enhancements §3). All optional —
             # legacy entries and validation-stripped entries both read None.
             'relation_type': None,
-            'confidence': None,
             'subject': None,
             'temporal_scope': None,
         }
@@ -659,16 +634,10 @@ class ReflectionEngine:
             # Ontology fields (RFC §3). Missing fields are tolerated — we
             # only enforce consistency when the LLM does fill them in, so
             # older prompts stay compatible. Validation failure degrades
-            # to null (soft fail per §3.3.6) rather than dropping the whole
-            # reflection.
+            # to null (soft fail) rather than dropping the whole reflection.
             rel_type = result.get('relation_type')
             if rel_type is not None and not isinstance(rel_type, str):
                 rel_type = None
-            conf_raw = result.get('confidence')
-            try:
-                confidence = float(conf_raw) if conf_raw is not None else None
-            except (TypeError, ValueError):
-                confidence = None
             temporal = result.get('temporal_scope')
             if temporal is not None and not isinstance(temporal, str):
                 temporal = None
@@ -677,7 +646,7 @@ class ReflectionEngine:
                 subject = None
 
             ok, reason = _validate_reflection_ontology(
-                reflection_entity, rel_type, confidence, temporal, reflection_text,
+                reflection_entity, rel_type, temporal, reflection_text,
             )
             if not ok:
                 logger.info(
@@ -689,7 +658,6 @@ class ReflectionEngine:
                 # (no class but still a subject label), which downstream
                 # grouping/filtering can't interpret consistently.
                 rel_type = None
-                confidence = None
                 temporal = None
                 subject = None
         except Exception as e:
@@ -728,7 +696,6 @@ class ReflectionEngine:
             # validation demoted them. Callers that want to filter or group
             # by relation_type should treat None as "uncategorized".
             'relation_type': rel_type,
-            'confidence': confidence,
             'temporal_scope': temporal,
             'subject': subject,
         })

--- a/tests/unit/test_persona_version_history.py
+++ b/tests/unit/test_persona_version_history.py
@@ -4,8 +4,12 @@
 When resolve_corrections decides `replace`, the old text must be
 preserved in `version_history` on the replacing entry, chained across
 multiple corrections so temporal context (e.g., 主人以前住东京 → 搬到大阪)
-stays traceable."""
+stays traceable. `replace` is an in-place edit: id / source / evidence
+counters must survive the rewrite — only `text` and the history tail
+change."""
 from __future__ import annotations
+
+import json
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -42,11 +46,9 @@ def _install(tmpdir: str):
 
 
 def _make_llm_mock(payload: list[dict]):
-    """Return a fake chat-llm whose ainvoke yields `payload` as JSON."""
-    import json as _json
-
+    """Fake chat-llm whose ainvoke yields `payload` as JSON."""
     resp = MagicMock()
-    resp.content = _json.dumps(payload)
+    resp.content = json.dumps(payload)
 
     async def _ainvoke(*_args, **_kwargs):
         return resp
@@ -60,21 +62,29 @@ def _make_llm_mock(payload: list[dict]):
     return llm
 
 
+async def _seed_master_fact(pm, name: str, text: str, **overrides) -> dict:
+    """Append a fact to `name`'s master section via the public API and
+    return the stored dict so the test can mutate/inspect it."""
+    persona = await pm.aensure_persona(name)
+    entry = pm._normalize_entry(text)
+    entry.update(overrides)
+    pm._get_section_facts(persona, "master").append(entry)
+    await pm.asave_persona(name, persona)
+    # Re-read so callers see the on-disk normalized copy.
+    persona = await pm.aensure_persona(name)
+    return next(
+        e for e in pm._get_section_facts(persona, "master")
+        if isinstance(e, dict) and e.get("text") == text
+    )
+
+
 @pytest.mark.asyncio
 async def test_replace_records_old_text_in_version_history(tmp_path):
     """replace 动作必须把旧文本压进 version_history，新 entry 的 text 是 merged。"""
     pm, _ = _install(str(tmp_path))
+    await _seed_master_fact(pm, "小天", "主人住在东京")
 
-    # Seed persona with an existing entry that will be replaced.
-    persona = await pm._aensure_persona_locked("小天")
-    section = pm._get_section_facts(persona, "master")
-    section.append(pm._normalize_entry("主人住在东京"))
-    await pm.asave_persona("小天", persona)
-
-    # Queue a correction pair.
     await pm._aqueue_correction("小天", "主人住在东京", "主人住在大阪", "master")
-
-    # Mock the correction LLM: return `replace` with merged text.
     fake_llm = _make_llm_mock([{
         "index": 0, "action": "replace", "text": "主人后来搬到了大阪",
     }])
@@ -82,40 +92,33 @@ async def test_replace_records_old_text_in_version_history(tmp_path):
         resolved = await pm.resolve_corrections("小天")
     assert resolved == 1
 
-    # Verify persona state.
-    persona = await pm._aensure_persona_locked("小天")
+    persona = await pm.aensure_persona("小天")
     master_facts = pm._get_section_facts(persona, "master")
-    # The replaced entry should carry the merged text.
     target = next(e for e in master_facts if e.get("text") == "主人后来搬到了大阪")
     history = target.get("version_history") or []
     assert len(history) == 1
     assert history[0]["text"] == "主人住在东京"
     assert history[0]["reason"] == "correction"
-    assert history[0]["replaced_at"]  # ISO timestamp populated
+    assert history[0]["replaced_at"]
 
 
 @pytest.mark.asyncio
 async def test_replace_chains_history_across_multiple_corrections(tmp_path):
     """连续两次 replace：history 应保留全链路，不覆盖。"""
     pm, _ = _install(str(tmp_path))
+    await _seed_master_fact(pm, "小天", "主人住在东京")
 
-    persona = await pm._aensure_persona_locked("小天")
-    pm._get_section_facts(persona, "master").append(pm._normalize_entry("主人住在东京"))
-    await pm.asave_persona("小天", persona)
-
-    # First correction: 东京 → 大阪
     await pm._aqueue_correction("小天", "主人住在东京", "主人住在大阪", "master")
     fake_llm = _make_llm_mock([{"index": 0, "action": "replace", "text": "主人住在大阪"}])
     with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
         await pm.resolve_corrections("小天")
 
-    # Second correction: 大阪 → 福冈
     await pm._aqueue_correction("小天", "主人住在大阪", "主人住在福冈", "master")
     fake_llm = _make_llm_mock([{"index": 0, "action": "replace", "text": "主人住在福冈"}])
     with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
         await pm.resolve_corrections("小天")
 
-    persona = await pm._aensure_persona_locked("小天")
+    persona = await pm.aensure_persona("小天")
     master_facts = pm._get_section_facts(persona, "master")
     target = next(e for e in master_facts if e.get("text") == "主人住在福冈")
     history = target.get("version_history") or []
@@ -125,22 +128,83 @@ async def test_replace_chains_history_across_multiple_corrections(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_replace_preserves_id_source_and_evidence_metadata(tmp_path):
+    """CodeRabbit-flagged: `replace` must be in-place — id / source /
+    reinforcement / recent_mentions survive the text rewrite."""
+    pm, _ = _install(str(tmp_path))
+    await _seed_master_fact(
+        pm, "小天", "主人住在东京",
+        id="prom_ref_tokyo",
+        source="reflection",
+        source_id="ref_tokyo",
+        reinforcement=2.5,
+        disputation=0.5,
+        rein_last_signal_at="2026-04-01T10:00:00",
+        recent_mentions=["2026-04-20T10:00:00", "2026-04-21T11:00:00"],
+        user_fact_reinforce_count=3,
+    )
+
+    await pm._aqueue_correction("小天", "主人住在东京", "主人住在大阪", "master")
+    fake_llm = _make_llm_mock([{"index": 0, "action": "replace", "text": "主人住在大阪"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await pm.resolve_corrections("小天")
+
+    persona = await pm.aensure_persona("小天")
+    master_facts = pm._get_section_facts(persona, "master")
+    target = next(e for e in master_facts if e.get("text") == "主人住在大阪")
+    # Identity + provenance preserved.
+    assert target["id"] == "prom_ref_tokyo"
+    assert target["source"] == "reflection"
+    assert target["source_id"] == "ref_tokyo"
+    # Evidence counters preserved — a confirmed entry stays confirmed after
+    # a text correction; callers rely on this for rein/disp accounting.
+    assert target["reinforcement"] == pytest.approx(2.5)
+    assert target["disputation"] == pytest.approx(0.5)
+    assert target["rein_last_signal_at"] == "2026-04-01T10:00:00"
+    assert target["user_fact_reinforce_count"] == 3
+    assert target["recent_mentions"] == [
+        "2026-04-20T10:00:00", "2026-04-21T11:00:00",
+    ]
+    # History still records the old text.
+    assert target["version_history"][0]["text"] == "主人住在东京"
+
+
+@pytest.mark.asyncio
+async def test_replace_invalidates_token_count_cache(tmp_path):
+    """text 变了 → token_count / sha / tokenizer 三元组必须重置。"""
+    pm, _ = _install(str(tmp_path))
+    await _seed_master_fact(
+        pm, "小天", "主人住在东京",
+        token_count=7,
+        token_count_text_sha256="deadbeef" * 8,
+        token_count_tokenizer="tiktoken:o200k_base",
+    )
+
+    await pm._aqueue_correction("小天", "主人住在东京", "主人住在大阪", "master")
+    fake_llm = _make_llm_mock([{"index": 0, "action": "replace", "text": "主人住在大阪"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await pm.resolve_corrections("小天")
+
+    persona = await pm.aensure_persona("小天")
+    master_facts = pm._get_section_facts(persona, "master")
+    target = next(e for e in master_facts if e.get("text") == "主人住在大阪")
+    assert target["token_count"] is None
+    assert target["token_count_text_sha256"] is None
+    assert target["token_count_tokenizer"] is None
+
+
+@pytest.mark.asyncio
 async def test_non_replace_actions_do_not_record_version_history(tmp_path):
     """keep_new / keep_old / keep_both: 不写 version_history（§2 明确范围）。"""
     pm, _ = _install(str(tmp_path))
+    await _seed_master_fact(pm, "小天", "主人喜欢绿茶")
 
-    persona = await pm._aensure_persona_locked("小天")
-    pm._get_section_facts(persona, "master").append(pm._normalize_entry("主人喜欢绿茶"))
-    await pm.asave_persona("小天", persona)
-
-    # keep_new: replaces old without going through `replace` branch.
     await pm._aqueue_correction("小天", "主人喜欢绿茶", "主人喜欢红茶", "master")
     fake_llm = _make_llm_mock([{"index": 0, "action": "keep_new"}])
     with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
         await pm.resolve_corrections("小天")
 
-    persona = await pm._aensure_persona_locked("小天")
+    persona = await pm.aensure_persona("小天")
     master_facts = pm._get_section_facts(persona, "master")
     new_entry = next(e for e in master_facts if e.get("text") == "主人喜欢红茶")
-    # Default from _normalize_entry is []; keep_new must not populate it.
     assert new_entry.get("version_history") == []

--- a/tests/unit/test_persona_version_history.py
+++ b/tests/unit/test_persona_version_history.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for fact version chain (RFC memory-enhancements §2).
+
+When resolve_corrections decides `replace`, the old text must be
+preserved in `version_history` on the replacing entry, chained across
+multiple corrections so temporal context (e.g., 主人以前住东京 → 搬到大阪)
+stays traceable."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    return cm
+
+
+def _install(tmpdir: str):
+    from memory.event_log import EventLog
+    from memory.persona import PersonaManager
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.persona.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+    return pm, cm
+
+
+def _make_llm_mock(payload: list[dict]):
+    """Return a fake chat-llm whose ainvoke yields `payload` as JSON."""
+    import json as _json
+
+    resp = MagicMock()
+    resp.content = _json.dumps(payload)
+
+    async def _ainvoke(*_args, **_kwargs):
+        return resp
+
+    async def _aclose():
+        return None
+
+    llm = MagicMock()
+    llm.ainvoke = _ainvoke
+    llm.aclose = _aclose
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_replace_records_old_text_in_version_history(tmp_path):
+    """replace 动作必须把旧文本压进 version_history，新 entry 的 text 是 merged。"""
+    pm, _ = _install(str(tmp_path))
+
+    # Seed persona with an existing entry that will be replaced.
+    persona = await pm._aensure_persona_locked("小天")
+    section = pm._get_section_facts(persona, "master")
+    section.append(pm._normalize_entry("主人住在东京"))
+    await pm.asave_persona("小天", persona)
+
+    # Queue a correction pair.
+    await pm._aqueue_correction("小天", "主人住在东京", "主人住在大阪", "master")
+
+    # Mock the correction LLM: return `replace` with merged text.
+    fake_llm = _make_llm_mock([{
+        "index": 0, "action": "replace", "text": "主人后来搬到了大阪",
+    }])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await pm.resolve_corrections("小天")
+    assert resolved == 1
+
+    # Verify persona state.
+    persona = await pm._aensure_persona_locked("小天")
+    master_facts = pm._get_section_facts(persona, "master")
+    # The replaced entry should carry the merged text.
+    target = next(e for e in master_facts if e.get("text") == "主人后来搬到了大阪")
+    history = target.get("version_history") or []
+    assert len(history) == 1
+    assert history[0]["text"] == "主人住在东京"
+    assert history[0]["reason"] == "correction"
+    assert history[0]["replaced_at"]  # ISO timestamp populated
+
+
+@pytest.mark.asyncio
+async def test_replace_chains_history_across_multiple_corrections(tmp_path):
+    """连续两次 replace：history 应保留全链路，不覆盖。"""
+    pm, _ = _install(str(tmp_path))
+
+    persona = await pm._aensure_persona_locked("小天")
+    pm._get_section_facts(persona, "master").append(pm._normalize_entry("主人住在东京"))
+    await pm.asave_persona("小天", persona)
+
+    # First correction: 东京 → 大阪
+    await pm._aqueue_correction("小天", "主人住在东京", "主人住在大阪", "master")
+    fake_llm = _make_llm_mock([{"index": 0, "action": "replace", "text": "主人住在大阪"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await pm.resolve_corrections("小天")
+
+    # Second correction: 大阪 → 福冈
+    await pm._aqueue_correction("小天", "主人住在大阪", "主人住在福冈", "master")
+    fake_llm = _make_llm_mock([{"index": 0, "action": "replace", "text": "主人住在福冈"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await pm.resolve_corrections("小天")
+
+    persona = await pm._aensure_persona_locked("小天")
+    master_facts = pm._get_section_facts(persona, "master")
+    target = next(e for e in master_facts if e.get("text") == "主人住在福冈")
+    history = target.get("version_history") or []
+    assert [h["text"] for h in history] == ["主人住在东京", "主人住在大阪"]
+    for h in history:
+        assert h["reason"] == "correction"
+
+
+@pytest.mark.asyncio
+async def test_non_replace_actions_do_not_record_version_history(tmp_path):
+    """keep_new / keep_old / keep_both: 不写 version_history（§2 明确范围）。"""
+    pm, _ = _install(str(tmp_path))
+
+    persona = await pm._aensure_persona_locked("小天")
+    pm._get_section_facts(persona, "master").append(pm._normalize_entry("主人喜欢绿茶"))
+    await pm.asave_persona("小天", persona)
+
+    # keep_new: replaces old without going through `replace` branch.
+    await pm._aqueue_correction("小天", "主人喜欢绿茶", "主人喜欢红茶", "master")
+    fake_llm = _make_llm_mock([{"index": 0, "action": "keep_new"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await pm.resolve_corrections("小天")
+
+    persona = await pm._aensure_persona_locked("小天")
+    master_facts = pm._get_section_facts(persona, "master")
+    new_entry = next(e for e in master_facts if e.get("text") == "主人喜欢红茶")
+    # Default from _normalize_entry is []; keep_new must not populate it.
+    assert new_entry.get("version_history") == []

--- a/tests/unit/test_reflection_ontology.py
+++ b/tests/unit/test_reflection_ontology.py
@@ -2,9 +2,10 @@
 """Unit tests for reflection ontology constraints (RFC memory-enhancements §3).
 
 The synthesize flow parses relation_type / temporal_scope from the LLM
-response and validates them against RELATION_TYPES / ENTITY_RELATION_MAP.
-Invalid fields degrade to None (soft fail) rather than dropping the
-whole reflection — the text itself is always preserved."""
+response and validates them against the kind-indexed
+RELATION_TYPES / KIND_RELATION_MAP (resolved via ENTITY_KINDS). Invalid
+fields degrade to None (soft fail) rather than dropping the whole
+reflection — the text itself is always preserved."""
 from __future__ import annotations
 
 import json
@@ -123,6 +124,54 @@ def test_validate_tolerates_missing_optional_fields():
     from memory.reflection import _validate_reflection_ontology
     ok, _ = _validate_reflection_ontology("master", None, None, "主人喜欢猫")
     assert ok is True
+
+
+# ── kind-based ontology (group-chat readiness) ─────────────────────
+
+
+def test_entity_kind_resolves_canonical_entities():
+    """master/neko/relationship resolve to their declared kinds."""
+    from memory.reflection import _entity_kind
+    assert _entity_kind("master") == "user"
+    assert _entity_kind("neko") == "character"
+    assert _entity_kind("relationship") == "relationship"
+
+
+def test_unknown_entity_defaults_to_user_kind():
+    """Future group members (e.g. 'guest_alice') should auto-inherit the
+    user template without requiring a code change to RELATION_TYPES."""
+    from memory.reflection import _allowed_relation_types, _entity_kind
+    assert _entity_kind("guest_alice") == "user"
+    allowed = _allowed_relation_types("guest_alice")
+    # Same set as `master`, since both are user-kind.
+    assert "preference" in allowed
+    assert "trait" in allowed
+    assert "habit" in allowed
+    # Must NOT bleed in character-kind or relationship-kind types.
+    assert "self_awareness" not in allowed
+    assert "dynamic" not in allowed
+
+
+def test_validate_accepts_unknown_user_kind_entity():
+    """Validator must let a hypothetical group-chat user use the user
+    relation set without a schema migration."""
+    from memory.reflection import _validate_reflection_ontology
+    ok, _ = _validate_reflection_ontology(
+        "guest_alice", "preference", "current", "alice 喜欢咖啡",
+    )
+    assert ok is True
+
+
+def test_validate_rejects_kind_mismatch_with_helpful_reason():
+    """Reason string includes resolved kind so debugging group-chat
+    misclassification doesn't require digging into the map."""
+    from memory.reflection import _validate_reflection_ontology
+    ok, reason = _validate_reflection_ontology(
+        "neko", "preference", "current", "x",
+    )
+    assert ok is False
+    assert "kind=" in reason
+    assert "character" in reason
 
 
 # ── synthesize integration ─────────────────────────────────────────

--- a/tests/unit/test_reflection_ontology.py
+++ b/tests/unit/test_reflection_ontology.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 """Unit tests for reflection ontology constraints (RFC memory-enhancements §3).
 
-The synthesize flow parses relation_type / confidence / temporal_scope from
-the LLM response and validates them against RELATION_TYPES /
-ENTITY_RELATION_MAP / MIN_REFLECTION_CONFIDENCE. Invalid or low-confidence
-fields degrade to None (soft fail per §3.3.6) — the reflection text itself
-is preserved."""
+The synthesize flow parses relation_type / temporal_scope from the LLM
+response and validates them against RELATION_TYPES / ENTITY_RELATION_MAP.
+Invalid fields degrade to None (soft fail) rather than dropping the
+whole reflection — the text itself is always preserved."""
 from __future__ import annotations
 
 import json
@@ -84,56 +83,36 @@ async def _run_synth(fs, re, payload: dict):
 
 def test_validate_accepts_matching_entity_and_type():
     from memory.reflection import _validate_reflection_ontology
-    ok, _ = _validate_reflection_ontology("master", "preference", 0.9, "current", "主人喜欢猫")
+    ok, _ = _validate_reflection_ontology("master", "preference", "current", "主人喜欢猫")
     assert ok is True
 
 
 def test_validate_rejects_cross_entity_relation():
     """master 不能用 dynamic（属于 relationship）。"""
     from memory.reflection import _validate_reflection_ontology
-    ok, reason = _validate_reflection_ontology("master", "dynamic", 0.9, "current", "x")
+    ok, reason = _validate_reflection_ontology("master", "dynamic", "current", "x")
     assert ok is False
     assert "not valid for entity" in reason
 
 
 def test_validate_rejects_unknown_relation_type():
     from memory.reflection import _validate_reflection_ontology
-    ok, reason = _validate_reflection_ontology("master", "nonsense", 0.9, "current", "x")
+    ok, reason = _validate_reflection_ontology("master", "nonsense", "current", "x")
     assert ok is False
     assert "unknown relation_type" in reason
 
 
-def test_validate_rejects_low_confidence():
+def test_validate_rejects_unknown_temporal_scope():
     from memory.reflection import _validate_reflection_ontology
-    ok, reason = _validate_reflection_ontology("master", "preference", 0.3, "current", "x")
+    ok, reason = _validate_reflection_ontology("master", "preference", "yesterday", "x")
     assert ok is False
-    assert "low confidence" in reason
-
-
-def test_validate_rejects_out_of_range_confidence():
-    """prompt contract is 0.0–1.0; hallucinated 1.7 must not persist."""
-    from memory.reflection import _validate_reflection_ontology
-    ok, reason = _validate_reflection_ontology("master", "preference", 1.7, "current", "x")
-    assert ok is False
-    assert "out of range" in reason
-    ok2, reason2 = _validate_reflection_ontology("master", "preference", -0.2, "current", "x")
-    assert ok2 is False
-    assert "out of range" in reason2
-
-
-def test_validate_rejects_non_finite_confidence():
-    """NaN / Infinity must not land on disk — they serialize to non-standard JSON."""
-    from memory.reflection import _validate_reflection_ontology
-    for bad in (float("nan"), float("inf"), float("-inf")):
-        ok, reason = _validate_reflection_ontology("master", "preference", bad, "current", "x")
-        assert ok is False, f"{bad!r} should be rejected"
-        assert "non-finite" in reason
+    assert "temporal_scope" in reason
 
 
 def test_validate_rejects_overlong_text():
     from memory.reflection import _validate_reflection_ontology
     ok, reason = _validate_reflection_ontology(
-        "master", "preference", 0.9, "current", "x" * 250,
+        "master", "preference", "current", "x" * 250,
     )
     assert ok is False
     assert "text too long" in reason
@@ -142,7 +121,7 @@ def test_validate_rejects_overlong_text():
 def test_validate_tolerates_missing_optional_fields():
     """None-valued optional fields should not cause validation to fail."""
     from memory.reflection import _validate_reflection_ontology
-    ok, _ = _validate_reflection_ontology("master", None, None, None, "主人喜欢猫")
+    ok, _ = _validate_reflection_ontology("master", None, None, "主人喜欢猫")
     assert ok is True
 
 
@@ -156,7 +135,6 @@ async def test_synthesize_persists_valid_ontology_fields(tmp_path):
         "reflection": "主人偏好用 Python 而非 JavaScript",
         "entity": "master",
         "relation_type": "preference",
-        "confidence": 0.9,
         "temporal_scope": "current",
     })
     assert len(results) == 1
@@ -164,8 +142,9 @@ async def test_synthesize_persists_valid_ontology_fields(tmp_path):
     reflections = await re._aload_reflections_full("小天")
     r = reflections[0]
     assert r["relation_type"] == "preference"
-    assert r["confidence"] == pytest.approx(0.9)
     assert r["temporal_scope"] == "current"
+    # `confidence` is no longer part of the schema.
+    assert "confidence" not in r
 
 
 @pytest.mark.asyncio
@@ -176,7 +155,6 @@ async def test_synthesize_degrades_invalid_relation_type_to_null(tmp_path):
         "reflection": "观察到的某个模式",
         "entity": "master",
         "relation_type": "dynamic",  # illegal: dynamic is relationship-only
-        "confidence": 0.9,
         "temporal_scope": "current",
     })
     assert len(results) == 1
@@ -186,7 +164,6 @@ async def test_synthesize_degrades_invalid_relation_type_to_null(tmp_path):
     # Soft fail: text preserved but ontology stripped.
     assert r["text"] == "观察到的某个模式"
     assert r["relation_type"] is None
-    assert r["confidence"] is None
     assert r["temporal_scope"] is None
 
 
@@ -199,7 +176,6 @@ async def test_synthesize_demotes_subject_alongside_other_ontology(tmp_path):
         "reflection": "某观察",
         "entity": "master",
         "relation_type": "dynamic",  # illegal for master → triggers demotion
-        "confidence": 0.9,
         "temporal_scope": "current",
         "subject": "主人",
     })
@@ -207,27 +183,8 @@ async def test_synthesize_demotes_subject_alongside_other_ontology(tmp_path):
     reflections = await re._aload_reflections_full("小天")
     r = reflections[0]
     assert r["relation_type"] is None
-    assert r["confidence"] is None
     assert r["temporal_scope"] is None
     assert r["subject"] is None
-
-
-@pytest.mark.asyncio
-async def test_synthesize_degrades_low_confidence_to_null(tmp_path):
-    fs, re = _install(str(tmp_path))
-    results = await _run_synth(fs, re, {
-        "reflection": "某个不太确定的观察",
-        "entity": "master",
-        "relation_type": "preference",
-        "confidence": 0.2,
-        "temporal_scope": "current",
-    })
-    assert len(results) == 1
-
-    reflections = await re._aload_reflections_full("小天")
-    r = reflections[0]
-    assert r["relation_type"] is None
-    assert r["confidence"] is None
 
 
 @pytest.mark.asyncio
@@ -243,27 +200,10 @@ async def test_synthesize_handles_legacy_prompt_missing_ontology(tmp_path):
     reflections = await re._aload_reflections_full("小天")
     r = reflections[0]
     assert r["relation_type"] is None
-    assert r["confidence"] is None
     assert r["temporal_scope"] is None
     # Entity and text still carry through.
     assert r["entity"] == "relationship"
     assert r["text"] == "legacy-style reflection"
-
-
-@pytest.mark.asyncio
-async def test_synthesize_tolerates_non_numeric_confidence(tmp_path):
-    """LLM 偶尔会返回 confidence 为字符串 'high'；降级为 null，不应崩溃。"""
-    fs, re = _install(str(tmp_path))
-    results = await _run_synth(fs, re, {
-        "reflection": "示例反思",
-        "entity": "master",
-        "relation_type": "preference",
-        "confidence": "high",
-        "temporal_scope": "current",
-    })
-    assert len(results) == 1
-    reflections = await re._aload_reflections_full("小天")
-    assert reflections[0]["confidence"] is None
 
 
 def test_normalize_reflection_backfills_ontology_defaults():
@@ -272,6 +212,7 @@ def test_normalize_reflection_backfills_ontology_defaults():
     legacy = {"id": "r1", "text": "旧反思", "entity": "master", "status": "pending"}
     out = ReflectionEngine._normalize_reflection(legacy)
     assert out["relation_type"] is None
-    assert out["confidence"] is None
     assert out["temporal_scope"] is None
     assert out["subject"] is None
+    # `confidence` is intentionally not in the default schema anymore.
+    assert "confidence" not in out

--- a/tests/unit/test_reflection_ontology.py
+++ b/tests/unit/test_reflection_ontology.py
@@ -191,6 +191,28 @@ async def test_synthesize_degrades_invalid_relation_type_to_null(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_synthesize_demotes_subject_alongside_other_ontology(tmp_path):
+    """Soft-fail must strip `subject` too — keeping it would leave a
+    half-structured record (no class but still a label)."""
+    fs, re = _install(str(tmp_path))
+    results = await _run_synth(fs, re, {
+        "reflection": "某观察",
+        "entity": "master",
+        "relation_type": "dynamic",  # illegal for master → triggers demotion
+        "confidence": 0.9,
+        "temporal_scope": "current",
+        "subject": "主人",
+    })
+    assert len(results) == 1
+    reflections = await re._aload_reflections_full("小天")
+    r = reflections[0]
+    assert r["relation_type"] is None
+    assert r["confidence"] is None
+    assert r["temporal_scope"] is None
+    assert r["subject"] is None
+
+
+@pytest.mark.asyncio
 async def test_synthesize_degrades_low_confidence_to_null(tmp_path):
     fs, re = _install(str(tmp_path))
     results = await _run_synth(fs, re, {

--- a/tests/unit/test_reflection_ontology.py
+++ b/tests/unit/test_reflection_ontology.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for reflection ontology constraints (RFC memory-enhancements §3).
+
+The synthesize flow parses relation_type / confidence / temporal_scope from
+the LLM response and validates them against RELATION_TYPES /
+ENTITY_RELATION_MAP / MIN_REFLECTION_CONFIDENCE. Invalid or low-confidence
+fields degrade to None (soft fail per §3.3.6) — the reflection text itself
+is preserved."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    return cm
+
+
+def _install(tmpdir: str):
+    from memory.event_log import EventLog
+    from memory.facts import FactStore
+    from memory.persona import PersonaManager
+    from memory.reflection import ReflectionEngine
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.event_log.get_config_manager", return_value=cm), \
+         patch("memory.facts.get_config_manager", return_value=cm), \
+         patch("memory.persona.get_config_manager", return_value=cm), \
+         patch("memory.reflection.get_config_manager", return_value=cm):
+        event_log = EventLog()
+        event_log._config_manager = cm
+        fs = FactStore()
+        fs._config_manager = cm
+        pm = PersonaManager(event_log=event_log)
+        pm._config_manager = cm
+        re = ReflectionEngine(fs, pm, event_log=event_log)
+        re._config_manager = cm
+    return fs, re
+
+
+async def _run_synth(fs, re, payload: dict):
+    """Seed 5 facts + mock LLM to return `payload`, then synthesize."""
+    for i in range(5):
+        fs._facts.setdefault("小天", []).append({
+            "id": f"f{i}", "text": f"事实 {i}",
+            "importance": 5, "entity": "master",
+            "tags": [], "hash": f"h{i}",
+            "created_at": "2026-04-23T10:00:00",
+            "absorbed": False,
+        })
+    await fs.asave_facts("小天")
+
+    resp = MagicMock()
+    resp.content = json.dumps(payload)
+
+    async def _ainvoke(*_a, **_k):
+        return resp
+
+    async def _aclose():
+        return None
+
+    fake_llm = MagicMock()
+    fake_llm.ainvoke = _ainvoke
+    fake_llm.aclose = _aclose
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        return await re.synthesize_reflections("小天")
+
+
+# ── happy path ─────────────────────────────────────────────────────
+
+
+def test_validate_accepts_matching_entity_and_type():
+    from memory.reflection import _validate_reflection_ontology
+    ok, _ = _validate_reflection_ontology("master", "preference", 0.9, "current", "主人喜欢猫")
+    assert ok is True
+
+
+def test_validate_rejects_cross_entity_relation():
+    """master 不能用 dynamic（属于 relationship）。"""
+    from memory.reflection import _validate_reflection_ontology
+    ok, reason = _validate_reflection_ontology("master", "dynamic", 0.9, "current", "x")
+    assert ok is False
+    assert "not valid for entity" in reason
+
+
+def test_validate_rejects_unknown_relation_type():
+    from memory.reflection import _validate_reflection_ontology
+    ok, reason = _validate_reflection_ontology("master", "nonsense", 0.9, "current", "x")
+    assert ok is False
+    assert "unknown relation_type" in reason
+
+
+def test_validate_rejects_low_confidence():
+    from memory.reflection import _validate_reflection_ontology
+    ok, reason = _validate_reflection_ontology("master", "preference", 0.3, "current", "x")
+    assert ok is False
+    assert "low confidence" in reason
+
+
+def test_validate_rejects_overlong_text():
+    from memory.reflection import _validate_reflection_ontology
+    ok, reason = _validate_reflection_ontology(
+        "master", "preference", 0.9, "current", "x" * 250,
+    )
+    assert ok is False
+    assert "text too long" in reason
+
+
+def test_validate_tolerates_missing_optional_fields():
+    """None-valued optional fields should not cause validation to fail."""
+    from memory.reflection import _validate_reflection_ontology
+    ok, _ = _validate_reflection_ontology("master", None, None, None, "主人喜欢猫")
+    assert ok is True
+
+
+# ── synthesize integration ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_synthesize_persists_valid_ontology_fields(tmp_path):
+    fs, re = _install(str(tmp_path))
+    results = await _run_synth(fs, re, {
+        "reflection": "主人偏好用 Python 而非 JavaScript",
+        "entity": "master",
+        "relation_type": "preference",
+        "confidence": 0.9,
+        "temporal_scope": "current",
+    })
+    assert len(results) == 1
+
+    reflections = await re._aload_reflections_full("小天")
+    r = reflections[0]
+    assert r["relation_type"] == "preference"
+    assert r["confidence"] == pytest.approx(0.9)
+    assert r["temporal_scope"] == "current"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_degrades_invalid_relation_type_to_null(tmp_path):
+    """LLM 返回了非法的 entity→relation_type 映射时，反思应保留但字段置空。"""
+    fs, re = _install(str(tmp_path))
+    results = await _run_synth(fs, re, {
+        "reflection": "观察到的某个模式",
+        "entity": "master",
+        "relation_type": "dynamic",  # illegal: dynamic is relationship-only
+        "confidence": 0.9,
+        "temporal_scope": "current",
+    })
+    assert len(results) == 1
+
+    reflections = await re._aload_reflections_full("小天")
+    r = reflections[0]
+    # Soft fail: text preserved but ontology stripped.
+    assert r["text"] == "观察到的某个模式"
+    assert r["relation_type"] is None
+    assert r["confidence"] is None
+    assert r["temporal_scope"] is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_degrades_low_confidence_to_null(tmp_path):
+    fs, re = _install(str(tmp_path))
+    results = await _run_synth(fs, re, {
+        "reflection": "某个不太确定的观察",
+        "entity": "master",
+        "relation_type": "preference",
+        "confidence": 0.2,
+        "temporal_scope": "current",
+    })
+    assert len(results) == 1
+
+    reflections = await re._aload_reflections_full("小天")
+    r = reflections[0]
+    assert r["relation_type"] is None
+    assert r["confidence"] is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_handles_legacy_prompt_missing_ontology(tmp_path):
+    """旧 prompt / 旧 model 不返回 ontology 字段时应当静默通过。"""
+    fs, re = _install(str(tmp_path))
+    results = await _run_synth(fs, re, {
+        "reflection": "legacy-style reflection",
+        "entity": "relationship",
+    })
+    assert len(results) == 1
+
+    reflections = await re._aload_reflections_full("小天")
+    r = reflections[0]
+    assert r["relation_type"] is None
+    assert r["confidence"] is None
+    assert r["temporal_scope"] is None
+    # Entity and text still carry through.
+    assert r["entity"] == "relationship"
+    assert r["text"] == "legacy-style reflection"
+
+
+@pytest.mark.asyncio
+async def test_synthesize_tolerates_non_numeric_confidence(tmp_path):
+    """LLM 偶尔会返回 confidence 为字符串 'high'；降级为 null，不应崩溃。"""
+    fs, re = _install(str(tmp_path))
+    results = await _run_synth(fs, re, {
+        "reflection": "示例反思",
+        "entity": "master",
+        "relation_type": "preference",
+        "confidence": "high",
+        "temporal_scope": "current",
+    })
+    assert len(results) == 1
+    reflections = await re._aload_reflections_full("小天")
+    assert reflections[0]["confidence"] is None
+
+
+def test_normalize_reflection_backfills_ontology_defaults():
+    """Legacy on-disk reflections missing ontology fields normalize to None."""
+    from memory.reflection import ReflectionEngine
+    legacy = {"id": "r1", "text": "旧反思", "entity": "master", "status": "pending"}
+    out = ReflectionEngine._normalize_reflection(legacy)
+    assert out["relation_type"] is None
+    assert out["confidence"] is None
+    assert out["temporal_scope"] is None
+    assert out["subject"] is None

--- a/tests/unit/test_reflection_ontology.py
+++ b/tests/unit/test_reflection_ontology.py
@@ -110,6 +110,26 @@ def test_validate_rejects_low_confidence():
     assert "low confidence" in reason
 
 
+def test_validate_rejects_out_of_range_confidence():
+    """prompt contract is 0.0–1.0; hallucinated 1.7 must not persist."""
+    from memory.reflection import _validate_reflection_ontology
+    ok, reason = _validate_reflection_ontology("master", "preference", 1.7, "current", "x")
+    assert ok is False
+    assert "out of range" in reason
+    ok2, reason2 = _validate_reflection_ontology("master", "preference", -0.2, "current", "x")
+    assert ok2 is False
+    assert "out of range" in reason2
+
+
+def test_validate_rejects_non_finite_confidence():
+    """NaN / Infinity must not land on disk — they serialize to non-standard JSON."""
+    from memory.reflection import _validate_reflection_ontology
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        ok, reason = _validate_reflection_ontology("master", "preference", bad, "current", "x")
+        assert ok is False, f"{bad!r} should be rejected"
+        assert "non-finite" in reason
+
+
 def test_validate_rejects_overlong_text():
     from memory.reflection import _validate_reflection_ontology
     ok, reason = _validate_reflection_ontology(


### PR DESCRIPTION
## What this PR ships

Two structural memory enhancements from the internal RFC. P2 (vector hybrid retrieval) is intentionally deferred to a follow-up PR with the design notes below.

### 1. Reflection ontology constraints — `memory/reflection.py`

Synthesized reflections now carry `relation_type` / `temporal_scope` / `subject` alongside the existing `entity` / `text`. The validation is **kind-indexed**, not entity-name-indexed: each entity resolves to a role kind (`user` / `character` / `relationship`) and the allowed `relation_type` set follows from the kind. Today this gives:

- `master` (kind = `user`): preference, trait, habit, identity, emotional, boundary
- `neko` (kind = `character`): self_awareness, learned, role_note
- `relationship` (kind = `relationship`): dynamic, milestone, tension, shared_memory, agreement

Unknown entities default to `user` kind, so a future group chat that introduces `guest_alice` automatically inherits the user template without a schema migration. Adding another AI character is a one-line registry edit; `RELATION_TYPES` itself stays frozen.

Validation is **soft-fail**: if the LLM returns a `relation_type` that's invalid for the entity's kind, an unknown `temporal_scope`, or text > 200 chars (compound-statement signal), the entire ontology tuple (`relation_type` / `temporal_scope` / `subject`) is demoted to null. The reflection text itself is always preserved — a half-structured record is worse than an unclassified one.

`confidence` was prototyped and pulled: LLM self-rated confidence is redundant with the entity↔kind constraint (a low-confidence reflection that maps to a valid pair is already useful; a genuinely shaky one violates the kind mapping and gets demoted via the existing path), and adds a value source we can't independently verify.

The synthesize prompt is updated across all five locales (zh / en / ja / ko / ru) with the relation-type vocabulary and the "stay focused on a single observation or pattern" guidance — the 2-3 sentence length budget is unchanged.

### 2. Fact version chain — `memory/persona.py`

`resolve_corrections`' `replace` branch now preserves the replaced text in a `version_history` list on the entry, chained across repeated corrections. This keeps temporal context like "主人以前住东京，后来搬到大阪" recoverable for later renders or queries. Zero extra LLM calls — we just stop discarding `old_text`.

`replace` is implemented as an **in-place edit**, not a rebuild: the new `text` and an appended history record are the only changes. `id` / `source` / `source_id` / `reinforcement` / `disputation` / `recent_mentions` / `user_fact_reinforce_count` all survive the rewrite, so a confirmed entry stays confirmed after a text correction. The token-count cache (`token_count` / `token_count_text_sha256` / `token_count_tokenizer`) is explicitly invalidated since the text changed. Legacy str entries (no metadata to preserve) still go through a fresh `_normalize_entry` path with the chain seeded.

Scope is strictly the `replace` action. `keep_new` / `keep_old` / `keep_both` are unchanged because they don't represent an evolutionary update of the same fact — `keep_new` is a clean supersede, `keep_both` is "these aren't actually contradictory", neither carries the "earlier truth that became outdated" semantics that justifies a chain.

## What's deferred (P2 — separate PR)

Vector hybrid retrieval is the larger of the three RFC items. The design has been re-evaluated and tightened beyond what the RFC originally proposed; key decisions captured here so the follow-up PR doesn't re-litigate them:

- **No vector database, no SQLite-VSS.** numpy brute-force over 1000-ish active entries stays under 1 ms. SQLite-VSS adds three platform-native binaries and a "which copy is source of truth" question that's out of proportion to the recall problem we're solving.
- **Embedding model: must be commercially-licensed and natively multilingual.** The RFC's primary suggestion (Jina v5-text-nano, CC BY-NC 4.0) is not usable given the project's distribution path. multilingual-e5-small (MIT), BGE-M3 small variant, or Snowflake Arctic Embed v2.0-xs (Apache 2.0) are the live candidates.
- **`embedding_dim = "auto"` by default.** Pick at first model load based on RAM, AVX-VNNI availability (which gates whether INT8 quantization is actually a speedup), and current CPU/RAM utilization. 64 / 128 / 256 / 384 are the discrete steps. INT8 only fires when VNNI is present; otherwise FP32. Hard-coding 128 is what the RFC said and it's the wrong default for variable hardware.
- **Lazy load gated on frontend ready signal.** The model file is ~150 MB and the first-time decompress is real. Load triggers only after the frontend emits a "fully initialized" signal (greeting played, prominent drained, etc.) — never during cold boot. Until then, the retrieval path runs without vectors and the whole feature degrades to evidence-only ranking.
- **Embeddings persist on the entry, not in-memory cache.** With `embedding_text_sha256` + `embedding_model_id` for cache invalidation. Cleared automatically by the same path that invalidates `token_count` (i.e. `replace` branch above). The RFC's "memory cache only" was a 1000-entry-cold-start latency trap.
- **Embedding compute is async w.r.t. writes.** `record_and_save` returns immediately; a background worker fills missing embeddings in batches. Detection paths that need an embedding tolerate its absence (degrade to text/keyword path for that one query).
- **Fact-level vector dedup, not just persona/reflection.** Hash-based dedup misses paraphrases ("主人喜欢猫" / "对猫咪很感兴趣" / "最近养了只猫") which today re-enter the unabsorbed queue and pollute reflection synthesis input. Vector dedup at write time (cosine > ~0.85 → merge into existing fact, bump importance) when the model is loaded; falls back to hash when it isn't. **No vector at fact-recall time** in v1 — the layered RFC's distant-fact recall idea is a separate, later question, because reflection is supposed to be the semantic aggregator already; if reflection is doing its job, recalling raw distant facts is mostly redundant.
- **Vectors are recall-only, never trigger.** Keyword scanning still gates whether stage-1/2 LLMs run. Mixing trigger and recall lets "semantically near but not actually intended" topics auto-activate, which is a UX trap.
- **Retrieval fusion is two-stage, not a linear `α·evidence + (1-α)·cosine`:**
  1. **Hard filter**: drop suppressed / terminal / `score < 0` entries.
  2. **Recall**: cosine top-K within remaining set, K bounded by per-source token budget.
  3. **Tie-break**: when cosines are within an epsilon, `evidence_score` (sigmoid-normalized) breaks the tie.

  The RFC's linear blend mixed dimensionally inconsistent quantities (`evidence_score` is unbounded ±, cosine is [0,1]) and ignored the existing `suppress` mechanism, which would produce "AI keeps bringing up the same confirmed memory" regressions.
- **Hardware gate for "vectors disabled".** No SSE4.2 → off. < 4 GB RAM after loading the rest of the app → off. Model file missing or onnxruntime import failure → off. User can force-disable via setting. When off, the retrieval path is identical to today's behavior.

## Test plan

- [x] 91 unit tests pass across `test_reflection_ontology` (12), `test_persona_version_history` (5), and the broader memory suites (`test_reflection_filters`, `test_reflection_idempotent`, `test_character_memory_regression`, `test_avatar_interaction_memory_contract`, `test_evidence_promote_merge`, `test_evidence_render_budget`, `test_i18n_locale_keys`, `test_prompt_shared`)
- [x] CodeRabbit + Codex review iterations resolved; no actionable comments remaining
- [ ] Manual smoke: trigger a real reflection synth + a real persona correction against a live model (one round each per locale) to confirm the prompt parses back into the expected JSON shape
- [ ] Soak for ~48h to observe ontology-demote ratio in the wild — if > 30% of synth output gets demoted, the prompt needs another tuning pass before we let group-chat scaffolding land on top of it

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 反思现在包含关系类型和时间范围等结构化元数据，提供更丰富的上下文信息
  * 修正人设事实时，系统现在维护完整的版本历史记录，保留所有更改的可审计跟踪

* **改进**
  * 强化反思数据的验证机制和完整性检查
  * 优化数据持久化，在修正操作时保留来源和证据元数据

<!-- end of auto-generated comment: release notes by coderabbit.ai -->