### PR TITLE
修复新手教程期间功能状态接管

### DIFF
--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -68,6 +68,19 @@
     let _proactiveLeaderHeartbeatTimer = null;
     let _wasLeaderLastTick = null; // 用于 leader 状态切换时主动 reschedule
 
+    function isHomeTutorialFeatureSuppressed() {
+        try {
+            const controller = window.NekoHomeTutorialFeatureController;
+            if (controller && typeof controller.isActive === 'function' && controller.isActive()) {
+                return true;
+            }
+            return typeof window.isNekoHomeTutorialInteractionLocked === 'function'
+                && window.isNekoHomeTutorialInteractionLocked() === true;
+        } catch (_) {
+            return false;
+        }
+    }
+
     try {
         if (typeof BroadcastChannel !== 'undefined' && PROACTIVE_SELF_RANK !== 99) {
             _proactiveLeaderChannel = new BroadcastChannel(PROACTIVE_LEADER_CHANNEL);
@@ -305,6 +318,10 @@
     mod._isUserRecentlySpeaking = _isUserRecentlySpeaking;
 
     function canTriggerProactively() {
+        if (isHomeTutorialFeatureSuppressed()) {
+            return false;
+        }
+
         // 「请她离开」状态下禁止一切主动搭话
         if (isGoodbyeActive()) {
             return false;
@@ -602,6 +619,11 @@
     async function triggerProactiveChat() {
         var requestSent = false;
         try {
+            if (isHomeTutorialFeatureSuppressed()) {
+                console.log('[ProactiveChat] 首页新手教程接管中，跳过主动搭话');
+                return false;
+            }
+
             // 主备协调：本窗口非 leader 时不触发，避免和 Pet 主窗口重复发请求。
             // 这里再 guard 一次是为了防止 leader 切换后旧定时器仍然触发。
             if (!isProactiveLeader()) {
@@ -1633,6 +1655,16 @@
         }
     }
     mod.releaseProactiveVisionStream = releaseProactiveVisionStream;
+
+    window.addEventListener('neko:home-tutorial-features-suppressed', function (event) {
+        var detail = event && event.detail ? event.detail : {};
+        if (detail.active === true) {
+            stopProactiveChatSchedule();
+            stopProactiveVisionDuringSpeech();
+        } else if (detail.active === false && S.proactiveChatEnabled && hasAnyChatModeEnabled()) {
+            scheduleProactiveChat();
+        }
+    });
 
     // ======================== backward-compat window exports ========================
 

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -1113,6 +1113,18 @@
         );
     }
 
+    function isHomeTutorialInteractionLocked() {
+        if (state.homeTutorialInteractionLocked || isHomeTutorialRunning()) {
+            return true;
+        }
+        try {
+            return typeof window.isNekoHomeTutorialInteractionLocked === 'function'
+                && window.isNekoHomeTutorialInteractionLocked() === true;
+        } catch (_) {
+            return false;
+        }
+    }
+
     function setGalgameModeTemporarilyDisabled(disabled) {
         var next = !!disabled;
         var changed = state.galgameTemporarilyDisabled !== next;
@@ -1131,7 +1143,7 @@
     function setGalgameModeEnabled(enabled, options) {
         var requestOptions = options || {};
         var next = !!enabled;
-        if (next && isGalgameModeTemporarilyDisabled()) {
+        if (next && !requestOptions.force && (isGalgameModeTemporarilyDisabled() || isHomeTutorialInteractionLocked())) {
             next = false;
         }
         var changed = state.galgameModeEnabled !== next;
@@ -1338,6 +1350,10 @@
     }
 
     function handleGalgameModeToggle() {
+        if (isHomeTutorialInteractionLocked()) {
+            setGalgameModeEnabled(false, { persist: false });
+            return;
+        }
         if (isGalgameModeTemporarilyDisabled()) {
             setGalgameModeEnabled(false, { persist: false });
             return;
@@ -1347,6 +1363,7 @@
     }
 
     function handleGalgameOptionSelect(option) {
+        if (isHomeTutorialInteractionLocked()) return;
         if (!option || typeof option.text !== 'string') return;
         var text = option.text.trim();
         if (!text) return;
@@ -1373,6 +1390,7 @@
     // 直接 callback；这里只是 BC 兜底）；source==='mini_game_invite' 走新逻辑。
 
     function handleChoiceSelect(option, source) {
+        if (isHomeTutorialInteractionLocked()) return;
         if (!option || typeof option.choice !== 'string') return;
         if (source === 'galgame') {
             // Forward to legacy galgame handler if it shows up here
@@ -1388,6 +1406,7 @@
     }
 
     function handleMiniGameInviteChoice(option) {
+        if (isHomeTutorialInteractionLocked()) return;
         var prompt = state.choicePrompt;
         if (!prompt || prompt.source !== 'mini_game_invite') return;
         var sessionId = prompt.sessionId || '';
@@ -2594,7 +2613,7 @@
         // from a storage namespace the barrier is about to remap.
         // setGalgameModeEnabled idempotently syncs state + body class + fires
         // the change event when the resolved pref differs from the safe default.
-        if (isHomeTutorialRunning()) {
+        if (isHomeTutorialInteractionLocked()) {
             setGalgameModeTemporarilyDisabled(true);
         } else {
             setGalgameModeEnabled(readGalgameModePreference(), { persist: false });

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -73,6 +73,15 @@
      * 用于定期备份和跨会话持久化
      */
     async function syncSettingsToServer() {
+        try {
+            const controller = window.NekoHomeTutorialFeatureController;
+            if (controller && typeof controller.isActive === 'function' && controller.isActive()) {
+                console.log('[app-settings] home tutorial suppression active, skip conversation settings sync');
+                return;
+            }
+        } catch (_) {
+            // keep settings sync best-effort if the tutorial controller is unavailable
+        }
         const settings = getConversationSettings();
         try {
             const response = await fetch('/api/config/conversation-settings', {

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -164,16 +164,28 @@
 
     function snapshotProactiveState() {
         const snapshot = {};
+        const appState = window.appState || null;
         HOME_TUTORIAL_PROACTIVE_KEYS.forEach(function (key) {
-            snapshot[key] = !!window[key];
+            if (typeof window[key] !== 'undefined') {
+                snapshot[key] = !!window[key];
+            } else if (appState && typeof appState[key] !== 'undefined') {
+                snapshot[key] = !!appState[key];
+            } else {
+                snapshot[key] = false;
+            }
         });
         return snapshot;
     }
 
     function applyProactiveState(values) {
+        const appState = window.appState || null;
         HOME_TUTORIAL_PROACTIVE_KEYS.forEach(function (key) {
             if (Object.prototype.hasOwnProperty.call(values, key)) {
-                window[key] = !!values[key];
+                const next = !!values[key];
+                window[key] = next;
+                if (appState && typeof appState[key] !== 'undefined') {
+                    appState[key] = next;
+                }
             }
         });
         if (typeof window.stopProactiveChatSchedule === 'function') {
@@ -1408,6 +1420,12 @@
             emitHomeTutorialLockIfChanged('tutorial-skipped');
         });
 
+        // Keep this recovery bridge paired with handlePromptAcceptance:
+        // its catch path clears state.tutorialStartRequested, calls
+        // emitHomeTutorialLockIfChanged('tutorial-start-failed'), and this
+        // listener then rolls back beginHomeTutorialFeatureSuppression via
+        // endHomeTutorialFeatureSuppression. Removing it would leave feature
+        // suppression active for the early 'tutorial-start-requested' lock.
         window.addEventListener('neko:home-tutorial-lock-changed', function (event) {
             const detail = event && event.detail ? event.detail : {};
             if (detail.locked === true && detail.reason === 'tutorial-start-requested') {

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -8,6 +8,7 @@
     const HEARTBEAT_ENDPOINT = '/api/tutorial-prompt/heartbeat';
     const TUTORIAL_PROMPT_COORDINATION_KEY = 'home-tutorial-prompt';
     const TUTORIAL_PROMPT_PRIORITY = 200;
+    const HOME_TUTORIAL_AGENT_RESTORE_STORAGE_KEY = 'neko.homeTutorial.agentRestoreSnapshot.v1';
     const HOME_TUTORIAL_AGENT_FLAG_KEYS = Object.freeze([
         'agent_enabled',
         'computer_use_enabled',
@@ -274,6 +275,54 @@
         }
     }
 
+    function readPersistedAgentRestoreSnapshot() {
+        try {
+            const raw = localStorage.getItem(HOME_TUTORIAL_AGENT_RESTORE_STORAGE_KEY);
+            if (!raw) {
+                return null;
+            }
+            const payload = JSON.parse(raw);
+            if (!payload || !payload.agentFlags || typeof payload.agentFlags !== 'object') {
+                return null;
+            }
+            return payload;
+        } catch (error) {
+            console.warn('[TutorialPrompt] failed to read persisted agent restore snapshot:', error);
+            return null;
+        }
+    }
+
+    function persistAgentRestoreSnapshot(flags, token, reason) {
+        if (!flags) {
+            return;
+        }
+        try {
+            localStorage.setItem(HOME_TUTORIAL_AGENT_RESTORE_STORAGE_KEY, JSON.stringify({
+                version: 1,
+                token: token,
+                createdAt: Date.now(),
+                reason: reason || 'home-tutorial-suppression',
+                agentFlags: flags,
+            }));
+        } catch (error) {
+            console.warn('[TutorialPrompt] failed to persist agent restore snapshot:', error);
+        }
+    }
+
+    function clearPersistedAgentRestoreSnapshot(token) {
+        try {
+            if (token !== undefined) {
+                const payload = readPersistedAgentRestoreSnapshot();
+                if (payload && payload.token !== token) {
+                    return;
+                }
+            }
+            localStorage.removeItem(HOME_TUTORIAL_AGENT_RESTORE_STORAGE_KEY);
+        } catch (error) {
+            console.warn('[TutorialPrompt] failed to clear persisted agent restore snapshot:', error);
+        }
+    }
+
     function buildAgentChildFlags(values) {
         const flags = {};
         HOME_TUTORIAL_AGENT_FLAG_KEYS.forEach(function (key) {
@@ -365,7 +414,9 @@
             }
             if (state.featureSuppression.snapshot) {
                 state.featureSuppression.snapshot.agentFlags = flags;
+                state.featureSuppression.snapshot.agentRestoreToken = token;
             }
+            persistAgentRestoreSnapshot(flags, token, 'tutorial-suppression');
             await postAgentCommand('set_agent_enabled', { enabled: false });
             if (!state.featureSuppression.active || state.featureSuppression.token !== token) {
                 const restoreToken = state.featureSuppression.token;
@@ -375,6 +426,7 @@
                 try {
                     const restored = await restoreAgentSnapshot(flags, restoreToken);
                     if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                        clearPersistedAgentRestoreSnapshot(token);
                         syncAgentFlagsUi();
                     }
                 } catch (restoreError) {
@@ -391,6 +443,7 @@
                 try {
                     const restored = await restoreAgentSnapshot(flags, restoreToken);
                     if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                        clearPersistedAgentRestoreSnapshot(token);
                         syncAgentFlagsUi();
                     }
                 } catch (restoreError) {
@@ -462,6 +515,7 @@
             void restoreAgentSnapshot(snapshot.agentFlags, restoreToken)
                 .then(function (restored) {
                     if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                        clearPersistedAgentRestoreSnapshot(snapshot.agentRestoreToken);
                         syncAgentFlagsUi();
                     }
                 })
@@ -473,6 +527,30 @@
         window.dispatchEvent(new CustomEvent('neko:home-tutorial-features-suppressed', {
             detail: { active: false, reason: reason || 'tutorial-ended' },
         }));
+    }
+
+    function restoreInterruptedAgentSuppression(reason) {
+        if (state.featureSuppression.active) {
+            return;
+        }
+        const persisted = readPersistedAgentRestoreSnapshot();
+        if (!persisted) {
+            clearPersistedAgentRestoreSnapshot();
+            return;
+        }
+        const restoreToken = Date.now() + Math.random();
+        state.featureSuppression.token = restoreToken;
+        void restoreAgentSnapshot(persisted.agentFlags, restoreToken)
+            .then(function (restored) {
+                if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                    clearPersistedAgentRestoreSnapshot(persisted.token);
+                    syncAgentFlagsUi();
+                    console.log('[TutorialPrompt] restored interrupted agent suppression:', reason || 'init');
+                }
+            })
+            .catch(function (error) {
+                console.warn('[TutorialPrompt] failed to restore interrupted agent suppression:', error);
+            });
     }
 
     mod.beginHomeTutorialFeatureSuppression = beginHomeTutorialFeatureSuppression;
@@ -1353,6 +1431,7 @@
         state.initialized = true;
         syncForegroundWindow();
         bindEvents();
+        restoreInterruptedAgentSuppression('init');
 
         state.heartbeatTimer = setInterval(function () {
             void sendHeartbeat();

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -256,12 +256,86 @@
         }
     }
 
-    function buildDisabledAgentFlags() {
+    async function postAgentCommand(command, payload) {
+        const response = await fetch('/api/agent/command', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(Object.assign({
+                request_id: 'home-tutorial-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8),
+                command: command,
+            }, payload || {})),
+        });
+        if (!response || !response.ok) {
+            throw new Error('agent_command_post_failed');
+        }
+        const result = await response.json().catch(function () { return null; });
+        if (result && result.success === false) {
+            throw new Error(result.error || 'agent_command_rejected');
+        }
+    }
+
+    function buildAgentChildFlags(values) {
         const flags = {};
         HOME_TUTORIAL_AGENT_FLAG_KEYS.forEach(function (key) {
-            flags[key] = false;
+            if (key !== 'agent_enabled' && Object.prototype.hasOwnProperty.call(values, key)) {
+                flags[key] = !!values[key];
+            }
         });
         return flags;
+    }
+
+    function buildDisabledAgentChildFlags() {
+        const flags = {};
+        HOME_TUTORIAL_AGENT_FLAG_KEYS.forEach(function (key) {
+            if (key !== 'agent_enabled') {
+                flags[key] = false;
+            }
+        });
+        return flags;
+    }
+
+    function canRestoreAgentSnapshot(restoreToken) {
+        return !state.featureSuppression.active
+            && state.featureSuppression.token === restoreToken;
+    }
+
+    async function restoreAgentSnapshot(flags, restoreToken) {
+        if (!flags) {
+            return false;
+        }
+        if (restoreToken !== undefined && !canRestoreAgentSnapshot(restoreToken)) {
+            return false;
+        }
+        if (Object.prototype.hasOwnProperty.call(flags, 'agent_enabled')) {
+            await postAgentCommand('set_agent_enabled', {
+                enabled: !!flags.agent_enabled,
+            });
+        }
+        if (restoreToken !== undefined && !canRestoreAgentSnapshot(restoreToken)) {
+            if (state.featureSuppression.active && flags.agent_enabled) {
+                try {
+                    await postAgentCommand('set_agent_enabled', { enabled: false });
+                } catch (error) {
+                    console.warn('[TutorialPrompt] failed to re-suppress stale agent master restore:', error);
+                }
+            }
+            return false;
+        }
+        const childFlags = buildAgentChildFlags(flags);
+        if (Object.keys(childFlags).length > 0) {
+            await postAgentFlags(childFlags);
+        }
+        if (restoreToken !== undefined && !canRestoreAgentSnapshot(restoreToken)) {
+            if (state.featureSuppression.active && Object.keys(childFlags).length > 0) {
+                try {
+                    await postAgentFlags(buildDisabledAgentChildFlags());
+                } catch (error) {
+                    console.warn('[TutorialPrompt] failed to re-suppress stale agent child flag restore:', error);
+                }
+            }
+            return false;
+        }
+        return true;
     }
 
     function syncAgentFlagsUi() {
@@ -292,11 +366,33 @@
             if (state.featureSuppression.snapshot) {
                 state.featureSuppression.snapshot.agentFlags = flags;
             }
-            await postAgentFlags(buildDisabledAgentFlags());
+            await postAgentCommand('set_agent_enabled', { enabled: false });
             if (!state.featureSuppression.active || state.featureSuppression.token !== token) {
+                const restoreToken = state.featureSuppression.token;
+                if (state.featureSuppression.active || !canRestoreAgentSnapshot(restoreToken)) {
+                    return;
+                }
                 try {
-                    await postAgentFlags(flags);
-                    syncAgentFlagsUi();
+                    const restored = await restoreAgentSnapshot(flags, restoreToken);
+                    if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                        syncAgentFlagsUi();
+                    }
+                } catch (restoreError) {
+                    console.warn('[TutorialPrompt] failed to restore agent flags after stale master suppress:', restoreError);
+                }
+                return;
+            }
+            await postAgentFlags(buildDisabledAgentChildFlags());
+            if (!state.featureSuppression.active || state.featureSuppression.token !== token) {
+                const restoreToken = state.featureSuppression.token;
+                if (state.featureSuppression.active || !canRestoreAgentSnapshot(restoreToken)) {
+                    return;
+                }
+                try {
+                    const restored = await restoreAgentSnapshot(flags, restoreToken);
+                    if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                        syncAgentFlagsUi();
+                    }
                 } catch (restoreError) {
                     console.warn('[TutorialPrompt] failed to restore agent flags after stale suppress:', restoreError);
                 }
@@ -363,8 +459,12 @@
             maybeRestartProactiveSchedule(snapshot.proactive);
         }
         if (snapshot.agentFlags) {
-            void postAgentFlags(snapshot.agentFlags)
-                .then(syncAgentFlagsUi)
+            void restoreAgentSnapshot(snapshot.agentFlags, restoreToken)
+                .then(function (restored) {
+                    if (restored && canRestoreAgentSnapshot(restoreToken)) {
+                        syncAgentFlagsUi();
+                    }
+                })
                 .catch(function (error) {
                     console.warn('[TutorialPrompt] failed to restore agent flags:', error);
                 });

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -8,6 +8,25 @@
     const HEARTBEAT_ENDPOINT = '/api/tutorial-prompt/heartbeat';
     const TUTORIAL_PROMPT_COORDINATION_KEY = 'home-tutorial-prompt';
     const TUTORIAL_PROMPT_PRIORITY = 200;
+    const HOME_TUTORIAL_AGENT_FLAG_KEYS = Object.freeze([
+        'agent_enabled',
+        'computer_use_enabled',
+        'browser_use_enabled',
+        'user_plugin_enabled',
+        'openclaw_enabled',
+        'openfang_enabled',
+    ]);
+    const HOME_TUTORIAL_PROACTIVE_KEYS = Object.freeze([
+        'proactiveChatEnabled',
+        'proactiveVisionEnabled',
+        'proactiveVisionChatEnabled',
+        'proactiveNewsChatEnabled',
+        'proactiveVideoChatEnabled',
+        'proactivePersonalChatEnabled',
+        'proactiveMusicEnabled',
+        'proactiveMemeEnabled',
+        'proactiveMiniGameInviteEnabled',
+    ]);
 
     const promptShared = window.nekoPromptShared;
     if (!promptShared || typeof promptShared.createPromptTools !== 'function') {
@@ -53,6 +72,11 @@
         pendingTutorialStartPayload: null,
         userCohort: 'unknown',
         mobileResizeRetryBound: false,
+        featureSuppression: {
+            active: false,
+            token: 0,
+            snapshot: null,
+        },
     };
 
     const shortPromptToken = promptTools.shortToken;
@@ -96,6 +120,271 @@
         }
         return 'heartbeat-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
     }
+
+    function getReactChatWindowHost() {
+        return window.reactChatWindowHost || null;
+    }
+
+    function getStoredGalgamePreference() {
+        try {
+            const raw = localStorage.getItem('neko.reactChatWindow.galgameMode');
+            if (raw === null) return true;
+            return raw === 'true';
+        } catch (_) {
+            return true;
+        }
+    }
+
+    function snapshotGalgameState() {
+        const host = getReactChatWindowHost();
+        if (host && typeof host.isGalgameModeEnabled === 'function') {
+            try {
+                return !!host.isGalgameModeEnabled();
+            } catch (_) {}
+        }
+        return getStoredGalgamePreference();
+    }
+
+    function setGalgameState(enabled, options) {
+        const requestOptions = options || {};
+        const host = getReactChatWindowHost();
+        if (host && typeof host.setGalgameModeEnabled === 'function') {
+            try {
+                host.setGalgameModeEnabled(!!enabled, {
+                    persist: false,
+                    suppressRefetch: true,
+                    force: !!requestOptions.force,
+                });
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to set GalGame state:', error);
+            }
+        }
+    }
+
+    function snapshotProactiveState() {
+        const snapshot = {};
+        HOME_TUTORIAL_PROACTIVE_KEYS.forEach(function (key) {
+            snapshot[key] = !!window[key];
+        });
+        return snapshot;
+    }
+
+    function applyProactiveState(values) {
+        HOME_TUTORIAL_PROACTIVE_KEYS.forEach(function (key) {
+            if (Object.prototype.hasOwnProperty.call(values, key)) {
+                window[key] = !!values[key];
+            }
+        });
+        if (typeof window.stopProactiveChatSchedule === 'function') {
+            try {
+                window.stopProactiveChatSchedule();
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to stop proactive schedule:', error);
+            }
+        }
+        if (typeof window.stopProactiveVisionDuringSpeech === 'function') {
+            try {
+                window.stopProactiveVisionDuringSpeech();
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to stop proactive vision:', error);
+            }
+        }
+        if (typeof window.releaseProactiveVisionStream === 'function') {
+            try {
+                window.releaseProactiveVisionStream();
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to release proactive vision stream:', error);
+            }
+        }
+    }
+
+    function maybeRestartProactiveSchedule(snapshot) {
+        if (!snapshot || !snapshot.proactiveChatEnabled) {
+            return;
+        }
+        const hasMode = HOME_TUTORIAL_PROACTIVE_KEYS.some(function (key) {
+            return key !== 'proactiveChatEnabled' && !!snapshot[key];
+        });
+        if (!hasMode) {
+            return;
+        }
+        const scheduler = window.appProactive && typeof window.appProactive.scheduleProactiveChat === 'function'
+            ? window.appProactive.scheduleProactiveChat
+            : window.scheduleProactiveChat;
+        if (typeof scheduler === 'function') {
+            try {
+                scheduler();
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to restart proactive schedule:', error);
+            }
+        }
+    }
+
+    async function fetchAgentFlagSnapshot() {
+        const response = await fetch('/api/agent/flags', {
+            method: 'GET',
+            cache: 'no-store',
+        });
+        if (!response || !response.ok) {
+            throw new Error('agent_flags_get_failed');
+        }
+        const payload = await response.json();
+        if (!payload || payload.success === false) {
+            throw new Error('agent_flags_payload_invalid');
+        }
+        const flags = Object.assign({}, payload.agent_flags || {});
+        if (typeof payload.analyzer_enabled === 'boolean') {
+            flags.agent_enabled = payload.analyzer_enabled;
+        } else if (Object.prototype.hasOwnProperty.call(flags, 'agent_enabled')) {
+            flags.agent_enabled = !!flags.agent_enabled;
+        }
+        return flags;
+    }
+
+    async function postAgentFlags(flags) {
+        const response = await fetch('/api/agent/flags', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ flags: flags }),
+        });
+        if (!response || !response.ok) {
+            throw new Error('agent_flags_post_failed');
+        }
+        const payload = await response.json().catch(function () { return null; });
+        if (payload && payload.success === false) {
+            throw new Error(payload.error || 'agent_flags_post_rejected');
+        }
+    }
+
+    function buildDisabledAgentFlags() {
+        const flags = {};
+        HOME_TUTORIAL_AGENT_FLAG_KEYS.forEach(function (key) {
+            flags[key] = false;
+        });
+        return flags;
+    }
+
+    function syncAgentFlagsUi() {
+        if (typeof window.syncAgentFlagsFromBackend === 'function') {
+            try {
+                Promise.resolve(window.syncAgentFlagsFromBackend()).catch(function (error) {
+                    console.warn('[TutorialPrompt] agent flag UI sync failed:', error);
+                });
+            } catch (error) {
+                console.warn('[TutorialPrompt] agent flag UI sync failed:', error);
+            }
+        }
+        if (typeof window.checkAndToggleTaskHUD === 'function') {
+            try {
+                window.checkAndToggleTaskHUD();
+            } catch (error) {
+                console.warn('[TutorialPrompt] agent HUD sync failed:', error);
+            }
+        }
+    }
+
+    async function snapshotAndDisableAgentFlags(token) {
+        try {
+            const flags = await fetchAgentFlagSnapshot();
+            if (!state.featureSuppression.active || state.featureSuppression.token !== token) {
+                return;
+            }
+            if (state.featureSuppression.snapshot) {
+                state.featureSuppression.snapshot.agentFlags = flags;
+            }
+            await postAgentFlags(buildDisabledAgentFlags());
+            if (!state.featureSuppression.active || state.featureSuppression.token !== token) {
+                try {
+                    await postAgentFlags(flags);
+                    syncAgentFlagsUi();
+                } catch (restoreError) {
+                    console.warn('[TutorialPrompt] failed to restore agent flags after stale suppress:', restoreError);
+                }
+                return;
+            }
+            syncAgentFlagsUi();
+        } catch (error) {
+            console.warn('[TutorialPrompt] failed to suppress agent flags:', error);
+        }
+    }
+
+    function beginHomeTutorialFeatureSuppression(reason) {
+        if (!isHomePage()) {
+            return;
+        }
+        const suppression = state.featureSuppression;
+        if (suppression.active) {
+            return;
+        }
+        const token = Date.now() + Math.random();
+        const snapshot = {
+            galgameEnabled: snapshotGalgameState(),
+            proactive: snapshotProactiveState(),
+            agentFlags: null,
+            reason: reason || 'tutorial-started',
+        };
+        suppression.active = true;
+        suppression.token = token;
+        suppression.snapshot = snapshot;
+
+        setGalgameState(false);
+        const proactiveOff = {};
+        HOME_TUTORIAL_PROACTIVE_KEYS.forEach(function (key) {
+            proactiveOff[key] = false;
+        });
+        applyProactiveState(proactiveOff);
+        void snapshotAndDisableAgentFlags(token);
+
+        window.dispatchEvent(new CustomEvent('neko:home-tutorial-features-suppressed', {
+            detail: { active: true, reason: reason || 'tutorial-started' },
+        }));
+    }
+
+    function endHomeTutorialFeatureSuppression(reason) {
+        const suppression = state.featureSuppression;
+        if (!suppression.active && !suppression.snapshot) {
+            return;
+        }
+        const snapshot = suppression.snapshot || {};
+        suppression.active = false;
+        suppression.token = Date.now() + Math.random();
+        const restoreToken = suppression.token;
+        suppression.snapshot = null;
+
+        setGalgameState(!!snapshot.galgameEnabled, { force: true });
+        setTimeout(function () {
+            if (state.featureSuppression.active || state.featureSuppression.token !== restoreToken) {
+                return;
+            }
+            setGalgameState(!!snapshot.galgameEnabled, { force: true });
+        }, 0);
+        if (snapshot.proactive) {
+            applyProactiveState(snapshot.proactive);
+            maybeRestartProactiveSchedule(snapshot.proactive);
+        }
+        if (snapshot.agentFlags) {
+            void postAgentFlags(snapshot.agentFlags)
+                .then(syncAgentFlagsUi)
+                .catch(function (error) {
+                    console.warn('[TutorialPrompt] failed to restore agent flags:', error);
+                });
+        }
+
+        window.dispatchEvent(new CustomEvent('neko:home-tutorial-features-suppressed', {
+            detail: { active: false, reason: reason || 'tutorial-ended' },
+        }));
+    }
+
+    mod.beginHomeTutorialFeatureSuppression = beginHomeTutorialFeatureSuppression;
+    mod.endHomeTutorialFeatureSuppression = endHomeTutorialFeatureSuppression;
+    mod.isHomeTutorialFeatureSuppressionActive = function () {
+        return !!state.featureSuppression.active;
+    };
+    window.NekoHomeTutorialFeatureController = {
+        begin: beginHomeTutorialFeatureSuppression,
+        end: endHomeTutorialFeatureSuppression,
+        isActive: mod.isHomeTutorialFeatureSuppressionActive,
+    };
 
     function getHomeTutorialStorageKeys() {
         const keys = [];
@@ -852,6 +1141,7 @@
             state.tutorialStartRequested = false;
             state.tutorialStarted = true;
             state.homeTutorialCompleted = true;
+            endHomeTutorialFeatureSuppression('tutorial-completed');
             emitHomeTutorialLockIfChanged('tutorial-completed');
             void (async function () {
                 const source = event.detail.source || 'manual';
@@ -887,6 +1177,7 @@
             if (!event || !event.detail || event.detail.page !== 'home') {
                 return;
             }
+            beginHomeTutorialFeatureSuppression('tutorial-started');
             state.tutorialRunning = true;
             state.tutorialStartRequested = false;
             state.tutorialStarted = true;
@@ -935,7 +1226,17 @@
             }
             state.tutorialRunning = false;
             state.tutorialStartRequested = false;
+            endHomeTutorialFeatureSuppression('tutorial-skipped');
             emitHomeTutorialLockIfChanged('tutorial-skipped');
+        });
+
+        window.addEventListener('neko:home-tutorial-lock-changed', function (event) {
+            const detail = event && event.detail ? event.detail : {};
+            if (detail.locked === true && detail.reason === 'tutorial-start-requested') {
+                beginHomeTutorialFeatureSuppression('tutorial-start-requested');
+            } else if (detail.locked === false && !state.tutorialRunning && !state.tutorialStartRequested) {
+                endHomeTutorialFeatureSuppression(detail.reason || 'lock-released');
+            }
         });
 
         window.addEventListener('beforeunload', flushHeartbeatOnUnload);

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -817,6 +817,7 @@ def test_home_tutorial_feature_controller_restores_live_galgame_state_after_lega
             window.history.pushState({}, '', '/');
             window.localStorage.setItem('neko.reactChatWindow.galgameMode', 'false');
             window.__agentFlagBodies = [];
+            window.__agentCommandBodies = [];
         """,
         fetch_js="""
             if (requestUrl === '/api/tutorial-prompt/state') {
@@ -863,6 +864,10 @@ def test_home_tutorial_feature_controller_restores_live_galgame_state_after_lega
                 window.__agentFlagBodies.push(body);
                 return jsonResponse({ success: true });
             }
+            if (requestUrl === '/api/agent/command' && method === 'POST') {
+                window.__agentCommandBodies.push(body);
+                return jsonResponse({ success: true });
+            }
         """,
         script_names=("app-prompt-shared.js", "app-tutorial-prompt.js"),
         init_js="() => window.appTutorialPrompt.init()",
@@ -902,6 +907,10 @@ def test_home_tutorial_feature_controller_restores_live_galgame_state_after_lega
         "() => window.reactChatWindowHost.isGalgameModeEnabled() === false",
         timeout=5000,
     )
+    mock_page.wait_for_function(
+        "() => window.__agentCommandBodies.length === 1 && window.__agentFlagBodies.length === 1",
+        timeout=5000,
+    )
 
     mock_page.evaluate(
         """
@@ -921,7 +930,7 @@ def test_home_tutorial_feature_controller_restores_live_galgame_state_after_lega
         timeout=5000,
     )
     mock_page.wait_for_function(
-        "() => window.__agentFlagBodies.length === 2",
+        "() => window.__agentCommandBodies.length === 2 && window.__agentFlagBodies.length === 2",
         timeout=5000,
     )
     result = mock_page.evaluate(
@@ -929,13 +938,18 @@ def test_home_tutorial_feature_controller_restores_live_galgame_state_after_lega
         () => ({
             suppressed: window.NekoHomeTutorialFeatureController.isActive(),
             agentFlagBodies: window.__agentFlagBodies.slice(),
+            agentCommandBodies: window.__agentCommandBodies.slice(),
         })
         """
     )
     assert result["suppressed"] is False
-    assert result["agentFlagBodies"][0]["flags"]["agent_enabled"] is False
+    assert result["agentCommandBodies"][0]["command"] == "set_agent_enabled"
+    assert result["agentCommandBodies"][0]["enabled"] is False
+    assert result["agentCommandBodies"][1]["command"] == "set_agent_enabled"
+    assert result["agentCommandBodies"][1]["enabled"] is True
+    assert "agent_enabled" not in result["agentFlagBodies"][0]["flags"]
     assert result["agentFlagBodies"][0]["flags"]["computer_use_enabled"] is False
-    assert result["agentFlagBodies"][1]["flags"]["agent_enabled"] is True
+    assert "agent_enabled" not in result["agentFlagBodies"][1]["flags"]
     assert result["agentFlagBodies"][1]["flags"]["computer_use_enabled"] is True
 
 

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -808,6 +808,138 @@ def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_feature_controller_restores_live_galgame_state_after_legacy_listener(
+    mock_page: Page,
+):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.history.pushState({}, '', '/');
+            window.localStorage.setItem('neko.reactChatWindow.galgameMode', 'false');
+            window.__agentFlagBodies = [];
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-started') {
+                return jsonResponse({ ok: true, tutorial_run_token: 'run-token' });
+            }
+            if (requestUrl === '/api/agent/flags' && method === 'GET') {
+                return jsonResponse({
+                    success: true,
+                    analyzer_enabled: true,
+                    agent_flags: {
+                        computer_use_enabled: true,
+                        browser_use_enabled: false,
+                        user_plugin_enabled: false,
+                        openclaw_enabled: false,
+                        openfang_enabled: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/agent/flags' && method === 'POST') {
+                window.__agentFlagBodies.push(body);
+                return jsonResponse({ success: true });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "app-tutorial-prompt.js"),
+        init_js="() => window.appTutorialPrompt.init()",
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "app-react-chat-window.js"))
+
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost && window.reactChatWindowHost.isGalgameModeEnabled() === false",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.reactChatWindowHost.setGalgameModeEnabled(true, {
+                persist: false,
+                force: true,
+            });
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.isGalgameModeEnabled() === true",
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = true;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: { page: 'home' },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.reactChatWindowHost.isGalgameModeEnabled() === false",
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home' },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        """
+        () => window.reactChatWindowHost.isGalgameModeEnabled() === true
+            && window.localStorage.getItem('neko.reactChatWindow.galgameMode') === 'false'
+        """,
+        timeout=5000,
+    )
+    mock_page.wait_for_function(
+        "() => window.__agentFlagBodies.length === 2",
+        timeout=5000,
+    )
+    result = mock_page.evaluate(
+        """
+        () => ({
+            suppressed: window.NekoHomeTutorialFeatureController.isActive(),
+            agentFlagBodies: window.__agentFlagBodies.slice(),
+        })
+        """
+    )
+    assert result["suppressed"] is False
+    assert result["agentFlagBodies"][0]["flags"]["agent_enabled"] is False
+    assert result["agentFlagBodies"][0]["flags"]["computer_use_enabled"] is False
+    assert result["agentFlagBodies"][1]["flags"]["agent_enabled"] is True
+    assert result["agentFlagBodies"][1]["flags"]["computer_use_enabled"] is True
+
+
+@pytest.mark.frontend
 def test_react_chat_close_deactivates_active_tool_cursor(mock_page: Page):
     _bootstrap_page(
         mock_page,


### PR DESCRIPTION
新手教程开始前记录 GalGame、主动搭话和 Agent/猫抓相关开关状态，教程期间统一关闭并由教程流程接管，结束或跳过后恢复进入教程前的状态。

同时强化 GalGame 和选项交互在教程锁定期间的拦截，避免默认开启的 GalGame、主动搭话或 Agent 功能打断新手教程；补充回归用例覆盖 GalGame 实际状态恢复和 Agent flags 关闭/恢复流程。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 新增主页教程功能控制器（公开接口：begin()/end()/isActive()），可在引导流程中暂停并恢复主动聊天、视觉调度与交互状态。
  * 扩展教程相关的特性标记、偏好快照与恢复机制，支持中断恢复与还原。

* **Bug 修复**
  * 在教程或交互锁定期间正确抑制主动聊天、GalGame 选项与交互，避免意外触发或展示。
  * 在设置同步前检测教程活动，教程进行时跳过同步。

* **测试**
  * 新增前端测试，验证教程开始/跳过后功能状态与特性标记恢复正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->