### PR TITLE
feat(proactive): mini-game UI 联动收尾（galgame 互斥 + 默认难度 + 游戏期 chat/pet 联动）

### DIFF
--- a/config/prompts_game.py
+++ b/config/prompts_game.py
@@ -138,7 +138,7 @@ SOCCER_PREGAME_CONTEXT_PROMPT = """\
 决策规则：
 - 证据不足时，gameStance 必须是 neutral_play。
 - neutral_play 表示普通陪玩，不是关系修复，不是惩罚局。
-- neutral_play 的默认难度应当是 lv2 或 lv3；不要用 max。
+- neutral_play 的默认难度是 lv2；想轻一档放水可用 lv3，不要用 max。
 - punishing 才能在开局直接 max，但必须有近期记录中的强证据支持。
 - 生气 + max 难度下，默认普通能力 NEKO 基本不可能被多次得分；不要把“玩家多次得分”当作常规哄好条件。
 - 低落/自闭时，玩家专注陪 NEKO 玩本身可以轻微缓解；即使双方都没进球，也可视为陪伴证据。
@@ -446,7 +446,7 @@ Constraints:
 Decision rules:
 - With insufficient evidence, gameStance must be neutral_play.
 - neutral_play means ordinary play, not relationship repair or punishment.
-- neutral_play should default to lv2 or lv3, not max.
+- neutral_play should default to lv2; lv3 is fine if you want one notch softer; do not use max.
 - Only punishing may start directly at max, and it requires strong evidence in recent history.
 - In angry + max difficulty, a normal NEKO should not be easy for the player to score against repeatedly; do not treat "player scored many times" as the standard calming condition.
 - When NEKO is low or withdrawn, the player's focused companionship in the game may slightly soften her even without goals.
@@ -495,7 +495,7 @@ _SOCCER_PREGAME_CONTEXT_PROMPT_JA = """\
 判断ルール：
 - 証拠不足なら gameStance は必ず neutral_play。
 - neutral_play は普通の陪玩であり、関係修復でも罰ゲームでもない。
-- neutral_play の初期難易度は lv2 または lv3。max は使わない。
+- neutral_play の初期難易度は lv2。一段階手加減したいなら lv3 も可。max は使わない。
 - punishing の時だけ開局 max が可能で、最近の記録に強い証拠が必要。
 - 低落や引きこもり気味の時、プレイヤーが集中して一緒に遊ぶこと自体が少し和らげる証拠になる。
 - 楽しい/普通の開局でも局内対話で不満に傾くことはある。これは関係修復失敗ではない。
@@ -543,7 +543,7 @@ _SOCCER_PREGAME_CONTEXT_PROMPT_KO = """\
 판단 규칙:
 - 증거가 부족하면 gameStance 는 반드시 neutral_play.
 - neutral_play 는 일반적인 함께 놀기이며 관계 회복이나 처벌이 아닙니다.
-- neutral_play 기본 난이도는 lv2 또는 lv3 이며 max 를 쓰지 않습니다.
+- neutral_play 기본 난이도는 lv2 입니다. 한 단계 더 봐주고 싶다면 lv3 도 가능하며 max 는 쓰지 않습니다.
 - punishing 만 시작부터 max 가 가능하며 최근 기록의 강한 증거가 필요합니다.
 - NEKO 가 우울하거나 위축되어 있을 때, 플레이어가 집중해서 함께 놀아주는 것 자체가 약한 완화 증거가 될 수 있습니다.
 - 즐겁거나 평범한 시작도 게임 중 상호작용으로 불만 쪽으로 기울 수 있습니다. 이는 관계 회복 실패가 아닙니다.
@@ -591,7 +591,7 @@ _SOCCER_PREGAME_CONTEXT_PROMPT_RU = """\
 Правила решений:
 - Если доказательств недостаточно, gameStance обязан быть neutral_play.
 - neutral_play означает обычную совместную игру, не восстановление отношений и не наказание.
-- Для neutral_play начальная сложность должна быть lv2 или lv3, не max.
+- Для neutral_play начальная сложность должна быть lv2; lv3 допустим, если хочешь поддаться на одну ступень больше; max не используй.
 - Только punishing может начинать сразу с max, и для этого нужны сильные доказательства в недавней истории.
 - Если NEKO подавлена или замкнута, сосредоточенное совместное участие игрока в игре может слегка смягчить ее даже без голов.
 - Радостное или обычное начало может в процессе игры перейти к недовольству; это не провал восстановления отношений.

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -678,10 +678,17 @@ export default function App({
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
   const resolvedTranslateAriaLabel = translateButtonAriaLabel || translateButtonLabel;
   const resolvedGalgameAriaLabel = galgameToggleButtonAriaLabel || galgameToggleButtonLabel;
+  // ChoicePrompt（mini-game invite 等）和 galgame options 共用 composer 底部
+  // 同一块 slot 视觉位。两者同时活跃会渲染出 6 个按钮挤一起；invite 是少见
+  // 且需要用户即时响应的 transient event，galgame options 是常驻 mode →
+  // invite 优先，galgame slot 临时让位。invite resolve 后下一轮 assistant
+  // turn-end 会重新触发 galgame fetch，自然回归。
+  const choicePromptHasOptions = !!(choicePrompt && choicePrompt.options.length > 0);
   // 模式开启 ≠ 选项实际占位。光开开关、还没收到 AI 新一轮时 slot 不撑开；
   // 选项到位（loading 占位也算）才让 slot 长出来，输入壳跟着自然变高。
   const galgameOptionsVisible =
-    galgameModeEnabled && (galgameOptionsLoading || galgameOptions.length > 0);
+    galgameModeEnabled && !choicePromptHasOptions
+    && (galgameOptionsLoading || galgameOptions.length > 0);
   const emojiButtonAriaLabel = i18n('chat.emojiButtonAriaLabel', 'Emoji');
   const toolIconsAriaLabel = i18n('chat.toolIconsAriaLabel', 'Tool icons');
   const clearCursorToolAriaLabel = i18n('chat.clearCursorToolAriaLabel', '恢复鼠标');
@@ -1726,10 +1733,12 @@ export default function App({
                   }
                 }}
               />
-              {galgameModeEnabled ? (
+              {galgameModeEnabled && !choicePromptHasOptions ? (
                 // Slot 始终挂在树上，开/关靠 is-open（max-height + opacity 过渡）。
                 // 这样选项进/出时输入壳跟着自然长/缩，bottom-bar 锚在 panel 底
                 // 不动，textarea 顶端跟着 shell-top 上抬，视觉上是从下往上展开。
+                // mini-game invite 等 ChoicePrompt 占位时整块 slot 不挂树，避免
+                // 与下面 composer-choice-slot 视觉撞车（参见 choicePromptHasOptions）。
                 <div
                   className={`composer-galgame-slot${galgameOptionsVisible ? ' is-open' : ''}`}
                   aria-hidden={!galgameOptionsVisible}

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -4389,6 +4389,31 @@ async def game_route_state(game_type: str, lanlan_name: str = ""):
     return {"ok": True, "state": _public_route_state(state)}
 
 
+@router.get("/route/active")
+async def game_route_any_active(lanlan_name: str = ""):
+    """Bootstrap reconciliation endpoint：返回当前 lanlan_name 是否有任意活跃
+    game_route，给 chat.html / pet 等 game_window_state_change 事件订阅者用。
+
+    场景：edge-triggered 的 game_window_state_change WS 事件只在 activate /
+    finalize 那一瞬间推；订阅者初次加载（或 WS reconnect）时若 route 已经在
+    active，听不到历史 opened，UI 永远停在普通态。订阅者在 init 路径调本
+    endpoint，发现 active 就自己 dispatch 一次 opened DOM 事件，UI 与后端
+    state 对齐。codex P1。
+
+    单 GET、参数仅 lanlan_name、无副作用——不需要 CSRF 防护。"""
+    resolved = _resolve_lanlan_name(lanlan_name)
+    state = _get_active_game_route_state(resolved) if resolved else None
+    if state is None:
+        return {"ok": True, "active": False}
+    return {
+        "ok": True,
+        "active": True,
+        "game_type": str(state.get("game_type") or ""),
+        "session_id": str(state.get("session_id") or ""),
+        "lanlan_name": str(state.get("lanlan_name") or ""),
+    }
+
+
 @router.post("/{game_type}/route/drain")
 async def game_route_drain(game_type: str, request: Request):
     """Drain backend outputs caused by hijacked main-window input for the game page."""

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -4335,14 +4335,28 @@ async def game_route_start(game_type: str, request: Request):
     # 还原。注意：要在 supersede + activate 锁外推送，避免阻塞锁；soccer
     # pregame 上下文构建可能耗几秒，那段期间前端已经看到游戏窗口在加载，
     # 越早收缩越平滑——所以放在 pregame build 之前。
+    #
+    # 锁外 stale-opened 防护（codex P1）：start 释放锁后到 push 之间，并发的
+    # /route/end 或新 /route/start supersede 可能已把 state.game_route_active
+    # 翻 false 并推过 closed。如果不 recheck，stale opened 会在 closed 后 land，
+    # 让前端 UI 卡死收缩态再无 closed 抵消。recheck state 自身的 active 标志 +
+    # session_id 双重匹配（防 state 字典里同 (lanlan,game_type) key 已被新一轮
+    # supersede 替换为新 state）。
     mgr_for_ws = get_session_manager().get(lanlan_name)
-    await _push_game_window_state_change(
-        mgr_for_ws,
-        action="opened",
-        lanlan_name=lanlan_name,
-        game_type=game_type,
-        session_id=session_id,
-    )
+    if state.get("game_route_active") and str(state.get("session_id") or "") == session_id:
+        await _push_game_window_state_change(
+            mgr_for_ws,
+            action="opened",
+            lanlan_name=lanlan_name,
+            game_type=game_type,
+            session_id=session_id,
+        )
+    else:
+        logger.info(
+            "🎮 game_window_state_change=opened 跳过推送（route 已被 supersede / "
+            "end 抵消）: lanlan=%s game=%s session=%s",
+            lanlan_name, game_type, session_id,
+        )
     if game_type == "soccer":
         state["heartbeat_enabled"] = False
         try:

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -91,6 +91,55 @@ _SOCCER_QUICK_LINE_KEYS = {
 
 _DEFAULT_GAME_MEMORY_TAIL_COUNT = 6
 _MAX_GAME_MEMORY_TAIL_COUNT = 50
+
+
+async def _push_game_window_state_change(
+    mgr,
+    *,
+    action: str,
+    lanlan_name: str,
+    game_type: str,
+    session_id: str = "",
+) -> None:
+    """Broadcast 'game window opened/closed' WS event so chat.html / pet 多窗口
+    能联动收缩 / 还原（用户级 UX 联动，不参与任何 game-route 状态判定，单纯
+    驱动前端布局）。
+
+    单一事实源：``game_route_start`` 激活后推 ``opened``，
+    ``_finalize_game_route_state_inner`` 把 state 翻 inactive 之后推 ``closed``。
+    所有 finalize 路径（/route/end / heartbeat sweep / supersede）都走 inner，
+    覆盖率与 ``is_game_route_active`` 同步——前端不会出现"游戏已结束但 UI 仍
+    锁着收缩态"的孤岛。
+
+    多窗口转发依赖现有 ``WS_PROXY_CHANNELS.RAW_MESSAGE`` IPC（pet 主窗收 WS →
+    forwarder 转给 chat.html），与 mini_game_invite_resolved 走同一条总线，
+    无需新 IPC channel。
+    """
+    if not mgr or not lanlan_name:
+        return
+    payload: dict[str, Any] = {
+        "type": "game_window_state_change",
+        "action": action,
+        "lanlan_name": lanlan_name,
+        "game_type": game_type,
+    }
+    if session_id:
+        payload["session_id"] = session_id
+    try:
+        ws = getattr(mgr, "websocket", None)
+        if ws is None or not hasattr(ws, "send_json"):
+            return
+        client_state = getattr(ws, "client_state", None)
+        if client_state is not None and client_state != client_state.CONNECTED:
+            return
+        await ws.send_json(payload)
+    except Exception as exc:
+        logger.warning(
+            "game_window_state_change WS push failed (action=%s, game=%s, lanlan=%s): %s",
+            action, game_type, lanlan_name, exc,
+        )
+
+
 _DEFAULT_SOCCER_GAME_MEMORY_ENABLED = False
 _SOCCER_GAME_MEMORY_POLICY_FIELDS = (
     "soccer_game_memory_enabled",
@@ -3197,6 +3246,16 @@ async def _finalize_game_route_state_inner(
     state["heartbeat_enabled"] = False
     lanlan_name = str(state.get("lanlan_name") or "")
     mgr = get_session_manager().get(lanlan_name) if lanlan_name else None
+    # 推 closed 事件让前端还原 chat.html 折叠态 + 显回 pet 容器。所有 finalize
+    # 路径（/route/end / heartbeat sweep / supersede）都走本 inner，与 active
+    # flag 翻 false 同源，不会出现"已结束但 UI 仍锁着收缩态"的孤岛。
+    await _push_game_window_state_change(
+        mgr,
+        action="closed",
+        lanlan_name=lanlan_name,
+        game_type=str(state.get("game_type") or ""),
+        session_id=str(state.get("session_id") or ""),
+    )
     # Release the SessionManager-level takeover so ordinary chat handlers come
     # back online; chat LLM may produce auto-replies again, but the player has
     # exited the game so that's the desired behavior.
@@ -4270,6 +4329,20 @@ async def game_route_start(game_type: str, request: Request):
             state["nekoInitiated"] = neko_initiated
             state["nekoInviteText"] = neko_invite_text
             _update_route_start_state_from_payload(state, data)
+    # 推 WS 让多窗口前端联动收缩 chat.html（触发其内部 collapse 按钮态 + 移
+    # 至工作区左下角）+ 隐藏 pet (live2d/vrm/mmd) 容器。这只是 UX 联动事件，
+    # 不参与 game-route 状态判定；前端在 game_window_state_change=closed 时
+    # 还原。注意：要在 supersede + activate 锁外推送，避免阻塞锁；soccer
+    # pregame 上下文构建可能耗几秒，那段期间前端已经看到游戏窗口在加载，
+    # 越早收缩越平滑——所以放在 pregame build 之前。
+    mgr_for_ws = get_session_manager().get(lanlan_name)
+    await _push_game_window_state_change(
+        mgr_for_ws,
+        action="opened",
+        lanlan_name=lanlan_name,
+        game_type=game_type,
+        session_id=session_id,
+    )
     if game_type == "soccer":
         state["heartbeat_enabled"] = False
         try:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4252,14 +4252,29 @@ async def proactive_chat(request: Request):
                 action=_text_advance_outcome.get('action', 'suppress'),
             )
 
+        # 用户级 toggle：前端 CHAT_MODE_CONFIG 里的 ``proactiveMiniGameInviteEnabled``
+        # 通过 request body 的 ``mini_game_invite_enabled`` 字段透传。缺省 True 兼容
+        # 旧客户端。提到 _debug_force_invite 计算之前——把 user toggle 关同时
+        # 服务端开了调试旗标的场景下，下游早退 gate（closed / skip_probability）
+        # 也维持原有抑制语义；不能因为旗标开了就把 gate 一并 bypass 掉。
+        # CodeRabbit Major review 指出原版只在 _maybe_deliver_mini_game_invite
+        # 入口拦 user toggle，旗标已经把上游 gate 绕过 → 进 _maybe_deliver
+        # 又被 toggle 拦 None → caller 走普通 source picking，封禁场景仍然漏过。
+        _user_invite_toggle = bool(data.get('mini_game_invite_enabled', True))
+
         # 调试旗标 ``MINI_GAME_INVITE_FORCE_GAME_TYPE`` 非 None 时绕开本函数所有
         # 上游早退 gate（closed / skip_probability / restricted_screen_only），
         # 让 ``_maybe_deliver_mini_game_invite`` 能稳定接到本轮调用——契约是
         # "开启后主动搭话必定触发特定小游戏"。仅本地手测使用；生产
         # ``MINI_GAME_INVITE_ENABLED`` 总开关 + 旗标默认 None 双保险。
+        # 用户 toggle 关时旗标无效（与 _maybe_deliver_mini_game_invite 入口
+        # 的 toggle 检查同语义，单一事实源在前端 toggle）。
         # CodeRabbit Major 指出：这条不在 ``_maybe_deliver_mini_game_invite``
         # 内部加是因为那时已经过了上游 gate，旗标做不到"必定"。
-        _debug_force_invite = MINI_GAME_INVITE_FORCE_GAME_TYPE is not None
+        _debug_force_invite = (
+            MINI_GAME_INVITE_FORCE_GAME_TYPE is not None
+            and _user_invite_toggle
+        )
 
         # ========== Hard short-circuit: propensity=closed ==========
         # ``private`` state pins propensity to ``closed`` (see
@@ -4382,11 +4397,8 @@ async def proactive_chat(request: Request):
             invite_lang = _resolve_proactive_locale(data, mgr)
         except Exception:
             invite_lang = 'zh'
-        # 用户级 toggle：前端 CHAT_MODE_CONFIG 里的 ``proactiveMiniGameInviteEnabled``
-        # 通过 request body 的 ``mini_game_invite_enabled`` 字段透传。缺省 True 兼容
-        # 旧客户端（未携带该字段时维持现有行为）。MINI_GAME_INVITE_ENABLED 全局
-        # kill switch 仍是更上游的一道。
-        _user_invite_toggle = bool(data.get('mini_game_invite_enabled', True))
+        # _user_invite_toggle 已经在上面 _debug_force_invite 计算前算过——把
+        # toggle 关时旗标也连带禁用，保证早退 gate 不被绕过。
         invite_outcome = await _maybe_deliver_mini_game_invite(
             lanlan_name=lanlan_name,
             mgr=mgr,

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2375,12 +2375,17 @@ async def _maybe_deliver_mini_game_invite(
     if not MINI_GAME_INVITE_ENABLED:
         return None
 
-    # 调试旗标短路：非 None 时跳过所有用户/snapshot/cooldown/概率 gate，把 game_type
+    # 调试旗标短路：非 None 时跳过所有 snapshot/cooldown/概率 gate，把 game_type
     # 钉到旗标值上。仍然要求该 game_type 有对应文案；非法值 warn + 退出而不 raise，
     # 避免在配置抖动时把整个 proactive 流水线带挂。Force-first 标记成 True 让 caller
     # 路径与正常 first-time 邀请等价（不影响 ever_delivered 持久化）。
+    #
+    # 但用户级 toggle (proactiveMiniGameInviteEnabled) 仍要尊重——开发者本机
+    # 调试用旗标不应该绕过普通用户在前端关掉 mini-game source 的明确意图。
     force_game = MINI_GAME_INVITE_FORCE_GAME_TYPE
     debug_force = bool(force_game)
+    if debug_force and not user_toggle_enabled:
+        return None
     if debug_force:
         if force_game not in MINI_GAME_INVITE_LINES_BY_GAME:
             logger.warning(

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1542,6 +1542,17 @@
             gameType: String(payload.gameType || ''),
             options: cleanedOptions
         };
+        // mini-game invite 占用 composer 底部 slot 视觉位 → galgame options
+        // 让位（App.tsx 已把 galgame slot 在 choicePromptHasOptions 下不挂树）。
+        // 这里同步 abort 任何 in-flight / pending wait 的 galgame fetch + 清掉
+        // 残留 loading/options state：
+        //   1) 不再浪费 summary tier 推理（proactive invite 文本基本是
+        //      sudden-context，galgame option 生成大概率 timeout / unparseable
+        //      → 全是 fallback，纯浪费）
+        //   2) 防止 fetch 在 invite 解决前才返回，写回 state.galgameOptions
+        //      让 invite dismiss 后老结果突然冒出来（A/B/C 选项是基于 invite
+        //      文本生成的，与后续对话无关）
+        invalidatePendingGalgameRequest();
         renderWindow();
     }
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -581,6 +581,44 @@
             S._greetingCheckIsSwitch = !!S._pendingGreetingSwitch;
             S._pendingGreetingSwitch = false;
             _sendGreetingCheckIfReady();
+
+            // ── game-window-state 重连兜底（codex P2）──
+            // game_window_state_change 是 edge-triggered WS 事件——只在 activate
+            // / finalize 那一瞬推。WS 在 game 期间断开 + 期间 close 事件丢失 →
+            // _gameWindowActive 卡在 true，UI 永远停在收缩态。onopen 同时覆盖
+            // 首次连接和重连，主动查 /api/game/route/active 拿当前权威状态，
+            // dispatch 对应 CustomEvent 让既有 listener 走正常 minimize / restore
+            // 路径。idempotent：active=true + 已 minimize → _gameMinimizeForGame
+            // 早返回；active=false + 无 snap → _gameRestoreAfterGame 早返回。
+            (function syncGameWindowStateOnWsConnect() {
+                var lan = '';
+                try {
+                    if (window.appState && typeof window.appState.lanlan_name === 'string') {
+                        lan = window.appState.lanlan_name;
+                    }
+                    if (!lan && window.lanlan_config && typeof window.lanlan_config.lanlan_name === 'string') {
+                        lan = window.lanlan_config.lanlan_name;
+                    }
+                } catch (_) {}
+                if (!lan) return; // greeting 流水线还没解析角色 → 跳过本次，下次 onopen 再来
+                fetch('/api/game/route/active?lanlan_name=' + encodeURIComponent(lan))
+                    .then(function (resp) { return resp && resp.ok ? resp.json() : null; })
+                    .then(function (data) {
+                        if (!data) return;
+                        var action = data.active ? 'opened' : 'closed';
+                        try {
+                            window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+                                detail: {
+                                    action: action,
+                                    lanlanName: data.lanlan_name || lan,
+                                    gameType: data.game_type || '',
+                                    sessionId: data.session_id || ''
+                                }
+                            }));
+                        } catch (_) {}
+                    })
+                    .catch(function () {});
+            })();
         };
 
         // ---- onmessage ----

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1931,6 +1931,26 @@
                             url: response.game_url || '',
                         });
                     }
+
+                // -------- game_window_state_change --------
+                // 后端 game_route_start 激活后推 'opened'，_finalize 翻 inactive
+                // 后推 'closed'。前端把它转成 DOM 自定义事件让 chat.html / pet
+                // index.html 各自挂监听做布局联动（chat.html → 触发内部 collapse
+                // + 移到左下角；index.html → 加 body class 隐藏 live2d/vrm/mmd
+                // 容器）。多窗口模式下 RAW_MESSAGE forwarding 把同一条 WS 转给
+                // chat.html，两边监听同一个 DOM 事件名即可。
+                } else if (response.type === 'game_window_state_change') {
+                    try {
+                        var detail = {
+                            action: response.action || '',
+                            lanlanName: response.lanlan_name || '',
+                            gameType: response.game_type || '',
+                            sessionId: response.session_id || ''
+                        };
+                        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', { detail: detail }));
+                    } catch (gwErr) {
+                        console.warn('[GameWindow] dispatch failed:', gwErr);
+                    }
                 }
 
             } catch (parseError) {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -321,6 +321,15 @@ button * {
     visibility: hidden;
 }
 
+/* 游戏路由激活期间隐藏所有 avatar 容器（live2d / vrm / mmd 三家），让 pet 透明
+   窗口在 mini-game 进行时不抢屏。chat.html 收缩 + pet 隐藏由后端
+   game_window_state_change WS 事件统一驱动，game_route_end 时同步还原。 */
+body.neko-game-active #live2d-container,
+body.neko-game-active #vrm-container,
+body.neko-game-active #mmd-container {
+    display: none !important;
+}
+
 /* 看板娘VR模型画布样式 */
 #vrm-canvas {
     right: 0;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1231,8 +1231,19 @@
             var snap = _gameMinimizeSnap;
             _gameMinimizeSnap = null;
             if (snap.wasCollapsed) {
-                // 进游戏前本来就是球态 → 球搬回原坐标即可，savedWH 还原成进游戏
-                // 之前的展开尺寸（不是当前游戏期间窗口尺寸的副本）
+                if (!collapsed) {
+                    // codex P2：进游戏前球态 + 用户在 game 期间手动点球展开了
+                    // → 当前是展开态，DOM 已 hdr/wrap/tia 显示。如果还按 snap.bounds
+                    // (BALL × BALL) setBounds，窗口被压成 82×82 但 DOM 仍展开 →
+                    // 内容裁切，UI broken 直到用户再次手动恢复。尊重用户当前展开
+                    // 意图，不强行复位窗口尺寸；只恢复 savedWHBefore（让用户下次
+                    // 主动 collapse 时尺寸是进游戏前那个，而不是 game 期 collapseChat
+                    // 写入的中间值）。
+                    if (snap.savedWHBefore) savedWH = { w: snap.savedWHBefore.w, h: snap.savedWHBefore.h };
+                    return;
+                }
+                // 进游戏前球态 + 现在仍是球态 → 球搬回原坐标即可，savedWH 还原
+                // 成进游戏之前的展开尺寸（不是当前游戏期间窗口尺寸的副本）
                 W.setBounds(snap.bounds.x, snap.bounds.y, snap.bounds.width, snap.bounds.height);
                 if (snap.savedWHBefore) savedWH = { w: snap.savedWHBefore.w, h: snap.savedWHBefore.h };
                 return;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1148,6 +1148,27 @@
         // ``is_game_route_active`` 同源（_finalize 翻 false 时一并推 closed），
         // 不会出现"游戏已结束但 UI 仍锁着球态"的孤岛。
         var _gameMinimizeSnap = null;
+        // "用户当前是否仍应处于游戏最小化态"的目标态。所有异步分支（getBounds
+        // / rAF / collapseChat 700ms 落定 / restore 100ms 展开）都拿这个 flag
+        // 跟事件入口对照来判定 stale。
+        //
+        // 修两条 race：
+        // (1) codex P2：原版只在异步回调里写 _gameMinimizeSnap。opened →
+        //     getBounds pending 期间收到 closed → restore 因 snap=null 早返
+        //     → getBounds 落地把 snap 写出来 + 收成球态搬左下角 → 无 closed
+        //     抵消 → UI 永远卡球态。
+        // (2) CodeRabbit Major：closed 撞上 collapseChat() 进行中时，原版
+        //     restore 走 fallback setBounds 回原 bounds，但 doCollapse 内部
+        //     的 getWorkArea+setBounds 在动画 transitionend 后才跑，会把窗口
+        //     再 setBounds 到 ball 位 → 用户看到游戏已结束但聊天框已经被收
+        //     成球态、停在原始底部。
+        //
+        // 修法：
+        // - opened 设 active=true 后调 _gameMinimizeForGame，每条 await 出口
+        //   都 re-check active；closed 同理设 active=false 后调 restore。
+        // - restore 看到 animating=true 时 rAF 重试到动画落定再消费快照——避
+        //   开 doCollapse / expandChat 内部 setBounds 与 restore setBounds 抢位。
+        var _gameWindowActive = false;
 
         function _moveBallToWorkAreaBottomLeft() {
             return W.getWorkArea().then(function(wa) {
@@ -1158,14 +1179,15 @@
         }
 
         function _gameMinimizeForGame() {
-            if (_gameMinimizeSnap) return; // 重入保护：opened 重复来不再叠写 snap
+            if (!_gameWindowActive || _gameMinimizeSnap) return;
             if (animating) {
-                // 正在收/展过程中 → 等下一帧重试，避免把动画期 bounds 当原始尺寸抓拍
+                // 正在收/展过程中 → 等下一帧重试；rAF callback 自身仍 re-check
+                // active，closed 在 rAF 期间到达会让重试 noop
                 requestAnimationFrame(_gameMinimizeForGame);
                 return;
             }
             W.getBounds().then(function(b0) {
-                if (!b0) return;
+                if (!b0 || !_gameWindowActive || _gameMinimizeSnap) return;
                 _gameMinimizeSnap = {
                     bounds: { x: b0.x, y: b0.y, width: b0.width, height: b0.height },
                     wasCollapsed: collapsed,
@@ -1183,7 +1205,7 @@
                     // 缓冲（400ms 折叠动画 + 200ms ball-show + 100ms IPC 余量），
                     // 折叠真落定后再搬位置。
                     setTimeout(function() {
-                        if (!_gameMinimizeSnap) return;
+                        if (!_gameWindowActive || !_gameMinimizeSnap) return;
                         if (collapsed && !animating) _moveBallToWorkAreaBottomLeft();
                     }, 700);
                 }
@@ -1191,7 +1213,16 @@
         }
 
         function _gameRestoreAfterGame() {
-            if (!_gameMinimizeSnap) return;
+            if (_gameWindowActive || !_gameMinimizeSnap) return;
+            if (animating) {
+                // collapseChat / expandChat 进行中时不能立刻消费快照——doCollapse
+                // 的 getWorkArea+setBounds（或 expandChat 的对偶链）会在动画
+                // transitionend 后跑、把窗口拉到自己的目标位，覆盖 restore
+                // setBounds。等 animating 落定后再走 restore 主链路。
+                requestAnimationFrame(_gameRestoreAfterGame);
+                return;
+            }
+            // snap 一旦在本帧消费就 null 出去，避免 rAF 重入二次消费
             var snap = _gameMinimizeSnap;
             _gameMinimizeSnap = null;
             if (snap.wasCollapsed) {
@@ -1214,6 +1245,9 @@
             var b = snap.bounds;
             W.setBounds(b.x, b.y + b.height - BALL, BALL, BALL);
             setTimeout(function() {
+                // 100ms 内若 opened 又来（race：closed → restore → opened，
+                // 100ms 期间 active 翻 true），不再 expand 让新 opened 链路接手
+                if (_gameWindowActive) return;
                 if (!collapsed || animating) return;
                 savedWH = { w: b.width, h: b.height };
                 expandChat();
@@ -1223,8 +1257,10 @@
         window.addEventListener('neko-game-window-state-change', function(ev) {
             var detail = ev && ev.detail ? ev.detail : {};
             if (detail.action === 'opened') {
+                _gameWindowActive = true;
                 _gameMinimizeForGame();
             } else if (detail.action === 'closed') {
+                _gameWindowActive = false;
                 _gameRestoreAfterGame();
             }
         });

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1284,6 +1284,50 @@
             }
         });
 
+        // Bootstrap reconciliation：edge-triggered 的 game_window_state_change WS
+        // 事件只在 activate / finalize 推送，订阅者初次加载时若 route 已经在
+        // active 状态会听不到历史 opened（chat.html 是后开起来的窗口，可能
+        // game 已经先跑起来了）。init 路径主动查 /api/game/route/active，
+        // active 就自己 dispatch opened 让 UI 对齐。codex P1。
+        // closed 不需要 sync——初始 _gameWindowActive=false / snap=null 就是
+        // idle 状态，已对齐。
+        // WS reconnect 后 missing closed 的还原是更复杂的 case（需要订阅
+        // reconnect 事件 + 主动检查），本 PR 暂不覆盖。
+        (function syncGameWindowStateOnInit() {
+            var lan = '';
+            try {
+                if (window.appState && typeof window.appState.lanlan_name === 'string') {
+                    lan = window.appState.lanlan_name;
+                }
+                if (!lan && window.lanlan_config && typeof window.lanlan_config.lanlan_name === 'string') {
+                    lan = window.lanlan_config.lanlan_name;
+                }
+            } catch (_) {}
+            if (!lan) {
+                // lanlan_name 还没解析出来 → 100ms 后重试一次（chat.html 通常
+                // 在 appState 已就绪后才挂这个 IIFE，但 storage barrier 等可能
+                // 让 appState 滞后，给一次 retry 兜底）
+                setTimeout(syncGameWindowStateOnInit, 100);
+                return;
+            }
+            fetch('/api/game/route/active?lanlan_name=' + encodeURIComponent(lan))
+                .then(function(resp) { return resp && resp.ok ? resp.json() : null; })
+                .then(function(data) {
+                    if (!data || !data.active) return;
+                    try {
+                        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+                            detail: {
+                                action: 'opened',
+                                lanlanName: data.lanlan_name || lan,
+                                gameType: data.game_type || '',
+                                sessionId: data.session_id || ''
+                            }
+                        }));
+                    } catch (_) {}
+                })
+                .catch(function() { /* 静默 —— bootstrap 失败不影响普通态 UI */ });
+        })();
+
         // ===================== 边界检测与回弹 =====================
         var _bounceAnim = null;
         var _bouncing = false;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1235,9 +1235,12 @@
             // 进游戏前是展开态、当前是球态 → 把 expandChat 的目标尺寸钉到原 bounds
             // 让动画展开到原大小；球先搬到原 bounds 的底部对齐位（与 expandChat
             // 内部 newY = b.y + BALL - h 推算的"展开后还原原顶端"语义一致）。
-            if (!collapsed || animating) {
+            if (!collapsed) {
                 // 异常态（用户在 game 期间手动展开了？）—— 至少 setBounds 回去，
-                // 不动画，不再调 expandChat（会被 animating guard 拦住）
+                // 不动画，不再调 expandChat（会被 animating guard 拦住）。注：
+                // animating 在此分支已被入口的 rAF 等待保证为 false，不需要再
+                // OR 一遍（github-code-quality bot 指出原版 `|| animating` 永
+                // 远为 false 是 dead branch）。
                 W.setBounds(snap.bounds.x, snap.bounds.y, snap.bounds.width, snap.bounds.height);
                 if (snap.savedWHBefore) savedWH = { w: snap.savedWHBefore.w, h: snap.savedWHBefore.h };
                 return;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1174,6 +1174,11 @@
             return W.getWorkArea().then(function(wa) {
                 if (!wa) return;
                 if (!collapsed) return; // 状态在异步等待期变了 → 放弃，避免把展开窗口吸到 BALL 尺寸
+                // codex P1：getWorkArea pending 期间 closed 可能已到 → restore
+                // 已经把窗口搬回原 bounds；此时再 setBounds 到工作区左下角会
+                // 把刚还原的位置又覆盖掉，留个孤儿球在屏幕角。recheck 游戏态
+                // flag 与 snap 双双健在才搬位。
+                if (!_gameWindowActive || !_gameMinimizeSnap) return;
                 W.setBounds(wa.x, wa.y + wa.height - BALL, BALL, BALL);
             });
         }

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1137,6 +1137,98 @@
             scrollToBottom(false);
         }
 
+        // ===================== 游戏窗口联动（收缩 → 还原）=====================
+        // mini-game 路由激活时把 chat.html 收成呼吸球（复用已有 collapseChat
+        // 动画+样式，等同于用户点击右上角最小化按钮的效果）并搬到工作区左下角；
+        // 路由结束时按之前的 (bounds, collapsed?) 快照还原。
+        //
+        // 单一事件源：app-websocket.js 收到 ``game_window_state_change`` 后
+        // dispatch ``neko-game-window-state-change``，多窗口模式 RAW_MESSAGE
+        // forwarding 自动转给 chat.html follower。closed 路径覆盖率与
+        // ``is_game_route_active`` 同源（_finalize 翻 false 时一并推 closed），
+        // 不会出现"游戏已结束但 UI 仍锁着球态"的孤岛。
+        var _gameMinimizeSnap = null;
+
+        function _moveBallToWorkAreaBottomLeft() {
+            return W.getWorkArea().then(function(wa) {
+                if (!wa) return;
+                if (!collapsed) return; // 状态在异步等待期变了 → 放弃，避免把展开窗口吸到 BALL 尺寸
+                W.setBounds(wa.x, wa.y + wa.height - BALL, BALL, BALL);
+            });
+        }
+
+        function _gameMinimizeForGame() {
+            if (_gameMinimizeSnap) return; // 重入保护：opened 重复来不再叠写 snap
+            if (animating) {
+                // 正在收/展过程中 → 等下一帧重试，避免把动画期 bounds 当原始尺寸抓拍
+                requestAnimationFrame(_gameMinimizeForGame);
+                return;
+            }
+            W.getBounds().then(function(b0) {
+                if (!b0) return;
+                _gameMinimizeSnap = {
+                    bounds: { x: b0.x, y: b0.y, width: b0.width, height: b0.height },
+                    wasCollapsed: collapsed,
+                    // savedWH 是 collapseChat 折叠时记的展开尺寸；如果用户进游戏前
+                    // 已经手动折叠过一次，这个值非空，要原样保留以便 closed 还原后
+                    // 再用户手点展开时尺寸不变。
+                    savedWHBefore: savedWH ? { w: savedWH.w, h: savedWH.h } : null
+                };
+                if (collapsed) {
+                    _moveBallToWorkAreaBottomLeft();
+                } else {
+                    collapseChat();
+                    // collapseChat → doCollapse 内部链路：transitionend / 200ms timeout
+                    // 之后 collapsed=true、animating=false。这里给一个保守 700ms
+                    // 缓冲（400ms 折叠动画 + 200ms ball-show + 100ms IPC 余量），
+                    // 折叠真落定后再搬位置。
+                    setTimeout(function() {
+                        if (!_gameMinimizeSnap) return;
+                        if (collapsed && !animating) _moveBallToWorkAreaBottomLeft();
+                    }, 700);
+                }
+            });
+        }
+
+        function _gameRestoreAfterGame() {
+            if (!_gameMinimizeSnap) return;
+            var snap = _gameMinimizeSnap;
+            _gameMinimizeSnap = null;
+            if (snap.wasCollapsed) {
+                // 进游戏前本来就是球态 → 球搬回原坐标即可，savedWH 还原成进游戏
+                // 之前的展开尺寸（不是当前游戏期间窗口尺寸的副本）
+                W.setBounds(snap.bounds.x, snap.bounds.y, snap.bounds.width, snap.bounds.height);
+                if (snap.savedWHBefore) savedWH = { w: snap.savedWHBefore.w, h: snap.savedWHBefore.h };
+                return;
+            }
+            // 进游戏前是展开态、当前是球态 → 把 expandChat 的目标尺寸钉到原 bounds
+            // 让动画展开到原大小；球先搬到原 bounds 的底部对齐位（与 expandChat
+            // 内部 newY = b.y + BALL - h 推算的"展开后还原原顶端"语义一致）。
+            if (!collapsed || animating) {
+                // 异常态（用户在 game 期间手动展开了？）—— 至少 setBounds 回去，
+                // 不动画，不再调 expandChat（会被 animating guard 拦住）
+                W.setBounds(snap.bounds.x, snap.bounds.y, snap.bounds.width, snap.bounds.height);
+                if (snap.savedWHBefore) savedWH = { w: snap.savedWHBefore.w, h: snap.savedWHBefore.h };
+                return;
+            }
+            var b = snap.bounds;
+            W.setBounds(b.x, b.y + b.height - BALL, BALL, BALL);
+            setTimeout(function() {
+                if (!collapsed || animating) return;
+                savedWH = { w: b.width, h: b.height };
+                expandChat();
+            }, 100);
+        }
+
+        window.addEventListener('neko-game-window-state-change', function(ev) {
+            var detail = ev && ev.detail ? ev.detail : {};
+            if (detail.action === 'opened') {
+                _gameMinimizeForGame();
+            } else if (detail.action === 'closed') {
+                _gameRestoreAfterGame();
+            }
+        });
+
         // ===================== 边界检测与回弹 =====================
         var _bounceAnim = null;
         var _bouncing = false;

--- a/templates/index.html
+++ b/templates/index.html
@@ -388,6 +388,28 @@
             }
         });
     </script>
+    <!-- 游戏窗口联动：mini-game 路由激活时隐藏 live2d/vrm/mmd 容器（CSS class
+         开关，避免 pet 透明窗口在 mini-game 进行时挡屏）。事件源是
+         app-websocket.js dispatch 的 ``neko-game-window-state-change``，与
+         chat.html 的折叠联动同源；多窗口模式下 RAW_MESSAGE forwarding 让
+         pet 主窗 + chat.html follower 各自独立响应。 -->
+    <script>
+    (function() {
+        'use strict';
+        function applyGameWindowState(action) {
+            if (!document.body || !document.body.classList) return;
+            if (action === 'opened') {
+                document.body.classList.add('neko-game-active');
+            } else if (action === 'closed') {
+                document.body.classList.remove('neko-game-active');
+            }
+        }
+        window.addEventListener('neko-game-window-state-change', function(ev) {
+            var detail = ev && ev.detail ? ev.detail : {};
+            applyGameWindowState(detail.action || '');
+        });
+    })();
+    </script>
     <!-- 注意：初始化由 app.js 统一处理，避免重复初始化 -->
 </body>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -408,6 +408,40 @@
             var detail = ev && ev.detail ? ev.detail : {};
             applyGameWindowState(detail.action || '');
         });
+        // Bootstrap reconciliation：edge-triggered WS 事件只在 activate /
+        // finalize 推送，pet 主窗加载时若 game 已经先跑起来了会听不到历史
+        // opened，body class 不会加 neko-game-active → live2d/vrm/mmd 仍可见
+        // 挡屏。init 路径主动查 /api/game/route/active 对齐。codex P1。
+        // chat.html 用同一逻辑（在该模板 IIFE 内独立实现一份）。
+        function syncGameWindowStateOnInit() {
+            var lan = '';
+            try {
+                if (window.appState && typeof window.appState.lanlan_name === 'string') {
+                    lan = window.appState.lanlan_name;
+                }
+                if (!lan && window.lanlan_config && typeof window.lanlan_config.lanlan_name === 'string') {
+                    lan = window.lanlan_config.lanlan_name;
+                }
+            } catch (_) {}
+            if (!lan) { setTimeout(syncGameWindowStateOnInit, 100); return; }
+            fetch('/api/game/route/active?lanlan_name=' + encodeURIComponent(lan))
+                .then(function(resp) { return resp && resp.ok ? resp.json() : null; })
+                .then(function(data) {
+                    if (!data || !data.active) return;
+                    try {
+                        window.dispatchEvent(new CustomEvent('neko-game-window-state-change', {
+                            detail: {
+                                action: 'opened',
+                                lanlanName: data.lanlan_name || lan,
+                                gameType: data.game_type || '',
+                                sessionId: data.session_id || ''
+                            }
+                        }));
+                    } catch (_) {}
+                })
+                .catch(function() {});
+        }
+        syncGameWindowStateOnInit();
     })();
     </script>
     <!-- 注意：初始化由 app.js 统一处理，避免重复初始化 -->

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -1162,19 +1162,19 @@
 
   function flash(side) { state.flashTimer = 0.6; state.flashSide = side; }
 
-  // 难度档：从 max（最难）到 lv4（最弱）。普通陪玩默认从 lv2/lv3 开局，后续由 LLM 控制。
+  // 难度档：从 max（最难）到 lv4（最弱）。普通陪玩默认 lv2 起手，后续由 LLM 控制。
+  // 兜底难度统一钉到 lv2：原本的 lv2/lv3 random 让玩家受到的初始压力抖动 1 档，
+  // pre-game 端 LLM 又被 prompt 强制建议 neutral_play 选 lv2 → 兜底也对齐 lv2，
+  // 让 fallback 路径与 prompt 引导走同一档，避免"LLM 出 lv2 / 兜底出 lv3"的体感
+  // 差异。lv3 / lv4 仍可由 balance_hint 推荐 + LLM setDifficulty 切到，不会消失。
   const DIFFICULTY = [
     { name: 'max', kickCdMin: 0.4, kickCdMax: 0.6, windupSec: 0.00, speedMul: 1.00, allowAttack: true },
     { name: 'lv2', kickCdMin: 0.9, kickCdMax: 1.4, windupSec: 0.35, speedMul: 1.00, allowAttack: true },
     { name: 'lv3', kickCdMin: 0.9, kickCdMax: 1.4, windupSec: 0.35, speedMul: 0.78, allowAttack: true },
     { name: 'lv4', kickCdMin: 0.9, kickCdMax: 1.4, windupSec: 0.35, speedMul: 0.78, allowAttack: false },
   ];
-  function randomDefaultDifficultyIndex() {
-    const name = Math.random() < 0.5 ? 'lv2' : 'lv3';
-    const idx = DIFFICULTY.findIndex(d => d.name === name);
-    return idx >= 0 ? idx : 1;
-  }
-  let difficultyIdx = randomDefaultDifficultyIndex();
+  const DEFAULT_DIFFICULTY_INDEX = DIFFICULTY.findIndex(d => d.name === 'lv2');
+  let difficultyIdx = DEFAULT_DIFFICULTY_INDEX >= 0 ? DEFAULT_DIFFICULTY_INDEX : 1;
   function cycleDifficulty() {
     difficultyIdx = (difficultyIdx + 1) % DIFFICULTY.length;
   }
@@ -2096,7 +2096,7 @@
     unstickCd = 0;
     GAME_EVENTS.length = 0;
 
-    difficultyIdx = randomDefaultDifficultyIndex();
+    difficultyIdx = DEFAULT_DIFFICULTY_INDEX >= 0 ? DEFAULT_DIFFICULTY_INDEX : 1;
     __setMoodBase('calm');
     if (!_llm.keepMoodRotationDisabled) SoccerDemo.enableMoodRotation(20);
     for (const key of Object.keys(SPEECH_CD)) delete SPEECH_CD[key];

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -438,10 +438,11 @@ async def test_maybe_deliver_user_toggle_default_true_keeps_bc(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_force_game_type_overrides_all_gates(monkeypatch):
-    """``MINI_GAME_INVITE_FORCE_GAME_TYPE='soccer'`` 时，即使 user_toggle 关、
-    snapshot 是 None、cooldown 在期内、骰子必失，也强制走邀请投递。
-    仅 ``MINI_GAME_INVITE_ENABLED=False`` 才能拦住。"""
+async def test_force_game_type_overrides_snapshot_and_cooldown_gates(monkeypatch):
+    """``MINI_GAME_INVITE_FORCE_GAME_TYPE='soccer'`` 时跳过 snapshot/cooldown/骰
+    子 gate 强制投递；但用户级 toggle 仍要尊重（见
+    test_force_game_type_respects_user_toggle）。仅 ``MINI_GAME_INVITE_ENABLED=False``
+    或 user_toggle_enabled=False 才能拦住。"""
     monkeypatch.setattr(sr, 'MINI_GAME_INVITE_FORCE_GAME_TYPE', 'soccer')
     monkeypatch.setattr(sr, 'MINI_GAME_INVITE_TRIGGER_PROBABILITY', 0.0)
     sr._mini_game_invite_record_delivered(LANLAN, "stale-session")
@@ -450,11 +451,26 @@ async def test_force_game_type_overrides_all_gates(monkeypatch):
         lanlan_name=LANLAN, mgr=mgr,
         activity_snapshot=None,
         invite_lang='zh', master_name=MASTER,
-        user_toggle_enabled=False,
+        user_toggle_enabled=True,
     )
     assert out is not None
     assert out["action"] == "chat"
     assert out.get("game_type") == 'soccer'
+
+
+@pytest.mark.asyncio
+async def test_force_game_type_respects_user_toggle(monkeypatch):
+    """开发者旗标不应该绕过用户在前端关掉 mini-game source 的明确意图。
+    user_toggle_enabled=False 时 force-flag 仍 return None，与全局 kill switch
+    地位等同。"""
+    monkeypatch.setattr(sr, 'MINI_GAME_INVITE_FORCE_GAME_TYPE', 'soccer')
+    out = await sr._maybe_deliver_mini_game_invite(
+        lanlan_name=LANLAN, mgr=_make_mgr(),
+        activity_snapshot=None,
+        invite_lang='zh', master_name=MASTER,
+        user_toggle_enabled=False,
+    )
+    assert out is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
PR #1145 follow-up #3。三件事一起做掉。

## Summary

- **galgame options ↔ mini-game ChoicePrompt 互斥**：composer 底部 slot 两者同时活跃会渲染 6 个按钮挤一起；invite 抢占 slot，galgame 让位 + abort in-flight fetch
- **默认难度 lv2 钉死**：原本 lv2/lv3 50/50 random，5 locale prompt 同步改 `默认 lv2；想轻一档放水可用 lv3；不要用 max`
- **Electron 游戏期联动**：mini-game 路由激活时 chat.html 复用既有 collapseChat 动画收成球态 + 搬工作区左下角；pet (live2d/vrm/mmd) 容器整块隐藏。退出游戏后按快照还原

## 关键设计

后端单一事实源 `_push_game_window_state_change`：`game_route_start` 推 opened，`_finalize_game_route_state_inner` 推 closed，覆盖 /route/end / heartbeat sweep / supersede 三条 finalize 路径，与 `is_game_route_active` 同源不会出"已结束但 UI 仍锁着收缩态"的孤岛。

前端两条独立监听共用 DOM 事件 `neko-game-window-state-change`：app-websocket.js 把 WS message 转 CustomEvent，多窗口 RAW_MESSAGE forwarding 让 pet + chat.html follower 各自响应。chat.html IIFE 内抓 (bounds, collapsed?, savedWH?) 快照 → 调 collapseChat → 700ms 落定后 setBounds 左下角；closed 按快照精确还原。index.html 内仅切 body class `neko-game-active`，CSS 隐藏三家 avatar 容器。

galgame 互斥两层：
1. App.tsx `choicePromptHasOptions` 门同时关 galgameOptionsVisible 与 galgame slot 渲染
2. `setMiniGameInvitePrompt` 写完 state 立即 `invalidatePendingGalgameRequest()` —— invite 文本是 sudden context，galgame option 生成基本 timeout / unparseable → 全 fallback 纯浪费

## 改动文件

| 文件 | 改动 |
|---|---|
| `frontend/react-neko-chat/src/App.tsx` | `choicePromptHasOptions` 门 + galgame slot 不挂树 |
| `static/app-react-chat-window.js` | `setMiniGameInvitePrompt` 调 `invalidatePendingGalgameRequest()` |
| `templates/soccer_demo.html` | 默认难度 `DEFAULT_DIFFICULTY_INDEX = lv2`，删 random |
| `config/prompts_game.py` | 5 locale `neutral_play 默认 lv2` |
| `main_routers/game_router.py` | `_push_game_window_state_change` helper + start/finalize 两处 call |
| `static/app-websocket.js` | WS branch `game_window_state_change` → CustomEvent |
| `templates/chat.html` | IIFE 内 `_gameMinimizeForGame` / `_gameRestoreAfterGame` |
| `templates/index.html` | inline 监听切 `neko-game-active` body class |
| `static/css/index.css` | `body.neko-game-active` 下三家 avatar 容器 `display:none` |

## Test plan

- [x] `uv run pytest tests/unit/test_game_router.py tests/unit/test_mini_game_invite.py` —— 154 passed
- [x] React typecheck clean + vitest 36 passed
- [x] Jinja parse soccer_demo / chat / index 三模板 OK
- [ ] **手测三 context**（per `feedback_chat_three_contexts.md`）：index.html 宽屏 / 移动端窄屏 / chat.html Electron multi-window 三条路径，验证：
  - mini-game 启动联动 + 退出还原
  - 起始为球态 / 展开态两种快照路径都能精确回到原状
  - galgame mode 开 + invite 同时来时只显示 invite 三按钮
  - 默认难度起手是 lv2

## Out of scope

- pet 窗口实际位置移动到右下角"只剩脑袋" —— `window.nekoPetDrag` 不暴露 setBounds，需要 lanlan_frd 仓库新加 IPC；当前先 `display:none` 隐藏整块容器
- 游戏期间 chat.html 球态再被用户手动展开后退出游戏的还原（异常态走 setBounds 不动画 fallback）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 游戏窗口开关同步：前后端广播游戏窗口已打开/关闭，新增接口与事件以在加载/重连时恢复状态，触发聊天自动收起与恢复

* **优化改进**
  * 页面事件通知与 UI 协调，避免动画/布局冲突
  * 游戏中隐藏虚拟形象容器，避免与游戏界面重叠
  * 足球小游戏：中立玩法默认固定为 Lv2，禁止 max，仅允许逐步放宽到 Lv3
  * 邀请与选项展示改进：中止并发旧选项、强制邀请尊重用户开关、优化交互槽位可见性

* **测试**
  * 新增覆盖强制邀请与用户开关交互的单元测试
<!-- end of auto-generated comment: release notes by coderabbit.ai -->