### PR TITLE
feature: VAD MANUAL filling + chat+blind passthrough at main_server

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1747,6 +1747,55 @@ class LLMSessionManager:
             "turn_finalized": bool(finalize_turn),
         }
 
+    async def passthrough_to_chat_bubble(
+        self,
+        text: str,
+        *,
+        request_id: str | None = None,
+        turn_id: str | None = None,
+        source: str = "passthrough",
+    ) -> None:
+        """Render external text verbatim into the chat bubble WITHOUT
+        entering chat-LLM context.
+
+        Distinct from :meth:`mirror_assistant_output`: that writes to
+        ``sync_message_queue`` (so cross_server may add an AIMessage to
+        chat history). ``passthrough_to_chat_bubble`` skips
+        ``sync_message_queue`` entirely — frontend sees the bubble, but
+        the chat LLM never sees it in the next turn.
+
+        Use case: plugin / agent_server pushes verbatim with
+        ``visibility=["chat"] + ai_behavior="blind"`` — operator wants
+        the user to read it but the LLM should remain ignorant.
+
+        This is a generic SessionManager capability; it does not assume
+        any particular consumer.
+        """
+        clean = str(text or "").strip()
+        if not clean:
+            return
+        effective_turn_id = turn_id or request_id or str(uuid4())
+        message = {
+            "type": "gemini_response",
+            "text": clean,
+            "isNewMessage": True,
+            "turn_id": effective_turn_id,
+            "request_id": request_id,
+            "metadata": {"source": source, "passthrough": True},
+        }
+        try:
+            if (
+                self.websocket
+                and hasattr(self.websocket, "client_state")
+                and self.websocket.client_state == self.websocket.client_state.CONNECTED
+            ):
+                await self.websocket.send_json(message)
+        except Exception as e:
+            logger.warning(
+                "[%s] passthrough_to_chat_bubble WS send failed: %s",
+                self.lanlan_name, e,
+            )
+
     async def emit_mirror_turn_end(
         self,
         *,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1754,7 +1754,7 @@ class LLMSessionManager:
         request_id: str | None = None,
         turn_id: str | None = None,
         source: str = "passthrough",
-    ) -> None:
+    ) -> bool:
         """Render external text verbatim into the chat bubble WITHOUT
         entering chat-LLM context.
 
@@ -1770,6 +1770,15 @@ class LLMSessionManager:
 
         This is a generic SessionManager capability; it does not assume
         any particular consumer.
+
+        Returns ``True`` iff a ``gemini_response`` frame was actually
+        handed to ``send_json`` without raising. ``False`` covers every
+        no-op path: empty/whitespace text, websocket missing or
+        disconnected, and ``send_json`` failures swallowed below. Callers
+        that open an assistant-turn lifecycle on the frontend (e.g.
+        ``main_server`` chat-blind) MUST gate their turn-end emit on this
+        flag — a swallowed send means the frontend never opened a turn,
+        so emitting turn-end would close a lifecycle that never started.
         """
         # Why: caller passes raw_text deliberately (PR #1128 0ac9e8881).
         # We empty-check on the stripped form but forward the ORIGINAL so
@@ -1777,7 +1786,7 @@ class LLMSessionManager:
         # exactly as the plugin authored them.
         raw = str(text or "")
         if not raw or not raw.strip():
-            return
+            return False
         effective_turn_id = turn_id or request_id or str(uuid4())
         message = {
             "type": "gemini_response",
@@ -1787,18 +1796,21 @@ class LLMSessionManager:
             "request_id": request_id,
             "metadata": {"source": source, "passthrough": True},
         }
+        if not (
+            self.websocket
+            and hasattr(self.websocket, "client_state")
+            and self.websocket.client_state == self.websocket.client_state.CONNECTED
+        ):
+            return False
         try:
-            if (
-                self.websocket
-                and hasattr(self.websocket, "client_state")
-                and self.websocket.client_state == self.websocket.client_state.CONNECTED
-            ):
-                await self.websocket.send_json(message)
+            await self.websocket.send_json(message)
         except Exception as e:
             logger.warning(
                 "[%s] passthrough_to_chat_bubble WS send failed: %s",
                 self.lanlan_name, e,
             )
+            return False
+        return True
 
     async def emit_mirror_turn_end(
         self,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1771,13 +1771,17 @@ class LLMSessionManager:
         This is a generic SessionManager capability; it does not assume
         any particular consumer.
         """
-        clean = str(text or "").strip()
-        if not clean:
+        # Why: caller passes raw_text deliberately (PR #1128 0ac9e8881).
+        # We empty-check on the stripped form but forward the ORIGINAL so
+        # leading/trailing whitespace, newlines, and indentation render
+        # exactly as the plugin authored them.
+        raw = str(text or "")
+        if not raw or not raw.strip():
             return
         effective_turn_id = turn_id or request_id or str(uuid4())
         message = {
             "type": "gemini_response",
-            "text": clean,
+            "text": raw,
             "isNewMessage": True,
             "turn_id": effective_turn_id,
             "request_id": request_id,

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -675,6 +675,19 @@ class OmniRealtimeClient:
             raise ValueError(f"Invalid turn detection mode: {self.turn_detection_mode}")
 
         is_manual = self.turn_detection_mode == TurnDetectionMode.MANUAL
+        # MANUAL mode: every per-provider session.update below sends
+        # ``turn_detection: null``, so the provider will NOT emit
+        # speech_started / speech_stopped events. _has_server_vad was
+        # initialised in __init__ from provider/model heuristics
+        # (defaults to True for Qwen/GLM/GPT/Step/lanlan.tech-free), but
+        # those events won't arrive in MANUAL — so downstream branches in
+        # stream_audio() and _check_silence_timeout() must take the
+        # client-VAD path, same as Gemini / lanlan.app-free. Override the
+        # flag here uniformly across all providers; the Gemini connect
+        # path is unaffected because __init__ already set this to False
+        # for ``_is_gemini`` clients.
+        if is_manual:
+            self._has_server_vad = False
         self._modalities = ["text", "audio"] if native_audio else ["text"]
 
         if 'glm' in self._model_lower:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -671,153 +671,165 @@ class OmniRealtimeClient:
             logger.info(f"静默超时检测已禁用（{reason}），不会自动关闭会话")
 
         # Set up default session configuration
-        if self.turn_detection_mode == TurnDetectionMode.MANUAL:
-            raise NotImplementedError("Manual turn detection is not supported")
-        elif self.turn_detection_mode == TurnDetectionMode.SERVER_VAD:
-            self._modalities = ["text", "audio"] if native_audio else ["text"]
-            if 'glm' in self._model_lower:
-                glm_session = {
-                    "instructions": instructions,
-                    "modalities": self._modalities ,
-                    "voice": self.voice if self.voice else "tongtong",
-                    "input_audio_format": "pcm16",
-                    "output_audio_format": "pcm",
-                    "turn_detection": {
-                        "type": "server_vad",
-                    },
-                    "input_audio_noise_reduction": {
-                        "type": "far_field",
-                    },
-                    "beta_fields":{
-                        "chat_mode": "video_passive",
-                        "auto_search": True,
-                    },
-                    "temperature": 1.0
-                }
-                # GLM Realtime: tools only honoured in audio mode per docs.
-                # Use the flat (OpenAI-Realtime-style) schema GLM expects.
-                if self.has_tools() and 'audio' in self._modalities:
-                    glm_session["tools"] = self._tools_for_openai_realtime()
-                await self.update_session(glm_session)
-            elif "qwen" in self._model_lower:
-                qwen_session: Dict[str, Any] = {
-                    "instructions": instructions,
-                    "modalities": self._modalities ,
-                    "voice": self.voice if self.voice else "Momo",
-                    "input_audio_format": "pcm16",
-                    "output_audio_format": "pcm16",
-                    "input_audio_transcription": {
-                        "model": "gummy-realtime-v1"
-                    },
-                    "turn_detection": {
-                        # TODO: 未来需要cover更多型号
-                        "type": "semantic_vad" if "3.5" in self._model_lower else "server_vad",
-                        "threshold": 0.55,
-                        "prefix_padding_ms": 300,
-                        "silence_duration_ms": 600
-                    },
-                    "repetition_penalty": 1.2,
-                    "temperature": 0.7,
-                    # "enable_search": True,
-                    # "search_options": {'enable_source': True}
-                }
-                # Qwen-Omni-Realtime 自 2026 起支持 tools（嵌套 function 形，
-                # 同 StepFun）。重要约束：tools 与 enable_search 互斥——
-                # 我们注册了自定义工具时强制 enable_search=False，避免
-                # session.update 被服务端拒绝。文档参见 Aliyun client-events
-                # 章节 "工具调用（tools）和联网搜索（enable_search）不兼容"。
-                if self.has_tools():
-                    qwen_session["tools"] = self._tools_for_qwen()
-                    qwen_session["enable_search"] = False
-                await self.update_session(qwen_session)
-            elif "gpt" in self._model_lower:
-                gpt_session = {
-                    "type": "realtime",
-                    "model": self.model,
-                    "instructions": instructions,
-                    "output_modalities": ['audio'] if 'audio' in self._modalities else ['text'],
-                    "audio": {
-                        "input": {
-                            "transcription": {"model": "gpt-4o-mini-transcribe"},
-                            "turn_detection": { "type": "semantic_vad",
-                                "eagerness": "auto",
-                                "create_response": True,
-                                "interrupt_response": True
-                            },
-                        },
-                        "output": {
-                            "voice": self.voice if self.voice else "marin",
-                            "speed": 1.0
-                        }
-                    }
-                }
-                if self.has_tools():
-                    gpt_session["tools"] = self._tools_for_openai_realtime()
-                    gpt_session["tool_choice"] = "auto"
-                await self.update_session(gpt_session)
-            elif "step" in self._model_lower:
-                step_session = {
-                    "instructions": instructions,
-                    "modalities": ['text', 'audio'], # Step API只支持这一个模式
-                    "voice": self.voice if self.voice else "qingchunshaonv",
-                    "input_audio_format": "pcm16",
-                    "output_audio_format": "pcm16",
-                    "turn_detection": {
-                        "type": "server_vad"
-                    },
-                }
-                # Always keep the built-in web_search; append custom tools
-                # (StepFun supports both type:"web_search" and type:"function"
-                # in the same array — see official docs).
-                step_tools: List[Dict[str, Any]] = [
-                    {
-                        "type": "web_search",
-                        "function": {
-                            "description": "这个web_search用来搜索互联网的信息"
-                        }
-                    }
-                ]
-                if self.has_tools():
-                    step_tools.extend(self._tools_for_step())
-                step_session["tools"] = step_tools
-                await self.update_session(step_session)
-            elif "free" in self._model_lower:
-                # NOTE: lanlan.tech (China free) backs onto StepFun and
-                # supports the StepFun custom-function protocol — the
-                # server-side tool stripping the user mentioned will be
-                # lifted, after which our tools propagate naturally.
-                # lanlan.app (international free) backs onto Vertex AI
-                # Live; that path is currently TODO (no client→server
-                # tools propagation confirmed). Tools below match the
-                # StepFun shape and become a no-op on lanlan.app until
-                # the proxy supports them.
-                free_session = {
-                    "instructions": instructions,
-                    "modalities": ['text', 'audio'],
-                    "voice": self.voice if self.voice else "qingchunshaonv",
-                    "input_audio_format": "pcm16",
-                    "output_audio_format": "pcm16",
-                    "turn_detection": {
-                        "type": "server_vad"
-                    },
-                }
-                free_tools: List[Dict[str, Any]] = [
-                    {
-                        "type": "web_search",
-                        "function": {
-                            "description": "这个web_search用来搜索互联网的信息"
-                        }
-                    }
-                ]
-                if self.has_tools():
-                    free_tools.extend(self._tools_for_step())
-                free_session["tools"] = free_tools
-                await self.update_session(free_session)
-            else:
-                raise ValueError(f"Invalid model: {self.model}")
-            self.instructions = instructions
-        else:
+        if self.turn_detection_mode not in (TurnDetectionMode.MANUAL, TurnDetectionMode.SERVER_VAD):
             raise ValueError(f"Invalid turn detection mode: {self.turn_detection_mode}")
+
+        is_manual = self.turn_detection_mode == TurnDetectionMode.MANUAL
+        self._modalities = ["text", "audio"] if native_audio else ["text"]
+
+        if 'glm' in self._model_lower:
+            # GLM: server_vad payload in SERVER_VAD; turn_detection=null in MANUAL.
+            # Best-effort — provider may reject; if so we degrade to local-suppression-only.
+            glm_session = {
+                "instructions": instructions,
+                "modalities": self._modalities ,
+                "voice": self.voice if self.voice else "tongtong",
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm",
+                "turn_detection": None if is_manual else {
+                    "type": "server_vad",
+                },
+                "input_audio_noise_reduction": {
+                    "type": "far_field",
+                },
+                "beta_fields":{
+                    "chat_mode": "video_passive",
+                    "auto_search": True,
+                },
+                "temperature": 1.0
+            }
+            # GLM Realtime: tools only honoured in audio mode per docs.
+            # Use the flat (OpenAI-Realtime-style) schema GLM expects.
+            if self.has_tools() and 'audio' in self._modalities:
+                glm_session["tools"] = self._tools_for_openai_realtime()
+            await self.update_session(glm_session)
+        elif "qwen" in self._model_lower:
+            qwen_session: Dict[str, Any] = {
+                "instructions": instructions,
+                "modalities": self._modalities ,
+                "voice": self.voice if self.voice else "Momo",
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm16",
+                "input_audio_transcription": {
+                    "model": "gummy-realtime-v1"
+                },
+                "turn_detection": None if is_manual else {
+                    # TODO: 未来需要cover更多型号
+                    "type": "semantic_vad" if "3.5" in self._model_lower else "server_vad",
+                    "threshold": 0.55,
+                    "prefix_padding_ms": 300,
+                    "silence_duration_ms": 600
+                },
+                "repetition_penalty": 1.2,
+                "temperature": 0.7,
+                # "enable_search": True,
+                # "search_options": {'enable_source': True}
+            }
+            # Qwen-Omni-Realtime 自 2026 起支持 tools（嵌套 function 形，
+            # 同 StepFun）。重要约束：tools 与 enable_search 互斥——
+            # 我们注册了自定义工具时强制 enable_search=False，避免
+            # session.update 被服务端拒绝。文档参见 Aliyun client-events
+            # 章节 "工具调用（tools）和联网搜索（enable_search）不兼容"。
+            if self.has_tools():
+                qwen_session["tools"] = self._tools_for_qwen()
+                qwen_session["enable_search"] = False
+            await self.update_session(qwen_session)
+        elif "gpt" in self._model_lower:
+            gpt_session = {
+                "type": "realtime",
+                "model": self.model,
+                "instructions": instructions,
+                "output_modalities": ['audio'] if 'audio' in self._modalities else ['text'],
+                "audio": {
+                    "input": {
+                        "transcription": {"model": "gpt-4o-mini-transcribe"},
+                        "turn_detection": None if is_manual else {
+                            "type": "semantic_vad",
+                            "eagerness": "auto",
+                            "create_response": True,
+                            "interrupt_response": True
+                        },
+                    },
+                    "output": {
+                        "voice": self.voice if self.voice else "marin",
+                        "speed": 1.0
+                    }
+                }
+            }
+            if self.has_tools():
+                gpt_session["tools"] = self._tools_for_openai_realtime()
+                gpt_session["tool_choice"] = "auto"
+            await self.update_session(gpt_session)
+        elif "step" in self._model_lower:
+            step_session = {
+                "instructions": instructions,
+                "modalities": ['text', 'audio'], # Step API只支持这一个模式
+                "voice": self.voice if self.voice else "qingchunshaonv",
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm16",
+                "turn_detection": None if is_manual else {
+                    "type": "server_vad"
+                },
+            }
+            # Always keep the built-in web_search; append custom tools
+            # (StepFun supports both type:"web_search" and type:"function"
+            # in the same array — see official docs).
+            step_tools: List[Dict[str, Any]] = [
+                {
+                    "type": "web_search",
+                    "function": {
+                        "description": "这个web_search用来搜索互联网的信息"
+                    }
+                }
+            ]
+            if self.has_tools():
+                step_tools.extend(self._tools_for_step())
+            step_session["tools"] = step_tools
+            await self.update_session(step_session)
+        elif "free" in self._model_lower:
+            # NOTE: lanlan.tech (China free) backs onto StepFun and
+            # supports the StepFun custom-function protocol — the
+            # server-side tool stripping the user mentioned will be
+            # lifted, after which our tools propagate naturally.
+            # lanlan.app (international free) backs onto Vertex AI
+            # Live; that path is currently TODO (no client→server
+            # tools propagation confirmed). Tools below match the
+            # StepFun shape and become a no-op on lanlan.app until
+            # the proxy supports them.
+            #
+            # MANUAL mode: both proxies receive ``turn_detection: null``
+            # via the StepFun-shape websocket session config. lanlan.tech
+            # (StepFun proxy) honours it natively; lanlan.app (Vertex
+            # Gemini proxy) translates the disabled-VAD intent on the
+            # server side, since the proxy already maps StepFun-shape
+            # client events to Vertex Live (see _has_server_vad gate
+            # at __init__ — lanlan.app+free is already treated as
+            # client-side VAD only).
+            free_session = {
+                "instructions": instructions,
+                "modalities": ['text', 'audio'],
+                "voice": self.voice if self.voice else "qingchunshaonv",
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm16",
+                "turn_detection": None if is_manual else {
+                    "type": "server_vad"
+                },
+            }
+            free_tools: List[Dict[str, Any]] = [
+                {
+                    "type": "web_search",
+                    "function": {
+                        "description": "这个web_search用来搜索互联网的信息"
+                    }
+                }
+            ]
+            if self.has_tools():
+                free_tools.extend(self._tools_for_step())
+            free_session["tools"] = free_tools
+            await self.update_session(free_session)
+        else:
+            raise ValueError(f"Invalid model: {self.model}")
+        self.instructions = instructions
     
     async def _connect_gemini(self, instructions: str, native_audio: bool = True) -> None:
         """Establish connection with Gemini Live API using google-genai SDK."""
@@ -853,6 +865,17 @@ class OmniRealtimeClient:
                     )
                 ),
             }
+
+            # MANUAL turn detection: disable Gemini's automatic activity
+            # detection so end-of-turn is signalled explicitly by the
+            # client (audio_stream_end / activity_end). SERVER_VAD path
+            # leaves automatic_activity_detection at SDK default (enabled).
+            if self.turn_detection_mode == TurnDetectionMode.MANUAL:
+                config["realtime_input_config"] = types.RealtimeInputConfig(
+                    automatic_activity_detection=types.AutomaticActivityDetection(
+                        disabled=True
+                    )
+                )
             
             # 建立 Live 连接 - connect() 返回 async context manager
             logger.info(f"Connecting to Gemini Live API with model: {self.model}")

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1190,7 +1190,7 @@ class OmniRealtimeClient:
         """Send audio data to Gemini Live API."""
         if not self._gemini_session:
             return
-        
+
         try:
             # 发送实时音频输入
             await self._gemini_session.send_realtime_input(
@@ -1201,6 +1201,47 @@ class OmniRealtimeClient:
             logger.error(f"Error sending audio to Gemini: {e}")
             if "closed" in str(e).lower():
                 self._fatal_error_occurred = True
+
+    async def signal_user_activity_end(self) -> None:
+        """Explicitly signal end-of-turn in MANUAL VAD mode.
+
+        With ``TurnDetectionMode.MANUAL`` the server-side VAD is
+        disabled, so the client owns turn boundaries and must emit a
+        provider-specific signal when the user stops speaking. Without
+        this, the model will never see a turn boundary and never
+        respond.
+
+        Per provider (MANUAL only — no-op in SERVER_VAD):
+        - Gemini Live: ``send_realtime_input(activity_end=ActivityEnd())``
+          (Google genai SDK ``LiveClientRealtimeInput`` docs:
+          "If automatic voice detection is disabled, the client must
+          send activity signals." ``audio_stream_end`` is NOT applicable
+          here — it's documented as "only when automatic activity
+          detection is enabled".)
+        - OpenAI / Qwen / GLM / Step / Free: ``input_audio_buffer.commit``
+          followed by ``response.create``.
+        """
+        if self.turn_detection_mode != TurnDetectionMode.MANUAL:
+            return
+        if self._fatal_error_occurred:
+            return
+        if self._is_gemini:
+            if not self._gemini_session:
+                return
+            if types is None:
+                logger.error("signal_user_activity_end: genai.types unavailable")
+                return
+            try:
+                await self._gemini_session.send_realtime_input(
+                    activity_end=types.ActivityEnd()
+                )
+            except Exception as e:
+                logger.error(f"Error sending activity_end to Gemini: {e}")
+                if "closed" in str(e).lower():
+                    self._fatal_error_occurred = True
+            return
+        await self.send_event({"type": "input_audio_buffer.commit"})
+        await self.send_event({"type": "response.create"})
 
     async def _analyze_image_with_vision_model(self, image_b64: str) -> str:
         """Use VISION_MODEL to analyze image and return description."""

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -625,7 +625,11 @@ class OmniRealtimeClient:
 
     async def connect(self, instructions: str, native_audio=True) -> None:
         """Establish WebSocket connection with the Realtime API."""
-        
+        # Validate turn_detection_mode BEFORE any side effect (websockets.connect,
+        # silence-check task, or Gemini SDK init). Applies uniformly to all providers.
+        if self.turn_detection_mode not in (TurnDetectionMode.MANUAL, TurnDetectionMode.SERVER_VAD):
+            raise ValueError(f"Invalid turn detection mode: {self.turn_detection_mode}")
+
         # Gemini uses google-genai SDK, not raw WebSocket
         if self._is_gemini:
             await self._connect_gemini(instructions, native_audio)
@@ -671,9 +675,6 @@ class OmniRealtimeClient:
             logger.info(f"静默超时检测已禁用（{reason}），不会自动关闭会话")
 
         # Set up default session configuration
-        if self.turn_detection_mode not in (TurnDetectionMode.MANUAL, TurnDetectionMode.SERVER_VAD):
-            raise ValueError(f"Invalid turn detection mode: {self.turn_detection_mode}")
-
         is_manual = self.turn_detection_mode == TurnDetectionMode.MANUAL
         # MANUAL mode: every per-provider session.update below sends
         # ``turn_detection: null``, so the provider will NOT emit

--- a/main_server.py
+++ b/main_server.py
@@ -785,6 +785,38 @@ async def _handle_agent_event(event: dict):
                         "[EventBus] %s delivery=silent: skipping LLM channel (frontend HUD still fires)",
                         event_type,
                     )
+
+                # v2 chat+blind passthrough: render verbatim into chat
+                # bubble WITHOUT entering chat-LLM context. Distinct from
+                # mirror_assistant_output (which writes to sync_message_queue
+                # so cross_server may add an AIMessage). Both this branch
+                # and the HUD agent_notification below can fire when
+                # visibility=["chat","hud"] — they're orthogonal sinks.
+                #
+                # Gated on visibility containing "chat" AND ai_behavior=="blind"
+                # because non-blind ai_behavior already enqueues the LLM
+                # callback above and the AI's own response is what the
+                # user should see in the chat bubble.
+                _vis = event.get("visibility") or []
+                if (
+                    "chat" in _vis
+                    and event.get("ai_behavior") == "blind"
+                    and hasattr(mgr, "passthrough_to_chat_bubble")
+                ):
+                    try:
+                        await mgr.passthrough_to_chat_bubble(
+                            text,
+                            request_id=event.get("task_id") or None,
+                            source=event.get("source_kind") or "plugin",
+                        )
+                        logger.info(
+                            "[EventBus] passthrough_to_chat_bubble dispatched (text_len=%d, source=%s)",
+                            len(text), event.get("source_kind") or "plugin",
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "[EventBus] passthrough_to_chat_bubble failed: %s", e,
+                        )
                 ws = getattr(mgr, "websocket", None)
                 if _is_websocket_connected(ws):
                     try:

--- a/main_server.py
+++ b/main_server.py
@@ -825,15 +825,23 @@ async def _handle_agent_event(event: dict):
                         # plugin:*→plugin, else system). Falling back to event
                         # raw + "plugin" default would mislabel non-plugin sources.
                         passthrough_source = source_kind or "plugin"
-                        await mgr.passthrough_to_chat_bubble(
-                            raw_text,
-                            request_id=event.get("task_id") or None,
-                            source=passthrough_source,
+                        # Why: passthrough_to_chat_bubble swallows send_json
+                        # failures and is a no-op when WS is missing/disconnected,
+                        # so absence-of-exception is NOT proof a frame was sent.
+                        # We must gate handle_proactive_complete on the bool
+                        # return — otherwise we emit turn-end without a matching
+                        # turn-start (frontend never opened the assistant
+                        # lifecycle), corrupting proactive rescheduling.
+                        passthrough_dispatched = bool(
+                            await mgr.passthrough_to_chat_bubble(
+                                raw_text,
+                                request_id=event.get("task_id") or None,
+                                source=passthrough_source,
+                            )
                         )
-                        passthrough_dispatched = True
                         logger.info(
-                            "[EventBus] passthrough_to_chat_bubble dispatched (text_len=%d, source=%s)",
-                            len(text), passthrough_source,
+                            "[EventBus] passthrough_to_chat_bubble dispatched=%s (text_len=%d, source=%s)",
+                            passthrough_dispatched, len(text), passthrough_source,
                         )
                     except Exception as e:
                         logger.warning(

--- a/main_server.py
+++ b/main_server.py
@@ -637,7 +637,10 @@ async def _handle_agent_event(event: dict):
             logger.info("[EventBus] %s dropped: no session_manager for lanlan=%s", event_type, lanlan)
             return
         if event_type in ("task_result", "proactive_message"):
-            text = (event.get("text") or "").strip()
+            raw_text = event.get("text") or ""
+            # Why: chat-blind passthrough must preserve verbatim whitespace;
+            # only the empty-check / log / callback paths use the stripped form.
+            text = raw_text.strip()
 
             # v2 push_message: media parts (image/audio/video) ride on the
             # same proactive_message event.  Image parts go straight to the
@@ -822,7 +825,7 @@ async def _handle_agent_event(event: dict):
                         # raw + "plugin" default would mislabel non-plugin sources.
                         passthrough_source = source_kind or "plugin"
                         await mgr.passthrough_to_chat_bubble(
-                            text,
+                            raw_text,
                             request_id=event.get("task_id") or None,
                             source=passthrough_source,
                         )

--- a/main_server.py
+++ b/main_server.py
@@ -728,6 +728,15 @@ async def _handle_agent_event(event: dict):
                 delivery_mode = (event.get("delivery_mode") or "proactive").strip()
                 if delivery_mode not in ("proactive", "passive", "silent"):
                     delivery_mode = "proactive"
+                # Defensive: blind ai_behavior must NEVER reach the LLM channel,
+                # even if delivery_mode arrives as "proactive" / "passive". The
+                # plugin proactive_bridge already maps blind→silent, but this
+                # is an indirect contract — a future direct emitter (or a bug
+                # in another bridge) could violate it. Forcing silent here
+                # locks the (blind ⇒ no LLM enqueue) invariant on the host
+                # side regardless of caller-supplied delivery_mode.
+                if (event.get("ai_behavior") or "").strip() == "blind":
+                    delivery_mode = "silent"
                 # Default source_kind from channel when caller didn't specify one.
                 # Plugin emit sites already pass explicit source_kind/source_name.
                 _channel = event.get("channel") or "unknown"
@@ -804,14 +813,19 @@ async def _handle_agent_event(event: dict):
                     and hasattr(mgr, "passthrough_to_chat_bubble")
                 ):
                     try:
+                        # Reuse the already-resolved source_kind local (computed
+                        # above from channel: computer_use→cu, browser_use→browser,
+                        # plugin:*→plugin, else system). Falling back to event
+                        # raw + "plugin" default would mislabel non-plugin sources.
+                        passthrough_source = source_kind or "plugin"
                         await mgr.passthrough_to_chat_bubble(
                             text,
                             request_id=event.get("task_id") or None,
-                            source=event.get("source_kind") or "plugin",
+                            source=passthrough_source,
                         )
                         logger.info(
                             "[EventBus] passthrough_to_chat_bubble dispatched (text_len=%d, source=%s)",
-                            len(text), event.get("source_kind") or "plugin",
+                            len(text), passthrough_source,
                         )
                     except Exception as e:
                         logger.warning(

--- a/main_server.py
+++ b/main_server.py
@@ -806,10 +806,13 @@ async def _handle_agent_event(event: dict):
                 # because non-blind ai_behavior already enqueues the LLM
                 # callback above and the AI's own response is what the
                 # user should see in the chat bubble.
-                _vis = event.get("visibility") or []
+                _vis_raw = event.get("visibility")
+                _vis_present = isinstance(_vis_raw, list)
+                _vis = _vis_raw if _vis_present else []
+                _ai_behavior = (event.get("ai_behavior") or "").strip()
                 if (
                     "chat" in _vis
-                    and event.get("ai_behavior") == "blind"
+                    and _ai_behavior == "blind"
                     and hasattr(mgr, "passthrough_to_chat_bubble")
                 ):
                     try:
@@ -831,8 +834,21 @@ async def _handle_agent_event(event: dict):
                         logger.warning(
                             "[EventBus] passthrough_to_chat_bubble failed: %s", e,
                         )
+                # v2 visibility contract: HUD agent_notification fires only
+                # when "hud" is in visibility. Why: visibility=["chat"] must
+                # not double-render as both chat bubble AND HUD toast.
+                # Legacy emitters that omit the visibility field entirely
+                # (no v2 plumbing) keep the pre-v2 behavior of firing HUD
+                # by default — checked via _vis_present, not via _vis truthiness,
+                # so an explicit visibility=[] (v2 "no verbatim render") suppresses HUD.
+                _hud_allowed = ("hud" in _vis) if _vis_present else True
                 ws = getattr(mgr, "websocket", None)
-                if _is_websocket_connected(ws):
+                if not _hud_allowed:
+                    logger.info(
+                        "[EventBus] agent_notification suppressed by visibility=%s (no 'hud') for lanlan=%s",
+                        _vis, lanlan,
+                    )
+                elif _is_websocket_connected(ws):
                     try:
                         notif = {
                             "type": "agent_notification",

--- a/main_server.py
+++ b/main_server.py
@@ -818,6 +818,7 @@ async def _handle_agent_event(event: dict):
                     and _ai_behavior == "blind"
                     and hasattr(mgr, "passthrough_to_chat_bubble")
                 ):
+                    passthrough_dispatched = False
                     try:
                         # Reuse the already-resolved source_kind local (computed
                         # above from channel: computer_use→cu, browser_use→browser,
@@ -829,6 +830,7 @@ async def _handle_agent_event(event: dict):
                             request_id=event.get("task_id") or None,
                             source=passthrough_source,
                         )
+                        passthrough_dispatched = True
                         logger.info(
                             "[EventBus] passthrough_to_chat_bubble dispatched (text_len=%d, source=%s)",
                             len(text), passthrough_source,
@@ -837,6 +839,22 @@ async def _handle_agent_event(event: dict):
                         logger.warning(
                             "[EventBus] passthrough_to_chat_bubble failed: %s", e,
                         )
+                    # Why: gemini_response opens an assistant turn lifecycle on
+                    # the frontend (ensureAssistantTurnStarted in app-websocket.js);
+                    # without a matching turn-end event the assistant bubble
+                    # stays "in-progress" and proactive rescheduling / lifecycle
+                    # finalization never fire. handle_proactive_complete is the
+                    # canonical turn-end emitter shared with the direct task_result
+                    # reply path above. The HUD agent_notification branch below
+                    # does NOT open an assistant turn, so single-emit here is
+                    # sufficient even when visibility=["chat","hud"].
+                    if passthrough_dispatched and hasattr(mgr, "handle_proactive_complete"):
+                        try:
+                            await mgr.handle_proactive_complete()
+                        except Exception as e:
+                            logger.warning(
+                                "[EventBus] passthrough turn_end emit failed: %s", e,
+                            )
                 # v2 visibility contract: HUD agent_notification fires only
                 # when "hud" is in visibility. Why: visibility=["chat"] must
                 # not double-render as both chat bubble AND HUD toast.

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -254,6 +254,46 @@ async def test_main_server_proactive_chat_blind_invokes_passthrough(monkeypatch)
 
 
 @pytest.mark.unit
+async def test_main_server_proactive_chat_blind_preserves_verbatim_whitespace(monkeypatch):
+    """Verbatim contract: passthrough must receive the RAW event text with
+    leading/trailing whitespace intact, even though the empty-check / log /
+    callback paths in _handle_agent_event use a stripped local. CodeRabbit
+    PR #1128 r3182231689 — pre-fix the call shared the stripped local and
+    silently swallowed surrounding whitespace/newlines."""
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "  hello world\n\n",
+        "channel": "plugin:foo",
+        "task_id": "task-verbatim",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    call = fake_mgr.passthrough_to_chat_bubble.await_args
+    assert call.args[0] == "  hello world\n\n"
+
+
+@pytest.mark.unit
 async def test_main_server_proactive_chat_respond_does_not_invoke_passthrough(monkeypatch):
     """When ai_behavior != "blind", the passthrough branch must NOT fire
     even if visibility includes "chat" — non-blind ai_behavior already

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -179,6 +179,31 @@ async def test_passthrough_send_failure_is_logged_not_raised():
 
 
 @pytest.mark.unit
+async def test_passthrough_preserves_verbatim_whitespace_in_payload():
+    """Receiver-side verbatim contract: the WS payload's ``text`` field
+    must equal the input EXACTLY — leading/trailing whitespace, embedded
+    newlines, and indentation must all survive.
+
+    Codex PR #1128 r3182348366: prior code did ``clean = text.strip()``
+    and forwarded ``clean``, defeating the caller-side fix in
+    ``main_server`` (commit 0ac9e8881) that took care to pass raw_text.
+    Stripping must happen ONLY in the empty-check, never in the send path.
+    """
+    ws = _FakeWebsocket(connected=True)
+    mgr = _make_mgr(websocket=ws)
+
+    raw = "  hello\n\n"
+    await mgr.passthrough_to_chat_bubble(raw, request_id="r", source="plugin")
+
+    assert ws.send_json.await_count == 1
+    payload = ws.send_json.await_args.args[0]
+    assert payload["text"] == raw, (
+        f"passthrough must NOT strip text — got {payload['text']!r}, "
+        f"expected {raw!r}"
+    )
+
+
+@pytest.mark.unit
 async def test_passthrough_synthesizes_turn_id_when_missing():
     """When neither turn_id nor request_id is provided, the method must
     synthesize a turn_id so the frontend can group chunks into one bubble.

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -774,12 +774,67 @@ async def test_hud_only_blind_does_not_emit_turn_end(monkeypatch):
     fake_mgr.handle_proactive_complete.assert_not_called()
 
 
+def _blind_chat_event(task_id: str) -> dict:
+    return {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "blind chat line",
+        "channel": "plugin:foo",
+        "task_id": task_id,
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+
 @pytest.mark.unit
-async def test_chat_blind_passthrough_failure_skips_turn_end(monkeypatch):
-    """If ``passthrough_to_chat_bubble`` raises, no gemini_response was
-    sent — so the frontend never opened an assistant turn lifecycle, and
-    we must NOT emit a stray turn-end. Otherwise the frontend would
-    receive a turn-end without a corresponding turn-start.
+async def test_chat_blind_passthrough_noop_skips_turn_end(monkeypatch):
+    """Real failure semantics: ``passthrough_to_chat_bubble`` SWALLOWS
+    send_json failures and is a no-op when the WS is missing/disconnected
+    (see ``test_passthrough_send_failure_is_logged_not_raised`` and
+    ``test_passthrough_handles_disconnected_websocket_gracefully`` above).
+    In every such case the helper returns ``False`` — no
+    ``gemini_response`` was actually sent — so the frontend never opened
+    an assistant turn lifecycle, and we must NOT emit a stray turn-end.
+
+    The previous version of this test mocked the helper to raise, which
+    missed the most-likely-leaked path: helper returns success-shape
+    (``None`` under the old contract, ``False`` under the new one) but
+    never sent a frame, while ``main_server`` still emitted turn-end
+    based purely on absence-of-exception.
+    """
+    import main_server
+
+    fake_mgr = MagicMock()
+    # Simulate a swallowed no-op (e.g. WS disconnected mid-flight): the
+    # helper returns normally but reports False to indicate nothing was
+    # sent.
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock(return_value=False)
+    fake_mgr.handle_proactive_complete = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    await main_server._handle_agent_event(_blind_chat_event("task-blind-noop"))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    fake_mgr.handle_proactive_complete.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_chat_blind_passthrough_unexpected_raise_skips_turn_end(monkeypatch):
+    """Defensive belt-and-suspenders: the production helper is supposed
+    to swallow all WS failures internally (returns False, never raises),
+    but ``main_server`` still wraps the call in try/except. If a future
+    refactor accidentally lets an exception escape, we must still NOT
+    emit a stray turn-end.
     """
     import main_server
 
@@ -794,21 +849,37 @@ async def test_chat_blind_passthrough_failure_skips_turn_end(monkeypatch):
     monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
     monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
 
-    event = {
-        "event_type": "proactive_message",
-        "lanlan_name": "Test",
-        "text": "blind chat line",
-        "channel": "plugin:foo",
-        "task_id": "task-blind-fail",
-        "delivery_mode": "silent",
-        "ai_behavior": "blind",
-        "visibility": ["chat"],
-        "source_kind": "plugin",
-        "source_name": "foo",
-        "media_parts": [],
-    }
-
-    await main_server._handle_agent_event(event)
+    await main_server._handle_agent_event(_blind_chat_event("task-blind-raise"))
 
     fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
     fake_mgr.handle_proactive_complete.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_chat_blind_passthrough_real_helper_swallowed_send_skips_turn_end(monkeypatch):
+    """Lower-level integration: drive the REAL ``passthrough_to_chat_bubble``
+    against a websocket whose ``send_json`` raises. The helper must
+    swallow the exception, return False, and ``main_server`` must NOT
+    call ``handle_proactive_complete``.
+
+    This locks the end-to-end contract that motivated the bool return:
+    "send_json blew up, was swallowed; no turn was ever opened on the
+    frontend; do not close a phantom turn."
+    """
+    import main_server
+
+    real_mgr = _make_mgr(websocket=_FakeWebsocket(connected=True))
+    # Make send_json raise so the real helper exercises the swallow path.
+    real_mgr.websocket.send_json = AsyncMock(side_effect=RuntimeError("ws boom"))
+    real_mgr.handle_proactive_complete = AsyncMock()
+    real_mgr.enqueue_agent_callback = MagicMock()
+    real_mgr.trigger_agent_callbacks = AsyncMock()
+    real_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: real_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    await main_server._handle_agent_event(_blind_chat_event("task-blind-swallowed"))
+
+    assert real_mgr.websocket.send_json.await_count == 1
+    real_mgr.handle_proactive_complete.assert_not_called()

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -455,3 +455,156 @@ async def test_main_server_proactive_hud_only_blind_does_not_invoke_passthrough(
 
     fake_mgr.passthrough_to_chat_bubble.assert_not_called()
     fake_mgr.enqueue_agent_callback.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# HUD visibility-gating contract (codex P2 — PR #1128)
+# ──────────────────────────────────────────────────────────────────────
+#
+# These tests verify the v2 visibility contract for the HUD
+# ``agent_notification`` send path. Why they need their own block: prior
+# tests forced the websocket to disconnected so HUD never fired anyway —
+# they couldn't tell whether HUD was suppressed by visibility or by the
+# socket being down. Here we attach a real (mocked) websocket and assert
+# on send_json calls.
+
+
+def _hud_event(visibility, ai_behavior="blind", text="hud-or-chat line"):
+    """Build a proactive_message event with the requested visibility/behavior."""
+    return {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": text,
+        "channel": "plugin:foo",
+        "task_id": "task-vis",
+        "delivery_mode": "silent",
+        "ai_behavior": ai_behavior,
+        "visibility": visibility,
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+
+def _hud_fake_mgr():
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = MagicMock()
+    fake_mgr.websocket.send_json = AsyncMock()
+    fake_mgr._pending_agent_callback_task = None
+    return fake_mgr
+
+
+def _patch_main_server(monkeypatch, fake_mgr):
+    import main_server  # noqa: F401  (imported by callers)
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: True)
+
+
+def _hud_send_count(fake_mgr) -> int:
+    """Return count of agent_notification frames sent on the websocket."""
+    return sum(
+        1
+        for c in fake_mgr.websocket.send_json.await_args_list
+        if c.args and isinstance(c.args[0], dict) and c.args[0].get("type") == "agent_notification"
+    )
+
+
+@pytest.mark.unit
+async def test_visibility_chat_blind_chat_fires_hud_does_not(monkeypatch):
+    """visibility=["chat"] + blind → chat passthrough fires, HUD does NOT.
+
+    This is the codex P2 regression: prior code fired HUD unconditionally,
+    double-rendering chat-only events as both bubble and toast.
+    """
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(_hud_event(["chat"]))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    assert _hud_send_count(fake_mgr) == 0
+
+
+@pytest.mark.unit
+async def test_visibility_hud_blind_hud_fires_chat_does_not(monkeypatch):
+    """visibility=["hud"] + blind → HUD toast fires, chat passthrough does NOT."""
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(_hud_event(["hud"]))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_not_called()
+    assert _hud_send_count(fake_mgr) == 1
+
+
+@pytest.mark.unit
+async def test_visibility_chat_and_hud_blind_both_fire(monkeypatch):
+    """visibility=["chat","hud"] + blind → BOTH chat passthrough and HUD fire."""
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(_hud_event(["chat", "hud"]))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    assert _hud_send_count(fake_mgr) == 1
+
+
+@pytest.mark.unit
+async def test_visibility_empty_explicit_blind_suppresses_hud(monkeypatch):
+    """visibility=[] (explicit v2 empty) + blind → neither chat nor HUD fires.
+
+    Per the v2 schema (`plugin/sdk/shared/core/push_message_schema.py`)
+    an explicit empty list means "no verbatim user-facing render".
+    """
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(_hud_event([]))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_not_called()
+    assert _hud_send_count(fake_mgr) == 0
+
+
+@pytest.mark.unit
+async def test_visibility_absent_field_legacy_fires_hud(monkeypatch):
+    """visibility field ABSENT (legacy emitter, no v2 plumbing) → HUD fires.
+
+    Why: pre-v2 emitters that never learned about the visibility axis must
+    keep their original "fire HUD by default" behavior. We distinguish
+    "field absent" from "field == []" so v2 callers can opt out via [].
+    """
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    legacy_event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "legacy notice",
+        "channel": "plugin:foo",
+        "task_id": "task-legacy",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        # NB: no "visibility" key at all
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(legacy_event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_not_called()
+    assert _hud_send_count(fake_mgr) == 1

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -96,11 +96,14 @@ async def test_passthrough_writes_to_websocket_with_passthrough_metadata():
     ws = _FakeWebsocket(connected=True)
     mgr = _make_mgr(websocket=ws)
 
-    await mgr.passthrough_to_chat_bubble(
-        "hello world",
-        request_id="req-1",
-        turn_id="turn-1",
-        source="plugin",
+    assert (
+        await mgr.passthrough_to_chat_bubble(
+            "hello world",
+            request_id="req-1",
+            turn_id="turn-1",
+            source="plugin",
+        )
+        is True
     )
 
     assert ws.send_json.await_count == 1
@@ -139,9 +142,14 @@ async def test_passthrough_handles_empty_text_no_op():
     ws = _FakeWebsocket(connected=True)
     mgr = _make_mgr(websocket=ws)
 
-    await mgr.passthrough_to_chat_bubble("", request_id="r")
-    await mgr.passthrough_to_chat_bubble("   \n\t  ", request_id="r")
-    await mgr.passthrough_to_chat_bubble(None, request_id="r")  # type: ignore[arg-type]
+    assert await mgr.passthrough_to_chat_bubble("", request_id="r") is False
+    assert (
+        await mgr.passthrough_to_chat_bubble("   \n\t  ", request_id="r") is False
+    )
+    assert (
+        await mgr.passthrough_to_chat_bubble(None, request_id="r")  # type: ignore[arg-type]
+        is False
+    )
 
     ws.send_json.assert_not_called()
 
@@ -153,7 +161,9 @@ async def test_passthrough_handles_disconnected_websocket_gracefully():
     mgr = _make_mgr(websocket=ws)
 
     # Should not raise; should not call send_json (gate guards it).
-    await mgr.passthrough_to_chat_bubble("hello", request_id="r")
+    assert (
+        await mgr.passthrough_to_chat_bubble("hello", request_id="r") is False
+    )
     ws.send_json.assert_not_called()
 
 
@@ -162,7 +172,9 @@ async def test_passthrough_handles_missing_websocket():
     """websocket=None → silently no-op, no AttributeError."""
     mgr = _make_mgr(websocket=None)
     # Should not raise.
-    await mgr.passthrough_to_chat_bubble("hello", request_id="r")
+    assert (
+        await mgr.passthrough_to_chat_bubble("hello", request_id="r") is False
+    )
 
 
 @pytest.mark.unit
@@ -173,7 +185,9 @@ async def test_passthrough_send_failure_is_logged_not_raised():
     mgr = _make_mgr(websocket=ws)
 
     # Should not propagate the RuntimeError.
-    await mgr.passthrough_to_chat_bubble("hello", request_id="r")
+    assert (
+        await mgr.passthrough_to_chat_bubble("hello", request_id="r") is False
+    )
     # send_json was attempted exactly once.
     assert ws.send_json.await_count == 1
 
@@ -211,7 +225,7 @@ async def test_passthrough_synthesizes_turn_id_when_missing():
     ws = _FakeWebsocket(connected=True)
     mgr = _make_mgr(websocket=ws)
 
-    await mgr.passthrough_to_chat_bubble("hi", source="plugin")
+    assert await mgr.passthrough_to_chat_bubble("hi", source="plugin") is True
 
     payload = ws.send_json.await_args.args[0]
     assert isinstance(payload["turn_id"], str)

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -294,6 +294,134 @@ async def test_main_server_proactive_chat_respond_does_not_invoke_passthrough(mo
 
 
 @pytest.mark.unit
+async def test_blind_with_proactive_delivery_mode_does_not_enqueue_callback(monkeypatch):
+    """Defensive contract: ``ai_behavior="blind"`` MUST never reach the
+    LLM channel, even if the upstream emitter sets ``delivery_mode`` to
+    "proactive" or "passive". The plugin ``proactive_bridge`` already
+    maps blind→silent, but that's an indirect translation contract — a
+    future direct emitter (or another bridge) could violate it. The host
+    side must enforce the invariant locally.
+
+    This test deliberately constructs a malformed-from-the-bridge event
+    (blind + proactive) that today the bridge wouldn't produce, to lock
+    in the host-side defense.
+    """
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "blind text",
+        "channel": "plugin:foo",
+        "task_id": "task-blind-proactive",
+        # Bridge contract says blind→silent; we deliberately violate it
+        # here to exercise the defensive host-side check.
+        "delivery_mode": "proactive",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    # Host-side defense must downgrade delivery_mode to silent and skip
+    # the LLM enqueue path even though the event arrived as "proactive".
+    fake_mgr.enqueue_agent_callback.assert_not_called()
+    fake_mgr.trigger_agent_callbacks.assert_not_called()
+    # Chat passthrough still fires (visibility includes "chat", behavior is blind).
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_blind_with_passive_delivery_mode_does_not_enqueue_callback(monkeypatch):
+    """Symmetric to the proactive case: blind + passive must also be
+    forced to silent on the host side."""
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "blind passive text",
+        "channel": "plugin:foo",
+        "task_id": "task-blind-passive",
+        "delivery_mode": "passive",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.enqueue_agent_callback.assert_not_called()
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_passthrough_uses_resolved_source_kind_from_channel(monkeypatch):
+    """When the event omits ``source_kind`` but the channel implies one
+    (e.g. ``computer_use`` → ``cu``), the passthrough call must use the
+    locally-resolved ``source_kind`` rather than the raw event field
+    with a "plugin" default — otherwise non-plugin sources get
+    mislabeled as ``plugin`` in the chat bubble metadata.
+    """
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "computer-use blind line",
+        # No source_kind on event — must be derived from channel.
+        "channel": "computer_use",
+        "task_id": "task-cu-1",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    call = fake_mgr.passthrough_to_chat_bubble.await_args
+    # Channel "computer_use" must resolve to source_kind="cu", NOT "plugin".
+    assert call.kwargs.get("source") == "cu"
+
+
+@pytest.mark.unit
 async def test_main_server_proactive_hud_only_blind_does_not_invoke_passthrough(monkeypatch):
     """visibility=["hud"] + ai_behavior="blind" → HUD-only toast path,
     passthrough must NOT fire (no "chat" in visibility)."""

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -673,3 +673,142 @@ async def test_visibility_absent_field_legacy_fires_hud(monkeypatch):
 
     fake_mgr.passthrough_to_chat_bubble.assert_not_called()
     assert _hud_send_count(fake_mgr) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Turn-end emission after chat-blind passthrough (codex P2 — PR #1128)
+# ──────────────────────────────────────────────────────────────────────
+#
+# Background: ``passthrough_to_chat_bubble`` sends a ``gemini_response``
+# frame, which on the frontend opens an assistant turn lifecycle via
+# ``ensureAssistantTurnStarted``. Without a matching ``turn end`` /
+# ``turn end agent_callback`` system event, the assistant bubble stays
+# "in-progress" and proactive rescheduling never fires. The canonical
+# helper that emits this turn-end is
+# :py:meth:`LLMSessionManager.handle_proactive_complete`; the direct
+# task_result reply path at main_server.py:714 already calls it. The
+# chat-blind passthrough branch must do the same.
+#
+# The HUD-only branch (agent_notification) does NOT open an assistant
+# turn lifecycle on the frontend, so it does NOT need turn-end. This
+# means the dedup strategy is "emit once iff chat passthrough fired",
+# not "per-sink emit with explicit dedup".
+
+
+@pytest.mark.unit
+async def test_chat_blind_passthrough_emits_turn_end_via_proactive_complete(monkeypatch):
+    """visibility=["chat"] + blind → handle_proactive_complete called
+    exactly once after passthrough_to_chat_bubble returns. This is the
+    codex P2 regression: prior code dispatched the gemini_response bubble
+    but never closed the assistant turn lifecycle on the frontend.
+    """
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.handle_proactive_complete = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "blind chat line",
+        "channel": "plugin:foo",
+        "task_id": "task-blind-chat",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    fake_mgr.handle_proactive_complete.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_chat_and_hud_blind_emits_turn_end_exactly_once(monkeypatch):
+    """visibility=["chat","hud"] + blind → BOTH chat passthrough AND HUD
+    fire (per the existing visibility contract), but turn-end must be
+    emitted EXACTLY ONCE. The HUD branch doesn't open an assistant turn,
+    so a single emit gated on the chat passthrough is correct.
+    """
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    fake_mgr.handle_proactive_complete = AsyncMock()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(_hud_event(["chat", "hud"]))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    assert _hud_send_count(fake_mgr) == 1
+    fake_mgr.handle_proactive_complete.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_hud_only_blind_does_not_emit_turn_end(monkeypatch):
+    """visibility=["hud"] + blind → HUD toast fires alone. agent_notification
+    on the frontend is a toast that doesn't open an assistant turn lifecycle,
+    so turn-end must NOT be emitted (no lifecycle to close).
+    """
+    import main_server
+
+    fake_mgr = _hud_fake_mgr()
+    fake_mgr.handle_proactive_complete = AsyncMock()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(_hud_event(["hud"]))
+
+    fake_mgr.passthrough_to_chat_bubble.assert_not_called()
+    assert _hud_send_count(fake_mgr) == 1
+    fake_mgr.handle_proactive_complete.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_chat_blind_passthrough_failure_skips_turn_end(monkeypatch):
+    """If ``passthrough_to_chat_bubble`` raises, no gemini_response was
+    sent — so the frontend never opened an assistant turn lifecycle, and
+    we must NOT emit a stray turn-end. Otherwise the frontend would
+    receive a turn-end without a corresponding turn-start.
+    """
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock(side_effect=RuntimeError("ws boom"))
+    fake_mgr.handle_proactive_complete = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "blind chat line",
+        "channel": "plugin:foo",
+        "task_id": "task-blind-fail",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    fake_mgr.handle_proactive_complete.assert_not_called()

--- a/tests/unit/test_passthrough_to_chat_bubble.py
+++ b/tests/unit/test_passthrough_to_chat_bubble.py
@@ -1,0 +1,329 @@
+"""Tests for ``LLMSessionManager.passthrough_to_chat_bubble`` and the
+``main_server`` proactive_message → passthrough wiring.
+
+Background — see PR-1110 (squashed ``c49d6fe89``) and PR-4 brief:
+
+The plugin v2 schema (``plugin/sdk/shared/core/push_message_schema.py``)
+defines ``visibility=["chat"]`` + ``ai_behavior="blind"`` to mean
+"render verbatim into the chat bubble, but never feed to the LLM."
+PR-4 implements that path — distinct from PR-1110's mirror channel,
+which DOES enter chat history as an ``AIMessage``.
+
+Two distinguishing assertions matter:
+
+* mirror writes to ``sync_message_queue`` (cross_server picks it up
+  and may inject into chat history).
+* passthrough does NOT — frontend sees the bubble, LLM never does.
+
+We construct the manager via ``__new__`` (skipping the heavy real
+``__init__`` that needs a config_manager) and stub only the attributes
+``passthrough_to_chat_bubble`` reads: ``websocket``, ``lanlan_name``,
+``sync_message_queue``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from main_logic.core import LLMSessionManager  # noqa: E402
+
+
+class _ClientState:
+    """Stand-in for FastAPI's ``WebSocketState`` enum.
+
+    The production code in ``passthrough_to_chat_bubble`` does:
+        ws.client_state == ws.client_state.CONNECTED
+    so the actual *value* of ``client_state`` must expose an attribute
+    ``CONNECTED`` that compares equal to itself when ``client_state`` is
+    in the connected state, and not equal when disconnected.
+    """
+
+    def __init__(self, name: str):
+        self._name = name
+
+    # Class-level ``CONNECTED`` doesn't work for the production check
+    # because the check reads it off the *instance*, not the class.
+    @property
+    def CONNECTED(self):
+        return _ClientState._connected_singleton
+
+    def __eq__(self, other):
+        return isinstance(other, _ClientState) and other._name == self._name
+
+    def __hash__(self):
+        return hash(self._name)
+
+
+_ClientState._connected_singleton = _ClientState("CONNECTED")
+_DISCONNECTED_STATE = _ClientState("DISCONNECTED")
+
+
+class _FakeWebsocket:
+    """Minimal websocket stub that mimics FastAPI's WebSocket.client_state."""
+
+    def __init__(self, connected: bool = True):
+        self.client_state = _ClientState._connected_singleton if connected else _DISCONNECTED_STATE
+        self.send_json = AsyncMock()
+
+
+def _make_mgr(websocket=None, sync_queue=None) -> LLMSessionManager:
+    """Build a minimal LLMSessionManager that exposes only the attributes
+    ``passthrough_to_chat_bubble`` reads."""
+    mgr = LLMSessionManager.__new__(LLMSessionManager)
+    mgr.lanlan_name = "Test"
+    mgr.websocket = websocket
+    # passthrough_to_chat_bubble must NOT touch sync_message_queue;
+    # we wire one up so we can later assert it stays untouched.
+    mgr.sync_message_queue = sync_queue if sync_queue is not None else MagicMock()
+    return mgr
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Unit: passthrough_to_chat_bubble
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_passthrough_writes_to_websocket_with_passthrough_metadata():
+    """Connected websocket + non-empty text → send_json invoked once with
+    type=gemini_response, metadata.passthrough=True, source preserved."""
+    ws = _FakeWebsocket(connected=True)
+    mgr = _make_mgr(websocket=ws)
+
+    await mgr.passthrough_to_chat_bubble(
+        "hello world",
+        request_id="req-1",
+        turn_id="turn-1",
+        source="plugin",
+    )
+
+    assert ws.send_json.await_count == 1
+    payload = ws.send_json.await_args.args[0]
+    assert payload["type"] == "gemini_response"
+    assert payload["text"] == "hello world"
+    assert payload["isNewMessage"] is True
+    assert payload["turn_id"] == "turn-1"
+    assert payload["request_id"] == "req-1"
+    assert payload["metadata"] == {"source": "plugin", "passthrough": True}
+
+
+@pytest.mark.unit
+async def test_passthrough_skips_sync_message_queue():
+    """KEY contract: passthrough does NOT enqueue onto sync_message_queue.
+
+    This is what distinguishes passthrough from
+    ``mirror_assistant_output`` — the latter calls
+    ``send_lanlan_response`` which writes to ``sync_message_queue``,
+    causing cross_server to add an ``AIMessage`` to chat history.
+    Passthrough must keep the LLM blind.
+    """
+    ws = _FakeWebsocket(connected=True)
+    sync_queue = MagicMock()
+    mgr = _make_mgr(websocket=ws, sync_queue=sync_queue)
+
+    await mgr.passthrough_to_chat_bubble("hello", request_id="r", source="plugin")
+
+    sync_queue.put.assert_not_called()
+    sync_queue.put_nowait.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_passthrough_handles_empty_text_no_op():
+    """Empty / whitespace-only text → no websocket call, no exception."""
+    ws = _FakeWebsocket(connected=True)
+    mgr = _make_mgr(websocket=ws)
+
+    await mgr.passthrough_to_chat_bubble("", request_id="r")
+    await mgr.passthrough_to_chat_bubble("   \n\t  ", request_id="r")
+    await mgr.passthrough_to_chat_bubble(None, request_id="r")  # type: ignore[arg-type]
+
+    ws.send_json.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_passthrough_handles_disconnected_websocket_gracefully():
+    """Disconnected websocket → send_json NOT called, no exception raised."""
+    ws = _FakeWebsocket(connected=False)
+    mgr = _make_mgr(websocket=ws)
+
+    # Should not raise; should not call send_json (gate guards it).
+    await mgr.passthrough_to_chat_bubble("hello", request_id="r")
+    ws.send_json.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_passthrough_handles_missing_websocket():
+    """websocket=None → silently no-op, no AttributeError."""
+    mgr = _make_mgr(websocket=None)
+    # Should not raise.
+    await mgr.passthrough_to_chat_bubble("hello", request_id="r")
+
+
+@pytest.mark.unit
+async def test_passthrough_send_failure_is_logged_not_raised():
+    """If send_json raises (transient WS error), passthrough logs + swallows."""
+    ws = _FakeWebsocket(connected=True)
+    ws.send_json = AsyncMock(side_effect=RuntimeError("ws boom"))
+    mgr = _make_mgr(websocket=ws)
+
+    # Should not propagate the RuntimeError.
+    await mgr.passthrough_to_chat_bubble("hello", request_id="r")
+    # send_json was attempted exactly once.
+    assert ws.send_json.await_count == 1
+
+
+@pytest.mark.unit
+async def test_passthrough_synthesizes_turn_id_when_missing():
+    """When neither turn_id nor request_id is provided, the method must
+    synthesize a turn_id so the frontend can group chunks into one bubble.
+    """
+    ws = _FakeWebsocket(connected=True)
+    mgr = _make_mgr(websocket=ws)
+
+    await mgr.passthrough_to_chat_bubble("hi", source="plugin")
+
+    payload = ws.send_json.await_args.args[0]
+    assert isinstance(payload["turn_id"], str)
+    assert len(payload["turn_id"]) > 0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Integration-ish: main_server proactive_message → passthrough wiring
+# ──────────────────────────────────────────────────────────────────────
+#
+# Verifies that the visibility=["chat"] + ai_behavior="blind" branch in
+# ``_handle_agent_event`` actually invokes ``passthrough_to_chat_bubble``
+# on the resolved manager. We don't run main_server.py wholesale —
+# we extract the function under test and call it with a stubbed event +
+# a stubbed manager.
+
+
+@pytest.mark.unit
+async def test_main_server_proactive_chat_blind_invokes_passthrough(monkeypatch):
+    """main_server's _handle_agent_event with visibility=["chat"] +
+    ai_behavior="blind" must call mgr.passthrough_to_chat_bubble exactly
+    once with the event's text, source_kind, and task_id."""
+    # Late import: main_server is heavy; only import when needed.
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None  # disable HUD send for cleanliness
+    fake_mgr._pending_agent_callback_task = None
+
+    # Force the manager resolution helpers in main_server to find our fake.
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    # Also bypass ``_is_websocket_connected`` so HUD path is skipped.
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "verbatim line",
+        "summary": "verbatim line",
+        "detail": "verbatim line",
+        "channel": "plugin:foo",
+        "task_id": "task-42",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    call = fake_mgr.passthrough_to_chat_bubble.await_args
+    # text positional arg
+    assert call.args[0] == "verbatim line"
+    # request_id from task_id, source from source_kind
+    assert call.kwargs.get("request_id") == "task-42"
+    assert call.kwargs.get("source") == "plugin"
+    # silent + blind → LLM channel NOT engaged
+    fake_mgr.enqueue_agent_callback.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_main_server_proactive_chat_respond_does_not_invoke_passthrough(monkeypatch):
+    """When ai_behavior != "blind", the passthrough branch must NOT fire
+    even if visibility includes "chat" — non-blind ai_behavior already
+    enqueues the LLM callback, and the AI's own response is what fills
+    the chat bubble.
+    """
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "tell the user something",
+        "channel": "plugin:foo",
+        "task_id": "task-43",
+        "delivery_mode": "proactive",
+        "ai_behavior": "respond",
+        "visibility": ["chat"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_not_called()
+    # respond → LLM callback enqueued
+    fake_mgr.enqueue_agent_callback.assert_called_once()
+
+
+@pytest.mark.unit
+async def test_main_server_proactive_hud_only_blind_does_not_invoke_passthrough(monkeypatch):
+    """visibility=["hud"] + ai_behavior="blind" → HUD-only toast path,
+    passthrough must NOT fire (no "chat" in visibility)."""
+    import main_server
+
+    fake_mgr = MagicMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock()
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = None
+    fake_mgr._pending_agent_callback_task = None
+
+    monkeypatch.setattr("main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("main_server._is_websocket_connected", lambda ws: False)
+
+    event = {
+        "event_type": "proactive_message",
+        "lanlan_name": "Test",
+        "text": "hud notice",
+        "channel": "plugin:foo",
+        "task_id": "task-44",
+        "delivery_mode": "silent",
+        "ai_behavior": "blind",
+        "visibility": ["hud"],
+        "source_kind": "plugin",
+        "source_name": "foo",
+        "media_parts": [],
+    }
+
+    await main_server._handle_agent_event(event)
+
+    fake_mgr.passthrough_to_chat_bubble.assert_not_called()
+    fake_mgr.enqueue_agent_callback.assert_not_called()

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -1,7 +1,7 @@
 import pytest
 import json
 import base64
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 # Adjust path to import project modules
 import sys
@@ -183,3 +183,199 @@ async def test_receive_text_delta(realtime_client):
     
     # Verify response.done was processed
     assert response_done_mock.called
+
+
+# ──────────────────────────────────────────────────────────────────────
+# VAD MANUAL turn detection tests
+# ──────────────────────────────────────────────────────────────────────
+#
+# These tests exercise the MANUAL branch added in the
+# OmniRealtimeClient.connect() per-provider chain. For each provider we:
+#   1. Construct the client with turn_detection_mode=MANUAL
+#   2. Patch websockets.connect (websocket-based providers) or the
+#      genai live SDK (Gemini)
+#   3. Call connect() and capture the session config that was sent
+#   4. Assert the manual-mode payload structure (turn_detection=null,
+#      or for Gemini: realtime_input_config.automatic_activity_detection
+#      .disabled=True)
+#
+# All tests bypass real API keys / models — they construct a stub client
+# directly and only exercise connect() once the constructor has run with
+# valid placeholder values.
+
+
+def _make_manual_client(model: str, base_url: str = "wss://example.test/realtime", api_type: str = ""):
+    """Construct a minimal OmniRealtimeClient with TurnDetectionMode.MANUAL.
+
+    Skips dependency on real config — passes a valid model/base_url so the
+    provider selector inside connect() picks the right branch.
+    """
+    return OmniRealtimeClient(
+        base_url=base_url,
+        api_key="sk-test",
+        model=model,
+        turn_detection_mode=TurnDetectionMode.MANUAL,
+        api_type=api_type,
+    )
+
+
+async def _run_connect_and_capture_session(client):
+    """Patch websockets.connect, run client.connect(), return the session
+    dict from the captured session.update event.
+    """
+    captured: dict = {}
+
+    async def fake_send(payload):
+        try:
+            event = json.loads(payload)
+        except Exception:
+            return
+        if event.get("type") == "session.update":
+            captured["session"] = event.get("session")
+
+    mock_ws = AsyncMock()
+    mock_ws.send = AsyncMock(side_effect=fake_send)
+
+    with patch("websockets.connect", new_callable=AsyncMock) as mock_connect:
+        mock_connect.return_value = mock_ws
+        await client.connect(instructions="You are helpful.", native_audio=True)
+
+    return captured.get("session")
+
+
+@pytest.mark.unit
+async def test_connect_qwen_manual_vad_sends_null_turn_detection():
+    """Qwen MANUAL: turn_detection=None, transcription model preserved."""
+    client = _make_manual_client(model="qwen-omni-turbo-realtime", api_type="qwen")
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None, "session.update event not captured"
+    assert session.get("turn_detection") is None
+    # Qwen's input_audio_transcription must remain pinned to gummy-realtime-v1
+    assert session.get("input_audio_transcription") == {"model": "gummy-realtime-v1"}
+
+
+@pytest.mark.unit
+async def test_connect_openai_manual_vad_sends_null_audio_input_turn_detection():
+    """OpenAI MANUAL: audio.input.turn_detection=None, transcription preserved."""
+    client = _make_manual_client(
+        model="gpt-realtime",
+        base_url="wss://api.openai.com/v1/realtime",
+        api_type="openai",
+    )
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None, "session.update event not captured"
+    audio_input = session.get("audio", {}).get("input", {})
+    assert audio_input.get("turn_detection") is None
+    assert audio_input.get("transcription") == {"model": "gpt-4o-mini-transcribe"}
+
+
+@pytest.mark.unit
+async def test_connect_glm_manual_vad_sends_null_turn_detection():
+    """GLM MANUAL: turn_detection=None (best-effort; may be rejected server-side)."""
+    client = _make_manual_client(model="glm-realtime", api_type="glm")
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None
+    assert session.get("turn_detection") is None
+
+
+@pytest.mark.unit
+async def test_connect_step_manual_vad_sends_null_turn_detection():
+    """Step MANUAL: turn_detection=None."""
+    client = _make_manual_client(model="step-1o-audio", api_type="step")
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None
+    assert session.get("turn_detection") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "proxy_url",
+    [
+        "wss://lanlan.tech/realtime",  # StepFun proxy
+        "wss://lanlan.app/realtime",   # Vertex Gemini proxy
+    ],
+)
+async def test_connect_free_proxy_routes_manual_vad_per_backend(proxy_url):
+    """Free MANUAL: both StepFun (lanlan.tech) and Vertex Gemini (lanlan.app)
+    proxies receive turn_detection=None via the StepFun-shape websocket
+    session config. Server-side translation happens at the proxy.
+    """
+    client = _make_manual_client(model="free-model", base_url=proxy_url, api_type="free")
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None
+    assert session.get("turn_detection") is None
+
+
+@pytest.mark.unit
+async def test_connect_gemini_manual_vad_disables_automatic_activity_detection():
+    """Gemini MANUAL: realtime_input_config.automatic_activity_detection.disabled=True
+    is added to the LiveConnectConfig passed into client.aio.live.connect(...).
+    """
+    pytest.importorskip("google.genai")
+
+    client = _make_manual_client(
+        model="gemini-2.0-flash-exp",
+        base_url="https://generativelanguage.googleapis.com",
+        api_type="gemini",
+    )
+
+    # Patch the genai.Client constructor so we capture the LiveConnectConfig
+    # passed to client.aio.live.connect(). The connect() method returns an
+    # async context manager; we mock both __aenter__ and __aexit__.
+    captured: dict = {}
+
+    fake_session = AsyncMock()
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    def fake_live_connect(*, model, config):
+        captured["model"] = model
+        captured["config"] = config
+        return fake_ctx
+
+    fake_genai_client = MagicMock()
+    fake_genai_client.aio.live.connect = MagicMock(side_effect=fake_live_connect)
+
+    with patch("main_logic.omni_realtime_client.genai") as mock_genai_module:
+        mock_genai_module.Client = MagicMock(return_value=fake_genai_client)
+        await client.connect(instructions="You are helpful.", native_audio=True)
+
+    config = captured.get("config")
+    assert config is not None, "Gemini live.connect was not called"
+    rt_input = config.get("realtime_input_config")
+    assert rt_input is not None, (
+        "realtime_input_config missing — MANUAL mode must disable automatic VAD"
+    )
+    aad = getattr(rt_input, "automatic_activity_detection", None)
+    assert aad is not None
+    assert getattr(aad, "disabled", False) is True
+
+
+# ──────────────────────────────────────────────────────────────────────
+# VAD SERVER_VAD regression tests — ensure refactor preserved old behaviour
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_connect_qwen_server_vad_preserves_payload():
+    """Sanity check: SERVER_VAD path still sends the structured turn_detection dict."""
+    client = OmniRealtimeClient(
+        base_url="wss://example.test/realtime",
+        api_key="sk-test",
+        model="qwen-omni-turbo-realtime",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="qwen",
+    )
+    session = await _run_connect_and_capture_session(client)
+
+    assert session is not None
+    td = session.get("turn_detection")
+    assert isinstance(td, dict)
+    assert td.get("type") in ("server_vad", "semantic_vad")
+    assert "threshold" in td

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -487,7 +487,8 @@ async def test_signal_user_activity_end_websocket_manual_sends_commit_and_respon
     async def fake_send(payload):
         try:
             sent.append(json.loads(payload))
-        except Exception:
+        except json.JSONDecodeError:
+            # Why: payload may be bytes audio frames, not JSON — ignore non-JSON in this collector.
             pass
 
     mock_ws = AsyncMock()

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -365,6 +365,169 @@ async def test_connect_gemini_manual_vad_disables_automatic_activity_detection()
 
 
 # ──────────────────────────────────────────────────────────────────────
+# signal_user_activity_end() — MANUAL turn-end emission
+# ──────────────────────────────────────────────────────────────────────
+#
+# Codex PR #1128 r3182348361: with automatic_activity_detection.disabled=
+# True, end-of-turn becomes the client's responsibility. The Gemini
+# branch had no emission path — only raw audio chunks via
+# send_realtime_input(audio=...) — so manual sessions left the model
+# without a turn boundary.
+#
+# Authoritative source for the wire format (google-genai SDK
+# LiveClientRealtimeInput docs, types.py):
+#
+#   automatic_activity_detection: "If not set, automatic activity
+#   detection is enabled by default. If automatic voice detection is
+#   disabled, the client must send activity signals."
+#
+#   activity_end (ActivityEnd): "Marks the end of user activity. This
+#   can only be sent if automatic (i.e. server-side) activity detection
+#   is disabled."
+#
+#   audio_stream_end: "Indicates that the audio stream has ended ...
+#   This should only be sent when automatic activity detection is
+#   enabled (which is the default)." — therefore NOT applicable in our
+#   MANUAL path.
+
+
+@pytest.mark.unit
+async def test_signal_user_activity_end_gemini_manual_sends_activity_end():
+    """Gemini MANUAL: signal_user_activity_end() must emit activity_end
+    via send_realtime_input(activity_end=ActivityEnd()) — without it,
+    the model never sees a turn boundary and never responds to spoken
+    input.
+    """
+    pytest.importorskip("google.genai")
+    from google.genai import types as genai_types
+
+    client = _make_manual_client(
+        model="gemini-2.0-flash-exp",
+        base_url="https://generativelanguage.googleapis.com",
+        api_type="gemini",
+    )
+
+    fake_session = AsyncMock()
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_ctx.__aexit__ = AsyncMock(return_value=False)
+    fake_genai_client = MagicMock()
+    fake_genai_client.aio.live.connect = MagicMock(return_value=fake_ctx)
+
+    with patch("main_logic.omni_realtime_client.genai") as mock_genai_module:
+        mock_genai_module.Client = MagicMock(return_value=fake_genai_client)
+        await client.connect(instructions="hi", native_audio=True)
+
+    # Reset call tracking after connect; we only care about the
+    # signal_user_activity_end emission, not connect-time setup calls.
+    fake_session.send_realtime_input.reset_mock()
+
+    await client.signal_user_activity_end()
+
+    assert fake_session.send_realtime_input.await_count == 1, (
+        "MANUAL Gemini must emit exactly one activity_end signal"
+    )
+    call_kwargs = fake_session.send_realtime_input.await_args.kwargs
+    assert "activity_end" in call_kwargs, (
+        f"Expected kw 'activity_end' in send_realtime_input call, got {call_kwargs!r}. "
+        f"Per SDK docs (LiveClientRealtimeInput.activity_end), this is the "
+        f"canonical signal when automatic_activity_detection.disabled=True. "
+        f"audio_stream_end is NOT applicable — it's documented as "
+        f"'only when automatic activity detection is enabled'."
+    )
+    assert isinstance(call_kwargs["activity_end"], genai_types.ActivityEnd)
+    # No other kwargs — the SDK requires exactly one arg per call.
+    assert set(call_kwargs.keys()) == {"activity_end"}
+
+
+@pytest.mark.unit
+async def test_signal_user_activity_end_gemini_server_vad_is_noop():
+    """Gemini SERVER_VAD: signal_user_activity_end() must NOT emit
+    anything — server-side AAD owns turn detection in this mode, and
+    sending activity_end while AAD is enabled is rejected by the API.
+    """
+    pytest.importorskip("google.genai")
+
+    client = OmniRealtimeClient(
+        base_url="https://generativelanguage.googleapis.com",
+        api_key="sk-test",
+        model="gemini-2.0-flash-exp",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="gemini",
+    )
+
+    fake_session = AsyncMock()
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_ctx.__aexit__ = AsyncMock(return_value=False)
+    fake_genai_client = MagicMock()
+    fake_genai_client.aio.live.connect = MagicMock(return_value=fake_ctx)
+
+    with patch("main_logic.omni_realtime_client.genai") as mock_genai_module:
+        mock_genai_module.Client = MagicMock(return_value=fake_genai_client)
+        await client.connect(instructions="hi", native_audio=True)
+
+    fake_session.send_realtime_input.reset_mock()
+    await client.signal_user_activity_end()
+
+    fake_session.send_realtime_input.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_signal_user_activity_end_websocket_manual_sends_commit_and_response_create():
+    """OpenAI/Qwen/GLM/Step path MANUAL: signal_user_activity_end() must
+    emit ``input_audio_buffer.commit`` followed by ``response.create``.
+    Without these, the server holds the buffered audio forever and never
+    runs inference.
+    """
+    client = _make_manual_client(model="qwen-omni-turbo-realtime", api_type="qwen")
+
+    sent: list[dict] = []
+
+    async def fake_send(payload):
+        try:
+            sent.append(json.loads(payload))
+        except Exception:
+            pass
+
+    mock_ws = AsyncMock()
+    mock_ws.send = AsyncMock(side_effect=fake_send)
+    client.ws = mock_ws
+
+    await client.signal_user_activity_end()
+
+    types_sent = [e.get("type") for e in sent]
+    assert "input_audio_buffer.commit" in types_sent, (
+        f"MANUAL websocket path must send input_audio_buffer.commit; got {types_sent!r}"
+    )
+    assert "response.create" in types_sent, (
+        f"MANUAL websocket path must send response.create; got {types_sent!r}"
+    )
+    # Ordering: commit before response.create
+    assert types_sent.index("input_audio_buffer.commit") < types_sent.index("response.create")
+
+
+@pytest.mark.unit
+async def test_signal_user_activity_end_websocket_server_vad_is_noop():
+    """SERVER_VAD path: signal_user_activity_end() is a no-op — the
+    server emits turn-end signals on its own.
+    """
+    client = OmniRealtimeClient(
+        base_url="wss://example.test/realtime",
+        api_key="sk-test",
+        model="qwen-omni-turbo-realtime",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="qwen",
+    )
+    mock_ws = AsyncMock()
+    client.ws = mock_ws
+
+    await client.signal_user_activity_end()
+
+    mock_ws.send.assert_not_awaited()
+
+
+# ──────────────────────────────────────────────────────────────────────
 # VAD SERVER_VAD regression tests — ensure refactor preserved old behaviour
 # ──────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -379,3 +379,131 @@ async def test_connect_qwen_server_vad_preserves_payload():
     assert isinstance(td, dict)
     assert td.get("type") in ("server_vad", "semantic_vad")
     assert "threshold" in td
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Regression: connect() must reset _has_server_vad to False in MANUAL
+# mode for every provider that defaults to server-VAD. Otherwise
+# stream_audio() and _check_silence_timeout() take the wrong branch
+# (stale _last_speech_time, false GLM/free auto-close, mis-applied
+# client-VAD suppression). Codex finding on PR #1128 (id 3181989081).
+# ──────────────────────────────────────────────────────────────────────
+
+
+# Provider matrix → (model, base_url, api_type, expected_default_has_vad).
+# expected_default_has_vad is what __init__ would set for SERVER_VAD on the
+# same constructor args; MANUAL must override to False regardless.
+_VAD_PROVIDER_MATRIX = [
+    # provider id, model, base_url, api_type, default_has_server_vad
+    ("qwen", "qwen-omni-turbo-realtime", "wss://example.test/realtime", "qwen", True),
+    ("openai", "gpt-realtime", "wss://api.openai.com/v1/realtime", "openai", True),
+    ("glm", "glm-realtime", "wss://example.test/realtime", "glm", True),
+    ("step", "step-1o-audio", "wss://example.test/realtime", "step", True),
+    # lanlan.tech (China free, StepFun proxy) — has server VAD by default
+    ("free_stepfun", "free-model", "wss://lanlan.tech/realtime", "free", True),
+    # lanlan.app (international free, Vertex Gemini proxy) — __init__ already
+    # treats this as client-VAD only (False), so MANUAL has nothing to flip.
+    # Included to verify we don't accidentally re-enable server VAD.
+    ("free_vertex", "free-model", "wss://lanlan.app/realtime", "free", False),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    # NOTE: parameter renamed from ``base_url`` to ``ws_url`` to avoid
+    # collision with the session-scoped ``base_url`` fixture from
+    # pytest-base-url (otherwise pytest raises ScopeMismatch).
+    "provider_id,model,ws_url,api_type,default_has_vad",
+    _VAD_PROVIDER_MATRIX,
+    ids=[row[0] for row in _VAD_PROVIDER_MATRIX],
+)
+async def test_connect_manual_mode_resets_has_server_vad_for_all_providers(
+    provider_id, model, ws_url, api_type, default_has_vad,
+):
+    """MANUAL mode must force _has_server_vad=False for every websocket
+    provider, since connect() sends turn_detection=null and the provider
+    will not emit speech_started/stopped events.
+
+    Compares against the SERVER_VAD baseline to confirm the default
+    matches the codebase's __init__ heuristic, then asserts MANUAL flips
+    the flag to False post-connect().
+    """
+    # Baseline: SERVER_VAD client should keep the documented default.
+    server_vad_client = OmniRealtimeClient(
+        base_url=ws_url,
+        api_key="sk-test",
+        model=model,
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type=api_type,
+    )
+    assert server_vad_client._has_server_vad is default_has_vad, (
+        f"{provider_id}: SERVER_VAD default mismatch — fixture expectation "
+        f"is stale; expected {default_has_vad}, got {server_vad_client._has_server_vad}"
+    )
+
+    # MANUAL: pre-connect the flag matches __init__ default; post-connect
+    # it must be False regardless of provider default.
+    manual_client = _make_manual_client(model=model, base_url=ws_url, api_type=api_type)
+    assert manual_client._has_server_vad is default_has_vad, (
+        f"{provider_id}: pre-connect baseline drift"
+    )
+
+    await _run_connect_and_capture_session(manual_client)
+
+    assert manual_client._has_server_vad is False, (
+        f"{provider_id}: connect() MANUAL path must reset _has_server_vad to "
+        f"False so stream_audio/_check_silence_timeout pick the client-VAD "
+        f"branch (codex review id 3181989081)"
+    )
+
+
+@pytest.mark.unit
+async def test_connect_gemini_manual_mode_keeps_has_server_vad_false():
+    """Gemini path: __init__ already sets _has_server_vad=False (since
+    Gemini Live emits no speech_started/stopped). MANUAL path must not
+    accidentally flip it back to True. This guards the symmetry of the
+    fix across the websocket and Gemini connect paths.
+    """
+    pytest.importorskip("google.genai")
+
+    client = _make_manual_client(
+        model="gemini-2.0-flash-exp",
+        base_url="https://generativelanguage.googleapis.com",
+        api_type="gemini",
+    )
+    assert client._has_server_vad is False  # __init__ default for Gemini
+
+    fake_session = AsyncMock()
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_ctx.__aexit__ = AsyncMock(return_value=False)
+    fake_genai_client = MagicMock()
+    fake_genai_client.aio.live.connect = MagicMock(return_value=fake_ctx)
+
+    with patch("main_logic.omni_realtime_client.genai") as mock_genai_module:
+        mock_genai_module.Client = MagicMock(return_value=fake_genai_client)
+        await client.connect(instructions="hi", native_audio=True)
+
+    assert client._has_server_vad is False
+
+
+@pytest.mark.unit
+async def test_connect_server_vad_mode_preserves_has_server_vad_default():
+    """SERVER_VAD path must NOT touch _has_server_vad — provider defaults
+    from __init__ heuristic carry through. Counter-test to the MANUAL
+    override above.
+    """
+    client = OmniRealtimeClient(
+        base_url="wss://example.test/realtime",
+        api_key="sk-test",
+        model="qwen-omni-turbo-realtime",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="qwen",
+    )
+    assert client._has_server_vad is True
+
+    await _run_connect_and_capture_session(client)
+
+    assert client._has_server_vad is True, (
+        "SERVER_VAD must not flip _has_server_vad — only MANUAL forces False"
+    )

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -678,3 +678,64 @@ async def test_connect_server_vad_mode_preserves_has_server_vad_default():
     assert client._has_server_vad is True, (
         "SERVER_VAD must not flip _has_server_vad — only MANUAL forces False"
     )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Regression: connect() must validate turn_detection_mode BEFORE any
+# side effect (websocket open, _connect_gemini SDK init, silence-check
+# task spawn). CodeRabbit Major on PR #1128 (r3182466295): the original
+# check sat after websockets.connect() in the WebSocket branch and was
+# entirely bypassed by the early Gemini return — invalid modes either
+# leaked a half-open WebSocket or were silently accepted by Gemini.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_connect_gemini_invalid_turn_detection_mode_raises_before_side_effects():
+    """Gemini path: an invalid turn_detection_mode must raise ValueError
+    BEFORE _connect_gemini runs. Pre-fix the early Gemini return bypassed
+    validation entirely, so this asserts the hoist actually covers the
+    Gemini branch (the WebSocket branch already threw, just too late).
+    """
+    pytest.importorskip("google.genai")
+
+    client = OmniRealtimeClient(
+        base_url="https://generativelanguage.googleapis.com",
+        api_key="sk-test",
+        model="gemini-2.0-flash-exp",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="gemini",
+    )
+    # Inject an invalid mode post-construction. The Enum has only two
+    # legal members so we use a sentinel object that fails the
+    # ``in (MANUAL, SERVER_VAD)`` membership check.
+    client.turn_detection_mode = "bogus_mode"
+
+    with patch.object(
+        client, "_connect_gemini", new_callable=AsyncMock
+    ) as mock_connect_gemini:
+        with pytest.raises(ValueError, match="Invalid turn detection mode"):
+            await client.connect(instructions="hi", native_audio=True)
+
+        mock_connect_gemini.assert_not_awaited()
+
+
+@pytest.mark.unit
+async def test_connect_websocket_invalid_turn_detection_mode_raises_before_websocket_open():
+    """WebSocket path: validation hoist must fire before websockets.connect()
+    so we never leak a half-open socket on invalid mode.
+    """
+    client = OmniRealtimeClient(
+        base_url="wss://example.test/realtime",
+        api_key="sk-test",
+        model="qwen-omni-turbo-realtime",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="qwen",
+    )
+    client.turn_detection_mode = "bogus_mode"
+
+    with patch("websockets.connect", new_callable=AsyncMock) as mock_ws_connect:
+        with pytest.raises(ValueError, match="Invalid turn detection mode"):
+            await client.connect(instructions="hi", native_audio=True)
+
+        mock_ws_connect.assert_not_called()

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -238,7 +238,14 @@ async def _run_connect_and_capture_session(client):
 
     with patch("websockets.connect", new_callable=AsyncMock) as mock_connect:
         mock_connect.return_value = mock_ws
-        await client.connect(instructions="You are helpful.", native_audio=True)
+        try:
+            await client.connect(instructions="You are helpful.", native_audio=True)
+        finally:
+            # GLM/free providers start a background silence-detection task in
+            # connect(); without close() it lingers across tests and can cause
+            # cross-test interference / pytest warnings. close() cancels the
+            # task before returning.
+            await client.close()
 
     return captured.get("session")
 


### PR DESCRIPTION
## Summary

Two independent additive features building on PR #1110 (squashed `c49d6fe89`):

### 1. VAD MANUAL filling (`main_logic/omni_realtime_client.py`)

Replaces the `NotImplementedError` placeholder in `OmniRealtimeClient.connect()` for `TurnDetectionMode.MANUAL` across all six providers:

| Provider | MANUAL payload |
|---|---|
| Qwen | `turn_detection: null` (transcription preserved) |
| OpenAI | `audio.input.turn_detection: null` (transcription preserved) |
| GLM | `turn_detection: null` (best-effort; degrades to local suppression on reject) |
| Step | `turn_detection: null` |
| Free (lanlan.tech / lanlan.app) | `turn_detection: null` (proxies translate server-side) |
| Gemini | `realtime_input_config.automatic_activity_detection.disabled=True` on `LiveConnectConfig` |

Refactored the outer `if turn_detection_mode` gate into a per-provider chain that picks SERVER_VAD vs MANUAL inline. Each provider branch keeps its existing if/elif structure — no premature abstraction. VAD MANUAL is a startup-time choice (no runtime toggle).

### 2. chat+blind passthrough at main_server (`main_logic/core.py`, `main_server.py`)

Finishes the v2 plugin schema's `visibility=["chat"] + ai_behavior="blind"` path so plugins can render verbatim into the chat bubble WITHOUT entering the chat-LLM context. Distinct from PR #1110's mirror channel (which writes to `sync_message_queue` and DOES enter chat history as `AIMessage`).

- New `LLMSessionManager.passthrough_to_chat_bubble` — generic capability, not tied to any specific consumer
- `main_server._handle_agent_event` proactive_message branch fires passthrough when `visibility` includes `"chat"` AND `ai_behavior=="blind"`, placed between the silent-skip log and the HUD `agent_notification` path
- Both passthrough and HUD toast can fire orthogonally when `visibility=["chat","hud"]`
- `proactive_bridge.py` already propagates `visibility` and `ai_behavior` on the event (verified — line ~286-306, no change needed)

## Why two features in one PR

They're orthogonal but both small and unblocked. Per the brief: "additive, orthogonal, don't touch existing paths or PR-3's concurrency fixes."

## Test plan

- [x] `tests/unit/test_voice_session.py` — 6 new MANUAL tests (qwen, openai, glm, step, free×2 parametrized, gemini) + 1 SERVER_VAD regression check
- [x] `tests/unit/test_passthrough_to_chat_bubble.py` — 7 unit tests for `passthrough_to_chat_bubble` (write, skip-sync, empty, disconnected, missing-ws, send-failure, turn_id-synthesis) + 3 integration tests for the `main_server` wiring (chat+blind invokes, chat+respond does not, hud-only does not)
- [x] All 18 tests pass; 3 skipped (require live API keys, pre-existing)

## Reference

- PR #1110 (`c49d6fe89`) — Mirror channel + session takeover refactor; left MANUAL as `NotImplementedError`
- PR #1125 — Quick-win bug fixes (open, doesn't conflict)
- VAD MANUAL provider mapping per research note validated against the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增“透传”到聊天气泡：按原文逐字保留（含空白）、可选 request_id/turn_id，仅在已连接的 WebSocket 发送，发送失败记录警告并返回失败。
  * 连接新增 MANUAL（手动）模式支持：在 MANUAL 下禁用服务端 VAD/自动活动检测，并新增显式 signal_user_activity_end() 以结束用户回合。

* **修复**
  * ai_behavior="blind" 时强制静默，并按 visibility 列表决定是否透传聊天或抑制 HUD 通知。

* **测试**
  * 补充大量单元测试，覆盖透传行为、盲目模式、MANUAL/SERVER_VAD 行为、可见性与回合生命周期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->