### PR TITLE
feat(proactive): mini-game 邀请三选项按钮 + 关键词文本兜底（PR #1141 follow-up #2）

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1344,6 +1344,21 @@ MINI_GAME_INVITE_COOLDOWN_CHATS = 10
 - 与 MINI_GAME_INVITE_COOLDOWN_SECONDS 同时满足才解禁；任一不满足都继续抑制。
 - 上游：_mini_game_invite_in_cooldown 计数侧判定。"""
 
+MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS = 5 * 60
+"""用户选择「回头再说」后的短期再掷骰抑制秒数（默认 5min）。
+- D2 语义：reset state（delivered_at/responded_at/chats_since_response 都清零，
+  让 force-first 与普通 10% 掷骰都恢复正常）但加一个 ``suppressed_until`` 软门，
+  这段时间内 ``_mini_game_invite_in_cooldown`` 仍返回 True 防止下一次 proactive
+  立刻又邀请，体感上像"等等再问我"。过了这个窗口下次 proactive 才重新走骰子。
+- 上游：endpoint /api/mini_game/invite/respond 的 'later' action。"""
+
+MINI_GAME_LAUNCH_URL_BY_GAME: dict[str, str] = {
+    'soccer': '/soccer_demo',
+}
+"""game_type → 实际打开的页面 URL。前端 `window.open(url)` 让 Electron 主进程
+``setWindowOpenHandler`` 拦截开独立 BrowserWindow（普通浏览器是新 tab）；URL
+会带上 ``?lanlan_name=...&session_id=...`` query。新 mini-game 加新 entry 即可。"""
+
 PROACTIVE_SOURCE_HARD_SKIP_SECONDS = 5 * 3600
 """主动搭话 source 衰减历史的硬窗口（p_skip=1.0）。
 - 用途：5h 内同一 URL 必跳，超过后按 kind 半衰期指数衰减。
@@ -1641,6 +1656,8 @@ __all__ = [
     'MINI_GAME_INVITE_COOLDOWN_CHATS',
     'MINI_GAME_INVITE_NEW_USER_FORCE_AT',
     'MINI_GAME_INVITE_AVAILABLE_GAMES',
+    'MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS',
+    'MINI_GAME_LAUNCH_URL_BY_GAME',
     'PROACTIVE_SOURCE_HARD_SKIP_SECONDS',
     'PROACTIVE_SOURCE_HALF_LIFE_BY_KIND',
     'PROACTIVE_SOURCE_HALF_LIFE_DEFAULT',

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2402,10 +2402,13 @@ MINI_GAME_INVITE_OPTION_LABELS: dict[str, dict[str, str]] = {
 # 扫一遍而不是只看 active locale。
 MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
     'zh': {
-        # 注意：'玩' / '走' 这种过宽的字不能进 accept——会把 "不想玩" / "走开"
-        # 这种含 negation 的话误判成 accept（priority accept > decline）。
-        # 'ok' 也省掉，全字符串匹配下任何 "okayy" 都会命中 en branch。
-        'accept': ['好', '可以', '行', '来', '一起', '冲'],
+        # accept 必须用**短语 / 双字以上**避免和 decline 子串重叠：
+        # - 单字 '好' '行' 会被 "不好" / "我不行" / "不好玩" 当 substring 命中。
+        # - 单字 '玩' '走' 太宽——"不想玩" / "走开"。
+        # 改用「好啊 / 好的 / 行啊 / 来吧 / 一起」等明确表达。CodeRabbit Major
+        # 指出，配合 _match_mini_game_invite_keyword 的 negation-priority
+        # （decline > later > accept）双保险。
+        'accept': ['好啊', '好的', '可以', '行啊', '来吧', '一起', '冲'],
         'decline': ['不要', '不行', '不好', '不想', '算了', '拒绝', '不玩', '没空'],
         'later': ['回头', '等会', '等下', '晚点', '一会', '等等', '稍后', '过会'],
     },

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2405,10 +2405,12 @@ MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
         # accept 必须用**短语 / 双字以上**避免和 decline 子串重叠：
         # - 单字 '好' '行' 会被 "不好" / "我不行" / "不好玩" 当 substring 命中。
         # - 单字 '玩' '走' 太宽——"不想玩" / "走开"。
-        # 改用「好啊 / 好的 / 行啊 / 来吧 / 一起」等明确表达。CodeRabbit Major
+        # - 单字 '冲' 也宽——"冲个澡" / "冲咖啡" 这种普通对话会被 CJK
+        #   substring 误命中（codex P2 指出）。
+        # 改用「好啊 / 好的 / 行啊 / 来吧 / 一起玩」等明确表达。CodeRabbit Major
         # 指出，配合 _match_mini_game_invite_keyword 的 negation-priority
         # （decline > later > accept）双保险。
-        'accept': ['好啊', '好的', '可以', '行啊', '来吧', '一起', '冲'],
+        'accept': ['好啊', '好的', '可以', '行啊', '来吧', '一起玩'],
         'decline': ['不要', '不行', '不好', '不想', '算了', '拒绝', '不玩', '没空'],
         'later': ['回头', '等会', '等下', '晚点', '一会', '等等', '稍后', '过会'],
     },

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2422,8 +2422,16 @@ MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
         # 等常规英文表达（CodeRabbit Major 指出）。改用 'no thanks' / 'nope' /
         # 'don't want' / 'not now' 等 phrase。'after' 也太宽（"after lunch"），
         # 改用更长的 'after this' / 仅保留 'in a bit'/'in a minute' 等明确 later。
-        'accept': ['yes', 'sure', 'okay', "let's", 'sounds good', 'yeah', 'yep', "i'll play", 'wanna play'],
-        'decline': ['no thanks', 'nope', 'pass', 'skip', 'not now', 'not really', 'maybe not', "don't want"],
+        # 'okay' 已删——"not okay" 会被 word-boundary accept 命中且 decline 没
+        # 'not okay' 时 priority 救不了（codex P2 指出）。其它单词 accept ('sure'
+        # /'yes'/'yeah'/'yep') 同类风险靠 decline list 加 'not sure' / 'not yet'
+        # 等 negation phrase 双保险拦截。
+        'accept': ['yes', 'sure', "let's", 'sounds good', 'yeah', 'yep', "i'll play", 'wanna play'],
+        'decline': [
+            'no thanks', 'nope', 'pass', 'skip',
+            'not now', 'not really', 'maybe not', "don't want",
+            'not okay', 'not sure', 'not yet',
+        ],
         'later': ['later', 'in a bit', 'in a minute', 'in a moment', 'after this'],
     },
     'ja': {

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2402,16 +2402,18 @@ MINI_GAME_INVITE_OPTION_LABELS: dict[str, dict[str, str]] = {
 # 扫一遍而不是只看 active locale。
 MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
     'zh': {
-        # accept 必须用**短语 / 双字以上**避免和 decline 子串重叠：
-        # - 单字 '好' '行' 会被 "不好" / "我不行" / "不好玩" 当 substring 命中。
+        # accept 必须用**短语 / 双字以上**且**不被任何 decline 短语作 substring
+        # 包含**——CJK 走 substring 没 word boundary 兜底，priority 仅在 decline
+        # 也命中时救场，"不可以" 这种 decline list 没列的 negation phrase 完全
+        # 救不了。设计原则：accept 短语必须保证「decline phrase 不含它」。
+        # - 单字 '好' '行' 被 "不好" / "我不行" / "不好玩" 包含。
         # - 单字 '玩' '走' 太宽——"不想玩" / "走开"。
-        # - 单字 '冲' 也宽——"冲个澡" / "冲咖啡" 这种普通对话会被 CJK
-        #   substring 误命中（codex P2 指出）。
-        # 改用「好啊 / 好的 / 行啊 / 来吧 / 一起玩」等明确表达。CodeRabbit Major
-        # 指出，配合 _match_mini_game_invite_keyword 的 negation-priority
-        # （decline > later > accept）双保险。
-        'accept': ['好啊', '好的', '可以', '行啊', '来吧', '一起玩'],
-        'decline': ['不要', '不行', '不好', '不想', '算了', '拒绝', '不玩', '没空'],
+        # - 单字 '冲' 也宽——"冲个澡" / "冲咖啡"（codex P2 指出）。
+        # - 双字 '可以' 被 "不可以" 包含——decline list 又没 '不可以'，
+        #   priority 救不了（codex P2 指出后删）。
+        # 改用「好啊 / 好的 / 行啊 / 来吧 / 一起玩」等明确接受 phrase。
+        'accept': ['好啊', '好的', '行啊', '来吧', '一起玩'],
+        'decline': ['不要', '不行', '不好', '不想', '不可以', '算了', '拒绝', '不玩', '没空'],
         'later': ['回头', '等会', '等下', '晚点', '一会', '等等', '稍后', '过会'],
     },
     'en': {
@@ -2432,7 +2434,9 @@ MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
     },
     'ko': {
         # '안' 太宽（'안녕' / '안 그래도' 都会命中），改用 phrase。
-        'accept': ['좋아', '응', '그래', '가자', 'ㅇㅇ'],
+        # 单字 '응' 也宽——"적응" / "반응" 等含子串命中。codex P2 指出后删；
+        # 留 '좋아' / '그래' / '가자' / 'ㅇㅇ' 已 cover 接受意图。
+        'accept': ['좋아', '그래', '가자', 'ㅇㅇ'],
         'decline': ['싫어', '아니', '됐어', '안 해'],
         'later': ['나중', '이따', '잠시', '잠깐만'],
     },

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2393,10 +2393,14 @@ MINI_GAME_INVITE_OPTION_LABELS: dict[str, dict[str, str]] = {
 # 扫一遍这份关键词表：命中即触发对应 action（accept / decline / later），不吃掉
 # 用户消息（继续走普通 chat 流水线）。
 #
-# 匹配规则：消息**全文小写后包含任一关键词**视为命中；多类同时命中则按优先级
-# accept > later > decline（"好的不过等下" 这种倾向 accept-with-delay 当 later
-# 处理可能更尴尬，简单 accept-priority 兜底）。匹配在 main_routers.system_router
-# 的 helper 内做 —— 关键词列表本身放这里集中维护。
+# 匹配规则：消息**全文小写后包含任一关键词**视为命中；ASCII / Cyrillic 走
+# word-boundary regex 防 'yes' 命中 'yesterday'；CJK / Hiragana / Katakana /
+# Hangul 走 substring（无 word boundary）。多类同时命中按优先级
+# **decline > later > accept**（含明确 negation 必判 decline，"好的等下" 含
+# accept + later 关键词时判 later——别立刻开游戏）。匹配在
+# main_routers.system_router 的 helper 内做 —— 关键词列表本身放这里集中维护。
+# 早期版本曾用 accept-priority 简单兜底，被 codex / CodeRabbit Major 指出后
+# 改成 decline-priority 防 negation 句误判。
 #
 # 5 native locale 都列：用户可能切语言但仍用中文打字，所以匹配时逐个 locale 全
 # 扫一遍而不是只看 active locale。

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2430,10 +2430,16 @@ MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
         # 'not okay' 时 priority 救不了（codex P2 指出）。其它单词 accept ('sure'
         # /'yes'/'yeah'/'yep') 同类风险靠 decline list 加 'not sure' / 'not yet'
         # 等 negation phrase 双保险拦截。
-        'accept': ['yes', 'sure', "let's", 'sounds good', 'yeah', 'yep', "i'll play", 'wanna play'],
+        # accept："let's" 单字太宽（"let's not play" 命中），改 "let's play"
+        # 更具体；'wanna play' 同样被 "I don't wanna play" 命中，priority 兜底
+        # 不可靠（之前规则已加 "don't want"），但仍保留 'wanna play' 作 accept
+        # phrase——decline list 同步加 "don't wanna" / "let's not" 双保险
+        # （CodeRabbit Major 指出后调整）。
+        'accept': ['yes', 'sure', "let's play", 'sounds good', 'yeah', 'yep', "i'll play", 'wanna play'],
         'decline': [
             'no thanks', 'nope', 'pass', 'skip',
-            'not now', 'not really', 'maybe not', "don't want",
+            'not now', 'not really', 'maybe not', "don't want", "don't wanna",
+            "let's not",
             'not okay', 'not sure', 'not yet',
         ],
         'later': ['later', 'in a bit', 'in a minute', 'in a moment', 'after this'],

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2414,9 +2414,13 @@ MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
     },
     'en': {
         # 'play' 太宽——"don't want to play" 会被 accept 误命中。改用 phrase。
+        # 单字 'no' 已删——即使 word-boundary 也会命中 "no idea"/"no worries"
+        # 等常规英文表达（CodeRabbit Major 指出）。改用 'no thanks' / 'nope' /
+        # 'don't want' / 'not now' 等 phrase。'after' 也太宽（"after lunch"），
+        # 改用更长的 'after this' / 仅保留 'in a bit'/'in a minute' 等明确 later。
         'accept': ['yes', 'sure', 'okay', "let's", 'sounds good', 'yeah', 'yep', "i'll play", 'wanna play'],
-        'decline': ['no', 'nope', 'pass', 'skip', 'not now', 'not really', 'maybe not'],
-        'later': ['later', 'in a bit', 'in a minute', 'after', 'in a moment'],
+        'decline': ['no thanks', 'nope', 'pass', 'skip', 'not now', 'not really', 'maybe not', "don't want"],
+        'later': ['later', 'in a bit', 'in a minute', 'in a moment', 'after this'],
     },
     'ja': {
         # 'やる' 太宽（'やめる' 含子串），换成 'やるよ'。

--- a/config/prompts_proactive.py
+++ b/config/prompts_proactive.py
@@ -2355,6 +2355,85 @@ MINI_GAME_INVITE_LINES_BY_GAME: dict[str, dict[str, str]] = {
     },
 }
 
+# ---------- Mini-game 邀请三选项按钮 ----------
+# choice 是 wire-format 标识符（accept/decline/later），不进 UI；UI label 由
+# MINI_GAME_INVITE_OPTION_LABELS 按 locale 渲染。前端 ChoicePrompt 组件读
+# label 直接展示，点击发 ``choice`` 给 endpoint。文案设计：accept 热情但不
+# 过度、decline 客气不冷漠、later 自然不催促，三者语义清晰互不重叠。
+MINI_GAME_INVITE_OPTION_LABELS: dict[str, dict[str, str]] = {
+    'zh': {
+        'accept': '来一局！',
+        'decline': '现在不想玩',
+        'later': '等一会儿',
+    },
+    'en': {
+        'accept': "Let's play!",
+        'decline': 'Not feeling it',
+        'later': 'Maybe later',
+    },
+    'ja': {
+        'accept': 'やろう！',
+        'decline': '今はパス',
+        'later': 'あとでね',
+    },
+    'ko': {
+        'accept': '좋아, 가자!',
+        'decline': '지금은 됐어',
+        'later': '좀 이따',
+    },
+    'ru': {
+        'accept': 'Давай сыграем!',
+        'decline': 'Сейчас нет настроения',
+        'later': 'Чуть позже',
+    },
+}
+
+# ---------- Mini-game 邀请回应关键词（文本兜底匹配）----------
+# 用户没点按钮、自己打字时（"好啊"/"不要"/"晚点说"），后端 message handler 入口
+# 扫一遍这份关键词表：命中即触发对应 action（accept / decline / later），不吃掉
+# 用户消息（继续走普通 chat 流水线）。
+#
+# 匹配规则：消息**全文小写后包含任一关键词**视为命中；多类同时命中则按优先级
+# accept > later > decline（"好的不过等下" 这种倾向 accept-with-delay 当 later
+# 处理可能更尴尬，简单 accept-priority 兜底）。匹配在 main_routers.system_router
+# 的 helper 内做 —— 关键词列表本身放这里集中维护。
+#
+# 5 native locale 都列：用户可能切语言但仍用中文打字，所以匹配时逐个 locale 全
+# 扫一遍而不是只看 active locale。
+MINI_GAME_INVITE_KEYWORDS: dict[str, dict[str, list[str]]] = {
+    'zh': {
+        # 注意：'玩' / '走' 这种过宽的字不能进 accept——会把 "不想玩" / "走开"
+        # 这种含 negation 的话误判成 accept（priority accept > decline）。
+        # 'ok' 也省掉，全字符串匹配下任何 "okayy" 都会命中 en branch。
+        'accept': ['好', '可以', '行', '来', '一起', '冲'],
+        'decline': ['不要', '不行', '不好', '不想', '算了', '拒绝', '不玩', '没空'],
+        'later': ['回头', '等会', '等下', '晚点', '一会', '等等', '稍后', '过会'],
+    },
+    'en': {
+        # 'play' 太宽——"don't want to play" 会被 accept 误命中。改用 phrase。
+        'accept': ['yes', 'sure', 'okay', "let's", 'sounds good', 'yeah', 'yep', "i'll play", 'wanna play'],
+        'decline': ['no', 'nope', 'pass', 'skip', 'not now', 'not really', 'maybe not'],
+        'later': ['later', 'in a bit', 'in a minute', 'after', 'in a moment'],
+    },
+    'ja': {
+        # 'やる' 太宽（'やめる' 含子串），换成 'やるよ'。
+        'accept': ['やろう', 'いいよ', 'うん', 'はい', 'やるよ', 'やります'],
+        'decline': ['パス', '嫌', 'いいえ', 'やめる', 'いやだ'],
+        'later': ['あとで', '今度', 'また今度', 'もうちょい', 'ちょっと待って'],
+    },
+    'ko': {
+        # '안' 太宽（'안녕' / '안 그래도' 都会命中），改用 phrase。
+        'accept': ['좋아', '응', '그래', '가자', 'ㅇㅇ'],
+        'decline': ['싫어', '아니', '됐어', '안 해'],
+        'later': ['나중', '이따', '잠시', '잠깐만'],
+    },
+    'ru': {
+        'accept': ['да', 'давай', 'конечно', 'хорошо', 'ок'],
+        'decline': ['нет', 'не хочу', 'откажусь', 'пас'],
+        'later': ['потом', 'позже', 'попозже', 'не сейчас'],
+    },
+}
+
 # ---------- 音乐搜索结果格式化 ----------
 MUSIC_SEARCH_RESULT_TEXTS = {
     'zh': {

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -10,6 +10,9 @@ import {
   type AvatarInteractionPayload,
   type AvatarToolStatePayload,
   type GalgameOption,
+  type ChoiceOption,
+  type ChoicePrompt,
+  type ChoicePromptSource,
 } from './message-schema';
 
 export type ChatWindowProps = ChatWindowSchemaProps & {
@@ -24,6 +27,11 @@ export type ChatWindowProps = ChatWindowSchemaProps & {
   onTranslateToggle?: () => void;
   onGalgameModeToggle?: () => void;
   onGalgameOptionSelect?: (option: GalgameOption) => void;
+  // Generic ChoicePrompt（mini-game invite 等通用三选项框架）。
+  // galgame mode 现有路径继续走 galgameOptions / onGalgameOptionSelect（BC）；
+  // 本框架先只承载 mini_game_invite，未来可把 galgame 也迁过来。
+  choicePrompt?: ChoicePrompt | null;
+  onChoiceSelect?: (option: ChoiceOption, source: ChoicePromptSource) => void;
 };
 
 const defaultMessages: ChatMessage[] = [];
@@ -576,6 +584,8 @@ export default function App({
   onTranslateToggle,
   onGalgameModeToggle,
   onGalgameOptionSelect,
+  choicePrompt = null,
+  onChoiceSelect,
   rollbackDraft,
   _rollbackKey,
   _toolCursorResetKey,
@@ -1766,6 +1776,49 @@ export default function App({
                             </button>
                           ))
                         : null}
+                  </div>
+                </div>
+              ) : null}
+              {/*
+                Generic ChoicePrompt slot —— mini-game invite 等通用三选项
+                抽象。复用 .composer-galgame-* CSS 让 visual / animation 与
+                galgame mode 统一；本框架与 galgame slot 互不重叠（galgame
+                走自己的 galgameOptions 路径，BC），未来可统一迁移。
+              */}
+              {choicePrompt && choicePrompt.options.length > 0 ? (
+                <div
+                  className={`composer-galgame-slot composer-choice-slot is-open is-${choicePrompt.source}`}
+                  aria-hidden="false"
+                  data-choice-source={choicePrompt.source}
+                >
+                  <div
+                    className="composer-galgame-options composer-choice-options"
+                    role="group"
+                    aria-label={choicePrompt.source === 'mini_game_invite'
+                      ? i18n('chat.miniGameInviteOptionsAriaLabel', 'Mini-game invite options')
+                      : galgameToggleButtonLabel}
+                  >
+                    {choicePrompt.options.slice(0, 3).map((option, index) => (
+                      <button
+                        key={`${index}-${option.choice}`}
+                        type="button"
+                        className="composer-galgame-option composer-choice-option"
+                        title={option.label}
+                        onClick={() => {
+                          if (submittingRef.current) return;
+                          submittingRef.current = true;
+                          try {
+                            onChoiceSelect?.(option, choicePrompt.source);
+                          } finally {
+                            requestAnimationFrame(() => { submittingRef.current = false; });
+                          }
+                        }}
+                      >
+                        <span className="composer-galgame-option-text composer-choice-option-text">
+                          {option.label}
+                        </span>
+                      </button>
+                    ))}
                   </div>
                 </div>
               ) : null}

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -53,6 +53,32 @@ const galgameOptionSchema = z.object({
   text: z.string().min(1),
 });
 
+// Generic ChoicePrompt — composer-anchored "AI 给你出几个选项" UI 组件抽象。
+//
+// 当前 source：
+//   - 'galgame'           ：旧路径（galgameOptions / onGalgameOptionSelect 依然
+//                           保留 BC，本框架不替换它，作为渐进迁移目标）
+//   - 'mini_game_invite'  ：mini-game 邀请三选项（accept / decline / later）
+//
+// 未来扩展：
+//   - 'tutorial_step' / 'plugin_action' / ...
+//   - 当需要"对话框 + avatar 旁边同步显示"时，加 placement: 'composer' | 'avatar'
+//     | 'both'，不破坏 wire-format。
+//
+// option.choice 是后端 wire-format 标识符（accept/decline/later 之类），点击
+// 时回传给 onChoiceSelect；UI 显示用 option.label。
+const choiceOptionSchema = z.object({
+  choice: z.string().min(1),  // wire id (accept/decline/later/...)
+  label: z.string().min(1),   // 显示文本
+});
+
+const choicePromptSchema = z.object({
+  source: z.enum(['galgame', 'mini_game_invite']),
+  options: z.array(choiceOptionSchema).min(1),
+  sessionId: z.string().optional(),
+  gameType: z.string().optional(),
+}).nullable();
+
 const avatarInteractionPayloadBaseSchema = z.object({
   interactionId: z.string().min(1),
   target: z.literal('avatar'),
@@ -228,6 +254,12 @@ export const chatWindowPropsSchema = z.object({
     .args(galgameOptionSchema)
     .returns(z.void())
     .optional(),
+  // Generic ChoicePrompt（mini-game invite 等通用三选项框架）
+  choicePrompt: choicePromptSchema.optional(),
+  onChoiceSelect: z.function()
+    .args(choiceOptionSchema, z.string())  // (option, source)
+    .returns(z.void())
+    .optional(),
 });
 
 export type ChatMessageRole = z.infer<typeof chatMessageSchema>['role'];
@@ -239,6 +271,9 @@ export type StatusBlock = z.infer<typeof statusBlockSchema>;
 export type ButtonGroupBlock = z.infer<typeof buttonGroupBlockSchema>;
 export type ComposerAttachment = z.infer<typeof composerAttachmentSchema>;
 export type GalgameOption = z.infer<typeof galgameOptionSchema>;
+export type ChoiceOption = z.infer<typeof choiceOptionSchema>;
+export type ChoicePrompt = NonNullable<z.infer<typeof choicePromptSchema>>;
+export type ChoicePromptSource = ChoicePrompt['source'];
 export type AvatarInteractionPayload = z.infer<typeof avatarInteractionPayloadSchema>;
 export type AvatarToolStatePayload = z.infer<typeof avatarToolStatePayloadSchema>;
 export type MessageBlock = z.infer<typeof messageBlockSchema>;

--- a/frontend/react-neko-chat/src/message-schema.ts
+++ b/frontend/react-neko-chat/src/message-schema.ts
@@ -257,7 +257,9 @@ export const chatWindowPropsSchema = z.object({
   // Generic ChoicePrompt（mini-game invite 等通用三选项框架）
   choicePrompt: choicePromptSchema.optional(),
   onChoiceSelect: z.function()
-    .args(choiceOptionSchema, z.string())  // (option, source)
+    // source 必须是固定枚举，与 ChoicePrompt['source'] 对齐——CodeRabbit 指出
+    // 任意 z.string() 会让 zod 验证变松。
+    .args(choiceOptionSchema, z.enum(['galgame', 'mini_game_invite']))
     .returns(z.void())
     .optional(),
 });

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5035,6 +5035,43 @@ class LLMSessionManager:
                         is_voice_source=False,
                     )
 
+                    # Mini-game 邀请的关键词文本兜底（PR #1141 follow-up E2）。
+                    # 用户在 pending 邀请期间自己打字（没点 ChoicePrompt 三按
+                    # 钮）→ 扫关键词命中就触发对应 state 转换。**不吃掉消息**：
+                    # 继续走普通 chat 流水线，AI 仍然会回应这条话——AI 收到的
+                    # 上下文里也含这条用户输入，所以模型会自然把"好啊"、"不
+                    # 玩了"之类的回复处理掉。仅做 state side effect + accept 时
+                    # 推一条 mini_game_launch WS 让前端 window.open 游戏。
+                    try:
+                        from main_routers.system_router import _maybe_apply_mini_game_invite_keyword
+                        _kw_outcome = _maybe_apply_mini_game_invite_keyword(
+                            self.lanlan_name,
+                            data if isinstance(data, str) else '',
+                        )
+                    except Exception as _kw_err:
+                        logger.debug(
+                            f"[{self.lanlan_name}] mini-game invite keyword "
+                            f"matcher hook failed: {_kw_err}",
+                        )
+                        _kw_outcome = None
+                    if _kw_outcome and _kw_outcome.get('action') == 'open_game':
+                        try:
+                            if (self.websocket
+                                    and hasattr(self.websocket, 'send_json')):
+                                ws_state = getattr(self.websocket, 'client_state', None)
+                                if ws_state is None or ws_state == ws_state.CONNECTED:
+                                    await self.websocket.send_json({
+                                        'type': 'mini_game_launch',
+                                        'game_type': _kw_outcome.get('game_type'),
+                                        'game_url': _kw_outcome.get('game_url'),
+                                        'source': 'keyword',
+                                    })
+                        except Exception as _push_err:
+                            logger.warning(
+                                f"[{self.lanlan_name}] mini-game launch "
+                                f"WS push failed: {_push_err}",
+                            )
+
                     should_handoff, openclaw_messages = await self._should_handoff_text_to_openclaw(data)
                     if should_handoff:
                         handed_off = await self._dispatch_openclaw_handoff(data, openclaw_messages)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5054,25 +5054,30 @@ class LLMSessionManager:
                             f"matcher hook failed: {_kw_err}",
                         )
                         _kw_outcome = None
-                    if _kw_outcome and _kw_outcome.get('action') == 'open_game':
+                    # 推一条 mini_game_invite_resolved 给前端：accept 时兼当 launch
+                    # 信号（带 game_url），decline/later 时让 ChoicePrompt UI 清掉
+                    # 不让按钮挂着——codex P2 指出，原版只对 accept 推，
+                    # decline/later keyword 命中后前端 prompt 不消失，用户后续点
+                    # 按钮会被 endpoint 当 expired，state 早变了。
+                    if _kw_outcome and _kw_outcome.get('action'):
                         try:
                             if (self.websocket
                                     and hasattr(self.websocket, 'send_json')):
                                 ws_state = getattr(self.websocket, 'client_state', None)
                                 if ws_state is None or ws_state == ws_state.CONNECTED:
-                                    # 必须带 session_id：前端 _launchedMiniGameSessionIds
-                                    # dedupe 跨路径（按钮 endpoint / keyword WS）共享键，
-                                    # 缺 id 会让两路同时触发时双开窗口（codex P2 指出）。
-                                    await self.websocket.send_json({
-                                        'type': 'mini_game_launch',
+                                    payload = {
+                                        'type': 'mini_game_invite_resolved',
                                         'session_id': _kw_outcome.get('session_id') or '',
-                                        'game_type': _kw_outcome.get('game_type'),
-                                        'game_url': _kw_outcome.get('game_url'),
-                                        'source': 'keyword',
-                                    })
+                                        'action': _kw_outcome['action'],
+                                    }
+                                    if _kw_outcome.get('game_url'):
+                                        payload['game_url'] = _kw_outcome['game_url']
+                                    if _kw_outcome.get('game_type'):
+                                        payload['game_type'] = _kw_outcome['game_type']
+                                    await self.websocket.send_json(payload)
                         except Exception as _push_err:
                             logger.warning(
-                                f"[{self.lanlan_name}] mini-game launch "
+                                f"[{self.lanlan_name}] mini_game_invite_resolved "
                                 f"WS push failed: {_push_err}",
                             )
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5060,8 +5060,12 @@ class LLMSessionManager:
                                     and hasattr(self.websocket, 'send_json')):
                                 ws_state = getattr(self.websocket, 'client_state', None)
                                 if ws_state is None or ws_state == ws_state.CONNECTED:
+                                    # 必须带 session_id：前端 _launchedMiniGameSessionIds
+                                    # dedupe 跨路径（按钮 endpoint / keyword WS）共享键，
+                                    # 缺 id 会让两路同时触发时双开窗口（codex P2 指出）。
                                     await self.websocket.send_json({
                                         'type': 'mini_game_launch',
+                                        'session_id': _kw_outcome.get('session_id') or '',
                                         'game_type': _kw_outcome.get('game_type'),
                                         'game_url': _kw_outcome.get('game_url'),
                                         'source': 'keyword',

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2192,18 +2192,24 @@ async def _record_invite_delivery_persistent(lanlan_name: str) -> int:
 def _mini_game_invite_advance_response(
     lanlan_name: str, last_user_msg_at: float | None,
 ) -> None:
-    """如果有 pending 邀请且用户已经在 delivered_at 之后说过话，标记为已回应。
+    """pending 邀请期间用户发了任意普通消息（非显式 choice / 关键词命中）→
+    把 prompt 静默 dismiss + 5min 短抑制，**不**启动长冷却。
 
     每次进 proactive_chat（含 voice fast path 与 text path 两条）都调一次。
     last_user_msg_at 是「用户最后一次活动的时间戳」——caller 负责从合适来源
     解出来：text path 用 activity_snapshot.seconds_since_user_msg 反推；voice
     path 直接用 mgr.last_user_activity_time（voice 不走 activity tracker，但
-    session 自己跟踪 RMS / 文本输入活动）。任一缺失（None）都按"未回应"保留
-    pending，不主动 flip。
+    session 自己跟踪 RMS / 文本输入活动）。任一缺失（None）都 noop。
 
-    Anchor 到 last_user_msg_at 而不是"检测到的此刻"——advance 只在新一轮
-    proactive_chat 跑时被调，user 回完到下次 proactive 之间可能隔几小时，
-    用 now 会让 24h 冷却被这段间隔白白拉长。"""
+    历史与现行语义的差异（CodeRabbit Major 指出后改）：
+    - 旧 PR #1141 时代：没有 ChoicePrompt，「用户在邀请之后说话」=「隐式回应」
+      → 直接 mark responded_at，启动 1h+10 chats 长冷却。
+    - 现在 PR #1145 引入显式三选项按钮 + 关键词文本兜底；长冷却语义只该由
+      **显式选择**（accept / decline）触发。任意非命中消息只是「dismiss
+      prompt」——保留 ever_delivered（force-first 不会再 fire）+ 5min 短抑
+      制（防下次 proactive 立刻又邀请），但不长锁。等同于 'later' choice。
+      否则用户先说一句别的再点按钮 → endpoint 看到 responded_at != None →
+      "expired"，状态已悄悄进 1h 长冷却（违背 D2 语义、用户体验差）。"""
     state = _mini_game_invite_state.get(lanlan_name)
     if not state:
         return
@@ -2211,15 +2217,12 @@ def _mini_game_invite_advance_response(
         return
     if last_user_msg_at is None:
         return
-    if last_user_msg_at > state['delivered_at']:
-        state['responded_at'] = float(last_user_msg_at)
-        state['chats_since_response'] = 0
-        now = time.time()
-        logger.info(
-            "[%s] mini-game invite responded "
-            "(delivered_at=%.1fs ago, last user msg=%.1fs ago)",
-            lanlan_name, now - state['delivered_at'], now - float(last_user_msg_at),
-        )
+    if last_user_msg_at <= state['delivered_at']:
+        return
+    # 任意消息 = 隐式 dismiss → 等同 'later' choice 的 reset+短抑制语义。
+    # 复用 _apply_mini_game_invite_choice 保持单一事实源；source 标 'implicit_dismiss'
+    # 让日志能区分按钮路径与隐式路径。
+    _apply_mini_game_invite_choice(lanlan_name, 'later', source='implicit_dismiss')
 
 
 def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -5786,7 +5786,11 @@ def _apply_mini_game_invite_choice(
     if choice == 'accept':
         state['responded_at'] = now
         state['chats_since_response'] = 0
-        # source_id 进 game_url query，后端 game_router 后续可能用来对账
+        # session_id 既进 game_url query，又作为 result 顶层字段返回——keyword 路径
+        # core.py 要把它放进 mini_game_launch WS payload，前端 dedupe 才能跨路径
+        # 共享 key（codex P2 review 指出：缺这个 dedupe 就失效，同 invite 多路径
+        # 触发会双开窗口）。
+        invite_session_id = state.get('pending_session_id') or ''
         game_type = state.get('last_game_type') or 'soccer'
         url_template = MINI_GAME_LAUNCH_URL_BY_GAME.get(game_type)
         if not url_template:
@@ -5798,7 +5802,7 @@ def _apply_mini_game_invite_choice(
         from urllib.parse import urlencode as _urlencode
         query = _urlencode({
             'lanlan_name': lanlan_name,
-            'session_id': state.get('pending_session_id') or '',
+            'session_id': invite_session_id,
         })
         game_url = f"{url_template}?{query}"
         logger.info(
@@ -5809,6 +5813,7 @@ def _apply_mini_game_invite_choice(
             'action': 'open_game',
             'game_type': game_type,
             'game_url': game_url,
+            'session_id': invite_session_id,
         }
     if choice == 'decline':
         state['responded_at'] = now
@@ -5857,12 +5862,16 @@ async def mini_game_invite_respond(request: Request):
         - 过期 / 状态不匹配：``{success: true, action: 'expired', message}``——前端
           应停止显示选项按钮（邀请已过期）。
     """
-    try:
-        data = await request.json()
-    except Exception:
-        return JSONResponse({"success": False, "error": "invalid JSON"}, status_code=400)
-    if not isinstance(data, dict):
-        return JSONResponse({"success": False, "error": "invalid body"}, status_code=400)
+    payload = await _read_json_object(request)
+    # 这是个本地 mutation endpoint，会改写 invite cooldown 状态——必须走和同文件
+    # 其它 browser-facing mutation endpoint 一样的 CSRF / origin 校验，否则
+    # 第三方页面可对 localhost:port 盲 POST 替用户 accept / decline / later 当前
+    # 邀请。CodeRabbit Major review 指出。
+    validation_error = _validate_local_mutation_request(request, payload=payload)
+    if validation_error is not None:
+        _set_no_store_headers(validation_error)
+        return validation_error
+    data = payload if isinstance(payload, dict) else {}
     try:
         config_manager = get_config_manager()
         _, her_name_default, _, _, _, _, _, _, _ = await config_manager.aget_character_data()
@@ -5877,17 +5886,18 @@ async def mini_game_invite_respond(request: Request):
             {"success": False, "error": f"choice must be accept/decline/later, got {choice!r}"},
             status_code=400,
         )
-    session_id = (data.get('session_id') or '').strip() or None
+    session_id = (data.get('session_id') or '').strip()
 
+    # session_id 强校验：必须存在 + 必须等于 state.pending_session_id；任一失败都
+    # 走 expired。原版「missing → 放过去用当前 pending」会让调用方漏传 session_id
+    # 时绕过 stale-session 保护——CodeRabbit Major review 指出。
     state = _mini_game_invite_state.get(lanlan_name)
     pending_sid = state.get('pending_session_id') if state else None
-    if session_id and pending_sid and session_id != pending_sid:
-        # 用户点的是过期邀请的按钮（典型场景：浮窗里的旧邀请没刷新就被点）。
-        # 不报错，告诉前端 expired，让 UI 停掉旧 prompt。
+    if not session_id or not pending_sid or session_id != pending_sid:
         return JSONResponse({
             "success": True,
             "action": "expired",
-            "message": "invite session expired; a newer invite or no pending invite exists",
+            "message": "invite session expired or missing; a newer invite or no pending invite exists",
         })
 
     result = _apply_mini_game_invite_choice(lanlan_name, choice, source='button')
@@ -5905,9 +5915,15 @@ def _match_mini_game_invite_keyword(text: str) -> str | None:
     choice，未命中返 None。
 
     所有 native locale 的关键词列表全扫一遍——用户可能切了 UI 语言但仍用
-    原语言打字。优先级：accept > later > decline（暧昧文本如「好的不过等下」
-    倾向 accept-with-delay 当 accept 处理而不是 later，spec 偏向"用户表达
-    了正面意愿就当接受"）。空 text / 命中无视为 None。"""
+    原语言打字。
+
+    **优先级 decline > later > accept**：句子里同时含 negation 和接受词时
+    （e.g. "不好" 含 '好啊'? 否；但 "我不行了，回头说" 含 '不行' + '回头'），
+    decline 永远优先于 later 优先于 accept——含明确 negation 的句子绝不能因
+    accept 关键词凑巧 substring 匹配就反向触发开游戏。CodeRabbit Major 指
+    出后从 accept-priority 改成 decline-priority。
+
+    空 text / 命中无视为 None。"""
     if not text:
         return None
     norm = text.lower().strip()
@@ -5923,12 +5939,13 @@ def _match_mini_game_invite_keyword(text: str) -> str | None:
             hit_later = True
         if not hit_decline and any(kw and kw in norm for kw in lang_kw.get('decline', [])):
             hit_decline = True
-    if hit_accept:
-        return 'accept'
-    if hit_later:
-        return 'later'
+    # decline > later > accept：negation-priority。
     if hit_decline:
         return 'decline'
+    if hit_later:
+        return 'later'
+    if hit_accept:
+        return 'accept'
     return None
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -5940,6 +5940,11 @@ async def mini_game_invite_respond(request: Request):
     # 推一条 mini_game_invite_resolved 给所有可能在显示 prompt 的 page（pet 主窗
     # + chat.html 多窗口同时打开），让 cross-window 一致地 dismiss 选项 UI。
     # 单窗口模式只有一个监听者也无害（idempotent）。
+    #
+    # ⚠️ 故意不传 game_url / game_type —— button path 由触发 page（chat.html
+    # 收到 HTTP 响应后）自己 window.open；如果这里 push 的 WS 也带 game_url，
+    # pet 主窗（非 follower）也会 launch，多窗口下双开窗口（codex P2 指出）。
+    # WS broadcast 在 button path 里只承担 cross-window dismiss prompt 职责。
     try:
         mgr = get_session_manager().get(lanlan_name)
         if mgr is not None:
@@ -5947,8 +5952,7 @@ async def mini_game_invite_respond(request: Request):
                 mgr,
                 session_id=session_id,
                 action=result['action'],
-                game_url=result.get('game_url'),
-                game_type=result.get('game_type'),
+                # 故意不传 game_url / game_type
             )
     except Exception as exc:
         logger.warning(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -35,6 +35,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlsplit
+from uuid import uuid4
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, Response
@@ -79,6 +80,8 @@ from config import (
     MINI_GAME_INVITE_COOLDOWN_CHATS,
     MINI_GAME_INVITE_NEW_USER_FORCE_AT,
     MINI_GAME_INVITE_AVAILABLE_GAMES,
+    MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS,
+    MINI_GAME_LAUNCH_URL_BY_GAME,
     PROACTIVE_SOURCE_HARD_SKIP_SECONDS,
     PROACTIVE_SOURCE_HALF_LIFE_BY_KIND,
     PROACTIVE_SOURCE_HALF_LIFE_DEFAULT,
@@ -118,6 +121,8 @@ from config.prompts_proactive import (
     PROACTIVE_MUSIC_TAG_INSTRUCTIONS,
     MUSIC_SEARCH_RESULT_TEXTS,
     MINI_GAME_INVITE_LINES_BY_GAME,
+    MINI_GAME_INVITE_OPTION_LABELS,
+    MINI_GAME_INVITE_KEYWORDS,
     build_proactive_action_note,
 )
 from utils.file_utils import atomic_write_json_async, read_json
@@ -2045,6 +2050,12 @@ def _mini_game_invite_get_state(lanlan_name: str) -> dict[str, Any]:
             'responded_at': None,
             'chats_since_response': 0,
             'last_game_type': None,
+            # 当前 pending 邀请的 session_id；endpoint 收到回应时校验匹配，避免
+            # 用户点击过期邀请被错算成响应当前 pending。一旦投递新邀请会被刷新。
+            'pending_session_id': None,
+            # D2「回头再说」短期抑制：reset 后不允许下一次 proactive 立刻又掷骰。
+            # _in_cooldown 多查一道这个 gate。秒级 epoch；None = 不抑制。
+            'suppressed_until': None,
         }
         _mini_game_invite_state[lanlan_name] = state
     return state
@@ -2215,12 +2226,18 @@ def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:
     """是否处于冷却期。True = 本轮不该掷骰。
 
     覆盖：
+      - D2「回头再说」短期抑制（suppressed_until > now）→ True
       - pending（投递了但 responded_at=None）→ True
-      - 已回应但 24h 或 10 chats 任一未跨过 → True
+      - 已回应但 1h 或 10 chats 任一未跨过 → True
       - 从未投递 / 已完整跨过两道 → False
     """
     state = _mini_game_invite_state.get(lanlan_name)
-    if not state or state['delivered_at'] is None:
+    if not state:
+        return False
+    suppressed_until = state.get('suppressed_until')
+    if suppressed_until is not None and time.time() < float(suppressed_until):
+        return True
+    if state['delivered_at'] is None:
         return False
     if state['responded_at'] is None:
         return True
@@ -2231,12 +2248,20 @@ def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:
     )
 
 
-def _mini_game_invite_record_delivered(lanlan_name: str) -> None:
-    """记录一次成功投递的邀请。重置 responded/counter 进入新一轮 pending。"""
+def _mini_game_invite_record_delivered(lanlan_name: str, session_id: str) -> None:
+    """记录一次成功投递的邀请。重置 responded/counter 进入新一轮 pending。
+
+    session_id 来自 caller（``_maybe_deliver_mini_game_invite`` 投递时生成的
+    uuid），endpoint 验证用户回应是否匹配当前 pending。新一次投递会刷新这个
+    id——上一次投递留下的过期 session_id 在 endpoint 端会被识别为 stale 拒绝。"""
     state = _mini_game_invite_get_state(lanlan_name)
     state['delivered_at'] = time.time()
     state['responded_at'] = None
     state['chats_since_response'] = 0
+    state['pending_session_id'] = session_id
+    # 新邀请投递清掉 D2 的 short-suppression：本来是「上次回头再说」的窗口，
+    # 既然现在又投了新邀请说明那个窗口已过期，没必要保留。
+    state['suppressed_until'] = None
 
 
 def _mini_game_invite_count_post_response_chat(lanlan_name: str) -> None:
@@ -2383,16 +2408,42 @@ async def _maybe_deliver_mini_game_invite(
             "action": "pass",
             "message": "mini-game invite skipped: user took over before delivery",
         }
+    # 给本次邀请生成独立 session_id，前端按钮点击 / 文本关键词命中走 endpoint 时
+    # 必须带回这个 id 给后端校验：避免 stale 邀请的延迟回应被错算成响应当前 pending。
+    invite_session_id = str(uuid4())
+
     _record_proactive_chat(lanlan_name, invite_text, channel='mini_game')
-    _mini_game_invite_record_delivered(lanlan_name)
+    _mini_game_invite_record_delivered(lanlan_name, invite_session_id)
     _mini_game_invite_get_state(lanlan_name)['last_game_type'] = game_type
     # counter +1 + ever_delivered=True 一把锁内原子写盘。两份持久化数据必须
     # 一起落盘，否则 partial-state（totals 已 +1 但 ever_delivered 还是旧 false）
     # 会让重启后 force-first 重复触发——CodeRabbit Major review 指出。
     await _record_invite_delivery_persistent(lanlan_name)
+
+    # 推 WS message 给前端展示三选项按钮。前端复用 ChoicePrompt 抽象（与 galgame
+    # options 共用渲染），但 source='mini_game_invite' 走独立 endpoint，不翻
+    # galgame mode 开关。Pet 主窗收到后通过现有 RAW_MESSAGE IPC forwarding 自动
+    # 转给 chat.html，不需要新 IPC channel。
+    options_payload = _build_mini_game_invite_options_payload(
+        invite_lang=invite_lang,
+        game_type=game_type,
+        session_id=invite_session_id,
+    )
+    try:
+        if mgr.websocket and hasattr(mgr.websocket, 'send_json'):
+            client_state = getattr(mgr.websocket, 'client_state', None)
+            if client_state is None or client_state == client_state.CONNECTED:
+                await mgr.websocket.send_json(options_payload)
+    except Exception as exc:
+        logger.warning(
+            "[%s] mini-game invite options WS push failed: %s",
+            lanlan_name, exc,
+        )
+
     print(
         f"[{lanlan_name}] Mini-game invite delivered "
-        f"(game={game_type}, force_first={force_first}): {invite_text[:60]}…"
+        f"(game={game_type}, force_first={force_first}, "
+        f"session_id={invite_session_id[:8]}…): {invite_text[:60]}…"
     )
     return {
         "success": True,
@@ -2403,6 +2454,34 @@ async def _maybe_deliver_mini_game_invite(
         "force_first": force_first,
         "lanlan_name": lanlan_name,
         "turn_id": proactive_sid,
+        "invite_session_id": invite_session_id,
+    }
+
+
+def _build_mini_game_invite_options_payload(
+    *,
+    invite_lang: str,
+    game_type: str,
+    session_id: str,
+) -> dict[str, Any]:
+    """构造前端 ChoicePrompt 用的 WS payload。
+
+    label 走 i18n（accept/decline/later 三选项），choice 是 wire-format 标识符
+    （前端按钮点击发回 endpoint 时用），不变。"""
+    labels = MINI_GAME_INVITE_OPTION_LABELS.get(
+        invite_lang,
+        MINI_GAME_INVITE_OPTION_LABELS.get('zh', {}),
+    )
+    options = [
+        {'choice': 'accept', 'label': labels.get('accept', 'Yes')},
+        {'choice': 'decline', 'label': labels.get('decline', 'No')},
+        {'choice': 'later', 'label': labels.get('later', 'Later')},
+    ]
+    return {
+        'type': 'mini_game_invite_options',
+        'session_id': session_id,
+        'game_type': game_type,
+        'options': options,
     }
 
 
@@ -5681,6 +5760,202 @@ async def proactive_chat(request: Request):
 
 
 
+
+
+def _apply_mini_game_invite_choice(
+    lanlan_name: str, choice: str, *, source: str,
+) -> dict[str, Any]:
+    """处理 mini-game 邀请的三选项 state 转换。返回结构化结果给 endpoint /
+    keyword matcher 共用。
+
+    - accept：mark responded（启动 1h+10 chats 冷却）+ 返回 game_url
+    - decline：mark responded（同上冷却，但不开游戏）
+    - later (D2)：reset state（delivered_at=None，让 force-first / 普通 10% 都
+      恢复正常）+ 加 ``suppressed_until = now + 5min`` 防止下一次 proactive
+      立刻又掷骰
+
+    state 必须 already-pending（delivered_at != None and responded_at is None）；
+    否则当作 stale，返回 ``action='ignored'``，caller 自己决定是否反馈用户。"""
+    state = _mini_game_invite_state.get(lanlan_name)
+    if not state or state.get('delivered_at') is None:
+        return {'action': 'ignored', 'reason': 'no_pending_invite'}
+    if state.get('responded_at') is not None:
+        return {'action': 'ignored', 'reason': 'already_responded'}
+
+    now = time.time()
+    if choice == 'accept':
+        state['responded_at'] = now
+        state['chats_since_response'] = 0
+        # source_id 进 game_url query，后端 game_router 后续可能用来对账
+        game_type = state.get('last_game_type') or 'soccer'
+        url_template = MINI_GAME_LAUNCH_URL_BY_GAME.get(game_type)
+        if not url_template:
+            logger.warning(
+                "[%s] accept invite but no launch URL for game_type=%r; "
+                "fallback /soccer_demo", lanlan_name, game_type,
+            )
+            url_template = '/soccer_demo'
+        from urllib.parse import urlencode as _urlencode
+        query = _urlencode({
+            'lanlan_name': lanlan_name,
+            'session_id': state.get('pending_session_id') or '',
+        })
+        game_url = f"{url_template}?{query}"
+        logger.info(
+            "[%s] mini-game invite accepted via %s -> %s",
+            lanlan_name, source, url_template,
+        )
+        return {
+            'action': 'open_game',
+            'game_type': game_type,
+            'game_url': game_url,
+        }
+    if choice == 'decline':
+        state['responded_at'] = now
+        state['chats_since_response'] = 0
+        logger.info(
+            "[%s] mini-game invite declined via %s; cooldown started",
+            lanlan_name, source,
+        )
+        return {'action': 'cooldown'}
+    if choice == 'later':
+        # D2：完全 reset 但加短期 suppression。reset 之后 force-first 仍受
+        # ever_delivered（持久化）压制——已经被邀请过的用户即便 state 清掉也
+        # 不会被当成新用户重邀。
+        state['delivered_at'] = None
+        state['responded_at'] = None
+        state['chats_since_response'] = 0
+        state['pending_session_id'] = None
+        state['suppressed_until'] = now + MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS
+        logger.info(
+            "[%s] mini-game invite deferred via %s; suppressed for %.0fs",
+            lanlan_name, source, float(MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS),
+        )
+        return {'action': 'suppress'}
+    return {'action': 'ignored', 'reason': f'unknown_choice:{choice}'}
+
+
+@router.post('/mini_game/invite/respond')
+async def mini_game_invite_respond(request: Request):
+    """前端按钮点击 → 三选项 state 转换 endpoint。
+
+    Body：
+        {
+          "lanlan_name": str,                   // 当前角色（前端从 host 拿）
+          "choice": "accept" | "decline" | "later",
+          "session_id": str | null,             // 投递时由 backend 生成的 uuid；
+                                                // 必须与 state.pending_session_id
+                                                // 匹配，否则当 stale 处理
+        }
+
+    Response：
+        - accept：``{success, action: 'open_game', game_type, game_url}``——前端
+          收到后调 ``window.open(game_url)`` 让 Electron 主进程的
+          setWindowOpenHandler 拦截开独立窗口。
+        - decline：``{success, action: 'cooldown'}``
+        - later：``{success, action: 'suppress'}``
+        - 过期 / 状态不匹配：``{success: true, action: 'expired', message}``——前端
+          应停止显示选项按钮（邀请已过期）。
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return JSONResponse({"success": False, "error": "invalid JSON"}, status_code=400)
+    if not isinstance(data, dict):
+        return JSONResponse({"success": False, "error": "invalid body"}, status_code=400)
+    try:
+        config_manager = get_config_manager()
+        _, her_name_default, _, _, _, _, _, _, _ = await config_manager.aget_character_data()
+    except Exception:
+        her_name_default = ''
+    lanlan_name = (data.get('lanlan_name') or her_name_default or '').strip()
+    if not lanlan_name:
+        return JSONResponse({"success": False, "error": "lanlan_name missing"}, status_code=400)
+    choice = (data.get('choice') or '').strip().lower()
+    if choice not in ('accept', 'decline', 'later'):
+        return JSONResponse(
+            {"success": False, "error": f"choice must be accept/decline/later, got {choice!r}"},
+            status_code=400,
+        )
+    session_id = (data.get('session_id') or '').strip() or None
+
+    state = _mini_game_invite_state.get(lanlan_name)
+    pending_sid = state.get('pending_session_id') if state else None
+    if session_id and pending_sid and session_id != pending_sid:
+        # 用户点的是过期邀请的按钮（典型场景：浮窗里的旧邀请没刷新就被点）。
+        # 不报错，告诉前端 expired，让 UI 停掉旧 prompt。
+        return JSONResponse({
+            "success": True,
+            "action": "expired",
+            "message": "invite session expired; a newer invite or no pending invite exists",
+        })
+
+    result = _apply_mini_game_invite_choice(lanlan_name, choice, source='button')
+    if result['action'] == 'ignored':
+        return JSONResponse({
+            "success": True,
+            "action": "expired",
+            "message": result.get('reason') or 'no pending invite',
+        })
+    return JSONResponse({"success": True, **result, "lanlan_name": lanlan_name})
+
+
+def _match_mini_game_invite_keyword(text: str) -> str | None:
+    """扫一遍用户文本（小写 + strip），命中 accept/decline/later 关键词返
+    choice，未命中返 None。
+
+    所有 native locale 的关键词列表全扫一遍——用户可能切了 UI 语言但仍用
+    原语言打字。优先级：accept > later > decline（暧昧文本如「好的不过等下」
+    倾向 accept-with-delay 当 accept 处理而不是 later，spec 偏向"用户表达
+    了正面意愿就当接受"）。空 text / 命中无视为 None。"""
+    if not text:
+        return None
+    norm = text.lower().strip()
+    if not norm:
+        return None
+    hit_accept = False
+    hit_decline = False
+    hit_later = False
+    for lang_kw in MINI_GAME_INVITE_KEYWORDS.values():
+        if not hit_accept and any(kw and kw in norm for kw in lang_kw.get('accept', [])):
+            hit_accept = True
+        if not hit_later and any(kw and kw in norm for kw in lang_kw.get('later', [])):
+            hit_later = True
+        if not hit_decline and any(kw and kw in norm for kw in lang_kw.get('decline', [])):
+            hit_decline = True
+    if hit_accept:
+        return 'accept'
+    if hit_later:
+        return 'later'
+    if hit_decline:
+        return 'decline'
+    return None
+
+
+def _maybe_apply_mini_game_invite_keyword(
+    lanlan_name: str, text: str,
+) -> dict[str, Any] | None:
+    """文本入口（core.py user message handler）调一次。pending invite 时尝试
+    关键词匹配；命中即触发对应 state 转换，返回 dict 给 caller 决定是否要做
+    side effect（如 push WS message 让前端 window.open 游戏）。
+
+    **不吃掉用户消息**——caller 应继续走普通 chat 流水线，AI 仍然会回应这条
+    话。仅做 state side effect。
+
+    - 没 pending invite / 文本空 / 没命中 → None
+    - 命中 accept → ``{action: 'open_game', game_type, game_url}``
+    - 命中 decline / later → ``{action: 'cooldown' | 'suppress'}``
+    """
+    state = _mini_game_invite_state.get(lanlan_name)
+    if not state or state.get('delivered_at') is None or state.get('responded_at') is not None:
+        return None  # 没 pending
+    choice = _match_mini_game_invite_keyword(text)
+    if choice is None:
+        return None
+    result = _apply_mini_game_invite_choice(lanlan_name, choice, source='keyword')
+    if result.get('action') == 'ignored':
+        return None
+    return result
 
 
 @router.post('/proactive/music_played_through')

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2191,9 +2191,13 @@ async def _record_invite_delivery_persistent(lanlan_name: str) -> int:
 
 def _mini_game_invite_advance_response(
     lanlan_name: str, last_user_msg_at: float | None,
-) -> None:
+) -> dict[str, Any] | None:
     """pending 邀请期间用户发了任意普通消息（非显式 choice / 关键词命中）→
     把 prompt 静默 dismiss + 5min 短抑制，**不**启动长冷却。
+
+    Returns: 与 ``_apply_mini_game_invite_choice`` 同 shape 的 dict（含
+    ``action='suppress'`` + ``session_id``），caller 用它去 push
+    ``mini_game_invite_resolved`` WS event 让前端 dismiss UI。无动作时返 None。
 
     每次进 proactive_chat（含 voice fast path 与 text path 两条）都调一次。
     last_user_msg_at 是「用户最后一次活动的时间戳」——caller 负责从合适来源
@@ -2212,17 +2216,19 @@ def _mini_game_invite_advance_response(
       "expired"，状态已悄悄进 1h 长冷却（违背 D2 语义、用户体验差）。"""
     state = _mini_game_invite_state.get(lanlan_name)
     if not state:
-        return
+        return None
     if state['delivered_at'] is None or state['responded_at'] is not None:
-        return
+        return None
     if last_user_msg_at is None:
-        return
+        return None
     if last_user_msg_at <= state['delivered_at']:
-        return
+        return None
     # 任意消息 = 隐式 dismiss → 等同 'later' choice 的 reset+短抑制语义。
     # 复用 _apply_mini_game_invite_choice 保持单一事实源；source 标 'implicit_dismiss'
     # 让日志能区分按钮路径与隐式路径。
-    _apply_mini_game_invite_choice(lanlan_name, 'later', source='implicit_dismiss')
+    return _apply_mini_game_invite_choice(
+        lanlan_name, 'later', source='implicit_dismiss',
+    )
 
 
 def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:
@@ -4050,9 +4056,17 @@ async def proactive_chat(request: Request):
             # 活动）作为「用户最后一次活动时间」喂给 advance_response。否则纯
             # voice 用户收到 mini-game 邀请回应后，pending 永远翻不掉，邀请会被
             # 永久抑制；CodeRabbit Major review 指出。
-            _mini_game_invite_advance_response(
+            _voice_advance_outcome = _mini_game_invite_advance_response(
                 lanlan_name, getattr(mgr, 'last_user_activity_time', None),
             )
+            # advance 触发了隐式 dismiss → 推 WS 让前端清掉 prompt UI（cross-window
+            # 一致性）。codex P2 指出非按钮路径漏推 WS 让 UI 挂着。
+            if _voice_advance_outcome and _voice_advance_outcome.get('session_id'):
+                await _push_mini_game_invite_resolved(
+                    mgr,
+                    session_id=_voice_advance_outcome['session_id'],
+                    action=_voice_advance_outcome.get('action', 'suppress'),
+                )
             if not mgr.state.can_start_proactive(session=probe_session):
                 return JSONResponse({
                     "success": False,
@@ -4157,7 +4171,16 @@ async def proactive_chat(request: Request):
             _secs = getattr(activity_snapshot, 'seconds_since_user_msg', None)
             if _secs is not None:
                 _text_last_user_msg_at = time.time() - float(_secs)
-        _mini_game_invite_advance_response(lanlan_name, _text_last_user_msg_at)
+        _text_advance_outcome = _mini_game_invite_advance_response(
+            lanlan_name, _text_last_user_msg_at,
+        )
+        # 隐式 dismiss 推 WS（同 voice fast path 对称，codex P2）
+        if _text_advance_outcome and _text_advance_outcome.get('session_id'):
+            await _push_mini_game_invite_resolved(
+                mgr,
+                session_id=_text_advance_outcome['session_id'],
+                action=_text_advance_outcome.get('action', 'suppress'),
+            )
 
         # ========== Hard short-circuit: propensity=closed ==========
         # ``private`` state pins propensity to ``closed`` (see
@@ -5819,17 +5842,21 @@ def _apply_mini_game_invite_choice(
             'session_id': invite_session_id,
         }
     if choice == 'decline':
+        # 留 session_id 给 caller 推 mini_game_invite_resolved 用——所有
+        # outcome 都需要前端 dismiss prompt（codex P2）。
+        decline_session_id = state.get('pending_session_id') or ''
         state['responded_at'] = now
         state['chats_since_response'] = 0
         logger.info(
             "[%s] mini-game invite declined via %s; cooldown started",
             lanlan_name, source,
         )
-        return {'action': 'cooldown'}
+        return {'action': 'cooldown', 'session_id': decline_session_id}
     if choice == 'later':
         # D2：完全 reset 但加短期 suppression。reset 之后 force-first 仍受
         # ever_delivered（持久化）压制——已经被邀请过的用户即便 state 清掉也
         # 不会被当成新用户重邀。
+        later_session_id = state.get('pending_session_id') or ''
         state['delivered_at'] = None
         state['responded_at'] = None
         state['chats_since_response'] = 0
@@ -5839,7 +5866,7 @@ def _apply_mini_game_invite_choice(
             "[%s] mini-game invite deferred via %s; suppressed for %.0fs",
             lanlan_name, source, float(MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS),
         )
-        return {'action': 'suppress'}
+        return {'action': 'suppress', 'session_id': later_session_id}
     return {'action': 'ignored', 'reason': f'unknown_choice:{choice}'}
 
 
@@ -5910,7 +5937,94 @@ async def mini_game_invite_respond(request: Request):
             "action": "expired",
             "message": result.get('reason') or 'no pending invite',
         })
+    # 推一条 mini_game_invite_resolved 给所有可能在显示 prompt 的 page（pet 主窗
+    # + chat.html 多窗口同时打开），让 cross-window 一致地 dismiss 选项 UI。
+    # 单窗口模式只有一个监听者也无害（idempotent）。
+    try:
+        mgr = get_session_manager().get(lanlan_name)
+        if mgr is not None:
+            await _push_mini_game_invite_resolved(
+                mgr,
+                session_id=session_id,
+                action=result['action'],
+                game_url=result.get('game_url'),
+                game_type=result.get('game_type'),
+            )
+    except Exception as exc:
+        logger.warning(
+            "[%s] mini_game_invite_resolved WS push (button path) failed: %s",
+            lanlan_name, exc,
+        )
     return JSONResponse({"success": True, **result, "lanlan_name": lanlan_name})
+
+
+async def _push_mini_game_invite_resolved(
+    mgr,
+    *,
+    session_id: str,
+    action: str,
+    game_url: str | None = None,
+    game_type: str | None = None,
+) -> None:
+    """Push WS event让前端 dismiss ChoicePrompt（任一 outcome 都清，跨窗口一致）。
+    accept 时 payload 同时带 game_url，前端按 ``action=='open_game'`` 兼当
+    "launch" 信号 window.open。
+
+    替代了原 ``mini_game_launch`` event——单一 WS event 兼容 lifecycle 终结
+    （always clear prompt）+ 可选 game launch（accept 时）。codex P2 / CodeRabbit
+    指出：原版只在 accept 推 ``mini_game_launch``，decline / later keyword 命中
+    后前端 prompt 不消失，用户看着按钮但 state 已变。"""
+    if not mgr or not session_id:
+        return
+    payload: dict[str, Any] = {
+        'type': 'mini_game_invite_resolved',
+        'session_id': session_id,
+        'action': action,
+    }
+    if game_url:
+        payload['game_url'] = game_url
+    if game_type:
+        payload['game_type'] = game_type
+    try:
+        ws = getattr(mgr, 'websocket', None)
+        if ws is None or not hasattr(ws, 'send_json'):
+            return
+        client_state = getattr(ws, 'client_state', None)
+        if client_state is not None and client_state != client_state.CONNECTED:
+            return
+        await ws.send_json(payload)
+    except Exception as exc:
+        logger.warning(
+            "mini_game_invite_resolved WS push failed (session=%s, action=%s): %s",
+            session_id, action, exc,
+        )
+
+
+# ASCII / Cyrillic keyword 用 word-boundary regex 匹配；其它（CJK / Hiragana /
+# Katakana / Hangul）走 substring。Python `\b` 在 \w 边界判定，但中日韩字符也
+# 算 \w——同一脚本的字符之间没有 \b，硬套 word-boundary 会把"我好啊"漏掉。
+# Cyrillic 同 Latin 都是 letter-only，\b 工作良好。codex P1 指出，避免 'yes'
+# 命中 'yesterday'、'no' 命中 'no idea' 等英文误命中。
+_LETTER_ONLY_KW_RE = re.compile(r"^[A-Za-z0-9\s'\-Ѐ-ӿ]+$")
+_KEYWORD_PATTERN_CACHE: dict[str, "re.Pattern[str]"] = {}
+
+
+def _keyword_matches(keyword: str, norm_text: str) -> bool:
+    """Locale-aware substring/word-boundary match.
+
+    ASCII / 数字 / Cyrillic / 空格 / 撇号 / 连字符组成的关键词走 word-boundary
+    regex（``\\b...\\b``）；其它脚本（CJK / Hiragana / Katakana / Hangul）走
+    substring——Python regex 把这些字符纳入 \\w，加 \\b 反而会漏命中（"我好啊"
+    中 '好' 前没 boundary）。"""
+    if not keyword or not norm_text:
+        return False
+    if _LETTER_ONLY_KW_RE.fullmatch(keyword):
+        pattern = _KEYWORD_PATTERN_CACHE.get(keyword)
+        if pattern is None:
+            pattern = re.compile(r'\b' + re.escape(keyword) + r'\b', re.IGNORECASE)
+            _KEYWORD_PATTERN_CACHE[keyword] = pattern
+        return bool(pattern.search(norm_text))
+    return keyword in norm_text
 
 
 def _match_mini_game_invite_keyword(text: str) -> str | None:
@@ -5918,13 +6032,14 @@ def _match_mini_game_invite_keyword(text: str) -> str | None:
     choice，未命中返 None。
 
     所有 native locale 的关键词列表全扫一遍——用户可能切了 UI 语言但仍用
-    原语言打字。
+    原语言打字。匹配走 ``_keyword_matches`` —— ASCII / Cyrillic 用 word-boundary
+    防止 'yes' 命中 'yesterday' / 'no' 命中 'no idea' 这种 codex P1 指出的英文
+    误命中；CJK 仍走 substring（语言特性使然）。
 
-    **优先级 decline > later > accept**：句子里同时含 negation 和接受词时
-    （e.g. "不好" 含 '好啊'? 否；但 "我不行了，回头说" 含 '不行' + '回头'），
+    **优先级 decline > later > accept**：句子里同时含 negation 和接受词时，
     decline 永远优先于 later 优先于 accept——含明确 negation 的句子绝不能因
-    accept 关键词凑巧 substring 匹配就反向触发开游戏。CodeRabbit Major 指
-    出后从 accept-priority 改成 decline-priority。
+    accept 关键词凑巧匹配就反向触发开游戏。CodeRabbit Major 指出后从
+    accept-priority 改成 decline-priority。
 
     空 text / 命中无视为 None。"""
     if not text:
@@ -5936,11 +6051,11 @@ def _match_mini_game_invite_keyword(text: str) -> str | None:
     hit_decline = False
     hit_later = False
     for lang_kw in MINI_GAME_INVITE_KEYWORDS.values():
-        if not hit_accept and any(kw and kw in norm for kw in lang_kw.get('accept', [])):
+        if not hit_accept and any(_keyword_matches(kw, norm) for kw in lang_kw.get('accept', [])):
             hit_accept = True
-        if not hit_later and any(kw and kw in norm for kw in lang_kw.get('later', [])):
+        if not hit_later and any(_keyword_matches(kw, norm) for kw in lang_kw.get('later', [])):
             hit_later = True
-        if not hit_decline and any(kw and kw in norm for kw in lang_kw.get('decline', [])):
+        if not hit_decline and any(_keyword_matches(kw, norm) for kw in lang_kw.get('decline', [])):
             hit_decline = True
     # decline > later > accept：negation-priority。
     if hit_decline:

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1400,10 +1400,38 @@
             choice: option.choice,
             session_id: sessionId
         };
-        fetch('/api/mini_game/invite/respond', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(requestBody)
+        // 必须带 CSRF token：后端 endpoint 用 _validate_local_mutation_request
+        // 拒绝缺 token 的请求，否则所有合法点击都会被 403 reject、prompt 已清掉
+        // 但 invite state 没更新 —— codex P1 指出。沿用 nekoLocalMutationSecurity
+        // 共享 helper（其它 prompt endpoint 同款），含 token 缺失时 refresh + 重
+        // 试一次的协议。
+        var bodyJson = JSON.stringify(requestBody);
+        var doFetch = function (headers) {
+            return fetch('/api/mini_game/invite/respond', {
+                method: 'POST',
+                headers: Object.assign({ 'Content-Type': 'application/json' }, headers || {}),
+                body: bodyJson
+            });
+        };
+        var sec = window.nekoLocalMutationSecurity;
+        var firstHeadersPromise = sec && typeof sec.getMutationHeaders === 'function'
+            ? sec.getMutationHeaders()
+            : Promise.resolve({});
+        firstHeadersPromise.then(doFetch).then(function (resp) {
+            // 403 + csrf_validation_failed → refresh token 重试一次（与 prompt
+            // endpoint 同协议）
+            if (resp.status === 403 && sec && typeof sec.refreshToken === 'function') {
+                return resp.clone().json().catch(function () { return null; }).then(function (errBody) {
+                    var code = errBody && errBody.error_code;
+                    if (code === 'csrf_validation_failed') {
+                        return sec.refreshToken().then(function () {
+                            return sec.getMutationHeaders();
+                        }).then(doFetch);
+                    }
+                    return resp;
+                });
+            }
+            return resp;
         }).then(function (resp) {
             return resp.ok ? resp.json() : Promise.reject(new Error('HTTP ' + resp.status));
         }).then(function (data) {

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1512,10 +1512,19 @@
         // 任一 outcome（open_game / cooldown / suppress）都 dismiss 当前 prompt——
         // 跨窗口一致性。即便本 page 不是触发方，也保持 UI 同步。
         dismissChoicePromptIfMatches(sessionId);
-        // accept outcome 兼当 launch 信号 window.open；dedupe 由 launched session
-        // 集合保护，按钮 endpoint 路径同步推 WS 时不会双开（前者已在 launch set
-        // 注册）。
+        // launch path（仅 keyword 触发会带 game_url，button path backend 已不推
+        // game_url）：多窗口 Electron 模式下 backend 通过 RAW_MESSAGE IPC 把
+        // event 转给所有 page (pet + chat.html mirrors)，每个 page 都执行此函数。
+        // 不分 ownership 直接 window.open 会让所有 page 各自开一个 game 窗口
+        // （codex P2 指出，per-page _launchedMiniGameSessionIds 跨 page 不 dedupe）。
+        // 约定：only **non-follower** owner page (pet / 单窗口) 处理 WS-trigger
+        // launch；chat.html follower (window.__NEKO_MULTI_WINDOW__ === true) 仅
+        // dismiss UI。Button path 不走这条 WS launch（HTTP 响应里 chat.html 自己
+        // launch），所以不会双开。
         if (payload.action === 'open_game' && payload.url) {
+            if (window.__NEKO_MULTI_WINDOW__) {
+                return;  // chat.html follower：let pet leader 处理 launch
+            }
             launchMiniGameInternal({
                 sessionId: sessionId,
                 gameType: String(payload.gameType || ''),

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1679,6 +1679,13 @@
         state.messages = [];
         _sortKeySeq = 0;
         invalidatePendingGalgameRequest();
+        // 角色切换 / cloud reload 等触发 clearMessages 的路径也必须清掉 mini-game
+        // invite prompt——否则旧角色的按钮残留在新 context 里，用户点了 endpoint
+        // 会按新 lanlan_name 查旧 session_id 直接 expired。dedupe set 也清，防止
+        // 上一会话的 launched 标记错误地阻断新会话同 session_id 的 launch（虽然
+        // session_id 是 uuid 实际撞概率几乎 0，对偶清理更干净）。codex P2 指出。
+        state.choicePrompt = null;
+        state._launchedMiniGameSessionIds = Object.create(null);
         renderWindow();
     }
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1386,7 +1386,10 @@
         var prompt = state.choicePrompt;
         if (!prompt || prompt.source !== 'mini_game_invite') return;
         var sessionId = prompt.sessionId || '';
-        // 立刻清掉 prompt 让按钮消失，防止用户连点 / 等 endpoint 慢响应时重复触发
+        // 暂存原 prompt 用于失败回滚——网络异常时让用户能再点一次（CodeRabbit
+        // Major 指出原版 fetch fail 仅 console.warn，用户看着空 UI 不知道发生
+        // 啥）。立即清 prompt 防连点；fail catch 里恢复。
+        var rollbackPrompt = prompt;
         state.choicePrompt = null;
         renderWindow();
 
@@ -1439,12 +1442,21 @@
             // accept 路径直接 window.open；dedupe 让后续 ws push 同 session 不重开
             launchMiniGameInternal({
                 sessionId: sessionId,
-                gameType: data.game_type || prompt.gameType || '',
+                gameType: data.game_type || rollbackPrompt.gameType || '',
                 url: data.game_url,
                 source: 'button'
             });
         }).catch(function (err) {
             console.warn('[MiniGameInvite] respond endpoint failed:', err);
+            // 网络/服务异常 → 回滚 prompt 让用户能再试。但只在当前 prompt 仍是
+            // null（即用户没在 fetch 期间触发新 prompt）且会话仍未被 launch 过的
+            // 情况下回滚——否则强复活旧 UI 可能撞新邀请。
+            if (state.choicePrompt === null
+                    && sessionId
+                    && !state._launchedMiniGameSessionIds[sessionId]) {
+                state.choicePrompt = rollbackPrompt;
+                renderWindow();
+            }
         });
     }
 
@@ -1455,27 +1467,63 @@
         // 已经为该 session 开过游戏了 → 忽略 stale options（罕见：邀请 push 比
         // 用户键盘/按钮路径慢，但为了对偶仍 guard 一下）
         if (state._launchedMiniGameSessionIds[sessionId]) return;
-        var options = Array.isArray(payload.options) ? payload.options : [];
-        if (!options.length) return;
+        var rawOptions = Array.isArray(payload.options) ? payload.options : [];
+        if (!rawOptions.length) return;
+        // map → filter，再 recheck 长度——后端数据异常导致全部 filter 掉时不
+        // 渲染空按钮 prompt（CodeRabbit Minor 指出原版只检 raw 长度漏了这条）。
+        var cleanedOptions = rawOptions.map(function (o) {
+            return {
+                choice: String((o && o.choice) || ''),
+                label: String((o && o.label) || '')
+            };
+        }).filter(function (o) { return o.choice && o.label; });
+        if (!cleanedOptions.length) {
+            console.warn('[MiniGameInvite] all options filtered out, skipping render', payload);
+            return;
+        }
         state.choicePrompt = {
             source: 'mini_game_invite',
             sessionId: sessionId,
             gameType: String(payload.gameType || ''),
-            options: options.map(function (o) {
-                return {
-                    choice: String(o.choice || ''),
-                    label: String(o.label || '')
-                };
-            }).filter(function (o) { return o.choice && o.label; })
+            options: cleanedOptions
         };
         renderWindow();
+    }
+
+    function dismissChoicePromptIfMatches(sessionId) {
+        if (!sessionId) return;
+        if (state.choicePrompt
+                && state.choicePrompt.source === 'mini_game_invite'
+                && state.choicePrompt.sessionId === sessionId) {
+            state.choicePrompt = null;
+            renderWindow();
+        }
+    }
+
+    function handleMiniGameInviteResolved(payload) {
+        if (!payload) return;
+        var sessionId = String(payload.sessionId || '');
+        // 任一 outcome（open_game / cooldown / suppress）都 dismiss 当前 prompt——
+        // 跨窗口一致性。即便本 page 不是触发方，也保持 UI 同步。
+        dismissChoicePromptIfMatches(sessionId);
+        // accept outcome 兼当 launch 信号 window.open；dedupe 由 launched session
+        // 集合保护，按钮 endpoint 路径同步推 WS 时不会双开（前者已在 launch set
+        // 注册）。
+        if (payload.action === 'open_game' && payload.url) {
+            launchMiniGameInternal({
+                sessionId: sessionId,
+                gameType: String(payload.gameType || ''),
+                url: payload.url,
+                source: 'ws'
+            });
+        }
     }
 
     function launchMiniGameInternal(payload) {
         if (!payload || !payload.url) return;
         var sessionId = String(payload.sessionId || '');
-        // 同一 session 只 open 一次：endpoint 路径先 open 后，可能 backend 又 push
-        // mini_game_launch（keyword fallback 同时命中等情形）；不 dedupe 会双开窗口。
+        // 同一 session 只 open 一次：按钮 endpoint 直接 open 后，backend 还会 push
+        // mini_game_invite_resolved（cross-window 一致性广播）；不 dedupe 会双开。
         if (sessionId && state._launchedMiniGameSessionIds[sessionId]) return;
         if (sessionId) state._launchedMiniGameSessionIds[sessionId] = true;
         // window.open 在 Electron 模式下被主进程 setWindowOpenHandler 拦截开独立
@@ -2621,7 +2669,11 @@
         refreshGalgameOptions: fetchGalgameOptionsForLatestTurn,
         // Mini-game invite ChoicePrompt：app-websocket.js 收到对应 WS message 时调
         setMiniGameInvitePrompt: setMiniGameInvitePrompt,
-        launchMiniGame: launchMiniGameInternal,
+        // unified resolved handler：accept 兼 launch / decline / suppress 都通过
+        // 这条入口分发——前端 dismiss prompt UI + accept 时 window.open。替代了
+        // 旧 launchMiniGame（accept-only）路径，让 codex P2 的 cross-window
+        // dismiss 一致性能 cover decline / later 路径。
+        handleMiniGameInviteResolved: handleMiniGameInviteResolved,
         isMounted: function () { return mounted; }
     };
 })();

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1409,6 +1409,34 @@
             choice: option.choice,
             session_id: sessionId
         };
+
+        // accept 路径预开 popup（**仍在用户点击的同步上下文**）保留 user-gesture
+        // 上下文。后续 fetch resolve 后再 window.open 会被浏览器 popup blocker
+        // 识别为非手势触发拦截——pre-open 后 .location.href 注入 URL 不会被拦
+        // （codex P2 指出原版 fetch 后 window.open 失败时 state 已 responded
+        // 用户失去重试入口）。decline / later 路径不开窗口，无此处理。
+        var preOpenedWindow = null;
+        if (option.choice === 'accept') {
+            try {
+                preOpenedWindow = window.open('', '_blank');
+                if (preOpenedWindow) {
+                    // 给个临时占位文本免得用户看到 about:blank 一闪
+                    try {
+                        preOpenedWindow.document.write(
+                            '<title>Loading…</title><body style="background:#111;color:#888;font:14px sans-serif;padding:20px">Loading mini-game…</body>'
+                        );
+                    } catch (_) {}
+                }
+            } catch (_) {
+                preOpenedWindow = null;
+            }
+        }
+        var closePreOpened = function () {
+            if (preOpenedWindow && !preOpenedWindow.closed) {
+                try { preOpenedWindow.close(); } catch (_) {}
+            }
+        };
+
         // 必须带 CSRF token：后端 endpoint 用 _validate_local_mutation_request
         // 拒绝缺 token 的请求，否则所有合法点击都会被 403 reject、prompt 已清掉
         // 但 invite state 没更新 —— codex P1 指出。沿用 nekoLocalMutationSecurity
@@ -1444,8 +1472,28 @@
         }).then(function (resp) {
             return resp.ok ? resp.json() : Promise.reject(new Error('HTTP ' + resp.status));
         }).then(function (data) {
-            if (!data || data.action !== 'open_game' || !data.game_url) return;
-            // accept 路径直接 window.open；dedupe 让后续 ws push 同 session 不重开
+            if (!data || data.action !== 'open_game' || !data.game_url) {
+                // 非 accept outcome（cooldown / suppress / expired）→ 关掉占位 popup
+                closePreOpened();
+                return;
+            }
+            // accept：优先注入 URL 进 pre-opened popup（保留用户手势上下文，
+            // 浏览器 popup blocker 不拦）；pre-open 失败时 fallback 调
+            // launchMiniGameInternal（可能被拦但留个 console.warn 兜底）。
+            if (preOpenedWindow && !preOpenedWindow.closed) {
+                try {
+                    preOpenedWindow.location.href = data.game_url;
+                    if (sessionId) {
+                        state._launchedMiniGameSessionIds[sessionId] = true;
+                    }
+                    return;
+                } catch (err) {
+                    console.warn('[MiniGameInvite] pre-opened window navigation failed:', err);
+                    closePreOpened();
+                }
+            }
+            // pre-open 失败 fallback：直接 window.open（有被 popup blocker 拦
+            // 的风险，但 accept-path-via-pre-open 已是主路径，到此处罕见）。
             launchMiniGameInternal({
                 sessionId: sessionId,
                 gameType: data.game_type || rollbackPrompt.gameType || '',
@@ -1454,6 +1502,7 @@
             });
         }).catch(function (err) {
             console.warn('[MiniGameInvite] respond endpoint failed:', err);
+            closePreOpened();
             // 网络/服务异常 → 回滚 prompt 让用户能再试。但只在当前 prompt 仍是
             // null（即用户没在 fetch 期间触发新 prompt）且会话仍未被 launch 过的
             // 情况下回滚——否则强复活旧 UI 可能撞新邀请。

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -52,7 +52,14 @@
         galgameOptions: [],
         galgameOptionsLoading: false,
         galgameTemporarilyDisabled: false,
-        _galgameRequestSeq: 0
+        _galgameRequestSeq: 0,
+        // 通用 ChoicePrompt 框架（PR #1141 follow-up #2）。当前承载 mini_game_invite
+        // 三选项；galgame mode 仍走 galgameOptions 路径（BC，渐进迁移）。
+        // shape: { source: 'mini_game_invite', sessionId, gameType, options: [{choice,label}] } | null
+        choicePrompt: null,
+        // dedupe set：已经 window.open 过的 mini-game session_id。键集，行为按 set 用。
+        // 防止 endpoint 路径 + WS push 路径同一 session 双开窗口。
+        _launchedMiniGameSessionIds: Object.create(null)
     };
 
     function readGalgameModePreference() {
@@ -524,6 +531,7 @@
             galgameModeEnabled: !!state.galgameModeEnabled,
             galgameOptions: Array.isArray(state.galgameOptions) ? state.galgameOptions : [],
             galgameOptionsLoading: !!state.galgameOptionsLoading,
+            choicePrompt: state.choicePrompt || null,
             onMessageAction: handleMessageAction,
             onComposerImportImage: handleComposerImportImage,
             onComposerScreenshot: handleComposerScreenshot,
@@ -535,7 +543,8 @@
             onAvatarGeneratorClick: handleAvatarGeneratorClick,
             onTranslateToggle: handleTranslateToggle,
             onGalgameModeToggle: handleGalgameModeToggle,
-            onGalgameOptionSelect: handleGalgameOptionSelect
+            onGalgameOptionSelect: handleGalgameOptionSelect,
+            onChoiceSelect: handleChoiceSelect
         });
     }
 
@@ -1351,6 +1360,106 @@
         };
         handleComposerSubmit(detail);
         dispatchHostEvent('galgame-option-select', detail);
+    }
+
+    // ---- 通用 ChoicePrompt：mini-game invite 三选项 ----
+    // React 组件 onChoice 回调把 option + source 一起传上来。source==='galgame'
+    // 走旧路径（dummy fallback，正常不会到这里——galgame 仍然走 onGalgameOptionSelect
+    // 直接 callback；这里只是 BC 兜底）；source==='mini_game_invite' 走新逻辑。
+
+    function handleChoiceSelect(option, source) {
+        if (!option || typeof option.choice !== 'string') return;
+        if (source === 'galgame') {
+            // Forward to legacy galgame handler if it shows up here
+            if (typeof option.text === 'string') {
+                handleGalgameOptionSelect(option);
+            }
+            return;
+        }
+        if (source === 'mini_game_invite') {
+            handleMiniGameInviteChoice(option);
+            return;
+        }
+    }
+
+    function handleMiniGameInviteChoice(option) {
+        var prompt = state.choicePrompt;
+        if (!prompt || prompt.source !== 'mini_game_invite') return;
+        var sessionId = prompt.sessionId || '';
+        // 立刻清掉 prompt 让按钮消失，防止用户连点 / 等 endpoint 慢响应时重复触发
+        state.choicePrompt = null;
+        renderWindow();
+
+        var lanlanName = '';
+        try {
+            lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+        } catch (_) {}
+
+        var requestBody = {
+            lanlan_name: lanlanName,
+            choice: option.choice,
+            session_id: sessionId
+        };
+        fetch('/api/mini_game/invite/respond', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody)
+        }).then(function (resp) {
+            return resp.ok ? resp.json() : Promise.reject(new Error('HTTP ' + resp.status));
+        }).then(function (data) {
+            if (!data || data.action !== 'open_game' || !data.game_url) return;
+            // accept 路径直接 window.open；dedupe 让后续 ws push 同 session 不重开
+            launchMiniGameInternal({
+                sessionId: sessionId,
+                gameType: data.game_type || prompt.gameType || '',
+                url: data.game_url,
+                source: 'button'
+            });
+        }).catch(function (err) {
+            console.warn('[MiniGameInvite] respond endpoint failed:', err);
+        });
+    }
+
+    function setMiniGameInvitePrompt(payload) {
+        if (!payload) return;
+        var sessionId = String(payload.sessionId || '');
+        if (!sessionId) return;
+        // 已经为该 session 开过游戏了 → 忽略 stale options（罕见：邀请 push 比
+        // 用户键盘/按钮路径慢，但为了对偶仍 guard 一下）
+        if (state._launchedMiniGameSessionIds[sessionId]) return;
+        var options = Array.isArray(payload.options) ? payload.options : [];
+        if (!options.length) return;
+        state.choicePrompt = {
+            source: 'mini_game_invite',
+            sessionId: sessionId,
+            gameType: String(payload.gameType || ''),
+            options: options.map(function (o) {
+                return {
+                    choice: String(o.choice || ''),
+                    label: String(o.label || '')
+                };
+            }).filter(function (o) { return o.choice && o.label; })
+        };
+        renderWindow();
+    }
+
+    function launchMiniGameInternal(payload) {
+        if (!payload || !payload.url) return;
+        var sessionId = String(payload.sessionId || '');
+        // 同一 session 只 open 一次：endpoint 路径先 open 后，可能 backend 又 push
+        // mini_game_launch（keyword fallback 同时命中等情形）；不 dedupe 会双开窗口。
+        if (sessionId && state._launchedMiniGameSessionIds[sessionId]) return;
+        if (sessionId) state._launchedMiniGameSessionIds[sessionId] = true;
+        // window.open 在 Electron 模式下被主进程 setWindowOpenHandler 拦截开独立
+        // BrowserWindow；普通浏览器是新 tab。'_blank' target 让浏览器治理一致。
+        try {
+            var w = window.open(payload.url, '_blank');
+            if (!w) {
+                console.warn('[MiniGameInvite] window.open returned null (popup blocked?)');
+            }
+        } catch (err) {
+            console.warn('[MiniGameInvite] window.open failed:', err);
+        }
     }
 
     function setViewProps(nextViewProps) {
@@ -2482,6 +2591,9 @@
         },
         isGalgameModeEnabled: function () { return !!state.galgameModeEnabled; },
         refreshGalgameOptions: fetchGalgameOptionsForLatestTurn,
+        // Mini-game invite ChoicePrompt：app-websocket.js 收到对应 WS message 时调
+        setMiniGameInvitePrompt: setMiniGameInvitePrompt,
+        launchMiniGame: launchMiniGameInternal,
         isMounted: function () { return mounted; }
     };
 })();

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1395,7 +1395,13 @@
 
         var lanlanName = '';
         try {
-            lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+            // 优先读 window.appState.lanlan_name —— 角色切换时 appState 先更新，
+            // window.lanlan_config 可能滞后；用旧 lanlan_name 调 endpoint 会被
+            // 后端按错误角色查 pending invite 直接 expired。同 GalGame 请求路径
+            // 保持一致（CodeRabbit Major 指出）。
+            lanlanName = (window.appState && window.appState.lanlan_name)
+                || (window.lanlan_config && window.lanlan_config.lanlan_name)
+                || '';
         } catch (_) {}
 
         var requestBody = {
@@ -1525,16 +1531,24 @@
         // 同一 session 只 open 一次：按钮 endpoint 直接 open 后，backend 还会 push
         // mini_game_invite_resolved（cross-window 一致性广播）；不 dedupe 会双开。
         if (sessionId && state._launchedMiniGameSessionIds[sessionId]) return;
-        if (sessionId) state._launchedMiniGameSessionIds[sessionId] = true;
         // window.open 在 Electron 模式下被主进程 setWindowOpenHandler 拦截开独立
         // BrowserWindow；普通浏览器是新 tab。'_blank' target 让浏览器治理一致。
+        // dedupe flag 只在成功后设——popup blocker / throw 时让用户能再触发一次
+        // (codex P2 + CodeRabbit Major 指出原版 set-before-open 会让失败的 session
+        // 永远被 dedupe 锁死，prompt 已清掉用户彻底失去入口)。
+        var opened = false;
         try {
             var w = window.open(payload.url, '_blank');
             if (!w) {
                 console.warn('[MiniGameInvite] window.open returned null (popup blocked?)');
+            } else {
+                opened = true;
             }
         } catch (err) {
             console.warn('[MiniGameInvite] window.open failed:', err);
+        }
+        if (opened && sessionId) {
+            state._launchedMiniGameSessionIds[sessionId] = true;
         }
     }
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1914,20 +1914,21 @@
                         });
                     }
 
-                // -------- mini_game_launch --------
-                // 关键词文本兜底（用户没点按钮自己打字"好啊"）命中 accept 时由
-                // 后端 push。任何 page 收到都尝试 window.open(game_url)——主进程
-                // setWindowOpenHandler 拦截开独立 BrowserWindow（普通浏览器是新
-                // tab）。dedupe 由 launched session_id 保护：同一 session 再来一条
-                // 不重复 open；按钮路径 endpoint 直接 open 后也注册到 launched 集合。
-                } else if (response.type === 'mini_game_launch') {
+                // -------- mini_game_invite_resolved --------
+                // 邀请被 resolve（任一 outcome：accept / cooldown / suppress）→
+                // 前端 dismiss prompt UI（cross-window 一致性，pet + chat.html
+                // 多窗口同时显示 prompt 时全部清掉）。accept 时 payload 同时带
+                // game_url 当 launch 信号——前端 window.open 让 Electron 主进程
+                // setWindowOpenHandler 拦截开独立 BrowserWindow，dedupe 由
+                // launched session_id 保护防止双开。
+                } else if (response.type === 'mini_game_invite_resolved') {
                     if (window.reactChatWindowHost
-                            && typeof window.reactChatWindowHost.launchMiniGame === 'function') {
-                        window.reactChatWindowHost.launchMiniGame({
+                            && typeof window.reactChatWindowHost.handleMiniGameInviteResolved === 'function') {
+                        window.reactChatWindowHost.handleMiniGameInviteResolved({
                             sessionId: response.session_id || '',
+                            action: response.action || '',
                             gameType: response.game_type || '',
                             url: response.game_url || '',
-                            source: response.source || 'ws',
                         });
                     }
                 }

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1898,6 +1898,38 @@
                         ? window.t('app.repetitionDetected', { name: response.name })
                         : ('检测到高重复度对话。建议您终止对话，让' + response.name + '休息片刻。');
                     if (typeof window.showStatusToast === 'function') window.showStatusToast(warningMessage, 8000);
+
+                // -------- mini_game_invite_options --------
+                // 后端投递 mini-game 邀请时跟 invite text 一起 push 这条 options。
+                // 通用 ChoicePrompt 抽象，前端 ChoiceWindow 渲染三按钮（accept /
+                // decline / later）。多窗口模式下消息走 RAW_MESSAGE forwarding 自然
+                // 转给 chat.html，无需新 IPC channel。
+                } else if (response.type === 'mini_game_invite_options') {
+                    if (window.reactChatWindowHost
+                            && typeof window.reactChatWindowHost.setMiniGameInvitePrompt === 'function') {
+                        window.reactChatWindowHost.setMiniGameInvitePrompt({
+                            sessionId: response.session_id || '',
+                            gameType: response.game_type || '',
+                            options: Array.isArray(response.options) ? response.options : [],
+                        });
+                    }
+
+                // -------- mini_game_launch --------
+                // 关键词文本兜底（用户没点按钮自己打字"好啊"）命中 accept 时由
+                // 后端 push。任何 page 收到都尝试 window.open(game_url)——主进程
+                // setWindowOpenHandler 拦截开独立 BrowserWindow（普通浏览器是新
+                // tab）。dedupe 由 launched session_id 保护：同一 session 再来一条
+                // 不重复 open；按钮路径 endpoint 直接 open 后也注册到 launched 集合。
+                } else if (response.type === 'mini_game_launch') {
+                    if (window.reactChatWindowHost
+                            && typeof window.reactChatWindowHost.launchMiniGame === 'function') {
+                        window.reactChatWindowHost.launchMiniGame({
+                            sessionId: response.session_id || '',
+                            gameType: response.game_type || '',
+                            url: response.game_url || '',
+                            source: response.source || 'ws',
+                        });
+                    }
                 }
 
             } catch (parseError) {

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -743,6 +743,10 @@
     <script src="/static/subtitle.js?v={{ static_asset_version }}"></script>
 
     <!-- React Chat（与 index.html 相同的 bundle + 初始化器）-->
+    <!-- Local-mutation CSRF helper：mini-game invite respond endpoint 等本地
+         mutation 共用 window.nekoLocalMutationSecurity 拿 X-CSRF-Token；必须
+         在 app-react-chat-window.js 之前加载，与 index.html 同序。 -->
+    <script src="/static/app-prompt-shared.js?v={{ static_asset_version }}"></script>
     <script src="/static/react/neko-chat/neko-chat-window.iife.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-react-chat-window.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-chat-adapter.js?v={{ static_asset_version }}"></script>

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -9,11 +9,27 @@
 
 <!-- Mock 桌宠运行环境（必要最小子集，避免各 init 脚本崩溃） -->
 <script>
-  window.lanlan_config = window.lanlan_config || {
-    lanlan_name: 'soccer_demo',
-    master_name: '', master_profile_name: '', master_nickname: '', master_display_name: '',
-    model_type: 'vrm', live3d_sub_type: 'vrm'
-  };
+  // mini-game 邀请被接受后由 chat.html / Pet 主聊天 window.open 打开本页面，
+  // URL 形如 `/soccer_demo?lanlan_name=<active_character>&session_id=<invite_uuid>`。
+  // 提前从 query 解出来，覆盖默认 'soccer_demo' 值，避免后端 game route 用错角色。
+  // 直接手敲 /soccer_demo 进来时 query 缺失，沿用旧默认（route_start 内部会调
+  // /api/game/soccer/character 解出当前角色作为兜底，PR #1110 已实现）。
+  (function () {
+    var params = null;
+    try { params = new URLSearchParams(window.location.search); } catch (_) { params = null; }
+    var queryLanlan = (params && params.get('lanlan_name')) || '';
+    var queryInviteSession = (params && params.get('session_id')) || '';
+    window.lanlan_config = window.lanlan_config || {
+      lanlan_name: queryLanlan || 'soccer_demo',
+      master_name: '', master_profile_name: '', master_nickname: '', master_display_name: '',
+      model_type: 'vrm', live3d_sub_type: 'vrm'
+    };
+    if (queryLanlan && !window.lanlan_config.lanlan_name) {
+      window.lanlan_config.lanlan_name = queryLanlan;
+    }
+    // 留个全局让游戏内逻辑可见 invite 来源（例如赛后归档时打个 tag）
+    window.__nekoMiniGameInviteSessionId = queryInviteSession || '';
+  })();
   window.LanLan1 = window.LanLan1 || {};
   // 注意：mouseTrackingEnabled 要 true，不然 VRM 的眼/头 cursor-follow 不会跟鼠标
   window.mouseTrackingEnabled = true;

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -771,8 +771,12 @@
   const _i18n = (key, fallback, params) => {
     if (typeof window.t === 'function') return window.t(`soccer.${key}`, params || {});
     if (!params) return fallback;
+    // 替换模式必须避开 Jinja2 模板里的双花括号字面量——本文件顶部有 Jinja
+    // 渲染（VRM_DEFAULT_LIGHTING），整份模板会过 Jinja parser；下面 replaceAll
+    // 的源串若写成模板字面量的 dollar 引用形式会被 Jinja 当表达式 SyntaxError。
+    // 拆字符拼接绕开 parser，运行期 JS 仍得到 [open][open]KEY[close][close]。
     return Object.entries(params).reduce(
-      (s, [k, v]) => s.replaceAll(`{{${k}}}`, String(v)),
+      (s, [k, v]) => s.replaceAll('{' + '{' + k + '}' + '}', String(v)),
       fallback,
     );
   };

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -948,6 +948,26 @@ def test_keyword_matcher_no_false_positive_on_chong_substring():
     assert sr._match_mini_game_invite_keyword('来吧') == 'accept'
 
 
+def test_keyword_matcher_no_false_positive_on_keyi_negation():
+    """codex P2 回归保护：'可以' 已从 zh accept 删除（"不可以" 含 substring
+    '可以'，decline 没 '不可以' 时 priority 救不了）。同时 '不可以' 加进 decline
+    list 双保险——以防未来误把 '可以' 加回 accept。"""
+    # "不可以" 必须命中 decline，绝不能 accept
+    assert sr._match_mini_game_invite_keyword('不可以') == 'decline'
+    assert sr._match_mini_game_invite_keyword('不可以的') == 'decline'
+    # 单独 "可以" 不再命中（用户表达接受意图请改用 '好啊'/'行啊'/'来吧' 等）
+    assert sr._match_mini_game_invite_keyword('可以') is None
+
+
+def test_keyword_matcher_no_false_positive_on_korean_eung():
+    """codex P2 回归保护：单字 '응' 已从 ko accept 删除——"적응" / "반응" /
+    "응답" 等含 '응' 子串的常规韩语词不应命中 accept。"""
+    assert sr._match_mini_game_invite_keyword('적응 중이야') is None
+    assert sr._match_mini_game_invite_keyword('반응이 좋네') is None
+    # 双字 phrase '좋아' 仍命中
+    assert sr._match_mini_game_invite_keyword('좋아') == 'accept'
+
+
 def test_keyword_matcher_accept_does_not_match_negation():
     """关键词列表配合 priority 双保险：'不好'/'我不行' 不能被 accept 误命中。
     accept 现在用「好啊/好的/行啊」短语，'不好' 不含 substring '好啊'；同时

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -979,14 +979,23 @@ def test_keyword_matcher_priority_decline_over_later_over_accept():
     assert sr._match_mini_game_invite_keyword('不行吧，但可以下次') == 'decline'
 
 
-def test_keyword_matcher_no_false_positive_on_long_text():
-    """普通对话不应误命中：「好天气啊」按字面匹配会命中 '好'，是预期 — 关键词
-    匹配是兜底机制，spec 接受"模糊"匹配换取实现简单。但本测试 pin 住一些
-    明确不应命中的样例（确保关键词列表不包含太宽的字符）。"""
-    # '我现在没空'（含'不'？没；含'算了'？没；含'不想'？没；含'不要'？没）
-    # 但'我' '在' '空' 都不在任何 keyword list 里
-    assert sr._match_mini_game_invite_keyword('我现在没空') is None or \
-        sr._match_mini_game_invite_keyword('我现在没空') == 'decline'  # '没空' 在 decline
+def test_keyword_matcher_decline_via_phrase():
+    """「我现在没空」通过 '没空' phrase 命中 decline——pin 住关键词契约，
+    防止 '没空' 被从列表里误删（CodeRabbit Minor 指出原版 'None or decline'
+    断言放松过头，把"误命中回归"也放过去了）。"""
+    result = sr._match_mini_game_invite_keyword('我现在没空')
+    assert result == 'decline'
+
+
+def test_keyword_matcher_no_false_positive_on_common_english_phrases():
+    """codex P1 + CodeRabbit Major：英文 'no' 已从 decline 列表删除——
+    "I have no idea" / "no worries" / "know" 这些常规英文不应命中 decline。
+    pending invite 期间用户随口说这些不该启动 1h 长冷却。"""
+    assert sr._match_mini_game_invite_keyword('i have no idea') is None
+    assert sr._match_mini_game_invite_keyword('no worries') is None
+    assert sr._match_mini_game_invite_keyword('i know what you mean') is None
+    # 'no thanks' 是明确拒绝 phrase，应仍命中
+    assert sr._match_mini_game_invite_keyword('no thanks') == 'decline'
 
 
 def test_maybe_apply_keyword_noop_when_no_pending():

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -980,10 +980,21 @@ def test_keyword_matcher_accept_does_not_match_negation():
 
 def test_keyword_matcher_accept_en():
     assert sr._match_mini_game_invite_keyword('yes please') == 'accept'
-    assert sr._match_mini_game_invite_keyword("Let's go!") == 'accept'
-    # 'okay' 已从 accept 删（codex P2：'not okay' substring 命中）；用户表达
-    # 接受改用 yes / sure / let's / yeah / yep 等仍在 list 内的 phrase。
+    # "let's go!" 不再命中（"let's" 单字已改成 "let's play"，"go" 不在 list）；
+    # "let's play" / "i'll play" 等 phrase 才命中——CodeRabbit Major 指出后收紧。
+    assert sr._match_mini_game_invite_keyword("let's play this") == 'accept'
     assert sr._match_mini_game_invite_keyword('Yeah!') == 'accept'
+    assert sr._match_mini_game_invite_keyword('i wanna play') == 'accept'
+
+
+def test_keyword_matcher_decline_negated_let_and_wanna():
+    """CodeRabbit Major：accept "let's play" / "wanna play" 仍可能被否定句
+    "let's not play" / "I don't wanna play" 包含 substring 命中——decline list
+    必须加 "let's not" + "don't wanna" 进 priority 兜底。"""
+    assert sr._match_mini_game_invite_keyword("let's not play") == 'decline'
+    assert sr._match_mini_game_invite_keyword("I don't wanna play") == 'decline'
+    # 仍接受 positive phrase
+    assert sr._match_mini_game_invite_keyword("yeah let's play") == 'accept'
 
 
 def test_keyword_matcher_no_false_positive_on_negated_accept_phrases():

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -981,7 +981,24 @@ def test_keyword_matcher_accept_does_not_match_negation():
 def test_keyword_matcher_accept_en():
     assert sr._match_mini_game_invite_keyword('yes please') == 'accept'
     assert sr._match_mini_game_invite_keyword("Let's go!") == 'accept'
-    assert sr._match_mini_game_invite_keyword('OKAY') == 'accept'
+    # 'okay' 已从 accept 删（codex P2：'not okay' substring 命中）；用户表达
+    # 接受改用 yes / sure / let's / yeah / yep 等仍在 list 内的 phrase。
+    assert sr._match_mini_game_invite_keyword('Yeah!') == 'accept'
+
+
+def test_keyword_matcher_no_false_positive_on_negated_accept_phrases():
+    """codex P2：'okay' / 'sure' 等英文 accept word 即使 word-boundary 也会被
+    'not okay' / 'not sure' 整词命中——decline list 没列对应 negation phrase
+    时 priority 救不了。删 'okay' + 加 'not okay' / 'not sure' / 'not yet'
+    进 decline 双保险。"""
+    # 'okay' 已删，独立验证："not okay" / "okay" / "okay let's go" 行为
+    assert sr._match_mini_game_invite_keyword('not okay') == 'decline'
+    assert sr._match_mini_game_invite_keyword('okay') is None  # accept 已删
+    # 'sure' 仍在 accept，但 'not sure' 现在在 decline，priority 兜底
+    assert sr._match_mini_game_invite_keyword("i'm not sure") == 'decline'
+    assert sr._match_mini_game_invite_keyword('sure thing') == 'accept'
+    # 'not yet' 进 decline，cover "i'm not yet ready" 等
+    assert sr._match_mini_game_invite_keyword("not yet") == 'decline'
 
 
 def test_keyword_matcher_decline_zh():

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -938,6 +938,16 @@ def test_keyword_matcher_accept_zh():
     assert sr._match_mini_game_invite_keyword('一起玩吧') == 'accept'
 
 
+def test_keyword_matcher_no_false_positive_on_chong_substring():
+    """codex P2 回归保护：单字 '冲' 已从 zh accept 删除——
+    "我去冲个澡" / "冲咖啡" 等普通对话不应命中 accept（CJK 走 substring 没
+    word boundary 兜底）。"""
+    assert sr._match_mini_game_invite_keyword('我去冲个澡') is None
+    assert sr._match_mini_game_invite_keyword('在冲咖啡') is None
+    # 但完整 phrase 「来吧」仍命中 accept
+    assert sr._match_mini_game_invite_keyword('来吧') == 'accept'
+
+
 def test_keyword_matcher_accept_does_not_match_negation():
     """关键词列表配合 priority 双保险：'不好'/'我不行' 不能被 accept 误命中。
     accept 现在用「好啊/好的/行啊」短语，'不好' 不含 substring '好啊'；同时

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -123,7 +123,7 @@ def test_in_cooldown_false_when_never_delivered():
 
 def test_in_cooldown_true_when_pending():
     """投递了但还没被回应（pending）→ cooldown 锁住，避免又发一次。"""
-    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_record_delivered(LANLAN, "test-session-id")
     assert sr._mini_game_invite_in_cooldown(LANLAN) is True
 
 
@@ -188,7 +188,7 @@ def test_advance_response_noop_when_already_responded():
 
 def test_advance_response_noop_when_last_user_msg_at_none():
     """caller 没拿到 last_user_msg_at（隐私模式 / tracker 没数据）→ 保留 pending。"""
-    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_record_delivered(LANLAN, "test-session-id")
     sr._mini_game_invite_advance_response(LANLAN, None)
     assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
 
@@ -273,7 +273,7 @@ def test_count_noop_when_never_delivered():
 
 def test_count_noop_during_pending():
     """投递了但没回应（pending）→ counter 不推进，不能靠"邀请自身"耗掉 10 次。"""
-    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_record_delivered(LANLAN, "test-session-id")
     sr._mini_game_invite_count_post_response_chat(LANLAN)
     sr._mini_game_invite_count_post_response_chat(LANLAN)
     assert sr._mini_game_invite_state[LANLAN]['chats_since_response'] == 0
@@ -365,7 +365,7 @@ async def test_maybe_deliver_returns_none_when_unfinished_thread_pending(monkeyp
 async def test_maybe_deliver_returns_none_when_in_cooldown(monkeypatch):
     """pending 期间一律抑制掷骰。"""
     monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
-    sr._mini_game_invite_record_delivered(LANLAN)
+    sr._mini_game_invite_record_delivered(LANLAN, "test-session-id")
     out = await sr._maybe_deliver_mini_game_invite(
         lanlan_name=LANLAN, mgr=_make_mgr(),
         activity_snapshot=_make_snapshot(),
@@ -778,3 +778,285 @@ def test_new_user_force_at_is_4_by_default():
     """spec：「从未玩过的用户固定在开场第 4 次主动搭话邀请」。
     pin 住默认值，未来调整由 follow-up 显式翻。"""
     assert sr.MINI_GAME_INVITE_NEW_USER_FORCE_AT == 4
+
+
+def test_later_suppress_seconds_is_5min_by_default():
+    """spec D2：「回头再说」reset state 后 5min 内不再 roll。"""
+    assert sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS == 5 * 60
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D2 短期抑制（回头再说）
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_in_cooldown_true_when_suppressed_until_in_future():
+    """suppressed_until > now → cooldown 锁住，无论 delivered_at 状态。
+    这是 D2「回头再说」reset 后的窗口语义。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = None  # reset 已发生
+    state['responded_at'] = None
+    state['chats_since_response'] = 0
+    state['suppressed_until'] = time.time() + 60
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is True
+
+
+def test_in_cooldown_false_when_suppressed_until_past():
+    """suppressed_until <= now → 抑制窗口已过，cooldown 看 delivered_at。
+    delivered_at=None（reset 状态）→ 不在 cooldown，下一轮 proactive 重新掷骰。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = None
+    state['responded_at'] = None
+    state['chats_since_response'] = 0
+    state['suppressed_until'] = time.time() - 1
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
+
+
+def test_record_delivered_clears_suppressed_until():
+    """新一次邀请投递清掉旧的 D2 短期抑制窗口——既然又投了新邀请，
+    那个「回头再说」的等待窗口就过期了。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['suppressed_until'] = time.time() + 999
+    sr._mini_game_invite_record_delivered(LANLAN, "new-session")
+    assert state['suppressed_until'] is None
+
+
+def test_record_delivered_sets_pending_session_id():
+    """新一次投递必须刷新 pending_session_id，让旧 invite session 过期；
+    endpoint 收到旧 session_id 时返 expired。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['pending_session_id'] = 'old-session'
+    sr._mini_game_invite_record_delivered(LANLAN, 'new-session')
+    assert state['pending_session_id'] == 'new-session'
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _apply_mini_game_invite_choice (state machine)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_apply_choice_ignored_when_no_pending_invite():
+    """没 pending invite → 任何 choice 都返 ignored，不破坏 state。"""
+    result = sr._apply_mini_game_invite_choice(LANLAN, 'accept', source='test')
+    assert result['action'] == 'ignored'
+    assert result.get('reason') == 'no_pending_invite'
+
+
+def test_apply_choice_ignored_when_already_responded():
+    """已经 responded → 重复点击按钮被 ignored。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 60
+    state['responded_at'] = time.time() - 30
+    state['pending_session_id'] = 'sess'
+    result = sr._apply_mini_game_invite_choice(LANLAN, 'accept', source='test')
+    assert result['action'] == 'ignored'
+
+
+def test_apply_choice_accept_returns_open_game_with_url():
+    """accept → 返回 game_url（带 lanlan_name + session_id query），
+    state 翻成 responded（启动 1h+10 chats 冷却）。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['pending_session_id'] = 'sess-abc'
+    state['last_game_type'] = 'soccer'
+    result = sr._apply_mini_game_invite_choice(LANLAN, 'accept', source='button')
+    assert result['action'] == 'open_game'
+    assert result['game_type'] == 'soccer'
+    assert result['game_url'].startswith('/soccer_demo?')
+    assert 'lanlan_name=' + LANLAN in result['game_url']
+    assert 'session_id=sess-abc' in result['game_url']
+    # state 进 cooldown
+    assert state['responded_at'] is not None
+    assert state['chats_since_response'] == 0
+
+
+def test_apply_choice_decline_starts_cooldown_no_url():
+    """decline → mark responded（同样启动冷却），不开游戏。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['pending_session_id'] = 'sess'
+    result = sr._apply_mini_game_invite_choice(LANLAN, 'decline', source='button')
+    assert result['action'] == 'cooldown'
+    assert 'game_url' not in result
+    assert state['responded_at'] is not None
+
+
+def test_apply_choice_later_resets_state_with_suppression():
+    """later (D2) → 完全 reset delivered_at 等，但加 suppressed_until = now+5min。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['chats_since_response'] = 0
+    state['pending_session_id'] = 'sess'
+    before = time.time()
+    result = sr._apply_mini_game_invite_choice(LANLAN, 'later', source='button')
+    assert result['action'] == 'suppress'
+    assert state['delivered_at'] is None
+    assert state['responded_at'] is None
+    assert state['chats_since_response'] == 0
+    assert state['pending_session_id'] is None
+    assert state['suppressed_until'] is not None
+    suppress_window = state['suppressed_until'] - before
+    assert (
+        sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS - 5
+        <= suppress_window
+        <= sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS + 5
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 关键词匹配（E2 文本兜底）
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_keyword_matcher_returns_none_for_empty_text():
+    assert sr._match_mini_game_invite_keyword('') is None
+    assert sr._match_mini_game_invite_keyword('   ') is None
+    assert sr._match_mini_game_invite_keyword(None) is None
+
+
+def test_keyword_matcher_accept_zh():
+    assert sr._match_mini_game_invite_keyword('好啊') == 'accept'
+    assert sr._match_mini_game_invite_keyword('来！') == 'accept'
+    assert sr._match_mini_game_invite_keyword('一起玩吧') == 'accept'
+
+
+def test_keyword_matcher_accept_en():
+    assert sr._match_mini_game_invite_keyword('yes please') == 'accept'
+    assert sr._match_mini_game_invite_keyword("Let's go!") == 'accept'
+    assert sr._match_mini_game_invite_keyword('OKAY') == 'accept'
+
+
+def test_keyword_matcher_decline_zh():
+    assert sr._match_mini_game_invite_keyword('不要') == 'decline'
+    assert sr._match_mini_game_invite_keyword('算了吧') == 'decline'
+    assert sr._match_mini_game_invite_keyword('不想玩') == 'decline'
+
+
+def test_keyword_matcher_later_zh():
+    assert sr._match_mini_game_invite_keyword('回头说') == 'later'
+    assert sr._match_mini_game_invite_keyword('等会') == 'later'
+    assert sr._match_mini_game_invite_keyword('晚点吧') == 'later'
+
+
+def test_keyword_matcher_accept_priority_over_later():
+    """暧昧文本同时含 accept + later 关键词 → accept 优先（spec 偏向"用户表达
+    了正面意愿就当接受"）。"""
+    # "好" + "等下" 同时命中
+    result = sr._match_mini_game_invite_keyword('好的等下')
+    assert result == 'accept'
+
+
+def test_keyword_matcher_no_false_positive_on_long_text():
+    """普通对话不应误命中：「好天气啊」按字面匹配会命中 '好'，是预期 — 关键词
+    匹配是兜底机制，spec 接受"模糊"匹配换取实现简单。但本测试 pin 住一些
+    明确不应命中的样例（确保关键词列表不包含太宽的字符）。"""
+    # '我现在没空'（含'不'？没；含'算了'？没；含'不想'？没；含'不要'？没）
+    # 但'我' '在' '空' 都不在任何 keyword list 里
+    assert sr._match_mini_game_invite_keyword('我现在没空') is None or \
+        sr._match_mini_game_invite_keyword('我现在没空') == 'decline'  # '没空' 在 decline
+
+
+def test_maybe_apply_keyword_noop_when_no_pending():
+    """没 pending invite → keyword matcher hook 直接 None，不动 state。"""
+    result = sr._maybe_apply_mini_game_invite_keyword(LANLAN, '好啊')
+    assert result is None
+
+
+def test_maybe_apply_keyword_accept_returns_open_game():
+    """pending invite + accept 关键词 → 触发 state 转换，返回 open_game。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['pending_session_id'] = 'kw-sess'
+    state['last_game_type'] = 'soccer'
+    result = sr._maybe_apply_mini_game_invite_keyword(LANLAN, '好啊')
+    assert result is not None
+    assert result['action'] == 'open_game'
+    assert state['responded_at'] is not None  # mark responded
+
+
+def test_maybe_apply_keyword_decline_starts_cooldown():
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['pending_session_id'] = 'kw-sess'
+    result = sr._maybe_apply_mini_game_invite_keyword(LANLAN, '不要')
+    assert result is not None
+    assert result['action'] == 'cooldown'
+    assert state['responded_at'] is not None
+
+
+def test_maybe_apply_keyword_later_resets_state():
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['pending_session_id'] = 'kw-sess'
+    result = sr._maybe_apply_mini_game_invite_keyword(LANLAN, '回头再说')
+    assert result is not None
+    assert result['action'] == 'suppress'
+    assert state['delivered_at'] is None
+    assert state['suppressed_until'] is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 邀请投递推 WS message + session_id 流转
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_invite_delivery_pushes_options_via_websocket(monkeypatch):
+    """投递成功后必须 push 一条 mini_game_invite_options WS message 给前端，
+    带 options + session_id + game_type。前端 ChoicePrompt 渲染依赖这条。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    mgr = _make_mgr()
+    mgr.websocket = MagicMock()
+    mgr.websocket.send_json = AsyncMock()
+    # mock client_state 让 send_json 通过 connectivity 检查
+    fake_state = MagicMock()
+    fake_state.CONNECTED = fake_state
+    mgr.websocket.client_state = fake_state
+
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+    )
+    assert out is not None and out['action'] == 'chat'
+    mgr.websocket.send_json.assert_awaited_once()
+    payload = mgr.websocket.send_json.await_args.args[0]
+    assert payload['type'] == 'mini_game_invite_options'
+    assert payload['session_id'] == out['invite_session_id']
+    assert payload['game_type'] == 'soccer'
+    assert isinstance(payload['options'], list) and len(payload['options']) == 3
+    choices = [opt['choice'] for opt in payload['options']]
+    assert choices == ['accept', 'decline', 'later']
+    # state 同步存了 pending_session_id
+    state = sr._mini_game_invite_state[LANLAN]
+    assert state['pending_session_id'] == out['invite_session_id']
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# i18n 完整性
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_option_labels_cover_all_native_locales():
+    """5 个 native locale × 3 个 choice 必须有非空 label。"""
+    from config.prompts_proactive import MINI_GAME_INVITE_OPTION_LABELS
+    for lang in ('zh', 'en', 'ja', 'ko', 'ru'):
+        assert lang in MINI_GAME_INVITE_OPTION_LABELS, f"缺 {lang} option labels"
+        labels = MINI_GAME_INVITE_OPTION_LABELS[lang]
+        for choice in ('accept', 'decline', 'later'):
+            assert choice in labels, f"{lang} 缺 {choice} 标签"
+            assert labels[choice].strip(), f"{lang}/{choice} 标签空"
+
+
+def test_keywords_cover_all_native_locales():
+    """5 个 native locale × 3 个 choice 必须各有非空关键词列表。"""
+    from config.prompts_proactive import MINI_GAME_INVITE_KEYWORDS
+    for lang in ('zh', 'en', 'ja', 'ko', 'ru'):
+        assert lang in MINI_GAME_INVITE_KEYWORDS, f"缺 {lang} keywords"
+        kws = MINI_GAME_INVITE_KEYWORDS[lang]
+        for choice in ('accept', 'decline', 'later'):
+            assert choice in kws, f"{lang} 缺 {choice} 关键词"
+            assert isinstance(kws[choice], list) and kws[choice], (
+                f"{lang}/{choice} 关键词列表空"
+            )

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -193,15 +193,14 @@ def test_advance_response_noop_when_last_user_msg_at_none():
     assert sr._mini_game_invite_state[LANLAN]['responded_at'] is None
 
 
-def test_advance_response_flips_when_user_spoke_after_invite(monkeypatch):
-    """用户在 delivered_at 之后说过话 → 标记已回应、计数清零。
+def test_advance_response_dismisses_pending_invite_with_short_suppression(monkeypatch):
+    """用户在 delivered_at 之后发了任意普通消息（非显式 choice / 关键词命中）
+    → advance 把 prompt 静默 dismiss + 5min 短抑制，**不**启动长冷却。
 
-    `responded_at` 必须 anchor 到 *真实* 回应时间（last_user_msg_at），
-    而不是「检测到回应的此刻」。advance_response 只在下次 proactive_chat 才跑，
-    user 回完到下次 proactive 可能隔几小时；anchor 用 now 会让 24h 冷却被这段
-    间隔白白拉长。
-
-    冻结 sr.time.time —— 测试断言不依赖真实时钟、CI 拥塞下也确定。"""
+    历史：旧 PR #1141 时代「用户说话 = 隐式回应」直接 mark responded_at +
+    1h 长锁。CodeRabbit Major 指出会让"用户先发别的话再点按钮"被 endpoint
+    误判 expired 并已悄悄进入长冷却（违 D2 语义）。改成等同 'later' 选项的
+    reset+短抑制语义：保留 ever_delivered（force-first 不再 fire）但不长锁。"""
     fixed_now = 1_700_000_000.0
     monkeypatch.setattr(sr.time, 'time', lambda: fixed_now)
 
@@ -210,43 +209,57 @@ def test_advance_response_flips_when_user_spoke_after_invite(monkeypatch):
     state['delivered_at'] = delivered_at
     state['responded_at'] = None
     state['chats_since_response'] = 0
+    state['pending_session_id'] = 'pre-advance-sess'
 
     # 用户 5s 前说了话 → 落在 delivered_at 之后
     sr._mini_game_invite_advance_response(LANLAN, fixed_now - 5.0)
-    assert state['responded_at'] is not None
-    assert state['chats_since_response'] == 0
-    # Anchor 精确等于 last_user_msg_at = fixed_now - 5；冻结时钟下没有漂移，
-    # 不需要容差——直接精确断言，回归到 now（=fixed_now）会立刻挂。
-    assert state['responded_at'] == fixed_now - 5.0, (
-        f"responded_at={state['responded_at']:.3f} 应等于 last_user_msg_at "
-        f"({fixed_now - 5:.3f})；={fixed_now} 说明回归到了 now"
+    # 不再 set responded_at（避免长冷却）
+    assert state['responded_at'] is None, (
+        "advance_response 不应再 set responded_at——长冷却只该由显式 accept/decline 触发"
     )
+    # state 进 dismissed/reset：delivered_at 清掉，pending session 清掉
+    assert state['delivered_at'] is None
+    assert state['pending_session_id'] is None
+    # 5min 短抑制：suppressed_until = fixed_now + 5min
+    assert state['suppressed_until'] == fixed_now + sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS
 
 
-def test_advance_response_anchors_even_when_proactive_runs_long_after_reply(monkeypatch):
-    """关键回归保护：用户回完话后过 2 小时才跑下一次 proactive_chat，
-    `responded_at` 必须 anchor 到 ~2 小时前的回应时刻，而不是 now。否则
-    24h 冷却会被这段静默期白吃，整体冷却变成 ~26 小时，违背 spec。
-
-    冻结 sr.time.time —— anchor 是不是真的 = last_user_msg_at 可以精确比对。"""
-    fixed_now = 1_700_010_000.0
+def test_advance_response_does_not_trigger_long_cooldown(monkeypatch):
+    """关键回归保护（CodeRabbit Major 指出场景）：
+    1) 邀请投递；
+    2) 用户先发普通消息（不命中关键词）→ advance 跑；
+    3) 用户随后点 accept 按钮。
+    旧逻辑：advance 已 mark responded → endpoint 看到 responded_at != None →
+            返 expired，但状态早就进 1h 长冷却（错）。
+    新逻辑：advance 仅 dismiss + 5min 短抑制（≠长冷却）；endpoint 看到没
+            pending 仍返 expired（按钮已晚），但 5min 后下次 proactive 重新
+            走骰子可重新邀请，不长锁。"""
+    fixed_now = 1_700_005_000.0
     monkeypatch.setattr(sr.time, 'time', lambda: fixed_now)
 
-    # 模拟：邀请投递在 2h+10s 前；用户 2h 前回过话；之后一直没动；现在
-    # 第二次 proactive_chat 进来终于把 advance 跑上。
     state = sr._mini_game_invite_get_state(LANLAN)
-    state['delivered_at'] = fixed_now - 2 * 3600 - 10
+    state['delivered_at'] = fixed_now - 60
     state['responded_at'] = None
     state['chats_since_response'] = 0
+    state['pending_session_id'] = 'sess-x'
+    sr._invite_ever_delivered[LANLAN] = True
 
-    sr._mini_game_invite_advance_response(LANLAN, fixed_now - 2 * 3600)
-    assert state['responded_at'] is not None
-    # 冻结时钟下应精确等于 fixed_now - 2h；回归到 now 会让 24h 冷却被多锁 2h。
-    expected = fixed_now - 2 * 3600
-    assert state['responded_at'] == expected, (
-        f"responded_at={state['responded_at']:.1f} 应严格等于 "
-        f"{expected:.1f}（fixed_now={fixed_now}），偏差说明 anchor 出错"
-    )
+    # 用户 30s 前说了句普通话（advance 抓到）
+    sr._mini_game_invite_advance_response(LANLAN, fixed_now - 30.0)
+
+    # cooldown 检查应只反映 5min 短抑制（不到 1h 长锁）
+    assert state['responded_at'] is None
+    assert state['chats_since_response'] == 0  # 不是被锁的「已回应进入 10 chats 计数」
+    assert state['suppressed_until'] is not None
+    suppress_window = state['suppressed_until'] - fixed_now
+    assert (
+        sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS - 1
+        <= suppress_window
+        <= sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS + 1
+    ), f"suppressed_until 应是 5min 短抑制，实际 {suppress_window}s"
+    # 5min 后冷却应自然解除
+    monkeypatch.setattr(sr.time, 'time', lambda: fixed_now + sr.MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS + 1)
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
 
 
 def test_advance_response_does_not_flip_when_last_user_msg_predates_invite():

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -851,8 +851,9 @@ def test_apply_choice_ignored_when_already_responded():
 
 
 def test_apply_choice_accept_returns_open_game_with_url():
-    """accept → 返回 game_url（带 lanlan_name + session_id query），
-    state 翻成 responded（启动 1h+10 chats 冷却）。"""
+    """accept → 返回 game_url（带 lanlan_name + session_id query）+ 顶层
+    session_id 字段（前端 dedupe key），state 翻成 responded（启动 1h+10 chats
+    冷却）。"""
     state = sr._mini_game_invite_get_state(LANLAN)
     state['delivered_at'] = time.time() - 30
     state['responded_at'] = None
@@ -864,6 +865,10 @@ def test_apply_choice_accept_returns_open_game_with_url():
     assert result['game_url'].startswith('/soccer_demo?')
     assert 'lanlan_name=' + LANLAN in result['game_url']
     assert 'session_id=sess-abc' in result['game_url']
+    # 顶层 session_id 必须有，core.py keyword 路径推 mini_game_launch WS 时
+    # 把它放进 payload，让前端 dedupe set 跨「按钮 endpoint」/「keyword WS」
+    # 两路都用同一 key，避免双开窗口（codex P2 指出）。
+    assert result['session_id'] == 'sess-abc'
     # state 进 cooldown
     assert state['responded_at'] is not None
     assert state['chats_since_response'] == 0
@@ -916,8 +921,18 @@ def test_keyword_matcher_returns_none_for_empty_text():
 
 def test_keyword_matcher_accept_zh():
     assert sr._match_mini_game_invite_keyword('好啊') == 'accept'
-    assert sr._match_mini_game_invite_keyword('来！') == 'accept'
+    assert sr._match_mini_game_invite_keyword('来吧') == 'accept'
     assert sr._match_mini_game_invite_keyword('一起玩吧') == 'accept'
+
+
+def test_keyword_matcher_accept_does_not_match_negation():
+    """关键词列表配合 priority 双保险：'不好'/'我不行' 不能被 accept 误命中。
+    accept 现在用「好啊/好的/行啊」短语，'不好' 不含 substring '好啊'；同时
+    priority decline > accept 兜底——任一保护失效另一个仍 catch。"""
+    # 从 substring 层面：'不好' / '我不行' 不含 accept 短语
+    assert sr._match_mini_game_invite_keyword('不好') == 'decline'
+    assert sr._match_mini_game_invite_keyword('我不行') == 'decline'
+    assert sr._match_mini_game_invite_keyword('不好玩') == 'decline'
 
 
 def test_keyword_matcher_accept_en():
@@ -938,12 +953,17 @@ def test_keyword_matcher_later_zh():
     assert sr._match_mini_game_invite_keyword('晚点吧') == 'later'
 
 
-def test_keyword_matcher_accept_priority_over_later():
-    """暧昧文本同时含 accept + later 关键词 → accept 优先（spec 偏向"用户表达
-    了正面意愿就当接受"）。"""
-    # "好" + "等下" 同时命中
-    result = sr._match_mini_game_invite_keyword('好的等下')
-    assert result == 'accept'
+def test_keyword_matcher_priority_decline_over_later_over_accept():
+    """priority 是 decline > later > accept（CodeRabbit Major review 后调整）。
+    含 negation 的句子绝不能因 accept substring 凑巧命中就反向触发开游戏；
+    含 later 信号的句子优先于纯 accept。"""
+    # 'decline' > 'later'：含 '不要' (decline) + '回头' (later) → decline
+    assert sr._match_mini_game_invite_keyword('不要，回头说吧') == 'decline'
+    # 'later' > 'accept'：含 '好的' (accept) + '等下' (later) → later
+    # （用户语义"接受但等等"，later 比 accept 准——别立刻开游戏）
+    assert sr._match_mini_game_invite_keyword('好的等下') == 'later'
+    # 'decline' > 'accept'：含 '不行' (decline) + '可以' (accept)
+    assert sr._match_mini_game_invite_keyword('不行吧，但可以下次') == 'decline'
 
 
 def test_keyword_matcher_no_false_positive_on_long_text():

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -1031,6 +1031,101 @@ def test_maybe_apply_keyword_later_resets_state():
     assert state['suppressed_until'] is not None
 
 
+def test_keyword_matcher_no_false_positive_on_substring_words():
+    """codex P1：英文短词 'yes' / 'no' / 'okay' 必须 word-boundary 匹配，不能
+    被 'yesterday' / 'no idea' / 'book' 这种 substring 凑巧命中。"""
+    # 'yes' 不该命中 'yesterday'
+    assert sr._match_mini_game_invite_keyword('yesterday i talked to him') is None
+    # 'no' 不该命中 'no idea' —— '"no idea"' 的 'no' 是单独 token，应该命中 decline
+    # 让我们换个例子：'know' 含 'no' 子串，但 'no' 应该 word-boundary 不命中 'know'
+    assert sr._match_mini_game_invite_keyword('i know what you mean') is None
+    # 'sure' 是单独词时命中 accept
+    assert sr._match_mini_game_invite_keyword('sure thing') == 'accept'
+    # 'sure' 不应命中 'pressure' 这种含 substring 的（虽 'sure' 在 'pressure' 中）
+    assert sr._match_mini_game_invite_keyword('feeling pressure') is None
+
+
+@pytest.mark.asyncio
+async def test_button_endpoint_pushes_resolved_ws_for_all_actions(monkeypatch):
+    """codex P2：endpoint 处理 accept / decline / later 都必须 push
+    mini_game_invite_resolved WS event让所有 page 同步 dismiss prompt
+    UI（cross-window 一致性）。原版只对 accept push mini_game_launch，
+    decline / later 用户在另一窗口看着按钮挂着。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = time.time() - 30
+    state['responded_at'] = None
+    state['pending_session_id'] = 'btn-sess'
+    state['last_game_type'] = 'soccer'
+
+    # 模拟 mgr + websocket
+    mgr = MagicMock()
+    mgr.websocket = MagicMock()
+    mgr.websocket.send_json = AsyncMock()
+    fake_state = MagicMock()
+    fake_state.CONNECTED = fake_state
+    mgr.websocket.client_state = fake_state
+
+    await sr._push_mini_game_invite_resolved(
+        mgr, session_id='btn-sess', action='cooldown',
+    )
+    mgr.websocket.send_json.assert_awaited_once()
+    payload = mgr.websocket.send_json.await_args.args[0]
+    assert payload['type'] == 'mini_game_invite_resolved'
+    assert payload['session_id'] == 'btn-sess'
+    assert payload['action'] == 'cooldown'
+    # cooldown 不带 game_url
+    assert 'game_url' not in payload
+
+
+@pytest.mark.asyncio
+async def test_push_resolved_includes_game_url_for_open_game(monkeypatch):
+    """accept outcome 的 resolved WS 同时带 game_url——前端按 action=='open_game'
+    + game_url 决定 window.open。单一 event 兼当 lifecycle dismiss + launch 信号。"""
+    mgr = MagicMock()
+    mgr.websocket = MagicMock()
+    mgr.websocket.send_json = AsyncMock()
+    fake_state = MagicMock()
+    fake_state.CONNECTED = fake_state
+    mgr.websocket.client_state = fake_state
+
+    await sr._push_mini_game_invite_resolved(
+        mgr,
+        session_id='accept-sess',
+        action='open_game',
+        game_url='/soccer_demo?lanlan_name=foo&session_id=accept-sess',
+        game_type='soccer',
+    )
+    payload = mgr.websocket.send_json.await_args.args[0]
+    assert payload['action'] == 'open_game'
+    assert payload['game_url'].startswith('/soccer_demo?')
+    assert payload['game_type'] == 'soccer'
+
+
+@pytest.mark.asyncio
+async def test_push_resolved_noop_without_session_id():
+    """空 session_id → no-op（防止误广播过期 invite）。"""
+    mgr = MagicMock()
+    mgr.websocket = MagicMock()
+    mgr.websocket.send_json = AsyncMock()
+    await sr._push_mini_game_invite_resolved(mgr, session_id='', action='cooldown')
+    mgr.websocket.send_json.assert_not_awaited()
+
+
+def test_advance_response_returns_outcome_for_caller_ws_push():
+    """advance_response 不再仅 mutate state，要 return result dict 让 caller
+    push WS（用户隐式 dismiss 也要 cross-window 通知）。"""
+    fixed_now = 1_700_020_000.0
+    state = sr._mini_game_invite_get_state(LANLAN)
+    state['delivered_at'] = fixed_now - 60
+    state['responded_at'] = None
+    state['pending_session_id'] = 'adv-sess'
+
+    result = sr._mini_game_invite_advance_response(LANLAN, fixed_now - 30)
+    assert result is not None
+    assert result['action'] == 'suppress'
+    assert result['session_id'] == 'adv-sess'
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 邀请投递推 WS message + session_id 流转
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
[PR #1143](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1143) 之后做掉 spec 第 6 条 + D2 短期抑制 + E2 关键词文本匹配。前端复用 galgame 按钮 UI 框架但**不走 galgame 开关**。

## 行为合同

邀请投递时后端推 WS message ``mini_game_invite_options`` 给前端，带 3 个本地化按钮（accept / decline / later）+ session_id + game_type。前端用通用 ChoicePrompt 抽象渲染。用户点击：

| 选项 | 文案（zh） | 后端动作 | 前端动作 |
|---|---|---|---|
| accept | 来一局！ | mark responded（启动 1h+10 chats 冷却） | ``window.open(/soccer_demo?lanlan_name=...&session_id=...)`` |
| decline | 现在不想玩 | mark responded（同样冷却但不开游戏） | 隐藏 prompt |
| later (D2) | 等一会儿 | reset state + ``suppressed_until = now + 5min`` | 隐藏 prompt |

**关键词文本兜底**（用户没点按钮自己打字"好啊"/"不要"/"晚点"）：core.py 文本入口扫一遍 ``MINI_GAME_INVITE_KEYWORDS``（5 locale × 3 choice），命中即触发对应 state 转换；**不吃掉消息**——继续走普通 chat 流水线，AI 仍然回应这条话。accept 命中时后端额外 push ``mini_game_launch`` WS 让前端 window.open 游戏。

## 关键设计选择

- **通用 ChoicePrompt 抽象**（B 拍板）：前端 ``state.choicePrompt`` + ``ChoicePrompt`` schema，``source: 'galgame'|'mini_game_invite'`` 两路并存。当前 galgame mode 仍走旧 ``galgameOptions`` 字段（BC，零回归）；mini-game invite 走新 ``choicePrompt``。未来"对话框 + avatar 旁同步选项"扩展只需加 ``placement`` 字段。
- **lanlan_frd 仓库零改动**：复用现有 ``setWindowOpenHandler`` 拦截 + ``WS_PROXY_CHANNELS.RAW_MESSAGE`` 从 Pet 主窗 IPC 转给 chat.html，前端对所有窗口都用 ``window.open`` 一致触发，主进程一处拦截。
- **session_id 防 stale**：每次投递生成 uuid，state.pending_session_id 持有；endpoint 收到不匹配 → ``action='expired'`` 让前端隐藏过期 prompt 而不报错。
- **dedupe 双开**：endpoint 路径 + WS push 路径都可能开同一 session 的游戏，前端 ``_launchedMiniGameSessionIds`` set 让同一 session 只 ``window.open`` 一次。
- **关键词列表去掉太宽的字**（'玩' / '走' / 'play' / '안'）—— "不想玩" / "don't want to play" 不能被 substring 匹配误命中 accept。

## 改动文件

| 文件 | 改动 |
|---|---|
| ``config/__init__.py`` | +2 常量：``LATER_SUPPRESS_SECONDS=300`` + ``MINI_GAME_LAUNCH_URL_BY_GAME`` |
| ``config/prompts_proactive.py`` | +``MINI_GAME_INVITE_OPTION_LABELS`` 5 locale × 3 choice + ``MINI_GAME_INVITE_KEYWORDS`` 5 locale × 3 choice |
| ``main_routers/system_router.py`` | state 加 ``pending_session_id`` / ``suppressed_until``；投递推 WS payload；新 endpoint ``/api/mini_game/invite/respond``；3 个 helper（``_apply_mini_game_invite_choice`` / ``_match_mini_game_invite_keyword`` / ``_maybe_apply_mini_game_invite_keyword``） |
| ``main_logic/core.py`` | 文本入口（``_publish_user_utterance_to_plugin_bus`` 之后）调关键词 hook，accept 时推 ``mini_game_launch`` WS |
| ``frontend/react-neko-chat/src/message-schema.ts`` | +``ChoiceOption`` / ``ChoicePrompt`` zod schema + types |
| ``frontend/react-neko-chat/src/App.tsx`` | +``choicePrompt`` / ``onChoiceSelect`` props，渲染 ``composer-choice-slot``（复用 ``.composer-galgame-*`` CSS） |
| ``static/app-react-chat-window.js`` | +``state.choicePrompt`` / ``_launchedMiniGameSessionIds`` + 4 helper（``handleChoiceSelect`` / ``handleMiniGameInviteChoice`` / ``setMiniGameInvitePrompt`` / ``launchMiniGameInternal``）+ host 暴露 |
| ``static/app-websocket.js`` | +2 WS message branches: ``mini_game_invite_options`` / ``mini_game_launch`` |
| ``templates/soccer_demo.html`` | URL query parse ``lanlan_name`` / ``session_id`` 覆盖默认 |
| ``tests/unit/test_mini_game_invite.py`` | +24 个测试：D2 suppression / 三 choice state machine / 关键词匹配 / WS payload push / i18n 完整性 |

## Test plan

- [x] ``uv run pytest tests/unit/test_mini_game_invite.py`` —— **65 passed**
- [x] 联跑 proactive + game-router suite —— **340 passed**，无回归
- [x] React ``npm run typecheck`` —— clean
- [x] React ``npm run build`` —— 成功，``static/react/neko-chat`` 产物刷新
- [x] React ``npm run test`` (vitest) —— **36 passed**（含 23 App tests，galgame BC 不回归）
- [x] ``check_prompt_hygiene.py`` / ``check_i18n_sync.py`` / ``check_api_trailing_slash.py`` / ``check_frontend_api_trailing_slash.py`` —— 我的改动 clean
- [ ] **手测三 context** ([feedback_chat_three_contexts](https://github.com/Project-N-E-K-O/N.E.K.O/issues/?) 必须)：index.html 宽屏 / 移动端窄屏 / chat.html Electron multi-window 三条路径——验证 ChoicePrompt 渲染、accept 打开 soccer_demo、退出回主聊天

## Out of scope

- "avatar 旁同步显示选项" placement 扩展（schema 已留口子，后续 PR 加）
- Galgame mode options migrate 到 ``choicePrompt`` 抽象（当前 BC 优先）
- Electron 主进程对 ``/soccer_demo`` URL 的特殊窗口策略（如游戏专用尺寸）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 聊天新增可交互“选择提示”（最多 3 项），支持按钮点击回调并区分来源（如 galgame / mini_game_invite）
  * 小游戏邀请支持按游戏类型的启动 URL 且随会话 ID 打开对应页面

* **改进**
  * 会话感知的邀请状态机：会话 ID、去重、短期“稍后”抑制与冷却逻辑加强
  * 多语言（中/英/日/韩/俄）按钮文案与关键词匹配（优先级：拒绝>稍后>接受）

* **其他**
  * 前后端通过实时通道同步邀请选项/结果，新增邀请响应接口及前端弹窗/重试与测试覆盖扩大
<!-- end of auto-generated comment: release notes by coderabbit.ai -->