### PR TITLE
concurrency: address audit findings B1-B8 (route_start/cleanup race, organizer dup, finalize policy, session create lock, character switch)

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2201,7 +2201,28 @@ async def set_current_catgirl(request: Request):
     # 只需刷新 globals 即可。N=20 只猫娘时从 O(N) 降到 O(1)。
     switch_current_catgirl_fast = get_switch_current_catgirl_fast()
     await switch_current_catgirl_fast()
-    
+
+    # B8: if the previous character had an active game route, finalize it
+    # immediately. Otherwise the heartbeat-based timeout (10-60s) would
+    # leave a stale ``OmniOfflineClient`` consuming game events under the
+    # outgoing character's name and keep the SessionManager takeover
+    # muting the incoming character's ordinary chat output.
+    if old_catgirl and old_catgirl != catgirl_name:
+        try:
+            from main_routers.game_router import finalize_game_routes_for_character
+            finalized = await finalize_game_routes_for_character(old_catgirl)
+            if finalized:
+                logger.info(
+                    "角色切换：已收尾 %d 个旧角色 %s 的游戏路由",
+                    finalized,
+                    old_catgirl,
+                )
+        except Exception as exc:
+            # Swallow — character switch must not fail because of
+            # game-route cleanup; the heartbeat sweep will eventually
+            # clean up if this hook misses.
+            logger.warning("角色切换游戏路由收尾失败: lanlan=%s err=%s", old_catgirl, exc)
+
     # 通过WebSocket通知所有连接的客户端
     # 使用session_manager中的websocket，但需要确保websocket已设置
     notification_count = 0

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3942,10 +3942,22 @@ async def _run_game_chat(
 
             session = entry['session']
             reply_chunks = entry['reply_chunks']
-            await _refresh_game_session_instructions(
-                entry, game_type, chat_session_id, lanlan_name,
-                postgame_snapshot=postgame_snapshot if allow_postgame else None,
-            )
+            try:
+                await _refresh_game_session_instructions(
+                    entry, game_type, chat_session_id, lanlan_name,
+                    postgame_snapshot=postgame_snapshot if allow_postgame else None,
+                )
+            except Exception as e:
+                logger.error("🎮 更新游戏 session 指令失败: %s", e)
+                err_result: Dict[str, Any] = {
+                    "error": f"更新 session 指令失败: {e}",
+                    "line": "",
+                    "control": {},
+                }
+                if allow_postgame:
+                    err_result["_postgame_entry"] = entry
+                    err_result["_postgame_cache_session_id"] = chat_session_id
+                return err_result
 
             # 清空上一次的回复
             reply_chunks.clear()

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3052,6 +3052,14 @@ async def _finalize_game_route_state(
       the first caller's ``False`` won; the second caller then redundantly
       invoked ``_close_and_remove_session`` outside the shield, racing
       with the inner finalize and producing double-pop / double-close.
+    - codex P2 follow-up: a late caller arriving with
+      ``close_game_session=True`` AFTER the inner runner already passed
+      its close-site check (or finished entirely) used to lose its
+      request — the dispatcher just awaited the cached task result. We
+      now re-check ``_exit_close_session_request`` against the inner's
+      result on the existing-task path and perform the close ourselves
+      if the inner missed it. ``_close_and_remove_session`` is
+      idempotent so concurrent late callers cannot double-close.
     """
     if close_game_session:
         state["_exit_close_session_request"] = True
@@ -3060,7 +3068,20 @@ async def _finalize_game_route_state(
 
     existing_task = state.get("_exit_task")
     if existing_task:
-        return await asyncio.shield(existing_task)
+        result = await asyncio.shield(existing_task)
+        if state.get("_exit_close_session_request") and not result.get("game_session_closed"):
+            closed_now = await _close_and_remove_session(
+                str(state.get("game_type") or ""),
+                str(state.get("session_id") or "default"),
+                str(state.get("lanlan_name") or ""),
+            )
+            if closed_now:
+                # Why: mutate the shared result dict so any other awaiter (or
+                # subsequent late caller) observes the close. The inner's
+                # return dict is the single source of truth handed back to
+                # every shielded await.
+                result["game_session_closed"] = True
+        return result
 
     task = asyncio.create_task(_finalize_game_route_state_inner(state, reason=reason))
     state["_exit_task"] = task

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3270,6 +3270,15 @@ async def _build_and_register_game_session(
     )
     try:
         await session.connect(instructions=system_prompt)
+    except asyncio.CancelledError:
+        # Why: CancelledError doesn't inherit from Exception in Python
+        # 3.8+; without this branch a cancelled connect leaks the half-
+        # open client.
+        try:
+            await session.close()
+        except Exception:
+            pass
+        raise
     except Exception:
         # Connect failed — ensure we don't leak a half-open client. close
         # is idempotent / tolerant of "never connected".

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3298,6 +3298,9 @@ async def _build_and_register_game_session(
         try:
             await session.close()
         except Exception:
+            # Why: cleanup must remain idempotent on the cancellation
+            # path — a close() failure here would mask the original
+            # CancelledError that we re-raise below.
             pass
         raise
     except Exception:
@@ -3306,6 +3309,9 @@ async def _build_and_register_game_session(
         try:
             await session.close()
         except Exception:
+            # Why: cleanup must not raise from the exception path —
+            # a close() failure would mask the original connect error
+            # that we re-raise below.
             pass
         raise
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3947,7 +3947,10 @@ async def _run_game_chat(
                 cached = _game_sessions.get(key)
                 if cached is entry:
                     _game_sessions.pop(key, None)
-                    _game_session_create_locks.pop(key, None)
+                    create_lock = _game_session_create_locks.get(key)
+                    waiters = getattr(create_lock, "_waiters", None) if create_lock else None
+                    if not waiters:
+                        _game_session_create_locks.pop(key, None)
                     orphan_session_to_close = entry.get('session')
                 short_circuit_route_inactive = True
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -15,6 +15,7 @@ import math
 import random
 import re
 import time
+import uuid
 from collections import OrderedDict
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -2836,6 +2837,7 @@ async def _deliver_postgame_text_bubble(
     proactive_sid = getattr(mgr, "current_speech_id", None)
     state_machine = getattr(mgr, "state", None)
     postgame_entry: Optional[dict] = None
+    postgame_cache_session_id: Optional[str] = None
     try:
         from main_logic.session_state import SessionEvent
         if state_machine and hasattr(state_machine, "fire"):
@@ -2858,7 +2860,9 @@ async def _deliver_postgame_text_bubble(
         llm_result = await _run_game_chat(
             game_type, session_id, event, allow_postgame=True,
         )
-        postgame_entry = llm_result.get("_postgame_entry") if isinstance(llm_result, dict) else None
+        if isinstance(llm_result, dict):
+            postgame_entry = llm_result.get("_postgame_entry")
+            postgame_cache_session_id = llm_result.get("_postgame_cache_session_id")
         line = str(llm_result.get("line") or "").strip()
         if not line:
             return {
@@ -2911,22 +2915,23 @@ async def _deliver_postgame_text_bubble(
                 await state_machine.fire(SessionEvent.PROACTIVE_DONE)
         except Exception as exc:
             logger.debug("🎮 赛后文本气泡状态机收尾失败: %s", exc, exc_info=True)
-        # Why: ``_run_game_chat(..., allow_postgame=True)`` may have built
-        # a fresh ``OmniOfflineClient`` after finalize already evicted
-        # the prior session; nothing else in the lifecycle would close it
-        # once the route is gone. Identity-gate the cache eviction so a
-        # racing ``/route/start`` that reused the same key after finalize
-        # released ``end_route_lock`` keeps its own freshly-built session
-        # untouched. We always close OUR captured entry's session object
-        # — even if the cache no longer points at it (peer evicted) — so
-        # the postgame client can never leak. ``OmniOfflineClient.close``
-        # is idempotent, so a peer's prior close is safe to re-run.
+        # Why: ``_run_game_chat(..., allow_postgame=True)`` builds the
+        # postgame's ``OmniOfflineClient`` at a private cache key
+        # (``::postgame::<uuid>`` suffix) so a fresh ``/route/start``
+        # reusing the user-facing ``session_id`` cannot land on the same
+        # ``_game_sessions`` slot. Identity-gating the eviction stays as
+        # defense in depth (a heartbeat sweep could theoretically pop
+        # then rebuild the postgame slot). We always close OUR captured
+        # entry's session object so the postgame client can never leak.
+        # ``OmniOfflineClient.close`` is idempotent, so a peer's prior
+        # close is safe to re-run.
         if postgame_entry is not None:
             postgame_lanlan = str(
                 postgame_entry.get("lanlan_name") or archive.get("lanlan_name") or ""
             )
+            cache_session_id = postgame_cache_session_id or session_id
             try:
-                key = _game_session_key(postgame_lanlan, game_type, session_id)
+                key = _game_session_key(postgame_lanlan, game_type, cache_session_id)
                 cached = _game_sessions.get(key)
                 if cached is postgame_entry:
                     _game_sessions.pop(key, None)
@@ -3278,7 +3283,7 @@ async def _build_and_register_game_session(
         master_name=char_info['master_name'],
     )
 
-    route_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+    route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), lanlan_name)
     pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
     game_context = _build_game_context_prompt_payload(route_state)
     system_prompt = _build_game_prompt(
@@ -3355,7 +3360,7 @@ async def _refresh_game_session_instructions(
 
     lanlan_name = str(lanlan_name or entry.get("lanlan_name") or "").strip()
     char_info = _get_character_info(lanlan_name)
-    route_state = _find_game_route_state_for_session(game_type, session_id, char_info["lanlan_name"])
+    route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), char_info["lanlan_name"])
     pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
     game_context = _build_game_context_prompt_payload(route_state)
     instructions = _build_game_prompt(
@@ -3626,6 +3631,31 @@ def _game_session_key(lanlan_name: str, game_type: str, session_id: str) -> str:
     return f"{game_type}:{session_id}"
 
 
+_POSTGAME_SESSION_MARKER = "::postgame::"
+
+
+def _make_postgame_session_id(session_id: str) -> str:
+    # Why: postgame's freshly-built session lives at a private cache key
+    # so a racing ``/route/start`` reusing the same user-facing session_id
+    # cannot land on the same ``_game_sessions`` slot. Without this, a
+    # peer's first ``/game_chat`` would be handed back postgame's cached
+    # entry by ``_get_or_create_session``, and postgame's ``finally``
+    # close (still identity-matching since the cache wasn't replaced)
+    # would tear down the active route's session mid-turn.
+    return f"{str(session_id or '')}{_POSTGAME_SESSION_MARKER}{uuid.uuid4().hex}"
+
+
+def _route_session_id(session_id: str) -> str:
+    # Why: route_state lookups must always use the user-facing session_id
+    # so postgame still resolves the prior route's preGameContext /
+    # game_context when building / refreshing its system prompt.
+    raw = str(session_id or "")
+    idx = raw.find(_POSTGAME_SESSION_MARKER)
+    if idx == -1:
+        return raw
+    return raw[:idx]
+
+
 def _parse_game_session_key(key: str) -> tuple[str, str, str]:
     parts = str(key or "").split(":", 2)
     if len(parts) == 3:
@@ -3731,6 +3761,12 @@ async def _run_game_chat(
     The caller (``_deliver_postgame_text_bubble``) is responsible for
     closing the freshly-built session afterwards via
     ``_close_and_remove_session`` so the bypass doesn't leak a client.
+
+    Postgame uses a private ``::postgame::<uuid>``-suffixed cache key so
+    a racing ``/route/start`` reusing the user-facing ``session_id``
+    cannot land on the same ``_game_sessions`` slot. The user-facing
+    ``session_id`` is preserved for route_state lookups via
+    ``_route_session_id``.
     """
     request_started_at = time.perf_counter()
 
@@ -3745,6 +3781,8 @@ async def _run_game_chat(
         if balance_hint:
             event = dict(event)
             event['balanceHint'] = balance_hint
+
+    chat_session_id = _make_postgame_session_id(session_id) if allow_postgame else session_id
 
     # B1/B2: pre-create short-circuit. If the route is mid-exit (or
     # already inactive) we must not spawn a fresh ``OmniOfflineClient``
@@ -3763,7 +3801,7 @@ async def _run_game_chat(
             return {"line": "", "control": {}, "skipped": "route_inactive"}
 
     try:
-        entry = await _get_or_create_session(game_type, session_id, lanlan_name)
+        entry = await _get_or_create_session(game_type, chat_session_id, lanlan_name)
     except Exception as e:
         logger.error("🎮 创建游戏 session 失败: %s", e)
         return {"error": f"创建 session 失败: {e}"}
@@ -3800,7 +3838,7 @@ async def _run_game_chat(
                 # Evict our entry IFF the cache still points at us. If
                 # a peer creator already overwrote our slot, they own
                 # the close.
-                key = _game_session_key(lanlan_name, game_type, session_id)
+                key = _game_session_key(lanlan_name, game_type, chat_session_id)
                 cached = _game_sessions.get(key)
                 if cached is entry:
                     _game_sessions.pop(key, None)
@@ -3813,7 +3851,7 @@ async def _run_game_chat(
             # creator overwrote us, or finalize closed the session while
             # we were waiting on entry['lock']). Continuing would call
             # ``stream_text`` on a closed client.
-            current_entry = _game_sessions.get(_game_session_key(lanlan_name, game_type, session_id))
+            current_entry = _game_sessions.get(_game_session_key(lanlan_name, game_type, chat_session_id))
             if current_entry is not entry:
                 logger.info(
                     "🎮 chat short-circuit: entry no longer cached game=%s sid=%s lanlan=%s",
@@ -3822,11 +3860,12 @@ async def _run_game_chat(
                 evicted_result: Dict[str, Any] = {"line": "", "control": {}, "skipped": "entry_evicted"}
                 if allow_postgame:
                     evicted_result["_postgame_entry"] = entry
+                    evicted_result["_postgame_cache_session_id"] = chat_session_id
                 return evicted_result
 
             session = entry['session']
             reply_chunks = entry['reply_chunks']
-            await _refresh_game_session_instructions(entry, game_type, session_id, lanlan_name)
+            await _refresh_game_session_instructions(entry, game_type, chat_session_id, lanlan_name)
 
             # 清空上一次的回复
             reply_chunks.clear()
@@ -3860,12 +3899,14 @@ async def _run_game_chat(
                 err_result: Dict[str, Any] = {"error": "LLM 响应超时", "line": "", "control": {}}
                 if allow_postgame:
                     err_result["_postgame_entry"] = entry
+                    err_result["_postgame_cache_session_id"] = chat_session_id
                 return err_result
             except Exception as e:
                 logger.error("🎮 游戏 LLM 调用失败: %s", e)
                 err_result = {"error": f"LLM 调用失败: {e}", "line": "", "control": {}}
                 if allow_postgame:
                     err_result["_postgame_entry"] = entry
+                    err_result["_postgame_cache_session_id"] = chat_session_id
                 return err_result
 
             llm_elapsed_ms = int((time.perf_counter() - llm_started_at) * 1000)
@@ -3898,12 +3939,13 @@ async def _run_game_chat(
     }
     result['llm_source'] = dict(entry.get('source') or {})
     if allow_postgame:
-        # Why: postgame teardown owns the lifecycle of the entry it used,
-        # but key-based close is racy — a fresh ``/route/start`` may
-        # reuse the same ``(lanlan, game_type, session_id)`` cache slot
-        # before the postgame's ``finally`` runs. Hand the caller the
-        # exact entry object so its close is identity-gated.
+        # Why: postgame teardown owns the lifecycle of the entry it used.
+        # Hand the caller the exact entry object (identity-gated close)
+        # AND the private cache key it lives under so the bubble's
+        # ``finally`` evicts the correct slot — a fresh ``/route/start``
+        # cannot collide with this private slot.
         result['_postgame_entry'] = entry
+        result['_postgame_cache_session_id'] = chat_session_id
     logger.info(
         "🎮 [%s:%s] LLM耗时=%sms 后端总耗时=%sms 事件=%s → 台词=%s",
         game_type, session_id, llm_elapsed_ms, total_elapsed_ms,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -16,7 +16,7 @@ import random
 import re
 import time
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 
@@ -2835,6 +2835,7 @@ async def _deliver_postgame_text_bubble(
 
     proactive_sid = getattr(mgr, "current_speech_id", None)
     state_machine = getattr(mgr, "state", None)
+    postgame_entry: Optional[dict] = None
     try:
         from main_logic.session_state import SessionEvent
         if state_machine and hasattr(state_machine, "fire"):
@@ -2857,6 +2858,7 @@ async def _deliver_postgame_text_bubble(
         llm_result = await _run_game_chat(
             game_type, session_id, event, allow_postgame=True,
         )
+        postgame_entry = llm_result.get("_postgame_entry") if isinstance(llm_result, dict) else None
         line = str(llm_result.get("line") or "").strip()
         if not line:
             return {
@@ -2911,20 +2913,38 @@ async def _deliver_postgame_text_bubble(
             logger.debug("🎮 赛后文本气泡状态机收尾失败: %s", exc, exc_info=True)
         # Why: ``_run_game_chat(..., allow_postgame=True)`` may have built
         # a fresh ``OmniOfflineClient`` after finalize already evicted
-        # the prior session. No other lifecycle hook will close it once
-        # the route is gone — we must do it here to avoid a permanent
-        # leak (the very risk that motivated the B1/B2 short-circuits).
-        try:
-            postgame_lanlan = str(archive.get("lanlan_name") or "")
-            if postgame_lanlan:
-                await _close_and_remove_session(
-                    game_type, session_id, postgame_lanlan,
-                )
-        except Exception as exc:
-            logger.debug(
-                "🎮 赛后文本气泡 session 清理失败: game=%s session=%s err=%s",
-                game_type, session_id, exc, exc_info=True,
+        # the prior session; nothing else in the lifecycle would close it
+        # once the route is gone. Identity-gate the cache eviction so a
+        # racing ``/route/start`` that reused the same key after finalize
+        # released ``end_route_lock`` keeps its own freshly-built session
+        # untouched. We always close OUR captured entry's session object
+        # — even if the cache no longer points at it (peer evicted) — so
+        # the postgame client can never leak. ``OmniOfflineClient.close``
+        # is idempotent, so a peer's prior close is safe to re-run.
+        if postgame_entry is not None:
+            postgame_lanlan = str(
+                postgame_entry.get("lanlan_name") or archive.get("lanlan_name") or ""
             )
+            try:
+                key = _game_session_key(postgame_lanlan, game_type, session_id)
+                cached = _game_sessions.get(key)
+                if cached is postgame_entry:
+                    _game_sessions.pop(key, None)
+                    _game_session_create_locks.pop(key, None)
+            except Exception as exc:
+                logger.debug(
+                    "🎮 赛后文本气泡 cache 清理失败: game=%s session=%s err=%s",
+                    game_type, session_id, exc, exc_info=True,
+                )
+            postgame_session = postgame_entry.get("session")
+            if postgame_session is not None:
+                try:
+                    await postgame_session.close()
+                except Exception as exc:
+                    logger.debug(
+                        "🎮 赛后文本气泡 session 清理失败: game=%s session=%s err=%s",
+                        game_type, session_id, exc, exc_info=True,
+                    )
 
 
 async def _deliver_game_postgame(
@@ -3755,7 +3775,10 @@ async def _run_game_chat(
                     "🎮 chat short-circuit: entry no longer cached game=%s sid=%s lanlan=%s",
                     game_type, session_id, lanlan_name,
                 )
-                return {"line": "", "control": {}, "skipped": "entry_evicted"}
+                evicted_result: Dict[str, Any] = {"line": "", "control": {}, "skipped": "entry_evicted"}
+                if allow_postgame:
+                    evicted_result["_postgame_entry"] = entry
+                return evicted_result
 
             session = entry['session']
             reply_chunks = entry['reply_chunks']
@@ -3790,10 +3813,16 @@ async def _run_game_chat(
                 )
             except asyncio.TimeoutError:
                 logger.warning("🎮 游戏 LLM 响应超时: game=%s sid=%s", game_type, session_id)
-                return {"error": "LLM 响应超时", "line": "", "control": {}}
+                err_result: Dict[str, Any] = {"error": "LLM 响应超时", "line": "", "control": {}}
+                if allow_postgame:
+                    err_result["_postgame_entry"] = entry
+                return err_result
             except Exception as e:
                 logger.error("🎮 游戏 LLM 调用失败: %s", e)
-                return {"error": f"LLM 调用失败: {e}", "line": "", "control": {}}
+                err_result = {"error": f"LLM 调用失败: {e}", "line": "", "control": {}}
+                if allow_postgame:
+                    err_result["_postgame_entry"] = entry
+                return err_result
 
             llm_elapsed_ms = int((time.perf_counter() - llm_started_at) * 1000)
             full_reply = ''.join(reply_chunks)
@@ -3824,6 +3853,13 @@ async def _run_game_chat(
         'total_ms': total_elapsed_ms,
     }
     result['llm_source'] = dict(entry.get('source') or {})
+    if allow_postgame:
+        # Why: postgame teardown owns the lifecycle of the entry it used,
+        # but key-based close is racy — a fresh ``/route/start`` may
+        # reuse the same ``(lanlan, game_type, session_id)`` cache slot
+        # before the postgame's ``finally`` runs. Hand the caller the
+        # exact entry object so its close is identity-gated.
+        result['_postgame_entry'] = entry
     logger.info(
         "🎮 [%s:%s] LLM耗时=%sms 后端总耗时=%sms 事件=%s → 台词=%s",
         game_type, session_id, llm_elapsed_ms, total_elapsed_ms,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -4489,47 +4489,67 @@ async def finalize_game_routes_for_character(old_lanlan_name: str) -> int:
     chat output). Finalizing immediately at switch time releases the
     takeover and closes the LLM session.
 
+    Concurrency (codex P2 follow-up): the snapshot + iterate + finalize
+    block runs under the per-``lanlan_name`` supersede lock (the same OUTER
+    lock ``game_route_start`` takes). Without it, a concurrent
+    ``/route/start`` for the same ``lanlan_name`` can activate a NEW route
+    AFTER we snapshot ``_game_route_states`` and escape cleanup — the
+    character switch then completes with an old-character route still
+    active (takeover, session, heartbeat all live), defeating B8's
+    "immediate teardown on switch" guarantee. Holding the supersede lock
+    across the whole sweep forces any concurrent ``/route/start`` for the
+    same ``lanlan_name`` to land strictly before (in which case our
+    snapshot includes it) or strictly after (in which case our cleanup
+    completed first and the new route is intentional post-switch state
+    the caller can deal with separately).
+
+    Lock ordering: OUTER ``_route_supersede_locks[lanlan_name]`` then
+    INNER ``_route_state_locks[(lanlan, game_type)]`` per iteration.
+    Same direction as ``game_route_start`` — no deadlock window.
+
     Returns the number of routes finalized.
     """
     target = str(old_lanlan_name or "")
     if not target:
         return 0
-    candidates = [
-        candidate
-        for candidate in list(_game_route_states.values())
-        if candidate.get("game_route_active")
-        and str(candidate.get("lanlan_name") or "") == target
-    ]
+    supersede_lock = _get_supersede_lock(target)
     finalized_count = 0
-    for old_state in candidates:
-        old_game_type = str(old_state.get("game_type") or "")
-        logger.warning(
-            "🎮 角色切换前结束旧角色游戏路由: lanlan=%s game=%s session=%s",
-            target,
-            old_game_type,
-            old_state.get("session_id") or "",
-        )
-        route_lock = _get_route_lock(target, old_game_type)
-        try:
-            async with route_lock:
-                if not old_state.get("game_route_active"):
-                    if old_state.get("_exit_task"):
-                        await asyncio.shield(old_state["_exit_task"])
-                    continue
-                await _finalize_game_route_state(
-                    old_state,
-                    reason="character_switch",
-                    close_game_session=True,
-                )
-                finalized_count += 1
-        except Exception as exc:
+    async with supersede_lock:
+        candidates = [
+            candidate
+            for candidate in list(_game_route_states.values())
+            if candidate.get("game_route_active")
+            and str(candidate.get("lanlan_name") or "") == target
+        ]
+        for old_state in candidates:
+            old_game_type = str(old_state.get("game_type") or "")
             logger.warning(
-                "🎮 角色切换收尾失败: lanlan=%s game=%s err=%s",
+                "🎮 角色切换前结束旧角色游戏路由: lanlan=%s game=%s session=%s",
                 target,
                 old_game_type,
-                exc,
-                exc_info=True,
+                old_state.get("session_id") or "",
             )
+            route_lock = _get_route_lock(target, old_game_type)
+            try:
+                async with route_lock:
+                    if not old_state.get("game_route_active"):
+                        if old_state.get("_exit_task"):
+                            await asyncio.shield(old_state["_exit_task"])
+                        continue
+                    await _finalize_game_route_state(
+                        old_state,
+                        reason="character_switch",
+                        close_game_session=True,
+                    )
+                    finalized_count += 1
+            except Exception as exc:
+                logger.warning(
+                    "🎮 角色切换收尾失败: lanlan=%s game=%s err=%s",
+                    target,
+                    old_game_type,
+                    exc,
+                    exc_info=True,
+                )
     return finalized_count
 
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -2809,6 +2809,8 @@ async def _deliver_postgame_text_bubble(
     mgr: Any,
     archive: dict,
     options: dict,
+    *,
+    postgame_snapshot: Optional[dict] = None,
 ) -> dict:
     if not mgr:
         return {"ok": False, "mode": "text", "action": "skip", "reason": "no_session_manager"}
@@ -2859,6 +2861,7 @@ async def _deliver_postgame_text_bubble(
         # any session built here and close it in the ``finally`` below.
         llm_result = await _run_game_chat(
             game_type, session_id, event, allow_postgame=True,
+            postgame_snapshot=postgame_snapshot,
         )
         if isinstance(llm_result, dict):
             postgame_entry = llm_result.get("_postgame_entry")
@@ -2958,6 +2961,8 @@ async def _deliver_game_postgame(
     lanlan_name: str,
     archive: dict,
     options: dict,
+    *,
+    postgame_snapshot: Optional[dict] = None,
 ) -> dict:
     if not options.get("enabled", True):
         return {"ok": True, "action": "skip", "reason": "disabled"}
@@ -2967,7 +2972,10 @@ async def _deliver_game_postgame(
         return await _deliver_postgame_to_realtime(mgr, archive, options)
     if mode == "realtime":
         return {"ok": False, "mode": "realtime", "action": "skip", "reason": "no_active_realtime_session"}
-    return await _deliver_postgame_text_bubble(game_type, session_id, mgr, archive, options)
+    return await _deliver_postgame_text_bubble(
+        game_type, session_id, mgr, archive, options,
+        postgame_snapshot=postgame_snapshot,
+    )
 
 
 async def _submit_game_archive_to_memory(archive: dict) -> dict:
@@ -3093,6 +3101,24 @@ async def _finalize_game_route_state(
     return await asyncio.shield(task)
 
 
+def _build_postgame_context_snapshot(state: dict) -> dict:
+    # Why: postgame's prompt context must be FROZEN at finalize time.
+    # Without this, ``_build_and_register_game_session`` /
+    # ``_refresh_game_session_instructions`` reverse-resolve live
+    # route_state via ``_find_game_route_state_for_session`` AFTER finalize
+    # has flipped this state inactive — and a fresh ``/route/start`` for
+    # the same ``(lanlan, game_type)`` key REPLACES the entry in
+    # ``_game_route_states``, so the lookup returns the NEW route's
+    # preGameContext / game_context. Snapshotting the two already-resolved
+    # dicts the prompt builder needs (``pre_game_context`` and
+    # ``game_context``) is the minimum-viable freeze.
+    pre_game_context = state.get("preGameContext") if isinstance(state.get("preGameContext"), dict) else None
+    return {
+        "pre_game_context": pre_game_context,
+        "game_context": _build_game_context_prompt_payload(state),
+    }
+
+
 async def _finalize_game_route_state_inner(
     state: dict,
     *,
@@ -3101,6 +3127,10 @@ async def _finalize_game_route_state_inner(
     state["_exit_flow_started"] = True
     state["exit_reason"] = reason
     state["exit_started_at"] = time.time()
+    # Capture postgame's prompt context BEFORE flipping the route inactive
+    # / before the archive resolution / before any peer ``/route/start``
+    # can replace this state in ``_game_route_states``.
+    postgame_context_snapshot = _build_postgame_context_snapshot(state)
     state["game_route_active"] = False
     state["game_external_voice_route_active"] = False
     state["game_external_text_route_active"] = False
@@ -3173,10 +3203,17 @@ async def _finalize_game_route_state_inner(
         "game_session_closed": session_closed,
         "exit_reason": reason,
         "realtime_restore": realtime_restore,
+        "postgame_context_snapshot": postgame_context_snapshot,
     }
 
 
-async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: str = "") -> dict:
+async def _get_or_create_session(
+    game_type: str,
+    session_id: str,
+    lanlan_name: str = "",
+    *,
+    postgame_snapshot: Optional[dict] = None,
+) -> dict:
     """获取或创建游戏 session.
 
     B6: serialize the cache-miss → ctor → connect → cache-insert sequence
@@ -3227,6 +3264,7 @@ async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: s
         try:
             return await _build_and_register_game_session(
                 canonical_key, game_type, session_id, char_info,
+                postgame_snapshot=postgame_snapshot,
             )
         except BaseException:
             # codex P2 (PR #1127 r3182157092): if the build raises,
@@ -3259,9 +3297,19 @@ async def _build_and_register_game_session(
     game_type: str,
     session_id: str,
     char_info: dict,
+    *,
+    postgame_snapshot: Optional[dict] = None,
 ) -> dict:
     """Build a fresh game session entry; caller must already hold the
-    per-key creation lock (see ``_get_or_create_session``)."""
+    per-key creation lock (see ``_get_or_create_session``).
+
+    ``postgame_snapshot`` (when set) is the authoritative prompt-context
+    source for postgame builds — see ``_build_postgame_context_snapshot``.
+    Without it, a postgame build that races a fresh ``/route/start`` for
+    the same ``(lanlan, game_type, session_id)`` would reverse-resolve
+    live route_state and pick up the NEW route's preGameContext /
+    game_context.
+    """
     from main_logic.omni_offline_client import OmniOfflineClient
     from utils.token_tracker import set_call_type
 
@@ -3283,9 +3331,13 @@ async def _build_and_register_game_session(
         master_name=char_info['master_name'],
     )
 
-    route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), lanlan_name)
-    pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
-    game_context = _build_game_context_prompt_payload(route_state)
+    if postgame_snapshot is not None:
+        pre_game_context = postgame_snapshot.get("pre_game_context")
+        game_context = postgame_snapshot.get("game_context")
+    else:
+        route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), lanlan_name)
+        pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
+        game_context = _build_game_context_prompt_payload(route_state)
     system_prompt = _build_game_prompt(
         game_type,
         char_info['lanlan_name'],
@@ -3352,6 +3404,8 @@ async def _refresh_game_session_instructions(
     game_type: str,
     session_id: str,
     lanlan_name: str = "",
+    *,
+    postgame_snapshot: Optional[dict] = None,
 ) -> None:
     session = entry.get("session") if isinstance(entry, dict) else None
     update = getattr(session, "update_session", None)
@@ -3360,9 +3414,13 @@ async def _refresh_game_session_instructions(
 
     lanlan_name = str(lanlan_name or entry.get("lanlan_name") or "").strip()
     char_info = _get_character_info(lanlan_name)
-    route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), char_info["lanlan_name"])
-    pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
-    game_context = _build_game_context_prompt_payload(route_state)
+    if postgame_snapshot is not None:
+        pre_game_context = postgame_snapshot.get("pre_game_context")
+        game_context = postgame_snapshot.get("game_context")
+    else:
+        route_state = _find_game_route_state_for_session(game_type, _route_session_id(session_id), char_info["lanlan_name"])
+        pre_game_context = route_state.get("preGameContext") if isinstance(route_state, dict) else None
+        game_context = _build_game_context_prompt_payload(route_state)
     instructions = _build_game_prompt(
         game_type,
         char_info["lanlan_name"],
@@ -3632,6 +3690,11 @@ def _game_session_key(lanlan_name: str, game_type: str, session_id: str) -> str:
 
 
 _POSTGAME_SESSION_MARKER = "::postgame::"
+# Why: ``_make_postgame_session_id`` produces ``<session_id>::postgame::<uuid4.hex>``
+# where ``uuid4().hex`` is exactly 32 lowercase hex chars. ``_route_session_id``
+# strips ONLY this exact synthetic suffix shape so a legitimate client-supplied
+# session_id that happens to contain ``::postgame::`` is left untouched.
+_POSTGAME_UUID_TAIL_RE = re.compile(r"[0-9a-f]{32}\Z")
 
 
 def _make_postgame_session_id(session_id: str) -> str:
@@ -3646,12 +3709,22 @@ def _make_postgame_session_id(session_id: str) -> str:
 
 
 def _route_session_id(session_id: str) -> str:
-    # Why: route_state lookups must always use the user-facing session_id
-    # so postgame still resolves the prior route's preGameContext /
-    # game_context when building / refreshing its system prompt.
+    # Why: this helper is now defensive. The critical postgame paths
+    # (``_build_and_register_game_session`` / ``_refresh_game_session_instructions``)
+    # use a frozen ``postgame_snapshot`` instead of reverse-resolving live
+    # route_state, so the marker no longer needs to round-trip through
+    # ``_find_game_route_state_for_session`` for prompt context. We still
+    # tolerate the synthetic shape elsewhere by stripping ONLY the exact
+    # suffix produced by ``_make_postgame_session_id`` (marker + 32-char
+    # uuid4 hex tail at end of string). A legitimate client session_id
+    # that happens to contain ``::postgame::`` mid-string — or with a
+    # non-uuid tail — is returned unchanged.
     raw = str(session_id or "")
-    idx = raw.find(_POSTGAME_SESSION_MARKER)
+    idx = raw.rfind(_POSTGAME_SESSION_MARKER)
     if idx == -1:
+        return raw
+    tail = raw[idx + len(_POSTGAME_SESSION_MARKER):]
+    if not _POSTGAME_UUID_TAIL_RE.fullmatch(tail):
         return raw
     return raw[:idx]
 
@@ -3748,6 +3821,7 @@ async def _run_game_chat(
     event: Any,
     *,
     allow_postgame: bool = False,
+    postgame_snapshot: Optional[dict] = None,
 ) -> Dict[str, Any]:
     """Run A-layer game LLM for both HTTP game events and hijacked external text.
 
@@ -3801,7 +3875,10 @@ async def _run_game_chat(
             return {"line": "", "control": {}, "skipped": "route_inactive"}
 
     try:
-        entry = await _get_or_create_session(game_type, chat_session_id, lanlan_name)
+        entry = await _get_or_create_session(
+            game_type, chat_session_id, lanlan_name,
+            postgame_snapshot=postgame_snapshot if allow_postgame else None,
+        )
     except Exception as e:
         logger.error("🎮 创建游戏 session 失败: %s", e)
         return {"error": f"创建 session 失败: {e}"}
@@ -3865,7 +3942,10 @@ async def _run_game_chat(
 
             session = entry['session']
             reply_chunks = entry['reply_chunks']
-            await _refresh_game_session_instructions(entry, game_type, chat_session_id, lanlan_name)
+            await _refresh_game_session_instructions(
+                entry, game_type, chat_session_id, lanlan_name,
+                postgame_snapshot=postgame_snapshot if allow_postgame else None,
+            )
 
             # 清空上一次的回复
             reply_chunks.clear()
@@ -5006,6 +5086,7 @@ async def _complete_game_end_from_payload(
             lanlan_name,
             archive,
             postgame_options,
+            postgame_snapshot=finalized.get("postgame_context_snapshot"),
         )
         # B5: closing the LLM session is the inner finalize's job (now
         # that ``close_game_session=True`` reliably propagates via

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -42,6 +42,7 @@ from utils.game_route_state import (
     _game_route_states,
     _get_active_game_route_state,
     _get_route_lock,
+    _get_supersede_lock,
     _route_state_key,
     is_game_route_active,
     register_voice_transcript_handler,
@@ -123,8 +124,15 @@ _GAME_DEBUG_MATERIAL_LOG_LIMIT = 24000
 # ``_game_sessions[key]`` so the first ``entry`` is now an orphan: its
 # ``lock`` is held by the first ``_run_game_chat``, but the cache no
 # longer points at it, so nothing will ever ``close()`` that session.
-# Keeping these locks process-scoped (never popped) is fine — at most one
-# Lock per ever-seen game session, negligible memory.
+#
+# Lifecycle (codex P2 follow-up): the create lock for a key is only
+# meaningful while a session for that key may be created or alive. After
+# ``_close_and_remove_session`` evicts the session from
+# ``_game_sessions``, any further ``_get_or_create_session`` call for
+# the same key would build a fresh session anyway — the lock entry just
+# accumulates without protecting anything. So evict the create lock at
+# the same time as the session, otherwise the dict grows unbounded over
+# uptime as session_ids churn.
 _game_session_create_locks: Dict[str, asyncio.Lock] = {}
 
 
@@ -3570,6 +3578,16 @@ async def _close_and_remove_session(
             return False
         session = popped.get('session')
 
+    # codex P2 follow-up: drop the per-key create lock alongside the
+    # evicted session so ``_game_session_create_locks`` does not grow
+    # unbounded over uptime. After eviction the lock would only protect
+    # a fresh, unrelated build — keeping the stale Lock instance buys
+    # nothing and accumulates memory as session_ids churn. Pop is
+    # synchronous (no await) so two concurrent close callers cannot
+    # race and double-pop into a KeyError; ``pop(..., None)`` is
+    # idempotent.
+    _game_session_create_locks.pop(key, None)
+
     if session:
         try:
             await session.close()
@@ -3790,60 +3808,77 @@ async def game_route_start(game_type: str, request: Request):
     # peers see the new slot via ``_get_active_*`` helpers; holding the
     # lock for the whole pregame would block heartbeat sweep with no
     # benefit.
+    #
+    # Cross-game_type concurrency (CodeRabbit follow-up):
+    # The per-(lanlan, game_type) route lock alone is too narrow for the
+    # supersede scan, which iterates `_game_route_states` for ANY active
+    # route belonging to `lanlan_name` regardless of `game_type`. Two
+    # concurrent /route/start calls for SAME lanlan_name but DIFFERENT
+    # game_type acquire different per-key locks, so each scan misses the
+    # other's pending activation and both end up activating in parallel,
+    # breaking the "one active game route per character" invariant.
+    #
+    # Fix: take the per-lanlan_name supersede lock as the OUTER lock
+    # before the per-(lanlan, game_type) route lock. Acquisition order
+    # (documented in `utils/game_route_state.py`) is OUTER->INNER; only
+    # the start-flow goes outer->inner, never the other direction, so no
+    # deadlock with finalize/end paths that only take the inner lock.
+    supersede_lock = _get_supersede_lock(lanlan_name)
     route_lock = _get_route_lock(lanlan_name, game_type)
-    async with route_lock:
-        for old_state in [
-            candidate
-            for candidate in list(_game_route_states.values())
-            if candidate.get("game_route_active")
-            and str(candidate.get("lanlan_name") or "") == lanlan_name
-        ]:
-            old_game_type = str(old_state.get("game_type") or "")
-            old_session_id = str(old_state.get("session_id") or "default")
-            logger.warning(
-                "🎮 新游戏路由启动前发现旧 active route，先结束旧局: old_game=%s old_session=%s new_game=%s new_session=%s lanlan=%s",
-                old_game_type,
-                old_session_id,
+    async with supersede_lock:
+        async with route_lock:
+            for old_state in [
+                candidate
+                for candidate in list(_game_route_states.values())
+                if candidate.get("game_route_active")
+                and str(candidate.get("lanlan_name") or "") == lanlan_name
+            ]:
+                old_game_type = str(old_state.get("game_type") or "")
+                old_session_id = str(old_state.get("session_id") or "default")
+                logger.warning(
+                    "🎮 新游戏路由启动前发现旧 active route，先结束旧局: old_game=%s old_session=%s new_game=%s new_session=%s lanlan=%s",
+                    old_game_type,
+                    old_session_id,
+                    game_type,
+                    session_id,
+                    lanlan_name,
+                )
+                await _finalize_game_route_state(
+                    old_state,
+                    reason="superseded_by_route_start",
+                    close_game_session=True,
+                )
+
+            neko_initiated = bool(data.get("nekoInitiated"))
+            neko_invite_text = _normalize_short_text(data.get("nekoInviteText"), max_chars=120) if neko_initiated else ""
+            state = _activate_game_route(
                 game_type,
                 session_id,
                 lanlan_name,
+                data.get("game_last_full_dialogue_count"),
             )
-            await _finalize_game_route_state(
-                old_state,
-                reason="superseded_by_route_start",
-                close_game_session=True,
+            # Take over the SessionManager: ordinary chat LLM output handlers must
+            # stay silent during the game, and any voice transcript that reaches
+            # the SessionManager must be redirected into route_external_voice_transcript.
+            mgr = get_session_manager().get(lanlan_name)
+            if mgr is not None:
+                async def _takeover_dispatcher(_lan, transcript_text, *, request_id):
+                    return await route_external_voice_transcript(
+                        _lan,
+                        transcript_text,
+                        request_id=request_id,
+                        game_type=game_type,
+                        session_id=session_id,
+                    )
+                mgr._takeover_active = True
+                mgr._takeover_input_dispatcher = _takeover_dispatcher
+            state["game_memory_tail_count"] = _normalize_game_memory_tail_count(
+                data.get("game_memory_tail_count", data.get("gameMemoryTailCount"))
             )
-
-        neko_initiated = bool(data.get("nekoInitiated"))
-        neko_invite_text = _normalize_short_text(data.get("nekoInviteText"), max_chars=120) if neko_initiated else ""
-        state = _activate_game_route(
-            game_type,
-            session_id,
-            lanlan_name,
-            data.get("game_last_full_dialogue_count"),
-        )
-        # Take over the SessionManager: ordinary chat LLM output handlers must
-        # stay silent during the game, and any voice transcript that reaches
-        # the SessionManager must be redirected into route_external_voice_transcript.
-        mgr = get_session_manager().get(lanlan_name)
-        if mgr is not None:
-            async def _takeover_dispatcher(_lan, transcript_text, *, request_id):
-                return await route_external_voice_transcript(
-                    _lan,
-                    transcript_text,
-                    request_id=request_id,
-                    game_type=game_type,
-                    session_id=session_id,
-                )
-            mgr._takeover_active = True
-            mgr._takeover_input_dispatcher = _takeover_dispatcher
-        state["game_memory_tail_count"] = _normalize_game_memory_tail_count(
-            data.get("game_memory_tail_count", data.get("gameMemoryTailCount"))
-        )
-        _update_game_memory_enabled_from_payload(state, data)
-        state["nekoInitiated"] = neko_initiated
-        state["nekoInviteText"] = neko_invite_text
-        _update_route_start_state_from_payload(state, data)
+            _update_game_memory_enabled_from_payload(state, data)
+            state["nekoInitiated"] = neko_initiated
+            state["nekoInviteText"] = neko_invite_text
+            _update_route_start_state_from_payload(state, data)
     if game_type == "soccer":
         state["heartbeat_enabled"] = False
         try:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3646,6 +3646,17 @@ async def _close_and_remove_session(
     the 15s ``stream_text`` timeout. New chats arriving after we set the
     route's ``_exit_flow_started`` flag short-circuit before they ever
     touch the entry lock.
+
+    codex P1 (PR #1127 r3182582714): identity-gate the cache eviction.
+    Two close callers can read the same ``entry`` then queue on its
+    lock; while they wait, a peer may pop the cache, a fresh
+    ``/route/start`` may build ``entry_NEW`` under the same key, and we
+    would otherwise wake up and pop ``entry_NEW`` — closing a live
+    session a different route owns. Mirrors the postgame ownership gate
+    in ``_deliver_postgame_text_bubble``'s finally. We always close OUR
+    captured ``entry``'s session (it's ours since the top of this
+    function) but only touch the cache / create-lock dicts if they
+    still point at us.
     """
     keys = []
     if lanlan_name:
@@ -3668,33 +3679,30 @@ async def _close_and_remove_session(
     entry_lock = entry.get('lock')
     if isinstance(entry_lock, asyncio.Lock):
         async with entry_lock:
-            popped = _game_sessions.pop(key, None)
-            if popped is None:
-                return False
-            session = popped.get('session')
+            cache_owned = _game_sessions.get(key) is entry
+            if cache_owned:
+                _game_sessions.pop(key, None)
+                _game_session_create_locks.pop(key, None)
     else:
-        popped = _game_sessions.pop(key, None)
-        if popped is None:
-            return False
-        session = popped.get('session')
+        cache_owned = _game_sessions.get(key) is entry
+        if cache_owned:
+            _game_sessions.pop(key, None)
+            _game_session_create_locks.pop(key, None)
 
-    # codex P2 follow-up: drop the per-key create lock alongside the
-    # evicted session so ``_game_session_create_locks`` does not grow
-    # unbounded over uptime. After eviction the lock would only protect
-    # a fresh, unrelated build — keeping the stale Lock instance buys
-    # nothing and accumulates memory as session_ids churn. Pop is
-    # synchronous (no await) so two concurrent close callers cannot
-    # race and double-pop into a KeyError; ``pop(..., None)`` is
-    # idempotent.
-    _game_session_create_locks.pop(key, None)
-
+    # Why: ``entry`` was captured at the top of this function; we own its
+    # lifecycle even if a peer closer rotated the cache to ``entry_NEW``
+    # while we waited on the lock. Always close OUR session so the
+    # client cannot leak. ``OmniOfflineClient.close`` is idempotent
+    # (omni_offline_client.py:1815-1835), so any peer's prior close on
+    # the same object is safe to re-run.
+    session = entry.get('session')
     if session:
         try:
             await session.close()
         except Exception as e:
             logger.debug("🎮 关闭游戏 session 失败: key=%s err=%s", key, e, exc_info=True)
 
-    logger.info("🎮 结束游戏 session: %s", key)
+    logger.info("🎮 结束游戏 session: %s cache_owned=%s", key, cache_owned)
     return True
 
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3178,9 +3178,34 @@ async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: s
             entry = _game_sessions[canonical_key]
             entry['last_activity'] = time.time()
             return entry
-        return await _build_and_register_game_session(
-            canonical_key, game_type, session_id, char_info,
-        )
+        try:
+            return await _build_and_register_game_session(
+                canonical_key, game_type, session_id, char_info,
+            )
+        except BaseException:
+            # codex P2 (PR #1127 r3182157092): if the build raises,
+            # nothing inserts into ``_game_sessions`` for this key, so
+            # ``_close_and_remove_session`` will never run for it and
+            # the per-key create lock would leak forever. Evict it
+            # here.
+            #
+            # Why conditional pop on ``_waiters``: if a peer task is
+            # already awaiting THIS lock (concurrent miss for the same
+            # canonical_key), unconditionally popping would let a new
+            # arrival call ``_get_session_create_lock`` and receive a
+            # FRESH lock object — distinct from the one the peer is
+            # awaiting — defeating the build serialization. Leaving
+            # the lock in place when there are waiters keeps them on
+            # the same Lock instance; the next successful build path
+            # registers an entry and ``_close_and_remove_session``
+            # will pop normally; another failed build will hit this
+            # branch again and eventually find ``_waiters`` empty.
+            # ``_waiters`` is CPython-private but stable across all
+            # supported Python versions.
+            waiters = getattr(create_lock, "_waiters", None)
+            if not waiters:
+                _game_session_create_locks.pop(canonical_key, None)
+            raise
 
 
 async def _build_and_register_game_session(
@@ -3682,6 +3707,15 @@ async def _run_game_chat(
     # Re-resolve canonical lanlan_name for state lookups.
     lanlan_name = str(entry.get("lanlan_name") or lanlan_name or "").strip()
 
+    # CR Major (PR #1127 r3182158697): when the post-lock route_inactive
+    # short-circuit trips and our build won the race against a finalize
+    # that ran during ``session.connect``, the freshly-registered entry
+    # would otherwise survive until the 30-min idle sweep. We capture
+    # the orphan inside the lock and close it AFTER releasing
+    # ``entry['lock']`` — ``_close_and_remove_session`` re-acquires that
+    # same lock, so closing through it under the lock would deadlock.
+    orphan_session_to_close = None
+    short_circuit_route_inactive = False
     async with entry['lock']:
         # B2: short-circuit if a finalize already kicked off (heartbeat
         # sweep, character switch, /route/end). Without this guard the
@@ -3699,60 +3733,85 @@ async def _run_game_chat(
                     "🎮 chat short-circuit: route exiting/inactive game=%s sid=%s lanlan=%s",
                     game_type, session_id, lanlan_name,
                 )
-                return {"line": "", "control": {}, "skipped": "route_inactive"}
+                # Evict our entry IFF the cache still points at us. If
+                # a peer creator already overwrote our slot, they own
+                # the close.
+                key = _game_session_key(lanlan_name, game_type, session_id)
+                cached = _game_sessions.get(key)
+                if cached is entry:
+                    _game_sessions.pop(key, None)
+                    _game_session_create_locks.pop(key, None)
+                    orphan_session_to_close = entry.get('session')
+                short_circuit_route_inactive = True
 
-        # B1: bail if our entry has been popped from the cache (peer
-        # creator overwrote us, or finalize closed the session while we
-        # were waiting on entry['lock']). Continuing would call
-        # ``stream_text`` on a closed client.
-        current_entry = _game_sessions.get(_game_session_key(lanlan_name, game_type, session_id))
-        if current_entry is not entry:
-            logger.info(
-                "🎮 chat short-circuit: entry no longer cached game=%s sid=%s lanlan=%s",
-                game_type, session_id, lanlan_name,
-            )
-            return {"line": "", "control": {}, "skipped": "entry_evicted"}
+        if not short_circuit_route_inactive:
+            # B1: bail if our entry has been popped from the cache (peer
+            # creator overwrote us, or finalize closed the session while
+            # we were waiting on entry['lock']). Continuing would call
+            # ``stream_text`` on a closed client.
+            current_entry = _game_sessions.get(_game_session_key(lanlan_name, game_type, session_id))
+            if current_entry is not entry:
+                logger.info(
+                    "🎮 chat short-circuit: entry no longer cached game=%s sid=%s lanlan=%s",
+                    game_type, session_id, lanlan_name,
+                )
+                return {"line": "", "control": {}, "skipped": "entry_evicted"}
 
-        session = entry['session']
-        reply_chunks = entry['reply_chunks']
-        await _refresh_game_session_instructions(entry, game_type, session_id, lanlan_name)
+            session = entry['session']
+            reply_chunks = entry['reply_chunks']
+            await _refresh_game_session_instructions(entry, game_type, session_id, lanlan_name)
 
-        # 清空上一次的回复
-        reply_chunks.clear()
+            # 清空上一次的回复
+            reply_chunks.clear()
 
-        if game_type == "soccer" and isinstance(event, dict):
-            route_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
-            anger_pressure_cap = _build_soccer_anger_pressure_cap(
-                event,
-                route_state,
-                lanlan_prompt=str(entry.get("lanlan_prompt") or ""),
-            )
-            if anger_pressure_cap:
-                event = dict(event)
-                event["angerPressureCap"] = anger_pressure_cap
+            if game_type == "soccer" and isinstance(event, dict):
+                route_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+                anger_pressure_cap = _build_soccer_anger_pressure_cap(
+                    event,
+                    route_state,
+                    lanlan_prompt=str(entry.get("lanlan_prompt") or ""),
+                )
+                if anger_pressure_cap:
+                    event = dict(event)
+                    event["angerPressureCap"] = anger_pressure_cap
 
-        # 格式化事件为文本发送给 LLM
-        import json as _json
-        if isinstance(event, dict):
-            event_text = _json.dumps(event, ensure_ascii=False)
-        else:
-            event_text = str(event)
+            # 格式化事件为文本发送给 LLM
+            import json as _json
+            if isinstance(event, dict):
+                event_text = _json.dumps(event, ensure_ascii=False)
+            else:
+                event_text = str(event)
 
-        llm_started_at = time.perf_counter()
-        try:
-            await asyncio.wait_for(
-                session.stream_text(event_text),
-                timeout=15.0,
-            )
-        except asyncio.TimeoutError:
-            logger.warning("🎮 游戏 LLM 响应超时: game=%s sid=%s", game_type, session_id)
-            return {"error": "LLM 响应超时", "line": "", "control": {}}
-        except Exception as e:
-            logger.error("🎮 游戏 LLM 调用失败: %s", e)
-            return {"error": f"LLM 调用失败: {e}", "line": "", "control": {}}
+            llm_started_at = time.perf_counter()
+            try:
+                await asyncio.wait_for(
+                    session.stream_text(event_text),
+                    timeout=15.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning("🎮 游戏 LLM 响应超时: game=%s sid=%s", game_type, session_id)
+                return {"error": "LLM 响应超时", "line": "", "control": {}}
+            except Exception as e:
+                logger.error("🎮 游戏 LLM 调用失败: %s", e)
+                return {"error": f"LLM 调用失败: {e}", "line": "", "control": {}}
 
-        llm_elapsed_ms = int((time.perf_counter() - llm_started_at) * 1000)
-        full_reply = ''.join(reply_chunks)
+            llm_elapsed_ms = int((time.perf_counter() - llm_started_at) * 1000)
+            full_reply = ''.join(reply_chunks)
+
+    if short_circuit_route_inactive:
+        # Close the orphan session OUTSIDE entry['lock'] to avoid
+        # deadlocking against any future caller that takes the same
+        # lock. ``orphan_session_to_close`` is None when a peer beat us
+        # to the eviction.
+        if orphan_session_to_close is not None:
+            try:
+                await orphan_session_to_close.close()
+            except Exception as e:
+                logger.debug(
+                    "🎮 关闭短路 game session 失败: game=%s sid=%s err=%s",
+                    game_type, session_id, e, exc_info=True,
+                )
+        return {"line": "", "control": {}, "skipped": "route_inactive"}
 
     result = _parse_control_instructions(full_reply)
     if game_type == "soccer" and isinstance(event, dict):

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -2849,7 +2849,14 @@ async def _deliver_postgame_text_bubble(
             lanlan_name=str(archive.get("lanlan_name") or ""),
             source="game_end",
         )
-        llm_result = await _run_game_chat(game_type, session_id, event)
+        # Why: postgame runs AFTER ``_finalize_game_route_state`` flips the
+        # route to inactive, so the standard B1/B2 short-circuits would
+        # silently drop this designed teardown step. ``allow_postgame``
+        # opts out of those route-active gates; we own the lifecycle of
+        # any session built here and close it in the ``finally`` below.
+        llm_result = await _run_game_chat(
+            game_type, session_id, event, allow_postgame=True,
+        )
         line = str(llm_result.get("line") or "").strip()
         if not line:
             return {
@@ -2902,6 +2909,22 @@ async def _deliver_postgame_text_bubble(
                 await state_machine.fire(SessionEvent.PROACTIVE_DONE)
         except Exception as exc:
             logger.debug("🎮 赛后文本气泡状态机收尾失败: %s", exc, exc_info=True)
+        # Why: ``_run_game_chat(..., allow_postgame=True)`` may have built
+        # a fresh ``OmniOfflineClient`` after finalize already evicted
+        # the prior session. No other lifecycle hook will close it once
+        # the route is gone — we must do it here to avoid a permanent
+        # leak (the very risk that motivated the B1/B2 short-circuits).
+        try:
+            postgame_lanlan = str(archive.get("lanlan_name") or "")
+            if postgame_lanlan:
+                await _close_and_remove_session(
+                    game_type, session_id, postgame_lanlan,
+                )
+        except Exception as exc:
+            logger.debug(
+                "🎮 赛后文本气泡 session 清理失败: game=%s session=%s err=%s",
+                game_type, session_id, exc, exc_info=True,
+            )
 
 
 async def _deliver_game_postgame(
@@ -3600,13 +3623,25 @@ async def _close_and_remove_session(
     return True
 
 
-async def _run_game_chat(game_type: str, session_id: str, event: Any) -> Dict[str, Any]:
+async def _run_game_chat(
+    game_type: str,
+    session_id: str,
+    event: Any,
+    *,
+    allow_postgame: bool = False,
+) -> Dict[str, Any]:
     """Run A-layer game LLM for both HTTP game events and hijacked external text.
 
     B1/B2/B3: short-circuit if the route is mid-exit (or already
     inactive). Otherwise the chat would call ``stream_text`` against a
     session that finalize is about to close, and ``_append_game_dialog``
     afterwards would write into an already-archived state slot.
+
+    ``allow_postgame=True`` is the legitimate exception: postgame text
+    bubble runs *after* finalize on purpose (designed teardown step).
+    The caller (``_deliver_postgame_text_bubble``) is responsible for
+    closing the freshly-built session afterwards via
+    ``_close_and_remove_session`` so the bypass doesn't leak a client.
     """
     request_started_at = time.perf_counter()
 
@@ -3626,16 +3661,17 @@ async def _run_game_chat(game_type: str, session_id: str, event: Any) -> Dict[st
     # already inactive) we must not spawn a fresh ``OmniOfflineClient``
     # — that would survive past the finalize and become a permanent leak
     # since nothing else in the lifecycle would close it.
-    pre_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
-    if isinstance(pre_state, dict) and (
-        pre_state.get("_exit_flow_started")
-        or pre_state.get("game_route_active") is False
-    ):
-        logger.info(
-            "🎮 chat short-circuit (pre-create): route exiting/inactive game=%s sid=%s lanlan=%s",
-            game_type, session_id, lanlan_name,
-        )
-        return {"line": "", "control": {}, "skipped": "route_inactive"}
+    if not allow_postgame:
+        pre_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+        if isinstance(pre_state, dict) and (
+            pre_state.get("_exit_flow_started")
+            or pre_state.get("game_route_active") is False
+        ):
+            logger.info(
+                "🎮 chat short-circuit (pre-create): route exiting/inactive game=%s sid=%s lanlan=%s",
+                game_type, session_id, lanlan_name,
+            )
+            return {"line": "", "control": {}, "skipped": "route_inactive"}
 
     try:
         entry = await _get_or_create_session(game_type, session_id, lanlan_name)
@@ -3653,16 +3689,17 @@ async def _run_game_chat(game_type: str, session_id: str, event: Any) -> Dict[st
         # already-closed ``OmniOfflineClient`` and append to a
         # ``pending_outputs`` / ``game_dialog_log`` slot whose archive
         # has already been written.
-        route_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
-        if isinstance(route_state, dict) and (
-            route_state.get("_exit_flow_started")
-            or route_state.get("game_route_active") is False
-        ):
-            logger.info(
-                "🎮 chat short-circuit: route exiting/inactive game=%s sid=%s lanlan=%s",
-                game_type, session_id, lanlan_name,
-            )
-            return {"line": "", "control": {}, "skipped": "route_inactive"}
+        if not allow_postgame:
+            route_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+            if isinstance(route_state, dict) and (
+                route_state.get("_exit_flow_started")
+                or route_state.get("game_route_active") is False
+            ):
+                logger.info(
+                    "🎮 chat short-circuit: route exiting/inactive game=%s sid=%s lanlan=%s",
+                    game_type, session_id, lanlan_name,
+                )
+                return {"line": "", "control": {}, "skipped": "route_inactive"}
 
         # B1: bail if our entry has been popped from the cache (peer
         # creator overwrote us, or finalize closed the session while we

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -41,6 +41,7 @@ from main_logic.mirror_meta import (
 from utils.game_route_state import (
     _game_route_states,
     _get_active_game_route_state,
+    _get_route_lock,
     _route_state_key,
     is_game_route_active,
     register_voice_transcript_handler,
@@ -113,6 +114,26 @@ _GAME_ROUTE_HEARTBEAT_SWEEP_SECONDS = 2.0
 _ACCIDENTAL_GAME_ENTRY_GRACE_MS = 10_000
 _SESSION_CLEANUP_SWEEP_SECONDS = 60.0
 _GAME_DEBUG_MATERIAL_LOG_LIMIT = 24000
+
+# Per-(lanlan, game_type, session_id) creation lock for ``_get_or_create_session``.
+#
+# B6: without this, two concurrent ``_run_game_chat`` calls for the same
+# key both miss the cache, both build an ``OmniOfflineClient`` and both
+# ``await session.connect(...)``. The second insertion overwrites
+# ``_game_sessions[key]`` so the first ``entry`` is now an orphan: its
+# ``lock`` is held by the first ``_run_game_chat``, but the cache no
+# longer points at it, so nothing will ever ``close()`` that session.
+# Keeping these locks process-scoped (never popped) is fine — at most one
+# Lock per ever-seen game session, negligible memory.
+_game_session_create_locks: Dict[str, asyncio.Lock] = {}
+
+
+def _get_session_create_lock(key: str) -> asyncio.Lock:
+    """Lazy-init the per-key creation lock; sync helper, never awaits."""
+    lock = _game_session_create_locks.get(key)
+    if lock is None:
+        lock = _game_session_create_locks.setdefault(key, asyncio.Lock())
+    return lock
 
 
 def _log_game_debug_material(
@@ -1301,7 +1322,20 @@ def _should_schedule_game_context_organizer(state: dict) -> bool:
 
 
 def _maybe_schedule_game_context_organizer(state: dict) -> None:
+    """Spawn the per-state organizer task at most once at any given time.
+
+    B4: ``running`` is a dict flag the audit flagged as racy. In practice,
+    on CPython this scheduler is invoked from sync code paths only — the
+    enclosing ``_append_game_dialog`` body has no ``await`` so two
+    coroutines on the same event loop cannot interleave inside it. Still,
+    we add a defensive previous-task done-check so an in-flight organizer
+    is never silently overwritten if a future change introduces an
+    ``await`` boundary in the call chain.
+    """
     if not _should_schedule_game_context_organizer(state):
+        return
+    prev = state.get("_game_context_organizer_task")
+    if prev is not None and hasattr(prev, "done") and not prev.done():
         return
     snapshot = [dict(item) for item in _game_context_pending_dialogues(state)]
     if len(snapshot) < _GAME_CONTEXT_ORGANIZE_TRIGGER_COUNT:
@@ -1319,6 +1353,13 @@ def _maybe_schedule_game_context_organizer(state: dict) -> None:
 
 
 def _append_game_dialog(state: dict, item: dict) -> None:
+    # B2: once finalize has started archiving, the snapshot of
+    # ``game_dialog_log`` has already been captured. Mutating it after
+    # that point produces entries that never reach the archive — they
+    # silently disappear when ``_game_route_states`` is eventually
+    # popped by the cleanup sweep. Drop late writes instead.
+    if state.get("_exit_flow_started"):
+        return
     item = dict(item)
     item.setdefault("ts", time.time())
     if item.get("id"):
@@ -1332,6 +1373,11 @@ def _append_game_dialog(state: dict, item: dict) -> None:
 
 
 def _append_game_output(state: dict, output: dict) -> None:
+    # B2: once finalize has started, ``pending_outputs`` will never be
+    # drained again (the route is exiting, the game page won't ``/drain``
+    # any further). Late writes accumulate into oblivion.
+    if state.get("_exit_flow_started"):
+        return
     pending = state.setdefault("pending_outputs", [])
     pending.append(output)
     del pending[:-_GAME_ROUTE_OUTPUT_LIMIT]
@@ -2940,26 +2986,32 @@ async def _finalize_game_route_state(
     reason: str,
     close_game_session: bool = False,
 ) -> dict:
-    """Run the game route exit flow once, including archive submission."""
+    """Run the game route exit flow once, including archive submission.
+
+    Concurrent-call semantics:
+
+    - The first caller spawns ``_finalize_game_route_state_inner`` and
+      shields its task. Subsequent callers ``await asyncio.shield`` the
+      same task.
+    - ``close_game_session`` uses **OR-merge** semantics across concurrent
+      callers (B5): we stash the requested value on the state under
+      ``_exit_close_session_request``, and the inner runner reads that
+      flag (not its constructor arg) when deciding whether to close.
+      Previously the second caller's ``True`` was silently dropped while
+      the first caller's ``False`` won; the second caller then redundantly
+      invoked ``_close_and_remove_session`` outside the shield, racing
+      with the inner finalize and producing double-pop / double-close.
+    """
+    if close_game_session:
+        state["_exit_close_session_request"] = True
+    elif "_exit_close_session_request" not in state:
+        state["_exit_close_session_request"] = False
+
     existing_task = state.get("_exit_task")
     if existing_task:
-        result = await asyncio.shield(existing_task)
-        if close_game_session and not result.get("game_session_closed"):
-            closed = await _close_and_remove_session(
-                str(state.get("game_type") or ""),
-                str(state.get("session_id") or "default"),
-                str(state.get("lanlan_name") or ""),
-            )
-            result["game_session_closed"] = closed
-        return result
+        return await asyncio.shield(existing_task)
 
-    task = asyncio.create_task(
-        _finalize_game_route_state_inner(
-            state,
-            reason=reason,
-            close_game_session=close_game_session,
-        )
-    )
+    task = asyncio.create_task(_finalize_game_route_state_inner(state, reason=reason))
     state["_exit_task"] = task
     return await asyncio.shield(task)
 
@@ -2968,7 +3020,6 @@ async def _finalize_game_route_state_inner(
     state: dict,
     *,
     reason: str,
-    close_game_session: bool,
 ) -> dict:
     state["_exit_flow_started"] = True
     state["exit_reason"] = reason
@@ -3027,8 +3078,12 @@ async def _finalize_game_route_state_inner(
             memory_result = await _submit_game_archive_to_memory(archive)
         state["archive_memory_result"] = memory_result
 
+    # B5: OR-merge close decision across concurrent callers (see note in
+    # ``_finalize_game_route_state``). Re-read the flag *after* awaiting
+    # the archive work so a second caller arriving mid-finalize with
+    # ``close_game_session=True`` still wins.
     session_closed = False
-    if close_game_session:
+    if state.get("_exit_close_session_request"):
         session_closed = await _close_and_remove_session(
             str(state.get("game_type") or ""),
             str(state.get("session_id") or "default"),
@@ -3045,7 +3100,20 @@ async def _finalize_game_route_state_inner(
 
 
 async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: str = "") -> dict:
-    """获取或创建游戏 session。"""
+    """获取或创建游戏 session.
+
+    B6: serialize the cache-miss → ctor → connect → cache-insert sequence
+    under a per-key ``asyncio.Lock`` so two concurrent ``_run_game_chat``
+    calls for the same ``(lanlan, game_type, session_id)`` cannot both
+    build a fresh ``OmniOfflineClient`` and overwrite each other in
+    ``_game_sessions``, leaking the loser's connection.
+
+    Note: ``lanlan_name`` may be empty on entry (caller-supplied) but
+    canonicalizes to ``char_info["lanlan_name"]`` after the cache miss.
+    The cache + lock keys must agree, so we recompute both under the
+    initial-key lock; if the canonical key differs, we re-acquire the
+    canonical lock to keep the dedup invariant.
+    """
     key = _game_session_key(lanlan_name, game_type, session_id)
 
     if key in _game_sessions:
@@ -3053,19 +3121,47 @@ async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: s
         entry['last_activity'] = time.time()
         return entry
 
-    # 延迟导入，避免循环依赖
+    create_lock = _get_session_create_lock(key)
+    async with create_lock:
+        if key in _game_sessions:
+            entry = _game_sessions[key]
+            entry['last_activity'] = time.time()
+            return entry
+
+        char_info = _get_character_info(lanlan_name)
+        lanlan_name = str(char_info.get("lanlan_name") or lanlan_name or "").strip()
+        canonical_key = _game_session_key(lanlan_name, game_type, session_id)
+        if canonical_key != key:
+            canonical_lock = _get_session_create_lock(canonical_key)
+            async with canonical_lock:
+                if canonical_key in _game_sessions:
+                    entry = _game_sessions[canonical_key]
+                    entry['last_activity'] = time.time()
+                    return entry
+                return await _build_and_register_game_session(
+                    canonical_key, game_type, session_id, char_info,
+                )
+        if key in _game_sessions:
+            entry = _game_sessions[key]
+            entry['last_activity'] = time.time()
+            return entry
+        return await _build_and_register_game_session(
+            key, game_type, session_id, char_info,
+        )
+
+
+async def _build_and_register_game_session(
+    key: str,
+    game_type: str,
+    session_id: str,
+    char_info: dict,
+) -> dict:
+    """Build a fresh game session entry; caller must already hold the
+    per-key creation lock (see ``_get_or_create_session``)."""
     from main_logic.omni_offline_client import OmniOfflineClient
     from utils.token_tracker import set_call_type
 
-    char_info = _get_character_info(lanlan_name)
-    lanlan_name = str(char_info.get("lanlan_name") or lanlan_name or "").strip()
-    key = _game_session_key(lanlan_name, game_type, session_id)
-    if key in _game_sessions:
-        entry = _game_sessions[key]
-        entry['last_activity'] = time.time()
-        return entry
-
-    # 创建回复收集器
+    lanlan_name = str(char_info.get("lanlan_name") or "").strip()
     reply_chunks: list[str] = []
 
     async def on_text_delta(text: str, is_first: bool):
@@ -3094,7 +3190,16 @@ async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: s
         game_context if isinstance(game_context, dict) else None,
         char_info.get("user_language"),
     )
-    await session.connect(instructions=system_prompt)
+    try:
+        await session.connect(instructions=system_prompt)
+    except Exception:
+        # Connect failed — ensure we don't leak a half-open client. close
+        # is idempotent / tolerant of "never connected".
+        try:
+            await session.close()
+        except Exception:
+            pass
+        raise
 
     entry = {
         'session': session,
@@ -3420,23 +3525,51 @@ async def _close_and_remove_session(
     session_id: str,
     lanlan_name: str = "",
 ) -> bool:
-    """关闭并移除指定游戏 session。"""
+    """关闭并移除指定游戏 session.
+
+    B1: serialize against in-flight ``_run_game_chat`` work for the same
+    entry by acquiring ``entry['lock']`` before popping + closing. Without
+    this, a concurrent close (from ``/route/start`` finalize, heartbeat
+    sweep, or ``/route/end``) would yank the session out of the cache and
+    close it while a chat call still held a reference and was mid
+    ``stream_text``, producing reads against a closed client.
+
+    The entry-level lock keeps the wait bounded — chat work is capped by
+    the 15s ``stream_text`` timeout. New chats arriving after we set the
+    route's ``_exit_flow_started`` flag short-circuit before they ever
+    touch the entry lock.
+    """
     keys = []
     if lanlan_name:
         keys.append(_game_session_key(lanlan_name, game_type, session_id))
     keys.append(_game_session_key("", game_type, session_id))
 
+    # First locate the entry (without popping) to grab its lock, then pop
+    # under the lock. Two close callers racing here both serialize on the
+    # same lock and only one observes a non-None entry after pop.
     key = ""
     entry = None
     for candidate in keys:
         key = candidate
-        entry = _game_sessions.pop(candidate, None)
+        entry = _game_sessions.get(candidate)
         if entry:
             break
     if not entry:
         return False
 
-    session = entry.get('session')
+    entry_lock = entry.get('lock')
+    if isinstance(entry_lock, asyncio.Lock):
+        async with entry_lock:
+            popped = _game_sessions.pop(key, None)
+            if popped is None:
+                return False
+            session = popped.get('session')
+    else:
+        popped = _game_sessions.pop(key, None)
+        if popped is None:
+            return False
+        session = popped.get('session')
+
     if session:
         try:
             await session.close()
@@ -3448,7 +3581,13 @@ async def _close_and_remove_session(
 
 
 async def _run_game_chat(game_type: str, session_id: str, event: Any) -> Dict[str, Any]:
-    """Run A-layer game LLM for both HTTP game events and hijacked external text."""
+    """Run A-layer game LLM for both HTTP game events and hijacked external text.
+
+    B1/B2/B3: short-circuit if the route is mid-exit (or already
+    inactive). Otherwise the chat would call ``stream_text`` against a
+    session that finalize is about to close, and ``_append_game_dialog``
+    afterwards would write into an already-archived state slot.
+    """
     request_started_at = time.perf_counter()
 
     if not event:
@@ -3463,16 +3602,62 @@ async def _run_game_chat(game_type: str, session_id: str, event: Any) -> Dict[st
             event = dict(event)
             event['balanceHint'] = balance_hint
 
+    # B1/B2: pre-create short-circuit. If the route is mid-exit (or
+    # already inactive) we must not spawn a fresh ``OmniOfflineClient``
+    # — that would survive past the finalize and become a permanent leak
+    # since nothing else in the lifecycle would close it.
+    pre_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+    if isinstance(pre_state, dict) and (
+        pre_state.get("_exit_flow_started")
+        or pre_state.get("game_route_active") is False
+    ):
+        logger.info(
+            "🎮 chat short-circuit (pre-create): route exiting/inactive game=%s sid=%s lanlan=%s",
+            game_type, session_id, lanlan_name,
+        )
+        return {"line": "", "control": {}, "skipped": "route_inactive"}
+
     try:
         entry = await _get_or_create_session(game_type, session_id, lanlan_name)
     except Exception as e:
         logger.error("🎮 创建游戏 session 失败: %s", e)
         return {"error": f"创建 session 失败: {e}"}
 
+    # Re-resolve canonical lanlan_name for state lookups.
+    lanlan_name = str(entry.get("lanlan_name") or lanlan_name or "").strip()
+
     async with entry['lock']:
+        # B2: short-circuit if a finalize already kicked off (heartbeat
+        # sweep, character switch, /route/end). Without this guard the
+        # chat call below would still ``stream_text`` against an
+        # already-closed ``OmniOfflineClient`` and append to a
+        # ``pending_outputs`` / ``game_dialog_log`` slot whose archive
+        # has already been written.
+        route_state = _find_game_route_state_for_session(game_type, session_id, lanlan_name)
+        if isinstance(route_state, dict) and (
+            route_state.get("_exit_flow_started")
+            or route_state.get("game_route_active") is False
+        ):
+            logger.info(
+                "🎮 chat short-circuit: route exiting/inactive game=%s sid=%s lanlan=%s",
+                game_type, session_id, lanlan_name,
+            )
+            return {"line": "", "control": {}, "skipped": "route_inactive"}
+
+        # B1: bail if our entry has been popped from the cache (peer
+        # creator overwrote us, or finalize closed the session while we
+        # were waiting on entry['lock']). Continuing would call
+        # ``stream_text`` on a closed client.
+        current_entry = _game_sessions.get(_game_session_key(lanlan_name, game_type, session_id))
+        if current_entry is not entry:
+            logger.info(
+                "🎮 chat short-circuit: entry no longer cached game=%s sid=%s lanlan=%s",
+                game_type, session_id, lanlan_name,
+            )
+            return {"line": "", "control": {}, "skipped": "entry_evicted"}
+
         session = entry['session']
         reply_chunks = entry['reply_chunks']
-        lanlan_name = str(entry.get("lanlan_name") or lanlan_name or "").strip()
         await _refresh_game_session_instructions(entry, game_type, session_id, lanlan_name)
 
         # 清空上一次的回复
@@ -3596,58 +3781,69 @@ async def game_route_start(game_type: str, request: Request):
     # is_game_route_active(lanlan_name) / _get_active_game_route_state(lanlan_name)
     # 这些不带 game_type 的查询会拿到 dict 迭代顺序里"先出现"的那个 route，导致
     # 文本/语音输入归属不确定。
-    for old_state in [
-        candidate
-        for candidate in list(_game_route_states.values())
-        if candidate.get("game_route_active")
-        and str(candidate.get("lanlan_name") or "") == lanlan_name
-    ]:
-        old_game_type = str(old_state.get("game_type") or "")
-        old_session_id = str(old_state.get("session_id") or "default")
-        logger.warning(
-            "🎮 新游戏路由启动前发现旧 active route，先结束旧局: old_game=%s old_session=%s new_game=%s new_session=%s lanlan=%s",
-            old_game_type,
-            old_session_id,
+    #
+    # B1: serialize the supersede + activation block under the per-(lanlan,
+    # game_type) route lock so heartbeat-sweep finalize and /route/end
+    # finalize cannot interleave the close + activate steps. The pregame
+    # context build (network call, can take seconds) is intentionally
+    # *outside* the lock — by then the new state is already activated, so
+    # peers see the new slot via ``_get_active_*`` helpers; holding the
+    # lock for the whole pregame would block heartbeat sweep with no
+    # benefit.
+    route_lock = _get_route_lock(lanlan_name, game_type)
+    async with route_lock:
+        for old_state in [
+            candidate
+            for candidate in list(_game_route_states.values())
+            if candidate.get("game_route_active")
+            and str(candidate.get("lanlan_name") or "") == lanlan_name
+        ]:
+            old_game_type = str(old_state.get("game_type") or "")
+            old_session_id = str(old_state.get("session_id") or "default")
+            logger.warning(
+                "🎮 新游戏路由启动前发现旧 active route，先结束旧局: old_game=%s old_session=%s new_game=%s new_session=%s lanlan=%s",
+                old_game_type,
+                old_session_id,
+                game_type,
+                session_id,
+                lanlan_name,
+            )
+            await _finalize_game_route_state(
+                old_state,
+                reason="superseded_by_route_start",
+                close_game_session=True,
+            )
+
+        neko_initiated = bool(data.get("nekoInitiated"))
+        neko_invite_text = _normalize_short_text(data.get("nekoInviteText"), max_chars=120) if neko_initiated else ""
+        state = _activate_game_route(
             game_type,
             session_id,
             lanlan_name,
+            data.get("game_last_full_dialogue_count"),
         )
-        await _finalize_game_route_state(
-            old_state,
-            reason="superseded_by_route_start",
-            close_game_session=True,
+        # Take over the SessionManager: ordinary chat LLM output handlers must
+        # stay silent during the game, and any voice transcript that reaches
+        # the SessionManager must be redirected into route_external_voice_transcript.
+        mgr = get_session_manager().get(lanlan_name)
+        if mgr is not None:
+            async def _takeover_dispatcher(_lan, transcript_text, *, request_id):
+                return await route_external_voice_transcript(
+                    _lan,
+                    transcript_text,
+                    request_id=request_id,
+                    game_type=game_type,
+                    session_id=session_id,
+                )
+            mgr._takeover_active = True
+            mgr._takeover_input_dispatcher = _takeover_dispatcher
+        state["game_memory_tail_count"] = _normalize_game_memory_tail_count(
+            data.get("game_memory_tail_count", data.get("gameMemoryTailCount"))
         )
-
-    neko_initiated = bool(data.get("nekoInitiated"))
-    neko_invite_text = _normalize_short_text(data.get("nekoInviteText"), max_chars=120) if neko_initiated else ""
-    state = _activate_game_route(
-        game_type,
-        session_id,
-        lanlan_name,
-        data.get("game_last_full_dialogue_count"),
-    )
-    # Take over the SessionManager: ordinary chat LLM output handlers must
-    # stay silent during the game, and any voice transcript that reaches
-    # the SessionManager must be redirected into route_external_voice_transcript.
-    mgr = get_session_manager().get(lanlan_name)
-    if mgr is not None:
-        async def _takeover_dispatcher(_lan, transcript_text, *, request_id):
-            return await route_external_voice_transcript(
-                _lan,
-                transcript_text,
-                request_id=request_id,
-                game_type=game_type,
-                session_id=session_id,
-            )
-        mgr._takeover_active = True
-        mgr._takeover_input_dispatcher = _takeover_dispatcher
-    state["game_memory_tail_count"] = _normalize_game_memory_tail_count(
-        data.get("game_memory_tail_count", data.get("gameMemoryTailCount"))
-    )
-    _update_game_memory_enabled_from_payload(state, data)
-    state["nekoInitiated"] = neko_initiated
-    state["nekoInviteText"] = neko_invite_text
-    _update_route_start_state_from_payload(state, data)
+        _update_game_memory_enabled_from_payload(state, data)
+        state["nekoInitiated"] = neko_initiated
+        state["nekoInviteText"] = neko_invite_text
+        _update_route_start_state_from_payload(state, data)
     if game_type == "soccer":
         state["heartbeat_enabled"] = False
         try:
@@ -4023,6 +4219,22 @@ async def _route_external_transcript_to_game(
     if not text:
         return True
 
+    # B3: state may have flipped to exiting/inactive between the caller's
+    # active-check and this call (the SessionManager dispatcher path in
+    # ``main_logic/core.py`` checks once at the dispatcher gate, then
+    # awaits us). Re-check here and short-circuit cleanly with no
+    # side-effects on a half-archived state. We treat short-circuit as
+    # "handled=True" (return True) so the caller does not also drive the
+    # transcript through the ordinary chat flow — the route was active at
+    # the dispatch gate, so the right semantic is "drop on the floor with
+    # no ordinary mirror" not "fall back to ordinary chat".
+    if state.get("_exit_flow_started") or state.get("game_route_active") is False:
+        logger.info(
+            "🎮 transcript short-circuit: route exiting/inactive lanlan=%s mode=%s kind=%s",
+            lanlan_name, mode, kind,
+        )
+        return True
+
     now = time.time()
     if kind == "user-voice":
         # Idempotency on request_id with a bounded TTL set rather than a
@@ -4226,6 +4438,62 @@ async def route_external_voice_transcript(
 # can call ``utils.game_route_state.route_external_voice_transcript`` instead
 # of importing from ``main_routers``.
 register_voice_transcript_handler(route_external_voice_transcript)
+
+
+async def finalize_game_routes_for_character(old_lanlan_name: str) -> int:
+    """Finalize every active game route for ``old_lanlan_name`` synchronously.
+
+    B8: when the user switches the active character via
+    ``POST /api/characters/current_catgirl``, the previous character may
+    still own an active game route. Without this hook, the route's heartbeat
+    keeps the slot live for up to 10-60s while the now-irrelevant
+    ``OmniOfflineClient`` keeps consuming events (and the stale
+    SessionManager takeover keeps muting the new character's ordinary
+    chat output). Finalizing immediately at switch time releases the
+    takeover and closes the LLM session.
+
+    Returns the number of routes finalized.
+    """
+    target = str(old_lanlan_name or "")
+    if not target:
+        return 0
+    candidates = [
+        candidate
+        for candidate in list(_game_route_states.values())
+        if candidate.get("game_route_active")
+        and str(candidate.get("lanlan_name") or "") == target
+    ]
+    finalized_count = 0
+    for old_state in candidates:
+        old_game_type = str(old_state.get("game_type") or "")
+        logger.warning(
+            "🎮 角色切换前结束旧角色游戏路由: lanlan=%s game=%s session=%s",
+            target,
+            old_game_type,
+            old_state.get("session_id") or "",
+        )
+        route_lock = _get_route_lock(target, old_game_type)
+        try:
+            async with route_lock:
+                if not old_state.get("game_route_active"):
+                    if old_state.get("_exit_task"):
+                        await asyncio.shield(old_state["_exit_task"])
+                    continue
+                await _finalize_game_route_state(
+                    old_state,
+                    reason="character_switch",
+                    close_game_session=True,
+                )
+                finalized_count += 1
+        except Exception as exc:
+            logger.warning(
+                "🎮 角色切换收尾失败: lanlan=%s game=%s err=%s",
+                target,
+                old_game_type,
+                exc,
+                exc_info=True,
+            )
+    return finalized_count
 
 
 async def route_external_stream_message(lanlan_name: str, message: dict) -> bool:
@@ -4439,7 +4707,18 @@ async def _complete_game_end_from_payload(
                 data.get("game_memory_tail_count", data.get("gameMemoryTailCount"))
             )
         _update_game_memory_enabled_from_payload(state, data)
-        finalized = await _finalize_game_route_state(state, reason=exit_reason)
+        # B1: serialize against /route/start supersede + heartbeat sweep
+        # finalize. ``_finalize_game_route_state`` itself dedupes via the
+        # state-attached ``_exit_task``, but acquiring the lock first
+        # guarantees that a fresh ``/route/start`` waits for our archive
+        # to land before activating a new state slot.
+        end_route_lock = _get_route_lock(lanlan_name, game_type)
+        async with end_route_lock:
+            finalized = await _finalize_game_route_state(
+                state,
+                reason=exit_reason,
+                close_game_session=True,
+            )
         archive = finalized["archive"]
         archive_memory = finalized["archive_memory"]
         if _soccer_game_memory_postgame_context_enabled(archive) is False:
@@ -4453,8 +4732,18 @@ async def _complete_game_end_from_payload(
             archive,
             postgame_options,
         )
-
-    closed = await _close_and_remove_session(game_type, session_id, lanlan_name)
+        # B5: closing the LLM session is the inner finalize's job (now
+        # that ``close_game_session=True`` reliably propagates via
+        # OR-merge). Calling ``_close_and_remove_session`` again here
+        # would race a finalize-from-heartbeat-sweep at the same key and
+        # double-close the underlying ``OmniOfflineClient``.
+        closed = bool(finalized.get("game_session_closed"))
+    else:
+        # No active route matched — fall through to the legacy direct close
+        # so an out-of-sync ``/game_end`` (e.g. page reloaded after the
+        # backend already finalized via heartbeat sweep) still cleans up a
+        # lingering LLM session if one exists.
+        closed = await _close_and_remove_session(game_type, session_id, lanlan_name)
     result = {
         "ok": True,
         "closed": closed,
@@ -4638,12 +4927,27 @@ async def cleanup_expired_sessions():
                 now - last_heartbeat,
                 now - last_activity,
             )
+            # B2: serialize against any concurrent /route/start (which may
+            # be supersede-finalizing this same slot) under the per-slot
+            # route lock so we don't double-finalize or interleave with
+            # an incoming route activation.
+            sweep_lanlan = str(state.get("lanlan_name") or "")
+            sweep_game_type = str(state.get("game_type") or "")
+            sweep_lock = _get_route_lock(sweep_lanlan, sweep_game_type)
             try:
-                await _finalize_game_route_state(
-                    state,
-                    reason="heartbeat_timeout",
-                    close_game_session=True,
-                )
+                async with sweep_lock:
+                    # Peer (e.g. /route/start supersede or /route/end) may
+                    # have already finalized the slot while we waited for
+                    # the lock; recheck and skip if so.
+                    if not state.get("game_route_active") or state.get("_exit_task"):
+                        if state.get("_exit_task"):
+                            await asyncio.shield(state["_exit_task"])
+                        continue
+                    await _finalize_game_route_state(
+                        state,
+                        reason="heartbeat_timeout",
+                        close_game_session=True,
+                    )
             except Exception as e:
                 logger.warning("🎮 游戏页心跳超时退出兜底失败: key=%s err=%s", key, e, exc_info=True)
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -2838,6 +2838,12 @@ async def _deliver_postgame_text_bubble(
 
     proactive_sid = getattr(mgr, "current_speech_id", None)
     state_machine = getattr(mgr, "state", None)
+    # Why: pre-allocated out-dict captures the postgame entry/cache key
+    # AS SOON AS ``_run_game_chat`` builds the entry, so the ``finally``
+    # below can close it on EVERY termination path — including
+    # ``asyncio.CancelledError`` (which is ``BaseException`` and bypasses
+    # the structured error-result paths inside ``_run_game_chat``).
+    postgame_meta: Dict[str, Any] = {}
     postgame_entry: Optional[dict] = None
     postgame_cache_session_id: Optional[str] = None
     try:
@@ -2862,6 +2868,7 @@ async def _deliver_postgame_text_bubble(
         llm_result = await _run_game_chat(
             game_type, session_id, event, allow_postgame=True,
             postgame_snapshot=postgame_snapshot,
+            postgame_meta_out=postgame_meta,
         )
         if isinstance(llm_result, dict):
             postgame_entry = llm_result.get("_postgame_entry")
@@ -2928,6 +2935,14 @@ async def _deliver_postgame_text_bubble(
         # entry's session object so the postgame client can never leak.
         # ``OmniOfflineClient.close`` is idempotent, so a peer's prior
         # close is safe to re-run.
+        if postgame_entry is None:
+            # Why: on ``asyncio.CancelledError`` (or any other
+            # ``BaseException``) the await above never returned, so the
+            # local ``postgame_entry``/``postgame_cache_session_id`` are
+            # still ``None``. The out-dict ``_run_game_chat`` populated
+            # mid-call still has the entry, so we fall back to it here.
+            postgame_entry = postgame_meta.get("_postgame_entry")
+            postgame_cache_session_id = postgame_meta.get("_postgame_cache_session_id")
         if postgame_entry is not None:
             postgame_lanlan = str(
                 postgame_entry.get("lanlan_name") or archive.get("lanlan_name") or ""
@@ -3822,6 +3837,7 @@ async def _run_game_chat(
     *,
     allow_postgame: bool = False,
     postgame_snapshot: Optional[dict] = None,
+    postgame_meta_out: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Run A-layer game LLM for both HTTP game events and hijacked external text.
 
@@ -3885,6 +3901,18 @@ async def _run_game_chat(
 
     # Re-resolve canonical lanlan_name for state lookups.
     lanlan_name = str(entry.get("lanlan_name") or lanlan_name or "").strip()
+
+    # Why: caller's ``finally`` (``_deliver_postgame_text_bubble``) needs
+    # to reach this entry even if the awaits below raise
+    # ``asyncio.CancelledError`` — which is ``BaseException``, not
+    # ``Exception``, so it bypasses the structured error-result paths
+    # that attach ``_postgame_entry``/``_postgame_cache_session_id``.
+    # We populate a shared out-dict the caller pre-allocates so the
+    # metadata is observable on every termination path (success,
+    # exception, cancellation).
+    if allow_postgame and postgame_meta_out is not None:
+        postgame_meta_out["_postgame_entry"] = entry
+        postgame_meta_out["_postgame_cache_session_id"] = chat_session_id
 
     # CR Major (PR #1127 r3182158697): when the post-lock route_inactive
     # short-circuit trips and our build won the race against a finalize
@@ -5310,6 +5338,14 @@ async def cleanup_expired_sessions():
                     if not state.get("game_route_active") or state.get("_exit_task"):
                         if state.get("_exit_task"):
                             await asyncio.shield(state["_exit_task"])
+                        continue
+                    # Why: a concurrent ``/route/heartbeat`` may have
+                    # bumped ``last_heartbeat_at`` between the lock-free
+                    # expired-scan and the lock acquisition above. The
+                    # browser is alive; finalizing here would kill a
+                    # live route. Re-check inside the lock with a fresh
+                    # ``time.time()`` and skip if the route recovered.
+                    if not _route_heartbeat_expired(state, time.time()):
                         continue
                     await _finalize_game_route_state(
                         state,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -3116,11 +3116,20 @@ async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: s
     build a fresh ``OmniOfflineClient`` and overwrite each other in
     ``_game_sessions``, leaking the loser's connection.
 
-    Note: ``lanlan_name`` may be empty on entry (caller-supplied) but
-    canonicalizes to ``char_info["lanlan_name"]`` after the cache miss.
-    The cache + lock keys must agree, so we recompute both under the
-    initial-key lock; if the canonical key differs, we re-acquire the
-    canonical lock to keep the dedup invariant.
+    CodeRabbit follow-up: ``lanlan_name`` may be empty on entry
+    (caller-supplied) but canonicalizes to ``char_info["lanlan_name"]``.
+    Resolve the canonical key BEFORE acquiring the create lock so we
+    only ever take one lock — under the canonical key. The previous
+    "lock under raw key, then re-lock under canonical key" shape left
+    an orphan ``_game_session_create_locks[raw_key]`` entry whenever
+    the canonical resolution changed the key, because
+    ``_close_and_remove_session`` only evicts the lock keyed by the
+    session's actual storage key (the canonical one).
+
+    The fast-path cache check still uses the raw key so a hit on the
+    pre-canonicalization shape (rare; only happens if a session was
+    cached under an empty lanlan_name) short-circuits without paying
+    the ``_get_character_info`` lookup.
     """
     key = _game_session_key(lanlan_name, game_type, session_id)
 
@@ -3129,32 +3138,25 @@ async def _get_or_create_session(game_type: str, session_id: str, lanlan_name: s
         entry['last_activity'] = time.time()
         return entry
 
-    create_lock = _get_session_create_lock(key)
-    async with create_lock:
-        if key in _game_sessions:
-            entry = _game_sessions[key]
-            entry['last_activity'] = time.time()
-            return entry
+    char_info = _get_character_info(lanlan_name)
+    canonical_lanlan = str(char_info.get("lanlan_name") or lanlan_name or "").strip()
+    canonical_key = _game_session_key(canonical_lanlan, game_type, session_id)
 
-        char_info = _get_character_info(lanlan_name)
-        lanlan_name = str(char_info.get("lanlan_name") or lanlan_name or "").strip()
-        canonical_key = _game_session_key(lanlan_name, game_type, session_id)
-        if canonical_key != key:
-            canonical_lock = _get_session_create_lock(canonical_key)
-            async with canonical_lock:
-                if canonical_key in _game_sessions:
-                    entry = _game_sessions[canonical_key]
-                    entry['last_activity'] = time.time()
-                    return entry
-                return await _build_and_register_game_session(
-                    canonical_key, game_type, session_id, char_info,
-                )
-        if key in _game_sessions:
-            entry = _game_sessions[key]
+    # Fast path: canonical_key may already be cached (e.g. another caller
+    # passed the canonical lanlan_name and built it).
+    if canonical_key in _game_sessions:
+        entry = _game_sessions[canonical_key]
+        entry['last_activity'] = time.time()
+        return entry
+
+    create_lock = _get_session_create_lock(canonical_key)
+    async with create_lock:
+        if canonical_key in _game_sessions:
+            entry = _game_sessions[canonical_key]
             entry['last_activity'] = time.time()
             return entry
         return await _build_and_register_game_session(
-            key, game_type, session_id, char_info,
+            canonical_key, game_type, session_id, char_info,
         )
 
 

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -2220,12 +2220,16 @@ async def test_game_end_delivers_one_shot_postgame_text_bubble(monkeypatch):
     async def fake_submit(archive):
         return {"ok": True, "status": "cached", "count": 1}
 
-    async def fake_run_game_chat(game_type, session_id, event):
+    async def fake_run_game_chat(game_type, session_id, event, **kwargs):
         assert game_type == "soccer"
         assert session_id == "match_1"
         assert event["kind"] == "postgame"
         assert event["lastUserText"] == "我好像踢不进去。"
         assert event["scoreText"] == "玩家 2 : 4 Lan"
+        # Postgame must opt into the inactive-route bypass; the production
+        # caller passes ``allow_postgame=True`` so the chat can run after
+        # finalize.
+        assert kwargs.get("allow_postgame") is True
         return {
             "line": "刚才那局不算，我下次慢点陪你踢。",
             "llm_source": {"provider": "fake"},
@@ -2279,11 +2283,12 @@ async def test_route_end_uses_full_game_end_contract(monkeypatch):
     async def fake_submit(archive):
         return {"ok": True, "status": "cached", "count": 1}
 
-    async def fake_run_game_chat(game_type, session_id, event):
+    async def fake_run_game_chat(game_type, session_id, event, **kwargs):
         assert game_type == "soccer"
         assert session_id == "match_1"
         assert event["kind"] == "postgame"
         assert event["lastUserText"] == "再来一球就追上了。"
+        assert kwargs.get("allow_postgame") is True
         return {"line": "刚才那脚挺像样的。", "llm_source": {"provider": "fake"}}
 
     monkeypatch.setattr(game_router, "_submit_game_archive_to_memory", fake_submit)

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -2188,6 +2188,170 @@ async def test_postgame_uses_snapshot_not_live_route_state(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_postgame_refresh_failure_returns_metadata_for_cleanup(monkeypatch):
+    """CR Major (PR #1127 r3183073856): when
+    ``_refresh_game_session_instructions`` raises inside
+    ``_run_game_chat(..., allow_postgame=True)``, the freshly-built
+    postgame ``OmniOfflineClient`` must still be teardown-reachable.
+
+    Pre-fix: the refresh call had no try/except. An exception there
+    propagated straight out of ``_run_game_chat`` and the structured
+    return path that attaches ``_postgame_entry`` /
+    ``_postgame_cache_session_id`` was skipped, so
+    ``_deliver_postgame_text_bubble``'s ``finally`` had no handle to
+    close — the new client survived until the 30-min idle sweep.
+
+    Post-fix: the call is wrapped, the error result carries the
+    postgame metadata (when ``allow_postgame=True``), and the bubble's
+    ``finally`` closes the client.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        # Activate then finalize a soccer route so postgame is the
+        # designed teardown step.
+        old_state = _activate_route("Lan", "soccer", "match_refresh_fail")
+        old_state["preGameContext"] = {"summary": "snap"}
+        old_state["_exit_flow_started"] = True
+        old_state["game_route_active"] = False
+        snapshot = game_router._build_postgame_context_snapshot(old_state)
+
+        async def _refresh_explodes(*_args, **_kwargs):
+            raise RuntimeError("test refresh failed")
+
+        monkeypatch.setattr(
+            game_router,
+            "_refresh_game_session_instructions",
+            _refresh_explodes,
+        )
+
+        fake_session = _FakeOmniSession(name="postgame_refresh")
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self, *, instructions: str = ""):
+                await fake_session.connect()
+
+            async def close(self):
+                await fake_session.close()
+
+            async def stream_text(self, text: str):
+                await fake_session.stream_text(text)
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+
+        # Part 1: call ``_run_game_chat`` directly and assert the error
+        # result carries the postgame metadata so the caller can close
+        # the freshly-built client.
+        event = {"lanlan_name": "Lan", "kind": "match_end"}
+        result = await game_router._run_game_chat(
+            "soccer", "match_refresh_fail", event,
+            allow_postgame=True, postgame_snapshot=snapshot,
+        )
+        assert isinstance(result, dict)
+        assert "error" in result and "session 指令失败" in result["error"]
+        # The two metadata keys are the load-bearing invariant: without
+        # them ``_deliver_postgame_text_bubble`` can't reach the session.
+        assert "_postgame_entry" in result, (
+            "postgame entry missing from refresh-failure result; "
+            "the freshly-built OmniOfflineClient cannot be closed"
+        )
+        assert "_postgame_cache_session_id" in result
+        leaked_entry = result["_postgame_entry"]
+        leaked_session = leaked_entry.get("session")
+        assert leaked_session is not None
+        # Sanity: the freshly built client did connect and was NOT
+        # closed by ``_run_game_chat`` itself — that's the caller's job.
+        assert fake_session.connect_calls == 1
+        assert fake_session.close_calls == 0
+
+        # Clean up before part 2 since part 1 left a postgame entry in
+        # the cache (caller never ran).
+        cache_key = game_router._game_session_key(
+            "Lan", "soccer", result["_postgame_cache_session_id"],
+        )
+        game_router._game_sessions.pop(cache_key, None)
+        game_router._game_session_create_locks.pop(cache_key, None)
+        await leaked_session.close()
+
+        # Part 2: full ``_deliver_postgame_text_bubble`` path. With the
+        # metadata propagated, the bubble's ``finally`` closes the
+        # postgame session.
+        fake_session2 = _FakeOmniSession(name="postgame_refresh_bubble")
+
+        class _StubOmni2:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self, *, instructions: str = ""):
+                await fake_session2.connect()
+
+            async def close(self):
+                await fake_session2.close()
+
+            async def stream_text(self, text: str):
+                await fake_session2.stream_text(text)
+
+            async def update_session(self, config):
+                pass
+
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni2)
+
+        class _StubManager:
+            current_speech_id = "speech-refresh-fail"
+            state = None
+
+            async def prepare_proactive_delivery(self, *, min_idle_secs=0.0):
+                return True
+
+            async def finish_proactive_delivery(self, line, *, expected_speech_id=None):
+                return True
+
+            async def feed_tts_chunk(self, line, *, expected_speech_id=None):
+                pass
+
+        archive = {"lanlan_name": "Lan", "preGameContext": {"summary": "snap"}}
+        bubble_result = await game_router._deliver_postgame_text_bubble(
+            "soccer", "match_refresh_fail", _StubManager(), archive,
+            {"enabled": True}, postgame_snapshot=snapshot,
+        )
+        # Bubble pass-skips because the LLM produced no line, but the
+        # postgame session was still cleaned up via the ``finally``.
+        assert bubble_result.get("action") in {"pass", "skip"}
+        assert fake_session2.connect_calls == 1
+        assert fake_session2.close_calls == 1, (
+            "postgame session was not closed after refresh failure; "
+            "metadata propagation is broken or finally did not reach close"
+        )
+        # Cache slot evicted by the bubble's finally.
+        for k in list(game_router._game_sessions.keys()):
+            assert game_router._POSTGAME_SESSION_MARKER not in k, (
+                f"postgame cache slot {k!r} was not evicted after "
+                f"refresh-failure cleanup"
+            )
+
+
+@pytest.mark.unit
 def test_route_session_id_only_strips_synthetic_uuid_tail():
     """codex P2 (PR #1127 r3182964201): ``_route_session_id`` must strip
     ONLY the exact suffix shape produced by ``_make_postgame_session_id``

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -134,22 +134,45 @@ async def test_b5_finalize_or_merges_close_session_request(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_b1_chat_short_circuits_when_route_exit_started():
+async def test_b1_chat_short_circuits_when_route_exit_started(monkeypatch):
     """B1/B2: ``_run_game_chat`` must short-circuit if the route flipped to
     ``_exit_flow_started`` before the call lands. Otherwise it would issue
     a ``stream_text`` against a session that finalize is about to close.
+
+    CodeRabbit Minor follow-up (PR #1127): pin the assertion to the
+    session-creation path. A pure return-value check would still pass if
+    the implementation regressed to "first build a session, then notice
+    the route is inactive, then return ``skipped``" — leaking the freshly
+    built ``OmniOfflineClient``. Monkeypatch ``_get_or_create_session`` to
+    raise on call AND assert ``_game_sessions`` / ``_game_session_create_locks``
+    were never touched, so any future regression that takes the slow path
+    fails this test loudly.
     """
     with reset_game_route_state():
         state = _activate_route("Lan", "soccer", "match_b1")
         state["_exit_flow_started"] = True
-        # No need to populate _game_sessions — the pre-create short-circuit
-        # in _run_game_chat must trip *before* ever calling
-        # _get_or_create_session.
+
+        async def _explode(*_args, **_kwargs):
+            raise AssertionError(
+                "B1/B2 short-circuit must trip BEFORE _get_or_create_session; "
+                "the route is inactive and creating a session would leak."
+            )
+
+        monkeypatch.setattr(game_router, "_get_or_create_session", _explode)
+
+        # Snapshot cache state to verify nothing was inserted.
+        sessions_snapshot = dict(game_router._game_sessions)
+        create_locks_snapshot = dict(game_router._game_session_create_locks)
+
         result = await game_router._run_game_chat(
             "soccer", "match_b1", {"kind": "free-ball", "lanlan_name": "Lan"},
         )
         assert result.get("skipped") == "route_inactive"
         assert result.get("line") == ""
+
+        # Cache invariants: no new entries materialized via the slow path.
+        assert game_router._game_sessions == sessions_snapshot
+        assert game_router._game_session_create_locks == create_locks_snapshot
 
 
 @pytest.mark.unit
@@ -263,32 +286,255 @@ async def test_b8_finalize_routes_for_character_closes_old_routes(monkeypatch):
     """B8: switching characters must finalize all active routes for the
     outgoing character, releasing the SessionManager takeover and
     closing the LLM session.
+
+    CodeRabbit Minor follow-up (PR #1127): seed at least TWO active
+    routes for the same ``lanlan_name`` (different ``game_type``) and
+    assert ``n == 2``. With a single route, an implementation that only
+    closes the first match — leaving sibling routes for the same
+    character alive after a character switch — would still pass. Two
+    routes guards against that regression directly.
     """
     _stub_archive_calls(monkeypatch)
     with reset_game_route_state():
-        state = _activate_route("Lan", "soccer", "match_b8")
-        fake_session = _FakeOmniSession(name="b8")
-        key = game_router._game_session_key("Lan", "soccer", "match_b8")
-        game_router._game_sessions[key] = {
-            "session": fake_session,
-            "reply_chunks": [],
-            "lanlan_name": "Lan",
-            "lanlan_prompt": "",
-            "source": {},
-            "last_activity": 0,
-            "lock": asyncio.Lock(),
-            "instructions": "",
-        }
+        state_soccer = _activate_route("Lan", "soccer", "match_b8")
+        state_chess = _activate_route("Lan", "chess", "match_b8_chess")
+        fake_session_soccer = _FakeOmniSession(name="b8_soccer")
+        fake_session_chess = _FakeOmniSession(name="b8_chess")
+        soccer_key = game_router._game_session_key("Lan", "soccer", "match_b8")
+        chess_key = game_router._game_session_key("Lan", "chess", "match_b8_chess")
+        for key, fake in (
+            (soccer_key, fake_session_soccer),
+            (chess_key, fake_session_chess),
+        ):
+            game_router._game_sessions[key] = {
+                "session": fake,
+                "reply_chunks": [],
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "source": {},
+                "last_activity": 0,
+                "lock": asyncio.Lock(),
+                "instructions": "",
+            }
 
         n = await game_router.finalize_game_routes_for_character("Lan")
 
-        assert n == 1
-        assert state.get("_exit_flow_started") is True
-        assert state.get("game_route_active") is False
-        assert fake_session.close_calls == 1
-        # Calling again is a no-op (route already inactive).
+        assert n == 2
+        # Both routes for ``Lan`` are now inactive and their sessions closed.
+        for state in (state_soccer, state_chess):
+            assert state.get("_exit_flow_started") is True
+            assert state.get("game_route_active") is False
+        assert fake_session_soccer.close_calls == 1
+        assert fake_session_chess.close_calls == 1
+        # Calling again is a no-op (both routes already inactive).
         n_again = await game_router.finalize_game_routes_for_character("Lan")
         assert n_again == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_postgame_bypass_runs_chat_after_finalize(monkeypatch):
+    """codex P1 follow-up (PR #1127 thread r3182095129): postgame text
+    generation runs AFTER ``_finalize_game_route_state`` flips the route
+    to inactive, on purpose. The B1/B2 short-circuits in ``_run_game_chat``
+    must therefore be bypass-able for this designed teardown step,
+    otherwise non-Realtime sessions silently lose the postgame bubble.
+
+    With ``allow_postgame=True`` the route-active gates are skipped and a
+    fresh chat call lands successfully. The test pins the contract:
+    given an inactive route state, the chat returns a non-empty line and
+    no ``skipped`` marker.
+    """
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_postgame_bypass")
+        # Mark the route as already finalized — this is exactly the
+        # state postgame observes when ``_complete_game_end_from_payload``
+        # runs ``_deliver_game_postgame`` after finalize.
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+
+        captured_callback = {"fn": None}
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                captured_callback["fn"] = kwargs.get("on_text_delta")
+                self._closed = False
+
+            async def connect(self, *, instructions: str = ""):
+                pass
+
+            async def close(self):
+                self._closed = True
+
+            async def stream_text(self, text: str):
+                cb = captured_callback["fn"]
+                if cb is not None:
+                    await cb("postgame line", True)
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        # Without allow_postgame: short-circuits to ``route_inactive``.
+        baseline = await game_router._run_game_chat(
+            "soccer",
+            "match_postgame_bypass",
+            {"kind": "postgame", "lanlan_name": "Lan"},
+        )
+        assert baseline.get("skipped") == "route_inactive"
+        assert baseline.get("line") == ""
+
+        # With allow_postgame=True: bypass trips, chat runs to completion.
+        result = await game_router._run_game_chat(
+            "soccer",
+            "match_postgame_bypass",
+            {"kind": "postgame", "lanlan_name": "Lan"},
+            allow_postgame=True,
+        )
+        assert result.get("skipped") is None, result
+        assert result.get("line") == "postgame line"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_postgame_text_bubble_closes_session_after_finalize(monkeypatch):
+    """codex P1 follow-up (PR #1127 thread r3182095129): the postgame
+    bypass must NOT leak the freshly-built ``OmniOfflineClient``.
+
+    ``_deliver_postgame_text_bubble`` runs after finalize has already
+    evicted the prior session. The bypass lets us build a NEW one to
+    generate the postgame line; nothing else in the lifecycle would
+    close it (which is exactly why the original B1/B2 guards existed),
+    so the bubble itself owns cleanup. Regressing the cleanup means
+    long-running processes accumulate one open ``OmniOfflineClient``
+    per finished game over uptime.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_postgame_leak")
+        # Simulate post-finalize state — the prior session is already
+        # gone (finalize closed it before postgame ran).
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+
+        captured_callback = {"fn": None}
+        constructed = []
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                captured_callback["fn"] = kwargs.get("on_text_delta")
+                self.closed = False
+                constructed.append(self)
+
+            async def connect(self, *, instructions: str = ""):
+                pass
+
+            async def close(self):
+                self.closed = True
+
+            async def stream_text(self, text: str):
+                cb = captured_callback["fn"]
+                if cb is not None:
+                    await cb("postgame bubble line", True)
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        # Minimal stub SessionManager mirroring the prepare/finish/feed_tts
+        # contract that ``_deliver_postgame_text_bubble`` calls.
+        class _StubManager:
+            is_active = False
+            session = None
+            current_speech_id = "speech-postgame"
+            state = None
+
+            def __init__(self):
+                self.delivered = None
+
+            async def prepare_proactive_delivery(self, *, min_idle_secs=0.0):
+                return True
+
+            async def finish_proactive_delivery(self, line, *, expected_speech_id=None):
+                self.delivered = line
+                return True
+
+            async def feed_tts_chunk(self, line, *, expected_speech_id=None):
+                pass
+
+        mgr = _StubManager()
+        archive = {
+            "lanlan_name": "Lan",
+            "summary": "",
+            "last_full_dialogues": [],
+            "last_state": {},
+            "finalScore": {},
+            "preGameContext": {},
+        }
+        options = {"enabled": True, "max_chars": 60, "include_last_dialogues": 0}
+
+        # Sanity: cache is empty before postgame runs.
+        key = game_router._game_session_key("Lan", "soccer", "match_postgame_leak")
+        assert key not in game_router._game_sessions
+
+        result = await game_router._deliver_postgame_text_bubble(
+            "soccer", "match_postgame_leak", mgr, archive, options,
+        )
+
+        # Bubble committed: postgame line was generated AND finished.
+        assert result.get("ok") is True, result
+        assert result.get("action") == "chat", result
+        assert result.get("line") == "postgame bubble line"
+        assert mgr.delivered == "postgame bubble line"
+
+        # Lifecycle invariant: exactly one client built, and it was
+        # closed + evicted from ``_game_sessions`` after the bubble.
+        assert len(constructed) == 1
+        assert constructed[0].closed is True
+        assert key not in game_router._game_sessions
+        assert key not in game_router._game_session_create_locks
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -207,8 +207,10 @@ async def test_b5_finalize_late_close_request_during_inner_archive(monkeypatch):
     """
     _stub_archive_calls(monkeypatch)
     barrier = asyncio.Event()
+    archive_started = asyncio.Event()
 
     async def _blocked_submit(_archive):
+        archive_started.set()
         await barrier.wait()
         return {"status": "ok"}
 
@@ -216,6 +218,15 @@ async def test_b5_finalize_late_close_request_during_inner_archive(monkeypatch):
 
     with reset_game_route_state():
         state = _activate_route("Lan", "soccer", "match_b5_mid")
+        # Force the inner to actually enter ``_submit_game_archive_to_memory``
+        # so the barrier in ``_blocked_submit`` becomes a real park point.
+        # Without these flags ``_game_archive_memory_skip_reason`` returns
+        # "game_not_started" / "soccer_game_memory_archive_disabled" and
+        # the submit call is bypassed entirely.
+        state["game_started"] = True
+        state["game_started_at"] = game_router.time.time() - 30
+        state["soccer_game_memory_enabled"] = True
+        state["soccer_game_memory_archive_enabled"] = True
         fake_session = _FakeOmniSession(name="b5_mid")
         key = game_router._game_session_key("Lan", "soccer", "match_b5_mid")
         game_router._game_sessions[key] = {
@@ -236,14 +247,11 @@ async def test_b5_finalize_late_close_request_during_inner_archive(monkeypatch):
                 state, reason="A_no_close", close_game_session=False,
             )
         )
-        # Yield until inner has spawned and parked on the barrier.
-        for _ in range(50):
-            if state.get("_exit_task") is not None and not barrier.is_set():
-                # Give the inner a chance to reach the barrier.
-                await asyncio.sleep(0)
-                if state.get("archive") is not None:
-                    break
-            await asyncio.sleep(0)
+        # Pin the timing: wait until the inner has actually entered
+        # ``_blocked_submit`` and is parked on ``barrier``. Explicit event
+        # sync — robust against future reordering of ``state["archive"]``
+        # assignment around the archive submit call.
+        await asyncio.wait_for(archive_started.wait(), timeout=5.0)
 
         # Caller B: close=True. Dispatcher ORs the flag and awaits the
         # in-flight task.

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -539,6 +539,157 @@ async def test_postgame_text_bubble_closes_session_after_finalize(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_postgame_text_bubble_identity_gates_close(monkeypatch):
+    """codex P1 / CR Major (PR #1127 r3182247827 / r3182218166): postgame
+    cleanup must close ONLY the entry it built, never the cache slot
+    blindly. After ``_complete_game_end_from_payload`` releases
+    ``end_route_lock``, a fresh ``/route/start`` for the same
+    ``(lanlan, game_type, session_id)`` can replace the cache entry
+    before postgame's ``finally`` runs. A key-based close would tear
+    down the new route's freshly-built ``OmniOfflineClient``.
+
+    Invariant: between ``_run_game_chat(..., allow_postgame=True)``
+    returning and the bubble's ``finally`` firing, swap the cache slot
+    with a peer-owned entry. The peer's session must remain intact and
+    cached after the bubble completes.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_postgame_replace")
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+
+        captured_callback = {"fn": None}
+        constructed: list = []
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                captured_callback["fn"] = kwargs.get("on_text_delta")
+                self.closed = False
+                constructed.append(self)
+
+            async def connect(self, *, instructions: str = ""):
+                pass
+
+            async def close(self):
+                self.closed = True
+
+            async def stream_text(self, text: str):
+                cb = captured_callback["fn"]
+                if cb is not None:
+                    await cb("postgame bubble line", True)
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        peer_session = _FakeOmniSession(name="peer_after_finalize")
+        peer_entry = {
+            "session": peer_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+        peer_lock = asyncio.Lock()
+        key = game_router._game_session_key(
+            "Lan", "soccer", "match_postgame_replace",
+        )
+
+        # Hook ``finish_proactive_delivery`` — it runs AFTER chat finishes
+        # but BEFORE the bubble's finally — to simulate a racing
+        # ``/route/start`` whose first ``/game_chat`` built a fresh entry
+        # and replaced postgame's cache slot.
+        class _StubManager:
+            is_active = False
+            session = None
+            current_speech_id = "speech-postgame"
+            state = None
+
+            def __init__(self):
+                self.delivered = None
+
+            async def prepare_proactive_delivery(self, *, min_idle_secs=0.0):
+                return True
+
+            async def finish_proactive_delivery(self, line, *, expected_speech_id=None):
+                # Simulate the race: a peer ``/route/start`` activated
+                # for the same key and its first ``/game_chat`` built a
+                # fresh entry, replacing postgame's cache slot.
+                game_router._game_sessions[key] = peer_entry
+                game_router._game_session_create_locks[key] = peer_lock
+                self.delivered = line
+                return True
+
+            async def feed_tts_chunk(self, line, *, expected_speech_id=None):
+                pass
+
+        mgr = _StubManager()
+        archive = {
+            "lanlan_name": "Lan",
+            "summary": "",
+            "last_full_dialogues": [],
+            "last_state": {},
+            "finalScore": {},
+            "preGameContext": {},
+        }
+        options = {"enabled": True, "max_chars": 60, "include_last_dialogues": 0}
+
+        result = await game_router._deliver_postgame_text_bubble(
+            "soccer", "match_postgame_replace", mgr, archive, options,
+        )
+
+        assert result.get("ok") is True, result
+        assert result.get("action") == "chat", result
+        assert result.get("line") == "postgame bubble line"
+
+        # Postgame built exactly one ``OmniOfflineClient`` and closed it.
+        assert len(constructed) == 1
+        assert constructed[0].closed is True
+
+        # CRITICAL: the peer's entry survived. The bubble must not have
+        # touched the cache slot once identity diverged from its own
+        # entry, and must NOT have closed the peer's session.
+        assert peer_session.close_calls == 0, (
+            "postgame finally closed the peer route's session — "
+            "key-based close regressed"
+        )
+        assert game_router._game_sessions.get(key) is peer_entry, (
+            "postgame finally evicted the peer route's cache entry — "
+            "key-based eviction regressed"
+        )
+        assert game_router._game_session_create_locks.get(key) is peer_lock, (
+            "postgame finally evicted the peer route's create lock — "
+            "key-based eviction regressed"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_b1_supersede_then_chat_does_not_revive_closed_route(monkeypatch):
     """B1: after a ``/route/start`` supersede finalizes a prior route,
     a stale chat for that prior route must not silently re-create an

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -2,12 +2,16 @@
 
 These cover the audit findings B1, B2, B3, B5, B6, B8 (B4 is a defensive
 guard verified in ``test_game_context_organizer.py``; B7 was landed in
-PR #1125), plus two PR #1127 follow-up tests:
+PR #1125), plus three PR #1127 follow-up tests:
 
 - ``test_route_start_serializes_supersede_across_game_types_for_same_lanlan``
   guards CodeRabbit's per-lanlan supersede-lock finding.
 - ``test_game_session_create_lock_evicted_with_session`` guards codex's
   ``_game_session_create_locks`` memory-leak finding.
+- ``test_character_switch_finalize_blocks_concurrent_route_start_for_same_lanlan``
+  guards codex's ``finalize_game_routes_for_character`` snapshot-without-
+  supersede-lock finding (race lets a concurrent ``/route/start`` activate
+  a NEW route AFTER the snapshot and escape character-switch cleanup).
 """
 from __future__ import annotations
 
@@ -536,3 +540,187 @@ async def test_get_or_create_session_canonical_key_mismatch_leaves_no_orphan_loc
         assert closed is True
         assert canonical_key not in game_router._game_session_create_locks
         assert raw_key not in game_router._game_session_create_locks
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_character_switch_finalize_blocks_concurrent_route_start_for_same_lanlan(
+    monkeypatch,
+):
+    """codex P2 follow-up (PR #1127 thread 3182019570):
+    ``finalize_game_routes_for_character`` must serialize with concurrent
+    ``/route/start`` calls for the same ``lanlan_name`` via the per-lanlan
+    supersede lock — otherwise a route activated AFTER finalize's snapshot
+    escapes cleanup and the character switch completes with an old-character
+    route still alive.
+
+    Pre-fix shape: ``finalize_game_routes_for_character`` snapshots
+    ``_game_route_states`` BEFORE acquiring any supersede lock. A
+    concurrent ``/route/start`` for the same ``lanlan_name`` could:
+      1. land its activation between the snapshot and the iterate step,
+      2. miss being included in the snapshot,
+      3. survive the character switch unfinalized.
+
+    Post-fix shape: finalize takes ``_route_supersede_locks[lanlan_name]``
+    (the OUTER lock per the lock-ordering rule documented in
+    ``utils/game_route_state.py``) BEFORE snapshotting. Any concurrent
+    ``/route/start`` for the same lanlan_name blocks on that lock until
+    cleanup finishes; the new route either lands strictly before the
+    snapshot (in which case finalize observes and cleans it) or strictly
+    after (in which case finalize already returned).
+
+    This test forces the race by externally holding the supersede lock
+    while ``finalize_game_routes_for_character`` is in flight, and then
+    firing a concurrent ``/route/start``. With the fix, finalize must
+    block on the supersede lock until we release it; without the fix,
+    finalize would complete immediately because it never tries to take
+    the lock.
+    """
+    _stub_archive_calls(monkeypatch)
+
+    async def _fake_pregame(**_kwargs):
+        return (
+            game_router._default_soccer_pregame_context(initial_difficulty="lv2"),
+            "fallback",
+            "",
+        )
+
+    monkeypatch.setattr(game_router, "_build_soccer_pregame_context", _fake_pregame)
+
+    with reset_game_route_state():
+        # Drop any leftover supersede / route locks so this test starts
+        # fresh — locks live across tests because they're a process-global
+        # registry by design (see comment on ``_route_state_locks``).
+        from utils import game_route_state as grs_mod
+        grs_mod._route_supersede_locks.pop("Lan", None)
+        grs_mod._route_state_locks.pop(grs_mod._route_state_key("Lan", "soccer"), None)
+
+        # Existing active route for the OLD character: this is what
+        # ``finalize_game_routes_for_character`` is supposed to clean up.
+        old_state = _activate_route("Lan", "soccer", "match_old")
+        fake_session = _FakeOmniSession(name="charswitch_old")
+        old_key = game_router._game_session_key("Lan", "soccer", "match_old")
+        game_router._game_sessions[old_key] = {
+            "session": fake_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+
+        # Acquire the supersede lock externally to simulate a /route/start
+        # already in progress. Post-fix: finalize must block on this lock.
+        # Pre-fix: finalize would NOT take this lock and would proceed
+        # without serialization.
+        supersede_lock = grs_mod._get_supersede_lock("Lan")
+        await supersede_lock.acquire()
+
+        try:
+            # Schedule finalize in the background. Post-fix, this awaits
+            # the supersede lock and never returns until we release it.
+            finalize_task = asyncio.create_task(
+                game_router.finalize_game_routes_for_character("Lan")
+            )
+
+            # Yield enough times to let finalize_task run as far as it can.
+            # Post-fix: it parks on supersede_lock.acquire().
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+            # Post-fix invariant: finalize is still running (blocked on
+            # supersede lock). Pre-fix: finalize would already be done.
+            assert not finalize_task.done(), (
+                "finalize_game_routes_for_character must block on the "
+                "per-lanlan supersede lock; it appears to have skipped "
+                "the lock and snapshotted _game_route_states without "
+                "serialization (codex P2 race window)."
+            )
+            # The old route is still active because finalize is parked
+            # before it could snapshot.
+            assert old_state.get("game_route_active") is True
+        finally:
+            # Release the lock so finalize can proceed and we don't leak
+            # a stuck task.
+            supersede_lock.release()
+
+        # Finalize now proceeds: snapshot, iterate, cleanup.
+        n = await finalize_task
+        assert n == 1
+        assert old_state.get("_exit_flow_started") is True
+        assert old_state.get("game_route_active") is False
+        assert fake_session.close_calls == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_character_switch_finalize_serializes_with_concurrent_route_start_via_gather(
+    monkeypatch,
+):
+    """codex P2 follow-up (PR #1127 thread 3182019570) — gather variant.
+
+    End-to-end: ``finalize_game_routes_for_character`` and a concurrent
+    ``game_route_start`` for the same ``lanlan_name`` are launched via
+    ``asyncio.gather``. After both complete, the per-lanlan supersede
+    lock guarantees that the resulting state is one of the two stable
+    interleavings (route_start-then-finalize, or finalize-then-
+    route_start), never a half-state where finalize "missed" a route
+    that was activated mid-iteration.
+
+    The load-bearing assertion is in the FIRST test
+    (``test_character_switch_finalize_blocks_concurrent_route_start_for_same_lanlan``)
+    which directly verifies the supersede lock is taken; this test just
+    smoke-checks that running both concurrently doesn't trip any
+    deadlock or lock-ordering inversion. The lock order in
+    ``finalize_game_routes_for_character`` is OUTER ``_route_supersede_locks``
+    then INNER ``_route_state_locks``, identical to ``game_route_start`` —
+    no deadlock window.
+    """
+    _stub_archive_calls(monkeypatch)
+
+    async def _fake_pregame(**_kwargs):
+        return (
+            game_router._default_soccer_pregame_context(initial_difficulty="lv2"),
+            "fallback",
+            "",
+        )
+
+    monkeypatch.setattr(game_router, "_build_soccer_pregame_context", _fake_pregame)
+
+    with reset_game_route_state():
+        from utils import game_route_state as grs_mod
+        grs_mod._route_supersede_locks.pop("Lan", None)
+        grs_mod._route_state_locks.pop(grs_mod._route_state_key("Lan", "soccer"), None)
+
+        # Both calls fired concurrently. The supersede lock serializes
+        # them; whichever lands inside the lock first runs to completion
+        # before the other proceeds. No deadlock should occur.
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                game_router.game_route_start(
+                    "soccer",
+                    _FakeRouteStartRequest({
+                        "lanlan_name": "Lan",
+                        "session_id": "match_charswitch_race",
+                    }),
+                ),
+                game_router.finalize_game_routes_for_character("Lan"),
+            ),
+            timeout=5.0,  # If serialization is broken, deadlock surfaces here.
+        )
+
+        route_start_result, _finalize_count = results
+        assert route_start_result.get("ok"), route_start_result
+
+        # Final state: AT MOST one active Lan route. Whichever
+        # interleaving the supersede lock chose, the result is a
+        # well-defined steady state — never two concurrently-active
+        # routes for the same character.
+        active_for_lan = [
+            key
+            for key, state in game_router._game_route_states.items()
+            if key[0] == "Lan" and state.get("game_route_active")
+        ]
+        assert len(active_for_lan) <= 1, active_for_lan

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -2396,3 +2396,236 @@ def test_route_session_id_only_strips_synthetic_uuid_tail():
     # synth = ``weird::postgame::client::postgame::<uuid_hex>`` — only the
     # final suffix shape matches; the inner ``::postgame::client`` stays.
     assert game_router._route_session_id(synth) == base
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_postgame_cleanup_runs_after_cancelled_error(monkeypatch):
+    """CR Major (PR #1127 r3183137463): if ``_run_game_chat(...,
+    allow_postgame=True)`` raises ``asyncio.CancelledError`` during
+    ``stream_text``, the freshly-built postgame ``OmniOfflineClient``
+    must still be closed by ``_deliver_postgame_text_bubble``'s
+    ``finally``.
+
+    Pre-fix: the only path that attached
+    ``_postgame_entry``/``_postgame_cache_session_id`` was the structured
+    return dict. ``CancelledError`` is ``BaseException`` (not
+    ``Exception``) so it bypassed the ``except Exception`` branches and
+    propagated without populating those keys. The caller's ``finally``
+    saw ``postgame_entry is None`` and skipped cleanup → orphan
+    private ``::postgame::...`` session until the 30-min idle sweep.
+
+    Post-fix: ``_run_game_chat`` populates a caller-allocated
+    ``postgame_meta_out`` dict as soon as the entry is built, BEFORE any
+    cancellable await. The bubble's ``finally`` falls back to that dict
+    and closes the entry on every termination path.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_cancel")
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+        snapshot = game_router._build_postgame_context_snapshot(state)
+
+        stream_started = asyncio.Event()
+        fake_session = _FakeOmniSession(name="postgame_cancel")
+
+        async def _stream_blocks_until_cancel(text: str):
+            stream_started.set()
+            # Park forever; the test cancels the parent task to trigger
+            # CancelledError from inside ``stream_text``.
+            await asyncio.Event().wait()
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                pass
+
+            async def connect(self, *, instructions: str = ""):
+                await fake_session.connect()
+
+            async def close(self):
+                await fake_session.close()
+
+            async def stream_text(self, text: str):
+                await _stream_blocks_until_cancel(text)
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        # Refresh is a no-op so the cancellation lands in stream_text.
+        async def _noop_refresh(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(
+            game_router,
+            "_refresh_game_session_instructions",
+            _noop_refresh,
+        )
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        class _StubManager:
+            current_speech_id = "speech-cancel"
+            state = None
+
+            async def prepare_proactive_delivery(self, *, min_idle_secs=0.0):
+                return True
+
+            async def finish_proactive_delivery(self, line, *, expected_speech_id=None):
+                return True
+
+            async def feed_tts_chunk(self, line, *, expected_speech_id=None):
+                pass
+
+        archive = {"lanlan_name": "Lan", "preGameContext": {"summary": "snap"}}
+
+        async def _drive():
+            return await game_router._deliver_postgame_text_bubble(
+                "soccer", "match_cancel", _StubManager(), archive,
+                {"enabled": True}, postgame_snapshot=snapshot,
+            )
+
+        bubble_task = asyncio.create_task(_drive())
+        # Wait until ``stream_text`` has parked. At this point the
+        # postgame entry is already in ``_game_sessions`` and the bubble
+        # is awaiting ``stream_text``.
+        await asyncio.wait_for(stream_started.wait(), timeout=5.0)
+
+        # Cancel the bubble — this propagates as ``CancelledError`` up
+        # through ``_run_game_chat`` (bypassing every ``except
+        # Exception``) and into the bubble's try/except. Pre-fix:
+        # ``postgame_entry`` stays ``None`` and the close in ``finally``
+        # is skipped.
+        bubble_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bubble_task
+
+        # Load-bearing invariant: the postgame session was closed by the
+        # bubble's ``finally``. Pre-fix this is 0; post-fix this is 1.
+        assert fake_session.connect_calls == 1
+        assert fake_session.close_calls == 1, (
+            "postgame session was not closed after CancelledError; "
+            "the bubble's finally had no handle to the freshly-built "
+            "OmniOfflineClient"
+        )
+
+        # The private postgame cache slot was evicted by the bubble's
+        # finally — no leftover ``::postgame::...`` keys.
+        for k in list(game_router._game_sessions.keys()):
+            assert game_router._POSTGAME_SESSION_MARKER not in k, (
+                f"postgame cache slot {k!r} was not evicted after "
+                f"CancelledError cleanup"
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_heartbeat_sweep_rechecks_expired_inside_lock(monkeypatch):
+    """CR Major (PR #1127 r3183137485): ``cleanup_expired_sessions``
+    flags expired routes lock-free, then takes the per-slot route lock
+    to finalize. A concurrent ``/route/heartbeat`` may bump
+    ``last_heartbeat_at`` between the lock-free scan and the lock
+    acquisition. Pre-fix: sweep finalized anyway, killing a route the
+    browser had just resumed.
+
+    Post-fix: re-check ``_route_heartbeat_expired`` inside the lock with
+    a fresh ``time.time()`` and skip if the route recovered.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        # Make the sweep fire fast.
+        monkeypatch.setattr(
+            game_router, "_GAME_ROUTE_HEARTBEAT_SWEEP_SECONDS", 0.01
+        )
+
+        finalize_calls: list[dict] = []
+
+        async def _track_finalize(state, *, reason, close_game_session):
+            finalize_calls.append(
+                {"reason": reason, "close_game_session": close_game_session}
+            )
+            return {"game_session_closed": False}
+
+        monkeypatch.setattr(
+            game_router, "_finalize_game_route_state", _track_finalize
+        )
+
+        # Build an expired route — last_heartbeat_at is well past the
+        # timeout window. ``_route_heartbeat_expired`` would return True
+        # against current time.
+        state = _activate_route("Lan", "soccer", "match_recheck")
+        state["heartbeat_timeout_seconds"] = 1.0
+        # Force the lock-free expired-scan to catch this route.
+        state["last_heartbeat_at"] = game_router.time.time() - 60.0
+        state["last_activity"] = game_router.time.time() - 60.0
+        state["created_at"] = game_router.time.time() - 60.0
+
+        # Pre-acquire the route lock so the sweep parks waiting for it.
+        # While parked, simulate a ``/route/heartbeat`` recovery by
+        # bumping ``last_heartbeat_at`` to NOW. After release, the
+        # post-fix recheck inside the lock observes the recovery and
+        # skips ``_finalize_game_route_state``.
+        route_lock = game_router._get_route_lock("Lan", "soccer")
+        await route_lock.acquire()
+        try:
+            sweep_task = asyncio.create_task(
+                game_router.cleanup_expired_sessions()
+            )
+            # Yield enough times for the sweep to: sleep → scan expired
+            # → reach ``async with sweep_lock`` and park on our held
+            # lock.
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if route_lock._waiters:  # type: ignore[attr-defined]
+                    break
+            assert route_lock._waiters, (  # type: ignore[attr-defined]
+                "sweep did not reach the route lock; test setup is broken"
+            )
+
+            # Browser sends a heartbeat — last_heartbeat_at moves to NOW
+            # while sweep is parked. The lock-free expired-scan saw the
+            # old value; the post-fix in-lock recheck must see the new
+            # one and skip.
+            state["last_heartbeat_at"] = game_router.time.time()
+            state["last_activity"] = game_router.time.time()
+        finally:
+            route_lock.release()
+
+        # Give the sweep a few yields to acquire the released lock and
+        # complete its iteration body.
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if finalize_calls:
+                break
+
+        sweep_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await sweep_task
+
+        # Load-bearing invariant: post-fix sweep observes the refreshed
+        # heartbeat inside the lock and skips finalize. Pre-fix this
+        # list contains a heartbeat_timeout entry.
+        assert finalize_calls == [], (
+            "sweep finalized a route whose heartbeat had recovered "
+            "before the lock was acquired; in-lock recheck is missing"
+        )

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -137,6 +137,140 @@ async def test_b5_finalize_or_merges_close_session_request(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_b5_finalize_late_close_request_after_inner_done(monkeypatch):
+    """codex P2 follow-up (PR #1127): a ``close_game_session=True`` caller
+    arriving AFTER the inner finalize already passed its close-site check
+    must still close the session.
+
+    Pre-fix race: Caller A spawns inner with ``close=False``; inner reads
+    ``_exit_close_session_request=False`` at the close site and returns
+    without closing. Caller B then arrives with ``close=True``; the
+    dispatcher ORs the flag but only awaits the cached (done) task and
+    returns its no-close result. Session leaks until heartbeat sweep.
+
+    Post-fix: dispatcher re-checks the OR-merge flag against the cached
+    result on the existing-task path and performs the close itself.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b5_late")
+        fake_session = _FakeOmniSession(name="b5_late")
+        key = game_router._game_session_key("Lan", "soccer", "match_b5_late")
+        game_router._game_sessions[key] = {
+            "session": fake_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+
+        # Caller A: close=False. Run to completion BEFORE B arrives so the
+        # inner task has fully passed its close-site check and returned.
+        result_a = await asyncio.wait_for(
+            game_router._finalize_game_route_state(
+                state, reason="A_no_close", close_game_session=False,
+            ),
+            timeout=5.0,
+        )
+        assert result_a["game_session_closed"] is False
+        assert fake_session.close_calls == 0
+        assert key in game_router._game_sessions
+
+        # Caller B arrives late with close=True. The cached task is already
+        # done; dispatcher must still honor B's close request.
+        result_b = await asyncio.wait_for(
+            game_router._finalize_game_route_state(
+                state, reason="B_late_close", close_game_session=True,
+            ),
+            timeout=5.0,
+        )
+        assert result_b["game_session_closed"] is True
+        assert fake_session.close_calls == 1
+        assert key not in game_router._game_sessions
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b5_finalize_late_close_request_during_inner_archive(monkeypatch):
+    """codex P2 follow-up (PR #1127): late ``close=True`` caller variant
+    where the inner is parked on archive submission when B arrives.
+
+    This exercises a finer-grained race: even if scheduling lets the inner
+    resume past its close-site check before observing B's flag set
+    (because B has not actually been scheduled yet at the resume point),
+    the dispatcher recheck on B's existing-task path still performs the
+    close. ``_close_and_remove_session`` is idempotent, so concurrent
+    close paths between inner and dispatcher cannot double-close.
+    """
+    _stub_archive_calls(monkeypatch)
+    barrier = asyncio.Event()
+
+    async def _blocked_submit(_archive):
+        await barrier.wait()
+        return {"status": "ok"}
+
+    monkeypatch.setattr(game_router, "_submit_game_archive_to_memory", _blocked_submit)
+
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b5_mid")
+        fake_session = _FakeOmniSession(name="b5_mid")
+        key = game_router._game_session_key("Lan", "soccer", "match_b5_mid")
+        game_router._game_sessions[key] = {
+            "session": fake_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+
+        # Caller A spawns inner with close=False; inner parks on the barrier
+        # at archive submission, BEFORE reaching the close-site check.
+        task_a = asyncio.create_task(
+            game_router._finalize_game_route_state(
+                state, reason="A_no_close", close_game_session=False,
+            )
+        )
+        # Yield until inner has spawned and parked on the barrier.
+        for _ in range(50):
+            if state.get("_exit_task") is not None and not barrier.is_set():
+                # Give the inner a chance to reach the barrier.
+                await asyncio.sleep(0)
+                if state.get("archive") is not None:
+                    break
+            await asyncio.sleep(0)
+
+        # Caller B: close=True. Dispatcher ORs the flag and awaits the
+        # in-flight task.
+        task_b = asyncio.create_task(
+            game_router._finalize_game_route_state(
+                state, reason="B_close", close_game_session=True,
+            )
+        )
+        await asyncio.sleep(0)
+
+        # Release the barrier so inner reaches its close-site check with
+        # the OR-merged flag set to True.
+        barrier.set()
+        result_a, result_b = await asyncio.wait_for(
+            asyncio.gather(task_a, task_b), timeout=5.0,
+        )
+
+        assert result_a["game_session_closed"] is True
+        assert result_b["game_session_closed"] is True
+        # Exactly one close, despite the dispatcher recheck path being
+        # eligible to fire.
+        assert fake_session.close_calls == 1
+        assert key not in game_router._game_sessions
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_b1_chat_short_circuits_when_route_exit_started(monkeypatch):
     """B1/B2: ``_run_game_chat`` must short-circuit if the route flipped to
     ``_exit_flow_started`` before the call lands. Otherwise it would issue

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -1692,3 +1692,143 @@ async def test_build_session_cancellation_closes_half_open_client(monkeypatch):
         # Cache state is clean: nothing was registered, lock evicted.
         assert canonical_key not in game_router._game_sessions
         assert canonical_key not in game_router._game_session_create_locks
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_close_and_remove_session_identity_gates_pop_after_lock_wait():
+    """codex P1 (PR #1127 r3182582714): ``_close_and_remove_session``
+    must identity-gate ``_game_sessions.pop`` against the captured
+    ``entry`` so a peer that rotated the cache to ``entry_NEW`` while we
+    waited on ``entry['lock']`` does NOT lose its live session.
+
+    Race window:
+      1. Caller A reads entry_A from the cache, awaits entry_A['lock'].
+      2. A peer closer (also queued on entry_A['lock']) wins the lock
+         first, pops entry_A, closes it, releases the lock.
+      3. ``/route/start`` reuses the same (lanlan, game_type, session_id)
+         and inserts entry_NEW at the same key with a fresh
+         ``OmniOfflineClient``.
+      4. Caller A finally acquires entry_A['lock'] and proceeds to its
+         pop — pre-fix this evicts entry_NEW (NOT entry_A) from the
+         cache and closes entry_NEW's live session. Post-fix the pop is
+         identity-gated on ``cache.get(key) is entry`` so Caller A
+         leaves entry_NEW alone and only closes its OWN entry_A
+         session.
+
+    The two ``_FakeOmniSession`` instances are distinct objects, so the
+    test asserts on the per-object ``close_calls`` to verify which side
+    was actually closed.
+    """
+    with reset_game_route_state():
+        key = game_router._game_session_key("Lan", "soccer", "match_close_idgate")
+        game_router._game_sessions.pop(key, None)
+        game_router._game_session_create_locks.pop(key, None)
+
+        session_a = _FakeOmniSession(name="entry_A")
+        lock_a = asyncio.Lock()
+        entry_a = {
+            "session": session_a,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": lock_a,
+            "instructions": "",
+        }
+        game_router._game_sessions[key] = entry_a
+
+        # A peer task holds entry_A's lock — stand-in for "another caller
+        # already won the lock acquisition race". Caller A will queue
+        # behind it.
+        peer_release = asyncio.Event()
+
+        async def _hold_entry_a_lock():
+            async with lock_a:
+                await peer_release.wait()
+
+        peer_task = asyncio.create_task(_hold_entry_a_lock())
+        # Yield until the peer has actually acquired lock_a.
+        for _ in range(50):
+            if lock_a.locked():
+                break
+            await asyncio.sleep(0)
+        assert lock_a.locked(), "peer task failed to acquire entry_A's lock"
+
+        # Caller A: enters _close_and_remove_session, captures entry_a,
+        # then awaits lock_a (parked behind the peer).
+        caller_a_task = asyncio.create_task(
+            game_router._close_and_remove_session("soccer", "match_close_idgate", "Lan")
+        )
+        # Spin until Caller A is waiting on the lock (i.e., it has read
+        # entry and is queued — lock has waiters).
+        for _ in range(200):
+            waiters = getattr(lock_a, "_waiters", None)
+            if waiters and len(waiters) > 0:
+                break
+            await asyncio.sleep(0)
+        waiters = getattr(lock_a, "_waiters", None)
+        assert waiters and len(waiters) > 0, (
+            "Caller A failed to queue on entry_A['lock']; "
+            "the test cannot reproduce the race without that queueing."
+        )
+
+        # Simulate the peer-rotation: the lock holder pops entry_A,
+        # closes it, and a fresh /route/start inserts entry_NEW at the
+        # same key with a NEW lock + NEW session BEFORE we release
+        # lock_a. We perform these synchronously while Caller A is
+        # still parked.
+        evicted = game_router._game_sessions.pop(key, None)
+        assert evicted is entry_a
+        game_router._game_session_create_locks.pop(key, None)
+
+        session_b = _FakeOmniSession(name="entry_NEW")
+        entry_new = {
+            "session": session_b,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+        game_router._game_sessions[key] = entry_new
+        # Stand-in create lock for entry_NEW so the assertion below can
+        # distinguish "evicted by us" from "never present".
+        entry_new_create_lock = game_router._get_session_create_lock(key)
+        assert key in game_router._game_session_create_locks
+
+        # Release the peer's hold on lock_a so Caller A wakes up.
+        peer_release.set()
+        await peer_task
+        result = await asyncio.wait_for(caller_a_task, timeout=5.0)
+
+        # Caller A reports success — it closed its own entry's session.
+        assert result is True
+
+        # Identity gate held: entry_NEW is still in the cache, untouched.
+        assert game_router._game_sessions.get(key) is entry_new, (
+            "Identity gate failed: Caller A's pop evicted entry_NEW. "
+            "This is the codex P1 bug — a fresh /route/start's session "
+            "would now be orphaned and its session closed by us."
+        )
+        assert session_b.close_calls == 0, (
+            "entry_NEW's session was closed by Caller A; identity gate "
+            "must protect it because Caller A captured entry_A, not "
+            "entry_NEW."
+        )
+        # entry_NEW's create lock must also still be present.
+        assert game_router._game_session_create_locks.get(key) is entry_new_create_lock
+
+        # entry_A's session was closed (Caller A always owns its captured
+        # entry's lifecycle, regardless of cache state).
+        assert session_a.close_calls == 1, (
+            "entry_A's session must be closed by Caller A even when the "
+            "cache rotated; the captured entry is our responsibility."
+        )
+
+        # Cleanup so we leave the registry clean for sibling tests.
+        game_router._game_sessions.pop(key, None)
+        game_router._game_session_create_locks.pop(key, None)

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -970,3 +970,349 @@ async def test_character_switch_finalize_serializes_with_concurrent_route_start_
             if key[0] == "Lan" and state.get("game_route_active")
         ]
         assert len(active_for_lan) <= 1, active_for_lan
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_or_create_session_evicts_create_lock_on_build_failure(monkeypatch):
+    """codex P2 follow-up (PR #1127 r3182157092): when
+    ``_build_and_register_game_session`` raises (e.g. ``session.connect``
+    fails) the per-key entry in ``_game_session_create_locks`` must be
+    evicted on the failure path. Without the eviction every failed
+    creation leaks one ``asyncio.Lock`` per unique session_id over
+    uptime — and crucially, ``_close_and_remove_session`` (the only
+    other place that prunes the lock map) is never called for sessions
+    that never registered.
+    """
+    with reset_game_route_state():
+        canonical_key = game_router._game_session_key(
+            "Lan", "soccer", "match_build_fail",
+        )
+        # Drop any leftover from prior runs.
+        game_router._game_session_create_locks.pop(canonical_key, None)
+
+        async def _explode(*_args, **_kwargs):
+            raise RuntimeError("connect failed (simulated)")
+
+        monkeypatch.setattr(
+            game_router, "_build_and_register_game_session", _explode,
+        )
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await game_router._get_or_create_session(
+                "soccer", "match_build_fail", "Lan",
+            )
+
+        # Critical invariant: the per-key create lock must NOT linger
+        # after a failed build, because nothing else in the lifecycle
+        # would prune it.
+        assert canonical_key not in game_router._game_session_create_locks, (
+            "Failed _build_and_register_game_session leaked its create lock; "
+            "_close_and_remove_session never runs for unregistered sessions."
+        )
+        # Sanity: nothing was inserted into _game_sessions either.
+        assert canonical_key not in game_router._game_sessions
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_or_create_session_keeps_create_lock_when_peer_waits(monkeypatch):
+    """codex P2 follow-up — peer-waiter variant: if Thread A's build
+    fails while Thread B is parked on the same per-key create lock, the
+    eviction must NOT pop the lock from the registry mid-flight.
+    Otherwise a third arrival would call ``_get_session_create_lock``,
+    receive a fresh ``asyncio.Lock``, and run its own build concurrently
+    with B — defeating the build serialization.
+
+    Implementation invariant: when ``create_lock._waiters`` is
+    non-empty on the failure path, leave the lock in place. We exercise
+    that branch with a real concurrent waiter and assert that AT THE
+    MOMENT A's failure unwinds, the registry still points at the
+    original lock (and Thread B subsequently re-uses it rather than
+    seeing a fresh one).
+    """
+    with reset_game_route_state():
+        canonical_key = game_router._game_session_key(
+            "Lan", "soccer", "match_peer_wait",
+        )
+        game_router._game_session_create_locks.pop(canonical_key, None)
+
+        # The build helper must NOT auto-yield before A reaches the
+        # async-with body, so A wins the lock acquisition. A then yields
+        # while raising so B has time to park as a waiter.
+        a_inside_build = asyncio.Event()
+        b_can_unblock = asyncio.Event()
+        captured: dict = {}
+
+        async def _explode_a(*_args, **_kwargs):
+            captured["lock_at_A_inside"] = (
+                game_router._game_session_create_locks.get(canonical_key)
+            )
+            a_inside_build.set()
+            # Park until B has had time to register as a waiter.
+            await b_can_unblock.wait()
+            # Confirm that B is in fact registered as a waiter on our
+            # lock by the time we raise.
+            lock = captured["lock_at_A_inside"]
+            captured["waiters_seen_at_A_raise"] = list(
+                getattr(lock, "_waiters", []) or ()
+            )
+            raise RuntimeError("A connect failed")
+
+        async def _succeed_b(*args, **kwargs):
+            # B's build runs after A fails; capture the lock instance
+            # at this point so we can prove it was not swapped.
+            captured["lock_at_B_build"] = (
+                game_router._game_session_create_locks.get(canonical_key)
+            )
+            # Build and register a minimal entry so this path resembles
+            # a successful retry.
+            from asyncio import Lock as _Lock
+            entry = {
+                "session": _DummySession(),
+                "reply_chunks": [],
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "source": {},
+                "last_activity": 0,
+                "lock": _Lock(),
+                "instructions": "",
+            }
+            game_router._game_sessions[canonical_key] = entry
+            return entry
+
+        class _DummySession:
+            async def close(self):
+                pass
+
+        # First call (A) explodes; second call (B) succeeds — we swap
+        # the dispatch after A's failure so the same monkeypatch slot
+        # serves both peers.
+        current_fn = {"fn": _explode_a}
+
+        async def _dispatch(*args, **kwargs):
+            return await current_fn["fn"](*args, **kwargs)
+
+        monkeypatch.setattr(
+            game_router, "_build_and_register_game_session", _dispatch,
+        )
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+
+        async def _a_runner():
+            try:
+                await game_router._get_or_create_session(
+                    "soccer", "match_peer_wait", "Lan",
+                )
+            except RuntimeError:
+                pass
+
+        async def _b_runner():
+            # Wait until A is INSIDE the lock so we park as a real
+            # waiter (not just sneak in before A acquires).
+            await a_inside_build.wait()
+            await game_router._get_or_create_session(
+                "soccer", "match_peer_wait", "Lan",
+            )
+
+        async def _release_a_after_b_parks():
+            await a_inside_build.wait()
+            # Yield several times to let B reach the async-with on the
+            # create lock and register as a waiter.
+            for _ in range(20):
+                await asyncio.sleep(0)
+            # Swap the build dispatcher so B's build succeeds when it
+            # eventually acquires the lock.
+            current_fn["fn"] = _succeed_b
+            b_can_unblock.set()
+
+        await asyncio.gather(_a_runner(), _b_runner(), _release_a_after_b_parks())
+
+        # Invariant 1: A saw a non-None waiter list at the moment of
+        # raise. This is the precondition for the conditional-pop guard
+        # to actually be exercised; if the test scaffold never produced
+        # a real waiter the assertion below would be vacuous.
+        assert captured["waiters_seen_at_A_raise"], (
+            "Test scaffold failed to register Thread B as a waiter; "
+            "the conditional-pop branch was not exercised."
+        )
+
+        # Invariant 2 (load-bearing): the lock B saw when its build ran
+        # is the SAME lock A had. If A's failure had unconditionally
+        # popped the registry, B's wake-up would have been on the old
+        # lock object but the registry would point at a fresh one for
+        # the next arrival — and `_succeed_b` here would observe a
+        # different lock instance, mismatched with the one B awaited.
+        assert captured["lock_at_B_build"] is captured["lock_at_A_inside"], (
+            "Create lock was swapped while a peer was awaiting it; "
+            "build serialization is broken."
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_partial_connect_race_does_not_orphan_session(monkeypatch):
+    """CR Major (PR #1127 r3182158697): if a finalize runs to a no-op
+    while ``_build_and_register_game_session`` is mid ``session.connect``
+    (because the entry isn't registered yet), the freshly-built
+    ``OmniOfflineClient`` would otherwise survive in ``_game_sessions``
+    until the 30-min idle sweep. The post-lock route_inactive short-
+    circuit in ``_run_game_chat`` must evict + close the orphan.
+
+    Race interleaving exercised here:
+      1. Thread A calls ``_run_game_chat`` → passes pre-create gate
+         (route still active) → enters ``_get_or_create_session`` →
+         awaits ``connect`` (we block this on a barrier).
+      2. Thread B flips ``_exit_flow_started`` / ``game_route_active``
+         on the route state, then calls ``_close_and_remove_session``
+         — which is a no-op because the entry isn't registered yet.
+      3. Barrier released → Thread A's build completes and registers
+         the entry → Thread A acquires ``entry['lock']`` → post-lock
+         route-active gate trips → fix path closes + evicts.
+
+    Pre-fix: Thread A's session lingers in ``_game_sessions`` and is
+    never closed (``close_calls == 0``).
+    Post-fix: Thread A evicts itself and awaits ``session.close()``
+    once before returning ``skipped=route_inactive``.
+    """
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_partial_connect")
+        canonical_key = game_router._game_session_key(
+            "Lan", "soccer", "match_partial_connect",
+        )
+        game_router._game_session_create_locks.pop(canonical_key, None)
+
+        connect_barrier = asyncio.Event()
+        connect_started = asyncio.Event()
+        constructed: list = []
+
+        class _BlockingOmni:
+            def __init__(self, **kwargs):
+                self.connect_calls = 0
+                self.close_calls = 0
+                self.stream_calls = 0
+                self._closed = False
+                constructed.append(self)
+
+            async def connect(self, *, instructions: str = ""):
+                self.connect_calls += 1
+                connect_started.set()
+                # Park here until Thread B has flipped the route state
+                # and run its no-op _close_and_remove_session.
+                await connect_barrier.wait()
+
+            async def close(self):
+                self.close_calls += 1
+                self._closed = True
+
+            async def stream_text(self, text: str):
+                if self._closed:
+                    raise RuntimeError("stream_text on closed session")
+                self.stream_calls += 1
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _BlockingOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        # Thread A: drive _run_game_chat. It will block on connect()
+        # until we release the barrier.
+        chat_task = asyncio.create_task(
+            game_router._run_game_chat(
+                "soccer",
+                "match_partial_connect",
+                {"kind": "free-ball", "lanlan_name": "Lan"},
+            )
+        )
+
+        # Wait until Thread A is parked inside connect(). Past this
+        # point the route's pre-create gate has been crossed but the
+        # entry isn't registered in _game_sessions yet.
+        await asyncio.wait_for(connect_started.wait(), timeout=2.0)
+        assert canonical_key not in game_router._game_sessions
+
+        # Thread B: simulate finalize racing in. Flip the route state
+        # to inactive, then call _close_and_remove_session — which is a
+        # no-op because Thread A's entry hasn't been inserted yet.
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+        no_op_close = await game_router._close_and_remove_session(
+            "soccer", "match_partial_connect", "Lan",
+        )
+        # Sanity: finalize's close was indeed a no-op.
+        assert no_op_close is False
+        assert canonical_key not in game_router._game_sessions
+
+        # Now release the barrier so Thread A's connect returns. The
+        # build then registers the entry, _run_game_chat acquires
+        # entry['lock'], hits the post-lock route_inactive gate, and
+        # (post-fix) evicts + closes its own orphan.
+        connect_barrier.set()
+        result = await asyncio.wait_for(chat_task, timeout=2.0)
+
+        assert result.get("skipped") == "route_inactive"
+        assert result.get("line") == ""
+
+        # Lifecycle invariants — these are what the fix guarantees:
+        # exactly one client built, closed exactly once, no orphan
+        # left behind in either the session cache or the create-lock
+        # map.
+        assert len(constructed) == 1
+        assert constructed[0].close_calls == 1, (
+            "Orphan OmniOfflineClient was not closed; partial-connect "
+            "race leaked a session past finalize."
+        )
+        assert canonical_key not in game_router._game_sessions, (
+            "Orphan entry survived in _game_sessions after the "
+            "route_inactive short-circuit."
+        )
+        assert canonical_key not in game_router._game_session_create_locks
+        # Stream was never invoked — short-circuit fired before
+        # stream_text.
+        assert constructed[0].stream_calls == 0

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -2022,3 +2022,213 @@ async def test_close_and_remove_session_identity_gates_pop_after_lock_wait():
         # Cleanup so we leave the registry clean for sibling tests.
         game_router._game_sessions.pop(key, None)
         game_router._game_session_create_locks.pop(key, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_postgame_uses_snapshot_not_live_route_state(monkeypatch):
+    """CR Major (PR #1127 r3182963544): postgame must build its prompt
+    from a context snapshot frozen at finalize time — not by reverse-
+    resolving live route_state.
+
+    Pre-fix path: ``_build_and_register_game_session`` and
+    ``_refresh_game_session_instructions`` strip the postgame marker via
+    ``_route_session_id`` and call ``_find_game_route_state_for_session``.
+    If a fresh ``/route/start`` for the same ``(lanlan, game_type)`` key
+    activates DURING postgame's bubble generation, that lookup returns
+    the NEW route's preGameContext / game_context — postgame's prompt
+    is built from the new route's context.
+
+    Post-fix: postgame receives an explicit ``postgame_snapshot`` from
+    finalize. Both helpers prefer the snapshot over the live lookup, so
+    a peer route activation cannot pollute postgame's prompt.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        # OLD route's preGameContext — what postgame should see.
+        old_pre = {"summary": "OLD_PREGAME", "marker": "old"}
+        new_pre = {"summary": "NEW_PREGAME", "marker": "new"}
+
+        # Activate OLD route, then simulate finalize (route_active=False)
+        # AND simulate a fresh /route/start that REPLACED the slot in
+        # ``_game_route_states`` with a NEW state under the same key.
+        # That's the dangerous mid-postgame topology: the OLD state dict
+        # has been kicked out, the lookup returns NEW.
+        old_state = _activate_route("Lan", "soccer", "match_snapshot")
+        old_state["preGameContext"] = old_pre
+        old_state["_exit_flow_started"] = True
+        old_state["game_route_active"] = False
+
+        # Snapshot captured during finalize (frozen on the OLD state).
+        snapshot = game_router._build_postgame_context_snapshot(old_state)
+
+        # Now simulate the racing /route/start: peer activates a new
+        # state at the SAME (lanlan, game_type) key — this REPLACES
+        # ``_game_route_states[key]`` per ``_activate_game_route``.
+        new_state = _activate_route("Lan", "soccer", "match_snapshot")
+        new_state["preGameContext"] = new_pre
+
+        # Sanity: live reverse-lookup now returns the NEW state. This is
+        # the contamination vector the snapshot defends against.
+        assert (
+            game_router._find_game_route_state_for_session(
+                "soccer", "match_snapshot", "Lan",
+            )
+            is new_state
+        )
+
+        captured_pre_contexts: list[Any] = []
+        captured_game_contexts: list[Any] = []
+
+        def _record_prompt(
+            game_type, lanlan, lanlan_prompt, pre_game_context, game_context, language,
+        ):
+            captured_pre_contexts.append(pre_game_context)
+            captured_game_contexts.append(game_context)
+            return "stub_prompt"
+
+        monkeypatch.setattr(game_router, "_build_game_prompt", _record_prompt)
+
+        captured_callback = {"fn": None}
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                captured_callback["fn"] = kwargs.get("on_text_delta")
+
+            async def connect(self, *, instructions: str = ""):
+                pass
+
+            async def close(self):
+                pass
+
+            async def stream_text(self, text: str):
+                cb = captured_callback["fn"]
+                if cb is not None:
+                    await cb("postgame line", True)
+
+            async def update_session(self, config):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+
+        class _StubManager:
+            current_speech_id = "speech-snapshot"
+            state = None
+
+            async def prepare_proactive_delivery(self, *, min_idle_secs=0.0):
+                return True
+
+            async def finish_proactive_delivery(self, line, *, expected_speech_id=None):
+                return True
+
+            async def feed_tts_chunk(self, line, *, expected_speech_id=None):
+                pass
+
+        archive = {"lanlan_name": "Lan", "preGameContext": old_pre}
+        options = {"enabled": True}
+
+        result = await game_router._deliver_postgame_text_bubble(
+            "soccer", "match_snapshot", _StubManager(), archive, options,
+            postgame_snapshot=snapshot,
+        )
+
+        assert result.get("ok") is True, result
+
+        # Postgame's prompt was built from the OLD route's preGameContext
+        # (frozen at finalize), NOT the NEW route's state that
+        # ``_find_game_route_state_for_session`` would now return.
+        assert captured_pre_contexts, "expected _build_game_prompt to be invoked"
+        for pre in captured_pre_contexts:
+            assert pre == old_pre, (
+                f"postgame prompt was built from live route_state, not the "
+                f"finalize-time snapshot. Got pre_game_context={pre!r}, "
+                f"expected old snapshot={old_pre!r}. The new route's "
+                f"preGameContext={new_pre!r} contaminated postgame."
+            )
+
+        # Negative-control: without a snapshot, the helpers fall back to
+        # the live reverse-lookup and DO pick up the NEW route's context.
+        # This documents the pre-fix bug that the snapshot path closes.
+        captured_pre_contexts.clear()
+        captured_game_contexts.clear()
+        # Clear any cached postgame entry from the previous run before
+        # the negative-control build.
+        for k in list(game_router._game_sessions.keys()):
+            if game_router._POSTGAME_SESSION_MARKER in k:
+                game_router._game_sessions.pop(k, None)
+
+        result_no_snapshot = await game_router._deliver_postgame_text_bubble(
+            "soccer", "match_snapshot", _StubManager(), archive, options,
+        )
+        assert result_no_snapshot.get("ok") is True, result_no_snapshot
+        assert captured_pre_contexts, "expected _build_game_prompt to be invoked again"
+        for pre in captured_pre_contexts:
+            assert pre == new_pre, (
+                f"negative-control: without snapshot, expected live lookup "
+                f"to surface NEW route's preGameContext={new_pre!r}, got "
+                f"{pre!r}. If this assertion changes, the snapshot test "
+                f"above is no longer demonstrating the contamination it "
+                f"defends against."
+            )
+
+
+@pytest.mark.unit
+def test_route_session_id_only_strips_synthetic_uuid_tail():
+    """codex P2 (PR #1127 r3182964201): ``_route_session_id`` must strip
+    ONLY the exact suffix shape produced by ``_make_postgame_session_id``
+    (marker + 32-char uuid4 hex tail at end-of-string). A legitimate
+    client session_id that happens to contain ``::postgame::`` mid-string
+    or with a non-uuid tail must be returned unchanged.
+    """
+    # 1) Synthetic id from the helper round-trips back to the original.
+    synthetic = game_router._make_postgame_session_id("real-session-42")
+    assert game_router._route_session_id(synthetic) == "real-session-42"
+
+    # 2) Bare client id with no marker is unchanged.
+    assert game_router._route_session_id("client::regular::id") == "client::regular::id"
+
+    # 3) Client id literally containing ``::postgame::`` but no uuid tail
+    # must NOT be truncated. Pre-fix: any occurrence triggered strip.
+    # Each of these is a legitimate client id whose meaning would change
+    # if silently rewritten.
+    benign_inputs = [
+        "client::postgame::data",                            # word tail
+        "client::postgame::",                                # empty tail
+        "client::postgame::12345",                           # short tail
+        "client::postgame::" + "g" * 32,                     # non-hex tail
+        "client::postgame::" + "0" * 31,                     # 31 chars (off by one)
+        "client::postgame::" + "0" * 33,                     # 33 chars
+        "client::postgame::deadbeef::extra",                 # extra suffix after fake tail
+        "client::postgame::" + "0" * 32 + "x",               # 32 hex + extra
+    ]
+    for raw in benign_inputs:
+        assert game_router._route_session_id(raw) == raw, (
+            f"_route_session_id must NOT strip benign input {raw!r}"
+        )
+
+    # 4) Empty / falsy inputs.
+    assert game_router._route_session_id("") == ""
+    assert game_router._route_session_id(None) == ""
+
+    # 5) An id with the marker MID-string AND a real synthetic suffix at
+    # the end strips only the suffix, preserving the mid-string marker.
+    base = "weird::postgame::client"
+    synth = game_router._make_postgame_session_id(base)
+    # synth = ``weird::postgame::client::postgame::<uuid_hex>`` — only the
+    # final suffix shape matches; the inner ``::postgame::client`` stays.
+    assert game_router._route_session_id(synth) == base

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -838,6 +838,184 @@ async def test_postgame_text_bubble_identity_gates_close(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_postgame_session_isolated_from_concurrent_route_start_reuse(monkeypatch):
+    """codex P1 follow-up (PR #1127 r3182591852): postgame's freshly-built
+    session must live at a private cache key so a racing ``/route/start``
+    reusing the user-facing ``(lanlan, game_type, session_id)`` cannot land
+    on the same ``_game_sessions`` slot.
+
+    Pre-fix race window:
+    1. ``_complete_game_end_from_payload`` finalizes route → closes
+       original session, releases ``end_route_lock`` and supersede lock.
+    2. ``_run_game_chat(allow_postgame=True)`` builds entry_pg, registers
+       it under the user-facing key.
+    3. Postgame's text generation parks at ``finish_proactive_delivery``.
+    4. A new ``/route/start`` for the same key activates and its first
+       ``/game_chat`` calls ``_get_or_create_session`` — finds entry_pg
+       STILL CACHED, returns it (cache reuse).
+    5. Postgame's ``finally`` runs. Identity check
+       ``cache[key] is entry_pg`` STILL passes (peer reused, didn't
+       replace) → finally closes ``entry_pg['session']`` — actively in
+       use by the new route → new route's first turn dies on closed WS.
+
+    Post-fix: postgame builds its session at ``::postgame::<uuid>``-
+    suffixed cache key. The new route's ``_get_or_create_session`` for
+    the user-facing key never sees postgame's slot, builds its own
+    fresh entry. Postgame's ``finally`` evicts only its private slot.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_postgame_reuse")
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+
+        captured_callback = {"fn": None}
+        constructed: list[_FakeOmniSession] = []
+
+        class _TrackingOmni:
+            def __init__(self, **kwargs):
+                captured_callback["fn"] = kwargs.get("on_text_delta")
+                self.fake = _FakeOmniSession(name=f"omni_{len(constructed)}")
+                constructed.append(self.fake)
+
+            async def connect(self, *, instructions: str = ""):
+                await self.fake.connect()
+
+            async def close(self):
+                await self.fake.close()
+
+            async def stream_text(self, text: str):
+                await self.fake.stream_text(text)
+                cb = captured_callback["fn"]
+                if cb is not None:
+                    await cb("postgame bubble line", True)
+
+            async def update_session(self, config):
+                await self.fake.update_session(config)
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _TrackingOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        # Hook ``finish_proactive_delivery`` — runs AFTER chat finishes
+        # but BEFORE the bubble's finally — to simulate a racing peer
+        # ``/route/start`` whose first ``/game_chat`` calls
+        # ``_get_or_create_session`` for the SAME user-facing key. Any
+        # cached entry it finds there is what postgame's finally will
+        # later close. Pre-fix: postgame's entry IS at that key →
+        # peer reuses postgame's session → finally closes peer's
+        # active session.
+        peer_entry_holder: dict = {"entry": None}
+
+        class _StubManager:
+            is_active = False
+            session = None
+            current_speech_id = "speech-postgame"
+            state = None
+
+            def __init__(self):
+                self.delivered = None
+
+            async def prepare_proactive_delivery(self, *, min_idle_secs=0.0):
+                return True
+
+            async def finish_proactive_delivery(self, line, *, expected_speech_id=None):
+                # Simulate the racing peer: it activated a fresh route
+                # for the same user-facing key after postgame's bypass
+                # registered. Its first ``/game_chat`` resolves through
+                # ``_get_or_create_session(..., session_id=user-facing)``.
+                peer_entry_holder["entry"] = await game_router._get_or_create_session(
+                    "soccer", "match_postgame_reuse", "Lan",
+                )
+                self.delivered = line
+                return True
+
+            async def feed_tts_chunk(self, line, *, expected_speech_id=None):
+                pass
+
+        mgr = _StubManager()
+        archive = {
+            "lanlan_name": "Lan",
+            "summary": "",
+            "last_full_dialogues": [],
+            "last_state": {},
+            "finalScore": {},
+            "preGameContext": {},
+        }
+        options = {"enabled": True, "max_chars": 60, "include_last_dialogues": 0}
+
+        user_facing_key = game_router._game_session_key(
+            "Lan", "soccer", "match_postgame_reuse",
+        )
+
+        result = await game_router._deliver_postgame_text_bubble(
+            "soccer", "match_postgame_reuse", mgr, archive, options,
+        )
+
+        assert result.get("ok") is True, result
+        assert result.get("action") == "chat", result
+
+        # Two distinct ``OmniOfflineClient`` instances were built —
+        # postgame's at the private key, peer's at the user-facing key.
+        # Pre-fix: only ONE instance built (peer reused postgame's).
+        assert len(constructed) == 2, (
+            f"Expected postgame and peer to build separate sessions, "
+            f"but {len(constructed)} OmniOfflineClient(s) were constructed — "
+            f"peer's _get_or_create_session reused postgame's cache slot."
+        )
+
+        peer_entry = peer_entry_holder["entry"]
+        assert peer_entry is not None
+        peer_session = peer_entry.get("session")
+        assert peer_session is not None
+
+        # CRITICAL: the peer's session is still alive. Pre-fix, postgame's
+        # finally would close it (close_calls == 1) because the cache
+        # identity check still pointed at the same entry the peer was
+        # handed back from cache reuse.
+        assert peer_session.fake.close_calls == 0, (
+            "postgame finally closed the peer route's session — "
+            "cache reuse race regressed"
+        )
+
+        # Peer's entry remains cached at the user-facing key.
+        assert game_router._game_sessions.get(user_facing_key) is peer_entry, (
+            "peer route's cache entry was evicted by postgame's finally"
+        )
+
+        # Postgame's private cache slot (whatever it was) has been
+        # cleaned up. Inspecting cache: only the peer entry should remain
+        # under any key matching this game_type/lanlan.
+        leaked = [
+            k for k, v in game_router._game_sessions.items()
+            if v is not peer_entry
+            and game_router._POSTGAME_SESSION_MARKER in k
+        ]
+        assert leaked == [], (
+            f"postgame entry leaked at private key(s): {leaked}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_b1_supersede_then_chat_does_not_revive_closed_route(monkeypatch):
     """B1: after a ``/route/start`` supersede finalizes a prior route,
     a stale chat for that prior route must not silently re-create an

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -443,3 +443,96 @@ async def test_game_session_create_lock_evicted_with_session():
         # The create lock for this evicted session must also be gone.
         assert key not in game_router._game_session_create_locks
         assert session.closed is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_or_create_session_canonical_key_mismatch_leaves_no_orphan_lock(
+    monkeypatch,
+):
+    """CodeRabbit follow-up (PR #1127): when caller passes an empty
+    ``lanlan_name`` and ``_get_character_info`` canonicalizes it to a
+    non-empty name, the raw key (``""+game_type+session_id``) must NOT
+    leave an orphan entry in ``_game_session_create_locks``.
+
+    Pre-fix shape acquired the create lock under the raw key, then
+    canonicalized inside the lock and acquired a SECOND lock under the
+    canonical key. The session was stored under the canonical key, so
+    ``_close_and_remove_session`` only evicted
+    ``_game_session_create_locks[canonical_key]`` — the raw-key entry
+    accumulated over uptime as an unreachable, never-cleaned ``Lock``.
+
+    Post-fix shape resolves the canonical key BEFORE locking, so only
+    one lock is ever taken and the dict only ever contains the
+    canonical-key entry (which the existing eviction path already
+    handles).
+    """
+    with reset_game_route_state():
+        raw_key = game_router._game_session_key("", "soccer", "match_canon")
+        canonical_key = game_router._game_session_key("Lan", "soccer", "match_canon")
+        assert raw_key != canonical_key  # sanity: keys actually differ.
+
+        # Drop any leftovers from earlier runs.
+        game_router._game_session_create_locks.pop(raw_key, None)
+        game_router._game_session_create_locks.pop(canonical_key, None)
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                self._closed = False
+
+            async def connect(self, *, instructions: str = ""):
+                pass
+
+            async def close(self):
+                self._closed = True
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            # Caller-supplied ``name`` is empty; canonicalize to "Lan".
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        # Caller passes empty lanlan_name → triggers canonical_key != key.
+        entry = await game_router._get_or_create_session(
+            "soccer", "match_canon", "",
+        )
+
+        # Session is stored under the canonical key, not the raw key.
+        assert canonical_key in game_router._game_sessions
+        assert raw_key not in game_router._game_sessions
+        assert game_router._game_sessions[canonical_key] is entry
+
+        # Critical invariant: no orphan lock under the raw key. Only the
+        # canonical key may have a lock entry — and that one will be
+        # evicted by ``_close_and_remove_session`` when the session ends.
+        assert raw_key not in game_router._game_session_create_locks, (
+            "Raw-key create lock leaked when canonical_key != key; "
+            "_close_and_remove_session would never evict it."
+        )
+
+        # Round-trip: closing the session via the canonical lookup must
+        # still clean up the (only) lock entry, leaving the dict free of
+        # any per-session entries for this case.
+        closed = await game_router._close_and_remove_session(
+            "soccer", "match_canon", "Lan",
+        )
+        assert closed is True
+        assert canonical_key not in game_router._game_session_create_locks
+        assert raw_key not in game_router._game_session_create_locks

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -1433,6 +1433,10 @@ async def test_get_or_create_session_keeps_create_lock_when_peer_waits(monkeypat
                     "soccer", "match_peer_wait", "Lan",
                 )
             except RuntimeError:
+                # Why: A's build dispatcher is the injected failing
+                # builder (peer-waiter orchestration). The RuntimeError
+                # is the expected outcome — we swallow it so B's
+                # subsequent acquire of the create lock can be observed.
                 pass
 
         async def _b_runner():

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -1,0 +1,320 @@
+"""Concurrency / race-condition tests for ``main_routers/game_router``.
+
+These cover the audit findings B1, B2, B3, B5, B6, B8 (B4 is a defensive
+guard verified in ``test_game_context_organizer.py``; B7 was landed in
+PR #1125).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from main_routers import game_router
+from utils import game_route_state as grs
+
+from .game_route_test_helpers import reset_game_route_state
+
+
+class _FakeOmniSession:
+    """Stand-in for ``OmniOfflineClient`` that records lifecycle calls."""
+
+    def __init__(self, *, name: str = "fake"):
+        self.name = name
+        self.connect_calls = 0
+        self.close_calls = 0
+        self.stream_calls = 0
+        self._closed = False
+
+    async def connect(self, *, instructions: str = ""):
+        self.connect_calls += 1
+
+    async def close(self):
+        self.close_calls += 1
+        self._closed = True
+
+    async def stream_text(self, text: str):
+        if self._closed:
+            raise RuntimeError("stream_text on closed session")
+        self.stream_calls += 1
+
+    async def update_session(self, config):
+        pass
+
+
+def _activate_route(lanlan: str, game_type: str, session_id: str) -> dict:
+    state = {
+        "game_route_active": True,
+        "game_type": game_type,
+        "session_id": session_id,
+        "lanlan_name": lanlan,
+        "created_at": game_router.time.time(),
+        "last_heartbeat_at": game_router.time.time(),
+        "last_activity": game_router.time.time(),
+        "heartbeat_enabled": True,
+        "pending_outputs": [],
+        "game_dialog_log": [],
+        "_external_voice_seen_request_ids": None,
+    }
+    game_router._game_route_states[grs._route_state_key(lanlan, game_type)] = state
+    return state
+
+
+def _stub_archive_calls(monkeypatch):
+    """Replace heavy archive helpers with no-ops so finalize tests focus
+    on the close_game_session decision rather than the AI archive flow.
+    """
+    async def _no_op(*_args, **_kwargs):
+        return None
+
+    async def _ok_submit(_archive):
+        return {"status": "ok"}
+
+    monkeypatch.setattr(
+        game_router, "_settle_game_context_organizer_before_archive", _no_op,
+    )
+    monkeypatch.setattr(
+        game_router, "_cancel_game_context_organizer_before_disabled_archive", _no_op,
+    )
+    monkeypatch.setattr(
+        game_router, "_submit_game_archive_to_memory", _ok_submit,
+    )
+    monkeypatch.setattr(game_router, "get_session_manager", lambda: {})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b5_finalize_or_merges_close_session_request(monkeypatch):
+    """B5: two finalize callers with conflicting close_game_session args
+    must produce exactly one close, and the True caller wins via OR-merge.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b5")
+        fake_session = _FakeOmniSession(name="b5")
+        key = game_router._game_session_key("Lan", "soccer", "match_b5")
+        game_router._game_sessions[key] = {
+            "session": fake_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+
+        # Caller A: close_game_session=False; Caller B: True.
+        results = await asyncio.gather(
+            game_router._finalize_game_route_state(
+                state, reason="A_no_close", close_game_session=False,
+            ),
+            game_router._finalize_game_route_state(
+                state, reason="B_close", close_game_session=True,
+            ),
+        )
+
+        # Both callers see the same finalized result (the shared task).
+        assert results[0]["game_session_closed"] is True
+        assert results[1]["game_session_closed"] is True
+
+        # The session was closed exactly once and removed from the cache.
+        assert fake_session.close_calls == 1
+        assert key not in game_router._game_sessions
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b1_chat_short_circuits_when_route_exit_started():
+    """B1/B2: ``_run_game_chat`` must short-circuit if the route flipped to
+    ``_exit_flow_started`` before the call lands. Otherwise it would issue
+    a ``stream_text`` against a session that finalize is about to close.
+    """
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b1")
+        state["_exit_flow_started"] = True
+        # No need to populate _game_sessions — the pre-create short-circuit
+        # in _run_game_chat must trip *before* ever calling
+        # _get_or_create_session.
+        result = await game_router._run_game_chat(
+            "soccer", "match_b1", {"kind": "free-ball", "lanlan_name": "Lan"},
+        )
+        assert result.get("skipped") == "route_inactive"
+        assert result.get("line") == ""
+
+
+@pytest.mark.unit
+def test_b2_append_dialog_drops_after_exit_started():
+    """B2: late writes after finalize starts must not mutate state."""
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b2")
+        state["_exit_flow_started"] = True
+        before_log_len = len(state["game_dialog_log"])
+        before_outputs_len = len(state["pending_outputs"])
+
+        game_router._append_game_dialog(state, {"type": "user", "text": "late"})
+        game_router._append_game_output(state, {"type": "game_event"})
+
+        assert len(state["game_dialog_log"]) == before_log_len
+        assert len(state["pending_outputs"]) == before_outputs_len
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b3_external_transcript_short_circuits_when_route_exiting():
+    """B3: dispatcher path must bail out cleanly if the route flipped to
+    exiting between the active-check and the transcript-route call.
+    """
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b3")
+        state["_exit_flow_started"] = True
+
+        handled = await game_router._route_external_transcript_to_game(
+            "Lan", state, "hello",
+            source="external_voice_route",
+            mode="voice",
+            kind="user-voice",
+            request_id="req-b3",
+        )
+        # Returns True (handled) so caller doesn't double-route through
+        # ordinary chat — the route was active at the dispatcher gate.
+        assert handled is True
+        # No game_dialog_log mutation, no game_chat call, no
+        # pending_outputs.
+        assert state["game_dialog_log"] == []
+        assert state["pending_outputs"] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b6_session_create_lock_serializes_concurrent_misses(monkeypatch):
+    """B6: two concurrent ``_get_or_create_session`` calls for the same key
+    must produce exactly one ``OmniOfflineClient`` + one ``connect`` call,
+    and exactly one entry in ``_game_sessions``.
+    """
+    with reset_game_route_state():
+        # Drop any leftover create lock for this key from a prior run.
+        key = game_router._game_session_key("Lan", "soccer", "match_b6")
+        game_router._game_session_create_locks.pop(key, None)
+
+        construct_count = {"n": 0}
+        connect_count = {"n": 0}
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                construct_count["n"] += 1
+                self._closed = False
+
+            async def connect(self, *, instructions: str = ""):
+                # Yield to let the peer reach the cache-recheck under lock.
+                await asyncio.sleep(0)
+                connect_count["n"] += 1
+
+            async def close(self):
+                self._closed = True
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        results = await asyncio.gather(
+            game_router._get_or_create_session("soccer", "match_b6", "Lan"),
+            game_router._get_or_create_session("soccer", "match_b6", "Lan"),
+        )
+
+        assert construct_count["n"] == 1
+        assert connect_count["n"] == 1
+        # Both calls return the same entry (cache hit on the second).
+        assert results[0] is results[1]
+        # Cache contains exactly one entry for this key.
+        assert key in game_router._game_sessions
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b8_finalize_routes_for_character_closes_old_routes(monkeypatch):
+    """B8: switching characters must finalize all active routes for the
+    outgoing character, releasing the SessionManager takeover and
+    closing the LLM session.
+    """
+    _stub_archive_calls(monkeypatch)
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_b8")
+        fake_session = _FakeOmniSession(name="b8")
+        key = game_router._game_session_key("Lan", "soccer", "match_b8")
+        game_router._game_sessions[key] = {
+            "session": fake_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+
+        n = await game_router.finalize_game_routes_for_character("Lan")
+
+        assert n == 1
+        assert state.get("_exit_flow_started") is True
+        assert state.get("game_route_active") is False
+        assert fake_session.close_calls == 1
+        # Calling again is a no-op (route already inactive).
+        n_again = await game_router.finalize_game_routes_for_character("Lan")
+        assert n_again == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_b1_supersede_then_chat_does_not_revive_closed_route(monkeypatch):
+    """B1: after a ``/route/start`` supersede finalizes a prior route,
+    a stale chat for that prior route must not silently re-create an
+    ``OmniOfflineClient`` for the now-inactive route slot.
+    """
+    with reset_game_route_state():
+        # Activate state for old session, then mark it as if route_start
+        # superseded it.
+        state = _activate_route("Lan", "soccer", "match_old")
+        state["_exit_flow_started"] = True
+        state["game_route_active"] = False
+
+        construct_count = {"n": 0}
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                construct_count["n"] += 1
+
+            async def connect(self, *, instructions: str = ""):
+                pass
+
+            async def close(self):
+                pass
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        result = await game_router._run_game_chat(
+            "soccer", "match_old", {"kind": "free-ball", "lanlan_name": "Lan"},
+        )
+
+        # Pre-create short-circuit must trip before any client is built.
+        assert construct_count["n"] == 0
+        assert result.get("skipped") == "route_inactive"

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -114,13 +114,16 @@ async def test_b5_finalize_or_merges_close_session_request(monkeypatch):
         }
 
         # Caller A: close_game_session=False; Caller B: True.
-        results = await asyncio.gather(
-            game_router._finalize_game_route_state(
-                state, reason="A_no_close", close_game_session=False,
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                game_router._finalize_game_route_state(
+                    state, reason="A_no_close", close_game_session=False,
+                ),
+                game_router._finalize_game_route_state(
+                    state, reason="B_close", close_game_session=True,
+                ),
             ),
-            game_router._finalize_game_route_state(
-                state, reason="B_close", close_game_session=True,
-            ),
+            timeout=5.0,
         )
 
         # Both callers see the same finalized result (the shared task).
@@ -267,9 +270,12 @@ async def test_b6_session_create_lock_serializes_concurrent_misses(monkeypatch):
             lambda *args, **kwargs: "stub_prompt",
         )
 
-        results = await asyncio.gather(
-            game_router._get_or_create_session("soccer", "match_b6", "Lan"),
-            game_router._get_or_create_session("soccer", "match_b6", "Lan"),
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                game_router._get_or_create_session("soccer", "match_b6", "Lan"),
+                game_router._get_or_create_session("soccer", "match_b6", "Lan"),
+            ),
+            timeout=5.0,
         )
 
         assert construct_count["n"] == 1
@@ -766,21 +772,24 @@ async def test_route_start_serializes_supersede_across_game_types_for_same_lanla
         grs_mod._route_state_locks.pop(grs_mod._route_state_key("Lan", "soccer"), None)
         grs_mod._route_state_locks.pop(grs_mod._route_state_key("Lan", "chess"), None)
 
-        results = await asyncio.gather(
-            game_router.game_route_start(
-                "soccer",
-                _FakeRouteStartRequest({
-                    "lanlan_name": "Lan",
-                    "session_id": "soccer_match",
-                }),
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                game_router.game_route_start(
+                    "soccer",
+                    _FakeRouteStartRequest({
+                        "lanlan_name": "Lan",
+                        "session_id": "soccer_match",
+                    }),
+                ),
+                game_router.game_route_start(
+                    "chess",
+                    _FakeRouteStartRequest({
+                        "lanlan_name": "Lan",
+                        "session_id": "chess_match",
+                    }),
+                ),
             ),
-            game_router.game_route_start(
-                "chess",
-                _FakeRouteStartRequest({
-                    "lanlan_name": "Lan",
-                    "session_id": "chess_match",
-                }),
-            ),
+            timeout=5.0,
         )
 
         assert all(r.get("ok") for r in results), results
@@ -1303,7 +1312,10 @@ async def test_get_or_create_session_keeps_create_lock_when_peer_waits(monkeypat
             current_fn["fn"] = _succeed_b
             b_can_unblock.set()
 
-        await asyncio.gather(_a_runner(), _b_runner(), _release_a_after_b_parks())
+        await asyncio.wait_for(
+            asyncio.gather(_a_runner(), _b_runner(), _release_a_after_b_parks()),
+            timeout=5.0,
+        )
 
         # Invariant 1: A saw a non-None waiter list at the moment of
         # raise. This is the precondition for the conditional-pop guard
@@ -1467,3 +1479,82 @@ async def test_partial_connect_race_does_not_orphan_session(monkeypatch):
         # Stream was never invoked — short-circuit fired before
         # stream_text.
         assert constructed[0].stream_calls == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_session_cancellation_closes_half_open_client(monkeypatch):
+    """CR Major (PR #1127 r3182318081): if ``_build_and_register_game_session``
+    is cancelled mid ``await session.connect(...)``, the half-open client
+    must still be closed. ``asyncio.CancelledError`` does not inherit from
+    ``Exception`` in Python 3.8+, so a bare ``except Exception`` would
+    swallow nothing here and leak the freshly built client.
+    """
+    with reset_game_route_state():
+        canonical_key = game_router._game_session_key(
+            "Lan", "soccer", "match_cancel_during_connect",
+        )
+        game_router._game_session_create_locks.pop(canonical_key, None)
+
+        connect_started = asyncio.Event()
+        # Connect parks on this event forever — the test cancels the
+        # build task while it is awaiting here.
+        connect_release = asyncio.Event()
+        constructed: list = []
+
+        class _StubOmni:
+            def __init__(self, **kwargs):
+                self.close_calls = 0
+                constructed.append(self)
+
+            async def connect(self, *, instructions: str = ""):
+                connect_started.set()
+                await connect_release.wait()
+
+            async def close(self):
+                self.close_calls += 1
+
+        import main_logic.omni_offline_client as omni_module
+        monkeypatch.setattr(omni_module, "OmniOfflineClient", _StubOmni)
+
+        def _stub_char_info(name):
+            return {
+                "lanlan_name": "Lan",
+                "lanlan_prompt": "",
+                "model": "stub",
+                "base_url": "https://stub.example.com",
+                "api_key": "stub",
+                "master_name": "Master",
+                "user_language": "en",
+                "api_type": "openai",
+            }
+
+        monkeypatch.setattr(game_router, "_get_character_info", _stub_char_info)
+        monkeypatch.setattr(
+            game_router,
+            "_build_game_prompt",
+            lambda *args, **kwargs: "stub_prompt",
+        )
+
+        build_task = asyncio.create_task(
+            game_router._get_or_create_session(
+                "soccer", "match_cancel_during_connect", "Lan",
+            )
+        )
+        await asyncio.wait_for(connect_started.wait(), timeout=2.0)
+
+        build_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await build_task
+
+        # Invariant: the half-open client must have been closed exactly
+        # once on the cancellation path. Pre-fix, this assertion fails
+        # because ``except Exception`` does not catch CancelledError.
+        assert len(constructed) == 1
+        assert constructed[0].close_calls == 1, (
+            "Cancelled session.connect leaked a half-open OmniOfflineClient; "
+            "CancelledError must trigger the same cleanup as Exception."
+        )
+        # Cache state is clean: nothing was registered, lock evicted.
+        assert canonical_key not in game_router._game_sessions
+        assert canonical_key not in game_router._game_session_create_locks

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -2629,3 +2629,117 @@ async def test_heartbeat_sweep_rechecks_expired_inside_lock(monkeypatch):
             "sweep finalized a route whose heartbeat had recovered "
             "before the lock was acquired; in-lock recheck is missing"
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_route_inactive_short_circuit_keeps_create_lock_when_peer_waits(
+    monkeypatch,
+):
+    """CR Major (PR #1127 r3183217909): when ``_run_game_chat`` hits the
+    post-lock route_inactive short-circuit AND a peer task is parked on
+    the per-key create lock, the eviction must NOT pop the lock from
+    ``_game_session_create_locks``. Otherwise the parked waiter and any
+    future arrival end up on two distinct ``asyncio.Lock`` instances and
+    the build-serialization invariant breaks — concurrent creators can
+    both run ``_build_and_register_game_session`` and the loser's
+    ``OmniOfflineClient`` leaks via the ``cached is not entry`` branch.
+
+    Mirrors the existing waiter-aware pattern in
+    ``_get_or_create_session``'s exception path
+    (``main_routers/game_router.py:3304-3306``).
+    """
+    with reset_game_route_state():
+        state = _activate_route("Lan", "soccer", "match_route_inactive_waiter")
+        key = game_router._game_session_key(
+            "Lan", "soccer", "match_route_inactive_waiter",
+        )
+        # Drop any leftovers; we'll seed the cache directly so
+        # _get_or_create_session cache-hits without touching the create
+        # lock.
+        game_router._game_sessions.pop(key, None)
+        game_router._game_session_create_locks.pop(key, None)
+
+        fake_session = _FakeOmniSession(name="route_inactive_waiter")
+        entry = {
+            "session": fake_session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+        game_router._game_sessions[key] = entry
+
+        # Seed the create lock with a real parked waiter. Holder owns it
+        # for the duration of the _run_game_chat call so the peer task
+        # cannot wake up — its future stays in ``_waiters``.
+        create_lock = asyncio.Lock()
+        game_router._game_session_create_locks[key] = create_lock
+        await create_lock.acquire()
+
+        async def _peer_waiter():
+            async with create_lock:
+                pass
+
+        peer_task = asyncio.create_task(_peer_waiter())
+        # Let the peer reach the await on lock.acquire() so it registers
+        # in ``_waiters``.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        waiters_before = getattr(create_lock, "_waiters", None)
+        assert waiters_before, (
+            "Test setup: peer task did not register as a waiter on the "
+            "create lock."
+        )
+
+        # Patch _get_or_create_session to (a) flip the route to inactive
+        # AFTER the pre-create gate, then (b) return our pre-seeded entry.
+        # This drives _run_game_chat into the post-lock route_inactive
+        # branch where the under-test pop lives.
+        original_get_or_create = game_router._get_or_create_session
+
+        async def _flip_then_return(*args, **kwargs):
+            state["_exit_flow_started"] = True
+            return entry
+
+        monkeypatch.setattr(
+            game_router, "_get_or_create_session", _flip_then_return,
+        )
+
+        try:
+            result = await asyncio.wait_for(
+                game_router._run_game_chat(
+                    "soccer",
+                    "match_route_inactive_waiter",
+                    {"kind": "free-ball", "lanlan_name": "Lan"},
+                ),
+                timeout=2.0,
+            )
+        finally:
+            create_lock.release()
+            await asyncio.wait_for(peer_task, timeout=1.0)
+            monkeypatch.setattr(
+                game_router, "_get_or_create_session", original_get_or_create,
+            )
+
+        assert result.get("skipped") == "route_inactive"
+        assert result.get("line") == ""
+        # Entry was evicted from the cache (route_inactive branch fired).
+        assert key not in game_router._game_sessions
+        # Orphan client closed exactly once.
+        assert fake_session.close_calls == 1
+        # CRITICAL invariant: the create lock is STILL in the registry
+        # because a peer waiter was parked on it. Pre-fix the
+        # unconditional pop would have removed it, splitting peers
+        # across two lock instances.
+        assert key in game_router._game_session_create_locks, (
+            "route_inactive short-circuit popped the create lock while a "
+            "peer waiter was still parked on it; peers will desync onto "
+            "distinct Lock instances and concurrent builds can race."
+        )
+        assert (
+            game_router._game_session_create_locks[key] is create_lock
+        ), "registry must point at the SAME lock instance the waiter is on"

--- a/tests/unit/test_game_router_concurrency.py
+++ b/tests/unit/test_game_router_concurrency.py
@@ -2,7 +2,12 @@
 
 These cover the audit findings B1, B2, B3, B5, B6, B8 (B4 is a defensive
 guard verified in ``test_game_context_organizer.py``; B7 was landed in
-PR #1125).
+PR #1125), plus two PR #1127 follow-up tests:
+
+- ``test_route_start_serializes_supersede_across_game_types_for_same_lanlan``
+  guards CodeRabbit's per-lanlan supersede-lock finding.
+- ``test_game_session_create_lock_evicted_with_session`` guards codex's
+  ``_game_session_create_locks`` memory-leak finding.
 """
 from __future__ import annotations
 
@@ -318,3 +323,123 @@ async def test_b1_supersede_then_chat_does_not_revive_closed_route(monkeypatch):
         # Pre-create short-circuit must trip before any client is built.
         assert construct_count["n"] == 0
         assert result.get("skipped") == "route_inactive"
+
+
+class _FakeRouteStartRequest:
+    """Minimal stand-in for ``fastapi.Request`` exposing only ``json()``."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_route_start_serializes_supersede_across_game_types_for_same_lanlan(monkeypatch):
+    """CodeRabbit follow-up: two concurrent /route/start calls for the same
+    ``lanlan_name`` but DIFFERENT ``game_type`` must be serialized so only
+    one active route remains for that character.
+
+    Without the per-lanlan supersede lock, each call holds a different
+    per-(lanlan, game_type) lock, both supersede scans miss the other's
+    pending activation, and both call ``_activate_game_route(...)`` —
+    leaving two active routes for the same character.
+    """
+    _stub_archive_calls(monkeypatch)
+
+    async def _fake_pregame(**_kwargs):
+        return (
+            game_router._default_soccer_pregame_context(initial_difficulty="lv2"),
+            "fallback",
+            "",
+        )
+
+    monkeypatch.setattr(game_router, "_build_soccer_pregame_context", _fake_pregame)
+
+    with reset_game_route_state():
+        # Drop any leftover supersede / route locks so this test starts fresh.
+        from utils import game_route_state as grs_mod
+        grs_mod._route_supersede_locks.pop("Lan", None)
+        grs_mod._route_state_locks.pop(grs_mod._route_state_key("Lan", "soccer"), None)
+        grs_mod._route_state_locks.pop(grs_mod._route_state_key("Lan", "chess"), None)
+
+        results = await asyncio.gather(
+            game_router.game_route_start(
+                "soccer",
+                _FakeRouteStartRequest({
+                    "lanlan_name": "Lan",
+                    "session_id": "soccer_match",
+                }),
+            ),
+            game_router.game_route_start(
+                "chess",
+                _FakeRouteStartRequest({
+                    "lanlan_name": "Lan",
+                    "session_id": "chess_match",
+                }),
+            ),
+        )
+
+        assert all(r.get("ok") for r in results), results
+
+        # Exactly one active route survives for ``Lan``. The second
+        # /route/start to acquire the supersede lock finalized the first.
+        active_for_lan = [
+            (key, state)
+            for key, state in game_router._game_route_states.items()
+            if key[0] == "Lan" and state.get("game_route_active")
+        ]
+        assert len(active_for_lan) == 1, active_for_lan
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_game_session_create_lock_evicted_with_session():
+    """codex P2 follow-up: ``_game_session_create_locks`` must drop its
+    per-key entry when the session is closed via ``_close_and_remove_session``.
+
+    Otherwise the dict accumulates one ``asyncio.Lock`` per ever-seen
+    session_id over uptime — a memory leak in long-running processes.
+    """
+    with reset_game_route_state():
+        key = game_router._game_session_key("Lan", "soccer", "match_evict")
+        # Drop any leftover from prior runs.
+        game_router._game_session_create_locks.pop(key, None)
+
+        # Lazily create the lock as ``_get_or_create_session`` would.
+        create_lock = game_router._get_session_create_lock(key)
+        assert key in game_router._game_session_create_locks
+        assert create_lock is game_router._game_session_create_locks[key]
+
+        # Register a session with a per-entry lock so close() goes through
+        # the locked branch (mirrors the production cache shape).
+        class _Closer:
+            def __init__(self):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        session = _Closer()
+        game_router._game_sessions[key] = {
+            "session": session,
+            "reply_chunks": [],
+            "lanlan_name": "Lan",
+            "lanlan_prompt": "",
+            "source": {},
+            "last_activity": 0,
+            "lock": asyncio.Lock(),
+            "instructions": "",
+        }
+
+        closed = await game_router._close_and_remove_session(
+            "soccer", "match_evict", "Lan",
+        )
+
+        assert closed is True
+        assert key not in game_router._game_sessions
+        # The create lock for this evicted session must also be gone.
+        assert key not in game_router._game_session_create_locks
+        assert session.closed is True

--- a/utils/game_route_state.py
+++ b/utils/game_route_state.py
@@ -18,7 +18,7 @@ finalize, archive, organizer). This module only holds:
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
+from typing import Awaitable, Callable, Dict, Optional, Tuple
 
 
 # Tuple key (not a `f"{lanlan}:{game_type}"` string):

--- a/utils/game_route_state.py
+++ b/utils/game_route_state.py
@@ -17,6 +17,7 @@ finalize, archive, organizer). This module only holds:
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 
 
@@ -41,6 +42,38 @@ _game_route_states: Dict[_RouteStateKey, dict] = {}
 
 def _route_state_key(lanlan_name: str, game_type: str) -> _RouteStateKey:
     return (str(lanlan_name or ""), str(game_type or ""))
+
+
+# Per-(lanlan_name, game_type) ``asyncio.Lock`` registry.
+#
+# Used by ``main_routers/game_router`` to serialize lifecycle transitions
+# (``/route/start`` finalize of any prior route, heartbeat-timeout sweep
+# finalize, character-switch finalize) against in-flight chat work for the
+# same route slot. Same key domain as ``_game_route_states`` so the
+# supersede invariant stays self-consistent — there is exactly one lock
+# per ``(lanlan, game_type)`` slot in this process, regardless of
+# session_id churn. We deliberately keep entries around even after the
+# state slot is popped: a fresh ``/route/start`` racing against the tail of
+# a sweep finalize must serialize against that same instance, and the
+# memory cost is negligible (one ``asyncio.Lock`` per character × game).
+_route_state_locks: Dict[_RouteStateKey, "asyncio.Lock"] = {}
+
+
+def _get_route_lock(lanlan_name: str, game_type: str) -> "asyncio.Lock":
+    """Return (and lazily create) the ``asyncio.Lock`` for ``(lanlan, game_type)``.
+
+    The dict insert + read happen entirely synchronously without ``await``,
+    so two coroutines racing into this helper on the same loop cannot both
+    create a fresh ``Lock`` — the first one to land at ``setdefault`` wins
+    and the second one observes the same instance. Cross-loop correctness
+    is irrelevant here: in production the FastAPI app loop is the only
+    consumer, and unit tests construct an isolated loop per test.
+    """
+    key = _route_state_key(lanlan_name, game_type)
+    lock = _route_state_locks.get(key)
+    if lock is None:
+        lock = _route_state_locks.setdefault(key, asyncio.Lock())
+    return lock
 
 
 def _get_active_game_route_state(

--- a/utils/game_route_state.py
+++ b/utils/game_route_state.py
@@ -59,6 +59,28 @@ def _route_state_key(lanlan_name: str, game_type: str) -> _RouteStateKey:
 _route_state_locks: Dict[_RouteStateKey, "asyncio.Lock"] = {}
 
 
+# Per-``lanlan_name`` supersede lock registry.
+#
+# OUTER lock (acquired BEFORE ``_route_state_locks``) for the
+# ``/route/start`` flow that scans ``_game_route_states`` for "any active
+# route for this lanlan_name regardless of game_type" and finalizes them
+# before activating a new one. Without this outer lock, two concurrent
+# ``/route/start`` calls for the SAME ``lanlan_name`` but DIFFERENT
+# ``game_type`` acquire DIFFERENT per-(lanlan, game_type) locks, so each
+# scan misses the other's pending activation and both end up activating
+# in parallel, breaking the "one active game route per character"
+# supersede invariant.
+#
+# Lock acquisition order (callers MUST follow to avoid deadlock):
+#
+#   1. ``_route_supersede_locks[lanlan_name]``          (OUTER)
+#   2. ``_route_state_locks[(lanlan_name, game_type)]`` (INNER)
+#
+# A code path that already holds an INNER lock must NOT then try to
+# acquire the OUTER lock for the same lanlan_name.
+_route_supersede_locks: Dict[str, "asyncio.Lock"] = {}
+
+
 def _get_route_lock(lanlan_name: str, game_type: str) -> "asyncio.Lock":
     """Return (and lazily create) the ``asyncio.Lock`` for ``(lanlan, game_type)``.
 
@@ -73,6 +95,22 @@ def _get_route_lock(lanlan_name: str, game_type: str) -> "asyncio.Lock":
     lock = _route_state_locks.get(key)
     if lock is None:
         lock = _route_state_locks.setdefault(key, asyncio.Lock())
+    return lock
+
+
+def _get_supersede_lock(lanlan_name: str) -> "asyncio.Lock":
+    """Return (and lazily create) the per-``lanlan_name`` supersede lock.
+
+    OUTER in the lock-ordering rule documented on
+    ``_route_supersede_locks``. Sync-init reasoning identical to
+    ``_get_route_lock``: dict ``get`` + ``setdefault`` happen without
+    ``await``, so a single Lock instance per lanlan_name wins regardless
+    of how many coroutines race into this helper.
+    """
+    key = str(lanlan_name or "")
+    lock = _route_supersede_locks.get(key)
+    if lock is None:
+        lock = _route_supersede_locks.setdefault(key, asyncio.Lock())
     return lock
 
 


### PR DESCRIPTION
## Summary

Follow-up PR to PR #1110 (squash `c49d6fe89`, mirror channel + session takeover refactor) and PR #1125 (`https://github.com/Project-N-E-K-O/N.E.K.O/pull/1125`, quick-win bug fixes). Addresses 7 race / lifecycle findings from an independent concurrency audit on `main_routers/game_router.py`.

**Targets PR #1125's branch** as base — finalize/state code in this PR depends on PR #1125's tuple-key change (B7 in the audit).

## Findings addressed

- **B1 (CRITICAL)** — `/route/start` race destroyed in-flight chat session. Wrap supersede+activation in per-(lanlan,game_type) `asyncio.Lock`; `_close_and_remove_session` now serializes against `entry['lock']` before pop+close; `_run_game_chat` short-circuits both pre-create and post-entry-lock when route is mid-exit.
- **B2 (CRITICAL)** — Heartbeat-expiry sweep raced with in-flight chat. `_append_game_dialog` / `_append_game_output` drop writes once `state['_exit_flow_started']` is set. Sweep takes route lock + rechecks active flag + awaits any existing exit task.
- **B3 (CRITICAL)** — STT transcript routed to LLM session mid-shutdown. `_route_external_transcript_to_game` short-circuits (returns True so caller doesn't double-route through ordinary chat) when the route is mid-exit.
- **B4 (HIGH)** — Defensive prev-task done check before `state['_game_context_organizer_task']` overwrite. The original race is theoretical on CPython (sync code path, no await boundary) but the check protects against future refactors.
- **B5 (HIGH)** — `_finalize_game_route_state` ignored its own `close_game_session` arg on second call. Now uses OR-merge across concurrent callers via `state['_exit_close_session_request']`. `_complete_game_end_from_payload` no longer redundantly calls `_close_and_remove_session` outside the shielded task — the inner finalize is the sole authority on session close.
- **B6 (HIGH)** — `_get_or_create_session` race leaked `OmniOfflineClient`. Per-key `asyncio.Lock` around cache-miss → ctor → connect → cache-insert. Connect-failure path closes the half-open session.
- **B7** — landed in PR #1125 (tuple key for `_game_route_states`).
- **B8 (MEDIUM)** — Character switch left old `lanlan_name`'s game route active until heartbeat sweep. New `finalize_game_routes_for_character()` hook called from `POST /api/characters/current_catgirl` finalizes all active routes for the outgoing character immediately.

## Lock taxonomy

Three lock layers, ordered outer → inner:

1. `_route_state_locks[(lanlan, game_type)]` (new) — per-route lifecycle serialization (start/end/sweep/character-switch).
2. `_game_session_create_locks[session_key]` (new) — per-key session-creation serialization.
3. `entry['lock']` (existing) — per-entry stream-text serialization. Now also held during `_close_and_remove_session` to bound mid-flight chat work.

No nested route-lock acquisitions — `/route/start` supersede holds only the new slot's lock, and the old slot's heartbeat sweep takes the old slot's own lock.

## Test plan

- [x] Existing baseline: 128 tests pass before changes
- [x] After changes: 138 pass (10 new concurrency tests, no regressions)
- [x] New concurrency tests in `tests/unit/test_game_router_concurrency.py`:
  - B5: gather two finalize callers (False vs True close arg) → exactly one OR-merged close
  - B1 pre-create short-circuit: chat does not spawn fresh client when route exiting
  - B1 supersede: stale chat for finalized route does not revive it
  - B2: append helpers drop writes when `_exit_flow_started`
  - B3: transcript dispatcher returns handled-true with no side-effects when exiting
  - B6: gather two creation calls → exactly one ctor/connect/cache entry
  - B8: `finalize_game_routes_for_character` closes session, marks state inactive, idempotent

## Related

- PR #1110 (`c49d6fe89`) — original mirror channel + session takeover refactor
- PR #1125 — quick-win bug fixes that this PR builds on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 切换角色时在后台安全终结并清理离开的所有活动游戏路由，日志记录成功或警告错误，结局（postgame）交付增强以防并发激活污染结局快照。

* **Bug Fixes**
  * 强化会话与路由并发控制：序列化会话创建、避免重复/双重关闭、保留单活路由不被竞态打破、路由退出与超时终结更幂等且免竞态。

* **Tests**
  * 新增大量并发与 postgame 相关单元测试，覆盖会话创建互斥、终结幂等性、快照隔离与会话 ID 处理，并调整现有测试以验证 postgame 标志传递。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->