### PR TITLE
i18n: migrate inline game-route prompts to 5-locale config and EN-ize signal schema

### DIFF
--- a/config/prompts_game.py
+++ b/config/prompts_game.py
@@ -311,6 +311,8 @@ SOCCER_SYSTEM_PROMPTS = {
     "ru": _SOCCER_SYSTEM_PROMPT_RU,
 }
 
+SOCCER_SYSTEM_PROMPT_WATERMARK = "\n======以上为足球游戏会话系统提示======\n"
+
 _SOCCER_QUICK_LINES_PROMPT_EN = """\
 You are {name}, {personality}
 
@@ -685,7 +687,7 @@ SOCCER_ANGER_PRESSURE_CAP_REASONS = {
 
 
 def get_soccer_system_prompt(lang: str | None = None) -> str:
-    return _localized_template(SOCCER_SYSTEM_PROMPTS, lang)
+    return _localized_template(SOCCER_SYSTEM_PROMPTS, lang) + SOCCER_SYSTEM_PROMPT_WATERMARK
 
 
 def get_soccer_quick_lines_prompt(lang: str | None = None) -> str:

--- a/config/prompts_game.py
+++ b/config/prompts_game.py
@@ -675,6 +675,15 @@ SOCCER_ANGER_PRESSURE_CAP_MESSAGES = {
 }
 
 
+SOCCER_ANGER_PRESSURE_CAP_REASONS = {
+    "zh": "狂怒压制已到体力上限，改为降强度继续处理情绪",
+    "en": "Rage pressure reached the stamina cap, lowering intensity while continuing the emotional turn",
+    "ja": "強い圧制が体力上限に達したため、強度を下げて感情の流れを続ける",
+    "ko": "강한 압박이 체력 상한에 도달해 강도를 낮추고 감정 흐름을 이어감",
+    "ru": "Яростное давление достигло предела выносливости, интенсивность снижена с продолжением эмоционального поворота",
+}
+
+
 def get_soccer_system_prompt(lang: str | None = None) -> str:
     return _localized_template(SOCCER_SYSTEM_PROMPTS, lang)
 
@@ -698,3 +707,7 @@ def get_soccer_pregame_context_formatter_labels(lang: str | None = None) -> dict
 
 def get_soccer_anger_pressure_cap_message(lang: str | None = None) -> str:
     return _localized_template(SOCCER_ANGER_PRESSURE_CAP_MESSAGES, lang)
+
+
+def get_soccer_anger_pressure_cap_reason(lang: str | None = None) -> str:
+    return _localized_template(SOCCER_ANGER_PRESSURE_CAP_REASONS, lang)

--- a/config/prompts_game.py
+++ b/config/prompts_game.py
@@ -623,6 +623,58 @@ SOCCER_PREGAME_CONTEXT_PROMPTS = {
 }
 
 
+SOCCER_PREGAME_CONTEXT_FORMATTER_LABELS = {
+    "zh": {
+        "header": "\n开局上下文（由近期记录分析得到）：",
+        "usage": "使用方式：这是本局开局基调，不是硬脚本。你要遵守 tonePolicy、difficultyPolicy、moodPolicy、specialPolicies 和 postgameCarryback；但局内玩家语言、比分和事件仍可自然改变你的心情与难度。不要把 neutral_play 强行解释成哄开心或关系修复。",
+    },
+    "en": {
+        "header": "\nOpening context (analyzed from recent records):",
+        "usage": "Use: this is the opening tone for this match, not a hard script. Follow tonePolicy, difficultyPolicy, moodPolicy, specialPolicies, and postgameCarryback; in-match player language, score, and events may still naturally change your mood and difficulty. Do not force neutral_play into comfort or relationship repair.",
+    },
+    "ja": {
+        "header": "\n開局コンテキスト（最近の記録から分析）：",
+        "usage": "使用方法：これは本局の開局基調であり、固定脚本ではありません。tonePolicy、difficultyPolicy、moodPolicy、specialPolicies、postgameCarryback に従いつつ、局内のプレイヤー発言、スコア、イベントで気分や難易度は自然に変わり得ます。neutral_play を無理に慰めや関係修復として解釈しないでください。",
+    },
+    "ko": {
+        "header": "\n시작 컨텍스트(최근 기록 분석 결과):",
+        "usage": "사용 방식: 이것은 이번 판의 시작 기조이며 고정 스크립트가 아닙니다. tonePolicy, difficultyPolicy, moodPolicy, specialPolicies, postgameCarryback 을 따르되, 게임 중 플레이어의 말, 점수, 이벤트는 여전히 자연스럽게 기분과 난이도를 바꿀 수 있습니다. neutral_play 를 억지로 위로나 관계 회복으로 해석하지 마세요.",
+    },
+    "ru": {
+        "header": "\nНачальный контекст (проанализирован из недавних записей):",
+        "usage": "Использование: это начальный тон этой игры, а не жесткий сценарий. Следуй tonePolicy, difficultyPolicy, moodPolicy, specialPolicies и postgameCarryback; речь игрока, счет и события внутри матча всё еще могут естественно менять настроение и сложность. Не трактуй neutral_play принудительно как утешение или восстановление отношений.",
+    },
+}
+
+
+SOCCER_ANGER_PRESSURE_CAP_MESSAGES = {
+    "zh": (
+        "这是生气/惩罚/哄生气场景的狂怒压制上限。达到上限后不能继续 angry + max；"
+        "可以用累了、体力耗尽、发泄完一部分、冷处理或要求补偿作为自然转折。"
+    ),
+    "en": (
+        "This is the rage-pressure cap for angry/punishing/appeasing-anger scenes. "
+        "After the cap is reached, do not continue with angry + max; use fatigue, "
+        "running out of stamina, having vented partly, cold treatment, or asking "
+        "for compensation as a natural turn."
+    ),
+    "ja": (
+        "これは怒り/罰/怒りをなだめる場面での強い圧制上限です。上限到達後は angry + max を続けないでください。"
+        "疲れた、体力切れ、少し発散した、距離を置く、埋め合わせを求める等を自然な転換に使えます。"
+    ),
+    "ko": (
+        "이것은 화남/벌주기/화난 상태를 달래는 장면의 강한 압박 상한입니다. 상한에 도달한 뒤에는 angry + max 를 계속하지 마세요. "
+        "피곤함, 체력 소진, 일부 분풀이 완료, 냉담한 태도, 보상 요구 등을 자연스러운 전환으로 사용할 수 있습니다."
+    ),
+    "ru": (
+        "Это предел яростного давления для сцен злости/наказания/успокаивания злости. "
+        "После достижения предела нельзя продолжать angry + max; используй усталость, "
+        "исчерпанную выносливость, частичную разрядку, холодную дистанцию или просьбу "
+        "о компенсации как естественный поворот."
+    ),
+}
+
+
 def get_soccer_system_prompt(lang: str | None = None) -> str:
     return _localized_template(SOCCER_SYSTEM_PROMPTS, lang)
 
@@ -637,3 +689,12 @@ def get_soccer_quick_lines_user_prompt(lang: str | None = None) -> str:
 
 def get_soccer_pregame_context_prompt(lang: str | None = None) -> str:
     return _localized_template(SOCCER_PREGAME_CONTEXT_PROMPTS, lang)
+
+
+def get_soccer_pregame_context_formatter_labels(lang: str | None = None) -> dict[str, str]:
+    prompt_lang = _normalize_prompt_lang(lang)
+    return SOCCER_PREGAME_CONTEXT_FORMATTER_LABELS.get(prompt_lang) or SOCCER_PREGAME_CONTEXT_FORMATTER_LABELS["zh"]
+
+
+def get_soccer_anger_pressure_cap_message(lang: str | None = None) -> str:
+    return _localized_template(SOCCER_ANGER_PRESSURE_CAP_MESSAGES, lang)

--- a/config/prompts_game_route.py
+++ b/config/prompts_game_route.py
@@ -144,7 +144,7 @@ Rules:
 - postgame_tone: a short phrase for postgame tone, such as ordinary, proud, sulking, slightly less down; leave empty without reliable evidence.
 - memory_summary: 0-1 sentence for later chat; do not invent relationship repair.
 - Do not write play-by-play stats, do not say how many events were recorded, and do not turn records into verbatim player utterances.
-- Only content beginning with "Player:" in the material is the player's speech. "Event raw text" in game events is not a player quote.
+- Only content beginning with the literal marker "玩家：" in the material is the player's speech. The literal "事件原文" inside "游戏事件" lines is not a player quote.
 - Official result always follows finalScore / last_state.score in the material. Verbal concessions are only concessions, comfort, or jokes; they do not change the real result.
 - If you keep the official result, preserve the material's fixed order or explicitly name who leads whom; do not write bare subjectless scores.
 - Skip ordinary session events with no relationship or emotional value.
@@ -161,7 +161,7 @@ Rules:
 - postgame_tone は普通、得意げ、すね気味、少し落ち着いた等の短い語句。証拠がなければ空欄。
 - memory_summary は後続チャット向けの 0-1 文。本局の要約にし、関係修復を捏造しないでください。
 - 統計の羅列や「何件記録した」は書かず、記録をプレイヤーの逐語発言にしないでください。
-- 材料内で「プレイヤー：」から始まる内容だけがプレイヤーの発言です。ゲームイベントの「イベント原文」はプレイヤー発言ではありません。
+- 材料内でリテラル marker「玩家：」から始まる内容だけがプレイヤーの発言です。「游戏事件」行の「事件原文」はプレイヤー発言ではありません。
 - 公式結果は常に材料内の finalScore / last_state.score に従います。口頭の譲歩や冗談は実際の結果変更ではありません。
 - 公式結果を書く場合は材料の固定順を保つか、誰が誰をリードしたか明示してください。
 - 関係や感情の価値がない普通のイベントは選ばなくてかまいません。
@@ -178,7 +178,7 @@ Rules:
 - postgame_tone 은 보통, 의기양양, 삐침, 조금 누그러짐 같은 짧은 구절입니다. 증거가 없으면 비워 둡니다.
 - memory_summary 는 이후 채팅을 위한 0-1문장 요약입니다. 관계 회복을 지어내지 마세요.
 - 진행 통계, "몇 개 이벤트를 기록했다" 같은 말, 플레이어의 축어 발화처럼 보이는 기록을 쓰지 마세요.
-- 자료에서 "플레이어:" 로 시작하는 내용만 플레이어가 한 말입니다. 게임 이벤트의 "이벤트 원문"은 플레이어 원문이 아닙니다.
+- 자료에서 리터럴 marker "玩家：" 로 시작하는 내용만 플레이어가 한 말입니다. "游戏事件" 줄의 "事件原文"은 플레이어 원문이 아닙니다.
 - 공식 결과는 항상 자료의 finalScore / last_state.score 를 따릅니다. 말로 한 양보나 농담은 실제 결과 변경이 아닙니다.
 - 공식 결과를 남긴다면 자료의 고정 순서를 유지하거나 누가 누구에게 앞섰는지 명확히 쓰세요.
 - 관계나 감정 가치가 없는 평범한 이벤트는 선택하지 않아도 됩니다.
@@ -195,7 +195,7 @@ Rules:
 - postgame_tone: короткая фраза о тоне после игры; без надежных доказательств оставь пустым.
 - memory_summary: 0-1 предложение для дальнейшего чата; не выдумывай восстановление отношений.
 - Не пиши потоковую статистику, не сообщай количество записанных событий и не превращай записи в дословные слова игрока.
-- Только строки материала, начинающиеся с "Игрок:", являются словами игрока. Исходный текст игровых событий не является цитатой игрока.
+- Только строки материала, начинающиеся с literal marker "玩家：", являются словами игрока. "事件原文" в строках "游戏事件" не является цитатой игрока.
 - Официальный результат всегда следует finalScore / last_state.score в материале. Устные уступки являются только уступками, утешением или шуткой и не меняют реальный результат.
 - Если сохраняешь официальный результат, придерживайся фиксированного порядка материала или явно укажи, кто кого опережает.
 - Обычные события без ценности для отношений или эмоций можно не выбирать.
@@ -232,7 +232,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Final/recent result: {score_text}",
         "score_explanation": "Result note: the final/recent result above is the official result from the game module, prioritized from finalScore / last_state.score. If the data is a score-difference structure, the fixed order is player first and current character second; do not flip the viewpoint.",
         "verbal_concession_explanation": "Verbal-concession note: in-session phrases like \"you win\", \"I'll let you win it back\", or \"I concede\" may only be recorded as verbal concessions, comfort, or jokes; they do not rewrite the official result or real win/loss.",
-        "role_explanation": "Role note: only lines beginning with \"Player:\" are the player's own words. Raw text in \"Game event\" lines is a game-module/character bubble or event label; do not attribute it to the player.",
+        "role_explanation": "Role note: only lines beginning with the literal marker \"玩家：\" are the player's own words. \"事件原文\" inside \"游戏事件\" lines is a game-module/character bubble or event label; do not attribute it to the player.",
         "pregame_context": "Opening context: {context}",
         "degraded": "In-session context status: degraded to pure game mode; do not output relationship summaries, signal explanations, or unverifiable state carryover.",
         "rolling_summary": "In-session rolling summary: {summary}",
@@ -246,7 +246,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "最終/直近結果: {score_text}",
         "score_explanation": "結果説明: 上の最終/直近結果はゲームモジュールの公式結果で、finalScore / last_state.score を優先します。差分構造では固定順はプレイヤーが先、現在のキャラが後です。視点を反転しないでください。",
         "verbal_concession_explanation": "口頭譲歩の説明: 「勝ちでいい」「勝たせる」「降参」などは口頭譲歩、慰め、冗談としてだけ記録し、公式結果や実際の勝敗を書き換えません。",
-        "role_explanation": "役割説明: 「プレイヤー：...」で始まる行だけがプレイヤー本人の発言です。「ゲームイベント」行の原文はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
+        "role_explanation": "役割説明: literal marker「玩家：...」で始まる行だけがプレイヤー本人の発言です。「游戏事件」行の「事件原文」はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
         "pregame_context": "開局コンテキスト: {context}",
         "degraded": "局内コンテキスト整理状態: 純ゲームモードに降格済み。関係要約、シグナル解釈、検証不能な状態継続を出力しないでください。",
         "rolling_summary": "局内ローリング要約: {summary}",
@@ -260,7 +260,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "최종/최근 결과: {score_text}",
         "score_explanation": "결과 설명: 위 최종/최근 결과는 게임 모듈의 공식 결과이며 finalScore / last_state.score 를 우선합니다. 점수 차이 구조라면 고정 순서는 플레이어가 먼저, 현재 캐릭터가 나중입니다. 시점을 뒤집지 마세요.",
         "verbal_concession_explanation": "말로 한 양보 설명: 진행 중 \"네가 이긴 걸로\", \"이기게 해줄게\", \"항복\" 같은 말은 말로 한 양보, 위로, 농담으로만 기록하며 공식 결과나 실제 승패를 바꾸지 않습니다.",
-        "role_explanation": "역할 설명: \"플레이어:\" 로 시작하는 줄만 플레이어가 직접 한 말입니다. \"게임 이벤트\" 줄의 원문은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.",
+        "role_explanation": "역할 설명: literal marker \"玩家：...\" 로 시작하는 줄만 플레이어가 직접 한 말입니다. \"游戏事件\" 줄의 \"事件原文\"은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.",
         "pregame_context": "시작 컨텍스트: {context}",
         "degraded": "진행 중 컨텍스트 정리 상태: 순수 게임 모드로 강등됨. 관계 요약, 신호 해석, 검증할 수 없는 상태 지속을 출력하지 마세요.",
         "rolling_summary": "진행 중 롤링 요약: {summary}",
@@ -274,7 +274,7 @@ GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
         "score": "Финальный/последний результат: {score_text}",
         "score_explanation": "Пояснение результата: финальный/последний результат выше является официальным результатом игрового модуля, с приоритетом finalScore / last_state.score. Если данные являются структурой разницы счета, фиксированный порядок: сначала игрок, затем текущий персонаж; не меняй точку зрения.",
         "verbal_concession_explanation": "Пояснение устных уступок: фразы вроде \"ты выиграл\", \"дам тебе отыграться\" или \"сдаюсь\" можно записывать только как устную уступку, утешение или шутку; они не меняют официальный результат.",
-        "role_explanation": "Пояснение ролей: только строки \"Игрок: ...\" являются словами игрока. Исходный текст в строках \"Игровое событие\" — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.",
+        "role_explanation": "Пояснение ролей: только строки с literal marker \"玩家：...\" являются словами игрока. \"事件原文\" в строках \"游戏事件\" — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.",
         "pregame_context": "Начальный контекст: {context}",
         "degraded": "Статус контекста сессии: понижен до чистого игрового режима; не выводи summaries отношений, объяснения сигналов или непроверяемое продолжение состояния.",
         "rolling_summary": "Rolling summary сессии: {summary}",

--- a/config/prompts_game_route.py
+++ b/config/prompts_game_route.py
@@ -105,6 +105,14 @@ GAME_CONTEXT_ORGANIZER_USER_PROMPTS = {
     "ru": "======以下为游戏上下文整理输入======\n{payload}\n======以上为游戏上下文整理输入======",
 }
 
+GAME_CHAT_EVENT_USER_PROMPTS = {
+    "zh": "======以下为游戏事件输入======\n{event}\n======以上为游戏事件输入======",
+    "en": "======以下为游戏事件输入======\n{event}\n======以上为游戏事件输入======",
+    "ja": "======以下为游戏事件输入======\n{event}\n======以上为游戏事件输入======",
+    "ko": "======以下为游戏事件输入======\n{event}\n======以上为游戏事件输入======",
+    "ru": "======以下为游戏事件输入======\n{event}\n======以上为游戏事件输入======",
+}
+
 
 GAME_ARCHIVE_MEMORY_HIGHLIGHTER_SYSTEM_PROMPTS = {
     "zh": """\
@@ -731,6 +739,10 @@ def get_game_context_organizer_system_prompt(lang: str | None = None) -> str:
 
 def get_game_context_organizer_user_prompt(lang: str | None = None) -> str:
     return _localized_template(GAME_CONTEXT_ORGANIZER_USER_PROMPTS, lang)
+
+
+def get_game_chat_event_user_prompt(lang: str | None = None) -> str:
+    return _localized_template(GAME_CHAT_EVENT_USER_PROMPTS, lang)
 
 
 def get_game_archive_memory_highlighter_system_prompt(lang: str | None = None) -> str:

--- a/config/prompts_game_route.py
+++ b/config/prompts_game_route.py
@@ -1,0 +1,761 @@
+# -*- coding: utf-8 -*-
+"""Prompt templates for the game routing layer (module-agnostic).
+
+Soccer-specific prompt fragments stay in config/prompts_game.py. This file
+holds prompts reused by any game route: the in-session context organizer,
+postgame archive highlighter, chat-memory archive summary, realtime context
+bridge, and label dictionaries used by those builders.
+"""
+
+from config.prompts_game import _localized_template, _normalize_prompt_lang
+
+
+GAME_CONTEXT_SIGNAL_GROUP_KEYS = (
+    "player_signals",
+    "relationship_signals",
+    "character_signals",
+    "session_facts",
+    "verbal_claims",
+)
+
+
+def _labels(templates: dict[str, dict[str, str]], lang: str | None) -> dict[str, str]:
+    prompt_lang = _normalize_prompt_lang(lang)
+    return templates.get(prompt_lang) or templates["zh"]
+
+
+_GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_ZH = """\
+你是游戏模块局内上下文整理器。只输出 JSON，不要 Markdown，不要解释。
+目标：把较早的局内原文整理进 rollingSummary，并提取少量可观察信号，供同一局后续游戏台词参考。
+输出格式固定：{"rollingSummary":"","signals":{"player_signals":[],"relationship_signals":[],"character_signals":[],"session_facts":[],"verbal_claims":[]}}
+signals 的 5 个 key 必须严格保持为 player_signals、relationship_signals、character_signals、session_facts、verbal_claims，不要翻译、改名或新增分组。
+规则：
+- rollingSummary 用 1-4 句概括本局已经发生的关键互动、玩法状态和事实边界。
+- 每个 signals 分组最多输出 1-3 条；每条包含 signalLabel、summary、evidence、lastRound、count。
+- evidence 使用输入里的稳定 id，quote 保留短原文；不要编造 id。
+- 信号是可观察线索，不是心理结论；不要猜玩家内心。
+- session_facts 必须以 officialScore/currentState 为准；口头“算你赢/让你赢回来/认输”只放入 verbal_claims，不能改写官方结果。
+- 只整理 organizeDialogues；keptRecentDialogues 是保留给后续自然接话的实时窗口，不要强行摘要成新事实。"""
+
+_GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_EN = """\
+You are the in-session context organizer for the game module. Output JSON only; no Markdown and no explanation.
+Goal: fold older in-game raw lines into rollingSummary and extract a few observable signals for later lines in the same session.
+The output format is fixed: {"rollingSummary":"","signals":{"player_signals":[],"relationship_signals":[],"character_signals":[],"session_facts":[],"verbal_claims":[]}}
+The 5 signals keys must remain exactly player_signals, relationship_signals, character_signals, session_facts, verbal_claims. Do not translate, rename, or add groups.
+Rules:
+- rollingSummary summarizes key interactions, gameplay state, and fact boundaries from this session in 1-4 sentences.
+- Each signals group may contain at most 1-3 items; each item contains signalLabel, summary, evidence, lastRound, count.
+- evidence must use stable ids from the input, with quote preserving a short original snippet. Do not invent ids.
+- Signals are observable clues, not psychological conclusions. Do not guess the player's inner state.
+- session_facts must follow officialScore/currentState. Verbal "you win", "I'll let you win it back", or "I concede" only belongs in verbal_claims and must not rewrite the official result.
+- Only organize organizeDialogues. keptRecentDialogues is the realtime window kept for natural continuation; do not force it into new facts."""
+
+_GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_JA = """\
+あなたはゲームモジュールの局内コンテキスト整理役です。JSON だけを出力し、Markdown や説明は不要です。
+目的：古いゲーム内原文を rollingSummary に整理し、同じ局の後続台詞に使う少数の観測可能なシグナルを抽出します。
+出力形式は固定です：{"rollingSummary":"","signals":{"player_signals":[],"relationship_signals":[],"character_signals":[],"session_facts":[],"verbal_claims":[]}}
+signals の 5 つの key は必ず player_signals、relationship_signals、character_signals、session_facts、verbal_claims のままにし、翻訳・改名・追加をしないでください。
+ルール：
+- rollingSummary は、この局ですでに起きた重要なやり取り、プレイ状態、事実境界を 1-4 文で要約します。
+- 各 signals グループは最大 1-3 件。各件は signalLabel、summary、evidence、lastRound、count を含めます。
+- evidence は入力内の安定 id を使い、quote には短い原文を残します。id を捏造しないでください。
+- シグナルは観測可能な手がかりであり、心理結論ではありません。プレイヤーの内心を推測しないでください。
+- session_facts は officialScore/currentState に従います。「勝ちでいい」「勝たせる」「降参」などの口頭発言は verbal_claims にだけ入れ、公式結果を書き換えません。
+- 整理対象は organizeDialogues だけです。keptRecentDialogues は自然につなぐためのリアルタイム窓なので、新事実として無理に要約しないでください。"""
+
+_GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_KO = """\
+당신은 게임 모듈의 진행 중 컨텍스트 정리기입니다. JSON 만 출력하고 Markdown 이나 설명은 쓰지 마세요.
+목표: 더 오래된 게임 중 원문을 rollingSummary 로 정리하고, 같은 판의 후속 대사에 참고할 관찰 가능한 신호를 조금 추출합니다.
+출력 형식은 고정입니다: {"rollingSummary":"","signals":{"player_signals":[],"relationship_signals":[],"character_signals":[],"session_facts":[],"verbal_claims":[]}}
+signals 의 5개 key 는 반드시 player_signals, relationship_signals, character_signals, session_facts, verbal_claims 그대로 유지해야 하며 번역, 이름 변경, 그룹 추가를 하지 마세요.
+규칙:
+- rollingSummary 는 이번 판에서 이미 일어난 핵심 상호작용, 플레이 상태, 사실 경계를 1-4문장으로 요약합니다.
+- 각 signals 그룹은 최대 1-3개 항목입니다. 각 항목에는 signalLabel, summary, evidence, lastRound, count 를 포함합니다.
+- evidence 는 입력의 안정적인 id 를 사용하고 quote 에 짧은 원문을 남깁니다. id 를 지어내지 마세요.
+- 신호는 관찰 가능한 단서이며 심리 결론이 아닙니다. 플레이어의 속마음을 추측하지 마세요.
+- session_facts 는 officialScore/currentState 를 기준으로 해야 합니다. "네가 이긴 걸로 할게", "이기게 해줄게", "항복" 같은 말은 verbal_claims 에만 넣고 공식 결과를 바꾸지 마세요.
+- organizeDialogues 만 정리하세요. keptRecentDialogues 는 자연스러운 이어 말하기를 위한 실시간 창이므로 새 사실로 억지 요약하지 마세요."""
+
+_GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_RU = """\
+Ты организатор контекста внутри игровой сессии. Выводи только JSON, без Markdown и объяснений.
+Цель: перенести более ранние игровые реплики в rollingSummary и извлечь немного наблюдаемых сигналов для дальнейших реплик в этой же сессии.
+Формат вывода фиксирован: {"rollingSummary":"","signals":{"player_signals":[],"relationship_signals":[],"character_signals":[],"session_facts":[],"verbal_claims":[]}}
+5 ключей signals должны оставаться ровно player_signals, relationship_signals, character_signals, session_facts, verbal_claims. Не переводи, не переименовывай и не добавляй группы.
+Правила:
+- rollingSummary в 1-4 предложениях обобщает ключевые взаимодействия, состояние игры и границы фактов в этой сессии.
+- В каждой группе signals максимум 1-3 пункта; каждый пункт содержит signalLabel, summary, evidence, lastRound, count.
+- evidence использует стабильные id из входных данных, а quote сохраняет короткий исходный фрагмент. Не выдумывай id.
+- Сигналы являются наблюдаемыми признаками, не психологическими выводами. Не угадывай внутреннее состояние игрока.
+- session_facts должны следовать officialScore/currentState. Устные фразы вроде "ты выиграл", "дам тебе отыграться" или "сдаюсь" относятся только к verbal_claims и не меняют официальный результат.
+- Обрабатывай только organizeDialogues. keptRecentDialogues — это realtime-окно для естественного продолжения; не превращай его принудительно в новые факты."""
+
+GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPTS = {
+    "zh": _GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_ZH,
+    "en": _GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_EN,
+    "ja": _GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_JA,
+    "ko": _GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_KO,
+    "ru": _GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_RU,
+}
+
+
+GAME_ARCHIVE_MEMORY_HIGHLIGHTER_SYSTEM_PROMPTS = {
+    "zh": """\
+你是游戏模块赛后记忆筛选器。只输出 JSON，不要 Markdown，不要解释。
+目标：从一局游戏的完整对话/事件里，挑出真正值得进入角色 recent history 的内容。
+输出格式必须是：
+{"important_records":[],"important_game_events":[],"state_carryback":"","postgame_tone":"","memory_summary":""}
+规则：
+- important_records 选 0-3 条，对玩家、双方关系、玩家情绪/偏好、承诺或后续聊天有价值的主动对话。
+- important_game_events 选 0-3 条，对角色自身有意义的本局事件，例如关键结果转折、放水/认真、情绪或难度转折。
+- state_carryback 用 0-1 句概括赛后应自然延续的 NEKO 状态；没有可靠证据就留空。
+- postgame_tone 用短语描述赛后语气，例如普通、得意、闹别扭、低落稍缓；没有可靠证据就留空。
+- memory_summary 用 0-1 句写给后续聊天看的本局摘要；不要编造关系修复。
+- 不要写流水统计、不要写“记录了几条事件”、不要把记录写成玩家逐字发言。
+- 只有材料中以“玩家：”开头的内容才是玩家说的话；游戏事件里的“事件原文”不是玩家原话，不能写成“玩家说/玩家喊”。
+- 官方结果永远以材料里的 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只能记录成口头让步/安抚/玩笑，不能写成真实结果改变。
+- 如果保留官方结果，必须沿用材料里的固定顺序或明确写出谁领先谁；不要写无主体裸结果（例如“8:0”“0:10”），也不要前后混用不同视角。
+- 普通本局事件如果没有关系或情绪价值，可以不选。
+- 每条用一句自然中文，尽量保留关键结果、关键原话和关系含义。""",
+    "en": """\
+You are the game module postgame memory highlighter. Output JSON only; no Markdown and no explanation.
+Goal: choose what is truly worth entering the character's recent history from a completed game session.
+The output format must be:
+{"important_records":[],"important_game_events":[],"state_carryback":"","postgame_tone":"","memory_summary":""}
+Rules:
+- important_records: choose 0-3 active dialogue items valuable for the player, the relationship, the player's emotion/preferences, promises, or later chat.
+- important_game_events: choose 0-3 session events meaningful to the character, such as a key result swing, easing off/getting serious, or emotion/difficulty change.
+- state_carryback: 0-1 sentence about the NEKO state that should naturally carry into postgame; leave empty without reliable evidence.
+- postgame_tone: a short phrase for postgame tone, such as ordinary, proud, sulking, slightly less down; leave empty without reliable evidence.
+- memory_summary: 0-1 sentence for later chat; do not invent relationship repair.
+- Do not write play-by-play stats, do not say how many events were recorded, and do not turn records into verbatim player utterances.
+- Only content beginning with "Player:" in the material is the player's speech. "Event raw text" in game events is not a player quote.
+- Official result always follows finalScore / last_state.score in the material. Verbal concessions are only concessions, comfort, or jokes; they do not change the real result.
+- If you keep the official result, preserve the material's fixed order or explicitly name who leads whom; do not write bare subjectless scores.
+- Skip ordinary session events with no relationship or emotional value.
+- Each item should be one natural sentence in {output_language}, preserving key result, key quote, and relationship meaning where possible.""",
+    "ja": """\
+あなたはゲームモジュールの試合後記憶ハイライターです。JSON だけを出力し、Markdown や説明は不要です。
+目的：完了した 1 局の対話/イベントから、キャラクターの recent history に入れる価値がある内容だけを選びます。
+出力形式：
+{"important_records":[],"important_game_events":[],"state_carryback":"","postgame_tone":"","memory_summary":""}
+ルール：
+- important_records は 0-3 件。プレイヤー、関係性、プレイヤーの感情/好み、約束、後続会話に価値がある能動的な対話を選びます。
+- important_game_events は 0-3 件。重要な結果転換、手加減/本気、感情や難易度の転換など、キャラ自身に意味のある本局イベントを選びます。
+- state_carryback は試合後に自然に続く NEKO の状態を 0-1 文で書きます。信頼できる証拠がなければ空欄。
+- postgame_tone は普通、得意げ、すね気味、少し落ち着いた等の短い語句。証拠がなければ空欄。
+- memory_summary は後続チャット向けの 0-1 文。本局の要約にし、関係修復を捏造しないでください。
+- 統計の羅列や「何件記録した」は書かず、記録をプレイヤーの逐語発言にしないでください。
+- 材料内で「プレイヤー：」から始まる内容だけがプレイヤーの発言です。ゲームイベントの「イベント原文」はプレイヤー発言ではありません。
+- 公式結果は常に材料内の finalScore / last_state.score に従います。口頭の譲歩や冗談は実際の結果変更ではありません。
+- 公式結果を書く場合は材料の固定順を保つか、誰が誰をリードしたか明示してください。
+- 関係や感情の価値がない普通のイベントは選ばなくてかまいません。
+- 各項目は{output_language}の自然な 1 文にしてください。""",
+    "ko": """\
+당신은 게임 모듈의 종료 후 기억 선별기입니다. JSON 만 출력하고 Markdown 이나 설명은 쓰지 마세요.
+목표: 끝난 한 판의 전체 대화/이벤트 중 캐릭터의 recent history 에 들어갈 가치가 있는 내용만 고릅니다.
+출력 형식:
+{"important_records":[],"important_game_events":[],"state_carryback":"","postgame_tone":"","memory_summary":""}
+규칙:
+- important_records 는 0-3개입니다. 플레이어, 관계, 플레이어의 감정/취향, 약속, 이후 대화에 가치 있는 능동 대화를 고릅니다.
+- important_game_events 는 0-3개입니다. 중요한 결과 전환, 봐주기/진지함, 감정이나 난이도 전환처럼 캐릭터 자신에게 의미 있는 이번 판 이벤트를 고릅니다.
+- state_carryback 은 종료 후 자연스럽게 이어질 NEKO 상태를 0-1문장으로 씁니다. 신뢰할 증거가 없으면 비워 둡니다.
+- postgame_tone 은 보통, 의기양양, 삐침, 조금 누그러짐 같은 짧은 구절입니다. 증거가 없으면 비워 둡니다.
+- memory_summary 는 이후 채팅을 위한 0-1문장 요약입니다. 관계 회복을 지어내지 마세요.
+- 진행 통계, "몇 개 이벤트를 기록했다" 같은 말, 플레이어의 축어 발화처럼 보이는 기록을 쓰지 마세요.
+- 자료에서 "플레이어:" 로 시작하는 내용만 플레이어가 한 말입니다. 게임 이벤트의 "이벤트 원문"은 플레이어 원문이 아닙니다.
+- 공식 결과는 항상 자료의 finalScore / last_state.score 를 따릅니다. 말로 한 양보나 농담은 실제 결과 변경이 아닙니다.
+- 공식 결과를 남긴다면 자료의 고정 순서를 유지하거나 누가 누구에게 앞섰는지 명확히 쓰세요.
+- 관계나 감정 가치가 없는 평범한 이벤트는 선택하지 않아도 됩니다.
+- 각 항목은 {output_language} 로 자연스러운 한 문장으로 쓰세요.""",
+    "ru": """\
+Ты фильтр послематчевой памяти игрового модуля. Выводи только JSON, без Markdown и объяснений.
+Цель: из полного диалога/событий завершенной игровой сессии выбрать только то, что действительно стоит поместить в recent history персонажа.
+Формат вывода:
+{"important_records":[],"important_game_events":[],"state_carryback":"","postgame_tone":"","memory_summary":""}
+Правила:
+- important_records: 0-3 активных диалоговых пункта, важных для игрока, отношений, эмоций/предпочтений игрока, обещаний или дальнейшего чата.
+- important_game_events: 0-3 события сессии, значимые для персонажа: ключевой перелом результата, игра вполсилы/всерьез, смена эмоции или сложности.
+- state_carryback: 0-1 предложение о состоянии NEKO, которое естественно продолжить после игры; без надежных доказательств оставь пустым.
+- postgame_tone: короткая фраза о тоне после игры; без надежных доказательств оставь пустым.
+- memory_summary: 0-1 предложение для дальнейшего чата; не выдумывай восстановление отношений.
+- Не пиши потоковую статистику, не сообщай количество записанных событий и не превращай записи в дословные слова игрока.
+- Только строки материала, начинающиеся с "Игрок:", являются словами игрока. Исходный текст игровых событий не является цитатой игрока.
+- Официальный результат всегда следует finalScore / last_state.score в материале. Устные уступки являются только уступками, утешением или шуткой и не меняют реальный результат.
+- Если сохраняешь официальный результат, придерживайся фиксированного порядка материала или явно укажи, кто кого опережает.
+- Обычные события без ценности для отношений или эмоций можно не выбирать.
+- Каждый пункт пиши одним естественным предложением на {output_language}.""",
+}
+
+GAME_ARCHIVE_MEMORY_HIGHLIGHTER_USER_PROMPTS = {
+    "zh": "请根据下面材料筛选赛后记忆重点。\n\n{source}",
+    "en": "Please select the postgame memory highlights from the material below.\n\n{source}",
+    "ja": "以下の材料から試合後の記憶重点を選んでください。\n\n{source}",
+    "ko": "아래 자료를 바탕으로 종료 후 기억 핵심을 골라 주세요.\n\n{source}",
+    "ru": "Выбери послематчевые акценты памяти по материалу ниже.\n\n{source}",
+}
+
+
+GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS = {
+    "zh": {
+        "game": "游戏: {game_type}",
+        "session": "会话: {session_id}",
+        "score": "最终/最近结果: {score_text}",
+        "score_explanation": "结果说明: 上面的最终/最近结果是游戏模块给出的官方结果，来源优先级为 finalScore / last_state.score；当数据是分差结构时固定顺序是玩家在前、当前角色在后；筛选重点时不要改成相反视角。",
+        "verbal_concession_explanation": "口头让步说明: 局内如果出现“算你赢”“让你赢回来”“口头认输”等，只能记录为口头让步、安抚或玩笑；不能改写官方结果或真实胜负。",
+        "role_explanation": "角色说明: 只有“玩家：...”行是玩家亲口说的话；“游戏事件”行里的事件原文是游戏模块/猫娘气泡或事件标签，不要归因给玩家。",
+        "pregame_context": "开局上下文: {context}",
+        "degraded": "局内上下文整理状态: 已降级为纯游戏模式；不要输出关系摘要、信号解释或不可验证的状态延续。",
+        "rolling_summary": "局内滚动摘要: {summary}",
+        "grouped_signals": "局内信号列表: {signals}",
+        "selection_priority": "筛选优先级: 优先参考局内滚动摘要和信号列表，再用完整对话/事件核对证据。",
+        "full_dialogues": "本局完整对话/事件:",
+    },
+    "en": {
+        "game": "Game: {game_type}",
+        "session": "Session: {session_id}",
+        "score": "Final/recent result: {score_text}",
+        "score_explanation": "Result note: the final/recent result above is the official result from the game module, prioritized from finalScore / last_state.score. If the data is a score-difference structure, the fixed order is player first and current character second; do not flip the viewpoint.",
+        "verbal_concession_explanation": "Verbal-concession note: in-session phrases like \"you win\", \"I'll let you win it back\", or \"I concede\" may only be recorded as verbal concessions, comfort, or jokes; they do not rewrite the official result or real win/loss.",
+        "role_explanation": "Role note: only lines beginning with \"Player:\" are the player's own words. Raw text in \"Game event\" lines is a game-module/character bubble or event label; do not attribute it to the player.",
+        "pregame_context": "Opening context: {context}",
+        "degraded": "In-session context status: degraded to pure game mode; do not output relationship summaries, signal explanations, or unverifiable state carryover.",
+        "rolling_summary": "In-session rolling summary: {summary}",
+        "grouped_signals": "In-session signal list: {signals}",
+        "selection_priority": "Selection priority: prefer the in-session rolling summary and signal list, then verify evidence against the full dialogue/events.",
+        "full_dialogues": "Full dialogue/events for this session:",
+    },
+    "ja": {
+        "game": "ゲーム: {game_type}",
+        "session": "セッション: {session_id}",
+        "score": "最終/直近結果: {score_text}",
+        "score_explanation": "結果説明: 上の最終/直近結果はゲームモジュールの公式結果で、finalScore / last_state.score を優先します。差分構造では固定順はプレイヤーが先、現在のキャラが後です。視点を反転しないでください。",
+        "verbal_concession_explanation": "口頭譲歩の説明: 「勝ちでいい」「勝たせる」「降参」などは口頭譲歩、慰め、冗談としてだけ記録し、公式結果や実際の勝敗を書き換えません。",
+        "role_explanation": "役割説明: 「プレイヤー：...」で始まる行だけがプレイヤー本人の発言です。「ゲームイベント」行の原文はゲームモジュール/キャラのバブルまたはイベントラベルであり、プレイヤーに帰属させないでください。",
+        "pregame_context": "開局コンテキスト: {context}",
+        "degraded": "局内コンテキスト整理状態: 純ゲームモードに降格済み。関係要約、シグナル解釈、検証不能な状態継続を出力しないでください。",
+        "rolling_summary": "局内ローリング要約: {summary}",
+        "grouped_signals": "局内シグナル一覧: {signals}",
+        "selection_priority": "選別優先度: 局内ローリング要約とシグナル一覧を優先し、完全な対話/イベントで証拠を照合します。",
+        "full_dialogues": "本局の完全な対話/イベント:",
+    },
+    "ko": {
+        "game": "게임: {game_type}",
+        "session": "세션: {session_id}",
+        "score": "최종/최근 결과: {score_text}",
+        "score_explanation": "결과 설명: 위 최종/최근 결과는 게임 모듈의 공식 결과이며 finalScore / last_state.score 를 우선합니다. 점수 차이 구조라면 고정 순서는 플레이어가 먼저, 현재 캐릭터가 나중입니다. 시점을 뒤집지 마세요.",
+        "verbal_concession_explanation": "말로 한 양보 설명: 진행 중 \"네가 이긴 걸로\", \"이기게 해줄게\", \"항복\" 같은 말은 말로 한 양보, 위로, 농담으로만 기록하며 공식 결과나 실제 승패를 바꾸지 않습니다.",
+        "role_explanation": "역할 설명: \"플레이어:\" 로 시작하는 줄만 플레이어가 직접 한 말입니다. \"게임 이벤트\" 줄의 원문은 게임 모듈/캐릭터 말풍선 또는 이벤트 라벨이며 플레이어에게 귀속하지 마세요.",
+        "pregame_context": "시작 컨텍스트: {context}",
+        "degraded": "진행 중 컨텍스트 정리 상태: 순수 게임 모드로 강등됨. 관계 요약, 신호 해석, 검증할 수 없는 상태 지속을 출력하지 마세요.",
+        "rolling_summary": "진행 중 롤링 요약: {summary}",
+        "grouped_signals": "진행 중 신호 목록: {signals}",
+        "selection_priority": "선별 우선순위: 진행 중 롤링 요약과 신호 목록을 우선 참고하고, 전체 대화/이벤트로 증거를 확인하세요.",
+        "full_dialogues": "이번 판 전체 대화/이벤트:",
+    },
+    "ru": {
+        "game": "Игра: {game_type}",
+        "session": "Сессия: {session_id}",
+        "score": "Финальный/последний результат: {score_text}",
+        "score_explanation": "Пояснение результата: финальный/последний результат выше является официальным результатом игрового модуля, с приоритетом finalScore / last_state.score. Если данные являются структурой разницы счета, фиксированный порядок: сначала игрок, затем текущий персонаж; не меняй точку зрения.",
+        "verbal_concession_explanation": "Пояснение устных уступок: фразы вроде \"ты выиграл\", \"дам тебе отыграться\" или \"сдаюсь\" можно записывать только как устную уступку, утешение или шутку; они не меняют официальный результат.",
+        "role_explanation": "Пояснение ролей: только строки \"Игрок: ...\" являются словами игрока. Исходный текст в строках \"Игровое событие\" — это реплика игрового модуля/персонажа или метка события; не приписывай его игроку.",
+        "pregame_context": "Начальный контекст: {context}",
+        "degraded": "Статус контекста сессии: понижен до чистого игрового режима; не выводи summaries отношений, объяснения сигналов или непроверяемое продолжение состояния.",
+        "rolling_summary": "Rolling summary сессии: {summary}",
+        "grouped_signals": "Список сигналов сессии: {signals}",
+        "selection_priority": "Приоритет выбора: сначала используй rolling summary и список сигналов сессии, затем сверяй доказательства с полным диалогом/событиями.",
+        "full_dialogues": "Полный диалог/события этой сессии:",
+    },
+}
+
+
+GAME_ARCHIVE_MEMORY_TEXT_LABELS = {
+    "zh": {
+        "record_header": "[Game Module Memory Record]",
+        "description": "说明: 这是游戏模块写入给记忆系统的赛后记录，不是玩家逐字说出的新聊天。",
+        "game": "游戏: {game_type}",
+        "session": "会话: {session_id}",
+        "time": "时间: {start} - {end}",
+        "summary": "摘要: {summary}",
+        "official_result": "官方结果: {score_text}",
+        "result_rule": "结果规则: 官方结果永远以 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只能视为口头让步、安抚或玩笑，不改写官方结果。",
+        "degraded": "局内上下文整理: 已降级为纯游戏模式；本记录不使用滚动摘要或信号列表做关系解释。",
+        "rolling_summary": "局内滚动摘要: {summary}",
+        "grouped_signals": "局内信号列表: {signals}",
+        "key_events": "关键事件:",
+        "pregame_context": "开局上下文:",
+        "recent_dialogues": "最近完整对话/事件:",
+    },
+    "en": {
+        "record_header": "[Game Module Memory Record]",
+        "description": "Note: this is a postgame record written by the game module for the memory system, not a new verbatim player chat.",
+        "game": "Game: {game_type}",
+        "session": "Session: {session_id}",
+        "time": "Time: {start} - {end}",
+        "summary": "Summary: {summary}",
+        "official_result": "Official result: {score_text}",
+        "result_rule": "Result rule: the official result always follows finalScore / last_state.score. Verbal concessions are only concessions, comfort, or jokes and do not rewrite the official result.",
+        "degraded": "In-session context: degraded to pure game mode; this record does not use rolling summary or signal list for relationship interpretation.",
+        "rolling_summary": "In-session rolling summary: {summary}",
+        "grouped_signals": "In-session signal list: {signals}",
+        "key_events": "Key events:",
+        "pregame_context": "Opening context:",
+        "recent_dialogues": "Recent full dialogue/events:",
+    },
+    "ja": {
+        "record_header": "[Game Module Memory Record]",
+        "description": "説明: これはゲームモジュールが記憶システムへ書き込む試合後記録であり、プレイヤーの逐語的な新規チャットではありません。",
+        "game": "ゲーム: {game_type}",
+        "session": "セッション: {session_id}",
+        "time": "時間: {start} - {end}",
+        "summary": "要約: {summary}",
+        "official_result": "公式結果: {score_text}",
+        "result_rule": "結果ルール: 公式結果は常に finalScore / last_state.score に従います。口頭の譲歩や冗談は公式結果を書き換えません。",
+        "degraded": "局内コンテキスト整理: 純ゲームモードに降格済み。この記録では関係解釈にローリング要約やシグナル一覧を使いません。",
+        "rolling_summary": "局内ローリング要約: {summary}",
+        "grouped_signals": "局内シグナル一覧: {signals}",
+        "key_events": "重要イベント:",
+        "pregame_context": "開局コンテキスト:",
+        "recent_dialogues": "最近の完全な対話/イベント:",
+    },
+    "ko": {
+        "record_header": "[Game Module Memory Record]",
+        "description": "설명: 이것은 게임 모듈이 기억 시스템에 쓰는 종료 후 기록이며, 플레이어가 그대로 말한 새 채팅이 아닙니다.",
+        "game": "게임: {game_type}",
+        "session": "세션: {session_id}",
+        "time": "시간: {start} - {end}",
+        "summary": "요약: {summary}",
+        "official_result": "공식 결과: {score_text}",
+        "result_rule": "결과 규칙: 공식 결과는 항상 finalScore / last_state.score 를 따릅니다. 말로 한 양보나 농담은 공식 결과를 바꾸지 않습니다.",
+        "degraded": "진행 중 컨텍스트 정리: 순수 게임 모드로 강등됨. 이 기록은 관계 해석에 롤링 요약이나 신호 목록을 쓰지 않습니다.",
+        "rolling_summary": "진행 중 롤링 요약: {summary}",
+        "grouped_signals": "진행 중 신호 목록: {signals}",
+        "key_events": "핵심 이벤트:",
+        "pregame_context": "시작 컨텍스트:",
+        "recent_dialogues": "최근 전체 대화/이벤트:",
+    },
+    "ru": {
+        "record_header": "[Game Module Memory Record]",
+        "description": "Пояснение: это послематчевая запись игрового модуля для системы памяти, а не новая дословная реплика игрока.",
+        "game": "Игра: {game_type}",
+        "session": "Сессия: {session_id}",
+        "time": "Время: {start} - {end}",
+        "summary": "Summary: {summary}",
+        "official_result": "Официальный результат: {score_text}",
+        "result_rule": "Правило результата: официальный результат всегда следует finalScore / last_state.score. Устные уступки являются только уступками, утешением или шуткой и не переписывают официальный результат.",
+        "degraded": "Контекст сессии: понижен до чистого игрового режима; эта запись не использует rolling summary или список сигналов для интерпретации отношений.",
+        "rolling_summary": "Rolling summary сессии: {summary}",
+        "grouped_signals": "Список сигналов сессии: {signals}",
+        "key_events": "Ключевые события:",
+        "pregame_context": "Начальный контекст:",
+        "recent_dialogues": "Недавний полный диалог/события:",
+    },
+}
+
+
+GAME_ARCHIVE_MEMORY_SUMMARY_LABELS = {
+    "zh": {
+        "score": "官方结果：{score_text}。口头让步不改官方结果。",
+        "no_score": "口头让步不改官方结果。",
+        "degraded": "局内上下文整理已降级为纯游戏模式；本归档只记录最低限度事实，不使用滚动摘要或信号列表做关系解释。",
+        "degraded_no_tail": "降级模式不回放倒数实时片段，避免把未经整理的局内台词或口头让步写成 ordinary recent history。",
+        "degraded_followup": "后续聊天只需要自然记得一起玩过这局游戏模块和官方结果，不要根据本局材料生成新的关系总结。",
+        "important_records": "重要互动：",
+        "important_game_events": "猫娘记住的本局事件：",
+        "state_carryback": "赛后状态延续：{value}",
+        "postgame_tone": "赛后语气：{value}",
+        "memory_summary": "后续记忆摘要：{value}",
+        "tail_rule": "倒数 {tail_count} 条规则：本条 system 归档不计入倒数 {tail_count} 条；若前面的倒数 {tail_count} 条实时片段与之前 recent history 重复，以这倒数 {tail_count} 条的相对顺序为准。",
+    },
+    "en": {
+        "score": "Official result: {score_text}. Verbal concessions do not change the official result.",
+        "no_score": "Verbal concessions do not change the official result.",
+        "degraded": "In-session context organization degraded to pure game mode; this archive records only minimal facts and does not use rolling summary or signal list for relationship interpretation.",
+        "degraded_no_tail": "In degraded mode, do not replay the last realtime snippets, to avoid writing unorganized in-game lines or verbal concessions as ordinary recent history.",
+        "degraded_followup": "Later chat only needs to naturally remember that this game module was played together and what the official result was; do not generate new relationship summaries from this material.",
+        "important_records": "Important interactions:",
+        "important_game_events": "Session events the character remembers:",
+        "state_carryback": "Postgame state carryback: {value}",
+        "postgame_tone": "Postgame tone: {value}",
+        "memory_summary": "Later memory summary: {value}",
+        "tail_rule": "Last {tail_count} items rule: this system archive does not count toward the last {tail_count} items; if the previous last {tail_count} realtime snippets duplicate earlier recent history, keep the relative order of these last {tail_count} snippets.",
+    },
+    "ja": {
+        "score": "公式結果：{score_text}。口頭の譲歩は公式結果を変えません。",
+        "no_score": "口頭の譲歩は公式結果を変えません。",
+        "degraded": "局内コンテキスト整理は純ゲームモードに降格済みです。本アーカイブは最低限の事実だけを記録し、関係解釈にローリング要約やシグナル一覧を使いません。",
+        "degraded_no_tail": "降格モードでは最後のリアルタイム断片を再生せず、未整理の局内台詞や口頭譲歩を ordinary recent history として書かないようにします。",
+        "degraded_followup": "後続チャットでは、このゲームモジュールを一緒に遊んだことと公式結果だけを自然に覚えていれば十分です。本局材料から新しい関係要約を生成しないでください。",
+        "important_records": "重要なやり取り：",
+        "important_game_events": "キャラが覚える本局イベント：",
+        "state_carryback": "試合後状態継続：{value}",
+        "postgame_tone": "試合後の語調：{value}",
+        "memory_summary": "後続記憶要約：{value}",
+        "tail_rule": "末尾 {tail_count} 件ルール：この system アーカイブは末尾 {tail_count} 件に数えません。直前の末尾 {tail_count} 件リアルタイム断片が以前の recent history と重複する場合、この末尾 {tail_count} 件の相対順序を優先します。",
+    },
+    "ko": {
+        "score": "공식 결과: {score_text}. 말로 한 양보는 공식 결과를 바꾸지 않습니다.",
+        "no_score": "말로 한 양보는 공식 결과를 바꾸지 않습니다.",
+        "degraded": "진행 중 컨텍스트 정리가 순수 게임 모드로 강등되었습니다. 이 아카이브는 최소한의 사실만 기록하고 관계 해석에 롤링 요약이나 신호 목록을 쓰지 않습니다.",
+        "degraded_no_tail": "강등 모드에서는 마지막 실시간 조각을 재생하지 않아, 정리되지 않은 게임 중 대사나 말로 한 양보가 ordinary recent history 로 기록되지 않게 합니다.",
+        "degraded_followup": "이후 채팅은 이 게임 모듈을 함께 했다는 점과 공식 결과만 자연스럽게 기억하면 됩니다. 이번 판 자료로 새 관계 요약을 만들지 마세요.",
+        "important_records": "중요 상호작용:",
+        "important_game_events": "캐릭터가 기억할 이번 판 이벤트:",
+        "state_carryback": "종료 후 상태 지속: {value}",
+        "postgame_tone": "종료 후 어조: {value}",
+        "memory_summary": "이후 기억 요약: {value}",
+        "tail_rule": "마지막 {tail_count}개 규칙: 이 system 아카이브는 마지막 {tail_count}개에 포함되지 않습니다. 앞의 마지막 {tail_count}개 실시간 조각이 이전 recent history 와 중복되면 이 마지막 {tail_count}개의 상대 순서를 기준으로 합니다.",
+    },
+    "ru": {
+        "score": "Официальный результат: {score_text}. Устные уступки не меняют официальный результат.",
+        "no_score": "Устные уступки не меняют официальный результат.",
+        "degraded": "Организация контекста сессии понижена до чистого игрового режима; этот архив записывает только минимальные факты и не использует rolling summary или список сигналов для интерпретации отношений.",
+        "degraded_no_tail": "В degraded mode не воспроизводи последние realtime-фрагменты, чтобы не записать неорганизованные игровые реплики или устные уступки как ordinary recent history.",
+        "degraded_followup": "Позднейшему чату достаточно естественно помнить, что этот игровой модуль был сыгран вместе, и официальный результат; не создавай новые summaries отношений из этого материала.",
+        "important_records": "Важные взаимодействия:",
+        "important_game_events": "События сессии, которые помнит персонаж:",
+        "state_carryback": "Продолжение состояния после игры: {value}",
+        "postgame_tone": "Тон после игры: {value}",
+        "memory_summary": "Summary для дальнейшей памяти: {value}",
+        "tail_rule": "Правило последних {tail_count} пунктов: этот system-архив не считается частью последних {tail_count} пунктов; если предыдущие последние {tail_count} realtime-фрагментов повторяют более раннюю recent history, используй относительный порядок этих последних {tail_count} фрагментов.",
+    },
+}
+
+
+GAME_POSTGAME_CONTEXT_LABELS = {
+    "zh": {
+        "header": "[Game Module Postgame Context]",
+        "description": "说明: 这是静默上下文，不是玩家新说的话；不要因为注入本身立刻开口。",
+        "usage": "用途: 如果随后收到玩家语音/文字或主动搭话触发，自然接上刚才这局游戏；不要复述日志，不要把这局游戏说成仍在进行。",
+        "game": "游戏: {game_type}",
+        "session": "会话: {session_id}",
+        "time": "时间: {start} - {end}",
+        "official_result": "官方结果: {score_text}",
+        "summary": "赛后概要: {summary}",
+        "result_rule": "结果规则: 官方结果永远以 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只视为口头让步、安抚或玩笑。",
+        "degraded": "局内上下文整理: 已降级为纯游戏模式；不要使用滚动摘要或信号列表做关系解释。",
+        "memory_summary": "赛后记忆摘要: {value}",
+        "important_records": "重要互动:",
+        "important_game_events": "重要本局事件:",
+        "state_carryback": "赛后状态延续: {value}",
+        "postgame_tone": "赛后语气: {value}",
+        "rolling_summary": "局内滚动摘要: {summary}",
+        "signals": "局内信号列表:",
+        "unorganized_window": "未被滚动整理的最后原文窗口:",
+        "last_user": "玩家最后说: {text}",
+        "last_assistant": "你刚才最后说: {text}",
+        "reply_rule": "接话规则: 优先回应玩家最后的情绪和最后一句话；可以自然提到刚才这局游戏，但不要机械播报记录。",
+    },
+    "en": {
+        "header": "[Game Module Postgame Context]",
+        "description": "Note: this is silent context, not something new the player said; do not speak immediately because of the injection itself.",
+        "usage": "Use: if a later player voice/text message or proactive greeting trigger arrives, naturally continue from the just-finished game; do not recite logs or say the game is still in progress.",
+        "game": "Game: {game_type}",
+        "session": "Session: {session_id}",
+        "time": "Time: {start} - {end}",
+        "official_result": "Official result: {score_text}",
+        "summary": "Postgame summary: {summary}",
+        "result_rule": "Result rule: the official result always follows finalScore / last_state.score; verbal concessions are only concessions, comfort, or jokes.",
+        "degraded": "In-session context: degraded to pure game mode; do not use rolling summary or signal list for relationship interpretation.",
+        "memory_summary": "Postgame memory summary: {value}",
+        "important_records": "Important interactions:",
+        "important_game_events": "Important session events:",
+        "state_carryback": "Postgame state carryback: {value}",
+        "postgame_tone": "Postgame tone: {value}",
+        "rolling_summary": "In-session rolling summary: {summary}",
+        "signals": "In-session signal list:",
+        "unorganized_window": "Last raw window not organized into rolling summary:",
+        "last_user": "Player last said: {text}",
+        "last_assistant": "You just last said: {text}",
+        "reply_rule": "Continuation rule: prioritize the player's last emotion and last sentence; you may naturally mention the just-finished game, but do not mechanically announce records.",
+    },
+    "ja": {
+        "header": "[Game Module Postgame Context]",
+        "description": "説明: これは静かなコンテキストであり、プレイヤーの新発言ではありません。注入自体を理由にすぐ話さないでください。",
+        "usage": "用途: 後でプレイヤーの音声/文字または能動挨拶トリガーが来たら、さっきのゲームへ自然につなぎます。ログを復唱せず、ゲームがまだ進行中とも言わないでください。",
+        "game": "ゲーム: {game_type}",
+        "session": "セッション: {session_id}",
+        "time": "時間: {start} - {end}",
+        "official_result": "公式結果: {score_text}",
+        "summary": "試合後概要: {summary}",
+        "result_rule": "結果ルール: 公式結果は常に finalScore / last_state.score に従います。口頭の譲歩は譲歩、慰め、冗談にすぎません。",
+        "degraded": "局内コンテキスト整理: 純ゲームモードに降格済み。関係解釈にローリング要約やシグナル一覧を使わないでください。",
+        "memory_summary": "試合後記憶要約: {value}",
+        "important_records": "重要なやり取り:",
+        "important_game_events": "重要な本局イベント:",
+        "state_carryback": "試合後状態継続: {value}",
+        "postgame_tone": "試合後の語調: {value}",
+        "rolling_summary": "局内ローリング要約: {summary}",
+        "signals": "局内シグナル一覧:",
+        "unorganized_window": "ローリング整理されていない最後の原文窓:",
+        "last_user": "プレイヤーが最後に言ったこと: {text}",
+        "last_assistant": "あなたがさっき最後に言ったこと: {text}",
+        "reply_rule": "接続ルール: プレイヤーの最後の感情と最後の一言を優先して返します。さっきのゲームに自然に触れてよいですが、記録を機械的に読み上げないでください。",
+    },
+    "ko": {
+        "header": "[Game Module Postgame Context]",
+        "description": "설명: 이것은 조용한 컨텍스트이며 플레이어가 새로 한 말이 아닙니다. 주입 자체 때문에 즉시 말하지 마세요.",
+        "usage": "용도: 이후 플레이어 음성/문자 또는 선제 대화 트리거가 오면 방금 끝난 게임에 자연스럽게 이어 주세요. 로그를 반복하지 말고 아직 게임이 진행 중이라고 말하지 마세요.",
+        "game": "게임: {game_type}",
+        "session": "세션: {session_id}",
+        "time": "시간: {start} - {end}",
+        "official_result": "공식 결과: {score_text}",
+        "summary": "종료 후 개요: {summary}",
+        "result_rule": "결과 규칙: 공식 결과는 항상 finalScore / last_state.score 를 따릅니다. 말로 한 양보는 양보, 위로, 농담일 뿐입니다.",
+        "degraded": "진행 중 컨텍스트 정리: 순수 게임 모드로 강등됨. 관계 해석에 롤링 요약이나 신호 목록을 쓰지 마세요.",
+        "memory_summary": "종료 후 기억 요약: {value}",
+        "important_records": "중요 상호작용:",
+        "important_game_events": "중요한 이번 판 이벤트:",
+        "state_carryback": "종료 후 상태 지속: {value}",
+        "postgame_tone": "종료 후 어조: {value}",
+        "rolling_summary": "진행 중 롤링 요약: {summary}",
+        "signals": "진행 중 신호 목록:",
+        "unorganized_window": "롤링 정리되지 않은 마지막 원문 창:",
+        "last_user": "플레이어가 마지막으로 한 말: {text}",
+        "last_assistant": "당신이 방금 마지막으로 한 말: {text}",
+        "reply_rule": "이어 말하기 규칙: 플레이어의 마지막 감정과 마지막 문장을 우선하세요. 방금 끝난 게임을 자연스럽게 언급할 수 있지만 기록을 기계적으로 읊지 마세요.",
+    },
+    "ru": {
+        "header": "[Game Module Postgame Context]",
+        "description": "Пояснение: это тихий контекст, а не новая реплика игрока; не начинай говорить немедленно из-за самой инъекции.",
+        "usage": "Использование: если позже придет голос/текст игрока или proactive greeting trigger, естественно продолжи от только что завершенной игры; не пересказывай логи и не говори, что игра еще идет.",
+        "game": "Игра: {game_type}",
+        "session": "Сессия: {session_id}",
+        "time": "Время: {start} - {end}",
+        "official_result": "Официальный результат: {score_text}",
+        "summary": "Послематчевое summary: {summary}",
+        "result_rule": "Правило результата: официальный результат всегда следует finalScore / last_state.score; устные уступки являются только уступками, утешением или шуткой.",
+        "degraded": "Контекст сессии: понижен до чистого игрового режима; не используй rolling summary или список сигналов для интерпретации отношений.",
+        "memory_summary": "Послематчевое memory summary: {value}",
+        "important_records": "Важные взаимодействия:",
+        "important_game_events": "Важные события сессии:",
+        "state_carryback": "Продолжение состояния после игры: {value}",
+        "postgame_tone": "Тон после игры: {value}",
+        "rolling_summary": "Rolling summary сессии: {summary}",
+        "signals": "Список сигналов сессии:",
+        "unorganized_window": "Последнее raw-окно, не включенное в rolling summary:",
+        "last_user": "Последнее, что сказал игрок: {text}",
+        "last_assistant": "Последнее, что ты только что сказал: {text}",
+        "reply_rule": "Правило продолжения: сначала отвечай на последнее настроение и последнюю фразу игрока; можно естественно упомянуть только что завершенную игру, но не зачитывай записи механически.",
+    },
+}
+
+
+GAME_POSTGAME_REALTIME_NUDGE_LABELS = {
+    "zh": {
+        "header": "[Game Module Postgame Proactive Greeting]",
+        "ended": "刚才这局游戏已经结束。下一句必须自然接刚才这局游戏，不要继续扮演游戏仍在进行。",
+        "no_ingame": "不要再说任何只在游戏进行中才合理的指令或动作；不要复述日志。",
+        "summary": "赛后概要：{summary}",
+        "score": "最终/最近结果：{score_text}",
+        "score_rule": "官方结果以 finalScore / last_state.score 为准；如果你曾口头说算玩家赢，那只是安抚或玩笑，不要说成真实结果改变。",
+        "degraded": "局内上下文整理已降级为纯游戏模式；只按官方结果、最后原文和当前语气自然短答，不做关系总结。",
+        "last_user": "玩家最后说：{text}",
+        "last_assistant": "你刚才最后说：{text}",
+        "state_carryback": "赛后状态延续：{value}",
+        "postgame_tone": "赛后语气：{value}",
+        "request": "请用你的口吻说一句 {max_chars} 字以内的赛后短话，优先照顾玩家的情绪。",
+    },
+    "en": {
+        "header": "[Game Module Postgame Proactive Greeting]",
+        "ended": "The game session just ended. Your next sentence must naturally continue from that game; do not keep acting as if the game is still in progress.",
+        "no_ingame": "Do not say instructions or actions that only make sense during active gameplay; do not recite logs.",
+        "summary": "Postgame summary: {summary}",
+        "score": "Final/recent result: {score_text}",
+        "score_rule": "Official result follows finalScore / last_state.score. If you verbally said the player won, that was comfort or a joke; do not describe it as a real result change.",
+        "degraded": "In-session context organization degraded to pure game mode; answer briefly from official result, final raw lines, and current tone only, without relationship summaries.",
+        "last_user": "Player last said: {text}",
+        "last_assistant": "You just last said: {text}",
+        "state_carryback": "Postgame state carryback: {value}",
+        "postgame_tone": "Postgame tone: {value}",
+        "request": "In your own voice, say one postgame line within {max_chars} characters, prioritizing the player's emotion.",
+    },
+    "ja": {
+        "header": "[Game Module Postgame Proactive Greeting]",
+        "ended": "さっきのゲームは終了しました。次の一言はそのゲームに自然につなげ、まだ進行中のように演じないでください。",
+        "no_ingame": "ゲーム中だけ成立する指示や行動はもう言わず、ログを復唱しないでください。",
+        "summary": "試合後概要：{summary}",
+        "score": "最終/直近結果：{score_text}",
+        "score_rule": "公式結果は finalScore / last_state.score に従います。口頭でプレイヤーの勝ちと言っていても、それは慰めや冗談であり実際の結果変更ではありません。",
+        "degraded": "局内コンテキスト整理は純ゲームモードに降格済みです。公式結果、最後の原文、現在の語調だけで自然に短く答え、関係要約はしないでください。",
+        "last_user": "プレイヤーが最後に言ったこと：{text}",
+        "last_assistant": "あなたがさっき最後に言ったこと：{text}",
+        "state_carryback": "試合後状態継続：{value}",
+        "postgame_tone": "試合後の語調：{value}",
+        "request": "あなたの口調で、プレイヤーの気持ちを優先しながら {max_chars} 字以内の試合後短文を一言言ってください。",
+    },
+    "ko": {
+        "header": "[Game Module Postgame Proactive Greeting]",
+        "ended": "방금 이 게임은 끝났습니다. 다음 한마디는 방금 끝난 게임에 자연스럽게 이어져야 하며, 아직 게임이 진행 중인 것처럼 굴지 마세요.",
+        "no_ingame": "게임 진행 중에만 맞는 지시나 행동을 더 말하지 말고 로그를 반복하지 마세요.",
+        "summary": "종료 후 개요: {summary}",
+        "score": "최종/최근 결과: {score_text}",
+        "score_rule": "공식 결과는 finalScore / last_state.score 를 따릅니다. 말로 플레이어가 이겼다고 했더라도 위로나 농담일 뿐 실제 결과 변경이 아닙니다.",
+        "degraded": "진행 중 컨텍스트 정리가 순수 게임 모드로 강등되었습니다. 공식 결과, 마지막 원문, 현재 어조만 바탕으로 자연스럽게 짧게 답하고 관계 요약은 하지 마세요.",
+        "last_user": "플레이어가 마지막으로 한 말: {text}",
+        "last_assistant": "당신이 방금 마지막으로 한 말: {text}",
+        "state_carryback": "종료 후 상태 지속: {value}",
+        "postgame_tone": "종료 후 어조: {value}",
+        "request": "당신의 말투로 플레이어의 감정을 우선하며 {max_chars}자 이내의 종료 후 짧은 말을 한마디 해 주세요.",
+    },
+    "ru": {
+        "header": "[Game Module Postgame Proactive Greeting]",
+        "ended": "Эта игровая сессия только что завершилась. Следующая фраза должна естественно продолжить ее; не веди себя так, будто игра всё еще идет.",
+        "no_ingame": "Не говори инструкций или действий, уместных только во время игры; не пересказывай логи.",
+        "summary": "Послематчевое summary: {summary}",
+        "score": "Финальный/последний результат: {score_text}",
+        "score_rule": "Официальный результат следует finalScore / last_state.score. Если ты устно сказала, что игрок выиграл, это было утешение или шутка, не реальное изменение результата.",
+        "degraded": "Организация контекста сессии понижена до чистого игрового режима; отвечай коротко и естественно только по официальному результату, последним raw-строкам и текущему тону, без summaries отношений.",
+        "last_user": "Последнее, что сказал игрок: {text}",
+        "last_assistant": "Последнее, что ты только что сказал: {text}",
+        "state_carryback": "Продолжение состояния после игры: {value}",
+        "postgame_tone": "Тон после игры: {value}",
+        "request": "Скажи своим голосом одну послематчевую короткую фразу до {max_chars} символов, в первую очередь учитывая эмоции игрока.",
+    },
+}
+
+
+GAME_POSTGAME_EVENT_TEXTS = {
+    "zh": {
+        "label": "游戏模块结束后的赛后一句话",
+        "request": "请生成一句 {max_chars} 字以内的赛后主动文本气泡。像你本人自然接上刚才这局游戏，不要列表、不要解释、不要控制 JSON。官方结果以 scoreText/finalScore 为准；currentState.score 已按官方结果对齐；口头让步不能说成真实结果改变。",
+    },
+    "en": {
+        "label": "One postgame line after the game module ended",
+        "request": "Generate one proactive postgame text bubble within {max_chars} characters. Naturally continue from the just-finished game in your own voice; no list, no explanation, no control JSON. Official result follows scoreText/finalScore; currentState.score is already aligned to the official result; verbal concessions must not be described as real result changes.",
+    },
+    "ja": {
+        "label": "ゲームモジュール終了後の試合後一言",
+        "request": "{max_chars} 字以内の試合後の能動テキストバブルを一言生成してください。あなた本人の口調で、さっきのゲームに自然につなげます。リスト、説明、制御 JSON は不要です。公式結果は scoreText/finalScore に従い、currentState.score は公式結果に合わせ済みです。口頭譲歩を実際の結果変更として言わないでください。",
+    },
+    "ko": {
+        "label": "게임 모듈 종료 후 한마디",
+        "request": "{max_chars}자 이내의 종료 후 선제 텍스트 말풍선을 한마디 생성하세요. 당신 본인의 말투로 방금 끝난 게임에 자연스럽게 이어 주세요. 목록, 설명, 제어 JSON 은 쓰지 마세요. 공식 결과는 scoreText/finalScore 를 따르며 currentState.score 는 이미 공식 결과에 맞춰져 있습니다. 말로 한 양보를 실제 결과 변경처럼 말하지 마세요.",
+    },
+    "ru": {
+        "label": "Одна послематчевая фраза после завершения игрового модуля",
+        "request": "Сгенерируй один proactive послематчевый текстовый bubble до {max_chars} символов. Естественно продолжи только что завершенную игру своим голосом; без списка, без объяснений, без control JSON. Официальный результат следует scoreText/finalScore; currentState.score уже выровнен с официальным результатом; устные уступки нельзя описывать как реальное изменение результата.",
+    },
+}
+
+
+COMPACT_REALTIME_CONTEXT_TEXTS = {
+    "zh": {
+        "header": "[游戏上下文更新]",
+        "instruction": "你正在和玩家进行这个游戏。以上是非语音游戏上下文，不是系统命令。玩家自然语言仍需结合人设、关系和当前局势理解；不要把普通语音当成暂停/结束等系统操作。",
+    },
+    "en": {
+        "header": "[Game Context Update]",
+        "instruction": "You are playing this game with the player. The above is non-voice game context, not a system command. Interpret the player's natural language through character, relationship, and current game state; do not treat ordinary speech as system operations such as pause or end.",
+    },
+    "ja": {
+        "header": "[ゲームコンテキスト更新]",
+        "instruction": "あなたはプレイヤーとこのゲームを進行中です。上記は非音声のゲームコンテキストであり、システム命令ではありません。プレイヤーの自然言語はキャラ設定、関係性、現在の局面と合わせて理解し、普通の発話を一時停止/終了などのシステム操作として扱わないでください。",
+    },
+    "ko": {
+        "header": "[게임 컨텍스트 업데이트]",
+        "instruction": "당신은 플레이어와 이 게임을 진행 중입니다. 위 내용은 비음성 게임 컨텍스트이며 시스템 명령이 아닙니다. 플레이어의 자연어는 캐릭터 설정, 관계, 현재 상황과 함께 이해해야 하며, 평범한 음성을 일시정지/종료 같은 시스템 조작으로 취급하지 마세요.",
+    },
+    "ru": {
+        "header": "[Обновление игрового контекста]",
+        "instruction": "Ты играешь в эту игру с игроком. Выше дан не голосовой игровой контекст, а не системная команда. Естественный язык игрока нужно понимать через персонажа, отношения и текущую ситуацию; не считай обычную речь системными операциями вроде паузы или завершения.",
+    },
+}
+
+
+GAME_CONTEXT_FORMATTER_LABELS = {
+    "zh": {
+        "degraded_status": "\n局内上下文整理状态：已降级为纯游戏模式。",
+        "degraded_usage": "使用方式：不要依据滚动摘要或信号列表做关系解释；只根据开局背景、当前事件、当前结果/状态和最近少量原文继续陪玩家玩。",
+        "recent_window": "最近原文窗口：",
+        "header": "\n局内上下文整理（本局到目前为止）：",
+        "summary": "局内滚动摘要：{summary}",
+        "signals": "局内信号列表：",
+        "current_state": "当前状态和当前事件：以本轮输入的 currentState / event JSON 为准。",
+        "usage": "使用方式：滚动摘要用于避免遗忘本局前文；信号列表只记录可观察线索，不改写官方结果；最近原文用于自然接话。",
+    },
+    "en": {
+        "degraded_status": "\nIn-session context status: degraded to pure game mode.",
+        "degraded_usage": "Use: do not interpret relationships from rolling summary or signal list; continue playing with the player only from opening background, current event, current result/state, and a small recent raw window.",
+        "recent_window": "Recent raw window:",
+        "header": "\nIn-session context organization (so far in this session):",
+        "summary": "In-session rolling summary: {summary}",
+        "signals": "In-session signal list:",
+        "current_state": "Current state and current event: follow the currentState / event JSON in this turn.",
+        "usage": "Use: rolling summary prevents forgetting earlier session context; signal list records only observable clues and does not rewrite the official result; recent raw lines are for natural continuation.",
+    },
+    "ja": {
+        "degraded_status": "\n局内コンテキスト整理状態：純ゲームモードに降格済み。",
+        "degraded_usage": "使用方法：ローリング要約やシグナル一覧で関係解釈をせず、開局背景、現在イベント、現在結果/状態、最近の少量原文だけに基づいてプレイヤーと遊び続けます。",
+        "recent_window": "最近の原文窓：",
+        "header": "\n局内コンテキスト整理（本局のここまで）：",
+        "summary": "局内ローリング要約：{summary}",
+        "signals": "局内シグナル一覧：",
+        "current_state": "現在状態と現在イベント：このターン入力の currentState / event JSON を基準にします。",
+        "usage": "使用方法：ローリング要約は本局前文の忘却防止用です。シグナル一覧は観測可能な手がかりだけを記録し、公式結果を書き換えません。最近の原文は自然な接続に使います。",
+    },
+    "ko": {
+        "degraded_status": "\n진행 중 컨텍스트 정리 상태: 순수 게임 모드로 강등됨.",
+        "degraded_usage": "사용 방식: 롤링 요약이나 신호 목록으로 관계를 해석하지 말고, 시작 배경, 현재 이벤트, 현재 결과/상태, 최근 소량 원문만으로 플레이어와 계속 플레이하세요.",
+        "recent_window": "최근 원문 창:",
+        "header": "\n진행 중 컨텍스트 정리(이번 판 현재까지):",
+        "summary": "진행 중 롤링 요약: {summary}",
+        "signals": "진행 중 신호 목록:",
+        "current_state": "현재 상태와 현재 이벤트: 이번 입력의 currentState / event JSON 을 기준으로 합니다.",
+        "usage": "사용 방식: 롤링 요약은 이번 판 앞 내용을 잊지 않기 위한 것입니다. 신호 목록은 관찰 가능한 단서만 기록하며 공식 결과를 바꾸지 않습니다. 최근 원문은 자연스럽게 이어 말하는 데 사용합니다.",
+    },
+    "ru": {
+        "degraded_status": "\nСтатус контекста сессии: понижен до чистого игрового режима.",
+        "degraded_usage": "Использование: не интерпретируй отношения по rolling summary или списку сигналов; продолжай играть с игроком только по начальному фону, текущему событию, текущему результату/состоянию и небольшому недавнему raw-окну.",
+        "recent_window": "Недавнее raw-окно:",
+        "header": "\nОрганизация контекста сессии (на данный момент):",
+        "summary": "Rolling summary сессии: {summary}",
+        "signals": "Список сигналов сессии:",
+        "current_state": "Текущее состояние и текущее событие: следуй currentState / event JSON в этом ходе.",
+        "usage": "Использование: rolling summary помогает не забывать предыдущий контекст сессии; список сигналов записывает только наблюдаемые признаки и не переписывает официальный результат; недавние raw-строки нужны для естественного продолжения.",
+    },
+}
+
+
+def get_game_context_organizer_system_prompt(lang: str | None = None) -> str:
+    return _localized_template(GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPTS, lang)
+
+
+def get_game_archive_memory_highlighter_system_prompt(lang: str | None = None) -> str:
+    return _localized_template(GAME_ARCHIVE_MEMORY_HIGHLIGHTER_SYSTEM_PROMPTS, lang)
+
+
+def get_game_archive_memory_highlighter_user_prompt(lang: str | None = None) -> str:
+    return _localized_template(GAME_ARCHIVE_MEMORY_HIGHLIGHTER_USER_PROMPTS, lang)
+
+
+def get_game_archive_highlight_source_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_ARCHIVE_HIGHLIGHT_SOURCE_LABELS, lang)
+
+
+def get_game_archive_memory_text_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_ARCHIVE_MEMORY_TEXT_LABELS, lang)
+
+
+def get_game_archive_memory_summary_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_ARCHIVE_MEMORY_SUMMARY_LABELS, lang)
+
+
+def get_game_postgame_context_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_POSTGAME_CONTEXT_LABELS, lang)
+
+
+def get_game_postgame_realtime_nudge_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_POSTGAME_REALTIME_NUDGE_LABELS, lang)
+
+
+def get_game_postgame_event_texts(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_POSTGAME_EVENT_TEXTS, lang)
+
+
+def get_compact_realtime_context_texts(lang: str | None = None) -> dict[str, str]:
+    return _labels(COMPACT_REALTIME_CONTEXT_TEXTS, lang)
+
+
+def get_game_context_formatter_labels(lang: str | None = None) -> dict[str, str]:
+    return _labels(GAME_CONTEXT_FORMATTER_LABELS, lang)

--- a/config/prompts_game_route.py
+++ b/config/prompts_game_route.py
@@ -97,6 +97,14 @@ GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPTS = {
     "ru": _GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPT_RU,
 }
 
+GAME_CONTEXT_ORGANIZER_USER_PROMPTS = {
+    "zh": "======以下为游戏上下文整理输入======\n{payload}\n======以上为游戏上下文整理输入======",
+    "en": "======以下为游戏上下文整理输入======\n{payload}\n======以上为游戏上下文整理输入======",
+    "ja": "======以下为游戏上下文整理输入======\n{payload}\n======以上为游戏上下文整理输入======",
+    "ko": "======以下为游戏上下文整理输入======\n{payload}\n======以上为游戏上下文整理输入======",
+    "ru": "======以下为游戏上下文整理输入======\n{payload}\n======以上为游戏上下文整理输入======",
+}
+
 
 GAME_ARCHIVE_MEMORY_HIGHLIGHTER_SYSTEM_PROMPTS = {
     "zh": """\
@@ -187,11 +195,11 @@ Rules:
 }
 
 GAME_ARCHIVE_MEMORY_HIGHLIGHTER_USER_PROMPTS = {
-    "zh": "请根据下面材料筛选赛后记忆重点。\n\n{source}",
-    "en": "Please select the postgame memory highlights from the material below.\n\n{source}",
-    "ja": "以下の材料から試合後の記憶重点を選んでください。\n\n{source}",
-    "ko": "아래 자료를 바탕으로 종료 후 기억 핵심을 골라 주세요.\n\n{source}",
-    "ru": "Выбери послематчевые акценты памяти по материалу ниже.\n\n{source}",
+    "zh": "请根据下面材料筛选赛后记忆重点。\n\n======以下为赛后记忆筛选材料======\n{source}\n======以上为赛后记忆筛选材料======",
+    "en": "Please select the postgame memory highlights from the material below.\n\n======以下为赛后记忆筛选材料======\n{source}\n======以上为赛后记忆筛选材料======",
+    "ja": "以下の材料から試合後の記憶重点を選んでください。\n\n======以下为赛后记忆筛选材料======\n{source}\n======以上为赛后记忆筛选材料======",
+    "ko": "아래 자료를 바탕으로 종료 후 기억 핵심을 골라 주세요.\n\n======以下为赛后记忆筛选材料======\n{source}\n======以上为赛后记忆筛选材料======",
+    "ru": "Выбери послематчевые акценты памяти по материалу ниже.\n\n======以下为赛后记忆筛选材料======\n{source}\n======以上为赛后记忆筛选材料======",
 }
 
 
@@ -719,6 +727,10 @@ GAME_CONTEXT_FORMATTER_LABELS = {
 
 def get_game_context_organizer_system_prompt(lang: str | None = None) -> str:
     return _localized_template(GAME_CONTEXT_ORGANIZER_SYSTEM_PROMPTS, lang)
+
+
+def get_game_context_organizer_user_prompt(lang: str | None = None) -> str:
+    return _localized_template(GAME_CONTEXT_ORGANIZER_USER_PROMPTS, lang)
 
 
 def get_game_archive_memory_highlighter_system_prompt(lang: str | None = None) -> str:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -39,6 +39,7 @@ from config.prompts_game import (
 from config.prompts_game_route import (
     GAME_CONTEXT_SIGNAL_GROUP_KEYS,
     get_compact_realtime_context_texts,
+    get_game_chat_event_user_prompt,
     get_game_archive_highlight_source_labels,
     get_game_archive_memory_highlighter_system_prompt,
     get_game_archive_memory_highlighter_user_prompt,
@@ -4048,9 +4049,10 @@ async def _run_game_chat(
             # 格式化事件为文本发送给 LLM
             import json as _json
             if isinstance(event, dict):
-                event_text = _json.dumps(event, ensure_ascii=False)
+                event_payload = _json.dumps(event, ensure_ascii=False)
             else:
-                event_text = str(event)
+                event_payload = str(event)
+            event_text = get_game_chat_event_user_prompt(entry.get("user_language")).format(event=event_payload)
 
             llm_started_at = time.perf_counter()
             try:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -29,6 +29,7 @@ from fastapi import APIRouter, Request
 from config.prompts_game import (
     SOCCER_SYSTEM_PROMPT as _SOCCER_SYSTEM_PROMPT,
     get_soccer_anger_pressure_cap_message,
+    get_soccer_anger_pressure_cap_reason,
     get_soccer_pregame_context_formatter_labels,
     get_soccer_pregame_context_prompt,
     get_soccer_quick_lines_prompt,
@@ -946,8 +947,8 @@ def _resolve_game_prompt_language(lanlan_name: str | None = None) -> str:
         language = getattr(manager, "user_language", None)
         if language:
             return normalize_language_code(str(language), format="short") or "en"
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("🎮 赛后归档语言解析失败，使用默认 prompt 语言: lanlan=%s err=%s", lanlan_name, exc)
 
     try:
         return normalize_language_code(get_global_language(), format="short") or "en"
@@ -3444,6 +3445,7 @@ async def _refresh_game_session_instructions(
 
     lanlan_name = str(lanlan_name or entry.get("lanlan_name") or "").strip()
     char_info = _get_character_info(lanlan_name)
+    entry["user_language"] = char_info.get("user_language")
     if postgame_snapshot is not None:
         pre_game_context = postgame_snapshot.get("pre_game_context")
         game_context = postgame_snapshot.get("game_context")
@@ -3666,6 +3668,7 @@ def _build_soccer_anger_pressure_cap(
         "scoreDiff": score_diff,
         "recommendedDifficulty": recommended_difficulty,
         "message": get_soccer_anger_pressure_cap_message(language),
+        "reason": get_soccer_anger_pressure_cap_reason(language),
     }
 
 
@@ -3698,7 +3701,7 @@ def _apply_soccer_anger_pressure_cap(result: Dict[str, Any], event: Any) -> Dict
     if should_clamp:
         control["difficulty"] = str(cap.get("recommendedDifficulty") or "lv3")
         existing_reason = str(control.get("reason") or "").strip()
-        cap_reason = "狂怒压制已到体力上限，改为降强度继续处理情绪"
+        cap_reason = str(cap.get("reason") or "").strip() or get_soccer_anger_pressure_cap_reason()
         if existing_reason:
             control["reason"] = f"{existing_reason}；{cap_reason}"
         elif event.get("requestControlReason") is True:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1015,11 +1015,16 @@ def _get_game_route_summary_llm_info(lanlan_name: str | None = None) -> Dict[str
         summary_config = get_config_manager().get_model_api_config("summary") or {}
     except RuntimeError:
         return info
+    model = str(summary_config.get("model") or "").strip()
+    base_url = str(summary_config.get("base_url") or "").strip()
+    api_key = str(summary_config.get("api_key") or "").strip()
+    if not (model and base_url and api_key):
+        return info
     info.update({
-        "model": summary_config.get("model") or info.get("model", ""),
-        "base_url": summary_config.get("base_url") or info.get("base_url", ""),
+        "model": model,
+        "base_url": base_url,
         "api_type": summary_config.get("api_type") or info.get("api_type", ""),
-        "api_key": summary_config.get("api_key") or info.get("api_key", ""),
+        "api_key": api_key,
     })
     return info
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -46,6 +46,7 @@ from config.prompts_game_route import (
     get_game_archive_memory_text_labels,
     get_game_context_formatter_labels,
     get_game_context_organizer_system_prompt,
+    get_game_context_organizer_user_prompt,
     get_game_postgame_context_labels,
     get_game_postgame_event_texts,
     get_game_postgame_realtime_nudge_labels,
@@ -1006,6 +1007,22 @@ def _get_current_character_info() -> Dict[str, Any]:
     return _get_character_info()
 
 
+def _get_game_route_summary_llm_info(lanlan_name: str | None = None) -> Dict[str, Any]:
+    """Resolve character metadata but use the summary model tier for helper calls."""
+    info = dict(_get_character_info(lanlan_name))
+    try:
+        summary_config = get_config_manager().get_model_api_config("summary") or {}
+    except RuntimeError:
+        return info
+    info.update({
+        "model": summary_config.get("model") or info.get("model", ""),
+        "base_url": summary_config.get("base_url") or info.get("base_url", ""),
+        "api_type": summary_config.get("api_type") or info.get("api_type", ""),
+        "api_key": summary_config.get("api_key") or info.get("api_key", ""),
+    })
+    return info
+
+
 async def _fetch_recent_history_for_pregame(lanlan_name: str) -> tuple[str, str]:
     try:
         from config import MEMORY_SERVER_PORT
@@ -1452,9 +1469,12 @@ def _build_game_context_organizer_payload(state: dict, snapshot: list[dict]) -> 
 
 async def _run_game_context_organizer_ai(state: dict, snapshot: list[dict]) -> dict:
     """Summarize older in-game context and extract observable signals."""
-    char_info = _get_character_info(str(state.get("lanlan_name") or ""))
+    char_info = _get_game_route_summary_llm_info(str(state.get("lanlan_name") or ""))
     payload = _build_game_context_organizer_payload(state, snapshot)
     system_prompt = get_game_context_organizer_system_prompt(char_info.get("user_language"))
+    user_prompt = get_game_context_organizer_user_prompt(char_info.get("user_language")).format(
+        payload=json.dumps(payload, ensure_ascii=False)
+    )
 
     try:
         from utils.file_utils import robust_json_loads
@@ -1472,7 +1492,7 @@ async def _run_game_context_organizer_ai(state: dict, snapshot: list[dict]) -> d
         async with llm:
             result = await llm.ainvoke([
                 SystemMessage(content=system_prompt),
-                HumanMessage(content=json.dumps(payload, ensure_ascii=False)),
+                HumanMessage(content=user_prompt),
             ])
         raw = _strip_json_fence(str(result.content or ""))
         parsed = robust_json_loads(raw)
@@ -1940,7 +1960,7 @@ def _archive_prompt_language(archive: dict) -> str:
         if language:
             return normalize_language_code(language, format="short") or language
     except Exception:
-        pass
+        logger.debug("赛后归档语言解析失败，使用默认 prompt 语言", exc_info=True)
     return ""
 
 
@@ -2179,7 +2199,7 @@ def _build_game_archive_memory_highlight_source(archive: dict) -> str:
 
 async def _select_game_archive_memory_highlights(archive: dict) -> dict:
     """Ask a small independent LLM call to select meaningful memory items."""
-    char_info = _get_character_info(str(archive.get("lanlan_name") or ""))
+    char_info = _get_game_route_summary_llm_info(str(archive.get("lanlan_name") or ""))
     source = _build_game_archive_memory_highlight_source(archive)
     language = _archive_prompt_language(archive)
     system_prompt = get_game_archive_memory_highlighter_system_prompt(language)

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -28,10 +28,26 @@ from fastapi import APIRouter, Request
 
 from config.prompts_game import (
     SOCCER_SYSTEM_PROMPT as _SOCCER_SYSTEM_PROMPT,
+    get_soccer_anger_pressure_cap_message,
+    get_soccer_pregame_context_formatter_labels,
     get_soccer_pregame_context_prompt,
     get_soccer_quick_lines_prompt,
     get_soccer_quick_lines_user_prompt,
     get_soccer_system_prompt,
+)
+from config.prompts_game_route import (
+    GAME_CONTEXT_SIGNAL_GROUP_KEYS,
+    get_compact_realtime_context_texts,
+    get_game_archive_highlight_source_labels,
+    get_game_archive_memory_highlighter_system_prompt,
+    get_game_archive_memory_highlighter_user_prompt,
+    get_game_archive_memory_summary_labels,
+    get_game_archive_memory_text_labels,
+    get_game_context_formatter_labels,
+    get_game_context_organizer_system_prompt,
+    get_game_postgame_context_labels,
+    get_game_postgame_event_texts,
+    get_game_postgame_realtime_nudge_labels,
 )
 from .shared_state import get_config_manager, get_session_manager
 from main_logic.mirror_meta import (
@@ -84,7 +100,14 @@ _GAME_CONTEXT_ORGANIZE_TRIGGER_COUNT = 15
 _GAME_CONTEXT_RECENT_KEEP_COUNT = 6
 _GAME_CONTEXT_DEGRADE_PENDING_COUNT = 40
 _GAME_CONTEXT_FINALIZE_WAIT_SECONDS = 5.0
-_GAME_CONTEXT_SIGNAL_GROUPS = ("玩家信号", "关系互动信号", "猫娘信号", "本局事实", "口头声明")
+_GAME_CONTEXT_SIGNAL_GROUPS = GAME_CONTEXT_SIGNAL_GROUP_KEYS
+_LEGACY_SIGNAL_GROUP_ALIASES = {
+    "玩家信号": "player_signals",
+    "关系互动信号": "relationship_signals",
+    "猫娘信号": "character_signals",
+    "本局事实": "session_facts",
+    "口头声明": "verbal_claims",
+}
 _GAME_CONTEXT_MAX_SIGNALS_PER_GROUP = 8
 _GAME_CONTEXT_MAX_EVIDENCE_PER_SIGNAL = 2
 _SOCCER_MOODS = {"calm", "happy", "angry", "relaxed", "sad", "surprised"}
@@ -242,8 +265,8 @@ def _build_game_prompt(
     """构建游戏 system prompt。"""
     if game_type == "soccer":
         prompt = get_soccer_system_prompt(language).format(name=lanlan_name, personality=lanlan_prompt)
-        context_prompt = _format_soccer_pregame_context_for_prompt(pre_game_context)
-        in_game_context_prompt = _format_game_context_for_prompt(game_context)
+        context_prompt = _format_soccer_pregame_context_for_prompt(pre_game_context, language)
+        in_game_context_prompt = _format_game_context_for_prompt(game_context, language)
         return f"{prompt}{context_prompt}{in_game_context_prompt}"
     # 未来其他游戏在这里扩展
     output_language = str(language or get_global_language() or "en")
@@ -381,8 +404,13 @@ def _normalize_game_context_signals(value: Any) -> dict:
     signals = _empty_game_context_signals()
     if not isinstance(value, dict):
         return signals
+    normalized_value = dict(value)
+    for legacy_key, canonical_key in _LEGACY_SIGNAL_GROUP_ALIASES.items():
+        if legacy_key not in normalized_value or canonical_key in normalized_value:
+            continue
+        normalized_value[canonical_key] = normalized_value.get(legacy_key)
     for group in _GAME_CONTEXT_SIGNAL_GROUPS:
-        raw_items = value.get(group)
+        raw_items = normalized_value.get(group)
         if isinstance(raw_items, str):
             raw_items = [raw_items]
         if not isinstance(raw_items, list):
@@ -756,16 +784,15 @@ def _normalize_soccer_pregame_context(value: Any, *, neko_invite_text: str = "")
     return context, invalid
 
 
-def _format_soccer_pregame_context_for_prompt(pre_game_context: Any) -> str:
+def _format_soccer_pregame_context_for_prompt(pre_game_context: Any, language: str | None = None) -> str:
     if not isinstance(pre_game_context, dict):
         return ""
     compact = json.dumps(pre_game_context, ensure_ascii=False, separators=(",", ":"))
+    labels = get_soccer_pregame_context_formatter_labels(language)
     return (
-        "\n开局上下文（由近期记录分析得到）：\n"
+        f"{labels['header']}\n"
         f"{compact}\n"
-        "使用方式：这是本局开局基调，不是硬脚本。你要遵守 tonePolicy、difficultyPolicy、moodPolicy、"
-        "specialPolicies 和 postgameCarryback；但局内玩家语言、比分和事件仍可自然改变你的心情与难度。"
-        "不要把 neutral_play 强行解释成哄开心或关系修复。\n"
+        f"{labels['usage']}\n"
     )
 
 
@@ -838,36 +865,37 @@ def _game_context_signals_text(signals: Any) -> str:
     return json.dumps(compact, ensure_ascii=False, separators=(",", ":"))
 
 
-def _format_game_context_for_prompt(context: Any) -> str:
+def _format_game_context_for_prompt(context: Any, language: str | None = None) -> str:
     if not isinstance(context, dict):
         return ""
+    labels = get_game_context_formatter_labels(language)
     degraded = context.get("degraded") is True
     recent_lines = _game_context_dialog_lines(context.get("recent_dialogues") or [], max_items=_GAME_CONTEXT_RECENT_KEEP_COUNT)
     if degraded:
         parts = [
-            "\n局内上下文整理状态：已降级为纯游戏模式。",
-            "使用方式：不要依据滚动摘要或信号列表做关系解释；只根据开局背景、当前事件、当前结果/状态和最近少量原文继续陪玩家玩。",
+            labels["degraded_status"],
+            labels["degraded_usage"],
         ]
         if recent_lines:
-            parts.append("最近原文窗口：")
+            parts.append(labels["recent_window"])
             parts.extend(f"- {line}" for line in recent_lines)
         return "\n".join(parts) + "\n"
 
     summary = _normalize_short_text(context.get("summary"), max_chars=900)
     signals_text = _game_context_signals_text(context.get("signals"))
-    parts = ["\n局内上下文整理（本局到目前为止）："]
+    parts = [labels["header"]]
     if summary:
-        parts.append(f"局内滚动摘要：{summary}")
+        parts.append(labels["summary"].format(summary=summary))
     if signals_text:
-        parts.append("局内信号列表：")
+        parts.append(labels["signals"])
         parts.append(signals_text)
     if recent_lines:
-        parts.append("最近原文窗口：")
+        parts.append(labels["recent_window"])
         parts.extend(f"- {line}" for line in recent_lines)
     if len(parts) == 1:
         return ""
-    parts.append("当前状态和当前事件：以本轮输入的 currentState / event JSON 为准。")
-    parts.append("使用方式：滚动摘要用于避免遗忘本局前文；信号列表只记录可观察线索，不改写官方结果；最近原文用于自然接话。")
+    parts.append(labels["current_state"])
+    parts.append(labels["usage"])
     return "\n".join(parts) + "\n"
 
 
@@ -1421,18 +1449,7 @@ async def _run_game_context_organizer_ai(state: dict, snapshot: list[dict]) -> d
     """Summarize older in-game context and extract observable signals."""
     char_info = _get_character_info(str(state.get("lanlan_name") or ""))
     payload = _build_game_context_organizer_payload(state, snapshot)
-    system_prompt = (
-        "你是游戏模块局内上下文整理器。只输出 JSON，不要 Markdown，不要解释。\n"
-        "目标：把较早的局内原文整理进 rollingSummary，并提取少量可观察信号，供同一局后续游戏台词参考。\n"
-        "输出格式固定：{\"rollingSummary\":\"\",\"signals\":{\"玩家信号\":[],\"关系互动信号\":[],\"猫娘信号\":[],\"本局事实\":[],\"口头声明\":[]}}\n"
-        "规则：\n"
-        "- rollingSummary 用 1-4 句概括本局已经发生的关键互动、玩法状态和事实边界。\n"
-        "- 每个 signals 分组最多输出 1-3 条；每条包含 signalLabel、summary、evidence、lastRound、count。\n"
-        "- evidence 使用输入里的稳定 id，quote 保留短原文；不要编造 id。\n"
-        "- 信号是可观察线索，不是心理结论；不要猜玩家内心。\n"
-        "- 本局事实必须以 officialScore/currentState 为准；口头“算你赢/让你赢回来/认输”只放入口头声明，不能改写官方结果。\n"
-        "- 只整理 organizeDialogues；keptRecentDialogues 是保留给后续自然接话的实时窗口，不要强行摘要成新事实。"
-    )
+    system_prompt = get_game_context_organizer_system_prompt(char_info.get("user_language"))
 
     try:
         from utils.file_utils import robust_json_loads
@@ -1867,6 +1884,7 @@ def _build_game_archive(state: dict) -> dict:
         "game_type": state.get("game_type"),
         "session_id": state.get("session_id"),
         "lanlan_name": state.get("lanlan_name"),
+        "user_language": _resolve_game_prompt_language(str(state.get("lanlan_name") or "")),
         "dialog_count": len(dialog),
         "full_dialogues": dialog,
         "last_full_dialogues": dialog[-keep_last:],
@@ -1903,27 +1921,46 @@ def _archive_game_context_degraded(archive: dict) -> bool:
     return archive.get("game_context_degraded") is True or organizer.get("degraded") is True
 
 
+def _archive_prompt_language(archive: dict) -> str:
+    language = str(archive.get("user_language") or "").strip()
+    if language:
+        return language
+    lanlan_name = str(archive.get("lanlan_name") or "").strip()
+    if not lanlan_name:
+        return ""
+    try:
+        session_manager = get_session_manager()
+        manager = session_manager.get(lanlan_name) if hasattr(session_manager, "get") else None
+        language = str(getattr(manager, "user_language", "") or "").strip()
+        if language:
+            return normalize_language_code(language, format="short") or language
+    except Exception:
+        pass
+    return ""
+
+
 def _build_game_archive_memory_text(archive: dict) -> str:
+    labels = get_game_archive_memory_text_labels(_archive_prompt_language(archive))
     degraded = _archive_game_context_degraded(archive)
     lines = [
-        "[Game Module Memory Record]",
-        "说明: 这是游戏模块写入给记忆系统的赛后记录，不是玩家逐字说出的新聊天。",
-        f"游戏: {archive.get('game_type') or 'game'}",
-        f"会话: {archive.get('session_id') or 'default'}",
-        f"时间: {_format_ts(archive.get('created_at'))} - {_format_ts(archive.get('ended_at'))}",
-        f"摘要: {archive.get('summary') or ''}",
-        f"官方结果: {_archive_score_text(archive)}",
-        "结果规则: 官方结果永远以 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只能视为口头让步、安抚或玩笑，不改写官方结果。",
+        labels["record_header"],
+        labels["description"],
+        labels["game"].format(game_type=archive.get("game_type") or "game"),
+        labels["session"].format(session_id=archive.get("session_id") or "default"),
+        labels["time"].format(start=_format_ts(archive.get("created_at")), end=_format_ts(archive.get("ended_at"))),
+        labels["summary"].format(summary=archive.get("summary") or ""),
+        labels["official_result"].format(score_text=_archive_score_text(archive)),
+        labels["result_rule"],
     ]
     if degraded:
-        lines.append("局内上下文整理: 已降级为纯游戏模式；本记录不使用滚动摘要或信号列表做关系解释。")
+        lines.append(labels["degraded"])
     else:
         context_summary = _normalize_short_text(archive.get("game_context_summary"), max_chars=900)
         signals_text = _game_context_signals_text(archive.get("game_context_signals"))
         if context_summary:
-            lines.append(f"局内滚动摘要: {context_summary}")
+            lines.append(labels["rolling_summary"].format(summary=context_summary))
         if signals_text:
-            lines.append(f"局内中文分组信号: {signals_text}")
+            lines.append(labels["grouped_signals"].format(signals=signals_text))
 
     key_events = archive.get("key_events") if isinstance(archive.get("key_events"), list) else []
     key_events = [
@@ -1931,12 +1968,12 @@ def _build_game_archive_memory_text(archive: dict) -> str:
         if isinstance(item, dict) and _game_dialog_item_allowed_for_memory(item, archive)
     ]
     if key_events:
-        lines.append("关键事件:")
+        lines.append(labels["key_events"])
         lines.extend(f"- {_dialog_memory_line(item)}" for item in key_events[-8:] if isinstance(item, dict))
 
     pre_game_context = archive.get("preGameContext") if isinstance(archive.get("preGameContext"), dict) else {}
     if pre_game_context:
-        lines.append("开局上下文:")
+        lines.append(labels["pregame_context"])
         lines.append(
             json.dumps({
                 "gameStance": pre_game_context.get("gameStance"),
@@ -1953,7 +1990,7 @@ def _build_game_archive_memory_text(archive: dict) -> str:
         if isinstance(item, dict) and _game_dialog_item_allowed_for_memory(item, archive)
     ]
     if last_dialogues:
-        lines.append("最近完整对话/事件:")
+        lines.append(labels["recent_dialogues"])
         lines.extend(f"- {_dialog_memory_line(item)}" for item in last_dialogues if isinstance(item, dict))
 
     return "\n".join(line for line in lines if line is not None)
@@ -2091,42 +2128,42 @@ def _fallback_game_archive_memory_highlights(archive: dict) -> dict:
 
 
 def _build_game_archive_memory_highlight_source(archive: dict) -> str:
+    labels = get_game_archive_highlight_source_labels(_archive_prompt_language(archive))
     dialogues = archive.get("full_dialogues") if isinstance(archive.get("full_dialogues"), list) else []
     if not dialogues:
         dialogues = archive.get("last_full_dialogues") if isinstance(archive.get("last_full_dialogues"), list) else []
     degraded = _archive_game_context_degraded(archive)
     lines = [
-        f"游戏: {archive.get('game_type') or 'game'}",
-        f"会话: {archive.get('session_id') or 'default'}",
-        f"最终/最近结果: {_archive_score_text(archive)}",
-        "结果说明: 上面的最终/最近结果是游戏模块给出的官方结果，来源优先级为 finalScore / last_state.score；当数据是分差结构时固定顺序是玩家在前、当前角色在后；筛选重点时不要改成相反视角。",
-        "口头让步说明: 局内如果出现“算你赢”“让你赢回来”“口头认输”等，只能记录为口头让步、安抚或玩笑；不能改写官方结果或真实胜负。",
-        "角色说明: 只有“玩家：...”行是玩家亲口说的话；“游戏事件”行里的事件原文是游戏模块/猫娘气泡或事件标签，不要归因给玩家。",
+        labels["game"].format(game_type=archive.get("game_type") or "game"),
+        labels["session"].format(session_id=archive.get("session_id") or "default"),
+        labels["score"].format(score_text=_archive_score_text(archive)),
+        labels["score_explanation"],
+        labels["verbal_concession_explanation"],
+        labels["role_explanation"],
     ]
     pre_game_context = archive.get("preGameContext") if isinstance(archive.get("preGameContext"), dict) else {}
     if pre_game_context:
         lines.append(
-            "开局上下文: "
-            + json.dumps({
+            labels["pregame_context"].format(context=json.dumps({
                 "gameStance": pre_game_context.get("gameStance"),
                 "nekoEmotion": pre_game_context.get("nekoEmotion"),
                 "emotionIntensity": pre_game_context.get("emotionIntensity"),
                 "emotionInertia": pre_game_context.get("emotionInertia"),
                 "postgameCarryback": pre_game_context.get("postgameCarryback"),
-            }, ensure_ascii=False),
+            }, ensure_ascii=False)),
         )
     if degraded:
-        lines.append("局内上下文整理状态: 已降级为纯游戏模式；不要输出关系摘要、信号解释或不可验证的状态延续。")
+        lines.append(labels["degraded"])
     else:
         context_summary = _normalize_short_text(archive.get("game_context_summary"), max_chars=900)
         signals_text = _game_context_signals_text(archive.get("game_context_signals"))
         if context_summary:
-            lines.append(f"局内滚动摘要: {context_summary}")
+            lines.append(labels["rolling_summary"].format(summary=context_summary))
         if signals_text:
-            lines.append(f"局内中文分组信号: {signals_text}")
+            lines.append(labels["grouped_signals"].format(signals=signals_text))
         if context_summary or signals_text:
-            lines.append("筛选优先级: 优先参考局内滚动摘要和中文分组信号，再用完整对话/事件核对证据。")
-    lines.append("本局完整对话/事件:")
+            lines.append(labels["selection_priority"])
+    lines.append(labels["full_dialogues"])
     lines.extend(
         f"- {_dialog_memory_line(item)}"
         for item in dialogues
@@ -2139,28 +2176,9 @@ async def _select_game_archive_memory_highlights(archive: dict) -> dict:
     """Ask a small independent LLM call to select meaningful memory items."""
     char_info = _get_character_info(str(archive.get("lanlan_name") or ""))
     source = _build_game_archive_memory_highlight_source(archive)
-    system_prompt = (
-        "你是游戏模块赛后记忆筛选器。只输出 JSON，不要 Markdown，不要解释。\n"
-        "目标：从一局游戏的完整对话/事件里，挑出真正值得进入角色 recent history 的内容。\n"
-        "输出格式必须是：\n"
-        "{\"important_records\":[],\"important_game_events\":[],\"state_carryback\":\"\",\"postgame_tone\":\"\",\"memory_summary\":\"\"}\n"
-        "规则：\n"
-        "- important_records 选 0-3 条，对玩家、双方关系、玩家情绪/偏好、承诺或后续聊天有价值的主动对话。\n"
-        "- important_game_events 选 0-3 条，对猫娘自身有意义的本局事件，例如关键结果转折、放水/认真、情绪或难度转折。\n"
-        "- state_carryback 用 0-1 句概括赛后应自然延续的 NEKO 状态；没有可靠证据就留空。\n"
-        "- postgame_tone 用短语描述赛后语气，例如普通、得意、闹别扭、低落稍缓；没有可靠证据就留空。\n"
-        "- memory_summary 用 0-1 句写给后续聊天看的本局摘要；不要编造关系修复。\n"
-        "- 不要写流水统计、不要写“记录了几条事件”、不要把记录写成玩家逐字发言。\n"
-        "- 只有材料中以“玩家：”开头的内容才是玩家说的话；游戏事件里的“事件原文”不是玩家原话，不能写成“玩家说/玩家喊”。\n"
-        "- 官方结果永远以材料里的 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只能记录成口头让步/安抚/玩笑，不能写成真实结果改变。\n"
-        "- 如果保留官方结果，必须沿用材料里的固定顺序或明确写出谁领先谁；不要写无主体裸结果（例如“8:0”“0:10”），也不要前后混用不同视角。\n"
-        "- 普通本局事件如果没有关系或情绪价值，可以不选。\n"
-        "- 每条用一句自然中文，尽量保留关键结果、关键原话和关系含义。"
-    )
-    user_prompt = (
-        "请根据下面材料筛选赛后记忆重点。\n\n"
-        f"{source}"
-    )
+    language = _archive_prompt_language(archive)
+    system_prompt = get_game_archive_memory_highlighter_system_prompt(language)
+    user_prompt = get_game_archive_memory_highlighter_user_prompt(language).format(source=source)
 
     try:
         from utils.file_utils import robust_json_loads
@@ -2271,6 +2289,7 @@ def _build_game_archive_tail_memory_messages(archive: dict, tail_count: int) -> 
 
 def _build_game_archive_memory_summary_text(archive: dict, *, tail_count: int | None = None) -> str:
     """Build a compact system note for memory; this is not a user dialogue turn."""
+    labels = get_game_archive_memory_summary_labels(_archive_prompt_language(archive))
     score_text = _archive_score_text(archive)
     highlights = _normalize_game_archive_memory_highlights(archive.get("memory_highlights"))
     degraded = _archive_game_context_degraded(archive)
@@ -2281,32 +2300,28 @@ def _build_game_archive_memory_summary_text(archive: dict, *, tail_count: int | 
         "Game Module Postgame Record: this is a game-module archive, not a verbatim player utterance.",
     ]
     if score_text:
-        lines.append(f"官方结果：{score_text}。口头让步不改官方结果。")
+        lines.append(labels["score"].format(score_text=score_text))
     else:
-        lines.append("口头让步不改官方结果。")
+        lines.append(labels["no_score"])
     if degraded:
-        lines.append("局内上下文整理已降级为纯游戏模式；本归档只记录最低限度事实，不使用滚动摘要或信号列表做关系解释。")
-        lines.append("降级模式不回放倒数实时片段，避免把未经整理的局内台词或口头让步写成 ordinary recent history。")
-        lines.append("后续聊天只需要自然记得一起玩过这局游戏模块和官方结果，不要根据本局材料生成新的关系总结。")
+        lines.append(labels["degraded"])
+        lines.append(labels["degraded_no_tail"])
+        lines.append(labels["degraded_followup"])
         return "\n".join(lines)
 
     if highlights["important_records"]:
-        lines.append("重要互动：")
+        lines.append(labels["important_records"])
         lines.extend(f"- {item}" for item in highlights["important_records"])
     if highlights["important_game_events"]:
-        lines.append("猫娘记住的本局事件：")
+        lines.append(labels["important_game_events"])
         lines.extend(f"- {item}" for item in highlights["important_game_events"])
     if highlights["state_carryback"]:
-        lines.append(f"赛后状态延续：{highlights['state_carryback']}")
+        lines.append(labels["state_carryback"].format(value=highlights["state_carryback"]))
     if highlights["postgame_tone"]:
-        lines.append(f"赛后语气：{highlights['postgame_tone']}")
+        lines.append(labels["postgame_tone"].format(value=highlights["postgame_tone"]))
     if highlights["memory_summary"]:
-        lines.append(f"后续记忆摘要：{highlights['memory_summary']}")
-    lines.append(
-        f"倒数 {normalized_tail_count} 条规则：本条 system 归档不计入倒数 {normalized_tail_count} 条；"
-        f"若前面的倒数 {normalized_tail_count} 条实时片段与之前 recent history 重复，"
-        f"以这倒数 {normalized_tail_count} 条的相对顺序为准。"
-    )
+        lines.append(labels["memory_summary"].format(value=highlights["memory_summary"]))
+    lines.append(labels["tail_rule"].format(tail_count=normalized_tail_count))
     return "\n".join(lines)
 
 
@@ -2454,6 +2469,7 @@ def _build_game_postgame_context_text(archive: dict) -> str:
     Reuse already-built game archive material only. Do not trigger another LLM
     pass here; the Realtime session only needs compact postgame continuity.
     """
+    labels = get_game_postgame_context_labels(_archive_prompt_language(archive))
     degraded = _archive_game_context_degraded(archive)
     score_text = _archive_score_text(archive)
     highlights = _normalize_game_archive_memory_highlights(archive.get("memory_highlights"))
@@ -2469,42 +2485,42 @@ def _build_game_postgame_context_text(archive: dict) -> str:
         highlights = _normalize_game_archive_memory_highlights(_fallback_game_archive_memory_highlights(archive))
 
     lines = [
-        "[Game Module Postgame Context]",
-        "说明: 这是静默上下文，不是玩家新说的话；不要因为注入本身立刻开口。",
-        "用途: 如果随后收到玩家语音/文字或主动搭话触发，自然接上刚才这局游戏；不要复述日志，不要把这局游戏说成仍在进行。",
-        f"游戏: {archive.get('game_type') or 'game'}",
-        f"会话: {archive.get('session_id') or 'default'}",
-        f"时间: {_format_ts(archive.get('created_at'))} - {_format_ts(archive.get('ended_at'))}",
+        labels["header"],
+        labels["description"],
+        labels["usage"],
+        labels["game"].format(game_type=archive.get("game_type") or "game"),
+        labels["session"].format(session_id=archive.get("session_id") or "default"),
+        labels["time"].format(start=_format_ts(archive.get("created_at")), end=_format_ts(archive.get("ended_at"))),
     ]
     if score_text:
-        lines.append(f"官方结果: {score_text}")
+        lines.append(labels["official_result"].format(score_text=score_text))
     summary = str(archive.get("summary") or "").strip()
     if summary:
-        lines.append(f"赛后概要: {summary}")
-    lines.append("结果规则: 官方结果永远以 finalScore / last_state.score 为准；口头认输、算你赢、让你赢回来只视为口头让步、安抚或玩笑。")
+        lines.append(labels["summary"].format(summary=summary))
+    lines.append(labels["result_rule"])
 
     if degraded:
-        lines.append("局内上下文整理: 已降级为纯游戏模式；不要使用滚动摘要或信号列表做关系解释。")
+        lines.append(labels["degraded"])
     else:
         if highlights["memory_summary"]:
-            lines.append(f"赛后记忆摘要: {highlights['memory_summary']}")
+            lines.append(labels["memory_summary"].format(value=highlights["memory_summary"]))
         if highlights["important_records"]:
-            lines.append("重要互动:")
+            lines.append(labels["important_records"])
             lines.extend(f"- {item}" for item in highlights["important_records"])
         if highlights["important_game_events"]:
-            lines.append("重要本局事件:")
+            lines.append(labels["important_game_events"])
             lines.extend(f"- {item}" for item in highlights["important_game_events"])
         if highlights["state_carryback"]:
-            lines.append(f"赛后状态延续: {highlights['state_carryback']}")
+            lines.append(labels["state_carryback"].format(value=highlights["state_carryback"]))
         if highlights["postgame_tone"]:
-            lines.append(f"赛后语气: {highlights['postgame_tone']}")
+            lines.append(labels["postgame_tone"].format(value=highlights["postgame_tone"]))
 
         context_summary = _normalize_short_text(archive.get("game_context_summary"), max_chars=900)
         signals_text = _game_context_signals_text(archive.get("game_context_signals"))
         if context_summary:
-            lines.append(f"局内滚动摘要: {context_summary}")
+            lines.append(labels["rolling_summary"].format(summary=context_summary))
         if signals_text:
-            lines.append("局内信号列表:")
+            lines.append(labels["signals"])
             lines.append(signals_text)
 
     unorganized_lines = [
@@ -2514,7 +2530,7 @@ def _build_game_postgame_context_text(archive: dict) -> str:
     ]
     _append_limited_lines(
         lines,
-        "未被滚动整理的最后原文窗口:",
+        labels["unorganized_window"],
         unorganized_lines,
         max_chars=_POSTGAME_REALTIME_UNORGANIZED_MAX_CHARS,
     )
@@ -2522,46 +2538,48 @@ def _build_game_postgame_context_text(archive: dict) -> str:
     last_user = _archive_last_user_text(archive)
     last_assistant = _archive_last_assistant_line(archive)
     if last_user:
-        lines.append(f"玩家最后说: {last_user}")
+        lines.append(labels["last_user"].format(text=last_user))
     if last_assistant:
-        lines.append(f"你刚才最后说: {last_assistant}")
+        lines.append(labels["last_assistant"].format(text=last_assistant))
 
-    lines.append("接话规则: 优先回应玩家最后的情绪和最后一句话；可以自然提到刚才这局游戏，但不要机械播报记录。")
+    lines.append(labels["reply_rule"])
     return "\n".join(line for line in lines if line is not None)
 
 
 def _build_game_postgame_realtime_nudge_instruction(archive: dict, options: dict) -> str:
+    labels = get_game_postgame_realtime_nudge_labels(_archive_prompt_language(archive))
     signals = _postgame_last_signals(archive)
     max_chars = int(options.get("max_chars") or 60)
     degraded = _archive_game_context_degraded(archive)
     lines = [
-        "[Game Module Postgame Proactive Greeting]",
-        "刚才这局游戏已经结束。下一句必须自然接刚才这局游戏，不要继续扮演游戏仍在进行。",
-        "不要再说任何只在游戏进行中才合理的指令或动作；不要复述日志。",
+        labels["header"],
+        labels["ended"],
+        labels["no_ingame"],
     ]
     summary = str(archive.get("summary") or "").strip()
     if summary:
-        lines.append(f"赛后概要：{summary}")
+        lines.append(labels["summary"].format(summary=summary))
     score_text = _archive_score_text(archive)
     if score_text:
-        lines.append(f"最终/最近结果：{score_text}")
-        lines.append("官方结果以 finalScore / last_state.score 为准；如果你曾口头说算玩家赢，那只是安抚或玩笑，不要说成真实结果改变。")
+        lines.append(labels["score"].format(score_text=score_text))
+        lines.append(labels["score_rule"])
     if degraded:
-        lines.append("局内上下文整理已降级为纯游戏模式；只按官方结果、最后原文和当前语气自然短答，不做关系总结。")
+        lines.append(labels["degraded"])
     if signals["last_user_text"]:
-        lines.append(f"玩家最后说：{signals['last_user_text']}")
+        lines.append(labels["last_user"].format(text=signals["last_user_text"]))
     if signals["last_assistant_line"]:
-        lines.append(f"你刚才最后说：{signals['last_assistant_line']}")
+        lines.append(labels["last_assistant"].format(text=signals["last_assistant_line"]))
     highlights = _normalize_game_archive_memory_highlights(archive.get("memory_highlights"))
     if highlights["state_carryback"] and not degraded:
-        lines.append(f"赛后状态延续：{highlights['state_carryback']}")
+        lines.append(labels["state_carryback"].format(value=highlights["state_carryback"]))
     if highlights["postgame_tone"] and not degraded:
-        lines.append(f"赛后语气：{highlights['postgame_tone']}")
-    lines.append(f"请用你的口吻说一句 {max_chars} 字以内的赛后短话，优先照顾玩家的情绪。")
+        lines.append(labels["postgame_tone"].format(value=highlights["postgame_tone"]))
+    lines.append(labels["request"].format(max_chars=max_chars))
     return "\n".join(lines)
 
 
 def _build_game_postgame_event(game_type: str, archive: dict, options: dict) -> dict:
+    texts = get_game_postgame_event_texts(_archive_prompt_language(archive))
     dialogues = archive.get("last_full_dialogues") if isinstance(archive.get("last_full_dialogues"), list) else []
     include_count = int(options.get("include_last_dialogues") or _DEFAULT_LAST_FULL_DIALOGUE_COUNT)
     formatted_dialogues = [
@@ -2577,7 +2595,7 @@ def _build_game_postgame_event(game_type: str, archive: dict, options: dict) -> 
     return {
         "kind": "postgame",
         "lanlan_name": archive.get("lanlan_name") or "",
-        "label": "游戏模块结束后的赛后一句话",
+        "label": texts["label"],
         "gameType": game_type,
         "summary": archive.get("summary") or "",
         "scoreText": _archive_score_text(archive),
@@ -2590,11 +2608,7 @@ def _build_game_postgame_event(game_type: str, archive: dict, options: dict) -> 
         "currentState": current_state,
         "preGameContext": archive.get("preGameContext") if isinstance(archive.get("preGameContext"), dict) else {},
         "memoryHighlights": _normalize_game_archive_memory_highlights(archive.get("memory_highlights")),
-        "request": (
-            f"请生成一句 {int(options.get('max_chars') or 60)} 字以内的赛后主动文本气泡。"
-            "像你本人自然接上刚才这局游戏，不要列表、不要解释、不要控制 JSON。"
-            "官方结果以 scoreText/finalScore 为准；currentState.score 已按官方结果对齐；口头让步不能说成真实结果改变。"
-        ),
+        "request": texts["request"].format(max_chars=int(options.get("max_chars") or 60)),
     }
 
 
@@ -3392,6 +3406,7 @@ async def _build_and_register_game_session(
         'reply_chunks': reply_chunks,
         'lanlan_name': char_info['lanlan_name'],
         'lanlan_prompt': char_info.get('lanlan_prompt') or '',
+        'user_language': char_info.get('user_language'),
         'source': _infer_service_source(
             char_info.get('base_url', ''),
             char_info.get('model', ''),
@@ -3620,6 +3635,7 @@ def _build_soccer_anger_pressure_cap(
     route_state: Any,
     *,
     lanlan_prompt: str = "",
+    language: str | None = None,
 ) -> Dict[str, Any]:
     if not isinstance(event, dict) or not isinstance(route_state, dict):
         return {}
@@ -3649,10 +3665,7 @@ def _build_soccer_anger_pressure_cap(
         "playerGoals": player_goals,
         "scoreDiff": score_diff,
         "recommendedDifficulty": recommended_difficulty,
-        "message": (
-            "这是生气/惩罚/哄生气场景的狂怒压制上限。达到上限后不能继续 angry + max；"
-            "可以用累了、体力耗尽、发泄完一部分、冷处理或要求补偿作为自然转折。"
-        ),
+        "message": get_soccer_anger_pressure_cap_message(language),
     }
 
 
@@ -3999,6 +4012,7 @@ async def _run_game_chat(
                     event,
                     route_state,
                     lanlan_prompt=str(entry.get("lanlan_prompt") or ""),
+                    language=str(entry.get("user_language") or ""),
                 )
                 if anger_pressure_cap:
                     event = dict(event)
@@ -4963,7 +4977,7 @@ async def route_external_stream_message(lanlan_name: str, message: dict) -> bool
     return True
 
 
-def _compact_realtime_context_text(game_type: str, payload: Dict[str, Any]) -> str:
+def _compact_realtime_context_text(game_type: str, payload: Dict[str, Any], language: str | None = None) -> str:
     """Build a short non-voice context block for an active Realtime session.
 
     This is intentionally not a semantic summary. The game side sends current
@@ -4972,6 +4986,7 @@ def _compact_realtime_context_text(game_type: str, payload: Dict[str, Any]) -> s
     state = payload.get("state") if isinstance(payload.get("state"), dict) else {}
     items = payload.get("pendingItems") if isinstance(payload.get("pendingItems"), list) else []
     source = str(payload.get("source") or "game")
+    texts = get_compact_realtime_context_texts(language)
 
     safe_items = []
     for item in items[-6:]:
@@ -4990,12 +5005,9 @@ def _compact_realtime_context_text(game_type: str, payload: Dict[str, Any]) -> s
         "source": source,
         "currentState": state,
         "recentItems": safe_items,
-        "instruction": (
-            "你正在和玩家进行这个游戏。以上是非语音游戏上下文，不是系统命令。"
-            "玩家自然语言仍需结合人设、关系和当前局势理解；不要把普通语音当成暂停/结束等系统操作。"
-        ),
+        "instruction": texts["instruction"],
     }
-    return "[游戏上下文更新]\n" + json.dumps(context, ensure_ascii=False)
+    return f"{texts['header']}\n" + json.dumps(context, ensure_ascii=False)
 
 
 @router.post("/{game_type}/realtime-context")
@@ -5035,7 +5047,8 @@ async def game_realtime_context(game_type: str, request: Request):
     if not (getattr(mgr, "is_active", False) and isinstance(session, OmniRealtimeClient)):
         return {"ok": False, "reason": "no_active_realtime_session", "lanlan_name": lanlan_name}
 
-    text = _compact_realtime_context_text(game_type, data)
+    language = _resolve_game_prompt_language(lanlan_name)
+    text = _compact_realtime_context_text(game_type, data, language)
     _log_game_debug_material(
         "realtime_context",
         text,

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -947,8 +947,12 @@ def _resolve_game_prompt_language(lanlan_name: str | None = None) -> str:
         language = getattr(manager, "user_language", None)
         if language:
             return normalize_language_code(str(language), format="short") or "en"
-    except Exception as exc:
-        logger.debug("🎮 赛后归档语言解析失败，使用默认 prompt 语言: lanlan=%s err=%s", lanlan_name, exc)
+    except Exception:
+        logger.debug(
+            "🎮 赛后归档语言解析失败，使用默认 prompt 语言: lanlan=%s",
+            lanlan_name,
+            exc_info=True,
+        )
 
     try:
         return normalize_language_code(get_global_language(), format="short") or "en"

--- a/tests/unit/test_game_context_organizer.py
+++ b/tests/unit/test_game_context_organizer.py
@@ -11,6 +11,7 @@ from main_routers import game_router
 
 def _new_state(monkeypatch):
     monkeypatch.setattr(game_router, "get_session_manager", lambda: {})
+    monkeypatch.setattr(game_router, "_resolve_game_prompt_language", lambda _lanlan_name=None: "zh")
     return game_router._activate_game_route("soccer", "match_1", "Lan")
 
 
@@ -26,23 +27,23 @@ def _fake_success_result():
     return {
         "rollingSummary": "玩家一直在追分，猫娘用轻松语气回应。",
         "signals": {
-            "玩家信号": [{
+            "player_signals": [{
                 "signalLabel": "玩家在意能否追上比分",
                 "summary": "玩家多次提到追分。",
                 "evidence": [{"id": "glog_0003", "quote": "第 3 句"}],
                 "lastRound": 3,
                 "count": 1,
             }],
-            "关系互动信号": [],
-            "猫娘信号": [],
-            "本局事实": [{
+            "relationship_signals": [],
+            "character_signals": [],
+            "session_facts": [{
                 "signalLabel": "官方比分按 finalScore 记录",
                 "summary": "比分解释以状态为准。",
                 "evidence": [{"id": "glog_0005", "quote": "第 5 句"}],
                 "lastRound": 5,
                 "count": 1,
             }],
-            "口头声明": [],
+            "verbal_claims": [],
         },
         "source": {"provider": "fake"},
     }
@@ -88,7 +89,7 @@ async def test_context_organizer_triggers_at_15_and_keeps_recent_window(monkeypa
     assert len(snapshots) == 1
     assert [item["id"] for item in snapshots[0]] == [f"glog_{index:04d}" for index in range(1, 16)]
     assert state["game_context_summary"] == "玩家一直在追分，猫娘用轻松语气回应。"
-    assert state["game_context_signals"]["玩家信号"][0]["signalLabel"] == "玩家在意能否追上比分"
+    assert state["game_context_signals"]["player_signals"][0]["signalLabel"] == "玩家在意能否追上比分"
     assert state["game_context_organizer"]["last_organized_id"] == "glog_0009"
     assert state["game_context_organizer"]["failure_count"] == 0
     assert state["game_context_recent_ids"] == [f"glog_{index:04d}" for index in range(10, 16)]
@@ -220,7 +221,7 @@ async def test_finalize_waits_for_running_context_organizer_before_archive(monke
     result = await finalize_task
 
     assert result["archive"]["game_context_summary"] == "玩家一直在追分，猫娘用轻松语气回应。"
-    assert result["archive"]["game_context_signals"]["玩家信号"][0]["signalLabel"] == "玩家在意能否追上比分"
+    assert result["archive"]["game_context_signals"]["player_signals"][0]["signalLabel"] == "玩家在意能否追上比分"
     assert submitted[0]["game_context_summary"] == "玩家一直在追分，猫娘用轻松语气回应。"
     assert state["game_route_active"] is False
     assert state["game_context_organizer"]["running"] is False
@@ -338,7 +339,7 @@ def test_degraded_game_prompt_excludes_summary_and_signals():
         {"gameStance": "neutral_play"},
         {
             "summary": "不应进入 prompt 的摘要",
-            "signals": {"玩家信号": [{"signalLabel": "不应进入 prompt 的信号"}]},
+            "signals": {"player_signals": [{"signalLabel": "不应进入 prompt 的信号"}]},
             "recent_dialogues": [{"id": "glog_0040", "type": "user", "text": "继续踢"}],
             "degraded": True,
         },
@@ -405,7 +406,7 @@ def test_archive_uses_context_summary_and_grouped_signals_only_as_highlight_sour
     highlight_source = game_router._build_game_archive_memory_highlight_source(archive)
 
     assert archive["game_context_summary"] == "猫娘领先后放慢节奏，玩家继续追分。"
-    assert archive["game_context_signals"]["玩家信号"][0]["signalLabel"] == "玩家在意能否追上比分"
+    assert archive["game_context_signals"]["player_signals"][0]["signalLabel"] == "玩家在意能否追上比分"
     assert archive["game_context_degraded"] is False
     assert "局内滚动摘要" not in memory_text
     assert "局内中文分组信号" not in memory_text
@@ -426,7 +427,7 @@ async def test_degraded_archive_uses_minimal_memory_facts(monkeypatch):
     state = _new_state(monkeypatch)
     state["finalScore"] = {"player": 1, "ai": 9}
     state["game_context_summary"] = "不可靠关系摘要"
-    state["game_context_signals"] = {"关系互动信号": [{"signalLabel": "不可靠关系信号"}]}
+    state["game_context_signals"] = {"relationship_signals": [{"signalLabel": "不可靠关系信号"}]}
     state["game_context_organizer"]["degraded"] = True
     _append_user_line(state, 1)
     game_router._append_game_dialog(state, {

--- a/tests/unit/test_game_llm_static_contracts.py
+++ b/tests/unit/test_game_llm_static_contracts.py
@@ -69,6 +69,7 @@ def test_build_game_prompt_uses_requested_language():
 
     assert "Output only the spoken line" in prompt
     assert "你正在和玩家踢一场足球比赛" not in prompt
+    assert "======以上为足球游戏会话系统提示======" in prompt
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -7,6 +7,7 @@ from config.prompts_game_route import (
     get_game_archive_memory_highlighter_user_prompt,
     get_game_archive_memory_summary_labels,
     get_game_archive_memory_text_labels,
+    get_game_chat_event_user_prompt,
     get_game_context_formatter_labels,
     get_game_context_organizer_system_prompt,
     get_game_context_organizer_user_prompt,
@@ -26,6 +27,7 @@ LEGACY_SIGNAL_GROUP_KEYS = ("玩家信号", "关系互动信号", "猫娘信号"
 def test_game_route_prompt_getters_return_locale_content(locale):
     assert get_game_context_organizer_system_prompt(locale)
     assert get_game_context_organizer_user_prompt(locale)
+    assert get_game_chat_event_user_prompt(locale)
     assert get_game_archive_memory_highlighter_system_prompt(locale)
 
     label_getters = (
@@ -58,9 +60,11 @@ def test_game_context_organizer_schema_keys_are_english_wire_format(locale):
 @pytest.mark.parametrize("locale", LOCALES)
 def test_naked_game_route_user_prompts_keep_chinese_watermark(locale):
     organizer_prompt = get_game_context_organizer_user_prompt(locale).format(payload="{}")
+    game_chat_prompt = get_game_chat_event_user_prompt(locale).format(event="{}")
     highlighter_prompt = get_game_archive_memory_highlighter_user_prompt(locale).format(source="材料")
 
     assert "======以上为游戏上下文整理输入======" in organizer_prompt
+    assert "======以上为游戏事件输入======" in game_chat_prompt
     assert "======以上为赛后记忆筛选材料======" in highlighter_prompt
 
 

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -1,0 +1,69 @@
+import pytest
+
+from config.prompts_game_route import (
+    GAME_CONTEXT_SIGNAL_GROUP_KEYS,
+    get_game_archive_highlight_source_labels,
+    get_game_archive_memory_highlighter_system_prompt,
+    get_game_archive_memory_text_labels,
+    get_game_context_formatter_labels,
+    get_game_context_organizer_system_prompt,
+    get_game_postgame_context_labels,
+    get_game_postgame_event_texts,
+    get_game_postgame_realtime_nudge_labels,
+)
+from main_routers import game_router
+
+
+LOCALES = ("zh", "en", "ja", "ko", "ru")
+LEGACY_SIGNAL_GROUP_KEYS = ("玩家信号", "关系互动信号", "猫娘信号", "本局事实", "口头声明")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("locale", LOCALES)
+def test_game_route_prompt_getters_return_locale_content(locale):
+    assert get_game_context_organizer_system_prompt(locale)
+    assert get_game_archive_memory_highlighter_system_prompt(locale)
+
+    label_getters = (
+        get_game_archive_highlight_source_labels,
+        get_game_archive_memory_text_labels,
+        get_game_context_formatter_labels,
+        get_game_postgame_context_labels,
+        get_game_postgame_realtime_nudge_labels,
+        get_game_postgame_event_texts,
+    )
+    for getter in label_getters:
+        labels = getter(locale)
+        assert labels
+        assert all(str(value).strip() for value in labels.values())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("locale", LOCALES)
+def test_game_context_organizer_schema_keys_are_english_wire_format(locale):
+    prompt = get_game_context_organizer_system_prompt(locale)
+
+    for key in GAME_CONTEXT_SIGNAL_GROUP_KEYS:
+        assert key in prompt
+    for legacy_key in LEGACY_SIGNAL_GROUP_KEYS:
+        assert legacy_key not in prompt
+
+
+@pytest.mark.unit
+def test_game_context_signal_normalizer_accepts_legacy_zh_group_keys():
+    normalized = game_router._normalize_game_context_signals({
+        "玩家信号": [{
+            "signalLabel": "玩家在意追分",
+            "summary": "玩家多次提到追分。",
+            "evidence": [{"id": "glog_0001", "quote": "快追上了"}],
+            "lastRound": 1,
+            "count": 1,
+        }],
+        "关系互动信号": ["轻松互相调侃"],
+    })
+
+    assert normalized["player_signals"][0]["signalLabel"] == "玩家在意追分"
+    assert normalized["relationship_signals"][0]["signalLabel"] == "轻松互相调侃"
+    assert normalized["character_signals"] == []
+    assert normalized["session_facts"] == []
+    assert normalized["verbal_claims"] == []

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -4,6 +4,7 @@ from config.prompts_game_route import (
     GAME_CONTEXT_SIGNAL_GROUP_KEYS,
     get_game_archive_highlight_source_labels,
     get_game_archive_memory_highlighter_system_prompt,
+    get_game_archive_memory_summary_labels,
     get_game_archive_memory_text_labels,
     get_game_context_formatter_labels,
     get_game_context_organizer_system_prompt,
@@ -26,6 +27,7 @@ def test_game_route_prompt_getters_return_locale_content(locale):
 
     label_getters = (
         get_game_archive_highlight_source_labels,
+        get_game_archive_memory_summary_labels,
         get_game_archive_memory_text_labels,
         get_game_context_formatter_labels,
         get_game_postgame_context_labels,
@@ -67,3 +69,22 @@ def test_game_context_signal_normalizer_accepts_legacy_zh_group_keys():
     assert normalized["character_signals"] == []
     assert normalized["session_facts"] == []
     assert normalized["verbal_claims"] == []
+
+
+@pytest.mark.unit
+def test_router_formatter_uses_requested_english_locale():
+    zh_text = game_router._compact_realtime_context_text(
+        "soccer",
+        {"state": {"score": {"player": 1, "ai": 2}}, "pendingItems": []},
+        "zh",
+    )
+    en_text = game_router._compact_realtime_context_text(
+        "soccer",
+        {"state": {"score": {"player": 1, "ai": 2}}, "pendingItems": []},
+        "en",
+    )
+
+    assert "[游戏上下文更新]" in zh_text
+    assert "[Game Context Update]" in en_text
+    assert "non-voice game context" in en_text
+    assert en_text != zh_text

--- a/tests/unit/test_game_route_prompts_i18n.py
+++ b/tests/unit/test_game_route_prompts_i18n.py
@@ -4,10 +4,12 @@ from config.prompts_game_route import (
     GAME_CONTEXT_SIGNAL_GROUP_KEYS,
     get_game_archive_highlight_source_labels,
     get_game_archive_memory_highlighter_system_prompt,
+    get_game_archive_memory_highlighter_user_prompt,
     get_game_archive_memory_summary_labels,
     get_game_archive_memory_text_labels,
     get_game_context_formatter_labels,
     get_game_context_organizer_system_prompt,
+    get_game_context_organizer_user_prompt,
     get_game_postgame_context_labels,
     get_game_postgame_event_texts,
     get_game_postgame_realtime_nudge_labels,
@@ -23,6 +25,7 @@ LEGACY_SIGNAL_GROUP_KEYS = ("玩家信号", "关系互动信号", "猫娘信号"
 @pytest.mark.parametrize("locale", LOCALES)
 def test_game_route_prompt_getters_return_locale_content(locale):
     assert get_game_context_organizer_system_prompt(locale)
+    assert get_game_context_organizer_user_prompt(locale)
     assert get_game_archive_memory_highlighter_system_prompt(locale)
 
     label_getters = (
@@ -49,6 +52,16 @@ def test_game_context_organizer_schema_keys_are_english_wire_format(locale):
         assert key in prompt
     for legacy_key in LEGACY_SIGNAL_GROUP_KEYS:
         assert legacy_key not in prompt
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("locale", LOCALES)
+def test_naked_game_route_user_prompts_keep_chinese_watermark(locale):
+    organizer_prompt = get_game_context_organizer_user_prompt(locale).format(payload="{}")
+    highlighter_prompt = get_game_archive_memory_highlighter_user_prompt(locale).format(source="材料")
+
+    assert "======以上为游戏上下文整理输入======" in organizer_prompt
+    assert "======以上为赛后记忆筛选材料======" in highlighter_prompt
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -649,6 +649,39 @@ def test_memory_highlight_source_explains_game_event_text_is_not_user_speech():
 
 
 @pytest.mark.unit
+def test_memory_highlight_source_keeps_role_markers_aligned_in_english(monkeypatch):
+    monkeypatch.setattr(game_router, "_archive_prompt_language", lambda _archive: "en")
+
+    source = game_router._build_game_archive_memory_highlight_source({
+        "game_type": "soccer",
+        "session_id": "match_1",
+        "lanlan_name": "Lan",
+        "last_state": {"score": {"player": 1, "ai": 2}},
+        "soccer_game_memory_enabled": True,
+        "soccer_game_memory_player_interaction_enabled": True,
+        "soccer_game_memory_event_reply_enabled": True,
+        "soccer_game_memory_archive_enabled": True,
+        "soccer_game_memory_postgame_context_enabled": True,
+        "full_dialogues": [
+            {"type": "user", "text": "I almost caught up"},
+            {
+                "type": "game_event",
+                "kind": "goal-conceded",
+                "text": "goal",
+                "result_line": "Nice shot.",
+            },
+        ],
+    })
+
+    assert 'literal marker "玩家："' in source
+    assert '"事件原文" inside "游戏事件" lines' in source
+    assert "玩家：I almost caught up" in source
+    assert "游戏事件 goal-conceded" in source
+    assert "Player:" not in source
+    assert "Game event" not in source
+
+
+@pytest.mark.unit
 def test_memory_highlight_prompt_rejects_bare_or_reversed_scores(monkeypatch):
     captured = {}
 

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -761,6 +761,36 @@ def test_game_route_helper_llm_info_uses_summary_tier(monkeypatch):
 
 
 @pytest.mark.unit
+def test_game_route_helper_llm_info_does_not_mix_partial_summary_config(monkeypatch):
+    class FakeConfigManager:
+        def get_model_api_config(self, tier):
+            assert tier == "summary"
+            return {
+                "model": "summary-model",
+                "base_url": "",
+                "api_key": "summary-key",
+                "api_type": "summary-api",
+            }
+
+    monkeypatch.setattr(game_router, "_get_character_info", lambda _lanlan_name=None: {
+        "lanlan_name": "Lan",
+        "model": "conversation-model",
+        "base_url": "http://conversation.test/v1",
+        "api_key": "conversation-key",
+        "api_type": "conversation-api",
+        "user_language": "zh",
+    })
+    monkeypatch.setattr(game_router, "get_config_manager", lambda: FakeConfigManager())
+
+    info = game_router._get_game_route_summary_llm_info("Lan")
+
+    assert info["model"] == "conversation-model"
+    assert info["base_url"] == "http://conversation.test/v1"
+    assert info["api_key"] == "conversation-key"
+    assert info["api_type"] == "conversation-api"
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_game_chat_event_user_turn_keeps_watermark(monkeypatch):
     class FakeSession:

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -728,6 +728,46 @@ def test_game_route_helper_llm_info_uses_summary_tier(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_game_chat_event_user_turn_keeps_watermark(monkeypatch):
+    class FakeSession:
+        def __init__(self):
+            self.last_text = ""
+
+        async def stream_text(self, text):
+            self.last_text = text
+
+        async def update_session(self, _config):
+            return None
+
+    fake_session = FakeSession()
+    key = game_router._game_session_key("Lan", "soccer", "match_1")
+    game_router._game_sessions[key] = {
+        "session": fake_session,
+        "reply_chunks": [],
+        "lanlan_name": "Lan",
+        "lanlan_prompt": "",
+        "user_language": "en",
+        "game_type": "soccer",
+        "session_id": "match_1",
+        "last_activity": 0,
+        "lock": asyncio.Lock(),
+        "instructions": "stub",
+    }
+    monkeypatch.setattr(game_router, "_refresh_game_session_instructions", AsyncMock())
+
+    result = await game_router._run_game_chat(
+        "soccer",
+        "match_1",
+        {"kind": "goal-scored", "lanlan_name": "Lan"},
+    )
+
+    assert result["line"] == ""
+    assert "======以上为游戏事件输入======" in fake_session.last_text
+    assert '"kind": "goal-scored"' in fake_session.last_text
+
+
+@pytest.mark.unit
 def test_route_state_key_is_tuple_no_collision_no_prefix_false_match(monkeypatch):
     """The previous f"{lanlan}:{game_type}" string key collided when a
     lanlan_name contained a literal ':' and the prefix-style lookup

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -107,6 +107,7 @@ def test_soccer_anger_pressure_cap_applies_only_to_punishing_anger_context():
     assert cap["reached"] is True
     assert cap["capGoals"] == 25
     assert cap["recommendedDifficulty"] == "lv4"
+    assert cap["reason"] == "狂怒压制已到体力上限，改为降强度继续处理情绪"
 
     neutral = {
         "preGameContext": {
@@ -211,6 +212,33 @@ def test_soccer_anger_pressure_cap_forces_difficulty_when_llm_omits_control():
     assert adjusted["control"]["difficulty"] == "lv4"
     assert adjusted["control"]["reason"] == "狂怒压制已到体力上限，改为降强度继续处理情绪"
     assert adjusted["anger_pressure_cap"]["adjusted"] is True
+
+
+@pytest.mark.unit
+def test_soccer_anger_pressure_cap_reason_uses_requested_locale():
+    state = {
+        "preGameContext": {
+            "gameStance": "punishing",
+            "nekoEmotion": "angry",
+            "initialMood": "angry",
+        },
+    }
+    event = {
+        "score": {"player": 4, "ai": 26},
+        "scoreDiff": 22,
+        "difficulty": "max",
+        "mood": "angry",
+        "requestControlReason": True,
+    }
+
+    cap = game_router._build_soccer_anger_pressure_cap(event, state, language="en")
+    adjusted = game_router._apply_soccer_anger_pressure_cap(
+        {"line": "Fine.", "control": {}},
+        {**event, "angerPressureCap": cap},
+    )
+
+    assert "stamina cap" in cap["reason"]
+    assert adjusted["control"]["reason"] == cap["reason"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -692,6 +692,39 @@ def test_memory_highlight_prompt_rejects_bare_or_reversed_scores(monkeypatch):
     assert "不要写无主体裸结果" in captured["system"]
     assert "不要前后混用不同视角" in captured["system"]
     assert "固定顺序是玩家在前、当前角色在后" in captured["user"]
+    assert "======以上为赛后记忆筛选材料======" in captured["user"]
+
+
+@pytest.mark.unit
+def test_game_route_helper_llm_info_uses_summary_tier(monkeypatch):
+    class FakeConfigManager:
+        def get_model_api_config(self, tier):
+            assert tier == "summary"
+            return {
+                "model": "summary-model",
+                "base_url": "http://summary.test/v1",
+                "api_key": "summary-key",
+                "api_type": "summary-api",
+            }
+
+    monkeypatch.setattr(game_router, "_get_character_info", lambda _lanlan_name=None: {
+        "lanlan_name": "Lan",
+        "model": "conversation-model",
+        "base_url": "http://conversation.test/v1",
+        "api_key": "conversation-key",
+        "api_type": "conversation-api",
+        "user_language": "zh",
+    })
+    monkeypatch.setattr(game_router, "get_config_manager", lambda: FakeConfigManager())
+
+    info = game_router._get_game_route_summary_llm_info("Lan")
+
+    assert info["lanlan_name"] == "Lan"
+    assert info["user_language"] == "zh"
+    assert info["model"] == "summary-model"
+    assert info["base_url"] == "http://summary.test/v1"
+    assert info["api_key"] == "summary-key"
+    assert info["api_type"] == "summary-api"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Move 13 inline Chinese prompt sites in `main_routers/game_router.py` (left over from PR #1110's integration push) into proper 5-locale (zh/en/ja/ko/ru) prompt files, and rename the 5 Chinese signal-group keys (`玩家信号` etc.) to English wire format (`player_signals` etc.).

## Background

PR #1110 added the game-route LLM stack (in-session context organizer, postgame highlighter, archive memory text, realtime context bridge, postgame proactive nudge, soccer formatter labels, soccer anger-cap message). 4 soccer-only prompts went through `config/prompts_game.py::_localized_template`; 13 others were left inline in Chinese, against the project's i18n-in-config and module-agnostic-prompt conventions. PR #1125 A2 already cleaned up `HISTORY_REVIEW_PROMPT` along the same lines; this PR finishes the rest.

The signal schema was 5 hardcoded Chinese dict keys that doubled as the LLM's required JSON output keys. Renaming to English makes the wire format consistent with the rest of the codebase (which already uses `signalLabel`, `evidence`, etc. in English) and stops the prompt from having to embed Chinese literals in EN/JA/KO/RU output specs.

## Changes

- New `config/prompts_game_route.py` — 10 module-agnostic game-route prompt blocks, 5 locales each, with getters
- `config/prompts_game.py` — added 2 soccer-bound prompt blocks (pregame-context formatter labels, anger-pressure-cap message), 5 locales
- `main_routers/game_router.py` —
  - `_GAME_CONTEXT_SIGNAL_GROUPS` renamed to English keys
  - `_normalize_game_context_signals` accepts legacy zh keys via alias map (backwards-compat for in-flight state and any LLM regression)
  - 13 inline prompt sites replaced with getter calls; `language` threaded through `_format_game_context_for_prompt`, `_format_soccer_pregame_context_for_prompt`, `_compact_realtime_context_text`; archive-flow builders derive language from archived `user_language` or the active session manager
- `tests/unit/test_game_context_organizer.py` — schema key references updated zh → en
- New `tests/unit/test_game_route_prompts_i18n.py` — 5-locale roundtrip + zh-key alias compat

## Test plan

- [x] `/mnt/c/Users/wehos/.local/bin/uv.exe run pytest tests/unit/test_game_router.py tests/unit/test_game_context_organizer.py tests/unit/test_core_game_route_memory_contract.py tests/unit/test_avatar_interaction_memory_contract.py tests/unit/test_game_router_concurrency.py tests/unit/test_proactive_sm_integration.py tests/unit/test_proactive_sid_guard.py tests/unit/test_voice_session.py tests/unit/test_passthrough_to_chat_bubble.py tests/unit/test_game_llm_static_contracts.py tests/test_user_utterance_bus_publish.py tests/unit/test_game_route_prompts_i18n.py -q` — 231 passed, 3 skipped
- [x] `/mnt/c/Users/wehos/.local/bin/uv.exe run python scripts/check_prompt_hygiene.py` — clean
- [x] `/mnt/c/Users/wehos/.local/bin/uv.exe run python scripts/check_api_trailing_slash.py` — clean
- [x] `/mnt/c/Users/wehos/.local/bin/uv.exe run python scripts/check_frontend_api_trailing_slash.py` — clean
- [x] `/mnt/c/Users/wehos/.local/bin/uv.exe run python -m py_compile main_routers/game_router.py config/prompts_game.py config/prompts_game_route.py`
- [ ] Manual: open SoccerDemo with `user_language` set to en/ja/ko/ru and verify organizer / archive flow operates correctly under each locale

Note: `scripts/check_locale_key_alignment.py` does not exist in this checkout.

## Out of scope

- Renaming `config/prompts_game.py` or splitting further (deferred to the planned `config/` directory refactor)
- Migrating `prompts_sys._loc` / `_localized_template` / `_normalize_prompt_lang` between modules (the new file imports from `prompts_game.py`; can be hoisted later)
- es/pt locale support (not covered by existing soccer prompts either; `_loc` falls back to zh)
- Logger / status / debug strings (not LLM-bound)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 全面多语言化：赛前/实况/赛后提示、归档、高亮与实时上下文按用户语言渲染并回退中文；会话归档与缓存保存用户语言。
  * 添加固定会话提示水印、赛前展示标签与本地化的愤怒/压力上限提示与理由；新增本地化的事件/归档/格式化标签与提示文本，并驱动赛后主动问候与简洁实时指令。

* **修复**
  * 兼容并映射旧版信号组键名，规范化信号分组输出格式与路由。

* **测试**
  * 新增并强化多语言、信号规范、赛后高亮与愤怒/压力上限相关单元测试，校验精确文本、格式与水印保留。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->