### PR TITLE
fix(proactive): 主动搭话失败 retry + 静默化，不再泄露上游 HTML 错误页

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1693,78 +1693,153 @@ class OmniOfflineClient:
             + [HumanMessage(content=instruction)]
         )
 
+        # Retry 策略与 stream_text 对偶（max_retries=3, [1, 2]s 间隔）。
+        # 但主动搭话语义不同：用户没在等回复，retry 用尽时**静默吞掉**，
+        # 不发任何 status_message 给前端 —— 失败 = 这一轮 AI 根本没想说话。
+        # 唯一例外：欠费 / API Key / 配额这类账户级错误必须上报，否则用户
+        # 永远不知道为什么主动搭话不工作。
+        max_retries = 3
+        retry_delays = [1, 2]
         assistant_message = ""
-        is_first_chunk = True
-        chunk_usage = None
-        prefix_buffer = ""
-        prefix_checked = not bool(self._prefix_buffer_size)
 
         try:
             self._is_responding = True
             set_call_type("proactive")
-            # 主动搭话同样走 tool-aware streaming —— agent 注入的 stage
-            # direction 也可能让模型决定调用工具（比如 "讲一下今天天气"）。
-            async for chunk in self._astream_with_tools(messages_to_send):
-                if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
-                    chunk_usage = chunk.usage_metadata
-                    logger.debug(f"🔍 [Usage-Proactive] {chunk_usage}")
-                if hasattr(chunk, 'response_metadata') and chunk.response_metadata:
-                    if 'token_usage' in chunk.response_metadata or 'usage' in chunk.response_metadata:
-                        logger.debug(f"🔍 [Meta-Proactive] {chunk.response_metadata}")
+            for attempt in range(max_retries):
+                # 每次 attempt 重置流式状态（assistant_message / prefix /
+                # is_first_chunk 全部归零）。
+                assistant_message = ""
+                is_first_chunk = True
+                prefix_buffer = ""
+                prefix_checked = not bool(self._prefix_buffer_size)
+                emitted_any = False  # 本 attempt 是否已经向前端 emit 过文本
 
-                if not self._is_responding:
-                    break
-                content = chunk.content if hasattr(chunk, "content") else str(chunk)
-                if content and content.strip():
-                    emit_content = content
+                try:
+                    # 主动搭话同样走 tool-aware streaming —— agent 注入的 stage
+                    # direction 也可能让模型决定调用工具（比如 "讲一下今天天气"）。
+                    async for chunk in self._astream_with_tools(messages_to_send):
+                        if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
+                            logger.debug(f"🔍 [Usage-Proactive] {chunk.usage_metadata}")
+                        if hasattr(chunk, 'response_metadata') and chunk.response_metadata:
+                            if 'token_usage' in chunk.response_metadata or 'usage' in chunk.response_metadata:
+                                logger.debug(f"🔍 [Meta-Proactive] {chunk.response_metadata}")
 
-                    # ── 前缀检测阶段：缓冲初始输出，剥离角色名前缀 ──
-                    if not prefix_checked:
-                        prefix_buffer += emit_content
-                        if len(prefix_buffer) >= self._prefix_buffer_size:
-                            prefix_checked = True
-                            master_match = self._match_name_prefix(prefix_buffer, self.master_name)
-                            lanlan_match = self._match_name_prefix(prefix_buffer, self.lanlan_name)
-                            if master_match:
-                                logger.info(f"OmniOfflineClient.prompt_ephemeral: 剥离主人名前缀 '{prefix_buffer[:master_match]}'")
-                                emit_content = prefix_buffer[master_match:]
-                            elif lanlan_match:
-                                logger.info(f"OmniOfflineClient.prompt_ephemeral: 剥离角色名前缀 '{prefix_buffer[:lanlan_match]}'")
-                                emit_content = prefix_buffer[lanlan_match:]
-                            else:
-                                emit_content = prefix_buffer
-                            if not (emit_content and emit_content.strip()):
-                                continue
+                        if not self._is_responding:
+                            break
+                        content = chunk.content if hasattr(chunk, "content") else str(chunk)
+                        if content and content.strip():
+                            emit_content = content
+
+                            # ── 前缀检测阶段：缓冲初始输出，剥离角色名前缀 ──
+                            if not prefix_checked:
+                                prefix_buffer += emit_content
+                                if len(prefix_buffer) >= self._prefix_buffer_size:
+                                    prefix_checked = True
+                                    master_match = self._match_name_prefix(prefix_buffer, self.master_name)
+                                    lanlan_match = self._match_name_prefix(prefix_buffer, self.lanlan_name)
+                                    if master_match:
+                                        logger.info(f"OmniOfflineClient.prompt_ephemeral: 剥离主人名前缀 '{prefix_buffer[:master_match]}'")
+                                        emit_content = prefix_buffer[master_match:]
+                                    elif lanlan_match:
+                                        logger.info(f"OmniOfflineClient.prompt_ephemeral: 剥离角色名前缀 '{prefix_buffer[:lanlan_match]}'")
+                                        emit_content = prefix_buffer[lanlan_match:]
+                                    else:
+                                        emit_content = prefix_buffer
+                                    if not (emit_content and emit_content.strip()):
+                                        continue
+                                else:
+                                    continue  # 缓冲区未满，等更多 chunk
+
+                            assistant_message += emit_content
+                            if self.on_text_delta:
+                                await self.on_text_delta(emit_content, is_first_chunk)
+                            is_first_chunk = False
+                            emitted_any = True
+
+                    # ── flush 前缀缓冲区（流提前结束时） ──
+                    if prefix_buffer and not prefix_checked:
+                        prefix_checked = True
+                        master_match = self._match_name_prefix(prefix_buffer, self.master_name)
+                        lanlan_match = self._match_name_prefix(prefix_buffer, self.lanlan_name)
+                        if master_match:
+                            logger.info("OmniOfflineClient.prompt_ephemeral: 流结束时剥离主人名前缀")
+                            flush_text = prefix_buffer[master_match:]
+                        elif lanlan_match:
+                            logger.info("OmniOfflineClient.prompt_ephemeral: 流结束时剥离角色名前缀")
+                            flush_text = prefix_buffer[lanlan_match:]
                         else:
-                            continue  # 缓冲区未满，等更多 chunk
+                            flush_text = prefix_buffer
+                        if flush_text and flush_text.strip():
+                            assistant_message += flush_text
+                            if self.on_text_delta:
+                                await self.on_text_delta(flush_text, is_first_chunk)
+                            is_first_chunk = False
+                            emitted_any = True
 
-                    assistant_message += emit_content
-                    if self.on_text_delta:
-                        await self.on_text_delta(emit_content, is_first_chunk)
-                    is_first_chunk = False
+                    break  # 流正常结束，跳出 retry 循环
 
-            # ── flush 前缀缓冲区（流提前结束时） ──
-            if prefix_buffer and not prefix_checked:
-                prefix_checked = True
-                master_match = self._match_name_prefix(prefix_buffer, self.master_name)
-                lanlan_match = self._match_name_prefix(prefix_buffer, self.lanlan_name)
-                if master_match:
-                    logger.info("OmniOfflineClient.prompt_ephemeral: 流结束时剥离主人名前缀")
-                    flush_text = prefix_buffer[master_match:]
-                elif lanlan_match:
-                    logger.info("OmniOfflineClient.prompt_ephemeral: 流结束时剥离角色名前缀")
-                    flush_text = prefix_buffer[lanlan_match:]
-                else:
-                    flush_text = prefix_buffer
-                if flush_text and flush_text.strip():
-                    assistant_message += flush_text
-                    if self.on_text_delta:
-                        await self.on_text_delta(flush_text, is_first_chunk)
-                    is_first_chunk = False
+                except (APIConnectionError, InternalServerError, RateLimitError) as e:
+                    error_type = type(e).__name__
+                    error_str_lower = str(e).lower()
+                    logger.info(f"ℹ️ prompt_ephemeral 捕获到 {error_type} 错误")
+
+                    # 账户级错误必须上报：欠费 / API Key 直接放弃 retry，
+                    # 配额错误上报后继续 retry（与 stream_text 对偶）。
+                    if '欠费' in error_str_lower or 'standing' in error_str_lower:
+                        logger.error(f"prompt_ephemeral: 检测到欠费错误，直接上报: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_ARREARS"}))
+                        assistant_message = ""
+                        return False
+                    elif ('401' in error_str_lower or 'unauthorized' in error_str_lower
+                            or 'authentication' in error_str_lower
+                            or ('invalid' in error_str_lower and 'key' in error_str_lower)):
+                        logger.error(f"prompt_ephemeral: 检测到 API Key 错误，直接上报: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_KEY_REJECTED"}))
+                        assistant_message = ""
+                        return False
+                    elif 'quota' in error_str_lower or 'time limit' in error_str_lower:
+                        logger.warning(f"prompt_ephemeral: 检测到配额错误，上报前端: {e}")
+                        if self.on_status_message:
+                            await self.on_status_message(json.dumps({"code": "API_QUOTA_TIME"}))
+
+                    # 已经吐过文本就不能再 retry —— 否则前端会拼出"半截 + 重新生成"
+                    # 的怪异回复。直接 break 让半截文本走 finally 的 persist 路径。
+                    if emitted_any:
+                        logger.info(
+                            "prompt_ephemeral: %s 发生时已 emit 文本，放弃 retry",
+                            error_type,
+                        )
+                        break
+
+                    if attempt < max_retries - 1:
+                        wait_time = retry_delays[attempt]
+                        logger.warning(
+                            "prompt_ephemeral: LLM 调用失败 (尝试 %d/%d)，%d 秒后重试: %s",
+                            attempt + 1, max_retries, wait_time, error_type,
+                        )
+                        await asyncio.sleep(wait_time)
+                        continue
+
+                    # Retry 用尽：B 部分语义 —— 静默放弃。主动搭话失败用户
+                    # 不需要知道，只 log 一条 warning（截断 str(e) 防 HTML
+                    # 错误页淹没日志）。
+                    logger.warning(
+                        "prompt_ephemeral: %s 重试 %d 次后仍失败，静默放弃: %s",
+                        error_type, max_retries, str(e)[:200],
+                    )
+                    assistant_message = ""
+                    return False
         except Exception as e:
-            logger.error("OmniOfflineClient.prompt_ephemeral error: %s", e, exc_info=True)
-            if self.on_status_message:
-                await self.on_status_message(json.dumps({"code": "PROACTIVE_GEN_FAILED", "details": {"error_type": type(e).__name__, "error": str(e)}}))
+            # 兜底：非 API 错误（编程错误 / 数据异常）静默吞掉，截断错误文本
+            # 防 HTML 错误页之类淹没日志。和上方 (APIConnectionError 等) 分支
+            # 语义对偶 —— 都不向前端发 status_message。
+            logger.error(
+                "OmniOfflineClient.prompt_ephemeral 未分类异常 %s: %s",
+                type(e).__name__, str(e)[:200],
+                exc_info=True,
+            )
             assistant_message = ""
             return False
         finally:

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 LLM connection failed ({{error_type}}), exhausted {{max_retries}} retries: {{error}}",
         "TEXT_GEN_ERROR": "💥 Text generation error: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM returned no response. Please check your API connection and configuration.",
-        "PROACTIVE_GEN_FAILED": "💥 Proactive response generation failed: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}} is heading to another terminal...",
         "RELOAD_PAGE": "Voice updated, page will refresh shortly",
         "AGENT_AUTO_DISABLED_COMPUTER": "Keyboard/mouse control auto-disabled: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 Error en la conexión LLM ({{error_type}}), agotados {{max_retries}} reintentos: {{error}}",
         "TEXT_GEN_ERROR": "💥 Error de generación de texto: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM no obtuvo respuesta. Verifique su conexión y configuración de API.",
-        "PROACTIVE_GEN_FAILED": "💥 Error en la generación de respuesta proactiva: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}} se dirige a otra terminal...",
         "RELOAD_PAGE": "Voz actualizada, la página se actualizará en breve",
         "AGENT_AUTO_DISABLED_COMPUTER": "Control de teclado/ratón deshabilitado automáticamente: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 LLM接続失敗（{{error_type}}）、{{max_retries}}回リトライ済み: {{error}}",
         "TEXT_GEN_ERROR": "💥 テキスト生成エラー: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLMから応答がありませんでした。API接続と設定を確認してください。",
-        "PROACTIVE_GEN_FAILED": "💥 プロアクティブ応答の生成に失敗: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}}が別のターミナルに移動中...",
         "RELOAD_PAGE": "音声が更新されました。ページがまもなく更新されます",
         "AGENT_AUTO_DISABLED_COMPUTER": "キーボード/マウス制御が自動無効化されました: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 LLM 연결 실패 ({{error_type}}), {{max_retries}}회 재시도 완료: {{error}}",
         "TEXT_GEN_ERROR": "💥 텍스트 생성 오류: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM이 응답을 반환하지 않았습니다. API 연결 및 설정을 확인하세요.",
-        "PROACTIVE_GEN_FAILED": "💥 능동 응답 생성 실패: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}}이(가) 다른 터미널로 이동 중...",
         "RELOAD_PAGE": "음성이 업데이트되었습니다. 페이지가 곧 새로고침됩니다",
         "AGENT_AUTO_DISABLED_COMPUTER": "키보드/마우스 제어가 자동 비활성화되었습니다: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 Falha na conexão LLM ({{error_type}}), tentativas esgotadas de {{max_retries}}: {{error}}",
         "TEXT_GEN_ERROR": "💥 Erro de geração de texto: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM não retornou resposta. Verifique sua conexão e configuração da API.",
-        "PROACTIVE_GEN_FAILED": "💥 Falha na geração de resposta proativa: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}} está indo para outro terminal...",
         "RELOAD_PAGE": "Voz atualizada, a página será atualizada em breve",
         "AGENT_AUTO_DISABLED_COMPUTER": "Controle de teclado/mouse desabilitado automaticamente: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 Ошибка подключения LLM ({{error_type}}), исчерпано {{max_retries}} попыток: {{error}}",
         "TEXT_GEN_ERROR": "💥 Ошибка генерации текста: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM не вернул ответ. Проверьте подключение к API и настройки.",
-        "PROACTIVE_GEN_FAILED": "💥 Ошибка генерации проактивного ответа: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}} переходит на другой терминал...",
         "RELOAD_PAGE": "Голос обновлён, страница скоро обновится",
         "AGENT_AUTO_DISABLED_COMPUTER": "Управление клавиатурой/мышью автоматически отключено: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 LLM连接失败（{{error_type}}），已重试{{max_retries}}次: {{error}}",
         "TEXT_GEN_ERROR": "💥 文本生成异常: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM未返回任何回复，请检查API连接和配置",
-        "PROACTIVE_GEN_FAILED": "💥 主动回复生成失败: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}}正在前往另一个终端...",
         "RELOAD_PAGE": "语音已更新，页面即将刷新",
         "AGENT_AUTO_DISABLED_COMPUTER": "已自动关闭键鼠控制: $t(agent.precheck.{{reason_code}})",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -583,7 +583,6 @@
         "LLM_CONNECTION_EXHAUSTED": "💥 LLM連接失敗（{{error_type}}），已重試{{max_retries}}次: {{error}}",
         "TEXT_GEN_ERROR": "💥 文字生成異常: {{error_type}}: {{error}}",
         "LLM_NO_RESPONSE": "💥 LLM未回傳任何回覆，請檢查API連接和配置",
-        "PROACTIVE_GEN_FAILED": "💥 主動回覆生成失敗: {{error_type}}: {{error}}",
         "CHARACTER_SWITCHING_TERMINAL": "{{name}}正在前往另一個終端...",
         "RELOAD_PAGE": "語音已更新，頁面即將刷新",
         "AGENT_AUTO_DISABLED_COMPUTER": "已自動關閉鍵鼠控制: $t(agent.precheck.{{reason_code}})",


### PR DESCRIPTION
## 问题

主动搭话（`prompt_ephemeral`）失败时，上游 LLM 网关返回 5xx HTML 错误页（CDN/WAF 错误页）会被整段塞进 `PROACTIVE_GEN_FAILED` 的 `details.error`，前端 i18n 模板 `"💥 主动回复生成失败: {error_type}: {error}"` 原样渲染 —— 用户聊天窗里出现几屏 inline CSS。

更深层的两个问题：
- 主对话路径已经对 `InternalServerError` 特判成 `LLM_UPSTREAM_ERROR`（不带原文），主动搭话路径只有 `except Exception` 兜底裸奔，对偶性破了
- 主动搭话语义上用户没在等回复，失败本就不该弹个 💥 红色错误气泡

## 改动

**A. retry 套上**：`max_retries=3 / [1,2]s` 退避，捕获 `(APIConnectionError, InternalServerError, RateLimitError)`，与 `stream_text` 完全对偶。

**B. retry 用尽静默**：只 log warning（`str(e)[:200]` 防 HTML 错误页淹没日志），**不发** status_message。`PROACTIVE_GEN_FAILED` 状态码完全退役，8 个 locale 的 i18n 字串一并删掉。

**保留账户级错误上报**（用户必须知道）：
- 欠费 → `API_ARREARS`（放弃 retry）
- API Key 拒绝 → `API_KEY_REJECTED`（放弃 retry）
- 配额 → `API_QUOTA_TIME`（上报后继续 retry）

**mid-stream 失败保护**：已 emit 过文本则不 retry（避免拼出"半截 + 重新生成"），半截走 finally 的 persist 路径。

## 测试

- `tests/unit/test_proactive_*` 109 passed
- 8 个 locale JSON 仍合法
- `PROACTIVE_GEN_FAILED` 全仓 grep 0 结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进生成失败时的错误处理和重试机制，提供更精确的错误诊断信息。
  * 优化网络故障处理策略，防止用户看到重复生成的内容。

* **Localization**
  * 为多种语言（英文、西班牙文、日文、韩文、葡萄牙文、俄文、简体中文、繁体中文）添加新的错误消息支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->