### PR TITLE
Adjust minimum widths for options components to handle text overflow

### DIFF
--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1093,16 +1093,6 @@ svg {
   min-width: 0;
 }
 
-.composer {
-  /* 同上：作为 .composer-panel 的 grid item，显式 min-width: 0
-     让窗口收缩时跟随 panel 一起收，而不被自身 min-content 卡住。 */
-  min-width: 0;
-}
-
-.composer-input-shell {
-  min-width: 0;
-}
-
 /* Hide empty music-player-mount so it doesn't occupy a grid row */
 #music-player-mount:empty {
   display: none;
@@ -1155,12 +1145,16 @@ svg {
 /* ===== 输入框统一容器 ===== */
 .composer {
   display: block;
+  /* 作为 .composer-panel 的 grid item，显式 min-width: 0
+     让窗口收缩时跟随 panel 一起收，而不被自身 min-content 卡住。 */
+  min-width: 0;
 }
 
 .composer-input-shell {
   display: flex;
   flex-direction: column;
   min-height: 98px;
+  min-width: 0;
   padding: 0 16px;
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.91);
@@ -1706,7 +1700,6 @@ svg {
   /* 关键：默认 min-width: auto 会让长文本沿 flex 链向上传染，把整个输入壳撑宽；
      置 0 后按钮严格遵循 width:100%，长文本走下面的 ellipsis 路径。 */
   min-width: 0;
-  max-width: 100%;
   padding: 6px 10px;
   border-radius: 10px;
   border: 1px solid rgba(127, 144, 170, 0.22);

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1081,11 +1081,26 @@ svg {
 
 .composer-panel {
   display: grid;
+  /* 显式 1 列、min 边为 0：阻断 grid item 默认 min-width: auto 把内部
+     nowrap 文本的 min-content 一路向上撑宽（galgame 选项过长时会让整个
+     panel 抗拒收缩，进而被 chat-window overflow: hidden 截断）。 */
+  grid-template-columns: minmax(0, 1fr);
   gap: 4px;
   padding: 6px;
   position: relative;
   z-index: 15;
   background: rgba(255, 255, 255, 0.91);
+  min-width: 0;
+}
+
+.composer {
+  /* 同上：作为 .composer-panel 的 grid item，显式 min-width: 0
+     让窗口收缩时跟随 panel 一起收，而不被自身 min-content 卡住。 */
+  min-width: 0;
+}
+
+.composer-input-shell {
+  min-width: 0;
 }
 
 /* Hide empty music-player-mount so it doesn't occupy a grid row */

--- a/frontend/react-neko-chat/src/styles.css
+++ b/frontend/react-neko-chat/src/styles.css
@@ -1679,6 +1679,8 @@ svg {
   flex-direction: column;
   gap: 4px;
   margin: 4px 0 2px;
+  /* 让选项列在窄窗口下能跟随 input-shell 收缩，而不被内部 nowrap 文本顶宽。 */
+  min-width: 0;
 }
 
 .composer-galgame-option {
@@ -1686,6 +1688,10 @@ svg {
   align-items: center;
   gap: 8px;
   width: 100%;
+  /* 关键：默认 min-width: auto 会让长文本沿 flex 链向上传染，把整个输入壳撑宽；
+     置 0 后按钮严格遵循 width:100%，长文本走下面的 ellipsis 路径。 */
+  min-width: 0;
+  max-width: 100%;
   padding: 6px 10px;
   border-radius: 10px;
   border: 1px solid rgba(127, 144, 170, 0.22);
@@ -1722,6 +1728,9 @@ svg {
 
 .composer-galgame-option-text {
   flex: 1 1 auto;
+  /* min-width: 0 是 ellipsis 在 flex row 里真正生效的前置条件，
+     否则 flex item 默认 min-width:auto = 内容固有宽度，永远不会被裁。 */
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Set explicit minimum widths for the composer panel and related components to prevent layout issues caused by overflowing text. This change ensures that the components can shrink appropriately without being constrained by their content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复了作曲器/编辑器在窄屏或紧凑布局下被长文本选项撑宽的问题，界面可正确收缩。
  * 长选项文本在空间不足时会以省略号显示，避免破坏父容器布局。
  * 优化后各项在弹性/栅格布局中能正确收缩并保持预期的溢出行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->