### PR TITLE
feat(activity): 信任 + 控制 + 风格 follow-up（隐私 + override + 配置外置 + tone + 游戏二维度）

### DIFF
--- a/config/activity_keywords.py
+++ b/config/activity_keywords.py
@@ -474,7 +474,9 @@ GAME_TITLE_KEYWORDS: list = [
     ('Rocket League', ['Rocket League', '火箭联盟', '火箭聯盟', 'ロケットリーグ', '로켓 리그'], 'competitive', 'sports'),
     ('Fall Guys', ['Fall Guys', '糖豆人', '糖豆人', 'フォールガイズ', '폴 가이즈'], 'casual', 'party'),
     ('Among Us', ['Among Us', '我们之中', '在我们之中', 'アモングアス'], 'casual', 'party'),
-    ('Genshin', ['Genshin'], 'casual', 'rpg'),  # safety alias
+    # 'Genshin' alone was a leftover safety-alias entry — already covered
+    # by the 'Genshin Impact' canonical above; first-match wins, so this
+    # tuple was unreachable. Removed.
     ('Roblox', ['Roblox', '罗布乐思', '邏輯思維 Roblox', 'ロブロックス', '로블록스'], 'varied', 'party'),
     ('Minecraft', ['Minecraft', '我的世界', 'マインクラフト', '마인크래프트'], 'varied', 'sim'),
     ('Terraria', ['Terraria', '泰拉瑞亚', '泰拉瑞亞', 'テラリア', '테라리아'], 'casual', 'sim'),
@@ -557,7 +559,9 @@ GAME_TITLE_KEYWORDS: list = [
     ('EA Sports FC', ['EA Sports FC', 'FIFA', 'EA SPORTS FC 25', 'FC 25', 'EA SPORTS FC 24'], 'competitive', 'sports'),
     # Family-name canonical so per-year overrides remain addressable
     ('NBA 2K', ['NBA 2K25', 'NBA 2K24', 'NBA 2K23', 'NBA 2K'], 'competitive', 'sports'),
-    ('Rocket League', ['Rocket League'], 'competitive', 'sports'),
+    # Rocket League was duplicated here (same alias as the entry above
+    # in the Western multiplayer section); first-match wins so this was
+    # unreachable. Removed.
 
     # ============================================================
     # MOBA / shooter / extras

--- a/config/activity_keywords.py
+++ b/config/activity_keywords.py
@@ -101,12 +101,21 @@ ActivityCategory = Literal[
                    # records, etc.) never leaves the process.
     'own_app',     # The N.E.K.O / catgirl app itself in foreground.
                    # Tracker treats as "no new window data this tick" —
-                   # window observation is NOT updated, GPU fallback is
-                   # suppressed, dwell timer keeps running on whatever
-                   # the user was doing before opening the catgirl. Avoids
-                   # the recursive feedback where "user is looking at the
-                   # catgirl app" feeds back into the catgirl's chat
-                   # decisions.
+                   # window observation is NOT updated and the previous
+                   # window's dwell timer is FROZEN: state machine
+                   # records ``_own_app_freeze_started_at`` on entry and,
+                   # on the next non-own_app observation, advances
+                   # ``_current_window_started_at`` by the freeze
+                   # duration so dwell only counts non-own-app time.
+                   # GPU fallback gaming is intentionally NOT
+                   # short-circuited during own_app foreground —
+                   # catgirl Live2D/VRM rendering typically lands below
+                   # the gaming threshold, and a high-GPU app the user
+                   # was already running in the background continues to
+                   # be the user's "real activity" worth classifying.
+                   # Avoids the recursive feedback where "user is
+                   # looking at the catgirl app" feeds back into the
+                   # catgirl's chat decisions.
 ]
 
 
@@ -228,9 +237,16 @@ PRIVATE_PROCESS_NAMES: list[str] = [
 # === OWN-APP EXCLUSION (second-highest priority, after private) ===
 #
 # The N.E.K.O / catgirl app itself. When in foreground, the tracker
-# treats this as "no fresh window data" — observation is NOT updated,
-# GPU fallback is suppressed (the app's own GPU usage during model
-# rendering would otherwise look like gaming), dwell timer freezes.
+# treats this as "no fresh window data" — observation is NOT updated
+# and the previous window's dwell timer is FROZEN: state machine
+# records ``_own_app_freeze_started_at`` on entry and on the next
+# non-own_app observation advances ``_current_window_started_at`` by
+# the freeze duration, so a brief glance at the catgirl can't push the
+# previously-foreground app past dwell thresholds (e.g. focused_work's
+# 90s). GPU fallback gaming is intentionally NOT short-circuited
+# during own_app foreground (catgirl Live2D/VRM typically lands below
+# the threshold; a high-GPU app the user was running in the
+# background remains their "real activity" worth classifying).
 # Avoids the recursive feedback where "user is looking at the catgirl"
 # becomes a signal the catgirl uses to decide whether to chat.
 #
@@ -358,7 +374,10 @@ GAME_TITLE_KEYWORDS: list = [
     ('Counter-Strike 2', ['Counter-Strike 2', 'CS2', 'Counter Strike', '反恐精英2', 'カウンターストライク 2', '카운터 스트라이크 2'], 'competitive', 'fps'),
     ('Dota 2', ['Dota 2', 'DOTA2', 'DOTA', '刀塔2', 'ドータ2'], 'competitive', 'moba'),
     ('PUBG: Battlegrounds', ['PUBG', 'PlayerUnknown', '绝地求生', '絕地求生', 'PUBG: バトルグラウンズ', '배틀그라운드'], 'competitive', 'fps'),
-    ('Apex Legends', ['Apex Legends', 'Apex', '英雄', 'エーペックスレジェンズ', '에이펙스 레전드'], 'competitive', 'fps'),
+    # `英雄` was originally an alias here but was too generic — pure-CJK
+    # substring match would hit any title containing the two characters
+    # (e.g. "魔兽世界·英雄之路", news articles, blog posts). Removed.
+    ('Apex Legends', ['Apex Legends', 'Apex', 'エーペックスレジェンズ', '에이펙스 레전드'], 'competitive', 'fps'),
     ('Fortnite', ['Fortnite', '堡垒之夜', '堡壘之夜', 'フォートナイト', '포트나이트'], 'competitive', 'fps'),
     ('Grand Theft Auto V', ['Grand Theft Auto V', 'GTA V', 'GTA5', 'GTAV', '侠盗猎车手V', '俠盜獵車手V', 'グランド・セフト・オート V'], 'varied', 'action'),
     ('Red Dead Redemption 2', ['Red Dead Redemption 2', 'RDR2', '荒野大镖客2', '碧血狂殺2', 'レッド・デッド・リデンプション2', '레드 데드 리뎀션 2'], 'immersive', 'rpg'),
@@ -468,7 +487,10 @@ GAME_TITLE_KEYWORDS: list = [
     ('Don’t Starve Together', ['Don’t Starve', "Don't Starve Together", '饥荒', '飢荒', 'ドント・スターブ'], 'casual', 'sim'),
     ('Phasmophobia', ['Phasmophobia', '恐鬼症'], 'immersive', 'horror'),
     ('Lethal Company', ['Lethal Company', '致命公司'], 'casual', 'horror'),
-    ('REPO', ['R.E.P.O.', 'R.E.P.O', 'REPO'], 'casual', 'horror'),
+    # Bare `REPO` removed — _make_needle word-boundary match would hit
+    # common dev-tool titles like "repo - Visual Studio Code" before the
+    # WORK_TITLE_KEYWORDS table could classify them. Dotted forms only.
+    ('REPO', ['R.E.P.O.', 'R.E.P.O'], 'casual', 'horror'),
     ('Content Warning', ['Content Warning'], 'casual', 'horror'),
     ('Pals', ['Palworld', '幻兽帕鲁', '幻獸帕魯', 'パルワールド', '팰월드'], 'casual', 'action'),
     ('Manor Lords', ['Manor Lords', '庄园领主', '莊園領主']),
@@ -2798,8 +2820,12 @@ def _build_title_table() -> list[tuple[Needle, ClassifyResult]]:
 
     Privacy and own-app come first by design — privacy must short-circuit
     all classification (the tracker bypasses caching downstream), and
-    own-app must short-circuit gaming-by-GPU (catgirl rendering its own
-    Live2D/VRM looks like gaming load otherwise).
+    own-app must surface as a distinct category so the state machine
+    can apply its dwell-freeze book-keeping (record entry time, advance
+    ``_current_window_started_at`` on exit so own-app time doesn't
+    inflate the previous window's dwell). GPU fallback gaming is NOT
+    short-circuited during own-app foreground: the user's real activity
+    (whatever was running in the background) keeps its classification.
     """
     table: list[tuple[Needle, ClassifyResult]] = []
 

--- a/config/activity_keywords.py
+++ b/config/activity_keywords.py
@@ -81,6 +81,8 @@ __all__ = [
     'ENTERTAINMENT_DOMAIN_KEYWORDS',
     'COMMUNICATION_TITLE_KEYWORDS', 'COMMUNICATION_PROCESS_NAMES',
     'COMMUNICATION_DOMAIN_KEYWORDS',
+    'PRIVATE_TITLE_KEYWORDS', 'PRIVATE_PROCESS_NAMES',
+    'OWN_APP_TITLE_KEYWORDS', 'OWN_APP_PROCESS_NAMES',
     # Classifier
     'ActivityCategory', 'ClassifyResult',
     'classify_window_title', 'classify_process_name', 'classify_browser_title',
@@ -92,6 +94,19 @@ __all__ = [
 
 ActivityCategory = Literal[
     'gaming', 'work', 'entertainment', 'communication', 'unknown',
+    'private',     # Highest priority — sensitive app foreground.
+                   # State machine maps to state='private', propensity='closed',
+                   # tracker bypasses LLM enrichment + buffers entirely so
+                   # the user's secret (password manager, banking, health
+                   # records, etc.) never leaves the process.
+    'own_app',     # The N.E.K.O / catgirl app itself in foreground.
+                   # Tracker treats as "no new window data this tick" —
+                   # window observation is NOT updated, GPU fallback is
+                   # suppressed, dwell timer keeps running on whatever
+                   # the user was doing before opening the catgirl. Avoids
+                   # the recursive feedback where "user is looking at the
+                   # catgirl app" feeds back into the catgirl's chat
+                   # decisions.
 ]
 
 
@@ -103,10 +118,20 @@ class ClassifyResult:
     subcategory and canonical are the specifics, kept for downstream UX
     (e.g. logging "user is in VS Code" vs. "user is in some IDE").
     ``unknown`` results have both detail fields set to ``None``.
+
+    ``intensity`` and ``genre`` are populated only for ``category='gaming'``
+    with ``subcategory='game'`` (actual games, not launchers). They drive
+    propensity / skip_probability / tone derivation in the state machine.
+    Both stay ``None`` for non-gaming results and for games not yet
+    tagged in the keyword DB (state machine treats unspecified as
+    ``intensity='varied'`` / ``genre='misc'`` — conservative fallback,
+    same behaviour as PR #1015 single-bucket gaming).
     """
     category: ActivityCategory
     subcategory: str | None
     canonical: str | None
+    intensity: str | None = None    # 'competitive' | 'casual' | 'immersive' | 'varied' | None
+    genre: str | None = None        # 'fps' | 'moba' | 'rpg' | 'sim' | 'horror' | ... | None
 
 
 _UNKNOWN = ClassifyResult('unknown', None, None)
@@ -142,61 +167,176 @@ BROWSER_PROCESS_NAMES: tuple[str, ...] = (
 # ====================================================================
 
 
+# === PRIVACY BLACKLIST (highest classification priority) ===
+#
+# When any of these match the active window title or process name, the
+# state machine emits state='private' with propensity='closed'. The
+# tracker additionally bypasses LLM enrichment and skips appending the
+# observation to conversation buffers — sensitive app text never leaves
+# the process. Privacy match short-circuits ALL other classification
+# rules (including own-app exclusion below), since these apps are by
+# definition more sensitive than any other category.
+#
+# Editorial rule: only list apps whose *primary purpose* is handling
+# user secrets (passwords, financial data, health records). Apps that
+# *might* show secrets in some flows (Slack with a payroll thread,
+# email with a 2FA code) are NOT private — that's the user's
+# responsibility to gate. We catch the unambiguous cases.
+#
+# Sources: vendor download pages + Wikipedia (cross-referenced for
+# verified executable names). NSFW / dating / chat-secret apps are
+# deliberately not in this list — that's a separate category the user
+# would handle via ``user_app_overrides`` if desired.
+PRIVATE_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
+    # Password managers
+    ('KeePass',     ['KeePass', 'KeePassXC', 'KeePassDX']),
+    ('1Password',   ['1Password']),
+    ('Bitwarden',   ['Bitwarden']),
+    ('LastPass',    ['LastPass']),
+    ('Dashlane',    ['Dashlane']),
+    ('Enpass',      ['Enpass']),
+    ('NordPass',    ['NordPass']),
+    ('RoboForm',    ['RoboForm']),
+    ('Proton Pass', ['Proton Pass', 'ProtonPass']),
+    # Authenticator apps (rare on desktop but exist)
+    ('Authy',       ['Authy Desktop', 'Authy']),
+    # Banking apps + crypto wallets (canonical names; broad match)
+    ('Ledger Live', ['Ledger Live']),
+    ('Trezor Suite',['Trezor Suite']),
+    ('Exodus',      ['Exodus Wallet']),
+    # Self-hosted secret stores
+    ('Vaultwarden', ['Vaultwarden']),
+]
+
+PRIVATE_PROCESS_NAMES: list[str] = [
+    'KeePass.exe',
+    'KeePassXC.exe',
+    '1Password.exe',
+    'Bitwarden.exe',
+    'LastPass.exe',
+    'Dashlane.exe',
+    'Enpass.exe',
+    'NordPass.exe',
+    'RoboForm.exe',
+    'authy.exe',
+    'ledger live.exe',
+    'Trezor Suite.exe',
+    'Exodus.exe',
+]
+
+
+# === OWN-APP EXCLUSION (second-highest priority, after private) ===
+#
+# The N.E.K.O / catgirl app itself. When in foreground, the tracker
+# treats this as "no fresh window data" — observation is NOT updated,
+# GPU fallback is suppressed (the app's own GPU usage during model
+# rendering would otherwise look like gaming), dwell timer freezes.
+# Avoids the recursive feedback where "user is looking at the catgirl"
+# becomes a signal the catgirl uses to decide whether to chat.
+#
+# Process names from ``specs/launcher.spec`` (PyInstaller output for
+# the Windows desktop build) and known sibling executables shipped
+# alongside it.
+OWN_APP_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
+    ('N.E.K.O', ['N.E.K.O', 'NEKO', 'Project N.E.K.O', 'Project NEKO']),
+    ('Xiao8',   ['Xiao8', '小八']),
+    # The launcher window briefly surfaces "projectneko_server" as its
+    # console title before settling on the main UI; catch that too.
+    ('projectneko_server', ['projectneko_server']),
+    ('lanlan_frd', ['lanlan_frd']),
+]
+
+OWN_APP_PROCESS_NAMES: list[str] = [
+    'projectneko_server.exe',
+    'Xiao8.exe',
+    'lanlan_frd.exe',
+    # Source-install run paths — when devs run via uv / python directly
+    # the foreground process is python itself, but the title would be
+    # one of the matches above. We don't blacklist python.exe broadly
+    # (that would silence Jupyter, scripts, etc.) — title-only catches
+    # this case.
+]
+
+
 # === GAMES (294 titles / 218 process names / 41 launcher processes) ===
 
-# (canonical_name, [aliases including all known localized titles])
+# Game title keywords. Two shapes coexist as the intensity/genre retag
+# proceeds incrementally:
+#
+#   (canonical_name, [aliases])
+#   (canonical_name, [aliases], intensity, genre)
+#
+# Where ``intensity`` is one of 'competitive' / 'casual' / 'immersive' /
+# 'varied' (or None to fall through to state-machine ``varied`` default),
+# and ``genre`` is one of 'fps' / 'moba' / 'rpg' / 'sim' / 'horror' /
+# 'racing' / 'rhythm' / 'strategy' / 'sports' / 'party' / 'action' /
+# 'misc' (or None for ``misc`` default).
+#
+# Tagged games drive propensity / skip_probability / tone derivation:
+#
+#   competitive            → propensity=restricted_screen_only, skip 0.3,
+#                            tone=terse  (LoL team fight, CS round, etc.)
+#   immersive horror       → propensity=restricted_screen_only, skip 0.3,
+#                            tone=hushed (silent hill, RE2, etc.)
+#   immersive (other)      → propensity=restricted_screen_only, skip 0.0,
+#                            tone=mellow (RPG, story-driven)
+#   casual                 → propensity=open, skip 0.0, tone=playful
+#                            (animal crossing, stardew, idle/clicker)
+#   varied / untagged      → propensity=restricted_screen_only, skip 0.0,
+#                            tone=concise (PR #1015 single-bucket behavior)
+#
 # Aliases match against window-title substrings, case-insensitive.
-GAME_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
+GAME_TITLE_KEYWORDS: list = [
     # ============================================================
     # Hoyoverse / miHoYo
     # ============================================================
-    ('Genshin Impact', ['Genshin Impact', 'Genshin', '原神', '원신']),
-    ('Honkai: Star Rail', ['Honkai: Star Rail', 'Honkai Star Rail', 'Star Rail', '崩坏：星穹铁道', '崩壞：星穹鐵道', '崩壊：スターレイル', '붕괴: 스타레일']),
-    ('Honkai Impact 3rd', ['Honkai Impact 3rd', 'Honkai Impact', '崩坏3', '崩壊3rd', '붕괴3rd']),
-    ('Zenless Zone Zero', ['Zenless Zone Zero', 'ZenlessZoneZero', 'ZZZ', '绝区零', '絕區零', 'ゼンレスゾーンゼロ', '젠레스 존 제로']),
+    ('Genshin Impact', ['Genshin Impact', 'Genshin', '原神', '원신'], 'casual', 'rpg'),
+    ('Honkai: Star Rail', ['Honkai: Star Rail', 'Honkai Star Rail', 'Star Rail', '崩坏：星穹铁道', '崩壞：星穹鐵道', '崩壊：スターレイル', '붕괴: 스타레일'], 'casual', 'rpg'),
+    ('Honkai Impact 3rd', ['Honkai Impact 3rd', 'Honkai Impact', '崩坏3', '崩壊3rd', '붕괴3rd'], 'casual', 'action'),
+    ('Zenless Zone Zero', ['Zenless Zone Zero', 'ZenlessZoneZero', 'ZZZ', '绝区零', '絕區零', 'ゼンレスゾーンゼロ', '젠레스 존 제로'], 'casual', 'action'),
     ('Tears of Themis', ['Tears of Themis', '未定事件簿', '未定事件簿', '未定事件簿', '테르멘티스의 눈물']),
 
     # ============================================================
     # Tencent
     # ============================================================
-    ('Honor of Kings', ['Honor of Kings', '王者荣耀', '王者榮耀', 'オナー オブ キングス']),
-    ('Game for Peace / PUBG Mobile', ['Game for Peace', '和平精英', 'PUBG MOBILE', 'PUBGM']),
+    ('Honor of Kings', ['Honor of Kings', '王者荣耀', '王者榮耀', 'オナー オブ キングス'], 'competitive', 'moba'),
+    ('Game for Peace / PUBG Mobile', ['Game for Peace', '和平精英', 'PUBG MOBILE', 'PUBGM'], 'competitive', 'fps'),
     ('Dungeon & Fighter', ['Dungeon & Fighter', 'DNF', '地下城与勇士', '地下城與勇士', 'ダンジョン&ファイター', '던전앤파이터']),
     ('CrossFire', ['CrossFire', '穿越火线', '穿越火線', 'クロスファイア', '크로스파이어']),
-    ('League of Legends: Wild Rift', ['Wild Rift', 'LOL: Wild Rift', '英雄联盟手游', '英雄聯盟：激鬥峽谷', 'ワイルドリフト']),
-    ('Naraka: Bladepoint', ['Naraka: Bladepoint', 'Naraka', '永劫无间', '永劫無間', 'ナラカ: ブレードポイント', '나라카: 블레이드포인트']),
-    ('League of Legends', ['League of Legends', 'LoL', '英雄联盟', '英雄聯盟', 'リーグ・オブ・レジェンド', '리그 오브 레전드']),
-    ('Valorant', ['VALORANT', 'Valorant', '无畏契约', '特戰英豪', 'ヴァロラント', '발로란트']),
-    ('Teamfight Tactics', ['Teamfight Tactics', 'TFT', '云顶之弈', '聯盟戰棋', 'チームファイトタクティクス', '전략적 팀 전투']),
-    ('CrossFire HD', ['CrossFire HD', '穿越火线HD']),
-    ('QQ Speed', ['QQ Speed', 'QQ飞车', 'QQ飛車']),
-    ('Delta Force', ['Delta Force', '三角洲行动', '三角洲行動', 'デルタフォース']),
-    ('Arena Breakout', ['Arena Breakout', '暗区突围', '暗區突圍']),
+    ('League of Legends: Wild Rift', ['Wild Rift', 'LOL: Wild Rift', '英雄联盟手游', '英雄聯盟：激鬥峽谷', 'ワイルドリフト'], 'competitive', 'moba'),
+    ('Naraka: Bladepoint', ['Naraka: Bladepoint', 'Naraka', '永劫无间', '永劫無間', 'ナラカ: ブレードポイント', '나라카: 블레이드포인트'], 'competitive', 'action'),
+    ('League of Legends', ['League of Legends', 'LoL', '英雄联盟', '英雄聯盟', 'リーグ・オブ・レジェンド', '리그 오브 레전드'], 'competitive', 'moba'),
+    ('Valorant', ['VALORANT', 'Valorant', '无畏契约', '特戰英豪', 'ヴァロラント', '발로란트'], 'competitive', 'fps'),
+    ('Teamfight Tactics', ['Teamfight Tactics', 'TFT', '云顶之弈', '聯盟戰棋', 'チームファイトタクティクス', '전략적 팀 전투'], 'competitive', 'strategy'),
+    ('CrossFire HD', ['CrossFire HD', '穿越火线HD'], 'competitive', 'fps'),
+    ('QQ Speed', ['QQ Speed', 'QQ飞车', 'QQ飛車'], 'casual', 'racing'),
+    ('Delta Force', ['Delta Force', '三角洲行动', '三角洲行動', 'デルタフォース'], 'competitive', 'fps'),
+    ('Arena Breakout', ['Arena Breakout', '暗区突围', '暗區突圍'], 'competitive', 'fps'),
 
     # ============================================================
     # NetEase
     # ============================================================
-    ('Identity V', ['Identity V', '第五人格', 'IdentityV', 'アイデンティティV', '제5인격']),
-    ('Onmyoji', ['Onmyoji', '阴阳师', '陰陽師', '음양사']),
-    ('Justice Online', ['Justice Online', '逆水寒', 'Justice Mobile']),
-    ('Eggy Party', ['Eggy Party', '蛋仔派对', '蛋仔派對']),
-    ('Marvel Rivals', ['Marvel Rivals', '漫威争锋', '漫威爭鋒', 'マーベル ライバルズ', '마블 라이벌즈']),
-    ('Once Human', ['Once Human', '七日世界', '七日世界']),
-    ('Where Winds Meet', ['Where Winds Meet', '燕云十六声']),
+    ('Identity V', ['Identity V', '第五人格', 'IdentityV', 'アイデンティティV', '제5인격'], 'competitive', 'horror'),
+    ('Onmyoji', ['Onmyoji', '阴阳师', '陰陽師', '음양사'], 'casual', 'rpg'),
+    ('Justice Online', ['Justice Online', '逆水寒', 'Justice Mobile'], 'casual', 'rpg'),
+    ('Eggy Party', ['Eggy Party', '蛋仔派对', '蛋仔派對'], 'casual', 'party'),
+    ('Marvel Rivals', ['Marvel Rivals', '漫威争锋', '漫威爭鋒', 'マーベル ライバルズ', '마블 라이벌즈'], 'competitive', 'fps'),
+    ('Once Human', ['Once Human', '七日世界', '七日世界'], 'casual', 'action'),
+    ('Where Winds Meet', ['Where Winds Meet', '燕云十六声'], 'casual', 'rpg'),
 
     # ============================================================
     # miHoYo / Kuro / Bilibili / others (CN gacha & MMO)
     # ============================================================
-    ('Wuthering Waves', ['Wuthering Waves', '鸣潮', '鳴潮', 'ワザリングウェーブ', '명조']),
-    ('Punishing: Gray Raven', ['Punishing: Gray Raven', 'PGR', '战双帕弥什', '戰雙帕彌什', 'パニシング:グレイレイヴン', '퍼니싱: 그레이 레이븐']),
-    ('Path to Nowhere', ['Path to Nowhere', '无期迷途', '無期迷途']),
-    ('Arknights', ['Arknights', '明日方舟', 'アークナイツ', '명일방주']),
-    ('Azur Lane', ['Azur Lane', '碧蓝航线', '碧藍航線', 'アズールレーン', '벽람항로']),
-    ('Girls Frontline 2', ['Girls Frontline 2', 'Girls’ Frontline 2', '少女前线2', '少女前線2', 'ドールズフロントライン2']),
-    ('Reverse: 1999', ['Reverse: 1999', '重返未来：1999', '重返未來：1999', 'リバース：1999']),
-    ('Snowbreak: Containment Zone', ['Snowbreak', '尘白禁区', '塵白禁區']),
-    ('Infinity Nikki', ['Infinity Nikki', '无限暖暖', '無限暖暖', 'インフィニティニキ']),
-    ('Love and Deepspace', ['Love and Deepspace', '恋与深空', '戀與深空']),
+    ('Wuthering Waves', ['Wuthering Waves', '鸣潮', '鳴潮', 'ワザリングウェーブ', '명조'], 'casual', 'rpg'),
+    ('Punishing: Gray Raven', ['Punishing: Gray Raven', 'PGR', '战双帕弥什', '戰雙帕彌什', 'パニシング:グレイレイヴン', '퍼니싱: 그레이 레이븐'], 'casual', 'action'),
+    ('Path to Nowhere', ['Path to Nowhere', '无期迷途', '無期迷途'], 'casual', 'strategy'),
+    ('Arknights', ['Arknights', '明日方舟', 'アークナイツ', '명일방주'], 'casual', 'strategy'),
+    ('Azur Lane', ['Azur Lane', '碧蓝航线', '碧藍航線', 'アズールレーン', '벽람항로'], 'casual', 'sim'),
+    ('Girls Frontline 2', ['Girls Frontline 2', 'Girls’ Frontline 2', '少女前线2', '少女前線2', 'ドールズフロントライン2'], 'casual', 'rpg'),
+    ('Reverse: 1999', ['Reverse: 1999', '重返未来：1999', '重返未來：1999', 'リバース：1999'], 'casual', 'rpg'),
+    ('Snowbreak: Containment Zone', ['Snowbreak', '尘白禁区', '塵白禁區'], 'casual', 'fps'),
+    ('Infinity Nikki', ['Infinity Nikki', '无限暖暖', '無限暖暖', 'インフィニティニキ'], 'casual', 'sim'),
+    ('Love and Deepspace', ['Love and Deepspace', '恋与深空', '戀與深空'], 'casual', 'rpg'),
 
     # ============================================================
     # Xishanju / 西山居
@@ -207,59 +347,59 @@ GAME_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
     # ============================================================
     # Steam Top 100 - Western AAA / multiplayer
     # ============================================================
-    ('Counter-Strike 2', ['Counter-Strike 2', 'CS2', 'Counter Strike', '反恐精英2', 'カウンターストライク 2', '카운터 스트라이크 2']),
-    ('Dota 2', ['Dota 2', 'DOTA2', 'DOTA', '刀塔2', 'ドータ2']),
-    ('PUBG: Battlegrounds', ['PUBG', 'PlayerUnknown', '绝地求生', '絕地求生', 'PUBG: バトルグラウンズ', '배틀그라운드']),
-    ('Apex Legends', ['Apex Legends', 'Apex', '英雄', 'エーペックスレジェンズ', '에이펙스 레전드']),
-    ('Fortnite', ['Fortnite', '堡垒之夜', '堡壘之夜', 'フォートナイト', '포트나이트']),
-    ('Grand Theft Auto V', ['Grand Theft Auto V', 'GTA V', 'GTA5', 'GTAV', '侠盗猎车手V', '俠盜獵車手V', 'グランド・セフト・オート V']),
-    ('Red Dead Redemption 2', ['Red Dead Redemption 2', 'RDR2', '荒野大镖客2', '碧血狂殺2', 'レッド・デッド・リデンプション2', '레드 데드 리뎀션 2']),
-    ('Cyberpunk 2077', ['Cyberpunk 2077', 'Cyberpunk', '赛博朋克2077', '電馭叛客 2077', 'サイバーパンク 2077', '사이버펑크 2077']),
-    ('The Witcher 3', ['The Witcher 3', 'Witcher 3', '巫师3', '巫師3', 'ウィッチャー3', '위쳐 3']),
-    ('Elden Ring', ['Elden Ring', 'ELDEN RING', '艾尔登法环', '艾爾登法環', 'エルデンリング', '엘든 링']),
-    ('Sekiro', ['Sekiro', 'SEKIRO', '只狼', 'SEKIRO: SHADOWS DIE TWICE', 'SEKIRO：影逝二度', '隻狼', 'SEKIRO 影武者', '세키로']),
-    ('Dark Souls III', ['Dark Souls III', 'Dark Souls 3', '黑暗之魂3', 'ダークソウル III']),
-    ('Dark Souls Remastered', ['Dark Souls Remastered', 'Dark Souls: REMASTERED', '黑暗之魂 重制版']),
-    ('Bloodborne', ['Bloodborne', '血源', '血源詛咒', 'ブラッドボーン']),
-    ('Baldur’s Gate 3', ['Baldur’s Gate 3', "Baldur's Gate 3", 'BG3', '博德之门3', '柏德之門3', 'バルダーズ・ゲート3', '발더스 게이트 3']),
-    ('Helldivers 2', ['Helldivers 2', 'HELLDIVERS 2', '绝地潜兵2', '地獄潛者2', 'ヘルダイバー2', '헬다이버즈 2']),
-    ('Diablo IV', ['Diablo IV', 'Diablo 4', '暗黑破坏神IV', '暗黑破壞神IV', 'ディアブロ IV', '디아블로 IV']),
-    ('Diablo II Resurrected', ['Diablo II: Resurrected', 'Diablo 2 Resurrected', '暗黑破坏神II 重制版']),
-    ('Diablo III', ['Diablo III', 'Diablo 3', '暗黑破坏神3']),
-    ('World of Warcraft', ['World of Warcraft', 'WoW', '魔兽世界', '魔獸世界', 'ワールド・オブ・ウォークラフト', '월드 오브 워크래프트']),
-    ('Hearthstone', ['Hearthstone', '炉石传说', '爐石戰記', 'ハースストーン', '하스스톤']),
-    ('StarCraft II', ['StarCraft II', 'StarCraft 2', '星际争霸II', '星海爭霸II', 'スタークラフト II', '스타크래프트 II']),
-    ('Overwatch 2', ['Overwatch 2', 'Overwatch', '守望先锋', '鬥陣特攻', 'オーバーウォッチ 2', '오버워치 2']),
-    ('Call of Duty', ['Call of Duty', 'COD', 'Modern Warfare', 'Black Ops', 'Warzone', '使命召唤', '決勝時刻', 'コール オブ デューティ', '콜 오브 듀티']),
-    ('Battlefield 2042', ['Battlefield 2042', 'Battlefield V', 'Battlefield 1', '战地2042', '戰地風雲2042', 'バトルフィールド']),
-    ('Rainbow Six Siege', ['Rainbow Six Siege', 'R6 Siege', '彩虹六号', '虹彩六號', 'レインボーシックス シージ', '레인보우 식스 시즈']),
-    ('Destiny 2', ['Destiny 2', '命运2', '天命 2', 'デスティニー 2']),
-    ('Escape from Tarkov', ['Escape from Tarkov', 'EFT', '逃离塔科夫', '逃離塔科夫', 'エスケープフロムタルコフ']),
-    ('Path of Exile', ['Path of Exile', 'PoE', '流放之路', '流亡黯道', 'パス・オブ・エクサイル']),
-    ('Path of Exile 2', ['Path of Exile 2', 'PoE2', '流放之路2', '流亡黯道2']),
-    ('Grim Dawn', ['Grim Dawn', '恐怖黎明']),
-    ('Last Epoch', ['Last Epoch', '最后纪元', '最後紀元']),
+    ('Counter-Strike 2', ['Counter-Strike 2', 'CS2', 'Counter Strike', '反恐精英2', 'カウンターストライク 2', '카운터 스트라이크 2'], 'competitive', 'fps'),
+    ('Dota 2', ['Dota 2', 'DOTA2', 'DOTA', '刀塔2', 'ドータ2'], 'competitive', 'moba'),
+    ('PUBG: Battlegrounds', ['PUBG', 'PlayerUnknown', '绝地求生', '絕地求生', 'PUBG: バトルグラウンズ', '배틀그라운드'], 'competitive', 'fps'),
+    ('Apex Legends', ['Apex Legends', 'Apex', '英雄', 'エーペックスレジェンズ', '에이펙스 레전드'], 'competitive', 'fps'),
+    ('Fortnite', ['Fortnite', '堡垒之夜', '堡壘之夜', 'フォートナイト', '포트나이트'], 'competitive', 'fps'),
+    ('Grand Theft Auto V', ['Grand Theft Auto V', 'GTA V', 'GTA5', 'GTAV', '侠盗猎车手V', '俠盜獵車手V', 'グランド・セフト・オート V'], 'varied', 'action'),
+    ('Red Dead Redemption 2', ['Red Dead Redemption 2', 'RDR2', '荒野大镖客2', '碧血狂殺2', 'レッド・デッド・リデンプション2', '레드 데드 리뎀션 2'], 'immersive', 'rpg'),
+    ('Cyberpunk 2077', ['Cyberpunk 2077', 'Cyberpunk', '赛博朋克2077', '電馭叛客 2077', 'サイバーパンク 2077', '사이버펑크 2077'], 'immersive', 'rpg'),
+    ('The Witcher 3', ['The Witcher 3', 'Witcher 3', '巫师3', '巫師3', 'ウィッチャー3', '위쳐 3'], 'immersive', 'rpg'),
+    ('Elden Ring', ['Elden Ring', 'ELDEN RING', '艾尔登法环', '艾爾登法環', 'エルデンリング', '엘든 링'], 'immersive', 'rpg'),
+    ('Sekiro', ['Sekiro', 'SEKIRO', '只狼', 'SEKIRO: SHADOWS DIE TWICE', 'SEKIRO：影逝二度', '隻狼', 'SEKIRO 影武者', '세키로'], 'immersive', 'action'),
+    ('Dark Souls III', ['Dark Souls III', 'Dark Souls 3', '黑暗之魂3', 'ダークソウル III'], 'immersive', 'rpg'),
+    ('Dark Souls Remastered', ['Dark Souls Remastered', 'Dark Souls: REMASTERED', '黑暗之魂 重制版'], 'immersive', 'rpg'),
+    ('Bloodborne', ['Bloodborne', '血源', '血源詛咒', 'ブラッドボーン'], 'immersive', 'rpg'),
+    ('Baldur’s Gate 3', ['Baldur’s Gate 3', "Baldur's Gate 3", 'BG3', '博德之门3', '柏德之門3', 'バルダーズ・ゲート3', '발더스 게이트 3'], 'immersive', 'rpg'),
+    ('Helldivers 2', ['Helldivers 2', 'HELLDIVERS 2', '绝地潜兵2', '地獄潛者2', 'ヘルダイバー2', '헬다이버즈 2'], 'casual', 'fps'),
+    ('Diablo IV', ['Diablo IV', 'Diablo 4', '暗黑破坏神IV', '暗黑破壞神IV', 'ディアブロ IV', '디아블로 IV'], 'immersive', 'rpg'),
+    ('Diablo II Resurrected', ['Diablo II: Resurrected', 'Diablo 2 Resurrected', '暗黑破坏神II 重制版'], 'immersive', 'rpg'),
+    ('Diablo III', ['Diablo III', 'Diablo 3', '暗黑破坏神3'], 'immersive', 'rpg'),
+    ('World of Warcraft', ['World of Warcraft', 'WoW', '魔兽世界', '魔獸世界', 'ワールド・オブ・ウォークラフト', '월드 오브 워크래프트'], 'immersive', 'rpg'),
+    ('Hearthstone', ['Hearthstone', '炉石传说', '爐石戰記', 'ハースストーン', '하스스톤'], 'casual', 'strategy'),
+    ('StarCraft II', ['StarCraft II', 'StarCraft 2', '星际争霸II', '星海爭霸II', 'スタークラフト II', '스타크래프트 II'], 'competitive', 'strategy'),
+    ('Overwatch 2', ['Overwatch 2', 'Overwatch', '守望先锋', '鬥陣特攻', 'オーバーウォッチ 2', '오버워치 2'], 'competitive', 'fps'),
+    ('Call of Duty', ['Call of Duty', 'COD', 'Modern Warfare', 'Black Ops', 'Warzone', '使命召唤', '決勝時刻', 'コール オブ デューティ', '콜 오브 듀티'], 'competitive', 'fps'),
+    ('Battlefield 2042', ['Battlefield 2042', 'Battlefield V', 'Battlefield 1', '战地2042', '戰地風雲2042', 'バトルフィールド'], 'competitive', 'fps'),
+    ('Rainbow Six Siege', ['Rainbow Six Siege', 'R6 Siege', '彩虹六号', '虹彩六號', 'レインボーシックス シージ', '레인보우 식스 시즈'], 'competitive', 'fps'),
+    ('Destiny 2', ['Destiny 2', '命运2', '天命 2', 'デスティニー 2'], 'casual', 'fps'),
+    ('Escape from Tarkov', ['Escape from Tarkov', 'EFT', '逃离塔科夫', '逃離塔科夫', 'エスケープフロムタルコフ'], 'competitive', 'fps'),
+    ('Path of Exile', ['Path of Exile', 'PoE', '流放之路', '流亡黯道', 'パス・オブ・エクサイル'], 'immersive', 'rpg'),
+    ('Path of Exile 2', ['Path of Exile 2', 'PoE2', '流放之路2', '流亡黯道2'], 'immersive', 'rpg'),
+    ('Grim Dawn', ['Grim Dawn', '恐怖黎明'], 'immersive', 'rpg'),
+    ('Last Epoch', ['Last Epoch', '最后纪元', '最後紀元'], 'immersive', 'rpg'),
 
     # ============================================================
     # Japanese / SEA popular
     # ============================================================
-    ('Final Fantasy XIV', ['FINAL FANTASY XIV', 'FFXIV', 'FF14', '最终幻想XIV', '最終幻想XIV', 'ファイナルファンタジーXIV', '파이널 판타지 XIV']),
-    ('Final Fantasy VII Remake', ['FINAL FANTASY VII REMAKE', 'FF7 Remake', '最终幻想7 重制版', 'ファイナルファンタジーVII リメイク']),
-    ('Final Fantasy VII Rebirth', ['FINAL FANTASY VII REBIRTH', 'FF7 Rebirth', '最终幻想7 重生']),
-    ('Final Fantasy XVI', ['FINAL FANTASY XVI', 'FF16', '最终幻想XVI', 'ファイナルファンタジーXVI']),
-    ('Monster Hunter Wilds', ['Monster Hunter Wilds', 'MHWilds', '怪物猎人 荒野', '魔物獵人 荒野', 'モンスターハンター ワイルズ', '몬스터 헌터 와일즈']),
-    ('Monster Hunter World', ['Monster Hunter World', 'MHW', '怪物猎人：世界', '魔物獵人：世界', 'モンスターハンター：ワールド', '몬스터 헌터: 월드']),
-    ('Monster Hunter Rise', ['Monster Hunter Rise', 'MHRise', '怪物猎人 崛起', '魔物獵人 崛起', 'モンスターハンターライズ', '몬스터 헌터 라이즈']),
-    ('Persona 5 Royal', ['Persona 5 Royal', 'P5R', '女神异闻录5 皇家版', '女神異聞錄5 皇家版', 'ペルソナ5 ザ・ロイヤル', '페르소나 5 더 로열']),
-    ('Persona 3 Reload', ['Persona 3 Reload', 'P3R', '女神异闻录3 Reload', 'ペルソナ3 リロード']),
-    ('Persona 4 Golden', ['Persona 4 Golden', 'P4G', '女神异闻录4 黄金版', 'ペルソナ4 ザ・ゴールデン']),
-    ('Tekken 8', ['Tekken 8', 'TEKKEN 8', '铁拳8', '鐵拳8', '鉄拳8', '철권 8']),
-    ('Street Fighter 6', ['Street Fighter 6', 'SF6', '街头霸王6', '快打旋風6', 'ストリートファイター6', '스트리트 파이터 6']),
-    ('Guilty Gear Strive', ['Guilty Gear Strive', 'GGST', '罪恶装备 Strive', 'GUILTY GEAR -STRIVE-', '길티기어 스트라이브']),
+    ('Final Fantasy XIV', ['FINAL FANTASY XIV', 'FFXIV', 'FF14', '最终幻想XIV', '最終幻想XIV', 'ファイナルファンタジーXIV', '파이널 판타지 XIV'], 'immersive', 'rpg'),
+    ('Final Fantasy VII Remake', ['FINAL FANTASY VII REMAKE', 'FF7 Remake', '最终幻想7 重制版', 'ファイナルファンタジーVII リメイク'], 'immersive', 'rpg'),
+    ('Final Fantasy VII Rebirth', ['FINAL FANTASY VII REBIRTH', 'FF7 Rebirth', '最终幻想7 重生'], 'immersive', 'rpg'),
+    ('Final Fantasy XVI', ['FINAL FANTASY XVI', 'FF16', '最终幻想XVI', 'ファイナルファンタジーXVI'], 'immersive', 'rpg'),
+    ('Monster Hunter Wilds', ['Monster Hunter Wilds', 'MHWilds', '怪物猎人 荒野', '魔物獵人 荒野', 'モンスターハンター ワイルズ', '몬스터 헌터 와일즈'], 'immersive', 'action'),
+    ('Monster Hunter World', ['Monster Hunter World', 'MHW', '怪物猎人：世界', '魔物獵人：世界', 'モンスターハンター：ワールド', '몬스터 헌터: 월드'], 'immersive', 'action'),
+    ('Monster Hunter Rise', ['Monster Hunter Rise', 'MHRise', '怪物猎人 崛起', '魔物獵人 崛起', 'モンスターハンターライズ', '몬스터 헌터 라이즈'], 'immersive', 'action'),
+    ('Persona 5 Royal', ['Persona 5 Royal', 'P5R', '女神异闻录5 皇家版', '女神異聞錄5 皇家版', 'ペルソナ5 ザ・ロイヤル', '페르소나 5 더 로열'], 'immersive', 'rpg'),
+    ('Persona 3 Reload', ['Persona 3 Reload', 'P3R', '女神异闻录3 Reload', 'ペルソナ3 リロード'], 'immersive', 'rpg'),
+    ('Persona 4 Golden', ['Persona 4 Golden', 'P4G', '女神异闻录4 黄金版', 'ペルソナ4 ザ・ゴールデン'], 'immersive', 'rpg'),
+    ('Tekken 8', ['Tekken 8', 'TEKKEN 8', '铁拳8', '鐵拳8', '鉄拳8', '철권 8'], 'competitive', 'action'),
+    ('Street Fighter 6', ['Street Fighter 6', 'SF6', '街头霸王6', '快打旋風6', 'ストリートファイター6', '스트리트 파이터 6'], 'competitive', 'action'),
+    ('Guilty Gear Strive', ['Guilty Gear Strive', 'GGST', '罪恶装备 Strive', 'GUILTY GEAR -STRIVE-', '길티기어 스트라이브'], 'competitive', 'action'),
     ('Granblue Fantasy: Relink', ['Granblue Fantasy: Relink', 'GBF Relink', '碧蓝幻想 Relink', 'グランブルーファンタジー リリンク']),
     ('Granblue Fantasy Versus', ['Granblue Fantasy Versus', 'GBVS', 'グランブルーファンタジー ヴァーサス']),
-    ('NieR: Automata', ['NieR: Automata', 'NieR Automata', '尼尔：机械纪元', '尼爾：自動人形', 'ニーア オートマタ', '니어: 오토마타']),
-    ('NieR Replicant', ['NieR Replicant', '尼尔：人工生命', 'ニーア レプリカント']),
+    ('NieR: Automata', ['NieR: Automata', 'NieR Automata', '尼尔：机械纪元', '尼爾：自動人形', 'ニーア オートマタ', '니어: 오토마타'], 'immersive', 'action'),
+    ('NieR Replicant', ['NieR Replicant', '尼尔：人工生命', 'ニーア レプリカント'], 'immersive', 'action'),
     ('Atelier Ryza', ['Atelier Ryza', '莱莎的炼金工房', '萊莎的鍊金工房', 'アトリエ ライザ']),
     ('Atelier Yumia', ['Atelier Yumia', '尤米娅的炼金工房', 'アトリエ ユミア']),
     ('Ys X: Nordics', ['Ys X', 'Ys X: Nordics', '伊苏X', 'イースX']),
@@ -270,24 +410,24 @@ GAME_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
     ('Like a Dragon: Infinite Wealth', ['Like a Dragon: Infinite Wealth', 'Yakuza', '如龙8', '人中之龙8', '龍が如く8']),
     ('Yakuza 0', ['Yakuza 0', '人中之龙0', '龍が如く0']),
     ('Like a Dragon: Ishin', ['Like a Dragon: Ishin', '如龙 维新', '龍が如く 維新']),
-    ('Resident Evil 4 Remake', ['Resident Evil 4', 'RE4 Remake', '生化危机4 重制版', '惡靈古堡4 重製版', 'バイオハザード RE:4', '레지던트 이블 4']),
-    ('Resident Evil Village', ['Resident Evil Village', 'RE Village', '生化危机 村庄', 'バイオハザード ヴィレッジ']),
-    ('Resident Evil 2 Remake', ['Resident Evil 2', '生化危机2 重制版', 'バイオハザード RE:2']),
-    ('Resident Evil 3 Remake', ['Resident Evil 3', '生化危机3 重制版', 'バイオハザード RE:3']),
-    ('Devil May Cry 5', ['Devil May Cry 5', 'DMC5', '鬼泣5', '惡魔獵人5', 'デビル メイ クライ 5']),
-    ('Dragon’s Dogma 2', ['Dragon’s Dogma 2', "Dragon's Dogma 2", '龙之信条2', '龍族教義2', 'ドラゴンズドグマ2']),
+    ('Resident Evil 4 Remake', ['Resident Evil 4', 'RE4 Remake', '生化危机4 重制版', '惡靈古堡4 重製版', 'バイオハザード RE:4', '레지던트 이블 4'], 'immersive', 'horror'),
+    ('Resident Evil Village', ['Resident Evil Village', 'RE Village', '生化危机 村庄', 'バイオハザード ヴィレッジ'], 'immersive', 'horror'),
+    ('Resident Evil 2 Remake', ['Resident Evil 2', '生化危机2 重制版', 'バイオハザード RE:2'], 'immersive', 'horror'),
+    ('Resident Evil 3 Remake', ['Resident Evil 3', '生化危机3 重制版', 'バイオハザード RE:3'], 'immersive', 'horror'),
+    ('Devil May Cry 5', ['Devil May Cry 5', 'DMC5', '鬼泣5', '惡魔獵人5', 'デビル メイ クライ 5'], 'immersive', 'action'),
+    ('Dragon’s Dogma 2', ['Dragon’s Dogma 2', "Dragon's Dogma 2", '龙之信条2', '龍族教義2', 'ドラゴンズドグマ2'], 'immersive', 'rpg'),
     ('Pokemon', ['Pokemon', 'Pokémon', '宝可梦', '寶可夢', 'ポケモン', '포켓몬']),
     ('Splatoon', ['Splatoon', '斯普拉遁', '斯普拉遁', 'スプラトゥーン']),
     ('The Legend of Zelda', ['Legend of Zelda', 'Zelda', 'Tears of the Kingdom', 'Breath of the Wild', '塞尔达传说', '薩爾達傳說', 'ゼルダの伝説', '젤다의 전설']),
-    ('Black Myth: Wukong', ['Black Myth: Wukong', 'Black Myth Wukong', '黑神话：悟空', '黑神話：悟空', '黒神話：悟空', '검은 신화: 오공']),
+    ('Black Myth: Wukong', ['Black Myth: Wukong', 'Black Myth Wukong', '黑神话：悟空', '黑神話：悟空', '黒神話：悟空', '검은 신화: 오공'], 'immersive', 'action'),
 
     # ============================================================
     # Korean MMOs
     # ============================================================
-    ('Lost Ark', ['Lost Ark', 'LostArk', '失落的方舟', '命運方舟', 'ロストアーク', '로스트아크']),
-    ('MapleStory', ['MapleStory', 'Maple Story', '冒险岛', '新楓之谷', 'メイプルストーリー', '메이플스토리']),
-    ('Black Desert Online', ['Black Desert', 'Black Desert Online', 'BDO', '黑色沙漠', 'ブラックデザートオンライン', '검은사막']),
-    ('Throne and Liberty', ['Throne and Liberty', 'TL', 'THRONE AND LIBERTY', '王权与自由', '王權與自由', 'スローン&リバティ', '쓰론 앤 리버티']),
+    ('Lost Ark', ['Lost Ark', 'LostArk', '失落的方舟', '命運方舟', 'ロストアーク', '로스트아크'], 'casual', 'rpg'),
+    ('MapleStory', ['MapleStory', 'Maple Story', '冒险岛', '新楓之谷', 'メイプルストーリー', '메이플스토리'], 'casual', 'rpg'),
+    ('Black Desert Online', ['Black Desert', 'Black Desert Online', 'BDO', '黑色沙漠', 'ブラックデザートオンライン', '검은사막'], 'casual', 'rpg'),
+    ('Throne and Liberty', ['Throne and Liberty', 'TL', 'THRONE AND LIBERTY', '王权与自由', '王權與自由', 'スローン&リバティ', '쓰론 앤 리버티'], 'casual', 'rpg'),
     ('Blade & Soul', ['Blade & Soul', 'Blade and Soul', 'BnS', '剑灵', '劍靈', 'ブレイド アンド ソウル', '블레이드 앤 소울']),
     ('Lineage W', ['Lineage W', 'Lineage', '天堂W', 'リネージュW', '리니지W']),
     ('Lineage 2M', ['Lineage 2M', '天堂2M', '리니지2M']),
@@ -301,28 +441,28 @@ GAME_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
     # ============================================================
     # Western multiplayer / battle royale
     # ============================================================
-    ('Rocket League', ['Rocket League', '火箭联盟', '火箭聯盟', 'ロケットリーグ', '로켓 리그']),
-    ('Fall Guys', ['Fall Guys', '糖豆人', '糖豆人', 'フォールガイズ', '폴 가이즈']),
-    ('Among Us', ['Among Us', '我们之中', '在我们之中', 'アモングアス']),
-    ('Genshin', ['Genshin']),  # safety alias
-    ('Roblox', ['Roblox', '罗布乐思', '邏輯思維 Roblox', 'ロブロックス', '로블록스']),
-    ('Minecraft', ['Minecraft', '我的世界', 'マインクラフト', '마인크래프트']),
-    ('Terraria', ['Terraria', '泰拉瑞亚', '泰拉瑞亞', 'テラリア', '테라리아']),
-    ('Stardew Valley', ['Stardew Valley', '星露谷物语', '星露谷物語', 'スターデューバレー', '스타듀밸리']),
-    ('Hades', ['Hades', '哈迪斯', '黑帝斯', 'ハデス', '하데스']),
-    ('Hades II', ['Hades II', 'Hades 2', '哈迪斯2']),
-    ('Hollow Knight', ['Hollow Knight', '空洞骑士', '空洞騎士', 'ホロウナイト', '할로우 나이트']),
-    ('Hollow Knight: Silksong', ['Silksong', 'Hollow Knight: Silksong', '丝之歌', '絲之歌']),
-    ('Celeste', ['Celeste', '蔚蓝', '蔚藍', 'セレステ']),
-    ('Cuphead', ['Cuphead', '茶杯头', '茶杯頭', 'カップヘッド']),
-    ('Dead Cells', ['Dead Cells', '死亡细胞', '死亡細胞', 'デッドセルズ']),
-    ('Risk of Rain 2', ['Risk of Rain 2', '雨中冒险2']),
-    ('Don’t Starve Together', ['Don’t Starve', "Don't Starve Together", '饥荒', '飢荒', 'ドント・スターブ']),
-    ('Phasmophobia', ['Phasmophobia', '恐鬼症']),
-    ('Lethal Company', ['Lethal Company', '致命公司']),
-    ('REPO', ['R.E.P.O.', 'R.E.P.O', 'REPO']),
-    ('Content Warning', ['Content Warning']),
-    ('Pals', ['Palworld', '幻兽帕鲁', '幻獸帕魯', 'パルワールド', '팰월드']),
+    ('Rocket League', ['Rocket League', '火箭联盟', '火箭聯盟', 'ロケットリーグ', '로켓 리그'], 'competitive', 'sports'),
+    ('Fall Guys', ['Fall Guys', '糖豆人', '糖豆人', 'フォールガイズ', '폴 가이즈'], 'casual', 'party'),
+    ('Among Us', ['Among Us', '我们之中', '在我们之中', 'アモングアス'], 'casual', 'party'),
+    ('Genshin', ['Genshin'], 'casual', 'rpg'),  # safety alias
+    ('Roblox', ['Roblox', '罗布乐思', '邏輯思維 Roblox', 'ロブロックス', '로블록스'], 'varied', 'party'),
+    ('Minecraft', ['Minecraft', '我的世界', 'マインクラフト', '마인크래프트'], 'varied', 'sim'),
+    ('Terraria', ['Terraria', '泰拉瑞亚', '泰拉瑞亞', 'テラリア', '테라리아'], 'casual', 'sim'),
+    ('Stardew Valley', ['Stardew Valley', '星露谷物语', '星露谷物語', 'スターデューバレー', '스타듀밸리'], 'casual', 'sim'),
+    ('Hades', ['Hades', '哈迪斯', '黑帝斯', 'ハデス', '하데스'], 'immersive', 'action'),
+    ('Hades II', ['Hades II', 'Hades 2', '哈迪斯2'], 'immersive', 'action'),
+    ('Hollow Knight', ['Hollow Knight', '空洞骑士', '空洞騎士', 'ホロウナイト', '할로우 나이트'], 'immersive', 'action'),
+    ('Hollow Knight: Silksong', ['Silksong', 'Hollow Knight: Silksong', '丝之歌', '絲之歌'], 'immersive', 'action'),
+    ('Celeste', ['Celeste', '蔚蓝', '蔚藍', 'セレステ'], 'immersive', 'action'),
+    ('Cuphead', ['Cuphead', '茶杯头', '茶杯頭', 'カップヘッド'], 'immersive', 'action'),
+    ('Dead Cells', ['Dead Cells', '死亡细胞', '死亡細胞', 'デッドセルズ'], 'casual', 'action'),
+    ('Risk of Rain 2', ['Risk of Rain 2', '雨中冒险2'], 'casual', 'action'),
+    ('Don’t Starve Together', ['Don’t Starve', "Don't Starve Together", '饥荒', '飢荒', 'ドント・スターブ'], 'casual', 'sim'),
+    ('Phasmophobia', ['Phasmophobia', '恐鬼症'], 'immersive', 'horror'),
+    ('Lethal Company', ['Lethal Company', '致命公司'], 'casual', 'horror'),
+    ('REPO', ['R.E.P.O.', 'R.E.P.O', 'REPO'], 'casual', 'horror'),
+    ('Content Warning', ['Content Warning'], 'casual', 'horror'),
+    ('Pals', ['Palworld', '幻兽帕鲁', '幻獸帕魯', 'パルワールド', '팰월드'], 'casual', 'action'),
     ('Manor Lords', ['Manor Lords', '庄园领主', '莊園領主']),
     ('Banishers', ['Banishers: Ghosts of New Eden', 'Banishers']),
 
@@ -372,25 +512,25 @@ GAME_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
     # ============================================================
     # Racing / sports
     # ============================================================
-    ('Forza Horizon 5', ['Forza Horizon 5', 'FH5', '极限竞速：地平线5', '極限競速：地平線5']),
-    ('Forza Horizon 4', ['Forza Horizon 4', 'FH4', '极限竞速：地平线4']),
-    ('Forza Motorsport', ['Forza Motorsport', '极限竞速', '極限競速']),
-    ('F1 24', ['F1 24', 'F1 25', 'F1 23']),
-    ('Gran Turismo 7', ['Gran Turismo 7', 'GT7', 'グランツーリスモ7']),
-    ('iRacing', ['iRacing']),
-    ('Assetto Corsa', ['Assetto Corsa', '神力科莎']),
-    ('Assetto Corsa Competizione', ['Assetto Corsa Competizione', 'ACC']),
-    ('EA Sports FC', ['EA Sports FC', 'FIFA', 'EA SPORTS FC 25', 'FC 25', 'EA SPORTS FC 24']),
-    ('NBA 2K25', ['NBA 2K25', 'NBA 2K24', 'NBA 2K23', 'NBA 2K']),
-    ('Rocket League', ['Rocket League']),
+    ('Forza Horizon 5', ['Forza Horizon 5', 'FH5', '极限竞速：地平线5', '極限競速：地平線5'], 'casual', 'racing'),
+    ('Forza Horizon 4', ['Forza Horizon 4', 'FH4', '极限竞速：地平线4'], 'casual', 'racing'),
+    ('Forza Motorsport', ['Forza Motorsport', '极限竞速', '極限競速'], 'competitive', 'racing'),
+    ('F1 24', ['F1 24', 'F1 25', 'F1 23'], 'competitive', 'racing'),
+    ('Gran Turismo 7', ['Gran Turismo 7', 'GT7', 'グランツーリスモ7'], 'casual', 'racing'),
+    ('iRacing', ['iRacing'], 'competitive', 'racing'),
+    ('Assetto Corsa', ['Assetto Corsa', '神力科莎'], 'casual', 'racing'),
+    ('Assetto Corsa Competizione', ['Assetto Corsa Competizione', 'ACC'], 'competitive', 'racing'),
+    ('EA Sports FC', ['EA Sports FC', 'FIFA', 'EA SPORTS FC 25', 'FC 25', 'EA SPORTS FC 24'], 'competitive', 'sports'),
+    ('NBA 2K25', ['NBA 2K25', 'NBA 2K24', 'NBA 2K23', 'NBA 2K'], 'competitive', 'sports'),
+    ('Rocket League', ['Rocket League'], 'competitive', 'sports'),
 
     # ============================================================
     # MOBA / shooter / extras
     # ============================================================
-    ('The Finals', ['The Finals', '最终决战', 'THE FINALS']),
-    ('XDefiant', ['XDefiant']),
-    ('Splitgate', ['Splitgate']),
-    ('Hunt: Showdown', ['Hunt: Showdown', '猎杀对决', '獵殺：對決']),
+    ('The Finals', ['The Finals', '最终决战', 'THE FINALS'], 'competitive', 'fps'),
+    ('XDefiant', ['XDefiant'], 'competitive', 'fps'),
+    ('Splitgate', ['Splitgate'], 'competitive', 'fps'),
+    ('Hunt: Showdown', ['Hunt: Showdown', '猎杀对决', '獵殺：對決'], 'competitive', 'fps'),
     ('Sea of Thieves', ['Sea of Thieves', '盗贼之海', '盜賊之海']),
     ('Halo Infinite', ['Halo Infinite', '光环：无限', '最後一戰：無限', 'ヘイロー インフィニット']),
     ('Halo: The Master Chief Collection', ['Halo MCC', 'Master Chief Collection']),
@@ -2625,18 +2765,54 @@ def _match(needle: Needle, text_lower: str) -> bool:
     return needle.search(text_lower) is not None
 
 
+def _unpack_game_row(row) -> tuple[str, list[str], str | None, str | None]:
+    """Accept either 2-tuple (legacy) or 4-tuple game keyword rows.
+
+    The schema is migrating from ``(canonical, [aliases])`` to
+    ``(canonical, [aliases], intensity, genre)`` — top games get the
+    intensity/genre tags that drive propensity / skip_probability /
+    tone, the long tail can stay 2-tuple and falls through to the
+    state machine's ``varied / misc`` defaults. Both shapes coexist
+    while the retag effort proceeds incrementally.
+    """
+    if len(row) == 4:
+        canonical, aliases, intensity, genre = row
+        return canonical, aliases, intensity, genre
+    canonical, aliases = row
+    return canonical, aliases, None, None
+
+
 def _build_title_table() -> list[tuple[Needle, ClassifyResult]]:
     """Window-title needles in priority order.
 
-    gaming launchers come AFTER game titles (a launcher window is a
-    weaker gaming signal than the game itself) but BEFORE work/etc so
-    that ``Steam`` doesn't get misclassified as work.
+    Priority (highest → lowest):
+      private  > own_app  > game > game_launcher > work > comm > ent
+
+    Privacy and own-app come first by design — privacy must short-circuit
+    all classification (the tracker bypasses caching downstream), and
+    own-app must short-circuit gaming-by-GPU (catgirl rendering its own
+    Live2D/VRM looks like gaming load otherwise).
     """
     table: list[tuple[Needle, ClassifyResult]] = []
 
-    for canonical, aliases in GAME_TITLE_KEYWORDS:
+    # PRIVATE — highest priority, always wins.
+    for canonical, aliases in PRIVATE_TITLE_KEYWORDS:
         for alias in aliases:
-            table.append((_make_needle(alias), ClassifyResult('gaming', 'game', canonical)))
+            table.append((_make_needle(alias), ClassifyResult('private', None, canonical)))
+
+    # OWN_APP — second priority. Beats gaming because the catgirl app's
+    # own GPU usage would otherwise trip gaming-by-GPU fallback.
+    for canonical, aliases in OWN_APP_TITLE_KEYWORDS:
+        for alias in aliases:
+            table.append((_make_needle(alias), ClassifyResult('own_app', None, canonical)))
+
+    for row in GAME_TITLE_KEYWORDS:
+        canonical, aliases, intensity, genre = _unpack_game_row(row)
+        for alias in aliases:
+            table.append((
+                _make_needle(alias),
+                ClassifyResult('gaming', 'game', canonical, intensity, genre),
+            ))
     for canonical, aliases in GAME_LAUNCHER_TITLE_KEYWORDS:
         for alias in aliases:
             table.append((_make_needle(alias), ClassifyResult('gaming', 'launcher', canonical)))
@@ -2661,6 +2837,12 @@ def _build_title_table() -> list[tuple[Needle, ClassifyResult]]:
 def _build_process_table() -> list[tuple[Needle, ClassifyResult]]:
     """Process-name needles in priority order. Same order as titles."""
     table: list[tuple[Needle, ClassifyResult]] = []
+
+    for proc in PRIVATE_PROCESS_NAMES:
+        table.append((_make_needle(proc), ClassifyResult('private', None, proc)))
+
+    for proc in OWN_APP_PROCESS_NAMES:
+        table.append((_make_needle(proc), ClassifyResult('own_app', None, proc)))
 
     for proc in GAME_PROCESS_NAMES:
         table.append((_make_needle(proc), ClassifyResult('gaming', 'game', proc)))
@@ -2725,6 +2907,8 @@ def _assert_no_process_dups() -> None:
     quietly mis-classifying user activity.
     """
     pools_raw: dict[str, list[str]] = {
+        'private':  list(PRIVATE_PROCESS_NAMES),
+        'own_app':  list(OWN_APP_PROCESS_NAMES),
         'game':     list(GAME_PROCESS_NAMES),
         'launcher': list(GAME_LAUNCHER_PROCESS_NAMES),
         'work':     [p for p, _ in WORK_PROCESS_NAMES],

--- a/config/activity_keywords.py
+++ b/config/activity_keywords.py
@@ -398,7 +398,10 @@ GAME_TITLE_KEYWORDS: list = [
     ('StarCraft II', ['StarCraft II', 'StarCraft 2', '星际争霸II', '星海爭霸II', 'スタークラフト II', '스타크래프트 II'], 'competitive', 'strategy'),
     ('Overwatch 2', ['Overwatch 2', 'Overwatch', '守望先锋', '鬥陣特攻', 'オーバーウォッチ 2', '오버워치 2'], 'competitive', 'fps'),
     ('Call of Duty', ['Call of Duty', 'COD', 'Modern Warfare', 'Black Ops', 'Warzone', '使命召唤', '決勝時刻', 'コール オブ デューティ', '콜 오브 듀티'], 'competitive', 'fps'),
-    ('Battlefield 2042', ['Battlefield 2042', 'Battlefield V', 'Battlefield 1', '战地2042', '戰地風雲2042', 'バトルフィールド'], 'competitive', 'fps'),
+    # Family-name canonical so per-year `user_game_overrides` keys map
+    # consistently — bundling BFV / BF1 / BF2042 under "Battlefield 2042"
+    # would block users from targeting other titles in the series.
+    ('Battlefield', ['Battlefield 2042', 'Battlefield V', 'Battlefield 1', '战地2042', '戰地風雲2042', 'バトルフィールド'], 'competitive', 'fps'),
     ('Rainbow Six Siege', ['Rainbow Six Siege', 'R6 Siege', '彩虹六号', '虹彩六號', 'レインボーシックス シージ', '레인보우 식스 시즈'], 'competitive', 'fps'),
     ('Destiny 2', ['Destiny 2', '命运2', '天命 2', 'デスティニー 2'], 'casual', 'fps'),
     ('Escape from Tarkov', ['Escape from Tarkov', 'EFT', '逃离塔科夫', '逃離塔科夫', 'エスケープフロムタルコフ'], 'competitive', 'fps'),
@@ -545,13 +548,15 @@ GAME_TITLE_KEYWORDS: list = [
     ('Forza Horizon 5', ['Forza Horizon 5', 'FH5', '极限竞速：地平线5', '極限競速：地平線5'], 'casual', 'racing'),
     ('Forza Horizon 4', ['Forza Horizon 4', 'FH4', '极限竞速：地平线4'], 'casual', 'racing'),
     ('Forza Motorsport', ['Forza Motorsport', '极限竞速', '極限競速'], 'competitive', 'racing'),
-    ('F1 24', ['F1 24', 'F1 25', 'F1 23'], 'competitive', 'racing'),
+    # Family-name canonical so per-year overrides remain addressable
+    ('F1', ['F1 25', 'F1 24', 'F1 23'], 'competitive', 'racing'),
     ('Gran Turismo 7', ['Gran Turismo 7', 'GT7', 'グランツーリスモ7'], 'casual', 'racing'),
     ('iRacing', ['iRacing'], 'competitive', 'racing'),
     ('Assetto Corsa', ['Assetto Corsa', '神力科莎'], 'casual', 'racing'),
     ('Assetto Corsa Competizione', ['Assetto Corsa Competizione', 'ACC'], 'competitive', 'racing'),
     ('EA Sports FC', ['EA Sports FC', 'FIFA', 'EA SPORTS FC 25', 'FC 25', 'EA SPORTS FC 24'], 'competitive', 'sports'),
-    ('NBA 2K25', ['NBA 2K25', 'NBA 2K24', 'NBA 2K23', 'NBA 2K'], 'competitive', 'sports'),
+    # Family-name canonical so per-year overrides remain addressable
+    ('NBA 2K', ['NBA 2K25', 'NBA 2K24', 'NBA 2K23', 'NBA 2K'], 'competitive', 'sports'),
     ('Rocket League', ['Rocket League'], 'competitive', 'sports'),
 
     # ============================================================

--- a/config/activity_keywords.py
+++ b/config/activity_keywords.py
@@ -238,7 +238,15 @@ PRIVATE_PROCESS_NAMES: list[str] = [
 # the Windows desktop build) and known sibling executables shipped
 # alongside it.
 OWN_APP_TITLE_KEYWORDS: list[tuple[str, list[str]]] = [
-    ('N.E.K.O', ['N.E.K.O', 'NEKO', 'Project N.E.K.O', 'Project NEKO']),
+    # Aliases must be DISTINCTIVE — `_make_needle` does word-boundary
+    # matching, so a generic alias like ``NEKO`` would match any
+    # standalone "Neko" in unrelated titles ("Neko Atsume", random
+    # browser tabs about cats, etc.) and false-positive into our
+    # special own_app branch (window dropped, dwell frozen, GPU
+    # fallback suppressed). Keep only the dotted form; ``Project N.E.K.O``
+    # is similarly safe because the literal string with dots almost
+    # never appears outside this app.
+    ('N.E.K.O', ['N.E.K.O', 'Project N.E.K.O']),
     ('Xiao8',   ['Xiao8', '小八']),
     # The launcher window briefly surfaces "projectneko_server" as its
     # console title before settling on the main UI; catch that too.

--- a/config/prompts_activity.py
+++ b/config/prompts_activity.py
@@ -274,6 +274,7 @@ ACTIVITY_STATE_LABELS: dict[str, dict[str, str]] = {
         'voice_engaged':   '语音对话中',
         'idle':            '空闲',
         'transitioning':   '切换状态中',
+        'private':         '隐私应用前台',
     },
     'en': {
         'away':            'away',
@@ -285,6 +286,7 @@ ACTIVITY_STATE_LABELS: dict[str, dict[str, str]] = {
         'voice_engaged':   'voice conversation',
         'idle':            'idle',
         'transitioning':   'transitioning',
+        'private':         'private app foreground',
     },
     'ja': {
         'away':            '離席',
@@ -296,6 +298,7 @@ ACTIVITY_STATE_LABELS: dict[str, dict[str, str]] = {
         'voice_engaged':   'ボイス会話中',
         'idle':            'アイドル',
         'transitioning':   '状態切替中',
+        'private':         'プライベートアプリ前面',
     },
     'ko': {
         'away':            '자리 비움',
@@ -307,6 +310,7 @@ ACTIVITY_STATE_LABELS: dict[str, dict[str, str]] = {
         'voice_engaged':   '음성 대화 중',
         'idle':            '유휴',
         'transitioning':   '상태 전환 중',
+        'private':         '비공개 앱 전면',
     },
     'ru': {
         'away':            'отсутствует',
@@ -318,6 +322,70 @@ ACTIVITY_STATE_LABELS: dict[str, dict[str, str]] = {
         'voice_engaged':   'голосовая беседа',
         'idle':            'простой',
         'transitioning':   'смена контекста',
+        'private':         'приватное приложение в фокусе',
+    },
+}
+
+
+# ── Tone hints (single-line style modifier) ─────────────────────────
+#
+# Tone is orthogonal to propensity: propensity decides *what kind of
+# source* the AI may draw from, tone decides *how to deliver it*. The
+# Phase 2 prompt renders tone as one extra line:
+#
+#     口吻：短句优先，不延展话题，避免动作描写
+#
+# Tones and when they fire (see ``derive_tone`` in
+# ``main_logic/activity/snapshot.py`` for the full table):
+#
+#   * ``terse``   — competitive games, rhythm games
+#   * ``hushed``  — immersive horror games
+#   * ``mellow``  — immersive RPG / story-driven games
+#   * ``playful`` — casual gaming, casual_browsing
+#   * ``warm``    — voice / chatting / stale_returning
+#   * ``concise`` — focused_work / idle / default (rendered nothing —
+#                   format_activity_state_section skips when concise to
+#                   save a line in the common case)
+ACTIVITY_TONE_HINTS: dict[str, dict[str, str]] = {
+    'zh': {
+        'terse':   '短句优先，不延展话题，避免动作描写',
+        'hushed':  '轻声细语，配合氛围克制说话',
+        'mellow':  '慢节奏放松陪伴，不丢专业术语进来',
+        'playful': '闲适带点小俏皮，可以开玩笑',
+        'warm':    '自然对话，回应感强',
+        'concise': '不啰嗦，专业克制',
+    },
+    'en': {
+        'terse':   'short sentences first; do not extend topics; avoid action narration',
+        'hushed':  'soft and quiet, restrained to match the atmosphere',
+        'mellow':  'slow-paced, relaxed companionship; no jargon dumps',
+        'playful': 'easygoing with a touch of mischief; jokes welcome',
+        'warm':    'natural conversation, responsive in tone',
+        'concise': 'no fluff, professional and restrained',
+    },
+    'ja': {
+        'terse':   '短文優先・話題を広げない・動作描写を避ける',
+        'hushed':  '小声で控えめに、雰囲気に合わせて',
+        'mellow':  'ゆったりした寄り添い、専門用語は出さない',
+        'playful': 'のんびりしつつ少し茶目っ気、冗談 OK',
+        'warm':    '自然な会話、反応性高め',
+        'concise': '冗長なし、控えめでプロフェッショナル',
+    },
+    'ko': {
+        'terse':   '짧은 문장 우선, 화제 확장 금지, 동작 묘사 자제',
+        'hushed':  '낮은 목소리로, 분위기에 맞게 절제',
+        'mellow':  '느긋한 동행, 전문 용어는 자제',
+        'playful': '편안하게 약간 장난스럽게, 농담도 OK',
+        'warm':    '자연스러운 대화, 반응성 높게',
+        'concise': '군더더기 없이, 절제된 전문성',
+    },
+    'ru': {
+        'terse':   'короткие фразы; не расширять тему; без описаний действий',
+        'hushed':  'тихо и сдержанно, в тон атмосфере',
+        'mellow':  'неспешное сопровождение, без жаргона',
+        'playful': 'непринуждённо и слегка игриво, шутки уместны',
+        'warm':    'естественный разговор, отзывчивая интонация',
+        'concise': 'без воды, сдержанно и профессионально',
     },
 }
 
@@ -395,6 +463,7 @@ ACTIVITY_REASON_TEMPLATES: dict[str, dict[str, str]] = {
         'state_chatting':        '前台聊天：{app}',
         'state_transitioning':   '近期窗口频繁切换',
         'state_idle':            '在电脑前但无明显任务',
+        'state_private':         '前台是隐私应用——不分类、不缓存',
         'high_cpu':              'CPU 30s 均值 {cpu_percent}%',
         'high_gpu':              'GPU 利用率 {gpu_percent}%',
         'gaming_by_gpu':         'GPU 持续高负载（怀疑未识别的游戏）',
@@ -409,6 +478,7 @@ ACTIVITY_REASON_TEMPLATES: dict[str, dict[str, str]] = {
         'state_chatting':        'foreground chat: {app}',
         'state_transitioning':   'rapid window switching recently',
         'state_idle':            'at the computer but no clear task',
+        'state_private':         'private app in foreground — not classifying / caching',
         'high_cpu':              'CPU 30s avg {cpu_percent}%',
         'high_gpu':              'GPU utilization {gpu_percent}%',
         'gaming_by_gpu':         'sustained high GPU (likely unrecognized game)',
@@ -423,6 +493,7 @@ ACTIVITY_REASON_TEMPLATES: dict[str, dict[str, str]] = {
         'state_chatting':        'フォアグラウンドチャット：{app}',
         'state_transitioning':   '最近のウィンドウ切替が頻繁',
         'state_idle':            'PC前にいるが明確な作業なし',
+        'state_private':         'プライベートアプリ前面——分類もキャッシュもしない',
         'high_cpu':              'CPU 30秒平均 {cpu_percent}%',
         'high_gpu':              'GPU 使用率 {gpu_percent}%',
         'gaming_by_gpu':         'GPU 高負荷継続（未識別のゲームの可能性）',
@@ -437,6 +508,7 @@ ACTIVITY_REASON_TEMPLATES: dict[str, dict[str, str]] = {
         'state_chatting':        '전경 채팅: {app}',
         'state_transitioning':   '최근 창 전환 빈번',
         'state_idle':            'PC 앞에 있으나 명확한 작업 없음',
+        'state_private':         '비공개 앱 전면 — 분류/캐시하지 않음',
         'high_cpu':              'CPU 30초 평균 {cpu_percent}%',
         'high_gpu':              'GPU 사용률 {gpu_percent}%',
         'gaming_by_gpu':         'GPU 고부하 지속 (미식별 게임 의심)',
@@ -451,6 +523,7 @@ ACTIVITY_REASON_TEMPLATES: dict[str, dict[str, str]] = {
         'state_chatting':        'переписка на переднем плане: {app}',
         'state_transitioning':   'недавно частая смена окон',
         'state_idle':            'за компьютером без явной задачи',
+        'state_private':         'приватное приложение в фокусе — не классифицируем / не кэшируем',
         'high_cpu':              'CPU средн. 30с {cpu_percent}%',
         'high_gpu':              'загрузка GPU {gpu_percent}%',
         'gaming_by_gpu':         'устойчиво высокая GPU (вероятно нераспознанная игра)',
@@ -497,6 +570,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         'activity_scores_label': '评估',
         'activity_guess_label': '叙述',
         'open_threads_label': '开放话题',
+        'tone_label': '口吻',
         'time_user_ai_fmt': '{time} | 用户 {user} | AI {ai}',
         'time_user_only_fmt': '{time} | 用户 {user}',
         'time_only_fmt': '{time}',
@@ -517,6 +591,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         'activity_scores_label': 'scores',
         'activity_guess_label': 'narrative',
         'open_threads_label': 'open threads',
+        'tone_label': 'tone',
         'time_user_ai_fmt': '{time} | user msg {user} ago | AI {ai} ago',
         'time_user_only_fmt': '{time} | user msg {user} ago',
         'time_only_fmt': '{time}',
@@ -537,6 +612,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         'activity_scores_label': '評価',
         'activity_guess_label': '叙述',
         'open_threads_label': '保留話題',
+        'tone_label': '口調',
         'time_user_ai_fmt': '{time} | ユーザー {user} | AI {ai}',
         'time_user_only_fmt': '{time} | ユーザー {user}',
         'time_only_fmt': '{time}',
@@ -557,6 +633,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         'activity_scores_label': '평가',
         'activity_guess_label': '서술',
         'open_threads_label': '보류 화제',
+        'tone_label': '말투',
         'time_user_ai_fmt': '{time} | 사용자 {user} | AI {ai}',
         'time_user_only_fmt': '{time} | 사용자 {user}',
         'time_only_fmt': '{time}',
@@ -577,6 +654,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         'activity_scores_label': 'оценки',
         'activity_guess_label': 'описание',
         'open_threads_label': 'открытые нити',
+        'tone_label': 'тон',
         'time_user_ai_fmt': '{time} | польз. {user} назад | AI {ai} назад',
         'time_user_only_fmt': '{time} | польз. {user} назад',
         'time_only_fmt': '{time}',

--- a/docs/design/user-activity-tracker.md
+++ b/docs/design/user-activity-tracker.md
@@ -71,7 +71,8 @@ for all fields.
 |---|---|---|---|
 | `away` | System idle ≥ 15 min | `open` | Normal proactive — frontend backoff handles frequency |
 | `stale_returning` | Just back from `away` (≤ 60s window) | `greeting_window` | Encourage greeting, allow 1d+ reminiscence |
-| `gaming` | Game window in foreground (subcategory='game') | `restricted_screen_only` | Only screen-derived chatter; no externals, no reminisce |
+| `private` | Sensitive app (password mgr / banking / wallet) foreground | `closed` | Hard skip — no LLM, no enrichment, no buffer caching |
+| `gaming` | Game window in foreground (subcategory='game') | `restricted_screen_only` *or* `open` (casual intensity) | Intensity / genre refines further (see "Game intensity & genre" below) |
 | `focused_work` | Work window + ≥ 90s dwell + recent input | `restricted_screen_only` | Same as gaming |
 | `casual_browsing` | Entertainment window + ≥ 30s dwell | `open` | Encourage external material |
 | `chatting` | Communication app in foreground | `open` | Allow externals, careful with screen comments |
@@ -85,17 +86,185 @@ the existing frontend backoff curve in `static/app-proactive.js`),
 not "don't speak". The greeting machinery in `core.py:trigger_greeting`
 uses a separate path on first reconnect.
 
+The `own_app` keyword category (catgirl app foreground) is handled at
+the observation layer — see "Own-app exclusion" below. It never
+produces a state, just a no-op tick.
+
 ## Propensity directives (what Phase 2 sees)
 
 | Propensity | Allowed channels | Recommended emphasis |
 |---|---|---|
-| `closed` | (reserved; no longer emitted) | — |
+| `closed` | None — hard skip | Used only by `private` state; proactive Phase 1 short-circuits before any LLM call |
 | `restricted_screen_only` | Screen only | Avoid duplication with last 1h; no externals; no reminiscence |
 | `open` | All channels | Reminiscence and externals both available |
 | `greeting_window` | All channels | Encourage gentle greeting + 1d+ reminiscence |
 
 Phase 2 prompt rewrites map these directives into language directives
 (see `config/prompts_proactive.py` for the post-revision prompt).
+
+## Skip probability (probabilistic gate, distinct from propensity)
+
+`ActivitySnapshot.skip_probability` is rolled at proactive Phase 1 entry
+*before any other gating* — if `random() < skip_probability` and there's
+no unfinished thread to follow up on, the round is skipped entirely
+(no LLM, no source fetch, no prompt assembly). Default 0 means "always
+proceed".
+
+Defaults are derived from `(state, intensity, genre)` in
+`derive_skip_probability()`:
+
+| Combo | Default skip |
+|---|---|
+| `gaming + competitive` (any genre) | 0.3 |
+| `gaming + immersive + horror` | 0.3 |
+| `gaming + immersive` (other genre) | 0.0 |
+| `gaming + casual` | 0.0 |
+| `gaming + varied` / untagged | 0.0 |
+| Non-gaming states | 0.0 |
+
+User overrides via `activity_preferences.json::skip_probability_overrides`
+take precedence — set `1.0` for "fully silent during this combo" or
+`0.0` to disable. Keys are intensity-only (`competitive`) or
+intensity_genre joined with underscore (`immersive_horror`).
+
+The `unfinished_thread` guard means an open AI question still gets its
+follow-up window even at `skip_probability=1.0`. Promise-keeping trumps
+silence; the existing 2-followup hard cap prevents harassment.
+
+## Tone modifier (style hint, orthogonal to propensity)
+
+`ActivitySnapshot.tone` is a single-axis style hint that controls *how*
+the AI delivers its message. Six tones, derived in `derive_tone()`:
+
+| Tone | When | Prompt hint (zh) |
+|---|---|---|
+| `terse` | competitive games / rhythm | "短句优先，不延展话题，避免动作描写" |
+| `hushed` | immersive horror | "轻声细语，配合氛围克制说话" |
+| `mellow` | immersive RPG / story | "慢节奏放松陪伴，不丢专业术语进来" |
+| `playful` | casual gaming / casual_browsing | "闲适带点小俏皮，可以开玩笑" |
+| `warm` | voice / chatting / stale_returning | "自然对话，回应感强" |
+| `concise` | focused_work / idle / default | "不啰嗦，专业克制" |
+
+Rendered by `format_activity_state_section` as one extra line:
+
+```
+口吻：短句优先，不延展话题，避免动作描写
+```
+
+`concise` (the safe fallback) and any tone under `propensity=closed`
+are NOT rendered — saves a token line in the common case.
+
+`silent` is intentionally not a tone. Silencing the AI is the
+`skip_probability` mechanism's job; conflating "voice" with "presence"
+muddies both axes.
+
+## Game intensity & genre
+
+Game-keyword rows in `config/activity_keywords.py::GAME_TITLE_KEYWORDS`
+support two shapes:
+
+```python
+# Legacy 2-tuple (untagged — falls through to varied/None)
+('Some Indie Game', ['Some Indie Game', 'SIG'])
+
+# New 4-tuple (tagged)
+('League of Legends', ['LoL', '英雄联盟'], 'competitive', 'moba')
+```
+
+`intensity` (`competitive` / `casual` / `immersive` / `varied`) drives
+propensity + skip_probability. `genre` (`fps` / `moba` / `rpg` / `sim` /
+`horror` / `racing` / `rhythm` / `strategy` / `sports` / `party` /
+`action` / `misc`) refines tone — the only genre-specific branch is
+`horror` triggering the `hushed` tone.
+
+User overrides (`user_game_overrides` in preferences) patch
+intensity/genre on top of static-DB classification by canonical name —
+useful for "I'm playing Elden Ring chill, not sweaty" style flips.
+
+The retag is incremental: top ~70 well-known games are tagged at the
+moment this doc was written; long-tail entries stay 2-tuple and behave
+identically to PR #1015's single `gaming → restricted_screen_only`
+bucket.
+
+## Privacy blacklist
+
+`PRIVATE_TITLE_KEYWORDS` and `PRIVATE_PROCESS_NAMES` in
+`config/activity_keywords.py` list password managers (KeePass /
+1Password / Bitwarden / etc), authenticator apps, and crypto wallets.
+A match emits `state='private', propensity='closed'`. The state
+machine sanitizes the observation (clears title + process_name from the
+snapshot's `active_window`) and the tracker bypasses LLM enrichment +
+suppresses background `activity_guess` ticks while in this state. Net
+effect: sensitive context never reaches the prompt or any model API.
+
+User app/title overrides cannot demote a static-DB privacy hit.
+Game intensity/genre overrides still apply (no privacy implication).
+
+## Own-app exclusion
+
+`OWN_APP_TITLE_KEYWORDS` and `OWN_APP_PROCESS_NAMES` cover the catgirl
+app's own windows (`projectneko_server.exe`, `Xiao8.exe`,
+`lanlan_frd.exe`, plus titles `N.E.K.O` / `Xiao8` / `小八` / `Project
+N.E.K.O`). When the catgirl app is foreground, the tracker treats the
+tick as "no fresh window data" — observation is dropped, dwell timer
+freezes, GPU fallback gaming doesn't trip on the catgirl's own
+Live2D / VRM rendering. Avoids the recursive feedback where "user is
+looking at the catgirl" itself becomes an input the catgirl reasons
+over.
+
+## User overrides & externalized config
+
+`utils/activity_config.py` reads the `activity` sub-dict from
+`user_preferences.json::__global_conversation__`:
+
+```json
+{
+  "model_path": "__global_conversation__",
+  "activity": {
+    "thresholds": {
+      "away_idle_seconds": 600,
+      "focused_work_min_dwell_seconds": 60
+    },
+    "user_app_overrides": {
+      "MyCorpApp.exe": {"category": "work", "subcategory": "office", "canonical": "MyCorpApp"}
+    },
+    "user_title_overrides": {
+      "MyCustomDashboard": {"category": "work", "subcategory": "office"}
+    },
+    "user_game_overrides": {
+      "Elden Ring": {"intensity": "casual"}
+    },
+    "skip_probability_overrides": {
+      "competitive":      0.5,
+      "immersive_horror": 1.0
+    }
+  }
+}
+```
+
+* **thresholds** — every state-machine constant (away_idle_seconds,
+  focused_work_min_dwell_seconds, etc.) can be tuned. Code defaults
+  remain hardcoded in `state_machine.py` as the fallback when an entry
+  is missing or invalid (positive numbers only; bad values silently
+  dropped).
+* **user_app_overrides** — process-name keyed, lowercased. Patches the
+  classifier result before state derivation. Cannot demote `private` or
+  `own_app` static-DB hits (privacy guarantee).
+* **user_title_overrides** — title-substring keyed, lowercased. Same
+  rules as app overrides; only fires when static DB returns `unknown`.
+* **user_game_overrides** — canonical-name keyed (case-sensitive).
+  Patches `(intensity, genre)` on top of an existing gaming
+  classification.
+* **skip_probability_overrides** — float in [0, 1] per intensity[_genre]
+  combo. Beats default lookups; out-of-range values are clamped.
+
+Cache: file is read at most once per 30s with mtime-based
+invalidation. Edits to the JSON take effect on the next reload tick.
+`invalidate_activity_preferences_cache()` is exposed for tests + for
+explicit reload after a settings UI write.
+
+There's no save path for the activity sub-dict yet — users hand-edit
+the JSON. Add a settings-UI write path when a UI lands.
 
 ## Architecture
 

--- a/docs/design/user-activity-tracker.md
+++ b/docs/design/user-activity-tracker.md
@@ -122,10 +122,11 @@ Defaults are derived from `(state, intensity, genre)` in
 | `gaming + varied` / untagged | 0.0 |
 | Non-gaming states | 0.0 |
 
-User overrides via `activity_preferences.json::skip_probability_overrides`
-take precedence — set `1.0` for "fully silent during this combo" or
-`0.0` to disable. Keys are intensity-only (`competitive`) or
-intensity_genre joined with underscore (`immersive_horror`).
+User overrides via `user_preferences.json`'s
+`__global_conversation__::activity::skip_probability_overrides` take
+precedence — set `1.0` for "fully silent during this combo" or `0.0`
+to disable. Keys are intensity-only (`competitive`) or intensity_genre
+joined with underscore (`immersive_horror`).
 
 The `unfinished_thread` guard means an open AI question still gets its
 follow-up window even at `skip_probability=1.0`. Promise-keeping trumps
@@ -247,14 +248,20 @@ over.
   remain hardcoded in `state_machine.py` as the fallback when an entry
   is missing or invalid (positive numbers only; bad values silently
   dropped).
-* **user_app_overrides** — process-name keyed, lowercased. Patches the
-  classifier result before state derivation. Cannot demote `private` or
-  `own_app` static-DB hits (privacy guarantee).
+* **user_app_overrides** — process-name keyed, lowercased. **Additive
+  only**: fires only when the static DB returned `unknown`. Cannot
+  rewrite stable static classifications (e.g. `Code.exe → work/ide`
+  cannot be flipped to `entertainment` via override). Cannot demote
+  `private` or `own_app` static-DB hits (privacy / catgirl-app
+  guarantee).
 * **user_title_overrides** — title-substring keyed, lowercased. Same
-  rules as app overrides; only fires when static DB returns `unknown`.
-* **user_game_overrides** — canonical-name keyed (case-sensitive).
-  Patches `(intensity, genre)` on top of an existing gaming
-  classification.
+  additive rule as app overrides — fires only when the static DB
+  returned `unknown`.
+* **user_game_overrides** — canonical-name keyed (case-sensitive). The
+  one exception to the additive rule: it patches `(intensity, genre)`
+  on top of an existing gaming classification (doesn't change
+  category/subcategory/canonical, only refines intensity / genre tags
+  within gaming).
 * **skip_probability_overrides** — float in [0, 1] per intensity[_genre]
   combo. Beats default lookups; out-of-range values are clamped.
 

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -38,14 +38,73 @@ ActivityState = Literal[
     'voice_engaged',       # Voice mode and recent RMS / VAD activity
     'idle',                # At the computer but no clear activity bucket
     'transitioning',       # Recent rapid window switches / mode change
+    'private',             # Sensitive app foreground — DO NOT classify or
+                           # cache. Propensity hard-pinned to ``closed`` so
+                           # proactive chat skips the round entirely. The
+                           # tracker also bypasses LLM enrichment + buffers
+                           # so the user's secret never leaves the process.
 ]
 
 
 Propensity = Literal[
-    'closed',                   # Reserved; not currently emitted (away no longer = PASS)
+    'closed',                   # Hard skip — do not surface anything. Currently
+                                # emitted only by ``private`` state (privacy
+                                # blacklist hit). All other states stay open
+                                # in some form so the AI keeps a baseline of
+                                # presence; ``closed`` is reserved for
+                                # "user's screen is showing something we
+                                # promised not to look at".
     'restricted_screen_only',   # Only allow screen-derived chatter; no externals/no reminisce
     'open',                     # Default: any channel allowed
     'greeting_window',          # Stale-returning / first-contact: encourage reminiscence
+]
+
+
+# Tone modifier — a style hint orthogonal to propensity. Propensity says
+# *what kind of source* the AI may draw from; tone says *how to deliver
+# it*. Phase 2 prompt renders the tone hint as a single line so the AI
+# can adapt voice without changing source filtering.
+#
+# Six tones, deliberately vivid (one-line prompt hint each, see
+# ``ACTIVITY_TONE_HINTS`` in ``config/prompts_activity.py``):
+#   * ``terse``   — competitive games, rhythm games: short, low-intrusion
+#   * ``hushed``  — horror games: deliberately quiet, atmospheric
+#   * ``mellow``  — immersive RPG / story-driven: relaxed in-the-moment
+#   * ``playful`` — casual gaming, casual_browsing: light, joke-friendly
+#   * ``warm``    — voice / chatting / stale_returning: conversational
+#   * ``concise`` — focused_work / idle / default: short, professional
+#
+# ``silent`` is intentionally not a tone — silencing the AI is the
+# ``skip_probability`` mechanism's job (probabilistic gate before any
+# tone matters), and conflating "voice" with "presence" muddies both.
+ActivityTone = Literal[
+    'terse',
+    'hushed',
+    'mellow',
+    'playful',
+    'warm',
+    'concise',
+]
+
+
+# Game intensity / genre tags (only meaningful when state == 'gaming').
+# ``intensity`` drives propensity + skip_probability defaults; ``genre``
+# refines tone selection (horror → hushed, sim → playful, etc.).
+GameIntensity = Literal[
+    'competitive',  # Multi-player adversarial; interruption causes mistakes
+    'casual',       # Pause-anytime, no momentum cost (sim, idle, party)
+    'immersive',    # Single-player narrative; interruption breaks flow
+    'varied',       # Default — unclassified, indie, mod-heavy, gray zone
+]
+
+
+# Genre tags are a free-form-ish string but with a recommended vocabulary
+# below. Code never branches on the exact value; only ``horror`` is
+# called out for its tone override. New genres can be added in
+# ``activity_keywords`` without state-machine changes.
+GameGenre = Literal[
+    'fps', 'moba', 'rpg', 'sim', 'horror', 'racing', 'rhythm',
+    'strategy', 'sports', 'party', 'action', 'misc',
 ]
 
 
@@ -57,13 +116,21 @@ class WindowObservation:
 
     Held inside ``ActivitySnapshot`` only as the most recent observation;
     the rolling history lives in ``UserActivityTracker``'s buffer.
+
+    ``intensity`` / ``genre`` are populated only for games that were
+    tagged in the keyword DB or via ``user_game_overrides``. Both
+    ``None`` for non-games and untagged games — state machine treats
+    those as ``intensity='varied' / genre='misc'`` by convention
+    (conservative fallback, same behaviour as PR #1015).
     """
     process_name: str | None
     title: str | None
-    category: str            # 'gaming' | 'work' | 'entertainment' | 'communication' | 'unknown'
+    category: str            # 'gaming' | 'work' | 'entertainment' | 'communication' | 'unknown' | 'private' | 'own_app'
     subcategory: str | None  # e.g. 'ide' / 'video' / 'im' / 'game'
     canonical: str | None    # e.g. 'VS Code'
     is_browser: bool
+    intensity: str | None = None  # GameIntensity-shaped, only when category='gaming' subcategory='game'
+    genre: str | None = None      # GameGenre-shaped, same gating
 
 
 @dataclass(frozen=True, slots=True)
@@ -106,6 +173,34 @@ class ActivitySnapshot:
 
     # --- Propensity (prompt directive) ---
     propensity: Propensity
+
+    # --- Skip probability (independent gate before any source filtering) ---
+    # ``skip_probability`` is rolled by the proactive_chat router at Phase 1
+    # entry — if random() < skip_probability AND no unfinished_thread is
+    # active, the round is skipped entirely (no LLM call, no source fetch).
+    # Default 0 means "always proceed". Defaults are derived from
+    # (state, intensity, genre) by the state machine; user overrides via
+    # ``activity_preferences.json::skip_probability_overrides`` can tune
+    # them per-combo. Setting 1.0 = fully silent for that combo (user
+    # opt-in "don't talk at all during X"); 0.0 = no skip, just rely on
+    # propensity.
+    #
+    # The unfinished_thread guard means the AI's open questions still get
+    # follow-up windows even in high-skip states — interrupting yourself
+    # mid-thread is rude even when you're trying to be quiet.
+    skip_probability: float = 0.0
+
+    # --- Tone modifier (style hint, orthogonal to propensity) ---
+    # See ``ActivityTone`` doc for the six values. Default ``concise``
+    # is the safe fallback — short, professional, won't surprise.
+    tone: ActivityTone = 'concise'
+
+    # --- Game classification (only meaningful when state == 'gaming') ---
+    # Both None for non-gaming states. ``intensity`` drives propensity
+    # + skip_probability; ``genre`` refines tone (horror → hushed). User
+    # can override per-game via ``user_game_overrides`` in preferences.
+    game_intensity: GameIntensity | None = None
+    game_genre: GameGenre | None = None
     # Structured reasons: each entry is ``(code, params)`` where ``code``
     # is a reason key looked up in ``ACTIVITY_REASON_TEMPLATES`` (in
     # ``config/prompts_activity.py``) and ``params`` is a dict
@@ -188,12 +283,154 @@ _STATE_TO_PROPENSITY: dict[ActivityState, Propensity] = {
     'transitioning':    'open',                    # User said: transitioning still allows screen;
                                                    # external sources just get a small weight cut
                                                    # (handled in source-weight layer, not propensity)
+    'private':          'closed',                  # Sensitive app foreground — hard skip.
 }
 
 
 def state_to_propensity(state: ActivityState) -> Propensity:
     """Map an ``ActivityState`` to its prompt-level propensity directive."""
     return _STATE_TO_PROPENSITY.get(state, 'open')
+
+
+def derive_propensity(
+    state: ActivityState,
+    *,
+    game_intensity: GameIntensity | None = None,
+    game_genre: GameGenre | None = None,
+) -> Propensity:
+    """Pick the propensity, allowing game intensity to override the default.
+
+    The base mapping in ``_STATE_TO_PROPENSITY`` collapses all gaming
+    states to ``restricted_screen_only`` (PR #1015 behaviour). When the
+    state machine has more information (intensity tagged in the keyword
+    DB or via user override), this function refines:
+
+      * ``casual`` gaming → ``open``  (animal crossing / stardew —
+                                       chatting while playing is fine)
+      * ``competitive`` / ``immersive`` / ``varied`` / untagged →
+        keep the default (``restricted_screen_only``); skip_probability
+        and tone do the further differentiation.
+
+    Genre is currently a tone-axis only (no genre flips propensity);
+    parameter is accepted for symmetry with ``derive_tone`` /
+    ``derive_skip_probability`` and forward compatibility.
+    """
+    if state == 'gaming' and game_intensity == 'casual':
+        return 'open'
+    return state_to_propensity(state)
+
+
+# ── State + game tag → tone derivation ─────────────────────────────
+#
+# Tone is a single-axis style hint, derived from the combination of
+# state and (when gaming) intensity/genre. Kept here rather than in the
+# state machine because it's a pure mapping — no time/state evolution.
+# Tests can pin the table directly.
+#
+# Override priority (highest → lowest):
+#   1. state == 'voice_engaged'    → 'warm'  (voice flow trumps everything)
+#   2. state == 'private'          → 'concise' (won't be rendered anyway —
+#                                              propensity=closed gates first)
+#   3. state == 'gaming':
+#       intensity=competitive       → 'terse'
+#       intensity=immersive,
+#         genre=horror              → 'hushed'
+#       intensity=immersive,
+#         genre=other               → 'mellow'
+#       intensity=casual            → 'playful'
+#       intensity=varied / None     → 'concise' (conservative fallback)
+#   4. state == 'casual_browsing'  → 'playful'
+#   5. state == 'chatting'         → 'warm'
+#   6. state == 'stale_returning'  → 'warm' (greeting moment)
+#   7. state == 'focused_work'     → 'concise'
+#   8. state in {idle, transitioning, away} → 'concise' (default)
+def derive_tone(
+    state: ActivityState,
+    *,
+    game_intensity: GameIntensity | None = None,
+    game_genre: GameGenre | None = None,
+) -> ActivityTone:
+    """Pick the tone hint for the current activity context.
+
+    Pure function of inputs — no I/O, no time. Called from the state
+    machine on every snapshot construction, and from tests directly.
+    """
+    if state == 'voice_engaged':
+        return 'warm'
+    if state == 'private':
+        # Won't be rendered (closed propensity skips proactive entirely),
+        # but we return a value to keep the type total.
+        return 'concise'
+    if state == 'gaming':
+        if game_intensity == 'competitive':
+            return 'terse'
+        if game_intensity == 'immersive':
+            if game_genre == 'horror':
+                return 'hushed'
+            return 'mellow'
+        if game_intensity == 'casual':
+            return 'playful'
+        # game_intensity in {'varied', None}
+        return 'concise'
+    if state in ('casual_browsing',):
+        return 'playful'
+    if state in ('chatting', 'stale_returning'):
+        return 'warm'
+    # focused_work / idle / transitioning / away
+    return 'concise'
+
+
+# ── Default skip_probability for gaming subtypes ───────────────────
+#
+# Source: design doc + user direction (concise: competitive, immersive
+# horror are the only two non-zero defaults; casual/immersive_rpg/varied
+# all stay at 0). User can shift via ``skip_probability_overrides``
+# in preferences. Keys are gaming-only; non-gaming states always have
+# default 0 (skip is not a propensity-strength choice for non-game).
+_DEFAULT_GAMING_SKIP_PROB: dict[tuple[GameIntensity, str | None], float] = {
+    ('competitive', None):     0.3,   # Any competitive game (genre doesn't refine further)
+    ('immersive',   'horror'): 0.3,   # Atmospheric tension — interruption breaks immersion
+    ('immersive',   None):     0.0,   # RPG / story — propensity already restricts to screen
+    ('casual',      None):     0.0,   # Pause-anytime
+    ('varied',      None):     0.0,   # Unknown — don't make conservative guess any noisier
+}
+
+
+def derive_skip_probability(
+    state: ActivityState,
+    *,
+    game_intensity: GameIntensity | None = None,
+    game_genre: GameGenre | None = None,
+    overrides: dict[str, float] | None = None,
+) -> float:
+    """Pick the skip probability for the current activity context.
+
+    ``overrides`` is the user's per-combo dict from
+    ``activity_preferences.json::skip_probability_overrides``. Keys are
+    string combos like ``'competitive'`` (any genre), ``'immersive_horror'``
+    (intensity_genre with underscore), or ``'casual'``. Override values
+    in [0, 1] take precedence over defaults.
+    """
+    if state != 'gaming' or game_intensity is None:
+        return 0.0
+
+    # User override lookup — try most specific (intensity_genre) first
+    if overrides:
+        if game_genre and game_intensity != 'varied':
+            key_specific = f'{game_intensity}_{game_genre}'
+            if key_specific in overrides:
+                v = overrides[key_specific]
+                return max(0.0, min(1.0, float(v)))
+        if game_intensity in overrides:
+            v = overrides[game_intensity]
+            return max(0.0, min(1.0, float(v)))
+
+    # Default lookup — try genre-specific first, then intensity-only.
+    if game_genre and game_intensity != 'varied':
+        key = (game_intensity, game_genre)
+        if key in _DEFAULT_GAMING_SKIP_PROB:
+            return _DEFAULT_GAMING_SKIP_PROB[key]
+    return _DEFAULT_GAMING_SKIP_PROB.get((game_intensity, None), 0.0)
 
 
 # ── Localized strings for prompt injection ─────────────────────────
@@ -211,6 +448,7 @@ from config.prompts_activity import (
     ACTIVITY_REASON_TEMPLATES,
     ACTIVITY_STATE_LABELS,
     ACTIVITY_STATE_SECTION_LABELS,
+    ACTIVITY_TONE_HINTS,
     OS_DEGRADED_MARKER,
 )
 
@@ -309,6 +547,18 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
 
     # Line 1: state + propensity directive on a single line.
     lines.append(f"{snap.state}（{state_label}）→ {propensity_directive}")
+
+    # Line 1.5: tone hint (style modifier orthogonal to propensity).
+    # Skip rendering when the state would already be silenced (closed)
+    # or when tone is the safe default ``concise`` — saves a token line
+    # in the common case where there's nothing notable to say about
+    # voice. Renders as a single line: "口吻：{hint}".
+    if snap.propensity != 'closed' and snap.tone != 'concise':
+        tone_hints = ACTIVITY_TONE_HINTS.get(L, ACTIVITY_TONE_HINTS['en'])
+        tone_text = tone_hints.get(snap.tone)
+        if tone_text:
+            tone_label = labels.get('tone_label', 'tone')
+            lines.append(f"{tone_label}: {tone_text}")
 
     # Line 2: rule reasons (skip if empty — happens for unknown states).
     if snap.propensity_reasons:

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -180,7 +180,7 @@ class ActivitySnapshot:
     # active, the round is skipped entirely (no LLM call, no source fetch).
     # Default 0 means "always proceed". Defaults are derived from
     # (state, intensity, genre) by the state machine; user overrides via
-    # ``activity_preferences.json::skip_probability_overrides`` can tune
+    # ``user_preferences.json::__global_conversation__::activity::skip_probability_overrides`` can tune
     # them per-combo. Setting 1.0 = fully silent for that combo (user
     # opt-in "don't talk at all during X"); 0.0 = no skip, just rely on
     # propensity.
@@ -406,7 +406,7 @@ def derive_skip_probability(
     """Pick the skip probability for the current activity context.
 
     ``overrides`` is the user's per-combo dict from
-    ``activity_preferences.json::skip_probability_overrides``. Keys are
+    ``user_preferences.json::__global_conversation__::activity::skip_probability_overrides``. Keys are
     string combos like ``'competitive'`` (any genre), ``'immersive_horror'``
     (intensity_genre with underscore), or ``'casual'``. Override values
     in [0, 1] take precedence over defaults.

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -526,6 +526,18 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
     """
     if snap is None:
         return ''
+    # Defense in depth: when propensity is ``closed`` (currently emitted
+    # only by ``private`` state) emit nothing. Proactive chat already
+    # short-circuits on ``closed`` before reaching this formatter, but
+    # other consumers (debug logging, future side panels, prompt
+    # snapshotters) might pass a closed snapshot through. Rendering
+    # state name / reason templates / msg-recency / cached enrichment
+    # for a private snapshot would leak the fact that the user just
+    # opened a sensitive app — and potentially residual cached context
+    # from before that app opened. Empty string everywhere is the only
+    # leak-free contract.
+    if snap.propensity == 'closed':
+        return ''
     L = _normalize_lang(lang)
     labels = ACTIVITY_STATE_SECTION_LABELS.get(L, ACTIVITY_STATE_SECTION_LABELS['en'])
     state_label = ACTIVITY_STATE_LABELS.get(L, ACTIVITY_STATE_LABELS['en']).get(

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -570,9 +570,19 @@ class ActivityStateMachine:
 
         # Apply stale_returning override AFTER the bookkeeping so the
         # underlying state still advances (we want to know what state
-        # they "really" entered, just expose the stale window for prompt)
+        # they "really" entered, just expose the stale window for prompt).
+        # Two states are exempt:
+        #   * 'away' — obviously, we're transitioning OUT of away
+        #   * 'private' — privacy lockdown must remain ``closed``, not
+        #     downgrade to ``greeting_window``. If the user comes back
+        #     from being away with a password manager still foreground,
+        #     proactive chat must still hard-skip.
         effective_state: ActivityState = self._current_state
-        if ts < self._stale_returning_until and self._current_state != 'away':
+        if (
+            ts < self._stale_returning_until
+            and self._current_state != 'away'
+            and self._current_state != 'private'
+        ):
             effective_state = 'stale_returning'
 
         # Game tag pass-through is needed to resolve propensity for gaming

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -205,26 +205,18 @@ def _apply_user_overrides(
 ) -> ClassifyResult:
     """Patch a base classifier result with user-supplied overrides.
 
-    Override priority (highest → lowest):
-      1. ``user_app_overrides`` — process-name match (case-insensitive)
-      2. ``user_title_overrides`` — title-substring match (case-insensitive)
-      3. Static keyword DB result (already in ``result``)
-      4. ``user_game_overrides`` — patches intensity/genre on the
-         resolved canonical (only when category ends up as 'gaming')
+    Override semantics are **additive**, not overriding:
 
-    App / title overrides REPLACE the keyword classification (user wins
-    over static DB). Game overrides MERGE on top — they don't change
-    category/subcategory/canonical, only intensity/genre.
-
-    Override priority is **additive**, not overriding: app/title overrides
-    only fire when the static keyword DB returned ``unknown``. They
-    classify what the DB missed; they don't rewrite stable DB hits.
-    Privacy / own_app classifications are also locked, so a user override
-    of "work" on KeePass.exe stays as ``private``. Game
-    intensity/genre overrides are the one exception — they patch within
-    an existing gaming classification (don't change category, only
-    refine intensity/genre tags) and run regardless of static-locked
-    status because they're a different axis.
+      * ``user_app_overrides`` (process-name, case-insensitive) and
+        ``user_title_overrides`` (title-substring, case-insensitive) only
+        fire when the static keyword DB returned ``unknown``. They
+        classify what the DB missed; they never rewrite stable DB hits.
+      * Privacy / own_app classifications are locked — a user override
+        of "work" on KeePass.exe stays as ``private``.
+      * ``user_game_overrides`` is the one exception: it patches
+        intensity/genre on top of an existing gaming classification
+        (never changes category/subcategory/canonical) and runs
+        regardless of static-locked status because it's a different axis.
     """
     # Privacy + own-app guarantee — those are static-DB-only categories.
     # User overrides can't promote OR demote them (suppressed below).

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -922,9 +922,14 @@ class ActivityStateMachine:
         # supplementary context, never gates a state).
         if sys_snap and sys_snap.cpu_avg_30s > 70:
             reasons.append(('high_cpu', {'cpu_percent': int(sys_snap.cpu_avg_30s)}))
+        # Boundary: matches the classifier's ``>=`` at line 809 so a GPU
+        # value sitting exactly on the threshold gets the explanatory
+        # reason whenever it gets the gaming-by-GPU classification.
+        # Otherwise the prompt would see "user is gaming" without the
+        # GPU evidence sentence, which reads inconsistent.
         if (
             sys_snap and sys_snap.gpu_utilization is not None
-            and sys_snap.gpu_utilization > self._gaming_gpu_threshold_percent
+            and sys_snap.gpu_utilization >= self._gaming_gpu_threshold_percent
         ):
             reasons.append(('high_gpu', {'gpu_percent': int(sys_snap.gpu_utilization)}))
 

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -311,6 +311,16 @@ def observation_from_system(
         if result.category == 'unknown':
             # Fallback: title-only classification (Notion, Figma, etc.)
             result = classify_window_title(sys_snap.window_title)
+            # Privacy guard: a title-only ``private`` hit from inside a
+            # browser is almost always a false positive — marketing
+            # page ("Bitwarden Pricing"), docs ("KeePass User Guide"),
+            # blog posts about password managers, etc. Native private
+            # apps surface via the process_name match below; only those
+            # should drive the privacy lockdown. Demote the browser-tab
+            # title hit to ``unknown`` so we don't kill enrichment +
+            # proactive chat over what could be reading-about-security.
+            if result.category == 'private':
+                result = ClassifyResult('unknown', None, None)
     else:
         # Non-browser: try title first, then process name as fallback.
         result = classify_window_title(sys_snap.window_title)

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -41,14 +41,16 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from config.activity_keywords import (
-    classify_browser_title, classify_window_title, is_browser_process,
+    ClassifyResult, classify_browser_title, classify_window_title,
+    classify_process_name, is_browser_process,
 )
 
 from main_logic.activity.snapshot import (
-    ActivitySnapshot, ActivityState, UnfinishedThread, WindowObservation,
-    state_to_propensity,
+    ActivitySnapshot, ActivityState, GameGenre, GameIntensity, UnfinishedThread,
+    WindowObservation, derive_propensity, derive_skip_probability, derive_tone,
 )
 from main_logic.activity.system_signals import SystemSnapshot
+from utils.activity_config import ActivityPreferences, get_activity_preferences
 
 
 # ── Tunables ────────────────────────────────────────────────────────
@@ -196,13 +198,100 @@ def _hour_to_period(hour: int) -> str:
     return 'night'
 
 
-def observation_from_system(sys_snap: SystemSnapshot) -> WindowObservation | None:
+def _apply_user_overrides(
+    result: ClassifyResult,
+    sys_snap: SystemSnapshot,
+    prefs: ActivityPreferences,
+) -> ClassifyResult:
+    """Patch a base classifier result with user-supplied overrides.
+
+    Override priority (highest → lowest):
+      1. ``user_app_overrides`` — process-name match (case-insensitive)
+      2. ``user_title_overrides`` — title-substring match (case-insensitive)
+      3. Static keyword DB result (already in ``result``)
+      4. ``user_game_overrides`` — patches intensity/genre on the
+         resolved canonical (only when category ends up as 'gaming')
+
+    App / title overrides REPLACE the keyword classification (user wins
+    over static DB). Game overrides MERGE on top — they don't change
+    category/subcategory/canonical, only intensity/genre.
+
+    Privacy and own_app are special: they always come from the static DB
+    (the user shouldn't be able to mark KeePass as "work" — that defeats
+    the privacy guarantee). When the static DB result is already
+    ``private`` or ``own_app``, app/title overrides are SKIPPED so a
+    user override of "work" on KeePass.exe doesn't downgrade the privacy
+    classification. Game intensity/genre overrides are still applied
+    (those don't change category, only refine within gaming).
+    """
+    # Privacy + own-app guarantee — skip app/title overrides if the
+    # static DB already nailed this as one of those special categories.
+    static_locked = result.category in ('private', 'own_app')
+
+    # User app overrides — keyed by lowercased process name
+    if not static_locked and prefs.user_app_overrides and sys_snap.process_name:
+        key = sys_snap.process_name.lower()
+        # Try exact basename match (handles full paths)
+        basename = key.replace('\\', '/').rsplit('/', 1)[-1]
+        ov = prefs.user_app_overrides.get(basename) or prefs.user_app_overrides.get(key)
+        if ov is not None:
+            result = ClassifyResult(
+                category=ov.category,
+                subcategory=ov.subcategory,
+                canonical=ov.canonical or sys_snap.process_name,
+            )
+
+    # User title overrides — keyed by lowercased title substring.
+    # Same locked-categories guarantee.
+    if (
+        result.category == 'unknown'
+        and not static_locked
+        and prefs.user_title_overrides
+        and sys_snap.window_title
+    ):
+        title_low = sys_snap.window_title.lower()
+        for needle, ov in prefs.user_title_overrides.items():
+            if needle in title_low:
+                result = ClassifyResult(
+                    category=ov.category,
+                    subcategory=ov.subcategory,
+                    canonical=ov.canonical or sys_snap.window_title,
+                )
+                break
+
+    # Game intensity/genre override — patches on top of an existing
+    # gaming classification. Keyed by canonical name (case-sensitive)
+    # to match the keyword DB.
+    if (
+        result.category == 'gaming'
+        and result.subcategory == 'game'
+        and result.canonical
+        and prefs.user_game_overrides
+    ):
+        ov = prefs.user_game_overrides.get(result.canonical)
+        if ov is not None:
+            result = ClassifyResult(
+                category=result.category,
+                subcategory=result.subcategory,
+                canonical=result.canonical,
+                intensity=ov.intensity if ov.intensity is not None else result.intensity,
+                genre=ov.genre if ov.genre is not None else result.genre,
+            )
+
+    return result
+
+
+def observation_from_system(
+    sys_snap: SystemSnapshot,
+    prefs: ActivityPreferences | None = None,
+) -> WindowObservation | None:
     """Build a ``WindowObservation`` from a raw ``SystemSnapshot``.
 
     Browser windows are routed to the domain table first (page URL/title
     is more telling than the bare browser name) with title-table
     fallback for branded SaaS apps where the title surfaces the app name
-    rather than the domain (e.g. "Notion").
+    rather than the domain (e.g. "Notion"). User overrides from
+    ``ActivityPreferences`` apply on top of the static keyword DB.
     """
     if sys_snap.window_title is None and sys_snap.process_name is None:
         return None
@@ -217,8 +306,10 @@ def observation_from_system(sys_snap: SystemSnapshot) -> WindowObservation | Non
         # Non-browser: try title first, then process name as fallback.
         result = classify_window_title(sys_snap.window_title)
         if result.category == 'unknown':
-            from config.activity_keywords import classify_process_name
             result = classify_process_name(sys_snap.process_name)
+
+    if prefs is not None:
+        result = _apply_user_overrides(result, sys_snap, prefs)
 
     return WindowObservation(
         process_name=sys_snap.process_name,
@@ -227,6 +318,8 @@ def observation_from_system(sys_snap: SystemSnapshot) -> WindowObservation | Non
         subcategory=result.subcategory,
         canonical=result.canonical,
         is_browser=is_browser,
+        intensity=result.intensity,
+        genre=result.genre,
     )
 
 
@@ -257,7 +350,54 @@ class ActivityStateMachine:
         snap = sm.get_snapshot(now=time.time())
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, prefs: ActivityPreferences | None = None) -> None:
+        # Resolve preferences once at construction. Threshold overrides are
+        # applied as instance attributes; user override dicts stay live on
+        # ``self._prefs`` for runtime lookup (the loader has its own
+        # mtime-based cache, so re-fetching from prefs every call is fine).
+        if prefs is None:
+            prefs = get_activity_preferences()
+        self._prefs = prefs
+        self._away_idle_seconds = prefs.thresholds.get(
+            'away_idle_seconds', AWAY_IDLE_SECONDS,
+        )
+        self._stale_recovery_seconds = prefs.thresholds.get(
+            'stale_recovery_seconds', STALE_RECOVERY_SECONDS,
+        )
+        self._voice_active_window_seconds = prefs.thresholds.get(
+            'voice_active_window_seconds', VOICE_ACTIVE_WINDOW_SECONDS,
+        )
+        self._focused_work_min_dwell_seconds = prefs.thresholds.get(
+            'focused_work_min_dwell_seconds', FOCUSED_WORK_MIN_DWELL_SECONDS,
+        )
+        self._focused_work_recent_input_seconds = prefs.thresholds.get(
+            'focused_work_recent_input_seconds', FOCUSED_WORK_RECENT_INPUT_SECONDS,
+        )
+        self._casual_browsing_min_dwell_seconds = prefs.thresholds.get(
+            'casual_browsing_min_dwell_seconds', CASUAL_BROWSING_MIN_DWELL_SECONDS,
+        )
+        self._window_switch_transition_threshold = int(prefs.thresholds.get(
+            'window_switch_transition_threshold', WINDOW_SWITCH_TRANSITION_THRESHOLD,
+        ))
+        self._window_history_lookback_seconds = prefs.thresholds.get(
+            'window_history_lookback_seconds', WINDOW_HISTORY_LOOKBACK_SECONDS,
+        )
+        self._transition_recent_window_seconds = prefs.thresholds.get(
+            'transition_recent_window_seconds', TRANSITION_RECENT_WINDOW_SECONDS,
+        )
+        self._unfinished_thread_window_seconds = prefs.thresholds.get(
+            'unfinished_thread_window_seconds', UNFINISHED_THREAD_WINDOW_SECONDS,
+        )
+        self._unfinished_thread_max_followups = int(prefs.thresholds.get(
+            'unfinished_thread_max_followups', UNFINISHED_THREAD_MAX_FOLLOWUPS,
+        ))
+        self._gaming_gpu_threshold_percent = prefs.thresholds.get(
+            'gaming_gpu_threshold_percent', GAMING_GPU_THRESHOLD_PERCENT,
+        )
+        self._gaming_gpu_max_idle_seconds = prefs.thresholds.get(
+            'gaming_gpu_max_idle_seconds', GAMING_GPU_MAX_IDLE_SECONDS,
+        )
+
         self._current_state: ActivityState = 'idle'
         self._previous_state: ActivityState | None = None
         self._state_started_at: float = time.time()
@@ -299,10 +439,40 @@ class ActivityStateMachine:
         Identical-category consecutive observations are collapsed —
         the dwell timer keeps running. A category change (e.g.
         work → entertainment) starts a fresh dwell timer.
+
+        Special handling:
+          * ``own_app`` (catgirl app itself in foreground) — observation
+            is discarded entirely. Window tracking pretends nothing
+            happened so dwell on the previous app keeps accumulating
+            and GPU fallback gaming doesn't trip on the catgirl's own
+            Live2D / VRM rendering.
+          * ``private`` — observation IS recorded (state classifier
+            needs to see it to emit state='private'), but title /
+            process_name fields are scrubbed before storing so the
+            sensitive content never reaches downstream consumers
+            (prompt rendering, LLM enrichment, conversation buffers).
         """
         if obs is None:
             return
         ts = now if now is not None else time.time()
+
+        if obs.category == 'own_app':
+            return  # transparent — no window update, no history entry
+
+        if obs.category == 'private':
+            # Sanitize: keep category + canonical (user/AI sees just
+            # "private app foreground"), drop title/process — those are
+            # the leaky bits.
+            obs = WindowObservation(
+                process_name=None,
+                title=None,
+                category='private',
+                subcategory=None,
+                canonical=obs.canonical or '[private]',
+                is_browser=False,
+                intensity=None,
+                genre=None,
+            )
 
         prev = self._current_window
         same = (
@@ -394,7 +564,7 @@ class ActivityStateMachine:
             self._previous_state = self._current_state
             # Stale-recovery trigger: leaving 'away' for anything else.
             if self._current_state == 'away' and new_state != 'away':
-                self._stale_returning_until = ts + STALE_RECOVERY_SECONDS
+                self._stale_returning_until = ts + self._stale_recovery_seconds
             self._current_state = new_state
             self._state_started_at = ts
 
@@ -405,16 +575,38 @@ class ActivityStateMachine:
         if ts < self._stale_returning_until and self._current_state != 'away':
             effective_state = 'stale_returning'
 
-        propensity = state_to_propensity(effective_state)
+        # Game tag pass-through is needed to resolve propensity for gaming
+        # subtypes (casual → open). Compute it here BEFORE the propensity
+        # lookup; the full assignment to game_intensity / game_genre
+        # comes after active_window resolution below.
+        _pre_intensity: GameIntensity | None = None
+        _pre_genre: GameGenre | None = None
+        if (
+            effective_state == 'gaming'
+            and self._current_window is not None
+        ):
+            _pre_intensity = self._current_window.intensity  # type: ignore[assignment]
+            _pre_genre = self._current_window.genre  # type: ignore[assignment]
+
+        propensity = derive_propensity(
+            effective_state,
+            game_intensity=_pre_intensity,
+            game_genre=_pre_genre,
+        )
         reasons = self._build_propensity_reasons(effective_state, ts)
 
-        # Window observation summary
+        # Window observation summary. For ``private`` state we redact
+        # active_window entirely — even the sanitized canonical we kept
+        # internally for state-machine bookkeeping shouldn't ride out
+        # to the prompt or LLM enrichment.
         active_window = self._current_window
+        if effective_state == 'private':
+            active_window = None
 
         # Switch rate over the lookback window
         switch_rate = sum(
             1 for entry in self._window_history
-            if ts - entry.timestamp <= WINDOW_HISTORY_LOOKBACK_SECONDS
+            if ts - entry.timestamp <= self._window_history_lookback_seconds
         )
 
         sys_snap = self._latest_system
@@ -431,7 +623,7 @@ class ActivityStateMachine:
 
         voice_recent = (
             self._voice_mode_active
-            and (ts - self._voice_last_rms_at) < VOICE_ACTIVE_WINDOW_SECONDS
+            and (ts - self._voice_last_rms_at) < self._voice_active_window_seconds
         )
 
         # Time context
@@ -439,25 +631,45 @@ class ActivityStateMachine:
         period = _hour_to_period(local.hour)
 
         transitioned_recently = (
-            ts - self._state_started_at <= TRANSITION_RECENT_WINDOW_SECONDS
+            ts - self._state_started_at <= self._transition_recent_window_seconds
             and self._previous_state is not None
         )
 
-        # Unfinished thread: surface it if still within the 5-min window
+        # Unfinished thread: surface it if still within the window
         # and under the follow-up cap. Past the window, retire the record
         # so future ticks don't keep evaluating the same expired data.
         unfinished = None
         if self._unfinished_thread is not None:
             age = ts - self._unfinished_thread['started_at']
-            if age > UNFINISHED_THREAD_WINDOW_SECONDS:
+            if age > self._unfinished_thread_window_seconds:
                 self._unfinished_thread = None
-            elif self._unfinished_thread['follow_up_count'] < UNFINISHED_THREAD_MAX_FOLLOWUPS:
+            elif self._unfinished_thread['follow_up_count'] < self._unfinished_thread_max_followups:
                 unfinished = UnfinishedThread(
                     text=self._unfinished_thread['tail'],
                     age_seconds=age,
                     follow_up_count=self._unfinished_thread['follow_up_count'],
-                    max_follow_ups=UNFINISHED_THREAD_MAX_FOLLOWUPS,
+                    max_follow_ups=self._unfinished_thread_max_followups,
                 )
+
+        # Game tags are resolved earlier (pre-propensity); reuse them
+        # here for the snapshot fields. Active_window may have been
+        # redacted by the private branch — but private and gaming are
+        # mutually exclusive states, so nothing's lost.
+        game_intensity: GameIntensity | None = _pre_intensity
+        game_genre: GameGenre | None = _pre_genre
+
+        # Tone + skip probability — pure derivation from above.
+        tone = derive_tone(
+            effective_state,
+            game_intensity=game_intensity,
+            game_genre=game_genre,
+        )
+        skip_probability = derive_skip_probability(
+            effective_state,
+            game_intensity=game_intensity,
+            game_genre=game_genre,
+            overrides=self._prefs.skip_probability_overrides or None,
+        )
 
         return ActivitySnapshot(
             state=effective_state,
@@ -467,6 +679,10 @@ class ActivityStateMachine:
             stale_returning=(ts < self._stale_returning_until and self._current_state != 'away'),
             propensity=propensity,
             propensity_reasons=reasons,
+            skip_probability=skip_probability,
+            tone=tone,
+            game_intensity=game_intensity,
+            game_genre=game_genre,
             system_idle_seconds=idle_seconds,
             cpu_avg_30s=cpu_avg,
             cpu_instant=cpu_now,
@@ -491,25 +707,34 @@ class ActivityStateMachine:
 
         # 1. away — system-wide input idle dominates everything else.
         # OS idle is the only signal that survives the user walking away.
-        if sys_snap is not None and sys_snap.idle_seconds >= AWAY_IDLE_SECONDS:
+        # ``private`` deliberately does NOT win here: a privacy-app
+        # window left open while the user walked away is just an idle
+        # situation; nobody's looking at the secrets right now.
+        if sys_snap is not None and sys_snap.idle_seconds >= self._away_idle_seconds:
             return 'away'
 
-        # 2. voice_engaged — voice mode + recent RMS activity is the
+        # 2. private — sensitive app foreground, user actively present.
+        # Wins above voice/gaming/work/etc so the AI never proactively
+        # speaks while the password manager / banking app is up.
+        win = self._current_window
+        if win is not None and win.category == 'private':
+            return 'private'
+
+        # 3. voice_engaged — voice mode + recent RMS activity is the
         # strongest "in active conversation" signal we have.
         if (
             self._voice_mode_active
-            and (now - self._voice_last_rms_at) < VOICE_ACTIVE_WINDOW_SECONDS
+            and (now - self._voice_last_rms_at) < self._voice_active_window_seconds
         ):
             return 'voice_engaged'
 
-        # 3. gaming — actual game (subcategory='game') in foreground.
+        # 4. gaming — actual game (subcategory='game') in foreground.
         # Launchers ('subcategory'='launcher') are intentionally NOT here:
         # browsing the Steam store doesn't mean "playing".
-        win = self._current_window
         if win is not None and win.category == 'gaming' and win.subcategory == 'game':
             return 'gaming'
 
-        # 3b. gaming-by-GPU fallback. Catches small / indie / new titles
+        # 4b. gaming-by-GPU fallback. Catches small / indie / new titles
         # not yet in the keyword DB. Gates:
         #   - active window category MUST be 'unknown' — never override
         #     work/communication/entertainment classifications, those are
@@ -518,55 +743,58 @@ class ActivityStateMachine:
         #   - User actually present (input within last minute) — long-idle
         #     high GPU is usually background rendering or AFK farming, not
         #     active engagement we should hesitate to interrupt.
+        # Own-app foreground was already filtered upstream in update_window
+        # (no observation recorded), so the catgirl's own GPU usage doesn't
+        # reach this branch.
         if (
             win is not None and win.category == 'unknown'
             and sys_snap is not None and sys_snap.gpu_utilization is not None
-            and sys_snap.gpu_utilization >= GAMING_GPU_THRESHOLD_PERCENT
-            and sys_snap.idle_seconds <= GAMING_GPU_MAX_IDLE_SECONDS
+            and sys_snap.gpu_utilization >= self._gaming_gpu_threshold_percent
+            and sys_snap.idle_seconds <= self._gaming_gpu_max_idle_seconds
         ):
             return 'gaming'
 
-        # 4. focused_work — work-category window with sustained dwell AND
+        # 5. focused_work — work-category window with sustained dwell AND
         # recent input. The combo is what filters out "left VS Code open
         # while watching YouTube in another monitor" cases.
         if win is not None and win.category == 'work':
             dwell = now - self._current_window_started_at
             recent_input = (
                 self._last_user_msg_at is not None
-                and (now - self._last_user_msg_at) <= FOCUSED_WORK_RECENT_INPUT_SECONDS
+                and (now - self._last_user_msg_at) <= self._focused_work_recent_input_seconds
             )
             recent_system_active = (
                 sys_snap is not None
-                and sys_snap.idle_seconds < FOCUSED_WORK_RECENT_INPUT_SECONDS
+                and sys_snap.idle_seconds < self._focused_work_recent_input_seconds
             )
-            if dwell >= FOCUSED_WORK_MIN_DWELL_SECONDS and (recent_input or recent_system_active):
+            if dwell >= self._focused_work_min_dwell_seconds and (recent_input or recent_system_active):
                 return 'focused_work'
 
-        # 5. casual_browsing — entertainment dominates with reasonable dwell.
+        # 6. casual_browsing — entertainment dominates with reasonable dwell.
         if win is not None and win.category == 'entertainment':
             dwell = now - self._current_window_started_at
-            if dwell >= CASUAL_BROWSING_MIN_DWELL_SECONDS:
+            if dwell >= self._casual_browsing_min_dwell_seconds:
                 return 'casual_browsing'
 
-        # 6. chatting — communication app in foreground. We deliberately
+        # 7. chatting — communication app in foreground. We deliberately
         # do NOT gate on "low CPU" per the user's instruction (signal
         # too unreliable). A short dwell is fine — chat windows are
         # small, often briefly raised to read a message.
         if win is not None and win.category == 'communication':
             return 'chatting'
 
-        # 7. transitioning — no clear category dominates AND there's been
+        # 8. transitioning — no clear category dominates AND there's been
         # a flurry of window switches recently. Note this still produces
         # ``open`` propensity (per user clarification — screen channel
         # always allowed); only the source-weight layer should care.
         switches = sum(
             1 for entry in self._window_history
-            if now - entry.timestamp <= WINDOW_HISTORY_LOOKBACK_SECONDS
+            if now - entry.timestamp <= self._window_history_lookback_seconds
         )
-        if switches >= WINDOW_SWITCH_TRANSITION_THRESHOLD:
+        if switches >= self._window_switch_transition_threshold:
             return 'transitioning'
 
-        # 8. idle — at the computer (not away) but no clear bucket.
+        # 9. idle — at the computer (not away) but no clear bucket.
         return 'idle'
 
     # ── reason strings (for prompt + debugging) ──────────────────
@@ -623,6 +851,8 @@ class ActivityStateMachine:
             reasons.append(('state_transitioning', {}))
         elif state == 'idle':
             reasons.append(('state_idle', {}))
+        elif state == 'private':
+            reasons.append(('state_private', {}))
 
         # CPU / GPU augmentations — appended only when notably high so
         # we don't add noise to the typical case.

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -216,20 +216,29 @@ def _apply_user_overrides(
     over static DB). Game overrides MERGE on top — they don't change
     category/subcategory/canonical, only intensity/genre.
 
-    Privacy and own_app are special: they always come from the static DB
-    (the user shouldn't be able to mark KeePass as "work" — that defeats
-    the privacy guarantee). When the static DB result is already
-    ``private`` or ``own_app``, app/title overrides are SKIPPED so a
-    user override of "work" on KeePass.exe doesn't downgrade the privacy
-    classification. Game intensity/genre overrides are still applied
-    (those don't change category, only refine within gaming).
+    Override priority is **additive**, not overriding: app/title overrides
+    only fire when the static keyword DB returned ``unknown``. They
+    classify what the DB missed; they don't rewrite stable DB hits.
+    Privacy / own_app classifications are also locked, so a user override
+    of "work" on KeePass.exe stays as ``private``. Game
+    intensity/genre overrides are the one exception — they patch within
+    an existing gaming classification (don't change category, only
+    refine intensity/genre tags) and run regardless of static-locked
+    status because they're a different axis.
     """
-    # Privacy + own-app guarantee — skip app/title overrides if the
-    # static DB already nailed this as one of those special categories.
+    # Privacy + own-app guarantee — those are static-DB-only categories.
+    # User overrides can't promote OR demote them (suppressed below).
     static_locked = result.category in ('private', 'own_app')
 
-    # User app overrides — keyed by lowercased process name
-    if not static_locked and prefs.user_app_overrides and sys_snap.process_name:
+    # User app overrides — keyed by lowercased process name. Only fire
+    # when static result is 'unknown' (consistent with title overrides
+    # and the additive design rule).
+    if (
+        result.category == 'unknown'
+        and not static_locked
+        and prefs.user_app_overrides
+        and sys_snap.process_name
+    ):
         key = sys_snap.process_name.lower()
         # Try exact basename match (handles full paths)
         basename = key.replace('\\', '/').rsplit('/', 1)[-1]
@@ -242,7 +251,7 @@ def _apply_user_overrides(
             )
 
     # User title overrides — keyed by lowercased title substring.
-    # Same locked-categories guarantee.
+    # Same additive rule as app overrides.
     if (
         result.category == 'unknown'
         and not static_locked
@@ -903,10 +912,20 @@ class ActivityStateMachine:
             reasons.append(('state_private', {}))
 
         # CPU / GPU augmentations — appended only when notably high so
-        # we don't add noise to the typical case.
+        # we don't add noise to the typical case. GPU threshold reuses
+        # ``self._gaming_gpu_threshold_percent`` so the reason text and
+        # the gaming-by-GPU classifier always agree on "is GPU notable";
+        # otherwise a user lifting / lowering the gaming threshold would
+        # see prompt explanations disagree with state decisions.
+        # CPU reason stays at the hardcoded 70 — there's no per-instance
+        # CPU threshold to thread through (CPU only ever shows up as
+        # supplementary context, never gates a state).
         if sys_snap and sys_snap.cpu_avg_30s > 70:
             reasons.append(('high_cpu', {'cpu_percent': int(sys_snap.cpu_avg_30s)}))
-        if sys_snap and sys_snap.gpu_utilization is not None and sys_snap.gpu_utilization > 60:
+        if (
+            sys_snap and sys_snap.gpu_utilization is not None
+            and sys_snap.gpu_utilization > self._gaming_gpu_threshold_percent
+        ):
             reasons.append(('high_gpu', {'gpu_percent': int(sys_snap.gpu_utilization)}))
 
         return reasons

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -395,9 +395,30 @@ class ActivityStateMachine:
         self._casual_browsing_min_dwell_seconds = prefs.thresholds.get(
             'casual_browsing_min_dwell_seconds', CASUAL_BROWSING_MIN_DWELL_SECONDS,
         )
-        self._window_switch_transition_threshold = int(prefs.thresholds.get(
-            'window_switch_transition_threshold', WINDOW_SWITCH_TRANSITION_THRESHOLD,
-        ))
+        # Count-shaped thresholds need integer semantics — bare ``int(...)``
+        # would silently truncate ``0.9`` → ``0`` or ``1.7`` → ``1``,
+        # producing surprising behaviour (transitioning never trips,
+        # unfinished_thread_max_followups gets capped at 1 instead of 2).
+        # ``_parse_thresholds`` only validates "positive number", not
+        # "integer", so a typo'd float in user_preferences.json reaches
+        # this point. Reject non-integer floats and fall back to the
+        # default rather than silently rounding.
+        def _int_threshold(name: str, default: int) -> int:
+            raw = prefs.thresholds.get(name)
+            if raw is None or isinstance(raw, bool):
+                return default
+            try:
+                if not float(raw).is_integer():
+                    return default
+            except (TypeError, ValueError):
+                return default
+            value = int(raw)
+            return value if value >= 1 else default
+
+        self._window_switch_transition_threshold = _int_threshold(
+            'window_switch_transition_threshold',
+            WINDOW_SWITCH_TRANSITION_THRESHOLD,
+        )
         self._window_history_lookback_seconds = prefs.thresholds.get(
             'window_history_lookback_seconds', WINDOW_HISTORY_LOOKBACK_SECONDS,
         )
@@ -407,9 +428,10 @@ class ActivityStateMachine:
         self._unfinished_thread_window_seconds = prefs.thresholds.get(
             'unfinished_thread_window_seconds', UNFINISHED_THREAD_WINDOW_SECONDS,
         )
-        self._unfinished_thread_max_followups = int(prefs.thresholds.get(
-            'unfinished_thread_max_followups', UNFINISHED_THREAD_MAX_FOLLOWUPS,
-        ))
+        self._unfinished_thread_max_followups = _int_threshold(
+            'unfinished_thread_max_followups',
+            UNFINISHED_THREAD_MAX_FOLLOWUPS,
+        )
         self._gaming_gpu_threshold_percent = prefs.thresholds.get(
             'gaming_gpu_threshold_percent', GAMING_GPU_THRESHOLD_PERCENT,
         )

--- a/main_logic/activity/state_machine.py
+++ b/main_logic/activity/state_machine.py
@@ -431,6 +431,17 @@ class ActivityStateMachine:
         # detects the 5-minute window has expired.
         self._unfinished_thread: dict | None = None
 
+        # Own-app dwell freeze. When the catgirl app is in the foreground,
+        # ``update_window`` early-returns so the previous app stays the
+        # active window — but the previous app's dwell timer would
+        # otherwise keep ticking, so a brief glance at the catgirl could
+        # artificially push the prior window past dwell thresholds (e.g.
+        # focused_work's 90s). On entering own_app we record the freeze
+        # start; on the next non-own-app observation we advance
+        # ``_current_window_started_at`` by the freeze duration, so dwell
+        # only counts time the user spent on non-own-app windows.
+        self._own_app_freeze_started_at: float | None = None
+
     # ── update inputs ────────────────────────────────────────────
 
     def update_window(self, obs: WindowObservation | None, *, now: float | None = None) -> None:
@@ -457,7 +468,22 @@ class ActivityStateMachine:
         ts = now if now is not None else time.time()
 
         if obs.category == 'own_app':
-            return  # transparent — no window update, no history entry
+            # Transparent: previous window stays the active observation.
+            # Record the freeze entry time so the next non-own-app
+            # observation can subtract own-app time from dwell.
+            if self._own_app_freeze_started_at is None:
+                self._own_app_freeze_started_at = ts
+            return
+
+        # Resume from own-app freeze: advance the dwell start by the
+        # time spent in own_app so the previous (or new) window's dwell
+        # only counts non-own-app time. Done unconditionally on the
+        # first non-own-app observation following an own_app stretch —
+        # if this observation is a category change, the assignment to
+        # _current_window_started_at below will overwrite it (harmless).
+        if self._own_app_freeze_started_at is not None:
+            self._current_window_started_at += (ts - self._own_app_freeze_started_at)
+            self._own_app_freeze_started_at = None
 
         if obs.category == 'private':
             # Sanitize: keep category + canonical (user/AI sees just
@@ -475,11 +501,20 @@ class ActivityStateMachine:
             )
 
         prev = self._current_window
+        # Include intensity / genre in the equivalence check: when a user
+        # hot-reloads ``user_game_overrides`` while the same game stays
+        # foreground, the new observation has identical
+        # category/subcategory/canonical but different intensity/genre.
+        # Without these in the check, the collapse logic treats it as
+        # "same window" → propensity / skip_probability / tone keep
+        # using the old tags until the user actually switches windows.
         same = (
             prev is not None
             and prev.category == obs.category
             and prev.subcategory == obs.subcategory
             and (prev.canonical or '') == (obs.canonical or '')
+            and prev.intensity == obs.intensity
+            and prev.genre == obs.genre
         )
         if not same:
             self._current_window = obs
@@ -533,14 +568,17 @@ class ActivityStateMachine:
 
         Called by the proactive chat path after a successful emission
         when the snapshot's ``unfinished_thread`` was active. Once the
-        counter reaches ``UNFINISHED_THREAD_MAX_FOLLOWUPS``, subsequent
-        snapshots will hide the thread from the prompt — so the AI gets
-        at most that many follow-up attempts without a user reply.
+        counter reaches ``self._unfinished_thread_max_followups``,
+        subsequent snapshots will hide the thread from the prompt — so
+        the AI gets at most that many follow-up attempts without a user
+        reply. Honors the per-instance threshold loaded from
+        ``ActivityPreferences.thresholds`` rather than the module
+        constant, so user tuning actually takes effect here.
         """
         if self._unfinished_thread is None:
             return
         self._unfinished_thread['follow_up_count'] += 1
-        if self._unfinished_thread['follow_up_count'] >= UNFINISHED_THREAD_MAX_FOLLOWUPS:
+        if self._unfinished_thread['follow_up_count'] >= self._unfinished_thread_max_followups:
             # Cap reached — drop entirely so we don't keep allocating
             # state for a thread that can no longer be surfaced.
             self._unfinished_thread = None

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -297,7 +297,10 @@ class UserActivityTracker:
         (a one-shot ``await`` on first call). Subsequent calls are
         effectively synchronous. The returned snapshot has cached
         emotion-tier enrichment fields (``activity_scores``,
-        ``activity_guess``, ``open_threads``) merged in.
+        ``activity_guess``, ``open_threads``) merged in — except when
+        the resolved state is ``private``, in which case enrichment
+        is suppressed (LLM input + cached output both bypassed) so the
+        user's secret context never reaches the model.
         """
         await self._ensure_collector_started()
 
@@ -305,9 +308,25 @@ class UserActivityTracker:
 
         sys_snap = self._select_system_snapshot(ts)
         self._sm.update_system(sys_snap)
-        self._sm.update_window(observation_from_system(sys_snap), now=ts)
+        self._sm.update_window(
+            observation_from_system(sys_snap, self._sm._prefs),
+            now=ts,
+        )
 
         snap = self._sm.get_snapshot(now=ts)
+        if snap.state == 'private':
+            # Privacy lockdown — explicitly empty enrichment fields rather
+            # than splicing in caches built from earlier (non-private)
+            # state. Even though state machine drops the title/process
+            # at update_window, the cached enrichment narrative might
+            # still reference what the user was doing 30s ago, which
+            # could leak intent ("master is logging into bank...").
+            return dc_replace(
+                snap,
+                activity_scores={},
+                activity_guess='',
+                open_threads=[],
+            )
         # Patch in emotion-tier enrichment caches. ``snap`` is a frozen
         # dataclass; ``replace`` returns a new instance without mutating
         # the original. Callers always get a self-consistent snapshot.
@@ -325,7 +344,7 @@ class UserActivityTracker:
         the collector-start guard — callers must ensure collection is
         running, or accept that ``SystemSnapshot`` defaults will be in
         play. Enrichment caches are merged in the same way as
-        ``get_snapshot``.
+        ``get_snapshot``, with the same private-state suppression.
         """
         ts = now if now is not None else time.time()
         # Use _select_system_snapshot to honour frontend-pushed signals
@@ -334,8 +353,18 @@ class UserActivityTracker:
         # in sync callers.
         sys_snap = self._select_system_snapshot(ts)
         self._sm.update_system(sys_snap)
-        self._sm.update_window(observation_from_system(sys_snap), now=ts)
+        self._sm.update_window(
+            observation_from_system(sys_snap, self._sm._prefs),
+            now=ts,
+        )
         snap = self._sm.get_snapshot(now=ts)
+        if snap.state == 'private':
+            return dc_replace(
+                snap,
+                activity_scores={},
+                activity_guess='',
+                open_threads=[],
+            )
         return dc_replace(
             snap,
             activity_scores=dict(self._activity_scores_cache),
@@ -355,14 +384,22 @@ class UserActivityTracker:
         on its previous value (potentially empty), which the prompt
         formatter renders or omits accordingly.
 
-        Idempotent in three useful ways:
+        Idempotent in four useful ways:
+          * If the rule state is currently ``private`` → skip (no LLM
+            calls during privacy lockdown — even the conversation
+            buffer might reference sensitive context that was just
+            mentioned).
           * If the cache seq matches the current user-message seq, no
             new user has spoken since last compute → skip.
           * If a previous task is still running → skip (don't queue).
           * If conversation buffers are empty → skip (nothing to score).
         """
-        # 隐私模式下整个 enrichment 通路都关掉。
-        if _privacy_mode_active():
+        # Two privacy gates, OR'd: user-toggled "privacy mode" disables
+        # the entire tracker (PR #1024); static-DB ``private`` state means
+        # a sensitive app (KeePass etc) is foreground right now even while
+        # the user has the tracker on. Either condition skips enrichment
+        # — cheap O(1) checks, safe under sync callers.
+        if _privacy_mode_active() or self._sm._current_state == 'private':
             return
         if self._open_threads_computed_at_seq == self._conv_seq:
             return
@@ -446,11 +483,22 @@ class UserActivityTracker:
                 ts = time.time()
                 sys_snap = self._select_system_snapshot(ts)
                 self._sm.update_system(sys_snap)
-                self._sm.update_window(observation_from_system(sys_snap), now=ts)
+                self._sm.update_window(
+                    observation_from_system(sys_snap, self._sm._prefs),
+                    now=ts,
+                )
                 rule_snap = self._sm.get_snapshot(now=ts)
 
                 # Bail on away — nothing useful to narrate.
                 if rule_snap.state == 'away':
+                    continue
+
+                # Bail on private — explicitly do NOT send sensitive app
+                # context (or even surrounding conversation) to the
+                # emotion-tier LLM. Existing cached values stay frozen
+                # until the user leaves the private app; on resume the
+                # state-signature dedup will refresh naturally.
+                if rule_snap.state == 'private':
                     continue
 
                 # Anti-thrash: respect the minimum refresh interval.

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -47,6 +47,7 @@ from main_logic.activity.state_machine import (
 from main_logic.activity.system_signals import (
     SystemSignalCollector, SystemSnapshot, get_system_signal_collector,
 )
+from utils.activity_config import get_activity_preferences
 
 logger = logging.getLogger(__name__)
 
@@ -303,6 +304,7 @@ class UserActivityTracker:
         user's secret context never reaches the model.
         """
         await self._ensure_collector_started()
+        self._refresh_prefs()
 
         ts = now if now is not None else time.time()
 
@@ -346,6 +348,7 @@ class UserActivityTracker:
         play. Enrichment caches are merged in the same way as
         ``get_snapshot``, with the same private-state suppression.
         """
+        self._refresh_prefs()
         ts = now if now is not None else time.time()
         # Use _select_system_snapshot to honour frontend-pushed signals
         # exactly like the async path — otherwise remote deployments
@@ -564,6 +567,29 @@ class UserActivityTracker:
             except Exception as e:
                 # Stay alive — one bad tick shouldn't kill the loop.
                 logger.debug('[%s] activity_guess loop tick failed: %s', self.lanlan_name, e)
+
+    def _refresh_prefs(self) -> None:
+        """Pick up live edits to ``user_preferences.json::activity``.
+
+        The preferences loader has its own mtime-based 30s cache, so this
+        is cheap (one lock acquisition + identity compare in the common
+        path). When the cache reloads, we swap the new prefs into the
+        state machine so override lookups (``user_app_overrides`` /
+        ``user_title_overrides`` / ``user_game_overrides`` /
+        ``skip_probability_overrides``) reflect the user's current
+        config without requiring a session restart.
+
+        Threshold values (``away_idle_seconds``, etc.) are intentionally
+        NOT re-derived: those are read into instance attributes at
+        ``ActivityStateMachine.__init__`` and stay frozen for the
+        session. Treating thresholds as session-stable while overrides
+        are live is the deliberate split — thresholds are tuning
+        constants people set once, overrides are how users react to a
+        misclassification right now.
+        """
+        fresh = get_activity_preferences()
+        if fresh is not self._sm._prefs:
+            self._sm._prefs = fresh
 
     def _select_system_snapshot(self, now: float) -> SystemSnapshot:
         """Pick external (frontend-pushed) snapshot when fresh, else local.

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -3381,10 +3381,61 @@ async def proactive_chat(request: Request):
             try:
                 activity_snapshot = await mgr._activity_tracker.get_snapshot()
                 print(f"[{lanlan_name}] activity snapshot: state={activity_snapshot.state} "
-                      f"propensity={activity_snapshot.propensity} reasons={activity_snapshot.propensity_reasons}")
+                      f"propensity={activity_snapshot.propensity} reasons={activity_snapshot.propensity_reasons} "
+                      f"skip_prob={activity_snapshot.skip_probability:.2f} tone={activity_snapshot.tone}")
             except Exception as _act_err:
                 logger.warning(f"[{lanlan_name}] activity snapshot fetch failed: {_act_err}; falling back to open propensity")
                 activity_snapshot = None
+
+        # ========== Hard short-circuit: propensity=closed ==========
+        # ``private`` state pins propensity to ``closed`` (see
+        # main_logic/activity/snapshot.py). Skip everything — no LLM,
+        # no source fetch, no prompt assembly. The user is in a
+        # password manager / banking app / etc and we promised not to
+        # look. Bypassed for the unfinished_thread override is
+        # deliberate: if the AI just asked a question, hanging on it
+        # mid-private is rude. closed > thread.
+        if activity_snapshot is not None and activity_snapshot.propensity == 'closed':
+            print(f"[{lanlan_name}] propensity=closed (state={activity_snapshot.state}), 跳过本轮 proactive")
+            return await _end_proactive(JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": f"user state={activity_snapshot.state} → closed (privacy lockdown)",
+            }))
+
+        # ========== Probabilistic skip (intensity-driven gate) ==========
+        # ``skip_probability`` is rolled BEFORE we burn LLM cost.
+        # Default 0 for non-gaming and varied gaming, so this only
+        # kicks in for tagged competitive / immersive-horror gaming
+        # — or whatever combos the user has dialed up via
+        # preferences.json::skip_probability_overrides.
+        #
+        # The unfinished_thread guard means open threads still get
+        # follow-ups even at skip=1.0: if the AI promised to come
+        # back to something, we honour that promise regardless of
+        # how silenced the user wanted us. The thread mechanism's
+        # 2-followup hard cap already prevents harassment.
+        if (
+            activity_snapshot is not None
+            and activity_snapshot.skip_probability > 0
+            and activity_snapshot.unfinished_thread is None
+        ):
+            import random as _random
+            if _random.random() < activity_snapshot.skip_probability:
+                print(
+                    f"[{lanlan_name}] skip_probability={activity_snapshot.skip_probability:.2f} "
+                    f"rolled (state={activity_snapshot.state} intensity={activity_snapshot.game_intensity} "
+                    f"genre={activity_snapshot.game_genre})，本轮跳过"
+                )
+                return await _end_proactive(JSONResponse({
+                    "success": True,
+                    "action": "pass",
+                    "message": (
+                        f"probabilistic skip: state={activity_snapshot.state} "
+                        f"intensity={activity_snapshot.game_intensity} "
+                        f"skip_prob={activity_snapshot.skip_probability:.2f}"
+                    ),
+                }))
 
         # ========== 解析 enabled_modes ==========
         enabled_modes = data.get('enabled_modes', [])

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -63,11 +63,19 @@ def _sys_snap(
     ('KeePass - vault.kdbx', 'KeePass.exe'),
     ('1Password 8', '1Password.exe'),
     ('Bitwarden', 'Bitwarden.exe'),
-    ('Vaultwarden Web Vault', 'chrome.exe'),  # title-only match
     ('Ledger Live - Portfolio', 'Ledger Live.exe'),
 ])
 def test_privacy_classification_emits_private_state(title, process):
-    """Sensitive apps classify as state='private', propensity='closed'."""
+    """Sensitive apps classify as state='private', propensity='closed'.
+
+    Native apps only — title-based ``private`` classification fired
+    inside a browser process gets demoted to ``unknown`` (see
+    ``observation_from_system``) to avoid false-positives on marketing
+    pages, docs, and HN posts about password managers. So
+    Vaultwarden-via-chrome.exe is intentionally NOT in this list any
+    more; covered separately by
+    ``test_private_title_in_browser_does_not_trigger_lockdown``.
+    """
     prefs = ActivityPreferences()
     sm = ActivityStateMachine(prefs=prefs)
     sn = _sys_snap(title=title, process=process)
@@ -120,6 +128,36 @@ def test_private_state_yields_to_away():
 
     snap = sm.get_snapshot()
     assert snap.state == 'away'
+
+
+@pytest.mark.parametrize('title,process', [
+    ('Bitwarden Pricing | Best Password Manager - Bitwarden', 'chrome.exe'),
+    ('KeePass User Guide - Documentation', 'firefox.exe'),
+    ('1Password vs LastPass - blog comparison', 'msedge.exe'),
+    ('Why I switched to Vaultwarden — Hacker News', 'brave.exe'),
+])
+def test_private_title_in_browser_does_not_trigger_lockdown(title, process):
+    """Browser tabs about password managers (marketing pages, docs,
+    blog posts, HN comments) MUST NOT trip the privacy lockdown.
+
+    Native private apps catch via ``PRIVATE_PROCESS_NAMES`` (process
+    match in ``observation_from_system``); the title-only path inside
+    a browser is too noisy and would silence proactive chat over
+    "user is reading about KeePass". Only real running password
+    managers should drive the lockdown.
+    """
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title=title, process=process)
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+    sm.update_user_message()
+
+    snap = sm.get_snapshot()
+    assert snap.state != 'private', (
+        f"browser tab {title!r} (process={process}) must NOT classify "
+        f"as 'private'; got state={snap.state}"
+    )
 
 
 # ── #4 Own-app exclusion (N.E.K.O / Xiao8) ──────────────────────────

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -352,6 +352,43 @@ def test_thresholds_load_from_preferences():
     assert snap.state == 'away'
 
 
+def test_count_thresholds_reject_non_integer_floats():
+    """``window_switch_transition_threshold`` and
+    ``unfinished_thread_max_followups`` are count-shaped — floats like
+    ``0.9`` or ``1.7`` must NOT silently truncate to 0 / 1 (which would
+    break transitioning detection or cap unfinished_thread at 1 instead
+    of the user's intended 2). Loader-side validation only checks
+    "positive number"; the integer guard lives in ActivityStateMachine.
+
+    Verify by direct ActivityPreferences construction (bypasses the
+    loader's validation) — if the int guard ever regresses, this catches it.
+    """
+    # Float that would silently round to 0 or 1
+    bad_prefs = ActivityPreferences(thresholds={
+        'window_switch_transition_threshold': 0.9,    # int(0.9) → 0 (broken)
+        'unfinished_thread_max_followups': 1.7,        # int(1.7) → 1 (off-by-one)
+    })
+    sm = ActivityStateMachine(prefs=bad_prefs)
+    # Both must fall back to defaults rather than truncate
+    assert sm._window_switch_transition_threshold == 5, (
+        f'non-integer float must fall back to default 5; '
+        f'got {sm._window_switch_transition_threshold}'
+    )
+    assert sm._unfinished_thread_max_followups == 2, (
+        f'non-integer float must fall back to default 2; '
+        f'got {sm._unfinished_thread_max_followups}'
+    )
+
+    # Whole-number floats (3.0) are OK — they ARE integers in value.
+    ok_prefs = ActivityPreferences(thresholds={
+        'window_switch_transition_threshold': 7.0,
+        'unfinished_thread_max_followups': 3.0,
+    })
+    sm2 = ActivityStateMachine(prefs=ok_prefs)
+    assert sm2._window_switch_transition_threshold == 7
+    assert sm2._unfinished_thread_max_followups == 3
+
+
 def test_loader_drops_invalid_threshold_values():
     """The JSON-side loader silently drops malformed threshold entries.
 
@@ -528,6 +565,53 @@ def test_loader_keeps_last_good_prefs_on_parse_failure(tmp_path, monkeypatch):
     p2 = _load_from_file(str(pref_file))
     assert p2 is None, 'parse failure must signal None, not return defaults'
 
+    # Round 3: end-to-end through the public API. Pin the contract that
+    # `get_activity_preferences()` keeps the previously cached prefs
+    # intact when `_load_from_file` returns None — not just that the
+    # private helper signals None correctly. Without this leg, a future
+    # refactor that "helpfully" replaces the cache with defaults on
+    # parse failure would still let the test above pass while breaking
+    # the user-facing contract (their overrides quietly vanish).
+    from utils.activity_config import (
+        get_activity_preferences,
+        invalidate_activity_preferences_cache,
+    )
+    monkeypatch.setattr(
+        'utils.activity_config._resolve_preferences_path',
+        lambda: str(pref_file),
+    )
+    invalidate_activity_preferences_cache()
+
+    # Restore valid file content + populate cache via the public API
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'activity': {
+                'thresholds': {'away_idle_seconds': 300},
+                'user_app_overrides': {
+                    'mycorp.exe': {'category': 'work'},
+                },
+            },
+        }]),
+        encoding='utf-8',
+    )
+    cached_good = get_activity_preferences()
+    assert cached_good.thresholds == {'away_idle_seconds': 300.0}
+    assert 'mycorp.exe' in cached_good.user_app_overrides
+
+    # Now corrupt the file and force a reload. The public API must
+    # serve the previous good cache, NOT defaults.
+    pref_file.write_text('{ malformed json again', encoding='utf-8')
+    invalidate_activity_preferences_cache()
+    cached_after_corrupt = get_activity_preferences()
+    assert cached_after_corrupt.thresholds == {'away_idle_seconds': 300.0}, (
+        'parse failure must preserve previously cached thresholds; '
+        f'got {cached_after_corrupt.thresholds}'
+    )
+    assert 'mycorp.exe' in cached_after_corrupt.user_app_overrides, (
+        'parse failure must preserve previously cached user_app_overrides'
+    )
+
 
 def test_loader_returns_defaults_when_no_activity_section(tmp_path):
     """Successfully parsed file without activity section returns defaults
@@ -590,11 +674,29 @@ def test_tracker_picks_up_fresh_prefs_via_refresh_hook():
     original = _cache.prefs
     try:
         _cache.prefs = new_prefs
+
+        # Direct private-hook call — sanity check that _refresh_prefs
+        # itself swaps prefs correctly when invoked.
         tracker._refresh_prefs()
-        # Now classify with the post-swap prefs
         obs2 = observation_from_system(sn, tracker._sm._prefs)
         assert obs2.category == 'work'
         assert obs2.canonical == 'SomeUnknownApp'
+
+        # Public API check — the contract is "get_snapshot_sync triggers
+        # _refresh_prefs at the entry point". If a future refactor
+        # removes that call from the public entry, the direct test
+        # above would still pass while live sessions stop hot-reloading.
+        # Restore an older prefs object so the next public call has to
+        # re-pick the cached new_prefs.
+        sentinel_prefs = ActivityPreferences()  # baseline w/ no overrides
+        tracker._sm._prefs = sentinel_prefs
+        _cache.prefs = new_prefs  # the loader cache stays on new_prefs
+        tracker.get_snapshot_sync()  # public entry — must call _refresh_prefs
+        assert tracker._sm._prefs is new_prefs, (
+            'public get_snapshot_sync must call _refresh_prefs to swap '
+            'in fresh cached prefs; if a future refactor removes that '
+            'call, live sessions will stop hot-reloading user overrides'
+        )
     finally:
         _cache.prefs = original
 

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -407,7 +407,7 @@ def test_private_survives_stale_returning_window():
 def test_loader_keeps_last_good_prefs_on_parse_failure(tmp_path, monkeypatch):
     """A mid-edit corrupted JSON must NOT wipe previously cached overrides."""
     from utils.activity_config import (
-        _CacheState, _GLOBAL_CONVERSATION_KEY, _load_from_file,
+        _GLOBAL_CONVERSATION_KEY, _load_from_file,
     )
 
     # Round 1: write a valid file with overrides

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -504,3 +504,164 @@ def test_tracker_picks_up_fresh_prefs_via_refresh_hook():
         assert obs2.canonical == 'SomeUnknownApp'
     finally:
         _cache.prefs = original
+
+
+# ── update_window collapse: intensity/genre must invalidate (CR Major) ─
+
+
+def test_update_window_collapses_on_canonical_but_invalidates_on_intensity_change():
+    """Hot-reloaded ``user_game_overrides`` must propagate immediately.
+
+    When the user is in a tagged game (e.g. League of Legends, default
+    competitive moba) and edits ``user_game_overrides`` to flip it to
+    ``casual``, the next observation has identical
+    category/subcategory/canonical but a NEW intensity. The collapse
+    logic must treat this as a window state change so propensity /
+    skip_probability / tone re-derive against the new intensity.
+    """
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+
+    sn = _sys_snap(title='League of Legends', process='LeagueClient.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+    snap1 = sm.get_snapshot()
+    assert snap1.game_intensity == 'competitive'
+    assert snap1.tone == 'terse'
+
+    # Hot-reload: user override flips LoL to casual
+    new_prefs = ActivityPreferences(
+        user_game_overrides={
+            'League of Legends': _GameOverride(intensity='casual'),
+        },
+    )
+    sm._prefs = new_prefs
+    sm.update_window(observation_from_system(sn, new_prefs))
+    snap2 = sm.get_snapshot()
+    assert snap2.game_intensity == 'casual', (
+        'collapse logic must include intensity in same-check; '
+        f'got {snap2.game_intensity}'
+    )
+    assert snap2.propensity == 'open'   # casual unlocks open propensity
+    assert snap2.tone == 'playful'
+
+
+# ── unfinished_thread max_followups respects threshold (CR Major) ─────
+
+
+def test_mark_unfinished_thread_used_honors_threshold_override():
+    """When prefs set max_followups=3, the cap retires the thread on the
+    third call (not the second — the module constant default)."""
+    prefs = ActivityPreferences(
+        thresholds={'unfinished_thread_max_followups': 3.0},
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+    # Trip the question heuristic so an unfinished thread opens
+    sm.update_ai_message(text='主人，你今天准备做什么呢?')
+    assert sm._unfinished_thread is not None
+    assert sm._unfinished_thread['follow_up_count'] == 0
+
+    sm.mark_unfinished_thread_used()
+    assert sm._unfinished_thread is not None
+    assert sm._unfinished_thread['follow_up_count'] == 1
+
+    sm.mark_unfinished_thread_used()
+    assert sm._unfinished_thread is not None  # still alive at 2/3
+    assert sm._unfinished_thread['follow_up_count'] == 2
+
+    sm.mark_unfinished_thread_used()
+    # Hits the threshold (3) — record retired
+    assert sm._unfinished_thread is None, (
+        'threshold override 3 must retire on the 3rd usage, not 2 (module constant)'
+    )
+
+
+# ── own_app dwell freeze (CR Major) ───────────────────────────────────
+
+
+def test_own_app_freezes_dwell_timer_on_previous_window():
+    """Brief glance at the catgirl app must NOT artificially extend
+    the previous window's dwell.
+
+    Scenario: user is in VS Code for 60s (below 90s focused_work
+    threshold). They glance at N.E.K.O for 40s, then return to VS Code.
+    Without the dwell freeze, total elapsed at return is 100s, which
+    would trip focused_work even though actual VS Code time is only
+    60s + ε. With the freeze, dwell-on-VS-Code at return ≈ 60s, still
+    below threshold (correct).
+    """
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+
+    base = time.time()
+
+    # t=0: VS Code first observation
+    work = _sys_snap(title='proactive_chat.py - VS Code', process='Code.exe', ts=base)
+    sm.update_system(work)
+    sm.update_window(observation_from_system(work, prefs), now=base)
+    sm.update_user_message(now=base)
+
+    # t=80: still in VS Code, dwell ≈ 80s (below 90s threshold)
+    sm.update_user_message(now=base + 80)
+    snap_pre = sm.get_snapshot(now=base + 80)
+    assert snap_pre.state in ('idle', 'focused_work')  # boundary case
+
+    # t=85-130: 45s detour to N.E.K.O — own_app foreground
+    own = _sys_snap(title='Project N.E.K.O', process='Xiao8.exe', ts=base + 85)
+    sm.update_system(own)
+    sm.update_window(observation_from_system(own, prefs), now=base + 85)
+    # Multiple polls during own_app stretch (only first matters for freeze)
+    sm.update_window(observation_from_system(own, prefs), now=base + 100)
+    sm.update_window(observation_from_system(own, prefs), now=base + 120)
+
+    # t=130: return to VS Code. Dwell-on-Code should be ~85s (= 80 + ε
+    # before detour, then resumed), NOT 130s. Since 85 < 90, focused_work
+    # must NOT have tripped from the brief detour alone.
+    work_resume = _sys_snap(title='proactive_chat.py - VS Code', process='Code.exe', ts=base + 130)
+    sm.update_system(work_resume)
+    sm.update_window(observation_from_system(work_resume, prefs), now=base + 130)
+    sm.update_user_message(now=base + 130)
+    snap_post = sm.get_snapshot(now=base + 132)
+
+    # Dwell should be roughly equivalent to time spent in VS Code only
+    # (80 + 2 ≈ 82s), not full elapsed (132s). Threshold 90 not yet hit.
+    dwell = base + 132 - sm._current_window_started_at
+    assert dwell < 90, (
+        f'dwell freeze must subtract own_app time; got {dwell:.1f}s '
+        f'(would be ~132 without the freeze)'
+    )
+
+
+# ── canonical fallback in loader (CR Minor) ───────────────────────────
+
+
+def test_loader_canonical_falls_back_to_override_key(tmp_path):
+    """Doc says canonical defaults to override key when missing — verify."""
+    from utils.activity_config import (
+        _GLOBAL_CONVERSATION_KEY, _load_from_file,
+    )
+    pref_file = tmp_path / 'user_preferences.json'
+    import json
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'activity': {
+                'user_app_overrides': {
+                    'MyCorpApp.exe': {'category': 'work'},  # no canonical
+                },
+                'user_title_overrides': {
+                    'MyDashboard': {'category': 'work'},     # no canonical
+                },
+            },
+        }]),
+        encoding='utf-8',
+    )
+    prefs = _load_from_file(str(pref_file))
+    assert prefs is not None
+    # App override key gets lowercased for dict storage; canonical
+    # preserves the original-case key value.
+    assert 'mycorpapp.exe' in prefs.user_app_overrides
+    assert prefs.user_app_overrides['mycorpapp.exe'].canonical == 'MyCorpApp.exe'
+    # Title override falls back the same way
+    assert 'mydashboard' in prefs.user_title_overrides
+    assert prefs.user_title_overrides['mydashboard'].canonical == 'MyDashboard'

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -150,23 +150,51 @@ def test_own_app_does_not_replace_window_observation():
     assert snap_during.state == 'focused_work'
 
 
-def test_own_app_suppresses_gpu_fallback_gaming():
-    """Catgirl rendering its own Live2D/VRM should NOT trip gaming-by-GPU."""
+def test_own_app_preserves_previous_window_for_gpu_fallback():
+    """own_app foreground keeps prev window's classification active.
+
+    Critically, own_app does NOT suppress gaming-by-GPU on the prev
+    window — if the user had an unknown high-GPU game running and
+    briefly tabs to N.E.K.O, their real activity is still that game
+    and the classification should reflect it. The own_app contract is
+    "freeze dwell + don't replace the observation", not "disable
+    background classification".
+    """
     prefs = ActivityPreferences()
     sm = ActivityStateMachine(prefs=prefs)
 
-    # High GPU + own app foreground — would normally trip gaming-by-GPU
-    # if ``unknown`` category, but own_app is filtered upstream so the
-    # GPU fallback branch never sees this observation.
+    # Step 1: unknown high-GPU app (an indie game not in keyword DB).
+    # GPU fallback should fire and classify as gaming.
+    indie = _sys_snap(title='SomeIndieGame', process='IndieGame.exe', gpu=85.0)
+    sm.update_system(indie)
+    sm.update_window(observation_from_system(indie, prefs))
+    sm.update_user_message()
+    snap_pre = sm.get_snapshot()
+    assert snap_pre.state == 'gaming', (
+        f'GPU fallback should classify unknown high-GPU + active user as gaming; '
+        f'got {snap_pre.state}'
+    )
+
+    # Step 2: brief glance at N.E.K.O. Prev observation must NOT be
+    # replaced; gaming-by-GPU continues to fire on the prev window data.
     own = _sys_snap(title='N.E.K.O', process='projectneko_server.exe', gpu=85.0)
     sm.update_system(own)
     sm.update_window(observation_from_system(own, prefs))
-    sm.update_user_message()
-    snap = sm.get_snapshot()
+    snap_during = sm.get_snapshot()
 
-    # Without any prior observation, default state is 'idle' — the key
-    # assertion is "NOT gaming".
-    assert snap.state != 'gaming'
+    assert snap_during.active_window is not None
+    # ``canonical`` is None for unknown-category observations (the
+    # static DB had nothing); compare process_name which IS preserved.
+    assert snap_during.active_window.process_name == 'IndieGame.exe', (
+        'own_app must not replace prev window observation; '
+        f'got process_name={snap_during.active_window.process_name}'
+    )
+    assert snap_during.active_window.category == 'unknown'
+    assert snap_during.state == 'gaming', (
+        "own_app must NOT short-circuit prev window's gaming-by-GPU classification — "
+        "user's real activity (the indie game) is what matters; "
+        f'got {snap_during.state}'
+    )
 
 
 # ── #4 User app overrides ───────────────────────────────────────────

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -29,6 +29,7 @@ from main_logic.activity.system_signals import SystemSnapshot
 from utils.activity_config import (
     ActivityPreferences,
     _AppOverride,
+    _cache,
     _GameOverride,
 )
 
@@ -493,14 +494,13 @@ def test_tracker_picks_up_fresh_prefs_via_refresh_hook():
     )
 
     # Simulate the loader returning a different cached object
-    import utils.activity_config as ac_mod
-    original = ac_mod._cache.prefs
+    original = _cache.prefs
     try:
-        ac_mod._cache.prefs = new_prefs
+        _cache.prefs = new_prefs
         tracker._refresh_prefs()
         # Now classify with the post-swap prefs
         obs2 = observation_from_system(sn, tracker._sm._prefs)
         assert obs2.category == 'work'
         assert obs2.canonical == 'SomeUnknownApp'
     finally:
-        ac_mod._cache.prefs = original
+        _cache.prefs = original

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -13,6 +13,7 @@ to avoid touching the real user_preferences.json, and feeds a fabricated
 
 from __future__ import annotations
 
+import asyncio
 import time
 
 import pytest
@@ -300,13 +301,11 @@ def test_user_app_override_cannot_unmask_private():
     sm.update_window(observation_from_system(sn, prefs))
 
     snap = sm.get_snapshot()
-    # Override DOES change the WindowObservation (user said so), but
-    # classification then runs through static DB first via the keyword
-    # match — except in our current implementation user override wins.
-    # The intentional behaviour: keyword DB hit is checked FIRST, then
-    # user override patches. So static private match wins. Confirm.
-    # NOTE: depending on implementation order this may be the inverse;
-    # the test pins the safer (privacy-preserving) ordering.
+    # Contract: user_app_overrides / user_title_overrides are additive-only —
+    # they only fire when the static keyword DB returned ``unknown``
+    # (`result.category == 'unknown'`). On a static private hit the override
+    # is suppressed by the `static_locked` guard in `_apply_user_overrides`,
+    # so a "work" override on KeePass.exe stays as `private`.
     assert snap.state == 'private', (
         'User app override must not be allowed to demote a privacy-DB hit'
     )
@@ -696,6 +695,22 @@ def test_tracker_picks_up_fresh_prefs_via_refresh_hook():
             'public get_snapshot_sync must call _refresh_prefs to swap '
             'in fresh cached prefs; if a future refactor removes that '
             'call, live sessions will stop hot-reloading user overrides'
+        )
+
+        # Async path parity — the same contract must hold for the async
+        # public entry. Reset the in-memory prefs to the sentinel and
+        # leave the loader cache pointing at new_prefs, then await
+        # get_snapshot() and assert the swap happened. Without this,
+        # an async-path refactor could silently strip _refresh_prefs
+        # while the sync test stays green.
+        tracker._sm._prefs = sentinel_prefs
+        _cache.prefs = new_prefs
+        asyncio.run(tracker.get_snapshot())
+        assert tracker._sm._prefs is new_prefs, (
+            'public async get_snapshot must call _refresh_prefs to swap '
+            'in fresh cached prefs; if a future refactor removes that '
+            'call from the async entry, live sessions will stop '
+            'hot-reloading user overrides'
         )
     finally:
         _cache.prefs = original

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -18,7 +18,6 @@ import time
 import pytest
 
 from main_logic.activity.snapshot import (
-    ActivitySnapshot,
     derive_skip_probability,
     derive_tone,
 )
@@ -361,3 +360,147 @@ def test_skip_probability_specific_combo_beats_intensity_only():
     assert derive_skip_probability(
         'gaming', game_intensity='immersive', game_genre='rpg', overrides=overrides,
     ) == pytest.approx(0.4)
+
+
+# ── Privacy + stale_returning regression (Codex P1) ─────────────────
+
+
+def test_private_survives_stale_returning_window():
+    """Privacy lockdown must NOT downgrade to greeting_window when the
+    stale-returning sticky window happens to be active.
+
+    Scenario: user was away (15+ min idle), returns, opens KeePass as
+    their first action. Without the fix, ``effective_state`` would be
+    ``stale_returning`` → propensity ``greeting_window`` → proactive
+    chat would run and could even nudge a reminisce, while the user
+    is staring at password manager. Privacy must win.
+    """
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+
+    # Simulate "user was away" then returns → open KeePass
+    base = time.time()
+    away_snap = _sys_snap(idle=20 * 60, ts=base)
+    sm.update_system(away_snap)
+    sm.get_snapshot(now=base)  # state machine sees away
+
+    # User returns, opens KeePass within the stale_recovery window
+    return_ts = base + 10
+    keepass = _sys_snap(title='KeePass - vault.kdbx', process='KeePass.exe', idle=2.0, ts=return_ts)
+    sm.update_system(keepass)
+    sm.update_window(observation_from_system(keepass, prefs), now=return_ts)
+
+    snap = sm.get_snapshot(now=return_ts)
+    assert snap.state == 'private', (
+        'Stale-recovery window must NOT override private state; '
+        f'got {snap.state}'
+    )
+    assert snap.propensity == 'closed', (
+        f'private must keep closed propensity (got {snap.propensity})'
+    )
+
+
+# ── Loader robustness (Codex P2) ────────────────────────────────────
+
+
+def test_loader_keeps_last_good_prefs_on_parse_failure(tmp_path, monkeypatch):
+    """A mid-edit corrupted JSON must NOT wipe previously cached overrides."""
+    from utils.activity_config import (
+        _CacheState, _GLOBAL_CONVERSATION_KEY, _load_from_file,
+    )
+
+    # Round 1: write a valid file with overrides
+    pref_file = tmp_path / 'user_preferences.json'
+    import json
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'activity': {
+                'thresholds': {'away_idle_seconds': 300},
+                'user_app_overrides': {
+                    'mycorp.exe': {'category': 'work'},
+                },
+            },
+        }]),
+        encoding='utf-8',
+    )
+    p1 = _load_from_file(str(pref_file))
+    assert p1 is not None
+    assert p1.thresholds == {'away_idle_seconds': 300.0}
+    assert 'mycorp.exe' in p1.user_app_overrides
+
+    # Round 2: corrupt the file (simulating mid-edit save)
+    pref_file.write_text('{ malformed json without closing', encoding='utf-8')
+    p2 = _load_from_file(str(pref_file))
+    assert p2 is None, 'parse failure must signal None, not return defaults'
+
+
+def test_loader_returns_defaults_when_no_activity_section(tmp_path):
+    """Successfully parsed file without activity section returns defaults
+    (NOT None — that's reserved for parse failures)."""
+    from utils.activity_config import (
+        _GLOBAL_CONVERSATION_KEY, _load_from_file,
+    )
+    pref_file = tmp_path / 'user_preferences.json'
+    import json
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'proactiveChatEnabled': True,
+            # No 'activity' field
+        }]),
+        encoding='utf-8',
+    )
+    p = _load_from_file(str(pref_file))
+    assert p is not None
+    assert isinstance(p, ActivityPreferences)
+    assert p.thresholds == {}
+    assert p.user_app_overrides == {}
+
+
+# ── Hot-reload (Codex P2) ───────────────────────────────────────────
+
+
+def test_tracker_picks_up_fresh_prefs_via_refresh_hook():
+    """``UserActivityTracker._refresh_prefs`` swaps in updated prefs.
+
+    The state machine stores prefs at __init__, so a long-lived session
+    won't see edits unless someone refreshes. This test calls the
+    refresh hook directly with a new prefs object and verifies the
+    state machine starts honouring the new override.
+    """
+    from main_logic.activity.tracker import UserActivityTracker
+    from main_logic.activity.system_signals import (
+        SystemSignalCollector, get_system_signal_collector,
+    )
+
+    # Round 1 — empty prefs, nothing classified
+    initial_prefs = ActivityPreferences()
+    tracker = UserActivityTracker(
+        lanlan_name='_test_hot_reload',
+        collector=get_system_signal_collector(),  # singleton fine; we don't start it
+    )
+    tracker._sm = ActivityStateMachine(prefs=initial_prefs)
+    sn = _sys_snap(title='SomeUnknownApp', process='SomeUnknownApp.exe')
+    obs = observation_from_system(sn, tracker._sm._prefs)
+    assert obs.category == 'unknown', f'unknown app should classify as unknown, got {obs.category}'
+
+    # Round 2 — bring in fresh prefs with override; tracker swaps in
+    new_prefs = ActivityPreferences(
+        user_app_overrides={
+            'someunknownapp.exe': _AppOverride(category='work', subcategory='office', canonical='SomeUnknownApp'),
+        },
+    )
+
+    # Simulate the loader returning a different cached object
+    import utils.activity_config as ac_mod
+    original = ac_mod._cache.prefs
+    try:
+        ac_mod._cache.prefs = new_prefs
+        tracker._refresh_prefs()
+        # Now classify with the post-swap prefs
+        obs2 = observation_from_system(sn, tracker._sm._prefs)
+        assert obs2.category == 'work'
+        assert obs2.canonical == 'SomeUnknownApp'
+    finally:
+        ac_mod._cache.prefs = original

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -194,6 +194,33 @@ def test_user_app_override_patches_unknown():
     assert snap.active_window.canonical == 'MyCorpApp'
 
 
+def test_user_app_override_does_not_rewrite_stable_static_classification():
+    """User app override fires ONLY when static classifier returned 'unknown'.
+
+    Symmetric with title-override behaviour: overrides are additive
+    (they classify what the static DB missed), they don't rewrite a
+    stable DB hit. Otherwise a user typo / mistaken category in the
+    override dict could quietly break classification of a well-known app.
+    """
+    prefs = ActivityPreferences(
+        user_app_overrides={
+            'code.exe': _AppOverride(category='entertainment', canonical='Code'),
+        },
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+    # Code.exe is in the static DB as work/ide; user override should be ignored.
+    sn = _sys_snap(title='proactive_chat.py - Visual Studio Code', process='Code.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    assert snap.active_window is not None
+    assert snap.active_window.category == 'work', (
+        'static DB hit (Code.exe → work) must not be rewritten by user override; '
+        f'got category={snap.active_window.category}'
+    )
+
+
 def test_user_app_override_cannot_unmask_private():
     """User can't override KeePass to 'work' — privacy guarantee survives."""
     prefs = ActivityPreferences(
@@ -639,6 +666,48 @@ def test_own_app_freezes_dwell_timer_on_previous_window():
 
 
 # ── canonical fallback in loader (CR Minor) ───────────────────────────
+
+
+def test_high_gpu_reason_uses_threshold_override():
+    """``high_gpu`` reason must respect the same threshold as gaming-by-GPU.
+
+    If the user lifts ``gaming_gpu_threshold_percent`` to 85, GPU at 70
+    should NOT trigger gaming-by-GPU AND should NOT emit ``high_gpu``
+    reason — both are 'is the GPU notable right now?' decisions and
+    mustn't disagree.
+    """
+    prefs = ActivityPreferences(
+        thresholds={'gaming_gpu_threshold_percent': 85.0},
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+    # GPU at 70 — between default 60 and overridden 85. With the fix,
+    # neither classifier nor reason emitter should flag it.
+    sn = _sys_snap(title='SomeUnknownApp', process='Other.exe', gpu=70.0)
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+    sm.update_user_message()
+
+    snap = sm.get_snapshot()
+    reason_codes = [r[0] for r in snap.propensity_reasons]
+    assert 'high_gpu' not in reason_codes, (
+        f'high_gpu reason must respect user threshold (85%); '
+        f'got reasons={reason_codes} for GPU=70%'
+    )
+    assert snap.state != 'gaming', (
+        f'gaming-by-GPU must respect threshold (85%); got state={snap.state}'
+    )
+
+    # Now push GPU above the override — both should fire
+    sn2 = _sys_snap(title='SomeUnknownApp', process='Other.exe', gpu=90.0)
+    sm.update_system(sn2)
+    sm.update_window(observation_from_system(sn2, prefs))
+
+    snap2 = sm.get_snapshot()
+    reason_codes2 = [r[0] for r in snap2.propensity_reasons]
+    assert 'high_gpu' in reason_codes2, (
+        f'high_gpu reason should fire above override threshold (85%); '
+        f'got reasons={reason_codes2} for GPU=90%'
+    )
 
 
 def test_loader_canonical_falls_back_to_override_key(tmp_path):

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -630,6 +630,12 @@ def test_own_app_freezes_dwell_timer_on_previous_window():
         f'dwell freeze must subtract own_app time; got {dwell:.1f}s '
         f'(would be ~132 without the freeze)'
     )
+    # Same assertion expressed at the state-machine API level: the brief
+    # own_app detour must NOT cause focused_work to fire on return.
+    assert snap_post.state != 'focused_work', (
+        f'dwell freeze should keep state below focused_work threshold '
+        f'after a 45s own_app detour; got {snap_post.state}'
+    )
 
 
 # ── canonical fallback in loader (CR Minor) ───────────────────────────

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1,0 +1,363 @@
+"""Tests for the activity tracker follow-up bundle.
+
+Covers the privacy / own-app / user-override / config-externalization /
+tone-modifier features that landed on top of PR #1015's base tracker.
+``#1`` (game intensity × genre schema) is exercised by the override
+tests since the schema accepts both 2-tuple (legacy) and 4-tuple
+(new) game keyword rows.
+
+Each test constructs the state machine with explicit ``ActivityPreferences``
+to avoid touching the real user_preferences.json, and feeds a fabricated
+``SystemSnapshot`` to drive classification — no I/O, no real polling.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from main_logic.activity.snapshot import (
+    ActivitySnapshot,
+    derive_skip_probability,
+    derive_tone,
+)
+from main_logic.activity.state_machine import (
+    ActivityStateMachine,
+    observation_from_system,
+)
+from main_logic.activity.system_signals import SystemSnapshot
+from utils.activity_config import (
+    ActivityPreferences,
+    _AppOverride,
+    _GameOverride,
+)
+
+
+def _sys_snap(
+    *,
+    title: str | None = None,
+    process: str | None = None,
+    idle: float = 1.0,
+    cpu: float = 10.0,
+    gpu: float | None = None,
+    ts: float | None = None,
+) -> SystemSnapshot:
+    """Tiny SystemSnapshot factory for test brevity."""
+    return SystemSnapshot(
+        timestamp=ts if ts is not None else time.time(),
+        idle_seconds=idle,
+        cpu_avg_30s=cpu,
+        cpu_instant=cpu,
+        window_title=title,
+        process_name=process,
+        gpu_utilization=gpu,
+        os_signals_available=True,
+    )
+
+
+# ── #3 Privacy blacklist ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize('title,process', [
+    ('KeePass - vault.kdbx', 'KeePass.exe'),
+    ('1Password 8', '1Password.exe'),
+    ('Bitwarden', 'Bitwarden.exe'),
+    ('Vaultwarden Web Vault', 'chrome.exe'),  # title-only match
+    ('Ledger Live - Portfolio', 'Ledger Live.exe'),
+])
+def test_privacy_classification_emits_private_state(title, process):
+    """Sensitive apps classify as state='private', propensity='closed'."""
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title=title, process=process)
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    assert snap.state == 'private'
+    assert snap.propensity == 'closed'
+
+
+def test_private_state_redacts_active_window():
+    """ActivitySnapshot.active_window is None when state=private — no leakage."""
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title='KeePass - mybank.kdbx', process='KeePass.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    assert snap.active_window is None  # title 'mybank' must not leak
+
+
+def test_private_state_overrides_voice_engaged():
+    """Privacy wins over voice mode — secrets-app foreground silences AI even mid-voice."""
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+    sm.update_voice_mode(True)
+    sm.update_voice_rms()
+    sn = _sys_snap(title='1Password', process='1Password.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    assert snap.state == 'private'
+
+
+def test_private_state_yields_to_away():
+    """When the user has been idle for AWAY_IDLE_SECONDS, away wins.
+
+    Privacy app left open while user walked away is just an idle desk —
+    no secrets being handled right now. Away → frontend backoff handles
+    cadence, no proactive misfire concern.
+    """
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title='KeePass', process='KeePass.exe', idle=20 * 60)
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    assert snap.state == 'away'
+
+
+# ── #4 Own-app exclusion (N.E.K.O / Xiao8) ──────────────────────────
+
+
+def test_own_app_does_not_replace_window_observation():
+    """Catgirl-app foreground is transparent — previous window stays active."""
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+
+    # Step 1: User in VS Code (work) for 100s
+    work = _sys_snap(title='proactive_chat.py - VS Code', process='Code.exe')
+    sm.update_system(work)
+    sm.update_window(observation_from_system(work, prefs))
+    sm.update_user_message()
+    snap_before = sm.get_snapshot(now=time.time() + 100)
+    assert snap_before.state == 'focused_work'
+
+    # Step 2: User opens N.E.K.O
+    own = _sys_snap(title='Project N.E.K.O', process='Xiao8.exe', gpu=85.0)
+    sm.update_system(own)
+    sm.update_window(observation_from_system(own, prefs), now=time.time() + 200)
+    snap_during = sm.get_snapshot(now=time.time() + 201)
+
+    # Window should still be Code.exe — own_app was filtered out
+    assert snap_during.active_window is not None
+    assert snap_during.active_window.canonical == 'Code.exe'
+    assert snap_during.state == 'focused_work'
+
+
+def test_own_app_suppresses_gpu_fallback_gaming():
+    """Catgirl rendering its own Live2D/VRM should NOT trip gaming-by-GPU."""
+    prefs = ActivityPreferences()
+    sm = ActivityStateMachine(prefs=prefs)
+
+    # High GPU + own app foreground — would normally trip gaming-by-GPU
+    # if ``unknown`` category, but own_app is filtered upstream so the
+    # GPU fallback branch never sees this observation.
+    own = _sys_snap(title='N.E.K.O', process='projectneko_server.exe', gpu=85.0)
+    sm.update_system(own)
+    sm.update_window(observation_from_system(own, prefs))
+    sm.update_user_message()
+    snap = sm.get_snapshot()
+
+    # Without any prior observation, default state is 'idle' — the key
+    # assertion is "NOT gaming".
+    assert snap.state != 'gaming'
+
+
+# ── #4 User app overrides ───────────────────────────────────────────
+
+
+def test_user_app_override_patches_unknown():
+    """Unknown app + user override → classifies as the override category."""
+    prefs = ActivityPreferences(
+        user_app_overrides={
+            'mycorpapp.exe': _AppOverride(
+                category='work', subcategory='office', canonical='MyCorpApp',
+            ),
+        },
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title='MyCorpApp - Documents', process='MyCorpApp.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+    sm.update_user_message()
+
+    snap = sm.get_snapshot(now=time.time() + 100)  # past dwell threshold
+    assert snap.state == 'focused_work'
+    assert snap.active_window is not None
+    assert snap.active_window.category == 'work'
+    assert snap.active_window.canonical == 'MyCorpApp'
+
+
+def test_user_app_override_cannot_unmask_private():
+    """User can't override KeePass to 'work' — privacy guarantee survives."""
+    prefs = ActivityPreferences(
+        user_app_overrides={
+            'keepass.exe': _AppOverride(category='work'),
+        },
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title='KeePass', process='KeePass.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    # Override DOES change the WindowObservation (user said so), but
+    # classification then runs through static DB first via the keyword
+    # match — except in our current implementation user override wins.
+    # The intentional behaviour: keyword DB hit is checked FIRST, then
+    # user override patches. So static private match wins. Confirm.
+    # NOTE: depending on implementation order this may be the inverse;
+    # the test pins the safer (privacy-preserving) ordering.
+    assert snap.state == 'private', (
+        'User app override must not be allowed to demote a privacy-DB hit'
+    )
+
+
+def test_user_game_override_patches_intensity():
+    """User can flip a game's intensity/genre."""
+    prefs = ActivityPreferences(
+        user_game_overrides={
+            'League of Legends': _GameOverride(intensity='casual', genre='moba'),
+        },
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+    sn = _sys_snap(title='League of Legends', process='LeagueClient.exe')
+    sm.update_system(sn)
+    sm.update_window(observation_from_system(sn, prefs))
+
+    snap = sm.get_snapshot()
+    assert snap.state == 'gaming'
+    assert snap.game_intensity == 'casual'
+    # casual gaming → propensity=open per derivation table
+    assert snap.propensity == 'open'
+    assert snap.tone == 'playful'
+
+
+# ── #5 Threshold externalization ────────────────────────────────────
+
+
+def test_thresholds_load_from_preferences():
+    """Threshold overrides take effect at state machine construction."""
+    prefs = ActivityPreferences(
+        thresholds={
+            'away_idle_seconds': 60.0,  # default 900; aggressive 1min
+            'focused_work_min_dwell_seconds': 5.0,
+        },
+    )
+    sm = ActivityStateMachine(prefs=prefs)
+
+    # 65s idle should now trip 'away' even though default is 15min.
+    sn = _sys_snap(idle=65.0)
+    sm.update_system(sn)
+    snap = sm.get_snapshot()
+    assert snap.state == 'away'
+
+
+def test_loader_drops_invalid_threshold_values():
+    """The JSON-side loader silently drops malformed threshold entries.
+
+    Direct ``ActivityPreferences(thresholds={...})`` construction trusts
+    the caller (no second-pass validation), but the JSON loader is the
+    real-user path and must be defensive against typos / wrong types.
+    """
+    from utils.activity_config import _parse_thresholds
+    out = _parse_thresholds({
+        'away_idle_seconds': 60.0,           # valid positive number
+        'stale_recovery_seconds': -5,        # negative → dropped
+        'voice_active_window_seconds': 0,    # zero → dropped (positive only)
+        'focused_work_min_dwell_seconds': True,  # bool → dropped (subclass of int)
+        'casual_browsing_min_dwell_seconds': 'hi',  # string → dropped
+        'gaming_gpu_threshold_percent': 60.0,
+    })
+    assert out == {
+        'away_idle_seconds': 60.0,
+        'gaming_gpu_threshold_percent': 60.0,
+    }
+
+
+# ── #7 Tone modifier ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize('state,intensity,genre,expected', [
+    ('voice_engaged',   None,           None,     'warm'),
+    ('chatting',        None,           None,     'warm'),
+    ('stale_returning', None,           None,     'warm'),
+    ('focused_work',    None,           None,     'concise'),
+    ('idle',            None,           None,     'concise'),
+    ('away',            None,           None,     'concise'),
+    ('casual_browsing', None,           None,     'playful'),
+    ('private',         None,           None,     'concise'),
+    ('gaming',          'competitive',  'moba',   'terse'),
+    ('gaming',          'competitive',  'fps',    'terse'),
+    ('gaming',          'immersive',    'horror', 'hushed'),
+    ('gaming',          'immersive',    'rpg',    'mellow'),
+    ('gaming',          'immersive',    'action', 'mellow'),
+    ('gaming',          'casual',       'sim',    'playful'),
+    ('gaming',          'varied',       'misc',   'concise'),
+    ('gaming',          None,           None,     'concise'),
+])
+def test_tone_derivation_table(state, intensity, genre, expected):
+    """Pin the (state, intensity, genre) → tone mapping."""
+    assert derive_tone(state, game_intensity=intensity, game_genre=genre) == expected
+
+
+# ── #1 / skip_probability ───────────────────────────────────────────
+
+
+def test_skip_probability_defaults():
+    """Pin the default skip-probability table."""
+    # Non-gaming → always 0
+    assert derive_skip_probability('focused_work') == 0.0
+    assert derive_skip_probability('chatting') == 0.0
+    assert derive_skip_probability('idle') == 0.0
+
+    # Gaming defaults
+    assert derive_skip_probability('gaming', game_intensity='competitive') == pytest.approx(0.3)
+    assert derive_skip_probability(
+        'gaming', game_intensity='immersive', game_genre='horror',
+    ) == pytest.approx(0.3)
+    assert derive_skip_probability(
+        'gaming', game_intensity='immersive', game_genre='rpg',
+    ) == 0.0
+    assert derive_skip_probability('gaming', game_intensity='casual') == 0.0
+    assert derive_skip_probability('gaming', game_intensity='varied') == 0.0
+
+
+def test_skip_probability_user_overrides_replace_defaults():
+    """User overrides win and clamp into [0, 1]."""
+    overrides = {
+        'competitive':       0.8,
+        'immersive_horror':  1.0,
+        'casual':            1.5,    # clamps to 1.0
+        'immersive_rpg':     -0.5,   # clamps to 0.0
+    }
+    assert derive_skip_probability(
+        'gaming', game_intensity='competitive', overrides=overrides,
+    ) == pytest.approx(0.8)
+    assert derive_skip_probability(
+        'gaming', game_intensity='immersive', game_genre='horror', overrides=overrides,
+    ) == pytest.approx(1.0)
+    assert derive_skip_probability(
+        'gaming', game_intensity='casual', overrides=overrides,
+    ) == 1.0
+    assert derive_skip_probability(
+        'gaming', game_intensity='immersive', game_genre='rpg', overrides=overrides,
+    ) == 0.0
+
+
+def test_skip_probability_specific_combo_beats_intensity_only():
+    """``immersive_horror`` override wins over an ``immersive`` override."""
+    overrides = {'immersive': 0.4, 'immersive_horror': 0.9}
+    assert derive_skip_probability(
+        'gaming', game_intensity='immersive', game_genre='horror', overrides=overrides,
+    ) == pytest.approx(0.9)
+    # Without horror genre, falls through to intensity-only override
+    assert derive_skip_probability(
+        'gaming', game_intensity='immersive', game_genre='rpg', overrides=overrides,
+    ) == pytest.approx(0.4)

--- a/utils/activity_config.py
+++ b/utils/activity_config.py
@@ -1,0 +1,380 @@
+"""User-configurable activity tracker preferences.
+
+Reads the ``activity`` sub-dict from ``user_preferences.json``'s
+``__global_conversation__`` entry — see
+``utils/preferences.py:GLOBAL_CONVERSATION_KEY`` for the file shape.
+
+Schema (all fields optional; missing fields fall through to code defaults
+in ``main_logic/activity/state_machine.py``):
+
+```
+{
+  "model_path": "__global_conversation__",
+  ... existing global settings ...
+  "activity": {
+    "thresholds": {
+      "away_idle_seconds": 900,
+      "stale_recovery_seconds": 60,
+      "voice_active_window_seconds": 8,
+      "focused_work_min_dwell_seconds": 90,
+      "focused_work_recent_input_seconds": 300,
+      "casual_browsing_min_dwell_seconds": 30,
+      "window_switch_transition_threshold": 5,
+      "window_history_lookback_seconds": 300,
+      "transition_recent_window_seconds": 30,
+      "unfinished_thread_window_seconds": 300,
+      "unfinished_thread_max_followups": 2,
+      "gaming_gpu_threshold_percent": 60,
+      "gaming_gpu_max_idle_seconds": 60
+    },
+    "user_app_overrides": {
+      "MyCompanyApp.exe": {"category": "work", "subcategory": "office", "canonical": "MyCompanyApp"},
+      "OurGameLauncher.exe": {"category": "gaming", "subcategory": "game"}
+    },
+    "user_title_overrides": {
+      "MyCustomTitle": {"category": "work", "subcategory": "office", "canonical": "Custom"}
+    },
+    "user_game_overrides": {
+      "Elden Ring": {"intensity": "casual", "genre": "rpg"}
+    },
+    "skip_probability_overrides": {
+      "competitive": 0.5,
+      "immersive_horror": 1.0,
+      "casual": 0.0
+    }
+  }
+}
+```
+
+Why a separate loader (not reusing
+``utils/preferences.load_global_conversation_settings``):
+
+* That function is whitelist-filtered (``_ALLOWED_CONVERSATION_SETTINGS``)
+  and would drop the ``activity`` sub-dict.
+* Adding ``activity`` to the whitelist + extending the per-field validator
+  to handle nested structure couples this subsystem to the cloudsave
+  write path. We don't need a write path yet — users edit the file
+  directly. Add one when a UI needs it.
+
+Caching: the file is read at most once per
+``_PREFERENCES_RELOAD_INTERVAL_SECONDS`` (default 30s) per process. Edits
+to ``user_preferences.json`` take effect on the next reload tick.
+``invalidate_activity_preferences_cache()`` is exposed for tests + for
+explicit reload after settings UI writes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from utils.config_manager import get_config_manager
+
+logger = logging.getLogger(__name__)
+
+
+_PREFERENCES_RELOAD_INTERVAL_SECONDS = 30.0
+_GLOBAL_CONVERSATION_KEY = '__global_conversation__'
+
+# Whitelisted intensity / genre values — invalid entries are silently
+# dropped from user overrides so a typo doesn't poison classification.
+_VALID_INTENSITIES = frozenset({'competitive', 'casual', 'immersive', 'varied'})
+_VALID_GENRES = frozenset({
+    'fps', 'moba', 'rpg', 'sim', 'horror', 'racing', 'rhythm',
+    'strategy', 'sports', 'party', 'action', 'misc',
+})
+_VALID_CATEGORIES = frozenset({
+    'gaming', 'work', 'entertainment', 'communication', 'private', 'own_app',
+})
+
+
+@dataclass(frozen=True, slots=True)
+class _AppOverride:
+    """One user-supplied app classification override.
+
+    ``subcategory`` and ``canonical`` are optional — the loader falls
+    back to the override key (the app's identifier) if canonical is
+    missing.
+    """
+    category: str
+    subcategory: str | None = None
+    canonical: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _GameOverride:
+    """One user-supplied game intensity / genre override."""
+    intensity: str | None = None
+    genre: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityPreferences:
+    """Resolved activity tracker preferences.
+
+    All fields have safe defaults — accessing the dataclass when
+    ``user_preferences.json`` is missing or empty returns ``ActivityPreferences()``,
+    which in turn means the state machine falls through to its hard-coded
+    defaults.
+    """
+
+    # Threshold overrides — None means "use code default in state_machine.py".
+    # Names map 1:1 to the constants at the top of state_machine.py.
+    thresholds: dict[str, float] = field(default_factory=dict)
+
+    # Process-name → override. Lookup is case-insensitive (loader lowercases keys).
+    user_app_overrides: dict[str, _AppOverride] = field(default_factory=dict)
+
+    # Window-title-substring → override. Lookup is case-insensitive.
+    user_title_overrides: dict[str, _AppOverride] = field(default_factory=dict)
+
+    # Game canonical-name → intensity/genre override. Patches the result
+    # of GAME_TITLE_KEYWORDS classification before state machine derivation.
+    user_game_overrides: dict[str, _GameOverride] = field(default_factory=dict)
+
+    # Skip probability overrides. Keys are intensity-only ('competitive')
+    # or intensity_genre ('immersive_horror'); values in [0, 1].
+    skip_probability_overrides: dict[str, float] = field(default_factory=dict)
+
+
+# ── Module-level cache ────────────────────────────────────────────────
+
+_cache_lock = threading.Lock()
+_cached_prefs: ActivityPreferences = ActivityPreferences()
+_cached_at: float = 0.0
+_cached_path: str | None = None
+_cached_mtime: float | None = None
+
+
+def get_activity_preferences() -> ActivityPreferences:
+    """Return cached preferences, reloading if stale or file changed.
+
+    Cheap to call frequently — the actual JSON read happens at most once
+    per ``_PREFERENCES_RELOAD_INTERVAL_SECONDS``. Always returns a valid
+    object; on parse failure the cache stays on its previous value (or
+    defaults if there's never been a successful load).
+    """
+    global _cached_prefs, _cached_at, _cached_path, _cached_mtime
+    now = time.time()
+    with _cache_lock:
+        if (
+            _cached_at
+            and now - _cached_at < _PREFERENCES_RELOAD_INTERVAL_SECONDS
+        ):
+            return _cached_prefs
+
+        path = _resolve_preferences_path()
+        if path is None:
+            _cached_prefs = ActivityPreferences()
+            _cached_at = now
+            _cached_path = None
+            _cached_mtime = None
+            return _cached_prefs
+
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            mtime = None
+
+        # If the path AND mtime are unchanged, skip the parse and just
+        # advance the freshness timestamp.
+        if path == _cached_path and mtime == _cached_mtime and mtime is not None:
+            _cached_at = now
+            return _cached_prefs
+
+        prefs = _load_from_file(path)
+        _cached_prefs = prefs
+        _cached_at = now
+        _cached_path = path
+        _cached_mtime = mtime
+        return prefs
+
+
+def invalidate_activity_preferences_cache() -> None:
+    """Force the next ``get_activity_preferences()`` call to re-read the file.
+
+    Useful for tests + post-settings-UI-write hooks.
+    """
+    global _cached_at, _cached_path, _cached_mtime
+    with _cache_lock:
+        _cached_at = 0.0
+        _cached_path = None
+        _cached_mtime = None
+
+
+def _resolve_preferences_path() -> str | None:
+    """Pick the live preferences file path.
+
+    Mirrors ``utils/preferences.py`` — prefer the runtime (writable)
+    path; fall back to the read path only if runtime is missing
+    (covers fresh installs that haven't migrated yet).
+    """
+    try:
+        cm = get_config_manager()
+        write_path = str(cm.get_runtime_config_path('user_preferences.json'))
+        if os.path.exists(write_path):
+            return write_path
+        read_path = str(cm.get_config_path('user_preferences.json'))
+        if os.path.exists(read_path):
+            return read_path
+    except Exception as e:
+        logger.debug('activity_config: cannot resolve preferences path: %s', e)
+    return None
+
+
+def _load_from_file(path: str) -> ActivityPreferences:
+    """Read user_preferences.json and extract the ``activity`` sub-dict.
+
+    Returns ``ActivityPreferences()`` (all defaults) on any error or if
+    the activity section is absent. Validation is best-effort — invalid
+    entries inside the section are silently dropped without rejecting
+    the rest of the section. We never want a typo to wedge the tracker.
+    """
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.debug('activity_config: failed to read %s: %s', path, e)
+        return ActivityPreferences()
+
+    if not isinstance(data, list):
+        # Legacy dict-shaped preferences file — no global entry to look at.
+        return ActivityPreferences()
+
+    activity_dict: dict | None = None
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get('model_path') == _GLOBAL_CONVERSATION_KEY:
+            sub = entry.get('activity')
+            if isinstance(sub, dict):
+                activity_dict = sub
+            break
+
+    if activity_dict is None:
+        return ActivityPreferences()
+
+    return _parse_activity_section(activity_dict)
+
+
+def _parse_activity_section(section: dict) -> ActivityPreferences:
+    """Extract + validate fields from a raw activity sub-dict."""
+    return ActivityPreferences(
+        thresholds=_parse_thresholds(section.get('thresholds')),
+        user_app_overrides=_parse_app_overrides(section.get('user_app_overrides')),
+        user_title_overrides=_parse_app_overrides(section.get('user_title_overrides')),
+        user_game_overrides=_parse_game_overrides(section.get('user_game_overrides')),
+        skip_probability_overrides=_parse_skip_overrides(
+            section.get('skip_probability_overrides'),
+        ),
+    )
+
+
+def _parse_thresholds(raw: Any) -> dict[str, float]:
+    """Threshold values must be positive numbers. Drop anything else."""
+    out: dict[str, float] = {}
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if not isinstance(k, str):
+            continue
+        if isinstance(v, bool):
+            continue  # bool is a subclass of int — exclude explicitly
+        if not isinstance(v, (int, float)):
+            continue
+        if v <= 0:
+            continue
+        out[k] = float(v)
+    return out
+
+
+def _parse_app_overrides(raw: Any) -> dict[str, _AppOverride]:
+    """Process or title overrides: ``{key: {category, subcategory?, canonical?}}``.
+
+    Keys are lowercased for case-insensitive lookup. Categories outside
+    ``_VALID_CATEGORIES`` are dropped.
+    """
+    out: dict[str, _AppOverride] = {}
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if not isinstance(k, str) or not k:
+            continue
+        if not isinstance(v, dict):
+            continue
+        cat = v.get('category')
+        if cat not in _VALID_CATEGORIES:
+            continue
+        sub = v.get('subcategory')
+        canon = v.get('canonical')
+        if sub is not None and not isinstance(sub, str):
+            sub = None
+        if canon is not None and not isinstance(canon, str):
+            canon = None
+        out[k.lower()] = _AppOverride(
+            category=cat,
+            subcategory=sub,
+            canonical=canon,
+        )
+    return out
+
+
+def _parse_game_overrides(raw: Any) -> dict[str, _GameOverride]:
+    """Game canonical-name → intensity/genre override.
+
+    Keys preserved as given (matched by canonical name from the keyword
+    DB, which is case-sensitive). Invalid intensity / genre values are
+    dropped; an entry with both invalid is omitted entirely.
+    """
+    out: dict[str, _GameOverride] = {}
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if not isinstance(k, str) or not k:
+            continue
+        if not isinstance(v, dict):
+            continue
+        intensity = v.get('intensity')
+        genre = v.get('genre')
+        if intensity is not None and intensity not in _VALID_INTENSITIES:
+            intensity = None
+        if genre is not None and genre not in _VALID_GENRES:
+            genre = None
+        if intensity is None and genre is None:
+            continue
+        out[k] = _GameOverride(intensity=intensity, genre=genre)
+    return out
+
+
+def _parse_skip_overrides(raw: Any) -> dict[str, float]:
+    """Skip probability overrides: ``{combo_key: float ∈ [0, 1]}``.
+
+    Keys aren't strictly validated — they're consumed by
+    ``snapshot.derive_skip_probability`` which has its own format
+    expectation. Out-of-range values are clamped.
+    """
+    out: dict[str, float] = {}
+    if not isinstance(raw, dict):
+        return out
+    for k, v in raw.items():
+        if not isinstance(k, str):
+            continue
+        if isinstance(v, bool):
+            continue
+        if not isinstance(v, (int, float)):
+            continue
+        clamped = max(0.0, min(1.0, float(v)))
+        out[k] = clamped
+    return out
+
+
+__all__ = [
+    'ActivityPreferences',
+    'get_activity_preferences',
+    'invalidate_activity_preferences_cache',
+]

--- a/utils/activity_config.py
+++ b/utils/activity_config.py
@@ -388,6 +388,14 @@ def _parse_app_overrides(raw: Any) -> dict[str, _AppOverride]:
             sub = None
         if canon is not None and not isinstance(canon, str):
             canon = None
+        # Fall back to the user's override key when no explicit canonical
+        # was supplied, matching the docstring contract on _AppOverride.
+        # This keeps the canonical stable across the loader → state machine
+        # → snapshot path: downstream displays the user's intended
+        # identifier rather than the raw foreground process basename or
+        # full window title.
+        if canon is None:
+            canon = k
         out[k.lower()] = _AppOverride(
             category=cat,
             subcategory=sub,

--- a/utils/activity_config.py
+++ b/utils/activity_config.py
@@ -4,47 +4,55 @@ Reads the ``activity`` sub-dict from ``user_preferences.json``'s
 ``__global_conversation__`` entry — see
 ``utils/preferences.py:GLOBAL_CONVERSATION_KEY`` for the file shape.
 
-Schema (all fields optional; missing fields fall through to code defaults
-in ``main_logic/activity/state_machine.py``):
+The on-disk file is always a JSON ARRAY whose entries are dicts; one
+entry has ``model_path == "__global_conversation__"`` and holds the
+global settings. The activity sub-dict lives there:
 
-```
-{
-  "model_path": "__global_conversation__",
-  ... existing global settings ...
-  "activity": {
-    "thresholds": {
-      "away_idle_seconds": 900,
-      "stale_recovery_seconds": 60,
-      "voice_active_window_seconds": 8,
-      "focused_work_min_dwell_seconds": 90,
-      "focused_work_recent_input_seconds": 300,
-      "casual_browsing_min_dwell_seconds": 30,
-      "window_switch_transition_threshold": 5,
-      "window_history_lookback_seconds": 300,
-      "transition_recent_window_seconds": 30,
-      "unfinished_thread_window_seconds": 300,
-      "unfinished_thread_max_followups": 2,
-      "gaming_gpu_threshold_percent": 60,
-      "gaming_gpu_max_idle_seconds": 60
-    },
-    "user_app_overrides": {
-      "MyCompanyApp.exe": {"category": "work", "subcategory": "office", "canonical": "MyCompanyApp"},
-      "OurGameLauncher.exe": {"category": "gaming", "subcategory": "game"}
-    },
-    "user_title_overrides": {
-      "MyCustomTitle": {"category": "work", "subcategory": "office", "canonical": "Custom"}
-    },
-    "user_game_overrides": {
-      "Elden Ring": {"intensity": "casual", "genre": "rpg"}
-    },
-    "skip_probability_overrides": {
-      "competitive": 0.5,
-      "immersive_horror": 1.0,
-      "casual": 0.0
+```json
+[
+  {
+    "model_path": "__global_conversation__",
+    "proactiveChatEnabled": true,
+    "...other existing global settings...": "...",
+    "activity": {
+      "thresholds": {
+        "away_idle_seconds": 900,
+        "stale_recovery_seconds": 60,
+        "voice_active_window_seconds": 8,
+        "focused_work_min_dwell_seconds": 90,
+        "focused_work_recent_input_seconds": 300,
+        "casual_browsing_min_dwell_seconds": 30,
+        "window_switch_transition_threshold": 5,
+        "window_history_lookback_seconds": 300,
+        "transition_recent_window_seconds": 30,
+        "unfinished_thread_window_seconds": 300,
+        "unfinished_thread_max_followups": 2,
+        "gaming_gpu_threshold_percent": 60,
+        "gaming_gpu_max_idle_seconds": 60
+      },
+      "user_app_overrides": {
+        "MyCompanyApp.exe": {"category": "work", "subcategory": "office", "canonical": "MyCompanyApp"},
+        "OurGameLauncher.exe": {"category": "gaming", "subcategory": "game"}
+      },
+      "user_title_overrides": {
+        "MyCustomTitle": {"category": "work", "subcategory": "office", "canonical": "Custom"}
+      },
+      "user_game_overrides": {
+        "Elden Ring": {"intensity": "casual", "genre": "rpg"}
+      },
+      "skip_probability_overrides": {
+        "competitive": 0.5,
+        "immersive_horror": 1.0,
+        "casual": 0.0
+      }
     }
-  }
-}
+  },
+  {"model_path": "...some 3D model path...", "...": "..."}
+]
 ```
+
+All fields are optional; missing entries fall through to code defaults
+in ``main_logic/activity/state_machine.py``.
 
 Why a separate loader (not reusing
 ``utils/preferences.load_global_conversation_settings``):
@@ -88,8 +96,24 @@ _VALID_GENRES = frozenset({
     'fps', 'moba', 'rpg', 'sim', 'horror', 'racing', 'rhythm',
     'strategy', 'sports', 'party', 'action', 'misc',
 })
+
+# Categories users may target via ``user_app_overrides`` /
+# ``user_title_overrides``. ``private`` and ``own_app`` are intentionally
+# EXCLUDED — those are static-keyword-only categories with security /
+# correctness contracts that user-supplied overrides shouldn't be able
+# to forge:
+#   * ``private`` — privacy lockdown comes with extra guarantees
+#     (window data scrubbed, LLM enrichment bypassed). The state machine
+#     additionally treats static-DB private hits as "locked" so user
+#     overrides can't downgrade them. Letting users mint NEW private
+#     entries via override would be confusing — accept it here, but
+#     state_machine's private-locked semantics only apply to static-DB
+#     hits, so the override would never actually trigger the privacy
+#     bypass. Reject at load time so the asymmetry doesn't surprise.
+#   * ``own_app`` — same reasoning. The catgirl-app exclusion is a
+#     codebase invariant, not a user setting.
 _VALID_CATEGORIES = frozenset({
-    'gaming', 'work', 'entertainment', 'communication', 'private', 'own_app',
+    'gaming', 'work', 'entertainment', 'communication',
 })
 
 
@@ -143,12 +167,39 @@ class ActivityPreferences:
 
 
 # ── Module-level cache ────────────────────────────────────────────────
+#
+# Bundled into one mutable holder rather than four module-level globals
+# so each cache update is an attribute write — this way the cross-call
+# state is structurally explicit, and intra-function flow analysis (e.g.
+# CodeQL's "unused global" rule) doesn't keep flagging the assignments
+# as dead just because they aren't read again in the same function body.
+
+
+class _CacheState:
+    """Cross-invocation cache for ``get_activity_preferences``.
+
+    Single-instance holder. ``prefs`` always returns the most recently
+    successfully loaded value (or the all-defaults fallback). The other
+    three fields gate when to skip an expensive reload.
+    """
+
+    __slots__ = ('prefs', 'fetched_at', 'path', 'mtime')
+
+    def __init__(self) -> None:
+        self.prefs: ActivityPreferences = ActivityPreferences()
+        self.fetched_at: float = 0.0
+        self.path: str | None = None
+        self.mtime: float | None = None
+
+    def reset_metadata(self) -> None:
+        """Force the next ``get_activity_preferences`` call to re-read the file."""
+        self.fetched_at = 0.0
+        self.path = None
+        self.mtime = None
+
 
 _cache_lock = threading.Lock()
-_cached_prefs: ActivityPreferences = ActivityPreferences()
-_cached_at: float = 0.0
-_cached_path: str | None = None
-_cached_mtime: float | None = None
+_cache = _CacheState()
 
 
 def get_activity_preferences() -> ActivityPreferences:
@@ -159,22 +210,21 @@ def get_activity_preferences() -> ActivityPreferences:
     object; on parse failure the cache stays on its previous value (or
     defaults if there's never been a successful load).
     """
-    global _cached_prefs, _cached_at, _cached_path, _cached_mtime
     now = time.time()
     with _cache_lock:
         if (
-            _cached_at
-            and now - _cached_at < _PREFERENCES_RELOAD_INTERVAL_SECONDS
+            _cache.fetched_at
+            and now - _cache.fetched_at < _PREFERENCES_RELOAD_INTERVAL_SECONDS
         ):
-            return _cached_prefs
+            return _cache.prefs
 
         path = _resolve_preferences_path()
         if path is None:
-            _cached_prefs = ActivityPreferences()
-            _cached_at = now
-            _cached_path = None
-            _cached_mtime = None
-            return _cached_prefs
+            _cache.prefs = ActivityPreferences()
+            _cache.fetched_at = now
+            _cache.path = None
+            _cache.mtime = None
+            return _cache.prefs
 
         try:
             mtime = os.path.getmtime(path)
@@ -183,15 +233,27 @@ def get_activity_preferences() -> ActivityPreferences:
 
         # If the path AND mtime are unchanged, skip the parse and just
         # advance the freshness timestamp.
-        if path == _cached_path and mtime == _cached_mtime and mtime is not None:
-            _cached_at = now
-            return _cached_prefs
+        if path == _cache.path and mtime == _cache.mtime and mtime is not None:
+            _cache.fetched_at = now
+            return _cache.prefs
 
         prefs = _load_from_file(path)
-        _cached_prefs = prefs
-        _cached_at = now
-        _cached_path = path
-        _cached_mtime = mtime
+        if prefs is None:
+            # Parse / read failed (file mid-edit, malformed JSON, etc).
+            # Keep the previously cached prefs intact rather than wiping
+            # them with defaults — a transient bad write shouldn't
+            # silently disable all the user's overrides until the next
+            # successful save. Advance ``fetched_at`` so we don't retry
+            # on every call; let the next mtime change trigger a real
+            # reload.
+            _cache.fetched_at = now
+            _cache.path = path
+            _cache.mtime = mtime
+            return _cache.prefs
+        _cache.prefs = prefs
+        _cache.fetched_at = now
+        _cache.path = path
+        _cache.mtime = mtime
         return prefs
 
 
@@ -200,11 +262,8 @@ def invalidate_activity_preferences_cache() -> None:
 
     Useful for tests + post-settings-UI-write hooks.
     """
-    global _cached_at, _cached_path, _cached_mtime
     with _cache_lock:
-        _cached_at = 0.0
-        _cached_path = None
-        _cached_mtime = None
+        _cache.reset_metadata()
 
 
 def _resolve_preferences_path() -> str | None:
@@ -227,23 +286,36 @@ def _resolve_preferences_path() -> str | None:
     return None
 
 
-def _load_from_file(path: str) -> ActivityPreferences:
+def _load_from_file(path: str) -> ActivityPreferences | None:
     """Read user_preferences.json and extract the ``activity`` sub-dict.
 
-    Returns ``ActivityPreferences()`` (all defaults) on any error or if
-    the activity section is absent. Validation is best-effort — invalid
-    entries inside the section are silently dropped without rejecting
-    the rest of the section. We never want a typo to wedge the tracker.
+    Returns:
+      * ``ActivityPreferences()`` (all defaults) when the file parses
+        successfully but has no activity section — a legitimate "user
+        hasn't configured anything" state.
+      * Parsed ``ActivityPreferences`` when the activity section is
+        present.
+      * ``None`` when the read or JSON parse FAILED — caller's contract
+        is to keep the previous cached value rather than overwriting
+        with defaults. Distinguishing parse-failure from
+        no-activity-section is what prevents a transient corrupt write
+        from wiping the user's overrides.
+
+    Validation is best-effort within the activity section — invalid
+    entries inside it are silently dropped without rejecting the rest.
+    We never want a typo to wedge the tracker.
     """
     try:
         with open(path, 'r', encoding='utf-8') as f:
             data = json.load(f)
     except Exception as e:
         logger.debug('activity_config: failed to read %s: %s', path, e)
-        return ActivityPreferences()
+        return None
 
     if not isinstance(data, list):
-        # Legacy dict-shaped preferences file — no global entry to look at.
+        # Legacy dict-shaped preferences file — no global entry to look at,
+        # but the file IS valid (just an old shape). Treat as "no activity
+        # section configured" → defaults.
         return ActivityPreferences()
 
     activity_dict: dict | None = None


### PR DESCRIPTION
## 背景

PR #1015 落了 activity tracker 基础后，截图比对里"他们"那份设计有 10 项可借鉴差距。本 PR 一次性吃下 5 项「信任 + 控制 + 风格」相关的小包：#3 隐私黑名单 / #4 用户 override + N.E.K.O 自身排除 / #5 配置外置 / #7 tone modifier / #1 游戏 intensity × genre。剩下两条单独 issue 走（#2 系统压力自请退出 → [#1020](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1020)，#9 跨平台 OS 信号 → [#1023](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1023)）；#10 默认关 + 同意书按用户决定**先不动**。

## 主要内容

### #3 隐私黑名单
`PRIVATE_TITLE_KEYWORDS` / `PRIVATE_PROCESS_NAMES` 列出密码管理器（KeePass / 1Password / Bitwarden / Vaultwarden / LastPass / Dashlane / Enpass / NordPass / RoboForm / Proton Pass）+ 验证器（Authy）+ 加密钱包（Ledger Live / Trezor Suite / Exodus）。命中 → `state='private'`，propensity 硬钉 `'closed'`：
- state machine 把 active_window 脱敏（清 title / process_name）
- tracker 跳过 LLM enrichment、后台 activity_guess loop、open_threads kickoff
- proactive_chat Phase 1 看到 `closed` 短路 PASS，不调 LLM、不拉 source
- 用户的 app/title override **不能**把 KeePass 降级成 work（privacy 保证）

### #4 用户 override + N.E.K.O 自身排除
新建 [`utils/activity_config.py`](utils/activity_config.py) — preferences loader 读 `user_preferences.json::__global_conversation__::activity` 子 dict，mtime-based 30s 缓存 + 单字段 validator（坏值静默丢弃）。三档 override：
- `user_app_overrides`（process-name keyed）
- `user_title_overrides`（title-substring keyed，仅 unknown 走）
- `user_game_overrides`（canonical-name keyed，patches intensity/genre）

`OWN_APP_TITLE_KEYWORDS` / `OWN_APP_PROCESS_NAMES`（`projectneko_server.exe` / `Xiao8.exe` / `lanlan_frd.exe` + 标题 N.E.K.O / Xiao8 / 小八 / Project N.E.K.O）→ state machine `update_window` 早退，dwell 时钟冻结、GPU fallback 不被自家 Live2D/VRM 骗。

### #5 配置外置
state_machine.py 的 13 个常量（`AWAY_IDLE_SECONDS` / `STALE_RECOVERY_SECONDS` / `VOICE_ACTIVE_WINDOW_SECONDS` / `FOCUSED_WORK_*` / `WINDOW_*` / `UNFINISHED_THREAD_*` / `GAMING_GPU_*`）改成 instance 属性，构造时从 `ActivityPreferences.thresholds` 读取，code-default 兜底。

### #7 tone modifier
snapshot.py 加 `ActivityTone` enum + 纯函数 `derive_tone()`：六档 `terse / hushed / mellow / playful / warm / concise`，从 `(state, intensity, genre, voice_engaged)` 派生。`format_activity_state_section` 渲染一行「口吻：xxx」（concise 默认 + closed 不渲染，省 token）。配 5 lang × 6 tone 提示文。**没有 silent**——静音是 skip_probability 的活，跟"语气"是正交维度。

### #1 游戏 intensity × genre
`GAME_TITLE_KEYWORDS` schema 升 4 元组：
\`\`\`python
('League of Legends', ['LoL', '英雄联盟'], 'competitive', 'moba')
\`\`\`
2 元组（未打标的）继续兼容（`_unpack_game_row`），行为退到 PR #1015 的 `varied/None` 默认。**top ~70 游戏已打 intensity/genre 标签**（Hoyo gacha + 腾讯/网易 + Steam top 100 + JP/KR MMO + 主机大作 + horror/casual）。

### skip_probability（替代之前提的 silent propensity）
`derive_skip_probability()` 派生概率：
- `competitive` 任意 → 0.3
- `immersive + horror` → 0.3
- 其余 gaming + 非 gaming → 0.0

`proactive_chat` Phase 1 起点掷骰，roll < skip_prob → PASS。两道守卫：
- `propensity=closed`：硬短路，先于骰子，连 unfinished_thread 都让位（隐私优先）
- `unfinished_thread is not None`：跳过骰子（AI 已经问了问题，跟进不该被概率打断）

用户可在 preferences 改 `skip_probability_overrides`：写 1.0 实现"完全静音"，0.0 关闭，任意值在中间 — 把"是否完全 silent"完全交给用户。

## 改动对比表

| 文件 | 性质 | 行数 |
|---|---|---|
| [main_logic/activity/snapshot.py](main_logic/activity/snapshot.py) | 改 | +254 |
| [main_logic/activity/state_machine.py](main_logic/activity/state_machine.py) | 改 | +302 / -76 |
| [main_logic/activity/tracker.py](main_logic/activity/tracker.py) | 改 | +60 / -8 |
| [main_routers/system_router.py](main_routers/system_router.py) | 改 | +53 / -1 |
| [config/activity_keywords.py](config/activity_keywords.py) | 改 | +452 / -90 |
| [config/prompts_activity.py](config/prompts_activity.py) | 改 | +78 |
| [docs/design/user-activity-tracker.md](docs/design/user-activity-tracker.md) | 改 | +173 / -6 |
| [utils/activity_config.py](utils/activity_config.py) | **新** | +331 |
| [tests/test_activity_tracker_followup.py](tests/test_activity_tracker_followup.py) | **新** | +331 |

## Test plan

- [x] 34 个新单测全过（隐私分类参数化×5、私密脱敏 / yields-to-away / vs-voice、own-app 透传 + GPU 抑制、app override + 不可降级 private、game override 翻 intensity、阈值外置 + validator 丢坏值、tone 全表参数化×16、skip 默认值 + override clamp + 特定 combo 优先级）
- [x] 全量 unit-test 1363 passed / 14 skipped（除 PR #1015 合并时遗留的 6 个 pre-broken Mock 测试）
- [x] ruff 全过
- [ ] 真实 Windows 桌面环境 smoke：开 KeePass / 打开 N.E.K.O 自身窗口 / 玩 LoL（competitive）vs 玩 Stardew（casual）观察 propensity / skip / tone 派生
- [ ] 配 user_preferences.json 写入 activity 子 dict，验证 thresholds + override 生效
- [ ] 长时间运行观察 skip_probability 实际跳过比例是否符合 0.3 默认

## 关联

- 基于 PR #1015（活动追踪器基础）
- Issue [#1020](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1020) 系统压力自请退出（独立 follow-up）
- Issue [#1023](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1023) 跨平台 OS 信号（Electron 推送方案，单独 PR B）
- 后续 long-tail 游戏 retag 走增量 PR（schema 已就位）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 private 与 own_app 活动类别；引入 skip_probability、tone、game_intensity/game_genre 与按语种的 tone 提示；快照在 private 状态下跳过富化/缓存并脱敏；支持运行时热加载并应用用户偏好覆盖（含游戏强度/类型与概率覆写）；主动流在调试输出中暴露 skip_probability 与 tone，并基于概率短路主动响应。
* **文档**
  * 更新活动追踪设计：隐私黑名单、own_app 冻结行为、跳过概率策略、音调轴、游戏标注新旧格式兼容与优先级说明。
* **测试**
  * 新增广泛回归测试覆盖 private/own_app 行为、偏好加载与校验、跳过概率与音调推导、游戏强度/类型与阈值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->