### PR TITLE
refactor(voice): 默认 voice 改读 free_voices['cuteGirl'] 避免配置漂移

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2451,9 +2451,11 @@ async def add_catgirl(request: Request):
                 catgirl_data[k] = v
 
     characters['猫娘'][key] = catgirl_data
-    # 默认 free preset voice：仅在 free + lanlan.tech 通道下生效，
-    # 其他通道由 LLMSessionManager.__init__/start_session/热切换 三处 gate 清空 self.voice_id 后透给 worker。
-    set_reserved(catgirl_data, 'voice_id', 'voice-tone-PGLiyZt65w')
+    # 默认走 free preset：非 free / 非 lanlan.tech 通道由 LLMSessionManager 现有 gate 清空 self.voice_id，不会泄漏给其他 TTS provider。
+    # 从 free_voices['cuteGirl'] 读以避免硬编码漂移；缺失时退回 PR 前 yui-origin 历史值。
+    from utils.api_config_loader import get_free_voices
+    default_free_voice_id = (get_free_voices() or {}).get('cuteGirl') or 'voice-tone-PGLiyZt65w'
+    set_reserved(catgirl_data, 'voice_id', default_free_voice_id)
     await _config_manager.asave_characters(characters)
     pending_mark_ok, pending_mark_error = await _mark_new_character_greeting_pending_safe(_config_manager, key, "create")
 


### PR DESCRIPTION
Follow-up to #1211 — 应用 CodeRabbit 在那条 PR 上提的 refactor nit（squash-merge 时 fix commit `6a5ab820c` 还没进 main，所以补一个 PR）。

## CodeRabbit 原 nit

> 这里直接硬编码 `voice-tone-PGLiyZt65w`，后续若配置侧调整同 key 的值，新增角色会悄悄继续写旧值喵。建议"配置优先 + 当前值兜底"喵。

## 改动

`main_routers/characters_router.py` 的 `add_catgirl`：把硬编码的 `'voice-tone-PGLiyZt65w'` 改成 `free_voices['cuteGirl']` 优先 + 字面量兜底。

```python
from utils.api_config_loader import get_free_voices
default_free_voice_id = (get_free_voices() or {}).get('cuteGirl') or 'voice-tone-PGLiyZt65w'
set_reserved(catgirl_data, 'voice_id', default_free_voice_id)
```

## 行为等价

- 当前 `config/api_providers.json` 里 `cuteGirl` 就是 `voice-tone-PGLiyZt65w`，运行时值完全一致。
- 兜底字面量保留 PR #1211 之前的 yui-origin 历史值，避免 `get_free_voices()` 加载失败时新角色拿不到默认 voice。
- 运行时 gate 完全不变（`main_logic/core.py` 的 `LLMSessionManager.__init__` / `start_session` / 热切换 三处仍会在非 free / 非 lanlan.tech 通道清空 `self.voice_id`，不会把 free preset id 泄漏给其他 TTS provider）。
- 后续若配置侧把 `cuteGirl` 调成新的 voice id，新增角色会自动跟随，不再悄悄写旧值。

## 测试

`uv run pytest tests/unit/test_character_memory_regression.py -q` → 28 passed。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEYFxcnFjse5Acvg2CzAnP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 改进了新建角色的默认语音分配机制，系统现在会智能地动态读取免费版本的语音映射配置，为新角色选择最佳的默认语音选项，增强了角色创建时的用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->