### PR TITLE
fix: API URL 末尾不带斜杠，修反代下角色卡加载失败 + 前后端 lint 守门

### DIFF
--- a/.agent/rules/neko-guide.md
+++ b/.agent/rules/neko-guide.md
@@ -16,6 +16,25 @@ trigger: always_on
   - **模型从 tier 拿，不 hardcoded fallback**：每个 LLM 调用都通过 `config_manager.get_model_api_config(<tier>)` 拿 model/base_url/api_key 三件套。不要再写 `api_config.get('model', SETTING_PROPOSER_MODEL)` 这类 fallback——`SETTING_PROPOSER_MODEL` / `SETTING_VERIFIER_MODEL` 已于 2026-04 退环境。tier 未配好时让 API 直接拒绝，比静默回退到 qwen-max 更安全。
   - **memory 子模块按职责选 tier**：fact extraction / signal detection / reflection synthesis / fact dedup / recall rerank 走 `summary`；recent.review + persona.correction + promotion merge 走 `correction`。不要为单点新增 hardcoded 模型名。
 
+## API URL 末尾不带斜杠（前后端硬性要求）
+
+后端 route 声明、前端调用都必须用**不带末尾斜杠**的形式：
+
+- ✅ `/api/characters`、`/api/live2d/models`、`/api/memory/funnel/{lanlan_name}`
+- ❌ `/api/characters/`、`/api/live2d/models/`
+
+理由：
+1. **跟主流 REST API 一致**：Stripe / GitHub / Google / AWS / Microsoft REST API Guidelines 全都禁止末尾斜杠。
+2. **反代场景下不会炸**：FastAPI/Starlette 默认 `redirect_slashes=True`，把 `/foo/` 307 重定向到 `/foo`，但 `Location` 是用 request `Host` 拼出来的**绝对 URL**。如果反代没透传 `Host`、或 `proxy_headers` 没开（`NEKO_BEHIND_PROXY=1`），重定向就指向上游 `127.0.0.1:<内网端口>`，浏览器从局域网跟过去拿到 `ERR_CONNECTION_REFUSED`。PR #938 引发的角色卡管理回归就是这个 bug，根因不在反代而在我们前端写了带斜杠的 URL 把锅推给了 starlette 的脆弱重定向。**不带斜杠 = 永远不触发 307 = 整类问题消失。**
+
+具体规则：
+- **后端**：`APIRouter(prefix="/api/foo")` + `@router.get('')`（不是 `@router.get('/')`）。唯一例外是 `pages_router.py` 里 `@router.get("/")` —— 那是根页面 `index.html`，本来就该是 `/`。
+- **前端**：`fetch('/api/foo')`，不是 `fetch('/api/foo/')`。**前缀拼接**（例如 `` `/api/foo/${id}` `` 或 `` '/api/foo/' + encodeURIComponent(name) + '/sub' ``）里的中间斜杠是路径分隔符，不算违反——最终 URL 不带末尾斜杠就行。
+
+CI 守门：
+- `scripts/check_api_trailing_slash.py` —— AST 扫 `main_routers/*.py` 和 `*_server.py` 里的 `@router.get/post/...` 装饰器
+- `scripts/check_frontend_api_trailing_slash.py` —— 正则扫 `static/` / `frontend/` / `templates/` 里以 `/'` 或 `/"` 或 `` /` `` 结尾的 `/api/...` 字面量（前缀拼接形式自动豁免）
+
 ## 代码风格
 
 - **对偶性（symmetry）是硬性要求**：如果 MiniMax 拆了单独文件，Qwen 也必须拆；如果有三个 provider，它们的处理路径必须结构对称。不对偶的代码会被直接打回。

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   python-lint:
-    name: Python lint (ruff + async-blocking + no-loguru + no-temperature + prompt-hygiene + i18n-sync + docs-no-relative-paths)
+    name: Python lint (ruff + async-blocking + no-loguru + no-temperature + prompt-hygiene + i18n-sync + docs-no-relative-paths + api-trailing-slash + frontend-api-trailing-slash)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -97,3 +97,27 @@ jobs:
         # Fix is to inline the path as code (`foo/bar.js`) instead of a
         # link, or move the referenced content into docs/.
         run: python scripts/check_docs_no_relative_paths.py
+
+      - name: Forbid trailing-slash route paths on FastAPI decorators (backend)
+        # Project convention: every backend HTTP/WebSocket endpoint is
+        # declared WITHOUT a trailing slash. Avoids Starlette's absolute-URL
+        # 307 redirect under reverse proxies — root cause of the PR #938
+        # chara_manager regression: nginx/etc that don't transparently
+        # forward Host send the redirect Location to 127.0.0.1:<internal>,
+        # which the LAN browser can't reach (ERR_CONNECTION_REFUSED).
+        # The lint exempts the literal '/' root page and explicit alias pairs
+        # (same function carrying both '/foo' and '/foo/'). See
+        # .agent/rules/neko-guide.md (§"API URL 末尾不带斜杠") and
+        # main_routers/characters_router.py docstring.
+        run: python scripts/check_api_trailing_slash.py
+
+      - name: Forbid trailing-slash /api/... URL literals (frontend)
+        # Counterpart to check_api_trailing_slash.py: the backend may declare
+        # /api/foo without trailing slash, but if frontend code calls
+        # fetch('/api/foo/') the same 307 → ERR_CONNECTION_REFUSED happens.
+        # Regex sniffer over static/, frontend/, templates/. Recognises
+        # prefix builders ('/api/foo/' + id, `/api/foo/${id}`) and exempts
+        # them; flags only standalone literals ending in '/'. Suppress with
+        # // noqa: API_TRAILING_SLASH if calling a third-party API that
+        # genuinely requires the slash.
+        run: python scripts/check_frontend_api_trailing_slash.py

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -14,6 +14,28 @@
 - **No framework** — The frontend uses vanilla JS by design
 - **i18n** — All user-facing strings should use the locale system
 
+## API URLs — no trailing slash
+
+Every backend API endpoint and every frontend caller MUST use the no-trailing-slash form:
+
+- ✅ `/api/characters`, `/api/live2d/models`, `/api/memory/funnel/{lanlan_name}`
+- ❌ `/api/characters/`, `/api/live2d/models/`
+
+Rationale (see `.agent/rules/neko-guide.md` for the full incident write-up):
+
+1. **Industry convention.** Stripe, GitHub, Google, AWS, and the Microsoft REST API Guidelines all forbid trailing slashes on REST resources. We follow the same convention so callers' instincts match.
+2. **Reverse-proxy safety.** FastAPI/Starlette's `redirect_slashes=True` (default) sends a 307 to the no-slash form with an **absolute** `Location` header built from the request's `Host`. Behind a reverse proxy that doesn't preserve `Host` (or with `proxy_headers` off), that absolute URL points at the internal `127.0.0.1:<port>` and the browser fails with `ERR_CONNECTION_REFUSED`. The bug we shipped in PR #938 (chara_manager regression on LAN reverse proxies) is exactly this. Avoiding the redirect entirely sidesteps the whole class of failure.
+
+Concrete rules:
+
+- **Backend** — `APIRouter(prefix="/api/foo")` + `@router.get('')` (NOT `@router.get('/')`). The only exception is the literal root page `@router.get("/")` in `pages_router.py`.
+- **Frontend** — `fetch('/api/foo')`, never `fetch('/api/foo/')`. Prefix builders that concatenate a variable (e.g. `` `/api/foo/${id}` ``, `` '/api/foo/' + encodeURIComponent(name) ``) are fine — the slash is a path separator, the final URL still has no trailing slash.
+
+Both rules are enforced by CI:
+
+- `scripts/check_api_trailing_slash.py` — backend AST check on `main_routers/*.py` and `*_server.py`
+- `scripts/check_frontend_api_trailing_slash.py` — frontend regex check on `static/`, `frontend/`, `templates/`
+
 ## Commit messages
 
 Follow conventional commits when possible:

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -7,6 +7,11 @@ Handles agent-related endpoints including:
 - Health checks
 - Task status
 - Admin control
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import time

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -6,6 +6,18 @@ Handles character (catgirl) management endpoints including:
 - Character CRUD operations
 - Voice settings
 - Microphone settings
+
+URL convention
+--------------
+Every endpoint here is declared WITHOUT a trailing slash (e.g.
+``@router.get('')`` not ``@router.get('/')``, ``@router.get('/voices')`` not
+``@router.get('/voices/')``). Frontend callers must match exactly — never
+``fetch('/api/characters/')``. Triggering Starlette's slash-redirect 307
+returns an absolute ``Location`` built from the request ``Host`` and breaks
+under reverse proxies that don't transparently forward ``Host``. See
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the full
+rationale and the PR #938 incident; ``scripts/check_api_trailing_slash.py``
++ ``scripts/check_frontend_api_trailing_slash.py`` enforce this in CI.
 """
 import re
 import json

--- a/main_routers/cloudsave_router.py
+++ b/main_routers/cloudsave_router.py
@@ -4,6 +4,11 @@ Cloudsave Router
 
 Provides cloudsave summary, single-character upload/download APIs,
 and safety checks around runtime reload.
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -7,6 +7,11 @@ Handles configuration-related API endpoints including:
 - API configuration (core and custom APIs)
 - Steam language settings
 - API providers
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/cookies_login_router.py
+++ b/main_routers/cookies_login_router.py
@@ -2,8 +2,13 @@
 """
 Cookies Login Router - Enhanced
 
-Handles authentication-related endpoints with strict validation and 
+Handles authentication-related endpoints with strict validation and
 unified logic for credential management.
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/jukebox_router.py
+++ b/main_routers/jukebox_router.py
@@ -7,6 +7,11 @@ Handles jukebox-related endpoints including:
 - Action/VMD management (upload, list, delete)
 - Song-Action binding management
 - Configuration import/export
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/live2d_router.py
+++ b/main_routers/live2d_router.py
@@ -8,6 +8,11 @@ Handles Live2D model-related endpoints including:
 - Model parameters
 - Emotion mappings
 - Model upload
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/memory_router.py
+++ b/main_routers/memory_router.py
@@ -5,6 +5,11 @@ Memory Router
 Handles memory-related endpoints including:
 - Recent files listing
 - Memory review configuration
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/mmd_router.py
+++ b/main_routers/mmd_router.py
@@ -7,6 +7,11 @@ Handles MMD model-related endpoints including:
 - MMD model upload
 - VMD animation listing and upload
 - MMD emotion mapping configuration
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import asyncio

--- a/main_routers/music_router.py
+++ b/main_routers/music_router.py
@@ -1,4 +1,14 @@
-# 音乐路由
+# -*- coding: utf-8 -*-
+"""
+Music Router
+
+Handles music search / playback / lyric proxy endpoints.
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
+"""
 
 import asyncio
 

--- a/main_routers/pages_router.py
+++ b/main_routers/pages_router.py
@@ -3,6 +3,14 @@
 Pages Router
 
 Handles HTML page rendering endpoints.
+
+URL convention: routes declared WITHOUT trailing slash. The literal root
+``@router.get("/")`` is the only legitimate trailing-slash route in the entire
+codebase (it serves ``index.html``); the lint exempts it explicitly. Every
+other page route uses ``@router.get('/voice_clone')``, ``@router.get('/api_key')``,
+etc. See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import time

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -4,6 +4,11 @@ Storage-location bootstrap API for the main web app.
 
 Stage 3 keeps the same homepage bootstrap entry, adds the shutdown/restart
 checkpoint flow, and exposes maintenance-state diagnostics for the web UI.
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 from __future__ import annotations

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -7,6 +7,11 @@ Handles system-related endpoints including:
 - Emotion analysis
 - Steam achievements
 - File utilities (file-exists, find-first-image, proxy-image)
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import os

--- a/main_routers/tool_router.py
+++ b/main_routers/tool_router.py
@@ -42,6 +42,11 @@ Endpoints
 
 The HTTP dispatcher does NOT proxy in-process tools — those are
 registered directly via ``LLMSessionManager.register_tool``.
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 from __future__ import annotations
 

--- a/main_routers/vrm_router.py
+++ b/main_routers/vrm_router.py
@@ -7,6 +7,11 @@ Handles VRM model-related endpoints including:
 - VRM model upload
 - VRM animation listing
 - VRM emotion mapping configuration
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import json

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -6,6 +6,12 @@ Handles WebSocket endpoints including:
 - Main WebSocket connection for chat
 - Proactive chat
 - Task notifications
+
+URL convention: WebSocket routes (``@router.websocket('/ws/...')``) follow the
+same no-trailing-slash rule as HTTP routes. See
+``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import json

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -7,6 +7,11 @@ Handles Steam Workshop-related endpoints including:
 - Item publishing
 - Workshop configuration
 - Local items management
+
+URL convention: routes declared WITHOUT trailing slash (no ``@router.get('/')``).
+See ``main_routers/characters_router.py`` docstring or
+``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") for the rationale;
+enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import os

--- a/scripts/check_api_trailing_slash.py
+++ b/scripts/check_api_trailing_slash.py
@@ -190,6 +190,14 @@ def _extract_methods(call: ast.Call, decorator_method: str) -> frozenset[str]:
         for elt in kw.value.elts:
             if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
                 out.add(elt.value.upper())
+            else:
+                # Mixed static/dynamic list — e.g. ``methods=["GET", SOME_CONST]``.
+                # Returning the partial set would let a sibling that only covers
+                # the static methods (e.g. an explicit GET sibling) falsely
+                # exempt the trailing-slash decorator while the dynamic method
+                # remains uncovered. Fail closed. Reported by CodeRabbit on
+                # PR #1082.
+                return frozenset()
         return frozenset(out)
     return _API_ROUTE_DEFAULT_METHODS
 
@@ -405,9 +413,14 @@ def main(argv: list[str] | None = None) -> int:
     targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
 
     total = 0
+    parse_failures = 0
     for file in _iter_python_files(targets):
         tree = _parse_file(file)
         if tree is None:
+            # Read failure / SyntaxError. Don't silently skip — that's
+            # fail-open (the file might have contained the very violation
+            # we exist to catch). Reported by CodeRabbit on PR #1082.
+            parse_failures += 1
             continue
         for lineno, col, msg in check_file(file, tree):
             rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
@@ -425,6 +438,15 @@ def main(argv: list[str] | None = None) -> int:
             "characters_router.py docstring for the full write-up.",
             file=sys.stderr,
         )
+    if parse_failures:
+        print(
+            f"\n{parse_failures} file(s) could not be parsed and were skipped — "
+            "fix the syntax/encoding errors above before re-running. The lint "
+            "exits non-zero in this case to avoid silently passing files it "
+            "didn't actually scan.",
+            file=sys.stderr,
+        )
+    if total or parse_failures:
         return 1
     return 0
 

--- a/scripts/check_api_trailing_slash.py
+++ b/scripts/check_api_trailing_slash.py
@@ -277,10 +277,17 @@ class TrailingSlashChecker(ast.NodeVisitor):
         #   paths are ``/b/foo`` vs ``/a/foo/`` — different namespaces,
         #   the no-slash form for the trailing-slash route still 307s
         #   (Codex finding, round 4).
-        # Owner of ``None`` means we couldn't resolve the LHS of the
-        # decorator (rare); ``None`` is its own group, so two
-        # unresolvable decorators won't accidentally cross-cover.
-        sibling: set[tuple[str | None, str, str]] = set()
+        # Decorators whose owner can't be statically resolved (e.g.
+        # ``@a.router.get(...)`` where the LHS is itself an Attribute,
+        # not a Name) are NOT added to the sibling set, and the
+        # exemption check below also rejects ``owner is None``. Two
+        # unresolved decorators on the same function would otherwise
+        # both map to ``(None, method, path)`` and falsely cross-cover —
+        # caught by CodeRabbit on PR #1082 in the round-5 follow-up
+        # ("Python's `None == None` means the key collides"). Fail
+        # closed: if we can't tell which router owns the decorator, we
+        # can't safely confirm a sibling covers it.
+        sibling: set[tuple[str, str, str]] = set()
         for deco in decos:
             method_name = _is_route_decorator(deco)
             if method_name is None:
@@ -289,6 +296,8 @@ class TrailingSlashChecker(ast.NodeVisitor):
             if extracted is None:
                 continue
             owner = _decorator_owner(deco)
+            if owner is None:
+                continue
             for m in _extract_methods(deco, method_name):
                 sibling.add((owner, m, extracted[0]))
 
@@ -318,9 +327,15 @@ class TrailingSlashChecker(ast.NodeVisitor):
             # method AND the same router. Reported by Codex on PR #1082 in
             # two rounds: round 2 (per-method) and round 4 (per-owner so
             # decorators stacking different routers don't cross-cover).
+            # ``owner is None`` (couldn't statically resolve the decorator
+            # LHS) blocks exemption — see sibling-collection comment above.
             no_slash = route_path.rstrip("/")
             methods = _extract_methods(deco, decorator_method)
-            if methods and all((owner, m, no_slash) in sibling for m in methods):
+            if (
+                owner is not None
+                and methods
+                and all((owner, m, no_slash) in sibling for m in methods)
+            ):
                 continue
             self.violations.append(
                 (

--- a/scripts/check_api_trailing_slash.py
+++ b/scripts/check_api_trailing_slash.py
@@ -36,14 +36,23 @@ where ``router`` is any name and the HTTP method comes from
 
 Allowed exceptions
 ------------------
-* ``@<thing>.get("/")`` — the literal root page. We have exactly one of
-  these: ``main_routers/pages_router.py`` serving ``index.html``. Allowed
-  globally because the root page IS the slash; there's no no-slash form.
+* ``@router.get("/")`` on a router whose declared ``APIRouter(prefix=...)``
+  is empty — the literal root page. We have exactly one of these:
+  ``main_routers/pages_router.py`` serving ``index.html``. Routers with a
+  non-empty prefix are NOT exempt because ``prefix="/api/foo"`` +
+  ``@router.get("/")`` registers ``/api/foo/`` which IS a trailing-slash
+  route (and triggers the same 307 hazard). Reported by CodeRabbit on
+  PR #1082.
 * **Explicit alias pair** — when the same function carries BOTH
   ``@router.get("/foo")`` and ``@router.get("/foo/")``, the trailing-slash
   one is a deliberate alias. The 307-redirect attack vector is gone (the
   slash form returns 200 directly), so the convention's safety property is
-  preserved. SPA entry points (``/ui`` + ``/ui/``) use this pattern.
+  preserved. SPA entry points (``/ui`` + ``/ui/``) use this pattern. The
+  alias check is **per HTTP method**: a trailing-slash GET needs a sibling
+  no-slash GET (a sibling POST does NOT cover it, because GET callers
+  hitting the no-slash form would still trigger the 307). For
+  ``api_route(..., methods=[...])``, every method in the list must have a
+  matching sibling.
 
 Scope
 -----
@@ -152,28 +161,121 @@ def _extract_path_arg(call: ast.Call) -> tuple[str, int, int] | None:
     return None
 
 
+# Methods that ``api_route(..., methods=[...])`` defaults to when the kwarg
+# is omitted. FastAPI matches Starlette here: GET only.
+_API_ROUTE_DEFAULT_METHODS: frozenset[str] = frozenset({"GET"})
+
+
+def _extract_methods(call: ast.Call, decorator_method: str) -> frozenset[str]:
+    """Return the uppercase HTTP method set the decorator registers.
+
+    For ``@router.get/post/...`` the method is implicit in the attribute
+    name. For ``@router.api_route(..., methods=[...])`` it comes from the
+    ``methods`` kwarg (default GET). For ``@router.websocket(...)`` we use
+    the synthetic name ``WEBSOCKET`` so it never collides with HTTP verbs.
+    """
+    if decorator_method == "websocket":
+        return frozenset({"WEBSOCKET"})
+    if decorator_method != "api_route":
+        return frozenset({decorator_method.upper()})
+    # api_route — read methods=[...] kwarg, default GET (matches FastAPI)
+    for kw in call.keywords:
+        if kw.arg != "methods":
+            continue
+        if not isinstance(kw.value, (ast.List, ast.Tuple, ast.Set)):
+            # Dynamic methods list — give up safely (treat as no method, so
+            # alias-pair check fails and the trailing slash gets flagged).
+            return frozenset()
+        out: set[str] = set()
+        for elt in kw.value.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                out.add(elt.value.upper())
+        return frozenset(out)
+    return _API_ROUTE_DEFAULT_METHODS
+
+
+def _collect_router_prefixes(tree: ast.Module) -> dict[str, str]:
+    """Map each module-level router/app name to its declared ``prefix=``.
+
+    Looks for assignments like::
+
+        router = APIRouter(prefix="/api/foo")
+        router = APIRouter()              # → ""
+        app    = FastAPI()                # → "" (FastAPI has no prefix)
+
+    Used by the ``"/"`` exemption: a literal ``@router.get("/")`` is the
+    legitimate root only when the router has no prefix; otherwise the
+    effective registered path is ``<prefix>/`` which IS a trailing-slash
+    route. Reported by CodeRabbit on PR #1082.
+
+    Anything we can't resolve statically (re-imported router, dynamic
+    construction, etc.) is omitted from the map. The downstream check
+    treats "unknown router" conservatively — the ``"/"`` exemption fires
+    only on a known-empty prefix.
+    """
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        # We only care about single-target Name = Call assignments.
+        if len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        func = node.value.func
+        ctor = None
+        if isinstance(func, ast.Name):
+            ctor = func.id
+        elif isinstance(func, ast.Attribute):
+            ctor = func.attr
+        if ctor not in ("APIRouter", "FastAPI"):
+            continue
+        prefix = ""
+        for kw in node.value.keywords:
+            if kw.arg == "prefix" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                prefix = kw.value.value
+                break
+        out[target.id] = prefix
+    return out
+
+
+def _decorator_owner(call: ast.Call) -> str | None:
+    """Return the variable name on the LHS of ``@<name>.<method>(...)``."""
+    if isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name):
+        return call.func.value.id
+    return None
+
+
 class TrailingSlashChecker(ast.NodeVisitor):
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, router_prefixes: dict[str, str]) -> None:
         self.path = path
+        self.router_prefixes = router_prefixes
         self.violations: list[tuple[int, int, str]] = []
 
     def _visit_decorated(self, node: ast.AST) -> None:
         decos = getattr(node, "decorator_list", []) or []
 
-        # First pass: collect every route-decorator path on this function.
-        # Used to detect explicit alias pairs (``/foo`` + ``/foo/``).
-        sibling_paths: set[str] = set()
+        # First pass: collect every (METHOD, path) pair this function
+        # registers. The alias-pair exemption must match BOTH method and
+        # path — see _is_aliased_safely() below for why a same-path /
+        # different-method "sibling" is not safe.
+        sibling: set[tuple[str, str]] = set()
         for deco in decos:
-            if _is_route_decorator(deco) is None:
+            method_name = _is_route_decorator(deco)
+            if method_name is None:
                 continue
             extracted = _extract_path_arg(deco)
             if extracted is None:
                 continue
-            sibling_paths.add(extracted[0])
+            for m in _extract_methods(deco, method_name):
+                sibling.add((m, extracted[0]))
 
         for deco in decos:
-            method = _is_route_decorator(deco)
-            if method is None:
+            decorator_method = _is_route_decorator(deco)
+            if decorator_method is None:
                 continue
             extracted = _extract_path_arg(deco)
             if extracted is None:
@@ -181,13 +283,28 @@ class TrailingSlashChecker(ast.NodeVisitor):
             route_path, lineno, col = extracted
             if not route_path.endswith("/"):
                 continue
-            # Allow the literal root page — there's no no-slash form.
+            # Allow the literal root page — but ONLY when the owning router
+            # has an empty prefix. ``APIRouter(prefix="/api/foo")`` +
+            # ``@router.get("/")`` registers the effective path
+            # ``/api/foo/`` which IS a trailing-slash route, exactly the
+            # bug this lint exists to catch. Reported by CodeRabbit on
+            # PR #1082. If we can't resolve the owner statically (cross-
+            # module router etc.) be conservative and don't exempt.
             if route_path == "/":
-                continue
-            # Allow if a sibling decorator on the same function explicitly
-            # registers the no-slash form. This makes the slash form a
-            # direct 200 (not a 307), neutralising the reverse-proxy hazard.
-            if route_path.rstrip("/") in sibling_paths:
+                owner = _decorator_owner(deco)
+                if owner is not None and self.router_prefixes.get(owner, None) == "":
+                    continue
+            # Allow ONLY if every method this trailing-slash decorator
+            # registers ALSO has a sibling no-slash decorator for the same
+            # method. Otherwise a caller hitting the no-slash form with an
+            # uncovered method still triggers Starlette's 307 redirect (the
+            # exact bug this lint exists to prevent). Reported by Codex on
+            # PR #1082 — without the per-method check, mixed pairs like
+            # ``@router.get('/foo/')`` + ``@router.post('/foo')`` would slip
+            # through even though ``GET /foo`` still 307s.
+            no_slash = route_path.rstrip("/")
+            methods = _extract_methods(deco, decorator_method)
+            if methods and all((m, no_slash) in sibling for m in methods):
                 continue
             self.violations.append(
                 (
@@ -199,8 +316,10 @@ class TrailingSlashChecker(ast.NodeVisitor):
                     ".agent/rules/neko-guide.md (§'API URL 末尾不带斜杠') "
                     "and main_routers/characters_router.py docstring. If you "
                     "genuinely need both forms, register an explicit alias by "
-                    "stacking @router.get('/foo') above @router.get('/foo/') "
-                    "on the same function.",
+                    "stacking @router.<METHOD>('/foo') above "
+                    "@router.<METHOD>('/foo/') on the same function — and the "
+                    "method must match (a sibling POST won't cover a GET that "
+                    "still 307s).",
                 )
             )
         self.generic_visit(node)
@@ -263,7 +382,7 @@ def _parse_file(path: Path) -> ast.Module | None:
 
 
 def check_file(path: Path, tree: ast.Module) -> list[tuple[int, int, str]]:
-    checker = TrailingSlashChecker(path)
+    checker = TrailingSlashChecker(path, _collect_router_prefixes(tree))
     checker.visit(tree)
     return checker.violations
 

--- a/scripts/check_api_trailing_slash.py
+++ b/scripts/check_api_trailing_slash.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Static check: forbid trailing-slash route paths on FastAPI router/app decorators.
+
+Why this exists
+---------------
+Project convention: every backend HTTP/WebSocket endpoint is declared WITHOUT
+a trailing slash. The convention matches Stripe / GitHub / Google / AWS /
+Microsoft REST API Guidelines, but more importantly it sidesteps a class of
+production failure under reverse proxies:
+
+* FastAPI/Starlette's ``redirect_slashes=True`` (default) will 307-redirect
+  ``/foo/`` to ``/foo``.
+* The ``Location`` header is an **absolute** URL built from the request
+  ``Host``. Behind a reverse proxy that doesn't preserve ``Host`` (or with
+  ``proxy_headers`` off, i.e. ``NEKO_BEHIND_PROXY != 1``), that absolute URL
+  points at the internal ``127.0.0.1:<port>`` and the browser dies with
+  ``ERR_CONNECTION_REFUSED``.
+* PR #938 (chara_manager regression on LAN reverse proxies) was exactly this
+  bug. See ``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") and
+  ``main_routers/characters_router.py`` docstring for the full write-up.
+
+Avoiding the redirect entirely (= never declaring a trailing slash) makes
+the whole class of failure impossible.
+
+What it flags
+-------------
+Any decorator call of the form:
+
+    @router.get("/foo/")           # trailing-slash literal
+    @router.post("/foo/bar/")
+    @router.websocket("/ws/foo/")
+    @app.put("/api/v1/foo/")
+
+where ``router`` is any name and the HTTP method comes from
+``METHOD_NAMES``. Path is the first positional argument or ``path=...``.
+
+Allowed exceptions
+------------------
+* ``@<thing>.get("/")`` — the literal root page. We have exactly one of
+  these: ``main_routers/pages_router.py`` serving ``index.html``. Allowed
+  globally because the root page IS the slash; there's no no-slash form.
+* **Explicit alias pair** — when the same function carries BOTH
+  ``@router.get("/foo")`` and ``@router.get("/foo/")``, the trailing-slash
+  one is a deliberate alias. The 307-redirect attack vector is gone (the
+  slash form returns 200 directly), so the convention's safety property is
+  preserved. SPA entry points (``/ui`` + ``/ui/``) use this pattern.
+
+Scope
+-----
+Default scan: ``main_routers/`` + ``*_server.py`` at the repo root +
+``plugin/server/routes/``. Pass paths explicitly to scan elsewhere.
+
+Suppression
+-----------
+None. If you genuinely need a trailing-slash route, delete this script in
+the same PR and justify it in the description.
+
+Output
+------
+Every violation prints as ``path:line:col  API_TRAILING_SLASH  message``.
+Exit status is 1 when any violation is found, 0 otherwise.
+
+Usage::
+
+    uv run python scripts/check_api_trailing_slash.py [paths...]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_PATHS: list[str] = [
+    "main_routers",
+    "main_server.py",
+    "memory_server.py",
+    "agent_server.py",
+    "plugin/server/routes",
+]
+
+EXCLUDE_DIRS = {
+    ".venv",
+    "venv",
+    "frontend",
+    "dist",
+    "build",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    ".tox",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "plugin/plugins",
+}
+
+EXCLUDE_FILES: set[str] = {
+    "scripts/check_api_trailing_slash.py",
+}
+
+# Decorator method names that register a route. Covers FastAPI HTTP verbs
+# plus WebSocket. ``api_route`` (used to register multiple methods at once)
+# is included for completeness.
+METHOD_NAMES = {
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "head",
+    "options",
+    "trace",
+    "websocket",
+    "api_route",
+}
+
+CODE = "API_TRAILING_SLASH"
+
+
+def _is_route_decorator(node: ast.expr) -> str | None:
+    """If ``node`` is ``@<something>.<METHOD>(...)`` return METHOD; else None."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if func.attr not in METHOD_NAMES:
+        return None
+    return func.attr
+
+
+def _extract_path_arg(call: ast.Call) -> tuple[str, int, int] | None:
+    """Pull the route path string + its lineno/col from the decorator call.
+
+    The path is the first positional arg, or the ``path=`` kwarg. We only
+    flag string literals — dynamic paths can't be checked statically and
+    are vanishingly rare for routes anyway.
+    """
+    # path=... kwarg first — explicit beats implicit
+    for kw in call.keywords:
+        if kw.arg == "path" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value, kw.value.lineno, kw.value.col_offset + 1
+    # Otherwise, first positional
+    if call.args:
+        first = call.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            return first.value, first.lineno, first.col_offset + 1
+    return None
+
+
+class TrailingSlashChecker(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.violations: list[tuple[int, int, str]] = []
+
+    def _visit_decorated(self, node: ast.AST) -> None:
+        decos = getattr(node, "decorator_list", []) or []
+
+        # First pass: collect every route-decorator path on this function.
+        # Used to detect explicit alias pairs (``/foo`` + ``/foo/``).
+        sibling_paths: set[str] = set()
+        for deco in decos:
+            if _is_route_decorator(deco) is None:
+                continue
+            extracted = _extract_path_arg(deco)
+            if extracted is None:
+                continue
+            sibling_paths.add(extracted[0])
+
+        for deco in decos:
+            method = _is_route_decorator(deco)
+            if method is None:
+                continue
+            extracted = _extract_path_arg(deco)
+            if extracted is None:
+                continue
+            route_path, lineno, col = extracted
+            if not route_path.endswith("/"):
+                continue
+            # Allow the literal root page — there's no no-slash form.
+            if route_path == "/":
+                continue
+            # Allow if a sibling decorator on the same function explicitly
+            # registers the no-slash form. This makes the slash form a
+            # direct 200 (not a 307), neutralising the reverse-proxy hazard.
+            if route_path.rstrip("/") in sibling_paths:
+                continue
+            self.violations.append(
+                (
+                    lineno,
+                    col,
+                    f"route path {route_path!r} ends with '/'. Drop the trailing "
+                    f"slash (e.g. {route_path.rstrip('/') or ''!r}). Project "
+                    "convention forbids trailing-slash routes — see "
+                    ".agent/rules/neko-guide.md (§'API URL 末尾不带斜杠') "
+                    "and main_routers/characters_router.py docstring. If you "
+                    "genuinely need both forms, register an explicit alias by "
+                    "stacking @router.get('/foo') above @router.get('/foo/') "
+                    "on the same function.",
+                )
+            )
+        self.generic_visit(node)
+
+    # FastAPI route decorators land on functions / async functions / class
+    # methods. We don't care which, but ast splits them.
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_decorated(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_decorated(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_decorated(node)
+
+
+def _is_excluded(path: Path) -> bool:
+    parts = set(path.parts)
+    if parts & EXCLUDE_DIRS:
+        return True
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in EXCLUDE_FILES:
+        return True
+    for ex in EXCLUDE_DIRS:
+        if "/" in ex and (rel == ex or rel.startswith(ex + "/")):
+            return True
+    return False
+
+
+def _iter_python_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if not p.exists():
+            # Don't blow up on optional default paths that are absent — the
+            # default list spans both main_server and plugin/, but a checkout
+            # of just one slice should still lint cleanly.
+            continue
+        if p.is_file():
+            if p.suffix == ".py" and not _is_excluded(p):
+                yield p
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.py")):
+                if not _is_excluded(f):
+                    yield f
+
+
+def _parse_file(path: Path) -> ast.Module | None:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped — {e}", file=sys.stderr)
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        print(f"{path}:{e.lineno}: syntax error — {e.msg}", file=sys.stderr)
+        return None
+
+
+def check_file(path: Path, tree: ast.Module) -> list[tuple[int, int, str]]:
+    checker = TrailingSlashChecker(path)
+    checker.visit(tree)
+    return checker.violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Forbid trailing-slash route paths in FastAPI decorators."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Files/directories to scan (default: main_routers/ + *_server.py "
+            "at repo root + plugin/server/routes/)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    raw_paths = args.paths or DEFAULT_PATHS
+    targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
+
+    total = 0
+    for file in _iter_python_files(targets):
+        tree = _parse_file(file)
+        if tree is None:
+            continue
+        for lineno, col, msg in check_file(file, tree):
+            rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
+            print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
+            total += 1
+
+    if total:
+        print(
+            f"\n{total} trailing-slash route path(s) found.\n"
+            "Project convention: every backend HTTP/WebSocket endpoint is "
+            "declared WITHOUT a trailing slash. This avoids Starlette's "
+            "absolute-URL 307 redirect under reverse proxies (root cause of "
+            "the PR #938 chara_manager regression). See .agent/rules/"
+            "neko-guide.md (§'API URL 末尾不带斜杠') and main_routers/"
+            "characters_router.py docstring for the full write-up.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_api_trailing_slash.py
+++ b/scripts/check_api_trailing_slash.py
@@ -266,11 +266,21 @@ class TrailingSlashChecker(ast.NodeVisitor):
     def _visit_decorated(self, node: ast.AST) -> None:
         decos = getattr(node, "decorator_list", []) or []
 
-        # First pass: collect every (METHOD, path) pair this function
-        # registers. The alias-pair exemption must match BOTH method and
-        # path — see _is_aliased_safely() below for why a same-path /
-        # different-method "sibling" is not safe.
-        sibling: set[tuple[str, str]] = set()
+        # First pass: collect every (OWNER, METHOD, path) triple this
+        # function registers. The alias-pair exemption must match all
+        # three — same router (so prefixes line up), same method, same
+        # no-slash path. Why all three:
+        # - METHOD: ``@router.post('/foo')`` doesn't cover ``GET /foo``
+        #   (Codex finding, round 2).
+        # - OWNER: ``@r2.get('/foo')`` (prefix ``/b``) does NOT cover
+        #   ``@r1.get('/foo/')`` (prefix ``/a``) because the resolved
+        #   paths are ``/b/foo`` vs ``/a/foo/`` — different namespaces,
+        #   the no-slash form for the trailing-slash route still 307s
+        #   (Codex finding, round 4).
+        # Owner of ``None`` means we couldn't resolve the LHS of the
+        # decorator (rare); ``None`` is its own group, so two
+        # unresolvable decorators won't accidentally cross-cover.
+        sibling: set[tuple[str | None, str, str]] = set()
         for deco in decos:
             method_name = _is_route_decorator(deco)
             if method_name is None:
@@ -278,8 +288,9 @@ class TrailingSlashChecker(ast.NodeVisitor):
             extracted = _extract_path_arg(deco)
             if extracted is None:
                 continue
+            owner = _decorator_owner(deco)
             for m in _extract_methods(deco, method_name):
-                sibling.add((m, extracted[0]))
+                sibling.add((owner, m, extracted[0]))
 
         for deco in decos:
             decorator_method = _is_route_decorator(deco)
@@ -291,6 +302,7 @@ class TrailingSlashChecker(ast.NodeVisitor):
             route_path, lineno, col = extracted
             if not route_path.endswith("/"):
                 continue
+            owner = _decorator_owner(deco)
             # Allow the literal root page — but ONLY when the owning router
             # has an empty prefix. ``APIRouter(prefix="/api/foo")`` +
             # ``@router.get("/")`` registers the effective path
@@ -299,20 +311,16 @@ class TrailingSlashChecker(ast.NodeVisitor):
             # PR #1082. If we can't resolve the owner statically (cross-
             # module router etc.) be conservative and don't exempt.
             if route_path == "/":
-                owner = _decorator_owner(deco)
                 if owner is not None and self.router_prefixes.get(owner, None) == "":
                     continue
             # Allow ONLY if every method this trailing-slash decorator
             # registers ALSO has a sibling no-slash decorator for the same
-            # method. Otherwise a caller hitting the no-slash form with an
-            # uncovered method still triggers Starlette's 307 redirect (the
-            # exact bug this lint exists to prevent). Reported by Codex on
-            # PR #1082 — without the per-method check, mixed pairs like
-            # ``@router.get('/foo/')`` + ``@router.post('/foo')`` would slip
-            # through even though ``GET /foo`` still 307s.
+            # method AND the same router. Reported by Codex on PR #1082 in
+            # two rounds: round 2 (per-method) and round 4 (per-owner so
+            # decorators stacking different routers don't cross-cover).
             no_slash = route_path.rstrip("/")
             methods = _extract_methods(deco, decorator_method)
-            if methods and all((m, no_slash) in sibling for m in methods):
+            if methods and all((owner, m, no_slash) in sibling for m in methods):
                 continue
             self.violations.append(
                 (
@@ -325,9 +333,10 @@ class TrailingSlashChecker(ast.NodeVisitor):
                     "and main_routers/characters_router.py docstring. If you "
                     "genuinely need both forms, register an explicit alias by "
                     "stacking @router.<METHOD>('/foo') above "
-                    "@router.<METHOD>('/foo/') on the same function — and the "
-                    "method must match (a sibling POST won't cover a GET that "
-                    "still 307s).",
+                    "@router.<METHOD>('/foo/') on the same function — same "
+                    "router, same method (a sibling on a different router or "
+                    "a sibling POST for a trailing-slash GET won't cover the "
+                    "no-slash form, which still 307s).",
                 )
             )
         self.generic_visit(node)

--- a/scripts/check_frontend_api_trailing_slash.py
+++ b/scripts/check_frontend_api_trailing_slash.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Static check: forbid trailing-slash ``/api/...`` URL literals in frontend code.
+
+Why this exists
+---------------
+Counterpart to ``scripts/check_api_trailing_slash.py``. The backend script
+forbids declaring trailing-slash routes; this one forbids calling them.
+
+If frontend code does ``fetch('/api/foo/')`` while the backend route is
+``/api/foo``, FastAPI/Starlette 307-redirects to the no-slash form with an
+**absolute** ``Location`` built from the request ``Host``. Behind a reverse
+proxy that doesn't preserve ``Host`` (or with ``proxy_headers`` off, i.e.
+``NEKO_BEHIND_PROXY != 1``), that absolute URL points at the internal
+``127.0.0.1:<port>`` and the browser dies with ``ERR_CONNECTION_REFUSED``.
+PR #938 (chara_manager regression on LAN reverse proxies) was exactly this
+bug. See ``.agent/rules/neko-guide.md`` (§"API URL 末尾不带斜杠") and
+``main_routers/characters_router.py`` docstring for the full write-up.
+
+What it flags
+-------------
+String literals like ``'/api/...'``, ``"/api/..."``, ```/api/...``` whose
+last character before the closing quote is ``/``. Quote types covered:
+single, double, backtick.
+
+What it does NOT flag (intentional)
+-----------------------------------
+* **Prefix builders** — a ``/api/...`` literal whose closing quote is
+  immediately followed by a string-concat continuation (``+``, template
+  ``${`` interpolation closing brace, etc.). Example:
+  ``'/api/characters/catgirl/' + encodeURIComponent(name)`` is fine — the
+  trailing ``/`` is a path separator before an appended segment, the final
+  URL still has no trailing slash.
+* **The ``/api/`` prefix alone** — too short to be a real endpoint, very
+  likely a base-URL constant that gets things appended.
+
+The detection is a regex check rather than a JS parser to keep CI fast and
+zero-dep. Edge cases (e.g. a literal that's stored in a variable and only
+*sometimes* concatenated) will produce false negatives, which is the
+acceptable failure mode — we'd rather miss an exotic dynamic call than flag
+every prefix-builder.
+
+Scope
+-----
+Default: ``static/``, ``frontend/``, ``templates/``. Pass paths explicitly
+to scan elsewhere.
+
+Suppression
+-----------
+Add ``// noqa: API_TRAILING_SLASH`` on the same line for JS/TS or
+``<!-- noqa: API_TRAILING_SLASH -->`` for HTML if you genuinely need the
+trailing slash (e.g. you're calling a third-party API that requires it).
+
+Output
+------
+Every violation prints as ``path:line:col  API_TRAILING_SLASH  message``.
+Exit status is 1 when any violation is found, 0 otherwise.
+
+Usage::
+
+    uv run python scripts/check_frontend_api_trailing_slash.py [paths...]
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_PATHS: list[str] = ["static", "frontend", "templates"]
+
+EXCLUDE_DIRS = {
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    ".vite",
+    ".cache",
+    ".next",
+    "coverage",
+    "plugin/plugins",  # third-party plugin payloads, not our code
+}
+
+EXCLUDE_FILES: set[str] = {
+    "scripts/check_frontend_api_trailing_slash.py",
+}
+
+# File extensions worth scanning. We deliberately skip ``.json`` (locale
+# strings, package manifests) — they'd produce a flood of false hits if
+# we ever shipped an API URL inside one, but in practice they don't.
+SCAN_SUFFIXES = {".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".vue", ".html", ".htm"}
+
+CODE = "API_TRAILING_SLASH"
+
+# Match an /api/... string literal whose final char before the closing quote
+# is '/'. Three quote variants. Capture the literal so we can suggest a fix
+# and so we can sniff what comes after the close-quote (concat → false alarm).
+#
+# We require at least one path segment after ``/api/`` (``[^"'`+\s]+``) to
+# rule out the base ``/api/`` prefix and to keep the regex from matching
+# across line breaks or expression boundaries.
+_LITERAL_RE = re.compile(
+    r"""(?P<quote>['"`])/api/(?P<rest>[^'"`+\s]+)/(?P=quote)""",
+)
+
+# After the closing quote, what comes next? If the next non-whitespace token
+# is ``+`` (string concat) or ``,`` ``)`` ``;`` ``}`` ``]`` (call-site /
+# statement terminator) we can decide. ``+`` → prefix builder, allow.
+# Anything else (terminator) → standalone URL, flag.
+_NEXT_TOKEN_RE = re.compile(r"\s*(\+|[,);:\]}\n])")
+
+# Same-line suppression marker. Mirrors how check_prompt_hygiene does noqa.
+_NOQA_RE = re.compile(r"(?:#|//|<!--)\s*noqa\s*:\s*API_TRAILING_SLASH", re.IGNORECASE)
+
+
+def _is_excluded(path: Path) -> bool:
+    parts = set(path.parts)
+    if parts & EXCLUDE_DIRS:
+        return True
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in EXCLUDE_FILES:
+        return True
+    for ex in EXCLUDE_DIRS:
+        if "/" in ex and (rel == ex or rel.startswith(ex + "/")):
+            return True
+    return False
+
+
+def _iter_source_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if not p.exists():
+            continue
+        if p.is_file():
+            if p.suffix.lower() in SCAN_SUFFIXES and not _is_excluded(p):
+                yield p
+        elif p.is_dir():
+            for f in sorted(p.rglob("*")):
+                if f.is_file() and f.suffix.lower() in SCAN_SUFFIXES and not _is_excluded(f):
+                    yield f
+
+
+def _check_text(source: str) -> Iterator[tuple[int, int, str, str]]:
+    """Yield (lineno, col, literal, suggestion) for each violation."""
+    # Build a line-offset table once so we can map absolute char offsets
+    # back to (line, col) without re-scanning.
+    line_starts = [0]
+    for i, ch in enumerate(source):
+        if ch == "\n":
+            line_starts.append(i + 1)
+
+    def _locate(pos: int) -> tuple[int, int]:
+        # Binary search would be faster but lines are cheap here.
+        lo, hi = 0, len(line_starts) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if line_starts[mid] <= pos:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo + 1, pos - line_starts[lo] + 1
+
+    for m in _LITERAL_RE.finditer(source):
+        # Skip if this line carries a noqa marker for this code.
+        line_no, col = _locate(m.start())
+        line_end_idx = source.find("\n", m.start())
+        if line_end_idx == -1:
+            line_end_idx = len(source)
+        line_text = source[line_starts[line_no - 1]:line_end_idx]
+        if _NOQA_RE.search(line_text):
+            continue
+
+        # Look at what follows the close quote — if it's '+' or '${' or
+        # similar concat continuation, this is a prefix builder, not a
+        # standalone URL.
+        after = source[m.end():m.end() + 64]
+        nxt = _NEXT_TOKEN_RE.match(after)
+        if nxt and nxt.group(1) == "+":
+            continue
+        # Template-literal interpolation: ``/api/foo/${id}`` — the regex
+        # won't match those at all (they use ``${`` mid-literal, the
+        # closing-quote check fails). So no extra branch needed here.
+
+        rest = m.group("rest")
+        suggestion = f"/api/{rest}"
+        literal = m.group(0)
+        yield line_no, col, literal, suggestion
+
+
+def check_file(path: Path) -> list[tuple[int, int, str]]:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped — {e}", file=sys.stderr)
+        return []
+    out: list[tuple[int, int, str]] = []
+    for lineno, col, literal, suggestion in _check_text(source):
+        out.append(
+            (
+                lineno,
+                col,
+                f"URL literal {literal} ends with '/'. Drop the trailing slash "
+                f"(e.g. {suggestion!r}). Project convention: every frontend "
+                "API call must match the backend's no-trailing-slash route — "
+                "see .agent/rules/neko-guide.md (§'API URL 末尾不带斜杠') and "
+                "docs/contributing/code-style.md. If this is a prefix builder "
+                "that gets a segment appended, write it as a template literal "
+                "(e.g. `/api/foo/${id}`) or string-concat (e.g. '/api/foo/' + "
+                "id) so the lint can recognise it.",
+            )
+        )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Forbid trailing-slash /api/... URL literals in frontend code."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files/directories to scan (default: static/ + frontend/ + templates/).",
+    )
+    args = parser.parse_args(argv)
+
+    raw_paths = args.paths or DEFAULT_PATHS
+    targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
+
+    total = 0
+    for file in _iter_source_files(targets):
+        for lineno, col, msg in check_file(file):
+            rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
+            print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
+            total += 1
+
+    if total:
+        print(
+            f"\n{total} trailing-slash /api/... URL literal(s) found.\n"
+            "Project convention: every frontend API call must match the "
+            "backend's no-trailing-slash route. Triggering Starlette's 307 "
+            "slash-redirect breaks under reverse proxies that don't preserve "
+            "Host (root cause of the PR #938 chara_manager regression). "
+            "See .agent/rules/neko-guide.md (§'API URL 末尾不带斜杠') and "
+            "docs/contributing/code-style.md.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_frontend_api_trailing_slash.py
+++ b/scripts/check_frontend_api_trailing_slash.py
@@ -105,12 +105,18 @@ CODE = "API_TRAILING_SLASH"
 # the previous regex hard-coded ``/<close-quote>`` and silently missed
 # ``fetch('/api/foo/?x=1')`` even though it still 307s.
 #
-# Path segment chars: anything except quote, ``+`` (concat continuation
-# heuristic), whitespace, ``?`` and ``#`` (those start the qf tail).
+# Char-class rationale: anything except the matching quote (terminates the
+# literal), whitespace (terminates an unquoted token), and — for urlpath
+# only — ``?`` and ``#`` (those mark the start of the qf tail). ``+`` is
+# DELIBERATELY allowed in both: it's a valid URL byte (the form-encoded
+# space, very common in query strings — second Codex finding on PR #1082).
+# The string-concat detection happens post-quote via ``_NEXT_TOKEN_RE`` so
+# we don't need to exclude ``+`` from the literal's char class to spot
+# prefix builders.
 # Slash IS allowed in path so multi-segment URLs match. Require at least
 # one char after ``/api/`` to rule out the bare prefix.
 _LITERAL_RE = re.compile(
-    r"""(?P<quote>['"`])/api/(?P<urlpath>[^'"`+\s?#]+)(?P<qf>[?#][^'"`+\s]*)?(?P=quote)""",
+    r"""(?P<quote>['"`])/api/(?P<urlpath>[^'"`\s?#]+)(?P<qf>[?#][^'"`\s]*)?(?P=quote)""",
 )
 
 # After the closing quote, what comes next? If the next non-whitespace token

--- a/scripts/check_frontend_api_trailing_slash.py
+++ b/scripts/check_frontend_api_trailing_slash.py
@@ -97,15 +97,20 @@ SCAN_SUFFIXES = {".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".vue", ".html", 
 
 CODE = "API_TRAILING_SLASH"
 
-# Match an /api/... string literal whose final char before the closing quote
-# is '/'. Three quote variants. Capture the literal so we can suggest a fix
-# and so we can sniff what comes after the close-quote (concat → false alarm).
+# Match an ``/api/...`` string literal. Three quote variants. We capture
+# the path part separately from any optional ``?query`` / ``#fragment``
+# tail so the violation check can ask "did the URL PATH end with '/'?",
+# which is the right question — Starlette's 307 fires on path-vs-route
+# mismatch, query string is irrelevant. Reported by Codex on PR #1082:
+# the previous regex hard-coded ``/<close-quote>`` and silently missed
+# ``fetch('/api/foo/?x=1')`` even though it still 307s.
 #
-# We require at least one path segment after ``/api/`` (``[^"'`+\s]+``) to
-# rule out the base ``/api/`` prefix and to keep the regex from matching
-# across line breaks or expression boundaries.
+# Path segment chars: anything except quote, ``+`` (concat continuation
+# heuristic), whitespace, ``?`` and ``#`` (those start the qf tail).
+# Slash IS allowed in path so multi-segment URLs match. Require at least
+# one char after ``/api/`` to rule out the bare prefix.
 _LITERAL_RE = re.compile(
-    r"""(?P<quote>['"`])/api/(?P<rest>[^'"`+\s]+)/(?P=quote)""",
+    r"""(?P<quote>['"`])/api/(?P<urlpath>[^'"`+\s?#]+)(?P<qf>[?#][^'"`+\s]*)?(?P=quote)""",
 )
 
 # After the closing quote, what comes next? If the next non-whitespace token
@@ -168,6 +173,13 @@ def _check_text(source: str) -> Iterator[tuple[int, int, str, str]]:
         return lo + 1, pos - line_starts[lo] + 1
 
     for m in _LITERAL_RE.finditer(source):
+        urlpath = m.group("urlpath")
+        # The actual violation check: did the URL **path** end with '/'?
+        # The query/fragment tail (qf) is irrelevant — Starlette's 307
+        # fires on path-vs-route mismatch, query string isn't part of it.
+        if not urlpath.endswith("/"):
+            continue
+
         # Skip if this line carries a noqa marker for this code.
         line_no, col = _locate(m.start())
         line_end_idx = source.find("\n", m.start())
@@ -188,32 +200,38 @@ def _check_text(source: str) -> Iterator[tuple[int, int, str, str]]:
         # won't match those at all (they use ``${`` mid-literal, the
         # closing-quote check fails). So no extra branch needed here.
 
-        rest = m.group("rest")
-        suggestion = f"/api/{rest}"
+        qf = m.group("qf") or ""
+        suggestion = f"/api/{urlpath.rstrip('/')}{qf}"
         literal = m.group(0)
         yield line_no, col, literal, suggestion
+
+
+class _ReadFailed(Exception):
+    """Raised by check_file when a file can't be read; main() turns this
+    into a non-zero exit so a read failure doesn't silently pass the lint
+    (fail-closed). Reported by CodeRabbit on PR #1082."""
 
 
 def check_file(path: Path) -> list[tuple[int, int, str]]:
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
-        print(f"{path}: skipped — {e}", file=sys.stderr)
-        return []
+        print(f"{path}: read failed — {e}", file=sys.stderr)
+        raise _ReadFailed(str(path)) from e
     out: list[tuple[int, int, str]] = []
     for lineno, col, literal, suggestion in _check_text(source):
         out.append(
             (
                 lineno,
                 col,
-                f"URL literal {literal} ends with '/'. Drop the trailing slash "
-                f"(e.g. {suggestion!r}). Project convention: every frontend "
-                "API call must match the backend's no-trailing-slash route — "
-                "see .agent/rules/neko-guide.md (§'API URL 末尾不带斜杠') and "
-                "docs/contributing/code-style.md. If this is a prefix builder "
-                "that gets a segment appended, write it as a template literal "
-                "(e.g. `/api/foo/${id}`) or string-concat (e.g. '/api/foo/' + "
-                "id) so the lint can recognise it.",
+                f"URL literal {literal} has a trailing-slash path component. "
+                f"Drop it (e.g. {suggestion!r}). Project convention: every "
+                "frontend API call must match the backend's no-trailing-slash "
+                "route — see .agent/rules/neko-guide.md (§'API URL 末尾不带斜杠') "
+                "and docs/contributing/code-style.md. If this is a prefix "
+                "builder that gets a segment appended, write it as a template "
+                "literal (e.g. `/api/foo/${id}`) or string-concat (e.g. "
+                "'/api/foo/' + id) so the lint can recognise it.",
             )
         )
     return out
@@ -234,8 +252,14 @@ def main(argv: list[str] | None = None) -> int:
     targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
 
     total = 0
+    read_failures = 0
     for file in _iter_source_files(targets):
-        for lineno, col, msg in check_file(file):
+        try:
+            results = check_file(file)
+        except _ReadFailed:
+            read_failures += 1
+            continue
+        for lineno, col, msg in results:
             rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
             print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
             total += 1
@@ -251,6 +275,15 @@ def main(argv: list[str] | None = None) -> int:
             "docs/contributing/code-style.md.",
             file=sys.stderr,
         )
+    if read_failures:
+        print(
+            f"\n{read_failures} file(s) could not be read and were skipped — "
+            "fix the encoding/permission errors above before re-running. The "
+            "lint exits non-zero in this case to avoid silently passing files "
+            "it didn't actually scan.",
+            file=sys.stderr,
+        )
+    if total or read_failures:
         return 1
     return 0
 

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -5412,7 +5412,7 @@ window.Jukebox = {
       try {
         const catgirlName = window.lanlan_config?.catgirl_name;
         if (catgirlName) {
-          const charRes = await fetch('/api/characters/');
+          const charRes = await fetch('/api/characters');
           if (charRes.ok) {
             const charData = await charRes.json();
             idleUrl = charData?.['猫娘']?.[catgirlName]?.mmd_idle_animation;

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -510,7 +510,7 @@
                         window.lanlan_config.vrmIdleAnimations = [];
                         if (nameForConfig) {
                             try {
-                                var charResVrm = await fetch('/api/characters/');
+                                var charResVrm = await fetch('/api/characters');
                                 if (charResVrm.ok) {
                                     var charDataVrm = await charResVrm.json();
                                     var catDataVrm = charDataVrm?.['猫娘']?.[nameForConfig];
@@ -665,7 +665,7 @@
                         // 播放待机动作 & 启动轮换
                         if (nameForConfig) {
                             try {
-                                const charRes = await fetch('/api/characters/');
+                                const charRes = await fetch('/api/characters');
                                 if (charRes.ok) {
                                     const charData = await charRes.json();
                                     const catData = charData?.['猫娘']?.[nameForConfig];
@@ -961,7 +961,7 @@
             }
 
             // 2. 从 characters.json 获取保存的待机动作路径
-            const response = await fetch('/api/characters/');
+            const response = await fetch('/api/characters');
             const data = await response.json();
 
             // 【竞态防护】如果中途角色被切换了，立刻中止

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -2573,7 +2573,7 @@ function syncTitleDataText() {
 // 加载角色卡数据
 async function loadCharacterData() {
     try {
-        const resp = await fetch('/api/characters/');
+        const resp = await fetch('/api/characters');
         if (!resp.ok) {
             throw new Error(`HTTP ${resp.status}`);
         }
@@ -4888,7 +4888,7 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
                 loadCharacterCards();
                 // 模型管理器关闭后，重新获取角色数据并更新模型显示名称
                 try {
-                    const resp = await fetch('/api/characters/');
+                    const resp = await fetch('/api/characters');
                     if (resp.ok) {
                         const allData = await resp.json();
                         const updatedCat = allData?.['猫娘']?.[catgirlName];
@@ -5610,7 +5610,7 @@ async function workshopDeleteCatgirl(name) {
 
     // 检查是否只剩一只猫娘
     try {
-        const resp = await fetch('/api/characters/', { cache: 'no-store' });
+        const resp = await fetch('/api/characters', { cache: 'no-store' });
         if (resp.ok) {
             const allData = await resp.json();
             const catgirls = allData?.['猫娘'] || {};

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -997,7 +997,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const initialModel = window.live2dManager?.getCurrentModel() || live2dModel;
             if (!initialModel) return;
 
-            const data = await RequestHelper.fetchJson('/api/characters/');
+            const data = await RequestHelper.fetchJson('/api/characters');
             // 模型可能已在 await 期间切换
             if (window.live2dManager?.getCurrentModel() !== initialModel) {
                 console.log('[Live2D Restore] 模型已在 fetchJson 期间切换，跳过恢复');
@@ -2667,7 +2667,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     try {
                         const _lanlanName = await getLanlanName();
                         if (_lanlanName) {
-                            const _charData = await RequestHelper.fetchJson('/api/characters/');
+                            const _charData = await RequestHelper.fetchJson('/api/characters');
                             savedLightingConfig = _charData['猫娘']?.[_lanlanName]?.lighting || null;
                         }
                     } catch (e) {
@@ -5543,7 +5543,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const lanlanName = await getLanlanName();
             if (!lanlanName) return;
 
-            const data = await RequestHelper.fetchJson('/api/characters/');
+            const data = await RequestHelper.fetchJson('/api/characters');
             const charData = data['猫娘']?.[lanlanName];
             let vrmIdleAnimation = charData?.idle_animation;
             if (vrmIdleAnimation == null) {
@@ -5649,7 +5649,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const lanlanName = await getLanlanName();
             if (!lanlanName) return;
 
-            const data = await RequestHelper.fetchJson('/api/characters/');
+            const data = await RequestHelper.fetchJson('/api/characters');
             const charData = data['猫娘']?.[lanlanName];
             let mmdIdleAnimation = charData?.mmd_idle_animations ?? charData?.mmd_idle_animation;
 
@@ -6015,7 +6015,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (!lanlanName) return;
 
             // 使用 RequestHelper 确保统一的错误处理和超时
-            const data = await RequestHelper.fetchJson('/api/characters/');
+            const data = await RequestHelper.fetchJson('/api/characters');
             const charData = data['猫娘']?.[lanlanName];
             const lighting = charData?.lighting;
 

--- a/static/mmd-init.js
+++ b/static/mmd-init.js
@@ -545,7 +545,7 @@
             // 播放待机动作 & 启动轮换
             if (catgirlName) {
                 try {
-                    const charRes = await fetch('/api/characters/');
+                    const charRes = await fetch('/api/characters');
                     if (charRes.ok) {
                         const charData = await charRes.json();
                         const catData = charData?.['猫娘']?.[catgirlName];

--- a/templates/openclaw_guide.html
+++ b/templates/openclaw_guide.html
@@ -468,7 +468,7 @@
                 title: 'openclawGuide.pageTitle',
             };
 
-            const GUIDE_ROUTE_BASE = '/api/agent/openclaw/guide/';
+            const GUIDE_ROUTE_BASE = '/api/agent/openclaw/guide';
             const LANGUAGE_OPTIONS = ['zh-CN', 'zh-TW', 'en', 'ja', 'ko', 'ru'];
             const LOCALE_SHORT_LABELS = {
                 'zh-CN': '简',
@@ -537,7 +537,7 @@
                     return text;
                 }
                 const normalized = text.replace(/^\.?\//, '');
-                return GUIDE_ROUTE_BASE + normalized;
+                return GUIDE_ROUTE_BASE + '/' + normalized;
             }
 
             function renderMarkdown(markdown) {


### PR DESCRIPTION
## Summary

修反代场景下角色卡管理页面无法加载角色卡的回归（PR #938 引入），并把 "API URL 不带末尾斜杠" 这条约定文档化 + 加 CI 守门。

### 根因

PR #938（"完全重置角色管理和steam创意工坊页面，将他们融合为角色卡管理"）把两个页面合并成 `character_card_manager.js` 时，重命名继承了旧 `workshop_manager.js` 里 `fetch('/api/characters/')` 的写法（带末尾斜杠）。后端 router 是 `@router.get('')` 注册的 `/api/characters`（不带斜杠）。FastAPI 默认 `redirect_slashes=True` 会 307 跳到 `/api/characters`，但 **`Location` 是用 request `Host` 拼出来的绝对 URL**：

- 反代如果没透传 `Host`（如缺 `proxy_set_header Host $http_host;`）
- 或 uvicorn 没开 `proxy_headers`（`NEKO_BEHIND_PROXY != 1`）

→ 重定向 Location 就指向上游 `http://127.0.0.1:<内网端口>/api/characters`，浏览器从局域网跟过去拿 `ERR_CONNECTION_REFUSED`。开页就触发 `loadCharacterCards()`，所以反代用户进角色卡管理页面就直接挂。

### 修复

- 前端 13 处 `fetch('/api/characters/')` → `fetch('/api/characters')`（character_card_manager / model_manager / app-interpage / Jukebox / mmd-init）
- `templates/openclaw_guide.html` `GUIDE_ROUTE_BASE` 常量去掉末尾斜杠，join 处补 `'/'`

### 约定文档化（3 处）

- `docs/contributing/code-style.md` 加 "API URLs — no trailing slash" 段，含两条理由（业界惯例 + 反代安全）+ 前后端规则 + lint 链接
- `.agent/rules/neko-guide.md` 加 "API URL 末尾不带斜杠（前后端硬性要求）" 段，PR #938 的因果链写明
- `main_routers/*_router.py` 全部 17 个 router docstring 末尾加 URL convention 段；`characters_router.py` 是 canonical 长版，其他 16 个短版 + 指回它

### CI 守门（2 个新 lint）

- `scripts/check_api_trailing_slash.py`：AST 扫 `main_routers/` + `*_server.py` + `plugin/server/routes/`，识别 `@router.get/post/put/delete/patch/head/options/trace/websocket/api_route` 装饰器，禁 `@router.get('/foo/')`。豁免 (1) 根 `'/'`、(2) 同函数显式 alias 对（同时挂 `'/foo'` + `'/foo/'`，这种不会触发 307，安全 — `plugin/server/routes/frontend.py` 和 `plugin_ui.py` 的 SPA 入口就是这个模式）
- `scripts/check_frontend_api_trailing_slash.py`：正则扫 `static/` + `frontend/` + `templates/` 下的 .js/.ts/.tsx/.vue/.html 等，禁 `'/api/foo/'` 字面量。自动放行 prefix builder（`'/api/foo/' + id`、`` `/api/foo/${id}` ``），支持 `// noqa: API_TRAILING_SLASH` 同行抑制
- 两条都接到 `.github/workflows/analyze.yml` 的 `python-lint` job 末尾

## Test plan

- [x] `uv run python scripts/check_api_trailing_slash.py` → exit 0
- [x] `uv run python scripts/check_frontend_api_trailing_slash.py` → exit 0
- [x] 两条 lint 的 sanity test：注入合成违规 + 合成 alias 对 + 合成 prefix builder + 合成 noqa，确认 detection / 豁免均工作正常
- [ ] 反代实测：在 nginx `proxy_pass http://127.0.0.1:<port>;` 不加 `proxy_set_header Host` 的最小配置下访问 `http://<lan>:567/character_card_manager`，确认页面能正常加载角色卡（修复前会挂在 `loadCharacterCards` 的 `ERR_CONNECTION_REFUSED`）
- [ ] 直连 localhost dev 模式回归：跑 `uv run python main_server.py` 进角色卡管理 / model_manager / Jukebox / openclaw_guide 各页面，确认正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增后端音乐相关 API：代理、域名列表、搜索与播放（含对付费曲目的兼容处理）。

* **静态检查 / CI**
  * CI 增强：新增后端路由与前端字面量的末尾斜杠检测并支持既有例外规则。

* **文档**
  * 更新开发规范与路由说明，明确要求 API URL 不含末尾斜杠。

* **修复**
  * 统一修正前端多个 fetch/链接，移除 /api/... 末尾斜杠并调整相应拼接逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->