### PR TITLE
refactor(memory): 5 站点开 thinking + 锁外化 + rebuttal drain + 周期降至 180s

### DIFF
--- a/memory/persona.py
+++ b/memory/persona.py
@@ -137,6 +137,12 @@ class PersonaManager:
         # (pure-Python block, no await inside).
         self._alocks: dict[str, asyncio.Lock] = {}
         self._alocks_guard = threading.Lock()
+        # 独立的 resolve_corrections 串行锁——只为防多入口（IdleMaint subtask 2
+        # 与 _extract_facts_and_check_feedback）并发触发同名角色的 LLM 重叠
+        # 应用导致重复处理同一批 corrections。本锁与 _alocks (data lock)
+        # 完全分开，所以 LLM 期间 aadd_fact / arecord_mentions / aapply_signal
+        # 仍能正常拿 _alocks 推进（不再卡 /process 路径）。
+        self._resolve_alocks: dict[str, asyncio.Lock] = {}
         # memory-evidence-rfc §3.3.3：evidence 写路径必须走 record_and_save，
         # 保证 event↔view 合约。event_log 注入；None 时 aapply_signal 不可用。
         self._event_log = event_log
@@ -153,6 +159,19 @@ class PersonaManager:
                 if name not in self._alocks:
                     self._alocks[name] = asyncio.Lock()
         return self._alocks[name]
+
+    def _get_resolve_alock(self, name: str) -> asyncio.Lock:
+        """Per-character asyncio.Lock 专用于 resolve_corrections 串行化。
+
+        只 serialize resolve_corrections 之间的并发，**不**与 data lock
+        (_get_alock) 互锁。LLM 调用在本锁内、data lock 外——data lock 仅
+        在 LLM 前后的短临界区被借用。
+        """
+        if name not in self._resolve_alocks:
+            with self._alocks_guard:
+                if name not in self._resolve_alocks:
+                    self._resolve_alocks[name] = asyncio.Lock()
+        return self._resolve_alocks[name]
 
     # ── file paths ───────────────────────────────────────────────────
 
@@ -1559,76 +1578,118 @@ class PersonaManager:
         将所有 pending corrections 合并为一个 prompt 发给 correction model，
         返回处理的矛盾数量。
 
-        P2.a.2: 角色级 asyncio.Lock 串行化；整个流程（load + LLM + write back）
-        都在锁内，避免 aadd_fact / arecord_mentions 并发写 persona.json。
-        """
-        async with self._get_alock(name):
-            return await self._resolve_corrections_locked(name)
+        C4 重构 + thinking：LLM 调用在 data lock 外。data lock 仅在 LLM
+        前后短暂借用（load corrections / load persona + apply + save）。
+        独立的 _resolve_alock 串行同名角色的 resolve_corrections 调用，
+        防多入口（IdleMaint subtask 2 与 _extract_facts_and_check_feedback）
+        并发触发同一批 corrections 被重复处理（特别是 keep_new 没有 dedup
+        会导致重复 append）。
 
-    async def _resolve_corrections_locked(self, name: str) -> int:
-        """resolve_corrections 的内部实现。调用方必须已持有
-        self._get_alock(name)。"""
+        为什么这样安全：
+        - LLM 期间 aadd_fact / arecord_mentions / aapply_signal / aensure_persona
+          可正常拿 data lock 推进，不再卡 /process 路径
+        - resolve 之间互斥（resolve_alock）防同批 corrections 重复处理
+        - apply 阶段读 fresh persona，与 LLM 期间被并发写入的 persona 状态
+          自然合并
+        - 末尾"重读 corrections 文件 → filter processed_keys → save"已经
+          做了对 LLM 期间新增 correction 的保护
+        """
         from config.prompts_memory import persona_correction_prompt
 
-        corrections = await self.aload_pending_corrections(name)
-        if not corrections:
-            return 0
+        # ── 串行 resolve（独立锁，与 data lock 不互锁） ──
+        async with self._get_resolve_alock(name):
+            # ── 短临界 1: 拿 corrections 列表 ──
+            async with self._get_alock(name):
+                corrections = await self.aload_pending_corrections(name)
+            if not corrections:
+                return 0
 
-        # 合并所有矛盾为单个 prompt。受 PERSONA_CORRECTION_BATCH_LIMIT
-        # 限制：corrections 队列可能堆积，单次只处理前 N 条，剩下的下次
-        # 触发时再处理。
-        from config import PERSONA_CORRECTION_BATCH_LIMIT
-        pairs = []
-        for i, item in enumerate(corrections):
-            old_text = item.get('old_text', '')
-            new_text = item.get('new_text', '')
-            if old_text and new_text:
-                pairs.append((i, item))
-            if len(pairs) >= PERSONA_CORRECTION_BATCH_LIMIT:
-                break
-        if not pairs:
-            return 0
-        # 仅允许"本批送进 prompt"的全局 index 被消费 —— LLM 偶尔会回写
-        # 没在这一批 prompt 里的合法全局 index（比如 hallucinate 出未来批
-        # 的 idx），不防的话会误改未送审的 corrections，导致队列数据被
-        # 错误消费。
-        allowed_indices = {i for i, _ in pairs}
+            # 合并所有矛盾为单个 prompt。受 PERSONA_CORRECTION_BATCH_LIMIT
+            # 限制：corrections 队列可能堆积，单次只处理前 N 条，剩下的下次
+            # 触发时再处理。
+            from config import PERSONA_CORRECTION_BATCH_LIMIT
+            pairs = []
+            for i, item in enumerate(corrections):
+                old_text = item.get('old_text', '')
+                new_text = item.get('new_text', '')
+                if old_text and new_text:
+                    pairs.append((i, item))
+                if len(pairs) >= PERSONA_CORRECTION_BATCH_LIMIT:
+                    break
+            if not pairs:
+                return 0
+            # 仅允许"本批送进 prompt"的全局 index 被消费 —— LLM 偶尔会回写
+            # 没在这一批 prompt 里的合法全局 index（比如 hallucinate 出未来批
+            # 的 idx），不防的话会误改未送审的 corrections，导致队列数据被
+            # 错误消费。
+            allowed_indices = {i for i, _ in pairs}
 
-        batch_text = "\n".join(
-            f"[{i}] 已有: {item['old_text']} | 新观察: {item['new_text']}"
-            for i, item in pairs
-        )
-        prompt = persona_correction_prompt.format(pairs=batch_text, count=len(pairs))
-
-        try:
-            from utils.token_tracker import set_call_type
-            from utils.llm_client import create_chat_llm
-            set_call_type("memory_correction")
-            api_config = self._config_manager.get_model_api_config('correction')
-            # timeout=90: 持 PersonaManager 锁，锁住期间会卡 /process 路径上的
-            # arecord_mentions / aapply_signal / aensure_persona，必须有时长上限。
-            # max_retries=0: 禁 SDK 自动重试，避免叠加（这里没业务 retry，单次即终态）。
-            llm = create_chat_llm(
-                api_config['model'],
-                api_config['base_url'], api_config['api_key'],
-                timeout=90, max_retries=0,
+            batch_text = "\n".join(
+                f"[{i}] 已有: {item['old_text']} | 新观察: {item['new_text']}"
+                for i, item in pairs
             )
-            try:
-                resp = await llm.ainvoke(prompt)
-            finally:
-                await llm.aclose()
-            raw = resp.content
-            if raw.startswith("```"):
-                raw = raw.replace("```json", "").replace("```", "").strip()
-            results = robust_json_loads(raw)
-            if not isinstance(results, list):
-                results = [results]
-        except Exception as e:
-            logger.warning(f"[Persona] {name}: correction model 调用失败: {e}")
-            return 0
+            prompt = persona_correction_prompt.format(pairs=batch_text, count=len(pairs))
 
-        # 应用结果（本函数被 resolve_corrections 在锁下调用，故用 _locked 变体）
-        persona = await self._aensure_persona_locked(name)
+            # ── LLM (锁外) ──
+            try:
+                from utils.token_tracker import set_call_type
+                from utils.llm_client import create_chat_llm
+                set_call_type("memory_correction")
+                api_config = self._config_manager.get_model_api_config('correction')
+                # timeout=120: 开 thinking 后批量决策（每对 keep_old/keep_new/
+                # keep_both/replace + 重写 merged_text）值得思考——后果不可逆
+                # （persona pollution）。LLM 在 data lock 外，可放宽 timeout
+                # 不阻塞 /process 路径上的 arecord_mentions / aapply_signal。
+                # max_retries=0: 禁 SDK 自动重试（这里没业务 retry，单次即终态）。
+                # extra_body=None: 显式开 thinking。
+                llm = create_chat_llm(
+                    api_config['model'],
+                    api_config['base_url'], api_config['api_key'],
+                    timeout=120, max_retries=0,
+                    extra_body=None,
+                )
+                try:
+                    resp = await llm.ainvoke(prompt)
+                finally:
+                    await llm.aclose()
+                raw = resp.content
+                if raw.startswith("```"):
+                    raw = raw.replace("```json", "").replace("```", "").strip()
+                results = robust_json_loads(raw)
+                if not isinstance(results, list):
+                    results = [results]
+            except Exception as e:
+                logger.warning(f"[Persona] {name}: correction model 调用失败: {e}")
+                return 0
+
+            # ── 短临界 2: load fresh persona + apply + save ──
+            return await self._apply_correction_results(
+                name, corrections, allowed_indices, results,
+            )
+
+    async def _apply_correction_results(
+        self,
+        name: str,
+        corrections: list[dict],
+        allowed_indices: set,
+        results: list,
+    ) -> int:
+        """resolve_corrections 的 LLM-后应用阶段。在 data lock 内执行。"""
+        async with self._get_alock(name):
+            persona = await self._aensure_persona_locked(name)
+            return await self._apply_correction_results_locked(
+                name, persona, corrections, allowed_indices, results,
+            )
+
+    async def _apply_correction_results_locked(
+        self,
+        name: str,
+        persona: dict,
+        corrections: list[dict],
+        allowed_indices: set,
+        results: list,
+    ) -> int:
+        """data lock 已持有时的 apply 实现。"""
         resolved = 0
         for result in results:
             if not isinstance(result, dict):

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -1527,12 +1527,17 @@ class ReflectionEngine:
         try:
             set_call_type("memory_rebuttal_check")
             api_config = self._config_manager.get_model_api_config('summary')
-            # timeout=60: 周期性反驳扫描，后台跑无人等。
+            # timeout=90: 开 thinking 后判断"用户最近的话否定了哪条 confirmed
+            # reflection"——drain 模式下每批最多 20 条 user msg × 多条
+            # confirmed reflection，思考能改善误判（防止把 user 的反讽 / 情景
+            # 转换误标为否定）。完全后台无锁，没人等结果，安全开 thinking。
             # max_retries=0: 禁 SDK 自动重试，失败 cursor 不推进自然下轮重试。
+            # extra_body=None: 显式开 thinking。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
-                timeout=60, max_retries=0,
+                timeout=90, max_retries=0,
+                extra_body=None,
             )
             try:
                 resp = await llm.ainvoke(prompt)

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -617,15 +617,15 @@ class ReflectionEngine:
           4. 始终在末尾 amark_absorbed，确保 save 成功但 mark 失败后的
              重启补跑能真正把 facts 的 absorbed 置为 True。
 
-        并发（P2.a.2）：整个方法在角色级 asyncio.Lock 下串行，避免与
-        aauto_promote_stale / aconfirm_promotion 竞写 reflections.json。
+        并发（C3 重构 + thinking）：LLM 调用在锁外。锁仅守护"再 load → id
+        dedup → append → save"这一段几十毫秒的临界区。这样：
+          - LLM (90-120s with thinking) 期间不阻塞同角色其他 reflection 写
+            （aapply_signal / aauto_promote_stale 的 pending→confirmed 段 /
+             arecord_mentions / aget_followup_topics 等）
+          - 双写防御：rid 由 source_fact_ids 决定（确定性），并发 synth 拿同
+            一批 facts 算出同 rid，post-LLM 锁内 dedup append 兜住。失败一方
+            返回 [] 不污染 caller 视图。
         """
-        async with self._get_alock(lanlan_name):
-            return await self._synthesize_reflections_locked(lanlan_name)
-
-    async def _synthesize_reflections_locked(self, lanlan_name: str) -> list[dict]:
-        """synthesize_reflections 的内部实现。调用方必须已持有
-        self._get_alock(lanlan_name)。"""
         from config.prompts_memory import get_reflection_prompt
         from utils.language_utils import get_global_language
         from utils.llm_client import create_chat_llm
@@ -656,6 +656,8 @@ class ReflectionEngine:
 
         # 幂等 short-circuit：同一批 facts 的 reflection 已持久化 →
         # 不重复调 LLM，仅补跑 mark_absorbed（致命点 3 的重启补救路径）
+        # 注：这里是 lock-外的 advisory check，提早避免无谓 LLM；最终
+        # dedup 在 lock-内重做（防 LLM 期间并发写入）。
         existing_reflections = await self.aload_reflections(lanlan_name)
         existing = next((r for r in existing_reflections if r.get('id') == rid), None)
         if existing is not None:
@@ -678,14 +680,18 @@ class ReflectionEngine:
         try:
             set_call_type("memory_reflection")
             api_config = self._config_manager.get_model_api_config('summary')
-            # timeout=90: 持 reflection 锁，输出多字段 JSON ontology（reflection
-            # text + entity + relation_type + temporal_scope + subject）较长。
+            # timeout=120: 开 thinking 后输出多字段 JSON ontology（reflection
+            # text + entity + relation_type + temporal_scope + subject）+ 思考
+            # 过程，比简单分类长。LLM 在锁外，不阻塞同角色其他 reflection 写。
             # max_retries=0: 禁 SDK 自动重试（无业务 retry，单次即终态，外层
             # try/except 兜底返回 []）。
+            # extra_body=None: 显式开 thinking——synth 是创意+结构化合成，
+            # 思考能改善 ontology 字段的一致性和 reflection text 的质量。
             llm = create_chat_llm(
                 api_config['model'],
                 api_config['base_url'], api_config['api_key'],
-                timeout=90, max_retries=0,
+                timeout=120, max_retries=0,
+                extra_body=None,
             )
             try:
                 resp = await llm.ainvoke(prompt)
@@ -777,19 +783,22 @@ class ReflectionEngine:
             'subject': subject,
         })
 
-        # 再次 load：LLM 调用期间可能有并发 synth；用最新 list 做 id dedup 追加
-        reflections = await self.aload_reflections(lanlan_name)
-        created = False
-        if any(r.get('id') == rid for r in reflections):
-            logger.info(
-                f"[Reflection] {lanlan_name}: reflection {rid} 已被并发 synth 写入，跳过重复 append"
-            )
-        else:
-            reflections.append(reflection)
-            await self.asave_reflections(lanlan_name, reflections)
-            created = True
+        # ── LOCK 仅护住 re-load + dedup append + save ──
+        async with self._get_alock(lanlan_name):
+            # 再次 load：LLM 调用期间可能有并发 synth；用最新 list 做 id dedup 追加
+            reflections = await self.aload_reflections(lanlan_name)
+            created = False
+            if any(r.get('id') == rid for r in reflections):
+                logger.info(
+                    f"[Reflection] {lanlan_name}: reflection {rid} 已被并发 synth 写入，跳过重复 append"
+                )
+            else:
+                reflections.append(reflection)
+                await self.asave_reflections(lanlan_name, reflections)
+                created = True
 
         # 无条件 mark_absorbed：幂等，且覆盖 save 成功后但在此崩溃的补跑情况
+        # （fact_store 自己有锁，不需要在 reflection 锁内）
         await self._fact_store.amark_absorbed(lanlan_name, source_fact_ids)
 
         if not created:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -2093,15 +2093,18 @@ class ReflectionEngine:
         api_config = self._config_manager.get_model_api_config(
             EVIDENCE_PROMOTION_MERGE_MODEL_TIER,
         )
-        # timeout=45: LLM 在 reflection 锁外，但 /process 末尾会同步等
-        # aauto_promote_stale 串行处理多个 reflection。每个 promote_merge
-        # prompt 决策短、输出短，应该 <10s 完成；45s 给 4-5x 裕度，超时即
-        # 触发已有 throttle/backoff 路径（EVIDENCE_PROMOTE_RETRY_BACKOFF_MINUTES）。
+        # timeout=90: 开 thinking 后 promote merge 决策（merge_into / promote_fresh /
+        # reject + target_id 选择 + 重写 merged_text）值得思考——后果不可逆
+        # （persona pollution），已有 throttle/backoff/dead-letter 兜底，开
+        # thinking 完全在收益侧。LLM 调用本身在锁外（pre/post 短临界区分别拿
+        # reflection 锁做 stamp 和 CAS），所以 90s 不阻塞同角色其他 reflection 写。
         # max_retries=0: 禁 SDK 自动重试，由 throttle/dead-letter 兜底。
+        # extra_body=None: 显式开 thinking。
         llm = create_chat_llm(
             api_config['model'],
             api_config['base_url'], api_config['api_key'],
-            timeout=45, max_retries=0,
+            timeout=90, max_retries=0,
+            extra_body=None,
         )
         try:
             resp = await llm.ainvoke(prompt)

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -307,10 +307,19 @@ class TimeIndexedMemory:
     async def aretrieve_summary_by_timeframe(self, lanlan_name, start_time, end_time):
         return []
 
-    def retrieve_original_by_timeframe(self, lanlan_name, start_time, end_time):
-        # 懒加载：首次访问时（例如重启后立刻读取）需要注册 engine，
-        # 否则 rebuttal loop 会静默跳过，直到 store_conversation 才触发建表。
-        # 读路径走 readonly，维护态也允许读。
+    def retrieve_original_by_timeframe(self, lanlan_name, start_time, end_time, limit_rows: int | None = None):
+        """读取 [start_time, end_time] 窗口内的原始对话行。
+
+        返回 ``[(timestamp, session_id, message), ...]``，按 timestamp ASC 排
+        序——保证 caller 可以基于最后一行的 ts 推进 cursor 做 drainage。
+
+        ``limit_rows`` 不为 None 时在 SQL 层加 LIMIT，防止超长 fallback 窗口
+        把整张表拉进内存。
+
+        懒加载：首次访问（例如重启后立刻读取）需要注册 engine，否则 rebuttal
+        loop 会静默跳过，直到 store_conversation 才触发建表。读路径走
+        readonly，维护态也允许读。
+        """
         try:
             if not self._ensure_engine_exists(lanlan_name, readonly=True):
                 return []
@@ -319,20 +328,25 @@ class TimeIndexedMemory:
             return []
         table_name = self._validate_table_name(TIME_ORIGINAL_TABLE_NAME)
         try:
-            # 查询指定时间范围内的对话
+            sql = (
+                f"SELECT timestamp, session_id, message FROM {table_name} "
+                f"WHERE timestamp BETWEEN :start_time AND :end_time "
+                f"ORDER BY timestamp ASC"
+            )
+            params: dict = {"start_time": start_time, "end_time": end_time}
+            if limit_rows is not None and limit_rows > 0:
+                sql += " LIMIT :limit_rows"
+                params["limit_rows"] = int(limit_rows)
             with self.engines[lanlan_name].connect() as conn:
-                result = conn.execute(
-                    text(f"SELECT session_id, message FROM {table_name} WHERE timestamp BETWEEN :start_time AND :end_time"),
-                    {"start_time": start_time, "end_time": end_time}
-                )
+                result = conn.execute(text(sql), params)
                 return result.fetchall()
         except Exception as e:
             logger.warning(f"[TimeIndexedMemory] 按时间范围读取原始对话失败: {e}")
             return []
 
-    async def aretrieve_original_by_timeframe(self, lanlan_name, start_time, end_time):
+    async def aretrieve_original_by_timeframe(self, lanlan_name, start_time, end_time, limit_rows: int | None = None):
         return await asyncio.to_thread(
-            self.retrieve_original_by_timeframe, lanlan_name, start_time, end_time
+            self.retrieve_original_by_timeframe, lanlan_name, start_time, end_time, limit_rows
         )
 
     # ── FTS5 事实索引 ─────────────────────────────────────────────

--- a/memory_server.py
+++ b/memory_server.py
@@ -2140,20 +2140,29 @@ async def api_reflect(lanlan_name: str):
     absorbed 标记竞态问题。
     """
     lanlan_name = validate_lanlan_name(lanlan_name)
-    auto_transitions = 0
     reflection_result = None
-    try:
-        auto_transitions = await reflection_engine.aauto_promote_stale(lanlan_name)
-    except Exception as e:
-        logger.debug(f"[ReflectAPI] {lanlan_name}: auto_promote_stale 失败: {e}")
+    # auto_promote_stale 改 fire-and-forget：开 thinking 后 promote_merge 单
+    # 调用可能 30-90s，串行多个 confirmed reflection 累计能超 client 15s
+    # timeout。periodic auto_promote loop 每 180s 跑一次会兜底，本端点不
+    # 等也安全。caller (system_router) 仅用 auto_transitions 打 log，丢失
+    # 计数无功能影响。
+    _spawn_background_task(_safe_auto_promote(lanlan_name))
     try:
         reflection_result = await reflection_engine.reflect(lanlan_name)
     except Exception as e:
         logger.debug(f"[ReflectAPI] {lanlan_name}: reflect 失败: {e}")
     return {
         "reflection": reflection_result,
-        "auto_transitions": auto_transitions,
+        "auto_transitions": 0,  # fire-and-forget，本调用不返回真实计数
     }
+
+
+async def _safe_auto_promote(lanlan_name: str) -> None:
+    """fire-and-forget 包装，吞 reflection_engine.aauto_promote_stale 的异常。"""
+    try:
+        await reflection_engine.aauto_promote_stale(lanlan_name)
+    except Exception as e:
+        logger.debug(f"[ReflectAPI] {lanlan_name}: 后台 auto_promote_stale 失败: {e}")
 
 
 @app.get("/followup_topics/{lanlan_name}")

--- a/memory_server.py
+++ b/memory_server.py
@@ -645,17 +645,42 @@ REBUTTAL_DRAIN_BATCH_LIMIT = 20
 REBUTTAL_SQL_ROW_LIMIT = 200
 
 
-def _extract_user_messages_with_ts_from_rows(rows: list) -> list[tuple[str, object]]:
+def _coerce_db_ts(ts) -> datetime | None:
+    """归一化 SQL 行里的 timestamp 字段为 datetime。
+
+    SQLAlchemy + SQLite 在某些 driver 配置下返回字符串而非 datetime；与
+    memory/timeindex.py:get_last_conversation_time 同款归一化。返回 None
+    表示无法解析（caller 应跳过此行而不是把 None 写进 cursor）。
+    """
+    if isinstance(ts, datetime):
+        return ts
+    if isinstance(ts, str):
+        try:
+            return datetime.fromisoformat(ts)
+        except ValueError:
+            try:
+                return datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")
+            except ValueError:
+                return None
+    return None
+
+
+def _extract_user_messages_with_ts_from_rows(rows: list) -> list[tuple[str, datetime]]:
     """从 time_indexed SQL 查询结果中提取 (用户消息文本, timestamp) 元组。
 
     rows: [(timestamp, session_id, message_json), ...] (ASC ordered by ts)
     message_json 是 langchain SQLChatMessageHistory 存储的 JSON 字符串。
     content 可能是 str 或 list[{type, text}]。
 
-    返回的 list 同样按 ts ASC 排序，caller 可基于 last item 的 ts 推 cursor。
+    返回的 list 按 ts ASC 排序，caller 可基于 last item 的 ts 推 cursor。
+    timestamp 通过 _coerce_db_ts 归一化为 datetime 对象（SQL driver 可能
+    返回 str）；解析失败的行会被跳过。
     """
-    out: list[tuple[str, object]] = []
-    for ts, _, msg_json in rows:
+    out: list[tuple[str, datetime]] = []
+    for ts_raw, _, msg_json in rows:
+        ts = _coerce_db_ts(ts_raw)
+        if ts is None:
+            continue
         try:
             msg = json.loads(msg_json) if isinstance(msg_json, str) else msg_json
             if isinstance(msg, dict) and msg.get('type') == 'human':
@@ -801,17 +826,19 @@ async def _periodic_rebuttal_loop():
                     )
                     return
 
-                # 提取 (msg, ts) 元组（ASC by ts）
+                # 提取 (msg, ts) 元组（ASC by ts；ts 已归一化为 datetime）
                 user_msgs_with_ts = _extract_user_messages_with_ts_from_rows(rows)
                 if not user_msgs_with_ts:
                     # 窗口里只有 AI 消息或无 user 内容 → 推进 cursor 到 SQL 截
                     # 取的最后一行 ts（如果命中 LIMIT 还有更多行）或 now（清空了）
-                    last_row_ts = rows[-1][0]
-                    if len(rows) >= REBUTTAL_SQL_ROW_LIMIT:
+                    last_row_ts = _coerce_db_ts(rows[-1][0])
+                    if len(rows) >= REBUTTAL_SQL_ROW_LIMIT and last_row_ts is not None:
                         await cursor_store.aset_cursor(
                             name, CURSOR_REBUTTAL_CHECKED_UNTIL, last_row_ts,
                         )
                     else:
+                        # 既然没命中 LIMIT，窗口已经全部扫过；直接推到 now。
+                        # last_row_ts 解析失败也走这条（保守 fallback）。
                         await cursor_store.aset_cursor(
                             name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
                         )

--- a/memory_server.py
+++ b/memory_server.py
@@ -844,8 +844,25 @@ async def _periodic_rebuttal_loop():
                         )
                     return
 
-                # Drain 取前 N 条 user msg
+                # Drain 取前 N 条 user msg。然后扩展 batch 把和 batch 末位
+                # 共享同 ts 的后续 user msg 也吸收进来——因为 SQL 用
+                # ``timestamp BETWEEN`` (inclusive)，cursor 推进到 batch[-1].ts
+                # 后下一轮会把同 ts 的行原样重读。如果不扩展，多条同 ts 的
+                # user msg 在 batch 边界被切，会出现"只处理一部分，剩下的下
+                # 轮当 batch 边界又被切"的死循环（``store_conversation`` 一
+                # 批 message 共享 timestamp，所以同 ts 多条很常见）。
+                # 扩展受 SQL 行 LIMIT 兜底，不会无界增长。
                 batch = user_msgs_with_ts[:REBUTTAL_DRAIN_BATCH_LIMIT]
+                if len(user_msgs_with_ts) > len(batch):
+                    boundary_ts = batch[-1][1]
+                    extend_idx = len(batch)
+                    while (
+                        extend_idx < len(user_msgs_with_ts)
+                        and user_msgs_with_ts[extend_idx][1] == boundary_ts
+                    ):
+                        extend_idx += 1
+                    if extend_idx > len(batch):
+                        batch = user_msgs_with_ts[:extend_idx]
                 user_msgs = [m for m, _ in batch]
 
                 # 复用 check_feedback 判断反驳
@@ -858,16 +875,27 @@ async def _periodic_rebuttal_loop():
                     return
 
                 # 成功才推进游标并持久化。Drain 推进规则：
-                # - 处理了所有 user msg（batch 等于全量）且 SQL 没命中 LIMIT
-                #   → cursor 推进到 now（窗口已干净）
-                # - 命中 drain limit 或 SQL limit（还有未处理的）
-                #   → cursor 只推进到本批最后一条 ts，下一轮接着排
+                # - 还有 user msgs 在本次 read 内未处理（batch 已扩展含所有
+                #   同 ts，所以剩余的 ts 一定 > batch[-1].ts）
+                #   → cursor 推到第一个未处理 user msg 的 ts（next read 的
+                #     BETWEEN 起点，包含该行不会重处理因为它本来就 unprocessed）
+                # - SQL 命中 LIMIT 但 user msgs 全处理 → cursor 推到最后一行 ts
+                #   (next read 会重读 same-ts cluster 但 LLM 调用幂等无害)
+                # - 全干净 → cursor 推到 now
                 more_user_msgs = len(user_msgs_with_ts) > len(batch)
                 hit_sql_limit = len(rows) >= REBUTTAL_SQL_ROW_LIMIT
-                if more_user_msgs or hit_sql_limit:
-                    new_cursor = batch[-1][1]
+                if more_user_msgs:
+                    new_cursor = user_msgs_with_ts[len(batch)][1]
                     logger.info(
-                        f"[Rebuttal] {name}: drain 处理 {len(batch)} 条，cursor 推进到 batch 末位 ts，下轮续"
+                        f"[Rebuttal] {name}: drain 处理 {len(batch)} 条，"
+                        f"cursor 推进到下一未处理 user msg ts，下轮续"
+                    )
+                elif hit_sql_limit:
+                    last_row_ts = _coerce_db_ts(rows[-1][0])
+                    new_cursor = last_row_ts if last_row_ts is not None else now
+                    logger.info(
+                        f"[Rebuttal] {name}: drain 处理 {len(batch)} 条 user msg，"
+                        f"SQL 命中 LIMIT，cursor 推进到最后一行 ts，下轮续"
                     )
                 else:
                     new_cursor = now

--- a/memory_server.py
+++ b/memory_server.py
@@ -635,19 +635,52 @@ async def shutdown_memory_server():
         logger.error(f"处理关闭信号时出错: {e}")
         return {"status": "error", "message": str(e)}
 
-REBUTTAL_CHECK_INTERVAL = 300  # 5 分钟
+REBUTTAL_CHECK_INTERVAL = 180  # 3 分钟
 REBUTTAL_FIRST_RUN_LOOKBACK_HOURS = 1  # 首次启动 / 时钟回拨兜底回扫窗口
+# Drain pattern: 一次最多处理 N 条 user 消息，避免高频用户场景下 prompt 爆炸。
+# 多余的留到下一轮（cursor 推进到第 N 条的 timestamp，不丢消息）。
+REBUTTAL_DRAIN_BATCH_LIMIT = 20
+# 读 SQL 时的硬上限——bound memory，防止 1h fallback 把整张表拉进来。
+# 200 行通常包含 50-100 条 user 消息，足以喂多次 drain。
+REBUTTAL_SQL_ROW_LIMIT = 200
+
+
+def _extract_user_messages_with_ts_from_rows(rows: list) -> list[tuple[str, object]]:
+    """从 time_indexed SQL 查询结果中提取 (用户消息文本, timestamp) 元组。
+
+    rows: [(timestamp, session_id, message_json), ...] (ASC ordered by ts)
+    message_json 是 langchain SQLChatMessageHistory 存储的 JSON 字符串。
+    content 可能是 str 或 list[{type, text}]。
+
+    返回的 list 同样按 ts ASC 排序，caller 可基于 last item 的 ts 推 cursor。
+    """
+    out: list[tuple[str, object]] = []
+    for ts, _, msg_json in rows:
+        try:
+            msg = json.loads(msg_json) if isinstance(msg_json, str) else msg_json
+            if isinstance(msg, dict) and msg.get('type') == 'human':
+                content = msg.get('data', {}).get('content', '')
+                if isinstance(content, str):
+                    if content.strip():
+                        out.append((content, ts))
+                elif isinstance(content, list):
+                    for part in content:
+                        if isinstance(part, dict) and part.get('type') == 'text':
+                            text_val = part.get('text', '')
+                            if text_val.strip():
+                                out.append((text_val, ts))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return out
 
 
 def _extract_user_messages_from_rows(rows: list) -> list[str]:
-    """从 time_indexed SQL 查询结果中提取用户消息文本。
+    """从 time_indexed SQL 查询结果中提取用户消息文本（legacy text-only 视图）。
 
-    rows: [(session_id, message_json), ...]
-    message_json 是 langchain SQLChatMessageHistory 存储的 JSON 字符串。
-    content 可能是 str 或 list[{type, text}]，与 _extract_user_messages 对齐。
+    rows: [(timestamp, session_id, message_json), ...]
     """
     user_msgs = []
-    for _, msg_json in rows:
+    for _, _, msg_json in rows:
         try:
             msg = json.loads(msg_json) if isinstance(msg_json, str) else msg_json
             if isinstance(msg, dict) and msg.get('type') == 'human':
@@ -739,7 +772,13 @@ async def _periodic_rebuttal_loop():
 
         async def _check_one_rebuttal(name: str):
             """单个 catgirl 的反驳检查。各角色互相独立，外层 gather 并行。
-            内部对 feedbacks 仍串行 areject_promotion（同 reflection 不能并发处理）。"""
+            内部对 feedbacks 仍串行 areject_promotion（同 reflection 不能并发处理）。
+
+            Drain 模式：每轮最多处理 ``REBUTTAL_DRAIN_BATCH_LIMIT`` (=20) 条
+            user 消息，cursor 推进到第 N 条的 timestamp。背压期（高频对话用户
+            或 1h fallback）下分多个 tick 排干，每次 LLM prompt 大小受控；
+            消息不丢（cursor 严格按已处理位置推进）。
+            """
             try:
                 confirmed = await reflection_engine.aget_confirmed_reflections(name)
                 if not confirmed:
@@ -754,6 +793,7 @@ async def _periodic_rebuttal_loop():
                 start_time = await _resolve_rebuttal_start_time(name, now)
                 rows = await time_manager.aretrieve_original_by_timeframe(
                     name, start_time, now,
+                    limit_rows=REBUTTAL_SQL_ROW_LIMIT,
                 )
                 if not rows:
                     await cursor_store.aset_cursor(
@@ -761,12 +801,25 @@ async def _periodic_rebuttal_loop():
                     )
                     return
 
-                user_msgs = _extract_user_messages_from_rows(rows)
-                if not user_msgs:
-                    await cursor_store.aset_cursor(
-                        name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
-                    )
+                # 提取 (msg, ts) 元组（ASC by ts）
+                user_msgs_with_ts = _extract_user_messages_with_ts_from_rows(rows)
+                if not user_msgs_with_ts:
+                    # 窗口里只有 AI 消息或无 user 内容 → 推进 cursor 到 SQL 截
+                    # 取的最后一行 ts（如果命中 LIMIT 还有更多行）或 now（清空了）
+                    last_row_ts = rows[-1][0]
+                    if len(rows) >= REBUTTAL_SQL_ROW_LIMIT:
+                        await cursor_store.aset_cursor(
+                            name, CURSOR_REBUTTAL_CHECKED_UNTIL, last_row_ts,
+                        )
+                    else:
+                        await cursor_store.aset_cursor(
+                            name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
+                        )
                     return
+
+                # Drain 取前 N 条 user msg
+                batch = user_msgs_with_ts[:REBUTTAL_DRAIN_BATCH_LIMIT]
+                user_msgs = [m for m, _ in batch]
 
                 # 复用 check_feedback 判断反驳
                 feedbacks = await reflection_engine.check_feedback_for_confirmed(
@@ -777,9 +830,22 @@ async def _periodic_rebuttal_loop():
                     logger.warning(f"[Rebuttal] {name}: 反驳检查失败，保留游标待重试")
                     return
 
-                # 成功才推进游标并持久化
+                # 成功才推进游标并持久化。Drain 推进规则：
+                # - 处理了所有 user msg（batch 等于全量）且 SQL 没命中 LIMIT
+                #   → cursor 推进到 now（窗口已干净）
+                # - 命中 drain limit 或 SQL limit（还有未处理的）
+                #   → cursor 只推进到本批最后一条 ts，下一轮接着排
+                more_user_msgs = len(user_msgs_with_ts) > len(batch)
+                hit_sql_limit = len(rows) >= REBUTTAL_SQL_ROW_LIMIT
+                if more_user_msgs or hit_sql_limit:
+                    new_cursor = batch[-1][1]
+                    logger.info(
+                        f"[Rebuttal] {name}: drain 处理 {len(batch)} 条，cursor 推进到 batch 末位 ts，下轮续"
+                    )
+                else:
+                    new_cursor = now
                 await cursor_store.aset_cursor(
-                    name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
+                    name, CURSOR_REBUTTAL_CHECKED_UNTIL, new_cursor,
                 )
                 for fb in feedbacks:
                     if isinstance(fb, dict) and fb.get('feedback') == 'denied':
@@ -799,7 +865,7 @@ async def _periodic_rebuttal_loop():
         await asyncio.sleep(REBUTTAL_CHECK_INTERVAL)
 
 
-AUTO_PROMOTE_CHECK_INTERVAL = 300  # 5 分钟
+AUTO_PROMOTE_CHECK_INTERVAL = 180  # 3 分钟（与 rebuttal 同步，覆盖同样级别的状态变化）
 
 async def _periodic_auto_promote_loop():
     """定期执行 auto_promote_stale：pending→confirmed→promoted 状态迁移。


### PR DESCRIPTION
## Summary

PR #977 后续：把剩下 4 个 memory LLM 站点开 thinking、抑制锁内 LLM、把 rebuttal 改 drain 模式、统一周期。完成后所有 memory LLM 站点的 timeout / thinking / 锁状态都对齐到设计。

## 5 个 commit

| # | Commit | 内容 |
|---|---|---|
| C1 | ae012fb7 | rebuttal queue+drain (≤20/批) + rebuttal/auto_promote 周期 300→180s |
| C2 | 58f5527b | promote_merge 开 thinking + api_reflect auto_promote 改 fire-and-forget |
| C3 | 11f25036 | reflection synthesize 锁外化 LLM + 开 thinking |
| C4 | c4a6aaa4 | persona resolve_corrections 锁外化 LLM + 开 thinking |
| C5 | 942c64b1 | rebuttal (check_feedback_for_confirmed) 开 thinking |

## 关键改动

### C1 — rebuttal drain
之前 rebuttal loop 把 [cursor, now] 窗口里所有 user msg 一次喂 LLM，1h fallback 兜底窗口下 prompt 可达 30k+ token。改 drain 模式：每轮最多处理 \`REBUTTAL_DRAIN_BATCH_LIMIT(=20)\` 条，cursor 严格按已处理位置推进。配合 \`REBUTTAL_SQL_ROW_LIMIT(=200)\` 硬上限 bound memory。多 tick 排干，消息不丢。

\`time_manager.aretrieve_original_by_timeframe\` 加 \`limit_rows\` 参数 + ORDER BY timestamp ASC；返回 (ts, session_id, message) 三元组（之前是二元组，caller 需要 ts 才能按 drain 进度推 cursor）。

\`REBUTTAL_CHECK_INTERVAL\` / \`AUTO_PROMOTE_CHECK_INTERVAL\`: 300 → 180s。两者保持同步——rebuttal 比 auto_promote 先跑能更早拦住"用户已否定但 auto_promote 即将提升"的窗口。

### C2 — promote_merge 开 thinking
LLM 已在 reflection 锁外（PR #936 设计）。timeout: 45 → 90s，加 \`extra_body=None\`。

附带改动：\`api_reflect\` 端点的 \`aauto_promote_stale\` 改 fire-and-forget——开 thinking 后单 promote_merge 30-90s，串行多个 confirmed reflection 累计能超 client (system_router) 15s timeout。periodic auto_promote loop 每 180s 兜底，本端点不等也安全。caller 仅用 \`auto_transitions\` 计数打 log，丢失无功能影响。

### C3 — reflection synthesize 锁外化
合并 \`synthesize_reflections\` / \`_synthesize_reflections_locked\` 为一个方法。LLM 调用挪到 reflection 锁外，仅"再 load + dedup append + save"那一段几十毫秒留在锁内。

为什么安全：
- rid 由 source_fact_ids 决定（确定性 hash），并发 synth 拿同一批 facts 算出同 rid，post-LLM 锁内 dedup append 兜住
- pre-LLM short-circuit 保留作为 advisory check
- mark_absorbed 移到锁外（fact_store 自己有锁）

LLM (90-120s with thinking) 期间不再阻塞同角色 \`aapply_signal\` / \`aauto_promote_stale\` 的 pending→confirmed 段 / \`arecord_mentions\` / \`aget_followup_topics\`。

timeout: 90 → 120s，加 \`extra_body=None\`。tier 仍 summary。

### C4 — persona resolve_corrections 锁外化
最复杂的一项。引入新的 \`_resolve_alocks\` 字典 + \`_get_resolve_alock\` 方法：per-name asyncio.Lock 专门串行化 \`resolve_corrections\` 调用之间的并发——防止 IdleMaint subtask 2 与 \`_extract_facts_and_check_feedback\` 同时进入触发同批 corrections 被重复处理（特别是 \`keep_new\` 没有 dedup 会重复 append）。

\`_resolve_alock\` 与 data lock (\`_get_alock\`) 完全独立。data lock 仅在 LLM 前后短暂借用：

\`\`\`
pre-LLM 短临界:  load corrections 列表
LLM (无 data lock): 120s thinking 跑
post-LLM 短临界: load fresh persona + apply decisions + save persona
                + filter processed corrections + save corrections file
\`\`\`

代码结构拆成三段：\`resolve_corrections\` 顶层入口 / \`_apply_correction_results\` data lock 包装 / \`_apply_correction_results_locked\` 实际 apply 逻辑。

timeout: 90 → 120s，加 \`extra_body=None\`。tier 仍 correction。

### C5 — rebuttal 开 thinking
锁与依赖分析：rebuttal LLM 不持任何 manager 锁。\`areject_promotion\` 仅在 LLM 后短暂持 reflection 锁。无人等结果——\`auto_promote\` 有 30min per-reflection backoff，rebuttal 慢 90s 不会让错的 reflection 实际进 persona。

C1 把 rebuttal 改 drain 模式后 prompt 大小已经受控；开 thinking 唯一代价是 background loop 同角色下一轮触发延后，无功能影响。

timeout: 60 → 90s，加 \`extra_body=None\`。tier 仍 summary。

## Timeout 全量审计表（终态）

| 站点 | tier | timeout | thinking | path |
|---|---|---|---|---|
| Stage-1 fact extraction | summary | 60 | ❌ | 后台 |
| Stage-2 signal detection | summary | 90 | ✅ | 后台 |
| negative-keyword check | emotion | 60 | ❌ | 后台 |
| fact_dedup aresolve | summary | 60 | ❌ | 后台（持锁但只阻 worker）|
| persona resolve_corrections | correction | **120** | ✅ | 后台（**LLM 锁外**）|
| recall reranker | summary | 8 | ❌ | **请求路径** |
| recent.compress | summary | 30 | ❌ | **请求路径** |
| recent.review_history | correction | 120 | ✅ | 后台（无锁）|
| reflection synthesize | summary | **120** | ✅ | 后台（**LLM 锁外**）|
| per-turn feedback check | summary | 60 | ❌ | 后台 |
| rebuttal | summary | **90** | ✅ | 后台（无锁）|
| promote_merge | correction | **90** | ✅ | 后台（锁外）|

✅ 所有站点显式 \`max_retries=0\`
✅ 所有 thinking 站点用 \`extra_body=None\`
✅ 请求路径 timeout ≤30s，覆盖上游截断
✅ 后台 thinking 站点 90-120s
✅ 无站点遗留 SDK 默认 600s 兜底

## Test plan

- [x] \`uv run python scripts/check_no_temperature.py\` 通过
- [x] memory 模块单测 95 全过
- [x] AST parse 全文件 OK
- [ ] 启动后观察 rebuttal/auto_promote 按 180s 周期跑
- [ ] 高频对话用户 rebuttal drain 多 tick 工作（cursor 按 batch 末位推进）
- [ ] 同角色 \`/process\` 在 \`resolve_corrections\` LLM (120s thinking) 期间不卡 \`arecord_mentions\` / \`aapply_signal\`
- [ ] 同角色 \`/process\` 末尾 \`auto_promote_stale\` 在 \`reflection synthesize\` (120s thinking) 期间不卡

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能优化**
  * 缩小并发锁粒度以减少阻塞并提升并发性能
  * 反驳与自动晋升轮询间隔由5分钟降至3分钟，处理改为有界批量并后台异步执行
  * 内存查询支持可选行数限制并按时间升序返回以支持游标推进

* **错误修复**
  * 改进反射合成与更正写回流程以避免竞态和重复
  * 调整多处 LLM 调用超时与“思考”配置以提高稳定性

* **行为变更**
  * 反射端点现在立即返回，自动晋升在后台运行，响应中自动转换计数固定为0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->