### PR TITLE
ci(lint): prompt-hygiene + i18n-sync 静态检查

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -13,11 +13,16 @@ permissions:
 
 jobs:
   python-lint:
-    name: Python lint (ruff + async-blocking + no-loguru + no-temperature)
+    name: Python lint (ruff + async-blocking + no-loguru + no-temperature + prompt-hygiene + i18n-sync)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # i18n-sync needs full history to diff against the merge-base of
+          # origin/main. Other lint steps don't care, but fetch-depth: 0 has
+          # negligible cost on this repo.
+          fetch-depth: 0
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -62,3 +67,24 @@ jobs:
         # across memory tasks. See memory/__init__.py and .agent/rules/
         # neko-guide.md for the rationale.
         run: python scripts/check_no_temperature.py
+
+      - name: Enforce prompt-i18n conventions (inline-EN-only + multilang-in-config)
+        # Two rules in one walker:
+        #   - INLINE_PROMPT_NON_EN: any string at an LLM call site or in a
+        #     module-level *PROMPT/*INSTRUCTION/*SYSTEM constant must be
+        #     English-bodied (CJK ratio <30%). Embedded short examples in
+        #     CJK are allowed under the threshold.
+        #   - I18N_NOT_IN_CONFIG: multi-language dicts (≥2 lang keys, must
+        #     include 'en') belong in config/prompts_*.py, not regular code.
+        # Per-line `# noqa: <CODE>` suppression supported. See PR #974 for
+        # the reference incident that motivated this lint.
+        run: python scripts/check_prompt_hygiene.py
+
+      - name: Verify i18n locale files move in lockstep (PR-only)
+        # Diff-based: when ANY static/locales/*.json or
+        # frontend/plugin-manager/src/i18n/locales/*.ts changes, ALL files
+        # in the group must change AND every hunk must occupy the same line
+        # ranges across all languages. Skipped on direct push to main —
+        # there's nothing to diff against.
+        if: github.event_name == 'pull_request'
+        run: python scripts/check_i18n_sync.py --base "origin/${{ github.base_ref }}"

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2792,3 +2792,40 @@ def get_greeting_prompt(gap_seconds: float, lang: str = 'zh') -> str | None:
     else:  # ≥ 24h
         table = GREETING_PROMPT_VERY_LONG
     return table.get(lang_key, table.get('en', table['zh']))
+
+
+# ── 节日 / 周末提示模板 ─────────────────────────────────────────────
+# Consumed by utils.holiday_cache for proactive holiday/weekend hint
+# injection. Templates carry {name} (holiday name) and optionally {days}.
+
+HOLIDAY_HINT_TODAY: dict[str, str] = {
+    'zh': '今天是{name}！这是一个特别的日子。',
+    'en': 'Today is {name}! It is a special day.',
+    'ja': '今日は{name}だ！特別な日だね。',
+    'ko': '오늘은 {name}이다! 특별한 날이야.',
+    'ru': 'Сегодня {name}! Это особенный день.',
+}
+
+HOLIDAY_HINT_SOON: dict[str, str] = {
+    'zh': '再过{days}天就是{name}假期了，可以期待一下。',
+    'en': 'The {name} holiday is coming in {days} days — something to look forward to.',
+    'ja': 'あと{days}日で{name}の休日だ。楽しみだね。',
+    'ko': '{days}일 후면 {name} 연휴다. 기대되네.',
+    'ru': 'Через {days} дней начнутся праздники {name} — есть чего ждать.',
+}
+
+HOLIDAY_HINT_WEEK: dict[str, str] = {
+    'zh': '这周就是{name}假期了哦。',
+    'en': 'The {name} holiday is coming up this week.',
+    'ja': '今週は{name}の休日がやってくるよ。',
+    'ko': '이번 주에 {name} 연휴가 다가오고 있어.',
+    'ru': 'На этой неделе начнутся праздники {name}.',
+}
+
+WEEKEND_HINT: dict[str, str] = {
+    'zh': '今天是周末，好好放松吧。',
+    'en': 'It is the weekend — time to relax.',
+    'ja': '今日は週末だ。ゆっくり過ごしてね。',
+    'ko': '오늘은 주말이다. 푹 쉬어.',
+    'ru': 'Сегодня выходной — время отдохнуть.',
+}

--- a/scripts/check_i18n_sync.py
+++ b/scripts/check_i18n_sync.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""PR-only check: frontend i18n locale files must be modified in lockstep.
+
+Two groups, one rule each. Diff is computed against the merge-base of HEAD
+and the base ref (default ``origin/main``). On a regular ``main`` push or
+when nothing in the watched folders changed, this script is a no-op.
+
+Group 1 — static/locales/*.json
+   When ANY file in static/locales/ changes, ALL 8 language files must
+   change AND every hunk header (``@@ -OLD,COUNT +NEW,COUNT @@``) must
+   match across all 8. The locale JSONs are line-aligned by convention
+   (the same key sits on the same line across languages); strict alignment
+   catches "added a key in zh-CN but forgot the others" at the diff stage.
+
+Group 2 — frontend/plugin-manager/src/i18n/locales/*.ts
+   Same rule but for plugin-manager TS locales. ``yuiGuide.ts`` is
+   excluded from the group because it's a domain-scoped guide that
+   intentionally ships single-language only.
+
+Suppression
+-----------
+None at the line level. If a structural reorganisation legitimately needs
+to break alignment, edit the script's GROUPS definition in the same PR
+and explain in the description.
+
+Output
+------
+Each violation prints a short line. Exit 1 on any, 0 otherwise.
+
+Usage:
+    python scripts/check_i18n_sync.py [--base origin/main]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+GROUPS: list[dict[str, object]] = [
+    {
+        "name": "static/locales",
+        "dir": "static/locales",
+        "files": [
+            "en.json", "es.json", "ja.json", "ko.json",
+            "pt.json", "ru.json", "zh-CN.json", "zh-TW.json",
+        ],
+    },
+    {
+        "name": "plugin-manager i18n locales",
+        "dir": "frontend/plugin-manager/src/i18n/locales",
+        "files": [
+            "en-US.ts", "es.ts", "ja.ts", "ko.ts",
+            "pt.ts", "ru.ts", "zh-CN.ts", "zh-TW.ts",
+        ],
+        # yuiGuide.ts intentionally excluded — domain-scoped single-language guide.
+    },
+]
+
+
+def _git(*args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True, text=True, check=False,
+    )
+    if check and result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        sys.exit(2)
+    return result.stdout
+
+
+def _changed_files(base: str) -> set[str]:
+    """Files changed in HEAD relative to merge-base with `base`. Posix-style."""
+    out = _git("diff", "--name-only", f"{base}...HEAD")
+    return {ln.strip().replace("\\", "/") for ln in out.splitlines() if ln.strip()}
+
+
+_HUNK_HEADER_RE = re.compile(
+    r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@"
+)
+
+
+def _parse_hunks(diff_text: str) -> list[tuple[int, int, int, int]]:
+    """Parse a unified diff. Returns list of (old_start, old_count, new_start, new_count).
+
+    Implicit count is ``1`` per the unified-diff spec (matching ``git diff``)."""
+    out: list[tuple[int, int, int, int]] = []
+    for line in diff_text.splitlines():
+        m = _HUNK_HEADER_RE.match(line)
+        if m:
+            os_, oc, ns, nc = m.groups()
+            out.append((
+                int(os_),
+                int(oc) if oc is not None else 1,
+                int(ns),
+                int(nc) if nc is not None else 1,
+            ))
+    return out
+
+
+def _file_diff(base: str, path: str) -> str:
+    return _git("diff", "--unified=0", f"{base}...HEAD", "--", path)
+
+
+def _check_group(group: dict, base: str, changed: set[str]) -> list[str]:
+    errors: list[str] = []
+    dir_prefix = str(group["dir"]).rstrip("/") + "/"
+    files: list[str] = list(group["files"])  # type: ignore[assignment]
+    files_in_group = [dir_prefix + name for name in files]
+    touched = [f for f in files_in_group if f in changed]
+
+    if not touched:
+        return errors  # nothing in the group changed → quiet
+
+    missing = [f for f in files_in_group if f not in touched]
+    if missing:
+        errors.append(
+            f"[{group['name']}] modified {len(touched)}/{len(files_in_group)} "
+            f"locale file(s); missing changes in: {', '.join(missing)}. "
+            f"All locales in the group must be edited together."
+        )
+        return errors  # alignment check is meaningless when files are missing
+
+    hunks_by_file: dict[str, list[tuple[int, int, int, int]]] = {}
+    for f in files_in_group:
+        diff = _file_diff(base, f)
+        hunks_by_file[f] = sorted(_parse_hunks(diff))
+
+    ref_file = files_in_group[0]
+    ref_hunks = hunks_by_file[ref_file]
+    for f in files_in_group[1:]:
+        if hunks_by_file[f] != ref_hunks:
+            errors.append(
+                f"[{group['name']}] hunk ranges in {f} differ from "
+                f"{ref_file}; locale changes must touch the same line "
+                f"ranges across all languages.\n"
+                f"  reference ({ref_file}): {ref_hunks}\n"
+                f"  this file ({f}): {hunks_by_file[f]}"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify all locale files in a group change in lockstep "
+                    "(same set of hunk ranges, no language left behind).",
+    )
+    parser.add_argument(
+        "--base",
+        default=os.environ.get("I18N_SYNC_BASE", "origin/main"),
+        help="Base ref to diff against (default: origin/main, "
+             "override via $I18N_SYNC_BASE).",
+    )
+    args = parser.parse_args(argv)
+
+    # If base ref doesn't exist, the whole check is moot — skip with a warning.
+    rev_check = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", args.base],
+        cwd=REPO_ROOT,
+        capture_output=True, text=True, check=False,
+    )
+    if rev_check.returncode != 0:
+        print(
+            f"i18n-sync: base ref `{args.base}` not found; skipping. "
+            f"(Set $I18N_SYNC_BASE or pass --base to override.)",
+            file=sys.stderr,
+        )
+        return 0
+
+    changed = _changed_files(args.base)
+    all_errors: list[str] = []
+    for group in GROUPS:
+        all_errors.extend(_check_group(group, args.base, changed))
+
+    if all_errors:
+        for e in all_errors:
+            print(e)
+        print(
+            f"\n{len(all_errors)} i18n-sync violation(s) found.\n"
+            "Locale files within each group must move together — same set of "
+            "line ranges modified across all languages.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_prompt_hygiene.py
+++ b/scripts/check_prompt_hygiene.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Static check: enforce prompt-internationalisation conventions.
+
+Two rules in one walker:
+
+INLINE_PROMPT_NON_EN
+   Any string passed to an LLM call site (``ainvoke`` / ``create`` /
+   ``update_session`` / ``connect(instructions=)`` / etc.) and any
+   module-level constant whose name (case-insensitive) contains
+   ``prompt`` / ``instruction`` / ``system_`` MUST be English-bodied.
+   The trigger is CJK character ratio (CJK Unified + Kana + Hangul) above
+   30% over non-whitespace characters. The threshold leaves room for short
+   embedded examples (real Chinese user phrases inside an otherwise-English
+   prompt — see PR #974 for the reference fix).
+
+I18N_NOT_IN_CONFIG
+   Any dict literal whose keys form a multi-language map — at least two of
+   ``{'zh', 'en', 'ja', 'ko', 'ru', 'zh-CN', 'zh-TW', 'es', 'pt'}`` AND
+   including ``'en'`` — belongs in ``config/prompts_*.py``. Such dicts
+   anywhere else are flagged.
+
+The project's i18n convention:
+   - Inline prompts at the call site MUST be English-only.
+   - Multi-language prompts MUST live in ``config/prompts_*.py``, served
+     via ``_loc(MULTILANG_DICT, language_code)`` or
+     ``get_xxx_prompt(lang)``.
+
+Suppression
+-----------
+Append ``# noqa: INLINE_PROMPT_NON_EN`` or ``# noqa: I18N_NOT_IN_CONFIG``
+to any line spanned by the offending node (start line through end line —
+useful for triple-quoted strings where the start line ends with ``\"\"\"``).
+Bare ``# noqa`` matches any code in this script. Use sparingly — these
+rules exist for good reason.
+
+Output
+------
+Every violation prints as ``path:line:col  CODE  message``. Exit 1 on any
+violation, 0 otherwise.
+
+Usage:
+    python scripts/check_prompt_hygiene.py [paths...]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_PATHS: list[str] = ["."]
+
+# Directories never scanned. config/, plugin/, templates/, static/ are by
+# project convention out of scope: config holds the legit multi-lang
+# prompts; plugin payloads are third-party; templates/static don't have
+# Python LLM call sites. tests/ is excluded because test fixtures
+# intentionally use multi-lang strings to exercise the i18n pipeline.
+# frontend/ is TS, not Python.
+EXCLUDE_DIRS = {
+    ".venv", "venv",
+    ".git", "__pycache__", ".tox", ".mypy_cache", ".ruff_cache", ".pytest_cache",
+    "dist", "build", "node_modules",
+    "frontend", "static", "templates",
+    "config", "plugin", "tests",
+    "local_server",  # subprocess-spawned TTS / telemetry servers — no LLM call sites
+}
+
+# This script defines the language-code set as part of its rules, which
+# makes it look like an i18n dict to itself. Skip it.
+EXCLUDE_FILES = {
+    "scripts/check_prompt_hygiene.py",
+}
+
+# CJK ratio threshold. Strings above this are considered "non-English-bodied".
+# 30% gives room for inlined real-language examples inside an otherwise-
+# English prompt. Tweaking down is safe; tweaking up is risky.
+CJK_THRESHOLD = 0.30
+
+# Language codes recognised as i18n keys. Union of codes used by
+# config/prompts_*.py (zh / zh-CN / zh-TW / en / ja / ko / ru) plus es/pt
+# (used by static/locales).
+LANG_CODES = {"zh", "zh-CN", "zh-TW", "en", "ja", "ko", "ru", "es", "pt"}
+REQUIRED_LANG_KEY = "en"
+MIN_LANG_KEYS = 2
+
+# Variable / constant name regex. Case-insensitive substring match.
+# False-positives at the name level are filtered by CJK_THRESHOLD on value.
+PROMPT_NAME_RE = re.compile(r"prompt|instruction|system_", re.IGNORECASE)
+
+# Method names whose call argument trees we inspect for inline prompts.
+# Match the last component of an Attribute (``foo.ainvoke``) or a Name
+# (``ainvoke``). Includes LangChain (.ainvoke / .invoke / .astream / .stream),
+# OpenAI (.chat.completions.create), Anthropic (.messages.create),
+# OmniRealtimeClient (.update_session / .connect / .prime_context /
+# .prompt_ephemeral), and Gemini (.generate_content / .generate).
+LLM_METHOD_NAMES = {
+    "ainvoke", "invoke", "astream", "stream",
+    "create",
+    "update_session",
+    "prime_context",
+    "prompt_ephemeral",
+    "connect",
+    "generate", "generate_content",
+}
+
+# Keys whose values count as prompt content inside dict-literal messages
+# like ``{"role": "system", "content": "..."}``.
+PROMPT_FIELD_KEYS = {
+    "content", "instructions", "system",
+    "system_prompt", "system_instruction",
+}
+
+# Same set, used for kwargs (``ainvoke(..., system="...")``).
+PROMPT_KWARGS = PROMPT_FIELD_KEYS
+
+# LangChain message wrapper class names. ``SystemMessage(content=...)``
+# and friends are unwrapped to their content arg.
+LC_MESSAGE_NAMES = {"SystemMessage", "HumanMessage", "AIMessage", "ChatMessage"}
+
+# CJK ranges: CJK Unified, Hiragana, Katakana, Hangul Syllables.
+CJK_RANGES = (
+    ("一", "鿿"),
+    ("぀", "ゟ"),
+    ("゠", "ヿ"),
+    ("가", "힣"),
+)
+
+CODE_INLINE = "INLINE_PROMPT_NON_EN"
+CODE_I18N = "I18N_NOT_IN_CONFIG"
+
+
+def _has_non_ascii(s: str) -> bool:
+    """True if `s` contains any character outside ASCII (codepoint > 127).
+    Used to distinguish genuine i18n content (translated prose with CJK,
+    Cyrillic, accented Latin) from code-mapping dicts whose values are
+    pure-ASCII identifiers like 'cmn-CN' or 'Chinese'."""
+    return any(ord(ch) > 127 for ch in s)
+
+
+def _cjk_ratio(s: str) -> float:
+    """Fraction of non-whitespace chars that are CJK (Unified, Kana, Hangul)."""
+    cjk = 0
+    total = 0
+    for ch in s:
+        if ch.isspace():
+            continue
+        total += 1
+        for lo, hi in CJK_RANGES:
+            if lo <= ch <= hi:
+                cjk += 1
+                break
+    return cjk / total if total else 0.0
+
+
+def _has_noqa(line: str, code: str) -> bool:
+    """True if `line` contains `# noqa` (bare) or `# noqa: ...,CODE,...`.
+
+    Tolerates a trailing explanatory comment after the noqa, e.g.
+    ``# noqa: CODE  # rationale``. The codes block stops at the next
+    ``#`` or end-of-line — matching ruff/flake8 behaviour."""
+    m = re.search(r"#\s*noqa\b(?:\s*:\s*([A-Za-z0-9_,\s]+?))?(?=#|$)", line)
+    if not m:
+        return False
+    raw = m.group(1)
+    if raw is None or not raw.strip():
+        return True
+    codes = {c.strip() for c in raw.split(",") if c.strip()}
+    return code in codes
+
+
+def _string_value(node: ast.AST | None) -> str | None:
+    """Return the literal string content of a Constant or JoinedStr (f-string).
+    None if the node is not string-shaped. For f-strings, only LITERAL
+    constant segments contribute — interpolated expressions are skipped."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for v in node.values:
+            if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                parts.append(v.value)
+        return "".join(parts)
+    return None
+
+
+def _const_str(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _call_method_name(call: ast.Call) -> str | None:
+    f = call.func
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    if isinstance(f, ast.Name):
+        return f.id
+    return None
+
+
+class PromptHygieneChecker(ast.NodeVisitor):
+    def __init__(self, path: Path, source_lines: list[str]) -> None:
+        self.path = path
+        self.source_lines = source_lines
+        self.violations: list[tuple[int, int, str, str]] = []
+
+    # Module-scope first: rule (b) module-level prompt-named constants.
+    def visit_Module(self, node: ast.Module) -> None:
+        for stmt in node.body:
+            self._check_module_assign(stmt)
+        self.generic_visit(node)
+
+    def _check_module_assign(self, stmt: ast.AST) -> None:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                self._maybe_check_named(target, stmt.value)
+        elif isinstance(stmt, ast.AnnAssign):
+            if stmt.value is not None:
+                self._maybe_check_named(stmt.target, stmt.value)
+
+    def _maybe_check_named(self, target: ast.AST, value: ast.AST) -> None:
+        if not isinstance(target, ast.Name):
+            return
+        if not PROMPT_NAME_RE.search(target.id):
+            return
+        s = _string_value(value)
+        if s is None:
+            return
+        self._flag_inline(value, s, source=f"const {target.id}")
+
+    # Rule (a): LLM call argument analysis.
+    def visit_Call(self, node: ast.Call) -> None:
+        method = _call_method_name(node)
+        if method in LLM_METHOD_NAMES:
+            for arg in node.args:
+                self._scan_prompt_args(arg)
+            for kw in node.keywords:
+                if kw.arg in PROMPT_KWARGS:
+                    s = _string_value(kw.value)
+                    if s is not None:
+                        self._flag_inline(kw.value, s, source=f"kwarg {kw.arg}=")
+                elif kw.arg == "messages":
+                    self._scan_prompt_args(kw.value)
+        self.generic_visit(node)
+
+    def _scan_prompt_args(self, node: ast.AST) -> None:
+        # List/tuple of messages → recurse.
+        if isinstance(node, (ast.List, ast.Tuple)):
+            for el in node.elts:
+                self._scan_prompt_args(el)
+            return
+        # Dict literal {"role": ..., "content": "..."}.
+        if isinstance(node, ast.Dict):
+            for k, v in zip(node.keys, node.values):
+                kname = _const_str(k)
+                if kname in PROMPT_FIELD_KEYS:
+                    s = _string_value(v)
+                    if s is not None:
+                        self._flag_inline(v, s, source=f'dict["{kname}"]')
+            return
+        # SystemMessage(content="...") / HumanMessage("...").
+        if isinstance(node, ast.Call):
+            method = _call_method_name(node)
+            if method in LC_MESSAGE_NAMES:
+                if node.args:
+                    s = _string_value(node.args[0])
+                    if s is not None:
+                        self._flag_inline(node.args[0], s, source=f"{method}()")
+                for kw in node.keywords:
+                    if kw.arg == "content":
+                        s = _string_value(kw.value)
+                        if s is not None:
+                            self._flag_inline(
+                                kw.value, s, source=f"{method}(content=)"
+                            )
+            return
+        # Bare string at top level (e.g. ainvoke("..."), prime_context(text)).
+        if isinstance(node, (ast.Constant, ast.JoinedStr)):
+            s = _string_value(node)
+            if s is not None:
+                self._flag_inline(node, s, source="positional arg")
+
+    # Rule i18n: dict literal that looks like a language map.
+    def visit_Dict(self, node: ast.Dict) -> None:
+        keys: list[str | None] = [_const_str(k) for k in node.keys]
+        if any(k is None for k in keys):
+            self.generic_visit(node)
+            return
+        keys_set: set[str] = {k for k in keys if k is not None}
+        lang_keys = keys_set & LANG_CODES
+        if len(lang_keys) >= MIN_LANG_KEYS and REQUIRED_LANG_KEY in lang_keys:
+            values = [_string_value(v) for v in node.values]
+            if all(v is not None for v in values):
+                # Filter out code-mapping dicts (lang -> short ASCII code/name
+                # like 'zh' -> 'cmn-CN' or 'zh' -> 'Chinese'). Genuine i18n
+                # content has at least one non-ASCII value somewhere — Chinese
+                # / Japanese / Korean / Cyrillic prose translations.
+                if any(_has_non_ascii(v) for v in values if v is not None):
+                    self._flag_i18n(node, sorted(lang_keys))
+        self.generic_visit(node)
+
+    # ---- helpers ----
+
+    def _flag_inline(self, node: ast.AST, s: str, source: str) -> None:
+        ratio = _cjk_ratio(s)
+        if ratio < CJK_THRESHOLD:
+            return
+        if self._is_noqa(node, CODE_INLINE):
+            return
+        lineno = getattr(node, "lineno", 0) or 0
+        col = (getattr(node, "col_offset", 0) or 0) + 1
+        msg = (
+            f"inline prompt at {source} has {ratio:.0%} CJK characters "
+            f"(threshold {int(CJK_THRESHOLD * 100)}%); rewrite the body in English "
+            f"or move the multi-language version into config/prompts_*.py."
+        )
+        self.violations.append((lineno, col, CODE_INLINE, msg))
+
+    def _flag_i18n(self, node: ast.Dict, lang_keys: list[str]) -> None:
+        if self._is_noqa(node, CODE_I18N):
+            return
+        lineno = getattr(node, "lineno", 0) or 0
+        col = (getattr(node, "col_offset", 0) or 0) + 1
+        msg = (
+            f"multi-language dict (keys: {', '.join(lang_keys)}) belongs in "
+            f"config/prompts_*.py, not in regular code. Convention: import the "
+            f"dict from config.prompts_xxx and resolve via _loc(DICT, lang)."
+        )
+        self.violations.append((lineno, col, CODE_I18N, msg))
+
+    def _is_noqa(self, node: ast.AST, code: str) -> bool:
+        start = getattr(node, "lineno", 0) or 0
+        end = getattr(node, "end_lineno", start) or start
+        if start <= 0:
+            return False
+        last = min(end, len(self.source_lines))
+        for ln in range(start, last + 1):
+            if _has_noqa(self.source_lines[ln - 1], code):
+                return True
+        return False
+
+
+def _is_excluded(path: Path) -> bool:
+    parts = set(path.parts)
+    if parts & EXCLUDE_DIRS:
+        return True
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in EXCLUDE_FILES:
+        return True
+    for ex in EXCLUDE_DIRS:
+        if "/" in ex and (rel == ex or rel.startswith(ex + "/")):
+            return True
+    return False
+
+
+def _iter_python_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if p.is_file():
+            if p.suffix == ".py" and not _is_excluded(p):
+                yield p
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.py")):
+                if not _is_excluded(f):
+                    yield f
+
+
+def _parse_file(path: Path) -> tuple[ast.Module | None, list[str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped — {e}", file=sys.stderr)
+        return None, []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        print(f"{path}:{e.lineno}: syntax error — {e.msg}", file=sys.stderr)
+        return None, []
+    return tree, source.splitlines()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Enforce prompt-i18n conventions: inline prompts must be English; "
+            "multi-language dicts must live in config/prompts_*.py."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files/directories to scan (default: entire repo, minus EXCLUDE_DIRS).",
+    )
+    args = parser.parse_args(argv)
+
+    raw_paths = args.paths or DEFAULT_PATHS
+    targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
+
+    total = 0
+    for file in _iter_python_files(targets):
+        tree, lines = _parse_file(file)
+        if tree is None:
+            continue
+        checker = PromptHygieneChecker(file, lines)
+        checker.visit(tree)
+        for lineno, col, code, msg in checker.violations:
+            try:
+                rel = file.relative_to(REPO_ROOT)
+            except ValueError:
+                rel = file
+            print(f"{rel}:{lineno}:{col}  {code}  {msg}")
+            total += 1
+
+    if total:
+        print(
+            f"\n{total} prompt-hygiene violation(s) found.\n"
+            "Inline LLM prompts MUST be English-only. Multi-language prompts MUST "
+            "live in config/prompts_*.py. To override a single line, append "
+            "`# noqa: INLINE_PROMPT_NON_EN` or `# noqa: I18N_NOT_IN_CONFIG`.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/holiday_cache.py
+++ b/utils/holiday_cache.py
@@ -33,6 +33,13 @@ from typing import TypedDict
 
 import httpx
 
+from config.prompts_proactive import (
+    HOLIDAY_HINT_TODAY,
+    HOLIDAY_HINT_SOON,
+    HOLIDAY_HINT_WEEK,
+    WEEKEND_HINT,
+)
+
 logger = logging.getLogger(__name__)
 
 # ── language → country code mapping ──────────────────────────────────
@@ -105,12 +112,15 @@ _FETCH_TIMEOUT = 10.0
 
 # ── 全局补充节日（所有国家共享，固定日期，API 可能不含） ──────────
 # 格式: (month, day, localName_dict)
+# Holiday display names below are *data*, not LLM prompts — they're returned
+# as HolidayEntry.localName for display. The dict-shape happens to match the
+# i18n-leak detector but the project convention exempts pure localized data.
 _GLOBAL_EXTRA_HOLIDAYS: list[tuple[int, int, dict[str, str]]] = [
-    (2, 14, {
+    (2, 14, {  # noqa: I18N_NOT_IN_CONFIG  # holiday display data, not LLM prompt
         'zh': '情人节', 'en': "Valentine's Day", 'ja': 'バレンタインデー',
         'ko': '발렌타인데이', 'ru': 'День святого Валентина',
     }),
-    (12, 25, {
+    (12, 25, {  # noqa: I18N_NOT_IN_CONFIG  # holiday display data, not LLM prompt
         'zh': '圣诞节', 'en': 'Christmas', 'ja': 'クリスマス',
         'ko': '크리스마스', 'ru': 'Рождество',
     }),
@@ -540,37 +550,8 @@ except Exception:
 #  High-level hint builder
 # =====================================================================
 
-_HOLIDAY_HINT_TODAY: dict[str, str] = {
-    'zh': '今天是{name}！这是一个特别的日子。',
-    'en': 'Today is {name}! It is a special day.',
-    'ja': '今日は{name}だ！特別な日だね。',
-    'ko': '오늘은 {name}이다! 특별한 날이야.',
-    'ru': 'Сегодня {name}! Это особенный день.',
-}
-
-_HOLIDAY_HINT_SOON: dict[str, str] = {
-    'zh': '再过{days}天就是{name}假期了，可以期待一下。',
-    'en': 'The {name} holiday is coming in {days} days — something to look forward to.',
-    'ja': 'あと{days}日で{name}の休日だ。楽しみだね。',
-    'ko': '{days}일 후면 {name} 연휴다. 기대되네.',
-    'ru': 'Через {days} дней начнутся праздники {name} — есть чего ждать.',
-}
-
-_HOLIDAY_HINT_WEEK: dict[str, str] = {
-    'zh': '这周就是{name}假期了哦。',
-    'en': 'The {name} holiday is coming up this week.',
-    'ja': '今週は{name}の休日がやってくるよ。',
-    'ko': '이번 주에 {name} 연휴가 다가오고 있어.',
-    'ru': 'На этой неделе начнутся праздники {name}.',
-}
-
-_WEEKEND_HINT: dict[str, str] = {
-    'zh': '今天是周末，好好放松吧。',
-    'en': 'It is the weekend — time to relax.',
-    'ja': '今日は週末だ。ゆっくり過ごしてね。',
-    'ko': '오늘은 주말이다. 푹 쉬어.',
-    'ru': 'Сегодня выходной — время отдохнуть.',
-}
+# Templates HOLIDAY_HINT_{TODAY,SOON,WEEK} and WEEKEND_HINT are imported
+# from config.prompts_proactive — see top of file.
 
 
 async def get_holiday_or_weekend_hint(lang: str, character: str) -> str | None:
@@ -590,23 +571,23 @@ async def get_holiday_or_weekend_hint(lang: str, character: str) -> str | None:
             return None
 
         name = proximity.period.display_name
-        lang_key = lang if lang in _HOLIDAY_HINT_TODAY else 'en'
+        lang_key = lang if lang in HOLIDAY_HINT_TODAY else 'en'
 
         if proximity.is_today:
-            tpl = _HOLIDAY_HINT_TODAY.get(lang_key, _HOLIDAY_HINT_TODAY['en'])
+            tpl = HOLIDAY_HINT_TODAY.get(lang_key, HOLIDAY_HINT_TODAY['en'])
             return tpl.format(name=name)
         elif proximity.days_away <= 3:
-            tpl = _HOLIDAY_HINT_SOON.get(lang_key, _HOLIDAY_HINT_SOON['en'])
+            tpl = HOLIDAY_HINT_SOON.get(lang_key, HOLIDAY_HINT_SOON['en'])
             return tpl.format(name=name, days=proximity.days_away)
         else:
-            tpl = _HOLIDAY_HINT_WEEK.get(lang_key, _HOLIDAY_HINT_WEEK['en'])
+            tpl = HOLIDAY_HINT_WEEK.get(lang_key, HOLIDAY_HINT_WEEK['en'])
             return tpl.format(name=name)
 
     # No holiday → check weekend
     if datetime.now().weekday() >= 5:
         if not try_consume_weekend(character):
             return None
-        return _WEEKEND_HINT.get(lang, _WEEKEND_HINT.get('en', ''))
+        return WEEKEND_HINT.get(lang, WEEKEND_HINT.get('en', ''))
 
     return None
 
@@ -644,15 +625,15 @@ def _has_weekend_budget(character: str) -> bool:
 def _build_holiday_hint_text(lang: str, proximity: HolidayProximity) -> str:
     """Build hint text from a proximity object (no side effects)."""
     name = proximity.period.display_name
-    lang_key = lang if lang in _HOLIDAY_HINT_TODAY else 'en'
+    lang_key = lang if lang in HOLIDAY_HINT_TODAY else 'en'
     if proximity.is_today:
-        tpl = _HOLIDAY_HINT_TODAY.get(lang_key, _HOLIDAY_HINT_TODAY['en'])
+        tpl = HOLIDAY_HINT_TODAY.get(lang_key, HOLIDAY_HINT_TODAY['en'])
         return tpl.format(name=name)
     elif proximity.days_away <= 3:
-        tpl = _HOLIDAY_HINT_SOON.get(lang_key, _HOLIDAY_HINT_SOON['en'])
+        tpl = HOLIDAY_HINT_SOON.get(lang_key, HOLIDAY_HINT_SOON['en'])
         return tpl.format(name=name, days=proximity.days_away)
     else:
-        tpl = _HOLIDAY_HINT_WEEK.get(lang_key, _HOLIDAY_HINT_WEEK['en'])
+        tpl = HOLIDAY_HINT_WEEK.get(lang_key, HOLIDAY_HINT_WEEK['en'])
         return tpl.format(name=name)
 
 
@@ -678,7 +659,7 @@ async def preview_holiday_or_weekend_hint(
     if datetime.now().weekday() >= 5:
         if not _has_weekend_budget(character):
             return None, None
-        text = _WEEKEND_HINT.get(lang, _WEEKEND_HINT.get('en', ''))
+        text = WEEKEND_HINT.get(lang, WEEKEND_HINT.get('en', ''))
         return text, ("weekend",)
 
     return None, None


### PR DESCRIPTION
## Summary
- 加两个 lint 脚本，挂到 [analyze.yml](.github/workflows/analyze.yml) 的同一个 job 里，PR 自动跑：
  - **`scripts/check_prompt_hygiene.py`** — Python AST walker，两条规则合并：
    - `INLINE_PROMPT_NON_EN`：LLM 调用实参 / 模块级 `*PROMPT/*INSTRUCTION/*SYSTEM` 命名常量里的字符串字面量，CJK 占比 ≥30% 即报错（threshold 给真实中文示例留口子，参考 [PR #974](https://github.com/Project-N-E-K-O/N.E.K.O/pull/974) 的修复场景）
    - `I18N_NOT_IN_CONFIG`：多语言 dict（≥2 个语言键且必含 `'en'`、至少一个值带非 ASCII 字符）必须搬到 `config/prompts_*.py`
    - 行内 `# noqa: <CODE>` 豁免，兼容尾随注释（`# noqa: CODE  # 解释`）
  - **`scripts/check_i18n_sync.py`** — git diff-based PR-only：
    - `static/locales/*.json` 8 个语言必须同步改、每条 hunk 行号范围在所有文件上必须完全一致
    - `frontend/plugin-manager/src/i18n/locales/*.ts` 同理，排除 `yuiGuide.ts`
    - base ref 默认 `origin/main`，不存在时优雅退化为 no-op

- 顺便修跑 lint 暴露的现存违规：
  - `utils/holiday_cache.py` 里 4 个 `_HOLIDAY_HINT_TODAY/SOON/WEEK` + `_WEEKEND_HINT` 搬到 `config/prompts_proactive.py`（保留原 5 lang `zh/en/ja/ko/ru`，es/pt 后续单独补）
  - 同文件 `_GLOBAL_EXTRA_HOLIDAYS` 里 2 个节日显示名 dict 加 `# noqa: I18N_NOT_IN_CONFIG  # holiday display data, not LLM prompt`

## Background
[PR #974](https://github.com/Project-N-E-K-O/N.E.K.O/pull/974) 修了 inline 中文 prompt（违反"inline 必须英文 / 多语言走 config"约定）后，加这条 lint 防止下次再出现。`I18N_NOT_IN_CONFIG` 不只针对 prompt，也对所有外溢的多语言 dict 起拦截作用。

## Test plan
- [x] `python scripts/check_prompt_hygiene.py` exit 0 in 当前分支
- [x] `python scripts/check_i18n_sync.py --base origin/main` exit 0 in 当前分支
- [x] 手动验证 i18n-sync 三个场景：8 个文件全改且行号对齐 → pass；只改 1 个文件 → fail；8 个全改但行号错位 → fail
- [x] 验证 noqa 兼容尾随注释格式（`# noqa: CODE  # 解释`）
- [x] `import utils.holiday_cache` 烟雾测试，新 import 不引入循环依赖
- [ ] CI 跑通

## 阈值 / 设计决策
- CJK 30% threshold：太低误报，太高漏报。30% 让 `MAGIC_INTENT_SYSTEM_PROMPT`（修复后 ~6%）这种合规、`_HOLIDAY_HINT_TODAY`（zh 100%）这种非合规清晰区分
- I18n dict 必含 `en`：过滤掉 `_LANG_TO_COUNTRY`（`zh→CN, en→US...`）这种 lang-only 映射的误报
- I18n dict 至少一个值非 ASCII：进一步过滤 `_TTS_LANGUAGE_CODE_MAP`（`zh→cmn-CN`）这种 code-mapping
- 排除 `tests/` `local_server/`：测试 fixture 和 TTS 子进程脚本不在约定范围

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新增功能**
  * 添加多语言假期和周末提示功能，支持多种语言本地化。

* **改进**
  * 增强国际化内容的质量检查和同步验证机制，确保多语言支持的一致性和准确性。
  * 优化假期提示模板管理，提升多语言本地化体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->