### PR TITLE
fix(realtime): bound audio stream backlog

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -385,6 +385,11 @@ class LLMSessionManager:
         self._screenshot_future: asyncio.Future | None = None
         self._avatar_position: dict | None = None  # 前端传来的 Avatar 归一化坐标 {centerX, centerY, width, height}
         self.current_speech_id = None
+        self._audio_stream_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=300)
+        self._audio_stream_worker_task: Optional[asyncio.Task] = None
+        self._audio_stream_dropped_total = 0
+        self._audio_stream_epoch = 0
+        self._last_audio_stream_backlog_log_time = 0.0
         self.emoji_pattern = re.compile(r'[^\w\u4e00-\u9fff\s>][^\w\u4e00-\u9fff\s]{2,}[^\w\u4e00-\u9fff\s<]', flags=re.UNICODE)
         self.emoji_pattern2 = re.compile("["
         u"\U0001F600-\U0001F64F"  # emoticons
@@ -570,6 +575,76 @@ class LLMSessionManager:
         self._bg_tasks.add(task)
         task.add_done_callback(self._bg_tasks.discard)
         return task
+
+    def _ensure_audio_stream_worker(self):
+        if self._audio_stream_worker_task and not self._audio_stream_worker_task.done():
+            return
+        self._audio_stream_worker_task = self._fire_task(self._audio_stream_worker_loop())
+
+    def _clear_audio_stream_queue(self, reason: str):
+        dropped = 0
+        while True:
+            try:
+                self._audio_stream_queue.get_nowait()
+                self._audio_stream_queue.task_done()
+                dropped += 1
+            except asyncio.QueueEmpty:
+                break
+        if dropped:
+            self._audio_stream_dropped_total += dropped
+            logger.info(
+                "[%s] audio stream queue cleared reason=%s dropped=%d total_dropped=%d",
+                self.lanlan_name, reason, dropped, self._audio_stream_dropped_total,
+            )
+
+    def _cancel_audio_stream_worker(self, reason: str):
+        task = self._audio_stream_worker_task
+        if not task:
+            return
+        if task.done():
+            self._audio_stream_worker_task = None
+            return
+        if task is asyncio.current_task():
+            return
+        task.cancel()
+        self._audio_stream_worker_task = None
+        logger.debug("[%s] audio stream worker cancelled reason=%s", self.lanlan_name, reason)
+
+    async def _enqueue_audio_stream_data(self, message: dict):
+        self._ensure_audio_stream_worker()
+        if self._audio_stream_queue.full():
+            try:
+                self._audio_stream_queue.get_nowait()
+                self._audio_stream_queue.task_done()
+                self._audio_stream_dropped_total += 1
+            except asyncio.QueueEmpty:
+                pass
+        await self._audio_stream_queue.put(message)
+        qsize = self._audio_stream_queue.qsize()
+        now = time.time()
+        if qsize >= 250 and now - self._last_audio_stream_backlog_log_time >= 2.0:
+            self._last_audio_stream_backlog_log_time = now
+            logger.warning(
+                "[%s] audio stream queue backlog qsize=%d max=%d total_dropped=%d",
+                self.lanlan_name,
+                qsize,
+                self._audio_stream_queue.maxsize,
+                self._audio_stream_dropped_total,
+            )
+
+    async def _audio_stream_worker_loop(self):
+        while True:
+            while not self.session_ready and self._starting_session_count > 0:
+                await asyncio.sleep(0.02)
+            message = await self._audio_stream_queue.get()
+            try:
+                await self._stream_data_now(message)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("[%s] audio stream worker error: %s", self.lanlan_name, exc)
+            finally:
+                self._audio_stream_queue.task_done()
 
     def _emit_cooldown_turn_end_if_needed(self):
         """冷却期间去重发送 turn_end，每秒最多一次。返回 True 表示当前处于冷却中。"""
@@ -1983,7 +2058,10 @@ class LLMSessionManager:
                     try:
                         # 重新调用stream_data处理缓存的数据
                         # 注意：这里直接处理，不再缓存（因为session_ready已设为True）
-                        await self._process_stream_data_internal(message)
+                        if message.get("input_type") == "audio":
+                            await self._enqueue_audio_stream_data(message)
+                        else:
+                            await self._process_stream_data_internal(message)
                     except Exception as e:
                         logger.error(f"💥 发送缓存的输入数据失败: {e}")
                         break
@@ -4221,6 +4299,12 @@ class LLMSessionManager:
         await self.cleanup(expected_session=expected_session)
     
     async def stream_data(self, message: dict):  # 向Core API发送Media数据
+        if message.get("input_type") == "audio":
+            await self._enqueue_audio_stream_data(message)
+            return
+        await self._stream_data_now(message)
+
+    async def _stream_data_now(self, message: dict):
         input_type = message.get("input_type")
         
         # 检查session是否就绪
@@ -4228,6 +4312,8 @@ class LLMSessionManager:
             if not self.session_ready:
                 # 检查是否正在启动session - 只有在启动过程中才缓存
                 if self._starting_session_count > 0:
+                    if input_type == "audio":
+                        return
                     # Session正在启动中，缓存输入数据
                     self.pending_input_data.append(message)
                     if len(self.pending_input_data) == 1:
@@ -4434,7 +4520,9 @@ class LLMSessionManager:
                         return
                 
                 # 检查WebSocket连接
-                if not hasattr(self.session, 'ws') or not self.session.ws:
+                session_ref = self.session
+                audio_epoch = self._audio_stream_epoch
+                if not hasattr(session_ref, 'ws') or not session_ref.ws:
                     logger.error("💥 Stream: Session websocket not available")
                     return
                 try:
@@ -4447,16 +4535,16 @@ class LLMSessionManager:
                         is_48khz = (num_samples == 480)
                         
                         processed_audio = audio_bytes  # 默认使用原始音频
-                        if is_48khz and isinstance(self.session, OmniRealtimeClient):
+                        if is_48khz and isinstance(session_ref, OmniRealtimeClient):
                             # 使用session的AudioProcessor处理音频
-                            if hasattr(self.session, '_audio_processor') and self.session._audio_processor:
+                            if hasattr(session_ref, '_audio_processor') and session_ref._audio_processor:
                                 try:
                                     # Use async wrapper to avoid blocking main loop
-                                    if hasattr(self.session, 'process_audio_chunk_async'):
-                                        processed_audio = await self.session.process_audio_chunk_async(audio_bytes)
+                                    if hasattr(session_ref, 'process_audio_chunk_async'):
+                                        processed_audio = await session_ref.process_audio_chunk_async(audio_bytes)
                                     else:
                                         # Fallback (should not happen if client updated)
-                                        processed_audio = self.session._audio_processor.process_chunk(audio_bytes)
+                                        processed_audio = session_ref._audio_processor.process_chunk(audio_bytes)
                                         
                                     # RNNoise可能返回空字节（缓冲中），跳过
                                     if len(processed_audio) == 0:
@@ -4464,6 +4552,12 @@ class LLMSessionManager:
                                 except Exception as e:
                                     logger.error(f"💥 音频预处理失败: {e}")
                                     return
+                        if (
+                            self.session is not session_ref
+                            or not self.is_active
+                            or self._audio_stream_epoch != audio_epoch
+                        ):
+                            return
                         
                         # 热切换期间或推送缓存期间，缓存处理后的音频（16kHz，已降噪）
                         if self.is_hot_swap_imminent or self.is_flushing_hot_swap_cache:
@@ -4478,7 +4572,7 @@ class LLMSessionManager:
                             return  # 静默拒绝，不记录log
                         
                         # 再次检查session状态（防止在处理过程中session被关闭）
-                        if not self.session or not hasattr(self.session, 'ws') or not self.session.ws:
+                        if not session_ref or not hasattr(session_ref, 'ws') or not session_ref.ws:
                             # 限流log：2秒内只记录一次
                             current_time = asyncio.get_event_loop().time()
                             if current_time - self.last_audio_send_error_time > self.audio_error_log_interval:
@@ -4487,7 +4581,7 @@ class LLMSessionManager:
                             return
                         
                         # 检查致命错误状态
-                        if hasattr(self.session, '_fatal_error_occurred') and self.session._fatal_error_occurred:
+                        if hasattr(session_ref, '_fatal_error_occurred') and session_ref._fatal_error_occurred:
                             current_time = asyncio.get_event_loop().time()
                             if current_time - self.last_audio_send_error_time > self.audio_error_log_interval:
                                 logger.warning("⚠️ Session已发生致命错误，跳过音频数据发送")
@@ -4495,7 +4589,7 @@ class LLMSessionManager:
                             return
                         
                         # 发送音频到session（stream_audio会检测是否48kHz，16kHz不会再处理）
-                        await self.session.stream_audio(processed_audio)
+                        await session_ref.stream_audio(processed_audio)
                     else:
                         logger.error(f"💥 Stream: Invalid audio data type: {type(data)}")
                         return
@@ -4599,6 +4693,9 @@ class LLMSessionManager:
                 # 即使会话未完全激活（如 start_session 失败），也要清理
                 # 可能残留的 TTS 重试状态，防止污染下一次会话
                 self._reset_tts_retry_state()
+                self._audio_stream_epoch += 1
+                self._clear_audio_stream_queue("end_session_inactive")
+                self._cancel_audio_stream_worker("end_session_inactive")
                 _inactive_early = True
                 # start_tts_if_needed 可能已启动 TTS 线程/handler，
                 # 但 is_active 尚未置 True 就失败了——快照引用以便释放锁后清理
@@ -4627,6 +4724,9 @@ class LLMSessionManager:
         async with self.lock:
             # Re-check after await: another task may have deactivated or swapped session.
             if not self.is_active:
+                self._audio_stream_epoch += 1
+                self._clear_audio_stream_queue("end_session_post_init_inactive")
+                self._cancel_audio_stream_worker("end_session_post_init_inactive")
                 return
             if expected_session is not None and expected_session is not self.session:
                 logger.info("⏭️ end_session: expected_session stale (post-init), skipping")
@@ -4640,6 +4740,9 @@ class LLMSessionManager:
             # 会穿过，产生孤儿 OmniRealtimeClient（silence_check_task/ws 泄漏）。
             if reset_starting_count:
                 self._starting_session_count = 0
+            self._audio_stream_epoch += 1
+            self._clear_audio_stream_queue("end_session")
+            self._cancel_audio_stream_worker("end_session")
 
             # Activity tracker：session 关闭，voice_engaged 不再可能触发。
             self._activity_tracker.on_voice_mode(False)

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -158,7 +158,10 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                     session_manager[lanlan_name]._avatar_position = av_pos
                 else:
                     session_manager[lanlan_name]._avatar_position = None
-                _fire_task(session_manager[lanlan_name].stream_data(message))
+                if message.get("input_type") == "audio":
+                    await session_manager[lanlan_name].stream_data(message)
+                else:
+                    _fire_task(session_manager[lanlan_name].stream_data(message))
 
             elif action == "avatar_interaction":
                 _fire_task(session_manager[lanlan_name].handle_avatar_interaction(message))

--- a/tests/unit/test_audio_stream_queue.py
+++ b/tests/unit/test_audio_stream_queue.py
@@ -1,0 +1,95 @@
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from main_logic.core import LLMSessionManager
+from main_logic.omni_realtime_client import OmniRealtimeClient
+
+
+async def test_starting_session_audio_does_not_enter_pending_input_data():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.session_ready = False
+    mgr._starting_session_count = 1
+    mgr.pending_input_data = []
+    mgr.input_cache_lock = asyncio.Lock()
+
+    await LLMSessionManager._stream_data_now(mgr, {"input_type": "audio", "data": [0] * 480})
+
+    assert mgr.pending_input_data == []
+
+
+async def test_flush_pending_input_data_routes_audio_through_bounded_queue():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    audio_msg = {"input_type": "audio", "data": [1] * 480}
+    text_msg = {"input_type": "text", "data": "hello"}
+    mgr.pending_input_data = [audio_msg, text_msg]
+    mgr.input_cache_lock = asyncio.Lock()
+    mgr.session = object()
+    mgr.is_active = True
+    mgr._enqueue_audio_stream_data = AsyncMock()
+    mgr._process_stream_data_internal = AsyncMock()
+
+    await LLMSessionManager._flush_pending_input_data(mgr)
+
+    mgr._enqueue_audio_stream_data.assert_awaited_once_with(audio_msg)
+    mgr._process_stream_data_internal.assert_awaited_once_with(text_msg)
+    assert mgr.pending_input_data == []
+
+
+async def test_audio_stream_queue_drops_oldest_when_full():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr._audio_stream_queue = asyncio.Queue(maxsize=2)
+    mgr._audio_stream_dropped_total = 0
+    mgr._last_audio_stream_backlog_log_time = 0.0
+    mgr._ensure_audio_stream_worker = lambda: None
+
+    await LLMSessionManager._enqueue_audio_stream_data(mgr, {"seq": 1})
+    await LLMSessionManager._enqueue_audio_stream_data(mgr, {"seq": 2})
+    await LLMSessionManager._enqueue_audio_stream_data(mgr, {"seq": 3})
+
+    assert mgr._audio_stream_dropped_total == 1
+    assert mgr._audio_stream_queue.get_nowait()["seq"] == 2
+    assert mgr._audio_stream_queue.get_nowait()["seq"] == 3
+
+
+async def test_inflight_audio_is_dropped_when_epoch_changes():
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.session_ready = True
+    mgr._starting_session_count = 0
+    mgr.is_active = True
+    mgr.session_start_failure_count = 0
+    mgr.session_start_max_failures = 3
+    mgr._session_start_circuit_open = False
+    mgr._audio_stream_epoch = 0
+    mgr.session_closed_by_server = False
+    mgr.last_audio_send_error_time = 0.0
+    mgr.audio_error_log_interval = 2.0
+    mgr.is_hot_swap_imminent = False
+    mgr.is_flushing_hot_swap_cache = False
+    mgr.hot_swap_cache_lock = asyncio.Lock()
+
+    class _RealtimeSession(OmniRealtimeClient):
+        def __init__(self):
+            self.ws = object()
+            self._fatal_error_occurred = False
+            self._audio_processor = object()
+            self.stream_audio = AsyncMock()
+
+        async def process_audio_chunk_async(self, audio_bytes):
+            mgr._audio_stream_epoch += 1
+            return audio_bytes
+
+    session = _RealtimeSession()
+    mgr.session = session
+
+    await LLMSessionManager._process_stream_data_internal(
+        mgr,
+        {"input_type": "audio", "data": [1] * 480},
+    )
+
+    session.stream_audio.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Route realtime audio input through a bounded manager-owned queue instead of spawning a background task for every audio frame.
- Drop the oldest queued audio frame when the queue is full, keeping realtime voice input low-latency instead of replaying stale audio.
- Avoid caching audio frames in `pending_input_data` while a session is still starting.
- Add an audio stream epoch guard so in-flight audio is discarded if the session changes or ends while audio preprocessing is awaiting.
- Cancel the audio queue worker during session teardown so inactive managers are not kept alive by idle worker tasks.
- Keep non-audio `stream_data` behavior unchanged.

## Why

Audio input arrives at a high frequency, and the previous path could keep spawning background work faster than the session could process it when startup, preprocessing, or websocket sends were slow. That could create unbounded backlog and allow stale audio to cross session lifecycle boundaries.

This change treats audio as realtime data: bounded, ordered, and disposable when the system is already behind. It preserves the existing session circuit breaker, hot-swap, and stale-session protections while adding backpressure to the audio ingress path.

## Test plan

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/codex-pycache python3 -m py_compile main_logic/core.py main_routers/websocket_router.py tests/unit/test_audio_stream_queue.py`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/tmp/neko-upstream-audio-venv PYTHONPYCACHEPREFIX=/tmp/codex-pycache TMPDIR=/tmp uv run pytest -q tests/unit/test_audio_stream_queue.py -s`

Result:

- `4 passed, 2 warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **问题修复**
  * 改进了音频流处理的稳定性和性能，防止会话切换时出现过期音频数据的问题。
  * 优化了音频消息队列管理，更好地处理高频音频数据输入，减少丢包情况。

* **测试**
  * 新增音频流队列相关单元测试，确保音频处理的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->