### PR TITLE
fix(i18n): 统一 PR #938 遗留的 8 个 locale key 差异

### DIFF
--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -184,7 +184,6 @@
         "previewImageMissing": "No se encontró el archivo de imagen de vista previa, verifique la ruta",
         "uploadReady": "Listo para cargar {{itemName}}",
         "pageDescription": "Gestiona tarjetas de personaje: explora, edita, importa/exporta tarjetas y administra modelos y voces (incluyendo Steam Workshop como fuente opcional)",
-        "voiceNote": "Para la configuración de voz, vaya a la página de configuración de Live2D para registrarse manualmente",
         "openVoiceClone": "Abrir en clon de voz",
         "configurePath": "Configurar ruta",
         "localModPathConfig": "Configuración de ruta de modificación local",
@@ -3428,6 +3427,7 @@
         "savingCardFace": "Guardando...",
         "saveCardFaceSuccess": "¡Guardado correctamente!",
         "saveCardFaceFailed": "Error al guardar: {{error}}",
+        "saveCardFacePartialSuccess": "PNG guardado, pero la escritura de metadatos falló: {{error}}",
         "renderFailed": "No se puede renderizar la imagen de la tarjeta",
         "exportTitle": "Exportar tarjeta de personaje"
     },

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -3427,6 +3427,7 @@
         "savingCardFace": "保存中...",
         "saveCardFaceSuccess": "保存しました！",
         "saveCardFaceFailed": "保存に失敗しました: {{error}}",
+        "saveCardFacePartialSuccess": "PNGは保存されましたが、メタデータの書き込みに失敗しました: {{error}}",
         "renderFailed": "カード画像をレンダリングできません",
         "exportTitle": "キャラクターカードをエクスポート"
     },

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -3427,6 +3427,7 @@
         "savingCardFace": "저장 중...",
         "saveCardFaceSuccess": "저장 성공!",
         "saveCardFaceFailed": "저장 실패: {{error}}",
+        "saveCardFacePartialSuccess": "PNG는 저장되었지만 메타데이터 쓰기에 실패했습니다: {{error}}",
         "renderFailed": "카드 이미지를 렌더링할 수 없습니다",
         "exportTitle": "캐릭터 카드 내보내기"
     },

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -184,7 +184,6 @@
         "previewImageMissing": "Arquivo de imagem de visualização não encontrado, verifique o caminho",
         "uploadReady": "Pronto para carregar {{itemName}}",
         "pageDescription": "Navegue, assine, baixe e gerencie modelos e vozes Live2D do Steam Workshop",
-        "voiceNote": "Para configurações de voz, vá para a página de configurações do Live2D para registrar manualmente",
         "openVoiceClone": "Abrir no clone de voz",
         "configurePath": "Configurar caminho",
         "localModPathConfig": "Configuração do caminho do mod local",
@@ -3428,6 +3427,7 @@
         "savingCardFace": "Salvando...",
         "saveCardFaceSuccess": "Salvo com sucesso!",
         "saveCardFaceFailed": "Falha ao salvar: {{error}}",
+        "saveCardFacePartialSuccess": "PNG salvo, mas a escrita de metadados falhou: {{error}}",
         "renderFailed": "Não foi possível renderizar o rosto do cartão",
         "exportTitle": "Exportar cartão de personagem"
     },

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3427,6 +3427,7 @@
         "savingCardFace": "Сохранение...",
         "saveCardFaceSuccess": "Сохранено успешно!",
         "saveCardFaceFailed": "Ошибка сохранения: {{error}}",
+        "saveCardFacePartialSuccess": "PNG сохранён, но запись метаданных не удалась: {{error}}",
         "renderFailed": "Не удалось отрендерить изображение карточки",
         "exportTitle": "Экспорт карточки персонажа"
     },

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -3427,6 +3427,7 @@
         "savingCardFace": "保存中...",
         "saveCardFaceSuccess": "保存成功！",
         "saveCardFaceFailed": "保存失败: {{error}}",
+        "saveCardFacePartialSuccess": "PNG 已保存，但元数据写入失败: {{error}}",
         "renderFailed": "无法渲染卡面图片",
         "exportTitle": "导出角色卡"
     },

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -3427,6 +3427,7 @@
         "savingCardFace": "儲存中...",
         "saveCardFaceSuccess": "儲存成功！",
         "saveCardFaceFailed": "儲存失敗: {{error}}",
+        "saveCardFacePartialSuccess": "PNG 已儲存，但中繼資料寫入失敗: {{error}}",
         "renderFailed": "無法渲染卡面圖片",
         "exportTitle": "匯出角色卡"
     },


### PR DESCRIPTION
## 背景

[PR #938](https://github.com/Project-N-E-K-O/N.E.K.O/pull/938) 合并时 8 个 locale 的 diff 行数不一致 (en +57/-21, es +58/-22, ja +56/-21, ko +56/-21, pt +53/-17, ru +56/-21, zh-CN +56/-21, zh-TW +57/-22)。导出对全 locale flat-key 集合后发现两处真正的不一致。

## 改动

### 1. 补 `cardExport.saveCardFacePartialSuccess`（7 个 locale）

只有 en 加了这个 key。它被 [card_maker.js:705](static/js/card_maker.js#L705) 引用，缺失会让 7 个 locale 一直回退到代码里的中文 fallback `"PNG 已保存，但元数据写入失败: {{error}}"`。本 PR 在每个 locale 紧邻 `saveCardFaceFailed` 后补上对应翻译。

### 2. 删 `steam.voiceNote`（es / pt）

es/pt 残留了这条 key，但是其他 6 个 locale 在 #938 里已经删掉，且全代码 grep 不到任何 `steam.voiceNote` 引用，是旧 Steam Workshop 页面的死翻译。

## 校验

```
union total keys: 2940
en/es/ja/ko/pt/ru/zh-CN/zh-TW: 2940 keys, missing 0
ALL LOCALES IDENTICAL: True
```

8 个 locale flat-key 集完全一致，JSON 都能 `json.load` 通过。

## Test plan

- [ ] 8 个 locale 切换浏览角色卡管理页，文案显示正常
- [ ] 卡面保存时如果元数据写入失败，按钮文字应该按当前语言显示（不再回退到中文）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 在卡牌面部导出流程中添加了新的状态提示消息，支持多种语言

* **本地化更新**
  * 为西班牙语、日语、韩语、葡萄牙语、俄语、简体中文和繁体中文添加了相应的新增翻译
  * 移除了西班牙语和葡萄牙语中的语音配置相关文本

<!-- end of auto-generated comment: release notes by coderabbit.ai -->