### PR TITLE
fix(utils): robust_json_loads 容忍结构 token 间的幻觉字符

### DIFF
--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -49,6 +49,12 @@ def test_galgame_korean_char_pollution():
         ('[결{"x":1}]', [{"x": 1}]),
         ('[{"x":1},X{"y":2}]', [{"x": 1}, {"y": 2}]),
         ('[1,2,결[3,4]]', [1, 2, [3, 4]]),
+        # 数字、字符串、null/true/false 也是合法值起始 —— 不仅是 `{`/`[`。
+        ('[1,결2]', [1, 2]),
+        ('["a",결"b"]', ["a", "b"]),
+        ('[1,X-3]', [1, -3]),
+        ('[1,Xtrue]', [1, True]),
+        ('{"a":1,결"b":2}', {"a": 1, "b": 2}),
     ],
 )
 def test_stray_char_between_structural_tokens(raw, expected):
@@ -60,3 +66,20 @@ def test_legitimate_string_with_cjk_not_corrupted():
     """合法 JSON 内字符串里有 CJK 不应触发清洗（json.loads 直接成功）。"""
     raw = '{"text": "结果是 {x}, 不要乱搞"}'
     assert robust_json_loads(raw) == {"text": "结果是 {x}, 不要乱搞"}
+
+
+@pytest.mark.unit
+def test_string_content_preserved_through_fallback_path():
+    """关键回归：fallback 路径触发时（无引号 key），string 内的 `,abc{` 不应被误清洗。
+
+    旧版（无状态 regex）会把 `"x,abc{y"` 静默改成 `"x,{y"`，破坏数据。
+    """
+    raw = "{a: 'x,abc{y', b: 1}"
+    assert robust_json_loads(raw) == {"a": "x,abc{y", "b": 1}
+
+
+@pytest.mark.unit
+def test_string_with_escaped_quote_not_breaking_scanner():
+    """字符串内含转义引号时，扫描器应正确识别字符串边界。"""
+    raw = '{a: "say \\"x,bc{y\\" loud", b: 2}'
+    assert robust_json_loads(raw) == {"a": 'say "x,bc{y" loud', "b": 2}

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -47,18 +47,19 @@ def test_galgame_korean_char_pollution():
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
+        # CJK 污染 + 各种合法值起始
         ('[결{"x":1}]', [{"x": 1}]),
-        ('[{"x":1},X{"y":2}]', [{"x": 1}, {"y": 2}]),
         ('[1,2,결[3,4]]', [1, 2, [3, 4]]),
-        # 数字、字符串、null/true/false 也是合法值起始 —— 不仅是 `{`/`[`。
         ('[1,결2]', [1, 2]),
         ('["a",결"b"]', ["a", "b"]),
-        ('[1,X-3]', [1, -3]),
-        ('[1,Xtrue]', [1, True]),
         ('{"a":1,결"b":2}', {"a": 1, "b": 2}),
+        # 多字符 CJK 污染（≤3 字）
+        ('[1,결결2]', [1, 2]),
+        # emoji 也是非 ASCII，同样应剥离
+        ('[1,🚀2]', [1, 2]),
     ],
 )
-def test_stray_char_between_structural_tokens(raw, expected):
+def test_non_ascii_pollution_stripped(raw, expected):
     assert robust_json_loads(raw) == expected
 
 
@@ -87,12 +88,21 @@ def test_string_with_escaped_quote_not_breaking_scanner():
 
 
 @pytest.mark.unit
-def test_leading_decimal_not_silently_dropped():
-    """关键回归：`.` 不能被当成 1 字符污染删掉。
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '[1,.5]',   # `.5` 非合法 JSON number；旧实现会删 `.` → 5
+        '[1,+5]',   # `+5` 非合法 JSON number；旧实现会删 `+` → 5
+        '[1,e3]',   # `e3` 非合法；旧实现会删 `e` → 3
+        '[1,X{"y":2}]',  # ASCII 字母也不剥
+    ],
+)
+def test_ascii_chars_not_stripped_to_avoid_silent_numeric_corruption(raw):
+    """关键安全保证：ASCII 字符（包括 `+`、`.`、`e`、字母）一律不剥。
 
-    旧实现：`[1,.5]` 触发 fallback 后 scanner 把 `.` 当幻觉删，
-    `,5` 解析成 5 → 0.5 被静默改成 5，数值 silent corruption。
-    现在 `.` 算作疑似数字起始，scanner 不删，让 json.loads 自己抛错。
+    LLM 实测的污染基本都是非 ASCII（CJK / emoji）；ASCII 多半是某种半合法值的
+    一部分（malformed number、unquoted literal 等），剥掉会把数值/语义静默改坏。
+    宁可让 json.loads 自己抛错走 fallback，也不能 silent corruption。
     """
     with pytest.raises(json.JSONDecodeError):
-        robust_json_loads('[1,.5]')
+        robust_json_loads(raw)

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -106,3 +106,25 @@ def test_ascii_chars_not_stripped_to_avoid_silent_numeric_corruption(raw):
     """
     with pytest.raises(json.JSONDecodeError):
         robust_json_loads(raw)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '[1,−2]',  # U+2212 MINUS SIGN（数学减号）；category=Sm
+        '[1,＋5]',  # U+FF0B FULLWIDTH PLUS SIGN；category=Sm
+        '[1,－2]',  # U+FF0D FULLWIDTH HYPHEN-MINUS；category=Pd
+        '[1,０]',   # U+FF10 FULLWIDTH DIGIT ZERO；category=Nd
+        '[1,٠2]',  # U+0660 ARABIC-INDIC DIGIT ZERO；category=Nd
+    ],
+)
+def test_unicode_numeric_prefixes_not_stripped(raw):
+    """Unicode 数字符号（math symbol / dash / 全角数字 / Arabic-Indic digits）
+    不能被当 CJK 污染删掉，否则 `[1,−2]` → `[1,2]` 之类 silent numeric corruption。
+
+    只剥 Unicode category Lo (Other Letter，CJK/韩文/etc.) 和 So (Other Symbol，emoji)；
+    Sm / Pd / Nd 等数字相关类别一律放行。
+    """
+    with pytest.raises(json.JSONDecodeError):
+        robust_json_loads(raw)

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -96,6 +96,31 @@ def test_minimum_strip_when_already_parseable_after_earlier_transform():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 字符串内的 Python 字面量不应被替换
+        ("{'text': 'True'}", {"text": "True"}),
+        ("{'a': 'False', 'b': 'None'}", {"a": "False", "b": "None"}),
+        # 字符串内的 `{{`/`}}` 不应被改
+        ("{'tpl': 'hello {{name}}'}", {"tpl": "hello {{name}}"}),
+        # 字符串内的 `,]` `,}` pattern 不应被去尾逗号
+        ("{'pat': 'foo,]bar'}", {"pat": "foo,]bar"}),
+        # 字符串内含像 unquoted key 的 pattern 不应被加引号
+        ("{'sql': 'SELECT a: 1 FROM t'}", {"sql": "SELECT a: 1 FROM t"}),
+        # 上述全部综合 + 双引号字符串内含相同 pattern
+        ('{"text": "True", "tpl": "{{x}}"}', {"text": "True", "tpl": "{{x}}"}),
+    ],
+)
+def test_string_content_protected_from_text_transforms(raw, expected):
+    """关键回归：fallback pipeline 里所有纯文本 transform 都段感知。
+
+    旧版会在 step 2 先把字符串内的 `True` 替换成 `true`，最终静默篡改字符串值。
+    """
+    assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
 def test_strict_json_with_cjk_not_touched_at_all():
     """关键回归：raw 能直接 parse，原值无条件返回，scanner 完全不介入。
 

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -74,6 +74,27 @@ def test_pollution_run_over_2_chars_not_stripped():
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
+        # `❤️` = U+2764 (HEAVY BLACK HEART, So) + U+FE0F (VARIATION SELECTOR-16, Mn)
+        ('[1,❤️2]', [1, 2]),
+        # `🧑‍💻` = U+1F9D1 + U+200D (ZWJ, Cf) + U+1F4BB —— 3 codepoint 1 cluster
+        ('[1,\U0001F9D1‍\U0001F4BB2]', [1, 2]),
+        # 上限 2 cluster：两个 ❤️ 连一起也行
+        ('[1,❤️❤️2]', [1, 2]),
+    ],
+)
+def test_multi_codepoint_emoji_clusters_treated_as_single(raw, expected):
+    """`❤️` / `🧑‍💻` 等 multi-codepoint emoji 算 1 个 grapheme cluster。
+
+    base (Lo/So) 后的 combining marks (Mn/Me/Mc) 和 ZWJ (Cf) 一并视为 cluster
+    的扩展，scanner 上限保持 2 cluster。
+    """
+    assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
         # LLM pretty-printed 输出常见：污染字符后接空格 / 换行
         ('[1,결 {"x":1}]', [1, {"x": 1}]),
         ('{"a":1,결\n  "b":2}', {"a": 1, "b": 2}),

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 
@@ -83,3 +84,15 @@ def test_string_with_escaped_quote_not_breaking_scanner():
     """字符串内含转义引号时，扫描器应正确识别字符串边界。"""
     raw = '{a: "say \\"x,bc{y\\" loud", b: 2}'
     assert robust_json_loads(raw) == {"a": 'say "x,bc{y" loud', "b": 2}
+
+
+@pytest.mark.unit
+def test_leading_decimal_not_silently_dropped():
+    """关键回归：`.` 不能被当成 1 字符污染删掉。
+
+    旧实现：`[1,.5]` 触发 fallback 后 scanner 把 `.` 当幻觉删，
+    `,5` 解析成 5 → 0.5 被静默改成 5，数值 silent corruption。
+    现在 `.` 算作疑似数字起始，scanner 不删，让 json.loads 自己抛错。
+    """
+    with pytest.raises(json.JSONDecodeError):
+        robust_json_loads('[1,.5]')

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -53,7 +53,7 @@ def test_galgame_korean_char_pollution():
         ('[1,결2]', [1, 2]),
         ('["a",결"b"]', ["a", "b"]),
         ('{"a":1,결"b":2}', {"a": 1, "b": 2}),
-        # 多字符 CJK 污染（≤3 字）
+        # 上限 2 字符
         ('[1,결결2]', [1, 2]),
         # emoji 也是非 ASCII，同样应剥离
         ('[1,🚀2]', [1, 2]),
@@ -61,6 +61,36 @@ def test_galgame_korean_char_pollution():
 )
 def test_non_ascii_pollution_stripped(raw, expected):
     assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
+def test_pollution_run_over_2_chars_not_stripped():
+    """超过 2 个连续污染字符不剥 —— scanner 上限是 1–2，避免破坏太多结构。"""
+    with pytest.raises(json.JSONDecodeError):
+        robust_json_loads('[1,결결결2]')
+
+
+@pytest.mark.unit
+def test_minimum_strip_when_already_parseable_after_earlier_transform():
+    """关键回归（"原本能 parse 就用原本"）：
+    fallback pipeline 每步 transform 后应立刻 try parse，能 parse 立即停。
+    `{a: 1}`（无引号 key）经 unquoted-key 修补后已是合法 JSON，scanner 不应再动手。
+    """
+    raw = "{a: 1}"
+    assert robust_json_loads(raw) == {"a": 1}
+
+
+@pytest.mark.unit
+def test_strict_json_with_cjk_not_touched_at_all():
+    """关键回归：raw 能直接 parse，原值无条件返回，scanner 完全不介入。
+
+    （即使 CJK 出现在数组分隔符位置 —— 因为是合法 string 内容。）
+    """
+    raw = '["你好",결]'  # 这条本身非法，作为反例：scanner 会动
+    with pytest.raises(json.JSONDecodeError):
+        robust_json_loads(raw)
+    # 而合法的就直接通过：
+    assert robust_json_loads('["你好","결"]') == ["你好", "결"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+import pytest
+
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from utils.file_utils import robust_json_loads
+
+
+@pytest.mark.unit
+def test_strict_json_passthrough():
+    assert robust_json_loads('{"a": 1, "b": [2, 3]}') == {"a": 1, "b": [2, 3]}
+
+
+@pytest.mark.unit
+def test_python_literals_and_unquoted_keys():
+    assert robust_json_loads("{a: True, b: None, c: False}") == {
+        "a": True,
+        "b": None,
+        "c": False,
+    }
+
+
+@pytest.mark.unit
+def test_trailing_comma():
+    assert robust_json_loads('[1, 2, 3,]') == [1, 2, 3]
+
+
+@pytest.mark.unit
+def test_galgame_korean_char_pollution():
+    """实测案例：GalGame LLM 在数组分隔符位置吐出韩文字符 `결`。"""
+    raw = (
+        '{"options":[{"label":"A","text":"你想要什么口味的奶昔？"},'
+        '결{"label":"B","text":"当然买，只要你开心。"},'
+        '결{"label":"C","text":"奶昔会变成魔法药水吗？"}]}'
+    )
+    parsed = robust_json_loads(raw)
+    assert parsed["options"][0]["label"] == "A"
+    assert parsed["options"][1]["label"] == "B"
+    assert parsed["options"][2]["label"] == "C"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('[결{"x":1}]', [{"x": 1}]),
+        ('[{"x":1},X{"y":2}]', [{"x": 1}, {"y": 2}]),
+        ('[1,2,결[3,4]]', [1, 2, [3, 4]]),
+    ],
+)
+def test_stray_char_between_structural_tokens(raw, expected):
+    assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
+def test_legitimate_string_with_cjk_not_corrupted():
+    """合法 JSON 内字符串里有 CJK 不应触发清洗（json.loads 直接成功）。"""
+    raw = '{"text": "结果是 {x}, 不要乱搞"}'
+    assert robust_json_loads(raw) == {"text": "结果是 {x}, 不要乱搞"}

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -71,6 +71,21 @@ def test_pollution_run_over_2_chars_not_stripped():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # LLM pretty-printed 输出常见：污染字符后接空格 / 换行
+        ('[1,결 {"x":1}]', [1, {"x": 1}]),
+        ('{"a":1,결\n  "b":2}', {"a": 1, "b": 2}),
+        ('[1,결결 [2,3]]', [1, [2, 3]]),
+    ],
+)
+def test_whitespace_after_pollution_still_strippable(raw, expected):
+    """污染段后接空白 + 合法值起始也算可恢复（pretty-printed 输出场景）。"""
+    assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
 def test_minimum_strip_when_already_parseable_after_earlier_transform():
     """关键回归（"原本能 parse 就用原本"）：
     fallback pipeline 每步 transform 后应立刻 try parse，能 parse 立即停。

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -80,13 +80,37 @@ def test_pollution_run_over_2_chars_not_stripped():
         ('[1,\U0001F9D1‍\U0001F4BB2]', [1, 2]),
         # 上限 2 cluster：两个 ❤️ 连一起也行
         ('[1,❤️❤️2]', [1, 2]),
+        # 上限 2 cluster：两个 ZWJ 复合 emoji（每个 1 cluster）
+        ('[1,\U0001F9D1‍\U0001F4BB\U0001F9D1‍\U0001F4BB2]', [1, 2]),
     ],
 )
 def test_multi_codepoint_emoji_clusters_treated_as_single(raw, expected):
     """`❤️` / `🧑‍💻` 等 multi-codepoint emoji 算 1 个 grapheme cluster。
 
     base (Lo/So) 后的 combining marks (Mn/Me/Mc) 和 ZWJ (Cf) 一并视为 cluster
-    的扩展，scanner 上限保持 2 cluster。
+    的扩展；ZWJ 后跟新的 pollution base 也并入同一 cluster。scanner 上限保持
+    2 cluster。
+    """
+    assert robust_json_loads(raw) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 关键回归：含 Python 字面量子串的标识符不应被改
+        ('{TrueValue: 1}', {"TrueValue": 1}),
+        ('{NoneType: "x"}', {"NoneType": "x"}),
+        ('{IsFalse: 0}', {"IsFalse": 0}),
+        # 但单独的 Python 字面量仍然要转
+        ('{"flag": True, "n": None, "off": False}', {"flag": True, "n": None, "off": False}),
+        ('[True, None, False]', [True, None, False]),
+    ],
+)
+def test_python_literal_replacement_uses_word_boundary(raw, expected):
+    """关键回归：`{TrueValue: 1}` 旧版会被改成 `{trueValue: 1}` 然后 unquoted-key
+    包成 `{"trueValue": 1}` 静默返回 —— key 名被篡改成完全不同字符串。
+    新实现用 word-boundary regex，仅替换独立的 True/False/None。
     """
     assert robust_json_loads(raw) == expected
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -15,19 +15,20 @@ _UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
 
 # 合法 JSON 值起始字符：`"` (string) / `{` (object) / `[` (array) /
 # `-` 或数字 (number) / `t` `f` `n` (true/false/null)。
-# `.` 严格 JSON 中不是合法 number 起始 (.5 非法)，但 LLM 偶尔会写出来；
-# 算作"疑似数字起始"放进集合，scanner 不主动删它 —— 让 json.loads 自己抛错，
-# 避免把 `[1,.5]` 静默清成 `[1,5]` 这种数值 silent corruption。
-_VALUE_START_CHARS = frozenset('"{[-.tfn0123456789')
+_VALUE_START_CHARS = frozenset('"{[-tfn0123456789')
 
 
 def _strip_stray_chars_between_tokens(s: str) -> str:
-    """Strip 1–3 hallucinated chars between `,`/`[` and the next value start.
+    """Strip 1–3 hallucinated **non-ASCII** chars between `,`/`[` and the next value.
 
     Stateful scanner — only acts outside of quoted strings (with backslash escape
-    handling) so legitimate string contents containing ``,abc{`` patterns are
-    untouched. Lookahead accepts any valid JSON value-start char (not just
-    ``{`` / ``[``), so cases like ``[1,결2]`` or ``["a",결"b"]`` also recover.
+    handling). 仅剥**非 ASCII** 污染（CJK / emoji / etc.）—— LLM 实测幻觉
+    几乎都是这种；ASCII 字符一律放行，避免把可能是某种半合法值前缀的内容
+    （`+5`、`.5`、`e3` 等）静默改成完全不同的数值。即便剥不掉，
+    后续 json.loads 自己抛 JSONDecodeError 走 fallback，比 silent corruption 安全。
+
+    覆盖完整合法值起始集合 (``"``/``{``/``[``/``-``/数字/``t/f/n``)，
+    所以 ``[1,결2]`` / ``["a",결"b"]`` / ``{"a":1,결"b":2}`` 都能恢复。
     """
     out: list[str] = []
     i = 0
@@ -55,18 +56,17 @@ def _strip_stray_chars_between_tokens(s: str) -> str:
         i += 1
         if c not in ',[':
             continue
-        # 跳过 separator 后的空白，再看接下来是不是合法值起始
+        # 跳过 separator 后的空白，找疑似污染段（连续 1–3 个非 ASCII 字符）
         j = i
         while j < n and s[j].isspace():
             j += 1
-        if j >= n or s[j] in _VALUE_START_CHARS:
-            continue
-        # 1–3 字符内若能落到合法值起始，视作幻觉污染，删掉中间这段
-        for k in range(1, 4):
-            if j + k < n and s[j + k] in _VALUE_START_CHARS:
-                out.append(s[i:j])  # 保留空白
-                i = j + k
-                break
+        end = j
+        while end < j + 3 and end < n and ord(s[end]) > 127:
+            end += 1
+        # 必须真的吃到了非 ASCII 字符，且后面紧跟合法值起始才算污染
+        if end > j and end < n and s[end] in _VALUE_START_CHARS:
+            out.append(s[i:j])  # 保留空白
+            i = end
     return ''.join(out)
 
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -35,13 +35,16 @@ def _is_likely_pollution_char(c: str) -> bool:
 
 
 def _strip_stray_chars_between_tokens(s: str) -> str:
-    """Strip 1–3 hallucinated chars between `,`/`[` and the next value start.
+    """Strip 1–2 hallucinated chars between `,`/`[` and the next value start.
 
     Stateful scanner — only acts outside of quoted strings (with backslash escape
     handling). 仅剥**非 ASCII Letter / emoji**（LLM 实测幻觉污染源）；ASCII 字符
     与 Unicode 数字符号 / 标点 / dash / 全角数字一律放行，避免把
     `+5`、`.5`、`e3`、`−2`（U+2212）、`＋5`（U+FF0B）等半合法值前缀静默改坏。
     剥不掉就让 json.loads 自己抛 JSONDecodeError 走 fallback。
+
+    Best-effort 最少破坏：从 k=1 起递增到 2，第一个能让 lookahead 命中
+    合法值起始的 k 立刻停 —— 不贪。
     """
     out: list[str] = []
     i = 0
@@ -69,53 +72,76 @@ def _strip_stray_chars_between_tokens(s: str) -> str:
         i += 1
         if c not in ',[':
             continue
-        # 跳过 separator 后的空白，找疑似污染段（连续 1–3 个 Letter/emoji 类字符）
+        # 跳过 separator 后的空白，从最少 (k=1) 开始尝试，越少越好
         j = i
         while j < n and s[j].isspace():
             j += 1
-        end = j
-        while end < j + 3 and end < n and _is_likely_pollution_char(s[end]):
-            end += 1
-        # 必须真的吃到了污染字符，且后面紧跟合法值起始才剥
-        if end > j and end < n and s[end] in _VALUE_START_CHARS:
-            out.append(s[i:j])  # 保留空白
-            i = end
+        for k in (1, 2):
+            if j + k > n:
+                break
+            # 第 k 个字符必须是 pollution；否则再大的 k 也只会更糟
+            if not _is_likely_pollution_char(s[j + k - 1]):
+                break
+            if j + k < n and s[j + k] in _VALUE_START_CHARS:
+                out.append(s[i:j])  # 保留空白
+                i = j + k
+                break
     return ''.join(out)
+
+
+def _try_json_loads(s: str) -> tuple[Any, bool]:
+    try:
+        return json.loads(s), True
+    except json.JSONDecodeError:
+        return None, False
 
 
 def robust_json_loads(raw: str) -> Any:
     """json.loads with fallback for common LLM JSON quirks.
 
+    原始输入若能直接 parse，无条件返回原结果（绝不预先 transform）。否则按
+    fallback pipeline 逐步修补 —— 每步 transform 后立即 try parse，能 parse
+    即停，避免后续步骤（尤其是 scanner）在不必要时动文本。
+
     Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
     single-quoted strings (including mixed-quote scenarios), and stray hallucinated
-    characters between structural tokens (e.g. ``,결{`` → ``,{``).
+    chars between structural tokens (e.g. ``,결{`` → ``,{``).
     """
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        pass
-    s = raw
-    # {{ }} → { }  (LLM 模仿 prompt 模板转义)
-    s = s.replace("{{", "{").replace("}}", "}")
-    # Python 字面值 → JSON
-    s = s.replace("True", "true").replace("False", "false").replace("None", "null")
-    # 尾逗号
-    s = re.sub(r',\s*([}\]])', r'\1', s)
-    # 无引号 key:  {key: "v"} → {"key": "v"}
-    s = _UNQUOTED_KEY_RE.sub(r' "\1":', s)
-    # 单引号 → 双引号
-    if '"' not in s:
-        s = s.replace("'", '"')
-    else:
+    parsed, ok = _try_json_loads(raw)
+    if ok:
+        return parsed
+
+    def _normalize_quotes(s: str) -> str:
+        if '"' not in s:
+            return s.replace("'", '"')
         # 混合引号：逐步替换单引号 key/value
         s = re.sub(r"'([^']*?)'\s*:", r'"\1":', s)           # key
         s = re.sub(r":\s*'([^']*?)'", r': "\1"', s)         # value
         s = re.sub(r"'\s*([,\]\}])", r'"\1', s)              # 数组尾
         s = re.sub(r"([,\[\{])\s*'", r'\1"', s)              # 数组头
-    # LLM 偶尔在结构 token 之间塞 1–3 个幻觉字符（实例：`,결{` 应是 `,{`）。
-    # 用有状态扫描器避免误伤合法 string 内容里出现的同形 pattern。
-    s = _strip_stray_chars_between_tokens(s)
-    return json.loads(s)
+        return s
+
+    transforms = (
+        # {{ }} → { }  (LLM 模仿 prompt 模板转义)
+        lambda s: s.replace("{{", "{").replace("}}", "}"),
+        # Python 字面值 → JSON
+        lambda s: s.replace("True", "true").replace("False", "false").replace("None", "null"),
+        # 尾逗号
+        lambda s: re.sub(r',\s*([}\]])', r'\1', s),
+        # 无引号 key:  {key: "v"} → {"key": "v"}
+        lambda s: _UNQUOTED_KEY_RE.sub(r' "\1":', s),
+        # 单引号 → 双引号
+        _normalize_quotes,
+        # 最后才动：清掉 `,결{` 类结构 token 间幻觉污染
+        _strip_stray_chars_between_tokens,
+    )
+    s = raw
+    for transform in transforms:
+        s = transform(s)
+        parsed, ok = _try_json_loads(s)
+        if ok:
+            return parsed
+    return json.loads(s)  # 让最终错误带完整上下文抛出
 
 
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -13,6 +13,10 @@ from typing import Any, Callable
 # LLM 经常返回带有格式瑕疵的 JSON（无引号 key、尾逗号、Python 字面值等）。
 # 先尝试标准解析，失败后逐步修补再试。
 _UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
+# Python 字面量 → JSON。用 word boundary 避免误改 `TrueValue` / `NoneType` 等
+# 含字面量子串的标识符（裸 `.replace` 会把 key 名静默篡改成完全不同的字符串）。
+_PY_LITERAL_RE = re.compile(r'(?<!\w)(True|False|None)(?!\w)')
+_PY_LITERAL_MAP = {'True': 'true', 'False': 'false', 'None': 'null'}
 
 # 合法 JSON 值起始字符：`"` (string) / `{` (object) / `[` (array) /
 # `-` 或数字 (number) / `t` `f` `n` (true/false/null)。
@@ -39,18 +43,35 @@ def _is_likely_pollution_char(c: str) -> bool:
     return unicodedata.category(c) in _POLLUTION_UNICODE_CATEGORIES
 
 
+_ZWJ = '‍'
+
+
 def _consume_pollution_grapheme(s: str, i: int) -> int:
     """尝试消费一个污染 grapheme cluster，返回结束位置。
 
-    如果 ``s[i]`` 是 pollution base char (Lo/So)，连同后续 combining marks
-    与 ZWJ 等扩展字符一起视作一个 cluster。不是 pollution 则返回 i 不变。
+    如果 ``s[i]`` 是 pollution base char (Lo/So)，连同后续 combining marks 与
+    ZWJ 等扩展字符一起视作一个 cluster。ZWJ 后若紧跟另一个 pollution base，则
+    继续并入同一 cluster（emoji 复合体如 ``🧑‍💻`` = PERSON + ZWJ + COMPUTER）。
+    不是 pollution 则返回 i 不变。
     """
     n = len(s)
     if i >= n or not _is_likely_pollution_char(s[i]):
         return i
     end = i + 1
-    while end < n and unicodedata.category(s[end]) in _GRAPHEME_EXTEND_CATEGORIES:
-        end += 1
+    while True:
+        # 吃掉 combining marks / ZWJ / format chars
+        while end < n and unicodedata.category(s[end]) in _GRAPHEME_EXTEND_CATEGORIES:
+            end += 1
+        # ZWJ 后若紧跟新的 pollution base，并入同一 cluster 继续
+        if (
+            end < n
+            and end >= 2
+            and s[end - 1] == _ZWJ
+            and _is_likely_pollution_char(s[end])
+        ):
+            end += 1
+            continue
+        break
     return end
 
 
@@ -234,12 +255,11 @@ def robust_json_loads(raw: str) -> Any:
         lambda s: _apply_outside_strings(
             s, lambda t: t.replace("{{", "{").replace("}}", "}"),
         ),
-        # Python 字面值 → JSON；段感知（避免改字符串内的 "True" 等）
+        # Python 字面值 → JSON；段感知（避免改字符串内的 "True" 等）+
+        # word-boundary regex（避免改 `TrueValue` / `NoneType` 这类标识符）
         lambda s: _apply_outside_strings(
             s,
-            lambda t: t.replace("True", "true")
-                       .replace("False", "false")
-                       .replace("None", "null"),
+            lambda t: _PY_LITERAL_RE.sub(lambda m: _PY_LITERAL_MAP[m.group(1)], t),
         ),
         # 尾逗号；段感知
         lambda s: _apply_outside_strings(s, lambda t: re.sub(r',\s*([}\]])', r'\1', t)),

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -18,7 +18,8 @@ def robust_json_loads(raw: str) -> Any:
     """json.loads with fallback for common LLM JSON quirks.
 
     Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
-    single-quoted strings (including mixed-quote scenarios).
+    single-quoted strings (including mixed-quote scenarios), and stray hallucinated
+    characters between structural tokens (e.g. ``,결{`` → ``,{``).
     """
     try:
         return json.loads(raw)
@@ -42,6 +43,10 @@ def robust_json_loads(raw: str) -> Any:
         s = re.sub(r":\s*'([^']*?)'", r': "\1"', s)         # value
         s = re.sub(r"'\s*([,\]\}])", r'"\1', s)              # 数组尾
         s = re.sub(r"([,\[\{])\s*'", r'\1"', s)              # 数组头
+    # LLM 偶尔在结构 token 之间塞 1–3 个幻觉字符（实例：`,결{` 应是 `,{`）。
+    # 严格 JSON 中 `,` / `[` 之后只允许空白和合法值起始字符 (`"`, `{`, `[`, `-`, 数字, `t/f/n`)，
+    # 其他必为污染；限定 1–3 字以降低误伤合法字符串内容的概率。
+    s = re.sub(r'([,\[]\s*)[^\s",\[\]\{\}\d\-tfn]{1,3}(\s*[\{\[])', r'\1\2', s)
     return json.loads(s)
 
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -7,7 +7,7 @@ import re
 import tempfile
 import unicodedata
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 # ── LLM JSON tolerance ─────────────────────────��────────────────────────
 # LLM 经常返回带有格式瑕疵的 JSON（无引号 key、尾逗号、Python 字面值等）。
@@ -101,12 +101,103 @@ def _try_json_loads(s: str) -> tuple[Any, bool]:
         return None, False
 
 
+def _apply_outside_strings(s: str, transform: Callable[[str], str]) -> str:
+    """Run ``transform`` only on text outside of quoted strings.
+
+    Both ``'...'`` and ``"..."`` are recognized as string boundaries (LLM 常输出
+    Python-repr 风格混合引号). Backslash inside strings escapes the next char.
+    Inside-string content is preserved bytewise — protects e.g. the literal value
+    ``"True"`` from the Python-literal substitution step.
+    """
+    out: list[str] = []
+    buf: list[str] = []  # outside-string segment buffer
+    quote: str | None = None
+    escape = False
+
+    def _flush_outside() -> None:
+        if buf:
+            out.append(transform(''.join(buf)))
+            buf.clear()
+
+    for c in s:
+        if escape:
+            out.append(c)
+            escape = False
+            continue
+        if quote is not None:
+            out.append(c)
+            if c == '\\':
+                escape = True
+            elif c == quote:
+                quote = None
+        else:
+            if c in ('"', "'"):
+                _flush_outside()
+                out.append(c)
+                quote = c
+            else:
+                buf.append(c)
+    _flush_outside()
+    return ''.join(out)
+
+
+def _normalize_quotes(s: str) -> str:
+    """Convert single-quoted strings to double-quoted; preserve inside content.
+
+    段感知：扫一次按 ``'`` / ``"`` 边界切片，仅把 ``'...'`` 段改成 ``"..."``，
+    并对内部出现的 ``\\'`` 解转义、对裸 ``"`` 加转义。已经是双引号字符串的段
+    一字不动。
+    """
+    out: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    escape = False
+    for c in s:
+        if escape:
+            current.append(c)
+            escape = False
+            continue
+        if quote is not None:
+            if c == '\\':
+                current.append(c)
+                escape = True
+            elif c == quote:
+                # 字符串结束
+                if quote == "'":
+                    inner = ''.join(current)
+                    # 解 \' → '，保留 \\ 不动；为目标双引号字符串再转义裸 "
+                    inner = re.sub(r"\\'", "'", inner)
+                    inner = re.sub(r'(?<!\\)"', r'\\"', inner)
+                    out.append('"' + inner + '"')
+                else:
+                    out.append('"' + ''.join(current) + '"')
+                current = []
+                quote = None
+            else:
+                current.append(c)
+        else:
+            if c in ('"', "'"):
+                quote = c
+                current = []
+            else:
+                out.append(c)
+    if quote is not None:
+        # 未闭合 —— 原样吐出（让 json.loads 自己抛错）
+        out.append(quote)
+        out.append(''.join(current))
+    return ''.join(out)
+
+
 def robust_json_loads(raw: str) -> Any:
     """json.loads with fallback for common LLM JSON quirks.
 
     原始输入若能直接 parse，无条件返回原结果（绝不预先 transform）。否则按
     fallback pipeline 逐步修补 —— 每步 transform 后立即 try parse，能 parse
     即停，避免后续步骤（尤其是 scanner）在不必要时动文本。
+
+    所有"纯文本替换" transform（Python 字面量、`{{}}`、尾逗号、无引号 key）
+    都通过 ``_apply_outside_strings`` 包装，仅在字符串外生效，避免把字符串值
+    （如 ``"True"`` / ``"x,]"``）静默改坏。
 
     Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
     single-quoted strings (including mixed-quote scenarios), and stray hallucinated
@@ -116,28 +207,25 @@ def robust_json_loads(raw: str) -> Any:
     if ok:
         return parsed
 
-    def _normalize_quotes(s: str) -> str:
-        if '"' not in s:
-            return s.replace("'", '"')
-        # 混合引号：逐步替换单引号 key/value
-        s = re.sub(r"'([^']*?)'\s*:", r'"\1":', s)           # key
-        s = re.sub(r":\s*'([^']*?)'", r': "\1"', s)         # value
-        s = re.sub(r"'\s*([,\]\}])", r'"\1', s)              # 数组尾
-        s = re.sub(r"([,\[\{])\s*'", r'\1"', s)              # 数组头
-        return s
-
     transforms = (
-        # {{ }} → { }  (LLM 模仿 prompt 模板转义)
-        lambda s: s.replace("{{", "{").replace("}}", "}"),
-        # Python 字面值 → JSON
-        lambda s: s.replace("True", "true").replace("False", "false").replace("None", "null"),
-        # 尾逗号
-        lambda s: re.sub(r',\s*([}\]])', r'\1', s),
-        # 无引号 key:  {key: "v"} → {"key": "v"}
-        lambda s: _UNQUOTED_KEY_RE.sub(r' "\1":', s),
-        # 单引号 → 双引号
+        # {{ }} → { }  (LLM 模仿 prompt 模板转义)；段感知
+        lambda s: _apply_outside_strings(
+            s, lambda t: t.replace("{{", "{").replace("}}", "}"),
+        ),
+        # Python 字面值 → JSON；段感知（避免改字符串内的 "True" 等）
+        lambda s: _apply_outside_strings(
+            s,
+            lambda t: t.replace("True", "true")
+                       .replace("False", "false")
+                       .replace("None", "null"),
+        ),
+        # 尾逗号；段感知
+        lambda s: _apply_outside_strings(s, lambda t: re.sub(r',\s*([}\]])', r'\1', t)),
+        # 无引号 key:  {key: "v"} → {"key": "v"}；段感知
+        lambda s: _apply_outside_strings(s, lambda t: _UNQUOTED_KEY_RE.sub(r' "\1":', t)),
+        # 单引号 → 双引号；自身已段感知
         _normalize_quotes,
-        # 最后才动：清掉 `,결{` 类结构 token 间幻觉污染
+        # 最后才动：清掉 `,결{` 类结构 token 间幻觉污染；自身已双引号感知
         _strip_stray_chars_between_tokens,
     )
     s = raw

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -18,13 +18,18 @@ _UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
 # `-` 或数字 (number) / `t` `f` `n` (true/false/null)。
 _VALUE_START_CHARS = frozenset('"{[-tfn0123456789')
 
-# Unicode 类别白名单 —— 只剥这两类视作幻觉污染：
+# Unicode 类别白名单 —— 只剥这两类视作幻觉污染 base 字符：
 #   Lo: Other Letter，含 CJK / 韩文 / 日文 / 阿拉伯文 等（实测污染源，如 `결`）
 #   So: Other Symbol，主要是 emoji
 # 故意排除 Sm (Math Symbol，含 `−` U+2212 / `＋` U+FF0B 等)、Pd (Dash)、
 # Nd (含全角数字 `０`-`９`、阿拉伯数字 `٠` 等) 等可能是 Unicode 数字前缀的类别 ——
 # 删掉它们会把 `[1,−2]` → `[1,2]` 这种 silent numeric corruption。
 _POLLUTION_UNICODE_CATEGORIES = frozenset({'Lo', 'So'})
+
+# Combining marks / format chars，附属于前一个 base 字符（grapheme cluster 的一部分）。
+# 例：`❤️` = U+2764 (So) + U+FE0F (Mn variation selector)；
+#     `🧑‍💻` = U+1F9D1 (So) + U+200D (Cf ZWJ) + U+1F4BB (So)。
+_GRAPHEME_EXTEND_CATEGORIES = frozenset({'Mn', 'Me', 'Mc', 'Cf'})
 
 
 def _is_likely_pollution_char(c: str) -> bool:
@@ -34,8 +39,23 @@ def _is_likely_pollution_char(c: str) -> bool:
     return unicodedata.category(c) in _POLLUTION_UNICODE_CATEGORIES
 
 
+def _consume_pollution_grapheme(s: str, i: int) -> int:
+    """尝试消费一个污染 grapheme cluster，返回结束位置。
+
+    如果 ``s[i]`` 是 pollution base char (Lo/So)，连同后续 combining marks
+    与 ZWJ 等扩展字符一起视作一个 cluster。不是 pollution 则返回 i 不变。
+    """
+    n = len(s)
+    if i >= n or not _is_likely_pollution_char(s[i]):
+        return i
+    end = i + 1
+    while end < n and unicodedata.category(s[end]) in _GRAPHEME_EXTEND_CATEGORIES:
+        end += 1
+    return end
+
+
 def _strip_stray_chars_between_tokens(s: str) -> str:
-    """Strip 1–2 hallucinated chars between `,`/`[` and the next value start.
+    """Strip 1–2 hallucinated grapheme clusters between `,`/`[` and the next value.
 
     Stateful scanner — only acts outside of quoted strings (with backslash escape
     handling). 仅剥**非 ASCII Letter / emoji**（LLM 实测幻觉污染源）；ASCII 字符
@@ -43,8 +63,10 @@ def _strip_stray_chars_between_tokens(s: str) -> str:
     `+5`、`.5`、`e3`、`−2`（U+2212）、`＋5`（U+FF0B）等半合法值前缀静默改坏。
     剥不掉就让 json.loads 自己抛 JSONDecodeError 走 fallback。
 
-    Best-effort 最少破坏：从 k=1 起递增到 2，第一个能让 lookahead 命中
-    合法值起始的 k 立刻停 —— 不贪。
+    Best-effort 最少破坏：上限 2 个 grapheme cluster，从 k=1 起递增，第一个能让
+    lookahead 命中合法值起始的 k 立刻停 —— 不贪。一个 cluster = 1 个 pollution
+    base char + 0 或多个后续 combining marks/ZWJ，所以 `❤️`(U+2764+U+FE0F) 或
+    `🧑‍💻`(含 ZWJ) 这类 multi-codepoint emoji 也算 1 cluster。
     """
     out: list[str] = []
     i = 0
@@ -72,24 +94,24 @@ def _strip_stray_chars_between_tokens(s: str) -> str:
         i += 1
         if c not in ',[':
             continue
-        # 跳过 separator 后的空白，从最少 (k=1) 开始尝试，越少越好
+        # 跳过 separator 后的空白，从最少 (k=1 cluster) 开始
         j = i
         while j < n and s[j].isspace():
             j += 1
-        for k in (1, 2):
-            if j + k > n:
-                break
-            # 第 k 个字符必须是 pollution；否则再大的 k 也只会更糟
-            if not _is_likely_pollution_char(s[j + k - 1]):
-                break
+        cur = j
+        for _ in range(2):  # 上限 2 个 grapheme cluster
+            nxt = _consume_pollution_grapheme(s, cur)
+            if nxt == cur:
+                break  # 不是 pollution，再大 k 也只会更糟
+            cur = nxt
             # 污染段后允许跟若干空白（pretty-printed 输出常见），
             # 再看下一个非空白字符是不是合法值起始
-            m = j + k
+            m = cur
             while m < n and s[m].isspace():
                 m += 1
             if m < n and s[m] in _VALUE_START_CHARS:
                 out.append(s[i:j])  # 保留 separator 后的空白
-                i = j + k  # 跳过污染段；后续空白由主循环正常 append
+                i = cur  # 跳过污染段；后续空白由主循环正常 append
                 break
     return ''.join(out)
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -15,7 +15,10 @@ _UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
 
 # 合法 JSON 值起始字符：`"` (string) / `{` (object) / `[` (array) /
 # `-` 或数字 (number) / `t` `f` `n` (true/false/null)。
-_VALUE_START_CHARS = frozenset('"{[-tfn0123456789')
+# `.` 严格 JSON 中不是合法 number 起始 (.5 非法)，但 LLM 偶尔会写出来；
+# 算作"疑似数字起始"放进集合，scanner 不主动删它 —— 让 json.loads 自己抛错，
+# 避免把 `[1,.5]` 静默清成 `[1,5]` 这种数值 silent corruption。
+_VALUE_START_CHARS = frozenset('"{[-.tfn0123456789')
 
 
 def _strip_stray_chars_between_tokens(s: str) -> str:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -13,6 +13,59 @@ from typing import Any
 # 先尝试标准解析，失败后逐步修补再试。
 _UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
 
+# 合法 JSON 值起始字符：`"` (string) / `{` (object) / `[` (array) /
+# `-` 或数字 (number) / `t` `f` `n` (true/false/null)。
+_VALUE_START_CHARS = frozenset('"{[-tfn0123456789')
+
+
+def _strip_stray_chars_between_tokens(s: str) -> str:
+    """Strip 1–3 hallucinated chars between `,`/`[` and the next value start.
+
+    Stateful scanner — only acts outside of quoted strings (with backslash escape
+    handling) so legitimate string contents containing ``,abc{`` patterns are
+    untouched. Lookahead accepts any valid JSON value-start char (not just
+    ``{`` / ``[``), so cases like ``[1,결2]`` or ``["a",결"b"]`` also recover.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    in_string = False
+    escape = False
+    while i < n:
+        c = s[i]
+        if in_string:
+            out.append(c)
+            if escape:
+                escape = False
+            elif c == '\\':
+                escape = True
+            elif c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+            out.append(c)
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+        if c not in ',[':
+            continue
+        # 跳过 separator 后的空白，再看接下来是不是合法值起始
+        j = i
+        while j < n and s[j].isspace():
+            j += 1
+        if j >= n or s[j] in _VALUE_START_CHARS:
+            continue
+        # 1–3 字符内若能落到合法值起始，视作幻觉污染，删掉中间这段
+        for k in range(1, 4):
+            if j + k < n and s[j + k] in _VALUE_START_CHARS:
+                out.append(s[i:j])  # 保留空白
+                i = j + k
+                break
+    return ''.join(out)
+
 
 def robust_json_loads(raw: str) -> Any:
     """json.loads with fallback for common LLM JSON quirks.
@@ -44,9 +97,8 @@ def robust_json_loads(raw: str) -> Any:
         s = re.sub(r"'\s*([,\]\}])", r'"\1', s)              # 数组尾
         s = re.sub(r"([,\[\{])\s*'", r'\1"', s)              # 数组头
     # LLM 偶尔在结构 token 之间塞 1–3 个幻觉字符（实例：`,결{` 应是 `,{`）。
-    # 严格 JSON 中 `,` / `[` 之后只允许空白和合法值起始字符 (`"`, `{`, `[`, `-`, 数字, `t/f/n`)，
-    # 其他必为污染；限定 1–3 字以降低误伤合法字符串内容的概率。
-    s = re.sub(r'([,\[]\s*)[^\s",\[\]\{\}\d\-tfn]{1,3}(\s*[\{\[])', r'\1\2', s)
+    # 用有状态扫描器避免误伤合法 string 内容里出现的同形 pattern。
+    s = _strip_stray_chars_between_tokens(s)
     return json.loads(s)
 
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -82,9 +82,14 @@ def _strip_stray_chars_between_tokens(s: str) -> str:
             # 第 k 个字符必须是 pollution；否则再大的 k 也只会更糟
             if not _is_likely_pollution_char(s[j + k - 1]):
                 break
-            if j + k < n and s[j + k] in _VALUE_START_CHARS:
-                out.append(s[i:j])  # 保留空白
-                i = j + k
+            # 污染段后允许跟若干空白（pretty-printed 输出常见），
+            # 再看下一个非空白字符是不是合法值起始
+            m = j + k
+            while m < n and s[m].isspace():
+                m += 1
+            if m < n and s[m] in _VALUE_START_CHARS:
+                out.append(s[i:j])  # 保留 separator 后的空白
+                i = j + k  # 跳过污染段；后续空白由主循环正常 append
                 break
     return ''.join(out)
 

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import tempfile
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -17,18 +18,30 @@ _UNQUOTED_KEY_RE = re.compile(r'(?<=[{,])\s*([A-Za-z_]\w*)\s*:')
 # `-` 或数字 (number) / `t` `f` `n` (true/false/null)。
 _VALUE_START_CHARS = frozenset('"{[-tfn0123456789')
 
+# Unicode 类别白名单 —— 只剥这两类视作幻觉污染：
+#   Lo: Other Letter，含 CJK / 韩文 / 日文 / 阿拉伯文 等（实测污染源，如 `결`）
+#   So: Other Symbol，主要是 emoji
+# 故意排除 Sm (Math Symbol，含 `−` U+2212 / `＋` U+FF0B 等)、Pd (Dash)、
+# Nd (含全角数字 `０`-`９`、阿拉伯数字 `٠` 等) 等可能是 Unicode 数字前缀的类别 ——
+# 删掉它们会把 `[1,−2]` → `[1,2]` 这种 silent numeric corruption。
+_POLLUTION_UNICODE_CATEGORIES = frozenset({'Lo', 'So'})
+
+
+def _is_likely_pollution_char(c: str) -> bool:
+    """非 ASCII 且属 Other Letter (CJK/etc.) 或 Other Symbol (emoji) 类别。"""
+    if ord(c) <= 127:
+        return False
+    return unicodedata.category(c) in _POLLUTION_UNICODE_CATEGORIES
+
 
 def _strip_stray_chars_between_tokens(s: str) -> str:
-    """Strip 1–3 hallucinated **non-ASCII** chars between `,`/`[` and the next value.
+    """Strip 1–3 hallucinated chars between `,`/`[` and the next value start.
 
     Stateful scanner — only acts outside of quoted strings (with backslash escape
-    handling). 仅剥**非 ASCII** 污染（CJK / emoji / etc.）—— LLM 实测幻觉
-    几乎都是这种；ASCII 字符一律放行，避免把可能是某种半合法值前缀的内容
-    （`+5`、`.5`、`e3` 等）静默改成完全不同的数值。即便剥不掉，
-    后续 json.loads 自己抛 JSONDecodeError 走 fallback，比 silent corruption 安全。
-
-    覆盖完整合法值起始集合 (``"``/``{``/``[``/``-``/数字/``t/f/n``)，
-    所以 ``[1,결2]`` / ``["a",결"b"]`` / ``{"a":1,결"b":2}`` 都能恢复。
+    handling). 仅剥**非 ASCII Letter / emoji**（LLM 实测幻觉污染源）；ASCII 字符
+    与 Unicode 数字符号 / 标点 / dash / 全角数字一律放行，避免把
+    `+5`、`.5`、`e3`、`−2`（U+2212）、`＋5`（U+FF0B）等半合法值前缀静默改坏。
+    剥不掉就让 json.loads 自己抛 JSONDecodeError 走 fallback。
     """
     out: list[str] = []
     i = 0
@@ -56,14 +69,14 @@ def _strip_stray_chars_between_tokens(s: str) -> str:
         i += 1
         if c not in ',[':
             continue
-        # 跳过 separator 后的空白，找疑似污染段（连续 1–3 个非 ASCII 字符）
+        # 跳过 separator 后的空白，找疑似污染段（连续 1–3 个 Letter/emoji 类字符）
         j = i
         while j < n and s[j].isspace():
             j += 1
         end = j
-        while end < j + 3 and end < n and ord(s[end]) > 127:
+        while end < j + 3 and end < n and _is_likely_pollution_char(s[end]):
             end += 1
-        # 必须真的吃到了非 ASCII 字符，且后面紧跟合法值起始才算污染
+        # 必须真的吃到了污染字符，且后面紧跟合法值起始才剥
         if end > j and end < n and s[end] in _VALUE_START_CHARS:
             out.append(s[i:j])  # 保留空白
             i = end


### PR DESCRIPTION
## Summary

- LLM 偶尔在 JSON 数组分隔符位置吐杂字符（实测 GalGame 模式输出 `,결{`，韩文"决"塞在 options 元素之间），`json.loads` 失败 → 走 fallback 选项。
- 在 `robust_json_loads` 里加一道清洗：`,` / `[` 之后只允许空白和合法值起始字符（`"`、`{`、`[`、`-`、数字、`t/f/n`），其他 1–3 字符必为污染，剥离即可。限 1–3 字以降低误伤合法字符串内容。
- 新加 `tests/unit/test_robust_json_loads.py`（8 个 case），覆盖 GalGame 实测污染、数组头/中间的杂字符、以及合法字符串内 CJK 不被破坏。

## 实测案例
日志里看到的原始输入：
\`\`\`
{"options":[{"label":"A","text":"你想要什么口味的奶昔？"},결{"label":"B","text":"当然买，只要你开心。"},결{"label":"C","text":"奶昔会变成魔法药水吗？"}]}
\`\`\`

## Test plan

- [x] `uv run pytest tests/unit/test_robust_json_loads.py -v` —— 8 passed
- [ ] CI 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 优化 JSON 解析流程：优先接受合法 JSON，按阶段尝试安全恢复，清理结构标记间少量非 ASCII 污染，保留合法字符串内的 CJK/Unicode 内容，并严格拒绝可能导致数字或符号静默篡改的畸形输入。

* **测试**
  * 新增全面单元测试，覆盖尾随逗号、未加引号的键、布尔/空字面量恢复、杂字符污染边界、多码点 emoji、转义引号与恢复早停等场景以验证恢复与安全保障。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->