### PR TITLE
fix(jukebox): restore drag from SAM panel footer area

### DIFF
--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3960,7 +3960,7 @@ window.Jukebox = {
 
     const onMouseDown = (e) => {
       // 忽略所有交互元素
-      if (e.target.closest('button, input, a, select, textarea, .sam-close-btn, .sam-tab, .sam-content, .sam-checkbox')) return;
+      if (e.target.closest('button, input, a, select, textarea, .sam-close-btn, .sam-tab, .sam-content, .sam-checkbox, .sam-click-add')) return;
 
       e.preventDefault();
       const clientX = e.touches ? e.touches[0].clientX : e.clientX;

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3960,7 +3960,7 @@ window.Jukebox = {
 
     const onMouseDown = (e) => {
       // 忽略所有交互元素
-      if (e.target.closest('button, input, a, select, textarea, .sam-close-btn, .sam-tab, .sam-footer, .sam-content, .sam-checkbox')) return;
+      if (e.target.closest('button, input, a, select, textarea, .sam-close-btn, .sam-tab, .sam-content, .sam-checkbox')) return;
 
       e.preventDefault();
       const clientX = e.touches ? e.touches[0].clientX : e.clientX;

--- a/templates/jukebox_manager.html
+++ b/templates/jukebox_manager.html
@@ -59,8 +59,7 @@
         .jukebox-sam-panel .sam-unbind-btn,
         .jukebox-sam-panel .sam-add-binding-btn,
         .jukebox-sam-panel .sam-click-add,
-        .jukebox-sam-panel .sam-file-drop-zone,
-        .jukebox-sam-panel .sam-footer {
+        .jukebox-sam-panel .sam-file-drop-zone {
             -webkit-app-region: no-drag !important;
         }
     </style>


### PR DESCRIPTION
修复点歌台管理器面板（SAM）底部区域在所有模式下无法拖动的问题。

1. Jukebox.js:3963 — JS bindPanelDrag 排除列表包含 .sam-footer，导致网页版浮层面板无法从 footer 区域拖动
2. jukebox_manager.html:63 — CSS -webkit-app-region: no-drag 覆盖，导致无边框管理器窗口无法从 footer 区域拖动窗口

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了管理面板的拖拽交互：调整了哪些子元素会触发或阻止面板拖动（包括表单项、复选框、内容区与底部区域的交互边界），并更新了文件拖放区的拖拽响应行为，使面板拖拽与原生拖放更一致且操作更流畅。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->