### PR TITLE
chore(log): 静音 stream_data DIAG 日志，避免音频高频刷屏

### DIFF
--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -76,7 +76,7 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
     
     this_session_id = uuid.uuid4()
     # [DIAG] stream_data 计数器：按连接独立，重连后 `#1` 首包可见
-    sd_log_counter = 0
+    # sd_log_counter = 0
     async with _lock:
         session_id = get_session_id()
         session_id[lanlan_name] = this_session_id
@@ -128,15 +128,15 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
 
             elif action == "stream_data":
                 # [DIAG] 切换猫娘后语音 STT 不触发的排查：确认前端是否送达音频
-                _input_type_dbg = message.get("input_type")
-                _data = message.get("data")
-                _data_len = len(_data) if isinstance(_data, (str, bytes, bytearray)) else -1
-                # 按连接计数，重连后 #1 首包仍可见；每 50 次打一条够判断通路是否活
-                sd_log_counter += 1
-                if sd_log_counter == 1 or sd_log_counter % 50 == 0:
-                    logger.info(
-                        f"[{lanlan_name}] stream_data #{sd_log_counter} input_type={_input_type_dbg} data_len={_data_len}"
-                    )
+                # _input_type_dbg = message.get("input_type")
+                # _data = message.get("data")
+                # _data_len = len(_data) if isinstance(_data, (str, bytes, bytearray)) else -1
+                # # 按连接计数，重连后 #1 首包仍可见；每 50 次打一条够判断通路是否活
+                # sd_log_counter += 1
+                # if sd_log_counter == 1 or sd_log_counter % 50 == 0:
+                #     logger.info(
+                #         f"[{lanlan_name}] stream_data #{sd_log_counter} input_type={_input_type_dbg} data_len={_data_len}"
+                #     )
                 # Extract and store avatar position metadata (paired with screenshot)
                 # 显式清空：前端不发 avatar_position = 不应叠加，防止旧坐标残留
                 av_pos = message.get("avatar_position")


### PR DESCRIPTION
## Summary
- 注释 `main_routers/websocket_router.py` 里的 `[DIAG] stream_data` INFO 日志 + 计数器
- 该日志原本用于排查"切换猫娘后语音 STT 不触发"，已经完成历史使命；语音模式下 stream_data ~50 帧/秒，节流后仍约 1 秒一条，把后端日志窗口刷满
- 保留注释 + `[DIAG]` 标记，日后需要时直接取消注释即可

## Test plan
- [ ] 启动后端，进入语音模式，确认 backend 窗口不再被 `stream_data #N` 刷屏
- [ ] 其它 INFO/WARN 日志可见
- [ ] WebSocket stream_data 路径功能正常（avatar_position、screenshot 等仍处理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化**
  * 精简了WebSocket数据流处理中的诊断日志代码，移除了不必要的追踪和计数器逻辑，保留核心流数据处理功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->