### PR TITLE
perf(async): 消除主 event loop 上的 TTS / cross_server 高频轮询

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4300,15 +4300,20 @@ class LLMSessionManager:
             logger.error(f"💥 WS Send Response Error: {e}")
 
     async def tts_response_handler(self):
-        import queue as _queue_mod
         q = self.tts_response_queue
         logger.info(f"🎧 tts_response_handler started (queue id={id(q):#x})")
         while True:
             try:
-                try:
-                    data = q.get_nowait()
-                except _queue_mod.Empty:
-                    await asyncio.sleep(0.01)
+                # 阻塞 get 挂在线程池里，无消息时主 event loop 完全沉默；
+                # 取消时 except CancelledError 分支会 push 哨兵唤醒线程池里那个
+                # 仍在 q.get() 上的线程，避免线程泄漏。
+                data = await asyncio.to_thread(q.get)
+
+                # 处理 cancel 时为唤醒泄漏线程而 push 的哨兵。同一个 handler 实例
+                # 不会在 cancel 之后继续运行（CancelledError 已 raise），所以这里
+                # 只是为了在 handler 被替换后，新 handler（绑同一 queue）若意外
+                # 读到旧 handler 留下的哨兵也能正确忽略。
+                if isinstance(data, tuple) and len(data) == 2 and data[0] == "__handler_exit__":
                     continue
 
                 if isinstance(data, tuple) and len(data) == 2:
@@ -4450,6 +4455,13 @@ class LLMSessionManager:
                 await self.send_speech(data)
             except asyncio.CancelledError:
                 logger.info("🎧 tts_response_handler cancelled")
+                # asyncio.to_thread 取消后，线程池里那个 thread 仍阻塞在 q.get()。
+                # push 哨兵唤醒它返回，避免线程泄漏（线程持有 queue ref，整个 queue
+                # 也会被一起留住）。put_nowait 失败不影响主流程。
+                try:
+                    q.put_nowait(("__handler_exit__", None))
+                except Exception:
+                    pass
                 raise
             except Exception as e:
                 logger.error(f"💥 tts_response_handler error (will retry): {e}")

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -14,7 +14,6 @@ import asyncio
 import time
 import pickle
 import aiohttp
-from queue import Empty
 from config import (
     MONITOR_SERVER_PORT,
     MEMORY_SERVER_PORT,
@@ -336,57 +335,85 @@ def _mark_memory_cache_exception(
         logger.warning(msg)
 
 
-def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_server_url=f"ws://127.0.0.1:{MONITOR_SERVER_PORT}", config=None, status_callback=None):
-    """独立进程运行的同步连接器
+async def run_sync_connector(
+    message_queue,
+    lanlan_name,
+    sync_server_url=f"ws://127.0.0.1:{MONITOR_SERVER_PORT}",
+    config=None,
+    status_callback=None,
+):
+    """Async-native 同步连接器，跑在调用方主 event loop 上。
+
+    历史：最早是 multiprocessing 子进程（``*_process`` 命名遗留），
+    后来变成 daemon Thread + 内部 ``asyncio.new_event_loop()``。现在合并到
+    主 loop：
+    - 取消通过 ``asyncio.CancelledError`` 触发；cleanup 在 finally 完成
+    - ``message_queue`` 改为 ``asyncio.Queue``，用 ``await get()`` 替代 20ms
+      轮询。生产端 ``put_nowait()`` 与旧版 ``queue.Queue`` API 兼容
+    - 应用层 heartbeat 节流到 10s 一次；底层 ws ping/pong 由
+      ``aiohttp.ws_connect(heartbeat=10)`` 自动维持
 
     Args:
-        status_callback: Optional callable(str) -> None, thread-safe, invoked
-            on the caller's event loop to push status/error messages to the frontend.
+        status_callback: 可选 ``Callable[[str], None]``。运行在主 loop 上，
+            可直接 ``asyncio.create_task(...)``，无需 ``run_coroutine_threadsafe``。
     """
-
-    # 创建一个新的事件循环
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    chat_history = []
+    chat_history: list = []
     default_config = {'bullet': True, 'monitor': True}
     if config is None:
         config = {}
     config = default_config | config
 
-    async def maintain_connection(chat_history, lanlan_name):
-        sync_session = None
-        sync_ws = None
-        sync_reader = None
-        binary_session = None
-        binary_ws = None
-        binary_reader = None
-        bullet_session = None
-        bullet_ws = None
-        bullet_reader = None
+    # 历史保留：旧 thread 版本里多处 ``if shutdown_event.is_set(): break`` 用于
+    # 子进程时代跳过对正在关闭的 memory_server 的 HTTP 调用。改 async 后取消
+    # 由 await 点自然 raise CancelledError 顶替，guard 不再有意义。统一替换成
+    # 永远 False 的 stub，避免大面积重排缩进；这些 guard 现在是死代码，但语义
+    # 仍然正确（不阻挡正常路径），后续清理 PR 可一并删。
+    class _NeverShutdown:
+        @staticmethod
+        def is_set() -> bool:
+            return False
+    shutdown_event = _NeverShutdown()
 
-        user_input_cache = ''
-        text_output_cache = '' # lanlan的当前消息
-        current_turn = 'user'
-        had_user_input_this_turn = False  # 当前 turn 是否有用户输入（False = 主动搭话）
-        current_turn_start_index = 0
-        last_screen = None
-        pending_user_images = []
-        last_synced_index = 0  # 用于 turn end 时仅同步新增消息到 memory，避免 memory_browser 不更新
-        avatar_interaction_memory_cache: dict[str, dict[str, int | str]] = {}
-        memory_cache_health_state = {
-            MEMORY_CACHE_SCOPE_AVATAR: False,
-            MEMORY_CACHE_SCOPE_TURN_END: False,
-        }
+    sync_session = None
+    sync_ws = None
+    sync_reader = None
+    binary_session = None
+    binary_ws = None
+    binary_reader = None
+    bullet_session = None
+    bullet_ws = None
+    bullet_reader = None
 
-        while not shutdown_event.is_set():
+    user_input_cache = ''
+    text_output_cache = ''  # lanlan的当前消息
+    current_turn = 'user'
+    had_user_input_this_turn = False  # 当前 turn 是否有用户输入（False = 主动搭话）
+    current_turn_start_index = 0
+    last_screen = None
+    pending_user_images: list = []
+    last_synced_index = 0  # 用于 turn end 时仅同步新增消息到 memory，避免 memory_browser 不更新
+    avatar_interaction_memory_cache: dict[str, dict[str, int | str]] = {}
+    memory_cache_health_state = {
+        MEMORY_CACHE_SCOPE_AVATAR: False,
+        MEMORY_CACHE_SCOPE_TURN_END: False,
+    }
+
+    last_heartbeat_at = 0.0
+    HEARTBEAT_INTERVAL = 10.0  # 主动 heartbeat 节流间隔
+    IDLE_TIMEOUT = 10.0  # 没消息时仍每 10s 唤醒一次 ws 检查/重连
+
+    try:
+        while True:
+            message = None
             try:
-                # 检查消息队列
-                while not message_queue.empty():
-                    try:
-                        message = message_queue.get_nowait()
-                    except Empty:
-                        break
+                message = await asyncio.wait_for(
+                    message_queue.get(), timeout=IDLE_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                pass
 
+            if message is not None:
+                try:
                     if message["type"] == "json":
                         # Forward to monitor if enabled
                         if config['monitor'] and sync_ws:
@@ -803,11 +830,9 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
                                 last_synced_index = 0
                         except Exception as e:
                             logger.error(f"[{lanlan_name}] System message error: {e}", exc_info=True)
-                    await asyncio.sleep(0.02)
-            except Exception as e:
-                logger.error(f"[{lanlan_name}] Message processing error: {e}", exc_info=True)
-                await asyncio.sleep(0.02)
-            
+                except Exception as e:
+                    logger.error(f"[{lanlan_name}] Message processing error: {e}", exc_info=True)
+
             # WebSocket 连接管理（独立于消息处理）
             try:
                 # 如果连接不存在，尝试建立连接
@@ -843,14 +868,21 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
                                 # logger.warning(f"[{lanlan_name}] Monitor二进制连接失败: {e}")
                                 binary_ws = None
 
-                        # 发送心跳（捕获异常以检测连接断开）
-                        if config['monitor'] and sync_ws:
+                        # 发送应用层心跳（节流到每 HEARTBEAT_INTERVAL 一次）。
+                        # 底层 ws ping/pong 已由 aiohttp.ws_connect(heartbeat=10)
+                        # 维持，应用层 heartbeat 主要作为 send 失败 = 连接断的探针。
+                        _now_ts = time.time()
+                        _should_heartbeat = (_now_ts - last_heartbeat_at >= HEARTBEAT_INTERVAL)
+                        if _should_heartbeat:
+                            last_heartbeat_at = _now_ts
+
+                        if _should_heartbeat and config['monitor'] and sync_ws:
                             try:
-                                await sync_ws.send_json({"type": "heartbeat", "timestamp": time.time()})
+                                await sync_ws.send_json({"type": "heartbeat", "timestamp": _now_ts})
                             except Exception:
                                 sync_ws = None
-                                
-                        if config['monitor'] and binary_ws:
+
+                        if _should_heartbeat and config['monitor'] and binary_ws:
                             try:
                                 await binary_ws.send_bytes(b'\x00\x01\x02\x03')
                             except Exception:
@@ -880,21 +912,25 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
                 except Exception as e:
                     logger.error(f"[{lanlan_name}] Bullet连接异常: {e}", exc_info=True)
                     bullet_ws = None
-                
-                # 短暂休眠避免CPU占用过高
-                await asyncio.sleep(0.02)
+
+                # 不再需要 0.02s 的 spin sleep —— 上层 await message_queue.get()
+                # 已经是阻塞的，无消息时整个 loop 自然挂起，不会忙等。
 
             except asyncio.CancelledError:
-                break
+                # 让外层 try 的 finally 接管 cleanup
+                raise
             except Exception as e:
-                # WebSocket 连接异常，标记连接为失败状态
                 logger.error(f"[{lanlan_name}] WebSocket连接异常: {e}")
                 sync_ws = None
                 binary_ws = None
                 bullet_ws = None
-                await asyncio.sleep(0.03)  # 重连前等待
+                await asyncio.sleep(0.5)  # 出错时退避 0.5s 再重连，避免快速失败 spam
 
-        # 关闭资源（并行：3 个 ws + 3 个 session 互相独立）
+    except asyncio.CancelledError:
+        raise
+    finally:
+        # 关闭资源（并行：3 个 ws + 3 个 session 互相独立）。无论是正常完成、
+        # 取消、还是异常退出，都走这里清理。
         async def _safe_close(target):
             if target is None:
                 return
@@ -909,45 +945,13 @@ def sync_connector_process(message_queue, shutdown_event, lanlan_name, sync_serv
             _safe_close(sync_session), _safe_close(binary_session), _safe_close(bullet_session),
             return_exceptions=True,
         )
-        for rdr in [sync_reader, binary_reader, bullet_reader]:
-            if rdr:
+        for rdr in (sync_reader, binary_reader, bullet_reader):
+            if rdr is not None:
                 try:
                     rdr.cancel()
                 except Exception:
                     pass
-
-    async def _shutdown_watcher():
-        """轮询 shutdown_event，一旦触发就让 maintain_connection 自然退出并执行清理"""
-        while not shutdown_event.is_set():
-            await asyncio.sleep(0.2)
-        # shutdown_event 已触发，maintain_connection 的 while 循环会在下次检查时退出，
-        # 并执行自身的清理逻辑（关闭 WebSocket / aiohttp session / reader task）。
-        # 不再强制取消所有 task，避免打断 maintain_connection 的 finally/cleanup 流程。
-
-    async def _run_with_shutdown():
-        watcher = asyncio.ensure_future(_shutdown_watcher())
-        try:
-            await maintain_connection(chat_history, lanlan_name)
-        except asyncio.CancelledError:
-            pass
-        finally:
-            watcher.cancel()
-            try:
-                await watcher
-            except asyncio.CancelledError:
-                pass
-
-    try:
-        loop.run_until_complete(_run_with_shutdown())
-    except Exception as e:
-        logger.error(f"[{lanlan_name}] Sync进程错误: {e}", exc_info=True)
-    finally:
-        try:
-            from utils.internal_http_client import aclose_internal_http_client_current_loop
-
-            loop.run_until_complete(aclose_internal_http_client_current_loop())
-        except Exception:
-            pass
-        loop.close()
-        # 线程退出阶段测试环境可能已经关闭日志捕获流；这里避免再做收尾 info 日志，
-        # 以免 shutdown 正常完成时反而刷出 logging error 噪音。
+        # 注意：不在这里调用 aclose_internal_http_client_current_loop()。
+        # 旧版子进程/独立线程拥有自己的 event loop，其 http client 也是 per-loop
+        # 缓存的，退出时需要 close。现在合并到主 loop，client 由主代码共享，
+        # 我们没有所有权，不应当 close。

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -336,7 +336,7 @@ def _mark_memory_cache_exception(
 
 
 async def run_sync_connector(
-    message_queue,
+    message_queue: asyncio.Queue,
     lanlan_name,
     sync_server_url=f"ws://127.0.0.1:{MONITOR_SERVER_PORT}",
     config=None,
@@ -399,7 +399,12 @@ async def run_sync_connector(
     }
 
     last_heartbeat_at = 0.0
-    HEARTBEAT_INTERVAL = 10.0  # 主动 heartbeat 节流间隔
+    # 节流后的应用层 heartbeat 间隔。原因不是省 CPU（aiohttp ws_connect(heartbeat=10)
+    # 已经在底层做了 ping/pong），而是控制 send-fail → ws=None → 下一轮 reconnect
+    # 这条链路的检测延迟。1s 在 idle 期足够安静（远低于改造前 50Hz），同时把
+    # 断线检测窗口锁在 ~1s。设太大（比如 10s）会让 idle→burst 切换时第一波消息
+    # 撞到旧 ws 上更长一段时间。
+    HEARTBEAT_INTERVAL = 1.0
     IDLE_TIMEOUT = 10.0  # 没消息时仍每 10s 唤醒一次 ws 检查/重连
 
     try:
@@ -948,12 +953,18 @@ async def run_sync_connector(
             _safe_close(sync_session), _safe_close(binary_session), _safe_close(bullet_session),
             return_exceptions=True,
         )
-        for rdr in (sync_reader, binary_reader, bullet_reader):
-            if rdr is not None:
-                try:
-                    rdr.cancel()
-                except Exception:
-                    pass
+        # cancel reader task 后必须 await，否则 task 在 loop 关闭时还 pending
+        # 会触发 "Task was destroyed but it is pending!" 告警。keep_reader 内部
+        # 已经处理 CancelledError → break，所以 gather(return_exceptions=True)
+        # 会安静地收掉 cancel 副作用。
+        readers = [r for r in (sync_reader, binary_reader, bullet_reader) if r is not None]
+        for rdr in readers:
+            try:
+                rdr.cancel()
+            except Exception:
+                pass
+        if readers:
+            await asyncio.gather(*readers, return_exceptions=True)
         # 注意：不在这里调用 aclose_internal_http_client_current_loop()。
         # 旧版子进程/独立线程拥有自己的 event loop，其 http client 也是 per-loop
         # 缓存的，退出时需要 close。现在合并到主 loop，client 由主代码共享，

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -350,8 +350,8 @@ async def run_sync_connector(
     - 取消通过 ``asyncio.CancelledError`` 触发；cleanup 在 finally 完成
     - ``message_queue`` 改为 ``asyncio.Queue``，用 ``await get()`` 替代 20ms
       轮询。生产端 ``put_nowait()`` 与旧版 ``queue.Queue`` API 兼容
-    - 应用层 heartbeat 节流到 10s 一次；底层 ws ping/pong 由
-      ``aiohttp.ws_connect(heartbeat=10)`` 自动维持
+    - 应用层 heartbeat 节流到 ``HEARTBEAT_INTERVAL`` 一次（当前 1s）；底层 ws
+      ping/pong 由 ``aiohttp.ws_connect(heartbeat=10)`` 自动维持
 
     Args:
         status_callback: 可选 ``Callable[[str], None]``。运行在主 loop 上，
@@ -424,8 +424,9 @@ async def run_sync_connector(
                 )
             except asyncio.TimeoutError:
                 # 超时 = 没消息：保持 message=None 走到下面 ws 维持段做周期性
-                # reconnect/heartbeat 检查。这条路径在 idle 期每 IDLE_TIMEOUT
-                # 触发一次，不打日志否则会变成稳定噪音。
+                # reconnect/heartbeat 检查。idle 期每 LOOP_TICK 触发一次（当前
+                # 1s，由 min(IDLE_TIMEOUT, HEARTBEAT_INTERVAL) 决定）；不打日志
+                # 否则会变成稳定噪音。
                 pass
 
             if message is not None:

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -406,13 +406,17 @@ async def run_sync_connector(
     # 撞到旧 ws 上更长一段时间。
     HEARTBEAT_INTERVAL = 1.0
     IDLE_TIMEOUT = 10.0  # 没消息时仍每 10s 唤醒一次 ws 检查/重连
+    # 外层 loop 唤醒粒度必须 <= heartbeat 间隔，否则 idle 期 heartbeat / reconnect
+    # 检查仍要等 IDLE_TIMEOUT 才轮上一次——HEARTBEAT_INTERVAL 调到 1s 但 wait_for
+    # 还卡 10s 的话，注释里写的"~1s 探测窗口"就是空头支票。
+    LOOP_TICK = min(IDLE_TIMEOUT, HEARTBEAT_INTERVAL)
 
     try:
         while True:
             message = None
             try:
                 message = await asyncio.wait_for(
-                    message_queue.get(), timeout=IDLE_TIMEOUT
+                    message_queue.get(), timeout=LOOP_TICK
                 )
             except asyncio.TimeoutError:
                 # 超时 = 没消息：保持 message=None 走到下面 ws 维持段做周期性

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -410,6 +410,9 @@ async def run_sync_connector(
                     message_queue.get(), timeout=IDLE_TIMEOUT
                 )
             except asyncio.TimeoutError:
+                # 超时 = 没消息：保持 message=None 走到下面 ws 维持段做周期性
+                # reconnect/heartbeat 检查。这条路径在 idle 期每 IDLE_TIMEOUT
+                # 触发一次，不打日志否则会变成稳定噪音。
                 pass
 
             if message is not None:

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -958,11 +958,10 @@ async def run_sync_connector(
         # 已经处理 CancelledError → break，所以 gather(return_exceptions=True)
         # 会安静地收掉 cancel 副作用。
         readers = [r for r in (sync_reader, binary_reader, bullet_reader) if r is not None]
+        # asyncio.Task.cancel() 不抛异常（返回 bool），所以这里不需要 try/except
+        # 包裹——旧线程版本的过度防御代码已删除。
         for rdr in readers:
-            try:
-                rdr.cancel()
-            except Exception:
-                pass
+            rdr.cancel()
         if readers:
             await asyncio.gather(*readers, return_exceptions=True)
         # 注意：不在这里调用 aclose_internal_http_client_current_loop()。

--- a/main_logic/cross_server.py
+++ b/main_logic/cross_server.py
@@ -415,8 +415,12 @@ async def run_sync_connector(
         while True:
             message = None
             try:
+                # check_async_blocking.py 用纯名字启发式（``*_queue.get()`` 一律拍），
+                # 类型标注不影响判断；这里 message_queue 实际是 ``asyncio.Queue``，
+                # ``.get()`` 返回 coroutine 由 wait_for 调度，不会阻塞 event loop。
                 message = await asyncio.wait_for(
-                    message_queue.get(), timeout=LOOP_TICK
+                    message_queue.get(),  # noqa: ASYNC_BLOCK — asyncio.Queue, not queue.Queue
+                    timeout=LOOP_TICK,
                 )
             except asyncio.TimeoutError:
                 # 超时 = 没消息：保持 message=None 走到下面 ws 维持段做周期性

--- a/main_server.py
+++ b/main_server.py
@@ -337,8 +337,17 @@ class RoleState:
       websocket_router / _init_character_resources 后续赋值。
 
     历史字段：``sync_shutdown_event: ThreadEvent`` 和 ``sync_process: Thread``
-    在 cross_server 合并到主 event loop 后已删除（不再起独立线程）。生命周期
-    改由 ``sync_task: asyncio.Task`` 管理，shutdown 走 ``task.cancel()``。
+    在 cross_server 合并到主 event loop 后语义上已删除（不再起独立线程）。
+    生命周期改由 ``sync_task: asyncio.Task`` 管理，shutdown 走 ``task.cancel()``。
+
+    但 ``main_routers/shared_state.py`` 的 ``_RoleStateFieldView`` 仍为
+    ``sync_shutdown_event`` / ``sync_process`` 暴露 dict-like 视图（``get_sync_shutdown_event()``
+    / ``get_sync_process()`` 公共 router API）。视图的 ``__getitem__`` 用
+    ``getattr(rs, field)``（不带 default），如果字段不存在会 ``AttributeError``。
+    保留这两个 ``Optional[Any] = None`` 占位字段维护 shim 的"永远空字典"语义：
+    ``__contains__`` 看到 None 返回 False、``__getitem__`` 走 ``raise KeyError``，
+    所有调用者得到一致的空状态而不是崩溃。这两个字段不再被赋值，未来如果
+    确认外部确无依赖再清。
     """
     sync_message_queue: _SyncMessageQueue
     websocket_lock: asyncio.Lock
@@ -347,6 +356,9 @@ class RoleState:
     # 用 Any 而非 core.LLMSessionManager：避免 dataclass 运行时求值 annotation
     # 时踩到 forward-ref / 循环引用边界
     session_manager: Optional[Any] = None
+    # 仅为 main_routers/shared_state.py 的 legacy field-view 提供占位；永远 None
+    sync_shutdown_event: Optional[Any] = None
+    sync_process: Optional[Any] = None
 
 
 # 角色名 -> RoleState 的主存储；所有 per-k 同步资源都通过它访问
@@ -859,8 +871,16 @@ async def _init_character_resources(k: str, is_new_character: bool):
                         # cross_server 现在和我们在同一个主 loop 上，回调
                         # 也是从主 loop 同步调用的——直接 create_task 即可，
                         # 不再需要 run_coroutine_threadsafe。
+                        # done_callback 消化 task 的 exception，避免 ws 断开时
+                        # asyncio 输出 "Task exception was never retrieved" 噪音；
+                        # status 是 best-effort 降级路径，丢一条不影响主逻辑。
+                        def _swallow_status_send_exc(_t):
+                            exc = _t.exception()
+                            if exc is not None:
+                                logger.debug("status 回调 ws.send_text 失败（已忽略）: %s", exc)
                         try:
-                            asyncio.create_task(ws.send_text(data))
+                            _t = asyncio.create_task(ws.send_text(data))
+                            _t.add_done_callback(_swallow_status_send_exc)
                         except RuntimeError:
                             # 极端情况：当前没有 running loop（理论上不会发生
                             # 在 cross_server 调用路径上，但兜底）。回退到旧

--- a/main_server.py
+++ b/main_server.py
@@ -874,7 +874,12 @@ async def _init_character_resources(k: str, is_new_character: bool):
                         # done_callback 消化 task 的 exception，避免 ws 断开时
                         # asyncio 输出 "Task exception was never retrieved" 噪音；
                         # status 是 best-effort 降级路径，丢一条不影响主逻辑。
+                        # cancelled 态下 task.exception() 自身会 raise CancelledError，
+                        # 必须先用 task.cancelled() 早返回，否则 callback 自己又制造
+                        # 一条 "exception was never retrieved" 噪音。
                         def _swallow_status_send_exc(_t):
+                            if _t.cancelled():
+                                return
                             exc = _t.exception()
                             if exc is not None:
                                 logger.debug("status 回调 ws.send_text 失败（已忽略）: %s", exc)

--- a/main_server.py
+++ b/main_server.py
@@ -94,8 +94,6 @@ try:
     from main_logic import core as core, cross_server as cross_server # noqa
     from main_logic.agent_event_bus import MainServerAgentBridge, notify_analyze_ack, set_main_bridge # noqa
     from fastapi.templating import Jinja2Templates # noqa
-    from threading import Thread, Event as ThreadEvent # noqa
-    from queue import Queue, Empty as QueueEmpty # noqa
     from dataclasses import dataclass # noqa
     from typing import Any, Optional # noqa
 except Exception as e:
@@ -302,6 +300,25 @@ async def _request_memory_server_block_startup(reason: str = "") -> None:
     except Exception as e:
         raise RuntimeError(f"failed to restore memory_server limited-mode startup: {e}") from e
 
+class _SyncMessageQueue(asyncio.Queue):
+    """``asyncio.Queue`` with sync ``put()`` aliased to ``put_nowait()``.
+
+    ``sync_message_queue`` 历史上是 ``queue.Queue``（线程安全），生产端在
+    core.py / system_router.py 等 14+ 处用同步 ``q.put(item)`` 调用。
+    cross_server 改成主 loop 上的 ``asyncio.Task`` 后，message_queue 切到
+    ``asyncio.Queue``。原生 ``asyncio.Queue.put`` 是 coroutine，原 sync 调用
+    会变成"未 await 的 coroutine"——既不入队也产生 RuntimeWarning。
+
+    覆盖 ``put`` 为 sync alias 到 ``put_nowait`` 保持向后兼容：sync_message_queue
+    全部 unbounded（无 maxsize），``put_nowait`` 永远不会因满而 raise，所以
+    替换在语义上等价。
+    """
+
+    def put(self, item):  # type: ignore[override]
+        # 故意 sync override：原 asyncio.Queue.put 是 coroutine。
+        self.put_nowait(item)
+
+
 @dataclass
 class RoleState:
     """单个 catgirl 的 per-k 运行态容器。
@@ -312,19 +329,21 @@ class RoleState:
     见 issue #857 / PR #855 review。
 
     不变量：
-    - sync_message_queue / sync_shutdown_event / websocket_lock 在
-      _ensure_character_slots 一次性构造，之后**永不替换**。特别是
-      websocket_lock —— 替换会让已经 ``async with`` 进来的协程阻塞在一把
-      孤立的旧 Lock 上；如果任何逻辑需要整体重建 role_state[k]，必须
-      把旧 lock 原样传过去。
-    - session_id / sync_process / session_manager 初始为 None，分别由
+    - sync_message_queue / websocket_lock 在 _ensure_character_slots
+      一次性构造，之后**永不替换**。特别是 websocket_lock —— 替换会让已经
+      ``async with`` 进来的协程阻塞在一把孤立的旧 Lock 上；如果任何逻辑
+      需要整体重建 role_state[k]，必须把旧 lock 原样传过去。
+    - session_id / sync_task / session_manager 初始为 None，分别由
       websocket_router / _init_character_resources 后续赋值。
+
+    历史字段：``sync_shutdown_event: ThreadEvent`` 和 ``sync_process: Thread``
+    在 cross_server 合并到主 event loop 后已删除（不再起独立线程）。生命周期
+    改由 ``sync_task: asyncio.Task`` 管理，shutdown 走 ``task.cancel()``。
     """
-    sync_message_queue: Queue
-    sync_shutdown_event: ThreadEvent
+    sync_message_queue: _SyncMessageQueue
     websocket_lock: asyncio.Lock
     session_id: Optional[str] = None
-    sync_process: Optional[Thread] = None
+    sync_task: Optional[asyncio.Task] = None
     # 用 Any 而非 core.LLMSessionManager：避免 dataclass 运行时求值 annotation
     # 时踩到 forward-ref / 循环引用边界
     session_manager: Optional[Any] = None
@@ -334,73 +353,82 @@ class RoleState:
 role_state: dict[str, RoleState] = {}
 
 
-def _iter_sync_connector_threads():
-    """迭代所有仍然存活的同步连接器线程（按 role_state 为准）。"""
+def _iter_sync_connector_tasks():
+    """迭代所有仍然存活的同步连接器 task（按 role_state 为准）。"""
     for name, rs in role_state.items():
-        thread = rs.sync_process
-        if thread is None:
+        task = rs.sync_task
+        if task is None:
             continue
-        yield name, thread
+        yield name, task
 
 
 def _signal_sync_connectors_shutdown(*, log: bool = True) -> None:
+    """取消所有同步连接器 task。task.cancel() 是同步、幂等、loop 关闭后亦无害的，
+    所以 atexit 二次调用安全。"""
     if log:
-        logger.info("正在关闭同步线程...")
+        logger.info("正在关闭同步连接器 task...")
     for rs in role_state.values():
         try:
-            rs.sync_shutdown_event.set()
+            task = rs.sync_task
+            if task is not None and not task.done():
+                task.cancel()
         except Exception as e:
-            logger.debug(f"设置同步关闭事件失败: {e}", exc_info=True)
+            logger.debug(f"取消同步连接器 task 失败: {e}", exc_info=True)
 
 
-async def join_sync_connector_threads(timeout: float = 3.0) -> list[str]:
-    """并行 join 所有同步连接器线程，返回在 timeout 内仍未退出的线程名。
+async def join_sync_connector_tasks(timeout: float = 3.0) -> list[str]:
+    """并行 await 所有同步连接器 task，返回在 timeout 内未结束的角色名。
 
-    N 个角色串行 join 会把最坏墙钟放大成 N * timeout；gather + to_thread
-    让每个 join 在自己的线程里跑，墙钟收敛到单个 timeout。
+    通常调用前已经 ``_signal_sync_connectors_shutdown`` 取消过；这里只是等
+    各 task 走完 finally cleanup（关闭 ws/session/reader）。
     """
     wait_timeout = max(0.0, float(timeout))
-    targets = list(_iter_sync_connector_threads())
+    targets = list(_iter_sync_connector_tasks())
     if not targets:
         return []
 
-    async def _join_one(name: str, thread) -> str | None:
+    async def _wait_one(name: str, task: asyncio.Task) -> str | None:
         try:
-            await asyncio.to_thread(thread.join, wait_timeout)
-        except Exception as e:
-            logger.debug(f"等待同步连接器线程 {name} 退出时出错: {e}", exc_info=True)
+            await asyncio.wait_for(asyncio.shield(task), timeout=wait_timeout)
+        except asyncio.TimeoutError:
+            return name
+        except asyncio.CancelledError:
+            # task 正常 cancel 走完 finally 后会 raise CancelledError
             return None
-        return name if thread.is_alive() else None
+        except Exception as e:
+            logger.debug(f"同步连接器 task {name} 退出时抛异常: {e}", exc_info=True)
+            return None
+        return None
 
     results = await asyncio.gather(
-        *(_join_one(name, thread) for name, thread in targets),
+        *(_wait_one(name, task) for name, task in targets),
         return_exceptions=False,
     )
-    alive_threads = [name for name in results if name]
+    pending = [name for name in results if name]
 
-    if alive_threads:
+    if pending:
         logger.warning(
-            "以下同步连接器线程未在 %.1fs 内退出: %s",
+            "以下同步连接器 task 未在 %.1fs 内退出: %s",
             wait_timeout,
-            ", ".join(alive_threads),
+            ", ".join(pending),
         )
-    return alive_threads
+    return pending
+
+
+# 兼容别名：旧名 join_sync_connector_threads 在文件内有调用，先保留 alias 减小 diff
+join_sync_connector_threads = join_sync_connector_tasks
 
 
 def cleanup(*, log: bool = True):
-    """通知所有同步线程停止。log=False 用于 atexit 二次触发时抑制重复日志。"""
+    """通知所有同步连接器 task 停止。log=False 用于 atexit 二次触发时抑制重复日志。"""
     _signal_sync_connectors_shutdown(log=log)
 
 
 def _reset_sync_connector_shutdown_events() -> None:
-    for rs in role_state.values():
-        try:
-            thread = rs.sync_process
-            if thread is not None and thread.is_alive():
-                continue
-            rs.sync_shutdown_event.clear()
-        except Exception as exc:
-            logger.debug("重置同步关闭事件失败: %s", exc, exc_info=True)
+    """已是空实现：旧版用 ThreadEvent.clear() 让下次启动可以复用线程槽位；
+    现在 task 模式下没有可重置的状态——已死的 task 会被 ``_init_character_resources``
+    检测后直接 ``asyncio.create_task`` 重启。保留函数名以避免修改众多调用点。"""
+    return
 
 
 # 只在主进程中注册 cleanup 函数，防止子进程退出时执行清理
@@ -706,17 +734,20 @@ async def _refresh_character_globals():
 
 
 def _ensure_character_slots(k: str) -> bool:
-    """为单个 catgirl 预备 per-k 同步资源槽位。返回是否为新建角色（决定后续要不要强制启动线程）。
+    """为单个 catgirl 预备 per-k 同步资源槽位。返回是否为新建角色（决定后续要不要强制启动 task）。
 
     纯内存的原子操作：要么 role_state[k] 已经存在（什么都不做），要么一次性
-    把 queue / shutdown_event / websocket_lock 三件全部填好。避免旧代码里
-    6 张 dict 用两种不同 sentinel（sync_message_queue vs websocket_locks）
-    各自判断 "角色是否已有槽位" 造成的半初始化风险。
+    把 queue / websocket_lock 两件全部填好。避免旧代码里 6 张 dict 用两种不同
+    sentinel（sync_message_queue vs websocket_locks）各自判断 "角色是否已有
+    槽位" 造成的半初始化风险。
+
+    注：``asyncio.Queue`` 在 Python 3.10+ 创建时不需要 running loop；
+    本函数虽然是 sync，但调用链上来自 ``initialize_character_data`` /
+    ``_init_character_resources`` 等 async 上下文，loop 可用。
     """
     if k not in role_state:
         role_state[k] = RoleState(
-            sync_message_queue=Queue(),
-            sync_shutdown_event=ThreadEvent(),
+            sync_message_queue=_SyncMessageQueue(),
             websocket_lock=asyncio.Lock(),
         )
         logger.info(f"为角色 {k} 初始化新资源")
@@ -725,10 +756,10 @@ def _ensure_character_slots(k: str) -> bool:
 
 
 async def _init_character_resources(k: str, is_new_character: bool):
-    """为单个 catgirl 完成 session_manager 更新 + 同步连接器线程检查/重启。
+    """为单个 catgirl 完成 session_manager 更新 + 同步连接器 task 检查/重启。
 
     依赖 module globals: master_name, lanlan_prompt, lanlan_basic_config（调用方负责先刷新）。
-    写入 per-k 槽位: role_state[k].session_manager / sync_process —— 不同 k 之间
+    写入 per-k 槽位: role_state[k].session_manager / sync_task —— 不同 k 之间
     不共享状态，可安全并行。
     """
     rs = role_state[k]  # 调用方必须先 _ensure_character_slots，保证这里可直接索引
@@ -804,89 +835,97 @@ async def _init_character_resources(k: str, is_new_character: bool):
 
             rs.session_manager = new_mgr
 
-    # 检查并启动同步连接器线程
-    # 如果是新角色，或者线程不存在/已停止，需要启动线程
-    need_start_thread = False
+    # 检查并启动同步连接器 task
+    # 如果是新角色，或者 task 不存在/已结束，需要启动
+    need_start_task = False
     if is_new_character:
-        need_start_thread = True
-    elif rs.sync_process is None:
-        need_start_thread = True
-    elif hasattr(rs.sync_process, 'is_alive') and not await asyncio.to_thread(rs.sync_process.is_alive):
-        need_start_thread = True
-        try:
-            await asyncio.to_thread(rs.sync_process.join, timeout=0.1)
-        except Exception:
-            # 注意不要写成 bare except：to_thread 是 cancellation point，
-            # 如果 catch 了 BaseException 会吞掉 asyncio.CancelledError
-            pass
+        need_start_task = True
+    elif rs.sync_task is None or rs.sync_task.done():
+        need_start_task = True
 
-    if need_start_thread:
+    if need_start_task:
         try:
-            if rs.sync_shutdown_event.is_set():
-                rs.sync_shutdown_event.clear()
             _char_name = k
+
             def _make_status_cb(char_name):
                 def _cb(msg):
                     mgr = _get_session_manager(char_name)
                     if not mgr:
                         return
-                    loop = _server_loop
-                    if loop is None or loop.is_closed():
-                        return
                     ws = mgr.websocket
                     if ws and hasattr(ws, 'client_state') and ws.client_state == ws.client_state.CONNECTED:
                         import json as _json
                         data = _json.dumps({"type": "status", "message": msg})
-                        asyncio.run_coroutine_threadsafe(ws.send_text(data), loop)
+                        # cross_server 现在和我们在同一个主 loop 上，回调
+                        # 也是从主 loop 同步调用的——直接 create_task 即可，
+                        # 不再需要 run_coroutine_threadsafe。
+                        try:
+                            asyncio.create_task(ws.send_text(data))
+                        except RuntimeError:
+                            # 极端情况：当前没有 running loop（理论上不会发生
+                            # 在 cross_server 调用路径上，但兜底）。回退到旧
+                            # 跨 loop 路径。
+                            loop = _server_loop
+                            if loop is not None and not loop.is_closed():
+                                asyncio.run_coroutine_threadsafe(ws.send_text(data), loop)
                 return _cb
+
             _status_cb = _make_status_cb(_char_name)
 
-            new_thread = Thread(
-                target=cross_server.sync_connector_process,
-                args=(rs.sync_message_queue, rs.sync_shutdown_event, k, f"ws://127.0.0.1:{MONITOR_SERVER_PORT}", {'bullet': False, 'monitor': True}, _status_cb),
-                daemon=True,
-                name=f"SyncConnector-{k}"
+            new_task = asyncio.create_task(
+                cross_server.run_sync_connector(
+                    rs.sync_message_queue,
+                    k,
+                    f"ws://127.0.0.1:{MONITOR_SERVER_PORT}",
+                    {'bullet': False, 'monitor': True},
+                    _status_cb,
+                ),
+                name=f"SyncConnector-{k}",
             )
-            rs.sync_process = new_thread
-            new_thread.start()
-            logger.info(f"✅ 已为角色 {k} 启动同步连接器线程 ({new_thread.name})")
-            await asyncio.sleep(0.1)  # 线程启动更快，减少等待时间
-            # 与上面 is_alive 检查保持一致，走 to_thread 避免任何潜在阻塞
-            if not await asyncio.to_thread(new_thread.is_alive):
-                logger.error(f"❌ 同步连接器线程 {k} ({new_thread.name}) 启动后立即退出！")
-            else:
-                logger.info(f"✅ 同步连接器线程 {k} ({new_thread.name}) 正在运行")
+            rs.sync_task = new_task
+            logger.info(f"✅ 已为角色 {k} 启动同步连接器 task ({new_task.get_name()})")
         except Exception as e:
-            logger.error(f"❌ 启动角色 {k} 的同步连接器线程失败: {e}", exc_info=True)
+            logger.error(f"❌ 启动角色 {k} 的同步连接器 task 失败: {e}", exc_info=True)
 
 
 async def _stop_character_thread(k: str):
-    """停止单个 catgirl 的同步连接器线程（最多 3s join）。dict 清理留给调用方顺序做。"""
+    """停止单个 catgirl 的同步连接器 task（最多 3s 等待 cleanup）。dict 清理留给调用方顺序做。
+
+    函数名保留 ``_thread`` 后缀以避免修改众多调用点；现在底层是 ``asyncio.Task``。
+    """
     rs = role_state.get(k)
-    if rs is None or rs.sync_process is None:
+    if rs is None or rs.sync_task is None:
         return
+    task = rs.sync_task
     try:
-        logger.info(f"正在停止角色 {k} 的同步连接器线程...")
-        rs.sync_shutdown_event.set()
-        await asyncio.to_thread(rs.sync_process.join, timeout=3)  # 等待线程正常结束
-        if await asyncio.to_thread(rs.sync_process.is_alive):
-            logger.warning(f"⚠️ 同步连接器线程 {k} 未能在超时内停止，将作为daemon线程自动清理")
+        logger.info(f"正在停止角色 {k} 的同步连接器 task...")
+        if not task.done():
+            task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=3.0)
+        except asyncio.TimeoutError:
+            logger.warning(f"⚠️ 同步连接器 task {k} 未能在 3s 内退出，放任其自行结束")
+        except asyncio.CancelledError:
+            # cancel 后 await 抛 CancelledError 是正常路径
+            pass
+        except Exception as e:
+            logger.debug(f"同步连接器 task {k} 退出时异常: {e}", exc_info=True)
         else:
-            logger.info(f"✅ 已停止角色 {k} 的同步连接器线程")
+            logger.info(f"✅ 已停止角色 {k} 的同步连接器 task")
     except Exception as e:
-        logger.warning(f"停止角色 {k} 的同步连接器线程时出错: {e}")
+        logger.warning(f"停止角色 {k} 的同步连接器 task 时出错: {e}")
 
 
 def _cleanup_character_dicts(k: str):
-    """同步清理单个 catgirl 的 per-k 槽位。调用前确保对应线程已停或超时。"""
+    """同步清理单个 catgirl 的 per-k 槽位。调用前确保对应 task 已停或超时。"""
     rs = role_state.get(k)
     if rs is None:
         return
-    # 清理队列（queue.Queue 没有 close/join_thread 方法）
+    # 清理队列（asyncio.Queue 也没有 close/join_thread 方法，drain 即可）
     try:
         while not rs.sync_message_queue.empty():
             rs.sync_message_queue.get_nowait()
-    except QueueEmpty:
+    except asyncio.QueueEmpty:
         # while empty + get_nowait 本身是 racy idiom：另一线程可能先 drain 掉，
         # 导致 get_nowait 抛 Empty。这里 role_state[k] 即将被 del 掉，忽略无害。
         pass

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -2,9 +2,7 @@ import asyncio
 import importlib
 import json
 import os
-import threading
 from pathlib import Path
-from queue import Queue
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -16,20 +14,22 @@ from main_routers.shared_state import init_shared_state
 
 
 def _make_role_state_for_test(session_managers: dict) -> dict:
-    """Seed role_state with pre-existing session_managers (new post-#855 API).
+    """Seed role_state with pre-existing session_managers (post-#855 + cross_server async).
 
     The legacy 6-dict layout (sync_message_queue / sync_shutdown_event /
     session_manager / session_id / sync_process / websocket_locks) was
-    consolidated into RoleState on main. Tests that only care about
-    seeding session_manager construct stub RoleState entries with live
-    Queue / Event / asyncio.Lock so adapters don't crash on attribute access.
+    consolidated into RoleState on main. ``sync_shutdown_event`` /
+    ``sync_process`` were further removed when cross_server moved from
+    daemon thread to a main-loop ``asyncio.Task`` (now ``sync_task``).
+    Tests that only care about seeding session_manager construct stub
+    RoleState entries with live Queue / asyncio.Lock so adapters don't
+    crash on attribute access.
     """
     # Import lazily to avoid circular import at module load time
-    from main_server import RoleState
+    from main_server import RoleState, _SyncMessageQueue
     return {
         name: RoleState(
-            sync_message_queue=Queue(),
-            sync_shutdown_event=threading.Event(),
+            sync_message_queue=_SyncMessageQueue(),
             websocket_lock=asyncio.Lock(),
             session_manager=session_manager,
         )

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -2,9 +2,7 @@ import contextlib
 import json
 import shutil
 import asyncio
-import threading
 from pathlib import Path
-from queue import Queue
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -16,15 +14,16 @@ def _role_state_from_session_managers(session_managers: dict) -> dict:
     """Build a role_state dict seeded with the given session_managers.
 
     Post-#855 consolidation: the old module-level ``session_manager`` dict
-    became ``role_state[name].session_manager``. Tests that want to stub
+    became ``role_state[name].session_manager``. ``sync_shutdown_event`` /
+    ``sync_process`` were later removed when cross_server moved from daemon
+    thread to a main-loop ``asyncio.Task``. Tests that want to stub
     shutdown-time behavior construct RoleState stubs here (with live
-    Queue/Event/Lock so any adapter access does not explode).
+    Queue/Lock so any adapter access does not explode).
     """
-    from main_server import RoleState
+    from main_server import RoleState, _SyncMessageQueue
     return {
         name: RoleState(
-            sync_message_queue=Queue(),
-            sync_shutdown_event=threading.Event(),
+            sync_message_queue=_SyncMessageQueue(),
             websocket_lock=asyncio.Lock(),
             session_manager=session_manager,
         )
@@ -730,22 +729,23 @@ async def test_main_server_cancel_workshop_background_tasks_uses_public_api():
 
 @pytest.mark.unit
 def test_main_server_resets_sync_shutdown_events_after_startup_rollback():
+    """``_reset_sync_connector_shutdown_events`` 现在是 no-op：cross_server 改成
+    主 loop 上的 asyncio.Task 后，没有 ThreadEvent 可以 reset。函数保留是为了
+    避免改动文件内众多调用点，本测试只验证它仍可调用且不会抛异常。
+    """
     import main_server
+    from main_server import _SyncMessageQueue
 
-    event = threading.Event()
-    event.set()
     role_state = {
         "小满": main_server.RoleState(
-            sync_message_queue=Queue(),
-            sync_shutdown_event=event,
+            sync_message_queue=_SyncMessageQueue(),
             websocket_lock=asyncio.Lock(),
         )
     }
 
     with patch.object(main_server, "role_state", role_state):
+        # 不抛异常即视为通过；旧版会清 threading.Event，新版无状态可清
         main_server._reset_sync_connector_shutdown_events()
-
-    assert event.is_set() is False
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -744,8 +744,9 @@ def test_main_server_resets_sync_shutdown_events_after_startup_rollback():
     }
 
     with patch.object(main_server, "role_state", role_state):
-        # 不抛异常即视为通过；旧版会清 threading.Event，新版无状态可清
-        main_server._reset_sync_connector_shutdown_events()
+        # 不抛异常即视为通过；旧版会清 threading.Event，新版无状态可清。
+        # 显式断言返回值为 None，未来若改成有副作用返回时能更早暴露。
+        assert main_server._reset_sync_connector_shutdown_events() is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_cloudsave_router.py
+++ b/tests/unit/test_cloudsave_router.py
@@ -3,9 +3,7 @@ import importlib
 import sys
 import json
 import shutil
-import threading
 from pathlib import Path
-from queue import Queue
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -18,11 +16,10 @@ from main_routers.shared_state import init_shared_state
 
 def _make_role_state_for_test(session_managers: dict) -> dict:
     """See tests/unit/test_character_memory_regression.py for rationale."""
-    from main_server import RoleState
+    from main_server import RoleState, _SyncMessageQueue
     return {
         name: RoleState(
-            sync_message_queue=Queue(),
-            sync_shutdown_event=threading.Event(),
+            sync_message_queue=_SyncMessageQueue(),
             websocket_lock=asyncio.Lock(),
             session_manager=session_manager,
         )


### PR DESCRIPTION
## Summary

把两条把主 event loop 当秒表用的常驻轮询改成事件驱动。目标：减小用户感受到的主 loop jank（无声/空闲段也在 50–100Hz 唤醒、跑 callback、抢 GIL）。

- **TTS response handler**：100Hz 轮询 (`q.get_nowait()` + `asyncio.sleep(0.01)`) → `await asyncio.to_thread(q.get)` 阻塞等。无消息时主 loop 完全沉默。
- **cross_server**：从「每个 catgirl 一条 daemon Thread + 内部独立 event loop + 20ms 双层轮询」拆成「主 loop 上的 asyncio.Task + asyncio.Queue + cancellation」。多 catgirl 场景下从 N×50Hz GIL 抢占点降到事件驱动。

## Motivation

`tts_response_handler` 和 `cross_server.sync_connector_process` 是两类常驻、高频、且无事可做时也在唤醒的循环。前者 100Hz、后者 N×50Hz（N = catgirl 数）。即使每次 callback 只占主 loop 0.5ms，累计起来就是 25ms+/秒的不可用时间，叠加到 LLM 输出 / WebSocket 收发 / TTS 编码上就是肉眼可见的卡顿。

`cross_server.sync_connector_process` 命名残留自 multiprocessing 子进程时代——子进程独占 GIL，20ms 轮询 + multiprocessing.Queue 无 asyncio 接口，那个奢侈的设计在子进程时代是合理的。后来变成线程仍跑独立 loop，N+1 个 loop 跨 GIL 互拍，奢侈品成了 jank 源。

## Changes

### `main_logic/core.py` — TTS handler 阻塞 get
- `tts_response_handler` 改 `await asyncio.to_thread(q.get)`
- cancel 时 push `__handler_exit__` 哨兵唤醒线程池里仍卡在 `q.get()` 的线程，避免线程泄漏（线程持 queue ref，否则 queue 跟着 leak）

### `main_logic/cross_server.py` — 去线程化
- 新 `async def run_sync_connector(...)` 替代 `def sync_connector_process(...)`
- 删 `asyncio.new_event_loop()` 包装、`_shutdown_watcher`、`_run_with_shutdown`
- `while not q.empty(): get_nowait()` + 20ms sleep → `await asyncio.wait_for(message_queue.get(), 10.0)`
- 应用层 heartbeat 节流到 10s 一次（底层 `ws_connect(heartbeat=10)` 本来就在维持 ws ping/pong）
- shutdown 改 `asyncio.CancelledError`；cleanup 进 `finally`
- 删 `aclose_internal_http_client_current_loop`（client 现归主 loop 所有）
- 9 处 `shutdown_event.is_set()` guard 通过 `_NeverShutdown` stub 保留为 no-op，避免本 PR 大面积重排缩进；后续 PR 可清

### `main_server.py` — 边界 API 适配
- `RoleState`：去掉 `sync_shutdown_event` / `sync_process`，加 `sync_task: asyncio.Task`
- 新 `_SyncMessageQueue(asyncio.Queue)`：`put` 同步 alias 到 `put_nowait`，让 core.py / system_router 14+ 处生产端 `q.put(item)` **零改动**兼容
- spawn：`Thread(...).start()` → `asyncio.create_task(run_sync_connector(...))`
- `_status_cb`：`asyncio.run_coroutine_threadsafe` → `asyncio.create_task`（同 loop 了）
- `join_sync_connector_threads` 保留为 alias；内部由 `thread.join` 切 `asyncio.wait_for(asyncio.shield(task))`
- `_reset_sync_connector_shutdown_events` 退化为 no-op

### tests
3 个 fixture 同步更新（`test_cloudsave_router` / `test_cloudsave_lifecycle_flow` / `test_character_memory_regression`）：去掉 `sync_shutdown_event=` kwarg、`sync_message_queue` 改 `_SyncMessageQueue()`。`test_main_server_resets_sync_shutdown_events_after_startup_rollback` 改成验证 no-op 不抛异常。

## Test plan

- [x] `cross_server.py` / `main_server.py` 语法解析通过
- [x] 烟雾测试：`_SyncMessageQueue` 同步 `put` / async `await get` / `wait_for` timeout
- [x] TTS 相关 unit tests 全过：128 passed
- [x] proactive sid guard / proactive sm integration 全过
- [x] cloudsave + character memory regression 76 passed
- [x] 全 unit sweep：1316 passed / 14 skipped（剩 1 个 i18n 失败 pre-existing，已确认与本 PR 无关）
- [ ] 实跑会话验证：`NEKO_DEBUG_ASYNC=1 NEKO_DEBUG_HEARTBEAT=1` 跑一次多 catgirl 会话，对比改前/改后 slow callback warning 数量和心跳缺席分布

## 监测

监测基础设施已存在（[main_server.py:1689](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/main_server.py#L1689) `slow_callback_duration=0.05`、[main_server.py:1696](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/main_server.py#L1696) 200ms 心跳），跑会话即可量化收益。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **重构**
  * 将语音响应与跨服务器连接的消息处理改为基于异步任务与阻塞/等待机制，消除事件循环空转，改进取消释放（避免阻塞等待）与清理流程；引入更温和的重连退避与应用层心跳节流，提升稳定性与资源利用率。
* **测试**
  * 更新单元测试与测试辅助构造以兼容新的异步消息队列与任务模型。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->