### PR TITLE
修复角色卡切换角色后主页面持续低帧，以及角色卡面板收起时预览资源可能残留的问题

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -366,24 +366,29 @@
                 }
 
                 if (window.live2dManager) {
-                    // 1. 清理模型
-                    if (window.live2dManager.currentModel) {
+                    // 1. 使用 Live2DManager 的统一清理入口。
+                    // 只 destroy currentModel 会绕过 removeModel() 中的 ticker 回调、鼠标跟踪、
+                    // idle motion 定时器、浮动按钮 ticker 等清理逻辑；这些残留会在 PIXI ticker
+                    // 每帧继续运行，角色卡切换几次后表现为持续低 FPS。
+                    if (typeof window.live2dManager.removeModel === 'function') {
+                        await window.live2dManager.removeModel({ skipCloseWindows: true });
+                    } else if (window.live2dManager.currentModel) {
+                        // 兼容兜底：旧版本没有 removeModel 时仍尽量销毁模型。
                         if (typeof window.live2dManager.currentModel.destroy === 'function') {
-                            window.live2dManager.currentModel.destroy();
+                            window.live2dManager.currentModel.destroy({ children: true });
                         }
                         window.live2dManager.currentModel = null;
                     }
 
-                    // 2. 停止ticker（但保留 pixi_app，以便后续重启）
+                    // 2. 停止 ticker（但保留 pixi_app，以便 Live2D 分支加载完成后重启）。
+                    // removeModel() 为了让空舞台保持可恢复会重启 ticker；切到非 Live2D 时必须再次停掉。
                     if (window.live2dManager.pixi_app && window.live2dManager.pixi_app.ticker) {
-                        // 只有在切换到非 Live2D 模型时才停止 ticker
-                        // 如果切换到 Live2D，ticker 会在加载新模型后重启
                         if (effectiveModelType !== 'live2d') {
                             window.live2dManager.pixi_app.ticker.stop();
                         }
                     }
 
-                    // 3. 清理舞台（但不销毁pixi_app）
+                    // 3. 清理舞台残留（但不销毁 pixi_app）
                     if (window.live2dManager.pixi_app && window.live2dManager.pixi_app.stage) {
                         window.live2dManager.pixi_app.stage.removeChildren();
                     }

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -4159,13 +4159,20 @@ async function closeCatgirlPanel() {
     if (overlay.dataset.closing === 'true') return;
     overlay.dataset.closing = 'true';
 
+    // 取消所有预览加载：包括尚未完成的 Live2D/VRM/MMD 异步加载，避免清理后又把预览建回来
+    if (typeof cancelWorkshopPreviewLoads === 'function') {
+        cancelWorkshopPreviewLoads();
+    } else if (typeof cancelPendingLive2DPreviewLoads === 'function') {
+        cancelPendingLive2DPreviewLoads();
+    }
+
     // 取消尚未触发的 Steam 标签页延迟初始化，避免在清理后又把预览建回来
     if (overlay._steamTabInitTimer) {
         clearTimeout(overlay._steamTabInitTimer);
         overlay._steamTabInitTimer = null;
     }
 
-    // 清理模型预览资源（如果 Steam 标签页曾加载过）
+    // 清理模型预览资源（如果 Steam 标签页曾加载过）；清理完成后再执行收起动画
     try {
         const cleanupTasks = [];
         if (typeof disposeWorkshopVrm === 'function') cleanupTasks.push(disposeWorkshopVrm());
@@ -6819,6 +6826,30 @@ let _workshopVrmModulesLoaded = false;
 let _workshopMmdModulesLoaded = false;
 let _workshopVrmModulesLoading = false;
 let _workshopMmdModulesLoading = false;
+let _workshopPreviewGeneration = 0;
+
+function cancelWorkshopPreviewLoads() {
+    _workshopPreviewGeneration += 1;
+    cancelPendingLive2DPreviewLoads();
+}
+
+function isWorkshopPreviewLoadCurrent(generation) {
+    return generation === _workshopPreviewGeneration && !!document.querySelector('.catgirl-panel-overlay');
+}
+
+async function disposeStaleWorkshopPreviewManager(manager, type) {
+    if (!manager) return;
+    try {
+        if (type === 'mmd' && typeof manager.stopAnimation === 'function') {
+            manager.stopAnimation();
+        }
+        if (typeof manager.dispose === 'function') {
+            await manager.dispose();
+        }
+    } catch (e) {
+        console.warn(`[Workshop ${String(type || '').toUpperCase()}] 清理过期预览实例失败:`, e);
+    }
+}
 
 // 按需加载 VRM 模块
 async function ensureVrmModulesLoaded() {
@@ -7006,6 +7037,8 @@ function scheduleWorkshop3DPreviewResize(manager, canvasId) {
 
 // 加载 VRM 模型预览
 async function loadVrmPreview(modelPath, rawData) {
+    const previewGeneration = ++_workshopPreviewGeneration;
+    let localVrmManager = null;
     try {
         cancelPendingLive2DPreviewLoads();
         selectedModelInfo = null;
@@ -7014,6 +7047,7 @@ async function loadVrmPreview(modelPath, rawData) {
         // 先清理之前的 3D 预览
         await disposeWorkshopVrm();
         await disposeWorkshopMmd();
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration)) return;
 
         // 清理 Live2D 预览（如果有）
         if (live2dPreviewManager && live2dPreviewManager.currentModel) {
@@ -7037,6 +7071,7 @@ async function loadVrmPreview(modelPath, rawData) {
 
         // 确保 VRM 模块已加载
         const loaded = await ensureVrmModulesLoaded();
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration)) return;
         if (!loaded) {
             console.error('[Workshop VRM] 模块加载失败');
             showMessage(window.t ? window.t('steam.vrmModuleLoadFailed') || 'VRM 模块加载失败' : 'VRM 模块加载失败', 'error');
@@ -7048,13 +7083,18 @@ async function loadVrmPreview(modelPath, rawData) {
         if (vrmContainer) vrmContainer.style.display = 'block';
 
         // 创建 VRM 管理器实例
-        workshopVrmManager = new window.VRMManager();
+        localVrmManager = new window.VRMManager();
+        workshopVrmManager = localVrmManager;
 
         // 获取光照配置
         const lighting = rawData?.['lighting'] || null;
 
         // 初始化 Three.js 场景
-        await workshopVrmManager.initThreeJS('vrm-preview-canvas', 'vrm-preview-container', lighting);
+        await localVrmManager.initThreeJS('vrm-preview-canvas', 'vrm-preview-container', lighting);
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration) || workshopVrmManager !== localVrmManager) {
+            await disposeStaleWorkshopPreviewManager(localVrmManager, 'vrm');
+            return;
+        }
 
         // 修正容器样式：VRMCore.init 会设置 position:fixed 覆盖全屏，
         // 这里覆盖为 absolute 使其嵌入预览区域内
@@ -7070,7 +7110,7 @@ async function loadVrmPreview(modelPath, rawData) {
 
         // 按预览区域实际尺寸同步 renderer / camera / effect，避免 CSS 尺寸和 WebGL 后备尺寸不一致。
         const previewContent = document.getElementById('live2d-preview-content');
-        syncWorkshop3DPreviewSize(workshopVrmManager, 'vrm-preview-canvas');
+        syncWorkshop3DPreviewSize(localVrmManager, 'vrm-preview-canvas');
 
         // 允许 3D 交互：临时启用预览区域的 pointer-events
         if (previewContent) previewContent.style.pointerEvents = 'auto';
@@ -7081,15 +7121,19 @@ async function loadVrmPreview(modelPath, rawData) {
         const idleAnimation = rawData?.['idleAnimation'] || '/static/vrm/animation/wait03.vrma';
 
         // 加载模型
-        const result = await workshopVrmManager.loadModel(modelPath, {
+        const result = await localVrmManager.loadModel(modelPath, {
             canvasId: 'vrm-preview-canvas',
             containerId: 'vrm-preview-container',
             addShadow: true,
             idleAnimation: idleAnimation
         });
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration) || workshopVrmManager !== localVrmManager) {
+            await disposeStaleWorkshopPreviewManager(localVrmManager, 'vrm');
+            return;
+        }
 
         if (result) {
-            scheduleWorkshop3DPreviewResize(workshopVrmManager, 'vrm-preview-canvas');
+            scheduleWorkshop3DPreviewResize(localVrmManager, 'vrm-preview-canvas');
             console.log('[Workshop VRM] 模型预览加载成功');
             showMessage(window.t ? window.t('steam.vrmPreviewLoaded') || 'VRM 模型预览已加载' : 'VRM 模型预览已加载', 'success');
         }
@@ -7101,6 +7145,8 @@ async function loadVrmPreview(modelPath, rawData) {
 
 // 加载 MMD 模型预览
 async function loadMmdPreview(modelPath, rawData) {
+    const previewGeneration = ++_workshopPreviewGeneration;
+    let localMmdManager = null;
     try {
         cancelPendingLive2DPreviewLoads();
         selectedModelInfo = null;
@@ -7109,6 +7155,7 @@ async function loadMmdPreview(modelPath, rawData) {
         // 先清理之前的 3D 预览
         await disposeWorkshopVrm();
         await disposeWorkshopMmd();
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration)) return;
 
         // 清理 Live2D 预览（如果有）
         if (live2dPreviewManager && live2dPreviewManager.currentModel) {
@@ -7132,6 +7179,7 @@ async function loadMmdPreview(modelPath, rawData) {
 
         // 确保 MMD 模块已加载
         const loaded = await ensureMmdModulesLoaded();
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration)) return;
         if (!loaded) {
             console.error('[Workshop MMD] 模块加载失败');
             showMessage(window.t ? window.t('steam.mmdModuleLoadFailed') || 'MMD 模块加载失败' : 'MMD 模块加载失败', 'error');
@@ -7143,10 +7191,15 @@ async function loadMmdPreview(modelPath, rawData) {
         if (mmdContainer) mmdContainer.style.display = 'block';
 
         // 创建 MMD 管理器实例
-        workshopMmdManager = new window.MMDManager();
+        localMmdManager = new window.MMDManager();
+        workshopMmdManager = localMmdManager;
 
         // 初始化
-        await workshopMmdManager.init('mmd-preview-canvas', 'mmd-preview-container');
+        await localMmdManager.init('mmd-preview-canvas', 'mmd-preview-container');
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration) || workshopMmdManager !== localMmdManager) {
+            await disposeStaleWorkshopPreviewManager(localMmdManager, 'mmd');
+            return;
+        }
 
         // 修正容器样式：MMDCore.init 会设置 position:fixed 覆盖全屏，
         // 这里覆盖为 absolute 使其嵌入预览区域内
@@ -7162,7 +7215,7 @@ async function loadMmdPreview(modelPath, rawData) {
 
         // 按预览区域实际尺寸同步 renderer / camera / effect，避免 CSS 尺寸和 WebGL 后备尺寸不一致。
         const previewContent = document.getElementById('live2d-preview-content');
-        syncWorkshop3DPreviewSize(workshopMmdManager, 'mmd-preview-canvas');
+        syncWorkshop3DPreviewSize(localMmdManager, 'mmd-preview-canvas');
 
         // 允许 3D 交互：临时启用预览区域的 pointer-events
         if (previewContent) previewContent.style.pointerEvents = 'auto';
@@ -7170,16 +7223,24 @@ async function loadMmdPreview(modelPath, rawData) {
         if (overlay) overlay.style.display = 'none';
 
         // 加载模型
-        const modelInfo = await workshopMmdManager.loadModel(modelPath);
+        const modelInfo = await localMmdManager.loadModel(modelPath);
+        if (!isWorkshopPreviewLoadCurrent(previewGeneration) || workshopMmdManager !== localMmdManager) {
+            await disposeStaleWorkshopPreviewManager(localMmdManager, 'mmd');
+            return;
+        }
 
         if (modelInfo) {
-            scheduleWorkshop3DPreviewResize(workshopMmdManager, 'mmd-preview-canvas');
+            scheduleWorkshop3DPreviewResize(localMmdManager, 'mmd-preview-canvas');
             // 如果有 idle 动画，尝试加载
             const idleAnimation = rawData?.['mmd_idle_animation'] || '';
-            if (idleAnimation && typeof workshopMmdManager.loadAnimation === 'function') {
+            if (idleAnimation && typeof localMmdManager.loadAnimation === 'function') {
                 try {
-                    await workshopMmdManager.loadAnimation(idleAnimation);
-                    workshopMmdManager.playAnimation();
+                    await localMmdManager.loadAnimation(idleAnimation);
+                    if (!isWorkshopPreviewLoadCurrent(previewGeneration) || workshopMmdManager !== localMmdManager) {
+                        await disposeStaleWorkshopPreviewManager(localMmdManager, 'mmd');
+                        return;
+                    }
+                    localMmdManager.playAnimation();
                 } catch (e) {
                     console.warn('[Workshop MMD] idle 动画加载失败:', e);
                 }
@@ -7195,6 +7256,7 @@ async function loadMmdPreview(modelPath, rawData) {
 
 // 清除所有模型预览（Live2D + VRM + MMD）
 async function clearAllModelPreviews(showModelNotSetMessage = false) {
+    cancelWorkshopPreviewLoads();
     selectedModelInfo = null;
     setLive2DPreviewRefreshButtonState(false, false);
     await disposeWorkshopVrm();

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -6848,6 +6848,13 @@ async function disposeStaleWorkshopPreviewManager(manager, type) {
         }
     } catch (e) {
         console.warn(`[Workshop ${String(type || '').toUpperCase()}] 清理过期预览实例失败:`, e);
+    } finally {
+        if (type === 'vrm' && workshopVrmManager === manager) {
+            workshopVrmManager = null;
+        }
+        if (type === 'mmd' && workshopMmdManager === manager) {
+            workshopMmdManager = null;
+        }
     }
 }
 
@@ -7139,6 +7146,8 @@ async function loadVrmPreview(modelPath, rawData) {
         }
     } catch (error) {
         console.error('[Workshop VRM] 加载预览失败:', error);
+        await disposeStaleWorkshopPreviewManager(localVrmManager, 'vrm');
+        currentPreviewModel = null;
         showMessage(window.t ? window.t('steam.vrmPreviewFailed') || 'VRM 模型预览加载失败' : 'VRM 模型预览加载失败', 'error');
     }
 }
@@ -7250,6 +7259,8 @@ async function loadMmdPreview(modelPath, rawData) {
         }
     } catch (error) {
         console.error('[Workshop MMD] 加载预览失败:', error);
+        await disposeStaleWorkshopPreviewManager(localMmdManager, 'mmd');
+        currentPreviewModel = null;
         showMessage(window.t ? window.t('steam.mmdPreviewFailed') || 'MMD 模型预览加载失败' : 'MMD 模型预览加载失败', 'error');
     }
 }


### PR DESCRIPTION
主页面切换角色时改用 Live2D 统一清理入口，完整释放 ticker 回调、鼠标跟踪、定时器和旧模型资源；角色卡面板关闭时先取消未完成的 Live2D/VRM/MMD 异步预览加载并清理现有预览实例，再执行收起动画，避免旧预览任务复活或残留渲染循环

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 Live2D 资源清理与舞台/ticker 处理 — 更可靠释放旧模型并保持舞台可恢复，避免清理时中断渲染环境。
  * 提升三维预览加载稳定性 — 引入加载代数校验与过期处理，主动终止已过期的预览加载与动画，防止已关闭或已更换的预览被重新创建。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->