### PR TITLE
feat(proactive): 三块剩余 i18n 文案改 {master} 占位符 + 51 个 guard 测试

### DIFF
--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -1278,6 +1278,28 @@ def _normalize_prompt_language(lang: str) -> str:
     return 'en'
 
 
+def _resolve_master_for_template(master_name: str | None, lang_key: str) -> str:
+    """把 master_name 归一化成可直接塞进 {master} 占位符的字符串。
+
+    空名 / None / 全空白 时返回 PROACTIVE_ACTION_NOTE_PLACEHOLDERS 里
+    对应 locale 的中性兜底（"对方" / "them" / "相手" / "상대" /
+    "собеседника"），避免任何模板里再出现"主人"等物化称呼。
+
+    lang_key 必须已经过 _normalize_prompt_language 归一化；caller 传未归一化
+    的区域标签（zh-CN / ja-JP）只能拿到英文兜底，丢失本地化。
+
+    PROACTIVE_ACTION_NOTE_PLACEHOLDERS 的引用故意放在函数体内：模块顶层执行
+    顺序里，本 helper 比 PROACTIVE_ACTION_NOTE_PLACEHOLDERS 字典定义早出现，
+    放函数体里靠延迟查找规避前向引用。
+    """
+    name = ' '.join(str(master_name or '').split())
+    if name:
+        return name
+    return PROACTIVE_ACTION_NOTE_PLACEHOLDERS.get(
+        lang_key, PROACTIVE_ACTION_NOTE_PLACEHOLDERS['en']
+    )['master']
+
+
 PROACTIVE_CHAT_PROMPTS = {
     'zh': {
         'home': proactive_chat_prompt,
@@ -1375,11 +1397,11 @@ _P2_MUSIC_INSTRUCTION = {
 }
 
 _P2_MEME_INSTRUCTION = {
-    'zh': '\n- 关于表情包：当你决定结合表情包进行搭话时，系统会自动发送一张搞笑图片表情包（如熊猫头、沙雕图等）给主人看。你的文字中请不要直接评论"这张图"（比如不要说"这张图好搞笑"），而是直接利用这张图片的情绪/内容来表达你想说的话（比如配合一张累瘫的图说："主人你该休息啦"）。**注意：表情包是发给主人看的，不是发给你的；你不需要对它做出外部反应。**',
-    'en': '\n- About memes: When you decide to combine a meme with your message, the system will automatically send a funny meme image to the master. Please do NOT directly comment on "the image" in your text (e.g., don\'t say "This image is funny"). Instead, directly use the mood/content of the image to express what you want to say. **Note: The meme is sent TO the master, not TO you; you don\'t need to "react" to it externally.**',
-    'ja': '\n- ミームについて：ミームを取り入れて話しかけると決めたとき、システムが自動的に面白い画像をご主人に送信します。テキストの中で直接「この画像」について言及しないでください（例：「この画像面白いね」と言わないでください）。代わりに、画像の雰囲気や内容をそのまま利用して、伝えたいことを表現してください。**注意：ミームはご主人に送られるもので、あなたに送られるものではありません。外部から「反応」するのではなく、画像と一緒に思いを表現してください。**',
-    'ko': '\n- 밈에 대해: 밈을 결합하여 말을 걸기로 결정했을 때, 시스템이 자동으로 재미있는 이미지를 주인에게 보냅니다. 텍스트에서 직접 "이 사진"(예: "이 사진 웃기네요")에 대해 언급하지 마세요. 대신 이미지의 분위기나 내용을 직접 활용하여 하고 싶은 말을 표현하세요. **참고: 밈은 주인에게 보내는 것이지 당신에게 보내는 것이 아닙니다.**',
-    'ru': '\n- О мемах: когда вы решаете включить мем в свою реплику, система автоматически отправит смешное изображение хозяину. Пожалуйста, НЕ комментируйте само "изображение" в тексте (например, не говорите "эта картинка смешная"). Вместо этого напрямую используйте настроение или содержание картинки, чтобы выразить свою мысль. **Внимание: мем отправляется хозяину, а не вам; вам не нужно "реагировать" на него со стороны.**',
+    'zh': '\n- 关于表情包：当你决定结合表情包进行搭话时，系统会自动发送一张搞笑图片表情包（如熊猫头、沙雕图等）给{master}看。你的文字中请不要直接评论"这张图"（比如不要说"这张图好搞笑"），而是直接利用这张图片的情绪/内容来表达你想说的话（比如配合一张累瘫的图说："{master}你该休息啦"）。**注意：表情包是发给{master}看的，不是发给你的；你不需要对它做出外部反应。**',
+    'en': '\n- About memes: When you decide to combine a meme with your message, the system will automatically send a funny meme image to {master}. Please do NOT directly comment on "the image" in your text (e.g., don\'t say "This image is funny"). Instead, directly use the mood/content of the image to express what you want to say. **Note: The meme is sent TO {master}, not TO you; you don\'t need to "react" to it externally.**',
+    'ja': '\n- ミームについて：ミームを取り入れて話しかけると決めたとき、システムが自動的に面白い画像を{master}に送信します。テキストの中で直接「この画像」について言及しないでください（例：「この画像面白いね」と言わないでください）。代わりに、画像の雰囲気や内容をそのまま利用して、伝えたいことを表現してください。**注意：ミームは{master}に送られるもので、あなたに送られるものではありません。外部から「反応」するのではなく、画像と一緒に思いを表現してください。**',
+    'ko': '\n- 밈에 대해: 밈을 결합하여 말을 걸기로 결정했을 때, 시스템이 자동으로 재미있는 이미지를 {master}에게 보냅니다. 텍스트에서 직접 "이 사진"(예: "이 사진 웃기네요")에 대해 언급하지 마세요. 대신 이미지의 분위기나 내용을 직접 활용하여 하고 싶은 말을 표현하세요. **참고: 밈은 {master}에게 보내는 것이지 당신에게 보내는 것이 아닙니다.**',
+    'ru': '\n- О мемах: когда вы решаете включить мем в свою реплику, система автоматически отправит смешное изображение для {master}. Пожалуйста, НЕ комментируйте само "изображение" в тексте (например, не говорите "эта картинка смешная"). Вместо этого напрямую используйте настроение или содержание картинки, чтобы выразить свою мысль. **Внимание: мем отправляется для {master}, а не вам; вам не нужно "реагировать" на него со стороны.**',
 }
 
 
@@ -1928,10 +1950,13 @@ def get_proactive_screen_prompt(channel: str, lang: str = 'zh') -> str:
 
 
 def get_proactive_generate_prompt(lang: str = 'zh', music_playing_hint: str = "",
-                                  has_music: bool = False, has_meme: bool = False) -> str:
+                                  has_music: bool = False, has_meme: bool = False,
+                                  master_name: str | None = None) -> str:
     """
     获取 Phase 2 生成阶段 prompt。
     has_music / has_meme 控制是否注入音乐/表情包行为指令，避免无来源时产生幻觉。
+    master_name 用于把表情包指令里的 {master} 占位符提前展开成用户实际设定的名字
+    （或本地化中性兜底，例如"对方"/"them"），避免出现"主人"等物化称呼。
     """
     lang_key = _normalize_prompt_language(lang)
     prompt = PROACTIVE_GENERATE_PROMPTS.get(lang_key, PROACTIVE_GENERATE_PROMPTS.get('en', PROACTIVE_GENERATE_PROMPTS['zh']))
@@ -1939,6 +1964,11 @@ def get_proactive_generate_prompt(lang: str = 'zh', music_playing_hint: str = ""
     # 动态注入音乐/表情包行为指令
     music_instr = _P2_MUSIC_INSTRUCTION.get(lang_key, _P2_MUSIC_INSTRUCTION.get('en', _P2_MUSIC_INSTRUCTION['zh'])) if has_music else ''
     meme_instr = _P2_MEME_INSTRUCTION.get(lang_key, _P2_MEME_INSTRUCTION.get('en', _P2_MEME_INSTRUCTION['zh'])) if has_meme else ''
+    # meme_instr 含 {master} 占位符，需要在拼回外层 prompt 之前展开掉。否则它会
+    # 流到 main_routers/system_router.py 的整体 .format(master_name=..., ...) 那里，
+    # 而那一步只传 master_name 不传 master，会触发 KeyError。
+    if meme_instr:
+        meme_instr = meme_instr.format(master=_resolve_master_for_template(master_name, lang_key))
     prompt = prompt.replace('{music_instruction}', music_instr).replace('{meme_instruction}', meme_instr)
 
     if music_playing_hint:
@@ -2150,11 +2180,11 @@ SCREEN_WINDOW_TITLE = {
 
 # ---------- 截图提示 ----------
 SCREEN_IMG_HINT = {
-    'zh': '（上方附有主人当前的屏幕截图，请直接观察截图内容来搭话）',
-    'en': "(The master's current screenshot is attached above — observe it directly)",
-    'ja': '（上にご主人のスクリーンショットがあります。直接観察してください）',
-    'ko': '(위에 주인의 스크린샷이 첨부되어 있습니다. 직접 관찰하세요)',
-    'ru': '(Выше прикреплён текущий скриншот экрана хозяина — наблюдайте его напрямую)',
+    'zh': '（上方附有{master}当前的屏幕截图，请直接观察截图内容来搭话）',
+    'en': "(The current screenshot of {master} is attached above — observe it directly)",
+    'ja': '（上に{master}のスクリーンショットがあります。直接観察してください）',
+    'ko': '(위에 {master}의 스크린샷이 첨부되어 있습니다. 직접 관찰하세요)',
+    'ru': '(Выше прикреплён текущий скриншот экрана для {master} — наблюдайте его напрямую)',
 }
 
 # ---------- 触发 LLM 开始生成 ----------
@@ -2200,13 +2230,13 @@ RECENT_PROACTIVE_CHANNEL_LABELS = {
     'ru': {'vision': 'экран', 'web': 'веб'},
 }
 
-# ---------- 主人屏幕区块 ----------
+# ---------- 屏幕区块 ----------
 SCREEN_SECTION_HEADER = {
-    'zh': '======主人的屏幕======',
-    'en': "======Master's Screen======",
-    'ja': '======ご主人の画面======',
-    'ko': '======주인의 화면======',
-    'ru': '======Экран хозяина======',
+    'zh': '======{master}的屏幕======',
+    'en': "======Screen of {master}======",
+    'ja': '======{master}の画面======',
+    'ko': '======{master}의 화면======',
+    'ru': '======Экран для {master}======',
 }
 
 SCREEN_SECTION_FOOTER = {
@@ -2464,7 +2494,7 @@ CONTEXT_SUMMARY_TASK_FOOTER = {
 
 # ---------- 主动搭话：当前正在放歌时的提示（引导 AI 聊当前的歌，而不是推荐新歌） ----------
 PROACTIVE_MUSIC_PLAYING_HINT = {
-    'zh': '\n[绝对指令] 当前正在播放音乐："{track_name}"。请仅限评价或探讨这首歌、歌手或音乐风格。**严禁**推荐新歌、**严禁**尝试更换曲目，请全力维持当前的听歌氛围，不要打扰主人的雅致。',
+    'zh': '\n[绝对指令] 当前正在播放音乐："{track_name}"。请仅限评价或探讨这首歌、歌手或音乐风格。**严禁**推荐新歌、**严禁**尝试更换曲目，请全力维持当前的听歌氛围，不要打扰{master}的雅致。',
     'en': '\n[ABSOLUTE COMMAND] Current music playing: "{track_name}". Please limit your discussion strictly to this song, artist, or genre. **DO NOT** recommend new songs or try to change the music. Focus entirely on maintaining the current vibe.',
     'ja': '\n[絶対命令] 現在音楽「{track_name}」を再生中です。この曲、アーティスト、または音楽ジャンルについてのみお話しください。新しい曲を勧めたり、曲を変更したりすることは**厳禁**です。現在の雰囲気を維持することに全力を注いでください。',
     'ko': '\n[절대 명령] 현재 음악 "{track_name}"이(가) 재생 중입니다. 오직 이 곡, 아티스트 또는 음악 장르에 대해서만 이야기하십시오. 새로운 곡을 추천하거나 곡을 바꾸는 것은 **엄격히 금지**됩니다. 현재의 분위기를 유지하는 데 집중하십시오.',
@@ -2480,11 +2510,11 @@ PROACTIVE_MUSIC_UNKNOWN_TRACK = {
 }
 
 PROACTIVE_MUSIC_FAILSAFE_HINTS = {
-    'zh': '\n[环境提示] 当前未找到与关键词精准匹配的资源。为你提供了一些风格相似的兜底曲目，请在对话中向主人说明，并确认是否符合他的心意。',
-    'en': '\n[Environment Hint] No exact match found for the keyword. Provided some fallback tracks with a similar style. Please explain this to the master and confirm if they like it.',
-    'ja': '\n[環境提示] キーワードに正確に一致するリソースが見つかりませんでした。似たようなスタイルの代替曲を提供しました。主人にその旨を説明し、気に入ってもらえるか確認してください。',
-    'ko': '\n[환경 힌트] 키워드와 정확히 일치하는 리소스를 찾을 수 없습니다. 유사한 스타일의 대체 곡을 제공했습니다. 주인에게 이 내용을 설명하고 마음에 드는지 확인하세요.',
-    'ru': '\n[Экологическая подсказка] Точного соответствия ключевому слову не найдено. Предоставлены запасные треки в похожем стиле. Пожалуйста, объясни это хозяину и уточни, нравятся ли они ему.',
+    'zh': '\n[环境提示] 当前未找到与关键词精准匹配的资源。为你提供了一些风格相似的兜底曲目，请在对话中向{master}说明，并确认是否符合心意。',
+    'en': '\n[Environment Hint] No exact match found for the keyword. Provided some fallback tracks with a similar style. Please explain this to {master} and confirm if they like it.',
+    'ja': '\n[環境提示] キーワードに正確に一致するリソースが見つかりませんでした。似たようなスタイルの代替曲を提供しました。{master}にその旨を説明し、気に入ってもらえるか確認してください。',
+    'ko': '\n[환경 힌트] 키워드와 정확히 일치하는 리소스를 찾을 수 없습니다. 유사한 스타일의 대체 곡을 제공했습니다. {master}에게 이 내용을 설명하고 마음에 드는지 확인하세요.',
+    'ru': '\n[Экологическая подсказка] Точного соответствия ключевому слову не найдено. Предоставлены запасные треки в похожем стиле. Пожалуйста, объясни это для {master} и уточни, нравятся ли они.',
 }
 
 PROACTIVE_MUSIC_STRICT_CONSTRAINT = {
@@ -2504,23 +2534,45 @@ def get_proactive_music_unknown_track_name(lang: str = 'zh') -> str:
     return PROACTIVE_MUSIC_UNKNOWN_TRACK.get(lang_key, PROACTIVE_MUSIC_UNKNOWN_TRACK.get('en', PROACTIVE_MUSIC_UNKNOWN_TRACK['zh']))
 
 
-def get_proactive_music_playing_hint(track_name: str, lang: str = 'zh') -> str:
+def get_proactive_music_playing_hint(track_name: str, master_name: str | None = None,
+                                     lang: str = 'zh') -> str:
     """
-    获取“正在放歌”的提示语
+    获取“正在放歌”的提示语。zh 模板含 {master} 占位符，由本函数展开成用户名或本地化
+    中性兜底（避免"主人"）；其它语言模板暂无 {master}，多余 kwarg 会被 .format 忽略。
     """
     lang_key = _normalize_prompt_language(lang)
     template = PROACTIVE_MUSIC_PLAYING_HINT.get(lang_key, PROACTIVE_MUSIC_PLAYING_HINT.get('en', PROACTIVE_MUSIC_PLAYING_HINT['zh']))
     # 对歌名中的花括号进行转义，防止后续整体 prompt.format() 时触发 KeyError
     safe_track_name = track_name.replace('{', '{{').replace('}', '}}')
-    return template.format(track_name=safe_track_name)
+    return template.format(
+        track_name=safe_track_name,
+        master=_resolve_master_for_template(master_name, lang_key),
+    )
 
 
-def get_proactive_music_failsafe_hint(lang: str = 'zh') -> str:
+def get_proactive_music_failsafe_hint(master_name: str | None = None, lang: str = 'zh') -> str:
     """
-    获取“模糊匹配/无资源”的兜底提示语
+    获取“模糊匹配/无资源”的兜底提示语。模板含 {master} 占位符，本函数负责展开。
     """
     lang_key = _normalize_prompt_language(lang)
-    return PROACTIVE_MUSIC_FAILSAFE_HINTS.get(lang_key, PROACTIVE_MUSIC_FAILSAFE_HINTS.get('en', PROACTIVE_MUSIC_FAILSAFE_HINTS['zh']))
+    template = PROACTIVE_MUSIC_FAILSAFE_HINTS.get(
+        lang_key, PROACTIVE_MUSIC_FAILSAFE_HINTS.get('en', PROACTIVE_MUSIC_FAILSAFE_HINTS['zh'])
+    )
+    return template.format(master=_resolve_master_for_template(master_name, lang_key))
+
+
+def get_screen_section_header(master_name: str | None = None, lang: str = 'zh') -> str:
+    """获取 vision 通道的屏幕区块标题（含 {master} 占位符的本地化展开）。"""
+    lang_key = _normalize_prompt_language(lang)
+    template = SCREEN_SECTION_HEADER.get(lang_key, SCREEN_SECTION_HEADER.get('en', SCREEN_SECTION_HEADER['zh']))
+    return template.format(master=_resolve_master_for_template(master_name, lang_key))
+
+
+def get_screen_img_hint(master_name: str | None = None, lang: str = 'zh') -> str:
+    """获取截图说明 hint（含 {master} 占位符的本地化展开）。"""
+    lang_key = _normalize_prompt_language(lang)
+    template = SCREEN_IMG_HINT.get(lang_key, SCREEN_IMG_HINT.get('en', SCREEN_IMG_HINT['zh']))
+    return template.format(master=_resolve_master_for_template(master_name, lang_key))
 
 
 def get_proactive_music_strict_constraint(lang: str = 'zh') -> str:

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -1300,6 +1300,21 @@ def _resolve_master_for_template(master_name: str | None, lang_key: str) -> str:
     )['master']
 
 
+def _escape_format_braces(value: str) -> str:
+    """把字符串里的 ``{`` / ``}`` 双倍转义，让它在后续 str.format() 里被当字面量。
+
+    用于"先在 helper 里 .format(master=...) 展开本地 {master} 占位符、再把
+    结果拼回外层模板交给外层 .format() 处理"的双层 format 路径。如果 master_name
+    本身含 `{` `}`（用户起的怪名字 "A{B}"），第一次 .format 会原样塞入字面量
+    `A{B}`，但第二次 .format 会把它当成新的 `{B}` 占位符并 KeyError。
+
+    本 helper 在第一次 .format 前对 master 值做 ``{`` → ``{{`` / ``}`` → ``}}``
+    转义，第一次 .format 后字符串里就是 ``A{{B}}``；第二次 .format 把 ``{{`` /
+    ``}}`` 还原为 ``{`` / ``}``，最终输出 ``A{B}`` 字面量，且不会被误解析。
+    """
+    return value.replace('{', '{{').replace('}', '}}')
+
+
 PROACTIVE_CHAT_PROMPTS = {
     'zh': {
         'home': proactive_chat_prompt,
@@ -1967,8 +1982,12 @@ def get_proactive_generate_prompt(lang: str = 'zh', music_playing_hint: str = ""
     # meme_instr 含 {master} 占位符，需要在拼回外层 prompt 之前展开掉。否则它会
     # 流到 main_routers/system_router.py 的整体 .format(master_name=..., ...) 那里，
     # 而那一步只传 master_name 不传 master，会触发 KeyError。
+    # master_name 含 `{` / `}`（异常但合法的用户输入，例如 "A{B}"）时必须先转义，
+    # 否则第一次 .format 把字面量 `{B}` 注进 meme_instr，外层 .format 会再次解析
+    # 这个字面量并报 KeyError。Codex review #1043 r3164599879 抓的就是这条。
     if meme_instr:
-        meme_instr = meme_instr.format(master=_resolve_master_for_template(master_name, lang_key))
+        master_value = _escape_format_braces(_resolve_master_for_template(master_name, lang_key))
+        meme_instr = meme_instr.format(master=master_value)
     prompt = prompt.replace('{music_instruction}', music_instr).replace('{meme_instruction}', meme_instr)
 
     if music_playing_hint:
@@ -2539,15 +2558,16 @@ def get_proactive_music_playing_hint(track_name: str, master_name: str | None = 
     """
     获取“正在放歌”的提示语。zh 模板含 {master} 占位符，由本函数展开成用户名或本地化
     中性兜底（避免"主人"）；其它语言模板暂无 {master}，多余 kwarg 会被 .format 忽略。
+
+    本函数返回值会被 system_router 拼到 generate_prompt 末尾、再走整体 .format()，
+    所以 track_name 和 master_name 都需要先 escape `{` / `}`，否则用户起的怪
+    歌名/怪用户名会让外层 .format() KeyError（Codex review #1043 r3164599885）。
     """
     lang_key = _normalize_prompt_language(lang)
     template = PROACTIVE_MUSIC_PLAYING_HINT.get(lang_key, PROACTIVE_MUSIC_PLAYING_HINT.get('en', PROACTIVE_MUSIC_PLAYING_HINT['zh']))
-    # 对歌名中的花括号进行转义，防止后续整体 prompt.format() 时触发 KeyError
-    safe_track_name = track_name.replace('{', '{{').replace('}', '}}')
-    return template.format(
-        track_name=safe_track_name,
-        master=_resolve_master_for_template(master_name, lang_key),
-    )
+    safe_track_name = _escape_format_braces(track_name)
+    safe_master = _escape_format_braces(_resolve_master_for_template(master_name, lang_key))
+    return template.format(track_name=safe_track_name, master=safe_master)
 
 
 def get_proactive_music_failsafe_hint(master_name: str | None = None, lang: str = 'zh') -> str:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -83,11 +83,12 @@ from config.prompts_proactive import (
     get_proactive_music_failsafe_hint,
     get_proactive_music_strict_constraint,
     get_proactive_format_sections,
+    get_screen_section_header, get_screen_img_hint,
     RECENT_PROACTIVE_CHATS_HEADER, RECENT_PROACTIVE_CHATS_FOOTER,
     RECENT_PROACTIVE_TIME_LABELS, RECENT_PROACTIVE_CHANNEL_LABELS,
     BEGIN_GENERATE,
-    SCREEN_SECTION_HEADER, SCREEN_SECTION_FOOTER,
-    SCREEN_WINDOW_TITLE, SCREEN_IMG_HINT,
+    SCREEN_SECTION_FOOTER,
+    SCREEN_WINDOW_TITLE,
     EXTERNAL_TOPIC_HEADER, EXTERNAL_TOPIC_FOOTER,
     MUSIC_SECTION_HEADER, MUSIC_SECTION_FOOTER,
     MEME_SECTION_HEADER, MEME_SECTION_FOOTER,
@@ -4392,11 +4393,11 @@ async def proactive_chat(request: Request):
         # 构建屏幕内容段（vision 通道）
         screen_section = ""
         if screenshot_b64_for_phase2:
-            sl = _loc(SCREEN_SECTION_HEADER, proactive_lang)
+            sl = get_screen_section_header(master_name_current, proactive_lang)
             sf = _loc(SCREEN_SECTION_FOOTER, proactive_lang)
             vision_window = vision_content.get('window_title', '') if vision_content else ''
             window_line = _loc(SCREEN_WINDOW_TITLE, proactive_lang).format(window=vision_window) if vision_window else ""
-            hint = _loc(SCREEN_IMG_HINT, proactive_lang)
+            hint = get_screen_img_hint(master_name_current, proactive_lang)
             screen_section = f"{sl}\n{window_line}{hint}\n{sf}"
             print(f"[{lanlan_name}] Phase 2 将使用 vision 模型直接看截图")
         else:
@@ -4443,7 +4444,7 @@ async def proactive_chat(request: Request):
         music_playing_hint = ""
         if is_playing_music and current_track:
             track_name = current_track.get('name') or get_proactive_music_unknown_track_name(proactive_lang)
-            music_playing_hint = get_proactive_music_playing_hint(track_name, proactive_lang)
+            music_playing_hint = get_proactive_music_playing_hint(track_name, master_name_current, proactive_lang)
 
         # 静动分离：generate_prompt 作为静态 SystemMessage（可被缓存），
         # 追加的音乐/表情包指令作为动态上下文注入 HumanMessage
@@ -4482,6 +4483,7 @@ async def proactive_chat(request: Request):
         generate_prompt = get_proactive_generate_prompt(
             proactive_lang, music_playing_hint,
             has_music=bool(music_section), has_meme=bool(meme_section),
+            master_name=master_name_current,
         ).format(
             character_prompt=character_prompt,
             inner_thoughts=inner_thoughts,
@@ -4504,7 +4506,7 @@ async def proactive_chat(request: Request):
             )
             raw_data = music_content.get('raw_data', {}) if music_content else {}
             if raw_data.get('best_match', {}).get('status') == 'fuzzy':
-                dynamic_context_for_phase2 += get_proactive_music_failsafe_hint(proactive_lang)
+                dynamic_context_for_phase2 += get_proactive_music_failsafe_hint(master_name_current, proactive_lang)
 
         if is_playing_music:
             dynamic_context_for_phase2 += get_proactive_music_strict_constraint(proactive_lang)

--- a/tests/unit/test_proactive_text_does_not_dehumanize.py
+++ b/tests/unit/test_proactive_text_does_not_dehumanize.py
@@ -166,3 +166,74 @@ def test_generate_prompt_does_not_dehumanize_when_no_meme() -> None:
             lang, music_playing_hint='', has_music=False, has_meme=False, master_name=MASTER,
         )
         _assert_no_forbidden(prompt, ctx=f"generate_prompt lang={lang} has_meme=False")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 大括号转义 —— 防御 master_name 含 ``{`` / ``}`` 的边界 case
+#
+# generate_prompt 和 music_playing_hint 走的是"helper 内先 .format(master=...)、
+# 拼回 prompt 后 system_router 再整体 .format()"的双层路径。helper 第一次 format
+# 时把 master_name 字面量原样注入，**不会** escape 它含的花括号；外层第二次
+# .format() 看到 ``{B}`` 这种残留就会 KeyError，proactive 直接 abort。Codex
+# review #1043 (r3164599879 / r3164599885) 抓的就是这两条 P1。
+# ─────────────────────────────────────────────────────────────────────────────
+
+WEIRD_MASTER = 'A{B}'  # 含双括号的"用户起的怪名字"
+
+
+def _simulate_outer_format(generate_prompt: str, music_playing_hint: str = '') -> str:
+    """模拟 system_router.py L4485 的整体 .format(...)，验证不会 KeyError。"""
+    return generate_prompt.format(
+        character_prompt='<char>',
+        inner_thoughts='<inner>',
+        state_section='<state>',
+        memory_context='<mem>',
+        recent_chats_section='<recent>',
+        screen_section='<screen>',
+        external_section='<ext>',
+        music_section='<music>',
+        meme_section='<meme>',
+        master_name=WEIRD_MASTER,
+        source_instruction='<src>',
+        output_format_section='<out>',
+    )
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_generate_prompt_with_braced_master_survives_outer_format(lang: str) -> None:
+    """master_name='A{B}' 时 helper 必须把 master 值的花括号 escape，外层 .format
+    才不会把残留 ``{B}`` 当占位符 KeyError。修完后最终字符串里应该有字面量 ``A{B}``。"""
+    prompt = get_proactive_generate_prompt(
+        lang, music_playing_hint='', has_music=False, has_meme=True,
+        master_name=WEIRD_MASTER,
+    )
+    final = _simulate_outer_format(prompt)
+    assert WEIRD_MASTER in final, f"lang={lang} 字面量 {WEIRD_MASTER!r} 丢失：{final!r}"
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_music_playing_hint_with_braced_master_survives_outer_format(lang: str) -> None:
+    """zh 模板含 {master} 占位符，master_name='A{B}' 时 helper 要 escape；
+    其它 locale 模板没 {master}，但传同样的 master_name 也不应 raise。
+    music_playing_hint 在 system_router 里被拼回 generate_prompt 内层、走整体 .format()。"""
+    hint = get_proactive_music_playing_hint('Some Track', WEIRD_MASTER, lang)
+    prompt = get_proactive_generate_prompt(
+        lang, music_playing_hint=hint, has_music=False, has_meme=False,
+        master_name=WEIRD_MASTER,
+    )
+    final = _simulate_outer_format(prompt)
+    if lang == 'zh':
+        assert WEIRD_MASTER in final, f"lang={lang} hint 内字面量 {WEIRD_MASTER!r} 丢失"
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_music_playing_hint_with_braced_track_name_survives_outer_format(lang: str) -> None:
+    """歌名带 ``{`` / ``}``（如 'Bohemian {Rhapsody}'）时 helper 也要 escape，
+    否则同样会让外层 .format() KeyError。这是 master 修法的对照回归。"""
+    weird_track = 'Bohemian {Rhapsody}'
+    hint = get_proactive_music_playing_hint(weird_track, MASTER, lang)
+    prompt = get_proactive_generate_prompt(
+        lang, music_playing_hint=hint, has_music=False, has_meme=False, master_name=MASTER,
+    )
+    final = _simulate_outer_format(prompt)
+    assert weird_track in final, f"lang={lang} 歌名 {weird_track!r} 丢失：{final!r}"

--- a/tests/unit/test_proactive_text_does_not_dehumanize.py
+++ b/tests/unit/test_proactive_text_does_not_dehumanize.py
@@ -1,0 +1,168 @@
+"""主动搭话相关 prompt 文案的反 AI 物化称呼护栏。
+
+PR #1041 修复了 PROACTIVE_ACTION_NOTE_* 和 _AVATAR_INTERACTION_MEMORY_NOTE_TEMPLATES
+的物化称呼字面量。本文件覆盖剩下三块还在 prompts_proactive.py 里的本地化文案：
+
+1. ``_P2_MEME_INSTRUCTION``：表情包行为指令，由 ``get_proactive_generate_prompt``
+   注入 Phase 2 system prompt。
+2. ``SCREEN_SECTION_HEADER`` / ``SCREEN_IMG_HINT``：vision 通道的屏幕区块标题
+   和截图说明，由 ``get_screen_section_header`` / ``get_screen_img_hint`` 输出。
+3. ``PROACTIVE_MUSIC_PLAYING_HINT`` / ``PROACTIVE_MUSIC_FAILSAFE_HINTS``：放歌时的
+   行为约束 + 模糊匹配兜底，由 ``get_proactive_music_playing_hint`` /
+   ``get_proactive_music_failsafe_hint`` 输出。
+
+每个 helper 都过一遍：
+- 实名传入（``MASTER = "小明"``）→ 名字应原样出现，且禁词字面量都不在结果里。
+- 空名传入 → 应回退到 PROACTIVE_ACTION_NOTE_PLACEHOLDERS 的本地化中性词
+  ("对方" / "them" / "相手" / "상대" / "собеседника")，禁词仍不在结果里。
+
+禁词列表覆盖五种语言的常见物化变体——这是项目核心价值观，下次有人想再悄悄
+把"主人"加回模板会被这层挡住。
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from config.prompts_proactive import (
+    PROACTIVE_ACTION_NOTE_PLACEHOLDERS,
+    get_proactive_generate_prompt,
+    get_proactive_music_failsafe_hint,
+    get_proactive_music_playing_hint,
+    get_screen_img_hint,
+    get_screen_section_header,
+)
+
+LOCALES = ('zh', 'en', 'ja', 'ko', 'ru')
+MASTER = "小明"
+
+# master 的物化变体（含 #1041 PROACTIVE_ACTION_NOTE 测试同款，再加上"Master"
+# 大写——SCREEN_SECTION_HEADER en 旧文案是 "Master's Screen"，要专门把这种
+# 句首大写挡住）
+FORBIDDEN_TERMS = ('主人', 'master', 'Master', 'ご主人', '주인', 'хозяин', 'Хозяин')
+
+# 剥掉 ``{xxx}`` 形式的未展开占位符，避免诸如 ``{master_name}`` / ``{MASTER_NAME}``
+# 这种合法的 Python format placeholder 名字误命中 "master" 禁词。仅匹配安全字符
+# （字母/数字/下划线），保留模板里的实际文案不动。
+_PLACEHOLDER_RE = re.compile(r'\{[A-Za-z_][A-Za-z0-9_]*\}')
+
+
+def _assert_no_forbidden(text: str, *, ctx: str) -> None:
+    stripped = _PLACEHOLDER_RE.sub('', text)
+    for word in FORBIDDEN_TERMS:
+        assert word not in stripped, f"{ctx}: 含物化称呼 '{word}' → {text!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 屏幕区块（vision 通道）
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_screen_section_header_expands_master_name(lang: str) -> None:
+    out = get_screen_section_header(MASTER, lang)
+    assert MASTER in out, f"lang={lang} 实名未注入: {out!r}"
+    _assert_no_forbidden(out, ctx=f"screen_section_header lang={lang}")
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_screen_section_header_falls_back_when_master_empty(lang: str) -> None:
+    fallback = PROACTIVE_ACTION_NOTE_PLACEHOLDERS[lang]['master']
+    for empty in ('', None, '   '):
+        out = get_screen_section_header(empty, lang)
+        assert fallback in out, f"lang={lang} 兜底 {fallback!r} 未注入: {out!r}"
+        _assert_no_forbidden(out, ctx=f"screen_section_header lang={lang} empty={empty!r}")
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_screen_img_hint_expands_master_name(lang: str) -> None:
+    out = get_screen_img_hint(MASTER, lang)
+    assert MASTER in out, f"lang={lang} 实名未注入: {out!r}"
+    _assert_no_forbidden(out, ctx=f"screen_img_hint lang={lang}")
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_screen_img_hint_falls_back_when_master_empty(lang: str) -> None:
+    fallback = PROACTIVE_ACTION_NOTE_PLACEHOLDERS[lang]['master']
+    out = get_screen_img_hint('', lang)
+    assert fallback in out, f"lang={lang} 兜底 {fallback!r} 未注入: {out!r}"
+    _assert_no_forbidden(out, ctx=f"screen_img_hint lang={lang} empty")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 音乐相关（放歌中 + 模糊匹配兜底）
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_music_playing_hint_no_dehumanize_with_master(lang: str) -> None:
+    # track_name 含 {} 字面量，验证 helper 的转义路径仍然工作。
+    out = get_proactive_music_playing_hint('Bohemian {Rhapsody}', MASTER, lang)
+    _assert_no_forbidden(out, ctx=f"music_playing_hint lang={lang}")
+    # zh 模板含 {master}，应注入实名；其它 locale 模板无 {master}，不强求。
+    if lang == 'zh':
+        assert MASTER in out
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_music_playing_hint_no_dehumanize_with_empty_master(lang: str) -> None:
+    out = get_proactive_music_playing_hint('Some Track', '', lang)
+    _assert_no_forbidden(out, ctx=f"music_playing_hint lang={lang} empty")
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_music_failsafe_hint_expands_master_name(lang: str) -> None:
+    out = get_proactive_music_failsafe_hint(MASTER, lang)
+    assert MASTER in out, f"lang={lang} 实名未注入: {out!r}"
+    _assert_no_forbidden(out, ctx=f"music_failsafe lang={lang}")
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_music_failsafe_hint_falls_back_when_master_empty(lang: str) -> None:
+    fallback = PROACTIVE_ACTION_NOTE_PLACEHOLDERS[lang]['master']
+    out = get_proactive_music_failsafe_hint(None, lang)
+    assert fallback in out
+    _assert_no_forbidden(out, ctx=f"music_failsafe lang={lang} empty")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2 generate prompt（表情包行为指令注入）
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_meme_instruction_expanded_inside_generate_prompt(lang: str) -> None:
+    """当 has_meme=True，generate_prompt 必须把 _P2_MEME_INSTRUCTION 里的 {master}
+    占位符在返回前展开，避免外层 .format(master_name=...) 因不知道 master 报 KeyError。
+    """
+    prompt = get_proactive_generate_prompt(
+        lang, music_playing_hint='', has_music=False, has_meme=True, master_name=MASTER,
+    )
+    # 必须没有未展开的 {master}
+    assert '{master}' not in prompt, f"lang={lang} 残留未展开占位符: {prompt!r}"
+    # 必须把名字注入了
+    assert MASTER in prompt, f"lang={lang} 名字未出现"
+    _assert_no_forbidden(prompt, ctx=f"generate_prompt lang={lang} has_meme=True")
+
+
+@pytest.mark.parametrize('lang', LOCALES)
+def test_meme_instruction_falls_back_when_master_empty(lang: str) -> None:
+    fallback = PROACTIVE_ACTION_NOTE_PLACEHOLDERS[lang]['master']
+    prompt = get_proactive_generate_prompt(
+        lang, music_playing_hint='', has_music=False, has_meme=True, master_name='',
+    )
+    assert '{master}' not in prompt
+    assert fallback in prompt, f"lang={lang} 兜底未注入"
+    _assert_no_forbidden(prompt, ctx=f"generate_prompt lang={lang} empty has_meme=True")
+
+
+def test_generate_prompt_does_not_dehumanize_when_no_meme() -> None:
+    """has_meme=False 路径里 _P2_MEME_INSTRUCTION 不会被注入，但 generate prompt 里
+    其它本地化文本也不应混进物化称呼。"""
+    for lang in LOCALES:
+        prompt = get_proactive_generate_prompt(
+            lang, music_playing_hint='', has_music=False, has_meme=False, master_name=MASTER,
+        )
+        _assert_no_forbidden(prompt, ctx=f"generate_prompt lang={lang} has_meme=False")


### PR DESCRIPTION
## 背景

PR #1041 把 `PROACTIVE_ACTION_NOTE_*` 和 `_AVATAR_INTERACTION_MEMORY_NOTE_TEMPLATES` 里的物化称呼改成 `{master}` 占位符 + master_name 实名展开。但 `config/prompts_proactive.py` 里还剩 3 块本地化文案没动，本 PR 把这部分清掉。

## 改动范围

### 1. `_P2_MEME_INSTRUCTION`（Phase 2 表情包行为指令）

5 个 locale 的"表情包给主人看 / send to the master / ご主人に / 주인에게 / хозяину"全部改成 `{master}`。这段被 `get_proactive_generate_prompt` 注入 Phase 2 system prompt，是 LLM 直接看到的指令文。

### 2. `SCREEN_SECTION_HEADER` + `SCREEN_IMG_HINT`（vision 通道屏幕区块）

5 个 locale 的"主人的屏幕 / Master's Screen / ご主人の画面 / 주인의 화면 / Экран хозяина"等改 `{master}`。新增两个 helper：
- `get_screen_section_header(master_name, lang)`
- `get_screen_img_hint(master_name, lang)`

把 `.format(master=...)` 收口在 helper 内部，调用方只传 `master_name`，避免重复散落在多处。

### 3. `PROACTIVE_MUSIC_PLAYING_HINT` + `PROACTIVE_MUSIC_FAILSAFE_HINTS`（音乐场景）

zh 的"不要打扰主人的雅致"+ 5 个 locale 的兜底提示里的物化称呼改 `{master}`。既有 helper `get_proactive_music_playing_hint` / `get_proactive_music_failsafe_hint` 加 `master_name` 参数。

## 关键实现

- **共享 helper `_resolve_master_for_template(master_name, lang_key)`**：空名/None/全空白 → 复用 PR #1041 已有的 `PROACTIVE_ACTION_NOTE_PLACEHOLDERS` 本地化中性兜底（对方 / them / 相手 / 상대 / собеседника），不会再出现"主人"等物化称呼。
- **`get_proactive_generate_prompt` 加 `master_name` 参数**：在把 `_P2_MEME_INSTRUCTION` 拼回外层 prompt **之前**先 `.format(master=...)` 展开掉。否则它会流到 `main_routers/system_router.py` 的整体 `.format(master_name=..., ...)` 那一步——而那一步只传 `master_name` 不传 `master`，留着 `{master}` 会触发 KeyError。
- **`main_routers/system_router.py` 的 5 处 caller** 全部更新成传 `master_name_current`，import 表里把 `SCREEN_SECTION_HEADER` / `SCREEN_IMG_HINT` 替换成两个 helper。

## 测试

新文件 `tests/unit/test_proactive_text_does_not_dehumanize.py`，**51 个 case**：

- 5 个 helper × 5 locale × {实名 / 空名兜底} 矩阵
- 实名应原样注入；空名应回退到本地化中性词；所有分支禁词列表 `('主人/master/Master/ご主人/주인/хозяин/Хозяин')` 都不出现
- 禁词比对前先用 regex 剥掉 `{xxx}` 占位符，避免 `{master_name}` 这种合法 Python format placeholder 名字误命中 `master` 子串
- `_P2_MEME_INSTRUCTION` 的特殊路径单独验证：`get_proactive_generate_prompt(has_meme=True)` 返回值里**不能残留** `{master}` 未展开占位符

### 回归

| 测试集 | 结果 |
|--------|------|
| 新 guard `test_proactive_text_does_not_dehumanize` | 51 passed |
| 既有相关 (`test_proactive_action_note` / `test_avatar_interaction_memory_contract` / `test_proactive_sm_integration` / `test_proactive_sid_guard`) | 56 passed |
| 全 `tests/unit/` | 1524 passed, 14 skipped |

## 不在本 PR 范围

按用户决策，**不动**以下内容（另开 task）：

- `config/prompts_activity.py` 的 5 行 few-shot 示例 `"guess"` 字符串（"用户"也算物化嫌疑，要重新拟措辞）
- `config/__init__.py:465,582` + 6 个 `config/characters.*.json` 里的 `"主人":` dict key（这是结构标识符，要做 key 迁移 + 老 `characters.json` 的兼容回退路径，是独立的 product naming 决定）
- `config/prompts_memory.py:1697-1698` 代码注释里的"主人喜欢猫/讨厌猫"举例（不进 LLM context，低风险）
- 跨整个仓库的 docs / UI 文案 / 插件目录 / tests fixtures


---
_Generated by [Claude Code](https://claude.ai/code/session_01K7rVgxjSjknXNAGPTmZudf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 个性化支持：用户名可注入到音乐提示、截图提示和屏幕区块标题及表情包提示，支持多语言显示。
* **修复**
  * 处理包含大括号等特殊字符的姓名/曲名，避免提示格式化错误或丢失内容。
* **测试**
  * 新增跨五种语言的单元测试，确保注入/回退逻辑正确且避免不当称呼或去人性化用语。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->