### PR TITLE
[codex] fix common dialogs unit harness

### DIFF
--- a/tests/unit/test_common_dialogs.py
+++ b/tests/unit/test_common_dialogs.py
@@ -215,6 +215,26 @@ global.window = global;
 global.document = document;
 global.navigator = {{}};
 global.console = silentConsole;
+global.location = {{ origin: 'http://localhost' }};
+global._listeners = new Map();
+global.addEventListener = function (type, handler) {{
+  const handlers = this._listeners.get(type) || [];
+  handlers.push(handler);
+  this._listeners.set(type, handlers);
+}};
+global.removeEventListener = function (type, handler) {{
+  const handlers = this._listeners.get(type) || [];
+  const index = handlers.indexOf(handler);
+  if (index >= 0) {{
+    handlers.splice(index, 1);
+  }}
+}};
+global.dispatchEvent = function (event) {{
+  const handlers = this._listeners.get(event.type) || [];
+  for (const handler of [...handlers]) {{
+    handler.call(this, event);
+  }}
+}};
 global.Blob = class FakeBlob {{
   constructor(parts, options) {{
     this.parts = parts;


### PR DESCRIPTION
## Summary

- Update the Node-based `common_dialogs.js` unit-test harness to provide a minimal `window` event target API.
- Add a test `window.location.origin` so the new restore-window `message` listener can be registered under the fake browser environment.

## Root Cause

Latest `main` added a `window.addEventListener('message', ...)` listener in `static/common_dialogs.js`, but the unit harness only mocked `document.addEventListener`. Loading the script in Node failed before the dialog scenarios could run.

## Validation

- `uv run pytest -q tests/unit/test_common_dialogs.py tests/unit/test_no_hyphen_python_packages.py`
- `uv run pytest -q tests/unit`

`tests/unit` passed: `2036 passed, 14 skipped`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 改进了测试框架的浏览器环保境模拟，增强了事件处理机制的准确性，确保对话框和用户交互场景的测试更加可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->