### PR TITLE
Fix/long reply guard no reroll

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1305,6 +1305,29 @@ class OmniOfflineClient:
                             # / max_attempts 进度条要 1/2 → 2/2 才合理。
                             total_attempts = self.max_response_rerolls + 1
 
+                            recovery_text = ""
+                            if discard_reason and "length>" in discard_reason:
+                                # 长回复已经流式吐给前端了；若它仍是正常可读文本，
+                                # 直接截到完整句子收尾，不 reroll，避免用户看到
+                                # “输出完又报错并重输一遍”。
+                                if not _is_gibberish_response(assistant_message_total):
+                                    capped = truncate_to_tokens(
+                                        assistant_message_total, self.max_response_length,
+                                    )
+                                    recovery_text = _truncate_to_last_sentence_end(capped)
+
+                            if recovery_text:
+                                logger.info(
+                                    "OmniOfflineClient: 长回复已流式输出，停止生成并按最后句末入历史 "
+                                    "(原 %d tokens → 截断后 %d tokens)",
+                                    count_tokens(assistant_message_total), count_tokens(recovery_text),
+                                )
+                                self._conversation_history.append(AIMessage(content=recovery_text))
+                                await self._check_repetition(recovery_text)
+                                assistant_message = recovery_text
+                                guard_exhausted = True
+                                break
+
                             if will_retry:
                                 # 还能 retry：发 will_retry 通知，循环继续。前端
                                 # 收到 response_discarded(will_retry=True, message=None)
@@ -1339,7 +1362,6 @@ class OmniOfflineClient:
                             # max_response_length 再找句末，否则截出来的句末仍
                             # 可能在 token 上限之外（比如最后一个句号在 950 token
                             # 处但 cap 是 300）。
-                            recovery_text = ""
                             if discard_reason and "length>" in discard_reason:
                                 # 整轮判定：gibberish / 截断必须看 _total，否则
                                 # tool 轮 sentinel 把 final-segment 清空之后整段

--- a/static/subtitle.js
+++ b/static/subtitle.js
@@ -37,6 +37,13 @@ let subtitleEnabled = initialSubtitleSettings
         ? window.appState.subtitleEnabled
         : localStorage.getItem('subtitleEnabled') === 'true');
 
+function isSubtitleTranslationOwner() {
+    return !(window.__NEKO_MULTI_WINDOW__ &&
+             window.nekoChatWindow &&
+             window.location &&
+             window.location.pathname === '/chat');
+}
+
 function applySharedSubtitleSettings(patch, options) {
     if (!SubtitleShared || typeof SubtitleShared.updateSettings !== 'function') {
         if (Object.prototype.hasOwnProperty.call(patch, 'subtitleEnabled')) {
@@ -357,6 +364,7 @@ async function processIncrementalTranslationQueue(requestSnapId) {
     if (incrementalTranslationActive) return;
     if (!incrementalTranslationQueue.length) return;
     if (!subtitleEnabled) return;
+    if (!isSubtitleTranslationOwner()) return;
     if (requestSnapId !== incrementalRequestId) return;
 
     var textToTranslate = incrementalTranslationQueue.shift();
@@ -448,6 +456,7 @@ function updateSubtitleStreamingText(text) {
     currentTurnOriginalText = cleaned;
 
     if (!subtitleEnabled) return;
+    if (!isSubtitleTranslationOwner()) return;
     if (userLanguage === null) getUserLanguage();
 
     var splitResult = splitSubtitleSentences(cleaned);
@@ -593,6 +602,9 @@ async function translateAndShowSubtitle(text) {
     currentTurnOriginalText = text;
 
     if (!subtitleEnabled) {
+        return;
+    }
+    if (!isSubtitleTranslationOwner()) {
         return;
     }
 

--- a/tests/frontend/test_subtitle_incremental.py
+++ b/tests/frontend/test_subtitle_incremental.py
@@ -7,9 +7,14 @@ from playwright.sync_api import Page
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _open_subtitle_harness(mock_page: Page, body_class: str, body_html: str) -> None:
+def _open_subtitle_harness(
+    mock_page: Page,
+    body_class: str,
+    body_html: str,
+    path: str = "/subtitle-harness",
+) -> None:
     mock_page.route(
-        "**/subtitle-harness",
+        f"**{path}",
         lambda route: route.fulfill(
             status=200,
             content_type="text/html",
@@ -19,7 +24,7 @@ def _open_subtitle_harness(mock_page: Page, body_class: str, body_html: str) -> 
             ),
         ),
     )
-    mock_page.goto("http://neko.test/subtitle-harness")
+    mock_page.goto(f"http://neko.test{path}")
 
 
 @pytest.mark.frontend
@@ -87,6 +92,77 @@ def test_subtitle_incremental_translation_starts_when_sentence_punctuation_arriv
 
     assert result["text"] == "你好世界。"
     assert [request["text"] for request in result["requests"]] == ["Hello world."]
+
+
+@pytest.mark.frontend
+def test_electron_chat_window_does_not_start_subtitle_translation_requests(
+    mock_page: Page,
+):
+    _open_subtitle_harness(
+        mock_page,
+        "subtitle-web-host",
+        """
+        <div id="subtitle-display" class="hidden">
+            <div id="subtitle-scroll"><span id="subtitle-text"></span></div>
+        </div>
+        """,
+        path="/chat",
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.__translateRequests = [];
+            window.__NEKO_MULTI_WINDOW__ = true;
+            window.nekoChatWindow = {};
+            window.fetch = async (url, options) => {
+                const requestUrl = String(url);
+                const body = options && options.body ? JSON.parse(options.body) : {};
+                if (requestUrl === '/api/config/user_language') {
+                    return new Response(JSON.stringify({ success: true, language: 'zh' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                if (requestUrl === '/api/translate') {
+                    window.__translateRequests.push(body);
+                    return new Response(JSON.stringify({
+                        success: true,
+                        translated_text: '你好世界。',
+                        source_lang: 'en',
+                        target_lang: body.target_lang || 'zh',
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    });
+                }
+                throw new Error('Unexpected request: ' + requestUrl);
+            };
+            window.localStorage.setItem('subtitleEnabled', 'true');
+            window.localStorage.setItem('userLanguage', 'zh');
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle-shared.js"))
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static/subtitle.js"))
+
+    result = mock_page.evaluate(
+        """
+        async () => {
+            window.beginSubtitleTurn();
+            window.subtitleBridge.setSubtitleEnabled(true);
+            window.updateSubtitleStreamingText('Hello world.');
+            await window.translateAndShowSubtitle('Hello world.');
+            await new Promise((resolve) => setTimeout(resolve, 450));
+            return {
+                text: document.getElementById('subtitle-text').textContent,
+                requests: window.__translateRequests,
+            };
+        }
+        """
+    )
+
+    assert result["text"] == ""
+    assert result["requests"] == []
 
 
 @pytest.mark.frontend

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -854,6 +854,81 @@ async def test_stream_text_notifies_discarded_when_partial_text_then_error(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_text_length_guard_finishes_visible_long_reply_without_discard(monkeypatch):
+    """正常长回复已经流式吐到前端时，长度 guard 不应走 discard/recovery。
+
+    response_discarded 会清掉旧气泡/字幕，然后 recovery 再整段重发；这会
+    让字幕翻译处理两份同一轮文本，TTS 也可能收到过长的整段恢复文本。
+    """
+    from main_logic import omni_offline_client as _ofc
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import LLMStreamChunk, SystemMessage
+
+    monkeypatch.setattr(_ofc, "count_tokens", lambda text: len((text or "").split()))
+    monkeypatch.setattr(
+        _ofc,
+        "truncate_to_tokens",
+        lambda text, budget: " ".join((text or "").split()[:budget]),
+    )
+
+    stream_calls = 0
+
+    async def _astream_long_reply(self, messages, **overrides):
+        nonlocal stream_calls
+        stream_calls += 1
+        yield LLMStreamChunk(content="one two three four. five")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream_long_reply)
+
+    discarded_calls: list = []
+    text_emitted: list = []
+
+    async def fake_notify_discarded(reason, attempt, max_attempts, will_retry, message=None):
+        discarded_calls.append({
+            "reason": reason,
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+            "will_retry": will_retry,
+            "message": message,
+        })
+
+    async def fake_text_delta(text, is_first):
+        text_emitted.append(text)
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.lanlan_name = "T"
+    client.master_name = "M"
+    client._prefix_buffer_size = 0
+    client._conversation_history = [SystemMessage(content="sys")]
+    client._pending_images = []
+    client._is_responding = False
+    client._recent_responses = []
+    client._repetition_threshold = 0.8
+    client._max_recent_responses = 3
+    client.max_response_length = 4
+    client.max_response_rerolls = 1
+    client.enable_response_guard = True
+    client.vision_model = ""
+    client.model = "x"
+    client.on_text_delta = fake_text_delta
+    client.on_input_transcript = noop
+    client.on_response_done = noop
+    client.on_response_discarded = fake_notify_discarded
+    client.on_status_message = noop
+    client.on_repetition_detected = None
+
+    await client.stream_text("write a long reply")
+
+    assert stream_calls == 1
+    assert "".join(text_emitted) == "one two three four. five"
+    assert discarded_calls == []
+    assert client._conversation_history[-1].content == "one two three four."
+
+
+@pytest.mark.asyncio
 async def test_offline_silent_fallback_when_genai_did_not_emit(monkeypatch):
     """对偶：genai 路径还没 yield 过任何文本就抛 transient 异常时，
     `_astream_with_tools` 仍然应该静默 fallback 到 OpenAI-compat 兜底——


### PR DESCRIPTION
## 变更内容

修复长回复超过长度保护后，被当成异常丢弃并重新输出的问题。

现在正常可读的长回复触发长度保护时，会直接停止继续生成，并按最后一个完整句子收尾，不再走 `response_discarded` / recovery 重发流程。

## 修复的问题

- 避免长篇回复输出完后又提示“猫娘链接异常”
- 避免同一轮回复被重复输出
- 避免字幕翻译同时处理旧流式文本和恢复文本，导致翻译对不上或卡住
- 避免 TTS 收到整段恢复文本后报 `text is too long`

## 测试

- `python -m pytest tests/unit/test_tool_calling.py -q`
- 结果：`35 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 优化了文本长度超限时的恢复机制，现在会智能截断文本至完整句子而非直接丢弃
  * 修复了多窗口模式下字幕翻译的重复执行问题，确保翻译仅在主窗口进行

* **Tests**
  * 增加了新的测试用例，涵盖多窗口字幕处理和文本长度限制场景

<!-- end of auto-generated comment: release notes by coderabbit.ai -->