### PR TITLE
feat(plugin): 持久化 Extension 启停开关到 user config

### DIFF
--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -36,6 +36,7 @@ except ImportError:  # pragma: no cover
 from plugin._types.events import EventHandler, EventMeta, EVENT_META_ATTR
 from plugin._types.version import SDK_VERSION
 from plugin.server.infrastructure.config_resolver import resolve_plugin_config_from_path
+from plugin.server.infrastructure.runtime_overrides import get_runtime_override
 from plugin.core.state import state
 from plugin._types.models import PluginMeta, PluginAuthor, PluginDependency
 from plugin.settings import (
@@ -1027,7 +1028,20 @@ def _parse_single_plugin_config(
     if isinstance(runtime_cfg, dict):
         enabled_val = parse_bool_config(runtime_cfg.get("enabled"), default=True)
         auto_start_val = parse_bool_config(runtime_cfg.get("auto_start"), default=True)
-    
+
+    # 应用用户级运行时开关覆盖（来自 plugin_runtime_overrides.json，
+    # 由 plugin manager UI 的 disable/enable 按钮写入；与 manifest 默认值的
+    # 关系是 manifest -> profile overlay -> user override，user override 最后生效）
+    override = get_runtime_override(str(pid))
+    if override is not None and override != enabled_val:
+        logger.info(
+            "Plugin {} runtime_enabled overridden by user preference: {} -> {}",
+            pid,
+            enabled_val,
+            override,
+        )
+        enabled_val = override
+
     if not enabled_val:
         logger.info(
             "Plugin {} is disabled by plugin_runtime.enabled=false; will register for visibility only (no runtime load)",

--- a/plugin/core/registry.py
+++ b/plugin/core/registry.py
@@ -1228,12 +1228,13 @@ def _build_extension_map(
         if not host_pid:
             continue
         
-        # 检查是否启用
-        runtime_cfg = ctx.conf.get("plugin_runtime")
-        if isinstance(runtime_cfg, dict):
-            if not parse_bool_config(runtime_cfg.get("enabled"), default=True):
-                continue
-        
+        # 用 ctx.enabled 而不是直接重读 conf —— 前者已包含 manifest 默认值
+        # 之上叠加的 user override（plugin_runtime_overrides.json），重读 conf
+        # 会绕过 override，导致初始 host 注入清单和 state.plugins.runtime_enabled
+        # 不一致。
+        if not ctx.enabled:
+            continue
+
         extension_map.setdefault(host_pid, []).append({
             "ext_id": ctx.pid,
             "ext_entry": ctx.entry,

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -30,6 +30,10 @@ from plugin.server.domain import IO_RUNTIME_ERRORS, RUNTIME_ERRORS
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.application.plugins.registry_service import PluginRegistryService
 from plugin.server.infrastructure.config_resolver import resolve_plugin_config_from_path
+from plugin.server.infrastructure.runtime_overrides import (
+    clear_runtime_override,
+    set_runtime_override,
+)
 from plugin.server.messaging.lifecycle_events import emit_lifecycle_event
 from plugin.settings import PLUGIN_CONFIG_ROOTS, PLUGIN_SHUTDOWN_TIMEOUT
 from plugin.utils import parse_bool_config
@@ -934,6 +938,7 @@ class PluginLifecycleService:
             await asyncio.to_thread(_pop_plugin_host_sync, plugin_id)
             await asyncio.to_thread(_remove_event_handlers_sync, plugin_id)
             await asyncio.to_thread(_remove_plugin_metadata_sync, plugin_id)
+            await asyncio.to_thread(clear_runtime_override, plugin_id)
             await plugin_registry_service.refresh_registry()
         except ServerDomainError:
             raise
@@ -1026,6 +1031,7 @@ class PluginLifecycleService:
             result["message"] = "Host not running; extension metadata updated"
 
         await asyncio.to_thread(_set_plugin_runtime_enabled_sync, ext_id, False)
+        await asyncio.to_thread(set_runtime_override, ext_id, False)
         _emit_lifecycle_event(
             event_type="extension_disabled",
             plugin_id=ext_id,
@@ -1116,6 +1122,7 @@ class PluginLifecycleService:
             result["message"] = "Host not running; extension will be injected when host starts"
 
         await asyncio.to_thread(_set_plugin_runtime_enabled_sync, ext_id, True)
+        await asyncio.to_thread(set_runtime_override, ext_id, True)
         _emit_lifecycle_event(
             event_type="extension_enabled",
             plugin_id=ext_id,

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -1,0 +1,127 @@
+"""User-level persistence for per-plugin runtime toggles.
+
+Plugin manifests declare a default ``plugin_runtime.enabled`` value. The plugin
+manager UI lets users override that default at runtime (currently only the
+"Disable / Enable Extension" buttons exposed by ``PluginActions.vue``). Without
+persistence those toggles live only in :data:`plugin.core.state.state.plugins`
+and are lost on restart.
+
+This module persists the user-toggled subset to ``plugin_runtime_overrides.json``
+under the user's app config directory (``ConfigManager.config_dir``). On the
+next registry scan the override is layered on top of the manifest's default so
+the user's choice survives restarts.
+
+Only entries the user actually toggled are stored; the file is intentionally
+small and append-only sparse so that re-installing or upgrading a plugin still
+inherits its manifest default unless the user already had an explicit
+preference.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Mapping
+
+from plugin.logging_config import get_logger
+
+logger = get_logger("server.infrastructure.runtime_overrides")
+
+OVERRIDES_FILENAME = "plugin_runtime_overrides.json"
+
+_cache_lock = threading.Lock()
+_cache: dict[str, bool] | None = None
+
+
+def _coerce_overrides(raw: object) -> dict[str, bool]:
+    if not isinstance(raw, Mapping):
+        return {}
+    result: dict[str, bool] = {}
+    for key, value in raw.items():
+        if isinstance(key, str) and isinstance(value, bool):
+            result[key] = value
+    return result
+
+
+def _load_from_disk() -> dict[str, bool]:
+    try:
+        from utils.config_manager import get_config_manager
+
+        cm = get_config_manager()
+        raw = cm.load_json_config(OVERRIDES_FILENAME, default_value={})
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.warning(
+            "Failed to load plugin runtime overrides from {}: {}",
+            OVERRIDES_FILENAME,
+            exc,
+        )
+        return {}
+    return _coerce_overrides(raw)
+
+
+def _save_to_disk(overrides: dict[str, bool]) -> None:
+    try:
+        from utils.config_manager import get_config_manager
+
+        cm = get_config_manager()
+        cm.save_json_config(OVERRIDES_FILENAME, dict(overrides))
+    except Exception as exc:
+        logger.warning(
+            "Failed to persist plugin runtime overrides to {}: {}",
+            OVERRIDES_FILENAME,
+            exc,
+        )
+
+
+def load_runtime_overrides() -> dict[str, bool]:
+    """Return a snapshot of the persisted overrides; loads on first access."""
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        return dict(_cache)
+
+
+def get_runtime_override(plugin_id: str) -> bool | None:
+    """Return the persisted override for ``plugin_id`` or ``None`` if unset."""
+    if not plugin_id:
+        return None
+    return load_runtime_overrides().get(plugin_id)
+
+
+def set_runtime_override(plugin_id: str, enabled: bool) -> None:
+    """Persist ``enabled`` as the user's override for ``plugin_id``."""
+    if not plugin_id:
+        return
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        if _cache.get(plugin_id) == enabled:
+            return
+        _cache[plugin_id] = enabled
+        snapshot = dict(_cache)
+    _save_to_disk(snapshot)
+
+
+def clear_runtime_override(plugin_id: str) -> None:
+    """Remove the override for ``plugin_id`` (e.g. when the plugin is deleted)."""
+    if not plugin_id:
+        return
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        if plugin_id not in _cache:
+            return
+        _cache.pop(plugin_id, None)
+        snapshot = dict(_cache)
+    _save_to_disk(snapshot)
+
+
+def reset_cache_for_testing() -> None:
+    """Reset in-memory cache; intended for tests that swap the underlying store."""
+    global _cache
+    with _cache_lock:
+        _cache = None

--- a/plugin/server/infrastructure/runtime_overrides.py
+++ b/plugin/server/infrastructure/runtime_overrides.py
@@ -91,7 +91,12 @@ def get_runtime_override(plugin_id: str) -> bool | None:
 
 
 def set_runtime_override(plugin_id: str, enabled: bool) -> None:
-    """Persist ``enabled`` as the user's override for ``plugin_id``."""
+    """Persist ``enabled`` as the user's override for ``plugin_id``.
+
+    The disk write happens while ``_cache_lock`` is still held so that two
+    concurrent toggles cannot race and overwrite each other with stale
+    snapshots (each writer would see only its own mutation).
+    """
     if not plugin_id:
         return
     global _cache
@@ -101,12 +106,15 @@ def set_runtime_override(plugin_id: str, enabled: bool) -> None:
         if _cache.get(plugin_id) == enabled:
             return
         _cache[plugin_id] = enabled
-        snapshot = dict(_cache)
-    _save_to_disk(snapshot)
+        _save_to_disk(dict(_cache))
 
 
 def clear_runtime_override(plugin_id: str) -> None:
-    """Remove the override for ``plugin_id`` (e.g. when the plugin is deleted)."""
+    """Remove the override for ``plugin_id`` (e.g. when the plugin is deleted).
+
+    Holds ``_cache_lock`` across the disk write for the same race-avoidance
+    reason as :func:`set_runtime_override`.
+    """
     if not plugin_id:
         return
     global _cache
@@ -116,8 +124,7 @@ def clear_runtime_override(plugin_id: str) -> None:
         if plugin_id not in _cache:
             return
         _cache.pop(plugin_id, None)
-        snapshot = dict(_cache)
-    _save_to_disk(snapshot)
+        _save_to_disk(dict(_cache))
 
 
 def reset_cache_for_testing() -> None:

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -34,6 +34,32 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture(autouse=True)
+def _isolate_runtime_overrides(monkeypatch: pytest.MonkeyPatch):
+    """Redirect plugin runtime override persistence to an in-memory dict for tests.
+
+    Without this, tests that exercise `disable_extension` / `enable_extension`
+    (directly or via `delete_plugin`) would write to the real user's
+    ``plugin_runtime_overrides.json``, persistently disabling extensions on the
+    developer's machine.
+    """
+    from plugin.server.infrastructure import runtime_overrides as _ro
+
+    fake_store: dict[str, bool] = {}
+
+    monkeypatch.setattr(_ro, "_load_from_disk", lambda: dict(fake_store))
+    monkeypatch.setattr(
+        _ro,
+        "_save_to_disk",
+        lambda overrides: fake_store.clear() or fake_store.update(overrides),
+    )
+    _ro.reset_cache_for_testing()
+    try:
+        yield fake_store
+    finally:
+        _ro.reset_cache_for_testing()
+
+
+@pytest.fixture(autouse=True)
 def _clear_leaked_running_loop(request: pytest.FixtureRequest):
     """Temporarily clear any running event loop leaked by Playwright's greenlet
     so that sync tests see a clean ``asyncio.get_running_loop() → RuntimeError``

--- a/plugin/tests/unit/core/test_registry_build_extension_map.py
+++ b/plugin/tests/unit/core/test_registry_build_extension_map.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugin.core import registry as module
+
+
+def _make_ctx(pid: str, host_pid: str, *, enabled: bool, conf_enabled: bool) -> module.PluginContext:
+    return module.PluginContext(
+        pid=pid,
+        toml_path=Path(f"/tmp/{pid}/plugin.toml"),
+        conf={"plugin_runtime": {"enabled": conf_enabled}},
+        pdata={
+            "id": pid,
+            "type": "extension",
+            "host": {"plugin_id": host_pid, "prefix": ""},
+        },
+        entry=f"tests.fake_{pid}:Plugin",
+        dependencies=[],
+        sdk_supported_str=None,
+        sdk_recommended_str=None,
+        sdk_untested_str=None,
+        sdk_conflicts_list=[],
+        enabled=enabled,
+        auto_start=False,
+    )
+
+
+@pytest.mark.plugin_unit
+def test_build_extension_map_respects_ctx_enabled_user_override():
+    """Regression: user override (mirrored into ctx.enabled) must gate host injection.
+
+    When the user disables an extension via the UI we persist the override and
+    apply it during ``_parse_single_plugin_config``, which sets ``ctx.enabled``.
+    ``_build_extension_map`` previously re-read ``ctx.conf['plugin_runtime']``
+    instead, which holds the raw manifest value — so the extension would still
+    be injected into the host on next start despite the override.
+    """
+    ctx_disabled_via_override = _make_ctx(
+        "ext_off", "host", enabled=False, conf_enabled=True
+    )
+    ctx_normal = _make_ctx("ext_on", "host", enabled=True, conf_enabled=True)
+
+    extension_map = module._build_extension_map([ctx_disabled_via_override, ctx_normal])
+
+    assert "host" in extension_map
+    assert [item["ext_id"] for item in extension_map["host"]] == ["ext_on"]
+
+
+@pytest.mark.plugin_unit
+def test_build_extension_map_skips_when_ctx_disabled_even_if_conf_enabled():
+    ctx = _make_ctx("ext", "host", enabled=False, conf_enabled=True)
+    assert module._build_extension_map([ctx]) == {}
+
+
+@pytest.mark.plugin_unit
+def test_build_extension_map_includes_when_ctx_enabled_and_conf_missing():
+    """conf 没声明 plugin_runtime 时也走 ctx.enabled。"""
+    ctx = module.PluginContext(
+        pid="ext",
+        toml_path=Path("/tmp/ext/plugin.toml"),
+        conf={},  # 无 plugin_runtime 段
+        pdata={
+            "id": "ext",
+            "type": "extension",
+            "host": {"plugin_id": "host", "prefix": ""},
+        },
+        entry="tests.fake_ext:Plugin",
+        dependencies=[],
+        sdk_supported_str=None,
+        sdk_recommended_str=None,
+        sdk_untested_str=None,
+        sdk_conflicts_list=[],
+        enabled=True,
+        auto_start=False,
+    )
+    extension_map = module._build_extension_map([ctx])
+    assert extension_map == {"host": [{"ext_id": "ext", "ext_entry": "tests.fake_ext:Plugin", "prefix": ""}]}

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -12,6 +12,7 @@ from plugin.core import registry as registry_module
 from plugin.server.application.plugins import query_service as query_module
 from plugin.server.application.plugins import lifecycle_service as module
 from plugin.server.domain.errors import ServerDomainError
+from plugin.server.infrastructure import runtime_overrides as runtime_overrides_module
 from plugin.sdk.plugin.decorators import plugin_entry
 
 
@@ -1063,6 +1064,129 @@ async def test_delete_plugin_rejects_host_with_bound_extensions(
         assert exc_info.value.status_code == 409
         assert "demo_ext" in exc_info.value.message
         assert host_dir.exists() is True
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+def _seed_extension(config_path: Path, host_plugin_id: str = "host_plugin") -> None:
+    with module.state.acquire_plugins_write_lock():
+        module.state.plugins.clear()
+        module.state.plugins["demo_ext"] = {
+            "id": "demo_ext",
+            "name": "Demo Extension",
+            "type": "extension",
+            "config_path": str(config_path),
+            "entry_point": "tests.fake_ext:Plugin",
+            "host_plugin_id": host_plugin_id,
+            "runtime_enabled": True,
+        }
+    with module.state.acquire_plugin_hosts_write_lock():
+        module.state.plugin_hosts.clear()
+        module.state.plugin_hosts[host_plugin_id] = _FakeProcessHost(
+            plugin_id=host_plugin_id,
+            entry_point="tests.fake:Host",
+            config_path=config_path.parent.parent / host_plugin_id / "plugin.toml",
+        )
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_disable_and_enable_extension_persist_runtime_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    config_path = tmp_path / "demo_ext" / "plugin.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[plugin]\nid='demo_ext'\n", encoding="utf-8")
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        _seed_extension(config_path)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+        service = module.PluginLifecycleService()
+        await service.disable_extension("demo_ext")
+        assert _isolate_runtime_overrides == {"demo_ext": False}
+        assert runtime_overrides_module.get_runtime_override("demo_ext") is False
+
+        await service.enable_extension("demo_ext")
+        assert _isolate_runtime_overrides == {"demo_ext": True}
+        assert runtime_overrides_module.get_runtime_override("demo_ext") is True
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_delete_plugin_clears_runtime_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    plugin_dir = tmp_path / "demo_plugin"
+    config_path = plugin_dir / "plugin.toml"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[plugin]\nid='demo_plugin'\nentry='tests.fake:Plugin'\n",
+        encoding="utf-8",
+    )
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins["demo_plugin"] = {
+                "id": "demo_plugin",
+                "name": "Demo",
+                "type": "plugin",
+                "config_path": str(config_path),
+                "entry_point": "tests.fake:Plugin",
+            }
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+
+        runtime_overrides_module.set_runtime_override("demo_plugin", False)
+        assert _isolate_runtime_overrides == {"demo_plugin": False}
+
+        async def _refresh_registry() -> dict[str, object]:
+            return {"success": True}
+
+        monkeypatch.setattr(module, "PLUGIN_CONFIG_ROOTS", (tmp_path,))
+        monkeypatch.setattr(module.plugin_registry_service, "refresh_registry", _refresh_registry)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+        service = module.PluginLifecycleService()
+        await service.delete_plugin("demo_plugin")
+
+        assert _isolate_runtime_overrides == {}
+        assert runtime_overrides_module.get_runtime_override("demo_plugin") is None
     finally:
         with module.state.acquire_plugins_write_lock():
             module.state.plugins.clear()

--- a/plugin/tests/unit/server/test_runtime_overrides.py
+++ b/plugin/tests/unit/server/test_runtime_overrides.py
@@ -63,3 +63,34 @@ def test_coerce_overrides_drops_invalid_entries():
 def test_coerce_overrides_handles_non_mapping():
     assert ro._coerce_overrides([1, 2, 3]) == {}
     assert ro._coerce_overrides(None) == {}
+
+
+@pytest.mark.plugin_unit
+def test_set_runtime_override_holds_cache_lock_during_disk_write(
+    _isolate_runtime_overrides, monkeypatch
+):
+    """Regression: set/clear must serialize the disk write under _cache_lock.
+
+    Releasing the lock before writing lets two concurrent toggles capture
+    independent snapshots, then race on `_save_to_disk` order — the second
+    write wins and the first toggle's plugin_id silently disappears.
+    """
+    lock_held_during_save: list[bool] = []
+    original_save = ro._save_to_disk
+
+    def _spy(overrides):
+        # On a non-reentrant Lock, a non-blocking acquire from the holder thread
+        # still returns False — so this is True iff the lock is currently held.
+        acquired = ro._cache_lock.acquire(blocking=False)
+        lock_held_during_save.append(not acquired)
+        if acquired:
+            ro._cache_lock.release()
+        original_save(overrides)
+
+    monkeypatch.setattr(ro, "_save_to_disk", _spy)
+    ro.reset_cache_for_testing()
+
+    ro.set_runtime_override("alpha", False)
+    ro.clear_runtime_override("alpha")
+
+    assert lock_held_during_save == [True, True]

--- a/plugin/tests/unit/server/test_runtime_overrides.py
+++ b/plugin/tests/unit/server/test_runtime_overrides.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from plugin.server.infrastructure import runtime_overrides as ro
+
+
+@pytest.mark.plugin_unit
+def test_runtime_overrides_set_load_clear_roundtrip(_isolate_runtime_overrides):
+    assert ro.load_runtime_overrides() == {}
+
+    ro.set_runtime_override("alpha", False)
+    ro.set_runtime_override("beta", True)
+    assert ro.load_runtime_overrides() == {"alpha": False, "beta": True}
+    assert ro.get_runtime_override("alpha") is False
+    assert ro.get_runtime_override("beta") is True
+    assert ro.get_runtime_override("missing") is None
+
+    ro.clear_runtime_override("alpha")
+    assert ro.load_runtime_overrides() == {"beta": True}
+    assert ro.get_runtime_override("alpha") is None
+
+
+@pytest.mark.plugin_unit
+def test_runtime_overrides_set_no_op_when_unchanged(_isolate_runtime_overrides, monkeypatch):
+    write_calls: list[dict[str, bool]] = []
+
+    original_save = ro._save_to_disk
+
+    def _spy_save(overrides):
+        write_calls.append(dict(overrides))
+        original_save(overrides)
+
+    monkeypatch.setattr(ro, "_save_to_disk", _spy_save)
+    ro.reset_cache_for_testing()
+
+    ro.set_runtime_override("alpha", False)
+    ro.set_runtime_override("alpha", False)  # 同值，不应再写
+    ro.set_runtime_override("alpha", True)   # 翻转，应写
+
+    assert [list(call.items()) for call in write_calls] == [
+        [("alpha", False)],
+        [("alpha", True)],
+    ]
+
+
+@pytest.mark.plugin_unit
+def test_runtime_overrides_ignore_blank_plugin_id(_isolate_runtime_overrides):
+    ro.set_runtime_override("", False)
+    ro.clear_runtime_override("")
+    assert ro.get_runtime_override("") is None
+    assert ro.load_runtime_overrides() == {}
+
+
+@pytest.mark.plugin_unit
+def test_coerce_overrides_drops_invalid_entries():
+    """Non-bool / non-string entries from disk are silently dropped."""
+    coerced = ro._coerce_overrides({"good": True, "bad": "yes", 42: True, "neg": False})
+    assert coerced == {"good": True, "neg": False}
+
+
+@pytest.mark.plugin_unit
+def test_coerce_overrides_handles_non_mapping():
+    assert ro._coerce_overrides([1, 2, 3]) == {}
+    assert ro._coerce_overrides(None) == {}


### PR DESCRIPTION
## Summary

- 之前 Extension 的 disable/enable 只更新内存里的 `state.plugins[id]["runtime_enabled"]`，重启或刷新 registry 后用户的选择会丢失，回到 manifest 默认值。
- 现在把 toggle 落盘到 `<ConfigManager.config_dir>/plugin_runtime_overrides.json`，registry 扫描在 manifest 默认值之上再叠一层 user override，重启后保持一致。
- delete_plugin 时清理对应 override，防止同名插件重装后被残留偏好误关。

## 关键改动

- `plugin/server/infrastructure/runtime_overrides.py`：load/get/set/clear API + 模块级缓存，I/O 走 `ConfigManager.load_json_config` / `save_json_config`，失败仅 warn 不抛。
- `plugin/core/registry.py:_parse_single_plugin_config`：在解析完 `plugin_runtime.enabled` 后应用 override，叠加顺序为 manifest → profile overlay → user override。
- `plugin/server/application/plugins/lifecycle_service.py`：`disable_extension` / `enable_extension` 落盘对应 override，`delete_plugin` 走 `clear_runtime_override`。
- `plugin/tests/conftest.py`：autouse fixture 把 override 存储重定向到 in-memory dict，避免 lifecycle 测试污染开发者真实 `~/Documents/N.E.K.O/config/`。

## Test plan

- [x] 新增 `test_runtime_overrides.py`：load/set/clear roundtrip、重复写值无 op、空 plugin_id 安全、payload coerce。
- [x] 在 `test_plugins_lifecycle_service.py` 加两个测试：`disable_extension` → 落盘、`enable_extension` → 落盘翻转、`delete_plugin` → 清理。
- [x] `uv run pytest plugin/tests`：450 passed / 1 skipped / 0 failed。
- [ ] 手动：重启 app，UI 关掉一个 extension，重启再看是否仍处于 disabled。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加用户可控的插件运行时启用/禁用覆盖，并持久化保存与读取，支持立即生效。

* **修复/改进**
  * 在插件启用/禁用与删除时同步并清理运行时覆盖，防止遗留不一致。
  * 主机注入逻辑现在尊重用户运行时覆盖，避免注入列表与运行时状态不一致。

* **测试**
  * 新增单元测试覆盖持久化、读取、清理、并发保护及注入行为，测试互相隔离。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->