### PR TITLE
feat(livestream): 主播 config 抽到独立文件 livestream_config.json

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -342,7 +342,7 @@
       "restricted": true
     }
   },
-  "_comment_livestream_config": "Livestream (主播) overlay on top of core_api_type='free': when enabled with non-empty server_prefix, free路 URLs (/core /text/v1 /tts) auto-derive from server_prefix, voice falls back to voice_id (bypasses free_voices preset gate), and OmniRealtimeClient skips 90s silence-timeout. Leave server_prefix/voice_id empty in committed configs—fill in locally.",
+  "_comment_livestream_config": "Livestream (主播) overlay on top of core_api_type='free': when enabled with non-empty server_prefix, free路 URLs (/core /text/v1 /tts) auto-derive from server_prefix, voice falls back to voice_id (bypasses free_voices preset gate), and OmniRealtimeClient skips 90s silence-timeout. Preferred path: drop a standalone config/livestream_config.json (untracked via .gitignore) for single-file distribution. The field below is a fallback only; keep server_prefix/voice_id empty in committed configs.",
   "livestream_config": {
     "enabled": false,
     "server_prefix": "",

--- a/utils/api_config_loader.py
+++ b/utils/api_config_loader.py
@@ -339,19 +339,47 @@ def cosyvoice_model_supports_language_hints(model: str | None) -> bool:
     return not str(model or _COSYVOICE_CLONE_MODEL_DEFAULT).startswith("cosyvoice-v2")
 
 
+def _get_livestream_config_path() -> Path:
+    """独立 livestream 配置文件路径。
+
+    优先于 api_providers.json 中的 livestream_config 字段，方便分发给
+    主播作为单文件补丁——把这个 json 丢进 config 目录即可生效，无需
+    动 tracked 的 api_providers.json。文件被 .gitignore 的 config/*.json
+    默认覆盖，不会进 git。
+    """
+    return _get_app_root() / "config" / "livestream_config.json"
+
+
 def get_livestream_config() -> Dict[str, Any]:
-    """读取 api_providers.json → livestream_config 节。
+    """读取 livestream 配置（独立文件优先，api_providers.json 字段 fallback）。
 
     Livestream 模式是叠加在 core_api_type='free' 之上的子模式，启用后：
     - free 路所有 lanlan.tech URL 重写为 server_prefix 派生地址（/core /text/v1 /tts）
     - free 路 voice 强制使用 voice_id（绕过 free_voices preset gate）
     - OmniRealtimeClient 跳过 90 秒静默闭麦判定
 
+    优先级：
+    1. ``config/livestream_config.json``（untracked，主播分发场景的单文件补丁）
+    2. ``config/api_providers.json`` 的 ``livestream_config`` 字段（兼容路径）
+
     Returns:
         Dict: {'enabled': bool, 'server_prefix': str, 'voice_id': str}
-        缺失字段以默认值（False / 空串）兜底。
+        缺失/读取失败/字段缺失时以默认值（False / 空串）兜底。
     """
-    raw = get_config().get('livestream_config') or {}
+    raw: Optional[Dict[str, Any]] = None
+    standalone_path = _get_livestream_config_path()
+    if standalone_path.is_file():
+        try:
+            with open(standalone_path, "r", encoding="utf-8") as f:
+                loaded = json.load(f)
+            if isinstance(loaded, dict):
+                raw = loaded
+        except Exception as e:
+            logger.warning(
+                f"读取 {standalone_path.name} 失败，回退到 api_providers.json: {e}"
+            )
+    if raw is None:
+        raw = get_config().get('livestream_config') or {}
     return {
         'enabled': bool(raw.get('enabled', False)),
         'server_prefix': str(raw.get('server_prefix', '') or '').strip(),


### PR DESCRIPTION
## Summary

\`get_livestream_config()\` 优先读 \`config/livestream_config.json\` 独立文件，缺失/损坏时 fallback 到 \`api_providers.json\` 的 \`livestream_config\` 字段。

主播分发场景：单文件补丁丢进 config 目录即生效，不用动 tracked 的 \`api_providers.json\`。文件被 \`.gitignore\` 的 \`config/*.json\` 默认覆盖，不会进 git。

## 优先级

1. \`config/livestream_config.json\`（untracked，主播单文件补丁）
2. \`config/api_providers.json\` 的 \`livestream_config\` 字段（兼容路径，保留占位 false）

文件结构同 #1096 落地的 schema：
\`\`\`json
{ "enabled": true, "server_prefix": "http://...", "voice_id": "xxx" }
\`\`\`

## Test plan

- [x] 独立文件存在 → 用独立文件值
- [x] 独立文件缺失 → fallback 到 api_providers.json
- [x] 独立文件 JSON 损坏 → 打 warning，fallback
- [x] 默认 disabled（独立文件不存在 + api_providers.json 是 placeholder false）→ livestream 整路短路，行为等价于无该 PR
- [ ] 本地放上真实 livestream_config.json 验证 free 路 URL 派生 + voice + 跳闭麦正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 现支持使用独立配置文件进行直播设置，提供更灵活的配置管理方式
  
* **文档**
  * 更新直播配置指南，明确配置文件的用途和回退机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->