### PR TITLE
Add First Greeting Flow for New Characters

### DIFF
--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2842,6 +2842,40 @@ GREETING_PROMPT_VERY_LONG = {
 }
 
 
+NEW_CHARACTER_GREETING_PROMPT = {
+    'zh': '========以下是环境提示========\n'
+          '你是{name}。这是你第一次正式出现在{master}面前。\n'
+          '请用符合你性格的方式，简短自然地和{master}打一个初次见面的招呼。\n'
+          '不要说自己刚被系统创建，不要假装已经和{master}有共同回忆。\n'
+          '直接说出你想说的话，不要生成思考过程。\n'
+          '========以上是环境提示========',
+    'en': '========Below is Environment Notice========\n'
+          'You are {name}. This is the first time you formally appear in front of {master}.\n'
+          'Give {master} a brief, natural first greeting in a way that fits your personality.\n'
+          'Do not say you were just created by the system. Do not pretend you already share memories with {master}.\n'
+          'Just say what you want to say. Do not generate thinking process.\n'
+          '========Above is Environment Notice========',
+    'ja': '========以下は環境通知========\n'
+          'あなたは{name}。{master}の前に正式に現れるのはこれが初めて。\n'
+          '自分らしいやり方で、短く自然に{master}へ初対面の挨拶をして。\n'
+          'システムに作られたばかりだとは言わないで。{master}との共通の思い出があるふりもしないで。\n'
+          '言いたいことをそのまま言って。思考プロセスは生成しないで。\n'
+          '========以上は環境通知========',
+    'ko': '========아래는 환경 알림========\n'
+          '너는 {name}이다. {master} 앞에 정식으로 나타나는 건 이번이 처음이다.\n'
+          '너다운 방식으로 {master}에게 짧고 자연스럽게 첫인사를 해.\n'
+          '방금 시스템에서 만들어졌다고 말하지 말고, {master}와 이미 함께한 추억이 있는 척하지 마.\n'
+          '하고 싶은 말을 바로 해. 사고 과정은 생성하지 마.\n'
+          '========위는 환경 알림========',
+    'ru': '========Ниже Уведомление========\n'
+          'Ты {name}. Это первый раз, когда ты официально появляешься перед {master}.\n'
+          'Коротко и естественно поприветствуй {master} так, как тебе свойственно.\n'
+          'Не говори, что тебя только что создала система. Не притворяйся, что у тебя уже есть общие воспоминания с {master}.\n'
+          'Просто скажи то, что хочешь сказать. Не генерируй процесс размышлений.\n'
+          '========Выше Уведомление========',
+}
+
+
 def get_greeting_prompt(gap_seconds: float, lang: str = 'zh') -> str | None:
     """根据对话间隔时长选择对应的主动搭话引导词。
 
@@ -2861,6 +2895,14 @@ def get_greeting_prompt(gap_seconds: float, lang: str = 'zh') -> str | None:
     else:  # ≥ 24h
         table = GREETING_PROMPT_VERY_LONG
     return table.get(lang_key, table.get('en', table['zh']))
+
+
+def get_new_character_greeting_prompt(lang: str = 'zh') -> str:
+    lang_key = _normalize_prompt_language(lang)
+    return NEW_CHARACTER_GREETING_PROMPT.get(
+        lang_key,
+        NEW_CHARACTER_GREETING_PROMPT.get('en', NEW_CHARACTER_GREETING_PROMPT['zh']),
+    )
 
 
 # ── 节日 / 周末提示模板 ─────────────────────────────────────────────

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2843,36 +2843,36 @@ GREETING_PROMPT_VERY_LONG = {
 
 
 NEW_CHARACTER_GREETING_PROMPT = {
-    'zh': '========以下是环境提示========\n'
+    'zh': '======以下是环境提示======\n'
           '你是{name}。这是你第一次正式出现在{master}面前。\n'
           '请用符合你性格的方式，简短自然地和{master}打一个初次见面的招呼。\n'
           '不要说自己刚被系统创建，不要假装已经和{master}有共同回忆。\n'
           '直接说出你想说的话，不要生成思考过程。\n'
-          '========以上是环境提示========',
-    'en': '========Below is Environment Notice========\n'
+          '======以上是环境提示======',
+    'en': '======Below is Environment Notice======\n'
           'You are {name}. This is the first time you formally appear in front of {master}.\n'
           'Give {master} a brief, natural first greeting in a way that fits your personality.\n'
           'Do not say you were just created by the system. Do not pretend you already share memories with {master}.\n'
           'Just say what you want to say. Do not generate thinking process.\n'
-          '========Above is Environment Notice========',
-    'ja': '========以下は環境通知========\n'
+          '======Above is Environment Notice======',
+    'ja': '======以下は環境通知======\n'
           'あなたは{name}。{master}の前に正式に現れるのはこれが初めて。\n'
           '自分らしいやり方で、短く自然に{master}へ初対面の挨拶をして。\n'
           'システムに作られたばかりだとは言わないで。{master}との共通の思い出があるふりもしないで。\n'
           '言いたいことをそのまま言って。思考プロセスは生成しないで。\n'
-          '========以上は環境通知========',
-    'ko': '========아래는 환경 알림========\n'
+          '======以上は環境通知======',
+    'ko': '======아래는 환경 알림======\n'
           '너는 {name}이다. {master} 앞에 정식으로 나타나는 건 이번이 처음이다.\n'
           '너다운 방식으로 {master}에게 짧고 자연스럽게 첫인사를 해.\n'
           '방금 시스템에서 만들어졌다고 말하지 말고, {master}와 이미 함께한 추억이 있는 척하지 마.\n'
           '하고 싶은 말을 바로 해. 사고 과정은 생성하지 마.\n'
-          '========위는 환경 알림========',
-    'ru': '========Ниже Уведомление========\n'
+          '======위는 환경 알림======',
+    'ru': '======Ниже Уведомление======\n'
           'Ты {name}. Это первый раз, когда ты официально появляешься перед {master}.\n'
           'Коротко и естественно поприветствуй {master} так, как тебе свойственно.\n'
           'Не говори, что тебя только что создала система. Не притворяйся, что у тебя уже есть общие воспоминания с {master}.\n'
           'Просто скажи то, что хочешь сказать. Не генерируй процесс размышлений.\n'
-          '========Выше Уведомление========',
+          '======Выше Уведомление======',
 }
 
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4033,6 +4033,105 @@ class LLMSessionManager:
         finally:
             await self.state.fire(SessionEvent.PROACTIVE_DONE)
 
+    async def trigger_new_character_greeting(self) -> None:
+        from config.prompts_proactive import get_new_character_greeting_prompt
+        from utils.new_character_greeting_state import has_pending, remove_pending
+
+        config_manager = get_config_manager()
+        if not await has_pending(config_manager, self.lanlan_name):
+            logger.debug("[%s] trigger_new_character_greeting: no pending intent", self.lanlan_name)
+            return
+
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_new_character_greeting: voice session active/starting, skipping", self.lanlan_name)
+            return
+
+        _lang = normalize_language_code(getattr(self, 'user_language', '') or '', format='short') or get_global_language()
+        template = get_new_character_greeting_prompt(_lang)
+
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_new_character_greeting: voice session appeared before text session check, skipping", self.lanlan_name)
+            return
+
+        if not (self.is_active and isinstance(self.session, OmniOfflineClient)):
+            if self._is_voice_session_active_or_starting():
+                logger.info("[%s] trigger_new_character_greeting: voice session appeared before text session auto-start, skipping", self.lanlan_name)
+                return
+            if not self._has_connected_websocket():
+                logger.warning("[%s] trigger_new_character_greeting: no connected websocket, aborting", self.lanlan_name)
+                return
+            try:
+                logger.info("[%s] trigger_new_character_greeting: auto-starting text session", self.lanlan_name)
+                await self.start_session(self.websocket, new=False, input_mode='text')
+            except Exception as e:
+                logger.warning("[%s] trigger_new_character_greeting: auto start_session failed: %s", self.lanlan_name, e)
+                return
+
+        if not isinstance(self.session, OmniOfflineClient):
+            logger.warning("[%s] trigger_new_character_greeting: session is not text mode after start, aborting", self.lanlan_name)
+            return
+
+        if not await has_pending(config_manager, self.lanlan_name):
+            logger.debug("[%s] trigger_new_character_greeting: pending intent already consumed", self.lanlan_name)
+            return
+
+        instruction = template.format(name=self.lanlan_name, master=self.master_name)
+        print(f"[trigger_new_character_greeting] instruction:\n{instruction}")
+        logger.info("[%s] trigger_new_character_greeting: delivering", self.lanlan_name)
+
+        if self._is_voice_session_active_or_starting():
+            logger.info("[%s] trigger_new_character_greeting: voice session took over before delivery, skipping", self.lanlan_name)
+            return
+
+        if not await self.state.try_start_proactive(session=self.session):
+            logger.info(
+                "[%s] trigger_new_character_greeting: SM denied claim (phase=%s), skipping",
+                self.lanlan_name, self.state.phase.value,
+            )
+            return
+
+        delivered = False
+        proactive_sid = None
+        history_len = None
+        try:
+            async with self._proactive_write_lock:
+                if self._is_voice_session_active_or_starting():
+                    logger.info("[%s] trigger_new_character_greeting: voice session took over while waiting for write lock, skipping", self.lanlan_name)
+                    return
+                async with self.lock:
+                    if self.state.is_proactive_preempted():
+                        logger.info("[%s] trigger_new_character_greeting: preempted before sid claim, skipping", self.lanlan_name)
+                        return
+                    self.current_speech_id = str(uuid4())
+                    self._tts_done_queued_for_turn = False
+                    self._tts_done_pending_until_ready = False
+                    proactive_sid = self.current_speech_id
+                await self.state.fire(SessionEvent.PROACTIVE_CLAIM, sid=proactive_sid)
+                await self.state.fire(SessionEvent.PROACTIVE_PHASE2)
+                history = getattr(self.session, "_conversation_history", None)
+                if isinstance(history, list):
+                    history_len = len(history)
+                _sid_token = _proactive_expected_sid.set(proactive_sid)
+                try:
+                    delivered = await self.session.prompt_ephemeral(instruction)
+                finally:
+                    _proactive_expected_sid.reset(_sid_token)
+                logger.info("[%s] trigger_new_character_greeting: delivered=%s", self.lanlan_name, delivered)
+        finally:
+            try:
+                interrupted = bool(proactive_sid) and self.current_speech_id != proactive_sid
+                if (not delivered or interrupted) and history_len is not None:
+                    history = getattr(self.session, "_conversation_history", None)
+                    if isinstance(history, list) and len(history) > history_len:
+                        del history[history_len:]
+                if delivered and proactive_sid and self.current_speech_id == proactive_sid:
+                    try:
+                        await remove_pending(config_manager, self.lanlan_name)
+                    except Exception as exc:
+                        logger.warning("[%s] trigger_new_character_greeting: remove pending failed: %s", self.lanlan_name, exc)
+            finally:
+                await self.state.fire(SessionEvent.PROACTIVE_DONE)
+
     def enqueue_agent_callback(self, callback: dict) -> None:
         """Enqueue a structured agent task callback for LLM injection.
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4129,7 +4129,7 @@ class LLMSessionManager:
                         suffix_len = len(appended_snapshot)
                         if suffix_len <= len(history) and history[-suffix_len:] == appended_snapshot:
                             del history[-suffix_len:]
-                if delivered:
+                if delivered and not interrupted:
                     try:
                         await remove_pending(config_manager, self.lanlan_name)
                     except Exception as exc:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4093,6 +4093,7 @@ class LLMSessionManager:
         delivered = False
         proactive_sid = None
         history_len = None
+        appended_snapshot = None
         try:
             async with self._proactive_write_lock:
                 if self._is_voice_session_active_or_starting():
@@ -4116,15 +4117,19 @@ class LLMSessionManager:
                     delivered = await self.session.prompt_ephemeral(instruction)
                 finally:
                     _proactive_expected_sid.reset(_sid_token)
+                if history_len is not None and isinstance(history, list) and len(history) > history_len:
+                    appended_snapshot = list(history[history_len:])
                 logger.info("[%s] trigger_new_character_greeting: delivered=%s", self.lanlan_name, delivered)
         finally:
             try:
                 interrupted = bool(proactive_sid) and self.current_speech_id != proactive_sid
                 if (not delivered or interrupted) and history_len is not None:
                     history = getattr(self.session, "_conversation_history", None)
-                    if isinstance(history, list) and len(history) > history_len:
-                        del history[history_len:]
-                if delivered and proactive_sid and self.current_speech_id == proactive_sid:
+                    if isinstance(history, list) and appended_snapshot:
+                        suffix_len = len(appended_snapshot)
+                        if suffix_len <= len(history) and history[-suffix_len:] == appended_snapshot:
+                            del history[-suffix_len:]
+                if delivered:
                     try:
                         await remove_pending(config_manager, self.lanlan_name)
                     except Exception as exc:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -114,12 +114,13 @@ logger = get_module_logger(__name__, "Main")
 CHARACTER_RESERVED_FIELD_SET = set(CHARACTER_RESERVED_FIELDS)
 
 
-async def _mark_new_character_greeting_pending_safe(config_manager, character_name: str, source: str) -> None:
+async def _mark_new_character_greeting_pending_safe(config_manager, character_name: str, source: str) -> bool:
     try:
         await mark_new_character_greeting_pending(config_manager, character_name, source=source)
+        return True
     except Exception:
         logger.exception("mark new character greeting pending failed: %s", character_name)
-        raise
+        return False
 
 
 def _json_no_store_response(content, *, status_code: int = 200):
@@ -2364,7 +2365,7 @@ async def add_catgirl(request: Request):
 
     characters['猫娘'][key] = catgirl_data
     await _config_manager.asave_characters(characters)
-    await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
+    pending_mark_ok = await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
 
     # Fast path：新增只需为 `key` 这一个 catgirl 分配资源 + 启动线程，不影响其它角色。
     init_one_catgirl = get_init_one_catgirl()
@@ -2372,11 +2373,15 @@ async def add_catgirl(request: Request):
 
     memory_server_reloaded = await notify_memory_server_reload(reason=f"新角色: {key}")
 
-    return {
+    response: dict = {
         "success": True,
         "character_name": key,
         "memory_server_reloaded": memory_server_reloaded,
     }
+    if not pending_mark_ok:
+        response["partial_success"] = True
+        response["pending_mark_failed"] = True
+    return response
 
 
 @router.put('/catgirl/{name}')
@@ -4007,15 +4012,21 @@ async def save_character_card(request: Request):
         await _config_manager.asave_characters(characters)
 
         if is_new_character:
-            await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
-        
+            pending_mark_ok = await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
+        else:
+            pending_mark_ok = True
+
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
         if initialize_character_data:
             await initialize_character_data()
 
         logger.info(f"角色卡已成功保存到characters.json: {chara_name}")
-        return {"success": True, "character_card_name": chara_name}
+        result: dict = {"success": True, "character_card_name": chara_name}
+        if not pending_mark_ok:
+            result["partial_success"] = True
+            result["pending_mark_failed"] = True
+        return result
     except Exception as e:
         logger.error(f"保存角色卡到characters.json失败: {e}")
         return JSONResponse({"success": False, "error": str(e)}, status_code=500)
@@ -4731,7 +4742,7 @@ async def import_character_card(
 
             # 保存到文件
             await _config_manager.asave_characters(characters)
-            await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
+            pending_mark_ok = await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
 
             # 刷新内存中的角色数据，确保磁盘和内存同步
             initialize_character_data = get_initialize_character_data()
@@ -4805,11 +4816,15 @@ async def import_character_card(
             except Exception as face_err:
                 logger.warning(f"[导入角色卡] 保存载体 PNG 为卡面失败: {face_err}")
 
-        return JSONResponse({
+        import_result: dict = {
             'success': True,
             'character_name': character_name,
-            'message': f'角色卡 "{character_name}" 导入成功'
-        })
+            'message': f'角色卡 "{character_name}" 导入成功',
+        }
+        if not pending_mark_ok:
+            import_result['partial_success'] = True
+            import_result['pending_mark_failed'] = True
+        return JSONResponse(import_result)
 
     except zipfile.BadZipFile:
         logger.error("导入角色卡失败：无效的ZIP文件")

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -88,6 +88,11 @@ from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.frontend_utils import find_models, find_model_directory, is_user_imported_model
 from utils.language_utils import normalize_language_code
 from utils.logger_config import get_module_logger
+from utils.new_character_greeting_state import (
+    mark_pending as mark_new_character_greeting_pending,
+    remove_pending as remove_new_character_greeting_pending,
+    rename_pending as rename_new_character_greeting_pending,
+)
 from utils.persona_presets import (
     build_persona_override_payload,
     get_persona_preset,
@@ -107,6 +112,13 @@ logger = get_module_logger(__name__, "Main")
 
 
 CHARACTER_RESERVED_FIELD_SET = set(CHARACTER_RESERVED_FIELDS)
+
+
+async def _mark_new_character_greeting_pending_safe(config_manager, character_name: str, source: str) -> None:
+    try:
+        await mark_new_character_greeting_pending(config_manager, character_name, source=source)
+    except Exception as exc:
+        logger.warning("mark new character greeting pending failed: %s (%s)", character_name, exc)
 
 
 def _json_no_store_response(content, *, status_code: int = 200):
@@ -1889,6 +1901,11 @@ async def rename_catgirl(old_name: str, request: Request):
         except Exception as e:
             logger.warning(f"发送重命名通知给 {old_name} 失败: {e}")
 
+    try:
+        await rename_new_character_greeting_pending(_config_manager, old_name, new_name)
+    except Exception as exc:
+        logger.warning("rename new character greeting pending failed: %s -> %s (%s)", old_name, new_name, exc)
+
     return {
         "success": True,
         "memory_renamed": True,
@@ -2354,6 +2371,7 @@ async def add_catgirl(request: Request):
     await init_one_catgirl(key, is_new=True)
 
     memory_server_reloaded = await notify_memory_server_reload(reason=f"新角色: {key}")
+    await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
 
     return {
         "success": True,
@@ -2597,6 +2615,11 @@ async def delete_catgirl(name: str):
                 },
                 status_code=500,
             )
+
+    try:
+        await remove_new_character_greeting_pending(_config_manager, name)
+    except Exception as exc:
+        logger.warning("remove new character greeting pending failed: %s (%s)", name, exc)
 
     return {"success": True, "memory_server_reloaded": memory_server_reloaded}
 
@@ -3972,6 +3995,7 @@ async def save_character_card(request: Request):
         if name_error:
             return JSONResponse({"success": False, "error": f"角色名称无效: {name_error}"}, status_code=400)
         chara_name = str(chara_name).strip()
+        is_new_character = chara_name not in characters['猫娘']
         filtered_chara_data = _filter_mutable_catgirl_fields(chara_data)
         
         # 创建猫娘数据，只保存非空字段
@@ -3992,6 +4016,9 @@ async def save_character_card(request: Request):
         if initialize_character_data:
             await initialize_character_data()
         
+        if is_new_character:
+            await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
+
         logger.info(f"角色卡已成功保存到characters.json: {chara_name}")
         return {"success": True, "character_card_name": chara_name}
     except Exception as e:
@@ -4738,6 +4765,7 @@ async def import_character_card(
                 await asyncio.to_thread(_write_card_meta, meta_path, meta)
             except Exception as meta_err:
                 logger.warning(f"[导入角色卡] 写入卡面元数据失败: {meta_err}")
+                await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
                 return JSONResponse({
                     "success": True,
                     "error": f"角色数据已导入，但卡面元数据写入失败: {meta_err}",
@@ -4782,6 +4810,7 @@ async def import_character_card(
             except Exception as face_err:
                 logger.warning(f"[导入角色卡] 保存载体 PNG 为卡面失败: {face_err}")
 
+        await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
         return JSONResponse({
             'success': True,
             'character_name': character_name,

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -117,8 +117,9 @@ CHARACTER_RESERVED_FIELD_SET = set(CHARACTER_RESERVED_FIELDS)
 async def _mark_new_character_greeting_pending_safe(config_manager, character_name: str, source: str) -> None:
     try:
         await mark_new_character_greeting_pending(config_manager, character_name, source=source)
-    except Exception as exc:
-        logger.warning("mark new character greeting pending failed: %s (%s)", character_name, exc)
+    except Exception:
+        logger.exception("mark new character greeting pending failed: %s", character_name)
+        raise
 
 
 def _json_no_store_response(content, *, status_code: int = 200):
@@ -1870,6 +1871,8 @@ async def rename_catgirl(old_name: str, request: Request):
                     },
                     status_code=500,
                 )
+
+            await rename_new_character_greeting_pending(_config_manager, old_name, new_name)
         except MaintenanceModeError as exc:
             rollback_error = await _rollback_character_operation(
                 _config_manager,
@@ -1900,11 +1903,6 @@ async def rename_catgirl(old_name: str, request: Request):
             logger.info(f"已向 {old_name} 发送重命名通知")
         except Exception as e:
             logger.warning(f"发送重命名通知给 {old_name} 失败: {e}")
-
-    try:
-        await rename_new_character_greeting_pending(_config_manager, old_name, new_name)
-    except Exception as exc:
-        logger.warning("rename new character greeting pending failed: %s -> %s (%s)", old_name, new_name, exc)
 
     return {
         "success": True,
@@ -2585,6 +2583,7 @@ async def delete_catgirl(name: str):
             memory_server_reloaded = await notify_memory_server_reload(reason=f"删除角色: {name}")
             if not memory_server_reloaded:
                 raise RuntimeError("notify_memory_server_reload returned False")
+            await remove_new_character_greeting_pending(_config_manager, name)
         except MaintenanceModeError as exc:
             rollback_error = await _rollback_character_operation(
                 _config_manager,
@@ -2616,11 +2615,6 @@ async def delete_catgirl(name: str):
                 },
                 status_code=500,
             )
-
-    try:
-        await remove_new_character_greeting_pending(_config_manager, name)
-    except Exception as exc:
-        logger.warning("remove new character greeting pending failed: %s (%s)", name, exc)
 
     return {"success": True, "memory_server_reloaded": memory_server_reloaded}
 

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -114,13 +114,13 @@ logger = get_module_logger(__name__, "Main")
 CHARACTER_RESERVED_FIELD_SET = set(CHARACTER_RESERVED_FIELDS)
 
 
-async def _mark_new_character_greeting_pending_safe(config_manager, character_name: str, source: str) -> bool:
+async def _mark_new_character_greeting_pending_safe(config_manager, character_name: str, source: str) -> tuple[bool, str]:
     try:
         await mark_new_character_greeting_pending(config_manager, character_name, source=source)
-        return True
-    except Exception:
+        return True, ""
+    except Exception as exc:
         logger.exception("mark new character greeting pending failed: %s", character_name)
-        return False
+        return False, str(exc)
 
 
 def _json_no_store_response(content, *, status_code: int = 200):
@@ -1873,7 +1873,6 @@ async def rename_catgirl(old_name: str, request: Request):
                     status_code=500,
                 )
 
-            await rename_new_character_greeting_pending(_config_manager, old_name, new_name)
         except MaintenanceModeError as exc:
             rollback_error = await _rollback_character_operation(
                 _config_manager,
@@ -1905,11 +1904,26 @@ async def rename_catgirl(old_name: str, request: Request):
         except Exception as e:
             logger.warning(f"发送重命名通知给 {old_name} 失败: {e}")
 
-    return {
+    pending_rename_ok = True
+    pending_rename_error = ""
+    try:
+        await rename_new_character_greeting_pending(_config_manager, old_name, new_name)
+    except Exception as exc:
+        pending_rename_ok = False
+        pending_rename_error = str(exc)
+        logger.exception("rename new character greeting pending failed: %s -> %s", old_name, new_name)
+
+    result = {
         "success": True,
         "memory_renamed": True,
         "memory_server_reloaded": memory_server_reloaded,
     }
+    if not pending_rename_ok:
+        result["partial_success"] = True
+        result["pending_rename_ok"] = False
+        result["pending_rename_failed"] = True
+        result["pending_rename_error"] = pending_rename_error
+    return result
 
 
 @router.post('/catgirl/{name}/unregister_voice')
@@ -2365,7 +2379,7 @@ async def add_catgirl(request: Request):
 
     characters['猫娘'][key] = catgirl_data
     await _config_manager.asave_characters(characters)
-    pending_mark_ok = await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
+    pending_mark_ok, pending_mark_error = await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
 
     # Fast path：新增只需为 `key` 这一个 catgirl 分配资源 + 启动线程，不影响其它角色。
     init_one_catgirl = get_init_one_catgirl()
@@ -2380,7 +2394,9 @@ async def add_catgirl(request: Request):
     }
     if not pending_mark_ok:
         response["partial_success"] = True
+        response["pending_mark_ok"] = False
         response["pending_mark_failed"] = True
+        response["pending_mark_error"] = pending_mark_error
     return response
 
 
@@ -2588,7 +2604,6 @@ async def delete_catgirl(name: str):
             memory_server_reloaded = await notify_memory_server_reload(reason=f"删除角色: {name}")
             if not memory_server_reloaded:
                 raise RuntimeError("notify_memory_server_reload returned False")
-            await remove_new_character_greeting_pending(_config_manager, name)
         except MaintenanceModeError as exc:
             rollback_error = await _rollback_character_operation(
                 _config_manager,
@@ -2621,7 +2636,22 @@ async def delete_catgirl(name: str):
                 status_code=500,
             )
 
-    return {"success": True, "memory_server_reloaded": memory_server_reloaded}
+    pending_remove_ok = True
+    pending_remove_error = ""
+    try:
+        await remove_new_character_greeting_pending(_config_manager, name)
+    except Exception as exc:
+        pending_remove_ok = False
+        pending_remove_error = str(exc)
+        logger.exception("remove new character greeting pending failed: %s", name)
+
+    result = {"success": True, "memory_server_reloaded": memory_server_reloaded}
+    if not pending_remove_ok:
+        result["partial_success"] = True
+        result["pending_remove_ok"] = False
+        result["pending_remove_failed"] = True
+        result["pending_remove_error"] = pending_remove_error
+    return result
 
 @router.post('/clear_voice_ids')
 async def clear_voice_ids():
@@ -4012,9 +4042,10 @@ async def save_character_card(request: Request):
         await _config_manager.asave_characters(characters)
 
         if is_new_character:
-            pending_mark_ok = await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
+            pending_mark_ok, pending_mark_error = await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
         else:
             pending_mark_ok = True
+            pending_mark_error = ""
 
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
@@ -4025,7 +4056,9 @@ async def save_character_card(request: Request):
         result: dict = {"success": True, "character_card_name": chara_name}
         if not pending_mark_ok:
             result["partial_success"] = True
+            result["pending_mark_ok"] = False
             result["pending_mark_failed"] = True
+            result["pending_mark_error"] = pending_mark_error
         return result
     except Exception as e:
         logger.error(f"保存角色卡到characters.json失败: {e}")
@@ -4742,7 +4775,7 @@ async def import_character_card(
 
             # 保存到文件
             await _config_manager.asave_characters(characters)
-            pending_mark_ok = await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
+            pending_mark_ok, pending_mark_error = await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
 
             # 刷新内存中的角色数据，确保磁盘和内存同步
             initialize_character_data = get_initialize_character_data()
@@ -4772,12 +4805,18 @@ async def import_character_card(
                 await asyncio.to_thread(_write_card_meta, meta_path, meta)
             except Exception as meta_err:
                 logger.warning(f"[导入角色卡] 写入卡面元数据失败: {meta_err}")
-                return JSONResponse({
+                partial_result = {
                     "success": True,
+                    "partial_success": True,
                     "error": f"角色数据已导入，但卡面元数据写入失败: {meta_err}",
                     "card_meta_saved": False,
                     "character_name": character_name,
-                }, status_code=200)
+                    "pending_mark_ok": pending_mark_ok,
+                }
+                if not pending_mark_ok:
+                    partial_result["pending_mark_failed"] = True
+                    partial_result["pending_mark_error"] = pending_mark_error
+                return JSONResponse(partial_result, status_code=200)
 
             # 老角色卡兼容：如果前端上传了载体 PNG，且本地还没有同名卡面，
             # 则直接使用该 PNG 作为卡面（带 neKo chunk 不影响质量）。
@@ -4823,7 +4862,9 @@ async def import_character_card(
         }
         if not pending_mark_ok:
             import_result['partial_success'] = True
+            import_result['pending_mark_ok'] = False
             import_result['pending_mark_failed'] = True
+            import_result['pending_mark_error'] = pending_mark_error
         return JSONResponse(import_result)
 
     except zipfile.BadZipFile:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2366,12 +2366,13 @@ async def add_catgirl(request: Request):
 
     characters['猫娘'][key] = catgirl_data
     await _config_manager.asave_characters(characters)
+    await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
+
     # Fast path：新增只需为 `key` 这一个 catgirl 分配资源 + 启动线程，不影响其它角色。
     init_one_catgirl = get_init_one_catgirl()
     await init_one_catgirl(key, is_new=True)
 
     memory_server_reloaded = await notify_memory_server_reload(reason=f"新角色: {key}")
-    await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
 
     return {
         "success": True,
@@ -4010,14 +4011,14 @@ async def save_character_card(request: Request):
         
         # 保存到characters.json
         await _config_manager.asave_characters(characters)
+
+        if is_new_character:
+            await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
         
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
         if initialize_character_data:
             await initialize_character_data()
-        
-        if is_new_character:
-            await _mark_new_character_greeting_pending_safe(_config_manager, chara_name, "character_card_save")
 
         logger.info(f"角色卡已成功保存到characters.json: {chara_name}")
         return {"success": True, "character_card_name": chara_name}
@@ -4736,6 +4737,7 @@ async def import_character_card(
 
             # 保存到文件
             await _config_manager.asave_characters(characters)
+            await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
 
             # 刷新内存中的角色数据，确保磁盘和内存同步
             initialize_character_data = get_initialize_character_data()
@@ -4765,7 +4767,6 @@ async def import_character_card(
                 await asyncio.to_thread(_write_card_meta, meta_path, meta)
             except Exception as meta_err:
                 logger.warning(f"[导入角色卡] 写入卡面元数据失败: {meta_err}")
-                await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
                 return JSONResponse({
                     "success": True,
                     "error": f"角色数据已导入，但卡面元数据写入失败: {meta_err}",
@@ -4810,7 +4811,6 @@ async def import_character_card(
             except Exception as face_err:
                 logger.warning(f"[导入角色卡] 保存载体 PNG 为卡面失败: {face_err}")
 
-        await _mark_new_character_greeting_pending_safe(_config_manager, character_name, "import")
         return JSONResponse({
             'success': True,
             'character_name': character_name,

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -19,6 +19,7 @@ import uuid
 import asyncio
 
 from utils.logger_config import get_module_logger
+from utils.new_character_greeting_state import has_pending as has_new_character_greeting_pending
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from .shared_state import (
@@ -193,8 +194,12 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                 last_disconnect = _ws_disconnect_time.get(lanlan_name, 0)
                 since_disconnect = _time.time() - last_disconnect if last_disconnect else float('inf')
                 if is_switch or since_disconnect > 15:
-                    logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s → triggering")
-                    _fire_task(session_manager[lanlan_name].trigger_greeting())
+                    if await has_new_character_greeting_pending(_config_manager, lanlan_name):
+                        logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s → new character greeting")
+                        _fire_task(session_manager[lanlan_name].trigger_new_character_greeting())
+                    else:
+                        logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s → triggering")
+                        _fire_task(session_manager[lanlan_name].trigger_greeting())
                 else:
                     logger.info(f"[{lanlan_name}] greeting_check: since_disconnect={since_disconnect:.1f}s ≤15s → skip (refresh/reconnect)")
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -17,6 +17,8 @@
     const S = window.appState;
     const C = window.appConst;
     const USER_ACTIVITY_CANCEL_GRACE_MS = 700;
+    const GREETING_CHECK_RETRY_BASE_MS = 800;
+    const GREETING_CHECK_RETRY_MAX_MS = 5000;
     let _pendingUserActivityCancelTimer = 0;
     let _pendingUserActivityCancelTurnId = null;
 
@@ -574,6 +576,7 @@
             console.log(window.t('console.heartbeatStarted'));
 
             // ── 首次连接 / 切换角色：标记 greeting 意图，若模型已就绪则立即发送 ──
+            _resetGreetingCheckRetry(true);
             S._greetingCheckPending = true;
             S._greetingCheckIsSwitch = !!S._pendingGreetingSwitch;
             S._pendingGreetingSwitch = false;
@@ -2001,7 +2004,6 @@
     }
     function _isGreetingCheckBlocked() {
         if (!S.socket || S.socket.readyState !== WebSocket.OPEN) return true;
-        if (window.location && /^\/chat(?:\/|$)/.test(window.location.pathname || '')) return true;
         if (_isTutorialBlockingGreeting()) return true;
         if (S.isRecording || S.isPlaying) return true;
         if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
@@ -2017,17 +2019,29 @@
             '.storage-location-modal'
         ]);
     }
+    function _resetGreetingCheckRetry(clearTimer) {
+        S._greetingCheckRetryDelay = 0;
+        if (clearTimer && S._greetingCheckRetryTimer) {
+            clearTimeout(S._greetingCheckRetryTimer);
+            S._greetingCheckRetryTimer = 0;
+        }
+    }
     function _scheduleGreetingCheckRetry() {
         if (S._greetingCheckRetryTimer) {
             clearTimeout(S._greetingCheckRetryTimer);
         }
+        var delay = Number(S._greetingCheckRetryDelay) || GREETING_CHECK_RETRY_BASE_MS;
+        S._greetingCheckRetryDelay = Math.min(delay * 2, GREETING_CHECK_RETRY_MAX_MS);
         S._greetingCheckRetryTimer = setTimeout(function () {
             S._greetingCheckRetryTimer = 0;
             _sendGreetingCheckIfReady();
-        }, 800);
+        }, delay);
     }
     function _sendGreetingCheckIfReady() {
-        if (!S._greetingCheckPending || !S._modelReady) return;
+        if (!S._greetingCheckPending || !S._modelReady) {
+            if (!S._greetingCheckPending) _resetGreetingCheckRetry(true);
+            return;
+        }
         if (_isGreetingCheckBlocked()) {
             _scheduleGreetingCheckRetry();
             return;
@@ -2040,10 +2054,7 @@
                     language: (window.i18next && window.i18next.language) || ''
                 }));
                 S._greetingCheckPending = false;
-                if (S._greetingCheckRetryTimer) {
-                    clearTimeout(S._greetingCheckRetryTimer);
-                    S._greetingCheckRetryTimer = 0;
-                }
+                _resetGreetingCheckRetry(true);
                 console.log('[greeting_check] sent, is_switch=' + !!S._greetingCheckIsSwitch);
             }
         } catch (e) {

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1980,7 +1980,16 @@
         }
         return false;
     }
+    function _isHomeTutorialPage() {
+        if (window.location && typeof window.location.pathname === 'string') {
+            var path = window.location.pathname || '/';
+            return path === '/' || path === '/index.html';
+        }
+        var manager = window.universalTutorialManager || null;
+        return !!(manager && manager.currentPage === 'home');
+    }
     function _isTutorialBlockingGreeting() {
+        if (!_isHomeTutorialPage()) return false;
         try {
             if (typeof window.isNekoHomeTutorialBlockingGreeting === 'function'
                     && window.isNekoHomeTutorialBlockingGreeting() === true) {

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1962,9 +1962,67 @@
     // ========================  Greeting check (after model loaded)  ========================
     // 需要 WS 已连接 AND 模型已加载 两个条件同时满足才发送，
     // 无论哪个先就绪都由后到的那个触发。
+    function _isElementVisible(el) {
+        if (!el || el.hidden) return false;
+        var style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+        if (style && (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0')) {
+            return false;
+        }
+        var rect = el.getBoundingClientRect ? el.getBoundingClientRect() : null;
+        return !rect || rect.width > 0 || rect.height > 0;
+    }
+    function _hasVisibleGreetingBlocker(selectors) {
+        for (var i = 0; i < selectors.length; i += 1) {
+            var nodes = document.querySelectorAll(selectors[i]);
+            for (var j = 0; j < nodes.length; j += 1) {
+                if (_isElementVisible(nodes[j])) return true;
+            }
+        }
+        return false;
+    }
+    function _isTutorialBlockingGreeting() {
+        try {
+            if (typeof window.isNekoHomeTutorialBlockingGreeting === 'function'
+                    && window.isNekoHomeTutorialBlockingGreeting() === true) {
+                return true;
+            }
+        } catch (_) {}
+        return window.isInTutorial === true
+            || !!(window.universalTutorialManager && window.universalTutorialManager.isTutorialRunning);
+    }
+    function _isGreetingCheckBlocked() {
+        if (!S.socket || S.socket.readyState !== WebSocket.OPEN) return true;
+        if (window.location && /^\/chat(?:\/|$)/.test(window.location.pathname || '')) return true;
+        if (_isTutorialBlockingGreeting()) return true;
+        if (S.isRecording || S.isPlaying) return true;
+        if (S.assistantTurnId && S.assistantTurnId !== S.assistantTurnCompletedId) return true;
+        if (S.assistantTurnAwaitingBubble || S.assistantSpeechActiveTurnId) return true;
+        return _hasVisibleGreetingBlocker([
+            '#prominent-notice-overlay',
+            '.modal-overlay',
+            '.modal-dialog',
+            '.driver-popover',
+            '.driver-overlay',
+            '.storage-location-completion-card',
+            '#storage-location-overlay',
+            '.storage-location-modal'
+        ]);
+    }
+    function _scheduleGreetingCheckRetry() {
+        if (S._greetingCheckRetryTimer) {
+            clearTimeout(S._greetingCheckRetryTimer);
+        }
+        S._greetingCheckRetryTimer = setTimeout(function () {
+            S._greetingCheckRetryTimer = 0;
+            _sendGreetingCheckIfReady();
+        }, 800);
+    }
     function _sendGreetingCheckIfReady() {
         if (!S._greetingCheckPending || !S._modelReady) return;
-        S._greetingCheckPending = false;
+        if (_isGreetingCheckBlocked()) {
+            _scheduleGreetingCheckRetry();
+            return;
+        }
         try {
             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
                 S.socket.send(JSON.stringify({
@@ -1972,10 +2030,16 @@
                     is_switch: !!S._greetingCheckIsSwitch,
                     language: (window.i18next && window.i18next.language) || ''
                 }));
+                S._greetingCheckPending = false;
+                if (S._greetingCheckRetryTimer) {
+                    clearTimeout(S._greetingCheckRetryTimer);
+                    S._greetingCheckRetryTimer = 0;
+                }
                 console.log('[greeting_check] sent, is_switch=' + !!S._greetingCheckIsSwitch);
             }
         } catch (e) {
             console.warn('[greeting_check] send failed:', e);
+            _scheduleGreetingCheckRetry();
         }
     }
     function _onModelReady() {

--- a/utils/new_character_greeting_state.py
+++ b/utils/new_character_greeting_state.py
@@ -1,0 +1,105 @@
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from utils.file_utils import atomic_write_json_async, read_json_async
+from utils.logger_config import get_module_logger
+
+
+logger = get_module_logger(__name__, "Main")
+
+STATE_VERSION = 1
+STATE_FILENAME = "new_character_greeting_state.json"
+
+_lock = asyncio.Lock()
+
+
+def _state_path(config_manager) -> Path:
+    root = getattr(config_manager, "local_state_dir", None)
+    if root is None:
+        root = Path(getattr(config_manager, "app_docs_dir", ".")) / "state"
+    return Path(root) / STATE_FILENAME
+
+
+def _empty_state() -> dict[str, Any]:
+    return {"version": STATE_VERSION, "pending": {}}
+
+
+def _normalize_state(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return _empty_state()
+    pending = raw.get("pending")
+    if not isinstance(pending, dict):
+        pending = {}
+    return {"version": STATE_VERSION, "pending": dict(pending)}
+
+
+async def _load_state(config_manager) -> dict[str, Any]:
+    path = _state_path(config_manager)
+    if not await asyncio.to_thread(path.exists):
+        return _empty_state()
+    try:
+        return _normalize_state(await read_json_async(path))
+    except Exception as exc:
+        logger.warning("load new character greeting state failed: %s", exc)
+        return _empty_state()
+
+
+async def _save_state(config_manager, state: dict[str, Any]) -> None:
+    path = _state_path(config_manager)
+    await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+    await atomic_write_json_async(path, _normalize_state(state), ensure_ascii=False, indent=2)
+
+
+def _clean_name(character_name: str) -> str:
+    return str(character_name or "").strip()
+
+
+async def mark_pending(config_manager, character_name: str, source: str = "") -> None:
+    name = _clean_name(character_name)
+    if not name:
+        return
+    async with _lock:
+        state = await _load_state(config_manager)
+        pending = state.setdefault("pending", {})
+        pending[name] = {
+            "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "source": str(source or "").strip(),
+        }
+        await _save_state(config_manager, state)
+
+
+async def has_pending(config_manager, character_name: str) -> bool:
+    name = _clean_name(character_name)
+    if not name:
+        return False
+    async with _lock:
+        state = await _load_state(config_manager)
+        return name in state.get("pending", {})
+
+
+async def remove_pending(config_manager, character_name: str) -> None:
+    name = _clean_name(character_name)
+    if not name:
+        return
+    async with _lock:
+        state = await _load_state(config_manager)
+        pending = state.setdefault("pending", {})
+        if name in pending:
+            pending.pop(name, None)
+            await _save_state(config_manager, state)
+
+
+async def rename_pending(config_manager, old_name: str, new_name: str) -> None:
+    old = _clean_name(old_name)
+    new = _clean_name(new_name)
+    if not old or not new or old == new:
+        return
+    async with _lock:
+        state = await _load_state(config_manager)
+        pending = state.setdefault("pending", {})
+        if old not in pending:
+            return
+        pending[new] = pending.pop(old)
+        await _save_state(config_manager, state)

--- a/utils/new_character_greeting_state.py
+++ b/utils/new_character_greeting_state.py
@@ -16,10 +16,7 @@ _lock = asyncio.Lock()
 
 
 def _state_path(config_manager) -> Path:
-    root = getattr(config_manager, "local_state_dir", None)
-    if root is None:
-        root = Path(getattr(config_manager, "app_docs_dir", ".")) / "state"
-    return Path(root) / STATE_FILENAME
+    return Path(config_manager.local_state_dir) / STATE_FILENAME
 
 
 def _empty_state() -> dict[str, Any]:


### PR DESCRIPTION
新增新角色首次问候 prompt，支持多语言。
新增首次问候 pending 状态管理，用于记录、重命名和清理待问候角色。
在创建、保存、导入角色卡时标记首次问候状态。
WebSocket 问候检查时优先触发新角色首次问候，否则走原有主动问候逻辑。
前端在模型加载完成后增加阻塞检测，避开录音、播放、弹窗、首页新手引导等场景，并自动重试发送问候检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 添加多语言“首次出现角色”问候模板（中文/英文/日文/韩文/俄文）并实现语言回退。
  * 引入可持久化的“首次问候待办”状态，支持标记、查询、重命名与清除。
  * 在存在待办时触发并交付主动问候。

* **修复**
  * 提升问候交付可靠性：更稳健的中断处理与会话历史回滚。
  * 后端在问候状态写入失败时返回 partial_success，不影响主要操作成功。
  * 客户端问候检查添加可见性/状态阻塞与指数退避重试，减少误触发与丢失。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->