### PR TITLE
fix(tests/proactive): 修 main 上 8 个 unit test 失败

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3425,15 +3425,19 @@ class LLMSessionManager:
             )
             return
 
-        # Drop the proactive subset from the queue once we have the SM
-        # claim — keep the passive cbs for the next user-turn drain. 与
-        # voice-mode 分支对称（line 3394-3397）：voice 在 hot-swap 前 trim，
-        # text 在 claim 成功后 trim。preempt / not-delivered / exception 路径
-        # 靠 ``extend(callbacks_snapshot)`` 把 proactive 子集放回队列，保证
-        # 投递失败不会丢消息。
+        # Drop only the snapshot cbs from the queue once we have the SM
+        # claim — keep both pre-existing passive cbs and any callbacks
+        # that another task enqueued during the ``await try_start_proactive``
+        # window (``enqueue_agent_callback`` is sync + lock-free, so this race
+        # window is real). Filtering by ``delivery_mode == "passive"`` would
+        # wipe such fresh proactive cbs since ``callbacks_snapshot`` only
+        # restores pre-claim entries on exception. preempt / not-delivered /
+        # exception 路径靠 ``extend(callbacks_snapshot)`` 把本次 snapshot
+        # 放回队列，保证投递失败不会丢消息。
+        snapshot_ids = {id(cb) for cb in callbacks_snapshot}
         self.pending_agent_callbacks = [
             cb for cb in self.pending_agent_callbacks
-            if cb.get("delivery_mode") == "passive"
+            if id(cb) not in snapshot_ids
         ]
 
         try:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3425,6 +3425,17 @@ class LLMSessionManager:
             )
             return
 
+        # Drop the proactive subset from the queue once we have the SM
+        # claim — keep the passive cbs for the next user-turn drain. 与
+        # voice-mode 分支对称（line 3394-3397）：voice 在 hot-swap 前 trim，
+        # text 在 claim 成功后 trim。preempt / not-delivered / exception 路径
+        # 靠 ``extend(callbacks_snapshot)`` 把 proactive 子集放回队列，保证
+        # 投递失败不会丢消息。
+        self.pending_agent_callbacks = [
+            cb for cb in self.pending_agent_callbacks
+            if cb.get("delivery_mode") == "passive"
+        ]
+
         try:
             if isinstance(self.session, OmniOfflineClient):
                 await self._deliver_agent_callbacks_text(instruction, callbacks_snapshot)

--- a/tests/unit/test_proactive_sid_guard.py
+++ b/tests/unit/test_proactive_sid_guard.py
@@ -55,6 +55,10 @@ def _make_mgr() -> LLMSessionManager:
     # 状态机：finish_proactive_delivery / handle_new_message 会 fire 事件，
     # 所以测试 mgr 也要有真实 SM 实例（轻量、无外部依赖）。
     mgr.state = SessionStateMachine(lanlan_name="Test")
+    # finish_proactive_delivery 会调 _flush_ai_turn_text_to_tracker → activity_tracker；
+    # 这里 mock 掉即可，不影响 sid guard 行为本身。
+    mgr._activity_tracker = MagicMock()
+    mgr._current_ai_turn_text = ''
     return mgr
 
 

--- a/tests/unit/test_prompt_shared.py
+++ b/tests/unit/test_prompt_shared.py
@@ -23,6 +23,10 @@ class FakeElement {{}}
 
 global.window = global;
 global.Element = FakeElement;
+// app-prompt-shared.js 模块顶层会注册 beforeunload/pagehide listener，
+// node 的 global 默认没有 addEventListener，这里 noop stub 即可。
+global.addEventListener = function () {{}};
+global.removeEventListener = function () {{}};
 global.document = {{
   visibilityState: 'visible',
   hasFocus() {{


### PR DESCRIPTION
## Summary

main 当前 \`pytest tests/unit/ --ignore=tests/testbench\` 8 fail，分三组根因——两组测试 fixture 没跟上源码改动，一组 #1032 留下的源码 bug。

### ① test_proactive_sid_guard.py（2 fail）— mock 漏属性

PR #1015 给 \`finish_proactive_delivery\` 加了 \`_flush_ai_turn_text_to_tracker\` → \`self._activity_tracker.on_ai_message(...)\`，但 [\`_make_mgr()\`](tests/unit/test_proactive_sid_guard.py) 没补 \`_activity_tracker\` / \`_current_ai_turn_text\`，sid guard 的 finish 分支跑到这里直接 \`AttributeError\`。补 \`MagicMock\` + \`''\`。

### ② test_proactive_sm_integration.py（2 fail）— **源码 bug，#1032 回归**

PR #1032 把 \`_deliver_agent_callbacks_text\` 里的 \`self.pending_agent_callbacks.clear()\` 删了，注释说 \"queue mutation moved to caller (trigger_agent_callbacks extracts the proactive subset before claim)\"。

实际上 caller \`trigger_agent_callbacks\` 的 text-mode 路径只是 list-comp 出 \`proactive_cbs\`（用作渲染 + snapshot），**根本没修改 \`self.pending_agent_callbacks\`**——把 \"过滤出新列表\" 误当成了 \"从队列移出\"。voice-mode 那段（line 3394-3397）才是真 reassign。

后果：
- happy path 投递完队列还残留 proactive cbs，下次 trigger 重复发
- exception 路径 \`extend(callbacks_snapshot)\` 完队列重复

修法：text-mode 在拿到 SM claim 后补对称的 reassign trim（保留 passive、丢 proactive）。preempt / not-delivered / exception 原有的 \`extend(callbacks_snapshot)\` 路径正好把 snapshot 加回去，丢消息保护不变。

### ③ test_prompt_shared.py（4 fail）— Node harness 缺 stub

PR #1010 给 [\`app-prompt-shared.js:243-244\`](static/app-prompt-shared.js) 加了模块顶层的 \`window.addEventListener('beforeunload', ...)\` / \`'pagehide'\`。Harness 里 \`global.window = global\`，但 Node 的 \`global\` 默认没有 \`addEventListener\`，import 阶段直接抛 \`TypeError\`。harness 补 noop \`addEventListener\` / \`removeEventListener\`。

## Test plan
- [x] \`uv run pytest tests/unit/test_proactive_sid_guard.py tests/unit/test_proactive_sm_integration.py tests/unit/test_prompt_shared.py\` → 29/29
- [x] \`uv run pytest tests/unit/ --ignore=tests/testbench\` → **1402 passed, 14 skipped**（main 是 1394 passed / 8 failed）
- [ ] CI 跑通

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 优化主动交付期间的回调队列处理：在确认启动后即时移除已声明子集，确保被动回调和同时加入的新回调被保留以供后续交付，降低回调丢失风险并提升稳定性。

* **Tests**
  * 增强单元测试隔离性：屏蔽/模拟环境依赖和副作用（如活动追踪与浏览器事件），提高测试在不同运行环境下的稳定性与可复现性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->