### PR TITLE
log: DEBUG 单独落到源码 logs/，不污染用户统一日志

### DIFF
--- a/memory_server.py
+++ b/memory_server.py
@@ -1199,7 +1199,7 @@ async def _periodic_new_dialog_qps_log_loop():
         snapshot = dict(_new_dialog_qps_counter)
         _new_dialog_qps_counter.clear()
         total = sum(snapshot.values())
-        logger.info(
+        logger.debug(
             f"[QPS] /new_dialog last {NEW_DIALOG_QPS_FLUSH_INTERVAL}s: "
             f"total={total} per_char={snapshot}"
         )

--- a/utils/logger_config.py
+++ b/utils/logger_config.py
@@ -320,23 +320,33 @@ class RobustLoggerConfig:
             raise
     
     def _cleanup_old_logs(self):
-        """清理超过保留期的旧日志文件"""
-        try:
-            cutoff_date = datetime.now() - timedelta(days=self.retention_days)
-            
-            for log_file in self.log_dir.glob(f"{self.app_name}_*.log*"):
-                try:
-                    # 获取文件的修改时间
-                    file_mtime = datetime.fromtimestamp(log_file.stat().st_mtime)
-                    
-                    # 如果文件太旧，删除它
-                    if file_mtime < cutoff_date:
-                        log_file.unlink()
-                        print(f"Cleaned up old log file: {log_file.name}")
-                except Exception as e:
-                    print(f"Warning: Failed to clean up log file {log_file}: {e}", file=sys.stderr)
-        except Exception as e:
-            print(f"Warning: Failed to cleanup old logs: {e}", file=sys.stderr)
+        """清理超过保留期的旧日志文件。
+
+        除了主日志目录外，源码运行时还会顺手清一下 dev DEBUG 目录
+        （``<repo>/logs/``），避免按天滚的 ``*_debug_YYYYMMDD.log`` 无限堆积。
+        """
+        cutoff_date = datetime.now() - timedelta(days=self.retention_days)
+        dirs_to_scan = [self.log_dir]
+        if not getattr(sys, "frozen", False):
+            try:
+                dev_dir = _get_application_root() / "logs"
+                if dev_dir.exists() and dev_dir.resolve() != self.log_dir.resolve():
+                    dirs_to_scan.append(dev_dir)
+            except Exception as e:
+                print(f"Warning: Failed to resolve dev debug dir for cleanup: {e}", file=sys.stderr)
+
+        for scan_dir in dirs_to_scan:
+            try:
+                for log_file in scan_dir.glob(f"{self.app_name}_*.log*"):
+                    try:
+                        file_mtime = datetime.fromtimestamp(log_file.stat().st_mtime)
+                        if file_mtime < cutoff_date:
+                            log_file.unlink()
+                            print(f"Cleaned up old log file: {log_file.name}")
+                    except Exception as e:
+                        print(f"Warning: Failed to clean up log file {log_file}: {e}", file=sys.stderr)
+            except Exception as e:
+                print(f"Warning: Failed to cleanup old logs in {scan_dir}: {e}", file=sys.stderr)
     
     def _resolve_console_level(self) -> int:
         """决定 console handler 的级别。

--- a/utils/logger_config.py
+++ b/utils/logger_config.py
@@ -338,6 +338,19 @@ class RobustLoggerConfig:
         except Exception as e:
             print(f"Warning: Failed to cleanup old logs: {e}", file=sys.stderr)
     
+    def _resolve_console_level(self) -> int:
+        """决定 console handler 的级别。
+
+        默认：max(log_level, INFO) —— 即便整体开 DEBUG，控制台也只显示 INFO+，
+        DEBUG 走文件。可用 NEKO_LOG_CONSOLE_LEVEL=DEBUG/INFO/... 覆盖。
+        """
+        override = (os.environ.get("NEKO_LOG_CONSOLE_LEVEL") or "").strip().upper()
+        if override:
+            level = logging.getLevelName(override)
+            if isinstance(level, int):
+                return level
+        return max(self.log_level, logging.INFO)
+
     def get_log_file_path(self):
         """获取日志文件路径"""
         return str(self.log_file)
@@ -380,10 +393,14 @@ class RobustLoggerConfig:
         date_format = '%Y-%m-%d %H:%M:%S'
         formatter = logging.Formatter(log_format, date_format)
         
+        # 控制台默认钳到 INFO：DEBUG 量太大会瞬间淹没终端，落盘即可。
+        # 想让 console 也吐 DEBUG（极少数本地排障场景），设 NEKO_LOG_CONSOLE_LEVEL=DEBUG。
+        console_level = self._resolve_console_level()
+
         # 1. 控制台Handler
         try:
             console_handler = logging.StreamHandler(sys.stdout)
-            console_handler.setLevel(self.log_level)
+            console_handler.setLevel(console_level)
             console_handler.setFormatter(formatter)
             logger.addHandler(console_handler)
         except Exception as e:
@@ -398,13 +415,39 @@ class RobustLoggerConfig:
                 backupCount=self.backup_count,
                 encoding='utf-8'
             )
-            file_handler.setLevel(self.log_level)
+            # 主日志钳到 INFO+：DEBUG 走单独的 dev 文件，不污染用户统一日志。
+            file_handler.setLevel(max(self.log_level, logging.INFO))
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)
         except Exception as e:
             print(f"Error: Failed to add file handler: {e}", file=sys.stderr)
             # 文件handler失败不应该阻止应用运行
-        
+
+        # 2b. Dev-only DEBUG Handler：仅源码运行时启用，落到源码 ``logs/`` 下，
+        # 只收 DEBUG 一级（INFO+ 已经在主日志里）。frozen 时不挂——AppImage
+        # squashfs 只读，且打包后用户不需要 dev 调试日志。
+        if not getattr(sys, "frozen", False) and self.log_level <= logging.DEBUG:
+            try:
+                dev_debug_dir = _get_application_root() / "logs"
+                dev_debug_dir.mkdir(parents=True, exist_ok=True)
+                if self.service_name:
+                    debug_filename = f"{self.app_name}_{self.service_name}_debug_{datetime.now().strftime('%Y%m%d')}.log"
+                else:
+                    debug_filename = f"{self.app_name}_debug_{datetime.now().strftime('%Y%m%d')}.log"
+                debug_handler = RotatingFileHandler(
+                    dev_debug_dir / debug_filename,
+                    maxBytes=self.max_bytes,
+                    backupCount=self.backup_count,
+                    encoding='utf-8',
+                    delay=True,
+                )
+                debug_handler.setLevel(logging.DEBUG)
+                debug_handler.addFilter(lambda r: r.levelno < logging.INFO)
+                debug_handler.setFormatter(formatter)
+                logger.addHandler(debug_handler)
+            except Exception as e:
+                print(f"Warning: Failed to add dev debug handler: {e}", file=sys.stderr)
+
         # 3. 错误日志Handler（单独记录ERROR及以上级别）
         try:
             if self.service_name:


### PR DESCRIPTION
## Summary
- 控制台 / 主日志 handler 钳到 `max(log_level, INFO)`：DEBUG 量大时不再淹没终端和 `<docs>/N.E.K.O/logs/` 用户统一日志
- 源码运行时（`not frozen`）且 `log_level=DEBUG` 时，新增 dev-only DEBUG handler，落到 `<repo>/logs/<App>_<Service>_debug_<日期>.log`，只收 DEBUG 一级
- 控制台级别可用 `NEKO_LOG_CONSOLE_LEVEL=DEBUG` 覆盖（极少数排障场景）
- `memory_server` 的 `/new_dialog` QPS 心跳从 INFO 降为 DEBUG（默认 INFO 模式下不再每分钟刷一行）

## 触发方式
把对应 server 的 \`setup_logging(..., log_level=logging.DEBUG)\` 改一下即可（`memory_server.py:77`、`main_server.py:73` 等），DEBUG 全部进源码 \`logs/\`，主日志和终端不动。frozen 打包时整个 dev DEBUG handler 直接跳过。

## Test plan
- [ ] `log_level=INFO`（默认）：控制台 + 用户统一日志只有 INFO+，源码 `logs/` 不产生 dev debug 文件
- [ ] `log_level=DEBUG`：控制台仍只显示 INFO+，用户统一日志也只到 INFO+，DEBUG 全部进 `<repo>/logs/<App>_<Service>_debug_<日期>.log`
- [ ] `NEKO_LOG_CONSOLE_LEVEL=DEBUG` + `log_level=DEBUG`：控制台也吐 DEBUG
- [ ] memory_server 默认启动后 60s+ 不再看到 `[QPS] /new_dialog ...` INFO 行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进

* **日志系统**
  * 解耦控制台与文件日志级别，支持通过环境变量 NEKO_LOG_CONSOLE_LEVEL 单独设置控制台输出级别
  * 主日志文件排除 DEBUG 级别，开发环境下新增独立的调试日志文件以便诊断
  * 日志清理扩展为扫描主日志目录及源码运行时的应用根目录 logs/，对旧日志文件分别执行保留期删除并输出更细化的警告信息
* **其它**
  * 将周期性上报 /new_dialog 的 QPS 日志级别从 INFO 降为 DEBUG，减少运行时噪声
<!-- end of auto-generated comment: release notes by coderabbit.ai -->