### PR TITLE
refactor: 后端禁用 tkinter + lint 守门 GUI-on-frontend 架构

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -59,6 +59,20 @@ jobs:
         # plugin/main parity. This check fails the build on any such import.
         run: python scripts/check_no_loguru.py
 
+      - name: Forbid `tkinter` imports
+        # Architecture rule: frontend/backend are split, ALL GUI operations
+        # belong on the Electron frontend (Node.js renderer/main), not the
+        # Python backend. The backend is a headless HTTP/async service —
+        # it must stay relocatable (remote deployment, headless CI) and
+        # not own a Tcl/Tk event loop. Past incident: PR #1014's Windows
+        # tk screenshot overlay crashed the whole app under Nuitka builds
+        # without `--enable-plugin=tk-inter` (SystemExit from tk.Tk()
+        # escaped the asyncio worker, killed uvicorn). For dialogs use
+        # Electron's `dialog` (or platform-native shell bridges in
+        # storage_location_router.py); for screenshot framing use
+        # Electron's desktopCapturer region path.
+        run: python scripts/check_no_tkinter.py
+
       - name: Forbid `temperature=` kwargs on LLM client calls (memory + utils)
         # Project policy: do NOT pass `temperature=` to create_chat_llm /
         # ChatOpenAI / wrappers in memory_server.py + memory/ + utils/. The

--- a/main_routers/storage_location_router.py
+++ b/main_routers/storage_location_router.py
@@ -677,66 +677,17 @@ def _pick_directory_via_linux_dialog(*, start_path: str) -> str:
     )
 
 
-def _pick_directory_via_tkinter(*, start_path: str) -> str:
-    try:
-        import tkinter as tk
-        from tkinter import filedialog
-    except Exception as exc:
-        raise _DirectoryPickerUnavailable(
-            "directory_picker_unavailable",
-            "当前环境暂不支持系统目录选择，请手动输入路径。",
-        ) from exc
-
-    root = None
-    try:
-        root = tk.Tk()
-        root.withdraw()
-        try:
-            root.attributes("-topmost", True)
-            root.lift()
-            root.focus_force()
-        except Exception:
-            pass
-        root.update_idletasks()
-        selected_root = filedialog.askdirectory(
-            parent=root,
-            initialdir=start_path or None,
-            title="请选择存储位置目录",
-            mustexist=False,
-        )
-    except Exception as exc:
-        raise _DirectoryPickerUnavailable(
-            "directory_picker_failed",
-            f"打开系统目录选择器失败: {exc}",
-        ) from exc
-    finally:
-        if root is not None:
-            try:
-                root.destroy()
-            except Exception:
-                pass
-
-    if not selected_root:
-        raise _DirectoryPickerCancelled()
-    return str(selected_root)
-
-
 def _pick_storage_location_directory(*, start_path: str) -> str:
+    # 项目策略：不带 Tk/Tcl。每个平台只信任其原生桥（osascript / PowerShell /
+    # zenity-kdialog-yad），原生桥失败就直接 _DirectoryPickerUnavailable，让前端
+    # 提示用户手填路径——而不是落到 tkinter 兜底（Nuitka 不带 tk-inter 时
+    # tk.Tk() 抛 SystemExit 拖死后端）。检查由 scripts/check_no_tkinter.py 守门。
     normalized_start_path = _normalize_directory_picker_start_path(start_path)
     if sys.platform == "darwin":
-        try:
-            return _pick_directory_via_osascript(start_path=normalized_start_path)
-        except _DirectoryPickerUnavailable:
-            return _pick_directory_via_tkinter(start_path=normalized_start_path)
+        return _pick_directory_via_osascript(start_path=normalized_start_path)
     if sys.platform == "win32":
-        try:
-            return _pick_directory_via_powershell(start_path=normalized_start_path)
-        except _DirectoryPickerUnavailable:
-            return _pick_directory_via_tkinter(start_path=normalized_start_path)
-    try:
-        return _pick_directory_via_linux_dialog(start_path=normalized_start_path)
-    except _DirectoryPickerUnavailable:
-        return _pick_directory_via_tkinter(start_path=normalized_start_path)
+        return _pick_directory_via_powershell(start_path=normalized_start_path)
+    return _pick_directory_via_linux_dialog(start_path=normalized_start_path)
 
 
 def _open_path_in_file_manager(path: Path | str) -> None:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -222,242 +222,6 @@ def _run_macos_interactive_screenshot(output_path: str) -> tuple[int, str]:
     return completed.returncode, (completed.stderr or "").strip()
 
 
-def _set_windows_process_dpi_awareness() -> None:
-    try:
-        ctypes = __import__("ctypes")
-        try:
-            ctypes.windll.shcore.SetProcessDpiAwareness(2)
-            return
-        except Exception:
-            pass
-        try:
-            ctypes.windll.user32.SetProcessDPIAware()
-        except Exception:
-            pass
-    except Exception:
-        pass
-
-
-def _get_windows_virtual_screen_geometry() -> tuple[int, int, int, int]:
-    ctypes = __import__("ctypes")
-    user32 = ctypes.windll.user32
-    sm_xvirtualscreen = 76
-    sm_yvirtualscreen = 77
-    sm_cxvirtualscreen = 78
-    sm_cyvirtualscreen = 79
-
-    left = int(user32.GetSystemMetrics(sm_xvirtualscreen))
-    top = int(user32.GetSystemMetrics(sm_yvirtualscreen))
-    width = int(user32.GetSystemMetrics(sm_cxvirtualscreen))
-    height = int(user32.GetSystemMetrics(sm_cyvirtualscreen))
-
-    if width <= 0 or height <= 0:
-        raise RuntimeError("virtual screen metrics unavailable")
-    return left, top, width, height
-
-
-def _run_windows_interactive_screenshot(output_path: str) -> tuple[int, str]:
-    try:
-        import tkinter as tk
-        from PIL import ImageGrab
-    except Exception as exc:
-        raise RuntimeError(f"Windows interactive screenshot dependencies unavailable: {exc}") from exc
-
-    _set_windows_process_dpi_awareness()
-    screen_left, screen_top, screen_width, screen_height = _get_windows_virtual_screen_geometry()
-
-    result: dict[str, Any] = {
-        "bbox": None,
-        "canceled": True,
-        "error": "",
-    }
-
-    root = None
-    try:
-        root = tk.Tk()
-        root.overrideredirect(True)
-        root.attributes("-topmost", True)
-        try:
-            root.attributes("-alpha", 0.22)
-        except Exception:
-            pass
-        try:
-            root.configure(bg="black")
-        except Exception:
-            pass
-        root.geometry(f"{screen_width}x{screen_height}{screen_left:+d}{screen_top:+d}")
-        root.lift()
-        root.focus_force()
-
-        canvas = tk.Canvas(root, cursor="crosshair", highlightthickness=0, bd=0, bg="black")
-        canvas.pack(fill="both", expand=True)
-
-        state = {
-            "start_x": 0,
-            "start_y": 0,
-            "current_x": 0,
-            "current_y": 0,
-            "dragging": False,
-            "rect_id": None,
-            "cross_v_id": None,
-            "cross_h_id": None,
-        }
-
-        def _screen_point(event: Any) -> tuple[int, int]:
-            x = int(screen_left + canvas.canvasx(event.x))
-            y = int(screen_top + canvas.canvasy(event.y))
-            return x, y
-
-        def _clear_guides() -> None:
-            for key in ("rect_id", "cross_v_id", "cross_h_id"):
-                item_id = state.get(key)
-                if item_id:
-                    try:
-                        canvas.delete(item_id)
-                    except Exception:
-                        pass
-                    state[key] = None
-
-        def _draw_guides() -> None:
-            local_x1 = state["start_x"] - screen_left
-            local_y1 = state["start_y"] - screen_top
-            local_x2 = state["current_x"] - screen_left
-            local_y2 = state["current_y"] - screen_top
-
-            x1, x2 = sorted((int(local_x1), int(local_x2)))
-            y1, y2 = sorted((int(local_y1), int(local_y2)))
-
-            if state["cross_v_id"]:
-                canvas.coords(state["cross_v_id"], local_x2, 0, local_x2, screen_height)
-            else:
-                state["cross_v_id"] = canvas.create_line(
-                    local_x2, 0, local_x2, screen_height,
-                    fill="#ffffff",
-                    dash=(4, 4),
-                    width=1,
-                )
-
-            if state["cross_h_id"]:
-                canvas.coords(state["cross_h_id"], 0, local_y2, screen_width, local_y2)
-            else:
-                state["cross_h_id"] = canvas.create_line(
-                    0, local_y2, screen_width, local_y2,
-                    fill="#ffffff",
-                    dash=(4, 4),
-                    width=1,
-                )
-
-            if state["dragging"]:
-                if state["rect_id"]:
-                    canvas.coords(state["rect_id"], x1, y1, x2, y2)
-                else:
-                    state["rect_id"] = canvas.create_rectangle(
-                        x1, y1, x2, y2,
-                        outline="#4cc2ff",
-                        width=2,
-                        fill="#ffffff",
-                        stipple="gray25",
-                    )
-
-        def _on_press(event: Any) -> None:
-            x, y = _screen_point(event)
-            state["start_x"] = x
-            state["start_y"] = y
-            state["current_x"] = x
-            state["current_y"] = y
-            state["dragging"] = True
-            _draw_guides()
-
-        def _on_drag(event: Any) -> None:
-            x, y = _screen_point(event)
-            state["current_x"] = max(screen_left, min(screen_left + screen_width, x))
-            state["current_y"] = max(screen_top, min(screen_top + screen_height, y))
-            _draw_guides()
-
-        def _finish_selection() -> None:
-            left = max(screen_left, min(state["start_x"], state["current_x"]))
-            top = max(screen_top, min(state["start_y"], state["current_y"]))
-            right = min(screen_left + screen_width, max(state["start_x"], state["current_x"]))
-            bottom = min(screen_top + screen_height, max(state["start_y"], state["current_y"]))
-
-            if (right - left) < 4 or (bottom - top) < 4:
-                result["bbox"] = None
-                result["canceled"] = True
-            else:
-                result["bbox"] = (left, top, right, bottom)
-                result["canceled"] = False
-
-            try:
-                root.quit()
-            except Exception:
-                pass
-
-        def _on_release(event: Any) -> None:
-            if not state["dragging"]:
-                return
-            _on_drag(event)
-            state["dragging"] = False
-            _finish_selection()
-
-        def _on_cancel(_event: Any = None) -> None:
-            result["bbox"] = None
-            result["canceled"] = True
-            try:
-                root.quit()
-            except Exception:
-                pass
-
-        def _on_motion(event: Any) -> None:
-            if state["dragging"]:
-                return
-            x, y = _screen_point(event)
-            state["current_x"] = x
-            state["current_y"] = y
-            _draw_guides()
-
-        canvas.bind("<ButtonPress-1>", _on_press)
-        canvas.bind("<B1-Motion>", _on_drag)
-        canvas.bind("<ButtonRelease-1>", _on_release)
-        canvas.bind("<Motion>", _on_motion)
-        root.bind("<Escape>", _on_cancel)
-        root.bind("<Button-3>", _on_cancel)
-        root.bind("<FocusOut>", lambda _event: root.after(10, root.lift))
-
-        root.update_idletasks()
-        root.mainloop()
-
-        bbox = result.get("bbox")
-        if result.get("canceled") or not bbox:
-            return 1, ""
-
-        root.withdraw()
-        root.update_idletasks()
-        time.sleep(0.12)
-
-        full_image = ImageGrab.grab(all_screens=True)
-        crop_box = (
-            int(bbox[0] - screen_left),
-            int(bbox[1] - screen_top),
-            int(bbox[2] - screen_left),
-            int(bbox[3] - screen_top),
-        )
-        cropped = full_image.crop(crop_box)
-        cropped.save(output_path, format="PNG")
-        return 0, ""
-    except Exception as exc:
-        return 2, str(exc)
-    finally:
-        if root is not None:
-            try:
-                _clear_guides()
-            except Exception:
-                pass
-            try:
-                root.destroy()
-            except Exception:
-                pass
-
-
 def _image_path_to_jpeg_data_url(image_path: str) -> tuple[str, int]:
     with Image.open(image_path) as shot:
         if shot.mode in ("RGBA", "LA", "P"):
@@ -3980,11 +3744,11 @@ async def backend_interactive_screenshot(request: Request):
 
     if sys.platform == "darwin":
         runner = _run_macos_interactive_screenshot
-    elif sys.platform == "win32":
-        runner = _run_windows_interactive_screenshot
     else:
+        # Windows / Linux 没有可靠的"系统级框选 + 回传"原语，统一交给前端 Electron
+        # 的 desktopCapturer 区域选择路径处理；这里直接 501 让 caller 走兜底链。
         return _json_no_store_response(
-            {"success": False, "error": "interactive screenshot is only supported on macOS and Windows"},
+            {"success": False, "error": "interactive screenshot is only supported on macOS"},
             status_code=501,
         )
 
@@ -4026,6 +3790,15 @@ async def backend_interactive_screenshot(request: Request):
     except FileNotFoundError as e:
         logger.warning("系统原生交互截图不可用: %s", e)
         return _json_no_store_response({"success": False, "error": str(e)}, status_code=501)
+    except SystemExit as e:
+        # Nuitka 等场景下，缺失某些可选依赖会用 SystemExit 当 sentinel 抛出（继承 BaseException
+        # 而非 Exception）。如果不在这里截住，会逃出 asyncio worker thread → 拖死整个后端
+        # 进程，连带 Electron shell 一起崩。这里转成普通 500，让前端能继续走兜底链。
+        logger.error("系统原生交互截图 runner 抛 SystemExit: %s", e)
+        return _json_no_store_response(
+            {"success": False, "error": f"interactive screenshot runner aborted: {e}"},
+            status_code=500,
+        )
     except Exception as e:
         logger.error(f"系统原生交互截图失败: {e}")
         return _json_no_store_response({"success": False, "error": str(e)}, status_code=500)

--- a/scripts/check_no_tkinter.py
+++ b/scripts/check_no_tkinter.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Static check: forbid `tkinter` (and submodules) anywhere in the repo.
+
+Why this exists — architecture rule
+-----------------------------------
+**This codebase is split frontend / backend, and all GUI operations
+belong on the frontend.** The Python side (FastAPI + uvicorn + asyncio)
+is a headless service: it serves HTTP, talks to LLMs, manages state,
+runs background workers. It does NOT open windows, render dialogs, or
+own a Tcl/Tk event loop. Anything the user clicks, drags, or sees lives
+in the Electron main/renderer process (Node.js / Chromium) — directory
+pickers via Electron's `dialog.showOpenDialog`, screenshot framing via
+`desktopCapturer` + a renderer-side overlay, app chrome via the
+existing HTML/React UI.
+
+`tkinter` is the canonical violation of that split. Every time someone
+reaches for it, they're putting a UI widget toolkit into the backend,
+which:
+
+1. Wires a Tcl/Tk event loop into a process that is supposed to be
+   request-driven and async. The two loops fight; you end up with
+   threading hacks, focus glitches, "why is my window behind
+   everything", and `mainloop()` calls inside FastAPI handlers.
+2. Couples backend behaviour to the user's local display server. The
+   backend stops being relocatable — it can't run remotely (envisioned
+   by `NEKO_ACTIVITY_TRACKER_REMOTE`), can't run headless under
+   Docker/CI without a virtual framebuffer, and can't be exercised by
+   ordinary HTTP integration tests.
+3. Drags Tcl/Tk into the packaged dist (tens of MB of runtime + DLLs).
+4. Crashes the WHOLE app under Nuitka. Concrete past incident: PR
+   #1014's Windows `_run_windows_interactive_screenshot` opened a
+   tk overlay for screenshot region selection. Nuitka builds without
+   ``--enable-plugin=tk-inter`` (the default) make ``tkinter.__init__``
+   raise ``SystemExit("Nuitka: Need to use '--enable-plugin=tk-inter'
+   option…")`` on the first ``tk.Tk()`` call. ``SystemExit`` inherits
+   from ``BaseException`` not ``Exception``, so the request handler's
+   ``try/except Exception`` doesn't contain it — it escaped the asyncio
+   worker thread, killed uvicorn, and Electron tore down with its dead
+   Python child. End-user symptom: press the screenshot button, the
+   entire app closes.
+
+The fix is not "wrap it in `except BaseException`". The fix is "the
+backend should never have been opening a window in the first place".
+That's what this lint enforces.
+
+What goes where (rule of thumb)
+-------------------------------
+* **Directory / file pickers** → Electron's `dialog` module (renderer
+  → main IPC). For non-Electron contexts (raw `index.html` in browser,
+  CLI scripts) fall back to the platform-native bridges already in
+  `main_routers/storage_location_router.py`: PowerShell on Windows,
+  osascript on macOS, zenity/kdialog/yad on Linux. None of those open
+  Tk; they shell out to the OS dialog. If the native bridge fails,
+  surface `_DirectoryPickerUnavailable` to the frontend and let the
+  user type the path manually — do NOT add a "tk fallback".
+* **Screenshot region selection** → Electron's `desktopCapturer` plus a
+  transparent BrowserWindow overlay in the renderer. Code path is
+  already in `static/app-buttons.js::captureDesktopRegionDirectly`.
+* **Status notifications, error dialogs, confirmation modals** →
+  existing React/HTML UI in the renderer. The backend reports state via
+  HTTP/WebSocket; the frontend renders it.
+* **Anything else GUI** → frontend.
+
+What it flags
+-------------
+Any of the following at module scope, function scope, or inside ``if``
+/ ``try`` blocks (the AST walker descends everywhere):
+
+    import tkinter
+    import tkinter.filedialog
+    import tkinter as tk
+    from tkinter import filedialog
+    from tkinter.ttk import Frame
+    from tkinter import Tk as Root
+
+Comments, docstrings, and string literals mentioning the name are NOT
+flagged — only real ``import`` statements. That keeps kill-warning
+comments ("don't add tkinter back") legal.
+
+Suppression
+-----------
+None. The architecture rule is the whole point — a per-line escape
+hatch would let "just this once" creep back in. If you genuinely need
+tkinter (you almost certainly don't), delete this script in the same
+PR and justify in the description why this particular GUI operation
+must live in the Python process instead of the Electron renderer.
+
+Output
+------
+Every violation prints as ``path:line:col  NO_TKINTER  message``. Exit
+status is 1 when any violation is found, 0 otherwise.
+
+Usage:
+    python scripts/check_no_tkinter.py [paths...]
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_PATHS: list[str] = ["."]
+
+EXCLUDE_DIRS = {
+    ".venv",
+    "venv",
+    "frontend",
+    "dist",
+    "build",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    ".tox",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "plugin/plugins",  # third-party plugin payloads, not our code
+}
+
+EXCLUDE_FILES = {
+    "scripts/check_no_tkinter.py",
+}
+
+CODE = "NO_TKINTER"
+
+BANNED_PACKAGES = {
+    "tkinter",
+}
+
+
+def _is_banned(module_name: str | None) -> str | None:
+    if not module_name:
+        return None
+    head = module_name.split(".", 1)[0]
+    if head in BANNED_PACKAGES:
+        return head
+    return None
+
+
+class TkinterImportChecker(ast.NodeVisitor):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.violations: list[tuple[int, int, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            banned = _is_banned(alias.name)
+            if banned is not None:
+                self.violations.append(
+                    (
+                        node.lineno,
+                        node.col_offset + 1,
+                        f"`import {alias.name}` is forbidden — GUI operations belong "
+                        f"on the Electron frontend (Node.js renderer/main), not the "
+                        f"Python backend. The backend is a headless HTTP/async "
+                        f"service; opening Tk windows from it breaks the "
+                        f"frontend/backend split, blocks remote/headless "
+                        f"deployment, and crashes Nuitka builds. See module "
+                        f"docstring for what to use instead.",
+                    )
+                )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        banned = _is_banned(node.module)
+        if banned is not None:
+            names = ", ".join(a.name for a in node.names) or "*"
+            self.violations.append(
+                (
+                    node.lineno,
+                    node.col_offset + 1,
+                    f"`from {node.module} import {names}` is forbidden — GUI "
+                    f"operations belong on the Electron frontend (Node.js "
+                    f"renderer/main), not the Python backend. The backend is a "
+                    f"headless HTTP/async service; opening Tk windows from it "
+                    f"breaks the frontend/backend split, blocks remote/headless "
+                    f"deployment, and crashes Nuitka builds. See module docstring "
+                    f"for what to use instead.",
+                )
+            )
+
+
+def _is_excluded(path: Path) -> bool:
+    parts = set(path.parts)
+    if parts & EXCLUDE_DIRS:
+        return True
+    try:
+        rel = path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in EXCLUDE_FILES:
+        return True
+    for ex in EXCLUDE_DIRS:
+        if "/" in ex and (rel == ex or rel.startswith(ex + "/")):
+            return True
+    return False
+
+
+def _iter_python_files(paths: Iterable[Path]) -> Iterator[Path]:
+    for p in paths:
+        if p.is_file():
+            if p.suffix == ".py" and not _is_excluded(p):
+                yield p
+        elif p.is_dir():
+            for f in sorted(p.rglob("*.py")):
+                if not _is_excluded(f):
+                    yield f
+
+
+def _parse_file(path: Path) -> ast.Module | None:
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"{path}: skipped — {e}", file=sys.stderr)
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        print(f"{path}:{e.lineno}: syntax error — {e.msg}", file=sys.stderr)
+        return None
+
+
+def check_file(path: Path, tree: ast.Module) -> list[tuple[int, int, str]]:
+    checker = TkinterImportChecker(path)
+    checker.visit(tree)
+    return checker.violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Forbid `tkinter` imports anywhere in the repo."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files/directories to scan (default: entire repo, minus EXCLUDE_DIRS).",
+    )
+    args = parser.parse_args(argv)
+
+    raw_paths = args.paths or DEFAULT_PATHS
+    targets = [Path(p) if Path(p).is_absolute() else REPO_ROOT / p for p in raw_paths]
+
+    total = 0
+    for file in _iter_python_files(targets):
+        tree = _parse_file(file)
+        if tree is None:
+            continue
+        for lineno, col, msg in check_file(file, tree):
+            rel = file.relative_to(REPO_ROOT) if file.is_relative_to(REPO_ROOT) else file
+            print(f"{rel}:{lineno}:{col}  {CODE}  {msg}")
+            total += 1
+
+    if total:
+        print(
+            f"\n{total} forbidden-import violation(s) found.\n"
+            "Architecture rule: this codebase splits frontend/backend, and ALL GUI "
+            "operations belong on the Electron frontend (Node.js renderer/main), "
+            "not the Python backend. The backend is a headless service — it serves "
+            "HTTP, talks to LLMs, manages state. It does not own a Tcl/Tk event "
+            "loop, does not open windows, and must remain relocatable (remote "
+            "deployment, headless CI). Reach for Electron's `dialog` / "
+            "`desktopCapturer` / a renderer-side React modal instead; if Electron "
+            "isn't available in the context (raw browser, CLI script), use the "
+            "platform-native shell bridges in storage_location_router.py "
+            "(PowerShell / osascript / zenity-kdialog-yad) and surface "
+            "`_DirectoryPickerUnavailable` on failure rather than falling back to "
+            "Tk. Past incident proving this matters: PR #1014's Windows tk "
+            "screenshot overlay crashed the whole app under Nuitka builds without "
+            "`--enable-plugin=tk-inter` (SystemExit escaped the asyncio worker and "
+            "killed uvicorn). If you genuinely need tkinter, delete this script in "
+            "the same PR and explain why this particular GUI operation must live "
+            "in the Python process instead of the renderer.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_storage_location_router.py
+++ b/tests/unit/test_storage_location_router.py
@@ -963,19 +963,17 @@ def test_storage_location_pick_directory_reports_cancelled_selection(tmp_path):
 
 
 @pytest.mark.unit
-def test_storage_location_pick_directory_uses_windows_native_picker_first(tmp_path):
+def test_storage_location_pick_directory_uses_windows_native_picker(tmp_path):
     with patch.object(storage_location_router_module.sys, "platform", "win32"):
         with patch.object(
             storage_location_router_module,
             "_pick_directory_via_powershell",
             return_value=str((tmp_path / "picked-win").resolve()),
         ) as powershell_picker:
-            with patch.object(storage_location_router_module, "_pick_directory_via_tkinter") as tkinter_picker:
-                selected_root = storage_location_router_module._pick_storage_location_directory(start_path=str(tmp_path))
+            selected_root = storage_location_router_module._pick_storage_location_directory(start_path=str(tmp_path))
 
     assert selected_root == str((tmp_path / "picked-win").resolve())
     powershell_picker.assert_called_once()
-    tkinter_picker.assert_not_called()
 
 
 @pytest.mark.unit
@@ -1016,7 +1014,8 @@ def test_windows_powershell_directory_picker_uses_topmost_owner(tmp_path):
 
 
 @pytest.mark.unit
-def test_storage_location_pick_directory_falls_back_to_tkinter_when_linux_native_dialog_unavailable(tmp_path):
+def test_storage_location_pick_directory_propagates_native_unavailable_on_linux(tmp_path):
+    """Linux native dialog 不可用时直接 raise，不再有 tkinter 兜底（项目策略：不带 tk）。"""
     with patch.object(storage_location_router_module.sys, "platform", "linux"):
         with patch.object(
             storage_location_router_module,
@@ -1026,16 +1025,10 @@ def test_storage_location_pick_directory_falls_back_to_tkinter_when_linux_native
                 "native picker unavailable",
             ),
         ) as linux_picker:
-            with patch.object(
-                storage_location_router_module,
-                "_pick_directory_via_tkinter",
-                return_value=str((tmp_path / "picked-linux").resolve()),
-            ) as tkinter_picker:
-                selected_root = storage_location_router_module._pick_storage_location_directory(start_path=str(tmp_path))
+            with pytest.raises(storage_location_router_module._DirectoryPickerUnavailable):
+                storage_location_router_module._pick_storage_location_directory(start_path=str(tmp_path))
 
-    assert selected_root == str((tmp_path / "picked-linux").resolve())
     linux_picker.assert_called_once()
-    tkinter_picker.assert_called_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_system_screenshot_router.py
+++ b/tests/unit/test_system_screenshot_router.py
@@ -250,15 +250,17 @@ def test_interactive_screenshot_passes_with_valid_csrf_and_origin(monkeypatch):
 
 
 @pytest.mark.unit
-def test_interactive_screenshot_returns_unsupported_on_non_macos(monkeypatch):
+@pytest.mark.parametrize("platform_name", ["linux", "win32"])
+def test_interactive_screenshot_returns_unsupported_on_non_macos(monkeypatch, platform_name):
+    """Win32 / Linux 不再有 backend interactive 路径，统一 501 让前端走 Electron 兜底。"""
     monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
-    monkeypatch.setattr(system_router_module.sys, "platform", "linux")
+    monkeypatch.setattr(system_router_module.sys, "platform", platform_name)
 
     with _build_client() as client:
         response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
 
     assert response.status_code == 501
-    assert "only supported on macOS and Windows" in response.json()["error"]
+    assert "only supported on macOS" in response.json()["error"]
 
 
 @pytest.mark.unit
@@ -302,10 +304,10 @@ def test_interactive_screenshot_treats_macos_cancel_with_stderr_as_canceled(monk
 @pytest.mark.unit
 def test_interactive_screenshot_returns_failure_for_runtime_errors(monkeypatch):
     monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
-    monkeypatch.setattr(system_router_module.sys, "platform", "win32")
+    monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
     monkeypatch.setattr(
         system_router_module,
-        "_run_windows_interactive_screenshot",
+        "_run_macos_interactive_screenshot",
         lambda _path: (2, "boom"),
     )
 
@@ -317,6 +319,31 @@ def test_interactive_screenshot_returns_failure_for_runtime_errors(monkeypatch):
     assert payload["success"] is False
     assert payload["canceled"] is False
     assert payload["error"] == "boom"
+
+
+@pytest.mark.unit
+def test_interactive_screenshot_swallows_systemexit_from_runner(monkeypatch):
+    """Nuitka 等场景下 runner 抛 SystemExit（如缺 tk-inter 插件）必须被截住转 500，
+    否则会逃出 asyncio worker thread 拖死后端进程。"""
+    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
+    monkeypatch.setattr(system_router_module.sys, "platform", "darwin")
+
+    def _runner_raises_systemexit(_path):
+        raise SystemExit("Nuitka: Need to use '--enable-plugin=tk-inter'")
+
+    monkeypatch.setattr(
+        system_router_module,
+        "_run_macos_interactive_screenshot",
+        _runner_raises_systemexit,
+    )
+
+    with _build_client() as client:
+        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["success"] is False
+    assert "aborted" in payload["error"].lower()
 
 
 @pytest.mark.unit
@@ -346,46 +373,3 @@ def test_interactive_screenshot_returns_cropped_image_data(monkeypatch):
     assert response.headers["Cache-Control"] == "no-store, no-cache, must-revalidate, max-age=0"
 
 
-@pytest.mark.unit
-def test_interactive_screenshot_returns_canceled_when_windows_user_aborts(monkeypatch):
-    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
-    monkeypatch.setattr(system_router_module.sys, "platform", "win32")
-    monkeypatch.setattr(
-        system_router_module,
-        "_run_windows_interactive_screenshot",
-        lambda _path: (1, ""),
-    )
-
-    with _build_client() as client:
-        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
-
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["success"] is False
-    assert payload["canceled"] is True
-
-
-@pytest.mark.unit
-def test_interactive_screenshot_returns_windows_cropped_image_data(monkeypatch):
-    monkeypatch.setattr(system_router_module, "_is_loopback_request", lambda _request: True)
-    monkeypatch.setattr(system_router_module.sys, "platform", "win32")
-
-    def _fake_run(output_path: str):
-        Image.new("RGB", (90, 60), (220, 120, 40)).save(output_path, format="PNG")
-        return 0, ""
-
-    monkeypatch.setattr(
-        system_router_module,
-        "_run_windows_interactive_screenshot",
-        _fake_run,
-    )
-
-    with _build_client() as client:
-        response = client.post(INTERACTIVE_SCREENSHOT_ENDPOINT, headers=_local_headers())
-
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["success"] is True
-    assert payload["interactive"] is True
-    assert payload["size"] > 0
-    assert payload["data"].startswith("data:image/jpeg;base64,")


### PR DESCRIPTION
## 架构规则

前后端分离，**所有 GUI 操作都由 Electron 前端（Node.js renderer/main）做**，不在 Python 后端做。Python 端是 headless HTTP/async 服务，不持 Tcl/Tk event loop、不开窗、不弹对话框；任何用户能看见 / 点 / 拖的东西都属于 renderer。

`tkinter` 是这条规则最常见的违例，本次全面禁用并加 CI lint 守门，防止再 creep 回来。

## 触发事故

某 Nuitka 打包产物按一次截图键就把整个 app 关掉。日志显示 ``SystemExit: Nuitka: Need to use '--enable-plugin=tk-inter' option during compilation for tk-inter to work!`` 来自 [main_routers/system_router.py](main_routers/system_router.py) 的 `_run_windows_interactive_screenshot`（PR #1014 引入的 Windows tk 截图选区 overlay）。

链路：截图按钮 → `app-buttons.js::captureScreenshotDataUrl` → 非移动端**第一优先级** `fetchBackendInteractiveScreenshot` → POST `/api/screenshot/interactive` → win32 → `tk.Tk()` 抛 `SystemExit`。

`SystemExit` 继承 `BaseException` 非 `Exception`，请求处理器的 `except Exception` 抓不住 → 穿透 `asyncio.to_thread` worker → 杀 uvicorn → Electron 跟着 shutdown。

## 变更

### 后端
- 删 [main_routers/system_router.py](main_routers/system_router.py) 中 `_run_windows_interactive_screenshot` 及两个 Windows DPI/虚拟屏几何 helper（共 -236 行）。win32 直接返回 501，前端 fallthrough 到 `captureDesktopRegionDirectly` 走 Electron `desktopCapturer` 区域选择路径。
- 同文件 `backend_interactive_screenshot` 加 `except SystemExit` 兜底——这是防御不是主修，主修是"后端本来就不该开窗"。
- 删 [main_routers/storage_location_router.py](main_routers/storage_location_router.py) 的 `_pick_directory_via_tkinter` fallback。原生桥（PowerShell / osascript / zenity-kdialog-yad）失败直接 raise `_DirectoryPickerUnavailable` 让前端提示手填，**不再**有 tk fallback。

### 前端
- 没动。`fetchBackendInteractiveScreenshot` 调用保留——macOS 还要用同一个 endpoint 走 `screencapture -i`。Windows 上后端 501 自然 fallthrough。

### Lint
- [scripts/check_no_tkinter.py](scripts/check_no_tkinter.py)：AST 检查 ``import tkinter`` / ``from tkinter import ...``，违规 fail。Docstring 详述架构规则、各 GUI 操作的正确归属（Electron `dialog` / `desktopCapturer` / React modal）、以及本事故的来龙去脉。无 per-line escape hatch——白名单要连同删除该 lint，PR 描述里说理由。
- [.github/workflows/analyze.yml](.github/workflows/analyze.yml)：在 Analyze job 加一步跑该 lint。

### 测试
- 删除 / 重写依赖已删函数的测试，新增 `SystemExit` 兜底的单测。

## Test plan

- [x] `uv run pytest tests/unit/test_storage_location_router.py tests/unit/test_system_screenshot_router.py -q` → 80 passed
- [x] `uv run python scripts/check_no_tkinter.py` → 0 violations (clean repo)
- [x] 合成 `import tkinter` 文件喂给 lint → exit 1 + 报错指出违规位置
- [ ] macOS 实地点截图按钮验证 `screencapture -i` 仍可用（同 endpoint，没动）
- [ ] Windows 实地点截图按钮验证落到 Electron `captureDesktopRegionDirectly` 不再崩

## 后续 / 未做

- **没碰 Nuitka build 配置**。这次 PR 砍了所有调用方，但如果以后误把 `tkinter` 加回来，build 不会因为缺 `--enable-plugin=tk-inter` 而 fail。可以另开 PR 在 Nuitka 配置里加 `--noinclude-module=tkinter` 显式排除作为对称守门。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进目录选择器，现使用原生平台工具确保更好的兼容性和可靠性
  * 优化交互式截图错误处理，添加了异常中止的处理机制

* **New Features**
  * 交互式截图功能现明确标识为仅支持macOS平台

* **Chores**
  * 添加项目架构验证，确保后端代码符合技术规范

<!-- end of auto-generated comment: release notes by coderabbit.ai -->