### PR TITLE
[codex] hide dirty voice transcripts

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -308,6 +308,12 @@ DEFAULT_AGENT_MODEL = "qwen3.5-plus"
 DEFAULT_REALTIME_MODEL = "qwen3-omni-flash-realtime"  # 全模态模型(语音+文字+图片)，与 api_providers.json 对齐
 DEFAULT_TTS_MODEL = "qwen3-omni-flash-realtime"   # 与Realtime对应的TTS模型(Native TTS)，与 api_providers.json 对齐
 
+# Hide likely assistant/proactive speech that leaks back through microphone STT.
+# Conservative by design: the runtime only suppresses non-empty voice transcripts
+# that closely match recently displayed AI text; unrelated user barge-in remains
+# visible and enters memory normally.
+HIDE_DIRTY_VOICE_TRANSCRIPTS = True
+
 
 CONFIG_FILES = [
     'characters.json',
@@ -1566,6 +1572,7 @@ __all__ = [
     'DEFAULT_AGENT_MODEL',
     'DEFAULT_REALTIME_MODEL',
     'DEFAULT_TTS_MODEL',
+    'HIDE_DIRTY_VOICE_TRANSCRIPTS',
     # 用户自定义模型配置的 URL/API_KEY
     'DEFAULT_CONVERSATION_MODEL_URL',
     'DEFAULT_CONVERSATION_MODEL_API_KEY',

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -22,6 +22,7 @@ from typing import Any, Awaitable, Callable, Optional
 # None collapses both into the same code path and would let recovery /
 # proactive paths accidentally bind their messages to a newer request_id.
 _REQUEST_ID_UNSET: Any = object()
+_REMEMBER_VOICE_ECHO_UNSET: Any = object()
 from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
@@ -1660,7 +1661,7 @@ class LLMSessionManager:
         request_id: Any = _REQUEST_ID_UNSET,
         track_ai_turn: bool = True,
         cache_for_new_session: bool = True,
-        remember_voice_echo: bool = True,
+        remember_voice_echo: Any = _REMEMBER_VOICE_ECHO_UNSET,
     ):
         """Qwen输出转录回调: 可用于前端显示/缓存/同步。
 
@@ -1675,6 +1676,8 @@ class LLMSessionManager:
         默认 sentinel 用 module-level ``_REQUEST_ID_UNSET = object()`` 区分
         "未传"和"显式 None"，与单纯 ``request_id is None`` 检测不同。
         """
+        if remember_voice_echo is _REMEMBER_VOICE_ECHO_UNSET:
+            remember_voice_echo = not self.use_tts
         text_clean = self.emotion_pattern.sub('', text)
         # 累加到当前轮 AI 文本 buffer，turn end 时一并交给 activity tracker 做
         # unfinished_thread 检测。emotion_pattern 已剥掉表情标签，但保留 <expr>

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1526,6 +1526,9 @@ class LLMSessionManager:
         self._pending_ai_voice_echo_text = "".join(pending_chunks)
 
     def _confirm_pending_ai_voice_echo(self, speech_id: str | None = None) -> None:
+        if speech_id is None:
+            return
+
         confirmed_speech_ids = getattr(self, "_confirmed_ai_voice_echo_audio_speech_ids", None)
         if confirmed_speech_ids is None:
             confirmed_speech_ids = set()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1464,6 +1464,13 @@ class LLMSessionManager:
         self._recent_ai_voice_echo_text = ''
         self._recent_ai_voice_echo_at = 0.0
 
+    def _remember_recent_ai_voice_echo(self, text: str) -> None:
+        if not text:
+            return
+        recent_echo_text = (getattr(self, "_recent_ai_voice_echo_text", "") or "") + text
+        self._recent_ai_voice_echo_text = recent_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
+        self._recent_ai_voice_echo_at = time.time()
+
     def _should_suppress_dirty_voice_transcript(self, transcript_text: str) -> bool:
         if not HIDE_DIRTY_VOICE_TRANSCRIPTS:
             return False
@@ -1657,10 +1664,7 @@ class LLMSessionManager:
         # 等可能的 markup——tracker 自己会做二次 strip。
         if track_ai_turn:
             self._current_ai_turn_text += text_clean
-            if text_clean:
-                recent_echo_text = (getattr(self, "_recent_ai_voice_echo_text", "") or "") + text_clean
-                self._recent_ai_voice_echo_text = recent_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
-                self._recent_ai_voice_echo_at = time.time()
+            self._remember_recent_ai_voice_echo(text_clean)
         effective_turn_id = turn_id or self.current_speech_id
         effective_request_id = (
             self._active_text_request_id
@@ -1992,6 +1996,8 @@ class LLMSessionManager:
                     self.tts_pending_chunks.append((turn_id, clean))
                 status = self._request_tts_done_locked()
                 audio_queued = status in {"queued", "deferred", "already"}
+        if audio_queued:
+            self._remember_recent_ai_voice_echo(clean)
 
         if emit_turn_end_after:
             await self.emit_mirror_turn_end(

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -593,6 +593,7 @@ class LLMSessionManager:
         self._recent_ai_voice_echo_text: str = ''
         self._recent_ai_voice_echo_at: float = 0.0
         self._pending_ai_voice_echo_text: str = ''
+        self._pending_ai_voice_echo_chunks = deque()
 
         # 事件驱动状态机：收口 "谁占用当前 turn" 的所有信号，供 proactive 流水线
         # 零成本（O(1) 读）频繁询问 is_proactive_preempted。事件发射点分布在
@@ -1477,6 +1478,11 @@ class LLMSessionManager:
         self._recent_ai_voice_echo_text = ''
         self._recent_ai_voice_echo_at = 0.0
         self._pending_ai_voice_echo_text = ''
+        pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
+        if pending_chunks is None:
+            self._pending_ai_voice_echo_chunks = deque()
+        else:
+            pending_chunks.clear()
 
     def _remember_recent_ai_voice_echo(self, text: str) -> None:
         if not text:
@@ -1488,18 +1494,54 @@ class LLMSessionManager:
     def _remember_pending_ai_voice_echo(self, text: str) -> None:
         if not text:
             return
-        pending_echo_text = (getattr(self, "_pending_ai_voice_echo_text", "") or "") + text
-        self._pending_ai_voice_echo_text = pending_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
+        pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
+        if pending_chunks is None:
+            pending_chunks = deque()
+            self._pending_ai_voice_echo_chunks = pending_chunks
+        pending_chunks.append(text)
+        self._sync_pending_ai_voice_echo_text()
+
+    def _sync_pending_ai_voice_echo_text(self) -> None:
+        pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
+        if pending_chunks is None:
+            pending_chunks = deque()
+            pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
+            if pending_echo_text:
+                pending_chunks.append(pending_echo_text)
+            self._pending_ai_voice_echo_chunks = pending_chunks
+
+        pending_echo_text = "".join(pending_chunks)
+        excess = max(0, len(pending_echo_text) - _VOICE_ECHO_LOOKBACK_CHARS)
+        while pending_chunks and excess >= len(pending_chunks[0]):
+            excess -= len(pending_chunks.popleft())
+        if pending_chunks and excess > 0:
+            pending_chunks[0] = pending_chunks[0][excess:]
+
+        self._pending_ai_voice_echo_text = "".join(pending_chunks)
 
     def _confirm_pending_ai_voice_echo(self) -> None:
-        pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
-        if not pending_echo_text:
+        pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
+        if pending_chunks is None:
+            pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
+            if not pending_echo_text:
+                return
+            self._pending_ai_voice_echo_text = ''
+            self._remember_recent_ai_voice_echo(pending_echo_text)
             return
-        self._pending_ai_voice_echo_text = ''
+
+        if not pending_chunks:
+            self._pending_ai_voice_echo_text = ''
+            return
+
+        pending_echo_text = pending_chunks.popleft()
+        self._sync_pending_ai_voice_echo_text()
         self._remember_recent_ai_voice_echo(pending_echo_text)
 
     def _discard_pending_ai_voice_echo(self) -> None:
         self._pending_ai_voice_echo_text = ''
+        pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
+        if pending_chunks is not None:
+            pending_chunks.clear()
 
     def _should_suppress_dirty_voice_transcript(self, transcript_text: str) -> bool:
         if not HIDE_DIRTY_VOICE_TRANSCRIPTS:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -6039,8 +6039,7 @@ class LLMSessionManager:
 
                 size = len(data) if isinstance(data, (bytes, bytearray)) else f"type={type(data).__name__}"
                 logger.debug(f"🎧 handler dequeued audio: {size}, qsize≈{q.qsize()}")
-                if await self.send_speech(data):
-                    self._confirm_pending_ai_voice_echo(getattr(self, "current_speech_id", None))
+                await self.send_speech(data)
             except asyncio.CancelledError:
                 logger.info("🎧 tts_response_handler cancelled")
                 # asyncio.to_thread 取消后，线程池里那个 thread 仍阻塞在 q.get()。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1460,6 +1460,10 @@ class LLMSessionManager:
                     self.lanlan_name, bucket, exc,
                 )
 
+    def _reset_voice_echo_suppression_cache(self) -> None:
+        self._recent_ai_voice_echo_text = ''
+        self._recent_ai_voice_echo_at = 0.0
+
     def _should_suppress_dirty_voice_transcript(self, transcript_text: str) -> bool:
         if not HIDE_DIRTY_VOICE_TRANSCRIPTS:
             return False
@@ -2883,6 +2887,7 @@ class LLMSessionManager:
             logger.info(f"启动新session: input_mode={input_mode}, new={new}")
             self.websocket = websocket
             self.input_mode = input_mode
+            self._reset_voice_echo_suppression_cache()
         
             # 立即通知前端系统正在准备（静默期开始）
             await self.send_session_preparing(input_mode)
@@ -5483,6 +5488,7 @@ class LLMSessionManager:
                 self._audio_stream_epoch += 1
                 self._clear_audio_stream_queue("end_session_inactive")
                 self._cancel_audio_stream_worker("end_session_inactive")
+                self._reset_voice_echo_suppression_cache()
                 _inactive_early = True
                 # start_tts_if_needed 可能已启动 TTS 线程/handler，
                 # 但 is_active 尚未置 True 就失败了——快照引用以便释放锁后清理
@@ -5525,6 +5531,7 @@ class LLMSessionManager:
                 self._audio_stream_epoch += 1
                 self._clear_audio_stream_queue("end_session_post_init_inactive")
                 self._cancel_audio_stream_worker("end_session_post_init_inactive")
+                self._reset_voice_echo_suppression_cache()
                 return
             if expected_session is not None and expected_session is not self.session:
                 logger.info("⏭️ end_session: expected_session stale (post-init), skipping")
@@ -5542,6 +5549,7 @@ class LLMSessionManager:
             self._audio_stream_epoch += 1
             self._clear_audio_stream_queue("end_session")
             self._cancel_audio_stream_worker("end_session")
+            self._reset_voice_echo_suppression_cache()
 
             # Activity tracker：session 关闭，voice_engaged 不再可能触发。
             self._activity_tracker.on_voice_mode(False)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -952,6 +952,9 @@ class LLMSessionManager:
         async with self.tts_cache_lock:
             self.tts_pending_chunks.clear()
             self._tts_done_pending_until_ready = False
+            # Any text cached from project TTS enqueue may not have reached the
+            # frontend if this pipeline was interrupted or discarded.
+            self._reset_voice_echo_suppression_cache()
 
     @property
     def is_tts_pipeline_ready(self) -> bool:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1036,6 +1036,7 @@ class LLMSessionManager:
         if is_first_chunk and self.use_tts:
             async with self.tts_cache_lock:
                 self.tts_pending_chunks.clear()
+                self._discard_pending_ai_voice_echo()
 
             if self.tts_thread and self.tts_thread.is_alive():
                 # 清空响应队列中待发送的音频数据

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -594,6 +594,7 @@ class LLMSessionManager:
         self._recent_ai_voice_echo_at: float = 0.0
         self._pending_ai_voice_echo_text: str = ''
         self._pending_ai_voice_echo_chunks = deque()
+        self._confirmed_ai_voice_echo_audio_speech_ids: set[str | None] = set()
 
         # 事件驱动状态机：收口 "谁占用当前 turn" 的所有信号，供 proactive 流水线
         # 零成本（O(1) 读）频繁询问 is_proactive_preempted。事件发射点分布在
@@ -1483,6 +1484,11 @@ class LLMSessionManager:
             self._pending_ai_voice_echo_chunks = deque()
         else:
             pending_chunks.clear()
+        confirmed_speech_ids = getattr(self, "_confirmed_ai_voice_echo_audio_speech_ids", None)
+        if confirmed_speech_ids is None:
+            self._confirmed_ai_voice_echo_audio_speech_ids = set()
+        else:
+            confirmed_speech_ids.clear()
 
     def _remember_recent_ai_voice_echo(self, text: str) -> None:
         if not text:
@@ -1519,13 +1525,21 @@ class LLMSessionManager:
 
         self._pending_ai_voice_echo_text = "".join(pending_chunks)
 
-    def _confirm_pending_ai_voice_echo(self) -> None:
+    def _confirm_pending_ai_voice_echo(self, speech_id: str | None = None) -> None:
+        confirmed_speech_ids = getattr(self, "_confirmed_ai_voice_echo_audio_speech_ids", None)
+        if confirmed_speech_ids is None:
+            confirmed_speech_ids = set()
+            self._confirmed_ai_voice_echo_audio_speech_ids = confirmed_speech_ids
+        if speech_id in confirmed_speech_ids:
+            return
+
         pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
         if pending_chunks is None:
             pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
             if not pending_echo_text:
                 return
             self._pending_ai_voice_echo_text = ''
+            confirmed_speech_ids.add(speech_id)
             self._remember_recent_ai_voice_echo(pending_echo_text)
             return
 
@@ -1535,6 +1549,7 @@ class LLMSessionManager:
 
         pending_echo_text = pending_chunks.popleft()
         self._sync_pending_ai_voice_echo_text()
+        confirmed_speech_ids.add(speech_id)
         self._remember_recent_ai_voice_echo(pending_echo_text)
 
     def _discard_pending_ai_voice_echo(self) -> None:
@@ -1542,6 +1557,9 @@ class LLMSessionManager:
         pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
         if pending_chunks is not None:
             pending_chunks.clear()
+        confirmed_speech_ids = getattr(self, "_confirmed_ai_voice_echo_audio_speech_ids", None)
+        if confirmed_speech_ids is not None:
+            confirmed_speech_ids.clear()
 
     def _should_suppress_dirty_voice_transcript(self, transcript_text: str) -> bool:
         if not HIDE_DIRTY_VOICE_TRANSCRIPTS:
@@ -6016,13 +6034,13 @@ class LLMSessionManager:
                 elif isinstance(data, tuple) and len(data) == 3 and data[0] == "__audio__":
                     _, speech_id, audio_payload = data
                     if await self.send_speech(audio_payload, speech_id=speech_id):
-                        self._confirm_pending_ai_voice_echo()
+                        self._confirm_pending_ai_voice_echo(speech_id)
                     continue
 
                 size = len(data) if isinstance(data, (bytes, bytearray)) else f"type={type(data).__name__}"
                 logger.debug(f"🎧 handler dequeued audio: {size}, qsize≈{q.qsize()}")
                 if await self.send_speech(data):
-                    self._confirm_pending_ai_voice_echo()
+                    self._confirm_pending_ai_voice_echo(getattr(self, "current_speech_id", None))
             except asyncio.CancelledError:
                 logger.info("🎧 tts_response_handler cancelled")
                 # asyncio.to_thread 取消后，线程池里那个 thread 仍阻塞在 q.get()。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -782,6 +782,7 @@ class LLMSessionManager:
         if not text:
             return
         self.tts_request_queue.put((speech_id, text))
+        self._remember_recent_ai_voice_echo(text)
 
     def _reset_tts_stream_normalizer(self) -> None:
         """清空所有 TTS 文本 stripper 状态。中断 / 轮次结束 / session 重建时调用。"""
@@ -819,6 +820,7 @@ class LLMSessionManager:
         self._tts_bracket_stripper.flush()
         if flushed and self._tts_norm_speech_id is not None:
             self.tts_request_queue.put((self._tts_norm_speech_id, flushed))
+            self._remember_recent_ai_voice_echo(flushed)
 
         self.tts_request_queue.put((None, None))
         self._tts_done_queued_for_turn = True
@@ -1038,7 +1040,11 @@ class LLMSessionManager:
                         break
 
         # 文本模式下，无论是否使用TTS，都要发送文本到前端显示
-        await self.send_lanlan_response(text, is_first_chunk)
+        await self.send_lanlan_response(
+            text,
+            is_first_chunk,
+            remember_voice_echo=not self.use_tts,
+        )
         
         # 如果配置了TTS，将文本发送到TTS队列或缓存
         if self.use_tts:
@@ -1616,7 +1622,11 @@ class LLMSessionManager:
             )
             return
         # 无论是否使用TTS，都要发送文本到前端显示
-        await self.send_lanlan_response(text, is_first_chunk)
+        await self.send_lanlan_response(
+            text,
+            is_first_chunk,
+            remember_voice_echo=not self.use_tts,
+        )
         
         # 如果配置了TTS，将文本发送到TTS队列或缓存
         if self.use_tts:
@@ -1647,6 +1657,7 @@ class LLMSessionManager:
         request_id: Any = _REQUEST_ID_UNSET,
         track_ai_turn: bool = True,
         cache_for_new_session: bool = True,
+        remember_voice_echo: bool = True,
     ):
         """Qwen输出转录回调: 可用于前端显示/缓存/同步。
 
@@ -1667,7 +1678,8 @@ class LLMSessionManager:
         # 等可能的 markup——tracker 自己会做二次 strip。
         if track_ai_turn:
             self._current_ai_turn_text += text_clean
-            self._remember_recent_ai_voice_echo(text_clean)
+            if remember_voice_echo:
+                self._remember_recent_ai_voice_echo(text_clean)
         effective_turn_id = turn_id or self.current_speech_id
         effective_request_id = (
             self._active_text_request_id
@@ -1999,9 +2011,6 @@ class LLMSessionManager:
                     self.tts_pending_chunks.append((turn_id, clean))
                 status = self._request_tts_done_locked()
                 audio_queued = status in {"queued", "deferred", "already"}
-        if audio_queued:
-            self._remember_recent_ai_voice_echo(clean)
-
         if emit_turn_end_after:
             await self.emit_mirror_turn_end(
                 metadata=metadata,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -78,6 +78,7 @@ _STATUS_EMOJI = {
 _VOICE_ECHO_LOOKBACK_SECONDS = 20.0
 _VOICE_ECHO_LOOKBACK_CHARS = 1200
 _VOICE_ECHO_MIN_NORMALIZED_CHARS = 6
+_VOICE_ECHO_MIN_WINDOW_CHARS = 10
 _VOICE_ECHO_SIMILARITY_THRESHOLD = 0.88
 _VOICE_ECHO_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
 
@@ -99,10 +100,12 @@ def _looks_like_recent_ai_echo(transcript: str, recent_ai_text: str) -> bool:
     recent_norm = _normalize_voice_echo_text(recent_ai_text)
     if len(recent_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
         return False
-    if transcript_norm in recent_norm:
-        return True
     if len(transcript_norm) > len(recent_norm):
         return SequenceMatcher(None, transcript_norm, recent_norm).ratio() >= _VOICE_ECHO_SIMILARITY_THRESHOLD
+    if len(transcript_norm) < _VOICE_ECHO_MIN_WINDOW_CHARS:
+        return False
+    if transcript_norm in recent_norm:
+        return True
 
     window_len = len(transcript_norm)
     step = max(1, window_len // 3)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1621,29 +1621,19 @@ class LLMSessionManager:
             buffer twice)
         """
         transcript_text = transcript.strip()
-        if (
-            is_voice_source
-            and transcript_text
-            and self._should_suppress_dirty_voice_transcript(transcript_text)
-        ):
-            logger.info(
-                "[%s] suppressed likely AI echo voice transcript len=%d",
-                self.lanlan_name, len(transcript_text),
-            )
-            return
+        voice_rms_recorded = False
 
         # 更新用户活动时间戳（用于主动搭话检测）
         self.last_user_activity_time = time.time()
-        if is_voice_source:
-            # transcript 到达 → VAD 在窗口内捕捉到声音，标记 voice RMS 活跃；
-            # 即使转录为空（VAD 误触发或转录失败）也算一次"用户在发声"，
-            # 维持 voice_engaged 状态。
-            self._activity_tracker.on_voice_rms()
         if (
             is_voice_source
             and transcript_text
             and self._takeover_input_dispatcher is not None
         ):
+            # takeover 路由优先于 echo suppression；否则接管流程里用户说出
+            # 与 AI 近期播报相同的口令时，会被当成脏回声提前吞掉。
+            self._activity_tracker.on_voice_rms()
+            voice_rms_recorded = True
             try:
                 handled = await self._takeover_input_dispatcher(
                     self.lanlan_name,
@@ -1664,6 +1654,23 @@ class LLMSessionManager:
                     return
             except Exception as exc:
                 logger.warning("[%s] session takeover dispatcher failed: %s", self.lanlan_name, exc)
+
+        if (
+            is_voice_source
+            and transcript_text
+            and self._should_suppress_dirty_voice_transcript(transcript_text)
+        ):
+            logger.info(
+                "[%s] suppressed likely AI echo voice transcript len=%d",
+                self.lanlan_name, len(transcript_text),
+            )
+            return
+
+        if is_voice_source and not voice_rms_recorded:
+            # transcript 到达 → VAD 在窗口内捕捉到声音，标记 voice RMS 活跃；
+            # 即使转录为空（VAD 误触发或转录失败）也算一次"用户在发声"，
+            # 维持 voice_engaged 状态。
+            self._activity_tracker.on_voice_rms()
 
         if is_voice_source:
             # 仅非空转录才算"用户消息"：on_user_message 会清掉 unfinished_thread、
@@ -6079,6 +6086,7 @@ class LLMSessionManager:
                 size = len(data) if isinstance(data, (bytes, bytearray)) else f"type={type(data).__name__}"
                 logger.debug(f"🎧 handler dequeued audio: {size}, qsize≈{q.qsize()}")
                 await self.send_speech(data)
+                self._discard_pending_ai_voice_echo()
             except asyncio.CancelledError:
                 logger.info("🎧 tts_response_handler cancelled")
                 # asyncio.to_thread 取消后，线程池里那个 thread 仍阻塞在 q.get()。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -10,6 +10,7 @@ import struct  # For packing audio data
 import re
 import time
 from collections import deque
+from difflib import SequenceMatcher
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional
@@ -46,6 +47,7 @@ from config import (
     SESSION_ARCHIVE_TRIGGER_TOKENS,
     SESSION_TURN_THRESHOLD,
     AVATAR_INTERACTION_DEDUPE_MAX_ITEMS,
+    HIDE_DIRTY_VOICE_TRANSCRIPTS,
 )
 from config.prompts_sys import (
     _loc,
@@ -72,6 +74,49 @@ _STATUS_EMOJI = {
     "failed": "❌",
     "cancelled": "🚫",
 }
+
+_VOICE_ECHO_LOOKBACK_SECONDS = 20.0
+_VOICE_ECHO_LOOKBACK_CHARS = 1200
+_VOICE_ECHO_MIN_NORMALIZED_CHARS = 6
+_VOICE_ECHO_SIMILARITY_THRESHOLD = 0.88
+_VOICE_ECHO_NORMALIZE_RE = re.compile(r"[\W_]+", re.UNICODE)
+
+
+def _normalize_voice_echo_text(text: str) -> str:
+    return _VOICE_ECHO_NORMALIZE_RE.sub("", str(text or "").casefold())
+
+
+def _looks_like_recent_ai_echo(transcript: str, recent_ai_text: str) -> bool:
+    """Return True when STT text is probably the assistant's own recent audio.
+
+    This intentionally requires a close text match. Voice barge-in during AI
+    playback should keep flowing unless it resembles the AI text that was just
+    rendered/spoken.
+    """
+    transcript_norm = _normalize_voice_echo_text(transcript)
+    if len(transcript_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
+        return False
+    recent_norm = _normalize_voice_echo_text(recent_ai_text)
+    if len(recent_norm) < _VOICE_ECHO_MIN_NORMALIZED_CHARS:
+        return False
+    if transcript_norm in recent_norm:
+        return True
+    if len(transcript_norm) > len(recent_norm):
+        return SequenceMatcher(None, transcript_norm, recent_norm).ratio() >= _VOICE_ECHO_SIMILARITY_THRESHOLD
+
+    window_len = len(transcript_norm)
+    step = max(1, window_len // 3)
+    best = 0.0
+    last_start = len(recent_norm) - window_len
+    starts = list(range(0, last_start + 1, step))
+    if not starts or starts[-1] != last_start:
+        starts.append(last_start)
+    for start in starts:
+        candidate = recent_norm[start:start + window_len]
+        best = max(best, SequenceMatcher(None, transcript_norm, candidate).ratio())
+        if best >= _VOICE_ECHO_SIMILARITY_THRESHOLD:
+            return True
+    return False
 
 
 def _format_callback_source(cb: dict, lang: str) -> str:
@@ -542,6 +587,8 @@ class LLMSessionManager:
         # 时连同 on_ai_message 一起喂给 tracker。后者用末尾文本判断是否问问号
         # → 触发 unfinished_thread 机制（5 分钟内允许至多 2 次跟进）。
         self._current_ai_turn_text: str = ''
+        self._recent_ai_voice_echo_text: str = ''
+        self._recent_ai_voice_echo_at: float = 0.0
 
         # 事件驱动状态机：收口 "谁占用当前 turn" 的所有信号，供 proactive 流水线
         # 零成本（O(1) 读）频繁询问 is_proactive_preempted。事件发射点分布在
@@ -1413,6 +1460,15 @@ class LLMSessionManager:
                     self.lanlan_name, bucket, exc,
                 )
 
+    def _should_suppress_dirty_voice_transcript(self, transcript_text: str) -> bool:
+        if not HIDE_DIRTY_VOICE_TRANSCRIPTS:
+            return False
+        recent_ai_at = float(getattr(self, "_recent_ai_voice_echo_at", 0.0) or 0.0)
+        if recent_ai_at <= 0 or (time.time() - recent_ai_at) > _VOICE_ECHO_LOOKBACK_SECONDS:
+            return False
+        recent_ai_text = getattr(self, "_recent_ai_voice_echo_text", "") or ""
+        return _looks_like_recent_ai_echo(transcript_text, recent_ai_text)
+
     async def handle_input_transcript(self, transcript: str, *, is_voice_source: bool = True):
         """输入转录回调：同步转录文本到消息队列和缓存，并发送到前端显示
 
@@ -1426,6 +1482,18 @@ class LLMSessionManager:
             twice would double-bump _conv_seq and add the text to the
             buffer twice)
         """
+        transcript_text = transcript.strip()
+        if (
+            is_voice_source
+            and transcript_text
+            and self._should_suppress_dirty_voice_transcript(transcript_text)
+        ):
+            logger.info(
+                "[%s] suppressed likely AI echo voice transcript len=%d",
+                self.lanlan_name, len(transcript_text),
+            )
+            return
+
         # 更新用户活动时间戳（用于主动搭话检测）
         self.last_user_activity_time = time.time()
         if is_voice_source:
@@ -1433,7 +1501,6 @@ class LLMSessionManager:
             # 即使转录为空（VAD 误触发或转录失败）也算一次"用户在发声"，
             # 维持 voice_engaged 状态。
             self._activity_tracker.on_voice_rms()
-        transcript_text = transcript.strip()
         if (
             is_voice_source
             and transcript_text
@@ -1586,6 +1653,10 @@ class LLMSessionManager:
         # 等可能的 markup——tracker 自己会做二次 strip。
         if track_ai_turn:
             self._current_ai_turn_text += text_clean
+            if text_clean:
+                recent_echo_text = (getattr(self, "_recent_ai_voice_echo_text", "") or "") + text_clean
+                self._recent_ai_voice_echo_text = recent_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
+                self._recent_ai_voice_echo_at = time.time()
         effective_turn_id = turn_id or self.current_speech_id
         effective_request_id = (
             self._active_text_request_id

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -592,6 +592,7 @@ class LLMSessionManager:
         self._current_ai_turn_text: str = ''
         self._recent_ai_voice_echo_text: str = ''
         self._recent_ai_voice_echo_at: float = 0.0
+        self._pending_ai_voice_echo_text: str = ''
 
         # 事件驱动状态机：收口 "谁占用当前 turn" 的所有信号，供 proactive 流水线
         # 零成本（O(1) 读）频繁询问 is_proactive_preempted。事件发射点分布在
@@ -782,7 +783,7 @@ class LLMSessionManager:
         if not text:
             return
         self.tts_request_queue.put((speech_id, text))
-        self._remember_recent_ai_voice_echo(text)
+        self._remember_pending_ai_voice_echo(text)
 
     def _reset_tts_stream_normalizer(self) -> None:
         """清空所有 TTS 文本 stripper 状态。中断 / 轮次结束 / session 重建时调用。"""
@@ -820,7 +821,7 @@ class LLMSessionManager:
         self._tts_bracket_stripper.flush()
         if flushed and self._tts_norm_speech_id is not None:
             self.tts_request_queue.put((self._tts_norm_speech_id, flushed))
-            self._remember_recent_ai_voice_echo(flushed)
+            self._remember_pending_ai_voice_echo(flushed)
 
         self.tts_request_queue.put((None, None))
         self._tts_done_queued_for_turn = True
@@ -952,9 +953,9 @@ class LLMSessionManager:
         async with self.tts_cache_lock:
             self.tts_pending_chunks.clear()
             self._tts_done_pending_until_ready = False
-            # Any text cached from project TTS enqueue may not have reached the
-            # frontend if this pipeline was interrupted or discarded.
-            self._reset_voice_echo_suppression_cache()
+            # Drop only queued-but-unconfirmed TTS text. Already-confirmed
+            # audio may still be echoed by STT shortly after an interrupt.
+            self._discard_pending_ai_voice_echo()
 
     @property
     def is_tts_pipeline_ready(self) -> bool:
@@ -1475,6 +1476,7 @@ class LLMSessionManager:
     def _reset_voice_echo_suppression_cache(self) -> None:
         self._recent_ai_voice_echo_text = ''
         self._recent_ai_voice_echo_at = 0.0
+        self._pending_ai_voice_echo_text = ''
 
     def _remember_recent_ai_voice_echo(self, text: str) -> None:
         if not text:
@@ -1482,6 +1484,22 @@ class LLMSessionManager:
         recent_echo_text = (getattr(self, "_recent_ai_voice_echo_text", "") or "") + text
         self._recent_ai_voice_echo_text = recent_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
         self._recent_ai_voice_echo_at = time.time()
+
+    def _remember_pending_ai_voice_echo(self, text: str) -> None:
+        if not text:
+            return
+        pending_echo_text = (getattr(self, "_pending_ai_voice_echo_text", "") or "") + text
+        self._pending_ai_voice_echo_text = pending_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
+
+    def _confirm_pending_ai_voice_echo(self) -> None:
+        pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
+        if not pending_echo_text:
+            return
+        self._pending_ai_voice_echo_text = ''
+        self._remember_recent_ai_voice_echo(pending_echo_text)
+
+    def _discard_pending_ai_voice_echo(self) -> None:
+        self._pending_ai_voice_echo_text = ''
 
     def _should_suppress_dirty_voice_transcript(self, transcript_text: str) -> bool:
         if not HIDE_DIRTY_VOICE_TRANSCRIPTS:
@@ -5795,13 +5813,17 @@ class LLMSessionManager:
                 self._last_speech_output_time = time.time()
                 self._last_speech_output_bytes = len(tts_audio)
                 self.sync_message_queue.put({"type": "binary", "data": tts_audio})
+                return True
             else:
                 ws_state = getattr(self.websocket, 'client_state', None) if self.websocket else None
                 logger.warning(f"⚠️ send_speech skipped: ws={self.websocket is not None}, state={ws_state}")
+                return False
         except WebSocketDisconnect:
             logger.warning("⚠️ send_speech: WebSocket disconnected")
+            return False
         except Exception as e:
             logger.error(f"💥 WS Send Response Error: {e}")
+            return False
 
     async def tts_response_handler(self):
         q = self.tts_response_queue
@@ -5951,12 +5973,14 @@ class LLMSessionManager:
                         continue
                 elif isinstance(data, tuple) and len(data) == 3 and data[0] == "__audio__":
                     _, speech_id, audio_payload = data
-                    await self.send_speech(audio_payload, speech_id=speech_id)
+                    if await self.send_speech(audio_payload, speech_id=speech_id):
+                        self._confirm_pending_ai_voice_echo()
                     continue
 
                 size = len(data) if isinstance(data, (bytes, bytearray)) else f"type={type(data).__name__}"
                 logger.debug(f"🎧 handler dequeued audio: {size}, qsize≈{q.qsize()}")
-                await self.send_speech(data)
+                if await self.send_speech(data):
+                    self._confirm_pending_ai_voice_echo()
             except asyncio.CancelledError:
                 logger.info("🎧 tts_response_handler cancelled")
                 # asyncio.to_thread 取消后，线程池里那个 thread 仍阻塞在 q.get()。

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -22,7 +22,6 @@ from typing import Any, Awaitable, Callable, Optional
 # None collapses both into the same code path and would let recovery /
 # proactive paths accidentally bind their messages to a newer request_id.
 _REQUEST_ID_UNSET: Any = object()
-_REMEMBER_VOICE_ECHO_UNSET: Any = object()
 from datetime import datetime
 from websockets import exceptions as web_exceptions
 from fastapi import WebSocket, WebSocketDisconnect
@@ -1661,7 +1660,7 @@ class LLMSessionManager:
         request_id: Any = _REQUEST_ID_UNSET,
         track_ai_turn: bool = True,
         cache_for_new_session: bool = True,
-        remember_voice_echo: Any = _REMEMBER_VOICE_ECHO_UNSET,
+        remember_voice_echo: bool = False,
     ):
         """Qwen输出转录回调: 可用于前端显示/缓存/同步。
 
@@ -1676,8 +1675,6 @@ class LLMSessionManager:
         默认 sentinel 用 module-level ``_REQUEST_ID_UNSET = object()`` 区分
         "未传"和"显式 None"，与单纯 ``request_id is None`` 检测不同。
         """
-        if remember_voice_echo is _REMEMBER_VOICE_ECHO_UNSET:
-            remember_voice_echo = not self.use_tts
         text_clean = self.emotion_pattern.sub('', text)
         # 累加到当前轮 AI 文本 buffer，turn end 时一并交给 activity tracker 做
         # unfinished_thread 检测。emotion_pattern 已剥掉表情标签，但保留 <expr>

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1533,6 +1533,7 @@ class LLMSessionManager:
         if confirmed_speech_ids is None:
             confirmed_speech_ids = set()
             self._confirmed_ai_voice_echo_audio_speech_ids = confirmed_speech_ids
+        # Without chunk-level playback confirmation, one speech id can only safely promote one chunk.
         if speech_id in confirmed_speech_ids:
             return
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -594,7 +594,7 @@ class LLMSessionManager:
         self._recent_ai_voice_echo_at: float = 0.0
         self._pending_ai_voice_echo_text: str = ''
         self._pending_ai_voice_echo_chunks = deque()
-        self._confirmed_ai_voice_echo_audio_speech_ids: set[str | None] = set()
+        self._confirmed_ai_voice_echo_audio_speech_ids: set[str] = set()
 
         # 事件驱动状态机：收口 "谁占用当前 turn" 的所有信号，供 proactive 流水线
         # 零成本（O(1) 读）频繁询问 is_proactive_preempted。事件发射点分布在
@@ -785,7 +785,7 @@ class LLMSessionManager:
         if not text:
             return
         self.tts_request_queue.put((speech_id, text))
-        self._remember_pending_ai_voice_echo(text)
+        self._remember_pending_ai_voice_echo(speech_id, text)
 
     def _reset_tts_stream_normalizer(self) -> None:
         """清空所有 TTS 文本 stripper 状态。中断 / 轮次结束 / session 重建时调用。"""
@@ -823,7 +823,7 @@ class LLMSessionManager:
         self._tts_bracket_stripper.flush()
         if flushed and self._tts_norm_speech_id is not None:
             self.tts_request_queue.put((self._tts_norm_speech_id, flushed))
-            self._remember_pending_ai_voice_echo(flushed)
+            self._remember_pending_ai_voice_echo(self._tts_norm_speech_id, flushed)
 
         self.tts_request_queue.put((None, None))
         self._tts_done_queued_for_turn = True
@@ -1498,14 +1498,26 @@ class LLMSessionManager:
         self._recent_ai_voice_echo_text = recent_echo_text[-_VOICE_ECHO_LOOKBACK_CHARS:]
         self._recent_ai_voice_echo_at = time.time()
 
-    def _remember_pending_ai_voice_echo(self, text: str) -> None:
+    @staticmethod
+    def _pending_ai_voice_echo_item_speech_id(item) -> str | None:
+        if isinstance(item, tuple) and len(item) == 2:
+            return item[0]
+        return None
+
+    @staticmethod
+    def _pending_ai_voice_echo_item_text(item) -> str:
+        if isinstance(item, tuple) and len(item) == 2:
+            return item[1]
+        return item
+
+    def _remember_pending_ai_voice_echo(self, speech_id: str | None, text: str) -> None:
         if not text:
             return
         pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
         if pending_chunks is None:
             pending_chunks = deque()
             self._pending_ai_voice_echo_chunks = pending_chunks
-        pending_chunks.append(text)
+        pending_chunks.append((speech_id, text))
         self._sync_pending_ai_voice_echo_text()
 
     def _sync_pending_ai_voice_echo_text(self) -> None:
@@ -1514,17 +1526,33 @@ class LLMSessionManager:
             pending_chunks = deque()
             pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
             if pending_echo_text:
-                pending_chunks.append(pending_echo_text)
+                pending_chunks.append((None, pending_echo_text))
             self._pending_ai_voice_echo_chunks = pending_chunks
 
-        pending_echo_text = "".join(pending_chunks)
+        pending_echo_text = "".join(
+            self._pending_ai_voice_echo_item_text(chunk)
+            for chunk in pending_chunks
+        )
         excess = max(0, len(pending_echo_text) - _VOICE_ECHO_LOOKBACK_CHARS)
-        while pending_chunks and excess >= len(pending_chunks[0]):
-            excess -= len(pending_chunks.popleft())
+        while pending_chunks:
+            first_text = self._pending_ai_voice_echo_item_text(pending_chunks[0])
+            if not first_text:
+                pending_chunks.popleft()
+                continue
+            if excess < len(first_text):
+                break
+            excess -= len(first_text)
+            pending_chunks.popleft()
         if pending_chunks and excess > 0:
-            pending_chunks[0] = pending_chunks[0][excess:]
+            first_chunk = pending_chunks[0]
+            first_speech_id = self._pending_ai_voice_echo_item_speech_id(first_chunk)
+            first_text = self._pending_ai_voice_echo_item_text(first_chunk)
+            pending_chunks[0] = (first_speech_id, first_text[excess:])
 
-        self._pending_ai_voice_echo_text = "".join(pending_chunks)
+        self._pending_ai_voice_echo_text = "".join(
+            self._pending_ai_voice_echo_item_text(chunk)
+            for chunk in pending_chunks
+        )
 
     def _confirm_pending_ai_voice_echo(self, speech_id: str | None = None) -> None:
         if speech_id is None:
@@ -1541,18 +1569,22 @@ class LLMSessionManager:
         pending_chunks = getattr(self, "_pending_ai_voice_echo_chunks", None)
         if pending_chunks is None:
             pending_echo_text = getattr(self, "_pending_ai_voice_echo_text", "") or ""
-            if not pending_echo_text:
-                return
-            self._pending_ai_voice_echo_text = ''
-            confirmed_speech_ids.add(speech_id)
-            self._remember_recent_ai_voice_echo(pending_echo_text)
+            pending_chunks = deque()
+            if pending_echo_text:
+                pending_chunks.append((None, pending_echo_text))
+            self._pending_ai_voice_echo_chunks = pending_chunks
+            self._sync_pending_ai_voice_echo_text()
             return
 
         if not pending_chunks:
             self._pending_ai_voice_echo_text = ''
             return
 
-        pending_echo_text = pending_chunks.popleft()
+        pending_speech_id = self._pending_ai_voice_echo_item_speech_id(pending_chunks[0])
+        if pending_speech_id != speech_id:
+            return
+
+        pending_echo_text = self._pending_ai_voice_echo_item_text(pending_chunks.popleft())
         self._sync_pending_ai_voice_echo_text()
         confirmed_speech_ids.add(speech_id)
         self._remember_recent_ai_voice_echo(pending_echo_text)

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -6039,6 +6039,8 @@ class LLMSessionManager:
                     _, speech_id, audio_payload = data
                     if await self.send_speech(audio_payload, speech_id=speech_id):
                         self._confirm_pending_ai_voice_echo(speech_id)
+                    else:
+                        self._discard_pending_ai_voice_echo()
                     continue
 
                 size = len(data) if isinstance(data, (bytes, bytearray)) else f"type={type(data).__name__}"

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -426,7 +426,7 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
     mgr._recent_ai_voice_echo_at = FIXED_TS
     mgr._pending_ai_voice_echo_text = "还没确认播放的文本"
-    mgr._pending_ai_voice_echo_chunks.append("还没确认播放的文本")
+    mgr._pending_ai_voice_echo_chunks.append(("old-speech", "还没确认播放的文本"))
     mgr._confirmed_ai_voice_echo_audio_speech_ids.add("old-speech")
 
     core_module.LLMSessionManager._reset_voice_echo_suppression_cache(mgr)
@@ -493,18 +493,19 @@ async def test_mirror_assistant_speech_confirms_audio_echo_after_tts_audio(monke
     )
 
     assert result["audio_queued"] is True
+    speech_id = mgr.tts_request_queue.messages[0][0]
     assert mgr.tts_request_queue.messages[0][1] == "要不要休息一下喝点水"
     assert mgr._pending_ai_voice_echo_text == "要不要休息一下喝点水"
-    assert list(mgr._pending_ai_voice_echo_chunks) == ["要不要休息一下喝点水"]
+    assert list(mgr._pending_ai_voice_echo_chunks) == [(speech_id, "要不要休息一下喝点水")]
     assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
 
-    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "old-speech")
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, speech_id)
 
     assert mgr._pending_ai_voice_echo_text == ""
     assert list(mgr._pending_ai_voice_echo_chunks) == []
-    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == {"old-speech"}
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == {speech_id}
     assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
@@ -514,15 +515,15 @@ def test_confirm_pending_ai_voice_echo_promotes_only_next_played_chunk(monkeypat
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
 
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "已经发出音频的第一句")
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "还在队列里的第二句")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "speech-1", "已经发出音频的第一句")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "speech-1", "还在队列里的第二句")
 
     core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "speech-1")
 
     assert mgr._recent_ai_voice_echo_text == "已经发出音频的第一句"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
     assert mgr._pending_ai_voice_echo_text == "还在队列里的第二句"
-    assert list(mgr._pending_ai_voice_echo_chunks) == ["还在队列里的第二句"]
+    assert list(mgr._pending_ai_voice_echo_chunks) == [("speech-1", "还在队列里的第二句")]
 
 
 @pytest.mark.unit
@@ -530,14 +531,14 @@ def test_confirm_pending_ai_voice_echo_skips_sidless_confirmation(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
 
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "无法确认归属的文本")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "speech-1", "无法确认归属的文本")
 
     core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
     assert mgr._pending_ai_voice_echo_text == "无法确认归属的文本"
-    assert list(mgr._pending_ai_voice_echo_chunks) == ["无法确认归属的文本"]
+    assert list(mgr._pending_ai_voice_echo_chunks) == [("speech-1", "无法确认归属的文本")]
     assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
 
 
@@ -546,15 +547,39 @@ def test_confirm_pending_ai_voice_echo_promotes_once_per_speech_id(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
 
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "第一段文本")
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "第二段未播文本")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "speech-1", "第一段文本")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "speech-1", "第二段未播文本")
 
     core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "speech-1")
     core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "speech-1")
 
     assert mgr._recent_ai_voice_echo_text == "第一段文本"
     assert mgr._pending_ai_voice_echo_text == "第二段未播文本"
-    assert list(mgr._pending_ai_voice_echo_chunks) == ["第二段未播文本"]
+    assert list(mgr._pending_ai_voice_echo_chunks) == [("speech-1", "第二段未播文本")]
+
+
+@pytest.mark.unit
+def test_confirm_pending_ai_voice_echo_ignores_late_old_speech_id_for_new_pending(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "new-speech", "new turn pending text")
+
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "old-speech")
+
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_at == 0.0
+    assert mgr._pending_ai_voice_echo_text == "new turn pending text"
+    assert list(mgr._pending_ai_voice_echo_chunks) == [("new-speech", "new turn pending text")]
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
+
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "new-speech")
+
+    assert mgr._recent_ai_voice_echo_text == "new turn pending text"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
+    assert mgr._pending_ai_voice_echo_text == ""
+    assert list(mgr._pending_ai_voice_echo_chunks) == []
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == {"new-speech"}
 
 
 @pytest.mark.unit
@@ -569,7 +594,7 @@ async def test_text_first_chunk_drops_stale_pending_echo_before_new_tts(monkeypa
     mgr.tts_pending_chunks = [("old-speech", "old cached text")]
     mgr.tts_response_queue.put(("__audio__", "old-speech", b"old-audio"))
 
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "old unplayed text")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "old-speech", "old unplayed text")
     mgr._confirmed_ai_voice_echo_audio_speech_ids.add("old-speech")
 
     await core_module.LLMSessionManager.handle_text_data(
@@ -582,7 +607,7 @@ async def test_text_first_chunk_drops_stale_pending_echo_before_new_tts(monkeypa
     assert mgr.tts_pending_chunks == []
     assert mgr.tts_request_queue.messages == [("new-speech", "new tts text")]
     assert mgr._pending_ai_voice_echo_text == "new tts text"
-    assert list(mgr._pending_ai_voice_echo_chunks) == ["new tts text"]
+    assert list(mgr._pending_ai_voice_echo_chunks) == [("new-speech", "new tts text")]
     assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
     assert mgr._recent_ai_voice_echo_text == ""
 
@@ -597,7 +622,7 @@ async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
     mgr.current_speech_id = "new-turn"
     send_called = asyncio.Event()
 
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "new turn pending text")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "new-turn", "new turn pending text")
 
     async def send_speech(audio, speech_id=None):
         assert audio == b"sidless-audio"
@@ -615,7 +640,7 @@ async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._pending_ai_voice_echo_text == "new turn pending text"
-    assert list(mgr._pending_ai_voice_echo_chunks) == ["new turn pending text"]
+    assert list(mgr._pending_ai_voice_echo_chunks) == [("new-turn", "new turn pending text")]
 
 
 @pytest.mark.unit
@@ -627,7 +652,7 @@ async def test_failed_tts_audio_send_drops_unplayed_pending_echo(monkeypatch):
     mgr.tts_response_queue.put(("__audio__", "speech-1", b"failed-audio"))
     send_called = asyncio.Event()
 
-    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "unplayed pending text")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "speech-1", "unplayed pending text")
 
     async def send_speech(audio, speech_id=None):
         assert audio == b"failed-audio"
@@ -658,7 +683,7 @@ async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     mgr._recent_ai_voice_echo_text = "已经播出的尾音"
     mgr._recent_ai_voice_echo_at = FIXED_TS
     mgr._pending_ai_voice_echo_text = "还没来得及播放的队列文本"
-    mgr._pending_ai_voice_echo_chunks.append("还没来得及播放的队列文本")
+    mgr._pending_ai_voice_echo_chunks.append(("old-speech", "还没来得及播放的队列文本"))
     mgr._confirmed_ai_voice_echo_audio_speech_ids.add("old-speech")
     mgr.tts_pending_chunks = [("sid-old", "pending text")]
 

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -559,6 +559,36 @@ def test_confirm_pending_ai_voice_echo_promotes_once_per_speech_id(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_text_first_chunk_drops_stale_pending_echo_before_new_tts(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.use_tts = True
+    mgr.tts_ready = True
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.current_speech_id = "new-speech"
+    mgr.tts_pending_chunks = [("old-speech", "old cached text")]
+    mgr.tts_response_queue.put(("__audio__", "old-speech", b"old-audio"))
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "old unplayed text")
+    mgr._confirmed_ai_voice_echo_audio_speech_ids.add("old-speech")
+
+    await core_module.LLMSessionManager.handle_text_data(
+        mgr,
+        "new tts text",
+        is_first_chunk=True,
+    )
+
+    assert mgr.tts_response_queue.empty()
+    assert mgr.tts_pending_chunks == []
+    assert mgr.tts_request_queue.messages == [("new-speech", "new tts text")]
+    assert mgr._pending_ai_voice_echo_text == "new tts text"
+    assert list(mgr._pending_ai_voice_echo_chunks) == ["new tts text"]
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
+    assert mgr._recent_ai_voice_echo_text == ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -1,3 +1,4 @@
+from collections import deque
 import queue
 from unittest.mock import Mock
 
@@ -92,6 +93,7 @@ def _make_manager():
     mgr._recent_ai_voice_echo_text = ""
     mgr._recent_ai_voice_echo_at = 0.0
     mgr._pending_ai_voice_echo_text = ""
+    mgr._pending_ai_voice_echo_chunks = deque()
     mgr.tts_ready = False
     mgr.tts_thread = None
     mgr.tts_request_queue = _FakeQueue()
@@ -398,12 +400,14 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
     mgr._recent_ai_voice_echo_at = FIXED_TS
     mgr._pending_ai_voice_echo_text = "还没确认播放的文本"
+    mgr._pending_ai_voice_echo_chunks.append("还没确认播放的文本")
 
     core_module.LLMSessionManager._reset_voice_echo_suppression_cache(mgr)
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
     assert mgr._pending_ai_voice_echo_text == ""
+    assert list(mgr._pending_ai_voice_echo_chunks) == []
 
 
 @pytest.mark.unit
@@ -462,14 +466,32 @@ async def test_mirror_assistant_speech_confirms_audio_echo_after_tts_audio(monke
     assert result["audio_queued"] is True
     assert mgr.tts_request_queue.messages[0][1] == "要不要休息一下喝点水"
     assert mgr._pending_ai_voice_echo_text == "要不要休息一下喝点水"
+    assert list(mgr._pending_ai_voice_echo_chunks) == ["要不要休息一下喝点水"]
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
 
     core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
 
     assert mgr._pending_ai_voice_echo_text == ""
+    assert list(mgr._pending_ai_voice_echo_chunks) == []
     assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
+
+
+@pytest.mark.unit
+def test_confirm_pending_ai_voice_echo_promotes_only_next_played_chunk(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "已经发出音频的第一句")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "还在队列里的第二句")
+
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
+
+    assert mgr._recent_ai_voice_echo_text == "已经发出音频的第一句"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
+    assert mgr._pending_ai_voice_echo_text == "还在队列里的第二句"
+    assert list(mgr._pending_ai_voice_echo_chunks) == ["还在队列里的第二句"]
 
 
 @pytest.mark.unit
@@ -481,6 +503,7 @@ async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     mgr._recent_ai_voice_echo_text = "已经播出的尾音"
     mgr._recent_ai_voice_echo_at = FIXED_TS
     mgr._pending_ai_voice_echo_text = "还没来得及播放的队列文本"
+    mgr._pending_ai_voice_echo_chunks.append("还没来得及播放的队列文本")
     mgr.tts_pending_chunks = [("sid-old", "pending text")]
 
     await core_module.LLMSessionManager._clear_tts_pipeline(mgr)
@@ -488,6 +511,7 @@ async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     assert mgr.tts_request_queue.messages == [("__interrupt__", None)]
     assert mgr.tts_pending_chunks == []
     assert mgr._pending_ai_voice_echo_text == ""
+    assert list(mgr._pending_ai_voice_echo_chunks) == []
     assert mgr._recent_ai_voice_echo_text == "已经播出的尾音"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -348,6 +348,30 @@ async def test_ai_echo_voice_transcript_switch_can_disable_suppression(monkeypat
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_stale_ai_echo_voice_transcript_is_not_suppressed(monkeypatch):
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
+    mgr._recent_ai_voice_echo_at = FIXED_TS - 25
+
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
+
+    assert mgr._activity_tracker.voice_rms_count == 1
+    assert mgr._activity_tracker.user_messages == ["要不要休息一下喝点水"]
+    assert mgr._session_turn_count == 1
+    mgr._publish_user_utterance_to_plugin_bus.assert_called_once_with(
+        "要不要休息一下喝点水",
+        is_voice_source=True,
+    )
+    assert mgr.sync_message_queue.messages == [{
+        "type": "user",
+        "data": {"input_type": "transcript", "data": "要不要休息一下喝点水"},
+    }]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(monkeypatch):
     mgr = _make_transcript_manager()
     monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -5,6 +5,9 @@ import pytest
 import main_logic.core as core_module
 
 
+FIXED_TS = 1_700_000_000.0
+
+
 class _AsyncNullLock:
     async def __aenter__(self):
         return self
@@ -51,6 +54,11 @@ class _FakeActivityTracker:
 
     def on_user_message(self, text):
         self.user_messages.append(text)
+
+
+class _FakeAliveThread:
+    def is_alive(self):
+        return True
 
 
 def _make_manager():
@@ -279,8 +287,9 @@ async def test_no_takeover_voice_transcript_uses_ordinary_flow():
 async def test_likely_ai_echo_voice_transcript_is_suppressed(monkeypatch):
     mgr = _make_transcript_manager()
     monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
-    mgr._recent_ai_voice_echo_at = core_module.time.time()
+    mgr._recent_ai_voice_echo_at = FIXED_TS
 
     await core_module.LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
 
@@ -296,8 +305,9 @@ async def test_likely_ai_echo_voice_transcript_is_suppressed(monkeypatch):
 async def test_ai_echo_voice_transcript_switch_can_disable_suppression(monkeypatch):
     mgr = _make_transcript_manager()
     monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", False)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
-    mgr._recent_ai_voice_echo_at = core_module.time.time()
+    mgr._recent_ai_voice_echo_at = FIXED_TS
 
     await core_module.LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
 
@@ -319,8 +329,9 @@ async def test_ai_echo_voice_transcript_switch_can_disable_suppression(monkeypat
 async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(monkeypatch):
     mgr = _make_transcript_manager()
     monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
-    mgr._recent_ai_voice_echo_at = core_module.time.time()
+    mgr._recent_ai_voice_echo_at = FIXED_TS
 
     await core_module.LLMSessionManager.handle_input_transcript(mgr, "先别休息帮我打开设置", is_voice_source=True)
 
@@ -341,12 +352,45 @@ async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(mon
 def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     mgr = _make_transcript_manager()
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
-    mgr._recent_ai_voice_echo_at = core_module.time.time()
+    mgr._recent_ai_voice_echo_at = FIXED_TS
 
     core_module.LLMSessionManager._reset_voice_echo_suppression_cache(mgr)
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mirror_assistant_speech_remembers_audio_echo_when_tts_queued(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.tts_thread = _FakeAliveThread()
+    mgr.tts_ready = True
+    enqueued = []
+
+    def enqueue_tts_text_chunk(speech_id, text):
+        enqueued.append((speech_id, text))
+
+    def request_tts_done_locked():
+        return "queued"
+
+    mgr._enqueue_tts_text_chunk = enqueue_tts_text_chunk
+    mgr._request_tts_done_locked = request_tts_done_locked
+
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
+        mgr,
+        "要不要休息一下喝点水",
+        metadata=_soccer_mirror_meta({"kind": "opening-line"}),
+        request_id="req-mirror-voice",
+        mirror_text=False,
+        emit_turn_end_after=False,
+    )
+
+    assert result["audio_queued"] is True
+    assert enqueued and enqueued[0][1] == "要不要休息一下喝点水"
+    assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -442,6 +442,7 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
 @pytest.mark.asyncio
 async def test_send_lanlan_response_defaults_to_skip_display_echo_cache(monkeypatch):
     mgr = _make_manager()
+    mgr.use_tts = True
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
 
     await core_module.LLMSessionManager.send_lanlan_response(mgr, "显示文本（括号也显示）")
@@ -516,12 +517,28 @@ def test_confirm_pending_ai_voice_echo_promotes_only_next_played_chunk(monkeypat
     core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "已经发出音频的第一句")
     core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "还在队列里的第二句")
 
-    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "speech-1")
 
     assert mgr._recent_ai_voice_echo_text == "已经发出音频的第一句"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
     assert mgr._pending_ai_voice_echo_text == "还在队列里的第二句"
     assert list(mgr._pending_ai_voice_echo_chunks) == ["还在队列里的第二句"]
+
+
+@pytest.mark.unit
+def test_confirm_pending_ai_voice_echo_skips_sidless_confirmation(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "无法确认归属的文本")
+
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
+
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_at == 0.0
+    assert mgr._pending_ai_voice_echo_text == "无法确认归属的文本"
+    assert list(mgr._pending_ai_voice_echo_chunks) == ["无法确认归属的文本"]
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -1,3 +1,4 @@
+import queue
 from unittest.mock import Mock
 
 import pytest
@@ -48,7 +49,7 @@ class _FakeQueue:
 
     def get_nowait(self):
         if not self.messages:
-            raise IndexError("empty queue")
+            raise queue.Empty
         return self.messages.pop(0)
 
 
@@ -90,6 +91,7 @@ def _make_manager():
     mgr._current_ai_turn_text = ""
     mgr._recent_ai_voice_echo_text = ""
     mgr._recent_ai_voice_echo_at = 0.0
+    mgr._pending_ai_voice_echo_text = ""
     mgr.tts_ready = False
     mgr.tts_thread = None
     mgr.tts_request_queue = _FakeQueue()
@@ -395,11 +397,13 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     mgr = _make_transcript_manager()
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
     mgr._recent_ai_voice_echo_at = FIXED_TS
+    mgr._pending_ai_voice_echo_text = "还没确认播放的文本"
 
     core_module.LLMSessionManager._reset_voice_echo_suppression_cache(mgr)
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
+    assert mgr._pending_ai_voice_echo_text == ""
 
 
 @pytest.mark.unit
@@ -434,7 +438,7 @@ async def test_send_lanlan_response_can_explicitly_remember_voice_echo_with_tts(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_mirror_assistant_speech_remembers_audio_echo_when_tts_queued(monkeypatch):
+async def test_mirror_assistant_speech_confirms_audio_echo_after_tts_audio(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr.tts_thread = _FakeAliveThread()
@@ -457,26 +461,35 @@ async def test_mirror_assistant_speech_remembers_audio_echo_when_tts_queued(monk
 
     assert result["audio_queued"] is True
     assert mgr.tts_request_queue.messages[0][1] == "要不要休息一下喝点水"
+    assert mgr._pending_ai_voice_echo_text == "要不要休息一下喝点水"
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_at == 0.0
+
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
+
+    assert mgr._pending_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_clear_tts_pipeline_drops_unplayed_echo_cache(monkeypatch):
+async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr.tts_thread = _FakeAliveThread()
-    mgr._recent_ai_voice_echo_text = "还没来得及播放的队列文本"
+    mgr._recent_ai_voice_echo_text = "已经播出的尾音"
     mgr._recent_ai_voice_echo_at = FIXED_TS
+    mgr._pending_ai_voice_echo_text = "还没来得及播放的队列文本"
     mgr.tts_pending_chunks = [("sid-old", "pending text")]
 
     await core_module.LLMSessionManager._clear_tts_pipeline(mgr)
 
     assert mgr.tts_request_queue.messages == [("__interrupt__", None)]
     assert mgr.tts_pending_chunks == []
-    assert mgr._recent_ai_voice_echo_text == ""
-    assert mgr._recent_ai_voice_echo_at == 0.0
+    assert mgr._pending_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_text == "已经播出的尾音"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -349,6 +349,30 @@ async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(mon
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_short_keyword_barge_in_from_recent_ai_text_is_not_suppressed(monkeypatch):
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr._recent_ai_voice_echo_text = "Do you want tea or coffee?"
+    mgr._recent_ai_voice_echo_at = FIXED_TS
+
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "coffee", is_voice_source=True)
+
+    assert mgr._activity_tracker.voice_rms_count == 1
+    assert mgr._activity_tracker.user_messages == ["coffee"]
+    assert mgr._session_turn_count == 1
+    mgr._publish_user_utterance_to_plugin_bus.assert_called_once_with(
+        "coffee",
+        is_voice_source=True,
+    )
+    assert mgr.sync_message_queue.messages == [{
+        "type": "user",
+        "data": {"input_type": "transcript", "data": "coffee"},
+    }]
+
+
+@pytest.mark.unit
 def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     mgr = _make_transcript_manager()
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -94,6 +94,7 @@ def _make_manager():
     mgr._recent_ai_voice_echo_at = 0.0
     mgr._pending_ai_voice_echo_text = ""
     mgr._pending_ai_voice_echo_chunks = deque()
+    mgr._confirmed_ai_voice_echo_audio_speech_ids = set()
     mgr.tts_ready = False
     mgr.tts_thread = None
     mgr.tts_request_queue = _FakeQueue()
@@ -425,6 +426,7 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     mgr._recent_ai_voice_echo_at = FIXED_TS
     mgr._pending_ai_voice_echo_text = "还没确认播放的文本"
     mgr._pending_ai_voice_echo_chunks.append("还没确认播放的文本")
+    mgr._confirmed_ai_voice_echo_audio_speech_ids.add("old-speech")
 
     core_module.LLMSessionManager._reset_voice_echo_suppression_cache(mgr)
 
@@ -432,6 +434,7 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
     assert mgr._recent_ai_voice_echo_at == 0.0
     assert mgr._pending_ai_voice_echo_text == ""
     assert list(mgr._pending_ai_voice_echo_chunks) == []
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
 
 
 @pytest.mark.unit
@@ -491,13 +494,15 @@ async def test_mirror_assistant_speech_confirms_audio_echo_after_tts_audio(monke
     assert mgr.tts_request_queue.messages[0][1] == "要不要休息一下喝点水"
     assert mgr._pending_ai_voice_echo_text == "要不要休息一下喝点水"
     assert list(mgr._pending_ai_voice_echo_chunks) == ["要不要休息一下喝点水"]
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
 
-    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr)
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "old-speech")
 
     assert mgr._pending_ai_voice_echo_text == ""
     assert list(mgr._pending_ai_voice_echo_chunks) == []
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == {"old-speech"}
     assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
@@ -519,6 +524,22 @@ def test_confirm_pending_ai_voice_echo_promotes_only_next_played_chunk(monkeypat
 
 
 @pytest.mark.unit
+def test_confirm_pending_ai_voice_echo_promotes_once_per_speech_id(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "第一段文本")
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "第二段未播文本")
+
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "speech-1")
+    core_module.LLMSessionManager._confirm_pending_ai_voice_echo(mgr, "speech-1")
+
+    assert mgr._recent_ai_voice_echo_text == "第一段文本"
+    assert mgr._pending_ai_voice_echo_text == "第二段未播文本"
+    assert list(mgr._pending_ai_voice_echo_chunks) == ["第二段未播文本"]
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     mgr = _make_manager()
@@ -528,6 +549,7 @@ async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     mgr._recent_ai_voice_echo_at = FIXED_TS
     mgr._pending_ai_voice_echo_text = "还没来得及播放的队列文本"
     mgr._pending_ai_voice_echo_chunks.append("还没来得及播放的队列文本")
+    mgr._confirmed_ai_voice_echo_audio_speech_ids.add("old-speech")
     mgr.tts_pending_chunks = [("sid-old", "pending text")]
 
     await core_module.LLMSessionManager._clear_tts_pipeline(mgr)
@@ -536,6 +558,7 @@ async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     assert mgr.tts_pending_chunks == []
     assert mgr._pending_ai_voice_echo_text == ""
     assert list(mgr._pending_ai_voice_echo_chunks) == []
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
     assert mgr._recent_ai_voice_echo_text == "已经播出的尾音"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -338,6 +338,18 @@ async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(mon
 
 
 @pytest.mark.unit
+def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
+    mgr = _make_transcript_manager()
+    mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
+    mgr._recent_ai_voice_echo_at = core_module.time.time()
+
+    core_module.LLMSessionManager._reset_voice_echo_suppression_cache(mgr)
+
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_at == 0.0
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_no_takeover_non_voice_transcript_reuse_keeps_existing_ordinary_flow():
     mgr = _make_transcript_manager()

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -72,9 +72,12 @@ class _FakeAliveThread:
 def _make_manager():
     mgr = object.__new__(core_module.LLMSessionManager)
     mgr.websocket = None
+    mgr.websocket_lock = None
     mgr.session = None
     mgr.sync_message_queue = _FakeQueue()
     mgr.lanlan_name = "Lan"
+    mgr.master_name = "Master"
+    mgr.emotion_pattern = core_module.re.compile("<(.*?)>")
     mgr.lock = _AsyncNullLock()
     mgr.audio_resampler = _FakeResampler()
     mgr.use_tts = False
@@ -397,6 +400,50 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._recent_ai_voice_echo_at == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_defaults_to_skip_display_echo_when_tts_enabled(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.use_tts = True
+
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "显示文本（括号也显示）")
+
+    assert mgr._current_ai_turn_text == "显示文本（括号也显示）"
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_at == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_can_explicitly_remember_voice_echo_with_tts(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.use_tts = True
+
+    await core_module.LLMSessionManager.send_lanlan_response(
+        mgr,
+        "确认已经播报的文本",
+        remember_voice_echo=True,
+    )
+
+    assert mgr._recent_ai_voice_echo_text == "确认已经播报的文本"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_lanlan_response_defaults_to_remember_echo_without_tts(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.use_tts = False
+
+    await core_module.LLMSessionManager.send_lanlan_response(mgr, "原生语音输出文本")
+
+    assert mgr._recent_ai_voice_echo_text == "原生语音输出文本"
+    assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -404,10 +404,9 @@ def test_voice_echo_suppression_cache_reset_clears_cross_session_state():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_send_lanlan_response_defaults_to_skip_display_echo_when_tts_enabled(monkeypatch):
+async def test_send_lanlan_response_defaults_to_skip_display_echo_cache(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
-    mgr.use_tts = True
 
     await core_module.LLMSessionManager.send_lanlan_response(mgr, "显示文本（括号也显示）")
 
@@ -430,19 +429,6 @@ async def test_send_lanlan_response_can_explicitly_remember_voice_echo_with_tts(
     )
 
     assert mgr._recent_ai_voice_echo_text == "确认已经播报的文本"
-    assert mgr._recent_ai_voice_echo_at == FIXED_TS
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_send_lanlan_response_defaults_to_remember_echo_without_tts(monkeypatch):
-    mgr = _make_manager()
-    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
-    mgr.use_tts = False
-
-    await core_module.LLMSessionManager.send_lanlan_response(mgr, "原生语音输出文本")
-
-    assert mgr._recent_ai_voice_echo_text == "原生语音输出文本"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 
 

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 import pytest
 
 import main_logic.core as core_module
-from main_logic.core import LLMSessionManager
 
 
 class _AsyncNullLock:
@@ -55,7 +54,7 @@ class _FakeActivityTracker:
 
 
 def _make_manager():
-    mgr = object.__new__(LLMSessionManager)
+    mgr = object.__new__(core_module.LLMSessionManager)
     mgr.websocket = None
     mgr.session = None
     mgr.sync_message_queue = _FakeQueue()
@@ -136,7 +135,7 @@ async def test_mirror_assistant_speech_text_mirror_carries_metadata():
     }
     metadata = _soccer_mirror_meta(event)
 
-    result = await LLMSessionManager.mirror_assistant_speech(
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
         mgr,
         "看我这一脚",
         metadata=metadata,
@@ -163,7 +162,7 @@ async def test_mirror_assistant_speech_text_mirror_carries_metadata():
 async def test_mirror_assistant_speech_can_leave_turn_end_to_text_mirror():
     mgr = _make_manager()
 
-    result = await LLMSessionManager.mirror_assistant_speech(
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
         mgr,
         "只播放语音",
         metadata=_soccer_mirror_meta({"kind": "user-text", "hasUserText": True}),
@@ -186,7 +185,7 @@ async def test_mirror_assistant_speech_can_leave_turn_end_to_text_mirror():
 async def test_mirror_assistant_speech_interrupt_audio_triggers_existing_interrupt_path():
     mgr = _make_manager()
 
-    result = await LLMSessionManager.mirror_assistant_speech(
+    result = await core_module.LLMSessionManager.mirror_assistant_speech(
         mgr,
         "先听我说完",
         metadata=_soccer_mirror_meta({"kind": "user-text", "hasUserText": True}),
@@ -209,7 +208,7 @@ async def test_mirror_assistant_output_can_finalize_user_reply_turn():
     event = {"kind": "user-text", "hasUserText": True}
     metadata = _soccer_mirror_meta(event)
 
-    result = await LLMSessionManager.mirror_assistant_output(
+    result = await core_module.LLMSessionManager.mirror_assistant_output(
         mgr,
         "听见啦，我会放慢一点。",
         metadata=metadata,
@@ -243,7 +242,7 @@ async def test_takeover_dispatcher_handles_voice_transcript_and_skips_ordinary_u
     mgr._takeover_active = True
     mgr._takeover_input_dispatcher = fake_dispatcher
 
-    await LLMSessionManager.handle_input_transcript(mgr, "  我要射门了  ", is_voice_source=True)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "  我要射门了  ", is_voice_source=True)
 
     assert routed and routed[0][0] == "Lan"
     assert routed[0][1] == "我要射门了"
@@ -260,7 +259,7 @@ async def test_takeover_dispatcher_handles_voice_transcript_and_skips_ordinary_u
 async def test_no_takeover_voice_transcript_uses_ordinary_flow():
     mgr = _make_transcript_manager()
 
-    await LLMSessionManager.handle_input_transcript(mgr, "  普通语音  ", is_voice_source=True)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "  普通语音  ", is_voice_source=True)
 
     assert mgr._activity_tracker.voice_rms_count == 1
     assert mgr._activity_tracker.user_messages == ["  普通语音  "]
@@ -283,7 +282,7 @@ async def test_likely_ai_echo_voice_transcript_is_suppressed(monkeypatch):
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
     mgr._recent_ai_voice_echo_at = core_module.time.time()
 
-    await LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
 
     assert mgr._activity_tracker.voice_rms_count == 0
     assert mgr._activity_tracker.user_messages == []
@@ -300,7 +299,7 @@ async def test_ai_echo_voice_transcript_switch_can_disable_suppression(monkeypat
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
     mgr._recent_ai_voice_echo_at = core_module.time.time()
 
-    await LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
 
     assert mgr._activity_tracker.voice_rms_count == 1
     assert mgr._activity_tracker.user_messages == ["要不要休息一下喝点水"]
@@ -323,7 +322,7 @@ async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(mon
     mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
     mgr._recent_ai_voice_echo_at = core_module.time.time()
 
-    await LLMSessionManager.handle_input_transcript(mgr, "先别休息帮我打开设置", is_voice_source=True)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "先别休息帮我打开设置", is_voice_source=True)
 
     assert mgr._activity_tracker.voice_rms_count == 1
     assert mgr._activity_tracker.user_messages == ["先别休息帮我打开设置"]
@@ -343,7 +342,7 @@ async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(mon
 async def test_no_takeover_non_voice_transcript_reuse_keeps_existing_ordinary_flow():
     mgr = _make_transcript_manager()
 
-    await LLMSessionManager.handle_input_transcript(mgr, "文本复用", is_voice_source=False)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "文本复用", is_voice_source=False)
 
     assert mgr._activity_tracker.voice_rms_count == 0
     assert mgr._activity_tracker.user_messages == []
@@ -366,7 +365,7 @@ async def test_takeover_dispatcher_does_not_intercept_non_voice_transcript_reuse
     mgr._takeover_active = True
     mgr._takeover_input_dispatcher = fail_dispatcher
 
-    await LLMSessionManager.handle_input_transcript(mgr, "文本复用", is_voice_source=False)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "文本复用", is_voice_source=False)
 
     assert mgr._activity_tracker.voice_rms_count == 0
     assert mgr._activity_tracker.user_messages == []
@@ -393,7 +392,7 @@ async def test_takeover_dispatcher_falls_back_when_unhandled(dispatcher_outcome)
     mgr._takeover_active = True
     mgr._takeover_input_dispatcher = fake_dispatcher
 
-    await LLMSessionManager.handle_input_transcript(mgr, "继续普通流程", is_voice_source=True)
+    await core_module.LLMSessionManager.handle_input_transcript(mgr, "继续普通流程", is_voice_source=True)
 
     assert mgr._activity_tracker.voice_rms_count == 1
     assert mgr._activity_tracker.user_messages == ["继续普通流程"]
@@ -418,7 +417,7 @@ async def test_takeover_response_complete_clears_interrupted_ordinary_turn():
     mgr.tts_pending_chunks = [("sid-old", "queued text")]
     mgr._takeover_active = True
 
-    await LLMSessionManager.handle_response_complete(mgr)
+    await core_module.LLMSessionManager.handle_response_complete(mgr)
 
     assert mgr._active_text_request_id is None
     assert mgr._pending_turn_meta is None

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -43,6 +43,14 @@ class _FakeQueue:
     def put(self, message):
         self.messages.append(message)
 
+    def empty(self):
+        return not self.messages
+
+    def get_nowait(self):
+        if not self.messages:
+            raise IndexError("empty queue")
+        return self.messages.pop(0)
+
 
 class _FakeActivityTracker:
     def __init__(self):
@@ -81,8 +89,15 @@ def _make_manager():
     mgr._recent_ai_voice_echo_at = 0.0
     mgr.tts_ready = False
     mgr.tts_thread = None
+    mgr.tts_request_queue = _FakeQueue()
+    mgr.tts_response_queue = _FakeQueue()
     mgr.tts_pending_chunks = []
     mgr.tts_cache_lock = _AsyncNullLock()
+    mgr._tts_stream_normalizer = core_module.TtsStreamNormalizer()
+    mgr._tts_markdown_stripper = core_module.TtsMarkdownStripper()
+    mgr._tts_bracket_stripper = core_module.TtsBracketStripper()
+    mgr._tts_norm_speech_id = None
+    mgr._tts_normalize_enabled = False
     mgr.tts_handler_task = None
     mgr._takeover_active = False
     mgr._takeover_input_dispatcher = None
@@ -411,6 +426,24 @@ async def test_mirror_assistant_speech_remembers_audio_echo_when_tts_queued(monk
     assert mgr.tts_request_queue.messages[0][1] == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_clear_tts_pipeline_drops_unplayed_echo_cache(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.tts_thread = _FakeAliveThread()
+    mgr._recent_ai_voice_echo_text = "还没来得及播放的队列文本"
+    mgr._recent_ai_voice_echo_at = FIXED_TS
+    mgr.tts_pending_chunks = [("sid-old", "pending text")]
+
+    await core_module.LLMSessionManager._clear_tts_pipeline(mgr)
+
+    assert mgr.tts_request_queue.messages == [("__interrupt__", None)]
+    assert mgr.tts_pending_chunks == []
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._recent_ai_voice_echo_at == 0.0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -590,6 +590,37 @@ async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_failed_tts_audio_send_drops_unplayed_pending_echo(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.tts_response_queue = queue.Queue()
+    mgr.tts_response_queue.put(("__audio__", "speech-1", b"failed-audio"))
+    send_called = asyncio.Event()
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "unplayed pending text")
+
+    async def send_speech(audio, speech_id=None):
+        assert audio == b"failed-audio"
+        assert speech_id == "speech-1"
+        send_called.set()
+        return False
+
+    monkeypatch.setattr(mgr, "send_speech", send_speech)
+
+    task = asyncio.create_task(core_module.LLMSessionManager.tts_response_handler(mgr))
+    await asyncio.wait_for(send_called.wait(), timeout=1)
+    task.cancel()
+    cancelled_result = await asyncio.gather(task, return_exceptions=True)
+    assert isinstance(cancelled_result[0], asyncio.CancelledError)
+
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._pending_ai_voice_echo_text == ""
+    assert list(mgr._pending_ai_voice_echo_chunks) == []
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_clear_tts_pipeline_drops_only_unplayed_echo_cache(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
+import main_logic.core as core_module
 from main_logic.core import LLMSessionManager
 
 
@@ -69,6 +70,8 @@ def _make_manager():
     mgr._active_text_request_id = None
     mgr._pending_turn_meta = None
     mgr._current_ai_turn_text = ""
+    mgr._recent_ai_voice_echo_text = ""
+    mgr._recent_ai_voice_echo_at = 0.0
     mgr.tts_ready = False
     mgr.tts_thread = None
     mgr.tts_pending_chunks = []
@@ -269,6 +272,69 @@ async def test_no_takeover_voice_transcript_uses_ordinary_flow():
     assert mgr.sync_message_queue.messages == [{
         "type": "user",
         "data": {"input_type": "transcript", "data": "普通语音"},
+    }]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_likely_ai_echo_voice_transcript_is_suppressed(monkeypatch):
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
+    mgr._recent_ai_voice_echo_at = core_module.time.time()
+
+    await LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
+
+    assert mgr._activity_tracker.voice_rms_count == 0
+    assert mgr._activity_tracker.user_messages == []
+    assert mgr._session_turn_count == 0
+    mgr._publish_user_utterance_to_plugin_bus.assert_not_called()
+    assert mgr.sync_message_queue.messages == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ai_echo_voice_transcript_switch_can_disable_suppression(monkeypatch):
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", False)
+    mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
+    mgr._recent_ai_voice_echo_at = core_module.time.time()
+
+    await LLMSessionManager.handle_input_transcript(mgr, "要不要休息一下喝点水", is_voice_source=True)
+
+    assert mgr._activity_tracker.voice_rms_count == 1
+    assert mgr._activity_tracker.user_messages == ["要不要休息一下喝点水"]
+    assert mgr._session_turn_count == 1
+    mgr._publish_user_utterance_to_plugin_bus.assert_called_once_with(
+        "要不要休息一下喝点水",
+        is_voice_source=True,
+    )
+    assert mgr.sync_message_queue.messages == [{
+        "type": "user",
+        "data": {"input_type": "transcript", "data": "要不要休息一下喝点水"},
+    }]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_user_barge_in_different_from_recent_ai_text_is_not_suppressed(monkeypatch):
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    mgr._recent_ai_voice_echo_text = "刚才我主动说了一句：要不要休息一下喝点水。"
+    mgr._recent_ai_voice_echo_at = core_module.time.time()
+
+    await LLMSessionManager.handle_input_transcript(mgr, "先别休息帮我打开设置", is_voice_source=True)
+
+    assert mgr._activity_tracker.voice_rms_count == 1
+    assert mgr._activity_tracker.user_messages == ["先别休息帮我打开设置"]
+    assert mgr._session_turn_count == 1
+    mgr._publish_user_utterance_to_plugin_bus.assert_called_once_with(
+        "先别休息帮我打开设置",
+        is_voice_source=True,
+    )
+    assert mgr.sync_message_queue.messages == [{
+        "type": "user",
+        "data": {"input_type": "transcript", "data": "先别休息帮我打开设置"},
     }]
 
 

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -580,8 +580,8 @@ async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
     task = asyncio.create_task(core_module.LLMSessionManager.tts_response_handler(mgr))
     await asyncio.wait_for(send_called.wait(), timeout=1)
     task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    cancelled_result = await asyncio.gather(task, return_exceptions=True)
+    assert isinstance(cancelled_result[0], asyncio.CancelledError)
 
     assert mgr._recent_ai_voice_echo_text == ""
     assert mgr._pending_ai_voice_echo_text == "new turn pending text"

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -288,6 +288,38 @@ async def test_takeover_dispatcher_handles_voice_transcript_and_skips_ordinary_u
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_takeover_dispatcher_receives_voice_echo_match_before_suppression(monkeypatch):
+    mgr = _make_transcript_manager()
+    monkeypatch.setattr(core_module, "HIDE_DIRTY_VOICE_TRANSCRIPTS", True)
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr._recent_ai_voice_echo_text = "开始比赛吧朋友"
+    mgr._recent_ai_voice_echo_at = FIXED_TS
+    routed = []
+
+    async def fake_dispatcher(lanlan_name, text, *, request_id):
+        routed.append((lanlan_name, text, request_id))
+        return True
+
+    mgr._takeover_active = True
+    mgr._takeover_input_dispatcher = fake_dispatcher
+
+    await core_module.LLMSessionManager.handle_input_transcript(
+        mgr,
+        "开始比赛吧朋友",
+        is_voice_source=True,
+    )
+
+    assert routed and routed[0][1] == "开始比赛吧朋友"
+    assert routed[0][2].startswith("realtime-stt-")
+    assert mgr._activity_tracker.voice_rms_count == 1
+    assert mgr._activity_tracker.user_messages == []
+    assert mgr._session_turn_count == 0
+    mgr._publish_user_utterance_to_plugin_bus.assert_not_called()
+    assert mgr.sync_message_queue.messages == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_no_takeover_voice_transcript_uses_ordinary_flow():
     mgr = _make_transcript_manager()
 
@@ -614,7 +646,7 @@ async def test_text_first_chunk_drops_stale_pending_echo_before_new_tts(monkeypa
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
+async def test_sidless_tts_audio_discards_pending_echo(monkeypatch):
     mgr = _make_manager()
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr.tts_response_queue = queue.Queue()
@@ -639,8 +671,9 @@ async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
     assert isinstance(cancelled_result[0], asyncio.CancelledError)
 
     assert mgr._recent_ai_voice_echo_text == ""
-    assert mgr._pending_ai_voice_echo_text == "new turn pending text"
-    assert list(mgr._pending_ai_voice_echo_chunks) == [("new-turn", "new turn pending text")]
+    assert mgr._pending_ai_voice_echo_text == ""
+    assert list(mgr._pending_ai_voice_echo_chunks) == []
+    assert mgr._confirmed_ai_voice_echo_audio_speech_ids == set()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import deque
 import queue
 from unittest.mock import Mock
@@ -537,6 +538,37 @@ def test_confirm_pending_ai_voice_echo_promotes_once_per_speech_id(monkeypatch):
     assert mgr._recent_ai_voice_echo_text == "第一段文本"
     assert mgr._pending_ai_voice_echo_text == "第二段未播文本"
     assert list(mgr._pending_ai_voice_echo_chunks) == ["第二段未播文本"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sidless_tts_audio_does_not_confirm_pending_echo(monkeypatch):
+    mgr = _make_manager()
+    monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
+    mgr.tts_response_queue = queue.Queue()
+    mgr.tts_response_queue.put(b"sidless-audio")
+    mgr.current_speech_id = "new-turn"
+    send_called = asyncio.Event()
+
+    core_module.LLMSessionManager._remember_pending_ai_voice_echo(mgr, "new turn pending text")
+
+    async def send_speech(audio, speech_id=None):
+        assert audio == b"sidless-audio"
+        assert speech_id is None
+        send_called.set()
+        return True
+
+    monkeypatch.setattr(mgr, "send_speech", send_speech)
+
+    task = asyncio.create_task(core_module.LLMSessionManager.tts_response_handler(mgr))
+    await asyncio.wait_for(send_called.wait(), timeout=1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert mgr._recent_ai_voice_echo_text == ""
+    assert mgr._pending_ai_voice_echo_text == "new turn pending text"
+    assert list(mgr._pending_ai_voice_echo_chunks) == ["new turn pending text"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_core_game_route_memory_contract.py
+++ b/tests/unit/test_core_game_route_memory_contract.py
@@ -391,20 +391,16 @@ async def test_mirror_assistant_speech_remembers_audio_echo_when_tts_queued(monk
     monkeypatch.setattr(core_module.time, "time", lambda: FIXED_TS)
     mgr.tts_thread = _FakeAliveThread()
     mgr.tts_ready = True
-    enqueued = []
-
-    def enqueue_tts_text_chunk(speech_id, text):
-        enqueued.append((speech_id, text))
-
-    def request_tts_done_locked():
-        return "queued"
-
-    mgr._enqueue_tts_text_chunk = enqueue_tts_text_chunk
-    mgr._request_tts_done_locked = request_tts_done_locked
+    mgr.tts_request_queue = _FakeQueue()
+    mgr._tts_stream_normalizer = core_module.TtsStreamNormalizer()
+    mgr._tts_markdown_stripper = core_module.TtsMarkdownStripper()
+    mgr._tts_bracket_stripper = core_module.TtsBracketStripper()
+    mgr._tts_norm_speech_id = None
+    mgr._tts_normalize_enabled = False
 
     result = await core_module.LLMSessionManager.mirror_assistant_speech(
         mgr,
-        "要不要休息一下喝点水",
+        "要不要休息一下（这句不会念）喝点水",
         metadata=_soccer_mirror_meta({"kind": "opening-line"}),
         request_id="req-mirror-voice",
         mirror_text=False,
@@ -412,7 +408,7 @@ async def test_mirror_assistant_speech_remembers_audio_echo_when_tts_queued(monk
     )
 
     assert result["audio_queued"] is True
-    assert enqueued and enqueued[0][1] == "要不要休息一下喝点水"
+    assert mgr.tts_request_queue.messages[0][1] == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_text == "要不要休息一下喝点水"
     assert mgr._recent_ai_voice_echo_at == FIXED_TS
 


### PR DESCRIPTION
## Summary

- add a config switch, `HIDE_DIRTY_VOICE_TRANSCRIPTS`, for hiding likely dirty voice transcripts
- cache recent assistant text and suppress voice STT only when it closely matches that recent AI output
- cover the echo path, disabled-switch path, and normal user barge-in path with unit tests

## Why

Voice chat and proactive speech can leak back through the microphone as user transcripts. Those dirty transcripts should not show as user bubbles, enter ordinary memory, or reset proactive backoff.

The suppression is conservative: unrelated user speech during AI playback still flows through normally.

## Validation

- `uv run pytest tests/unit/test_proactive_sid_guard.py tests/unit/test_core_game_route_memory_contract.py -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加可配置的语音回声抑制开关（默认开启），在转录与近期助手输出高度相似且时间接近时自动屏蔽疑似回声。
  * 引入会话级回声生命周期：区分待确认与已确认播报，仅在实际播放确认后将文本记为近期助手输出。

* **缺陷修复**
  * 优化播报发送与确认流程：播放失败、中断或未确认时丢弃待确认回声，避免误触发后续转录屏蔽。

* **测试**
  * 扩展单元测试，覆盖抑制规则、确认/丢弃逻辑及缓存重置场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->