### PR TITLE
[Memory] P2 step 2 — fact vector dedup with LLM arbitration

### DIFF
--- a/config/prompts_memory.py
+++ b/config/prompts_memory.py
@@ -1621,3 +1621,106 @@ def get_persona_correction_prompt(lang: str = 'zh') -> str:
 
 
 persona_correction_prompt = PERSONA_CORRECTION_PROMPT['zh']
+
+
+# ---------- fact_dedup_prompt → i18n dict ----------
+# Drives memory/fact_dedup.py's resolve loop. Vector cosine selects
+# candidate (candidate_text, existing_text) pairs above a similarity
+# threshold; this prompt asks the LLM to classify each pair into
+# merge / replace / keep_both. The LLM is the arbiter, vector is just
+# the candidate generator — cosine alone can't separate "主人喜欢猫"
+# from "主人讨厌猫", so we always defer the final call to the model.
+FACT_DEDUP_PROMPT = {
+    'zh': """以下是 {COUNT} 组通过向量相似度筛选出的候选事实对，请逐组判断是否真的指向同一件事，并选择处理方式。
+
+======以下为候选事实对======
+{PAIRS}
+======以上为候选事实对======
+
+对于每组，从下列动作中选一个：
+- merge: 两条记录的确指向同一事件/偏好/状态，保留 existing，丢弃 candidate（existing 的 importance 会自动+1，candidate id 会被记入 merged_from_ids）
+- replace: 同样指向同一件事，但 candidate 措辞更准确/更新，应保留 candidate、丢弃 existing
+- keep_both: 看似相似但其实是两件不同的事（如"喜欢"与"讨厌"，或同一对象在不同情境下的不同状态），都保留
+
+注意：
+- cosine 高只是相似度高，不代表语义相同，特别要警惕褒贬相反、肯定/否定相反的情况
+- 优先选 keep_both 而非误合并；记忆系统对错误合并的容忍度低于对冗余的容忍度
+
+仅输出 JSON 数组，每项包含 index、action：
+[{{"index": 0, "action": "merge"}}, {{"index": 1, "action": "keep_both"}}]""",
+    'en': """Below are {COUNT} candidate fact pairs flagged by cosine similarity. For each pair, decide whether they actually refer to the same thing and choose how to handle it.
+
+======candidate pairs below======
+{PAIRS}
+======candidate pairs above======
+
+For each pair, pick one action:
+- merge: the two records do refer to the same event/preference/state — keep existing, drop candidate (existing's importance will auto +1; candidate id is recorded in merged_from_ids)
+- replace: same underlying thing, but the candidate's wording is more accurate/up-to-date — keep candidate, drop existing
+- keep_both: they look similar but are actually distinct ("likes" vs "dislikes", or the same subject in different contexts) — keep both
+
+Notes:
+- High cosine means high *surface* similarity, not semantic identity. Be especially careful about polarity flips (positive/negative, like/dislike).
+- Prefer keep_both over a wrongful merge — the memory system tolerates redundancy much better than incorrect merges.
+
+Output only a JSON array, each item containing index and action:
+[{{"index": 0, "action": "merge"}}, {{"index": 1, "action": "keep_both"}}]""",
+    'ja': """以下は {COUNT} 組のベクトル類似度で抽出された候補ペアです。各ペアについて、本当に同じ事柄を指しているか判断し、処理方法を選んでください。
+
+======候補ペアここから======
+{PAIRS}
+======候補ペアここまで======
+
+各ペアについて、以下のいずれかを選択：
+- merge: 同じ出来事/嗜好/状態を指している → existing を残し candidate を削除（existing の importance が自動 +1、candidate id は merged_from_ids に記録）
+- replace: 同じ事柄だが candidate の方が正確/最新 → candidate を残し existing を削除
+- keep_both: 似ているが実際には別の事柄（"好き"と"嫌い"のような極性反転、あるいは異なる文脈での同じ対象）→ 両方残す
+
+注意：
+- 高い cosine は表層的な類似度であり、意味的同一性ではない。特に極性反転（肯定/否定、好き/嫌い）に注意
+- 誤合併よりも keep_both を優先。記憶システムは冗長性より誤合併に対する耐性が低い
+
+JSON 配列のみを出力し、各項目に index と action を含めてください：
+[{{"index": 0, "action": "merge"}}, {{"index": 1, "action": "keep_both"}}]""",
+    'ko': """아래는 벡터 유사도로 선별된 {COUNT}쌍의 후보 사실 쌍입니다. 각 쌍에 대해 실제로 같은 것을 가리키는지 판단하고 처리 방법을 선택하세요.
+
+======후보 쌍 시작======
+{PAIRS}
+======후보 쌍 끝======
+
+각 쌍에 대해 다음 중 하나를 선택:
+- merge: 두 기록이 실제로 같은 사건/선호/상태를 가리킴 — existing 유지, candidate 제거 (existing의 importance가 자동 +1, candidate id는 merged_from_ids에 기록됨)
+- replace: 같은 것을 가리키지만 candidate의 표현이 더 정확/최신 — candidate 유지, existing 제거
+- keep_both: 비슷해 보이지만 실제로는 다른 것 ("좋아함"과 "싫어함" 같은 극성 반전, 혹은 다른 맥락의 같은 대상) — 둘 다 유지
+
+주의:
+- 높은 cosine은 표면적 유사도일 뿐 의미적 동일성을 보장하지 않음. 특히 극성 반전(긍정/부정, 좋아함/싫어함)에 주의
+- 잘못된 병합보다 keep_both를 우선. 기억 시스템은 중복보다 잘못된 병합에 대한 내성이 더 낮음
+
+JSON 배열만 출력하고 각 항목에 index와 action을 포함하세요:
+[{{"index": 0, "action": "merge"}}, {{"index": 1, "action": "keep_both"}}]""",
+    'ru': """Ниже представлены {COUNT} пар фактов-кандидатов, отобранных по косинусной близости. Для каждой пары определите, действительно ли они описывают одно и то же, и выберите способ обработки.
+
+======пары кандидатов ниже======
+{PAIRS}
+======пары кандидатов выше======
+
+Для каждой пары выберите одно из действий:
+- merge: записи описывают одно и то же событие/предпочтение/состояние — сохранить existing, отбросить candidate (importance у existing увеличится на 1, id candidate запишется в merged_from_ids)
+- replace: то же самое, но формулировка candidate точнее/актуальнее — сохранить candidate, отбросить existing
+- keep_both: похожи внешне, но на самом деле разные ("любит" vs "не любит", тот же объект в разных контекстах) — сохранить обе
+
+Замечания:
+- Высокий cosine означает поверхностное сходство, а не семантическую идентичность. Особенно осторожно с инверсией полярности (положительное/отрицательное, любит/не любит).
+- Предпочитайте keep_both ошибочному слиянию — система памяти переносит избыточность лучше, чем неверные слияния.
+
+Выводите только JSON-массив, каждый элемент содержит index и action:
+[{{"index": 0, "action": "merge"}}, {{"index": 1, "action": "keep_both"}}]""",
+}
+
+
+def get_fact_dedup_prompt(lang: str = 'zh') -> str:
+    return _loc(FACT_DEDUP_PROMPT, lang)
+
+
+fact_dedup_prompt = FACT_DEDUP_PROMPT['zh']

--- a/config/prompts_memory.py
+++ b/config/prompts_memory.py
@@ -1724,3 +1724,102 @@ def get_fact_dedup_prompt(lang: str = 'zh') -> str:
 
 
 fact_dedup_prompt = FACT_DEDUP_PROMPT['zh']
+
+
+# ---------- memory_recall_rerank_prompt → i18n dict ----------
+# Drives memory/recall.py's _fine_rank step. Cosine pre-filtering
+# narrows the candidate set down to ~3× the budget; this prompt asks
+# the LLM to pick the top {BUDGET} most-relevant items for the query.
+# evidence_score appears parenthetically as auxiliary signal — the
+# LLM weighs it together with semantic relevance instead of mixing
+# into a single ranking number (cosine vs evidence are
+# dimensionally inconsistent).
+MEMORY_RECALL_RERANK_PROMPT = {
+    'zh': """以下是用户最近提到的话题。请从候选记忆中挑选最相关的 {BUDGET} 条用于注入对话上下文。
+
+======用户当前话题======
+{QUERY}
+======用户当前话题======
+
+======候选记忆======
+{CANDIDATES}
+======候选记忆======
+
+每条候选前的 score 是用户对该记忆的累计确认度（高 = 反复确认，低 = 较少证据）。可作为辅助信号——同等相关度时优先选 score 高的；但不要让 score 完全压倒相关性，无关的高 score 记忆不该入选。
+
+仅输出 JSON 数组，按重要程度从高到低排列，每项包含 id 字段：
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+最多 {BUDGET} 条；若候选不足 {BUDGET} 条相关，可返回更少。""",
+    'en': """Below are topics the user has just mentioned. From the candidate memories, pick the {BUDGET} most relevant ones to inject into the conversation context.
+
+======current topics======
+{QUERY}
+======current topics======
+
+======candidate memories======
+{CANDIDATES}
+======candidate memories======
+
+The `score` annotation on each candidate is the user's cumulative confirmation count for that memory (high = repeatedly confirmed, low = thin evidence). Use it as an auxiliary signal — when relevance is tied, prefer the higher score; but do not let score override relevance, an irrelevant high-score memory should not be picked.
+
+Output only a JSON array, ordered most-important first. Each item must contain an `id` field:
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+At most {BUDGET} items; return fewer if not enough candidates are relevant.""",
+    'ja': """以下はユーザーが最近言及したトピックです。候補メモリから、対話コンテキストに注入する最も関連性の高い {BUDGET} 件を選んでください。
+
+======現在のトピック======
+{QUERY}
+======現在のトピック======
+
+======候補メモリ======
+{CANDIDATES}
+======候補メモリ======
+
+各候補の score 注釈は、ユーザーがそのメモリを累積確認した回数です（高 = 繰り返し確認、低 = 証拠が薄い）。補助シグナルとして利用してください。関連性が同等なら score の高い方を優先しますが、関連性を score が完全に覆すべきではありません。
+
+JSON 配列のみを出力し、重要度順に並べてください。各項目に `id` フィールドを含めます：
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+最大 {BUDGET} 件。関連する候補がそれ以下なら、より少なく返しても構いません。""",
+    'ko': """아래는 사용자가 최근 언급한 주제입니다. 후보 메모리 중에서 대화 컨텍스트에 주입할 가장 관련성 높은 {BUDGET}개를 선택하세요.
+
+======현재 주제======
+{QUERY}
+======현재 주제======
+
+======후보 메모리======
+{CANDIDATES}
+======후보 메모리======
+
+각 후보의 score는 사용자가 해당 메모리를 누적적으로 확인한 횟수입니다(높음 = 반복 확인, 낮음 = 증거 부족). 보조 신호로 활용하세요. 관련성이 같으면 score 높은 쪽을 우선하지만, 관련성을 score가 완전히 압도해서는 안 됩니다.
+
+JSON 배열만 출력하고 중요도 순으로 정렬하세요. 각 항목에 `id` 필드를 포함:
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+최대 {BUDGET}개; 관련 후보가 부족하면 더 적게 반환해도 됩니다.""",
+    'ru': """Ниже представлены темы, которые пользователь только что упомянул. Из кандидатов памяти выберите {BUDGET} наиболее релевантных для внедрения в контекст диалога.
+
+======текущие темы======
+{QUERY}
+======текущие темы======
+
+======кандидаты======
+{CANDIDATES}
+======кандидаты======
+
+Аннотация `score` рядом с каждым кандидатом — это накопленное число подтверждений пользователем (высокое = повторяющееся подтверждение, низкое = слабые доказательства). Используйте как вспомогательный сигнал: при равной релевантности предпочтите более высокий score, но не позволяйте score полностью перевесить релевантность.
+
+Выводите только JSON-массив, упорядоченный по важности. Каждый элемент содержит поле `id`:
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+Не более {BUDGET} элементов; верните меньше, если релевантных кандидатов меньше.""",
+}
+
+
+def get_memory_recall_rerank_prompt(lang: str = 'zh') -> str:
+    return _loc(MEMORY_RECALL_RERANK_PROMPT, lang)
+
+
+memory_recall_rerank_prompt = MEMORY_RECALL_RERANK_PROMPT['zh']

--- a/memory/embedding_worker.py
+++ b/memory/embedding_worker.py
@@ -79,12 +79,19 @@ class EmbeddingWarmupWorker:
         fact_store,
         get_character_names,         # callable returning list[str]
         warmup_delay_seconds: float,
+        dedup_resolver=None,         # optional FactDedupResolver
     ) -> None:
         self._persona_manager = persona_manager
         self._reflection_engine = reflection_engine
         self._fact_store = fact_store
         self._get_character_names = get_character_names
         self._warmup_delay = warmup_delay_seconds
+        # Optional — when None, fact embeddings still get backfilled
+        # but the dedup queue is never populated. That's the right
+        # behaviour for tests that don't want the LLM-call-prone
+        # dedup path, and for installations that prefer pure hash
+        # dedup until they've evaluated the LLM cost.
+        self._dedup_resolver = dedup_resolver
 
         self._service = get_embedding_service()
         self._first_process_event = asyncio.Event()
@@ -166,7 +173,10 @@ class EmbeddingWarmupWorker:
             try:
                 await asyncio.wait_for(self._stop_event.wait(), timeout=interval)
             except asyncio.TimeoutError:
-                pass
+                # Timeout means "no stop signal during the interval";
+                # continue the loop. Distinct from a real cancellation,
+                # which propagates as CancelledError and exits.
+                continue
 
     async def _wait_for_warmup_trigger(self) -> bool:
         """Wait for ``warmup_delay`` OR the first /process call. Returns
@@ -283,6 +293,16 @@ class EmbeddingWarmupWorker:
             return len(targets)
 
     async def _sweep_facts(self, name: str, budget: int) -> int:
+        """Embed stale fact rows in place, then opportunistically scan
+        the freshly-embedded rows for cosine collisions against the
+        rest of the fact pool — collisions go into the dedup queue
+        for the LLM-arbitrated resolve pass to handle later.
+
+        FactStore uses a threading.Lock around `asave_facts` (not an
+        asyncio.Lock like persona/reflection), and the embedding triple
+        is the only field this worker touches, so a per-character
+        asyncio lock isn't needed here — the field-level race is empty.
+        """
         try:
             facts = await self._fact_store.aload_facts(name)
         except Exception as e:  # noqa: BLE001
@@ -300,6 +320,28 @@ class EmbeddingWarmupWorker:
             logger.warning(
                 "[EmbeddingWorker] fact save failed for %s: %s", name, e,
             )
+
+        # Dedup pass: only the rows we just embedded are candidates;
+        # we don't want to repeatedly scan the entire fact history on
+        # every sweep. detect_candidates is entity-scoped + absorbed-
+        # aware, so its output is already a clean set of (candidate,
+        # existing) pairs ready for the LLM arbitration queue.
+        if self._dedup_resolver is not None:
+            try:
+                from memory.fact_dedup import FactDedupResolver  # local import keeps the worker importable when dedup module isn't loaded
+                only_for_ids = {
+                    e.get("id") for e in targets if e.get("id")
+                }
+                pairs = FactDedupResolver.detect_candidates(
+                    facts, only_for_ids=only_for_ids,
+                )
+                if pairs:
+                    await self._dedup_resolver.aenqueue_candidates(name, pairs)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "[EmbeddingWorker] dedup enqueue failed for %s: %s",
+                    name, e,
+                )
         return len(targets)
 
     # ── helpers ──────────────────────────────────────────────────────

--- a/memory/embedding_worker.py
+++ b/memory/embedding_worker.py
@@ -85,7 +85,7 @@ class EmbeddingWarmupWorker:
         get_fact_store,              # callable returning current FactStore
         get_character_names,         # callable returning list[str]
         warmup_delay_seconds: float,
-        dedup_resolver=None,         # optional FactDedupResolver
+        get_dedup_resolver=None,     # callable returning current FactDedupResolver, or None to disable
     ) -> None:
         # All store/manager accesses go through getters so /reload (which
         # rebinds the memory_server module globals) is observed on the next
@@ -96,12 +96,17 @@ class EmbeddingWarmupWorker:
         self._get_fact_store = get_fact_store
         self._get_character_names = get_character_names
         self._warmup_delay = warmup_delay_seconds
-        # Optional — when None, fact embeddings still get backfilled
-        # but the dedup queue is never populated. That's the right
-        # behaviour for tests that don't want the LLM-call-prone
-        # dedup path, and for installations that prefer pure hash
-        # dedup until they've evaluated the LLM cost.
-        self._dedup_resolver = dedup_resolver
+        # Same /reload-staleness shape as the managers above: reload
+        # rebuilds fact_dedup_resolver against the new FactStore, so the
+        # worker resolves the current instance per sweep instead of
+        # capturing the startup one. Without this, post-reload enqueue
+        # would write through the OLD resolver while the idle-maintenance
+        # loop's resolve runs through the NEW one — two instances racing
+        # on the same facts_pending_dedup.json without a shared lock.
+        # Pass None to disable dedup entirely (e.g. tests, or
+        # installations that prefer pure hash + FTS5 dedup until they
+        # have evaluated LLM cost).
+        self._get_dedup_resolver = get_dedup_resolver
 
         self._service = get_embedding_service()
         self._first_process_event = asyncio.Event()
@@ -361,7 +366,11 @@ class EmbeddingWarmupWorker:
         # every sweep. detect_candidates is entity-scoped + absorbed-
         # aware, so its output is already a clean set of (candidate,
         # existing) pairs ready for the LLM arbitration queue.
-        if self._dedup_resolver is not None:
+        dedup_resolver = (
+            self._get_dedup_resolver()
+            if self._get_dedup_resolver is not None else None
+        )
+        if dedup_resolver is not None:
             try:
                 from memory.fact_dedup import FactDedupResolver  # local import keeps the worker importable when dedup module isn't loaded
                 only_for_ids = {
@@ -371,7 +380,7 @@ class EmbeddingWarmupWorker:
                     facts, only_for_ids=only_for_ids,
                 )
                 if pairs:
-                    await self._dedup_resolver.aenqueue_candidates(name, pairs)
+                    await dedup_resolver.aenqueue_candidates(name, pairs)
             except Exception as e:  # noqa: BLE001
                 logger.warning(
                     "[EmbeddingWorker] dedup enqueue failed for %s: %s",

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -1,0 +1,485 @@
+# -*- coding: utf-8 -*-
+"""
+FactDedupResolver — vector-aware deduplication of newly-written facts.
+
+The flow is intentionally LLM-arbitrated, NOT auto-merge on cosine
+threshold:
+
+  1. The embedding-worker sweep computes a vector for each fact and,
+     while it has both old and new vectors in hand, scans for
+     cosine > FACT_DEDUP_COSINE_THRESHOLD against existing facts of
+     the same entity.  Hits go into ``facts_pending_dedup.json``.
+  2. The idle-maintenance loop periodically calls ``aresolve(name)``,
+     which batches the queue into one LLM call asking the model to
+     classify each (candidate, existing) pair as ``merge`` / ``replace``
+     / ``keep_both``.
+  3. Decisions are applied to facts.json under the FactStore's
+     existing per-character file lock, then processed queue items
+     are removed.
+
+Why an LLM is in the loop:
+
+  * Cosine alone can't distinguish "主人喜欢猫" from "主人讨厌猫".
+    Both surface forms vary by 1 token but ride opposite poles.
+  * Hash-based dedup remains the first line of defence (catches exact
+    repeats, no LLM cost) and the FTS5 lightweight near-dup check
+    handles strong textual overlap.  This module addresses the
+    *paraphrase* class — "对猫咪很感兴趣" / "最近养了只猫" — that
+    legacy dedup misses entirely.
+
+When the EmbeddingService is disabled, no candidates are ever
+enqueued, so ``aresolve`` always sees an empty queue and the legacy
+hash + FTS5 dedup path is the entire dedup pipeline — exactly the
+behaviour pre-P2.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from memory.embeddings import cosine_similarity
+from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
+from utils.file_utils import (
+    atomic_write_json_async,
+    read_json_async,
+    robust_json_loads,
+)
+
+if TYPE_CHECKING:
+    from memory.facts import FactStore
+
+logger = logging.getLogger(__name__)
+
+
+# Cosine cutoff for "candidate is *probably* a paraphrase". 0.85 is
+# the design number from the P2 plan — empirically what Jina-v5 nano
+# emits for "主人喜欢猫" vs "对猫咪很感兴趣" (≈0.88) without false-
+# positives between "主人喜欢猫" / "主人讨厌猫" (≈0.78). Tunable per
+# deploy via the constant; lower values flood the LLM, higher misses
+# real paraphrases.
+FACT_DEDUP_COSINE_THRESHOLD = 0.85
+
+# Cap how many candidate pairs go into a single LLM call. The prompt
+# scales linearly with batch size, and the LLM's reliability degrades
+# past ~20 simultaneous classifications. Excess items wait for the
+# next aresolve tick.
+FACT_DEDUP_BATCH_LIMIT = 20
+
+# Cap how many pairs we enqueue from a single sweep. A pathological
+# new fact that's near-duplicate of 50 existing rows would otherwise
+# stuff the queue with N pairs, all about the same row. Bounded so
+# the queue stays interpretable.
+FACT_DEDUP_PAIRS_PER_NEW = 3
+
+
+class FactDedupResolver:
+    """Co-resident with FactStore. Owns the pending_dedup queue file
+    and the LLM-arbitrated resolve path.
+
+    Concurrency model: per-character asyncio.Lock guards the queue
+    file (multiple writers — embedding-worker enqueue + resolve-loop
+    consume).  FactStore's own threading.Lock guards facts.json, so
+    apply_decision delegates to FactStore's save path rather than
+    writing the file directly."""
+
+    def __init__(self, fact_store: "FactStore") -> None:
+        self._fact_store = fact_store
+        self._config_manager = fact_store._config_manager
+        self._alocks: dict[str, asyncio.Lock] = {}
+        self._alocks_guard = threading.Lock()
+
+    # ── lock helper ──────────────────────────────────────────────────
+
+    def _get_alock(self, name: str) -> asyncio.Lock:
+        """Per-character asyncio.Lock; lazy + DCL-guarded.
+
+        Same shape as PersonaManager._get_alock. asyncio.Lock binds to
+        the running loop on first acquire (CPython 3.10+), so the
+        threading.Lock here only protects the dict-mutation race —
+        not loop binding.
+        """
+        if name not in self._alocks:
+            with self._alocks_guard:
+                if name not in self._alocks:
+                    self._alocks[name] = asyncio.Lock()
+        return self._alocks[name]
+
+    # ── file paths ───────────────────────────────────────────────────
+
+    def _pending_path(self, name: str) -> str:
+        from memory import ensure_character_dir
+        return os.path.join(
+            ensure_character_dir(self._config_manager.memory_dir, name),
+            'facts_pending_dedup.json',
+        )
+
+    # ── queue I/O ────────────────────────────────────────────────────
+
+    async def aload_pending(self, name: str) -> list[dict]:
+        path = self._pending_path(name)
+        if not await asyncio.to_thread(os.path.exists, path):
+            return []
+        try:
+            data = await read_json_async(path)
+            if isinstance(data, list):
+                return data
+        except (json.JSONDecodeError, OSError):
+            # Corrupt queue file — treat as empty. The next enqueue
+            # rebuilds it; we'd rather lose pending dedup work than
+            # crash the resolver.
+            pass
+        return []
+
+    async def _asave_pending(self, name: str, items: list[dict]) -> None:
+        try:
+            assert_cloudsave_writable(
+                self._config_manager,
+                operation="save",
+                target=f"memory/{name}/facts_pending_dedup.json",
+            )
+        except MaintenanceModeError as exc:
+            logger.debug(
+                "[FactDedup] %s: 维护态跳过 facts_pending_dedup.json 写入: %s",
+                name, exc,
+            )
+            return
+        await atomic_write_json_async(
+            self._pending_path(name), items, indent=2, ensure_ascii=False,
+        )
+
+    async def aenqueue_candidates(
+        self, name: str, pairs: list[dict],
+    ) -> int:
+        """Append candidate (candidate_id, existing_id, …) pairs to
+        the queue. Returns count actually appended (de-duped against
+        existing pending items by (candidate_id, existing_id) pair).
+
+        Each pair dict must contain:
+          * candidate_id / existing_id — stable fact ids
+          * candidate_text / existing_text — for the LLM prompt
+          * cosine — scoring transparency (debugging + threshold tuning)
+
+        The id-pair dedup matters because an oscillating worker (e.g.
+        re-embed under a new model_id) would otherwise re-enqueue the
+        same pair on every sweep.
+        """
+        if not pairs:
+            return 0
+        async with self._get_alock(name):
+            existing = await self.aload_pending(name)
+            existing_keys = {
+                (it.get('candidate_id'), it.get('existing_id'))
+                for it in existing
+            }
+            now_iso = datetime.now().isoformat()
+            appended = 0
+            for p in pairs:
+                key = (p.get('candidate_id'), p.get('existing_id'))
+                if key in existing_keys or None in key:
+                    continue
+                existing.append({
+                    'candidate_id': p.get('candidate_id'),
+                    'existing_id': p.get('existing_id'),
+                    'candidate_text': p.get('candidate_text', ''),
+                    'existing_text': p.get('existing_text', ''),
+                    'entity': p.get('entity'),
+                    'cosine': float(p.get('cosine', 0.0)),
+                    'queued_at': now_iso,
+                })
+                existing_keys.add(key)
+                appended += 1
+            if appended:
+                await self._asave_pending(name, existing)
+                logger.info(
+                    "[FactDedup] %s: 入队 %d 对候选（队列总长 %d）",
+                    name, appended, len(existing),
+                )
+        return appended
+
+    # ── candidate detection ──────────────────────────────────────────
+
+    @staticmethod
+    def detect_candidates(
+        facts: list[dict],
+        *,
+        threshold: float = FACT_DEDUP_COSINE_THRESHOLD,
+        per_fact_limit: int = FACT_DEDUP_PAIRS_PER_NEW,
+        only_for_ids: set[str] | None = None,
+    ) -> list[dict]:
+        """Pure function: scan facts for cosine > threshold pairs.
+
+        ``only_for_ids`` constrains the *candidate* (newer) side so
+        the worker can pass the ids it just embedded — we don't want
+        to repeatedly scan the entire history on every sweep, only
+        check the new arrivals against existing rows.
+
+        Pairs are entity-scoped: ``主人喜欢猫`` (entity=master) should
+        not collide with ``关系融洽`` (entity=relationship) even if
+        the embeddings happen to be close. Cross-entity overlap is
+        weird enough that we'd rather defer it to manual review.
+
+        Pairs are absorbed-aware on the existing side: an existing
+        fact already absorbed into a reflection is skipped. Re-merging
+        a paraphrase into an absorbed fact would resurrect it from the
+        archive path, which is worse than the duplicate.
+        """
+        results: list[dict] = []
+        # Pre-bucket by entity so the inner loop only walks relevant rows.
+        by_entity: dict[str, list[dict]] = {}
+        for f in facts:
+            if not isinstance(f, dict):
+                continue
+            entity = f.get('entity') or 'master'
+            by_entity.setdefault(entity, []).append(f)
+
+        for f in facts:
+            if not isinstance(f, dict):
+                continue
+            cid = f.get('id')
+            if not cid:
+                continue
+            if only_for_ids is not None and cid not in only_for_ids:
+                continue
+            if f.get('absorbed'):
+                # Already folded into a reflection — merging or
+                # replacing now would create an inconsistency between
+                # the absorbed marker and the row's continued
+                # existence in active facts.
+                continue
+            cvec = f.get('embedding')
+            if not cvec:
+                # Cannot dedup without an embedding — skip; the
+                # worker will retry on its next sweep once the vector
+                # is filled.
+                continue
+            entity = f.get('entity') or 'master'
+            ctext = f.get('text', '')
+            collected = 0
+            # Sort siblings by cosine descending so we capture the
+            # strongest pair first; the per_fact_limit cap then keeps
+            # the queue interpretable when N rows are all near.
+            scored: list[tuple[float, dict]] = []
+            for sib in by_entity.get(entity, ()):
+                sid = sib.get('id')
+                if not sid or sid == cid:
+                    continue
+                if sib.get('absorbed'):
+                    continue
+                svec = sib.get('embedding')
+                if not svec:
+                    continue
+                cos = cosine_similarity(cvec, svec)
+                if cos < threshold:
+                    continue
+                scored.append((cos, sib))
+            scored.sort(key=lambda x: x[0], reverse=True)
+            for cos, sib in scored:
+                if collected >= per_fact_limit:
+                    break
+                results.append({
+                    'candidate_id': cid,
+                    'existing_id': sib.get('id'),
+                    'candidate_text': ctext,
+                    'existing_text': sib.get('text', ''),
+                    'entity': entity,
+                    'cosine': cos,
+                })
+                collected += 1
+        return results
+
+    # ── resolve loop ─────────────────────────────────────────────────
+
+    async def aresolve(self, name: str) -> int:
+        """Process one batch of pending items via a single LLM call.
+
+        Returns the number of items resolved (i.e. removed from the
+        queue this round). On LLM failure, the queue is preserved
+        intact so the next tick retries — failures here are transient
+        by definition (otherwise the model would never resolve them).
+
+        Concurrency: holds the per-character lock for the whole
+        load → LLM → apply → save sequence. The LLM call is the long
+        leg; concurrent enqueue calls block on the lock. That's
+        intentional — the alternative (release lock during LLM call)
+        introduces a TOCTOU between deciding which queue items we're
+        about to remove and removing them, which would lose new pairs
+        that landed mid-call.
+        """
+        async with self._get_alock(name):
+            return await self._aresolve_locked(name)
+
+    async def _aresolve_locked(self, name: str) -> int:
+        from config import SETTING_PROPOSER_MODEL
+        from config.prompts_memory import get_fact_dedup_prompt
+        from utils.language_utils import get_global_language
+        from utils.llm_client import create_chat_llm
+        from utils.token_tracker import set_call_type
+
+        pending = await self.aload_pending(name)
+        if not pending:
+            return 0
+
+        batch = pending[:FACT_DEDUP_BATCH_LIMIT]
+        pairs_text = "\n".join(
+            f"[{i}] candidate: {item.get('candidate_text', '')}"
+            f" | existing: {item.get('existing_text', '')}"
+            f" | cosine={item.get('cosine', 0.0):.3f}"
+            for i, item in enumerate(batch)
+        )
+        prompt = (
+            get_fact_dedup_prompt(get_global_language())
+            .replace('{PAIRS}', pairs_text)
+            .replace('{COUNT}', str(len(batch)))
+        )
+
+        try:
+            set_call_type("memory_fact_dedup")
+            api_config = self._config_manager.get_model_api_config('correction')
+            llm = create_chat_llm(
+                api_config.get('model', SETTING_PROPOSER_MODEL),
+                api_config['base_url'], api_config['api_key'],
+                temperature=0.2,
+            )
+            try:
+                resp = await llm.ainvoke(prompt)
+            finally:
+                await llm.aclose()
+            raw = resp.content.strip()
+            if raw.startswith("```"):
+                raw = raw.replace("```json", "").replace("```", "").strip()
+            results = robust_json_loads(raw)
+            if not isinstance(results, list):
+                logger.warning(
+                    "[FactDedup] %s: LLM 返回非数组 (%s)，跳过本轮",
+                    name, type(results).__name__,
+                )
+                return 0
+        except Exception as e:
+            logger.warning("[FactDedup] %s: LLM 调用失败: %s", name, e)
+            return 0
+
+        applied = await self._aapply_decisions(name, batch, results)
+
+        # Read-modify-write the queue so concurrent enqueue calls
+        # that landed during the LLM call survive — same shape as
+        # PersonaManager._resolve_corrections_locked's processed-keys
+        # filter at the end.
+        processed_keys: set[tuple] = set()
+        for r in results:
+            try:
+                idx = int(r.get('index', -1))
+            except (TypeError, ValueError):
+                continue
+            if 0 <= idx < len(batch):
+                item = batch[idx]
+                processed_keys.add((item.get('candidate_id'), item.get('existing_id')))
+        current = await self.aload_pending(name)
+        remaining = [
+            it for it in current
+            if (it.get('candidate_id'), it.get('existing_id')) not in processed_keys
+        ]
+        await self._asave_pending(name, remaining)
+        if applied:
+            logger.info(
+                "[FactDedup] %s: 处理 %d 对，剩余队列 %d 条",
+                name, applied, len(remaining),
+            )
+        return applied
+
+    async def _aapply_decisions(
+        self, name: str, batch: list[dict], results: list[dict],
+    ) -> int:
+        """Translate LLM decisions into facts.json mutations.
+
+        Decision vocabulary:
+          * ``merge``    — drop the candidate, bump existing.importance
+                           by +1 (capped at 10), append candidate_id
+                           to existing.merged_from_ids
+          * ``replace``  — drop the existing, keep the candidate
+                           (paraphrase but the new wording is better)
+          * ``keep_both``— no mutation, just clear from queue (LLM
+                           judged they're not actually duplicates)
+
+        Decisions referencing ids that no longer exist (e.g. a
+        concurrent /process absorbed them) are silently skipped —
+        the next sweep will re-enqueue if the situation recurs.
+        """
+        if not results:
+            return 0
+        facts = await self._fact_store.aload_facts(name)
+        by_id = {f.get('id'): f for f in facts if isinstance(f, dict) and f.get('id')}
+        applied = 0
+        ids_to_remove: set[str] = set()
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            try:
+                idx = int(r.get('index', -1))
+            except (TypeError, ValueError):
+                continue
+            if not (0 <= idx < len(batch)):
+                continue
+            item = batch[idx]
+            action = r.get('action', 'keep_both')
+            cand_id = item.get('candidate_id')
+            exist_id = item.get('existing_id')
+            cand = by_id.get(cand_id)
+            existing = by_id.get(exist_id)
+            if cand is None or existing is None:
+                # One side disappeared between enqueue and resolve —
+                # not an error, just stale; skip silently.
+                continue
+            if action == 'merge':
+                # Bump importance and record provenance on the existing
+                # row, then schedule the candidate for removal. The
+                # cap-at-10 mirrors _apersist_new_facts' clamp so a
+                # parade of paraphrases can't grow importance unbounded.
+                merged = list(existing.get('merged_from_ids') or [])
+                if cand_id not in merged:
+                    merged.append(cand_id)
+                existing['merged_from_ids'] = merged
+                cur_imp = int(existing.get('importance', 5) or 5)
+                existing['importance'] = min(10, cur_imp + 1)
+                ids_to_remove.add(cand_id)
+                applied += 1
+            elif action == 'replace':
+                # Mirror image: drop existing, keep candidate. Carry
+                # the existing's merged_from chain forward so we don't
+                # lose provenance back to its earlier paraphrases.
+                merged = list(cand.get('merged_from_ids') or [])
+                for mid in (existing.get('merged_from_ids') or []):
+                    if mid not in merged:
+                        merged.append(mid)
+                if exist_id not in merged:
+                    merged.append(exist_id)
+                cand['merged_from_ids'] = merged
+                # Importance: max of the two so a "replace" doesn't
+                # silently demote a high-importance row.
+                cur = int(cand.get('importance', 5) or 5)
+                old = int(existing.get('importance', 5) or 5)
+                cand['importance'] = max(cur, old)
+                ids_to_remove.add(exist_id)
+                applied += 1
+            else:  # keep_both
+                # No mutation, just count it as resolved so the queue
+                # entry is consumed.
+                applied += 1
+
+        if ids_to_remove:
+            # Use the in-memory list reference and rely on FactStore's
+            # asave_facts to persist. Removing in place preserves the
+            # FactStore's view-cache identity (same list object).
+            facts[:] = [f for f in facts if f.get('id') not in ids_to_remove]
+            await self._fact_store.asave_facts(name)
+        elif applied:
+            # Even pure keep_both rounds may have nudged nothing on
+            # facts.json, but we still need a save if importance was
+            # bumped on a merge above (handled by the ids_to_remove
+            # branch). The else here is no-op for the no-mutation case.
+            pass
+        return applied

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -408,6 +408,18 @@ class FactDedupResolver:
         Decisions referencing ids that no longer exist (e.g. a
         concurrent /process absorbed them) are silently skipped —
         the next sweep will re-enqueue if the situation recurs.
+
+        Conflict avoidance (Codex PR-957 P1): if the LLM returns
+        reciprocal decisions in the same batch — e.g. ``merge`` for
+        (c1, e1) (drop c1) and ``replace`` for (e1, c1) (drop e1) —
+        a naive "remove all ids in ids_to_remove at the end" would
+        delete BOTH facts and leave the user with nothing.  The
+        defensive guard is an in-loop check: if either side of the
+        current pair is already scheduled for removal by a prior
+        decision, skip this decision entirely.  The earlier decision
+        wins (LLM ordering matters), and the conflicting pair stays
+        out of the queue (consumed as `applied += 1`) so the next
+        round doesn't keep flagging it.
         """
         if not results:
             return 0
@@ -433,6 +445,18 @@ class FactDedupResolver:
             if cand is None or existing is None:
                 # One side disappeared between enqueue and resolve —
                 # not an error, just stale; skip silently.
+                continue
+            # Reciprocal-pair guard: an earlier decision in this batch
+            # already scheduled one side for removal. Honouring this
+            # decision too would either delete both facts (merge after
+            # replace) or mutate a row about to vanish.  Treat as
+            # consumed so the queue entry clears, but skip the apply.
+            if cand_id in ids_to_remove or exist_id in ids_to_remove:
+                logger.info(
+                    "[FactDedup] %s: 跳过冲突决策 cand=%s exist=%s (一方已被前一决策处理)",
+                    name, cand_id, exist_id,
+                )
+                applied += 1
                 continue
             if action == 'merge':
                 # Bump importance and record provenance on the existing

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -363,21 +363,18 @@ class FactDedupResolver:
             logger.warning("[FactDedup] %s: LLM 调用失败: %s", name, e)
             return 0
 
-        applied = await self._aapply_decisions(name, batch, results)
+        applied, processed_keys = await self._aapply_decisions(
+            name, batch, results,
+        )
 
         # Read-modify-write the queue so concurrent enqueue calls
         # that landed during the LLM call survive — same shape as
         # PersonaManager._resolve_corrections_locked's processed-keys
-        # filter at the end.
-        processed_keys: set[tuple] = set()
-        for r in results:
-            try:
-                idx = int(r.get('index', -1))
-            except (TypeError, ValueError):
-                continue
-            if 0 <= idx < len(batch):
-                item = batch[idx]
-                processed_keys.add((item.get('candidate_id'), item.get('existing_id')))
+        # filter at the end.  ``processed_keys`` comes from
+        # _aapply_decisions and explicitly excludes pairs whose LLM
+        # decision was malformed (unknown action) — those stay queued
+        # for retry rather than being silently dropped (CodeRabbit
+        # PR-957 Major).
         current = await self.aload_pending(name)
         remaining = [
             it for it in current
@@ -391,9 +388,17 @@ class FactDedupResolver:
             )
         return applied
 
+    # Whitelist of action vocabulary the LLM may return. Anything
+    # outside this set (case mismatch, trailing whitespace, localised
+    # synonym) is treated as malformed and the queue entry is
+    # preserved for retry — the alternative is silently dropping a
+    # paraphrase pair the next batch can no longer surface (CodeRabbit
+    # PR-957 Major).
+    _VALID_ACTIONS = frozenset({'merge', 'replace', 'keep_both'})
+
     async def _aapply_decisions(
         self, name: str, batch: list[dict], results: list[dict],
-    ) -> int:
+    ) -> tuple[int, set[tuple]]:
         """Translate LLM decisions into facts.json mutations.
 
         Decision vocabulary:
@@ -417,16 +422,23 @@ class FactDedupResolver:
         defensive guard is an in-loop check: if either side of the
         current pair is already scheduled for removal by a prior
         decision, skip this decision entirely.  The earlier decision
-        wins (LLM ordering matters), and the conflicting pair stays
-        out of the queue (consumed as `applied += 1`) so the next
-        round doesn't keep flagging it.
+        wins (LLM ordering matters); the conflicting pair is still
+        consumed (so the next round doesn't keep flagging it).
+
+        Returns ``(applied_count, processed_pair_keys)``.  The set
+        contains the (candidate_id, existing_id) keys for queue
+        entries the caller should *remove* — exactly the entries we
+        applied or consumed via the conflict guard, NOT the ones we
+        skipped due to malformed LLM output (those stay queued for
+        retry).
         """
         if not results:
-            return 0
+            return 0, set()
         facts = await self._fact_store.aload_facts(name)
         by_id = {f.get('id'): f for f in facts if isinstance(f, dict) and f.get('id')}
         applied = 0
         ids_to_remove: set[str] = set()
+        processed_pairs: set[tuple] = set()
         for r in results:
             if not isinstance(r, dict):
                 continue
@@ -437,14 +449,36 @@ class FactDedupResolver:
             if not (0 <= idx < len(batch)):
                 continue
             item = batch[idx]
-            action = r.get('action', 'keep_both')
+            action = r.get('action')
+            # Strict whitelist (CodeRabbit PR-957 Major): unknown
+            # action ⇒ leave the queue entry alone so the next round
+            # gets a fresh chance.  Without this, "MERGE" / "merge "
+            # / a localised synonym would silently drop into the
+            # else-branch, then get cleared from the queue by the
+            # caller's `processed_keys` filter — losing the
+            # arbitration entirely.  Defensive normalisation
+            # (lowercase + strip) gives the LLM a tiny grace margin
+            # without opening the door to genuine garbage.
+            if isinstance(action, str):
+                action_norm = action.strip().lower()
+            else:
+                action_norm = None
+            if action_norm not in self._VALID_ACTIONS:
+                logger.warning(
+                    "[FactDedup] %s: LLM 返回未知 action=%r，pair (%s,%s) 保留队列待下轮重试",
+                    name, action, item.get('candidate_id'), item.get('existing_id'),
+                )
+                continue
+            action = action_norm
             cand_id = item.get('candidate_id')
             exist_id = item.get('existing_id')
             cand = by_id.get(cand_id)
             existing = by_id.get(exist_id)
             if cand is None or existing is None:
                 # One side disappeared between enqueue and resolve —
-                # not an error, just stale; skip silently.
+                # not an error, just stale; consume the queue entry
+                # so it doesn't keep blocking subsequent batches.
+                processed_pairs.add((cand_id, exist_id))
                 continue
             # Reciprocal-pair guard: an earlier decision in this batch
             # already scheduled one side for removal. Honouring this
@@ -456,6 +490,7 @@ class FactDedupResolver:
                     "[FactDedup] %s: 跳过冲突决策 cand=%s exist=%s (一方已被前一决策处理)",
                     name, cand_id, exist_id,
                 )
+                processed_pairs.add((cand_id, exist_id))
                 applied += 1
                 continue
             if action == 'merge':
@@ -470,6 +505,7 @@ class FactDedupResolver:
                 cur_imp = int(existing.get('importance', 5) or 5)
                 existing['importance'] = min(10, cur_imp + 1)
                 ids_to_remove.add(cand_id)
+                processed_pairs.add((cand_id, exist_id))
                 applied += 1
             elif action == 'replace':
                 # Mirror image: drop existing, keep candidate. Carry
@@ -488,10 +524,12 @@ class FactDedupResolver:
                 old = int(existing.get('importance', 5) or 5)
                 cand['importance'] = max(cur, old)
                 ids_to_remove.add(exist_id)
+                processed_pairs.add((cand_id, exist_id))
                 applied += 1
             else:  # keep_both
                 # No mutation, just count it as resolved so the queue
                 # entry is consumed.
+                processed_pairs.add((cand_id, exist_id))
                 applied += 1
 
         if ids_to_remove:
@@ -506,4 +544,4 @@ class FactDedupResolver:
             # bumped on a merge above (handled by the ids_to_remove
             # branch). The else here is no-op for the no-mutation case.
             pass
-        return applied
+        return applied, processed_pairs

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -457,6 +457,7 @@ class FactStore:
     async def _aload_signal_targets(
         self, lanlan_name: str,
         reflection_engine=None, persona_manager=None,
+        new_facts: list[dict] | None = None,
     ) -> list[dict]:
         """Assemble the Stage-2 `existing_observations` set.
 
@@ -466,8 +467,12 @@ class FactStore:
 
         Scale control (§3.4.2 end):
           - Hard cap: top-N by evidence_score DESC (N = EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS)
-          - TODO PR follow-up: filter by new_facts[*].entity once Stage-1
-            returns entity; for now broad pool is acceptable (<200 items typical).
+          - When ``new_facts`` is provided AND the EmbeddingService is
+            ready, the cap is replaced by a vector-prefiltered + LLM-
+            reranked top-N (see memory/recall.py). Vectors save the
+            Stage-2 prompt tokens by narrowing the candidate set
+            from ~200 down to a much smaller LLM-validated subset;
+            the LLM call itself is still made.
 
         Injection pattern: memory_server wires `reflection_engine` / `persona_manager`
         references at call time. Without them we return empty, which simply
@@ -492,6 +497,20 @@ class FactStore:
                         'text': r.get('text', ''),
                         'entity': r.get('entity', 'relationship'),
                         'score': evidence_score(r, now),
+                        'embedding': r.get('embedding'),
+                        'embedding_text_sha256': r.get('embedding_text_sha256'),
+                        'embedding_model_id': r.get('embedding_model_id'),
+                        'status': r.get('status'),
+                        # Carry the AI-mention rate-limit suppress flag
+                        # so MemoryRecallReranker._hard_filter can drop
+                        # suppressed reflections from the rerank pool —
+                        # reflections share persona's 5h-window mention
+                        # gating (see ReflectionEngine._normalize_reflection).
+                        # Codex PR-958 P2: without this, a vector-recall
+                        # path with a suppressed reflection would slip
+                        # past the filter and re-enter Stage-2 signal
+                        # detection, defeating the suppression contract.
+                        'suppress': r.get('suppress'),
                     })
             except Exception as e:
                 logger.debug(
@@ -519,13 +538,40 @@ class FactStore:
                             'text': entry.get('text', ''),
                             'entity': entity_key,
                             'score': evidence_score(entry, now),
+                            'embedding': entry.get('embedding'),
+                            'embedding_text_sha256': entry.get('embedding_text_sha256'),
+                            'embedding_model_id': entry.get('embedding_model_id'),
+                            'suppress': entry.get('suppress'),
                         })
             except Exception as e:
                 logger.debug(
                     f"[FactStore] _aload_signal_targets 读取 persona 失败: {e}"
                 )
 
-        # Top-N by score DESC (most relevant first)
+        # P2 step 3: vector + LLM rerank when we have a query (new_facts)
+        # and the embedding service is ready. Otherwise legacy "top-N
+        # by evidence_score" — same behaviour as before P2.
+        if new_facts:
+            try:
+                from memory.recall import MemoryRecallReranker
+                reranker = MemoryRecallReranker()
+                if reranker._service.is_available():
+                    query_texts = [
+                        f.get('text', '') for f in new_facts if f.get('text')
+                    ]
+                    return await reranker.aretrieve_candidates(
+                        pool, query_texts,
+                        budget=EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS,
+                        config_manager=self._config_manager,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "[FactStore] vector+LLM rerank failed (%s: %s); "
+                    "falling back to evidence_score order",
+                    type(e).__name__, e,
+                )
+
+        # Fallback / legacy path: top-N by score DESC (most relevant first).
         pool.sort(key=lambda o: o.get('score', 0.0), reverse=True)
         return pool[:EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS]
 
@@ -652,6 +698,11 @@ class FactStore:
             lanlan_name,
             reflection_engine=reflection_engine,
             persona_manager=persona_manager,
+            # Pass the freshly-persisted facts as the recall query so
+            # the vector+LLM rerank can narrow the candidate set
+            # semantically. Without new_facts the call falls back to
+            # evidence_score ordering (the legacy behaviour).
+            new_facts=persisted,
         )
         if not existing_observations:
             return persisted, []

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -161,6 +161,19 @@ class MemoryRecallReranker:
 
     # ── phase 1: hard filter ─────────────────────────────────────────
 
+    # Reflection statuses we drop from the rerank pool.  Note that
+    # ``promoted`` is NOT here even though it lives in
+    # `memory.reflection.REFLECTION_TERMINAL_STATUSES`: the upstream
+    # `_aload_signal_targets` deliberately ships ``confirmed +
+    # promoted`` as Stage-2 observation candidates (a promoted
+    # reflection is the strongest signal we have — confirmed,
+    # consolidated into persona, and still active).  Filtering it out
+    # here would silently shrink the pool below what the legacy path
+    # produced (CodeRabbit PR-957 Major).
+    _REFLECTION_DROP_STATUSES = frozenset({
+        'denied', 'archived', 'merged', 'promote_blocked',
+    })
+
     @staticmethod
     def _hard_filter(observations: list[dict]) -> list[dict]:
         """Drop everything we know up-front shouldn't reach the LLM:
@@ -168,8 +181,10 @@ class MemoryRecallReranker:
           * ``score < 0`` — evidence net-negative; user has been
             disputing this more than confirming it.
           * suppressed — explicit "AI is over-mentioning this" gate.
-          * terminal-status reflection — promoted/denied/archived/etc
-            shouldn't generate fresh signals.
+          * truly-dead reflection (denied / archived / merged /
+            promote_blocked) — these are dead-letter or already
+            consumed, can't generate fresh signals.  ``promoted`` is
+            kept because the upstream pool includes it.
           * protected persona — character-card source; evidence is
             effectively infinite there, no signal would ever flip it.
 
@@ -177,8 +192,6 @@ class MemoryRecallReranker:
         consolidated into one function so callers don't duplicate the
         list.
         """
-        from memory.reflection import REFLECTION_TERMINAL_STATUSES
-
         out: list[dict] = []
         for o in observations:
             if not isinstance(o, dict):
@@ -192,7 +205,8 @@ class MemoryRecallReranker:
                 continue
             target_type = o.get('target_type')
             status = o.get('status')
-            if target_type == 'reflection' and status in REFLECTION_TERMINAL_STATUSES:
+            if (target_type == 'reflection'
+                    and status in MemoryRecallReranker._REFLECTION_DROP_STATUSES):
                 continue
             text = o.get('text', '')
             if not text or not text.strip():
@@ -244,7 +258,16 @@ class MemoryRecallReranker:
         if not query_vectors:
             return evidence_sorted[:k]
 
-        scored: list[tuple[float, dict]] = []
+        # Split into two pools so un-embedded candidates can't be
+        # starved out by embedded ones at the [:k] truncation
+        # (CodeRabbit PR-957 Major).  The original implementation
+        # tagged un-embedded with cosine = -1.0, then sorted+sliced —
+        # whenever there were ≥k embedded candidates, every
+        # unembedded one fell off the cliff before reaching the LLM
+        # rerank, even though the docstring promised they'd "fall
+        # through to the LLM rerank below the cosine-ranked rows".
+        embedded_scored: list[tuple[float, dict]] = []
+        unembedded: list[dict] = []
         for o in observations:
             text = o.get('text', '')
             cvec = o.get('embedding')
@@ -255,15 +278,36 @@ class MemoryRecallReranker:
                 best = max(
                     cosine_similarity(cvec, qv) for qv in query_vectors
                 )
+                embedded_scored.append((best, o))
             else:
-                best = -1.0  # below all cosine values, but above "missing"
-            scored.append((best, o))
-        # Sort: cosine DESC, evidence_score DESC as tie-breaker.
-        scored.sort(
+                unembedded.append(o)
+        # Sort embedded by cosine DESC, evidence_score DESC tie-break.
+        embedded_scored.sort(
             key=lambda pair: (pair[0], pair[1].get('score', 0.0)),
             reverse=True,
         )
-        return [o for _, o in scored[:k]]
+        embedded_ranked = [o for _, o in embedded_scored]
+        # Sort unembedded by evidence_score DESC — the only signal we
+        # have for them, and the legacy fallback for the whole pool
+        # uses the same key.
+        unembedded.sort(key=lambda o: o.get('score', 0.0), reverse=True)
+        # Reserve up to UNEMBEDDED_QUOTA slots for unembedded entries
+        # so the LLM rerank gets a chance to text-match them.  Fill
+        # the rest with embedded entries (the cosine-ranked majority).
+        unembed_quota = max(1, k // (COARSE_OVERSAMPLE + 1)) if unembedded else 0
+        unembed_quota = min(unembed_quota, len(unembedded))
+        embed_slot_count = max(0, k - unembed_quota)
+        result = (
+            embedded_ranked[:embed_slot_count]
+            + unembedded[:unembed_quota]
+        )
+        # If the embedded pool was smaller than its allotment, top up
+        # from the unembedded tail so we always emit min(k, total).
+        deficit = k - len(result)
+        if deficit > 0:
+            tail = unembedded[unembed_quota:unembed_quota + deficit]
+            result.extend(tail)
+        return result[:k]
 
     # ── phase 3: LLM rerank ──────────────────────────────────────────
 

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -47,14 +47,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+import re
 
 from memory.embeddings import (
     cosine_similarity,
     get_embedding_service,
     is_cached_embedding_valid,
 )
-from memory.evidence import evidence_score
 
 logger = logging.getLogger(__name__)
 
@@ -269,9 +268,12 @@ class MemoryRecallReranker:
         embedded_scored: list[tuple[float, dict]] = []
         unembedded: list[dict] = []
         for o in observations:
+            # ``observations`` already passed through ``_hard_filter``,
+            # which guarantees every entry is a dict with non-empty
+            # text — no need for a defensive isinstance check here.
             text = o.get('text', '')
             cvec = o.get('embedding')
-            if isinstance(o, dict) and is_cached_embedding_valid(o, text, model_id):
+            if is_cached_embedding_valid(o, text, model_id):
                 # Max-cosine across query vectors. Candidates with
                 # equal cosine fall back to evidence_score for tie-
                 # breaking — covered in the unit test.
@@ -375,7 +377,14 @@ class MemoryRecallReranker:
             await llm.aclose()
         raw = resp.content.strip()
         if raw.startswith("```"):
-            raw = raw.replace("```json", "").replace("```", "").strip()
+            # Case-insensitive strip handles ``` / ```json / ```JSON /
+            # ```Json — small models occasionally emit non-canonical
+            # casing or trailing newline immediately after the fence
+            # tag, which the previous literal `.replace("```json", "")`
+            # would miss.
+            raw = re.sub(r'^```\w*\s*\n?', '', raw, count=1)
+            raw = re.sub(r'\n?\s*```\s*$', '', raw, count=1)
+            raw = raw.strip()
         decisions = robust_json_loads(raw)
         if not isinstance(decisions, list):
             logger.warning(

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -1,0 +1,371 @@
+# -*- coding: utf-8 -*-
+"""
+MemoryRecallReranker — vector pre-rank + LLM rerank for memory recall.
+
+Step 3 of P2.  Replaces the "top-N by evidence_score" heuristic that
+``FactStore._aload_signal_targets`` uses today to pick candidates for
+the Stage-2 signal-detection LLM call.  The new pipeline is:
+
+  1. **Hard filter** — exclude entries with ``evidence_score < 0``,
+     suppressed entries, terminal-status reflections, and persona
+     entries marked ``protected`` (character-card sources).  Same
+     semantics as today's render-time filters.
+
+  2. **Coarse rank (vectors)** — when the EmbeddingService is
+     available AND the caller passed in query texts (typically the
+     newly-extracted facts), embed the queries, compute max-cosine
+     between each candidate and any query, sort DESC, keep the top
+     ``budget * COARSE_OVERSAMPLE`` rows (default 3 ×).  Without an
+     embedding service or without query texts, this stage is a no-op
+     and the original list passes through.
+
+  3. **Fine rank (LLM)** — when embeddings produced more than
+     ``budget`` candidates AND the LLM rerank prompt is configured,
+     send the candidate set + query texts to a small LLM call asking
+     for the most relevant ``budget`` items.  ``evidence_score`` is
+     surfaced in the prompt as an auxiliary signal ("this entry has
+     been confirmed N times by the user") rather than mixed into the
+     ranking math — the LLM weighs it together with semantic
+     relevance.  When the LLM call fails or vectors are off, the
+     coarse-rank order (or evidence_score when even coarse failed)
+     is used as the final order.
+
+Fallback: when ``EmbeddingService`` is permanently disabled, the
+whole pipeline degrades to "evidence_score DESC + top ``budget``" —
+exactly the current behaviour, no LLM call cost added.
+
+Why vectors are a *prefilter*, not a replacement: cosine alone can't
+tell ``主人喜欢猫`` from ``主人讨厌猫`` (≈0.78), and "semantically
+near" entries that the user didn't actually mean to bring up trigger
+false positives in Stage-2 signal detection (which would either
+reinforce or negate the wrong observation).  Keeping the LLM as the
+arbiter means we save *prompt tokens* (smaller candidate set in the
+Stage-2 prompt), not *LLM calls* — RFC §3.4 stays unchanged in
+shape.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+from memory.embeddings import (
+    cosine_similarity,
+    get_embedding_service,
+    is_cached_embedding_valid,
+)
+from memory.evidence import evidence_score
+
+logger = logging.getLogger(__name__)
+
+
+# Coarse-rank oversample factor — top-K = budget * this. The factor is
+# the "confidence headroom" we give the LLM rerank: 3× means the
+# semantic shortlist is 3× the budget so the LLM has 2 candidates per
+# slot to choose from. Lower would over-trust cosine; higher would
+# stuff the LLM prompt with more text than it can rank reliably.
+COARSE_OVERSAMPLE = 3
+
+
+class MemoryRecallReranker:
+    """Stateless apart from the embedding service handle. Construct
+    once per process and call ``aretrieve_candidates`` per recall."""
+
+    def __init__(self) -> None:
+        self._service = get_embedding_service()
+
+    async def aretrieve_candidates(
+        self,
+        observations: list[dict],
+        query_texts: list[str] | None,
+        *,
+        budget: int,
+        config_manager,            # for the LLM rerank call
+        rerank: bool = True,
+    ) -> list[dict]:
+        """Return up to ``budget`` candidate observations, ranked.
+
+        ``observations`` is the union of persona + reflection rows the
+        caller wants to consider, each carrying at least ``id``,
+        ``text``, ``entity``, ``score`` (evidence_score, see
+        ``memory.evidence.evidence_score``), and ideally an
+        ``embedding`` triple.
+
+        ``query_texts`` is the recall query in natural language —
+        typically the texts of newly-extracted facts.  None or
+        empty disables the cosine prefilter and falls back to
+        evidence_score order.
+
+        ``rerank=False`` skips the LLM call (used by tests and the
+        fallback path) and returns the coarse-ranked top-``budget``
+        directly.
+        """
+        if not observations:
+            return []
+
+        # Phase 1: hard filter (suppressed / terminal / score < 0 /
+        # protected).  This is the only stage that uses evidence_score
+        # *directly* — everything else treats it as auxiliary signal.
+        survivors = self._hard_filter(observations)
+        if not survivors:
+            return []
+
+        # Phase 2: coarse rank.
+        coarse_pool_size = budget * COARSE_OVERSAMPLE
+        coarse = await self._coarse_rank(
+            survivors, query_texts, k=coarse_pool_size,
+        )
+        if len(coarse) <= budget or not rerank:
+            return coarse[:budget]
+
+        # When the embedding service isn't available, the coarse step
+        # already produced an evidence_score-DESC ordering — there's
+        # no semantic basis to rerank further, so don't pay the LLM
+        # cost. Mirrors the design intent: "vectors disabled ⇒
+        # entirely the legacy stage 1/2 path".
+        if not self._service.is_available():
+            return coarse[:budget]
+
+        # Phase 3: LLM rerank — only fires when we have enough
+        # candidates that picking the best `budget` actually involves
+        # judgment. Below the budget, every candidate makes the cut
+        # anyway, so the LLM call would be wasted tokens.
+        try:
+            from config.prompts_memory import get_memory_recall_rerank_prompt
+            from utils.language_utils import get_global_language
+        except ImportError:
+            # Prompt not available yet — degrade to coarse rank.
+            return coarse[:budget]
+
+        if not query_texts:
+            # No queries → no semantic basis for an LLM rerank;
+            # coarse order (which is also evidence_score order in
+            # this branch) is the best we can do.
+            return coarse[:budget]
+
+        try:
+            ranked = await self._fine_rank(
+                coarse, query_texts, budget=budget,
+                config_manager=config_manager,
+                lang=get_global_language(),
+                prompt_loader=get_memory_recall_rerank_prompt,
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort, never crash recall
+            logger.warning(
+                "[MemoryRecall] LLM rerank failed (%s: %s); "
+                "falling back to coarse rank order",
+                type(e).__name__, e,
+            )
+            ranked = coarse[:budget]
+        return ranked
+
+    # ── phase 1: hard filter ─────────────────────────────────────────
+
+    @staticmethod
+    def _hard_filter(observations: list[dict]) -> list[dict]:
+        """Drop everything we know up-front shouldn't reach the LLM:
+
+          * ``score < 0`` — evidence net-negative; user has been
+            disputing this more than confirming it.
+          * suppressed — explicit "AI is over-mentioning this" gate.
+          * terminal-status reflection — promoted/denied/archived/etc
+            shouldn't generate fresh signals.
+          * protected persona — character-card source; evidence is
+            effectively infinite there, no signal would ever flip it.
+
+        These are the same exclusions the render path already uses,
+        consolidated into one function so callers don't duplicate the
+        list.
+        """
+        from memory.reflection import REFLECTION_TERMINAL_STATUSES
+
+        out: list[dict] = []
+        for o in observations:
+            if not isinstance(o, dict):
+                continue
+            score = o.get('score')
+            if score is not None and score < 0:
+                continue
+            if o.get('suppress') or o.get('suppressed'):
+                continue
+            if o.get('protected'):
+                continue
+            target_type = o.get('target_type')
+            status = o.get('status')
+            if target_type == 'reflection' and status in REFLECTION_TERMINAL_STATUSES:
+                continue
+            text = o.get('text', '')
+            if not text or not text.strip():
+                continue
+            out.append(o)
+        return out
+
+    # ── phase 2: coarse rank by cosine ───────────────────────────────
+
+    async def _coarse_rank(
+        self,
+        observations: list[dict],
+        query_texts: list[str] | None,
+        *,
+        k: int,
+    ) -> list[dict]:
+        """Cosine top-K against ``query_texts``. Falls through to
+        evidence_score order when vectors aren't usable.
+
+        Each candidate is scored as the *max* cosine across all query
+        texts (``query_text`` represents "things the user just
+        mentioned"; we want the candidate to be relevant to ANY of
+        them, not the average across all). max-pool also matches the
+        single-query case trivially.
+
+        Candidates without a usable embedding (worker hasn't reached
+        them yet, or model_id mismatch) are kept in the coarse pool
+        but with cosine = 0 — they fall through to the LLM rerank
+        below the cosine-ranked rows. Better than dropping them
+        entirely, since they may still be the right answer if the LLM
+        can match on text alone.
+        """
+        # Default: evidence_score order (the legacy behaviour).
+        evidence_sorted = sorted(
+            observations, key=lambda o: o.get('score', 0.0), reverse=True,
+        )
+        if not query_texts:
+            return evidence_sorted[:k]
+        if not self._service.is_available():
+            return evidence_sorted[:k]
+        model_id = self._service.model_id()
+        if model_id is None:
+            return evidence_sorted[:k]
+
+        query_vectors = await self._service.embed_batch(
+            [t for t in query_texts if t],
+        )
+        query_vectors = [v for v in query_vectors if v is not None]
+        if not query_vectors:
+            return evidence_sorted[:k]
+
+        scored: list[tuple[float, dict]] = []
+        for o in observations:
+            text = o.get('text', '')
+            cvec = o.get('embedding')
+            if isinstance(o, dict) and is_cached_embedding_valid(o, text, model_id):
+                # Max-cosine across query vectors. Candidates with
+                # equal cosine fall back to evidence_score for tie-
+                # breaking — covered in the unit test.
+                best = max(
+                    cosine_similarity(cvec, qv) for qv in query_vectors
+                )
+            else:
+                best = -1.0  # below all cosine values, but above "missing"
+            scored.append((best, o))
+        # Sort: cosine DESC, evidence_score DESC as tie-breaker.
+        scored.sort(
+            key=lambda pair: (pair[0], pair[1].get('score', 0.0)),
+            reverse=True,
+        )
+        return [o for _, o in scored[:k]]
+
+    # ── phase 3: LLM rerank ──────────────────────────────────────────
+
+    async def _fine_rank(
+        self,
+        candidates: list[dict],
+        query_texts: list[str],
+        *,
+        budget: int,
+        config_manager,
+        lang: str,
+        prompt_loader,
+    ) -> list[dict]:
+        """Single LLM call: rerank ``candidates`` against
+        ``query_texts``, return up to ``budget`` items in the LLM's
+        preferred order.
+
+        ``evidence_score`` is included in the prompt as a parenthetical
+        annotation ("score=N") so the LLM can use it as auxiliary
+        signal (a confirmed-many-times observation deserves slight
+        priority over a fresh one), but the math no longer mixes
+        evidence into a single rank — the dimension mismatch with
+        cosine and the inability to encode "user has explicitly
+        suppressed this" both make a linear blend wrong.
+        """
+        from utils.file_utils import robust_json_loads
+        from utils.token_tracker import set_call_type
+        from utils.llm_client import create_chat_llm
+        from config import SETTING_PROPOSER_MODEL
+
+        # The id-keyed indirection prevents the LLM from inventing
+        # ids that aren't in the candidate set.
+        cand_lines = []
+        id_to_obs: dict[str, dict] = {}
+        for c in candidates:
+            cid = c.get('id') or c.get('raw_id')
+            if not cid:
+                continue
+            id_to_obs[cid] = c
+            score = c.get('score', 0.0)
+            cand_lines.append(
+                f"[{cid}] (score={score:.2f}) {c.get('text', '')}"
+            )
+        if not cand_lines:
+            return []
+
+        query_text = "\n".join(f"- {q}" for q in query_texts if q)
+        prompt = (
+            prompt_loader(lang)
+            .replace('{QUERY}', query_text)
+            .replace('{CANDIDATES}', "\n".join(cand_lines))
+            .replace('{BUDGET}', str(budget))
+        )
+
+        set_call_type("memory_recall_rerank")
+        api_config = config_manager.get_model_api_config('correction')
+        llm = create_chat_llm(
+            api_config.get('model', SETTING_PROPOSER_MODEL),
+            api_config['base_url'], api_config['api_key'],
+            temperature=0.2,
+        )
+        try:
+            resp = await llm.ainvoke(prompt)
+        finally:
+            await llm.aclose()
+        raw = resp.content.strip()
+        if raw.startswith("```"):
+            raw = raw.replace("```json", "").replace("```", "").strip()
+        decisions = robust_json_loads(raw)
+        if not isinstance(decisions, list):
+            logger.warning(
+                "[MemoryRecall] rerank returned non-list (%s); falling back",
+                type(decisions).__name__,
+            )
+            return candidates[:budget]
+
+        # Pull ids in order, drop any the LLM hallucinated, cap at
+        # budget. If the LLM returned fewer than budget, top up from
+        # the coarse-rank tail so the caller still gets `budget` rows
+        # whenever there were that many candidates.
+        ranked: list[dict] = []
+        seen: set[str] = set()
+        for d in decisions:
+            if not isinstance(d, dict):
+                continue
+            cid = d.get('id')
+            if not isinstance(cid, str) or cid in seen:
+                continue
+            obs = id_to_obs.get(cid)
+            if obs is None:
+                continue
+            ranked.append(obs)
+            seen.add(cid)
+            if len(ranked) >= budget:
+                break
+        if len(ranked) < budget:
+            for c in candidates:
+                cid = c.get('id') or c.get('raw_id')
+                if cid in seen or not cid:
+                    continue
+                ranked.append(c)
+                seen.add(cid)
+                if len(ranked) >= budget:
+                    break
+        return ranked

--- a/memory_server.py
+++ b/memory_server.py
@@ -1698,12 +1698,11 @@ async def startup_event_handler():
         # globals atomically; capturing the instances here would let
         # the worker keep writing through the old managers and clobber
         # post-reload updates from the new ones.
-        # Dedup resolver shares the FactStore — its enqueue side is
-        # called from the embedding worker after each fact-sweep, its
-        # resolve side is called from the idle-maintenance loop below.
-        # NOTE: this resolver still snapshots fact_store at construction,
-        # which has the same /reload-staleness shape the worker just
-        # fixed. Tracked for a follow-up — see PR comment.
+        # The dedup resolver follows the same pattern: reload rebuilds
+        # it against the new FactStore (see reload_memory_components),
+        # and the worker reads the current instance per sweep so
+        # enqueue and the idle-maintenance loop's resolve never end up
+        # racing on facts_pending_dedup.json across two instances.
         fact_dedup_resolver = FactDedupResolver(fact_store)
 
         embedding_warmup_worker = EmbeddingWarmupWorker(
@@ -1712,7 +1711,7 @@ async def startup_event_handler():
             get_fact_store=lambda: fact_store,
             get_character_names=_current_catgirl_names,
             warmup_delay_seconds=VECTORS_WARMUP_DELAY_SECONDS,
-            dedup_resolver=fact_dedup_resolver,
+            get_dedup_resolver=lambda: fact_dedup_resolver,
         )
         embedding_warmup_worker.start()
     except Exception as e:

--- a/memory_server.py
+++ b/memory_server.py
@@ -168,7 +168,7 @@ async def reload_memory_components():
     atomic_write_json 保证单次写原子，极端 last-writer-wins 场景下最多
     损失一次 cursor 推进——下一轮 tick 即恢复。
     """
-    global recent_history_manager, settings_manager, time_manager, fact_store, persona_manager, reflection_engine, cursor_store, outbox, event_log, reconciler
+    global recent_history_manager, settings_manager, time_manager, fact_store, persona_manager, reflection_engine, cursor_store, outbox, event_log, reconciler, fact_dedup_resolver
     async with _reload_lock:
         logger.info("[MemoryServer] 开始重新加载记忆组件配置...")
         old_time_manager = time_manager
@@ -187,6 +187,19 @@ async def reload_memory_components():
             new_outbox = Outbox()
             new_reconciler = Reconciler(new_event_log)
             _register_evidence_handlers(new_reconciler, new_persona, new_reflection)
+            # P2 step 2: rebuild fact_dedup_resolver against the NEW
+            # FactStore so /reload doesn't leave the resolver pointing
+            # at the orphaned old store (Codex PR-957 P2). The
+            # embedding worker bound to the old fact_store keeps
+            # writing into facts_pending_dedup.json under the
+            # per-character path, which the new resolver picks up
+            # automatically since the queue is on disk.
+            try:
+                from memory.fact_dedup import FactDedupResolver
+                new_fact_dedup_resolver = FactDedupResolver(new_facts)
+            except Exception as e:
+                logger.warning(f"[MemoryServer] reload: fact_dedup_resolver 重建失败: {e}")
+                new_fact_dedup_resolver = None
 
             # 然后原子性地交换引用
             recent_history_manager = new_recent
@@ -199,6 +212,7 @@ async def reload_memory_components():
             outbox = new_outbox
             event_log = new_event_log
             reconciler = new_reconciler
+            fact_dedup_resolver = new_fact_dedup_resolver
 
             if old_time_manager is not None and old_time_manager is not new_time:
                 _defer_time_manager_cleanup(old_time_manager)
@@ -789,6 +803,32 @@ async def _periodic_idle_maintenance_loop():
                     except Exception as e:
                         logger.warning(f"[IdleMaint] {name}: 历史记录压缩失败: {e}")
 
+                # ── 子任务1b: Fact 向量去重（P2 step 2） ──
+                # Runs *before* the review-gate so a character with
+                # short history still gets paraphrase consolidation
+                # (Codex PR-957 P2). The embedding worker enqueued
+                # candidate paraphrase pairs after the last fact-sweep;
+                # resolve them here via a single LLM call.
+                # fact_dedup_resolver is None when vectors are disabled
+                # or bootstrap failed — legacy hash + FTS5 dedup
+                # remains the entire dedup pipeline in that case.
+                if fact_dedup_resolver is not None:
+                    if not _is_idle():
+                        break
+                    try:
+                        pending_dedup = await fact_dedup_resolver.aload_pending(name)
+                        if pending_dedup:
+                            logger.info(
+                                f"[IdleMaint] {name}: 发现 {len(pending_dedup)} 对未处理的 fact 候选去重，触发 LLM 审视"
+                            )
+                            resolved = await fact_dedup_resolver.aresolve(name)
+                            if resolved:
+                                logger.info(
+                                    f"[IdleMaint] {name}: 完成 {resolved} 对 fact 去重决策"
+                                )
+                    except Exception as e:
+                        logger.warning(f"[IdleMaint] {name}: fact 向量去重失败: {e}")
+
                 # 历史不足 REVIEW_SKIP_HISTORY_LEN 条，或全局开关关闭 → 跳过矛盾审视和 review
                 if history_len < REVIEW_SKIP_HISTORY_LEN or not review_enabled:
                     continue
@@ -807,30 +847,6 @@ async def _periodic_idle_maintenance_loop():
                             logger.info(f"[IdleMaint] {name}: 审视了 {resolved} 条 persona 矛盾")
                 except Exception as e:
                     logger.warning(f"[IdleMaint] {name}: persona 矛盾审视失败: {e}")
-
-                # ── 子任务2b: Fact 向量去重（P2 step 2） ──
-                # The embedding worker enqueued candidate paraphrase
-                # pairs after the last fact-sweep; resolve them here
-                # via a single LLM call. fact_dedup_resolver is None
-                # when vectors are disabled or bootstrap failed —
-                # legacy hash + FTS5 dedup remains the entire dedup
-                # pipeline in that case.
-                if fact_dedup_resolver is not None:
-                    if not _is_idle():
-                        break
-                    try:
-                        pending_dedup = await fact_dedup_resolver.aload_pending(name)
-                        if pending_dedup:
-                            logger.info(
-                                f"[IdleMaint] {name}: 发现 {len(pending_dedup)} 对未处理的 fact 候选去重，触发 LLM 审视"
-                            )
-                            resolved = await fact_dedup_resolver.aresolve(name)
-                            if resolved:
-                                logger.info(
-                                    f"[IdleMaint] {name}: 完成 {resolved} 对 fact 去重决策"
-                                )
-                    except Exception as e:
-                        logger.warning(f"[IdleMaint] {name}: fact 向量去重失败: {e}")
 
                 # ── 子任务3: 记忆整理 review ──
                 if not _is_idle():

--- a/memory_server.py
+++ b/memory_server.py
@@ -136,6 +136,11 @@ reconciler: Reconciler | None = None
 # unblock the warmup wait early. None when vectors are disabled or
 # the worker bootstrap raised.
 embedding_warmup_worker = None
+# memory-enhancements P2: fact vector dedup resolver. Shares the
+# FactStore with the embedding worker (worker enqueues candidates,
+# the idle-maintenance loop resolves them). None when bootstrap
+# fails or the embedding service is permanently disabled.
+fact_dedup_resolver = None
 
 # 用于保护重新加载操作的锁
 _reload_lock = asyncio.Lock()
@@ -802,6 +807,30 @@ async def _periodic_idle_maintenance_loop():
                             logger.info(f"[IdleMaint] {name}: 审视了 {resolved} 条 persona 矛盾")
                 except Exception as e:
                     logger.warning(f"[IdleMaint] {name}: persona 矛盾审视失败: {e}")
+
+                # ── 子任务2b: Fact 向量去重（P2 step 2） ──
+                # The embedding worker enqueued candidate paraphrase
+                # pairs after the last fact-sweep; resolve them here
+                # via a single LLM call. fact_dedup_resolver is None
+                # when vectors are disabled or bootstrap failed —
+                # legacy hash + FTS5 dedup remains the entire dedup
+                # pipeline in that case.
+                if fact_dedup_resolver is not None:
+                    if not _is_idle():
+                        break
+                    try:
+                        pending_dedup = await fact_dedup_resolver.aload_pending(name)
+                        if pending_dedup:
+                            logger.info(
+                                f"[IdleMaint] {name}: 发现 {len(pending_dedup)} 对未处理的 fact 候选去重，触发 LLM 审视"
+                            )
+                            resolved = await fact_dedup_resolver.aresolve(name)
+                            if resolved:
+                                logger.info(
+                                    f"[IdleMaint] {name}: 完成 {resolved} 对 fact 去重决策"
+                                )
+                    except Exception as e:
+                        logger.warning(f"[IdleMaint] {name}: fact 向量去重失败: {e}")
 
                 # ── 子任务3: 记忆整理 review ──
                 if not _is_idle():
@@ -1621,9 +1650,10 @@ async def startup_event_handler():
     # batches. The whole feature is a no-op if the EmbeddingService can't
     # find onnxruntime + a model file, so we always start the task — the
     # service's own fallback gate decides whether anything actually happens.
-    global embedding_warmup_worker
+    global embedding_warmup_worker, fact_dedup_resolver
     try:
         from memory.embedding_worker import EmbeddingWarmupWorker
+        from memory.fact_dedup import FactDedupResolver
         from config import VECTORS_WARMUP_DELAY_SECONDS
 
         # Resolve characters dynamically on each tick rather than
@@ -1643,12 +1673,18 @@ async def startup_event_handler():
                 # known characters keep getting backfilled.
                 return list(catgirl_names)
 
+        # Dedup resolver shares the FactStore — its enqueue side is
+        # called from the embedding worker after each fact-sweep, its
+        # resolve side is called from the idle-maintenance loop below.
+        fact_dedup_resolver = FactDedupResolver(fact_store)
+
         embedding_warmup_worker = EmbeddingWarmupWorker(
             persona_manager=persona_manager,
             reflection_engine=reflection_engine,
             fact_store=fact_store,
             get_character_names=_current_catgirl_names,
             warmup_delay_seconds=VECTORS_WARMUP_DELAY_SECONDS,
+            dedup_resolver=fact_dedup_resolver,
         )
         embedding_warmup_worker.start()
     except Exception as e:
@@ -1656,6 +1692,7 @@ async def startup_event_handler():
         # vectors are an optimization, not a correctness requirement.
         logger.warning(f"[Memory] embedding worker bootstrap failed: {e}")
         embedding_warmup_worker = None
+        fact_dedup_resolver = None
 
 
 @app.on_event("shutdown")

--- a/tests/unit/test_embedding_worker.py
+++ b/tests/unit/test_embedding_worker.py
@@ -157,6 +157,7 @@ class _FactStub:
 
 def _build_worker(
     *, service, persona, reflection, fact, names=("小天",), warmup_delay=0.01,
+    dedup_resolver=None,
 ) -> EmbeddingWarmupWorker:
     w = EmbeddingWarmupWorker(
         persona_manager=persona,
@@ -164,11 +165,24 @@ def _build_worker(
         fact_store=fact,
         get_character_names=lambda: list(names),
         warmup_delay_seconds=warmup_delay,
+        dedup_resolver=dedup_resolver,
     )
     # Hand the stub in by replacement — get_embedding_service() was
     # called in __init__, so we override the attribute directly.
     w._service = service
     return w
+
+
+class _DedupResolverStub:
+    """Captures aenqueue_candidates calls so the integration test can
+    assert the worker forwards the right pairs after a fact sweep."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[dict]]] = []
+
+    async def aenqueue_candidates(self, name: str, pairs: list[dict]) -> int:
+        self.calls.append((name, list(pairs)))
+        return len(pairs)
 
 
 # ── tests ────────────────────────────────────────────────────────────
@@ -437,6 +451,75 @@ async def test_notify_first_process_idempotent():
     w.notify_first_process()
     w.notify_first_process()
     assert w._first_process_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_fact_sweep_forwards_dedup_candidates_when_resolver_present():
+    """End-to-end integration with FactDedupResolver: after the worker
+    embeds new fact rows, it should call aenqueue_candidates with the
+    cosine-collision pairs detected against the rest of the pool.
+    Confirms the wiring step 2 added in memory_server.py — without
+    this, the dedup queue stays empty even with vectors enabled."""
+    service = _FakeService(
+        available=True, model_id="fake-128d-int8",
+        # Force every embedding to be the same vector so cosine = 1.0
+        # for every pair, guaranteed above the 0.85 threshold.
+        vector_factory=lambda text: [1.0, 0.0, 0.0, 0.0],
+    )
+    persona = _PersonaStub()
+    reflection = _ReflectionStub()
+    fact = _FactStub()
+    fact.store["小天"] = [
+        # Pre-seeded existing row with a vector under the SAME model_id
+        # — this is the cosine-collision target.
+        {"id": "e1", "text": "主人喜欢猫", "entity": "master",
+         "embedding": [1.0, 0.0, 0.0, 0.0],
+         "embedding_text_sha256": _embedding_text_sha256("主人喜欢猫"),
+         "embedding_model_id": "fake-128d-int8",
+         "absorbed": False},
+        # New row needing embedding — worker fills it in this sweep
+        # and then detects the collision against e1.
+        {"id": "c1", "text": "对猫咪很感兴趣", "entity": "master",
+         "embedding": None, "embedding_text_sha256": None,
+         "embedding_model_id": None, "absorbed": False},
+    ]
+    dedup = _DedupResolverStub()
+    w = _build_worker(
+        service=service, persona=persona, reflection=reflection, fact=fact,
+        dedup_resolver=dedup,
+    )
+    processed = await w._sweep_once()
+    assert processed >= 1
+    # Worker must have called the resolver for the freshly-embedded row.
+    assert dedup.calls, "worker did not forward dedup candidates"
+    name, pairs = dedup.calls[0]
+    assert name == "小天"
+    assert any(p["candidate_id"] == "c1" and p["existing_id"] == "e1" for p in pairs)
+
+
+@pytest.mark.asyncio
+async def test_fact_sweep_skips_dedup_when_resolver_is_none():
+    """Without a resolver attached, the worker still embeds fact rows
+    but never calls into the dedup path. This preserves the legacy
+    hash-only dedup behaviour for installations that haven't enabled
+    the LLM arbitration loop yet."""
+    service = _FakeService(available=True, model_id="fake-128d-int8")
+    persona = _PersonaStub()
+    reflection = _ReflectionStub()
+    fact = _FactStub()
+    fact.store["小天"] = [
+        {"id": "c1", "text": "x", "entity": "master",
+         "embedding": None, "embedding_text_sha256": None,
+         "embedding_model_id": None, "absorbed": False},
+    ]
+    w = _build_worker(
+        service=service, persona=persona, reflection=reflection, fact=fact,
+        dedup_resolver=None,
+    )
+    processed = await w._sweep_once()
+    # Embedding still happened; no dedup machinery to crash on.
+    assert processed >= 1
+    assert fact.store["小天"][0]["embedding"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_embedding_worker.py
+++ b/tests/unit/test_embedding_worker.py
@@ -165,7 +165,7 @@ def _build_worker(
         get_fact_store=lambda: fact,
         get_character_names=lambda: list(names),
         warmup_delay_seconds=warmup_delay,
-        dedup_resolver=dedup_resolver,
+        get_dedup_resolver=(lambda: dedup_resolver) if dedup_resolver is not None else None,
     )
     # Hand the stub in by replacement — get_embedding_service() was
     # called in __init__, so we override the attribute directly.
@@ -624,3 +624,72 @@ async def test_save_failure_returns_zero_to_avoid_hot_loop():
     # progress accounting must reflect 0 so the outer loop backs off.
     assert fact.save_calls == 1
     assert processed == 0
+
+
+@pytest.mark.asyncio
+async def test_dedup_resolver_observed_via_live_getter():
+    """Regression for the resolver's /reload swap: reload_memory_components
+    rebuilds fact_dedup_resolver against the new FactStore, but the
+    embedding worker has to look up the current resolver per sweep —
+    otherwise post-reload enqueue still hits the OLD resolver while
+    idle-maintenance's resolve runs against the NEW one, racing on the
+    same facts_pending_dedup.json without a shared lock.
+
+    This test pins the getter pattern; if someone reverts to a snapshot
+    on `__init__`, the second sweep would still call the old resolver
+    and the assertion on `new_resolver.calls` would fail."""
+    service = _FakeService(available=True, model_id="fake-128d-int8")
+
+    persona = _PersonaStub()
+    reflection = _ReflectionStub()
+    state = {
+        "fact": _FactStub(),
+        "resolver": _DedupResolverStub(),
+    }
+    # Two pre-existing facts with embeddings + one fresh fact — the
+    # detect_candidates pass needs an embedded neighbour to flag the
+    # fresh one as a paraphrase candidate. Cosine >= 0.9 threshold;
+    # identical 4-vec gives cosine 1.0.
+    base_emb = [0.5, 0.5, 0.5, 0.5]
+    state["fact"].store["小天"] = [
+        {"id": "fact-old", "entity": "user", "text": "old",
+         "embedding": list(base_emb), "embedding_text_sha256": "x",
+         "embedding_model_id": "fake-128d-int8", "absorbed": False},
+        {"id": "fact-new", "entity": "user", "text": "old paraphrase",
+         "embedding": None,
+         "embedding_text_sha256": None, "embedding_model_id": None,
+         "absorbed": False},
+    ]
+    w = EmbeddingWarmupWorker(
+        get_persona_manager=lambda: persona,
+        get_reflection_engine=lambda: reflection,
+        get_fact_store=lambda: state["fact"],
+        get_character_names=lambda: ["小天"],
+        warmup_delay_seconds=0.01,
+        get_dedup_resolver=lambda: state["resolver"],
+    )
+    w._service = service
+    # First sweep: original resolver receives the enqueue.
+    await w._sweep_once()
+    assert len(state["resolver"].calls) >= 1
+    original_resolver = state["resolver"]
+
+    # Simulate /reload: new fact store + new resolver, queued candidate.
+    new_fact = _FactStub()
+    new_fact.store["小天"] = [
+        {"id": "fact-a", "entity": "user", "text": "alpha",
+         "embedding": list(base_emb), "embedding_text_sha256": "y",
+         "embedding_model_id": "fake-128d-int8", "absorbed": False},
+        {"id": "fact-b", "entity": "user", "text": "alpha rephrased",
+         "embedding": None,
+         "embedding_text_sha256": None, "embedding_model_id": None,
+         "absorbed": False},
+    ]
+    new_resolver = _DedupResolverStub()
+    state["fact"] = new_fact
+    state["resolver"] = new_resolver
+
+    await w._sweep_once()
+    # The NEW resolver got the enqueue, not the old one.
+    assert len(new_resolver.calls) >= 1
+    assert len(original_resolver.calls) == 1  # unchanged after reload

--- a/tests/unit/test_fact_dedup.py
+++ b/tests/unit/test_fact_dedup.py
@@ -1,0 +1,511 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for memory.fact_dedup.FactDedupResolver — vector-aware
+fact deduplication via LLM arbitration.
+
+Covers four contracts:
+
+  1. ``detect_candidates`` returns entity-scoped, absorbed-aware,
+     cosine-thresholded (candidate, existing) pairs and respects the
+     per-fact cap so a pathological row can't flood the queue.
+  2. ``aenqueue_candidates`` deduplicates by (candidate_id, existing_id)
+     so an oscillating worker (e.g. re-embed under a new model_id)
+     can't grow the queue unboundedly with the same pair.
+  3. ``aresolve`` translates LLM ``merge`` / ``replace`` / ``keep_both``
+     decisions into facts.json mutations correctly: merge bumps
+     importance + records candidate id under merged_from_ids, replace
+     promotes the candidate and carries provenance forward, keep_both
+     leaves both rows untouched.
+  4. The whole pipeline degrades correctly when the LLM call fails —
+     queue stays intact for the next tick, no facts are lost.
+
+We do NOT exercise the real LLM. The resolve-path tests stub
+`utils.llm_client.create_chat_llm` the same way PR #941's
+test_persona_version_history.py does."""
+from __future__ import annotations
+
+import json
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from memory.fact_dedup import (
+    FACT_DEDUP_BATCH_LIMIT,
+    FACT_DEDUP_COSINE_THRESHOLD,
+    FACT_DEDUP_PAIRS_PER_NEW,
+    FactDedupResolver,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _mock_cm(tmpdir: str):
+    cm = MagicMock()
+    cm.memory_dir = tmpdir
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    return cm
+
+
+def _install_resolver(tmpdir: str):
+    """Build a FactStore + FactDedupResolver bound to ``tmpdir`` so
+    facts.json and facts_pending_dedup.json round-trip through real
+    file I/O — that's the contract the queue depends on for crash-
+    recovery."""
+    from memory.facts import FactStore
+
+    cm = _mock_cm(tmpdir)
+    with patch("memory.facts.get_config_manager", return_value=cm):
+        fs = FactStore()
+        fs._config_manager = cm
+    resolver = FactDedupResolver(fs)
+    resolver._config_manager = cm
+    return fs, resolver
+
+
+def _fact(fid: str, text: str, *, entity: str = "master",
+          embedding: list[float] | None = None,
+          importance: int = 5,
+          absorbed: bool = False,
+          merged_from_ids: list[str] | None = None) -> dict:
+    return {
+        "id": fid,
+        "text": text,
+        "entity": entity,
+        "importance": importance,
+        "tags": [],
+        "hash": fid + "h",
+        "created_at": "2026-04-25T10:00:00",
+        "absorbed": absorbed,
+        "merged_from_ids": merged_from_ids or [],
+        "embedding": list(embedding) if embedding is not None else None,
+        "embedding_text_sha256": "sha-" + fid if embedding else None,
+        "embedding_model_id": "jina-v5-nano-128d-int8" if embedding else None,
+    }
+
+
+def _make_llm_mock(payload):
+    resp = MagicMock()
+    resp.content = json.dumps(payload)
+
+    async def _ainvoke(*_a, **_k):
+        return resp
+
+    async def _aclose():
+        return None
+
+    llm = MagicMock()
+    llm.ainvoke = _ainvoke
+    llm.aclose = _aclose
+    return llm
+
+
+# ── detect_candidates ────────────────────────────────────────────────
+
+
+def test_detect_candidates_emits_pair_above_threshold():
+    """The bread-and-butter case: two near-identical embeddings under
+    the same entity surface as a candidate pair."""
+    a_vec = [1.0, 0.0, 0.0, 0.0]
+    b_vec = [0.99, 0.05, 0.05, 0.05]
+    facts = [
+        _fact("f1", "主人喜欢猫", embedding=a_vec),
+        _fact("f2", "主人对猫咪很感兴趣", embedding=b_vec),
+    ]
+    pairs = FactDedupResolver.detect_candidates(facts)
+    assert len(pairs) >= 1
+    pair = next(p for p in pairs if p["candidate_id"] == "f1")
+    assert pair["existing_id"] == "f2"
+    assert pair["entity"] == "master"
+    assert pair["cosine"] > FACT_DEDUP_COSINE_THRESHOLD
+
+
+def test_detect_candidates_below_threshold_no_pair():
+    """Cosine < threshold ⇒ no pair. Keeps "主人喜欢猫" / "主人讨厌猫"
+    style polarity flips out of the queue (they ride opposite halves
+    of the embedding space ≈0.78 in practice)."""
+    a_vec = [1.0, 0.0, 0.0]
+    b_vec = [0.0, 1.0, 0.0]
+    facts = [
+        _fact("f1", "主人喜欢猫", embedding=a_vec),
+        _fact("f2", "主人讨厌猫", embedding=b_vec),
+    ]
+    assert FactDedupResolver.detect_candidates(facts) == []
+
+
+def test_detect_candidates_respects_entity_scope():
+    """master + relationship entries don't collide even with identical
+    embeddings — cross-entity dedup is too risky to defer to vectors."""
+    same_vec = [1.0, 0.0, 0.0]
+    facts = [
+        _fact("f1", "主人喜欢猫", entity="master", embedding=same_vec),
+        _fact("f2", "他们关系融洽", entity="relationship", embedding=same_vec),
+    ]
+    assert FactDedupResolver.detect_candidates(facts) == []
+
+
+def test_detect_candidates_skips_absorbed_existing():
+    """An absorbed fact has already been folded into a reflection; we
+    don't want to resurrect it via a paraphrase merge."""
+    same_vec = [1.0, 0.0, 0.0]
+    facts = [
+        _fact("f1", "新表述", embedding=same_vec),
+        _fact("f2", "旧表述", embedding=same_vec, absorbed=True),
+    ]
+    assert FactDedupResolver.detect_candidates(facts) == []
+
+
+def test_detect_candidates_skips_self():
+    """A row never collides with itself (cosine = 1 trivially)."""
+    facts = [_fact("f1", "x", embedding=[1.0, 0.0])]
+    assert FactDedupResolver.detect_candidates(facts) == []
+
+
+def test_detect_candidates_only_for_ids_filters_candidate_side():
+    """only_for_ids constrains the *candidate* (newer) side so the
+    worker doesn't repeatedly scan the entire history on every sweep
+    — only the rows it just embedded count as candidates."""
+    same_vec = [1.0, 0.0, 0.0]
+    facts = [
+        _fact("f1", "old", embedding=same_vec),
+        _fact("f2", "old paraphrase", embedding=same_vec),
+        _fact("f3", "new", embedding=same_vec),
+    ]
+    # Only f3 is "new"; f1/f2 should never appear as candidate side.
+    pairs = FactDedupResolver.detect_candidates(
+        facts, only_for_ids={"f3"},
+    )
+    assert all(p["candidate_id"] == "f3" for p in pairs)
+
+
+def test_detect_candidates_per_fact_limit_caps_collisions():
+    """A pathological row near 5 existing rows must not produce 5
+    pairs — the cap keeps the queue interpretable."""
+    same_vec = [1.0, 0.0, 0.0]
+    facts = [_fact("f0", "candidate", embedding=same_vec)]
+    for i in range(8):
+        facts.append(_fact(f"e{i}", f"existing {i}", embedding=same_vec))
+    pairs = FactDedupResolver.detect_candidates(
+        facts, only_for_ids={"f0"},
+    )
+    assert len(pairs) == FACT_DEDUP_PAIRS_PER_NEW
+
+
+def test_detect_candidates_skips_rows_without_embedding():
+    """A row whose embedding hasn't been computed yet can't participate
+    — the warmup worker will retry on its next sweep."""
+    facts = [
+        _fact("f1", "x", embedding=[1.0, 0.0]),
+        _fact("f2", "y", embedding=None),
+    ]
+    assert FactDedupResolver.detect_candidates(facts) == []
+
+
+# ── aenqueue_candidates ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aenqueue_candidates_appends_and_persists(tmp_path):
+    """Append round-trips through atomic_write_json + read_json so
+    crash-recovery works (queue file IS the source of truth)."""
+    _, resolver = _install_resolver(str(tmp_path))
+    appended = await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "f1", "existing_id": "f2",
+        "candidate_text": "a", "existing_text": "b",
+        "entity": "master", "cosine": 0.91,
+    }])
+    assert appended == 1
+    pending = await resolver.aload_pending("小天")
+    assert len(pending) == 1
+    assert pending[0]["candidate_id"] == "f1"
+    assert pending[0]["cosine"] == pytest.approx(0.91)
+    assert pending[0]["queued_at"]
+
+
+@pytest.mark.asyncio
+async def test_aenqueue_dedups_same_pair_across_calls(tmp_path):
+    """Re-enqueue of the same (candidate_id, existing_id) pair must
+    no-op — otherwise an oscillating worker (re-embed under new
+    model_id) would grow the queue unboundedly with duplicates."""
+    _, resolver = _install_resolver(str(tmp_path))
+    pair = {
+        "candidate_id": "f1", "existing_id": "f2",
+        "candidate_text": "a", "existing_text": "b",
+        "entity": "master", "cosine": 0.91,
+    }
+    await resolver.aenqueue_candidates("小天", [pair])
+    appended2 = await resolver.aenqueue_candidates("小天", [pair])
+    assert appended2 == 0
+    pending = await resolver.aload_pending("小天")
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_aenqueue_skips_rows_with_missing_ids(tmp_path):
+    """Defensive: malformed pair (no candidate_id) shouldn't pollute
+    the queue or crash."""
+    _, resolver = _install_resolver(str(tmp_path))
+    appended = await resolver.aenqueue_candidates("小天", [
+        {"candidate_id": None, "existing_id": "f2"},
+        {"candidate_id": "f1", "existing_id": None},
+    ])
+    assert appended == 0
+    assert await resolver.aload_pending("小天") == []
+
+
+# ── aresolve: action handling ────────────────────────────────────────
+
+
+async def _seed_facts(fs, name: str, facts: list[dict]) -> None:
+    """Write facts straight to the in-memory store and flush to disk."""
+    fs._facts[name] = list(facts)
+    await fs.asave_facts(name)
+
+
+@pytest.mark.asyncio
+async def test_aresolve_merge_drops_candidate_and_bumps_importance(tmp_path):
+    """merge ⇒ keep existing, drop candidate, importance += 1 (capped at 10),
+    candidate id appended to existing.merged_from_ids."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "对猫咪很感兴趣", embedding=[1.0, 0.0])
+    existing = _fact("e1", "主人喜欢猫", embedding=[0.99, 0.05], importance=4)
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": cand["text"], "existing_text": existing["text"],
+        "entity": "master", "cosine": 0.99,
+    }])
+    fake_llm = _make_llm_mock([{"index": 0, "action": "merge"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 1
+    facts = await fs.aload_facts("小天")
+    ids = {f["id"] for f in facts}
+    assert ids == {"e1"}  # candidate removed
+    survivor = next(f for f in facts if f["id"] == "e1")
+    assert survivor["importance"] == 5  # 4 + 1
+    assert "c1" in (survivor.get("merged_from_ids") or [])
+    # Queue is empty after resolve.
+    assert await resolver.aload_pending("小天") == []
+
+
+@pytest.mark.asyncio
+async def test_aresolve_merge_caps_importance_at_ten(tmp_path):
+    """A parade of paraphrase merges shouldn't grow importance above
+    the documented 1..10 range — same clamp as _apersist_new_facts."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "x", embedding=[1.0, 0.0])
+    existing = _fact("e1", "y", embedding=[0.99, 0.05], importance=10)
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": "x", "existing_text": "y",
+        "entity": "master", "cosine": 0.99,
+    }])
+    fake_llm = _make_llm_mock([{"index": 0, "action": "merge"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await resolver.aresolve("小天")
+    survivor = next(f for f in await fs.aload_facts("小天") if f["id"] == "e1")
+    assert survivor["importance"] == 10
+
+
+@pytest.mark.asyncio
+async def test_aresolve_replace_keeps_candidate_and_carries_provenance(tmp_path):
+    """replace ⇒ keep candidate, drop existing. Existing's
+    merged_from_ids chain transfers to candidate so we don't lose the
+    earlier paraphrase trail."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "新表述", embedding=[1.0, 0.0], importance=6)
+    existing = _fact(
+        "e1", "旧表述", embedding=[0.99, 0.05], importance=4,
+        merged_from_ids=["older_id"],
+    )
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": "新表述", "existing_text": "旧表述",
+        "entity": "master", "cosine": 0.99,
+    }])
+    fake_llm = _make_llm_mock([{"index": 0, "action": "replace"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 1
+    facts = await fs.aload_facts("小天")
+    assert {f["id"] for f in facts} == {"c1"}
+    survivor = next(f for f in facts if f["id"] == "c1")
+    # Importance: max of the two (don't silently demote a strong row)
+    assert survivor["importance"] == 6
+    chain = set(survivor.get("merged_from_ids") or [])
+    assert "older_id" in chain
+    assert "e1" in chain
+
+
+@pytest.mark.asyncio
+async def test_aresolve_keep_both_leaves_facts_untouched(tmp_path):
+    """keep_both ⇒ both rows survive intact, queue cleared.
+    This is the safety-net branch for "high cosine but actually
+    different" decisions."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "主人喜欢猫", embedding=[1.0, 0.0], importance=5)
+    existing = _fact("e1", "主人讨厌狗", embedding=[0.95, 0.05], importance=3)
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": cand["text"], "existing_text": existing["text"],
+        "entity": "master", "cosine": 0.99,
+    }])
+    fake_llm = _make_llm_mock([{"index": 0, "action": "keep_both"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 1
+    facts = await fs.aload_facts("小天")
+    assert {f["id"] for f in facts} == {"c1", "e1"}
+    # Importance unchanged on both
+    assert next(f for f in facts if f["id"] == "c1")["importance"] == 5
+    assert next(f for f in facts if f["id"] == "e1")["importance"] == 3
+    # Queue is consumed even though no mutation happened
+    assert await resolver.aload_pending("小天") == []
+
+
+@pytest.mark.asyncio
+async def test_aresolve_skips_decision_for_disappeared_row(tmp_path):
+    """If a fact in the queue has been deleted between enqueue and
+    resolve (e.g. concurrent absorbed-archive sweep), the decision
+    silently no-ops — better than crashing the whole batch."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    # Only the existing survives; candidate "c1" is absent from disk.
+    existing = _fact("e1", "x", embedding=[1.0, 0.0], importance=5)
+    await _seed_facts(fs, "小天", [existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": "x", "existing_text": "x",
+        "entity": "master", "cosine": 0.99,
+    }])
+    fake_llm = _make_llm_mock([{"index": 0, "action": "merge"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        # Resolved count is 0 because the merge couldn't apply (cand missing).
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 0
+    survivor = next(f for f in await fs.aload_facts("小天") if f["id"] == "e1")
+    assert survivor["importance"] == 5  # untouched
+    # Queue entry IS still removed — staleness shouldn't keep it
+    # blocking the next batch.
+    pending = await resolver.aload_pending("小天")
+    assert all(p["candidate_id"] != "c1" for p in pending)
+
+
+# ── aresolve: failure modes ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aresolve_llm_failure_preserves_queue(tmp_path):
+    """LLM call raises ⇒ queue is intact for the next tick. Losing
+    pending dedup work is worse than skipping a round."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "x", embedding=[1.0, 0.0])
+    existing = _fact("e1", "y", embedding=[0.99, 0.05])
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": "x", "existing_text": "y",
+        "entity": "master", "cosine": 0.99,
+    }])
+
+    class _BoomLLM:
+        async def ainvoke(self, *_a, **_k):
+            raise RuntimeError("simulated network failure")
+
+        async def aclose(self):
+            return None
+
+    with patch("utils.llm_client.create_chat_llm", return_value=_BoomLLM()):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 0
+    # Both facts still present, queue still has the pair.
+    assert {f["id"] for f in await fs.aload_facts("小天")} == {"c1", "e1"}
+    pending = await resolver.aload_pending("小天")
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_aresolve_empty_queue_is_noop(tmp_path):
+    """No pending pairs ⇒ early-out without an LLM call. Critical for
+    the idle loop to be cheap when nothing's queued."""
+    fs, resolver = _install_resolver(str(tmp_path))
+
+    # Patch create_chat_llm to a mock that records calls; assert it's
+    # never invoked because aresolve must early-out before calling.
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 0
+    assert create_llm.call_count == 0
+
+
+def test_fact_dedup_prompt_has_all_five_locales_with_placeholders():
+    """The prompt is sent to a multilingual model — all five locales
+    must be present and each must include both placeholders the
+    resolver substitutes (PAIRS, COUNT). A missing locale would silently
+    fall back to zh via _loc; a missing placeholder would let the LLM
+    see literal {PAIRS} / {COUNT} text and produce garbage."""
+    from config.prompts_memory import FACT_DEDUP_PROMPT, get_fact_dedup_prompt
+    expected_locales = {"zh", "en", "ja", "ko", "ru"}
+    assert set(FACT_DEDUP_PROMPT.keys()) >= expected_locales
+    for lang in expected_locales:
+        rendered = (
+            get_fact_dedup_prompt(lang)
+            .replace("{PAIRS}", "X")
+            .replace("{COUNT}", "1")
+        )
+        # No leftover unsubstituted placeholders.
+        assert "{PAIRS}" not in rendered, lang
+        assert "{COUNT}" not in rendered, lang
+
+
+@pytest.mark.asyncio
+async def test_aresolve_batch_limit_caps_in_flight_pairs(tmp_path):
+    """Resolve only processes BATCH_LIMIT items per call so the LLM
+    prompt stays within sane bounds; remainder waits for next tick."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    facts = []
+    pending_pairs = []
+    for i in range(FACT_DEDUP_BATCH_LIMIT + 5):
+        facts.append(_fact(f"c{i}", f"cand {i}", embedding=[1.0, 0.0]))
+        facts.append(_fact(f"e{i}", f"exist {i}", embedding=[1.0, 0.0]))
+        pending_pairs.append({
+            "candidate_id": f"c{i}", "existing_id": f"e{i}",
+            "candidate_text": "x", "existing_text": "y",
+            "entity": "master", "cosine": 0.99,
+        })
+    await _seed_facts(fs, "小天", facts)
+    await resolver.aenqueue_candidates("小天", pending_pairs)
+    # LLM responds keep_both for every batch item — easiest
+    # decision with no facts.json mutations to assert against.
+    response = [
+        {"index": i, "action": "keep_both"}
+        for i in range(FACT_DEDUP_BATCH_LIMIT)
+    ]
+    fake_llm = _make_llm_mock(response)
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == FACT_DEDUP_BATCH_LIMIT
+    pending = await resolver.aload_pending("小天")
+    assert len(pending) == 5  # remaining queued pairs
+
+    # Second tick clears the rest.
+    response2 = [
+        {"index": i, "action": "keep_both"} for i in range(5)
+    ]
+    fake_llm2 = _make_llm_mock(response2)
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm2):
+        resolved2 = await resolver.aresolve("小天")
+    assert resolved2 == 5
+    assert await resolver.aload_pending("小天") == []

--- a/tests/unit/test_fact_dedup.py
+++ b/tests/unit/test_fact_dedup.py
@@ -415,6 +415,67 @@ async def test_aresolve_reciprocal_pair_does_not_delete_both(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aresolve_unknown_action_preserves_queue_for_retry(tmp_path):
+    """CodeRabbit PR-957 Major: an LLM that returns an action outside
+    the {merge, replace, keep_both} whitelist (case mismatch, trailing
+    whitespace, localised synonym, hallucinated word) used to fall
+    into the keep_both branch AND get cleared from the queue, silently
+    losing the arbitration. The fix: strict whitelist + queue
+    preservation so the next round gets a fresh chance."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "x", embedding=[1.0, 0.0])
+    existing = _fact("e1", "y", embedding=[0.99, 0.05], importance=4)
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": "x", "existing_text": "y",
+        "entity": "master", "cosine": 0.99,
+    }])
+    # LLM returns "MERGE" (uppercase) instead of "merge" — the strict
+    # whitelist+normalise lets this through (we lowercase + strip), but
+    # genuine garbage like "FOOBAR" must NOT be silently consumed.
+    fake_llm = _make_llm_mock([{"index": 0, "action": "FOOBAR"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await resolver.aresolve("小天")
+    # No mutation applied — both rows survive intact, importance unchanged.
+    facts = await fs.aload_facts("小天")
+    assert {f["id"] for f in facts} == {"c1", "e1"}
+    assert next(f for f in facts if f["id"] == "e1")["importance"] == 4
+    # Queue entry MUST still be there for the next round to retry.
+    pending = await resolver.aload_pending("小天")
+    assert len(pending) == 1
+    assert (pending[0]["candidate_id"], pending[0]["existing_id"]) == ("c1", "e1")
+    # `applied` count is 0 — nothing was actually decided.
+    assert resolved == 0
+
+
+@pytest.mark.asyncio
+async def test_aresolve_normalises_case_and_whitespace_in_action(tmp_path):
+    """The whitelist accepts a tiny normalisation grace margin
+    (lowercase + strip) so a model that emits "MERGE" or "merge "
+    isn't rejected for trivial formatting. Exercises the contract
+    documented in `_VALID_ACTIONS`."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    cand = _fact("c1", "x", embedding=[1.0, 0.0])
+    existing = _fact("e1", "y", embedding=[0.99, 0.05], importance=4)
+    await _seed_facts(fs, "小天", [cand, existing])
+    await resolver.aenqueue_candidates("小天", [{
+        "candidate_id": "c1", "existing_id": "e1",
+        "candidate_text": "x", "existing_text": "y",
+        "entity": "master", "cosine": 0.99,
+    }])
+    # "  MERGE  " — extra whitespace + uppercase should normalise to "merge"
+    fake_llm = _make_llm_mock([{"index": 0, "action": "  MERGE  "}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        resolved = await resolver.aresolve("小天")
+    assert resolved == 1
+    facts = await fs.aload_facts("小天")
+    assert {f["id"] for f in facts} == {"e1"}  # candidate dropped per merge
+    assert next(f for f in facts if f["id"] == "e1")["importance"] == 5
+    assert await resolver.aload_pending("小天") == []
+
+
+@pytest.mark.asyncio
 async def test_aresolve_skips_decision_for_disappeared_row(tmp_path):
     """If a fact in the queue has been deleted between enqueue and
     resolve (e.g. concurrent absorbed-archive sweep), the decision

--- a/tests/unit/test_fact_dedup.py
+++ b/tests/unit/test_fact_dedup.py
@@ -376,6 +376,45 @@ async def test_aresolve_keep_both_leaves_facts_untouched(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aresolve_reciprocal_pair_does_not_delete_both(tmp_path):
+    """Codex PR-957 P1: if the LLM emits reciprocal decisions on the
+    same two facts (merge for (c1,e1) AND replace for (e1,c1)) in one
+    batch, a naive removal pass would drop BOTH rows. The defensive
+    guard must keep the first decision and skip the second."""
+    fs, resolver = _install_resolver(str(tmp_path))
+    a = _fact("c1", "x", embedding=[1.0, 0.0])
+    b = _fact("e1", "y", embedding=[0.99, 0.05])
+    await _seed_facts(fs, "小天", [a, b])
+    await resolver.aenqueue_candidates("小天", [
+        {
+            "candidate_id": "c1", "existing_id": "e1",
+            "candidate_text": "x", "existing_text": "y",
+            "entity": "master", "cosine": 0.99,
+        },
+        {
+            "candidate_id": "e1", "existing_id": "c1",
+            "candidate_text": "y", "existing_text": "x",
+            "entity": "master", "cosine": 0.99,
+        },
+    ])
+    # First decision: merge (c1, e1) → drop c1, keep e1.
+    # Second decision: replace (e1, c1) — would drop e1 + keep c1
+    # if applied naively. With the guard, it must skip (because c1
+    # is already in ids_to_remove from the first decision).
+    fake_llm = _make_llm_mock([
+        {"index": 0, "action": "merge"},
+        {"index": 1, "action": "replace"},
+    ])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        await resolver.aresolve("小天")
+    surviving_ids = {f["id"] for f in await fs.aload_facts("小天")}
+    # The bug condition is "both rows deleted". With the guard, at
+    # least one of the two original rows must remain.
+    assert len(surviving_ids) >= 1
+    assert surviving_ids <= {"c1", "e1"}
+
+
+@pytest.mark.asyncio
 async def test_aresolve_skips_decision_for_disappeared_row(tmp_path):
     """If a fact in the queue has been deleted between enqueue and
     resolve (e.g. concurrent absorbed-archive sweep), the decision

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -451,9 +451,11 @@ async def test_aretrieve_tops_up_when_llm_returns_fewer_than_budget():
         )
     assert len(out) == 3
     assert out[0]["id"] == "o5"
-    # Top-up draws from the coarse-rank tail in order — those are
-    # the highest-evidence_score rows the LLM didn't pick.
-    assert "o5" in {o["id"] for o in out}
+    # The remaining two slots top up from the coarse-rank tail in
+    # order — those are the highest-evidence_score rows the LLM
+    # didn't pick. Position 0 already pinned to o5 above; here we
+    # just assert the top-up didn't somehow drop o5.
+    assert {o["id"] for o in out[1:]}.isdisjoint({"o5"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -1,0 +1,571 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for memory.recall.MemoryRecallReranker.
+
+The reranker has three phases (hard filter → coarse cosine rank →
+LLM fine rank). Tests cover each phase in isolation plus the
+end-to-end ``aretrieve_candidates`` flow including the fallback path
+when the EmbeddingService is disabled.
+
+We never call a real LLM — the fine-rank tests stub
+`utils.llm_client.create_chat_llm` the same way PR #941's
+test_persona_version_history.py does."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memory.embeddings import (
+    _embedding_text_sha256,
+    reset_embedding_service_for_tests,
+)
+from memory.recall import COARSE_OVERSAMPLE, MemoryRecallReranker
+
+
+# ── stub embedding service ───────────────────────────────────────────
+
+
+class _FakeService:
+    """Minimal stand-in for EmbeddingService used by recall tests.
+    The reranker only touches a handful of methods; keep the stub
+    narrow so tests stay readable."""
+
+    def __init__(
+        self, *, available: bool = True, model_id: str = "fake-128d-int8",
+        vector_factory=None,
+    ) -> None:
+        self._available = available
+        self._model_id = model_id
+        self._vector_factory = vector_factory or (lambda text: [1.0, 0.0])
+        self.embed_calls: list[list[str]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def model_id(self):
+        return self._model_id if self._available else None
+
+    async def embed_batch(self, texts):
+        self.embed_calls.append(list(texts))
+        return [self._vector_factory(t) if t else None for t in texts]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singleton():
+    reset_embedding_service_for_tests()
+    yield
+    reset_embedding_service_for_tests()
+
+
+def _make_reranker(service: _FakeService) -> MemoryRecallReranker:
+    r = MemoryRecallReranker()
+    r._service = service
+    return r
+
+
+def _obs(oid: str, text: str, *, score: float = 1.0,
+         entity: str = "master",
+         target_type: str = "persona",
+         embedding: list[float] | None = None,
+         model_id: str = "fake-128d-int8",
+         status: str | None = None,
+         suppress: bool = False,
+         protected: bool = False) -> dict:
+    """Build an observation dict in the shape ``_aload_signal_targets``
+    emits — keep all the keys the reranker may inspect."""
+    o = {
+        "id": oid,
+        "raw_id": oid.split(".")[-1],
+        "target_type": target_type,
+        "entity": entity,
+        "entity_key": entity,
+        "text": text,
+        "score": score,
+        "suppress": suppress,
+        "protected": protected,
+        "embedding": list(embedding) if embedding is not None else None,
+        "embedding_text_sha256": _embedding_text_sha256(text) if embedding else None,
+        "embedding_model_id": model_id if embedding else None,
+    }
+    if status is not None:
+        o["status"] = status
+    return o
+
+
+def _make_llm_mock(payload):
+    resp = MagicMock()
+    resp.content = json.dumps(payload)
+
+    async def _ainvoke(*_a, **_k):
+        return resp
+
+    async def _aclose():
+        return None
+
+    llm = MagicMock()
+    llm.ainvoke = _ainvoke
+    llm.aclose = _aclose
+    return llm
+
+
+# ── phase 1: hard filter ─────────────────────────────────────────────
+
+
+def test_hard_filter_drops_negative_score():
+    """User-disputed entries (evidence_score < 0) must not feed back
+    into the LLM signal-detection pool — Stage-2 would either
+    reinforce the dispute or, worse, cancel it."""
+    obs = [
+        _obs("p.master.a", "kept", score=1.5),
+        _obs("p.master.b", "dropped", score=-0.5),
+        _obs("p.master.c", "kept", score=0.0),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    ids = {o["id"] for o in out}
+    assert "p.master.a" in ids
+    assert "p.master.c" in ids
+    assert "p.master.b" not in ids
+
+
+def test_hard_filter_drops_suppressed():
+    obs = [
+        _obs("p.master.a", "kept"),
+        _obs("p.master.b", "dropped", suppress=True),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    assert {o["id"] for o in out} == {"p.master.a"}
+
+
+def test_hard_filter_drops_protected_persona():
+    """character_card-sourced entries have effectively infinite
+    evidence — they're never the target of a Stage-2 signal."""
+    obs = [
+        _obs("p.master.a", "kept"),
+        _obs("p.master.card", "dropped", protected=True),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    assert {o["id"] for o in out} == {"p.master.a"}
+
+
+def test_hard_filter_drops_terminal_reflections():
+    """promoted/denied/archived/etc reflections shouldn't appear in
+    the active signal pool. Same exclusion as the render path."""
+    from memory.reflection import REFLECTION_TERMINAL_STATUSES
+    obs = [
+        _obs("r.x", "kept", target_type="reflection", status="confirmed"),
+    ]
+    for status in REFLECTION_TERMINAL_STATUSES:
+        obs.append(_obs(f"r.{status}", "drop", target_type="reflection", status=status))
+    out = MemoryRecallReranker._hard_filter(obs)
+    ids = {o["id"] for o in out}
+    assert "r.x" in ids
+    for status in REFLECTION_TERMINAL_STATUSES:
+        assert f"r.{status}" not in ids
+
+
+def test_hard_filter_drops_empty_text():
+    """Defensive — an empty-text observation can't be embedded or
+    matched; surface as zero-row noise rather than going through."""
+    obs = [
+        _obs("p.master.a", ""),
+        _obs("p.master.b", "   "),
+        _obs("p.master.c", "real text"),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    assert {o["id"] for o in out} == {"p.master.c"}
+
+
+# ── phase 2: coarse rank by cosine ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_falls_back_when_service_unavailable():
+    """No embedding service ⇒ pure evidence_score order, top-k slice."""
+    svc = _FakeService(available=False)
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "x", score=0.5),
+        _obs("b", "y", score=2.0),
+        _obs("c", "z", score=1.0),
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=3)
+    assert [o["id"] for o in out] == ["b", "c", "a"]
+    # Service was never asked to embed anything.
+    assert svc.embed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_falls_back_when_no_query():
+    """Empty/None query ⇒ no semantic basis, evidence order applies."""
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "x", score=0.5),
+        _obs("b", "y", score=2.0),
+    ]
+    out = await r._coarse_rank(obs, query_texts=None, k=2)
+    assert [o["id"] for o in out] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_uses_max_cosine_across_queries():
+    """A candidate that's near ANY query vector should win — recall
+    should not require relevance to ALL topics. Implements the
+    documented max-pool semantics."""
+    # Two queries: q1 → vec [1,0], q2 → vec [0,1]. Candidates:
+    #   a: [1,0]   → cosine vs q1 = 1.0, vs q2 = 0.0  ⇒ max = 1.0
+    #   b: [0,1]   → cosine vs q1 = 0.0, vs q2 = 1.0  ⇒ max = 1.0
+    #   c: [.5,.5] → cosine vs q1 = .707, vs q2 = .707 ⇒ max = .707
+    qmap = {"q1": [1.0, 0.0], "q2": [0.0, 1.0]}
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: qmap.get(text, [0.0, 0.0]),
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "ta", score=0.0, embedding=[1.0, 0.0]),
+        _obs("b", "tb", score=0.0, embedding=[0.0, 1.0]),
+        _obs("c", "tc", score=0.0, embedding=[0.7071, 0.7071]),
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q1", "q2"], k=3)
+    # a and b tie at cosine 1.0 (both should rank above c).
+    assert {out[0]["id"], out[1]["id"]} == {"a", "b"}
+    assert out[2]["id"] == "c"
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_breaks_ties_with_evidence_score():
+    """Two candidates with identical cosine should fall back to
+    evidence_score for the tie-break — explicit assertion of the
+    documented contract."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "ta", score=0.5, embedding=[1.0, 0.0]),
+        _obs("b", "tb", score=2.0, embedding=[1.0, 0.0]),
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=2)
+    assert [o["id"] for o in out] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_demotes_candidates_without_embedding():
+    """A row with embedding=None gets cosine = -1 so it ranks below
+    everything that does have a vector — the LLM rerank can still
+    pick it up if it's the right answer text-wise."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("with_vec", "t", score=0.0, embedding=[1.0, 0.0]),
+        _obs("no_vec", "t", score=10.0),  # no embedding → no model_id
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=2)
+    assert [o["id"] for o in out] == ["with_vec", "no_vec"]
+
+
+# ── phase 3: LLM rerank ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_skips_llm_when_candidates_within_budget():
+    """When coarse rank already produces ≤ budget candidates, the LLM
+    call is wasted (every candidate makes the cut). Skip it."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs("a", "ta", embedding=[1.0, 0.0]),
+        _obs("b", "tb", embedding=[1.0, 0.0]),
+    ]
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=5, config_manager=cm,
+        )
+    assert {o["id"] for o in out} == {"a", "b"}
+    assert create_llm.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_invokes_llm_when_pool_exceeds_budget():
+    """Coarse pool is 3 × budget by default; with budget=2 and 6+
+    cosine-ranked candidates, the LLM should be asked to pick 2."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0]) for i in range(8)
+    ]
+    # LLM picks o3 then o5 — assert order is preserved in the output.
+    fake_llm = _make_llm_mock([{"id": "o3"}, {"id": "o5"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2, config_manager=cm,
+        )
+    assert [o["id"] for o in out] == ["o3", "o5"]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_drops_hallucinated_ids_from_llm():
+    """LLM returns an id that isn't in the candidate set — must be
+    silently dropped (not crash, not pass through)."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0]) for i in range(8)
+    ]
+    fake_llm = _make_llm_mock([
+        {"id": "ghost"}, {"id": "o2"}, {"id": "another_ghost"}, {"id": "o5"},
+    ])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2, config_manager=cm,
+        )
+    assert [o["id"] for o in out] == ["o2", "o5"]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_tops_up_when_llm_returns_fewer_than_budget():
+    """LLM only returns 1 item but budget=3 — top up from the coarse-
+    rank tail so the caller still gets `budget` rows when there were
+    that many candidates."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0], score=10 - i)
+        for i in range(8)
+    ]
+    fake_llm = _make_llm_mock([{"id": "o5"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=3, config_manager=cm,
+        )
+    assert len(out) == 3
+    assert out[0]["id"] == "o5"
+    # Top-up draws from the coarse-rank tail in order — those are
+    # the highest-evidence_score rows the LLM didn't pick.
+    assert "o5" in {o["id"] for o in out}
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_falls_back_to_coarse_on_llm_error():
+    """LLM raises ⇒ best-effort fallback to coarse rank order; never
+    crash the recall path. Stage-2 signal detection then runs against
+    the coarse-ranked top-budget."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0], score=10 - i)
+        for i in range(8)
+    ]
+
+    class _BoomLLM:
+        async def ainvoke(self, *_a, **_k):
+            raise RuntimeError("simulated network failure")
+
+        async def aclose(self):
+            return None
+
+    with patch("utils.llm_client.create_chat_llm", return_value=_BoomLLM()):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2, config_manager=cm,
+        )
+    # Falls back to coarse rank: cosine ties → score DESC ⇒ o0, o1.
+    assert len(out) == 2
+    assert {o["id"] for o in out} == {"o0", "o1"}
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_skips_rerank_when_disabled():
+    """rerank=False ⇒ coarse-rank top-budget directly. Used by tests
+    and callers that want the cosine prefilter without the LLM cost."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0], score=10 - i)
+        for i in range(8)
+    ]
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2,
+            config_manager=cm, rerank=False,
+        )
+    assert create_llm.call_count == 0
+    assert len(out) == 2
+
+
+# ── full-pipeline fallback ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_full_fallback_when_service_disabled():
+    """Vectors completely off ⇒ pipeline collapses to evidence_score
+    order, top-budget. No LLM call. This is the path that runs when
+    onnxruntime / model file isn't installed."""
+    svc = _FakeService(available=False)
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs(f"o{i}", f"t{i}", score=float(i))
+        for i in range(10)
+    ]
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=3, config_manager=cm,
+        )
+    assert create_llm.call_count == 0
+    assert [o["id"] for o in out] == ["o9", "o8", "o7"]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_empty_observations_returns_empty():
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    out = await r.aretrieve_candidates(
+        [], query_texts=["q"], budget=5, config_manager=cm,
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_hard_filter_zero_returns_empty():
+    """Every observation excluded by hard filter ⇒ empty result; no
+    coarse rank, no LLM call."""
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs("a", "x", suppress=True),
+        _obs("b", "y", protected=True),
+        _obs("c", "z", score=-1.0),
+    ]
+    out = await r.aretrieve_candidates(
+        obs, query_texts=["q"], budget=5, config_manager=cm,
+    )
+    assert out == []
+
+
+# ── prompt locale coverage ───────────────────────────────────────────
+
+
+def test_memory_recall_rerank_prompt_has_all_five_locales_with_placeholders():
+    """All five locales rendered + every placeholder substituted —
+    same contract test as fact_dedup.test_fact_dedup_prompt..."""
+    from config.prompts_memory import (
+        MEMORY_RECALL_RERANK_PROMPT,
+        get_memory_recall_rerank_prompt,
+    )
+    expected_locales = {"zh", "en", "ja", "ko", "ru"}
+    assert set(MEMORY_RECALL_RERANK_PROMPT.keys()) >= expected_locales
+    for lang in expected_locales:
+        rendered = (
+            get_memory_recall_rerank_prompt(lang)
+            .replace("{QUERY}", "X")
+            .replace("{CANDIDATES}", "Y")
+            .replace("{BUDGET}", "3")
+        )
+        assert "{QUERY}" not in rendered, lang
+        assert "{CANDIDATES}" not in rendered, lang
+        assert "{BUDGET}" not in rendered, lang
+
+
+def test_oversample_constant_is_at_least_two():
+    """COARSE_OVERSAMPLE = 1 would defeat the rerank — every coarse
+    candidate would already fit the budget. Lock the lower bound so
+    a future tweak can't accidentally collapse the LLM step."""
+    assert COARSE_OVERSAMPLE >= 2
+
+
+# ── _aload_signal_targets propagates suppress flag ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_aload_signal_targets_carries_reflection_suppress_flag(tmp_path):
+    """Codex PR-958 P2 regression: when ``_aload_signal_targets``
+    materialises reflection rows for the rerank pool, it must copy
+    ``suppress`` over from the source dict.  Without it, a
+    suppressed reflection would survive the reranker's hard filter
+    (which checks ``o.get('suppress')``) and leak back into Stage-2
+    signal detection — defeating the AI-mention rate-limit gate."""
+    from unittest.mock import AsyncMock, MagicMock
+    from memory.facts import FactStore
+
+    cm = MagicMock()
+    cm.memory_dir = str(tmp_path)
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    with patch("memory.facts.get_config_manager", return_value=cm):
+        fs = FactStore()
+        fs._config_manager = cm
+
+    # Build a stub reflection engine that returns one suppressed +
+    # one not-suppressed confirmed reflection.
+    refl_engine = MagicMock()
+
+    async def _fake_load(_name):
+        return [
+            {"id": "r_active", "text": "active observation",
+             "entity": "master", "status": "confirmed",
+             "suppress": False},
+            {"id": "r_silent", "text": "silenced observation",
+             "entity": "master", "status": "confirmed",
+             "suppress": True, "suppressed_at": "2026-04-25T00:00:00"},
+        ]
+
+    refl_engine._aload_reflections_full = _fake_load
+
+    # Persona stub returns nothing — the bug under test is reflection-side.
+    persona = MagicMock()
+
+    async def _fake_persona(_name):
+        return {}
+
+    persona.aensure_persona = _fake_persona
+
+    pool = await fs._aload_signal_targets(
+        "小天", reflection_engine=refl_engine, persona_manager=persona,
+    )
+    by_id = {o["id"]: o for o in pool}
+    assert "reflection.r_silent" in by_id
+    assert by_id["reflection.r_silent"]["suppress"] is True
+    assert by_id["reflection.r_active"]["suppress"] is False
+
+    # And the reranker's hard filter actually drops the silenced one
+    # — the end-to-end check that the propagation matters.
+    survivors = MemoryRecallReranker._hard_filter(pool)
+    survivor_ids = {o["id"] for o in survivors}
+    assert "reflection.r_active" in survivor_ids
+    assert "reflection.r_silent" not in survivor_ids

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -148,19 +148,32 @@ def test_hard_filter_drops_protected_persona():
     assert {o["id"] for o in out} == {"p.master.a"}
 
 
-def test_hard_filter_drops_terminal_reflections():
-    """promoted/denied/archived/etc reflections shouldn't appear in
-    the active signal pool. Same exclusion as the render path."""
-    from memory.reflection import REFLECTION_TERMINAL_STATUSES
+def test_hard_filter_drops_only_dead_reflection_statuses():
+    """The drop set is intentionally a *subset* of
+    `REFLECTION_TERMINAL_STATUSES` — `promoted` is kept because the
+    upstream `_aload_signal_targets` ships it as part of the
+    `confirmed + promoted` Stage-2 observation pool (a promoted
+    reflection is the strongest signal we have: confirmed,
+    consolidated, still active).  Filtering it out here would
+    silently shrink the rerank pool below what the legacy path
+    produced (CodeRabbit PR-957 Major regression test).
+
+    Truly-dead statuses (denied / archived / merged / promote_blocked)
+    still get dropped — those are dead-letter or already consumed."""
     obs = [
-        _obs("r.x", "kept", target_type="reflection", status="confirmed"),
+        _obs("r.confirmed", "kept", target_type="reflection", status="confirmed"),
+        _obs("r.promoted", "kept", target_type="reflection", status="promoted"),
     ]
-    for status in REFLECTION_TERMINAL_STATUSES:
+    drop_statuses = ("denied", "archived", "merged", "promote_blocked")
+    for status in drop_statuses:
         obs.append(_obs(f"r.{status}", "drop", target_type="reflection", status=status))
     out = MemoryRecallReranker._hard_filter(obs)
     ids = {o["id"] for o in out}
-    assert "r.x" in ids
-    for status in REFLECTION_TERMINAL_STATUSES:
+    assert "r.confirmed" in ids
+    assert "r.promoted" in ids, (
+        "promoted must NOT be filtered — upstream pool includes it"
+    )
+    for status in drop_statuses:
         assert f"r.{status}" not in ids
 
 
@@ -254,9 +267,9 @@ async def test_coarse_rank_breaks_ties_with_evidence_score():
 
 @pytest.mark.asyncio
 async def test_coarse_rank_demotes_candidates_without_embedding():
-    """A row with embedding=None gets cosine = -1 so it ranks below
-    everything that does have a vector — the LLM rerank can still
-    pick it up if it's the right answer text-wise."""
+    """A row with embedding=None falls below the cosine-ranked
+    embedded ones — the LLM rerank can still pick it up if it's the
+    right answer text-wise. With k=2 and one of each, both survive."""
     svc = _FakeService(
         available=True,
         vector_factory=lambda text: [1.0, 0.0],
@@ -268,6 +281,84 @@ async def test_coarse_rank_demotes_candidates_without_embedding():
     ]
     out = await r._coarse_rank(obs, query_texts=["q"], k=2)
     assert [o["id"] for o in out] == ["with_vec", "no_vec"]
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_reserves_quota_for_unembedded_candidates():
+    """CodeRabbit PR-957 Major regression: when there are ≥k embedded
+    candidates, the previous implementation tagged un-embedded with
+    cosine=-1 and let `[:k]` truncate them off entirely, so the LLM
+    rerank never saw them despite the docstring promising they'd
+    "fall through". Fix: split into two pools and reserve a quota
+    for un-embedded entries (top by evidence_score) so they reach
+    the LLM for text-based matching."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    # 6 embedded + 3 un-embedded; k=6 (would be budget*COARSE_OVERSAMPLE
+    # in real call). Without the fix, all 6 slots go to embedded, and
+    # the un-embedded ones (even with high evidence_score) get starved.
+    obs = []
+    for i in range(6):
+        obs.append(_obs(f"emb{i}", "t", score=float(i), embedding=[1.0, 0.0]))
+    for i in range(3):
+        # High evidence_score so they'd win on a fairer ranking.
+        obs.append(_obs(f"unemb{i}", "t", score=100.0 + i))
+    out = await r._coarse_rank(obs, query_texts=["q"], k=6)
+    # With the quota fix, at least one un-embedded entry must reach
+    # the output so the LLM rerank gets a chance at it.
+    out_ids = {o["id"] for o in out}
+    unembedded_in_out = {oid for oid in out_ids if oid.startswith("unemb")}
+    assert len(unembedded_in_out) >= 1, (
+        "un-embedded entries must reserve at least one slot in the "
+        "coarse pool — otherwise text-matching by LLM is impossible"
+    )
+    # And we still emit exactly k entries.
+    assert len(out) == 6
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_unembedded_quota_picks_highest_evidence():
+    """When the un-embedded slot count is smaller than the un-embedded
+    pool, slot allocation goes to the highest-evidence_score entries —
+    evidence is the only signal we have for them.
+
+    k=4 with COARSE_OVERSAMPLE=3 yields quota = max(1, 4 // 4) = 1, so
+    exactly one un-embedded entry should reach the output, and it
+    should be the higher-score one."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [_obs(f"emb{i}", "t", score=0.0, embedding=[1.0, 0.0])
+           for i in range(8)]
+    obs.append(_obs("unemb_low", "t", score=1.0))
+    obs.append(_obs("unemb_high", "t", score=99.0))
+    out = await r._coarse_rank(obs, query_texts=["q"], k=4)
+    out_ids = {o["id"] for o in out}
+    # Quota=1 → only the higher-evidence un-embedded entry survives.
+    assert "unemb_high" in out_ids
+    assert "unemb_low" not in out_ids
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_no_unembedded_uses_full_quota_for_embedded():
+    """When the pool has no un-embedded entries, the full k goes to
+    embedded — quota mechanism mustn't waste slots on a pool that
+    doesn't exist."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [_obs(f"emb{i}", "t", score=float(i), embedding=[1.0, 0.0])
+           for i in range(6)]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=4)
+    assert len(out) == 4
+    assert all(o["id"].startswith("emb") for o in out)
 
 
 # ── phase 3: LLM rerank ──────────────────────────────────────────────


### PR DESCRIPTION
**Stacked on top of #956** (P2 step 1).  Review #956 first; this PR's diff is *only* the new step-2 work.  Merge order: #956 → this PR.

Step 2 of three for P2 (vector hybrid retrieval).  Adds the LLM-arbitrated paraphrase deduplication path that the existing hash + FTS5 dedup misses entirely (e.g. "主人喜欢猫" vs "对猫咪很感兴趣" vs "最近养了只猫" — same fact, three surface forms, three rows in facts.json today).

## Pipeline (write → enqueue → resolve)

1. `_apersist_new_facts` writes facts with `embedding=None` as before (no inline embedding compute — keeps /process latency unchanged).
2. The embedding worker's fact sweep computes vectors for the new rows, then calls `FactDedupResolver.detect_candidates` to find cosine-collision pairs against existing rows of the *same entity*. Pairs go into `memory/{name}/facts_pending_dedup.json` via the atomic-write pattern that mirrors `persona_corrections.json`.
3. The idle-maintenance loop in memory_server.py periodically calls `aresolve(name)` — single LLM call per batch, classifies each pair as `merge` / `replace` / `keep_both`, applies decisions to facts.json under FactStore's existing file lock.

Vectors are the *candidate generator*; the LLM is the arbiter. This matters because cosine alone can't separate "主人喜欢猫" from "主人讨厌猫" — both differ by one token but ride opposite poles of the embedding space (~0.78 in practice). An auto-merge on cosine threshold would silently corrupt the persona-feed pipeline; LLM arbitration with a prompt that explicitly warns about polarity flips keeps the bad merges out.

## Decision semantics

- `merge` — drop candidate, bump existing.importance by +1 (capped at 10), append candidate id to existing.merged_from_ids for provenance.
- `replace` — drop existing, keep candidate. Existing's merged_from_ids chain transfers forward so we don't lose the earlier paraphrase trail. Importance becomes max(candidate, existing) so a "replace" doesn't silently demote a high-importance row.
- `keep_both` — both rows survive. Queue entry consumed. Safety net for "high cosine but actually different" decisions (the polarity-flip guard).

## Fallback

When the EmbeddingService is disabled (no onnxruntime / no model file / low RAM / user opt-out / sticky-disable from inference failure), the worker never calls `aenqueue_candidates`, so the queue stays empty and `aresolve` is a no-op. Hash + FTS5 dedup remains the entire dedup pipeline — exactly the pre-P2 behaviour.

The dedup_resolver is wired into the worker via constructor injection. When None (tests, opt-out), the fact sweep still backfills embeddings normally; only the dedup-enqueue side stays quiet.

## Detect-candidates rules

- Entity-scoped — master / neko / relationship pools don't cross. Cross-entity overlap is too risky to defer to vectors.
- Absorbed-aware — both candidate and existing must be unabsorbed. Re-merging into an absorbed row would create an inconsistency between the absorbed marker and the row's continued existence.
- `only_for_ids` — limits the candidate (newer) side to the rows the worker just embedded, so we don't repeatedly scan the entire fact history on every sweep.
- Per-fact cap (`FACT_DEDUP_PAIRS_PER_NEW=3`) — a pathological row near 50 existing rows produces at most 3 pairs, sorted by cosine descending. Keeps the queue interpretable.

## Resolve concurrency

The full load → LLM → apply → save sequence holds the per-character asyncio.Lock so concurrent enqueue calls block until the round finishes. Releasing the lock during the LLM call would introduce a TOCTOU between deciding which queue items we're about to remove and actually removing them — same lock pattern as `PersonaManager._resolve_corrections_locked`.

## Failure tolerance

- LLM call raises ⇒ queue preserved intact for the next tick. Losing pending dedup work is worse than skipping a round.
- Decision references a fact id that no longer exists (concurrent archive sweep) ⇒ silently no-op, but queue entry IS removed so staleness can't keep blocking the batch.
- `BATCH_LIMIT=20` caps the per-call prompt so the model stays within reliable context bounds; remainder waits for next tick.

## Prompt

`FACT_DEDUP_PROMPT` in 5 locales (zh / en / ja / ko / ru) — same locale layout as `PERSONA_CORRECTION_PROMPT` from #941. Each includes both `{PAIRS}` and `{COUNT}` placeholders; tests assert that every locale renders cleanly. The prompt explicitly warns about polarity flips (positive/negative, like/dislike) and prefers `keep_both` over a wrongful merge.

## What's deferred to step 3

- Persona / reflection retrieval. Hard filter (suppressed / terminal / score < 0) → cosine top-K candidate set → LLM rerank (passing `evidence_score` as auxiliary signal) → final injection list. Vectors save *prompt tokens*, not LLM calls.

## Test plan

- [x] 20 fact_dedup tests covering: detect_candidates (above/below threshold, entity scoping, absorbed-skip, self-skip, only_for_ids candidate filter, per-fact cap, missing-embedding skip); aenqueue_candidates (round-trip, dedup of same-id pair, malformed rows); aresolve (merge / replace / keep_both decisions, importance cap at 10, provenance carryover, missing row no-op, LLM failure preserves queue, empty queue early-out, batch limit); 5-locale prompt rendering.
- [x] 2 worker integration tests: end-to-end forwarding of dedup candidates after fact sweep; resolver=None path stays quiet.
- [x] 71 P2-related tests green (30 service + 9 schema + 12 worker + 20 dedup).
- [x] 330 broader memory tests still green (only pre-existing Windows file-lock flake remains).
- [ ] Manual smoke with model installed: write three paraphrase facts, observe queue grows after worker sweep, then confirm idle-maint LLM-arbitration applies the right merge/keep_both decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加智能事实去重功能：系统现在通过LLM判断相似事实是否应合并、替换或保留，提升知识库质量
  * 增强记忆召回排序：采用向量相似性预过滤和LLM重新排序机制，显著提升相关记忆的检索准确性和相关性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->