### PR TITLE
feat(proactive): mini-game 邀请用户级 toggle + 调试 force-game-type 旗标

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1359,6 +1359,17 @@ MINI_GAME_LAUNCH_URL_BY_GAME: dict[str, str] = {
 ``setWindowOpenHandler`` 拦截开独立 BrowserWindow（普通浏览器是新 tab）；URL
 会带上 ``?lanlan_name=...&session_id=...`` query。新 mini-game 加新 entry 即可。"""
 
+MINI_GAME_INVITE_FORCE_GAME_TYPE: str | None = None
+"""【调试用临时旗标】非 None 时，每次合格的主动搭话都强制走 mini-game 邀请短路，
+且使用此值作为 game_type，跳过 activity_snapshot / propensity / away /
+unfinished_thread / cooldown / probability / force-first / 用户级 toggle 等所有
+gate；仅 ``MINI_GAME_INVITE_ENABLED`` 总开关仍生效作为最后 kill switch。
+- 取值约定：None 关闭（生产默认）；'soccer' 等 ``MINI_GAME_INVITE_LINES_BY_GAME``
+  里存在的合法 key。非法 key 会在投递时 warn + 跳过。
+- 用途：本地手测三 context UI 时，不想等 force-first 凑齐 N-1 次主动搭话、也不
+  想反复重启 fixture 调 cooldown。线上不要打开。
+- 上游：``main_routers/system_router._maybe_deliver_mini_game_invite``。"""
+
 PROACTIVE_SOURCE_HARD_SKIP_SECONDS = 5 * 3600
 """主动搭话 source 衰减历史的硬窗口（p_skip=1.0）。
 - 用途：5h 内同一 URL 必跳，超过后按 kind 半衰期指数衰减。
@@ -1658,6 +1669,7 @@ __all__ = [
     'MINI_GAME_INVITE_AVAILABLE_GAMES',
     'MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS',
     'MINI_GAME_LAUNCH_URL_BY_GAME',
+    'MINI_GAME_INVITE_FORCE_GAME_TYPE',
     'PROACTIVE_SOURCE_HARD_SKIP_SECONDS',
     'PROACTIVE_SOURCE_HALF_LIFE_BY_KIND',
     'PROACTIVE_SOURCE_HALF_LIFE_DEFAULT',

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -75,6 +75,7 @@ from config import (
     PROACTIVE_PHASE1_UNIFIED_MAX_TOKENS,
     PROACTIVE_CHAT_HISTORY_MAX,
     MINI_GAME_INVITE_ENABLED,
+    MINI_GAME_INVITE_FORCE_GAME_TYPE,
     MINI_GAME_INVITE_TRIGGER_PROBABILITY,
     MINI_GAME_INVITE_COOLDOWN_SECONDS,
     MINI_GAME_INVITE_COOLDOWN_CHATS,
@@ -2307,11 +2308,14 @@ async def _maybe_deliver_mini_game_invite(
     activity_snapshot,
     invite_lang: str,
     master_name: str,
+    user_toggle_enabled: bool = True,
 ) -> dict | None:
     """命中即投递 mini-game 邀请、返回 _end_proactive 用的 JSON dict；未命中返 None。
 
     短路条件（任一不满足即返 None，由 caller 继续走原 Phase1/2 流水线）：
-      - MINI_GAME_INVITE_ENABLED=False
+      - MINI_GAME_INVITE_ENABLED=False（全局 kill switch，生产侧的总开关）
+      - user_toggle_enabled=False（用户在前端 CHAT_MODE_CONFIG 关掉了
+        ``proactiveMiniGameInviteEnabled`` toggle）
       - activity_snapshot is None（隐私模式 / tracker 不可用——保守不发）
       - propensity == 'restricted_screen_only'（focused_work / non-casual gaming）
       - state == 'away'（用户离场，邀请没人接）
@@ -2320,6 +2324,11 @@ async def _maybe_deliver_mini_game_invite(
         restricted_screen_only 对 unfinished_thread 的优先级约定对齐）
       - _mini_game_invite_in_cooldown
       - 非 force-first 路径下 random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY
+
+    调试旗标：``config.MINI_GAME_INVITE_FORCE_GAME_TYPE`` 非 None 时绕开除
+    ``MINI_GAME_INVITE_ENABLED`` 之外的所有 gate（含用户 toggle、cooldown、
+    probability、unfinished_thread、snapshot None / propensity / away、force-first
+    判定），把 game_type 钉到旗标值上。仅供本地手测，生产应保持 None。
 
     Force-first 分支：当
       ``state.delivered_at is None`` 且
@@ -2333,54 +2342,78 @@ async def _maybe_deliver_mini_game_invite(
     game_type 从 ``MINI_GAME_INVITE_AVAILABLE_GAMES`` random.choice。"""
     if not MINI_GAME_INVITE_ENABLED:
         return None
-    if activity_snapshot is None:
-        return None
-    propensity = getattr(activity_snapshot, 'propensity', None)
-    state_label = getattr(activity_snapshot, 'state', None)
-    if propensity == 'restricted_screen_only':
-        return None
-    if state_label == 'away':
-        return None
-    # AI 上一轮抛了问题（含 ?/吗/呢/么 等）用户还没接 → 跟进 thread 优先。
-    # skip_probability 在 system_router.py 同一文件的 propensity 段也是这条
-    # 优先级，统一不让 mini-game 邀请把 promised follow-up 抢走。
-    if getattr(activity_snapshot, 'unfinished_thread', None) is not None:
-        return None
-    if _mini_game_invite_in_cooldown(lanlan_name):
-        return None
 
-    # Force-first：从未发过邀请 + 累计已成功投递 N-1 条主动搭话 → 本条强制变邀请。
-    # proactive_chat_total 在 _record_proactive_chat 之后才 +1，所以"第 N 次"的
-    # 当下值是 N-1。计数走持久化文件，跨重启保留——否则用户每次重启都再"第 N 次"
-    # 一回，邀请密度抖。
-    #
-    # "is new user" 必须查持久化的 ever_delivered，不能查 in-memory 的
-    # ``state.delivered_at is None``——后者会被 PR-B「回头再说」reset，且重启清零；
-    # codex review (P1) 指出，没这条 force-first 在每次重启后都会把已邀请过的
-    # 用户当新用户重新强制邀请。
-    await _ensure_proactive_chat_totals_loaded()
-    never_delivered = not _was_invite_ever_delivered(lanlan_name)
-    total_so_far = _get_proactive_chat_total(lanlan_name)
-    force_first = (
-        never_delivered
-        and total_so_far >= max(0, MINI_GAME_INVITE_NEW_USER_FORCE_AT - 1)
-    )
-
-    if not force_first:
-        import random as _random
-        if _random.random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY:
+    # 调试旗标短路：非 None 时跳过所有用户/snapshot/cooldown/概率 gate，把 game_type
+    # 钉到旗标值上。仍然要求该 game_type 有对应文案；非法值 warn + 退出而不 raise，
+    # 避免在配置抖动时把整个 proactive 流水线带挂。Force-first 标记成 True 让 caller
+    # 路径与正常 first-time 邀请等价（不影响 ever_delivered 持久化）。
+    force_game = MINI_GAME_INVITE_FORCE_GAME_TYPE
+    debug_force = bool(force_game)
+    if debug_force:
+        if force_game not in MINI_GAME_INVITE_LINES_BY_GAME:
+            logger.warning(
+                "[%s] MINI_GAME_INVITE_FORCE_GAME_TYPE=%r is not in "
+                "MINI_GAME_INVITE_LINES_BY_GAME=%r — skipping invite. "
+                "Set the flag to a valid key or back to None.",
+                lanlan_name, force_game, list(MINI_GAME_INVITE_LINES_BY_GAME.keys()),
+            )
+            return None
+        await _ensure_proactive_chat_totals_loaded()
+        game_type = force_game
+        # 让下面 success-log 共用同一字段；调试旗标语义上等同于 "强制走 first-time
+        # 路径"，print 出来好认。
+        force_first = True
+    else:
+        if not user_toggle_enabled:
+            return None
+        if activity_snapshot is None:
+            return None
+        propensity = getattr(activity_snapshot, 'propensity', None)
+        state_label = getattr(activity_snapshot, 'state', None)
+        if propensity == 'restricted_screen_only':
+            return None
+        if state_label == 'away':
+            return None
+        # AI 上一轮抛了问题（含 ?/吗/呢/么 等）用户还没接 → 跟进 thread 优先。
+        # skip_probability 在 system_router.py 同一文件的 propensity 段也是这条
+        # 优先级，统一不让 mini-game 邀请把 promised follow-up 抢走。
+        if getattr(activity_snapshot, 'unfinished_thread', None) is not None:
+            return None
+        if _mini_game_invite_in_cooldown(lanlan_name):
             return None
 
-    game_type = _pick_mini_game_type()
-    if game_type is None:
-        logger.warning(
-            "[%s] mini-game invite skipped: no game_type available "
-            "(MINI_GAME_INVITE_AVAILABLE_GAMES=%r, LINES keys=%r)",
-            lanlan_name,
-            MINI_GAME_INVITE_AVAILABLE_GAMES,
-            list(MINI_GAME_INVITE_LINES_BY_GAME.keys()),
+        # Force-first：从未发过邀请 + 累计已成功投递 N-1 条主动搭话 → 本条强制变邀请。
+        # proactive_chat_total 在 _record_proactive_chat 之后才 +1，所以"第 N 次"的
+        # 当下值是 N-1。计数走持久化文件，跨重启保留——否则用户每次重启都再"第 N 次"
+        # 一回，邀请密度抖。
+        #
+        # "is new user" 必须查持久化的 ever_delivered，不能查 in-memory 的
+        # ``state.delivered_at is None``——后者会被 PR-B「回头再说」reset，且重启清零；
+        # codex review (P1) 指出，没这条 force-first 在每次重启后都会把已邀请过的
+        # 用户当新用户重新强制邀请。
+        await _ensure_proactive_chat_totals_loaded()
+        never_delivered = not _was_invite_ever_delivered(lanlan_name)
+        total_so_far = _get_proactive_chat_total(lanlan_name)
+        force_first = (
+            never_delivered
+            and total_so_far >= max(0, MINI_GAME_INVITE_NEW_USER_FORCE_AT - 1)
         )
-        return None
+
+        if not force_first:
+            import random as _random
+            if _random.random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY:
+                return None
+
+        game_type = _pick_mini_game_type()
+        if game_type is None:
+            logger.warning(
+                "[%s] mini-game invite skipped: no game_type available "
+                "(MINI_GAME_INVITE_AVAILABLE_GAMES=%r, LINES keys=%r)",
+                lanlan_name,
+                MINI_GAME_INVITE_AVAILABLE_GAMES,
+                list(MINI_GAME_INVITE_LINES_BY_GAME.keys()),
+            )
+            return None
     template = _loc(MINI_GAME_INVITE_LINES_BY_GAME[game_type], invite_lang)
     safe_master = (master_name or '').strip()
     try:
@@ -4296,12 +4329,18 @@ async def proactive_chat(request: Request):
             )
         except Exception:
             invite_lang = 'zh'
+        # 用户级 toggle：前端 CHAT_MODE_CONFIG 里的 ``proactiveMiniGameInviteEnabled``
+        # 通过 request body 的 ``mini_game_invite_enabled`` 字段透传。缺省 True 兼容
+        # 旧客户端（未携带该字段时维持现有行为）。MINI_GAME_INVITE_ENABLED 全局
+        # kill switch 仍是更上游的一道。
+        _user_invite_toggle = bool(data.get('mini_game_invite_enabled', True))
         invite_outcome = await _maybe_deliver_mini_game_invite(
             lanlan_name=lanlan_name,
             mgr=mgr,
             activity_snapshot=activity_snapshot,
             invite_lang=invite_lang,
             master_name=master_name_current,
+            user_toggle_enabled=_user_invite_toggle,
         )
         if invite_outcome is not None:
             return await _end_proactive(JSONResponse(invite_outcome))

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4215,6 +4215,15 @@ async def proactive_chat(request: Request):
                 action=_text_advance_outcome.get('action', 'suppress'),
             )
 
+        # 调试旗标 ``MINI_GAME_INVITE_FORCE_GAME_TYPE`` 非 None 时绕开本函数所有
+        # 上游早退 gate（closed / skip_probability / restricted_screen_only），
+        # 让 ``_maybe_deliver_mini_game_invite`` 能稳定接到本轮调用——契约是
+        # "开启后主动搭话必定触发特定小游戏"。仅本地手测使用；生产
+        # ``MINI_GAME_INVITE_ENABLED`` 总开关 + 旗标默认 None 双保险。
+        # CodeRabbit Major 指出：这条不在 ``_maybe_deliver_mini_game_invite``
+        # 内部加是因为那时已经过了上游 gate，旗标做不到"必定"。
+        _debug_force_invite = MINI_GAME_INVITE_FORCE_GAME_TYPE is not None
+
         # ========== Hard short-circuit: propensity=closed ==========
         # ``private`` state pins propensity to ``closed`` (see
         # main_logic/activity/snapshot.py). Skip everything — no LLM,
@@ -4223,7 +4232,11 @@ async def proactive_chat(request: Request):
         # look. Bypassed for the unfinished_thread override is
         # deliberate: if the AI just asked a question, hanging on it
         # mid-private is rude. closed > thread.
-        if activity_snapshot is not None and activity_snapshot.propensity == 'closed':
+        if (
+            not _debug_force_invite
+            and activity_snapshot is not None
+            and activity_snapshot.propensity == 'closed'
+        ):
             print(f"[{lanlan_name}] propensity=closed (state={activity_snapshot.state}), 跳过本轮 proactive")
             return await _end_proactive(JSONResponse({
                 "success": True,
@@ -4244,7 +4257,8 @@ async def proactive_chat(request: Request):
         # how silenced the user wanted us. The thread mechanism's
         # 2-followup hard cap already prevents harassment.
         if (
-            activity_snapshot is not None
+            not _debug_force_invite
+            and activity_snapshot is not None
             and activity_snapshot.skip_probability > 0
             and activity_snapshot.unfinished_thread is None
         ):
@@ -4266,9 +4280,13 @@ async def proactive_chat(request: Request):
                 }))
 
         # ========== 解析 enabled_modes ==========
-        enabled_modes = data.get('enabled_modes', [])
-        # 兼容旧版前端
-        if not enabled_modes:
+        # 兼容旧版前端：``enabled_modes`` 字段缺席 → 根据其它字段推断；显式传 ``[]``
+        # 表示新版客户端"用户把所有 source toggle 都关了"，不能再走 BC fallback
+        # 退化到 home/trending（否则 mini-game 邀请 toggle 单独开启的场景下 dice
+        # miss 会让 home 兜底打破 toggle 契约——codex P1）。
+        if 'enabled_modes' in data:
+            enabled_modes = data.get('enabled_modes') or []
+        else:
             content_type = data.get('content_type', None)
             screenshot_data = data.get('screenshot_data')
             if screenshot_data and isinstance(screenshot_data, str):
@@ -4297,7 +4315,11 @@ async def proactive_chat(request: Request):
         # 直接 pass —— 没东西可看，又不让聊外部，没必要继续。
         # 例外：有未收尾话题（5min 内 AI 提的问题用户还没回）→ 即使没 vision
         # 也允许跑下去，跟进上一个问题不需要外部素材。
-        if activity_snapshot is not None and activity_snapshot.propensity == 'restricted_screen_only':
+        if (
+            not _debug_force_invite
+            and activity_snapshot is not None
+            and activity_snapshot.propensity == 'restricted_screen_only'
+        ):
             if 'vision' in enabled_modes:
                 enabled_modes = ['vision']
                 print(f"[{lanlan_name}] propensity=restricted_screen_only, 收紧 enabled_modes 到仅 vision")
@@ -4344,6 +4366,20 @@ async def proactive_chat(request: Request):
         )
         if invite_outcome is not None:
             return await _end_proactive(JSONResponse(invite_outcome))
+
+        # 用户把所有 source toggle 都关了（仅留 mini-game 邀请独立 toggle 触发本轮
+        # 请求），mini-game 短路又没命中：没什么可聊。直接 pass 而不是落到下面源
+        # picking 走空 list / 撞 "所有信息源获取失败" 500 分支。例外：仍然有未收尾
+        # 话题 → 让 Phase 2 走 text-only 跟进路径（与 sources={} 但 thread 在的兜
+        # 底语义对齐）。codex P1 指出：BC fallback 已经按 "字段缺席 vs 显式 []" 分
+        # 流，这里对显式空清晰退出。
+        if not enabled_modes and not _has_unfinished_thread:
+            print(f"[{lanlan_name}] enabled_modes 空 + mini-game miss + 无 unfinished_thread → pass")
+            return await _end_proactive(JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": "no source modes enabled and mini-game invite did not fire",
+            }))
 
         # 全局 source 衰减历史：进入 picking 前确保已惰性加载到内存（首次为线程池
         # IO，后续是 O(1) flag 检查）。同步 picking loop 后续直接读 dict。

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -245,7 +245,8 @@
     function hasAnyChatModeEnabled() {
         return S.proactiveVisionChatEnabled || S.proactiveNewsChatEnabled ||
             S.proactiveVideoChatEnabled || S.proactivePersonalChatEnabled ||
-            S.proactiveMusicEnabled || S.proactiveMemeEnabled;
+            S.proactiveMusicEnabled || S.proactiveMemeEnabled ||
+            S.proactiveMiniGameInviteEnabled;
     }
     mod.hasAnyChatModeEnabled = hasAnyChatModeEnabled;
 
@@ -323,21 +324,24 @@
         // 必须选择至少一种搭话方式
         if (!S.proactiveVisionChatEnabled && !S.proactiveNewsChatEnabled &&
             !S.proactiveVideoChatEnabled && !S.proactivePersonalChatEnabled &&
-            !S.proactiveMusicEnabled && !S.proactiveMemeEnabled) {
+            !S.proactiveMusicEnabled && !S.proactiveMemeEnabled &&
+            !S.proactiveMiniGameInviteEnabled) {
             return false;
         }
 
         // 如果只选择了视觉搭话，需要同时开启自主视觉
         if (S.proactiveVisionChatEnabled && !S.proactiveNewsChatEnabled &&
             !S.proactiveVideoChatEnabled && !S.proactivePersonalChatEnabled &&
-            !S.proactiveMusicEnabled && !S.proactiveMemeEnabled) {
+            !S.proactiveMusicEnabled && !S.proactiveMemeEnabled &&
+            !S.proactiveMiniGameInviteEnabled) {
             return S.proactiveVisionEnabled;
         }
 
         // 如果只选择了个人动态搭话，需要同时开启个人动态
         if (!S.proactiveVisionChatEnabled && !S.proactiveNewsChatEnabled &&
             !S.proactiveVideoChatEnabled && S.proactivePersonalChatEnabled &&
-            !S.proactiveMusicEnabled && !S.proactiveMemeEnabled) {
+            !S.proactiveMusicEnabled && !S.proactiveMemeEnabled &&
+            !S.proactiveMiniGameInviteEnabled) {
             return S.proactivePersonalChatEnabled;
         }
 
@@ -627,7 +631,10 @@
                     body: JSON.stringify({
                         lanlan_name: lanlanName,
                         enabled_modes: voiceModes,
-                        voice_mode: true
+                        voice_mode: true,
+                        // mini-game 邀请的用户级 toggle；后端 _maybe_deliver_mini_game_invite
+                        // 与 source-driven sources 解耦，不进 enabled_modes 数组。
+                        mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled
                     })
                 });
                 requestSent = true;
@@ -688,10 +695,14 @@
                 availableModes.push('meme');
             }
 
-            // 如果没有选择任何搭话方式，跳过本次搭话
+            // 如果没有选择任何搭话方式，跳过本次搭话——除非 mini-game 邀请独立开着
+            // （那条路径与 enabled_modes 解耦，后端短路通道仍可能掷骰投递邀请）。
             if (availableModes.length === 0) {
-                console.log('未选择任何搭话方式，跳过本次搭话');
-                return;
+                if (!S.proactiveMiniGameInviteEnabled) {
+                    console.log('未选择任何搭话方式，跳过本次搭话');
+                    return;
+                }
+                console.log('availableModes 为空但 mini-game 邀请开着，让请求过去走短路通道');
             }
 
             console.log('主动搭话：启用模式 [' + availableModes.join(', ') + ']，将并行获取所有信息源');
@@ -702,7 +713,10 @@
                 enabled_modes: availableModes,
                 is_playing_music: (typeof window.isMusicPlaying === 'function') ? window.isMusicPlaying() : false,
                 current_track: (typeof window.getMusicCurrentTrack === 'function') ? window.getMusicCurrentTrack() : null,
-                music_cooldown: (typeof window.isMusicCooldown === 'function') ? window.isMusicCooldown() : false
+                music_cooldown: (typeof window.isMusicCooldown === 'function') ? window.isMusicCooldown() : false,
+                // mini-game 邀请的用户级 toggle；后端 _maybe_deliver_mini_game_invite
+                // 与 source-driven sources 解耦，不进 enabled_modes 数组。
+                mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled
             };
 
             // 独立计时器：确保 vision/window 模式的屏幕感知间隔不低于 proactiveVisionInterval

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -31,6 +31,7 @@
             proactiveVideoChatEnabled: S.proactiveVideoChatEnabled,
             proactivePersonalChatEnabled: S.proactivePersonalChatEnabled,
             proactiveMusicEnabled: S.proactiveMusicEnabled,
+            proactiveMiniGameInviteEnabled: S.proactiveMiniGameInviteEnabled,
             mergeMessagesEnabled: S.mergeMessagesEnabled,
             focusModeEnabled: S.focusModeEnabled,
             avatarReactionBubbleEnabled: S.avatarReactionBubbleEnabled,
@@ -172,6 +173,9 @@
         const currentMemeChat = typeof window.proactiveMemeEnabled !== 'undefined'
             ? window.proactiveMemeEnabled
             : S.proactiveMemeEnabled;
+        const currentMiniGameInviteChat = typeof window.proactiveMiniGameInviteEnabled !== 'undefined'
+            ? window.proactiveMiniGameInviteEnabled
+            : S.proactiveMiniGameInviteEnabled;
         const currentAvatarReactionBubble = typeof window.avatarReactionBubbleEnabled !== 'undefined'
             ? window.avatarReactionBubbleEnabled
             : S.avatarReactionBubbleEnabled;
@@ -218,6 +222,7 @@
             proactivePersonalChatEnabled: currentPersonalChat,
             proactiveMusicEnabled: currentMusicChat,
             proactiveMemeEnabled: currentMemeChat,
+            proactiveMiniGameInviteEnabled: currentMiniGameInviteChat,
             mergeMessagesEnabled: currentMerge,
             focusModeEnabled: currentFocus,
             avatarReactionBubbleEnabled: currentAvatarReactionBubble,
@@ -244,6 +249,7 @@
         S.proactivePersonalChatEnabled = currentPersonalChat;
         S.proactiveMusicEnabled = currentMusicChat;
         S.proactiveMemeEnabled = currentMemeChat;
+        S.proactiveMiniGameInviteEnabled = currentMiniGameInviteChat;
         S.mergeMessagesEnabled = currentMerge;
         S.focusModeEnabled = currentFocus;
         S.avatarReactionBubbleEnabled = currentAvatarReactionBubble;
@@ -330,6 +336,7 @@
                 S.proactivePersonalChatEnabled = settings.proactivePersonalChatEnabled ?? false;
                 S.proactiveMusicEnabled = settings.proactiveMusicEnabled ?? true;
                 S.proactiveMemeEnabled = settings.proactiveMemeEnabled ?? true;
+                S.proactiveMiniGameInviteEnabled = settings.proactiveMiniGameInviteEnabled ?? true;
                 S.mergeMessagesEnabled = settings.mergeMessagesEnabled ?? false;
                 S.focusModeEnabled = settings.focusModeEnabled ?? false;
                 S.avatarReactionBubbleEnabled = settings.avatarReactionBubbleEnabled ?? true;
@@ -405,9 +412,10 @@
                     console.log('首次启动：检测到中国地区用户，已自动开启自主视觉');
                 }
 
-                // 首次启动默认开启音乐/meme搭话
+                // 首次启动默认开启音乐/meme搭话 + mini-game 邀请
                 S.proactiveMusicEnabled = true;
                 S.proactiveMemeEnabled = true;
+                S.proactiveMiniGameInviteEnabled = true;
                 // 首次启动默认 token 上限 300（tiktoken o200k_base）
                 S.textGuardMaxLength = 300;
                 window.textGuardMaxLength = 300;
@@ -545,7 +553,7 @@
         }
 
         // 如果已开启主动搭话且选择了搭话方式，立即启动定时器
-        if (S.proactiveChatEnabled && (S.proactiveVisionChatEnabled || S.proactiveNewsChatEnabled || S.proactiveVideoChatEnabled || S.proactivePersonalChatEnabled || S.proactiveMusicEnabled || S.proactiveMemeEnabled)) {
+        if (S.proactiveChatEnabled && (S.proactiveVisionChatEnabled || S.proactiveNewsChatEnabled || S.proactiveVideoChatEnabled || S.proactivePersonalChatEnabled || S.proactiveMusicEnabled || S.proactiveMemeEnabled || S.proactiveMiniGameInviteEnabled)) {
             // 主动搭话启动自检
             console.log('========== 主动搭话启动自检 ==========');
             console.log('[自检] proactiveChatEnabled: ' + S.proactiveChatEnabled);
@@ -555,6 +563,7 @@
             console.log('[自检] proactivePersonalChatEnabled: ' + S.proactivePersonalChatEnabled);
             console.log('[自检] proactiveMusicEnabled: ' + S.proactiveMusicEnabled);
             console.log('[自检] proactiveMemeEnabled: ' + S.proactiveMemeEnabled);
+            console.log('[自检] proactiveMiniGameInviteEnabled: ' + S.proactiveMiniGameInviteEnabled);
             console.log('[自检] localStorage设置: ' + (localStorage.getItem('project_neko_settings') ? '已存在' : '不存在'));
 
             // 检查WebSocket连接状态
@@ -570,7 +579,7 @@
         } else {
             console.log('[App] 主动搭话未满足启动条件，跳过调度器启动:');
             console.log('  - proactiveChatEnabled: ' + S.proactiveChatEnabled);
-            console.log('  - 任意搭话模式启用: ' + (S.proactiveVisionChatEnabled || S.proactiveNewsChatEnabled || S.proactiveVideoChatEnabled || S.proactivePersonalChatEnabled || S.proactiveMusicEnabled));
+            console.log('  - 任意搭话模式启用: ' + (S.proactiveVisionChatEnabled || S.proactiveNewsChatEnabled || S.proactiveVideoChatEnabled || S.proactivePersonalChatEnabled || S.proactiveMusicEnabled || S.proactiveMemeEnabled || S.proactiveMiniGameInviteEnabled));
         }
 
         // 所有步骤完成后，最后才设置初始化成功的标志

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -134,6 +134,7 @@
         proactivePersonalChatEnabled: false,
         proactiveMusicEnabled: true,
         proactiveMemeEnabled: true,
+        proactiveMiniGameInviteEnabled: true,
         mergeMessagesEnabled: false,
         proactiveChatTimer: null,
         proactiveChatBackoffLevel: 0,
@@ -193,7 +194,8 @@
     const proactiveKeys = [
         'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
         'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
-        'proactiveMusicEnabled', 'proactiveMemeEnabled', 'mergeMessagesEnabled', 'focusModeEnabled',
+        'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
+        'mergeMessagesEnabled', 'focusModeEnabled',
         'proactiveChatInterval', 'proactiveVisionInterval', 'avatarReactionBubbleEnabled',
         'renderQuality', 'targetFrameRate', 'isRecording',
     ];

--- a/static/avatar-ui-drag.js
+++ b/static/avatar-ui-drag.js
@@ -547,6 +547,12 @@ window.CHAT_MODE_CONFIG = [
         labelKey: 'settings.toggles.proactiveMemeChat',
         tooltipKey: 'settings.toggles.proactiveMemeChatTooltip',
         globalVarName: 'proactiveMemeEnabled'
+    },
+    {
+        mode: 'mini_game',
+        labelKey: 'settings.toggles.proactiveMiniGameInviteChat',
+        tooltipKey: 'settings.toggles.proactiveMiniGameInviteChatTooltip',
+        globalVarName: 'proactiveMiniGameInviteEnabled'
     }
 ];
 

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "Use recommended music for proactive chat",
             "proactiveMemeChat": "Meme Sharing",
             "proactiveMemeChatTooltip": "Share funny memes for proactive chat",
+            "proactiveMiniGameInviteChat": "Mini-game Invites",
+            "proactiveMiniGameInviteChatTooltip": "Invite you to play a mini-game when conditions are right",
             "agentMaster": "NekoClaw Master Switch",
             "keyboardControl": "Keyboard/Mouse Control",
             "userPlugin": "User Plugin",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "Utilice música recomendada para un chat proactivo",
             "proactiveMemeChat": "Compartir memes",
             "proactiveMemeChatTooltip": "Comparte memes divertidos para un chat proactivo",
+            "proactiveMiniGameInviteChat": "Invitaciones a minijuegos",
+            "proactiveMiniGameInviteChatTooltip": "Invitarte a un minijuego cuando se cumplan las condiciones",
             "agentMaster": "Interruptor maestro NekoClaw",
             "keyboardControl": "Control de teclado/ratón",
             "userPlugin": "Complemento de usuario",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "おすすめの音楽を提案しながら話しかける",
             "proactiveMemeChat": "ミーム共有",
             "proactiveMemeChatTooltip": "面白いミームを共有して話しかける",
+            "proactiveMiniGameInviteChat": "ミニゲームへのお誘い",
+            "proactiveMiniGameInviteChatTooltip": "条件が整ったときミニゲームに誘って話しかける",
             "agentMaster": "ネコクローマスタースイッチ",
             "keyboardControl": "キーボード/マウス操作",
             "userPlugin": "ユーザープラグイン",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "추천 음악을 사용하여 채팅",
             "proactiveMemeChat": "밈 공유",
             "proactiveMemeChatTooltip": "재미있는 밈을 공유하여 채팅",
+            "proactiveMiniGameInviteChat": "미니게임 초대",
+            "proactiveMiniGameInviteChatTooltip": "조건이 맞을 때 미니게임에 초대하여 말걸기",
             "agentMaster": "네코클로 마스터 스위치",
             "keyboardControl": "키보드/마우스 제어",
             "userPlugin": "사용자 플러그인",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "Use músicas recomendadas para bate-papo proativo",
             "proactiveMemeChat": "Compartilhamento de memes",
             "proactiveMemeChatTooltip": "Compartilhe memes engraçados para um bate-papo proativo",
+            "proactiveMiniGameInviteChat": "Convites para minijogos",
+            "proactiveMiniGameInviteChatTooltip": "Convidar você para um minijogo quando as condições forem ideais",
             "agentMaster": "Interruptor mestre NekoClaw",
             "keyboardControl": "Controle de teclado/mouse",
             "userPlugin": "Plug-in do usuário",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "Использовать рекомендуемую музыку для проактивного чата",
             "proactiveMemeChat": "Мемы",
             "proactiveMemeChatTooltip": "Делиться смешными мемами для проактивного чата",
+            "proactiveMiniGameInviteChat": "Приглашения в мини-игры",
+            "proactiveMiniGameInviteChatTooltip": "Приглашать тебя в мини-игру, когда подходящие условия",
             "agentMaster": "Главный переключатель Лапки Неко",
             "keyboardControl": "Управление клавиатурой/мышью",
             "userPlugin": "Пользовательский плагин",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2295,7 +2295,7 @@
             "proactiveMemeChat": "Мемы",
             "proactiveMemeChatTooltip": "Делиться смешными мемами для проактивного чата",
             "proactiveMiniGameInviteChat": "Приглашения в мини-игры",
-            "proactiveMiniGameInviteChatTooltip": "Приглашать тебя в мини-игру, когда подходящие условия",
+            "proactiveMiniGameInviteChatTooltip": "Приглашать тебя в мини-игру, когда складываются подходящие условия",
             "agentMaster": "Главный переключатель Лапки Неко",
             "keyboardControl": "Управление клавиатурой/мышью",
             "userPlugin": "Пользовательский плагин",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "使用推荐音乐进行搭话",
             "proactiveMemeChat": "表情包分享",
             "proactiveMemeChatTooltip": "使用有趣表情包进行搭话",
+            "proactiveMiniGameInviteChat": "小游戏邀请",
+            "proactiveMiniGameInviteChatTooltip": "符合条件时邀请你一起玩小游戏",
             "agentMaster": "猫爪总开关",
             "keyboardControl": "键鼠控制",
             "userPlugin": "用户插件",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2294,6 +2294,8 @@
             "proactiveMusicChatTooltip": "使用推薦音樂進行搭話",
             "proactiveMemeChat": "表情包分享",
             "proactiveMemeChatTooltip": "使用有趣表情包進行搭話",
+            "proactiveMiniGameInviteChat": "小遊戲邀請",
+            "proactiveMiniGameInviteChatTooltip": "符合條件時邀請你一起玩小遊戲",
             "agentMaster": "貓爪總開關",
             "keyboardControl": "鍵鼠控製",
             "userPlugin": "用戶插件",

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -70,15 +70,23 @@ def _clear_mini_game_state():
 
 @pytest.fixture(autouse=True)
 def _force_invite_enabled_default(monkeypatch):
-    """每个 test 默认强制 MINI_GAME_INVITE_ENABLED=True。
+    """每个 test 默认强制 MINI_GAME_INVITE_ENABLED=True、调试 force-game-type
+    flag=None。
 
-    本测试套件大部分用例都假定 invite 通道开着、然后验证某条 gate 是否生效。
-    如果哪天 module 默认值被翻成 False（例如灰度阶段），这些 deliver / gate
-    测试都会静默退化成「ENABLED 短路全部命中」，无法捕获真正的 gate 退化。
+    - ENABLED=True：本测试套件大部分用例都假定 invite 通道开着、然后验证某条
+      gate 是否生效。如果哪天 module 默认值被翻成 False（例如灰度阶段），这些
+      deliver / gate 测试都会静默退化成「ENABLED 短路全部命中」，无法捕获真正
+      的 gate 退化。
+    - FORCE_GAME_TYPE=None：开发者本地手测时常把 ``MINI_GAME_INVITE_FORCE_
+      GAME_TYPE`` 翻成 'soccer'（设计就是 dev override），未 reset 时会让所有
+      gate 测试都被旗标短路，导致 cooldown / dice-miss / propensity 等用例假
+      性失败。autouse 拉回 None 让 gate 路径在测试里始终 deterministic。
+
     autouse 把契约前置：测试断言「此通道开着且 X gate 生效」，要测 disabled
-    分支的用例（test_maybe_deliver_returns_none_when_disabled）自己 setattr
-    回 False。"""
+    分支的用例（test_maybe_deliver_returns_none_when_disabled）或 force-game
+    分支自己 setattr 回 False / 'soccer'。"""
     monkeypatch.setattr(sr, 'MINI_GAME_INVITE_ENABLED', True)
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_FORCE_GAME_TYPE', None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -400,6 +400,85 @@ async def test_maybe_deliver_returns_none_when_dice_misses(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_maybe_deliver_returns_none_when_user_toggle_disabled(monkeypatch):
+    """用户在前端 CHAT_MODE_CONFIG 关掉了 mini-game 邀请开关 →
+    `_maybe_deliver_mini_game_invite(user_toggle_enabled=False)` 即使其它 gate
+    全过、骰子必中也不投递。这是 PR 的核心契约，对偶其它 source 的可独立 toggle。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+        user_toggle_enabled=False,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_deliver_user_toggle_default_true_keeps_bc(monkeypatch):
+    """旧客户端不发 ``mini_game_invite_enabled`` 字段 → caller 传 default=True →
+    fall through 到原 eligibility 路径不退化。pin 默认值契约。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 1.0)
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(sid='sid-bc'),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+        # 故意不传 user_toggle_enabled，让 default 生效
+    )
+    assert out is not None
+    assert out["action"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_force_game_type_overrides_all_gates(monkeypatch):
+    """``MINI_GAME_INVITE_FORCE_GAME_TYPE='soccer'`` 时，即使 user_toggle 关、
+    snapshot 是 None、cooldown 在期内、骰子必失，也强制走邀请投递。
+    仅 ``MINI_GAME_INVITE_ENABLED=False`` 才能拦住。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_FORCE_GAME_TYPE', 'soccer')
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 0.0)
+    sr._mini_game_invite_record_delivered(LANLAN, "stale-session")
+    mgr = _make_mgr(sid='sid-forced')
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=mgr,
+        activity_snapshot=None,
+        invite_lang='zh', master_name=MASTER,
+        user_toggle_enabled=False,
+    )
+    assert out is not None
+    assert out["action"] == "chat"
+    assert out.get("game_type") == 'soccer'
+
+
+@pytest.mark.asyncio
+async def test_force_game_type_invalid_value_warns_and_skips(monkeypatch):
+    """旗标设成 ``MINI_GAME_INVITE_LINES_BY_GAME`` 里没有的 key → warn + 返 None
+    而不是 raise；保证配置抖动不带挂 proactive 流水线。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_FORCE_GAME_TYPE', 'definitely_not_a_game')
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+        user_toggle_enabled=True,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_force_game_type_still_respects_global_kill_switch(monkeypatch):
+    """``MINI_GAME_INVITE_ENABLED=False`` + 调试旗标都开 → 总开关 wins。
+    pin "总开关是终极 kill switch" 契约。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_ENABLED', False)
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_FORCE_GAME_TYPE', 'soccer')
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=_make_snapshot(),
+        invite_lang='zh', master_name=MASTER,
+        user_toggle_enabled=True,
+    )
+    assert out is None
+
+
+@pytest.mark.asyncio
 async def test_maybe_deliver_chat_when_eligible(monkeypatch):
     """全部 eligibility 通过 + 必中骰子 → 走 prepare → feed_tts → finish 投递；
     state 翻成 pending；写入 _proactive_chat_history。"""

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -310,7 +310,8 @@ GLOBAL_CONVERSATION_KEY = "__global_conversation__"
 _ALLOWED_CONVERSATION_SETTINGS = {
     'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
     'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
-    'proactiveMusicEnabled', 'proactiveMemeEnabled', 'mergeMessagesEnabled', 'focusModeEnabled',
+    'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
+    'mergeMessagesEnabled', 'focusModeEnabled',
     'avatarReactionBubbleEnabled',
     'proactiveChatInterval', 'proactiveVisionInterval', 'subtitleEnabled', 'userLanguage',
     'textGuardMaxLength', 'noiseReductionEnabled'
@@ -416,7 +417,8 @@ def save_global_conversation_settings(settings: Dict[str, Any]) -> bool:
         _BOOL_FIELDS = {
             'proactiveChatEnabled', 'proactiveVisionEnabled', 'proactiveVisionChatEnabled',
             'proactiveNewsChatEnabled', 'proactiveVideoChatEnabled', 'proactivePersonalChatEnabled',
-            'proactiveMusicEnabled', 'proactiveMemeEnabled', 'mergeMessagesEnabled', 'focusModeEnabled',
+            'proactiveMusicEnabled', 'proactiveMemeEnabled', 'proactiveMiniGameInviteEnabled',
+            'mergeMessagesEnabled', 'focusModeEnabled',
             'avatarReactionBubbleEnabled', 'subtitleEnabled', 'noiseReductionEnabled'
         }
         _INT_INTERVAL_FIELDS = {'proactiveChatInterval', 'proactiveVisionInterval'}


### PR DESCRIPTION
PR #1145 之后两件事：补齐 mini-game 邀请与其它 proactive source 的 UI 对称性，
和加一个本地手测 force-game-type 旗标。

## 1. CHAT_MODE_CONFIG 加 mini_game 条目（用户级 toggle）

之前 mini-game 邀请跟其它 source（vision / news / video / personal / music /
meme）不对称——其它都能在 avatar-ui-popup proactive 侧边栏独立 toggle on/off，
mini-game 完全后端 hardcoded（过完 enabled_modes 解析后独立掷骰，不读 toggle）。

| 层 | 改动 |
|---|---|
| ``static/avatar-ui-drag.js`` | CHAT_MODE_CONFIG 新增 ``{ mode: 'mini_game', globalVarName: 'proactiveMiniGameInviteEnabled', labelKey/tooltipKey }`` |
| ``static/app-state.js`` | 默认 ``proactiveMiniGameInviteEnabled: true`` + 加进 ``proactiveKeys`` 双向绑定列表 |
| ``static/app-settings.js`` | getConversationSettings + saveSettings 读写 + loadSettings ``?? true`` 默认 + 首次启动默认 + 自检 console.log |
| ``static/app-proactive.js`` | ``hasAnyChatModeEnabled`` / ``canTriggerProactively`` 三处 standalone 单选检查并入；request body 加独立字段 ``mini_game_invite_enabled``（不进 ``enabled_modes`` 数组——它不是 source）；availableModes 为空但 toggle 开着仍发请求让后端短路通道掷骰 |
| ``utils/preferences.py`` | 加进 ``_ALLOWED_CONVERSATION_SETTINGS`` + ``_BOOL_FIELDS`` 白名单 |
| 8 locale json | ``proactiveMiniGameInviteChat`` + ``…Tooltip`` 全覆盖（``check_i18n.py`` 0 missing） |
| ``main_routers/system_router.py`` | ``_maybe_deliver_mini_game_invite`` 新参 ``user_toggle_enabled: bool = True``；caller 从 ``data.get('mini_game_invite_enabled', True)`` 读取，BC 默认 True 兼容旧客户端 |

## 2. MINI_GAME_INVITE_FORCE_GAME_TYPE 调试旗标

``config/__init__.py`` 加 ``MINI_GAME_INVITE_FORCE_GAME_TYPE: str | None = None``。
非 None 时 ``_maybe_deliver_mini_game_invite`` 跳过 user toggle / snapshot None
/ propensity / away / unfinished_thread / cooldown / probability / force-first
全部 gate，把 ``game_type`` 钉到旗标值；唯一拦得住的是全局 ``MINI_GAME_INVITE_
ENABLED=False`` kill switch。

非法 key warn + skip 不 raise——避免配置抖动带挂 proactive 流水线。生产保持
None；本地手测三 context UI 时设成 'soccer' 即可不等 force-first 凑齐 N-1 次
也不需调 cooldown。

## 关键设计选择

- **toggle 走独立字段、不进 enabled_modes**：后者是 source 列表（用于源选取
  / 内容抓取），mini-game 邀请是独立短路通道，混入会污染语义。前端 fetch
  body 加 ``mini_game_invite_enabled: bool``，后端 gate 单独读
- **空 availableModes 仍发请求 if mini_game on**：让用户能"只开 mini-game
  邀请、关其它 source"——availableModes=[] 时本来直接 return，现在 toggle
  开着就让请求过去走后端短路通道
- **调试旗标只让 ENABLED 总开关 wins**：旗标 + ENABLED=False 测试 pin
  契约（kill switch 永远在最上游），避免未来误把 ENABLED 砍掉、旗标变成
  prod 后门
- **BC 默认 True**：旧客户端不发 ``mini_game_invite_enabled`` 字段时维持
  现有行为（per-PR #1145 用户已经体验到的语义），不静默退化

## Test plan

- [x] ``uv run pytest tests/unit/test_mini_game_invite.py`` —— **82 passed**
  （6 新 + 76 baseline）
- [x] 联跑 ``-k \"proactive or mini_game\"`` —— **231 passed**，无回归
- [x] ``scripts/check_i18n.py`` —— 8 locales total 3308 keys 0 missing
- [x] ``scripts/check_i18n_sync.py`` —— exit 0
- [x] ``scripts/check_prompt_hygiene.py`` —— 我的改动 clean
- [ ] **手测三 context** ([feedback_chat_three_contexts](https://github.com/Project-N-E-K-O/N.E.K.O/issues/?) 必须)：index.html 宽屏 / 移动端窄屏 / chat.html Electron multi-window 三条路径——
  - 验证新 toggle 在 sidebar 渲染、labelKey/tooltipKey 切语言
  - toggle 关时后端不再投递 mini-game 邀请（user_toggle_enabled=False 早 return）
  - 设 ``MINI_GAME_INVITE_FORCE_GAME_TYPE = 'soccer'`` 后每次合格 proactive 必出邀请

## Out of scope

- 修 ``getConversationSettings()`` 漏写 ``proactiveMemeEnabled`` 的历史 bug
  （明显但与本 PR 无关，单独 PR 处理）
- 把 ``MINI_GAME_INVITE_FORCE_GAME_TYPE`` 暴露给前端 debug toggle（当前仅
  config 改值；Electron / dev 环境 hot-reload 即可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在设置中新增“小游戏邀请”开关，允许启用/禁用主动小游戏邀请并纳入主动搭话模式选项。
  * 前端调度与触发流程支持仅由小游戏邀请触发的调度路径；请求体包含相应开关信息以保持兼容。
  * 添加多语言界面文本（英/西/日/韩/葡/俄/简繁中）。

* **测试**
  * 新增单元测试覆盖小游戏邀请逻辑、用户开关行为及开发调试强制触发场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->