### PR TITLE
perf(galgame): cap RapidOCR onnxruntime threads, skip warmup in tests

### DIFF
--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -30,10 +30,9 @@ DEFAULT_RAPIDOCR_OCR_VERSION = "PP-OCRv5"
 DEFAULT_RAPIDOCR_PIP_SPEC = "rapidocr_onnxruntime"
 DEFAULT_ONNXRUNTIME_PIP_SPEC = "onnxruntime"
 _INSTALL_STATE_NAME = "install_state.json"
-# RapidOCR builds 3 onnxruntime sessions (det/cls/rec); without a cap each
-# defaults to one intra-op worker per logical core, freezing the desktop on
-# many-core machines during every OCR pass.
-_RAPIDOCR_INFERENCE_THREAD_LIMIT = 2
+# RapidOCR builds 3 onnxruntime sessions (det/cls/rec); cap intra-op threads
+# so each inference burst doesn't saturate every logical core on the host.
+_RAPIDOCR_INFERENCE_THREAD_LIMIT = 4
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 _RAPIDOCR_IMPORT_CONTEXT_LOCK = threading.RLock()
 

--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -30,6 +30,10 @@ DEFAULT_RAPIDOCR_OCR_VERSION = "PP-OCRv5"
 DEFAULT_RAPIDOCR_PIP_SPEC = "rapidocr_onnxruntime"
 DEFAULT_ONNXRUNTIME_PIP_SPEC = "onnxruntime"
 _INSTALL_STATE_NAME = "install_state.json"
+# RapidOCR builds 3 onnxruntime sessions (det/cls/rec); without a cap each
+# defaults to one intra-op worker per logical core, freezing the desktop on
+# many-core machines during every OCR pass.
+_RAPIDOCR_INFERENCE_THREAD_LIMIT = 2
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 _RAPIDOCR_IMPORT_CONTEXT_LOCK = threading.RLock()
 
@@ -417,6 +421,34 @@ def _build_runtime_constructor_kwargs(
     return kwargs
 
 
+@contextmanager
+def _onnxruntime_intra_op_thread_cap(limit: int) -> Iterator[None]:
+    """Clamp default SessionOptions thread counts while RapidOCR builds its sessions."""
+    try:
+        import onnxruntime as _ort
+    except Exception:
+        yield
+        return
+    options_cls = getattr(_ort, "SessionOptions", None)
+    if options_cls is None:
+        yield
+        return
+    orig_init = options_cls.__init__
+
+    def _clamped_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        orig_init(self, *args, **kwargs)
+        if getattr(self, "intra_op_num_threads", 0) == 0:
+            self.intra_op_num_threads = limit
+        if getattr(self, "inter_op_num_threads", 0) == 0:
+            self.inter_op_num_threads = 1
+
+    options_cls.__init__ = _clamped_init
+    try:
+        yield
+    finally:
+        options_cls.__init__ = orig_init
+
+
 def load_rapidocr_runtime(
     *,
     install_target_dir_raw: str,
@@ -441,16 +473,17 @@ def load_rapidocr_runtime(
         runtime_class = getattr(module, "RapidOCR", None)
         if runtime_class is None:
             raise RuntimeError("RapidOCR runtime class not found")
-        runtime = runtime_class(
-            **_build_runtime_constructor_kwargs(
-                runtime_class,
-                engine_type=engine_type,
-                lang_type=lang_type,
-                model_type=model_type,
-                ocr_version=ocr_version,
-                model_cache_dir=model_cache_dir,
+        with _onnxruntime_intra_op_thread_cap(_RAPIDOCR_INFERENCE_THREAD_LIMIT):
+            runtime = runtime_class(
+                **_build_runtime_constructor_kwargs(
+                    runtime_class,
+                    engine_type=engine_type,
+                    lang_type=lang_type,
+                    model_type=model_type,
+                    ocr_version=ocr_version,
+                    model_cache_dir=model_cache_dir,
+                )
             )
-        )
     metadata = {
         "detected_path": str(Path(getattr(module, "__file__", "")).resolve().parent),
         "model_cache_dir": str(model_cache_dir),

--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -30,9 +30,8 @@ DEFAULT_RAPIDOCR_OCR_VERSION = "PP-OCRv5"
 DEFAULT_RAPIDOCR_PIP_SPEC = "rapidocr_onnxruntime"
 DEFAULT_ONNXRUNTIME_PIP_SPEC = "onnxruntime"
 _INSTALL_STATE_NAME = "install_state.json"
-# ~1/4 of logical cores, bounded 2..8: small hosts behave like ORT defaults,
-# big hosts don't over-thread (ORT inference gains plateau past ~8 threads).
-_RAPIDOCR_INFERENCE_THREAD_LIMIT = max(2, min(8, (os.cpu_count() or 4) // 4))
+# Leave one core free for the OS / interactive use; floor at 2 so 1-2 core hosts still parallelise.
+_RAPIDOCR_INFERENCE_THREAD_LIMIT = max(2, (os.cpu_count() or 2) - 1)
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 _RAPIDOCR_IMPORT_CONTEXT_LOCK = threading.RLock()
 
@@ -444,14 +443,11 @@ def _ensure_session_options_patch_installed() -> None:
 
         def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
             orig_init(self, *args, **kwargs)
-            cap = getattr(_SESSION_OPTIONS_PATCH_TLS, "cap", None)
-            if cap is None:
+            intra = getattr(_SESSION_OPTIONS_PATCH_TLS, "intra", None)
+            if intra is None:
                 return
-            intra, inter = cap
             if getattr(self, "intra_op_num_threads", 0) == 0:
                 self.intra_op_num_threads = intra
-            if getattr(self, "inter_op_num_threads", 0) == 0:
-                self.inter_op_num_threads = inter
 
         options_cls.__init__ = _patched_init
         _SESSION_OPTIONS_PATCH_INSTALLED = True
@@ -459,20 +455,20 @@ def _ensure_session_options_patch_installed() -> None:
 
 @contextmanager
 def _onnxruntime_intra_op_thread_cap(limit: int) -> Iterator[None]:
-    """Clamp SessionOptions thread counts on the calling thread only."""
+    """Clamp SessionOptions.intra_op_num_threads on the calling thread only."""
     _ensure_session_options_patch_installed()
-    prev = getattr(_SESSION_OPTIONS_PATCH_TLS, "cap", None)
-    _SESSION_OPTIONS_PATCH_TLS.cap = (limit, 1)
+    prev = getattr(_SESSION_OPTIONS_PATCH_TLS, "intra", None)
+    _SESSION_OPTIONS_PATCH_TLS.intra = limit
     try:
         yield
     finally:
         if prev is None:
             try:
-                del _SESSION_OPTIONS_PATCH_TLS.cap
+                del _SESSION_OPTIONS_PATCH_TLS.intra
             except AttributeError:
                 pass
         else:
-            _SESSION_OPTIONS_PATCH_TLS.cap = prev
+            _SESSION_OPTIONS_PATCH_TLS.intra = prev
 
 
 def load_rapidocr_runtime(

--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -30,9 +30,9 @@ DEFAULT_RAPIDOCR_OCR_VERSION = "PP-OCRv5"
 DEFAULT_RAPIDOCR_PIP_SPEC = "rapidocr_onnxruntime"
 DEFAULT_ONNXRUNTIME_PIP_SPEC = "onnxruntime"
 _INSTALL_STATE_NAME = "install_state.json"
-# RapidOCR builds 3 onnxruntime sessions (det/cls/rec); cap intra-op threads
-# so each inference burst doesn't saturate every logical core on the host.
-_RAPIDOCR_INFERENCE_THREAD_LIMIT = 4
+# ~1/4 of logical cores, bounded 2..8: small hosts behave like ORT defaults,
+# big hosts don't over-thread (ORT inference gains plateau past ~8 threads).
+_RAPIDOCR_INFERENCE_THREAD_LIMIT = max(2, min(8, (os.cpu_count() or 4) // 4))
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 _RAPIDOCR_IMPORT_CONTEXT_LOCK = threading.RLock()
 

--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -420,32 +420,59 @@ def _build_runtime_constructor_kwargs(
     return kwargs
 
 
+_SESSION_OPTIONS_PATCH_TLS = threading.local()
+_SESSION_OPTIONS_PATCH_LOCK = threading.Lock()
+_SESSION_OPTIONS_PATCH_INSTALLED = False
+
+
+def _ensure_session_options_patch_installed() -> None:
+    """Patch ort.SessionOptions.__init__ once; the patch only acts on threads that opted in."""
+    global _SESSION_OPTIONS_PATCH_INSTALLED
+    if _SESSION_OPTIONS_PATCH_INSTALLED:
+        return
+    with _SESSION_OPTIONS_PATCH_LOCK:
+        if _SESSION_OPTIONS_PATCH_INSTALLED:
+            return
+        try:
+            import onnxruntime as _ort
+        except Exception:
+            return
+        options_cls = getattr(_ort, "SessionOptions", None)
+        if options_cls is None:
+            return
+        orig_init = options_cls.__init__
+
+        def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+            orig_init(self, *args, **kwargs)
+            cap = getattr(_SESSION_OPTIONS_PATCH_TLS, "cap", None)
+            if cap is None:
+                return
+            intra, inter = cap
+            if getattr(self, "intra_op_num_threads", 0) == 0:
+                self.intra_op_num_threads = intra
+            if getattr(self, "inter_op_num_threads", 0) == 0:
+                self.inter_op_num_threads = inter
+
+        options_cls.__init__ = _patched_init
+        _SESSION_OPTIONS_PATCH_INSTALLED = True
+
+
 @contextmanager
 def _onnxruntime_intra_op_thread_cap(limit: int) -> Iterator[None]:
-    """Clamp default SessionOptions thread counts while RapidOCR builds its sessions."""
-    try:
-        import onnxruntime as _ort
-    except Exception:
-        yield
-        return
-    options_cls = getattr(_ort, "SessionOptions", None)
-    if options_cls is None:
-        yield
-        return
-    orig_init = options_cls.__init__
-
-    def _clamped_init(self: Any, *args: Any, **kwargs: Any) -> None:
-        orig_init(self, *args, **kwargs)
-        if getattr(self, "intra_op_num_threads", 0) == 0:
-            self.intra_op_num_threads = limit
-        if getattr(self, "inter_op_num_threads", 0) == 0:
-            self.inter_op_num_threads = 1
-
-    options_cls.__init__ = _clamped_init
+    """Clamp SessionOptions thread counts on the calling thread only."""
+    _ensure_session_options_patch_installed()
+    prev = getattr(_SESSION_OPTIONS_PATCH_TLS, "cap", None)
+    _SESSION_OPTIONS_PATCH_TLS.cap = (limit, 1)
     try:
         yield
     finally:
-        options_cls.__init__ = orig_init
+        if prev is None:
+            try:
+                del _SESSION_OPTIONS_PATCH_TLS.cap
+            except AttributeError:
+                pass
+        else:
+            _SESSION_OPTIONS_PATCH_TLS.cap = prev
 
 
 def load_rapidocr_runtime(

--- a/plugin/tests/conftest.py
+++ b/plugin/tests/conftest.py
@@ -35,6 +35,16 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture(autouse=True)
+def _disable_galgame_rapidocr_warmup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op RapidOcrBackend.warmup_async so tests don't oversubscribe cores via daemon ONNX threads."""
+    try:
+        from plugin.plugins.galgame_plugin.ocr_reader import RapidOcrBackend
+    except Exception:
+        return
+    monkeypatch.setattr(RapidOcrBackend, "warmup_async", lambda self, logger=None: None)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_runtime_overrides(monkeypatch: pytest.MonkeyPatch):
     """Redirect plugin runtime override persistence to an in-memory dict for tests.
 


### PR DESCRIPTION
## Summary
- **Production**: cap onnxruntime `intra_op_num_threads=2` / `inter_op_num_threads=1` while RapidOCR builds its 3 sessions (det/cls/rec) inside `load_rapidocr_runtime`. Default behaviour spawns one intra-op worker per logical core *per session* — a single OCR pass on a 20-core box momentarily pegs every core and noticeably degrades desktop responsiveness during play.
- **Tests**: add an autouse fixture in `plugin/tests/conftest.py` that no-ops `RapidOcrBackend.warmup_async`. Each `OcrReaderManager` construction otherwise schedules a daemon thread that imports RapidOCR and runs an ONNX inference; with 277+ galgame tests creating fresh managers, dozens of these run concurrently and oversubscribe every logical core, making the developer's machine unresponsive during `pytest`.
- The single test that explicitly exercises warmup wiring (`test_ocr_reader_manager_initializes_with_rapidocr_warmup_enabled`) already monkeypatches `warmup_async` itself, so it overrides the autouse no-op cleanly with no test changes needed.

## Test plan
- [x] `uv run python -m pytest plugin/tests/unit/plugins/test_galgame_ocr_reader.py -k "rapidocr or warmup or tesseract or backend or capture_worker or extract_text or load_runtime"` → 22 passed, 6 pre-existing failures (verified identical set on pristine branch — unrelated to this change).
- [x] `uv run python -m pytest plugin/tests/unit/plugins/test_galgame_bridge.py -k "scene_summary or pushes_context_summary or query_status or session_change"` → 20/20 passing in 0.7s.
- [ ] Manual: launch galgame plugin on a many-core machine, confirm OCR doesn't peg all cores during inference.

https://claude.ai/code/session_01GoPyB4P6hw9rM8p1vdcSjw

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoPyB4P6hw9rM8p1vdcSjw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 在运行时初始化阶段引入线程并发上限，限制 OCR 运行时构造时的线程使用，降低初始化期间的 CPU 过载风险，提升资源利用的稳定性与可预测性。

* **测试改进**
  * 在测试环境自动禁用 OCR 后台的预热并发行为，避免占用过多核心，提升测试运行的稳定性与可重复性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->