### PR TITLE
fix(voice-swap): 切音色相关三处 race（连接失败 / 角色离开 / trigger_greeting 崩溃）

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2506,18 +2506,22 @@ class LLMSessionManager:
                 # 的"硬撕 voice → 重建 text"自动切换路径，把刚 ready 的 voice
                 # session 撕成 CHARACTER_LEFT / "角色离开"——这是用户在切音色
                 # 后开语音、麦启动期打字的典型 race。这里只防御 text → voice
-                # 这一条不对偶的路径；audio 在 _stream_data_now 缓存阶段已经
+                # 这一条不对偶的路径；screen / camera 等 vision 输入会在
+                # _process_stream_data_internal 里路由到
+                # OmniRealtimeClient.stream_image（5262-5278），是 voice session
+                # 的合法路径，不能误丢。audio 在 _stream_data_now 缓存阶段已经
                 # 直接 return 不缓存，pending_input_data 不会出现 audio。
                 is_voice_session = isinstance(self.session, OmniRealtimeClient)
                 dropped_text_for_voice = 0
                 for message in self.pending_input_data:
+                    msg_input_type = message.get("input_type")
                     try:
                         # 重新调用stream_data处理缓存的数据
                         # 注意：这里直接处理，不再缓存（因为session_ready已设为True）
-                        if message.get("input_type") == "audio":
+                        if msg_input_type == "audio":
                             await self._enqueue_audio_stream_data(message)
                         else:
-                            if is_voice_session:
+                            if is_voice_session and msg_input_type == "text":
                                 dropped_text_for_voice += 1
                                 continue
                             await self._process_stream_data_internal(message)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -4514,7 +4514,26 @@ class LLMSessionManager:
                 await self.state.fire(SessionEvent.PROACTIVE_PHASE2)
                 _sid_token = _proactive_expected_sid.set(proactive_sid)
                 try:
-                    delivered = await self.session.prompt_ephemeral(instruction)
+                    # 防御 stale session: 4429 start_session 之后到这里又过了
+                    # 多次 await（holiday hint / try_start_proactive /
+                    # _proactive_write_lock / self.lock / state.fire ×2），
+                    # 期间 cleanup / disconnected_by_server / 切音色重建路径
+                    # 都可能把 self.session 置 None 或换为 OmniRealtimeClient。
+                    # 直接 self.session.prompt_ephemeral 会触发 AttributeError
+                    # 把 trigger_greeting task 整个挂掉（参考切音色后并发
+                    # session 重建期间 trigger_greeting 撞 self.session=None
+                    # 的崩溃 trace）。先快照本地引用 + 类型校验，stale 时
+                    # 静默 skip，外层 finally 会 fire PROACTIVE_DONE 让 SM
+                    # 不卡在 PHASE2 / CLAIM。
+                    session_ref = self.session
+                    if not isinstance(session_ref, OmniOfflineClient):
+                        logger.info(
+                            "[%s] trigger_greeting: session swapped/nullified "
+                            "before prompt_ephemeral (now=%s), skipping",
+                            self.lanlan_name, type(session_ref).__name__,
+                        )
+                        return
+                    delivered = await session_ref.prompt_ephemeral(instruction)
                 finally:
                     _proactive_expected_sid.reset(_sid_token)
                 logger.info("[%s] trigger_greeting: delivered=%s", self.lanlan_name, delivered)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2498,8 +2498,18 @@ class LLMSessionManager:
         async with self.input_cache_lock:
             if not self.pending_input_data:
                 return
-            
+
             if self.session and self.is_active:
+                # 缓存阶段（_stream_data_now）不知道 session 最终是 voice 还是
+                # text。如果最终启好的是 voice session，缓存里的 text 输入若
+                # 直接 flush 进 _process_stream_data_internal，会触发 4977-4995
+                # 的"硬撕 voice → 重建 text"自动切换路径，把刚 ready 的 voice
+                # session 撕成 CHARACTER_LEFT / "角色离开"——这是用户在切音色
+                # 后开语音、麦启动期打字的典型 race。这里只防御 text → voice
+                # 这一条不对偶的路径；audio 在 _stream_data_now 缓存阶段已经
+                # 直接 return 不缓存，pending_input_data 不会出现 audio。
+                is_voice_session = isinstance(self.session, OmniRealtimeClient)
+                dropped_text_for_voice = 0
                 for message in self.pending_input_data:
                     try:
                         # 重新调用stream_data处理缓存的数据
@@ -2507,11 +2517,20 @@ class LLMSessionManager:
                         if message.get("input_type") == "audio":
                             await self._enqueue_audio_stream_data(message)
                         else:
+                            if is_voice_session:
+                                dropped_text_for_voice += 1
+                                continue
                             await self._process_stream_data_internal(message)
                     except Exception as e:
                         logger.error(f"💥 发送缓存的输入数据失败: {e}")
                         break
-            
+                if dropped_text_for_voice:
+                    logger.info(
+                        "[%s] _flush_pending_input_data: dropped %d cached text "
+                        "message(s) because final session is voice mode",
+                        self.lanlan_name, dropped_text_for_voice,
+                    )
+
             # 清空缓存
             self.pending_input_data.clear()
     

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1683,7 +1683,11 @@ async def update_catgirl_voice_id(name: str, request: Request):
                 logger.info(f"{name} 的session已结束")
             except Exception as e:
                 logger.error(f"结束session时出错: {e}")
-    
+            # 切音色后，前一会话累计的失败计数 / 熔断不再适用：
+            # reload 页面后用户的下一次 start_session 应是全新尝试，否则
+            # 这条 SessionManager 实例还会被旧失败计数 / 熔断继续静默拦截。
+            session_manager[name].reset_session_start_circuit()
+
     # 方案3：条件性重新加载 - 只有当前猫娘才重新加载配置
     if is_current_catgirl:
         # 3. 重新加载配置，让新的voice_id生效
@@ -1959,6 +1963,9 @@ async def unregister_voice(name: str):
                     logger.info(f"{name} 的session已结束")
                 except Exception as e:
                     logger.error(f"结束session时出错: {e}")
+                # 与 set_voice_id 路径对偶：清掉前一会话的失败计数 / 熔断，
+                # 否则 reload 后新 start_session 会被旧熔断静默拦截。
+                session_manager[name].reset_session_start_circuit()
 
         # 自动重新加载配置
         if is_current_catgirl:
@@ -2522,6 +2529,9 @@ async def update_catgirl(name: str, request: Request):
                 logger.info(f"{name} 的session已结束")
             except Exception as e:
                 logger.error(f"结束session时出错: {e}")
+            # 与 set_voice_id 路径对偶：清掉前一会话的失败计数 / 熔断，
+            # 否则 reload 后新 start_session 会被旧熔断静默拦截。
+            session_manager[name].reset_session_start_circuit()
 
         if is_current_catgirl:
             # Fast path：只刷新被编辑角色的 session_manager（prompt/voice_id），
@@ -3008,6 +3018,9 @@ async def delete_voice(voice_id: str):
                         logger.info(f"已结束受影响角色 {name} 的 session")
                     except Exception as e:
                         logger.error(f"结束受影响角色 {name} 的 session 时出错: {e}")
+                    # 与 set_voice_id 路径对偶：清掉前一会话的失败计数 / 熔断，
+                    # 否则 reload 后新 start_session 会被旧熔断静默拦截。
+                    session_manager[name].reset_session_start_circuit()
 
                 if affected_active_names:
                     await asyncio.gather(

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1788,6 +1788,12 @@
                     if (typeof window.showStatusToast === 'function') {
                         window.showStatusToast(reloadMsg || (window.t ? window.t('app.configUpdated') : '配置已更新，页面即将刷新'), 3000);
                     }
+                    // 后端在发 reload_page 之前已经 end_session，前端 2.5s 后才真
+                    // reload。这 2.5s 内 isTextSessionActive 若残留 true，用户敲
+                    // 文字会绕过 start_session action 直接送 stream_data，错过
+                    // websocket_router 的 reset_session_start_circuit 守卫，触发
+                    // 后端"未指定 ↔ 免费 音色切换后概率连接失败"那条路径。
+                    S.isTextSessionActive = false;
                     setTimeout(function () {
                         console.log(window.t('console.reloadPageStarting'));
                         if (window.closeAllSettingsWindows) window.closeAllSettingsWindows();


### PR DESCRIPTION
## 修了什么

切音色 / voice swap 触发的三个独立 race，凑在一起表现为「切完音色直接发文字概率失败、开语音概率角色离开、greeting task 静默崩溃」。

| | Bug | 状态 |
|---|---|---|
| **A** | 切「免费 ↔ 未指定」音色后立刻发文字概率失败，弹「连接失败」toast | 基于代码分析的对偶防御，本次提交的日志窗口里没复现到 trigger condition |
| **B** | 切音色后立刻开语音、麦启动期打字，概率没文本显示并触发「角色离开」 | 日志实证：17 秒内 audio↔text **6 次**硬撕重建，2 次 `💥 文本模式Session重建失败，放弃本次数据流` |
| **C** | `trigger_greeting` 在 `prompt_ephemeral` 调用时撞 `self.session=None` 崩溃 | 日志实证：`AttributeError: 'NoneType' object has no attribute 'prompt_ephemeral'` |

## 根因

**A**：voice swap 路径的 `end_session(by_server=True)` 没清 `_session_start_circuit_open` / `session_start_failure_count`。`websocket_router` 的 `reset_session_start_circuit()` 守卫只覆盖用户显式 `start_session` action，绕过它的 auto-create 路径会保留旧失败计数。**注**：本次提交的日志窗口里失败次数从未累积到 ≥3，没有复现到熔断 early-return 路径——但代码读上去对偶性确实缺一块，按防御性补齐，后续若有日志能复现可锁实。

**B**：text 输入在 `_starting_session_count > 0` 时被缓存到 `pending_input_data`，voice session ready 后 `_flush_pending_input_data` 把它 flush 到 `_process_stream_data_internal`，触发 `core.py:4977-4995` 的「硬撕 voice → 重建 text」自动切换路径，刚 ready 的 voice session 被撕。日志里看到此模式振荡 6 次、累计丢弃 399 个 audio chunk。

**C**：`trigger_greeting` 走 auto-start text session → 多次 `await`（holiday hint / `try_start_proactive` / `_proactive_write_lock` / `self.lock` / `state.fire ×2`）到达 `prompt_ephemeral`。期间另一条 `cleanup` / `disconnected_by_server` 路径可把 `self.session` 置 None，直接 `await self.session.prompt_ephemeral(...)` 触发 `AttributeError`，task 静默死，外层 SM `PROACTIVE_DONE` 也不 fire（卡在 PHASE2）。

## 改动

- **`characters_router.py` × 4**：voice swap 路径在 `end_session` 后调 `reset_session_start_circuit()`。语义上等价于 websocket_router 收到用户显式 `start_session` action 时的清理路径——切音色本身就是用户显式行为。**(A)**
- **`app-websocket.js`**：`reload_page` 处理时同步置 `isTextSessionActive=false`，关 reload 前 2.5s 窗口期：用户输入文字会走 `start_session` action（过 websocket_router 的 reset 守卫），而不是绕过去裸送 stream_data。**(A)**
- **`_flush_pending_input_data`**：voice session ready 时丢弃缓存的 **text** 输入仅 log，不触发硬撕重建。`screen` / `camera` vision 输入正常 fall through 到 `OmniRealtimeClient.stream_image`（Codex/CodeRabbit P2 follow-up）；`audio` 在 `_stream_data_now` 缓存阶段就直接 return，pending 不会出现 audio。**(B)**
- **`trigger_greeting`**：`prompt_ephemeral` 调用前快照 `self.session` 到本地变量 + isinstance 校验（与 4436-4438 处 start_session 后立即做的同型校验对偶）。stale 时静默 return，外层 finally 仍会 fire `PROACTIVE_DONE` 让 SM 不卡在 PHASE2。**(C)**

整体 +60 行 / -3 行，没有改任何已存在路径的行为，只在 race 路径上加守护。

## ⚠️ 已知未修

同型 stale-session race 在 `trigger_agent_callbacks(4146)` / `trigger_new_character_greeting(4366)` / 另一处 proactive 路径(4609) / `handle_stream` agent callback inject(5124) 也存在 4 个 `self.session.prompt_ephemeral(...)` 调用点。目前只有 `trigger_greeting` 这条有崩溃 trace 实证，按「只在有证据的路径加守护」的保守原则**不一并改**，留待后续单独验证后再补。

## Test plan

- [ ] 切「免费 preset 音色」→「未指定音色」→ 等 reload → 立刻发文字（不等主动招呼），不应再有「连接失败」（A）
- [ ] 反向操作（未指定 → 免费 preset），同样路径验证（A）
- [ ] 切音色后立刻开麦，麦启动期打字，不应触发「角色离开」（B；日志里 dropped/total_dropped/重建次数应明显减少）
- [ ] 切音色 + reload 期间 trigger_greeting 自动触发，不应再有 `AttributeError: 'NoneType' object has no attribute 'prompt_ephemeral'`（C）
- [ ] 正常路径回归（不切音色、单纯发文字 / 开麦、热切角色等），行为不变

观测信号：
- `🔄 重置 session 启动熔断` — 命中 (A)
- `[xxx] _flush_pending_input_data: dropped N cached text message(s) because final session is voice mode` — 命中 (B)
- `[xxx] trigger_greeting: session swapped/nullified before prompt_ephemeral (now=...)` — 命中 (C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

* **Bug 修复**
  * 改进文本/语音会话切换：在语音会话下仅转发音频输入并丢弃文本缓存，避免错误处理
  * 修复更新或删除语音设置后导致会话启动被阻塞的问题：重置会话启动电路以允许后续启动
  * 优化主动问候逻辑：在异步等待后校验会话快照，若会话已被替换或无效则跳过调用
  * 优化页面重载时的会话状态重置，防止重载延迟期间残留状态影响会话行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->