### PR TITLE
fix(proactive): mute 时不刷 RMS + user_transcript 复位语音 nudge 计数

### DIFF
--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -382,6 +382,16 @@
             return;
         }
 
+        // mute 状态下 audio 在 worklet onmessage 处被丢弃，根本没送到后端，
+        // 此时 analyser 仍连在增益链上能听到本地噪声（键盘/风扇/呼吸）。
+        // 把这部分 RMS 当 0：不读、不写 userRecentSpeechTime，避免 proactive
+        // guard 把"本地噪声"误判成"用户在说话"导致语音模式 nudge 被静默
+        // skip 卡死 (`_isUserRecentlySpeaking()` 8s 窗口拖尾)。
+        if (S.isMicMuted) {
+            requestAnimationFrame(monitorInputVolume);
+            return;
+        }
+
         const dataArray = new Uint8Array(S.inputAnalyser.fftSize);
         S.inputAnalyser.getByteTimeDomainData(dataArray);
 
@@ -968,6 +978,11 @@
         S.isMicMuted = !S.isMicMuted;
         if (S.isMicMuted) {
             stopSilenceDetection();
+            // 立刻清掉"用户最近在说话"的时间戳。否则 mute 前最后一帧
+            // RMS 写入的 userRecentSpeechTime 会在 8s 内继续让
+            // _isUserRecentlySpeaking() 返回 true，proactive nudge
+            // 在窗口期内仍会被 skip。
+            S.userRecentSpeechTime = 0;
         } else if (S.isRecording) {
             startSilenceDetection();
         }

--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1002,6 +1002,8 @@
         S.isMicMuted = muted;
         if (S.isMicMuted) {
             stopSilenceDetection();
+            // 与 toggleMicMute 对齐：进入 muted 时清掉时间戳，避免拖尾。
+            S.userRecentSpeechTime = 0;
         } else if (S.isRecording) {
             startSilenceDetection();
         }

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -751,6 +751,14 @@
                         clearTimeout(S._voiceSessionInitialTimer);
                         S._voiceSessionInitialTimer = null;
                     }
+                    // 真用户语音到达 → 等同于一次"用户输入"：清退避级别 +
+                    // 复位语音模式无回复计数。否则连续被 preempt / 长时间没
+                    // 回应都不会复位 _voiceProactiveNoResponseCount，10 轮后
+                    // 主动搭话会被永久关闭，即使用户其实一直在讲话。
+                    // 跨窗口通过 BroadcastChannel 广播，让 leader 同步。
+                    if (typeof window.resetProactiveChatBackoff === 'function') {
+                        window.resetProactiveChatBackoff();
+                    }
                     var now = Date.now();
                     var shouldMerge = S.isRecording &&
                         S.lastVoiceUserMessage &&


### PR DESCRIPTION
## Summary

修三件互相关联的 proactive 卡死 bug。起因：用户反馈"主动搭话放了首音乐之后就完全没后文了"，2~3 分钟空白。

### Bug 1: mute 状态下本地噪声把前端 proactive guard 卡死

`startAudioWorklet` 把 `inputAnalyser` 接在增益链上 (`source → micGainNode → inputAnalyser`)，跟 `workletNode` 是分叉的两路。`toggleMicMute()` 只在 worklet 的 `onmessage` 里 `if (S.isMicMuted) return;` 把数据丢了——audio 不送到后端，但 analyser 一直在跑。

`monitorInputVolume()` 每帧读 analyser，RMS > 0.01 就刷 `S.userRecentSpeechTime = Date.now()`。键盘敲击、风扇、呼吸、桌面振动都能轻松超过 0.01。

然后 [`_isUserRecentlySpeaking()`](static/app-proactive.js#L294)（语音模式 proactive 调度器的 8s guard）因此持续返回 true，每次 timer 触发都静默 skip + reschedule，永远不发请求。日志只看到 timer 在自旋。

**修法**：`monitorInputVolume()` 在 mute 时直接续帧返回，跳过 RMS 读写。`toggleMicMute()` 进入 muted 时清掉 `userRecentSpeechTime`，避免 mute 前最后一帧的时间戳在 8s 内拖尾。

原则：RMS 是给"用户是否在向后端输入语音"做判定的，**前端能听到 ≠ 后端在收**，前者是噪声、后者才是信号。所以非"真正的语音会话状态"（含 mute）下 RMS 一律按 0 处理。

### Bug 2: 语音模式 `_voiceProactiveNoResponseCount` 没有"用户开口"这条复位路径

[scheduleProactiveChat](static/app-proactive.js#L383) 语音模式的 hard cap 是 `_voiceProactiveNoResponseCount >= 10` 永久停。复位只在切麦克风/停录音/拖动头像等少量路径调 [`resetProactiveChatBackoff`](static/app-proactive.js#L1261)。

用户开口（语音模式下用户语音 transcript 经 WS 到前端）**不会**复位。结果：连续被 preempt 或长时间没回应累计到 10 轮，主动搭话被永久关停，即使用户其实一直在讲话。

**修法**：`user_transcript` WS handler 调一次 `resetProactiveChatBackoff()`，把退避级别和无回复计数一起清，同时通过 BroadcastChannel 让 leader 同步。

## Test plan

JS-only 改动，仓库无 JS 测试套件，纯人工验证：

- [ ] 开语音录音，点 mute 按钮看到 "麦克风已静音" toast
- [ ] mute 状态下保持 30s+，观察 console，应该看到 proactive timer 触发后**不再**频繁打 `[ProactiveChat] 语音模式：用户最近在发声，本次 nudge 跳过`，而是正常发出 nudge 请求
- [ ] mute 立即 unmute，proactive 调度恢复正常
- [ ] 语音对话场景下连续讲话 10 轮以上，proactive 不会因 `_voiceProactiveNoResponseCount` 触顶停掉
- [ ] mute 时 ambient 噪声（键盘、风扇）不应触发后端任何 transcription（已经是这样，本 PR 不动后端）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 版本说明

* **Bug Fixes**
  * 修复静音后语音活动状态未立即清除的问题：麦克风静音时会立即重置“最近讲话”状态，避免本地噪声或静音前残留导致误判。

* **Improvements**
  * 优化语音转录触发处理：真实语音到达时会重置主动聊天的退避状态，使系统更快恢复响应，减少因长时间静默引起的停用行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->