### PR TITLE
feat(proactive): mini-game 邀请短路通道（10% 触发 + 24h+10 chats 冷却）

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1300,6 +1300,29 @@ PROACTIVE_CHAT_HISTORY_MAX = 10
 - 用途：每个 lanlan 维护的最近主动搭话记录，用于 1h 内去重。
 - 上游：proactive 触发的搭话事件。"""
 
+MINI_GAME_INVITE_ENABLED = True
+"""Mini-game 邀请短路通道总开关（默认开）。
+- 用途：proactive_chat 在过完 propensity / skip_probability / restricted_screen_only
+  这几道门后，按 MINI_GAME_INVITE_TRIGGER_PROBABILITY 概率短路成"邀请玩家来玩
+  小游戏"，跳过 Phase 1/2 LLM。关掉此开关 = 永远不触发该分支，proactive_chat
+  退化回纯 source-driven。
+- 上游：main_routers/system_router._maybe_deliver_mini_game_invite。"""
+
+MINI_GAME_INVITE_TRIGGER_PROBABILITY = 0.1
+"""每次 eligible 主动搭话进入 mini-game 邀请短路的概率。
+- 取值约定：[0.0, 1.0]，0.0=禁用（等价于 ENABLED=False），1.0=每次都邀请。
+- 上游：random.random() < 此值 → 命中 → 走邀请短路。"""
+
+MINI_GAME_INVITE_COOLDOWN_SECONDS = 24 * 3600
+"""一次邀请被回应后的最小静默秒数（默认 24h）。
+- 配合 MINI_GAME_INVITE_COOLDOWN_CHATS：两条件都跨过才允许下次掷骰。
+- 上游：_mini_game_invite_in_cooldown 时间侧判定。"""
+
+MINI_GAME_INVITE_COOLDOWN_CHATS = 10
+"""一次邀请被回应后，需要再经过的"成功投递的主动搭话"次数。
+- 与 MINI_GAME_INVITE_COOLDOWN_SECONDS 同时满足才解禁；任一不满足都继续抑制。
+- 上游：_mini_game_invite_in_cooldown 计数侧判定。"""
+
 PROACTIVE_SOURCE_HARD_SKIP_SECONDS = 5 * 3600
 """主动搭话 source 衰减历史的硬窗口（p_skip=1.0）。
 - 用途：5h 内同一 URL 必跳，超过后按 kind 半衰期指数衰减。
@@ -1591,6 +1614,10 @@ __all__ = [
     'PROACTIVE_PHASE2_GENERATE_MAX_TOKENS',
     'PROACTIVE_PHASE1_UNIFIED_MAX_TOKENS',
     'PROACTIVE_CHAT_HISTORY_MAX',
+    'MINI_GAME_INVITE_ENABLED',
+    'MINI_GAME_INVITE_TRIGGER_PROBABILITY',
+    'MINI_GAME_INVITE_COOLDOWN_SECONDS',
+    'MINI_GAME_INVITE_COOLDOWN_CHATS',
     'PROACTIVE_SOURCE_HARD_SKIP_SECONDS',
     'PROACTIVE_SOURCE_HALF_LIFE_BY_KIND',
     'PROACTIVE_SOURCE_HALF_LIFE_DEFAULT',

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2329,11 +2329,24 @@ MEME_SECTION_FOOTER = {
 
 # ---------- 主动搭话信息源标签 ----------
 PROACTIVE_SOURCE_LABELS = {
-    'zh': {'news': '热议话题', 'video': '视频推荐', 'home': '首页推荐', 'window': '窗口上下文', 'personal': '个人动态', 'music': '音乐推荐'},
-    'en': {'news': 'Trending Topics', 'video': 'Video Recommendations', 'home': 'Home Recommendations', 'window': 'Window Context', 'personal': 'Personal Updates', 'music': 'Music Recommendations'},
-    'ja': {'news': 'トレンド話題', 'video': '動画のおすすめ', 'home': 'ホームおすすめ', 'window': 'ウィンドウコンテキスト', 'personal': '個人の動向', 'music': '音楽のおすすめ'},
-    'ko': {'news': '화제의 토픽', 'video': '동영상 추천', 'home': '홈 추천', 'window': '창 컨텍스트', 'personal': '개인 소식', 'music': '음악 추천'},
-    'ru': {'news': 'Горячие темы', 'video': 'Видео рекомендации', 'home': 'Рекомендации на главной', 'window': 'Контекст окна', 'personal': 'Личные новости', 'music': 'Музыкальные рекомендации'},
+    'zh': {'news': '热议话题', 'video': '视频推荐', 'home': '首页推荐', 'window': '窗口上下文', 'personal': '个人动态', 'music': '音乐推荐', 'mini_game': '小游戏邀请'},
+    'en': {'news': 'Trending Topics', 'video': 'Video Recommendations', 'home': 'Home Recommendations', 'window': 'Window Context', 'personal': 'Personal Updates', 'music': 'Music Recommendations', 'mini_game': 'Mini-game Invitation'},
+    'ja': {'news': 'トレンド話題', 'video': '動画のおすすめ', 'home': 'ホームおすすめ', 'window': 'ウィンドウコンテキスト', 'personal': '個人の動向', 'music': '音楽のおすすめ', 'mini_game': 'ミニゲームのお誘い'},
+    'ko': {'news': '화제의 토픽', 'video': '동영상 추천', 'home': '홈 추천', 'window': '창 컨텍스트', 'personal': '개인 소식', 'music': '음악 추천', 'mini_game': '미니게임 초대'},
+    'ru': {'news': 'Горячие темы', 'video': 'Видео рекомендации', 'home': 'Рекомендации на главной', 'window': 'Контекст окна', 'personal': 'Личные новости', 'music': 'Музыкальные рекомендации', 'mini_game': 'Приглашение в мини-игру'},
+}
+
+# ---------- Mini-game 邀请短路文案 ----------
+# proactive_chat 在 propensity / skip_probability / restricted_screen_only
+# 全过之后 10% 概率短路成"邀请玩家来玩小游戏"，跳过 Phase 1/2 LLM。文案保持
+# 单句、轻量、不预设玩家答应；称呼用 master_name 实名，不用"主人"等物化称呼。
+# 24h+10 chats cooldown 在 main_routers.system_router 那侧管理，与文案解耦。
+MINI_GAME_INVITE_LINE = {
+    'zh': '{master_name}，要不要现在跟我一起踢一会儿足球小游戏？',
+    'en': "{master_name}, want to play a quick round of the soccer mini-game with me?",
+    'ja': '{master_name}、今ちょっとサッカーのミニゲーム、一緒にやらない？',
+    'ko': '{master_name}, 지금 같이 축구 미니게임 한 판 어때?',
+    'ru': '{master_name}, не хочешь сыграть со мной партию в мини-футбол?',
 }
 
 # ---------- 音乐搜索结果格式化 ----------

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -73,6 +73,10 @@ from config import (
     PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
     PROACTIVE_PHASE1_UNIFIED_MAX_TOKENS,
     PROACTIVE_CHAT_HISTORY_MAX,
+    MINI_GAME_INVITE_ENABLED,
+    MINI_GAME_INVITE_TRIGGER_PROBABILITY,
+    MINI_GAME_INVITE_COOLDOWN_SECONDS,
+    MINI_GAME_INVITE_COOLDOWN_CHATS,
     PROACTIVE_SOURCE_HARD_SKIP_SECONDS,
     PROACTIVE_SOURCE_HALF_LIFE_BY_KIND,
     PROACTIVE_SOURCE_HALF_LIFE_DEFAULT,
@@ -111,6 +115,7 @@ from config.prompts_proactive import (
     PROACTIVE_SOURCE_LABELS,
     PROACTIVE_MUSIC_TAG_INSTRUCTIONS,
     MUSIC_SEARCH_RESULT_TEXTS,
+    MINI_GAME_INVITE_LINE,
     build_proactive_action_note,
 )
 from utils.file_utils import atomic_write_json_async, read_json
@@ -1465,6 +1470,20 @@ async def get_changelog(since: str = "", lang: str = ""):
 # {lanlan_name: deque([(timestamp, message), ...], maxlen=10)}
 _proactive_chat_history: dict[str, deque] = {}
 
+# --- Mini-game 邀请短路状态（每角色独立）---
+# {lanlan_name: {'delivered_at': float|None,
+#                'responded_at': float|None,
+#                'chats_since_response': int}}
+# - delivered_at: 上次成功投递邀请的时间戳。None=从未发过 / 已过完整冷却。
+# - responded_at: 投递后被用户回应（任何用户消息时间戳 > delivered_at）的时间。
+#   pending（delivered_at!=None and responded_at=None）期间一律抑制掷骰，避免
+#   邀请挂着不响应又再发第二次。
+# - chats_since_response: responded_at 设上后成功投递的"普通主动搭话"次数。
+#   两条件（>= COOLDOWN_SECONDS 且 >= COOLDOWN_CHATS）都跨过才允许下次掷骰。
+# 进程内 dict，重启清零——24h 跟 10 chats 都是软冷却，重启后多发一次邀请的
+# 代价远小于持久化存储引依赖的代价；与 _proactive_chat_history 同样是内存。
+_mini_game_invite_state: dict[str, dict[str, Any]] = {}
+
 _RECENT_CHAT_MAX_AGE_SECONDS = 3600  # 1小时内的搭话记录
 _PROACTIVE_SIMILARITY_THRESHOLD = 0.94  # 高阈值，尽量避免误杀
 _PHASE1_FETCH_PER_SOURCE = PROACTIVE_PHASE1_FETCH_PER_SOURCE  # Phase 1 每个信息源固定抓取条数
@@ -1974,6 +1993,184 @@ def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
     if lanlan_name not in _proactive_chat_history:
         _proactive_chat_history[lanlan_name] = deque(maxlen=PROACTIVE_CHAT_HISTORY_MAX)
     _proactive_chat_history[lanlan_name].append((time.time(), message, channel))
+
+
+# ---------- Mini-game 邀请短路状态管理 ----------
+# 入口在 proactive_chat 内部、过完 propensity / skip_probability /
+# restricted_screen_only 几道门之后调 _maybe_deliver_mini_game_invite。命中
+# 即静态 i18n 模板 → feed_tts_chunk + finish_proactive_delivery 直投递；不走
+# Phase 1/2 LLM。冷却语义：一次邀请被回应后，必须同时跨过
+#   ``time.time() - responded_at >= MINI_GAME_INVITE_COOLDOWN_SECONDS``
+# 与
+#   ``chats_since_response >= MINI_GAME_INVITE_COOLDOWN_CHATS``
+# 才允许下次掷骰。pending（投递了但还没被回应）期间一律抑制，避免邀请挂着
+# 不响应又再发第二次。
+
+def _mini_game_invite_get_state(lanlan_name: str) -> dict[str, Any]:
+    """Lazy-init per-character state."""
+    state = _mini_game_invite_state.get(lanlan_name)
+    if state is None:
+        state = {
+            'delivered_at': None,
+            'responded_at': None,
+            'chats_since_response': 0,
+        }
+        _mini_game_invite_state[lanlan_name] = state
+    return state
+
+
+def _mini_game_invite_advance_response(lanlan_name: str, activity_snapshot) -> None:
+    """如果有 pending 邀请且用户已经在 delivered_at 之后说过话，标记为已回应。
+
+    每次进 proactive_chat 都调一次。activity_snapshot 可能为 None（隐私模式 /
+    tracker 不可用），或 seconds_since_user_msg 为 None（进程内 user 从未说过
+    话）——任一缺失都按"未回应"保留 pending，不主动 flip。"""
+    state = _mini_game_invite_state.get(lanlan_name)
+    if not state:
+        return
+    if state['delivered_at'] is None or state['responded_at'] is not None:
+        return
+    if activity_snapshot is None:
+        return
+    secs = getattr(activity_snapshot, 'seconds_since_user_msg', None)
+    if secs is None:
+        return
+    now = time.time()
+    last_user_msg_at = now - float(secs)
+    if last_user_msg_at > state['delivered_at']:
+        state['responded_at'] = now
+        state['chats_since_response'] = 0
+        logger.info(
+            "[%s] mini-game invite responded "
+            "(delivered_at=%.1fs ago, last user msg=%.1fs ago)",
+            lanlan_name, now - state['delivered_at'], float(secs),
+        )
+
+
+def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:
+    """是否处于冷却期。True = 本轮不该掷骰。
+
+    覆盖：
+      - pending（投递了但 responded_at=None）→ True
+      - 已回应但 24h 或 10 chats 任一未跨过 → True
+      - 从未投递 / 已完整跨过两道 → False
+    """
+    state = _mini_game_invite_state.get(lanlan_name)
+    if not state or state['delivered_at'] is None:
+        return False
+    if state['responded_at'] is None:
+        return True
+    elapsed = time.time() - state['responded_at']
+    return (
+        elapsed < MINI_GAME_INVITE_COOLDOWN_SECONDS
+        or state['chats_since_response'] < MINI_GAME_INVITE_COOLDOWN_CHATS
+    )
+
+
+def _mini_game_invite_record_delivered(lanlan_name: str) -> None:
+    """记录一次成功投递的邀请。重置 responded/counter 进入新一轮 pending。"""
+    state = _mini_game_invite_get_state(lanlan_name)
+    state['delivered_at'] = time.time()
+    state['responded_at'] = None
+    state['chats_since_response'] = 0
+
+
+def _mini_game_invite_count_post_response_chat(lanlan_name: str) -> None:
+    """每次成功投递的主动搭话调一次：若上次邀请已被回应，counter +1。
+
+    在 _record_proactive_chat 后立即调。任何 channel 都计——只要 AI 真发了
+    一条主动搭话出去，"24h+10次"里的 10 次门就推进一格。pending 期间（还没
+    被回应）此函数 no-op，避免靠"邀请自身这一条"提前耗 counter。"""
+    state = _mini_game_invite_state.get(lanlan_name)
+    if not state or state['responded_at'] is None:
+        return
+    state['chats_since_response'] += 1
+
+
+async def _maybe_deliver_mini_game_invite(
+    *,
+    lanlan_name: str,
+    mgr,
+    activity_snapshot,
+    invite_lang: str,
+    master_name: str,
+) -> dict | None:
+    """命中即投递 mini-game 邀请、返回 _end_proactive 用的 JSON dict；未命中返 None。
+
+    短路条件（任一不满足即返 None，由 caller 继续走原 Phase1/2 流水线）：
+      - MINI_GAME_INVITE_ENABLED=False
+      - activity_snapshot is None（隐私模式 / tracker 不可用——保守不发）
+      - propensity == 'restricted_screen_only'（focused_work / non-casual gaming）
+      - state == 'away'（用户离场，邀请没人接）
+      - _mini_game_invite_in_cooldown
+      - random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY
+
+    投递路径完全镜像 ``main_routers/game_router._deliver_postgame_text_bubble``：
+    prepare_proactive_delivery → feed_tts_chunk → finish_proactive_delivery。
+    不走 Phase 1/2 LLM；文案来自 ``MINI_GAME_INVITE_LINE`` 静态 i18n 模板。"""
+    if not MINI_GAME_INVITE_ENABLED:
+        return None
+    if activity_snapshot is None:
+        return None
+    propensity = getattr(activity_snapshot, 'propensity', None)
+    state_label = getattr(activity_snapshot, 'state', None)
+    if propensity == 'restricted_screen_only':
+        return None
+    if state_label == 'away':
+        return None
+    if _mini_game_invite_in_cooldown(lanlan_name):
+        return None
+    import random as _random
+    if _random.random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY:
+        return None
+
+    template = _loc(MINI_GAME_INVITE_LINE, invite_lang)
+    safe_master = (master_name or '').strip()
+    try:
+        invite_text = template.format(master_name=safe_master).strip()
+    except Exception:
+        invite_text = template.replace('{master_name}', safe_master).strip()
+    if not invite_text:
+        return None
+
+    if not await mgr.prepare_proactive_delivery(min_idle_secs=10.0):
+        return {
+            "success": True,
+            "action": "pass",
+            "message": "mini-game invite skipped: prepare_proactive_delivery refused",
+        }
+    proactive_sid = mgr.current_speech_id
+    from main_logic.session_state import SessionEvent as _SE
+    await mgr.state.fire(_SE.PROACTIVE_PHASE2)
+    try:
+        feed = getattr(mgr, 'feed_tts_chunk', None)
+        if callable(feed):
+            await feed(invite_text, expected_speech_id=proactive_sid)
+    except Exception as exc:
+        logger.warning(
+            "[%s] mini-game invite feed_tts_chunk failed: %s", lanlan_name, exc,
+        )
+    committed = await mgr.finish_proactive_delivery(
+        invite_text,
+        expected_speech_id=proactive_sid,
+    )
+    if not committed:
+        return {
+            "success": True,
+            "action": "pass",
+            "message": "mini-game invite skipped: user took over before delivery",
+        }
+    _record_proactive_chat(lanlan_name, invite_text, channel='mini_game')
+    _mini_game_invite_record_delivered(lanlan_name)
+    print(f"[{lanlan_name}] Mini-game invite delivered: {invite_text[:60]}…")
+    return {
+        "success": True,
+        "action": "chat",
+        "message": "mini-game invite delivered",
+        "channel": "mini_game",
+        "lanlan_name": lanlan_name,
+        "turn_id": proactive_sid,
+    }
 
 
 def _clear_channel_from_proactive_history(lanlan_name: str, channel: str) -> int:
@@ -3621,6 +3818,11 @@ async def proactive_chat(request: Request):
                 logger.warning(f"[{lanlan_name}] activity snapshot fetch failed: {_act_err}; falling back to open propensity")
                 activity_snapshot = None
 
+        # 进 proactive_chat 后第一时间推进 mini-game invite 的"已回应"判定：
+        # 即便本轮不发邀请，pending 的上一次邀请也得在用户已说话时翻成已回应，
+        # 否则 cooldown 永远卡在 pending。
+        _mini_game_invite_advance_response(lanlan_name, activity_snapshot)
+
         # ========== Hard short-circuit: propensity=closed ==========
         # ``private`` state pins propensity to ``closed`` (see
         # main_logic/activity/snapshot.py). Skip everything — no LLM,
@@ -3718,6 +3920,32 @@ async def proactive_chat(request: Request):
                 }))
 
         print(f"[{lanlan_name}] 启用的搭话模式: {enabled_modes}")
+
+        # ========== Mini-game 邀请短路 ==========
+        # 过完 propensity / skip_probability / restricted_screen_only 这几道门后，
+        # 独立掷一次 10% 骰子；命中即用静态 i18n 模板直投递邀请，跳过 Phase 1/2
+        # LLM 与 source fetching。一次邀请被回应后 24h+10 chats cooldown，期间
+        # 不再掷骰。activity_snapshot is None（隐私模式 / tracker 不可用）保守
+        # 不发——无法判断是否在工作状态。
+        try:
+            _request_lang_for_invite = (
+                data.get('language') or data.get('lang') or data.get('i18n_language')
+            )
+            invite_lang = (
+                normalize_language_code(_request_lang_for_invite, format='short')
+                if _request_lang_for_invite else get_global_language()
+            )
+        except Exception:
+            invite_lang = 'zh'
+        invite_outcome = await _maybe_deliver_mini_game_invite(
+            lanlan_name=lanlan_name,
+            mgr=mgr,
+            activity_snapshot=activity_snapshot,
+            invite_lang=invite_lang,
+            master_name=master_name_current,
+        )
+        if invite_outcome is not None:
+            return await _end_proactive(JSONResponse(invite_outcome))
 
         # 全局 source 衰减历史：进入 picking 前确保已惰性加载到内存（首次为线程池
         # IO，后续是 O(1) flag 检查）。同步 picking loop 后续直接读 dict。
@@ -5057,6 +5285,10 @@ async def proactive_chat(request: Request):
 
         # 记录主动搭话
         _record_proactive_chat(lanlan_name, response_text, primary_channel)
+        # Mini-game 邀请冷却 counter 推进：spec 是"被回应后再 10 次搭话才解禁"，
+        # 任何 channel 的成功投递都算一次，pending 期间（responded_at=None）函数
+        # 内部自然 no-op，不靠"邀请自身"提前耗 counter。
+        _mini_game_invite_count_post_response_chat(lanlan_name)
         # Reminiscence usage：本轮 surfaced 了 pending reflection（不管 AI 最终
         # 用了什么标签，followup 都出现在 prompt 里）→ 记一次 reminiscence 用量。
         # 用独立 buffer (_reminiscence_usage_history) 而不是把同一条 message

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2038,7 +2038,11 @@ def _mini_game_invite_advance_response(lanlan_name: str, activity_snapshot) -> N
     now = time.time()
     last_user_msg_at = now - float(secs)
     if last_user_msg_at > state['delivered_at']:
-        state['responded_at'] = now
+        # Anchor 到用户实际回应时间戳，而不是"我们注意到的时刻"。advance_response
+        # 只在每次新一轮 proactive_chat 跑时被调，user 回完到下次 proactive 之间
+        # 可能隔几小时；用 now 会让 24h 冷却窗口被这段间隔白白拉长，违背 spec
+        # 「回应之后 24 小时」的字面含义。
+        state['responded_at'] = last_user_msg_at
         state['chats_since_response'] = 0
         logger.info(
             "[%s] mini-game invite responded "

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2106,6 +2106,9 @@ async def _maybe_deliver_mini_game_invite(
       - activity_snapshot is None（隐私模式 / tracker 不可用——保守不发）
       - propensity == 'restricted_screen_only'（focused_work / non-casual gaming）
       - state == 'away'（用户离场，邀请没人接）
+      - activity_snapshot.unfinished_thread is not None（AI 刚抛了问题用户
+        还没接，跟进 thread 优先于换话题；与 skip_probability /
+        restricted_screen_only 对 unfinished_thread 的优先级约定对齐）
       - _mini_game_invite_in_cooldown
       - random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY
 
@@ -2121,6 +2124,11 @@ async def _maybe_deliver_mini_game_invite(
     if propensity == 'restricted_screen_only':
         return None
     if state_label == 'away':
+        return None
+    # AI 上一轮抛了问题（含 ?/吗/呢/么 等）用户还没接 → 跟进 thread 优先。
+    # skip_probability 在 system_router.py 同一文件的 propensity 段也是这条
+    # 优先级，统一不让 mini-game 邀请把 promised follow-up 抢走。
+    if getattr(activity_snapshot, 'unfinished_thread', None) is not None:
         return None
     if _mini_game_invite_in_cooldown(lanlan_name):
         return None

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2019,35 +2019,36 @@ def _mini_game_invite_get_state(lanlan_name: str) -> dict[str, Any]:
     return state
 
 
-def _mini_game_invite_advance_response(lanlan_name: str, activity_snapshot) -> None:
+def _mini_game_invite_advance_response(
+    lanlan_name: str, last_user_msg_at: float | None,
+) -> None:
     """如果有 pending 邀请且用户已经在 delivered_at 之后说过话，标记为已回应。
 
-    每次进 proactive_chat 都调一次。activity_snapshot 可能为 None（隐私模式 /
-    tracker 不可用），或 seconds_since_user_msg 为 None（进程内 user 从未说过
-    话）——任一缺失都按"未回应"保留 pending，不主动 flip。"""
+    每次进 proactive_chat（含 voice fast path 与 text path 两条）都调一次。
+    last_user_msg_at 是「用户最后一次活动的时间戳」——caller 负责从合适来源
+    解出来：text path 用 activity_snapshot.seconds_since_user_msg 反推；voice
+    path 直接用 mgr.last_user_activity_time（voice 不走 activity tracker，但
+    session 自己跟踪 RMS / 文本输入活动）。任一缺失（None）都按"未回应"保留
+    pending，不主动 flip。
+
+    Anchor 到 last_user_msg_at 而不是"检测到的此刻"——advance 只在新一轮
+    proactive_chat 跑时被调，user 回完到下次 proactive 之间可能隔几小时，
+    用 now 会让 24h 冷却被这段间隔白白拉长。"""
     state = _mini_game_invite_state.get(lanlan_name)
     if not state:
         return
     if state['delivered_at'] is None or state['responded_at'] is not None:
         return
-    if activity_snapshot is None:
+    if last_user_msg_at is None:
         return
-    secs = getattr(activity_snapshot, 'seconds_since_user_msg', None)
-    if secs is None:
-        return
-    now = time.time()
-    last_user_msg_at = now - float(secs)
     if last_user_msg_at > state['delivered_at']:
-        # Anchor 到用户实际回应时间戳，而不是"我们注意到的时刻"。advance_response
-        # 只在每次新一轮 proactive_chat 跑时被调，user 回完到下次 proactive 之间
-        # 可能隔几小时；用 now 会让 24h 冷却窗口被这段间隔白白拉长，违背 spec
-        # 「回应之后 24 小时」的字面含义。
-        state['responded_at'] = last_user_msg_at
+        state['responded_at'] = float(last_user_msg_at)
         state['chats_since_response'] = 0
+        now = time.time()
         logger.info(
             "[%s] mini-game invite responded "
             "(delivered_at=%.1fs ago, last user msg=%.1fs ago)",
-            lanlan_name, now - state['delivered_at'], float(secs),
+            lanlan_name, now - state['delivered_at'], now - float(last_user_msg_at),
         )
 
 
@@ -3742,6 +3743,14 @@ async def proactive_chat(request: Request):
         # 语音模式下不走 Phase1/Phase2，不占 SM 的 proactive phase；先用只读
         # can_start_proactive 做 409 判定即可。
         if data.get('voice_mode') and mgr.is_active and isinstance(mgr.session, OmniRealtimeClient):
+            # Mini-game invite 状态机推进：voice fast path 不走 activity tracker，
+            # 直接用 mgr.last_user_activity_time（session 自己跟踪 RMS / 文本输入
+            # 活动）作为「用户最后一次活动时间」喂给 advance_response。否则纯
+            # voice 用户收到 mini-game 邀请回应后，pending 永远翻不掉，邀请会被
+            # 永久抑制；CodeRabbit Major review 指出。
+            _mini_game_invite_advance_response(
+                lanlan_name, getattr(mgr, 'last_user_activity_time', None),
+            )
             if not mgr.state.can_start_proactive(session=probe_session):
                 return JSONResponse({
                     "success": False,
@@ -3750,6 +3759,10 @@ async def proactive_chat(request: Request):
                     "state": mgr.state.snapshot(),
                 }, status_code=409)
             delivered = await mgr.trigger_voice_proactive_nudge()
+            if delivered:
+                # 24h+10 chats 冷却的 chat counter：voice nudge 也算一次主动搭话，
+                # 与 text path 在 _record_proactive_chat 之后调 count 对称。
+                _mini_game_invite_count_post_response_chat(lanlan_name)
             return JSONResponse({
                 "success": True,
                 "action": "chat" if delivered else "pass",
@@ -3832,8 +3845,15 @@ async def proactive_chat(request: Request):
 
         # 进 proactive_chat 后第一时间推进 mini-game invite 的"已回应"判定：
         # 即便本轮不发邀请，pending 的上一次邀请也得在用户已说话时翻成已回应，
-        # 否则 cooldown 永远卡在 pending。
-        _mini_game_invite_advance_response(lanlan_name, activity_snapshot)
+        # 否则 cooldown 永远卡在 pending。Text path 从 activity_snapshot 反推
+        # last_user_msg_at；voice fast path 在上面的 voice block 内独立调一次
+        # （用 mgr.last_user_activity_time），两边对称。
+        _text_last_user_msg_at: float | None = None
+        if activity_snapshot is not None:
+            _secs = getattr(activity_snapshot, 'seconds_since_user_msg', None)
+            if _secs is not None:
+                _text_last_user_msg_at = time.time() - float(_secs)
+        _mini_game_invite_advance_response(lanlan_name, _text_last_user_msg_at)
 
         # ========== Hard short-circuit: propensity=closed ==========
         # ``private`` state pins propensity to ``closed`` (see

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -151,8 +151,14 @@ def test_advance_response_noop_when_seconds_since_user_msg_none():
 
 
 def test_advance_response_flips_when_user_spoke_after_invite():
-    """用户在 delivered_at 之后说过话 → 标记已回应、计数清零。"""
-    delivered_at = time.time() - 30
+    """用户在 delivered_at 之后说过话 → 标记已回应、计数清零。
+
+    `responded_at` 必须 anchor 到 *真实* 回应时间（now - seconds_since_user_msg），
+    而不是「检测到回应的此刻」。advance_response 只在下次 proactive_chat 才跑，
+    user 回完到下次 proactive 可能隔几小时；anchor 用 now 会让 24h 冷却被这段
+    间隔白白拉长。"""
+    now_at_call = time.time()
+    delivered_at = now_at_call - 30
     state = sr._mini_game_invite_get_state(LANLAN)
     state['delivered_at'] = delivered_at
     state['responded_at'] = None
@@ -165,6 +171,39 @@ def test_advance_response_flips_when_user_spoke_after_invite():
     assert state['responded_at'] is not None
     assert state['responded_at'] >= delivered_at
     assert state['chats_since_response'] == 0
+    # Anchor 必须落在 last_user_msg_at（≈ now - 5s）附近，不是 now。
+    # 给 1.5s 容差，覆盖 advance_response 内部 time.time() 与 test 抓的
+    # now_at_call 之间的微秒级漂移；远小于"5s vs 0s"的分辨率。
+    assert state['responded_at'] < now_at_call - 3.0, (
+        f"responded_at={state['responded_at']:.3f} 没有 anchor 到用户实际回应时间"
+        f"（应 ≈ {now_at_call - 5:.3f}），疑似回归到了 now"
+    )
+
+
+def test_advance_response_anchors_even_when_proactive_runs_long_after_reply():
+    """关键回归保护：用户回完话后过 2 小时才跑下一次 proactive_chat，
+    `responded_at` 必须 anchor 到 ~2 小时前的回应时刻，而不是 now。否则
+    24h 冷却会被这段静默期白吃，整体冷却变成 ~26 小时，违背 spec。"""
+    now_at_call = time.time()
+    # 模拟：邀请投递在 2h+10s 前；用户 2h 前回过话；之后一直没动；现在
+    # 第二次 proactive_chat 进来终于把 advance 跑上。
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = now_at_call - 2 * 3600 - 10
+    state['responded_at'] = None
+    state['chats_since_response'] = 0
+
+    sr._mini_game_invite_advance_response(
+        LANLAN, _make_snapshot(seconds_since_user_msg=2 * 3600.0)
+    )
+    assert state['responded_at'] is not None
+    # responded_at 必须落在 ~2h 前，绝不能是 now。容差给 5s，覆盖 time.time()
+    # 漂移 + 整数化误差。
+    expected = now_at_call - 2 * 3600
+    assert abs(state['responded_at'] - expected) < 5.0, (
+        f"responded_at={state['responded_at']:.1f} 偏离用户实际回应时间 "
+        f"{expected:.1f}（now={now_at_call:.1f}），24h 冷却会被多锁约 "
+        f"{(state['responded_at'] - expected) / 3600:.2f}h"
+    )
 
 
 def test_advance_response_does_not_flip_when_last_user_msg_predates_invite():

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -156,15 +156,19 @@ def test_advance_response_noop_when_seconds_since_user_msg_none():
     assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
 
 
-def test_advance_response_flips_when_user_spoke_after_invite():
+def test_advance_response_flips_when_user_spoke_after_invite(monkeypatch):
     """用户在 delivered_at 之后说过话 → 标记已回应、计数清零。
 
     `responded_at` 必须 anchor 到 *真实* 回应时间（now - seconds_since_user_msg），
     而不是「检测到回应的此刻」。advance_response 只在下次 proactive_chat 才跑，
     user 回完到下次 proactive 可能隔几小时；anchor 用 now 会让 24h 冷却被这段
-    间隔白白拉长。"""
-    now_at_call = time.time()
-    delivered_at = now_at_call - 30
+    间隔白白拉长。
+
+    冻结 sr.time.time —— 测试断言不依赖真实时钟、CI 拥塞下也确定。"""
+    fixed_now = 1_700_000_000.0
+    monkeypatch.setattr(sr.time, 'time', lambda: fixed_now)
+
+    delivered_at = fixed_now - 30
     state = sr._mini_game_invite_get_state(LANLAN)
     state['delivered_at'] = delivered_at
     state['responded_at'] = None
@@ -175,26 +179,28 @@ def test_advance_response_flips_when_user_spoke_after_invite():
         LANLAN, _make_snapshot(seconds_since_user_msg=5.0)
     )
     assert state['responded_at'] is not None
-    assert state['responded_at'] >= delivered_at
     assert state['chats_since_response'] == 0
-    # Anchor 必须落在 last_user_msg_at（≈ now - 5s）附近，不是 now。
-    # 给 1.5s 容差，覆盖 advance_response 内部 time.time() 与 test 抓的
-    # now_at_call 之间的微秒级漂移；远小于"5s vs 0s"的分辨率。
-    assert state['responded_at'] < now_at_call - 3.0, (
-        f"responded_at={state['responded_at']:.3f} 没有 anchor 到用户实际回应时间"
-        f"（应 ≈ {now_at_call - 5:.3f}），疑似回归到了 now"
+    # Anchor 精确等于 last_user_msg_at = fixed_now - 5；冻结时钟下没有漂移，
+    # 不需要容差——直接精确断言，回归到 now（=fixed_now）会立刻挂。
+    assert state['responded_at'] == fixed_now - 5.0, (
+        f"responded_at={state['responded_at']:.3f} 应等于 last_user_msg_at "
+        f"({fixed_now - 5:.3f})；={fixed_now} 说明回归到了 now"
     )
 
 
-def test_advance_response_anchors_even_when_proactive_runs_long_after_reply():
+def test_advance_response_anchors_even_when_proactive_runs_long_after_reply(monkeypatch):
     """关键回归保护：用户回完话后过 2 小时才跑下一次 proactive_chat，
     `responded_at` 必须 anchor 到 ~2 小时前的回应时刻，而不是 now。否则
-    24h 冷却会被这段静默期白吃，整体冷却变成 ~26 小时，违背 spec。"""
-    now_at_call = time.time()
+    24h 冷却会被这段静默期白吃，整体冷却变成 ~26 小时，违背 spec。
+
+    冻结 sr.time.time —— anchor 是不是真的 = last_user_msg_at 可以精确比对。"""
+    fixed_now = 1_700_010_000.0
+    monkeypatch.setattr(sr.time, 'time', lambda: fixed_now)
+
     # 模拟：邀请投递在 2h+10s 前；用户 2h 前回过话；之后一直没动；现在
     # 第二次 proactive_chat 进来终于把 advance 跑上。
     state = sr._mini_game_invite_get_state(LANLAN)
-    state['delivered_at'] = now_at_call - 2 * 3600 - 10
+    state['delivered_at'] = fixed_now - 2 * 3600 - 10
     state['responded_at'] = None
     state['chats_since_response'] = 0
 
@@ -202,13 +208,11 @@ def test_advance_response_anchors_even_when_proactive_runs_long_after_reply():
         LANLAN, _make_snapshot(seconds_since_user_msg=2 * 3600.0)
     )
     assert state['responded_at'] is not None
-    # responded_at 必须落在 ~2h 前，绝不能是 now。容差给 5s，覆盖 time.time()
-    # 漂移 + 整数化误差。
-    expected = now_at_call - 2 * 3600
-    assert abs(state['responded_at'] - expected) < 5.0, (
-        f"responded_at={state['responded_at']:.1f} 偏离用户实际回应时间 "
-        f"{expected:.1f}（now={now_at_call:.1f}），24h 冷却会被多锁约 "
-        f"{(state['responded_at'] - expected) / 3600:.2f}h"
+    # 冻结时钟下应精确等于 fixed_now - 2h；回归到 now 会让 24h 冷却被多锁 2h。
+    expected = fixed_now - 2 * 3600
+    assert state['responded_at'] == expected, (
+        f"responded_at={state['responded_at']:.1f} 应严格等于 "
+        f"{expected:.1f}（fixed_now={fixed_now}），偏差说明 anchor 出错"
     )
 
 

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -27,13 +27,19 @@ LANLAN = "test_lanlan"
 MASTER = "小明"
 
 
-def _make_snapshot(state="casual_browsing", propensity="open", seconds_since_user_msg=None):
+def _make_snapshot(
+    state="casual_browsing",
+    propensity="open",
+    seconds_since_user_msg=None,
+    unfinished_thread=None,
+):
     """构造一个 ActivitySnapshot duck-typed 替身——只用到 .state /
-    .propensity / .seconds_since_user_msg 三个字段。"""
+    .propensity / .seconds_since_user_msg / .unfinished_thread 四个字段。"""
     return types.SimpleNamespace(
         state=state,
         propensity=propensity,
         seconds_since_user_msg=seconds_since_user_msg,
+        unfinished_thread=unfinished_thread,
     )
 
 
@@ -296,6 +302,24 @@ async def test_maybe_deliver_returns_none_when_away(monkeypatch):
     out = await sr._maybe_deliver_mini_game_invite(
         lanlan_name=LANLAN, mgr=_make_mgr(),
         activity_snapshot=_make_snapshot(state='away', propensity='open'),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_unfinished_thread_pending(monkeypatch):
+    """AI 刚抛了问题用户还没接 → 跟进 thread 优先于 mini-game 邀请。
+    与 skip_probability / restricted_screen_only 对 unfinished_thread 的优先级
+    约定对齐——promised follow-up 永远不让外部 source / 邀请抢走。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    fake_thread = types.SimpleNamespace(
+        text='你今天准备几点出发?', age_seconds=60.0,
+        follow_up_count=0, max_follow_ups=2,
+    )
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(unfinished_thread=fake_thread),
         invite_lang='zh', master_name=MASTER,
     )
     assert out is None

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -134,7 +134,7 @@ def test_in_cooldown_false_when_both_thresholds_passed():
 
 def test_advance_response_noop_when_never_delivered():
     """没投递过，advance 是 no-op。"""
-    sr._mini_game_invite_advance_response(LANLAN, _make_snapshot(seconds_since_user_msg=1.0))
+    sr._mini_game_invite_advance_response(LANLAN, time.time() - 1.0)
     assert LANLAN not in sr._mini_game_invite_state
 
 
@@ -146,33 +146,22 @@ def test_advance_response_noop_when_already_responded():
     state['responded_at'] = original_responded
     state['chats_since_response'] = 3
 
-    sr._mini_game_invite_advance_response(
-        LANLAN, _make_snapshot(seconds_since_user_msg=10.0)
-    )
+    sr._mini_game_invite_advance_response(LANLAN, time.time() - 10.0)
     assert state['responded_at'] == original_responded
     assert state['chats_since_response'] == 3
 
 
-def test_advance_response_noop_when_snapshot_none():
-    """activity_snapshot 缺失 → 保留 pending。"""
+def test_advance_response_noop_when_last_user_msg_at_none():
+    """caller 没拿到 last_user_msg_at（隐私模式 / tracker 没数据）→ 保留 pending。"""
     sr._mini_game_invite_record_delivered(LANLAN)
     sr._mini_game_invite_advance_response(LANLAN, None)
-    assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
-
-
-def test_advance_response_noop_when_seconds_since_user_msg_none():
-    """活动 tracker 没记录用户最后一句话 → 保留 pending。"""
-    sr._mini_game_invite_record_delivered(LANLAN)
-    sr._mini_game_invite_advance_response(
-        LANLAN, _make_snapshot(seconds_since_user_msg=None)
-    )
     assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
 
 
 def test_advance_response_flips_when_user_spoke_after_invite(monkeypatch):
     """用户在 delivered_at 之后说过话 → 标记已回应、计数清零。
 
-    `responded_at` 必须 anchor 到 *真实* 回应时间（now - seconds_since_user_msg），
+    `responded_at` 必须 anchor 到 *真实* 回应时间（last_user_msg_at），
     而不是「检测到回应的此刻」。advance_response 只在下次 proactive_chat 才跑，
     user 回完到下次 proactive 可能隔几小时；anchor 用 now 会让 24h 冷却被这段
     间隔白白拉长。
@@ -188,9 +177,7 @@ def test_advance_response_flips_when_user_spoke_after_invite(monkeypatch):
     state['chats_since_response'] = 0
 
     # 用户 5s 前说了话 → 落在 delivered_at 之后
-    sr._mini_game_invite_advance_response(
-        LANLAN, _make_snapshot(seconds_since_user_msg=5.0)
-    )
+    sr._mini_game_invite_advance_response(LANLAN, fixed_now - 5.0)
     assert state['responded_at'] is not None
     assert state['chats_since_response'] == 0
     # Anchor 精确等于 last_user_msg_at = fixed_now - 5；冻结时钟下没有漂移，
@@ -217,9 +204,7 @@ def test_advance_response_anchors_even_when_proactive_runs_long_after_reply(monk
     state['responded_at'] = None
     state['chats_since_response'] = 0
 
-    sr._mini_game_invite_advance_response(
-        LANLAN, _make_snapshot(seconds_since_user_msg=2 * 3600.0)
-    )
+    sr._mini_game_invite_advance_response(LANLAN, fixed_now - 2 * 3600)
     assert state['responded_at'] is not None
     # 冻结时钟下应精确等于 fixed_now - 2h；回归到 now 会让 24h 冷却被多锁 2h。
     expected = fixed_now - 2 * 3600
@@ -231,15 +216,14 @@ def test_advance_response_anchors_even_when_proactive_runs_long_after_reply(monk
 
 def test_advance_response_does_not_flip_when_last_user_msg_predates_invite():
     """用户 last msg 早于邀请投递时间（投完一直没说话）→ 保留 pending。"""
-    delivered_at = time.time() - 5
+    now = time.time()
+    delivered_at = now - 5
     state = sr._mini_game_invite_get_state(LANLAN)
     state['delivered_at'] = delivered_at
     state['responded_at'] = None
 
     # 用户 100s 前说了话，远早于 5s 前的投递
-    sr._mini_game_invite_advance_response(
-        LANLAN, _make_snapshot(seconds_since_user_msg=100.0)
-    )
+    sr._mini_game_invite_advance_response(LANLAN, now - 100.0)
     assert state['responded_at'] is None
 
 

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -1,0 +1,400 @@
+"""Mini-game 邀请短路通道测试。
+
+覆盖三层契约：
+1. ``_mini_game_invite_in_cooldown`` —— pending（投递了但没回应）一律 cooldown；
+   已回应后必须同时跨过 24h 与 10 chats 才能解除。
+2. ``_mini_game_invite_advance_response`` —— pending 期间，用户 last msg 时间戳
+   晚于 delivered_at 时翻成已回应；activity_snapshot 缺失则保留 pending。
+3. ``_maybe_deliver_mini_game_invite`` —— eligibility 顺序：DISABLED →
+   activity_snapshot None → restricted_screen_only → away → cooldown → 掷骰；
+   命中即走 prepare → feed_tts → finish 三步投递并写 _proactive_chat_history。
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+import main_routers.system_router as sr  # noqa: E402
+
+LANLAN = "test_lanlan"
+MASTER = "小明"
+
+
+def _make_snapshot(state="casual_browsing", propensity="open", seconds_since_user_msg=None):
+    """构造一个 ActivitySnapshot duck-typed 替身——只用到 .state /
+    .propensity / .seconds_since_user_msg 三个字段。"""
+    return types.SimpleNamespace(
+        state=state,
+        propensity=propensity,
+        seconds_since_user_msg=seconds_since_user_msg,
+    )
+
+
+def _make_mgr(*, prepare_ok=True, finish_ok=True, sid="sid-test"):
+    mgr = MagicMock()
+    mgr.prepare_proactive_delivery = AsyncMock(return_value=prepare_ok)
+    mgr.finish_proactive_delivery = AsyncMock(return_value=finish_ok)
+    mgr.feed_tts_chunk = AsyncMock()
+    mgr.current_speech_id = sid
+    mgr.state = MagicMock()
+    mgr.state.fire = AsyncMock()
+    return mgr
+
+
+@pytest.fixture(autouse=True)
+def _clear_mini_game_state():
+    """每个 test 进来前后都清干净 module-level state。"""
+    sr._mini_game_invite_state.clear()
+    sr._proactive_chat_history.clear()
+    yield
+    sr._mini_game_invite_state.clear()
+    sr._proactive_chat_history.clear()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _mini_game_invite_in_cooldown
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_in_cooldown_false_when_never_delivered():
+    """从未投递过邀请 → 不在 cooldown。"""
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
+
+
+def test_in_cooldown_true_when_pending():
+    """投递了但还没被回应（pending）→ cooldown 锁住，避免又发一次。"""
+    sr._mini_game_invite_record_delivered(LANLAN)
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is True
+
+
+def test_in_cooldown_true_when_responded_within_24h_and_under_10_chats():
+    """已回应但 24h 没到 + 10 次没到 → cooldown。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 60
+    state['responded_at'] = time.time() - 60
+    state['chats_since_response'] = 5
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is True
+
+
+def test_in_cooldown_true_when_only_time_elapsed_chats_short():
+    """24h 已过但 chats 没到 10 次 → 仍 cooldown（AND 语义）。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
+    state['responded_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
+    state['chats_since_response'] = 3
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is True
+
+
+def test_in_cooldown_true_when_only_chats_done_time_short():
+    """chats 跨过 10 但 24h 没到 → 仍 cooldown（AND 语义）。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 600
+    state['responded_at'] = time.time() - 600
+    state['chats_since_response'] = 99
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is True
+
+
+def test_in_cooldown_false_when_both_thresholds_passed():
+    """24h 和 10 chats 都过了 → 解禁，下次掷骰。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
+    state['responded_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
+    state['chats_since_response'] = sr.MINI_GAME_INVITE_COOLDOWN_CHATS
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _mini_game_invite_advance_response
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_advance_response_noop_when_never_delivered():
+    """没投递过，advance 是 no-op。"""
+    sr._mini_game_invite_advance_response(LANLAN, _make_snapshot(seconds_since_user_msg=1.0))
+    assert LANLAN not in sr._mini_game_invite_state
+
+
+def test_advance_response_noop_when_already_responded():
+    """已经回应过，再 advance 不再回写时间戳。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 1000
+    original_responded = time.time() - 500
+    state['responded_at'] = original_responded
+    state['chats_since_response'] = 3
+
+    sr._mini_game_invite_advance_response(
+        LANLAN, _make_snapshot(seconds_since_user_msg=10.0)
+    )
+    assert state['responded_at'] == original_responded
+    assert state['chats_since_response'] == 3
+
+
+def test_advance_response_noop_when_snapshot_none():
+    """activity_snapshot 缺失 → 保留 pending。"""
+    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_advance_response(LANLAN, None)
+    assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
+
+
+def test_advance_response_noop_when_seconds_since_user_msg_none():
+    """活动 tracker 没记录用户最后一句话 → 保留 pending。"""
+    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_advance_response(
+        LANLAN, _make_snapshot(seconds_since_user_msg=None)
+    )
+    assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
+
+
+def test_advance_response_flips_when_user_spoke_after_invite():
+    """用户在 delivered_at 之后说过话 → 标记已回应、计数清零。"""
+    delivered_at = time.time() - 30
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = delivered_at
+    state['responded_at'] = None
+    state['chats_since_response'] = 0
+
+    # 用户 5s 前说了话 → 落在 delivered_at 之后
+    sr._mini_game_invite_advance_response(
+        LANLAN, _make_snapshot(seconds_since_user_msg=5.0)
+    )
+    assert state['responded_at'] is not None
+    assert state['responded_at'] >= delivered_at
+    assert state['chats_since_response'] == 0
+
+
+def test_advance_response_does_not_flip_when_last_user_msg_predates_invite():
+    """用户 last msg 早于邀请投递时间（投完一直没说话）→ 保留 pending。"""
+    delivered_at = time.time() - 5
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = delivered_at
+    state['responded_at'] = None
+
+    # 用户 100s 前说了话，远早于 5s 前的投递
+    sr._mini_game_invite_advance_response(
+        LANLAN, _make_snapshot(seconds_since_user_msg=100.0)
+    )
+    assert state['responded_at'] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _mini_game_invite_count_post_response_chat
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_count_noop_when_never_delivered():
+    sr._mini_game_invite_count_post_response_chat(LANLAN)
+    assert LANLAN not in sr._mini_game_invite_state
+
+
+def test_count_noop_during_pending():
+    """投递了但没回应（pending）→ counter 不推进，不能靠"邀请自身"耗掉 10 次。"""
+    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_count_post_response_chat(LANLAN)
+    sr._mini_game_invite_count_post_response_chat(LANLAN)
+    assert sr._mini_game_invite_state[LANLAN]['chats_since_response'] == 0
+
+
+def test_count_increments_after_responded():
+    """已回应后每次成功投递 +1，与 channel 无关。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 1000
+    state['responded_at'] = time.time() - 500
+    state['chats_since_response'] = 0
+
+    for _ in range(7):
+        sr._mini_game_invite_count_post_response_chat(LANLAN)
+    assert state['chats_since_response'] == 7
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _maybe_deliver_mini_game_invite —— eligibility 与 投递路径
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_disabled(monkeypatch):
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_ENABLED', False)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_snapshot_none():
+    """隐私模式 / tracker 不可用 → 保守不发——无法判断是否在工作状态。"""
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=None,
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_restricted_screen_only(monkeypatch):
+    """工作状态（focused_work / non-casual gaming）→ 不邀请。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(
+            state='focused_work', propensity='restricted_screen_only',
+        ),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_away(monkeypatch):
+    """用户离场 → 邀请没人接。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(state='away', propensity='open'),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_in_cooldown(monkeypatch):
+    """pending 期间一律抑制掷骰。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    sr._mini_game_invite_record_delivered(LANLAN)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_dice_misses(monkeypatch):
+    """概率没过 → 不投递。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 0.0)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_chat_when_eligible(monkeypatch):
+    """全部 eligibility 通过 + 必中骰子 → 走 prepare → feed_tts → finish 投递；
+    state 翻成 pending；写入 _proactive_chat_history。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    mgr = _make_mgr(sid='sid-eligible')
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is not None
+    assert out["action"] == "chat"
+    assert out["channel"] == "mini_game"
+    assert out["turn_id"] == "sid-eligible"
+
+    mgr.prepare_proactive_delivery.assert_awaited_once()
+    mgr.finish_proactive_delivery.assert_awaited_once()
+    # feed_tts 与 finish 都要带上当前 speech_id
+    feed_call = mgr.feed_tts_chunk.await_args
+    assert feed_call.kwargs.get('expected_speech_id') == 'sid-eligible'
+    finish_call = mgr.finish_proactive_delivery.await_args
+    assert finish_call.kwargs.get('expected_speech_id') == 'sid-eligible'
+
+    # state 进 pending
+    state = sr._mini_game_invite_state[LANLAN]
+    assert state['delivered_at'] is not None
+    assert state['responded_at'] is None
+    assert state['chats_since_response'] == 0
+
+    # _proactive_chat_history 也写了一条 channel='mini_game'
+    history = sr._proactive_chat_history[LANLAN]
+    assert len(history) == 1
+    _, message, channel = history[0]
+    assert MASTER in message
+    assert channel == 'mini_game'
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_pass_when_prepare_refuses(monkeypatch):
+    """prepare 拒绝（用户刚说过话 / 没 websocket / 等）→ 返回 pass，不写 state。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    mgr = _make_mgr(prepare_ok=False)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is not None
+    assert out["action"] == "pass"
+    mgr.finish_proactive_delivery.assert_not_awaited()
+    assert LANLAN not in sr._mini_game_invite_state
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_pass_when_user_takes_over_before_finish(monkeypatch):
+    """finish_proactive_delivery 返回 False（用户在投递期间抢占）→
+    不计入 history、不更新 cooldown state，避免后续被错误抑制。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    mgr = _make_mgr(finish_ok=False)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is not None
+    assert out["action"] == "pass"
+    assert LANLAN not in sr._mini_game_invite_state
+    assert LANLAN not in sr._proactive_chat_history
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_uses_localized_template(monkeypatch):
+    """invite_lang 选英文 → 文案落英文模板，master_name 实名展开。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    mgr = _make_mgr()
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=_make_snapshot(),
+        invite_lang='en', master_name='Alice',
+    )
+    assert out is not None
+    history = sr._proactive_chat_history[LANLAN]
+    _, message, _ = history[0]
+    assert 'Alice' in message
+    assert 'soccer' in message.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# i18n 覆盖契约
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_invite_line_covers_all_native_locales():
+    """5 个 native locale（zh/en/ja/ko/ru）都必须有可格式化模板。"""
+    from config.prompts_proactive import MINI_GAME_INVITE_LINE
+    for lang in ('zh', 'en', 'ja', 'ko', 'ru'):
+        line = MINI_GAME_INVITE_LINE[lang]
+        assert '{master_name}' in line, f"{lang} 模板缺 master_name 占位符"
+        rendered = line.format(master_name='测试')
+        assert '测试' in rendered
+        # 模板长度合理（不空、不爆）
+        assert 5 <= len(line) <= 200, f"{lang} 模板长度异常: {len(line)}"
+
+
+def test_source_label_covers_mini_game():
+    """PROACTIVE_SOURCE_LABELS 必须为 mini_game 通道补齐 5 个 native locale 标签。"""
+    from config.prompts_proactive import PROACTIVE_SOURCE_LABELS
+    for lang in ('zh', 'en', 'ja', 'ko', 'ru'):
+        assert 'mini_game' in PROACTIVE_SOURCE_LABELS[lang], \
+            f"{lang} 缺 mini_game 标签"
+        assert PROACTIVE_SOURCE_LABELS[lang]['mini_game'].strip()

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -64,6 +64,19 @@ def _clear_mini_game_state():
     sr._proactive_chat_history.clear()
 
 
+@pytest.fixture(autouse=True)
+def _force_invite_enabled_default(monkeypatch):
+    """每个 test 默认强制 MINI_GAME_INVITE_ENABLED=True。
+
+    本测试套件大部分用例都假定 invite 通道开着、然后验证某条 gate 是否生效。
+    如果哪天 module 默认值被翻成 False（例如灰度阶段），这些 deliver / gate
+    测试都会静默退化成「ENABLED 短路全部命中」，无法捕获真正的 gate 退化。
+    autouse 把契约前置：测试断言「此通道开着且 X gate 生效」，要测 disabled
+    分支的用例（test_maybe_deliver_returns_none_when_disabled）自己 setattr
+    回 False。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_ENABLED', True)
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # _mini_game_invite_in_cooldown
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -430,10 +430,43 @@ def test_invite_line_covers_all_native_locales():
         assert 5 <= len(line) <= 200, f"{lang} 模板长度异常: {len(line)}"
 
 
-def test_source_label_covers_mini_game():
-    """PROACTIVE_SOURCE_LABELS 必须为 mini_game 通道补齐 5 个 native locale 标签。"""
-    from config.prompts_proactive import PROACTIVE_SOURCE_LABELS
+def test_format_recent_proactive_chats_renders_mini_game_channel():
+    """Runtime 渲染契约：成功投递的 mini_game 邀请被 _record_proactive_chat
+    写进 _proactive_chat_history 后，下一轮 proactive 的 prompt 由
+    _format_recent_proactive_chats 拼出近期搭话段——这条记录必须能渲染出
+    可读的「时间 · 通道」标签，并且至少在 5 个 native locale 下不崩。
+
+    通道 label 走 RECENT_PROACTIVE_CHANNEL_LABELS（不是 PROACTIVE_SOURCE_LABELS！
+    后者只在 Phase 1 web 聚合时用，mini_game 短路在 Phase 1 之前不会触达）。
+    现 dict 只为 vision/web 提供翻译，music/meme/news/video/home/personal/
+    window/mini_game 这些都走 ``cl.get(ch, ch)`` raw-key fallback，所以期望
+    输出里直接出现 'mini_game' 字面量——和 music/meme 现状一致。"""
+    sample = "{master_name}, ".format(master_name=MASTER) + "要不要踢一会儿足球？"
+    sr._proactive_chat_history[LANLAN] = __import__('collections').deque(
+        [(time.time() - 30, sample, 'mini_game')], maxlen=10,
+    )
     for lang in ('zh', 'en', 'ja', 'ko', 'ru'):
-        assert 'mini_game' in PROACTIVE_SOURCE_LABELS[lang], \
-            f"{lang} 缺 mini_game 标签"
-        assert PROACTIVE_SOURCE_LABELS[lang]['mini_game'].strip()
+        rendered = sr._format_recent_proactive_chats(LANLAN, lang)
+        assert rendered, f"{lang} 渲染输出空"
+        assert sample in rendered, f"{lang} 渲染丢了消息正文"
+        assert 'mini_game' in rendered, (
+            f"{lang} 渲染丢了 channel 标记——"
+            f"应至少用 raw-key fallback 暴露 mini_game"
+        )
+
+
+@pytest.mark.asyncio
+async def test_invite_e2e_renders_in_recent_chats(monkeypatch):
+    """端到端：_maybe_deliver_mini_game_invite 投出来的内容立刻被
+    _format_recent_proactive_chats 拼回来，确认整条链路跑通且 channel 标签生效。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    mgr = _make_mgr()
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is not None
+    rendered = sr._format_recent_proactive_chats(LANLAN, 'zh')
+    assert MASTER in rendered
+    assert 'mini_game' in rendered


### PR DESCRIPTION
## Summary

给主动搭话加一个 **mini-game 邀请**新来源：默认启用，工作 / gaming / 离场不发，eligible 状态下每次主动搭话有 10% 概率短路成「来玩一会儿足球小游戏吗？」邀请。一次邀请被回应后 **24h + 10 次成功主动搭话**双门冷却，期间不再掷骰。

入口顺带补回 [PR #1110](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1110) 之后足球小游戏「除手敲 `/soccer_demo` URL 别无入口」的洞——AI 主动开口邀请。用户答应后自动 deep-link 到 `/soccer_demo` 留给后续 PR。

## 行为合同

eligible 状态下每次进 [`POST /api/proactive_chat`](main_routers/system_router.py)：

1. **推进 pending invite 的「已回应」判定** —— activity_snapshot 的 `seconds_since_user_msg` 比对 `delivered_at`，用户已说话则 flip。
2. **过完现有 propensity / skip_probability / restricted_screen_only 几道门**。
3. **独立 10% 掷骰** —— 命中即 `prepare_proactive_delivery → feed_tts_chunk → finish_proactive_delivery` 投递静态 i18n 邀请词，channel='mini_game' 写入 `_proactive_chat_history`；不走 Phase 1/2 LLM 与 source fetching。
4. **投递后进 pending**；下次用户开口 → flip responded；之后每次成功投递的普通主动搭话推进 chats counter；同时跨过 24h **和** 10 chats 才能再掷骰。

skip 条件：
- `MINI_GAME_INVITE_ENABLED=False`
- `activity_snapshot is None`（隐私模式 / tracker 不可用——无法判断是否在工作状态，保守不发）
- `propensity == 'restricted_screen_only'`（focused_work / non-casual gaming——和现有「屏蔽外部 source」的 gate 对齐）
- `state == 'away'`（用户离场邀请没人接）
- 处于冷却期
- `random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY`

## 关键设计决策

| 选择 | 取值 | 理由 |
|---|---|---|
| 「工作状态」 = | `propensity == 'restricted_screen_only'` | 字面 `focused_work` + non-casual `gaming`；与现有 source-fetch 屏蔽 gate 对齐 |
| 「24h + 10 次」 = | **AND**（两条件都跨过才解禁） | 「+」读成叠加；OR 会让任一单独触发，窗口太短 |
| 邀请文案 = | 静态 i18n 模板（5 locales） | 「踢一会儿足球」单句，烧 LLM 换不来角色化收益，还增加 race 面 |
| 持久化 = | 内存 dict（重启清零） | 24h+10 chats 是软冷却；引落盘依赖 ROI 不正 |
| 投递路径 = | 镜像 `_deliver_postgame_text_bubble` 的 prepare→feed_tts→finish | 与赛后气泡同一套 TTS / WebSocket / 历史落库通道 |

## 改动文件

| 文件 | 改动 |
|---|---|
| [config/__init__.py](config/__init__.py) | +4 常量：`MINI_GAME_INVITE_ENABLED=True` / `TRIGGER_PROBABILITY=0.1` / `COOLDOWN_SECONDS=86400` / `COOLDOWN_CHATS=10` |
| [config/prompts_proactive.py](config/prompts_proactive.py) | `PROACTIVE_SOURCE_LABELS` 加 `mini_game` 键（zh/en/ja/ko/ru）；新 `MINI_GAME_INVITE_LINE`（5 locales，`{master_name}` 占位） |
| [main_routers/system_router.py](main_routers/system_router.py) | 模块级 `_mini_game_invite_state` + 5 helper（`_get_state` / `_advance_response` / `_in_cooldown` / `_record_delivered` / `_count_post_response_chat`）+ `_maybe_deliver_mini_game_invite` 短路；`proactive_chat` 两处插钩——activity_snapshot 后 advance pending、`enabled_modes` 解析后掷骰；`_record_proactive_chat` 后推进 chats counter |
| [tests/unit/test_mini_game_invite.py](tests/unit/test_mini_game_invite.py) | 新文件，27 个 test：cooldown AND 语义、响应检测、各 eligibility gate、prepare/finish 失败 fallback、5 locales i18n 覆盖 |

## Test plan

- [x] `uv run pytest tests/unit/test_mini_game_invite.py -v` —— **27 passed**
- [x] `uv run pytest tests/unit/test_proactive_action_note.py tests/unit/test_proactive_sm_integration.py tests/unit/test_proactive_sid_guard.py tests/unit/test_session_state.py tests/unit/test_avatar_interaction_memory_contract.py tests/unit/test_passthrough_to_chat_bubble.py` —— **132 passed**（无回归）
- [x] `uv run pytest tests/unit/test_game_router.py tests/unit/test_game_router_concurrency.py tests/unit/test_game_route_prompts_i18n.py tests/unit/test_core_game_route_memory_contract.py tests/unit/test_game_llm_static_contracts.py tests/unit/test_voice_session.py` —— **159 passed, 3 skipped**（无回归）
- [x] `uv run python scripts/check_prompt_hygiene.py` —— clean
- [x] `uv run python scripts/check_api_trailing_slash.py` —— clean
- [x] `uv run python scripts/check_frontend_api_trailing_slash.py` —— clean
- [ ] 手测：让 `MINI_GAME_INVITE_TRIGGER_PROBABILITY=1.0`，跑一轮 proactive_chat 看 TTS / 前端气泡 / 历史落库三路；用户回一句话后再跑 10 次 proactive 验证 cooldown 解锁

## Out of scope（后续）

- 邀请被回应后自动 deep-link / 弹窗到 `/soccer_demo`（本 PR 只做「AI 主动开口邀请」，让用户产品级感知到游戏存在；具体怎么打开的体验留给后续）
- 持久化（24h 跨进程重启）—— 当前内存 dict，重启清零是有意妥协
- es / pt 模板 —— 跟 `PROACTIVE_SOURCE_LABELS` 现有 5-locale 覆盖一致，等其他 proactive 系列扩 locale 时一起补
- 多游戏拓展（mini-game 不止足球时）—— `mini_game` channel 名已是 game-agnostic，文案当前 hard-code 足球；多游戏场景下把 `MINI_GAME_INVITE_LINE` 拆成 game_type → templates 的两层结构即可

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“小游戏邀请”能力：可通过配置开关、触发概率及回应后的时长/聊天次数冷却控制投递；投递会基于用户在线/活动/未完成会话等条件与概率决策，记录已投递与已回应状态并在冷却期间抑制重复投递；若投递流程未能完成则安全回退不写入状态。

* **本地化**
  * 邀请文案已支持中/英/日/韩/俄，可按主名格式化渲染。

* **测试**
  * 新增单元测试覆盖投递资格、冷却规则、状态推进、投递链路与多语言渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->