### PR TITLE
禁止窗口标题栏和导航按钮中的装饰图标被拖拽，避免图片被拖到桌面或复制出应用

### DIFF
--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -1783,6 +1783,7 @@
         var closeIcon = doc.createElement('img');
         closeIcon.src = '/static/icons/close_button.png';
         closeIcon.alt = translateLabel('common.close', 'Close');
+        closeIcon.draggable = false;
         closeButton.appendChild(closeIcon);
 
         header.appendChild(title);

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -25,3 +25,14 @@ select:focus-visible,
     outline: 2px solid #40C5F1;
     outline-offset: 2px;
 }
+
+/* 按钮图标是控件内容，禁止浏览器把图片当作可拖拽文件处理 */
+button img,
+.close-btn img,
+.close-page-btn img,
+.panel-close-btn img,
+.touch-config-close img,
+.chat-export-preview-close img {
+    -webkit-user-drag: none;
+    user-select: none;
+}

--- a/static/css/live2d_parameter_editor.css
+++ b/static/css/live2d_parameter_editor.css
@@ -757,6 +757,8 @@ transform: translateY(-50%);
 z-index: 10;  
 flex-shrink: 0;
 pointer-events: none;
+-webkit-user-drag: none;
+user-select: none;
 filter: drop-shadow(0 2px 4px rgba(34, 179, 255, 0.3)) drop-shadow(0 1px 2px rgba(34, 179, 255, 0.2));
 }
         
@@ -769,6 +771,8 @@ transform: translateY(-50%);
 z-index: 10;  
 flex-shrink: 0;
 pointer-events: none;
+-webkit-user-drag: none;
+user-select: none;
 }
         
 #backToMainBtn span {

--- a/static/css/mmd_emotion_manager.css
+++ b/static/css/mmd_emotion_manager.css
@@ -93,6 +93,8 @@ body {
     width: 32px;
     height: 32px;
     object-fit: contain;
+    -webkit-user-drag: none;
+    user-select: none;
 }
 
 .header h1 {

--- a/static/css/model_manager.css
+++ b/static/css/model_manager.css
@@ -370,6 +370,8 @@ body {
     z-index: 10;
     flex-shrink: 0;
     pointer-events: none;
+    -webkit-user-drag: none;
+    user-select: none;
     filter: drop-shadow(0 2px 4px rgba(34, 179, 255, 0.3)) drop-shadow(0 1px 2px rgba(34, 179, 255, 0.2));
 }
 
@@ -382,6 +384,8 @@ body {
     z-index: 10;
     flex-shrink: 0;
     pointer-events: none;
+    -webkit-user-drag: none;
+    user-select: none;
 }
 
 #backToMainBtn span {

--- a/static/css/touch-config.css
+++ b/static/css/touch-config.css
@@ -128,7 +128,6 @@
     height: 32px;
     object-fit: contain;
     -webkit-user-drag: none;
-    user-select: none;
 }
 
 .touch-config-content {

--- a/static/css/touch-config.css
+++ b/static/css/touch-config.css
@@ -127,6 +127,8 @@
     width: 32px;
     height: 32px;
     object-fit: contain;
+    -webkit-user-drag: none;
+    user-select: none;
 }
 
 .touch-config-content {

--- a/static/css/vrm_emotion_manager.css
+++ b/static/css/vrm_emotion_manager.css
@@ -98,6 +98,8 @@ body {
     width: 32px;
     height: 32px;
     object-fit: contain;
+    -webkit-user-drag: none;
+    user-select: none;
 }
 
 .header h1 {

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -4269,6 +4269,7 @@ function openCatgirlPanel(card, originEl) {
     const closeBtnImg = document.createElement('img');
     closeBtnImg.src = '/static/icons/close_button.png';
     closeBtnImg.alt = window.t ? window.t('common.close') : '关闭';
+    closeBtnImg.draggable = false;
     closeBtn.appendChild(closeBtnImg);
     closeBtn.onclick = closeCatgirlPanel;
     headerBar.appendChild(closeBtn);

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -2041,7 +2041,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // 如果结构被破坏了，重新创建
         if (!textSpan || !backImg || !pawImg) {
-            backToMainBtn.innerHTML = '<img src="/static/icons/back_to_main_button.png?v=1" alt="返回" class="back-icon" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;"><span class="round-stroke-text" id="back-text" data-text="返回主页">返回主页</span><img src="/static/icons/paw_ui.png?v=1" alt="猫爪" class="paw-icon" style="height: 70px; width: auto; max-width: 60px; image-rendering: crisp-edges; margin-left: auto; flex-shrink: 0; object-fit: contain; display: inline-block;">';
+            backToMainBtn.innerHTML = '<img src="/static/icons/back_to_main_button.png?v=1" alt="返回" class="back-icon" draggable="false" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;"><span class="round-stroke-text" id="back-text" data-text="返回主页">返回主页</span><img src="/static/icons/paw_ui.png?v=1" alt="猫爪" class="paw-icon" draggable="false" style="height: 70px; width: auto; max-width: 60px; image-rendering: crisp-edges; margin-left: auto; flex-shrink: 0; object-fit: contain; display: inline-block;">';
             textSpan = document.getElementById('back-text');
         }
 

--- a/static/touch-config.js
+++ b/static/touch-config.js
@@ -456,7 +456,7 @@ function createTouchConfigFloatingWindow(options = {}){
     if (showCloseButton) {
         const closeButton = document.createElement("button")
         closeButton.className = "touch-config-close"
-        closeButton.innerHTML = '<img src="/static/icons/close_button.png" alt="关闭">'
+        closeButton.innerHTML = '<img src="/static/icons/close_button.png" alt="关闭" draggable="false">'
         closeButton.onclick = function(){
             windowObj.close()
         }

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -62,7 +62,7 @@
             <div class="container-header">
                 <h2 data-i18n="api.settings" data-text="API Key Settings">API Key 设置</h2>
                 <button class="close-btn" onclick="closeSettingsPage()" data-i18n-title="common.close"><img
-                        src="/static/icons/close_button.png" data-i18n-alt="common.close"
+                        src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false"
                         style="width: 32px; height: 32px;"></button>
             </div>
             <div class="container-content">

--- a/templates/api_key_settings.html
+++ b/templates/api_key_settings.html
@@ -61,7 +61,7 @@
         <div class="container">
             <div class="container-header">
                 <h2 data-i18n="api.settings" data-text="API Key Settings">API Key 设置</h2>
-                <button class="close-btn" onclick="closeSettingsPage()" data-i18n-title="common.close"><img
+                <button class="close-btn" onclick="closeSettingsPage()" data-i18n-title="common.close" data-i18n-aria="common.close" aria-label="关闭"><img
                         src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false"
                         style="width: 32px; height: 32px;"></button>
             </div>

--- a/templates/card_maker.html
+++ b/templates/card_maker.html
@@ -19,7 +19,7 @@
     <div class="page-title-bar">
         <h2 data-i18n="cardExport.title" data-text="卡面制作">卡面制作</h2>
         <button id="back-btn" class="close-btn" data-i18n-title="cardExport.back" title="返回">
-            <img src="/static/icons/close_button.png" data-i18n-alt="common.close" alt="关闭">
+            <img src="/static/icons/close_button.png" data-i18n-alt="common.close" alt="关闭" draggable="false">
         </button>
     </div>
 

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -408,7 +408,7 @@
             <button class="maximize-btn" id="maximizeBtn" onclick="toggleMaximize()" data-i18n-title="common.maximize" title="最大化">
                 <span class="maximize-icon"></span>
             </button>
-            <button class="close-btn" onclick="window.close(); window.history.back();" data-i18n-title="common.close" title="关闭">
+            <button class="close-btn" onclick="window.close(); window.history.back();" data-i18n-title="common.close" data-i18n-aria="common.close" title="关闭" aria-label="关闭">
                 <img src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false">
             </button>
         </div>

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -409,7 +409,7 @@
                 <span class="maximize-icon"></span>
             </button>
             <button class="close-btn" onclick="window.close(); window.history.back();" data-i18n-title="common.close" title="关闭">
-                <img src="/static/icons/close_button.png" data-i18n-alt="common.close">
+                <img src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false">
             </button>
         </div>
     </div>

--- a/templates/cookies_login.html
+++ b/templates/cookies_login.html
@@ -40,7 +40,7 @@
         }
         .container-header h2 { margin: 0; font-size: 1.2rem; font-weight: 700; color: white; letter-spacing: 0.5px; }
         .container-header .close-btn { -webkit-app-region: no-drag; background: transparent; border: none; cursor: pointer; padding: 8px; margin-right: -8px; /* 增大点击热区 */ }
-        .container-header .close-btn img { width: 24px; height: 24px; filter: drop-shadow(0 1px 2px rgba(0,0,0,0.1)); }
+        .container-header .close-btn img { width: 24px; height: 24px; filter: drop-shadow(0 1px 2px rgba(0,0,0,0.1)); -webkit-user-drag: none; user-select: none; }
 
         /* 内容滚动容器 */
         .dashboard-wrapper { 
@@ -468,7 +468,7 @@
     <div class="container-header">
         <h2 data-i18n="cookiesLogin.header">🔐 凭证获取中心</h2>
         <button class="close-btn" onclick="window.close()" title="关闭" aria-label="关闭" data-i18n-title="common.close" data-i18n-aria="common.close">
-            <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="common.close">
+            <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="common.close" draggable="false">
         </button>
     </div>
     <div class="dashboard-wrapper">

--- a/templates/live2d_emotion_manager.html
+++ b/templates/live2d_emotion_manager.html
@@ -103,6 +103,8 @@
             width: 32px;
             height: 32px;
             object-fit: contain;
+            -webkit-user-drag: none;
+            user-select: none;
         }
 
         .header h1 {
@@ -623,7 +625,7 @@
                 <p data-i18n="emotionManager.subtitle">配置不同情绪下的动作和表情</p>
             </div>
             <button class="close-btn" onclick="window.close(); window.history.back();" title="关闭" data-i18n-title="common.close">
-                <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="common.close">
+                <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="common.close" draggable="false">
             </button>
         </div>
 

--- a/templates/live2d_parameter_editor.html
+++ b/templates/live2d_parameter_editor.html
@@ -18,9 +18,9 @@
     <div id="sidebar">
         <div class="control-group">
             <button id="backToMainBtn" class="btn btn-primary" data-i18n-title="live2d.parameterEditor.backToL2DManager">
-                <img src="/static/icons/back_to_main_button.png?v=1" data-i18n-alt="live2d.parameterEditor.backToL2DManager" class="back-icon" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;">
+                <img src="/static/icons/back_to_main_button.png?v=1" data-i18n-alt="live2d.parameterEditor.backToL2DManager" class="back-icon" draggable="false" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;">
                 <span class="round-stroke-text" id="back-text" data-i18n="live2d.parameterEditor.backToL2DManager" data-text="返回模型管理">返回模型管理</span>
-                <img src="/static/icons/paw_ui.png?v=1" alt="" class="paw-icon" style="height: 70px; width: auto; max-width: 60px; image-rendering: crisp-edges; margin-left: auto; flex-shrink: 0; object-fit: contain; display: inline-block;">
+                <img src="/static/icons/paw_ui.png?v=1" alt="" class="paw-icon" draggable="false" style="height: 70px; width: auto; max-width: 60px; image-rendering: crisp-edges; margin-left: auto; flex-shrink: 0; object-fit: contain; display: inline-block;">
             </button>
         </div>
 

--- a/templates/memory_browser.html
+++ b/templates/memory_browser.html
@@ -20,7 +20,7 @@
         <div class="container-header">
             <h2 data-i18n="memory.title" data-text="Memory Browser">记忆浏览</h2>
             <button class="close-page-btn" onclick="closeMemoryBrowser()" data-i18n-title="common.close">
-                <img src="/static/icons/close_button.png" data-i18n-alt="common.close">
+                <img src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false">
             </button>
         </div>
         <div class="container-content">

--- a/templates/mmd_emotion_manager.html
+++ b/templates/mmd_emotion_manager.html
@@ -23,7 +23,7 @@
                 <p data-i18n="mmdEmotionManager.subtitle">配置不同情绪对应的 MorphTarget 映射</p>
             </div>
             <button class="close-btn" onclick="window.close(); window.history.back();" title="关闭" data-i18n-title="mmdEmotionManager.close">
-                <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="mmdEmotionManager.close">
+                <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="mmdEmotionManager.close" draggable="false">
             </button>
         </div>
 

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -25,9 +25,9 @@
         <div id="sidebar-controls" class="sidebar-controls">
         <div class="control-group">
             <button id="backToMainBtn" class="btn btn-primary" data-i18n-title="live2d.backToMain">
-                <img src="/static/icons/back_to_main_button.png?v=1" data-i18n-alt="live2d.backToMain" class="back-icon" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;">
+                <img src="/static/icons/back_to_main_button.png?v=1" data-i18n-alt="live2d.backToMain" class="back-icon" draggable="false" style="height: 40px; width: auto; max-width: 80px; image-rendering: crisp-edges; margin-right: 10px; flex-shrink: 0; object-fit: contain; display: inline-block;">
                 <span class="round-stroke-text" id="back-text" data-i18n="live2d.backToMain" data-text="Back to Main">返回主页</span>
-                <img src="/static/icons/paw_ui.png?v=1" alt="" class="paw-icon" style="height: 70px; width: auto; max-width: 60px; image-rendering: crisp-edges; margin-left: auto; flex-shrink: 0; object-fit: contain; display: inline-block;">
+                <img src="/static/icons/paw_ui.png?v=1" alt="" class="paw-icon" draggable="false" style="height: 70px; width: auto; max-width: 60px; image-rendering: crisp-edges; margin-left: auto; flex-shrink: 0; object-fit: contain; display: inline-block;">
             </button>
         </div>
 

--- a/templates/voice_clone.html
+++ b/templates/voice_clone.html
@@ -18,7 +18,7 @@
             <h2 data-i18n="voice.title" data-text="Voice Registration">音色注册</h2>
             <a href="javascript:void(0)" onclick="openApiSettings()" class="goto-api-settings-btn" data-i18n="voice.gotoApiSettings">前往API设置</a>
             <button class="close-page-btn" onclick="closeVoiceClonePage()" data-i18n-title="common.close">
-                <img src="/static/icons/close_button.png" data-i18n-alt="common.close">
+                <img src="/static/icons/close_button.png" data-i18n-alt="common.close" draggable="false">
             </button>
         </div>
         <div class="container-content">

--- a/templates/vrm_emotion_manager.html
+++ b/templates/vrm_emotion_manager.html
@@ -23,7 +23,7 @@
                 <p data-i18n="vrmEmotionManager.subtitle">配置不同情绪对应的表情映射</p>
             </div>
             <button class="close-btn" onclick="window.close(); window.history.back();" title="关闭" data-i18n-title="vrmEmotionManager.close">
-                <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="vrmEmotionManager.close">
+                <img src="/static/icons/close_button.png" alt="关闭" data-i18n-alt="vrmEmotionManager.close" draggable="false">
             </button>
         </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* 禁用了关闭按钮、返回按钮及其他界面图标的拖拽（添加 draggable="false" 与相关 CSS），防止图标被拖动。
* 在多个界面添加了禁止图像拖拽与禁止选取的样式（-webkit-user-drag: none; user-select: none;），改善按钮/图标交互，避免意外选择与拖动操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->