### PR TITLE
fix(react-chat): 修复消息列表自动滚动到底部失效（绕开 Electron smooth scroll silent no-op）

### DIFF
--- a/frontend/react-neko-chat/README.md
+++ b/frontend/react-neko-chat/README.md
@@ -18,6 +18,32 @@ The following rules are part of this refactor and should be treated as project c
 4. The new UI is not a visual copy of the current floating chat box.
 5. The new layout should move toward a QQ-like chat window experience.
 
+## Three host contexts (any change must be verified in all three)
+
+The same React bundle is mounted into three host contexts, and they behave
+differently. Any change here must be checked in **all three** before shipping —
+"works in the browser dev server" is **not** sufficient.
+
+1. **`index.html` — desktop browser (wide viewport)**
+   - Chat is a collapsible floating panel on top of the main page.
+   - Vite dev server (`npm run dev`) approximates this path.
+2. **`index.html` — mobile (narrow viewport)**
+   - Same route, but the mobile-detection branch kicks in: collapsed bubble,
+     drag handle, keyboard-aware scroll, touch-only behaviors.
+   - Reproduce by resizing the browser window or via mobile emulation.
+3. **`chat.html` — Electron standalone window**
+   - The desktop distribution opens chat in its own BrowserWindow. Full-screen
+     layout, **no Live2D / side panels**, and **mobile detection is bypassed**
+     even if the window is dragged narrow.
+   - Electron's Chromium fork is **not** equivalent to a regular browser.
+     Known divergence: `scrollTo({ behavior: 'smooth' })` is a silent no-op in
+     Electron 41 — so anything depending on smooth scroll must fall back to
+     instant assignment (`scrollTop = scrollHeight`).
+
+When editing scroll, sizing, animation, ResizeObserver, keyboard, or touch
+logic, mentally walk all three paths first, then smoke-test all three before
+declaring the change done.
+
 ## UI direction
 
 The target interaction model is a QQ-style chat window, not a full QQ-like application system.

--- a/frontend/react-neko-chat/src/MessageList.tsx
+++ b/frontend/react-neko-chat/src/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useRef, useEffect, useMemo } from 'react';
 import MessageBubble from './MessageBubble';
 import { i18n } from './i18n';
 import { type ChatMessage, type MessageAction } from './message-schema';
@@ -41,32 +41,14 @@ export default function MessageList({
     [messages],
   );
 
-  const isStreaming = displayMessages.some(m => m.status === 'streaming');
-
-  const scrollToBottom = useCallback(() => {
+  // Always instant scroll: behavior:'smooth' is silently broken in our Electron
+  // host (window.scrollTo / element.scrollTo with behavior:'smooth' is a no-op),
+  // which left the chat stuck at scrollTop=0 on mount and after each new message.
+  useEffect(() => {
     const container = containerRef.current;
     if (!container || !shouldScrollRef.current) return;
-
-    const shouldUseInstantScroll =
-      isStreaming
-      || (
-        typeof document !== 'undefined'
-        && document.body.classList.contains('yui-taking-over')
-      );
-
-    if (shouldUseInstantScroll) {
-      container.scrollTop = container.scrollHeight;
-    } else {
-      container.scrollTo({
-        top: container.scrollHeight,
-        behavior: 'smooth',
-      });
-    }
-  }, [isStreaming]);
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [displayMessages, scrollToBottom]);
+    container.scrollTop = container.scrollHeight;
+  }, [displayMessages]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary

- 分发版 Electron host 里 `element.scrollTo({ behavior: 'smooth' })` 是 silent no-op，调用返回但 scrollTop 不动，导致 react-neko-chat 在非 streaming / 非 yui-taking-over 路径下：初次挂载卡 scrollTop=0、用户消息追加不贴底、galgame slot 切换后留在历史位置。
- `MessageList` 直接拆掉 smooth 分支，`useEffect [displayMessages]` 永远 \`scrollTop = scrollHeight\`；同时去掉派生的 \`isStreaming\` 和 \`scrollToBottom\` useCallback 包装。
- 和 #1114 加的 \`observer.observe(container)\` 互补——ResizeObserver 这条路径不变，负责 streaming 文本增长 / galgame 面板挤压容器等 resize 触发场景；新改的 useEffect 路径负责消息数组变化触发场景。
- README 加 \"Three host contexts\" 一节，记录 react-neko-chat 改动需要在 index.html 宽屏 / index.html 窄宽手机版 / chat.html Electron 三条路径分别验证，并把这次 smooth scroll 这个 Electron Web API 偏差写进 known divergence。

## Why this 之前不显眼

- 助手 streaming 消息路径走 instant fallback（e7c237b7a 加的）一直工作，掩盖了底层 smooth scroll 在 Electron 失效的事实。
- 加 galgame mode 之前，layout 变化几乎只来自新消息；新消息会让 \`[displayMessages.length]\` 那条 useEffect 重建 ResizeObserver，新观察的子元素首帧 fire 一次 instant scroll，把 smooth scroll 这条路盖住了。
- galgame mode 引入了非消息触发的 layout 变化（A/B/C 选项 slot 展开收起、loading 态切换），smooth scroll 这条路独立暴露，bug 才显形。

## Test plan

- [x] vitest \`npm run test\`（36/36 pass）
- [x] \`npm run typecheck\` clean
- [x] vite dev server 复现 + 验证（Claude Preview / Electron 41 host）：
  - 初次挂载 12 条历史 → 落到底
  - 新消息追加 → 跟到底
  - streaming 8 段 chunk 追加 → 每段都贴底
  - 用户上滑后追加新消息 → scrollTop 不动（粘底暂停生效）
- [ ] 三 host 真机回归（建议 reviewer 协助）：
  - [ ] index.html 桌面浏览器
  - [ ] index.html 手机版（窄宽 + mobile UA）
  - [ ] chat.html Electron 独立窗口

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档更新**
  * 增加了跨平台环境（桌面、移动、Electron）验证指南，确保在所有平台上充分测试后再发布

* **改进**
  * 优化了消息列表滚动行为，使其立即跳转到最新消息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->