### PR TITLE
fix: make all showStatus toast types auto-dismiss with clearTimeout guard

### DIFF
--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -158,8 +158,8 @@ function showStatus(message, type = 'info') {
     statusDiv.className = `status ${type}`;
     statusDiv.style.display = 'block';
 
-    var delay = type === 'error' ? 5000 : 3000;
-    showStatus._hideTimer = setTimeout(function () {
+    const delay = type === 'error' ? 5000 : 3000;
+    showStatus._hideTimer = setTimeout(() => {
         statusDiv.style.display = 'none';
         showStatus._hideTimer = null;
     }, delay);

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -148,15 +148,21 @@ function showStatus(message, type = 'info') {
         return;
     }
 
+    // 清除之前的自动隐藏定时器，避免新消息被旧定时器提前关闭
+    if (showStatus._hideTimer) {
+        clearTimeout(showStatus._hideTimer);
+        showStatus._hideTimer = null;
+    }
+
     statusDiv.textContent = message;
     statusDiv.className = `status ${type}`;
     statusDiv.style.display = 'block';
 
-    if (type === 'success') {
-        setTimeout(() => {
-            statusDiv.style.display = 'none';
-        }, 3000);
-    }
+    var delay = type === 'error' ? 5000 : 3000;
+    showStatus._hideTimer = setTimeout(function () {
+        statusDiv.style.display = 'none';
+        showStatus._hideTimer = null;
+    }, delay);
 }
 
 function showCurrentApiKey(message, rawKey = '', hasKey = false) {


### PR DESCRIPTION
## Summary

The `showStatus()` function in `static/js/api_key_settings.js` only auto-hides `success` toasts after 3 seconds. `error` and `info` toasts stay on screen indefinitely, blocking page interaction since `#status` is a centered fixed overlay (`position: fixed; top: 50%; left: 50%; z-index: 10001`).

This is most noticeable when GPT-SoVITS voice list refresh fails — the `TTS_CONNECTION_FAILED` error toast never disappears.

### Changes

- `error` toasts now auto-dismiss after 5 seconds (longer than success to give users time to read)
- `success` and `info` toasts remain at 3 seconds
- Added `clearTimeout` guard so rapid consecutive `showStatus` calls don't have timer races (old timer closing a newer message early)

## Test plan

- Simulated TTS connection failure by requesting voice list with GPT-SoVITS service offline — error toast now disappears after 5 seconds
- Verified success toasts still dismiss at 3 seconds
- Tested rapid consecutive calls (trigger error then immediately trigger success) — the success message displays correctly without being prematurely hidden by the error timer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了状态消息展示逻辑，避免连续调用时出现竞态或覆盖问题。
  * 统一启用消息自动隐藏：错误消息显示 5 秒，其他类型消息显示 3 秒。
  * 确保自动隐藏计时器在隐藏后被重置，防止残留定时器影响后续显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->