### PR TITLE
修复 N.E.K.O-PC 桌面端聊天框无法加载的问题

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -633,6 +633,12 @@ def _resolve_emotion_prompt_language(text):
         return 'zh'
 
 
+@router.get("/v1/system/status")
+async def get_system_status():
+    """返回系统就绪状态，供桌面端存储闸门判断是否可以创建卫星窗口。"""
+    return {"ready": True}
+
+
 @router.get("/token-usage")
 async def get_token_usage(days: int = 7):
     """返回最近 N 天的 LLM token 用量统计。"""


### PR DESCRIPTION
桌面端通过 /api/v1/system/status 判断后端就绪状态后才会创建聊天窗口，
但后端缺少该路由，导致存储闸门永远阻塞，聊天框无法自动或手动打开。
补充该端点并返回 ready: true，使桌面端能正常创建卫星窗口。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增系统状态检查端点，允许客户端查询系统就绪状态

<!-- end of auto-generated comment: release notes by coderabbit.ai -->