### PR TITLE
fix(model-manager): 启用模型选择后的保存按钮以避免禁用状态

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -3632,8 +3632,13 @@ document.addEventListener('DOMContentLoaded', async () => {
                     type: 'mmd'
                 };
 
+                // 选择模型后立即启用保存按钮（即使是页面初始化的 suppressed 事件，
+                // 否则进入页面后只调属性时按钮会一直保持 HTML 模板里的 disabled）
+                if (savePositionBtn) {
+                    savePositionBtn.disabled = false;
+                }
+
                 if (!isSuppressedModelManagerChangeEvent(e)) {
-                    if (savePositionBtn) savePositionBtn.disabled = false;
                     window.hasUnsavedChanges = true;
                     markModelChangedForCardFacePrompt();
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **改进**
  * 优化了模型选择工作流：保存按钮现在在模型更改后立即启用，使用户可以更快地保存所做的更改。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->