### PR TITLE
Fix/subtitle drag handle logic

### DIFF
--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -66,26 +66,26 @@ body.subtitle-window-host #subtitle-display {
     pointer-events: auto;
     scrollbar-gutter: stable;
     scrollbar-width: thin;
-    scrollbar-color: rgba(255, 255, 255, 0.55) rgba(255, 255, 255, 0.12);
+    scrollbar-color: rgba(255, 255, 255, 0.42) transparent;
     padding: 4px 0;
 }
 
 #subtitle-scroll::-webkit-scrollbar {
-    width: 4px;
+    width: 3px;
 }
 
 #subtitle-scroll::-webkit-scrollbar-track {
-    background: rgba(255, 255, 255, 0.12);
+    background: transparent;
     border-radius: 999px;
 }
 
 #subtitle-scroll::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.55);
+    background: rgba(255, 255, 255, 0.42);
     border-radius: 999px;
 }
 
 #subtitle-scroll::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.75);
+    background: rgba(255, 255, 255, 0.68);
 }
 
 #subtitle-text {

--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -10,18 +10,18 @@ body.subtitle-window-host {
 }
 
 #subtitle-display {
-    padding: 10px 18px;
-    padding-top: 28px;
-    min-height: 80px;
+    padding: 10px 46px;
+    padding-top: 24px;
+    /* min-height, max-height, font-size 由 JS preset 控制 */
     background: linear-gradient(135deg, rgba(68, 183, 254, 0.95) 0%, rgba(68, 183, 254, 0.9) 50%, rgba(100, 200, 255, 0.95) 100%);
     color: #fff;
     border-radius: 12px;
-    font-size: 17px;
     font-weight: 500;
     line-height: 1.5;
     text-align: center;
     overflow-wrap: break-word;
     white-space: normal;
+    overflow: visible;
     box-shadow: 0 6px 24px rgba(68, 183, 254, 0.35),
         0 0 0 1px rgba(255, 255, 255, 0.3) inset;
     border: 1.5px solid rgba(255, 255, 255, 0.4);
@@ -42,8 +42,12 @@ body.subtitle-web-host #subtitle-display {
     max-width: min(var(--subtitle-max-width, 500px), 85%);
     opacity: 0;
     visibility: hidden;
-    transition: opacity 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), visibility 0.4s, max-width 0.3s ease, min-height 0.3s ease;
+    transition: opacity 0.4s cubic-bezier(0.34, 1.56, 0.64, 1), visibility 0.4s, max-width 0.3s ease, min-height 0.3s ease, max-height 0.3s ease, font-size 0.3s ease;
     pointer-events: none;
+}
+
+body.subtitle-web-host #subtitle-display.drag-anywhere {
+    pointer-events: auto;
 }
 
 body.subtitle-window-host #subtitle-display {
@@ -51,24 +55,42 @@ body.subtitle-window-host #subtitle-display {
     top: 0;
     left: 0;
     width: 100%;
-    transition: min-height 0.3s ease, font-size 0.3s ease;
+    transition: min-height 0.3s ease, max-height 0.3s ease, font-size 0.3s ease;
 }
 
 #subtitle-scroll {
     width: 100%;
-    max-height: 100%;
+    max-height: var(--subtitle-content-max-height, 120px);
     overflow-y: auto;
-    scrollbar-width: none;
-    padding: 4px 0 28px 0;
+    overscroll-behavior: contain;
+    pointer-events: auto;
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.55) rgba(255, 255, 255, 0.12);
+    padding: 4px 0;
 }
 
 #subtitle-scroll::-webkit-scrollbar {
-    display: none;
+    width: 4px;
+}
+
+#subtitle-scroll::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+}
+
+#subtitle-scroll::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+}
+
+#subtitle-scroll::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.75);
 }
 
 #subtitle-text {
     display: block;
-    margin-right: 24px;
+    margin-right: 8px;
     white-space: pre-wrap;
     overflow-wrap: break-word;
 }
@@ -118,8 +140,9 @@ body.subtitle-window-host #subtitle-display {
 
 #subtitle-settings-panel {
     position: absolute;
-    top: 30px;
-    right: 4px;
+    top: auto;
+    right: 0;
+    bottom: calc(100% + 8px);
     min-width: 210px;
     padding: 8px 10px;
     background: rgba(0, 0, 0, 0.65);
@@ -129,6 +152,12 @@ body.subtitle-window-host #subtitle-display {
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
     pointer-events: auto;
     z-index: 10;
+}
+
+body.subtitle-window-host #subtitle-settings-panel {
+    top: calc(100% + 8px);
+    right: 4px;
+    bottom: auto;
 }
 
 #subtitle-settings-panel.hidden {
@@ -365,8 +394,7 @@ body.subtitle-web-host #subtitle-display.show {
         bottom: 80px;
         min-width: 180px;
         max-width: min(var(--subtitle-max-width, 500px), 92%);
-        font-size: 15px;
-        padding: 6px 14px;
+        padding: 6px 42px;
         padding-top: 24px;
     }
 }

--- a/static/css/subtitle.css
+++ b/static/css/subtitle.css
@@ -46,10 +46,6 @@ body.subtitle-web-host #subtitle-display {
     pointer-events: none;
 }
 
-body.subtitle-web-host #subtitle-display.drag-anywhere {
-    pointer-events: auto;
-}
-
 body.subtitle-window-host #subtitle-display {
     position: absolute;
     top: 0;
@@ -288,6 +284,7 @@ body.subtitle-window-host #subtitle-settings-panel {
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.95), 0 0 0 5px rgba(68, 183, 254, 0.35);
 }
 
+body.subtitle-web-host #subtitle-display.drag-anywhere,
 #subtitle-display.drag-anywhere {
     cursor: grab;
     pointer-events: auto;

--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -19,9 +19,9 @@
         subtitleSize: 'subtitleSize'
     };
     var SIZE_PRESETS = {
-        small: { width: 400, minHeight: 60 },
-        medium: { width: 600, minHeight: 80 },
-        large: { width: 800, minHeight: 100 }
+        small:  { width: 400, minHeight: 36, maxHeight: 120, fontSize: 14 },
+        medium: { width: 600, minHeight: 40, maxHeight: 160, fontSize: 17 },
+        large:  { width: 800, minHeight: 48, maxHeight: 200, fontSize: 21 }
     };
     var UI_KEY_MAP = {
         settingsBtn: 'subtitle.settings.settingsBtn',
@@ -442,6 +442,10 @@
         var preset = getSizePreset(size);
         display.dataset.subtitleSize = normalizeSizePreset(size);
         display.style.minHeight = preset.minHeight + 'px';
+        display.style.maxHeight = preset.maxHeight + 'px';
+        display.style.fontSize = preset.fontSize + 'px';
+        display.style.setProperty('--subtitle-max-height', preset.maxHeight + 'px');
+        display.style.setProperty('--subtitle-content-max-height', Math.max(24, preset.maxHeight - 40) + 'px');
         if (!options || options.host !== 'window') {
             display.style.setProperty('--subtitle-max-width', preset.width + 'px');
         }
@@ -455,7 +459,7 @@
         applySubtitlePreset(refs.display, state.subtitleSize, { host: host });
         refs.display.classList.toggle('drag-anywhere', !!state.subtitleDragAnywhere);
         if (refs.dragHandle) {
-            refs.dragHandle.style.display = state.subtitleDragAnywhere ? 'none' : '';
+            refs.dragHandle.style.display = state.subtitleDragAnywhere ? '' : 'none';
         }
         if (refs.langSelect) {
             refs.langSelect.value = state.userLanguage;
@@ -691,12 +695,12 @@
         }
 
         function onHandleMouseDown(e) {
-            if (isDragAnywhereMode()) return;
+            if (!isDragAnywhereMode()) return;
             beginDrag(e);
         }
 
         function onHandleTouchStart(e) {
-            if (isDragAnywhereMode()) return;
+            if (!isDragAnywhereMode()) return;
             beginTouchDrag(e);
         }
 
@@ -795,13 +799,13 @@
         }
 
         function onHandleMouseDown(e) {
-            if (isDragAnywhereMode()) return;
+            if (!isDragAnywhereMode()) return;
             startDrag(e);
             refs.dragHandle.style.cursor = 'grabbing';
         }
 
         function onHandleTouchStart(e) {
-            if (isDragAnywhereMode()) return;
+            if (!isDragAnywhereMode()) return;
             startDrag(e);
             refs.dragHandle.style.cursor = 'grabbing';
         }
@@ -876,15 +880,25 @@
         }
 
         if (refs.settingsBtn && refs.settingsPanel) {
+            var notifySettingsPanelChanged = function(source) {
+                if (typeof options.onSettingsApplied === 'function') {
+                    options.onSettingsApplied(getSettings(), refs, {
+                        changedKeys: [],
+                        source: source
+                    });
+                }
+            };
             var onSettingsClick = function(e) {
                 e.stopPropagation();
                 refs.settingsPanel.classList.toggle('hidden');
+                notifySettingsPanelChanged('subtitle-ui-panel');
             };
             var onDocumentDown = function(e) {
                 if (refs.settingsPanel.classList.contains('hidden')) return;
                 if (refs.settingsPanel.contains(e.target)) return;
                 if (refs.settingsBtn.contains(e.target)) return;
                 refs.settingsPanel.classList.add('hidden');
+                notifySettingsPanelChanged('subtitle-ui-panel');
             };
             refs.settingsBtn.addEventListener('click', onSettingsClick);
             document.addEventListener('mousedown', onDocumentDown);

--- a/static/subtitle-shared.js
+++ b/static/subtitle-shared.js
@@ -19,9 +19,9 @@
         subtitleSize: 'subtitleSize'
     };
     var SIZE_PRESETS = {
-        small:  { width: 400, minHeight: 36, maxHeight: 120, fontSize: 14 },
-        medium: { width: 600, minHeight: 40, maxHeight: 160, fontSize: 17 },
-        large:  { width: 800, minHeight: 48, maxHeight: 200, fontSize: 21 }
+        small:  { width: 400, minHeight: 64, maxHeight: 120, fontSize: 14 },
+        medium: { width: 600, minHeight: 68, maxHeight: 160, fontSize: 17 },
+        large:  { width: 800, minHeight: 76, maxHeight: 200, fontSize: 21 }
     };
     var UI_KEY_MAP = {
         settingsBtn: 'subtitle.settings.settingsBtn',

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -17,14 +17,20 @@
         var api = window.nekoSubtitle;
         var state = SubtitleShared.getSettings();
         var preset = SubtitleShared.getSizePreset(state.subtitleSize);
+        var settingsPanelOpen = refs.settingsPanel && !refs.settingsPanel.classList.contains('hidden');
+        var panelHeight = settingsPanelOpen && refs.settingsPanel
+            ? refs.settingsPanel.offsetHeight
+            : 0;
+        var panelGap = settingsPanelOpen ? 8 : 0;
 
         SubtitleShared.applySubtitlePreset(refs.display, state.subtitleSize, { host: 'window' });
+        refs.display.style.maxHeight = preset.maxHeight + 'px';
 
         if (!refs.text) return;
         if (!currentTranscript.trim()) {
             refs.text.style.fontSize = '';
             if (api && typeof api.setSize === 'function') {
-                api.setSize(preset.width, Math.max(preset.minHeight, WINDOW_DROPDOWN_HEIGHT));
+                api.setSize(preset.width, preset.minHeight + panelGap + panelHeight);
             }
             return;
         }
@@ -35,11 +41,12 @@
             presetKey: state.subtitleSize,
             maxWidth: preset.width,
             minHeight: preset.minHeight,
-            maxHeight: 280
+            maxHeight: preset.maxHeight,
+            baseFont: preset.fontSize
         });
-        refs.text.style.fontSize = layout.fontSize < 17 ? layout.fontSize + 'px' : '';
+        refs.text.style.fontSize = layout.fontSize < preset.fontSize ? layout.fontSize + 'px' : '';
         if (api && typeof api.setSize === 'function') {
-            api.setSize(layout.width, Math.max(layout.height, WINDOW_DROPDOWN_HEIGHT));
+            api.setSize(layout.width, Math.max(layout.height + panelGap + panelHeight, preset.minHeight));
         }
     }
 

--- a/static/subtitle-window.js
+++ b/static/subtitle-window.js
@@ -4,7 +4,6 @@
     var SubtitleShared = window.nekoSubtitleShared || null;
     var subtitleWindowController = null;
     var currentTranscript = '';
-    var WINDOW_DROPDOWN_HEIGHT = 230;
 
     if (!SubtitleShared) {
         console.error('[SubtitleWindow] subtitle-shared.js 未加载');

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -178,7 +178,6 @@ let turnBoundaryLatched = false;
 // --- 增量逐句翻译状态 ---
 let incrementalTranslatedCount = 0;
 let incrementalTranslatedSentences = [];
-let incrementalTranslateTimer = null;
 let incrementalAbortController = null;
 let incrementalRequestId = 0;
 let incrementalQueuedCount = 0;
@@ -326,10 +325,6 @@ function resetIncrementalTranslationState() {
     incrementalQueuedCount = 0;
     incrementalTranslationQueue = [];
     incrementalTranslationActive = false;
-    if (incrementalTranslateTimer) {
-        clearTimeout(incrementalTranslateTimer);
-        incrementalTranslateTimer = null;
-    }
     if (incrementalAbortController) {
         incrementalAbortController.abort();
         incrementalAbortController = null;
@@ -343,7 +338,7 @@ function resumeIncrementalTranslationQueue() {
 }
 
 function countCjkChars(text) {
-    var matches = (text || '').match(/[\u3400-\u9FFF\uF900-\uFAFF]/g);
+    var matches = (text || '').match(/[\u1100-\u11FF\u3040-\u30FF\u31F0-\u31FF\u3400-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF]/g);
     return matches ? matches.length : 0;
 }
 
@@ -586,12 +581,6 @@ async function translateAndShowSubtitle(text) {
     const requestTurnId = currentTurnId;
     const requestId = ++currentTranslationRequestId;
     isCurrentTurnFinalized = true;
-
-    // 取消 pending 的增量翻译定时器
-    if (incrementalTranslateTimer) {
-        clearTimeout(incrementalTranslateTimer);
-        incrementalTranslateTimer = null;
-    }
 
     if (userLanguage === null) {
         await getUserLanguage();

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -200,7 +200,6 @@ function splitSubtitleSentences(buffer) {
     function isBoundary(ch, next) {
         if (ch === '\n') return true;
         if (isPunctForBoundary(ch) && next && isPunctForBoundary(next)) return false;
-        if (isPunctForBoundary(ch) && !next) return false;
         if (ch === '\u3002' || ch === '\uFF01' || ch === '\uFF1F') return true;
         if (ch === '!' || ch === '?') return true;
         if (ch === '\u2026') return true;
@@ -298,11 +297,13 @@ function writeSubtitleText(text) {
                 presetKey: preset.subtitleSize,
                 maxWidth: presetSize.width,
                 minHeight: presetSize.minHeight,
+                maxHeight: presetSize.maxHeight,
+                baseFont: presetSize.fontSize,
                 availableWidth: Math.max(0, (display.clientWidth || presetSize.width) - 48),
-                availableHeight: Math.max(display.offsetHeight || presetSize.minHeight, presetSize.minHeight)
+                availableHeight: presetSize.maxHeight
             })
             : { fontSize: 17 };
-        subtitleText.style.fontSize = layout.fontSize < 17 ? layout.fontSize + 'px' : '';
+        subtitleText.style.fontSize = layout.fontSize < presetSize.fontSize ? layout.fontSize + 'px' : '';
         syncSubtitleRenderState('subtitle-text-resize');
     }, 200);
 }
@@ -336,28 +337,21 @@ async function translateNewSentencesIncremental(newSentences, requestSnapId) {
         });
 
         if (!response.ok) {
-            appendIncrementalFallback(newSentences, requestSnapId);
+            markIncrementalSentencesHandled(newSentences, requestSnapId);
             return;
         }
 
         var result = await response.json();
         if (requestSnapId !== incrementalRequestId) return;
 
-        if (result.success && result.translated_text &&
-            result.source_lang && result.target_lang &&
-            result.source_lang !== result.target_lang &&
-            result.source_lang !== 'unknown') {
+        if (result.success && result.translated_text) {
             incrementalTranslatedSentences.push(result.translated_text.trim());
-        } else {
-            for (var j = 0; j < newSentences.length; j++) {
-                incrementalTranslatedSentences.push(newSentences[j]);
-            }
         }
         incrementalTranslatedCount += newSentences.length;
         updateIncrementalDisplay();
     } catch (error) {
         if (error.name === 'AbortError') return;
-        appendIncrementalFallback(newSentences, requestSnapId);
+        markIncrementalSentencesHandled(newSentences, requestSnapId);
     } finally {
         if (incrementalAbortController === abortCtrl) {
             incrementalAbortController = null;
@@ -365,11 +359,8 @@ async function translateNewSentencesIncremental(newSentences, requestSnapId) {
     }
 }
 
-function appendIncrementalFallback(sentences, requestSnapId) {
+function markIncrementalSentencesHandled(sentences, requestSnapId) {
     if (requestSnapId !== incrementalRequestId) return;
-    for (var i = 0; i < sentences.length; i++) {
-        incrementalTranslatedSentences.push(sentences[i]);
-    }
     incrementalTranslatedCount += sentences.length;
     updateIncrementalDisplay();
 }
@@ -413,21 +404,6 @@ function updateSubtitleStreamingText(text) {
             incrementalTranslateTimer = null;
             translateNewSentencesIncremental(newSentences, requestSnapId);
         }, 300);
-
-        // 防抖期间先显示原文 preview
-        var preview = incrementalTranslatedSentences.slice();
-        for (var i = 0; i < newSentences.length; i++) {
-            preview.push(newSentences[i]);
-        }
-        if (rest.trim()) preview.push(rest.trim());
-        ensureSubtitleVisibleIfEnabled();
-        writeSubtitleText(preview.join(' '));
-    } else if (rest.trim()) {
-        // 无新句子但有尾部更新
-        var displayParts = incrementalTranslatedSentences.slice();
-        displayParts.push(rest.trim());
-        ensureSubtitleVisibleIfEnabled();
-        writeSubtitleText(displayParts.join(' '));
     }
 }
 
@@ -590,7 +566,7 @@ async function translateAndShowSubtitle(text) {
     // 无剩余 → 直接显示已有的增量翻译
     if (!remainingText.trim()) {
         ensureSubtitleVisibleIfEnabled();
-        writeSubtitleText(incrementalTranslatedSentences.join(' ') || text);
+        writeSubtitleText(incrementalTranslatedSentences.join(' '));
         return;
     }
 
@@ -618,11 +594,8 @@ async function translateAndShowSubtitle(text) {
 
         if (!response.ok) {
             console.warn('字幕翻译请求失败:', response.status);
-            var fallbackParts = incrementalTranslatedSentences.slice();
-            if (remainingSentences.length) fallbackParts = fallbackParts.concat(remainingSentences);
-            if (trailingRest && trailingRest.trim()) fallbackParts.push(trailingRest.trim());
             ensureSubtitleVisibleIfEnabled();
-            writeSubtitleText(fallbackParts.join(' ') || text);
+            writeSubtitleText(incrementalTranslatedSentences.join(' '));
             return;
         }
 
@@ -633,21 +606,12 @@ async function translateAndShowSubtitle(text) {
         }
         if (!subtitleEnabled) return;
 
-        if (result.success && result.translated_text &&
-            result.source_lang && result.target_lang &&
-            result.source_lang !== result.target_lang &&
-            result.source_lang !== 'unknown') {
+        if (result.success && result.translated_text) {
             incrementalTranslatedSentences.push(result.translated_text.trim());
             ensureSubtitleVisibleIfEnabled();
             writeSubtitleText(incrementalTranslatedSentences.join(' '));
             console.log('字幕翻译完成:', incrementalTranslatedSentences.join(' ').substring(0, 80));
         } else {
-            if (remainingSentences.length) {
-                incrementalTranslatedSentences = incrementalTranslatedSentences.concat(remainingSentences);
-            }
-            if (trailingRest && trailingRest.trim()) {
-                incrementalTranslatedSentences.push(trailingRest.trim());
-            }
             ensureSubtitleVisibleIfEnabled();
             writeSubtitleText(incrementalTranslatedSentences.join(' '));
         }
@@ -655,7 +619,7 @@ async function translateAndShowSubtitle(text) {
         if (error.name === 'AbortError') return;
         if (subtitleEnabled && requestTurnId === currentTurnId) {
             ensureSubtitleVisibleIfEnabled();
-            writeSubtitleText(text);
+            writeSubtitleText(incrementalTranslatedSentences.join(' '));
         }
         console.error('字幕翻译异常:', {
             error: error.message,
@@ -798,14 +762,14 @@ window.subtitleBridge = {
         });
 
         if (subtitleEnabled) {
-            // 优先显示已有的增量翻译，其次原文
+            // 只显示译文；翻译回来前不预览原文
             var incrementalText = incrementalTranslatedSentences.join(' ');
             if (incrementalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText(incrementalText);
             } else if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
-                writeSubtitleText(currentTurnOriginalText);
+                writeSubtitleText('');
             } else {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText('');
@@ -837,7 +801,7 @@ window.subtitleBridge = {
             }
             hideSubtitle();
         } else {
-            // 优先显示已有的增量翻译
+            // 只显示译文；翻译回来前不预览原文
             var incrementalText = incrementalTranslatedSentences.join(' ');
             if (incrementalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
@@ -847,7 +811,7 @@ window.subtitleBridge = {
                 }
             } else if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
-                writeSubtitleText(currentTurnOriginalText);
+                writeSubtitleText('');
                 if (isCurrentTurnFinalized) {
                     translateAndShowSubtitle(currentTurnOriginalText);
                 }

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -319,6 +319,29 @@ function enqueueIncrementalSentences(sentences) {
     processIncrementalTranslationQueue(incrementalRequestId);
 }
 
+function resetIncrementalTranslationState() {
+    incrementalRequestId += 1;
+    incrementalTranslatedCount = 0;
+    incrementalTranslatedSentences = [];
+    incrementalQueuedCount = 0;
+    incrementalTranslationQueue = [];
+    incrementalTranslationActive = false;
+    if (incrementalTranslateTimer) {
+        clearTimeout(incrementalTranslateTimer);
+        incrementalTranslateTimer = null;
+    }
+    if (incrementalAbortController) {
+        incrementalAbortController.abort();
+        incrementalAbortController = null;
+    }
+}
+
+function resumeIncrementalTranslationQueue() {
+    if (subtitleEnabled && incrementalTranslationQueue.length) {
+        processIncrementalTranslationQueue(incrementalRequestId);
+    }
+}
+
 function countCjkChars(text) {
     var matches = (text || '').match(/[\u3400-\u9FFF\uF900-\uFAFF]/g);
     return matches ? matches.length : 0;
@@ -454,6 +477,11 @@ function updateSubtitleStreamingText(text) {
 function markSubtitleStructured() {
     if (isCurrentTurnFinalized) return;
     if (currentTurnIsStructured) return; // 已是结构化，幂等
+    resetIncrementalTranslationState();
+    if (currentTranslateAbortController) {
+        currentTranslateAbortController.abort();
+        currentTranslateAbortController = null;
+    }
     currentTurnIsStructured = true;
     const placeholder = getStructuredPlaceholder();
     currentTurnOriginalText = placeholder;
@@ -469,6 +497,7 @@ function markSubtitleStructured() {
 function finalizeSubtitleAsStructured() {
     isCurrentTurnFinalized = true;
     currentTurnIsStructured = true;
+    resetIncrementalTranslationState();
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
@@ -493,23 +522,7 @@ function resetSubtitleTurnState() {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
     }
-    // 增量翻译状态复位
-    incrementalTranslatedCount = 0;
-    incrementalTranslatedSentences = [];
-    incrementalQueuedCount = 0;
-    incrementalTranslationQueue = [];
-    incrementalTranslationActive = false;
-    if (incrementalTranslateTimer) {
-        clearTimeout(incrementalTranslateTimer);
-        incrementalTranslateTimer = null;
-    }
-    if (incrementalAbortController) {
-        incrementalAbortController.abort();
-        incrementalAbortController = null;
-    }
-    // 不重置 incrementalRequestId；保持单调递增作为失效令牌，
-    // 使旧的翻译响应无法与新的请求 ID 碰撞。
-    incrementalRequestId += 1;
+    resetIncrementalTranslationState();
 }
 
 /**
@@ -605,6 +618,10 @@ async function translateAndShowSubtitle(text) {
         enqueueIncrementalSentences(remainingSentences);
         return;
     }
+    if (!incrementalTranslationActive && incrementalTranslationQueue.length) {
+        resumeIncrementalTranslationQueue();
+        return;
+    }
     if (!incrementalTranslationActive && !incrementalTranslationQueue.length) {
         ensureSubtitleVisibleIfEnabled();
         writeSubtitleText(incrementalTranslatedSentences.join(' '));
@@ -651,19 +668,7 @@ function initSubtitleDrag() {
 }
 
 function retranslateCurrentSubtitle() {
-    incrementalTranslatedCount = 0;
-    incrementalTranslatedSentences = [];
-    incrementalQueuedCount = 0;
-    incrementalTranslationQueue = [];
-    incrementalTranslationActive = false;
-    if (incrementalTranslateTimer) {
-        clearTimeout(incrementalTranslateTimer);
-        incrementalTranslateTimer = null;
-    }
-    if (incrementalAbortController) {
-        incrementalAbortController.abort();
-        incrementalAbortController = null;
-    }
+    resetIncrementalTranslationState();
     if (currentTranslateAbortController) {
         currentTranslateAbortController.abort();
         currentTranslateAbortController = null;
@@ -745,16 +750,13 @@ window.subtitleBridge = {
         if (subtitleEnabled) {
             // 只显示译文；翻译回来前不预览原文
             var incrementalText = incrementalTranslatedSentences.join(' ');
+            ensureSubtitleVisibleIfEnabled();
             if (incrementalText.trim()) {
-                ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText(incrementalText);
-            } else if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
-                ensureSubtitleVisibleIfEnabled();
-                writeSubtitleText('');
             } else {
-                ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText('');
             }
+            resumeIncrementalTranslationQueue();
         } else {
             hideSubtitle();
         }
@@ -787,18 +789,21 @@ window.subtitleBridge = {
             if (incrementalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText(incrementalText);
+                resumeIncrementalTranslationQueue();
                 if (isCurrentTurnFinalized) {
                     translateAndShowSubtitle(currentTurnOriginalText);
                 }
             } else if (currentTurnOriginalText && currentTurnOriginalText.trim()) {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText('');
+                resumeIncrementalTranslationQueue();
                 if (isCurrentTurnFinalized) {
                     translateAndShowSubtitle(currentTurnOriginalText);
                 }
             } else {
                 ensureSubtitleVisibleIfEnabled();
                 writeSubtitleText('');
+                resumeIncrementalTranslationQueue();
             }
         }
 

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -57,7 +57,7 @@ function applySharedSubtitleSettings(patch, options) {
         refreshUiLocale: options && options.refreshUiLocale === true
     });
     subtitleEnabled = !!next.subtitleEnabled;
-    if (next.userLanguage) {
+    if (Object.prototype.hasOwnProperty.call(patch, 'userLanguage') && next.userLanguage) {
         userLanguage = next.userLanguage;
     }
     return next;
@@ -319,6 +319,19 @@ function enqueueIncrementalSentences(sentences) {
     processIncrementalTranslationQueue(incrementalRequestId);
 }
 
+function countCjkChars(text) {
+    var matches = (text || '').match(/[\u3400-\u9FFF\uF900-\uFAFF]/g);
+    return matches ? matches.length : 0;
+}
+
+function hasUnexpectedSourceResidue(translatedText, targetLang) {
+    var normalizedTarget = (targetLang || '').toLowerCase();
+    if (!translatedText || normalizedTarget === 'zh' || normalizedTarget === 'ja' || normalizedTarget === 'ko') {
+        return false;
+    }
+    return countCjkChars(translatedText) >= 4;
+}
+
 /**
  * 增量翻译核心：按发现顺序逐句翻译并追加到字幕显示。
  */
@@ -338,12 +351,19 @@ async function processIncrementalTranslationQueue(requestSnapId) {
     var abortCtrl = incrementalAbortController;
 
     try {
+        if (userLanguage === null) {
+            await getUserLanguage();
+        }
+        if (!subtitleEnabled) return;
+        if (requestSnapId !== incrementalRequestId) return;
+
+        var targetLanguage = userLanguage !== null ? userLanguage : 'zh';
         var response = await fetch('/api/translate', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 text: textToTranslate,
-                target_lang: (userLanguage !== null ? userLanguage : 'zh'),
+                target_lang: targetLanguage,
                 source_lang: null
             }),
             signal: abortCtrl.signal
@@ -358,7 +378,12 @@ async function processIncrementalTranslationQueue(requestSnapId) {
         if (requestSnapId !== incrementalRequestId) return;
 
         if (result.success && result.translated_text) {
-            incrementalTranslatedSentences.push(result.translated_text.trim());
+            var translated = result.translated_text.trim();
+            if (hasUnexpectedSourceResidue(translated, result.target_lang || targetLanguage)) {
+                console.warn('字幕翻译结果仍包含源语言片段，已跳过该句。');
+            } else {
+                incrementalTranslatedSentences.push(translated);
+            }
         }
         incrementalTranslatedCount += 1;
         updateIncrementalDisplay();

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -181,6 +181,9 @@ let incrementalTranslatedSentences = [];
 let incrementalTranslateTimer = null;
 let incrementalAbortController = null;
 let incrementalRequestId = 0;
+let incrementalQueuedCount = 0;
+let incrementalTranslationQueue = [];
+let incrementalTranslationActive = false;
 
 /**
  * 句子分割（用于增量翻译）。
@@ -308,15 +311,25 @@ function writeSubtitleText(text) {
     }, 200);
 }
 
+function enqueueIncrementalSentences(sentences) {
+    if (!sentences || !sentences.length) return;
+    for (var i = 0; i < sentences.length; i++) {
+        incrementalTranslationQueue.push(sentences[i]);
+    }
+    processIncrementalTranslationQueue(incrementalRequestId);
+}
+
 /**
- * 增量翻译核心：翻译新完成的句子并追加到字幕显示。
+ * 增量翻译核心：按发现顺序逐句翻译并追加到字幕显示。
  */
-async function translateNewSentencesIncremental(newSentences, requestSnapId) {
-    if (!newSentences || newSentences.length === 0) return;
+async function processIncrementalTranslationQueue(requestSnapId) {
+    if (incrementalTranslationActive) return;
+    if (!incrementalTranslationQueue.length) return;
     if (!subtitleEnabled) return;
     if (requestSnapId !== incrementalRequestId) return;
 
-    var textToTranslate = newSentences.join(' ');
+    var textToTranslate = incrementalTranslationQueue.shift();
+    incrementalTranslationActive = true;
 
     if (incrementalAbortController) {
         incrementalAbortController.abort();
@@ -337,7 +350,7 @@ async function translateNewSentencesIncremental(newSentences, requestSnapId) {
         });
 
         if (!response.ok) {
-            markIncrementalSentencesHandled(newSentences, requestSnapId);
+            markIncrementalSentenceHandled(requestSnapId);
             return;
         }
 
@@ -347,21 +360,25 @@ async function translateNewSentencesIncremental(newSentences, requestSnapId) {
         if (result.success && result.translated_text) {
             incrementalTranslatedSentences.push(result.translated_text.trim());
         }
-        incrementalTranslatedCount += newSentences.length;
+        incrementalTranslatedCount += 1;
         updateIncrementalDisplay();
     } catch (error) {
         if (error.name === 'AbortError') return;
-        markIncrementalSentencesHandled(newSentences, requestSnapId);
+        markIncrementalSentenceHandled(requestSnapId);
     } finally {
         if (incrementalAbortController === abortCtrl) {
             incrementalAbortController = null;
         }
+        incrementalTranslationActive = false;
+        if (requestSnapId === incrementalRequestId && incrementalTranslationQueue.length) {
+            processIncrementalTranslationQueue(requestSnapId);
+        }
     }
 }
 
-function markIncrementalSentencesHandled(sentences, requestSnapId) {
+function markIncrementalSentenceHandled(requestSnapId) {
     if (requestSnapId !== incrementalRequestId) return;
-    incrementalTranslatedCount += sentences.length;
+    incrementalTranslatedCount += 1;
     updateIncrementalDisplay();
 }
 
@@ -393,17 +410,12 @@ function updateSubtitleStreamingText(text) {
     var splitResult = splitSubtitleSentences(cleaned);
     var allSentences = splitResult.sentences;
     var rest = splitResult.rest;
-    var newCount = allSentences.length - incrementalTranslatedCount;
+    var newCount = allSentences.length - incrementalQueuedCount;
 
     if (newCount > 0) {
-        var newSentences = allSentences.slice(incrementalTranslatedCount);
-
-        if (incrementalTranslateTimer) clearTimeout(incrementalTranslateTimer);
-        var requestSnapId = ++incrementalRequestId;
-        incrementalTranslateTimer = setTimeout(function() {
-            incrementalTranslateTimer = null;
-            translateNewSentencesIncremental(newSentences, requestSnapId);
-        }, 300);
+        var newSentences = allSentences.slice(incrementalQueuedCount);
+        incrementalQueuedCount = allSentences.length;
+        enqueueIncrementalSentences(newSentences);
     }
 }
 
@@ -459,6 +471,9 @@ function resetSubtitleTurnState() {
     // 增量翻译状态复位
     incrementalTranslatedCount = 0;
     incrementalTranslatedSentences = [];
+    incrementalQueuedCount = 0;
+    incrementalTranslationQueue = [];
+    incrementalTranslationActive = false;
     if (incrementalTranslateTimer) {
         clearTimeout(incrementalTranslateTimer);
         incrementalTranslateTimer = null;
@@ -469,6 +484,7 @@ function resetSubtitleTurnState() {
     }
     // 不重置 incrementalRequestId；保持单调递增作为失效令牌，
     // 使旧的翻译响应无法与新的请求 ID 碰撞。
+    incrementalRequestId += 1;
 }
 
 /**
@@ -516,7 +532,7 @@ function onAssistantTurnStart() {
 }
 
 /**
- * Turn 结束时调用：翻译剩余未处理部分并追加到增量翻译结果。
+ * Turn 结束时调用：把剩余未入队文本补进逐句翻译队列。
  */
 async function translateAndShowSubtitle(text) {
     if (!text || !text.trim()) {
@@ -553,83 +569,20 @@ async function translateAndShowSubtitle(text) {
         return;
     }
 
-    // 计算剩余未翻译部分
     var splitResult = splitSubtitleSentences(text);
-    var totalSentences = splitResult.sentences;
-    var trailingRest = splitResult.rest;
-    var remainingSentences = totalSentences.slice(incrementalTranslatedCount);
-    var remainingText = remainingSentences.join(' ');
-    if (trailingRest && trailingRest.trim()) {
-        remainingText = (remainingText ? remainingText + ' ' : '') + trailingRest.trim();
+    var finalSentences = splitResult.sentences.slice();
+    if (splitResult.rest && splitResult.rest.trim()) {
+        finalSentences.push(splitResult.rest.trim());
     }
-
-    // 无剩余 → 直接显示已有的增量翻译
-    if (!remainingText.trim()) {
-        ensureSubtitleVisibleIfEnabled();
-        writeSubtitleText(incrementalTranslatedSentences.join(' '));
+    var remainingSentences = finalSentences.slice(incrementalQueuedCount);
+    if (remainingSentences.length) {
+        incrementalQueuedCount = finalSentences.length;
+        enqueueIncrementalSentences(remainingSentences);
         return;
     }
-
-    if (incrementalAbortController) {
-        incrementalAbortController.abort();
-        incrementalAbortController = null;
-    }
-    if (currentTranslateAbortController) {
-        currentTranslateAbortController.abort();
-    }
-    currentTranslateAbortController = new AbortController();
-    const abortController = currentTranslateAbortController;
-
-    try {
-        const response = await fetch('/api/translate', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                text: remainingText,
-                target_lang: (userLanguage !== null ? userLanguage : 'zh'),
-                source_lang: null
-            }),
-            signal: abortController.signal
-        });
-
-        if (!response.ok) {
-            console.warn('字幕翻译请求失败:', response.status);
-            ensureSubtitleVisibleIfEnabled();
-            writeSubtitleText(incrementalTranslatedSentences.join(' '));
-            return;
-        }
-
-        const result = await response.json();
-
-        if (requestTurnId !== currentTurnId || requestId !== currentTranslationRequestId) {
-            return;
-        }
-        if (!subtitleEnabled) return;
-
-        if (result.success && result.translated_text) {
-            incrementalTranslatedSentences.push(result.translated_text.trim());
-            ensureSubtitleVisibleIfEnabled();
-            writeSubtitleText(incrementalTranslatedSentences.join(' '));
-            console.log('字幕翻译完成:', incrementalTranslatedSentences.join(' ').substring(0, 80));
-        } else {
-            ensureSubtitleVisibleIfEnabled();
-            writeSubtitleText(incrementalTranslatedSentences.join(' '));
-        }
-    } catch (error) {
-        if (error.name === 'AbortError') return;
-        if (subtitleEnabled && requestTurnId === currentTurnId) {
-            ensureSubtitleVisibleIfEnabled();
-            writeSubtitleText(incrementalTranslatedSentences.join(' '));
-        }
-        console.error('字幕翻译异常:', {
-            error: error.message,
-            text: text.substring(0, 50) + '...',
-            userLanguage: userLanguage
-        });
-    } finally {
-        if (currentTranslateAbortController === abortController) {
-            currentTranslateAbortController = null;
-        }
+    if (!incrementalTranslationActive && !incrementalTranslationQueue.length) {
+        ensureSubtitleVisibleIfEnabled();
+        writeSubtitleText(incrementalTranslatedSentences.join(' '));
     }
 }
 
@@ -675,6 +628,9 @@ function initSubtitleDrag() {
 function retranslateCurrentSubtitle() {
     incrementalTranslatedCount = 0;
     incrementalTranslatedSentences = [];
+    incrementalQueuedCount = 0;
+    incrementalTranslationQueue = [];
+    incrementalTranslationActive = false;
     if (incrementalTranslateTimer) {
         clearTimeout(incrementalTranslateTimer);
         incrementalTranslateTimer = null;

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -394,8 +394,40 @@ def test_subtitle_incremental_translation_waits_for_user_language_before_request
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize(
+    (
+        "original_text",
+        "source_lang",
+        "first_translation",
+        "second_translation",
+    ),
+    [
+        (
+            "明明没什么本事。你还到处惹麻烦。",
+            "zh",
+            "明明没什么本事, you still keep acting tough.",
+            "You keep causing trouble.",
+        ),
+        (
+            "こんにちは。まだ翻訳されていません。",
+            "ja",
+            "こんにちは, still not translated.",
+            "Still not translated.",
+        ),
+        (
+            "안녕하세요. 아직 번역되지 않았습니다.",
+            "ko",
+            "안녕하세요, still not translated.",
+            "Still not translated.",
+        ),
+    ],
+)
 def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
     mock_page: Page,
+    original_text: str,
+    source_lang: str,
+    first_translation: str,
+    second_translation: str,
 ):
     _open_subtitle_harness(
         mock_page,
@@ -408,7 +440,7 @@ def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
     )
     mock_page.evaluate(
         """
-        () => {
+        ({ sourceLang, firstTranslation, secondTranslation }) => {
             let requestCount = 0;
             window.fetch = async (url, options) => {
                 const requestUrl = String(url);
@@ -422,12 +454,12 @@ def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
                 if (requestUrl === '/api/translate') {
                     requestCount += 1;
                     const translated = requestCount === 1
-                        ? '明明没什么本事, you still keep acting tough.'
-                        : 'You keep causing trouble.';
+                        ? firstTranslation
+                        : secondTranslation;
                     return new Response(JSON.stringify({
                         success: true,
                         translated_text: translated,
-                        source_lang: 'zh',
+                        source_lang: sourceLang,
                         target_lang: body.target_lang || 'en',
                     }), {
                         status: 200,
@@ -439,22 +471,27 @@ def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
             window.localStorage.setItem('subtitleEnabled', 'true');
             window.localStorage.setItem('userLanguage', 'en');
         }
-        """
+        """,
+        {
+            "sourceLang": source_lang,
+            "firstTranslation": first_translation,
+            "secondTranslation": second_translation,
+        },
     )
     mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
     mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
 
     result = mock_page.evaluate(
         """
-        async () => {
+        async ({ originalText, expectedText }) => {
             window.beginSubtitleTurn();
             window.subtitleBridge.setSubtitleEnabled(true);
-            window.updateSubtitleStreamingText('明明没什么本事。你还到处惹麻烦。');
+            window.updateSubtitleStreamingText(originalText);
             await new Promise((resolve, reject) => {
                 const startedAt = Date.now();
                 const poll = () => {
                     const text = document.getElementById('subtitle-text').textContent;
-                    if (text === 'You keep causing trouble.') {
+                    if (text === expectedText) {
                         resolve();
                         return;
                     }
@@ -468,10 +505,14 @@ def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
             });
             return document.getElementById('subtitle-text').textContent;
         }
-        """
+        """,
+        {
+            "originalText": original_text,
+            "expectedText": second_translation,
+        },
     )
 
-    assert result == "You keep causing trouble."
+    assert result == second_translation
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -174,6 +174,268 @@ def test_subtitle_streaming_does_not_show_original_text_while_translation_is_pen
 
 
 @pytest.mark.frontend
+def test_subtitle_incremental_translation_does_not_merge_fast_streaming_sentences(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.__translateResolvers = {};
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    await new Promise((resolve) => {
+                        window.__translateResolvers[body.text] = resolve;
+                    });
+                    const translated = body.text === 'First sentence.'
+                        ? '第一句。'
+                        : '第二句。';
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: translated,
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('First sentence.');
+            await new Promise((resolve) => setTimeout(resolve, 350));
+            window.updateSubtitleStreamingText('First sentence. Second sentence.');
+            await new Promise((resolve) => setTimeout(resolve, 350));
+            const requestsBeforeResolve = window.__translateRequests.map((request) => request.text);
+
+            window.__translateResolvers['First sentence.']();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === '第一句。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('first translated subtitle did not render'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            const afterFirstResolve = document.getElementById('subtitle-text').textContent;
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.map((request) => request.text).includes('Second sentence.')) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('second sentence translation request did not start'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            const requestsAfterFirstResolve = window.__translateRequests.map((request) => request.text);
+
+            window.__translateResolvers['Second sentence.']();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === '第一句。 第二句。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('second translated subtitle did not render'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return {
+                requestsBeforeResolve,
+                requestsAfterFirstResolve,
+                afterFirstResolve,
+                finalText: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert result["requestsBeforeResolve"] == ["First sentence."]
+    assert result["requestsAfterFirstResolve"] == ["First sentence.", "Second sentence."]
+    assert result["afterFirstResolve"] == "第一句。"
+    assert result["finalText"] == "第一句。 第二句。"
+
+
+@pytest.mark.frontend
+def test_subtitle_turn_end_keeps_pending_incremental_sentence_queue(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.__translateResolvers = {};
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    await new Promise((resolve) => {
+                        window.__translateResolvers[body.text] = resolve;
+                    });
+                    const translated = body.text === 'First sentence.'
+                        ? '第一句。'
+                        : '第二句。';
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: translated,
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('First sentence.');
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            window.updateSubtitleStreamingText('First sentence. Second sentence.');
+            window.translateAndShowSubtitle('First sentence. Second sentence.');
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            const requestsAfterTurnEnd = window.__translateRequests.map((request) => request.text);
+
+            window.__translateResolvers['First sentence.']();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === '第一句。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('first translated subtitle did not render after turn end'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.map((request) => request.text).includes('Second sentence.')) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('second sentence translation request did not start after turn end'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            window.__translateResolvers['Second sentence.']();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === '第一句。 第二句。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('second translated subtitle did not render after turn end'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return {
+                requestsAfterTurnEnd,
+                finalRequests: window.__translateRequests.map((request) => request.text),
+                finalText: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert result["requestsAfterTurnEnd"] == ["First sentence."]
+    assert result["finalRequests"] == ["First sentence.", "Second sentence."]
+    assert "First sentence. Second sentence." not in result["finalRequests"]
+    assert result["finalText"] == "第一句。 第二句。"
+
+
+@pytest.mark.frontend
 def test_subtitle_translation_failure_does_not_fall_back_to_original_text(
     mock_page: Page,
 ):

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -553,6 +553,8 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
             document.dispatchEvent(new Event('DOMContentLoaded'));
             await new Promise((resolve) => setTimeout(resolve, 0));
             const emptySize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            const emptySettingsBtnRect = document.getElementById('subtitle-settings-btn').getBoundingClientRect();
+            const emptyDragHandleRect = document.getElementById('subtitle-drag-handle').getBoundingClientRect();
             window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
                 detail: {
                     transcript: '这是一段很长很长的翻译字幕，用来测试窗口高度会按内容增长，但是不会超过中号字幕的最大高度。'.repeat(8),
@@ -576,6 +578,8 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
             const textStyle = getComputedStyle(document.getElementById('subtitle-text'));
             return {
                 emptySize,
+                emptyControlsOverlap: emptySettingsBtnRect.bottom > emptyDragHandleRect.top,
+                emptyControlsGap: emptyDragHandleRect.top - emptySettingsBtnRect.bottom,
                 longSize,
                 panelOpenSize,
                 displayHeight: displayRect.height,
@@ -600,7 +604,9 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
         """
     )
 
-    assert result["emptySize"]["height"] == 40
+    assert result["emptySize"]["height"] == 68
+    assert result["emptyControlsOverlap"] is False
+    assert result["emptyControlsGap"] >= 8
     assert result["longSize"]["height"] <= 160
     assert result["longSize"]["height"] >= 40
     assert result["panelOpenSize"]["height"] >= result["panelBottom"]

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -572,6 +572,7 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
             const scrollStyle = getComputedStyle(document.getElementById('subtitle-scroll'));
             const scrollThumbStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar-thumb');
             const scrollBarStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar');
+            const scrollTrackStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar-track');
             const textStyle = getComputedStyle(document.getElementById('subtitle-text'));
             return {
                 emptySize,
@@ -591,6 +592,7 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
                 scrollBarColor: scrollStyle.scrollbarColor,
                 scrollBarGutter: scrollStyle.scrollbarGutter,
                 webkitScrollBarWidth: scrollBarStyle.width,
+                scrollTrackBackground: scrollTrackStyle.backgroundColor,
                 scrollThumbBackground: scrollThumbStyle.backgroundColor,
                 textMarginRight: textStyle.marginRight,
             };
@@ -611,8 +613,9 @@ def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
     assert result["scrollBarWidth"] == "thin"
     assert "rgba" in result["scrollBarColor"]
     assert result["scrollBarGutter"] == "stable"
-    assert result["webkitScrollBarWidth"] == "4px"
-    assert result["scrollThumbBackground"] != "rgba(0, 0, 0, 0)"
+    assert result["webkitScrollBarWidth"] == "3px"
+    assert result["scrollTrackBackground"] == "rgba(0, 0, 0, 0)"
+    assert result["scrollThumbBackground"] == "rgba(255, 255, 255, 0.42)"
     assert result["textMarginRight"] == "8px"
 
 
@@ -670,6 +673,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
             const scrollStyle = getComputedStyle(document.getElementById('subtitle-scroll'));
             const scrollThumbStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar-thumb');
             const scrollBarStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar');
+            const scrollTrackStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar-track');
             const textStyle = getComputedStyle(document.getElementById('subtitle-text'));
             return {
                 scrollTop: scrollRect.top,
@@ -688,6 +692,7 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
                 scrollBarColor: scrollStyle.scrollbarColor,
                 scrollBarGutter: scrollStyle.scrollbarGutter,
                 webkitScrollBarWidth: scrollBarStyle.width,
+                scrollTrackBackground: scrollTrackStyle.backgroundColor,
                 scrollThumbBackground: scrollThumbStyle.backgroundColor,
                 textMarginRight: textStyle.marginRight,
             };
@@ -705,8 +710,9 @@ def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
     assert result["scrollBarWidth"] == "thin"
     assert "rgba" in result["scrollBarColor"]
     assert result["scrollBarGutter"] == "stable"
-    assert result["webkitScrollBarWidth"] == "4px"
-    assert result["scrollThumbBackground"] != "rgba(0, 0, 0, 0)"
+    assert result["webkitScrollBarWidth"] == "3px"
+    assert result["scrollTrackBackground"] == "rgba(0, 0, 0, 0)"
+    assert result["scrollThumbBackground"] == "rgba(255, 255, 255, 0.42)"
     assert result["textMarginRight"] == "8px"
 
 

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -306,6 +306,175 @@ def test_subtitle_incremental_translation_does_not_merge_fast_streaming_sentence
 
 
 @pytest.mark.frontend
+def test_subtitle_incremental_translation_waits_for_user_language_before_request(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.__resolveLanguage = null;
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    await new Promise((resolve) => { window.__resolveLanguage = resolve; });
+                    return new Response(JSON.stringify({ success: true, language: 'en' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: 'Hello world.',
+                        source_lang: 'zh',
+                        target_lang: body.target_lang || 'en',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.removeItem('userLanguage');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('你好世界。');
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            const requestsBeforeLanguage = window.__translateRequests.slice();
+            window.__resolveLanguage();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.length > 0) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('translation request did not start'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return {
+                requestsBeforeLanguage,
+                requests: window.__translateRequests,
+                text: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert result["requestsBeforeLanguage"] == []
+    assert result["requests"][0]["target_lang"] == "en"
+    assert result["text"] == "Hello world."
+
+
+@pytest.mark.frontend
+def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            let requestCount = 0;
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'en' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    requestCount += 1;
+                    const translated = requestCount === 1
+                        ? '明明没什么本事, you still keep acting tough.'
+                        : 'You keep causing trouble.';
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: translated,
+                        source_lang: 'zh',
+                        target_lang: body.target_lang || 'en',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'en');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('明明没什么本事。你还到处惹麻烦。');
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    const text = document.getElementById('subtitle-text').textContent;
+                    if (text === 'You keep causing trouble.') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1200) {
+                        reject(new Error('clean translated subtitle did not render'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return document.getElementById('subtitle-text').textContent;
+        }
+        """
+    )
+
+    assert result == "You keep causing trouble."
+
+
+@pytest.mark.frontend
 def test_subtitle_turn_end_keeps_pending_incremental_sentence_queue(
     mock_page: Page,
 ):

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -475,6 +475,341 @@ def test_subtitle_skips_translated_sentence_with_unexpected_source_residue(
 
 
 @pytest.mark.frontend
+def test_subtitle_reenable_restarts_pending_incremental_queue(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.__translateResolvers = {};
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    await new Promise((resolve) => {
+                        window.__translateResolvers[body.text] = resolve;
+                    });
+                    const translated = body.text === 'First sentence.'
+                        ? '第一句。'
+                        : '第二句。';
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: translated,
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('First sentence. Second sentence.');
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.map((request) => request.text).includes('First sentence.')) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('first sentence translation request did not start'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            window.subtitleBridge.setSubtitleEnabled(false);
+            window.__translateResolvers['First sentence.']();
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            const requestsWhileDisabled = window.__translateRequests.map((request) => request.text);
+            window.translateAndShowSubtitle('First sentence. Second sentence.');
+            window.subtitleBridge.setSubtitleEnabled(true);
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.map((request) => request.text).includes('Second sentence.')) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('second sentence translation request did not restart'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            window.__translateResolvers['Second sentence.']();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === '第一句。 第二句。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('queued subtitle did not finish after re-enable'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return {
+                requestsWhileDisabled,
+                finalRequests: window.__translateRequests.map((request) => request.text),
+                finalText: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert result["requestsWhileDisabled"] == ["First sentence."]
+    assert result["finalRequests"] == ["First sentence.", "Second sentence."]
+    assert result["finalText"] == "第一句。 第二句。"
+
+
+@pytest.mark.frontend
+def test_subtitle_retranslate_invalidates_stale_incremental_response(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.__translateResolvers = [];
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'en' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    await new Promise((resolve) => {
+                        window.__translateResolvers.push(resolve);
+                    });
+                    const translated = body.target_lang === 'ja' ? 'こんにちは。' : 'Hello.';
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: translated,
+                        source_lang: 'zh',
+                        target_lang: body.target_lang || 'en',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'en');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('你好。');
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.length === 1) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('initial translation request did not start'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            window.subtitleBridge.setUserLanguage('ja');
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__translateRequests.length === 2) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('retranslation request did not start'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            window.__translateResolvers[0]();
+            await new Promise((resolve) => setTimeout(resolve, 80));
+            const afterStaleResolve = document.getElementById('subtitle-text').textContent;
+            window.__translateResolvers[1]();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === 'こんにちは。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('retranslated subtitle did not render'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return {
+                requests: window.__translateRequests,
+                afterStaleResolve,
+                finalText: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert [request["target_lang"] for request in result["requests"]] == ["en", "ja"]
+    assert result["afterStaleResolve"] == ""
+    assert result["finalText"] == "こんにちは。"
+
+
+@pytest.mark.frontend
+def test_subtitle_structured_mode_invalidates_pending_incremental_response(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__resolveTranslate = null;
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    await new Promise((resolve) => { window.__resolveTranslate = resolve; });
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: '你好世界。',
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('Hello world.');
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (window.__resolveTranslate) {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('translation request did not start'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            window.markSubtitleStructured();
+            const placeholder = document.getElementById('subtitle-text').textContent;
+            window.__resolveTranslate();
+            await new Promise((resolve) => setTimeout(resolve, 120));
+            return {
+                placeholder,
+                finalText: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert result["placeholder"] == "[markdown]"
+    assert result["finalText"] == "[markdown]"
+
+
+@pytest.mark.frontend
 def test_subtitle_turn_end_keeps_pending_incremental_sentence_queue(
     mock_page: Page,
 ):

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -1,0 +1,523 @@
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _open_subtitle_harness(mock_page: Page, body_class: str, body_html: str) -> None:
+    mock_page.route(
+        "**/subtitle-harness",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="text/html",
+            body=(
+                "<!doctype html><html><head></head>"
+                f"<body class=\"{body_class}\">{body_html}</body></html>"
+            ),
+        ),
+    )
+    mock_page.goto("http://neko.test/subtitle-harness")
+
+
+@pytest.mark.frontend
+def test_subtitle_incremental_translation_starts_when_sentence_punctuation_arrives(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: '你好世界。',
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('Hello world.');
+            await new Promise((resolve) => setTimeout(resolve, 450));
+            return {
+                text: document.getElementById('subtitle-text').textContent,
+                requests: window.__translateRequests,
+            };
+        }
+        """
+    )
+
+    assert result["text"] == "你好世界。"
+    assert [request["text"] for request in result["requests"]] == ["Hello world."]
+
+
+@pytest.mark.frontend
+def test_subtitle_streaming_does_not_show_original_text_while_translation_is_pending(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__resolveTranslate = null;
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    await new Promise((resolve) => { window.__resolveTranslate = resolve; });
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: '你好世界。',
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('Hello world.');
+            await new Promise((resolve) => setTimeout(resolve, 350));
+            const beforeResolve = document.getElementById('subtitle-text').textContent;
+            window.__resolveTranslate();
+            await new Promise((resolve, reject) => {
+                const startedAt = Date.now();
+                const poll = () => {
+                    if (document.getElementById('subtitle-text').textContent === '你好世界。') {
+                        resolve();
+                        return;
+                    }
+                    if (Date.now() - startedAt > 1000) {
+                        reject(new Error('translated subtitle did not render'));
+                        return;
+                    }
+                    setTimeout(poll, 20);
+                };
+                poll();
+            });
+            return {
+                beforeResolve,
+                afterResolve: document.getElementById('subtitle-text').textContent,
+            };
+        }
+        """
+    )
+
+    assert result["beforeResolve"] == ""
+    assert result["afterResolve"] == "你好世界。"
+
+
+@pytest.mark.frontend
+def test_subtitle_translation_failure_does_not_fall_back_to_original_text(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.fetch = async (url) => {
+                const requestUrl = String(url);
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    return new Response(JSON.stringify({ success: false }), {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('Hello world.');
+            await new Promise((resolve) => setTimeout(resolve, 450));
+            await window.translateAndShowSubtitle('Hello world.');
+            return document.getElementById('subtitle-text').textContent;
+        }
+        """
+    )
+
+    assert result == ""
+
+
+@pytest.mark.frontend
+def test_subtitle_window_height_uses_content_bounds_not_dropdown_height(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-window-host",
+        """
+        <div id="subtitle-display">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden">
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="targetLang">目标语言</span>
+                    <select id="subtitle-lang-select"><option value="zh">中文</option><option value="en">English</option></select>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="opacity">不透明度</span>
+                    <input type="range" id="subtitle-opacity-slider" min="20" max="100" value="95">
+                    <span id="subtitle-opacity-value">95%</span>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="dragAnywhere">整体拖动</span>
+                    <label class="subtitle-settings-switch"><input type="checkbox" id="subtitle-drag-mode-toggle"><span class="subtitle-settings-track"></span></label>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="size">大小</span>
+                    <div class="subtitle-size-group">
+                        <button type="button" class="subtitle-size-btn" data-size="small">小</button>
+                        <button type="button" class="subtitle-size-btn active" data-size="medium">中</button>
+                        <button type="button" class="subtitle-size-btn" data-size="large">大</button>
+                    </div>
+                </div>
+            </div>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__subtitleSizes = [];
+            window.localStorage.setItem('subtitleDragAnywhere', 'true');
+            window.nekoSubtitle = {
+                setSize: (width, height) => window.__subtitleSizes.push({ width, height }),
+                changeSettings: () => {},
+                dragStart: () => {},
+                dragStop: () => {},
+            };
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-window.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const emptySize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            window.dispatchEvent(new CustomEvent('neko-ws-transcript', {
+                detail: {
+                    transcript: '这是一段很长很长的翻译字幕，用来测试窗口高度会按内容增长，但是不会超过中号字幕的最大高度。'.repeat(8),
+                },
+            }));
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const longSize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            document.getElementById('subtitle-settings-btn').click();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const panelOpenSize = window.__subtitleSizes[window.__subtitleSizes.length - 1];
+            const displayRect = document.getElementById('subtitle-display').getBoundingClientRect();
+            const scrollRect = document.getElementById('subtitle-scroll').getBoundingClientRect();
+            const settingsBtnRect = document.getElementById('subtitle-settings-btn').getBoundingClientRect();
+            const dragHandleRect = document.getElementById('subtitle-drag-handle').getBoundingClientRect();
+            const panelRect = document.getElementById('subtitle-settings-panel').getBoundingClientRect();
+            const displayStyle = getComputedStyle(document.getElementById('subtitle-display'));
+            const scrollStyle = getComputedStyle(document.getElementById('subtitle-scroll'));
+            const scrollThumbStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar-thumb');
+            const scrollBarStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar');
+            const textStyle = getComputedStyle(document.getElementById('subtitle-text'));
+            return {
+                emptySize,
+                longSize,
+                panelOpenSize,
+                displayHeight: displayRect.height,
+                scrollHeight: scrollRect.height,
+                scrollRight: scrollRect.right,
+                settingsBtnLeft: settingsBtnRect.left,
+                dragHandleLeft: dragHandleRect.left,
+                panelBottom: panelRect.bottom,
+                overlapsVertically: panelRect.bottom > scrollRect.top && panelRect.top < scrollRect.bottom,
+                displayOverflow: displayStyle.overflowY,
+                scrollOverflow: scrollStyle.overflowY,
+                scrollPointerEvents: scrollStyle.pointerEvents,
+                scrollBarWidth: scrollStyle.scrollbarWidth,
+                scrollBarColor: scrollStyle.scrollbarColor,
+                scrollBarGutter: scrollStyle.scrollbarGutter,
+                webkitScrollBarWidth: scrollBarStyle.width,
+                scrollThumbBackground: scrollThumbStyle.backgroundColor,
+                textMarginRight: textStyle.marginRight,
+            };
+        }
+        """
+    )
+
+    assert result["emptySize"]["height"] == 40
+    assert result["longSize"]["height"] <= 160
+    assert result["longSize"]["height"] >= 40
+    assert result["panelOpenSize"]["height"] >= result["panelBottom"]
+    assert result["overlapsVertically"] is False
+    assert result["displayOverflow"] == "visible"
+    assert result["scrollOverflow"] == "auto"
+    assert result["scrollPointerEvents"] == "auto"
+    assert result["scrollRight"] <= result["settingsBtnLeft"] - 6
+    assert result["scrollRight"] <= result["dragHandleLeft"] - 6
+    assert result["scrollBarWidth"] == "thin"
+    assert "rgba" in result["scrollBarColor"]
+    assert result["scrollBarGutter"] == "stable"
+    assert result["webkitScrollBarWidth"] == "4px"
+    assert result["scrollThumbBackground"] != "rgba(0, 0, 0, 0)"
+    assert result["textMarginRight"] == "8px"
+
+
+@pytest.mark.frontend
+def test_web_subtitle_settings_panel_does_not_overlap_subtitle_text(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="show" style="display:flex; opacity:1; visibility:visible;">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden">
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="targetLang">目标语言</span>
+                    <select id="subtitle-lang-select"><option value="zh">中文</option><option value="en">English</option></select>
+                </div>
+                <div class="subtitle-settings-row">
+                    <span class="subtitle-settings-label" data-subtitle-label="opacity">不透明度</span>
+                    <input type="range" id="subtitle-opacity-slider" min="20" max="100" value="95">
+                    <span id="subtitle-opacity-value">95%</span>
+                </div>
+            </div>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitleDragAnywhere', 'true');
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const shared = window.nekoSubtitleShared;
+            shared.initSubtitleUI({ host: 'web' });
+            shared.applySubtitlePreset(document.getElementById('subtitle-display'), 'medium', { host: 'web' });
+            document.getElementById('subtitle-text').textContent =
+                'Hmph, you persistent idiot. You and now you are hooked, huh?';
+            document.getElementById('subtitle-settings-btn').click();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            const scrollRect = document.getElementById('subtitle-scroll').getBoundingClientRect();
+            const settingsBtnRect = document.getElementById('subtitle-settings-btn').getBoundingClientRect();
+            const dragHandleRect = document.getElementById('subtitle-drag-handle').getBoundingClientRect();
+            const panelRect = document.getElementById('subtitle-settings-panel').getBoundingClientRect();
+            const displayStyle = getComputedStyle(document.getElementById('subtitle-display'));
+            const scrollStyle = getComputedStyle(document.getElementById('subtitle-scroll'));
+            const scrollThumbStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar-thumb');
+            const scrollBarStyle = getComputedStyle(document.getElementById('subtitle-scroll'), '::-webkit-scrollbar');
+            const textStyle = getComputedStyle(document.getElementById('subtitle-text'));
+            return {
+                scrollTop: scrollRect.top,
+                scrollBottom: scrollRect.bottom,
+                scrollRight: scrollRect.right,
+                settingsBtnLeft: settingsBtnRect.left,
+                dragHandleLeft: dragHandleRect.left,
+                panelTop: panelRect.top,
+                panelBottom: panelRect.bottom,
+                overlapsVertically: panelRect.bottom > scrollRect.top && panelRect.top < scrollRect.bottom,
+                panelHidden: document.getElementById('subtitle-settings-panel').classList.contains('hidden'),
+                displayOverflow: displayStyle.overflowY,
+                scrollOverflow: scrollStyle.overflowY,
+                scrollPointerEvents: scrollStyle.pointerEvents,
+                scrollBarWidth: scrollStyle.scrollbarWidth,
+                scrollBarColor: scrollStyle.scrollbarColor,
+                scrollBarGutter: scrollStyle.scrollbarGutter,
+                webkitScrollBarWidth: scrollBarStyle.width,
+                scrollThumbBackground: scrollThumbStyle.backgroundColor,
+                textMarginRight: textStyle.marginRight,
+            };
+        }
+        """
+    )
+
+    assert result["panelHidden"] is False
+    assert result["overlapsVertically"] is False
+    assert result["displayOverflow"] == "visible"
+    assert result["scrollOverflow"] == "auto"
+    assert result["scrollPointerEvents"] == "auto"
+    assert result["scrollRight"] <= result["settingsBtnLeft"] - 6
+    assert result["scrollRight"] <= result["dragHandleLeft"] - 6
+    assert result["scrollBarWidth"] == "thin"
+    assert "rgba" in result["scrollBarColor"]
+    assert result["scrollBarGutter"] == "stable"
+    assert result["webkitScrollBarWidth"] == "4px"
+    assert result["scrollThumbBackground"] != "rgba(0, 0, 0, 0)"
+    assert result["textMarginRight"] == "8px"
+
+
+@pytest.mark.frontend
+def test_web_subtitle_drag_mode_shows_handle_and_accepts_pointer_events_when_enabled(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="show" style="display:flex; opacity:1; visibility:visible;">
+            <div id="subtitle-scroll"><span id="subtitle-text">可拖动字幕</span></div>
+            <button type="button" id="subtitle-settings-btn"></button>
+            <div id="subtitle-settings-panel" class="hidden"></div>
+            <label class="subtitle-settings-switch">
+                <input type="checkbox" id="subtitle-drag-mode-toggle">
+                <span class="subtitle-settings-track"></span>
+            </label>
+            <div id="subtitle-drag-handle"></div>
+        </div>
+        """,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('subtitleDragAnywhere', 'true');
+        }
+        """
+    )
+    mock_page.add_style_tag(path=str(PROJECT_ROOT / "static/css/subtitle.css"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            const shared = window.nekoSubtitleShared;
+            shared.initSubtitleUI({ host: 'web' });
+            const display = document.getElementById('subtitle-display');
+            const dragHandle = document.getElementById('subtitle-drag-handle');
+            const displayPointerEventsWhenEnabled = getComputedStyle(display).pointerEvents;
+            const dragHandleDisplayWhenEnabled = getComputedStyle(dragHandle).display;
+            const handleRect = dragHandle.getBoundingClientRect();
+            dragHandle.dispatchEvent(new MouseEvent('mousedown', {
+                bubbles: true,
+                button: 0,
+                clientX: handleRect.left + 4,
+                clientY: handleRect.top + 4,
+            }));
+            document.dispatchEvent(new MouseEvent('mousemove', {
+                bubbles: true,
+                clientX: handleRect.left + 20,
+                clientY: handleRect.top + 20,
+            }));
+            const draggingAfterMove = display.classList.contains('dragging');
+            document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+            window.nekoSubtitleShared.updateSettings({ subtitleDragAnywhere: false }, {
+                source: 'test-toggle-off',
+            });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return {
+                dragAnywhere: display.classList.contains('drag-anywhere'),
+                displayPointerEventsWhenEnabled,
+                dragHandleDisplayWhenEnabled,
+                draggingAfterMove,
+                dragHandleDisplayWhenDisabled: getComputedStyle(dragHandle).display,
+            };
+        }
+        """
+    )
+
+    assert result["dragHandleDisplayWhenEnabled"] != "none"
+    assert result["displayPointerEventsWhenEnabled"] == "auto"
+    assert result["draggingAfterMove"] is True
+    assert result["dragAnywhere"] is False
+    assert result["dragHandleDisplayWhenDisabled"] == "none"


### PR DESCRIPTION
## 修复说明

- 字幕流式输出只显示翻译文本，不再在翻译返回前预览原文
- 支持字幕逐句增量翻译，句子完成后按翻译结果追加显示
- 重新调整字幕框高度、字号和滚动区域，避免长字幕撑开窗口
- 为字幕内容区增加细滚动条，并修复鼠标悬停在字幕内滚动失效的问题
- 修复字幕设置面板与字幕内容、小中大按钮互相遮挡的问题
- 修正“整体拖动”逻辑：开启时显示右下角拖动按钮，关闭时隐藏

## 验证

- `uv run pytest tests/frontend/test_subtitle_incremental.py -q`
- `uv run pytest tests/frontend/test_chat_switch_reset.py -q`
- `node --check static/subtitle.js`
- `node --check static/subtitle-shared.js`
- `node --check static/subtitle-window.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 扩展大小预设（小/中/大）并同步显示约束
  * 引入增量翻译队列与异步处理，支持逐句翻译与重置点

* **功能改进**
  * 改良拖拽体验：任意拖拽模式、拖拽手柄与状态样式
  * 优化滚动/滚动条样式、指针事件与移动端间距
  * 设置面板与字幕窗口布局联动，动态计算并同步高度与间隙
  * 翻译显示逻辑更稳健，优先已翻译文本

* **测试**
  * 新增全面的增量翻译前端测试用例集
<!-- end of auto-generated comment: release notes by coderabbit.ai -->