### PR TITLE
统一禁用传统页面、React 聊天窗口和插件管理器中的装饰性图片拖拽

### DIFF
--- a/frontend/plugin-manager/src/assets/base.css
+++ b/frontend/plugin-manager/src/assets/base.css
@@ -87,3 +87,12 @@ body {
   -moz-osx-font-smoothing: grayscale;
   overflow: hidden;
 }
+
+img,
+svg {
+  -webkit-user-drag: none;
+  -khtml-user-drag: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}

--- a/frontend/plugin-manager/src/components/layout/AppLayout.vue
+++ b/frontend/plugin-manager/src/components/layout/AppLayout.vue
@@ -2,7 +2,7 @@
   <div class="app-root">
     <div class="window-titlebar">
       <div class="titlebar-left">
-        <img src="@/assets/paw.png" alt="" class="titlebar-paw" />
+        <img src="@/assets/paw.png" alt="" class="titlebar-paw" draggable="false" />
         <span class="titlebar-text">{{ t('app.titleSuffix') }}</span>
       </div>
       <button class="titlebar-close" :title="t('common.close')" @click="closeWindow">

--- a/frontend/plugin-manager/src/components/layout/Sidebar.vue
+++ b/frontend/plugin-manager/src/components/layout/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <nav class="sidebar">
     <div class="sidebar-brand">
-      <img src="@/assets/neko-logo.png" alt="N.E.K.O" class="sidebar-brand__logo" />
+      <img src="@/assets/neko-logo.png" alt="N.E.K.O" class="sidebar-brand__logo" draggable="false" />
       <span class="sidebar-brand__text">N.E.K.O</span>
     </div>
     <div class="sidebar-nav">

--- a/frontend/plugin-manager/src/main.ts
+++ b/frontend/plugin-manager/src/main.ts
@@ -27,6 +27,43 @@ import { initPluginDashboardYuiGuideRuntime } from './yui-guide-runtime'
 initDarkMode()
 initPluginDashboardYuiGuideRuntime()
 
+function initDecorativeImageDragGuard() {
+  const markImage = (img: HTMLImageElement) => {
+    img.draggable = false
+    img.setAttribute('draggable', 'false')
+  }
+
+  const markImages = (root: ParentNode | HTMLImageElement = document) => {
+    if (root instanceof HTMLImageElement) {
+      markImage(root)
+      return
+    }
+    root.querySelectorAll<HTMLImageElement>('img').forEach(markImage)
+  }
+
+  const handleDragStart = (event: DragEvent) => {
+    if (event.target instanceof HTMLImageElement) {
+      event.preventDefault()
+    }
+  }
+
+  markImages(document)
+  document.addEventListener('dragstart', handleDragStart, true)
+
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (node instanceof Element) {
+          markImages(node)
+        }
+      })
+    })
+  })
+  observer.observe(document.documentElement, { childList: true, subtree: true })
+}
+
+initDecorativeImageDragGuard()
+
 console.log('🚀 Starting N.E.K.O Plugin Management System...')
 
 const app = createApp(App)

--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -730,6 +730,47 @@ export default function App({
       clearActiveCursorToolSelection();
     }
   }, [_toolCursorResetKey, clearActiveCursorToolSelection]);
+
+  useEffect(() => {
+    const markImage = (img: HTMLImageElement) => {
+      img.draggable = false;
+      img.setAttribute('draggable', 'false');
+    };
+
+    const markImages = (root: ParentNode | HTMLImageElement = document) => {
+      if (root instanceof HTMLImageElement) {
+        markImage(root);
+        return;
+      }
+      root.querySelectorAll?.<HTMLImageElement>('img').forEach(markImage);
+    };
+
+    const handleDragStart = (event: DragEvent) => {
+      if (event.target instanceof HTMLImageElement) {
+        event.preventDefault();
+      }
+    };
+
+    markImages(document);
+    document.addEventListener('dragstart', handleDragStart, true);
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof Element) {
+            markImages(node);
+          }
+        });
+      });
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener('dragstart', handleDragStart, true);
+    };
+  }, []);
+
   const resolvedImportImageAriaLabel = importImageButtonAriaLabel || importImageButtonLabel;
   const resolvedScreenshotAriaLabel = screenshotButtonAriaLabel || screenshotButtonLabel;
   const resolvedTranslateAriaLabel = translateButtonAriaLabel || translateButtonLabel;

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -54,6 +54,15 @@ button * {
   user-select: none;
 }
 
+img,
+svg {
+  -webkit-user-drag: none;
+  -khtml-user-drag: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 .app-shell {
   width: 100%;
   height: 100%;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -36,3 +36,11 @@ button img,
     -webkit-user-drag: none;
     user-select: none;
 }
+
+img,
+svg,
+[aria-hidden="true"] img {
+    -webkit-user-drag: none;
+    -khtml-user-drag: none;
+    user-select: none;
+}

--- a/static/i18n-i18next.js
+++ b/static/i18n-i18next.js
@@ -32,6 +32,53 @@
     // 更新语言包内容时可以递增此值
     const LOCALE_VERSION = '2026-05-03-1';
 
+    function initDecorativeImageDragGuard() {
+        const markImage = (img) => {
+            if (!(img instanceof HTMLImageElement)) return;
+            img.draggable = false;
+            img.setAttribute('draggable', 'false');
+        };
+
+        const markImages = (root = document) => {
+            if (root instanceof HTMLImageElement) {
+                markImage(root);
+                return;
+            }
+            if (!root.querySelectorAll) return;
+            root.querySelectorAll('img').forEach(markImage);
+        };
+
+        const start = () => {
+            markImages(document);
+
+            document.addEventListener('dragstart', (event) => {
+                const target = event.target;
+                if (target instanceof HTMLImageElement) {
+                    event.preventDefault();
+                }
+            }, true);
+
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    mutation.addedNodes.forEach((node) => {
+                        if (node instanceof Element) {
+                            markImages(node);
+                        }
+                    });
+                });
+            });
+            observer.observe(document.documentElement, { childList: true, subtree: true });
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', start, { once: true });
+        } else {
+            start();
+        }
+    }
+
+    initDecorativeImageDragGuard();
+
     function getLanguageFromQuery() {
         try {
             const params = new URLSearchParams(window.location.search || '');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本发布说明

* **Bug 修复**
  * 修复了应用程序中图片被意外拖动的问题
  * 在所有应用和静态页面中统一禁用了图片及 SVG 元素的拖动和文本选择功能
  * 确保新加载的图片元素也受到拖动限制

* **改进**
  * 为多语言资源添加了缓存版本控制支持

<!-- end of auto-generated comment: release notes by coderabbit.ai -->