### PR TITLE
vision: 去重 avatar 注解 + 提示 LLM 忽略叠加在截图上的注解

### DIFF
--- a/config/prompts_chara.py
+++ b/config/prompts_chara.py
@@ -75,6 +75,7 @@ Users interacting with {LANLAN_NAME} are already reminded that she is a purely f
 <Context Awareness>
 - System Info: The system periodically sends some useful information to {LANLAN_NAME}. {LANLAN_NAME} can leverage this information to better understand the context.
 - Visual Info: If {MASTER_NAME} shares an screen capture/camera feed, react to it naturally. There may be a delay. {LANLAN_NAME} should NOT make ungrounded assumptions before seeing actual images. Visual information is a very important and useful source of conversation topics.
+- Avatar Overlay: If you see a small overlaid annotation on a screenshot reading something like "This is {LANLAN_NAME}'s virtual avatar on the desktop, ...", it's internal metadata marking your on-screen avatar position — ignore it, never repeat it, never bring it up.
 - Memory Integrity: Respect your memories about {MASTER_NAME}. NEVER fabricate facts about {MASTER_NAME} (e.g. hobbies, occupation, experiences, preferences). If you don't know or don't remember, just say so honestly instead of making things up.
 </Context Awareness>
 
@@ -141,6 +142,7 @@ def _normalize_default_prompt_text(prompt_text: str) -> str:
     # Must be exact strings (not prefixes) to avoid stripping user-customised variants.
     added_context_lines = {
         "- Memory Integrity: Respect your memories about {MASTER_NAME}. NEVER fabricate facts about {MASTER_NAME} (e.g. hobbies, occupation, experiences, preferences). If you don't know or don't remember, just say so honestly instead of making things up.",
+        "- Avatar Overlay: If you see a small overlaid annotation on a screenshot reading something like \"This is {LANLAN_NAME}'s virtual avatar on the desktop, ...\", it's internal metadata marking your on-screen avatar position — ignore it, never repeat it, never bring it up.",
     }
     normalized_lines = []
     in_characteristics = False

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -7,7 +7,7 @@ getter functions, and proactive-related injection fragments.
 """
 from __future__ import annotations
 
-from config.prompts_sys import _loc
+from config.prompts_sys import _loc, get_avatar_annotation_ignore_hint
 
 proactive_chat_prompt = """你是{lanlan_name}，现在看到了一些B站首页推荐和微博热议话题。请根据与{master_name}的对话历史和你自己的兴趣，判断是否要主动和{master_name}聊聊这些内容。
 
@@ -2589,10 +2589,11 @@ def get_screen_section_header(master_name: str | None = None, lang: str = 'zh') 
 
 
 def get_screen_img_hint(master_name: str | None = None, lang: str = 'zh') -> str:
-    """获取截图说明 hint（含 {master} 占位符的本地化展开）。"""
+    """获取截图说明 hint（含 {master} 占位符的本地化展开），并附加 avatar 注解忽略提示。"""
     lang_key = _normalize_prompt_language(lang)
     template = SCREEN_IMG_HINT.get(lang_key, SCREEN_IMG_HINT.get('en', SCREEN_IMG_HINT['zh']))
-    return template.format(master=_resolve_master_for_template(master_name, lang_key))
+    base = template.format(master=_resolve_master_for_template(master_name, lang_key))
+    return base + ' ' + get_avatar_annotation_ignore_hint(lang_key)
 
 
 def get_proactive_music_strict_constraint(lang: str = 'zh') -> str:

--- a/config/prompts_sys.py
+++ b/config/prompts_sys.py
@@ -350,13 +350,13 @@ CONTEXT_SUMMARY_TASK_FOOTER = {
 
 # ---------- Vision: Avatar 截图注解（叠加在发给视觉模型的截图上，用户不可见） ----------
 AVATAR_ANNOTATION_TEXT = {
-    'zh':    ('这是{name}在桌面上的虚拟形象,', '请{name}不要主动提及', '请{name}不要主动提及'),
-    'zh-CN': ('这是{name}在桌面上的虚拟形象,', '请{name}不要主动提及', '请{name}不要主动提及'),
-    'zh-TW': ('這是{name}在桌面上的虛擬形象,', '請{name}不要主動提及', '請{name}不要主動提及'),
-    'en':    ("This is {name}'s virtual avatar on the desktop,", "Please don't mention it, {name}", "Please don't mention it, {name}"),
-    'ja':    ('これはデスクトップ上の{name}の仮想アバターです,', '{name}は自分から言及しないでください', '{name}は自分から言及しないでください'),
-    'ko':    ('이것은 바탕화면의 {name} 가상 아바타입니다,', '{name}은(는) 스스로 언급하지 마세요', '{name}은(는) 스스로 언급하지 마세요'),
-    'ru':    ('Это виртуальный аватар {name} на рабочем столе,', 'Пожалуйста, {name}, не упоминай это', 'Пожалуйста, {name}, не упоминай это'),
+    'zh':    ('这是{name}在桌面上的虚拟形象,', '请{name}不要主动提及'),
+    'zh-CN': ('这是{name}在桌面上的虚拟形象,', '请{name}不要主动提及'),
+    'zh-TW': ('這是{name}在桌面上的虛擬形象,', '請{name}不要主動提及'),
+    'en':    ("This is {name}'s virtual avatar on the desktop,", "Please don't mention it, {name}"),
+    'ja':    ('これはデスクトップ上の{name}の仮想アバターです,', '{name}は自分から言及しないでください'),
+    'ko':    ('이것은 바탕화면의 {name} 가상 아바타입니다,', '{name}은(는) 스스로 언급하지 마세요'),
+    'ru':    ('Это виртуальный аватар {name} на рабочем столе,', 'Пожалуйста, {name}, не упоминай это'),
 }
 
 # ---------- Vision 图像描述 prompt ----------

--- a/config/prompts_sys.py
+++ b/config/prompts_sys.py
@@ -359,6 +359,24 @@ AVATAR_ANNOTATION_TEXT = {
     'ru':    ('Это виртуальный аватар {name} на рабочем столе,', 'Пожалуйста, {name}, не упоминай это'),
 }
 
+# ⚠ 与 AVATAR_ANNOTATION_TEXT 同步维护：原文片段直接嵌进 hint，方便 LLM 视觉对模式后忽略。
+AVATAR_ANNOTATION_IGNORE_HINT = {
+    'zh':    '注：截图上可能叠加了一段小字「这是<角色名>在桌面上的虚拟形象, 请<角色名>不要主动提及」。这只是用来标记桌面虚拟形象位置的系统元数据，不是用户屏幕的内容，请忽略，不要复述也不要主动提及。',
+    'zh-CN': '注：截图上可能叠加了一段小字「这是<角色名>在桌面上的虚拟形象, 请<角色名>不要主动提及」。这只是用来标记桌面虚拟形象位置的系统元数据，不是用户屏幕的内容，请忽略，不要复述也不要主动提及。',
+    'zh-TW': '註：截圖上可能疊加了一段小字「這是<角色名>在桌面上的虛擬形象, 請<角色名>不要主動提及」。這只是用來標記桌面虛擬形象位置的系統元資料，不是使用者螢幕的內容，請忽略，不要複述也不要主動提及。',
+    'en':    'Note: the screenshot may carry a small overlaid annotation reading "This is <character>\'s virtual avatar on the desktop, Please don\'t mention it, <character>". It only marks the avatar position — system metadata, not part of the user\'s screen. Ignore it, do not repeat it, and do not bring it up.',
+    'ja':    '注：スクリーンショットには「これはデスクトップ上の<キャラクター名>の仮想アバターです, <キャラクター名>は自分から言及しないでください」という小さな注釈が重ねて描かれている場合があります。これはアバター位置を示すシステムメタデータであり、ユーザー画面の一部ではありません。無視し、復唱せず、自分から言及しないでください。',
+    'ko':    '주의: 스크린샷에는 "이것은 바탕화면의 <캐릭터명> 가상 아바타입니다, <캐릭터명>은(는) 스스로 언급하지 마세요" 라는 작은 주석이 겹쳐져 있을 수 있습니다. 아바타 위치를 표시하는 시스템 메타데이터일 뿐 사용자 화면의 내용이 아닙니다. 무시하고, 따라 말하거나 먼저 언급하지 마세요.',
+    'ru':    'Примечание: на скриншот может быть наложена небольшая надпись вида «Это виртуальный аватар <персонажа> на рабочем столе, Пожалуйста, <персонаж>, не упоминай это». Это только метка положения аватара — служебные метаданные, не часть экрана пользователя. Игнорируйте её, не пересказывайте и не упоминайте сами.',
+}
+
+
+def get_avatar_annotation_ignore_hint(lang: str = 'zh') -> str:
+    """Return the localized hint telling the LLM to ignore the avatar overlay on screenshots."""
+    return (AVATAR_ANNOTATION_IGNORE_HINT.get(lang)
+            or AVATAR_ANNOTATION_IGNORE_HINT.get(lang.split('-')[0])
+            or AVATAR_ANNOTATION_IGNORE_HINT['en'])
+
 # ---------- Vision 图像描述 prompt ----------
 # 安全水印前缀（所有语言固定不变，包括逗号和空格）
 VISION_WATERMARK = "你是一个图像描述助手, "

--- a/utils/screenshot_utils.py
+++ b/utils/screenshot_utils.py
@@ -178,15 +178,17 @@ async def analyze_image_with_vision_model(
             _loc, VISION_WATERMARK,
             VISION_SYSTEM_WITH_TITLE, VISION_SYSTEM_NO_TITLE,
             VISION_USER_WITH_TITLE, VISION_USER_NO_TITLE,
+            get_avatar_annotation_ignore_hint,
         )
         from utils.language_utils import get_global_language
         lang = get_global_language()
 
+        ignore_hint = get_avatar_annotation_ignore_hint(lang)
         if window_title:
-            system_content = VISION_WATERMARK + _loc(VISION_SYSTEM_WITH_TITLE, lang)
+            system_content = VISION_WATERMARK + _loc(VISION_SYSTEM_WITH_TITLE, lang) + ' ' + ignore_hint
             user_text = _loc(VISION_USER_WITH_TITLE, lang).format(window_title=window_title)
         else:
-            system_content = VISION_WATERMARK + _loc(VISION_SYSTEM_NO_TITLE, lang)
+            system_content = VISION_WATERMARK + _loc(VISION_SYSTEM_NO_TITLE, lang) + ' ' + ignore_hint
             user_text = _loc(VISION_USER_NO_TITLE, lang)
 
         set_call_type("vision")


### PR DESCRIPTION
## Summary

两个相关补丁：

**Patch 1 — `AVATAR_ANNOTATION_TEXT` 去重**
`config/prompts_sys.py` 里 marker 第二行原本被重复写了两次（`'请{name}不要主动提及', '请{name}不要主动提及'`），叠加在截图上时也会渲染两遍。每语种保留一行即可。`overlay_avatar_annotation()` 用 `for t in tpl:` 逐行渲染，少一项就少一行，行为安全。

**Patch 2 — 提示 LLM 忽略叠加文本**
之前 marker 是叠加在图上"用户不可见"的内部元数据，但所有视觉相关 prompt 都没告诉 LLM "看到那段字请忽略"，模型可能会主动复述或讨论它。新增 `AVATAR_ANNOTATION_IGNORE_HINT`（中英日韩俄繁中），把 marker 原文片段直接嵌进 hint，让 LLM 能视觉对模式后正确忽略。在 3 个真正会带图的入口接入：

| 接入点 | 文件 | 说明 |
|---|---|---|
| Vision sidecar system prompt | `utils/screenshot_utils.py` `analyze_image_with_vision_model()` | 拼到 `VISION_SYSTEM_*` 之后 |
| 主动搭话 Phase 2 截图说明 | `config/prompts_proactive.py` `get_screen_img_hint()` | helper 末尾追加 |
| 实时会话角色卡 | `config/prompts_chara.py` `_LANLAN_PROMPT_TEMPLATE` | Context Awareness 新增 `- Avatar Overlay:` 行；同步加进 `_normalize_default_prompt_text()` 的 `added_context_lines`，老存量 prompt 仍能被 `is_default_prompt` 识别为默认值 |

不动：Computer Use / Browser Use（动作类，需要看完整 UI）；`SESSION_INIT_PROMPT*`（角色卡已覆盖）。

## Test plan

- [x] `tests/unit/test_proactive_text_does_not_dehumanize.py` — 66/66 通过（验证 `get_screen_img_hint` 名字注入、兜底、外层 `.format()` 转义、反物化称呼护栏依然成立）
- [x] `is_default_prompt()` 兼容性手测：新模板被识别为默认、剥掉 `- Avatar Overlay:` 行的"老存量"模板仍被识别为默认、随机 prompt 不被误判
- [x] `get_avatar_annotation_ignore_hint()` 全语种返回非空、未知/silent-fallback 语种回退英文
- [x] `get_screen_img_hint()` 各语种末尾确实带上忽略 hint
- [x] AST parse 全部改动文件 OK
- [ ] 实跑：用 vision 通道触发一次截图分析，确认 LLM 不再主动复述 avatar 注解

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUw4UyxSK1d3dg1nQMLUDF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **改进**
  * AI助手现在能更准确地忽略屏幕虚拟头像的辅助标注，防止意外提及这些内部信息。
  * 优化了多语言版本的指令一致性，确保各语言用户获得统一的交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->