### PR TITLE
fix(tutorial): 增强教程结束时的 UI 清理，修复按钮残留和锁死问题

### DIFF
--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -3254,6 +3254,20 @@ class UniversalTutorialManager {
                 delete element.dataset.tutorialDisabled;
             }
         });
+        // 兜底：扫描整个文档中残留的 data-tutorial-disabled 节点。
+        // 模型管理 MMD 教程结束后曾出现 #vrm-model-select-btn / #mmd-animation-select-btn
+        // 等按钮被 pointer-events:none 卡死的情况，根因是 await 期间集合被提前 clear，
+        // 后续被遗漏。这里独立做一遍 DOM 兜底清理。
+        try {
+            document.querySelectorAll('[data-tutorial-disabled]').forEach(element => {
+                element.style.pointerEvents = '';
+                element.style.cursor = '';
+                element.style.userSelect = '';
+                delete element.dataset.tutorialDisabled;
+            });
+        } catch (error) {
+            console.warn('[Tutorial] 扫描残留 tutorial-disabled 元素失败:', error);
+        }
         this.tutorialInteractionStates.clear();
         this.tutorialControlledElements = new Set();
         this.tutorialMarkerDisplayCache = null;
@@ -3743,7 +3757,25 @@ class UniversalTutorialManager {
         }, 500);
 
         // 监听事件
-        this.driver.on('destroy', () => this.onTutorialEnd());
+        // driver.on('destroy') 触发后，先做关键 UI 清理（移除跳过按钮 +
+        // 还原 pointer-events），再走完整的 onTutorialEnd 流程。
+        // 这两步独立 try/catch，确保即便 onTutorialEnd 任一环节抛错或被早返回，
+        // 也不会留下右上角残余按钮 / 模型列表锁死。
+        // (MMD/VRM 模型管理教程结束后跳过按钮残留 & 模型列表锁死的修复路径。)
+        this.driver.on('destroy', () => {
+            console.log('[Tutorial] driver destroy → 执行关键 UI 清理');
+            try {
+                this.hideSkipButton();
+            } catch (error) {
+                console.warn('[Tutorial] destroy 清理 hideSkipButton 失败:', error);
+            }
+            try {
+                this.restoreTutorialInteractionState();
+            } catch (error) {
+                console.warn('[Tutorial] destroy 清理 restoreTutorialInteractionState 失败:', error);
+            }
+            this.onTutorialEnd();
+        });
         this.driver.on('next', () => this.onStepChange().catch(err => {
             console.error('[Tutorial] 步骤切换失败:', err);
         }));
@@ -4677,6 +4709,23 @@ class UniversalTutorialManager {
      * 因此既能给正常结束（onTutorialEnd）复用，也能给启动失败的回退路径复用。
      */
     _teardownTutorialUI() {
+        // 关键 UI 清理：必须先于 _teardownPromise early-return 守卫执行，
+        // 且必须幂等。MMD 模型管理教程曾出现：用户走到末步点「完成」后
+        // 跳过按钮残留、模型列表按钮 pointer-events:none 卡死。
+        // 根因是 teardown 触发时 _teardownPromise 已被前一次未完成的链占用，
+        // early-return 直接跳过了 hideSkipButton / restoreTutorialInteractionState。
+        // 把这两个操作提到守卫之前，可在任何重复/并发调用下都保证用户能继续操作。
+        try {
+            this.hideSkipButton();
+        } catch (error) {
+            console.warn('[Tutorial] hideSkipButton 失败:', error);
+        }
+        try {
+            this.restoreTutorialInteractionState();
+        } catch (error) {
+            console.warn('[Tutorial] restoreTutorialInteractionState 失败:', error);
+        }
+
         if (this._teardownPromise) {
             return this._teardownPromise;
         }
@@ -4693,9 +4742,6 @@ class UniversalTutorialManager {
         this._tutorialEndReason = null;
         this._tutorialEndRawReason = null;
         this.currentTutorialStartSource = 'auto';
-
-        // 移除跳过按钮
-        this.hideSkipButton();
 
         // 清除刷新定时器
         if (this._refreshTimers) {

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -3258,11 +3258,14 @@ class UniversalTutorialManager {
         // 模型管理 MMD 教程结束后曾出现 #vrm-model-select-btn / #mmd-animation-select-btn
         // 等按钮被 pointer-events:none 卡死的情况，根因是 await 期间集合被提前 clear，
         // 后续被遗漏。这里独立做一遍 DOM 兜底清理。
+        // 优先从 tutorialInteractionStates 还原原始 inline 值，仅在没有保存态时
+        // 退化为清空，避免误把页面上原本就 pointer-events:none 的元素重新激活。
         try {
             document.querySelectorAll('[data-tutorial-disabled]').forEach(element => {
-                element.style.pointerEvents = '';
-                element.style.cursor = '';
-                element.style.userSelect = '';
+                const state = this.tutorialInteractionStates.get(element);
+                element.style.pointerEvents = state?.pointerEvents || '';
+                element.style.cursor = state?.cursor || '';
+                element.style.userSelect = state?.userSelect || '';
                 delete element.dataset.tutorialDisabled;
             });
         } catch (error) {

--- a/templates/model_manager.html
+++ b/templates/model_manager.html
@@ -699,7 +699,7 @@
     <link rel="stylesheet" href="/static/libs/driver.min.css">
 
     <!-- 通用教程管理器 -->
-    <script src="/static/universal-tutorial-manager.js?v=12"></script>
+    <script src="/static/universal-tutorial-manager.js?v=13"></script>
     <link rel="stylesheet" href="/static/css/touch-config.css">
     <script src="/static/touch-config.js"></script>
     <!-- 初始化 -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 增加了可进入/退出的全屏引导流程及全屏提示，支持在进入全屏后触发教程。

* **Bug 修复**
  * 修复并加固了教程拆卸与销毁时的清理逻辑，避免残留的 UI 标记或交互状态。
  * 提高了在页面切换与重启场景下的恢复与清理幂等性，减少竞态问题。

* **改进**
  * 改善了在动态页面中自动展开/恢复相关面板和设置以保证教程步骤稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->