### PR TITLE
fix(lip_sync): MMD 语音口型同步期间清零其他元音残留

### DIFF
--- a/static/mmd-expression.js
+++ b/static/mmd-expression.js
@@ -307,6 +307,16 @@ class MMDExpression {
                 });
             }
             if (lipValue > 0.05) {
+                // mixer.update 在本帧可能已写入待机 VMD 的 い/う/え 口型轨道，
+                // setMouth 之后只覆盖 あ/お，其余元音残留会与 lip sync 叠加成混合口型。
+                // 这里在写 あ/お 之前先把 lip sync 不主动驱动的 い/う/え 置 0，确保
+                // 语音口型同步期间嘴部完全由 lip sync 驱动。清零只在 lipValue>0.05
+                // 分支执行——非 lip sync 帧仍保留 VMD 口型轨道的正常播放。
+                for (const phoneme of ['i', 'u', 'e']) {
+                    for (const name of (this.lipMorphNames[phoneme] || [])) {
+                        this.setMorphWeight(name, 0);
+                    }
+                }
                 this.setMouth(lipValue);
             } else {
                 this.setMouth(0);


### PR DESCRIPTION
## 问题

MMD 渲染顺序中，`animationModule.update(delta)` 内 `mixer.update` 会先评估 VMD morph 轨道，把 `あ/い/う/え/お` 写到 `morphTargetInfluences`；随后 `expression.update(delta)` 调 `setMouth(value)`，只覆盖 `あ`（×1.0）和 `お`（×0.3）。如果待机 VMD 包含 `い/う/え` 口型轨道，残留就会与 lip sync 输出的 `あ/お` 叠加成混合口型。

## 修复

在 [`static/mmd-expression.js`](static/mmd-expression.js) `update(delta)` 的 `lipValue > 0.05` 分支中，写入 `あ/お` 之前先把 `い/う/え` 置 0。清零只在 lip sync 激活时执行——非 lip sync 帧保留 VMD 口型轨道的正常播放（不放进 `setMouth` 内部的原因：`expression.update` 在 `lipValue <= 0.05` 也会调 `setMouth(0)`，写在那里会让无语音帧的 VMD 口型轨道完全失效）。

## 与 PR #1053 的关系

同源 bug——PR #1053 已修 VRM 路径（`_updateLipSync` 只覆盖 `aa`，剩余 `ih/ou/ee/oh` 残留），这次补 MMD。机制完全一致：动画 mixer 先写、lip sync 后覆盖部分元音。

## 验证

本地无法跑端到端验证（需要带 `い/う/え` 关键帧的 VMD + 实时音频输入），改动很窄、依赖 CI。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了唇形同步功能,修复了口型形变混合问题,确保启用唇同步时口型表现更加清晰准确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->