### PR TITLE
[codex] Fix plugin phase1 empty candidate handling

### DIFF
--- a/brain/plugin_filter.py
+++ b/brain/plugin_filter.py
@@ -2,11 +2,13 @@
 """
 Two-stage plugin filtering for agent assessment.
 
-Stage 1 (coarse — only when plugin descriptions > 4000 chars):
+Stage 1 (coarse — only when plugin descriptions exceed
+config.AGENT_PLUGIN_DESC_BM25_THRESHOLD tokens):
   - BM25 text matching: select plugins with token overlap to user intent
   - LLM coarse screening: pick semantically relevant plugins by id + short_description
   - Keyword hit: plugins whose configured regex keywords match the user text
-  → Union of all three goes to Stage 2
+  → Union of all three goes to Stage 2. If the union is empty, Stage 2
+    receives no plugin candidates rather than falling back to the full list.
 
 Stage 2 (fine — always runs):
   - Full LLM assessment with complete plugin descriptions (current behavior)

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -1150,8 +1150,10 @@ class DirectTaskExecutor:
     async def _assess_user_plugin(self, conversation: str, plugins: Any, lang: str = "en") -> UserPluginDecision:
         """
         Two-stage plugin assessment:
-        - Stage 2 only (< 4000 chars): full LLM assessment with all plugins
-        - Stage 1 + 2 (>= 4000 chars): BM25 + LLM coarse screen + keyword → filtered → Stage 2
+        - Stage 2 only (plugins_desc <= AGENT_PLUGIN_DESC_BM25_THRESHOLD tokens):
+          full LLM assessment with all active plugins
+        - Stage 1 + 2 (plugins_desc > AGENT_PLUGIN_DESC_BM25_THRESHOLD tokens):
+          BM25 + LLM coarse screen + keyword -> filtered candidates -> Stage 2
         """
         # 如果没有插件，快速返回
         try:
@@ -1247,8 +1249,9 @@ class DirectTaskExecutor:
                 selected_ids = bm25_ids | llm_id_set | set(keyword_hit_ids)
 
                 if not selected_ids:
-                    logger.info("[UserPlugin] Stage 1: no plugins selected, falling back to full list for stage 2")
-                    stage2_plugins = plugin_list
+                    logger.info("[UserPlugin] Stage 1: no plugins selected; stage 2 will receive no plugin candidates")
+                    stage2_plugins = []
+                    plugins_desc = "No plugins available."
                 else:
                     stage2_plugins = [p for p in plugin_list if p.get("id") in selected_ids]
                     lines = self._build_plugin_desc_lines(stage2_plugins)
@@ -1374,11 +1377,14 @@ class DirectTaskExecutor:
                 d_pid = decision.get("plugin_id")
                 d_eid = decision.get("entry_id") or decision.get("plugin_entry_id") or decision.get("event_id")
 
-                # Build lookup from ALL plugins (including pre-filtered ones) so error reasons
-                # can distinguish "no visible entries" from "plugin not found".
+                # Build the executable lookup from the plugins actually shown in this
+                # Stage 2 prompt. In large plugin lists, Stage 1 may filter every
+                # plugin out; a hallucinated id from the full registry must not pass
+                # validation just because the plugin exists globally.
                 valid_entries_map: Dict[str, List[str]] = {}
+                all_entries_map: Dict[str, List[str]] = {}
                 try:
-                    for p in all_plugin_list:
+                    for p in plugins:
                         pid = p.get("id") if isinstance(p, dict) else None
                         if not pid:
                             continue
@@ -1386,6 +1392,15 @@ class DirectTaskExecutor:
                         valid_entries_map[pid] = eids
                 except Exception:
                     valid_entries_map = {}
+                try:
+                    for p in all_plugin_list:
+                        pid = p.get("id") if isinstance(p, dict) else None
+                        if not pid:
+                            continue
+                        eids = [str(e.get("id")) for e in self._agent_visible_plugin_entries(p) if e.get("id")]
+                        all_entries_map[pid] = eids
+                except Exception:
+                    all_entries_map = {}
 
                 # Normalize numeric plugin_id (LLM may return int instead of str)
                 if isinstance(d_pid, int):
@@ -1398,7 +1413,10 @@ class DirectTaskExecutor:
                     if not d_pid:
                         correction_hint = f"plugin_id is required when has_task/can_execute are true. Available plugins: {list(valid_entries_map.keys())}"
                     elif d_pid not in valid_entries_map:
-                        correction_hint = f"plugin_id '{d_pid}' does not exist. Available plugins: {list(valid_entries_map.keys())}"
+                        if all_entries_map.get(d_pid) == []:
+                            correction_hint = f"plugin '{d_pid}' has no Agent-visible entries."
+                        else:
+                            correction_hint = f"plugin_id '{d_pid}' is not available in the current candidate set. Available plugins: {list(valid_entries_map.keys())}"
                     elif visible_entries == []:
                         correction_hint = f"plugin '{d_pid}' has no Agent-visible entries."
                     elif not d_eid and valid_entries_map.get(d_pid):
@@ -1444,10 +1462,13 @@ class DirectTaskExecutor:
                 if final_has and final_can:
                     final_visible = valid_entries_map.get(final_pid)
                     if final_pid not in valid_entries_map:
-                        logger.warning("[UserPlugin Assessment] Final check: plugin_id '%s' still invalid after retry, forcing can_execute=false", final_pid)
+                        logger.warning("[UserPlugin Assessment] Final check: plugin_id '%s' is not in current candidate set, forcing can_execute=false", final_pid)
                         final_can = False
                         decision["can_execute"] = False
-                        decision["reason"] = f"plugin_id '{final_pid}' not found"
+                        if all_entries_map.get(final_pid) == []:
+                            decision["reason"] = "no_agent_visible_entries"
+                        else:
+                            decision["reason"] = f"plugin_id '{final_pid}' not available in current candidates"
                     elif final_visible == []:
                         logger.warning(
                             "[UserPlugin Assessment] Final check: plugin_id '%s' has no Agent-visible entries, forcing can_execute=false",

--- a/tests/unit/test_user_plugin_stage1_filtering.py
+++ b/tests/unit/test_user_plugin_stage1_filtering.py
@@ -1,0 +1,100 @@
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, content: str):
+        self.content = content
+        self.calls = []
+
+    async def ainvoke(self, messages):
+        self.calls.append(messages)
+        return _FakeResponse(self.content)
+
+
+def _make_plugins():
+    return [
+        {
+            "id": "alpha",
+            "description": "alpha plugin does calendar automation",
+            "entries": [{"id": "run", "description": "run alpha"}],
+        },
+        {
+            "id": "beta",
+            "description": "beta plugin controls lights",
+            "entries": [{"id": "run", "description": "run beta"}],
+        },
+    ]
+
+
+async def _no_quota(_call_site):
+    return None
+
+
+async def _no_coarse_ids(_user_text, _plugins, lang="en"):
+    return []
+
+
+@pytest.mark.asyncio
+async def test_stage1_empty_union_does_not_fallback_to_full_plugin_list(monkeypatch):
+    from brain import task_executor as task_executor_module
+    from brain.task_executor import DirectTaskExecutor
+
+    monkeypatch.setattr(task_executor_module, "stage1_filter", lambda *args, **kwargs: ([], []))
+
+    executor = object.__new__(DirectTaskExecutor)
+    executor._STAGE1_TRIGGER_TOKENS = 1
+    executor._stage1_llm_coarse_screen = _no_coarse_ids
+    executor._check_agent_quota = _no_quota
+
+    fake_llm = _FakeLLM(
+        '{"has_task": false, "can_execute": false, "task_description": "", '
+        '"plugin_id": null, "entry_id": null, "plugin_args": null, "reason": "no candidates"}'
+    )
+    executor._get_llm = lambda **_kwargs: fake_llm
+
+    result = await executor._assess_user_plugin(
+        "LATEST_USER_REQUEST: unrelated request",
+        _make_plugins(),
+        lang="en",
+    )
+
+    assert result.can_execute is False
+    assert fake_llm.calls
+    stage2_system_prompt = fake_llm.calls[0][0]["content"]
+    assert "No plugins available." in stage2_system_prompt
+    assert "- alpha:" not in stage2_system_prompt
+    assert "- beta:" not in stage2_system_prompt
+
+
+@pytest.mark.asyncio
+async def test_stage1_empty_union_rejects_hallucinated_existing_plugin(monkeypatch):
+    from brain import task_executor as task_executor_module
+    from brain.task_executor import DirectTaskExecutor
+
+    monkeypatch.setattr(task_executor_module, "stage1_filter", lambda *args, **kwargs: ([], []))
+
+    executor = object.__new__(DirectTaskExecutor)
+    executor._STAGE1_TRIGGER_TOKENS = 1
+    executor._stage1_llm_coarse_screen = _no_coarse_ids
+    executor._check_agent_quota = _no_quota
+
+    fake_llm = _FakeLLM(
+        '{"has_task": true, "can_execute": true, "task_description": "run alpha", '
+        '"plugin_id": "alpha", "entry_id": "run", "plugin_args": {}, "reason": "hallucinated"}'
+    )
+    executor._get_llm = lambda **_kwargs: fake_llm
+
+    result = await executor._assess_user_plugin(
+        "LATEST_USER_REQUEST: unrelated request",
+        _make_plugins(),
+        lang="en",
+    )
+
+    assert result.can_execute is False
+    assert result.plugin_id == "alpha"
+    assert result.reason == "plugin_id 'alpha' not available in current candidates"


### PR DESCRIPTION
## What changed

- Stop falling back to the full plugin list when Phase 1 BM25, LLM coarse-screen, and keyword matching all select no plugin candidates.
- Validate Stage 2 plugin decisions against the candidate set actually shown to the model, so hallucinated plugin IDs outside the current candidate set cannot execute.
- Update stale Stage 1 comments/docs from the old 4000-character wording to the current token-threshold behavior.
- Add regression tests for empty Phase 1 unions and hallucinated existing plugin IDs.

## Why

When Phase 1 finds no relevant plugin, falling back to all active plugins defeats the coarse filter and can let unrelated plugins reach the final assessment. Empty selection should mean no plugin candidates for this request.

## Validation

- `/mnt/c/Users/wehos/.local/bin/uv.exe run pytest tests/unit/test_user_plugin_stage1_filtering.py tests/test_agent_rewrite_regression.py::test_task_executor_skips_plugin_with_only_agent_hidden_entries tests/test_agent_rewrite_regression.py::test_task_executor_hides_agent_auto_disabled_plugin_entries`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了插件候选集的过滤逻辑，确保在第一阶段无可用插件时，第二阶段正确处理空集合而不回退到全量列表。
  * 增强了插件验证机制，更准确地区分插件不可用的原因。
  * 新增单元测试以确保空候选集场景的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->