### PR TITLE
fix(react-chat): 30s 内严格 group 连续消息（隐藏重复 author/time）

### DIFF
--- a/frontend/react-neko-chat/src/MessageBubble.tsx
+++ b/frontend/react-neko-chat/src/MessageBubble.tsx
@@ -140,7 +140,7 @@ export default function MessageBubble({
   const bubbleClassName = getBubbleClassName(message);
   const rowClassName = getRowClassName(message);
   const showAvatar = message.role !== 'system' && !isGroupedWithPrevious;
-  const showMeta = message.role !== 'system';
+  const showMeta = message.role !== 'system' && !isGroupedWithPrevious;
 
   if (message.role === 'system') {
     return (

--- a/frontend/react-neko-chat/src/MessageBubble.tsx
+++ b/frontend/react-neko-chat/src/MessageBubble.tsx
@@ -141,6 +141,7 @@ export default function MessageBubble({
   const rowClassName = getRowClassName(message);
   const showAvatar = message.role !== 'system' && !isGroupedWithPrevious;
   const showMeta = message.role !== 'system' && !isGroupedWithPrevious;
+  const showFailed = message.role !== 'system' && message.status === 'failed';
 
   if (message.role === 'system') {
     return (
@@ -190,11 +191,11 @@ export default function MessageBubble({
       )}
 
       <div className="message-stack">
-        {showMeta ? (
+        {(showMeta || showFailed) ? (
           <div className="message-meta">
-            <span className="message-author">{message.author}</span>
-            <span className="message-time">{message.time}</span>
-            {message.status === 'failed' ? <span className="message-delivery message-delivery-failed">{failedStatusLabel}</span> : null}
+            {showMeta ? <span className="message-author">{message.author}</span> : null}
+            {showMeta ? <span className="message-time">{message.time}</span> : null}
+            {showFailed ? <span className="message-delivery message-delivery-failed">{failedStatusLabel}</span> : null}
           </div>
         ) : null}
         <div className={bubbleClassName}>

--- a/frontend/react-neko-chat/src/MessageList.tsx
+++ b/frontend/react-neko-chat/src/MessageList.tsx
@@ -18,7 +18,7 @@ function shouldGroupWithPrevious(current: ChatMessage, previous?: ChatMessage) {
   if (current.author !== previous.author) return false;
   if (current.role === 'system') return false;
   if (typeof current.createdAt === 'number' && typeof previous.createdAt === 'number') {
-    if (Math.abs(current.createdAt - previous.createdAt) > 5 * 60 * 1000) {
+    if (Math.abs(current.createdAt - previous.createdAt) > 30 * 1000) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- React 聊天里"30 秒内连续同 author 消息不重复显示日期/名字"实际只藏了头像，author + time 一直在渲染。`MessageBubble` 的 `showMeta` 没接 `isGroupedWithPrevious`，从初版（#515）就是这样
- `showMeta` 接上 `!isGroupedWithPrevious`，与 `showAvatar` 对齐
- `MessageList.shouldGroupWithPrevious` 阈值从 `5 * 60 * 1000` 收紧到 `30 * 1000`，符合"严格 group"语义

## Test plan

- [x] `npx vitest run` — 36/36 通过（含既有 grouping 用例：1ms 间隔仍 group）
- [ ] 真实场景：连续两条 AI 消息间隔 <30s 时只在第一条显示头像/名字/时间，>30s 则恢复显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化消息元数据显示逻辑：分组消息不再重复显示作者和时间，界面更整洁。
  * 优化失败投递提示：消息发送失败时会显示失败标识，即便该消息与前一条被分组隐藏了作者/时间。
  * 调整消息分组时间阈值：缩短为 30 秒，改善相邻消息的分组与展示体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->