### PR TITLE
fix(character_card): VRM/MMD 子扫描失败时回退为 [] 而非沿用旧值

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -6790,16 +6790,14 @@ async function scanModels(loadSequence) {
         }
 
         // 提交到全局变量（用于角色卡加载，包括static目录的模型）
+        // 注意：6 个全局必须无条件覆写到本轮结果，VRM/MMD 子扫描失败时落 [] 而非沿用旧值；
+        // 否则 tab 切换路径里如果 VRM/MMD 端点偶发失败，会保留上一轮的 stale 列表造成假阳性
         window.allModels = models;
         availableModels = uploadableModels;
-        if (scannedAllVrmModels) {
-            window.allVrmModels = scannedAllVrmModels;
-            availableVrmModels = nextAvailableVrmModels;
-        }
-        if (scannedAllMmdModels) {
-            window.allMmdModels = scannedAllMmdModels;
-            availableMmdModels = nextAvailableMmdModels;
-        }
+        window.allVrmModels = scannedAllVrmModels || [];
+        availableVrmModels = nextAvailableVrmModels || [];
+        window.allMmdModels = scannedAllMmdModels || [];
+        availableMmdModels = nextAvailableMmdModels || [];
 
         // 触发模型扫描完成事件，通知其他组件刷新 UI（具有容错能力）
         try {


### PR DESCRIPTION
## Summary

#1028 review 里 CodeRabbit 指出 `scanModels` 在 VRM/MMD 子端点失败时只保留旧值，会让 tab 切换路径（不走 `loadCharacterCards` 的 6 全局清零）在偶发失败后沿用上一轮的 stale 列表，造成上传/预览按钮假阳性。这条 minor 在 PR #1028 merge 时还没修，本 PR 作为 follow-up 补上。

## Changes

`static/js/character_card_manager.js` — `scanModels` 通过 sequence 校验后无条件覆写 6 个全局：`window.all{Vrm,Mmd}Models` / `available{Vrm,Mmd}Models` 在子扫描失败时 fallback 到 `[]`，确保单次 `scanModels` 调用要么提交完整一致的本轮结果，要么因 sequence 不匹配整体丢弃。

## 为什么不是 reviewer 字面建议的 "up-front clear"

reviewer 直觉建议在 fetch/parse 之前先把全局清成 `[]`，但这会破坏 #1028 里加的 sequence race 校验：旧轮 `scanModels` 在 sequence 不匹配时会 `return false`，若先清再 fetch，旧轮会冲掉新轮已经落地的数据。所以写入必须在 sequence 校验**之后**做，本 PR 即按此结构。

## Test plan

- [ ] 切到 character cards tab，confirm Live2D/VRM/MMD 模型列表正常加载。
- [ ] 模拟 `/api/model/vrm/models` 端点失败（504/500），切 tab 触发 `scanModels`，confirm `availableVrmModels` 落 `[]` 而非保留上一轮值。
- [ ] 连续触发 `loadCharacterCards`，confirm sequence 校验仍然把旧轮丢弃，不被 follow-up 清零逻辑破坏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了模型列表在标签页切换后显示过期数据的问题，确保模型状态在每个扫描周期都被正确刷新，防止旧的模型列表影响用户界面操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->