### PR TITLE
fix(galgame): 严格限制 OCR 捕获兜底列表上限并降低用例 flakiness

### DIFF
--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -6638,7 +6638,6 @@ class OcrReaderManager:
                             >= _OCR_MAX_ABANDONED_CAPTURE_WORKERS
                         ):
                             if executor is not None:
-                                self._abandoned_capture_workers.append((executor, current))
                                 executors_to_shutdown.append(executor)
                             self._capture_executor = None
                             self._capture_future = None

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1581,7 +1581,7 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
 
     try:
         first = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
-        assert started.wait(timeout=0.5) is True
+        assert started.wait(timeout=2.0) is True
         assert first.runtime["detail"] == "capture_failed"
         assert "timed out" in first.runtime["last_capture_error"]
 
@@ -1731,7 +1731,6 @@ async def test_ocr_reader_capture_timeout_recovery_is_bounded(
             assert manager._capture_future_timed_out is False
             assert manager._abandoned_capture_workers == [
                 (abandoned_executor, abandoned),
-                (current_executor, current),
             ]
 
         retry = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})


### PR DESCRIPTION
## Summary
- #1193 review 漏的两处 follow-up：
  - `_submit_capture_worker` 在 `_abandoned_capture_workers` 已达 `_OCR_MAX_ABANDONED_CAPTURE_WORKERS` 时，仍然 `append((executor, current))` 让列表实际超出 cap；改为只把 executor 放进 `executors_to_shutdown` 兜底清理，不再存储该 tuple，仍清空 `_capture_executor` 等状态。
  - `test_ocr_reader_capture_timeout_skips_stuck_worker_immediately` 中 `started.wait(timeout=0.5)` 在高负载 CI 上偶发超时，提升到 `2.0`。
- 同步修订 `test_ocr_reader_capture_timeout_recovery_is_bounded` 对 `_abandoned_capture_workers` 内容的断言以匹配新行为。

## Test plan
- [x] `uv run pytest tests/unit/plugins/test_galgame_ocr_reader.py::test_ocr_reader_capture_timeout_recovery_is_bounded`
- [x] `uv run pytest tests/unit/plugins/test_galgame_ocr_reader.py::test_ocr_reader_capture_timeout_skips_stuck_worker_immediately`
- [x] 在 `-k "capture or timeout or stuck or worker"` 范围内全部通过（除 `test_win32_capture_backend_explicit_selection_falls_back_with_detail` 在 main 上即已失败、与本改动无关的 Windows 句柄环境依赖）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 优化了光学字符识别(OCR)读取的超时恢复逻辑，增强了系统在处理异常卡顿任务时的稳定性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->