### PR TITLE
fix(tutorial): keep persona onboarding after auto start

### DIFF
--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -155,7 +155,9 @@
     }
 
     function isHomeTutorialSeen() {
-        return localStorage.getItem(getHomeTutorialStorageKey()) === 'true';
+        return getHomeTutorialStorageKeys().some(function (storageKey) {
+            return localStorage.getItem(storageKey) === 'true';
+        });
     }
 
     function isHomePage() {

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -97,14 +97,61 @@
         return 'heartbeat-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
     }
 
-    function getHomeTutorialStorageKey() {
+    function getHomeTutorialStorageKeys() {
+        const keys = [];
+        const manager = window.universalTutorialManager || null;
+        const addKey = function (value) {
+            const key = typeof value === 'string' ? value.trim() : '';
+            if (key && !keys.includes(key)) {
+                keys.push(key);
+            }
+        };
+
+        if (manager && typeof manager.getStorageKeysForPage === 'function') {
+            try {
+                const managerKeys = manager.getStorageKeysForPage('home');
+                if (Array.isArray(managerKeys)) {
+                    managerKeys.forEach(addKey);
+                }
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to read home tutorial storage keys:', error);
+            }
+        }
+        if (manager && typeof manager.getStorageKey === 'function' && manager.currentPage === 'home') {
+            try {
+                addKey(manager.getStorageKey());
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to read preferred home tutorial storage key:', error);
+            }
+        }
+        if (manager && typeof manager.getPreferredStoragePageKey === 'function'
+            && typeof window.getTutorialStorageKeyForPage === 'function') {
+            try {
+                addKey(window.getTutorialStorageKeyForPage(manager.getPreferredStoragePageKey('home')));
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to read versioned home tutorial storage key:', error);
+            }
+        }
         if (typeof window.getTutorialStorageKeyForPage === 'function') {
-            return window.getTutorialStorageKeyForPage('home');
+            addKey(window.getTutorialStorageKeyForPage('home'));
         }
-        if (window.universalTutorialManager && window.universalTutorialManager.STORAGE_KEY_PREFIX) {
-            return window.universalTutorialManager.STORAGE_KEY_PREFIX + 'home';
+        if (manager && manager.STORAGE_KEY_PREFIX) {
+            addKey(manager.STORAGE_KEY_PREFIX + 'home');
         }
-        return HOME_TUTORIAL_STORAGE_KEY_FALLBACK;
+        addKey(HOME_TUTORIAL_STORAGE_KEY_FALLBACK);
+
+        return keys;
+    }
+
+    function getHomeTutorialStorageKey() {
+        const keys = getHomeTutorialStorageKeys();
+        return keys.length ? keys[0] : HOME_TUTORIAL_STORAGE_KEY_FALLBACK;
+    }
+
+    function markHomeTutorialStorageSeen() {
+        getHomeTutorialStorageKeys().forEach(function (storageKey) {
+            localStorage.setItem(storageKey, 'true');
+        });
     }
 
     function isHomeTutorialSeen() {
@@ -200,6 +247,7 @@
             state.homeTutorialCompleted = true;
             state.tutorialRunToken = null;
             state.tutorialRunning = false;
+            markHomeTutorialStorageSeen();
         }
         if ((Number.isFinite(chatTurns) && chatTurns > 0) || (Number.isFinite(voiceSessions) && voiceSessions > 0)) {
             state.meaningfulActionTaken = true;

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -88,6 +88,7 @@
             this.openReason = 'onboarding';
             this.typewriterRunId = 0;
             this.typewriterTimer = null;
+            this.lastTutorialPromptState = null;
             this.bindTutorialLifecycleEvents();
         }
 
@@ -250,6 +251,7 @@
                     continue;
                 }
                 const status = this.normalizeTutorialPromptStatus(tutorialPromptState);
+                this.lastTutorialPromptState = tutorialPromptState;
                 if (this.isTutorialPromptSettled(tutorialPromptState)) {
                     return;
                 }
@@ -375,6 +377,10 @@
                     return;
                 }
                 if (!this.overlay || this.overlay.hidden) {
+                    return;
+                }
+                const source = String(event.detail.source || '').trim().toLowerCase();
+                if (source === 'auto' && this.isTutorialPromptSettled(this.lastTutorialPromptState)) {
                     return;
                 }
                 this.pendingResumeAfterTutorial = true;

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -425,6 +425,73 @@ def test_completed_home_tutorial_server_state_marks_all_home_storage_keys_seen(
 
 
 @pytest.mark.frontend
+def test_legacy_home_tutorial_storage_key_counts_as_seen(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        include_common_dialogs=True,
+        setup_js="""
+            window.__heartbeatBodies = [];
+            window.localStorage.setItem('neko_tutorial_home', 'true');
+            window.universalTutorialManager = {
+                currentPage: 'home',
+                isTutorialRunning: false,
+                getStorageKeysForPage: function(page) {
+                    return page === 'home'
+                        ? ['neko_tutorial_home_yui_v1', 'neko_tutorial_home']
+                        : [];
+                },
+                getStorageKey: function() {
+                    return 'neko_tutorial_home_yui_v1';
+                },
+                hasSeenTutorial: function() {
+                    return false;
+                },
+                logPromptFlow: function() {},
+                requestTutorialStart: async function() {
+                    return false;
+                },
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: true,
+                    prompt_reason: 'idle_timeout',
+                    prompt_token: 'legacy-seen-token',
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function("() => window.__heartbeatBodies.length > 0")
+
+    assert mock_page.evaluate("() => window.__heartbeatBodies[0].home_tutorial_completed") is True
+    expect(mock_page.locator(".modal-overlay")).to_have_count(0)
+
+
+@pytest.mark.frontend
 def test_tutorial_prompt_prefers_window_t_over_safe_t(
     mock_page: Page,
 ):

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -353,6 +353,78 @@ def test_home_prompt_queue_serializes_tutorial_and_autostart_prompts(
 
 
 @pytest.mark.frontend
+def test_completed_home_tutorial_server_state_marks_all_home_storage_keys_seen(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.universalTutorialManager = {
+                currentPage: 'home',
+                isTutorialRunning: false,
+                getStorageKeysForPage: function(page) {
+                    return page === 'home'
+                        ? ['neko_tutorial_home_yui_v1', 'neko_tutorial_home']
+                        : [];
+                },
+                hasSeenTutorial: function() {
+                    return false;
+                },
+                logPromptFlow: function() {},
+                requestTutorialStart: async function() {
+                    return false;
+                },
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: 'completed',
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => localStorage.getItem('neko_tutorial_home_yui_v1') === 'true'"
+    )
+
+    assert mock_page.evaluate(
+        """
+        () => ({
+            preferred: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacy: localStorage.getItem('neko_tutorial_home'),
+        })
+        """
+    ) == {
+        "preferred": "true",
+        "legacy": "true",
+    }
+
+
+@pytest.mark.frontend
 def test_tutorial_prompt_prefers_window_t_over_safe_t(
     mock_page: Page,
 ):

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -444,6 +444,47 @@ def test_onboarding_does_not_preempt_new_user_tutorial_prompt_flow(mock_page: Pa
 
 
 @pytest.mark.frontend
+def test_onboarding_ignores_stale_auto_home_tutorial_start_after_prompt_completed(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
 def test_onboarding_does_not_treat_tutorial_prompt_fetch_failure_as_settled(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -361,6 +361,29 @@ def test_manual_tutorial_started_route_persists_started_state(tutorial_prompt_cl
 
 
 @pytest.mark.unit
+def test_auto_tutorial_started_route_persists_started_state(tutorial_prompt_client):
+    client, config = tutorial_prompt_client
+
+    response = client.post("/api/tutorial-prompt/tutorial-started", json={
+        "page": "home",
+        "source": "auto",
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["ignored"] is False
+    assert body["state"]["status"] == "started"
+    assert body["tutorial_run_token"]
+
+    state = load_tutorial_prompt_state(config)
+    assert state["started_at"] > 0
+    assert state["manual_home_tutorial_viewed"] is True
+    assert state["active_tutorial_run_source"] == "auto"
+    assert state["active_tutorial_run_token"] == body["tutorial_run_token"]
+
+
+@pytest.mark.unit
 def test_prompt_tutorial_started_route_requires_valid_prompt_token(tutorial_prompt_client):
     client, config = tutorial_prompt_client
     heartbeat = client.post("/api/tutorial-prompt/heartbeat", json={

--- a/utils/tutorial_prompt_state.py
+++ b/utils/tutorial_prompt_state.py
@@ -66,6 +66,7 @@ VALID_USER_COHORTS = {
 }
 
 VALID_TUTORIAL_EVENT_SOURCES = {
+    "auto",
     "manual",
     "idle_prompt",
 }


### PR DESCRIPTION
## 修复内容

- 修复新用户教程结束后，初始人格选择弹层可能被陈旧的自动主页教程事件隐藏的问题
- 后端教程已完成时，同步标记新版和旧版主页教程 localStorage key，避免前端误判教程未完成
- 允许 tutorial lifecycle 接收 `auto` 来源，避免 `/api/tutorial-prompt/tutorial-started` 返回 invalid source

## 验证

- `uv run pytest tests/unit/test_tutorial_prompt_router.py tests/unit/test_tutorial_prompt_state.py -q`
  - 77 passed
- `uv run pytest tests/frontend/test_initial_personality_onboarding.py tests/frontend/test_home_prompt_flow.py -q`
  - 50 passed

## 手测

- 使用临时新用户目录启动项目
- 走新用户存储位置流程
- 打开主页教程并点击 Skip
- 初始人格选择正常出现 3 个选项
- 等待 15 秒后弹层仍保持显示，未再复现自动消失问题


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持“自动”来源的教程启动流程

* **改进**
  * 教程完成状态现在在多个本地存储键间同步持久化，检查逻辑覆盖所有相关键
  * 入门/个性化流程优化：避免已完成提示导致过时的自动恢复或遮挡用户操作

* **测试**
  * 新增前端与单元测试，验证教程完成标记、自动启动和入门保护行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->