### PR TITLE
fix(memory): keyword/BM25 层先剥离 master/lanlan 名字与昵称

### DIFF
--- a/memory/persona.py
+++ b/memory/persona.py
@@ -32,6 +32,11 @@ from config import (
     SETTING_PROPOSER_MODEL,
 )
 from memory.evidence import evidence_score
+from memory.stop_names import (
+    acollect_stop_names,
+    collect_stop_names,
+    strip_stop_names,
+)
 from utils.cloudsave_runtime import assert_cloudsave_writable
 from utils.config_manager import get_config_manager
 from utils.file_utils import (
@@ -60,12 +65,19 @@ AUTO_CONFIRM_DAYS = 3                # pending reflection N 天无反对 → 自
 # Split on any CJK/Latin punctuation, symbols, whitespace
 _SPLIT_RE = re.compile(r'[，。、！？；：\u201c\u201d\u2018\u2019（）()\[\]{}<>《》【】\s,.!?;:\-\u2014\u2026\xb7\u3000]+')
 
-def _extract_keywords(text: str) -> set[str]:
+def _extract_keywords(text: str, stop_names: list[str] | None = None) -> set[str]:
     """从文本提取关键词/n-gram，支持 CJK 和拉丁文。
 
     - 拉丁文按空格分词，保留 len>=2 的 token
     - CJK 文本生成 2-gram 和 3-gram 滑动窗口
+
+    ``stop_names`` 给定时（master/lanlan + 各自昵称），先在 tokenize 之前把这些
+    名字从原文剥离——否则高频实体名每轮对话都出现，会生成大量 n-gram，主导
+    ``_is_mentioned`` 的集合命中与 ``_texts_may_contradict`` 的 fuzzy 矛盾检测，
+    放大无效匹配。
     """
+    if stop_names:
+        text = strip_stop_names(text, stop_names)
     segments = _SPLIT_RE.split(text)
     keywords: set[str] = set()
 
@@ -88,14 +100,24 @@ def _extract_keywords(text: str) -> set[str]:
     return keywords
 
 
-def _is_mentioned(fact_text: str, response_text: str) -> bool:
-    """判断 response 中是否"提及"了某条 persona 事实。"""
+def _is_mentioned(
+    fact_text: str,
+    response_text: str,
+    stop_names: list[str] | None = None,
+) -> bool:
+    """判断 response 中是否"提及"了某条 persona 事实。
+
+    ``stop_names`` 给定时同时从 fact 与 response 中剥离——否则 AI 几乎
+    每轮都会喊 master/lanlan 名字，触发"提及"误命中并把无关 fact 推入
+    suppress 流程。
+    """
     if not fact_text or not response_text:
         return False
-    keywords = _extract_keywords(fact_text)
+    keywords = _extract_keywords(fact_text, stop_names=stop_names)
     if not keywords:
         return False
-    return any(kw in response_text for kw in keywords)
+    haystack = strip_stop_names(response_text, stop_names) if stop_names else response_text
+    return any(kw in haystack for kw in keywords)
 
 
 class PersonaManager:
@@ -803,7 +825,7 @@ class PersonaManager:
         """
         persona = self.ensure_persona(name)
         section_facts = self._get_section_facts(persona, entity)
-        stop_names = self._get_entity_stop_names()
+        stop_names = self._get_entity_stop_names(name)
 
         code, old_text = self._evaluate_fact_contradiction(name, text, section_facts, stop_names)
         if code == self.FACT_REJECTED_CARD:
@@ -827,7 +849,7 @@ class PersonaManager:
         async with self._get_alock(name):
             persona = await self._aensure_persona_locked(name)
             section_facts = self._get_section_facts(persona, entity)
-            stop_names = await self._aget_entity_stop_names()
+            stop_names = await self._aget_entity_stop_names(name)
 
             code, old_text = self._evaluate_fact_contradiction(name, text, section_facts, stop_names)
             if code == self.FACT_REJECTED_CARD:
@@ -1416,55 +1438,33 @@ class PersonaManager:
     def _get_section_facts(self, persona: dict, entity: str) -> list:
         return persona.setdefault(entity, {}).setdefault('facts', [])
 
-    def _get_entity_stop_names(self) -> list[str]:
-        """Return master + neko names to strip from contradiction keywords."""
-        try:
-            master_name, her_name, _, _, _, _, _, _, _ = (
-                self._config_manager.get_character_data()
-            )
-            names = []
-            if master_name:
-                names.append(master_name)
-            if her_name:
-                names.append(her_name)
-            return names
-        except Exception:
-            return []
+    def _get_entity_stop_names(self, lanlan_name: str | None = None) -> list[str]:
+        """Return master + lanlan names + their 昵称 — used to strip stop-names
+        before any keyword/BM25/extraction step in the memory pipeline.
 
-    async def _aget_entity_stop_names(self) -> list[str]:
-        try:
-            master_name, her_name, _, _, _, _, _, _, _ = (
-                await self._config_manager.aget_character_data()
-            )
-            names = []
-            if master_name:
-                names.append(master_name)
-            if her_name:
-                names.append(her_name)
-            return names
-        except Exception:
-            return []
+        ``lanlan_name`` 缺省走 "当前猫娘"。给定时用该角色自己的 ``昵称``——
+        这条路径下 ``aadd_fact`` 等显式拿到了目标角色，避免在多角色配置里
+        误用当前活跃角色的昵称。
+        """
+        return collect_stop_names(self._config_manager, lanlan_name)
+
+    async def _aget_entity_stop_names(self, lanlan_name: str | None = None) -> list[str]:
+        return await acollect_stop_names(self._config_manager, lanlan_name)
 
     @staticmethod
     def _texts_may_contradict(old_text: str, new_text: str,
                               stop_names: list[str] | None = None) -> bool:
         """Lightweight keyword-overlap heuristic for contradiction detection.
 
-        Uses the same CJK-aware tokenization as _is_mentioned.
-        ``stop_names`` — entity names (master/neko) whose n-grams are
-        stripped from both sides so that shared names alone don't inflate
-        the overlap ratio.
+        Uses the same CJK-aware tokenization as ``_is_mentioned``.
+        ``stop_names`` — master/lanlan + 各自昵称——会先从原文 substring
+        replace 掉，然后再切 n-gram，避免共享的实体名独自拉高 overlap 比例
+        造成误报。
         """
         if not old_text or not new_text:
             return False
-        old_kw = _extract_keywords(old_text)
-        new_kw = _extract_keywords(new_text)
-        if stop_names:
-            stop_kw: set[str] = set()
-            for sn in stop_names:
-                stop_kw |= _extract_keywords(sn)
-            old_kw -= stop_kw
-            new_kw -= stop_kw
+        old_kw = _extract_keywords(old_text, stop_names=stop_names)
+        new_kw = _extract_keywords(new_text, stop_names=stop_names)
         if not old_kw or not new_kw:
             return False
         overlap = old_kw & new_kw
@@ -1723,7 +1723,12 @@ class PersonaManager:
 
     # ── 提及疲劳：记录 + 更新 suppress ───────────────────────────
 
-    def _apply_record_mentions(self, persona: dict, response_text: str) -> bool:
+    def _apply_record_mentions(
+        self,
+        persona: dict,
+        response_text: str,
+        stop_names: list[str] | None = None,
+    ) -> bool:
         now_str = datetime.now().isoformat()
         now = datetime.now()
         cutoff = now - timedelta(hours=SUPPRESS_WINDOW_HOURS)
@@ -1734,7 +1739,7 @@ class PersonaManager:
                 continue
             if entry.get('protected'):
                 continue
-            if not _is_mentioned(entry.get('text', ''), response_text):
+            if not _is_mentioned(entry.get('text', ''), response_text, stop_names=stop_names):
                 continue
 
             mentions = entry.get('recent_mentions', [])
@@ -1752,15 +1757,19 @@ class PersonaManager:
         """主动搭话投递后，扫描 response 中哪些 persona 条目被提及。
 
         核心逻辑：5小时内提及 > SUPPRESS_MENTION_LIMIT 次 → suppress。
+        Stop-names 在进 ``_is_mentioned`` 之前剥掉，避免 master/lanlan
+        每轮被喊一次就把无关 fact 全部判成 mentioned。
         """
         persona = self.ensure_persona(name)
-        if self._apply_record_mentions(persona, response_text):
+        stop_names = self._get_entity_stop_names(name)
+        if self._apply_record_mentions(persona, response_text, stop_names=stop_names):
             self.save_persona(name, persona)
 
     async def arecord_mentions(self, name: str, response_text: str) -> None:
+        stop_names = await self._aget_entity_stop_names(name)
         async with self._get_alock(name):
             persona = await self._aensure_persona_locked(name)
-            if self._apply_record_mentions(persona, response_text):
+            if self._apply_record_mentions(persona, response_text, stop_names=stop_names):
                 await self.asave_persona(name, persona)
 
     def _apply_update_suppressions(self, persona: dict) -> bool:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -52,6 +52,7 @@ from memory.persona import (
     SUPPRESS_WINDOW_HOURS,
     _is_mentioned,
 )
+from memory.stop_names import acollect_stop_names
 
 if TYPE_CHECKING:
     from memory.event_log import EventLog
@@ -1143,11 +1144,17 @@ class ReflectionEngine:
 
     @classmethod
     def _apply_record_reflection_mentions(
-        cls, reflections: list[dict], response_text: str,
+        cls,
+        reflections: list[dict],
+        response_text: str,
+        stop_names: list[str] | None = None,
     ) -> bool:
         """AI response 提到任一 **confirmed** reflection 的文本 → recent_mentions 累加。
         Pending reflection 本意就是"AI 主动试探"，抑制会反向破坏机制——
         所以只扫 confirmed。语义和 persona._apply_record_mentions 对齐。
+
+        ``stop_names`` 在进 ``_is_mentioned`` 之前剥掉，避免高频出现的
+        master/lanlan + 昵称把无关 reflection 也判成 mentioned。
         """
         now = datetime.now()
         now_str = now.isoformat()
@@ -1158,7 +1165,7 @@ class ReflectionEngine:
                 continue
             if r.get('status') != 'confirmed':
                 continue
-            if not _is_mentioned(r.get('text', ''), response_text):
+            if not _is_mentioned(r.get('text', ''), response_text, stop_names=stop_names):
                 continue
             mentions = r.get('recent_mentions', [])
             mentions.append(now_str)
@@ -1211,9 +1218,12 @@ class ReflectionEngine:
         """
         if not response_text:
             return
+        stop_names = await acollect_stop_names(self._config_manager, lanlan_name)
         async with self._get_alock(lanlan_name):
             reflections = await self._aload_reflections_full(lanlan_name)
-            if self._apply_record_reflection_mentions(reflections, response_text):
+            if self._apply_record_reflection_mentions(
+                reflections, response_text, stop_names=stop_names,
+            ):
                 active = [
                     r for r in reflections
                     if r.get('status') not in REFLECTION_TERMINAL_STATUSES

--- a/memory/stop_names.py
+++ b/memory/stop_names.py
@@ -26,6 +26,17 @@ import re
 # Comma / 中文逗号 / 顿号 / 分号 / 空白都视为昵称字段分隔符。
 _NICKNAME_SPLIT_RE = re.compile(r"[,，;；、\s]+")
 
+# 纯拉丁/数字字母的别名（"Tony"、"al"、"T-酱" 也算，只要不含 CJK / 其他脚本）。
+# 这类别名走 word-boundary 替换，避免 ``Al`` 把 ``Algorithm`` 截掉一截。
+_LATIN_ALIAS_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+# 别名最短长度。Codex PR-971 P2: 单字符 alias（``T`` / ``天``）做全文 substring
+# replace 会把所有命中字符抹掉——``今天天气好`` + stop=``天`` 会留下
+# ``今  气好``，``_extract_keywords`` 抽到的 n-gram 只剩 ``气好`` 一个，悄无声
+# 息地把 BM25/记忆召回的 recall 砍光。漏掉一个真单字别名是次要损失，比起
+# 把每条 fact 都腌一遍完全可接受。
+_MIN_STOP_NAME_LEN = 2
+
 
 def split_nickname_aliases(raw) -> list[str]:
     """Split a ``昵称`` field (comma/space-separated) into individual aliases.
@@ -102,19 +113,41 @@ async def acollect_stop_names(
 
 
 def strip_stop_names(text: str, stop_names: list[str] | None) -> str:
-    """Remove every ``stop_name`` occurrence from ``text`` (substring replace).
+    """Remove every ``stop_name`` occurrence from ``text``.
 
-    Names are replaced with a single space rather than empty string so
-    that ``_extract_keywords`` ' tokenizer sees a clean word boundary
-    instead of merging the surrounding characters into a fake n-gram.
-    Caller is expected to pass ``stop_names`` ordered longest-first
+    Names are replaced with a single space (not empty) so that
+    ``_extract_keywords`` ' tokenizer sees a clean separator instead of
+    merging the surrounding characters into a fake n-gram. Caller is
+    expected to pass ``stop_names`` ordered longest-first
     (``collect_stop_names`` already guarantees this).
+
+    Per-alias strategy (Codex PR-971 P2):
+      * len < 2 → 跳过。单字符 alias（``T`` 或 ``天``）做全文 substring
+        replace 会把所有命中字符抹掉，对 ``_extract_keywords`` 的 n-gram
+        切分是毁灭性的；漏剥一个真单字别名远比悄无声息腐蚀全量 fact 文本
+        要轻。
+      * 纯拉丁 alias (``Tony`` / ``Al``) → word-boundary 替换，否则
+        ``Al`` 会把 ``Algorithm`` 截成 `` gorithm``。boundary 用显式
+        ``[A-Za-z0-9_]`` 前后查 ascii，避免 ``\\b`` 在 Python 默认
+        Unicode 模式下把 CJK 算成 word-char 而失效（``\\bTony\\b`` 在
+        ``今天Tony来了`` 里不命中）。
+      * CJK / 混合脚本 alias (``T酱`` / ``小天``) → 仍走 substring
+        replace。CJK 没有 word boundary 概念，且 ≥2 字符的 CJK 串足够
+        specific，substring 误伤 vanishingly rare。
     """
     if not text or not stop_names:
         return text
     out = text
     for n in stop_names:
-        if not n:
+        if not n or len(n) < _MIN_STOP_NAME_LEN:
             continue
-        out = out.replace(n, ' ')
+        if _LATIN_ALIAS_RE.fullmatch(n):
+            pattern = (
+                r"(?<![A-Za-z0-9_])"
+                + re.escape(n)
+                + r"(?![A-Za-z0-9_])"
+            )
+            out = re.sub(pattern, ' ', out, flags=re.IGNORECASE)
+        else:
+            out = out.replace(n, ' ')
     return out

--- a/memory/stop_names.py
+++ b/memory/stop_names.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""
+Stop-name helpers for the memory module's keyword / BM25 / extraction layer.
+
+Why this exists: ``master_name``、``lanlan_name`` 以及它们各自的 ``昵称``
+几乎在每一轮对话里都会出现——一旦把它们也喂给 ``_extract_keywords`` /
+``_is_mentioned`` / FTS5 BM25，这些 token 会主导关键词重叠或检索得分，
+触发大量误命中（无关 fact 被判定 "mentioned"、dedup 误判相似、矛盾检测
+误报）。统一在调用关键词层之前剥离这些 stop-name，避免无效匹配。
+
+Design notes:
+- 入口集中在 ``collect_stop_names`` / ``acollect_stop_names``，从
+  ``ConfigManager.get_character_data`` 取 ``主人.档案名`` + ``主人.昵称``
+  与给定 ``lanlan_name`` 自身 + 该角色的 ``昵称``。``lanlan_name`` 缺省
+  退回 "当前猫娘"，因为部分调用点只关心当前活跃角色。
+- ``昵称`` 字段是逗号分隔字符串（中英文标点皆可），统一拆成单条别名。
+- 列表按长度倒序去重——substring replace 时长 alias 优先匹配，避免
+  ``T酱`` 先剥离时把 ``小T酱`` 截断成 ``小``。
+- ``strip_stop_names`` 是 substring replace；CJK / 短拉丁名足够用，
+  长拉丁名想做 word-boundary 留给后续按需扩展。
+"""
+from __future__ import annotations
+
+import re
+
+# Comma / 中文逗号 / 顿号 / 分号 / 空白都视为昵称字段分隔符。
+_NICKNAME_SPLIT_RE = re.compile(r"[,，;；、\s]+")
+
+
+def split_nickname_aliases(raw) -> list[str]:
+    """Split a ``昵称`` field (comma/space-separated) into individual aliases.
+
+    Empty / whitespace tokens are dropped. Always returns a list (never None).
+    """
+    if not raw:
+        return []
+    return [s.strip() for s in _NICKNAME_SPLIT_RE.split(str(raw)) if s.strip()]
+
+
+def _assemble_stop_names(
+    master_name: str | None,
+    her_name: str | None,
+    master_basic: dict | None,
+    catgirl_data: dict | None,
+    lanlan_name: str | None,
+) -> list[str]:
+    target = lanlan_name or her_name
+    names: list[str] = []
+    if master_name:
+        names.append(str(master_name))
+    if target:
+        names.append(str(target))
+    if isinstance(master_basic, dict):
+        names.extend(split_nickname_aliases(master_basic.get('昵称', '')))
+    if target and isinstance(catgirl_data, dict):
+        char_cfg = catgirl_data.get(target)
+        if isinstance(char_cfg, dict):
+            names.extend(split_nickname_aliases(char_cfg.get('昵称', '')))
+    seen: set[str] = set()
+    unique: list[str] = []
+    for n in names:
+        if n and n not in seen:
+            seen.add(n)
+            unique.append(n)
+    # Longest-first so substring replace doesn't leave fragments of longer aliases.
+    unique.sort(key=len, reverse=True)
+    return unique
+
+
+def collect_stop_names(config_manager, lanlan_name: str | None = None) -> list[str]:
+    """Sync: master + master_nicknames + lanlan + lanlan_nicknames.
+
+    ``lanlan_name`` defaults to the current catgirl when ``None``.
+    Failures (config corruption, etc.) degrade silently to ``[]`` so the
+    caller's keyword layer keeps working — losing stop-name stripping is
+    strictly less harmful than crashing the recall path.
+    """
+    try:
+        master_name, her_name, master_basic, catgirl_data, *_ = (
+            config_manager.get_character_data()
+        )
+    except Exception:
+        return []
+    return _assemble_stop_names(
+        master_name, her_name, master_basic, catgirl_data, lanlan_name,
+    )
+
+
+async def acollect_stop_names(
+    config_manager, lanlan_name: str | None = None,
+) -> list[str]:
+    """Async twin of :func:`collect_stop_names`."""
+    try:
+        master_name, her_name, master_basic, catgirl_data, *_ = (
+            await config_manager.aget_character_data()
+        )
+    except Exception:
+        return []
+    return _assemble_stop_names(
+        master_name, her_name, master_basic, catgirl_data, lanlan_name,
+    )
+
+
+def strip_stop_names(text: str, stop_names: list[str] | None) -> str:
+    """Remove every ``stop_name`` occurrence from ``text`` (substring replace).
+
+    Names are replaced with a single space rather than empty string so
+    that ``_extract_keywords`` ' tokenizer sees a clean word boundary
+    instead of merging the surrounding characters into a fake n-gram.
+    Caller is expected to pass ``stop_names`` ordered longest-first
+    (``collect_stop_names`` already guarantees this).
+    """
+    if not text or not stop_names:
+        return text
+    out = text
+    for n in stop_names:
+        if not n:
+            continue
+        out = out.replace(n, ' ')
+    return out

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -1,6 +1,7 @@
 from utils.llm_client import SQLChatMessageHistory, SystemMessage
 from sqlalchemy import create_engine, text
 from config import TIME_ORIGINAL_TABLE_NAME, TIME_COMPRESSED_TABLE_NAME
+from memory.stop_names import collect_stop_names, strip_stop_names
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.config_manager import get_config_manager
 from utils.logger_config import get_module_logger
@@ -373,12 +374,21 @@ class TimeIndexedMemory:
         await asyncio.to_thread(self._ensure_fts_table, lanlan_name)
 
     def index_fact(self, lanlan_name: str, fact_id: str, content: str) -> None:
-        """将事实插入 FTS5 索引。"""
+        """将事实插入 FTS5 索引。
+
+        索引前先剥离 master/lanlan + 各自昵称：这些 token 几乎在每条 fact
+        里都出现，BM25 IDF 虽然会自动降权，但留着仍会让 dedup 时的得分
+        被它们噪声化（"主人喜欢猫" vs "主人讨厌狗" 仍因共享"主人"获得
+        非零相似度）。索引侧 + 查询侧同步剥离才能让 BM25 完全围绕
+        substantive 内容算分。
+        """
         self._assert_timeindex_writable(lanlan_name)
         if not self._ensure_engine_exists(lanlan_name):
             return
         if not self._ensure_fts_table(lanlan_name):
             return
+        stop_names = collect_stop_names(get_config_manager(), lanlan_name)
+        indexed_content = strip_stop_names(content, stop_names)
         try:
             with self.engines[lanlan_name].connect() as conn:
                 # 先检查是否已存在
@@ -390,7 +400,7 @@ class TimeIndexedMemory:
                     return  # 已索引
                 conn.execute(
                     text(f"INSERT INTO {self.FACTS_FTS_TABLE}(fact_id, content) VALUES(:fid, :content)"),
-                    {"fid": fact_id, "content": content}
+                    {"fid": fact_id, "content": indexed_content}
                 )
                 conn.commit()
         except Exception as e:
@@ -403,6 +413,9 @@ class TimeIndexedMemory:
         """通过 FTS5 BM25 搜索事实。返回 [(fact_id, bm25_score), ...]。
 
         FTS5 bm25() 分数通常为负值，分数越小（越负）代表相关性越高。
+        查询前先剥离 master/lanlan + 各自昵称：和 ``index_fact`` 对称，
+        只有索引侧与查询侧同时去掉这些 stop-name，BM25 才能围绕
+        substantive 内容真正区分相似度。
         """
         try:
             if not self._ensure_engine_exists(lanlan_name, readonly=True):
@@ -412,9 +425,15 @@ class TimeIndexedMemory:
         except MaintenanceModeError as exc:
             logger.debug(f"[TimeIndexedMemory] 维护态跳过搜索 {lanlan_name} 的 FTS 索引初始化: {exc}")
             return []
+        stop_names = collect_stop_names(get_config_manager(), lanlan_name)
+        normalized_query = strip_stop_names(query, stop_names)
+        if not normalized_query.strip():
+            # Stripping 后什么都没剩——多半是纯名字查询，不让 FTS5 在空
+            # query 上抛 syntax error。
+            return []
         try:
             # 转义 FTS5 特殊字符
-            safe_query = query.replace('"', '""')
+            safe_query = normalized_query.replace('"', '""')
             with self.engines[lanlan_name].connect() as conn:
                 result = conn.execute(
                     text(


### PR DESCRIPTION
## Summary

- 新增 `memory/stop_names.py`：从 `ConfigManager` 拼 master 档案名 + 昵称、目标 lanlan 档案名 + 昵称，作为 stop-name 集合（按长度倒序去重）。提供 sync / async helper。
- `memory/persona.py`：`_extract_keywords` / `_is_mentioned` / `_texts_may_contradict` 接受 `stop_names`，tokenize 之前先把名字 substring replace 成空格；`_get_entity_stop_names` 现在带昵称且接受目标 lanlan_name；`record_mentions` / `arecord_mentions` / `aadd_fact` 自行查询透传。
- `memory/reflection.py`：`_apply_record_reflection_mentions` / `arecord_mentions` 同步加链路。
- `memory/timeindex.py`：`index_fact` / `search_facts` 索引侧与查询侧对称剥离；纯名字查询直接返回 `[]` 避 FTS5 语法错误。

## Why

`master_name` / `lanlan_name` 及各自的 `昵称` 字段几乎每轮对话都出现。喂给关键词 / BM25 / n-gram 提取层会主导得分，触发：

- `_is_mentioned` 把无关 fact 全判成"提及"，5 小时内累计 > 2 次直接打上 `suppress` → 用户真正关心的偏好被静默隐藏
- `_texts_may_contradict` 仅靠共享名字就过 0.4 重叠阈值 → 误进 correction 队列
- FTS5 BM25 dedup 被高频名字噪声化 → "主人喜欢猫" vs "主人讨厌狗" 也拿到非零相似度

修复后 (manual 验证)：
```python
_is_mentioned("小天是一只猫娘", "小天，你好呀", stop_names=["小天"]) == False  # 修复前 True
_is_mentioned("小天是一只猫娘", "小天确实是猫娘", stop_names=["小天"]) == True  # 实质内容仍触发
```

## 故意不改

- `brain/plugin_filter.py` BM25 — 非 memory 模块，是 plugin 选择器
- `config/prompts_memory.scan_negative_keywords` — 关键词是 "别再说" / "stop talking about" 这类固定短语，与名字无重叠
- `memory/recall.py` 的 cosine pre-rank、`memory/fact_dedup.py` 的 cosine 候选 — **稠密 embedding 不存在 "高频词主导" 问题**。fact_dedup.py:62 自带数据："主人喜欢猫" vs "主人讨厌猫" ≈ 0.78 (不会过 0.85)，说明名字根本没主导 cosine。剥名反而会把 "主人喜欢猫" / "T酱喜欢猫" 这种不同主语事实误判为相同，损害 LLM `keep_both` 仲裁的语义信号
- `memory/facts.py` LLM 提取链路 — 大模型本身理解名字，剥名字反而破坏语义

## Test plan

- [x] 299 个 memory 相关 pytest 全过 (`-k "persona or reflection or timeindex or facts or memory or recall or stop_names or evidence"`)
- [x] `tests/test_persona_mock.py` + `tests/unit/test_evidence_promote_merge.py` 全过 (31)
- [x] manual 单测验证 `_is_mentioned` / `_texts_may_contradict` / `strip_stop_names` / `collect_stop_names` 行为
- [x] 全量 pytest 中残留 28 个 failure 已确认在 main 同样失败 (`test_home_prompt_flow.py` chromium / `test_character_memory_regression.py` event-loop 串扰)，与本次改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 统一并强化了名字/昵称的识别与屏蔽逻辑，提高关键词提取和提及检测的准确性
  * 搜索与索引在查询前会过滤名字变体，避免无效或噪声匹配，提升搜索相关性
* **新增**
  * 增加了专门的名字别名处理层以更稳健地处理多种别名格式和语言变体
<!-- end of auto-generated comment: release notes by coderabbit.ai -->