### PR TITLE
Galgame 依赖安装时自动定位安装面板

### DIFF
--- a/plugin/plugins/galgame_plugin/static/index.html
+++ b/plugin/plugins/galgame_plugin/static/index.html
@@ -385,7 +385,7 @@
           </details>
         </section>
 
-        <section class="panel">
+        <section id="installSection" class="panel">
           <div class="panel-title-row">
             <h2 data-i18n="ui.install.title">依赖安装</h2>
           </div>

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -5477,6 +5477,9 @@ async function withButtonPending(buttonOrId, pendingText, fn) {
 
 async function startInstall(kind, force = false) {
   const config = getInstallConfig(kind);
+
+  navigateToInstallPanel(kind);
+
   const state = getInstallState(kind);
   const { button } = getInstallNodes(kind);
   state.inProgress = true;
@@ -6427,6 +6430,45 @@ function switchInstallTab(tab) {
   const memoryBanner = document.getElementById('textractorPrompt');
   if (memoryBanner) {
     memoryBanner.hidden = false;
+  }
+}
+
+function navigateToInstallPanel(kind) {
+  const advancedSettings = document.getElementById('advancedSettings');
+  const advancedToggleBtn = document.getElementById('advancedToggleBtn');
+  const dependencyModule = document.getElementById('dependencyModule');
+  const installSection = document.getElementById('installSection');
+
+  localStorage.setItem('galgame_skip_onboarding', '1');
+  document.body.classList.remove('onboarding-active');
+  const onboardingView = document.getElementById('onboardingView');
+  if (onboardingView) {
+    onboardingView.hidden = true;
+  }
+
+  if (advancedSettings && !advancedSettings.classList.contains('open')) {
+    advancedSettings.classList.add('open');
+    if (advancedToggleBtn) {
+      advancedToggleBtn.textContent = uiT('ui.advanced.collapse_settings', '收起高级设置');
+    }
+    const firstRunGuide = document.getElementById('firstRunGuide');
+    if (firstRunGuide) {
+      firstRunGuide.hidden = true;
+    }
+  }
+
+  if (dependencyModule && !dependencyModule.open) {
+    dependencyModule.open = true;
+  }
+
+  if (OCR_INSTALL_TABS.includes(kind)) {
+    switchInstallTab(kind);
+  }
+
+  if (installSection) {
+    requestAnimationFrame(() => {
+      installSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
   }
 }
 

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -6439,7 +6439,11 @@ function navigateToInstallPanel(kind) {
   const dependencyModule = document.getElementById('dependencyModule');
   const installSection = document.getElementById('installSection');
 
-  localStorage.setItem('galgame_skip_onboarding', '1');
+  try {
+    localStorage.setItem('galgame_skip_onboarding', '1');
+  } catch (error) {
+    console.warn('[galgame_plugin ui] persist onboarding skip failed', error);
+  }
   document.body.classList.remove('onboarding-active');
   const onboardingView = document.getElementById('onboardingView');
   if (onboardingView) {


### PR DESCRIPTION
## 概述
  - 为 Galgame 依赖安装面板新增 `installSection` 定位锚点。
  - 点击依赖安装前自动展开高级设置和依赖安装模块。
  - RapidOCR、DXcam、Tesseract 安装时自动切换到对应 OCR 安装 tab。
  - 从 onboarding 首屏触发安装时，自动退出 onboarding，确保主界面安装进度可见。

  ## 验证
  - 已执行 `node --check N.E.K.O\plugin\plugins\galgame_plugin\static\main.js`。
  - 已确认变更范围仅限 Galgame 插件静态 UI 文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在高级设置中新增集中安装面板，将依赖安装流程整合为一处，界面更清晰易用
  * 为常见模块（OCR、截图/记忆相关等）提供独立选项卡与操作，便于选择和管理
  * 改进安装流程导航，支持一键跳转并聚焦到安装区域，简化用户操作与上手流程
<!-- end of auto-generated comment: release notes by coderabbit.ai -->