### PR TITLE
fix(galgame): 默认难度后端钉到 lv2 与前端对齐

### DIFF
--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -725,7 +725,7 @@ def _default_soccer_pregame_context(*, initial_difficulty: str | None = None) ->
         "initialDifficulty": difficulty,
         "openingLine": "",
         "tonePolicy": "普通陪玩，轻松自然，不强行解释成哄开心或关系修复。",
-        "difficultyPolicy": "普通陪玩默认随机中等难度；后续由局内互动和游戏 AI 自然调整。",
+        "difficultyPolicy": "普通陪玩默认中等难度；后续由局内互动和游戏 AI 自然调整。",
         "moodPolicy": "沿用普通陪玩表现；不引入强情绪惯性。",
         "softeningSignals": [],
         "hardeningSignals": [],

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -349,7 +349,9 @@ def _strip_json_fence(text: str) -> str:
 
 
 def _soccer_random_default_difficulty() -> str:
-    return str(random.choice(_SOCCER_DEFAULT_DIFFICULTIES))
+    # 默认锁 lv2 与前端 DEFAULT_DIFFICULTY_INDEX / prompts_game initialDifficulty 对齐；
+    # lv3 仍是 _SOCCER_DEFAULT_DIFFICULTIES 合法值，允许 upstream 显式 soften 一档。
+    return "lv2"
 
 
 def _normalize_short_text(value: Any, *, max_chars: int = 120) -> str:

--- a/tests/unit/test_game_router.py
+++ b/tests/unit/test_game_router.py
@@ -51,9 +51,7 @@ def test_soccer_prompt_marks_game_event_text_as_not_user_speech():
 
 
 @pytest.mark.unit
-def test_neutral_pregame_context_uses_lv2_lv3_default(monkeypatch):
-    monkeypatch.setattr(game_router.random, "choice", lambda seq: "lv3")
-
+def test_neutral_pregame_context_falls_back_to_lv2_default():
     context, invalid = game_router._normalize_soccer_pregame_context({
         "gameStance": "neutral_play",
         "initialDifficulty": "max",
@@ -62,13 +60,11 @@ def test_neutral_pregame_context_uses_lv2_lv3_default(monkeypatch):
 
     assert invalid is True
     assert context["gameStance"] == "neutral_play"
-    assert context["initialDifficulty"] == "lv3"
+    assert context["initialDifficulty"] == "lv2"
 
 
 @pytest.mark.unit
-def test_special_pregame_context_can_keep_max_difficulty(monkeypatch):
-    monkeypatch.setattr(game_router.random, "choice", lambda seq: "lv2")
-
+def test_special_pregame_context_can_keep_max_difficulty():
     context, invalid = game_router._normalize_soccer_pregame_context({
         "gameStance": "punishing",
         "initialDifficulty": "max",
@@ -329,7 +325,6 @@ async def test_build_pregame_context_uses_empty_history_fallback(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_pregame_context_invalid_json_falls_back(monkeypatch):
-    monkeypatch.setattr(game_router.random, "choice", lambda seq: "lv3")
     monkeypatch.setattr(game_router, "_get_current_character_info", lambda: {
         "lanlan_name": "Lan",
         "master_name": "玩家",
@@ -360,13 +355,12 @@ async def test_build_pregame_context_invalid_json_falls_back(monkeypatch):
     assert source == "fallback"
     assert error == "invalid_json"
     assert context["gameStance"] == "neutral_play"
-    assert context["initialDifficulty"] == "lv3"
+    assert context["initialDifficulty"] == "lv2"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_pregame_context_partial_invalid_fields(monkeypatch):
-    monkeypatch.setattr(game_router.random, "choice", lambda seq: "lv2")
     monkeypatch.setattr(game_router, "_get_current_character_info", lambda: {
         "lanlan_name": "Lan",
         "master_name": "玩家",


### PR DESCRIPTION
## Summary
- 之前 `_soccer_random_default_difficulty` 在 `("lv2", "lv3")` 之间 50/50 random，让 neutral_play 兜底有一半概率给 lv3，与前端 [`DEFAULT_DIFFICULTY_INDEX`](templates/soccer_demo.html) (硬编码 lv2)、`prompts_game.py` 默认 lv2、以及 commit 116e66d13 message 声明的"默认难度钉到 lv2"全部不一致。
- 简化为直接 `return "lv2"`。`lv3` 仍是 `_SOCCER_DEFAULT_DIFFICULTIES` 合法值，upstream（LLM-judge 出来的 pre_game_context）显式给 lv3 仍能保留 — `test_route_start_accepts_neko_invite_context` 覆盖此路径。
- 顺手清掉两处 `monkeypatch.setattr(game_router.random, "choice", ...)`：函数已不再走 `random.choice`，原 mock 是死代码。

## 不在本 PR 范围
- 之前一起 triage 出"语音 fast path 主动搭话漏 gate"是 false positive：`is_game_route_active(...)` 检查在 `/api/proactive_chat` 函数入口（`main_routers/system_router.py:4104`），voice/text 两条路径在它之后才分叉，已经覆盖。所以这次只修难度。

## Test plan
- [x] `uv run pytest tests/unit/test_game_router.py` — 72 passed
- [x] `uv run pytest tests/unit/test_game_router_concurrency.py` — 29 passed
- [x] `test_route_start_accepts_neko_invite_context` (lv3 显式 override 路径) 仍 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 修正了足球模式默认难度，改为始终使用一致的中等难度（LV2），不再随机选择。
* **测试**
  * 更新并调整了单元测试以反映默认难度的确定性行为，确保中立预赛配置回退到 LV2。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->