### PR TITLE
fix(memory): /new_dialog 不再 cancel 在跑的 review + QPS 观测

### DIFF
--- a/memory_server.py
+++ b/memory_server.py
@@ -1190,17 +1190,19 @@ async def _periodic_idle_maintenance_loop():
 
 
 async def _periodic_new_dialog_qps_log_loop():
-    """每 NEW_DIALOG_QPS_FLUSH_INTERVAL 秒输出一次 /new_dialog 调用计数并清零。"""
+    """每 NEW_DIALOG_QPS_FLUSH_INTERVAL 秒输出一次 /new_dialog 调用计数并清零。
+
+    无流量时也打 total=0 心跳——避免静默时无法区分'真零流量'与'loop 已挂'。
+    """
     while True:
         await asyncio.sleep(NEW_DIALOG_QPS_FLUSH_INTERVAL)
-        if _new_dialog_qps_counter:
-            snapshot = dict(_new_dialog_qps_counter)
-            _new_dialog_qps_counter.clear()
-            total = sum(snapshot.values())
-            logger.info(
-                f"[QPS] /new_dialog last {NEW_DIALOG_QPS_FLUSH_INTERVAL}s: "
-                f"total={total} per_char={snapshot}"
-            )
+        snapshot = dict(_new_dialog_qps_counter)
+        _new_dialog_qps_counter.clear()
+        total = sum(snapshot.values())
+        logger.info(
+            f"[QPS] /new_dialog last {NEW_DIALOG_QPS_FLUSH_INTERVAL}s: "
+            f"total={total} per_char={snapshot}"
+        )
 
 
 # memory-evidence-rfc §3.3.6 Reconciler handlers live in

--- a/memory_server.py
+++ b/memory_server.py
@@ -331,6 +331,13 @@ _settle_locks: dict[str, asyncio.Lock] = {}
 # 强引用注册表：防止 fire-and-forget task 被 GC
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
+# /new_dialog QPS 观测：每角色累计调用次数，由 _periodic_new_dialog_qps_log_loop
+# 每 NEW_DIALOG_QPS_FLUSH_INTERVAL 秒打一行 INFO 日志后清零。用于 A 之后观测
+# proactive_chat 路径是否成为 memory_server 真正的负载来源；如不是，则不必再
+# 上 main_server 端缓存（C+ 方案）。
+_new_dialog_qps_counter: dict[str, int] = {}
+NEW_DIALOG_QPS_FLUSH_INTERVAL = 60
+
 # ── 空闲维护相关 ────────────────────────────────────────────────────
 _last_activity_time: datetime = datetime.now()            # 最后一次对话活动时间
 IDLE_CHECK_INTERVAL = 40             # 空闲检查轮询间隔（秒）
@@ -1182,6 +1189,20 @@ async def _periodic_idle_maintenance_loop():
             await asyncio.sleep(IDLE_CHECK_INTERVAL)
 
 
+async def _periodic_new_dialog_qps_log_loop():
+    """每 NEW_DIALOG_QPS_FLUSH_INTERVAL 秒输出一次 /new_dialog 调用计数并清零。"""
+    while True:
+        await asyncio.sleep(NEW_DIALOG_QPS_FLUSH_INTERVAL)
+        if _new_dialog_qps_counter:
+            snapshot = dict(_new_dialog_qps_counter)
+            _new_dialog_qps_counter.clear()
+            total = sum(snapshot.values())
+            logger.info(
+                f"[QPS] /new_dialog last {NEW_DIALOG_QPS_FLUSH_INTERVAL}s: "
+                f"total={total} per_char={snapshot}"
+            )
+
+
 # memory-evidence-rfc §3.3.6 Reconciler handlers live in
 # memory/evidence_handlers.py — imported at module top as
 # `_register_evidence_handlers`. Keeping the handlers in their own module
@@ -1993,6 +2014,7 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
             if EVIDENCE_SIGNAL_CHECK_ENABLED:
                 _spawn_background_task(_periodic_signal_extraction_loop())
             _spawn_background_task(_periodic_archive_sweep_loop())
+            _spawn_background_task(_periodic_new_dialog_qps_log_loop())
             _memory_background_tasks_started = True
 
         # memory-enhancements P2: vector embedding warmup + backfill worker.
@@ -2897,7 +2919,7 @@ async def cancel_correction(lanlan_name: str):
 async def new_dialog(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
     _touch_activity()
-    global correction_tasks, correction_cancel_flags
+    _new_dialog_qps_counter[lanlan_name] = _new_dialog_qps_counter.get(lanlan_name, 0) + 1
 
     # 检查角色是否存在于配置中
     try:
@@ -2910,23 +2932,12 @@ async def new_dialog(lanlan_name: str):
         logger.error(f"检查角色配置失败: {e}")
         return PlainTextResponse("")
 
-    # 等待 /renew 或 /settle 的首轮摘要完成，确保读到最新数据
+    # settle_lock 保留：等 /renew /settle 的首轮摘要完成，读到一致数据。
+    # review 不持此锁，且写盘是「整体引用替换 + fingerprint patch」原子操作，
+    # 与本路径读取无 race；Phase C 已让 review 设计成可与 /process 并行的后台
+    # 任务，/new_dialog 不再 cancel 在跑的 review（之前的 cancel 是 Phase A
+    # 遗留物，会让 review 在活跃会话里几乎永不完成）。
     async with _get_settle_lock(lanlan_name):
-        # 中断正在进行的correction任务
-        if lanlan_name in correction_tasks and not correction_tasks[lanlan_name].done():
-            logger.info(f"🛑 收到new_dialog请求，中断 {lanlan_name} 的correction任务")
-
-            if lanlan_name in correction_cancel_flags:
-                correction_cancel_flags[lanlan_name].set()
-
-            correction_tasks[lanlan_name].cancel()
-            try:
-                await correction_tasks[lanlan_name]
-            except asyncio.CancelledError:
-                logger.info(f"✅ {lanlan_name} 的correction任务已成功中断")
-            except Exception as e:
-                logger.warning(f"⚠️ 中断 {lanlan_name} 的correction任务时出现异常: {e}")
-
         # 正则表达式：删除所有类型括号及其内容（包括[]、()、{}、<>、【】、（）等）
         brackets_pattern = re.compile(r'(\[.*?\]|\(.*?\)|（.*?）|【.*?】|\{.*?\}|<.*?>)')
         master_name, _, _, _, name_mapping, _, _, _, _ = await _config_manager.aget_character_data()

--- a/memory_server.py
+++ b/memory_server.py
@@ -2919,7 +2919,6 @@ async def cancel_correction(lanlan_name: str):
 async def new_dialog(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
     _touch_activity()
-    _new_dialog_qps_counter[lanlan_name] = _new_dialog_qps_counter.get(lanlan_name, 0) + 1
 
     # 检查角色是否存在于配置中
     try:
@@ -2931,6 +2930,10 @@ async def new_dialog(lanlan_name: str):
     except Exception as e:
         logger.error(f"检查角色配置失败: {e}")
         return PlainTextResponse("")
+
+    # 仅对合法角色计数：QPS 观测的目的是评估 C+ 缓存决策，无效请求不构成
+    # cacheable 机会，记进来反而污染 per_char 分布。
+    _new_dialog_qps_counter[lanlan_name] = _new_dialog_qps_counter.get(lanlan_name, 0) + 1
 
     # settle_lock 保留：等 /renew /settle 的首轮摘要完成，读到一致数据。
     # review 不持此锁，且写盘是「整体引用替换 + fingerprint patch」原子操作，


### PR DESCRIPTION
## Summary

修复 history review 在活跃会话里 0% 完成率的死循环：proactive_chat 每 15s 一次 /new_dialog 必杀 in-flight review，导致 \`last_reviewed_cutoff_tail\` 永远落不下来 → Gate 5 永远 ∞ 放行 → spawn-cancel 死循环。

详细排查见 [memory_server.py:2188-2310](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/inspiring-liskov-d06863/memory_server.py#L2188) 的 \`maybe_spawn_review\` / \`_run_review_in_background\` 配套逻辑。

## 根因链

1. /process /renew /settle 在 Phase C 已经不再 cancel review（[commit 4d4b3ab1](https://github.com/Project-N-E-K-O/N.E.K.O/commit/4d4b3ab1)），但 /new_dialog 的 cancel 块是 Phase A 遗留物，没同步删
2. proactive_chat 每 15s POST → /proactive_chat handler 必拉一次 /new_dialog 做 Phase 1 topic 决策
3. /new_dialog 看到 in-flight review 无差别杀
4. review 被 cancel → finally 里不更新 fingerprint → \`_count_new_user_msgs_since_last_review\` 永远 ∞ → Gate 5 永远放行
5. Gate 4（30/60s 间隔）一过就 spawn → /new_dialog 又来 → 杀 → ...

实际日志（修复前）：
\`\`\`
23:15:29 [Review/spawn] 悠怡: 触发 review (history_len=8)
23:15:56 🛑 收到new_dialog请求，中断 悠怡 的correction任务
23:16:09 [Review/spawn] 悠怡: 触发 review (history_len=8)
23:16:36 🛑 收到new_dialog请求，中断 悠怡 的correction任务
... 重复几十轮
\`\`\`

## Why safe to remove cancel

- review 写盘走 \`self.user_histories[name] = new_history\`（[memory/recent.py:704](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/inspiring-liskov-d06863/memory/recent.py#L704)），整体引用替换 + GIL 原子，与 /new_dialog 的 \`aget_recent_history\` 读取无 race
- review 走 fingerprint patch（snapshot 拍下时刻为基准，提交时按 fingerprint 在当前 history 找 cutoff），跟并发 /process 也兼容
- settle_lock 保留——那是给 /renew /settle 首轮摘要用的，与 review cancel 是两件事
- /cancel_correction 显式端点不动（用户手动编辑记忆后立刻生效的合法路径）

最差情况：一次 /new_dialog 拿到的 history 是 review patch 前的版本，下一次 /new_dialog 看到 patch 后的。**今天的行为是 review 永远跑不完**，根本就没有 patch 后的版本，删 cancel 只有改进没有 regression。

## QPS 观测

加每 60s 一次 INFO 日志：
\`\`\`
[QPS] /new_dialog last 60s: total=4 per_char={'悠怡': 4, 'Tian': 0}
\`\`\`

跑一周看 proactive 路径是否真的撑爆 memory_server CPU，再决定要不要做 main_server 端 cache（C+ 方案）。在没 measured 数据前不上 cache——TTL/baseline 对齐有静默 bug 风险，性价比不明。

## Test plan

- [x] \`uv run pytest tests/unit/ -k "memory or review or new_dialog or recent"\` — 88 passed
- [x] 语法检查 \`ast.parse\`
- [ ] 部署后观察日志确认 \`✅ 〈name〉 的记忆整理任务完成\` 正常出现
- [ ] 观察 \`[QPS] /new_dialog\` 日志的实际负载分布

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 增加周期性对话接口调用量（QPS）监控与汇总日志，按角色统计并定期输出使用量（即便无流量也会记录）。

* **改进**
  * 创建新对话时仅记录按角色的请求计数，不再中断或等待后台修正任务；启动时将并行运行该周期性统计任务以保证稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->