### PR TITLE
  美化 Galgame 模式切换并优化切换反馈

### DIFF
--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -5674,7 +5674,6 @@ function scheduleSettingsAutosave() {
 }
 
 async function saveMode({ auto = false } = {}) {
-  const requestId = ++modeSaveRequestId;
   let modeCommitted = false;
   clearSettingsAutosaveTimer();
   const mode = document.getElementById('modeSelect').value;
@@ -5708,6 +5707,7 @@ async function saveMode({ auto = false } = {}) {
     clearPendingModeSelection(mode);
     return;
   }
+  const requestId = ++modeSaveRequestId;
   try {
     if (mode && (!latestStatus || latestStatus.mode !== mode)) {
       pendingModeSelection = mode;
@@ -5733,29 +5733,34 @@ async function saveMode({ auto = false } = {}) {
       vision_enabled: visionEnabled,
       vision_max_image_px: Math.round(visionMaxImagePx),
     });
+    if (requestId !== modeSaveRequestId) {
+      return;
+    }
     setFlash(auto ? uiT('ui.flash.settings_auto_saved', '设置已自动保存') : uiT('ui.flash.settings_saved', '设置已保存'), 'success');
     settingsDirty = false;
     settingsSaveInFlight = false;
     updateSettingsDirtyHint();
-    if (requestId === modeSaveRequestId) {
-      await refreshAll({ preserveFlash: true, forceInsights: true, forceRefresh: true });
-    }
+    await refreshAll({ preserveFlash: true, forceInsights: true, forceRefresh: true });
   } catch (error) {
-    if (requestId === modeSaveRequestId) {
-      if (modeCommitted) {
-        try {
-          await refreshAll({ preserveFlash: true, forceRefresh: true });
-        } catch (refreshError) {
-          console.error('[galgame] mode save reconcile refresh failed', refreshError);
-        }
-      } else {
-        clearPendingModeSelection(mode);
+    if (requestId !== modeSaveRequestId) {
+      console.error('[galgame] stale saveMode error suppressed', error);
+      return;
+    }
+    if (modeCommitted) {
+      try {
+        await refreshAll({ preserveFlash: true, forceRefresh: true });
+      } catch (refreshError) {
+        console.error('[galgame] mode save reconcile refresh failed', refreshError);
       }
+    } else {
+      clearPendingModeSelection(mode);
     }
     setFlash(error instanceof Error ? error.message : String(error), 'error');
   } finally {
-    settingsSaveInFlight = false;
-    updateSettingsDirtyHint();
+    if (requestId === modeSaveRequestId) {
+      settingsSaveInFlight = false;
+      updateSettingsDirtyHint();
+    }
   }
 }
 

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -2954,10 +2954,8 @@ function renderInstallTaskState(kind) {
 
 function renderPluginUnavailable(error) {
   latestStatus = null;
-  const modeSwitchEl = document.getElementById('modeSwitch');
-  if (modeSwitchEl) {
-    modeSwitchEl.dataset.ready = 'false';
-  }
+  pendingModeSelection = '';
+  updateModeSwitchControl('', { ready: false });
   const pluginNotStarted = uiT('ui.diag.plugin_not_started.title', '插件尚未启动');
   const message = error instanceof Error ? error.message : String(error || pluginNotStarted);
   document.getElementById('summaryText').textContent = pluginNotStarted;
@@ -3208,10 +3206,17 @@ function updateModeSwitchControl(currentMode, { ready = true } = {}) {
     return;
   }
   document.querySelectorAll('#modeSwitch .mode-btn').forEach((btn) => {
-    btn.classList.toggle('active', btn.dataset.mode === currentMode);
+    btn.classList.toggle('active', ready && btn.dataset.mode === currentMode);
+    btn.disabled = !ready;
+    btn.setAttribute('aria-disabled', ready ? 'false' : 'true');
   });
-  modeSwitchEl.dataset.active = currentMode;
+  modeSwitchEl.dataset.active = ready ? currentMode : '';
   modeSwitchEl.dataset.ready = ready ? 'true' : 'false';
+  if (!ready) {
+    modeSwitchEl.style.removeProperty('--indicator-left');
+    modeSwitchEl.style.removeProperty('--indicator-width');
+    return;
+  }
   const activeBtn = modeSwitchEl.querySelector('.mode-btn.active');
   if (activeBtn) {
     const sr = modeSwitchEl.getBoundingClientRect();
@@ -6816,6 +6821,10 @@ document.querySelectorAll('.install-tab').forEach((btn) => {
 
 document.querySelectorAll('#modeSwitch .mode-btn').forEach((btn) => {
   btn.addEventListener('click', () => {
+    const modeSwitchEl = document.getElementById('modeSwitch');
+    if (!modeSwitchEl || modeSwitchEl.dataset.ready !== 'true') {
+      return;
+    }
     const mode = btn.dataset.mode;
     const select = document.getElementById('modeSelect');
     if (select && mode) {

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -3238,6 +3238,16 @@ function updateSummaryMode(currentMode) {
   });
 }
 
+function clearPendingModeSelection(mode) {
+  if (!pendingModeSelection || (mode && pendingModeSelection !== mode)) {
+    return;
+  }
+  pendingModeSelection = '';
+  if (latestStatus) {
+    renderStatus(latestStatus);
+  }
+}
+
 function renderStatus(status) {
   latestStatus = status;
   syncSettingsValue('modeSelect', status.mode || 'companion');
@@ -5673,18 +5683,22 @@ async function saveMode({ auto = false } = {}) {
   const visionMaxImagePx = Number(visionMaxRaw || 768);
   if (!['auto', 'memory_reader', 'ocr_reader'].includes(readerMode)) {
     setFlash(uiT('ui.flash.invalid_reader_mode', '文本读取模式无效。'), 'error');
+    clearPendingModeSelection(mode);
     return;
   }
   if (!Number.isFinite(ocrPollInterval) || ocrPollInterval < 0.5 || ocrPollInterval > 10) {
     setFlash(uiT('ui.flash.invalid_ocr_interval', 'OCR/DXcam 识别间隔必须在 0.5 到 10 秒之间。'), 'error');
+    clearPendingModeSelection(mode);
     return;
   }
   if (!['interval', 'after_advance'].includes(ocrTriggerMode)) {
     setFlash(uiT('ui.flash.invalid_ocr_trigger', 'OCR 触发方式无效。'), 'error');
+    clearPendingModeSelection(mode);
     return;
   }
   if (!Number.isFinite(visionMaxImagePx) || visionMaxImagePx < 64 || visionMaxImagePx > 2048) {
     setFlash(uiT('ui.flash.invalid_vision_max', 'Vision 最大边长必须在 64 到 2048 之间。'), 'error');
+    clearPendingModeSelection(mode);
     return;
   }
   try {
@@ -5717,12 +5731,7 @@ async function saveMode({ auto = false } = {}) {
     updateSettingsDirtyHint();
     await refreshAll({ preserveFlash: true, forceInsights: true, forceRefresh: true });
   } catch (error) {
-    if (pendingModeSelection === mode) {
-      pendingModeSelection = '';
-      if (latestStatus) {
-        renderStatus(latestStatus);
-      }
-    }
+    clearPendingModeSelection(mode);
     setFlash(error instanceof Error ? error.message : String(error), 'error');
   } finally {
     settingsSaveInFlight = false;

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -3208,6 +3208,17 @@ function renderStatus(status) {
   document.querySelectorAll('#modeSwitch .mode-btn').forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.mode === currentMode);
   });
+  const modeSwitchEl = document.getElementById('modeSwitch');
+  if (modeSwitchEl) {
+    modeSwitchEl.dataset.active = currentMode;
+    const activeBtn = modeSwitchEl.querySelector('.mode-btn.active');
+    if (activeBtn) {
+      const sr = modeSwitchEl.getBoundingClientRect();
+      const br = activeBtn.getBoundingClientRect();
+      modeSwitchEl.style.setProperty('--indicator-left', `${br.left - sr.left}px`);
+      modeSwitchEl.style.setProperty('--indicator-width', `${br.width}px`);
+    }
+  }
   const currentSpeed = status.advance_speed || 'medium';
   document.querySelectorAll('#speedSwitch .speed-btn').forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.speed === currentSpeed);

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -691,6 +691,7 @@ let autoRefreshIntervalMs = AUTO_REFRESH_INTERVAL_MS;
 let activeInstallTab = 'rapidocr';
 let settingsDirty = false;
 let settingsSaveInFlight = false;
+let pendingModeSelection = '';
 let settingsAutosaveTimer = null;
 let flashTimer = null;
 let flashToken = 0;
@@ -2953,6 +2954,10 @@ function renderInstallTaskState(kind) {
 
 function renderPluginUnavailable(error) {
   latestStatus = null;
+  const modeSwitchEl = document.getElementById('modeSwitch');
+  if (modeSwitchEl) {
+    modeSwitchEl.dataset.ready = 'false';
+  }
   const pluginNotStarted = uiT('ui.diag.plugin_not_started.title', '插件尚未启动');
   const message = error instanceof Error ? error.message : String(error || pluginNotStarted);
   document.getElementById('summaryText').textContent = pluginNotStarted;
@@ -3197,28 +3202,58 @@ async function restoreTesseractInstallState() {
   await restoreInstallState('tesseract');
 }
 
+function updateModeSwitchControl(currentMode, { ready = true } = {}) {
+  const modeSwitchEl = document.getElementById('modeSwitch');
+  if (!modeSwitchEl) {
+    return;
+  }
+  document.querySelectorAll('#modeSwitch .mode-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.mode === currentMode);
+  });
+  modeSwitchEl.dataset.active = currentMode;
+  modeSwitchEl.dataset.ready = ready ? 'true' : 'false';
+  const activeBtn = modeSwitchEl.querySelector('.mode-btn.active');
+  if (activeBtn) {
+    const sr = modeSwitchEl.getBoundingClientRect();
+    const br = activeBtn.getBoundingClientRect();
+    modeSwitchEl.style.setProperty('--indicator-left', `${br.left - sr.left}px`);
+    modeSwitchEl.style.setProperty('--indicator-width', `${br.width}px`);
+  }
+}
+
+function updateSummaryMode(currentMode) {
+  const summaryNode = document.getElementById('summaryText');
+  if (!summaryNode) {
+    return;
+  }
+  if (latestStatus) {
+    summaryNode.textContent = buildStatusSummaryText({
+      ...latestStatus,
+      mode: currentMode,
+    });
+    return;
+  }
+  summaryNode.textContent = uiTf('ui.summary.mode_part', '模式：{mode}', {
+    mode: modeLabel(currentMode, currentMode),
+  });
+}
+
 function renderStatus(status) {
   latestStatus = status;
-  document.getElementById('summaryText').textContent = buildStatusSummaryText(status);
   syncSettingsValue('modeSelect', status.mode || 'companion');
   syncSettingsChecked('pushToggle', Boolean(status.push_notifications));
   syncSettingsValue('advanceSpeedSelect', status.advance_speed || 'medium');
 
-  const currentMode = status.mode || 'companion';
-  document.querySelectorAll('#modeSwitch .mode-btn').forEach((btn) => {
-    btn.classList.toggle('active', btn.dataset.mode === currentMode);
-  });
-  const modeSwitchEl = document.getElementById('modeSwitch');
-  if (modeSwitchEl) {
-    modeSwitchEl.dataset.active = currentMode;
-    const activeBtn = modeSwitchEl.querySelector('.mode-btn.active');
-    if (activeBtn) {
-      const sr = modeSwitchEl.getBoundingClientRect();
-      const br = activeBtn.getBoundingClientRect();
-      modeSwitchEl.style.setProperty('--indicator-left', `${br.left - sr.left}px`);
-      modeSwitchEl.style.setProperty('--indicator-width', `${br.width}px`);
-    }
+  const statusMode = status.mode || 'companion';
+  if (pendingModeSelection && statusMode === pendingModeSelection) {
+    pendingModeSelection = '';
   }
+  const currentMode = pendingModeSelection || statusMode;
+  document.getElementById('summaryText').textContent = buildStatusSummaryText({
+    ...status,
+    mode: currentMode,
+  });
+  updateModeSwitchControl(currentMode);
   const currentSpeed = status.advance_speed || 'medium';
   document.querySelectorAll('#speedSwitch .speed-btn').forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.speed === currentSpeed);
@@ -5653,6 +5688,11 @@ async function saveMode({ auto = false } = {}) {
     return;
   }
   try {
+    if (mode && (!latestStatus || latestStatus.mode !== mode)) {
+      pendingModeSelection = mode;
+      updateModeSwitchControl(mode);
+      updateSummaryMode(mode);
+    }
     settingsSaveInFlight = true;
     updateSettingsDirtyHint(auto ? uiT('ui.pending.auto_saving', '正在自动保存...') : uiT('ui.pending.saving', '保存中...'));
     setFlash(auto ? uiT('ui.flash.auto_saving_settings', '正在自动保存设置...') : uiT('ui.flash.saving_settings', '正在保存设置...'), 'info');
@@ -5677,6 +5717,12 @@ async function saveMode({ auto = false } = {}) {
     updateSettingsDirtyHint();
     await refreshAll({ preserveFlash: true, forceInsights: true, forceRefresh: true });
   } catch (error) {
+    if (pendingModeSelection === mode) {
+      pendingModeSelection = '';
+      if (latestStatus) {
+        renderStatus(latestStatus);
+      }
+    }
     setFlash(error instanceof Error ? error.message : String(error), 'error');
   } finally {
     settingsSaveInFlight = false;
@@ -6766,6 +6812,9 @@ document.querySelectorAll('#modeSwitch .mode-btn').forEach((btn) => {
     if (select && mode) {
       select.value = mode;
       select.dispatchEvent(new Event('change'));
+      pendingModeSelection = mode;
+      updateModeSwitchControl(mode);
+      updateSummaryMode(mode);
       saveMode().catch((error) => { console.error('[galgame] async action failed', error); });
     }
   });

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -692,6 +692,7 @@ let activeInstallTab = 'rapidocr';
 let settingsDirty = false;
 let settingsSaveInFlight = false;
 let pendingModeSelection = '';
+let modeSaveRequestId = 0;
 let settingsAutosaveTimer = null;
 let flashTimer = null;
 let flashToken = 0;
@@ -3255,15 +3256,14 @@ function clearPendingModeSelection(mode) {
 
 function renderStatus(status) {
   latestStatus = status;
-  syncSettingsValue('modeSelect', status.mode || 'companion');
-  syncSettingsChecked('pushToggle', Boolean(status.push_notifications));
-  syncSettingsValue('advanceSpeedSelect', status.advance_speed || 'medium');
-
   const statusMode = status.mode || 'companion';
   if (pendingModeSelection && statusMode === pendingModeSelection) {
     pendingModeSelection = '';
   }
   const currentMode = pendingModeSelection || statusMode;
+  syncSettingsValue('modeSelect', currentMode);
+  syncSettingsChecked('pushToggle', Boolean(status.push_notifications));
+  syncSettingsValue('advanceSpeedSelect', status.advance_speed || 'medium');
   document.getElementById('summaryText').textContent = buildStatusSummaryText({
     ...status,
     mode: currentMode,
@@ -5674,6 +5674,8 @@ function scheduleSettingsAutosave() {
 }
 
 async function saveMode({ auto = false } = {}) {
+  const requestId = ++modeSaveRequestId;
+  let modeCommitted = false;
   clearSettingsAutosaveTimer();
   const mode = document.getElementById('modeSelect').value;
   const pushNotifications = document.getElementById('pushToggle').checked;
@@ -5721,6 +5723,7 @@ async function saveMode({ auto = false } = {}) {
       advance_speed: advanceSpeed,
       reader_mode: readerMode,
     });
+    modeCommitted = true;
     await callPlugin('galgame_set_ocr_timing', {
       poll_interval_seconds: ocrPollInterval,
       trigger_mode: ocrTriggerMode,
@@ -5734,9 +5737,21 @@ async function saveMode({ auto = false } = {}) {
     settingsDirty = false;
     settingsSaveInFlight = false;
     updateSettingsDirtyHint();
-    await refreshAll({ preserveFlash: true, forceInsights: true, forceRefresh: true });
+    if (requestId === modeSaveRequestId) {
+      await refreshAll({ preserveFlash: true, forceInsights: true, forceRefresh: true });
+    }
   } catch (error) {
-    clearPendingModeSelection(mode);
+    if (requestId === modeSaveRequestId) {
+      if (modeCommitted) {
+        try {
+          await refreshAll({ preserveFlash: true, forceRefresh: true });
+        } catch (refreshError) {
+          console.error('[galgame] mode save reconcile refresh failed', refreshError);
+        }
+      } else {
+        clearPendingModeSelection(mode);
+      }
+    }
     setFlash(error instanceof Error ? error.message : String(error), 'error');
   } finally {
     settingsSaveInFlight = false;

--- a/plugin/plugins/galgame_plugin/static/style.css
+++ b/plugin/plugins/galgame_plugin/static/style.css
@@ -1918,16 +1918,107 @@ body:not(.onboarding-active) #onboardingView {
   align-items: center;
 }
 
-.mode-switch,
-.speed-switch {
+/* ---- mode-switch (pill segmented control) ---- */
+
+.mode-switch {
+  position: relative;
   display: flex;
+  gap: 2px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(31, 42, 51, 0.06);
+  isolation: isolate;
+}
+
+.mode-switch::before {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: var(--indicator-left, 76px);
+  width: var(--indicator-width, 72px);
+  height: calc(100% - 8px);
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(31, 42, 51, 0.1), 0 1px 2px rgba(31, 42, 51, 0.06);
+  transition: left 300ms cubic-bezier(0.4, 0, 0.2, 1),
+              width 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.mode-btn {
+  position: relative;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  border: none;
+  cursor: pointer;
+  transition: color 200ms ease;
+  z-index: 1;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.mode-btn:hover {
+  color: var(--ink);
+}
+
+.mode-btn.active {
+  background: transparent;
+  box-shadow: none;
+}
+
+.mode-btn:active {
+  transform: scale(0.95);
+  transition: transform 100ms ease;
+}
+
+.mode-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+/* ---- Mode accents ---- */
+
+.mode-btn[data-mode="silent"].active {
+  color: var(--muted);
+}
+
+.mode-switch[data-active="silent"]::before {
+  background: #f0f0f0;
+  box-shadow: 0 2px 8px rgba(31, 42, 51, 0.08);
+}
+
+.mode-btn[data-mode="companion"].active {
+  color: var(--brand-strong);
+}
+
+.mode-switch[data-active="companion"]::before {
+  background: rgba(14, 138, 124, 0.1);
+  box-shadow: 0 2px 8px rgba(14, 138, 124, 0.12);
+}
+
+.mode-btn[data-mode="choice_advisor"].active {
+  color: var(--accent);
+}
+
+.mode-switch[data-active="choice_advisor"]::before {
+  background: rgba(210, 95, 69, 0.08);
+  box-shadow: 0 2px 8px rgba(210, 95, 69, 0.12);
+}
+
+/* ---- speed-switch ---- */
+
+.speed-switch {
   gap: 4px;
   padding: 4px;
   border-radius: 999px;
   background: rgba(31, 42, 51, 0.06);
 }
 
-.mode-btn,
 .speed-btn {
   padding: 8px 16px;
   border-radius: 999px;
@@ -1939,12 +2030,10 @@ body:not(.onboarding-active) #onboardingView {
   transition: background 150ms ease, color 150ms ease;
 }
 
-.mode-btn:hover,
 .speed-btn:hover {
   background: rgba(255, 255, 255, 0.5);
 }
 
-.mode-btn.active,
 .speed-btn.active {
   background: #fff;
   color: var(--brand-strong);
@@ -2156,9 +2245,13 @@ body:not(.onboarding-active) #onboardingView {
     align-items: stretch;
   }
 
-  .mode-switch,
+  .mode-switch {
+    align-self: flex-start;
+  }
+
   .speed-switch {
     flex-direction: column;
+    align-self: stretch;
   }
 
   .primary-diagnosis-actions,

--- a/plugin/plugins/galgame_plugin/static/style.css
+++ b/plugin/plugins/galgame_plugin/static/style.css
@@ -1209,10 +1209,16 @@ button.active {
 }
 
 .flash-message {
-  margin-top: 14px;
+  position: fixed;
+  top: 18px;
+  right: 24px;
+  z-index: 1000;
+  width: min(420px, calc(100vw - 32px));
+  margin: 0;
   padding: 12px 14px;
   border-radius: var(--radius-sm);
   font-size: 14px;
+  box-shadow: 0 12px 30px rgba(31, 42, 51, 0.14);
 }
 
 .flash-message.success {
@@ -1942,8 +1948,13 @@ body:not(.onboarding-active) #onboardingView {
   box-shadow: 0 2px 8px rgba(31, 42, 51, 0.1), 0 1px 2px rgba(31, 42, 51, 0.06);
   transition: left 300ms cubic-bezier(0.4, 0, 0.2, 1),
               width 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  opacity: 0;
   z-index: 0;
   pointer-events: none;
+}
+
+.mode-switch[data-ready="true"]::before {
+  opacity: 1;
 }
 
 .mode-btn {

--- a/plugin/plugins/galgame_plugin/static/style.css
+++ b/plugin/plugins/galgame_plugin/static/style.css
@@ -1212,7 +1212,7 @@ button.active {
   position: fixed;
   top: 18px;
   right: 24px;
-  z-index: 1000;
+  z-index: 1100;
   width: min(420px, calc(100vw - 32px));
   margin: 0;
   padding: 12px 14px;


### PR DESCRIPTION

  ## 概要

  - 为 Galgame 模式切换控件增加滑动指示器和模式色彩区分
  - 拆分 mode-switch 与 speed-switch 样式，避免影响速度切换控件
  - 加入 hover、按下、键盘焦点等微交互
  - 加载状态未就绪时隐藏滑块，避免初始错位显示
  - 点击模式后立即更新滑块和摘要文字，避免等待下一次状态刷新
  - 增加 pending 模式保护，避免旧状态刷新把滑块拉回点击前模式
  - 将保存提示改为右上角 toast，提升点击反馈可见性

  ## 验证

  - `node --check plugin\plugins\galgame_plugin\static\main.js`
  - `git diff --check -- plugin/plugins/galgame_plugin/static/style.css plugin/plugins/galgame_plugin/static/main.js`
  - CSS 大括号数量检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 引入待定模式切换工作流：切换先进入队列并在界面反映，需通过单独“保存”操作才持久化
  * 添加待定状态管理与界面辅助，保存失败或插件不可用时会清除待定状态

* **修复**
  * 增加模式输入校验：无效输入会清除待定并阻止异常状态

* **样式**
  * 优化模式/速度切换的胶囊式样式与响应式布局
  * 新增右上角固定吐司提示样式与定位
<!-- end of auto-generated comment: release notes by coderabbit.ai -->