### PR TITLE
fix(launcher): Resolve issue where Ctrl+C fails to terminate processes when starting with uv run on Windows

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -80,6 +80,16 @@ def _maybe_reexec_into_project_venv(project_dir: str) -> None:
     if IS_FROZEN:
         return
 
+    # 获取预期的 .venv 目录和当前环境的根目录
+    expected_venv_dir = os.path.abspath(os.path.join(project_dir, ".venv"))
+    current_venv_dir = os.path.abspath(sys.prefix)
+
+    # 校验当前环境是否真的是本项目的 .venv（忽略大小写差异）
+    # 这样既能兼容 uv run，又能防止在其他无关虚拟环境中误跑此脚本导致报错
+    if os.path.normcase(current_venv_dir) == os.path.normcase(expected_venv_dir):
+        return
+
+    # 如果根目录不匹配，再进行原有的解释器路径严格校验
     current_executable = os.path.abspath(sys.executable or "")
     if not current_executable:
         return


### PR DESCRIPTION
**本次更改**
- 引入 sys.prefix 校验：获取当前运行环境的根目录（sys.prefix），并与项目实际的 .venv 物理目录进行对比。
- 路径规范化：使用 os.path.normcase 消除 Windows 下路径大小写可能带来的误判。
- 跳过不必要的进程切换：只要确认当前 Python 实例的根目录确实位于项目的 .venv 中，就直接信任当前环境管理器（如 uv）的挂载状态，跳过 os.execv。这保证了原始进程树的完整性，使信号能够正确向下传递。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了虚拟环境检测机制，现在当应用程序已在项目的虚拟环境中运行时，可以智能地跳过不必要的重新执行步骤。这一改进不仅增强了启动性能，还提高了系统与 uv run 等第三方工具和运行器的兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->