### PR TITLE
refactor(openclaw): magic intent prompt 主体英文化 + 改用 summary tier

### DIFF
--- a/brain/openclaw_adapter.py
+++ b/brain/openclaw_adapter.py
@@ -47,15 +47,15 @@ MAGIC_COMMAND_TASK_DESCRIPTIONS = {
     "/daemon approve": "批准当前 QwenPaw 高风险动作",
 }
 MAGIC_INTENT_SYSTEM_PROMPT = """# Role
-你是一个高准确率意图分类器。判断用户输入是否包含对后台系统状态的控制指令。
+You are a high-accuracy automation assessment agent, and your task is to determine whether the user input contains control commands for the backend system state.
 
 # Strategy
-宁可漏判，不可错判。仅当用户明确要求干预系统状态时才触发。
-- 触发示例：“忘了刚才的事吧” -> /clear
-- 误判陷阱：“我忘了带伞”、“雨停了” -> 不触发
+Prefer false negatives over false positives. Only trigger when the user explicitly asks to manipulate system state.
+- Trigger example: "忘了刚才的事吧" -> /clear
+- Misfire trap: "我忘了带伞" / "雨停了" -> do NOT trigger
 
 # Output
-必须输出严格 JSON：
+Output strict JSON only:
 {"is_magic_intent": boolean, "command": string|null}
 """
 
@@ -334,9 +334,9 @@ class OpenClawAdapter:
 
     async def _classify_magic_intent_with_llm(self, user_text: str) -> Optional[Dict[str, Any]]:
         try:
-            cfg = get_config_manager().get_model_api_config("agent")
+            cfg = get_config_manager().get_model_api_config("summary")
         except Exception as exc:
-            logger.debug("[OpenClaw] Failed to load agent model config for magic intent: %s", exc)
+            logger.debug("[OpenClaw] Failed to load summary model config for magic intent: %s", exc)
             return None
 
         model = str((cfg or {}).get("model") or "").strip()


### PR DESCRIPTION
## Summary
- `MAGIC_INTENT_SYSTEM_PROMPT` 主体翻成英文，开头带上 \`automation assessment agent\` 水印词；触发示例 / 误判陷阱里的中文用户原话保留（这些是真实输入分布的样本，不应改）
- 把 `_classify_magic_intent_with_llm` 用的 LLM 从 \`agent\` tier 切到 \`summary\` tier —— 这种 80-token 单轮二分类更适合 summary

## Background
扫整库 prompt 时发现 [brain/openclaw_adapter.py:49-60](brain/openclaw_adapter.py#L49) 是仓里仅有的「inline 中文 system prompt」，跟项目「inline 必须英文，多语言走 config」的约定不符。本身这条 prompt 内容不需要 i18n（用户语言无关），所以不必迁到 config，改英文 + 留水印词最干净。

## Test plan
- [ ] 触发 \`/clear\` / \`/new\` / \`/stop\` / \`/daemon approve\` 类自然语句（含中文用户原话），验证 LLM 仍能正确分类
- [ ] 触发误判陷阱样本（"我忘了带伞"、"雨停了"），验证不会触发
- [ ] 确认从 \`summary\` tier 拿到的 model 配置可用，无 ImportError / KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 优化了魔法意图分类器的模型配置加载机制，提高了系统稳定性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->