### PR TITLE
Rebalance realistic chat backlog

### DIFF
--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -134,10 +134,7 @@
 
     // ======================== 句子分割（从 app-chat.js 复刻） ========================
 
-    function splitIntoSentences(buffer, options) {
-        options = options || {};
-        var mode = options.mode || 'normal';
-        var flushTrailingBoundary = options.flushTrailingBoundary !== false;
+    function splitIntoSentences(buffer) {
         var sentences = [];
         var s = normalizeGeminiText(buffer);
         var start = 0;
@@ -149,13 +146,11 @@
         function isBoundary(ch, next) {
             if (ch === '\n') return true;
             if (isPunctForBoundary(ch) && next && isPunctForBoundary(next)) return false;
-            if (isPunctForBoundary(ch) && !next) return flushTrailingBoundary;
+            if (isPunctForBoundary(ch) && !next) return true;
             if (ch === '\u3002' || ch === '\uFF01' || ch === '\uFF1F') return true;
-            if (mode === 'coarse') return false;
             if (ch === '!' || ch === '?') return true;
-            if (ch === '\u2026') return mode === 'normal';
+            if (ch === '\u2026') return true;
             if (ch === '.') {
-                if (mode !== 'normal') return false;
                 if (!next) return true;
                 return /\s|\n|["')\]]/.test(next);
             }
@@ -174,21 +169,6 @@
 
         var rest = s.slice(start);
         return { sentences: sentences, rest: rest };
-    }
-
-    // Queue thresholds reflect visible backlog pressure; chunk thresholds catch
-    // fast streams before enough queued bubbles accumulate.
-    var BALANCED_QUEUE_THRESHOLD = 4;
-    var BALANCED_CHUNK_THRESHOLD = 16;
-    var COARSE_QUEUE_THRESHOLD = 8;
-    var COARSE_CHUNK_THRESHOLD = 32;
-
-    function getRealisticSplitMode() {
-        var queueLen = Array.isArray(window._realisticGeminiQueue) ? window._realisticGeminiQueue.length : 0;
-        var chunkCount = window._realisticGeminiChunkCount || 0;
-        if (queueLen >= COARSE_QUEUE_THRESHOLD || chunkCount >= COARSE_CHUNK_THRESHOLD) return 'coarse';
-        if (queueLen >= BALANCED_QUEUE_THRESHOLD || chunkCount >= BALANCED_CHUNK_THRESHOLD) return 'balanced';
-        return 'normal';
     }
 
     function isFullWidthJoinPunctuation(ch) {
@@ -219,33 +199,48 @@
         return joined;
     }
 
-    function rebalanceRealisticQueueIfNeeded() {
-        var mode = getRealisticSplitMode();
-        if (mode === 'normal') return;
-        var queue = window._realisticGeminiQueue;
-        if (!Array.isArray(queue) || queue.length < 2) return;
+    function isMiddleSplitBoundary(text, index) {
+        var prev = text.charAt(index - 1);
+        var next = text.charAt(index);
+        return /\s/.test(prev) || /\s/.test(next) ||
+            isFullWidthJoinPunctuation(prev) ||
+            /[.!?;,]/.test(prev);
+    }
 
-        var originalBuffer = typeof window._realisticGeminiBuffer === 'string' ? window._realisticGeminiBuffer : '';
-        var queueText = joinRealisticPendingPieces(queue);
-        if (!queueText) return;
+    function splitRealisticTextNearMiddle(text) {
+        var normalized = normalizeGeminiText(text).replace(/^\s+/, '').replace(/\s+$/, '');
+        if (!normalized) return [];
+        if (normalized.length < 2) return [normalized];
 
-        var pieces = [queueText];
-        if (originalBuffer) pieces.push(originalBuffer);
-        var pendingText = joinRealisticPendingPieces(pieces);
-        var splitResult = splitIntoSentences(pendingText, {
-            mode: mode,
-            flushTrailingBoundary: !originalBuffer
-        });
-
-        if (splitResult.sentences.length === 0) {
-            window._realisticGeminiQueue = [queueText];
-            window._realisticGeminiBuffer = originalBuffer;
-            return;
+        var midpoint = Math.floor(normalized.length / 2);
+        var splitAt = midpoint;
+        for (var offset = 0; offset < normalized.length; offset++) {
+            var left = midpoint - offset;
+            var right = midpoint + offset;
+            if (left > 0 && left < normalized.length && isMiddleSplitBoundary(normalized, left)) {
+                splitAt = left;
+                break;
+            }
+            if (right > 0 && right < normalized.length && isMiddleSplitBoundary(normalized, right)) {
+                splitAt = right;
+                break;
+            }
         }
 
-        if (splitResult.sentences.length <= queue.length) {
-            window._realisticGeminiQueue = splitResult.sentences;
-            window._realisticGeminiBuffer = splitResult.rest;
+        var first = normalized.slice(0, splitAt).replace(/^\s+/, '').replace(/\s+$/, '');
+        var second = normalized.slice(splitAt).replace(/^\s+/, '').replace(/\s+$/, '');
+        if (!first || !second) return [normalized];
+        return [first, second];
+    }
+
+    function rebalanceRealisticQueueIfNeeded() {
+        var queue = window._realisticGeminiQueue;
+        if (!Array.isArray(queue) || queue.length <= 2) return;
+
+        var queueText = joinRealisticPendingPieces(queue);
+        var splitQueue = splitRealisticTextNearMiddle(queueText);
+        if (splitQueue.length > 0 && splitQueue.length <= queue.length) {
+            window._realisticGeminiQueue = splitQueue;
         }
     }
 
@@ -522,7 +517,6 @@
                 window._pendingMusicCommand = '';
                 window._structuredGeminiStreaming = false;
                 window._turnIsStructured = false;
-                window._realisticGeminiChunkCount = 0;
                 window.currentTurnGeminiBubbles = [];
                 window.currentTurnGeminiAttachments = [];
                 // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
@@ -561,7 +555,6 @@
                 window._pendingMusicCommand = '';
             }
 
-            window._realisticGeminiChunkCount = (window._realisticGeminiChunkCount || 0) + 1;
             var incoming = normalizeGeminiText(text);
 
             // 未闭合的音乐指令片段
@@ -612,7 +605,6 @@
             window._realisticGeminiBuffer = '';
             window._realisticGeminiQueue = [];
             window._lastBubbleTime = 0;
-            window._realisticGeminiChunkCount = 0;
 
             var cleanNewText = cleanMusicFromChunk(text);
 

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -134,7 +134,10 @@
 
     // ======================== 句子分割（从 app-chat.js 复刻） ========================
 
-    function splitIntoSentences(buffer) {
+    function splitIntoSentences(buffer, options) {
+        options = options || {};
+        var mode = options.mode || 'normal';
+        var flushTrailingBoundary = !!options.flushTrailingBoundary;
         var sentences = [];
         var s = normalizeGeminiText(buffer);
         var start = 0;
@@ -146,11 +149,13 @@
         function isBoundary(ch, next) {
             if (ch === '\n') return true;
             if (isPunctForBoundary(ch) && next && isPunctForBoundary(next)) return false;
-            if (isPunctForBoundary(ch) && !next) return false;
+            if (isPunctForBoundary(ch) && !next) return flushTrailingBoundary;
             if (ch === '\u3002' || ch === '\uFF01' || ch === '\uFF1F') return true;
+            if (mode === 'coarse') return false;
             if (ch === '!' || ch === '?') return true;
-            if (ch === '\u2026') return true;
+            if (ch === '\u2026') return mode === 'normal';
             if (ch === '.') {
+                if (mode !== 'normal') return false;
                 if (!next) return true;
                 return /\s|\n|["')\]]/.test(next);
             }
@@ -169,6 +174,67 @@
 
         var rest = s.slice(start);
         return { sentences: sentences, rest: rest };
+    }
+
+    function getRealisticSplitMode() {
+        var queueLen = Array.isArray(window._realisticGeminiQueue) ? window._realisticGeminiQueue.length : 0;
+        var chunkCount = window._realisticGeminiChunkCount || 0;
+        if (queueLen >= 8 || chunkCount >= 32) return 'coarse';
+        if (queueLen >= 4 || chunkCount >= 16) return 'balanced';
+        return 'normal';
+    }
+
+    function isFullWidthJoinPunctuation(ch) {
+        return ch === '\u3001' || ch === '\u3002' || ch === '\uFF0C' || ch === '\uFF01' ||
+            ch === '\uFF1F' || ch === '\uFF1B' || ch === '\uFF1A' || ch === '\u2026';
+    }
+
+    function joinRealisticPendingPieces(pieces) {
+        var joined = '';
+        for (var i = 0; i < pieces.length; i++) {
+            var piece = normalizeGeminiText(pieces[i]).replace(/^\s+/, '').replace(/\s+$/, '');
+            if (!piece) continue;
+            if (!joined) {
+                joined = piece;
+                continue;
+            }
+            var prev = joined.replace(/\s+$/, '');
+            var prevLast = prev.charAt(prev.length - 1);
+            var nextFirst = piece.replace(/^\s+/, '').charAt(0);
+            var glue = (isFullWidthJoinPunctuation(prevLast) || isFullWidthJoinPunctuation(nextFirst)) ? '' : ' ';
+            joined = prev + glue + piece;
+        }
+        return joined;
+    }
+
+    function rebalanceRealisticQueueIfNeeded() {
+        var mode = getRealisticSplitMode();
+        if (mode === 'normal') return;
+        var queue = window._realisticGeminiQueue;
+        if (!Array.isArray(queue) || queue.length < 2) return;
+
+        var originalBuffer = typeof window._realisticGeminiBuffer === 'string' ? window._realisticGeminiBuffer : '';
+        var queueText = joinRealisticPendingPieces(queue);
+        if (!queueText) return;
+
+        var pieces = [queueText];
+        if (originalBuffer) pieces.push(originalBuffer);
+        var pendingText = joinRealisticPendingPieces(pieces);
+        var splitResult = splitIntoSentences(pendingText, {
+            mode: mode,
+            flushTrailingBoundary: !originalBuffer
+        });
+
+        if (splitResult.sentences.length === 0) {
+            window._realisticGeminiQueue = [queueText];
+            window._realisticGeminiBuffer = originalBuffer;
+            return;
+        }
+
+        if (splitResult.sentences.length <= queue.length) {
+            window._realisticGeminiQueue = splitResult.sentences;
+            window._realisticGeminiBuffer = splitResult.rest;
+        }
     }
 
     // ======================== 合并模式检测 ========================
@@ -444,6 +510,7 @@
                 window._pendingMusicCommand = '';
                 window._structuredGeminiStreaming = false;
                 window._turnIsStructured = false;
+                window._realisticGeminiChunkCount = 0;
                 window.currentTurnGeminiBubbles = [];
                 window.currentTurnGeminiAttachments = [];
                 // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
@@ -480,8 +547,10 @@
                 window._realisticGeminiQueue = [];
                 window._lastBubbleTime = 0;
                 window._pendingMusicCommand = '';
+                window._realisticGeminiChunkCount = 0;
             }
 
+            window._realisticGeminiChunkCount = (window._realisticGeminiChunkCount || 0) + 1;
             var incoming = normalizeGeminiText(text);
 
             // 未闭合的音乐指令片段
@@ -522,6 +591,7 @@
             if (splitResult.sentences.length > 0) {
                 window._realisticGeminiQueue = window._realisticGeminiQueue || [];
                 window._realisticGeminiQueue.push.apply(window._realisticGeminiQueue, splitResult.sentences);
+                rebalanceRealisticQueueIfNeeded();
                 processRealisticQueue(window._realisticGeminiVersion || 0);
                 createdVisibleBubble = (window.currentTurnGeminiBubbles ? window.currentTurnGeminiBubbles.length : 0) > bubbleCountBefore;
             }
@@ -531,6 +601,7 @@
             window._realisticGeminiBuffer = '';
             window._realisticGeminiQueue = [];
             window._lastBubbleTime = 0;
+            window._realisticGeminiChunkCount = 0;
 
             var cleanNewText = cleanMusicFromChunk(text);
 

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -137,7 +137,7 @@
     function splitIntoSentences(buffer, options) {
         options = options || {};
         var mode = options.mode || 'normal';
-        var flushTrailingBoundary = !!options.flushTrailingBoundary;
+        var flushTrailingBoundary = options.flushTrailingBoundary !== false;
         var sentences = [];
         var s = normalizeGeminiText(buffer);
         var start = 0;
@@ -186,7 +186,12 @@
 
     function isFullWidthJoinPunctuation(ch) {
         return ch === '\u3001' || ch === '\u3002' || ch === '\uFF0C' || ch === '\uFF01' ||
-            ch === '\uFF1F' || ch === '\uFF1B' || ch === '\uFF1A' || ch === '\u2026';
+            ch === '\uFF1F' || ch === '\uFF1B' || ch === '\uFF1A' || ch === '\u2026' ||
+            ch === '\u201D' || ch === '\u2019' || ch === ')' || ch === ']' || ch === '}' ||
+            ch === '\uFF09' || ch === '\uFF3D' || ch === '\uFF5D' ||
+            ch === '\u3009' || ch === '\u300B' || ch === '\u300D' || ch === '\u300F' ||
+            ch === '\u3011' || ch === '\u3015' || ch === '\u3017' || ch === '\u3019' ||
+            ch === '\u301B' || ch === '\u301E' || ch === '\u301F';
     }
 
     function joinRealisticPendingPieces(pieces) {

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -176,11 +176,18 @@
         return { sentences: sentences, rest: rest };
     }
 
+    // Queue thresholds reflect visible backlog pressure; chunk thresholds catch
+    // fast streams before enough queued bubbles accumulate.
+    var BALANCED_QUEUE_THRESHOLD = 4;
+    var BALANCED_CHUNK_THRESHOLD = 16;
+    var COARSE_QUEUE_THRESHOLD = 8;
+    var COARSE_CHUNK_THRESHOLD = 32;
+
     function getRealisticSplitMode() {
         var queueLen = Array.isArray(window._realisticGeminiQueue) ? window._realisticGeminiQueue.length : 0;
         var chunkCount = window._realisticGeminiChunkCount || 0;
-        if (queueLen >= 8 || chunkCount >= 32) return 'coarse';
-        if (queueLen >= 4 || chunkCount >= 16) return 'balanced';
+        if (queueLen >= COARSE_QUEUE_THRESHOLD || chunkCount >= COARSE_CHUNK_THRESHOLD) return 'coarse';
+        if (queueLen >= BALANCED_QUEUE_THRESHOLD || chunkCount >= BALANCED_CHUNK_THRESHOLD) return 'balanced';
         return 'normal';
     }
 
@@ -552,7 +559,6 @@
                 window._realisticGeminiQueue = [];
                 window._lastBubbleTime = 0;
                 window._pendingMusicCommand = '';
-                window._realisticGeminiChunkCount = 0;
             }
 
             window._realisticGeminiChunkCount = (window._realisticGeminiChunkCount || 0) + 1;

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -146,7 +146,7 @@
         function isBoundary(ch, next) {
             if (ch === '\n') return true;
             if (isPunctForBoundary(ch) && next && isPunctForBoundary(next)) return false;
-            if (isPunctForBoundary(ch) && !next) return true;
+            if (isPunctForBoundary(ch) && !next) return false;
             if (ch === '\u3002' || ch === '\uFF01' || ch === '\uFF1F') return true;
             if (ch === '!' || ch === '?') return true;
             if (ch === '\u2026') return true;


### PR DESCRIPTION
## Summary
- Add adaptive split modes for realistic chat queues based on pending queue length and streamed chunk count.
- Rebalance only undisplayed realistic backlog plus the current buffer, preserving already displayed bubbles.
- Use punctuation-aware joining so full-width punctuation stays tight while half-width boundaries get spaces.

## Test plan
- node --check static/app-chat-adapter.js
- IDE lints for static/app-chat-adapter.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复因标点与句片边界判断导致的分句异常与多余空句，提升流式输出的稳定性与连贯性。

* **Performance Improvements**
  * 引入基于标点与空白的实时队列重平衡与拆分策略，减少分割/重组引发的卡顿。
  * 改进全角标点与连接规则处理，新增句子入队后即时重平衡以提高显示一致性与响应速度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->