### PR TITLE
feat: 加 livestream 模式（free 子模式：URL 派生 + voice + 跳闭麦）

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -342,6 +342,12 @@
       "restricted": true
     }
   },
+  "_comment_livestream_config": "Livestream (主播) overlay on top of core_api_type='free': when enabled with non-empty server_prefix, free路 URLs (/core /text/v1 /tts) auto-derive from server_prefix, voice falls back to voice_id (bypasses free_voices preset gate), and OmniRealtimeClient skips 90s silence-timeout. Leave server_prefix/voice_id empty in committed configs—fill in locally.",
+  "livestream_config": {
+    "enabled": false,
+    "server_prefix": "",
+    "voice_id": ""
+  },
   "_comment_free_voices": "Shape: {voiceKey: voice_id}. Keys are i18n identifiers (e.g., playfulGirl, cuteGirl) that the frontend must localize for display. Do not treat keys as display names.",
   "free_voices": {
     "playfulGirl": "voice-tone-PGLiTXeJCS",

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -185,7 +185,11 @@ from config.prompts_avatar_interaction import (
 # )
 from utils.config_manager import get_config_manager, get_reserved
 from utils.logger_config import get_module_logger
-from utils.api_config_loader import get_free_voices
+from utils.api_config_loader import (
+    get_free_voices,
+    get_livestream_config,
+    is_livestream_active,
+)
 from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
 import threading
 from threading import Thread
@@ -2077,6 +2081,31 @@ class LLMSessionManager:
             legacy_keys=('voice_id',),
         )
 
+    def _is_livestream_active(self) -> bool:
+        """Livestream 是 core_api_type='free' 之上的子模式，二者必须同时成立。"""
+        return self.core_api_type == 'free' and is_livestream_active()
+
+    def _resolve_realtime_free_voice(self, realtime_config: dict):
+        """决定 OmniRealtimeClient free 路传给 server 的 voice。
+
+        优先级：
+        1. livestream 子模式启用且配置了 voice_id → 用 livestream voice_id
+           （绕过 free_voices preset gate，base_url 已被派生不含 lanlan.tech）
+        2. 否则保留原逻辑：仅在角色 voice 是 free preset、core_api_type='free'
+           且 base_url 仍指向 lanlan.tech 域时下发，避免把 preset id 透给非
+           lanlan 服务（lanlan.app 的屏蔽由 _should_block_free_preset_voice 兜底）
+        """
+        if self._is_livestream_active():
+            ls_voice = get_livestream_config().get('voice_id', '')
+            if ls_voice:
+                return ls_voice
+        base_url = realtime_config.get('base_url', '') or ''
+        if (self._is_free_preset_voice
+                and self.core_api_type == 'free'
+                and 'lanlan.tech' in base_url):
+            return self.voice_id
+        return None
+
     def _enqueue_voice_migration_notice(self, legacy_names: list) -> None:
         """将语音迁移通知推入缓冲池，委托模块级函数统一去重。"""
         enqueue_voice_migration_notice(legacy_names)
@@ -2512,8 +2541,7 @@ class LLMSessionManager:
                         base_url=realtime_config.get('base_url', ''),
                         api_key=realtime_config['api_key'],
                         model=realtime_config['model'],
-                        voice=self.voice_id if self._is_free_preset_voice and self.core_api_type == 'free'
-                            and 'lanlan.tech' in realtime_config.get('base_url', '') else None,
+                        voice=self._resolve_realtime_free_voice(realtime_config),
                         on_text_delta=self.handle_text_data,
                         on_audio_delta=self.handle_audio_data,
                         on_new_message=self.handle_new_message,
@@ -2527,6 +2555,7 @@ class LLMSessionManager:
                         api_type=self.core_api_type,
                         on_tool_call=self._on_tool_call,
                         tool_definitions=_initial_tool_defs,
+                        livestream_mode=self._is_livestream_active(),
                     )
                     # Apply user's noise reduction preference to the AudioProcessor
                     nr_enabled = (await aload_global_conversation_settings()).get('noiseReductionEnabled', True)
@@ -2926,8 +2955,7 @@ class LLMSessionManager:
                     base_url=realtime_config.get('base_url', ''),
                     api_key=realtime_config['api_key'],
                     model=realtime_config['model'],
-                    voice=self.voice_id if self._is_free_preset_voice and self.core_api_type == 'free'
-                        and 'lanlan.tech' in realtime_config.get('base_url', '') else None,
+                    voice=self._resolve_realtime_free_voice(realtime_config),
                     on_text_delta=self.handle_text_data,
                     on_audio_delta=self.handle_audio_data,
                     on_new_message=self.handle_new_message,
@@ -2941,6 +2969,7 @@ class LLMSessionManager:
                     api_type=self.core_api_type,
                     on_tool_call=self._on_tool_call,
                     tool_definitions=_pending_tool_defs,
+                    livestream_mode=self._is_livestream_active(),
                 )
                 # Apply user's noise reduction preference to the AudioProcessor
                 nr_enabled = (await aload_global_conversation_settings()).get('noiseReductionEnabled', True)

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -210,6 +210,7 @@ class OmniRealtimeClient:
         api_type: Optional[str] = None,
         on_tool_call: Optional[OnToolCallCallback] = None,
         tool_definitions: Optional[List[ToolDefinition]] = None,
+        livestream_mode: bool = False,
     ):
         self.base_url = base_url
         self.api_key = api_key
@@ -258,8 +259,12 @@ class OmniRealtimeClient:
         # 只在 GLM 和 free API 时启用90秒静默超时，Qwen 和 Step 放行
         self._last_speech_time = None
         self._api_type = api_type or ""
-        # 只在 GLM 和 free 时启用静默超时
-        self._enable_silence_timeout = self._api_type.lower() in ['glm', 'free']
+        self._livestream_mode = bool(livestream_mode)
+        # 只在 GLM 和 free 时启用静默超时；livestream 模式（主播长会话）整路跳过
+        self._enable_silence_timeout = (
+            self._api_type.lower() in ['glm', 'free']
+            and not self._livestream_mode
+        )
         self._silence_timeout_seconds = 90  # 90秒无语音输入则自动关闭
         self._silence_check_task = None
         self._silence_timeout_triggered = False
@@ -651,7 +656,8 @@ class OmniRealtimeClient:
         if self._enable_silence_timeout:
             self._silence_check_task = asyncio.create_task(self._check_silence_timeout())
         else:
-            logger.info(f"静默超时检测已禁用（API类型: {self._api_type}），不会自动关闭会话")
+            reason = "livestream模式" if self._livestream_mode else f"API类型: {self._api_type}"
+            logger.info(f"静默超时检测已禁用（{reason}），不会自动关闭会话")
 
         # Set up default session configuration
         if self.turn_detection_mode == TurnDetectionMode.MANUAL:

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -775,6 +775,13 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                 ls_voice = get_livestream_config().get('voice_id', '')
                 if ls_voice:
                     voice_id = ls_voice
+                else:
+                    # 半配置状态（启用了但没填 voice_id）：明确告警，避免误以为
+                    # 直播音色已生效却实际还在用 caller 传入或默认 preset
+                    logger.warning(
+                        "livestream_config.enabled=true 但 voice_id 为空，"
+                        f"继续使用 caller 传入或默认音色: {voice_id or 'qingchunshaonv'}"
+                    )
         except Exception as e:
             logger.warning(f"读取 livestream voice_id 失败，回退到 caller 传入值: {e}")
 

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -758,13 +758,26 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
     """
     StepFun实时TTS worker（用于默认音色）
     使用阶跃星辰的实时TTS API（step-tts-mini）
-    
+
     Args:
         request_queue: 多进程请求队列，接收(speech_id, text)元组
         response_queue: 多进程响应队列，发送音频数据（也用于发送就绪信号）
         audio_api_key: API密钥
         voice_id: 音色ID，默认使用"qingchunshaonv"
     """
+    # free + livestream 子模式：voice_id 优先取 api_providers.json 的
+    # livestream_config.voice_id（绕过 caller 的 free_voices preset 路径）。
+    # 多进程 worker 这里独立 import，与主进程对偶。
+    if free_mode:
+        try:
+            from utils.api_config_loader import is_livestream_active, get_livestream_config
+            if is_livestream_active():
+                ls_voice = get_livestream_config().get('voice_id', '')
+                if ls_voice:
+                    voice_id = ls_voice
+        except Exception as e:
+            logger.warning(f"读取 livestream voice_id 失败，回退到 caller 传入值: {e}")
+
     # 使用默认音色 "qingchunshaonv"
     if not voice_id:
         voice_id = "qingchunshaonv"

--- a/utils/api_config_loader.py
+++ b/utils/api_config_loader.py
@@ -339,6 +339,35 @@ def cosyvoice_model_supports_language_hints(model: str | None) -> bool:
     return not str(model or _COSYVOICE_CLONE_MODEL_DEFAULT).startswith("cosyvoice-v2")
 
 
+def get_livestream_config() -> Dict[str, Any]:
+    """读取 api_providers.json → livestream_config 节。
+
+    Livestream 模式是叠加在 core_api_type='free' 之上的子模式，启用后：
+    - free 路所有 lanlan.tech URL 重写为 server_prefix 派生地址（/core /text/v1 /tts）
+    - free 路 voice 强制使用 voice_id（绕过 free_voices preset gate）
+    - OmniRealtimeClient 跳过 90 秒静默闭麦判定
+
+    Returns:
+        Dict: {'enabled': bool, 'server_prefix': str, 'voice_id': str}
+        缺失字段以默认值（False / 空串）兜底。
+    """
+    raw = get_config().get('livestream_config') or {}
+    return {
+        'enabled': bool(raw.get('enabled', False)),
+        'server_prefix': str(raw.get('server_prefix', '') or '').strip(),
+        'voice_id': str(raw.get('voice_id', '') or '').strip(),
+    }
+
+
+def is_livestream_active() -> bool:
+    """livestream 实际生效需要同时具备 enabled=True 且 server_prefix 非空。
+
+    voice_id 不强制要求（缺省时 free 路保留原 voice 解析路径）。
+    """
+    cfg = get_livestream_config()
+    return cfg['enabled'] and bool(cfg['server_prefix'])
+
+
 # 导出主要函数
 __all__ = [
     'get_core_api_profiles',
@@ -352,4 +381,6 @@ __all__ = [
     'get_free_voices',
     'get_cosyvoice_clone_model',
     'cosyvoice_model_supports_language_hints',
+    'get_livestream_config',
+    'is_livestream_active',
 ]

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2522,20 +2522,29 @@ class ConfigManager:
             print(f"[GeoIP] Dual check indeterminate (IP={ip_result}, Steam={steam_result}), transient mainland default", file=sys.stderr)
         return False
 
+    # Livestream 派生只接管 free 路这三个已知端点，避免劫持其他 lanlan.tech 路径
+    # （例如未来新增 /docs /metrics 之类的非数据端点）
+    _LIVESTREAM_DERIVE_PATHS = frozenset({'/core', '/text/v1', '/tts'})
+
     def _adjust_free_api_url(self, url: str, is_free: bool) -> str:
         """Internal URL adjustment for free API users.
 
         优先级：livestream prefix 派生 > 海外 lanlan.tech→lanlan.app 切换 > 原样返回。
-        livestream 启用时直接接管 lanlan.tech 域名，跳过地区判定。
+        livestream 启用时仅接管 lanlan.tech 域下白名单内的 free 路端点
+        （/core /text/v1 /tts），其他 path 走原地区切换。
         """
         if not url or 'lanlan.tech' not in url:
             return url
 
         try:
             if is_livestream_active():
-                derived = self._derive_livestream_url(url, get_livestream_config()['server_prefix'])
-                if derived:
-                    return derived
+                orig_path = urlparse(url).path or ''
+                if orig_path in self._LIVESTREAM_DERIVE_PATHS:
+                    derived = self._derive_livestream_url(
+                        url, get_livestream_config()['server_prefix']
+                    )
+                    if derived:
+                        return derived
         except Exception as e:
             logger.warning(f"Livestream URL 派生失败，回退到原始路径: {e}")
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -28,6 +28,8 @@ from utils.api_config_loader import (
     get_core_api_profiles,
     get_assist_api_profiles,
     get_assist_api_key_fields,
+    get_livestream_config,
+    is_livestream_active,
 )
 from utils.custom_tts_adapter import check_custom_tts_voice_allowed
 from utils.file_utils import atomic_write_json
@@ -2521,17 +2523,62 @@ class ConfigManager:
         return False
 
     def _adjust_free_api_url(self, url: str, is_free: bool) -> str:
-        """Internal URL adjustment for free API users based on region."""
+        """Internal URL adjustment for free API users.
+
+        优先级：livestream prefix 派生 > 海外 lanlan.tech→lanlan.app 切换 > 原样返回。
+        livestream 启用时直接接管 lanlan.tech 域名，跳过地区判定。
+        """
         if not url or 'lanlan.tech' not in url:
             return url
-        
+
+        try:
+            if is_livestream_active():
+                derived = self._derive_livestream_url(url, get_livestream_config()['server_prefix'])
+                if derived:
+                    return derived
+        except Exception as e:
+            logger.warning(f"Livestream URL 派生失败，回退到原始路径: {e}")
+
         try:
             if self._check_non_mainland():
                 return url.replace('lanlan.tech', 'lanlan.app')
         except Exception:
             pass
-        
+
         return url
+
+    @staticmethod
+    def _derive_livestream_url(original_url: str, prefix: str) -> str:
+        """从 livestream server_prefix 派生 lanlan.tech URL 的等价地址。
+
+        - 保留原 URL 的 path（``/core`` / ``/tts`` / ``/text/v1``）拼到 prefix path 之后
+        - scheme 家族不变（原 ws/wss → 输出 ws/wss；原 http/https → 输出 http/https）
+        - 加密与否（``s`` 后缀）按 prefix 的 scheme 走（prefix 是 https/wss → 输出加密）
+
+        例：
+        - ``wss://www.lanlan.tech/core`` + ``http://host:port/tok`` → ``ws://host:port/tok/core``
+        - ``https://www.lanlan.tech/text/v1`` + ``http://host:port/tok`` → ``http://host:port/tok/text/v1``
+        - ``wss://www.lanlan.tech/tts`` + ``https://host/tok`` → ``wss://host/tok/tts``
+        """
+        if not original_url or not prefix:
+            return ''
+        try:
+            orig = urlparse(original_url)
+            pref = urlparse(prefix)
+        except Exception:
+            return ''
+        if not pref.scheme or not pref.netloc:
+            return ''
+
+        is_ws_family = orig.scheme in ('ws', 'wss')
+        is_secure = pref.scheme in ('https', 'wss')
+        if is_ws_family:
+            out_scheme = 'wss' if is_secure else 'ws'
+        else:
+            out_scheme = 'https' if is_secure else 'http'
+
+        base_path = pref.path.rstrip('/')
+        return f"{out_scheme}://{pref.netloc}{base_path}{orig.path}"
 
     def get_core_config(self):
         """动态读取核心配置"""


### PR DESCRIPTION
## Summary

抽出 livestream（主播）模式：作为 `core_api_type='free'` 的子模式叠加，配置一次 prefix + voice_id 就替代了"硬改 lanlan.tech URL + voice 写死 + 跳闭麦"这套手活。

## 启用方式（本地，不要 commit 实际值）

`config/api_providers.json` 的占位节默认空：
\`\`\`json
"livestream_config": { "enabled": false, "server_prefix": "", "voice_id": "" }
\`\`\`
本地填 `enabled=true` + `server_prefix` + `voice_id` 即可。默认关闭时所有逻辑短路，行为完全等价于改动前。

## URL 派生规则

`_adjust_free_api_url` 命中 `lanlan.tech` 域时优先走 livestream 派生（次于派生才是海外 `lanlan.app` 切换）。新增 staticmethod `_derive_livestream_url(orig, prefix)`：
- 保留原 path（`/core` / `/text/v1` / `/tts`）拼到 `prefix.path` 之后
- scheme 家族不变（原 ws/wss → 输出 ws/wss；原 http/https → 输出 http/https）
- 加密与否按 prefix scheme 走（prefix `https/wss` → 输出加密）

例：
| 原 URL | + prefix `http://host:port/tok` | 输出 |
| --- | --- | --- |
| `wss://www.lanlan.tech/core` | | `ws://host:port/tok/core` |
| `https://www.lanlan.tech/text/v1` | | `http://host:port/tok/text/v1` |
| `wss://www.lanlan.tech/tts` | | `ws://host:port/tok/tts` |

## Voice 覆盖

`core.py` 新增 `_resolve_realtime_free_voice(realtime_config)`：livestream 启用时直接返回配置的 `voice_id`，绕过 `_is_free_preset_voice` gate（livestream voice 通常不在 `free_voices` 字典里）；否则保留原"角色 voice 必须是 free preset + base_url 仍指向 lanlan.tech"逻辑。两处 OmniRealtimeClient 构造点（main + pending hot-swap）对偶替换。

`step_realtime_tts_worker` 在 free_mode 子进程内独立 import `api_config_loader.get_livestream_config()` 覆盖 voice_id，与主进程对偶。

## 跳闭麦

`OmniRealtimeClient.__init__` 增 `livestream_mode: bool = False` 形参；`_enable_silence_timeout` 叠加 `and not livestream_mode`，主播长会话场景整路跳过 90s 闭麦判定。日志里禁用理由也区分了 livestream / api_type。

## Test plan

- [x] `_derive_livestream_url` 三类输入（ws/https/wss）+ http/https prefix 都 OK
- [x] livestream 关闭时 `_adjust_free_api_url` 行为等价于改动前
- [x] `main_logic/{omni_realtime_client,core,tts_client}` import 健康，`OmniRealtimeClient.__init__` 接受 `livestream_mode` kwarg
- [ ] 本地填上真实 prefix + voice_id 跑一会主播长会话验证：闭麦不再触发，TTS/realtime/text 都走内网
- [ ] 关闭 livestream 跑一次普通 free 模式验证默认路径未受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增直播模式支持，提供可配置的直播服务器前缀和语音ID。
  * 实时语音处理支持在直播模式下优先使用配置的语音ID，并在缺失时安全回退。

* **改进**
  * 优化免费API会话管理以更好支持直播场景。
  * 直播感知的URL路由，可根据直播配置智能切换服务端点并调整超时行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->