### PR TITLE
style(react-chat): 最小化球去 hover 灰底 + 关闭叉缩小淡化

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -922,9 +922,12 @@ body.react-chat-window-resizing {
 }
 
 [data-theme="dark"] #avatarPreviewHeaderButton,
-[data-theme="dark"] #reactChatWindowMinimizeButton,
-[data-theme="dark"] #reactChatWindowCloseButton {
+[data-theme="dark"] #reactChatWindowMinimizeButton {
     color: #aab0bc;
+}
+
+[data-theme="dark"] #reactChatWindowCloseButton {
+    color: #8a8f9c;
 }
 
 [data-theme="dark"] #avatarPreviewHeaderButton:hover,

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -798,7 +798,14 @@ body.react-chat-adapter-active #chat-container {
     justify-content: center;
 }
 
-#reactChatWindowMinimizeButton:hover,
+#reactChatWindowCloseButton {
+    width: 24px;
+    height: 24px;
+    font-size: 1rem;
+    line-height: 24px;
+    color: #9aa3b4;
+}
+
 #reactChatWindowCloseButton:hover {
     background: rgba(88, 108, 145, 0.12);
     color: #2b3851;
@@ -921,7 +928,6 @@ body.react-chat-window-resizing {
 }
 
 [data-theme="dark"] #avatarPreviewHeaderButton:hover,
-[data-theme="dark"] #reactChatWindowMinimizeButton:hover,
 [data-theme="dark"] #reactChatWindowCloseButton:hover {
     background: rgba(200, 210, 230, 0.12);
     color: #dde0e8;


### PR DESCRIPTION
## Summary
- 最小化球（右上角的 minimize button）取消 `:hover` 灰底反馈 —— 球本身就是 affordance，不需要叠加方框背景
- 右上角关闭叉 `×` 由 32×32 / 1.3rem 缩到 **24×24 / 1rem**，颜色由 `#5f6c82` 淡化到 `#9aa3b4`，视觉权重明显低于左侧球，避免用户下意识误点关闭
- dark mode 同步更新

## 影响范围
- 只动 `static/css/index.css` 三处（`#reactChatWindowMinimizeButton:hover` 拆分 + close button override + dark mode hover 拆分）
- **不影响缩小态**：缩小态下 `#react-chat-window-header-actions` 整块 `display:none`，所改的 hover/尺寸都打不到

## Test plan
- [ ] 展开聊天框，鼠标移到右上角球图标 —— 不应再出现灰色圆角方框
- [ ] 鼠标移到关闭叉 —— 仍有 hover 灰底（保留点击反馈）
- [ ] 关闭叉视觉上明显小一圈、颜色更淡
- [ ] 点击最小化 → 50px 浮球 + 呼吸光照常，无变化
- [ ] dark mode 下同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 关闭按钮尺寸调整为 24×24，字体与行高同步以改善排版。
  * 关闭按钮基础色调略微变浅以提升可视性。
  * 深色主题下悬停效果仅作用于关闭按钮，交互反馈更明确。
  * 深色主题中将关闭与最小化按钮的基色拆分，关闭按钮使用更深的色值以区分功能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->