### PR TITLE
feat(voice): 新增 yui_cn 音色 + 新角色默认 free preset voice

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -359,6 +359,7 @@
     "gentleMaiden": "voice-tone-PGLlrd5SNM",
     "sweetLady": "voice-tone-PGLmTEeUOu",
     "frailMaiden": "voice-tone-PGLmzXEX44",
-    "childishMaiden": "voice-tone-PGLnVNQn7A"
+    "childishMaiden": "voice-tone-PGLnVNQn7A",
+    "yui_cn": "voice-tone-QqMv39SYSW"
   }
 }

--- a/config/characters.en.json
+++ b/config/characters.en.json
@@ -29,7 +29,7 @@
       ],
       "Signature Line": "The only cat girl who can do this and that to Carbon-Based Lifeform is yours truly, meow~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-PGLiyZt65w",
+      "voice_id": "voice-tone-QqMv39SYSW",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters.ja.json
+++ b/config/characters.ja.json
@@ -29,7 +29,7 @@
       ],
       "一言セリフ": "炭素生物にあんなことやこんなことができるのは、本にゃんだけにゃん〜",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-PGLiyZt65w",
+      "voice_id": "voice-tone-QqMv39SYSW",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters.ko.json
+++ b/config/characters.ko.json
@@ -29,7 +29,7 @@
       ],
       "대사 한마디": "탄소 생물한테 이런저런 걸 할 수 있는 건 이 냥이뿐이다냥~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-PGLiyZt65w",
+      "voice_id": "voice-tone-QqMv39SYSW",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters.ru.json
+++ b/config/characters.ru.json
@@ -29,7 +29,7 @@
       ],
       "Коронная фраза": "Не-не-не, даже не думай — возиться с этой Углеродной формой жизни позволено только мне, мяу~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-PGLiyZt65w",
+      "voice_id": "voice-tone-QqMv39SYSW",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters.zh-CN.json
+++ b/config/characters.zh-CN.json
@@ -29,7 +29,7 @@
       ],
       "一句话台词": "能对碳基生物做这样那样的事情的，只有本喵一只猫娘喵~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-PGLiyZt65w",
+      "voice_id": "voice-tone-QqMv39SYSW",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters.zh-TW.json
+++ b/config/characters.zh-TW.json
@@ -29,7 +29,7 @@
       ],
       "一句話台詞": "能對碳基生物做這樣那樣的事情的，只有本喵一隻貓娘喵~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-PGLiyZt65w",
+      "voice_id": "voice-tone-QqMv39SYSW",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2451,6 +2451,9 @@ async def add_catgirl(request: Request):
                 catgirl_data[k] = v
 
     characters['猫娘'][key] = catgirl_data
+    # 默认 free preset voice：仅在 free + lanlan.tech 通道下生效，
+    # 其他通道由 LLMSessionManager.__init__/start_session/热切换 三处 gate 清空 self.voice_id 后透给 worker。
+    set_reserved(catgirl_data, 'voice_id', 'voice-tone-PGLiyZt65w')
     await _config_manager.asave_characters(characters)
     pending_mark_ok, pending_mark_error = await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
 

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "Gentle Maiden",
             "sweetLady": "Sweet Lady",
             "frailMaiden": "Frail Maiden",
-            "childishMaiden": "Childish Maiden"
+            "childishMaiden": "Childish Maiden",
+            "yui_cn": "YUI (Chinese)"
         },
         "cloneMethod": "Clone Method",
         "cloneMethodFile": "Local File",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "Doncella gentil",
             "sweetLady": "dulce dama",
             "frailMaiden": "doncella frágil",
-            "childishMaiden": "doncella infantil"
+            "childishMaiden": "doncella infantil",
+            "yui_cn": "YUI (chino)"
         },
         "cloneMethod": "Método de clonación",
         "cloneMethodFile": "Archivo Local",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "優しい乙女",
             "sweetLady": "甘々な女性",
             "frailMaiden": "病弱な少女",
-            "childishMaiden": "幼い少女"
+            "childishMaiden": "幼い少女",
+            "yui_cn": "YUI（中国語）"
         },
         "cloneMethod": "クローン方式",
         "cloneMethodFile": "ローカルファイル",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "부드러운 아가씨",
             "sweetLady": "달콤한 누나",
             "frailMaiden": "병약한 아가씨",
-            "childishMaiden": "철없는 아가씨"
+            "childishMaiden": "철없는 아가씨",
+            "yui_cn": "YUI (중국어)"
         },
         "cloneMethod": "클론 방식",
         "cloneMethodFile": "로컬 파일",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "Gentil donzela",
             "sweetLady": "Doce senhora",
             "frailMaiden": "Donzela Frágil",
-            "childishMaiden": "Donzela Infantil"
+            "childishMaiden": "Donzela Infantil",
+            "yui_cn": "YUI (chinês)"
         },
         "cloneMethod": "Método Clonar",
         "cloneMethodFile": "Arquivo local",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "Нежная девушка",
             "sweetLady": "Сладкая леди",
             "frailMaiden": "Хрупкая девушка",
-            "childishMaiden": "Детская девушка"
+            "childishMaiden": "Детская девушка",
+            "yui_cn": "YUI (китайский)"
         },
         "cloneMethod": "Способ клонирования",
         "cloneMethodFile": "Локальный файл",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "温柔少女",
             "sweetLady": "甜美御姐",
             "frailMaiden": "病弱少女",
-            "childishMaiden": "稚气少女"
+            "childishMaiden": "稚气少女",
+            "yui_cn": "YUI（中文）"
         },
         "cloneMethod": "克隆方式",
         "cloneMethodFile": "本地文件",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1491,7 +1491,8 @@
             "gentleMaiden": "溫柔少女",
             "sweetLady": "甜美御姐",
             "frailMaiden": "病弱少女",
-            "childishMaiden": "稚氣少女"
+            "childishMaiden": "稚氣少女",
+            "yui_cn": "YUI（中文）"
         },
         "cloneMethod": "克隆方式",
         "cloneMethodFile": "本地檔案",


### PR DESCRIPTION
## Summary
- 新增 `yui_cn` (`voice-tone-QqMv39SYSW`) 到 `api_providers.json` 的 `free_voices`，同步 8 个 UI locale 显示名
- `yui-origin` 角色 voice_id 切到 `yui_cn`
- `add_catgirl` 为新角色写默认 free preset voice (`voice-tone-PGLiyZt65w` / `cuteGirl` tone，PR 前 yui-origin 默认音色)，避免新人物初始无声音

## 防漏（核心约束）
默认 voice 仅在 `free + lanlan.tech` 通道实际下发：

- **Realtime 通道**：`_resolve_realtime_free_voice` ([core.py:2639](main_logic/core.py)) 仅 `core_api_type=='free' && base_url 含 'lanlan.tech' && voice ∈ free_voices` 才下发；`lanlan.app` 由 `_should_block_free_preset_voice` 兜底
- **TTS Worker 通道**：`LLMSessionManager` 三处现有 gate（`__init__` [:436](main_logic/core.py)、`start_session` [:2847](main_logic/core.py)、热切换 [:3501](main_logic/core.py)）在非 free 通道下把 `self.voice_id` 清成空，worker 走自身默认音色。`qwen/glm/gemini/openai/cogtts/local TTS` 不会收到 preset id
- **持久化**：`cleanup_invalid_voice_ids` ([config_manager.py:2349](utils/config_manager.py)) 对 free preset 白名单放行——切走再切回 free + lanlan.tech 时，preset 自动恢复生效

## Test plan
- [x] `uv run pytest tests/unit/test_character_memory_regression.py` (28 passed)
- [x] `uv run pytest tests/unit/test_character_persona_router.py tests/unit/test_initial_personality_state.py tests/unit/test_tutorial_prompt_state.py` (75 passed)
- [x] `uv run python -m py_compile main_routers/characters_router.py` (compile OK)
- [ ] manual：新建角色 → free + lanlan.tech 通道下默认音色生效
- [ ] manual：切到 qwen/openai/glm 等通道 → preset voice 不透传，走 provider 默认音色
- [ ] manual：再切回 free + lanlan.tech → 默认音色自动恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增两个免费语音预设选项：稚气少女和YUI中文版本。
  * 更新YUI角色的语音设置，优化语音质量和听感体验。
  * 支持多语言本地化，涵盖英文、西班牙文、日文、韩文、葡萄牙文、俄文以及中文等多个语言环境。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->