### PR TITLE
feat: LLM prompt placeholder leak 自动检测器

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1017,6 +1017,19 @@ class OmniRealtimeClient:
 
     async def update_session(self, config: Dict[str, Any]) -> None:
         """Update session configuration."""
+        # Mirror the chat-completion chokepoint: catch any unrendered
+        # {placeholder} before the system instruction (nested at provider-
+        # specific paths inside `config`) is shipped over the wire. See
+        # utils/llm_prompt_leak_check.py for rationale.
+        try:
+            from utils import llm_prompt_leak_check
+            llm_prompt_leak_check.check_dict_strings_for_leaks(
+                config, context="OmniRealtimeClient.update_session"
+            )
+        except AssertionError:
+            raise
+        except Exception:
+            pass
         event = {
             "type": "session.update",
             "session": config

--- a/tests/unit/test_llm_prompt_leak_check.py
+++ b/tests/unit/test_llm_prompt_leak_check.py
@@ -1,0 +1,273 @@
+"""Tests for utils.llm_prompt_leak_check.
+
+Pre-condition for the assertion-mode tests in this file: pytest itself sets
+``PYTEST_CURRENT_TEST`` while executing each test, which is exactly the
+condition under which ``llm_prompt_leak_check`` switches from "log warning"
+to "raise AssertionError". So just calling the detector with leaky input
+inside a test function is enough to exercise the raise path.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from utils import llm_prompt_leak_check
+from utils.llm_prompt_leak_check import (
+    check_dict_strings_for_leaks,
+    check_messages_for_leaks,
+    check_text_for_leaks,
+)
+
+
+# ────────────────────────────────────────────────────────────────
+# check_text_for_leaks: positive / negative cases
+# ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("{master}", ["{master}"]),
+        ("hello {master}, today is {weekday}", ["{master}", "{weekday}"]),
+        ("foo {x} bar", ["{x}"]),
+        ("{a1b2_c3}", ["{a1b2_c3}"]),
+        # Doubled braces are an .format() escape → not a leak.
+        ("{{escaped}}", []),
+        ("Use {{master}} for the literal value.", []),
+        # Empty / non-template braces should not match.
+        ("", []),
+        ("{}", []),
+        ("{ master }", []),  # spaces → not a Python identifier in single braces
+        # Pure punctuation noise.
+        ("text with } and { but no pair", []),
+        # Numeric leading char — also not the bug class we chase.
+        ("{0}", []),
+        # Non-string falls back to no leaks rather than raising.
+        (None, []),
+        (12345, []),
+    ],
+)
+def test_check_text_for_leaks(text, expected):
+    assert check_text_for_leaks(text) == expected
+
+
+# ────────────────────────────────────────────────────────────────
+# check_messages_for_leaks: only system role is scanned
+# ────────────────────────────────────────────────────────────────
+
+
+def test_user_role_with_braces_is_ignored():
+    """User content can legitimately contain `{...}` (code snippets, JSON)."""
+    messages = [
+        {"role": "user", "content": "How do I render `{master}` in Jinja?"},
+        {"role": "assistant", "content": "Use `{{ master }}` not `{master}`."},
+    ]
+    # Must not raise — these are non-system roles by design.
+    check_messages_for_leaks(messages)
+
+
+def test_system_role_with_leak_raises_in_pytest():
+    messages = [{"role": "system", "content": "Hello {master}, focus on the task."}]
+    with pytest.raises(AssertionError) as exc:
+        check_messages_for_leaks(messages, context="unit-test")
+    assert "{master}" in str(exc.value)
+    assert "unit-test" in str(exc.value)
+
+
+def test_system_role_without_leak_is_clean():
+    messages = [{"role": "system", "content": "You are a helpful assistant."}]
+    check_messages_for_leaks(messages)
+
+
+def test_system_multimodal_content_is_scanned():
+    """System messages with multimodal content (list of parts) must be scanned;
+    image_url parts must be skipped (no false-positive on b64 payload)."""
+    messages = [
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Greet {master} warmly."},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abcd"},
+                },
+            ],
+        }
+    ]
+    with pytest.raises(AssertionError) as exc:
+        check_messages_for_leaks(messages)
+    assert "{master}" in str(exc.value)
+
+
+def test_doubled_braces_in_system_is_clean():
+    messages = [
+        {"role": "system", "content": "Use literal {{master}} for the example."},
+    ]
+    check_messages_for_leaks(messages)
+
+
+def test_empty_messages_is_noop():
+    check_messages_for_leaks([])
+    check_messages_for_leaks(None)
+
+
+def test_non_dict_entries_are_skipped():
+    """Defensive: caller passes a list with stray non-dicts → skip silently."""
+    check_messages_for_leaks(["raw string", 42, None])
+
+
+def test_assertion_can_be_disabled_outside_pytest_context(monkeypatch):
+    """In production (no PYTEST_CURRENT_TEST and no NEKO_PROMPT_LEAK_RAISE),
+    leaks log a warning rather than raise."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("NEKO_PROMPT_LEAK_RAISE", raising=False)
+    messages = [{"role": "system", "content": "Hi {master}"}]
+    with patch.object(llm_prompt_leak_check.logger, "warning") as warn:
+        check_messages_for_leaks(messages, context="prod-sim")
+    warn.assert_called_once()
+    (warn_msg,), _ = warn.call_args
+    assert "{master}" in warn_msg
+    assert "prod-sim" in warn_msg
+
+
+def test_force_raise_via_env(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("NEKO_PROMPT_LEAK_RAISE", "1")
+    messages = [{"role": "system", "content": "Hi {master}"}]
+    with pytest.raises(AssertionError):
+        check_messages_for_leaks(messages)
+
+
+# ────────────────────────────────────────────────────────────────
+# check_dict_strings_for_leaks: realtime path
+# ────────────────────────────────────────────────────────────────
+
+
+def test_dict_strings_nested_leak():
+    """Mirrors the realtime session config: instruction nested several
+    levels deep. Detector must surface the path."""
+    config = {
+        "instructions": "Hello {master}, please help.",
+        "voice": "alloy",
+    }
+    with pytest.raises(AssertionError) as exc:
+        check_dict_strings_for_leaks(config, context="realtime")
+    assert "{master}" in str(exc.value)
+    assert "instructions" in str(exc.value)
+
+
+def test_dict_strings_deeply_nested_leak():
+    """Gemini-Live-shaped config: setup.system_instruction.parts[0].text"""
+    config = {
+        "setup": {
+            "system_instruction": {
+                "parts": [{"text": "Be helpful to {master}."}],
+            },
+        },
+    }
+    with pytest.raises(AssertionError) as exc:
+        check_dict_strings_for_leaks(config, context="gemini-live")
+    assert "{master}" in str(exc.value)
+
+
+def test_dict_strings_no_leak():
+    config = {
+        "instructions": "Be helpful.",
+        "voice": "alloy",
+        "tools": [{"name": "lookup"}],
+    }
+    check_dict_strings_for_leaks(config)
+
+
+def test_dict_strings_doubled_brace_not_a_leak():
+    config = {"instructions": "Use {{master}} as a placeholder."}
+    check_dict_strings_for_leaks(config)
+
+
+# ────────────────────────────────────────────────────────────────
+# Integration: ChatOpenAI._params actually calls the detector
+# ────────────────────────────────────────────────────────────────
+
+
+def _build_chat_openai():
+    """Build a ChatOpenAI without hitting the network. Constructor only
+    instantiates the SDK clients; that's fine in a unit test because we
+    never call the SDK methods."""
+    from utils.llm_client import ChatOpenAI
+
+    return ChatOpenAI(
+        model="test-model",
+        base_url="http://127.0.0.1:0/v1",
+        api_key="test",
+    )
+
+
+def test_chat_openai_params_raises_on_system_leak():
+    client = _build_chat_openai()
+    messages = [{"role": "system", "content": "Hello {master}."}]
+    with pytest.raises(AssertionError):
+        client._params(messages)
+
+
+def test_chat_openai_params_clean_passes():
+    client = _build_chat_openai()
+    messages = [{"role": "system", "content": "Be helpful."}]
+    p = client._params(messages)
+    assert p["messages"][0]["content"] == "Be helpful."
+
+
+def test_chat_openai_params_user_braces_pass():
+    """Regression guard: user content with literal `{x}` must NOT raise."""
+    client = _build_chat_openai()
+    messages = [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": "What does `{name}` mean in Python f-strings?"},
+    ]
+    client._params(messages)
+
+
+# ────────────────────────────────────────────────────────────────
+# PR #1075 regression smoke
+# ────────────────────────────────────────────────────────────────
+
+
+def test_pr1075_regression_smoke():
+    """Mimic the exact failure mode from PR #1075:
+
+    A prompt-dict entry contains ``{master}`` (added so the footer mirrors
+    the header's placeholder). The consumer fetches it via a ``_loc``-style
+    helper that returns the raw template, then concatenates straight into
+    the system message — no ``.format()`` between the two. The detector
+    must catch this end-to-end via the ``_params`` chokepoint.
+    """
+    SCREEN_SECTION_FOOTER = {
+        "zh": "（屏幕信息结束，{master}）",
+        "en": "(End of screen info, {master})",
+    }
+
+    def _loc(d: dict, lang: str) -> str:  # mimics config.prompts_sys._loc
+        return d.get(lang, d.get("en", d.get("zh", "")))
+
+    sf = _loc(SCREEN_SECTION_FOOTER, "en")  # bug: forgot .format(master=name)
+    system_prompt = f"You are a helpful assistant.\n\n{sf}"
+
+    client = _build_chat_openai()
+    with pytest.raises(AssertionError) as exc:
+        client._params([{"role": "system", "content": system_prompt}])
+    assert "{master}" in str(exc.value)
+
+
+def test_pr1075_regression_fixed_path():
+    """Same scenario, but the consumer remembered to .format(). Must pass."""
+    SCREEN_SECTION_FOOTER = {
+        "en": "(End of screen info, {master})",
+    }
+    sf = SCREEN_SECTION_FOOTER["en"].format(master="Alice")
+    system_prompt = f"You are a helpful assistant.\n\n{sf}"
+
+    client = _build_chat_openai()
+    p = client._params([{"role": "system", "content": system_prompt}])
+    assert "{master}" not in p["messages"][0]["content"]
+    assert "Alice" in p["messages"][0]["content"]

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -330,6 +330,21 @@ class ChatOpenAI:
         # straight through to the SDK call.
         p.update(overrides)
 
+        # Catch prompt-template leaks: literal {placeholder} that should have
+        # been .format()-ed before reaching the wire. See
+        # utils/llm_prompt_leak_check.py for the rationale and severity
+        # contract (raise in tests, warn in prod).
+        try:
+            from utils import llm_prompt_leak_check
+            llm_prompt_leak_check.check_messages_for_leaks(
+                p["messages"], context=f"ChatOpenAI._params model={self.model}"
+            )
+        except AssertionError:
+            raise
+        except Exception:
+            # Detector bugs must never break the LLM call itself.
+            pass
+
         # TEMPORARY: prompt audit log (env NEKO_LLM_PROMPT_AUDIT=1). Remove with
         # utils/llm_prompt_audit.py once budget tuning is done.
         try:

--- a/utils/llm_prompt_leak_check.py
+++ b/utils/llm_prompt_leak_check.py
@@ -1,0 +1,239 @@
+"""LLM prompt placeholder leak detector.
+
+Bug class this guards against
+-----------------------------
+Prompt templates in ``config/prompts_*.py`` use Python ``str.format()`` style
+placeholders like ``{master}`` / ``{window}``. The producer side embeds the
+placeholder; the consumer side is responsible for calling ``.format(...)`` to
+expand it. When a consumer forgets — e.g. ``sf = _loc(SOME_TEMPLATE, lang)``
+returns the raw template string and gets concatenated straight into a system
+message — the literal ``{master}`` characters reach the LLM, which is at best
+confusing and at worst leaks framework internals into the model output.
+
+Real-world case that motivated this module: PR #1075. ``SCREEN_SECTION_FOOTER``
+in ``config/prompts_proactive.py`` was given a ``{master}`` placeholder so it
+mirrored the corresponding header. The header was rendered with ``.format()``;
+the footer's consumer in ``main_routers/system_router.py`` used ``_loc()``
+without ``.format()``. The literal ``{master}`` shipped to the LLM. Caught only
+by a Codex review — i.e. by luck.
+
+Strategy
+--------
+Per-prompt unit tests don't scale: every new prompt would need someone to
+remember to add its test. The only layer that automatically covers all current
+*and future* prompts is the LLM-call chokepoint, since every prompt has to
+flow through it on the way out. So we hook the request-body construction in
+``utils.llm_client.ChatOpenAI._params()`` and the realtime equivalent in
+``main_logic.omni_realtime_client.OmniRealtimeClient.update_session()``.
+
+Scope: system role only
+-----------------------
+We deliberately scan only ``role == "system"`` messages. Justification:
+
+* The bug class is "template not rendered". Templates are almost exclusively
+  used in instructional/system prompts. Renderers do not pour templates into
+  user/assistant turns in this codebase today.
+* User and assistant content can legitimately contain literal ``{...}``
+  characters — users paste Python f-string snippets, JSON schemas, Rust
+  generic syntax, etc. Scanning those would produce false positives that
+  drown the real signal.
+* If a future feature ever pushes a template through a non-system role
+  (e.g. `system_router` starts injecting a rendered system prompt as a
+  ``user`` priming turn), expand the role allowlist below. Don't widen it
+  speculatively.
+
+Tool-calling fields (``tool_calls`` arguments JSON, ``tool`` role results)
+are also skipped: those are model-generated or pre-serialized JSON where a
+bare ``{`` is structural, not a placeholder.
+
+Severity
+--------
+* Test/CI environments (``PYTEST_CURRENT_TEST`` is set, or the user explicitly
+  requests with ``NEKO_PROMPT_LEAK_RAISE=1``): raise ``AssertionError``. This
+  way *any* existing test that happens to hit the buggy path will fail loud,
+  even if it wasn't designed as a prompt-leak test.
+* Production: ``logger.warning(...)``. We never want a malformed prompt to
+  break the user's running session — but we still want the warning in the
+  logs for the bug-bash next morning.
+
+The detector itself must never raise into the LLM call site (other than the
+intentional test-mode ``AssertionError``). Callers wrap invocations in
+``try/except`` and let ``AssertionError`` propagate while swallowing other
+exceptions. See ``utils.llm_client._params`` for the canonical wiring.
+"""
+from __future__ import annotations
+
+import os
+import re
+from typing import Any, Iterable
+
+from utils.logger_config import get_module_logger
+
+logger = get_module_logger(__name__)
+
+# Match ``{name}`` / ``{master_name}`` / ``{a1b2}`` — a Python identifier
+# wrapped in single braces. Negative look-around on ``{{`` / ``}}`` lets the
+# legitimate doubled-brace escape pass through. The leading char must be
+# ``[A-Za-z_]`` to avoid matching ``{0}`` etc., which we don't use anywhere
+# in this codebase but are also not the bug shape we're chasing.
+_PLACEHOLDER_RE = re.compile(r"(?<!\{)\{[A-Za-z_][A-Za-z_0-9]*\}(?!\})")
+
+# Roles where a template leak is plausible. Keep narrow on purpose — see the
+# module docstring.
+_SCANNED_ROLES = frozenset({"system"})
+
+
+def _is_test_or_forced() -> bool:
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return True
+    flag = os.environ.get("NEKO_PROMPT_LEAK_RAISE", "")
+    return flag.lower() in ("1", "true", "yes")
+
+
+def check_text_for_leaks(text: Any) -> list[str]:
+    """Return all unresolved ``{placeholder}`` substrings found in ``text``.
+
+    ``text`` may be ``None`` or a non-string; in those cases we return ``[]``
+    silently so callers can pass message ``content`` straight in without
+    type-checking. Order is preserved; duplicates are kept (so a callsite log
+    line communicates how bad the leak is).
+    """
+    if not isinstance(text, str) or not text:
+        return []
+    return _PLACEHOLDER_RE.findall(text)
+
+
+def _iter_text_parts(content: Any) -> Iterable[str]:
+    """Yield every text-like fragment inside an OpenAI ``content`` field.
+
+    Handles plain strings, multimodal lists (``[{type:'text', text:...},
+    {type:'image_url', ...}]``) and the rare single-dict shape. Image parts
+    are skipped — base64 payloads can't contain a stray ``{master}`` and
+    scanning them would just waste cycles and risk regex pathologies.
+    """
+    if isinstance(content, str):
+        yield content
+        return
+    if isinstance(content, list):
+        for part in content:
+            yield from _iter_text_parts(part)
+        return
+    if isinstance(content, dict):
+        ptype = content.get("type")
+        if ptype in ("text", "input_text", "output_text"):
+            t = content.get("text")
+            if isinstance(t, str):
+                yield t
+        # image_url / input_image / tool_use payloads etc. → skip.
+        return
+    # Unknown shape: don't try to coerce to str — that would risk producing
+    # spurious placeholder hits from dict reprs.
+    return
+
+
+def _report(leaks: list[str], where: str) -> None:
+    """Emit a leak report. Raises in test mode, warns otherwise.
+
+    ``where`` is a short tag identifying the call-site (e.g. ``"_params:
+    model=gpt-4o-mini, msg[0]"``). Kept free-form since callers know best
+    what context to surface.
+    """
+    if not leaks:
+        return
+    # Dedupe for the message body but preserve count for the summary so we
+    # don't bury a 50-instance leak under a tidy "{master}".
+    unique = sorted(set(leaks))
+    msg = (
+        f"LLM payload contains {len(leaks)} unresolved placeholder occurrence(s) "
+        f"({len(unique)} unique): {unique} at {where}"
+    )
+    if _is_test_or_forced():
+        raise AssertionError(msg)
+    logger.warning(msg)
+
+
+def check_messages_for_leaks(messages: Any, context: str = "") -> None:
+    """Scan an OpenAI-format ``messages`` list for unresolved placeholders.
+
+    Only inspects ``role == "system"`` messages — see the module docstring
+    for the rationale and the criteria for widening the scope.
+
+    ``messages`` is permitted to be any iterable of dicts; non-dict entries
+    are skipped silently (the message-normalization layer in ``llm_client``
+    has already coerced everything by the time we get here, but we stay
+    defensive so this function is also callable in tests against raw
+    fixtures).
+    """
+    if not messages:
+        return
+    try:
+        iterator = list(messages)
+    except TypeError:
+        return
+    all_leaks: list[tuple[int, list[str]]] = []
+    for idx, msg in enumerate(iterator):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role not in _SCANNED_ROLES:
+            continue
+        for text in _iter_text_parts(msg.get("content")):
+            hits = check_text_for_leaks(text)
+            if hits:
+                all_leaks.append((idx, hits))
+    if not all_leaks:
+        return
+    flat: list[str] = []
+    for _idx, hits in all_leaks:
+        flat.extend(hits)
+    where_parts: list[str] = []
+    if context:
+        where_parts.append(context)
+    where_parts.append(
+        "messages[" + ",".join(str(i) for i, _ in all_leaks) + "].content"
+    )
+    _report(flat, where=" | ".join(where_parts))
+
+
+def check_dict_strings_for_leaks(d: Any, context: str = "") -> None:
+    """Recursively scan every string value inside a nested dict/list ``d``.
+
+    Used by the realtime path: the OpenAI Realtime / Gemini Live session
+    config nests the system instruction at provider-specific paths
+    (``session.instructions`` vs ``setup.system_instruction.parts[].text``
+    vs ``config.system_instruction.parts[].text``). Walking the whole tree
+    is simpler and provider-agnostic, which the codebase's symmetry rules
+    require.
+
+    Same severity contract as ``check_messages_for_leaks``: raise in tests,
+    warn in production.
+    """
+    if d is None:
+        return
+    leaks: list[str] = []
+    paths: list[str] = []
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, str):
+            hits = check_text_for_leaks(node)
+            if hits:
+                leaks.extend(hits)
+                paths.append(path or "<root>")
+            return
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _walk(v, f"{path}.{k}" if path else str(k))
+            return
+        if isinstance(node, list):
+            for i, v in enumerate(node):
+                _walk(v, f"{path}[{i}]")
+            return
+
+    _walk(d, "")
+    if not leaks:
+        return
+    where_parts: list[str] = []
+    if context:
+        where_parts.append(context)
+    where_parts.append("paths=" + ",".join(paths))
+    _report(leaks, where=" | ".join(where_parts))


### PR DESCRIPTION
## Motivation

防一类 bug：prompt dict 里加了 `{xxx}` 占位符（本应被 `.format()` 展开），但消费端用 `_loc()` 直接拿原文没 format，结果字面 `{xxx}` 漏到发给 LLM 的 payload 里。

最近一个真实案例：**PR #1075**。`config/prompts_proactive.py` 的 `SCREEN_SECTION_FOOTER` 加了 `{master}`（为了和 header 对偶），但 `main_routers/system_router.py` 的 `sf = _loc(SCREEN_SECTION_FOOTER, lang)` 没调 `.format()`。Codex review 抓到了，但人肉 review 不可靠——所以做这个自动检测。

## 设计

唯一对的层是 LLM 调用 chokepoint——任何 prompt 离开系统前必经之路，自动覆盖未来所有新 prompt（per-prompt 测试方案明确否决：新 prompt 没人记得加测，覆盖不全）。

**严重程度**
- 测试/CI 态（`PYTEST_CURRENT_TEST` 存在 或 `NEKO_PROMPT_LEAK_RAISE=1`）→ `raise AssertionError`，让任何跑过该路径的现有测试一并失败
- prod 态 → `logger.warning(...)`，永不打断 LLM 调用

**扫描范围（重要！避免误伤）**
- **只扫 `role == "system"` 的 message**——bug class 是模板渲染漏 `.format()`，模板几乎只用在 system 角色
- user/assistant 是对话内容，可能合法包含 `{...}` 字面（用户贴 Python/Rust 代码片段、JSON schema 例子等），扫了会误伤
- multimodal content 递归进 text part，跳过 image_url

**正则**：`(?<!\{)\{[a-zA-Z_][a-zA-Z_0-9]*\}(?!\})` — 匹配 `{name}` `{master_name}`，忽略 `{{escaped}}` / `{0}` / 孤零零的 `{`/`}`

## 改动

| 文件 | 内容 |
|---|---|
| `utils/llm_prompt_leak_check.py` (新) | 检测器，提供 `check_text_for_leaks` / `check_messages_for_leaks` / `check_dict_strings_for_leaks` |
| `utils/llm_client.py` | `ChatOpenAI._params()` 在 audit hook 之前接入文本/视觉路径 |
| `main_logic/omni_realtime_client.py` | `OmniRealtimeClient.update_session()` 接入 realtime 路径（递归扫 session config，provider-agnostic 满足 OpenAI Realtime / Gemini Live 不同的嵌套 schema） |
| `tests/unit/test_llm_prompt_leak_check.py` (新) | 31 个测试 |

两个接入点都用 `try/except AssertionError → raise else pass` 守护：detector bug 不能拖累 LLM 调用，但测试态故意 raise 必须传播。

## 测试覆盖

- `check_text_for_leaks` 正/反例：`{master}` ✓ / `{{escaped}}` ✗ / `{}` ✗ / `{ master }` ✗ / `{0}` ✗ / None ✗
- 只扫 system：user/assistant 含 `{master}` 不报；system 含 `{master}` 在 pytest 态 raise
- multimodal：system content 是 list of `{type:text}` + `{type:image_url}` 也能命中（且 image base64 不会误判）
- 双花括号转义：`{{master}}` 在 system 也不报
- prod-vs-test 模式：用 `monkeypatch` 模拟无 pytest 环境验证 logger.warning + `NEKO_PROMPT_LEAK_RAISE=1` 强制 raise
- `_params()` 集成：mock ChatOpenAI 实例传 leaky system message → raise；user 含 `{name}` → 不 raise
- PR #1075 端到端 regression smoke：复刻 `_loc` 漏 `.format()` 的真实路径，确认能被 `_params` 抓到

## 验证

```
uv run pytest tests/unit/ --tb=short -q
1653 passed, 14 skipped, 11 warnings in 97.61s
```

新加的 31 个测试全过；现有测试全过——无 false positive，无现存隐藏 bug。

## 后续扩展点（不在本 PR 范围）

- 如果将来 `system_router` 把模板扔进 user 角色（priming），把 `_SCANNED_ROLES` 加上 `"user"`
- 如果有合法的 `{xxx}` 字面常量需要白名单，在 detector 里加白名单 set（目前不需要）


---
_Generated by [Claude Code](https://claude.ai/code/session_017WNxNn7kNHKGL9Y98MbKvN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增提示泄漏检测机制，可识别并阻止未解析的格式字符串意外进入模型请求。

* **测试**
  * 新增单元测试，全面覆盖提示泄漏检测功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->