### PR TITLE
perf(proactive): BS4/regex/JSON 解析推到线程池，消除主动搭话 event loop 阻塞

### DIFF
--- a/utils/meme_fetcher.py
+++ b/utils/meme_fetcher.py
@@ -223,9 +223,10 @@ class MemeFetcher:
             html = await self._fetch_html(self.search_url, params=params)
             if not html:
                 return []
-                
-            soup = BeautifulSoup(html, 'html.parser')
-            
+
+            # BS4 解析放线程池，避免阻塞 event loop
+            soup = await asyncio.to_thread(BeautifulSoup, html, 'html.parser')
+
             # Imgflip 的搜索结果
             target_links = soup.find_all('a', href=re.compile(r'^/(i|gif)/[a-zA-Z0-9]+$'))
             
@@ -523,34 +524,37 @@ class DoutubFetcher:
             html = await self._fetch_html(search_url)
             if not html:
                 return []
-            
-            soup = BeautifulSoup(html, 'html.parser')
-            results = []
-            
-            # 优先嗅探 SSR 静态数据块
-            ssr_data = None
+
             import re
             import json
-            
-            nuxt_match = re.search(r'window\.__NUXT__\s*=\s*({.*?});', html, re.DOTALL)
-            next_match = re.search(r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', html, re.DOTALL)
-            init_match = re.search(r'window\.__INITIAL_STATE__\s*=\s*({.*?});', html, re.DOTALL)
-            
-            if next_match:
-                try:
-                    ssr_data = json.loads(next_match.group(1))
-                except json.JSONDecodeError:
-                    pass
-            elif nuxt_match:
-                try:
-                    ssr_data = json.loads(nuxt_match.group(1))
-                except json.JSONDecodeError:
-                    pass
-            elif init_match:
-                try:
-                    ssr_data = json.loads(init_match.group(1))
-                except json.JSONDecodeError:
-                    pass
+
+            # BS4 + DOTALL 正则 + JSON 解析整体放线程池，full HTML 上的 .*?
+            # 全文扫描在 event loop 里能阻塞百毫秒级。
+            def _parse_html_blob(_html: str) -> tuple:
+                _soup = BeautifulSoup(_html, 'html.parser')
+                _ssr = None
+                _nuxt = re.search(r'window\.__NUXT__\s*=\s*({.*?});', _html, re.DOTALL)
+                _next = re.search(r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', _html, re.DOTALL)
+                _init = re.search(r'window\.__INITIAL_STATE__\s*=\s*({.*?});', _html, re.DOTALL)
+                if _next:
+                    try:
+                        _ssr = json.loads(_next.group(1))
+                    except json.JSONDecodeError:
+                        pass
+                elif _nuxt:
+                    try:
+                        _ssr = json.loads(_nuxt.group(1))
+                    except json.JSONDecodeError:
+                        pass
+                elif _init:
+                    try:
+                        _ssr = json.loads(_init.group(1))
+                    except json.JSONDecodeError:
+                        pass
+                return _soup, _ssr
+
+            soup, ssr_data = await asyncio.to_thread(_parse_html_blob, html)
+            results = []
 
             found_urls = set()
             
@@ -763,7 +767,8 @@ class DoutupkFetcher:
             if not html:
                 return []
 
-            soup = BeautifulSoup(html, 'html.parser')
+            # BS4 解析放线程池
+            soup = await asyncio.to_thread(BeautifulSoup, html, 'html.parser')
             results: List[Dict[str, Any]] = []
 
             # 懒加载结构：img.image_dtb[data-original=真实URL]，src 是 loader 占位图
@@ -958,10 +963,11 @@ class FabiaoqingFetcher:
             html = await self._fetch_html(search_url)
             if not html:
                 return []
-            
-            soup = BeautifulSoup(html, 'html.parser')
+
+            # BS4 解析放线程池
+            soup = await asyncio.to_thread(BeautifulSoup, html, 'html.parser')
             results = []
-            
+
             img_items = soup.select('img.bqppsearch')
             
             for img in img_items:

--- a/utils/meme_fetcher.py
+++ b/utils/meme_fetcher.py
@@ -225,7 +225,7 @@ class MemeFetcher:
                 return []
 
             # BS4 解析放线程池，避免阻塞 event loop
-            soup = await asyncio.to_thread(BeautifulSoup, html, 'html.parser')
+            soup = await asyncio.to_thread(BeautifulSoup, html, 'lxml')
 
             # Imgflip 的搜索结果
             target_links = soup.find_all('a', href=re.compile(r'^/(i|gif)/[a-zA-Z0-9]+$'))
@@ -531,7 +531,10 @@ class DoutubFetcher:
             # BS4 + DOTALL 正则 + JSON 解析整体放线程池，full HTML 上的 .*?
             # 全文扫描在 event loop 里能阻塞百毫秒级。
             def _parse_html_blob(_html: str) -> tuple:
-                _soup = BeautifulSoup(_html, 'html.parser')
+                _soup = BeautifulSoup(_html, 'lxml')
+                # 三种框架的 SSR 注入格式按优先级尝试：Next.js → Nuxt.js → 通用 INITIAL_STATE。
+                # 任一格式 JSON 解析失败都静默吞异常（页面脚本可能被压缩/截断/混淆），
+                # _ssr 保持 None，调用方会回退到下方 XHR API 抓取，无需中断流程。
                 _ssr = None
                 _nuxt = re.search(r'window\.__NUXT__\s*=\s*({.*?});', _html, re.DOTALL)
                 _next = re.search(r'<script id="__NEXT_DATA__" type="application/json">(.*?)</script>', _html, re.DOTALL)
@@ -540,17 +543,17 @@ class DoutubFetcher:
                     try:
                         _ssr = json.loads(_next.group(1))
                     except json.JSONDecodeError:
-                        pass
+                        pass  # 见上方 SSR 降级注释
                 elif _nuxt:
                     try:
                         _ssr = json.loads(_nuxt.group(1))
                     except json.JSONDecodeError:
-                        pass
+                        pass  # 见上方 SSR 降级注释
                 elif _init:
                     try:
                         _ssr = json.loads(_init.group(1))
                     except json.JSONDecodeError:
-                        pass
+                        pass  # 见上方 SSR 降级注释
                 return _soup, _ssr
 
             soup, ssr_data = await asyncio.to_thread(_parse_html_blob, html)
@@ -768,7 +771,7 @@ class DoutupkFetcher:
                 return []
 
             # BS4 解析放线程池
-            soup = await asyncio.to_thread(BeautifulSoup, html, 'html.parser')
+            soup = await asyncio.to_thread(BeautifulSoup, html, 'lxml')
             results: List[Dict[str, Any]] = []
 
             # 懒加载结构：img.image_dtb[data-original=真实URL]，src 是 loader 占位图
@@ -965,7 +968,7 @@ class FabiaoqingFetcher:
                 return []
 
             # BS4 解析放线程池
-            soup = await asyncio.to_thread(BeautifulSoup, html, 'html.parser')
+            soup = await asyncio.to_thread(BeautifulSoup, html, 'lxml')
             results = []
 
             img_items = soup.select('img.bqppsearch')

--- a/utils/music_crawlers.py
+++ b/utils/music_crawlers.py
@@ -746,7 +746,7 @@ class MusopenCrawler(BaseMusicCrawler):
             response = await self.client.get(url)
             response.raise_for_status()
             # === Musopen 封面抓取 ===
-            soup = BeautifulSoup(response.text, 'lxml')
+            soup = await asyncio.to_thread(BeautifulSoup, response.text, 'lxml')
             cover_url = ""
             
             # 1. 提取网页头部的 Open Graph 图片 (最清晰的原版封面或肖像)
@@ -819,8 +819,8 @@ class FMACrawler(BaseMusicCrawler):
             # 交给 httpx 自动进行 URL 安全编码
             response = await self.client.get(search_url, params=params)
             response.raise_for_status()
-            soup = BeautifulSoup(response.text, 'lxml')
-            
+            soup = await asyncio.to_thread(BeautifulSoup, response.text, 'lxml')
+
             # FMA 将音轨信息存在 `data-track-info` 属性中
             play_items = soup.find_all(attrs={"data-track-info": True})
             
@@ -897,8 +897,8 @@ class BandcampCrawler(BaseMusicCrawler):
             response = await self.client.get(url, params=params) # httpx 会自动编码
             if response.status_code != 200:
                 return []
-                
-            soup = BeautifulSoup(response.text, 'lxml')
+
+            soup = await asyncio.to_thread(BeautifulSoup, response.text, 'lxml')
             
             # 搜索页的链接藏在 .heading a 里面
             items = soup.select('.heading a')
@@ -919,7 +919,7 @@ class BandcampCrawler(BaseMusicCrawler):
                 
                 try:
                     track_res = await self.client.get(target_url)
-                    track_soup = BeautifulSoup(track_res.text, 'lxml')
+                    track_soup = await asyncio.to_thread(BeautifulSoup, track_res.text, 'lxml')
                     
                     script_data = track_soup.find('script', attrs={'data-tralbum': True})
                     if not script_data:

--- a/utils/music_crawlers.py
+++ b/utils/music_crawlers.py
@@ -746,7 +746,7 @@ class MusopenCrawler(BaseMusicCrawler):
             response = await self.client.get(url)
             response.raise_for_status()
             # === Musopen 封面抓取 ===
-            soup = BeautifulSoup(response.text, 'html.parser')
+            soup = BeautifulSoup(response.text, 'lxml')
             cover_url = ""
             
             # 1. 提取网页头部的 Open Graph 图片 (最清晰的原版封面或肖像)
@@ -819,7 +819,7 @@ class FMACrawler(BaseMusicCrawler):
             # 交给 httpx 自动进行 URL 安全编码
             response = await self.client.get(search_url, params=params)
             response.raise_for_status()
-            soup = BeautifulSoup(response.text, 'html.parser')
+            soup = BeautifulSoup(response.text, 'lxml')
             
             # FMA 将音轨信息存在 `data-track-info` 属性中
             play_items = soup.find_all(attrs={"data-track-info": True})
@@ -898,7 +898,7 @@ class BandcampCrawler(BaseMusicCrawler):
             if response.status_code != 200:
                 return []
                 
-            soup = BeautifulSoup(response.text, 'html.parser')
+            soup = BeautifulSoup(response.text, 'lxml')
             
             # 搜索页的链接藏在 .heading a 里面
             items = soup.select('.heading a')
@@ -919,7 +919,7 @@ class BandcampCrawler(BaseMusicCrawler):
                 
                 try:
                     track_res = await self.client.get(target_url)
-                    track_soup = BeautifulSoup(track_res.text, 'html.parser')
+                    track_soup = BeautifulSoup(track_res.text, 'lxml')
                     
                     script_data = track_soup.find('script', attrs={'data-tralbum': True})
                     if not script_data:

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -463,7 +463,7 @@ async def fetch_weibo_trending(limit: int = 10) -> Dict[str, Any]:
             return await _fetch_weibo_trending_fallback(limit)
 
         html = response.text
-        soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, 'lxml')
 
         # 解析热搜列表 (td-02 class)
         td_items = soup.find_all('td', class_='td-02')
@@ -759,7 +759,7 @@ async def _fetch_twitter_trending_fallback(limit: int = 10) -> Dict[str, Any]:
             if response.status_code == 200:
                 # BS4 解析 + 解析器迭代统一放线程池，避免阻塞 event loop
                 def _parse_in_thread(html: str, parser, _limit: int) -> List[Dict[str, Any]]:
-                    return parser(BeautifulSoup(html, 'html.parser'), _limit)
+                    return parser(BeautifulSoup(html, 'lxml'), _limit)
                 trending_list = await asyncio.to_thread(
                     _parse_in_thread, response.text, source['parser'], limit
                 )
@@ -1461,7 +1461,7 @@ def parse_google_results(html_content: str, limit: int = 5) -> List[Dict[str, st
     
     try:
         from urllib.parse import urljoin, urlparse, parse_qs
-        soup = BeautifulSoup(html_content, 'html.parser')
+        soup = BeautifulSoup(html_content, 'lxml')
         
         # 查找搜索结果容器
         # Google使用各种类名，尝试多个选择器
@@ -1615,7 +1615,7 @@ def parse_baidu_results(html_content: str, limit: int = 5) -> List[Dict[str, str
     
     try:
         from urllib.parse import urljoin
-        soup = BeautifulSoup(html_content, 'html.parser')
+        soup = BeautifulSoup(html_content, 'lxml')
         
         # 提取搜索结果容器
         containers = soup.find_all('div', class_=lambda x: x and 'c-container' in x, limit=limit * 2)

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -757,8 +757,12 @@ async def _fetch_twitter_trending_fallback(limit: int = 10) -> Dict[str, Any]:
             response = await client.get(source['url'], headers=headers, timeout=5.0)
 
             if response.status_code == 200:
-                soup = BeautifulSoup(response.text, 'html.parser')
-                trending_list = source['parser'](soup, limit)
+                # BS4 解析 + 解析器迭代统一放线程池，避免阻塞 event loop
+                def _parse_in_thread(html: str, parser, _limit: int) -> List[Dict[str, Any]]:
+                    return parser(BeautifulSoup(html, 'html.parser'), _limit)
+                trending_list = await asyncio.to_thread(
+                    _parse_in_thread, response.text, source['parser'], limit
+                )
 
                 if trending_list:
                     logger.info(f"从{source['name']}获取到{len(trending_list)}条Twitter热门")
@@ -1412,8 +1416,8 @@ async def search_google(query: str, limit: int = 10) -> Dict[str, Any]:
         response.raise_for_status()
         html_content = response.text
 
-        # 解析搜索结果
-        results = parse_google_results(html_content, limit)
+        # 解析搜索结果（BS4 大 HTML 同步解析放线程池，避免阻塞 event loop）
+        results = await asyncio.to_thread(parse_google_results, html_content, limit)
 
         if results:
             return {
@@ -1567,7 +1571,7 @@ async def search_baidu(query: str, limit: int = 5) -> Dict[str, Any]:
         html_content = response.text
 
         # 解析搜索结果
-        results = parse_baidu_results(html_content, limit)
+        results = await asyncio.to_thread(parse_baidu_results, html_content, limit)
 
         if results:
             return {

--- a/utils/web_scraper.py
+++ b/utils/web_scraper.py
@@ -463,7 +463,8 @@ async def fetch_weibo_trending(limit: int = 10) -> Dict[str, Any]:
             return await _fetch_weibo_trending_fallback(limit)
 
         html = response.text
-        soup = BeautifulSoup(html, 'lxml')
+        # BS4 解析放线程池（与 Google/Baidu/Twitter 链路一致）
+        soup = await asyncio.to_thread(BeautifulSoup, html, 'lxml')
 
         # 解析热搜列表 (td-02 class)
         td_items = soup.find_all('td', class_='td-02')


### PR DESCRIPTION
## Summary
- 主动搭话每轮跑 3× Google 搜索 + Twitter trends + meme 抓取，原先 `parse_google_results` 等同步函数在 async 路径里 BeautifulSoup 解析 200KB+ 的 SERP HTML，单次 100-300ms 阻塞 event loop。
- 实测日志反复出现 `heartbeat stall 350-680ms (expected ~200ms)` 与 asyncio `Task ... took 0.3-0.5s` 警告，集中在 proactive_chat 期间。
- 修复：把 7 处同步解析统一 `await asyncio.to_thread(...)` 推到线程池，loop 期间可继续处理 WS 心跳和其他 async 任务。

## Changes
**utils/web_scraper.py**
- `search_google` 调用 `parse_google_results` 改 to_thread（主要凶手，每轮 ×3）
- `search_baidu` 调用 `parse_baidu_results` 改 to_thread
- `_fetch_twitter_trending_fallback` 里 BS4 + parser(soup) 整体 to_thread

**utils/meme_fetcher.py**
- Imgflip / Doutupk / Fabiaoqing：`BeautifulSoup(html, 'html.parser')` 改 `await asyncio.to_thread(BeautifulSoup, html, 'html.parser')`
- Doutub：BS4 + 三条 DOTALL 全文正则 + `json.loads` 整体打包成 `_parse_html_blob` 单次 to_thread（DOTALL 全文扫描在 event loop 里能阻塞百毫秒级）

## Test plan
- [ ] AST parse 通过（`python -c "import ast; ast.parse(...)"` ✓）
- [ ] 启用 `NEKO_DEBUG_HEARTBEAT=1` 跑一轮主动搭话，确认 `heartbeat stall` 出现频率与幅度明显下降
- [ ] 主动搭话功能回归：Google 搜索结果解析、Twitter trends24、Imgflip/Doutupk/Fabiaoqing meme 抓取均能正常返回非空结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 将耗时的 HTML 解析与服务端渲染数据提取迁移到后台线程，减少主事件循环阻塞，提升响应速度与稳定性。
  * 统一切换为更兼容、稳定的 lxml 解析器，改善各类网页解析的兼容性与准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->