### PR TITLE
fix(catgirl-switch): MMD rollback 重建 + VRM reserved path 解析

### DIFF
--- a/static/app-character.js
+++ b/static/app-character.js
@@ -138,6 +138,11 @@
         // 保存旧连接引用，finally 中确保关闭（防止 try 中途 throw 导致永久泄露）
         let _switchOldSocket = null;
         let _switchOldHeartbeat = null;
+        // MMD→非 MMD 切换时延后 dispose 旧 mmdManager 用的引用：
+        // 清理阶段无条件 dispose 会把旧 MMD 实例销毁，但失败回滚仅重启 Live2D ticker /
+        // VRM animation——MMD 没有恢复路径，从 MMD 切出去时任一步失败都留下空白模型区。
+        // 暂存到 commit 之后 dispose；rollback 时跳过 dispose + 重显容器/按钮。
+        let _mmdDeferredDispose = null;
 
         if (S.isSwitchingCatgirl) {
             console.log('[猫娘切换] 正在切换中，忽略本次请求');
@@ -565,11 +570,18 @@
                 }
 
                 // 清理 MMD UI 资源（浮动按钮、锁图标等）
-                // MMD→MMD 切换时需要完全销毁旧实例，避免状态残留导致的问题
+                // MMD→MMD 切换时需要完全销毁旧实例，避免新旧 GPU/物理 world 实例并存；
+                // MMD→非 MMD 切换时延后到 commit 之后销毁，让中途失败 rollback 还能让旧
+                // MMD 模型重新可见——否则用户看到空白模型区只能再切一次或刷新。
                 if (window.mmdManager && typeof window.mmdManager.dispose === 'function') {
-                    console.log('[猫娘切换] 完全销毁旧 MMD 管理器实例');
-                    window.mmdManager.dispose();
-                    window.mmdManager = null;
+                    if (effectiveModelType === 'mmd') {
+                        console.log('[猫娘切换] 完全销毁旧 MMD 管理器实例（MMD→MMD）');
+                        window.mmdManager.dispose();
+                        window.mmdManager = null;
+                    } else {
+                        _mmdDeferredDispose = window.mmdManager;
+                        console.log('[猫娘切换] 延后旧 MMD 实例 dispose 到 commit（MMD→', effectiveModelType, '）');
+                    }
                 }
                 if (effectiveModelType !== 'mmd') {
                     document.querySelectorAll('#mmd-floating-buttons, #mmd-lock-icon, #mmd-return-button-container')
@@ -1556,6 +1568,21 @@
             // newCatgirl，剩下的只是 unlockAchievement 等无关副作用 await。从这里开始 watchdog
             // 触发应识别为"已完成"跳过回滚（避免破坏成功状态）。
             switchHasCommitted = true;
+            // commit 之后再 dispose 延后保留的旧 MMD 实例（MMD→非 MMD 路径）。
+            // commit 前 dispose 会让中途失败的 rollback 没法恢复旧 MMD（容器没渲染 + 实例已销毁）。
+            if (_mmdDeferredDispose) {
+                try {
+                    if (typeof _mmdDeferredDispose.dispose === 'function') {
+                        _mmdDeferredDispose.dispose();
+                    }
+                } catch (disposeErr) {
+                    console.warn('[猫娘切换] 延后 dispose 旧 MMD 出错:', disposeErr);
+                }
+                if (window.mmdManager === _mmdDeferredDispose) {
+                    window.mmdManager = null;
+                }
+                _mmdDeferredDispose = null;
+            }
             showStatusToast(window.t ? window.t('app.switchedCatgirl', { name: newCatgirl }) : `已切换到 ${newCatgirl}`, 3000);
 
             // 【成就】解锁换肤成就
@@ -1653,6 +1680,29 @@
                         window.vrmManager.startAnimation();
                     }
                 } catch (_e) { /* ignore */ }
+                // MMD rollback 恢复：清理阶段为防 MMD→非 MMD 切换中途失败让模型区空白，
+                // 把旧 mmdManager.dispose 延后到了 commit 之后。这里 commit 没到，旧实例
+                // 还活着；恢复 mmd-container 可见性 + 浮动按钮，让用户看到旧模型而不是空白。
+                if (_mmdDeferredDispose && window.mmdManager === _mmdDeferredDispose) {
+                    try {
+                        const mmdContainer = document.getElementById('mmd-container');
+                        if (mmdContainer) {
+                            mmdContainer.style.removeProperty('display');
+                            mmdContainer.classList.remove('hidden');
+                        }
+                        const mmdCanvas = document.getElementById('mmd-canvas');
+                        if (mmdCanvas) {
+                            clearMMDCanvasLoadingSession(mmdCanvas);
+                        }
+                        if (typeof _mmdDeferredDispose.setupFloatingButtons === 'function') {
+                            _mmdDeferredDispose.setupFloatingButtons();
+                        }
+                    } catch (recoveryErr) {
+                        console.warn('[猫娘切换] MMD rollback 恢复出错:', recoveryErr);
+                    }
+                    // 旧实例继续作为 active mmdManager；不再 commit 时 dispose。
+                    _mmdDeferredDispose = null;
+                }
             }
         } finally {
             clearTimeout(switchWatchdogId);
@@ -1677,6 +1727,19 @@
                     clearInterval(_switchOldHeartbeat);
                 }
             } catch (_e) { /* ignore */ }
+
+            // 兜底 dispose 延后保留的旧 MMD 实例：commit 成功 / rollback 恢复 / 抢占退出
+            // 三条路径都已把 _mmdDeferredDispose 置 null。这里只剩残余 case：catch 进了
+            // stale 分支或 guard 没匹配（如 S.socket !== _switchOldSocket）——orphan 引用
+            // 既不是 active mmdManager 也不会被 commit 路径清理，dispose 释放 GPU 资源。
+            if (_mmdDeferredDispose && window.mmdManager !== _mmdDeferredDispose) {
+                try {
+                    if (typeof _mmdDeferredDispose.dispose === 'function') {
+                        _mmdDeferredDispose.dispose();
+                    }
+                } catch (_e) { /* ignore */ }
+                _mmdDeferredDispose = null;
+            }
 
             if (isCurrentAttempt) {
                 S.isSwitchingCatgirl = false;

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -173,6 +173,21 @@
             // 旧实例继续作为 active mmdManager；不再 commit 时 dispose。
             _mmdDeferredDispose = null;
         };
+        // dispose 延后保留的旧 MMD 实例，commit / finally 兜底 / watchdog 错配三个路径
+        // 都用这个 helper（避免 dispose 调用 + window.mmdManager null 化 + 引用清空的
+        // 三步散在多处出现数字后缀的代码重复）。
+        const _disposeDeferredMmd = () => {
+            if (!_mmdDeferredDispose) return;
+            try {
+                if (typeof _mmdDeferredDispose.dispose === 'function') {
+                    _mmdDeferredDispose.dispose();
+                }
+            } catch (_e) { /* ignore */ }
+            if (window.mmdManager === _mmdDeferredDispose) {
+                window.mmdManager = null;
+            }
+            _mmdDeferredDispose = null;
+        };
 
         if (S.isSwitchingCatgirl) {
             console.log('[猫娘切换] 正在切换中，忽略本次请求');
@@ -306,10 +321,18 @@
                             clearInterval(_switchOldHeartbeat);
                         }
                     } catch (_e) { /* ignore socket cleanup failures */ }
-                    // MMD UI 恢复：watchdog 卡死路径下旧 mmdManager 实例还活着但 mmd-container
-                    // 已在清理阶段被隐藏 + 浮动按钮被移除——不恢复的话 lanlan_config 已回滚但
-                    // 模型区仍空白，跟 catch rollback 那条路径同样症状。
-                    _restoreDeferredMmdUi();
+                    // MMD UI 处理：只在 socket 也回滚到旧 ws 时才显示旧 MMD（与 catch 路径
+                    // line ~1716 的 `S.socket === _switchOldSocket` guard 对偶）。新 ws 已抢占
+                    // S.socket 时显示旧 MMD 会跟后端会话错配（前端 lanlan_config 回滚到旧角色
+                    // 但 server 在和新角色通过新 ws 对话），dispose 旧实例既消除错配又避免 GPU
+                    // 泄漏。watchdog 后 async chain 苏醒进 catch 是 stale 路径，finally 的
+                    // isFailedNoRecovery 因 isCurrentAttempt=false 不触发——这里不显式 dispose
+                    // 就漏（与连接态正常 commit 后的 connected-replaced 边界 case 同源）。
+                    if (_switchOldSocket && S.socket === _switchOldSocket) {
+                        _restoreDeferredMmdUi();
+                    } else {
+                        _disposeDeferredMmd();
+                    }
                 }
                 // 收掉可能还挂着的 MMD loading overlay：watchdog 触发说明某 await 永挂，
                 // catch 永远不进，里面 stale 分支的 MMDLoadingOverlay.fail 永远不执行 →
@@ -1602,19 +1625,7 @@
             switchHasCommitted = true;
             // commit 之后再 dispose 延后保留的旧 MMD 实例（MMD→非 MMD 路径）。
             // commit 前 dispose 会让中途失败的 rollback 没法恢复旧 MMD（容器没渲染 + 实例已销毁）。
-            if (_mmdDeferredDispose) {
-                try {
-                    if (typeof _mmdDeferredDispose.dispose === 'function') {
-                        _mmdDeferredDispose.dispose();
-                    }
-                } catch (disposeErr) {
-                    console.warn('[猫娘切换] 延后 dispose 旧 MMD 出错:', disposeErr);
-                }
-                if (window.mmdManager === _mmdDeferredDispose) {
-                    window.mmdManager = null;
-                }
-                _mmdDeferredDispose = null;
-            }
+            _disposeDeferredMmd();
             showStatusToast(window.t ? window.t('app.switchedCatgirl', { name: newCatgirl }) : `已切换到 ${newCatgirl}`, 3000);
 
             // 【成就】解锁换肤成就
@@ -1761,15 +1772,7 @@
                 const isOrphan = window.mmdManager !== _mmdDeferredDispose;
                 const isFailedNoRecovery = isCurrentAttempt && !switchHasCommitted;
                 if (isOrphan || isFailedNoRecovery) {
-                    try {
-                        if (typeof _mmdDeferredDispose.dispose === 'function') {
-                            _mmdDeferredDispose.dispose();
-                        }
-                    } catch (_e) { /* ignore */ }
-                    if (window.mmdManager === _mmdDeferredDispose) {
-                        window.mmdManager = null;
-                    }
-                    _mmdDeferredDispose = null;
+                    _disposeDeferredMmd();
                 }
             }
 

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -715,7 +715,18 @@
             // socket 关掉、lanlan_name 覆盖回老目标、用老 lanlan_name 重连。
             throwIfStale();
             if (S.socket) S.socket.close();
-            if (S.heartbeatInterval) clearInterval(S.heartbeatInterval);
+            // 不在这里 clear 旧 heartbeat：新 connectWebSocket onopen（app-websocket.js
+            // line 594-602）会自己 clearInterval + 重建。中途 close 完老 ws 还没等到新
+            // onopen 这段窗口里，老 heartbeat 的 callback 已 fail-safe 检查
+            // `S.socket && readyState === OPEN`，老 ws CLOSING / 新 ws CONNECTING / null
+            // 期间都直接跳过，无害。
+            // 关键：rollback 路径上（catch line ~1645 / watchdog line ~301 把 S.socket 从
+            // null 恢复回 _switchOldSocket）老 heartbeat 必须仍活着，否则即便 socket 塞
+            // 回去也没有保活，连接很快被 server idle timeout 关掉、用户失败切角色后看到
+            // 莫名断线重连——pre-existing 自 PR #1167 引入 socket rollback 但漏了 heartbeat
+            // 重启的这一脉。finally line ~1762 的 `S.heartbeatInterval !== _switchOldHeartbeat`
+            // 已正确区分"成功路径 onopen 替换了 heartbeat → 关老的"和"失败路径 onopen 没
+            // 跑过 → 不动"，所以删掉这里的提前 clear 不会引入 success-path 残留。
 
             window.lanlan_config.lanlan_name = newCatgirl;
 

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -347,12 +347,18 @@
                 if (!s || lower === 'undefined' || lower === 'null') return '';
                 return s;
             };
-            // mmdPath/vrmPath 提前在 live3d 分支统一计算，subType 已知和 subType 缺失两条
-            // 路径都用同一份净化后的路径来源（顶层 + _reserved），让下游 VRM/MMD 加载分支
-            // 直接复用——避免 VRM 分支自己重新解析时只看顶层 catgirlConfig.vrm 漏掉规范化
-            // live3d+vrm 卡的 _reserved.avatar.vrm.model_path（参见 VRM 分支注释）。
-            let mmdPath = '';
-            let vrmPath = '';
+            // mmdPath/vrmPath 在所有 modelType 路径上统一计算（不只 live3d），让下游 VRM/MMD
+            // 加载分支可以直接复用一份已 _sanitize 的路径来源（顶层 + _reserved）：
+            // - 规范化的 live3d+vrm/mmd 卡：权威路径在 _reserved.avatar.{vrm,mmd}.model_path
+            // - legacy 卡（model_type='vrm'，无 live3d_sub_type）：路径在顶层 catgirlConfig.vrm
+            // 之前只在 live3d 分支算 vrmPath，legacy VRM 卡走 VRM 分支时 vrmPath='' 让真实
+            // 模型路径被吃掉静默 fallback 默认模型，回归 PR 之前的行为，bug 由 review 抓出。
+            const mmdPath = _sanitize(catgirlConfig.mmd)
+                || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
+                || '';
+            const vrmPath = _sanitize(catgirlConfig.vrm)
+                || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
+                || '';
             let effectiveModelType = modelType;
             if (modelType === 'live3d') {
                 const subType = (
@@ -360,13 +366,6 @@
                     || catgirlConfig.live3d_sub_type
                     || ''
                 ).toString().trim().toLowerCase();
-
-                mmdPath = _sanitize(catgirlConfig.mmd)
-                    || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
-                    || '';
-                vrmPath = _sanitize(catgirlConfig.vrm)
-                    || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
-                    || '';
 
                 if (subType === 'vrm') {
                     effectiveModelType = 'vrm';
@@ -681,13 +680,14 @@
                 // 加载 VRM 模型（currentSwitchId 在 try 顶部已无条件刷过，VRM 分支直接复用）
                 console.log('[猫娘切换] 进入VRM加载分支');
 
-                // VRM 模型路径解析：优先用前面 subType 探测时算好的 vrmPath（已 _sanitize，
-                // 涵盖 _reserved.avatar.vrm.model_path 和顶层 catgirlConfig.vrm，与 MMD 分支
-                // line 1098 `mmdModelPath = mmdPath || catgirlConfig.mmd || _reserved...` 对偶）。
-                // 不再单独检查 catgirlConfig.vrm 字段——规范化为 live3d+vrm 子类型的角色卡
-                // 没有顶层 vrm 字段（其权威来源是 _reserved.avatar.vrm.model_path），原本只看
-                // 顶层会把它误判成"未配置"，触发 fallback 默认模型 + auto-repair PUT 写
-                // model_type='vrm' + 顶层 vrm 字段把规范化卡反向反规范化、污染后端配置。
+                // VRM 模型路径解析：复用前面已 _sanitize 的 vrmPath（涵盖 _reserved.avatar
+                // .vrm.model_path 和顶层 catgirlConfig.vrm 两条来源，无论 modelType=='live3d'
+                // 还是 legacy 'vrm' 都会被填充），与 MMD 分支 `mmdModelPath = mmdPath || ...`
+                // 对偶。
+                // 不再在 VRM 分支自己重新解析顶层 catgirlConfig.vrm——规范化为 live3d+vrm
+                // 子类型的角色卡没有顶层 vrm 字段（其权威来源是 _reserved.avatar.vrm.model_path），
+                // 原本只看顶层会把它误判成"未配置"，触发 fallback 默认模型 + auto-repair PUT
+                // 写 model_type='vrm' + 顶层 vrm 字段把规范化卡反向反规范化、污染后端配置。
                 let vrmModelPath = vrmPath || '';
 
                 // 仅 legacy（catgirlConfig.model_type === 'vrm'）格式参与 auto-repair：规范化
@@ -1680,7 +1680,11 @@
                 } catch (_e) { /* ignore */ }
                 // MMD rollback 恢复：清理阶段为防 MMD→非 MMD 切换中途失败让模型区空白，
                 // 把旧 mmdManager.dispose 延后到了 commit 之后。这里 commit 没到，旧实例
-                // 还活着；恢复 mmd-container 可见性 + 浮动按钮，让用户看到旧模型而不是空白。
+                // 还活着；恢复 mmd-container + canvas 可见性 + 浮动按钮，让用户看到旧模型
+                // 而不是空白。注意 canvas 这里要显式恢复 visibility/display/pointerEvents
+                // 而非用 clearMMDCanvasLoadingSession——后者只清 dataset 但反过来把 canvas
+                // 设成 visibility:hidden + pointerEvents:none（line 117-119），会立刻把刚
+                // 恢复的容器再藏回去，rollback 等于没做。
                 if (_mmdDeferredDispose && window.mmdManager === _mmdDeferredDispose) {
                     try {
                         const mmdContainer = document.getElementById('mmd-container');
@@ -1690,7 +1694,10 @@
                         }
                         const mmdCanvas = document.getElementById('mmd-canvas');
                         if (mmdCanvas) {
-                            clearMMDCanvasLoadingSession(mmdCanvas);
+                            delete mmdCanvas.dataset.mmdLoadingSessionId;
+                            mmdCanvas.style.display = 'block';
+                            mmdCanvas.style.visibility = 'visible';
+                            mmdCanvas.style.pointerEvents = 'auto';
                         }
                         if (typeof _mmdDeferredDispose.setupFloatingButtons === 'function') {
                             _mmdDeferredDispose.setupFloatingButtons();

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -1742,17 +1742,35 @@
                 }
             } catch (_e) { /* ignore */ }
 
-            // 兜底 dispose 延后保留的旧 MMD 实例：commit 成功 / rollback 恢复 / 抢占退出
-            // 三条路径都已把 _mmdDeferredDispose 置 null。这里只剩残余 case：catch 进了
-            // stale 分支或 guard 没匹配（如 S.socket !== _switchOldSocket）——orphan 引用
-            // 既不是 active mmdManager 也不会被 commit 路径清理，dispose 释放 GPU 资源。
-            if (_mmdDeferredDispose && window.mmdManager !== _mmdDeferredDispose) {
-                try {
-                    if (typeof _mmdDeferredDispose.dispose === 'function') {
-                        _mmdDeferredDispose.dispose();
+            // 兜底 dispose 延后保留的旧 MMD 实例。commit 成功 / rollback 恢复 / 抢占
+            // 退出三条路径都已把 _mmdDeferredDispose 置 null。残余 case 需要分类处理：
+            //
+            // - **orphan**：stale 退出且新 attempt 已替换 mmdManager
+            //   （window.mmdManager !== ours）——必须 dispose 释放 GPU。
+            // - **failed-no-recovery**：catch 进了非 stale 分支但 socket guard 没匹配
+            //   （`S.socket !== _switchOldSocket`，常见于 connectWebSocket 已替换 S.socket
+            //   后再发生的 model load 失败），rollback helper 没被调用。这条路径上
+            //   isCurrentAttempt && !switchHasCommitted 同时成立、window.mmdManager 仍是
+            //   旧实例——只用 orphan 检查会漏掉，让旧 MMD 永远活着 + 容器隐藏，泄漏 GPU
+            //   memory（Codex P2 抓出来的回归）。这条路径 dispose 而不重显容器，保持
+            //   pre-PR 在此边界 case 的"空白但无泄漏"语义，与 L2D/VRM 在同一 guard 下
+            //   不重启 ticker/animation 的行为对偶。
+            // - **shared with new attempt**：stale 但新 attempt 也持有同一引用——orphan
+            //   检查命中 false 跳过，留给新 attempt 处理，避免双 dispose。
+            if (_mmdDeferredDispose) {
+                const isOrphan = window.mmdManager !== _mmdDeferredDispose;
+                const isFailedNoRecovery = isCurrentAttempt && !switchHasCommitted;
+                if (isOrphan || isFailedNoRecovery) {
+                    try {
+                        if (typeof _mmdDeferredDispose.dispose === 'function') {
+                            _mmdDeferredDispose.dispose();
+                        }
+                    } catch (_e) { /* ignore */ }
+                    if (window.mmdManager === _mmdDeferredDispose) {
+                        window.mmdManager = null;
                     }
-                } catch (_e) { /* ignore */ }
-                _mmdDeferredDispose = null;
+                    _mmdDeferredDispose = null;
+                }
             }
 
             if (isCurrentAttempt) {

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -143,6 +143,36 @@
         // VRM animation——MMD 没有恢复路径，从 MMD 切出去时任一步失败都留下空白模型区。
         // 暂存到 commit 之后 dispose；rollback 时跳过 dispose + 重显容器/按钮。
         let _mmdDeferredDispose = null;
+        // 恢复延后保留的旧 MMD 实例可见性 + UI（catch rollback / watchdog 超时两条路径
+        // 都要走这套逻辑）。canvas 显式 display/visibility/pointerEvents 而非用 helper：
+        // clearMMDCanvasLoadingSession 实际是"退役 canvas"，会再次设 visibility:hidden +
+        // pointerEvents:none（line 117-119），把刚显式恢复的 mmd-container 又藏回去。
+        // restoreMMDCanvasForLoadingSession 有 sessionId 门闩匹配，rollback 时无 token，
+        // 也用不上。所以这里直接内联恢复逻辑。
+        const _restoreDeferredMmdUi = () => {
+            if (!_mmdDeferredDispose || window.mmdManager !== _mmdDeferredDispose) return;
+            try {
+                const mmdContainer = document.getElementById('mmd-container');
+                if (mmdContainer) {
+                    mmdContainer.style.removeProperty('display');
+                    mmdContainer.classList.remove('hidden');
+                }
+                const mmdCanvas = document.getElementById('mmd-canvas');
+                if (mmdCanvas) {
+                    delete mmdCanvas.dataset.mmdLoadingSessionId;
+                    mmdCanvas.style.display = 'block';
+                    mmdCanvas.style.visibility = 'visible';
+                    mmdCanvas.style.pointerEvents = 'auto';
+                }
+                if (typeof _mmdDeferredDispose.setupFloatingButtons === 'function') {
+                    _mmdDeferredDispose.setupFloatingButtons();
+                }
+            } catch (recoveryErr) {
+                console.warn('[猫娘切换] MMD UI 恢复出错:', recoveryErr);
+            }
+            // 旧实例继续作为 active mmdManager；不再 commit 时 dispose。
+            _mmdDeferredDispose = null;
+        };
 
         if (S.isSwitchingCatgirl) {
             console.log('[猫娘切换] 正在切换中，忽略本次请求');
@@ -276,6 +306,10 @@
                             clearInterval(_switchOldHeartbeat);
                         }
                     } catch (_e) { /* ignore socket cleanup failures */ }
+                    // MMD UI 恢复：watchdog 卡死路径下旧 mmdManager 实例还活着但 mmd-container
+                    // 已在清理阶段被隐藏 + 浮动按钮被移除——不恢复的话 lanlan_config 已回滚但
+                    // 模型区仍空白，跟 catch rollback 那条路径同样症状。
+                    _restoreDeferredMmdUi();
                 }
                 // 收掉可能还挂着的 MMD loading overlay：watchdog 触发说明某 await 永挂，
                 // catch 永远不进，里面 stale 分支的 MMDLoadingOverlay.fail 永远不执行 →
@@ -1680,34 +1714,9 @@
                 } catch (_e) { /* ignore */ }
                 // MMD rollback 恢复：清理阶段为防 MMD→非 MMD 切换中途失败让模型区空白，
                 // 把旧 mmdManager.dispose 延后到了 commit 之后。这里 commit 没到，旧实例
-                // 还活着；恢复 mmd-container + canvas 可见性 + 浮动按钮，让用户看到旧模型
-                // 而不是空白。注意 canvas 这里要显式恢复 visibility/display/pointerEvents
-                // 而非用 clearMMDCanvasLoadingSession——后者只清 dataset 但反过来把 canvas
-                // 设成 visibility:hidden + pointerEvents:none（line 117-119），会立刻把刚
-                // 恢复的容器再藏回去，rollback 等于没做。
-                if (_mmdDeferredDispose && window.mmdManager === _mmdDeferredDispose) {
-                    try {
-                        const mmdContainer = document.getElementById('mmd-container');
-                        if (mmdContainer) {
-                            mmdContainer.style.removeProperty('display');
-                            mmdContainer.classList.remove('hidden');
-                        }
-                        const mmdCanvas = document.getElementById('mmd-canvas');
-                        if (mmdCanvas) {
-                            delete mmdCanvas.dataset.mmdLoadingSessionId;
-                            mmdCanvas.style.display = 'block';
-                            mmdCanvas.style.visibility = 'visible';
-                            mmdCanvas.style.pointerEvents = 'auto';
-                        }
-                        if (typeof _mmdDeferredDispose.setupFloatingButtons === 'function') {
-                            _mmdDeferredDispose.setupFloatingButtons();
-                        }
-                    } catch (recoveryErr) {
-                        console.warn('[猫娘切换] MMD rollback 恢复出错:', recoveryErr);
-                    }
-                    // 旧实例继续作为 active mmdManager；不再 commit 时 dispose。
-                    _mmdDeferredDispose = null;
-                }
+                // 还活着；helper 恢复 mmd-container + canvas 可见性 + 浮动按钮，让用户看到
+                // 旧模型而不是空白（watchdog 超时分支也复用同一个 helper）。
+                _restoreDeferredMmdUi();
             }
         } finally {
             clearTimeout(switchWatchdogId);

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -347,6 +347,10 @@
                 if (!s || lower === 'undefined' || lower === 'null') return '';
                 return s;
             };
+            // mmdPath/vrmPath 提前在 live3d 分支统一计算，subType 已知和 subType 缺失两条
+            // 路径都用同一份净化后的路径来源（顶层 + _reserved），让下游 VRM/MMD 加载分支
+            // 直接复用——避免 VRM 分支自己重新解析时只看顶层 catgirlConfig.vrm 漏掉规范化
+            // live3d+vrm 卡的 _reserved.avatar.vrm.model_path（参见 VRM 分支注释）。
             let mmdPath = '';
             let vrmPath = '';
             let effectiveModelType = modelType;
@@ -357,18 +361,19 @@
                     || ''
                 ).toString().trim().toLowerCase();
 
+                mmdPath = _sanitize(catgirlConfig.mmd)
+                    || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
+                    || '';
+                vrmPath = _sanitize(catgirlConfig.vrm)
+                    || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
+                    || '';
+
                 if (subType === 'vrm') {
                     effectiveModelType = 'vrm';
                 } else if (subType === 'mmd') {
                     effectiveModelType = 'mmd';
                 } else {
-                    // sub_type 缺失时回退到路径探测
-                    mmdPath = _sanitize(catgirlConfig.mmd)
-                        || _sanitize(catgirlConfig._reserved?.avatar?.mmd?.model_path)
-                        || '';
-                    vrmPath = _sanitize(catgirlConfig.vrm)
-                        || _sanitize(catgirlConfig._reserved?.avatar?.vrm?.model_path)
-                        || '';
+                    // sub_type 缺失时根据路径探测
                     if (mmdPath && !vrmPath) {
                         effectiveModelType = 'mmd';
                     } else if (vrmPath) {
@@ -676,93 +681,86 @@
                 // 加载 VRM 模型（currentSwitchId 在 try 顶部已无条件刷过，VRM 分支直接复用）
                 console.log('[猫娘切换] 进入VRM加载分支');
 
-                // 安全获取 VRM 模型路径，处理各种边界情况
-                let vrmModelPath = null;
-                // 检查 vrm 字段是否存在且有效
-                const hasVrmField = catgirlConfig.hasOwnProperty('vrm');
-                const vrmValue = catgirlConfig.vrm;
+                // VRM 模型路径解析：优先用前面 subType 探测时算好的 vrmPath（已 _sanitize，
+                // 涵盖 _reserved.avatar.vrm.model_path 和顶层 catgirlConfig.vrm，与 MMD 分支
+                // line 1098 `mmdModelPath = mmdPath || catgirlConfig.mmd || _reserved...` 对偶）。
+                // 不再单独检查 catgirlConfig.vrm 字段——规范化为 live3d+vrm 子类型的角色卡
+                // 没有顶层 vrm 字段（其权威来源是 _reserved.avatar.vrm.model_path），原本只看
+                // 顶层会把它误判成"未配置"，触发 fallback 默认模型 + auto-repair PUT 写
+                // model_type='vrm' + 顶层 vrm 字段把规范化卡反向反规范化、污染后端配置。
+                let vrmModelPath = vrmPath || '';
 
-                // 检查 vrmValue 是否是有效的值（排除字符串 "undefined" 和 "null"）
+                // 仅 legacy（catgirlConfig.model_type === 'vrm'）格式参与 auto-repair：规范化
+                // live3d+vrm 卡走到 fallback 时不应触发 PUT，否则反向反规范化把 model_type
+                // 改回 'vrm'、写入顶层 vrm 字段，破坏 PR #510 后采用的 live3d 规范化格式。
+                const isLegacyVrmCard = catgirlConfig.model_type === 'vrm';
+                const hasVrmField = Object.prototype.hasOwnProperty.call(catgirlConfig, 'vrm');
+                const vrmValue = catgirlConfig.vrm;
+                // 检查顶层 vrm 字段是否是字符串 "undefined"/"null" 等无效字面值（仅用于决定
+                // 是否触发 auto-repair 警告/PUT，不影响 vrmModelPath 解析——后者已由前置
+                // _sanitize 处理）
                 let isVrmValueInvalid = false;
                 if (hasVrmField && vrmValue !== undefined && vrmValue !== null) {
-                    const rawValue = vrmValue;
-                    if (typeof rawValue === 'string') {
-                        const trimmed = rawValue.trim();
-                        const lowerTrimmed = trimmed.toLowerCase();
-                        // 检查是否是无效的字符串值（包括 "undefined", "null" 等）
-                        isVrmValueInvalid = trimmed === '' ||
-                            lowerTrimmed === 'undefined' ||
-                            lowerTrimmed === 'null' ||
-                            lowerTrimmed.includes('undefined') ||
-                            lowerTrimmed.includes('null');
-                        if (!isVrmValueInvalid) {
-                            vrmModelPath = trimmed;
-                        }
-                    } else {
-                        // 非字符串类型，转换为字符串后也要验证
-                        const strValue = String(rawValue);
-                        const lowerStr = strValue.toLowerCase();
-                        isVrmValueInvalid = lowerStr === 'undefined' || lowerStr === 'null' || lowerStr.includes('undefined');
-                        if (!isVrmValueInvalid) {
-                            vrmModelPath = strValue;
-                        }
-                    }
+                    const rawStr = typeof vrmValue === 'string' ? vrmValue : String(vrmValue);
+                    const trimmed = rawStr.trim();
+                    const lowerTrimmed = trimmed.toLowerCase();
+                    isVrmValueInvalid = trimmed === ''
+                        || lowerTrimmed === 'undefined'
+                        || lowerTrimmed === 'null'
+                        || lowerTrimmed.includes('undefined')
+                        || lowerTrimmed.includes('null');
                 }
 
-                // 如果路径无效，使用默认模型或抛出错误
+                // 如果路径仍无效，使用默认模型
                 if (!vrmModelPath) {
-                    // 如果配置中明确指定了 model_type 为 'vrm'，静默使用默认模型
-                    if (catgirlConfig.model_type === 'vrm') {
-                        vrmModelPath = '/static/vrm/sister1.0.vrm';
+                    // effectiveModelType === 'vrm' 才进入这一分支：legacy（model_type='vrm'）
+                    // 和规范化（live3d+vrm 子类型）两条路径都走默认模型 fallback。
+                    // 改用 effectiveModelType 而非 catgirlConfig.model_type：规范化卡 model_type
+                    // 是 'live3d'，原条件会让它走错误抛出分支拒载；现在统一 fallback 到默认。
+                    vrmModelPath = '/static/vrm/sister1.0.vrm';
 
-                        // 如果 vrmValue 是字符串 "undefined" 或 "null"，视为"未配置"，不显示警告
-                        // 只有在 vrm 字段存在且值不是字符串 "undefined"/"null" 时才显示警告
-                        if (hasVrmField && vrmValue !== undefined && vrmValue !== null && !isVrmValueInvalid) {
-                            // 这种情况不应该发生，因为 isVrmValueInvalid 为 false 时应该已经设置了 vrmModelPath
-                            const vrmValueStr = typeof vrmValue === 'string' ? `"${vrmValue}"` : String(vrmValue);
-                            console.warn(`[猫娘切换] VRM 模型路径无效 (${vrmValueStr})，使用默认模型`);
-                        } else {
-                            // vrmValue 是字符串 "undefined"、"null" 或未配置，视为正常情况，只显示 info
-                            console.info('[猫娘切换] VRM 模型路径未配置或无效，使用默认模型');
+                    if (hasVrmField && vrmValue !== undefined && vrmValue !== null && !isVrmValueInvalid) {
+                        // 走到这一分支说明顶层 vrm 字段值看起来合法但 _sanitize 没让它进 vrmPath
+                        // ——理论上不该发生，留着诊断
+                        const vrmValueStr = typeof vrmValue === 'string' ? `"${vrmValue}"` : String(vrmValue);
+                        console.warn(`[猫娘切换] VRM 模型路径无效 (${vrmValueStr})，使用默认模型`);
+                    } else {
+                        console.info('[猫娘切换] VRM 模型路径未配置或无效，使用默认模型');
 
-                            // 如果 vrmValue 是字符串 "undefined"，尝试自动修复后端配置
-                            if (hasVrmField && isVrmValueInvalid && typeof vrmValue === 'string') {
-                                try {
-                                    // VRM 自动修复 PUT 是对后端配置的持久化写入。如果切换在
-                                    // PUT/json 两个 await 之间被新 attempt 顶掉，旧 attempt 仍替
-                                    // 过期目标 newCatgirl 写后端默认 VRM 路径，污染后端配置。
-                                    // 在每个 await 后立刻 stale check，stale 时让 catch 走 stale
-                                    // 分支静默退出（catch 已加 isStaleSwitchAttempt rethrow 兜底）。
-                                    const fixResponse = await fetch(`/api/characters/catgirl/l2d/${encodeURIComponent(newCatgirl)}`, {
-                                        method: 'PUT',
-                                        headers: { 'Content-Type': 'application/json' },
-                                        body: JSON.stringify({
-                                            model_type: 'vrm',
-                                            vrm: vrmModelPath  // 使用默认模型路径
-                                        })
-                                    });
+                        // auto-repair：仅 legacy 卡 + 顶层 vrm 字段是 "undefined" 字面值时触发。
+                        // 规范化卡（live3d+vrm 子类型）跳过：PUT 写 model_type='vrm' + 顶层 vrm
+                        // 会反向反规范化，污染后端配置；规范化卡的权威来源是 _reserved.avatar.vrm
+                        // .model_path，正常路径下根本不该走到 fallback（vrmPath 已经覆盖）。
+                        if (isLegacyVrmCard && hasVrmField && isVrmValueInvalid && typeof vrmValue === 'string') {
+                            try {
+                                // VRM 自动修复 PUT 是对后端配置的持久化写入。如果切换在
+                                // PUT/json 两个 await 之间被新 attempt 顶掉，旧 attempt 仍替
+                                // 过期目标 newCatgirl 写后端默认 VRM 路径，污染后端配置。
+                                // 在每个 await 后立刻 stale check，stale 时让 catch 走 stale
+                                // 分支静默退出（catch 已加 isStaleSwitchAttempt rethrow 兜底）。
+                                const fixResponse = await fetch(`/api/characters/catgirl/l2d/${encodeURIComponent(newCatgirl)}`, {
+                                    method: 'PUT',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({
+                                        model_type: 'vrm',
+                                        vrm: vrmModelPath  // 使用默认模型路径
+                                    })
+                                });
+                                throwIfStale();
+                                if (fixResponse.ok) {
+                                    const fixResult = await fixResponse.json();
                                     throwIfStale();
-                                    if (fixResponse.ok) {
-                                        const fixResult = await fixResponse.json();
-                                        throwIfStale();
-                                        if (fixResult.success) {
-                                            console.log(`[猫娘切换] 已自动修复角色 ${newCatgirl} 的 VRM 模型路径配置（从 "undefined" 修复为默认模型）`);
-                                        }
+                                    if (fixResult.success) {
+                                        console.log(`[猫娘切换] 已自动修复角色 ${newCatgirl} 的 VRM 模型路径配置（从 "undefined" 修复为默认模型）`);
                                     }
-                                } catch (fixError) {
-                                    if (fixError?.isStaleSwitchAttempt) throw fixError;
-                                    console.warn('[猫娘切换] 自动修复配置时出错:', fixError);
                                 }
+                            } catch (fixError) {
+                                if (fixError?.isStaleSwitchAttempt) throw fixError;
+                                console.warn('[猫娘切换] 自动修复配置时出错:', fixError);
                             }
                         }
-                        console.info('[猫娘切换] 使用默认 VRM 模型:', vrmModelPath);
-                    } else {
-                        // model_type 不是 'vrm'，抛出错误
-                        const vrmValueStr = hasVrmField && vrmValue !== undefined && vrmValue !== null
-                            ? (typeof vrmValue === 'string' ? `"${vrmValue}"` : String(vrmValue))
-                            : '(未配置)';
-                        throw new Error(`VRM 模型路径无效: ${vrmValueStr}`);
                     }
+                    console.info('[猫娘切换] 使用默认 VRM 模型:', vrmModelPath);
                 }
 
                 // 确保 VRM 管理器已初始化


### PR DESCRIPTION
## Summary

修两个跟切角色相关的预存在 bug，是从 [PR #1167](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1167) review thread [#r3194622310](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1167#discussion_r3194622310) 挖出来的，但跟那 PR 主题（dedupe + attempt id 隔离）正交所以没顺手修。

两条独立 commit，可分别 review：

### Commit 1（MMD rollback 重建）

`handleCatgirlSwitch` 在切角色清理阶段会无条件 `window.mmdManager.dispose()` 把旧 MMD 实例销毁，但失败回滚段（catch 里 `S.socket === _switchOldSocket` 的 rollback 分支）只重启 Live2D ticker / VRM animationFrame——**MMD 没有恢复路径**。从一个 MMD 角色切到非 MMD 角色时只要后续任一步 fetch/loadModel 失败，`lanlan_config` 和 socket 会回滚到旧角色，但画面已经没有旧 MMD 模型，留下空白模型区。用户必须再切一次或刷新页面才能看到模型。

修法（reviewer 讨论里倾向方案 A，独立判断后采纳）：把 `mmdManager.dispose()` 推迟到 commit point（`switchHasCommitted = true` 之前）。
- **MMD→MMD** 路径保持原行为（comment 说明的"完全销毁旧实例避免新旧 GPU/物理 world 实例并存"约束）
- **MMD→非 MMD** 路径暂存到 `_mmdDeferredDispose`，commit 后才 dispose
- catch 的 rollback 段里重显 `mmd-container` + `setupFloatingButtons()` 让旧 MMD 重新可见（实例本来就还活着）
- finally 兜底：stale 分支等没走 commit / rollback 的残余路径下 orphan dispose 释放 GPU 资源

### Commit 2（VRM reserved path 解析）

VRM 加载分支原本只看顶层 `catgirlConfig.vrm` 决定 `vrmModelPath`，fallback 条件也只看 `catgirlConfig.model_type === 'vrm'`。对已经规范化成 `model_type: 'live3d'` + `live3d_sub_type: 'vrm'` 的角色卡（PR #510 后采用的规范化格式），权威路径在 `_reserved.avatar.vrm.model_path`，但 VRM 分支看不到，会把它误判成"未配置"——并且 `model_type !== 'vrm'` 让原 fallback 直接 throw 拒载。

副作用更糟：当顶层 `vrm` 字段恰好是字符串 `"undefined"` 时，auto-repair PUT 会写 `model_type='vrm'` + `vrm=defaultPath` 把规范化卡反向反规范化，**污染后端配置**。

修法（与 MMD 分支 `mmdModelPath = mmdPath || catgirlConfig.mmd || _reserved...` 对偶）：
1. live3d 子类型探测段把 `mmdPath`/`vrmPath` 提前到 subType 已知 / subType 缺失两条路径都计算
2. VRM 加载分支改用 `vrmModelPath = vrmPath || ''`，覆盖顶层和 `_reserved` 两个来源
3. Fallback 条件改为基于 `effectiveModelType`（含 live3d+vrm 子类型），删掉 throw 分支统一 fallback 到默认
4. Auto-repair PUT 加 `isLegacyVrmCard` 守护：仅 `catgirlConfig.model_type === 'vrm'` 的 legacy 卡参与，规范化卡跳过避免反规范化

## Test plan

- [x] `node --check static/app-character.js` 通过
- [x] `uv run pytest tests/frontend/test_character_card_manager_regressions.py` 8 通过 1 deselect（deselect 那条是 main 上预存在的 fail，与本 PR 无关）
- [x] `uv run pytest tests/frontend/test_chat_switch_reset.py` 2 通过（直接调 `handleCatgirlSwitch` 的回归测试）
- [x] `uv run pytest tests/frontend/test_mmd_loading_overlay.py` 1 通过
- [ ] 端到端手测：本仓库要 main_server + agent + memory 三套 + 角色数据 + Steam 才跑得起来，本机环境凑不齐，**未做端到端验证**。需要 reviewer / 用户在分发环境（Electron）下走一遍 MMD→VRM 失败路径 + live3d+vrm 规范化角色卡切换确认实际行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 切换角色时显示成功提示并尝试解锁相关成就（含防止陈旧切换重复解锁的保护）。
  * 在检测到损坏或异常的 VRM 模型路径时自动修复，并可将修复结果回写后端。

* **改进**
  * 统一并规范化模型路径处理，增强对 VRM/Live2D/MMD 的兼容性与回退支持。
  * 强化切换的提交/回滚与界面恢复流程，保留旧界面直到提交完成以避免空白屏。
  * 引入延迟旧资源释放与最终清理机制，防止显存泄漏并保证回滚时恢复旧界面。
  * 增加超时守护（45 秒级）与恢复逻辑，提升切换稳健性与故障恢复能力。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->