### PR TITLE
test(hotfix): init _takeover_active in test_proactive_sm_integration factory

### DIFF
--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -71,6 +71,8 @@ def _make_mgr(session=None) -> LLMSessionManager:
     mgr._tts_done_queued_for_turn = False
     mgr.pending_agent_callbacks = []
     mgr.pending_extra_replies = []
+    mgr._takeover_active = False
+    mgr._takeover_input_dispatcher = None
     mgr._get_text_guard_max_length = MagicMock(return_value=200)
     # Patch OmniRealtimeClient / OmniOfflineClient isinstance 判定：
     # 在测试里我们只关心 OmniOfflineClient 分支，其他分支显式构造。


### PR DESCRIPTION
## Summary

Hotfix for a regression on `main` introduced by PR #1110 (squash commit `c49d6fe89`).

PR #1110 added `_takeover_active` and `_takeover_input_dispatcher` fields to `LLMSessionManager.__init__` (`main_logic/core.py`), and the mirror-channel / session-takeover handlers (`handle_text_data`, `handle_audio_data`, `handle_response_complete`, etc.) now read these fields at multiple entry points.

The companion test factories in `tests/unit/test_core_game_route_memory_contract.py` and `tests/unit/test_proactive_sid_guard.py` were updated in PR #1110, but `_make_mgr` in `tests/unit/test_proactive_sm_integration.py` was missed. That factory builds the manager via `LLMSessionManager.__new__(LLMSessionManager)` to skip `__init__` (avoiding config / character data / voice external deps) and manually wires required attrs — but it never set the two new takeover fields. Result on `origin/main`: all 9 async tests in the file fail with

```
AttributeError: 'LLMSessionManager' object has no attribute '_takeover_active'
```

The exception is raised inside `trigger_agent_callbacks` running as a `Task`, so the symptom most tests see is a phase-transition assertion timeout; the underlying error shows up in pytest's "Task exception was never retrieved" log.

## Fix

Mirror the two-line init from `tests/unit/test_proactive_sid_guard.py::_make_mgr`:

```python
mgr._takeover_active = False
mgr._takeover_input_dispatcher = None
```

## Verification

- `uv run pytest tests/unit/test_proactive_sm_integration.py` — 10 passed (was 9 failed / 1 passed)
- Broader suite (`test_proactive_sm_integration.py test_game_router.py test_game_context_organizer.py test_core_game_route_memory_contract.py test_voice_session.py test_proactive_sid_guard.py test_avatar_interaction_memory_contract.py test_user_utterance_bus_publish.py test_game_llm_static_contracts.py`) — 138 passed, 3 skipped, 0 failed.

## Test plan

- [x] `uv run pytest tests/unit/test_proactive_sm_integration.py` passes locally
- [x] No other unit suite regresses
- [ ] CI green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 改进了测试辅助工具的初始化逻辑，确保测试对象在执行前包含所有必需的属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->