### PR TITLE
fix(proactive): 邀请文案/Phase 1-2 LLM 跟 session locale + soccer loading-text 居中

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2301,6 +2301,38 @@ def _pick_mini_game_type() -> str | None:
     return _random.choice(candidates)
 
 
+def _resolve_proactive_locale(data: dict, mgr) -> str:
+    """主动搭话路径解析"用户当前 locale"的统一入口（短码 zh / en / ja / ko / ru / es / pt）。
+
+    proactive_chat 路径解 locale 历来三层兜底，但前两层之前漏了 session 真值：
+
+      1. request body 显式 ``language`` / ``lang`` / ``i18n_language`` —— 前端请求可
+         以一锤定音，最高优先。
+      2. ``mgr.user_language`` —— websocket 建连时由前端 i18n 推上来（见
+         ``main_routers/websocket_router.py`` 处理 ``message['language']`` 的分支），
+         in-game / Phase 2 LLM 都已在用，proactive 早先没接，导致 Steam SDK 在后端
+         启动时拿不到值就一直缓存系统 locale。
+      3. ``get_global_language()`` —— 进程级缓存，从 Steam SDK / 系统 locale 读一次。
+         Steam SDK 启动期 race 失败（schinese 没拿到）就退化为系统 locale，前后端
+         看到不同结果（前端异步 ``/api/config/steam_language`` 端点重读，能拿到对的
+         schinese → zh）。在 Steam=zh / 系统=en 的场景下尤其明显。
+
+    把 session 真值塞进第二层，proactive 邀请文案 / Phase 1-2 LLM 输出语言都跟在线
+    会话保持一致；仅在没有任何 session 上下文时才退到全局缓存。
+    """
+    request_lang = data.get('language') or data.get('lang') or data.get('i18n_language')
+    if request_lang:
+        normalized = normalize_language_code(request_lang, format='short')
+        if normalized:
+            return normalized
+    session_lang = getattr(mgr, 'user_language', None)
+    if session_lang:
+        normalized = normalize_language_code(session_lang, format='short')
+        if normalized:
+            return normalized
+    return get_global_language() or 'zh'
+
+
 async def _maybe_deliver_mini_game_invite(
     *,
     lanlan_name: str,
@@ -4342,13 +4374,7 @@ async def proactive_chat(request: Request):
         # 不再掷骰。activity_snapshot is None（隐私模式 / tracker 不可用）保守
         # 不发——无法判断是否在工作状态。
         try:
-            _request_lang_for_invite = (
-                data.get('language') or data.get('lang') or data.get('i18n_language')
-            )
-            invite_lang = (
-                normalize_language_code(_request_lang_for_invite, format='short')
-                if _request_lang_for_invite else get_global_language()
-            )
+            invite_lang = _resolve_proactive_locale(data, mgr)
         except Exception:
             invite_lang = 'zh'
         # 用户级 toggle：前端 CHAT_MODE_CONFIG 里的 ``proactiveMiniGameInviteEnabled``
@@ -4580,12 +4606,10 @@ async def proactive_chat(request: Request):
             return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_memory")))
 
         # ========== 2. 选择语言 ==========
+        # 与 mini-game 邀请短路同源：request body → mgr.user_language → 全局缓存。
+        # 见 _resolve_proactive_locale 的 docstring。
         try:
-            request_lang = data.get('language') or data.get('lang') or data.get('i18n_language')
-            if request_lang:
-                proactive_lang = normalize_language_code(request_lang, format='short')
-            else:
-                proactive_lang = get_global_language()
+            proactive_lang = _resolve_proactive_locale(data, mgr)
         except Exception:
             proactive_lang = 'zh'
         

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -708,6 +708,23 @@
             console.log('主动搭话：启用模式 [' + availableModes.join(', ') + ']，将并行获取所有信息源');
 
             var lanlanName = (window.lanlan_config && window.lanlan_config.lanlan_name) || '';
+            // 当前 UI locale —— 让后端 mini-game 邀请短路 + Phase 1/2 LLM 与
+            // 前端 i18n 显示完全对齐，不再依赖后端 ``get_global_language()``
+            // 的进程级缓存（Steam SDK 启动期 race 失败时会退化到系统 locale，
+            // Steam=中文 / 系统=英文 的用户会看到邀请文案是英文）。后端
+            // ``_resolve_proactive_locale`` 优先读这个字段，缺时再回落到
+            // ``mgr.user_language`` / 全局缓存。
+            var i18nLanguage = '';
+            try {
+                if (window.i18next && typeof window.i18next.language === 'string') {
+                    i18nLanguage = window.i18next.language;
+                } else if (typeof localStorage !== 'undefined') {
+                    i18nLanguage = localStorage.getItem('i18nextLng') || '';
+                }
+                if (!i18nLanguage && typeof navigator !== 'undefined' && typeof navigator.language === 'string') {
+                    i18nLanguage = navigator.language;
+                }
+            } catch (_) { i18nLanguage = ''; }
             var requestBody = {
                 lanlan_name: lanlanName,
                 enabled_modes: availableModes,
@@ -716,7 +733,8 @@
                 music_cooldown: (typeof window.isMusicCooldown === 'function') ? window.isMusicCooldown() : false,
                 // mini-game 邀请的用户级 toggle；后端 _maybe_deliver_mini_game_invite
                 // 与 source-driven sources 解耦，不进 enabled_modes 数组。
-                mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled
+                mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled,
+                i18n_language: i18nLanguage
             };
 
             // 独立计时器：确保 vision/window 模式的屏幕感知间隔不低于 proactiveVisionInterval

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -182,7 +182,10 @@
   }
   #loading-spinner[hidden],
   #loading-actions[hidden] { display: none; }
-  #loading-text { min-width: 180px; }
+  /* min-width 防止 spinner 隐藏前后整行宽度抖动；text-align: center 让短文案
+     （"模型加载完成"等 4-6 字状态串）在 180px 槽位内视觉居中——之前缺这条所以
+     文字落在槽位左侧、偏离 panel 中心约 50px。 */
+  #loading-text { min-width: 180px; text-align: center; }
   #soccer-start-button {
     min-width: 112px;
     padding: 8px 18px;


### PR DESCRIPTION
PR #1149 follow-up：用户报告 Steam=中文 / 系统=英文 时 mini-game 邀请文案是英文（``Want to play a quick round of...``），而 in-game 台词、前端 UI 都是中文。

## 1. proactive_chat locale 三层兜底接上 session 真值

**root cause**：``proactive_chat`` 路径解 locale 直接从 ``get_global_language()`` 拿。后者在 main_server 启动时调一次 ``_get_steam_language()`` 就缓存终生不变（``utils/language_utils.py:204-240``），Steam SDK 启动期没就绪/调用失败就退化到系统 locale，整个进程之后都是英文。

而**前端**通过 ``/api/config/steam_language`` 端点异步重读 Steam SDK，能拿到正确的 ``schinese`` → ``zh``，所以 UI 中文；**in-game 台词**走 session 路径（``mgr.user_language``，由 websocket 建连时 frontend i18n 通过 ``message['language']`` 字段推上来——见 ``main_routers/websocket_router.py:120-121``、``main_logic/core.py:5465``），也是中文。**proactive 这条线之前没接 session 真值**，所以孤零零地用错的全局缓存——既影响 mini-game 邀请短路的静态模板（``MINI_GAME_INVITE_LINES_BY_GAME``），也影响 Phase 1/2 LLM 的输出语言。

**修法**：抽 ``_resolve_proactive_locale(data, mgr)`` 三层兜底：

1. request body ``language`` / ``lang`` / ``i18n_language``（前端显式传）
2. ``mgr.user_language``（websocket 已经同步的 session 真值）
3. ``get_global_language()``（进程级缓存兜底）

替换 mini-game 邀请短路 + Phase 2 选择语言两处旧代码。

配套 ``static/app-proactive.js`` requestBody 加 ``i18n_language`` 字段（``window.i18next.language`` → ``localStorage 'i18nextLng'`` → ``navigator.language`` 三级兜底），让 (1) 路径也命中而不是只靠 (2) 。两个修法对偶——前端显式传是 wire 上明摆着的真值；后端 session 兜底是 wire 漏传时的安全网，配合后任一步坏了仍有备份。

## 2. soccer loading-text 文字偏左

PR #1149 把 ``#loading-text`` 接进 i18n 后，多语言短文案（``"模型加载完成"``、``"VRM ready"`` 等 4-6 字串）在 180px 槽位里走默认 ``text-align: start`` 落在槽位左侧，视觉中心偏离 panel 中心约 48px。``min-width: 180px`` 是为防 spinner 隐藏前后行宽抖动而设——保留之，加 ``text-align: center``。

用 preview_eval 实测：修前 ``glyphsCenterX=592`` / ``panelCenterX=640``（delta=-48px），修后两者均为 640（delta=0）。

## 范围之外（与本 PR 无关，已与用户对齐）

用户同时反映：当前角色是 VRM 时足球游戏 AI 还是加载 Live2D（fallback 到 mao_pro）。这是已知设计限制（``main_routers/game_router.py:5283`` docstring 已注），soccer demo AI 侧目前只支持 Live2D；本 PR 不动。

## Test plan

- [x] ``uv run pytest tests/unit/test_mini_game_invite.py tests/unit/test_proactive_sm_integration.py`` —— 92 passed
- [x] ``scripts/check_i18n.py`` —— exit 0
- [x] ``_resolve_proactive_locale`` 6 case smoke：req body 优先 / mgr 兜底 / 全局兜底 / 空字符串穿透到 mgr 都正确
- [x] preview_eval 量 loading-text 几何：修前 delta=-48px、修后 delta=0
- [ ] **手测**（per ``feedback_chat_three_contexts``）：Steam=zh / 系统=en 设置下，mini-game 邀请文案是中文；soccer demo 进入流程"模型加载完成"等状态串视觉居中。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 优化加载界面样式，确保状态信息显示稳定居中。

* **优化改进**
  * 增强语言和地区设置检测机制，支持多级别的语言配置识别。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->