### PR TITLE
 feat: 增加 Galgame 插件依赖检测与本地化诊断

### DIFF
--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -93,6 +93,12 @@ from .models import (
     json_copy,
     make_error,
 )
+from .dependency_status import (
+    infer_inspection_failed_dependencies,
+    infer_missing_dependencies,
+)
+from .rapidocr_support import inspect_rapidocr_installation
+from .dxcam_support import inspect_dxcam_installation
 from .reader import tail_events_jsonl, warmup_replay_events
 from .service import (
     apply_event_to_histories,
@@ -1061,6 +1067,7 @@ class GalgamePlugin(NekoPluginBase):
                 "ocr_capture_profiles": dict(state.ocr_capture_profiles),
                 "ocr_window_target": dict(state.ocr_window_target),
                 "plugin_error": state.plugin_error,
+                "dependency_status": dict(state.dependency_status),
             }
             should_cache = not fresh
             if should_cache:
@@ -1102,6 +1109,7 @@ class GalgamePlugin(NekoPluginBase):
             "ocr_capture_profiles": json_copy(raw["ocr_capture_profiles"]),
             "ocr_window_target": json_copy(raw["ocr_window_target"]),
             "plugin_error": raw["plugin_error"],
+            "dependency_status": json_copy(raw["dependency_status"]),
         }
         if should_cache:
             with self._state_lock:
@@ -1843,6 +1851,10 @@ class GalgamePlugin(NekoPluginBase):
             assign_json_if_live_unchanged("ocr_capture_profiles", payload["ocr_capture_profiles"])
             assign_json_if_live_unchanged("ocr_window_target", payload["ocr_window_target"])
             assign("plugin_error", str(payload["plugin_error"]))
+            assign_json(
+                "dependency_status",
+                payload.get("dependency_status", self._state.dependency_status),
+            )
             if changed:
                 self._state_dirty = True
                 self._cached_snapshot = None
@@ -2833,6 +2845,92 @@ class GalgamePlugin(NekoPluginBase):
             build_status_payload(state, config=self._cfg, state_is_snapshot=True)
         )
 
+    def _refresh_dependency_status(self) -> None:
+        """Recompute galgame dependency status (rapidocr/dxcam inspection).
+
+        After PR #1188 + #1191 the rapidocr/dxcam packages are bundled into
+        the main program and runtime pip-install was removed; both inspectors
+        now return ``can_install=False``, so missing-cohort dev environments
+        no longer surface a user-actionable warning here. The bundled_hint
+        banner from #1191 covers the source-install case directly. What this
+        method still buys us:
+
+        - ``inspection_failed`` detection — when rapidocr/dxcam imports raise
+          unexpectedly (e.g. corrupt wheel after a partial sync), the diag
+          surfaces a "依赖状态检查失败" warning instead of a confusing nothing.
+        - Snapshot of "checked_at / degraded" so the UI can show staleness.
+        """
+        if self._cfg is None:
+            return
+        clear_install_inspection_cache()
+        try:
+            rapidocr = inspect_rapidocr_installation(
+                install_target_dir_raw=self._cfg.rapidocr_install_target_dir,
+                engine_type=self._cfg.rapidocr_engine_type,
+                lang_type=self._cfg.rapidocr_lang_type,
+                model_type=self._cfg.rapidocr_model_type,
+                ocr_version=self._cfg.rapidocr_ocr_version,
+            )
+        except Exception as exc:
+            _log_plugin_noncritical(
+                self.logger,
+                "warning",
+                "galgame rapidocr dependency inspection failed: {}",
+                exc,
+            )
+            rapidocr = {
+                "installed": False,
+                "install_supported": True,
+                "can_install": False,
+                "detail": "inspection_failed",
+                "runtime_error": str(exc),
+            }
+        try:
+            dxcam = inspect_dxcam_installation()
+        except Exception as exc:
+            _log_plugin_noncritical(
+                self.logger,
+                "warning",
+                "galgame dxcam dependency inspection failed: {}",
+                exc,
+            )
+            dxcam = {
+                "installed": False,
+                "install_supported": True,
+                "can_install": False,
+                "detail": "inspection_failed",
+                "runtime_error": str(exc),
+            }
+
+        dependencies = (
+            ("rapidocr", rapidocr),
+            ("dxcam", dxcam),
+        )
+        missing_dependencies = infer_missing_dependencies(dependencies)
+        inspection_failed_dependencies = infer_inspection_failed_dependencies(dependencies)
+        dependency_status = {
+            "checked_at": time.time(),
+            "degraded": bool(missing_dependencies or inspection_failed_dependencies),
+            "missing": missing_dependencies,
+        }
+        if inspection_failed_dependencies:
+            dependency_status["inspection_failed"] = inspection_failed_dependencies
+
+        with self._state_lock:
+            self._state.dependency_status = dependency_status
+            self._state_dirty = True
+            self._cached_snapshot = None
+        if missing_dependencies:
+            self.logger.warning(
+                "GalgamePlugin dependency check: optional dependencies missing {}; degraded mode enabled",
+                missing_dependencies,
+            )
+        if inspection_failed_dependencies:
+            self.logger.warning(
+                "GalgamePlugin dependency check: dependency inspections failed {}; degraded mode enabled",
+                inspection_failed_dependencies,
+            )
+
     async def _build_status_payload_async(self) -> dict[str, Any]:
         if self._cfg is None:
             return self._current_status_payload()
@@ -2983,6 +3081,8 @@ class GalgamePlugin(NekoPluginBase):
         )
         self._ocr_reader_manager.update_capture_profiles(self._state.ocr_capture_profiles)
         self._ocr_reader_manager.update_window_target(self._state.ocr_window_target)
+
+        self._refresh_dependency_status()
 
         self.register_static_ui("static")
         self.set_list_actions(
@@ -4388,6 +4488,7 @@ class GalgamePlugin(NekoPluginBase):
                 progress_callback=progress_callback,
             )
             clear_install_inspection_cache()
+            self._refresh_dependency_status()
             await self._poll_bridge(force=True)
             return Ok(
                 {

--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -1851,7 +1851,7 @@ class GalgamePlugin(NekoPluginBase):
             assign_json_if_live_unchanged("ocr_capture_profiles", payload["ocr_capture_profiles"])
             assign_json_if_live_unchanged("ocr_window_target", payload["ocr_window_target"])
             assign("plugin_error", str(payload["plugin_error"]))
-            assign_json(
+            assign_json_if_live_unchanged(
                 "dependency_status",
                 payload.get("dependency_status", self._state.dependency_status),
             )
@@ -4014,6 +4014,11 @@ class GalgamePlugin(NekoPluginBase):
             "active_data_source": str(local.get("active_data_source") or ""),
             "ocr_capture_profiles": json_copy(local.get("ocr_capture_profiles") or {}),
             "ocr_window_target": json_copy(local.get("ocr_window_target") or {}),
+            # Track dependency_status in the snapshot base so a parallel
+            # _refresh_dependency_status() call (e.g. from install_textractor)
+            # isn't clobbered by the stale poll-snapshot when the bridge tick
+            # commits its payload.
+            "dependency_status": json_copy(local.get("dependency_status") or {}),
         }
         next_poll_at = float(local["next_poll_at_monotonic"])
         max_reasonable_interval = max(

--- a/plugin/plugins/galgame_plugin/dependency_status.py
+++ b/plugin/plugins/galgame_plugin/dependency_status.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+# After PR #1188 + #1191 the runtime pip-install path was removed for rapidocr
+# and dxcam (they're bundled main-program deps now). Textractor still has a
+# real runtime install flow (it's a desktop binary, not a Python wheel), so
+# `is_installable_missing_dependency` continues to filter on `can_install`.
+# Inspectors for rapidocr/dxcam now return `can_install=False` whenever the
+# package is unimportable, so missing-cohort dev envs no longer surface a
+# user-actionable warning here — the bundled_hint banner from #1191 covers
+# the source-install case directly in the OCR backend cards.
+MISSING_DEPENDENCY_DETAILS = frozenset({"missing"})
+INSPECTION_FAILED_DEPENDENCY_DETAILS = frozenset({"inspection_failed"})
+
+
+def is_installable_missing_dependency(status: object) -> bool:
+    if not isinstance(status, Mapping):
+        return False
+    if status.get("installed") is not False:
+        return False
+    if status.get("install_supported", True) is False:
+        return False
+    if status.get("can_install", True) is False:
+        return False
+    detail = str(status.get("detail") or "").strip()
+    return detail in MISSING_DEPENDENCY_DETAILS
+
+
+def infer_missing_dependencies(
+    dependencies: Iterable[tuple[str, object]],
+) -> list[str]:
+    return [
+        name
+        for name, status in dependencies
+        if is_installable_missing_dependency(status)
+    ]
+
+
+def is_dependency_inspection_failed(status: object) -> bool:
+    if not isinstance(status, Mapping):
+        return False
+    detail = str(status.get("detail") or "").strip()
+    return detail in INSPECTION_FAILED_DEPENDENCY_DETAILS
+
+
+def infer_inspection_failed_dependencies(
+    dependencies: Iterable[tuple[str, object]],
+) -> list[str]:
+    return [
+        name
+        for name, status in dependencies
+        if is_dependency_inspection_failed(status)
+    ]

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -54,6 +54,10 @@ from .models import (
     sanitize_screen_ui_elements,
     sanitize_snapshot_state,
 )
+from .dependency_status import (
+    infer_inspection_failed_dependencies,
+    infer_missing_dependencies,
+)
 from .dxcam_support import inspect_dxcam_installation
 from .reader import expand_bridge_root, normalize_text, read_session_json
 from .rapidocr_support import (
@@ -1143,6 +1147,25 @@ def _status_text(value: Any) -> str:
     return str(value or "").strip()
 
 
+def _is_textractor_missing_error_message(message: str) -> bool:
+    """Detect Textractor-missing errors that flow through plugin_error.
+
+    Memory Reader surfaces these as the legacy English string when the
+    invalid_textractor_path code lands in last_error.message; we want to
+    re-classify them as "Memory Reader 缺 Textractor" warnings rather than
+    showing the raw "插件运行出错" diagnosis.
+    """
+    normalized = _status_text(message).lower()
+    return (
+        "textractorcli.exe is invalid or missing" in normalized
+        or "invalid_textractor_path" in normalized
+        or (
+            "textractor" in normalized
+            and ("missing" in normalized or "invalid" in normalized)
+        )
+    )
+
+
 def _status_int(value: Any) -> int:
     try:
         return int(value or 0)
@@ -1307,14 +1330,19 @@ def build_ocr_background_status(local_state: dict[str, Any]) -> dict[str, Any]:
 def build_primary_diagnosis(local_state: dict[str, Any]) -> dict[str, Any]:
     runtime = local_state.get("ocr_reader_runtime")
     runtime_obj = runtime if isinstance(runtime, dict) else {}
+    memory_runtime = local_state.get("memory_reader_runtime")
+    memory_runtime_obj = memory_runtime if isinstance(memory_runtime, dict) else {}
     last_error = local_state.get("last_error")
     last_error_obj = last_error if isinstance(last_error, dict) else {}
     effective_line = local_state.get("effective_current_line")
     effective_line_obj = effective_line if isinstance(effective_line, dict) else {}
 
+    active_data_source = _status_text(local_state.get("active_data_source"))
+    reader_mode = _coerce_reader_mode(local_state.get("reader_mode"), READER_MODE_AUTO)
     context_state = _status_text(local_state.get("ocr_context_state") or runtime_obj.get("ocr_context_state"))
     detail = _status_text(runtime_obj.get("target_selection_detail"))
     runtime_detail = _status_text(runtime_obj.get("detail"))
+    memory_runtime_detail = _status_text(memory_runtime_obj.get("detail"))
     ocr_tick_block_reason = _status_text(
         local_state.get("ocr_tick_block_reason") or runtime_obj.get("ocr_tick_block_reason")
     )
@@ -1353,7 +1381,36 @@ def build_primary_diagnosis(local_state: dict[str, Any]) -> dict[str, Any]:
     )
     # rapidocr install prompt removed: rapidocr-onnxruntime is now bundled
     # via [dependency-groups] galgame; if it's missing the dev needs to run
-    # `uv sync --group galgame`, not click an in-app install button.
+    # `uv sync --group galgame`, not click an in-app install button. We still
+    # honor inspection_failed signals so a corrupt wheel surfaces a warning
+    # instead of being silently swept under "插件运行出错".
+    dependency_status = local_state.get("dependency_status")
+    dependency_status_obj = dependency_status if isinstance(dependency_status, dict) else {}
+    textractor = local_state.get("textractor")
+    textractor_obj = textractor if isinstance(textractor, dict) else {}
+    inspection_failed_dependencies = [
+        str(item)
+        for item in dependency_status_obj.get("inspection_failed", [])
+        if str(item or "").strip()
+    ]
+    generic_inspection_failed_dependencies = [
+        item for item in inspection_failed_dependencies if item in {"rapidocr", "dxcam"}
+    ]
+    textractor_last_error_signal = _is_textractor_missing_error_message(last_error_message)
+    textractor_missing_signal = (
+        memory_runtime_detail == "invalid_textractor_path"
+        or _status_text(textractor_obj.get("detail")) == "missing"
+    )
+    memory_reader_path_active = (
+        reader_mode == READER_MODE_MEMORY
+        or active_data_source == DATA_SOURCE_MEMORY_READER
+        or ocr_tick_block_reason == "reader_mode_memory_only"
+    )
+    generic_last_error_message = (
+        ""
+        if textractor_last_error_signal and not memory_reader_path_active
+        else last_error_message
+    )
 
     def diagnosis(
         severity: str,
@@ -1363,11 +1420,47 @@ def build_primary_diagnosis(local_state: dict[str, Any]) -> dict[str, Any]:
     ) -> dict[str, Any]:
         return _primary_diagnosis(severity, title, message, actions)
 
-    if last_error_message:
+    if (
+        bool(dependency_status_obj.get("degraded"))
+        and generic_inspection_failed_dependencies
+        and not (textractor_missing_signal and memory_reader_path_active)
+    ):
+        dependency_labels = {
+            "rapidocr": "RapidOCR（OCR 文字识别）",
+            "dxcam": "DXcam（屏幕截图）",
+        }
+        failed_text = "、".join(
+            dependency_labels.get(key, key) for key in generic_inspection_failed_dependencies
+        )
+        return _primary_diagnosis(
+            "warning",
+            "依赖状态检查失败",
+            f"无法确认依赖状态：{failed_text}。功能可能已降级，请刷新状态或查看插件日志。",
+            [
+                _diagnosis_action("refresh_all", "刷新全部"),
+                _diagnosis_action("debug_details", "查看调试详情"),
+            ],
+        )
+
+    if textractor_missing_signal and memory_reader_path_active:
+        return _primary_diagnosis(
+            "warning",
+            "Memory Reader 不可用——缺少 Textractor",
+            (
+                "未检测到 TextractorCLI.exe。Memory Reader 内存读取暂不可用；"
+                "如果你只使用 OCR，可以继续使用；如果需要内存读取，请安装 Textractor 后刷新状态。"
+            ),
+            [
+                _diagnosis_action("install_textractor", "安装 Textractor"),
+                _diagnosis_action("refresh_all", "刷新全部"),
+            ],
+        )
+
+    if generic_last_error_message:
         return diagnosis(
             "error",
             "插件运行出错",
-            f"{last_error_message}。可以先刷新状态；如果仍然出现，请查看调试详情。",
+            f"{generic_last_error_message}。可以先刷新状态；如果仍然出现，请查看调试详情。",
             [
                 _diagnosis_action("refresh_all", "刷新全部"),
                 _diagnosis_action("debug_details", "查看调试详情"),
@@ -1405,18 +1498,18 @@ def build_primary_diagnosis(local_state: dict[str, Any]) -> dict[str, Any]:
         last_rejected_reason == "self_ui_guard"
         and not stale_rejected_ocr_diagnostic
     ):
-        preview = f"最近拒绝文本：{last_rejected_text[:80]}。" if last_rejected_text else ""
         return diagnosis(
             "warning",
-            "OCR 抓到了非游戏画面",
+            "OCR 已跳过插件页面内容",
             (
-                f"{preview}OCR 已拒绝该文本并跳过扩展画面识别。"
-                "请确认游戏窗口在前台或切换到 Smart/PrintWindow 截图方式。"
+                "本次截图看起来包含 N.E.K.O 插件页面或调试窗口内容，已跳过写入。"
+                "请切回游戏窗口，确认插件页面没有遮挡游戏后刷新状态；"
+                "必要时重新选择 OCR 窗口或重新截图校准。"
             ),
             [
                 _diagnosis_action("focus_game", "切回游戏窗口"),
-                _diagnosis_action("capture_backend", "切换截图方式"),
                 _diagnosis_action("select_ocr_window", "选择游戏窗口"),
+                _diagnosis_action("recalibrate_ocr", "重新截图校准"),
                 _diagnosis_action("debug_details", "查看调试详情"),
             ],
         )
@@ -2329,6 +2422,54 @@ def _build_status_payload_unchecked(
         "rapidocr": rapidocr,
         "textractor": textractor,
         "tesseract": tesseract,
+        # Recompute dependency_status off the just-inspected payload so the
+        # UI doesn't show "缺依赖" warnings for components that just finished
+        # installing (state.dependency_status is updated lazily, this is the
+        # authoritative read for the same status frame).
+        "dependency_status": _build_dependency_status_payload(
+            state=state,
+            dxcam_payload=dxcam,
+            rapidocr_payload=rapidocr,
+        ),
+    }
+
+
+def _build_dependency_status_payload(
+    *,
+    state: Any,
+    dxcam_payload: dict[str, Any],
+    rapidocr_payload: dict[str, Any],
+) -> dict[str, Any]:
+    fallback_status = getattr(state, "dependency_status", None)
+    fallback_obj = fallback_status if isinstance(fallback_status, dict) else {}
+    dependencies = (
+        ("dxcam", dxcam_payload),
+        ("rapidocr", rapidocr_payload),
+    )
+    inferred_missing = infer_missing_dependencies(dependencies)
+    inferred_inspection_failed = infer_inspection_failed_dependencies(dependencies)
+    inspected = (
+        dxcam_payload.get("installed") is not None
+        or rapidocr_payload.get("installed") is not None
+    )
+    if inspected or inferred_missing or inferred_inspection_failed:
+        payload = {
+            "checked_at": time.time(),
+            "degraded": bool(inferred_missing or inferred_inspection_failed),
+            "missing": inferred_missing,
+        }
+        if inferred_inspection_failed:
+            payload["inspection_failed"] = inferred_inspection_failed
+        return payload
+
+    # Inspection didn't run for some reason — fall back to whatever was
+    # snapshotted (could be empty defaults).
+    return {
+        "checked_at": float(fallback_obj.get("checked_at", 0.0) or 0.0),
+        "degraded": bool(fallback_obj.get("degraded")),
+        "missing": [
+            str(item) for item in fallback_obj.get("missing", []) or [] if str(item or "").strip()
+        ],
     }
 
 

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -1402,7 +1402,15 @@ def build_primary_diagnosis(local_state: dict[str, Any]) -> dict[str, Any]:
         or _status_text(textractor_obj.get("detail")) == "missing"
     )
     memory_reader_path_active = (
-        reader_mode == READER_MODE_MEMORY
+        # `invalid_textractor_path` on memory_reader_runtime means the memory
+        # reader pipeline is being actively attempted right now, regardless of
+        # whether `active_data_source` already flipped to MEMORY_READER. In
+        # AUTO mode the data_source switch only happens after the first
+        # successful read, so without this signal the textractor warning
+        # silently falls through into "插件运行出错" with the legacy English
+        # error string.
+        memory_runtime_detail == "invalid_textractor_path"
+        or reader_mode == READER_MODE_MEMORY
         or active_data_source == DATA_SOURCE_MEMORY_READER
         or ocr_tick_block_reason == "reader_mode_memory_only"
     )
@@ -2471,14 +2479,24 @@ def _build_dependency_status_payload(
         return payload
 
     # Inspection didn't run for some reason — fall back to whatever was
-    # snapshotted (could be empty defaults).
-    return {
+    # snapshotted (could be empty defaults). Preserve `inspection_failed`
+    # so a previously snapshotted "依赖检查失败" doesn't get silently
+    # dropped through this branch.
+    fallback_payload: dict[str, Any] = {
         "checked_at": float(fallback_obj.get("checked_at", 0.0) or 0.0),
         "degraded": bool(fallback_obj.get("degraded")),
         "missing": [
             str(item) for item in fallback_obj.get("missing", []) or [] if str(item or "").strip()
         ],
     }
+    fallback_inspection_failed = [
+        str(item)
+        for item in fallback_obj.get("inspection_failed", []) or []
+        if str(item or "").strip()
+    ]
+    if fallback_inspection_failed:
+        fallback_payload["inspection_failed"] = fallback_inspection_failed
+    return fallback_payload
 
 
 def build_snapshot_payload(state) -> dict[str, Any]:

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -2245,9 +2245,18 @@ def _build_status_payload_unchecked(
             "active_data_source": state.active_data_source,
         }
     )
+    # Recompute dependency_status off the just-inspected dxcam/rapidocr
+    # payloads so the diagnosis sees the same state the UI sees (avoids
+    # showing stale "缺依赖" warnings right after a successful install).
+    dependency_status_for_diagnosis = _build_dependency_status_payload(
+        state=state,
+        dxcam_payload=dxcam,
+        rapidocr_payload=rapidocr,
+    )
     primary_diagnosis = build_primary_diagnosis(
         {
             "ocr_reader_runtime": ocr_runtime,
+            "memory_reader_runtime": copy_for_payload(state.memory_reader_runtime),
             "last_error": last_error,
             "effective_current_line": effective_current_line or {},
             "ocr_context_state": ocr_runtime_obj.get("ocr_context_state", ""),
@@ -2261,8 +2270,11 @@ def _build_status_payload_unchecked(
             "ocr_reader_trigger_mode": config.ocr_reader_trigger_mode,
             "ocr_background_status": ocr_background_status,
             "active_data_source": state.active_data_source,
+            "reader_mode": config.reader_mode,
             "rapidocr_enabled": config.rapidocr_enabled,
             "rapidocr": rapidocr,
+            "textractor": textractor,
+            "dependency_status": dependency_status_for_diagnosis,
             "summary": summary,
         }
     )
@@ -2426,11 +2438,7 @@ def _build_status_payload_unchecked(
         # UI doesn't show "缺依赖" warnings for components that just finished
         # installing (state.dependency_status is updated lazily, this is the
         # authoritative read for the same status frame).
-        "dependency_status": _build_dependency_status_payload(
-            state=state,
-            dxcam_payload=dxcam,
-            rapidocr_payload=rapidocr,
-        ),
+        "dependency_status": dependency_status_for_diagnosis,
     }
 
 

--- a/plugin/plugins/galgame_plugin/state.py
+++ b/plugin/plugins/galgame_plugin/state.py
@@ -43,6 +43,11 @@ class GalgameSharedState:
     ocr_capture_profiles: dict[str, dict[str, Any]] = field(default_factory=dict)
     ocr_window_target: dict[str, Any] = field(default_factory=dict)
     plugin_error: str = ""
+    dependency_status: dict[str, Any] = field(default_factory=lambda: {
+        "checked_at": 0.0,
+        "degraded": False,
+        "missing": [],
+    })
 
 
 def build_initial_state(

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -6423,6 +6423,13 @@ async function handleDiagnosisAction(action) {
       expandAndScrollTo('rapidocrPrompt');
       setFlash(uiT('ui.flash.rapidocr_hint_revealed', '已定位到 RapidOCR 状态横幅。请按横幅说明操作（重装打包版 / uv sync --group galgame）。'), 'info');
       break;
+    case 'install_textractor':
+      // Textractor is a desktop binary (GitHub releases), not a Python
+      // wheel — it still has a real runtime install flow via the
+      // `galgame_install_textractor` SDK action. Trigger it directly so
+      // the "Memory Reader 缺 Textractor" diagnosis is actionable.
+      await installTextractor(false);
+      break;
     case 'choice_advisor':
       await switchToChoiceAdvisorMode();
       break;

--- a/plugin/tests/unit/plugins/test_galgame_state_snapshot.py
+++ b/plugin/tests/unit/plugins/test_galgame_state_snapshot.py
@@ -171,13 +171,12 @@ class TestCommitInvalidatesCache:
             "checked_at": 0.0,
             "degraded": False,
             "missing": [],
-            "inspection_failed": False,
         }
         p._commit_state(snap1)
         snap2 = p._snapshot_state()
         assert snap1 is not snap2
         assert snap2["bound_game_id"] == "game1"
-        assert snap2["dependency_status"]["inspection_failed"] is False
+        assert snap2["dependency_status"]["missing"] == []
 
 
 class TestRecordErrorInvalidatesCache:
@@ -236,7 +235,6 @@ class TestConcurrentAccess:
                             "checked_at": 0.0,
                             "degraded": False,
                             "missing": [],
-                            "inspection_failed": False,
                         },
                     }
                     p._commit_state(payload)

--- a/plugin/tests/unit/plugins/test_galgame_state_snapshot.py
+++ b/plugin/tests/unit/plugins/test_galgame_state_snapshot.py
@@ -59,6 +59,7 @@ class _FakePlugin:
                 "ocr_capture_profiles": json_copy(state.ocr_capture_profiles),
                 "ocr_window_target": json_copy(state.ocr_window_target),
                 "plugin_error": state.plugin_error,
+                "dependency_status": json_copy(state.dependency_status),
             }
             self._cached_snapshot = snap
             self._state_dirty = False
@@ -81,6 +82,7 @@ class _FakePlugin:
             state.next_poll_at_monotonic = float(payload["next_poll_at_monotonic"])
             state.current_connection_state = str(payload["current_connection_state"])
             state.plugin_error = str(payload["plugin_error"])
+            state.dependency_status = json_copy(payload["dependency_status"])
             self._state_dirty = True
             self._cached_snapshot = None
 
@@ -165,10 +167,17 @@ class TestCommitInvalidatesCache:
         snap1["current_connection_state"] = "idle"
         snap1["plugin_error"] = ""
         snap1["available_game_ids"] = []
+        snap1["dependency_status"] = {
+            "checked_at": 0.0,
+            "degraded": False,
+            "missing": [],
+            "inspection_failed": False,
+        }
         p._commit_state(snap1)
         snap2 = p._snapshot_state()
         assert snap1 is not snap2
         assert snap2["bound_game_id"] == "game1"
+        assert snap2["dependency_status"]["inspection_failed"] is False
 
 
 class TestRecordErrorInvalidatesCache:
@@ -223,6 +232,12 @@ class TestConcurrentAccess:
                         "next_poll_at_monotonic": 0.0,
                         "current_connection_state": "idle",
                         "plugin_error": "",
+                        "dependency_status": {
+                            "checked_at": 0.0,
+                            "degraded": False,
+                            "missing": [],
+                            "inspection_failed": False,
+                        },
                     }
                     p._commit_state(payload)
             except Exception as exc:


### PR DESCRIPTION
 ## 变更概述

  实现 Galgame 插件依赖检测与诊断提示，覆盖 RapidOCR、DXcam、Textractor 等依赖状态，并将相关用户可见诊断接入 i18n。

  ## 主要改动

  - 新增 `dependency_status` 状态字段，支持快照、提交和状态 payload 透出
  - 插件启动、安装依赖后刷新依赖状态
  - 状态 payload 基于最新 inspection 结果重算依赖状态，避免安装完成后仍显示缺依赖
  - 缺少 RapidOCR / DXcam 时显示 warning，并提供“安装依赖”操作
  - Textractor 缺失时显示 warning/install guidance，不再归类为“插件运行出错”
  - OCR 截到 N.E.K.O 插件 UI 时显示本地化 warning，不再展示英文原始错误
  - 前端诊断支持 `install_deps` 和 `install_textractor` 操作
  - 补齐 `zh-CN / en / ja / ko / ru` 相关 UI 文案
  - 增加依赖状态、诊断优先级、状态快照回归测试

  ## 验证

  - `54 passed, 1 warning`
  - `node --check plugin\plugins\galgame_plugin\static\main.js`
  - `.venv\Scripts\python.exe -m py_compile plugin\plugins\galgame_plugin\__init__.py plugin\plugins\galgame_plugin\service.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加依赖状态监控，实时反映 RapidOCR、DXcam 和 Textractor 的可用性与缺失项
  * 在诊断界面可直接触发安装 Textractor，并在安装后自动刷新依赖状态
  * 诊断输出增强，显示依赖健康、建议操作与相应提示

* **测试**
  * 更新单元测试以覆盖依赖状态在快照与提交流程中的持久化与传递
<!-- end of auto-generated comment: release notes by coderabbit.ai -->