### PR TITLE
fix: support VRM0 orientation compatibility

### DIFF
--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -8415,16 +8415,16 @@ document.addEventListener('DOMContentLoaded', async () => {
                             await new Promise(resolve => requestAnimationFrame(resolve));
                         }
 
-                        // 检测并修正朝向（会自动保存到preferences）
+                        // 保存加载管线处理后的朝向到 preferences
                         if (window.vrmManager.currentModel && window.vrmManager.currentModel.vrm) {
                             const vrm = window.vrmManager.currentModel.vrm;
 
-                            // 检测朝向
-                            const needsRotation = window.VRMOrientationDetector.detectNeedsRotation(vrm);
+                            // loadModel 已经完成 VRM0.x 版本兼容和启发式朝向处理。
+                            // 这里保存最终旋转，避免上传流程再次用旧启发式覆盖加载结果。
                             const detectedRotation = {
-                                x: 0,
-                                y: needsRotation ? Math.PI : 0,
-                                z: 0
+                                x: vrm.scene.rotation.x,
+                                y: vrm.scene.rotation.y,
+                                z: vrm.scene.rotation.z
                             };
 
                             // 应用旋转

--- a/static/vrm-core.js
+++ b/static/vrm-core.js
@@ -88,6 +88,7 @@ class VRMCore {
 
         // 旧逻辑可能把漏判的 VRM0.x 朝向自动保存为 identity。
         // 对有明确 VRM0.x 版本默认旋转的模型，将该缓存视为可迁移旧值。
+        // 这也会迁移用户有意保存的 VRM0 identity；特殊背对模型需保存非 identity 旋转或按个案处理。
         if (this.vrmVersion === '0.0' &&
             VRMCore._isIdentityRotation(savedRotation) &&
             VRMCore._isFiniteRotation(versionDefaultRotation) &&
@@ -916,7 +917,7 @@ class VRMCore {
             // 先通过检测器检测并修复方向，然后应用最终的旋转值
             const savedRotation = this.getEffectiveSavedRotation(preferences?.rotation, versionDefaultRotation);
             
-            const detectedRotation = window.VRMOrientationDetector 
+            let detectedRotation = window.VRMOrientationDetector
                 ? window.VRMOrientationDetector.detectAndFixOrientation(vrm, savedRotation, {
                     defaultRotation: versionDefaultRotation
                 })
@@ -932,12 +933,14 @@ class VRMCore {
                     Number.isFinite(savedRotation.z)) {
                     vrm.scene.rotation.set(savedRotation.x, savedRotation.y, savedRotation.z);
                     vrm.scene.updateMatrixWorld(true);
+                    detectedRotation = VRMCore._getSceneRotation(vrm) || detectedRotation;
                 } else if (versionDefaultRotation &&
                     Number.isFinite(versionDefaultRotation.x) &&
                     Number.isFinite(versionDefaultRotation.y) &&
                     Number.isFinite(versionDefaultRotation.z)) {
                     vrm.scene.rotation.set(versionDefaultRotation.x, versionDefaultRotation.y, versionDefaultRotation.z);
                     vrm.scene.updateMatrixWorld(true);
+                    detectedRotation = VRMCore._getSceneRotation(vrm) || detectedRotation;
                 }
             }
             

--- a/static/vrm-core.js
+++ b/static/vrm-core.js
@@ -54,6 +54,85 @@ class VRMCore {
         }
     }
 
+    static _getSceneRotation(vrm) {
+        if (!vrm || !vrm.scene || !vrm.scene.rotation) {
+            return null;
+        }
+
+        const { x, y, z } = vrm.scene.rotation;
+        if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) {
+            return null;
+        }
+
+        return { x, y, z };
+    }
+
+    static _isFiniteRotation(rotation) {
+        return !!rotation &&
+            Number.isFinite(rotation.x) &&
+            Number.isFinite(rotation.y) &&
+            Number.isFinite(rotation.z);
+    }
+
+    static _isIdentityRotation(rotation) {
+        return VRMCore._isFiniteRotation(rotation) &&
+            Math.abs(rotation.x) < 0.000001 &&
+            Math.abs(rotation.y) < 0.000001 &&
+            Math.abs(rotation.z) < 0.000001;
+    }
+
+    getEffectiveSavedRotation(savedRotation, versionDefaultRotation) {
+        if (!VRMCore._isFiniteRotation(savedRotation)) {
+            return null;
+        }
+
+        // 旧逻辑可能把漏判的 VRM0.x 朝向自动保存为 identity。
+        // 对有明确 VRM0.x 版本默认旋转的模型，将该缓存视为可迁移旧值。
+        if (this.vrmVersion === '0.0' &&
+            VRMCore._isIdentityRotation(savedRotation) &&
+            VRMCore._isFiniteRotation(versionDefaultRotation) &&
+            !VRMCore._isIdentityRotation(versionDefaultRotation)) {
+            console.log('[VRM Core] 忽略旧版 VRM0.x identity rotation 缓存，改用版本默认旋转');
+            return null;
+        }
+
+        return savedRotation;
+    }
+
+    /**
+     * 对 VRM0.x 应用 three-vrm 官方朝向兼容，并返回统一旋转管线应使用的默认旋转。
+     * VRM1.0 不需要该兼容处理；已有用户保存 rotation 时，后续统一旋转管线仍会优先使用用户值。
+     */
+    async applyVRM0CompatibilityRotation(vrm) {
+        if (this.vrmVersion !== '0.0' || !vrm || !vrm.scene) {
+            return null;
+        }
+
+        try {
+            const VRMUtils = await VRMCore._getVRMUtils();
+            if (VRMUtils && typeof VRMUtils.rotateVRM0 === 'function') {
+                VRMUtils.rotateVRM0(vrm);
+                if (VRMCore._isIdentityRotation(VRMCore._getSceneRotation(vrm))) {
+                    console.warn('[VRM Core] VRMUtils.rotateVRM0 未产生旋转，回退到 Y 轴 180 度旋转');
+                    vrm.scene.rotation.y = Math.PI;
+                }
+            } else {
+                vrm.scene.rotation.y = Math.PI;
+            }
+        } catch (error) {
+            console.warn('[VRM Core] VRM0.x 官方朝向兼容失败，回退到 Y 轴 180 度旋转:', error);
+            vrm.scene.rotation.y = Math.PI;
+        }
+
+        vrm.scene.updateMatrixWorld(true);
+
+        const rotation = VRMCore._getSceneRotation(vrm);
+        if (rotation) {
+            console.log('[VRM Core] 已应用 VRM0.x 朝向兼容:', rotation);
+        }
+        return rotation;
+    }
+
     /**
      * 检测设备性能模式
      */
@@ -682,6 +761,7 @@ class VRMCore {
 
             // 检测 VRM 模型版本（0.0 或 1.0）
             this.vrmVersion = this.detectVRMVersion(vrm, gltf);
+            const versionDefaultRotation = await this.applyVRM0CompatibilityRotation(vrm);
 
             // 计算模型的边界框，用于确定合适的初始大小
             const box = new THREE.Box3().setFromObject(vrm.scene);
@@ -834,29 +914,34 @@ class VRMCore {
             
             // 旋转设置统一在这里处理，确保只应用一次
             // 先通过检测器检测并修复方向，然后应用最终的旋转值
-            const savedRotation = preferences?.rotation;
+            const savedRotation = this.getEffectiveSavedRotation(preferences?.rotation, versionDefaultRotation);
             
             const detectedRotation = window.VRMOrientationDetector 
-                ? window.VRMOrientationDetector.detectAndFixOrientation(vrm, savedRotation)
-                : { x: 0, y: 0, z: 0 };
+                ? window.VRMOrientationDetector.detectAndFixOrientation(vrm, savedRotation, {
+                    defaultRotation: versionDefaultRotation
+                })
+                : (versionDefaultRotation || { x: 0, y: 0, z: 0 });
             
             if (window.VRMOrientationDetector) {
                 window.VRMOrientationDetector.applyRotation(vrm, detectedRotation);
             } else {
-                // 如果没有检测器，回退到直接使用保存的旋转值
+                // 如果没有检测器，回退到直接使用保存的旋转值或版本默认旋转
                 if (savedRotation && 
                     Number.isFinite(savedRotation.x) && 
                     Number.isFinite(savedRotation.y) && 
                     Number.isFinite(savedRotation.z)) {
                     vrm.scene.rotation.set(savedRotation.x, savedRotation.y, savedRotation.z);
                     vrm.scene.updateMatrixWorld(true);
+                } else if (versionDefaultRotation &&
+                    Number.isFinite(versionDefaultRotation.x) &&
+                    Number.isFinite(versionDefaultRotation.y) &&
+                    Number.isFinite(versionDefaultRotation.z)) {
+                    vrm.scene.rotation.set(versionDefaultRotation.x, versionDefaultRotation.y, versionDefaultRotation.z);
+                    vrm.scene.updateMatrixWorld(true);
                 }
             }
             
-            const hasSavedRotation = savedRotation && 
-                Number.isFinite(savedRotation.x) && 
-                Number.isFinite(savedRotation.y) && 
-                Number.isFinite(savedRotation.z);
+            const hasSavedRotation = VRMCore._isFiniteRotation(savedRotation);
             
             if (!hasSavedRotation && typeof this.saveUserPreferences === 'function') {
                 // 标准化位置为普通对象 {x, y, z}
@@ -1355,4 +1440,3 @@ window.addEventListener('neko-render-quality-changed', (e) => {
         window.vrmManager.core.applyQualitySettings(quality);
     }
 });
-

--- a/static/vrm-manager.js
+++ b/static/vrm-manager.js
@@ -855,7 +855,14 @@ class VRMManager {
 
         // 2) 应用朝向检测（保持和初次加载一致）
         if (window.VRMOrientationDetector && vrm) {
-            const detectedRotation = window.VRMOrientationDetector.detectAndFixOrientation(vrm, null);
+            const versionDefaultRotation = this.core?.vrmVersion === '0.0'
+                ? { x: 0, y: Math.PI, z: 0 }
+                : null;
+            const detectedRotation = window.VRMOrientationDetector.detectAndFixOrientation(
+                vrm,
+                null,
+                { defaultRotation: versionDefaultRotation }
+            );
             window.VRMOrientationDetector.applyRotation(vrm, detectedRotation);
         }
 

--- a/static/vrm-orientation.js
+++ b/static/vrm-orientation.js
@@ -68,9 +68,11 @@ class VRMOrientationDetector {
      * 检测并处理模型朝向
      * @param {Object} vrm - VRM模型实例
      * @param {Object} savedRotation - 已保存的旋转信息（如果有）
+     * @param {Object} options - 额外选项
+     * @param {Object} options.defaultRotation - 加载管线已确定的版本默认旋转
      * @returns {Object} 返回处理后的旋转信息 {x, y, z}
      */
-    static detectAndFixOrientation(vrm, savedRotation = null) {
+    static detectAndFixOrientation(vrm, savedRotation = null, options = {}) {
         // 仅当所有旋转分量都有效时才使用保存的旋转值（全有或全无策略）
         if (savedRotation && 
             Number.isFinite(savedRotation.x) && 
@@ -80,6 +82,18 @@ class VRMOrientationDetector {
                 x: savedRotation.x,
                 y: savedRotation.y,
                 z: savedRotation.z
+            };
+        }
+
+        const defaultRotation = options?.defaultRotation;
+        if (defaultRotation &&
+            Number.isFinite(defaultRotation.x) &&
+            Number.isFinite(defaultRotation.y) &&
+            Number.isFinite(defaultRotation.z)) {
+            return {
+                x: defaultRotation.x,
+                y: defaultRotation.y,
+                z: defaultRotation.z
             };
         }
 


### PR DESCRIPTION
## Summary
- Apply VRM0.x orientation compatibility during VRM loading using `VRMUtils.rotateVRM0` with a `Math.PI` fallback.
- Feed the VRM0 default rotation through the existing orientation pipeline so later rotation application does not overwrite it.
- Preserve explicit saved user rotations while migrating stale VRM0 identity rotation caches.
- Keep upload orientation saving and reset-position behavior aligned with the main load path.

## Test plan
- `node --check static/vrm-core.js`
- `node --check static/vrm-orientation.js`
- `node --check static/vrm-manager.js`
- `node --check static/js/model_manager.js`
- `git diff --check`
- Simulated the rotation decision logic with Node to verify VRM0 stale identity rotations migrate to the VRM0 default rotation, explicit `Math.PI` rotations are preserved, and VRM1 identity rotations are not migrated.
- Manually regressed the VRM0.x sensei model in the N.E.K.O PC UI: repeated "reset character position" no longer flips the model front/back, and tested other VRM0.x models showed no negative impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 动态加载 VRM/MMD 模型模块与跨窗口通信，支持通信降级。
  * 可视化下拉菜单（截断、多语言默认文案、滚动条优化、全局收起）。
  * 保存后可选卡片封面编辑与截图/渲染导出。

* **改进**
  * 自动检测并纠正 VRM 方向，兼容旧版 VRM0.x。
  * 更稳的 Live2D/Live3D 切换、空闲动画与物理过渡。
  * 更友好的错误与状态提示、未保存变更提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->