### PR TITLE
fix(i18n): 修正 PR #1024 interval 标签错位（chat=最低间隔, vision=感知间隔）

### DIFF
--- a/static/avatar-ui-popup.js
+++ b/static/avatar-ui-popup.js
@@ -1589,7 +1589,7 @@ function createIntervalControl(manager, prefix, toggle) {
     });
 
     const labelKey = toggle.id === 'proactive-chat' ? 'settings.interval.chatIntervalBase' : 'settings.interval.visionInterval';
-    const defaultLabel = toggle.id === 'proactive-chat' ? '感知间隔' : '读取间隔';
+    const defaultLabel = toggle.id === 'proactive-chat' ? '最低间隔' : '感知间隔';
     const labelText = document.createElement('span');
     labelText.textContent = window.t ? window.t(labelKey) : defaultLabel;
     labelText.setAttribute('data-i18n', labelKey);

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2225,8 +2225,8 @@
             "ru": "Русский"
         },
         "interval": {
-            "chatIntervalBase": "Perception Interval",
-            "visionInterval": "Read Interval"
+            "chatIntervalBase": "Minimum Interval",
+            "visionInterval": "Perception Interval"
         },
         "toggles": {
             "allowInterrupt": "Allow Interrupt",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2225,8 +2225,8 @@
             "ru": "ruso"
         },
         "interval": {
-            "chatIntervalBase": "Intervalo de percepción",
-            "visionInterval": "Intervalo de lectura"
+            "chatIntervalBase": "Intervalo mínimo",
+            "visionInterval": "Intervalo de percepción"
         },
         "toggles": {
             "allowInterrupt": "Permitir interrupción",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2225,8 +2225,8 @@
             "ru": "Русский"
         },
         "interval": {
-            "chatIntervalBase": "感知間隔",
-            "visionInterval": "読取間隔"
+            "chatIntervalBase": "最小間隔",
+            "visionInterval": "感知間隔"
         },
         "toggles": {
             "allowInterrupt": "割り込み許可",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2225,8 +2225,8 @@
             "ru": "Русский"
         },
         "interval": {
-            "chatIntervalBase": "인지 간격",
-            "visionInterval": "읽기 간격"
+            "chatIntervalBase": "최소 간격",
+            "visionInterval": "인지 간격"
         },
         "toggles": {
             "allowInterrupt": "인터럽트 허용",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2225,8 +2225,8 @@
             "ru": "Russo"
         },
         "interval": {
-            "chatIntervalBase": "Intervalo de Percepção",
-            "visionInterval": "Intervalo de leitura"
+            "chatIntervalBase": "Intervalo Mínimo",
+            "visionInterval": "Intervalo de Percepção"
         },
         "toggles": {
             "allowInterrupt": "Permitir interrupção",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2225,8 +2225,8 @@
             "ru": "Русский"
         },
         "interval": {
-            "chatIntervalBase": "Интервал восприятия",
-            "visionInterval": "Интервал чтения"
+            "chatIntervalBase": "Минимальный интервал",
+            "visionInterval": "Интервал восприятия"
         },
         "toggles": {
             "allowInterrupt": "Разрешить прерывание",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2225,8 +2225,8 @@
             "ru": "Русский"
         },
         "interval": {
-            "chatIntervalBase": "感知间隔",
-            "visionInterval": "读取间隔"
+            "chatIntervalBase": "最低间隔",
+            "visionInterval": "感知间隔"
         },
         "toggles": {
             "allowInterrupt": "允许打断",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2225,8 +2225,8 @@
             "ru": "Русский"
         },
         "interval": {
-            "chatIntervalBase": "感知間隔",
-            "visionInterval": "視覺間隔"
+            "chatIntervalBase": "最低間隔",
+            "visionInterval": "感知間隔"
         },
         "toggles": {
             "allowInterrupt": "允許打斷",


### PR DESCRIPTION
## Summary

- PR [#1024](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1024) 的 i18n 改动改错了对象：原意是把 proactive vision 旁的"读取间隔"改成"感知间隔"，结果改的是 proactive chat 的"基础间隔"。
- 本 PR 把两个 label 摆正：proactive chat → "最低间隔"（退避起点），proactive vision → "感知间隔"（屏幕感知频率）。
- 8 个 locale (zh-CN/zh-TW/en/ja/ko/es/pt/ru) + `avatar-ui-popup.js` 里的兜底 default 全部对齐。

## Test plan

- [ ] 切到各语言，打开设置面板，确认 proactive chat slider 标签为"最低间隔"类语义，proactive vision slider 标签为"感知间隔"类语义
- [ ] 关闭设置再打开，i18n 不回退到旧字符串

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 更新了多语言间隔设置的UI标签文本
  * 优化了英文、西班牙文、日文、韩文、葡萄牙文、俄文、简体中文和繁体中文等8种语言版本的本地化标签，提高了标签的清晰度和一致性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->