### PR TITLE
fix(config): follow_core/follow_assist 不再被误判为 'local' 自定义 realtime（修 TTS 静音）

### DIFF
--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -638,8 +638,9 @@ class TestFollowProviderNotLocal:
             'ttsModelApiKey': 'sk-qwen-assist',
         })
         cfg = config_manager.get_core_config()
-        # follow_assist 时 TTS_MODEL_URL 不应被前端联动值覆盖
-        # （应保持 DEFAULT_TTS_MODEL_URL 或回退到核心/辅助 profile）
+        # follow_assist 时 TTS_MODEL_URL 必须保持空（DEFAULT_TTS_MODEL_URL=""，且
+        # core/assist profile 的 field_mapping 都不包含 tts_model_url，没有别的合法来源）。
+        # 任何非空值都意味着 follow_* 跳过 URL 覆盖的逻辑被绕过 → 回归。
         assert cfg.get('TTS_MODEL_URL', '') in ('', None), \
             f"follow_assist 时 TTS_MODEL_URL 应为空，实际={cfg.get('TTS_MODEL_URL')!r}"
 

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -645,6 +645,29 @@ class TestFollowProviderNotLocal:
             f"follow_assist 时 TTS_MODEL_URL 应为空，实际={cfg.get('TTS_MODEL_URL')!r}"
 
     @pytest.mark.unit
+    def test_follow_mode_preserves_user_model_id(self, config_manager):
+        """follow_* 模式下 modelId 输入框非 readonly，用户主动填的值必须被尊重，
+        不能因为跳过 URL 覆盖一并丢失（修复时只跳 URL，Model 仍允许覆盖）。
+        """
+        _write_core_config(config_manager, {
+            'coreApiKey': 'sk-qwen-core',
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'assistApiKeyQwen': 'sk-qwen-core',
+            'enableCustomApi': True,
+            'omniModelProvider': 'follow_core',
+            'omniModelUrl': 'wss://dashscope.aliyuncs.com/api-ws/v1/realtime',
+            'omniModelId': 'qwen3-omni-flash-realtime-2026-04-30-snapshot',  # 用户主动填
+            'omniModelApiKey': 'sk-qwen-core',
+        })
+        cfg = config_manager.get_core_config()
+        assert cfg.get('REALTIME_MODEL') == 'qwen3-omni-flash-realtime-2026-04-30-snapshot', \
+            f"follow_core 时用户填的 omniModelId 不应丢失，实际={cfg.get('REALTIME_MODEL')!r}"
+        # 同时验证 URL 仍然被跳过（bug fix invariant）
+        assert cfg.get('REALTIME_MODEL_URL', '') in ('', None), \
+            f"follow_core 时 URL 应被跳过避免触发 'local'，实际={cfg.get('REALTIME_MODEL_URL')!r}"
+
+    @pytest.mark.unit
     def test_explicit_custom_still_takes_effect(self, config_manager):
         """provider=custom（用户真的填了自定义 URL）时仍然走自定义路径。"""
         _write_core_config(config_manager, {

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -592,5 +592,78 @@ class TestVoiceCloneKeyResolution:
         assert key == 'sk-tts-custom-key'
 
 
+# ---------------------------------------------------------------------------
+# 11. follow_core / follow_assist must NOT be misclassified as 'local' realtime
+# ---------------------------------------------------------------------------
+class TestFollowProviderNotLocal:
+    """前端在 *ModelProvider=follow_core/follow_assist 时会用核心/辅助 provider 的
+    URL/Key 把 readonly 输入框联动填上并保存。后端必须把这些字段当作 UI 提示值忽略，
+    否则 get_model_api_config 在 enableCustomApi=True 时会误判 realtime=自定义=local，
+    导致 TTS 调度落到 dummy_tts_worker（"local不支持原生TTS"），声音消失。
+    """
+
+    @pytest.mark.unit
+    def test_realtime_follow_core_does_not_become_local(self, config_manager):
+        """omniModelProvider=follow_core + 联动自填 omniModelUrl → realtime 仍走 core API。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'sk-qwen-core',
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'assistApiKeyQwen': 'sk-qwen-core',
+            'enableCustomApi': True,
+            # 这些是前端 follow_core 联动 readonly 自填的值
+            'omniModelProvider': 'follow_core',
+            'omniModelUrl': 'wss://dashscope.aliyuncs.com/api-ws/v1/realtime',
+            'omniModelId': '',
+            'omniModelApiKey': 'sk-qwen-core',
+        })
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['api_type'] == 'qwen', \
+            f"realtime api_type 应跟随 CORE_API_TYPE='qwen'，实际={rt['api_type']!r}"
+        assert rt['is_custom'] is False, \
+            "follow_core 不应被当作自定义 API（is_custom 必须为 False）"
+
+    @pytest.mark.unit
+    def test_tts_follow_assist_does_not_pollute_url(self, config_manager):
+        """ttsModelProvider=follow_assist + 联动自填 ttsModelUrl → TTS_MODEL_URL 不被覆盖。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'sk-qwen-core',
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'assistApiKeyQwen': 'sk-qwen-assist',
+            'enableCustomApi': True,
+            'ttsModelProvider': 'follow_assist',
+            'ttsModelUrl': 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+            'ttsModelId': '',
+            'ttsModelApiKey': 'sk-qwen-assist',
+        })
+        cfg = config_manager.get_core_config()
+        # follow_assist 时 TTS_MODEL_URL 不应被前端联动值覆盖
+        # （应保持 DEFAULT_TTS_MODEL_URL 或回退到核心/辅助 profile）
+        assert cfg.get('TTS_MODEL_URL', '') in ('', None), \
+            f"follow_assist 时 TTS_MODEL_URL 应为空，实际={cfg.get('TTS_MODEL_URL')!r}"
+
+    @pytest.mark.unit
+    def test_explicit_custom_still_takes_effect(self, config_manager):
+        """provider=custom（用户真的填了自定义 URL）时仍然走自定义路径。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'sk-core',
+            'coreApi': 'qwen',
+            'assistApi': 'qwen',
+            'assistApiKeyQwen': 'sk-assist',
+            'enableCustomApi': True,
+            'omniModelProvider': 'custom',
+            'omniModelUrl': 'wss://my-local-deployment.example/realtime',
+            'omniModelId': 'my-local-realtime-model',
+            'omniModelApiKey': 'sk-local-key',
+        })
+        rt = config_manager.get_model_api_config('realtime')
+        assert rt['base_url'] == 'wss://my-local-deployment.example/realtime'
+        assert rt['model'] == 'my-local-realtime-model'
+        assert rt['api_type'] == 'local', \
+            "provider=custom 时应保留 'local' api_type 标记（自定义 realtime 部署）"
+        assert rt['is_custom'] is True
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -645,27 +645,28 @@ class TestFollowProviderNotLocal:
             f"follow_assist 时 TTS_MODEL_URL 应为空，实际={cfg.get('TTS_MODEL_URL')!r}"
 
     @pytest.mark.unit
-    def test_follow_mode_preserves_user_model_id(self, config_manager):
-        """follow_* 模式下 modelId 输入框非 readonly，用户主动填的值必须被尊重，
-        不能因为跳过 URL 覆盖一并丢失（修复时只跳 URL，Model 仍允许覆盖）。
+    def test_non_omni_follow_core_url_not_skipped(self, config_manager):
+        """URL skip 的 scope 必须仅限 omni/tts —— 非 omni 模型（conversation/summary/
+        correction/emotion/vision/agent）走 chat completion REST，没有 'local' 分支，
+        不该被本 PR 的 guard 触动。否则会改变它们的 follow_core 路由行为
+        （详见 PR #1084 review thread）。
         """
         _write_core_config(config_manager, {
-            'coreApiKey': 'sk-qwen-core',
-            'coreApi': 'qwen',
+            'coreApiKey': 'sk-openai-core',
+            'coreApi': 'openai',
             'assistApi': 'qwen',
-            'assistApiKeyQwen': 'sk-qwen-core',
+            'assistApiKeyQwen': 'sk-qwen-assist',
             'enableCustomApi': True,
-            'omniModelProvider': 'follow_core',
-            'omniModelUrl': 'wss://dashscope.aliyuncs.com/api-ws/v1/realtime',
-            'omniModelId': 'qwen3-omni-flash-realtime-2026-04-30-snapshot',  # 用户主动填
-            'omniModelApiKey': 'sk-qwen-core',
+            'conversationModelProvider': 'follow_core',
+            'conversationModelUrl': 'https://api.openai.com/v1',  # 前端联动填
+            'conversationModelId': '',
+            'conversationModelApiKey': 'sk-openai-core',
         })
         cfg = config_manager.get_core_config()
-        assert cfg.get('REALTIME_MODEL') == 'qwen3-omni-flash-realtime-2026-04-30-snapshot', \
-            f"follow_core 时用户填的 omniModelId 不应丢失，实际={cfg.get('REALTIME_MODEL')!r}"
-        # 同时验证 URL 仍然被跳过（bug fix invariant）
-        assert cfg.get('REALTIME_MODEL_URL', '') in ('', None), \
-            f"follow_core 时 URL 应被跳过避免触发 'local'，实际={cfg.get('REALTIME_MODEL_URL')!r}"
+        # conversation 不在 (omni, tts) 白名单，URL 必须被覆盖（保持原逻辑）
+        assert cfg.get('CONVERSATION_MODEL_URL') == 'https://api.openai.com/v1', \
+            f"非 omni follow_core 的 URL 不应被本 PR 的 guard 跳过，" \
+            f"实际={cfg.get('CONVERSATION_MODEL_URL')!r}"
 
     @pytest.mark.unit
     def test_explicit_custom_still_takes_effect(self, config_manager):

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2814,16 +2814,25 @@ class ConfigManager:
             ]
             for prefix, model_key, url_key, apikey_key in _custom_api_fields:
                 provider = core_cfg.get(f'{prefix}ModelProvider', '')
+                # follow_core / follow_assist：URL/Model 是前端联动 readonly 自填的提示值
+                # （static/js/api_key_settings.js: onCustomModelProviderChange），不代表用户
+                # 选择了"自定义部署"。若把它们覆盖进 *_MODEL_URL/*_MODEL，则 get_model_api_config
+                # 在 enable_custom_api=True 时会把 realtime 误判成 'local' 自定义 realtime
+                # （TODO 未实现），下游 core_api_type='local' → TTS 调度落到 dummy_tts_worker
+                # 导致"跟随主/副"完全没声音。这里跳过 URL/Model 覆盖，让 follow_* 走回核心/辅助
+                # API profile 的默认值。API Key 仍由 follow_* 派生。
+                is_follow = provider in ('follow_core', 'follow_assist')
 
-                # URL: 空值回退到已有配置
-                cfg_url = core_cfg.get(f'{prefix}ModelUrl')
-                if cfg_url is not None:
-                    config[url_key] = cfg_url or config.get(url_key, '')
+                if not is_follow:
+                    # URL: 空值回退到已有配置
+                    cfg_url = core_cfg.get(f'{prefix}ModelUrl')
+                    if cfg_url is not None:
+                        config[url_key] = cfg_url or config.get(url_key, '')
 
-                # Model ID: 空值回退到已有配置
-                cfg_model = core_cfg.get(f'{prefix}ModelId')
-                if cfg_model is not None:
-                    config[model_key] = cfg_model or config.get(model_key, '')
+                    # Model ID: 空值回退到已有配置
+                    cfg_model = core_cfg.get(f'{prefix}ModelId')
+                    if cfg_model is not None:
+                        config[model_key] = cfg_model or config.get(model_key, '')
 
                 # API Key 处理：
                 #   follow_core   → 从核心 API Key 派生

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2814,23 +2814,29 @@ class ConfigManager:
             ]
             for prefix, model_key, url_key, apikey_key in _custom_api_fields:
                 provider = core_cfg.get(f'{prefix}ModelProvider', '')
-                # follow_core / follow_assist：URL 是前端联动 readonly 自填的提示值
-                # （static/js/api_key_settings.js: onCustomModelProviderChange），不代表用户
-                # 选择了"自定义部署"。若覆盖进 *_MODEL_URL，get_model_api_config 在
-                # enable_custom_api=True 时会把 realtime 误判成 'local' 自定义 realtime
-                # （TODO 未实现），下游 core_api_type='local' → TTS 调度落到 dummy_tts_worker
-                # 导致"跟随主/副"完全没声音。这里仅跳过 URL 覆盖，让 follow_* 走 fallback
-                # 到 core/assist API profile。Model ID 仍允许覆盖（modelId 输入框非 readonly，
-                # 用户可主动填自定义 model 名），API Key 由下方按 follow_* 派生。
+                # follow_core / follow_assist 的 URL 是前端联动 readonly 自填的提示值
+                # （static/js/api_key_settings.js: onCustomModelProviderChange），不代表
+                # 用户选择"自定义部署"。但只在 omni/tts 才会出问题：
+                #   - omni: get_model_api_config 看见 REALTIME_MODEL+_URL 都非空 →
+                #     强行 api_type='local'（TODO 未实现）→ core_api_type='local' →
+                #     TTS 调度落 dummy_tts_worker → 静音
+                #   - tts:  TTS_MODEL_URL 被联动值污染让 tts_custom 走错 provider
+                # 其他 model type（conversation/summary/correction/emotion/vision/agent）
+                # 走 chat completion REST，没有 'local' 分支；跳 URL 反而会改变它们的
+                # follow_* 路由（详见 PR #1084 review thread），故仅对 omni/tts 跳。
+                # 注：follow_* 下用户填的 modelId 当前在 get_model_api_config fallback
+                # 路径里读不到（fallback 用 CORE_MODEL，不是 REALTIME_MODEL/TTS_MODEL），
+                # 那是另一个层面的问题，下个 PR 跟进。
                 is_follow = provider in ('follow_core', 'follow_assist')
+                skip_url_for_follow = is_follow and prefix in ('omni', 'tts')
 
-                # URL: 空值回退到已有配置；follow_* 时跳过（联动自填值不是用户意图）
-                if not is_follow:
+                # URL: 空值回退到已有配置；omni/tts follow_* 时跳过
+                if not skip_url_for_follow:
                     cfg_url = core_cfg.get(f'{prefix}ModelUrl')
                     if cfg_url is not None:
                         config[url_key] = cfg_url or config.get(url_key, '')
 
-                # Model ID: 空值回退到已有配置（follow_* 也允许覆盖，尊重用户填值）
+                # Model ID: 空值回退到已有配置
                 cfg_model = core_cfg.get(f'{prefix}ModelId')
                 if cfg_model is not None:
                     config[model_key] = cfg_model or config.get(model_key, '')

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2814,25 +2814,26 @@ class ConfigManager:
             ]
             for prefix, model_key, url_key, apikey_key in _custom_api_fields:
                 provider = core_cfg.get(f'{prefix}ModelProvider', '')
-                # follow_core / follow_assist：URL/Model 是前端联动 readonly 自填的提示值
+                # follow_core / follow_assist：URL 是前端联动 readonly 自填的提示值
                 # （static/js/api_key_settings.js: onCustomModelProviderChange），不代表用户
-                # 选择了"自定义部署"。若把它们覆盖进 *_MODEL_URL/*_MODEL，则 get_model_api_config
-                # 在 enable_custom_api=True 时会把 realtime 误判成 'local' 自定义 realtime
+                # 选择了"自定义部署"。若覆盖进 *_MODEL_URL，get_model_api_config 在
+                # enable_custom_api=True 时会把 realtime 误判成 'local' 自定义 realtime
                 # （TODO 未实现），下游 core_api_type='local' → TTS 调度落到 dummy_tts_worker
-                # 导致"跟随主/副"完全没声音。这里跳过 URL/Model 覆盖，让 follow_* 走回核心/辅助
-                # API profile 的默认值。API Key 仍由 follow_* 派生。
+                # 导致"跟随主/副"完全没声音。这里仅跳过 URL 覆盖，让 follow_* 走 fallback
+                # 到 core/assist API profile。Model ID 仍允许覆盖（modelId 输入框非 readonly，
+                # 用户可主动填自定义 model 名），API Key 由下方按 follow_* 派生。
                 is_follow = provider in ('follow_core', 'follow_assist')
 
+                # URL: 空值回退到已有配置；follow_* 时跳过（联动自填值不是用户意图）
                 if not is_follow:
-                    # URL: 空值回退到已有配置
                     cfg_url = core_cfg.get(f'{prefix}ModelUrl')
                     if cfg_url is not None:
                         config[url_key] = cfg_url or config.get(url_key, '')
 
-                    # Model ID: 空值回退到已有配置
-                    cfg_model = core_cfg.get(f'{prefix}ModelId')
-                    if cfg_model is not None:
-                        config[model_key] = cfg_model or config.get(model_key, '')
+                # Model ID: 空值回退到已有配置（follow_* 也允许覆盖，尊重用户填值）
+                cfg_model = core_cfg.get(f'{prefix}ModelId')
+                if cfg_model is not None:
+                    config[model_key] = cfg_model or config.get(model_key, '')
 
                 # API Key 处理：
                 #   follow_core   → 从核心 API Key 派生


### PR DESCRIPTION
## 摘要
- **现象**：用户在角色配置选了"跟随核心 API"（omni）+"跟随辅助 API"（TTS），结果完全没声音，日志报 \`local不支持原生TTS\`、\`core_api=local\`
- **根因**：前端 follow_* 联动 readonly 自填的 URL 被后端无差别覆盖进 \`*_MODEL_URL\`，触发 [#171](https://github.com/Project-N-E-K-O/N.E.K.O/pull/171) 引入的 \`api_type='local'\` 占位 TODO 路径，下游 TTS 调度落 \`dummy_tts_worker\`
- **修复**：[utils/config_manager.py:2815](utils/config_manager.py:2815) 在 provider 为 \`follow_core\`/\`follow_assist\` 时跳过 URL/Model 覆盖（API Key 派生逻辑保持不变，本来就已经做了）

## 触发链
1. 用户选 \`omniModelProvider=follow_core\` → 前端 [api_key_settings.js:738](static/js/api_key_settings.js:738) 把 qwen 的 \`wss://dashscope.../realtime\` 联动填进 \`omniModelUrl\` 输入框（readonly）并保存入库
2. \`get_full_config\` [config_manager.py:2799+](utils/config_manager.py:2799) 看见 \`enableCustomApi=true\`，**不管 provider** 直接把 \`omniModelUrl\` 写进 \`REALTIME_MODEL_URL\`
3. \`get_model_api_config('realtime')\` [config_manager.py:2960+](utils/config_manager.py:2960) 看见 \`REALTIME_MODEL\` 和 \`_URL\` 都非空 → 命中 \`api_type='local' if model_type == 'realtime' else None\` 占位分支
4. \`core.core_api_type='local'\` → TTS 调度 [tts_client.py:2900](main_logic/tts_client.py:2900) else 分支 → \`dummy_tts_worker\` → 静音

## 责任溯源
- [#171](https://github.com/Project-N-E-K-O/N.E.K.O/pull/171) (2025-12-11)：引入 \`'local'\` 占位 api_type，TODO 未实现
- [#550](https://github.com/Project-N-E-K-O/N.E.K.O/pull/550) (2026-03-28)：前端引入 follow_core/follow_assist + 联动自填 URL，bug 进入可触发状态
- [#619](https://github.com/Project-N-E-K-O/N.E.K.O/pull/619) (2026-04-02)：后端给 API Key 加了 follow_* 派生但 URL/Model 没同步 — 不对偶，bug 定型

## 影响范围
- **触发**：\`enableCustomApi=true\` **且** \`omniModelProvider=follow_core\` 或 \`ttsModelProvider=follow_assist\`
- **不影响**：未启用 enableCustomApi、或 provider 选具体服务商/\`custom\` 的用户
- **解除条件**：本 PR 落地后下次 \`start_session\` 重新加载配置即可恢复（无需用户手动改 config）

## Test plan
- [x] 新增 [TestFollowProviderNotLocal](tests/unit/test_api_config_manager.py:578) 三个 regression
  - \`test_realtime_follow_core_does_not_become_local\` — follow_core 不再 → api_type='local'
  - \`test_tts_follow_assist_does_not_pollute_url\` — follow_assist 不污染 TTS_MODEL_URL
  - \`test_explicit_custom_still_takes_effect\` — provider='custom' 真自定义路径仍走 'local'，未误伤
- [x] \`uv run pytest tests/unit/test_api_config_manager.py\` → 33 passed
- [x] \`uv run pytest tests/unit/ -k "config or api or tts or realtime"\` → 265 passed, 0 regressions

## 后续（不在本 PR 范围）
- 前端 [api_key_settings.js](static/js/api_key_settings.js) 在保存时 provider==follow_* 不发送 URL/Id/Key — 防御纵深
- \`'local'\` 占位分支要么实现要么 \`raise NotImplementedError\`，避免再被静默兜底成 \`dummy_tts_worker\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复在跟随模式下，omni/tts 的模型 URL 被错误覆盖的问题；保留用户提供的模型 ID，URL 覆盖仅在必要时跳过
  * 确保 TTS 配置不被意外写入/污染，API Key 继承逻辑保持正确
  * 非 omni/tts 的模型（如会话等）仍按原逻辑更新 URL
  * 显式自定义提供者仍然生效并保留自定义 URL/模型与标识

* **Tests**
  * 新增单元测试，验证跟随模式下配置继承与覆盖行为符合预期，且显式自定义配置保持优先级
<!-- end of auto-generated comment: release notes by coderabbit.ai -->