### PR TITLE
修复角色卡管理中 Steam 上传弹窗层级过低导致被展开角色卡面板遮挡的问题；上传前若角色卡已有卡面，则自动复制为 Workshop 预览…

### DIFF
--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -3344,6 +3344,20 @@ async def prepare_workshop_upload(request: Request):
             await asyncio.to_thread(shutil.copytree, model_dir, model_dest_dir, dirs_exist_ok=True)
             logger.info(f"模型文件已复制到临时目录: {model_dest_dir}")
         
+        # 如果角色卡已有卡面，则默认复制为 Workshop 预览图；没有卡面时保持原逻辑不变。
+        preview_image_path = None
+        if character_card_name:
+            try:
+                config_mgr = get_config_manager()
+                face_path = config_mgr.card_faces_dir / f"{character_card_name}.png"
+                if face_path.exists() and face_path.is_file():
+                    preview_image_path = os.path.join(temp_item_dir, 'preview.png')
+                    await asyncio.to_thread(shutil.copy2, str(face_path), preview_image_path)
+                    logger.info(f"已使用角色卡卡面作为默认 Workshop 预览图: {preview_image_path}")
+            except Exception as preview_error:
+                preview_image_path = None
+                logger.warning(f"复制角色卡卡面作为默认预览图失败，将保持预览图不变: {preview_error}")
+        
         # 读取 .workshop_meta.json（如果存在）
         workshop_item_id = None
         if character_card_name:
@@ -3352,13 +3366,16 @@ async def prepare_workshop_upload(request: Request):
                 workshop_item_id = meta_data.get('workshop_item_id')
                 logger.info(f"检测到已存在的 Workshop 物品 ID: {workshop_item_id}")
         
-        return JSONResponse({
+        response_data = {
             "success": True,
             "temp_folder": temp_item_dir,
             "item_id": item_id,
             "workshop_item_id": workshop_item_id,  # 如果存在，返回已存在的物品ID
             "message": "上传准备完成"
-        })
+        }
+        if preview_image_path:
+            response_data["preview_image"] = preview_image_path
+        return JSONResponse(response_data)
         
     except Exception as e:
         logger.error(f"准备上传失败: {e}")

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -2872,7 +2872,7 @@ left: 0;
 width: 100%;
 height: 100%;
 background: rgba(0, 0, 0, 0.5);
-z-index: 1000;
+z-index: 10000;
 justify-content: center;
 align-items: center;
 padding: 20px;
@@ -3001,6 +3001,15 @@ gap: 8px;
 }
 
 /* 上传到创意工坊模态框样式覆盖 */
+#uploadToWorkshopModal {
+z-index: 20000;
+}
+
+#cancelUploadModal,
+#duplicateUploadModal {
+z-index: 20010;
+}
+
 #uploadToWorkshopModal .modal-content {
 background: #e8f4fd;
 }

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -6358,6 +6358,7 @@ async function performUpload(data) {
                     const itemTitle = document.getElementById('item-title');
                     const itemDescription = document.getElementById('item-description');
                     const contentFolder = document.getElementById('content-folder');
+                    const previewImageInput = document.getElementById('preview-image');
                     const tagsContainer = document.getElementById('tags-container');
 
 
@@ -6372,6 +6373,11 @@ async function performUpload(data) {
                     }
                     // 使用临时目录路径（隐藏字段）
                     if (contentFolder) contentFolder.value = result.temp_folder;
+                    // 若后端成功从角色卡卡面复制出预览图，则默认带入；没有卡面时不改动用户当前预览图输入。
+                    if (previewImageInput && result.preview_image) {
+                        previewImageInput.value = result.preview_image;
+                        previewImageInput.classList.remove('error');
+                    }
                     resetWorkshopVoiceReferenceFields(cardName);
 
                     // 添加角色卡标签到上传标签（允许用户编辑）


### PR DESCRIPTION
…图并填入封面路径，没有卡面时保持原预览图逻辑不变

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新增功能
  * 工作坊上传流程现已支持自动预览图像检测与加载，优化用户体验。
  * 改进了模态框的显示层级，确保界面元素正确堆叠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->