### PR TITLE
fix(galgame): OCR 捕获线程卡死后替换新 worker，不再永久失败

### DIFF
--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -287,6 +287,15 @@ _OCR_STABILITY_IGNORED_CHARS_RE = re.compile(
 )
 _OCR_FOLLOWUP_CONFIRM_DELAY_SECONDS = 0.18
 _OCR_CAPTURE_TIMEOUT_SECONDS = 12.0
+
+
+class _CaptureStillRunning(TimeoutError):
+    """Backpressure: previous capture worker has not finished yet."""
+
+
+class _CaptureTimedOut(TimeoutError):
+    """A single capture/OCR call exceeded the deadline."""
+
 _FOREGROUND_ADVANCE_STABLE_GRACE_SECONDS = 2.0
 _CAPTURE_BACKEND_AUTO = "auto"
 _CAPTURE_BACKEND_SMART = "smart"
@@ -6487,15 +6496,23 @@ class OcrReaderManager:
             current = self._capture_future
             if current is not None and not current.done():
                 elapsed = max(0.0, time.monotonic() - float(self._capture_future_started_at or 0.0))
-                prefix = (
-                    "previous ocr_reader capture/OCR timed out and is still running"
-                    if self._capture_future_timed_out
-                    else "previous ocr_reader capture/OCR is still running"
-                )
-                raise TimeoutError(
-                    f"{prefix} after {elapsed:.1f}s; "
-                    "skipping new capture to avoid overlapping OCR work"
-                )
+                if self._capture_future_timed_out:
+                    old_executor = self._capture_executor
+                    if old_executor is not None:
+                        old_executor.shutdown(wait=False, cancel_futures=True)
+                    self._capture_future = None
+                    self._capture_future_started_at = 0.0
+                    self._capture_future_timed_out = False
+                    self._capture_executor = None
+                    self._logger.warning(
+                        "ocr_reader replacing stuck capture worker after %.1fs timeout",
+                        elapsed,
+                    )
+                else:
+                    raise _CaptureStillRunning(
+                        f"previous ocr_reader capture/OCR is still running after {elapsed:.1f}s; "
+                        "skipping new capture to avoid overlapping OCR work"
+                    )
             executor = self._capture_executor
             if executor is None:
                 executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="galgame-ocr-capture")
@@ -6547,7 +6564,7 @@ class OcrReaderManager:
             with self._capture_worker_lock:
                 if self._capture_future is future:
                     self._capture_future_timed_out = True
-            raise TimeoutError(
+            raise _CaptureTimedOut(
                 f"ocr_reader capture/OCR timed out after {timeout_seconds:.1f}s"
             ) from exc
         finally:
@@ -7606,6 +7623,18 @@ class OcrReaderManager:
                             )
                             if emitted:
                                 now = followup_now
+        except _CaptureStillRunning as exc:
+            self._logger.debug("ocr_reader tick skipped (backpressure): {}", exc)
+            result.warnings.append(f"ocr_reader tick skipped: {exc}")
+            capture_attempted = False
+        except _CaptureTimedOut as exc:
+            self._logger.warning("ocr_reader capture/OCR timed out: {}", exc)
+            capture_error = True
+            self._record_capture_error(now=now, error=exc)
+            self._reset_aihong_menu_state()
+            if int(self._writer.last_seq or 0) <= 1:
+                self._writer.discard_session()
+            result.warnings.append(f"ocr_reader capture timed out: {exc}")
         except Exception as exc:
             self._logger.warning("ocr_reader capture/OCR failed: {}", exc)
             capture_error = True

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6497,22 +6497,14 @@ class OcrReaderManager:
             if current is not None and not current.done():
                 elapsed = max(0.0, time.monotonic() - float(self._capture_future_started_at or 0.0))
                 if self._capture_future_timed_out:
-                    old_executor = self._capture_executor
-                    if old_executor is not None:
-                        old_executor.shutdown(wait=False, cancel_futures=True)
-                    self._capture_future = None
-                    self._capture_future_started_at = 0.0
-                    self._capture_future_timed_out = False
-                    self._capture_executor = None
-                    self._logger.warning(
-                        "ocr_reader replacing stuck capture worker after %.1fs timeout",
-                        elapsed,
-                    )
-                else:
                     raise _CaptureStillRunning(
-                        f"previous ocr_reader capture/OCR is still running after {elapsed:.1f}s; "
-                        "skipping new capture to avoid overlapping OCR work"
+                        f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
+                        "skipping new capture to avoid accumulating blocked OCR threads"
                     )
+                raise _CaptureStillRunning(
+                    f"previous ocr_reader capture/OCR is still running after {elapsed:.1f}s; "
+                    "skipping new capture to avoid overlapping OCR work"
+                )
             executor = self._capture_executor
             if executor is None:
                 executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="galgame-ocr-capture")

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6547,6 +6547,7 @@ class OcrReaderManager:
                             >= _OCR_MAX_ABANDONED_CAPTURE_WORKERS
                         ):
                             if executor is not None:
+                                self._abandoned_capture_workers.append((executor, current))
                                 executors_to_shutdown.append(executor)
                             self._capture_executor = None
                             self._capture_future = None

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6525,6 +6525,8 @@ class OcrReaderManager:
         executors_to_shutdown: list[ThreadPoolExecutor] = []
         recovered_elapsed = 0.0
         cancel_requested = False
+        timeout_error: _CaptureTimedOut | None = None
+        future: Future[OcrExtractionResult] | None = None
         with self._capture_worker_lock:
             executors_to_shutdown.extend(self._drain_completed_abandoned_capture_workers_locked())
             current = self._capture_future
@@ -6544,19 +6546,26 @@ class OcrReaderManager:
                             and len(self._abandoned_capture_workers)
                             >= _OCR_MAX_ABANDONED_CAPTURE_WORKERS
                         ):
-                            raise _CaptureTimedOut(
+                            if executor is not None:
+                                executors_to_shutdown.append(executor)
+                            self._capture_executor = None
+                            self._capture_future = None
+                            self._capture_future_started_at = 0.0
+                            self._capture_future_timed_out = False
+                            timeout_error = _CaptureTimedOut(
                                 f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
                                 "stuck capture worker recovery limit reached"
                             )
-                        if executor is not None:
+                        elif executor is not None:
                             if not cancel_requested and not current.done():
                                 self._abandoned_capture_workers.append((executor, current))
                             executors_to_shutdown.append(executor)
-                        self._capture_executor = None
-                        self._capture_future = None
-                        self._capture_future_started_at = 0.0
-                        self._capture_future_timed_out = False
-                        recovered_elapsed = elapsed
+                        if timeout_error is None:
+                            self._capture_executor = None
+                            self._capture_future = None
+                            self._capture_future_started_at = 0.0
+                            self._capture_future_timed_out = False
+                            recovered_elapsed = elapsed
                     else:
                         raise _CaptureStillRunning(
                             f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
@@ -6567,22 +6576,23 @@ class OcrReaderManager:
                         f"previous ocr_reader capture/OCR is still running after {elapsed:.1f}s; "
                         "skipping new capture to avoid overlapping OCR work"
                     )
-            executor = self._capture_executor
-            if executor is None:
-                executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="galgame-ocr-capture")
+            if timeout_error is None:
+                executor = self._capture_executor
+                if executor is None:
+                    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="galgame-ocr-capture")
+                    self._capture_executor = executor
+                future = executor.submit(
+                    self._capture_and_extract_text,
+                    target,
+                    profile,
+                    backend_plan,
+                    collect_background_hash,
+                    allow_separate_background_capture,
+                )
                 self._capture_executor = executor
-            future = executor.submit(
-                self._capture_and_extract_text,
-                target,
-                profile,
-                backend_plan,
-                collect_background_hash,
-                allow_separate_background_capture,
-            )
-            self._capture_executor = executor
-            self._capture_future = future
-            self._capture_future_started_at = time.monotonic()
-            self._capture_future_timed_out = False
+                self._capture_future = future
+                self._capture_future_started_at = time.monotonic()
+                self._capture_future_timed_out = False
         if recovered_elapsed > 0.0:
             self._logger.warning(
                 "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}",
@@ -6591,6 +6601,9 @@ class OcrReaderManager:
             )
         for executor_to_shutdown in executors_to_shutdown:
             executor_to_shutdown.shutdown(wait=False, cancel_futures=True)
+        if timeout_error is not None:
+            raise timeout_error
+        assert future is not None
         return future
 
     async def _capture_and_extract_text_with_timeout(

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -287,6 +287,7 @@ _OCR_STABILITY_IGNORED_CHARS_RE = re.compile(
 )
 _OCR_FOLLOWUP_CONFIRM_DELAY_SECONDS = 0.18
 _OCR_CAPTURE_TIMEOUT_SECONDS = 12.0
+_OCR_MAX_ABANDONED_CAPTURE_WORKERS = 1
 
 
 class _CaptureStillRunning(TimeoutError):
@@ -4520,6 +4521,9 @@ class OcrReaderManager:
         self._capture_future: Future[OcrExtractionResult] | None = None
         self._capture_future_started_at = 0.0
         self._capture_future_timed_out = False
+        self._abandoned_capture_workers: list[
+            tuple[ThreadPoolExecutor, Future[OcrExtractionResult]]
+        ] = []
         self._window_inventory_cache_at = 0.0
         self._window_inventory_cache: list[DetectedGameWindow] = []
         self._start_rapidocr_warmup_if_configured()
@@ -6451,38 +6455,64 @@ class OcrReaderManager:
             and not _ocr_stability_keys_match(cleaned_key, stable_key)
         )
 
+    def _drain_completed_abandoned_capture_workers_locked(self) -> list[ThreadPoolExecutor]:
+        executors: list[ThreadPoolExecutor] = []
+        active: list[tuple[ThreadPoolExecutor, Future[OcrExtractionResult]]] = []
+        for executor, future in self._abandoned_capture_workers:
+            if future.done():
+                executors.append(executor)
+                try:
+                    future.result()
+                except Exception as exc:
+                    self._logger.debug("ocr_reader abandoned timed-out capture eventually failed: {}", exc)
+            else:
+                active.append((executor, future))
+        self._abandoned_capture_workers = active
+        return executors
+
     def _shutdown_capture_worker(self) -> None:
-        executor: ThreadPoolExecutor | None = None
+        executors: list[ThreadPoolExecutor] = []
         with self._capture_worker_lock:
             future = self._capture_future
             if future is not None and not future.done():
                 future.cancel()
-            executor = self._capture_executor
+            if self._capture_executor is not None:
+                executors.append(self._capture_executor)
+            for executor, abandoned_future in self._abandoned_capture_workers:
+                if not abandoned_future.done():
+                    abandoned_future.cancel()
+                executors.append(executor)
+            self._abandoned_capture_workers = []
             self._capture_executor = None
             self._capture_future = None
             self._capture_future_started_at = 0.0
             self._capture_future_timed_out = False
-        if executor is not None:
+        for executor in executors:
             # Project requires Python 3.11; cancel_futures is available on >=3.9.
             executor.shutdown(wait=False, cancel_futures=True)
 
     def _clear_completed_capture_worker(self) -> None:
         future: Future[OcrExtractionResult] | None = None
         timed_out = False
+        executors_to_shutdown: list[ThreadPoolExecutor] = []
         with self._capture_worker_lock:
+            executors_to_shutdown.extend(self._drain_completed_abandoned_capture_workers_locked())
             current = self._capture_future
             if current is None or not current.done():
-                return
-            future = current
-            timed_out = bool(self._capture_future_timed_out)
-            self._capture_future = None
-            self._capture_future_started_at = 0.0
-            self._capture_future_timed_out = False
+                future = None
+            else:
+                future = current
+                timed_out = bool(self._capture_future_timed_out)
+                self._capture_future = None
+                self._capture_future_started_at = 0.0
+                self._capture_future_timed_out = False
         if timed_out and future is not None:
             try:
                 future.result()
             except Exception as exc:
                 self._logger.debug("ocr_reader previous timed-out capture eventually failed: {}", exc)
+        for executor in executors_to_shutdown:
+            executor.shutdown(wait=False, cancel_futures=True)
 
     def _submit_capture_worker(
         self,
@@ -6492,10 +6522,11 @@ class OcrReaderManager:
         collect_background_hash: bool,
         allow_separate_background_capture: bool,
     ) -> Future[OcrExtractionResult]:
-        executor_to_shutdown: ThreadPoolExecutor | None = None
+        executors_to_shutdown: list[ThreadPoolExecutor] = []
         recovered_elapsed = 0.0
         cancel_requested = False
         with self._capture_worker_lock:
+            executors_to_shutdown.extend(self._drain_completed_abandoned_capture_workers_locked())
             current = self._capture_future
             if current is not None and not current.done():
                 elapsed = max(0.0, time.monotonic() - float(self._capture_future_started_at or 0.0))
@@ -6506,18 +6537,26 @@ class OcrReaderManager:
                     recovery_after = timeout_seconds + max(timeout_seconds, 0.25)
                     if elapsed >= recovery_after:
                         cancel_requested = current.cancel()
-                        if cancel_requested or current.done():
-                            executor_to_shutdown = self._capture_executor
-                            self._capture_executor = None
-                            self._capture_future = None
-                            self._capture_future_started_at = 0.0
-                            self._capture_future_timed_out = False
-                            recovered_elapsed = elapsed
-                        else:
+                        executor = self._capture_executor
+                        if (
+                            not cancel_requested
+                            and not current.done()
+                            and len(self._abandoned_capture_workers)
+                            >= _OCR_MAX_ABANDONED_CAPTURE_WORKERS
+                        ):
                             raise _CaptureStillRunning(
                                 f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
-                                "cancel failed, keeping backpressure to avoid accumulating blocked OCR threads"
+                                "stuck capture worker recovery limit reached"
                             )
+                        if executor is not None:
+                            if not cancel_requested and not current.done():
+                                self._abandoned_capture_workers.append((executor, current))
+                            executors_to_shutdown.append(executor)
+                        self._capture_executor = None
+                        self._capture_future = None
+                        self._capture_future_started_at = 0.0
+                        self._capture_future_timed_out = False
+                        recovered_elapsed = elapsed
                     else:
                         raise _CaptureStillRunning(
                             f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
@@ -6544,12 +6583,13 @@ class OcrReaderManager:
             self._capture_future = future
             self._capture_future_started_at = time.monotonic()
             self._capture_future_timed_out = False
-        if executor_to_shutdown is not None:
+        if recovered_elapsed > 0.0:
             self._logger.warning(
                 "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}",
                 recovered_elapsed,
                 cancel_requested,
             )
+        for executor_to_shutdown in executors_to_shutdown:
             executor_to_shutdown.shutdown(wait=False, cancel_futures=True)
         return future
 

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6544,7 +6544,7 @@ class OcrReaderManager:
                             and len(self._abandoned_capture_workers)
                             >= _OCR_MAX_ABANDONED_CAPTURE_WORKERS
                         ):
-                            raise _CaptureStillRunning(
+                            raise _CaptureTimedOut(
                                 f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
                                 "stuck capture worker recovery limit reached"
                             )

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6506,12 +6506,18 @@ class OcrReaderManager:
                     recovery_after = timeout_seconds + max(timeout_seconds, 0.25)
                     if elapsed >= recovery_after:
                         cancel_requested = current.cancel()
-                        executor_to_shutdown = self._capture_executor
-                        self._capture_executor = None
-                        self._capture_future = None
-                        self._capture_future_started_at = 0.0
-                        self._capture_future_timed_out = False
-                        recovered_elapsed = elapsed
+                        if cancel_requested or current.done():
+                            executor_to_shutdown = self._capture_executor
+                            self._capture_executor = None
+                            self._capture_future = None
+                            self._capture_future_started_at = 0.0
+                            self._capture_future_timed_out = False
+                            recovered_elapsed = elapsed
+                        else:
+                            raise _CaptureStillRunning(
+                                f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
+                                "cancel failed, keeping backpressure to avoid accumulating blocked OCR threads"
+                            )
                     else:
                         raise _CaptureStillRunning(
                             f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6492,19 +6492,36 @@ class OcrReaderManager:
         collect_background_hash: bool,
         allow_separate_background_capture: bool,
     ) -> Future[OcrExtractionResult]:
+        executor_to_shutdown: ThreadPoolExecutor | None = None
+        recovered_elapsed = 0.0
+        cancel_requested = False
         with self._capture_worker_lock:
             current = self._capture_future
             if current is not None and not current.done():
                 elapsed = max(0.0, time.monotonic() - float(self._capture_future_started_at or 0.0))
                 if self._capture_future_timed_out:
+                    timeout_seconds = float(_OCR_CAPTURE_TIMEOUT_SECONDS)
+                    if timeout_seconds <= 0.0:
+                        timeout_seconds = 12.0
+                    recovery_after = timeout_seconds + max(timeout_seconds, 0.25)
+                    if elapsed >= recovery_after:
+                        cancel_requested = current.cancel()
+                        executor_to_shutdown = self._capture_executor
+                        self._capture_executor = None
+                        self._capture_future = None
+                        self._capture_future_started_at = 0.0
+                        self._capture_future_timed_out = False
+                        recovered_elapsed = elapsed
+                    else:
+                        raise _CaptureStillRunning(
+                            f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
+                            "skipping new capture to avoid accumulating blocked OCR threads"
+                        )
+                else:
                     raise _CaptureStillRunning(
-                        f"previous ocr_reader capture/OCR timed out and is still running after {elapsed:.1f}s; "
-                        "skipping new capture to avoid accumulating blocked OCR threads"
+                        f"previous ocr_reader capture/OCR is still running after {elapsed:.1f}s; "
+                        "skipping new capture to avoid overlapping OCR work"
                     )
-                raise _CaptureStillRunning(
-                    f"previous ocr_reader capture/OCR is still running after {elapsed:.1f}s; "
-                    "skipping new capture to avoid overlapping OCR work"
-                )
             executor = self._capture_executor
             if executor is None:
                 executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="galgame-ocr-capture")
@@ -6521,7 +6538,14 @@ class OcrReaderManager:
             self._capture_future = future
             self._capture_future_started_at = time.monotonic()
             self._capture_future_timed_out = False
-            return future
+        if executor_to_shutdown is not None:
+            self._logger.warning(
+                "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}",
+                recovered_elapsed,
+                cancel_requested,
+            )
+            executor_to_shutdown.shutdown(wait=False, cancel_futures=True)
+        return future
 
     async def _capture_and_extract_text_with_timeout(
         self,
@@ -7618,6 +7642,9 @@ class OcrReaderManager:
         except _CaptureStillRunning as exc:
             self._logger.debug("ocr_reader tick skipped (backpressure): {}", exc)
             result.warnings.append(f"ocr_reader tick skipped: {exc}")
+            self._last_capture_error = ""
+            self._runtime.last_capture_error = ""
+            self._runtime.detail = "capture_backpressure"
             capture_attempted = False
         except _CaptureTimedOut as exc:
             self._logger.warning("ocr_reader capture/OCR timed out: {}", exc)

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import Future
 from dataclasses import fields
 import hashlib
 import json
@@ -1480,7 +1481,55 @@ async def test_ocr_reader_capture_timeout_returns_capture_failed_runtime(
 
 
 @pytest.mark.asyncio
-async def test_ocr_reader_capture_timeout_does_not_overlap_still_running_capture(
+async def test_ocr_reader_backpressure_skip_is_not_capture_error(
+    tmp_path: Path,
+) -> None:
+    bridge_root = tmp_path / "bridge"
+    bridge_root.mkdir()
+    install_root = tmp_path / "Tesseract"
+    _install_fake_tesseract(install_root)
+    manager = OcrReaderManager(
+        logger=_Logger(),
+        config=_make_config(
+            bridge_root,
+            install_target_dir=str(install_root),
+            rapidocr_enabled=False,
+        ),
+        time_fn=lambda: 3001.0,
+        platform_fn=lambda: True,
+        window_scanner=lambda: [
+            DetectedGameWindow(
+                hwnd=102,
+                title="Demo Window",
+                process_name="DemoGame.exe",
+                pid=4243,
+                width=1280,
+                height=720,
+            )
+        ],
+        capture_backend=_FakeCaptureBackend(),
+        ocr_backend=_FakeOcrBackend(),
+        writer=OcrReaderBridgeWriter(bridge_root=bridge_root, time_fn=lambda: 3001.0),
+    )
+    pending: Future[OcrExtractionResult] = Future()
+    with manager._capture_worker_lock:
+        manager._capture_future = pending
+        manager._capture_future_started_at = time.monotonic()
+        manager._capture_future_timed_out = False
+
+    try:
+        result = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
+
+        assert result.runtime["detail"] != "capture_failed"
+        assert result.runtime["last_capture_error"] == ""
+        assert any("tick skipped" in warning and "still running" in warning for warning in result.warnings)
+    finally:
+        pending.cancel()
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ocr_reader_capture_timeout_replaces_stuck_worker(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1495,14 +1544,16 @@ async def test_ocr_reader_capture_timeout_does_not_overlap_still_running_capture
         def extract_text(self, image: str) -> str:
             del image
             self.calls += 1
-            started.set()
-            release.wait(timeout=2.0)
+            if self.calls == 1:
+                started.set()
+                release.wait(timeout=2.0)
             return "雪乃：恢复后的台词。"
 
     backend = _BlockingOcrBackend()
+    logger = _CapturingLogger()
     monkeypatch.setattr(galgame_ocr_reader, "_OCR_CAPTURE_TIMEOUT_SECONDS", 0.01)
     manager = OcrReaderManager(
-        logger=_Logger(),
+        logger=logger,
         config=_make_config(
             bridge_root,
             install_target_dir=str(install_root),
@@ -1533,10 +1584,13 @@ async def test_ocr_reader_capture_timeout_does_not_overlap_still_running_capture
 
         second = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 
-        assert backend.calls == 1
-        assert second.runtime["detail"] == "capture_failed"
-        assert "still running" in second.runtime["last_capture_error"]
-        assert any("still running" in warning for warning in second.warnings)
+        assert backend.calls == 2
+        assert second.runtime["detail"] == "receiving_text"
+        assert second.runtime["last_raw_ocr_text"] == "雪乃：恢复后的台词。"
+        assert any(
+            warning[0] == "ocr_reader replacing stuck capture worker after %.1fs timeout"
+            for warning in logger.warnings
+        )
     finally:
         release.set()
         await manager.shutdown()

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1718,9 +1718,12 @@ async def test_ocr_reader_capture_timeout_recovery_is_bounded(
         result = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 
         assert backend.calls == 0
-        assert result.runtime["detail"] == "capture_backpressure"
-        assert result.runtime["last_capture_error"] == ""
-        assert any("recovery limit reached" in warning for warning in result.warnings)
+        assert result.runtime["detail"] == "capture_failed"
+        assert "recovery limit reached" in result.runtime["last_capture_error"]
+        assert any(
+            "capture timed out" in warning and "recovery limit reached" in warning
+            for warning in result.warnings
+        )
     finally:
         await manager.shutdown()
 

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1599,15 +1599,72 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
             manager._capture_future_started_at = time.monotonic() - 1.0
         third = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 
-        assert backend.calls == 2
-        assert third.runtime["detail"] == "receiving_text"
-        assert any(
+        assert backend.calls == 1
+        assert third.runtime["detail"] == "capture_backpressure"
+        assert third.runtime["last_capture_error"] == ""
+        assert not any(
             warning[0]
             == "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}"
             for warning in logger.warnings
         )
     finally:
         release.set()
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ocr_reader_capture_timeout_recovers_cancellable_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_root = tmp_path / "bridge"
+    bridge_root.mkdir()
+    install_root = tmp_path / "Tesseract"
+    _install_fake_tesseract(install_root)
+    backend = _FakeOcrBackend(["雪乃：恢复后的台词。"])
+    logger = _CapturingLogger()
+    monkeypatch.setattr(galgame_ocr_reader, "_OCR_CAPTURE_TIMEOUT_SECONDS", 0.01)
+    manager = OcrReaderManager(
+        logger=logger,
+        config=_make_config(
+            bridge_root,
+            install_target_dir=str(install_root),
+            rapidocr_enabled=False,
+        ),
+        time_fn=lambda: 3001.0,
+        platform_fn=lambda: True,
+        window_scanner=lambda: [
+            DetectedGameWindow(
+                hwnd=102,
+                title="Demo Window",
+                process_name="DemoGame.exe",
+                pid=4243,
+                width=1280,
+                height=720,
+            )
+        ],
+        capture_backend=_FakeCaptureBackend(),
+        ocr_backend=backend,
+        writer=OcrReaderBridgeWriter(bridge_root=bridge_root, time_fn=lambda: 3001.0),
+    )
+    pending: Future[OcrExtractionResult] = Future()
+    with manager._capture_worker_lock:
+        manager._capture_future = pending
+        manager._capture_future_started_at = time.monotonic() - 1.0
+        manager._capture_future_timed_out = True
+
+    try:
+        result = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
+
+        assert pending.cancelled()
+        assert backend.calls == 1
+        assert result.runtime["detail"] == "receiving_text"
+        assert any(
+            warning[0]
+            == "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}"
+            for warning in logger.warnings
+        )
+    finally:
         await manager.shutdown()
 
 

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from concurrent.futures import Future
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import fields
 import hashlib
 import json
@@ -1706,10 +1706,11 @@ async def test_ocr_reader_capture_timeout_recovery_is_bounded(
     assert abandoned.set_running_or_notify_cancel()
     current: Future[OcrExtractionResult] = Future()
     assert current.set_running_or_notify_cancel()
-    executor = manager._capture_executor
-    assert executor is not None
+    abandoned_executor = ThreadPoolExecutor(max_workers=1)
+    current_executor = manager._capture_executor
+    assert current_executor is not None
     with manager._capture_worker_lock:
-        manager._abandoned_capture_workers = [(executor, abandoned)]
+        manager._abandoned_capture_workers = [(abandoned_executor, abandoned)]
         manager._capture_future = current
         manager._capture_future_started_at = time.monotonic() - 1.0
         manager._capture_future_timed_out = True
@@ -1728,6 +1729,10 @@ async def test_ocr_reader_capture_timeout_recovery_is_bounded(
             assert manager._capture_future is None
             assert manager._capture_executor is None
             assert manager._capture_future_timed_out is False
+            assert manager._abandoned_capture_workers == [
+                (abandoned_executor, abandoned),
+                (current_executor, current),
+            ]
 
         retry = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1724,6 +1724,15 @@ async def test_ocr_reader_capture_timeout_recovery_is_bounded(
             "capture timed out" in warning and "recovery limit reached" in warning
             for warning in result.warnings
         )
+        with manager._capture_worker_lock:
+            assert manager._capture_future is None
+            assert manager._capture_executor is None
+            assert manager._capture_future_timed_out is False
+
+        retry = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
+
+        assert backend.calls == 1
+        assert retry.runtime["detail"] == "receiving_text"
     finally:
         await manager.shutdown()
 

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1516,11 +1516,14 @@ async def test_ocr_reader_backpressure_skip_is_not_capture_error(
         manager._capture_future = pending
         manager._capture_future_started_at = time.monotonic()
         manager._capture_future_timed_out = False
+    manager._last_capture_error = "previous capture failed"
+    manager._runtime.detail = "capture_failed"
+    manager._runtime.last_capture_error = "previous capture failed"
 
     try:
         result = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 
-        assert result.runtime["detail"] != "capture_failed"
+        assert result.runtime["detail"] == "capture_backpressure"
         assert result.runtime["last_capture_error"] == ""
         assert any("tick skipped" in warning and "still running" in warning for warning in result.warnings)
     finally:
@@ -1529,7 +1532,7 @@ async def test_ocr_reader_backpressure_skip_is_not_capture_error(
 
 
 @pytest.mark.asyncio
-async def test_ocr_reader_capture_timeout_replaces_stuck_worker(
+async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1584,11 +1587,23 @@ async def test_ocr_reader_capture_timeout_replaces_stuck_worker(
 
         second = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 
-        assert backend.calls == 2
-        assert second.runtime["detail"] == "receiving_text"
-        assert second.runtime["last_raw_ocr_text"] == "雪乃：恢复后的台词。"
-        assert any(
+        assert backend.calls == 1
+        assert second.runtime["detail"] == "capture_backpressure"
+        assert second.runtime["last_capture_error"] == ""
+        assert not any(
             warning[0] == "ocr_reader replacing stuck capture worker after %.1fs timeout"
+            for warning in logger.warnings
+        )
+
+        with manager._capture_worker_lock:
+            manager._capture_future_started_at = time.monotonic() - 1.0
+        third = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
+
+        assert backend.calls == 2
+        assert third.runtime["detail"] == "receiving_text"
+        assert any(
+            warning[0]
+            == "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}"
             for warning in logger.warnings
         )
     finally:

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1599,10 +1599,9 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
             manager._capture_future_started_at = time.monotonic() - 1.0
         third = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
 
-        assert backend.calls == 1
-        assert third.runtime["detail"] == "capture_backpressure"
-        assert third.runtime["last_capture_error"] == ""
-        assert not any(
+        assert backend.calls == 2
+        assert third.runtime["detail"] == "receiving_text"
+        assert any(
             warning[0]
             == "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}"
             for warning in logger.warnings
@@ -1664,6 +1663,64 @@ async def test_ocr_reader_capture_timeout_recovers_cancellable_worker(
             == "ocr_reader rotating timed-out capture executor after {:.1f}s; cancel_requested={}"
             for warning in logger.warnings
         )
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ocr_reader_capture_timeout_recovery_is_bounded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_root = tmp_path / "bridge"
+    bridge_root.mkdir()
+    install_root = tmp_path / "Tesseract"
+    _install_fake_tesseract(install_root)
+    backend = _FakeOcrBackend(["雪乃：不应执行。"])
+    logger = _CapturingLogger()
+    monkeypatch.setattr(galgame_ocr_reader, "_OCR_CAPTURE_TIMEOUT_SECONDS", 0.01)
+    manager = OcrReaderManager(
+        logger=logger,
+        config=_make_config(
+            bridge_root,
+            install_target_dir=str(install_root),
+            rapidocr_enabled=False,
+        ),
+        time_fn=lambda: 3001.0,
+        platform_fn=lambda: True,
+        window_scanner=lambda: [
+            DetectedGameWindow(
+                hwnd=102,
+                title="Demo Window",
+                process_name="DemoGame.exe",
+                pid=4243,
+                width=1280,
+                height=720,
+            )
+        ],
+        capture_backend=_FakeCaptureBackend(),
+        ocr_backend=backend,
+        writer=OcrReaderBridgeWriter(bridge_root=bridge_root, time_fn=lambda: 3001.0),
+    )
+    abandoned: Future[OcrExtractionResult] = Future()
+    assert abandoned.set_running_or_notify_cancel()
+    current: Future[OcrExtractionResult] = Future()
+    assert current.set_running_or_notify_cancel()
+    executor = manager._capture_executor
+    assert executor is not None
+    with manager._capture_worker_lock:
+        manager._abandoned_capture_workers = [(executor, abandoned)]
+        manager._capture_future = current
+        manager._capture_future_started_at = time.monotonic() - 1.0
+        manager._capture_future_timed_out = True
+
+    try:
+        result = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
+
+        assert backend.calls == 0
+        assert result.runtime["detail"] == "capture_backpressure"
+        assert result.runtime["last_capture_error"] == ""
+        assert any("recovery limit reached" in warning for warning in result.warnings)
     finally:
         await manager.shutdown()
 

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from plugin.plugins.galgame_plugin.ocr_reader import (
+    _CaptureStillRunning,
+    DetectedGameWindow,
+    OcrCaptureProfile,
+    OcrExtractionResult,
+    OcrReaderManager,
+    SelectedOcrBackendPlan,
+)
+
+
+class _NullLogger:
+    def debug(self, *_args, **_kwargs) -> None:
+        pass
+
+    def warning(self, *_args, **_kwargs) -> None:
+        pass
+
+
+def test_timed_out_capture_does_not_replace_running_executor() -> None:
+    manager = object.__new__(OcrReaderManager)
+    manager._logger = _NullLogger()
+    manager._capture_worker_lock = threading.Lock()
+    manager._capture_executor = None
+    manager._capture_future = None
+    manager._capture_future_started_at = 0.0
+    manager._capture_future_timed_out = False
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def _blocked_capture(*_args, **_kwargs) -> OcrExtractionResult:
+        worker_started.set()
+        release_worker.wait(timeout=5.0)
+        return OcrExtractionResult(text="done")
+
+    manager._capture_and_extract_text = _blocked_capture
+
+    target = DetectedGameWindow(hwnd=1, width=800, height=600)
+    profile = OcrCaptureProfile()
+    backend_plan = SelectedOcrBackendPlan()
+
+    first_future = manager._submit_capture_worker(
+        target,
+        profile,
+        backend_plan,
+        True,
+        True,
+    )
+    assert worker_started.wait(timeout=1.0)
+    first_executor = manager._capture_executor
+
+    manager._capture_future_started_at = time.monotonic() - 30.0
+    manager._capture_future_timed_out = True
+
+    with pytest.raises(_CaptureStillRunning, match="accumulating blocked OCR threads"):
+        manager._submit_capture_worker(
+            target,
+            profile,
+            backend_plan,
+            True,
+            True,
+        )
+
+    assert manager._capture_executor is first_executor
+    assert manager._capture_future is first_future
+    assert not first_future.done()
+
+    release_worker.set()
+    try:
+        assert first_future.result(timeout=1.0).text == "done"
+    finally:
+        manager._shutdown_capture_worker()

--- a/tests/unit/test_galgame_ocr_capture_worker.py
+++ b/tests/unit/test_galgame_ocr_capture_worker.py
@@ -23,7 +23,13 @@ class _NullLogger:
         pass
 
 
-def test_timed_out_capture_does_not_replace_running_executor() -> None:
+def test_timed_out_capture_does_not_replace_running_executor_during_recovery_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "plugin.plugins.galgame_plugin.ocr_reader._OCR_CAPTURE_TIMEOUT_SECONDS",
+        12.0,
+    )
     manager = object.__new__(OcrReaderManager)
     manager._logger = _NullLogger()
     manager._capture_worker_lock = threading.Lock()
@@ -31,6 +37,7 @@ def test_timed_out_capture_does_not_replace_running_executor() -> None:
     manager._capture_future = None
     manager._capture_future_started_at = 0.0
     manager._capture_future_timed_out = False
+    manager._abandoned_capture_workers = []
 
     worker_started = threading.Event()
     release_worker = threading.Event()
@@ -56,7 +63,7 @@ def test_timed_out_capture_does_not_replace_running_executor() -> None:
     assert worker_started.wait(timeout=1.0)
     first_executor = manager._capture_executor
 
-    manager._capture_future_started_at = time.monotonic() - 30.0
+    manager._capture_future_started_at = time.monotonic() - 18.0
     manager._capture_future_timed_out = True
 
     with pytest.raises(_CaptureStillRunning, match="accumulating blocked OCR threads"):
@@ -75,5 +82,77 @@ def test_timed_out_capture_does_not_replace_running_executor() -> None:
     release_worker.set()
     try:
         assert first_future.result(timeout=1.0).text == "done"
+    finally:
+        manager._shutdown_capture_worker()
+
+
+def test_timed_out_running_capture_is_abandoned_after_recovery_grace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "plugin.plugins.galgame_plugin.ocr_reader._OCR_CAPTURE_TIMEOUT_SECONDS",
+        12.0,
+    )
+    manager = object.__new__(OcrReaderManager)
+    manager._logger = _NullLogger()
+    manager._capture_worker_lock = threading.Lock()
+    manager._capture_executor = None
+    manager._capture_future = None
+    manager._capture_future_started_at = 0.0
+    manager._capture_future_timed_out = False
+    manager._abandoned_capture_workers = []
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    capture_calls = 0
+    capture_calls_lock = threading.Lock()
+
+    def _capture(*_args, **_kwargs) -> OcrExtractionResult:
+        nonlocal capture_calls
+        with capture_calls_lock:
+            capture_calls += 1
+            call_number = capture_calls
+        if call_number == 1:
+            worker_started.set()
+            release_worker.wait(timeout=5.0)
+            return OcrExtractionResult(text="stale")
+        return OcrExtractionResult(text="recovered")
+
+    manager._capture_and_extract_text = _capture
+
+    target = DetectedGameWindow(hwnd=1, width=800, height=600)
+    profile = OcrCaptureProfile()
+    backend_plan = SelectedOcrBackendPlan()
+
+    first_future = manager._submit_capture_worker(
+        target,
+        profile,
+        backend_plan,
+        True,
+        True,
+    )
+    assert worker_started.wait(timeout=1.0)
+    first_executor = manager._capture_executor
+
+    manager._capture_future_started_at = time.monotonic() - 30.0
+    manager._capture_future_timed_out = True
+
+    second_future = manager._submit_capture_worker(
+        target,
+        profile,
+        backend_plan,
+        True,
+        True,
+    )
+
+    assert manager._capture_executor is not first_executor
+    assert manager._capture_future is second_future
+    assert manager._abandoned_capture_workers == [(first_executor, first_future)]
+    assert not first_future.done()
+    assert second_future.result(timeout=1.0).text == "recovered"
+
+    release_worker.set()
+    try:
+        assert first_future.result(timeout=1.0).text == "stale"
     finally:
         manager._shutdown_capture_worker()


### PR DESCRIPTION
## 问题                                                                                                                                                                                                   
                                                                
  OCR 捕获线程超时后卡死，每次后续 tick 都抛 TimeoutError，                                                                                                                                                 
  导致 OCR 永久不可用，必须重启插件。                                              

  ## 修复

  `_submit_capture_worker` 发现前一个 future 已超时且仍未完成时：

  1. `shutdown(wait=False, cancel_futures=True)` 结束旧 executor
  2. 重置 `_capture_future` / `_capture_executor` 等状态
  3. 创建新 executor 继续工作

  同时新增 `_CaptureStillRunning` / `_CaptureTimedOut` 两个异常类
  替代原来的消息字符串匹配，行为不再依赖日志措辞。

  ## 改动

  | 文件 | 内容 |
  |------|------|
  | `ocr_reader.py` | 新增异常类；超时分支替换 executor；`tick()` 按异常类型路由 |
  | `test_galgame_ocr_reader.py` | 新增背压跳过测试；重写超时恢复测试 |

  ## 测试

  test_ocr_reader_backpressure_skip_is_not_capture_error  PASSED
  test_ocr_reader_capture_timeout_replaces_stuck_worker   PASSED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 改进 OCR 捕获的超时与背压处理：区分“仍在运行”与“调用超时”，避免把背压误判为失败，按恢复策略轮换或取消超时工作并在运行循环中更新状态。

* **Tests**
  * 新增与调整并发/超时单元测试，覆盖跳过、保留、替换、轮换与清理路径，验证恢复与资源关闭行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->