### PR TITLE
fix(plugin-cli): pack/upload 产物落到用户可写目录

### DIFF
--- a/plugin/server/application/plugin_cli/service.py
+++ b/plugin/server/application/plugin_cli/service.py
@@ -8,7 +8,11 @@ import sys
 
 from plugin.logging_config import get_logger
 from plugin.server.domain.errors import ServerDomainError
-from plugin.settings import USER_PACKAGE_PROFILES_ROOT, USER_PLUGIN_CONFIG_ROOT
+from plugin.settings import (
+    USER_PACKAGE_PROFILES_ROOT,
+    USER_PLUGIN_CONFIG_ROOT,
+    USER_PLUGIN_PACKAGES_ROOT,
+)
 
 _PLUGIN_ROOT = Path(__file__).resolve().parents[3]
 _CLI_ROOT = _PLUGIN_ROOT / "neko-plugin-cli"
@@ -17,7 +21,9 @@ _RUNTIME_PLUGINS_ROOT = _PLUGIN_ROOT / "plugins"
 # unpack（导入）目标目录：统一落到用户我的文档下的 plugins 配置根。
 _UNPACK_PLUGINS_ROOT = USER_PLUGIN_CONFIG_ROOT
 _UNPACK_PROFILES_ROOT = USER_PACKAGE_PROFILES_ROOT
-_TARGET_ROOT = _CLI_ROOT / "target"
+# pack/upload 产物（``.neko-plugin`` / ``.neko-bundle``）落地目录：
+# 必须落到用户可写的我的文档目录，否则 Nuitka 打包安装到 Program Files 后会失败。
+_TARGET_ROOT = USER_PLUGIN_PACKAGES_ROOT
 
 # Allowed extensions for uploaded plugin packages
 _ALLOWED_UPLOAD_SUFFIXES = frozenset({".neko-plugin", ".neko-bundle"})

--- a/plugin/settings.py
+++ b/plugin/settings.py
@@ -92,9 +92,24 @@ def get_user_package_profiles_root() -> Path:
     return (get_user_plugin_config_root().parent / ".neko-package-profiles").resolve()
 
 
+def get_user_plugin_packages_root() -> Path:
+    """获取用户插件包（``.neko-plugin`` / ``.neko-bundle``）落地目录。
+
+    - Env: ``PLUGIN_PACKAGES_ROOT``
+    - 默认：``<user plugins root>/../.neko-plugin-packages``，与
+      ``USER_PLUGIN_CONFIG_ROOT`` / ``USER_PACKAGE_PROFILES_ROOT`` 同级，
+      避免落到 Nuitka 打包后的只读 dist 目录中。
+    """
+    custom_path = os.getenv("PLUGIN_PACKAGES_ROOT")
+    if custom_path:
+        return Path(custom_path).expanduser().resolve()
+    return (get_user_plugin_config_root().parent / ".neko-plugin-packages").resolve()
+
+
 BUILTIN_PLUGIN_CONFIG_ROOT = get_builtin_plugin_config_root()
 USER_PLUGIN_CONFIG_ROOT = get_user_plugin_config_root()
 USER_PACKAGE_PROFILES_ROOT = get_user_package_profiles_root()
+USER_PLUGIN_PACKAGES_ROOT = get_user_plugin_packages_root()
 # Deprecated compatibility alias for older single-root callers.
 PLUGIN_CONFIG_ROOT = BUILTIN_PLUGIN_CONFIG_ROOT
 PLUGIN_CONFIG_ROOTS = get_plugin_config_roots()
@@ -536,6 +551,7 @@ __all__ = [
     "BUILTIN_PLUGIN_CONFIG_ROOT",
     "USER_PLUGIN_CONFIG_ROOT",
     "USER_PACKAGE_PROFILES_ROOT",
+    "USER_PLUGIN_PACKAGES_ROOT",
     "PLUGIN_CONFIG_ROOT",
     "PLUGIN_CONFIG_ROOTS",
     "get_builtin_plugin_config_root",
@@ -543,6 +559,7 @@ __all__ = [
     "get_plugin_config_roots",
     "get_user_plugin_config_root",
     "get_user_package_profiles_root",
+    "get_user_plugin_packages_root",
     
     # 队列配置
     "EVENT_QUEUE_MAX",
@@ -621,6 +638,7 @@ PUBLIC_SYSTEM_CONFIG_KEYS = (
     "BUILTIN_PLUGIN_CONFIG_ROOT",
     "USER_PLUGIN_CONFIG_ROOT",
     "USER_PACKAGE_PROFILES_ROOT",
+    "USER_PLUGIN_PACKAGES_ROOT",
     "PLUGIN_CONFIG_ROOT",
     "PLUGIN_CONFIG_ROOTS",
     "EVENT_QUEUE_MAX",


### PR DESCRIPTION
## Summary
- Nuitka 打包后 `_TARGET_ROOT = _CLI_ROOT / "target"` 落在 dist 目录里，安装到 `C:\Program Files\N.E.K.O\` 这类只读目录时 pack / upload / list_local_packages 全部会失败。
- 新增 `USER_PLUGIN_PACKAGES_ROOT`（env: `PLUGIN_PACKAGES_ROOT`），默认 `<我的文档>/N.E.K.O/.neko-plugin-packages`，与 `USER_PLUGIN_CONFIG_ROOT` / `USER_PACKAGE_PROFILES_ROOT` 同级；`plugin_cli` service 改为指向该 root。
- `_CLI_ROOT` 仍指向 dist 内的 `neko-plugin-cli`，但只用作 `sys.path` 注入和 `from public import`，不再写文件。

## Test plan
- [x] `uv run pytest plugin/tests/unit/server/test_plugin_cli_route.py plugin/tests/unit/test_neko_plugin_cli_public.py plugin/tests/integration/test_neko_plugin_cli_workflow.py` — 19 passed
- [ ] 实机验证：Nuitka 打包后安装到 Program Files，从 UI 发起 plugin pack / upload，确认产物落到 `<我的文档>/N.E.K.O/.neko-plugin-packages` 且 list_local_packages 正常返回

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 插件包存储位置已从系统内部目录更改为用户可写目录，用户现可在"我的文档"等常规位置更便捷地管理和访问插件包。本地包列表、保存和验证功能已相应同步更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->