### PR TITLE
refactor(agent): 把 agent/plugin/tracker 的字符截断字面量收口到命名常量

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -31,7 +31,9 @@ from config import (
     TASK_ERROR_MAX_TOKENS,
     AGENT_HISTORY_TURNS,
     EXCEPTION_TEXT_MAX_CHARS,
+    ERROR_MESSAGE_MAX_CHARS,
     TASK_TRACKER_DETAIL_MAX_CHARS,
+    TASK_TRACKER_INJECT_DETAIL_MAX_CHARS,
     USER_NOTIFICATION_REASON_MAX_CHARS,
     USER_NOTIFICATION_ERROR_MAX_CHARS,
 )
@@ -271,7 +273,7 @@ class AgentTaskTracker:
             kind = r["kind"]
             method = r["method"]
             desc = _sanitize(r.get("desc", ""), TASK_DETAIL_MAX_TOKENS)
-            detail = _sanitize(r.get("detail", ""), 300)
+            detail = _sanitize(r.get("detail", ""), TASK_TRACKER_INJECT_DETAIL_MAX_CHARS)
             if kind == "assigned":
                 line = f"[ASSIGNED] method={method} | {desc}"
             elif kind == "completed":
@@ -2032,7 +2034,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_failed', _rp_lang(None)),
-                                error_message=str(nk_result.get("error") or "")[:EXCEPTION_TEXT_MAX_CHARS],
+                                error_message=str(nk_result.get("error") or "")[:ERROR_MESSAGE_MAX_CHARS],
                             )
                     except Exception as e:
                         logger.exception("[OpenClaw] magic command dispatch failed: %s", e)
@@ -2043,7 +2045,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_dispatch_failed', _rp_lang(None)),
-                                error_message=str(e)[:EXCEPTION_TEXT_MAX_CHARS],
+                                error_message=str(e)[:ERROR_MESSAGE_MAX_CHARS],
                             )
                         except Exception:
                             pass
@@ -2140,7 +2142,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_failed', _rp_lang(None)),
-                                error_message=str(nk_result.get("error") or "")[:EXCEPTION_TEXT_MAX_CHARS],
+                                error_message=str(nk_result.get("error") or "")[:ERROR_MESSAGE_MAX_CHARS],
                             )
                         await _emit_main_event(
                             "task_update",
@@ -2214,7 +2216,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_dispatch_failed', _rp_lang(None)),
-                                error_message=str(e)[:EXCEPTION_TEXT_MAX_CHARS],
+                                error_message=str(e)[:ERROR_MESSAGE_MAX_CHARS],
                             )
                         except Exception:
                             pass

--- a/agent_server.py
+++ b/agent_server.py
@@ -30,6 +30,10 @@ from config import (
     TASK_DETAIL_MAX_TOKENS,
     TASK_ERROR_MAX_TOKENS,
     AGENT_HISTORY_TURNS,
+    EXCEPTION_TEXT_MAX_CHARS,
+    TASK_TRACKER_DETAIL_MAX_CHARS,
+    USER_NOTIFICATION_REASON_MAX_CHARS,
+    USER_NOTIFICATION_ERROR_MAX_CHARS,
 )
 from utils.config_manager import get_config_manager
 from utils.tokenize import truncate_to_tokens as _tt
@@ -1566,10 +1570,10 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 logger.warning("[TaskExecutor] Assessment failed: %s", reason)
                 await _emit_main_event(
                     "agent_notification", lanlan_name,
-                    text=f"⚠️ Agent评估失败: {reason[:200]}",
+                    text=f"⚠️ Agent评估失败: {reason[:USER_NOTIFICATION_REASON_MAX_CHARS]}",
                     source="brain",
                     status="error",
-                    error_message=reason[:500],
+                    error_message=reason[:USER_NOTIFICATION_ERROR_MAX_CHARS],
                 )
             else:
                 logger.debug("[TaskExecutor] No actionable task found")
@@ -1877,7 +1881,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             except Exception as emit_err:
                                 logger.debug("[TaskExecutor] emit task_update(terminal) failed: task_id=%s plugin_id=%s error=%s", result.task_id, plugin_id, emit_err)
                     except asyncio.CancelledError as e:
-                        cancel_msg = str(e)[:500] if str(e) else "cancelled"
+                        cancel_msg = str(e)[:EXCEPTION_TEXT_MAX_CHARS] if str(e) else "cancelled"
                         _reg = Modules.task_registry.get(result.task_id)
                         if _reg:
                             _reg["status"] = "cancelled"
@@ -1885,7 +1889,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         _task_tracker.record_completed(
                             lanlan_name, task_id=result.task_id, method="user_plugin",
                             desc=f"{plugin_id}.{entry_id}: {result.task_description or ''}",
-                            detail=cancel_msg[:200], success=False, cancelled=True,
+                            detail=cancel_msg[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False, cancelled=True,
                         )
                         # Honor plugin's resolved delivery mode if it had a chance
                         # to run before cancel; default to "proactive" otherwise.
@@ -1932,14 +1936,14 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         _task_tracker.record_completed(
                             lanlan_name, task_id=result.task_id, method="user_plugin",
                             desc=f"{plugin_id}.{entry_id}: {result.task_description or ''}",
-                            detail=str(e)[:200], success=False,
+                            detail=str(e)[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False,
                         )
                         # Honor plugin's resolved delivery mode (if any); silent
                         # plugins stay silent even on dispatch exception.
                         if _delivery_mode != "silent":
                             try:
                                 display_id = await _get_plugin_display_id(plugin_id)
-                                _exc_text = str(e)[:500]
+                                _exc_text = str(e)[:EXCEPTION_TEXT_MAX_CHARS]
                                 await _emit_task_result(
                                     lanlan_name,
                                     channel="user_plugin",
@@ -2017,7 +2021,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 channel="openclaw",
                                 task_id=str(result.task_id or ""),
                                 success=True,
-                                summary=reply[:500] if reply else _rp_phrase('openclaw_done', _rp_lang(None)),
+                                summary=reply[:EXCEPTION_TEXT_MAX_CHARS] if reply else _rp_phrase('openclaw_done', _rp_lang(None)),
                                 detail=reply,
                                 direct_reply=direct_reply,
                             )
@@ -2028,7 +2032,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_failed', _rp_lang(None)),
-                                error_message=str(nk_result.get("error") or "")[:500],
+                                error_message=str(nk_result.get("error") or "")[:EXCEPTION_TEXT_MAX_CHARS],
                             )
                     except Exception as e:
                         logger.exception("[OpenClaw] magic command dispatch failed: %s", e)
@@ -2039,7 +2043,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_dispatch_failed', _rp_lang(None)),
-                                error_message=str(e)[:500],
+                                error_message=str(e)[:EXCEPTION_TEXT_MAX_CHARS],
                             )
                         except Exception:
                             pass
@@ -2117,7 +2121,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         _task_tracker.record_completed(
                             lanlan_name, task_id=result.task_id, method="openclaw",
                             desc=result.task_description or instruction or "",
-                            detail=reply[:200] if reply else "", success=success,
+                            detail=reply[:TASK_TRACKER_DETAIL_MAX_CHARS] if reply else "", success=success,
                         )
                         if success:
                             await _emit_task_result(
@@ -2125,7 +2129,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 channel="openclaw",
                                 task_id=str(result.task_id or ""),
                                 success=True,
-                                summary=reply[:500] if reply else _rp_phrase('openclaw_done', _rp_lang(None)),
+                                summary=reply[:EXCEPTION_TEXT_MAX_CHARS] if reply else _rp_phrase('openclaw_done', _rp_lang(None)),
                                 detail=reply,
                                 direct_reply=direct_reply,
                             )
@@ -2136,7 +2140,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_failed', _rp_lang(None)),
-                                error_message=str(nk_result.get("error") or "")[:500],
+                                error_message=str(nk_result.get("error") or "")[:EXCEPTION_TEXT_MAX_CHARS],
                             )
                         await _emit_main_event(
                             "task_update",
@@ -2152,7 +2156,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             },
                         )
                     except asyncio.CancelledError as e:
-                        cancel_msg = str(e)[:500] if str(e) else "cancelled"
+                        cancel_msg = str(e)[:EXCEPTION_TEXT_MAX_CHARS] if str(e) else "cancelled"
                         _reg = Modules.task_registry.get(result.task_id)
                         if _reg:
                             _reg["status"] = "cancelled"
@@ -2160,7 +2164,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         _task_tracker.record_completed(
                             lanlan_name, task_id=result.task_id, method="openclaw",
                             desc=result.task_description or instruction or "",
-                            detail=cancel_msg[:200], success=False, cancelled=True,
+                            detail=cancel_msg[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False, cancelled=True,
                         )
                         try:
                             await _emit_task_result(
@@ -2201,7 +2205,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         _task_tracker.record_completed(
                             lanlan_name, task_id=result.task_id, method="openclaw",
                             desc=result.task_description or instruction or "",
-                            detail=str(e)[:200], success=False,
+                            detail=str(e)[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False,
                         )
                         try:
                             await _emit_task_result(
@@ -2210,7 +2214,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                                 task_id=str(result.task_id or ""),
                                 success=False,
                                 summary=_rp_phrase('openclaw_dispatch_failed', _rp_lang(None)),
-                                error_message=str(e)[:500],
+                                error_message=str(e)[:EXCEPTION_TEXT_MAX_CHARS],
                             )
                         except Exception:
                             pass
@@ -2300,7 +2304,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         _task_tracker.record_completed(
                             lanlan_name, task_id=bu_task_id, method="browser_use",
                             desc=result.task_description or "",
-                            detail=bu_parsed[:200] if bu_parsed else "", success=success,
+                            detail=bu_parsed[:TASK_TRACKER_DETAIL_MAX_CHARS] if bu_parsed else "", success=success,
                         )
                         bu_info["status"] = "completed" if success else "failed"
                         bu_info["end_time"] = _now_iso()
@@ -2327,13 +2331,13 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         except Exception as emit_err:
                             logger.debug("[BrowserUse] emit task_update(terminal) failed: task_id=%s error=%s", bu_task_id, emit_err)
                     except asyncio.CancelledError as e:
-                        cancel_msg = str(e)[:500] if str(e) else "cancelled"
+                        cancel_msg = str(e)[:EXCEPTION_TEXT_MAX_CHARS] if str(e) else "cancelled"
                         bu_info["status"] = "cancelled"
                         bu_info["error"] = cancel_msg
                         bu_session.complete_task(cancel_msg, success=False)
                         _task_tracker.record_completed(
                             lanlan_name, task_id=bu_task_id, method="browser_use",
-                            desc=result.task_description or "", detail=cancel_msg[:200], success=False, cancelled=True,
+                            desc=result.task_description or "", detail=cancel_msg[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False, cancelled=True,
                         )
                         try:
                             await _emit_task_result(
@@ -2369,7 +2373,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         bu_info["end_time"] = _now_iso()
                         _task_tracker.record_completed(
                             lanlan_name, task_id=bu_task_id, method="browser_use",
-                            desc=result.task_description or "", detail=str(e)[:200], success=False,
+                            desc=result.task_description or "", detail=str(e)[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False,
                         )
                         bu_info["error"] = _tt(str(e), TASK_ERROR_MAX_TOKENS)
                         bu_session.complete_task(str(e), success=False)
@@ -2544,7 +2548,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             except Exception as emit_err:
                                 logger.debug("[OpenFang] emit task_update(terminal) failed: task_id=%s error=%s", of_task_id, emit_err)
                         except asyncio.CancelledError as e:
-                            cancel_msg = str(e)[:500] if str(e) else "cancelled"
+                            cancel_msg = str(e)[:EXCEPTION_TEXT_MAX_CHARS] if str(e) else "cancelled"
                             # Best-effort remote cancel
                             try:
                                 if Modules.openfang:
@@ -2557,7 +2561,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             of_session.complete_task(cancel_msg, success=False)
                             _task_tracker.record_completed(
                                 lanlan_name, task_id=of_task_id, method="openfang",
-                                desc=result.task_description or "", detail=cancel_msg[:200], success=False, cancelled=True,
+                                desc=result.task_description or "", detail=cancel_msg[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False, cancelled=True,
                             )
                             try:
                                 await _emit_task_result(
@@ -2590,7 +2594,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             of_session.complete_task(str(e), success=False)
                             _task_tracker.record_completed(
                                 lanlan_name, task_id=of_task_id, method="openfang",
-                                desc=result.task_description or "", detail=str(e)[:200], success=False,
+                                desc=result.task_description or "", detail=str(e)[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False,
                             )
                             try:
                                 await _emit_task_result(
@@ -2635,7 +2639,7 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                 text=f"💥 Agent后台任务异常: {type(e).__name__}: {e}",
                 source="brain",
                 status="error",
-                error_message=str(e)[:500],
+                error_message=str(e)[:USER_NOTIFICATION_ERROR_MAX_CHARS],
             )
         except Exception:
             logger.debug("[TaskExecutor] emit notification failed", exc_info=True)
@@ -3234,7 +3238,7 @@ async def plugin_execute_direct(payload: Dict[str, Any]):
             if _delivery_mode != "silent":
                 try:
                     display_id = await _get_plugin_display_id(plugin_id)
-                    _exc_text = str(e)[:500]
+                    _exc_text = str(e)[:EXCEPTION_TEXT_MAX_CHARS]
                     await _emit_task_result(
                         lanlan_name,
                         channel="user_plugin",

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1033,35 +1033,76 @@ TASK_ERROR_MAX_TOKENS = 350
 # notification）之前的硬截。
 #
 # 为什么是 char 而不是 token：
-# - LLM-facing 字段（summary / detail / error_message）真正的 prompt
-#   budget 在 _emit_task_result 内部用 TASK_*_MAX_TOKENS 二次截断；外层
-#   char-cap 只是为了避免把 MB 级原始字符串直接喂给 tiktoken（编码本身
-#   就很慢）。
-# - tracker.detail 进的是内存日志（去重 / 上下文交错），不直接进 LLM
-#   prompt；char 精度足够。
+# - LLM-facing 字段（summary / detail / error_message / tracker.detail）
+#   真正的 prompt budget 在 _emit_task_result 内部用 TASK_*_MAX_TOKENS
+#   二次截断；外层 char-cap 只是为了避免把 MB 级原始字符串直接喂给
+#   tiktoken（编码本身就很慢）。
 # - 前端 agent_notification 字段是 toast / 错误面板展示，不进 LLM；
 #   token 精度无业务意义。
+#
+# 常量值分组（按"是否进 LLM 上下文"切）：
+#   进上下文（防御性 char-cap，下游再走 token-cap）：
+#     - EXCEPTION_TEXT_MAX_CHARS         = 500  → summary 字段、_exc_text
+#                                                / cancel_msg 等共享变量
+#     - ERROR_MESSAGE_MAX_CHARS          = 300  → error_message 字段直接 cap
+#     - TASK_TRACKER_DETAIL_MAX_CHARS    = 300  → tracker.record_completed
+#                                                .detail 字段（inject 时进
+#                                                LLM 的 system 消息）
+#     - TASK_TRACKER_INJECT_DETAIL_MAX_CHARS = 300 → tracker.inject 渲染
+#                                                detail 写进 LLM prompt
+#                                                的最终一次 char-cap
+#   不进上下文（前端展示）：
+#     - USER_NOTIFICATION_REASON_MAX_CHARS = 200  → agent_notification.text
+#     - USER_NOTIFICATION_ERROR_MAX_CHARS  = 500  → agent_notification
+#                                                  .error_message
 
 EXCEPTION_TEXT_MAX_CHARS = 500
-"""异常 / 取消 / 插件 reply 等长字符串进入 LLM-facing 字段前的防御性
-char-cap。
-- 用途：str(e)[:N]、cancel_msg = str(e)[:N]、reply[:N] 在塞进
-  _emit_task_result 的 summary / detail / error_message 之前做的硬截。
+"""LLM-facing summary 字段 / 共享异常变量的防御性 char-cap。
+- 用途：
+  1. summary=reply[:N] / summary=_exc_text 等直接对 summary 字段的 char-cap。
+  2. cancel_msg = str(e)[:N] / _exc_text = str(e)[:N] 这类"一份截断给
+     summary/detail/error_message 三个字段共用"的局部变量。
 - 为什么是 char：tracebacks / API 错误体可能高达 MB，先 char-cap 再让
   _emit_task_result 内部用 TASK_SUMMARY_MAX_TOKENS / TASK_LARGE_DETAIL_
   MAX_TOKENS / TASK_ERROR_MAX_TOKENS 做精确 token 截，省去对整个原始
   字符串做 tiktoken 编码的开销。
-- 上游：异常文本、CancelledError msg、openclaw reply 原文。"""
+- 与 ERROR_MESSAGE_MAX_CHARS 的关系：单纯 error_message 字段直接 char-cap
+  统一走 300（更紧）；本常量是变量级 / summary 级，500 给 summary 留点
+  余量；当 cancel_msg / _exc_text 这类已经 500 的变量再赋给 error_message
+  时，沿用变量截断结果，不再做二次截。"""
 
-TASK_TRACKER_DETAIL_MAX_CHARS = 200
+ERROR_MESSAGE_MAX_CHARS = 300
+"""LLM-facing error_message 字段直接 char-cap。
+- 用途：error_message=str(e)[:N] / error_message=str(nk_result.get("error"))[:N]
+  这类直接对 error_message 字段的 char-cap（没有走中间共享变量的那种）。
+- 为什么是 char：和 EXCEPTION_TEXT_MAX_CHARS 同样是给下游 _emit_task_result
+  内部 TASK_ERROR_MAX_TOKENS（350 token）做防御性预处理。
+- 为什么和 EXCEPTION_TEXT_MAX_CHARS 数值不同：error_message 字段下游 token
+  budget 比 summary 紧（350 vs 400），300 char 能避免给 token-cap 留无效
+  空间，同时与 TASK_TRACKER_*_MAX_CHARS 对齐。"""
+
+TASK_TRACKER_DETAIL_MAX_CHARS = 300
 """AgentTaskTracker.record_completed 的 detail 字段 char-cap。
 - 用途：失败 / 取消路径上 detail=str(e)[:N] / detail=cancel_msg[:N] /
   detail=reply[:N] 等给 tracker 的 detail 字段做硬截。
-- 为什么是 char：tracker 记录只进内存日志（analyzer 去重 + 上下文交错
-  排序），不直接进 LLM prompt——200 char 足够人/规则判重，不需要 token
-  精度，也省一次 tiktoken 编码。
+- 为什么是 char：tracker.detail 看似只进内存日志，但 AgentTaskTracker.
+  inject() 会把整段记录拼成 system 消息塞进 task_executor 的下次决策
+  messages（agent_server.py 中的 _task_tracker.inject(messages, lanlan)），
+  所以这条字段实际上会进 LLM 上下文。三层防御链路：
+    1. 入站 char-cap = 本常量（300）
+    2. record_completed 内部 _tt(detail, TASK_DETAIL_MAX_TOKENS)（200 token）
+    3. inject 渲染时再 char-cap = TASK_TRACKER_INJECT_DETAIL_MAX_CHARS（300）
 - 注意：成功路径上 OpenFang 已用 _tt(_track_detail, TASK_DETAIL_MAX_TOKENS)
-  走 token-cap（见 agent_server.py），那条路径不在本常量管辖范围。"""
+  走 token-cap，那条路径不在本常量管辖范围。"""
+
+TASK_TRACKER_INJECT_DETAIL_MAX_CHARS = 300
+"""AgentTaskTracker.inject 渲染 detail 进 LLM system 消息时的最终 char-cap。
+- 用途：agent_server.AgentTaskTracker.inject 内部 _sanitize(detail, N) 在把
+  每条 record 的 detail 拼进 [AGENT TASK TRACKING …] system 消息前做的
+  最后一次 char-cap。
+- 为什么是 char：进 LLM prompt 前的硬上限——已经被入站 char-cap +
+  record_completed 内 token-cap 处理过；这里再 char-cap 是渲染时为了让
+  单行长度可控。"""
 
 USER_NOTIFICATION_REASON_MAX_CHARS = 200
 """agent_notification.text 内嵌 reason 片段的 char-cap。
@@ -1070,12 +1111,16 @@ USER_NOTIFICATION_REASON_MAX_CHARS = 200
 - 为什么是 char：toast 容量小、不进 LLM。"""
 
 USER_NOTIFICATION_ERROR_MAX_CHARS = 500
-"""agent_notification.error_message 字段 char-cap。
-- 用途：main_server EventBus 在转发 task_result / agent_notification 给
-  前端 WS 时对 error_message 做的硬截；agent_server 评估失败时也按此
-  cap reason 写进 error_message。
+"""agent_notification.error_message 字段 char-cap（前端展示，不进 LLM）。
+- 用途：main_server EventBus 在转发 agent_notification 给前端 WS 时对
+  error_message 做的硬截；agent_server 评估失败 / 后台异常时也按此
+  cap reason / str(e) 写进 agent_notification.error_message。
 - 为什么是 char：纯前端展示字段，不进 LLM；和 USER_NOTIFICATION_REASON_
-  MAX_CHARS 数值不同（错误详情比 toast 文本宽容）。"""
+  MAX_CHARS 数值不同（错误详情比 toast 文本宽容）。
+- 注意：本常量服务的是"前端 agent_notification 通道"的 error_message，
+  和 LLM-facing 的 ERROR_MESSAGE_MAX_CHARS（300）不是一回事——前者直
+  接灌 WS 帧给浏览器，后者是 _emit_task_result 字段经 callback 进
+  LLM prompt。"""
 
 AGENT_TASK_TRACKER_MAX_RECORDS = 50
 """AgentTaskTracker 最多保留的任务执行记录数。

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1027,6 +1027,56 @@ TASK_ERROR_MAX_TOKENS = 350
 - 用途：_emit_task_result 的 error 档位。
 - 上游：异常 stack / API 错误响应。"""
 
+# ---- Agent: defensive char-caps (NOT token caps) ----
+# 下面这些是"防御性 char-cap"——在异常文本 / cancel reason / plugin reply
+# 流入下游字段（summary / detail / error_message / tracker.detail / 前端
+# notification）之前的硬截。
+#
+# 为什么是 char 而不是 token：
+# - LLM-facing 字段（summary / detail / error_message）真正的 prompt
+#   budget 在 _emit_task_result 内部用 TASK_*_MAX_TOKENS 二次截断；外层
+#   char-cap 只是为了避免把 MB 级原始字符串直接喂给 tiktoken（编码本身
+#   就很慢）。
+# - tracker.detail 进的是内存日志（去重 / 上下文交错），不直接进 LLM
+#   prompt；char 精度足够。
+# - 前端 agent_notification 字段是 toast / 错误面板展示，不进 LLM；
+#   token 精度无业务意义。
+
+EXCEPTION_TEXT_MAX_CHARS = 500
+"""异常 / 取消 / 插件 reply 等长字符串进入 LLM-facing 字段前的防御性
+char-cap。
+- 用途：str(e)[:N]、cancel_msg = str(e)[:N]、reply[:N] 在塞进
+  _emit_task_result 的 summary / detail / error_message 之前做的硬截。
+- 为什么是 char：tracebacks / API 错误体可能高达 MB，先 char-cap 再让
+  _emit_task_result 内部用 TASK_SUMMARY_MAX_TOKENS / TASK_LARGE_DETAIL_
+  MAX_TOKENS / TASK_ERROR_MAX_TOKENS 做精确 token 截，省去对整个原始
+  字符串做 tiktoken 编码的开销。
+- 上游：异常文本、CancelledError msg、openclaw reply 原文。"""
+
+TASK_TRACKER_DETAIL_MAX_CHARS = 200
+"""AgentTaskTracker.record_completed 的 detail 字段 char-cap。
+- 用途：失败 / 取消路径上 detail=str(e)[:N] / detail=cancel_msg[:N] /
+  detail=reply[:N] 等给 tracker 的 detail 字段做硬截。
+- 为什么是 char：tracker 记录只进内存日志（analyzer 去重 + 上下文交错
+  排序），不直接进 LLM prompt——200 char 足够人/规则判重，不需要 token
+  精度，也省一次 tiktoken 编码。
+- 注意：成功路径上 OpenFang 已用 _tt(_track_detail, TASK_DETAIL_MAX_TOKENS)
+  走 token-cap（见 agent_server.py），那条路径不在本常量管辖范围。"""
+
+USER_NOTIFICATION_REASON_MAX_CHARS = 200
+"""agent_notification.text 内嵌 reason 片段的 char-cap。
+- 用途：DirectTaskExecutor 评估失败时把 reason 拼进面向前端 toast 的
+  text 字段（"⚠️ Agent评估失败: {reason[:N]}"）。
+- 为什么是 char：toast 容量小、不进 LLM。"""
+
+USER_NOTIFICATION_ERROR_MAX_CHARS = 500
+"""agent_notification.error_message 字段 char-cap。
+- 用途：main_server EventBus 在转发 task_result / agent_notification 给
+  前端 WS 时对 error_message 做的硬截；agent_server 评估失败时也按此
+  cap reason 写进 error_message。
+- 为什么是 char：纯前端展示字段，不进 LLM；和 USER_NOTIFICATION_REASON_
+  MAX_CHARS 数值不同（错误详情比 toast 文本宽容）。"""
+
 AGENT_TASK_TRACKER_MAX_RECORDS = 50
 """AgentTaskTracker 最多保留的任务执行记录数。
 - 用途：deque-like 结构 maxlen，供 analyzer 去重 / 上下文交错排序。

--- a/main_server.py
+++ b/main_server.py
@@ -52,7 +52,7 @@ import httpx # noqa
 import time # noqa
 import signal # noqa
 from datetime import datetime, timezone # noqa
-from config import MAIN_SERVER_PORT, MONITOR_SERVER_PORT # noqa
+from config import MAIN_SERVER_PORT, MONITOR_SERVER_PORT, USER_NOTIFICATION_ERROR_MAX_CHARS # noqa
 from utils.cloudsave_autocloud import get_cloudsave_manager # noqa
 from utils.cloudsave_runtime import (
     CloudsaveDeadlineExceeded,
@@ -735,7 +735,7 @@ async def _handle_agent_event(event: dict):
                         }
                         err_msg = event.get("error_message") or ""
                         if err_msg:
-                            notif["error_message"] = err_msg[:500]
+                            notif["error_message"] = err_msg[:USER_NOTIFICATION_ERROR_MAX_CHARS]
                         await ws.send_json(notif)
                         # text 是面向前端的通知正文，不写 logger
                         logger.info("[EventBus] agent_notification sent to frontend (text_len=%d)", len(text))
@@ -756,7 +756,7 @@ async def _handle_agent_event(event: dict):
                     }
                     err_msg = event.get("error_message") or ""
                     if err_msg:
-                        notif["error_message"] = err_msg[:500]
+                        notif["error_message"] = err_msg[:USER_NOTIFICATION_ERROR_MAX_CHARS]
                     await ws.send_json(notif)
                 except Exception as e:
                     logger.debug("[EventBus] agent_notification send failed: %s", e)


### PR DESCRIPTION
## 背景

PR #1032 review 时，用户问 `str(e)[:500]` 这个 500 是哪来的——发现 agent / plugin /
tracker 链路上散落着 ~30 处 char-level 硬截字面量（200 / 500 居多）。这些是
**防御性 char-cap**（避免把 MB 级字符串喂给 tiktoken 触发耗时编码），真正的
prompt 字段长度由 `TASK_*_MAX_TOKENS` 在 `_emit_task_result` 内部二次精确截。

本 PR **不改截断行为，只把载有业务语义的字面量按"是否进 LLM 上下文"分组到
命名常量**，并补一处之前漏审的 hardcoded `300`。

## 常量分组（`config/__init__.py`，紧邻 `TASK_*_MAX_TOKENS` 分组）

**进 LLM 上下文（防御性 char-cap，下游 `_emit_task_result` 内部走 token-cap）：**

| 常量 | 值 | 用途 |
|------|----|----|
| `EXCEPTION_TEXT_MAX_CHARS` | 500 | summary 字段 / `_exc_text` / `cancel_msg` 等共享变量 |
| `ERROR_MESSAGE_MAX_CHARS` | 300 | error_message 字段直接 char-cap |
| `TASK_TRACKER_DETAIL_MAX_CHARS` | 300 | tracker.record_completed.detail 入站 |
| `TASK_TRACKER_INJECT_DETAIL_MAX_CHARS` | 300 | tracker.inject 渲染 detail 进 LLM system 消息的最终 char-cap |

> 注：tracker.detail 看似只进内存日志，但 `AgentTaskTracker.inject()` 会把整段
> 记录拼成 system 消息塞进 task_executor 的下次决策 messages，所以这条字段
> 实际是 LLM-facing。三层防御：入站 char-cap (300) → record_completed 内
> token-cap (200 token) → inject 渲染 char-cap (300)。

**不进 LLM 上下文（前端 agent_notification）：**

| 常量 | 值 | 用途 |
|------|----|----|
| `USER_NOTIFICATION_REASON_MAX_CHARS` | 200 | toast text 内嵌 reason |
| `USER_NOTIFICATION_ERROR_MAX_CHARS` | 500 | agent_notification.error_message 字段 |

## 改动点（按文件）

### `agent_server.py`（22 处字面量 + 1 处漏审）

**LLM-facing 字段（A 防御性 char-cap）：**

- L1880 / L2155 / L2330 / L2547 `cancel_msg = str(e)[:500]` → `EXCEPTION_TEXT_MAX_CHARS`
- L1942 / L3237 `_exc_text = str(e)[:500]` → `EXCEPTION_TEXT_MAX_CHARS`
- L2020 / L2128 `summary=reply[:500]` → `EXCEPTION_TEXT_MAX_CHARS`
- L2031 `error_message=str(nk_result.get("error") or "")[:500]` → `ERROR_MESSAGE_MAX_CHARS`
- L2042 / L2213 `error_message=str(e)[:500]` → `ERROR_MESSAGE_MAX_CHARS`
- L2139 `error_message=str(nk_result.get("error") or "")[:500]` → `ERROR_MESSAGE_MAX_CHARS`

**Tracker detail（B；进 LLM context via inject）：**

- L1888 / L2163 / L2336 / L2560 `detail=cancel_msg[:200]` → `TASK_TRACKER_DETAIL_MAX_CHARS`
- L1935 / L2204 / L2372 / L2593 `detail=str(e)[:200]` → `TASK_TRACKER_DETAIL_MAX_CHARS`
- L2120 `detail=reply[:200]` → `TASK_TRACKER_DETAIL_MAX_CHARS`
- L2303 `detail=bu_parsed[:200]` → `TASK_TRACKER_DETAIL_MAX_CHARS`

**Tracker inject 渲染（B；之前漏审的 hardcoded 300）：**

- L274 `_sanitize(r.get("detail", ""), 300)` → `TASK_TRACKER_INJECT_DETAIL_MAX_CHARS`

**前端 agent_notification（C 不进 LLM）：**

- L1569 `reason[:200]` (toast text) → `USER_NOTIFICATION_REASON_MAX_CHARS`
- L1572 `error_message=reason[:500]` → `USER_NOTIFICATION_ERROR_MAX_CHARS`
- L2638 `error_message=str(e)[:500]` (background task error) → `USER_NOTIFICATION_ERROR_MAX_CHARS`

### `main_server.py`（2 处字面量）

- L738 / L759 `notif["error_message"] = err_msg[:500]` (前端 WS 帧) → `USER_NOTIFICATION_ERROR_MAX_CHARS`

## 保留的字面量及理由（debug-only，不影响业务语义）

`agent_server.py`：
- L1590 / L1594 `task_description[:80] / reason[:120]` — logger.info preview
- L1658 `task_description[:120]` — print preview
- L2492 / L2496 OpenFang `result/error[:500]` — debug RAW 输出
- L3623 `resp.text[:500]` — LLM Proxy upstream body debug
- L3835 `uuid.hex[:12]` — id 生成（不是字符串截断）

`main_server.py`：
- L658 / L742 `text[:60]` — print preview

`brain/task_executor.py`：
- L294 / L954 / L1232 / L1266 / L1274 / L1302 / L1860 / L1869 / L2005 全是
  `logger.warning` / `print` 的 raw response / HTTP body / prompt 调试输出。
  L728 `result[:24]` 是限制搜索词数量的 list slice。L820 / L826 `uuid.hex[:12]` 是 id 生成。

`main_logic/core.py`：
- L2252 / L2754 `resp.text[:200]` 在 ConnectionError 抛 message 里——memory 服务
  连接错误，**不在 agent/plugin 范围**。
- L2617 `t.get("id","")[:8]` 是 id 短码。
- L3189 `(full_text or '')[:40]` 是 proactive stream 的 print preview。

`plugin/server/messaging/proactive_bridge.py` 和 `plugin/core/context.py`：
- grep 全文无 char-cap 字面量。

## 不在范围

- 不改 `TASK_*_MAX_TOKENS` 数值
- 不改 truncation 行为（只改命名）
- 不把 char-cap 改成 token-cap（语义不同）
- 不改测试 mock 字符串字面量
- 不动已经在用 `_tt(text, _XXX_MAX_TOKENS)` 的 token-cap 站点

## 设计决策

**`error_message=cancel_msg` / `error_message=_exc_text` 这类共享变量站点不二次 cap：**
变量已在 500 处定义，沿用 "summary / _exc_text / cancel_msg 统一 500" 的对偶
——避免给同一份字符串做两套截断。只有**单独**对 error_message 字段直接
char-cap（没经中间共享变量）的 4 处 `error_message=str(...)[:N]` 才走
`ERROR_MESSAGE_MAX_CHARS`（300）。

**`TASK_TRACKER_DETAIL_MAX_CHARS` 由 200 → 300：**
跟 `ERROR_MESSAGE_MAX_CHARS` / `TASK_TRACKER_INJECT_DETAIL_MAX_CHARS` 对齐为
"进上下文统一 300"。tracker 内部 `record_completed` 还会再做一次
`_tt(detail, TASK_DETAIL_MAX_TOKENS)`（200 token），所以 char 由 200 放宽到
300 在多数情况下被 200 token 主导，行为差异微小。

## Test plan

- [x] `uv run pytest plugin/tests/unit/sdk/` — 237 passed
- [x] `uv run pytest tests/unit/ --ignore=tests/testbench` — 1394 passed；与
  `bdee455`（PR #1032 HEAD）相同的 8 个 pre-existing failures
  （`test_prompt_shared` / `test_proactive_sid_guard` /
  `test_proactive_sm_integration`），未引入新 regression
- [x] `grep -nE '\[:[0-9]{2,4}\]' agent_server.py main_server.py …` 剩余字面量
  全部为 debug print/logger preview 或非截断（id 生成 / list slice）

https://claude.ai/code/session_01JmM1iH8xyLJ8Tjx3o2odpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmM1iH8xyLJ8Tjx3o2odpA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 将系统通知和异常消息的字符长度限制改为可配置常量，提高了系统灵活性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->