### PR TITLE
fix(live2d): lipsync 在响时强制覆盖 motion mouth 参数

### DIFF
--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -3,6 +3,9 @@
  * 依赖: live2d-core.js (提供 Live2DManager 类和 window.LIPSYNC_PARAMS)
  */
 
+// lipsync 强制覆盖 motion mouth 参数的阈值：mouthValue 高于此值时强制写入，否则让位给 motion 自带的嘴部关键帧
+const LIPSYNC_OVERRIDE_THRESHOLD = 0.001;
+
 // 缓动函数集合（用于眨眼、口型等动画的平滑过渡）
 const Easing = {
     linear: (t) => t,
@@ -1485,8 +1488,8 @@ Live2DManager.prototype.installMouthOverride = function() {
                         } catch (_) {}
                     }
 
-                    // 口型参数：仅当 Motion 未接管时写入
-                    if (!this._isMouthDrivenByMotion) {
+                    // 口型参数：lipsync 在响（mouthValue > 0）时强制覆盖 motion；静默时让位给 motion 自带的嘴部动画
+                    if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD) {
                         for (const [id, idx] of Object.entries(mouthParamIndices)) {
                             try {
                                 coreModel.setParameterValueByIndex(idx, this.mouthValue);
@@ -1594,8 +1597,8 @@ Live2DManager.prototype.installMouthOverride = function() {
         try {
             // === 注入点 2（渲染前）：口型 + 眨眼 ===
             // 这是渲染前的最后一步，强制命令，绝对优先级
-            // 口型参数（仅当 Motion 未接管时）
-            if (!this._isMouthDrivenByMotion) {
+            // 口型参数：lipsync 在响（mouthValue > 0）时强制覆盖 motion；静默时让位给 motion 自带的嘴部动画
+            if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD) {
                 for (const [id, idx] of Object.entries(mouthParamIndices)) {
                     try {
                         currentCoreModel.setParameterValueByIndex(idx, this.mouthValue);


### PR DESCRIPTION
## Summary

修复 #925 (Add eye blink and idle motion subsystems) 引入的回归：motion 文件中的 `ParamMouthOpenY` 等关键帧反而压过 lipsync。

### 根因

[#925](https://github.com/Project-N-E-K-O/N.E.K.O/pull/925) 在 `installMouthOverride` 里加了 `_isMouthDrivenByMotion` 的 Diff 检测——每帧把 motion 应用前后的 mouth 参数对比，差 > 0.001 就标记 motion 接管，于是渲染前注入点的 `setParameterValueByIndex(idx, this.mouthValue)` 被守卫跳过。

这本身在 #925 单独看不破：常见 Live2D 模型的 Idle 动作里没有 mouthopen 关键帧。但 [#926](https://github.com/Project-N-E-K-O/N.E.K.O/pull/926)（idle motion 常驻循环）+ [#930](https://github.com/Project-N-E-K-O/N.E.K.O/pull/930)（持久化）落地后，用户可以选带嘴部动画的 motion 作为常驻 idle，每帧都触发 Diff，lipsync 永远让位。

### 改动

把 `coreModel.update` 注入点 2（[live2d-model.js:1601](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/crazy-wing-d506b0/static/live2d-model.js#L1601)）和 click-fade 分支（[live2d-model.js:1492](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/crazy-wing-d506b0/static/live2d-model.js#L1492)）的守卫改成：

```js
if (!this._isMouthDrivenByMotion || this.mouthValue > LIPSYNC_OVERRIDE_THRESHOLD)
```

- 说话期（`mouthValue > 0`）：lipsync 强制覆盖 motion ✓
- 静默期（`mouthValue == 0`）：让位给 motion 自带的嘴部关键帧（保留 #925 设计意图）✓

阈值 `0.001` 抽成 `LIPSYNC_OVERRIDE_THRESHOLD` 常量。

## Test plan

本地浏览器验证（`mao_pro` 模型 + idle motion 含 ParamMouthOpenY 关键帧）：

| 场景 | mouthValue | ParamMouthOpenY 帧 1 / 帧 2 | 结果 |
|---|---|---|---|
| 静默 | 0 | 0 / 0.034（motion 关键帧） | motion 接管 ✓ |
| 说话 | 0.85 | 0.85 / 0.243（physics 衰减，正常） | lipsync 覆盖 ✓ |

无 console error。

- [ ] 实音频对话验证 lipsync 嘴型同步
- [ ] 切到无 mouth 关键帧的 idle motion 验证不回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了口型同步与动画口型的交互处理，提升了口部动画的自然度和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->