### PR TITLE
修正 OpenClaw 子开关可用性判断

### DIFF
--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -340,7 +340,7 @@
                 : !!flags['openclaw_enabled'];
             openclaw.forEach(cb => {
                 cb.checked = optimisticVal && (canUse || disabledByPending);
-                cb.disabled = !!state.globalBusy || disabledByPending || !effectiveAnalyzerEnabled;
+                cb.disabled = !!state.globalBusy || disabledByPending || activating || !effectiveAnalyzerEnabled || !ready;
                 if (disabledByPending || activating) {
                     cb.title = window.t ? window.t('settings.toggles.checking') : '切换中...';
                 } else if (canUse) {
@@ -413,6 +413,11 @@
                     const ts = performance.now();
                     await fetchSnapshot().catch(() => { });
                     console.log('[AgentUIv2Timing]', { phase: 'fetch_snapshot_after_master', ms: Number((performance.now() - ts).toFixed(2)) });
+                    if (enabled) {
+                        const openclawTs = performance.now();
+                        await refreshOpenClawAvailability();
+                        console.log('[AgentUIv2Timing]', { phase: 'refresh_openclaw_after_master', ms: Number((performance.now() - openclawTs).toFixed(2)) });
+                    }
                 }
             } catch (e) {
                 if (opSeq === state.masterOpSeq) {


### PR DESCRIPTION
- 在 Agent 总开关开启后主动刷新 OpenClaw 可用性
- OpenClaw 不可用时禁用子开关，避免用户继续点击开启
- 保留开启探测中的禁用状态，防止重复触发切换


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes（错误修复）
  * 改进了全局代理主开关的控制逻辑，确保在启用或禁用后能正确刷新 OpenClaw 可用性状态
  * 优化了 OpenClaw 选项框的禁用状态判断，在代理激活过程中会正确禁用该选项，提升功能的响应一致性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->