### PR TITLE
fix(memory): review 不吞 head memo + qwen3.5 切 semantic_vad

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -693,10 +693,11 @@ class OmniRealtimeClient:
                         "model": "gummy-realtime-v1"
                     },
                     "turn_detection": {
-                        "type": "server_vad",
+                        # TODO: 未来需要cover更多型号
+                        "type": "semantic_vad" if "3.5" in self._model_lower else "server_vad",
                         "threshold": 0.55,
                         "prefix_padding_ms": 300,
-                        "silence_duration_ms": 650
+                        "silence_duration_ms": 600
                     },
                     "repetition_penalty": 1.2,
                     "temperature": 0.7,

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -684,7 +684,15 @@ class CompressedRecentHistoryManager:
                 # 不规范的话头部 memo 边界会被破，下游 prompt 拼装会拿到错位的
                 # system 行（甚至中段 SystemMessage 跟下游 compress 的"alien stop"
                 # 不变量打架）。
-                if snapshot and isinstance(snapshot[0], SystemMessage):
+                # 注意：必须 gate 在 corrected_messages 非空——LLM 返空列表是
+                # "整段都删"的语义信号，下面 take_count == 0 那条会按白 review
+                # 处理；这里塞 snapshot[0] 进去会绕过白 review 闸门、把对话区
+                # 全擦掉只剩 memo。
+                if (
+                    corrected_messages
+                    and snapshot
+                    and isinstance(snapshot[0], SystemMessage)
+                ):
                     sys_msgs = [m for m in corrected_messages if isinstance(m, SystemMessage)]
                     others = [m for m in corrected_messages if not isinstance(m, SystemMessage)]
                     head = sys_msgs[0] if sys_msgs else snapshot[0]

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -695,8 +695,15 @@ class CompressedRecentHistoryManager:
                 ):
                     sys_msgs = [m for m in corrected_messages if isinstance(m, SystemMessage)]
                     others = [m for m in corrected_messages if not isinstance(m, SystemMessage)]
-                    head = sys_msgs[0] if sys_msgs else snapshot[0]
-                    corrected_messages = [head] + others
+                    if not others:
+                        # LLM 只返 system、没返任何对话 ≡ "整段对话都删"语义信号，
+                        # 跟返空列表等价，应走白 review。重置成空让下面 take_count==0
+                        # 闸门接管；不然 normalize 会塞一条 SystemMessage 进 corrected，
+                        # 长度变 1 绕过闸门，对话区被擦光只剩 memo。
+                        corrected_messages = []
+                    else:
+                        head = sys_msgs[0] if sys_msgs else snapshot[0]
+                        corrected_messages = [head] + others
 
                 # ── Phase C 关键：基于 snapshot 算 capacity 做尾部对齐替换 ──
                 current = await self.aget_recent_history(lanlan_name)

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -663,8 +663,10 @@ class CompressedRecentHistoryManager:
                             content = str(content)
 
                     if role in ['system', 'system_message', name_mapping['system']]:
-                        # 跳过：summary 由 compress 拥有，review 不能改写
-                        continue
+                        # prompt <要点3> 让 LLM 保留+可编辑 memo，过滤掉等于
+                        # 让其在 prompt 里白做工，且 capacity 走过 head SystemMessage
+                        # 后这一格无人填补，导致 memo 在写盘时蒸发（场景 D）。
+                        corrected_messages.append(SystemMessage(content=content))
                     elif role in ['user', 'human', name_mapping['human']]:
                         corrected_messages.append(HumanMessage(content=content))
                     elif role in ['ai', 'assistant', name_mapping['ai']]:
@@ -672,6 +674,15 @@ class CompressedRecentHistoryManager:
                     else:
                         # 默认作为用户消息处理
                         corrected_messages.append(HumanMessage(content=content))
+
+                # 兜底：LLM 不听 <要点3> 把 memo 漏了 → 用 snapshot 头部
+                # 原 SystemMessage 回填，遵守"不允许删除"约束。
+                if (
+                    snapshot
+                    and isinstance(snapshot[0], SystemMessage)
+                    and not any(isinstance(m, SystemMessage) for m in corrected_messages)
+                ):
+                    corrected_messages.insert(0, snapshot[0])
 
                 # ── Phase C 关键：基于 snapshot 算 capacity 做尾部对齐替换 ──
                 current = await self.aget_recent_history(lanlan_name)

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -675,14 +675,20 @@ class CompressedRecentHistoryManager:
                         # 默认作为用户消息处理
                         corrected_messages.append(HumanMessage(content=content))
 
-                # 兜底：LLM 不听 <要点3> 把 memo 漏了 → 用 snapshot 头部
-                # 原 SystemMessage 回填，遵守"不允许删除"约束。
-                if (
-                    snapshot
-                    and isinstance(snapshot[0], SystemMessage)
-                    and not any(isinstance(m, SystemMessage) for m in corrected_messages)
-                ):
-                    corrected_messages.insert(0, snapshot[0])
+                # 规范化 SystemMessage 位置：snapshot 头是 memo 时，
+                # corrected_messages 必须以唯一一条 SystemMessage 开头。
+                # 处理三种 LLM 坏输出：
+                # (a) 完全漏返 → 用 snapshot[0] 兜底
+                # (b) 放在中间 → 提到头部
+                # (c) 多吐几条 → 只留首条
+                # 不规范的话头部 memo 边界会被破，下游 prompt 拼装会拿到错位的
+                # system 行（甚至中段 SystemMessage 跟下游 compress 的"alien stop"
+                # 不变量打架）。
+                if snapshot and isinstance(snapshot[0], SystemMessage):
+                    sys_msgs = [m for m in corrected_messages if isinstance(m, SystemMessage)]
+                    others = [m for m in corrected_messages if not isinstance(m, SystemMessage)]
+                    head = sys_msgs[0] if sys_msgs else snapshot[0]
+                    corrected_messages = [head] + others
 
                 # ── Phase C 关键：基于 snapshot 算 capacity 做尾部对齐替换 ──
                 current = await self.aget_recent_history(lanlan_name)

--- a/memory/recent.py
+++ b/memory/recent.py
@@ -666,7 +666,13 @@ class CompressedRecentHistoryManager:
                         # prompt <要点3> 让 LLM 保留+可编辑 memo，过滤掉等于
                         # 让其在 prompt 里白做工，且 capacity 走过 head SystemMessage
                         # 后这一格无人填补，导致 memo 在写盘时蒸发（场景 D）。
-                        corrected_messages.append(SystemMessage(content=content))
+                        # 但只在 snapshot 头本来就是 SystemMessage 时接收 LLM
+                        # 的 system 输出——否则 history 还没压缩过、不该有
+                        # SystemMessage，LLM 幻觉吐 system 必须丢，避免把伪
+                        # memo 注入未压缩对话区污染下游。
+                        if snapshot and isinstance(snapshot[0], SystemMessage):
+                            corrected_messages.append(SystemMessage(content=content))
+                        # else: 静默 drop，恢复老行为
                     elif role in ['user', 'human', name_mapping['human']]:
                         corrected_messages.append(HumanMessage(content=content))
                     elif role in ['ai', 'assistant', name_mapping['ai']]:

--- a/tests/unit/test_review_history_memo_preservation.py
+++ b/tests/unit/test_review_history_memo_preservation.py
@@ -223,6 +223,39 @@ def test_empty_llm_output_falls_through_to_white_review(tmp_path):
     assert isinstance(final[0], SystemMessage) and final[0].content == memo
 
 
+def test_pre_compression_drops_hallucinated_system(tmp_path):
+    """history 还没压缩过（snapshot[0] 不是 SystemMessage），LLM 幻觉吐
+    system 行：必须 drop，恢复老 filter 行为。否则 normalize 块不触发，
+    伪 memo 会被注入未压缩对话区污染下游（Codex P2）。"""
+    snapshot = [
+        HumanMessage(content="hi 1"),
+        AIMessage(content="ai 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 2"),
+        HumanMessage(content="hi 3"),
+        AIMessage(content="ai 3"),
+    ]
+    corrected = [
+        {"role": "Master", "content": "hi 1"},
+        {"role": "Xiaoba", "content": "ai 1"},
+        {"role": "SYSTEM_MESSAGE", "content": "fake hallucinated memo"},  # 幻觉
+        {"role": "Master", "content": "hi 2"},
+        {"role": "Xiaoba", "content": "ai 2"},
+        {"role": "Master", "content": "hi 3"},
+        {"role": "Xiaoba", "content": "ai 3"},
+    ]
+    fake_llm = _FakeLLM(corrected)
+    mgr, name, _master = _make_manager(tmp_path, snapshot, fake_llm)
+
+    status, _fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "patched"
+    final = _read_disk(mgr.log_file_path[name])
+    # 不能有任何 SystemMessage（snapshot 没有 → result 也不该有）
+    assert not any(isinstance(m, SystemMessage) for m in final), \
+        f"幻觉 system 必须被 drop，实际 final={[type(m).__name__ for m in final]}"
+
+
 def test_only_system_no_dialogue_falls_through_to_white_review(tmp_path):
     """LLM 只返 system 没返任何对话 ≡ 返空列表（语义上"整段对话都删"），
     应走白 review。

--- a/tests/unit/test_review_history_memo_preservation.py
+++ b/tests/unit/test_review_history_memo_preservation.py
@@ -193,6 +193,36 @@ def test_memo_restored_when_llm_hallucinates_delete(tmp_path):
     assert final[0].content == memo, "restored memo should be original (not LLM's omission)"
 
 
+def test_empty_llm_output_falls_through_to_white_review(tmp_path):
+    """LLM 返回空 corrected_dialogue 是"整段都删"的语义信号，原设计
+    在 take_count == 0 处按 white review 处理（不写盘、不更新 fingerprint）。
+
+    Regression：normalize 兜底必须在 corrected_messages 非空时才介入，
+    否则会把空列表强行补成 [snapshot[0]]，绕过白 review 闸门把对话区
+    擦掉只剩 memo（CodeRabbit Critical）。
+    """
+    memo = "先前对话的备忘录: original."
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        AIMessage(content="ai 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 2"),
+    ]
+    on_disk_before = list(snapshot)
+    fake_llm = _FakeLLM([])  # LLM 返回空
+    mgr, name, _master = _make_manager(tmp_path, on_disk_before, fake_llm)
+
+    status, fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "white", f"空 corrected → 应走 white review，实际 {status}"
+    assert fp is None
+    # 磁盘内容不动
+    final = _read_disk(mgr.log_file_path[name])
+    assert len(final) == len(on_disk_before)
+    assert isinstance(final[0], SystemMessage) and final[0].content == memo
+
+
 def test_memo_promoted_when_llm_misplaces_it_in_middle(tmp_path):
     """LLM hallucinates by putting SystemMessage at index 1 instead of 0.
     Expect: it gets promoted to head of corrected_messages."""

--- a/tests/unit/test_review_history_memo_preservation.py
+++ b/tests/unit/test_review_history_memo_preservation.py
@@ -21,7 +21,6 @@ import json
 import os
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/test_review_history_memo_preservation.py
+++ b/tests/unit/test_review_history_memo_preservation.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for review_history's memo (head SystemMessage) preservation.
+
+Bug (scenario D): when ``snapshot`` started with a SystemMessage memo and
+nothing intervened to break the fingerprint chain at index 0, the
+``_compute_review_capacity`` walk matched all the way through the head
+SystemMessage (snapshot[0] == current[0] for the same memo), so the
+replacement window covered the memo slot. The review LLM is told (via
+``<要点3>``) to keep the memo, returns it in ``corrected_dialogue`` with
+role ``SYSTEM_MESSAGE``, but the patching loop dropped any system role
+unconditionally — leaving the memo slot empty in ``new_history`` and the
+on-disk recent file ended up with no memo.
+
+Fix: accept LLM's SystemMessage output into ``corrected_messages``, plus
+defensive restore from snapshot[0] if LLM hallucinates a delete.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from memory.recent import CompressedRecentHistoryManager
+from utils.llm_client import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    messages_from_dict,
+    messages_to_dict,
+)
+
+
+# ─────────────── stub LLM ───────────────
+
+
+class _FakeLLM:
+    """Minimal stand-in for the review LLM. ``ainvoke`` returns a canned
+    JSON string with the prescribed ``corrected_dialogue`` shape."""
+
+    def __init__(self, corrected_dialogue: list[dict], explanation: str = "test"):
+        self._payload = json.dumps(
+            {"explanation": explanation, "corrected_dialogue": corrected_dialogue},
+            ensure_ascii=False,
+        )
+
+    async def ainvoke(self, prompt: str, **kwargs: Any) -> Any:
+        class _R:
+            content: str
+
+        r = _R()
+        r.content = self._payload
+        return r
+
+    async def aclose(self) -> None:
+        return None
+
+
+# ─────────────── manager builder bypassing __init__ ───────────────
+
+
+def _make_manager(tmp_path: Path, snapshot: list, fake_llm: _FakeLLM) -> tuple[
+    CompressedRecentHistoryManager, str, str,
+]:
+    """Build a CompressedRecentHistoryManager without touching ConfigManager.
+
+    ``snapshot`` is written to disk as ``recent.json`` so that
+    ``aget_recent_history`` reads it back as ``current``. The fake LLM is
+    bound via ``_get_review_llm``. ``name_mapping`` mirrors the real
+    config_manager output.
+    """
+    lanlan_name = "Xiaoba"
+    master = "Master"
+    file_path = str(tmp_path / "recent.json")
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(messages_to_dict(snapshot), f, ensure_ascii=False)
+
+    mgr = object.__new__(CompressedRecentHistoryManager)
+    mgr._config_manager = object()  # only used by assert_cloudsave_writable (patched)
+    mgr.max_history_length = 10
+    mgr.compress_threshold = 15
+    mgr.log_file_path = {lanlan_name: file_path}
+    mgr.name_mapping = {
+        "human": master,
+        "ai": lanlan_name,
+        "system": "SYSTEM_MESSAGE",
+    }
+    mgr.user_histories = {lanlan_name: list(snapshot)}
+    mgr._get_review_llm = lambda: fake_llm  # type: ignore[method-assign]
+    return mgr, lanlan_name, master
+
+
+def _read_disk(file_path: str) -> list:
+    with open(file_path, encoding="utf-8") as f:
+        return messages_from_dict(json.load(f))
+
+
+# ─────────────── tests ───────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_cloudsave_and_aget(monkeypatch):
+    """Stub out cloudsave gate and replace aget_recent_history with a
+    file-only reader so we don't need a real ConfigManager."""
+    monkeypatch.setattr(
+        "memory.recent.assert_cloudsave_writable",
+        lambda *a, **kw: None,
+    )
+
+    async def _fake_aget(self, lanlan_name):
+        fp = self.log_file_path[lanlan_name]
+        if os.path.exists(fp):
+            self.user_histories[lanlan_name] = _read_disk(fp)
+        return self.user_histories.get(lanlan_name, [])
+
+    monkeypatch.setattr(CompressedRecentHistoryManager, "aget_recent_history", _fake_aget)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_memo_preserved_when_snapshot_has_head_system_and_llm_returns_it(tmp_path):
+    """Scenario D: snapshot=[memo, dialogue...]; current identical (no
+    parallel compress); LLM returns memo at head of corrected_dialogue.
+    Expect: head SystemMessage survives, edited content from LLM applied."""
+    memo = "先前对话的备忘录: 用户喜欢深夜聊天。"
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 1"),
+        AIMessage(content="ai 2"),
+        HumanMessage(content="hi 3"),
+        AIMessage(content="ai 3"),
+    ]
+    edited_memo = "先前对话的备忘录: 该用户偏好夜聊。"
+    corrected = [
+        {"role": "SYSTEM_MESSAGE", "content": edited_memo},
+        {"role": "Master", "content": "hi 1"},
+        {"role": "Master", "content": "hi 2"},
+        {"role": "Xiaoba", "content": "ai 1"},
+        {"role": "Xiaoba", "content": "ai 2"},
+        {"role": "Master", "content": "hi 3"},
+        {"role": "Xiaoba", "content": "ai 3"},
+    ]
+    fake_llm = _FakeLLM(corrected)
+    mgr, name, _master = _make_manager(tmp_path, snapshot, fake_llm)
+
+    status, _fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "patched"
+    final = _read_disk(mgr.log_file_path[name])
+    assert isinstance(final[0], SystemMessage), f"head must remain system, got {type(final[0]).__name__}"
+    assert final[0].content == edited_memo, "LLM-edited memo content should be applied"
+    assert len(final) == len(snapshot), "no concurrent change → length unchanged"
+
+
+def test_memo_restored_when_llm_hallucinates_delete(tmp_path):
+    """Scenario D defensive: LLM ignores <要点3> and omits the system
+    entry from corrected_dialogue. Expect: snapshot[0] memo is restored
+    (don't allow LLM to silently drop the memo)."""
+    memo = "先前对话的备忘录: keep me."
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 1"),
+        AIMessage(content="ai 2"),
+        HumanMessage(content="hi 3"),
+        AIMessage(content="ai 3"),
+    ]
+    # LLM forgot the system entry entirely.
+    corrected = [
+        {"role": "Master", "content": "hi 1"},
+        {"role": "Master", "content": "hi 2"},
+        {"role": "Xiaoba", "content": "ai 1"},
+        {"role": "Xiaoba", "content": "ai 2"},
+        {"role": "Master", "content": "hi 3"},
+        {"role": "Xiaoba", "content": "ai 3"},
+    ]
+    fake_llm = _FakeLLM(corrected)
+    mgr, name, _master = _make_manager(tmp_path, snapshot, fake_llm)
+
+    status, _fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "patched"
+    final = _read_disk(mgr.log_file_path[name])
+    assert isinstance(final[0], SystemMessage), "memo must be restored from snapshot"
+    assert final[0].content == memo, "restored memo should be original (not LLM's omission)"
+
+
+def test_memo_preserved_with_concurrent_append(tmp_path):
+    """Scenario D + parallel append: snapshot=[memo, dialogue]; current=
+    snapshot+1 new message added during review. Expect: memo + edited
+    dialogue + new appended message all coexist."""
+    memo = "先前对话的备忘录: hello world."
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        AIMessage(content="ai 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 2"),
+    ]
+    # 模拟 review LLM 跑期间用户发了一条新消息，落到 disk 上
+    appended = HumanMessage(content="brand new")
+    current_on_disk = list(snapshot) + [appended]
+    fake_llm = _FakeLLM([
+        {"role": "SYSTEM_MESSAGE", "content": memo},
+        {"role": "Master", "content": "hi 1"},
+        {"role": "Xiaoba", "content": "ai 1"},
+        {"role": "Master", "content": "hi 2"},
+        {"role": "Xiaoba", "content": "ai 2"},
+    ])
+    mgr, name, _master = _make_manager(tmp_path, current_on_disk, fake_llm)
+
+    status, _fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "patched"
+    final = _read_disk(mgr.log_file_path[name])
+    assert isinstance(final[0], SystemMessage)
+    assert final[0].content == memo
+    assert final[-1].content == "brand new", "appended message must survive review patch"
+    assert len(final) == len(snapshot) + 1

--- a/tests/unit/test_review_history_memo_preservation.py
+++ b/tests/unit/test_review_history_memo_preservation.py
@@ -223,6 +223,40 @@ def test_empty_llm_output_falls_through_to_white_review(tmp_path):
     assert isinstance(final[0], SystemMessage) and final[0].content == memo
 
 
+def test_only_system_no_dialogue_falls_through_to_white_review(tmp_path):
+    """LLM 只返 system 没返任何对话 ≡ 返空列表（语义上"整段对话都删"），
+    应走白 review。
+
+    Regression：normalize 不能把这种坏输出"修正"成 [SystemMessage]，否则
+    长度=1 绕过 take_count==0 白 review 闸门，对话区被擦光只剩 memo
+    （Codex P1）。
+    """
+    memo = "先前对话的备忘录: original."
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        AIMessage(content="ai 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 2"),
+    ]
+    on_disk_before = list(snapshot)
+    fake_llm = _FakeLLM([
+        {"role": "SYSTEM_MESSAGE", "content": "memo only, no dialogue"},
+    ])
+    mgr, name, _master = _make_manager(tmp_path, on_disk_before, fake_llm)
+
+    status, fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "white", f"只返 system → 应走 white review，实际 {status}"
+    assert fp is None
+    # 磁盘原样不动
+    final = _read_disk(mgr.log_file_path[name])
+    assert len(final) == len(on_disk_before)
+    assert isinstance(final[0], SystemMessage) and final[0].content == memo
+    # 对话区原封不动
+    assert [type(m).__name__ for m in final[1:]] == ["HumanMessage", "AIMessage", "HumanMessage", "AIMessage"]
+
+
 def test_memo_promoted_when_llm_misplaces_it_in_middle(tmp_path):
     """LLM hallucinates by putting SystemMessage at index 1 instead of 0.
     Expect: it gets promoted to head of corrected_messages."""

--- a/tests/unit/test_review_history_memo_preservation.py
+++ b/tests/unit/test_review_history_memo_preservation.py
@@ -120,7 +120,7 @@ def _patch_cloudsave_and_aget(monkeypatch):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_memo_preserved_when_snapshot_has_head_system_and_llm_returns_it(tmp_path):
@@ -191,6 +191,77 @@ def test_memo_restored_when_llm_hallucinates_delete(tmp_path):
     final = _read_disk(mgr.log_file_path[name])
     assert isinstance(final[0], SystemMessage), "memo must be restored from snapshot"
     assert final[0].content == memo, "restored memo should be original (not LLM's omission)"
+
+
+def test_memo_promoted_when_llm_misplaces_it_in_middle(tmp_path):
+    """LLM hallucinates by putting SystemMessage at index 1 instead of 0.
+    Expect: it gets promoted to head of corrected_messages."""
+    memo = "先前对话的备忘录: 用户喜欢深夜聊天。"
+    misplaced_memo = "先前对话的备忘录: 用户偏好夜聊。"
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 1"),
+        AIMessage(content="ai 2"),
+        HumanMessage(content="hi 3"),
+        AIMessage(content="ai 3"),
+    ]
+    corrected = [
+        {"role": "Master", "content": "hi 1"},
+        {"role": "SYSTEM_MESSAGE", "content": misplaced_memo},  # 错位
+        {"role": "Master", "content": "hi 2"},
+        {"role": "Xiaoba", "content": "ai 1"},
+        {"role": "Xiaoba", "content": "ai 2"},
+        {"role": "Master", "content": "hi 3"},
+        {"role": "Xiaoba", "content": "ai 3"},
+    ]
+    fake_llm = _FakeLLM(corrected)
+    mgr, name, _master = _make_manager(tmp_path, snapshot, fake_llm)
+
+    status, _fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "patched"
+    final = _read_disk(mgr.log_file_path[name])
+    assert isinstance(final[0], SystemMessage), "memo 必须在头部"
+    assert final[0].content == misplaced_memo, "用 LLM 给的（首条 system）"
+    # 其余位置不能再有 SystemMessage
+    assert not any(isinstance(m, SystemMessage) for m in final[1:])
+
+
+def test_memo_dedup_when_llm_returns_multiple_systems(tmp_path):
+    """LLM 多吐几条 SystemMessage。Expect: 只留首条作为头部 memo。"""
+    memo = "先前对话的备忘录: 原文。"
+    snapshot = [
+        SystemMessage(content=memo),
+        HumanMessage(content="hi 1"),
+        HumanMessage(content="hi 2"),
+        AIMessage(content="ai 1"),
+        AIMessage(content="ai 2"),
+        HumanMessage(content="hi 3"),
+        AIMessage(content="ai 3"),
+    ]
+    corrected = [
+        {"role": "SYSTEM_MESSAGE", "content": "memo v1"},
+        {"role": "Master", "content": "hi 1"},
+        {"role": "SYSTEM_MESSAGE", "content": "memo v2 (bogus)"},  # 多吐
+        {"role": "Master", "content": "hi 2"},
+        {"role": "Xiaoba", "content": "ai 1"},
+        {"role": "Xiaoba", "content": "ai 2"},
+        {"role": "Master", "content": "hi 3"},
+        {"role": "Xiaoba", "content": "ai 3"},
+    ]
+    fake_llm = _FakeLLM(corrected)
+    mgr, name, _master = _make_manager(tmp_path, snapshot, fake_llm)
+
+    status, _fp = _run(mgr.review_history(name, snapshot=list(snapshot)))
+
+    assert status == "patched"
+    final = _read_disk(mgr.log_file_path[name])
+    sys_msgs = [m for m in final if isinstance(m, SystemMessage)]
+    assert len(sys_msgs) == 1, f"应只剩 1 条 system，实际 {len(sys_msgs)}"
+    assert isinstance(final[0], SystemMessage)
+    assert final[0].content == "memo v1", "只留首条作为头部 memo"
 
 
 def test_memo_preserved_with_concurrent_append(tmp_path):


### PR DESCRIPTION
## Summary

两个独立改动一并提：

### 1. `fix(memory)`: review 不再吞掉 head SystemMessage（memo 备忘录）

- 现状：`review_history` 把 LLM 返回的 `system` role entry 显式 `continue` 跳过（[memory/recent.py:665-667](memory/recent.py:665)），但 `_compute_review_capacity` 的 walk 不区分 system，snapshot 头部老总结指纹和 current 头部相等就一路走到 idx=0，把 memo slot 圈进替换窗口；slot 没人填 → memo 在写盘时蒸发。
- prompt `<要点3>` 已经显式让 LLM 保留 + 可编辑 memo（"你可以修改它，但不允许删除它"），但 LLM 干完活回填这一步把成果丢了 —— 这就是 bug 的所在。
- 修法：
  - `continue` 改成 `corrected_messages.append(SystemMessage(content=content))`，让 LLM 改过的 memo 真正进入回填路径
  - 兜底：snapshot 头是 SystemMessage 但 corrected 里没任何 SystemMessage → 用 snapshot[0] 原样回填，遵守"不允许删除"约束
- 回归测试 `tests/unit/test_review_history_memo_preservation.py` 覆盖三个场景（含 memo + LLM 返编辑版 / 含 memo + LLM 漏返 memo / 含 memo + 期间 append 新消息）

### 2. `chore(realtime)`: qwen3.5 走 semantic_vad

- `model_lower` 命中 `"3.5"` 时切到 `semantic_vad`，其他模型保留 `server_vad`（行为不变）
- `silence_duration_ms` 650 → 600
- 带 `# TODO: 未来需要cover更多型号` 标记

## Test plan

- [x] `pytest tests/unit/test_review_history_memo_preservation.py` 3 passed
- [x] `pytest tests/unit/test_memory_recall.py tests/unit/test_character_memory_regression.py` 55 passed
- [ ] qwen3.5 semantic_vad 由用户在实机 realtime 会话验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 改进对话历史审查：规范并仅保留单一开头系统消息，修复重复或错位，缺失或仅含系统消息时按回退规则恢复；并发写入场景下保持头部与新增内容一致。
  * 优化实时语音检测：针对不同模型在两种检测模式间切换（含对 "3.5" 型号的语义 VAD 优先），并微调静默判定时长与阈值以提升识别稳定性。

* **Tests**
  * 新增单元测试覆盖系统消息保护、促升/去重、并发写入及空输出降级情形。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->