### PR TITLE
refactor(onboarding): 通知/提示时序串行 — 让位初始人设 overlay

### DIFF
--- a/static/app-autostart-prompt.js
+++ b/static/app-autostart-prompt.js
@@ -488,21 +488,27 @@
             });
             if (data && data.should_prompt) {
                 try {
-                    // Gate: 等存档迁移/位置选择 + 初始人设走完再弹自启动提示，最多 15s 兜底防 hang。
-                    // 实际心跳间隔 15min，绝大多数情况下 onboarding 早已 settled，此处 await 立即过。
+                    // Gate: 等存档迁移/位置选择 + 初始人设走完再弹自启动提示。
+                    // 心跳间隔 15min，绝大多数情况下 onboarding 早已 settled，此处 await 立即过；
+                    // 拆分 race：超时只兜底"bootstrap 卡死"，overlay 显示中就无限等不超时。
                     const AUTOSTART_GATE_FALLBACK_MS = 15000;
-                    await Promise.race([
-                        (async () => {
-                            if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
-                                await window.waitForStorageLocationStartupBarrier();
+                    if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
+                        await window.waitForStorageLocationStartupBarrier();
+                    }
+                    const onboarding = window.CharacterPersonalityOnboarding;
+                    if (onboarding && typeof onboarding.whenSettled === 'function') {
+                        const settled = await Promise.race([
+                            onboarding.whenSettled().then(() => true),
+                            new Promise((resolve) => setTimeout(() => resolve(false), AUTOSTART_GATE_FALLBACK_MS)),
+                        ]);
+                        if (!settled) {
+                            const overlayActive = (onboarding.overlay && !onboarding.overlay.hidden)
+                                || onboarding.pendingResumeAfterTutorial;
+                            if (overlayActive) {
+                                await onboarding.whenSettled();
                             }
-                            if (window.CharacterPersonalityOnboarding
-                                && typeof window.CharacterPersonalityOnboarding.whenSettled === 'function') {
-                                await window.CharacterPersonalityOnboarding.whenSettled();
-                            }
-                        })(),
-                        new Promise((resolve) => setTimeout(resolve, AUTOSTART_GATE_FALLBACK_MS)),
-                    ]);
+                        }
+                    }
                     await maybeShowPrompt(data.prompt_token);
                 } catch (error) {
                     console.warn('[AutostartPrompt] prompt display failed:', error);

--- a/static/app-autostart-prompt.js
+++ b/static/app-autostart-prompt.js
@@ -488,6 +488,21 @@
             });
             if (data && data.should_prompt) {
                 try {
+                    // Gate: 等存档迁移/位置选择 + 初始人设走完再弹自启动提示，最多 15s 兜底防 hang。
+                    // 实际心跳间隔 15min，绝大多数情况下 onboarding 早已 settled，此处 await 立即过。
+                    const AUTOSTART_GATE_FALLBACK_MS = 15000;
+                    await Promise.race([
+                        (async () => {
+                            if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
+                                await window.waitForStorageLocationStartupBarrier();
+                            }
+                            if (window.CharacterPersonalityOnboarding
+                                && typeof window.CharacterPersonalityOnboarding.whenSettled === 'function') {
+                                await window.CharacterPersonalityOnboarding.whenSettled();
+                            }
+                        })(),
+                        new Promise((resolve) => setTimeout(resolve, AUTOSTART_GATE_FALLBACK_MS)),
+                    ]);
                     await maybeShowPrompt(data.prompt_token);
                 } catch (error) {
                     console.warn('[AutostartPrompt] prompt display failed:', error);

--- a/static/app.js
+++ b/static/app.js
@@ -278,28 +278,29 @@ window.addEventListener('load', async () => {
     }, 1000);
 
     // 拉取待弹重要通知 + 版本更新日志（chat 独立窗口跳过）
-    setTimeout(async () => {
+    // 同一个 modal 队列；按 changelog（背景）→ pending notices（行动召唤）顺序入队。
+    // 启动 gate：先等存档迁移/位置选择 + tutorial/初始人设走完，最多 15s 兜底防 hang。
+    (async () => {
         if (_isChatPage) return;
         if (typeof window.showProminentNotice !== 'function') return;
+
+        const NOTICE_GATE_FALLBACK_MS = 15000;
         try {
-            // 1) 常规 prominent notices
-            const r = await fetch('/api/pending-notices');
-            const data = await r.json();
-            const notices = Array.isArray(data) ? data : (data.notices || []);
-            const cursor = (data && typeof data.cursor === 'number') ? data.cursor : 0;
-            if (notices.length > 0) {
-                // 先全部入队（不 await），让 UI 能感知队列长度以显示"下一个"按钮
-                const promises = notices.filter(Boolean).map(n => window.showProminentNotice(n));
-                await Promise.all(promises);
-                await fetch('/api/pending-notices/ack', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ cursor }),
-                }).catch(() => { });
-            }
+            await Promise.race([
+                (async () => {
+                    if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
+                        await window.waitForStorageLocationStartupBarrier();
+                    }
+                    if (window.CharacterPersonalityOnboarding
+                        && typeof window.CharacterPersonalityOnboarding.whenSettled === 'function') {
+                        await window.CharacterPersonalityOnboarding.whenSettled();
+                    }
+                })(),
+                new Promise((resolve) => setTimeout(resolve, NOTICE_GATE_FALLBACK_MS)),
+            ]);
         } catch (_) { }
 
-        // 2) 版本更新日志
+        // 1) 版本更新日志（先讲背景）
         try {
             const lastVer = localStorage.getItem('neko_last_notified_version') || '';
             const lang = (window.i18next && window.i18next.language) || '';
@@ -326,7 +327,25 @@ window.addEventListener('load', async () => {
                 }
             }
         } catch (_) { }
-    }, 2000);
+
+        // 2) 常规 prominent notices（行动召唤）
+        try {
+            const r = await fetch('/api/pending-notices');
+            const data = await r.json();
+            const notices = Array.isArray(data) ? data : (data.notices || []);
+            const cursor = (data && typeof data.cursor === 'number') ? data.cursor : 0;
+            if (notices.length > 0) {
+                // 先全部入队（不 await），让 UI 能感知队列长度以显示"下一个"按钮
+                const promises = notices.filter(Boolean).map(n => window.showProminentNotice(n));
+                await Promise.all(promises);
+                await fetch('/api/pending-notices/ack', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ cursor }),
+                }).catch(() => { });
+            }
+        } catch (_) { }
+    })();
 });
 
 // 监听 voice_id 更新和 VRM 表情预览消息

--- a/static/app.js
+++ b/static/app.js
@@ -286,18 +286,25 @@ window.addEventListener('load', async () => {
 
         const NOTICE_GATE_FALLBACK_MS = 15000;
         try {
-            await Promise.race([
-                (async () => {
-                    if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
-                        await window.waitForStorageLocationStartupBarrier();
+            if (typeof window.waitForStorageLocationStartupBarrier === 'function') {
+                await window.waitForStorageLocationStartupBarrier();
+            }
+            const onboarding = window.CharacterPersonalityOnboarding;
+            if (onboarding && typeof onboarding.whenSettled === 'function') {
+                // 超时只兜底"bootstrap 内部卡死"：whenSettled 没 resolve 且 overlay 也没显示。
+                // 一旦 overlay 显示出来（用户在主动选择），就继续无限等 whenSettled——用户慢慢看 preset 是正常 UX，不该被超时强行放行。
+                const settled = await Promise.race([
+                    onboarding.whenSettled().then(() => true),
+                    new Promise((resolve) => setTimeout(() => resolve(false), NOTICE_GATE_FALLBACK_MS)),
+                ]);
+                if (!settled) {
+                    const overlayActive = (onboarding.overlay && !onboarding.overlay.hidden)
+                        || onboarding.pendingResumeAfterTutorial;
+                    if (overlayActive) {
+                        await onboarding.whenSettled();
                     }
-                    if (window.CharacterPersonalityOnboarding
-                        && typeof window.CharacterPersonalityOnboarding.whenSettled === 'function') {
-                        await window.CharacterPersonalityOnboarding.whenSettled();
-                    }
-                })(),
-                new Promise((resolve) => setTimeout(resolve, NOTICE_GATE_FALLBACK_MS)),
-            ]);
+                }
+            }
         } catch (_) { }
 
         // 1) 版本更新日志（先讲背景）

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -118,9 +118,20 @@
                 return;
             }
             this.bootstrapStarted = true;
+            // tutorial flow settle 有超时兜底：fetchTutorialPromptState() 持续 fail 时
+            // waitForTutorialFlowToSettle 会无限轮询，需要超时让 finally 能跑到。
+            const TUTORIAL_FLOW_TIMEOUT_MS = 15000;
             try {
                 await this.waitForStartupBarrier();
-                await this.waitForTutorialFlowToSettle();
+                const tutorialSettled = await Promise.race([
+                    this.waitForTutorialFlowToSettle().then(() => true),
+                    new Promise((resolve) => {
+                        window.setTimeout(() => resolve(false), TUTORIAL_FLOW_TIMEOUT_MS);
+                    }),
+                ]);
+                if (!tutorialSettled) {
+                    console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out, fallthrough');
+                }
                 if (await this.openIfManualReselectPending()) {
                     return;
                 }

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -89,7 +89,28 @@
             this.typewriterRunId = 0;
             this.typewriterTimer = null;
             this.lastTutorialPromptState = null;
+            // bootstrap 启动闭环 Promise：所有出口（不需要 / confirm / skip / 异常）都会 resolve；
+            // 供 app.js / app-autostart-prompt.js 在显示低优先级通知前 await，避免与 onboarding overlay 争焦点。
+            let settledResolveFn = null;
+            this._settledPromise = new Promise((resolve) => { settledResolveFn = resolve; });
+            this._settledResolve = () => {
+                if (settledResolveFn) {
+                    const fn = settledResolveFn;
+                    settledResolveFn = null;
+                    fn();
+                }
+            };
             this.bindTutorialLifecycleEvents();
+        }
+
+        markSettled() {
+            if (typeof this._settledResolve === 'function') {
+                this._settledResolve();
+            }
+        }
+
+        whenSettled() {
+            return this._settledPromise || Promise.resolve();
         }
 
         async bootstrap() {
@@ -97,12 +118,22 @@
                 return;
             }
             this.bootstrapStarted = true;
-            await this.waitForStartupBarrier();
-            await this.waitForTutorialFlowToSettle();
-            if (await this.openIfManualReselectPending()) {
-                return;
+            try {
+                await this.waitForStartupBarrier();
+                await this.waitForTutorialFlowToSettle();
+                if (await this.openIfManualReselectPending()) {
+                    return;
+                }
+                await this.openIfPending();
+            } catch (error) {
+                console.warn('[CharacterPersonalityOnboarding] bootstrap failed:', error);
+            } finally {
+                // 没显示 overlay（不需要 onboarding / 抛错 fallthrough）→ 立即 settle；
+                // 显示 overlay 时由 confirm/skip 各自 markSettled。
+                if (!this.overlay || this.overlay.hidden) {
+                    this.markSettled();
+                }
             }
-            await this.openIfPending();
         }
 
         async openFromSettings(characterName) {
@@ -735,6 +766,7 @@
                         body: JSON.stringify({ status: 'skipped' }),
                     });
                 }
+                this.markSettled();
                 this.hideOverlay();
             });
             actions.appendChild(skipButton);
@@ -911,6 +943,7 @@
                             presetId: selectedPresetId,
                         },
                     }));
+                    this.markSettled();
                     this.hideOverlay();
                 } catch (error) {
                     confirmButton.disabled = false;

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -89,6 +89,9 @@
             this.typewriterRunId = 0;
             this.typewriterTimer = null;
             this.lastTutorialPromptState = null;
+            // bootstrap 超时 fallthrough 时拉这个旗子，让 waitForTutorialFlowToSettle 的轮询循环退出，
+            // 避免后台每 120ms 一次的 /api/tutorial-prompt/state 永久泄漏。
+            this._tutorialFlowAborted = false;
             // bootstrap 启动闭环 Promise：所有出口（不需要 / confirm / skip / 异常）都会 resolve；
             // 供 app.js / app-autostart-prompt.js 在显示低优先级通知前 await，避免与 onboarding overlay 争焦点。
             let settledResolveFn = null;
@@ -130,6 +133,7 @@
                     }),
                 ]);
                 if (!tutorialSettled) {
+                    this._tutorialFlowAborted = true;
                     console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out, fallthrough');
                 }
                 if (await this.openIfManualReselectPending()) {
@@ -280,6 +284,9 @@
             await this.waitForTutorialCompletion();
 
             while (true) {
+                if (this._tutorialFlowAborted) {
+                    return;
+                }
                 if (window.universalTutorialManager && window.universalTutorialManager.isTutorialRunning) {
                     await this.waitForTutorialCompletion();
                     continue;


### PR DESCRIPTION
## Summary

之前 changelog / pending notices / autostart prompt 都不等 onboarding 完成，启动期间会和"初始人设" overlay 抢焦点。最容易撞车的场景：**老用户首次升级到带 onboarding 的版本**（`lastVer` 有 → changelog 弹；`initial_personality_prompt.json` 缺失 → onboarding 也弹）。

四件事现在严格串行：

```
storage barrier → tutorial → CharacterPersonalityOnboarding → 通知队列
                                                              (changelog → pending)
```

## 改动详情

**[`static/js/character_personality_onboarding.js`](static/js/character_personality_onboarding.js)**
- 新增 `whenSettled()` Promise + `markSettled()`：bootstrap 启动闭环出口信号
- `bootstrap()` 用 try/finally 包住——不显示 overlay / 抛错都立即 settle，**杜绝 hang**
- `confirm` / `skip` 显式 `markSettled()`；tutorial `queueResume` 的临时 `hideOverlay` 不 settle（仍要 resume）

**[`static/app.js`](static/app.js)**
- 删 `setTimeout(2000)`，改成 IIFE
- 加 `Promise.race([gate, 15s])`：`waitForStorageLocationStartupBarrier` + `whenSettled` 双等待，**超时兜底防 hang**
- 同一个 modal 队列入队顺序对调：**changelog 先（背景）→ pending notices 后（行动召唤）**——用户先看到"我们改了什么"，再看到"voice_migration 失效要重新克隆"，因果链顺
- 新用户 changelog gate（`!lastVer` → 跳过弹窗、记录当前版本）保持不变

**[`static/app-autostart-prompt.js`](static/app-autostart-prompt.js)**
- 心跳触发 `maybeShowPrompt` 前接同样的 gate
- 心跳间隔 15min，绝大多数情况 onboarding 早 settled，await 立即过；语义统一

## 时序矩阵

| 场景 | storage | tutorial | onboarding | changelog | pending notice |
|---|---|---|---|---|---|
| 真新用户 | selection_required ✅ | 弹（new cohort）✅ | 弹（status=pending）✅ | gate 跳过（lastVer 空）❌ | 队列空 ❌ |
| 老用户升级（缺 onboarding 文件） | 可能 migration_pending | existing cohort 不弹 ❌ | 弹（status=pending）✅ | 弹 ✅ | 看模块 |
| 老用户切 API | — | — | 不弹 ❌ | 弹 ✅ | voice_migration ✅ |

## Test plan

- [x] `node --check` (3 个 JS 文件) — syntax OK
- [x] `uv run pytest tests/unit/test_tutorial_prompt_state.py tests/unit/test_initial_personality_state.py tests/unit/test_character_persona_router.py -q` — **75 passed**
- [x] `uv run pytest tests/frontend/test_initial_personality_onboarding.py -q` — **31 passed**（覆盖 onboarding 等 tutorial 完成、stale event 防误判、fetch 失败兜底等关键时序场景）
- [ ] manual：模拟老用户场景（保留 lastVer，删 `initial_personality_prompt.json`）→ 应先弹 onboarding，关闭后再弹 changelog
- [ ] manual：onboarding fetch 故障（`/api/characters/persona-presets` 500）→ 15s 超时后 changelog 仍能弹
- [ ] manual：教程跑到一半时 onboarding 不弹（已有逻辑），changelog 也不应该弹

## 相关

衔接 #1211 的后续讨论：onboarding 之外还涉及 changelog / prominent notice / autostart_prompt 的整体启动时序梳理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 启动时的通知与提示展示改进：在显示自动启动提示与重要通知前，会等待个性化入门流程与存储就绪（最多等待15秒），并在入门流程显式完成时立即继续展示。

* **错误修复**
  * 优化启动期间的通知排序与时序，避免入门覆盖或阻塞导致的提示丢失或界面冲突。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->