### PR TITLE
调整卡面编辑页打开逻辑，已有编辑页时优先打开新窗口并关闭旧窗口；若新窗口打开失败，则回退刷新旧窗口，确保编辑页不多开且内容遵循最后一次打开

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -2917,9 +2917,15 @@ function openManagedPopup(url, windowName, features) {
         const replacementName = `${windowName}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
         const replacementWindow = window.open(url, replacementName, features);
         if (replacementWindow) {
+            try { existingWindow.close(); } catch (_) {}
+            try {
+                // 随机名只用于绕开旧窗口复用；新窗口接管后恢复固定名称，方便其他上下文继续定位。
+                replacementWindow.name = windowName;
+            } catch (error) {
+                console.warn('更新弹窗名称失败:', error);
+            }
             window._openWindows[windowName] = replacementWindow;
             try { replacementWindow.focus(); } catch (_) {}
-            try { existingWindow.close(); } catch (_) {}
             return replacementWindow;
         }
 

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -2896,6 +2896,7 @@ async function loadCharacterCards() {
 
 // 已设置卡面的猫娘名集合（避免无卡面的 404 控制台噪声）
 window._cardFaceNames = window._cardFaceNames || new Set();
+const CHARACTER_MANAGER_CARD_MAKER_WINDOW_NAME = 'neko_card_maker';
 async function loadCardFaceNames() {
     try {
         const resp = await fetch('/api/characters/card-faces');
@@ -2913,6 +2914,21 @@ function openManagedPopup(url, windowName, features) {
     window._openWindows = window._openWindows || {};
     const existingWindow = window._openWindows[windowName];
     if (existingWindow && !existingWindow.closed) {
+        const replacementName = `${windowName}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+        const replacementWindow = window.open(url, replacementName, features);
+        if (replacementWindow) {
+            window._openWindows[windowName] = replacementWindow;
+            try { replacementWindow.focus(); } catch (_) {}
+            try { existingWindow.close(); } catch (_) {}
+            return replacementWindow;
+        }
+
+        try {
+            // 新窗口被拦截时才复用旧窗口，仍然保证内容跟随最后一次打开。
+            existingWindow.location.href = new URL(url, window.location.origin).toString();
+        } catch (error) {
+            console.warn('更新弹窗地址失败:', error);
+        }
         existingWindow.focus();
         return existingWindow;
     }
@@ -2925,6 +2941,7 @@ function openManagedPopup(url, windowName, features) {
     }
     return popup;
 }
+window.openManagedPopup = openManagedPopup;
 
 function refreshOpenCardMetaBlock(name) {
     const panelWrapper = document.getElementById('catgirl-panel-wrapper');
@@ -4126,8 +4143,7 @@ function openCatgirlPanel(card, originEl) {
             return;
         }
         const makerUrl = `/card_maker?name=${encodeURIComponent(currentName)}&mode=maker`;
-        const windowName = `card_maker_${encodeURIComponent(currentName)}`;
-        openManagedPopup(makerUrl, windowName, 'width=1200,height=800');
+        openManagedPopup(makerUrl, CHARACTER_MANAGER_CARD_MAKER_WINDOW_NAME, 'width=1200,height=800');
     };
 
     // 点击卡面主体或右侧按钮打开角色卡制作页面
@@ -5680,7 +5696,7 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
                 const makerUrl = `/card_maker?name=${encodeURIComponent(catgirlName)}&mode=maker`;
                 const makerWindow = openManagedPopup(
                     makerUrl,
-                    `card_maker_${encodeURIComponent(catgirlName)}`,
+                    CHARACTER_MANAGER_CARD_MAKER_WINDOW_NAME,
                     'width=1200,height=800'
                 );
                 if (!makerWindow) {

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -674,6 +674,8 @@ async function notifyMainPageModelReload() {
     }
 }
 
+const MODEL_MANAGER_CARD_MAKER_WINDOW_NAME = 'neko_card_maker';
+
 function openCardMakerFromModelManager(lanlanName, options = {}) {
     const params = new URLSearchParams({
         name: lanlanName,
@@ -692,13 +694,16 @@ function openCardMakerFromModelManager(lanlanName, options = {}) {
     // 否则模型管理页关闭时，部分 Electron/浏览器环境会连带关闭卡面制作页。
     if (window.opener && !window.opener.closed) {
         try {
-            return window.opener.open(url, '_blank', features);
+            if (typeof window.opener.openManagedPopup === 'function') {
+                return window.opener.openManagedPopup(url, MODEL_MANAGER_CARD_MAKER_WINDOW_NAME, features);
+            }
+            return window.opener.open(url, MODEL_MANAGER_CARD_MAKER_WINDOW_NAME, features);
         } catch (error) {
             console.warn('[模型管理] 通过父窗口打开卡面制作页失败，回退当前窗口打开:', error);
         }
     }
 
-    return window.open(url, '_blank', features);
+    return window.open(url, MODEL_MANAGER_CARD_MAKER_WINDOW_NAME, features);
 }
 
 function notifyCardFaceUpdatedFromModelManager(name) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增统一的弹窗管理机制，改善卡牌编辑器窗口的打开与替换行为，提升跨窗口交互体验。

* **Bug 修复**
  * 修复并稳定了弹出窗口的管理逻辑，减少重复或失效窗口的问题。
  * 增强了与自定义弹窗打开接口的兼容性。
  * 统一了卡牌编辑器窗口的命名与打开流程，减少混乱和错误。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->