### PR TITLE
fix(game-window): 游戏期间隐藏 pet 上其余可交互 UI 让窗口真正穿透

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -321,12 +321,32 @@ button * {
     visibility: hidden;
 }
 
-/* 游戏路由激活期间隐藏所有 avatar 容器（live2d / vrm / mmd 三家），让 pet 透明
-   窗口在 mini-game 进行时不抢屏。chat.html 收缩 + pet 隐藏由后端
-   game_window_state_change WS 事件统一驱动，game_route_end 时同步还原。 */
+/* 游戏路由激活期间隐藏 pet 透明窗口上一切可见的可交互 UI，让 mini-game
+   进行时整张 pet 页面既不挡屏也不挡鼠标——只有这样 Electron preload 的
+   elementFromPoint 轮询才会拿到空命中，setIgnoreMouseEvents 把窗口翻成
+   穿透态，鼠标真正落到底下的 mini-game 窗口或桌面。
+   chat.html 收缩 + pet 隐藏由后端 game_window_state_change WS 事件统一
+   驱动，game_route_end 时同步还原（class 由 templates/index.html 内联
+   监听器在 closed 时移除）。
+   覆盖范围分两类：
+     1) 静态容器：avatar 三家（live2d/vrm/mmd）+ chat 主面板 + 字幕条 +
+        React chat 浮窗 + avatar preview 弹窗 + status toast。
+        #sidebar 自带 inline display:none 不需要再列。
+     2) 动态浮动 UI：avatar-ui-buttons.js 用 `{prefix}-floating-buttons` /
+        `{prefix}-return-button-container` / `{prefix}-lock-icon` 三组 ID
+        命名约定（live2d / vrm / mmd 各一份）注入到 body，靠属性后缀
+        匹配统一收掉，避免漏一个 prefix 留个浮动按钮挡鼠标。 */
 body.neko-game-active #live2d-container,
 body.neko-game-active #vrm-container,
-body.neko-game-active #mmd-container {
+body.neko-game-active #mmd-container,
+body.neko-game-active #chat-container,
+body.neko-game-active #status-toast,
+body.neko-game-active #subtitle-display,
+body.neko-game-active #react-chat-window-overlay,
+body.neko-game-active #chat-avatar-preview-popup,
+body.neko-game-active [id$="-floating-buttons"],
+body.neko-game-active [id$="-return-button-container"],
+body.neko-game-active [id$="-lock-icon"] {
     display: none !important;
 }
 


### PR DESCRIPTION
PR #1153 follow-up。

## 问题

#1153 在 pet (index.html) 这条线只做了一件事——给 body 加 `neko-game-active` class，再用 CSS 把 `#live2d-container / #vrm-container / #mmd-container` 三个 avatar 容器 `display:none`。结果游戏期间：

1. **按钮还在**：`#chat-container` 仍然挂在那里，带 avatar preview / reactChat / 截图 / 发送按钮 + textarea；`#subtitle-display`、`#react-chat-window-overlay`、`#status-toast`、`#chat-avatar-preview-popup` 同样不受影响；`avatar-ui-buttons.js` 注入的 `{live2d,vrm,mmd}-floating-buttons` / `*-return-button-container` / `*-lock-icon` 浮动按钮也还在
2. **穿透坏掉**：Electron pet 窗口靠 preload 轮询 `elementFromPoint(x,y)` 命中是否 `pointer-events:none` 来切 `setIgnoreMouseEvents`。上面这些元素都是 `pointer-events:auto`，cursor 落在它们身上时 preload 拒绝穿透 → 鼠标点不到底下的 mini-game 窗口或桌面

PR #1153 的 "Out of scope" 自己也承认了"当前先 display:none 隐藏整块容器"，但只覆盖了 3 个 avatar 容器、没把 pet 页面剩下的 UI 一并处理。

## 修法

`static/css/index.css:327` 那条 `body.neko-game-active` selector 扩成两类：

- **静态 ID**：补上 `#chat-container`、`#status-toast`、`#subtitle-display`、`#react-chat-window-overlay`、`#chat-avatar-preview-popup`（`#sidebar` 自带 inline `display:none` 跳过）
- **动态浮动**：用属性后缀 `[id$="-floating-buttons"]` / `[id$="-return-button-container"]` / `[id$="-lock-icon"]` 一次匹配 live2d/vrm/mmd 三套（命名规则源自 `static/avatar-ui-buttons.js:189-193`）

class 在 `game_window_state_change=closed` 时由 `templates/index.html` 既有的内联监听器移除，平时态完全不受影响。

## Test plan

- [ ] 游戏期间 pet (index.html) 上不再看到任何 chat / 字幕 / 浮动按钮
- [ ] 鼠标在 pet 窗口原本被按钮占位的区域可以点穿到底下的 mini-game / 桌面
- [ ] 退出游戏 (`game_route_end`) 后所有 UI 自然恢复（CSS class 移除即可，无快照逻辑）
- [ ] live2d / vrm / mmd 三种模式都验证浮动按钮被收掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sULGM31RdR83emnkxzALQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **风格改进**
  * 优化了小游戏模式下的界面显示，隐藏更多不必要的UI元素，提供更沉浸式的游戏体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->