### PR TITLE
Add retake button to avatar cropper

### DIFF
--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -505,13 +505,24 @@
 
     var cropperState = null;
 
-    function openAvatarCropper(sourceDataUrl, defaultCropRect, sourceWidth, sourceHeight) {
+    function measureImageDataUrl(dataUrl) {
         return new Promise(function (resolve) {
+            var tmp = new Image();
+            tmp.onload = function () { resolve({ w: tmp.naturalWidth || 640, h: tmp.naturalHeight || 640 }); };
+            tmp.onerror = function () { resolve({ w: 640, h: 640 }); };
+            tmp.src = dataUrl;
+        });
+    }
+
+    function openAvatarCropper(sourceDataUrl, defaultCropRect, sourceWidth, sourceHeight, options) {
+        return new Promise(function (resolve) {
+            options = options || {};
             var popup = S.dom.chatAvatarPreviewCard;
             var wrap = document.getElementById('avatar-cropper-wrap');
             var img = document.getElementById('avatar-cropper-img');
             var svgMask = document.getElementById('avatar-cropper-mask');
             var cropBox = document.getElementById('avatar-cropper-box');
+            var retakeBtn = document.getElementById('avatar-cropper-retake');
             var cancelBtn = document.getElementById('avatar-cropper-cancel');
             var saveBtn = document.getElementById('avatar-cropper-save');
 
@@ -520,11 +531,18 @@
                 return;
             }
 
+            var currentSourceDataUrl = sourceDataUrl;
+            var currentDefaultCropRect = defaultCropRect;
+            var currentSourceWidth = sourceWidth;
+            var currentSourceHeight = sourceHeight;
+            var currentModelType = options.modelType || getCurrentModelType();
+            var recaptureFn = typeof options.recaptureFn === 'function' ? options.recaptureFn : null;
             var displayW, displayH, scaleRatio;
             var crop = { x: 0, y: 0, size: 0 };
             var MIN_SIZE = 40;
             var settled = false;
             var drag = null;
+            var recapturing = false;
 
             function initLayout() {
                 // 计算可用宽度：需扣除控制面板宽度、弹窗 padding/border
@@ -537,27 +555,27 @@
                 var maxW = Math.min(360, popupContentW - controlsWidth - areaGap);
                 if (maxW < MIN_SIZE) maxW = MIN_SIZE;
                 var maxH = Math.min(360, window.innerHeight - 180);
-                var aspect = sourceWidth / sourceHeight;
+                var aspect = currentSourceWidth / currentSourceHeight;
                 if (aspect >= 1) {
-                    displayW = Math.min(maxW, sourceWidth);
+                    displayW = Math.min(maxW, currentSourceWidth);
                     displayH = Math.round(displayW / aspect);
                     if (displayH > maxH) { displayH = maxH; displayW = Math.round(displayH * aspect); }
                 } else {
-                    displayH = Math.min(maxH, sourceHeight);
+                    displayH = Math.min(maxH, currentSourceHeight);
                     displayW = Math.round(displayH * aspect);
                     if (displayW > maxW) { displayW = maxW; displayH = Math.round(displayW / aspect); }
                 }
-                scaleRatio = sourceWidth / displayW;
+                scaleRatio = currentSourceWidth / displayW;
                 img.style.width = displayW + 'px';
                 img.style.height = displayH + 'px';
                 wrap.style.width = displayW + 'px';
                 wrap.style.height = displayH + 'px';
 
-                if (defaultCropRect) {
-                    var rX = defaultCropRect.x || 0;
-                    var rY = defaultCropRect.y || 0;
-                    var rW = defaultCropRect.width || defaultCropRect.size || 0;
-                    var rH = defaultCropRect.height || defaultCropRect.size || 0;
+                if (currentDefaultCropRect) {
+                    var rX = currentDefaultCropRect.x || 0;
+                    var rY = currentDefaultCropRect.y || 0;
+                    var rW = currentDefaultCropRect.width || currentDefaultCropRect.size || 0;
+                    var rH = currentDefaultCropRect.height || currentDefaultCropRect.size || 0;
                     if (rW > rH) { rX += Math.round((rW - rH) / 2); rW = rH; }
                     else if (rH > rW) { rY += Math.round((rH - rW) / 2); rH = rW; }
                     crop.size = Math.round(rW / scaleRatio);
@@ -570,6 +588,18 @@
                 }
                 clampCrop();
                 renderCrop();
+            }
+
+            function applySource(next) {
+                currentSourceDataUrl = next.sourceDataUrl;
+                currentDefaultCropRect = next.cropRectPixels || null;
+                currentSourceWidth = next.sourceWidth || currentSourceWidth || 640;
+                currentSourceHeight = next.sourceHeight || currentSourceHeight || 640;
+                currentModelType = next.modelType || currentModelType || getCurrentModelType();
+                drag = null;
+                img.src = currentSourceDataUrl;
+                initLayout();
+                positionPopupNearTrigger(popup, activeTrigger);
             }
 
             function clampCrop() {
@@ -654,6 +684,7 @@
                 document.removeEventListener('pointerup', onPointerUp);
                 wrap.removeEventListener('pointerdown', onPointerDown);
                 wrap.removeEventListener('wheel', onWheel);
+                if (retakeBtn) retakeBtn.removeEventListener('click', onRetake);
                 if (cancelBtn) cancelBtn.removeEventListener('click', onCancel);
                 if (saveBtn) saveBtn.removeEventListener('click', onSave);
                 if (cropperState && cropperState.controlsEl) {
@@ -669,9 +700,13 @@
                 cleanup();
                 if (accepted) {
                     resolve({
-                        x: Math.round(crop.x * scaleRatio),
-                        y: Math.round(crop.y * scaleRatio),
-                        size: Math.round(crop.size * scaleRatio)
+                        cropRect: {
+                            x: Math.round(crop.x * scaleRatio),
+                            y: Math.round(crop.y * scaleRatio),
+                            size: Math.round(crop.size * scaleRatio)
+                        },
+                        sourceDataUrl: currentSourceDataUrl,
+                        modelType: currentModelType
                     });
                 } else {
                     resolve(null);
@@ -680,6 +715,35 @@
 
             function onCancel() { finish(false); }
             function onSave() { finish(true); }
+
+            async function onRetake() {
+                if (!recaptureFn || recapturing || settled) return;
+                recapturing = true;
+                if (retakeBtn) retakeBtn.disabled = true;
+                if (saveBtn) saveBtn.disabled = true;
+                setPreviewStatus(translateLabel('chat.avatarCropRetaking', '正在重新拍照...'));
+                setPreviewNote(translateLabel('chat.avatarPreviewCardNote', '将基于当前显示中的 Live2D / VRM / MMD 模型生成头像。'));
+                try {
+                    var next = await recaptureFn();
+                    if (settled) return;
+                    if (!next || !next.sourceDataUrl) {
+                        throw new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
+                    }
+                    applySource(next);
+                    setPreviewStatus(translateLabel('chat.avatarPreviewCropping', '请调整裁剪区域'));
+                } catch (error) {
+                    if (!settled) {
+                        setPreviewStatus(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
+                        setPreviewNote(getErrorMessage(error));
+                    }
+                } finally {
+                    recapturing = false;
+                    if (!settled) {
+                        if (retakeBtn) retakeBtn.disabled = false;
+                        if (saveBtn) saveBtn.disabled = false;
+                    }
+                }
+            }
 
             var MOVE_STEP = 10;
             var SIZE_STEP_RATIO = 0.1;
@@ -725,11 +789,15 @@
 
             var controlsEl = popup.querySelector('.avatar-cropper-controls');
 
-            img.src = sourceDataUrl;
+            img.src = currentSourceDataUrl;
             wrap.addEventListener('pointerdown', onPointerDown);
             wrap.addEventListener('wheel', onWheel, { passive: false });
             document.addEventListener('pointermove', onPointerMove);
             document.addEventListener('pointerup', onPointerUp);
+            if (retakeBtn) {
+                retakeBtn.hidden = !recaptureFn;
+                retakeBtn.addEventListener('click', onRetake);
+            }
             cancelBtn.addEventListener('click', onCancel);
             saveBtn.addEventListener('click', onSave);
             if (controlsEl) controlsEl.addEventListener('click', onCtrlAction);
@@ -834,20 +902,36 @@
                 setLoadingState(false);
                 setPreviewStatus(translateLabel('chat.avatarPreviewCropping', '请调整裁剪区域'));
 
-                var srcDims = await new Promise(function (res) {
-                    var tmp = new Image();
-                    tmp.onload = function () { res({ w: tmp.naturalWidth, h: tmp.naturalHeight }); };
-                    tmp.onerror = function () { res({ w: 640, h: 640 }); };
-                    tmp.src = result.sourceDataUrl;
-                });
+                var srcDims = await measureImageDataUrl(result.sourceDataUrl);
                 var defRect = result.cropRectPixels || null;
 
-                var userCrop = await openAvatarCropper(result.sourceDataUrl, defRect, srcDims.w, srcDims.h);
+                async function recaptureCropperSource() {
+                    var fresh = await captureAvatarPreview({ includeSourceDataUrl: true });
+                    if (!fresh || !fresh.sourceDataUrl) {
+                        throw new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
+                    }
+                    var dims = await measureImageDataUrl(fresh.sourceDataUrl);
+                    return {
+                        sourceDataUrl: fresh.sourceDataUrl,
+                        cropRectPixels: fresh.cropRectPixels || null,
+                        sourceWidth: dims.w,
+                        sourceHeight: dims.h,
+                        modelType: fresh.modelType || getCurrentModelType()
+                    };
+                }
+
+                var userCrop = await openAvatarCropper(result.sourceDataUrl, defRect, srcDims.w, srcDims.h, {
+                    modelType: result.modelType || getCurrentModelType(),
+                    recaptureFn: recaptureCropperSource
+                });
                 if (token !== activeCaptureToken) return;
 
                 if (userCrop) {
-                    var croppedDataUrl = await cropSourceToAvatar(result.sourceDataUrl, userCrop);
-                    applyPreviewResult({ dataUrl: croppedDataUrl, modelType: result.modelType }, cacheKey);
+                    var croppedDataUrl = await cropSourceToAvatar(userCrop.sourceDataUrl, userCrop.cropRect);
+                    applyPreviewResult(
+                        { dataUrl: croppedDataUrl, modelType: userCrop.modelType || result.modelType },
+                        getCurrentModelCacheKey() || cacheKey
+                    );
                 } else {
                     if (prevCachedPreview) {
                         cachedPreview = prevCachedPreview;

--- a/static/app-chat-avatar.js
+++ b/static/app-chat-avatar.js
@@ -536,6 +536,7 @@
             var currentSourceWidth = sourceWidth;
             var currentSourceHeight = sourceHeight;
             var currentModelType = options.modelType || getCurrentModelType();
+            var currentCacheKey = options.cacheKey || getCurrentModelCacheKey();
             var recaptureFn = typeof options.recaptureFn === 'function' ? options.recaptureFn : null;
             var displayW, displayH, scaleRatio;
             var crop = { x: 0, y: 0, size: 0 };
@@ -596,6 +597,7 @@
                 currentSourceWidth = next.sourceWidth || currentSourceWidth || 640;
                 currentSourceHeight = next.sourceHeight || currentSourceHeight || 640;
                 currentModelType = next.modelType || currentModelType || getCurrentModelType();
+                currentCacheKey = next.cacheKey || currentCacheKey || getCurrentModelCacheKey();
                 drag = null;
                 img.src = currentSourceDataUrl;
                 initLayout();
@@ -706,7 +708,8 @@
                             size: Math.round(crop.size * scaleRatio)
                         },
                         sourceDataUrl: currentSourceDataUrl,
-                        modelType: currentModelType
+                        modelType: currentModelType,
+                        cacheKey: currentCacheKey
                     });
                 } else {
                     resolve(null);
@@ -906,6 +909,7 @@
                 var defRect = result.cropRectPixels || null;
 
                 async function recaptureCropperSource() {
+                    var freshCacheKey = getCurrentModelCacheKey();
                     var fresh = await captureAvatarPreview({ includeSourceDataUrl: true });
                     if (!fresh || !fresh.sourceDataUrl) {
                         throw new Error(translateLabel('chat.avatarPreviewFailed', '生成头像失败'));
@@ -916,12 +920,14 @@
                         cropRectPixels: fresh.cropRectPixels || null,
                         sourceWidth: dims.w,
                         sourceHeight: dims.h,
-                        modelType: fresh.modelType || getCurrentModelType()
+                        modelType: fresh.modelType || getCurrentModelType(),
+                        cacheKey: freshCacheKey || getCurrentModelCacheKey()
                     };
                 }
 
                 var userCrop = await openAvatarCropper(result.sourceDataUrl, defRect, srcDims.w, srcDims.h, {
                     modelType: result.modelType || getCurrentModelType(),
+                    cacheKey: cacheKey,
                     recaptureFn: recaptureCropperSource
                 });
                 if (token !== activeCaptureToken) return;
@@ -930,7 +936,7 @@
                     var croppedDataUrl = await cropSourceToAvatar(userCrop.sourceDataUrl, userCrop.cropRect);
                     applyPreviewResult(
                         { dataUrl: croppedDataUrl, modelType: userCrop.modelType || result.modelType },
-                        getCurrentModelCacheKey() || cacheKey
+                        userCrop.cacheKey || cacheKey
                     );
                 } else {
                     if (prevCachedPreview) {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1439,7 +1439,15 @@ body.react-chat-window-dragging {
 .avatar-cropper-buttons {
     display: flex;
     gap: 10px;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.avatar-cropper-decision-buttons {
+    display: flex;
+    gap: 10px;
     justify-content: flex-end;
+    align-items: center;
 }
 
 .avatar-cropper-btn {
@@ -1456,6 +1464,10 @@ body.react-chat-window-dragging {
 .avatar-cropper-btn:hover {
     background: rgba(68, 183, 254, 0.14);
     border-color: rgba(68, 183, 254, 0.38);
+}
+.avatar-cropper-btn:disabled {
+    opacity: 0.55;
+    cursor: progress;
 }
 .avatar-cropper-btn.primary {
     background: rgba(68, 183, 254, 0.22);

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "Failed to generate avatar",
         "avatarCropperTitle": "Adjust avatar crop area",
         "avatarPreviewCropping": "Please adjust the crop area",
+        "avatarCropRetake": "Retake photo",
+        "avatarCropRetaking": "Retaking photo...",
         "avatarPreviewCropCancelled": "Manual crop cancelled, keeping the original avatar.",
         "avatarCropMoveUp": "Move up",
         "avatarCropMoveDown": "Move down",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "No se pudo generar avatar",
         "avatarCropperTitle": "Ajustar el área de recorte del avatar",
         "avatarPreviewCropping": "Por favor ajuste el área de recorte",
+        "avatarCropRetake": "Volver a tomar",
+        "avatarCropRetaking": "Volviendo a tomar...",
         "avatarPreviewCropCancelled": "Recorte manual cancelado, manteniendo el avatar original.",
         "avatarCropMoveUp": "Subir",
         "avatarCropMoveDown": "Bajar",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -660,7 +660,7 @@
         "avatarCropperTitle": "アバターの切り抜き範囲を調整",
         "avatarPreviewCropping": "切り抜き範囲を調整してください",
         "avatarCropRetake": "撮り直す",
-        "avatarCropRetaking": "撮り直しています...",
+        "avatarCropRetaking": "再撮影中...",
         "avatarPreviewCropCancelled": "手動切り抜きをキャンセルしました。元のアバターを維持します。",
         "avatarCropMoveUp": "上へ移動",
         "avatarCropMoveDown": "下へ移動",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "アバターの生成に失敗しました",
         "avatarCropperTitle": "アバターの切り抜き範囲を調整",
         "avatarPreviewCropping": "切り抜き範囲を調整してください",
+        "avatarCropRetake": "撮り直す",
+        "avatarCropRetaking": "撮り直しています...",
         "avatarPreviewCropCancelled": "手動切り抜きをキャンセルしました。元のアバターを維持します。",
         "avatarCropMoveUp": "上へ移動",
         "avatarCropMoveDown": "下へ移動",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "아바타 생성 실패",
         "avatarCropperTitle": "아바타 자르기 영역 조정",
         "avatarPreviewCropping": "자르기 영역을 조정하세요",
+        "avatarCropRetake": "다시 촬영",
+        "avatarCropRetaking": "다시 촬영 중...",
         "avatarPreviewCropCancelled": "수동 자르기가 취소되었습니다. 기존 아바타를 유지합니다.",
         "avatarCropMoveUp": "위로 이동",
         "avatarCropMoveDown": "아래로 이동",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "Falha ao gerar avatar",
         "avatarCropperTitle": "Ajustar a área de corte do avatar",
         "avatarPreviewCropping": "Ajuste a área de corte",
+        "avatarCropRetake": "Tirar novamente",
+        "avatarCropRetaking": "Tirando novamente...",
         "avatarPreviewCropCancelled": "Corte manual cancelado, mantendo o avatar original.",
         "avatarCropMoveUp": "Subir",
         "avatarCropMoveDown": "Mover para baixo",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "Не удалось создать аватар",
         "avatarCropperTitle": "Настройка области обрезки аватара",
         "avatarPreviewCropping": "Настройте область обрезки",
+        "avatarCropRetake": "Снять заново",
+        "avatarCropRetaking": "Повторная съемка...",
         "avatarPreviewCropCancelled": "Ручная обрезка отменена. Аватар остаётся прежним.",
         "avatarCropMoveUp": "Вверх",
         "avatarCropMoveDown": "Вниз",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "生成头像失败",
         "avatarCropperTitle": "调整头像裁剪区域",
         "avatarPreviewCropping": "请调整裁剪区域",
+        "avatarCropRetake": "重新拍照",
+        "avatarCropRetaking": "正在重新拍照...",
         "avatarPreviewCropCancelled": "已取消手动裁剪，保持原头像不变。",
         "avatarCropMoveUp": "上移",
         "avatarCropMoveDown": "下移",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -659,6 +659,8 @@
         "avatarPreviewFailed": "生成頭像失敗",
         "avatarCropperTitle": "調整頭像裁剪區域",
         "avatarPreviewCropping": "請調整裁剪區域",
+        "avatarCropRetake": "重新拍照",
+        "avatarCropRetaking": "正在重新拍照...",
         "avatarPreviewCropCancelled": "已取消手動裁剪，保持原頭像不變。",
         "avatarCropMoveUp": "上移",
         "avatarCropMoveDown": "下移",

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -702,8 +702,11 @@
                 </div>
             </div>
             <div class="avatar-cropper-buttons">
-                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropCancel">取消</button>
-                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button" data-i18n="chat.avatarCropSave">保存</button>
+                <button id="avatar-cropper-retake" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropRetake">重新拍照</button>
+                <div class="avatar-cropper-decision-buttons">
+                    <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropCancel">取消</button>
+                    <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button" data-i18n="chat.avatarCropSave">保存</button>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -257,8 +257,11 @@
                 </div>
             </div>
             <div class="avatar-cropper-buttons">
-                <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropCancel">取消</button>
-                <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button" data-i18n="chat.avatarCropSave">保存</button>
+                <button id="avatar-cropper-retake" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropRetake">重新拍照</button>
+                <div class="avatar-cropper-decision-buttons">
+                    <button id="avatar-cropper-cancel" class="avatar-cropper-btn" type="button" data-i18n="chat.avatarCropCancel">取消</button>
+                    <button id="avatar-cropper-save" class="avatar-cropper-btn primary" type="button" data-i18n="chat.avatarCropSave">保存</button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a retake button to the manual avatar cropper so users can refresh the current avatar source without closing and reopening the cropper
- keep the cropper open while retaking, refresh the source image/default crop box, and save from the latest retaken source
- add the button to both main and standalone chat templates, with i18n strings for all existing locales

## Test plan
- `node --check static/app-chat-avatar.js`
- parsed all locale JSON files for zh-CN, zh-TW, en, ja, ko, es, pt, and ru
- `git diff --check`
- manually verified the main-page avatar cropper shows the retake button
- manually verified the standalone chat avatar cropper shows the retake button
- manually verified clicking retake stays in the cropper
- manually verified retake disables the retake/save buttons while capture is in progress
- manually verified the new source image refreshes the crop box and mask
- manually verified saving uses the latest retaken avatar source


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 头像裁剪现支持“重新拍照”流程，用户可在裁剪界面触发重拍并继续裁剪与保存
* **界面优化**
  * 调整裁剪按钮布局，增加禁用态视觉反馈（透明度与指针样式）
* **本地化**
  * 在英、西、日、韩、葡、俄、简体中、繁体中添加裁剪相关文案（“重新拍照”/“正在重新拍照...”）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->