### PR TITLE
refactor(tts): 干掉 start_session 里 TTS 就绪信号的 20Hz 轮询

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1962,13 +1962,21 @@ class LLMSessionManager:
                     while time.time() - start_time < timeout:
                         # worker 线程已死亡则无需继续等待
                         if not self.tts_thread.is_alive():
-                            # 尝试取出可能的 ready(False) 信号
-                            try:
-                                msg = self.tts_response_queue.get_nowait()
+                            # 抽干此刻队列：__ready__ 用于决定本次等待结果，
+                            # 其他消息（如承载 NO_RETRY 错误码的 __error__）放回队列，
+                            # 让稍后启动的 tts_response_handler 处理，避免错误码丢失。
+                            _requeue: list = []
+                            while True:
+                                try:
+                                    msg = self.tts_response_queue.get_nowait()
+                                except Empty:
+                                    break
                                 if isinstance(msg, tuple) and len(msg) == 2 and msg[0] == "__ready__":
                                     tts_ready = msg[1]
-                            except Empty:
-                                pass
+                                else:
+                                    _requeue.append(msg)
+                            for _m in _requeue:
+                                self.tts_response_queue.put(_m)
                             if not tts_ready:
                                 logger.error("❌ TTS Worker 线程已退出，无法继续等待")
                             break

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -70,7 +70,7 @@ from utils.api_config_loader import get_free_voices
 from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
 import threading
 from threading import Thread
-from queue import Queue
+from queue import Queue, Empty
 from uuid import uuid4
 import numpy as np
 import soxr
@@ -1960,24 +1960,6 @@ class LLMSessionManager:
                     timeout = 12.0  # 最多等待12秒
                     _last_tts_log = 0.0
                     while time.time() - start_time < timeout:
-                        try:
-                            # 非阻塞检查队列
-                            if not self.tts_response_queue.empty():
-                                msg = self.tts_response_queue.get_nowait()
-                                # 检查是否是就绪信号
-                                if isinstance(msg, tuple) and len(msg) == 2 and msg[0] == "__ready__":
-                                    tts_ready = msg[1]
-                                    if tts_ready:
-                                        logger.info(f"✅ TTS进程已就绪 (用时: {time.time() - start_time:.2f}秒)")
-                                    else:
-                                        logger.error("❌ TTS进程初始化失败")
-                                    break
-                                else:
-                                    # 不是就绪信号，放回队列
-                                    self.tts_response_queue.put(msg)
-                                    break
-                        except: # noqa
-                            pass
                         # worker 线程已死亡则无需继续等待
                         if not self.tts_thread.is_alive():
                             # 尝试取出可能的 ready(False) 信号
@@ -1985,18 +1967,38 @@ class LLMSessionManager:
                                 msg = self.tts_response_queue.get_nowait()
                                 if isinstance(msg, tuple) and len(msg) == 2 and msg[0] == "__ready__":
                                     tts_ready = msg[1]
-                            except: # noqa
+                            except Empty:
                                 pass
                             if not tts_ready:
                                 logger.error("❌ TTS Worker 线程已退出，无法继续等待")
                             break
-                        # 每约2秒输出一次诊断日志，便于定位卡在哪一阶段
-                        _elapsed = time.time() - start_time
-                        if _elapsed - _last_tts_log >= 2.0:
-                            _last_tts_log = _elapsed
-                            logger.info(f"[语音会话诊断] TTS 就绪等待中... 已等待 {_elapsed:.1f}秒 / {timeout}秒")
-                        # 小睡眠避免忙等
-                        await asyncio.sleep(0.05)
+                        remaining = timeout - (time.time() - start_time)
+                        # 单次阻塞窗口封顶 2 秒，保证 worker 死亡探测与诊断日志能及时触发
+                        poll_window = min(remaining, 2.0)
+                        if poll_window <= 0:
+                            break
+                        try:
+                            msg = await asyncio.to_thread(
+                                self.tts_response_queue.get, True, poll_window
+                            )
+                        except Empty:
+                            # 每约2秒输出一次诊断日志，便于定位卡在哪一阶段
+                            _elapsed = time.time() - start_time
+                            if _elapsed - _last_tts_log >= 2.0:
+                                _last_tts_log = _elapsed
+                                logger.info(f"[语音会话诊断] TTS 就绪等待中... 已等待 {_elapsed:.1f}秒 / {timeout}秒")
+                            continue
+                        if isinstance(msg, tuple) and len(msg) == 2 and msg[0] == "__ready__":
+                            tts_ready = msg[1]
+                            if tts_ready:
+                                logger.info(f"✅ TTS进程已就绪 (用时: {time.time() - start_time:.2f}秒)")
+                            else:
+                                logger.error("❌ TTS进程初始化失败")
+                            break
+                        else:
+                            # 不是就绪信号，放回队列后退出（与旧行为一致）
+                            self.tts_response_queue.put(msg)
+                            break
 
                     if not tts_ready:
                         if time.time() - start_time >= timeout:


### PR DESCRIPTION
## Summary
- `start_session` 等待 TTS worker `__ready__` 的循环原本是 `while ... asyncio.sleep(0.05)`（20Hz × 最长 12s），改用 `await asyncio.to_thread(self.tts_response_queue.get, True, poll_window)`，事件驱动等待
- 单次阻塞窗口封顶 2 秒：既保留每 ~2 秒的诊断日志，也保证 worker 死亡时最迟 2s 内被探测到
- 完整保留原语义：12s 超时 → warning + 继续；worker 线程死亡 → 早退 + 最终 `get_nowait` drain；首条非 `__ready__` 消息 → 放回队列后退出
- 顺手把 `except: # noqa` 收紧成 `except Empty`（两处 `get_nowait` 真正只会抛 `Empty`）

## Why
这是 PR #1013 之后 `tts_response_queue` 残留的最后一处轮询消费者。`tts_response_handler` 已经切到 `await asyncio.to_thread(q.get)`；这次把 `start_session` 也对齐，每次启动语音会话能省掉 ~240 次无意义事件循环唤醒。

## Test plan
- [x] `uv run pytest tests/unit/test_proactive_sid_guard.py tests/unit/test_proactive_sm_integration.py tests/unit/test_minimax_tts_worker.py -q` → 39 passed
- [ ] 手动：启动一次语音会话，确认 `✅ TTS进程已就绪` 仍打印且耗时不变
- [ ] 手动：TTS 服务慢时确认 `[语音会话诊断] TTS 就绪等待中... 已等待 N.N秒 / 12.0秒` 仍每 ~2 秒出现一行
- [ ] 手动：mid-startup 杀掉 TTS worker，确认 `❌ TTS Worker 线程已退出，无法继续等待` 仍触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **重构**
  * 优化了文本转语音（TTS）启动就绪等待流程，采用有界轮询与超时机制，提高稳定性与响应性。
* **修复**
  * 防止在启动等待期间丢失或错误消费非就绪消息，保留并重新入队以便后续处理；改进了空队列超时的异常处理与诊断日志触发行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->