### PR TITLE
fix(multi-window): session_started 直接 hide 文本框，覆盖 chat.html 子窗口

### DIFF
--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1745,6 +1745,34 @@
                 } else if (response.type === 'session_started') {
                     console.log(window.t('console.sessionStartedReceived'), response.input_mode);
                     S.isTextSessionActive = response.input_mode === 'text';
+
+                    // Multi-window 文本框对偶 hide：每个 webview（index.html 主窗口、
+                    // chat.html 子窗口）都通过自己的 ws 收到 session_started，借此
+                    // 各自 hide 自己的 #text-input-area，不依赖
+                    // startMicCapture/syncVoiceChatComposerHidden 的 BroadcastChannel
+                    // 链路。原来 hide 只挂在主窗口 startMicCapture 上：
+                    //   - chat.html 子窗口无麦按钮永不调 startMicCapture
+                    //   - reload 后某些 audio session 启动路径不走 startMicCapture
+                    //   - BroadcastChannel 在 reload init 时序窗口里错过事件
+                    // 都会让子窗口的 #text-input-area 始终可见可输入，用户在
+                    // audio session 中打字 → 后端 start_session(text) → 撕重建
+                    // → 撞 PR #1176 修的 race（"neko 已离开"）。本路径与下方
+                    // session_ended_by_server 1844-1846 的 unhide 对偶，移动端
+                    // 维持原来"不 hide"设计（UI 上手机屏小希望保留文本框可见）。
+                    var _tiaStarted = document.getElementById('text-input-area');
+                    if (_tiaStarted) {
+                        if (response.input_mode === 'text') {
+                            _tiaStarted.classList.remove('hidden');
+                        } else if (!window.appUtils || !window.appUtils.isMobile()) {
+                            _tiaStarted.classList.add('hidden');
+                        }
+                    }
+                    if (typeof window.syncVoiceChatComposerHidden === 'function') {
+                        var _shouldHide = response.input_mode !== 'text'
+                            && (!window.appUtils || !window.appUtils.isMobile());
+                        window.syncVoiceChatComposerHidden(_shouldHide);
+                    }
+
                     setTimeout(function () {
                         if (typeof window.hideVoicePreparingToast === 'function') window.hideVoicePreparingToast();
                         if (S.sessionStartedResolver) {


### PR DESCRIPTION
## 修了什么

PR #1176 修了「audio session 中文本输入触发的 rebuild race」的**服务端**——但**触发路径**仍裸露：chat.html 子窗口（Electron 多窗口分发）的文本框在 audio session 进行中始终**可见可输入**，用户打字直接撞过去。本 PR 在前端把这条触发路径堵死。

## 根因（多窗口 DOM 隔离）

- 文本框 hide 逻辑只挂在 \`startMicCapture\`/\`stopMicCapture\` 上（[app-audio-capture.js:894-901](static/app-audio-capture.js#L894), [app-buttons.js:1093-1097](static/app-buttons.js#L1093)）
- chat.html 子窗口 UI 没麦按钮（[templates/chat.html:581-601](templates/chat.html#L581) 只有 textarea + send + screenshot），永不调 \`startMicCapture\`，自己的 \`#text-input-area\` 从未被 hide
- \`syncVoiceChatComposerHidden\` 虽然 broadcast 跨窗口（[app-interpage.js:1340-1348](static/app-interpage.js#L1340) → [1481-1497](static/app-interpage.js#L1481)），但仍依赖**主窗口先调一次**。Reload 后 BroadcastChannel init 时序、或某些不走 \`startMicCapture\` 的 audio 启动路径，会让 broadcast 根本没发出
- 结果：chat.html 子窗口（react composer + 兜底 \`#text-input-area\`）在 audio session 中可输入 → 用户敲字 → 后端 \`start_session(text)\` → 撕 audio session 重建 → 撞 PR #1176 修的 race（最坏"neko 已离开"+输入丢失）

## 改动

把 hide/unhide 直接挂在 ws \`session_started\` handler 上（[app-websocket.js:1749-1774](static/app-websocket.js#L1749)）——每个 webview 通过自己的 ws 都会收到这个消息（chat.html 的 ws 通过 preload WSProxy 转发到 Pet 真 ws），各自独立同步 \`#text-input-area\` + React composer。

与 [1844-1846](static/app-websocket.js#L1844) \`session_ended_by_server\` 已有的 unhide 对偶；[1797-1799](static/app-websocket.js#L1797) \`session_failed\` fallback 也已有 unhide，无需改动。

\`\`\`js
// session_started handler 1747 后加
var _tiaStarted = document.getElementById('text-input-area');
if (_tiaStarted) {
    if (response.input_mode === 'text') {
        _tiaStarted.classList.remove('hidden');
    } else if (!window.appUtils || !window.appUtils.isMobile()) {
        _tiaStarted.classList.add('hidden');
    }
}
if (typeof window.syncVoiceChatComposerHidden === 'function') {
    var _shouldHide = response.input_mode !== 'text'
        && (!window.appUtils || !window.appUtils.isMobile());
    window.syncVoiceChatComposerHidden(_shouldHide);
}
\`\`\`

整体 +28 行，无逻辑路径改动，只在 ws 事件上加对偶 UI 同步。

## 设计决策

**移动端维持原设计**：\`!appUtils.isMobile()\` 守卫保留——手机屏小，UI 上故意保留文本框可见，本 PR 不动这条。如需手机端也禁，应该单独评估走 \`disabled\` 而不走 \`hidden\`（保持视觉一致性，仅阻止输入），跟桌面端的"藏起来"是不同决策。

## Test plan

- [ ] index.html 主窗口开 audio 会话 → 文本框 hide（与原行为一致）
- [ ] index.html 主窗口结束 audio 会话 → 文本框 unhide
- [ ] **核心**：打开 chat.html 子窗口，主窗口开 audio 会话 → chat.html 子窗口的 \`#text-input-area\` 同步 hide，React composer 也禁用
- [ ] **核心**：在 chat.html 子窗口里**不应该**还能打字发送（PR #1176 race 触发路径不再裸露）
- [ ] 切音色 reload 后再开 audio 会话 → 子窗口仍然正确 hide（覆盖 BroadcastChannel 时序漏掉的场景）
- [ ] 移动端 UA 访问主窗口 → 行为不变（文本框保留可见）
- [ ] 文本会话场景 → 文本框正常可见可输入（input_mode === 'text' 走 unhide 分支）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 增强了多窗口间的界面同步协调，优化了文本输入区域的显示管理
* 改进了各类会话模式下的界面布局表现和跨窗口状态同步

<!-- end of auto-generated comment: release notes by coderabbit.ai -->