### PR TITLE
fix(plugin-bus): 用户原话写入 user-context bucket，激活 bus.memory.get 链路

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1178,6 +1178,47 @@ class LLMSessionManager:
             else:
                 pass  # websocket未连接时忽略
 
+    def _publish_user_utterance_to_plugin_bus(
+        self, text: Optional[str], *, is_voice_source: bool
+    ) -> None:
+        """把一条用户原话推到插件总线的 user-context bucket。
+
+        Plugin 端通过 ``ctx.bus.memory.get(bucket_id=...)`` 读取。会同时写入
+        两个 bucket：``"default"``（与 protocols.py 文档示例一致，全局可读）
+        和 ``self.lanlan_name``（按角色作用域）。
+
+        Why: 在此之前 ``state.add_user_context_event`` 整条链路是 dead
+        infrastructure —— 服务端、handler、plugin SDK 全都齐全，但没人写入，
+        plugin 永远读到空。这里是用户原话进入系统的第一道关口（语音转录 +
+        文本输入），从这里发布最贴合"用户原话"的语义。
+        """
+        if not isinstance(text, str):
+            return
+        cleaned = text.strip()
+        if not cleaned:
+            return
+        try:
+            from plugin.core.state import state as _plugin_state
+        except Exception:
+            return
+        event = {
+            "type": "user_message",
+            "content": cleaned,
+            "lanlan": self.lanlan_name,
+            "is_voice": bool(is_voice_source),
+            "source": "main_logic.core",
+        }
+        for bucket in ("default", self.lanlan_name):
+            if not isinstance(bucket, str) or not bucket:
+                continue
+            try:
+                _plugin_state.add_user_context_event(bucket, event)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] publish_user_utterance failed (bucket=%s): %s",
+                    self.lanlan_name, bucket, exc,
+                )
+
     async def handle_input_transcript(self, transcript: str, *, is_voice_source: bool = True):
         """输入转录回调：同步转录文本到消息队列和缓存，并发送到前端显示
 
@@ -1204,6 +1245,11 @@ class LLMSessionManager:
             if transcript.strip():
                 self._activity_tracker.on_user_message(text=transcript)
                 self._session_turn_count += 1
+                # 与 on_user_message 对偶：把"用户原话"推到插件总线 user-context
+                # bucket。文本路径在 _process_stream_data_internal 已自行调用，
+                # 这里只覆盖语音路径，避免 openclaw handoff（is_voice_source=False）
+                # 重复发布。
+                self._publish_user_utterance_to_plugin_bus(transcript, is_voice_source=True)
         else:
             # Non-voice reuse of this method (e.g. openclaw text handoff).
             # Skip activity-tracker hooks entirely — the text-mode entry
@@ -4265,6 +4311,14 @@ class LLMSessionManager:
                     # main_routers/system_router.py），那不算用户活动。
                     # text 进 buffer 给 emotion-tier 用。
                     self._activity_tracker.on_user_message(text=data if isinstance(data, str) else None)
+                    # 与 on_user_message 对偶：把"用户原话"推到插件总线 user-context
+                    # bucket。语音路径在 handle_input_transcript 里发布，这里只覆盖
+                    # 文本路径，避免 openclaw handoff（会再走一次 handle_input_transcript
+                    # 但 is_voice_source=False，不会重复发布）。
+                    self._publish_user_utterance_to_plugin_bus(
+                        data if isinstance(data, str) else None,
+                        is_voice_source=False,
+                    )
 
                     should_handoff, openclaw_messages = await self._should_handoff_text_to_openclaw(data)
                     if should_handoff:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -38,6 +38,7 @@ from main_logic.tool_calling import (
 )
 from utils.llm_client import AIMessage
 from main_logic.session_state import SessionStateMachine, SessionEvent
+from plugin.core.state import state as _plugin_state
 from utils.preferences import load_global_conversation_settings, aload_global_conversation_settings
 from config import (
     MEMORY_SERVER_PORT,
@@ -1185,7 +1186,8 @@ class LLMSessionManager:
 
         Plugin 端通过 ``ctx.bus.memory.get(bucket_id=...)`` 读取。会同时写入
         两个 bucket：``"default"``（与 protocols.py 文档示例一致，全局可读）
-        和 ``self.lanlan_name``（按角色作用域）。
+        和 ``self.lanlan_name``（按角色作用域），但若两者撞名则只写一次，
+        避免同一条原话被重复消费。
 
         Why: 在此之前 ``state.add_user_context_event`` 整条链路是 dead
         infrastructure —— 服务端、handler、plugin SDK 全都齐全，但没人写入，
@@ -1197,10 +1199,6 @@ class LLMSessionManager:
         cleaned = text.strip()
         if not cleaned:
             return
-        try:
-            from plugin.core.state import state as _plugin_state
-        except Exception:
-            return
         event = {
             "type": "user_message",
             "content": cleaned,
@@ -1208,7 +1206,9 @@ class LLMSessionManager:
             "is_voice": bool(is_voice_source),
             "source": "main_logic.core",
         }
-        for bucket in ("default", self.lanlan_name):
+        # dict.fromkeys 保留顺序的同时去重：lanlan_name == "default" 或为空
+        # 时不会重复写入 default bucket。
+        for bucket in dict.fromkeys(("default", self.lanlan_name)):
             if not isinstance(bucket, str) or not bucket:
                 continue
             try:

--- a/tests/test_user_utterance_bus_publish.py
+++ b/tests/test_user_utterance_bus_publish.py
@@ -1,0 +1,123 @@
+"""Tests for the user-utterance → plugin bus publishing helper.
+
+Covers ``LLMSessionManager._publish_user_utterance_to_plugin_bus`` — the
+bridge that calls ``state.add_user_context_event`` so plugins can read
+user history via ``ctx.bus.memory.get(bucket_id=...)``.
+
+We don't construct a real ``LLMSessionManager`` (heavy: needs config,
+websocket, sessions). Instead, we call the unbound method with a tiny
+SimpleNamespace that carries only the attributes the helper touches
+(``lanlan_name``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from main_logic.core import LLMSessionManager
+from plugin.core.state import state as plugin_state
+
+
+def _make_fake_core(lanlan_name: str = "皖萱") -> SimpleNamespace:
+    """Minimal stand-in for LLMSessionManager — only the attributes the helper reads."""
+    return SimpleNamespace(lanlan_name=lanlan_name)
+
+
+def _drain_bucket(bucket_id: str) -> list[dict]:
+    """Snapshot a bucket's events without affecting state."""
+    return plugin_state.get_user_context(bucket_id=bucket_id, limit=500)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_context():
+    """Each test starts with empty user-context stores. Restore after."""
+    snapshot_default = _drain_bucket("default")
+    snapshot_lanlan = _drain_bucket("皖萱")
+    plugin_state._user_context_store.clear()  # noqa: SLF001
+    yield
+    plugin_state._user_context_store.clear()  # noqa: SLF001
+    # The state is module-global; we don't restore the prior snapshot to
+    # keep tests independent (no test should depend on bucket contents
+    # from prior tests).
+    _ = (snapshot_default, snapshot_lanlan)  # silence lint
+
+
+@pytest.mark.unit
+def test_publish_writes_to_default_and_lanlan_buckets():
+    fake = _make_fake_core(lanlan_name="皖萱")
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, "你好啊", is_voice_source=True,
+    )
+
+    default_events = _drain_bucket("default")
+    lanlan_events = _drain_bucket("皖萱")
+
+    assert len(default_events) == 1
+    assert len(lanlan_events) == 1
+    for ev in (default_events[0], lanlan_events[0]):
+        assert ev["type"] == "user_message"
+        assert ev["content"] == "你好啊"
+        assert ev["lanlan"] == "皖萱"
+        assert ev["is_voice"] is True
+        assert ev["source"] == "main_logic.core"
+        assert isinstance(ev["_ts"], float)
+
+
+@pytest.mark.unit
+def test_publish_strips_whitespace_and_skips_empty():
+    fake = _make_fake_core()
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, "  hi  ", is_voice_source=False,
+    )
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, "   ", is_voice_source=False,
+    )
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, "", is_voice_source=False,
+    )
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, None, is_voice_source=False,
+    )
+
+    events = _drain_bucket("default")
+    assert len(events) == 1
+    assert events[0]["content"] == "hi"
+    assert events[0]["is_voice"] is False
+
+
+@pytest.mark.unit
+def test_publish_handles_missing_lanlan_name_gracefully():
+    """Empty/None lanlan_name should still write to default bucket."""
+    fake = _make_fake_core(lanlan_name="")
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, "ping", is_voice_source=True,
+    )
+    assert len(_drain_bucket("default")) == 1
+    # No second bucket should be created when lanlan_name is empty.
+    assert plugin_state._user_context_store.get("") is None  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_publish_non_string_input_is_ignored():
+    fake = _make_fake_core()
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, 12345, is_voice_source=True,  # type: ignore[arg-type]
+    )
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, ["not", "a", "string"], is_voice_source=True,  # type: ignore[arg-type]
+    )
+    assert _drain_bucket("default") == []
+
+
+@pytest.mark.unit
+def test_repeated_publishes_accumulate_in_chronological_order():
+    fake = _make_fake_core(lanlan_name="兰兰")
+    for i, msg in enumerate(["first", "second", "third"]):
+        LLMSessionManager._publish_user_utterance_to_plugin_bus(
+            fake, msg, is_voice_source=(i % 2 == 0),
+        )
+
+    contents = [ev["content"] for ev in _drain_bucket("兰兰")]
+    assert contents == ["first", "second", "third"]

--- a/tests/test_user_utterance_bus_publish.py
+++ b/tests/test_user_utterance_bus_publish.py
@@ -112,6 +112,19 @@ def test_publish_non_string_input_is_ignored():
 
 
 @pytest.mark.unit
+def test_publish_dedupes_when_lanlan_name_equals_default():
+    """If lanlan_name is literally "default", we must not write twice to it."""
+    fake = _make_fake_core(lanlan_name="default")
+    LLMSessionManager._publish_user_utterance_to_plugin_bus(
+        fake, "echo me once", is_voice_source=True,
+    )
+
+    events = _drain_bucket("default")
+    assert len(events) == 1
+    assert events[0]["content"] == "echo me once"
+
+
+@pytest.mark.unit
 def test_repeated_publishes_accumulate_in_chronological_order():
     fake = _make_fake_core(lanlan_name="兰兰")
     for i, msg in enumerate(["first", "second", "third"]):


### PR DESCRIPTION
## Summary

- 之前 `state.add_user_context_event(bucket_id, event)` 完整定义 + server handler `USER_CONTEXT_GET` + plugin SDK `ctx.bus.memory.get(bucket_id=...)` 全链路就位，但 codebase **零调用** —— plugin 永远读到空。同时 `main_logic` / `main_routers` 没有任何把用户原话 publish 到 bus 的代码路径。
- 在 [main_logic/core.py:1181](main_logic/core.py:1181) 新增 `_publish_user_utterance_to_plugin_bus`，跟 `_activity_tracker.on_user_message` 对偶挂在用户原话进入系统的两个真实入口：语音 (`handle_input_transcript`) + 文本 (`_process_stream_data_internal`)。
- 每条原话同时写到 `\"default\"` bucket（与 [plugin/_types/protocols.py:490](plugin/_types/protocols.py:490) 文档示例一致）和 `self.lanlan_name` bucket（按角色作用域），plugin 按需选 bucket 读。

## 设计要点

挂点选择沿用现有对偶约定：

| 入口 | `_activity_tracker.on_user_message` | 新增 publish |
|---|---|---|
| 语音 (`handle_input_transcript`, `is_voice_source=True`) | core.py:1205 | core.py 紧跟其后 |
| 文本 (`_process_stream_data_internal` text-mode) | core.py:4267 | core.py 紧跟其后 |
| openclaw handoff (`handle_input_transcript`, `is_voice_source=False`) | 跳过（文本入口已记录） | 跳过（同上原因，避免重复发布） |

helper 自身只读 `self.lanlan_name`，对空字符串 / None / 非 str 输入都做了兜底；写 bus 异常被 catch 后只 log warn，不影响用户对话主流程。

## Test plan

- [x] `uv run pytest tests/test_user_utterance_bus_publish.py -v` — 5 项全过（基本写入、空白裁剪、空 lanlan_name 兜底、非字符串忽略、多次发布顺序）
- [x] `uv run pytest plugin/tests/unit/server/test_server_request_handlers.py` — 服务端 `USER_CONTEXT_GET` handler 既有测试不回归
- [x] `uv run python -c \"import main_logic.core\"` — smoke import 无副作用

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化用户消息发布到插件总线：语音与文本路径分别处理，按来源区分并去重，支持按实例（lanlan）存储与默认存储，自动修剪空白并忽略空或非字符串输入。

* **测试**
  * 新增完整测试覆盖：验证事件结构、按桶写入逻辑、空输入处理、去重行为与时序累积。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->