### PR TITLE
统一角色旁菜单各类开关的选中指示器颜色，并修复对话设置、主动搭话和动画设置子菜单中蓝色背景常驻的问题，使蓝色背景仅在鼠标悬停时显示

### DIFF
--- a/static/avatar-ui-drag.js
+++ b/static/avatar-ui-drag.js
@@ -619,17 +619,21 @@ Live2DManager.prototype.showPopup = function (buttonId, popup) {
             if (!indicator || !checkmark) return;
             const checkedColor = 'var(--neko-popup-accent, #44b7fe)';
 
+            const hovered = toggleItem.matches(':hover');
             if (checkbox.checked) {
                 indicator.style.backgroundColor = checkedColor;
                 indicator.style.borderColor = checkedColor;
                 checkmark.style.opacity = '1';
-                toggleItem.style.background = 'transparent';
             } else {
                 indicator.style.backgroundColor = 'transparent';
                 indicator.style.borderColor = '#ccc';
                 checkmark.style.opacity = '0';
-                toggleItem.style.background = 'transparent';
             }
+            toggleItem.style.background = hovered
+                ? (checkbox.checked
+                    ? 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))'
+                    : 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))')
+                : 'transparent';
         };
 
         // 更新 merge messages checkbox 状态和视觉样式

--- a/static/avatar-ui-drag.js
+++ b/static/avatar-ui-drag.js
@@ -348,8 +348,8 @@ window.updateChatModeStyle = function(checkbox) {
     const checkmark = indicator?.querySelector('.chat-mode-checkmark');
     if (!indicator || !checkmark) return;
     if (checkbox.checked) {
-        indicator.style.backgroundColor = '#44b7fe';
-        indicator.style.borderColor = '#44b7fe';
+        indicator.style.backgroundColor = 'var(--neko-popup-accent, #44b7fe)';
+        indicator.style.borderColor = 'var(--neko-popup-accent, #44b7fe)';
         checkmark.style.opacity = '1';
     } else {
         indicator.style.backgroundColor = 'transparent';
@@ -358,13 +358,11 @@ window.updateChatModeStyle = function(checkbox) {
     }
 
     const hovered = wrapper.matches(':hover');
-    wrapper.style.background = checkbox.checked
-        ? (hovered
+    wrapper.style.background = hovered
+        ? (checkbox.checked
             ? 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))'
-            : 'var(--neko-popup-selected-bg, rgba(68,183,254,0.1))')
-        : (hovered
-            ? 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))'
-            : 'transparent');
+            : 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))')
+        : 'transparent';
 };
 
 // 兼容旧函数名
@@ -619,19 +617,18 @@ Live2DManager.prototype.showPopup = function (buttonId, popup) {
             const indicator = toggleItem.querySelector('[class*="-toggle-indicator"]');
             const checkmark = indicator?.querySelector('[class*="-toggle-checkmark"]');
             if (!indicator || !checkmark) return;
-            const alwaysTinted = ['live2d-merge-messages', 'live2d-focus-mode', 'live2d-avatar-reaction-bubble'].includes(checkbox.id);
-            const checkedColor = alwaysTinted ? '#69c5ff' : '#44b7fe';
+            const checkedColor = 'var(--neko-popup-accent, #44b7fe)';
 
             if (checkbox.checked) {
                 indicator.style.backgroundColor = checkedColor;
                 indicator.style.borderColor = checkedColor;
                 checkmark.style.opacity = '1';
-                toggleItem.style.background = 'rgba(68, 183, 254, 0.1)';
+                toggleItem.style.background = 'transparent';
             } else {
                 indicator.style.backgroundColor = 'transparent';
                 indicator.style.borderColor = '#ccc';
                 checkmark.style.opacity = '0';
-                toggleItem.style.background = alwaysTinted ? 'rgba(68, 183, 254, 0.1)' : 'transparent';
+                toggleItem.style.background = 'transparent';
             }
         };
 

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -1952,10 +1952,15 @@ function createSettingsToggleItem(manager, prefix, toggle) {
 
     const updateStyle = () => {
         const isChecked = checkbox.checked;
+        const hovered = toggleItem.matches(':hover');
         toggleItem.setAttribute('aria-checked', isChecked ? 'true' : 'false');
         indicator.setAttribute('aria-checked', isChecked ? 'true' : 'false');
         updateIndicatorStyle(isChecked);
-        toggleItem.style.background = 'transparent';
+        toggleItem.style.background = hovered
+            ? (isChecked
+                ? 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))'
+                : 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))')
+            : 'transparent';
     };
 
     updateStyle();
@@ -1965,9 +1970,7 @@ function createSettingsToggleItem(manager, prefix, toggle) {
     toggleItem.appendChild(label);
 
     toggleItem.addEventListener('mouseenter', () => {
-        toggleItem.style.background = checkbox.checked
-            ? 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))'
-            : 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))';
+        updateStyle();
     });
     toggleItem.addEventListener('mouseleave', () => {
         updateStyle();

--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -160,13 +160,12 @@ function injectPopupStyles(prefix) {
         .${prefix}-toggle-item:hover:not([aria-disabled="true"]) {
             background: var(--neko-popup-hover, rgba(68, 183, 254, 0.1));
         }
-        .${prefix}-toggle-item.${prefix}-toggle-item-static,
         .${prefix}-toggle-item.${prefix}-toggle-item-static:hover:not([aria-disabled="true"]) {
-            background: var(--neko-popup-selected-bg, rgba(68, 183, 254, 0.1)) !important;
+            background: var(--neko-popup-hover, rgba(68, 183, 254, 0.1)) !important;
         }
         .${prefix}-toggle-item.${prefix}-toggle-item-static .${prefix}-toggle-indicator[aria-checked="true"] {
-            background-color: #69c5ff;
-            border-color: #69c5ff;
+            background-color: var(--neko-popup-accent, #44b7fe);
+            border-color: var(--neko-popup-accent, #44b7fe);
         }
         .${prefix}-settings-menu-item {
             display: flex;
@@ -1110,6 +1109,20 @@ function createAnimationSettingsSidePanel(manager, prefix) {
         boxSizing: 'border-box',
         transition: 'background 0.2s ease'
     };
+    const updateTrackingToggleRowBackground = (row, checked) => {
+        if (!row) return;
+        const hovered = row.matches(':hover');
+        row.style.background = hovered
+            ? (checked
+                ? 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))'
+                : 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))')
+            : 'transparent';
+    };
+    const bindTrackingToggleRowHover = (row, getChecked) => {
+        if (!row || typeof getChecked !== 'function') return;
+        row.addEventListener('mouseenter', () => updateTrackingToggleRowBackground(row, getChecked()));
+        row.addEventListener('mouseleave', () => updateTrackingToggleRowBackground(row, getChecked()));
+    };
 
     // 鼠标跟踪复选框
     const checkbox = document.createElement('input');
@@ -1121,9 +1134,11 @@ function createAnimationSettingsSidePanel(manager, prefix) {
     const { indicator, updateStyle: updateIndicatorStyle } = manager._createCheckIndicator();
     Object.assign(indicator.style, { width: '20px', height: '20px', flexShrink: '0' });
 
+    let trackingClickArea = null;
     const updateRowStyle = () => {
         const isChecked = checkbox.checked;
         updateIndicatorStyle(isChecked);
+        updateTrackingToggleRowBackground(trackingClickArea, isChecked);
     };
     checkbox.updateStyle = updateRowStyle;
     updateRowStyle();
@@ -1135,11 +1150,13 @@ function createAnimationSettingsSidePanel(manager, prefix) {
     Object.assign(label.style, { userSelect: 'none', fontSize: '12px', whiteSpace: 'nowrap' });
 
     // 鼠标跟踪点击区域（左半部分）
-    const trackingClickArea = document.createElement('div');
+    trackingClickArea = document.createElement('div');
     Object.assign(trackingClickArea.style, trackingToggleRowStyle);
     trackingClickArea.appendChild(checkbox);
     trackingClickArea.appendChild(indicator);
     trackingClickArea.appendChild(label);
+    bindTrackingToggleRowHover(trackingClickArea, () => checkbox.checked);
+    updateRowStyle();
 
     const handleTrackingChange = () => {
         const enabled = !checkbox.checked;
@@ -1183,8 +1200,10 @@ function createAnimationSettingsSidePanel(manager, prefix) {
         modeClickArea.tabIndex = isEnabled ? 0 : -1;
     };
 
+    let modeClickArea = null;
     const updateModeRowStyle = () => {
         updateModeIndicatorStyle(modeCheckbox.checked);
+        updateTrackingToggleRowBackground(modeClickArea, modeCheckbox.checked);
     };
 
     const getTrackingModeState = () => {
@@ -1209,11 +1228,13 @@ function createAnimationSettingsSidePanel(manager, prefix) {
     }
     Object.assign(modeLabel.style, { userSelect: 'none', fontSize: '12px', whiteSpace: 'nowrap' });
 
-    const modeClickArea = document.createElement('div');
+    modeClickArea = document.createElement('div');
     Object.assign(modeClickArea.style, trackingToggleRowStyle);
     modeClickArea.appendChild(modeCheckbox);
     modeClickArea.appendChild(modeIndicator);
     modeClickArea.appendChild(modeLabel);
+    bindTrackingToggleRowHover(modeClickArea, () => modeCheckbox.checked);
+    updateModeRowStyle();
 
     // 初始化跟踪模式按钮状态
     updateTrackingModeToggleState();
@@ -1274,6 +1295,7 @@ function createAnimationSettingsSidePanel(manager, prefix) {
 
     const updateHoverFadeRowStyle = () => {
         updateHoverFadeIndicatorStyle(hoverFadeCheckbox.checked);
+        updateTrackingToggleRowBackground(hoverFadeRow, hoverFadeCheckbox.checked);
         hoverFadeRow.setAttribute('aria-checked', String(hoverFadeCheckbox.checked));
     };
     hoverFadeCheckbox.updateStyle = updateHoverFadeRowStyle;
@@ -1288,6 +1310,8 @@ function createAnimationSettingsSidePanel(manager, prefix) {
     hoverFadeRow.appendChild(hoverFadeIndicator);
     hoverFadeRow.appendChild(hoverFadeLabel);
     Object.assign(hoverFadeRow.style, { cursor: 'pointer' });
+    bindTrackingToggleRowHover(hoverFadeRow, () => hoverFadeCheckbox.checked);
+    updateHoverFadeRowStyle();
 
     const handleHoverFadeChange = () => {
         const enabled = !hoverFadeCheckbox.checked;
@@ -1901,7 +1925,7 @@ function createSettingsToggleItem(manager, prefix, toggle) {
 
     const updateIndicatorStyle = (checked) => {
         if (checked) {
-            const activeColor = toggle.alwaysTinted ? '#69c5ff' : 'var(--neko-popup-accent, #44b7fe)';
+            const activeColor = 'var(--neko-popup-accent, #44b7fe)';
             indicator.style.backgroundColor = activeColor;
             indicator.style.borderColor = activeColor;
             checkmark.style.opacity = '1';
@@ -1931,11 +1955,7 @@ function createSettingsToggleItem(manager, prefix, toggle) {
         toggleItem.setAttribute('aria-checked', isChecked ? 'true' : 'false');
         indicator.setAttribute('aria-checked', isChecked ? 'true' : 'false');
         updateIndicatorStyle(isChecked);
-        toggleItem.style.background = toggle.alwaysTinted
-            ? 'var(--neko-popup-selected-bg, rgba(68,183,254,0.1))'
-            : isChecked
-            ? 'var(--neko-popup-selected-bg, rgba(68,183,254,0.1))'
-            : 'transparent';
+        toggleItem.style.background = 'transparent';
     };
 
     updateStyle();
@@ -1944,18 +1964,14 @@ function createSettingsToggleItem(manager, prefix, toggle) {
     toggleItem.appendChild(indicator);
     toggleItem.appendChild(label);
 
-    if (!toggle.alwaysTinted) {
-        toggleItem.addEventListener('mouseenter', () => {
-            if (checkbox.checked) {
-                toggleItem.style.background = 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))';
-            } else {
-                toggleItem.style.background = 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))';
-            }
-        });
-        toggleItem.addEventListener('mouseleave', () => {
-            updateStyle();
-        });
-    }
+    toggleItem.addEventListener('mouseenter', () => {
+        toggleItem.style.background = checkbox.checked
+            ? 'var(--neko-popup-selected-hover, rgba(68,183,254,0.15))'
+            : 'var(--neko-popup-hover-subtle, rgba(68,183,254,0.08))';
+    });
+    toggleItem.addEventListener('mouseleave', () => {
+        updateStyle();
+    });
 
     const handleToggleChange = (isChecked) => {
         updateStyle();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **风格优化**
  * 统一使用主题色变量驱动聊天模式与设置开关的指示器颜色，替代硬编码色值。
  * 统一悬停与选中背景逻辑：开关行的背景由“悬停+选中”状态计算，不再保留持久选中背景或特殊分支。
  * 动画设置面板的开关行在渲染与交互时同步悬停背景，鼠标进出与状态更新均刷新样式，外观更一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->