### PR TITLE
fix(proactive): Phase 2 debug print 去掉 buffer 拼接的复读

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4692,7 +4692,11 @@ async def proactive_chat(request: Request):
                 await _emit_safe(cleaned)
         
         # --- 结果处理 ---
-        print(f"\n[PROACTIVE-DEBUG] Phase 2 STREAM output (aborted={aborted}, tag={source_tag}): {(buffer + full_text)[:300]}\n")
+        # buffer 是流前 ~80 字符的原始累积（含 [TAG]\n 前缀和正文头部），
+        # full_text 是去标签后真正投递给 TTS / send_lanlan_response 的内容。
+        # 两者拼起来打印会让正文头部"复读"一遍，看着像 bug 实际不是。
+        # 调试只需要 tag + 实际投递文本即可。
+        print(f"\n[PROACTIVE-DEBUG] Phase 2 STREAM output (aborted={aborted}, tag={source_tag}): {full_text[:300]}\n")
         if aborted or not full_text.strip():
             # 只有当用户没接管时才调 handle_new_message 清 TTS —— 否则会把
             # 用户正常回复的 TTS 也清掉（PR #862 修的 bug）。状态机的


### PR DESCRIPTION
## Summary

[main_routers/system_router.py:4695](main_routers/system_router.py:4695) 这条 debug print 把 `buffer + full_text` 拼起来打，导致输出看起来像正文"复读了一遍"——

```
[PROACTIVE-DEBUG] Phase 2 STREAM output (aborted=False, tag=MUSIC): [MUSIC]
系统说找不到完全匹配的，不过这几首也是超有活力的J-POP！...系统说找不到完全匹配的，不过这几首也是超有活力的J-POP！...
```

实际没复读：`buffer` 是流前 ~80 字符的原始累积（含 `[TAG]\n` 前缀和正文头部），`full_text` 是去标签后真正投递给 TTS / `send_lanlan_response` 的内容。两者头部重合，拼一起视觉上看着像 bug，实际是 print artifact。

改成只打 `full_text`，加注释说明 buffer/full_text 的语义差别，避免下次又有人误判成投递重复。

## Test plan
- [x] 本地阅读改动无逻辑影响（只动 print 字符串）
- [ ] 触发一次 proactive 主动搭话，确认 `[PROACTIVE-DEBUG] Phase 2 STREAM output (aborted=..., tag=...)` 行不再出现复读

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了调试日志输出，移除了重复的内容展示，使日志更清晰易读。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->