### PR TITLE
阻止页面中的链接、图片等元素被拖到桌面生成复制项

### DIFF
--- a/frontend/plugin-manager/src/main.ts
+++ b/frontend/plugin-manager/src/main.ts
@@ -42,11 +42,18 @@ function initNativeDragGuard() {
   }
 
   const handleDragStart = (event: DragEvent) => {
-    const target = event.target
+    const rawTarget = event.target
+    let target: Element | null = null
+    if (rawTarget instanceof Element) {
+      target = rawTarget
+    } else if (rawTarget instanceof Node) {
+      target = rawTarget.parentElement
+    }
+
     if (
       target instanceof HTMLAnchorElement
       || target instanceof HTMLImageElement
-      || (target instanceof Element && target.closest('a[href], img'))
+      || target?.closest('a[href], img')
     ) {
       event.preventDefault()
     }

--- a/frontend/plugin-manager/src/main.ts
+++ b/frontend/plugin-manager/src/main.ts
@@ -27,34 +27,39 @@ import { initPluginDashboardYuiGuideRuntime } from './yui-guide-runtime'
 initDarkMode()
 initPluginDashboardYuiGuideRuntime()
 
-function initDecorativeImageDragGuard() {
-  const markImage = (img: HTMLImageElement) => {
-    img.draggable = false
-    img.setAttribute('draggable', 'false')
+function initNativeDragGuard() {
+  const markNativeDragSource = (element: HTMLAnchorElement | HTMLImageElement) => {
+    element.draggable = false
+    element.setAttribute('draggable', 'false')
   }
 
-  const markImages = (root: ParentNode | HTMLImageElement = document) => {
-    if (root instanceof HTMLImageElement) {
-      markImage(root)
+  const markNativeDragSources = (root: ParentNode | HTMLAnchorElement | HTMLImageElement = document) => {
+    if (root instanceof HTMLAnchorElement || root instanceof HTMLImageElement) {
+      markNativeDragSource(root)
       return
     }
-    root.querySelectorAll<HTMLImageElement>('img').forEach(markImage)
+    root.querySelectorAll<HTMLAnchorElement | HTMLImageElement>('a[href], img').forEach(markNativeDragSource)
   }
 
   const handleDragStart = (event: DragEvent) => {
-    if (event.target instanceof HTMLImageElement) {
+    const target = event.target
+    if (
+      target instanceof HTMLAnchorElement
+      || target instanceof HTMLImageElement
+      || (target instanceof Element && target.closest('a[href], img'))
+    ) {
       event.preventDefault()
     }
   }
 
-  markImages(document)
+  markNativeDragSources(document)
   document.addEventListener('dragstart', handleDragStart, true)
 
   const observer = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node) => {
         if (node instanceof Element) {
-          markImages(node)
+          markNativeDragSources(node)
         }
       })
     })
@@ -62,7 +67,7 @@ function initDecorativeImageDragGuard() {
   observer.observe(document.documentElement, { childList: true, subtree: true })
 }
 
-initDecorativeImageDragGuard()
+initNativeDragGuard()
 
 console.log('🚀 Starting N.E.K.O Plugin Management System...')
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -39,6 +39,7 @@ button img,
 
 img,
 svg,
+a[href],
 [aria-hidden="true"] img {
     -webkit-user-drag: none;
     -khtml-user-drag: none;

--- a/static/js/window_controls.js
+++ b/static/js/window_controls.js
@@ -127,9 +127,16 @@
         window.__nekoNativeDragGuardBound = true;
 
         document.addEventListener('dragstart', (event) => {
-            const target = event.target;
-            if (!target || typeof target.closest !== 'function') return;
-            const source = target.closest(NATIVE_DRAG_SOURCE_SELECTOR);
+            const rawTarget = event.target;
+            let targetEl = null;
+            if (rawTarget && rawTarget.nodeType === Node.ELEMENT_NODE) {
+                targetEl = rawTarget;
+            } else if (rawTarget && rawTarget.parentElement) {
+                targetEl = rawTarget.parentElement;
+            }
+
+            if (!targetEl || typeof targetEl.closest !== 'function') return;
+            const source = targetEl.closest(NATIVE_DRAG_SOURCE_SELECTOR);
             if (!source) return;
             event.preventDefault();
         }, true);

--- a/static/js/window_controls.js
+++ b/static/js/window_controls.js
@@ -3,6 +3,7 @@
 
     const CONTROL_SELECTOR = '[data-neko-window-control]';
     const MAXIMIZE_ICON_SELECTOR = '.neko-window-maximize-icon';
+    const NATIVE_DRAG_SOURCE_SELECTOR = 'a[href], img, svg, video, audio';
 
     function translate(key, fallback) {
         try {
@@ -121,6 +122,19 @@
         }
     }
 
+    function initNativeDragGuard() {
+        if (window.__nekoNativeDragGuardBound) return;
+        window.__nekoNativeDragGuardBound = true;
+
+        document.addEventListener('dragstart', (event) => {
+            const target = event.target;
+            if (!target || typeof target.closest !== 'function') return;
+            const source = target.closest(NATIVE_DRAG_SOURCE_SELECTOR);
+            if (!source) return;
+            event.preventDefault();
+        }, true);
+    }
+
     async function restoreCurrentWindowFromOpener() {
         const api = window.nekoWindowControl;
         if (!api || typeof api.restore !== 'function') return;
@@ -139,8 +153,12 @@
     });
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initWindowControls);
+        document.addEventListener('DOMContentLoaded', () => {
+            initWindowControls();
+            initNativeDragGuard();
+        });
     } else {
         initWindowControls();
+        initNativeDragGuard();
     }
 })();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了原生拖拽防护，覆盖链接、图片及媒体元素，防止意外拖拽。
* **Improvements**
  * 拖拽防护在页面加载与动态添加的内容上更可靠，初始化时机与全局绑定得到加强，提升稳定性与用户体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->