### PR TITLE
feat(plugin): add bilibili_dm plugin as a built-in plugin

### DIFF
--- a/plugin/plugins/bilibili_dm/README.md
+++ b/plugin/plugins/bilibili_dm/README.md
@@ -81,7 +81,7 @@
 
 ## 文件结构
 
-```
+```text
 bilibili_dm/
 ├── __init__.py       # 插件主实现
 ├── plugin.toml       # 插件配置

--- a/plugin/plugins/bilibili_dm/README.md
+++ b/plugin/plugins/bilibili_dm/README.md
@@ -1,0 +1,99 @@
+# B站私信 N.E.K.O 插件
+
+通过 `bilibili_api` 监听 B站私信，使用 N.E.K.O AI 自动回复。
+
+## 功能特性
+
+| 消息类型 | 接收 | 发送 |
+|---------|------|------|
+| 文本 (TEXT) | ✅ | ✅ |
+| 图片 (PICTURE) | ✅ | ✅ |
+| 分享视频 (SHARE_VIDEO) | ✅ | — |
+
+### 详细说明
+
+- **接收文本消息**：直接提取文本内容，交给 AI 生成回复
+- **接收图片消息**：通过 Cookie 鉴权下载图片，转为 Base64 传递给 AI
+- **接收分享视频**：获取视频标题、UP主、播放量等信息，拼接为富文本
+- **发送文本消息**：通过 `send_msg` 发送纯文本回复
+- **发送图片消息**：支持 URL 和 Base64 两种图片来源
+- **用户昵称解析**：通过 `User.get_user_info()` API 获取真实昵称，带内存缓存
+- **权限管理**：支持 admin / trusted / normal 三级权限控制
+- **记忆同步**：管理员对话自动同步到 Memory Server
+
+## 配置项
+
+通过 WebUI 或 `plugin.toml` 配置以下字段：
+
+### B站 Cookie
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `sesdata` | string | B站 Cookie 中的 `SESSDATA`（必填） |
+| `bili_jct` | string | B站 Cookie 中的 `bili_jct`（CSRF Token） |
+| `buvid3` | string | B站 Cookie 中的 `buvid3` |
+| `dedeuserid` | string | B站 Cookie 中的 `DedeUserID` |
+| `ac_time_value` | string | B站 Cookie 中的 `ac_time_value` |
+
+### 权限配置
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `trusted_users` | list | 信任用户列表，格式: `[{uid = "12345", level = "admin"}]` |
+
+### 权限等级
+
+| 等级 | 说明 |
+|------|------|
+| `admin` | 管理员，享有最高权限，使用完整记忆上下文 |
+| `trusted` | 信任用户，可获得 AI 回复 |
+| `normal` | 普通用户，不自动回复 |
+
+## 插件入口
+
+| Entry ID | 名称 | 说明 |
+|----------|------|------|
+| `start_listening` | 开始监听 | 启动 B站私信监听并自动回复 |
+| `stop_listening` | 停止监听 | 停止监听 B站私信 |
+| `send_message` | 发送私信 | 向指定 B站用户发送一条私信 |
+| `add_trusted_user` | 添加信任用户 | 添加信任用户到白名单 |
+| `remove_trusted_user` | 移除信任用户 | 从白名单中移除用户 |
+| `set_user_nickname` | 设置用户昵称 | 为信任用户设置专属称呼 |
+| `list_trusted_users` | 列出信任用户 | 列出所有信任用户 |
+
+## 获取 Cookie
+
+1. 使用浏览器登录 [bilibili.com](https://www.bilibili.com)
+2. 打开浏览器开发者工具（F12）→ Application → Cookies
+3. 找到并复制以下字段的值：
+   - `SESSDATA`（必填）
+   - `bili_jct`
+   - `buvid3`
+   - `DedeUserID`
+   - `ac_time_value`
+
+> ⚠️ **注意**：Cookie 有效期有限，过期后需重新获取并更新配置。
+
+## 依赖
+
+- `bilibili_api` — B站 API 封装库
+- `httpx` — 异步 HTTP 客户端（用于图片下载）
+
+## 文件结构
+
+```
+bilibili_dm/
+├── __init__.py       # 插件主实现
+├── plugin.toml       # 插件配置
+├── bili_client.py    # B站私信客户端封装
+├── permission.py     # 权限管理模块
+├── README.md         # 本文件
+└── KiraAI_bili_dm_adapter/  # KiraAI 参考适配器
+```
+
+## 注意事项
+
+- 图片下载需要携带 B站 Cookie 才能正常访问，客户端内部已自动处理
+- 使用 `Session` 轮询机制，约每 6 秒检查一次新消息
+- 管理员对话会自动同步到 Memory Server，用于构建连续对话上下文
+- 超过 5 分钟空闲的会话会自动回收并结算记忆

--- a/plugin/plugins/bilibili_dm/__init__.py
+++ b/plugin/plugins/bilibili_dm/__init__.py
@@ -353,7 +353,8 @@ class BiliDMPlugin(NekoPluginBase):
             return Err(SdkError("INVALID_ARGUMENT: uid 必须是纯数字"))
 
         user_nickname = "" if level == "admin" else nickname
-        self.permission_mgr.add_user(uid_str, level, user_nickname)
+        if not self.permission_mgr.add_user(uid_str, level, user_nickname):
+            return Err(SdkError("INVALID_ARGUMENT: level 无效"))
         self._refresh_admin_uid()
 
         # 使现有会话失效
@@ -516,6 +517,7 @@ class BiliDMPlugin(NekoPluginBase):
         )
 
         # 构建消息文本
+        pending_image_b64: Optional[str] = None
         if content_type == "image_url":
             # 下载图片转 base64（用于 AI 分析）
             b64_url = None
@@ -523,7 +525,8 @@ class BiliDMPlugin(NekoPluginBase):
                 b64_url = await self.bili_client.download_image_as_base64(content)
             message_text = "[用户发送了一张图片]"
             if b64_url:
-                message_text = "[用户发送了一张图片，已下载为 base64]"
+                pending_image_b64 = b64_url
+                message_text = "[用户发送了一张图片]"
         elif msg_kind == "share_video":
             message_text = content  # 已经是格式化的视频信息
         else:
@@ -553,6 +556,7 @@ class BiliDMPlugin(NekoPluginBase):
             permission_level=permission_level,
             sender_uid=sender_uid,
             user_nickname=bili_nickname,
+            pending_image_b64=pending_image_b64,
         )
 
         if reply_text:
@@ -573,6 +577,7 @@ class BiliDMPlugin(NekoPluginBase):
         sender_uid: str,
         user_nickname: Optional[str] = None,
         persist_memory: Optional[bool] = None,
+        pending_image_b64: Optional[str] = None,
     ) -> Optional[str]:
         """生成 AI 回复内容"""
         if permission_level not in ("admin", "trusted"):
@@ -682,6 +687,10 @@ class BiliDMPlugin(NekoPluginBase):
 
             async with user_data["lock"]:
                 reply_chunks.clear()
+
+                # 如果有图片数据，先通过 stream_image 加入待发送队列
+                if pending_image_b64:
+                    await user_session.stream_image(pending_image_b64)
 
                 self.logger.info(f"发送消息到 AI (会话: {session_key}, 长度: {len(message)})")
                 await asyncio.wait_for(

--- a/plugin/plugins/bilibili_dm/__init__.py
+++ b/plugin/plugins/bilibili_dm/__init__.py
@@ -1,0 +1,999 @@
+"""
+B站私信 N.E.K.O 插件
+
+通过 bilibili_api 监听 B站私信，使用 AI 自动回复。
+支持文本、图片、分享视频等消息类型。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from plugin.sdk.plugin import (
+    NekoPluginBase, lifecycle, neko_plugin, plugin_entry,
+    Ok, Err, SdkError,
+)
+
+from .bili_client import BiliDMClient
+from .permission import PermissionManager
+
+
+@neko_plugin
+class BiliDMPlugin(NekoPluginBase):
+    """B站私信 N.E.K.O 插件
+
+    通过 bilibili_api 监听 B站私信，使用 AI 自动回复。
+    支持文本、图片、分享视频等消息类型。
+    """
+
+    SESSION_IDLE_TIMEOUT_SECONDS = 300
+    SESSION_SWEEP_INTERVAL_SECONDS = 30
+
+    def __init__(self, ctx):
+        super().__init__(ctx)
+        self.file_logger = self.enable_file_logging(log_level="INFO")
+        self.logger = self.file_logger
+
+        # B站客户端
+        self.bili_client: Optional[BiliDMClient] = None
+        self.permission_mgr: Optional[PermissionManager] = None
+
+        # 运行状态
+        self._running = False
+        self._message_task: Optional[asyncio.Task] = None
+        self._session_housekeeping_task: Optional[asyncio.Task] = None
+        self._handler_tasks: set[asyncio.Task] = set()
+
+        # AI 会话管理
+        self._user_sessions: dict[str, dict[str, Any]] = {}
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._session_locks_guard = asyncio.Lock()
+
+        # 并发控制
+        self._max_concurrent_messages = 3
+        self._message_concurrency = asyncio.Semaphore(self._max_concurrent_messages)
+        self._ai_connect_timeout_seconds = 10.0
+        self._ai_turn_timeout_seconds = 60.0
+        self._handler_shutdown_timeout_seconds = 10.0
+
+        # 管理员 UID
+        self._admin_uid: Optional[str] = None
+
+        # 配置缓存
+        self._cfg: dict = {}
+
+    def _refresh_admin_uid(self) -> None:
+        """刷新管理员 UID"""
+        self._admin_uid = None
+        if not self.permission_mgr:
+            return
+        for user in self.permission_mgr.list_users():
+            if user.get("level") == "admin":
+                uid = str(user.get("uid") or "").strip()
+                if uid:
+                    self._admin_uid = uid
+                    return
+
+    @staticmethod
+    def _build_session_key(sender_uid: str) -> str:
+        return f"bili_dm:{sender_uid}"
+
+    async def _get_session_lock(self, session_key: str) -> asyncio.Lock:
+        async with self._session_locks_guard:
+            lock = self._session_locks.get(session_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._session_locks[session_key] = lock
+            return lock
+
+    def _track_handler_task(self, task: asyncio.Task) -> None:
+        self._handler_tasks.add(task)
+        task.add_done_callback(self._on_handler_task_done)
+
+    def _on_handler_task_done(self, task: asyncio.Task) -> None:
+        self._handler_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            self.logger.error(f"消息处理任务失败: {exc}")
+
+    async def _run_message_handler(self, message: Dict[str, Any]) -> None:
+        if not self._running:
+            return
+        session_key = self._build_session_key(message["sender_uid"])
+        async with self._message_concurrency:
+            session_lock = await self._get_session_lock(session_key)
+            async with session_lock:
+                if not self._running:
+                    return
+                await self._handle_message(message)
+
+    async def _wait_session_response_complete(self, session: Any, timeout: float = 30.0) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            await asyncio.sleep(0.5)
+            if not getattr(session, "_is_responding", False):
+                return True
+        return False
+
+    # ===== Lifecycle =====
+
+    @lifecycle(id="startup")
+    async def startup(self, **_):
+        """插件启动时初始化"""
+        cfg = await self.config.dump(timeout=5.0)
+        cfg = cfg if isinstance(cfg, dict) else {}
+        self._cfg = cfg
+        bili_cfg = cfg.get("bilibili_dm", {})
+
+        # 初始化权限管理器（优先从 store 加载，回退到 TOML 配置）
+        store_users_result = await self.store.get("trusted_users")
+        if isinstance(store_users_result, Ok) and store_users_result.value is not None:
+            trusted_users = store_users_result.value
+            self.logger.info(f"从 store 加载 {len(trusted_users)} 个信任用户")
+        else:
+            trusted_users = bili_cfg.get("trusted_users", [])
+        self.permission_mgr = PermissionManager(trusted_users)
+
+        # 获取管理员 UID
+        self._refresh_admin_uid()
+
+        # 读取配置
+        self._max_concurrent_messages = max(1, int(bili_cfg.get("max_concurrent_messages", 3) or 3))
+        self._message_concurrency = asyncio.Semaphore(self._max_concurrent_messages)
+        self._ai_connect_timeout_seconds = max(1.0, float(bili_cfg.get("ai_connect_timeout_seconds", 10.0) or 10.0))
+        self._ai_turn_timeout_seconds = max(5.0, float(bili_cfg.get("ai_turn_timeout_seconds", 60.0) or 60.0))
+        self._handler_shutdown_timeout_seconds = max(1.0, float(bili_cfg.get("handler_shutdown_timeout_seconds", 10.0) or 10.0))
+
+        # 初始化 B站客户端
+        sesdata = bili_cfg.get("sesdata", "")
+        if not sesdata:
+            self.logger.warning("B站 Cookie (SESSDATA) 未配置，请在 plugin.toml 中填写")
+
+        self.bili_client = BiliDMClient(
+            sesdata=sesdata,
+            bili_jct=bili_cfg.get("bili_jct", ""),
+            buvid3=bili_cfg.get("buvid3", ""),
+            dedeuserid=bili_cfg.get("dedeuserid", ""),
+            ac_time_value=bili_cfg.get("ac_time_value", ""),
+            logger=self.logger,
+        )
+        self.logger.info("B站私信客户端已初始化")
+
+        return Ok({"status": "initialized"})
+
+    @lifecycle(id="shutdown")
+    async def shutdown(self, **_):
+        """插件关闭时清理资源"""
+        await self._stop_runtime()
+        await self._flush_all_sessions(reason="shutdown")
+
+        if self._session_housekeeping_task:
+            self._session_housekeeping_task.cancel()
+            try:
+                await self._session_housekeeping_task
+            except asyncio.CancelledError:
+                pass
+            self._session_housekeeping_task = None
+
+        self.logger.info("B站私信插件已停止")
+        return Ok({"status": "shutdown"})
+
+    # ===== Plugin Entries =====
+
+    @plugin_entry(
+        id="start_listening",
+        name="开始监听",
+        description="开始监听 B站私信并自动回复。",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def start_listening(self, **_):
+        """开始监听 B站私信"""
+        if self._running:
+            return Ok({"status": "already_running"})
+
+        if not self.bili_client:
+            return Err(SdkError("NOT_INITIALIZED: B站客户端未初始化"))
+
+        try:
+            await self.bili_client.connect()
+
+            self._running = True
+            self._message_task = asyncio.create_task(self._process_messages())
+
+            if self._session_housekeeping_task is None or self._session_housekeeping_task.done():
+                self._session_housekeeping_task = asyncio.create_task(self._session_housekeeping_loop())
+
+            self.logger.info("B站私信监听已启动")
+            return Ok({"status": "started"})
+        except Exception as e:
+            self.logger.exception("启动 B站私信监听失败")
+            return Err(SdkError(f"START_ERROR: 启动失败: {e}"))
+
+    @plugin_entry(
+        id="stop_listening",
+        name="停止监听",
+        description="停止监听 B站私信。",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def stop_listening(self, **_):
+        """停止监听 B站私信"""
+        if not self._running and not self._message_task:
+            return Ok({"status": "not_running"})
+
+        await self._stop_runtime()
+        self.logger.info("B站私信监听已停止")
+        return Ok({"status": "stopped"})
+
+    async def _stop_runtime(self):
+        """停止运行时资源"""
+        self._running = False
+
+        if self._message_task:
+            self._message_task.cancel()
+            try:
+                await self._message_task
+            except asyncio.CancelledError:
+                pass
+            self._message_task = None
+
+        if self._handler_tasks:
+            handler_tasks = list(self._handler_tasks)
+            for task in handler_tasks:
+                task.cancel()
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*handler_tasks, return_exceptions=True),
+                    timeout=self._handler_shutdown_timeout_seconds,
+                )
+            except asyncio.TimeoutError:
+                self.logger.warning(f"等待 {len(handler_tasks)} 个消息处理任务停止超时")
+            self._handler_tasks.clear()
+
+        if self.bili_client:
+            await self.bili_client.disconnect()
+
+        self._session_locks.clear()
+
+    @plugin_entry(
+        id="send_message",
+        name="发送私信",
+        description="向指定 B站用户发送一条私信。",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "目标用户 UID",
+                },
+                "message": {
+                    "type": "string",
+                    "description": "要发送的消息内容",
+                },
+            },
+            "required": ["user_id", "message"],
+        },
+    )
+    async def send_message(self, user_id: str, message: str, **_):
+        """发送私信到指定 B站用户"""
+        if not self.bili_client:
+            return Err(SdkError("NOT_INITIALIZED: B站客户端未初始化"))
+
+        try:
+            uid = str(user_id or "").strip()
+            if not uid:
+                return Err(SdkError("INVALID_ARGUMENT: user_id 不能为空"))
+            if not uid.isdigit():
+                return Err(SdkError("INVALID_ARGUMENT: user_id 必须是纯数字"))
+
+            msg_text = str(message or "").strip()
+            if not msg_text:
+                return Err(SdkError("INVALID_ARGUMENT: message 不能为空"))
+
+            await self.bili_client.send_text(uid, msg_text)
+            self.logger.info(f"已发送私信给 {uid}: {msg_text[:100]}")
+            return Ok({"user_id": uid, "message": msg_text})
+        except Exception as e:
+            self.logger.error(f"发送私信失败: {e}")
+            return Err(SdkError(f"SEND_FAILED: 发送私信失败: {e}"))
+
+    @plugin_entry(
+        id="add_trusted_user",
+        name="添加信任用户",
+        description="添加一个信任的 B站用户到白名单。",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string",
+                    "description": "B站用户 UID",
+                },
+                "level": {
+                    "type": "string",
+                    "description": "权限等级: admin, trusted, normal",
+                    "default": "trusted",
+                },
+                "nickname": {
+                    "type": "string",
+                    "description": "用户昵称（可选）",
+                    "default": "",
+                },
+            },
+            "required": ["uid"],
+        },
+    )
+    async def add_trusted_user(self, uid: str, level: str = "trusted", nickname: str = "", **_):
+        """添加信任用户并持久化到 store"""
+        if not self.permission_mgr:
+            return Err(SdkError("NOT_INITIALIZED: 权限管理器未初始化"))
+
+        uid_str = str(uid or "").strip()
+        if not uid_str:
+            return Err(SdkError("INVALID_ARGUMENT: uid 不能为空"))
+        if not uid_str.isdigit():
+            return Err(SdkError("INVALID_ARGUMENT: uid 必须是纯数字"))
+
+        user_nickname = "" if level == "admin" else nickname
+        self.permission_mgr.add_user(uid_str, level, user_nickname)
+        self._refresh_admin_uid()
+
+        # 使现有会话失效
+        session_key = self._build_session_key(uid_str)
+        if session_key in self._user_sessions:
+            user_data = self._user_sessions.pop(session_key, None)
+            if user_data and user_data.get("session"):
+                try:
+                    await user_data["session"].close()
+                except Exception:
+                    pass
+
+        self.logger.info(f"已添加信任用户: {uid_str}, 权限: {level}")
+
+        success = await self._save_trusted_users()
+        result_data = {"uid": uid_str, "level": level, "persisted": success}
+        if user_nickname:
+            result_data["nickname"] = user_nickname
+        if not success:
+            result_data["warning"] = "已添加到内存，但持久化失败"
+        return Ok(result_data)
+
+    @plugin_entry(
+        id="remove_trusted_user",
+        name="移除信任用户",
+        description="从白名单中移除一个 B站用户。",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string",
+                    "description": "B站用户 UID",
+                },
+            },
+            "required": ["uid"],
+        },
+    )
+    async def remove_trusted_user(self, uid: str, **_):
+        """移除信任用户并持久化到 store"""
+        if not self.permission_mgr:
+            return Err(SdkError("NOT_INITIALIZED: 权限管理器未初始化"))
+
+        uid_str = str(uid or "").strip()
+        if not uid_str:
+            return Err(SdkError("INVALID_ARGUMENT: uid 不能为空"))
+
+        self.permission_mgr.remove_user(uid_str)
+        self._refresh_admin_uid()
+
+        # 使现有会话失效
+        session_key = self._build_session_key(uid_str)
+        if session_key in self._user_sessions:
+            user_data = self._user_sessions.pop(session_key, None)
+            if user_data and user_data.get("session"):
+                try:
+                    await user_data["session"].close()
+                except Exception:
+                    pass
+
+        self.logger.info(f"已移除信任用户: {uid_str}")
+
+        success = await self._save_trusted_users()
+        result = {"uid": uid_str, "persisted": success}
+        if not success:
+            result["warning"] = "已从内存移除，但持久化失败"
+        return Ok(result)
+
+    @plugin_entry(
+        id="set_user_nickname",
+        name="设置用户昵称",
+        description="为信任用户设置专属称呼。",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "uid": {
+                    "type": "string",
+                    "description": "B站用户 UID",
+                },
+                "nickname": {
+                    "type": "string",
+                    "description": "昵称（留空则清除昵称）",
+                },
+            },
+            "required": ["uid"],
+        },
+    )
+    async def set_user_nickname(self, uid: str, nickname: str = "", **_):
+        """设置用户昵称并持久化到 store"""
+        if not self.permission_mgr:
+            return Err(SdkError("NOT_INITIALIZED: 权限管理器未初始化"))
+
+        uid_str = str(uid or "").strip()
+        if not uid_str:
+            return Err(SdkError("INVALID_ARGUMENT: uid 不能为空"))
+
+        permission_level = self.permission_mgr.get_permission_level(uid_str)
+        if permission_level == "none":
+            return Err(SdkError(f"USER_NOT_FOUND: 用户 {uid_str} 不在信任列表中"))
+
+        if permission_level == "admin":
+            return Err(SdkError("ADMIN_NO_NICKNAME: 管理员始终被称为主人，无法设置昵称"))
+
+        success = self.permission_mgr.set_nickname(uid_str, nickname)
+        if not success:
+            return Err(SdkError("SET_FAILED: 设置昵称失败"))
+
+        await self._save_trusted_users()
+        self.logger.info(f"已设置用户 {uid_str} 的昵称为: {nickname}")
+        return Ok({"uid": uid_str, "nickname": nickname})
+
+    @plugin_entry(
+        id="list_trusted_users",
+        name="列出信任用户",
+        description="列出所有信任的 B站用户。",
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def list_trusted_users(self, **_):
+        """列出所有信任用户"""
+        if not self.permission_mgr:
+            return Err(SdkError("NOT_INITIALIZED: 权限管理器未初始化"))
+
+        users = self.permission_mgr.list_users()
+        return Ok({"users": users, "count": len(users)})
+
+    # ===== Message Processing =====
+
+    async def _process_messages(self):
+        """处理接收到的 B站私信"""
+        while self._running:
+            try:
+                message = await self.bili_client.receive_message(timeout=1.0)
+                if message:
+                    task = asyncio.create_task(self._run_message_handler(message))
+                    self._track_handler_task(task)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self.logger.error(f"处理消息时出错: {e}")
+                await asyncio.sleep(1)
+
+    async def _handle_message(self, message: Dict[str, Any]):
+        """处理单条 B站私信"""
+        sender_uid = message["sender_uid"]
+        # bili_client 已通过 User.get_user_info() 获取真实 B站昵称
+        bili_nickname = message.get("sender_nickname", sender_uid)
+        content = message.get("content", "")
+        content_type = message.get("content_type", "text")
+        msg_kind = message.get("msg_kind", "text")
+
+        # 检查权限
+        if not self.permission_mgr.should_process(sender_uid):
+            self.logger.debug(f"忽略来自 {sender_uid} 的消息（权限不足）")
+            return
+
+        permission_level = self.permission_mgr.get_permission_level(sender_uid)
+
+        self.logger.info(
+            f"收到 B站私信 [{msg_kind}] from {sender_uid} ({bili_nickname}), "
+            f"权限: {permission_level}, 内容长度: {len(content)}"
+        )
+
+        # 构建消息文本
+        if content_type == "image_url":
+            # 下载图片转 base64（用于 AI 分析）
+            b64_url = None
+            if self.bili_client:
+                b64_url = await self.bili_client.download_image_as_base64(content)
+            message_text = "[用户发送了一张图片]"
+            if b64_url:
+                message_text = "[用户发送了一张图片，已下载为 base64]"
+        elif msg_kind == "share_video":
+            message_text = content  # 已经是格式化的视频信息
+        else:
+            message_text = content
+
+        if not message_text.strip():
+            return
+
+        # 在消息文本前附加发送者信息，让 AI 知道是谁在说话
+        sender_context = f"[来自 B站用户 {bili_nickname}（UID: {sender_uid}）的消息] "
+        message_with_context = sender_context + message_text
+
+        # 如果已有会话，更新 B站昵称缓存
+        session_key = self._build_session_key(sender_uid)
+        if session_key in self._user_sessions:
+            user_data = self._user_sessions[session_key]
+            old_nickname = user_data.get("bili_nickname", "")
+            if bili_nickname and bili_nickname != sender_uid and bili_nickname != old_nickname:
+                user_data["bili_nickname"] = bili_nickname
+                self.logger.info(
+                    f"更新用户 {sender_uid} 的 B站昵称: {old_nickname} -> {bili_nickname}"
+                )
+
+        # 生成 AI 回复
+        reply_text = await self._generate_reply(
+            message=message_with_context,
+            permission_level=permission_level,
+            sender_uid=sender_uid,
+            user_nickname=bili_nickname,
+        )
+
+        if reply_text:
+            try:
+                await self.bili_client.send_text(sender_uid, reply_text)
+                self.logger.info(
+                    f"已回复 {sender_uid} ({bili_nickname}): {reply_text[:100]}"
+                )
+            except Exception as e:
+                self.logger.error(f"发送回复给 {sender_uid} 失败: {e}")
+
+    # ===== AI Conversation =====
+
+    async def _generate_reply(
+        self,
+        message: str,
+        permission_level: str,
+        sender_uid: str,
+        user_nickname: Optional[str] = None,
+        persist_memory: Optional[bool] = None,
+    ) -> Optional[str]:
+        """生成 AI 回复内容"""
+        if permission_level not in ("admin", "trusted"):
+            return None
+
+        try:
+            from main_logic.omni_offline_client import OmniOfflineClient
+            from utils.config_manager import get_config_manager
+
+            config_manager = get_config_manager()
+
+            # 获取角色数据
+            master_name, her_name, _, catgirl_data, _, lanlan_prompt_map, _, _, _ = (
+                config_manager.get_character_data()
+            )
+
+            # 确定用户称呼（优先级：配置自定义昵称 > B站真实昵称 > UID）
+            custom_nickname = self.permission_mgr.get_nickname(sender_uid) if self.permission_mgr else None
+            if permission_level == "admin":
+                user_title = master_name if master_name else "主人"
+            else:
+                # 优先使用管理员在插件中设置的自定义昵称
+                if custom_nickname:
+                    user_title = custom_nickname
+                # 其次使用通过 B站 User.get_user_info() 获取的真实昵称
+                elif user_nickname and user_nickname != sender_uid:
+                    user_title = user_nickname
+                else:
+                    user_title = f"B站用户{sender_uid}"
+
+            # 获取角色配置
+            current_character = catgirl_data.get(her_name, {})
+            character_prompt = lanlan_prompt_map.get(her_name, "你是一个友好的AI助手")
+            character_card_fields = {}
+            for key, value in current_character.items():
+                if key not in [
+                    "_reserved", "voice_id", "system_prompt", "model_type",
+                    "live2d", "vrm", "vrm_animation", "lighting", "vrm_rotation",
+                    "live2d_item_id", "item_id", "idleAnimation",
+                ]:
+                    if isinstance(value, (str, int, float, bool)) and value:
+                        character_card_fields[key] = value
+
+            # 获取对话模型配置
+            conversation_config = config_manager.get_model_api_config("conversation")
+            base_url = conversation_config.get("base_url", "")
+            api_key = conversation_config.get("api_key", "")
+            model = conversation_config.get("model", "")
+
+            should_use_memory = (permission_level == "admin")
+            should_persist = should_use_memory if persist_memory is None else bool(persist_memory)
+
+            # 会话管理
+            session_key = self._build_session_key(sender_uid)
+
+            if session_key not in self._user_sessions:
+                self.logger.info(f"为 B站用户 {sender_uid} 创建新的 AI 会话")
+
+                reply_chunks: list[str] = []
+
+                async def on_text_delta(text: str, is_first: bool):
+                    reply_chunks.append(text)
+
+                user_session = OmniOfflineClient(
+                    base_url=base_url,
+                    api_key=api_key,
+                    model=model,
+                    on_text_delta=on_text_delta,
+                )
+
+                system_prompt = await self._build_session_instructions(
+                    her_name=her_name,
+                    master_name=master_name,
+                    character_prompt=character_prompt,
+                    character_card_fields=character_card_fields,
+                    permission_level=permission_level,
+                    sender_uid=sender_uid,
+                    user_title=user_title,
+                )
+
+                await asyncio.wait_for(
+                    user_session.connect(instructions=system_prompt),
+                    timeout=self._ai_connect_timeout_seconds,
+                )
+
+                self._user_sessions[session_key] = {
+                    "session": user_session,
+                    "reply_chunks": reply_chunks,
+                    "her_name": her_name,
+                    "last_synced_index": 0,
+                    "last_activity_at": time.time(),
+                    "memory_enabled": should_persist,
+                    "session_key": session_key,
+                    "sender_uid": sender_uid,
+                    "permission_level": permission_level,
+                    "user_title": user_title,
+                    "user_nickname": user_nickname,
+                    "bili_nickname": user_nickname or "",  # 缓存 B站真实昵称
+                    "lock": asyncio.Lock(),
+                }
+
+            user_data = self._user_sessions[session_key]
+            user_session = user_data["session"]
+            reply_chunks = user_data["reply_chunks"]
+            user_data["last_activity_at"] = time.time()
+            user_data.setdefault("lock", asyncio.Lock())
+
+            async with user_data["lock"]:
+                reply_chunks.clear()
+
+                self.logger.info(f"发送消息到 AI (会话: {session_key}, 长度: {len(message)})")
+                await asyncio.wait_for(
+                    user_session.stream_text(message),
+                    timeout=self._ai_turn_timeout_seconds,
+                )
+
+                completed = await self._wait_session_response_complete(user_session)
+                if not completed:
+                    self.logger.warning(f"会话 {session_key} 响应超时，关闭并丢弃该会话")
+                    await user_session.close()
+                    self._user_sessions.pop(session_key, None)
+                    return None
+
+                ai_reply = "".join(reply_chunks).strip()
+
+            if ai_reply:
+                # 记忆同步（可选）
+                if user_data.get("memory_enabled"):
+                    try:
+                        count = await self._cache_session_delta(session_key, user_data)
+                        if count:
+                            self.logger.info(
+                                f"[管理员] 成功同步 {count} 条消息到 Memory Server (会话: {session_key})"
+                            )
+                    except Exception as e:
+                        self.logger.error(f"记忆同步失败: {e}")
+
+                self.logger.info(f"AI 生成回复完成 (会话: {session_key}, 长度: {len(ai_reply)})")
+                return ai_reply
+            else:
+                self.logger.warning("AI 未生成回复")
+                return f"收到你的消息: {message}"
+
+        except asyncio.TimeoutError:
+            self.logger.warning(f"B站用户 {sender_uid} 会话处理超时")
+            user_data = self._user_sessions.pop(session_key, None)
+            session = user_data.get("session") if user_data else None
+            if session:
+                try:
+                    await session.close()
+                except Exception:
+                    pass
+            return None
+        except Exception as e:
+            self.logger.exception(f"AI 生成回复失败: {e}")
+            return f"收到你的消息: {message}"
+
+    async def _build_session_instructions(
+        self,
+        her_name: str,
+        master_name: str,
+        character_prompt: str,
+        character_card_fields: dict,
+        permission_level: str,
+        sender_uid: str,
+        user_title: str,
+    ) -> str:
+        """构建 AI 会话系统提示词"""
+        from config.prompts_sys import SESSION_INIT_PROMPT
+        from utils.language_utils import get_global_language
+
+        try:
+            from utils.i18n_utils import normalize_language_code
+        except Exception:
+            normalize_language_code = None
+
+        user_language = get_global_language()
+        short_language = (
+            normalize_language_code(user_language, format="short")
+            if normalize_language_code else user_language
+        )
+
+        init_prompt_template = SESSION_INIT_PROMPT.get(
+            short_language,
+            SESSION_INIT_PROMPT.get(user_language, SESSION_INIT_PROMPT["zh"]),
+        )
+
+        system_prompt_parts = [
+            init_prompt_template.format(name=her_name),
+            character_prompt,
+        ]
+
+        # 尝试加载记忆上下文
+        if permission_level == "admin":
+            try:
+                import httpx
+                from config import MEMORY_SERVER_PORT
+
+                async with httpx.AsyncClient(timeout=5.0, proxy=None, trust_env=False) as client:
+                    response = await client.get(f"http://127.0.0.1:{MEMORY_SERVER_PORT}/new_dialog/{her_name}")
+                    if response.is_success:
+                        memory_context = response.text.strip()
+                        if memory_context:
+                            from config.prompts_sys import CONTEXT_SUMMARY_READY
+                            context_ready_template = CONTEXT_SUMMARY_READY.get(
+                                short_language,
+                                CONTEXT_SUMMARY_READY.get(user_language, CONTEXT_SUMMARY_READY["zh"]),
+                            )
+                            system_prompt_parts.append(
+                                memory_context + context_ready_template.format(
+                                    name=her_name, master=master_name
+                                )
+                            )
+            except Exception as e:
+                self.logger.warning(f"读取 Memory Server 上下文失败: {e}")
+
+        # 角色卡额外设定
+        if character_card_fields:
+            system_prompt_parts.append("\n======角色卡额外设定======")
+            for field_name, field_value in character_card_fields.items():
+                system_prompt_parts.append(f"{field_name}: {field_value}")
+            system_prompt_parts.append("======角色卡设定结束======")
+
+        # B站私聊环境说明
+        friend_note = (
+            f"- 当前对话对象是{master_name if master_name else '主人'}的朋友，不是主人本人\n"
+            if permission_level != "admin" else ""
+        )
+        private_identity_target = (
+            f"- 当前对话对象：{user_title}（B站UID: {sender_uid}），这是当前私聊对象\n"
+            if permission_level != "admin" else
+            f"- 当前对话对象：{user_title}（B站UID: {sender_uid}），这就是主人/管理员本人\n"
+        )
+        system_prompt_parts.append(f"""
+======身份定义======
+- 你自己：{her_name}，你是当前回复者
+- 主人/管理员：{master_name if master_name else '主人'}，是固定身份
+{private_identity_target}{friend_note}- 即使当前对话对象的名字、B站昵称、主人名字、你的名字或角色设定中的人物名称相同，也必须按上述身份定义区分，绝不能混淆角色
+======身份定义结束======
+
+======B站私聊环境======
+- 你正在通过 B站私信与用户 {sender_uid} 对话
+- 对方的称呼是：{user_title}
+- 请保持角色设定，用简短自然的话回复（不超过50字）
+- 不要使用 Markdown 格式，不要使用表情符号
+- 记住你是 {her_name}，始终以 {her_name} 的身份回复
+- 在回复中自然地称呼对方为\"{user_title}\"
+- 注意不要重复之前的发言
+======环境说明结束======""")
+
+        system_prompt = "\n".join(system_prompt_parts)
+        self.logger.info(f"系统提示词长度: {len(system_prompt)} 字符")
+        return system_prompt
+
+    # ===== Session Housekeeping =====
+
+    async def _session_housekeeping_loop(self):
+        """定期回收空闲会话"""
+        try:
+            while True:
+                await asyncio.sleep(self.SESSION_SWEEP_INTERVAL_SECONDS)
+                await self._flush_idle_sessions()
+        except asyncio.CancelledError:
+            raise
+
+    async def _flush_idle_sessions(self):
+        """回收空闲会话"""
+        now = time.time()
+        idle_sessions = []
+        for session_key, user_data in list(self._user_sessions.items()):
+            if not user_data.get("memory_enabled"):
+                continue
+            last_activity_at = user_data.get("last_activity_at") or now
+            if now - last_activity_at >= self.SESSION_IDLE_TIMEOUT_SECONDS:
+                idle_sessions.append(session_key)
+
+        for session_key in idle_sessions:
+            async def _finalize_if_still_idle() -> bool:
+                current = self._user_sessions.get(session_key)
+                if not current or not current.get("memory_enabled"):
+                    return False
+                current_last_activity = current.get("last_activity_at") or now
+                if time.time() - current_last_activity < self.SESSION_IDLE_TIMEOUT_SECONDS:
+                    return False
+                return await self._finalize_session(session_key, reason="idle_timeout")
+
+            session_lock = await self._get_session_lock(session_key)
+            async with session_lock:
+                await _finalize_if_still_idle()
+
+    async def _flush_all_sessions(self, reason: str):
+        """回收所有会话"""
+        for session_key, user_data in list(self._user_sessions.items()):
+            if not user_data.get("memory_enabled"):
+                continue
+
+            async def _finalize_existing() -> bool:
+                current = self._user_sessions.get(session_key)
+                if not current or not current.get("memory_enabled"):
+                    return False
+                return await self._finalize_session(session_key, reason=reason)
+
+            session_lock = await self._get_session_lock(session_key)
+            async with session_lock:
+                await _finalize_existing()
+
+    async def _finalize_session(self, session_key: str, reason: str) -> bool:
+        """结算并关闭会话"""
+        user_data = self._user_sessions.get(session_key)
+        if not user_data or not user_data.get("memory_enabled"):
+            return False
+
+        session = user_data.get("session")
+        her_name = user_data.get("her_name")
+        if not session or not her_name:
+            self._user_sessions.pop(session_key, None)
+            return False
+
+        try:
+            conversation_history = getattr(session, "_conversation_history", []) or []
+            last_synced_index = int(user_data.get("last_synced_index", 0))
+            remaining_messages = self._conversation_slice_to_memory_messages(
+                conversation_history, last_synced_index
+            )
+
+            if remaining_messages:
+                result = await self._post_memory_history(
+                    "process", her_name, remaining_messages, timeout=30.0
+                )
+                if result.get("status") == "error":
+                    raise RuntimeError(result.get("message", "process failed"))
+                self.logger.info(
+                    f"[{reason}] 已为用户 {session_key} 完成记忆结算，消息数: {len(remaining_messages)}"
+                )
+            elif user_data.get("has_cached_memory"):
+                settled_messages = self._conversation_slice_to_memory_messages(conversation_history, 0)
+                result = await self._post_memory_history(
+                    "settle", her_name, settled_messages, timeout=30.0
+                )
+                if result.get("status") == "error":
+                    raise RuntimeError(result.get("message", "settle failed"))
+                self.logger.info(f"[{reason}] 已为用户 {session_key} 完成缓存记忆结算")
+
+            await session.close()
+            self._user_sessions.pop(session_key, None)
+            return True
+        except Exception as e:
+            self.logger.error(f"[{reason}] 用户 {session_key} 的记忆结算失败: {e}")
+            return False
+
+    def _conversation_slice_to_memory_messages(
+        self, conversation_history: list, start_index: int = 0
+    ) -> list[dict[str, Any]]:
+        """将对话历史转换为记忆格式"""
+        memory_messages = []
+        for msg in conversation_history[start_index:]:
+            msg_type = getattr(msg, "type", "")
+            if msg_type not in ("human", "ai"):
+                continue
+            role = "user" if msg_type == "human" else "assistant"
+            content = getattr(msg, "content", "")
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, list):
+                parts = []
+                for item in content:
+                    if isinstance(item, dict) and item.get("type") == "text":
+                        parts.append(item.get("text", ""))
+                    elif isinstance(item, str):
+                        parts.append(item)
+                text = "".join(parts)
+            else:
+                text = str(content)
+            if not text:
+                continue
+            memory_messages.append({
+                "role": role,
+                "content": [{"type": "text", "text": text}],
+            })
+        return memory_messages
+
+    async def _cache_session_delta(
+        self, session_key: str, user_data: dict[str, Any]
+    ) -> int:
+        """缓存会话增量到 Memory Server"""
+        session = user_data.get("session")
+        her_name = user_data.get("her_name")
+        if not session or not her_name:
+            return 0
+
+        conversation_history = getattr(session, "_conversation_history", []) or []
+        start_index = int(user_data.get("last_synced_index", 0))
+        delta_messages = self._conversation_slice_to_memory_messages(
+            conversation_history, start_index
+        )
+        if not delta_messages:
+            return 0
+
+        result = await self._post_memory_history(
+            "cache", her_name, delta_messages, timeout=5.0
+        )
+        if result.get("status") == "error":
+            raise RuntimeError(result.get("message", "cache failed"))
+
+        user_data["last_synced_index"] = len(conversation_history)
+        user_data["has_cached_memory"] = True
+        return len(delta_messages)
+
+    async def _post_memory_history(
+        self, endpoint: str, her_name: str, messages: list[dict[str, Any]], timeout: float = 5.0
+    ) -> dict[str, Any]:
+        """发送对话历史到 Memory Server"""
+        import httpx
+        from config import MEMORY_SERVER_PORT
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"http://localhost:{MEMORY_SERVER_PORT}/{endpoint}/{her_name}",
+                json={"input_history": json.dumps(messages, ensure_ascii=False)},
+                timeout=timeout,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    # ===== Persistence =====
+
+    async def _save_trusted_users(self) -> bool:
+        """持久化信任用户列表到 store"""
+        try:
+            users = self.permission_mgr.list_users()
+            await self.store.set("trusted_users", users)
+            self.logger.info(f"成功持久化 {len(users)} 个信任用户到 store")
+            return True
+        except Exception as e:
+            self.logger.error(f"持久化配置失败: {e}")
+            return False

--- a/plugin/plugins/bilibili_dm/__init__.py
+++ b/plugin/plugins/bilibili_dm/__init__.py
@@ -61,6 +61,9 @@ class BiliDMPlugin(NekoPluginBase):
         self._ai_turn_timeout_seconds = 60.0
         self._handler_shutdown_timeout_seconds = 10.0
 
+        # 权限模式（从 plugin.toml 加载）
+        self._permission_mode: str = "allow_list"
+
         # 管理员 UID
         self._admin_uid: Optional[str] = None
 
@@ -146,6 +149,8 @@ class BiliDMPlugin(NekoPluginBase):
         self._refresh_admin_uid()
 
         # 读取配置
+        self._permission_mode = str(bili_cfg.get("permission_mode", "allow_list") or "allow_list")
+
         self._max_concurrent_messages = max(1, int(bili_cfg.get("max_concurrent_messages", 3) or 3))
         self._message_concurrency = asyncio.Semaphore(self._max_concurrent_messages)
         self._ai_connect_timeout_seconds = max(1.0, float(bili_cfg.get("ai_connect_timeout_seconds", 10.0) or 10.0))
@@ -173,15 +178,6 @@ class BiliDMPlugin(NekoPluginBase):
     async def shutdown(self, **_):
         """插件关闭时清理资源"""
         await self._stop_runtime()
-        await self._flush_all_sessions(reason="shutdown")
-
-        if self._session_housekeeping_task:
-            self._session_housekeeping_task.cancel()
-            try:
-                await self._session_housekeeping_task
-            except asyncio.CancelledError:
-                pass
-            self._session_housekeeping_task = None
 
         self.logger.info("B站私信插件已停止")
         return Ok({"status": "shutdown"})
@@ -244,6 +240,14 @@ class BiliDMPlugin(NekoPluginBase):
                 pass
             self._message_task = None
 
+        if self._session_housekeeping_task:
+            self._session_housekeeping_task.cancel()
+            try:
+                await self._session_housekeeping_task
+            except asyncio.CancelledError:
+                pass
+            self._session_housekeeping_task = None
+
         if self._handler_tasks:
             handler_tasks = list(self._handler_tasks)
             for task in handler_tasks:
@@ -256,6 +260,8 @@ class BiliDMPlugin(NekoPluginBase):
             except asyncio.TimeoutError:
                 self.logger.warning(f"等待 {len(handler_tasks)} 个消息处理任务停止超时")
             self._handler_tasks.clear()
+
+        await self._flush_all_sessions(reason="stop")
 
         if self.bili_client:
             await self.bili_client.disconnect()
@@ -297,8 +303,14 @@ class BiliDMPlugin(NekoPluginBase):
             if not msg_text:
                 return Err(SdkError("INVALID_ARGUMENT: message 不能为空"))
 
-            await self.bili_client.send_text(uid, msg_text)
-            self.logger.info(f"已发送私信给 {uid}: {msg_text[:100]}")
+            if msg_text.startswith(("http://", "https://")) and any(
+                msg_text.lower().endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp")
+            ) or msg_text.startswith("data:image/"):
+                await self.bili_client.send_image(uid, msg_text)
+                self.logger.info(f"已发送图片私信给 {uid}")
+            else:
+                await self.bili_client.send_text(uid, msg_text)
+                self.logger.info(f"已发送私信给 {uid}: {msg_text[:100]}")
             return Ok({"user_id": uid, "message": msg_text})
         except Exception as e:
             self.logger.error(f"发送私信失败: {e}")
@@ -492,7 +504,7 @@ class BiliDMPlugin(NekoPluginBase):
         msg_kind = message.get("msg_kind", "text")
 
         # 检查权限
-        if not self.permission_mgr.should_process(sender_uid):
+        if not self.permission_mgr.should_process(sender_uid, self._permission_mode):
             self.logger.debug(f"忽略来自 {sender_uid} 的消息（权限不足）")
             return
 
@@ -831,8 +843,6 @@ class BiliDMPlugin(NekoPluginBase):
         now = time.time()
         idle_sessions = []
         for session_key, user_data in list(self._user_sessions.items()):
-            if not user_data.get("memory_enabled"):
-                continue
             last_activity_at = user_data.get("last_activity_at") or now
             if now - last_activity_at >= self.SESSION_IDLE_TIMEOUT_SECONDS:
                 idle_sessions.append(session_key)
@@ -840,7 +850,7 @@ class BiliDMPlugin(NekoPluginBase):
         for session_key in idle_sessions:
             async def _finalize_if_still_idle() -> bool:
                 current = self._user_sessions.get(session_key)
-                if not current or not current.get("memory_enabled"):
+                if not current:
                     return False
                 current_last_activity = current.get("last_activity_at") or now
                 if time.time() - current_last_activity < self.SESSION_IDLE_TIMEOUT_SECONDS:
@@ -854,12 +864,9 @@ class BiliDMPlugin(NekoPluginBase):
     async def _flush_all_sessions(self, reason: str):
         """回收所有会话"""
         for session_key, user_data in list(self._user_sessions.items()):
-            if not user_data.get("memory_enabled"):
-                continue
-
             async def _finalize_existing() -> bool:
                 current = self._user_sessions.get(session_key)
-                if not current or not current.get("memory_enabled"):
+                if not current:
                     return False
                 return await self._finalize_session(session_key, reason=reason)
 
@@ -870,39 +877,40 @@ class BiliDMPlugin(NekoPluginBase):
     async def _finalize_session(self, session_key: str, reason: str) -> bool:
         """结算并关闭会话"""
         user_data = self._user_sessions.get(session_key)
-        if not user_data or not user_data.get("memory_enabled"):
+        if not user_data:
             return False
 
         session = user_data.get("session")
         her_name = user_data.get("her_name")
-        if not session or not her_name:
+        if not session:
             self._user_sessions.pop(session_key, None)
             return False
 
         try:
-            conversation_history = getattr(session, "_conversation_history", []) or []
-            last_synced_index = int(user_data.get("last_synced_index", 0))
-            remaining_messages = self._conversation_slice_to_memory_messages(
-                conversation_history, last_synced_index
-            )
+            if user_data.get("memory_enabled") and her_name:
+                conversation_history = getattr(session, "_conversation_history", []) or []
+                last_synced_index = int(user_data.get("last_synced_index", 0))
+                remaining_messages = self._conversation_slice_to_memory_messages(
+                    conversation_history, last_synced_index
+                )
 
-            if remaining_messages:
-                result = await self._post_memory_history(
-                    "process", her_name, remaining_messages, timeout=30.0
-                )
-                if result.get("status") == "error":
-                    raise RuntimeError(result.get("message", "process failed"))
-                self.logger.info(
-                    f"[{reason}] 已为用户 {session_key} 完成记忆结算，消息数: {len(remaining_messages)}"
-                )
-            elif user_data.get("has_cached_memory"):
-                settled_messages = self._conversation_slice_to_memory_messages(conversation_history, 0)
-                result = await self._post_memory_history(
-                    "settle", her_name, settled_messages, timeout=30.0
-                )
-                if result.get("status") == "error":
-                    raise RuntimeError(result.get("message", "settle failed"))
-                self.logger.info(f"[{reason}] 已为用户 {session_key} 完成缓存记忆结算")
+                if remaining_messages:
+                    result = await self._post_memory_history(
+                        "process", her_name, remaining_messages, timeout=30.0
+                    )
+                    if result.get("status") == "error":
+                        raise RuntimeError(result.get("message", "process failed"))
+                    self.logger.info(
+                        f"[{reason}] 已为用户 {session_key} 完成记忆结算，消息数: {len(remaining_messages)}"
+                    )
+                elif user_data.get("has_cached_memory"):
+                    settled_messages = self._conversation_slice_to_memory_messages(conversation_history, 0)
+                    result = await self._post_memory_history(
+                        "settle", her_name, settled_messages, timeout=30.0
+                    )
+                    if result.get("status") == "error":
+                        raise RuntimeError(result.get("message", "settle failed"))
+                    self.logger.info(f"[{reason}] 已为用户 {session_key} 完成缓存记忆结算")
 
             await session.close()
             self._user_sessions.pop(session_key, None)

--- a/plugin/plugins/bilibili_dm/bili_client.py
+++ b/plugin/plugins/bilibili_dm/bili_client.py
@@ -1,0 +1,279 @@
+"""
+B站私信客户端封装（基于 bilibili_api）
+
+使用 bilibili_api.session.Session 监听私信事件，
+通过 send_msg 发送文本、图片、表情等消息。
+"""
+
+import asyncio
+import base64
+import json
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+import httpx
+from bilibili_api import Credential
+from bilibili_api.session import Session, EventType, Event
+from bilibili_api.user import User as BiliUser
+from bilibili_api.video import Video as BiliVideo
+
+
+class BiliDMClient:
+    """B站私信客户端"""
+
+    def __init__(
+        self,
+        sesdata: str,
+        bili_jct: str = "",
+        buvid3: str = "",
+        dedeuserid: str = "",
+        ac_time_value: str = "",
+        logger=None,
+    ):
+        self.logger = logger
+
+        self._credential = Credential(
+            sessdata=sesdata,
+            bili_jct=bili_jct,
+            buvid3=buvid3,
+            dedeuserid=dedeuserid,
+            ac_time_value=ac_time_value,
+        )
+
+        self._session: Optional[Session] = None
+        self._running = False
+        self._user_info_cache: Dict[int, Dict[str, Any]] = {}
+        self._message_queue: asyncio.Queue = asyncio.Queue(maxsize=1000)
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    async def connect(self):
+        """启动 B站私信监听"""
+        if self._running:
+            return
+
+        if not self._credential.sessdata:
+            raise RuntimeError("B站 Cookie (SESSDATA) 未配置，请在 plugin.toml 中填写")
+
+        try:
+            self._session = Session(self._credential, debug=False)
+
+            @self._session.on(EventType.TEXT)
+            async def on_text(event: Event):
+                await self._enqueue_event(event, "text")
+
+            @self._session.on(EventType.PICTURE)
+            async def on_picture(event: Event):
+                await self._enqueue_event(event, "picture")
+
+            @self._session.on(EventType.SHARE_VIDEO)
+            async def on_share_video(event: Event):
+                await self._enqueue_event(event, "share_video")
+
+            self._running = True
+            if self.logger:
+                self.logger.info("B站私信监听已启动")
+
+            # Session.start() 是阻塞式轮询，需要在后台任务中运行
+            asyncio.create_task(self._run_session())
+
+        except Exception as e:
+            self._running = False
+            if self.logger:
+                self.logger.error(f"启动 B站私信监听失败: {e}")
+            raise
+
+    async def _run_session(self):
+        """在后台运行 Session 轮询"""
+        try:
+            await self._session.start(exclude_self=True)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self._running = False
+            if self.logger:
+                self.logger.error(f"B站 Session 轮询异常退出: {e}")
+
+    async def disconnect(self):
+        """停止 B站私信监听"""
+        if self._session:
+            try:
+                self._session.close()
+                self._running = False
+                if self.logger:
+                    self.logger.info("B站私信监听已停止")
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(f"停止 B站私信监听失败: {e}")
+
+    async def _enqueue_event(self, event: Event, msg_kind: str):
+        """将原始事件标准化后放入队列"""
+        try:
+            sender_uid = str(event.sender_uid)
+
+            # 获取用户昵称
+            nickname = await self._get_user_nickname(event.sender_uid)
+
+            # 构建标准化消息
+            message = {
+                "sender_uid": sender_uid,
+                "sender_nickname": nickname,
+                "msg_kind": msg_kind,
+                "msg_key": str(event.msg_key),
+                "timestamp": int(event.timestamp) if event.timestamp else int(time.time()),
+                "raw_event": event,
+            }
+
+            # 根据消息类型提取内容
+            if msg_kind == "text":
+                message["content"] = str(event.content) if event.content else ""
+                message["content_type"] = "text"
+
+            elif msg_kind == "picture":
+                content = event.content
+                if hasattr(content, "url") and content.url:
+                    message["content"] = content.url
+                    message["content_type"] = "image_url"
+                else:
+                    message["content"] = "[图片]"
+                    message["content_type"] = "text"
+
+            elif msg_kind == "share_video":
+                content = event.content
+                if isinstance(content, BiliVideo):
+                    try:
+                        video_info = await content.get_info()
+                        title = video_info.get("title", "未知")
+                        bvid = video_info.get("bvid", "")
+                        owner_name = video_info.get("owner", {}).get("name", "未知")
+                        view = video_info.get("stat", {}).get("view", 0)
+                        like = video_info.get("stat", {}).get("like", 0)
+                        url = f"https://www.bilibili.com/video/{bvid}" if bvid else ""
+                        message["content"] = (
+                            f"[分享视频] {title}\nUP主: {owner_name} | 播放: {view} | 点赞: {like}\n{url}"
+                        )
+                    except Exception as e:
+                        bvid = getattr(content, "bvid", "")
+                        message["content"] = (
+                            f"[分享视频] https://www.bilibili.com/video/{bvid}"
+                            if bvid else "[分享视频]"
+                        )
+                elif hasattr(content, "bvid") and content.bvid:
+                    message["content"] = f"[分享视频] https://www.bilibili.com/video/{content.bvid}"
+                else:
+                    message["content"] = "[分享视频]"
+                message["content_type"] = "text"
+
+            # 放入队列
+            try:
+                self._message_queue.put_nowait(message)
+            except asyncio.QueueFull:
+                # 队列满时丢弃最旧的消息
+                _ = self._message_queue.get_nowait()
+                self._message_queue.put_nowait(message)
+
+            if self.logger:
+                self.logger.info(f"收到 B站私信 [{msg_kind}] from {sender_uid} ({nickname})")
+
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"处理 B站私信事件失败: {e}")
+
+    async def receive_message(self, timeout: float = 1.0) -> Optional[Dict[str, Any]]:
+        """接收一条标准化消息"""
+        try:
+            return await asyncio.wait_for(self._message_queue.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def _get_user_nickname(self, uid: int) -> str:
+        """获取 B站用户昵称（带内存缓存）"""
+        uid_int = int(uid)
+        if uid_int in self._user_info_cache:
+            return self._user_info_cache[uid_int].get("name", str(uid))
+
+        try:
+            bili_user = BiliUser(uid=uid_int, credential=self._credential)
+            info = await bili_user.get_user_info()
+            nickname = info.get("name", str(uid))
+            self._user_info_cache[uid_int] = info
+            return nickname
+        except Exception as e:
+            if self.logger:
+                self.logger.warning(f"获取用户 {uid} 昵称失败: {e}")
+            return str(uid)
+
+    async def download_image_as_base64(self, url: str) -> Optional[str]:
+        """下载 B站图片并转为 base64 data URL（需 Cookie 鉴权）"""
+        cookies = {}
+        if self._credential.sessdata:
+            cookies["SESSDATA"] = self._credential.sessdata
+        if self._credential.bili_jct:
+            cookies["bili_jct"] = self._credential.bili_jct
+        if self._credential.buvid3:
+            cookies["buvid3"] = self._credential.buvid3
+        if self._credential.dedeuserid:
+            cookies["DedeUserID"] = self._credential.dedeuserid
+
+        try:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as client:
+                resp = await client.get(
+                    url,
+                    cookies=cookies,
+                    headers={
+                        "Referer": "https://www.bilibili.com",
+                        "User-Agent": (
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                            "AppleWebKit/537.36 (KHTML, like Gecko) "
+                            "Chrome/116.0.0.0 Safari/537.36"
+                        ),
+                    },
+                )
+                resp.raise_for_status()
+                content_type = resp.headers.get("content-type", "image/png")
+                b64_str = base64.b64encode(resp.content).decode("utf-8")
+                return f"data:{content_type};base64,{b64_str}"
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"下载图片失败 {url}: {e}")
+            return None
+
+    async def send_text(self, user_id: str, text: str):
+        """发送文本私信"""
+        from bilibili_api.session import send_msg
+        from bilibili_api.session import EventType as SessionEventType
+
+        await send_msg(self._credential, int(user_id), SessionEventType.TEXT, text)
+        if self.logger:
+            self.logger.info(f"已发送文本私信给 {user_id}")
+
+    async def send_image(self, user_id: str, image_source: str):
+        """发送图片私信，支持 URL 和 base64 两种来源"""
+        from bilibili_api.session import send_msg
+        from bilibili_api.session import EventType as SessionEventType
+        from bilibili_api.utils.picture import Picture
+
+        if image_source.startswith("data:"):
+            # base64 data URL
+            # 提取 base64 部分
+            _, b64_data = image_source.split(",", 1)
+            img_bytes = base64.b64decode(b64_data)
+            pic = Picture.from_content(img_bytes, "png")
+        elif image_source.startswith(("http://", "https://")):
+            # URL
+            pic = await Picture.load_url(image_source)
+        else:
+            # 假设是 base64 字符串
+            img_bytes = base64.b64decode(image_source)
+            pic = Picture.from_content(img_bytes, "png")
+
+        await send_msg(self._credential, int(user_id), SessionEventType.PICTURE, pic)
+        if self.logger:
+            self.logger.info(f"已发送图片私信给 {user_id}")
+
+    async def send_emoji(self, user_id: str, emoji_text: str):
+        """发送表情私信（以文本形式发送 emoji 字符）"""
+        await self.send_text(user_id, emoji_text)

--- a/plugin/plugins/bilibili_dm/permission.py
+++ b/plugin/plugins/bilibili_dm/permission.py
@@ -41,19 +41,20 @@ class PermissionManager:
         level_text = str(level or "").strip().lower()
         return level_text if level_text in cls.VALID_LEVELS else None
 
-    def add_user(self, uid: str, level: str = "trusted", nickname: str = ""):
+    def add_user(self, uid: str, level: str = "trusted", nickname: str = "") -> bool:
         """添加用户"""
         uid_str = self._normalize_uid(uid)
         if not uid_str:
-            return
+            return False
         normalized = self._normalize_level(level)
         if not normalized:
-            return
+            return False
         self._users[uid_str] = normalized
         if nickname:
             self._nicknames[uid_str] = nickname
         elif uid_str in self._nicknames:
             del self._nicknames[uid_str]
+        return True
 
     def remove_user(self, uid: str):
         """移除用户"""

--- a/plugin/plugins/bilibili_dm/permission.py
+++ b/plugin/plugins/bilibili_dm/permission.py
@@ -52,8 +52,6 @@ class PermissionManager:
         self._users[uid_str] = normalized
         if nickname:
             self._nicknames[uid_str] = nickname
-        elif uid_str in self._nicknames:
-            del self._nicknames[uid_str]
         return True
 
     def remove_user(self, uid: str):
@@ -122,4 +120,4 @@ class PermissionManager:
             return level != "none"
         elif permission_mode == "deny_list":
             return level != "normal"
-        return True
+        return permission_mode == "open"

--- a/plugin/plugins/bilibili_dm/permission.py
+++ b/plugin/plugins/bilibili_dm/permission.py
@@ -1,0 +1,121 @@
+"""
+B站私信权限管理模块
+
+根据 B站 UID 管理用户权限等级，支持 admin / trusted / normal / none 四级。
+"""
+
+from typing import Dict, List, Optional
+
+
+class PermissionManager:
+    """B站私信权限管理器"""
+
+    VALID_LEVELS = {"admin", "trusted", "normal"}
+
+    def __init__(self, trusted_users: List[Dict[str, str]] = None):
+        """
+        初始化权限管理器
+
+        Args:
+            trusted_users: 信任用户列表，格式: [{"uid": "12345", "level": "admin", "nickname": "小明"}, ...]
+        """
+        self._users: Dict[str, str] = {}      # {uid: level}
+        self._nicknames: Dict[str, str] = {}   # {uid: nickname}
+
+        if trusted_users:
+            for user in trusted_users:
+                uid = self._normalize_uid(user.get("uid", ""))
+                level = self._normalize_level(user.get("level", "trusted"))
+                nickname = user.get("nickname", "")
+                if uid:
+                    self._users[uid] = level
+                    if nickname:
+                        self._nicknames[uid] = nickname
+
+    @staticmethod
+    def _normalize_uid(uid: str) -> str:
+        return str(uid or "").strip()
+
+    @classmethod
+    def _normalize_level(cls, level: str) -> str:
+        level_text = str(level or "trusted").strip().lower()
+        return level_text if level_text in cls.VALID_LEVELS else "trusted"
+
+    def add_user(self, uid: str, level: str = "trusted", nickname: str = ""):
+        """添加用户"""
+        uid_str = self._normalize_uid(uid)
+        if not uid_str:
+            return
+        self._users[uid_str] = self._normalize_level(level)
+        if nickname:
+            self._nicknames[uid_str] = nickname
+        elif uid_str in self._nicknames:
+            del self._nicknames[uid_str]
+
+    def remove_user(self, uid: str):
+        """移除用户"""
+        uid_str = self._normalize_uid(uid)
+        if uid_str in self._users:
+            del self._users[uid_str]
+        if uid_str in self._nicknames:
+            del self._nicknames[uid_str]
+
+    def get_permission_level(self, uid: str) -> str:
+        """
+        获取用户权限等级
+
+        Returns:
+            权限等级: admin, trusted, normal, none
+        """
+        uid_str = self._normalize_uid(uid)
+        return self._users.get(uid_str, "none")
+
+    def list_users(self) -> List[Dict[str, str]]:
+        """列出所有用户"""
+        result = []
+        for uid, level in self._users.items():
+            user_info = {"uid": uid, "level": level}
+            if uid in self._nicknames:
+                user_info["nickname"] = self._nicknames[uid]
+            result.append(user_info)
+        return result
+
+    def get_nickname(self, uid: str) -> Optional[str]:
+        """获取用户昵称"""
+        return self._nicknames.get(self._normalize_uid(uid))
+
+    def set_nickname(self, uid: str, nickname: str) -> bool:
+        """设置用户昵称"""
+        uid_str = self._normalize_uid(uid)
+        if uid_str in self._users:
+            if nickname:
+                self._nicknames[uid_str] = nickname
+            else:
+                if uid_str in self._nicknames:
+                    del self._nicknames[uid_str]
+            return True
+        return False
+
+    def is_admin(self, uid: str) -> bool:
+        """检查是否是管理员"""
+        return self.get_permission_level(uid) == "admin"
+
+    def is_trusted(self, uid: str) -> bool:
+        """检查是否是信任用户（包括管理员）"""
+        level = self.get_permission_level(uid)
+        return level in ("admin", "trusted")
+
+    def should_process(self, uid: str, permission_mode: str = "allow_list") -> bool:
+        """
+        根据权限模式判断是否应处理该用户的消息
+
+        allow_list 模式：只处理白名单中的用户
+        deny_list 模式：处理所有用户，除了黑名单中的
+        open 模式：处理所有用户
+        """
+        level = self.get_permission_level(uid)
+        if permission_mode == "allow_list":
+            return level != "none"
+        elif permission_mode == "deny_list":
+            return level != "normal"
+        return True

--- a/plugin/plugins/bilibili_dm/permission.py
+++ b/plugin/plugins/bilibili_dm/permission.py
@@ -25,9 +25,9 @@ class PermissionManager:
         if trusted_users:
             for user in trusted_users:
                 uid = self._normalize_uid(user.get("uid", ""))
-                level = self._normalize_level(user.get("level", "trusted"))
+                level = self._normalize_level(user.get("level", ""))
                 nickname = user.get("nickname", "")
-                if uid:
+                if uid and level:
                     self._users[uid] = level
                     if nickname:
                         self._nicknames[uid] = nickname
@@ -37,16 +37,19 @@ class PermissionManager:
         return str(uid or "").strip()
 
     @classmethod
-    def _normalize_level(cls, level: str) -> str:
-        level_text = str(level or "trusted").strip().lower()
-        return level_text if level_text in cls.VALID_LEVELS else "trusted"
+    def _normalize_level(cls, level: str) -> Optional[str]:
+        level_text = str(level or "").strip().lower()
+        return level_text if level_text in cls.VALID_LEVELS else None
 
     def add_user(self, uid: str, level: str = "trusted", nickname: str = ""):
         """添加用户"""
         uid_str = self._normalize_uid(uid)
         if not uid_str:
             return
-        self._users[uid_str] = self._normalize_level(level)
+        normalized = self._normalize_level(level)
+        if not normalized:
+            return
+        self._users[uid_str] = normalized
         if nickname:
             self._nicknames[uid_str] = nickname
         elif uid_str in self._nicknames:

--- a/plugin/plugins/bilibili_dm/plugin.toml
+++ b/plugin/plugins/bilibili_dm/plugin.toml
@@ -1,0 +1,36 @@
+[plugin]
+name = "B站私信"
+description = "接入 B站私信，实现与用户的 AI 自动对话。支持文本、图片、分享视频等消息类型。"
+short_description = "B站私信自动回复，通过 bilibili_api 监听私信并自动回复。"
+keywords = ["bilibili", "b站", "私信", "dm"]
+passive = true
+version = "1.0.0"
+id = "bilibili_dm"
+type = "plugin"
+entry = "plugin.plugins.bilibili_dm:BiliDMPlugin"
+
+[plugin.author]
+name = "xxynet"
+
+[plugin.sdk]
+recommended = ">=0.1.0,<0.2.0"
+supported = ">=0.1.0,<0.3.0"
+
+[plugin.store]
+enabled = true
+
+[plugin_runtime]
+enabled = true
+auto_start = false
+
+[bilibili_dm]
+bot_uid = ""
+permission_mode = "allow_list"
+trusted_users = []
+
+# B站 Cookie 配置（从浏览器开发者工具获取）
+sesdata = ""
+bili_jct = ""
+buvid3 = ""
+dedeuserid = ""
+ac_time_value = ""


### PR DESCRIPTION
# B站私信 N.E.K.O 插件

通过 `bilibili_api` 监听 B站私信，使用 N.E.K.O AI 自动回复。

## 功能特性

| 消息类型 | 接收 | 发送 |
|---------|------|------|
| 文本 (TEXT) | ✅ | ✅ |
| 图片 (PICTURE) | ✅ | ✅ |
| 分享视频 (SHARE_VIDEO) | ✅ | — |

### 详细说明

- **接收文本消息**：直接提取文本内容，交给 AI 生成回复
- **接收图片消息**：通过 Cookie 鉴权下载图片，转为 Base64 传递给 AI
- **接收分享视频**：获取视频标题、UP主、播放量等信息，拼接为富文本
- **发送文本消息**：通过 `send_msg` 发送纯文本回复
- **发送图片消息**：支持 URL 和 Base64 两种图片来源
- **用户昵称解析**：通过 `User.get_user_info()` API 获取真实昵称，带内存缓存
- **权限管理**：支持 admin / trusted / normal 三级权限控制
- **记忆同步**：管理员对话自动同步到 Memory Server

## 配置项

通过 WebUI 或 `plugin.toml` 配置以下字段：

### B站 Cookie

| 字段 | 类型 | 说明 |
|------|------|------|
| `sesdata` | string | B站 Cookie 中的 `SESSDATA`（必填） |
| `bili_jct` | string | B站 Cookie 中的 `bili_jct`（CSRF Token） |
| `buvid3` | string | B站 Cookie 中的 `buvid3` |
| `dedeuserid` | string | B站 Cookie 中的 `DedeUserID` |
| `ac_time_value` | string | B站 Cookie 中的 `ac_time_value` |

### 权限配置

| 字段 | 类型 | 说明 |
|------|------|------|
| `trusted_users` | list | 信任用户列表，格式: `[{uid = "12345", level = "admin"}]` |

### 权限等级

| 等级 | 说明 |
|------|------|
| `admin` | 管理员，享有最高权限，使用完整记忆上下文 |
| `trusted` | 信任用户，可获得 AI 回复 |
| `normal` | 普通用户，不自动回复 |

## 插件入口

| Entry ID | 名称 | 说明 |
|----------|------|------|
| `start_listening` | 开始监听 | 启动 B站私信监听并自动回复 |
| `stop_listening` | 停止监听 | 停止监听 B站私信 |
| `send_message` | 发送私信 | 向指定 B站用户发送一条私信 |
| `add_trusted_user` | 添加信任用户 | 添加信任用户到白名单 |
| `remove_trusted_user` | 移除信任用户 | 从白名单中移除用户 |
| `set_user_nickname` | 设置用户昵称 | 为信任用户设置专属称呼 |
| `list_trusted_users` | 列出信任用户 | 列出所有信任用户 |

## 获取 Cookie

1. 使用浏览器登录 [bilibili.com](https://www.bilibili.com)
2. 打开浏览器开发者工具（F12）→ Application → Cookies
3. 找到并复制以下字段的值：
   - `SESSDATA`（必填）
   - `bili_jct`
   - `buvid3`
   - `DedeUserID`
   - `ac_time_value`

> ⚠️ **注意**：Cookie 有效期有限，过期后需重新获取并更新配置。
## 依赖

- `bilibili_api` — B站 API 封装库
- `httpx` — 异步 HTTP 客户端（用于图片下载）

## 文件结构

```
bilibili_dm/
├── __init__.py       # 插件主实现
├── plugin.toml       # 插件配置
├── bili_client.py    # B站私信客户端封装
├── permission.py     # 权限管理模块
├── README.md         # 本文件
└── KiraAI_bili_dm_adapter/  # KiraAI 参考适配器
```

## 注意事项

- 图片下载需要携带 B站 Cookie 才能正常访问，客户端内部已自动处理
- 使用 `Session` 轮询机制，约每 6 秒检查一次新消息
- 管理员对话会自动同步到 Memory Server，用于构建连续对话上下文
- 超过 5 分钟空闲的会话会自动回收并结算记忆

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增哔哩哔哩私信插件：接收/发送文本、图片、分享视频与表情，支持启动/停止监听、AI 自动回复、会话与并发管理、消息队列与昵称缓存。
  * 用户权限与管理：支持多级权限（admin/trusted/normal）、信任用户管理、设置昵称及查询与处理策略（允许/拒绝/开放）。

* **文档**
  * 添加完整插件使用与配置指南，包含消息工作流、Cookie 与配置填写步骤及权限说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->