### PR TITLE
修复移动端触发教程后全局交互守卫拦截页面点击的问题

### DIFF
--- a/static/yui-guide-director.js
+++ b/static/yui-guide-director.js
@@ -2146,7 +2146,6 @@
             this.messageHandler = this.onWindowMessage.bind(this);
             this.skipButtonClickHandler = this.onSkipButtonClick.bind(this);
             this.interactionGuardHandler = this.onInteractionGuard.bind(this);
-            this.mobileTouchInteractionPassthrough = this.shouldUseMobileTouchInteractionPassthrough();
             this.externalizedChatSpotlightKind = '';
             const capabilityApi = window.homeTutorialPlatformCapabilities;
             this.platformCapabilities = capabilityApi && typeof capabilityApi.create === 'function'
@@ -8771,6 +8770,10 @@
             this.destroy();
         }
 
+        get mobileTouchInteractionPassthrough() {
+            return this.shouldUseMobileTouchInteractionPassthrough();
+        }
+
         shouldUseMobileTouchInteractionPassthrough() {
             const coarsePointer = !!(
                 window.matchMedia
@@ -8787,6 +8790,18 @@
 
             // 移动触控端没有幽灵鼠标接管语义，不能用全局捕获守卫吞掉页面点击。
             return !!((coarsePointer || touchCapable) && narrowViewport);
+        }
+
+        isTouchInteractionEvent(event) {
+            if (!event || typeof event.type !== 'string') {
+                return false;
+            }
+
+            if (event.type.indexOf('touch') === 0) {
+                return true;
+            }
+
+            return event.pointerType === 'touch';
         }
 
         isAllowedTutorialInteractionTarget(target) {
@@ -8866,7 +8881,7 @@
                 return;
             }
 
-            if (this.mobileTouchInteractionPassthrough) {
+            if (this.mobileTouchInteractionPassthrough && this.isTouchInteractionEvent(event)) {
                 return;
             }
 

--- a/static/yui-guide-director.js
+++ b/static/yui-guide-director.js
@@ -1,6 +1,9 @@
 (function () {
     'use strict';
 
+    // 最近一次触控事件时间戳，用于识别触控衍生的合成鼠标/点击事件
+    var lastTouchTime = 0;
+
     function translateGuideText(textKey, fallbackText) {
         const normalizedKey = typeof textKey === 'string' ? textKey.trim() : '';
         const normalizedFallback = typeof fallbackText === 'string' ? fallbackText : '';
@@ -8798,10 +8801,21 @@
             }
 
             if (event.type.indexOf('touch') === 0) {
+                lastTouchTime = Date.now();
                 return true;
             }
 
-            return event.pointerType === 'touch';
+            if (event.pointerType === 'touch') {
+                lastTouchTime = Date.now();
+                return true;
+            }
+
+            // 触控衍生的合成鼠标/点击事件：在触控后的短时间窗口内视为触控交互
+            if (/^(click|mousedown|mouseup)$/.test(event.type) && Date.now() - lastTouchTime < 500) {
+                return true;
+            }
+
+            return false;
         }
 
         isAllowedTutorialInteractionTarget(target) {

--- a/static/yui-guide-director.js
+++ b/static/yui-guide-director.js
@@ -8895,7 +8895,13 @@
                 return;
             }
 
-            if (this.mobileTouchInteractionPassthrough && this.isTouchInteractionEvent(event)) {
+            // 等待特定目标点击期间不得放行触控事件，否则会破坏 awaitIntroActivation / manualPluginDashboard 的守卫语义
+            if (
+                this.mobileTouchInteractionPassthrough
+                && this.isTouchInteractionEvent(event)
+                && !this.awaitingIntroActivation
+                && !this.manualPluginDashboardOpenAllowed
+            ) {
                 return;
             }
 

--- a/static/yui-guide-director.js
+++ b/static/yui-guide-director.js
@@ -2146,6 +2146,7 @@
             this.messageHandler = this.onWindowMessage.bind(this);
             this.skipButtonClickHandler = this.onSkipButtonClick.bind(this);
             this.interactionGuardHandler = this.onInteractionGuard.bind(this);
+            this.mobileTouchInteractionPassthrough = this.shouldUseMobileTouchInteractionPassthrough();
             this.externalizedChatSpotlightKind = '';
             const capabilityApi = window.homeTutorialPlatformCapabilities;
             this.platformCapabilities = capabilityApi && typeof capabilityApi.create === 'function'
@@ -8770,6 +8771,24 @@
             this.destroy();
         }
 
+        shouldUseMobileTouchInteractionPassthrough() {
+            const coarsePointer = !!(
+                window.matchMedia
+                && window.matchMedia('(hover: none), (pointer: coarse)').matches
+            );
+            const narrowViewport = Math.max(
+                window.innerWidth || 0,
+                document.documentElement ? document.documentElement.clientWidth || 0 : 0
+            ) <= 768;
+            const touchCapable = !!(
+                'ontouchstart' in window
+                || (navigator && Number(navigator.maxTouchPoints || 0) > 0)
+            );
+
+            // 移动触控端没有幽灵鼠标接管语义，不能用全局捕获守卫吞掉页面点击。
+            return !!((coarsePointer || touchCapable) && narrowViewport);
+        }
+
         isAllowedTutorialInteractionTarget(target) {
             if (!target || typeof target.closest !== 'function') {
                 return false;
@@ -8839,10 +8858,15 @@
                 return;
             }
 
+            const isAllowedTarget = this.isAllowedTutorialInteractionTarget(event.target);
             if (
-                this.isAllowedTutorialInteractionTarget(event.target)
+                isAllowedTarget
                 || this.isSystemDialogInteractionTarget(event.target)
             ) {
+                return;
+            }
+
+            if (this.mobileTouchInteractionPassthrough) {
                 return;
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在移动设备与窄视口上为引导/教程交互添加触摸交互穿透：在检测为原生触摸或触摸后短时间内的派生鼠标事件时，允许事件透过交互保护层，不再阻止默认行为或事件传播，从而改善移动端展示引导、对话框与目标元素时的触控体验与交互一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->