### PR TITLE
fix: restore character card manager preview behavior

### DIFF
--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -644,6 +644,75 @@ def find_preview_image_in_folder(folder_path):
     return None
 
 
+def _build_workshop_card_face_meta(item: dict) -> dict:
+    workshop_author = ''
+    try:
+        workshop_author = str(item.get('authorName') or item.get('author') or item.get('creatorName') or '').strip()[:64]
+    except Exception:
+        workshop_author = ''
+
+    now_iso = datetime.utcnow().isoformat() + 'Z'
+    return {
+        'author': workshop_author,
+        'origin': 'steam',
+        'created_at': now_iso,
+        'updated_at': now_iso,
+    }
+
+
+def _is_matching_workshop_character(catgirl_data: dict, item_id) -> bool:
+    if not isinstance(catgirl_data, dict):
+        return False
+
+    try:
+        source = str(get_reserved(catgirl_data, 'character_origin', 'source', default='') or '').strip()
+        if source != 'steam_workshop':
+            return False
+
+        current_item_id = str(item_id or '').strip()
+        if not current_item_id:
+            return True
+
+        source_id = str(get_reserved(catgirl_data, 'character_origin', 'source_id', default='') or '').strip()
+        return source_id == current_item_id
+    except Exception:
+        return False
+
+
+def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview_image_path: str | None) -> bool:
+    if not preview_image_path or not os.path.isfile(preview_image_path):
+        return False
+    if not config_mgr.ensure_card_faces_directory():
+        return False
+
+    face_path = config_mgr.card_faces_dir / f"{chara_name}.png"
+    if face_path.exists():
+        return False
+
+    from PIL import Image as PILImage, ImageOps
+
+    with PILImage.open(preview_image_path) as img:
+        img = ImageOps.exif_transpose(img)
+        if img.mode not in ('RGB', 'RGBA', 'L'):
+            has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
+            img = img.convert('RGBA' if has_alpha else 'RGB')
+        img.save(face_path, format='PNG')
+
+    return True
+
+
+def _ensure_workshop_card_face_meta(config_mgr, chara_name: str, item: dict) -> bool:
+    if not config_mgr.ensure_card_faces_directory():
+        return False
+
+    meta_path = config_mgr.card_face_meta_path(chara_name)
+    if meta_path.exists():
+        return False
+
+    atomic_write_json(meta_path, _build_workshop_card_face_meta(item), ensure_ascii=False, indent=2)
+    return True
+
+
 def _sanitize_voice_prefix(prefix: str, default_prefix: str = 'voice') -> str:
     normalized = ''.join(ch for ch in str(prefix or '') if ch.isascii() and ch.isalnum())[:10]
     if normalized:
@@ -3821,9 +3890,10 @@ async def sync_workshop_character_cards() -> dict:
     可在服务器启动时直接调用，无需等待用户打开创意工坊管理页面。
     
     Returns:
-        dict: {"added": int, "skipped": int, "errors": int}
+        dict: {"added": int, "backfilled_faces": int, "skipped": int, "errors": int}
     """
     added_count = 0
+    backfilled_face_count = 0
     skipped_count = 0
     error_count = 0
     
@@ -3835,22 +3905,22 @@ async def sync_workshop_character_cards() -> dict:
         if isinstance(items_result, JSONResponse):
             # JSONResponse — 说明出错了，直接返回
             logger.warning("sync_workshop_character_cards: 获取订阅物品失败（返回了 JSONResponse）")
-            return {"added": 0, "skipped": 0, "errors": 1}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 1}
         
         if not isinstance(items_result, dict) or not items_result.get('success'):
             logger.warning("sync_workshop_character_cards: 获取订阅物品失败")
-            return {"added": 0, "skipped": 0, "errors": 1}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 1}
         
         subscribed_items = items_result.get('items', [])
         if not subscribed_items:
             logger.info("sync_workshop_character_cards: 没有订阅物品，跳过同步")
-            return {"added": 0, "skipped": 0, "errors": 0}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 0}
         
         config_mgr = get_config_manager()
 
         if is_write_fence_active(config_mgr):
             logger.info("sync_workshop_character_cards: 检测到维护态写围栏，跳过本轮同步并等待后续重试")
-            return {"added": 0, "skipped": 0, "errors": 0, "blocked_by_write_fence": True}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 0, "blocked_by_write_fence": True}
         
         # 使用全局锁序列化 load_characters -> save_characters 流程，防止并发覆写
         async with _ugc_sync_lock:
@@ -3868,6 +3938,7 @@ async def sync_workshop_character_cards() -> dict:
                     continue
                 
                 item_id = item.get('publishedFileId', '')
+                preview_image_path = find_preview_image_in_folder(installed_folder)
                 
                 # 3. 扫描 .chara.json 文件（递归遍历子目录）
                 try:
@@ -3901,6 +3972,35 @@ async def sync_workshop_character_cards() -> dict:
                             # 已存在则跳过（当前设计：仅填充缺失角色卡，不覆盖已有数据；
                             # 如需支持创意工坊更新覆写本地数据，可添加 allow_workshop_overwrite 配置项）
                             if chara_name in characters['猫娘']:
+                                existing_data = characters['猫娘'].get(chara_name) or {}
+                                if _is_matching_workshop_character(existing_data, item_id):
+                                    try:
+                                        face_created = await asyncio.to_thread(
+                                            _ensure_workshop_card_face_from_preview,
+                                            config_mgr,
+                                            chara_name,
+                                            preview_image_path,
+                                        )
+                                        if face_created:
+                                            backfilled_face_count += 1
+                                            logger.info(
+                                                "sync_workshop_character_cards: 已回填角色卡封面 '%s' (来自物品 %s)",
+                                                chara_name,
+                                                item_id,
+                                            )
+                                            await asyncio.to_thread(
+                                                _ensure_workshop_card_face_meta,
+                                                config_mgr,
+                                                chara_name,
+                                                item,
+                                            )
+                                    except Exception as face_err:
+                                        logger.warning(
+                                            "sync_workshop_character_cards: 回填角色卡封面失败 %s (物品 %s): %s",
+                                            chara_name,
+                                            item_id,
+                                            face_err,
+                                        )
                                 skipped_count += 1
                                 continue
                             
@@ -3974,26 +4074,33 @@ async def sync_workshop_character_cards() -> dict:
                             added_count += 1
                             logger.info(f"sync_workshop_character_cards: 添加角色卡 '{chara_name}' (来自物品 {item_id})")
 
-                            # 写入卡面元数据 sidecar（origin=steam）
+                            # 同步生成本地卡面和 sidecar，前端封面只认 card_faces/{name}.png
                             try:
-                                config_mgr.ensure_card_faces_directory()
-                                meta_path = config_mgr.card_face_meta_path(chara_name)
-                                if not meta_path.exists():
-                                    workshop_author = ''
-                                    try:
-                                        workshop_author = str(item.get('authorName') or item.get('author') or item.get('creatorName') or '').strip()[:64]
-                                    except Exception:
-                                        workshop_author = ''
-                                    now_iso = datetime.utcnow().isoformat() + 'Z'
-                                    meta = {
-                                        'author': workshop_author,
-                                        'origin': 'steam',
-                                        'created_at': now_iso,
-                                        'updated_at': now_iso,
-                                    }
-                                    await atomic_write_json_async(meta_path, meta, ensure_ascii=False, indent=2)
-                            except Exception as meta_err:
-                                logger.warning(f"sync_workshop_character_cards: 写入卡面元数据失败 {chara_name}: {meta_err}")
+                                face_created = await asyncio.to_thread(
+                                    _ensure_workshop_card_face_from_preview,
+                                    config_mgr,
+                                    chara_name,
+                                    preview_image_path,
+                                )
+                                if face_created:
+                                    logger.info(
+                                        "sync_workshop_character_cards: 已生成角色卡封面 '%s' (来自物品 %s)",
+                                        chara_name,
+                                        item_id,
+                                    )
+                                await asyncio.to_thread(
+                                    _ensure_workshop_card_face_meta,
+                                    config_mgr,
+                                    chara_name,
+                                    item,
+                                )
+                            except Exception as face_meta_err:
+                                logger.warning(
+                                    "sync_workshop_character_cards: 补写角色卡封面或元数据失败 %s (物品 %s): %s",
+                                    chara_name,
+                                    item_id,
+                                    face_meta_err,
+                                )
                             
                         except Exception as e:
                             logger.warning(f"sync_workshop_character_cards: 处理文件 {chara_file_path} 失败: {e}")
@@ -4007,15 +4114,15 @@ async def sync_workshop_character_cards() -> dict:
             if need_save:
                 if is_write_fence_active(config_mgr):
                     logger.info("sync_workshop_character_cards: 保存前检测到维护态写围栏，跳过本轮同步并等待后续重试")
-                    return {"added": 0, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
+                    return {"added": 0, "backfilled_faces": backfilled_face_count, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
 
                 try:
                     await config_mgr.asave_characters(characters)
                 except MaintenanceModeError:
                     logger.info("sync_workshop_character_cards: 保存时进入维护态写围栏，跳过本轮同步并等待后续重试")
-                    return {"added": 0, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
+                    return {"added": 0, "backfilled_faces": backfilled_face_count, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
 
-                logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡")
+                logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡，回填 {backfilled_face_count} 个封面")
                 
                 try:
                     initialize_character_data = get_initialize_character_data()
@@ -4025,13 +4132,16 @@ async def sync_workshop_character_cards() -> dict:
                 except Exception as e:
                     logger.warning(f"sync_workshop_character_cards: 重新加载角色配置失败: {e}")
             else:
-                logger.info("sync_workshop_character_cards: 无需更新，所有角色卡已存在")
+                if backfilled_face_count > 0:
+                    logger.info(f"sync_workshop_character_cards: 无新增角色卡，但已回填 {backfilled_face_count} 个封面")
+                else:
+                    logger.info("sync_workshop_character_cards: 无需更新，所有角色卡已存在")
         
     except Exception as e:
         logger.error(f"sync_workshop_character_cards: 同步过程出错: {e}", exc_info=True)
         error_count += 1
     
-    return {"added": added_count, "skipped": skipped_count, "errors": error_count}
+    return {"added": added_count, "backfilled_faces": backfilled_face_count, "skipped": skipped_count, "errors": error_count}
 
 
 @router.post('/sync-characters')
@@ -4050,6 +4160,7 @@ async def api_sync_workshop_character_cards():
                     "code": "WRITE_FENCE_ACTIVE",
                     "error": "当前处于存储维护态，暂时不能同步创意工坊角色卡，请稍后重试。",
                     "added": result.get("added", 0),
+                    "backfilled_faces": result.get("backfilled_faces", 0),
                     "skipped": result.get("skipped", 0),
                     "errors": result.get("errors", 0),
                 },
@@ -4057,9 +4168,14 @@ async def api_sync_workshop_character_cards():
         return {
             "success": True,
             "added": result["added"],
+            "backfilled_faces": result.get("backfilled_faces", 0),
             "skipped": result["skipped"],
             "errors": result["errors"],
-            "message": f"同步完成：新增 {result['added']} 个角色卡，跳过 {result['skipped']} 个已存在，{result['errors']} 个错误"
+            "message": (
+                f"同步完成：新增 {result['added']} 个角色卡，"
+                f"回填 {result.get('backfilled_faces', 0)} 个封面，"
+                f"跳过 {result['skipped']} 个已存在，{result['errors']} 个错误"
+            )
         }
     except Exception as e:
         logger.error(f"API sync-characters 失败: {e}")

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -13,6 +13,7 @@ import os
 import sys
 import json
 import time
+import tempfile
 import asyncio
 import threading
 import mimetypes
@@ -670,10 +671,9 @@ def _is_matching_workshop_character(catgirl_data: dict, item_id) -> bool:
             return False
 
         current_item_id = str(item_id or '').strip()
-        if not current_item_id:
-            return True
-
         source_id = str(get_reserved(catgirl_data, 'character_origin', 'source_id', default='') or '').strip()
+        if not current_item_id or not source_id:
+            return False
         return source_id == current_item_id
     except Exception:
         return False
@@ -691,12 +691,29 @@ def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview
 
     from PIL import Image as PILImage, ImageOps
 
-    with PILImage.open(preview_image_path) as img:
-        img = ImageOps.exif_transpose(img)
-        if img.mode not in ('RGB', 'RGBA', 'L'):
-            has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
-            img = img.convert('RGBA' if has_alpha else 'RGB')
-        img.save(face_path, format='PNG')
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f".{face_path.name}.",
+        suffix=".tmp",
+        dir=str(face_path.parent),
+    )
+
+    try:
+        with os.fdopen(fd, 'w+b') as temp_file:
+            with PILImage.open(preview_image_path) as img:
+                img = ImageOps.exif_transpose(img)
+                if img.mode not in ('RGB', 'RGBA', 'L'):
+                    has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
+                    img = img.convert('RGBA' if has_alpha else 'RGB')
+                img.save(temp_file, format='PNG')
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, face_path)
+    except Exception:
+        try:
+            os.remove(temp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
     return True
 
@@ -3981,6 +3998,12 @@ async def sync_workshop_character_cards() -> dict:
                                             chara_name,
                                             preview_image_path,
                                         )
+                                        meta_created = await asyncio.to_thread(
+                                            _ensure_workshop_card_face_meta,
+                                            config_mgr,
+                                            chara_name,
+                                            item,
+                                        )
                                         if face_created:
                                             backfilled_face_count += 1
                                             logger.info(
@@ -3988,15 +4011,15 @@ async def sync_workshop_character_cards() -> dict:
                                                 chara_name,
                                                 item_id,
                                             )
-                                            await asyncio.to_thread(
-                                                _ensure_workshop_card_face_meta,
-                                                config_mgr,
+                                        if meta_created:
+                                            logger.info(
+                                                "sync_workshop_character_cards: 已补写角色卡封面元数据 '%s' (来自物品 %s)",
                                                 chara_name,
-                                                item,
+                                                item_id,
                                             )
                                     except Exception as face_err:
                                         logger.warning(
-                                            "sync_workshop_character_cards: 回填角色卡封面失败 %s (物品 %s): %s",
+                                            "sync_workshop_character_cards: 回填角色卡封面或元数据失败 %s (物品 %s): %s",
                                             chara_name,
                                             item_id,
                                             face_err,

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -3598,14 +3598,14 @@ margin-top: 10px;
 }
 
 /* 角色卡标签展示区外框（使用更高特异性选择器替代 !important） */
-#character-cards-content #character-card-tags-wrapper {
+#character-card-tags-wrapper {
     display: flex;
     align-items: center;
     border: 2px solid #b3e5fc;
     border-radius: 50px;
     background: #fff;
     flex: 1;
-    width: 100%;
+    width: auto;
     max-width: 100%;
     min-width: 0;
     min-height: 44px;
@@ -3620,13 +3620,13 @@ margin-top: 10px;
     -ms-overflow-style: none;
 }
 
-#character-cards-content #character-card-tags-wrapper::-webkit-scrollbar {
+#character-card-tags-wrapper::-webkit-scrollbar {
     width: 0;
     height: 0;
     display: none;
 }
 
-#character-cards-content #character-card-tags-container {
+#character-card-tags-container {
     width: max-content;
     min-width: max-content;
     min-height: 100%;
@@ -3634,7 +3634,7 @@ margin-top: 10px;
     align-content: center;
 }
 
-#character-cards-content #character-card-tags-container .tag {
+#character-card-tags-container .tag {
     flex: 0 0 auto;
     white-space: nowrap;
 }

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -598,10 +598,10 @@ if (characterCardTagInput) {
 }
 
 function updateCharacterCardTagScrollControls() {
-    const wrapper = document.getElementById('character-card-tags-wrapper');
-    const leftButton = document.getElementById('character-card-tags-scroll-left');
-    const rightButton = document.getElementById('character-card-tags-scroll-right');
-    if (!wrapper || !leftButton || !rightButton) return;
+    const controls = ensureCharacterCardTagScrollControls();
+    if (!controls) return;
+
+    const { wrapper, leftButton, rightButton } = controls;
 
     const hasOverflow = (wrapper.scrollWidth - wrapper.clientWidth) > 2;
     const atStart = wrapper.scrollLeft <= 2;
@@ -611,6 +611,79 @@ function updateCharacterCardTagScrollControls() {
     rightButton.classList.toggle('is-hidden', !hasOverflow);
     leftButton.disabled = !hasOverflow || atStart;
     rightButton.disabled = !hasOverflow || atEnd;
+}
+
+function createCharacterCardTagScrollButton(direction) {
+    const isLeft = direction < 0;
+    const button = document.createElement('button');
+    const labelKey = isLeft ? 'steam.scrollTagsLeftAriaLabel' : 'steam.scrollTagsRightAriaLabel';
+    const fallbackLabel = isLeft ? '向左滚动标签' : '向右滚动标签';
+
+    button.type = 'button';
+    button.id = isLeft ? 'character-card-tags-scroll-left' : 'character-card-tags-scroll-right';
+    button.className = 'tag-scroll-button is-hidden';
+    button.textContent = isLeft ? '<' : '>';
+    button.setAttribute('data-i18n-title', labelKey);
+    button.setAttribute('data-i18n-aria', labelKey);
+    button.setAttribute('title', window.t ? window.t(labelKey) : fallbackLabel);
+    button.setAttribute('aria-label', window.t ? window.t(labelKey) : fallbackLabel);
+    button.addEventListener('click', () => {
+        scrollCharacterCardTags(isLeft ? -1 : 1);
+    });
+
+    return button;
+}
+
+function ensureCharacterCardTagScrollControls() {
+    const wrapper = document.getElementById('character-card-tags-wrapper');
+    if (!wrapper) return null;
+
+    let shell = wrapper.parentElement && wrapper.parentElement.classList.contains('character-card-tags-scroll-shell')
+        ? wrapper.parentElement
+        : null;
+
+    if (!shell && wrapper.parentNode) {
+        shell = document.createElement('div');
+        shell.className = 'character-card-tags-scroll-shell';
+        wrapper.parentNode.insertBefore(shell, wrapper);
+        shell.appendChild(createCharacterCardTagScrollButton(-1));
+        shell.appendChild(wrapper);
+        shell.appendChild(createCharacterCardTagScrollButton(1));
+    }
+
+    if (!shell) return null;
+
+    let leftButton = shell.querySelector('#character-card-tags-scroll-left');
+    if (!leftButton) {
+        leftButton = createCharacterCardTagScrollButton(-1);
+        shell.insertBefore(leftButton, shell.firstChild || null);
+    }
+
+    let rightButton = shell.querySelector('#character-card-tags-scroll-right');
+    if (!rightButton) {
+        rightButton = createCharacterCardTagScrollButton(1);
+        shell.appendChild(rightButton);
+    }
+
+    if (wrapper.dataset.scrollControlsBound !== 'true') {
+        wrapper.addEventListener('scroll', updateCharacterCardTagScrollControls, { passive: true });
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const tagsContainer = document.getElementById('character-card-tags-container');
+            const tagsResizeObserver = new ResizeObserver(() => {
+                updateCharacterCardTagScrollControls();
+            });
+            tagsResizeObserver.observe(wrapper);
+            if (tagsContainer) {
+                tagsResizeObserver.observe(tagsContainer);
+            }
+            wrapper._tagScrollResizeObserver = tagsResizeObserver;
+        }
+
+        wrapper.dataset.scrollControlsBound = 'true';
+    }
+
+    return { wrapper, leftButton, rightButton };
 }
 
 function scrollCharacterCardTags(direction) {
@@ -684,6 +757,7 @@ function addTag(tagText, type = '', locked = false) {
 
     if (type === 'character-card') {
         updateCharacterCardTagScrollControls();
+        requestAnimationFrame(updateCharacterCardTagScrollControls);
     }
 }
 
@@ -696,6 +770,7 @@ function removeTag(tagElement, type = '') {
 
     if (type === 'character-card') {
         updateCharacterCardTagScrollControls();
+        requestAnimationFrame(updateCharacterCardTagScrollControls);
     }
 }
 
@@ -2279,8 +2354,9 @@ async function autoScanAndAddWorkshopCharacterCards() {
             } else {
                 const syncResult = await syncResponse.json();
                 if (syncResult.success) {
-                    if (syncResult.added > 0) {
-                        console.log(`[工坊同步] 服务端同步完成：新增 ${syncResult.added} 个角色卡，跳过 ${syncResult.skipped} 个已存在`);
+                    const backfilledFaces = Number(syncResult.backfilled_faces || 0);
+                    if (syncResult.added > 0 || backfilledFaces > 0) {
+                        console.log(`[工坊同步] 服务端同步完成：新增 ${syncResult.added} 个角色卡，回填 ${backfilledFaces} 个封面，跳过 ${syncResult.skipped} 个已存在`);
                         // 刷新角色卡列表
                         loadCharacterCards();
                     } else {
@@ -3981,8 +4057,8 @@ function openCatgirlPanel(card, originEl) {
                                     // 重新计算模型缩放和位置（修复在隐藏标签中加载导致的0尺寸问题）
                                     if (live2dPreviewManager.currentModel) {
                                         live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
-                                        if (live2dPreviewManager.app && live2dPreviewManager.app.renderer) {
-                                            live2dPreviewManager.app.renderer.render(live2dPreviewManager.app.stage);
+                                        if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                                            live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
                                         }
                                     }
                                 }
@@ -5514,12 +5590,12 @@ function buildSteamTabContent(name, rawData, card, container) {
 
     const tagsWrapper = document.createElement('div');
     tagsWrapper.id = 'character-card-tags-wrapper';
-    tagsWrapper.style.cssText = 'display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 15px; border: 2px solid #b3e5fc; border-radius: 50px; background-color: #fff; min-height: 40px; box-sizing: border-box; margin-top: 5px;';
     const tagsContainer = document.createElement('div');
     tagsContainer.className = 'tags-container';
     tagsContainer.id = 'character-card-tags-container';
     tagsWrapper.appendChild(tagsContainer);
     tagsControlGroup.appendChild(tagsWrapper);
+    ensureCharacterCardTagScrollControls();
     tagsArea.appendChild(tagsControlGroup);
     tagsButtonsSection.appendChild(tagsArea);
 
@@ -5785,6 +5861,7 @@ function expandCharacterCardSection(card) {
                 tagsContainer.appendChild(tagElement);
             });
         }
+        requestAnimationFrame(updateCharacterCardTagScrollControls);
     }
 
     // 显示角色卡区域
@@ -6376,6 +6453,65 @@ async function scanModels() {
 
 // 全局变量：当前选择的模型信息
 let selectedModelInfo = null;
+
+function fitLive2DPreviewModelToContainer(model) {
+    if (!live2dPreviewManager || !live2dPreviewManager.pixi_app || !model) return;
+
+    const renderer = live2dPreviewManager.pixi_app.renderer;
+    const screenWidth = Number(renderer?.screen?.width) || 0;
+    const screenHeight = Number(renderer?.screen?.height) || 0;
+    if (screenWidth <= 0 || screenHeight <= 0) return;
+
+    model.anchor.set(0.5, 0.5);
+    if (!Number.isFinite(model.scale?.x) || model.scale.x <= 0 || !Number.isFinite(model.scale?.y) || model.scale.y <= 0) {
+        model.scale.set(0.18);
+    }
+
+    model.x = screenWidth * 0.5;
+    model.y = screenHeight * 0.5;
+
+    // Live2DManager 在 addChild 之前会先调用 applyModelSettings。
+    // 这时直接依赖 getBounds() 做精确 fitting 并不稳定，先做保守居中，
+    // 等模型真正挂到 stage 上后再用 bounds 做二次校正。
+    if (!model.parent || typeof model.getBounds !== 'function') return;
+
+    let bounds = null;
+    try {
+        bounds = model.getBounds();
+    } catch (error) {
+        console.warn('[CharacterCard] 获取 Live2D 预览 bounds 失败:', error);
+        return;
+    }
+
+    const initialWidth = Number(bounds?.width) || 0;
+    const initialHeight = Number(bounds?.height) || 0;
+    if (initialWidth <= 1 || initialHeight <= 1) return;
+
+    const padding = 30;
+    const availableWidth = Math.max(80, screenWidth - padding * 2);
+    const availableHeight = Math.max(80, screenHeight - padding * 2);
+    const scaleRatio = Math.min(availableWidth / initialWidth, availableHeight / initialHeight);
+
+    if (Number.isFinite(scaleRatio) && scaleRatio > 0) {
+        const nextScaleX = Math.max(0.02, Math.min(model.scale.x * scaleRatio, 2.5));
+        const nextScaleY = Math.max(0.02, Math.min(model.scale.y * scaleRatio, 2.5));
+        model.scale.set(nextScaleX, nextScaleY);
+    }
+
+    try {
+        const fittedBounds = model.getBounds();
+        const fittedWidth = Number(fittedBounds?.width) || 0;
+        const fittedHeight = Number(fittedBounds?.height) || 0;
+        if (fittedWidth > 1 && fittedHeight > 1) {
+            const currentCenterX = (Number(fittedBounds.x) || 0) + fittedWidth * 0.5;
+            const currentCenterY = (Number(fittedBounds.y) || 0) + fittedHeight * 0.5;
+            model.x += (screenWidth * 0.5) - currentCenterX;
+            model.y += (screenHeight * 0.5) - currentCenterY;
+        }
+    } catch (error) {
+        console.warn('[CharacterCard] 校正 Live2D 预览位置失败:', error);
+    }
+}
 
 // 初始化模型选择功能
 // 音色相关函数（功能暂未实现）
@@ -7152,13 +7288,14 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         // 模型加载完成后，确保它在容器中正确显示
         setTimeout(() => {
             if (live2dPreviewManager && live2dPreviewManager.currentModel) {
-                live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
+                fitLive2DPreviewModelToContainer(live2dPreviewManager.currentModel);
                 // 确保canvas正确显示，占位符被隐藏
                 document.getElementById('live2d-preview-canvas').style.display = '';
-                document.querySelector('.preview-placeholder').style.display = 'none';
+                const placeholder = document.querySelector('#live2d-preview-content .preview-placeholder');
+                if (placeholder) placeholder.style.display = 'none';
                 // 强制重绘canvas
-                if (live2dPreviewManager.app && live2dPreviewManager.app.renderer) {
-                    live2dPreviewManager.app.renderer.render(live2dPreviewManager.app.stage);
+                if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                    live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
                 }
             }
         }, 100);
@@ -7316,7 +7453,6 @@ function updateCardPreview() {
 document.addEventListener('DOMContentLoaded', function () {
     // 只有 description 输入框仍然存在，为其添加事件监听器
     const descriptionInput = document.getElementById('character-card-description');
-    const characterCardTagsWrapper = document.getElementById('character-card-tags-wrapper');
 
     // 页面加载完成后自动加载音色列表
     loadVoices();
@@ -7325,17 +7461,8 @@ document.addEventListener('DOMContentLoaded', function () {
         descriptionInput.addEventListener('input', updateCardPreview);
     }
 
-    if (characterCardTagsWrapper) {
-        characterCardTagsWrapper.addEventListener('scroll', updateCharacterCardTagScrollControls, { passive: true });
-        if (typeof ResizeObserver !== 'undefined') {
-            const tagsResizeObserver = new ResizeObserver(() => {
-                updateCharacterCardTagScrollControls();
-            });
-            tagsResizeObserver.observe(characterCardTagsWrapper);
-        }
-    }
-
     window.addEventListener('resize', updateCharacterCardTagScrollControls);
+    ensureCharacterCardTagScrollControls();
     window.setTimeout(updateCharacterCardTagScrollControls, 0);
 });
 
@@ -7384,45 +7511,10 @@ async function initLive2DPreview() {
         live2dPreviewManager.applyModelSettings = function (model, options) {
             // 获取预览容器的尺寸
             const container = document.getElementById('live2d-preview-content');
-            if (!container) {
+            if (!container || !this.pixi_app || !this.pixi_app.renderer) {
                 return originalApplyModelSettings(model, options);
             }
-
-            const containerWidth = container.clientWidth;
-            const containerHeight = container.clientHeight;
-
-            // 先设置临时缩放和锚点以便获取实际边界
-            model.anchor.set(0.5, 0.5);
-            model.scale.set(0.1); // 临时缩放值
-            model.x = 0;
-            model.y = 0;
-
-            // 获取模型的实际边界
-            const bounds = model.getBounds();
-            const modelWidth = bounds.width / 0.1; // 还原原始宽度
-            const modelHeight = bounds.height / 0.1; // 还原原始高度
-
-            // 计算适合容器的缩放比例
-            const padding = 30;
-            const availableWidth = Math.max(50, containerWidth - padding * 2);
-            const availableHeight = Math.max(50, containerHeight - padding * 2);
-
-            // 基于实际模型尺寸计算缩放
-            const scaleX = availableWidth / modelWidth;
-            const scaleY = availableHeight / modelHeight;
-
-            // 取较小值确保完整显示
-            let defaultScale = Math.min(scaleX, scaleY);
-            defaultScale = Math.max(0.01, Math.min(defaultScale, 1.0));
-
-            model.scale.set(defaultScale);
-
-            // 将模型居中显示在容器中央
-            model.x = containerWidth * 0.5;
-            model.y = containerHeight * 0.5;
-
-            // 锚点保持中心，确保模型居中缩放
-            model.anchor.set(0.5, 0.5);
+            fitLive2DPreviewModelToContainer(model);
         };
 
         // 添加窗口大小变化的监听，当预览区域大小变化时重新计算模型缩放和位置
@@ -7435,6 +7527,9 @@ async function initLive2DPreview() {
             if (live2dPreviewManager && live2dPreviewManager.currentModel) {
                 // 调用我们覆盖的applyModelSettings方法，重新计算模型缩放和位置
                 live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
+                if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                    live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
+                }
             }
         }
 
@@ -7442,9 +7537,9 @@ async function initLive2DPreview() {
         if (!live2dPreviewManager.removeModel) {
             live2dPreviewManager.removeModel = async function (force) {
                 try {
-                    if (this.currentModel && this.app && this.app.stage) {
+                    if (this.currentModel && this.pixi_app && this.pixi_app.stage) {
                         // 移除当前模型
-                        this.app.stage.removeChild(this.currentModel);
+                        this.pixi_app.stage.removeChild(this.currentModel);
                         this.currentModel = null;
 
                         // 如果有清理资源的方法，调用它


### PR DESCRIPTION
可以直接用这个：

本次 PR 主要修复了角色卡管理与 Steam 创意工坊同步流程中的几个回归问题，包括恢复标签区域的左右滚动按钮及相关布局行为、为订阅的 Steam 角色资产生成并补齐本地 `card_faces` 预览图、在仅补齐缺失封面的同步场景下也能正确刷新角色卡列表，以及修复 Live2D 预览偶现不显示的问题，提升角色卡管理页面的整体可用性与稳定性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 角色卡牌同步可自动补填缺失的面部图像与来源元数据，且同步结果会报告补填数量。

* **改进**
  * 优化角色卡牌标签的滚动控制与布局，滚动按钮与容器自适应管理提升交互稳定性。
  * 提升 Live2D 预览的渲染与自适应拟合表现，改进模型加载与重绘体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->