### PR TITLE
fix(i18n): soccer / proactive 残余 Steam locale race —— 多路径 belt-and-su…

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -190,7 +190,7 @@ from utils.api_config_loader import (
     get_livestream_config,
     is_livestream_active,
 )
-from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full
+from utils.language_utils import normalize_language_code, get_global_language, get_global_language_full, is_supported_language_code
 import threading
 from threading import Thread
 from queue import Queue, Empty
@@ -5533,6 +5533,16 @@ class LLMSessionManager:
         """
         if not language:
             logger.warning(f"语言参数为空，保持当前语言: {self.user_language}")
+            return
+
+        # 校验原始输入：``normalize_language_code`` 对未识别值会默认回退 ``'en'``，
+        # 外部来源（ws ``message['language']`` 携带的 corrupted ``localStorage``、
+        # 第三方客户端发的 ``'undefined'`` / ``'null'`` / ``'estonian'`` 等 garbage）
+        # 会被静默归一成 ``'en'``，覆盖正确的 session locale。先用公共白名单挡掉。
+        if not is_supported_language_code(language):
+            logger.warning(
+                f"语言参数不支持: {language!r}，保持当前语言: {self.user_language}"
+            )
             return
 
         # 使用公共函数进行语言代码归一化

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2760,8 +2760,15 @@ class LLMSessionManager:
         self._memory_error_retry_after = 0
 
     async def start_session(self, websocket: WebSocket, new=False, input_mode='audio'):
-        # 每次 start_session 都重新获取全局语言，确保 Steam/系统语言变更能即时生效
-        self.user_language = normalize_language_code(get_global_language(), format='short')
+        # 之前每次 start_session 都无脑用 get_global_language() 覆盖 user_language，
+        # 想"语言变更即时生效"，但实际效果是把 ws greeting_check 已经推上来的
+        # 前端 i18n 真值（例如 Steam=zh / 系统=en 时正确的 'zh-CN'）一律打回错的
+        # 全局缓存值（race 失败时的 'en'），让游戏 / proactive / memory 的 prompt
+        # 全部回退英文。改为：仅在 user_language 还没被设过时才 seed 一次，已经
+        # 有 session 真值就保留——全局缓存晚到的更新由 refresh_global_language
+        # 路径独立处理（见 main_routers/config_router.py:steam_language 端点）。
+        if not getattr(self, 'user_language', None):
+            self.user_language = normalize_language_code(get_global_language(), format='short')
         # 重置防刷屏标志
         self.session_closed_by_server = False
         self.last_audio_send_error_time = 0.0

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5301,7 +5301,6 @@ class LLMSessionManager:
                         av_pos = message.get('avatar_position')
                         if av_pos and isinstance(av_pos, dict):
                             try:
-                                from utils.language_utils import get_global_language_full
                                 image_b64 = await asyncio.to_thread(
                                     overlay_avatar_annotation,
                                     image_b64, av_pos, self.lanlan_name,

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -447,8 +447,8 @@ async def get_steam_language():
     - 如果 IP 国家代码为 "CN"，则标记为中国大陆用户
     - 如果不存在 Steam 语言设置（无 Steam 环境），默认为非大陆用户
     """
-    from utils.language_utils import normalize_language_code
-    
+    from utils.language_utils import normalize_language_code, refresh_global_language
+
     try:
         steamworks = get_steamworks()
         
@@ -472,7 +472,18 @@ async def get_steam_language():
         # 使用 language_utils 的归一化函数，统一映射逻辑
         # format='full' 返回 'zh-CN', 'zh-TW', 'en', 'ja', 'ko' 格式（用于前端 i18n）
         i18n_language = normalize_language_code(steam_language, format='full')
-        
+
+        # 把这一次 Steam 真值回写到进程全局缓存：``initialize_global_language`` 在启动
+        # 时只读一次 Steam SDK，race 失败就锁死系统 locale；前端 bootstrap 这次能拿到
+        # 对的 schinese → zh-CN，把它顺手塞回缓存，下游 ``get_global_language()``
+        # 全部受益（mini-game prompt / memory / reflection / tts ...）。函数自己有
+        # "无变化即 no-op" 的守卫，前端反复刷新也不会刷屏。
+        if i18n_language:
+            try:
+                refresh_global_language(i18n_language)
+            except Exception:
+                logger.debug("refresh_global_language 失败", exc_info=True)
+
         # 获取用户 IP 所在国家（用于判断是否为中国大陆用户）
         ip_country = None
         is_mainland_china = False

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -447,7 +447,7 @@ async def get_steam_language():
     - 如果 IP 国家代码为 "CN"，则标记为中国大陆用户
     - 如果不存在 Steam 语言设置（无 Steam 环境），默认为非大陆用户
     """
-    from utils.language_utils import normalize_language_code, refresh_global_language
+    from utils.language_utils import normalize_language_code, refresh_global_language, is_supported_language_code
 
     try:
         steamworks = get_steamworks()
@@ -478,9 +478,13 @@ async def get_steam_language():
         # 对的 schinese → zh-CN，把它顺手塞回缓存，下游 ``get_global_language()``
         # 全部受益（mini-game prompt / memory / reflection / tts ...）。函数自己有
         # "无变化即 no-op" 的守卫，前端反复刷新也不会刷屏。
-        if i18n_language:
+        # 注意校验**原始 steam_language**而非 normalize 后的 i18n_language——后者对空 /
+        # 未知输入会默认回退 'en'，那是一个合法值能通过 refresh 内部白名单，会把已经
+        # 正确的全局缓存（来自 startup init / 上一次有效刷新）误覆盖成 en；前端 i18n
+        # 兜底用 'en' 不受影响（i18n_language 仍正常返回）。
+        if is_supported_language_code(steam_language):
             try:
-                refresh_global_language(i18n_language)
+                refresh_global_language(steam_language)
             except Exception:
                 logger.debug("refresh_global_language 失败", exc_info=True)
 

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -67,7 +67,7 @@ from utils.game_route_state import (
     is_game_route_active,
     register_voice_transcript_handler,
 )
-from utils.language_utils import get_global_language, normalize_language_code
+from utils.language_utils import get_global_language, normalize_language_code, is_supported_language_code
 from utils.logger_config import get_module_logger
 
 logger = get_module_logger(__name__, "Game")
@@ -1002,6 +1002,11 @@ def _absorb_request_language(data: Any, lanlan_name: str | None) -> str | None:
         return None
     raw = data.get('i18n_language') or data.get('language') or data.get('lang')
     if not raw:
+        return None
+    # 前端 / 第三方客户端可能传 ``'undefined'`` / corrupted localStorage / 任意 garbage，
+    # ``normalize_language_code`` 对未识别值默认回退 ``'en'``，会静默把 mgr.user_language
+    # 翻成英文。回写 session 状态前先用公共白名单 helper 挡掉。
+    if not is_supported_language_code(raw):
         return None
     try:
         normalized_short = normalize_language_code(str(raw), format='short')

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -5431,9 +5431,12 @@ async def game_quick_lines(game_type: str, request: Request):
             current_name = _get_current_character_info().get("lanlan_name") or ""
         except Exception:
             current_name = ""
-        _absorb_request_language(data, current_name)
+        # quick-lines 是 soccer 流程里第一个 LLM 端点：接住 _absorb_request_language
+        # 的返回值，避免在 SessionManager 还没 ready / mgr 拿不到的窗口下，char_info 的
+        # user_language 仍 stale 在全局缓存的旧值（首批 quick lines 落英文）。
+        request_language = _absorb_request_language(data, current_name)
         char_info = _get_current_character_info()
-        language = char_info.get("user_language")
+        language = request_language or char_info.get("user_language")
         prompt = get_soccer_quick_lines_prompt(language).format(
             name=char_info['lanlan_name'],
             personality=char_info['lanlan_prompt'],

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -989,8 +989,64 @@ def _normalize_quick_lines(value: Any) -> Dict[str, list[str]]:
     return normalized
 
 
-def _resolve_game_prompt_language(lanlan_name: str | None = None) -> str:
-    """Resolve the user's current language for game-route LLM prompts."""
+def _absorb_request_language(data: Any, lanlan_name: str | None) -> str | None:
+    """从 request body 抽出前端 i18n 真值，并顺手回写到 ``mgr.user_language``。
+
+    动机：``mgr.user_language`` 在 ``start_session`` 路径会被全局缓存覆盖（见
+    ``main_logic/core.py``），全局缓存又是 Steam SDK 启动期 race 失败的产物。前端
+    i18n 已经异步从 ``/api/config/steam_language`` 拿到对的值，只要把它在请求体
+    里捎带过来，就能即时纠正 session 状态。返回归一化后的短码（``zh`` / ``en`` ...）；
+    取不到时返回 ``None``，让上层走旧的兜底链。
+    """
+    if not isinstance(data, dict):
+        return None
+    raw = data.get('i18n_language') or data.get('language') or data.get('lang')
+    if not raw:
+        return None
+    try:
+        normalized_short = normalize_language_code(str(raw), format='short')
+    except Exception:
+        return None
+    if not normalized_short:
+        return None
+    try:
+        name = str(lanlan_name or "").strip()
+        if name:
+            session_manager = get_session_manager()
+            manager = session_manager.get(name) if hasattr(session_manager, "get") else None
+            if manager is not None:
+                normalized_full = normalize_language_code(str(raw), format='full')
+                current = getattr(manager, "user_language", None)
+                if normalized_full and current != normalized_full:
+                    setter = getattr(manager, "set_user_language", None)
+                    if callable(setter):
+                        setter(str(raw))
+    except Exception:
+        logger.debug("🎮 absorb request language 失败 lanlan=%s", lanlan_name, exc_info=True)
+    return normalized_short
+
+
+def _resolve_game_prompt_language(
+    lanlan_name: str | None = None,
+    data: Any = None,
+) -> str:
+    """Resolve the user's current language for game-route LLM prompts.
+
+    优先级（与 ``main_routers/system_router._resolve_proactive_locale`` 同形）：
+      1. ``data`` (request body) 里的 ``i18n_language`` / ``language`` / ``lang``
+         —— 前端显式传，最高优先；同时把值回写到 ``mgr.user_language``，让本次
+         请求里所有不接 data 的下游 ``_resolve_game_prompt_language`` 也命中。
+      2. ``mgr.user_language`` —— websocket greeting_check 同步的 session 真值。
+      3. ``get_global_language()`` —— 进程级缓存，最后兜底。
+
+    第 1 层是 PR #1150 之外的洞：Steam=zh / 系统=en 的环境下，``mgr.user_language``
+    在 ``start_session`` 时会被全局缓存（错的 'en'）覆盖，soccer 短路在前端 ws
+    greeting_check 还没把对的值推上来之前发起，就只能拿到错的 'en'。把请求体里
+    携带的 i18n 真值作为最优先来源，配合自愈写回，把这条 race 关掉。
+    """
+    request_lang = _absorb_request_language(data, lanlan_name)
+    if request_lang:
+        return request_lang
     try:
         name = str(lanlan_name or "").strip()
         session_manager = get_session_manager()
@@ -4206,6 +4262,10 @@ async def game_chat(game_type: str, request: Request):
     session_id = str(data.get('session_id', 'default'))
     event = data.get('event', {})
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+    # 把请求体里的 i18n 真值同步进 mgr.user_language，让本次 game_chat → _run_game_chat
+    # → _get_character_info 链上 _resolve_game_prompt_language 拿到的 user_language
+    # 与前端 i18n 保持一致，而不是被早期 start_session 覆盖回去的全局缓存值。
+    _absorb_request_language(data, lanlan_name)
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
     if state and state.get("session_id") == session_id:
         _update_game_memory_enabled_from_payload(state, data)
@@ -4242,6 +4302,9 @@ async def game_route_start(game_type: str, request: Request):
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
+    # 把请求体里的 i18n 真值同步进 mgr.user_language（详见 _absorb_request_language
+    # 文档）：route/start 是 game-route 整段生命周期的入口，越早 heal 越多下游受益。
+    _absorb_request_language(data, lanlan_name)
 
     session_id = str(data.get("session_id") or "default")
     # 同一角色同一时刻只允许一个 active 游戏路由：启动新路由前先结束所有其它仍活跃的
@@ -4422,6 +4485,7 @@ async def game_route_drain(game_type: str, request: Request):
     except Exception:
         data = {}
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+    _absorb_request_language(data, lanlan_name)
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
     if not state:
         return {"ok": True, "outputs": [], "state": {"game_route_active": False}}
@@ -4450,6 +4514,7 @@ async def game_route_voice_transcript(game_type: str, request: Request):
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
+    _absorb_request_language(data, lanlan_name)
 
     session_id = str(data.get("session_id") or "")
     state = _get_active_game_route_state(lanlan_name, game_type)
@@ -4483,6 +4548,7 @@ async def game_route_heartbeat(game_type: str, request: Request):
         data = {}
 
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+    _absorb_request_language(data, lanlan_name)
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
     if not state:
         return {"ok": True, "active": False, "state": {"game_route_active": False}}
@@ -4609,6 +4675,7 @@ async def game_project_mirror_assistant(game_type: str, request: Request):
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
+    _absorb_request_language(data, lanlan_name)
 
     mgr = get_session_manager().get(lanlan_name)
     if not mgr:
@@ -4663,6 +4730,7 @@ async def game_project_speak(game_type: str, request: Request):
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
+    _absorb_request_language(data, lanlan_name)
 
     mgr = get_session_manager().get(lanlan_name)
     if not mgr:
@@ -5193,7 +5261,9 @@ async def game_realtime_context(game_type: str, request: Request):
     if not (getattr(mgr, "is_active", False) and isinstance(session, OmniRealtimeClient)):
         return {"ok": False, "reason": "no_active_realtime_session", "lanlan_name": lanlan_name}
 
-    language = _resolve_game_prompt_language(lanlan_name)
+    # 直接把 data 传进去，让请求体里的 i18n_language 走第一层优先级（兼带回写
+    # mgr.user_language），与其他 soccer 端点的 _absorb_request_language 调用同形。
+    language = _resolve_game_prompt_language(lanlan_name, data=data)
     text = _compact_realtime_context_text(game_type, data, language)
     _log_game_debug_material(
         "realtime_context",
@@ -5243,6 +5313,9 @@ async def _complete_game_end_from_payload(
 ) -> dict:
     session_id = str(data.get('session_id', 'default'))
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+    # 包括 /route/end 与 /end 两条入口；postgame 投递依赖 mgr.user_language
+    # 决定旁白语言，所以这里也要 heal 一次（详见 _absorb_request_language）。
+    _absorb_request_language(data, lanlan_name)
     exit_reason = str(data.get("reason") or default_reason)
     postgame_options = _normalize_postgame_options(data.get("postgameProactive"), reason=exit_reason)
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
@@ -5330,17 +5403,30 @@ async def game_end(game_type: str, request: Request):
 
 
 @router.post("/{game_type}/quick-lines")
-async def game_quick_lines(game_type: str):
+async def game_quick_lines(game_type: str, request: Request):
     """进入游戏时生成一组当前猫娘专属快路径台词。
 
     产品语义：这是“游戏内上下文初始化”的一部分。代码告诉 LLM：
     接下来当前猫娘要和玩家踢足球，请按当前人设生成备用短句。
     成功时前端用这些短句替换内建快路径；失败时仍使用前端内建文案。
+
+    quick-lines 是 soccer 流程里第一个命中 LLM 的端点（在 /route/start 之前），
+    所以这里要从请求体吸收 ``i18n_language`` 主动 heal mgr.user_language——
+    否则首批 quick lines 会用 ``start_session`` 时全局缓存覆盖出来的英文。
     """
     if game_type != "soccer":
         return {"ok": False, "error": f"暂不支持 {game_type} 的快路径文案生成", "lines": {}}
 
     try:
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        try:
+            current_name = _get_current_character_info().get("lanlan_name") or ""
+        except Exception:
+            current_name = ""
+        _absorb_request_language(data, current_name)
         char_info = _get_current_character_info()
         language = char_info.get("user_language")
         prompt = get_soccer_quick_lines_prompt(language).format(

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -134,7 +134,7 @@ from utils.screenshot_utils import (
     COMPRESS_TARGET_HEIGHT,
     COMPRESS_JPEG_QUALITY,
 )
-from utils.language_utils import detect_language, translate_text, normalize_language_code, get_global_language
+from utils.language_utils import detect_language, translate_text, normalize_language_code, get_global_language, is_supported_language_code
 from utils.web_scraper import (
     fetch_trending_content, format_trending_content,
     fetch_window_context_content, format_window_context_content,
@@ -2321,7 +2321,11 @@ def _resolve_proactive_locale(data: dict, mgr) -> str:
     会话保持一致；仅在没有任何 session 上下文时才退到全局缓存。
     """
     request_lang = data.get('language') or data.get('lang') or data.get('i18n_language')
-    if request_lang:
+    # 与 ``main_routers/game_router._absorb_request_language`` 同形：第三方客户端 /
+    # corrupted localStorage 可能传 ``'undefined'`` / ``'estonian'`` 等 garbage，
+    # ``normalize_language_code`` 对未识别值默认回退 ``'en'``——必须先用公共白名单
+    # 挡掉，否则 proactive 邀请文案会被静默短路成英文，错过本应命中的 session 真值。
+    if request_lang and is_supported_language_code(request_lang):
         normalized = normalize_language_code(request_lang, format='short')
         if normalized:
             return normalized

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -256,6 +256,12 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                 await websocket.send_text(json.dumps({"type": "pong"}))
                 # logger.debug(f"收到心跳ping，已回复pong")
 
+            elif action == "language_update":
+                # 前端 i18next 'languageChanged' fire 时发的纯语言同步消息：``language``
+                # 字段已被 line 136-139 通用 handler 处理（``set_user_language``），
+                # 这里 no-op 以避免落到 default 分支推 UNKNOWN_ACTION 状态给前端。
+                pass
+
             else:
                 logger.warning(f"Unknown action received: {action}")
                 await session_manager[lanlan_name].send_status(json.dumps({"code": "UNKNOWN_ACTION", "details": {"action": action}}))

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2321,6 +2321,40 @@
     window.addEventListener('vrm-model-loaded', _onModelReady);
     window.addEventListener('mmd-model-loaded', _onModelReady);
 
+    // i18next 'languageChanged' → 重新把 i18n 真值同步到后端 mgr.user_language。
+    // 关键场景：socket open 早于 i18next bootstrap 完成时，首次 greeting_check
+    // 用 navigator/localStorage 兜底（可能跟 Steam 真值不同），i18next 异步从
+    // /api/config/steam_language 拉到对的值后 fire 'languageChanged'，这里重发
+    // 一条只携带 language 的 ws 消息，让后端 line 136-139 通用 language handler
+    // 把 mgr.user_language 纠正回真值。不复用 greeting_check action，避免再次
+    // 触发 greeting fire 逻辑——后端任何消息带 language 字段都会先调
+    // set_user_language（main_routers/websocket_router.py:136-139），用任意 action
+    // 即可。
+    function _syncLanguageToBackend(lng) {
+        if (!lng || typeof lng !== 'string') return;
+        if (!S.socket || S.socket.readyState !== WebSocket.OPEN) return;
+        try {
+            S.socket.send(JSON.stringify({
+                action: 'language_update',
+                language: lng,
+            }));
+        } catch (e) {
+            console.warn('[language_update] send failed:', e);
+        }
+    }
+    if (window.i18next && typeof window.i18next.on === 'function') {
+        window.i18next.on('languageChanged', _syncLanguageToBackend);
+    } else {
+        // i18next 还没就绪：监听 i18n-i18next.js 完成时 dispatch 的 localechange。
+        window.addEventListener('localechange', function () {
+            try {
+                var lng = (window.i18next && typeof window.i18next.language === 'string')
+                    ? window.i18next.language : '';
+                _syncLanguageToBackend(lng);
+            } catch (_) { /* noop */ }
+        });
+    }
+
     window.addEventListener('neko:home-tutorial-lock-changed', function (event) {
         var detail = event && event.detail ? event.detail : {};
         sendHomeTutorialState(detail.reason || 'lock-changed');

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2264,10 +2264,27 @@
         }
         try {
             if (S.socket && S.socket.readyState === WebSocket.OPEN) {
+                // greeting_check 是 ws 链路上唯一会推 mgr.user_language 的消息。
+                // 后端 set_user_language 见空串就 no-op（保留旧值，旧值是
+                // start_session seed 的全局缓存），所以这里宁可送 navigator
+                // 的 BCP47 也别送空串——至少能纠正 Steam SDK race 失败后留下
+                // 的错误英文（例如 Steam=zh / 系统=en，i18next 还在异步拉
+                // Steam API 时，navigator.language 通常已经是 zh-CN）。
+                var greetingLang = '';
+                try {
+                    if (window.i18next && typeof window.i18next.language === 'string' && window.i18next.language) {
+                        greetingLang = window.i18next.language;
+                    } else if (typeof localStorage !== 'undefined') {
+                        greetingLang = localStorage.getItem('i18nextLng') || '';
+                    }
+                    if (!greetingLang && typeof navigator !== 'undefined' && navigator.language) {
+                        greetingLang = navigator.language;
+                    }
+                } catch (_) { greetingLang = ''; }
                 S.socket.send(JSON.stringify({
                     action: 'greeting_check',
                     is_switch: !!S._greetingCheckIsSwitch,
-                    language: (window.i18next && window.i18next.language) || ''
+                    language: greetingLang
                 }));
                 S._greetingCheckPending = false;
                 _resetGreetingCheckRetry(true);

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -804,6 +804,29 @@
     if (tag.startsWith('pt')) return 'pt-BR';
     return raw;
   };
+  // 当前 UI locale（同 app-proactive.js 的 i18nLanguage 三级兜底）。
+  // 后端 _absorb_request_language 优先吃这个字段并回写 mgr.user_language，
+  // 不再依赖 ws greeting_check 的同步时机或全局缓存的 Steam SDK race。
+  // Steam=中文 / 系统=英文 + Steam SDK 启动期 race 失败的场景下，没有这条
+  // 路径 in-game LLM 的 prompt 会跑成英文。
+  window.SoccerCurrentI18nLang = function () {
+    try {
+      if (typeof window.i18next !== 'undefined'
+          && typeof window.i18next.language === 'string'
+          && window.i18next.language) {
+        return window.i18next.language;
+      }
+      if (typeof localStorage !== 'undefined') {
+        const cached = localStorage.getItem('i18nextLng');
+        if (cached) return cached;
+      }
+      if (typeof navigator !== 'undefined' && navigator.language) {
+        return navigator.language;
+      }
+    } catch (_) { /* swallow: fetch payload tolerates empty */ }
+    return '';
+  };
+  const _currentI18nLang = window.SoccerCurrentI18nLang;
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
   const debugCanvas = document.getElementById('debug');
@@ -1674,7 +1697,15 @@
 
   async function loadGeneratedQuickLines() {
     try {
-      const resp = await fetch('/api/game/soccer/quick-lines', { method: 'POST' });
+      // quick-lines 在 _startGameRoute 之前就开炮，是整个 soccer 流程里第一个会
+      // 命中 LLM 的端点；得自带 i18n_language 让后端 _absorb_request_language
+      // 在 mgr.user_language 还是错的全局缓存值时就把它纠正过来，否则首批 quick
+      // lines 会落英文。
+      const resp = await fetch('/api/game/soccer/quick-lines', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ i18n_language: _currentI18nLang() }),
+      });
       if (!resp.ok) {
         soccerRecoverableLog(`[SoccerQuickLines] 生成失败 | HTTP ${resp.status}，继续使用内建快路径`, LINES);
         return;
@@ -2245,6 +2276,10 @@
       gameStartedElapsedMs,
       game_started_elapsed_ms: gameStartedElapsedMs,
       gameStartedAtEpochMs: Math.round(Number(_llm.gameStartedAtEpochMs || 0)),
+      // 见 _currentI18nLang 注释：把前端 i18n 真值随 route/heartbeat/start/end/
+      // voice-transcript 一起捎给后端，后端 _absorb_request_language 自愈
+      // mgr.user_language。
+      i18n_language: _currentI18nLang(),
       ...extra,
     });
   }
@@ -2717,6 +2752,7 @@
           ...(_llm.routeLanlanName ? { lanlan_name: _llm.routeLanlanName } : {}),
           state: stateNow,
           pendingItems: safeItems,
+          i18n_language: _currentI18nLang(),
         }),
       });
       const data = await resp.json().catch(() => ({}));
@@ -2747,6 +2783,7 @@
           turn_id: `game-mirror-${requestId}`,
           finalize_turn: shouldFinalizeTurn,
           line: clean,
+          i18n_language: _currentI18nLang(),
           event: {
             kind: meta.kind || 'mailbox',
             round: meta.round,
@@ -2814,6 +2851,7 @@
           voice_arbiter_reason: voiceArbiterReason,
           line,
           state: stateNow,
+          i18n_language: _currentI18nLang(),
           event: {
             kind: meta.kind || 'mailbox',
             round: meta.round,
@@ -3301,6 +3339,7 @@
           session_id: _llm.sessionId,
           ...(_llm.routeLanlanName ? { lanlan_name: _llm.routeLanlanName } : {}),
           ..._soccerGameMemoryPolicyPayload(),
+          i18n_language: _currentI18nLang(),
           event: {
             ...eventPayload,
             ..._soccerGameMemoryPolicyPayload(),
@@ -3460,6 +3499,7 @@
         body: JSON.stringify({
           session_id: _llm.sessionId,
           ...(_llm.routeLanlanName ? { lanlan_name: _llm.routeLanlanName } : {}),
+          i18n_language: _currentI18nLang(),
         }),
       });
       if (!resp.ok) return;

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -337,16 +337,20 @@ def refresh_global_language(language: str) -> bool:
     # normalize_language_code 对未识别的输入会默认回退到 'en'，让 garbage / 空白
     # 字符串能静默把缓存写成英文。该函数是公共 utility，未来可能被未校验的来源
     # 调用，先把输入收紧到已知支持集合，不在白名单的直接 no-op。
+    # 用 ``_matches_lang_code`` 而不是裸 ``startswith``——后者会让 ``estonian`` /
+    # ``ptsd`` / ``essential`` 这类无意义前缀通过校验，再被 normalize 默认回退成
+    # ``en`` 误覆盖缓存，违背"无效就 no-op"的契约。
     raw = language.strip().lower()
     if not raw:
         return False
-    _supported_prefixes = ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt')
     _supported_steam_literals = {
         'schinese', 'tchinese', 'english', 'japanese',
         'koreana', 'korean', 'russian', 'spanish', 'latam',
         'portuguese', 'brazilian',
     }
-    if not (raw.startswith(_supported_prefixes) or raw in _supported_steam_literals):
+    _supported_codes = ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt')
+    if not (raw in _supported_steam_literals
+            or any(_matches_lang_code(raw, code) for code in _supported_codes)):
         return False
 
     short = normalize_language_code(raw, format='short')

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -329,7 +329,7 @@ def refresh_global_language(language: str) -> bool:
     Returns:
         ``True`` 表示发生了真实变更；``False`` 表示已是最新或参数无效。
     """
-    global _global_language, _global_language_full, _global_language_initialized
+    global _global_language, _global_language_full, _global_region, _global_language_initialized
 
     if not language:
         return False
@@ -365,6 +365,18 @@ def refresh_global_language(language: str) -> bool:
         prev_full = _global_language_full
         _global_language = short
         _global_language_full = full
+        # _global_region 必须和 _global_language_initialized 同时建立：``get_global_region``
+        # 看到 region 为 None 才会再调 ``initialize_global_language``，但后者一旦看到
+        # initialized=True 就 early-return，会把 region 永久卡在 None → 'non-china'
+        # fallback。startup 路径正常会先初始化 region；但 startup 异常 / 测试 / 子进程
+        # 等场景下若 refresh 先于 init 跑到这里，必须自补 region 来维持不变量。
+        if _global_region is None:
+            try:
+                _global_region = 'china' if _is_china_region() else 'non-china'
+                logger.info(f"系统区域判断（refresh 路径补齐）: {_global_region}")
+            except Exception:
+                _global_region = 'non-china'
+                logger.debug("refresh_global_language 补齐 region 失败，回落 non-china", exc_info=True)
         _global_language_initialized = True
         logger.info(
             f"全局语言已刷新（晚到真值覆盖）: {prev_short} -> {short} "

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -311,6 +311,49 @@ def set_global_language(language: str) -> None:
         logger.info(f"全局语言已手动设置为: {_global_language} (full: {_global_language_full})")
 
 
+def refresh_global_language(language: str) -> bool:
+    """重新校准全局语言缓存（用于晚到的真值，例如 Steam SDK 启动期 race 失败后才拿到）。
+
+    与 ``set_global_language`` 的区别：
+    - 静默 no-op：若归一化后值与当前缓存相同，直接返回 ``False``，不打 INFO 日志
+      （前端 i18n bootstrap 会调 ``/api/config/steam_language``，每次冷启都触发刷新，
+      不应每次都刷屏）。
+    - 仅当值不同 / 缓存未初始化时才覆盖并 log。
+
+    设计动机：``initialize_global_language`` 在进程启动时只跑一次，Steam SDK 没就绪
+    就退化到系统 locale 然后**终生缓存**；前端的 ``/api/config/steam_language`` 端点
+    每次重读 Steam 拿得到对的值，但没有路径回写到全局缓存——所有依赖
+    ``get_global_language()`` 的下游（memory / reflection / tts / soccer 兜底等）就
+    一直用错的英文。该函数就是这条回写路径。
+
+    Returns:
+        ``True`` 表示发生了真实变更；``False`` 表示已是最新或参数无效。
+    """
+    global _global_language, _global_language_full, _global_language_initialized
+
+    if not language:
+        return False
+
+    short = normalize_language_code(language, format='short')
+    full = normalize_language_code(language, format='full')
+    if not short:
+        return False
+
+    with _global_language_lock:
+        if _global_language_initialized and _global_language == short and _global_language_full == full:
+            return False
+        prev_short = _global_language
+        prev_full = _global_language_full
+        _global_language = short
+        _global_language_full = full
+        _global_language_initialized = True
+        logger.info(
+            f"全局语言已刷新（晚到真值覆盖）: {prev_short} -> {short} "
+            f"(full: {prev_full} -> {full})"
+        )
+    return True
+
+
 def get_global_region() -> str:
     """
     获取全局区域标识

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -381,7 +381,14 @@ def refresh_global_language(language: str) -> bool:
         return False
 
     with _global_language_lock:
-        if _global_language_initialized and _global_language == short and _global_language_full == full:
+        # ``_global_region is not None`` 也要 hold，否则 ``set_global_language`` 这条
+        # pre-existing 路径（只置 ``_global_language_initialized=True``、不碰 region）
+        # 留下的 ``language=short, region=None`` 状态会让本次 refresh 走早 return，
+        # 漏掉 region 自愈，``get_global_region`` 永久卡 ``'non-china'`` fallback。
+        if (_global_language_initialized
+                and _global_language == short
+                and _global_language_full == full
+                and _global_region is not None):
             return False
         prev_short = _global_language
         prev_full = _global_language_full

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -334,8 +334,23 @@ def refresh_global_language(language: str) -> bool:
     if not language:
         return False
 
-    short = normalize_language_code(language, format='short')
-    full = normalize_language_code(language, format='full')
+    # normalize_language_code 对未识别的输入会默认回退到 'en'，让 garbage / 空白
+    # 字符串能静默把缓存写成英文。该函数是公共 utility，未来可能被未校验的来源
+    # 调用，先把输入收紧到已知支持集合，不在白名单的直接 no-op。
+    raw = language.strip().lower()
+    if not raw:
+        return False
+    _supported_prefixes = ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt')
+    _supported_steam_literals = {
+        'schinese', 'tchinese', 'english', 'japanese',
+        'koreana', 'korean', 'russian', 'spanish', 'latam',
+        'portuguese', 'brazilian',
+    }
+    if not (raw.startswith(_supported_prefixes) or raw in _supported_steam_literals):
+        return False
+
+    short = normalize_language_code(raw, format='short')
+    full = normalize_language_code(raw, format='full')
     if not short:
         return False
 

--- a/utils/language_utils.py
+++ b/utils/language_utils.py
@@ -52,6 +52,40 @@ def _matches_lang_code(lang_lower: str, code: str, aliases: Optional[set] = None
     )
 
 
+_SUPPORTED_LANGUAGE_CODES: tuple = ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt')
+_SUPPORTED_STEAM_LITERALS: frozenset = frozenset({
+    'schinese', 'tchinese', 'english', 'japanese',
+    'koreana', 'korean', 'russian', 'spanish', 'latam',
+    'portuguese', 'brazilian',
+})
+
+
+def is_supported_language_code(raw: Any) -> bool:
+    """判断原始输入是否落在 ``normalize_language_code`` 真正能识别的支持集合内。
+
+    背景：``normalize_language_code`` 对未识别的输入会默认回退到 ``'en'``，让 garbage
+    （``'undefined'`` / ``'estonian'`` / 空白）被静默当作英文写入下游状态（全局缓存
+    或 ``mgr.user_language``）。所有"接受请求体语言再回写状态"的入口（例如
+    ``refresh_global_language`` / ``_absorb_request_language``）必须先用此 helper
+    把输入挡在外面，再调归一化。
+
+    支持集合 = 与 ``normalize_language_code`` 实际真识别的码 / Steam literal 一致；
+    用 ``_matches_lang_code`` 而不是 ``startswith`` 避免 ``estonian`` / ``ptsd`` /
+    ``essential`` 这种无意义前缀通过校验。
+    """
+    if not raw:
+        return False
+    try:
+        s = str(raw).strip().lower()
+    except Exception:
+        return False
+    if not s:
+        return False
+    if s in _SUPPORTED_STEAM_LITERALS:
+        return True
+    return any(_matches_lang_code(s, code) for code in _SUPPORTED_LANGUAGE_CODES)
+
+
 def _is_china_region() -> bool:
     """
     判断当前系统是否在中文区
@@ -334,24 +368,12 @@ def refresh_global_language(language: str) -> bool:
     if not language:
         return False
 
-    # normalize_language_code 对未识别的输入会默认回退到 'en'，让 garbage / 空白
-    # 字符串能静默把缓存写成英文。该函数是公共 utility，未来可能被未校验的来源
-    # 调用，先把输入收紧到已知支持集合，不在白名单的直接 no-op。
-    # 用 ``_matches_lang_code`` 而不是裸 ``startswith``——后者会让 ``estonian`` /
-    # ``ptsd`` / ``essential`` 这类无意义前缀通过校验，再被 normalize 默认回退成
-    # ``en`` 误覆盖缓存，违背"无效就 no-op"的契约。
+    # 用 ``is_supported_language_code`` 把 garbage / ``'undefined'`` / ``'estonian'``
+    # 等未识别值挡在外面：normalize 对未识别输入会默认回退到 ``'en'``，会静默把缓存
+    # 误覆盖，违背"无效就 no-op"的契约。
+    if not is_supported_language_code(language):
+        return False
     raw = language.strip().lower()
-    if not raw:
-        return False
-    _supported_steam_literals = {
-        'schinese', 'tchinese', 'english', 'japanese',
-        'koreana', 'korean', 'russian', 'spanish', 'latam',
-        'portuguese', 'brazilian',
-    }
-    _supported_codes = ('zh', 'en', 'ja', 'ko', 'ru', 'es', 'pt')
-    if not (raw in _supported_steam_literals
-            or any(_matches_lang_code(raw, code) for code in _supported_codes)):
-        return False
 
     short = normalize_language_code(raw, format='short')
     full = normalize_language_code(raw, format='full')


### PR DESCRIPTION
## Summary

PR #1150 把 proactive 路径接到 session locale 后，**Steam=中文 / 系统=英文 + Steam SDK 启动期 race 失败**的场景下 soccer in-game LLM 仍会输出英文。诊断结论是除 #1150 已修的口子外还有四个互相独立的洞，一次到位补齐：

1. **soccer 端点没接 `i18n_language`** —— `/api/game/soccer/*` 全靠 `mgr.user_language` + 全局缓存兜底，#1150 没覆盖到。
2. **`start_session` 无脑覆盖 `mgr.user_language`** —— 用 `get_global_language()` 把 ws greeting_check 推上来的对的值打回错的英文。
3. **`get_global_language()` 进程级缓存永不刷新** —— 前端 `/api/config/steam_language` 拿到对的 `schinese → zh` 也没人回写。
4. **`greeting_check` 在 i18next 还没 init 完时送空串** —— 后端 `set_user_language` 见空就 no-op。

修后三条路径（global cache 回写 / mgr session 真值 / per-request absorb）独立并行，任意一条对都能让 soccer LLM 拿到正确语言。

## 改动清单

| 文件 | 改动 |
|------|------|
| `utils/language_utils.py` | 新增 `refresh_global_language(lang)` —— 同值 no-op、新值覆盖+log 的进程级缓存刷新点 |
| `main_routers/config_router.py` | `/api/config/steam_language` 拿到 Steam 真值后调 `refresh_global_language`。**根治**：所有依赖 `get_global_language()` 的下游（memory / reflection / tts / qq_auto_reply / ...）一并自愈 |
| `main_routers/game_router.py` | 抽 `_absorb_request_language(data, lanlan_name)`；升级 `_resolve_game_prompt_language(lanlan_name, data=None)` 为三层兜底（与 `_resolve_proactive_locale` 同形）；在 11 个 soccer 端点入口处 absorb 一次 |
| `templates/soccer_demo.html` | 加 `_currentI18nLang()` 三级兜底，灌进 `_gameRoutePayload` + chat / realtime-context / mirror-assistant / speak / drain / quick-lines 各 fetch body。quick-lines 是 soccer 第一个命中 LLM 的端点（在 `/route/start` 之前），必须自带，否则首批快路径文案落英文 |
| `main_logic/core.py` | `start_session` 仅在 `user_language` 还没设过时才 seed，已被 greeting_check 推上来的真值不再被打回 |
| `static/app-websocket.js` | `greeting_check` 的 `language` 字段三级 fallback（`i18next.language` → `localStorage.i18nextLng` → `navigator.language`），不再空串 no-op |

## Test plan

- [x] `refresh_global_language` 6 case smoke：seed / 同值 no-op / 新值切换 / 空值忽略 / 反复同值 no-op —— 全 PASS
- [x] `_absorb_request_language` + `_resolve_game_prompt_language` 9 case smoke：空 body / `i18n_language` heal / `language` 别名 / `lang` 别名 / data 优先于 mgr / no-data 走 mgr / 未知 lanlan 落全局 / 非法输入容错 / 空字段穿透到 mgr —— 全 PASS
- [x] 所有改动 Python 文件 `ast.parse` OK
- [x] `soccer_demo.html` 主 IIFE (135KB) `new Function()` 解析 OK
- [x] `app-websocket.js` `new Function()` 解析 OK
- [ ] **建议补跑**：`uv run pytest tests/unit/test_game_router*.py tests/unit/test_proactive_sm_integration.py tests/unit/test_mini_game_invite.py`（本地系统 Python 缺项目深度 deps）
- [ ] **建议手测**：Steam=zh / 系统=en 启动，开 soccer，验快路径文案 / in-game 台词 / postgame 旁白都是中文

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 前端新增全局语言读取与同步机制，所有相关请求统一携带 i18n_language，后端新增刷新并同步全局语言的入口，路由层集中按请求吸收并即时归一化与回写语言信息。
* **Bug Fixes**
  * 语言初始化仅在未设置时写入以保留用户选择；增强语言校验与归一化，记录或拒绝不支持的输入，改善跨平台、Steam 与延迟回写场景的稳定性与一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->