### PR TITLE
允许对话框表情/工具按钮在已选中工具时再次点击主按钮直接取消选择

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -1356,13 +1356,19 @@ export default function App({
   const emojiToolMenuNode = (
     <div className="composer-tool-menu" ref={toolMenuRef}>
       <button
-        className={`composer-tool-btn composer-emoji-btn${toolMenuOpen ? ' is-active' : ''}`}
+        className={`composer-tool-btn composer-emoji-btn${toolMenuOpen || activeToolItem ? ' is-active' : ''}`}
         type="button"
         aria-label={selectedEmojiButtonAriaLabel}
         title={selectedEmojiButtonAriaLabel}
         aria-controls={toolMenuOpen ? 'composer-tool-popover' : undefined}
         aria-expanded={toolMenuOpen}
-        onClick={() => setToolMenuOpen(open => !open)}
+        onClick={() => {
+          if (activeToolItem) {
+            clearActiveCursorToolSelection();
+            return;
+          }
+          setToolMenuOpen(open => !open);
+        }}
       >
         <img
           src={activeToolMenuVisual?.imagePath || '/static/icons/emoji_icon.png'}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化了表情工具菜单按钮的活跃状态判断逻辑，改进了光标工具与菜单的交互行为
* 调整点击行为以更好地处理活跃工具选择与菜单切换的关系

<!-- end of auto-generated comment: release notes by coderabbit.ai -->