### PR TITLE
修复新手教程结束后重逢问好被重连保护吞掉

### DIFF
--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -239,17 +239,20 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                     logger.info(f"[{lanlan_name}] greeting_check: skipped by home tutorial guard")
                     continue
                 is_switch = message.get("is_switch", False)
+                greeting_reason = str(message.get("reason") or "").strip().lower()[:64]
+                # 教程结束释放的是延迟问好，不应被刚经历过的页面/窗口重连保护吞掉。
+                bypass_reconnect_guard = greeting_reason in {"tutorial-completed", "tutorial-skipped"}
                 last_disconnect = _ws_disconnect_time.get(lanlan_name, 0)
                 since_disconnect = time.time() - last_disconnect if last_disconnect else float('inf')
-                if is_switch or since_disconnect > 15:
+                if is_switch or since_disconnect > 15 or bypass_reconnect_guard:
                     if await has_new_character_greeting_pending(_config_manager, lanlan_name):
-                        logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s → new character greeting")
+                        logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s reason={greeting_reason or '-'} → new character greeting")
                         _fire_task(session_manager[lanlan_name].trigger_new_character_greeting())
                     else:
-                        logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s → triggering")
+                        logger.info(f"[{lanlan_name}] greeting_check: is_switch={is_switch} since_disconnect={since_disconnect:.1f}s reason={greeting_reason or '-'} → triggering")
                         _fire_task(session_manager[lanlan_name].trigger_greeting())
                 else:
-                    logger.info(f"[{lanlan_name}] greeting_check: since_disconnect={since_disconnect:.1f}s ≤15s → skip (refresh/reconnect)")
+                    logger.info(f"[{lanlan_name}] greeting_check: since_disconnect={since_disconnect:.1f}s ≤15s reason={greeting_reason or '-'} → skip (refresh/reconnect)")
 
             elif action == "ping":
                 # 心跳保活消息，回复pong

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -679,10 +679,7 @@
 
             // ── 首次连接 / 切换角色：标记 greeting 意图，若模型已就绪则立即发送 ──
             _resetGreetingCheckRetry(true);
-            _markGreetingCheckPending(
-                !!S._pendingGreetingSwitch || !!S._greetingCheckIsSwitch,
-                S._greetingCheckReason || 'ws-open'
-            );
+            _markGreetingCheckPending(!!S._pendingGreetingSwitch, S._greetingCheckReason || 'ws-open');
             S._pendingGreetingSwitch = false;
             _sendGreetingCheckIfReady();
 
@@ -2409,18 +2406,20 @@
                         greetingLang = navigator.language;
                     }
                 } catch (_) { greetingLang = ''; }
-                var greetingReason = S._greetingCheckReason || (S._greetingCheckIsSwitch ? 'character-switch' : 'ws-open');
+                var greetingIsSwitch = !!S._greetingCheckIsSwitch;
+                var greetingReason = S._greetingCheckReason || (greetingIsSwitch ? 'character-switch' : 'ws-open');
                 sendHomeTutorialState('greeting-check-ready');
                 S.socket.send(JSON.stringify({
                     action: 'greeting_check',
-                    is_switch: !!S._greetingCheckIsSwitch,
+                    is_switch: greetingIsSwitch,
                     language: greetingLang,
                     reason: greetingReason
                 }));
                 S._greetingCheckPending = false;
+                S._greetingCheckIsSwitch = false;
                 S._greetingCheckReason = '';
                 _resetGreetingCheckRetry(true);
-                console.log('[greeting_check] sent, is_switch=' + !!S._greetingCheckIsSwitch + ', reason=' + greetingReason);
+                console.log('[greeting_check] sent, is_switch=' + greetingIsSwitch + ', reason=' + greetingReason);
             }
         } catch (e) {
             console.warn('[greeting_check] send failed:', e);

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -46,6 +46,18 @@
                 return window.isNekoHomeTutorialInteractionLocked() === true;
             }
         } catch (_) {}
+        try {
+            if (window.NekoHomeTutorialFeatureController
+                && typeof window.NekoHomeTutorialFeatureController.isActive === 'function'
+                && window.NekoHomeTutorialFeatureController.isActive() === true) {
+                return true;
+            }
+        } catch (_) {}
+        try {
+            if (document.body && document.body.classList.contains('yui-taking-over')) {
+                return true;
+            }
+        } catch (_) {}
         return false;
     }
 
@@ -663,8 +675,7 @@
 
             // ── 首次连接 / 切换角色：标记 greeting 意图，若模型已就绪则立即发送 ──
             _resetGreetingCheckRetry(true);
-            S._greetingCheckPending = true;
-            S._greetingCheckIsSwitch = !!S._pendingGreetingSwitch;
+            _markGreetingCheckPending(!!S._pendingGreetingSwitch, 'ws-open');
             S._pendingGreetingSwitch = false;
             _sendGreetingCheckIfReady();
 
@@ -2358,6 +2369,11 @@
             _sendGreetingCheckIfReady();
         }, delay);
     }
+    function _markGreetingCheckPending(isSwitch, reason) {
+        S._greetingCheckPending = true;
+        S._greetingCheckIsSwitch = !!isSwitch;
+        S._greetingCheckReason = reason || '';
+    }
     function _sendGreetingCheckIfReady() {
         if (!S._greetingCheckPending || !S._modelReady) {
             if (!S._greetingCheckPending) _resetGreetingCheckRetry(true);
@@ -2386,14 +2402,18 @@
                         greetingLang = navigator.language;
                     }
                 } catch (_) { greetingLang = ''; }
+                var greetingReason = S._greetingCheckReason || (S._greetingCheckIsSwitch ? 'character-switch' : 'ws-open');
+                sendHomeTutorialState('greeting-check-ready');
                 S.socket.send(JSON.stringify({
                     action: 'greeting_check',
                     is_switch: !!S._greetingCheckIsSwitch,
-                    language: greetingLang
+                    language: greetingLang,
+                    reason: greetingReason
                 }));
                 S._greetingCheckPending = false;
+                S._greetingCheckReason = '';
                 _resetGreetingCheckRetry(true);
-                console.log('[greeting_check] sent, is_switch=' + !!S._greetingCheckIsSwitch);
+                console.log('[greeting_check] sent, is_switch=' + !!S._greetingCheckIsSwitch + ', reason=' + greetingReason);
             }
         } catch (e) {
             console.warn('[greeting_check] send failed:', e);
@@ -2464,6 +2484,9 @@
         var detail = event && event.detail ? event.detail : {};
         sendHomeTutorialState(detail.reason || 'lock-changed');
         if (detail.locked === false) {
+            if (detail.reason === 'tutorial-completed' || detail.reason === 'tutorial-skipped') {
+                _markGreetingCheckPending(false, detail.reason);
+            }
             _sendGreetingCheckIfReady();
         }
     });

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -679,7 +679,10 @@
 
             // ── 首次连接 / 切换角色：标记 greeting 意图，若模型已就绪则立即发送 ──
             _resetGreetingCheckRetry(true);
-            _markGreetingCheckPending(!!S._pendingGreetingSwitch, 'ws-open');
+            _markGreetingCheckPending(
+                !!S._pendingGreetingSwitch || !!S._greetingCheckIsSwitch,
+                S._greetingCheckReason || 'ws-open'
+            );
             S._pendingGreetingSwitch = false;
             _sendGreetingCheckIfReady();
 

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -2488,8 +2488,9 @@
         var detail = event && event.detail ? event.detail : {};
         sendHomeTutorialState(detail.reason || 'lock-changed');
         if (detail.locked === false) {
-            if (detail.reason === 'tutorial-completed' || detail.reason === 'tutorial-skipped') {
-                _markGreetingCheckPending(false, detail.reason);
+            if ((detail.reason === 'tutorial-completed' || detail.reason === 'tutorial-skipped')
+                && S._greetingCheckPending) {
+                S._greetingCheckReason = detail.reason;
             }
             _sendGreetingCheckIfReady();
         }

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -40,10 +40,14 @@
     function isHomeTutorialLockedForGreeting() {
         try {
             if (typeof window.isNekoHomeTutorialBlockingGreeting === 'function') {
-                return window.isNekoHomeTutorialBlockingGreeting() === true;
+                if (window.isNekoHomeTutorialBlockingGreeting() === true) {
+                    return true;
+                }
             }
             if (typeof window.isNekoHomeTutorialInteractionLocked === 'function') {
-                return window.isNekoHomeTutorialInteractionLocked() === true;
+                if (window.isNekoHomeTutorialInteractionLocked() === true) {
+                    return true;
+                }
             }
         } catch (_) {}
         try {


### PR DESCRIPTION
- 将首页教程的功能压制态和 YUI 接管态纳入 greeting_check 阻塞判断
- 教程完成/跳过后重新标记一次延迟 greeting_check，并携带触发原因
- 后端仅允许 tutorial-completed / tutorial-skipped 绕过 15 秒重连保护
- 在发送 greeting_check 前同步一次教程阻塞状态，避免后端 TTL guard 残留


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 问候检查新增基于原因的绕过：当原因为“tutorial-completed”或“tutorial-skipped”时允许触发问候，即便最近断开不足15秒。
  * 在发送问候检查时携带并记录 reason 字段，日志包含断开间隔与归一化后的原因，便于决策与排查。
  * 连接打开时以挂起标记跟踪问候检查，发送后清理挂起与存储的原因/重试状态。
  * 强化首页教程锁检测：在教程接管或特定页面状态下阻止问候，解锁时仅对完成/跳过原因设置挂起。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->