### PR TITLE
refactor(memory): IdleMaint 调度清理 + LLM timeout 兜底 + review snapshot 重设计开 thinking

### DIFF
--- a/.agent/rules/neko-guide.md
+++ b/.agent/rules/neko-guide.md
@@ -13,7 +13,7 @@ trigger: always_on
 - **辅助 LLM 调用约定（memory/ + utils/）**：
   - **不下发 `temperature`**：所有 `utils.llm_client.create_chat_llm` / `ChatOpenAI` 及其包装 helper 一律不传 `temperature=...`，默认 `None` 表示"不写进请求体"。理由：(1) 兼容 o1/o3/gpt-5-thinking/Claude extended-thinking；(2) 各 task 自定温度会引入难复现的回归。守门：`scripts/check_no_temperature.py`（CI 见 `.github/workflows/analyze.yml`）。
   - **模型从 tier 拿，不 hardcoded fallback**：每个 LLM 调用都通过 `config_manager.get_model_api_config(<tier>)` 拿 model/base_url/api_key 三件套。不要再写 `api_config.get('model', SETTING_PROPOSER_MODEL)` 这类 fallback——`SETTING_PROPOSER_MODEL` / `SETTING_VERIFIER_MODEL` 已于 2026-04 退环境。tier 未配好时让 API 直接拒绝，比静默回退到 qwen-max 更安全。
-  - **memory 子模块按职责选 tier**：fact extraction / signal detection / reflection / promotion merge / fact dedup / recall rerank 走 `summary`；recent.review + persona.correction 走 `correction`。不要为单点新增 hardcoded 模型名。
+  - **memory 子模块按职责选 tier**：fact extraction / signal detection / reflection synthesis / fact dedup / recall rerank 走 `summary`；recent.review + persona.correction + promotion merge 走 `correction`。不要为单点新增 hardcoded 模型名。
 
 ## 代码风格
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -862,7 +862,7 @@ REFLECTION_SYNTHESIS_CONTEXT_ABSORBED_DAYS = 14    # 且在 N 天内
 # Gate 3: LLM tier 选型（候选见 RFC §6.5 Gate 3 表）
 # "summary" = qwen-plus 级；"correction" = qwen-max 级；"emotion" = qwen-flash 级
 EVIDENCE_EXTRACT_FACTS_MODEL_TIER = "summary"       # Stage-1 抽 fact
-EVIDENCE_DETECT_SIGNALS_MODEL_TIER = "correction"   # Stage-2 判 signal 映射
+EVIDENCE_DETECT_SIGNALS_MODEL_TIER = "summary"      # Stage-2 判 signal 映射
 EVIDENCE_NEGATIVE_TARGET_MODEL_TIER = "emotion"     # 关键词二次判定（延迟敏感）
 EVIDENCE_PROMOTION_MERGE_MODEL_TIER = "correction"  # Promote 合并决策
 

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -22,9 +22,10 @@
    掩盖。
 
 3. **memory 子模块走的 tier**：现役 LLM 路径全部跑在 ``summary`` 或 ``correction``
-   tier 上（fact extraction / signal detection / reflection synthesis / promotion
-   merge / fact dedup / recall rerank → ``summary``；recent.review +
-   persona.correction → ``correction``）。不要再引入新的 hardcoded 模型名字。
+   tier 上（fact extraction / signal detection / reflection synthesis /
+   fact dedup / recall rerank → ``summary``；recent.review +
+   persona.correction + promotion merge → ``correction``）。不要再引入新的
+   hardcoded 模型名字。
 
 如果有非常具体的理由需要绕过，先删 ``scripts/check_no_temperature.py`` 并在
 PR 描述里说明，由 reviewer 把关。

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -400,9 +400,13 @@ class FactDedupResolver:
         try:
             set_call_type("memory_fact_dedup")
             api_config = self._config_manager.get_model_api_config('summary')
+            # timeout=60: 持 FactDedup 锁但只阻 embedding worker enqueue
+            # （background→background），用户路径无感。
+            # max_retries=0: 禁 SDK 自动重试（这里没业务 retry，单次即终态）。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
+                timeout=60, max_retries=0,
             )
             try:
                 resp = await llm.ainvoke(prompt)

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -46,6 +46,11 @@ logger = get_module_logger(__name__, "Memory")
 _ARCHIVE_AGE_DAYS = 7          # absorbed 且创建超过此天数的 facts 被归档
 _ARCHIVE_COOLDOWN_HOURS = 24   # 两次归档尝试之间的最小间隔
 
+# Sentinel：让 _allm_call_with_retries 区分"调用方没指定 extra_body"（默认走
+# create_chat_llm 自动解析）和"调用方显式传 None"（关闭 extra_body 自动解析，
+# 保留 thinking）。Phase D：Stage-2 signal detection 显式传 None 开 thinking。
+_DEFAULT_EXTRA_BODY = object()
+
 
 class FactExtractionFailed(RuntimeError):
     """Stage-1 LLM call exhausted retries (RFC §3.4.2 末段).
@@ -282,6 +287,7 @@ class FactStore:
         self, prompt: str, lanlan_name: str, tier: str, call_type: str,
         max_retries: int = 3,
         timeout: float = 60,
+        extra_body=_DEFAULT_EXTRA_BODY,
     ):
         """Shared LLM helper: retry on network errors + JSON errors, same
         policy as the old `extract_facts`. Returns parsed JSON or None on
@@ -294,7 +300,12 @@ class FactStore:
         timeout 默认 60s 适配后台 LLM（Stage-1 fact extract / Stage-2 signal
         detect / negative keyword check）；调用方可按需提高（如 Stage-2 开
         thinking 后传 90s）。SDK max_retries=0 避免双层 retry 叠加（业务层
-        已经有 max_retries 参数控制）。"""
+        已经有 max_retries 参数控制）。
+
+        extra_body：默认 _DEFAULT_EXTRA_BODY 让 create_chat_llm 自动按模型
+        解析（多数 provider 落地为 disable thinking）；显式传 None 表示"不
+        下发 extra_body" → 模型默认行为（thinking 模型会进入 thinking 模式）。
+        Phase D：Stage-2 signal detection 显式传 None 开 thinking。"""
         from openai import APIConnectionError, InternalServerError, RateLimitError
         from utils.llm_client import create_chat_llm
 
@@ -303,10 +314,13 @@ class FactStore:
             try:
                 set_call_type(call_type)
                 api_config = self._config_manager.get_model_api_config(tier)
+                _llm_kwargs = dict(timeout=timeout, max_retries=0)
+                if extra_body is not _DEFAULT_EXTRA_BODY:
+                    _llm_kwargs['extra_body'] = extra_body
                 llm = create_chat_llm(
                     api_config['model'],
                     api_config['base_url'], api_config['api_key'],
-                    timeout=timeout, max_retries=0,
+                    **_llm_kwargs,
                 )
                 try:
                     resp = await llm.ainvoke(prompt)
@@ -654,10 +668,17 @@ class FactStore:
             .replace('{EXISTING_OBSERVATIONS}', obs_text) \
             .replace('{LANLAN_NAME}', lanlan_name)
 
+        # Phase D：Stage-2 signal detection 开 thinking——
+        # 任务是 new_fact × existing_observation 的关系判断 + target_id 选择，
+        # 现有 [memory/facts.py:670-708](memory/facts.py:670) 防御代码本身就是
+        # 在补 LLM 幻觉，思考能减少 target_id 错位。完全后台 (signal extraction
+        # loop)，无人等。timeout 拉到 90s 给 thinking 模型留余量。
         parsed = await self._allm_call_with_retries(
             prompt, lanlan_name,
             tier=EVIDENCE_DETECT_SIGNALS_MODEL_TIER,
             call_type="memory_signal_detection",
+            timeout=90,
+            extra_body=None,
         )
         if parsed is None:
             return None

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -281,6 +281,7 @@ class FactStore:
     async def _allm_call_with_retries(
         self, prompt: str, lanlan_name: str, tier: str, call_type: str,
         max_retries: int = 3,
+        timeout: float = 60,
     ):
         """Shared LLM helper: retry on network errors + JSON errors, same
         policy as the old `extract_facts`. Returns parsed JSON or None on
@@ -288,7 +289,12 @@ class FactStore:
 
         Note: 不再接受 temperature。项目级约定一律不下发该参数（守门见
         scripts/check_no_temperature.py）。模型从 ``tier`` 对应的 api_config
-        直接拿，不再走 SETTING_PROPOSER_MODEL fallback。"""
+        直接拿，不再走 SETTING_PROPOSER_MODEL fallback。
+
+        timeout 默认 60s 适配后台 LLM（Stage-1 fact extract / Stage-2 signal
+        detect / negative keyword check）；调用方可按需提高（如 Stage-2 开
+        thinking 后传 90s）。SDK max_retries=0 避免双层 retry 叠加（业务层
+        已经有 max_retries 参数控制）。"""
         from openai import APIConnectionError, InternalServerError, RateLimitError
         from utils.llm_client import create_chat_llm
 
@@ -300,6 +306,7 @@ class FactStore:
                 llm = create_chat_llm(
                     api_config['model'],
                     api_config['base_url'], api_config['api_key'],
+                    timeout=timeout, max_retries=0,
                 )
                 try:
                     resp = await llm.ainvoke(prompt)

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1595,9 +1595,13 @@ class PersonaManager:
             from utils.llm_client import create_chat_llm
             set_call_type("memory_correction")
             api_config = self._config_manager.get_model_api_config('correction')
+            # timeout=90: 持 PersonaManager 锁，锁住期间会卡 /process 路径上的
+            # arecord_mentions / aapply_signal / aensure_persona，必须有时长上限。
+            # max_retries=0: 禁 SDK 自动重试，避免叠加（这里没业务 retry，单次即终态）。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
+                timeout=90, max_retries=0,
             )
             try:
                 resp = await llm.ainvoke(prompt)

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -376,9 +376,14 @@ class MemoryRecallReranker:
 
         set_call_type("memory_recall_rerank")
         api_config = config_manager.get_model_api_config('summary')
+        # timeout=8: recall 在 query_memory 请求路径上，上游 plugin/core/context.py
+        # 默认 5s 截断；本地 8s 给 connect + 一次失败裕度。超时即抛
+        # APITimeoutError，外层 try/except 已会降级到 coarse rank。
+        # max_retries=0: 禁 SDK 自动重试，超时直接降级。
         llm = create_chat_llm(
             api_config['model'],
             api_config['base_url'], api_config['api_key'],
+            timeout=8, max_retries=0,
         )
         try:
             resp = await llm.ainvoke(prompt)

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -27,6 +27,97 @@ from utils.tokenize import acount_tokens
 # 500-char/word cap is independent of this gate).
 MAX_SUMMARY_TOKENS = 1000
 
+# ── Phase C review snapshot/capacity 算法 ─────────────────────────────
+# Fingerprint = 末尾 K 条消息的 (type, content[:50]) 元组列表。K=3 兼顾
+# 抗碰撞（连续 3 条 mixed user+ai 几乎不会误命中）和定位精度。
+REVIEW_FINGERPRINT_K = 3
+REVIEW_FINGERPRINT_CONTENT_PREFIX = 50
+
+
+def _msg_fingerprint(m) -> tuple[str, str]:
+    """归一化一条消息为 (type, content_prefix) 元组用于 fingerprint 比对。
+
+    支持消息对象（HumanMessage/AIMessage/...）和 dict（持久化 fingerprint）。
+    content 是 list 时（multimodal）拼成 string。content 截断到前
+    REVIEW_FINGERPRINT_CONTENT_PREFIX 字符——只要重启用户没改写已有消息内容，
+    这个前缀稳定。
+    """
+    if isinstance(m, dict):
+        t = m.get('type', '') or ''
+        c = m.get('content', '') if 'content' in m else (m.get('data', {}).get('content', '') if isinstance(m.get('data'), dict) else '')
+    else:
+        t = getattr(m, 'type', '') or ''
+        c = getattr(m, 'content', '') or ''
+    if isinstance(c, list):
+        parts = []
+        for p in c:
+            if isinstance(p, dict):
+                parts.append(p.get('text', '') or str(p))
+            else:
+                parts.append(str(p))
+        c = ' '.join(parts)
+    elif not isinstance(c, str):
+        c = str(c)
+    return (str(t), c[:REVIEW_FINGERPRINT_CONTENT_PREFIX])
+
+
+def build_review_fingerprint(snapshot, k: int = REVIEW_FINGERPRINT_K) -> list[dict]:
+    """从 snapshot 末尾取 K 条做 fingerprint，序列化成可 JSON 持久化的 dict 列表。"""
+    if not snapshot:
+        return []
+    tail = snapshot[-k:] if len(snapshot) >= k else list(snapshot)
+    out = []
+    for m in tail:
+        t, c = _msg_fingerprint(m)
+        out.append({'type': t, 'content': c})
+    return out
+
+
+def _find_fingerprint_position(current: list, fingerprint: list[dict]) -> int | None:
+    """在 current 里找最后一段连续 K 条消息匹配 fingerprint 的位置。
+
+    返回 fingerprint 末位（也就是 cutoff）在 current 里的 index；
+    找不到返回 None。从尾往前搜，多个候选时取最靠后的（最近）。
+    """
+    if not current or not fingerprint:
+        return None
+    k = len(fingerprint)
+    if len(current) < k:
+        return None
+    fp_norm = [(fp['type'], fp['content']) for fp in fingerprint]
+    for i in range(len(current) - k, -1, -1):
+        if all(_msg_fingerprint(current[i + j]) == fp_norm[j] for j in range(k)):
+            return i + k - 1
+    return None
+
+
+def _compute_review_capacity(snapshot: list, current: list) -> tuple[int, int | None]:
+    """给定 review 启动时的 snapshot 和当前 history，算出 (capacity, cutoff_idx)。
+
+    1. 用 snapshot 末尾 K 条做 anchor 在 current 里定位 cutoff_idx。
+    2. 从 cutoff_idx 起逆向走，对比 snapshot[-1], snapshot[-2], ... 与
+       current[cutoff_idx], current[cutoff_idx-1], ... 的连续匹配长度
+       即 capacity（当中间出现压缩 SystemMessage 等"alien"条目时停下）。
+
+    返回 ``(0, None)`` 表示白 review。
+    """
+    if not snapshot or not current:
+        return (0, None)
+    anchor = build_review_fingerprint(snapshot, REVIEW_FINGERPRINT_K)
+    cutoff_idx = _find_fingerprint_position(current, anchor)
+    if cutoff_idx is None:
+        return (0, None)
+    # 从 cutoff 起逆向走（包含 cutoff 自身），算 capacity
+    capacity = 0
+    s_idx = len(snapshot) - 1
+    c_idx = cutoff_idx
+    while s_idx >= 0 and c_idx >= 0 and _msg_fingerprint(current[c_idx]) == _msg_fingerprint(snapshot[s_idx]):
+        capacity += 1
+        s_idx -= 1
+        c_idx -= 1
+    return (capacity, cutoff_idx)
+
+
 # Setup logger
 from utils.file_utils import (
     atomic_write_json,
@@ -152,15 +243,20 @@ class CompressedRecentHistoryManager:
     def _get_review_llm(self):
         """动态获取审核LLM实例以支持配置热重载。
 
-        timeout=120 给 review_history 重写历史足够余量（prompt 长，可能含 thinking
-        模型 1-2 分钟响应）。review 是后台任务，没人等它，可以放宽。
-        max_retries=0 同上。
+        timeout=120 给 review_history 重写历史足够余量。review 是纯后台任务
+        （Phase C 重设计后不持锁、不阻塞用户路径、并发跑也无所谓），完全可以
+        开 thinking——重写历史的判断密度高，思考受益明显。
+
+        Phase D：extra_body=None 显式覆盖 create_chat_llm 自动解析，让 thinking
+        模型按其默认行为响应（thinking 模式开启）。
+        max_retries=0 同上：禁 SDK 自动重试，由业务层 retry 兜底。
         """
         api_config = self._config_manager.get_model_api_config('correction')
         return create_chat_llm(
             api_config['model'], api_config['base_url'],
             api_config['api_key'] or None,
             timeout=120, max_retries=0,
+            extra_body=None,
         )
 
     async def update_history(self, new_messages, lanlan_name, detailed=False, compress=True):
@@ -391,54 +487,50 @@ class CompressedRecentHistoryManager:
 
         return self.user_histories.get(lanlan_name, [])
 
-    async def review_history(self, lanlan_name, cancel_event=None):
+    async def review_history(self, lanlan_name, snapshot=None, cancel_event=None):
         """
-        审阅历史记录，寻找并修正矛盾、冗余、逻辑混乱或复读的部分
-        :param lanlan_name: 角色名称
-        :param cancel_event: asyncio.Event对象，用于取消操作
+        审阅历史记录，寻找并修正矛盾、冗余、逻辑混乱或复读的部分。
+
+        Phase C 重设计（snapshot + capacity-based 替换）：
+        - ``snapshot``：spawn 时拍下的 history 副本（list of message objects）。
+          LLM 输入用 snapshot 不用当前 history——这样 review LLM 期间用户路径
+          可以继续追加消息 / 触发压缩，互不干扰。
+        - 完成时基于 snapshot 末尾 K=3 条做 fingerprint 匹配，定位 cutoff 在
+          当前 history 里的位置；逆向走出 capacity（连续匹配长度）；用 corrected
+          末尾 ``min(capacity, len(corrected))`` 条替换当前 history 里 cutoff 前
+          连续 ``capacity`` 个 slot；cutoff 之后的新增消息保持不动。
+        - cutoff 找不到（被压缩吞了 / 被 /new_dialog 清了）→ 整段丢弃 = 白 review
+          → caller 应将 fingerprint 设为 None，下一轮 review 立刻可起。
+
+        Returns:
+            True   → 成功 patch 并落盘
+            'white' → cutoff 在当前 history 里失配，整段丢弃
+            False  → LLM 失败 / 被取消 / 历史为空 / 响应格式错误
         """
         # 检查是否被取消
         if cancel_event and cancel_event.is_set():
             print(f"⚠️ {lanlan_name} 的记忆整理被取消（启动前）")
             return False
-            
-        # 检查配置文件中是否禁用自动审阅
-        try:
-            from utils.config_manager import get_config_manager
-            config_manager = get_config_manager()
-            config_path = str(config_manager.get_runtime_config_path('core_config.json'))
-            if await asyncio.to_thread(os.path.exists, config_path):
-                config_data = await read_json_async(config_path)
-                if 'recent_memory_auto_review' in config_data and not config_data['recent_memory_auto_review']:
-                    print(f"{lanlan_name} 的自动记忆整理已禁用，跳过审阅")
-                    return False
-        except Exception as e:
-            print(f"读取配置文件失败：{e}，继续执行审阅")
 
-        # 获取当前历史记录
+        # snapshot 由 caller 提供（spawn 时拍下）；为兼容老调用兜底从磁盘读
+        if snapshot is None:
+            snapshot = await self.aget_recent_history(lanlan_name)
 
-        current_history = await self.aget_recent_history(lanlan_name)
-        
-        if not current_history:
+        if not snapshot:
             print(f"{lanlan_name} 的历史记录为空，无需审阅")
             return False
-        
-        # 检查是否被取消
-        if cancel_event and cancel_event.is_set():
-            print(f"{lanlan_name} 的记忆整理被取消（获取历史后）")
-            return False
-        
-        # 将消息转换为可读的文本格式
+
+        # 将 snapshot 转为可读文本格式（喂 LLM）
         name_mapping = self.name_mapping.copy()
         name_mapping['ai'] = lanlan_name
-        
+
         history_text = ""
-        for msg in current_history:
+        for msg in snapshot:
             if hasattr(msg, 'type') and msg.type in name_mapping:
                 role = name_mapping[msg.type]
             else:
                 role = "unknown"
-            
+
             if hasattr(msg, 'content'):
                 if isinstance(msg.content, str):
                     content = msg.content
@@ -448,14 +540,14 @@ class CompressedRecentHistoryManager:
                     content = str(msg.content)
             else:
                 content = str(msg)
-            
+
             history_text += f"{role}: {content}\n\n"
-        
+
         # 检查是否被取消
         if cancel_event and cancel_event.is_set():
             print(f"⚠️ {lanlan_name} 的记忆整理被取消（准备调用LLM前）")
             return False
-        
+
         retries = 0
         max_retries = 3
         while retries < max_retries:
@@ -468,12 +560,12 @@ class CompressedRecentHistoryManager:
                     response_content = (await review_llm.ainvoke(prompt)).content
                 finally:
                     await review_llm.aclose()
-                
+
                 # 检查是否被取消（LLM调用后）
                 if cancel_event and cancel_event.is_set():
                     print(f"⚠️ {lanlan_name} 的记忆整理被取消（LLM调用后，保存前）")
                     return False
-                
+
                 # 确保response_content是字符串
                 response_content = str(response_content).strip()
 
@@ -484,48 +576,72 @@ class CompressedRecentHistoryManager:
 
                 # 解析JSON响应
                 review_result = robust_json_loads(response_content)
-                
-                if '修正说明' in review_result and '修正后的对话' in review_result:
-                    print(f"记忆整理结果：{review_result['修正说明']}")
-                    
-                    # 将修正后的对话转换回消息格式
-                    corrected_messages = []
-                    for msg_data in review_result['修正后的对话']:
-                        role = msg_data.get('role', 'user')
-                        content = msg_data.get('content', '')
-                        
-                        if role in ['user', 'human', name_mapping['human']]:
-                            corrected_messages.append(HumanMessage(content=content))
-                        elif role in ['ai', 'assistant', name_mapping['ai']]:
-                            corrected_messages.append(AIMessage(content=content))
-                        elif role in ['system', 'system_message', name_mapping['system']]:
-                            corrected_messages.append(SystemMessage(content=content))
-                        else:
-                            # 默认作为用户消息处理
-                            corrected_messages.append(HumanMessage(content=content))
-                    
-                    # 更新历史记录
-                    self.user_histories[lanlan_name] = corrected_messages
 
-                    # 保存到文件
-                    assert_cloudsave_writable(
-                        self._config_manager,
-                        operation="save",
-                        target=f"memory/{lanlan_name}/recent.json",
-                    )
-                    await atomic_write_json_async(
-                        self.log_file_path[lanlan_name],
-                        await asyncio.to_thread(messages_to_dict, corrected_messages),
-                        indent=2,
-                        ensure_ascii=False,
-                    )
-                    
-                    print(f"✅ {lanlan_name} 的记忆已修正并保存")
-                    return True
-                else:
+                if not (isinstance(review_result, dict) and '修正说明' in review_result and '修正后的对话' in review_result):
                     print(f"❌ 审阅响应格式错误：{response_content}")
                     return False
-                    
+
+                print(f"记忆整理结果：{review_result['修正说明']}")
+
+                # 将修正后的对话转换回消息格式。SystemMessage 类型由 compress
+                # 产生（summary 备忘录），review 不应该输出，丢弃以保护压缩边界。
+                corrected_messages = []
+                for msg_data in review_result['修正后的对话']:
+                    role = msg_data.get('role', 'user')
+                    content = msg_data.get('content', '')
+
+                    if role in ['system', 'system_message', name_mapping['system']]:
+                        # 跳过：summary 由 compress 拥有，review 不能改写
+                        continue
+                    elif role in ['user', 'human', name_mapping['human']]:
+                        corrected_messages.append(HumanMessage(content=content))
+                    elif role in ['ai', 'assistant', name_mapping['ai']]:
+                        corrected_messages.append(AIMessage(content=content))
+                    else:
+                        # 默认作为用户消息处理
+                        corrected_messages.append(HumanMessage(content=content))
+
+                # ── Phase C 关键：基于 snapshot 算 capacity 做尾部对齐替换 ──
+                current = await self.aget_recent_history(lanlan_name)
+                capacity, cutoff_idx = _compute_review_capacity(snapshot, current)
+
+                if cutoff_idx is None:
+                    # 白 review：cutoff 在当前 history 里失配（被压缩 / 被清空）
+                    print(f"⚠️ {lanlan_name} review 完成但 cutoff 失配（白 review，丢弃）")
+                    return 'white'
+
+                take_count = min(capacity, len(corrected_messages))
+                # 替换 [cutoff_idx - capacity + 1, cutoff_idx] 这 capacity 个 slot
+                # 为 corrected 末尾 take_count 条；cutoff_idx 之后新增的保留。
+                # take_count < capacity 时，前 (capacity - take_count) 个 slot
+                # 直接消失（review 决定删条，结果就比原来短）。
+                new_history = (
+                    current[:cutoff_idx - capacity + 1]
+                    + corrected_messages[-take_count:]
+                    + current[cutoff_idx + 1:]
+                )
+
+                # 更新 + 落盘
+                self.user_histories[lanlan_name] = new_history
+                assert_cloudsave_writable(
+                    self._config_manager,
+                    operation="save",
+                    target=f"memory/{lanlan_name}/recent.json",
+                )
+                await atomic_write_json_async(
+                    self.log_file_path[lanlan_name],
+                    await asyncio.to_thread(messages_to_dict, new_history),
+                    indent=2,
+                    ensure_ascii=False,
+                )
+
+                print(
+                    f"✅ {lanlan_name} 的记忆已修正：cutoff_idx={cutoff_idx}, "
+                    f"capacity={capacity}, corrected={len(corrected_messages)}, "
+                    f"take={take_count}, history {len(current)}→{len(new_history)}"
+                )
+                return True
+
             except (APIConnectionError, InternalServerError, RateLimitError) as e:
                 logger.info(f"ℹ️ 捕获到 {type(e).__name__} 错误")
                 retries += 1
@@ -543,7 +659,7 @@ class CompressedRecentHistoryManager:
             except Exception as e:
                 logger.error(f"❌ 历史记录审阅失败：{e}")
                 return False
-        
+
         # 如果所有重试都失败
         print(f"❌ {lanlan_name} 的记忆整理失败，已达到最大重试次数")
         return False

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -136,19 +136,31 @@ class CompressedRecentHistoryManager:
             return f.read()
     
     def _get_llm(self):
-        """动态获取LLM实例以支持配置热重载"""
+        """动态获取LLM实例以支持配置热重载。
+
+        timeout=30 配合业务层 max_retries=3 + 指数 backoff（最坏 ~127s）
+        覆盖 /process 上游 30s timeout 后的"放弃" 上限。
+        max_retries=0 禁掉 OpenAI SDK 默认 2 次自动重试，避免与业务层 retry 叠加翻 3 倍。
+        """
         api_config = self._config_manager.get_model_api_config('summary')
         return create_chat_llm(
             api_config['model'], api_config['base_url'],
             api_config['api_key'] or None,
+            timeout=30, max_retries=0,
         )
 
     def _get_review_llm(self):
-        """动态获取审核LLM实例以支持配置热重载"""
+        """动态获取审核LLM实例以支持配置热重载。
+
+        timeout=120 给 review_history 重写历史足够余量（prompt 长，可能含 thinking
+        模型 1-2 分钟响应）。review 是后台任务，没人等它，可以放宽。
+        max_retries=0 同上。
+        """
         api_config = self._config_manager.get_model_api_config('correction')
         return create_chat_llm(
             api_config['model'], api_config['base_url'],
             api_config['api_key'] or None,
+            timeout=120, max_retries=0,
         )
 
     async def update_history(self, new_messages, lanlan_name, detailed=False, compress=True):

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -503,14 +503,19 @@ class CompressedRecentHistoryManager:
           → caller 应将 fingerprint 设为 None，下一轮 review 立刻可起。
 
         Returns:
-            True   → 成功 patch 并落盘
-            'white' → cutoff 在当前 history 里失配，整段丢弃
-            False  → LLM 失败 / 被取消 / 历史为空 / 响应格式错误
+            (str, list[dict] | None) tuple:
+              ('patched', new_fingerprint) — 成功 patch 并落盘；new_fingerprint
+                  是 patch 后 new_history 末尾 review 区的 K 条 fingerprint，供
+                  caller 写入 maint_state（**必须**用这个新 fingerprint，而不是
+                  ``build_review_fingerprint(snapshot)``——review 可能改写过末
+                  尾 K 条里的任一条，旧 fingerprint 在新 history 里再也定位不到）
+              ('white', None) — cutoff 在当前 history 里失配，整段丢弃
+              ('failed', None) — LLM 失败 / 被取消 / 历史为空 / 响应格式错误
         """
         # 检查是否被取消
         if cancel_event and cancel_event.is_set():
             print(f"⚠️ {lanlan_name} 的记忆整理被取消（启动前）")
-            return False
+            return ('failed', None)
 
         # snapshot 由 caller 提供（spawn 时拍下）；为兼容老调用兜底从磁盘读
         if snapshot is None:
@@ -518,7 +523,7 @@ class CompressedRecentHistoryManager:
 
         if not snapshot:
             print(f"{lanlan_name} 的历史记录为空，无需审阅")
-            return False
+            return ('failed', None)
 
         # 将 snapshot 转为可读文本格式（喂 LLM）
         name_mapping = self.name_mapping.copy()
@@ -546,7 +551,7 @@ class CompressedRecentHistoryManager:
         # 检查是否被取消
         if cancel_event and cancel_event.is_set():
             print(f"⚠️ {lanlan_name} 的记忆整理被取消（准备调用LLM前）")
-            return False
+            return ('failed', None)
 
         retries = 0
         max_retries = 3
@@ -564,7 +569,7 @@ class CompressedRecentHistoryManager:
                 # 检查是否被取消（LLM调用后）
                 if cancel_event and cancel_event.is_set():
                     print(f"⚠️ {lanlan_name} 的记忆整理被取消（LLM调用后，保存前）")
-                    return False
+                    return ('failed', None)
 
                 # 确保response_content是字符串
                 response_content = str(response_content).strip()
@@ -579,7 +584,7 @@ class CompressedRecentHistoryManager:
 
                 if not (isinstance(review_result, dict) and '修正说明' in review_result and '修正后的对话' in review_result):
                     print(f"❌ 审阅响应格式错误：{response_content}")
-                    return False
+                    return ('failed', None)
 
                 print(f"记忆整理结果：{review_result['修正说明']}")
 
@@ -608,9 +613,16 @@ class CompressedRecentHistoryManager:
                 if cutoff_idx is None:
                     # 白 review：cutoff 在当前 history 里失配（被压缩 / 被清空）
                     print(f"⚠️ {lanlan_name} review 完成但 cutoff 失配（白 review，丢弃）")
-                    return 'white'
+                    return ('white', None)
 
                 take_count = min(capacity, len(corrected_messages))
+                if take_count == 0:
+                    # corrected 为空（罕见：LLM 返回空"修正后的对话"），等价于
+                    # 整段删除 review 范围。视为白 review 让下轮重建锚点；不去
+                    # 写盘也不更新 fingerprint（避免 anchor 漂移到非 review 区）。
+                    print(f"⚠️ {lanlan_name} review 输出为空，按白 review 处理")
+                    return ('white', None)
+
                 # 替换 [cutoff_idx - capacity + 1, cutoff_idx] 这 capacity 个 slot
                 # 为 corrected 末尾 take_count 条；cutoff_idx 之后新增的保留。
                 # take_count < capacity 时，前 (capacity - take_count) 个 slot
@@ -635,19 +647,30 @@ class CompressedRecentHistoryManager:
                     ensure_ascii=False,
                 )
 
+                # ── Issue #3 修复：基于 patched 后的 new_history 算新 fingerprint ──
+                # patched 区在 new_history 里的范围是 [patched_start, patched_end]：
+                #   patched_start = cutoff_idx - capacity + 1
+                #   patched_end   = patched_start + take_count - 1
+                # 新 fingerprint = K 条以 patched_end 结尾的消息。如果 patched_end
+                # 之前的消息不足 K-1 条，取从 0 开始所有可用的。
+                patched_end = (cutoff_idx - capacity + 1) + take_count - 1
+                fp_start = max(0, patched_end - REVIEW_FINGERPRINT_K + 1)
+                fp_messages = new_history[fp_start:patched_end + 1]
+                new_fingerprint = build_review_fingerprint(fp_messages, k=REVIEW_FINGERPRINT_K)
+
                 print(
                     f"✅ {lanlan_name} 的记忆已修正：cutoff_idx={cutoff_idx}, "
                     f"capacity={capacity}, corrected={len(corrected_messages)}, "
                     f"take={take_count}, history {len(current)}→{len(new_history)}"
                 )
-                return True
+                return ('patched', new_fingerprint)
 
             except (APIConnectionError, InternalServerError, RateLimitError) as e:
                 logger.info(f"ℹ️ 捕获到 {type(e).__name__} 错误")
                 retries += 1
                 if retries >= max_retries:
                     print(f'❌ 记忆整理失败，已达到最大重试次数: {e}')
-                    return False
+                    return ('failed', None)
                 # 指数退避: 1, 2, 4 秒
                 wait_time = 2 ** (retries - 1)
                 print(f'⚠️ 遇到网络或429错误，等待 {wait_time} 秒后重试 (第 {retries}/{max_retries} 次)')
@@ -655,11 +678,11 @@ class CompressedRecentHistoryManager:
                 # 检查是否被取消
                 if cancel_event and cancel_event.is_set():
                     print(f"⚠️ {lanlan_name} 的记忆整理在重试等待期间被取消")
-                    return False
+                    return ('failed', None)
             except Exception as e:
                 logger.error(f"❌ 历史记录审阅失败：{e}")
-                return False
+                return ('failed', None)
 
         # 如果所有重试都失败
         print(f"❌ {lanlan_name} 的记忆整理失败，已达到最大重试次数")
-        return False
+        return ('failed', None)

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -590,10 +590,31 @@ class CompressedRecentHistoryManager:
 
                 # 将修正后的对话转换回消息格式。SystemMessage 类型由 compress
                 # 产生（summary 备忘录），review 不应该输出，丢弃以保护压缩边界。
+                #
+                # content 归一化（trust-boundary 防御）：thinking 模型偶尔会把
+                # JSON content 字段输出为 list/dict 而非 string。现有
+                # compress_history（[memory/recent.py:329-340](memory/recent.py:329)）
+                # 已经针对这种情况做过处理；review 的输出同样是模型生成、同样
+                # 不可信，必须归一化后再写回 recent history，否则下游（recall /
+                # prompt build / fingerprint 比对的 content[:50] 截取）会拿到非
+                # 字符串数据炸掉。
                 corrected_messages = []
                 for msg_data in review_result['修正后的对话']:
                     role = msg_data.get('role', 'user')
                     content = msg_data.get('content', '')
+
+                    # 归一化 content 到 str
+                    if not isinstance(content, str):
+                        if isinstance(content, list):
+                            parts = []
+                            for item in content:
+                                if isinstance(item, dict):
+                                    parts.append(item.get('text', '') or str(item))
+                                else:
+                                    parts.append(str(item))
+                            content = '\n'.join(parts)
+                        else:
+                            content = str(content)
 
                     if role in ['system', 'system_message', name_mapping['system']]:
                         # 跳过：summary 由 compress 拥有，review 不能改写

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -663,9 +663,14 @@ class ReflectionEngine:
         try:
             set_call_type("memory_reflection")
             api_config = self._config_manager.get_model_api_config('summary')
+            # timeout=90: 持 reflection 锁，输出多字段 JSON ontology（reflection
+            # text + entity + relation_type + temporal_scope + subject）较长。
+            # max_retries=0: 禁 SDK 自动重试（无业务 retry，单次即终态，外层
+            # try/except 兜底返回 []）。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
+                timeout=90, max_retries=0,
             )
             try:
                 resp = await llm.ainvoke(prompt)
@@ -1432,9 +1437,12 @@ class ReflectionEngine:
         try:
             set_call_type("memory_feedback_check")
             api_config = self._config_manager.get_model_api_config('summary')
+            # timeout=60: 后台 task 内调用，二分类任务 prompt + 输出都不大。
+            # max_retries=0: 禁 SDK 自动重试。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
+                timeout=60, max_retries=0,
             )
             try:
                 resp = await llm.ainvoke(prompt)
@@ -1493,9 +1501,12 @@ class ReflectionEngine:
         try:
             set_call_type("memory_rebuttal_check")
             api_config = self._config_manager.get_model_api_config('summary')
+            # timeout=60: 周期性反驳扫描，后台跑无人等。
+            # max_retries=0: 禁 SDK 自动重试，失败 cursor 不推进自然下轮重试。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
+                timeout=60, max_retries=0,
             )
             try:
                 resp = await llm.ainvoke(prompt)
@@ -2059,9 +2070,15 @@ class ReflectionEngine:
         api_config = self._config_manager.get_model_api_config(
             EVIDENCE_PROMOTION_MERGE_MODEL_TIER,
         )
+        # timeout=45: LLM 在 reflection 锁外，但 /process 末尾会同步等
+        # aauto_promote_stale 串行处理多个 reflection。每个 promote_merge
+        # prompt 决策短、输出短，应该 <10s 完成；45s 给 4-5x 裕度，超时即
+        # 触发已有 throttle/backoff 路径（EVIDENCE_PROMOTE_RETRY_BACKOFF_MINUTES）。
+        # max_retries=0: 禁 SDK 自动重试，由 throttle/dead-letter 兜底。
         llm = create_chat_llm(
             api_config['model'],
             api_config['base_url'], api_config['api_key'],
+            timeout=45, max_retries=0,
         )
         try:
             resp = await llm.ainvoke(prompt)

--- a/memory_server.py
+++ b/memory_server.py
@@ -322,6 +322,10 @@ enable_shutdown = False
 # 全局变量用于管理correction任务
 correction_tasks = {}  # {lanlan_name: asyncio.Task}
 correction_cancel_flags = {}  # {lanlan_name: asyncio.Event}
+# Phase C: 防 spawn 竞态——/process /renew /settle / IdleMaint 都共用 maybe_spawn_review，
+# 多入口同时进 gate 检查会有 in-flight check → spawn 之间的 await 窗口；用 per-name lock
+# 串行化 gate+spawn 这一段，确保同名角色至多一个 review 在跑。
+_review_spawn_locks: dict[str, asyncio.Lock] = {}
 # 每角色结算锁：首轮摘要期间阻塞 /new_dialog，确保热切换后读到最新数据
 _settle_locks: dict[str, asyncio.Lock] = {}
 # 强引用注册表：防止 fire-and-forget task 被 GC
@@ -331,8 +335,9 @@ _BACKGROUND_TASKS: set[asyncio.Task] = set()
 _last_activity_time: datetime = datetime.now()            # 最后一次对话活动时间
 IDLE_CHECK_INTERVAL = 40             # 空闲检查轮询间隔（秒）
 IDLE_THRESHOLD = 10                  # 多少秒无活动视为空闲（匹配最低 proactive 间隔）
-REVIEW_MIN_INTERVAL = 300            # review（correction）最短间隔（秒）。Phase C 改为 30s + 活跃 ×2
-REVIEW_SKIP_HISTORY_LEN = 8          # 历史不足此数的角色跳过 review / correction
+REVIEW_MIN_INTERVAL = 30             # review 最短间隔（秒）。配合 active 时 ×2 + 消息门 双重限流
+REVIEW_SKIP_HISTORY_LEN = 8          # 历史不足此数的角色跳过 review
+MIN_NEW_MSGS_FOR_REVIEW = 5          # 自上次 review cutoff 起累积 ≥ N 条 user msg 才允许触发新一轮
 
 # ── 启动错峰 initial_delay（避免首轮全部撞 startup + interval 同一时刻） ──
 # 每个循环首次执行时间 = startup + 该 delay；之后按各自 INTERVAL 周期跑。
@@ -864,8 +869,6 @@ async def _periodic_idle_maintenance_loop():
                 logger.debug(f"[IdleMaint] 加载角色列表失败: {e}")
                 continue
 
-            review_enabled = await _ais_review_enabled()
-
             for name in catgirl_names:
                 # 每处理一个角色前重新检查空闲，一旦变忙立即退出
                 if not _is_idle():
@@ -932,34 +935,14 @@ async def _periodic_idle_maintenance_loop():
                     except Exception as e:
                         logger.warning(f"[IdleMaint] {name}: persona 矛盾审视失败: {e}")
 
-                    # 历史不足 REVIEW_SKIP_HISTORY_LEN 条，或全局开关关闭 → 跳过 review
-                    if history_len < REVIEW_SKIP_HISTORY_LEN or not review_enabled:
-                        continue
-
                     # ── 子任务3: 记忆整理 review ──
+                    # Phase C: gate 逻辑全部集中到 maybe_spawn_review，IdleMaint
+                    # 不再做单点门禁。spawn 函数内部自查 review_enabled / 历史长度
+                    # / min_interval / 新消息门 / in-flight，不过门就 skip。
                     if not _is_idle():
                         break
-                    # 已 review 且没有新对话 → 跳过
-                    if _is_review_clean(name):
-                        continue
-                    # 已有 review 任务在跑 → 跳过
-                    if name in correction_tasks and not correction_tasks[name].done():
-                        continue
-                    # 最短间隔限制
-                    last_review = _maint_state.get(name, {}).get('last_review_ts')
-                    if last_review:
-                        try:
-                            elapsed = (datetime.now() - datetime.fromisoformat(last_review)).total_seconds()
-                            if elapsed < REVIEW_MIN_INTERVAL:
-                                continue
-                        except (ValueError, TypeError):
-                            logger.debug(f"[IdleMaint] {name}: last_review_ts 格式无效，视为未 review 过")
-                    logger.info(f"[IdleMaint] {name}: 空闲期间执行记忆整理")
                     try:
-                        cancel_event = asyncio.Event()
-                        correction_cancel_flags[name] = cancel_event
-                        task = asyncio.create_task(_run_review_in_background(name))
-                        correction_tasks[name] = task
+                        await maybe_spawn_review(name)
                     except Exception as e:
                         logger.warning(f"[IdleMaint] {name}: 记忆整理启动失败: {e}")
 
@@ -1880,39 +1863,134 @@ async def shutdown_event_handler():
     logger.info("Memory server已关闭")
 
 
-async def _run_review_in_background(lanlan_name: str):
-    """在后台运行review_history，支持取消"""
-    global correction_tasks, correction_cancel_flags
-    
-    # 获取该角色的取消标志
+def _get_review_spawn_lock(name: str) -> asyncio.Lock:
+    """惰性 per-name asyncio.Lock，串行化 gate+spawn 检查。"""
+    lock = _review_spawn_locks.get(name)
+    if lock is None:
+        lock = asyncio.Lock()
+        _review_spawn_locks[name] = lock
+    return lock
+
+
+def _count_new_user_msgs_since_last_review(name: str, current_history: list) -> float:
+    """数自上次 review cutoff 起 history 里的 user msg 数。
+
+    白 review（fingerprint=None）→ 视为足够多放行。
+    fingerprint 在 current 里找不到（被压缩 / 清空）→ 同样视为足够多放行
+    （应当尽快重 review 重建 fingerprint）。
+    """
+    from memory.recent import _find_fingerprint_position
+    fp = _maint_state.get(name, {}).get('last_reviewed_cutoff_tail')
+    if not fp:
+        return float('inf')
+    cutoff_idx = _find_fingerprint_position(current_history, fp)
+    if cutoff_idx is None:
+        return float('inf')
+    return sum(
+        1 for m in current_history[cutoff_idx + 1:]
+        if getattr(m, 'type', '') == 'human'
+    )
+
+
+async def maybe_spawn_review(name: str) -> None:
+    """统一 review 触发入口（Phase C）。
+
+    /process /renew /settle / IdleMaint 都调这一个函数。本身**不**取消任何
+    在跑的 review——看到 in-flight 直接 skip 本次 spawn。由 spawn 锁串行化
+    gate+spawn 防多入口竞态。
+
+    Gates（任一不过都 skip）：
+    1. 已有 review 在跑（in-flight）
+    2. ``review_enabled``（``recent_memory_auto_review`` flag）
+    3. 历史长度 < ``REVIEW_SKIP_HISTORY_LEN``
+    4. 距上次 review 完成 < ``REVIEW_MIN_INTERVAL``（活跃时 ×2）
+    5. 自上次 review cutoff 起累积 user msg < ``MIN_NEW_MSGS_FOR_REVIEW``
+    """
+    async with _get_review_spawn_lock(name):
+        # Gate 1: in-flight
+        existing = correction_tasks.get(name)
+        if existing is not None and not existing.done():
+            return
+        # Gate 2: review_enabled
+        if not await _ais_review_enabled():
+            return
+        # 拉 history（gate 3/5 + 后续做 snapshot 都需要）
+        try:
+            history = await recent_history_manager.aget_recent_history(name)
+        except Exception as e:
+            logger.debug(f"[Review/spawn] {name}: 拉 history 失败: {e}")
+            return
+        # Gate 3: history 长度
+        if len(history) < REVIEW_SKIP_HISTORY_LEN:
+            return
+        # Gate 4: min interval (active doubled)
+        last_review = _maint_state.get(name, {}).get('last_review_ts')
+        if last_review:
+            try:
+                elapsed = (datetime.now() - datetime.fromisoformat(last_review)).total_seconds()
+                effective_min = REVIEW_MIN_INTERVAL * (2 if not _is_idle() else 1)
+                if elapsed < effective_min:
+                    return
+            except (ValueError, TypeError):
+                pass
+        # Gate 5: 够多新 user 消息
+        if _count_new_user_msgs_since_last_review(name, history) < MIN_NEW_MSGS_FOR_REVIEW:
+            return
+        # 全过 → spawn
+        logger.info(f"[Review/spawn] {name}: 触发 review (history_len={len(history)})")
+        cancel_event = asyncio.Event()
+        correction_cancel_flags[name] = cancel_event
+        snapshot = list(history)  # 浅拷贝即可，消息对象不可变
+        task = asyncio.create_task(_run_review_in_background(name, snapshot))
+        correction_tasks[name] = task
+
+
+async def _run_review_in_background(lanlan_name: str, snapshot: list):
+    """在后台运行 review_history，支持取消。
+
+    Phase C 改动：
+    - snapshot 由 caller 拍下传入（不再重新读 history）
+    - review_history 返回 True / 'white' / False，分别对应：成功 patch /
+      cutoff 失配丢弃 / LLM 失败或被取消
+    - 成功：更新 last_review_ts + last_reviewed_cutoff_tail (K=3 fingerprint)
+    - 'white'：把 last_reviewed_cutoff_tail 设 None（caller 决定立刻重 review）
+    - False：不动 maint_state，下轮 gate 重判
+    """
+    from memory.recent import build_review_fingerprint
+
     cancel_event = correction_cancel_flags.get(lanlan_name)
-    if not cancel_event:
+    if cancel_event is None:
         cancel_event = asyncio.Event()
         correction_cancel_flags[lanlan_name] = cancel_event
-    
+
     try:
-        # 直接异步调用review_history方法
-        success = await recent_history_manager.review_history(lanlan_name, cancel_event)
-        if success:
+        result = await recent_history_manager.review_history(
+            lanlan_name, snapshot, cancel_event=cancel_event,
+        )
+        state = _maint_state.setdefault(lanlan_name, {})
+        if result is True:
             logger.info(f"✅ {lanlan_name} 的记忆整理任务完成")
-            # 仅在 review 实际成功修正并保存时标记 clean + 记录时间
-            state = _maint_state.setdefault(lanlan_name, {})
             state['review_clean'] = True
             state['last_review_ts'] = datetime.now().isoformat()
+            state['last_reviewed_cutoff_tail'] = build_review_fingerprint(snapshot)
+            await _asave_maint_state()
+        elif result == 'white':
+            logger.info(f"⚠️ {lanlan_name} 白 review（cutoff 失配），fingerprint 清空允许立即重试")
+            state['last_reviewed_cutoff_tail'] = None
+            state['last_review_ts'] = datetime.now().isoformat()  # interval 仍生效
             await _asave_maint_state()
         else:
-            logger.info(f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或条件不满足）")
+            logger.info(f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败）")
     except asyncio.CancelledError:
         logger.info(f"⚠️ {lanlan_name} 的记忆整理任务被取消")
     except Exception as e:
         logger.error(f"❌ {lanlan_name} 的记忆整理任务出错: {e}")
     finally:
-        # 清理任务记录
-        if lanlan_name in correction_tasks:
-            del correction_tasks[lanlan_name]
-        # 重置取消标志
-        if lanlan_name in correction_cancel_flags:
-            correction_cancel_flags[lanlan_name].clear()
+        if correction_tasks.get(lanlan_name) is not None:
+            correction_tasks.pop(lanlan_name, None)
+        ev = correction_cancel_flags.get(lanlan_name)
+        if ev is not None:
+            ev.clear()
 
 def _extract_ai_response(messages: list) -> str:
     """从消息列表中提取最后一条 AI 回复的文本。"""
@@ -2213,19 +2291,11 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
         # 异步事实提取（不阻塞返回，失败静默跳过）
         await _spawn_outbox_extract_facts(lanlan_name, input_history)
 
-        # 在后台启动review_history任务
-        if lanlan_name in correction_tasks and not correction_tasks[lanlan_name].done():
-            # 如果已有任务在运行，取消它
-            correction_tasks[lanlan_name].cancel()
-            try:
-                await correction_tasks[lanlan_name]
-            except asyncio.CancelledError:
-                pass
-        
-        # 启动新的review任务
-        task = asyncio.create_task(_run_review_in_background(lanlan_name))
-        correction_tasks[lanlan_name] = task
-        
+        # Phase C: 不再 cancel-and-restart review；让 maybe_spawn_review 在新消息
+        # 门 + min_interval + in-flight 多重 gate 后决定起或不起。在跑的 review
+        # 跑完会自行 patch 当前 history 末尾的可改区，新消息保留不动。
+        await maybe_spawn_review(lanlan_name)
+
         return {"status": "processed"}
     except Exception as e:
         logger.error(f"处理对话历史失败: {e}")
@@ -2264,19 +2334,9 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
         # 异步事实提取
         await _spawn_outbox_extract_facts(lanlan_name, input_history)
 
-        # 在后台启动review_history任务
-        if lanlan_name in correction_tasks and not correction_tasks[lanlan_name].done():
-            # 如果已有任务在运行，取消它
-            correction_tasks[lanlan_name].cancel()
-            try:
-                await correction_tasks[lanlan_name]
-            except asyncio.CancelledError:
-                pass
-        
-        # 启动新的review任务
-        task = asyncio.create_task(_run_review_in_background(lanlan_name))
-        correction_tasks[lanlan_name] = task
-        
+        # Phase C: 见 /process 的注释——不再 cancel-and-restart。
+        await maybe_spawn_review(lanlan_name)
+
         return {"status": "processed"}
     except Exception as e:
         return {"status": "error", "message": str(e)}
@@ -2308,14 +2368,8 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
         if input_history:
             await _spawn_outbox_extract_facts(lanlan_name, input_history)
 
-        if lanlan_name in correction_tasks and not correction_tasks[lanlan_name].done():
-            correction_tasks[lanlan_name].cancel()
-            try:
-                await correction_tasks[lanlan_name]
-            except asyncio.CancelledError:
-                pass
-        task = asyncio.create_task(_run_review_in_background(lanlan_name))
-        correction_tasks[lanlan_name] = task
+        # Phase C: 见 /process 的注释——不再 cancel-and-restart。
+        await maybe_spawn_review(lanlan_name)
 
         return {"status": "settled"}
     except Exception as e:

--- a/memory_server.py
+++ b/memory_server.py
@@ -1944,43 +1944,62 @@ async def maybe_spawn_review(name: str) -> None:
         cancel_event = asyncio.Event()
         correction_cancel_flags[name] = cancel_event
         snapshot = list(history)  # 浅拷贝即可，消息对象不可变
-        task = asyncio.create_task(_run_review_in_background(name, snapshot))
+        # 把 cancel_event 显式传给后台 task（不再依靠 finally 时再从 dict 拿），
+        # 这样 task 自己持有的 event 引用不会被并发的新 spawn 覆盖。
+        task = asyncio.create_task(_run_review_in_background(name, snapshot, cancel_event))
         correction_tasks[name] = task
 
 
-async def _run_review_in_background(lanlan_name: str, snapshot: list):
+async def _run_review_in_background(
+    lanlan_name: str, snapshot: list, cancel_event: asyncio.Event,
+):
     """在后台运行 review_history，支持取消。
 
     Phase C 改动：
-    - snapshot 由 caller 拍下传入（不再重新读 history）
-    - review_history 返回 True / 'white' / False，分别对应：成功 patch /
-      cutoff 失配丢弃 / LLM 失败或被取消
-    - 成功：更新 last_review_ts + last_reviewed_cutoff_tail (K=3 fingerprint)
-    - 'white'：把 last_reviewed_cutoff_tail 设 None（caller 决定立刻重 review）
-    - False：不动 maint_state，下轮 gate 重判
+    - snapshot + cancel_event 由 caller 拍下传入（task 自己持有引用）
+    - review_history 返回 (status, fingerprint) tuple：
+        ('patched', new_fp) → 成功 patch；new_fp 是 patch 后 new_history 末尾
+                              的 K 条 fingerprint，**必须**用这个新 fingerprint
+                              （review 可能改写过末尾 K 条里的任一条，
+                              ``build_review_fingerprint(snapshot)`` 是旧的）
+        ('white', None)    → cutoff 失配 / 整段丢弃
+        ('failed', None)   → LLM 失败 / 被取消 / 格式错误
+
+    白 review 处理（CodeRabbit Issue #1 修复）：
+    - **不**更新 last_review_ts → 下轮 gate 4 视为"距上次 review 时间已久"
+      → 配合 fingerprint=None → MIN_NEW_MSGS gate 视为 ∞ → 下次 /process
+      立即重 review，重建锚点。这才符合"白 review = 锚点丢失，应尽快重建"
+      的用户原意。
+
+    清理（CodeRabbit Issue #2 修复）：
+    - finally 按 task/event 身份比对再 pop/clear，避免并发新 spawn 写入的
+      条目被误删。理论上 spawn lock + asyncio finally 同步语义已经排除了
+      race，但身份检查是廉价的防御。
     """
-    from memory.recent import build_review_fingerprint
-
-    cancel_event = correction_cancel_flags.get(lanlan_name)
-    if cancel_event is None:
-        cancel_event = asyncio.Event()
-        correction_cancel_flags[lanlan_name] = cancel_event
-
     try:
         result = await recent_history_manager.review_history(
             lanlan_name, snapshot, cancel_event=cancel_event,
         )
+        # 兼容意外的返回类型，统一解包
+        if isinstance(result, tuple) and len(result) == 2:
+            status, fingerprint = result
+        else:
+            status, fingerprint = ('failed', None)
+
         state = _maint_state.setdefault(lanlan_name, {})
-        if result is True:
+        if status == 'patched':
             logger.info(f"✅ {lanlan_name} 的记忆整理任务完成")
             state['review_clean'] = True
             state['last_review_ts'] = datetime.now().isoformat()
-            state['last_reviewed_cutoff_tail'] = build_review_fingerprint(snapshot)
+            state['last_reviewed_cutoff_tail'] = fingerprint
             await _asave_maint_state()
-        elif result == 'white':
-            logger.info(f"⚠️ {lanlan_name} 白 review（cutoff 失配），fingerprint 清空允许立即重试")
+        elif status == 'white':
+            logger.info(
+                f"⚠️ {lanlan_name} 白 review（cutoff 失配），fingerprint 清空、不刷 ts，允许立即重试"
+            )
             state['last_reviewed_cutoff_tail'] = None
-            state['last_review_ts'] = datetime.now().isoformat()  # interval 仍生效
+            # 故意不更新 last_review_ts：让下轮 gate 4 用旧 ts（通常已过 30/60s）
+            # 直接放行，配合 fingerprint=None 触发 gate 5 的 ∞ 通行 → 立即重 review。
             await _asave_maint_state()
         else:
             logger.info(f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败）")
@@ -1989,11 +2008,13 @@ async def _run_review_in_background(lanlan_name: str, snapshot: list):
     except Exception as e:
         logger.error(f"❌ {lanlan_name} 的记忆整理任务出错: {e}")
     finally:
-        if correction_tasks.get(lanlan_name) is not None:
+        # 按 task/event 身份比对再清理：如果并发的新 spawn 已经写入了新 task /
+        # 新 event，本 task 不应该把它们清掉。
+        current_task = asyncio.current_task()
+        if correction_tasks.get(lanlan_name) is current_task:
             correction_tasks.pop(lanlan_name, None)
-        ev = correction_cancel_flags.get(lanlan_name)
-        if ev is not None:
-            ev.clear()
+        if correction_cancel_flags.get(lanlan_name) is cancel_event:
+            correction_cancel_flags.pop(lanlan_name, None)
 
 def _extract_ai_response(messages: list) -> str:
     """从消息列表中提取最后一条 AI 回复的文本。"""

--- a/memory_server.py
+++ b/memory_server.py
@@ -1932,6 +1932,9 @@ async def maybe_spawn_review(name: str) -> None:
                 if elapsed < effective_min:
                     return
             except (ValueError, TypeError):
+                # last_review_ts 格式损坏（旧版本字段 / 手改文件 / 编码错误）→
+                # 视为"从未 review 过"，不阻塞触发；继续走 gate 5（新消息门）。
+                # 下次 review 成功后会用合法 ISO 字符串覆写。
                 pass
         # Gate 5: 够多新 user 消息
         if _count_new_user_msgs_since_last_review(name, history) < MIN_NEW_MSGS_FOR_REVIEW:

--- a/memory_server.py
+++ b/memory_server.py
@@ -329,11 +329,22 @@ _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 # ── 空闲维护相关 ────────────────────────────────────────────────────
 _last_activity_time: datetime = datetime.now()            # 最后一次对话活动时间
-IDLE_CHECK_INTERVAL = 40             # 空闲检查轮询间隔（秒，正常阶段）
-IDLE_CHECK_INTERVAL_STARTUP = 10     # 启动阶段高频轮询间隔
+IDLE_CHECK_INTERVAL = 40             # 空闲检查轮询间隔（秒）
 IDLE_THRESHOLD = 10                  # 多少秒无活动视为空闲（匹配最低 proactive 间隔）
-REVIEW_MIN_INTERVAL = 300            # review（correction）最短间隔（秒）
+REVIEW_MIN_INTERVAL = 300            # review（correction）最短间隔（秒）。Phase C 改为 30s + 活跃 ×2
 REVIEW_SKIP_HISTORY_LEN = 8          # 历史不足此数的角色跳过 review / correction
+
+# ── 启动错峰 initial_delay（避免首轮全部撞 startup + interval 同一时刻） ──
+# 每个循环首次执行时间 = startup + 该 delay；之后按各自 INTERVAL 周期跑。
+# 设计原则：archive sweep 用最长 INTERVAL (3600s) 但很多用户不到 1h 就退出，
+# 必须显著前移；rebuttal/auto_promote 同 300s 间隔但不能同时跑，错开 60s；
+# IdleMaint/Signal 已经间隔短，仅给 startup tasks (cloudsave / outbox replay /
+# migration) 一点喘息空间。EmbeddingWarmupWorker 自带 30s warmup gate，不在此处。
+_INITIAL_DELAY_IDLE_MAINT = 20       # IdleMaint 首次 (原 10s startup 高频已废)
+_INITIAL_DELAY_SIGNAL = 60           # Signal extraction 首次 (原 40s)
+_INITIAL_DELAY_REBUTTAL = 100        # Rebuttal 首次 (原 300s)
+_INITIAL_DELAY_AUTO_PROMOTE = 150    # Auto-promote 首次 (原 300s, 错开 rebuttal 50s)
+_INITIAL_DELAY_ARCHIVE = 250         # Archive sweep 首次 (原 3600s, 大幅前移确保短会话用户也能跑到)
 
 # ── 持久化维护状态（跨重启保留 review_clean 标记） ──────────────────
 _maint_state: dict[str, dict] = {}   # {角色名: {"review_clean": bool, "last_review_ts": str}}
@@ -478,7 +489,7 @@ OutboxHandler = Callable[[str, dict], Awaitable[None]]
 _OUTBOX_HANDLERS: dict[str, OutboxHandler] = {}
 
 # 启动期补跑 fan-out 并发上限：防止 24h 停机后的 outbox 洪水冲击 LLM 后端。
-_REPLAY_CONCURRENCY = 4
+_REPLAY_CONCURRENCY = 2
 _replay_semaphore: asyncio.Semaphore | None = None  # 懒构造（event loop-bound）
 
 
@@ -706,14 +717,17 @@ async def _periodic_rebuttal_loop():
 
     游标持久化（P0 修复）：`CURSOR_REBUTTAL_CHECKED_UNTIL` 写入 cursors.json，
     关机→重启后从磁盘读取，消灭"默认只回扫 1 小时导致关机期间反驳丢失"的缺陷。
+
+    首轮启动延迟 _INITIAL_DELAY_REBUTTAL 秒（与其他后台循环错峰）。
     """
+    await asyncio.sleep(_INITIAL_DELAY_REBUTTAL)
     while True:
-        await asyncio.sleep(REBUTTAL_CHECK_INTERVAL)
         try:
             character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
         except Exception as e:
             logger.debug(f"[Rebuttal] 加载角色列表失败: {e}")
+            await asyncio.sleep(REBUTTAL_CHECK_INTERVAL)
             continue
 
         now = datetime.now()
@@ -777,6 +791,8 @@ async def _periodic_rebuttal_loop():
                 return_exceptions=True,
             )
 
+        await asyncio.sleep(REBUTTAL_CHECK_INTERVAL)
+
 
 AUTO_PROMOTE_CHECK_INTERVAL = 300  # 5 分钟
 
@@ -790,14 +806,17 @@ async def _periodic_auto_promote_loop():
 
     Per-character 用 asyncio.gather 并行——每个角色内部仍是顺序操作
     （锁串行），但跨角色可以打满。
+
+    首轮启动延迟 _INITIAL_DELAY_AUTO_PROMOTE 秒（与其他后台循环错峰）。
     """
+    await asyncio.sleep(_INITIAL_DELAY_AUTO_PROMOTE)
     while True:
-        await asyncio.sleep(AUTO_PROMOTE_CHECK_INTERVAL)
         try:
             character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
         except Exception as e:
             logger.debug(f"[AutoPromote] 加载角色列表失败: {e}")
+            await asyncio.sleep(AUTO_PROMOTE_CHECK_INTERVAL)
             continue
 
         async def _promote_one(name: str):
@@ -814,141 +833,140 @@ async def _periodic_auto_promote_loop():
                 return_exceptions=True,
             )
 
+        await asyncio.sleep(AUTO_PROMOTE_CHECK_INTERVAL)
+
 
 async def _periodic_idle_maintenance_loop():
     """定期检查系统是否空闲，空闲时自动执行记忆维护任务。
 
-    启动阶段以 IDLE_CHECK_INTERVAL_STARTUP(10s) 高频轮询，尽快捕获启动后的
-    首个空闲窗口执行维护（用户上次强制退出导致的未完成任务在这里收尾）。
-    首轮维护完成或 recent_memory_auto_review 被禁用后恢复 IDLE_CHECK_INTERVAL(40s)。
+    首次执行延迟 _INITIAL_DELAY_IDLE_MAINT 秒（让 startup 期 cloudsave / outbox
+    replay / migration 任务先消化），之后每 IDLE_CHECK_INTERVAL 秒轮询一次。
 
     每轮为每个角色依次执行：
     1. 历史记录压缩 — 有需要就跑（history > max_history_length）
-    2. Persona 矛盾审视 — 有需要就跑（pending corrections 非空，history >= 8）
-    3. 记忆整理 review — review_clean 则跳过；受 REVIEW_MIN_INTERVAL 最短间隔；history < 8 跳过
+    1b. Fact 向量去重 — 有需要就跑（vectors 启用且 pending dedup 队列非空）
+    2. Persona 矛盾审视 — 有需要就跑（pending corrections 非空）；不受 recent_memory_auto_review
+       开关或 REVIEW_SKIP_HISTORY_LEN 影响：persona corrections 不读 recent history，是独立的
+       矛盾消解管线，不应被 review 开关一刀切。
+    3. 记忆整理 review — review_clean 则跳过；受 REVIEW_MIN_INTERVAL 最短间隔；
+       history < REVIEW_SKIP_HISTORY_LEN 或 review_enabled 关闭则跳过。
     """
-    startup_phase = True
+    await asyncio.sleep(_INITIAL_DELAY_IDLE_MAINT)
     while True:
-        await asyncio.sleep(IDLE_CHECK_INTERVAL_STARTUP if startup_phase else IDLE_CHECK_INTERVAL)
-
-        # correction 被禁用 → 无需高频轮询
-        if startup_phase and not await _ais_review_enabled():
-            startup_phase = False
-
-        if not _is_idle():
-            continue
-
         try:
-            character_data = await _config_manager.aload_characters()
-            catgirl_names = list(character_data.get('猫娘', {}).keys())
-        except Exception as e:
-            logger.debug(f"[IdleMaint] 加载角色列表失败: {e}")
-            continue
-
-        review_enabled = await _ais_review_enabled()
-
-        for name in catgirl_names:
-            # 每处理一个角色前重新检查空闲，一旦变忙立即退出
             if not _is_idle():
-                logger.debug("[IdleMaint] 检测到新活动，中断本轮维护")
-                break
+                continue
 
             try:
-                history = await recent_history_manager.aget_recent_history(name)
-                history_len = len(history)
+                character_data = await _config_manager.aload_characters()
+                catgirl_names = list(character_data.get('猫娘', {}).keys())
+            except Exception as e:
+                logger.debug(f"[IdleMaint] 加载角色列表失败: {e}")
+                continue
 
-                # ── 子任务1: 历史记录压缩（有需要就跑，不受全局开关控制） ──
-                if history_len > recent_history_manager.max_history_length:
-                    logger.info(
-                        f"[IdleMaint] {name}: 历史记录过长 ({history_len} > "
-                        f"{recent_history_manager.max_history_length})，触发压缩"
-                    )
-                    try:
-                        # 传空消息列表仅触发压缩逻辑
-                        await recent_history_manager.update_history([], name, detailed=True)
-                        logger.info(f"[IdleMaint] {name}: 历史记录压缩完成")
-                    except Exception as e:
-                        logger.warning(f"[IdleMaint] {name}: 历史记录压缩失败: {e}")
+            review_enabled = await _ais_review_enabled()
 
-                # ── 子任务1b: Fact 向量去重（P2 step 2） ──
-                # Runs *before* the review-gate so a character with
-                # short history still gets paraphrase consolidation
-                # (Codex PR-957 P2). The embedding worker enqueued
-                # candidate paraphrase pairs after the last fact-sweep;
-                # resolve them here via a single LLM call.
-                # fact_dedup_resolver is None when vectors are disabled
-                # or bootstrap failed — legacy hash + FTS5 dedup
-                # remains the entire dedup pipeline in that case.
-                if fact_dedup_resolver is not None:
+            for name in catgirl_names:
+                # 每处理一个角色前重新检查空闲，一旦变忙立即退出
+                if not _is_idle():
+                    logger.debug("[IdleMaint] 检测到新活动，中断本轮维护")
+                    break
+
+                try:
+                    history = await recent_history_manager.aget_recent_history(name)
+                    history_len = len(history)
+
+                    # ── 子任务1: 历史记录压缩（有需要就跑，不受全局开关控制） ──
+                    if history_len > recent_history_manager.max_history_length:
+                        logger.info(
+                            f"[IdleMaint] {name}: 历史记录过长 ({history_len} > "
+                            f"{recent_history_manager.max_history_length})，触发压缩"
+                        )
+                        try:
+                            # 传空消息列表仅触发压缩逻辑
+                            await recent_history_manager.update_history([], name, detailed=True)
+                            logger.info(f"[IdleMaint] {name}: 历史记录压缩完成")
+                        except Exception as e:
+                            logger.warning(f"[IdleMaint] {name}: 历史记录压缩失败: {e}")
+
+                    # ── 子任务1b: Fact 向量去重（P2 step 2） ──
+                    # Runs *before* the review-gate so a character with
+                    # short history still gets paraphrase consolidation
+                    # (Codex PR-957 P2). The embedding worker enqueued
+                    # candidate paraphrase pairs after the last fact-sweep;
+                    # resolve them here via a single LLM call.
+                    # fact_dedup_resolver is None when vectors are disabled
+                    # or bootstrap failed — legacy hash + FTS5 dedup
+                    # remains the entire dedup pipeline in that case.
+                    if fact_dedup_resolver is not None:
+                        if not _is_idle():
+                            break
+                        try:
+                            pending_dedup = await fact_dedup_resolver.aload_pending(name)
+                            if pending_dedup:
+                                logger.info(
+                                    f"[IdleMaint] {name}: 发现 {len(pending_dedup)} 对未处理的 fact 候选去重，触发 LLM 审视"
+                                )
+                                resolved = await fact_dedup_resolver.aresolve(name)
+                                if resolved:
+                                    logger.info(
+                                        f"[IdleMaint] {name}: 完成 {resolved} 对 fact 去重决策"
+                                    )
+                        except Exception as e:
+                            logger.warning(f"[IdleMaint] {name}: fact 向量去重失败: {e}")
+
+                    # ── 子任务2: Persona 矛盾审视（有需要就跑，不受 review_enabled / history_len 限制） ──
+                    # resolve_corrections 不读 recent history，矛盾队列由独立的 evidence 管线
+                    # 维护，应当永远跑。把 review 闸门移到子任务 3 之前。
                     if not _is_idle():
                         break
                     try:
-                        pending_dedup = await fact_dedup_resolver.aload_pending(name)
-                        if pending_dedup:
+                        pending_corrections = await persona_manager.aload_pending_corrections(name)
+                        if pending_corrections:
                             logger.info(
-                                f"[IdleMaint] {name}: 发现 {len(pending_dedup)} 对未处理的 fact 候选去重，触发 LLM 审视"
+                                f"[IdleMaint] {name}: 发现 {len(pending_corrections)} 条未处理的 persona 矛盾，触发审视"
                             )
-                            resolved = await fact_dedup_resolver.aresolve(name)
+                            resolved = await persona_manager.resolve_corrections(name)
                             if resolved:
-                                logger.info(
-                                    f"[IdleMaint] {name}: 完成 {resolved} 对 fact 去重决策"
-                                )
+                                logger.info(f"[IdleMaint] {name}: 审视了 {resolved} 条 persona 矛盾")
                     except Exception as e:
-                        logger.warning(f"[IdleMaint] {name}: fact 向量去重失败: {e}")
+                        logger.warning(f"[IdleMaint] {name}: persona 矛盾审视失败: {e}")
 
-                # 历史不足 REVIEW_SKIP_HISTORY_LEN 条，或全局开关关闭 → 跳过矛盾审视和 review
-                if history_len < REVIEW_SKIP_HISTORY_LEN or not review_enabled:
-                    continue
+                    # 历史不足 REVIEW_SKIP_HISTORY_LEN 条，或全局开关关闭 → 跳过 review
+                    if history_len < REVIEW_SKIP_HISTORY_LEN or not review_enabled:
+                        continue
 
-                # ── 子任务2: Persona 矛盾审视（有需要就跑） ──
-                if not _is_idle():
-                    break
-                try:
-                    pending_corrections = await persona_manager.aload_pending_corrections(name)
-                    if pending_corrections:
-                        logger.info(
-                            f"[IdleMaint] {name}: 发现 {len(pending_corrections)} 条未处理的 persona 矛盾，触发审视"
-                        )
-                        resolved = await persona_manager.resolve_corrections(name)
-                        if resolved:
-                            logger.info(f"[IdleMaint] {name}: 审视了 {resolved} 条 persona 矛盾")
-                except Exception as e:
-                    logger.warning(f"[IdleMaint] {name}: persona 矛盾审视失败: {e}")
-
-                # ── 子任务3: 记忆整理 review ──
-                if not _is_idle():
-                    break
-                # 已 review 且没有新对话 → 跳过
-                if _is_review_clean(name):
-                    continue
-                # 已有 review 任务在跑 → 跳过
-                if name in correction_tasks and not correction_tasks[name].done():
-                    continue
-                # 最短间隔限制
-                last_review = _maint_state.get(name, {}).get('last_review_ts')
-                if last_review:
+                    # ── 子任务3: 记忆整理 review ──
+                    if not _is_idle():
+                        break
+                    # 已 review 且没有新对话 → 跳过
+                    if _is_review_clean(name):
+                        continue
+                    # 已有 review 任务在跑 → 跳过
+                    if name in correction_tasks and not correction_tasks[name].done():
+                        continue
+                    # 最短间隔限制
+                    last_review = _maint_state.get(name, {}).get('last_review_ts')
+                    if last_review:
+                        try:
+                            elapsed = (datetime.now() - datetime.fromisoformat(last_review)).total_seconds()
+                            if elapsed < REVIEW_MIN_INTERVAL:
+                                continue
+                        except (ValueError, TypeError):
+                            logger.debug(f"[IdleMaint] {name}: last_review_ts 格式无效，视为未 review 过")
+                    logger.info(f"[IdleMaint] {name}: 空闲期间执行记忆整理")
                     try:
-                        elapsed = (datetime.now() - datetime.fromisoformat(last_review)).total_seconds()
-                        if elapsed < REVIEW_MIN_INTERVAL:
-                            continue
-                    except (ValueError, TypeError):
-                        logger.debug(f"[IdleMaint] {name}: last_review_ts 格式无效，视为未 review 过")
-                logger.info(f"[IdleMaint] {name}: 空闲期间执行记忆整理")
-                try:
-                    cancel_event = asyncio.Event()
-                    correction_cancel_flags[name] = cancel_event
-                    task = asyncio.create_task(_run_review_in_background(name))
-                    correction_tasks[name] = task
+                        cancel_event = asyncio.Event()
+                        correction_cancel_flags[name] = cancel_event
+                        task = asyncio.create_task(_run_review_in_background(name))
+                        correction_tasks[name] = task
+                    except Exception as e:
+                        logger.warning(f"[IdleMaint] {name}: 记忆整理启动失败: {e}")
+
                 except Exception as e:
-                    logger.warning(f"[IdleMaint] {name}: 记忆整理启动失败: {e}")
-
-            except Exception as e:
-                logger.debug(f"[IdleMaint] {name}: 处理失败，跳过: {e}")
-
-        # 首轮维护完成 → 恢复正常轮询间隔
-        if startup_phase:
-            startup_phase = False
-            logger.info("[IdleMaint] 启动阶段结束，恢复正常轮询间隔")
+                    logger.debug(f"[IdleMaint] {name}: 处理失败，跳过: {e}")
+        finally:
+            await asyncio.sleep(IDLE_CHECK_INTERVAL)
 
 
 # memory-evidence-rfc §3.3.6 Reconciler handlers live in
@@ -1142,15 +1160,19 @@ async def _periodic_archive_sweep_loop():
     Per-character iteration is parallel (`asyncio.gather`) — each
     character has independent files + locks; one slow char must not
     block another.
+
+    首轮启动延迟 _INITIAL_DELAY_ARCHIVE 秒（远小于 INTERVAL=3600s，确保
+    短会话用户也能跑到一次归档；之后按 INTERVAL 周期跑）。
     """
     from memory.evidence import maybe_mark_sub_zero
+    await asyncio.sleep(_INITIAL_DELAY_ARCHIVE)
     while True:
-        await asyncio.sleep(EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS)
         try:
             character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
         except Exception as e:
             logger.debug(f"[ArchiveSweep] 加载角色列表失败: {e}")
+            await asyncio.sleep(EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS)
             continue
 
         now = datetime.now()
@@ -1261,6 +1283,8 @@ async def _periodic_archive_sweep_loop():
                 *(_sweep_one(name) for name in catgirl_names),
                 return_exceptions=True,
             )
+
+        await asyncio.sleep(EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS)
 
 
 # ── memory-evidence-rfc §3.4.3: background signal extraction loop ───
@@ -1396,9 +1420,12 @@ async def _adispatch_evidence_signals(
 
 async def _periodic_signal_extraction_loop():
     """每 EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS 轮询，满足触发条件时对每个
-    catgirl 跑 Stage-1 + Stage-2 + signal dispatch（RFC §3.4.3）。"""
+    catgirl 跑 Stage-1 + Stage-2 + signal dispatch（RFC §3.4.3）。
+
+    首轮启动延迟 _INITIAL_DELAY_SIGNAL 秒（与其他后台循环错峰）。
+    """
+    await asyncio.sleep(_INITIAL_DELAY_SIGNAL)
     while True:
-        await asyncio.sleep(EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS)
         try:
             character_data = await _config_manager.aload_characters()
             catgirl_names = list(character_data.get('猫娘', {}).keys())
@@ -1490,6 +1517,8 @@ async def _periodic_signal_extraction_loop():
                 *(_signal_check_one(name) for name in catgirl_names),
                 return_exceptions=True,
             )
+
+        await asyncio.sleep(EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS)
 
 
 # ── memory-evidence-rfc §3.4.5: negative-keyword hook helpers ───────


### PR DESCRIPTION
## Summary

Memory 子系统 4 个独立 phase 的清理与重设计。前两个 phase 只是去 bug 和加防护栏，第三个是 review 调度的根本性重构，第四个开始让两个真后台 LLM 进入 thinking 模式。

### Phase A — IdleMaint 调度清理 (commit 3089bbdb)

| | 改动 |
|---|---|
| A1 | Outbox replay 启动并发 4→2，缓和 24h 停机后启动期 LLM 后端冲击 |
| A2 | **Bug fix**：IdleMaint subtask 2 (persona 矛盾审视) 不再被 `recent_memory_auto_review` 或 `REVIEW_SKIP_HISTORY_LEN` 限制——`resolve_corrections` 不读 recent history，是独立矛盾消解管线，本就不该跟 review 共用一道闸门。把 review 闸门移到 subtask 3 头部 |
| A3 | 5 个后台循环加 `_INITIAL_DELAY_*` 错峰首轮：IdleMaint 20s / Signal 60s / Rebuttal 100s / Auto-promote 150s / Archive 250s。EmbeddingWorker 自带 30s warmup gate 不动。Archive 远小于 INTERVAL=3600s，确保短会话用户也能跑到一次。顺手修了 `except: continue` 路径不 sleep 的 busy-loop 隐患 |
| A4 | Stage-2 signal detection tier `correction → summary`（与 [memory/__init__.py](memory/__init__.py) docstring 对齐）；同时把 promotion merge 从 docstring + neko-guide.md 的 summary 列表挪到 correction 列表（与 \`EVIDENCE_PROMOTION_MERGE_MODEL_TIER\` 实际值对齐）|

### Phase B — LLM timeout + max_retries 兜底 (commit f8481230)

之前所有 memory/ LLM 调用都没传 timeout，最坏走 SDK 默认 600s × max_retries=2 = **30 分钟单次调用上限**。recent.py 和 facts.py 还有业务层 retry，叠加后单次 attempt 最坏可达 1.5 小时。

按调用路径性质给每个站点加显式 timeout + max_retries=0：

| 站点 | timeout | 性质 |
|---|---|---|
| recall._fine_rank | 8s | 请求路径，上游 query_memory 5s 截断 |
| recent.compress_history / further_compress | 30s | 请求路径 |
| recent.review_history | 120s | 后台，prompt 长 |
| persona._resolve_corrections_locked | 90s | 持锁会卡 /process |
| fact_dedup._aresolve_locked | 60s | 持锁但只阻 background worker |
| facts._allm_call_with_retries | 60s | Stage-1/2/negative-keyword 共享 |
| reflection._synthesize_reflections_locked | 90s | 持锁 |
| reflection._check_feedback_locked / check_feedback_for_confirmed | 60s | 后台 |
| reflection._allm_call_promotion_merge | 45s | /process 末尾会同步等多个 |

`max_retries=0` 把重试统一收口到业务层，避免与 SDK 默认 max_retries=2 叠加翻 3 倍。

### Phase C — review 调度根本性重设计 (commit 4d4b3ab1)

**问题**：原设计下 /process /renew /settle 每次都 \`task.cancel()\` + 重启 review，高频对话用户的 review 永远跑不完。即使加 \`cancel_event\` 优雅取消也是同样问题。

**新设计**：snapshot + capacity-based 替换 + 统一 spawn gate。

#### 算法
1. **spawn 时**拍下 history 快照传给 review_history
2. **LLM 跑期间**用户路径可继续追加消息 / 触发压缩，互不干扰
3. **完成时**基于 snapshot 末尾 K=3 条 \`(type, content[:50])\` fingerprint 在当前 history 里定位 cutoff_idx
4. **逆向走出 capacity**（snapshot 末尾 vs current 末尾的连续匹配长度，遇到压缩 SystemMessage 等"alien"条目就停）
5. **替换** \`current[cutoff_idx-capacity+1 : cutoff_idx+1]\` 这 capacity 个 slot 为 \`corrected[-take_count:]\`（\`take_count = min(capacity, len(corrected))\`）
6. **cutoff 失配**（被压缩吞了 / 被 /new_dialog 清了）→ 'white' 返回 → caller 把 fingerprint 设 None → 下轮 gate 视为∞放行 → 立即重 review

#### 5 个场景验证
| 场景 | snapshot | current | corrected | 最终态 |
|---|---|---|---|---|
| 纯追加 | [m1..m15] | [m1..m17] | [m1'..m13'] | [m1'..m13', m16, m17] |
| 中段压缩 | [m1..m15] | [S, m11..m17] | [m1'..m13'] | [S, m9'..m13', m16, m17] |
| cutoff 被吞 | [m1..m15] | [S2, m17, m18] | 任意 | 白 review |
| 删条狠 | [m1..m15] | [m1..m17] | [m1', m2', m3'] | [m1', m2', m3', m16, m17] |
| corrected 比 capacity 长 | [m1..m5] | [m1..m5] | [m1'..m20'] | [m16'..m20'] |

#### 统一 spawn gate
新增 \`maybe_spawn_review(name)\`，per-name asyncio.Lock 串行化 gate+spawn 防多入口竞态。5 道闸：
- in-flight check
- \`recent_memory_auto_review\` flag
- history_len ≥ REVIEW_SKIP_HISTORY_LEN
- 距上次 review 完成 ≥ \`REVIEW_MIN_INTERVAL\`（300s → **30s**），活跃时 ×2
- 自上次 cutoff 累积 user msg ≥ \`MIN_NEW_MSGS_FOR_REVIEW = 5\`

/process /renew /settle / IdleMaint 全部改调 \`maybe_spawn_review\`，删掉所有内联 cancel-and-restart 和单点门禁。\`/cancel_correction\` / \`/new_dialog\` 仍保留主动 cancel（用户显式停止）。

review_history 输出里如果出现 SystemMessage（review 不该改写 summary 但 LLM 可能幻觉）强制丢弃，保护压缩边界。

新增持久化字段 \`_maint_state[name].last_reviewed_cutoff_tail\` (K=3 fingerprint)。

### Phase D — 开 thinking on Stage-2 + review_history (同 commit 4d4b3ab1)

锁与依赖分析后确认这两个站点开 thinking 完全在收益侧：

- **Stage-2 signal detection**: \`new_fact × existing_observation\` 关系判断 + target_id 选择，现有 [memory/facts.py:670-708](memory/facts.py:670) 的防御代码就在补 LLM 幻觉，思考能减少 target_id 错位。完全无锁、不在请求路径，开 thinking 唯一代价是同角色下一轮触发延后。timeout 拉到 90s。
- **review_history**: Phase C 重设计后不持任何 manager 锁、不阻塞用户路径、并发跑也无所谓——重写历史的判断密度高，思考受益明显。timeout 保持 120s。

实现方式：在 \`_allm_call_with_retries\` 加 \`extra_body\` 参数（默认 sentinel 表示"走 \`create_chat_llm\` 自动解析"，显式 \`None\` 表示"开 thinking"），保持 Stage-1 / negative keyword 等其他调用方行为不变。

## Test plan

- [x] \`uv run python scripts/check_no_temperature.py\` 通过（CI 守门）
- [x] memory 模块单测全过：105 passed
- [x] AST parse 全部 OK
- [x] 算法手工 5 场景验证通过：见 commit message
- [ ] 启动后日志确认 6 个后台循环按错峰跑：IdleMaint 20s / EmbeddingWorker 30s / Signal 60s / Rebuttal 100s / Auto-promote 150s / Archive 250s
- [ ] 高频对话用户 review 终于能跑完（验证 cancel-and-restart 解除）
- [ ] thinking 开启后单次 review 时长落在 30-120s 内（timeout=120 余量足够）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **优化**
  * 中央化并强化内存审核调度：快照驱动的审核触发、串行化审核门控、避免不必要的重启/取消、降低并发并引入启动延迟以均衡负载与重试行为。
  * 多处长耗时调用设定明确超时并关闭 SDK 自动重试，减少锁竞争与重试导致的延迟与不稳定性。
  * 审核结果与补丁机制改为基于容量与指纹锚定，更稳健地保留或替换记录尾部。
* **文档**
  * 更新内存子模块的层级与路由分类，调整 reflection 与 promotion 的分派映射。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->