### PR TITLE
fix(voice-swap): rebuild path 跨 end_session 窗口补 guard（堵 PR #1161 漏的 race）

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5033,6 +5033,16 @@ class LLMSessionManager:
                     # 等本路径走到 await self.start_session(text) 时命中 2776 的
                     # "Session正在启动中" guard 被静默忽略，重建静默失败
                     # （ERROR "💥 文本模式Session重建失败"）。
+                    #
+                    # 同时把 session_ready 提前置 False，与 start_session 2867-2868
+                    # 的初始化对偶：rebuild 期间若 session_ready 仍是 True，并发
+                    # _stream_data_now 跳过 4926-4938 的 cache 分支（条件为
+                    # not session_ready），落到 _process_stream_data_internal 后
+                    # 命中 4975 的 count>0 早退被 silent drop——用户在 rebuild
+                    # 窗口内打的字直接丢失。提前置 False 让 cache 路径接住，
+                    # rebuild 完成后 _flush_pending_input_data 会 flush 出去。
+                    async with self.input_cache_lock:
+                        self.session_ready = False
                     self._starting_session_count += 1
                     try:
                         if self.session:
@@ -5182,9 +5192,13 @@ class LLMSessionManager:
                         return
                     
                     logger.info(f"语音模式需要 OmniRealtimeClient，但当前是 {type(self.session).__name__}. 自动重建 session。")
-                    # 与上面 text 重建路径对偶：占用 guard 跨过 end_session 窗口期，
-                    # 防止并发 _stream_data_now 抢跑 start_session(text) 造成本路径
-                    # 命中 2776 guard 静默失败（ERROR "💥 语音模式Session重建失败"）。
+                    # 与上面 text 重建路径对偶：先置 session_ready=False 让 cache
+                    # 路径接住窗口期内的输入，再占用 guard 跨过 end_session，防止
+                    # 并发 _stream_data_now 抢跑 start_session(text) 造成本路径
+                    # 命中 2776 guard 静默失败（ERROR "💥 语音模式Session重建失败"）
+                    # 或落到 _process_stream_data_internal 4975 早退被 silent drop。
+                    async with self.input_cache_lock:
+                        self.session_ready = False
                     self._starting_session_count += 1
                     try:
                         if self.session:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5025,12 +5025,25 @@ class LLMSessionManager:
                         return
                     
                     logger.info(f"文本模式需要 OmniOfflineClient，但当前是 {type(self.session).__name__}. 自动重建 session。")
-                    # 先关闭旧 session
-                    if self.session:
-                        await self.end_session()
-                    # 再创建新的文本模式 session
+                    # 占用 _starting_session_count guard 跨过 end_session 窗口期。
+                    # 默认 end_session(reset_starting_count=True) 会把 guard 清零；
+                    # 它内部又有多个 await 拆 session，期间另一条 _stream_data_now
+                    # （比如 audio worker 拉到下一包）看到 session=None / count=0 会
+                    # 从 4941-4953 的 auto-create 分支抢跑 start_session(audio)，
+                    # 等本路径走到 await self.start_session(text) 时命中 2776 的
+                    # "Session正在启动中" guard 被静默忽略，重建静默失败
+                    # （ERROR "💥 文本模式Session重建失败"）。
+                    self._starting_session_count += 1
+                    try:
+                        if self.session:
+                            await self.end_session(reset_starting_count=False)
+                    finally:
+                        self._starting_session_count = max(0, self._starting_session_count - 1)
+                    # 释放 guard 与下面的 start_session 之间禁止 await，否则窗口
+                    # 重新打开。start_session 入口的 +=1 (2781) 之前都是同步代码，
+                    # 函数调用本身不让出控制权，安全。
                     await self.start_session(self.websocket, new=False, input_mode='text')
-                    
+
                     # 检查重建是否成功
                     if not self.session or not self.is_active or not isinstance(self.session, OmniOfflineClient):
                         logger.error("💥 文本模式Session重建失败，放弃本次数据流")
@@ -5169,12 +5182,17 @@ class LLMSessionManager:
                         return
                     
                     logger.info(f"语音模式需要 OmniRealtimeClient，但当前是 {type(self.session).__name__}. 自动重建 session。")
-                    # 先关闭旧 session
-                    if self.session:
-                        await self.end_session()
-                    # 再创建新的语音模式 session
+                    # 与上面 text 重建路径对偶：占用 guard 跨过 end_session 窗口期，
+                    # 防止并发 _stream_data_now 抢跑 start_session(text) 造成本路径
+                    # 命中 2776 guard 静默失败（ERROR "💥 语音模式Session重建失败"）。
+                    self._starting_session_count += 1
+                    try:
+                        if self.session:
+                            await self.end_session(reset_starting_count=False)
+                    finally:
+                        self._starting_session_count = max(0, self._starting_session_count - 1)
                     await self.start_session(self.websocket, new=False, input_mode='audio')
-                    
+
                     # 检查重建是否成功
                     if not self.session or not self.is_active or not isinstance(self.session, OmniRealtimeClient):
                         logger.error("💥 语音模式Session重建失败，放弃本次数据流")


### PR DESCRIPTION
## 修了什么

PR #1161 修了 voice swap 后 `_flush_pending_input_data` 把缓存 text 灌进 voice session 触发硬撕重建那条路径；但同型 race 在 `_process_stream_data_internal` **自带的两条「类型不匹配自动重建」路径**还在，所以「切免费音色到未指定音色后立刻发文字 → 报连接失败 / neko 已离开」没修干净。

实证日志（2026-05-06 15:31:59，切到「未指定音色」后立刻打字）：

```
文本模式需要 OmniOfflineClient...自动重建 session     ← 文本 rebuild 开始
End Session: Starting cleanup...
Session 不存在或未激活，根据输入类型 audio 自动创建    ← 抢跑！
[语音会话诊断] 开始 start_session: input_mode=audio
End Session: Closing connection...                  ← 文本 rebuild 的 end_session 还在跑
... [双方交错完成] ...
⚠️ Session正在启动中，忽略重复请求                   ← 文本 start_session 被挡
💥 文本模式Session重建失败，放弃本次数据流
```

## 根因

`main_logic/core.py:5028` (text 重建) 和 `:5184` (audio 重建) 两条路径长这样：

```python
if self.session:
    await self.end_session()              # 默认 reset_starting_count=True，把 guard 清零
await self.start_session(..., input_mode='text')   # 这之间被并发抢跑
```

`end_session()` 内部跨多个 await 拆 session（cancel handler / close ws / settle 记忆 / clear queue / teardown TTS），期间另一条 `_stream_data_now`（audio worker 拉到下一包、用户继续打字、`_flush_pending_input_data` flush 出来的 vision 输入等）看到 `session=None / count=0` 就会从 4941-4953 的 auto-create 分支抢跑 `start_session(audio)`，等本路径走到 `await self.start_session(text)` 时命中 2776 的「Session 正在启动中」guard 被静默忽略——重建静默失败，用户视角是「neko 已离开」+ 输入丢失。

`start_session` 自己内部清旧 session 时（2902-2903）就用 `reset_starting_count=False` + 自递增 guard 的对偶模式守住的，注释上还专门写了「否则 guard 被清零后并发的第二次 start_session 会穿过」——这次就是把同一对偶模式补到这两条 rebuild 路径上。

## 改动

`main_logic/core.py:5036-5045` (text rebuild) + `:5188-5194` (audio rebuild)：

```python
self._starting_session_count += 1
try:
    if self.session:
        await self.end_session(reset_starting_count=False)
finally:
    self._starting_session_count = max(0, self._starting_session_count - 1)
await self.start_session(self.websocket, new=False, input_mode='text')
```

释放 guard 与 `start_session` 之间禁止 await：start_session 入口的 `+=1` (2781) 之前都是同步代码，函数调用本身不让出控制权——guard 是同步交接给 start_session 自己 +=1，窗口不会重开。

整体 +28 / -10，不改任何已存在路径行为，只在 race 路径上把对偶 guard 补齐。

## Test plan

- [ ] 切「免费 preset 音色」→「未指定音色」→ 等 reload → **立刻发文字**（不等主动招呼），不应再触发「neko 已离开」/「连接失败」
- [ ] 反向（未指定 → 免费 preset），同样路径验证
- [ ] 切完音色立刻开麦（语音模式），**麦启动期同时打字**，audio rebuild 这一条对偶路径同样不应失败
- [ ] 正常路径回归（不切音色、单纯发文字 / 开麦），行为不变

观测信号（出现说明命中且**已被守住**）：
- `语音模式需要 OmniRealtimeClient...自动重建 session` / `文本模式需要 OmniOfflineClient...自动重建 session` 后**不应再有** `⚠️ Session正在启动中，忽略重复请求` 紧跟 `💥 ...Session重建失败，放弃本次数据流`
- 不应再出现 `Session 不存在或未激活，根据输入类型 X 自动创建 session` 在 rebuild 的 end_session 中段抢跑

## ⚠️ 已知未修（架构层面）

这个 PR 只堵了「**race 不再发生**」，没回答「**race 发生后怎么自我修复**」——下面这些是同一类问题的兜底缺位，留待后续单独提：

1. **数据丢失没有重发**：rebuild 失败时用户那条 text 直接 return 丢掉，前端没重试逻辑、后端没把它加回 `pending_input_data`
2. **CHARACTER_LEFT 误发**：rebuild 内部 `end_session()` 默认 `by_server=False` → 走 5478 发 CHARACTER_LEFT，但内部其实 0.2s 后就 audio session 起来了——前端看到「角色离开」其实是误警
3. **没有"session 类型与期望模式不一致"的心跳校正**：当前只有 stream data 进来时才检查类型，错配中段没有定时校正

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 加强了文本与语音模式下的会话重建并发保护，避免并发重建导致的资源冲突与旧会话被错误覆盖。
  * 优化了会话结束与重建流程的清理与恢复逻辑，提升高并发场景下的稳定性和可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->