### PR TITLE
[codex] fix i18n error placeholder params

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -2290,7 +2290,7 @@ function unsubscribeItem(itemId, itemName) {
                     return;
                 }
                 const errorMsg = (data && (data.error || data.message)) || `HTTP ${response.status}`;
-                showMessage(`${window.t ? window.t('steam.unsubscribeFailed') : '取消订阅失败'}: ${errorMsg}`, 'error');
+                showMessage(window.t ? window.t('steam.unsubscribeFailed', { error: errorMsg }) : `取消订阅失败: ${errorMsg}`, 'error');
                 restoreCard();
                 return;
             }
@@ -2375,7 +2375,7 @@ function unsubscribeItem(itemId, itemName) {
                 }
             } else {
                 const errorMsg = (data && (data.error || data.message)) || (window.t ? window.t('common.unknownError') : '未知错误');
-                showMessage(`${window.t ? window.t('steam.unsubscribeFailed') : '取消订阅失败'}: ${errorMsg}`, 'error');
+                showMessage(window.t ? window.t('steam.unsubscribeFailed', { error: errorMsg }) : `取消订阅失败: ${errorMsg}`, 'error');
                 restoreCard();
             }
         })
@@ -3012,7 +3012,8 @@ function renderCardMetaBlock(container, name, isNew, rawData) {
                     if (window._cardMetas) window._cardMetas[name] = data.meta || { ...m, author: newVal };
                     showMessage(window.t ? window.t('character.cardAuthorUpdated') : '作者已更新', 'success');
                 } catch (e) {
-                    showMessage(window.t ? window.t('character.cardAuthorUpdateFailed') : '作者更新失败', 'error');
+                    const errorMessage = e.message || String(e);
+                    showMessage(window.t ? window.t('character.cardAuthorUpdateFailed', { error: errorMessage }) : '更新作者失败: ' + errorMessage, 'error');
                     authorInput.value = author;
                 } finally { saving = false; }
             };
@@ -4459,7 +4460,8 @@ function buildCatgirlDetailForm(name, rawData, isNew, container) {
             } catch (e) {
                 console.error('重命名失败:', e);
                 if (typeof showAlert === 'function') {
-                    await showAlert(window.t ? window.t('character.renameError') : '重命名时发生错误');
+                    const errorMessage = e.message || String(e);
+                    await showAlert(window.t ? window.t('character.renameError', { error: errorMessage }) : '重命名失败: ' + errorMessage);
                 }
             }
         });
@@ -5419,7 +5421,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                 const errorJson = JSON.parse(errorText);
                 if (errorJson.error) errorMessage = errorJson.error;
             } catch (e) { /* keep original */ }
-            showMessage((window.t ? window.t('character.saveFailedWithError') : '保存失败: ') + errorMessage, 'error');
+            showMessage(window.t ? window.t('character.saveFailedWithError', { error: errorMessage }) : '保存失败: ' + errorMessage, 'error');
             return;
         }
 
@@ -5442,13 +5444,13 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                     if (!voiceResp.ok || voiceResult.success === false) {
                         const detail = (voiceResult && voiceResult.error) || (voiceResp.status + ' ' + voiceResp.statusText);
                         showMessage(
-                            (window.t ? window.t('character.partialSaveVoiceFailed') : '角色已保存，但音色更新失败: ') + detail,
+                            window.t ? window.t('character.partialSaveVoiceFailed', { error: detail }) : '角色已保存，但音色更新失败: ' + detail,
                             'error'
                         );
                     }
                 } catch (voiceErr) {
                     showMessage(
-                        (window.t ? window.t('character.partialSaveVoiceFailed') : '角色已保存，但音色更新失败: ') + (voiceErr.message || String(voiceErr)),
+                        window.t ? window.t('character.partialSaveVoiceFailed', { error: voiceErr.message || String(voiceErr) }) : '角色已保存，但音色更新失败: ' + (voiceErr.message || String(voiceErr)),
                         'error'
                     );
                 }
@@ -5461,13 +5463,13 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                     if (!clearResp.ok || clearResult.success === false) {
                         const detail = (clearResult && clearResult.error) || (clearResp.status + ' ' + clearResp.statusText);
                         showMessage(
-                            (window.t ? window.t('character.partialSaveVoiceFailed') : '角色已保存，但音色更新失败: ') + detail,
+                            window.t ? window.t('character.partialSaveVoiceFailed', { error: detail }) : '角色已保存，但音色更新失败: ' + detail,
                             'error'
                         );
                     }
                 } catch (clearErr) {
                     showMessage(
-                        (window.t ? window.t('character.partialSaveVoiceFailed') : '角色已保存，但音色更新失败: ') + (clearErr.message || String(clearErr)),
+                        window.t ? window.t('character.partialSaveVoiceFailed', { error: clearErr.message || String(clearErr) }) : '角色已保存，但音色更新失败: ' + (clearErr.message || String(clearErr)),
                         'error'
                     );
                 }
@@ -5532,7 +5534,8 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
         await loadCharacterCards();
     } catch (error) {
         console.error('保存猫娘失败:', error);
-        showMessage(window.t ? window.t('character.saveError') : '保存时发生错误: ' + error.message, 'error');
+        const errorMessage = error.message || String(error);
+        showMessage(window.t ? window.t('character.saveError', { error: errorMessage }) : '保存时发生错误: ' + errorMessage, 'error');
     } finally {
         form.dataset.submitting = 'false';
     }
@@ -9137,7 +9140,8 @@ async function renameMaster() {
             showMessage(result.error || (window.t ? window.t('character.renameFailed') : '重命名失败'), 'error');
         }
     } catch (e) {
-        showMessage(window.t ? window.t('character.renameError') : '重命名时发生错误', 'error');
+        const errorMessage = e.message || String(e);
+        showMessage(window.t ? window.t('character.renameError', { error: errorMessage }) : '重命名失败: ' + errorMessage, 'error');
     }
 }
 

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1849,7 +1849,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         showStatus(t('live2d.pixiInitialized', 'PIXI 初始化完成'));
     } catch (pixiError) {
         console.error('[模型管理] PIXI 初始化失败:', pixiError);
-        showStatus(t('live2d.pixiInitFailed', `PIXI 初始化失败: ${pixiError.message}`));
+        showStatus(t('live2d.pixiInitFailed', `PIXI 初始化失败: ${pixiError.message}`, { error: pixiError.message || String(pixiError) }));
     }
 
     // 先加载模型列表
@@ -1898,7 +1898,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await switchModelDisplay(savedModelType, savedSubType);
     } catch (switchError) {
         console.error('[模型管理] 切换模型显示模式失败:', switchError);
-        showStatus(t('live2d.switchDisplayFailed', `切换显示模式失败: ${switchError.message}`), 3000);
+        showStatus(t('live2d.switchDisplayFailed', `切换显示模式失败: ${switchError.message}`, { error: switchError.message || String(switchError) }), 3000);
     }
 
     // 注意：loadCurrentCharacterModel() 的调用已移到所有事件监听器注册之后
@@ -2719,7 +2719,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     window.vrmManager = vrmManager;
                 } catch (error) {
                     console.error('VRM 管理器创建失败:', error);
-                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器创建失败: ${error.message}`));
+                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器创建失败: ${error.message}`, { error: error.message || String(error) }));
                     return;
                 }
             }
@@ -2770,7 +2770,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             } catch (error) {
                 console.error('VRM 场景初始化失败:', error);
-                showStatus(t('live2d.vrmInitFailed', `VRM 场景初始化失败: ${error.message}`));
+                showStatus(t('live2d.vrmInitFailed', `VRM 场景初始化失败: ${error.message}`, { error: error.message || String(error) }));
             }
             } else {
                 // MMD 子类型：暂停 VRM 渲染循环，避免后台仍然绘制已缓存的 VRM 模型
@@ -3311,7 +3311,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     showStatus(t('live2d.vrmInitialized', 'VRM 管理器初始化成功'));
                 } catch (error) {
                     console.error('VRM 管理器初始化失败:', error);
-                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器初始化失败: ${error.message}`));
+                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器初始化失败: ${error.message}`, { error: error.message || String(error) }));
                     return;
                 }
             }
@@ -3328,7 +3328,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     console.log('[模型管理] VRM 场景初始化成功');
                 } catch (initError) {
                     console.error('[模型管理] 场景初始化失败:', initError);
-                    showStatus(t('live2d.vrmInitFailed', `场景初始化失败: ${initError.message}`), 5000);
+                    showStatus(t('live2d.vrmInitFailed', `场景初始化失败: ${initError.message}`, { error: initError.message || String(initError) }), 5000);
                     return;
                 }
             }
@@ -3487,7 +3487,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 showStatus(t('live2d.vrmModelLoaded', `VRM 模型 ${modelPath} 加载成功`, { model: modelPath }));
             } catch (error) {
                 console.error('加载 VRM 模型失败:', error);
-                showStatus(t('live2d.vrmModelLoadFailed', `加载 VRM 模型失败: ${error.message}。您仍可以保存模型设置。`));
+                showStatus(t('live2d.vrmModelLoadFailed', `加载 VRM 模型失败: ${error.message}。您仍可以保存模型设置。`, { error: error.message || String(error) }));
                 // 即使模型加载失败，也尝试加载动作列表（可能用户想预览其他动作）
                 try {
                     await loadVRMAnimations(false);
@@ -3732,7 +3732,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     updateVRMAnimationPlayButtonIcon();
                 } catch (error) {
                     console.error('播放 VRM 动作失败:', error);
-                    showStatus(t('live2d.vrmAnimation.animationPlayFailed', `播放动作失败: ${error.message}`));
+                    showStatus(t('live2d.vrmAnimation.animationPlayFailed', `播放动作失败: ${error.message}`, { error: error.message || String(error) }));
                     isVrmAnimationPlaying = false;
                     updateVRMAnimationPlayButtonIcon();
                 }

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -1849,7 +1849,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         showStatus(t('live2d.pixiInitialized', 'PIXI 初始化完成'));
     } catch (pixiError) {
         console.error('[模型管理] PIXI 初始化失败:', pixiError);
-        showStatus(t('live2d.pixiInitFailed', `PIXI 初始化失败: ${pixiError.message}`, { error: pixiError.message || String(pixiError) }));
+        const errMsg = (pixiError && typeof pixiError.message === 'string') ? pixiError.message : String(pixiError ?? 'Unknown error');
+        showStatus(t('live2d.pixiInitFailed', `PIXI 初始化失败: ${errMsg}`, { error: errMsg }));
     }
 
     // 先加载模型列表
@@ -1898,7 +1899,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         await switchModelDisplay(savedModelType, savedSubType);
     } catch (switchError) {
         console.error('[模型管理] 切换模型显示模式失败:', switchError);
-        showStatus(t('live2d.switchDisplayFailed', `切换显示模式失败: ${switchError.message}`, { error: switchError.message || String(switchError) }), 3000);
+        const errMsg = (switchError && typeof switchError.message === 'string') ? switchError.message : String(switchError ?? 'Unknown error');
+        showStatus(t('live2d.switchDisplayFailed', `切换显示模式失败: ${errMsg}`, { error: errMsg }), 3000);
     }
 
     // 注意：loadCurrentCharacterModel() 的调用已移到所有事件监听器注册之后
@@ -2719,7 +2721,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     window.vrmManager = vrmManager;
                 } catch (error) {
                     console.error('VRM 管理器创建失败:', error);
-                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器创建失败: ${error.message}`, { error: error.message || String(error) }));
+                    const errMsg = (error && typeof error.message === 'string') ? error.message : String(error ?? 'Unknown error');
+                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器创建失败: ${errMsg}`, { error: errMsg }));
                     return;
                 }
             }
@@ -2770,7 +2773,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             } catch (error) {
                 console.error('VRM 场景初始化失败:', error);
-                showStatus(t('live2d.vrmInitFailed', `VRM 场景初始化失败: ${error.message}`, { error: error.message || String(error) }));
+                const errMsg = (error && typeof error.message === 'string') ? error.message : String(error ?? 'Unknown error');
+                showStatus(t('live2d.vrmInitFailed', `VRM 场景初始化失败: ${errMsg}`, { error: errMsg }));
             }
             } else {
                 // MMD 子类型：暂停 VRM 渲染循环，避免后台仍然绘制已缓存的 VRM 模型
@@ -3311,7 +3315,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     showStatus(t('live2d.vrmInitialized', 'VRM 管理器初始化成功'));
                 } catch (error) {
                     console.error('VRM 管理器初始化失败:', error);
-                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器初始化失败: ${error.message}`, { error: error.message || String(error) }));
+                    const errMsg = (error && typeof error.message === 'string') ? error.message : String(error ?? 'Unknown error');
+                    showStatus(t('live2d.vrmInitFailed', `VRM 管理器初始化失败: ${errMsg}`, { error: errMsg }));
                     return;
                 }
             }
@@ -3328,7 +3333,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     console.log('[模型管理] VRM 场景初始化成功');
                 } catch (initError) {
                     console.error('[模型管理] 场景初始化失败:', initError);
-                    showStatus(t('live2d.vrmInitFailed', `场景初始化失败: ${initError.message}`, { error: initError.message || String(initError) }), 5000);
+                    const errMsg = (initError && typeof initError.message === 'string') ? initError.message : String(initError ?? 'Unknown error');
+                    showStatus(t('live2d.vrmInitFailed', `场景初始化失败: ${errMsg}`, { error: errMsg }), 5000);
                     return;
                 }
             }
@@ -3487,7 +3493,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                 showStatus(t('live2d.vrmModelLoaded', `VRM 模型 ${modelPath} 加载成功`, { model: modelPath }));
             } catch (error) {
                 console.error('加载 VRM 模型失败:', error);
-                showStatus(t('live2d.vrmModelLoadFailed', `加载 VRM 模型失败: ${error.message}。您仍可以保存模型设置。`, { error: error.message || String(error) }));
+                const errMsg = (error && typeof error.message === 'string') ? error.message : String(error ?? 'Unknown error');
+                showStatus(t('live2d.vrmModelLoadFailed', `加载 VRM 模型失败: ${errMsg}。您仍可以保存模型设置。`, { error: errMsg }));
                 // 即使模型加载失败，也尝试加载动作列表（可能用户想预览其他动作）
                 try {
                     await loadVRMAnimations(false);
@@ -3732,7 +3739,8 @@ document.addEventListener('DOMContentLoaded', async () => {
                     updateVRMAnimationPlayButtonIcon();
                 } catch (error) {
                     console.error('播放 VRM 动作失败:', error);
-                    showStatus(t('live2d.vrmAnimation.animationPlayFailed', `播放动作失败: ${error.message}`, { error: error.message || String(error) }));
+                    const errMsg = (error && typeof error.message === 'string') ? error.message : String(error ?? 'Unknown error');
+                    showStatus(t('live2d.vrmAnimation.animationPlayFailed', `播放动作失败: ${errMsg}`, { error: errMsg }));
                     isVrmAnimationPlaying = false;
                     updateVRMAnimationPlayButtonIcon();
                 }

--- a/tests/unit/test_i18n_locale_keys.py
+++ b/tests/unit/test_i18n_locale_keys.py
@@ -120,6 +120,7 @@ def test_error_placeholder_i18n_calls_pass_error_params():
             key for key, value in _flatten_leaf_strings(payload) if "{{error}}" in value
         }
 
+    assert "en.json" in locale_error_keys, "en.json locale file not found - ensure it exists in the locales directory"
     baseline = locale_error_keys["en.json"]
     assert all(keys == baseline for keys in locale_error_keys.values())
 
@@ -130,7 +131,7 @@ def test_error_placeholder_i18n_calls_pass_error_params():
     missing_error_params: list[str] = []
 
     for key in sorted(baseline):
-        pattern = re.compile(r"(?:window\.)?t\s*\(\s*['\"]" + re.escape(key) + r"['\"]")
+        pattern = re.compile(r"(?:window\.)?t\s*\(\s*['\"`]" + re.escape(key) + r"['\"`]")
         for path, source in source_texts:
             for match in pattern.finditer(source):
                 call = _extract_call(source, match.start())

--- a/tests/unit/test_i18n_locale_keys.py
+++ b/tests/unit/test_i18n_locale_keys.py
@@ -1,4 +1,6 @@
 import json
+import os
+import re
 from pathlib import Path
 
 import pytest
@@ -30,6 +32,63 @@ def mock_memory_server():
     yield
 
 
+
+
+def _flatten_leaf_strings(payload, prefix=""):
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            dotted = f"{prefix}.{key}" if prefix else key
+            yield from _flatten_leaf_strings(value, dotted)
+    elif isinstance(payload, str):
+        yield prefix, payload
+
+
+def _iter_tracked_source_files():
+    ignored_dirs = {"node_modules", "dist", "build"}
+    source_roots = (REPO_ROOT / "static" / "js", REPO_ROOT / "templates")
+    source_suffixes = {".html", ".js", ".jsx", ".py", ".ts", ".tsx"}
+    for source_root in source_roots:
+        if not source_root.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(source_root):
+            dirnames[:] = [dirname for dirname in dirnames if dirname not in ignored_dirs]
+            root = Path(dirpath)
+            if root == LOCALES_DIR or LOCALES_DIR in root.parents:
+                continue
+            for filename in filenames:
+                path = root / filename
+                if path.suffix in source_suffixes:
+                    yield path
+
+
+def _extract_call(text: str, start: int) -> str | None:
+    paren = text.find("(", start)
+    if paren < 0:
+        return None
+
+    depth = 0
+    quote = None
+    escaped = False
+    for index in range(paren, len(text)):
+        char = text[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return text[start:index + 1]
+    return None
+
 def _has_nested_key(data: dict, dotted_key: str) -> bool:
     current = data
     for part in dotted_key.split("."):
@@ -50,3 +109,33 @@ def test_tutorial_prompt_locale_keys_exist_in_all_locales():
             missing_by_locale[locale_path.name] = missing
 
     assert missing_by_locale == {}
+
+
+@pytest.mark.unit
+def test_error_placeholder_i18n_calls_pass_error_params():
+    locale_error_keys: dict[str, set[str]] = {}
+    for locale_path in sorted(LOCALES_DIR.glob("*.json")):
+        payload = json.loads(locale_path.read_text(encoding="utf-8"))
+        locale_error_keys[locale_path.name] = {
+            key for key, value in _flatten_leaf_strings(payload) if "{{error}}" in value
+        }
+
+    baseline = locale_error_keys["en.json"]
+    assert all(keys == baseline for keys in locale_error_keys.values())
+
+    source_texts = [
+        (path, path.read_text(encoding="utf-8", errors="ignore"))
+        for path in _iter_tracked_source_files()
+    ]
+    missing_error_params: list[str] = []
+
+    for key in sorted(baseline):
+        pattern = re.compile(r"(?:window\.)?t\s*\(\s*['\"]" + re.escape(key) + r"['\"]")
+        for path, source in source_texts:
+            for match in pattern.finditer(source):
+                call = _extract_call(source, match.start())
+                line = source.count("\n", 0, match.start()) + 1
+                if call is None or not re.search(r"\berror\s*:", call):
+                    missing_error_params.append(f"{path.relative_to(REPO_ROOT)}:{line}: {key}")
+
+    assert missing_error_params == []


### PR DESCRIPTION
## Summary

Fix remaining frontend i18n calls that used locale strings containing `{{error}}` without passing an `error` interpolation param.

## Root cause

The locale files already define many user-facing error strings as templates such as `... {{error}}`, but several call sites either appended the detail outside `t(...)` or called `t(...)` with no params. That can leave raw `{{error}}` visible in UI when i18n is enabled.

## Changes

- Fill `error` params for affected `character` and `steam` messages in `static/js/character_card_manager.js`.
- Fill the third `params` argument for affected `live2d` / VRM messages in `static/js/model_manager.js`.
- Add a regression test that checks every static locale key containing `{{error}}` has a matching key set across locales and that frontend `t(...)` calls for those keys pass an `error:` param.

## Validation

- `uv run pytest tests/unit/test_i18n_locale_keys.py -q` -> `2 passed`
- `python3 scripts/check_i18n_sync.py --base FETCH_HEAD` -> passed
- independent audit: `ERROR_PLACEHOLDER_KEYS 136`, `LOCALE_KEY_SET_MISMATCHES {}`, `BAD_T_CALLS 0`
- `git diff --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化错误提示信息，在角色卡相关操作失败时（如保存、重命名、更新作者）显示具体错误详情
  * 完善模型加载、场景初始化等功能失败时的错误提示准确性

* **测试**
  * 新增国际化错误占位符验证测试，确保错误消息参数传递的一致性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->