### PR TITLE
fix(chat): remove avatar range hold timer

### DIFF
--- a/frontend/react-neko-chat/src/App.tsx
+++ b/frontend/react-neko-chat/src/App.tsx
@@ -697,12 +697,6 @@ export default function App({
       setIsCursorOverAvatarRange(previousValue => (
         previousValue === true ? previousValue : true
       ));
-      avatarRangeHoldTimerRef.current = window.setTimeout(() => {
-        avatarRangeHoldTimerRef.current = null;
-        if (performance.now() < avatarRangeHoldUntilRef.current) return;
-        avatarRangeHoldUntilRef.current = 0;
-        setIsCursorOverAvatarRange(previousValue => (previousValue ? false : previousValue));
-      }, avatarToolRangeHoldMs);
       return;
     }
 


### PR DESCRIPTION
道具交互状态不稳定问题修复
- 移除鼠标进入头像范围后的 hold timer 逻辑，
- 该定时器会在延迟后将 isCursorOverAvatarRange 重置为 false，
- 删除后光标进入头像范围时状态将保持不变。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了头像交互时的光标状态管理逻辑，改进了光标悬停响应的时序表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->