### PR TITLE
fix(chat-export): 修复下载链接在预览窗口中的上下文问题，确保移动端浏览器正确处理图像下载

### DIFF
--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -1602,9 +1602,14 @@
         // silently drop for image-sized blobs (markdown sometimes slips
         // through). Place the anchor in the popup's realm so the download
         // inherits the same user-activation context as the tap.
-        var hostWindow = (state.previewWindow && !state.previewWindow.closed && state.previewWindow.document)
-            ? state.previewWindow
-            : window;
+        var hostWindow = window;
+        try {
+            if (state.previewWindow && !state.previewWindow.closed && state.previewWindow.document) {
+                hostWindow = state.previewWindow;
+            }
+        } catch (_) {
+            hostWindow = window;
+        }
         var hostDoc = hostWindow.document;
         var hostURL = hostWindow.URL || hostWindow.webkitURL || URL;
         var url = hostURL.createObjectURL(blob);

--- a/static/app-chat-export.js
+++ b/static/app-chat-export.js
@@ -1596,14 +1596,30 @@
         var blob = content instanceof Blob
             ? content
             : new Blob([content], { type: contentType });
-        var url = URL.createObjectURL(blob);
-        var link = document.createElement('a');
+        // The preview popup is the active tab when the user clicks Download.
+        // Anchoring the <a download> in the opener's document means the
+        // synthetic click fires from a backgrounded tab, which mobile browsers
+        // silently drop for image-sized blobs (markdown sometimes slips
+        // through). Place the anchor in the popup's realm so the download
+        // inherits the same user-activation context as the tap.
+        var hostWindow = (state.previewWindow && !state.previewWindow.closed && state.previewWindow.document)
+            ? state.previewWindow
+            : window;
+        var hostDoc = hostWindow.document;
+        var hostURL = hostWindow.URL || hostWindow.webkitURL || URL;
+        var url = hostURL.createObjectURL(blob);
+        var link = hostDoc.createElement('a');
         link.href = url;
         link.download = fileName;
-        document.body.appendChild(link);
+        link.rel = 'noopener';
+        link.style.position = 'fixed';
+        link.style.left = '-9999px';
+        (hostDoc.body || hostDoc.documentElement).appendChild(link);
         link.click();
         link.remove();
-        setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+        setTimeout(function () {
+            try { hostURL.revokeObjectURL(url); } catch (_) {}
+        }, 1000);
     }
 
     async function copyTextToClipboard(text) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 重构了导出文件的下载流程：在有预览窗时优先在该窗体触发下载、在目标文档中动态创建并触发隐藏链接、并在操作后安全撤销资源与清理节点，以提升预览窗口环境下的稳定性与可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->