### PR TITLE
[Memory] P2 step 3 — vector+LLM rerank for memory recall

### DIFF
--- a/config/prompts_memory.py
+++ b/config/prompts_memory.py
@@ -1724,3 +1724,102 @@ def get_fact_dedup_prompt(lang: str = 'zh') -> str:
 
 
 fact_dedup_prompt = FACT_DEDUP_PROMPT['zh']
+
+
+# ---------- memory_recall_rerank_prompt → i18n dict ----------
+# Drives memory/recall.py's _fine_rank step. Cosine pre-filtering
+# narrows the candidate set down to ~3× the budget; this prompt asks
+# the LLM to pick the top {BUDGET} most-relevant items for the query.
+# evidence_score appears parenthetically as auxiliary signal — the
+# LLM weighs it together with semantic relevance instead of mixing
+# into a single ranking number (cosine vs evidence are
+# dimensionally inconsistent).
+MEMORY_RECALL_RERANK_PROMPT = {
+    'zh': """以下是用户最近提到的话题。请从候选记忆中挑选最相关的 {BUDGET} 条用于注入对话上下文。
+
+======用户当前话题======
+{QUERY}
+======用户当前话题======
+
+======候选记忆======
+{CANDIDATES}
+======候选记忆======
+
+每条候选前的 score 是用户对该记忆的累计确认度（高 = 反复确认，低 = 较少证据）。可作为辅助信号——同等相关度时优先选 score 高的；但不要让 score 完全压倒相关性，无关的高 score 记忆不该入选。
+
+仅输出 JSON 数组，按重要程度从高到低排列，每项包含 id 字段：
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+最多 {BUDGET} 条；若候选不足 {BUDGET} 条相关，可返回更少。""",
+    'en': """Below are topics the user has just mentioned. From the candidate memories, pick the {BUDGET} most relevant ones to inject into the conversation context.
+
+======current topics======
+{QUERY}
+======current topics======
+
+======candidate memories======
+{CANDIDATES}
+======candidate memories======
+
+The `score` annotation on each candidate is the user's cumulative confirmation count for that memory (high = repeatedly confirmed, low = thin evidence). Use it as an auxiliary signal — when relevance is tied, prefer the higher score; but do not let score override relevance, an irrelevant high-score memory should not be picked.
+
+Output only a JSON array, ordered most-important first. Each item must contain an `id` field:
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+At most {BUDGET} items; return fewer if not enough candidates are relevant.""",
+    'ja': """以下はユーザーが最近言及したトピックです。候補メモリから、対話コンテキストに注入する最も関連性の高い {BUDGET} 件を選んでください。
+
+======現在のトピック======
+{QUERY}
+======現在のトピック======
+
+======候補メモリ======
+{CANDIDATES}
+======候補メモリ======
+
+各候補の score 注釈は、ユーザーがそのメモリを累積確認した回数です（高 = 繰り返し確認、低 = 証拠が薄い）。補助シグナルとして利用してください。関連性が同等なら score の高い方を優先しますが、関連性を score が完全に覆すべきではありません。
+
+JSON 配列のみを出力し、重要度順に並べてください。各項目に `id` フィールドを含めます：
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+最大 {BUDGET} 件。関連する候補がそれ以下なら、より少なく返しても構いません。""",
+    'ko': """아래는 사용자가 최근 언급한 주제입니다. 후보 메모리 중에서 대화 컨텍스트에 주입할 가장 관련성 높은 {BUDGET}개를 선택하세요.
+
+======현재 주제======
+{QUERY}
+======현재 주제======
+
+======후보 메모리======
+{CANDIDATES}
+======후보 메모리======
+
+각 후보의 score는 사용자가 해당 메모리를 누적적으로 확인한 횟수입니다(높음 = 반복 확인, 낮음 = 증거 부족). 보조 신호로 활용하세요. 관련성이 같으면 score 높은 쪽을 우선하지만, 관련성을 score가 완전히 압도해서는 안 됩니다.
+
+JSON 배열만 출력하고 중요도 순으로 정렬하세요. 각 항목에 `id` 필드를 포함:
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+최대 {BUDGET}개; 관련 후보가 부족하면 더 적게 반환해도 됩니다.""",
+    'ru': """Ниже представлены темы, которые пользователь только что упомянул. Из кандидатов памяти выберите {BUDGET} наиболее релевантных для внедрения в контекст диалога.
+
+======текущие темы======
+{QUERY}
+======текущие темы======
+
+======кандидаты======
+{CANDIDATES}
+======кандидаты======
+
+Аннотация `score` рядом с каждым кандидатом — это накопленное число подтверждений пользователем (высокое = повторяющееся подтверждение, низкое = слабые доказательства). Используйте как вспомогательный сигнал: при равной релевантности предпочтите более высокий score, но не позволяйте score полностью перевесить релевантность.
+
+Выводите только JSON-массив, упорядоченный по важности. Каждый элемент содержит поле `id`:
+[{{"id": "persona.master.xxx"}}, {{"id": "reflection.ref_yyy"}}]
+
+Не более {BUDGET} элементов; верните меньше, если релевантных кандидатов меньше.""",
+}
+
+
+def get_memory_recall_rerank_prompt(lang: str = 'zh') -> str:
+    return _loc(MEMORY_RECALL_RERANK_PROMPT, lang)
+
+
+memory_recall_rerank_prompt = MEMORY_RECALL_RERANK_PROMPT['zh']

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -457,6 +457,7 @@ class FactStore:
     async def _aload_signal_targets(
         self, lanlan_name: str,
         reflection_engine=None, persona_manager=None,
+        new_facts: list[dict] | None = None,
     ) -> list[dict]:
         """Assemble the Stage-2 `existing_observations` set.
 
@@ -466,8 +467,12 @@ class FactStore:
 
         Scale control (§3.4.2 end):
           - Hard cap: top-N by evidence_score DESC (N = EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS)
-          - TODO PR follow-up: filter by new_facts[*].entity once Stage-1
-            returns entity; for now broad pool is acceptable (<200 items typical).
+          - When ``new_facts`` is provided AND the EmbeddingService is
+            ready, the cap is replaced by a vector-prefiltered + LLM-
+            reranked top-N (see memory/recall.py). Vectors save the
+            Stage-2 prompt tokens by narrowing the candidate set
+            from ~200 down to a much smaller LLM-validated subset;
+            the LLM call itself is still made.
 
         Injection pattern: memory_server wires `reflection_engine` / `persona_manager`
         references at call time. Without them we return empty, which simply
@@ -492,6 +497,10 @@ class FactStore:
                         'text': r.get('text', ''),
                         'entity': r.get('entity', 'relationship'),
                         'score': evidence_score(r, now),
+                        'embedding': r.get('embedding'),
+                        'embedding_text_sha256': r.get('embedding_text_sha256'),
+                        'embedding_model_id': r.get('embedding_model_id'),
+                        'status': r.get('status'),
                     })
             except Exception as e:
                 logger.debug(
@@ -519,13 +528,40 @@ class FactStore:
                             'text': entry.get('text', ''),
                             'entity': entity_key,
                             'score': evidence_score(entry, now),
+                            'embedding': entry.get('embedding'),
+                            'embedding_text_sha256': entry.get('embedding_text_sha256'),
+                            'embedding_model_id': entry.get('embedding_model_id'),
+                            'suppress': entry.get('suppress'),
                         })
             except Exception as e:
                 logger.debug(
                     f"[FactStore] _aload_signal_targets 读取 persona 失败: {e}"
                 )
 
-        # Top-N by score DESC (most relevant first)
+        # P2 step 3: vector + LLM rerank when we have a query (new_facts)
+        # and the embedding service is ready. Otherwise legacy "top-N
+        # by evidence_score" — same behaviour as before P2.
+        if new_facts:
+            try:
+                from memory.recall import MemoryRecallReranker
+                reranker = MemoryRecallReranker()
+                if reranker._service.is_available():
+                    query_texts = [
+                        f.get('text', '') for f in new_facts if f.get('text')
+                    ]
+                    return await reranker.aretrieve_candidates(
+                        pool, query_texts,
+                        budget=EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS,
+                        config_manager=self._config_manager,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "[FactStore] vector+LLM rerank failed (%s: %s); "
+                    "falling back to evidence_score order",
+                    type(e).__name__, e,
+                )
+
+        # Fallback / legacy path: top-N by score DESC (most relevant first).
         pool.sort(key=lambda o: o.get('score', 0.0), reverse=True)
         return pool[:EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS]
 
@@ -652,6 +688,11 @@ class FactStore:
             lanlan_name,
             reflection_engine=reflection_engine,
             persona_manager=persona_manager,
+            # Pass the freshly-persisted facts as the recall query so
+            # the vector+LLM rerank can narrow the candidate set
+            # semantically. Without new_facts the call falls back to
+            # evidence_score ordering (the legacy behaviour).
+            new_facts=persisted,
         )
         if not existing_observations:
             return persisted, []

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -501,6 +501,16 @@ class FactStore:
                         'embedding_text_sha256': r.get('embedding_text_sha256'),
                         'embedding_model_id': r.get('embedding_model_id'),
                         'status': r.get('status'),
+                        # Carry the AI-mention rate-limit suppress flag
+                        # so MemoryRecallReranker._hard_filter can drop
+                        # suppressed reflections from the rerank pool —
+                        # reflections share persona's 5h-window mention
+                        # gating (see ReflectionEngine._normalize_reflection).
+                        # Codex PR-958 P2: without this, a vector-recall
+                        # path with a suppressed reflection would slip
+                        # past the filter and re-enter Stage-2 signal
+                        # detection, defeating the suppression contract.
+                        'suppress': r.get('suppress'),
                     })
             except Exception as e:
                 logger.debug(

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -1,0 +1,371 @@
+# -*- coding: utf-8 -*-
+"""
+MemoryRecallReranker — vector pre-rank + LLM rerank for memory recall.
+
+Step 3 of P2.  Replaces the "top-N by evidence_score" heuristic that
+``FactStore._aload_signal_targets`` uses today to pick candidates for
+the Stage-2 signal-detection LLM call.  The new pipeline is:
+
+  1. **Hard filter** — exclude entries with ``evidence_score < 0``,
+     suppressed entries, terminal-status reflections, and persona
+     entries marked ``protected`` (character-card sources).  Same
+     semantics as today's render-time filters.
+
+  2. **Coarse rank (vectors)** — when the EmbeddingService is
+     available AND the caller passed in query texts (typically the
+     newly-extracted facts), embed the queries, compute max-cosine
+     between each candidate and any query, sort DESC, keep the top
+     ``budget * COARSE_OVERSAMPLE`` rows (default 3 ×).  Without an
+     embedding service or without query texts, this stage is a no-op
+     and the original list passes through.
+
+  3. **Fine rank (LLM)** — when embeddings produced more than
+     ``budget`` candidates AND the LLM rerank prompt is configured,
+     send the candidate set + query texts to a small LLM call asking
+     for the most relevant ``budget`` items.  ``evidence_score`` is
+     surfaced in the prompt as an auxiliary signal ("this entry has
+     been confirmed N times by the user") rather than mixed into the
+     ranking math — the LLM weighs it together with semantic
+     relevance.  When the LLM call fails or vectors are off, the
+     coarse-rank order (or evidence_score when even coarse failed)
+     is used as the final order.
+
+Fallback: when ``EmbeddingService`` is permanently disabled, the
+whole pipeline degrades to "evidence_score DESC + top ``budget``" —
+exactly the current behaviour, no LLM call cost added.
+
+Why vectors are a *prefilter*, not a replacement: cosine alone can't
+tell ``主人喜欢猫`` from ``主人讨厌猫`` (≈0.78), and "semantically
+near" entries that the user didn't actually mean to bring up trigger
+false positives in Stage-2 signal detection (which would either
+reinforce or negate the wrong observation).  Keeping the LLM as the
+arbiter means we save *prompt tokens* (smaller candidate set in the
+Stage-2 prompt), not *LLM calls* — RFC §3.4 stays unchanged in
+shape.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+from memory.embeddings import (
+    cosine_similarity,
+    get_embedding_service,
+    is_cached_embedding_valid,
+)
+from memory.evidence import evidence_score
+
+logger = logging.getLogger(__name__)
+
+
+# Coarse-rank oversample factor — top-K = budget * this. The factor is
+# the "confidence headroom" we give the LLM rerank: 3× means the
+# semantic shortlist is 3× the budget so the LLM has 2 candidates per
+# slot to choose from. Lower would over-trust cosine; higher would
+# stuff the LLM prompt with more text than it can rank reliably.
+COARSE_OVERSAMPLE = 3
+
+
+class MemoryRecallReranker:
+    """Stateless apart from the embedding service handle. Construct
+    once per process and call ``aretrieve_candidates`` per recall."""
+
+    def __init__(self) -> None:
+        self._service = get_embedding_service()
+
+    async def aretrieve_candidates(
+        self,
+        observations: list[dict],
+        query_texts: list[str] | None,
+        *,
+        budget: int,
+        config_manager,            # for the LLM rerank call
+        rerank: bool = True,
+    ) -> list[dict]:
+        """Return up to ``budget`` candidate observations, ranked.
+
+        ``observations`` is the union of persona + reflection rows the
+        caller wants to consider, each carrying at least ``id``,
+        ``text``, ``entity``, ``score`` (evidence_score, see
+        ``memory.evidence.evidence_score``), and ideally an
+        ``embedding`` triple.
+
+        ``query_texts`` is the recall query in natural language —
+        typically the texts of newly-extracted facts.  None or
+        empty disables the cosine prefilter and falls back to
+        evidence_score order.
+
+        ``rerank=False`` skips the LLM call (used by tests and the
+        fallback path) and returns the coarse-ranked top-``budget``
+        directly.
+        """
+        if not observations:
+            return []
+
+        # Phase 1: hard filter (suppressed / terminal / score < 0 /
+        # protected).  This is the only stage that uses evidence_score
+        # *directly* — everything else treats it as auxiliary signal.
+        survivors = self._hard_filter(observations)
+        if not survivors:
+            return []
+
+        # Phase 2: coarse rank.
+        coarse_pool_size = budget * COARSE_OVERSAMPLE
+        coarse = await self._coarse_rank(
+            survivors, query_texts, k=coarse_pool_size,
+        )
+        if len(coarse) <= budget or not rerank:
+            return coarse[:budget]
+
+        # When the embedding service isn't available, the coarse step
+        # already produced an evidence_score-DESC ordering — there's
+        # no semantic basis to rerank further, so don't pay the LLM
+        # cost. Mirrors the design intent: "vectors disabled ⇒
+        # entirely the legacy stage 1/2 path".
+        if not self._service.is_available():
+            return coarse[:budget]
+
+        # Phase 3: LLM rerank — only fires when we have enough
+        # candidates that picking the best `budget` actually involves
+        # judgment. Below the budget, every candidate makes the cut
+        # anyway, so the LLM call would be wasted tokens.
+        try:
+            from config.prompts_memory import get_memory_recall_rerank_prompt
+            from utils.language_utils import get_global_language
+        except ImportError:
+            # Prompt not available yet — degrade to coarse rank.
+            return coarse[:budget]
+
+        if not query_texts:
+            # No queries → no semantic basis for an LLM rerank;
+            # coarse order (which is also evidence_score order in
+            # this branch) is the best we can do.
+            return coarse[:budget]
+
+        try:
+            ranked = await self._fine_rank(
+                coarse, query_texts, budget=budget,
+                config_manager=config_manager,
+                lang=get_global_language(),
+                prompt_loader=get_memory_recall_rerank_prompt,
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort, never crash recall
+            logger.warning(
+                "[MemoryRecall] LLM rerank failed (%s: %s); "
+                "falling back to coarse rank order",
+                type(e).__name__, e,
+            )
+            ranked = coarse[:budget]
+        return ranked
+
+    # ── phase 1: hard filter ─────────────────────────────────────────
+
+    @staticmethod
+    def _hard_filter(observations: list[dict]) -> list[dict]:
+        """Drop everything we know up-front shouldn't reach the LLM:
+
+          * ``score < 0`` — evidence net-negative; user has been
+            disputing this more than confirming it.
+          * suppressed — explicit "AI is over-mentioning this" gate.
+          * terminal-status reflection — promoted/denied/archived/etc
+            shouldn't generate fresh signals.
+          * protected persona — character-card source; evidence is
+            effectively infinite there, no signal would ever flip it.
+
+        These are the same exclusions the render path already uses,
+        consolidated into one function so callers don't duplicate the
+        list.
+        """
+        from memory.reflection import REFLECTION_TERMINAL_STATUSES
+
+        out: list[dict] = []
+        for o in observations:
+            if not isinstance(o, dict):
+                continue
+            score = o.get('score')
+            if score is not None and score < 0:
+                continue
+            if o.get('suppress') or o.get('suppressed'):
+                continue
+            if o.get('protected'):
+                continue
+            target_type = o.get('target_type')
+            status = o.get('status')
+            if target_type == 'reflection' and status in REFLECTION_TERMINAL_STATUSES:
+                continue
+            text = o.get('text', '')
+            if not text or not text.strip():
+                continue
+            out.append(o)
+        return out
+
+    # ── phase 2: coarse rank by cosine ───────────────────────────────
+
+    async def _coarse_rank(
+        self,
+        observations: list[dict],
+        query_texts: list[str] | None,
+        *,
+        k: int,
+    ) -> list[dict]:
+        """Cosine top-K against ``query_texts``. Falls through to
+        evidence_score order when vectors aren't usable.
+
+        Each candidate is scored as the *max* cosine across all query
+        texts (``query_text`` represents "things the user just
+        mentioned"; we want the candidate to be relevant to ANY of
+        them, not the average across all). max-pool also matches the
+        single-query case trivially.
+
+        Candidates without a usable embedding (worker hasn't reached
+        them yet, or model_id mismatch) are kept in the coarse pool
+        but with cosine = 0 — they fall through to the LLM rerank
+        below the cosine-ranked rows. Better than dropping them
+        entirely, since they may still be the right answer if the LLM
+        can match on text alone.
+        """
+        # Default: evidence_score order (the legacy behaviour).
+        evidence_sorted = sorted(
+            observations, key=lambda o: o.get('score', 0.0), reverse=True,
+        )
+        if not query_texts:
+            return evidence_sorted[:k]
+        if not self._service.is_available():
+            return evidence_sorted[:k]
+        model_id = self._service.model_id()
+        if model_id is None:
+            return evidence_sorted[:k]
+
+        query_vectors = await self._service.embed_batch(
+            [t for t in query_texts if t],
+        )
+        query_vectors = [v for v in query_vectors if v is not None]
+        if not query_vectors:
+            return evidence_sorted[:k]
+
+        scored: list[tuple[float, dict]] = []
+        for o in observations:
+            text = o.get('text', '')
+            cvec = o.get('embedding')
+            if isinstance(o, dict) and is_cached_embedding_valid(o, text, model_id):
+                # Max-cosine across query vectors. Candidates with
+                # equal cosine fall back to evidence_score for tie-
+                # breaking — covered in the unit test.
+                best = max(
+                    cosine_similarity(cvec, qv) for qv in query_vectors
+                )
+            else:
+                best = -1.0  # below all cosine values, but above "missing"
+            scored.append((best, o))
+        # Sort: cosine DESC, evidence_score DESC as tie-breaker.
+        scored.sort(
+            key=lambda pair: (pair[0], pair[1].get('score', 0.0)),
+            reverse=True,
+        )
+        return [o for _, o in scored[:k]]
+
+    # ── phase 3: LLM rerank ──────────────────────────────────────────
+
+    async def _fine_rank(
+        self,
+        candidates: list[dict],
+        query_texts: list[str],
+        *,
+        budget: int,
+        config_manager,
+        lang: str,
+        prompt_loader,
+    ) -> list[dict]:
+        """Single LLM call: rerank ``candidates`` against
+        ``query_texts``, return up to ``budget`` items in the LLM's
+        preferred order.
+
+        ``evidence_score`` is included in the prompt as a parenthetical
+        annotation ("score=N") so the LLM can use it as auxiliary
+        signal (a confirmed-many-times observation deserves slight
+        priority over a fresh one), but the math no longer mixes
+        evidence into a single rank — the dimension mismatch with
+        cosine and the inability to encode "user has explicitly
+        suppressed this" both make a linear blend wrong.
+        """
+        from utils.file_utils import robust_json_loads
+        from utils.token_tracker import set_call_type
+        from utils.llm_client import create_chat_llm
+        from config import SETTING_PROPOSER_MODEL
+
+        # The id-keyed indirection prevents the LLM from inventing
+        # ids that aren't in the candidate set.
+        cand_lines = []
+        id_to_obs: dict[str, dict] = {}
+        for c in candidates:
+            cid = c.get('id') or c.get('raw_id')
+            if not cid:
+                continue
+            id_to_obs[cid] = c
+            score = c.get('score', 0.0)
+            cand_lines.append(
+                f"[{cid}] (score={score:.2f}) {c.get('text', '')}"
+            )
+        if not cand_lines:
+            return []
+
+        query_text = "\n".join(f"- {q}" for q in query_texts if q)
+        prompt = (
+            prompt_loader(lang)
+            .replace('{QUERY}', query_text)
+            .replace('{CANDIDATES}', "\n".join(cand_lines))
+            .replace('{BUDGET}', str(budget))
+        )
+
+        set_call_type("memory_recall_rerank")
+        api_config = config_manager.get_model_api_config('correction')
+        llm = create_chat_llm(
+            api_config.get('model', SETTING_PROPOSER_MODEL),
+            api_config['base_url'], api_config['api_key'],
+            temperature=0.2,
+        )
+        try:
+            resp = await llm.ainvoke(prompt)
+        finally:
+            await llm.aclose()
+        raw = resp.content.strip()
+        if raw.startswith("```"):
+            raw = raw.replace("```json", "").replace("```", "").strip()
+        decisions = robust_json_loads(raw)
+        if not isinstance(decisions, list):
+            logger.warning(
+                "[MemoryRecall] rerank returned non-list (%s); falling back",
+                type(decisions).__name__,
+            )
+            return candidates[:budget]
+
+        # Pull ids in order, drop any the LLM hallucinated, cap at
+        # budget. If the LLM returned fewer than budget, top up from
+        # the coarse-rank tail so the caller still gets `budget` rows
+        # whenever there were that many candidates.
+        ranked: list[dict] = []
+        seen: set[str] = set()
+        for d in decisions:
+            if not isinstance(d, dict):
+                continue
+            cid = d.get('id')
+            if not isinstance(cid, str) or cid in seen:
+                continue
+            obs = id_to_obs.get(cid)
+            if obs is None:
+                continue
+            ranked.append(obs)
+            seen.add(cid)
+            if len(ranked) >= budget:
+                break
+        if len(ranked) < budget:
+            for c in candidates:
+                cid = c.get('id') or c.get('raw_id')
+                if cid in seen or not cid:
+                    continue
+                ranked.append(c)
+                seen.add(cid)
+                if len(ranked) >= budget:
+                    break
+        return ranked

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -1,0 +1,502 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for memory.recall.MemoryRecallReranker.
+
+The reranker has three phases (hard filter → coarse cosine rank →
+LLM fine rank). Tests cover each phase in isolation plus the
+end-to-end ``aretrieve_candidates`` flow including the fallback path
+when the EmbeddingService is disabled.
+
+We never call a real LLM — the fine-rank tests stub
+`utils.llm_client.create_chat_llm` the same way PR #941's
+test_persona_version_history.py does."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from memory.embeddings import (
+    _embedding_text_sha256,
+    reset_embedding_service_for_tests,
+)
+from memory.recall import COARSE_OVERSAMPLE, MemoryRecallReranker
+
+
+# ── stub embedding service ───────────────────────────────────────────
+
+
+class _FakeService:
+    """Minimal stand-in for EmbeddingService used by recall tests.
+    The reranker only touches a handful of methods; keep the stub
+    narrow so tests stay readable."""
+
+    def __init__(
+        self, *, available: bool = True, model_id: str = "fake-128d-int8",
+        vector_factory=None,
+    ) -> None:
+        self._available = available
+        self._model_id = model_id
+        self._vector_factory = vector_factory or (lambda text: [1.0, 0.0])
+        self.embed_calls: list[list[str]] = []
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def model_id(self):
+        return self._model_id if self._available else None
+
+    async def embed_batch(self, texts):
+        self.embed_calls.append(list(texts))
+        return [self._vector_factory(t) if t else None for t in texts]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singleton():
+    reset_embedding_service_for_tests()
+    yield
+    reset_embedding_service_for_tests()
+
+
+def _make_reranker(service: _FakeService) -> MemoryRecallReranker:
+    r = MemoryRecallReranker()
+    r._service = service
+    return r
+
+
+def _obs(oid: str, text: str, *, score: float = 1.0,
+         entity: str = "master",
+         target_type: str = "persona",
+         embedding: list[float] | None = None,
+         model_id: str = "fake-128d-int8",
+         status: str | None = None,
+         suppress: bool = False,
+         protected: bool = False) -> dict:
+    """Build an observation dict in the shape ``_aload_signal_targets``
+    emits — keep all the keys the reranker may inspect."""
+    o = {
+        "id": oid,
+        "raw_id": oid.split(".")[-1],
+        "target_type": target_type,
+        "entity": entity,
+        "entity_key": entity,
+        "text": text,
+        "score": score,
+        "suppress": suppress,
+        "protected": protected,
+        "embedding": list(embedding) if embedding is not None else None,
+        "embedding_text_sha256": _embedding_text_sha256(text) if embedding else None,
+        "embedding_model_id": model_id if embedding else None,
+    }
+    if status is not None:
+        o["status"] = status
+    return o
+
+
+def _make_llm_mock(payload):
+    resp = MagicMock()
+    resp.content = json.dumps(payload)
+
+    async def _ainvoke(*_a, **_k):
+        return resp
+
+    async def _aclose():
+        return None
+
+    llm = MagicMock()
+    llm.ainvoke = _ainvoke
+    llm.aclose = _aclose
+    return llm
+
+
+# ── phase 1: hard filter ─────────────────────────────────────────────
+
+
+def test_hard_filter_drops_negative_score():
+    """User-disputed entries (evidence_score < 0) must not feed back
+    into the LLM signal-detection pool — Stage-2 would either
+    reinforce the dispute or, worse, cancel it."""
+    obs = [
+        _obs("p.master.a", "kept", score=1.5),
+        _obs("p.master.b", "dropped", score=-0.5),
+        _obs("p.master.c", "kept", score=0.0),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    ids = {o["id"] for o in out}
+    assert "p.master.a" in ids
+    assert "p.master.c" in ids
+    assert "p.master.b" not in ids
+
+
+def test_hard_filter_drops_suppressed():
+    obs = [
+        _obs("p.master.a", "kept"),
+        _obs("p.master.b", "dropped", suppress=True),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    assert {o["id"] for o in out} == {"p.master.a"}
+
+
+def test_hard_filter_drops_protected_persona():
+    """character_card-sourced entries have effectively infinite
+    evidence — they're never the target of a Stage-2 signal."""
+    obs = [
+        _obs("p.master.a", "kept"),
+        _obs("p.master.card", "dropped", protected=True),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    assert {o["id"] for o in out} == {"p.master.a"}
+
+
+def test_hard_filter_drops_terminal_reflections():
+    """promoted/denied/archived/etc reflections shouldn't appear in
+    the active signal pool. Same exclusion as the render path."""
+    from memory.reflection import REFLECTION_TERMINAL_STATUSES
+    obs = [
+        _obs("r.x", "kept", target_type="reflection", status="confirmed"),
+    ]
+    for status in REFLECTION_TERMINAL_STATUSES:
+        obs.append(_obs(f"r.{status}", "drop", target_type="reflection", status=status))
+    out = MemoryRecallReranker._hard_filter(obs)
+    ids = {o["id"] for o in out}
+    assert "r.x" in ids
+    for status in REFLECTION_TERMINAL_STATUSES:
+        assert f"r.{status}" not in ids
+
+
+def test_hard_filter_drops_empty_text():
+    """Defensive — an empty-text observation can't be embedded or
+    matched; surface as zero-row noise rather than going through."""
+    obs = [
+        _obs("p.master.a", ""),
+        _obs("p.master.b", "   "),
+        _obs("p.master.c", "real text"),
+    ]
+    out = MemoryRecallReranker._hard_filter(obs)
+    assert {o["id"] for o in out} == {"p.master.c"}
+
+
+# ── phase 2: coarse rank by cosine ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_falls_back_when_service_unavailable():
+    """No embedding service ⇒ pure evidence_score order, top-k slice."""
+    svc = _FakeService(available=False)
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "x", score=0.5),
+        _obs("b", "y", score=2.0),
+        _obs("c", "z", score=1.0),
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=3)
+    assert [o["id"] for o in out] == ["b", "c", "a"]
+    # Service was never asked to embed anything.
+    assert svc.embed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_falls_back_when_no_query():
+    """Empty/None query ⇒ no semantic basis, evidence order applies."""
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "x", score=0.5),
+        _obs("b", "y", score=2.0),
+    ]
+    out = await r._coarse_rank(obs, query_texts=None, k=2)
+    assert [o["id"] for o in out] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_uses_max_cosine_across_queries():
+    """A candidate that's near ANY query vector should win — recall
+    should not require relevance to ALL topics. Implements the
+    documented max-pool semantics."""
+    # Two queries: q1 → vec [1,0], q2 → vec [0,1]. Candidates:
+    #   a: [1,0]   → cosine vs q1 = 1.0, vs q2 = 0.0  ⇒ max = 1.0
+    #   b: [0,1]   → cosine vs q1 = 0.0, vs q2 = 1.0  ⇒ max = 1.0
+    #   c: [.5,.5] → cosine vs q1 = .707, vs q2 = .707 ⇒ max = .707
+    qmap = {"q1": [1.0, 0.0], "q2": [0.0, 1.0]}
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: qmap.get(text, [0.0, 0.0]),
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "ta", score=0.0, embedding=[1.0, 0.0]),
+        _obs("b", "tb", score=0.0, embedding=[0.0, 1.0]),
+        _obs("c", "tc", score=0.0, embedding=[0.7071, 0.7071]),
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q1", "q2"], k=3)
+    # a and b tie at cosine 1.0 (both should rank above c).
+    assert {out[0]["id"], out[1]["id"]} == {"a", "b"}
+    assert out[2]["id"] == "c"
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_breaks_ties_with_evidence_score():
+    """Two candidates with identical cosine should fall back to
+    evidence_score for the tie-break — explicit assertion of the
+    documented contract."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "ta", score=0.5, embedding=[1.0, 0.0]),
+        _obs("b", "tb", score=2.0, embedding=[1.0, 0.0]),
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=2)
+    assert [o["id"] for o in out] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_coarse_rank_demotes_candidates_without_embedding():
+    """A row with embedding=None gets cosine = -1 so it ranks below
+    everything that does have a vector — the LLM rerank can still
+    pick it up if it's the right answer text-wise."""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("with_vec", "t", score=0.0, embedding=[1.0, 0.0]),
+        _obs("no_vec", "t", score=10.0),  # no embedding → no model_id
+    ]
+    out = await r._coarse_rank(obs, query_texts=["q"], k=2)
+    assert [o["id"] for o in out] == ["with_vec", "no_vec"]
+
+
+# ── phase 3: LLM rerank ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_skips_llm_when_candidates_within_budget():
+    """When coarse rank already produces ≤ budget candidates, the LLM
+    call is wasted (every candidate makes the cut). Skip it."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs("a", "ta", embedding=[1.0, 0.0]),
+        _obs("b", "tb", embedding=[1.0, 0.0]),
+    ]
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=5, config_manager=cm,
+        )
+    assert {o["id"] for o in out} == {"a", "b"}
+    assert create_llm.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_invokes_llm_when_pool_exceeds_budget():
+    """Coarse pool is 3 × budget by default; with budget=2 and 6+
+    cosine-ranked candidates, the LLM should be asked to pick 2."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0]) for i in range(8)
+    ]
+    # LLM picks o3 then o5 — assert order is preserved in the output.
+    fake_llm = _make_llm_mock([{"id": "o3"}, {"id": "o5"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2, config_manager=cm,
+        )
+    assert [o["id"] for o in out] == ["o3", "o5"]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_drops_hallucinated_ids_from_llm():
+    """LLM returns an id that isn't in the candidate set — must be
+    silently dropped (not crash, not pass through)."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0]) for i in range(8)
+    ]
+    fake_llm = _make_llm_mock([
+        {"id": "ghost"}, {"id": "o2"}, {"id": "another_ghost"}, {"id": "o5"},
+    ])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2, config_manager=cm,
+        )
+    assert [o["id"] for o in out] == ["o2", "o5"]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_tops_up_when_llm_returns_fewer_than_budget():
+    """LLM only returns 1 item but budget=3 — top up from the coarse-
+    rank tail so the caller still gets `budget` rows when there were
+    that many candidates."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0], score=10 - i)
+        for i in range(8)
+    ]
+    fake_llm = _make_llm_mock([{"id": "o5"}])
+    with patch("utils.llm_client.create_chat_llm", return_value=fake_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=3, config_manager=cm,
+        )
+    assert len(out) == 3
+    assert out[0]["id"] == "o5"
+    # Top-up draws from the coarse-rank tail in order — those are
+    # the highest-evidence_score rows the LLM didn't pick.
+    assert "o5" in {o["id"] for o in out}
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_falls_back_to_coarse_on_llm_error():
+    """LLM raises ⇒ best-effort fallback to coarse rank order; never
+    crash the recall path. Stage-2 signal detection then runs against
+    the coarse-ranked top-budget."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0], score=10 - i)
+        for i in range(8)
+    ]
+
+    class _BoomLLM:
+        async def ainvoke(self, *_a, **_k):
+            raise RuntimeError("simulated network failure")
+
+        async def aclose(self):
+            return None
+
+    with patch("utils.llm_client.create_chat_llm", return_value=_BoomLLM()):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2, config_manager=cm,
+        )
+    # Falls back to coarse rank: cosine ties → score DESC ⇒ o0, o1.
+    assert len(out) == 2
+    assert {o["id"] for o in out} == {"o0", "o1"}
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_skips_rerank_when_disabled():
+    """rerank=False ⇒ coarse-rank top-budget directly. Used by tests
+    and callers that want the cosine prefilter without the LLM cost."""
+    svc = _FakeService(available=True, vector_factory=lambda t: [1.0, 0.0])
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs(f"o{i}", f"t{i}", embedding=[1.0, 0.0], score=10 - i)
+        for i in range(8)
+    ]
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=2,
+            config_manager=cm, rerank=False,
+        )
+    assert create_llm.call_count == 0
+    assert len(out) == 2
+
+
+# ── full-pipeline fallback ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_full_fallback_when_service_disabled():
+    """Vectors completely off ⇒ pipeline collapses to evidence_score
+    order, top-budget. No LLM call. This is the path that runs when
+    onnxruntime / model file isn't installed."""
+    svc = _FakeService(available=False)
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs(f"o{i}", f"t{i}", score=float(i))
+        for i in range(10)
+    ]
+    create_llm = MagicMock()
+    with patch("utils.llm_client.create_chat_llm", create_llm):
+        out = await r.aretrieve_candidates(
+            obs, query_texts=["q"], budget=3, config_manager=cm,
+        )
+    assert create_llm.call_count == 0
+    assert [o["id"] for o in out] == ["o9", "o8", "o7"]
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_empty_observations_returns_empty():
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    out = await r.aretrieve_candidates(
+        [], query_texts=["q"], budget=5, config_manager=cm,
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_aretrieve_hard_filter_zero_returns_empty():
+    """Every observation excluded by hard filter ⇒ empty result; no
+    coarse rank, no LLM call."""
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    cm = MagicMock()
+    obs = [
+        _obs("a", "x", suppress=True),
+        _obs("b", "y", protected=True),
+        _obs("c", "z", score=-1.0),
+    ]
+    out = await r.aretrieve_candidates(
+        obs, query_texts=["q"], budget=5, config_manager=cm,
+    )
+    assert out == []
+
+
+# ── prompt locale coverage ───────────────────────────────────────────
+
+
+def test_memory_recall_rerank_prompt_has_all_five_locales_with_placeholders():
+    """All five locales rendered + every placeholder substituted —
+    same contract test as fact_dedup.test_fact_dedup_prompt..."""
+    from config.prompts_memory import (
+        MEMORY_RECALL_RERANK_PROMPT,
+        get_memory_recall_rerank_prompt,
+    )
+    expected_locales = {"zh", "en", "ja", "ko", "ru"}
+    assert set(MEMORY_RECALL_RERANK_PROMPT.keys()) >= expected_locales
+    for lang in expected_locales:
+        rendered = (
+            get_memory_recall_rerank_prompt(lang)
+            .replace("{QUERY}", "X")
+            .replace("{CANDIDATES}", "Y")
+            .replace("{BUDGET}", "3")
+        )
+        assert "{QUERY}" not in rendered, lang
+        assert "{CANDIDATES}" not in rendered, lang
+        assert "{BUDGET}" not in rendered, lang
+
+
+def test_oversample_constant_is_at_least_two():
+    """COARSE_OVERSAMPLE = 1 would defeat the rerank — every coarse
+    candidate would already fit the budget. Lock the lower bound so
+    a future tweak can't accidentally collapse the LLM step."""
+    assert COARSE_OVERSAMPLE >= 2

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -500,3 +500,72 @@ def test_oversample_constant_is_at_least_two():
     candidate would already fit the budget. Lock the lower bound so
     a future tweak can't accidentally collapse the LLM step."""
     assert COARSE_OVERSAMPLE >= 2
+
+
+# ── _aload_signal_targets propagates suppress flag ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_aload_signal_targets_carries_reflection_suppress_flag(tmp_path):
+    """Codex PR-958 P2 regression: when ``_aload_signal_targets``
+    materialises reflection rows for the rerank pool, it must copy
+    ``suppress`` over from the source dict.  Without it, a
+    suppressed reflection would survive the reranker's hard filter
+    (which checks ``o.get('suppress')``) and leak back into Stage-2
+    signal detection — defeating the AI-mention rate-limit gate."""
+    from unittest.mock import AsyncMock, MagicMock
+    from memory.facts import FactStore
+
+    cm = MagicMock()
+    cm.memory_dir = str(tmp_path)
+    cm.aget_character_data = AsyncMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_character_data = MagicMock(return_value=(
+        "主人", "小天", {}, {}, {"human": "主人", "system": "SYS"}, {}, {}, {}, {},
+    ))
+    cm.get_model_api_config = MagicMock(return_value={
+        "model": "fake", "base_url": "http://fake", "api_key": "sk-fake",
+    })
+    with patch("memory.facts.get_config_manager", return_value=cm):
+        fs = FactStore()
+        fs._config_manager = cm
+
+    # Build a stub reflection engine that returns one suppressed +
+    # one not-suppressed confirmed reflection.
+    refl_engine = MagicMock()
+
+    async def _fake_load(_name):
+        return [
+            {"id": "r_active", "text": "active observation",
+             "entity": "master", "status": "confirmed",
+             "suppress": False},
+            {"id": "r_silent", "text": "silenced observation",
+             "entity": "master", "status": "confirmed",
+             "suppress": True, "suppressed_at": "2026-04-25T00:00:00"},
+        ]
+
+    refl_engine._aload_reflections_full = _fake_load
+
+    # Persona stub returns nothing — the bug under test is reflection-side.
+    persona = MagicMock()
+
+    async def _fake_persona(_name):
+        return {}
+
+    persona.aensure_persona = _fake_persona
+
+    pool = await fs._aload_signal_targets(
+        "小天", reflection_engine=refl_engine, persona_manager=persona,
+    )
+    by_id = {o["id"]: o for o in pool}
+    assert "reflection.r_silent" in by_id
+    assert by_id["reflection.r_silent"]["suppress"] is True
+    assert by_id["reflection.r_active"]["suppress"] is False
+
+    # And the reranker's hard filter actually drops the silenced one
+    # — the end-to-end check that the propagation matters.
+    survivors = MemoryRecallReranker._hard_filter(pool)
+    survivor_ids = {o["id"] for o in survivors}
+    assert "reflection.r_active" in survivor_ids
+    assert "reflection.r_silent" not in survivor_ids


### PR DESCRIPTION
**Stacked on top of #957** (P2 step 2), which is stacked on #956 (P2 step 1).  Review order: #956 → #957 → this PR.  Merge in the same order.

Step 3 of three for P2 (vector hybrid retrieval). Replaces the "top-N by evidence_score" heuristic that selects existing observations for the Stage-2 signal-detection LLM call with a three-phase pipeline: hard filter → cosine pre-rank → LLM rerank.

## Pipeline

`memory/recall.py` — `MemoryRecallReranker.aretrieve_candidates`:

1. **Hard filter** — drop entries with `evidence_score < 0`, suppressed entries, terminal-status reflections, protected persona (character_card sources), and empty-text rows. Same exclusions the render path already uses, consolidated into one helper.
2. **Coarse rank** — when EmbeddingService is available AND the caller passed query texts (typically newly-extracted facts), embed the queries, compute *max-cosine* between each candidate and any query, sort DESC, keep top `budget * COARSE_OVERSAMPLE` (default 3×). Without service or queries, this stage is a no-op and entries pass through in evidence_score order.
3. **Fine rank** — when the coarse pool exceeds budget AND vectors are available, single LLM call asks for the top `budget` items using `MEMORY_RECALL_RERANK_PROMPT`. evidence_score is exposed as auxiliary signal in the prompt (\"score=N\") but is NOT mixed into the ranking math. The LLM weighs it together with semantic relevance.

## Why it matters

Saves *prompt tokens* in Stage-2 signal detection. Today `_aload_signal_targets` returns up to 200 observations; under the new pipeline the LLM-validated subset is much smaller (still budget-bounded, but semantically scoped to what the user just said). Stage-2 LLM call itself is unchanged in shape — RFC §3.4 is preserved. Vectors are a *prefilter*, not a replacement.

## Why max-cosine across queries

A candidate that's near ANY query vector should win — recall should not require relevance to ALL topics the user just touched. max-pool also matches the single-query case trivially.

## Why evidence_score isn't in the ranking math

Cosine ∈ [0, 1]; evidence_score ∈ ℝ (unbounded). RFC's original `α·evidence + (1-α)·cosine` formula mixed dimensionally inconsistent quantities and ignored the suppress mechanism (which *is* in the hard filter). LLM rerank with evidence as auxiliary signal weights both factors with judgment instead of arithmetic.

## Fallback

Three escape hatches preserve the legacy \"top-N by evidence_score\" behaviour exactly:

- Empty queries OR EmbeddingService unavailable → coarse rank falls through to evidence_score order, top-budget. No LLM call.
- Coarse pool ≤ budget → every candidate passes; LLM call would be wasted, skipped.
- LLM call raises → falls back to the coarse rank order. Recall must never crash the signal-detection pipeline.

`memory/facts.py` — `_aload_signal_targets` now accepts an optional `new_facts` argument (the recall query). When provided AND vectors are available, the reranker is used; otherwise the legacy evidence_score sort runs. `aextract_facts_and_detect_signals` passes the freshly-persisted facts as the query so Stage-2 sees the LLM-validated candidate subset.

## Prompt

`MEMORY_RECALL_RERANK_PROMPT` in 5 locales (zh / en / ja / ko / ru). Each carries `{QUERY}`, `{CANDIDATES}`, `{BUDGET}` placeholders; test asserts every locale renders cleanly. Prompt explains `score=N` annotation as auxiliary signal and warns against letting score completely override relevance.

## Test plan

- [x] 21 memory_recall tests covering: hard filter (negative score, suppress, protected, terminal reflection, empty text); coarse rank (no service, no query, max-cosine across queries, evidence tie-break, missing-embedding demotion); LLM rerank (skip when candidates ≤ budget, invocation when > budget, hallucinated id drop, top-up when LLM returns < budget, fallback on LLM error, rerank=False bypass); full-pipeline fallback when service disabled; empty observations; hard-filter zero result; 5-locale prompt rendering; oversample lower-bound contract.
- [x] All 376 P2-related + memory tests still green (only pre-existing Windows file-lock flake remains).
- [ ] Manual smoke with model installed: send a turn that touches one specific topic, confirm Stage-2 logs show a noticeably smaller observations set than the legacy 200 cap, and that the chosen subset is semantically relevant to the turn.

## What this completes

P2 (vector hybrid retrieval) is fully landed across #956 / #957 / this PR. Follow-ups visible from here:

- **Worker restart on /reload** — the embedding worker captures the startup `fact_store`/`persona_manager`/`reflection_engine` references; today /reload doesn't restart it. Worker only writes the embedding triple, so staleness self-corrects via on-disk reads, but a clean restart-on-reload would be tidier.
- **Persona render uses the reranker** — currently only the signal-detection path uses cosine retrieval. The render path (`arender_persona_markdown`) still ranks by evidence_score. If we want per-turn semantic injection, the next change is to plumb the recent-conversation context through the render call.
- **Soak / tuning** — observe `FACT_DEDUP_COSINE_THRESHOLD` (0.85), `COARSE_OVERSAMPLE` (3), `BATCH_LIMIT` (20) under real traffic and adjust if the LLM rerank is doing too much work or too little.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强了内存回忆机制，采用更智能的多阶段候选项排名算法，提高了相关信息的检索准确性。
  * 新增多语言支持的记忆重排序配置。

* **测试**
  * 添加了全面的单元测试套件，确保内存排名功能的可靠性和正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->