### PR TITLE
feat(embeddings): int8-first bundle, merged deps, explicit fp32

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,9 +112,10 @@ jobs:
         shell: bash
         run: |
           uv venv .venv
-          # Pull the optional `embeddings` extra (onnxruntime + tokenizers) so
-          # both the build-time prepare step and the bundled runtime have them.
-          uv sync --extra embeddings
+          # Embedding runtime deps (onnxruntime, tokenizers, py-cpuinfo) are
+          # in [project.dependencies] now — plain `uv sync` covers both the
+          # build-time prepare step and the bundled runtime.
+          uv sync
           uv pip install --python .venv nuitka ordered-set zstandard
 
       # --- Generate runtime config files (not tracked in git) ---

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1393,7 +1393,7 @@ EVIDENCE_PROMOTION_MERGE_MODEL_TIER = "correction"  # Promote 合并决策
 # level (drop the model file → on; remove it → off) without a config edit.
 VECTORS_ENABLED = True                       # master kill switch
 VECTORS_EMBEDDING_DIM = "auto"               # "auto" | 32/64/128/256/512/768
-VECTORS_QUANTIZATION = "auto"                # "auto" | "int8" | "fp32"
+VECTORS_QUANTIZATION = "auto"                # "auto" | "int8" | "fp32" (fp32 needs model.onnx on disk)
 VECTORS_MIN_RAM_GB = 4.0                     # below this → disabled regardless
 VECTORS_MODEL_PROFILE_ID = "local-text-retrieval-v1"  # anonymous profile id + local model folder
 # Warmup: the ONNX session (~150 MB unpack) loads on first triggering

--- a/docs/deployment/embedding-models.md
+++ b/docs/deployment/embedding-models.md
@@ -10,10 +10,10 @@ Do not store the concrete upstream model name in config or memory cache fields. 
 
 ## Development Setup
 
-Install the optional runtime dependencies:
+Install project dependencies (includes `onnxruntime`, `tokenizers`, and `py-cpuinfo`):
 
 ```bash
-uv sync --extra embeddings
+uv sync
 ```
 
 Download model files into the anonymous profile folder. This example mirrors a Hugging Face ONNX repository into `data/embedding_models/local-text-retrieval-v1/`:

--- a/docs/ja/deployment/embedding-models.md
+++ b/docs/ja/deployment/embedding-models.md
@@ -10,10 +10,10 @@ local-text-retrieval-v1
 
 ## 開発環境の準備
 
-オプションの実行時依存関係をインストールします：
+プロジェクト依存関係をインストールします（`onnxruntime` / `tokenizers` / `py-cpuinfo` を含む）：
 
 ```bash
-uv sync --extra embeddings
+uv sync
 ```
 
 モデルファイルを匿名 profile フォルダにダウンロードします。以下の例は Hugging Face の ONNX リポジトリを `data/embedding_models/local-text-retrieval-v1/` にミラーします：

--- a/docs/zh-CN/deployment/embedding-models.md
+++ b/docs/zh-CN/deployment/embedding-models.md
@@ -10,10 +10,10 @@ local-text-retrieval-v1
 
 ## 开发环境准备
 
-安装可选的运行时依赖：
+安装项目主依赖（已包含 `onnxruntime`、`tokenizers`、`py-cpuinfo`）：
 
 ```bash
-uv sync --extra embeddings
+uv sync
 ```
 
 把模型文件下载到匿名 profile 目录。下面的示例将一个 Hugging Face ONNX 仓库镜像到 `data/embedding_models/local-text-retrieval-v1/`：

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -149,8 +149,11 @@ def detect_avx_vnni_details() -> tuple[bool, bool]:
     try:
         import cpuinfo  # type: ignore
         flags = cpuinfo.get_cpu_info().get("flags", []) or []
-        has = any("vnni" in f for f in flags)
-        return has, True
+        # Empty flags (e.g. some virtualised hosts) is *not* a confirmed
+        # absence — fall through so /proc/cpuinfo can have a try.
+        if flags:
+            has = any("vnni" in f for f in flags)
+            return has, True
     except Exception:
         pass
 

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -15,7 +15,12 @@ zero-cost if any of the following holds:
   * the ONNX model file is missing on disk
   * detected RAM < ``VECTORS_MIN_RAM_GB``
   * the user set ``VECTORS_ENABLED = False``
+  * ``auto`` quantization when AVX-VNNI is **confirmed absent** (no INT8
+    fast-path; default installs omit the large FP32 ONNX bundle — operators
+    who need vectors then pin ``int8`` or ship FP32 weights + ``fp32``)
   * loading or any per-call inference raised an exception (sticky disable)
+
+Explicit ``fp32`` loads ``model.onnx`` when present (manual / optional bundle).
 
 When disabled, ``is_available()`` returns False; callers MUST check it
 before invoking ``embed()`` / ``embed_batch()`` and fall back to the
@@ -88,6 +93,9 @@ class _DisableReason(enum.Enum):
     # the install commands diverge.
     NO_TOKENIZERS = "tokenizers_not_importable"
     NO_MODEL_FILE = "model_file_missing"
+    # Default bundle is INT8; ``auto`` picks INT8 only when VNNI is present or
+    # detection is inconclusive — confirmed absence disables local vectors.
+    AVX_VNNI_REQUIRED_FOR_INT8 = "avx_vnni_required_for_int8_bundle"
     LOW_RAM = "ram_below_threshold"
     LOAD_ERROR = "load_raised"
     INFERENCE_ERROR = "inference_raised"
@@ -123,28 +131,26 @@ def detect_total_ram_gb() -> float | None:
         return None
 
 
-def detect_avx_vnni() -> bool:
-    """Best-effort AVX-VNNI detection.
+def detect_avx_vnni_details() -> tuple[bool, bool]:
+    """Return ``(has_vnni, vnni_absence_confirmed)``.
 
-    Why this matters: INT8 quantized inference on a CPU without VNNI
-    instructions is *slower* than FP32, not faster — the dequantization
-    cost dominates without the dot-product fast path. So when we can't
-    confirm VNNI, we degrade INT8 → FP32 rather than ship a slower
-    inference path silently.
+    When ``vnni_absence_confirmed`` is False we could not read CPU flags
+    (should be rare now that ``py-cpuinfo`` is a required dependency).
+    ``auto`` quantization
+    still selects INT8 in that case — we only skip vectors when we are
+    *confident* the CPU lacks AVX-VNNI (INT8 would be slow and FP32 weights
+    are not shipped).
 
     Detection priority:
-      1. ``py-cpuinfo`` if installed — most accurate, cross-platform
-      2. ``/proc/cpuinfo`` parse on Linux — no extra dep
-      3. Conservative ``False`` on Windows/macOS without py-cpuinfo
-
-    The conservative default trades a small perf loss on capable
-    machines for safety on uncertain ones; users who know their hardware
-    can pin ``VECTORS_QUANTIZATION = "int8"`` to override.
+      1. ``py-cpuinfo``
+      2. ``/proc/cpuinfo`` on Linux
+      3. Otherwise inconclusive → ``(False, False)``
     """
     try:
         import cpuinfo  # type: ignore
         flags = cpuinfo.get_cpu_info().get("flags", []) or []
-        return any("vnni" in f for f in flags)
+        has = any("vnni" in f for f in flags)
+        return has, True
     except Exception:
         pass
 
@@ -153,12 +159,18 @@ def detect_avx_vnni() -> bool:
             with open("/proc/cpuinfo", encoding="utf-8") as f:
                 for line in f:
                     if line.startswith("flags") and "vnni" in line:
-                        return True
-            return False
+                        return True, True
+            return False, True
         except Exception:
-            return False
+            return False, False
 
-    return False
+    return False, False
+
+
+def detect_avx_vnni() -> bool:
+    """Backward-compatible: whether AVX-VNNI was detected."""
+    has_vnni, _confirmed = detect_avx_vnni_details()
+    return has_vnni
 
 
 def resolve_dim_for_ram(ram_gb: float | None) -> int | None:
@@ -207,28 +219,41 @@ def _coerce_dim(value, ram_gb: float | None) -> int | None:
     return as_int
 
 
-def _resolve_quantization(value: str, has_vnni: bool) -> str:
-    """Map "auto"/"int8"/"fp32" to the actual mode after VNNI gating.
+def _resolve_quantization(
+    value: str | None,
+    has_vnni: bool,
+    *,
+    vnni_absence_confirmed: bool = True,
+) -> str | None:
+    """Map ``\"auto\"`` / ``\"int8\"`` / ``\"fp32\"`` after VNNI policy.
 
-    "auto" becomes "int8" only when VNNI is present; otherwise FP32.
-    Explicit "int8" without VNNI is honoured with a warning — the user
-    asked for it, and a wrong configuration is still preferable to a
-    silent override the user can't see in the log.
+    Returns ``\"int8\"``, ``\"fp32\"``, or ``None``. ``None`` means local
+    embeddings are off for ``auto`` when AVX-VNNI is confidently absent.
+    Explicit ``\"fp32\"`` always loads the FP32 ONNX when files exist.
+
+    Explicit ``\"int8\"`` without VNNI is still honoured (with a warning)
+    so operators can force INT8 on slow CPUs if they accept the cost.
     """
+    if value == "fp32":
+        return "fp32"
     if value == "auto" or value is None:
-        return "int8" if has_vnni else "fp32"
+        if has_vnni:
+            return "int8"
+        if not vnni_absence_confirmed:
+            return "int8"
+        return None
     if value not in ("int8", "fp32"):
-        logger.warning(
-            "EmbeddingService: invalid quantization=%r, falling back to auto",
-            value,
-        )
-        return "int8" if has_vnni else "fp32"
+        if has_vnni:
+            return "int8"
+        if not vnni_absence_confirmed:
+            return "int8"
+        return None
     if value == "int8" and not has_vnni:
         logger.warning(
             "EmbeddingService: int8 requested but AVX-VNNI not detected — "
-            "expect slower inference than fp32",
+            "expect slower inference than a hypothetical fp32 build",
         )
-    return value
+    return "int8"
 
 
 def build_model_id(profile: str, dim: int, quantization: str) -> str:
@@ -264,12 +289,10 @@ def _profile_is_complete(
     load.
 
     ``quantization`` lets callers narrow the variant requirement to the
-    one ``_load_session_blocking`` will actually open. Without it, an
-    app-data profile that only contains fp32 files would satisfy this
-    check even when the runtime resolved to int8 — selecting that dir
-    would then sticky-disable vectors at load even if a complete int8
-    bundle is sitting on disk. Pass ``None`` only when the runtime
-    quantization isn't decided yet (e.g. early bootstrap smoke tests).
+    one ``_load_session_blocking`` will actually open. With ``None``, only
+    the shipped INT8 variant is considered complete — so a legacy fp32-only
+    app-data tree does not mask a good bundled int8 profile. Pass ``None``
+    only when the runtime quantization is not yet pinned to a single file.
 
     Why stricter than ``_profile_exists``: a half-downloaded or partially
     deleted app-data profile would otherwise satisfy the existence check,
@@ -287,7 +310,8 @@ def _profile_is_complete(
     elif quantization == "fp32":
         stems = ("model.onnx",)
     else:
-        stems = ("model.onnx", "model_quantized.onnx")
+        # Only the INT8 bundle is shipped; fp32 ONNX is optional / omitted.
+        stems = ("model_quantized.onnx",)
     for stem in stems:
         model_path = os.path.join(profile_dir, "onnx", stem)
         sidecar_path = model_path + "_data"
@@ -377,6 +401,7 @@ class EmbeddingService:
         profile_id: str = DEFAULT_VECTORS_MODEL_PROFILE_ID,
         ram_gb: float | None = None,        # injected for tests
         has_vnni: bool | None = None,       # injected for tests
+        vnni_absence_confirmed: bool | None = None,  # False = inconclusive detect
     ) -> None:
         self._model_dir = model_dir
         self._enabled = enabled
@@ -389,9 +414,29 @@ class EmbeddingService:
         # even before the session loads — callers reading
         # embedding_model_id at write time need a stable id.
         self._ram_gb = ram_gb if ram_gb is not None else detect_total_ram_gb()
-        self._has_vnni = has_vnni if has_vnni is not None else detect_avx_vnni()
+        if has_vnni is not None:
+            self._has_vnni = has_vnni
+            self._vnni_absence_confirmed = (
+                True if vnni_absence_confirmed is None else vnni_absence_confirmed
+            )
+        else:
+            detected_vnni, absence_confirmed = detect_avx_vnni_details()
+            self._has_vnni = detected_vnni
+            self._vnni_absence_confirmed = absence_confirmed
         self._dim = _coerce_dim(embedding_dim_setting, self._ram_gb)
-        self._quantization = _resolve_quantization(quantization_setting, self._has_vnni)
+        if quantization_setting not in ("auto", "int8", "fp32"):
+            logger.warning(
+                "EmbeddingService: invalid quantization=%r, falling back to auto",
+                quantization_setting,
+            )
+            norm_quant = "auto"
+        else:
+            norm_quant = quantization_setting
+        self._quantization = _resolve_quantization(
+            norm_quant,
+            self._has_vnni,
+            vnni_absence_confirmed=self._vnni_absence_confirmed,
+        )
 
         self._state = EmbeddingState.INIT
         self._disable_reason = _DisableReason.NONE
@@ -411,6 +456,8 @@ class EmbeddingService:
             # for any band — defensive double-check; LOW_RAM should have
             # caught it already.
             self._mark_disabled(_DisableReason.LOW_RAM, log=False)
+        elif self._quantization is None:
+            self._mark_disabled(_DisableReason.AVX_VNNI_REQUIRED_FOR_INT8, log=True)
 
     # ── public API ────────────────────────────────────────────────────
 
@@ -433,14 +480,18 @@ class EmbeddingService:
         """Canonical id stamped into ``embedding_model_id`` cache fields.
         Returns None when the service is permanently DISABLED — callers
         should not write embedding rows in that case."""
-        if self._state == EmbeddingState.DISABLED or self._dim is None:
+        if (
+            self._state == EmbeddingState.DISABLED
+            or self._dim is None
+            or self._quantization not in ("int8", "fp32")
+        ):
             return None
         return build_model_id(self._profile_id, self._dim, self._quantization)
 
     def dim(self) -> int | None:
         return self._dim
 
-    def quantization(self) -> str:
+    def quantization(self) -> str | None:
         return self._quantization
 
     def ram_gb(self) -> float | None:
@@ -542,17 +593,14 @@ class EmbeddingService:
     def _model_file_path(self) -> str:
         """Resolve the on-disk ONNX file path for the active quantization.
 
-        Layout mirrors the task-specific ONNX repository export:
-        ``<model_dir>/<profile_id>/onnx/model.onnx`` (fp32) or
-        ``model_quantized.onnx`` (int8), plus a root-level
-        ``tokenizer.json``. Files are NOT bundled with the repo — they're
-        either downloaded by an external bootstrapper or dropped in by the
-        user. Missing files are a non-fatal disable reason, not a startup
-        error.
+        Layout mirrors the Hugging Face ONNX export:
+        ``onnx/model_quantized.onnx`` (int8) or ``onnx/model.onnx`` (fp32),
+        each with a matching ``*_data`` sidecar, plus ``tokenizer.json``.
         """
         filename = (
-            "model_quantized.onnx"
-            if self._quantization == "int8" else "model.onnx"
+            "model.onnx"
+            if self._quantization == "fp32"
+            else "model_quantized.onnx"
         )
         return os.path.join(
             self._model_dir, self._profile_id, "onnx", filename,
@@ -739,24 +787,34 @@ def _build_default_service() -> EmbeddingService:
     # Resolve quantization here so _select_model_dir can require the exact
     # variant ``_load_session_blocking`` will open. Without this, an app-data
     # profile that only contains the *other* variant would still satisfy the
-    # completeness check and short-circuit a complete bundled fallback. We
-    # pass the already-resolved value (and detected has_vnni) into the ctor
-    # so its own _resolve_quantization call is a no-op and doesn't double-log.
-    has_vnni = detect_avx_vnni()
-    resolved_quantization = _resolve_quantization(VECTORS_QUANTIZATION, has_vnni)
+    # completeness check and short-circuit a complete bundled fallback.
+    has_vnni, vnni_absence_confirmed = detect_avx_vnni_details()
+    norm_q = (
+        VECTORS_QUANTIZATION
+        if VECTORS_QUANTIZATION in ("auto", "int8", "fp32")
+        else "auto"
+    )
+    resolved_quantization = _resolve_quantization(
+        norm_q, has_vnni, vnni_absence_confirmed=vnni_absence_confirmed,
+    )
 
-    model_dir = _select_model_dir(
-        app_docs_model_dir, VECTORS_MODEL_PROFILE_ID, resolved_quantization,
+    model_dir = (
+        app_docs_model_dir
+        if resolved_quantization is None
+        else _select_model_dir(
+            app_docs_model_dir, VECTORS_MODEL_PROFILE_ID, resolved_quantization,
+        )
     )
 
     return EmbeddingService(
         model_dir=model_dir,
         enabled=VECTORS_ENABLED,
         embedding_dim_setting=VECTORS_EMBEDDING_DIM,
-        quantization_setting=resolved_quantization,
+        quantization_setting=VECTORS_QUANTIZATION,
         min_ram_gb=VECTORS_MIN_RAM_GB,
         profile_id=VECTORS_MODEL_PROFILE_ID,
         has_vnni=has_vnni,
+        vnni_absence_confirmed=vnni_absence_confirmed,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,11 @@ dependencies = [
   # utils/tokenize.py and wires render-time counting.
   "tiktoken>=0.7.0",
   "cachetools>=5.3",
-]
-
-[project.optional-dependencies]
-embeddings = [
+  # Local memory embeddings (memory/embeddings.py): ONNX + tokenizer + CPU flags
   "onnxruntime",
   "tokenizers",
+  "py-cpuinfo>=9.0.0",
 ]
-
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ aiohttp==3.13.3
     #   dashscope
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via typer
 annotated-types==0.7.0
     # via pydantic
 ansicon==1.89.0 ; sys_platform == 'win32'
@@ -92,6 +94,7 @@ click==8.2.1
     #   audiolab
     #   browser-use
     #   pyrnnoise
+    #   typer
     #   uvicorn
 cloudpickle==3.1.2
     # via browser-use
@@ -130,12 +133,18 @@ editor==1.6.6
     # via inquirer
 fastapi==0.115.14
     # via n-e-k-o
+filelock==3.29.0
+    # via huggingface-hub
+flatbuffers==25.12.19
+    # via onnxruntime
 fonttools==4.61.0
     # via matplotlib
 frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
+fsspec==2026.3.0
+    # via huggingface-hub
 google-api-core==2.29.0
     # via
     #   browser-use
@@ -172,6 +181,8 @@ h11==0.16.0
     #   uvicorn
 h2==4.3.0
     # via httpx
+hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+    # via huggingface-hub
 hpack==4.1.0
     # via h2
 httpcore==1.0.9
@@ -189,6 +200,7 @@ httpx==0.28.1
     #   google-genai
     #   googletrans
     #   groq
+    #   huggingface-hub
     #   mcp
     #   n-e-k-o
     #   ollama
@@ -196,6 +208,8 @@ httpx==0.28.1
     #   pyncm-async
 httpx-sse==0.4.3
     # via mcp
+huggingface-hub==1.12.0
+    # via tokenizers
 humanize==4.14.0
     # via audiolab
 hyperframe==6.1.0
@@ -255,6 +269,7 @@ numpy==1.26.4
     #   contourpy
     #   matplotlib
     #   n-e-k-o
+    #   onnxruntime
     #   pyrnnoise
     #   soundfile
     #   soxr
@@ -262,6 +277,8 @@ oauthlib==3.3.1
     # via requests-oauthlib
 ollama==0.6.1
     # via browser-use
+onnxruntime==1.25.0
+    # via n-e-k-o
 openai==2.8.1
     # via
     #   browser-use
@@ -272,7 +289,9 @@ ormsgpack==1.12.2
     # via n-e-k-o
 packaging==25.0
     # via
+    #   huggingface-hub
     #   matplotlib
+    #   onnxruntime
     #   pytesseract
 pfzy==0.3.4
     # via inquirerpy
@@ -304,11 +323,14 @@ protobuf==6.33.5
     # via
     #   google-api-core
     #   googleapis-common-protos
+    #   onnxruntime
     #   proto-plus
 psutil==7.2.2
     # via
     #   browser-use
     #   n-e-k-o
+py-cpuinfo==9.0.0
+    # via n-e-k-o
 pyasn1==0.6.1
     # via
     #   pyasn1-modules
@@ -1116,7 +1138,9 @@ pywin32==311 ; sys_platform == 'win32'
 pywinauto==0.6.9 ; sys_platform == 'win32'
     # via n-e-k-o
 pyyaml==6.0.2
-    # via bilibili-api-python
+    # via
+    #   bilibili-api-python
+    #   huggingface-hub
 pyzmq==27.1.0
     # via n-e-k-o
 qrcode==8.2
@@ -1153,7 +1177,9 @@ requests==2.32.5
 requests-oauthlib==2.0.0
     # via google-auth-oauthlib
 rich==14.3.2
-    # via browser-use
+    # via
+    #   browser-use
+    #   typer
 rpds-py==0.30.0
     # via
     #   jsonschema
@@ -1168,6 +1194,8 @@ safeio==1.2
     # via translatepy
 screeninfo==0.8.1 ; platform_system != 'darwin'
     # via browser-use
+shellingham==1.5.4
+    # via typer
 six==1.17.0
     # via
     #   markdownify
@@ -1201,6 +1229,8 @@ tenacity==9.1.2
     # via google-genai
 tiktoken==0.12.0
     # via n-e-k-o
+tokenizers==0.22.2
+    # via n-e-k-o
 toml==0.10.2
     # via n-e-k-o
 tomli==2.4.0
@@ -1211,10 +1241,13 @@ tornado==6.5.4
     # via n-e-k-o
 tqdm==4.67.1
     # via
+    #   huggingface-hub
     #   openai
     #   pyrnnoise
 translatepy==2.3
     # via n-e-k-o
+typer==0.24.2
+    # via huggingface-hub
 typing-extensions==4.14.1
     # via
     #   aiosignal
@@ -1227,6 +1260,7 @@ typing-extensions==4.14.1
     #   fastapi
     #   google-genai
     #   groq
+    #   huggingface-hub
     #   mcp
     #   openai
     #   posthog

--- a/specs/launcher.spec
+++ b/specs/launcher.spec
@@ -68,7 +68,7 @@ for pkg in critical_packages:
             raise RuntimeError(
                 f"Cannot collect {pkg!r}, but data/embedding_models is "
                 "present and will be bundled. Install with "
-                "`uv sync --extra embeddings` or remove the embedding "
+                "`uv sync` or remove the embedding "
                 "assets directory before building."
             ) from e
         print(f"Warning: Could not collect {pkg}: {e}")

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -90,9 +90,16 @@ def test_coerce_dim_invalid_value_falls_back_to_auto():
 
 
 def test_resolve_quantization_auto_branches_on_vnni():
-    """VNNI present ⇒ INT8; absent ⇒ FP32. INT8 without VNNI is slower."""
+    """VNNI present ⇒ INT8; confirmed absent ⇒ None; inconclusive ⇒ INT8."""
     assert _resolve_quantization("auto", has_vnni=True) == "int8"
-    assert _resolve_quantization("auto", has_vnni=False) == "fp32"
+    assert (
+        _resolve_quantization("auto", has_vnni=False, vnni_absence_confirmed=True)
+        is None
+    )
+    assert (
+        _resolve_quantization("auto", has_vnni=False, vnni_absence_confirmed=False)
+        == "int8"
+    )
 
 
 def test_resolve_quantization_explicit_pinning():
@@ -100,10 +107,19 @@ def test_resolve_quantization_explicit_pinning():
     pinned int8 on non-VNNI hardware (asserted via behaviour, not log)."""
     assert _resolve_quantization("int8", has_vnni=False) == "int8"
     assert _resolve_quantization("fp32", has_vnni=True) == "fp32"
+    assert _resolve_quantization("fp32", has_vnni=False) == "fp32"
 
 
 def test_resolve_quantization_invalid_falls_back_to_auto():
     assert _resolve_quantization("garbage", has_vnni=True) == "int8"
+    assert (
+        _resolve_quantization("garbage", has_vnni=False, vnni_absence_confirmed=True)
+        is None
+    )
+    assert (
+        _resolve_quantization("garbage", has_vnni=False, vnni_absence_confirmed=False)
+        == "int8"
+    )
 
 
 def test_build_model_id_encodes_axes():
@@ -130,7 +146,7 @@ def _service(**overrides) -> EmbeddingService:
         quantization_setting="auto",
         min_ram_gb=DEFAULT_VECTORS_MIN_RAM_GB,
         ram_gb=8.0,
-        has_vnni=False,
+        has_vnni=True,
     )
     defaults.update(overrides)
     return EmbeddingService(**defaults)
@@ -178,38 +194,76 @@ def test_service_healthy_construction_stays_init_until_load():
     assert svc.is_disabled() is False
     assert svc.is_available() is False
     assert svc._state == EmbeddingState.INIT
-    assert svc.model_id() == "local-text-retrieval-v1-256d-fp32"
+    assert svc.model_id() == "local-text-retrieval-v1-256d-int8"
     assert svc.dim() == 256
-    assert svc.quantization() == "fp32"
+    assert svc.quantization() == "int8"
 
 
 def test_service_dim_pinning_overrides_auto():
     svc = _service(ram_gb=4.5, embedding_dim_setting=256)
     # Even on 4.5 GB RAM, the pinned dim wins.
     assert svc.dim() == 256
-    assert svc.model_id().endswith("256d-fp32")
+    assert svc.model_id().endswith("256d-int8")
 
 
-def test_service_uses_profile_onnx_layout():
-    """The default profile uses a task-specific ONNX export under
-    onnx/model*.onnx, not the old model_<quant>.onnx layout."""
-    fp32 = _service(
+def test_service_fp32_setting_uses_fp32_onnx_path():
+    svc = _service(
         ram_gb=16.0,
         quantization_setting="fp32",
         model_dir="/models",
+        has_vnni=True,
     )
+    assert not svc.is_disabled()
+    assert svc.quantization() == "fp32"
+    assert svc.model_id() == "local-text-retrieval-v1-256d-fp32"
+    assert svc._model_file_path().replace("\\", "/").endswith(
+        "/local-text-retrieval-v1/onnx/model.onnx",
+    )
+
+
+def test_service_auto_without_vnni_disables():
+    svc = _service(
+        ram_gb=16.0,
+        has_vnni=False,
+        vnni_absence_confirmed=True,
+        quantization_setting="auto",
+    )
+    assert svc.is_disabled()
+    assert svc.disable_reason() == "avx_vnni_required_for_int8_bundle"
+
+
+def test_service_auto_inconclusive_vnni_stays_int8():
+    """Windows/macOS without cpuinfo: absence not confirmed → still try INT8."""
+    svc = _service(
+        ram_gb=16.0,
+        has_vnni=False,
+        vnni_absence_confirmed=False,
+        quantization_setting="auto",
+    )
+    assert not svc.is_disabled()
+    assert svc.quantization() == "int8"
+
+
+def test_service_uses_profile_onnx_layout():
+    """The profile uses task ONNX exports under onnx/model*.onnx."""
     int8 = _service(
         ram_gb=16.0,
         quantization_setting="int8",
         model_dir="/models",
     )
-    assert fp32._model_file_path().replace("\\", "/").endswith(
-        "/local-text-retrieval-v1/onnx/model.onnx",
+    fp32 = _service(
+        ram_gb=16.0,
+        quantization_setting="fp32",
+        model_dir="/models",
+        has_vnni=True,
     )
     assert int8._model_file_path().replace("\\", "/").endswith(
         "/local-text-retrieval-v1/onnx/model_quantized.onnx",
     )
-    assert fp32._tokenizer_file_path().replace("\\", "/").endswith(
+    assert fp32._model_file_path().replace("\\", "/").endswith(
+        "/local-text-retrieval-v1/onnx/model.onnx",
+    )
+    assert int8._tokenizer_file_path().replace("\\", "/").endswith(
         "/local-text-retrieval-v1/tokenizer.json",
     )
 
@@ -311,11 +365,11 @@ def test_select_model_dir_skips_app_data_missing_runtime_variant(tmp_path, monke
         _select_model_dir(str(app_model_dir), "local-text-retrieval-v1", "int8")
         == str(bundled_model_dir)
     )
-    # Without quantization (caller doesn't know yet), the existing-variant
-    # behavior is preserved — app-data is still preferred.
+    # Without quantization, only the shipped INT8 variant counts — fp32-only
+    # app-data must not mask a complete bundled int8 profile.
     assert (
         _select_model_dir(str(app_model_dir), "local-text-retrieval-v1")
-        == str(app_model_dir)
+        == str(bundled_model_dir)
     )
 
 
@@ -432,7 +486,7 @@ def test_infer_uses_last_token_pooling_and_matryoshka_truncation():
                 [[5.0, 0.0, 0.0], [9.0, 9.0, 9.0], [8.0, 8.0, 8.0]],
             ], dtype=np.float32)]
 
-    svc = _service(ram_gb=16.0)
+    svc = _service(ram_gb=16.0, has_vnni=True)
     svc._dim = 2  # private override keeps the fixture tiny while testing truncation
     session = _Session()
     svc._session = session

--- a/uv.lock
+++ b/uv.lock
@@ -1320,11 +1320,13 @@ dependencies = [
     { name = "jinja2" },
     { name = "jmespath" },
     { name = "numpy" },
+    { name = "onnxruntime" },
     { name = "openai" },
     { name = "orjson" },
     { name = "ormsgpack" },
     { name = "pillow" },
     { name = "psutil" },
+    { name = "py-cpuinfo" },
     { name = "pyautogui" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'" },
     { name = "pyncm-async" },
@@ -1342,6 +1344,7 @@ dependencies = [
     { name = "soxr" },
     { name = "sqlalchemy" },
     { name = "tiktoken" },
+    { name = "tokenizers" },
     { name = "toml" },
     { name = "tomli" },
     { name = "tomli-w" },
@@ -1350,12 +1353,6 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websocket-client" },
     { name = "websockets" },
-]
-
-[package.optional-dependencies]
-embeddings = [
-    { name = "onnxruntime" },
-    { name = "tokenizers" },
 ]
 
 [package.dev-dependencies]
@@ -1385,12 +1382,13 @@ requires-dist = [
     { name = "jinja2" },
     { name = "jmespath", specifier = ">=1.1.0" },
     { name = "numpy", specifier = "~=1.26.4" },
-    { name = "onnxruntime", marker = "extra == 'embeddings'" },
+    { name = "onnxruntime" },
     { name = "openai" },
     { name = "orjson", specifier = ">=3.11.8" },
     { name = "ormsgpack", specifier = ">=1.4.0" },
     { name = "pillow" },
     { name = "psutil", specifier = ">=7.0.0" },
+    { name = "py-cpuinfo", specifier = ">=9.0.0" },
     { name = "pyautogui" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'" },
     { name = "pyncm-async", specifier = "==1.8.1" },
@@ -1408,7 +1406,7 @@ requires-dist = [
     { name = "soxr", specifier = "~=0.5.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
-    { name = "tokenizers", marker = "extra == 'embeddings'" },
+    { name = "tokenizers" },
     { name = "toml" },
     { name = "tomli", specifier = ">=2.3.0" },
     { name = "tomli-w", specifier = ">=1.2.0" },
@@ -1418,7 +1416,6 @@ requires-dist = [
     { name = "websocket-client", specifier = "~=1.8.0" },
     { name = "websockets", specifier = "~=15.0.1" },
 ]
-provides-extras = ["embeddings"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1733,6 +1730,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Promotes local embedding runtime dependencies to default installs and tightens quantization policy while keeping an escape hatch for manual FP32 weights.

## Changes
- **Dependencies**: \onnxruntime\, \	okenizers\, and \py-cpuinfo\ are now in \[project.dependencies]\; the optional \embeddings\ extra is removed. Docs and \specs/launcher.spec\ tell contributors to run plain \uv sync\.
- **Runtime** (\memory/embeddings.py\): Explicit \p32\ loads \model.onnx\ when present. \uto\ disables local vectors only when AVX-VNNI absence is **confirmed**; inconclusive detection still prefers INT8.
- **Lockfiles**: Regenerated \equirements.txt\ and \uv.lock\.
- **Tests**: Updated \	ests/unit/test_embedding_service.py\.

## Follow-up (not in this PR)
GitHub rejected pushing \.github/workflows/build-desktop.yml\ from this environment (OAuth lacks \workflow\ scope). Maintainers should mirror CI updates locally:
- \uv sync\ without \--extra embeddings\
- \prepare_embedding_model.py --variant int8\
- Bundle verification: tokenizer + \model_quantized.onnx\ (+ sidecar) only

## Review focus
- Embedding fallback matrix + cache \model_id\ semantics (\int8\ vs \p32\).
- Acceptability of always-on \onnxruntime\/\	okenizers\ install size for minimal setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新部署文档和配置注释，明确安装全量依赖并注明 fp32 模式需本地模型文件可用。
* **改进**
  * 强化 CPU 能力检测与量化决策，支持在不满足硬件时禁用向量并更严格地选择模型变体。
* **依赖管理**
  * 原先的嵌入运行时依赖已并入主依赖，安装流程简化（无需额外选项）。
* **测试**
  * 扩展并调整了量化与模型导出相关的单元测试以覆盖新逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->