### PR TITLE
fix: 同步足球小游戏语种到游戏路由

### DIFF
--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1025,12 +1025,18 @@ def _sync_game_language_from_payload(lanlan_name: str, data: dict | None) -> Non
     try:
         mgr = get_session_manager().get(lanlan_name)
         if mgr and hasattr(mgr, "set_user_language"):
-            normalized = normalize_language_code(language, format="full")
-            if str(getattr(mgr, "user_language", "") or "") == normalized:
+            normalized = normalize_language_code(language, format="short")
+            current_raw = str(getattr(mgr, "user_language", "") or "").strip()
+            current = normalize_language_code(current_raw, format="short") if current_raw else ""
+            if current == normalized:
                 return
             mgr.set_user_language(language)
     except Exception:
-        pass
+        logger.debug(
+            "🎮 游戏路由语言同步失败: lanlan=%s",
+            lanlan_name,
+            exc_info=True,
+        )
 
 
 def _get_character_info(lanlan_name: str | None = None) -> Dict[str, Any]:
@@ -5371,7 +5377,7 @@ async def game_quick_lines(game_type: str, request: Request):
             data = await request.json()
         except Exception:
             data = {}
-        lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+        lanlan_name = _resolve_lanlan_name(data.get("lanlan_name") or request.query_params.get("lanlan_name"))
         if lanlan_name:
             _sync_game_language_from_payload(lanlan_name, data)
         char_info = _get_current_character_info()

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1011,6 +1011,28 @@ def _resolve_game_prompt_language(lanlan_name: str | None = None) -> str:
         return "en"
 
 
+def _game_payload_language(data: dict | None) -> str:
+    if not isinstance(data, dict):
+        return ""
+    return str(data.get("language") or data.get("lang") or data.get("i18n_language") or "").strip()
+
+
+def _sync_game_language_from_payload(lanlan_name: str, data: dict | None) -> None:
+    """Mirror the game page's current i18n language into the active session."""
+    language = _game_payload_language(data)
+    if not language:
+        return
+    try:
+        mgr = get_session_manager().get(lanlan_name)
+        if mgr and hasattr(mgr, "set_user_language"):
+            normalized = normalize_language_code(language, format="full")
+            if str(getattr(mgr, "user_language", "") or "") == normalized:
+                return
+            mgr.set_user_language(language)
+    except Exception:
+        pass
+
+
 def _get_character_info(lanlan_name: str | None = None) -> Dict[str, Any]:
     """从 shared_state 获取指定角色信息；未指定时使用当前角色。"""
     try:
@@ -4207,6 +4229,8 @@ async def game_chat(game_type: str, request: Request):
     event = data.get('event', {})
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     state = _get_active_game_route_state(lanlan_name, game_type) if lanlan_name else None
+    if lanlan_name:
+        _sync_game_language_from_payload(lanlan_name, data)
     if state and state.get("session_id") == session_id:
         _update_game_memory_enabled_from_payload(state, data)
         if isinstance(event, dict):
@@ -4242,6 +4266,7 @@ async def game_route_start(game_type: str, request: Request):
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
+    _sync_game_language_from_payload(lanlan_name, data)
 
     session_id = str(data.get("session_id") or "default")
     # 同一角色同一时刻只允许一个 active 游戏路由：启动新路由前先结束所有其它仍活跃的
@@ -4450,6 +4475,7 @@ async def game_route_voice_transcript(game_type: str, request: Request):
     lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
     if not lanlan_name:
         return {"ok": False, "reason": "missing_lanlan_name"}
+    _sync_game_language_from_payload(lanlan_name, data)
 
     session_id = str(data.get("session_id") or "")
     state = _get_active_game_route_state(lanlan_name, game_type)
@@ -5330,7 +5356,7 @@ async def game_end(game_type: str, request: Request):
 
 
 @router.post("/{game_type}/quick-lines")
-async def game_quick_lines(game_type: str):
+async def game_quick_lines(game_type: str, request: Request):
     """进入游戏时生成一组当前猫娘专属快路径台词。
 
     产品语义：这是“游戏内上下文初始化”的一部分。代码告诉 LLM：
@@ -5341,6 +5367,13 @@ async def game_quick_lines(game_type: str):
         return {"ok": False, "error": f"暂不支持 {game_type} 的快路径文案生成", "lines": {}}
 
     try:
+        try:
+            data = await request.json()
+        except Exception:
+            data = {}
+        lanlan_name = _resolve_lanlan_name(data.get("lanlan_name"))
+        if lanlan_name:
+            _sync_game_language_from_payload(lanlan_name, data)
         char_info = _get_current_character_info()
         language = char_info.get("user_language")
         prompt = get_soccer_quick_lines_prompt(language).format(

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -804,6 +804,20 @@
     if (tag.startsWith('pt')) return 'pt-BR';
     return raw;
   };
+  const _currentGameLanguage = () => (
+    (typeof window.i18next !== 'undefined' && window.i18next.language)
+    || window.localStorage?.getItem('i18nextLng')
+    || (typeof navigator !== 'undefined' && navigator.language)
+    || document.documentElement?.lang
+    || 'zh-CN'
+  );
+  const _gameLanguagePayload = () => {
+    const language = _currentGameLanguage();
+    return {
+      language,
+      i18n_language: language,
+    };
+  };
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
   const debugCanvas = document.getElementById('debug');
@@ -1674,7 +1688,11 @@
 
   async function loadGeneratedQuickLines() {
     try {
-      const resp = await fetch('/api/game/soccer/quick-lines', { method: 'POST' });
+      const resp = await fetch('/api/game/soccer/quick-lines', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(_gameLanguagePayload()),
+      });
       if (!resp.ok) {
         soccerRecoverableLog(`[SoccerQuickLines] 生成失败 | HTTP ${resp.status}，继续使用内建快路径`, LINES);
         return;
@@ -2450,9 +2468,12 @@
 	    try {
 	      window.__SoccerLoading?.beginStart?.(_i18n('loading.beginStartDefault', '分析开局上下文…'));
 	      const resp = await fetch('/api/game/soccer/route/start', {
-	        method: 'POST',
-	        headers: { 'Content-Type': 'application/json' },
-	        body: _gameRoutePayload(_readGameRouteStartOptions()),
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: _gameRoutePayload({
+          ..._readGameRouteStartOptions(),
+          ..._gameLanguagePayload(),
+        }),
 	      });
 	      const data = await resp.json().catch(() => ({}));
 	      if (data.ok) {
@@ -3300,6 +3321,7 @@
         body: JSON.stringify({
           session_id: _llm.sessionId,
           ...(_llm.routeLanlanName ? { lanlan_name: _llm.routeLanlanName } : {}),
+          ..._gameLanguagePayload(),
           ..._soccerGameMemoryPolicyPayload(),
           event: {
             ...eventPayload,
@@ -3652,6 +3674,7 @@
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: _gameRoutePayload({
+          ..._gameLanguagePayload(),
           transcript: clean,
           source,
           request_id: requestId,

--- a/templates/soccer_demo.html
+++ b/templates/soccer_demo.html
@@ -804,19 +804,29 @@
     if (tag.startsWith('pt')) return 'pt-BR';
     return raw;
   };
-  const _currentGameLanguage = () => (
-    (typeof window.i18next !== 'undefined' && window.i18next.language)
-    || window.localStorage?.getItem('i18nextLng')
-    || (typeof navigator !== 'undefined' && navigator.language)
-    || document.documentElement?.lang
-    || 'zh-CN'
-  );
+  const _currentGameLanguage = () => {
+    let storedLanguage = '';
+    try {
+      storedLanguage = window.localStorage ? window.localStorage.getItem('i18nextLng') : '';
+    } catch (_) {
+      storedLanguage = '';
+    }
+    return (typeof window.i18next !== 'undefined' && window.i18next.language)
+      || storedLanguage
+      || (typeof navigator !== 'undefined' && navigator.language)
+      || document.documentElement?.lang
+      || 'zh-CN';
+  };
   const _gameLanguagePayload = () => {
     const language = _currentGameLanguage();
     return {
       language,
       i18n_language: language,
     };
+  };
+  const _currentGameLanlanName = () => {
+    const name = String((window.lanlan_config && window.lanlan_config.lanlan_name) || '').trim();
+    return name === 'soccer_demo' ? '' : name;
   };
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
@@ -1688,10 +1698,15 @@
 
   async function loadGeneratedQuickLines() {
     try {
-      const resp = await fetch('/api/game/soccer/quick-lines', {
+      const lanlanName = _currentGameLanlanName();
+      const query = lanlanName ? `?lanlan_name=${encodeURIComponent(lanlanName)}` : '';
+      const resp = await fetch(`/api/game/soccer/quick-lines${query}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(_gameLanguagePayload()),
+        body: JSON.stringify({
+          ..._gameLanguagePayload(),
+          ...(lanlanName ? { lanlan_name: lanlanName } : {}),
+        }),
       });
       if (!resp.ok) {
         soccerRecoverableLog(`[SoccerQuickLines] 生成失败 | HTTP ${resp.status}，继续使用内建快路径`, LINES);


### PR DESCRIPTION
- 在足球小游戏请求中携带当前前端语言，用于 quick-lines、route/start、chat 和语音转写
- 后端接收游戏请求时同步 SessionManager.user_language，避免 Steam 中文场景下游戏 LLM 回退英文
- 避免在心跳请求中携带 language，减少无意义语言同步和重复日志
- 同步前判断当前语言是否已一致，避免重复触发“用户语言已设置”日志

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 改进了游戏语言同步机制：客户端语言偏好会在聊天、路由启动、心跳/语音转写和快速生成线路等场景自动传播到会话中。
  * 统一了客户端语言检测与上报：前端在启动路由、发送聊天或请求快速线路时会随请求携带语言信息，确保界面与生成内容语言一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->