### PR TITLE
重做截图功能，使用系统原生框选截图

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -17,6 +17,9 @@ import difflib
 import math
 import re
 import secrets
+import shutil
+import subprocess
+import tempfile
 import time
 from collections import deque
 from io import BytesIO
@@ -30,6 +33,7 @@ from utils.llm_client import SystemMessage, HumanMessage, create_chat_llm
 from utils.tokenize import count_tokens
 import ssl
 import httpx
+from PIL import Image
 
 # Phase 2 proactive output ceiling. The model occasionally runs off; this
 # fence cuts the stream and aborts TTS once the running output exceeds the
@@ -129,6 +133,37 @@ def _set_no_store_headers(response: Response) -> None:
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = "0"
+
+
+def _is_loopback_request(request: Request) -> bool:
+    client_host = request.client.host if request.client else ""
+    return client_host in ("127.0.0.1", "::1", "localhost")
+
+
+def _run_macos_interactive_screenshot(output_path: str) -> tuple[int, str]:
+    cmd = shutil.which("screencapture")
+    if not cmd:
+        raise FileNotFoundError("screencapture not found")
+    completed = subprocess.run(
+        [cmd, "-i", "-s", "-x", output_path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return completed.returncode, (completed.stderr or "").strip()
+
+
+def _image_path_to_jpeg_data_url(image_path: str) -> tuple[str, int]:
+    with Image.open(image_path) as shot:
+        if shot.mode in ("RGBA", "LA", "P"):
+            shot = shot.convert("RGB")
+        jpg_bytes = compress_screenshot(
+            shot,
+            target_h=COMPRESS_TARGET_HEIGHT,
+            quality=COMPRESS_JPEG_QUALITY,
+        )
+    b64 = base64.b64encode(jpg_bytes).decode("utf-8")
+    return f"data:image/jpeg;base64,{b64}", len(jpg_bytes)
 
 
 def _derive_system_lifecycle_state(storage_bootstrap: dict[str, Any]) -> str:
@@ -2612,8 +2647,7 @@ async def backend_screenshot(request: Request):
     后端截图兜底：当前端所有屏幕捕获 API 都失败时，由后端用 pyautogui 截取本机屏幕。
     安全限制：仅允许来自 loopback 地址的请求。返回 JPEG base64 DataURL。
     """
-    client_host = request.client.host if request.client else ''
-    if client_host not in ('127.0.0.1', '::1', 'localhost'):
+    if not _is_loopback_request(request):
         return JSONResponse({"success": False, "error": "only available from localhost"}, status_code=403)
 
     try:
@@ -2652,6 +2686,60 @@ async def backend_screenshot(request: Request):
     except Exception as e:
         logger.error(f"后端截图失败: {e}")
         return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+
+
+@router.post('/screenshot/interactive')
+async def backend_interactive_screenshot(request: Request):
+    """
+    系统原生交互截图：优先给聊天截图按钮使用。
+    当前实现使用 macOS `screencapture` 的系统级框选能力，返回用户选区的 JPEG DataURL。
+    安全限制：仅允许来自 loopback 地址的请求。
+    """
+    if not _is_loopback_request(request):
+        return JSONResponse({"success": False, "error": "only available from localhost"}, status_code=403)
+
+    if sys.platform != "darwin":
+        return JSONResponse({"success": False, "error": "interactive screenshot is only supported on macOS"}, status_code=501)
+
+    fd, tmp_path = tempfile.mkstemp(prefix="neko-interactive-shot-", suffix=".png")
+    os.close(fd)
+    try:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+
+        returncode, stderr = await asyncio.to_thread(_run_macos_interactive_screenshot, tmp_path)
+        file_exists = os.path.exists(tmp_path)
+        file_size = os.path.getsize(tmp_path) if file_exists else 0
+
+        if returncode != 0 and file_size <= 0:
+            logger.info("系统原生交互截图已取消(returncode=%s, stderr=%s)", returncode, stderr)
+            return JSONResponse({"success": False, "canceled": True}, status_code=200)
+
+        if file_size <= 0:
+            logger.info("系统原生交互截图未生成文件，按取消处理")
+            return JSONResponse({"success": False, "canceled": True}, status_code=200)
+
+        data_url, jpg_size = await asyncio.to_thread(_image_path_to_jpeg_data_url, tmp_path)
+        return JSONResponse({
+            "success": True,
+            "data": data_url,
+            "size": jpg_size,
+            "interactive": True,
+        })
+    except FileNotFoundError as e:
+        logger.warning("系统原生交互截图不可用: %s", e)
+        return JSONResponse({"success": False, "error": str(e)}, status_code=501)
+    except Exception as e:
+        logger.error(f"系统原生交互截图失败: {e}")
+        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+    finally:
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except Exception:
+            logger.debug("清理交互截图临时文件失败: %s", tmp_path, exc_info=True)
 
 
 # ================================================================

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -402,6 +402,15 @@ def _image_path_to_jpeg_data_url(image_path: str) -> tuple[str, int]:
     return f"data:image/jpeg;base64,{b64}", len(jpg_bytes)
 
 
+def _is_interactive_screenshot_canceled(returncode: int, stderr: str, file_size: int) -> bool:
+    if file_size > 0:
+        return False
+    normalized_stderr = str(stderr or "").strip()
+    if returncode == 0:
+        return True
+    return returncode == 1 and not normalized_stderr
+
+
 def _derive_system_lifecycle_state(storage_bootstrap: dict[str, Any]) -> str:
     if not isinstance(storage_bootstrap, dict):
         return "starting"
@@ -2970,13 +2979,21 @@ async def backend_interactive_screenshot(request: Request):
         file_exists = os.path.exists(tmp_path)
         file_size = os.path.getsize(tmp_path) if file_exists else 0
 
-        if returncode != 0 and file_size <= 0:
+        if _is_interactive_screenshot_canceled(returncode, stderr, file_size):
             logger.info("系统原生交互截图已取消(returncode=%s, stderr=%s)", returncode, stderr)
             return JSONResponse({"success": False, "canceled": True}, status_code=200)
 
         if file_size <= 0:
-            logger.info("系统原生交互截图未生成文件，按取消处理")
-            return JSONResponse({"success": False, "canceled": True}, status_code=200)
+            error_message = str(stderr or "").strip() or f"interactive screenshot failed with returncode {returncode}"
+            logger.warning(
+                "系统原生交互截图失败且未生成文件(returncode=%s, stderr=%s)",
+                returncode,
+                stderr,
+            )
+            return JSONResponse(
+                {"success": False, "canceled": False, "error": error_message},
+                status_code=500,
+            )
 
         data_url, jpg_size = await asyncio.to_thread(_image_path_to_jpeg_data_url, tmp_path)
         return JSONResponse({

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -420,6 +420,12 @@ def _is_interactive_screenshot_canceled(platform_name: str, returncode: int, std
     return returncode == 1 and not normalized_stderr
 
 
+def _json_no_store_response(content: dict, status_code: int = 200) -> JSONResponse:
+    response = JSONResponse(content, status_code=status_code)
+    _set_no_store_headers(response)
+    return response
+
+
 def _derive_system_lifecycle_state(storage_bootstrap: dict[str, Any]) -> str:
     if not isinstance(storage_bootstrap, dict):
         return "starting"
@@ -2906,15 +2912,16 @@ async def backend_screenshot(request: Request):
         error_defaults={"success": False},
     )
     if validation_error is not None:
+        _set_no_store_headers(validation_error)
         return validation_error
 
     if not _is_loopback_request(request):
-        return JSONResponse({"success": False, "error": "only available from localhost"}, status_code=403)
+        return _json_no_store_response({"success": False, "error": "only available from localhost"}, status_code=403)
 
     try:
         import pyautogui
     except ImportError:
-        return JSONResponse({"success": False, "error": "pyautogui not installed"}, status_code=501)
+        return _json_no_store_response({"success": False, "error": "pyautogui not installed"}, status_code=501)
 
     try:
         def _capture_rgb_screenshot():
@@ -2934,7 +2941,10 @@ async def backend_screenshot(request: Request):
                 extrema = thumb.getextrema()  # ((min_r, max_r), (min_g, max_g), (min_b, max_b))
                 if all(mx <= 1 for _, mx in extrema):
                     logger.warning("后端截图检测到全黑图片，可能缺少 Screen Recording 权限")
-                    return JSONResponse({"success": False, "error": "screenshot is blank (Screen Recording permission may be denied)"}, status_code=403)
+                    return _json_no_store_response(
+                        {"success": False, "error": "screenshot is blank (Screen Recording permission may be denied)"},
+                        status_code=403,
+                    )
             except Exception:
                 logger.debug("macOS blank-screen detection failed, skipping check", exc_info=True)
 
@@ -2943,10 +2953,10 @@ async def backend_screenshot(request: Request):
         )
         b64 = base64.b64encode(jpg_bytes).decode('utf-8')
         data_url = f"data:image/jpeg;base64,{b64}"
-        return JSONResponse({"success": True, "data": data_url, "size": len(jpg_bytes)})
+        return _json_no_store_response({"success": True, "data": data_url, "size": len(jpg_bytes)})
     except Exception as e:
         logger.error(f"后端截图失败: {e}")
-        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+        return _json_no_store_response({"success": False, "error": str(e)}, status_code=500)
 
 
 @router.post('/screenshot/interactive')
@@ -2964,17 +2974,21 @@ async def backend_interactive_screenshot(request: Request):
         error_defaults={"success": False},
     )
     if validation_error is not None:
+        _set_no_store_headers(validation_error)
         return validation_error
 
     if not _is_loopback_request(request):
-        return JSONResponse({"success": False, "error": "only available from localhost"}, status_code=403)
+        return _json_no_store_response({"success": False, "error": "only available from localhost"}, status_code=403)
 
     if sys.platform == "darwin":
         runner = _run_macos_interactive_screenshot
     elif sys.platform == "win32":
         runner = _run_windows_interactive_screenshot
     else:
-        return JSONResponse({"success": False, "error": "interactive screenshot is only supported on macOS and Windows"}, status_code=501)
+        return _json_no_store_response(
+            {"success": False, "error": "interactive screenshot is only supported on macOS and Windows"},
+            status_code=501,
+        )
 
     fd, tmp_path = tempfile.mkstemp(prefix="neko-interactive-shot-", suffix=".png")
     os.close(fd)
@@ -2990,7 +3004,7 @@ async def backend_interactive_screenshot(request: Request):
 
         if _is_interactive_screenshot_canceled(sys.platform, returncode, stderr, file_size):
             logger.info("系统原生交互截图已取消(returncode=%s, stderr=%s)", returncode, stderr)
-            return JSONResponse({"success": False, "canceled": True}, status_code=200)
+            return _json_no_store_response({"success": False, "canceled": True}, status_code=200)
 
         if file_size <= 0:
             error_message = str(stderr or "").strip() or f"interactive screenshot failed with returncode {returncode}"
@@ -2999,13 +3013,13 @@ async def backend_interactive_screenshot(request: Request):
                 returncode,
                 stderr,
             )
-            return JSONResponse(
+            return _json_no_store_response(
                 {"success": False, "canceled": False, "error": error_message},
                 status_code=500,
             )
 
         data_url, jpg_size = await asyncio.to_thread(_image_path_to_jpeg_data_url, tmp_path)
-        return JSONResponse({
+        return _json_no_store_response({
             "success": True,
             "data": data_url,
             "size": jpg_size,
@@ -3013,10 +3027,10 @@ async def backend_interactive_screenshot(request: Request):
         })
     except FileNotFoundError as e:
         logger.warning("系统原生交互截图不可用: %s", e)
-        return JSONResponse({"success": False, "error": str(e)}, status_code=501)
+        return _json_no_store_response({"success": False, "error": str(e)}, status_code=501)
     except Exception as e:
         logger.error(f"系统原生交互截图失败: {e}")
-        return JSONResponse({"success": False, "error": str(e)}, status_code=500)
+        return _json_no_store_response({"success": False, "error": str(e)}, status_code=500)
     finally:
         try:
             if os.path.exists(tmp_path):

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -402,12 +402,14 @@ def _image_path_to_jpeg_data_url(image_path: str) -> tuple[str, int]:
     return f"data:image/jpeg;base64,{b64}", len(jpg_bytes)
 
 
-def _is_interactive_screenshot_canceled(returncode: int, stderr: str, file_size: int) -> bool:
+def _is_interactive_screenshot_canceled(platform_name: str, returncode: int, stderr: str, file_size: int) -> bool:
     if file_size > 0:
         return False
     normalized_stderr = str(stderr or "").strip()
     if returncode == 0:
         return True
+    if platform_name == "darwin":
+        return returncode == 1
     return returncode == 1 and not normalized_stderr
 
 
@@ -2979,7 +2981,7 @@ async def backend_interactive_screenshot(request: Request):
         file_exists = os.path.exists(tmp_path)
         file_size = os.path.getsize(tmp_path) if file_exists else 0
 
-        if _is_interactive_screenshot_canceled(returncode, stderr, file_size):
+        if _is_interactive_screenshot_canceled(sys.platform, returncode, stderr, file_size):
             logger.info("系统原生交互截图已取消(returncode=%s, stderr=%s)", returncode, stderr)
             return JSONResponse({"success": False, "canceled": True}, status_code=200)
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -153,6 +153,242 @@ def _run_macos_interactive_screenshot(output_path: str) -> tuple[int, str]:
     return completed.returncode, (completed.stderr or "").strip()
 
 
+def _set_windows_process_dpi_awareness() -> None:
+    try:
+        ctypes = __import__("ctypes")
+        try:
+            ctypes.windll.shcore.SetProcessDpiAwareness(2)
+            return
+        except Exception:
+            pass
+        try:
+            ctypes.windll.user32.SetProcessDPIAware()
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
+def _get_windows_virtual_screen_geometry() -> tuple[int, int, int, int]:
+    ctypes = __import__("ctypes")
+    user32 = ctypes.windll.user32
+    sm_xvirtualscreen = 76
+    sm_yvirtualscreen = 77
+    sm_cxvirtualscreen = 78
+    sm_cyvirtualscreen = 79
+
+    left = int(user32.GetSystemMetrics(sm_xvirtualscreen))
+    top = int(user32.GetSystemMetrics(sm_yvirtualscreen))
+    width = int(user32.GetSystemMetrics(sm_cxvirtualscreen))
+    height = int(user32.GetSystemMetrics(sm_cyvirtualscreen))
+
+    if width <= 0 or height <= 0:
+        raise RuntimeError("virtual screen metrics unavailable")
+    return left, top, width, height
+
+
+def _run_windows_interactive_screenshot(output_path: str) -> tuple[int, str]:
+    try:
+        import tkinter as tk
+        from PIL import ImageGrab
+    except Exception as exc:
+        raise RuntimeError(f"Windows interactive screenshot dependencies unavailable: {exc}") from exc
+
+    _set_windows_process_dpi_awareness()
+    screen_left, screen_top, screen_width, screen_height = _get_windows_virtual_screen_geometry()
+
+    result: dict[str, Any] = {
+        "bbox": None,
+        "canceled": True,
+        "error": "",
+    }
+
+    root = None
+    try:
+        root = tk.Tk()
+        root.overrideredirect(True)
+        root.attributes("-topmost", True)
+        try:
+            root.attributes("-alpha", 0.22)
+        except Exception:
+            pass
+        try:
+            root.configure(bg="black")
+        except Exception:
+            pass
+        root.geometry(f"{screen_width}x{screen_height}{screen_left:+d}{screen_top:+d}")
+        root.lift()
+        root.focus_force()
+
+        canvas = tk.Canvas(root, cursor="crosshair", highlightthickness=0, bd=0, bg="black")
+        canvas.pack(fill="both", expand=True)
+
+        state = {
+            "start_x": 0,
+            "start_y": 0,
+            "current_x": 0,
+            "current_y": 0,
+            "dragging": False,
+            "rect_id": None,
+            "cross_v_id": None,
+            "cross_h_id": None,
+        }
+
+        def _screen_point(event: Any) -> tuple[int, int]:
+            x = int(screen_left + canvas.canvasx(event.x))
+            y = int(screen_top + canvas.canvasy(event.y))
+            return x, y
+
+        def _clear_guides() -> None:
+            for key in ("rect_id", "cross_v_id", "cross_h_id"):
+                item_id = state.get(key)
+                if item_id:
+                    try:
+                        canvas.delete(item_id)
+                    except Exception:
+                        pass
+                    state[key] = None
+
+        def _draw_guides() -> None:
+            local_x1 = state["start_x"] - screen_left
+            local_y1 = state["start_y"] - screen_top
+            local_x2 = state["current_x"] - screen_left
+            local_y2 = state["current_y"] - screen_top
+
+            x1, x2 = sorted((int(local_x1), int(local_x2)))
+            y1, y2 = sorted((int(local_y1), int(local_y2)))
+
+            if state["cross_v_id"]:
+                canvas.coords(state["cross_v_id"], local_x2, 0, local_x2, screen_height)
+            else:
+                state["cross_v_id"] = canvas.create_line(
+                    local_x2, 0, local_x2, screen_height,
+                    fill="#ffffff",
+                    dash=(4, 4),
+                    width=1,
+                )
+
+            if state["cross_h_id"]:
+                canvas.coords(state["cross_h_id"], 0, local_y2, screen_width, local_y2)
+            else:
+                state["cross_h_id"] = canvas.create_line(
+                    0, local_y2, screen_width, local_y2,
+                    fill="#ffffff",
+                    dash=(4, 4),
+                    width=1,
+                )
+
+            if state["dragging"]:
+                if state["rect_id"]:
+                    canvas.coords(state["rect_id"], x1, y1, x2, y2)
+                else:
+                    state["rect_id"] = canvas.create_rectangle(
+                        x1, y1, x2, y2,
+                        outline="#4cc2ff",
+                        width=2,
+                        fill="#ffffff",
+                        stipple="gray25",
+                    )
+
+        def _on_press(event: Any) -> None:
+            x, y = _screen_point(event)
+            state["start_x"] = x
+            state["start_y"] = y
+            state["current_x"] = x
+            state["current_y"] = y
+            state["dragging"] = True
+            _draw_guides()
+
+        def _on_drag(event: Any) -> None:
+            x, y = _screen_point(event)
+            state["current_x"] = max(screen_left, min(screen_left + screen_width, x))
+            state["current_y"] = max(screen_top, min(screen_top + screen_height, y))
+            _draw_guides()
+
+        def _finish_selection() -> None:
+            left = max(screen_left, min(state["start_x"], state["current_x"]))
+            top = max(screen_top, min(state["start_y"], state["current_y"]))
+            right = min(screen_left + screen_width, max(state["start_x"], state["current_x"]))
+            bottom = min(screen_top + screen_height, max(state["start_y"], state["current_y"]))
+
+            if (right - left) < 4 or (bottom - top) < 4:
+                result["bbox"] = None
+                result["canceled"] = True
+            else:
+                result["bbox"] = (left, top, right, bottom)
+                result["canceled"] = False
+
+            try:
+                root.quit()
+            except Exception:
+                pass
+
+        def _on_release(event: Any) -> None:
+            if not state["dragging"]:
+                return
+            _on_drag(event)
+            state["dragging"] = False
+            _finish_selection()
+
+        def _on_cancel(_event: Any = None) -> None:
+            result["bbox"] = None
+            result["canceled"] = True
+            try:
+                root.quit()
+            except Exception:
+                pass
+
+        def _on_motion(event: Any) -> None:
+            if state["dragging"]:
+                return
+            x, y = _screen_point(event)
+            state["current_x"] = x
+            state["current_y"] = y
+            _draw_guides()
+
+        canvas.bind("<ButtonPress-1>", _on_press)
+        canvas.bind("<B1-Motion>", _on_drag)
+        canvas.bind("<ButtonRelease-1>", _on_release)
+        canvas.bind("<Motion>", _on_motion)
+        root.bind("<Escape>", _on_cancel)
+        root.bind("<Button-3>", _on_cancel)
+        root.bind("<FocusOut>", lambda _event: root.after(10, root.lift))
+
+        root.update_idletasks()
+        root.mainloop()
+
+        bbox = result.get("bbox")
+        if result.get("canceled") or not bbox:
+            return 1, ""
+
+        root.withdraw()
+        root.update_idletasks()
+        time.sleep(0.12)
+
+        full_image = ImageGrab.grab(all_screens=True)
+        crop_box = (
+            int(bbox[0] - screen_left),
+            int(bbox[1] - screen_top),
+            int(bbox[2] - screen_left),
+            int(bbox[3] - screen_top),
+        )
+        cropped = full_image.crop(crop_box)
+        cropped.save(output_path, format="PNG")
+        return 0, ""
+    except Exception as exc:
+        return 2, str(exc)
+    finally:
+        if root is not None:
+            try:
+                _clear_guides()
+            except Exception:
+                pass
+            try:
+                root.destroy()
+            except Exception:
+                pass
+
+
 def _image_path_to_jpeg_data_url(image_path: str) -> tuple[str, int]:
     with Image.open(image_path) as shot:
         if shot.mode in ("RGBA", "LA", "P"):
@@ -2641,12 +2877,19 @@ async def get_window_title_api():
         return JSONResponse({"success": False, "window_title": None})
 
 
-@router.get('/screenshot')
+@router.post('/screenshot')
 async def backend_screenshot(request: Request):
     """
     后端截图兜底：当前端所有屏幕捕获 API 都失败时，由后端用 pyautogui 截取本机屏幕。
     安全限制：仅允许来自 loopback 地址的请求。返回 JPEG base64 DataURL。
     """
+    validation_error = _validate_local_mutation_request(
+        request,
+        error_defaults={"success": False},
+    )
+    if validation_error is not None:
+        return validation_error
+
     if not _is_loopback_request(request):
         return JSONResponse({"success": False, "error": "only available from localhost"}, status_code=403)
 
@@ -2692,14 +2935,28 @@ async def backend_screenshot(request: Request):
 async def backend_interactive_screenshot(request: Request):
     """
     系统原生交互截图：优先给聊天截图按钮使用。
-    当前实现使用 macOS `screencapture` 的系统级框选能力，返回用户选区的 JPEG DataURL。
+    当前实现:
+      - macOS: `screencapture` 系统级框选
+      - Windows: 本地全桌面遮罩框选
+    返回用户选区的 JPEG DataURL。
     安全限制：仅允许来自 loopback 地址的请求。
     """
+    validation_error = _validate_local_mutation_request(
+        request,
+        error_defaults={"success": False},
+    )
+    if validation_error is not None:
+        return validation_error
+
     if not _is_loopback_request(request):
         return JSONResponse({"success": False, "error": "only available from localhost"}, status_code=403)
 
-    if sys.platform != "darwin":
-        return JSONResponse({"success": False, "error": "interactive screenshot is only supported on macOS"}, status_code=501)
+    if sys.platform == "darwin":
+        runner = _run_macos_interactive_screenshot
+    elif sys.platform == "win32":
+        runner = _run_windows_interactive_screenshot
+    else:
+        return JSONResponse({"success": False, "error": "interactive screenshot is only supported on macOS and Windows"}, status_code=501)
 
     fd, tmp_path = tempfile.mkstemp(prefix="neko-interactive-shot-", suffix=".png")
     os.close(fd)
@@ -2709,7 +2966,7 @@ async def backend_interactive_screenshot(request: Request):
         except FileNotFoundError:
             pass
 
-        returncode, stderr = await asyncio.to_thread(_run_macos_interactive_screenshot, tmp_path)
+        returncode, stderr = await asyncio.to_thread(runner, tmp_path)
         file_exists = os.path.exists(tmp_path)
         file_size = os.path.getsize(tmp_path) if file_exists else 0
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -14,6 +14,7 @@ import sys
 import asyncio
 import base64
 import difflib
+import ipaddress
 import math
 import re
 import secrets
@@ -137,7 +138,13 @@ def _set_no_store_headers(response: Response) -> None:
 
 def _is_loopback_request(request: Request) -> bool:
     client_host = request.client.host if request.client else ""
-    return client_host in ("127.0.0.1", "::1", "localhost")
+    if client_host == "localhost":
+        return True
+    normalized_host = str(client_host or "").removeprefix("::ffff:")
+    try:
+        return ipaddress.ip_address(normalized_host).is_loopback
+    except ValueError:
+        return False
 
 
 def _run_macos_interactive_screenshot(output_path: str) -> tuple[int, str]:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2968,15 +2968,9 @@ async def backend_interactive_screenshot(request: Request):
       - Windows: 本地全桌面遮罩框选
     返回用户选区的 JPEG DataURL。
     安全限制：仅允许来自 loopback 地址的请求。
+    说明：截图动作本身发生在本机，本地取消/失败由本地实现判断；
+    这里不再复用本地 mutation 的 CSRF/origin 校验链路。
     """
-    validation_error = _validate_local_mutation_request(
-        request,
-        error_defaults={"success": False},
-    )
-    if validation_error is not None:
-        _set_no_store_headers(validation_error)
-        return validation_error
-
     if not _is_loopback_request(request):
         return _json_no_store_response({"success": False, "error": "only available from localhost"}, status_code=403)
 

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -1806,6 +1806,120 @@
             document.documentElement.style.visibility = saved.visibility || '';
         }
 
+        function getDesktopRegionCaptureMethod() {
+            if (!window.electronDesktopCapturer) return null;
+            var bridge = window.electronDesktopCapturer;
+            var names = [
+                'beginDesktopRegionSelection',
+                'captureDesktopRegion',
+                'captureDesktopRegionAsDataUrl',
+                'captureSelectedRegion',
+                'startDesktopSelectionCapture'
+            ];
+            for (var i = 0; i < names.length; i++) {
+                var name = names[i];
+                if (typeof bridge[name] === 'function') {
+                    return { name: name, fn: bridge[name].bind(bridge) };
+                }
+            }
+            return null;
+        }
+
+        function isDesktopRegionCaptureUnavailable(errorLike) {
+            if (!errorLike) return false;
+            var code = errorLike.code || '';
+            if (code === 'ENOSYS' || code === 'UNSUPPORTED_API') return true;
+            var message = String(errorLike.message || errorLike.error || errorLike.reason || '').toLowerCase();
+            return message.indexOf('not implemented') !== -1
+                || message.indexOf('not supported') !== -1
+                || message.indexOf('unsupported') !== -1
+                || message.indexOf('unavailable') !== -1;
+        }
+
+        function normalizeDesktopRegionCaptureResult(raw) {
+            if (!raw) return null;
+            if (typeof raw === 'string') {
+                return { success: true, dataUrl: raw, originalDataUrl: raw };
+            }
+            if (raw.canceled || raw.cancelled) {
+                return { canceled: true };
+            }
+            if (raw.success === false) {
+                return {
+                    success: false,
+                    error: raw.error || raw.message || 'DESKTOP_REGION_CAPTURE_FAILED',
+                    code: raw.code || null
+                };
+            }
+            if (raw.dataUrl) {
+                return {
+                    success: true,
+                    dataUrl: raw.dataUrl,
+                    originalDataUrl: raw.originalDataUrl || raw.dataUrl,
+                    avatarPos: raw.avatarPos || raw.avatarPosition || null,
+                    captureType: raw.captureType || 'desktop-region',
+                    width: raw.width || 0,
+                    height: raw.height || 0
+                };
+            }
+            return null;
+        }
+
+        async function captureDesktopRegionDirectly() {
+            var regionMethod = getDesktopRegionCaptureMethod();
+            if (!regionMethod) return null;
+
+            var selectedSourceId = S.selectedScreenSourceId || null;
+            var payload = {
+                sourceId: selectedSourceId,
+                hideNeko: true,
+                returnDataUrl: true,
+                includeOriginalDataUrl: true
+            };
+
+            var raw = null;
+            try {
+                raw = await regionMethod.fn(payload);
+            } catch (err) {
+                if (isDesktopRegionCaptureUnavailable(err)) {
+                    console.info('[截图] 桌面框选接口当前不可用，回退到内置裁剪:', regionMethod.name);
+                    return null;
+                }
+                throw err;
+            }
+
+            var normalized = normalizeDesktopRegionCaptureResult(raw);
+            if (!normalized) {
+                console.warn('[截图] 桌面框选接口返回了无法识别的结果，回退到内置裁剪:', regionMethod.name, raw);
+                return null;
+            }
+            if (normalized.canceled) {
+                console.log('[截图] 用户取消了桌面框选');
+                return { canceled: true };
+            }
+            if (!normalized.success) {
+                if (typeof window.maybeClearSourceOnNotFound === 'function') {
+                    window.maybeClearSourceOnNotFound(normalized, 'desktop region capture Source not found');
+                }
+                if (isDesktopRegionCaptureUnavailable(normalized)) {
+                    console.info('[截图] 桌面框选接口声明不可用，回退到内置裁剪:', regionMethod.name);
+                    return null;
+                }
+                throw new Error(normalized.error || 'DESKTOP_REGION_CAPTURE_FAILED');
+            }
+
+            var scaled = await downscaleDataUrlTo720p(normalized.dataUrl);
+            console.log('[截图] 桌面框选捕获成功:', regionMethod.name, (scaled.width || normalized.width || 0) + 'x' + (scaled.height || normalized.height || 0));
+            return {
+                dataUrl: scaled.dataUrl,
+                originalDataUrl: normalized.originalDataUrl || normalized.dataUrl,
+                avatarPos: normalized.avatarPos || null,
+                captureType: normalized.captureType || 'desktop-region',
+                width: scaled.width || normalized.width || 0,
+                height: scaled.height || normalized.height || 0
+            };
+        }
+
         async function recaptureWithoutNeko() {
             // Priority 0 (Electron PC): 主进程原子化路径 — 一次 IPC 完成
             //   隐藏所有 NEKO 窗口 → 等合成 → desktopCapturer 抓图 → 恢复窗口。
@@ -1956,6 +2070,32 @@
                         }
                     }
                 } else {
+                    if (typeof window.fetchBackendInteractiveScreenshot === 'function') {
+                        var interactiveBackendResult = await window.fetchBackendInteractiveScreenshot();
+                        if (interactiveBackendResult && interactiveBackendResult.canceled) {
+                            return null;
+                        }
+                        if (interactiveBackendResult && interactiveBackendResult.dataUrl) {
+                            return {
+                                dataUrl: interactiveBackendResult.dataUrl,
+                                originalDataUrl: interactiveBackendResult.dataUrl,
+                                avatarPos: null
+                            };
+                        }
+                    }
+
+                    var desktopRegionResult = await captureDesktopRegionDirectly();
+                    if (desktopRegionResult) {
+                        if (desktopRegionResult.canceled) {
+                            return null;
+                        }
+                        return {
+                            dataUrl: desktopRegionResult.dataUrl,
+                            originalDataUrl: desktopRegionResult.originalDataUrl || desktopRegionResult.dataUrl,
+                            avatarPos: desktopRegionResult.avatarPos || null
+                        };
+                    }
+
                     var selectedSourceId = S.selectedScreenSourceId;
                     if (selectedSourceId && window.electronDesktopCapturer
                         && typeof window.electronDesktopCapturer.captureSourceAsDataUrl === 'function') {

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2084,8 +2084,9 @@
                             return null;
                         }
                         if (interactiveBackendResult && interactiveBackendResult.dataUrl) {
+                            var interactiveScaled = await downscaleDataUrlTo720p(interactiveBackendResult.dataUrl);
                             return {
-                                dataUrl: interactiveBackendResult.dataUrl,
+                                dataUrl: (interactiveScaled && interactiveScaled.dataUrl) || interactiveBackendResult.dataUrl,
                                 originalDataUrl: interactiveBackendResult.dataUrl,
                                 avatarPos: null
                             };

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -1898,8 +1898,16 @@
                 return { canceled: true };
             }
             if (!normalized.success) {
+                var sourceCleared = false;
                 if (typeof window.maybeClearSourceOnNotFound === 'function') {
-                    window.maybeClearSourceOnNotFound(normalized, 'desktop region capture Source not found');
+                    sourceCleared = window.maybeClearSourceOnNotFound(
+                        normalized,
+                        'desktop region capture Source not found'
+                    );
+                }
+                if (sourceCleared) {
+                    console.info('[截图] 桌面框选源已失效，回退到既有截图链路');
+                    return null;
                 }
                 if (isDesktopRegionCaptureUnavailable(normalized)) {
                     console.info('[截图] 桌面框选接口声明不可用，回退到内置裁剪:', regionMethod.name);

--- a/static/app-crop.js
+++ b/static/app-crop.js
@@ -207,6 +207,11 @@
         });
 
         overlay.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelAll();
+                return;
+            }
             var target = e.target;
             if (
                 target
@@ -218,11 +223,6 @@
                     || target.isContentEditable
                 )
             ) {
-                return;
-            }
-            if (e.key === 'Escape') {
-                e.preventDefault();
-                cancelAll();
                 return;
             }
             if ((e.key === 'Delete' || e.key === 'Backspace') && sel) {

--- a/static/app-crop.js
+++ b/static/app-crop.js
@@ -5,7 +5,8 @@
  *       confirm (✓) saves to clipboard + returns dataUrl, cancel (×) clears selection,
  *       top-bar "取消" or right-click exits entirely.
  *
- * Supports: drag to create selection, move selection, resize via corner/edge handles.
+ * Supports: drag to create selection, move selection, resize via corner/edge handles,
+ *           keyboard nudging (arrows), Enter confirm, Delete clear.
  *
  * Exports: window.appCrop
  *   - cropImage(dataUrl, opts) → Promise<string|null>
@@ -24,9 +25,16 @@
     var resolvePromise = null;
     var sourceDataUrl = null;
     var recaptureFn = null;
+    var selectionBox = null;
+    var selectionBadge = null;
+    var crosshairX = null;
+    var crosshairY = null;
+    var pointerBadge = null;
     // 单调递增 token：防止旧 recaptureFn 异步返回时把结果灌进新一轮 crop 会话，
     // 或在 finally 里把新会话刚显示的"隐藏NEKO"按钮文案/disabled 状态错误重置。
     var recaptureRunId = 0;
+    var renderQueued = false;
+    var pointerPos = null;
 
     // Selection rectangle (canvas coords, always normalized: x,y = top-left)
     var sel = null; // { x, y, w, h } or null
@@ -80,18 +88,6 @@
         overlay.setAttribute('aria-modal', 'true');
         overlay.style.display = 'none';
 
-        // Background image
-        imgEl = document.createElement('img');
-        imgEl.className = 'crop-bg-image';
-        imgEl.draggable = false;
-        overlay.appendChild(imgEl);
-
-        // Canvas
-        canvas = document.createElement('canvas');
-        canvas.className = 'crop-canvas';
-        overlay.appendChild(canvas);
-        ctx = canvas.getContext('2d');
-
         // ---- Top bar ----
         topBar = document.createElement('div');
         topBar.className = 'crop-topbar';
@@ -118,6 +114,58 @@
         topBar.appendChild(tabHideNeko);
         topBar.appendChild(tabCancel);
         overlay.appendChild(topBar);
+
+        // ---- Workspace ----
+        var workspace = document.createElement('div');
+        workspace.className = 'crop-workspace';
+        overlay.appendChild(workspace);
+
+        // Background image
+        imgEl = document.createElement('img');
+        imgEl.className = 'crop-bg-image';
+        imgEl.draggable = false;
+        workspace.appendChild(imgEl);
+
+        // Canvas
+        canvas = document.createElement('canvas');
+        canvas.className = 'crop-canvas';
+        workspace.appendChild(canvas);
+        ctx = canvas.getContext('2d');
+
+        selectionBox = document.createElement('div');
+        selectionBox.className = 'crop-selection-box';
+        selectionBox.setAttribute('aria-hidden', 'true');
+        selectionBox.style.display = 'none';
+        for (var i = 0; i < 4; i++) {
+            var gridLine = document.createElement('div');
+            gridLine.className = 'crop-selection-grid-line ' + (i < 2 ? 'h' + (i + 1) : 'v' + (i - 1));
+            selectionBox.appendChild(gridLine);
+        }
+        var handleNames = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
+        for (var j = 0; j < handleNames.length; j++) {
+            var handleEl = document.createElement('div');
+            handleEl.className = 'crop-selection-handle ' + handleNames[j];
+            selectionBox.appendChild(handleEl);
+        }
+        workspace.appendChild(selectionBox);
+
+        selectionBadge = document.createElement('div');
+        selectionBadge.className = 'crop-selection-badge';
+        selectionBadge.style.display = 'none';
+        workspace.appendChild(selectionBadge);
+
+        crosshairX = document.createElement('div');
+        crosshairX.className = 'crop-crosshair crop-crosshair-x';
+        workspace.appendChild(crosshairX);
+
+        crosshairY = document.createElement('div');
+        crosshairY.className = 'crop-crosshair crop-crosshair-y';
+        workspace.appendChild(crosshairY);
+
+        pointerBadge = document.createElement('div');
+        pointerBadge.className = 'crop-pointer-badge';
+        pointerBadge.style.display = 'none';
+        workspace.appendChild(pointerBadge);
 
         // ---- Floating action buttons (✓ / ×) ----
         actionBtns = document.createElement('div');
@@ -146,6 +194,8 @@
         canvas.addEventListener('mousedown', onPointerDown);
         document.addEventListener('mousemove', onPointerMove);
         document.addEventListener('mouseup', onPointerUp);
+        canvas.addEventListener('mouseleave', onPointerLeave);
+        canvas.addEventListener('dblclick', onDoubleClick);
         canvas.addEventListener('touchstart', onTouchStart, { passive: false });
         document.addEventListener('touchmove', onTouchMove, { passive: false });
         document.addEventListener('touchend', onTouchEnd);
@@ -157,7 +207,38 @@
         });
 
         overlay.addEventListener('keydown', function (e) {
-            if (e.key === 'Escape') cancelAll();
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                cancelAll();
+                return;
+            }
+            if ((e.key === 'Delete' || e.key === 'Backspace') && sel) {
+                e.preventDefault();
+                clearSelection();
+                return;
+            }
+            if ((e.key === 'Enter' || e.key === 'NumpadEnter') && sel) {
+                e.preventDefault();
+                confirmCrop();
+                return;
+            }
+            if (!sel) return;
+            var step = e.shiftKey ? 10 : 1;
+            var handled = true;
+            if (e.key === 'ArrowLeft') {
+                moveSelectionBy(-step, 0);
+            } else if (e.key === 'ArrowRight') {
+                moveSelectionBy(step, 0);
+            } else if (e.key === 'ArrowUp') {
+                moveSelectionBy(0, -step);
+            } else if (e.key === 'ArrowDown') {
+                moveSelectionBy(0, step);
+            } else {
+                handled = false;
+            }
+            if (handled) {
+                e.preventDefault();
+            }
         });
 
         document.body.appendChild(overlay);
@@ -196,13 +277,9 @@
     }
 
     // ======================== Coordinate helpers ========================
-    function getTopBarHeight() {
-        return (topBar && topBar.offsetHeight) || 40;
-    }
-
     function computeImgMetrics() {
         var overlayW = overlay.clientWidth;
-        var overlayH = overlay.clientHeight - getTopBarHeight();
+        var overlayH = overlay.clientHeight;
         var natW = imgEl.naturalWidth;
         var natH = imgEl.naturalHeight;
         imgNaturalWidth = natW;
@@ -221,7 +298,7 @@
             imgEl.style.width = imgDisplayWidth + 'px';
             imgEl.style.height = imgDisplayHeight + 'px';
             imgEl.style.left = imgDisplayLeft + 'px';
-            imgEl.style.top = (imgDisplayTop + getTopBarHeight()) + 'px';
+            imgEl.style.top = imgDisplayTop + 'px';
         }
     }
 
@@ -234,6 +311,22 @@
     function getPointerPos(e) {
         var rect = canvas.getBoundingClientRect();
         return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    }
+
+    function clampPointToImage(x, y) {
+        var right = imgDisplayLeft + imgDisplayWidth;
+        var bottom = imgDisplayTop + imgDisplayHeight;
+        return {
+            x: Math.max(imgDisplayLeft, Math.min(right, x)),
+            y: Math.max(imgDisplayTop, Math.min(bottom, y))
+        };
+    }
+
+    function isPointWithinImage(x, y) {
+        return x >= imgDisplayLeft
+            && x <= imgDisplayLeft + imgDisplayWidth
+            && y >= imgDisplayTop
+            && y <= imgDisplayTop + imgDisplayHeight;
     }
 
     function clampSel(s) {
@@ -310,87 +403,97 @@
         // Border
         ctx.strokeStyle = '#44b7fe';
         ctx.lineWidth = 2;
-        ctx.setLineDash([6, 3]);
+        ctx.setLineDash([8, 4]);
         ctx.strokeRect(cs.x, cs.y, cs.w, cs.h);
         ctx.setLineDash([]);
+    }
 
-        // Corner + edge handles
-        drawHandles(cs);
+    // ======================== Action buttons position ========================
+    function updateSelectionUI() {
+        if (!selectionBox || !selectionBadge || !actionBtns) return;
+        if (!sel) {
+            selectionBox.style.display = 'none';
+            selectionBadge.style.display = 'none';
+            actionBtns.style.display = 'none';
+            return;
+        }
+        var cs = clampSel(sel);
+        if (!cs) {
+            selectionBox.style.display = 'none';
+            selectionBadge.style.display = 'none';
+            actionBtns.style.display = 'none';
+            return;
+        }
 
-        // Dimension label
+        selectionBox.style.display = 'block';
+        selectionBox.style.left = cs.x + 'px';
+        selectionBox.style.top = cs.y + 'px';
+        selectionBox.style.width = cs.w + 'px';
+        selectionBox.style.height = cs.h + 'px';
+
         var c1 = canvasToImage(cs.x, cs.y);
         var c2 = canvasToImage(cs.x + cs.w, cs.y + cs.h);
         var cropW = Math.round(Math.abs(c2.x - c1.x));
         var cropH = Math.round(Math.abs(c2.y - c1.y));
-        if (cropW > 0 && cropH > 0) {
-            var label = cropW + ' \u00D7 ' + cropH;
-            ctx.font = '12px sans-serif';
-            var m = ctx.measureText(label);
-            var lx = cs.x + cs.w / 2 - m.width / 2 - 4;
-            var ly = cs.y + cs.h + 20;
-            if (ly > h - 30) ly = cs.y - 10;
-
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-            var rw = m.width + 8, rh = 20, rx = lx, ry = ly - 14, rr = 4;
-            ctx.beginPath();
-            if (ctx.roundRect) {
-                ctx.roundRect(rx, ry, rw, rh, rr);
-            } else {
-                ctx.moveTo(rx + rr, ry);
-                ctx.lineTo(rx + rw - rr, ry);
-                ctx.arcTo(rx + rw, ry, rx + rw, ry + rr, rr);
-                ctx.lineTo(rx + rw, ry + rh - rr);
-                ctx.arcTo(rx + rw, ry + rh, rx + rw - rr, ry + rh, rr);
-                ctx.lineTo(rx + rr, ry + rh);
-                ctx.arcTo(rx, ry + rh, rx, ry + rh - rr, rr);
-                ctx.lineTo(rx, ry + rr);
-                ctx.arcTo(rx, ry, rx + rr, ry, rr);
-                ctx.closePath();
-            }
-            ctx.fill();
-            ctx.fillStyle = '#fff';
-            ctx.fillText(label, lx + 4, ly);
-        }
-    }
-
-    function drawHandles(s) {
-        var hs = HANDLE_SIZE;
-        ctx.fillStyle = '#44b7fe';
-        var pts = [
-            [s.x, s.y], [s.x + s.w, s.y],
-            [s.x, s.y + s.h], [s.x + s.w, s.y + s.h],
-            [s.x + s.w / 2, s.y], [s.x + s.w / 2, s.y + s.h],
-            [s.x, s.y + s.h / 2], [s.x + s.w, s.y + s.h / 2]
-        ];
-        for (var i = 0; i < pts.length; i++) {
-            ctx.fillRect(pts[i][0] - hs / 2, pts[i][1] - hs / 2, hs, hs);
-        }
-    }
-
-    // ======================== Action buttons position ========================
-    function positionActionBtns() {
-        if (!sel || !actionBtns) { actionBtns.style.display = 'none'; return; }
-        var cs = clampSel(sel);
-        if (!cs) { actionBtns.style.display = 'none'; return; }
+        selectionBadge.textContent = cropW + ' × ' + cropH;
+        selectionBadge.style.display = 'block';
+        selectionBadge.style.left = cs.x + 'px';
+        selectionBadge.style.top = Math.max(12, cs.y - 36) + 'px';
 
         actionBtns.style.display = 'flex';
-        var canvasRect = canvas.getBoundingClientRect();
-        var btnW = actionBtns.offsetWidth || 72;
-        var btnH = actionBtns.offsetHeight || 32;
-
-        var left = canvasRect.left + cs.x + cs.w - btnW;
-        var top = canvasRect.top + cs.y + cs.h + 6;
+        var btnW = actionBtns.offsetWidth || 92;
+        var btnH = actionBtns.offsetHeight || 40;
+        var left = cs.x + cs.w - btnW;
+        var top = cs.y + cs.h + 12;
 
         // If overflows bottom, put above selection
-        if (top + btnH > window.innerHeight - 10) {
-            top = canvasRect.top + cs.y - btnH - 6;
+        if (top + btnH > overlay.clientHeight - 12) {
+            top = cs.y - btnH - 12;
         }
         // Clamp to viewport
-        if (left < 4) left = 4;
-        if (left + btnW > window.innerWidth - 4) left = window.innerWidth - btnW - 4;
+        if (left < 12) left = 12;
+        if (left + btnW > overlay.clientWidth - 12) left = overlay.clientWidth - btnW - 12;
+        if (top < 12) top = 12;
 
         actionBtns.style.left = left + 'px';
         actionBtns.style.top = top + 'px';
+    }
+
+    function updatePointerUI() {
+        if (!crosshairX || !crosshairY || !pointerBadge) return;
+        if (!pointerPos || !isPointWithinImage(pointerPos.x, pointerPos.y)) {
+            crosshairX.style.display = 'none';
+            crosshairY.style.display = 'none';
+            pointerBadge.style.display = 'none';
+            return;
+        }
+
+        var showCrosshair = !sel || mode === MODE_NEW;
+        crosshairX.style.display = showCrosshair ? 'block' : 'none';
+        crosshairY.style.display = showCrosshair ? 'block' : 'none';
+        pointerBadge.style.display = showCrosshair ? 'block' : 'none';
+
+        if (!showCrosshair) {
+            return;
+        }
+
+        crosshairX.style.top = pointerPos.y + 'px';
+        crosshairY.style.left = pointerPos.x + 'px';
+        var imgPoint = canvasToImage(pointerPos.x, pointerPos.y);
+        pointerBadge.textContent = Math.max(0, Math.round(imgPoint.x)) + ', ' + Math.max(0, Math.round(imgPoint.y));
+        pointerBadge.style.left = Math.min(overlay.clientWidth - 88, pointerPos.x + 18) + 'px';
+        pointerBadge.style.top = Math.max(12, pointerPos.y - 34) + 'px';
+    }
+
+    function requestRender() {
+        if (renderQueued) return;
+        renderQueued = true;
+        requestAnimationFrame(function () {
+            renderQueued = false;
+            drawOverlay();
+            updateSelectionUI();
+            updatePointerUI();
+        });
     }
 
     // ======================== Pointer events ========================
@@ -398,6 +501,7 @@
         if (e.button === 2) return; // right-click handled by contextmenu
         e.preventDefault();
         var pos = getPointerPos(e);
+        pointerPos = pos;
 
         // 1. Check handle hit
         var handle = hitTestHandle(pos.x, pos.y);
@@ -420,19 +524,21 @@
         }
 
         // 3. New selection
+        var startPos = clampPointToImage(pos.x, pos.y);
         mode = MODE_NEW;
-        dragStartX = pos.x;
-        dragStartY = pos.y;
-        sel = { x: pos.x, y: pos.y, w: 0, h: 0 };
+        dragStartX = startPos.x;
+        dragStartY = startPos.y;
+        sel = { x: startPos.x, y: startPos.y, w: 0, h: 0 };
         hideActionBtns();
-        drawOverlay();
+        requestRender();
     }
 
     function onPointerMove(e) {
+        var pos = getPointerPos(e);
+        pointerPos = pos;
         if (mode === MODE_NONE) {
             // Update cursor based on hover
             if (!canvas || !overlay || overlay.style.display === 'none') return;
-            var pos = getPointerPos(e);
             var h = hitTestHandle(pos.x, pos.y);
             if (h) {
                 canvas.style.cursor = getCursorForHandle(h);
@@ -441,11 +547,11 @@
             } else {
                 canvas.style.cursor = 'crosshair';
             }
+            requestRender();
             return;
         }
 
         e.preventDefault();
-        var pos = getPointerPos(e);
         var dx = pos.x - dragStartX;
         var dy = pos.y - dragStartY;
 
@@ -467,16 +573,17 @@
             sel = resizeSel(dragOrigSel, resizeHandle, dx, dy);
         }
 
-        drawOverlay();
+        requestRender();
     }
 
     function onPointerUp(e) {
         if (mode === MODE_NONE) return;
         var prevMode = mode;
         mode = MODE_NONE;
+        var pos = getPointerPos(e);
+        pointerPos = pos;
 
         if (prevMode === MODE_NEW) {
-            var pos = getPointerPos(e);
             sel = normRect(dragStartX, dragStartY, pos.x, pos.y);
         }
 
@@ -487,9 +594,23 @@
             hideActionBtns();
         } else {
             sel = cs;
-            positionActionBtns();
         }
-        drawOverlay();
+        requestRender();
+    }
+
+    function onPointerLeave() {
+        if (mode !== MODE_NONE) return;
+        pointerPos = null;
+        updatePointerUI();
+    }
+
+    function onDoubleClick(e) {
+        if (!sel) return;
+        var pos = getPointerPos(e);
+        if (hitTestInside(pos.x, pos.y)) {
+            e.preventDefault();
+            confirmCrop();
+        }
     }
 
     // Touch adapters
@@ -530,6 +651,21 @@
         return { x: x, y: y, w: w, h: h };
     }
 
+    function moveSelectionBy(dx, dy) {
+        if (!sel) return;
+        sel = {
+            x: sel.x + dx,
+            y: sel.y + dy,
+            w: sel.w,
+            h: sel.h
+        };
+        if (sel.x < imgDisplayLeft) sel.x = imgDisplayLeft;
+        if (sel.y < imgDisplayTop) sel.y = imgDisplayTop;
+        if (sel.x + sel.w > imgDisplayLeft + imgDisplayWidth) sel.x = imgDisplayLeft + imgDisplayWidth - sel.w;
+        if (sel.y + sel.h > imgDisplayTop + imgDisplayHeight) sel.y = imgDisplayTop + imgDisplayHeight - sel.h;
+        requestRender();
+    }
+
     // ======================== Actions ========================
     function hideActionBtns() {
         if (actionBtns) actionBtns.style.display = 'none';
@@ -539,7 +675,7 @@
         sel = null;
         mode = MODE_NONE;
         hideActionBtns();
-        drawOverlay();
+        requestRender();
     }
 
     function cropToDataUrl() {
@@ -599,7 +735,13 @@
         sourceDataUrl = null;
         recaptureFn = null;
         activeTab = 'screenshot';
+        pointerPos = null;
         hideActionBtns();
+        if (selectionBox) selectionBox.style.display = 'none';
+        if (selectionBadge) selectionBadge.style.display = 'none';
+        if (pointerBadge) pointerBadge.style.display = 'none';
+        if (crosshairX) crosshairX.style.display = 'none';
+        if (crosshairY) crosshairY.style.display = 'none';
 
         if (resolvePromise) {
             var fn = resolvePromise;
@@ -615,12 +757,12 @@
         computeImgMetrics();
         sel = null;
         hideActionBtns();
-        drawOverlay();
+        requestRender();
     }
 
     function sizeCanvas() {
         canvas.width = overlay.clientWidth;
-        canvas.height = overlay.clientHeight - getTopBarHeight();
+        canvas.height = overlay.clientHeight;
     }
 
     // ======================== Image loading ========================
@@ -630,7 +772,7 @@
             computeImgMetrics();
             sel = null;
             hideActionBtns();
-            drawOverlay();
+            requestRender();
             overlay.focus();
         };
         imgEl.onerror = function () {

--- a/static/app-crop.js
+++ b/static/app-crop.js
@@ -207,6 +207,19 @@
         });
 
         overlay.addEventListener('keydown', function (e) {
+            var target = e.target;
+            if (
+                target
+                && (
+                    target.tagName === 'BUTTON'
+                    || target.tagName === 'INPUT'
+                    || target.tagName === 'TEXTAREA'
+                    || target.tagName === 'SELECT'
+                    || target.isContentEditable
+                )
+            ) {
+                return;
+            }
             if (e.key === 'Escape') {
                 e.preventDefault();
                 cancelAll();
@@ -783,6 +796,7 @@
 
     // ======================== Public API ========================
     mod.cropImage = function cropImage(dataUrl, opts) {
+        var sessionResizeHandler = null;
         return new Promise(function (resolve) {
             ensureOverlay();
             if (resolvePromise) close(null);
@@ -811,9 +825,15 @@
             overlay.style.display = 'flex';
             overlay.tabIndex = -1;
             overlay.focus();
-            window.addEventListener('resize', onResize);
+            sessionResizeHandler = function () {
+                onResize();
+            };
+            window.addEventListener('resize', sessionResizeHandler);
         }).finally(function () {
-            window.removeEventListener('resize', onResize);
+            if (sessionResizeHandler) {
+                window.removeEventListener('resize', sessionResizeHandler);
+                sessionResizeHandler = null;
+            }
         });
     };
 

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -451,6 +451,62 @@
     }
     mod.acquireOrReuseCachedStream = acquireOrReuseCachedStream;
 
+    async function buildLocalSecureHeaders() {
+        var helper = window.nekoLocalMutationSecurity;
+        if (!helper || typeof helper.getMutationHeaders !== 'function') {
+            return {};
+        }
+        try {
+            return await helper.getMutationHeaders();
+        } catch (e) {
+            console.warn('[截图] 获取本地安全请求头失败:', e);
+            return {};
+        }
+    }
+
+    async function isLocalCsrfFailure(resp) {
+        if (!resp || resp.status !== 403) return false;
+        try {
+            var cloned = typeof resp.clone === 'function' ? resp.clone() : resp;
+            var payload = await cloned.json();
+            return !!(payload && payload.error_code === 'csrf_validation_failed');
+        } catch (_) {
+            return false;
+        }
+    }
+
+    async function secureLocalScreenshotFetch(url, options) {
+        var helper = window.nekoLocalMutationSecurity;
+        var requestOptions = options || {};
+        var baseHeaders = Object.assign({}, requestOptions.headers);
+
+        async function send(headers) {
+            return fetch(url, {
+                method: requestOptions.method || 'POST',
+                headers: headers,
+                body: requestOptions.body,
+                cache: requestOptions.cache,
+            });
+        }
+
+        var headers = Object.assign({}, baseHeaders, await buildLocalSecureHeaders());
+        var resp = await send(headers);
+        if (
+            await isLocalCsrfFailure(resp)
+            && helper
+            && typeof helper.refreshToken === 'function'
+        ) {
+            try {
+                await helper.refreshToken();
+                headers = Object.assign({}, baseHeaders, await buildLocalSecureHeaders());
+                resp = await send(headers);
+            } catch (e) {
+                console.warn('[截图] 刷新本地安全 token 失败:', e);
+            }
+        }
+        return resp;
+    }
+
     // ======================== fetchBackendScreenshot ========================
     /**
      * 后端截图兜底：当前端所有屏幕捕获 API 均失败时，请求后端用 pyautogui 截取本机屏幕。
@@ -463,7 +519,7 @@
             return { dataUrl: null, status: null };
         }
         try {
-            var resp = await fetch('/api/screenshot');
+            var resp = await secureLocalScreenshotFetch('/api/screenshot', { method: 'POST' });
             if (!resp.ok) return { dataUrl: null, status: resp.status };
             var json = await resp.json();
             if (json.success && json.data) {
@@ -489,7 +545,7 @@
             return { dataUrl: null, status: null, canceled: false, error: null };
         }
         try {
-            var resp = await fetch('/api/screenshot/interactive', { method: 'POST' });
+            var resp = await secureLocalScreenshotFetch('/api/screenshot/interactive', { method: 'POST' });
             var json = null;
             try {
                 json = await resp.json();

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -478,6 +478,45 @@
     }
     mod.fetchBackendScreenshot = fetchBackendScreenshot;
 
+    /**
+     * 后端系统原生交互截图：触发操作系统级的全桌面框选截图。
+     * 仅适合用户手势触发的场景（如点击聊天截图按钮）。
+     * @returns {Promise<{dataUrl: string|null, status: number|null, canceled?: boolean, error?: string|null}>}
+     */
+    async function fetchBackendInteractiveScreenshot() {
+        var h = window.location.hostname;
+        if (h !== 'localhost' && h !== '127.0.0.1' && h !== '0.0.0.0') {
+            return { dataUrl: null, status: null, canceled: false, error: null };
+        }
+        try {
+            var resp = await fetch('/api/screenshot/interactive', { method: 'POST' });
+            var json = null;
+            try {
+                json = await resp.json();
+            } catch (_) {
+                json = null;
+            }
+            if (json && json.canceled) {
+                console.log('[截图] 系统原生交互截图已取消');
+                return { dataUrl: null, status: resp.status, canceled: true, error: null };
+            }
+            if (resp.ok && json && json.success && json.data) {
+                console.log('[截图] 系统原生交互截图成功,', json.size, 'bytes');
+                return { dataUrl: json.data, status: resp.status, canceled: false, error: null };
+            }
+            return {
+                dataUrl: null,
+                status: resp.status,
+                canceled: false,
+                error: (json && json.error) ? json.error : null
+            };
+        } catch (e) {
+            console.warn('[截图] 系统原生交互截图请求失败:', e);
+            return { dataUrl: null, status: null, canceled: false, error: e && e.message ? e.message : null };
+        }
+    }
+    mod.fetchBackendInteractiveScreenshot = fetchBackendInteractiveScreenshot;
+
     // ======================== stopScreening ========================
     function stopScreening() {
         if (S.videoSenderInterval) {
@@ -1510,6 +1549,7 @@
     window.captureFrameFromStream = captureFrameFromStream;
     window.acquireOrReuseCachedStream = acquireOrReuseCachedStream;
     window.fetchBackendScreenshot = fetchBackendScreenshot;
+    window.fetchBackendInteractiveScreenshot = fetchBackendInteractiveScreenshot;
     window.getMobileCameraStream = getMobileCameraStream;
     window.startScreenVideoStreaming = startScreenVideoStreaming;
     window.stopScreening = stopScreening;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1691,9 +1691,8 @@ body.react-chat-window-dragging {
     position: fixed;
     inset: 0;
     z-index: 100040;
-    display: flex;
-    flex-direction: column;
-    background: #111;
+    display: block;
+    background: #090b10;
     pointer-events: auto;
     animation: crop-fade-in 0.2s ease;
 }
@@ -1703,47 +1702,59 @@ body.react-chat-window-dragging {
     to   { opacity: 1; }
 }
 
+.crop-workspace {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+}
+
 /* Top bar with tabs */
 .crop-topbar {
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 40px;
+    top: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+    height: 48px;
     display: flex;
     align-items: center;
-    gap: 2px;
-    padding: 0 12px;
-    background: rgba(0, 0, 0, 0.85);
-    border-bottom: 1px solid rgba(68, 183, 254, 0.3);
-    z-index: 2;
+    gap: 6px;
+    padding: 0 10px;
+    background: rgba(8, 11, 18, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    z-index: 5;
     user-select: none;
 }
 
 .crop-tab {
-    padding: 5px 16px;
+    padding: 8px 16px;
     border: none;
-    border-radius: 4px;
-    font-size: 0.85rem;
+    border-radius: 999px;
+    font-size: 0.84rem;
     font-weight: 500;
     cursor: pointer;
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(255, 255, 255, 0.72);
     background: transparent;
-    transition: background 0.15s, color 0.15s;
+    transition: background 0.15s, color 0.15s, transform 0.12s ease;
 }
 
 .crop-tab:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #fff;
+    transform: translateY(-1px);
 }
 
 .crop-tab-active {
-    background: rgba(68, 183, 254, 0.25);
-    color: #44b7fe;
+    background: rgba(68, 183, 254, 0.18);
+    color: #8bd8ff;
+    box-shadow: inset 0 0 0 1px rgba(68, 183, 254, 0.34);
 }
 
 .crop-tab-active:hover {
-    background: rgba(68, 183, 254, 0.35);
+    background: rgba(68, 183, 254, 0.28);
 }
 
 .crop-tab-cancel {
@@ -1782,30 +1793,131 @@ body.react-chat-window-dragging {
 
 .crop-canvas {
     position: absolute;
-    top: 40px;
+    top: 0;
     left: 0;
     width: 100%;
-    height: calc(100% - 40px);
+    height: 100%;
     cursor: crosshair;
     touch-action: none;
     z-index: 1;
 }
 
+.crop-selection-box {
+    position: absolute;
+    z-index: 3;
+    border: 1px solid rgba(255, 255, 255, 0.92);
+    box-shadow:
+        0 0 0 1px rgba(68, 183, 254, 0.9),
+        inset 0 0 0 1px rgba(68, 183, 254, 0.25),
+        0 12px 30px rgba(0, 0, 0, 0.22);
+    pointer-events: none;
+}
+
+.crop-selection-grid-line {
+    position: absolute;
+    background: rgba(255, 255, 255, 0.38);
+}
+
+.crop-selection-grid-line.h1,
+.crop-selection-grid-line.h2 {
+    left: 0;
+    right: 0;
+    height: 1px;
+}
+
+.crop-selection-grid-line.v1,
+.crop-selection-grid-line.v2 {
+    top: 0;
+    bottom: 0;
+    width: 1px;
+}
+
+.crop-selection-grid-line.h1 { top: 33.333%; }
+.crop-selection-grid-line.h2 { top: 66.666%; }
+.crop-selection-grid-line.v1 { left: 33.333%; }
+.crop-selection-grid-line.v2 { left: 66.666%; }
+
+.crop-selection-handle {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    margin-left: -5px;
+    margin-top: -5px;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #44b7fe;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+}
+
+.crop-selection-handle.nw { left: 0; top: 0; }
+.crop-selection-handle.n  { left: 50%; top: 0; }
+.crop-selection-handle.ne { left: 100%; top: 0; }
+.crop-selection-handle.e  { left: 100%; top: 50%; }
+.crop-selection-handle.se { left: 100%; top: 100%; }
+.crop-selection-handle.s  { left: 50%; top: 100%; }
+.crop-selection-handle.sw { left: 0; top: 100%; }
+.crop-selection-handle.w  { left: 0; top: 50%; }
+
+.crop-selection-badge,
+.crop-pointer-badge {
+    position: absolute;
+    z-index: 4;
+    min-width: 70px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    line-height: 1;
+    color: #fff;
+    background: rgba(8, 11, 18, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.26);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+.crop-crosshair {
+    position: absolute;
+    z-index: 2;
+    pointer-events: none;
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.crop-crosshair-x {
+    left: 0;
+    right: 0;
+    height: 1px;
+}
+
+.crop-crosshair-y {
+    top: 0;
+    bottom: 0;
+    width: 1px;
+}
+
 /* Floating ✓ / × buttons near selection */
 .crop-action-btns {
-    position: fixed;
+    position: absolute;
     display: flex;
-    gap: 4px;
-    z-index: 100041;
+    gap: 8px;
+    z-index: 6;
     pointer-events: auto;
     animation: crop-fade-in 0.15s ease;
+    padding: 6px;
+    border-radius: 999px;
+    background: rgba(8, 11, 18, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.32);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
 }
 
 .crop-action-btn {
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     border: none;
-    border-radius: 6px;
+    border-radius: 999px;
     font-size: 1.1rem;
     font-weight: 700;
     cursor: pointer;
@@ -1827,7 +1939,7 @@ body.react-chat-window-dragging {
 }
 
 .crop-action-cancel {
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.12);
     color: #ff6b7a;
     border: 1px solid rgba(220, 53, 69, 0.4);
 }
@@ -1840,26 +1952,27 @@ body.react-chat-window-dragging {
 /* Mobile adjustments */
 @media (max-width: 768px) {
     .crop-topbar {
-        height: 36px;
+        top: 14px;
+        height: 42px;
         padding: 0 8px;
+        max-width: calc(100vw - 20px);
     }
 
     .crop-tab {
-        padding: 4px 10px;
+        padding: 6px 10px;
         font-size: 0.78rem;
-    }
-
-    /* .crop-bg-image 的 top/width/height 由 app-crop.js computeImgMetrics() 写入 inline style，此处不再重复定义 */
-
-    .crop-canvas {
-        top: 36px;
-        height: calc(100% - 36px);
     }
 
     .crop-action-btn {
         width: 36px;
         height: 36px;
         font-size: 1.2rem;
+    }
+
+    .crop-selection-badge,
+    .crop-pointer-badge {
+        font-size: 11px;
+        padding: 5px 9px;
     }
 }
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -516,15 +516,15 @@
     <script src="/static/app-audio-playback.js"></script>
     <script src="/static/app-spatial-audio.js"></script>
     <script src="/static/app-audio-capture.js"></script>
-    <script src="/static/app-screen.js"></script>
-    <script src="/static/app-crop.js"></script>
+    <script src="/static/app-screen.js?v=20260428-ss2"></script>
+    <script src="/static/app-crop.js?v=20260428-ss2"></script>
     <script src="/static/app-interpage.js"></script>
     <script src="/static/app-proactive.js"></script>
     <script src="/static/app-settings.js"></script>
     <script src="/static/app-agent.js"></script>
     <script src="/static/app-character.js"></script>
     <script src="/static/app-websocket.js"></script>
-    <script src="/static/app-buttons.js"></script>
+    <script src="/static/app-buttons.js?v=20260428-ss2"></script>
     <script src="/static/app.js"></script>
     <script src="/static/subtitle.js"></script>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -347,8 +347,8 @@
     <script src="/static/app-audio-playback.js"></script>
     <script src="/static/app-spatial-audio.js"></script>
     <script src="/static/app-audio-capture.js"></script>
-    <script src="/static/app-screen.js"></script>
-    <script src="/static/app-crop.js"></script>
+    <script src="/static/app-screen.js?v=20260428-ss2"></script>
+    <script src="/static/app-crop.js?v=20260428-ss2"></script>
     <script src="/static/app-interpage.js"></script>
     <script src="/static/app-proactive.js"></script>
     <script src="/static/app-settings.js"></script>
@@ -356,7 +356,7 @@
     <script src="/static/app-agent.js"></script>
     <script src="/static/app-character.js"></script>
     <script src="/static/app-websocket.js"></script>
-    <script src="/static/app-buttons.js"></script>
+    <script src="/static/app-buttons.js?v=20260428-ss2"></script>
     <script src="/static/app-prompt-shared.js"></script>
     <script src="/static/app-autostart-provider.js"></script>
     <script src="/static/app-tutorial-prompt.js"></script>

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -44,6 +45,12 @@ def _local_headers():
         "Origin": "http://testserver",
         "X-CSRF-Token": "test-csrf-token",
     }
+
+
+@pytest.mark.unit
+def test_is_loopback_request_accepts_ipv4_mapped_ipv6_loopback():
+    request = SimpleNamespace(client=SimpleNamespace(host="::ffff:127.0.0.1"))
+    assert system_router_module._is_loopback_request(request) is True
 
 
 @pytest.mark.unit

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -1,0 +1,107 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from main_routers import system_router as system_router_module
+from main_routers.shared_state import init_shared_state
+
+
+INTERACTIVE_SCREENSHOT_ENDPOINT = "/api/screenshot/interactive"
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_state_after_test():
+    yield
+    init_shared_state(
+        role_state={},
+        steamworks=None,
+        templates=None,
+        config_manager=None,
+        logger=None,
+    )
+
+
+def _build_client():
+    init_shared_state(
+        role_state={},
+        steamworks=None,
+        templates=None,
+        config_manager=None,
+        logger=None,
+    )
+    app = FastAPI()
+    app.include_router(system_router_module.router)
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_rejects_non_loopback_requests():
+    with _build_client() as client, patch.object(
+        system_router_module,
+        "_is_loopback_request",
+        return_value=False,
+    ):
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+
+    assert response.status_code == 403
+    assert response.json()["error"] == "only available from localhost"
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_returns_unsupported_on_non_macos(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "linux")
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+
+    assert response.status_code == 501
+    assert "only supported on macOS" in response.json()["error"]
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_returns_canceled_when_user_aborts(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_macos_interactive_screenshot",
+        lambda _path: (1, ""),
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["canceled"] is True
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_returns_cropped_image_data(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
+
+    def _fake_run(output_path: str):
+        Image.new("RGB", (64, 48), (32, 128, 224)).save(output_path, format="PNG")
+        return 0, ""
+
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_macos_interactive_screenshot",
+        _fake_run,
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["interactive"] is True
+    assert payload["size"] > 0
+    assert payload["data"].startswith("data:image/jpeg;base64,")

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -102,6 +102,26 @@ def test_interactive_screenshot_returns_canceled_when_user_aborts(monkeypatch):
 
 
 @pytest.mark.unit
+def test_interactive_screenshot_returns_failure_for_runtime_errors(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_windows_interactive_screenshot",
+        lambda _path: (2, "boom"),
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["canceled"] is False
+    assert payload["error"] == "boom"
+
+
+@pytest.mark.unit
 def test_interactive_screenshot_returns_cropped_image_data(monkeypatch):
     monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
     monkeypatch.setattr(system_router_module.sys, "platform", "darwin")

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -102,6 +102,25 @@ def test_interactive_screenshot_returns_canceled_when_user_aborts(monkeypatch):
 
 
 @pytest.mark.unit
+def test_interactive_screenshot_treats_macos_cancel_with_stderr_as_canceled(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_macos_interactive_screenshot",
+        lambda _path: (1, "User canceled."),
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["canceled"] is True
+
+
+@pytest.mark.unit
 def test_interactive_screenshot_returns_failure_for_runtime_errors(monkeypatch):
     monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
     monkeypatch.setattr(system_router_module.sys, "platform", "win32")

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -62,6 +62,7 @@ def test_backend_screenshot_rejects_missing_csrf_headers():
     payload = response.json()
     assert payload["success"] is False
     assert payload["error_code"] == "csrf_validation_failed"
+    assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, max-age=0"
 
 
 @pytest.mark.unit
@@ -171,6 +172,7 @@ def test_interactive_screenshot_returns_cropped_image_data(monkeypatch):
     assert payload["interactive"] is True
     assert payload["size"] > 0
     assert payload["data"].startswith("data:image/jpeg;base64,")
+    assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, max-age=0"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -79,6 +79,18 @@ def test_interactive_screenshot_rejects_non_loopback_requests():
 
 
 @pytest.mark.unit
+def test_interactive_screenshot_does_not_require_csrf_headers(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "linux")
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+
+    assert response.status_code == 501
+    assert "only supported on macOS and Windows" in response.json()["error"]
+
+
+@pytest.mark.unit
 def test_interactive_screenshot_returns_unsupported_on_non_macos(monkeypatch):
     monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
     monkeypatch.setattr(system_router_module.sys, "platform", "linux")

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -9,11 +9,13 @@ from main_routers import system_router as system_router_module
 from main_routers.shared_state import init_shared_state
 
 
+SCREENSHOT_ENDPOINT = "/api/screenshot"
 INTERACTIVE_SCREENSHOT_ENDPOINT = "/api/screenshot/interactive"
 
 
 @pytest.fixture(autouse=True)
-def _reset_shared_state_after_test():
+def _reset_shared_state_after_test(monkeypatch):
+    monkeypatch.setattr(system_router_module, "AUTOSTART_CSRF_TOKEN", "test-csrf-token")
     yield
     init_shared_state(
         role_state={},
@@ -37,6 +39,24 @@ def _build_client():
     return TestClient(app)
 
 
+def _local_headers():
+    return {
+        "Origin": "http://testserver",
+        "X-CSRF-Token": "test-csrf-token",
+    }
+
+
+@pytest.mark.unit
+def test_backend_screenshot_rejects_missing_csrf_headers():
+    with _build_client() as client:
+        response = client.post(SCREENSHOT_ENDPOINT)
+
+    assert response.status_code == 403
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["error_code"] == "csrf_validation_failed"
+
+
 @pytest.mark.unit
 def test_interactive_screenshot_rejects_non_loopback_requests():
     with _build_client() as client, patch.object(
@@ -44,7 +64,7 @@ def test_interactive_screenshot_rejects_non_loopback_requests():
         "_is_loopback_request",
         return_value=False,
     ):
-        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
 
     assert response.status_code == 403
     assert response.json()["error"] == "only available from localhost"
@@ -56,10 +76,10 @@ def test_interactive_screenshot_returns_unsupported_on_non_macos(monkeypatch):
     monkeypatch.setattr(system_router_module.sys, "platform", "linux")
 
     with _build_client() as client:
-        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
 
     assert response.status_code == 501
-    assert "only supported on macOS" in response.json()["error"]
+    assert "only supported on macOS and Windows" in response.json()["error"]
 
 
 @pytest.mark.unit
@@ -73,7 +93,7 @@ def test_interactive_screenshot_returns_canceled_when_user_aborts(monkeypatch):
     )
 
     with _build_client() as client:
-        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
 
     assert response.status_code == 200
     payload = response.json()
@@ -97,7 +117,52 @@ def test_interactive_screenshot_returns_cropped_image_data(monkeypatch):
     )
 
     with _build_client() as client:
-        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT)
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["interactive"] is True
+    assert payload["size"] > 0
+    assert payload["data"].startswith("data:image/jpeg;base64,")
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_returns_canceled_when_windows_user_aborts(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_windows_interactive_screenshot",
+        lambda _path: (1, ""),
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is False
+    assert payload["canceled"] is True
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_returns_windows_cropped_image_data(monkeypatch):
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "win32")
+
+    def _fake_run(output_path: str):
+        Image.new("RGB", (90, 60), (220, 120, 40)).save(output_path, format="PNG")
+        return 0, ""
+
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_windows_interactive_screenshot",
+        _fake_run,
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
 
     assert response.status_code == 200
     payload = response.json()


### PR DESCRIPTION
## 变更内容

本次修改重做了聊天截图功能，目标是让截图体验更接近系统原生截图工具，而不是停留在网页内部裁剪。

主要改动包括：

- 新增后端系统原生交互截图接口 `POST /api/screenshot/interactive`
- 聊天截图按钮优先调用系统原生（mac/windows）框选截图
- 当系统原生截图不可用时，自动回退到现有截图链路，保证兼容性
- 优化现有裁剪界面的交互体验，作为兜底方案保留
- 给截图相关前端脚本增加版本参数，避免浏览器缓存旧代码
- 新增截图路由测试文件，覆盖本地访问限制、非 macOS、用户取消、成功返回等场景

## 影响文件

- `main_routers/system_router.py`
- `static/app-screen.js`
- `static/app-buttons.js`
- `static/app-crop.js`
- `static/css/index.css`
- `templates/index.html`
- `templates/chat.html`
- `tests/unit/test_system_screenshot_router.py`

## 测试

已执行：

```bash
node --check static/app-screen.js
node --check static/app-buttons.js
pytest tests/unit/test_system_screenshot_router.py -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增交互式桌面区域选择截图接口与前端交互（macOS/Windows），支持确认/取消并返回压缩 JPEG DataURL。

* **改进**
  * /api/screenshot 改为 POST，后端本机访问校验改为环回检测，截图响应统一设置 no-store。
  * 前端新增本地主动安全请求封装、多路径桌面捕获与降级逻辑，明确区分取消/失败/成功结果并重试令牌。

* **样式**
  * 重构裁剪覆盖层布局与交互，新增选择句柄、网格、十字线、提示徽章与键盘微调支持。

* **测试**
  * 新增交互截图与安全校验单元测试。

* **其他**
  * 静态脚本加入版本查询字符串以刷新缓存。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->