### PR TITLE
修复 Steam 角色卡封面显示与 Live2D 预览偶发丢失问题

### DIFF
--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -644,6 +644,75 @@ def find_preview_image_in_folder(folder_path):
     return None
 
 
+def _build_workshop_card_face_meta(item: dict) -> dict:
+    workshop_author = ''
+    try:
+        workshop_author = str(item.get('authorName') or item.get('author') or item.get('creatorName') or '').strip()[:64]
+    except Exception:
+        workshop_author = ''
+
+    now_iso = datetime.utcnow().isoformat() + 'Z'
+    return {
+        'author': workshop_author,
+        'origin': 'steam',
+        'created_at': now_iso,
+        'updated_at': now_iso,
+    }
+
+
+def _is_matching_workshop_character(catgirl_data: dict, item_id) -> bool:
+    if not isinstance(catgirl_data, dict):
+        return False
+
+    try:
+        source = str(get_reserved(catgirl_data, 'character_origin', 'source', default='') or '').strip()
+        if source != 'steam_workshop':
+            return False
+
+        current_item_id = str(item_id or '').strip()
+        if not current_item_id:
+            return True
+
+        source_id = str(get_reserved(catgirl_data, 'character_origin', 'source_id', default='') or '').strip()
+        return source_id == current_item_id
+    except Exception:
+        return False
+
+
+def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview_image_path: str | None) -> bool:
+    if not preview_image_path or not os.path.isfile(preview_image_path):
+        return False
+    if not config_mgr.ensure_card_faces_directory():
+        return False
+
+    face_path = config_mgr.card_faces_dir / f"{chara_name}.png"
+    if face_path.exists():
+        return False
+
+    from PIL import Image as PILImage, ImageOps
+
+    with PILImage.open(preview_image_path) as img:
+        img = ImageOps.exif_transpose(img)
+        if img.mode not in ('RGB', 'RGBA', 'L'):
+            has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
+            img = img.convert('RGBA' if has_alpha else 'RGB')
+        img.save(face_path, format='PNG')
+
+    return True
+
+
+def _ensure_workshop_card_face_meta(config_mgr, chara_name: str, item: dict) -> bool:
+    if not config_mgr.ensure_card_faces_directory():
+        return False
+
+    meta_path = config_mgr.card_face_meta_path(chara_name)
+    if meta_path.exists():
+        return False
+
+    atomic_write_json(meta_path, _build_workshop_card_face_meta(item), ensure_ascii=False, indent=2)
+    return True
+
+
 def _sanitize_voice_prefix(prefix: str, default_prefix: str = 'voice') -> str:
     normalized = ''.join(ch for ch in str(prefix or '') if ch.isascii() and ch.isalnum())[:10]
     if normalized:
@@ -3821,9 +3890,10 @@ async def sync_workshop_character_cards() -> dict:
     可在服务器启动时直接调用，无需等待用户打开创意工坊管理页面。
     
     Returns:
-        dict: {"added": int, "skipped": int, "errors": int}
+        dict: {"added": int, "backfilled_faces": int, "skipped": int, "errors": int}
     """
     added_count = 0
+    backfilled_face_count = 0
     skipped_count = 0
     error_count = 0
     
@@ -3835,22 +3905,22 @@ async def sync_workshop_character_cards() -> dict:
         if isinstance(items_result, JSONResponse):
             # JSONResponse — 说明出错了，直接返回
             logger.warning("sync_workshop_character_cards: 获取订阅物品失败（返回了 JSONResponse）")
-            return {"added": 0, "skipped": 0, "errors": 1}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 1}
         
         if not isinstance(items_result, dict) or not items_result.get('success'):
             logger.warning("sync_workshop_character_cards: 获取订阅物品失败")
-            return {"added": 0, "skipped": 0, "errors": 1}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 1}
         
         subscribed_items = items_result.get('items', [])
         if not subscribed_items:
             logger.info("sync_workshop_character_cards: 没有订阅物品，跳过同步")
-            return {"added": 0, "skipped": 0, "errors": 0}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 0}
         
         config_mgr = get_config_manager()
 
         if is_write_fence_active(config_mgr):
             logger.info("sync_workshop_character_cards: 检测到维护态写围栏，跳过本轮同步并等待后续重试")
-            return {"added": 0, "skipped": 0, "errors": 0, "blocked_by_write_fence": True}
+            return {"added": 0, "backfilled_faces": 0, "skipped": 0, "errors": 0, "blocked_by_write_fence": True}
         
         # 使用全局锁序列化 load_characters -> save_characters 流程，防止并发覆写
         async with _ugc_sync_lock:
@@ -3868,6 +3938,7 @@ async def sync_workshop_character_cards() -> dict:
                     continue
                 
                 item_id = item.get('publishedFileId', '')
+                preview_image_path = find_preview_image_in_folder(installed_folder)
                 
                 # 3. 扫描 .chara.json 文件（递归遍历子目录）
                 try:
@@ -3901,6 +3972,35 @@ async def sync_workshop_character_cards() -> dict:
                             # 已存在则跳过（当前设计：仅填充缺失角色卡，不覆盖已有数据；
                             # 如需支持创意工坊更新覆写本地数据，可添加 allow_workshop_overwrite 配置项）
                             if chara_name in characters['猫娘']:
+                                existing_data = characters['猫娘'].get(chara_name) or {}
+                                if _is_matching_workshop_character(existing_data, item_id):
+                                    try:
+                                        face_created = await asyncio.to_thread(
+                                            _ensure_workshop_card_face_from_preview,
+                                            config_mgr,
+                                            chara_name,
+                                            preview_image_path,
+                                        )
+                                        if face_created:
+                                            backfilled_face_count += 1
+                                            logger.info(
+                                                "sync_workshop_character_cards: 已回填角色卡封面 '%s' (来自物品 %s)",
+                                                chara_name,
+                                                item_id,
+                                            )
+                                            await asyncio.to_thread(
+                                                _ensure_workshop_card_face_meta,
+                                                config_mgr,
+                                                chara_name,
+                                                item,
+                                            )
+                                    except Exception as face_err:
+                                        logger.warning(
+                                            "sync_workshop_character_cards: 回填角色卡封面失败 %s (物品 %s): %s",
+                                            chara_name,
+                                            item_id,
+                                            face_err,
+                                        )
                                 skipped_count += 1
                                 continue
                             
@@ -3974,26 +4074,33 @@ async def sync_workshop_character_cards() -> dict:
                             added_count += 1
                             logger.info(f"sync_workshop_character_cards: 添加角色卡 '{chara_name}' (来自物品 {item_id})")
 
-                            # 写入卡面元数据 sidecar（origin=steam）
+                            # 同步生成本地卡面和 sidecar，前端封面只认 card_faces/{name}.png
                             try:
-                                config_mgr.ensure_card_faces_directory()
-                                meta_path = config_mgr.card_face_meta_path(chara_name)
-                                if not meta_path.exists():
-                                    workshop_author = ''
-                                    try:
-                                        workshop_author = str(item.get('authorName') or item.get('author') or item.get('creatorName') or '').strip()[:64]
-                                    except Exception:
-                                        workshop_author = ''
-                                    now_iso = datetime.utcnow().isoformat() + 'Z'
-                                    meta = {
-                                        'author': workshop_author,
-                                        'origin': 'steam',
-                                        'created_at': now_iso,
-                                        'updated_at': now_iso,
-                                    }
-                                    await atomic_write_json_async(meta_path, meta, ensure_ascii=False, indent=2)
-                            except Exception as meta_err:
-                                logger.warning(f"sync_workshop_character_cards: 写入卡面元数据失败 {chara_name}: {meta_err}")
+                                face_created = await asyncio.to_thread(
+                                    _ensure_workshop_card_face_from_preview,
+                                    config_mgr,
+                                    chara_name,
+                                    preview_image_path,
+                                )
+                                if face_created:
+                                    logger.info(
+                                        "sync_workshop_character_cards: 已生成角色卡封面 '%s' (来自物品 %s)",
+                                        chara_name,
+                                        item_id,
+                                    )
+                                await asyncio.to_thread(
+                                    _ensure_workshop_card_face_meta,
+                                    config_mgr,
+                                    chara_name,
+                                    item,
+                                )
+                            except Exception as face_meta_err:
+                                logger.warning(
+                                    "sync_workshop_character_cards: 补写角色卡封面或元数据失败 %s (物品 %s): %s",
+                                    chara_name,
+                                    item_id,
+                                    face_meta_err,
+                                )
                             
                         except Exception as e:
                             logger.warning(f"sync_workshop_character_cards: 处理文件 {chara_file_path} 失败: {e}")
@@ -4007,15 +4114,15 @@ async def sync_workshop_character_cards() -> dict:
             if need_save:
                 if is_write_fence_active(config_mgr):
                     logger.info("sync_workshop_character_cards: 保存前检测到维护态写围栏，跳过本轮同步并等待后续重试")
-                    return {"added": 0, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
+                    return {"added": 0, "backfilled_faces": backfilled_face_count, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
 
                 try:
                     await config_mgr.asave_characters(characters)
                 except MaintenanceModeError:
                     logger.info("sync_workshop_character_cards: 保存时进入维护态写围栏，跳过本轮同步并等待后续重试")
-                    return {"added": 0, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
+                    return {"added": 0, "backfilled_faces": backfilled_face_count, "skipped": skipped_count, "errors": error_count, "blocked_by_write_fence": True}
 
-                logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡")
+                logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡，回填 {backfilled_face_count} 个封面")
                 
                 try:
                     initialize_character_data = get_initialize_character_data()
@@ -4025,13 +4132,16 @@ async def sync_workshop_character_cards() -> dict:
                 except Exception as e:
                     logger.warning(f"sync_workshop_character_cards: 重新加载角色配置失败: {e}")
             else:
-                logger.info("sync_workshop_character_cards: 无需更新，所有角色卡已存在")
+                if backfilled_face_count > 0:
+                    logger.info(f"sync_workshop_character_cards: 无新增角色卡，但已回填 {backfilled_face_count} 个封面")
+                else:
+                    logger.info("sync_workshop_character_cards: 无需更新，所有角色卡已存在")
         
     except Exception as e:
         logger.error(f"sync_workshop_character_cards: 同步过程出错: {e}", exc_info=True)
         error_count += 1
     
-    return {"added": added_count, "skipped": skipped_count, "errors": error_count}
+    return {"added": added_count, "backfilled_faces": backfilled_face_count, "skipped": skipped_count, "errors": error_count}
 
 
 @router.post('/sync-characters')
@@ -4050,6 +4160,7 @@ async def api_sync_workshop_character_cards():
                     "code": "WRITE_FENCE_ACTIVE",
                     "error": "当前处于存储维护态，暂时不能同步创意工坊角色卡，请稍后重试。",
                     "added": result.get("added", 0),
+                    "backfilled_faces": result.get("backfilled_faces", 0),
                     "skipped": result.get("skipped", 0),
                     "errors": result.get("errors", 0),
                 },
@@ -4057,9 +4168,14 @@ async def api_sync_workshop_character_cards():
         return {
             "success": True,
             "added": result["added"],
+            "backfilled_faces": result.get("backfilled_faces", 0),
             "skipped": result["skipped"],
             "errors": result["errors"],
-            "message": f"同步完成：新增 {result['added']} 个角色卡，跳过 {result['skipped']} 个已存在，{result['errors']} 个错误"
+            "message": (
+                f"同步完成：新增 {result['added']} 个角色卡，"
+                f"回填 {result.get('backfilled_faces', 0)} 个封面，"
+                f"跳过 {result['skipped']} 个已存在，{result['errors']} 个错误"
+            )
         }
     except Exception as e:
         logger.error(f"API sync-characters 失败: {e}")

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -665,6 +665,7 @@ def _build_workshop_card_face_meta(item: dict) -> dict:
 
 
 def _read_card_face_origin(meta_path: Path) -> str | None:
+    """Read the persisted card-face origin marker from the sidecar file."""
     try:
         if not meta_path.exists():
             return None
@@ -679,6 +680,7 @@ def _read_card_face_origin(meta_path: Path) -> str | None:
 
 
 def _is_workshop_card_face_normalized(face_path: Path) -> bool:
+    """Return True when the existing face already matches the workshop 3:4 derivative shape."""
     if not face_path.exists():
         return False
 
@@ -699,10 +701,17 @@ def _is_workshop_card_face_normalized(face_path: Path) -> bool:
 
 
 def _should_refresh_workshop_card_face(face_path: Path, meta_path: Path) -> bool:
+    """Decide whether a workshop preview is allowed to replace the current card face."""
     if not face_path.exists():
         return True
 
     origin = _read_card_face_origin(meta_path)
+    if origin is None:
+        # 当 sidecar 缺失时，无法证明现有图片来源于工坊同步。
+        # 只有看起来已经像标准化工坊卡面的图片，才允许继续刷新；
+        # 其他情况一律保守保留，避免覆盖用户手动放入的自定义卡面。
+        return _is_workshop_card_face_normalized(face_path)
+
     if origin in {'self', 'imported'}:
         return False
 
@@ -710,6 +719,7 @@ def _should_refresh_workshop_card_face(face_path: Path, meta_path: Path) -> bool
 
 
 def _render_workshop_card_face_image(img):
+    """Render a workshop preview into the normalized 3:4 in-app card-face layout."""
     from PIL import Image as PILImage, ImageFilter, ImageOps
 
     resampling = getattr(PILImage, 'Resampling', PILImage)
@@ -770,6 +780,7 @@ def _is_matching_workshop_character(catgirl_data: dict, item_id) -> bool:
 
 
 def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview_image_path: str | None) -> bool:
+    """Create or refresh a workshop-derived card face from the Steam preview image."""
     if not preview_image_path or not os.path.isfile(preview_image_path):
         return False
     if not config_mgr.ensure_card_faces_directory():
@@ -807,6 +818,7 @@ def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview
 
 
 def _ensure_workshop_card_face_meta(config_mgr, chara_name: str, item: dict) -> bool:
+    """Persist sidecar metadata for workshop-generated card faces when missing."""
     if not config_mgr.ensure_card_faces_directory():
         return False
 

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -13,6 +13,7 @@ import os
 import sys
 import json
 import time
+import tempfile
 import asyncio
 import threading
 import mimetypes
@@ -670,10 +671,9 @@ def _is_matching_workshop_character(catgirl_data: dict, item_id) -> bool:
             return False
 
         current_item_id = str(item_id or '').strip()
-        if not current_item_id:
-            return True
-
         source_id = str(get_reserved(catgirl_data, 'character_origin', 'source_id', default='') or '').strip()
+        if not current_item_id or not source_id:
+            return False
         return source_id == current_item_id
     except Exception:
         return False
@@ -691,12 +691,29 @@ def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview
 
     from PIL import Image as PILImage, ImageOps
 
-    with PILImage.open(preview_image_path) as img:
-        img = ImageOps.exif_transpose(img)
-        if img.mode not in ('RGB', 'RGBA', 'L'):
-            has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
-            img = img.convert('RGBA' if has_alpha else 'RGB')
-        img.save(face_path, format='PNG')
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f".{face_path.name}.",
+        suffix=".tmp",
+        dir=str(face_path.parent),
+    )
+
+    try:
+        with os.fdopen(fd, 'w+b') as temp_file:
+            with PILImage.open(preview_image_path) as img:
+                img = ImageOps.exif_transpose(img)
+                if img.mode not in ('RGB', 'RGBA', 'L'):
+                    has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
+                    img = img.convert('RGBA' if has_alpha else 'RGB')
+                img.save(temp_file, format='PNG')
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, face_path)
+    except Exception:
+        try:
+            os.remove(temp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
     return True
 
@@ -3981,6 +3998,12 @@ async def sync_workshop_character_cards() -> dict:
                                             chara_name,
                                             preview_image_path,
                                         )
+                                        meta_created = await asyncio.to_thread(
+                                            _ensure_workshop_card_face_meta,
+                                            config_mgr,
+                                            chara_name,
+                                            item,
+                                        )
                                         if face_created:
                                             backfilled_face_count += 1
                                             logger.info(
@@ -3988,15 +4011,15 @@ async def sync_workshop_character_cards() -> dict:
                                                 chara_name,
                                                 item_id,
                                             )
-                                            await asyncio.to_thread(
-                                                _ensure_workshop_card_face_meta,
-                                                config_mgr,
+                                        if meta_created:
+                                            logger.info(
+                                                "sync_workshop_character_cards: 已补写角色卡封面元数据 '%s' (来自物品 %s)",
                                                 chara_name,
-                                                item,
+                                                item_id,
                                             )
                                     except Exception as face_err:
                                         logger.warning(
-                                            "sync_workshop_character_cards: 回填角色卡封面失败 %s (物品 %s): %s",
+                                            "sync_workshop_character_cards: 回填角色卡封面或元数据失败 %s (物品 %s): %s",
                                             chara_name,
                                             item_id,
                                             face_err,

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -707,10 +707,9 @@ def _should_refresh_workshop_card_face(face_path: Path, meta_path: Path) -> bool
 
     origin = _read_card_face_origin(meta_path)
     if origin is None:
-        # 当 sidecar 缺失时，无法证明现有图片来源于工坊同步。
-        # 只有看起来已经像标准化工坊卡面的图片，才允许继续刷新；
-        # 其他情况一律保守保留，避免覆盖用户手动放入的自定义卡面。
-        return _is_workshop_card_face_normalized(face_path)
+        # sidecar 缺失时无法确认来源，保守地把现有卡面视为受保护资源，
+        # 避免覆盖用户手动放入或历史遗留的自定义 PNG。
+        return False
 
     if origin in {'self', 'imported'}:
         return False

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -71,6 +71,9 @@ WORKSHOP_REFERENCE_AUDIO_CONTENT_TYPES = {
 }
 WORKSHOP_REFERENCE_LANGUAGES = {'ch', 'en', 'fr', 'de', 'ja', 'ko', 'ru'}
 WORKSHOP_REFERENCE_PROVIDER_HINTS = {'cosyvoice', 'minimax', 'minimax_intl'}
+WORKSHOP_CARD_FACE_SIZE = (768, 1024)
+WORKSHOP_CARD_FACE_PADDING = 48
+WORKSHOP_CARD_FACE_RATIO_TOLERANCE = 0.02
 
 
 async def cancel_background_tasks(*, timeout: float = 5.0) -> None:
@@ -661,6 +664,93 @@ def _build_workshop_card_face_meta(item: dict) -> dict:
     }
 
 
+def _read_card_face_origin(meta_path: Path) -> str | None:
+    try:
+        if not meta_path.exists():
+            return None
+        with open(meta_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return None
+        origin = str(data.get('origin', '') or '').strip()
+        return origin or None
+    except Exception:
+        return None
+
+
+def _is_workshop_card_face_normalized(face_path: Path) -> bool:
+    if not face_path.exists():
+        return False
+
+    from PIL import Image as PILImage
+
+    try:
+        with PILImage.open(face_path) as img:
+            width, height = img.size
+    except Exception:
+        return False
+
+    if width <= 0 or height <= 0:
+        return False
+
+    target_ratio = WORKSHOP_CARD_FACE_SIZE[0] / WORKSHOP_CARD_FACE_SIZE[1]
+    current_ratio = width / height
+    return abs(current_ratio - target_ratio) <= WORKSHOP_CARD_FACE_RATIO_TOLERANCE
+
+
+def _should_refresh_workshop_card_face(face_path: Path, meta_path: Path) -> bool:
+    if not face_path.exists():
+        return True
+
+    origin = _read_card_face_origin(meta_path)
+    if origin in {'self', 'imported'}:
+        return False
+
+    return not _is_workshop_card_face_normalized(face_path)
+
+
+def _render_workshop_card_face_image(img):
+    from PIL import Image as PILImage, ImageFilter, ImageOps
+
+    resampling = getattr(PILImage, 'Resampling', PILImage)
+    lanczos = getattr(resampling, 'LANCZOS', PILImage.BICUBIC)
+
+    img = ImageOps.exif_transpose(img)
+    has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
+    working = img.convert('RGBA' if has_alpha else 'RGB')
+    if working.mode != 'RGBA':
+        working = working.convert('RGBA')
+
+    canvas = PILImage.new('RGBA', WORKSHOP_CARD_FACE_SIZE, (231, 245, 255, 255))
+    background = ImageOps.fit(
+        working,
+        WORKSHOP_CARD_FACE_SIZE,
+        method=lanczos,
+        centering=(0.5, 0.5),
+    )
+    background = background.filter(ImageFilter.GaussianBlur(radius=28))
+    canvas = PILImage.blend(canvas, background, 0.82)
+    canvas = PILImage.alpha_composite(
+        canvas,
+        PILImage.new('RGBA', WORKSHOP_CARD_FACE_SIZE, (255, 255, 255, 30)),
+    )
+
+    foreground = working.copy()
+    foreground.thumbnail(
+        (
+            max(64, WORKSHOP_CARD_FACE_SIZE[0] - WORKSHOP_CARD_FACE_PADDING * 2),
+            max(64, WORKSHOP_CARD_FACE_SIZE[1] - WORKSHOP_CARD_FACE_PADDING * 2),
+        ),
+        resample=lanczos,
+    )
+    foreground = ImageOps.expand(foreground, border=8, fill=(255, 255, 255, 28))
+
+    offset_x = (WORKSHOP_CARD_FACE_SIZE[0] - foreground.width) // 2
+    offset_y = (WORKSHOP_CARD_FACE_SIZE[1] - foreground.height) // 2
+    canvas.alpha_composite(foreground, (offset_x, offset_y))
+    return canvas
+
+
 def _is_matching_workshop_character(catgirl_data: dict, item_id) -> bool:
     if not isinstance(catgirl_data, dict):
         return False
@@ -686,10 +776,11 @@ def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview
         return False
 
     face_path = config_mgr.card_faces_dir / f"{chara_name}.png"
-    if face_path.exists():
+    meta_path = config_mgr.card_face_meta_path(chara_name)
+    if not _should_refresh_workshop_card_face(face_path, meta_path):
         return False
 
-    from PIL import Image as PILImage, ImageOps
+    from PIL import Image as PILImage
 
     fd, temp_path = tempfile.mkstemp(
         prefix=f".{face_path.name}.",
@@ -700,11 +791,8 @@ def _ensure_workshop_card_face_from_preview(config_mgr, chara_name: str, preview
     try:
         with os.fdopen(fd, 'w+b') as temp_file:
             with PILImage.open(preview_image_path) as img:
-                img = ImageOps.exif_transpose(img)
-                if img.mode not in ('RGB', 'RGBA', 'L'):
-                    has_alpha = 'A' in img.getbands() or 'transparency' in (img.info or {})
-                    img = img.convert('RGBA' if has_alpha else 'RGB')
-                img.save(temp_file, format='PNG')
+                normalized = _render_workshop_card_face_image(img)
+                normalized.save(temp_file, format='PNG', optimize=True)
             temp_file.flush()
             os.fsync(temp_file.fileno())
         os.replace(temp_path, face_path)
@@ -4007,7 +4095,7 @@ async def sync_workshop_character_cards() -> dict:
                                         if face_created:
                                             backfilled_face_count += 1
                                             logger.info(
-                                                "sync_workshop_character_cards: 已回填角色卡封面 '%s' (来自物品 %s)",
+                                                "sync_workshop_character_cards: 已同步角色卡封面 '%s' (来自物品 %s)",
                                                 chara_name,
                                                 item_id,
                                             )

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -3597,7 +3597,7 @@ margin-top: 10px;
     color: #b3e5fc;
 }
 
-/* 角色卡标签展示区外框（使用更高特异性选择器替代 !important） */
+/* 角色卡标签展示区外框（提高选择器特异性，并由 wrapper 承担横向滚动与滚动条隐藏） */
 #character-card-tags-wrapper {
     display: flex;
     align-items: center;

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -3598,14 +3598,14 @@ margin-top: 10px;
 }
 
 /* 角色卡标签展示区外框（使用更高特异性选择器替代 !important） */
-#character-cards-content #character-card-tags-wrapper {
+#character-card-tags-wrapper {
     display: flex;
     align-items: center;
     border: 2px solid #b3e5fc;
     border-radius: 50px;
     background: #fff;
     flex: 1;
-    width: 100%;
+    width: auto;
     max-width: 100%;
     min-width: 0;
     min-height: 44px;
@@ -3620,13 +3620,13 @@ margin-top: 10px;
     -ms-overflow-style: none;
 }
 
-#character-cards-content #character-card-tags-wrapper::-webkit-scrollbar {
+#character-card-tags-wrapper::-webkit-scrollbar {
     width: 0;
     height: 0;
     display: none;
 }
 
-#character-cards-content #character-card-tags-container {
+#character-card-tags-container {
     width: max-content;
     min-width: max-content;
     min-height: 100%;
@@ -3634,7 +3634,7 @@ margin-top: 10px;
     align-content: center;
 }
 
-#character-cards-content #character-card-tags-container .tag {
+#character-card-tags-container .tag {
     flex: 0 0 auto;
     white-space: nowrap;
 }

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -6893,6 +6893,8 @@ async function disposeWorkshopMmd() {
 // 加载 VRM 模型预览
 async function loadVrmPreview(modelPath, rawData) {
     try {
+        cancelPendingLive2DPreviewLoads();
+
         // 先清理之前的 3D 预览
         await disposeWorkshopVrm();
         await disposeWorkshopMmd();
@@ -6993,6 +6995,8 @@ async function loadVrmPreview(modelPath, rawData) {
 // 加载 MMD 模型预览
 async function loadMmdPreview(modelPath, rawData) {
     try {
+        cancelPendingLive2DPreviewLoads();
+
         // 先清理之前的 3D 预览
         await disposeWorkshopVrm();
         await disposeWorkshopMmd();

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -598,10 +598,10 @@ if (characterCardTagInput) {
 }
 
 function updateCharacterCardTagScrollControls() {
-    const wrapper = document.getElementById('character-card-tags-wrapper');
-    const leftButton = document.getElementById('character-card-tags-scroll-left');
-    const rightButton = document.getElementById('character-card-tags-scroll-right');
-    if (!wrapper || !leftButton || !rightButton) return;
+    const controls = ensureCharacterCardTagScrollControls();
+    if (!controls) return;
+
+    const { wrapper, leftButton, rightButton } = controls;
 
     const hasOverflow = (wrapper.scrollWidth - wrapper.clientWidth) > 2;
     const atStart = wrapper.scrollLeft <= 2;
@@ -611,6 +611,79 @@ function updateCharacterCardTagScrollControls() {
     rightButton.classList.toggle('is-hidden', !hasOverflow);
     leftButton.disabled = !hasOverflow || atStart;
     rightButton.disabled = !hasOverflow || atEnd;
+}
+
+function createCharacterCardTagScrollButton(direction) {
+    const isLeft = direction < 0;
+    const button = document.createElement('button');
+    const labelKey = isLeft ? 'steam.scrollTagsLeftAriaLabel' : 'steam.scrollTagsRightAriaLabel';
+    const fallbackLabel = isLeft ? '向左滚动标签' : '向右滚动标签';
+
+    button.type = 'button';
+    button.id = isLeft ? 'character-card-tags-scroll-left' : 'character-card-tags-scroll-right';
+    button.className = 'tag-scroll-button is-hidden';
+    button.textContent = isLeft ? '<' : '>';
+    button.setAttribute('data-i18n-title', labelKey);
+    button.setAttribute('data-i18n-aria', labelKey);
+    button.setAttribute('title', window.t ? window.t(labelKey) : fallbackLabel);
+    button.setAttribute('aria-label', window.t ? window.t(labelKey) : fallbackLabel);
+    button.addEventListener('click', () => {
+        scrollCharacterCardTags(isLeft ? -1 : 1);
+    });
+
+    return button;
+}
+
+function ensureCharacterCardTagScrollControls() {
+    const wrapper = document.getElementById('character-card-tags-wrapper');
+    if (!wrapper) return null;
+
+    let shell = wrapper.parentElement && wrapper.parentElement.classList.contains('character-card-tags-scroll-shell')
+        ? wrapper.parentElement
+        : null;
+
+    if (!shell && wrapper.parentNode) {
+        shell = document.createElement('div');
+        shell.className = 'character-card-tags-scroll-shell';
+        wrapper.parentNode.insertBefore(shell, wrapper);
+        shell.appendChild(createCharacterCardTagScrollButton(-1));
+        shell.appendChild(wrapper);
+        shell.appendChild(createCharacterCardTagScrollButton(1));
+    }
+
+    if (!shell) return null;
+
+    let leftButton = shell.querySelector('#character-card-tags-scroll-left');
+    if (!leftButton) {
+        leftButton = createCharacterCardTagScrollButton(-1);
+        shell.insertBefore(leftButton, shell.firstChild || null);
+    }
+
+    let rightButton = shell.querySelector('#character-card-tags-scroll-right');
+    if (!rightButton) {
+        rightButton = createCharacterCardTagScrollButton(1);
+        shell.appendChild(rightButton);
+    }
+
+    if (wrapper.dataset.scrollControlsBound !== 'true') {
+        wrapper.addEventListener('scroll', updateCharacterCardTagScrollControls, { passive: true });
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const tagsContainer = document.getElementById('character-card-tags-container');
+            const tagsResizeObserver = new ResizeObserver(() => {
+                updateCharacterCardTagScrollControls();
+            });
+            tagsResizeObserver.observe(wrapper);
+            if (tagsContainer) {
+                tagsResizeObserver.observe(tagsContainer);
+            }
+            wrapper._tagScrollResizeObserver = tagsResizeObserver;
+        }
+
+        wrapper.dataset.scrollControlsBound = 'true';
+    }
+
+    return { wrapper, leftButton, rightButton };
 }
 
 function scrollCharacterCardTags(direction) {
@@ -684,6 +757,7 @@ function addTag(tagText, type = '', locked = false) {
 
     if (type === 'character-card') {
         updateCharacterCardTagScrollControls();
+        requestAnimationFrame(updateCharacterCardTagScrollControls);
     }
 }
 
@@ -696,6 +770,7 @@ function removeTag(tagElement, type = '') {
 
     if (type === 'character-card') {
         updateCharacterCardTagScrollControls();
+        requestAnimationFrame(updateCharacterCardTagScrollControls);
     }
 }
 
@@ -2279,8 +2354,9 @@ async function autoScanAndAddWorkshopCharacterCards() {
             } else {
                 const syncResult = await syncResponse.json();
                 if (syncResult.success) {
-                    if (syncResult.added > 0) {
-                        console.log(`[工坊同步] 服务端同步完成：新增 ${syncResult.added} 个角色卡，跳过 ${syncResult.skipped} 个已存在`);
+                    const backfilledFaces = Number(syncResult.backfilled_faces || 0);
+                    if (syncResult.added > 0 || backfilledFaces > 0) {
+                        console.log(`[工坊同步] 服务端同步完成：新增 ${syncResult.added} 个角色卡，回填 ${backfilledFaces} 个封面，跳过 ${syncResult.skipped} 个已存在`);
                         // 刷新角色卡列表
                         loadCharacterCards();
                     } else {
@@ -3981,8 +4057,8 @@ function openCatgirlPanel(card, originEl) {
                                     // 重新计算模型缩放和位置（修复在隐藏标签中加载导致的0尺寸问题）
                                     if (live2dPreviewManager.currentModel) {
                                         live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
-                                        if (live2dPreviewManager.app && live2dPreviewManager.app.renderer) {
-                                            live2dPreviewManager.app.renderer.render(live2dPreviewManager.app.stage);
+                                        if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                                            live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
                                         }
                                     }
                                 }
@@ -5514,12 +5590,12 @@ function buildSteamTabContent(name, rawData, card, container) {
 
     const tagsWrapper = document.createElement('div');
     tagsWrapper.id = 'character-card-tags-wrapper';
-    tagsWrapper.style.cssText = 'display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 8px 15px; border: 2px solid #b3e5fc; border-radius: 50px; background-color: #fff; min-height: 40px; box-sizing: border-box; margin-top: 5px;';
     const tagsContainer = document.createElement('div');
     tagsContainer.className = 'tags-container';
     tagsContainer.id = 'character-card-tags-container';
     tagsWrapper.appendChild(tagsContainer);
     tagsControlGroup.appendChild(tagsWrapper);
+    ensureCharacterCardTagScrollControls();
     tagsArea.appendChild(tagsControlGroup);
     tagsButtonsSection.appendChild(tagsArea);
 
@@ -5785,6 +5861,7 @@ function expandCharacterCardSection(card) {
                 tagsContainer.appendChild(tagElement);
             });
         }
+        requestAnimationFrame(updateCharacterCardTagScrollControls);
     }
 
     // 显示角色卡区域
@@ -6376,6 +6453,65 @@ async function scanModels() {
 
 // 全局变量：当前选择的模型信息
 let selectedModelInfo = null;
+
+function fitLive2DPreviewModelToContainer(model) {
+    if (!live2dPreviewManager || !live2dPreviewManager.pixi_app || !model) return;
+
+    const renderer = live2dPreviewManager.pixi_app.renderer;
+    const screenWidth = Number(renderer?.screen?.width) || 0;
+    const screenHeight = Number(renderer?.screen?.height) || 0;
+    if (screenWidth <= 0 || screenHeight <= 0) return;
+
+    model.anchor.set(0.5, 0.5);
+    if (!Number.isFinite(model.scale?.x) || model.scale.x <= 0 || !Number.isFinite(model.scale?.y) || model.scale.y <= 0) {
+        model.scale.set(0.18);
+    }
+
+    model.x = screenWidth * 0.5;
+    model.y = screenHeight * 0.5;
+
+    // Live2DManager 在 addChild 之前会先调用 applyModelSettings。
+    // 这时直接依赖 getBounds() 做精确 fitting 并不稳定，先做保守居中，
+    // 等模型真正挂到 stage 上后再用 bounds 做二次校正。
+    if (!model.parent || typeof model.getBounds !== 'function') return;
+
+    let bounds = null;
+    try {
+        bounds = model.getBounds();
+    } catch (error) {
+        console.warn('[CharacterCard] 获取 Live2D 预览 bounds 失败:', error);
+        return;
+    }
+
+    const initialWidth = Number(bounds?.width) || 0;
+    const initialHeight = Number(bounds?.height) || 0;
+    if (initialWidth <= 1 || initialHeight <= 1) return;
+
+    const padding = 30;
+    const availableWidth = Math.max(80, screenWidth - padding * 2);
+    const availableHeight = Math.max(80, screenHeight - padding * 2);
+    const scaleRatio = Math.min(availableWidth / initialWidth, availableHeight / initialHeight);
+
+    if (Number.isFinite(scaleRatio) && scaleRatio > 0) {
+        const nextScaleX = Math.max(0.02, Math.min(model.scale.x * scaleRatio, 2.5));
+        const nextScaleY = Math.max(0.02, Math.min(model.scale.y * scaleRatio, 2.5));
+        model.scale.set(nextScaleX, nextScaleY);
+    }
+
+    try {
+        const fittedBounds = model.getBounds();
+        const fittedWidth = Number(fittedBounds?.width) || 0;
+        const fittedHeight = Number(fittedBounds?.height) || 0;
+        if (fittedWidth > 1 && fittedHeight > 1) {
+            const currentCenterX = (Number(fittedBounds.x) || 0) + fittedWidth * 0.5;
+            const currentCenterY = (Number(fittedBounds.y) || 0) + fittedHeight * 0.5;
+            model.x += (screenWidth * 0.5) - currentCenterX;
+            model.y += (screenHeight * 0.5) - currentCenterY;
+        }
+    } catch (error) {
+        console.warn('[CharacterCard] 校正 Live2D 预览位置失败:', error);
+    }
+}
 
 // 初始化模型选择功能
 // 音色相关函数（功能暂未实现）
@@ -7152,13 +7288,14 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         // 模型加载完成后，确保它在容器中正确显示
         setTimeout(() => {
             if (live2dPreviewManager && live2dPreviewManager.currentModel) {
-                live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
+                fitLive2DPreviewModelToContainer(live2dPreviewManager.currentModel);
                 // 确保canvas正确显示，占位符被隐藏
                 document.getElementById('live2d-preview-canvas').style.display = '';
-                document.querySelector('.preview-placeholder').style.display = 'none';
+                const placeholder = document.querySelector('#live2d-preview-content .preview-placeholder');
+                if (placeholder) placeholder.style.display = 'none';
                 // 强制重绘canvas
-                if (live2dPreviewManager.app && live2dPreviewManager.app.renderer) {
-                    live2dPreviewManager.app.renderer.render(live2dPreviewManager.app.stage);
+                if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                    live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
                 }
             }
         }, 100);
@@ -7316,7 +7453,6 @@ function updateCardPreview() {
 document.addEventListener('DOMContentLoaded', function () {
     // 只有 description 输入框仍然存在，为其添加事件监听器
     const descriptionInput = document.getElementById('character-card-description');
-    const characterCardTagsWrapper = document.getElementById('character-card-tags-wrapper');
 
     // 页面加载完成后自动加载音色列表
     loadVoices();
@@ -7325,17 +7461,8 @@ document.addEventListener('DOMContentLoaded', function () {
         descriptionInput.addEventListener('input', updateCardPreview);
     }
 
-    if (characterCardTagsWrapper) {
-        characterCardTagsWrapper.addEventListener('scroll', updateCharacterCardTagScrollControls, { passive: true });
-        if (typeof ResizeObserver !== 'undefined') {
-            const tagsResizeObserver = new ResizeObserver(() => {
-                updateCharacterCardTagScrollControls();
-            });
-            tagsResizeObserver.observe(characterCardTagsWrapper);
-        }
-    }
-
     window.addEventListener('resize', updateCharacterCardTagScrollControls);
+    ensureCharacterCardTagScrollControls();
     window.setTimeout(updateCharacterCardTagScrollControls, 0);
 });
 
@@ -7384,45 +7511,10 @@ async function initLive2DPreview() {
         live2dPreviewManager.applyModelSettings = function (model, options) {
             // 获取预览容器的尺寸
             const container = document.getElementById('live2d-preview-content');
-            if (!container) {
+            if (!container || !this.pixi_app || !this.pixi_app.renderer) {
                 return originalApplyModelSettings(model, options);
             }
-
-            const containerWidth = container.clientWidth;
-            const containerHeight = container.clientHeight;
-
-            // 先设置临时缩放和锚点以便获取实际边界
-            model.anchor.set(0.5, 0.5);
-            model.scale.set(0.1); // 临时缩放值
-            model.x = 0;
-            model.y = 0;
-
-            // 获取模型的实际边界
-            const bounds = model.getBounds();
-            const modelWidth = bounds.width / 0.1; // 还原原始宽度
-            const modelHeight = bounds.height / 0.1; // 还原原始高度
-
-            // 计算适合容器的缩放比例
-            const padding = 30;
-            const availableWidth = Math.max(50, containerWidth - padding * 2);
-            const availableHeight = Math.max(50, containerHeight - padding * 2);
-
-            // 基于实际模型尺寸计算缩放
-            const scaleX = availableWidth / modelWidth;
-            const scaleY = availableHeight / modelHeight;
-
-            // 取较小值确保完整显示
-            let defaultScale = Math.min(scaleX, scaleY);
-            defaultScale = Math.max(0.01, Math.min(defaultScale, 1.0));
-
-            model.scale.set(defaultScale);
-
-            // 将模型居中显示在容器中央
-            model.x = containerWidth * 0.5;
-            model.y = containerHeight * 0.5;
-
-            // 锚点保持中心，确保模型居中缩放
-            model.anchor.set(0.5, 0.5);
+            fitLive2DPreviewModelToContainer(model);
         };
 
         // 添加窗口大小变化的监听，当预览区域大小变化时重新计算模型缩放和位置
@@ -7435,6 +7527,9 @@ async function initLive2DPreview() {
             if (live2dPreviewManager && live2dPreviewManager.currentModel) {
                 // 调用我们覆盖的applyModelSettings方法，重新计算模型缩放和位置
                 live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
+                if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                    live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
+                }
             }
         }
 
@@ -7442,9 +7537,9 @@ async function initLive2DPreview() {
         if (!live2dPreviewManager.removeModel) {
             live2dPreviewManager.removeModel = async function (force) {
                 try {
-                    if (this.currentModel && this.app && this.app.stage) {
+                    if (this.currentModel && this.pixi_app && this.pixi_app.stage) {
                         // 移除当前模型
-                        this.app.stage.removeChild(this.currentModel);
+                        this.pixi_app.stage.removeChild(this.currentModel);
                         this.currentModel = null;
 
                         // 如果有清理资源的方法，调用它

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -7116,6 +7116,8 @@ async function clearAllModelPreviews(showModelNotSetMessage = false) {
 // 清除Live2D预览并显示占位符
 async function clearLive2DPreview(showModelNotSetMessage = false) {
     try {
+        cancelPendingLive2DPreviewLoads();
+
         // 如果有模型加载，先移除它
         if (live2dPreviewManager && live2dPreviewManager.currentModel) {
             await live2dPreviewManager.removeModel(true);
@@ -7164,6 +7166,26 @@ async function clearLive2DPreview(showModelNotSetMessage = false) {
 
 // 通过模型名称加载Live2D模型
 async function loadLive2DModelByName(modelName, modelInfo = null) {
+    const loadGeneration = beginLive2DPreviewLoadGeneration();
+    let loadedModel = null;
+    const ensureCurrentLoad = async () => {
+        if (isCurrentLive2DPreviewLoad(loadGeneration)) {
+            return;
+        }
+
+        if (loadedModel && live2dPreviewManager?.currentModel === loadedModel) {
+            try {
+                await live2dPreviewManager.removeModel(true);
+            } catch (cleanupError) {
+                console.warn('[CharacterCard] 清理过期 Live2D 预览失败:', cleanupError);
+            }
+        }
+
+        const staleError = new Error('Stale Live2D preview load');
+        staleError.code = 'STALE_LIVE2D_PREVIEW_LOAD';
+        throw staleError;
+    };
+
     try {
         // 每次加载前都重新校验预览上下文。
         // Steam 详情面板会动态销毁并重建 canvas，仅凭 manager 是否存在
@@ -7172,6 +7194,7 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         if (!live2dPreviewManager || !live2dPreviewManager.pixi_app) {
             throw new Error('Live2D preview is not ready');
         }
+        await ensureCurrentLoad();
 
         // 强制resize PIXI应用，确保canvas尺寸正确
         // 这是必要的，因为当容器最初是隐藏的(display:none)时，PIXI的尺寸会是0
@@ -7188,6 +7211,7 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
             // 重置当前预览模型引用
             currentPreviewModel = null;
         }
+        await ensureCurrentLoad();
 
         // 如果没有传入modelInfo，则从API获取模型列表
         if (!modelInfo) {
@@ -7204,6 +7228,7 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
                 throw new Error(window.t('steam.modelNotFound', '模型未找到'));
             }
         }
+        await ensureCurrentLoad();
 
         // 确保获取正确的steam_id，优先使用modelInfo中的item_id
         let finalSteamId = modelInfo.item_id;
@@ -7224,6 +7249,7 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         }
         const filesData = await filesRes.json();
         if (!filesData.success) throw new Error(window.t('live2d.modelFilesFetchFailed', '无法获取模型文件列表'));
+        await ensureCurrentLoad();
         window._previewMotionFiles = filesData.motion_files || [];
 
         // 2. Fetch model config
@@ -7245,6 +7271,7 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         const modelConfigRes = await fetch(modelJsonUrl);
         if (!modelConfigRes.ok) throw new Error((window.t && window.t('live2d.modelConfigFetchFailed', { status: modelConfigRes.statusText })) || `无法获取模型配置: ${modelConfigRes.statusText}`);
         const modelConfig = await modelConfigRes.json();
+        await ensureCurrentLoad();
 
         // 3. Add URL context for the loader
         modelConfig.url = modelJsonUrl;
@@ -7278,22 +7305,30 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
             wheelEnabled: true,
             skipCloseWindows: true  // 创意工坊页面不需要关闭其他窗口
         });
+        loadedModel = live2dPreviewManager.currentModel || null;
+        await ensureCurrentLoad();
 
         // 设置当前预览模型引用，用于播放动作和表情
-        currentPreviewModel = live2dPreviewManager.currentModel;
+        currentPreviewModel = loadedModel;
 
         // 清除模型路径，防止拖动预览时自动保存到preference
         live2dPreviewManager._lastLoadedModelPath = null;
 
         // 更新预览控件
         await updatePreviewControlsAfterModelLoad(filesData);
+        await ensureCurrentLoad();
 
         // 模型加载完成后，确保它在容器中正确显示
         setTimeout(() => {
-            if (live2dPreviewManager && live2dPreviewManager.currentModel) {
+            if (!isCurrentLive2DPreviewLoad(loadGeneration)) {
+                return;
+            }
+
+            const canvas = document.getElementById('live2d-preview-canvas');
+            if (live2dPreviewManager && live2dPreviewManager.currentModel && canvas) {
                 fitLive2DPreviewModelToContainer(live2dPreviewManager.currentModel);
                 // 确保canvas正确显示，占位符被隐藏
-                document.getElementById('live2d-preview-canvas').style.display = '';
+                canvas.style.display = '';
                 const placeholder = document.querySelector('#live2d-preview-content .preview-placeholder');
                 if (placeholder) placeholder.style.display = 'none';
                 // 强制重绘canvas
@@ -7307,6 +7342,10 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         selectedModelInfo = modelInfo;
         showMessage((window.t && window.t('live2d.modelLoadSuccess', { model: modelName })) || `模型 ${modelName} 加载成功`, 'success');
     } catch (error) {
+        if (error && error.code === 'STALE_LIVE2D_PREVIEW_LOAD') {
+            return;
+        }
+
         console.error('Failed to load Live2D model by name:', error);
         showMessage((window.t && window.t('live2d.modelLoadFailed', { model: modelName })) || `加载模型 ${modelName} 失败`, 'error');
 
@@ -7488,6 +7527,20 @@ function clearTags(type) {
 // Live2D预览相关功能
 let live2dPreviewManager = null;
 let currentPreviewModel = null;
+let live2dPreviewLoadGeneration = 0;
+
+function beginLive2DPreviewLoadGeneration() {
+    live2dPreviewLoadGeneration += 1;
+    return live2dPreviewLoadGeneration;
+}
+
+function cancelPendingLive2DPreviewLoads() {
+    live2dPreviewLoadGeneration += 1;
+}
+
+function isCurrentLive2DPreviewLoad(loadGeneration) {
+    return loadGeneration === live2dPreviewLoadGeneration;
+}
 
 // 初始化Live2D预览环境
 async function initLive2DPreview() {

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -7165,9 +7165,12 @@ async function clearLive2DPreview(showModelNotSetMessage = false) {
 // 通过模型名称加载Live2D模型
 async function loadLive2DModelByName(modelName, modelInfo = null) {
     try {
-        // 确保live2dPreviewManager已初始化
+        // 每次加载前都重新校验预览上下文。
+        // Steam 详情面板会动态销毁并重建 canvas，仅凭 manager 是否存在
+        // 无法判断它是否还绑定在当前这次打开的预览节点上。
+        await initLive2DPreview();
         if (!live2dPreviewManager || !live2dPreviewManager.pixi_app) {
-            await initLive2DPreview();
+            throw new Error('Live2D preview is not ready');
         }
 
         // 强制resize PIXI应用，确保canvas尺寸正确
@@ -7494,43 +7497,70 @@ async function initLive2DPreview() {
             throw new Error('Live2DManager class not found');
         }
 
-        // 避免重复初始化
-        if (live2dPreviewManager && live2dPreviewManager.pixi_app) {
-            return; // 已经正常初始化，不需要重新初始化
+        const canvasId = 'live2d-preview-canvas';
+        const containerId = 'live2d-preview-content';
+        const canvas = document.getElementById(canvasId);
+        const container = document.getElementById(containerId);
+
+        // Steam 预览区域是动态创建的；在 DOM 尚未生成时静默跳过，
+        // 避免页面初始加载阶段提前报错并污染后续初始化状态。
+        if (!canvas || !container) {
+            return;
         }
 
-        // 清理可能存在的残缺实例
-        live2dPreviewManager = null;
+        if (!live2dPreviewManager) {
+            live2dPreviewManager = new Live2DManager();
+        }
 
-        // 创建一个新的Live2DManager实例
-        live2dPreviewManager = new Live2DManager();
-        await live2dPreviewManager.initPIXI('live2d-preview-canvas', 'live2d-preview-content');
+        const existingView = live2dPreviewManager.pixi_app?.view || null;
+        const needsPixiRebuild = !!(
+            existingView && (
+                existingView !== canvas ||
+                !existingView.isConnected
+            )
+        );
+
+        if (needsPixiRebuild && typeof live2dPreviewManager.rebuildPIXI === 'function') {
+            await live2dPreviewManager.rebuildPIXI(canvasId, containerId);
+        } else if (typeof live2dPreviewManager.ensurePIXIReady === 'function') {
+            await live2dPreviewManager.ensurePIXIReady(canvasId, containerId);
+        } else if (!live2dPreviewManager.pixi_app) {
+            await live2dPreviewManager.initPIXI(canvasId, containerId);
+        }
 
         // 覆盖applyModelSettings方法，为预览模式实现专门的显示逻辑
-        const originalApplyModelSettings = live2dPreviewManager.applyModelSettings;
-        live2dPreviewManager.applyModelSettings = function (model, options) {
-            // 获取预览容器的尺寸
-            const container = document.getElementById('live2d-preview-content');
-            if (!container || !this.pixi_app || !this.pixi_app.renderer) {
-                return originalApplyModelSettings(model, options);
-            }
-            fitLive2DPreviewModelToContainer(model);
-        };
+        if (!live2dPreviewManager._previewApplyModelSettingsPatched) {
+            const originalApplyModelSettings = live2dPreviewManager.applyModelSettings;
+            live2dPreviewManager.applyModelSettings = function (model, options) {
+                // 获取预览容器的尺寸
+                const previewContainer = document.getElementById(containerId);
+                if (!previewContainer || !this.pixi_app || !this.pixi_app.renderer) {
+                    return originalApplyModelSettings.call(this, model, options);
+                }
+                fitLive2DPreviewModelToContainer(model);
+            };
+            live2dPreviewManager._previewApplyModelSettingsPatched = true;
+        }
 
         // 添加窗口大小变化的监听，当预览区域大小变化时重新计算模型缩放和位置
-        function resizePreviewModel() {
-            const container = document.getElementById('live2d-preview-content');
-            if (live2dPreviewManager && live2dPreviewManager.pixi_app && container &&
-                container.clientWidth > 0 && container.clientHeight > 0) {
-                live2dPreviewManager.pixi_app.renderer.resize(container.clientWidth, container.clientHeight);
-            }
-            if (live2dPreviewManager && live2dPreviewManager.currentModel) {
-                // 调用我们覆盖的applyModelSettings方法，重新计算模型缩放和位置
-                live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
-                if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
-                    live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
+        if (!live2dPreviewManager._previewResizeHandlerBound) {
+            function resizePreviewModel() {
+                const previewContainer = document.getElementById(containerId);
+                if (live2dPreviewManager && live2dPreviewManager.pixi_app && previewContainer &&
+                    previewContainer.clientWidth > 0 && previewContainer.clientHeight > 0) {
+                    live2dPreviewManager.pixi_app.renderer.resize(previewContainer.clientWidth, previewContainer.clientHeight);
+                }
+                if (live2dPreviewManager && live2dPreviewManager.currentModel) {
+                    // 调用我们覆盖的applyModelSettings方法，重新计算模型缩放和位置
+                    live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
+                    if (live2dPreviewManager.pixi_app && live2dPreviewManager.pixi_app.renderer) {
+                        live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
+                    }
                 }
             }
+            live2dPreviewManager._previewResizeHandler = resizePreviewModel;
+            live2dPreviewManager._previewResizeHandlerBound = true;
+            window.addEventListener('resize', resizePreviewModel);
         }
 
         // 添加removeModel方法的fallback，防止调用时出错
@@ -7553,9 +7583,6 @@ async function initLive2DPreview() {
             };
         }
 
-        // 添加窗口大小变化监听
-        window.addEventListener('resize', resizePreviewModel);
-
     } catch (error) {
         console.error('Failed to initialize Live2D preview:', error);
         live2dPreviewManager = null;
@@ -7566,8 +7593,9 @@ async function initLive2DPreview() {
 // 从文件夹加载Live2D模型
 async function loadLive2DModelFromFolder(files) {
     try {
+        await initLive2DPreview();
         if (!live2dPreviewManager || !live2dPreviewManager.pixi_app) {
-            await initLive2DPreview();
+            throw new Error('Live2D preview is not ready');
         }
 
         // 获取第一个文件夹的名称
@@ -7814,12 +7842,6 @@ if (playExpressionBtn) {
         }
     });
 }
-
-// 页面加载完成后初始化Live2D预览环境
-document.addEventListener('DOMContentLoaded', function () {
-    // 延迟初始化，确保其他资源已加载
-    setTimeout(initLive2DPreview, 1000);
-});
 
 // 注意事项标签功能
 (function () {

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -7191,10 +7191,10 @@ async function loadLive2DModelByName(modelName, modelInfo = null) {
         // Steam 详情面板会动态销毁并重建 canvas，仅凭 manager 是否存在
         // 无法判断它是否还绑定在当前这次打开的预览节点上。
         await initLive2DPreview();
+        await ensureCurrentLoad();
         if (!live2dPreviewManager || !live2dPreviewManager.pixi_app) {
             throw new Error('Live2D preview is not ready');
         }
-        await ensureCurrentLoad();
 
         // 强制resize PIXI应用，确保canvas尺寸正确
         // 这是必要的，因为当容器最初是隐藏的(display:none)时，PIXI的尺寸会是0


### PR DESCRIPTION
本次提交主要修复两个问题。第一，针对 Steam 订阅角色卡封面，补充了封面标准化处理逻辑：当工坊预览图尺寸比例不适合作为角色卡卡面时，会自动生成统一的 3:4 卡面图，避免出现列表中封面缺失或展示效果不一致的问题，同时保留用户手动设置的卡面不被覆盖。第二，修复了角色卡管理页中 Steam 标签下 Live2D 预览偶发不显示的问题。此前角色详情面板是动态销毁并重建的，关闭后再次打开时，预览管理器可能仍然绑定旧的 canvas，导致动作和表情控件存在但模型画面空白。现在每次加载预览前都会重新校验并重建当前预览上下文，确保 Live2D 模型始终绑定到当前页面可见的 canvas 上。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持从本地预览图生成并回填角色卡牌面；同步结果与接口响应包含回填数量（backfilled_faces）。
  * 新增在新增角色流程中同时生成面图 PNG 与旁侧元数据。
* **Bug Fixes**
  * 更谨慎的回填/刷新策略：依据来源与长宽比容差避免不当覆盖，缺失 sidecar 时阻止刷新。
* **UI 改进**
  * 优化卡牌标签的横向滚动控制与样式作用域。
  * 改善 Live2D 预览的渲染、适配与加载稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->