### PR TITLE
 fix(galgame): 修复打包环境依赖安装的 Python 解释器发现

### DIFF
--- a/plugin/plugins/galgame_plugin/dxcam_support.py
+++ b/plugin/plugins/galgame_plugin/dxcam_support.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import importlib.util
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,57 @@ from typing import Any, Awaitable, Callable
 from .install_tasks import update_install_task_state
 from .memory_reader import is_windows_platform
 from .tesseract_support import _compute_phase_progress, _emit_progress
+
+
+def _find_python_executable() -> str:
+    """
+    Return a Python executable that can run pip.
+
+    In packaged builds, sys.executable may be projectneko_server.exe, which
+    refuses self-execution with "-m". Prefer real Python interpreters instead.
+    """
+
+    def _is_usable(path: str) -> bool:
+        try:
+            subprocess.run(
+                [path, "--version"],
+                check=True,
+                capture_output=True,
+                timeout=10,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            return True
+        except Exception:
+            return False
+
+    base = getattr(sys, "_base_executable", None)
+    if base and os.path.isfile(base) and _is_usable(base):
+        return base
+
+    exe_dir = Path(sys.executable).parent
+    for candidate in ["python.exe", "python3.exe"]:
+        candidate_path = exe_dir / candidate
+        if candidate_path.is_file() and _is_usable(str(candidate_path)):
+            return str(candidate_path)
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        for candidate in ["python.exe", "python3.exe"]:
+            candidate_path = Path(meipass) / candidate
+            if candidate_path.is_file() and _is_usable(str(candidate_path)):
+                return str(candidate_path)
+
+    for candidate in ["python", "python3"]:
+        found = shutil.which(candidate)
+        if found and _is_usable(found):
+            return found
+
+    raise RuntimeError(
+        "找不到可用的 Python 解释器，无法安装 pip 依赖。"
+        "请安装 Python 3.9+ 并添加到 PATH，或联系开发者获取内置依赖的版本。"
+        f"当前程序路径: {sys.executable}"
+    )
+
 
 DXCAM_PACKAGE_NAME = "dxcam"
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
@@ -69,7 +121,7 @@ def _run_pip_install(*, timeout_seconds: float) -> None:
     env["TEMP"] = str(temp_root)
     env["TMPDIR"] = str(temp_root)
     command = [
-        sys.executable,
+        _find_python_executable(),
         "-m",
         "pip",
         "install",

--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -22,6 +22,57 @@ from .memory_reader import is_windows_platform
 from .tesseract_support import _compute_phase_progress, _emit_progress
 from .install_tasks import update_install_task_state
 
+
+def _find_python_executable() -> str:
+    """
+    Return a Python executable that can run pip.
+
+    In packaged builds, sys.executable may be projectneko_server.exe, which
+    refuses self-execution with "-m". Prefer real Python interpreters instead.
+    """
+
+    def _is_usable(path: str) -> bool:
+        try:
+            subprocess.run(
+                [path, "--version"],
+                check=True,
+                capture_output=True,
+                timeout=10,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            return True
+        except Exception:
+            return False
+
+    base = getattr(sys, "_base_executable", None)
+    if base and os.path.isfile(base) and _is_usable(base):
+        return base
+
+    exe_dir = Path(sys.executable).parent
+    for candidate in ["python.exe", "python3.exe"]:
+        candidate_path = exe_dir / candidate
+        if candidate_path.is_file() and _is_usable(str(candidate_path)):
+            return str(candidate_path)
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        for candidate in ["python.exe", "python3.exe"]:
+            candidate_path = Path(meipass) / candidate
+            if candidate_path.is_file() and _is_usable(str(candidate_path)):
+                return str(candidate_path)
+
+    for candidate in ["python", "python3"]:
+        found = shutil.which(candidate)
+        if found and _is_usable(found):
+            return found
+
+    raise RuntimeError(
+        "找不到可用的 Python 解释器，无法安装 pip 依赖。"
+        "请安装 Python 3.9+ 并添加到 PATH，或联系开发者获取内置依赖的版本。"
+        f"当前程序路径: {sys.executable}"
+    )
+
+
 RAPIDOCR_PACKAGE_NAME = "rapidocr_onnxruntime"
 DEFAULT_RAPIDOCR_ENGINE_TYPE = "onnxruntime"
 DEFAULT_RAPIDOCR_LANG_TYPE = "ch"
@@ -615,7 +666,7 @@ def _run_subprocess(
 def _ensure_pip_available(*, timeout_seconds: float, temp_root: Path) -> None:
     env = _rapidocr_temp_env(temp_root=temp_root)
     try:
-        _run_subprocess([sys.executable, "-m", "pip", "--version"], timeout_seconds=timeout_seconds, env=env)
+        _run_subprocess([_find_python_executable(), "-m", "pip", "--version"], timeout_seconds=timeout_seconds, env=env)
         return
     except subprocess.CalledProcessError as exc:
         message = " ".join(
@@ -624,8 +675,8 @@ def _ensure_pip_available(*, timeout_seconds: float, temp_root: Path) -> None:
         if "No module named pip" not in message:
             raise
 
-    _run_subprocess([sys.executable, "-m", "ensurepip", "--upgrade"], timeout_seconds=timeout_seconds, env=env)
-    _run_subprocess([sys.executable, "-m", "pip", "--version"], timeout_seconds=timeout_seconds, env=env)
+    _run_subprocess([_find_python_executable(), "-m", "ensurepip", "--upgrade"], timeout_seconds=timeout_seconds, env=env)
+    _run_subprocess([_find_python_executable(), "-m", "pip", "--version"], timeout_seconds=timeout_seconds, env=env)
 
 
 def _run_pip_install(
@@ -639,7 +690,7 @@ def _run_pip_install(
     env = _rapidocr_temp_env(temp_root=temp_root)
     _ensure_pip_available(timeout_seconds=timeout_seconds, temp_root=temp_root)
     command = [
-        sys.executable,
+        _find_python_executable(),
         "-m",
         "pip",
         "install",

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -16,6 +16,7 @@ import pytest
 from plugin.plugins.galgame_plugin import ocr_capture as galgame_ocr_capture
 from plugin.plugins.galgame_plugin import ocr_backends as galgame_ocr_backends
 from plugin.plugins.galgame_plugin import ocr_reader as galgame_ocr_reader
+from plugin.plugins.galgame_plugin import dxcam_support as galgame_dxcam_support
 from plugin.plugins.galgame_plugin import rapidocr_support as galgame_rapidocr_support
 from plugin.plugins.galgame_plugin import install_tasks as galgame_install_tasks
 from plugin.plugins.galgame_plugin.models import (
@@ -1772,6 +1773,11 @@ def test_rapidocr_pip_install_uses_require_hashes(
         "_ensure_pip_available",
         lambda **kwargs: None,
     )
+    monkeypatch.setattr(
+        galgame_rapidocr_support,
+        "_find_python_executable",
+        lambda: "discovered-python.exe",
+    )
 
     def _capture_subprocess(command, *, timeout_seconds, env=None):
         del timeout_seconds, env
@@ -1789,8 +1795,75 @@ def test_rapidocr_pip_install_uses_require_hashes(
 
     assert len(commands) == 1
     command = commands[0]
+    assert command[:3] == ["discovered-python.exe", "-m", "pip"]
     assert command.index("--require-hashes") < command.index("rapidocr_onnxruntime==1.4.4")
     assert command[-2:] == ["rapidocr_onnxruntime==1.4.4", f"--hash=sha256:{digest}"]
+
+
+def test_rapidocr_python_discovery_skips_packaged_server_exe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packaged_exe = tmp_path / "projectneko_server.exe"
+    bundled_python = tmp_path / "python.exe"
+    packaged_exe.write_text("", encoding="utf-8")
+    bundled_python.write_text("", encoding="utf-8")
+    checked: list[str] = []
+
+    monkeypatch.setattr(galgame_rapidocr_support.sys, "executable", str(packaged_exe))
+    monkeypatch.setattr(galgame_rapidocr_support.sys, "_base_executable", None, raising=False)
+    monkeypatch.setattr(galgame_rapidocr_support.sys, "_MEIPASS", None, raising=False)
+    monkeypatch.setattr(galgame_rapidocr_support.shutil, "which", lambda name: None)
+
+    def _fake_run(command, **kwargs):
+        del kwargs
+        checked.append(command[0])
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(galgame_rapidocr_support.subprocess, "run", _fake_run)
+
+    assert galgame_rapidocr_support._find_python_executable() == str(bundled_python)
+    assert checked == [str(bundled_python)]
+
+
+def test_dxcam_pip_install_uses_discovered_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        galgame_dxcam_support,
+        "_find_python_executable",
+        lambda: "discovered-python.exe",
+    )
+
+    def _fake_run(command, **kwargs):
+        del kwargs
+        commands.append(command)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(galgame_dxcam_support.subprocess, "run", _fake_run)
+
+    galgame_dxcam_support._run_pip_install(timeout_seconds=5.0)
+
+    assert len(commands) == 1
+    assert commands[0][:3] == ["discovered-python.exe", "-m", "pip"]
+
+
+def test_dxcam_python_discovery_reports_missing_python(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    packaged_exe = tmp_path / "projectneko_server.exe"
+    packaged_exe.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(galgame_dxcam_support.sys, "executable", str(packaged_exe))
+    monkeypatch.setattr(galgame_dxcam_support.sys, "_base_executable", None, raising=False)
+    monkeypatch.setattr(galgame_dxcam_support.sys, "_MEIPASS", None, raising=False)
+    monkeypatch.setattr(galgame_dxcam_support.shutil, "which", lambda name: None)
+
+    with pytest.raises(RuntimeError, match="Python 3.9\\+"):
+        galgame_dxcam_support._find_python_executable()
 
 
 def test_background_hash_excludes_bottom_dialogue_region() -> None:


### PR DESCRIPTION

  ## 变更说明

  修复打包后的 N.E.K.O 环境中，RapidOCR / DXcam 依赖安装错误使用 `sys.executable -m pip` 的问题。

  在用户环境里，`sys.executable` 可能指向 `projectneko_server.exe`，该 exe 不支持 `-m pip`，会导致依赖安装失败。本 PR 新增 Python 解释器发现逻辑，安装依赖前先定位真正可执行 `-m pip` 的 Python。

  ## 主要改动

  - 为 RapidOCR / DXcam 安装流程新增 `_find_python_executable()`
  - 查找顺序：
    - `sys._base_executable`
    - 程序同目录 `python.exe` / `python3.exe`
    - PyInstaller `_MEIPASS` 目录
    - 系统 PATH 中的 `python` / `python3`
  - RapidOCR 的 `pip --version`、`ensurepip`、`pip install` 改用发现到的 Python
  - DXcam 的 `pip install` 改用发现到的 Python
  - 找不到 Python 时抛出明确错误，提示安装 Python 3.9+
  - 增加打包 exe 场景和 pip 命令选择的单测

  ## 验证

  - `uv run python -m py_compile plugin\plugins\galgame_plugin\rapidocr_support.py plugin\plugins\galgame_plugin\dxcam_support.py plugin\tests\unit\plugins\test_galgame_ocr_reader.py`
  - `uv run python -m pytest plugin\tests\unit\plugins\test_galgame_ocr_reader.py`

  结果：`160 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了 Python 解释器的发现机制，提高了包管理工具安装的可靠性，特别是在特殊环境中的表现。
  * 增强了 pip 可用性检查，添加了备选方案以确保安装流程的稳健性。

* **测试**
  * 扩展了测试覆盖范围，新增 Python 路径发现和安装流程的相关测试用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->