### PR TITLE
fix(tutorial): 真正的 auto 教程启动时正确隐藏人设选择

### DIFF
--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -380,7 +380,13 @@
                     return;
                 }
                 const source = String(event.detail.source || '').trim().toLowerCase();
-                if (source === 'auto' && this.isTutorialPromptSettled(this.lastTutorialPromptState)) {
+                const tutorialActuallyRunning = !!(window.universalTutorialManager
+                    && window.universalTutorialManager.isTutorialRunning);
+                if (
+                    source === 'auto'
+                    && !tutorialActuallyRunning
+                    && this.isTutorialPromptSettled(this.lastTutorialPromptState)
+                ) {
                     return;
                 }
                 this.pendingResumeAfterTutorial = true;

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -485,6 +485,61 @@ def test_onboarding_ignores_stale_auto_home_tutorial_start_after_prompt_complete
 
 
 @pytest.mark.frontend
+def test_onboarding_hides_overlay_when_real_auto_tutorial_starts_after_overlay(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = true;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_hidden()
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
 def test_onboarding_does_not_treat_tutorial_prompt_fetch_failure_as_settled(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(


### PR DESCRIPTION
## 背景

#1183 给人设选择 onboarding 加了一道保护：当 `lastTutorialPromptState` 已 settled（completed / deferred / never / error / observing+existing）时，忽略 `source: 'auto'` 的 `neko:tutorial-started` 事件，避免主页教程兜底派出的陈旧 auto 事件把已经弹出的人设面板隐藏掉。

但这道保护**只看缓存的状态**，不看 `universalTutorialManager.isTutorialRunning`。

## 触发路径

1. 后端 `home_tutorial_completed=True`（旧记录、跨机器迁移配置、localStorage 被清等场景），但客户端 localStorage 还没同步
2. `universalTutorialManager.checkAndStartTutorial()` 读 localStorage → 没看过 → 排了 1.5s 后自动开教程；同时 `applyServerState` 还没把 localStorage 同步成 'true'
3. `CharacterPersonalityOnboarding.bootstrap()` polling 拿到 status=`completed`，`isTutorialPromptSettled=true`，循环退出，**人设面板弹出**，`lastTutorialPromptState` 冻结成 `{status:'completed'}`
4. 1.5s 后教程真的跑起来，`emitTutorialStarted({source:'auto'})` 派事件
5. `queueResume`：source=auto，`lastTutorialPromptState` 还是 completed → 走 stale 分支 `return`，**面板不藏**
6. → 教程和人设选择叠在一起，用户首次启动看到两个 modal

## 修法

`bindTutorialLifecycleEvents.queueResume` 里 stale 判定多加一条 `!universalTutorialManager.isTutorialRunning`：

- `startTutorial()` 在 `emitTutorialStarted()` 之前把 `isTutorialRunning=true`（universal-tutorial-manager.js:3399 → 3631），所以事件触发时这个 flag 是可靠的
- 真在跑就藏面板（修复用户反馈的回归）
- 不真在跑（缓存说 completed = stale 兜底事件）才忽略，保留 #1183 的原意

## 验证

- 新增 `test_onboarding_hides_overlay_when_real_auto_tutorial_starts_after_overlay`：模拟用户场景，断言面板被隐藏，教程结束后再恢复
- `tests/frontend/test_initial_personality_onboarding.py` 全 31 通过（含 #1183 的 `test_onboarding_ignores_stale_auto_home_tutorial_start_after_prompt_completed` 仍然通过）
- `tests/frontend/test_home_prompt_flow.py` + `tests/unit/test_tutorial_prompt_router.py` + `tests/unit/test_tutorial_prompt_state.py` 全 99 通过

## Test plan

- [x] 新增的回归测试覆盖"真 auto 教程启动 → 隐藏 → 完成后恢复"完整路径
- [x] #1183 的 stale auto 测试仍通过（保证 stale 兜底机制没被打穿）
- [ ] 手测：清空 localStorage 但保留 `tutorial_prompt.json` 中 `home_tutorial_completed=true` 的 config 目录，启动看是否还会叠层

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了角色个性化入门指南的自动恢复逻辑，现在会检查教程是否实际运行中，以更准确地处理自动恢复功能和界面显示。

## Tests
* 新增测试覆盖入门界面叠层与自动教程启动及完成事件之间的交互行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->