### PR TITLE
fix(llm_client): 防御性读取 choices[0].message，避免 free-agent-model 空 message 崩溃

### DIFF
--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -567,7 +567,12 @@ class ComputerUseAdapter:
                     extra_body=extra or None,
                     timeout=20,
                 )
-                _ = resp.choices[0].message.content
+                # 连通性检测只关心 HTTP 层是否通、响应结构是否合法；某些上游
+                # （如 free-agent-model）会返回 choices 非空但 message=None
+                # 的合法 200，message 为空也视为成功。
+                choice = resp.choices[0] if resp.choices else None
+                msg = choice.message if choice else None
+                _ = getattr(msg, "content", None)
                 self.init_ok = True
                 self.last_error = None
                 logger.info("[CUA] LLM connectivity OK (%s @ %s)", model, base_url)

--- a/tests/unit/test_llm_client_response_safety.py
+++ b/tests/unit/test_llm_client_response_safety.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for ChatOpenAI defensive response reads.
+
+Background: free-agent-model 上游会返回 HTTP 200 + choices 非空，但
+choices[0].message 是 None 的合法响应。原来 ainvoke/invoke 直接
+.message.content 会触发 'NoneType' object has no attribute 'content'，
+连通性预检随之失败。这里固定该场景下不再崩溃、content 退化为 ""。
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from utils.llm_client import ChatOpenAI
+
+
+def _make_client_with_response(resp) -> ChatOpenAI:
+    """Construct a ChatOpenAI and stub both sync/async create() to return resp."""
+    client = ChatOpenAI(model="free-agent-model", base_url="https://example.com/v1", api_key="free-access")
+    client._aclient = MagicMock()
+    client._aclient.chat = MagicMock()
+    client._aclient.chat.completions = MagicMock()
+    client._aclient.chat.completions.create = AsyncMock(return_value=resp)
+    client._client = MagicMock()
+    client._client.chat = MagicMock()
+    client._client.chat.completions = MagicMock()
+    client._client.chat.completions.create = MagicMock(return_value=resp)
+    return client
+
+
+def _resp_with_none_message():
+    """choices=[choice], choice.message is None — what free-agent-model returns."""
+    resp = MagicMock()
+    choice = MagicMock()
+    choice.message = None
+    resp.choices = [choice]
+    resp.usage = None
+    return resp
+
+
+def _resp_with_empty_choices():
+    resp = MagicMock()
+    resp.choices = []
+    resp.usage = None
+    return resp
+
+
+def _resp_with_none_content():
+    resp = MagicMock()
+    choice = MagicMock()
+    choice.message = MagicMock()
+    choice.message.content = None
+    resp.choices = [choice]
+    resp.usage = None
+    return resp
+
+
+class TestAinvokeDefensiveRead:
+    @pytest.mark.asyncio
+    async def test_none_message_returns_empty_string(self):
+        client = _make_client_with_response(_resp_with_none_message())
+        out = await client.ainvoke([{"role": "user", "content": "hi"}])
+        assert out.content == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_returns_empty_string(self):
+        client = _make_client_with_response(_resp_with_empty_choices())
+        out = await client.ainvoke([{"role": "user", "content": "hi"}])
+        assert out.content == ""
+
+    @pytest.mark.asyncio
+    async def test_none_content_returns_empty_string(self):
+        client = _make_client_with_response(_resp_with_none_content())
+        out = await client.ainvoke([{"role": "user", "content": "hi"}])
+        assert out.content == ""
+
+
+class TestInvokeDefensiveRead:
+    def test_none_message_returns_empty_string(self):
+        client = _make_client_with_response(_resp_with_none_message())
+        out = client.invoke([{"role": "user", "content": "hi"}])
+        assert out.content == ""
+
+    def test_empty_choices_returns_empty_string(self):
+        client = _make_client_with_response(_resp_with_empty_choices())
+        out = client.invoke([{"role": "user", "content": "hi"}])
+        assert out.content == ""
+
+    def test_none_content_returns_empty_string(self):
+        client = _make_client_with_response(_resp_with_none_content())
+        out = client.invoke([{"role": "user", "content": "hi"}])
+        assert out.content == ""

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -372,14 +372,20 @@ class ChatOpenAI:
         ``_params()`` so concurrent callers on the same client don't
         clobber each other's budgets. See ``ainvoke_raw`` for details."""
         resp = await self._aclient.chat.completions.create(**self._params(messages, **overrides))
-        content = resp.choices[0].message.content if resp.choices else ""
+        # 防御性读取：部分上游（如 free-agent-model）会返回 choices 非空但
+        # message=None 的合法响应，直接 .message.content 会 NoneType 崩溃。
+        choice = resp.choices[0] if resp.choices else None
+        msg = choice.message if choice else None
+        content = getattr(msg, "content", None)
         usage_dict = resp.usage.model_dump() if resp.usage else {}
         return LLMResponse(content=content or "", response_metadata={"token_usage": usage_dict})
 
     def invoke(self, messages: Any, **overrides: Any) -> LLMResponse:
         """Sync twin of ``ainvoke``. See its docstring for ``overrides``."""
         resp = self._client.chat.completions.create(**self._params(messages, **overrides))
-        content = resp.choices[0].message.content if resp.choices else ""
+        choice = resp.choices[0] if resp.choices else None
+        msg = choice.message if choice else None
+        content = getattr(msg, "content", None)
         usage_dict = resp.usage.model_dump() if resp.usage else {}
         return LLMResponse(content=content or "", response_metadata={"token_usage": usage_dict})
 


### PR DESCRIPTION
## Summary

- 部分 OpenAI-兼容上游（如 `free-agent-model @ https://www.lanlan.app/text/v1`）会返回 HTTP 200 + `choices` 非空，但 `choices[0].message` 为 `None` 的合法响应。原代码直接访问 `.message.content` 触发 `'NoneType' object has no attribute 'content'`，连通性预检随之失败。
- [utils/llm_client.py](utils/llm_client.py) `ainvoke` / `invoke` 改为逐层 None-safe 读取（`choice → msg → content`），与已有 `astream` 的写法对齐。
- [brain/computer_use.py](brain/computer_use.py) CUA agent 连通性 ping 同步修同款访问，`message` 为空也视为 HTTP 层正常。

## Root cause

[utils/llm_client.py:375](utils/llm_client.py:375) 与 [utils/llm_client.py:382](utils/llm_client.py:382) 旧写法只判 `resp.choices` 是否为空，不判 `choices[0].message` 是否为 `None`：

```python
content = resp.choices[0].message.content if resp.choices else ""
```

新写法（与 `astream` 426–428 行对偶）：

```python
choice = resp.choices[0] if resp.choices else None
msg = choice.message if choice else None
content = getattr(msg, "content", None)
```

下游 `LLMResponse(content=content or "")` 已有 `or ""` 兜底，行为一致：`None`/空字符串 → 空 `LLMResponse`，不再抛异常。

## Test plan

- [x] 新增 [tests/unit/test_llm_client_response_safety.py](tests/unit/test_llm_client_response_safety.py)，覆盖 `ainvoke` / `invoke` × `(message=None / choices=[] / content=None)` 共 6 个 case，全部通过
- [x] 既有 [tests/unit/test_connectivity_endpoint.py](tests/unit/test_connectivity_endpoint.py) 48 个 case 全部通过，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了 LLM 连接性检查的鲁棒性，现在可以正确处理响应消息缺失的情况
* 增强了 LLM 客户端的防御性处理，在响应数据不完整时不再抛出错误
* 添加了全面的回归测试，确保边界情况下的响应处理正确性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->