### PR TITLE
Fix storage-root log placement

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -211,55 +211,11 @@ button * {
     /* 按钮内部元素不响应事件，由按钮本身处理 */
 }
 
-#restart-home-tutorial-btn {
-    position: fixed;
-    right: 20px;
-    bottom: 20px;
-    z-index: 100010;
-    pointer-events: auto;
-    border: 0;
-    border-radius: 999px;
-    padding: 10px 16px;
-    background: rgba(20, 24, 36, 0.88);
-    color: #fff;
-    font-size: 13px;
-    font-weight: 600;
-    line-height: 1;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
-    -webkit-backdrop-filter: blur(8px);
-    backdrop-filter: blur(8px);
-    cursor: pointer;
-    transition: transform 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-#restart-home-tutorial-btn:hover {
-    background: rgba(38, 44, 62, 0.94);
-    transform: translateY(-1px);
-    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.28);
-}
-
-#restart-home-tutorial-btn:active {
-    transform: translateY(0);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.22);
-}
-
-#restart-home-tutorial-btn:focus-visible {
-    outline: 2px solid rgba(255, 255, 255, 0.9);
-    outline-offset: 2px;
-}
-
 /* 响应式设计 */
 @media (max-width: 480px) {
     .container {
         width: 100%;
         height: 100%;
-    }
-
-    #restart-home-tutorial-btn {
-        right: 12px;
-        bottom: 12px;
-        padding: 9px 14px;
-        font-size: 12px;
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,9 +56,6 @@
 
     <!-- Status 气泡框 -->
     <div id="status-toast"></div>
-    <button type="button" id="restart-home-tutorial-btn" onclick="restartCurrentTutorial()">
-        重启新手教程
-    </button>
     <div id="chat-container">
         <div id="chat-header">
             <img src="/static/icons/chat_icon.png" data-i18n-alt="chat.title" alt="对话" style="width: 28px; height: 28px; object-fit: contain; margin-right: 6px; vertical-align: middle; image-rendering: -webkit-optimize-contrast; image-rendering: crisp-edges;">

--- a/tests/unit/test_logger_config_storage_root.py
+++ b/tests/unit/test_logger_config_storage_root.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_logger_config_prefers_selected_storage_root_for_new_logs(tmp_path, monkeypatch):
+    from utils.logger_config import RobustLoggerConfig
+
+    selected_root = tmp_path / "selected-root"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(selected_root))
+
+    config = RobustLoggerConfig(service_name="Main")
+
+    assert Path(config.get_log_directory_path()) == selected_root / "logs"
+    assert Path(config.get_log_file_path()).parent == selected_root / "logs"
+
+
+@pytest.mark.unit
+def test_logger_config_keeps_plugin_logs_under_selected_storage_root(tmp_path, monkeypatch):
+    from utils.logger_config import RobustLoggerConfig
+
+    selected_root = tmp_path / "selected-root"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(selected_root))
+
+    config = RobustLoggerConfig(service_name="Plugin_demo", log_subdir="plugin")
+
+    assert Path(config.get_log_directory_path()) == selected_root / "logs" / "plugin"
+    assert Path(config.get_log_file_path()).parent == selected_root / "logs" / "plugin"
+
+
+@pytest.mark.unit
+def test_plugin_log_reader_uses_selected_storage_root(tmp_path, monkeypatch):
+    from plugin.server.logs import SERVER_LOG_ID, get_plugin_log_dir
+
+    selected_root = tmp_path / "selected-root"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(selected_root))
+
+    assert get_plugin_log_dir(SERVER_LOG_ID) == selected_root / "logs"
+    assert get_plugin_log_dir("demo") == selected_root / "logs" / "plugin"

--- a/utils/logger_config.py
+++ b/utils/logger_config.py
@@ -35,6 +35,8 @@ from datetime import datetime, timedelta
 
 from config import APP_NAME
 
+NEKO_STORAGE_SELECTED_ROOT_ENV = "NEKO_STORAGE_SELECTED_ROOT"
+
 
 def _get_application_root() -> Path:
     if getattr(sys, "frozen", False):
@@ -49,6 +51,21 @@ def _get_writable_application_directory() -> Path:
     if getattr(sys, "frozen", False):
         return Path(sys.executable).resolve().parent
     return _get_application_root()
+
+
+def _get_selected_storage_root_from_env() -> Path | None:
+    raw_root = str(os.environ.get(NEKO_STORAGE_SELECTED_ROOT_ENV) or "").strip()
+    if not raw_root:
+        return None
+
+    try:
+        selected_root = Path(raw_root).expanduser()
+    except Exception:
+        return None
+
+    if not selected_root.is_absolute():
+        return None
+    return selected_root
 
 
 class RobustLoggerConfig:
@@ -111,16 +128,27 @@ class RobustLoggerConfig:
         """
         获取合适的日志目录
         优先级：
-        1. 用户文档目录/{APP_NAME}/logs（我的文档，默认首选）
-        2. 应用程序所在目录/logs
-        3. 用户数据目录（AppData等）
-        4. 用户主目录
-        5. 临时目录（最后的降级选项）
+        1. 已选择的运行时存储目录/logs（由启动器通过环境变量注入）
+        2. 用户文档目录/{APP_NAME}/logs（兼容旧版本和直接运行）
+        3. 应用程序所在目录/logs
+        4. 用户数据目录（AppData等）
+        5. 用户主目录
+        6. 临时目录（最后的降级选项）
         
         Returns:
             Path: 日志目录路径
         """
-        # 尝试1: 使用用户文档目录（我的文档，默认首选！）
+        # 尝试1: 使用当前存储根目录。老日志不迁移；新日志跟随新根目录。
+        try:
+            selected_root = _get_selected_storage_root_from_env()
+            if selected_root is not None:
+                log_dir = selected_root / "logs"
+                if self._test_directory_writable(log_dir):
+                    return log_dir
+        except Exception as e:
+            print(f"Warning: Failed to use selected storage log directory: {e}", file=sys.stderr)
+
+        # 尝试2: 使用用户文档目录（兼容旧版本和非 launcher 直接运行）
         try:
             docs_dir = self._get_documents_directory()
             # 使用配置的应用名称目录


### PR DESCRIPTION
- Route new runtime logs to the selected storage root via NEKO_STORAGE_SELECTED_ROOT.

- Keep old logs unmigrated while preserving fallback log locations.

- Cover logger writer and plugin log reader paths with unit tests.

- Remove the homepage restart tutorial button markup and styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了环境变量配置支持，允许自定义日志目录位置。

* **测试**
  * 新增单元测试以验证日志目录配置功能。

* **其他**
  * 移除了教程重启按钮。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->