### PR TITLE
test: 修两处 mock 漏洞 + 测试日志改写到临时目录

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,29 @@
+import os as _os
+import tempfile as _tempfile
+from pathlib import Path as _Path
+
+# Redirect test logs out of the user's real %USERPROFILE%/Documents/N.E.K.O/logs.
+# Without this, every pytest session — including ones that intentionally inject
+# OSError / 坏 JSON / mock-driven failures via patches — dumps ERROR lines into
+# the user's Documents tree.
+#
+# We override RobustLoggerConfig._get_log_directory directly (rather than going
+# through NEKO_STORAGE_SELECTED_ROOT) because that env var also drives
+# ConfigManager / cloudsave_runtime layout, and pointing those at the temp dir
+# triggers a legacy-app-root migration scan that rmtrees the temp dir mid-test.
+# Loggers are constructed at module import time, so the patch must happen here
+# in conftest BEFORE any project module is imported.
+_NEKO_TEST_LOG_ROOT = _Path(_tempfile.gettempdir()) / f"neko_test_logs_{_os.getpid()}"
+_NEKO_TEST_LOG_ROOT.mkdir(parents=True, exist_ok=True)
+from utils import logger_config as _logger_config_module
+# Override only the Documents-fallback hook (priority 2 in _get_log_directory).
+# Env-var-based override (priority 1) and the cascade through application/system
+# data dirs stay intact — so tests that use monkeypatch.setenv on
+# NEKO_STORAGE_SELECTED_ROOT still see the override they expect.
+_logger_config_module.RobustLoggerConfig._get_documents_directory = (
+    lambda self, _root=_NEKO_TEST_LOG_ROOT: _root
+)
+
 import asyncio
 import asyncio.runners
 import asyncio.coroutines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import os as _os
+import sys as _sys
 import tempfile as _tempfile
 from pathlib import Path as _Path
+
+# Project root must be on sys.path before importing `utils.*` — works even when
+# the project isn't installed as a wheel (e.g. bare `python -m pytest tests/`).
+_project_root = _os.path.abspath(_os.path.join(_os.path.dirname(__file__), '..'))
+if _project_root not in _sys.path:
+    _sys.path.insert(0, _project_root)
 
 # Redirect test logs out of the user's real %USERPROFILE%/Documents/N.E.K.O/logs.
 # Without this, every pytest session — including ones that intentionally inject
@@ -74,10 +81,8 @@ from pathlib import Path
 
 import uvicorn
 
-# Add project root to sys.path before importing project-local test helpers.
-_project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if _project_root not in sys.path:
-    sys.path.insert(0, _project_root)
+# (Project root was already inserted into sys.path at the top of this file
+# so the early `from utils import logger_config` works without `uv sync`.)
 
 import pytest
 

--- a/tests/unit/test_cloudsave_autocloud_router.py
+++ b/tests/unit/test_cloudsave_autocloud_router.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -102,7 +102,19 @@ async def test_cloudsave_router_exposes_steam_autocloud_configuration_payload():
 
             cloudsave_router_module = importlib.import_module("main_routers.cloudsave_router")
 
-            summary = await cloudsave_router_module.get_cloudsave_summary()
+            # 这个测试只关心 steam_autocloud 配置，不关心 workshop 状态查询。
+            # 不打 patch 的话 _enrich_cloudsave_payload_with_workshop_status 会调
+            # SimpleNamespace 上不存在的 .Workshop，把 ERROR 喷到日志里。
+            with patch.object(
+                cloudsave_router_module,
+                "get_subscribed_workshop_items",
+                AsyncMock(return_value={"success": True, "items": [], "total": 0}),
+            ), patch.object(
+                cloudsave_router_module,
+                "get_workshop_item_details",
+                AsyncMock(return_value={"success": True, "item": {"publishedFileId": "123456"}}),
+            ):
+                summary = await cloudsave_router_module.get_cloudsave_summary()
             assert summary["sync_backend"] == "steam_auto_cloud"
             assert summary["steam_autocloud"]["backend"] == "steam_auto_cloud"
             assert summary["steam_autocloud"]["app_id"] == "4099310"

--- a/tests/unit/test_outbox_wiring.py
+++ b/tests/unit/test_outbox_wiring.py
@@ -24,9 +24,11 @@ def _install_fresh_memory_state(tmpdir: str):
 
     mock_cm = MagicMock()
     mock_cm.memory_dir = tmpdir
-    mock_cm.load_characters = MagicMock(
-        return_value={"猫娘": {"小天": {}}, "当前猫娘": "小天"}
-    )
+    _initial_characters = {"猫娘": {"小天": {}}, "当前猫娘": "小天"}
+    mock_cm.load_characters = MagicMock(return_value=_initial_characters)
+    # _replay_pending_outbox awaits the async variant; without an AsyncMock
+    # the bare MagicMock attribute returns a MagicMock that can't be awaited.
+    mock_cm.aload_characters = AsyncMock(return_value=_initial_characters)
     with patch("memory.outbox.get_config_manager", return_value=mock_cm):
         ob = Outbox()
     ob._config_manager = mock_cm
@@ -198,9 +200,9 @@ async def test_replay_scans_disk_for_characters_not_in_config(tmp_path):
     await ob.aappend_pending("小天", OP_EXTRACT_FACTS, {"i": 1})
 
     # 模拟 config 被改成不再包含小天（但磁盘上的 outbox 还在）
-    mock_cm.load_characters = MagicMock(
-        return_value={"猫娘": {}, "当前猫娘": None}
-    )
+    _empty_characters = {"猫娘": {}, "当前猫娘": None}
+    mock_cm.load_characters = MagicMock(return_value=_empty_characters)
+    mock_cm.aload_characters = AsyncMock(return_value=_empty_characters)
 
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary

清理跑测试时一直在喷的几条 ERROR/WARNING 噪音——不是真 bug，是 mock 写漏了——以及一个更严重的问题：测试日志（包括故意 inject 的 ERROR）一直在落到用户真实的 \`%USERPROFILE%/Documents/N.E.K.O/logs\` 里污染生产日志。

## 改动

**1. \`tests/unit/test_outbox_wiring.py\` —— Outbox 启动补跑 mock 漏 async 版**

\`_install_fresh_memory_state\` 只装了 \`load_characters\`（同步版），但 \`_replay_pending_outbox\` 走的是 \`await _config_manager.aload_characters()\`。属性访问拿到裸 \`MagicMock\`，await 时炸 \`object MagicMock can't be used in 'await' expression\`。补上 \`aload_characters = AsyncMock(...)\`。\`test_replay_scans_disk_for_characters_not_in_config\` 处覆写时也补一份。

测试本来就会过——因为 \`_replay_pending_outbox\` 优雅捕获了 exception 走磁盘扫描兜底——但 warning 是误导的，遮蔽了"测试本意是测 happy path"这件事。

**2. \`tests/unit/test_cloudsave_autocloud_router.py\` —— Workshop mock 字段缺失**

\`_make_dummy_steamworks\` 的 \`SimpleNamespace\` 只挂了 \`IsSteamRunning\` / \`Users.LoggedOn\`，没有 \`.Workshop\`。\`get_cloudsave_summary()\` 里 \`_enrich_cloudsave_payload_with_workshop_status\` → \`get_subscribed_workshop_items / get_workshop_item_details\` 调 \`steamworks.Workshop.GetNumSubscribedItems()\` 时 \`AttributeError\`，被 workshop_router 的 try/except 捕获后喷两条 ERROR。

这个测试只关心 steam_autocloud 配置不关心 workshop 状态，按 \`test_cloudsave_router.py\` 的惯例 patch 掉两个 workshop 函数即可。

**3. \`tests/conftest.py\` —— 测试日志不再落到真实 Documents**

monkey-patch \`RobustLoggerConfig._get_documents_directory\` 在所有项目 import 之前覆写到 \`Temp/neko_test_logs_<pid>/\`。日志目录优先级是 \`NEKO_STORAGE_SELECTED_ROOT\` → \`_get_documents_directory()\` → app dir → …，我只覆写第二档，不动 env 变量，所以：
- 用 \`monkeypatch.setenv\` 测 env 行为的 \`test_logger_config_storage_root.py\` 不受影响
- 不会把 tmp 目录注册成 NEKO storage root（先尝试用 env 变量做，结果 \`cloudsave_runtime\` 把 tmp dir 当 legacy app root 给 rmtree 了）

跨平台：\`tempfile.gettempdir()\` + \`pathlib\` 走 stdlib，Win/Mac/Linux 都没问题；lambda 整段替换原方法，绕过原 \`if win32 ... elif darwin ...\` 分支。

> 注意：那批 \`disk full\` / \`policy unreadable\` / 坏 JSON 的 ERROR 是测试**本意要触发的错误处理分支**，代码就是要 log 出来证明这分支被走到。这次只是让它们落进 tmp 而不是真实 Documents，没改 log level——把生产环境真出问题的可见性砍掉得不偿失。

## Test plan

- [x] 单跑 \`test_outbox_wiring + test_cloudsave_autocloud_router\`：俩 ERROR 完全消失，只剩真测 inject 的 \`disk full\` warning
- [x] 跑 \`test_storage_layout + test_storage_location_bootstrap + test_logger_config_storage_root + test_outbox_wiring + test_cloudsave_autocloud_router + test_cloudsave_router\`（62 个）全过
- [x] 日志确认落到 \`Temp\neko_test_logs_<pid>\N.E.K.O\logs\`，不再去 \`D:\Documents\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 提前引导测试环境，插入项目根路径并将测试日志重定向到每进程临时目录，避免污染用户文档目录。
  * 在云存储路由相关测试中使用 AsyncMock，模拟订阅与详情接口以稳定输出并隔离外部依赖。
  * 在发件箱相关测试中为异步/同步角色加载器添加模拟返回值，确保重放与配置校验使用一致的测试数据。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->