### PR TITLE
feat(plugin): Minecraft 游戏代理 plugin（基于 #1035 + #1046 + #1055 重写）

### DIFF
--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -97,6 +97,19 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 迁移指南：原 `core.game_agent_enabled = True` + `core.game_agent_url = ...` 的两行代码不再需要；
 直接启用本插件并按需调整 `plugin.toml`。
 
+## 已知限制
+
+**协议没有 task ID，依赖 FIFO 完成顺序**：插件用一个 stale-frame drop 计数器
+来过滤老任务（已 timeout / overwrite / cancel）的延迟 `task_finished` 帧，
+假设 agent 按完成顺序发帧。如果你写的 agent 内部有并发使得"被 overwrite 的
+A 在替换者 B 之后才完成"（即帧顺序是 B-then-A），filter 会吞掉 B 的真完成、
+把 A 的延迟帧当成 B 的——当前 `minecraft_task` 调用会卡到 `task_timeout_seconds`。
+
+我们 ship 的目标 agent (mineflayer 系) 都是顺序处理：overwrite 会先停老任务
+再起新任务，不存在 out-of-order completion，实践上不会触发。如果你写的 agent
+内部有真正的并发，请在协议里给 `task` / `task_finished` 帧加 task ID，并提
+issue 让我们接 explicit correlation。
+
 ## 文件分工
 
 | 文件 | 作用 |

--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -1,0 +1,107 @@
+# Minecraft 游戏代理插件
+
+把本地 Minecraft Agent (WebSocket) 桥接到 N.E.K.O 的实时 LLM 会话上：模型可以
+通过 `minecraft_task` 工具下发指令，agent 执行过程中的截图实时推到模型的视觉
+上下文里，让模型一边玩一边解说。
+
+## 协议
+
+agent server 与本插件通过单一 WebSocket 连接通信，JSON 帧格式：
+
+| 方向 | `type` | 字段 |
+|------|--------|------|
+| → agent | `task` | `{"type": "task", "task": "<目标>"}` |
+| ← agent | `log` | `{"type": "log", "text": "..."}` |
+| ← agent | `screenshot` | `{"type": "screenshot", "image": "<base64>", "encoding": "png"\|"jpeg"}` |
+| ← agent | `task_finished` | `{"type": "task_finished", "status": "ok", "text": "..."}` |
+| ← agent | `agent_status` | informational, ignored by callbacks |
+
+agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.js --port 48909`
+或类似命令），插件只负责连进去。
+
+## 启用步骤
+
+1. 启动 Minecraft agent server，记下监听端口（默认 `48909`）
+2. 在 N.E.K.O 插件管理界面启用 `game_agent_minecraft` 插件
+3. 如需修改 agent 地址或超时，编辑 `plugin.toml` 的 `[game_agent]` 节，然后调
+   `game_agent_reload_config` entry 即可热更新（无需重启 WebSocket 连接）
+
+启用后无需任何 main_logic 代码改动 —— `minecraft_task` 工具会通过 SDK 的
+`@llm_tool` 装饰器自动注册到 `main_server` 的统一工具表。
+
+## 配置项
+
+`plugin.toml` 的 `[game_agent]` 节：
+
+| 字段 | 默认 | 含义 |
+|------|------|------|
+| `ws_url` | `ws://localhost:48909` | agent server WebSocket 地址 |
+| `reconnect_interval_seconds` | `5.0` | WS 断开后等待多久重连 |
+| `task_timeout_seconds` | `25.0` | `minecraft_task` 单次调用最长等待 agent 完成的秒数；超时返回 `{status: "timeout"}` 给 LLM |
+| `system_prompt_interval_seconds` | `5.0` | 自动 nudge 循环的最小间隔；不影响 `main_server` 自身的对话节奏控制 |
+| `skip_system_prompt_if_busy` | `true` | 任务进行中跳过 nudge，避免堆叠 |
+| `stream_screenshots_to_llm` | `true` | 收到 agent 截图就立即 push 到模型视觉上下文（`ai_behavior="read"`） |
+| `screenshot_cache_size` | `3` | 内存里保留的最近 N 张截图，nudge 时一并发出 |
+
+## LLM 工具：`minecraft_task`
+
+```
+{
+  "name": "minecraft_task",
+  "description": "Send a task to the Minecraft game system ...",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "task":      {"type": "string"},
+      "overwrite": {"type": "boolean"}
+    },
+    "required": ["task"]
+  }
+}
+```
+
+返回值（LLM 看到的）：
+
+| 形态 | 时机 |
+|------|------|
+| `{"status": "ok", "query": "..."}` | agent 正常完成 |
+| `{"status": "timeout", "query": "...", "reason": "..."}` | `task_timeout_seconds` 内 agent 未完成 |
+| `{"status": "interrupted", "query": "...", "reason": "..."}` | 被新任务（`overwrite=True`）抢占 |
+| `{"result": "busy", "currently_executing": "...", "hint": "..."}` | 已有任务在跑且 `overwrite=False`，新任务被拒 |
+| `{"output": {"error": "..."}, "is_error": true, "error": "AGENT_DISCONNECTED"}` | agent server 当前不可达 |
+
+## 自动 nudge 循环
+
+后台任务每 `system_prompt_interval_seconds` 秒检查一次：
+
+- 如果 agent 有日志或截图缓存，且当前没有 pending 任务（或 `skip_system_prompt_if_busy=false`），
+  就 push_message 一条 `GAME_SYSTEM | ...` 文本 + 缓存里的截图给 LLM
+- LLM 收到后通常会决定下一个 `minecraft_task`，或者只解说不下指令
+- 时机由 `main_server` 的 proactive_message handler 二次把关（用户/模型说话期间它不会真的打断），
+  插件这层只负责"别 5 秒里发 10 次"
+
+## 与原版 (`feat/game-agent-integration`) 的差别
+
+原方案把所有逻辑硬编码进 `main_logic/core.py` 和
+`main_logic/game_agent_client.py`，与 PR #1035 的统一 `ToolRegistry` 强冲突。
+这版完全是一个独立插件：
+
+| 项 | 原版 | 现版 |
+|----|------|------|
+| 工具注册 | 直接拼 Gemini 的 `function_declarations` | `@llm_tool` 装饰器，走统一 `ToolRegistry`，全 provider 通用（OpenAI / Gemini / GLM / Qwen Omni / StepFun ...） |
+| 截图入栈 | `session.send_media_input(bytes, mime)` 直调 | `push_message v2` `parts=[{"type":"image","data":...,"mime":...}]`，main_server 自动 `stream_image` |
+| 异步 task 完成回填 | 自维护 `_game_pending_tool_id` + `session.send_tool_response` | `asyncio.Event` 在 `@llm_tool` handler 里 await，task_finished 回调 set 事件 |
+| 自动 nudge | `session.create_response(prompt)` 直调 | `push_message v2` `ai_behavior="respond"` |
+| 启用方式 | 改 `core.py` 里两个属性 | 在插件管理界面打开开关 |
+
+迁移指南：原 `core.game_agent_enabled = True` + `core.game_agent_url = ...` 的两行代码不再需要；
+直接启用本插件并按需调整 `plugin.toml`。
+
+## 文件分工
+
+| 文件 | 作用 |
+|------|------|
+| `__init__.py` | 插件 facade —— 生命周期 hook、`@llm_tool` 装饰、状态查询 entries |
+| `service.py` | `GameAgentService` —— 跨回调状态、`asyncio.Event` 桥接、自动 nudge 循环 |
+| `client.py` | `GameAgentClient` —— WebSocket 连接 + 自动重连 + 帧分发 |
+| `plugin.toml` | 插件清单 + `[game_agent]` 配置 |

--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -29,8 +29,13 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 
 1. 启动 Minecraft agent server，记下监听端口（默认 `48909`）
 2. 在 N.E.K.O 插件管理界面启用 `game_agent_minecraft` 插件
-3. 如需修改 agent 地址或超时，编辑 `plugin.toml` 的 `[game_agent]` 节，然后调
-   `game_agent_reload_config` entry 即可热更新（无需重启 WebSocket 连接）
+3. 如需修改配置，编辑 `plugin.toml` 的 `[game_agent]` 节后调
+   `game_agent_reload_config` entry 应用：
+   - **非 transport 配置**（`task_timeout_seconds`、`system_prompt_interval_seconds`、
+     `screenshot_cache_size`、各种开关等）—— 当场生效，**不重连** WebSocket。
+   - **transport 配置**（`ws_url`、`reconnect_interval_seconds`）—— 会触发
+     WebSocket 客户端 stop+start 切换到新地址；entry 返回值的
+     `transport_restarted` 标志会反映这一点。
 
 启用后无需任何 main_logic 代码改动 —— `minecraft_task` 工具会通过 SDK 的
 `@llm_tool` 装饰器自动注册到 `main_server` 的统一工具表。

--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -10,11 +10,17 @@ agent server 与本插件通过单一 WebSocket 连接通信，JSON 帧格式：
 
 | 方向 | `type` | 字段 |
 |------|--------|------|
-| → agent | `task` | `{"type": "task", "task": "<目标>"}` |
+| → agent | `task` | `{"type": "task", "task": "<目标>", "task_id": "<uuid>"}` |
 | ← agent | `log` | `{"type": "log", "text": "..."}` |
 | ← agent | `screenshot` | `{"type": "screenshot", "image": "<base64>", "encoding": "png"\|"jpeg"}` |
-| ← agent | `task_finished` | `{"type": "task_finished", "status": "ok", "text": "..."}` |
+| ← agent | `task_finished` | `{"type": "task_finished", "status": "ok", "text": "...", "task_id": "<uuid>"}` |
 | ← agent | `agent_status` | informational, ignored by callbacks |
+
+`task_id` 是**可选的**显式关联字段。插件每次发 `task` 帧都会带一个新生成
+的 UUID；agent 如果在对应的 `task_finished` 帧里把这个 UUID 原样回传，插件
+就用 ID 严格匹配 pending 任务，跳过 FIFO 的 stale-frame 启发式。**不回传
+也兼容**——插件会回退到按完成顺序匹配（见下方"已知限制"）。建议有内部并发
+的 agent 实现一定带上 `task_id` 以避免 out-of-order 完成被错误归属。
 
 agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.js --port 48909`
 或类似命令），插件只负责连进去。
@@ -99,16 +105,16 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 
 ## 已知限制
 
-**协议没有 task ID，依赖 FIFO 完成顺序**：插件用一个 stale-frame drop 计数器
-来过滤老任务（已 timeout / overwrite / cancel）的延迟 `task_finished` 帧，
-假设 agent 按完成顺序发帧。如果你写的 agent 内部有并发使得"被 overwrite 的
-A 在替换者 B 之后才完成"（即帧顺序是 B-then-A），filter 会吞掉 B 的真完成、
+**FIFO 回退模式下的 out-of-order completion**：如果 agent 没有在
+`task_finished` 帧里回传 `task_id`，插件就退化到按完成顺序匹配 pending
+任务的 stale-frame drop 计数器。假设 agent 按完成顺序发帧——这对顺序处理
+的 agent（mineflayer 系等）成立，但若 agent 内部有并发使得"被 overwrite
+的 A 在替换者 B 之后才完成"（帧顺序 B-then-A），filter 会吞掉 B 的真完成、
 把 A 的延迟帧当成 B 的——当前 `minecraft_task` 调用会卡到 `task_timeout_seconds`。
 
-我们 ship 的目标 agent (mineflayer 系) 都是顺序处理：overwrite 会先停老任务
-再起新任务，不存在 out-of-order completion，实践上不会触发。如果你写的 agent
-内部有真正的并发，请在协议里给 `task` / `task_finished` 帧加 task ID，并提
-issue 让我们接 explicit correlation。
+**修复方法**：在 agent 端把 task 帧里收到的 `task_id` 原样回传到对应的
+`task_finished` 帧上即可。插件会自动切到显式 ID 匹配模式，不再依赖完成
+顺序。
 
 ## 文件分工
 

--- a/plugin/plugins/game_agent_minecraft/README.md
+++ b/plugin/plugins/game_agent_minecraft/README.md
@@ -51,7 +51,7 @@ agent 端启动方式由你自己决定（一般是 `node minecraft-agent/index.
 
 ## LLM 工具：`minecraft_task`
 
-```
+```json
 {
   "name": "minecraft_task",
   "description": "Send a task to the Minecraft game system ...",

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -1,0 +1,183 @@
+"""Minecraft Game Agent plugin.
+
+Bridges a local Minecraft agent server (WebSocket) to the LLM via the
+plugin SDK's ``@llm_tool`` decorator. Replaces the previous in-tree
+integration that lived in ``main_logic/core.py`` and ``main_logic/
+game_agent_client.py`` (commit ``bca0c5f3`` on the abandoned
+``feat/game-agent-integration`` branch). Now everything game-agent-
+specific is contained inside this directory and can be installed /
+removed without patching core code.
+
+Architecture (one paragraph): ``minecraft_task`` is registered as an
+LLM tool via :func:`plugin.sdk.plugin.llm_tool`; when the model picks
+it, the plugin sends the task text to the agent server over WebSocket
+and blocks the handler on an :class:`asyncio.Event` until the
+``task_finished`` frame arrives (or a configurable timeout fires).
+Screenshots streamed by the agent server are forwarded into the
+realtime LLM session via :class:`push_message v2 <push_message>` with
+``ai_behavior="read"`` so they enter the model's vision context. A
+background task periodically fires a "GAME_SYSTEM" nudge prompt with
+the latest log digest and screenshot cache so the model keeps playing
+autonomously when the user is silent.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from plugin.sdk.plugin import (
+    Err,
+    NekoPluginBase,
+    Ok,
+    SdkError,
+    lifecycle,
+    llm_tool,
+    neko_plugin,
+    plugin_entry,
+)
+
+from .service import GameAgentService
+
+# JSON Schema reused by the @llm_tool decorator below. Pulled into a
+# module-level constant so the plugin's introspection (status entry,
+# tests) can reference exactly what the LLM sees.
+MINECRAFT_TASK_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "task": {
+            "type": "string",
+            "description": "A concrete, directly executable Minecraft goal in English.",
+        },
+        "overwrite": {
+            "type": "boolean",
+            "description": (
+                "If True, interrupt the currently running task and start this one. "
+                "Default False — sending a new task while one is in flight returns "
+                "a 'busy' response without disturbing the in-flight task."
+            ),
+        },
+    },
+    "required": ["task"],
+}
+
+
+MINECRAFT_TASK_DESCRIPTION = (
+    "Send a task to the Minecraft game system. Use this when you describe a "
+    "concrete action you want to perform in Minecraft. The task should be a "
+    "single, clear, executable goal in English. Do not propose vague requests "
+    "such as: find a good place to build a house. Such vague tasks cannot be "
+    "executed. IMPORTANT: Do NOT set overwrite=True unless absolutely necessary."
+)
+
+
+@neko_plugin
+class GameAgentMinecraftPlugin(NekoPluginBase):
+    """Plugin facade — minimal: lifecycle wiring + tool surface.
+
+    Real logic lives in :class:`GameAgentService`; this class only
+    handles the SDK integration boilerplate.
+    """
+
+    def __init__(self, ctx):
+        super().__init__(ctx)
+        self.file_logger = self.enable_file_logging(log_level="INFO")
+        self.logger = self.file_logger
+        self._cfg: Dict[str, Any] = {}
+        self._service = GameAgentService(
+            logger=self.logger,
+            push_message_fn=self.push_message,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @lifecycle(id="startup")
+    async def startup(self, **_):
+        cfg = await self.config.dump(timeout=5.0)
+        cfg = cfg if isinstance(cfg, dict) else {}
+        self._cfg = (
+            cfg.get("game_agent", {})
+            if isinstance(cfg.get("game_agent"), dict)
+            else {}
+        )
+        self._service.configure(self._cfg)
+        try:
+            await self._service.start()
+        except Exception as exc:
+            # Plugin construction shouldn't be fatal if the agent server
+            # is offline — the WS client has its own reconnect loop, and
+            # we want the LLM tool registered regardless so the model
+            # can attempt a task and get a clean disconnected error.
+            self.logger.warning(
+                "[startup] service start raised; continuing — {}: {}",
+                type(exc).__name__, exc,
+            )
+        return Ok({"status": "ready", "result": self._service.get_status()})
+
+    @lifecycle(id="shutdown")
+    async def shutdown(self, **_):
+        await self._service.stop()
+        return Ok({"status": "shutdown"})
+
+    # ------------------------------------------------------------------
+    # LLM-callable tool
+    # ------------------------------------------------------------------
+
+    @llm_tool(
+        name="minecraft_task",
+        description=MINECRAFT_TASK_DESCRIPTION,
+        parameters=MINECRAFT_TASK_SCHEMA,
+        # Block the handler up to 30s (the full LLM tool ceiling) while
+        # the agent server runs the task. Service-internal timeout is a
+        # bit lower so we always return a clean ``status: timeout``
+        # before the SDK's outer wrapper times out.
+        timeout=30.0,
+    )
+    async def minecraft_task(self, *, task: str, overwrite: bool = False, **_):
+        return await self._service.execute_minecraft_task(
+            task=task, overwrite=overwrite,
+        )
+
+    # ------------------------------------------------------------------
+    # Diagnostic plugin entries (callable from the plugin UI / CLI)
+    # ------------------------------------------------------------------
+
+    @plugin_entry(
+        id="game_agent_status",
+        name="查询游戏代理状态",
+        description="查询 Minecraft Agent 连接状态、当前任务和缓存大小。",
+        llm_result_fields=["summary"],
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def game_agent_status(self, **_):
+        try:
+            status = self._service.get_status()
+            connected = "connected" if status.get("connected") else "disconnected"
+            pending = status.get("pending_task") or "(idle)"
+            status["summary"] = (
+                f"ws={status.get('ws_url')} | {connected} | task={pending}"
+            )
+            return Ok(status)
+        except Exception as exc:
+            return Err(f"{type(exc).__name__}: {exc}")
+
+    @plugin_entry(
+        id="game_agent_reload_config",
+        name="重载游戏代理配置",
+        description="不重启 WebSocket 连接的前提下重新读取 plugin.toml [game_agent] 配置。",
+        llm_result_fields=["summary"],
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def game_agent_reload_config(self, **_):
+        try:
+            cfg = await self.config.dump(timeout=5.0)
+            cfg = cfg if isinstance(cfg, dict) else {}
+            self._cfg = (
+                cfg.get("game_agent", {})
+                if isinstance(cfg.get("game_agent"), dict)
+                else {}
+            )
+            self._service.configure(self._cfg)
+            return Ok({"summary": "config reloaded", "result": self._service.get_status()})
+        except Exception as exc:
+            raise SdkError(f"reload failed: {type(exc).__name__}: {exc}")

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -127,11 +127,15 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
         name="minecraft_task",
         description=MINECRAFT_TASK_DESCRIPTION,
         parameters=MINECRAFT_TASK_SCHEMA,
-        # Block the handler up to 30s (the full LLM tool ceiling) while
-        # the agent server runs the task. Service-internal timeout is a
-        # bit lower so we always return a clean ``status: timeout``
-        # before the SDK's outer wrapper times out.
-        timeout=30.0,
+        # Set the SDK wrapper's timeout to the maximum the server
+        # accepts (300s, see ``ToolRegisterRequest.timeout_seconds``)
+        # so the *real* per-call cap is governed by the operator-
+        # configured ``[game_agent].task_timeout_seconds``. With a
+        # hardcoded 30s here, any user-set ``task_timeout_seconds`` >
+        # 30 would be silently truncated by the SDK's outer wrapper
+        # before the service could return its structured
+        # ``{status: "timeout"}`` shape.
+        timeout=300.0,
     )
     async def minecraft_task(self, *, task: str, overwrite: bool = False, **_):
         return await self._service.execute_minecraft_task(

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -164,7 +164,11 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
     @plugin_entry(
         id="game_agent_reload_config",
         name="重载游戏代理配置",
-        description="不重启 WebSocket 连接的前提下重新读取 plugin.toml [game_agent] 配置。",
+        description=(
+            "重新读取 plugin.toml [game_agent] 配置；纯数据项 (timeouts、"
+            "intervals、screenshot 开关) 直接生效，ws_url 或重连间隔变更则会"
+            "触发 WebSocket 客户端 stop+start 切换到新地址。"
+        ),
         llm_result_fields=["summary"],
         input_schema={"type": "object", "properties": {}},
     )
@@ -177,7 +181,16 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
                 if isinstance(cfg.get("game_agent"), dict)
                 else {}
             )
-            self._service.configure(self._cfg)
-            return Ok({"summary": "config reloaded", "result": self._service.get_status()})
+            transport_restarted = await self._service.reload_config_live(self._cfg)
+            summary = (
+                "config reloaded with transport restart"
+                if transport_restarted
+                else "config reloaded (live)"
+            )
+            return Ok({
+                "summary": summary,
+                "transport_restarted": transport_restarted,
+                "result": self._service.get_status(),
+            })
         except Exception as exc:
             raise SdkError(f"reload failed: {type(exc).__name__}: {exc}")

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 import websockets
 from websockets import exceptions as ws_exceptions
@@ -136,16 +136,25 @@ class GameAgentClient:
     # Outbound
     # ------------------------------------------------------------------
 
-    async def send_task(self, task: str) -> bool:
+    async def send_task(self, task: str, *, task_id: Optional[str] = None) -> bool:
         """Push a task command. Returns ``True`` on successful send,
-        ``False`` if the socket isn't connected (caller decides whether
-        to retry, queue, or surface as a tool error)."""
+        ``False`` if the socket isn't connected.
+
+        ``task_id`` is an *optional* per-task identifier the agent can
+        echo back on its ``task_finished`` frame to allow explicit
+        correlation under concurrent agent execution. Agents that
+        process tasks sequentially can ignore it; the plugin falls
+        back to FIFO ordering when the field is absent.
+        """
         ws = self._ws
         if ws is None or not self.is_connected:
             self._log_warning("not connected; dropping task: {}", task[:80])
             return False
+        payload: Dict[str, Any] = {"type": "task", "task": task}
+        if task_id is not None:
+            payload["task_id"] = task_id
         try:
-            await ws.send(json.dumps({"type": "task", "task": task}))
+            await ws.send(json.dumps(payload))
             self._log_info("sent task: {}", task[:120])
             return True
         except Exception as exc:

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -88,6 +88,22 @@ class GameAgentClient:
                 self.is_connected = True
                 self._log_info("connected to {}", self.uri)
                 await self._listen()
+                # ``_listen`` swallows ConnectionClosed internally and
+                # returns normally — without an explicit sleep here the
+                # outer loop reconnects immediately, which against an
+                # agent that's repeatedly dropping the socket becomes a
+                # tight loop. Mirror the exception-path reconnect
+                # interval for the clean-close path too.
+                self.is_connected = False
+                if self._running:
+                    self._log_info(
+                        "listen exited cleanly, reconnecting in {:.1f}s",
+                        self.reconnect_interval,
+                    )
+                    try:
+                        await asyncio.sleep(self.reconnect_interval)
+                    except asyncio.CancelledError:
+                        break
             except asyncio.CancelledError:
                 break
             except Exception as exc:

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -1,0 +1,232 @@
+"""WebSocket client for the local Minecraft agent server.
+
+The agent server speaks a small JSON protocol:
+
+* **client → server** ``{"type": "task", "task": "<goal>"}``
+* **server → client** ``{"type": "log",        "text": "..."}``
+* **server → client** ``{"type": "screenshot", "image": "<base64>", "encoding": "png"|"jpeg"}``
+* **server → client** ``{"type": "task_finished", "status": "ok", "text": "..."}``
+* **server → client** ``{"type": "agent_status", ...}``  # informational, ignored by callbacks
+
+Why a long-lived WebSocket instead of polling HTTP: screenshot frames can
+arrive at >1Hz, and the handshake cost of HTTP per frame would dominate
+latency. The plugin keeps one persistent connection and auto-reconnects
+when the agent restarts.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Awaitable, Callable, Optional
+
+import websockets
+from websockets import exceptions as ws_exceptions
+
+# Callback signatures.  All callbacks are async — the plugin's service
+# layer dispatches IPC notifications inside them.
+OnLog = Callable[[str], Awaitable[None]]
+OnScreenshot = Callable[[str, str], Awaitable[None]]  # (base64_payload, encoding_hint)
+OnTaskFinished = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+class GameAgentClient:
+    """Persistent WebSocket bridge to the agent server.
+
+    Lifecycle: ``await start()`` runs forever (auto-reconnect loop) until
+    ``await stop()`` is called. Outbound traffic uses ``await
+    send_task(text)`` which returns ``False`` if the socket is currently
+    not connected (caller decides how to surface that to the LLM).
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        *,
+        on_log: Optional[OnLog] = None,
+        on_screenshot: Optional[OnScreenshot] = None,
+        on_task_finished: Optional[OnTaskFinished] = None,
+        reconnect_interval: float = 5.0,
+        logger: Any = None,
+    ):
+        self.uri = uri
+        self.on_log = on_log
+        self.on_screenshot = on_screenshot
+        self.on_task_finished = on_task_finished
+        self.reconnect_interval = reconnect_interval
+        # Plugin SDK injects a per-plugin loguru logger; fall back to a
+        # noop when running outside that environment (unit tests).
+        self.logger = logger
+
+        self._ws: Optional[Any] = None
+        self._running = False
+        self.is_connected: bool = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Block until ``stop()`` — reconnects on transient failures.
+
+        Pattern: outer loop owns the reconnect interval; inner ``_listen``
+        loops on incoming frames until the socket closes. Any exception
+        below the cancellation level is logged and we sleep before
+        retrying so we don't busy-loop against a dead server.
+        """
+        self._running = True
+        while self._running:
+            try:
+                self._ws = await websockets.connect(
+                    self.uri,
+                    ping_interval=20,
+                    ping_timeout=20,
+                    close_timeout=3,
+                    # Screenshot frames can be hundreds of KB once
+                    # base64-encoded; disable the default 1 MiB cap.
+                    max_size=None,
+                )
+                self.is_connected = True
+                self._log_info("connected to {}", self.uri)
+                await self._listen()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self.is_connected = False
+                if self._running:
+                    self._log_warning(
+                        "connection failed ({}: {}), retrying in {:.1f}s",
+                        type(exc).__name__, exc, self.reconnect_interval,
+                    )
+                    try:
+                        await asyncio.sleep(self.reconnect_interval)
+                    except asyncio.CancelledError:
+                        break
+
+    async def stop(self) -> None:
+        self._running = False
+        self.is_connected = False
+        ws = self._ws
+        if ws is not None:
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        self._log_info("stopped")
+
+    # ------------------------------------------------------------------
+    # Outbound
+    # ------------------------------------------------------------------
+
+    async def send_task(self, task: str) -> bool:
+        """Push a task command. Returns ``True`` on successful send,
+        ``False`` if the socket isn't connected (caller decides whether
+        to retry, queue, or surface as a tool error)."""
+        ws = self._ws
+        if ws is None or not self.is_connected:
+            self._log_warning("not connected; dropping task: {}", task[:80])
+            return False
+        try:
+            await ws.send(json.dumps({"type": "task", "task": task}))
+            self._log_info("sent task: {}", task[:120])
+            return True
+        except Exception as exc:
+            self._log_error("failed to send task: {}: {}", type(exc).__name__, exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Inbound
+    # ------------------------------------------------------------------
+
+    async def _listen(self) -> None:
+        ws = self._ws
+        if ws is None:
+            return
+        try:
+            async for raw in ws:
+                try:
+                    data: dict = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    # Agent server should never emit non-JSON frames;
+                    # drop and keep listening rather than tearing down
+                    # the connection over malformed input.
+                    continue
+
+                msg_type = data.get("type", "")
+                try:
+                    if msg_type == "log" and self.on_log is not None:
+                        text = str(
+                            data.get("text")
+                            or data.get("data")
+                            or data.get("message")
+                            or ""
+                        )
+                        await self.on_log(text)
+
+                    elif msg_type == "screenshot" and self.on_screenshot is not None:
+                        img_payload = data.get("image") or data.get("data") or ""
+                        encoding = str(data.get("encoding") or "").lower()
+                        if isinstance(img_payload, str) and img_payload:
+                            await self.on_screenshot(img_payload, encoding)
+
+                    elif msg_type == "task_finished" and self.on_task_finished is not None:
+                        await self.on_task_finished(data)
+
+                    elif msg_type == "agent_status":
+                        # Informational status — the original integration
+                        # logged this at debug. Keep parity.
+                        self._log_debug("agent_status: {}", data)
+
+                except Exception as cb_err:
+                    # A misbehaving callback shouldn't kill the whole
+                    # WebSocket loop — log and continue.
+                    self._log_error(
+                        "callback error for type={}: {}: {}",
+                        msg_type, type(cb_err).__name__, cb_err,
+                    )
+
+        except ws_exceptions.ConnectionClosed:
+            self.is_connected = False
+            self._log_info("connection closed")
+        except Exception as exc:
+            self.is_connected = False
+            self._log_error("listen error: {}: {}", type(exc).__name__, exc)
+
+    # ------------------------------------------------------------------
+    # Logging helpers — silently no-op when no logger is supplied
+    # ------------------------------------------------------------------
+
+    def _log_info(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.info("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+    def _log_warning(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.warning("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+    def _log_error(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.error("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+    def _log_debug(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.debug("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+
+__all__ = [
+    "GameAgentClient",
+    "OnLog",
+    "OnScreenshot",
+    "OnTaskFinished",
+]

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -163,11 +163,19 @@ class GameAgentClient:
         try:
             async for raw in ws:
                 try:
-                    data: dict = json.loads(raw)
+                    data = json.loads(raw)
                 except (json.JSONDecodeError, TypeError):
                     # Agent server should never emit non-JSON frames;
                     # drop and keep listening rather than tearing down
                     # the connection over malformed input.
+                    continue
+                if not isinstance(data, dict):
+                    # JSON parsed successfully but the top-level value
+                    # isn't an object (e.g. ``null``, an array, a bare
+                    # string). The protocol requires objects with a
+                    # ``type`` field; calling ``.get`` on a non-dict
+                    # would raise AttributeError and crash the
+                    # listener.
                     continue
 
                 msg_type = data.get("type", "")

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -110,6 +110,9 @@ class GameAgentClient:
             try:
                 await ws.close()
             except Exception:
+                # Best-effort close on shutdown — if the socket is
+                # already torn down (peer hung up, OS reaped fd, ...)
+                # there's nothing for us to recover; we're stopping.
                 pass
         self._log_info("stopped")
 
@@ -192,7 +195,11 @@ class GameAgentClient:
             self._log_error("listen error: {}: {}", type(exc).__name__, exc)
 
     # ------------------------------------------------------------------
-    # Logging helpers — silently no-op when no logger is supplied
+    # Logging helpers — silently no-op when no logger is supplied.
+    # Each helper guards its emit with try/except because the plugin
+    # SDK's loguru-based logger can transiently fail (e.g. file rotation
+    # mid-write) and we never want a log line to surface as a real
+    # error in callers that just wanted to record diagnostics.
     # ------------------------------------------------------------------
 
     def _log_info(self, msg: str, *args: Any) -> None:
@@ -200,28 +207,28 @@ class GameAgentClient:
             try:
                 self.logger.info("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
     def _log_warning(self, msg: str, *args: Any) -> None:
         if self.logger is not None:
             try:
                 self.logger.warning("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
     def _log_error(self, msg: str, *args: Any) -> None:
         if self.logger is not None:
             try:
                 self.logger.error("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
     def _log_debug(self, msg: str, *args: Any) -> None:
         if self.logger is not None:
             try:
                 self.logger.debug("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
 
 __all__ = [

--- a/plugin/plugins/game_agent_minecraft/plugin.toml
+++ b/plugin/plugins/game_agent_minecraft/plugin.toml
@@ -1,0 +1,59 @@
+[plugin]
+id = "game_agent_minecraft"
+name = "Minecraft 游戏代理"
+description = "桥接本地 Minecraft Agent (WebSocket)，让 AI 通过 minecraft_task 工具下达指令并实时观看游戏画面进行解说。"
+short_description = "Minecraft autonomous gameplay with voice commentary."
+keywords = ["minecraft", "game-agent", "autonomous"]
+version = "0.1.0"
+entry = "plugin.plugins.game_agent_minecraft:GameAgentMinecraftPlugin"
+
+[plugin.author]
+name = "N.E.K.O Team"
+
+[plugin.sdk]
+recommended = ">=0.1.0,<0.2.0"
+supported = ">=0.1.0,<0.3.0"
+
+[plugin_runtime]
+enabled = true
+auto_start = false
+
+[plugin.store]
+enabled = true
+
+[game_agent]
+# WebSocket URI of the local Minecraft agent server. Must speak the JSON
+# protocol documented in this plugin's README (task / log / screenshot /
+# task_finished frames).
+ws_url = "ws://localhost:48909"
+
+# Reconnect interval if the WebSocket drops.
+reconnect_interval_seconds = 5.0
+
+# Per-call upper bound on minecraft_task. The handler awaits the agent's
+# task_finished frame; if it doesn't arrive within this window, the LLM
+# sees a {status: "timeout"} result and is free to issue a new task.
+# Capped at 300 server-side; 25s leaves ~5s of buffer below the 30-second
+# default LLM tool ceiling.
+task_timeout_seconds = 25.0
+
+# How often the autonomous loop nudges the LLM with the latest game state
+# when there's no pending task. The LLM sees a "GAME_SYSTEM" prompt with
+# accumulated logs and is asked to either issue the next minecraft_task or
+# provide voice commentary.
+system_prompt_interval_seconds = 5.0
+
+# Skip a system-prompt nudge if a tool call is already pending — the LLM is
+# busy and an extra prompt would just queue up.
+skip_system_prompt_if_busy = true
+
+# Forward screenshots received from the agent server into the realtime LLM
+# session via push_message v2 (visibility=[], ai_behavior="read"). When
+# false, screenshots are still cached locally for the periodic system-prompt
+# burst but not streamed in real time.
+stream_screenshots_to_llm = true
+
+# Cap on the in-memory screenshot ring buffer (most recent N frames are
+# kept; older ones drop). Used by the system-prompt burst to send a brief
+# visual summary alongside the textual nudge.
+screenshot_cache_size = 3

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -524,7 +524,6 @@ class GameAgentService:
         self._log_info("task_finished: status={}, text={}", status, text[:80])
         if text:
             self._log_cache.append(text)
-        self._task_finished = True
 
         async with self._pending_lock:
             # The agent server's protocol has no task ID, so a delayed
@@ -540,17 +539,26 @@ class GameAgentService:
                     "dropped stale task_finished (status={}, drops_remaining={})",
                     status, self._stale_task_finishes_to_drop,
                 )
+                # Don't touch ``_task_finished`` here — flipping it
+                # would leak the *old* task's completion state into
+                # the *new* (still in-flight) task, breaking the
+                # autonomous-loop's busy gate and the system prompt's
+                # "正在进行中 vs 已完成" branch.
                 return
             if self._pending is None:
                 # Stray task_finished (e.g. from agent restart) — nothing
-                # to wake. Just keep the log line for the next system
-                # prompt.
+                # to wake. Update the flag anyway so the autonomous
+                # loop knows the agent is idle and can resume nudging.
+                self._task_finished = True
                 return
             self._pending.result = {
                 "status": status,
                 "query": self._pending.task_text,
             }
             self._pending.event.set()
+            # Now safe to flip — this frame is being applied to the
+            # current pending task.
+            self._task_finished = True
             # Don't None-out here; ``execute_minecraft_task`` does that
             # after it reads ``result`` so we don't race the read.
 

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -530,8 +530,6 @@ class GameAgentService:
         )
         status = str(data.get("status") or "ok")
         self._log_info("task_finished: status={}, text={}", status, text[:80])
-        if text:
-            self._log_cache.append(text)
 
         async with self._pending_lock:
             # The agent server's protocol has no task ID, so a delayed
@@ -540,7 +538,10 @@ class GameAgentService:
             # fresh one for the current task. We assume the agent
             # emits frames in completion order and drain them FIFO:
             # for every task we abandoned without an ack, swallow one
-            # incoming frame.
+            # incoming frame. The stale frame's *text* must NOT enter
+            # ``_log_cache`` either — otherwise the next system prompt
+            # would surface "old task done" while a new task is still
+            # running, lying about both branches of the prompt.
             if self._stale_task_finishes_to_drop > 0:
                 self._stale_task_finishes_to_drop -= 1
                 self._log_info(
@@ -553,6 +554,10 @@ class GameAgentService:
                 # autonomous-loop's busy gate and the system prompt's
                 # "正在进行中 vs 已完成" branch.
                 return
+            # From here on the frame is being accepted; it's safe to
+            # commit the text + flag updates.
+            if text:
+                self._log_cache.append(text)
             if self._pending is None:
                 # Stray task_finished (e.g. from agent restart) — nothing
                 # to wake. Update the flag anyway so the autonomous
@@ -564,8 +569,6 @@ class GameAgentService:
                 "query": self._pending.task_text,
             }
             self._pending.event.set()
-            # Now safe to flip — this frame is being applied to the
-            # current pending task.
             self._task_finished = True
             # Don't None-out here; ``execute_minecraft_task`` does that
             # after it reads ``result`` so we don't race the read.

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -662,14 +662,25 @@ class GameAgentService:
                 # loop knows the agent is idle and can resume nudging.
                 self._task_finished = True
                 return
-            self._pending.result = {
+            # Snapshot the pending ref *and* clear the shared slot
+            # before calling ``event.set()`` — both still under the
+            # lock. If we leave ``self._pending`` pointing at the
+            # finished task, a racing ``stop()``/overwrite that
+            # acquires the lock between this block exiting and the
+            # waiter running could see ``self._pending is not None``
+            # and overwrite the result we just wrote (the waiter and
+            # ``self._pending`` reference the *same* PendingTask
+            # object, so a mutation here corrupts the waiter's read).
+            # The waiter holds its own ``my_pending`` local ref, so
+            # clearing ``self._pending`` here is safe.
+            pending = self._pending
+            self._pending = None
+            pending.result = {
                 "status": status,
-                "query": self._pending.task_text,
+                "query": pending.task_text,
             }
-            self._pending.event.set()
+            pending.event.set()
             self._task_finished = True
-            # Don't None-out here; ``execute_minecraft_task`` does that
-            # after it reads ``result`` so we don't race the read.
 
     # ------------------------------------------------------------------
     # Autonomous system-prompt loop

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -387,7 +387,22 @@ class GameAgentService:
             self._pending = my_pending
             self._task_finished = False
 
-        sent = await self._client.send_task(task)
+        try:
+            sent = await self._client.send_task(task)
+        except asyncio.CancelledError:
+            # Cancellation can hit during the dispatch await too (the
+            # outer SDK timeout fires, plugin shutdown sweeps tasks).
+            # The ``event.wait()`` cancellation handler below covers
+            # the post-dispatch window, but without this branch a
+            # cancel landing in the dispatch window leaves
+            # ``self._pending`` dangling and every subsequent call
+            # returns "busy" against an event nothing will ever set.
+            async with self._pending_lock:
+                if self._pending is my_pending:
+                    self._pending = None
+                    self._task_finished = True
+                    self._stale_task_finishes_to_drop += 1
+            raise
         # The ``send_task`` await is a suspension point — another
         # coroutine (overwrite / stop / a stale task_finished frame
         # filtered to fall through to ``_pending``) may have already

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -314,7 +314,7 @@ class GameAgentService:
     # ------------------------------------------------------------------
 
     async def execute_minecraft_task(
-        self, *, task: str, overwrite: bool = False
+        self, *, task: str, overwrite: Any = False
     ) -> Dict[str, Any]:
         """Implementation of the ``minecraft_task`` LLM tool.
 
@@ -343,14 +343,21 @@ class GameAgentService:
                 "error": "NOT_STARTED",
             }
 
+        # The schema declares ``overwrite: boolean`` but the LLM is
+        # not reliably constrained — it may emit a string ``"true"``,
+        # an int ``1``, or some other truthy value. Strict ``is True``
+        # only accepts the canonical Python bool so the destructive
+        # interrupt path doesn't fire by accident on an off-spec arg.
+        overwrite_flag = overwrite is True
+
         async with self._pending_lock:
             if self._pending is not None:
-                if not overwrite:
+                if not overwrite_flag:
                     # Refuse without disturbing the in-flight task.
                     return {
                         "result": "busy",
                         "currently_executing": self._pending.task_text,
-                        "hint": "Set overwrite=True to interrupt the current task.",
+                        "hint": "Set overwrite=true (boolean, not string) to interrupt the current task.",
                     }
                 # Wake the old handler with an "interrupted" verdict
                 # before claiming the slot for the new task. The agent

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -381,6 +381,22 @@ class GameAgentService:
             self._task_finished = False
 
         sent = await self._client.send_task(task)
+        # The ``send_task`` await is a suspension point — another
+        # coroutine (overwrite / stop / a stale task_finished frame
+        # filtered to fall through to ``_pending``) may have already
+        # written a verdict into ``my_pending.result`` and set the
+        # event during the suspend window. Honor that verdict
+        # *before* deciding to return AGENT_DISCONNECTED, otherwise
+        # we'd contradict whatever the system already recorded for
+        # this slot (e.g. surfacing AGENT_DISCONNECTED to the LLM
+        # while the rest of the system thinks the task was
+        # interrupted).
+        if my_pending.event.is_set():
+            async with self._pending_lock:
+                if self._pending is my_pending:
+                    self._pending = None
+            return my_pending.result or {"status": "ok", "query": task}
+
         if not sent:
             # Roll back the pending slot — the agent never accepted the
             # task, so we shouldn't keep reporting "busy" to subsequent

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -110,7 +110,13 @@ class GameAgentService:
         # task would be (incorrectly) attributed to whatever task is
         # currently pending. Drained FIFO in ``_on_task_finished``.
         self._stale_task_finishes_to_drop: int = 0
-        self._log_cache: list[str] = []
+        # Bounded ring buffer of agent log lines. Without a cap this
+        # would grow without bound when the autonomous loop is gated
+        # off (e.g. ``skip_system_prompt_if_busy=True`` and a long
+        # task is in flight); the agent emits log lines continuously
+        # and we'd never drain. ``deque(maxlen=...)`` drops oldest on
+        # overflow which is fine — the LLM only needs recent context.
+        self._log_cache: collections.deque[str] = collections.deque(maxlen=200)
         # Bounded ring buffer of (image_bytes, mime). We carry the mime
         # alongside the bytes because the JPEG→PNG conversion in
         # ``_on_screenshot`` can fall through to "ship as-is" on Pillow

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -569,12 +569,30 @@ class GameAgentService:
             # confirms what's already true (a task is in flight).
             self._task_finished = False
         elif text_strip == "Connection lost and re-established.":
-            if self._pending is None:
-                self._task_finished = True
-                # Connection bounce wipes the agent's task queue —
-                # any abandoned-task frames we were waiting to drain
-                # will never arrive. Reset the debt to avoid
-                # swallowing the next session's legitimate frames.
+            # Connection bounce wipes the agent's task queue. Two
+            # cases to clean up:
+            # 1. No task pending → just reset debt (any unpaid drops
+            #    from before the bounce will never arrive).
+            # 2. A task IS pending → its ``task_finished`` will
+            #    never come either; wake the handler with an
+            #    "interrupted" verdict so it doesn't sit on
+            #    ``event.wait`` until ``task_timeout_seconds``
+            #    expires. Clear the slot so a follow-up minecraft_task
+            #    isn't refused with "busy".
+            async with self._pending_lock:
+                pending = self._pending
+                if pending is None:
+                    self._task_finished = True
+                else:
+                    pending.result = {
+                        "status": "interrupted",
+                        "query": pending.task_text,
+                        "reason": "Agent connection bounced — task lost.",
+                    }
+                    self._pending = None
+                    pending.event.set()
+                    self._task_finished = True
+                # Drain debt unconditionally — agent state is gone.
                 self._stale_task_finishes_to_drop = 0
 
     async def _on_screenshot(self, payload: str, encoding: str) -> None:

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -193,7 +193,14 @@ class GameAgentService:
         if isinstance(url, str) and url:
             self._ws_url = url
         self._reconnect_interval = max(0.5, _f("reconnect_interval_seconds", 5.0))
-        self._task_timeout = max(1.0, _f("task_timeout_seconds", 25.0))
+        # Cap at 295s — 5s below the SDK wrapper's 300s ceiling
+        # (see ``@llm_tool(timeout=300.0)`` in ``__init__.py``). Without
+        # this clamp, an operator setting e.g. ``task_timeout_seconds = 600``
+        # would have the SDK wrapper time out at 300s and cancel the
+        # handler before the service could return its structured
+        # ``{status: "timeout"}`` shape — the LLM would see the cancel
+        # error path instead of the clean timeout result.
+        self._task_timeout = max(1.0, min(295.0, _f("task_timeout_seconds", 25.0)))
         self._system_prompt_interval = max(1.0, _f("system_prompt_interval_seconds", 5.0))
         self._skip_when_busy = _b("skip_system_prompt_if_busy", True)
         self._stream_screenshots = _b("stream_screenshots_to_llm", True)

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -36,6 +36,7 @@ import base64
 import collections
 import re
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional
 
@@ -57,6 +58,12 @@ class PendingTask:
     task_text: str
     event: asyncio.Event
     start_time: float
+    # Per-task ID we generate locally and forward to the agent on the
+    # outbound ``task`` frame. If the agent echoes it on
+    # ``task_finished``, we use it for explicit correlation; if not
+    # (sequential agents with no concurrency) we fall back to FIFO
+    # ordering on the stale-frame drop counter. See README "已知限制".
+    task_id: str = ""
     # Filled in by the WebSocket callback (or by overwrite/timeout
     # paths) right before ``event`` is set.
     result: Dict[str, Any] = field(default_factory=dict)
@@ -416,13 +423,16 @@ class GameAgentService:
             # whoever set the event also wrote into the dataclass we
             # hold here.
             my_pending = PendingTask(
-                task_text=task, event=asyncio.Event(), start_time=time.time(),
+                task_text=task,
+                event=asyncio.Event(),
+                start_time=time.time(),
+                task_id=uuid.uuid4().hex,
             )
             self._pending = my_pending
             self._task_finished = False
 
         try:
-            sent = await self._client.send_task(task)
+            sent = await self._client.send_task(task, task_id=my_pending.task_id)
         except asyncio.CancelledError:
             # Cancellation can hit during the dispatch await too (the
             # outer SDK timeout fires, plugin shutdown sweeps tasks).
@@ -682,6 +692,16 @@ class GameAgentService:
             data.get("text") or data.get("data") or data.get("message") or ""
         )
         status = str(data.get("status") or "ok")
+        # Optional explicit correlation: agents that opt in echo back
+        # the ``task_id`` we sent on the matching ``task`` frame.
+        # When present we trust it absolutely and skip the FIFO
+        # heuristic entirely (an out-of-order completion is
+        # disambiguated by ID, not by arrival order). Agents that
+        # don't emit it fall through to the FIFO drop counter as
+        # before.
+        echoed_task_id = data.get("task_id")
+        if not isinstance(echoed_task_id, str) or not echoed_task_id:
+            echoed_task_id = None
         self._log_info("task_finished: status={}, text={}", status, text[:80])
 
         async with self._pending_lock:
@@ -693,34 +713,47 @@ class GameAgentService:
             # for every task we abandoned without an ack, swallow one
             # incoming frame.
             #
-            # KNOWN LIMITATION: this FIFO assumption is exactly that —
-            # an assumption. If the agent server processes tasks with
-            # internal concurrency such that an *overwritten* task A
-            # finishes *after* the replacement task B (i.e. frames
-            # arrive in B-then-A order), this filter swallows B's
-            # real completion and later accepts A's stale frame as if
-            # it were B's. The current ``minecraft_task`` call would
-            # then hang until ``task_timeout_seconds`` while a wrong
-            # result eventually surfaces.
-            #
-            # Properly fixing this requires the agent protocol to
-            # carry a task ID on both ``task`` and ``task_finished``
-            # frames so we can correlate explicitly. That's a
-            # protocol-level change for upstream agents and out of
-            # scope here. In practice agents we ship against
-            # (mineflayer-based bots) process tasks sequentially —
-            # overwrite stops the current task before starting the
-            # next — so out-of-order completions don't occur. If you
-            # write an agent that does have internal concurrency,
-            # add task IDs to the protocol and we'll wire correlation
-            # in. The stale frame's *text* must NOT enter
+            # KNOWN LIMITATION (FIFO mode only): this FIFO assumption
+            # is exactly that — an assumption. Agents that opt into
+            # task_id correlation (the branch above) bypass it
+            # entirely. For agents that don't echo task_id, an
+            # internal-concurrency case where an *overwritten* task
+            # A finishes *after* the replacement task B (frames
+            # arrive B-then-A) breaks: this filter swallows B's
+            # real completion and later accepts A's stale frame as
+            # if it were B's; the current ``minecraft_task`` call
+            # hangs until ``task_timeout_seconds`` and a wrong
+            # result eventually surfaces. The fix is for the agent
+            # to echo task_id on the matching ``task_finished``
+            # frame — see README "已知限制" for details. The stale frame's *text* must NOT enter
             # ``_log_cache`` either — otherwise the next system prompt
             # would surface "old task done" while a new task is still
             # running, lying about both branches of the prompt.
-            if self._stale_task_finishes_to_drop > 0:
+            # Explicit correlation path (agent opted into task_id
+            # echoing): trust the ID. If it matches the current
+            # pending task, accept the frame normally (skip the
+            # stale-drop heuristic — even if drop counter is non-zero,
+            # this frame is unambiguously for the active task). If it
+            # doesn't match, it's stale by definition; drop it without
+            # touching the counter (counter is only for FIFO-mode
+            # agents).
+            if echoed_task_id is not None:
+                if self._pending is not None and self._pending.task_id == echoed_task_id:
+                    pass  # fall through to acceptance below
+                else:
+                    self._log_info(
+                        "dropped stale task_finished by id mismatch "
+                        "(echoed={}, pending={})",
+                        echoed_task_id,
+                        self._pending.task_id if self._pending else None,
+                    )
+                    if self._pending is None:
+                        self._task_finished = True
+                    return
+            elif self._stale_task_finishes_to_drop > 0:
                 self._stale_task_finishes_to_drop -= 1
                 self._log_info(
-                    "dropped stale task_finished (status={}, drops_remaining={})",
+                    "dropped stale task_finished (FIFO mode, status={}, drops_remaining={})",
                     status, self._stale_task_finishes_to_drop,
                 )
                 # If no task is currently pending, the agent has

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -601,11 +601,16 @@ class GameAgentService:
                     "dropped stale task_finished (status={}, drops_remaining={})",
                     status, self._stale_task_finishes_to_drop,
                 )
-                # Don't touch ``_task_finished`` here — flipping it
-                # would leak the *old* task's completion state into
-                # the *new* (still in-flight) task, breaking the
-                # autonomous-loop's busy gate and the system prompt's
-                # "正在进行中 vs 已完成" branch.
+                # If no task is currently pending, the agent has
+                # genuinely returned to idle (we just dropped what
+                # would have been the only signal). Flipping
+                # ``_task_finished`` here keeps the autonomous loop's
+                # busy gate accurate so it can resume nudging.
+                # When a task IS pending, leave the flag alone —
+                # flipping it would leak the *old* task's completion
+                # state into the *new* (still in-flight) task.
+                if self._pending is None:
+                    self._task_finished = True
                 return
             # From here on the frame is being accepted; it's safe to
             # commit the text + flag updates.

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -60,6 +60,14 @@ class PendingTask:
     # Filled in by the WebSocket callback (or by overwrite/timeout
     # paths) right before ``event`` is set.
     result: Dict[str, Any] = field(default_factory=dict)
+    # True once the task text was actually sent to the agent server
+    # (``client.send_task`` returned True). Drop-counter bumps for
+    # abandonment paths (timeout / overwrite / cancel / stop) must
+    # gate on this flag — if we never dispatched, the agent will
+    # never emit a stale ``task_finished`` for this task and bumping
+    # the counter would silently swallow the *next* legitimate
+    # frame.
+    dispatched: bool = False
 
 
 class GameAgentService:
@@ -257,22 +265,23 @@ class GameAgentService:
         # Drain pending handler first so it returns before we kill the
         # transport that would feed its event.
         async with self._pending_lock:
-            if self._pending is not None:
-                self._pending.result = {
+            pending = self._pending
+            if pending is not None:
+                pending.result = {
                     "status": "interrupted",
-                    "query": self._pending.task_text,
+                    "query": pending.task_text,
                     "reason": "Game agent plugin shutting down.",
                 }
-                self._pending.event.set()
+                pending.event.set()
                 self._pending = None
-                # We abandoned this task without an ack — bump the
-                # drop counter so a delayed ``task_finished`` (which
-                # might still hit us if ``stop()`` is part of a
-                # ``reload_config_live`` cycle and the same agent
-                # buffers and redelivers the frame after reconnect)
-                # doesn't bind to whatever new task the LLM picks
-                # next.
-                self._stale_task_finishes_to_drop += 1
+                # Bump only if the task was actually dispatched —
+                # otherwise the agent never received it and won't
+                # generate a stale frame. (Matters most for the
+                # ``reload_config_live`` stop+start cycle when the
+                # same agent might redeliver buffered frames after
+                # reconnect.)
+                if pending.dispatched:
+                    self._stale_task_finishes_to_drop += 1
             # Note: do NOT zero the counter — preserve any existing
             # debt from prior timeouts/overwrites that may still have
             # frames in flight from before this stop().
@@ -366,14 +375,21 @@ class GameAgentService:
                 self._log_warning(
                     "overwriting task: {} -> {}", self._pending.task_text, task
                 )
-                self._pending.result = {
+                old_pending = self._pending
+                old_pending.result = {
                     "status": "interrupted",
-                    "query": self._pending.task_text,
+                    "query": old_pending.task_text,
                     "reason": "Overwritten by a new task.",
                 }
-                self._pending.event.set()
+                old_pending.event.set()
                 self._pending = None
-                self._stale_task_finishes_to_drop += 1
+                # Only count a stale-frame debt if the old task was
+                # actually dispatched to the agent — if its handler
+                # hadn't reached past ``send_task`` yet, the agent
+                # never received it and won't emit a stale frame to
+                # consume.
+                if old_pending.dispatched:
+                    self._stale_task_finishes_to_drop += 1
 
             # The handler keeps a *local* reference to its own
             # PendingTask; ``self._pending`` may be reassigned (or
@@ -397,12 +413,19 @@ class GameAgentService:
             # cancel landing in the dispatch window leaves
             # ``self._pending`` dangling and every subsequent call
             # returns "busy" against an event nothing will ever set.
+            # Don't bump the drop counter — ``send_task`` was
+            # cancelled before completing, so the task was never
+            # delivered and won't generate a stale frame.
             async with self._pending_lock:
                 if self._pending is my_pending:
                     self._pending = None
                     self._task_finished = True
-                    self._stale_task_finishes_to_drop += 1
             raise
+        if sent:
+            # Mark as dispatched so abandonment paths (overwrite /
+            # timeout / cancel / stop) know whether to expect a
+            # stale ``task_finished`` frame for this task.
+            my_pending.dispatched = True
         # The ``send_task`` await is a suspension point — another
         # coroutine (overwrite / stop / a stale task_finished frame
         # filtered to fall through to ``_pending``) may have already
@@ -446,7 +469,8 @@ class GameAgentService:
             async with self._pending_lock:
                 if self._pending is my_pending:
                     self._pending = None
-                    self._stale_task_finishes_to_drop += 1
+                    if my_pending.dispatched:
+                        self._stale_task_finishes_to_drop += 1
             self._log_info("task timed out: {}", task[:80])
             return {
                 "status": "timeout",
@@ -464,7 +488,8 @@ class GameAgentService:
             async with self._pending_lock:
                 if self._pending is my_pending:
                     self._pending = None
-                    self._stale_task_finishes_to_drop += 1
+                    if my_pending.dispatched:
+                        self._stale_task_finishes_to_drop += 1
             raise
 
         # Read the verdict the callback (or overwrite/shutdown path)

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -468,25 +468,48 @@ class GameAgentService:
         self._log_cache.append(text_strip)
 
         # The original integration sniffed log strings to track agent
-        # state because the protocol didn't have explicit "task running"
-        # frames. Keep the same heuristics so existing agent servers
-        # work without protocol changes.
+        # state because some agent server implementations emit logs
+        # before / instead of explicit ``task_finished`` frames. Keep
+        # the heuristic so existing agents work, but gate the
+        # "True" transitions on ``_pending is None`` — without that
+        # gate, an old (timed-out / overwritten / cancelled) task's
+        # late "task run ended" log would prematurely flip the busy
+        # gate while the *new* in-flight task is still running. When
+        # a task IS pending, we defer to the explicit ``task_finished``
+        # frame which already does proper stale-frame filtering.
         if "task run ended" in text_strip:
-            self._task_finished = True
+            if self._pending is None:
+                self._task_finished = True
         elif "action selection" in text_strip:
+            # Setting False unconditionally is safe — at worst it
+            # confirms what's already true (a task is in flight).
             self._task_finished = False
         elif text_strip == "Connection lost and re-established.":
-            self._task_finished = True
+            if self._pending is None:
+                self._task_finished = True
 
     async def _on_screenshot(self, payload: str, encoding: str) -> None:
         """Decode a base64 screenshot, convert JPEG→PNG when needed, and
         either stream it into the realtime LLM session immediately or
         cache it for the next autonomous-prompt burst."""
+        # Some agents send screenshots as ``data:`` URIs that already
+        # carry the mime in the scheme; pull it out before stripping
+        # so we don't mis-tag JPEG bytes as PNG when the explicit
+        # ``encoding`` field is empty.
+        embedded_mime: Optional[str] = None
         try:
             stripped = payload
             if stripped.startswith("data:"):
                 comma = stripped.find(",")
                 if comma != -1:
+                    header = stripped[5:comma]  # after "data:"
+                    # Header looks like "image/jpeg;base64" or just
+                    # "image/png". Take the segment up to the first
+                    # ``;`` as the mime.
+                    semi = header.find(";")
+                    candidate = header[:semi] if semi != -1 else header
+                    if candidate and "/" in candidate:
+                        embedded_mime = candidate.lower()
                     stripped = stripped[comma + 1:]
             img_bytes = base64.b64decode(stripped, validate=False)
         except Exception as exc:
@@ -496,9 +519,16 @@ class GameAgentService:
             )
             return
 
+        # Resolve "is this a JPEG?" by considering both the explicit
+        # ``encoding`` field and the mime extracted from a data: URI.
+        # The explicit field wins when both are present (more
+        # authoritative); the URI scheme is a fallback when the
+        # encoding is empty.
         mime = "image/png"
         enc_lower = (encoding or "").lower()
-        if "jpeg" in enc_lower or "jpg" in enc_lower:
+        is_jpeg_explicit = "jpeg" in enc_lower or "jpg" in enc_lower
+        is_jpeg_embedded = embedded_mime in ("image/jpeg", "image/jpg")
+        if is_jpeg_explicit or (not enc_lower and is_jpeg_embedded):
             # Gemini's realtime media input prefers PNG; convert here so
             # downstream code can be format-agnostic. Pillow is already
             # a transitive project dep (used by avatar/MMD pipelines).

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -703,10 +703,19 @@ class GameAgentService:
             # clearing ``self._pending`` here is safe.
             pending = self._pending
             self._pending = None
-            pending.result = {
+            # Carry the agent's free-text message into the tool
+            # result so the LLM sees the agent's final commentary
+            # (e.g. "Mined 10 oak logs, inventory full" or "Path
+            # blocked by water"). Without this, the model only sees
+            # status/query and has to infer outcome detail —
+            # noticeably worse for narration and error recovery.
+            result_payload: Dict[str, Any] = {
                 "status": status,
                 "query": pending.task_text,
             }
+            if text:
+                result_payload["text"] = text
+            pending.result = result_payload
             pending.event.set()
             self._task_finished = True
 

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -103,6 +103,13 @@ class GameAgentService:
         # Cross-callback state
         self._pending: Optional[PendingTask] = None
         self._pending_lock = asyncio.Lock()
+        # Counter of tasks we abandoned without an acknowledged
+        # ``task_finished`` (timeout / overwrite / shutdown). Used to
+        # filter out stale frames from the agent: the protocol carries
+        # no task id, so without this a delayed completion for an old
+        # task would be (incorrectly) attributed to whatever task is
+        # currently pending. Drained FIFO in ``_on_task_finished``.
+        self._stale_task_finishes_to_drop: int = 0
         self._log_cache: list[str] = []
         # Bounded ring buffer — discarding old screenshots is fine,
         # the autonomous loop only ever sends "the latest few".
@@ -116,11 +123,25 @@ class GameAgentService:
     # Configuration / lifecycle
     # ------------------------------------------------------------------
 
+    # Keys whose changes only take effect on the next ``start()`` —
+    # the ``GameAgentClient`` constructor copies them once. Tracking
+    # them lets ``reload_config_live`` decide whether a stop+start
+    # cycle is needed to make the new value real.
+    _TRANSPORT_KEYS = ("_ws_url", "_reconnect_interval")
+
     def configure(self, cfg: Dict[str, Any]) -> None:
         """Read the ``[game_agent]`` section of ``plugin.toml`` (passed
         in by the plugin facade) and update local config. Defensive
         about missing/wrong types so a partial / hand-edited config
-        doesn't crash startup."""
+        doesn't crash startup.
+
+        Note: when called after ``start()``, transport-affecting keys
+        (``ws_url``, ``reconnect_interval_seconds``) update internal
+        state but do **not** swap the live ``GameAgentClient`` —
+        that's a transport-level identity change that needs a stop+
+        start cycle. Use :meth:`reload_config_live` if you want the
+        new transport values to take effect immediately.
+        """
         def _f(key: str, default: float) -> float:
             v = cfg.get(key, default)
             try:
@@ -154,6 +175,44 @@ class GameAgentService:
             self._screenshot_cache = collections.deque(
                 self._screenshot_cache, maxlen=size
             )
+
+    async def reload_config_live(self, cfg: Dict[str, Any]) -> bool:
+        """Apply a config update at runtime.
+
+        Pure-data keys (timeouts, intervals, screenshot toggles) update
+        in place — they're read on every loop tick / handler call.
+
+        Transport-affecting keys (``ws_url``,
+        ``reconnect_interval_seconds``) are baked into the live
+        :class:`GameAgentClient` instance at construction time, so a
+        change there requires a stop+start cycle to take effect. We
+        capture the old values, run ``configure``, then compare; if
+        they shifted and we're already running, restart the WS
+        client so the new endpoint is used.
+
+        Returns ``True`` if a transport restart actually happened.
+        """
+        was_running = self._client is not None
+        old_ws_url = self._ws_url
+        old_reconnect = self._reconnect_interval
+
+        self.configure(cfg)
+
+        transport_changed = (
+            self._ws_url != old_ws_url
+            or self._reconnect_interval != old_reconnect
+        )
+        if was_running and transport_changed:
+            self._log_info(
+                "config reload triggered transport restart "
+                "(ws_url={} -> {}, reconnect={} -> {})",
+                old_ws_url, self._ws_url,
+                old_reconnect, self._reconnect_interval,
+            )
+            await self.stop()
+            await self.start()
+            return True
+        return False
 
     async def start(self) -> None:
         """Spin up the WebSocket client + autonomous loop. Idempotent —
@@ -193,12 +252,19 @@ class GameAgentService:
                 }
                 self._pending.event.set()
                 self._pending = None
+            # Drop any in-flight ``task_finished`` frames that arrive
+            # after we've torn down — they would have nowhere to go.
+            self._stale_task_finishes_to_drop = 0
 
         if self._system_loop_task is not None:
             self._system_loop_task.cancel()
             try:
                 await self._system_loop_task
             except (asyncio.CancelledError, Exception):
+                # We just cancelled it — CancelledError is the
+                # expected shape; any other Exception means the loop
+                # raised on its way out (already logged inside the
+                # loop), nothing more to do here on shutdown.
                 pass
             self._system_loop_task = None
 
@@ -211,6 +277,9 @@ class GameAgentService:
             try:
                 await self._client_task
             except (asyncio.CancelledError, Exception):
+                # Same as above — cancellation we asked for, or a
+                # transport failure already surfaced via the WS
+                # client's own error logging.
                 pass
             self._client_task = None
 
@@ -263,7 +332,9 @@ class GameAgentService:
                         "hint": "Set overwrite=True to interrupt the current task.",
                     }
                 # Wake the old handler with an "interrupted" verdict
-                # before claiming the slot for the new task.
+                # before claiming the slot for the new task. The agent
+                # may still send a delayed ``task_finished`` for the
+                # old task, so flag one frame to drop when it arrives.
                 self._log_warning(
                     "overwriting task: {} -> {}", self._pending.task_text, task
                 )
@@ -274,6 +345,7 @@ class GameAgentService:
                 }
                 self._pending.event.set()
                 self._pending = None
+                self._stale_task_finishes_to_drop += 1
 
             # The handler keeps a *local* reference to its own
             # PendingTask; ``self._pending`` may be reassigned (or
@@ -310,12 +382,26 @@ class GameAgentService:
             async with self._pending_lock:
                 if self._pending is my_pending:
                     self._pending = None
+                    self._stale_task_finishes_to_drop += 1
             self._log_info("task timed out: {}", task[:80])
             return {
                 "status": "timeout",
                 "query": task,
                 "reason": f"Not finished within {self._task_timeout:.0f}s.",
             }
+        except asyncio.CancelledError:
+            # The outer SDK ``@llm_tool(timeout=...)`` wrapper or a
+            # plugin shutdown may cancel this task while we're still
+            # waiting. Without this branch ``self._pending`` would
+            # stick around forever, making subsequent calls return
+            # "busy" against an event nothing will ever set. Clean
+            # the slot first, then re-raise so the cancellation
+            # propagates as the SDK expects.
+            async with self._pending_lock:
+                if self._pending is my_pending:
+                    self._pending = None
+                    self._stale_task_finishes_to_drop += 1
+            raise
 
         # Read the verdict the callback (or overwrite/shutdown path)
         # wrote into ``my_pending.result`` before setting the event.
@@ -423,6 +509,20 @@ class GameAgentService:
         self._task_finished = True
 
         async with self._pending_lock:
+            # The agent server's protocol has no task ID, so a delayed
+            # ``task_finished`` for an old (timed-out / overwritten /
+            # shutdown-cancelled) task is indistinguishable from a
+            # fresh one for the current task. We assume the agent
+            # emits frames in completion order and drain them FIFO:
+            # for every task we abandoned without an ack, swallow one
+            # incoming frame.
+            if self._stale_task_finishes_to_drop > 0:
+                self._stale_task_finishes_to_drop -= 1
+                self._log_info(
+                    "dropped stale task_finished (status={}, drops_remaining={})",
+                    status, self._stale_task_finishes_to_drop,
+                )
+                return
             if self._pending is None:
                 # Stray task_finished (e.g. from agent restart) — nothing
                 # to wake. Just keep the log line for the next system
@@ -543,7 +643,10 @@ class GameAgentService:
         }
 
     # ------------------------------------------------------------------
-    # Logging helpers — silently no-op when no logger is supplied
+    # Logging helpers — silently no-op when no logger is supplied.
+    # Each helper guards its emit because the SDK's loguru-based logger
+    # can transiently fail (file rotation mid-write, etc.); we never
+    # want a diagnostic log line to surface as a real error.
     # ------------------------------------------------------------------
 
     def _log_info(self, msg: str, *args: Any) -> None:
@@ -551,21 +654,21 @@ class GameAgentService:
             try:
                 self.logger.info("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
     def _log_warning(self, msg: str, *args: Any) -> None:
         if self.logger is not None:
             try:
                 self.logger.warning("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
     def _log_error(self, msg: str, *args: Any) -> None:
         if self.logger is not None:
             try:
                 self.logger.error("[GameAgent] " + msg, *args)
             except Exception:
-                pass
+                pass  # log emission itself failed — see comment above
 
 
 __all__ = ["GameAgentService", "PendingTask"]

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -1,0 +1,571 @@
+"""GameAgentService — wires the WebSocket client to the LLM session.
+
+Responsibilities split off the plugin facade so it stays testable:
+
+1. Hold the cross-callback state (pending tool call, log/screenshot
+   caches, task-finished signal).
+2. Translate raw agent-server frames into push_message v2 payloads:
+   * screenshots → image parts on the realtime stream
+     (``ai_behavior="read"``)
+   * task_finished → wakes the pending ``minecraft_task`` handler so it
+     can return the result to the LLM
+3. Run the autonomous "system prompt" loop that periodically nudges the
+   LLM with the latest game state when there's nothing else for it to
+   talk about.
+
+The original integration in ``main_logic/core.py`` (commit ``bca0c5f3``,
+later abandoned) baked all of this directly into the realtime client
+class. This module keeps every game-agent concern inside the plugin so
+adding/removing the feature is a pure plugin install / uninstall.
+
+Async semantics
+---------------
+``minecraft_task`` is fundamentally async on the agent side: the LLM
+calls the tool, we send the task to the agent server, and the result
+arrives later as a separate ``task_finished`` frame. The SDK's
+``@llm_tool`` contract is that the handler returns a value when done.
+We bridge the two by having the handler block on an :class:`asyncio.Event`
+that the WebSocket callback sets when the result comes in. ``timeout``
+on the decorator caps the wait so a wedged agent server doesn't pin the
+LLM forever.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import collections
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+from .client import GameAgentClient
+
+# Strip ANSI colour escapes from agent log lines before relaying to the
+# LLM — we don't want VT100 noise in the model's context window.
+_ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+
+@dataclass
+class PendingTask:
+    """State for a single in-flight ``minecraft_task`` invocation.
+
+    The handler creates one when the LLM picks the tool, blocks on
+    ``event``, and reads ``result`` after waking.
+    """
+
+    task_text: str
+    event: asyncio.Event
+    start_time: float
+    # Filled in by the WebSocket callback (or by overwrite/timeout
+    # paths) right before ``event`` is set.
+    result: Dict[str, Any] = field(default_factory=dict)
+
+
+class GameAgentService:
+    """Per-plugin instance state + WebSocket lifecycle + autonomous loop.
+
+    The plugin facade injects two callables we don't construct ourselves:
+
+    * ``push_message_fn`` — bound to ``ctx.push_message`` so we can
+      forward image/text payloads upward without taking a hard dep on
+      the SDK base class.
+    * ``logger`` — the per-plugin loguru logger, already prefixed with
+      the plugin id.
+
+    Both are passed in at ``__init__`` time so unit tests can swap in
+    fakes.
+    """
+
+    def __init__(
+        self,
+        *,
+        logger: Any,
+        push_message_fn: Callable[..., Any],
+    ) -> None:
+        self.logger = logger
+        self._push_message = push_message_fn
+
+        # Configuration (filled in by ``configure``).
+        self._ws_url: str = "ws://localhost:48909"
+        self._reconnect_interval: float = 5.0
+        self._task_timeout: float = 25.0
+        self._system_prompt_interval: float = 5.0
+        self._skip_when_busy: bool = True
+        self._stream_screenshots: bool = True
+        self._screenshot_cache_size: int = 3
+
+        # WebSocket lifecycle
+        self._client: Optional[GameAgentClient] = None
+        self._client_task: Optional[asyncio.Task] = None
+        self._system_loop_task: Optional[asyncio.Task] = None
+
+        # Cross-callback state
+        self._pending: Optional[PendingTask] = None
+        self._pending_lock = asyncio.Lock()
+        self._log_cache: list[str] = []
+        # Bounded ring buffer — discarding old screenshots is fine,
+        # the autonomous loop only ever sends "the latest few".
+        self._screenshot_cache: collections.deque[bytes] = collections.deque(maxlen=3)
+        self._task_finished: bool = True
+
+        # Pacing state for the autonomous loop
+        self._last_system_prompt_time: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Configuration / lifecycle
+    # ------------------------------------------------------------------
+
+    def configure(self, cfg: Dict[str, Any]) -> None:
+        """Read the ``[game_agent]`` section of ``plugin.toml`` (passed
+        in by the plugin facade) and update local config. Defensive
+        about missing/wrong types so a partial / hand-edited config
+        doesn't crash startup."""
+        def _f(key: str, default: float) -> float:
+            v = cfg.get(key, default)
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return float(default)
+
+        def _i(key: str, default: int) -> int:
+            v = cfg.get(key, default)
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return int(default)
+
+        def _b(key: str, default: bool) -> bool:
+            v = cfg.get(key, default)
+            return bool(v) if isinstance(v, (bool, int)) else default
+
+        url = cfg.get("ws_url")
+        if isinstance(url, str) and url:
+            self._ws_url = url
+        self._reconnect_interval = max(0.5, _f("reconnect_interval_seconds", 5.0))
+        self._task_timeout = max(1.0, _f("task_timeout_seconds", 25.0))
+        self._system_prompt_interval = max(1.0, _f("system_prompt_interval_seconds", 5.0))
+        self._skip_when_busy = _b("skip_system_prompt_if_busy", True)
+        self._stream_screenshots = _b("stream_screenshots_to_llm", True)
+        size = max(1, _i("screenshot_cache_size", 3))
+        self._screenshot_cache_size = size
+        # ``deque(maxlen=...)`` is immutable post-construction, so swap.
+        if self._screenshot_cache.maxlen != size:
+            self._screenshot_cache = collections.deque(
+                self._screenshot_cache, maxlen=size
+            )
+
+    async def start(self) -> None:
+        """Spin up the WebSocket client + autonomous loop. Idempotent —
+        a second call after start() noops if already running."""
+        if self._client is not None:
+            return
+
+        self._client = GameAgentClient(
+            uri=self._ws_url,
+            on_log=self._on_log,
+            on_screenshot=self._on_screenshot,
+            on_task_finished=self._on_task_finished,
+            reconnect_interval=self._reconnect_interval,
+            logger=self.logger,
+        )
+        self._client_task = asyncio.create_task(
+            self._client.start(), name="game_agent_minecraft.ws_client"
+        )
+        self._system_loop_task = asyncio.create_task(
+            self._system_prompt_loop(),
+            name="game_agent_minecraft.system_loop",
+        )
+        self._log_info("started, ws_url={}", self._ws_url)
+
+    async def stop(self) -> None:
+        """Tear down WS client + loop, and resolve any pending tool call
+        with a "shutdown" status so the @llm_tool handler doesn't hang
+        until its timeout expires."""
+        # Drain pending handler first so it returns before we kill the
+        # transport that would feed its event.
+        async with self._pending_lock:
+            if self._pending is not None:
+                self._pending.result = {
+                    "status": "interrupted",
+                    "query": self._pending.task_text,
+                    "reason": "Game agent plugin shutting down.",
+                }
+                self._pending.event.set()
+                self._pending = None
+
+        if self._system_loop_task is not None:
+            self._system_loop_task.cancel()
+            try:
+                await self._system_loop_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._system_loop_task = None
+
+        if self._client is not None:
+            await self._client.stop()
+            self._client = None
+
+        if self._client_task is not None:
+            self._client_task.cancel()
+            try:
+                await self._client_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._client_task = None
+
+        self._log_cache.clear()
+        self._screenshot_cache.clear()
+        self._task_finished = True
+        self._log_info("stopped")
+
+    # ------------------------------------------------------------------
+    # @llm_tool handler — the LLM-visible side
+    # ------------------------------------------------------------------
+
+    async def execute_minecraft_task(
+        self, *, task: str, overwrite: bool = False
+    ) -> Dict[str, Any]:
+        """Implementation of the ``minecraft_task`` LLM tool.
+
+        Returns a dict the SDK callback route forwards to the model.
+        Two shapes of "non-error completion":
+
+        * ``{"status": "ok",         "query": ...}``      — agent finished
+        * ``{"status": "timeout",    "query": ..., "reason": ...}`` — capped
+        * ``{"status": "interrupted","query": ..., "reason": ...}`` — overwritten / shutdown
+        * ``{"result": "busy",       "currently_executing": ..., "hint": ...}`` — refused
+
+        Real failures (agent disconnected, etc.) come back as
+        ``{"output": ..., "is_error": True, "error": "..."}`` so the LLM
+        can adapt rather than hallucinate success.
+        """
+        if not isinstance(task, str) or not task.strip():
+            return {
+                "output": {"error": "task must be a non-empty string"},
+                "is_error": True,
+                "error": "INVALID_TASK",
+            }
+        if self._client is None:
+            return {
+                "output": {"error": "plugin is not started yet"},
+                "is_error": True,
+                "error": "NOT_STARTED",
+            }
+
+        async with self._pending_lock:
+            if self._pending is not None:
+                if not overwrite:
+                    # Refuse without disturbing the in-flight task.
+                    return {
+                        "result": "busy",
+                        "currently_executing": self._pending.task_text,
+                        "hint": "Set overwrite=True to interrupt the current task.",
+                    }
+                # Wake the old handler with an "interrupted" verdict
+                # before claiming the slot for the new task.
+                self._log_warning(
+                    "overwriting task: {} -> {}", self._pending.task_text, task
+                )
+                self._pending.result = {
+                    "status": "interrupted",
+                    "query": self._pending.task_text,
+                    "reason": "Overwritten by a new task.",
+                }
+                self._pending.event.set()
+                self._pending = None
+
+            # The handler keeps a *local* reference to its own
+            # PendingTask; ``self._pending`` may be reassigned (or
+            # cleared) by overwrite/shutdown paths before this handler
+            # wakes up, but ``my_pending.result`` survives because
+            # whoever set the event also wrote into the dataclass we
+            # hold here.
+            my_pending = PendingTask(
+                task_text=task, event=asyncio.Event(), start_time=time.time(),
+            )
+            self._pending = my_pending
+            self._task_finished = False
+
+        sent = await self._client.send_task(task)
+        if not sent:
+            # Roll back the pending slot — the agent never accepted the
+            # task, so we shouldn't keep reporting "busy" to subsequent
+            # calls.
+            async with self._pending_lock:
+                if self._pending is my_pending:
+                    self._pending = None
+            return {
+                "output": {
+                    "error": "agent server is not connected",
+                    "query": task,
+                },
+                "is_error": True,
+                "error": "AGENT_DISCONNECTED",
+            }
+
+        try:
+            await asyncio.wait_for(my_pending.event.wait(), timeout=self._task_timeout)
+        except asyncio.TimeoutError:
+            async with self._pending_lock:
+                if self._pending is my_pending:
+                    self._pending = None
+            self._log_info("task timed out: {}", task[:80])
+            return {
+                "status": "timeout",
+                "query": task,
+                "reason": f"Not finished within {self._task_timeout:.0f}s.",
+            }
+
+        # Read the verdict the callback (or overwrite/shutdown path)
+        # wrote into ``my_pending.result`` before setting the event.
+        # Note: we read from the *local* PendingTask, not
+        # ``self._pending``, because the latter may already have been
+        # reassigned to a different task by an overwrite call that woke
+        # us up.
+        async with self._pending_lock:
+            if self._pending is my_pending:
+                self._pending = None
+
+        return my_pending.result or {"status": "ok", "query": task}
+
+    # ------------------------------------------------------------------
+    # WebSocket inbound callbacks — invoked from the WS listener task
+    # ------------------------------------------------------------------
+
+    async def _on_log(self, text: str) -> None:
+        text_strip = text.strip() if isinstance(text, str) else ""
+        if not text_strip:
+            return
+        self._log_cache.append(text_strip)
+
+        # The original integration sniffed log strings to track agent
+        # state because the protocol didn't have explicit "task running"
+        # frames. Keep the same heuristics so existing agent servers
+        # work without protocol changes.
+        if "task run ended" in text_strip:
+            self._task_finished = True
+        elif "action selection" in text_strip:
+            self._task_finished = False
+        elif text_strip == "Connection lost and re-established.":
+            self._task_finished = True
+
+    async def _on_screenshot(self, payload: str, encoding: str) -> None:
+        """Decode a base64 screenshot, convert JPEG→PNG when needed, and
+        either stream it into the realtime LLM session immediately or
+        cache it for the next autonomous-prompt burst."""
+        try:
+            stripped = payload
+            if stripped.startswith("data:"):
+                comma = stripped.find(",")
+                if comma != -1:
+                    stripped = stripped[comma + 1:]
+            img_bytes = base64.b64decode(stripped, validate=False)
+        except Exception as exc:
+            self._log_error(
+                "screenshot base64 decode failed: {}: {}",
+                type(exc).__name__, exc,
+            )
+            return
+
+        mime = "image/png"
+        enc_lower = (encoding or "").lower()
+        if "jpeg" in enc_lower or "jpg" in enc_lower:
+            # Gemini's realtime media input prefers PNG; convert here so
+            # downstream code can be format-agnostic. Pillow is already
+            # a transitive project dep (used by avatar/MMD pipelines).
+            try:
+                from PIL import Image
+                import io
+
+                with Image.open(io.BytesIO(img_bytes)) as im:
+                    buf = io.BytesIO()
+                    im.save(buf, format="PNG")
+                    img_bytes = buf.getvalue()
+            except Exception as exc:
+                # Fall through with the original JPEG bytes — main_server
+                # won't choke if the mime type matches.
+                self._log_warning(
+                    "JPEG→PNG convert failed, sending as-is: {}: {}",
+                    type(exc).__name__, exc,
+                )
+                mime = "image/jpeg"
+
+        self._screenshot_cache.append(img_bytes)
+
+        # Stream immediately into the realtime LLM session. push_message
+        # v2 with ``ai_behavior="read"`` translates downstream into
+        # ``session.stream_image`` (see ``main_server.py`` proactive
+        # branch + the v2 changelog for the wire flow).
+        if self._stream_screenshots:
+            try:
+                self._push_message(
+                    source="game_agent_minecraft",
+                    visibility=[],
+                    ai_behavior="read",
+                    parts=[{"type": "image", "data": img_bytes, "mime": mime}],
+                    priority=3,
+                )
+            except Exception as exc:
+                self._log_error(
+                    "push_message screenshot failed: {}: {}",
+                    type(exc).__name__, exc,
+                )
+
+    async def _on_task_finished(self, data: Dict[str, Any]) -> None:
+        text = str(
+            data.get("text") or data.get("data") or data.get("message") or ""
+        )
+        status = str(data.get("status") or "ok")
+        self._log_info("task_finished: status={}, text={}", status, text[:80])
+        if text:
+            self._log_cache.append(text)
+        self._task_finished = True
+
+        async with self._pending_lock:
+            if self._pending is None:
+                # Stray task_finished (e.g. from agent restart) — nothing
+                # to wake. Just keep the log line for the next system
+                # prompt.
+                return
+            self._pending.result = {
+                "status": status,
+                "query": self._pending.task_text,
+            }
+            self._pending.event.set()
+            # Don't None-out here; ``execute_minecraft_task`` does that
+            # after it reads ``result`` so we don't race the read.
+
+    # ------------------------------------------------------------------
+    # Autonomous system-prompt loop
+    # ------------------------------------------------------------------
+
+    async def _system_prompt_loop(self) -> None:
+        """Periodically nudge the LLM with the latest game state.
+
+        We don't try to detect "user/model is currently speaking" from
+        inside the plugin — main_server's proactive_message handler
+        already gates timing on its end. The plugin's pacing here is
+        only about not flooding main_server with redundant wake-ups,
+        not about real-time conversation politeness.
+        """
+        try:
+            while True:
+                # 0.5s tick keeps us responsive to ``stop()`` without
+                # busy-looping.
+                await asyncio.sleep(0.5)
+
+                now = time.time()
+                if now - self._last_system_prompt_time < self._system_prompt_interval:
+                    continue
+                if self._skip_when_busy and self._pending is not None and not self._task_finished:
+                    # Avoid stacking prompts on top of an in-flight tool
+                    # call — the LLM is already committed to the result.
+                    continue
+                if not self._log_cache and not self._screenshot_cache and self._task_finished:
+                    # Nothing happened recently; don't poke the LLM.
+                    continue
+
+                await self._fire_system_prompt()
+                self._last_system_prompt_time = time.time()
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:
+            self._log_error(
+                "system prompt loop failed: {}: {}", type(exc).__name__, exc,
+            )
+
+    async def _fire_system_prompt(self) -> None:
+        """Build + push the autonomous nudge.
+
+        Body shape mirrors the original integration so prompt-engineering
+        carries over: a "GAME_SYSTEM" header, the recent agent log
+        snippet, and either a "task done — pick the next one" or a
+        "task running — comment if you like" tail.
+        """
+        log_text = ""
+        if self._log_cache:
+            log_text = _ANSI_RE.sub("", "\n".join(self._log_cache))
+            self._log_cache.clear()
+
+        sections: list[str] = []
+        if self._pending is not None:
+            sections.append(f"正在进行的操作: {self._pending.task_text}")
+        if log_text:
+            sections.append(f"先前操作的详细日志:\n---\n{log_text}\n---")
+        if self._task_finished:
+            sections.append(
+                "你先前的操作已经完成了。请使用minecraft_task，但不要说出来。"
+            )
+        else:
+            sections.append("你先前的操作仍在进行中，你可以选择性解说。")
+        prompt_text = "GAME_SYSTEM | " + "\n".join(sections)
+
+        # Build the parts list: cached screenshots first (so the LLM
+        # has visual context when it reads the prompt), then the
+        # GAME_SYSTEM text. Drain the cache after building the parts
+        # list so a flake on push_message doesn't re-send the same
+        # screenshots forever.
+        parts: list[Dict[str, Any]] = []
+        screenshots = list(self._screenshot_cache)
+        self._screenshot_cache.clear()
+        for img_bytes in screenshots:
+            parts.append({"type": "image", "data": img_bytes, "mime": "image/png"})
+        parts.append({"type": "text", "text": prompt_text})
+
+        try:
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="respond",
+                parts=parts,
+                priority=4,
+            )
+        except Exception as exc:
+            self._log_error(
+                "system prompt push_message failed: {}: {}",
+                type(exc).__name__, exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Diagnostics — surfaced via the plugin's status entries
+    # ------------------------------------------------------------------
+
+    def get_status(self) -> Dict[str, Any]:
+        connected = bool(self._client and self._client.is_connected)
+        return {
+            "ws_url": self._ws_url,
+            "connected": connected,
+            "task_finished": self._task_finished,
+            "pending_task": self._pending.task_text if self._pending else None,
+            "log_cache_size": len(self._log_cache),
+            "screenshot_cache_size": len(self._screenshot_cache),
+        }
+
+    # ------------------------------------------------------------------
+    # Logging helpers — silently no-op when no logger is supplied
+    # ------------------------------------------------------------------
+
+    def _log_info(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.info("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+    def _log_warning(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.warning("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+    def _log_error(self, msg: str, *args: Any) -> None:
+        if self.logger is not None:
+            try:
+                self.logger.error("[GameAgent] " + msg, *args)
+            except Exception:
+                pass
+
+
+__all__ = ["GameAgentService", "PendingTask"]

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -68,6 +68,14 @@ class PendingTask:
     # the counter would silently swallow the *next* legitimate
     # frame.
     dispatched: bool = False
+    # Set by overwrite/stop when they abandon an *undispatched* task
+    # (i.e. its handler is still suspended inside ``send_task``).
+    # Tells the handler: "if you successfully dispatch later, bump
+    # the stale-drop counter yourself — the agent will receive your
+    # task and emit a frame for it that no one is waiting for, and
+    # I (the abandoner) couldn't do the bump because dispatched was
+    # False at my point in time."
+    bump_on_late_dispatch: bool = False
 
 
 class GameAgentService:
@@ -274,14 +282,14 @@ class GameAgentService:
                 }
                 pending.event.set()
                 self._pending = None
-                # Bump only if the task was actually dispatched —
-                # otherwise the agent never received it and won't
-                # generate a stale frame. (Matters most for the
-                # ``reload_config_live`` stop+start cycle when the
-                # same agent might redeliver buffered frames after
-                # reconnect.)
+                # Same logic as overwrite: bump now if dispatched,
+                # otherwise arm the late-dispatch flag so the
+                # handler bumps when ``send_task`` eventually
+                # succeeds.
                 if pending.dispatched:
                     self._stale_task_finishes_to_drop += 1
+                else:
+                    pending.bump_on_late_dispatch = True
             # Note: do NOT zero the counter — preserve any existing
             # debt from prior timeouts/overwrites that may still have
             # frames in flight from before this stop().
@@ -383,13 +391,16 @@ class GameAgentService:
                 }
                 old_pending.event.set()
                 self._pending = None
-                # Only count a stale-frame debt if the old task was
-                # actually dispatched to the agent — if its handler
-                # hadn't reached past ``send_task`` yet, the agent
-                # never received it and won't emit a stale frame to
-                # consume.
+                # Stale-frame debt: bump now if old was dispatched, or
+                # arm the late-dispatch flag if it wasn't. Without the
+                # late-dispatch path, an old task whose ``send_task``
+                # succeeds *after* this overwrite would have its
+                # eventual ``task_finished`` frame misattributed to
+                # the new (B) task.
                 if old_pending.dispatched:
                     self._stale_task_finishes_to_drop += 1
+                else:
+                    old_pending.bump_on_late_dispatch = True
 
             # The handler keeps a *local* reference to its own
             # PendingTask; ``self._pending`` may be reassigned (or
@@ -426,6 +437,16 @@ class GameAgentService:
             # timeout / cancel / stop) know whether to expect a
             # stale ``task_finished`` frame for this task.
             my_pending.dispatched = True
+            # If we were already abandoned during the dispatch
+            # window (overwrite/stop ran while ``send_task`` was
+            # suspended), the abandoner couldn't bump the drop
+            # counter at that moment because ``dispatched`` was
+            # False. Now that the agent *has* received the task,
+            # we're the only ones with the information that a stale
+            # frame is coming for it — bump now to consume it.
+            if my_pending.bump_on_late_dispatch:
+                async with self._pending_lock:
+                    self._stale_task_finishes_to_drop += 1
         # The ``send_task`` await is a suspension point — another
         # coroutine (overwrite / stop / a stale task_finished frame
         # filtered to fall through to ``_pending``) may have already

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -111,9 +111,16 @@ class GameAgentService:
         # currently pending. Drained FIFO in ``_on_task_finished``.
         self._stale_task_finishes_to_drop: int = 0
         self._log_cache: list[str] = []
-        # Bounded ring buffer — discarding old screenshots is fine,
-        # the autonomous loop only ever sends "the latest few".
-        self._screenshot_cache: collections.deque[bytes] = collections.deque(maxlen=3)
+        # Bounded ring buffer of (image_bytes, mime). We carry the mime
+        # alongside the bytes because the JPEG→PNG conversion in
+        # ``_on_screenshot`` can fall through to "ship as-is" on Pillow
+        # failure; replaying that frame in the autonomous loop with
+        # ``image/png`` would mis-tag JPEG bytes and may confuse the
+        # downstream image part handler. Discarding old frames is fine
+        # — the autonomous loop only ever sends "the latest few".
+        self._screenshot_cache: collections.deque[tuple[bytes, str]] = collections.deque(
+            maxlen=3
+        )
         self._task_finished: bool = True
 
         # Pacing state for the autonomous loop
@@ -363,10 +370,15 @@ class GameAgentService:
         if not sent:
             # Roll back the pending slot — the agent never accepted the
             # task, so we shouldn't keep reporting "busy" to subsequent
-            # calls.
+            # calls. Also reset ``_task_finished`` (we flipped it to
+            # ``False`` above optimistically); without resetting, the
+            # autonomous loop's ``skip_system_prompt_if_busy`` gate
+            # would behave as if a task were still running, and the
+            # "正在进行的操作" branch of the system prompt would lie.
             async with self._pending_lock:
                 if self._pending is my_pending:
                     self._pending = None
+                    self._task_finished = True
             return {
                 "output": {
                     "error": "agent server is not connected",
@@ -477,7 +489,7 @@ class GameAgentService:
                 )
                 mime = "image/jpeg"
 
-        self._screenshot_cache.append(img_bytes)
+        self._screenshot_cache.append((img_bytes, mime))
 
         # Stream immediately into the realtime LLM session. push_message
         # v2 with ``ai_behavior="read"`` translates downstream into
@@ -609,8 +621,10 @@ class GameAgentService:
         parts: list[Dict[str, Any]] = []
         screenshots = list(self._screenshot_cache)
         self._screenshot_cache.clear()
-        for img_bytes in screenshots:
-            parts.append({"type": "image", "data": img_bytes, "mime": "image/png"})
+        for img_bytes, img_mime in screenshots:
+            # Preserve the per-frame mime — see ``_screenshot_cache``
+            # field comment for why this isn't always image/png.
+            parts.append({"type": "image", "data": img_bytes, "mime": img_mime})
         parts.append({"type": "text", "text": prompt_text})
 
         try:

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -555,6 +555,15 @@ class GameAgentService:
         if "task run ended" in text_strip:
             if self._pending is None:
                 self._task_finished = True
+                # Some agent implementations emit "task run ended" in
+                # lieu of (or alongside) an explicit ``task_finished``
+                # frame for the abandoned task. If we're currently
+                # carrying stale-frame debt, this log line *is* the
+                # signal of that abandoned task's completion — drain
+                # one drop so a future legitimate ``task_finished``
+                # frame doesn't get swallowed instead.
+                if self._stale_task_finishes_to_drop > 0:
+                    self._stale_task_finishes_to_drop -= 1
         elif "action selection" in text_strip:
             # Setting False unconditionally is safe — at worst it
             # confirms what's already true (a task is in flight).
@@ -562,6 +571,11 @@ class GameAgentService:
         elif text_strip == "Connection lost and re-established.":
             if self._pending is None:
                 self._task_finished = True
+                # Connection bounce wipes the agent's task queue —
+                # any abandoned-task frames we were waiting to drain
+                # will never arrive. Reset the debt to avoid
+                # swallowing the next session's legitimate frames.
+                self._stale_task_finishes_to_drop = 0
 
     async def _on_screenshot(self, payload: str, encoding: str) -> None:
         """Decode a base64 screenshot, convert JPEG→PNG when needed, and

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -691,7 +691,29 @@ class GameAgentService:
             # fresh one for the current task. We assume the agent
             # emits frames in completion order and drain them FIFO:
             # for every task we abandoned without an ack, swallow one
-            # incoming frame. The stale frame's *text* must NOT enter
+            # incoming frame.
+            #
+            # KNOWN LIMITATION: this FIFO assumption is exactly that —
+            # an assumption. If the agent server processes tasks with
+            # internal concurrency such that an *overwritten* task A
+            # finishes *after* the replacement task B (i.e. frames
+            # arrive in B-then-A order), this filter swallows B's
+            # real completion and later accepts A's stale frame as if
+            # it were B's. The current ``minecraft_task`` call would
+            # then hang until ``task_timeout_seconds`` while a wrong
+            # result eventually surfaces.
+            #
+            # Properly fixing this requires the agent protocol to
+            # carry a task ID on both ``task`` and ``task_finished``
+            # frames so we can correlate explicitly. That's a
+            # protocol-level change for upstream agents and out of
+            # scope here. In practice agents we ship against
+            # (mineflayer-based bots) process tasks sequentially —
+            # overwrite stops the current task before starting the
+            # next — so out-of-order completions don't occur. If you
+            # write an agent that does have internal concurrency,
+            # add task IDs to the protocol and we'll wire correlation
+            # in. The stale frame's *text* must NOT enter
             # ``_log_cache`` either — otherwise the next system prompt
             # would surface "old task done" while a new task is still
             # running, lying about both branches of the prompt.

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -265,9 +265,17 @@ class GameAgentService:
                 }
                 self._pending.event.set()
                 self._pending = None
-            # Drop any in-flight ``task_finished`` frames that arrive
-            # after we've torn down — they would have nowhere to go.
-            self._stale_task_finishes_to_drop = 0
+                # We abandoned this task without an ack — bump the
+                # drop counter so a delayed ``task_finished`` (which
+                # might still hit us if ``stop()`` is part of a
+                # ``reload_config_live`` cycle and the same agent
+                # buffers and redelivers the frame after reconnect)
+                # doesn't bind to whatever new task the LLM picks
+                # next.
+                self._stale_task_finishes_to_drop += 1
+            # Note: do NOT zero the counter — preserve any existing
+            # debt from prior timeouts/overwrites that may still have
+            # frames in flight from before this stop().
 
         if self._system_loop_task is not None:
             self._system_loop_task.cancel()

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -122,6 +122,11 @@ async def test_execute_returns_disconnected_when_send_fails():
     # Critical: ``_pending`` was rolled back so subsequent calls don't
     # see "busy" against an event nothing will ever set.
     assert service._pending is None
+    # And ``_task_finished`` was reset back to True — without that, the
+    # autonomous loop's "skip when busy" gate and the system prompt's
+    # "正在进行的操作" branch would behave as if a phantom task were
+    # still running.
+    assert service._task_finished is True
 
 
 # ---------------------------------------------------------------------------
@@ -293,6 +298,36 @@ async def test_screenshot_streaming_disabled_caches_only():
     assert push_calls == []
     # But the bytes should be cached for the next system-prompt burst.
     assert service.get_status()["screenshot_cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_replay_preserves_per_frame_mime():
+    """Cached screenshots may have heterogeneous mimes (PNG-converted
+    PNG vs. JPEG-passed-through if Pillow conversion failed). The
+    autonomous-loop replay must use each frame's actual mime, not a
+    hardcoded image/png — otherwise downstream ``stream_image`` would
+    receive mis-tagged JPEG bytes."""
+    service, push_calls = _make_service()
+    service.configure({"stream_screenshots_to_llm": False})  # cache only
+
+    # Manually plant cache entries with different mimes (skipping
+    # _on_screenshot decode path so we can choose mimes deterministically).
+    service._screenshot_cache.append((b"<png-bytes>", "image/png"))
+    service._screenshot_cache.append((b"<jpeg-bytes>", "image/jpeg"))
+    # Need at least one cached log line so the loop's "nothing to say"
+    # gate doesn't short-circuit.
+    service._log_cache.append("test event")
+
+    await service._fire_system_prompt()
+    assert len(push_calls) == 1
+    parts = push_calls[0]["parts"]
+    image_parts = [p for p in parts if p["type"] == "image"]
+    assert len(image_parts) == 2
+    mimes = [p["mime"] for p in image_parts]
+    assert mimes == ["image/png", "image/jpeg"]
+    # And the bytes survived round-trip too.
+    datas = [p["data"] for p in image_parts]
+    assert datas == [b"<png-bytes>", b"<jpeg-bytes>"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -452,6 +452,25 @@ async def test_stale_task_finished_after_timeout_is_dropped():
 
 
 @pytest.mark.asyncio
+async def test_stale_task_finished_does_not_pollute_log_cache():
+    """Stale frames must not contribute their text to ``_log_cache``
+    either — otherwise the next system prompt would surface "old task
+    done" alongside a still-running new task, contradicting itself."""
+    service, _ = _make_service()
+    service.configure({})
+    # Pre-bump drop counter as if a prior task had been abandoned.
+    service._stale_task_finishes_to_drop = 1
+
+    await service._on_task_finished({
+        "status": "ok",
+        "text": "old task completion message — should NOT appear in cache",
+    })
+    # Frame was dropped → text must not be cached.
+    assert list(service._log_cache) == []
+    assert service._stale_task_finishes_to_drop == 0
+
+
+@pytest.mark.asyncio
 async def test_stale_task_finished_does_not_flip_task_finished_flag():
     """Dropping a stale frame must not set ``_task_finished = True``,
     which would leak the abandoned task's completion state into the

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -855,6 +855,52 @@ async def test_stale_task_finished_after_overwrite_is_dropped():
 
 
 @pytest.mark.asyncio
+async def test_cancellation_during_send_task_clears_pending_slot():
+    """The cancellation handler around ``event.wait()`` only catches
+    cancels that land *after* dispatch. Cancellation during the
+    ``send_task`` await itself (e.g. plugin shutdown sweeps tasks
+    while the WS roundtrip is in flight) was previously a leak —
+    ``_pending`` would dangle and every subsequent call would return
+    'busy' against an event nothing would set."""
+
+    class _SlowSendClient:
+        is_connected = True
+
+        def __init__(self):
+            self.released = asyncio.Event()
+
+        async def send_task(self, task):
+            # Block until cancelled — the test cancels the runner
+            # while we're suspended here.
+            await self.released.wait()
+            return True
+
+        async def stop(self):
+            pass
+
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 30.0})
+    service._client = _SlowSendClient()
+
+    runner = asyncio.create_task(service.execute_minecraft_task(task="A"))
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set within poll budget")
+
+    runner.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await runner
+
+    assert service._pending is None
+    assert service._task_finished is True
+    # Bumped because we abandoned the task without an ack.
+    assert service._stale_task_finishes_to_drop == 1
+
+
+@pytest.mark.asyncio
 async def test_cancellation_clears_pending_slot():
     service, _ = _make_service()
     service.configure({"task_timeout_seconds": 30.0})

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -499,26 +499,33 @@ async def test_log_cache_is_bounded():
 
 
 @pytest.mark.asyncio
-async def test_screenshot_data_uri_jpeg_with_empty_encoding_picks_jpeg_mime():
+async def test_screenshot_data_uri_jpeg_with_empty_encoding_picks_jpeg_mime(monkeypatch):
     """Some agents send ``data:image/jpeg;base64,...`` payloads with
     an empty ``encoding`` field. Without parsing the URI scheme, the
-    handler defaults to PNG and tags JPEG bytes wrongly."""
+    handler defaults to PNG and tags JPEG bytes wrongly.
+
+    We use ``monkeypatch.setitem`` to force the JPEG-passthrough
+    branch (Pillow stubbed to fail) and rely on monkeypatch's
+    auto-rollback so the fake module state doesn't bleed into other
+    tests in the suite.
+    """
     import base64
-    service, push_calls = _make_service()
-    service.configure({})
-    # Stub Pillow to fail so the JPEG-passthrough branch fires
-    # (otherwise the JPEG→PNG conversion would mask the mime issue
-    # by re-encoding to PNG anyway).
     import sys
     import types
+
+    service, push_calls = _make_service()
+    service.configure({})
+    # Force the JPEG-passthrough branch by stubbing Pillow's
+    # ``Image.open`` to raise. Without this, a real PIL would
+    # re-encode JPEG → PNG and mask the mime-handling we're testing.
     fake_pil = types.ModuleType("PIL")
     fake_image = types.ModuleType("PIL.Image")
     def _open_raises(*_a, **_k):
-        raise RuntimeError("Pillow not available in this test")
+        raise RuntimeError("Pillow stubbed for this test")
     fake_image.open = _open_raises  # type: ignore[attr-defined]
     fake_pil.Image = fake_image  # type: ignore[attr-defined]
-    sys.modules.setdefault("PIL", fake_pil)
-    sys.modules.setdefault("PIL.Image", fake_image)
+    monkeypatch.setitem(sys.modules, "PIL", fake_pil)
+    monkeypatch.setitem(sys.modules, "PIL.Image", fake_image)
 
     jpeg_bytes = b"\xff\xd8\xff\xe0fakejpegmarker"
     payload = "data:image/jpeg;base64," + base64.b64encode(jpeg_bytes).decode()

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -247,6 +247,36 @@ async def test_execute_returns_disconnected_when_send_fails():
 
 
 @pytest.mark.asyncio
+async def test_task_finished_text_propagates_to_tool_result():
+    """The agent's free-text completion message (``text``/``data``/
+    ``message`` field on the task_finished frame) must reach the
+    LLM as part of the tool result — not just status/query."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    async def driver():
+        for _ in range(50):
+            if service._pending is not None:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise RuntimeError("handler never set _pending")
+        await service._on_task_finished({
+            "status": "ok",
+            "text": "Mined 10 oak logs, inventory full.",
+        })
+
+    runner = asyncio.create_task(driver())
+    out = await service.execute_minecraft_task(task="mine 10 oak logs")
+    await runner
+
+    assert out["status"] == "ok"
+    assert out["query"] == "mine 10 oak logs"
+    assert out["text"] == "Mined 10 oak logs, inventory full."
+
+
+@pytest.mark.asyncio
 async def test_finished_result_not_overwritten_by_racing_stop():
     """``_on_task_finished`` must clear ``self._pending`` BEFORE
     setting the event, so a racing ``stop()`` that acquires the lock
@@ -299,7 +329,10 @@ async def test_execute_completes_when_task_finished_fires():
             await asyncio.sleep(0.01)
         else:
             raise RuntimeError("handler never set _pending")
-        await service._on_task_finished({"status": "ok", "text": "done"})
+        # Frame without ``text`` — text propagation is covered by a
+        # dedicated test; here we only verify the basic resolve-on-
+        # ``task_finished`` contract.
+        await service._on_task_finished({"status": "ok"})
 
     runner = asyncio.create_task(driver())
     out = await service.execute_minecraft_task(task="mine 10 logs")
@@ -453,7 +486,7 @@ async def test_overwrite_interrupts_old_task_with_status():
     # resolves the runner.
     await service._on_task_finished({"status": "ok", "text": "old finished late"})
     assert service._pending is not None  # still waiting
-    await service._on_task_finished({"status": "ok", "text": "new finished"})
+    await service._on_task_finished({"status": "ok"})
     new_out = await asyncio.wait_for(new_runner, timeout=2.0)
     assert new_out == {"status": "ok", "query": "new task"}
 
@@ -737,7 +770,7 @@ async def test_stale_task_finished_after_timeout_is_dropped():
 
     # Late task_finished for A arrives — should be dropped, not
     # attached to anything.
-    await service._on_task_finished({"status": "ok", "text": "A done late"})
+    await service._on_task_finished({"status": "ok", "text": "A done late (stale)"})
     assert service._stale_task_finishes_to_drop == 0
     # No pending task got falsely resolved.
     assert service._pending is None
@@ -853,14 +886,14 @@ async def test_stale_task_finished_does_not_flip_task_finished_flag():
 
     # Stale frame for A arrives → must be dropped, must NOT flip
     # _task_finished to True (B is still running).
-    await service._on_task_finished({"status": "ok", "text": "A done late"})
+    await service._on_task_finished({"status": "ok", "text": "A done late (stale)"})
     assert service._stale_task_finishes_to_drop == 0
     assert service._task_finished is False
     assert service._pending is not None
     assert service._pending.task_text == "B"
 
     # Real B completion now flips the flag.
-    await service._on_task_finished({"status": "ok", "text": "B done"})
+    await service._on_task_finished({"status": "ok"})
     assert service._task_finished is True
     out_b = await asyncio.wait_for(runner, timeout=2.0)
     assert out_b == {"status": "ok", "query": "B"}
@@ -911,7 +944,7 @@ async def test_stale_task_finished_after_overwrite_is_dropped():
     assert service._pending.task_text == "new task"
 
     # Now the real frame for the new task arrives — should resolve normally.
-    await service._on_task_finished({"status": "ok", "text": "new done"})
+    await service._on_task_finished({"status": "ok"})
     new_out = await asyncio.wait_for(new_runner, timeout=2.0)
     assert new_out == {"status": "ok", "query": "new task"}
 
@@ -1056,7 +1089,7 @@ async def test_overwrite_during_send_task_bumps_via_late_dispatch_flag():
     assert service._pending is not None  # new still pending
 
     # 7. New's real frame arrives → resolves new.
-    await service._on_task_finished({"status": "ok", "text": "new done"})
+    await service._on_task_finished({"status": "ok"})
     new_out = await asyncio.wait_for(new_runner, timeout=2.0)
     assert new_out == {"status": "ok", "query": "new"}
 
@@ -1114,7 +1147,7 @@ async def test_overwrite_does_not_bump_drop_counter_for_undispatched_old():
 
     # Now drive the agent's task_finished for the new task — it
     # should resolve normally (NOT be swallowed as stale).
-    await service._on_task_finished({"status": "ok", "text": "new done"})
+    await service._on_task_finished({"status": "ok"})
     out = await asyncio.wait_for(new_runner, timeout=2.0)
     assert out == {"status": "ok", "query": "new"}
 

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -521,13 +521,13 @@ async def test_log_heuristic_does_not_flip_when_pending_task_active():
     await service._on_log("Connection lost and re-established.")
     assert service._task_finished is False
 
-    # Clean up — we cancelled it ourselves so both CancelledError
-    # and any incidental exception on the way out are expected and
-    # irrelevant to the assertions above.
     runner.cancel()
     try:
         await runner
     except (asyncio.CancelledError, Exception):
+        # Cleanup-only swallow — we cancelled it ourselves so both
+        # CancelledError and any incidental exception on the way out
+        # are expected and irrelevant to the assertions above.
         pass
 
 

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -22,6 +22,30 @@ if str(_ROOT) not in sys.path:
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_pending(service, *, predicate=None, timeout: float = 0.5):
+    """Spin until the service has a pending task that matches
+    ``predicate`` (or any pending task if predicate is None). Fails
+    fast with a clear assertion if the timeout fires — without this
+    fail-fast branch, a flaky test would surface as an unrelated
+    AttributeError on ``service._pending.task_text`` later, hiding
+    the real cause."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        pending = service._pending
+        if pending is not None and (predicate is None or predicate(pending)):
+            return pending
+        await asyncio.sleep(0.01)
+    pytest.fail(
+        f"_pending never satisfied predicate within {timeout}s; "
+        f"current _pending={service._pending!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Fakes
 # ---------------------------------------------------------------------------
 
@@ -149,6 +173,8 @@ async def test_dispatch_race_honors_concurrent_verdict_over_disconnected():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
     my_pending = service._pending
     assert my_pending is not None
     my_pending.result = {
@@ -256,6 +282,8 @@ async def test_concurrent_call_returns_busy_when_overwrite_false():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
 
     # Concurrent call without overwrite gets busy.
     out = await service.execute_minecraft_task(task="other task", overwrite=False)
@@ -267,6 +295,10 @@ async def test_concurrent_call_returns_busy_when_overwrite_false():
     try:
         await long_runner
     except (asyncio.CancelledError, Exception):
+        # We just cancelled it ourselves — both CancelledError and any
+        # exception raised on the way out are expected and irrelevant
+        # to the assertions above. Swallow so the test completes
+        # cleanly.
         pass
 
 
@@ -284,6 +316,8 @@ async def test_overwrite_interrupts_old_task_with_status():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
 
     # Issue overwrite — should kick old task into "interrupted" return.
     new_runner = asyncio.create_task(
@@ -301,6 +335,8 @@ async def test_overwrite_interrupts_old_task_with_status():
         if service._pending is not None and service._pending.task_text == "new task":
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never the new task within poll budget")
 
     # The agent will (eventually) emit a delayed task_finished for the
     # *old* task before the new one's frame arrives. Per the FIFO drop
@@ -413,6 +449,80 @@ async def test_log_cache_is_bounded():
 
 
 @pytest.mark.asyncio
+async def test_screenshot_data_uri_jpeg_with_empty_encoding_picks_jpeg_mime():
+    """Some agents send ``data:image/jpeg;base64,...`` payloads with
+    an empty ``encoding`` field. Without parsing the URI scheme, the
+    handler defaults to PNG and tags JPEG bytes wrongly."""
+    import base64
+    service, push_calls = _make_service()
+    service.configure({})
+    # Stub Pillow to fail so the JPEG-passthrough branch fires
+    # (otherwise the JPEG→PNG conversion would mask the mime issue
+    # by re-encoding to PNG anyway).
+    import sys
+    import types
+    fake_pil = types.ModuleType("PIL")
+    fake_image = types.ModuleType("PIL.Image")
+    def _open_raises(*_a, **_k):
+        raise RuntimeError("Pillow not available in this test")
+    fake_image.open = _open_raises  # type: ignore[attr-defined]
+    fake_pil.Image = fake_image  # type: ignore[attr-defined]
+    sys.modules.setdefault("PIL", fake_pil)
+    sys.modules.setdefault("PIL.Image", fake_image)
+
+    jpeg_bytes = b"\xff\xd8\xff\xe0fakejpegmarker"
+    payload = "data:image/jpeg;base64," + base64.b64encode(jpeg_bytes).decode()
+
+    # encoding="" — without the data-URI mime parsing, we'd default
+    # to PNG and silently mis-tag the JPEG bytes.
+    await service._on_screenshot(payload, encoding="")
+
+    assert len(push_calls) == 1
+    parts = push_calls[0]["parts"]
+    assert parts[0]["mime"] == "image/jpeg"
+    assert parts[0]["data"] == jpeg_bytes
+
+
+@pytest.mark.asyncio
+async def test_log_heuristic_does_not_flip_when_pending_task_active():
+    """An old task's late "task run ended" log must not flip
+    ``_task_finished`` to True while a new task is in flight —
+    otherwise the autonomous loop's busy gate breaks. We defer to
+    the explicit ``task_finished`` frame's stale-frame filtering
+    when a task is pending."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Start a task — _pending populated, _task_finished=False.
+    runner = asyncio.create_task(service.execute_minecraft_task(task="A"))
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set within poll budget")
+    assert service._task_finished is False
+
+    # An old task's late "task run ended" log arrives — must NOT
+    # flip _task_finished while A is still pending.
+    await service._on_log("task run ended (for some old task)")
+    assert service._task_finished is False
+    assert service._pending is not None  # still in flight
+
+    # Same for connection-lost log.
+    await service._on_log("Connection lost and re-established.")
+    assert service._task_finished is False
+
+    # Clean up
+    runner.cancel()
+    try:
+        await runner
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.asyncio
 async def test_log_callback_tracks_task_state_from_strings():
     service, _ = _make_service()
     service.configure({})
@@ -443,6 +553,8 @@ async def test_stop_unblocks_pending_handler():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
 
     await service.stop()
     out = await asyncio.wait_for(runner, timeout=2.0)
@@ -472,6 +584,8 @@ async def test_stop_preserves_stale_frame_debt():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
 
     await service.stop()
     out = await asyncio.wait_for(runner, timeout=2.0)
@@ -552,6 +666,8 @@ async def test_stale_task_finished_does_not_flip_task_finished_flag():
         if service._pending is not None and service._pending.task_text == "B":
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never task B within poll budget")
     assert service._task_finished is False
 
     # Stale frame for A arrives → must be dropped, must NOT flip
@@ -586,6 +702,8 @@ async def test_stale_task_finished_after_overwrite_is_dropped():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
 
     # Overwrite — old runner resolves with "interrupted", drop counter += 1.
     new_runner = asyncio.create_task(
@@ -600,6 +718,8 @@ async def test_stale_task_finished_after_overwrite_is_dropped():
         if service._pending is not None and service._pending.task_text == "new task":
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never the new task within poll budget")
 
     # Late task_finished for OLD task arrives first — must be dropped,
     # NOT attached to the new task.
@@ -634,6 +754,8 @@ async def test_cancellation_clears_pending_slot():
         if service._pending is not None:
             break
         await asyncio.sleep(0.01)
+    else:
+        pytest.fail("service._pending was never set within poll budget")
 
     runner.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -392,6 +392,37 @@ async def test_stop_unblocks_pending_handler():
     assert "shutting down" in out["reason"].lower()
 
 
+@pytest.mark.asyncio
+async def test_stop_preserves_stale_frame_debt():
+    """When stop() interrupts a pending task, it must bump the drop
+    counter (not zero it). reload_config_live = stop+start; if the
+    same agent buffers and redelivers the abandoned task's
+    task_finished after reconnect, the counter ensures it doesn't
+    bind to whatever the LLM picks next. Likewise, prior debt from
+    earlier timeouts must survive stop() instead of being zeroed."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 30.0})
+    service._client = _FakeClient()
+
+    # Pre-populate a debt of 2 from earlier abandons.
+    service._stale_task_finishes_to_drop = 2
+
+    runner = asyncio.create_task(
+        service.execute_minecraft_task(task="will be stopped")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    await service.stop()
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "interrupted"
+    # Counter should be 3: prior debt (2) preserved + this stop's
+    # abandoned task (+1).
+    assert service._stale_task_finishes_to_drop == 3
+
+
 # ---------------------------------------------------------------------------
 # Stale task_finished filtering — protocol has no task IDs, so a delayed
 # completion frame for an abandoned task must not be misattributed to the

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -70,7 +70,7 @@ class _FakeClient:
         # directly with this fake, so callbacks are invoked manually.
         self.on_task_finished = None
 
-    async def send_task(self, task: str) -> bool:
+    async def send_task(self, task: str, *, task_id: str = "") -> bool:
         self.sent.append(task)
         return self._send_returns
 
@@ -185,7 +185,7 @@ async def test_dispatch_race_honors_concurrent_verdict_over_disconnected():
             self.released = asyncio.Event()
             self.return_value = False  # simulate "send failed"
 
-        async def send_task(self, task):
+        async def send_task(self, task, *, task_id=""):
             # Suspend long enough for the test to inject a verdict.
             await self.released.wait()
             return self.return_value
@@ -835,6 +835,81 @@ async def test_stop_preserves_stale_frame_debt():
 
 
 @pytest.mark.asyncio
+async def test_explicit_task_id_correlation_resolves_out_of_order():
+    """When the agent echoes ``task_id`` on ``task_finished``, the
+    plugin trusts the ID over arrival order. An out-of-order
+    completion (B's frame before A's, but A's overwrite came first)
+    must NOT be swallowed by the FIFO drop counter — the ID matches
+    the active pending task and the frame is accepted."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Pre-bump drop counter as if FIFO mode was tracking an abandon —
+    # in explicit-correlation mode this counter must NOT be consumed
+    # for an ID-matching frame.
+    service._stale_task_finishes_to_drop = 1
+
+    runner = asyncio.create_task(
+        service.execute_minecraft_task(task="B")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set")
+    b_id = service._pending.task_id
+    assert b_id  # service generated a task_id
+
+    # Agent emits task_finished for B with matching task_id. Even
+    # though drop counter > 0, the ID match means "this is for the
+    # active task" so we accept it without touching the counter.
+    await service._on_task_finished({"status": "ok", "task_id": b_id})
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "ok"
+    # Counter untouched — explicit correlation skips FIFO drops.
+    assert service._stale_task_finishes_to_drop == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_task_id_correlation_drops_mismatch():
+    """When the agent echoes a ``task_id`` that doesn't match the
+    pending task, the frame is unambiguously stale — drop without
+    touching the FIFO counter (counter is only for the no-id mode)."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    runner = asyncio.create_task(
+        service.execute_minecraft_task(task="B")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set")
+
+    # Stale frame with non-matching task_id arrives.
+    await service._on_task_finished({
+        "status": "ok",
+        "task_id": "this-is-some-other-tasks-id",
+    })
+    # B's pending state is untouched.
+    assert service._pending is not None
+    assert service._pending.task_text == "B"
+
+    # B's real frame with matching id arrives.
+    await service._on_task_finished({
+        "status": "ok",
+        "task_id": service._pending.task_id,
+    })
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "ok"
+
+
+@pytest.mark.asyncio
 async def test_stale_task_finished_after_timeout_is_dropped():
     """After a task times out, a delayed task_finished frame for it
     should be swallowed instead of resolving the *next* call."""
@@ -1049,7 +1124,7 @@ async def test_cancellation_during_send_task_clears_pending_slot():
         def __init__(self):
             self.released = asyncio.Event()
 
-        async def send_task(self, task):
+        async def send_task(self, task, *, task_id=""):
             # Block until cancelled — the test cancels the runner
             # while we're suspended here.
             await self.released.wait()
@@ -1095,7 +1170,7 @@ async def test_overwrite_during_send_task_bumps_via_late_dispatch_flag():
             self.gates: list[asyncio.Event] = []
             self.sent_tasks: list[str] = []
 
-        async def send_task(self, task):
+        async def send_task(self, task, *, task_id=""):
             gate = asyncio.Event()
             self.gates.append(gate)
             await gate.wait()

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -130,14 +130,20 @@ def test_configure_clamps_invalid_numeric():
 
 def test_configure_clamps_task_timeout_below_sdk_ceiling():
     """``@llm_tool(timeout=300.0)`` is the SDK wrapper ceiling. The
-    service must clamp configured ``task_timeout_seconds`` *below*
-    that so its structured ``{status: "timeout"}`` response can fire
-    before the wrapper cancels the handler."""
+    service must clamp configured ``task_timeout_seconds`` strictly
+    *below* that with a meaningful buffer (≥ 1s) so its structured
+    ``{status: "timeout"}`` response reliably fires before the
+    wrapper cancels the handler — anything within 300s would race
+    the wrapper's cancel."""
     service, _ = _make_service()
     service.configure({"task_timeout_seconds": 600.0})
-    # Ceiling - small buffer so service-internal fires first.
-    assert service._task_timeout <= 300.0
-    assert service._task_timeout > 0.0
+    # Strict <= 295.0 (5s buffer below 300s SDK ceiling). If
+    # implementation regresses to a thinner buffer (e.g. 299.5),
+    # this test catches it.
+    assert service._task_timeout <= 295.0
+    assert 300.0 - service._task_timeout >= 1.0, (
+        "buffer below SDK ceiling must be at least 1s"
+    )
     # And a normal value passes through.
     service.configure({"task_timeout_seconds": 90.0})
     assert service._task_timeout == 90.0
@@ -632,6 +638,44 @@ async def test_screenshot_data_uri_jpeg_with_empty_encoding_picks_jpeg_mime(monk
     parts = push_calls[0]["parts"]
     assert parts[0]["mime"] == "image/jpeg"
     assert parts[0]["data"] == jpeg_bytes
+
+
+@pytest.mark.asyncio
+async def test_log_task_run_ended_drains_one_stale_debt():
+    """Some agent implementations emit ``task run ended`` log lines
+    in lieu of (or alongside) the explicit ``task_finished`` frame
+    for an abandoned task. When that log fires AND we're carrying
+    stale-frame debt AND no task is currently pending, this log line
+    IS the abandoned task's completion — drain one drop so a
+    future legitimate ``task_finished`` doesn't get swallowed."""
+    service, _ = _make_service()
+    service.configure({})
+
+    # Pre-bump debt as if a prior task had been abandoned.
+    service._stale_task_finishes_to_drop = 1
+    assert service._pending is None
+
+    await service._on_log("task run ended (for the abandoned task)")
+    assert service._stale_task_finishes_to_drop == 0, (
+        "log heuristic must drain one stale-frame debt"
+    )
+    assert service._task_finished is True
+
+
+@pytest.mark.asyncio
+async def test_log_connection_lost_clears_all_stale_debt():
+    """Agent reconnect wipes its task queue — any debts we were
+    holding for in-flight frames will never be paid off. Reset the
+    debt counter to avoid swallowing the next session's frames."""
+    service, _ = _make_service()
+    service.configure({})
+
+    service._stale_task_finishes_to_drop = 3
+    assert service._pending is None
+
+    await service._on_log("Connection lost and re-established.")
+    assert service._stale_task_finishes_to_drop == 0
+    assert service._task_finished is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -949,6 +949,96 @@ async def test_cancellation_during_send_task_clears_pending_slot():
 
 
 @pytest.mark.asyncio
+async def test_overwrite_during_send_task_bumps_via_late_dispatch_flag():
+    """Re-architected: drive the slow-send fake step by step to verify
+    the late-dispatch bump fires when overwrite sets the flag."""
+
+    class _SlowSendClient:
+        is_connected = True
+
+        def __init__(self):
+            self.gates: list[asyncio.Event] = []
+            self.sent_tasks: list[str] = []
+
+        async def send_task(self, task):
+            gate = asyncio.Event()
+            self.gates.append(gate)
+            await gate.wait()
+            self.sent_tasks.append(task)
+            return True
+
+        async def stop(self):
+            pass
+
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    slow = _SlowSendClient()
+    service._client = slow
+
+    # 1. Start old task. send_task suspends on gates[0].
+    old_runner = asyncio.create_task(service.execute_minecraft_task(task="old"))
+    for _ in range(50):
+        if len(slow.gates) >= 1 and service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("old's send_task never reached the gate")
+    old_pending = service._pending
+    assert old_pending.dispatched is False
+    assert service._stale_task_finishes_to_drop == 0
+
+    # 2. Overwrite arrives. send_task for new will suspend on gates[1].
+    new_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="new", overwrite=True)
+    )
+    for _ in range(50):
+        if len(slow.gates) >= 2:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("new's send_task never reached the gate")
+
+    # 3. After overwrite ran inside the lock:
+    #    - old's event was set + result=interrupted
+    #    - bump_on_late_dispatch was armed (because dispatched=False)
+    #    - drop counter NOT yet bumped
+    assert old_pending.bump_on_late_dispatch is True
+    assert service._stale_task_finishes_to_drop == 0
+
+    # 4. Release old's send_task. Handler runs: dispatched=True →
+    #    sees bump_on_late_dispatch → bumps counter → is_set() → returns.
+    slow.gates[0].set()
+    old_out = await asyncio.wait_for(old_runner, timeout=2.0)
+    assert old_out["status"] == "interrupted"
+    assert service._stale_task_finishes_to_drop == 1, (
+        "bump must have happened on late dispatch"
+    )
+
+    # 5. Release new's send_task and let new run normally to confirm
+    #    the slot is healthy.
+    slow.gates[1].set()
+    # Wait for new to enter event.wait, then drive task_finished.
+    for _ in range(50):
+        if service._pending is not None and service._pending.task_text == "new":
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("new never settled into pending state")
+
+    # 6. The agent's frame for old (the abandoned one) arrives first
+    #    — should be dropped via the counter we just bumped, NOT
+    #    misattributed to new.
+    await service._on_task_finished({"status": "ok", "text": "old's late frame"})
+    assert service._stale_task_finishes_to_drop == 0
+    assert service._pending is not None  # new still pending
+
+    # 7. New's real frame arrives → resolves new.
+    await service._on_task_finished({"status": "ok", "text": "new done"})
+    new_out = await asyncio.wait_for(new_runner, timeout=2.0)
+    assert new_out == {"status": "ok", "query": "new"}
+
+
+@pytest.mark.asyncio
 async def test_overwrite_does_not_bump_drop_counter_for_undispatched_old():
     """If the OLD task hadn't reached past ``send_task`` yet when
     overwrite arrives, the agent never received it and won't emit a

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -32,17 +32,24 @@ async def _wait_for_pending(service, *, predicate=None, timeout: float = 0.5):
     fast with a clear assertion if the timeout fires — without this
     fail-fast branch, a flaky test would surface as an unrelated
     AttributeError on ``service._pending.task_text`` later, hiding
-    the real cause."""
+    the real cause.
+    """
     deadline = asyncio.get_event_loop().time() + timeout
     while asyncio.get_event_loop().time() < deadline:
         pending = service._pending
         if pending is not None and (predicate is None or predicate(pending)):
             return pending
         await asyncio.sleep(0.01)
+    # ``pytest.fail`` raises ``pytest.failed.Exception`` and never
+    # returns, but its return type isn't annotated as ``NoReturn`` in
+    # all pytest versions, so the static analyzer warns about a
+    # potential implicit ``None`` fall-through. Make the
+    # never-returns property explicit with ``raise AssertionError``.
     pytest.fail(
         f"_pending never satisfied predicate within {timeout}s; "
         f"current _pending={service._pending!r}"
     )
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------
@@ -514,7 +521,9 @@ async def test_log_heuristic_does_not_flip_when_pending_task_active():
     await service._on_log("Connection lost and re-established.")
     assert service._task_finished is False
 
-    # Clean up
+    # Clean up — we cancelled it ourselves so both CancelledError
+    # and any incidental exception on the way out are expected and
+    # irrelevant to the assertions above.
     runner.cancel()
     try:
         await runner

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -310,6 +310,49 @@ async def test_concurrent_call_returns_busy_when_overwrite_false():
 
 
 @pytest.mark.asyncio
+async def test_overwrite_only_accepts_true_canonical_bool():
+    """The LLM may emit a non-canonical truthy value for ``overwrite``
+    (string ``"true"``, integer ``1``, etc.). The strict ``is True``
+    check ensures the destructive interrupt path only fires on the
+    canonical boolean — anything else falls through to the safe
+    ``"busy"`` response."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Start a task to occupy the slot.
+    long_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="incumbent")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("incumbent never claimed the slot")
+
+    # ``overwrite="true"`` (string) — must NOT interrupt.
+    out = await service.execute_minecraft_task(task="impostor", overwrite="true")
+    assert out["result"] == "busy"
+    assert out["currently_executing"] == "incumbent"
+
+    # ``overwrite=1`` (truthy int) — same.
+    out = await service.execute_minecraft_task(task="impostor", overwrite=1)
+    assert out["result"] == "busy"
+
+    # Sanity: the slot still holds the original task, not impostor.
+    assert service._pending is not None
+    assert service._pending.task_text == "incumbent"
+
+    long_runner.cancel()
+    try:
+        await long_runner
+    except (asyncio.CancelledError, Exception):
+        # Cleanup-only swallow — we cancelled it ourselves.
+        pass
+
+
+@pytest.mark.asyncio
 async def test_overwrite_interrupts_old_task_with_status():
     service, _ = _make_service()
     service.configure({"task_timeout_seconds": 5.0})

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the game_agent_minecraft plugin's service layer.
+
+Covers the in-process behaviour without spinning up a real WebSocket
+or the user_plugin_server: error paths, the ``asyncio.Event`` bridge
+between the WS callback and the ``@llm_tool`` handler, the ``busy`` /
+``overwrite`` semantics, and timeout handling. The plugin facade
+(``__init__.py``) is exercised separately via the SDK's auto-register
+pipeline (already covered by ``test_plugin_llm_tool_sdk.py``).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    """Stand-in for ``GameAgentClient`` — captures send_task calls and
+    lets the test drive on_task_finished from the outside."""
+
+    def __init__(self, *, send_task_returns: bool = True) -> None:
+        self.is_connected = True
+        self.sent: list[str] = []
+        self._send_returns = send_task_returns
+        # The service plugs callbacks in via the constructor in the
+        # real client; the test patches ``GameAgentService._client``
+        # directly with this fake, so callbacks are invoked manually.
+        self.on_task_finished = None
+
+    async def send_task(self, task: str) -> bool:
+        self.sent.append(task)
+        return self._send_returns
+
+    async def stop(self) -> None:
+        self.is_connected = False
+
+
+def _make_service(*, push_calls: list | None = None):
+    """Create a service with no real client. Tests that need to drive
+    ``execute_minecraft_task`` plug a ``_FakeClient`` in afterwards via
+    monkeypatching, since the public ``start()`` would launch real WS
+    code."""
+    from plugin.plugins.game_agent_minecraft.service import GameAgentService
+
+    captured = push_calls if push_calls is not None else []
+
+    def fake_push(**kwargs):
+        captured.append(kwargs)
+
+    service = GameAgentService(logger=None, push_message_fn=fake_push)
+    return service, captured
+
+
+# ---------------------------------------------------------------------------
+# configure() — defensive parsing
+# ---------------------------------------------------------------------------
+
+
+def test_configure_uses_defaults_when_keys_missing():
+    service, _ = _make_service()
+    service.configure({})
+    status = service.get_status()
+    # ws_url default mirrored from plugin.toml
+    assert status["ws_url"].startswith("ws://localhost")
+
+
+def test_configure_clamps_invalid_numeric():
+    service, _ = _make_service()
+    service.configure({
+        "ws_url": "ws://example:1234",
+        "task_timeout_seconds": "not a number",
+        "system_prompt_interval_seconds": -5.0,
+        "screenshot_cache_size": "abc",
+    })
+    # Bad strings fall back to defaults; negative interval clamps to ≥1.
+    status = service.get_status()
+    assert status["ws_url"] == "ws://example:1234"
+    # No way to inspect internal _task_timeout from the public API, but
+    # the fact that it didn't raise is the contract.
+
+
+# ---------------------------------------------------------------------------
+# execute_minecraft_task — error paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_empty_task():
+    service, _ = _make_service()
+    out = await service.execute_minecraft_task(task="")
+    assert out["is_error"] is True
+    assert out["error"] == "INVALID_TASK"
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_not_started_when_no_client():
+    service, _ = _make_service()
+    out = await service.execute_minecraft_task(task="mine 10 logs")
+    assert out["is_error"] is True
+    assert out["error"] == "NOT_STARTED"
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_disconnected_when_send_fails():
+    service, _ = _make_service()
+    service._client = _FakeClient(send_task_returns=False)
+    out = await service.execute_minecraft_task(task="mine 10 logs")
+    assert out["is_error"] is True
+    assert out["error"] == "AGENT_DISCONNECTED"
+    # Critical: ``_pending`` was rolled back so subsequent calls don't
+    # see "busy" against an event nothing will ever set.
+    assert service._pending is None
+
+
+# ---------------------------------------------------------------------------
+# execute_minecraft_task — happy path via task_finished callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_completes_when_task_finished_fires():
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    async def driver():
+        # Wait until the handler has set ``_pending``, then fire the
+        # task_finished callback so the handler's await wakes up.
+        for _ in range(50):
+            if service._pending is not None:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            raise RuntimeError("handler never set _pending")
+        await service._on_task_finished({"status": "ok", "text": "done"})
+
+    runner = asyncio.create_task(driver())
+    out = await service.execute_minecraft_task(task="mine 10 logs")
+    await runner
+
+    assert out == {"status": "ok", "query": "mine 10 logs"}
+    assert service._pending is None
+
+
+# ---------------------------------------------------------------------------
+# execute_minecraft_task — timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_times_out_when_no_finish_arrives():
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 0.1})
+    service._client = _FakeClient()
+
+    out = await service.execute_minecraft_task(task="dig forever")
+    assert out["status"] == "timeout"
+    assert out["query"] == "dig forever"
+    assert "Not finished" in out["reason"]
+    # Slot freed so a subsequent call isn't permanently busy.
+    assert service._pending is None
+
+
+# ---------------------------------------------------------------------------
+# execute_minecraft_task — busy / overwrite semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_call_returns_busy_when_overwrite_false():
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Start a long-running task in the background — never resolved.
+    long_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="long task")
+    )
+    # Wait for _pending to be set.
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    # Concurrent call without overwrite gets busy.
+    out = await service.execute_minecraft_task(task="other task", overwrite=False)
+    assert out["result"] == "busy"
+    assert out["currently_executing"] == "long task"
+
+    # Cancel the long runner so the test doesn't hang.
+    long_runner.cancel()
+    try:
+        await long_runner
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_overwrite_interrupts_old_task_with_status():
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Start old task.
+    old_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="old task")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    # Issue overwrite — should kick old task into "interrupted" return.
+    new_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="new task", overwrite=True)
+    )
+
+    # Old should resolve quickly with interrupted status.
+    old_out = await asyncio.wait_for(old_runner, timeout=2.0)
+    assert old_out["status"] == "interrupted"
+    assert old_out["query"] == "old task"
+    assert "Overwritten" in old_out["reason"]
+
+    # New task is still pending until we fire task_finished.
+    for _ in range(50):
+        if service._pending is not None and service._pending.task_text == "new task":
+            break
+        await asyncio.sleep(0.01)
+    await service._on_task_finished({"status": "ok"})
+    new_out = await asyncio.wait_for(new_runner, timeout=2.0)
+    assert new_out == {"status": "ok", "query": "new task"}
+
+
+# ---------------------------------------------------------------------------
+# Screenshot / log callbacks — pushed via push_message v2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_screenshot_callback_pushes_image_part():
+    import base64
+    service, push_calls = _make_service()
+    service.configure({"stream_screenshots_to_llm": True})
+
+    # Fake 1x1 PNG (minimal valid bytes).
+    png_bytes = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4"
+        b"\x89\x00\x00\x00\rIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01"
+        b"\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    payload = base64.b64encode(png_bytes).decode("ascii")
+    await service._on_screenshot(payload, "png")
+
+    assert len(push_calls) == 1
+    pc = push_calls[0]
+    assert pc["visibility"] == []
+    assert pc["ai_behavior"] == "read"
+    assert len(pc["parts"]) == 1
+    part = pc["parts"][0]
+    assert part["type"] == "image"
+    assert part["mime"] == "image/png"
+    assert part["data"] == png_bytes
+
+
+@pytest.mark.asyncio
+async def test_screenshot_streaming_disabled_caches_only():
+    service, push_calls = _make_service()
+    service.configure({"stream_screenshots_to_llm": False})
+
+    import base64
+    payload = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode("ascii")
+    await service._on_screenshot(payload, "png")
+    assert push_calls == []
+    # But the bytes should be cached for the next system-prompt burst.
+    assert service.get_status()["screenshot_cache_size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_callback_tracks_task_state_from_strings():
+    service, _ = _make_service()
+    service.configure({})
+
+    await service._on_log("action selection: chop wood")
+    assert service._task_finished is False
+    await service._on_log("task run ended")
+    assert service._task_finished is True
+    await service._on_log("Connection lost and re-established.")
+    assert service._task_finished is True
+
+
+# ---------------------------------------------------------------------------
+# stop() resolves pending callers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_unblocks_pending_handler():
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 30.0})
+    service._client = _FakeClient()
+
+    runner = asyncio.create_task(
+        service.execute_minecraft_task(task="long task")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    await service.stop()
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "interrupted"
+    assert "shutting down" in out["reason"].lower()

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -226,6 +226,44 @@ async def test_execute_returns_disconnected_when_send_fails():
 
 
 @pytest.mark.asyncio
+async def test_finished_result_not_overwritten_by_racing_stop():
+    """``_on_task_finished`` must clear ``self._pending`` BEFORE
+    setting the event, so a racing ``stop()`` that acquires the lock
+    after this block exits can't see the still-completed PendingTask
+    and overwrite its result with "interrupted". Without that
+    ordering, the waiter (which shares the same PendingTask object)
+    would read a corrupted result."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    runner = asyncio.create_task(service.execute_minecraft_task(task="A"))
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set")
+
+    # Fire task_finished. After this returns, self._pending should be
+    # cleared (so a racing stop() sees no pending task) but the
+    # waiter's local PendingTask still has the {"status": "ok"}
+    # result baked in.
+    await service._on_task_finished({"status": "ok"})
+    # ``self._pending`` was cleared inside the same lock block as
+    # ``event.set()``, so a stop() coming in here can't mutate the
+    # finished PendingTask's result.
+    assert service._pending is None
+
+    await service.stop()
+
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out == {"status": "ok", "query": "A"}, (
+        "stop() must not have overwritten the task_finished verdict"
+    )
+
+
+@pytest.mark.asyncio
 async def test_execute_completes_when_task_finished_fires():
     service, _ = _make_service()
     service.configure({"task_timeout_seconds": 5.0})

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -679,6 +679,40 @@ async def test_log_connection_lost_clears_all_stale_debt():
 
 
 @pytest.mark.asyncio
+async def test_log_connection_lost_wakes_pending_handler():
+    """If a task is pending when the agent reconnects, its
+    ``task_finished`` will never arrive (agent's task queue was
+    wiped). The handler must be woken with an "interrupted" verdict
+    so it doesn't sit blocked on ``event.wait`` until
+    ``task_timeout_seconds`` expires."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 30.0})
+    service._client = _FakeClient()
+
+    runner = asyncio.create_task(service.execute_minecraft_task(task="long task"))
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("_pending was never set")
+
+    # Pre-bump debt to verify it's also drained.
+    service._stale_task_finishes_to_drop = 2
+
+    await service._on_log("Connection lost and re-established.")
+
+    # Pending was woken with an interrupted verdict.
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out["status"] == "interrupted"
+    assert "connection bounced" in out["reason"].lower()
+    # Slot is free for the next call.
+    assert service._pending is None
+    # Debt drained (agent state is gone).
+    assert service._stale_task_finishes_to_drop == 0
+
+
+@pytest.mark.asyncio
 async def test_log_heuristic_does_not_flip_when_pending_task_active():
     """An old task's late "task run ended" log must not flip
     ``_task_finished`` to True while a new task is in flight —
@@ -704,10 +738,11 @@ async def test_log_heuristic_does_not_flip_when_pending_task_active():
     await service._on_log("task run ended (for some old task)")
     assert service._task_finished is False
     assert service._pending is not None  # still in flight
-
-    # Same for connection-lost log.
-    await service._on_log("Connection lost and re-established.")
-    assert service._task_finished is False
+    # Note: ``Connection lost and re-established.`` intentionally
+    # behaves differently when a task is pending — it wakes the
+    # handler with "interrupted" because the agent's task queue
+    # was wiped. That contract is pinned in
+    # ``test_log_connection_lost_wakes_pending_handler``.
 
     runner.cancel()
     try:

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -331,6 +331,30 @@ async def test_system_prompt_replay_preserves_per_frame_mime():
 
 
 @pytest.mark.asyncio
+async def test_log_cache_is_bounded():
+    """Without a cap, an idle ``skip_system_prompt_if_busy=True`` plus a
+    chatty agent would balloon the log cache without bound. The cap
+    drops oldest lines when full so memory stays flat."""
+    service, _ = _make_service()
+    service.configure({})
+
+    # Push more lines than the cap. The cap is an internal constant
+    # (200 at time of writing); we use a generous multiple so the test
+    # doesn't go stale if the constant grows modestly.
+    cap_estimate = 200
+    overflow_count = cap_estimate * 3
+    for i in range(overflow_count):
+        await service._on_log(f"line {i}")
+
+    cached = list(service._log_cache)
+    # Cap held; we only kept "the most recent N" lines, not all of them.
+    assert len(cached) < overflow_count
+    assert len(cached) <= cap_estimate
+    # And the survivors are the most recent ones, not the oldest.
+    assert cached[-1] == f"line {overflow_count - 1}"
+
+
+@pytest.mark.asyncio
 async def test_log_callback_tracks_task_state_from_strings():
     service, _ = _make_service()
     service.configure({})

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -115,11 +115,32 @@ def test_configure_clamps_invalid_numeric():
         "system_prompt_interval_seconds": -5.0,
         "screenshot_cache_size": "abc",
     })
-    # Bad strings fall back to defaults; negative interval clamps to ≥1.
     status = service.get_status()
     assert status["ws_url"] == "ws://example:1234"
-    # No way to inspect internal _task_timeout from the public API, but
-    # the fact that it didn't raise is the contract.
+    # Bad strings fall back to defaults; negative values clamp to the
+    # documented floor. Inspect the private attributes directly — we
+    # already test against private state throughout this file, and
+    # without these assertions a regression in the fallback or clamp
+    # logic would silently let this test pass.
+    assert service._task_timeout == 25.0  # default
+    assert service._system_prompt_interval == 1.0  # clamped from -5
+    assert service._screenshot_cache_size == 3  # default
+    assert service._reconnect_interval == 5.0  # default
+
+
+def test_configure_clamps_task_timeout_below_sdk_ceiling():
+    """``@llm_tool(timeout=300.0)`` is the SDK wrapper ceiling. The
+    service must clamp configured ``task_timeout_seconds`` *below*
+    that so its structured ``{status: "timeout"}`` response can fire
+    before the wrapper cancels the handler."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 600.0})
+    # Ceiling - small buffer so service-internal fires first.
+    assert service._task_timeout <= 300.0
+    assert service._task_timeout > 0.0
+    # And a normal value passes through.
+    service.configure({"task_timeout_seconds": 90.0})
+    assert service._task_timeout == 90.0
 
 
 # ---------------------------------------------------------------------------
@@ -520,20 +541,22 @@ async def test_log_cache_is_bounded():
     service, _ = _make_service()
     service.configure({})
 
-    # Push more lines than the cap. The cap is an internal constant
-    # (200 at time of writing); we use a generous multiple so the test
-    # doesn't go stale if the constant grows modestly.
-    cap_estimate = 200
-    overflow_count = cap_estimate * 3
+    # Read the actual cap off the deque rather than hardcoding it —
+    # otherwise bumping the constant in the implementation would
+    # spuriously fail this test even when the bounded-growth invariant
+    # is intact.
+    cap = service._log_cache.maxlen
+    assert cap is not None and cap > 0
+    overflow_count = cap * 3
+
     for i in range(overflow_count):
         await service._on_log(f"line {i}")
 
     cached = list(service._log_cache)
-    # Cap held; we only kept "the most recent N" lines, not all of them.
-    assert len(cached) < overflow_count
-    assert len(cached) <= cap_estimate
-    # And the survivors are the most recent ones, not the oldest.
+    assert len(cached) == cap, "cache should be at exactly the maxlen"
+    # Survivors are the most recent ones, not the oldest.
     assert cached[-1] == f"line {overflow_count - 1}"
+    assert cached[0] == f"line {overflow_count - cap}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -238,7 +238,14 @@ async def test_overwrite_interrupts_old_task_with_status():
         if service._pending is not None and service._pending.task_text == "new task":
             break
         await asyncio.sleep(0.01)
-    await service._on_task_finished({"status": "ok"})
+
+    # The agent will (eventually) emit a delayed task_finished for the
+    # *old* task before the new one's frame arrives. Per the FIFO drop
+    # rule, that first frame is swallowed and the new task's frame
+    # resolves the runner.
+    await service._on_task_finished({"status": "ok", "text": "old finished late"})
+    assert service._pending is not None  # still waiting
+    await service._on_task_finished({"status": "ok", "text": "new finished"})
     new_out = await asyncio.wait_for(new_runner, timeout=2.0)
     assert new_out == {"status": "ok", "query": "new task"}
 
@@ -324,3 +331,175 @@ async def test_stop_unblocks_pending_handler():
     out = await asyncio.wait_for(runner, timeout=2.0)
     assert out["status"] == "interrupted"
     assert "shutting down" in out["reason"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Stale task_finished filtering — protocol has no task IDs, so a delayed
+# completion frame for an abandoned task must not be misattributed to the
+# new pending task.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_task_finished_after_timeout_is_dropped():
+    """After a task times out, a delayed task_finished frame for it
+    should be swallowed instead of resolving the *next* call."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 0.1})
+    service._client = _FakeClient()
+
+    # Task A times out — leaves a "stale frame" debt of 1.
+    out_a = await service.execute_minecraft_task(task="task A")
+    assert out_a["status"] == "timeout"
+    assert service._stale_task_finishes_to_drop == 1
+
+    # Late task_finished for A arrives — should be dropped, not
+    # attached to anything.
+    await service._on_task_finished({"status": "ok", "text": "A done late"})
+    assert service._stale_task_finishes_to_drop == 0
+    # No pending task got falsely resolved.
+    assert service._pending is None
+
+
+@pytest.mark.asyncio
+async def test_stale_task_finished_after_overwrite_is_dropped():
+    """After overwrite, a delayed task_finished for the *old* task must
+    not be matched to the *new* pending task (which has its own id-less
+    frame coming later)."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Start old task.
+    old_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="old task")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    # Overwrite — old runner resolves with "interrupted", drop counter += 1.
+    new_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="new task", overwrite=True)
+    )
+    old_out = await asyncio.wait_for(old_runner, timeout=2.0)
+    assert old_out["status"] == "interrupted"
+    assert service._stale_task_finishes_to_drop == 1
+
+    # Wait for the new task's pending slot.
+    for _ in range(50):
+        if service._pending is not None and service._pending.task_text == "new task":
+            break
+        await asyncio.sleep(0.01)
+
+    # Late task_finished for OLD task arrives first — must be dropped,
+    # NOT attached to the new task.
+    await service._on_task_finished({"status": "ok", "text": "old done late"})
+    assert service._stale_task_finishes_to_drop == 0
+    # New task is still pending (drop didn't resolve it).
+    assert service._pending is not None
+    assert service._pending.task_text == "new task"
+
+    # Now the real frame for the new task arrives — should resolve normally.
+    await service._on_task_finished({"status": "ok", "text": "new done"})
+    new_out = await asyncio.wait_for(new_runner, timeout=2.0)
+    assert new_out == {"status": "ok", "query": "new task"}
+
+
+# ---------------------------------------------------------------------------
+# Cancellation cleanup — when the outer SDK timeout cancels the handler,
+# self._pending must not be left dangling.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancellation_clears_pending_slot():
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 30.0})
+    service._client = _FakeClient()
+
+    runner = asyncio.create_task(
+        service.execute_minecraft_task(task="long task")
+    )
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+
+    runner.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await runner
+    assert service._pending is None
+    # And the drop counter was bumped so a delayed frame doesn't bind
+    # to whatever task comes next.
+    assert service._stale_task_finishes_to_drop == 1
+
+
+# ---------------------------------------------------------------------------
+# reload_config_live — transport-affecting keys trigger restart
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reload_config_live_no_restart_when_not_running():
+    """Pure config update before start() — just mutates state, never
+    restarts (because there's nothing to restart)."""
+    service, _ = _make_service()
+    service.configure({"ws_url": "ws://localhost:48909"})
+    restarted = await service.reload_config_live({"ws_url": "ws://localhost:48910"})
+    assert restarted is False
+    assert service.get_status()["ws_url"] == "ws://localhost:48910"
+
+
+@pytest.mark.asyncio
+async def test_reload_config_live_restarts_on_ws_url_change():
+    """When a live client exists and ws_url changes, the service does
+    a stop+start cycle so the new URL takes effect."""
+    service, _ = _make_service()
+    service.configure({"ws_url": "ws://localhost:48909"})
+
+    # Plug a fake "running" state without launching real WS code:
+    # the reload path treats ``self._client is not None`` as "running",
+    # and ``stop()`` / ``start()`` deal with whatever's there.
+    fake_client = _FakeClient()
+    service._client = fake_client
+
+    # Patch start() to track invocations without spinning up a real
+    # WebSocket connection.
+    start_calls: list[str] = []
+
+    async def fake_start():
+        start_calls.append(service._ws_url)
+        service._client = _FakeClient()
+
+    service.start = fake_start  # type: ignore[method-assign]
+
+    restarted = await service.reload_config_live({"ws_url": "ws://example:9999"})
+    assert restarted is True
+    assert start_calls == ["ws://example:9999"]
+    assert service.get_status()["ws_url"] == "ws://example:9999"
+
+
+@pytest.mark.asyncio
+async def test_reload_config_live_no_restart_for_pure_data_keys():
+    """Changing only timeouts / intervals doesn't tear down the
+    transport — those are read on every tick."""
+    service, _ = _make_service()
+    service.configure({"ws_url": "ws://localhost:48909", "task_timeout_seconds": 25.0})
+    service._client = _FakeClient()
+
+    # Track that start() was NOT called.
+    start_calls: list[str] = []
+
+    async def fake_start():
+        start_calls.append(service._ws_url)
+
+    service.start = fake_start  # type: ignore[method-assign]
+
+    restarted = await service.reload_config_live({
+        "ws_url": "ws://localhost:48909",  # unchanged
+        "task_timeout_seconds": 60.0,
+    })
+    assert restarted is False
+    assert start_calls == []

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -896,8 +896,69 @@ async def test_cancellation_during_send_task_clears_pending_slot():
 
     assert service._pending is None
     assert service._task_finished is True
-    # Bumped because we abandoned the task without an ack.
-    assert service._stale_task_finishes_to_drop == 1
+    # NOT bumped — ``send_task`` was cancelled before completing, so
+    # the agent never received the task and won't emit a stale frame
+    # for it. Bumping would silently swallow the next legitimate
+    # ``task_finished`` from a future task.
+    assert service._stale_task_finishes_to_drop == 0
+
+
+@pytest.mark.asyncio
+async def test_overwrite_does_not_bump_drop_counter_for_undispatched_old():
+    """If the OLD task hadn't reached past ``send_task`` yet when
+    overwrite arrives, the agent never received it and won't emit a
+    stale frame. Bumping the drop counter in that case would silently
+    swallow the NEW task's legitimate completion frame.
+
+    We can't observe this directly via the public path (overwrite
+    inside the lock makes the race unreachable in production), but
+    the underlying invariant is: ``_stale_task_finishes_to_drop``
+    increments must gate on ``PendingTask.dispatched``. Verify by
+    pre-seeding an undispatched pending state and overwriting it."""
+    from plugin.plugins.game_agent_minecraft.service import PendingTask
+
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Plant an undispatched pending task in the slot directly. This
+    # simulates the corner where OLD's handler claimed _pending but
+    # was suspended inside ``send_task`` and never returned.
+    fake_old = PendingTask(
+        task_text="undispatched-old",
+        event=asyncio.Event(),
+        start_time=0.0,
+        dispatched=False,
+    )
+    service._pending = fake_old
+    service._task_finished = False
+
+    # New task arrives with overwrite=True — should set old's event,
+    # claim the slot, and crucially NOT bump the drop counter.
+    new_runner = asyncio.create_task(
+        service.execute_minecraft_task(task="new", overwrite=True)
+    )
+
+    # Wait for the new task to claim the slot.
+    for _ in range(50):
+        if service._pending is not None and service._pending is not fake_old:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("new task never claimed the slot")
+
+    # Old task's event was set → its handler would resolve, but we
+    # injected it directly so there's no handler to drain. Just
+    # verify the counter rule.
+    assert service._stale_task_finishes_to_drop == 0, (
+        "must not bump for undispatched abandoned task"
+    )
+
+    # Now drive the agent's task_finished for the new task — it
+    # should resolve normally (NOT be swallowed as stale).
+    await service._on_task_finished({"status": "ok", "text": "new done"})
+    out = await asyncio.wait_for(new_runner, timeout=2.0)
+    assert out == {"status": "ok", "query": "new"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -421,6 +421,47 @@ async def test_stale_task_finished_after_timeout_is_dropped():
 
 
 @pytest.mark.asyncio
+async def test_stale_task_finished_does_not_flip_task_finished_flag():
+    """Dropping a stale frame must not set ``_task_finished = True``,
+    which would leak the abandoned task's completion state into the
+    *current* in-flight task and break the autonomous loop's busy
+    gate."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Start a task → _task_finished flips to False → time it out so we
+    # accumulate a drop.
+    service.configure({"task_timeout_seconds": 0.1})
+    out = await service.execute_minecraft_task(task="A")
+    assert out["status"] == "timeout"
+    assert service._stale_task_finishes_to_drop == 1
+
+    # Start a fresh task — _task_finished is False again (in flight).
+    service.configure({"task_timeout_seconds": 5.0})
+    runner = asyncio.create_task(service.execute_minecraft_task(task="B"))
+    for _ in range(50):
+        if service._pending is not None and service._pending.task_text == "B":
+            break
+        await asyncio.sleep(0.01)
+    assert service._task_finished is False
+
+    # Stale frame for A arrives → must be dropped, must NOT flip
+    # _task_finished to True (B is still running).
+    await service._on_task_finished({"status": "ok", "text": "A done late"})
+    assert service._stale_task_finishes_to_drop == 0
+    assert service._task_finished is False
+    assert service._pending is not None
+    assert service._pending.task_text == "B"
+
+    # Real B completion now flips the flag.
+    await service._on_task_finished({"status": "ok", "text": "B done"})
+    assert service._task_finished is True
+    out_b = await asyncio.wait_for(runner, timeout=2.0)
+    assert out_b == {"status": "ok", "query": "B"}
+
+
+@pytest.mark.asyncio
 async def test_stale_task_finished_after_overwrite_is_dropped():
     """After overwrite, a delayed task_finished for the *old* task must
     not be matched to the *new* pending task (which has its own id-less

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -113,6 +113,64 @@ async def test_execute_returns_not_started_when_no_client():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_race_honors_concurrent_verdict_over_disconnected():
+    """If overwrite/stop/etc. wrote a verdict + set the event during
+    the ``await send_task(...)`` suspension, the handler must surface
+    that verdict instead of returning AGENT_DISCONNECTED — the rest
+    of the system already recorded the task as 'interrupted', so a
+    contradicting AGENT_DISCONNECTED tooltip would be wrong."""
+
+    class _SlowSendClient:
+        is_connected = True
+
+        def __init__(self):
+            self.released = asyncio.Event()
+            self.return_value = False  # simulate "send failed"
+
+        async def send_task(self, task):
+            # Suspend long enough for the test to inject a verdict.
+            await self.released.wait()
+            return self.return_value
+
+        async def stop(self):
+            pass
+
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    slow = _SlowSendClient()
+    service._client = slow
+
+    runner = asyncio.create_task(service.execute_minecraft_task(task="A"))
+
+    # Wait for the handler to claim _pending, then race in: write
+    # an interrupted verdict + set the event, while send_task is
+    # still suspended.
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    my_pending = service._pending
+    assert my_pending is not None
+    my_pending.result = {
+        "status": "interrupted",
+        "query": "A",
+        "reason": "Overwritten by a new task.",
+    }
+    my_pending.event.set()
+
+    # Now release send_task to return False ("disconnected"). Without
+    # the fix, the handler would return AGENT_DISCONNECTED and lose
+    # the interrupted verdict.
+    slow.released.set()
+    out = await asyncio.wait_for(runner, timeout=2.0)
+    assert out == {
+        "status": "interrupted",
+        "query": "A",
+        "reason": "Overwritten by a new task.",
+    }
+
+
+@pytest.mark.asyncio
 async def test_execute_returns_disconnected_when_send_fails():
     service, _ = _make_service()
     service._client = _FakeClient(send_task_returns=False)

--- a/tests/unit/test_game_agent_minecraft_plugin.py
+++ b/tests/unit/test_game_agent_minecraft_plugin.py
@@ -676,6 +676,67 @@ async def test_stale_task_finished_after_timeout_is_dropped():
 
 
 @pytest.mark.asyncio
+async def test_stale_task_finished_with_no_pending_marks_idle():
+    """When a stale frame drops AND there's no current pending task,
+    the agent has genuinely returned to idle. Set ``_task_finished``
+    to True so the autonomous loop knows it can resume nudging —
+    otherwise a flag stuck at False (from before stop()/abandon)
+    would silently keep the busy gate engaged forever."""
+    service, _ = _make_service()
+    service.configure({})
+    # Pre-conditions: a task is "in flight" from the loop's perspective
+    # (flag stuck at False) and we have one pending stale-frame drop
+    # but no actual pending task — the typical post-stop+restart shape.
+    service._stale_task_finishes_to_drop = 1
+    service._task_finished = False
+    assert service._pending is None
+
+    await service._on_task_finished({"status": "ok", "text": "late frame for abandoned task"})
+    assert service._stale_task_finishes_to_drop == 0
+    # Critical: the flag flipped to True even though the frame was
+    # dropped — agent is idle, busy gate must reflect that.
+    assert service._task_finished is True
+
+
+@pytest.mark.asyncio
+async def test_stale_task_finished_with_pending_keeps_flag_false():
+    """Counter-test to the above: when dropping a stale frame WHILE a
+    real task is pending, ``_task_finished`` must stay False (existing
+    invariant — pinned by ``test_stale_task_finished_does_not_flip_…``).
+    Combined with the prior test, this defines the rule: flip on
+    drop only when ``_pending is None``."""
+    service, _ = _make_service()
+    service.configure({"task_timeout_seconds": 5.0})
+    service._client = _FakeClient()
+
+    # Pre-bump drop counter as if a prior task had been abandoned.
+    service._stale_task_finishes_to_drop = 1
+
+    # Now start a fresh task — _pending=B, _task_finished=False.
+    runner = asyncio.create_task(service.execute_minecraft_task(task="B"))
+    for _ in range(50):
+        if service._pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("B never claimed the slot")
+    assert service._task_finished is False
+
+    # Stale drop while B is in flight — must NOT flip the flag.
+    await service._on_task_finished({"status": "ok", "text": "old"})
+    assert service._task_finished is False
+    assert service._pending is not None
+    assert service._pending.task_text == "B"
+
+    runner.cancel()
+    try:
+        await runner
+    except (asyncio.CancelledError, Exception):
+        # Cleanup-only swallow.
+        pass
+
+
+@pytest.mark.asyncio
 async def test_stale_task_finished_does_not_pollute_log_cache():
     """Stale frames must not contribute their text to ``_log_cache``
     either — otherwise the next system prompt would surface "old task


### PR DESCRIPTION
## Summary

把原本硬编码进 `main_logic/core.py` + `main_logic/game_agent_client.py` 的 Minecraft Agent 集成（参见已废弃的 `feat/game-agent-integration` 分支 commit `bca0c5f3`），整体重写成独立插件 `plugin/plugins/game_agent_minecraft/`。所有 game-agent 相关逻辑都封在插件目录下，开关只需在插件管理界面切换。

完全基于近期合并的三个基础设施 PR：

- **#1035**（统一 `ToolRegistry`）—— `minecraft_task` 通过 `@llm_tool` 注册到统一工具表，全 provider 通用，不再绑死 Gemini
- **#1046**（`push_message` v2）—— 截图通过 `parts=[{"type":"image","data":...,"mime":...}]` + `ai_behavior="read"` 推进 main_server，自动走 `stream_image`；自动 nudge 提示通过 `ai_behavior="respond"` 触发 LLM 响应
- **#1055**（`@llm_tool` SDK helper）—— 一行装饰器，注册/卸载/callback 全自动

## 关键设计决策

### 异步 task 完成的 `asyncio.Event` 桥接
原版的"LLM 调用 → agent 执行 → task_finished 帧回填 tool_response"是 OOB 异步流；现在的 `@llm_tool` handler 是同步语义（return = 结果）。桥接方式：handler 创建一个本地 `PendingTask(event=asyncio.Event())`，发送 task 到 WS 后 `await event.wait()`，WS 端的 `_on_task_finished` 回调写 `result` 然后 `event.set()` 唤醒 handler。`task_timeout_seconds`（默认 25s，留 5s buffer 在 LLM 工具默认 30s 超时之下）兜底。

### overwrite 路径的 race-free 语义
handler 持有自己的 `PendingTask` **局部引用**，不读 `self._pending`。这样当一个 overwrite 调用唤醒了老 handler 之后立刻把 `self._pending` 指向新任务时，老 handler 仍能从本地引用读到 overwrite 路径写入的 `{"status": "interrupted", ...}` —— 而不是误读到新任务的空 result。

### `stream_screenshots_to_llm` 双路径
WS 收到截图后既丢进本地 `deque(maxlen=3)` 缓存（给定期 nudge 用），也立即 `push_message` 一份给 main_server，让模型实时看到当前画面。可通过 `[game_agent].stream_screenshots_to_llm = false` 关掉实时流（仅保留缓存）。

## 文件结构

| 文件 | 作用 |
|------|------|
| [\`__init__.py\`](plugin/plugins/game_agent_minecraft/__init__.py) | 插件 facade — `@lifecycle` / `@llm_tool` / 状态查询 entries |
| [\`service.py\`](plugin/plugins/game_agent_minecraft/service.py) | `GameAgentService` — 跨回调状态、event 桥接、nudge 循环 |
| [\`client.py\`](plugin/plugins/game_agent_minecraft/client.py) | `GameAgentClient` — WebSocket 连接 + 自动重连 + 帧分发 |
| [\`plugin.toml\`](plugin/plugins/game_agent_minecraft/plugin.toml) | 清单 + `[game_agent]` 节（ws_url、超时、nudge 间隔等） |
| [\`README.md\`](plugin/plugins/game_agent_minecraft/README.md) | 协议、配置、迁移指南、与原版的差别对比表 |

## 与原版（`bca0c5f3`）的对比

| 项 | 原版 | 现版 |
|----|------|------|
| 工具注册 | 直接拼 Gemini 的 `function_declarations` | `@llm_tool`，统一 ToolRegistry |
| 截图入栈 | `session.send_media_input(bytes, mime)` 直调 | `push_message v2` `parts=[{type:image,data,mime}]` |
| 异步 task 完成 | 自维护 `_game_pending_tool_id` + `session.send_tool_response` | `asyncio.Event` + `@llm_tool` 超时 |
| 自动 nudge | `session.create_response(prompt)` 直调 | `push_message v2` `ai_behavior="respond"` |
| 启用方式 | 改 `core.py` 两个属性 | 在插件管理界面打开开关 |

## Test plan

- [x] `uv run pytest tests/unit/test_game_agent_minecraft_plugin.py` — 13/13 pass，覆盖：
  - configure 防御性解析（缺字段、类型错误回退）
  - execute_minecraft_task 4 种错误路径（INVALID_TASK / NOT_STARTED / AGENT_DISCONNECTED）+ happy path + timeout
  - busy 拒绝（`overwrite=False` 时新调用拿到 `{"result": "busy", ...}`，老 handler 不受影响）
  - overwrite 语义（老 handler 收到 `{status: "interrupted"}`，新 handler 正常 await）
  - 截图回调推 `push_message v2` 的 shape 校验
  - 日志字符串触发 task_finished 状态切换
  - `stop()` unblock 所有 pending handler
- [x] `uv run pytest tests/unit/test_plugin_llm_tool_sdk.py tests/unit/test_game_agent_minecraft_plugin.py tests/unit/test_tool_calling.py` — 69/69 pass（既有 SDK + tool_calling 套件未回归）
- [x] `uv run python -c "from plugin.plugins.game_agent_minecraft import GameAgentMinecraftPlugin; ..."` — 全模块 import 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Minecraft 游戏代理插件：WebSocket 双向桥接、本地任务派发（含 overwrite）、任务超时/中断处理、状态查询与热重载、实时截图流向 LLM 与自动推送提示。
* **文档**
  * 添加中文使用说明，详述消息协议、工具参数与返回形式、配置项与启用/重启行为及自动 nudge 逻辑。
* **测试**
  * 添加全面单元测试，覆盖配置解析、连接管理、并发/覆盖语义、截图/日志缓存与热重载行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->