### PR TITLE
feat(tts): 流式剥离括号与 markdown，朗读不读旁白/标记

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
 from utils.frontend_utils import contains_chinese, replace_blank, replace_corner_mark, remove_bracket, \
-    is_only_punctuation, TtsStreamNormalizer
+    is_only_punctuation, TtsStreamNormalizer, TtsBracketStripper, TtsMarkdownStripper
 from utils.screenshot_utils import process_screen_data, overlay_avatar_annotation
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.omni_offline_client import OmniOfflineClient
@@ -246,6 +246,14 @@ class LLMSessionManager:
         self._tts_stream_normalizer = TtsStreamNormalizer()
         self._tts_norm_speech_id: Optional[str] = None
         self._tts_normalize_enabled: bool = True  # 默认启用，_start_tts_thread 按 provider 类别覆盖
+        # 括号 / markdown 剥离器：朗读时不读括号内的旁白与 markdown 标记。
+        # 与 _tts_stream_normalizer 解耦——CJK 空格规范化是 provider 相关的
+        # （ws_bistream provider 关），但括号/markdown 剥离是 TTS 通用需求，
+        # 始终启用。两者串接顺序：normalizer → markdown → bracket，因为
+        # markdown 链接 ``[文本](url)`` 必须先剥成 ``文本`` 再交给 bracket，
+        # 否则 ``[`` ``]`` 会被 bracket 当成普通括号把链接文本一起吞掉。
+        self._tts_markdown_stripper = TtsMarkdownStripper()
+        self._tts_bracket_stripper = TtsBracketStripper()
         # 流式音频重采样器（24kHz→48kHz）- 维护内部状态避免 chunk 边界不连续
         self.audio_resampler = soxr.ResampleStream(24000, 48000, 1, dtype='float32')
         self.lock = asyncio.Lock()  # 使用异步锁替代同步锁
@@ -460,18 +468,31 @@ class LLMSessionManager:
         worker 退出）请继续用 ``tts_request_queue.put`` 直接发送，并在合适
         时机调用 ``_reset_tts_stream_normalizer``。
         """
+        # speech_id 切换时重置所有 stripper 状态（pending 内容属于上一轮，丢弃）
+        if speech_id != self._tts_norm_speech_id:
+            self._tts_stream_normalizer.reset()
+            self._tts_markdown_stripper.reset()
+            self._tts_bracket_stripper.reset()
+            self._tts_norm_speech_id = speech_id
+
         if self._tts_normalize_enabled:
-            if speech_id != self._tts_norm_speech_id:
-                self._tts_stream_normalizer.reset()
-                self._tts_norm_speech_id = speech_id
             text = self._tts_stream_normalizer.feed(text)
             if not text:
                 return
+        # markdown → bracket 顺序固定：链接先剥成文本再交给 bracket
+        text = self._tts_markdown_stripper.feed(text)
+        if not text:
+            return
+        text = self._tts_bracket_stripper.feed(text)
+        if not text:
+            return
         self.tts_request_queue.put((speech_id, text))
 
     def _reset_tts_stream_normalizer(self) -> None:
-        """清空 normalizer 状态。中断 / 轮次结束 / session 重建时调用。"""
+        """清空所有 TTS 文本 stripper 状态。中断 / 轮次结束 / session 重建时调用。"""
         self._tts_stream_normalizer.reset()
+        self._tts_markdown_stripper.reset()
+        self._tts_bracket_stripper.reset()
         self._tts_norm_speech_id = None
 
     def _request_tts_done_locked(self) -> str:
@@ -491,6 +512,18 @@ class LLMSessionManager:
         if not self.tts_ready or self.tts_pending_chunks:
             self._tts_done_pending_until_ready = True
             return "deferred"
+
+        # 把 markdown/bracket stripper 的 pending 兜底 emit：链 markdown.flush()
+        # → bracket.feed(...) → bracket.flush() 顺序，与 _enqueue_tts_text_chunk
+        # 的串接顺序一致。markdown.flush 把残留的孤立 marker 字符删掉再 emit；
+        # bracket.feed 处理任何残留括号字符；bracket.flush 直接 reset 不读
+        # 未闭合的括号内容。normalizer.flush 永远返回 ""，省略调用。
+        flushed = self._tts_markdown_stripper.flush()
+        if flushed:
+            flushed = self._tts_bracket_stripper.feed(flushed)
+        self._tts_bracket_stripper.flush()
+        if flushed and self._tts_norm_speech_id is not None:
+            self.tts_request_queue.put((self._tts_norm_speech_id, flushed))
 
         self.tts_request_queue.put((None, None))
         self._tts_done_queued_for_turn = True

--- a/tests/unit/test_tts_text_strippers.py
+++ b/tests/unit/test_tts_text_strippers.py
@@ -118,6 +118,34 @@ def test_bracket_stray_close_emits_literal():
     assert out == "a)b)c"
 
 
+def test_bracket_mismatched_close_does_not_close_other_type():
+    """``（旁白]继续`` 里 ``]`` 不应被当成 ``（`` 的合法闭合。
+
+    回归 CodeRabbit Major：旧版用 depth 计数，``]`` 把 ``（`` 的 depth
+    错误地减为 0，``继续`` 因此被当作括号外内容朗读出来——而旁白其实
+    没有真正闭合。type-pair stack 下 ``]`` 与 top ``）`` 不配对，作为
+    括号内标点随上下文一起丢，整个括号到 flush 才被清掉。
+    """
+    s = TtsBracketStripper()
+    out = _feed_chunks(s, ["（旁白]继续"])
+    # ``（`` 从未真正闭合 → 整段（含 ``继续``）都不应朗读出来
+    assert out == ""
+
+
+def test_bracket_mismatched_nesting_pairs_correctly():
+    """嵌套不同括号类型时按 type 配对，不会因为外层 close 提前匹配内层。"""
+    s = TtsBracketStripper()
+    # 标准嵌套：内层 ``】`` 配对内层 ``【``，外层 ``）`` 配对外层 ``（``
+    out = _feed_chunks(s, ["（中【深】中）"])
+    assert out == ""
+    # 反过来：外层 close 出现在内层未闭合时，作为括号内标点丢掉
+    s2 = TtsBracketStripper()
+    out2 = _feed_chunks(s2, ["（外【内）外】"])
+    # ``）`` 与 top ``】`` 不配对 → 丢；``】`` 配对 ``【`` → pop；
+    # ``（`` 仍未闭合 → flush 时清空，所有内容丢弃
+    assert out2 == ""
+
+
 # ============================================================================
 # TtsMarkdownStripper
 # ============================================================================
@@ -200,6 +228,41 @@ def test_markdown_link_split_across_chunks():
     s = TtsMarkdownStripper()
     out = _feed_chunks(s, ["see [doc", "s](http://x) end"])
     assert out == "see docs end"
+
+
+def test_markdown_link_split_at_bracket_paren_boundary():
+    """``[docs]`` / ``(url)`` 分两 chunk —— 不能让上一块就把 ``[docs]`` 提前 emit。
+
+    回归 CodeRabbit Major：旧版 ``_safe_split`` 只在 buf 已经包含 ``](``
+    时才 hold，所以这种刚好切在 ``]`` 后的 chunk 边界会让 ``[docs]``
+    早 emit，下游 bracket stripper 把它当成普通方括号整段吞掉，``docs``
+    根本不会朗读出来。
+    """
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["see [docs]", "(http://x) end"])
+    assert out == "see docs end"
+
+
+def test_markdown_link_split_immediately_after_close_bracket_not_link():
+    """``]`` 在 buf 末尾、下一 chunk 不是 ``(`` —— markdown 字面透传 ``[ ]``。
+
+    chunk1 末尾是 ``]`` 时 ``_safe_split`` 必须 hold（无法判断是否链接）；
+    待 chunk2 到达确认非 ``(`` 才 emit。markdown stripper 本身不剥非链接
+    的方括号，``[ref]`` 字面输出，由下游 bracket stripper 接力处理。
+    """
+    md = TtsMarkdownStripper()
+    br = TtsBracketStripper()
+    chunks = ["see [ref]", "X end"]
+    parts = []
+    for c in chunks:
+        t = md.feed(c)
+        if t:
+            parts.append(br.feed(t))
+    parts.append(br.feed(md.flush()))
+    br.flush()
+    out = "".join(parts)
+    # 链表既定设计：``[ref]`` 走 bracket 被整段吞掉，剩 ``see X end``
+    assert out == "see X end"
 
 
 def test_markdown_unclosed_bold_at_flush_strips_marker():

--- a/tests/unit/test_tts_text_strippers.py
+++ b/tests/unit/test_tts_text_strippers.py
@@ -169,6 +169,25 @@ def test_markdown_underscore_in_identifier_preserved():
     assert out == "use foo_bar variable"
 
 
+def test_markdown_underscore_emphasis_around_cjk():
+    """``你_好_`` 应作为 italic 剥离成 ``你好``——CJK 字符不算 ASCII word boundary。
+
+    回归：早期 _safe_split 用 ``str.isalnum()`` 把 CJK 当 alnum，结果开 ``_``
+    被错当 identifier 跳过、emit 后 _strip 又认成 marker——两边语义不一致
+    emphasis 漏剥（emit 出字面 ``你_好`` + 末尾 ``_`` 在 flush 删掉）。
+    """
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["你_好_"])
+    assert out == "你好"
+
+
+def test_markdown_underscore_emphasis_cjk_split_across_chunks():
+    """跨 chunk 的 CJK italic：``你_好_`` 切两片仍要正确剥离。"""
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["你_好", "_"])
+    assert out == "你好"
+
+
 def test_markdown_bold_split_across_chunks():
     """``**bold**`` 切在中间：marker 跨 chunk 时 hold pending 直到闭合。"""
     s = TtsMarkdownStripper()

--- a/tests/unit/test_tts_text_strippers.py
+++ b/tests/unit/test_tts_text_strippers.py
@@ -1,0 +1,257 @@
+"""TtsBracketStripper / TtsMarkdownStripper：流式剥离行为与跨 chunk 边界。
+
+覆盖：
+- 括号：所有半角/全角类型、嵌套、跨 chunk、未闭合 flush 处理、落单 close
+- markdown：bold/italic/strike/code/link/image/heading/list/quote、跨 chunk
+  边界（marker 被切开时延后 emit）、pending 上限兜底、flush 残留清理
+"""
+import os
+import sys
+
+import pytest
+
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from utils.frontend_utils import TtsBracketStripper, TtsMarkdownStripper
+
+
+# ============================================================================
+# TtsBracketStripper
+# ============================================================================
+
+
+def _feed_chunks(stripper, chunks):
+    """模拟流式输入：依次 feed，最后调 flush，返回拼接后的输出。"""
+    out = []
+    for c in chunks:
+        out.append(stripper.feed(c))
+    out.append(stripper.flush())
+    return "".join(out)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # 半角
+        ("hello (aside) world", "hello  world"),
+        # 全角中文括号
+        ("她（笑了笑）说道", "她说道"),
+        # 全角方括号
+        ("话题【打断】继续", "话题继续"),
+        # 全角书名号
+        ("看《三体》了吗", "看了吗"),
+        # 直角引号 / 双重直角引号
+        ("「话语」与『内容』", "与"),
+        # 角括号
+        ("〈引用〉文本", "文本"),
+        # 龟甲括号
+        ("〔注〕主体", "主体"),
+        # 全角方括号（FF3B/FF3D）
+        ("前［中间］后", "前后"),
+        # 全角圆括号
+        ("外（内部）外", "外外"),
+        # 嵌套
+        ("外（中（深）中）外", "外外"),
+        # 混型嵌套
+        ("外（中【深】中）外", "外外"),
+        # 多个独立括号
+        ("a（旁）b（白）c", "abc"),
+        # 没有括号 → passthrough
+        ("plain text 中文", "plain text 中文"),
+        # 落单的 close 不会乱吞内容
+        ("题目 50) 三分", "题目 50) 三分"),
+        # 空字符串
+        ("", ""),
+    ],
+)
+def test_bracket_one_shot(text, expected):
+    s = TtsBracketStripper()
+    assert _feed_chunks(s, [text]) == expected
+
+
+def test_bracket_split_across_chunks():
+    """``她（笑）说`` 拆 3 个 chunk 时，括号内容仍应整体丢弃。"""
+    s = TtsBracketStripper()
+    out = _feed_chunks(s, ["她（", "笑", "）说"])
+    assert out == "她说"
+
+
+def test_bracket_open_only_chunk():
+    """单独一个 ``（`` chunk 不会 emit 任何内容；后续内容被吞直到 ``）``。"""
+    s = TtsBracketStripper()
+    assert s.feed("（") == ""
+    assert s.feed("旁白") == ""
+    assert s.feed("）继续") == "继续"
+    assert s.flush() == ""
+
+
+def test_bracket_unclosed_at_flush_drops():
+    """轮次结束未闭合 → 已吞掉的内容不再补出来，flush 清零状态。"""
+    s = TtsBracketStripper()
+    assert s.feed("正常") == "正常"
+    assert s.feed("（未闭合") == ""
+    assert s.flush() == ""
+    # 状态已清零，下一轮 feed 不受影响
+    assert s.feed("新一轮") == "新一轮"
+
+
+def test_bracket_reset_clears_depth():
+    s = TtsBracketStripper()
+    s.feed("（深陷")
+    s.reset()
+    assert s.feed("正常文本") == "正常文本"
+
+
+def test_bracket_nested_split_across_chunks():
+    """嵌套括号跨 chunk：``外（中（深）``、``中）外`` → ``外外``。"""
+    s = TtsBracketStripper()
+    out = _feed_chunks(s, ["外（中（深）", "中）外"])
+    assert out == "外外"
+
+
+def test_bracket_stray_close_emits_literal():
+    """没有 open 的 close 应该按字面 emit，不污染深度状态。"""
+    s = TtsBracketStripper()
+    out = _feed_chunks(s, ["a)b)c"])
+    # 落单 ) 全部保留，内容不变
+    assert out == "a)b)c"
+
+
+# ============================================================================
+# TtsMarkdownStripper
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # bold
+        ("hello **world** end", "hello world end"),
+        ("hello __world__ end", "hello world end"),
+        # italic
+        ("a *italic* b", "a italic b"),
+        # strike
+        ("aaa ~~bbb~~ ccc", "aaa bbb ccc"),
+        # inline code
+        ("var `x` = 1", "var x = 1"),
+        # link
+        ("see [docs](https://example.com) here", "see docs here"),
+        # image 整段删
+        ("look ![cat](http://i/cat.png) up", "look  up"),
+        # heading 行首
+        ("# Title\nbody", "Title\nbody"),
+        # blockquote
+        ("> quote me\nrest", "quote me\nrest"),
+        # bullet list
+        ("- item one\n- item two", "item one\nitem two"),
+        # numbered list
+        ("1. first\n2. second", "first\nsecond"),
+        # 嵌套 markdown：bold + italic 在不同位置
+        ("**bold** and *it*", "bold and it"),
+        # 代码 fence
+        ("before\n```python\ncode here\n```\nafter", "before\n\nafter"),
+        # 没有 markdown → passthrough
+        ("纯中文内容，无任何标记。", "纯中文内容，无任何标记。"),
+        # 空字符串
+        ("", ""),
+    ],
+)
+def test_markdown_one_shot(text, expected):
+    s = TtsMarkdownStripper()
+    assert _feed_chunks(s, [text]) == expected
+
+
+def test_markdown_underscore_in_identifier_preserved():
+    """``foo_bar`` 不应被当成 italic 剥成 ``foobar``。"""
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["use foo_bar variable"])
+    assert out == "use foo_bar variable"
+
+
+def test_markdown_bold_split_across_chunks():
+    """``**bold**`` 切在中间：marker 跨 chunk 时 hold pending 直到闭合。"""
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["before **bo", "ld** after"])
+    assert out == "before bold after"
+
+
+def test_markdown_link_split_across_chunks():
+    """``[text](url)`` 切在 ``](`` 之间。"""
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["see [doc", "s](http://x) end"])
+    assert out == "see docs end"
+
+
+def test_markdown_unclosed_bold_at_flush_strips_marker():
+    """未闭合的 ``**foo``：flush 时把 ``**`` 删掉，保留 ``foo``。"""
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["text **未闭合内容"])
+    # ``**`` 被删，内容保留
+    assert out == "text 未闭合内容"
+
+
+def test_markdown_unclosed_link_at_flush_drops_brackets():
+    """未闭合的 ``[text(`` 类残骸：flush 时去掉孤立 ``[`` ``(`` 等。"""
+    s = TtsMarkdownStripper()
+    out = _feed_chunks(s, ["see [docs(http://x"])
+    # 残留孤立 marker 字符被清掉
+    assert "[" not in out and "(" not in out
+    assert "see " in out
+
+
+def test_markdown_reset_clears_pending():
+    s = TtsMarkdownStripper()
+    s.feed("before **half")  # pending 累积
+    s.reset()
+    assert s.feed("clean text") == "clean text"
+
+
+def test_markdown_pending_overflow_force_emit():
+    """pending 撑满 _MAX_PENDING 时强制 emit，不会无限累积。"""
+    s = TtsMarkdownStripper()
+    # 用大量未闭合 ``*`` 制造 pending 长期挂起
+    huge = "*" + "a" * (TtsMarkdownStripper._MAX_PENDING + 50)
+    out = s.feed(huge)
+    # 触发 overflow 兜底，强制 emit（不保证 strip 干净）
+    assert out  # 必须有输出
+    assert s._pending == ""  # pending 被清空
+
+
+def test_markdown_chained_with_bracket_link_intact():
+    """链接经 markdown 剥成纯文本后，bracket stripper 不会再吃链接文本。
+
+    模拟 _enqueue_tts_text_chunk 的串接顺序。
+    """
+    md = TtsMarkdownStripper()
+    br = TtsBracketStripper()
+    # 链接 + 全角括号旁白
+    chunks = ["看 [文档](http://x) （旁", "白）继续"]
+    out_parts = []
+    for c in chunks:
+        t = md.feed(c)
+        if t:
+            t = br.feed(t)
+        if t:
+            out_parts.append(t)
+    # flush
+    t = md.flush()
+    if t:
+        t = br.feed(t)
+        if t:
+            out_parts.append(t)
+    br.flush()
+    out = "".join(out_parts)
+    # 链接文本 ``文档`` 保留，旁白 ``（旁白）`` 整段不读
+    assert out == "看 文档 继续"
+
+
+def test_markdown_chained_with_bracket_image_dropped():
+    """图片 ``![alt](url)`` 经 markdown 整段删，bracket 不会看到任何残留。"""
+    md = TtsMarkdownStripper()
+    br = TtsBracketStripper()
+    text = "前 ![喵](http://i/cat.png) 后"
+    out = br.feed(md.feed(text))
+    out += br.feed(md.flush())
+    out += br.flush()
+    assert out == "前  后"

--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -290,6 +290,260 @@ class TtsStreamNormalizer:
         return ""
 
 
+class TtsBracketStripper:
+    """跨 chunk 安全的 TTS 括号剥离器。
+
+    括号内容连同括号本身**整体不读**（含所有半角/全角括号类型，包含
+    嵌套）。流式输入下一句 ``她（笑）说`` 可能被切成 ``她（``、``笑``、
+    ``）说`` 三个 chunk，本类用 ``depth`` 计数维持嵌套状态，跨 chunk
+    不丢失。
+
+    每个新 TTS 轮次（``speech_id`` 切换）必须调 :meth:`reset`，否则
+    上一轮悬挂的 open bracket 会把新一轮的开头一段静音掉。
+    :meth:`flush` 在 turn end 前调一次，把残留的未闭合括号 depth 直接
+    清零（半个 ``（thinking...`` 不读比读半个更安全）。
+
+    设计上和 markdown 剥离解耦：``[`` ``]`` 的"剥外壳保内容"语义留给
+    :class:`TtsMarkdownStripper` 处理（markdown 链接 ``[文本](URL)``
+    需要保留 ``文本``）。本类把 ``[`` ``]`` 视作整段不读的括号，因此
+    ``TtsMarkdownStripper`` 必须串在前面，先把链接等剥成纯文本再交给
+    本类，否则链接文本会被吃掉。
+    """
+
+    # 半角 + 全角 + 各类引用括号；刻意不含 `{` `｛` `}` `｝`
+    # （编程语境会出现，朗读时反而希望保留）。
+    _OPEN = frozenset("(（[［【〈〔《「『")
+    _CLOSE = frozenset(")）]］】〉〕》」』")
+
+    __slots__ = ("_depth",)
+
+    def __init__(self):
+        self._depth = 0
+
+    def reset(self) -> None:
+        """清空 depth。新 speech_id 或中断时调。"""
+        self._depth = 0
+
+    def feed(self, chunk: str) -> str:
+        """逐字符扫描，返回当前可 emit 的（深度为 0 之外的）文本。"""
+        if not chunk:
+            return ""
+        out = []
+        depth = self._depth
+        for c in chunk:
+            if c in self._OPEN:
+                depth += 1
+            elif c in self._CLOSE:
+                if depth > 0:
+                    depth -= 1
+                else:
+                    # 落单的 close 括号：当成普通标点 emit，避免把
+                    # ``50)`` 这种数学/列表写法的 ``)`` 整个吃掉。
+                    out.append(c)
+            elif depth == 0:
+                out.append(c)
+            # else: depth > 0，正在括号里，整个丢
+        self._depth = depth
+        return "".join(out)
+
+    def flush(self) -> str:
+        """轮次收尾：清零 depth，返回 ``""``。
+
+        未闭合括号的悬挂内容已经在 feed 阶段被丢弃，这里只需重置状态。
+        """
+        self._depth = 0
+        return ""
+
+
+class TtsMarkdownStripper:
+    """跨 chunk 安全的 markdown 剥离器（best effort）。
+
+    剥外壳保内容：``**X**`` → ``X``、``[X](url)`` → ``X`` 等。
+    覆盖以下模式（顺序 = 优先级）：
+
+    1. 三反引号 fence ``` ```lang\\nbody``` ``` → 整段丢（朗读代码无意义）
+    2. 行内 fence ``` ``X`` ``` → ``X``
+    3. 图片 ``![alt](url)`` → 整段丢（含 alt）
+    4. 链接 ``[text](url)`` → ``text``
+    5. ``**X**`` / ``__X__`` → ``X``
+    6. ``*X*`` / ``_X_`` → ``X``（``_`` 严格要求两侧非字母数字，避开变量名）
+    7. ``~~X~~`` → ``X``
+    8. 行首 ``#``/``##``/...``/``>``/``-``/``*``/``\\d+.`` 列表/标题/引用前缀 → 删
+
+    流式策略：用 ``_safe_split`` 找出"从最早未配对的 marker 起到 buf 末"的位置，
+    那段 hold 成 pending 等下个 chunk；前面的 emit。pending 上限 ``_MAX_PENDING``
+    防止模型半天不闭合一直憋着——超限就强制 emit + reset，避免内存膨胀。
+    :meth:`flush` 在 turn end 前调一次，把 pending strip 一遍并把残留的孤立
+    marker 字符（``*`` ``_`` ``~`` ``\\``` ``[`` ``]`` ``(`` ``)``）删掉再 emit。
+
+    刻意 best effort：嵌套 emphasis、跨 fence 的复杂场景不保证完美——LLM
+    很少这么写，过度工程化得不偿失。完全不会"吃"用户内容（坏情况只是漏剥）。
+    """
+
+    __slots__ = ("_pending",)
+
+    # pending 字节上限，防止模型不闭合时无限累加。超限直接 emit + reset。
+    _MAX_PENDING = 256
+
+    # 多字符 marker（必须先于单字符匹配，否则 ``**`` 会被算成两个 ``*``）。
+    _MULTI_MARKERS = ("```", "**", "__", "~~")
+    _SINGLE_MARKERS = ("*", "_", "~", "`")
+
+    # _strip 用的完整正则模式（顺序敏感）
+    _PATTERNS = (
+        # 多行 fence（含语言标签）整段删
+        (re.compile(r"```[^\n]*\n[\s\S]*?```"), ""),
+        # 行内 fence 保留内容
+        (re.compile(r"```([^`\n]*?)```"), r"\1"),
+        # 图片整段删（包括 alt 文本，避免朗读 "alt-text"）
+        (re.compile(r"!\[[^\]]*?\]\([^)]*?\)"), ""),
+        # 链接保留 text，丢 url
+        (re.compile(r"\[([^\]]+?)\]\([^)]*?\)"), r"\1"),
+        # bold（先于 italic 处理，避免 ``**X**`` 被当成两个 ``*X*``）
+        (re.compile(r"\*\*([^*\n]+?)\*\*"), r"\1"),
+        (re.compile(r"__([^_\n]+?)__"), r"\1"),
+        # italic
+        (re.compile(r"(?<!\*)\*([^*\n]+?)\*(?!\*)"), r"\1"),
+        # ``_`` 两侧必须非字母数字，否则会吃掉 ``foo_bar`` 这种变量名
+        (re.compile(r"(?<![A-Za-z0-9_])_([^_\n]+?)_(?![A-Za-z0-9_])"), r"\1"),
+        # strikethrough
+        (re.compile(r"~~([^~\n]+?)~~"), r"\1"),
+        # inline code
+        (re.compile(r"`+([^`\n]+?)`+"), r"\1"),
+        # 行首 marker（heading / blockquote / list）
+        (re.compile(r"(?m)^[ \t]*(?:#{1,6}|>+|[-*+]|\d+\.)[ \t]+"), ""),
+    )
+
+    # flush 兜底：删掉残留的孤立 marker 字符
+    _DANGLING_RE = re.compile(r"[*_~`\[\]()]+")
+
+    def __init__(self):
+        self._pending = ""
+
+    def reset(self) -> None:
+        """清空 pending。新 speech_id 或中断时调。"""
+        self._pending = ""
+
+    def feed(self, chunk: str) -> str:
+        """喂入新 chunk，返回当前可安全 emit 的已剥离文本。"""
+        if not chunk:
+            return ""
+        buf = self._pending + chunk
+
+        # pending 撑满兜底：模型一直不闭合时强制 emit + reset，避免内存膨胀
+        if len(buf) > self._MAX_PENDING:
+            out = self._strip(buf)
+            self._pending = ""
+            return out
+
+        split = self._safe_split(buf)
+        emit = buf[:split]
+        self._pending = buf[split:]
+
+        if not emit:
+            return ""
+        return self._strip(emit)
+
+    def flush(self) -> str:
+        """轮次收尾：strip pending，再删掉残留的孤立 marker 字符后 emit。"""
+        if not self._pending:
+            return ""
+        out = self._strip(self._pending)
+        out = self._DANGLING_RE.sub("", out)
+        self._pending = ""
+        return out
+
+    @classmethod
+    def _safe_split(cls, buf: str) -> int:
+        """找出 buf 中"从最早未配对 marker 到末尾"的起点。
+
+        前面的部分是"已经能确定不会被后续 chunk 改变"的，可以直接 emit；
+        从这个位置起到 buf 末是 pending，等更多 chunk 决定如何 strip。
+        """
+        split = len(buf)
+        work = list(buf)
+
+        # 多字符 marker：parity 检查。配对的 black-out，避免单字符再次计入。
+        for marker in cls._MULTI_MARKERS:
+            mlen = len(marker)
+            positions = []
+            i = 0
+            current = "".join(work)
+            while True:
+                j = current.find(marker, i)
+                if j < 0:
+                    break
+                positions.append(j)
+                i = j + mlen
+            if not positions:
+                continue
+            if len(positions) % 2:
+                # 末尾一个未配对，从它起 hold
+                split = min(split, positions[-1])
+                paired = positions[:-1]
+            else:
+                paired = positions
+            for p in paired:
+                for k in range(mlen):
+                    if 0 <= p + k < len(work):
+                        work[p + k] = "\0"
+
+        # 单字符 marker（已 black-out 多字符配对的视图）
+        work_str = "".join(work)
+        for marker in cls._SINGLE_MARKERS:
+            if marker == "_":
+                # ``_`` 两侧紧贴 alnum 时属于 identifier（``foo_bar``），不当 italic marker。
+                # 与 _strip 的 italic underscore 正则的 lookbehind/lookahead 保持一致。
+                positions = []
+                for i, c in enumerate(work_str):
+                    if c != "_":
+                        continue
+                    left_alnum = i > 0 and (work_str[i - 1].isalnum() or work_str[i - 1] == "_")
+                    right_alnum = (
+                        i + 1 < len(work_str)
+                        and (work_str[i + 1].isalnum() or work_str[i + 1] == "_")
+                    )
+                    if left_alnum and right_alnum:
+                        continue  # identifier 内的 _，不算 marker
+                    positions.append(i)
+            else:
+                positions = [i for i, c in enumerate(work_str) if c == marker]
+            if len(positions) % 2:
+                split = min(split, positions[-1])
+
+        # ``[ ]`` 配对
+        stack = []
+        for i, c in enumerate(work_str):
+            if c == "[":
+                stack.append(i)
+            elif c == "]" and stack:
+                stack.pop()
+        if stack:
+            split = min(split, stack[0])
+
+        # ``](`` 后未见 ``)`` —— 链接 URL 还没写完
+        idx = 0
+        while True:
+            j = work_str.find("](", idx)
+            if j < 0:
+                break
+            close = work_str.find(")", j + 2)
+            if close < 0:
+                bracket_pos = work_str.rfind("[", 0, j)
+                if bracket_pos >= 0:
+                    split = min(split, bracket_pos)
+                break
+            idx = close + 1
+
+        return max(0, split)
+
+    @classmethod
+    def _strip(cls, text: str) -> str:
+        for pat, repl in cls._PATTERNS:
+            text = pat.sub(repl, text)
+        return text
+
+
 def is_only_punctuation(text):
     # Regular expression: Match strings that consist only of punctuation marks or are empty.
     punctuation_pattern = r'^[\p{P}\p{S}]*$'

--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -310,48 +310,67 @@ class TtsBracketStripper:
     本类，否则链接文本会被吃掉。
     """
 
-    # 半角 + 全角 + 各类引用括号；刻意不含 `{` `｛` `}` `｝`
-    # （编程语境会出现，朗读时反而希望保留）。
-    _OPEN = frozenset("(（[［【〈〔《「『")
-    _CLOSE = frozenset(")）]］】〉〕》」』")
+    # 半角 + 全角 + 各类引用括号 → 配对的 close。刻意不含 `{` `｛`
+    # `}` `｝`（编程语境会出现，朗读时反而希望保留）。
+    _PAIRS = {
+        "(": ")",
+        "（": "）",
+        "[": "]",
+        "［": "］",
+        "【": "】",
+        "〈": "〉",
+        "〔": "〕",
+        "《": "》",
+        "「": "」",
+        "『": "』",
+    }
+    _OPEN = frozenset(_PAIRS.keys())
+    _CLOSE = frozenset(_PAIRS.values())
 
-    __slots__ = ("_depth",)
+    __slots__ = ("_stack",)
 
     def __init__(self):
-        self._depth = 0
+        self._stack = []
 
     def reset(self) -> None:
-        """清空 depth。新 speech_id 或中断时调。"""
-        self._depth = 0
+        """清空 opener stack。新 speech_id 或中断时调。"""
+        self._stack.clear()
 
     def feed(self, chunk: str) -> str:
-        """逐字符扫描，返回当前可 emit 的（深度为 0 之外的）文本。"""
+        """逐字符扫描，返回当前可 emit 的文本（opener stack 非空时为空）。
+
+        opener stack 替代单纯 depth 计数，做 type-pair 校验：close 只有
+        与 stack 顶 opener 配对时才弹栈，否则按字面 emit（depth 0 时）
+        或随括号内容一起丢（depth > 0 时）。这样 ``（旁白]继续`` 里的
+        ``]`` 不会被误当成 ``（`` 的合法闭合而提前结束括号态。
+        """
         if not chunk:
             return ""
         out = []
-        depth = self._depth
+        stack = self._stack
         for c in chunk:
             if c in self._OPEN:
-                depth += 1
+                stack.append(self._PAIRS[c])
             elif c in self._CLOSE:
-                if depth > 0:
-                    depth -= 1
-                else:
+                if stack and stack[-1] == c:
+                    stack.pop()
+                elif not stack:
                     # 落单的 close 括号：当成普通标点 emit，避免把
                     # ``50)`` 这种数学/列表写法的 ``)`` 整个吃掉。
                     out.append(c)
-            elif depth == 0:
+                # else: 在括号内但与 top opener 不配对（``（旁白]``），
+                # 当成括号内的一个标点字符随上下文一起丢。
+            elif not stack:
                 out.append(c)
-            # else: depth > 0，正在括号里，整个丢
-        self._depth = depth
+            # else: 在括号里，整个丢
         return "".join(out)
 
     def flush(self) -> str:
-        """轮次收尾：清零 depth，返回 ``""``。
+        """轮次收尾：清空 stack，返回 ``""``。
 
         未闭合括号的悬挂内容已经在 feed 阶段被丢弃，这里只需重置状态。
         """
-        self._depth = 0
+        self._stack.clear()
         return ""
 
 
@@ -516,29 +535,36 @@ class TtsMarkdownStripper:
             if len(positions) % 2:
                 split = min(split, positions[-1])
 
-        # ``[ ]`` 配对
-        stack = []
-        for i, c in enumerate(work_str):
+        # ``[ ... ]`` 链接识别：从最早未确认非链接的 ``[`` 起 hold pending。
+        # 必须在 ``]`` 之后看到非 ``(`` 字符才能确认"不是链接"——否则
+        # chunk1 = ``...[docs]`` / chunk2 = ``(url)`` 这种切法会让上一块
+        # 把 ``[docs]`` 提前 emit 给下游 bracket stripper，被当成普通方括
+        # 号整段吞掉，``docs`` 永远朗读不出来。``](`` 已出现且 ``)`` 未到
+        # 时同样 hold（链接 URL 还没写完）。
+        positions = []
+        i = 0
+        while i < len(work_str):
+            c = work_str[i]
             if c == "[":
-                stack.append(i)
-            elif c == "]" and stack:
-                stack.pop()
-        if stack:
-            split = min(split, stack[0])
-
-        # ``](`` 后未见 ``)`` —— 链接 URL 还没写完
-        idx = 0
-        while True:
-            j = work_str.find("](", idx)
-            if j < 0:
-                break
-            close = work_str.find(")", j + 2)
-            if close < 0:
-                bracket_pos = work_str.rfind("[", 0, j)
-                if bracket_pos >= 0:
-                    split = min(split, bracket_pos)
-                break
-            idx = close + 1
+                positions.append(i)
+                i += 1
+            elif c == "]" and positions:
+                if i + 1 >= len(work_str):
+                    break  # ``]`` 在 buf 末尾，下个 chunk 可能是 ``(`` → hold
+                if work_str[i + 1] == "(":
+                    close = work_str.find(")", i + 2)
+                    if close < 0:
+                        break  # ``](url`` 还没闭合 → hold from ``[``
+                    positions.pop()
+                    i = close + 1
+                else:
+                    # ``]X`` 且 X != ``(`` → 不是链接，settled
+                    positions.pop()
+                    i += 1
+            else:
+                i += 1
+        if positions:
+            split = min(split, positions[0])
 
         return max(0, split)
 

--- a/utils/frontend_utils.py
+++ b/utils/frontend_utils.py
@@ -492,16 +492,21 @@ class TtsMarkdownStripper:
         work_str = "".join(work)
         for marker in cls._SINGLE_MARKERS:
             if marker == "_":
-                # ``_`` 两侧紧贴 alnum 时属于 identifier（``foo_bar``），不当 italic marker。
-                # 与 _strip 的 italic underscore 正则的 lookbehind/lookahead 保持一致。
+                # ``_`` 两侧紧贴 ASCII alnum 时属于 identifier（``foo_bar``），不当 italic marker。
+                # 边界判定必须与 _strip 的 italic underscore 正则严格对齐：
+                # 那里用 ``[A-Za-z0-9_]``（ASCII-only），CJK / 西里尔等
+                # Unicode letter 不算 word boundary。如果这里改用
+                # ``str.isalnum()``（含 CJK），``你_好_`` 的开 `_` 在 split
+                # 阶段会被误判成 identifier 跳过，结果整段 emit 后 _strip
+                # 又把它认成 marker——两边语义不一致 emphasis 漏剥。
                 positions = []
                 for i, c in enumerate(work_str):
                     if c != "_":
                         continue
-                    left_alnum = i > 0 and (work_str[i - 1].isalnum() or work_str[i - 1] == "_")
+                    left_alnum = i > 0 and cls._is_ascii_word_char(work_str[i - 1])
                     right_alnum = (
                         i + 1 < len(work_str)
-                        and (work_str[i + 1].isalnum() or work_str[i + 1] == "_")
+                        and cls._is_ascii_word_char(work_str[i + 1])
                     )
                     if left_alnum and right_alnum:
                         continue  # identifier 内的 _，不算 marker
@@ -542,6 +547,15 @@ class TtsMarkdownStripper:
         for pat, repl in cls._PATTERNS:
             text = pat.sub(repl, text)
         return text
+
+    @staticmethod
+    def _is_ascii_word_char(c: str) -> bool:
+        """ASCII ``[A-Za-z0-9_]`` 字符判定，刻意不含 CJK / 其他 Unicode letter。
+
+        必须与 _PATTERNS 里 italic underscore 正则的 ``[A-Za-z0-9_]`` 字符类
+        语义一致——不要换成 ``str.isalnum()``（会把 CJK / Cyrillic 等当 alnum）。
+        """
+        return ("a" <= c <= "z") or ("A" <= c <= "Z") or ("0" <= c <= "9") or c == "_"
 
 
 def is_only_punctuation(text):


### PR DESCRIPTION
## Summary

- 新增 `TtsBracketStripper` / `TtsMarkdownStripper`（[utils/frontend_utils.py](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/priceless-khayyam-8aba2f/utils/frontend_utils.py)），串接在 `_enqueue_tts_text_chunk` 的现有 `TtsStreamNormalizer` 之后：`normalizer → markdown → bracket`。聊天气泡显示原文不变，TTS 不读括号内容与 markdown 标记。
- 括号支持全部半/全角类型 + 嵌套：`()` `（）` `[]` `［］` `【】` `〈〉` `〔〕` `《》` `「」` `『』`（刻意不含 `{}` 编程语境字符）；落单 close 当字面标点 emit 不吞内容。
- Markdown 是 best effort：`**bold** __b__ *it* _it_ ~~s~~ \`code\` [text](url) ![alt] \`\`\`fence\`\`\` 行首 `# > - * 1.`。`_` 在 identifier (`foo_bar`) 内不当 italic marker。
- 流式语义：speech_id 切换时三个 stripper 一起 reset；turn end 在 `(None, None)` 哨兵之前链式 flush（markdown 残留的 pending → bracket.feed → bracket.flush），未闭合括号内容直接丢，未闭合 markdown marker 字符在 flush 时删掉再 emit。

## 设计要点

- **顺序固定 markdown → bracket**：链接 `[文本](url)` 必须先剥成 `文本`，否则 `[ ]` 会被 bracket stripper 当成普通括号把链接文本一起吞掉。
- **始终启用，不受 `_tts_normalize_enabled` 影响**：现有 normalizer 对 ws_bistream provider（qwen / step / cosyvoice）关掉，因为服务端做 CJK 空格规范化；但服务端**不会**剥括号/markdown，所以这两个 stripper 必须独立，对所有 provider 启用。
- **pending 上限 256 字符**：防止模型不闭合时无限累积内存。
- **括号 flush 不补出来已吞内容**：半个 `（thinking...` 不读比读半个更安全；与现有"语速 fence + role hallucination guard"等丢弃语义一致。

## Test plan

- [x] `pytest tests/unit/test_tts_text_strippers.py` → 45 passed（括号 21 + markdown 24，含跨 chunk、嵌套、未闭合、落单 close、identifier 保护、pending overflow、与 bracket 链式协作）
- [x] `pytest tests/unit/test_tts_*.py` → 108 passed（含相邻的现有 `TtsStreamNormalizer` / `tts_language_hint` 测试，无 regress）
- [x] `python -c "import main_logic.core; from utils.frontend_utils import TtsBracketStripper, TtsMarkdownStripper"` → import 干净
- [ ] 实际跑一轮文本对话，让 LLM 产生 `（动作）` 旁白和 `**重点**` 标记，验证：聊天气泡显示完整原文 + TTS 朗读跳过标记

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强 TTS 预处理：在合成前按顺序移除 Markdown 标记（保留链接文字、删除图片等）并剥离各类括号与内嵌旁白，支持跨分块处理与刷新以避免串流残余。
* **测试**
  * 新增全面单元测试，覆盖分块边界、未闭合标记、嵌套/多种括号及溢出行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->