### PR TITLE
fix long reply guard without discard reroll

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1163,9 +1163,21 @@ class OmniOfflineClient:
                         fence_triggered = False  # 围栏是否已触发
                         guard_triggered = False
                         discard_reason = None
+                        length_guard_recovery_text = ""
+                        length_guard_persisted_prefix = ""
+                        length_guard_original_tokens = 0
                         chunk_usage = None
                         prefix_buffer = ""
                         prefix_checked = not bool(self._prefix_buffer_size)
+
+                        def _has_unpersisted_recovery_suffix(recovery_text: str) -> bool:
+                            if not recovery_text:
+                                return False
+                            if not length_guard_persisted_prefix:
+                                return True
+                            if not recovery_text.startswith(length_guard_persisted_prefix):
+                                return False
+                            return bool(recovery_text[len(length_guard_persisted_prefix):].strip())
 
                         # Tool-aware streaming: ``_astream_with_tools`` runs
                         # the multi-turn tool loop inside (executing tools and
@@ -1187,6 +1199,7 @@ class OmniOfflineClient:
                             # 第二次写进 history。``_total`` 不重置——重复检测
                             # / token 长度 guard 仍要看完整一轮的实际文本量。
                             if getattr(chunk, "tool_round_persisted", False):
+                                length_guard_persisted_prefix = assistant_message_total
                                 assistant_message = ""
                                 # 重置围栏 / prefix buffer：下一段是新的语义
                                 # 单元（模型基于 tool 结果重新出文本），不应
@@ -1240,23 +1253,48 @@ class OmniOfflineClient:
                                             break
 
                                 if truncated_content and truncated_content.strip():
-                                    assistant_message += truncated_content
-                                    assistant_message_total += truncated_content
-                                    if self.on_text_delta:
-                                        await self.on_text_delta(truncated_content, is_first_chunk)
-                                    is_first_chunk = False
-
+                                    emit_content = truncated_content
                                     if self.enable_response_guard:
-                                        # 长度 guard 看完整一轮（含 pre-tool）的 token 量，
-                                        # 不能只看 final-segment，否则 tool 轮前长篇大论 +
-                                        # tool 轮后短短一句也能逃过 guard。
-                                        current_length = count_tokens(assistant_message_total)
+                                        # 长度 guard 看完整一轮（含 pre-tool）的 token 量。
+                                        # 必须在 on_text_delta 前裁剪本 chunk，否则 UI/TTS
+                                        # 会先收到超限尾巴，而 history 只保存截断文本。
+                                        candidate_total = assistant_message_total + truncated_content
+                                        current_length = count_tokens(candidate_total)
                                         if current_length > self.max_response_length:
                                             guard_triggered = True
                                             discard_reason = f"length>{self.max_response_length}"
-                                            logger.info(f"OmniOfflineClient: 检测到长回复 ({current_length} tokens)，准备重试")
+                                            length_guard_original_tokens = current_length
+                                            logger.info(f"OmniOfflineClient: 检测到长回复 ({current_length} tokens)，准备停止生成")
                                             self._is_responding = False
-                                            break
+                                            emit_content = ""
+                                            if not _is_gibberish_response(candidate_total):
+                                                capped = truncate_to_tokens(
+                                                    candidate_total, self.max_response_length,
+                                                )
+                                                candidate_recovery = _truncate_to_last_sentence_end(capped)
+                                                if candidate_recovery:
+                                                    if candidate_recovery.startswith(assistant_message_total):
+                                                        recovery_suffix = candidate_recovery[len(assistant_message_total):]
+                                                        if recovery_suffix.strip():
+                                                            emit_content = recovery_suffix
+                                                            length_guard_recovery_text = candidate_recovery
+                                                    elif (
+                                                        assistant_message_total
+                                                        and _has_unpersisted_recovery_suffix(assistant_message_total)
+                                                    ):
+                                                        # 已流式发出的前缀无法撤回；保持 history 与
+                                                        # UI/TTS 一致，避免可见文本和上下文分叉。
+                                                        length_guard_recovery_text = assistant_message_total
+
+                                    if emit_content and emit_content.strip():
+                                        assistant_message += emit_content
+                                        assistant_message_total += emit_content
+                                        if self.on_text_delta:
+                                            await self.on_text_delta(emit_content, is_first_chunk)
+                                        is_first_chunk = False
+
+                                    if guard_triggered:
+                                        break
                             elif content and not content.strip():
                                 logger.debug(f"OmniOfflineClient: 过滤空白内容 - content_repr: {repr(content)[:100]}")
 
@@ -1283,17 +1321,38 @@ class OmniOfflineClient:
                                             fence_triggered = True
                                             break
                                 if flush_text and flush_text.strip():
-                                    assistant_message += flush_text
-                                    assistant_message_total += flush_text
-                                    if self.on_text_delta:
-                                        await self.on_text_delta(flush_text, is_first_chunk)
-                                    is_first_chunk = False
+                                    emit_flush_text = flush_text
                                     if self.enable_response_guard:
-                                        # 长度 guard 看整轮（含 pre-tool），与上方主累加块对偶
-                                        current_length = count_tokens(assistant_message_total)
+                                        # 长度 guard 看整轮（含 pre-tool），与上方主累加块对偶。
+                                        candidate_total = assistant_message_total + flush_text
+                                        current_length = count_tokens(candidate_total)
                                         if current_length > self.max_response_length:
                                             guard_triggered = True
                                             discard_reason = f"length>{self.max_response_length}"
+                                            length_guard_original_tokens = current_length
+                                            emit_flush_text = ""
+                                            if not _is_gibberish_response(candidate_total):
+                                                capped = truncate_to_tokens(
+                                                    candidate_total, self.max_response_length,
+                                                )
+                                                candidate_recovery = _truncate_to_last_sentence_end(capped)
+                                                if candidate_recovery:
+                                                    if candidate_recovery.startswith(assistant_message_total):
+                                                        recovery_suffix = candidate_recovery[len(assistant_message_total):]
+                                                        if recovery_suffix.strip():
+                                                            emit_flush_text = recovery_suffix
+                                                            length_guard_recovery_text = candidate_recovery
+                                                    elif (
+                                                        assistant_message_total
+                                                        and _has_unpersisted_recovery_suffix(assistant_message_total)
+                                                    ):
+                                                        length_guard_recovery_text = assistant_message_total
+                                    if emit_flush_text and emit_flush_text.strip():
+                                        assistant_message += emit_flush_text
+                                        assistant_message_total += emit_flush_text
+                                        if self.on_text_delta:
+                                            await self.on_text_delta(emit_flush_text, is_first_chunk)
+                                        is_first_chunk = False
 
                         if guard_triggered:
                             guard_attempt += 1
@@ -1304,6 +1363,34 @@ class OmniOfflineClient:
                             # rerolls 次数（rerolls 不含首次尝试）。前端 attempt
                             # / max_attempts 进度条要 1/2 → 2/2 才合理。
                             total_attempts = self.max_response_rerolls + 1
+
+                            recovery_text = length_guard_recovery_text
+                            if discard_reason and "length>" in discard_reason:
+                                # 长回复若是正常可读文本，直接按已发出的截断文本
+                                # 收尾，不 reroll，避免 UI/TTS 和 history 分叉。
+                                if not recovery_text and not _is_gibberish_response(assistant_message_total):
+                                    capped = truncate_to_tokens(
+                                        assistant_message_total, self.max_response_length,
+                                    )
+                                    candidate_recovery = _truncate_to_last_sentence_end(capped)
+                                    if _has_unpersisted_recovery_suffix(candidate_recovery):
+                                        recovery_text = candidate_recovery
+
+                            if recovery_text and _has_unpersisted_recovery_suffix(recovery_text):
+                                history_recovery_text = assistant_message
+                                original_tokens = length_guard_original_tokens or count_tokens(assistant_message_total)
+                                logger.info(
+                                    "OmniOfflineClient: 长回复已流式输出，停止生成并按最后句末入历史 "
+                                    "(原 %d tokens → 截断后 %d tokens)",
+                                    original_tokens, count_tokens(recovery_text),
+                                )
+                                if history_recovery_text:
+                                    self._conversation_history.append(AIMessage(content=history_recovery_text))
+                                await self._check_repetition(recovery_text)
+                                assistant_message = history_recovery_text
+                                guard_exhausted = True
+                                break
+                            recovery_text = ""
 
                             if will_retry:
                                 # 还能 retry：发 will_retry 通知，循环继续。前端
@@ -1339,7 +1426,6 @@ class OmniOfflineClient:
                             # max_response_length 再找句末，否则截出来的句末仍
                             # 可能在 token 上限之外（比如最后一个句号在 950 token
                             # 处但 cap 是 300）。
-                            recovery_text = ""
                             if discard_reason and "length>" in discard_reason:
                                 # 整轮判定：gibberish / 截断必须看 _total，否则
                                 # tool 轮 sentinel 把 final-segment 清空之后整段
@@ -1348,13 +1434,16 @@ class OmniOfflineClient:
                                     capped = truncate_to_tokens(
                                         assistant_message_total, self.max_response_length,
                                     )
-                                    recovery_text = _truncate_to_last_sentence_end(capped)
+                                    candidate_recovery = _truncate_to_last_sentence_end(capped)
+                                    if _has_unpersisted_recovery_suffix(candidate_recovery):
+                                        recovery_text = candidate_recovery
 
                             if recovery_text:
+                                original_tokens = length_guard_original_tokens or count_tokens(assistant_message_total)
                                 logger.info(
                                     "OmniOfflineClient: guard 重试耗尽，截断至最后句末 "
                                     "(原 %d tokens → 截断后 %d tokens)",
-                                    count_tokens(assistant_message_total), count_tokens(recovery_text),
+                                    original_tokens, count_tokens(recovery_text),
                                 )
                                 truncate_msg = json.dumps({
                                     "code": "RESPONSE_LENGTH_TRUNCATED",

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -854,6 +854,89 @@ async def test_stream_text_notifies_discarded_when_partial_text_then_error(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_text_length_guard_finishes_visible_long_reply_without_discard(monkeypatch):
+    """正常长回复已经流式吐到前端时，长度 guard 不应走 discard/recovery。
+
+    response_discarded 会清掉旧气泡/字幕，然后 recovery 再整段重发；这会
+    让字幕翻译处理两份同一轮文本，TTS 也可能收到过长的整段恢复文本。
+    """
+    from main_logic import omni_offline_client as _ofc
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import LLMStreamChunk, SystemMessage
+
+    monkeypatch.setattr(_ofc, "count_tokens", lambda text: len((text or "").split()))
+    monkeypatch.setattr(
+        _ofc,
+        "truncate_to_tokens",
+        lambda text, budget: " ".join((text or "").split()[:budget]),
+    )
+    length_log_args = []
+
+    def fake_logger_info(message, *args, **_kwargs):
+        if "长回复已流式输出" in message:
+            length_log_args.append(args)
+
+    monkeypatch.setattr(_ofc.logger, "info", fake_logger_info)
+
+    stream_calls = 0
+
+    async def _astream_long_reply(self, messages, **overrides):
+        nonlocal stream_calls
+        stream_calls += 1
+        yield LLMStreamChunk(content="one two three four. five")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream_long_reply)
+
+    discarded_calls: list = []
+    text_emitted: list = []
+
+    async def fake_notify_discarded(reason, attempt, max_attempts, will_retry, message=None):
+        discarded_calls.append({
+            "reason": reason,
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+            "will_retry": will_retry,
+            "message": message,
+        })
+
+    async def fake_text_delta(text, is_first):
+        text_emitted.append(text)
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.lanlan_name = "T"
+    client.master_name = "M"
+    client._prefix_buffer_size = 0
+    client._conversation_history = [SystemMessage(content="sys")]
+    client._pending_images = []
+    client._is_responding = False
+    client._recent_responses = []
+    client._repetition_threshold = 0.8
+    client._max_recent_responses = 3
+    client.max_response_length = 4
+    client.max_response_rerolls = 1
+    client.enable_response_guard = True
+    client.vision_model = ""
+    client.model = "x"
+    client.on_text_delta = fake_text_delta
+    client.on_input_transcript = noop
+    client.on_response_done = noop
+    client.on_response_discarded = fake_notify_discarded
+    client.on_status_message = noop
+    client.on_repetition_detected = None
+
+    await client.stream_text("write a long reply")
+
+    assert stream_calls == 1
+    assert "".join(text_emitted) == "one two three four."
+    assert discarded_calls == []
+    assert client._conversation_history[-1].content == "one two three four."
+    assert length_log_args[-1] == (5, 4)
+
+
+@pytest.mark.asyncio
 async def test_offline_silent_fallback_when_genai_did_not_emit(monkeypatch):
     """对偶：genai 路径还没 yield 过任何文本就抛 transient 异常时，
     `_astream_with_tools` 仍然应该静默 fallback 到 OpenAI-compat 兜底——
@@ -1206,6 +1289,176 @@ async def test_stream_text_does_not_double_write_pretool_text(monkeypatch):
         f"pre-tool 文本被双写进 history 了！final AIMessage.content={final_ai.content!r}"
     )
     assert final_ai.content == "22 度。"
+
+
+@pytest.mark.asyncio
+async def test_stream_text_length_guard_after_tool_call_does_not_double_write_pretool_text(monkeypatch):
+    """长度 guard 在 tool 轮之后触发时，history 只能追加未持久化的 post-tool 文本。
+
+    pre-tool 文本已经由 _astream_*_with_tools inline 写进 assistant.tool_calls.content。
+    recovery 分支如果把整轮文本再 append 一次，会让下一轮上下文重复看到 pre-tool 文本。
+    """
+    from main_logic import omni_offline_client as _ofc
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import LLMStreamChunk, AIMessage, SystemMessage
+
+    monkeypatch.setattr(_ofc, "count_tokens", lambda text: len((text or "").split()))
+    monkeypatch.setattr(
+        _ofc,
+        "truncate_to_tokens",
+        lambda text, budget: " ".join((text or "").split()[:budget]),
+    )
+
+    async def _astream_tool_then_long_reply(self, messages, **overrides):
+        yield LLMStreamChunk(content="checking now.")
+        messages.append({
+            "role": "assistant",
+            "content": "checking now.",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"}}],
+        })
+        messages.append({
+            "role": "tool", "tool_call_id": "c1", "name": "lookup",
+            "content": '{"ok":true}',
+        })
+        yield LLMStreamChunk(content="", tool_round_persisted=True)
+        yield LLMStreamChunk(content="answer one. answer two overflow")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream_tool_then_long_reply)
+
+    text_emitted: list = []
+    discarded_calls: list = []
+
+    async def fake_text_delta(text, is_first):
+        text_emitted.append(text)
+
+    async def fake_notify_discarded(reason, attempt, max_attempts, will_retry, message=None):
+        discarded_calls.append({
+            "reason": reason,
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+            "will_retry": will_retry,
+            "message": message,
+        })
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.lanlan_name = "T"
+    client.master_name = "M"
+    client._prefix_buffer_size = 0
+    client._conversation_history = [SystemMessage(content="sys")]
+    client._pending_images = []
+    client._is_responding = False
+    client._recent_responses = []
+    client._repetition_threshold = 0.8
+    client._max_recent_responses = 3
+    client.max_response_length = 5
+    client.max_response_rerolls = 0
+    client.enable_response_guard = True
+    client.vision_model = ""
+    client.model = "x"
+    client.on_text_delta = fake_text_delta
+    client.on_input_transcript = noop
+    client.on_response_done = noop
+    client.on_response_discarded = fake_notify_discarded
+    client.on_status_message = None
+    client.on_repetition_detected = None
+
+    await client.stream_text("lookup")
+
+    assert "".join(text_emitted) == "checking now.answer one."
+    assert discarded_calls == []
+
+    history = client._conversation_history
+    assistant_with_tool = next(
+        m for m in history if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert assistant_with_tool["content"] == "checking now."
+    final_ai = history[-1]
+    assert isinstance(final_ai, AIMessage)
+    assert final_ai.content == "answer one."
+
+
+@pytest.mark.asyncio
+async def test_stream_text_length_guard_after_tool_call_rejects_pretool_only_recovery(monkeypatch):
+    """tool 后续写还没有完整句子时，不能只用 pre-tool 文本当作成功恢复。"""
+    from main_logic import omni_offline_client as _ofc
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from utils.llm_client import LLMStreamChunk, AIMessage, SystemMessage
+
+    monkeypatch.setattr(_ofc, "count_tokens", lambda text: len((text or "").split()))
+    monkeypatch.setattr(
+        _ofc,
+        "truncate_to_tokens",
+        lambda text, budget: " ".join((text or "").split()[:budget]),
+    )
+
+    async def _astream_tool_then_unfinished_overflow(self, messages, **overrides):
+        yield LLMStreamChunk(content="checking now.")
+        messages.append({
+            "role": "assistant",
+            "content": "checking now.",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"}}],
+        })
+        messages.append({
+            "role": "tool", "tool_call_id": "c1", "name": "lookup",
+            "content": '{"ok":true}',
+        })
+        yield LLMStreamChunk(content="", tool_round_persisted=True)
+        yield LLMStreamChunk(content=" unfinished overflow")
+
+    monkeypatch.setattr(OmniOfflineClient, "_astream_with_tools", _astream_tool_then_unfinished_overflow)
+
+    text_emitted: list = []
+    discarded_calls: list = []
+
+    async def fake_text_delta(text, is_first):
+        text_emitted.append(text)
+
+    async def fake_notify_discarded(reason, attempt, max_attempts, will_retry, message=None):
+        discarded_calls.append({
+            "reason": reason,
+            "attempt": attempt,
+            "max_attempts": max_attempts,
+            "will_retry": will_retry,
+            "message": message,
+        })
+
+    async def noop(*_a, **_kw):
+        pass
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.lanlan_name = "T"
+    client.master_name = "M"
+    client._prefix_buffer_size = 0
+    client._conversation_history = [SystemMessage(content="sys")]
+    client._pending_images = []
+    client._is_responding = False
+    client._recent_responses = []
+    client._repetition_threshold = 0.8
+    client._max_recent_responses = 3
+    client.max_response_length = 2
+    client.max_response_rerolls = 0
+    client.enable_response_guard = True
+    client.vision_model = ""
+    client.model = "x"
+    client.on_text_delta = fake_text_delta
+    client.on_input_transcript = noop
+    client.on_response_done = noop
+    client.on_response_discarded = fake_notify_discarded
+    client.on_status_message = None
+    client.on_repetition_detected = None
+
+    await client.stream_text("lookup")
+
+    assert "".join(text_emitted) == "checking now."
+    assert len(discarded_calls) == 1
+    assert discarded_calls[0]["will_retry"] is False
+    assert json.loads(discarded_calls[0]["message"]) == {"code": "RESPONSE_TOO_LONG"}
+    assert not any(isinstance(m, AIMessage) for m in client._conversation_history[1:])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 变更内容

修复长回复超过长度保护后，被当成异常丢弃并重新输出很长的文本的问题。

现在正常可读的长回复触发长度保护时，会直接停止继续生成，并按最后一个完整句子收尾，不再走 `response_discarded` / recovery 重发流程。

## 修复的问题

- 避免长篇回复输出完后又提示“猫娘链接异常”
- 避免同一轮回复被重复输出
- 避免字幕翻译同时处理旧流式文本和恢复文本，导致翻译对不上或卡住
- 避免 TTS 收到整段恢复文本后报 `text is too long`

## 测试

- `python -m pytest tests/unit/test_tool_calling.py -q`
- 结果：`35 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  - 改进超长回复处理：在超过长度时截断到令牌预算并回退到最近完整句子，合法则将恢复文本作为已生成内容追加，避免占位或失败终止；在重试耗尽路径记录原/恢复令牌计数并提前结束生成。
  - 修复工具调用场景下的持久化行为，防止工具前后文本被重复写入。

* **测试**
  - 新增回归单元测试，覆盖常规与工具调用场景的截断、持久化和丢弃通知行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->