### PR TITLE
feat(activity): 工作模式下加喝水/防摸鱼提醒 + idle tone 改 playful

### DIFF
--- a/config/prompts_activity.py
+++ b/config/prompts_activity.py
@@ -715,3 +715,156 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         'time_only_fmt': '{time}',
     },
 }
+
+
+# ── Break-reminder seeds + prompt templates ─────────────────────────
+#
+# Two reminder paths emitted by the activity tracker (see
+# main_logic/activity/tracker.py). Both bypass Phase 1 entirely and
+# render via a minimal Phase 2 (only character_prompt + the env-notice
+# block below) so the model can focus on the single nudge instead of
+# juggling sources.
+#
+# Why a seed list for water-break but not anti-slack:
+#   * Water-break covers genuinely different actions ("drink water",
+#     "stretch", "rest eyes", ...) — the seed names *what* to suggest.
+#     Picked at delivery time so consecutive deliveries vary.
+#   * Anti-slack is one behaviour ("get back to work") — variation
+#     comes from {prev_app}/{new_app}/{minutes} + the AI's persona.
+#     A seed list of synonyms would just be tone-painting, which the
+#     model already does on its own.
+
+WORK_BREAK_SEED_HINTS: dict[str, list[str]] = {
+    'zh': ['喝口水', '活动一下', '休息下眼睛', '伸个懒腰', '放松一下'],
+    'en': ['drink some water', 'stretch a bit', 'rest their eyes', 'roll their shoulders', 'unwind for a sec'],
+    'ja': ['水を一口飲む', '少し体を動かす', '目を休める', '伸びをする', 'ちょっと一息つく'],
+    'ko': ['물 한 모금 마시기', '잠깐 몸 풀기', '눈을 좀 쉬게 하기', '기지개 켜기', '잠깐 한숨 돌리기'],
+    'ru': ['выпить воды', 'размять тело', 'дать глазам отдохнуть', 'потянуться', 'перевести дух'],
+}
+
+
+# Fallback label when an active window has no canonical name (rare —
+# usually only the GPU-fallback gaming branch and bare-desktop foregrounds
+# hit this). Used to fill ``{app}`` / ``{prev_app}`` / ``{new_app}`` in
+# the templates below so the slot doesn't render as ``?`` or empty.
+WORK_BREAK_GENERIC_WORK_LABEL: dict[str, str] = {
+    'zh': '手头上的活',
+    'en': 'their work',
+    'ja': '今の作業',
+    'ko': '하던 일',
+    'ru': 'своими делами',
+}
+
+WORK_BREAK_GENERIC_LEISURE_LABEL: dict[str, str] = {
+    'zh': '别的事情',
+    'en': 'something else',
+    'ja': 'ほかのこと',
+    'ko': '다른 것',
+    'ru': 'что-то другое',
+}
+
+
+# Water-break (regular drink/stretch nudge) Phase 2 system prompt.
+# Placeholders: {master} {app} {minutes} {seed}
+# Style modeled on GREETING_PROMPT_SHORT — set the scene, name the
+# motivation, hand the AI personality the wheel. Same ========以下是
+# 环境提示======== / Below is Environment Notice / 以下は環境通知 /
+# 아래는 환경 알림 / Ниже Уведомление delimiters as the greeting set,
+# kept below/above paired per the prompt-delimiter convention.
+WORK_BREAK_REMINDER_PROMPT: dict[str, str] = {
+    'zh': '========以下是环境提示========\n'
+          '{master}已经在{app}专注工作{minutes}分钟了。\n'
+          '你看着{master}有点心疼，想提醒{master}{seed}。\n'
+          '用符合你性格的方式自然搭话吧。直接说出你想说的话，简短自然即可，不要生成思考过程。\n'
+          '========以上是环境提示========',
+    'en': '========Below is Environment Notice========\n'
+          '{master} has been focused on {app} for {minutes} minutes.\n'
+          'Watching {master}, you feel a little worried and want to suggest {master} {seed}.\n'
+          'Talk to {master} in your own way, naturally. Just say what you want to say, keep it short and natural. Do not generate thinking process.\n'
+          '========Above is Environment Notice========',
+    'ja': '========以下は環境通知========\n'
+          '{master}は{app}に{minutes}分間ずっと集中している。\n'
+          '少し心配になって、{master}に{seed}よう勧めたい気持ち。\n'
+          '自分らしいやり方で自然に話しかけて。言いたいことをそのまま短く自然に。思考プロセスは生成しないで。\n'
+          '========以上は環境通知========',
+    'ko': '========아래는 환경 알림========\n'
+          '{master}가 {app}에 {minutes}분 동안 계속 집중하고 있다.\n'
+          '바라보다 보니 조금 걱정돼서, {master}에게 {seed} 권하고 싶다.\n'
+          '너다운 방식으로 자연스럽게 말을 걸어. 하고 싶은 말을 짧고 자연스럽게. 사고 과정은 생성하지 마.\n'
+          '========위는 환경 알림========',
+    'ru': '========Ниже Уведомление========\n'
+          '{master} уже {minutes} минут сосредоточенно работает в {app}.\n'
+          'Глядя на {master}, ты немного беспокоишься и хочешь предложить {master} {seed}.\n'
+          'Заговори с {master} так, как тебе свойственно. Просто скажи что хочешь — коротко и естественно. Не генерируй процесс размышлений.\n'
+          '========Выше Уведомление========',
+}
+
+
+# Anti-slack (just-left-focused-work) Phase 2 system prompt.
+# Placeholders: {master} {prev_app} {new_app} {minutes}
+# No seed slot — single behaviour, variation comes from app names +
+# minute count + AI persona. Same delimiter convention as the water-
+# break template above.
+ANTI_SLACK_REMINDER_PROMPT: dict[str, str] = {
+    'zh': '========以下是环境提示========\n'
+          '{master}刚才在{prev_app}专注工作{minutes}分钟，转头就切去了{new_app}。\n'
+          '你觉得{master}才进入状态就开始溜号，想拦一下，让{master}回去继续干完。\n'
+          '用符合你性格的方式半带玩笑提醒一下吧。直接说出你想说的话，简短自然即可，不要生成思考过程。\n'
+          '========以上是环境提示========',
+    'en': '========Below is Environment Notice========\n'
+          '{master} just spent {minutes} minutes focused on {prev_app}, then switched straight to {new_app}.\n'
+          'You feel {master} just hit their stride and is already drifting off — you want to pull {master} back to finish up.\n'
+          'Tease {master} a bit in your own way. Just say what you want to say, keep it short and natural. Do not generate thinking process.\n'
+          '========Above is Environment Notice========',
+    'ja': '========以下は環境通知========\n'
+          '{master}はさっきまで{prev_app}で{minutes}分間集中していたのに、急に{new_app}に切り替えた。\n'
+          'やっと調子が出てきたところでサボろうとしているように見えて、引き戻して続きをやらせたい気持ち。\n'
+          '自分らしいやり方でちょっと冗談めかして突っ込んで。言いたいことをそのまま短く自然に。思考プロセスは生成しないで。\n'
+          '========以上は環境通知========',
+    'ko': '========아래는 환경 알림========\n'
+          '{master}가 방금 {prev_app}에서 {minutes}분 동안 집중하고 있었는데 갑자기 {new_app}로 옮겼다.\n'
+          '이제 막 흐름을 탔는데 벌써 딴짓하려는 것 같아서, 끌어다가 마무리하게 하고 싶다.\n'
+          '너다운 방식으로 살짝 장난치듯 잡아끌어. 하고 싶은 말을 짧고 자연스럽게. 사고 과정은 생성하지 마.\n'
+          '========위는 환경 알림========',
+    'ru': '========Ниже Уведомление========\n'
+          '{master} только что сосредоточенно работал в {prev_app} {minutes} минут — и тут же переключился на {new_app}.\n'
+          'Тебе кажется, {master} только-только вошёл в ритм и уже отлынивает; хочется вернуть его и не дать бросить начатое.\n'
+          'Поддразни {master} так, как тебе свойственно. Просто скажи что хочешь — коротко и естественно. Не генерируй процесс размышлений.\n'
+          '========Выше Уведомление========',
+}
+
+
+# Water-break + game-invite combo prompt (50% branch).
+# Mirrors MINI_GAME_INVITE_LINES_BY_GAME shape: per game_type → per
+# locale. Adding a new game_type is a single-pass extension matching
+# the existing mini-game invite structure.
+# Placeholders: {master} {app} {minutes}
+WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME: dict[str, dict[str, str]] = {
+    'soccer': {
+        'zh': '========以下是环境提示========\n'
+              '{master}已经在{app}专注工作{minutes}分钟了。\n'
+              '你想让{master}停下来歇一会儿，顺便邀请{master}陪你玩一局足球小游戏放松一下。\n'
+              '用符合你性格的方式自然搭话吧——既要让{master}感觉到关心，也要把"一起玩一局"的邀请说出来。直接说出你想说的话，简短自然即可，不要生成思考过程。\n'
+              '========以上是环境提示========',
+        'en': '========Below is Environment Notice========\n'
+              '{master} has been focused on {app} for {minutes} minutes.\n'
+              'You want {master} to take a break — and you want to invite {master} to play a quick round of the soccer mini-game with you to unwind.\n'
+              'Talk to {master} in your own way, naturally — show that you care AND make the invite to play together clear. Just say what you want to say, keep it short and natural. Do not generate thinking process.\n'
+              '========Above is Environment Notice========',
+        'ja': '========以下は環境通知========\n'
+              '{master}は{app}に{minutes}分間ずっと集中している。\n'
+              '少し休ませてあげたくて、ついでにサッカーのミニゲームを一緒にやろうって誘いたい気持ち。\n'
+              '自分らしいやり方で自然に話しかけて——気にかけている雰囲気を出しつつ、「一緒に一局やろう」と誘う言葉を入れてね。言いたいことをそのまま短く自然に。思考プロセスは生成しないで。\n'
+              '========以上は環境通知========',
+        'ko': '========아래는 환경 알림========\n'
+              '{master}가 {app}에 {minutes}분 동안 계속 집중하고 있다.\n'
+              '잠깐 쉬게 하고 싶고, 겸사겸사 같이 축구 미니게임 한 판 하자고 권하고 싶다.\n'
+              '너다운 방식으로 자연스럽게 말을 걸어 — 걱정하는 마음을 보이면서 "같이 한 판 하자"는 초대도 분명히 담아. 하고 싶은 말을 짧고 자연스럽게. 사고 과정은 생성하지 마.\n'
+              '========위는 환경 알림========',
+        'ru': '========Ниже Уведомление========\n'
+              '{master} уже {minutes} минут сосредоточенно работает в {app}.\n'
+              'Хочется дать {master} отдохнуть — и заодно позвать его сыграть одну партию в мини-футбол, чтобы развеяться.\n'
+              'Заговори с {master} так, как тебе свойственно — пусть {master} почувствует заботу, и обязательно прозвучит приглашение «сыграем разок». Просто скажи что хочешь — коротко и естественно. Не генерируй процесс размышлений.\n'
+              '========Выше Уведомление========',
+    },
+}

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -134,6 +134,40 @@ class WindowObservation:
 
 
 @dataclass(frozen=True, slots=True)
+class WorkBreakPending:
+    """A water-break reminder is ready to fire on the next proactive turn.
+
+    Set by the tracker when its focused_work accumulator crosses
+    ``work_break_minutes`` (default 30) AND the live state is
+    ``focused_work``. Cleared by ``mark_work_break_used`` once the
+    reminder is delivered (which also resets the accumulator).
+
+    The seed for *what* to suggest (drink water / stretch / rest eyes /
+    etc.) is picked at delivery time in the router — not pinned here —
+    so consecutive failed-then-retried deliveries naturally rotate copy.
+    """
+    minutes: int                # Accumulated focused-work minutes
+    app: str                    # Canonical app the user is focused in (or generic fallback)
+
+
+@dataclass(frozen=True, slots=True)
+class AntiSlackPending:
+    """A "back to work" reminder is queued by a recent focused→leisure transition.
+
+    Set by the tracker when state transitions
+    ``focused_work → casual_browsing | gaming`` after at least
+    ``anti_slack_min_focus_minutes`` (default 5) of focused work and
+    while the per-character anti-slack cooldown has elapsed (default
+    15 min). Cleared by ``mark_anti_slack_used``, by the pending
+    window expiring (default 5 min), or by the user returning to
+    focused_work / a non-leisure state.
+    """
+    minutes: int                # How long the just-ended focused_work session was
+    prev_app: str               # Canonical name of the work app they left
+    new_app: str                # Canonical name of the leisure app they switched to
+
+
+@dataclass(frozen=True, slots=True)
 class UnfinishedThread:
     """An open conversation thread the AI may follow up on.
 
@@ -267,6 +301,17 @@ class ActivitySnapshot:
     # threads, etc.). Cache invalidates on the next user message.
     open_threads: list[str] = field(default_factory=list)
 
+    # --- Break-reminder pending flags (must-fire over normal proactive) ---
+    # When either is non-None on a snapshot fetched at proactive_chat
+    # entry, the router takes the dedicated minimal-Phase-2 delivery
+    # branch (skipping Phase 1 source fetching, propensity gating, and
+    # skip_probability rolls). Anti-slack outranks water-break — the
+    # transition trigger is more time-sensitive than the cumulative one.
+    # Populated/cleared exclusively by ``main_logic/activity/tracker.py``;
+    # see WorkBreakPending / AntiSlackPending docstrings for lifecycle.
+    work_break_pending: WorkBreakPending | None = None
+    anti_slack_pending: AntiSlackPending | None = None
+
 
 # ── State → propensity mapping ──────────────────────────────────────
 
@@ -372,11 +417,17 @@ def derive_tone(
             return 'playful'
         # game_intensity in {'varied', None}
         return 'concise'
-    if state in ('casual_browsing',):
+    if state in ('casual_browsing', 'idle'):
+        # Idle while the desk pet is foreground = the user is around but
+        # not driving any task. Pairing it with ``concise`` reads as
+        # businesslike when the natural register is light banter — same
+        # as casual_browsing. ``transitioning`` and ``away`` stay on
+        # ``concise`` deliberately: the former is mid-context-switch
+        # (short reactive lines fit), the latter doesn't render anyway.
         return 'playful'
     if state in ('chatting', 'stale_returning'):
         return 'warm'
-    # focused_work / idle / transitioning / away
+    # focused_work / transitioning / away
     return 'concise'
 
 

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -40,7 +40,9 @@ import time
 from collections import deque
 from dataclasses import replace as dc_replace
 
-from main_logic.activity.snapshot import ActivitySnapshot
+from main_logic.activity.snapshot import (
+    ActivitySnapshot, ActivityState, AntiSlackPending, WorkBreakPending,
+)
 from main_logic.activity.state_machine import (
     ActivityStateMachine, observation_from_system,
 )
@@ -71,6 +73,57 @@ _ACTIVITY_GUESS_MIN_REFRESH_SECONDS = 30.0
 # (which on remote deployments will be in degraded mode) — better to
 # advertise "no signal" than to keep using stale window data.
 _EXTERNAL_SIGNAL_TTL_SECONDS = 30.0
+
+
+# ── Break-reminder defaults ─────────────────────────────────────────
+# Override per-character via ``user_preferences.json::__global_conversation__::activity::thresholds``.
+# All values are minutes / seconds; the probability has its own dedicated
+# field on ``ActivityPreferences`` because 0 is meaningful (disabled) and
+# the threshold parser rejects ≤0.
+
+# Cumulative focused_work minutes that arms the water-break reminder.
+# Once armed, the next proactive_chat round in focused_work fires the
+# minimal-Phase-2 nudge and resets the accumulator.
+_WORK_BREAK_MINUTES = 30
+
+# How long a queued ``WorkBreakPending`` stays valid if proactive_chat
+# never fires. After this window the pending is dropped (the user has
+# clearly stopped focusing or the moment passed); the accumulator stays
+# at its current value so the next focused_work stretch can re-arm.
+_WORK_BREAK_PENDING_WINDOW_SECONDS = 5 * 60
+
+# Minimum focused_work session length before exiting it can fire an
+# anti-slack reminder. Below this, the user probably opened the wrong
+# window by accident — don't lecture them.
+_ANTI_SLACK_MIN_FOCUS_MINUTES = 5
+
+# Per-character cooldown after a successful anti-slack delivery. Decoupled
+# from the water-break / mini-game cooldowns so the two reminder types
+# don't accidentally throttle each other.
+_ANTI_SLACK_COOLDOWN_MINUTES = 15
+
+# How long a queued ``AntiSlackPending`` stays valid. The transition is
+# the trigger; if proactive doesn't fire within this window the moment
+# is gone (user has already settled into the new activity for a while).
+_ANTI_SLACK_PENDING_WINDOW_SECONDS = 5 * 60
+
+# Probability that a fired water-break reminder pivots into a "rest +
+# mini-game invite" branch instead of the regular drink/stretch nudge.
+# Falls through to ActivityPreferences override (0 disables).
+_WORK_BREAK_GAME_INVITE_PROBABILITY = 0.5
+
+# Cap on per-tick accumulator advance. Filters clock jumps / process
+# suspends / first-call jitter so a long gap between ticks doesn't
+# silently credit minutes the user didn't actually spend focused.
+_BREAK_REMINDER_TICK_MAX_DELTA_SECONDS = 30.0
+
+# States that count as "leisure" for anti-slack transition detection.
+# Idle is intentionally excluded — sitting at the desk staring is often
+# thinking, not slacking — as are voice_engaged / chatting (they are
+# producing). transitioning is excluded because it's not an end state.
+_ANTI_SLACK_LEISURE_STATES: frozenset[str] = frozenset({
+    'casual_browsing', 'gaming',
+})
 
 
 def _privacy_mode_active() -> bool:
@@ -160,6 +213,53 @@ class UserActivityTracker:
         # (which on a remote backend reports os_signals_available=False
         # and the state machine's snapshot makes that explicit).
         self._external_system_snap: SystemSnapshot | None = None
+
+        # ── Break-reminder accumulator + transition tracking ────────
+        # Single timestamp drives both: each tick computes
+        # ``now - _break_tick_last_at`` and credits the delta (capped) to
+        # the appropriate timer based on the current state. 0.0 = "first
+        # tick, no delta to credit yet".
+        self._break_tick_last_at: float = 0.0
+
+        # Cumulative focused_work seconds. Accumulates while state ==
+        # focused_work, OR state == transitioning AND accumulator > 0
+        # (transitioning extends an in-progress focus session — quick
+        # window flicks don't break the timer). Any other state resets
+        # to 0 immediately. See ``_tick_break_reminders``.
+        self._work_acc_seconds: float = 0.0
+
+        # State + session bookkeeping. ``_last_known_state`` lets us
+        # detect transitions across ticks; ``_focused_work_session_*``
+        # let us report how long the just-ended focused_work session
+        # was when an anti-slack transition fires.
+        self._last_known_state: ActivityState | None = None
+        self._focused_work_session_started_at: float | None = None
+        self._focused_work_session_app: str | None = None
+
+        # Anti-slack cooldown: epoch time of the last successful
+        # delivery. Until ``now - this >= cooldown_seconds`` no new
+        # AntiSlackPending is emitted (the cooldown gate runs at
+        # transition-detection time, not at delivery — symmetrical with
+        # the mini-game invite cooldown shape).
+        self._anti_slack_last_fired_at: float = 0.0
+
+        # Pending payloads. Lifecycle:
+        #   * Set when conditions trigger (water: focused_work +
+        #     accumulator past threshold; anti-slack: focused_work →
+        #     leisure transition past min focus + cooldown OK).
+        #   * Cleared by ``mark_work_break_used`` /
+        #     ``mark_anti_slack_used`` after successful delivery.
+        #   * Auto-cleared at tick time when the validity window
+        #     (``_WORK_BREAK_PENDING_WINDOW_SECONDS`` / ``_ANTI_SLACK_*``)
+        #     expires or the state changes to one that invalidates the
+        #     pending (e.g. anti-slack pending dies if user returns
+        #     to focused_work).
+        # Stored as dicts (not frozen dataclasses) so we can stamp a
+        # ``set_at`` timestamp for window-expiry checks; the snapshot
+        # builds the frozen WorkBreakPending / AntiSlackPending from
+        # these.
+        self._work_break_pending: dict | None = None
+        self._anti_slack_pending: dict | None = None
 
     # ── hooks (called from core.py and friends) ─────────────────
 
@@ -316,6 +416,11 @@ class UserActivityTracker:
         )
 
         snap = self._sm.get_snapshot(now=ts)
+        # Tick break-reminder accumulator + transition detection BEFORE
+        # building pending fields. Done after sm.get_snapshot so we have
+        # the resolved state (focused_work / leisure / etc) to drive
+        # accumulator and transition logic.
+        self._tick_break_reminders(snap, now=ts)
         if snap.state == 'private':
             # Privacy lockdown — explicitly empty enrichment fields rather
             # than splicing in caches built from earlier (non-private)
@@ -323,11 +428,15 @@ class UserActivityTracker:
             # at update_window, the cached enrichment narrative might
             # still reference what the user was doing 30s ago, which
             # could leak intent ("master is logging into bank...").
+            # Pending break-reminder fields also dropped — no proactive
+            # interrupt while a sensitive app is foreground.
             return dc_replace(
                 snap,
                 activity_scores={},
                 activity_guess='',
                 open_threads=[],
+                work_break_pending=None,
+                anti_slack_pending=None,
             )
         # Patch in emotion-tier enrichment caches. ``snap`` is a frozen
         # dataclass; ``replace`` returns a new instance without mutating
@@ -337,6 +446,8 @@ class UserActivityTracker:
             activity_scores=dict(self._activity_scores_cache),
             activity_guess=self._activity_guess_cache,
             open_threads=list(self._open_threads_cache),
+            work_break_pending=self._build_work_break_pending(),
+            anti_slack_pending=self._build_anti_slack_pending(),
         )
 
     def get_snapshot_sync(self, *, now: float | None = None) -> ActivitySnapshot:
@@ -361,19 +472,249 @@ class UserActivityTracker:
             now=ts,
         )
         snap = self._sm.get_snapshot(now=ts)
+        self._tick_break_reminders(snap, now=ts)
         if snap.state == 'private':
             return dc_replace(
                 snap,
                 activity_scores={},
                 activity_guess='',
                 open_threads=[],
+                work_break_pending=None,
+                anti_slack_pending=None,
             )
         return dc_replace(
             snap,
             activity_scores=dict(self._activity_scores_cache),
             activity_guess=self._activity_guess_cache,
             open_threads=list(self._open_threads_cache),
+            work_break_pending=self._build_work_break_pending(),
+            anti_slack_pending=self._build_anti_slack_pending(),
         )
+
+    # ── break-reminder accumulator + transition detection ──────────
+
+    def _tick_break_reminders(self, snap: ActivitySnapshot, *, now: float) -> None:
+        """Advance the focused_work accumulator and detect leisure transitions.
+
+        Idempotent and tolerant of arbitrary call frequency: per-call
+        delta is bounded by ``_BREAK_REMINDER_TICK_MAX_DELTA_SECONDS``,
+        so a long gap between calls (process suspend, idle deployment,
+        first-call bootstrap) doesn't silently credit minutes the user
+        didn't actually spend focused.
+
+        Called from ``get_snapshot``, ``get_snapshot_sync``, and the 20s
+        ``_activity_guess_loop`` — the latter ensures state transitions
+        are caught even when no proactive_chat round queries the tracker.
+
+        Reads thresholds via ``self._sm._prefs.thresholds`` so user
+        edits to ``user_preferences.json`` take effect on the next
+        cache reload tick (mirrors how the state machine handles
+        live-edit user overrides).
+        """
+        thresholds = self._sm._prefs.thresholds
+
+        # Resolve thresholds with code-default fallbacks. Live-edit safe:
+        # _refresh_prefs runs on every get_snapshot path; threshold
+        # constants reload via the activity_config 30s cache.
+        work_break_seconds = float(
+            thresholds.get('work_break_minutes', _WORK_BREAK_MINUTES)
+        ) * 60.0
+        work_break_window = float(
+            thresholds.get('work_break_pending_window_seconds', _WORK_BREAK_PENDING_WINDOW_SECONDS)
+        )
+        anti_slack_min_focus_seconds = float(
+            thresholds.get('anti_slack_min_focus_minutes', _ANTI_SLACK_MIN_FOCUS_MINUTES)
+        ) * 60.0
+        anti_slack_cooldown_seconds = float(
+            thresholds.get('anti_slack_cooldown_minutes', _ANTI_SLACK_COOLDOWN_MINUTES)
+        ) * 60.0
+        anti_slack_window = float(
+            thresholds.get('anti_slack_pending_window_seconds', _ANTI_SLACK_PENDING_WINDOW_SECONDS)
+        )
+
+        state = snap.state
+
+        # ── Accumulator advance ─────────────────────────────────
+        # First tick has no delta to credit — record now and exit. The
+        # next call computes a real delta against this point.
+        if self._break_tick_last_at == 0.0:
+            self._break_tick_last_at = now
+        else:
+            raw_delta = now - self._break_tick_last_at
+            self._break_tick_last_at = now
+            # Ignore zero / negative (clock jump) and overlong (suspended
+            # process / forgot-to-tick) gaps. Either bucket means the
+            # accumulator can't safely advance: we don't actually know
+            # what state the user was in during that gap.
+            if 0 < raw_delta <= _BREAK_REMINDER_TICK_MAX_DELTA_SECONDS:
+                if state == 'focused_work':
+                    self._work_acc_seconds += raw_delta
+                elif state == 'transitioning' and self._work_acc_seconds > 0:
+                    # Transitioning during a real focus session = quick
+                    # IDE↔terminal↔browser-docs flick. Don't break the
+                    # streak. (When acc=0 we never started a session, so
+                    # transitioning by itself can't kick one off.)
+                    self._work_acc_seconds += raw_delta
+                else:
+                    # Any other state immediately resets — per user spec.
+                    self._work_acc_seconds = 0.0
+
+        # ── Focused_work session bookkeeping (for anti-slack transition) ─
+        # Track entry/exit so we can report the just-ended session length
+        # and app name when the user pivots to leisure.
+        prev_known = self._last_known_state
+        active_window = snap.active_window
+        active_canonical = (
+            active_window.canonical if active_window and active_window.canonical
+            else (active_window.title if active_window and active_window.title else None)
+        )
+        if state == 'focused_work':
+            if prev_known != 'focused_work':
+                # Entering focused_work. Clear any anti-slack pending —
+                # user is back at it, no need to nag.
+                self._focused_work_session_started_at = now
+                self._focused_work_session_app = active_canonical
+                self._anti_slack_pending = None
+            elif self._focused_work_session_app is None and active_canonical:
+                # Late-arriving canonical (the state already became
+                # focused_work but the active_window was None at entry).
+                self._focused_work_session_app = active_canonical
+        elif state == 'transitioning' and prev_known == 'focused_work':
+            # Mid-flick to a sibling work window — keep session timer
+            # running, don't reset (mirrors the accumulator rule).
+            pass
+        elif prev_known == 'focused_work' or (
+            prev_known == 'transitioning' and self._focused_work_session_started_at is not None
+        ):
+            # Just left focused_work (possibly via transitioning). Capture
+            # the session length and app, then evaluate anti-slack.
+            session_started = self._focused_work_session_started_at
+            session_app = self._focused_work_session_app
+            self._focused_work_session_started_at = None
+            self._focused_work_session_app = None
+            if (
+                session_started is not None
+                and state in _ANTI_SLACK_LEISURE_STATES
+            ):
+                session_seconds = max(0.0, now - session_started)
+                cooldown_ok = (
+                    self._anti_slack_last_fired_at == 0.0
+                    or (now - self._anti_slack_last_fired_at) >= anti_slack_cooldown_seconds
+                )
+                if (
+                    session_seconds >= anti_slack_min_focus_seconds
+                    and cooldown_ok
+                ):
+                    new_canonical = active_canonical or ''
+                    self._anti_slack_pending = {
+                        'set_at': now,
+                        'minutes': max(1, int(session_seconds / 60)),
+                        'prev_app': session_app or '',
+                        'new_app': new_canonical,
+                    }
+
+        # Anti-slack pending invalidation: state moved out of leisure
+        # before we got to deliver — the moment is gone.
+        if (
+            self._anti_slack_pending is not None
+            and state not in _ANTI_SLACK_LEISURE_STATES
+        ):
+            self._anti_slack_pending = None
+        # Anti-slack pending window expiry.
+        if (
+            self._anti_slack_pending is not None
+            and (now - self._anti_slack_pending['set_at']) > anti_slack_window
+        ):
+            self._anti_slack_pending = None
+
+        self._last_known_state = state
+
+        # ── Water-break pending ─────────────────────────────────
+        # Armed when accumulator crosses threshold AND state is currently
+        # focused_work. Stays armed across ticks (no time pin) — the next
+        # proactive_chat round in focused_work fires it. If the user
+        # leaves focused_work, accumulator resets to 0 (above) which
+        # naturally clears the arming condition; we also drop the pending
+        # explicitly here for cleanliness.
+        if (
+            state == 'focused_work'
+            and self._work_acc_seconds >= work_break_seconds
+        ):
+            if self._work_break_pending is None:
+                self._work_break_pending = {
+                    'set_at': now,
+                    'minutes': max(1, int(self._work_acc_seconds / 60)),
+                    'app': active_canonical or '',
+                }
+            else:
+                # Refresh minutes (accumulator keeps growing) and app
+                # (window may have shifted to a different work app).
+                self._work_break_pending['minutes'] = max(
+                    1, int(self._work_acc_seconds / 60),
+                )
+                if active_canonical:
+                    self._work_break_pending['app'] = active_canonical
+        elif state != 'focused_work' and state != 'transitioning':
+            # User left focused work entirely (and isn't mid-flick).
+            # Drop pending — accumulator was already reset above.
+            self._work_break_pending = None
+        # Window expiry as a defense-in-depth: if proactive doesn't fire
+        # and the user keeps grinding, the pending stays valid (intent
+        # of must-fire) — but if the snapshot pipeline is wedged for
+        # >window_seconds and the moment is conceptually gone, reset.
+        # In practice this branch rarely fires because focused_work
+        # constantly refreshes set_at via the minutes-update above; but
+        # it keeps an upper bound on stale pending state.
+        if (
+            self._work_break_pending is not None
+            and state != 'focused_work'
+            and (now - self._work_break_pending['set_at']) > work_break_window
+        ):
+            self._work_break_pending = None
+
+    def _build_work_break_pending(self) -> WorkBreakPending | None:
+        """Project the internal pending dict into the frozen snapshot type."""
+        if self._work_break_pending is None:
+            return None
+        return WorkBreakPending(
+            minutes=self._work_break_pending['minutes'],
+            app=self._work_break_pending['app'],
+        )
+
+    def _build_anti_slack_pending(self) -> AntiSlackPending | None:
+        if self._anti_slack_pending is None:
+            return None
+        return AntiSlackPending(
+            minutes=self._anti_slack_pending['minutes'],
+            prev_app=self._anti_slack_pending['prev_app'],
+            new_app=self._anti_slack_pending['new_app'],
+        )
+
+    def mark_work_break_used(self, *, now: float | None = None) -> None:
+        """Reset the water-break accumulator + clear pending after delivery.
+
+        Called from ``main_routers/system_router.py`` once the minimal
+        Phase 2 delivery (regular drink/stretch nudge OR the 50% rest+
+        game-invite branch) commits successfully. Resets the accumulator
+        so the next break is at least ``work_break_minutes`` of
+        focused_work away, mirroring the unfinished-thread "used"
+        contract.
+        """
+        # ``now`` accepted for symmetry with other tracker hooks; not
+        # actually needed (we just zero out — no timestamp recorded).
+        del now
+        self._work_acc_seconds = 0.0
+        self._work_break_pending = None
+
+    def mark_anti_slack_used(self, *, now: float | None = None) -> None:
+        """Stamp anti-slack delivery and start its cooldown.
+
+        Independent of the water-break + mini-game cooldowns so the
+        three reminder paths don't accidentally throttle each other.
+        """
+        ts = now if now is not None else time.time()
+        self._anti_slack_last_fired_at = ts
+        self._anti_slack_pending = None
 
     # ── enrichment kickoff ──────────────────────────────────────
 
@@ -491,6 +832,17 @@ class UserActivityTracker:
                     now=ts,
                 )
                 rule_snap = self._sm.get_snapshot(now=ts)
+
+                # Tick break-reminder accumulator + transition detection
+                # every loop iteration regardless of the activity_guess
+                # short-circuits below. Without this the accumulator
+                # would only advance when proactive_chat queries the
+                # snapshot — and a state transition (focused_work →
+                # casual_browsing) between two proactive rounds 30 min
+                # apart would credit the user with 30 min of focus they
+                # weren't actually doing. This is the canonical heartbeat
+                # for the break-reminder timers.
+                self._tick_break_reminders(rule_snap, now=ts)
 
                 # Bail on away — nothing useful to narrate.
                 if rule_snap.state == 'away':

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -567,22 +567,31 @@ class UserActivityTracker:
                 else:
                     # Any other state immediately resets — per user spec.
                     self._work_acc_seconds = 0.0
-            elif raw_delta > _BREAK_REMINDER_TICK_MAX_DELTA_SECONDS:
-                # Long gap (process suspend / sleep / clock jump /
-                # forgot-to-tick). We don't know what state the user
-                # was in during the gap, so we can't safely credit OR
-                # carry forward accumulator minutes. Conservative reset
-                # of everything that could carry stale pre-gap context:
-                #   * accumulator → 0 (otherwise a post-gap focused_work
-                #     stretch would credit pre-gap minutes and trigger
-                #     water-break much earlier than the user's real
-                #     post-gap focus warrants — Codex P2 review).
+            else:
+                # Unsafe delta — two buckets, same conservative cleanup:
+                #   * ``raw_delta > cap`` — long gap (process suspend /
+                #     sleep / forgot-to-tick). Don't know what state
+                #     the user was in during the gap.
+                #   * ``raw_delta <= 0`` — non-monotonic clock (NTP
+                #     rollback, manual time change, duplicate ts). Can't
+                #     credit; pre-rollback focus also can't be trusted
+                #     to extend through the inverted segment.
+                # In both cases, allowing the in-range branch above to
+                # not run means the "any other state immediately resets"
+                # rule never fires for non-focus ticks — pre-transition
+                # focus minutes leak forward into post-gap focused_work
+                # and trip water_break_pending earlier than 30 min of
+                # genuine post-gap focus warrants. Codex P2 reviews:
+                # PR #1226 (long-gap and non-positive-delta findings).
+                #
+                # Conservative reset of everything that could carry
+                # stale pre-event context:
+                #   * accumulator → 0
                 #   * _last_known_state → None forces the bookkeeping
-                #     below to treat any post-gap focused_work as a
+                #     below to treat any post-event focused_work as a
                 #     fresh session entry, AND prevents anti-slack from
                 #     firing on a focused_work → leisure transition
-                #     observed across the gap (we have no idea whether
-                #     the gap itself was the slacking).
+                #     observed across the unsafe-delta tick.
                 #   * Pending dicts cleared since the snapshot they
                 #     reference is now ancient.
                 self._work_acc_seconds = 0.0

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -567,6 +567,28 @@ class UserActivityTracker:
                 else:
                     # Any other state immediately resets — per user spec.
                     self._work_acc_seconds = 0.0
+            elif raw_delta > _BREAK_REMINDER_TICK_MAX_DELTA_SECONDS:
+                # Long gap (process suspend / sleep / clock jump /
+                # forgot-to-tick). We don't know what state the user
+                # was in during the gap, so we can't safely credit OR
+                # carry forward accumulator minutes. Conservative reset
+                # of everything that could carry stale pre-gap context:
+                #   * accumulator → 0 (otherwise a post-gap focused_work
+                #     stretch would credit pre-gap minutes and trigger
+                #     water-break much earlier than the user's real
+                #     post-gap focus warrants — Codex P2 review).
+                #   * _last_known_state → None forces the bookkeeping
+                #     below to treat any post-gap focused_work as a
+                #     fresh session entry, AND prevents anti-slack from
+                #     firing on a focused_work → leisure transition
+                #     observed across the gap (we have no idea whether
+                #     the gap itself was the slacking).
+                #   * Pending dicts cleared since the snapshot they
+                #     reference is now ancient.
+                self._work_acc_seconds = 0.0
+                self._last_known_state = None
+                self._work_break_pending = None
+                self._anti_slack_pending = None
 
         # ── Focused_work session bookkeeping (for anti-slack transition) ─
         # Track entry/exit so we can report the just-ended session length

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -534,6 +534,15 @@ class UserActivityTracker:
 
         state = snap.state
 
+        # Capture accumulator BEFORE advance/reset. Used as the
+        # authoritative session length when the anti-slack branch fires
+        # below — wall-clock ``now - session_started_at`` would inflate
+        # after a long process suspend / sleep / stall (the gap discard
+        # in the advance block prevents the accumulator from ticking
+        # through the dead window, but ``session_started_at`` still
+        # points at pre-suspend time). Codex P1 review: PR #1226.
+        session_acc_at_start = self._work_acc_seconds
+
         # ── Accumulator advance ─────────────────────────────────
         # First tick has no delta to credit — record now and exit. The
         # next call computes a real delta against this point.
@@ -596,7 +605,11 @@ class UserActivityTracker:
                 session_started is not None
                 and state in _ANTI_SLACK_LEISURE_STATES
             ):
-                session_seconds = max(0.0, now - session_started)
+                # Use the accumulator value captured at tick start
+                # (before reset) — it honors the long-gap discard rule,
+                # while ``now - session_started`` would credit the user
+                # with sleep/suspend time as if they'd been working.
+                session_seconds = session_acc_at_start
                 cooldown_ok = (
                     self._anti_slack_last_fired_at == 0.0
                     or (now - self._anti_slack_last_fired_at) >= anti_slack_cooldown_seconds
@@ -662,9 +675,13 @@ class UserActivityTracker:
         # and the user keeps grinding, the pending stays valid (intent
         # of must-fire) — but if the snapshot pipeline is wedged for
         # >window_seconds and the moment is conceptually gone, reset.
-        # In practice this branch rarely fires because focused_work
-        # constantly refreshes set_at via the minutes-update above; but
-        # it keeps an upper bound on stale pending state.
+        # ``set_at`` is captured once on first arming and NOT refreshed
+        # by the minutes-update branch above, so this expiry check
+        # actually bites for any state that holds the pending — most
+        # commonly ``transitioning`` lingering past the window. The
+        # ``state != 'focused_work'`` gate keeps focused_work itself
+        # exempt: as long as the user is actively focused, the pending
+        # is canonical and shouldn't time out. CodeRabbit nitpick: PR #1226.
         if (
             self._work_break_pending is not None
             and state != 'focused_work'

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -2541,6 +2541,270 @@ async def _maybe_deliver_mini_game_invite(
     }
 
 
+# ---------- Break-reminder rendering + minimal-Phase-2 delivery ----------
+# Two reminder paths emitted by ``main_logic/activity/tracker.py``:
+#   * Anti-slack — fired when state transitions focused_work → leisure
+#     after a real focus session. Higher priority (transition is more
+#     time-sensitive than the cumulative water-break trigger).
+#   * Water-break — fired when focused_work accumulator crosses
+#     ``work_break_minutes``. 50% of the time, branches into a
+#     "rest + game-invite" combo (LLM-generated) that shares the
+#     mini-game cooldown so the two channels don't double-deliver.
+#
+# Both deliveries skip Phase 1 entirely (no source fetching, no
+# enabled_modes parsing, no propensity gating). Phase 2 runs with a
+# minimal SystemMessage (character_prompt + the env-notice template)
+# so the model focuses on the single nudge instead of juggling sources.
+# Mirrors ``_maybe_deliver_mini_game_invite`` in shape: try → fall
+# through OR skip; never falls through to normal proactive flow when
+# a pending exists (must-fire semantics).
+
+def _resolve_break_reminder_label(
+    canonical: str | None, lang: str, fallback_table: dict[str, str],
+) -> str:
+    """Pick a renderable app label, falling back to a localized generic."""
+    label = (canonical or '').strip()
+    if label:
+        return label
+    return fallback_table.get(lang, fallback_table.get('en', ''))
+
+
+def _render_work_break_prompt(
+    *,
+    pending,                       # WorkBreakPending
+    master_name: str,
+    lang: str,
+) -> tuple[str, str]:
+    """Pick a seed + render the regular drink/stretch nudge prompt.
+
+    Returns ``(system_prompt_text, seed)`` so the caller can log /
+    record which seed was used. Seed is picked at delivery time (not
+    pinned to the snapshot) so consecutive failed-then-retried
+    deliveries naturally rotate the suggested action.
+    """
+    from config.prompts_activity import (
+        WORK_BREAK_REMINDER_PROMPT, WORK_BREAK_SEED_HINTS,
+        WORK_BREAK_GENERIC_WORK_LABEL,
+    )
+    import random as _random
+    template = WORK_BREAK_REMINDER_PROMPT.get(
+        lang, WORK_BREAK_REMINDER_PROMPT.get('en', WORK_BREAK_REMINDER_PROMPT['zh']),
+    )
+    seeds = WORK_BREAK_SEED_HINTS.get(
+        lang, WORK_BREAK_SEED_HINTS.get('en', WORK_BREAK_SEED_HINTS['zh']),
+    ) or ['']
+    seed = _random.choice(seeds)
+    app_label = _resolve_break_reminder_label(pending.app, lang, WORK_BREAK_GENERIC_WORK_LABEL)
+    rendered = template.format(
+        master=master_name or '',
+        app=app_label,
+        minutes=pending.minutes,
+        seed=seed,
+    )
+    return rendered, seed
+
+
+def _render_anti_slack_prompt(
+    *,
+    pending,                       # AntiSlackPending
+    master_name: str,
+    lang: str,
+) -> str:
+    """Render the focused→leisure 'back to work' nudge prompt.
+
+    No seed slot — single behaviour, variation comes from prev/new app
+    names + minute count + AI persona. Returns the system prompt text.
+    """
+    from config.prompts_activity import (
+        ANTI_SLACK_REMINDER_PROMPT,
+        WORK_BREAK_GENERIC_WORK_LABEL, WORK_BREAK_GENERIC_LEISURE_LABEL,
+    )
+    template = ANTI_SLACK_REMINDER_PROMPT.get(
+        lang, ANTI_SLACK_REMINDER_PROMPT.get('en', ANTI_SLACK_REMINDER_PROMPT['zh']),
+    )
+    prev_app_label = _resolve_break_reminder_label(pending.prev_app, lang, WORK_BREAK_GENERIC_WORK_LABEL)
+    new_app_label = _resolve_break_reminder_label(pending.new_app, lang, WORK_BREAK_GENERIC_LEISURE_LABEL)
+    return template.format(
+        master=master_name or '',
+        prev_app=prev_app_label,
+        new_app=new_app_label,
+        minutes=pending.minutes,
+    )
+
+
+def _render_work_break_game_invite_prompt(
+    *,
+    pending,                       # WorkBreakPending
+    game_type: str,
+    master_name: str,
+    lang: str,
+) -> str | None:
+    """Render the rest+game-invite combo prompt (50% branch).
+
+    Returns the system prompt text, or None when no template exists for
+    the given game_type (caller falls back to the regular water-break
+    branch).
+    """
+    from config.prompts_activity import (
+        WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME, WORK_BREAK_GENERIC_WORK_LABEL,
+    )
+    per_lang = WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME.get(game_type)
+    if not per_lang:
+        return None
+    template = per_lang.get(lang, per_lang.get('en', per_lang.get('zh')))
+    if not template:
+        return None
+    app_label = _resolve_break_reminder_label(pending.app, lang, WORK_BREAK_GENERIC_WORK_LABEL)
+    return template.format(
+        master=master_name or '',
+        app=app_label,
+        minutes=pending.minutes,
+    )
+
+
+async def _deliver_break_reminder_via_llm(
+    *,
+    lanlan_name: str,
+    mgr,
+    system_prompt: str,
+    channel: str,                 # 'work_break' | 'anti_slack' | 'work_break_game_invite'
+    lang: str,
+    timeout_seconds: float = 25.0,
+) -> tuple[str | None, str | None]:
+    """Minimal Phase 2 LLM stream delivery for break reminders.
+
+    No Phase 1, no sources, no full activity_state_section in the
+    prompt — just ``character_prompt`` (already baked into
+    ``system_prompt`` by the caller) + the env-notice block, so the
+    model puts all attention on the single nudge.
+
+    Returns ``(delivered_text, proactive_sid)`` on success.
+    Returns ``(None, None)`` on:
+      * ``prepare_proactive_delivery`` rejection (user just spoke /
+        WS offline / etc — leave the source pending alone, next round
+        can retry)
+      * LLM error / timeout / preempt
+      * Empty output / [PASS] emission (defensive)
+
+    Caller is responsible for ``mark_*_used`` on success and for any
+    follow-up UI push (e.g. the mini-game options popup in the
+    work_break_game_invite branch).
+    """
+    # Model config — fetched here so the helper is self-contained
+    # (caller in proactive_chat doesn't need to load it before our
+    # must-fire branches, since those run before the existing config
+    # fetch block at line ~4700). Returns None on any misconfig: a
+    # working break reminder is strictly better than crashing the whole
+    # proactive_chat round, and the source pending stays armed for the
+    # next attempt once config is fixed.
+    config_manager = get_config_manager()
+    try:
+        correction_config = config_manager.get_model_api_config('correction')
+        correction_model = correction_config.get('model')
+        correction_base_url = correction_config.get('base_url')
+        correction_api_key = correction_config.get('api_key')
+        if not correction_model or not correction_api_key:
+            logger.warning(
+                "[%s] break reminder skipped: correction model misconfigured",
+                lanlan_name,
+            )
+            return None, None
+    except Exception as cfg_err:
+        logger.warning(
+            "[%s] break reminder skipped: model config fetch failed: %s",
+            lanlan_name, cfg_err,
+        )
+        return None, None
+
+    # Idle gate (10s) — same threshold mini-game invite uses. If the
+    # user just typed/spoke, don't interrupt.
+    if not await mgr.prepare_proactive_delivery(min_idle_secs=10.0):
+        return None, None
+
+    proactive_sid = mgr.current_speech_id
+    from main_logic.session_state import SessionEvent as _SE
+    await mgr.state.fire(_SE.PROACTIVE_PHASE2)
+
+    # Minimal HumanMessage — just ask the model to begin. The localized
+    # ``BEGIN_GENERATE`` matches what normal Phase 2 uses, so the model
+    # interprets the cue identically.
+    begin_text = _loc(BEGIN_GENERATE, lang)
+    messages = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=begin_text),
+    ]
+
+    print(
+        f"\n{'='*60}\n[BREAK-REMINDER] channel={channel} lang={lang} model={correction_model}\n"
+        f"{'='*60}\n{system_prompt}\n{'='*60}\n"
+    )
+
+    from utils.token_tracker import set_call_type
+    set_call_type("proactive")
+    full_text = ''
+    aborted = False
+    pass_probe = ''
+    _PASS_PROBE_LEN = 5  # len("[PASS]") - 1
+
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            async with create_chat_llm(
+                correction_model, correction_base_url, correction_api_key,
+                temperature=1.0,
+                max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
+                streaming=True,
+            ) as llm:
+                async for chunk in llm.astream(messages):
+                    if mgr.state.is_proactive_preempted(proactive_sid):
+                        aborted = True
+                        break
+                    content = chunk.content if hasattr(chunk, 'content') else ''
+                    if not content:
+                        continue
+                    combined = pass_probe + content
+                    if '[PASS]' in combined.upper():
+                        aborted = True
+                        break
+                    safe_text = combined[:-_PASS_PROBE_LEN] if len(combined) > _PASS_PROBE_LEN else ''
+                    pass_probe = combined[-_PASS_PROBE_LEN:] if len(combined) >= _PASS_PROBE_LEN else combined
+                    if safe_text:
+                        # Token-budget cap mirrors the normal Phase 2
+                        # path — break-reminder output should be short
+                        # in any case, but defensive.
+                        n_tokens = count_tokens(full_text + safe_text)
+                        if n_tokens > PHASE2_OUTPUT_MAX_TOKENS:
+                            aborted = True
+                            break
+                        full_text += safe_text
+                        await mgr.feed_tts_chunk(safe_text, expected_speech_id=proactive_sid)
+        # Flush remaining pass_probe (if it doesn't itself contain [PASS])
+        if not aborted and pass_probe and '[PASS]' not in pass_probe.upper():
+            full_text += pass_probe
+            await mgr.feed_tts_chunk(pass_probe, expected_speech_id=proactive_sid)
+    except (asyncio.TimeoutError, Exception) as e:
+        logger.warning(
+            "[%s] break reminder LLM stream failed (channel=%s): %s: %s",
+            lanlan_name, channel, type(e).__name__, e,
+        )
+        aborted = True
+
+    if aborted or not full_text.strip():
+        if not mgr.state.is_proactive_preempted(proactive_sid):
+            await mgr.handle_new_message()
+        return None, None
+
+    text = full_text.strip()
+    committed = await mgr.finish_proactive_delivery(text, expected_speech_id=proactive_sid)
+    if not committed:
+        return None, None
+
+    _record_proactive_chat(lanlan_name, text, channel=channel)
+    print(
+        f"[{lanlan_name}] break reminder delivered (channel={channel}): {text[:80]}…"
+    )
+    return text, proactive_sid
+
+
 def _build_mini_game_invite_options_payload(
     *,
     invite_lang: str,
@@ -4298,6 +4562,194 @@ async def proactive_chat(request: Request):
                 "success": True,
                 "action": "pass",
                 "message": f"user state={activity_snapshot.state} → closed (privacy lockdown)",
+            }))
+
+        # ========== Must-fire: break-reminder branches ==========
+        # Anti-slack outranks water-break (transition trigger more
+        # time-sensitive than the cumulative one). Both bypass Phase 1
+        # entirely and run via _deliver_break_reminder_via_llm — see
+        # the helper docstring above. ``private`` state already cleared
+        # both pendings inside the tracker, so reaching here implies
+        # not-private. Debug-force-invite still takes precedence so the
+        # mini-game force flag keeps its "guaranteed mini-game" contract.
+        if (
+            not _debug_force_invite
+            and activity_snapshot is not None
+            and (
+                activity_snapshot.anti_slack_pending is not None
+                or activity_snapshot.work_break_pending is not None
+            )
+        ):
+            try:
+                _break_lang = _resolve_proactive_locale(data, mgr)
+            except Exception:
+                _break_lang = 'zh'
+
+            # Anti-slack first — single-behavior 'back to work' nudge.
+            if activity_snapshot.anti_slack_pending is not None:
+                anti_pending = activity_snapshot.anti_slack_pending
+                anti_prompt = _render_anti_slack_prompt(
+                    pending=anti_pending,
+                    master_name=master_name_current,
+                    lang=_break_lang,
+                )
+                delivered_text, _proactive_sid_unused = await _deliver_break_reminder_via_llm(
+                    lanlan_name=lanlan_name,
+                    mgr=mgr,
+                    system_prompt=anti_prompt,
+                    channel='anti_slack',
+                    lang=_break_lang,
+                )
+                if delivered_text:
+                    try:
+                        mgr._activity_tracker.mark_anti_slack_used()
+                    except Exception as _mark_err:
+                        logger.warning(
+                            "[%s] mark_anti_slack_used failed: %s",
+                            lanlan_name, _mark_err,
+                        )
+                    await _increment_proactive_chat_total(lanlan_name)
+                    return await _end_proactive(JSONResponse({
+                        "success": True,
+                        "action": "chat",
+                        "message": "anti-slack reminder delivered",
+                        "channel": "anti_slack",
+                    }))
+                # Delivery rejected (user took over / config issue).
+                # Don't fall through to normal proactive — must-fire
+                # semantics: leave pending armed for the next round.
+                return await _end_proactive(JSONResponse({
+                    "success": True,
+                    "action": "pass",
+                    "message": "anti-slack reminder pending but delivery skipped",
+                }))
+
+            # Water-break — 50% pivots to a rest+game-invite combo
+            # (gated on mini-game cooldown / user toggle / global
+            # kill switch / existence of a valid game_type). Any of
+            # those gates failing falls through to the regular
+            # drink/stretch nudge instead of breaking the must-fire.
+            water_pending = activity_snapshot.work_break_pending
+            prefs_for_break = mgr._activity_tracker._sm._prefs
+            _gi_prob = prefs_for_break.work_break_game_invite_probability
+            if _gi_prob is None:
+                # Resolved at import time — see tracker.py defaults.
+                from main_logic.activity.tracker import _WORK_BREAK_GAME_INVITE_PROBABILITY as _gi_prob_default
+                _gi_prob = _gi_prob_default
+            branch_game_invite = False
+            chosen_game_type: str | None = None
+            gi_prompt: str | None = None
+            if (
+                MINI_GAME_INVITE_ENABLED
+                and _user_invite_toggle
+                and not _mini_game_invite_in_cooldown(lanlan_name)
+                and _gi_prob > 0
+            ):
+                import random as _random
+                if _random.random() < _gi_prob:
+                    chosen_game_type = _pick_mini_game_type()
+                    if chosen_game_type is not None:
+                        gi_prompt = _render_work_break_game_invite_prompt(
+                            pending=water_pending,
+                            game_type=chosen_game_type,
+                            master_name=master_name_current,
+                            lang=_break_lang,
+                        )
+                        if gi_prompt is not None:
+                            branch_game_invite = True
+
+            if branch_game_invite and chosen_game_type is not None and gi_prompt is not None:
+                delivered_text, _proactive_sid_unused = await _deliver_break_reminder_via_llm(
+                    lanlan_name=lanlan_name,
+                    mgr=mgr,
+                    system_prompt=gi_prompt,
+                    channel='work_break_game_invite',
+                    lang=_break_lang,
+                )
+                if delivered_text:
+                    invite_session_id = str(uuid4())
+                    _mini_game_invite_record_delivered(lanlan_name, invite_session_id)
+                    _mini_game_invite_get_state(lanlan_name)['last_game_type'] = chosen_game_type
+                    try:
+                        await _record_invite_delivery_persistent(lanlan_name)
+                    except Exception as _persist_err:
+                        logger.warning(
+                            "[%s] record_invite_delivery_persistent failed: %s",
+                            lanlan_name, _persist_err,
+                        )
+                    options_payload = _build_mini_game_invite_options_payload(
+                        invite_lang=_break_lang,
+                        game_type=chosen_game_type,
+                        session_id=invite_session_id,
+                    )
+                    try:
+                        if mgr.websocket and hasattr(mgr.websocket, 'send_json'):
+                            client_state = getattr(mgr.websocket, 'client_state', None)
+                            if client_state is None or client_state == client_state.CONNECTED:
+                                await mgr.websocket.send_json(options_payload)
+                    except Exception as _ws_err:
+                        logger.warning(
+                            "[%s] work_break+game_invite options WS push failed: %s",
+                            lanlan_name, _ws_err,
+                        )
+                    try:
+                        mgr._activity_tracker.mark_work_break_used()
+                    except Exception as _mark_err:
+                        logger.warning(
+                            "[%s] mark_work_break_used failed: %s",
+                            lanlan_name, _mark_err,
+                        )
+                    await _increment_proactive_chat_total(lanlan_name)
+                    return await _end_proactive(JSONResponse({
+                        "success": True,
+                        "action": "chat",
+                        "message": "work-break + game-invite delivered",
+                        "channel": "work_break_game_invite",
+                        "game_type": chosen_game_type,
+                        "invite_session_id": invite_session_id,
+                    }))
+                # Combo branch delivery failed → don't fall through to
+                # regular drink branch (would double-charge the user's
+                # attention). Pending stays armed for next round.
+                return await _end_proactive(JSONResponse({
+                    "success": True,
+                    "action": "pass",
+                    "message": "work-break + game-invite pending but delivery skipped",
+                }))
+
+            # Regular drink/stretch nudge branch
+            wb_prompt, wb_seed = _render_work_break_prompt(
+                pending=water_pending,
+                master_name=master_name_current,
+                lang=_break_lang,
+            )
+            delivered_text, _proactive_sid_unused = await _deliver_break_reminder_via_llm(
+                lanlan_name=lanlan_name,
+                mgr=mgr,
+                system_prompt=wb_prompt,
+                channel='work_break',
+                lang=_break_lang,
+            )
+            if delivered_text:
+                try:
+                    mgr._activity_tracker.mark_work_break_used()
+                except Exception as _mark_err:
+                    logger.warning(
+                        "[%s] mark_work_break_used failed: %s",
+                        lanlan_name, _mark_err,
+                    )
+                await _increment_proactive_chat_total(lanlan_name)
+                return await _end_proactive(JSONResponse({
+                    "success": True,
+                    "action": "chat",
+                    "message": "work-break reminder delivered",
+                    "channel": "work_break",
+                    "seed": wb_seed,
+                }))
+            return await _end_proactive(JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": "work-break reminder pending but delivery skipped",
             }))
 
         # ========== Probabilistic skip (intensity-driven gate) ==========

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4627,6 +4627,12 @@ async def proactive_chat(request: Request):
                             "[%s] mark_anti_slack_used failed: %s",
                             lanlan_name, _mark_err,
                         )
+                    # Mini-game cooldown counter — same contract as the
+                    # normal text proactive path at ~6253: any successful
+                    # proactive emission counts as one of the "10 chats
+                    # since user responded" gate. No-op when no prior
+                    # invite is pending. Codex/CodeRabbit Minor: PR #1226.
+                    _mini_game_invite_count_post_response_chat(lanlan_name)
                     await _increment_proactive_chat_total(lanlan_name)
                     return await _end_proactive(JSONResponse({
                         "success": True,
@@ -4769,6 +4775,8 @@ async def proactive_chat(request: Request):
                         "[%s] mark_work_break_used failed: %s",
                         lanlan_name, _mark_err,
                     )
+                # Same chats-since-response counter as anti_slack branch.
+                _mini_game_invite_count_post_response_chat(lanlan_name)
                 await _increment_proactive_chat_total(lanlan_name)
                 return await _end_proactive(JSONResponse({
                     "success": True,

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4585,6 +4585,25 @@ async def proactive_chat(request: Request):
             except Exception:
                 _break_lang = 'zh'
 
+            # Resolve character_prompt up front and prepend it to every
+            # break-reminder SystemMessage. Without this the model would
+            # see only the env-notice template and lose its persona —
+            # CodeRabbit Major review (PR #1226). Mirrors the
+            # placeholder substitution the normal Phase 2 path does at
+            # line ~5300 (LANLAN_NAME / MASTER_NAME).
+            _break_character_prompt = lanlan_prompt_map.get(lanlan_name, '')
+            if _break_character_prompt:
+                _break_character_prompt = (
+                    _break_character_prompt
+                    .replace('{LANLAN_NAME}', lanlan_name)
+                    .replace('{MASTER_NAME}', master_name_current)
+                )
+
+            def _compose_break_system_prompt(env_notice: str) -> str:
+                if not _break_character_prompt:
+                    return env_notice
+                return f'{_break_character_prompt}\n\n{env_notice}'
+
             # Anti-slack first — single-behavior 'back to work' nudge.
             if activity_snapshot.anti_slack_pending is not None:
                 anti_pending = activity_snapshot.anti_slack_pending
@@ -4596,7 +4615,7 @@ async def proactive_chat(request: Request):
                 delivered_text, _proactive_sid_unused = await _deliver_break_reminder_via_llm(
                     lanlan_name=lanlan_name,
                     mgr=mgr,
-                    system_prompt=anti_prompt,
+                    system_prompt=_compose_break_system_prompt(anti_prompt),
                     channel='anti_slack',
                     lang=_break_lang,
                 )
@@ -4662,7 +4681,7 @@ async def proactive_chat(request: Request):
                 delivered_text, _proactive_sid_unused = await _deliver_break_reminder_via_llm(
                     lanlan_name=lanlan_name,
                     mgr=mgr,
-                    system_prompt=gi_prompt,
+                    system_prompt=_compose_break_system_prompt(gi_prompt),
                     channel='work_break_game_invite',
                     lang=_break_lang,
                 )
@@ -4670,8 +4689,16 @@ async def proactive_chat(request: Request):
                     invite_session_id = str(uuid4())
                     _mini_game_invite_record_delivered(lanlan_name, invite_session_id)
                     _mini_game_invite_get_state(lanlan_name)['last_game_type'] = chosen_game_type
+                    # Persist counter+1 + ever_delivered atomically (mini-game cooldown
+                    # contract). Track success so we can fall back to the plain
+                    # _increment_proactive_chat_total if persistence fails — otherwise
+                    # the chat-total counter would skip this round entirely.
+                    # CodeRabbit Major: don't double-count — the persistent record
+                    # already does the +1, so plain counter is only the fallback.
+                    _persist_ok = False
                     try:
                         await _record_invite_delivery_persistent(lanlan_name)
+                        _persist_ok = True
                     except Exception as _persist_err:
                         logger.warning(
                             "[%s] record_invite_delivery_persistent failed: %s",
@@ -4699,7 +4726,11 @@ async def proactive_chat(request: Request):
                             "[%s] mark_work_break_used failed: %s",
                             lanlan_name, _mark_err,
                         )
-                    await _increment_proactive_chat_total(lanlan_name)
+                    if not _persist_ok:
+                        # Persistence path failed → counter wasn't bumped.
+                        # Fall back to the plain in-memory increment so the
+                        # round still counts toward proactive_chat totals.
+                        await _increment_proactive_chat_total(lanlan_name)
                     return await _end_proactive(JSONResponse({
                         "success": True,
                         "action": "chat",
@@ -4726,7 +4757,7 @@ async def proactive_chat(request: Request):
             delivered_text, _proactive_sid_unused = await _deliver_break_reminder_via_llm(
                 lanlan_name=lanlan_name,
                 mgr=mgr,
-                system_prompt=wb_prompt,
+                system_prompt=_compose_break_system_prompt(wb_prompt),
                 channel='work_break',
                 lang=_break_lang,
             )

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -997,7 +997,7 @@ def _tick_for_seconds(tracker, *, state: str, seconds: float, step: float = 20.0
 def test_break_acc_advances_during_focused_work():
     """Accumulator credits real time spent in focused_work."""
     tracker = _make_tracker_for_break_tests()
-    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=600)
+    _tick_for_seconds(tracker, state='focused_work', seconds=600)
     # 600s ± a tick — first call records timestamp without delta.
     assert 540 <= tracker._work_acc_seconds <= 610
 
@@ -1155,3 +1155,77 @@ def test_break_acc_tolerates_long_gaps():
     tracker._tick_break_reminders(snap, now=1000.0 + 3620.0)
     assert tracker._work_acc_seconds > 0
     assert tracker._work_acc_seconds < 60
+
+
+def test_anti_slack_uses_accumulator_not_wall_clock_after_suspend():
+    """Long suspend → resume → leisure does NOT inflate session minutes.
+
+    Regression test for Codex P1 (PR #1226): without the fix,
+    ``session_seconds`` was computed from ``now - session_started_at``,
+    so a 1-hour laptop sleep mid-focus session would emit anti-slack
+    pending claiming the user worked for 60+ minutes when the
+    accumulator only credited the genuine pre-sleep focus time.
+    """
+    # Set anti-slack threshold high enough that pre-sleep alone wouldn't
+    # trip it, so any inflation would be detected as a false positive.
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=5)
+    # Pre-sleep: only 1 minute of real focused_work (well below threshold).
+    snap_focus = _snap_for_state('focused_work')
+    tracker._tick_break_reminders(snap_focus, now=1000.0)
+    tracker._tick_break_reminders(snap_focus, now=1020.0)
+    tracker._tick_break_reminders(snap_focus, now=1040.0)
+    tracker._tick_break_reminders(snap_focus, now=1060.0)
+    pre_sleep_acc = tracker._work_acc_seconds
+    assert pre_sleep_acc < 100  # ~60s of real focus
+    # 1 hour of nothing — process suspended.
+    suspended_until = 1060.0 + 3600.0
+    # Resume: still in focused_work briefly (long delta gets discarded).
+    tracker._tick_break_reminders(snap_focus, now=suspended_until)
+    # Accumulator should NOT have ballooned — long gap was discarded.
+    assert tracker._work_acc_seconds < 100
+    # User immediately switches to YouTube post-resume.
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=suspended_until + 20.0)
+    # No anti-slack pending — real focused minutes were below threshold,
+    # wall-clock-based logic would have spuriously triggered with 61min.
+    assert tracker._anti_slack_pending is None
+
+
+def test_anti_slack_minutes_match_accumulator_not_wall_clock():
+    """When anti-slack DOES fire, reported minutes match real focus time."""
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=5)
+    # 6 minutes of real focused_work
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=360)
+    real_focus_minutes = int(tracker._work_acc_seconds / 60)
+    assert real_focus_minutes >= 5
+    # 30-minute suspend (no ticks)
+    suspended_until = end_t + 1800.0
+    # User comes back and immediately goes to YouTube
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=suspended_until)
+    assert tracker._anti_slack_pending is not None
+    # Reported minutes should reflect the genuine pre-suspend focus time,
+    # not the inflated wall-clock 36 minutes (6min + 30min suspend).
+    reported = tracker._anti_slack_pending['minutes']
+    assert reported <= real_focus_minutes + 1  # ±1 for rounding
+
+
+def test_unit_probability_rejects_out_of_range():
+    """Out-of-range probabilities → None (use default), not clamped.
+
+    Codex P2 (PR #1226): docstring contract says invalid → None,
+    consistent with the rest of activity_config's fail-soft parsers.
+    Without this, a typo like ``2`` would become ``always invite``.
+    """
+    from utils.activity_config import _parse_unit_probability
+    assert _parse_unit_probability(0.5) == 0.5
+    assert _parse_unit_probability(0) == 0.0
+    assert _parse_unit_probability(1) == 1.0
+    # Out of range → None (not clamped)
+    assert _parse_unit_probability(2) is None
+    assert _parse_unit_probability(-0.1) is None
+    assert _parse_unit_probability(1.5) is None
+    # Non-numeric / None / bool still rejected
+    assert _parse_unit_probability(None) is None
+    assert _parse_unit_probability('0.5') is None
+    assert _parse_unit_probability(True) is None

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1191,21 +1191,85 @@ def test_anti_slack_uses_accumulator_not_wall_clock_after_suspend():
     assert tracker._anti_slack_pending is None
 
 
-def test_anti_slack_minutes_match_accumulator_not_wall_clock():
-    """When anti-slack DOES fire, reported minutes match real focus time."""
+def test_break_acc_resets_when_long_gap_post_state_is_leisure():
+    """Long gap that lands on a leisure tick still resets accumulator.
+
+    Codex P2 (PR #1226): the original gap-discard branch only ran the
+    state-handling block when raw_delta was in range, so when a long
+    gap landed on a casual_browsing/gaming tick the ``acc=0`` reset
+    never executed and pre-gap focus minutes carried forward into the
+    next focused_work stretch — triggering water_break_pending much
+    earlier than 30 fresh minutes would warrant.
+    """
+    tracker = _make_tracker_for_break_tests(work_break_minutes=30)
+    # Build up 25 minutes of pre-gap focus.
+    _tick_for_seconds(tracker, state='focused_work', seconds=1500)
+    pre_gap_acc = tracker._work_acc_seconds
+    assert pre_gap_acc >= 1400  # generous lower bound for tick init
+    # Long gap (1 hour suspend) lands on a casual_browsing tick.
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(
+        snap_browsing, now=tracker._break_tick_last_at + 3600.0,
+    )
+    # Accumulator must have reset — otherwise the next focused_work
+    # stretch would inherit 25 pre-gap minutes.
+    assert tracker._work_acc_seconds == 0
+
+
+def test_long_gap_does_not_fire_anti_slack_on_first_post_gap_leisure():
+    """Long gap into leisure shouldn't claim the user just finished focusing.
+
+    Codex P2: prev_known carries focused_work across the gap with
+    stale session_started_at; without the long-gap reset, the
+    anti-slack branch would fire claiming the user worked the entire
+    gap — but we have no idea whether they were focused, away, or
+    sleeping.
+    """
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=2)
+    _tick_for_seconds(tracker, state='focused_work', seconds=600)
+    # Long gap then leisure tick
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(
+        snap_browsing, now=tracker._break_tick_last_at + 3600.0,
+    )
+    # No anti-slack pending — gap-induced reset cleared session bookkeeping.
+    assert tracker._anti_slack_pending is None
+
+
+def test_long_gap_clears_work_break_pending_too():
+    """Pre-gap water_break_pending shouldn't persist across long gaps."""
+    tracker = _make_tracker_for_break_tests(work_break_minutes=2)
+    _tick_for_seconds(tracker, state='focused_work', seconds=200)
+    assert tracker._work_break_pending is not None
+    # Long gap lands on focused_work tick → still resets
+    snap_focus = _snap_for_state('focused_work', app='VS Code')
+    tracker._tick_break_reminders(
+        snap_focus, now=tracker._break_tick_last_at + 3600.0,
+    )
+    assert tracker._work_break_pending is None
+    assert tracker._work_acc_seconds == 0
+
+
+def test_anti_slack_minutes_match_accumulator_when_no_gap():
+    """When anti-slack fires from a continuous focus → leisure transition,
+    reported minutes track the accumulator (not the wall-clock).
+
+    Originally pinned the Codex P1 fix (accumulator vs wall-clock) using a
+    suspend gap; the later Codex P2 fix made long-gap transitions skip
+    anti-slack entirely, so this case now exercises the no-gap path.
+    Minutes-match logic remains relevant for normal continuous sessions.
+    """
     tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=5)
-    # 6 minutes of real focused_work
+    # 6 minutes of continuous focused_work
     end_t = _tick_for_seconds(tracker, state='focused_work', seconds=360)
     real_focus_minutes = int(tracker._work_acc_seconds / 60)
     assert real_focus_minutes >= 5
-    # 30-minute suspend (no ticks)
-    suspended_until = end_t + 1800.0
-    # User comes back and immediately goes to YouTube
+    # Pivot to YouTube on the very next tick (no gap)
     snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
-    tracker._tick_break_reminders(snap_browsing, now=suspended_until)
+    tracker._tick_break_reminders(snap_browsing, now=end_t + 20.0)
     assert tracker._anti_slack_pending is not None
-    # Reported minutes should reflect the genuine pre-suspend focus time,
-    # not the inflated wall-clock 36 minutes (6min + 30min suspend).
+    # Reported minutes track the accumulator value at tick start, not
+    # ``now - session_started_at``.
     reported = tracker._anti_slack_pending['minutes']
     assert reported <= real_focus_minutes + 1  # ±1 for rounding
 

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1236,6 +1236,40 @@ def test_long_gap_does_not_fire_anti_slack_on_first_post_gap_leisure():
     assert tracker._anti_slack_pending is None
 
 
+def test_clock_rollback_resets_accumulator():
+    """Non-monotonic tick (NTP rollback / duplicate ts) clears stale focus.
+
+    Codex P2 (PR #1226): symmetric to the long-gap branch — without
+    the reset, a post-rollback focused_work tick would inherit
+    pre-rollback minutes and trip water_break early. Also verifies
+    that the unsafe-delta branch treats the post-rollback focused_work
+    state as a fresh session entry (session_started_at refreshes).
+    """
+    tracker = _make_tracker_for_break_tests()
+    snap_focus = _snap_for_state('focused_work')
+    # Build up some focus
+    tracker._tick_break_reminders(snap_focus, now=1000.0)
+    tracker._tick_break_reminders(snap_focus, now=1020.0)
+    tracker._tick_break_reminders(snap_focus, now=1040.0)
+    assert tracker._work_acc_seconds > 0
+    pre_rollback_session_start = tracker._focused_work_session_started_at
+    assert pre_rollback_session_start is not None
+    # NTP rollback — wall clock goes backward
+    tracker._tick_break_reminders(snap_focus, now=900.0)
+    assert tracker._work_acc_seconds == 0
+    # session_started_at refreshed to the post-rollback time, proving
+    # the bookkeeping branch saw prev_known==None and treated this as a
+    # fresh entry (rather than carrying the pre-rollback session).
+    assert tracker._focused_work_session_started_at == 900.0
+    # Duplicate timestamp (raw_delta == 0) also gets the reset
+    tracker._tick_break_reminders(snap_focus, now=1100.0)
+    tracker._tick_break_reminders(snap_focus, now=1100.0)
+    # First call credits delta, second call has raw_delta=0 → reset
+    # (we don't differentiate "0 is harmless" from "<0 is dangerous";
+    # both fall outside the `0 < raw_delta` window so both reset)
+    assert tracker._work_acc_seconds == 0
+
+
 def test_long_gap_clears_work_break_pending_too():
     """Pre-gap water_break_pending shouldn't persist across long gaps."""
     tracker = _make_tracker_for_break_tests(work_break_minutes=2)

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -1229,3 +1229,59 @@ def test_unit_probability_rejects_out_of_range():
     assert _parse_unit_probability(None) is None
     assert _parse_unit_probability('0.5') is None
     assert _parse_unit_probability(True) is None
+    # NaN / Inf must fall through too — NaN comparisons are always False so
+    # the range checks alone don't catch it. CodeRabbit Minor: PR #1226.
+    assert _parse_unit_probability(float('nan')) is None
+    assert _parse_unit_probability(float('inf')) is None
+    assert _parse_unit_probability(float('-inf')) is None
+
+
+def test_loader_wires_work_break_game_invite_probability(tmp_path):
+    """File → _load_from_file → ActivityPreferences carries the new field.
+
+    Pins the JSON loader path end-to-end so renaming the key or breaking
+    ``_parse_activity_section`` wiring fails loud here, not silently
+    falls back to the code default. CodeRabbit Nitpick: PR #1226.
+    """
+    import json
+    from utils.activity_config import _GLOBAL_CONVERSATION_KEY, _load_from_file
+
+    pref_file = tmp_path / 'user_preferences.json'
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'activity': {
+                'work_break_game_invite_probability': 0.25,
+            },
+        }]),
+        encoding='utf-8',
+    )
+    prefs = _load_from_file(str(pref_file))
+    assert prefs is not None
+    assert prefs.work_break_game_invite_probability == 0.25
+
+    # Negative case: invalid value falls through to None (uses code default).
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'activity': {
+                'work_break_game_invite_probability': 2,  # out of range
+            },
+        }]),
+        encoding='utf-8',
+    )
+    prefs = _load_from_file(str(pref_file))
+    assert prefs is not None
+    assert prefs.work_break_game_invite_probability is None
+
+    # Missing field → None (default).
+    pref_file.write_text(
+        json.dumps([{
+            'model_path': _GLOBAL_CONVERSATION_KEY,
+            'activity': {},
+        }]),
+        encoding='utf-8',
+    )
+    prefs = _load_from_file(str(pref_file))
+    assert prefs is not None
+    assert prefs.work_break_game_invite_probability is None

--- a/tests/test_activity_tracker_followup.py
+++ b/tests/test_activity_tracker_followup.py
@@ -418,7 +418,11 @@ def test_loader_drops_invalid_threshold_values():
     ('chatting',        None,           None,     'warm'),
     ('stale_returning', None,           None,     'warm'),
     ('focused_work',    None,           None,     'concise'),
-    ('idle',            None,           None,     'concise'),
+    # ``idle`` while desk-pet is up reads as 摸鱼 territory — pair with
+    # ``playful`` (matches casual_browsing) instead of the businesslike
+    # ``concise``. ``transitioning`` and ``away`` keep ``concise``:
+    # the former is mid-context-switch, the latter doesn't render.
+    ('idle',            None,           None,     'playful'),
     ('away',            None,           None,     'concise'),
     ('casual_browsing', None,           None,     'playful'),
     ('private',         None,           None,     'concise'),
@@ -923,3 +927,231 @@ def test_loader_canonical_falls_back_to_override_key(tmp_path):
     # Title override falls back the same way
     assert 'mydashboard' in prefs.user_title_overrides
     assert prefs.user_title_overrides['mydashboard'].canonical == 'MyDashboard'
+
+
+# ── Break-reminder accumulator + transition detection ──────────────
+
+
+def _make_tracker_for_break_tests(
+    *,
+    work_break_minutes: float = 30,
+    anti_slack_min_focus_minutes: float = 5,
+    anti_slack_cooldown_minutes: float = 15,
+):
+    """Build a UserActivityTracker with break-reminder thresholds set.
+
+    Bypasses collector startup — tests drive ``_tick_break_reminders``
+    directly with synthetic ActivitySnapshots, so the collector + system
+    signal pipeline never run.
+    """
+    from main_logic.activity.tracker import UserActivityTracker
+    tracker = UserActivityTracker('test_lanlan')
+    tracker._sm._prefs = ActivityPreferences(thresholds={
+        'work_break_minutes': work_break_minutes,
+        'anti_slack_min_focus_minutes': anti_slack_min_focus_minutes,
+        'anti_slack_cooldown_minutes': anti_slack_cooldown_minutes,
+    })
+    return tracker
+
+
+def _snap_for_state(state: str, *, app: str | None = 'VS Code'):
+    """Minimal ActivitySnapshot with the fields _tick_break_reminders reads."""
+    from main_logic.activity.snapshot import ActivitySnapshot, WindowObservation
+    win = (
+        WindowObservation(
+            process_name=None, title=None, category='work',
+            subcategory='ide', canonical=app, is_browser=False,
+        )
+        if app else None
+    )
+    return ActivitySnapshot(
+        state=state,
+        state_age_seconds=10.0,
+        previous_state=None,
+        transitioned_recently=False,
+        stale_returning=False,
+        propensity='open',
+        active_window=win,
+    )
+
+
+def _tick_for_seconds(tracker, *, state: str, seconds: float, step: float = 20.0,
+                     app: str | None = 'VS Code', start: float = 1000.0) -> float:
+    """Drive _tick_break_reminders forward by ``seconds`` total via ``step`` slices.
+
+    Per-tick advance is capped by ``_BREAK_REMINDER_TICK_MAX_DELTA_SECONDS``
+    (default 30s); using 20s steps mirrors the real activity_guess loop
+    cadence and keeps every step credited fully. Returns the final ``now``.
+    """
+    now = start
+    end = start + seconds
+    snap = _snap_for_state(state, app=app)
+    # First tick records the baseline timestamp (no delta credited).
+    tracker._tick_break_reminders(snap, now=now)
+    while now < end:
+        now = min(now + step, end)
+        tracker._tick_break_reminders(snap, now=now)
+    return now
+
+
+def test_break_acc_advances_during_focused_work():
+    """Accumulator credits real time spent in focused_work."""
+    tracker = _make_tracker_for_break_tests()
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=600)
+    # 600s ± a tick — first call records timestamp without delta.
+    assert 540 <= tracker._work_acc_seconds <= 610
+
+
+def test_break_acc_extends_through_transitioning_when_already_started():
+    """Transitioning during a real focus session keeps the timer running."""
+    tracker = _make_tracker_for_break_tests()
+    # Build up 5 minutes of focused_work.
+    t = _tick_for_seconds(tracker, state='focused_work', seconds=300)
+    pre_acc = tracker._work_acc_seconds
+    assert pre_acc >= 280  # tolerance for first-tick init
+    # Now flick to transitioning for 30 seconds — accumulator should keep growing.
+    snap_transitioning = _snap_for_state('transitioning')
+    tracker._tick_break_reminders(snap_transitioning, now=t + 20)
+    tracker._tick_break_reminders(snap_transitioning, now=t + 40)
+    assert tracker._work_acc_seconds > pre_acc
+
+
+def test_break_acc_resets_on_any_other_state():
+    """Anything other than focused_work / transitioning resets immediately."""
+    tracker = _make_tracker_for_break_tests()
+    _tick_for_seconds(tracker, state='focused_work', seconds=600)
+    assert tracker._work_acc_seconds > 500
+
+    # One tick of casual_browsing → reset
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=tracker._break_tick_last_at + 20)
+    assert tracker._work_acc_seconds == 0
+
+
+def test_break_acc_transitioning_alone_cannot_start_timer():
+    """Pure transitioning (acc==0) does not arm the timer."""
+    tracker = _make_tracker_for_break_tests()
+    snap = _snap_for_state('transitioning')
+    tracker._tick_break_reminders(snap, now=1000.0)
+    tracker._tick_break_reminders(snap, now=1020.0)
+    tracker._tick_break_reminders(snap, now=1040.0)
+    assert tracker._work_acc_seconds == 0
+    assert tracker._work_break_pending is None
+
+
+def test_work_break_pending_armed_at_threshold():
+    """work_break_pending populates once accumulator crosses threshold."""
+    tracker = _make_tracker_for_break_tests(work_break_minutes=2)  # 120s for fast test
+    _tick_for_seconds(tracker, state='focused_work', seconds=60)
+    assert tracker._work_break_pending is None  # below threshold
+    _tick_for_seconds(
+        tracker, state='focused_work', seconds=120,
+        start=tracker._break_tick_last_at,
+    )
+    assert tracker._work_break_pending is not None
+    assert tracker._work_break_pending['minutes'] >= 2
+    assert tracker._work_break_pending['app'] == 'VS Code'
+
+
+def test_work_break_pending_persists_until_cleared():
+    """Pending stays armed across ticks until mark_work_break_used."""
+    tracker = _make_tracker_for_break_tests(work_break_minutes=1)
+    _tick_for_seconds(tracker, state='focused_work', seconds=120)
+    assert tracker._work_break_pending is not None
+    # More focused_work ticks — pending stays, minutes refresh upward.
+    base_minutes = tracker._work_break_pending['minutes']
+    _tick_for_seconds(tracker, state='focused_work', seconds=120, start=tracker._break_tick_last_at)
+    assert tracker._work_break_pending is not None
+    assert tracker._work_break_pending['minutes'] >= base_minutes
+    # Clearing via the public API resets accumulator + drops pending.
+    tracker.mark_work_break_used()
+    assert tracker._work_break_pending is None
+    assert tracker._work_acc_seconds == 0
+
+
+def test_anti_slack_pending_fires_on_focus_to_leisure():
+    """Transitioning focused_work → casual_browsing arms anti-slack pending."""
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=2)
+    # 3 minutes of focused_work
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=180)
+    # Pivot to casual_browsing
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=end_t + 20)
+    assert tracker._anti_slack_pending is not None
+    assert tracker._anti_slack_pending['prev_app'] == 'VS Code'
+    assert tracker._anti_slack_pending['new_app'] == 'YouTube'
+    assert tracker._anti_slack_pending['minutes'] >= 2
+
+
+def test_anti_slack_skipped_when_focus_too_short():
+    """Below anti_slack_min_focus_minutes, the transition is silent."""
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=5)
+    # Only 90s of focus
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=90)
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=end_t + 20)
+    assert tracker._anti_slack_pending is None
+
+
+def test_anti_slack_skipped_for_idle_target():
+    """focused_work → idle does NOT fire (idle ≠ slacking; could be thinking)."""
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=2)
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=180)
+    snap_idle = _snap_for_state('idle', app=None)
+    tracker._tick_break_reminders(snap_idle, now=end_t + 20)
+    assert tracker._anti_slack_pending is None
+
+
+def test_anti_slack_respects_cooldown():
+    """Within cooldown, no new anti-slack pending is emitted."""
+    tracker = _make_tracker_for_break_tests(
+        anti_slack_min_focus_minutes=2, anti_slack_cooldown_minutes=15,
+    )
+    # First focus → leisure: emits, then mark_used to start cooldown.
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=180)
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=end_t + 20)
+    assert tracker._anti_slack_pending is not None
+    tracker.mark_anti_slack_used(now=end_t + 30)
+
+    # Second focus → leisure within cooldown: no pending.
+    end_t2 = _tick_for_seconds(
+        tracker, state='focused_work', seconds=180,
+        start=end_t + 30,
+    )
+    snap_browsing2 = _snap_for_state('casual_browsing', app='Reddit')
+    tracker._tick_break_reminders(snap_browsing2, now=end_t2 + 20)
+    assert tracker._anti_slack_pending is None
+
+
+def test_anti_slack_pending_cleared_on_return_to_focus():
+    """If user goes back to focused_work, the pending is dropped (no longer slacking)."""
+    tracker = _make_tracker_for_break_tests(anti_slack_min_focus_minutes=2)
+    end_t = _tick_for_seconds(tracker, state='focused_work', seconds=180)
+    snap_browsing = _snap_for_state('casual_browsing', app='YouTube')
+    tracker._tick_break_reminders(snap_browsing, now=end_t + 20)
+    assert tracker._anti_slack_pending is not None
+    # Return to focused_work
+    snap_back = _snap_for_state('focused_work', app='VS Code')
+    tracker._tick_break_reminders(snap_back, now=end_t + 40)
+    assert tracker._anti_slack_pending is None
+
+
+def test_break_acc_tolerates_long_gaps():
+    """Long gap between ticks doesn't credit the user fake minutes.
+
+    If something pauses the loop (process suspend, idle deployment),
+    the accumulator should not silently jump 30 minutes — the cap
+    discards the suspect delta.
+    """
+    tracker = _make_tracker_for_break_tests()
+    snap = _snap_for_state('focused_work')
+    tracker._tick_break_reminders(snap, now=1000.0)
+    # Tick again with a 1-hour gap → should be discarded
+    tracker._tick_break_reminders(snap, now=1000.0 + 3600.0)
+    # Accumulator stays at 0 (or near it) — the 3600s delta exceeds the cap
+    assert tracker._work_acc_seconds < 60
+    # Subsequent normal ticks credit normally
+    tracker._tick_break_reminders(snap, now=1000.0 + 3620.0)
+    assert tracker._work_acc_seconds > 0
+    assert tracker._work_acc_seconds < 60

--- a/utils/activity_config.py
+++ b/utils/activity_config.py
@@ -370,6 +370,12 @@ def _parse_unit_probability(raw: Any) -> float | None:
     (disabled), so the >0 invariant doesn't apply. Returns None when the
     user didn't supply this key, signalling "fall through to the code
     default" rather than "disabled".
+
+    Out-of-range (``< 0`` / ``> 1``) is rejected, NOT clamped: a typo
+    like ``2`` or ``-1`` should fall through to the default (0.5) rather
+    than silently flip to "always invite" (1.0) or "never invite" (0.0).
+    Same fail-soft contract the rest of this module uses for invalid
+    user input. Codex P2 review: PR #1226.
     """
     if raw is None:
         return None
@@ -377,7 +383,10 @@ def _parse_unit_probability(raw: Any) -> float | None:
         return None
     if not isinstance(raw, (int, float)):
         return None
-    return max(0.0, min(1.0, float(raw)))
+    value = float(raw)
+    if value < 0.0 or value > 1.0:
+        return None
+    return value
 
 
 def _parse_thresholds(raw: Any) -> dict[str, float]:

--- a/utils/activity_config.py
+++ b/utils/activity_config.py
@@ -81,6 +81,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import threading
 import time
@@ -384,6 +385,11 @@ def _parse_unit_probability(raw: Any) -> float | None:
     if not isinstance(raw, (int, float)):
         return None
     value = float(raw)
+    # NaN/Inf would slip past the range checks below (NaN comparisons are
+    # always False; +Inf > 1 catches it but -Inf < 0 also does, leaving
+    # NaN as the real concern). Reject them up front. CodeRabbit Minor: PR #1226.
+    if not math.isfinite(value):
+        return None
     if value < 0.0 or value > 1.0:
         return None
     return value

--- a/utils/activity_config.py
+++ b/utils/activity_config.py
@@ -28,8 +28,14 @@ global settings. The activity sub-dict lives there:
         "unfinished_thread_window_seconds": 300,
         "unfinished_thread_max_followups": 2,
         "gaming_gpu_threshold_percent": 60,
-        "gaming_gpu_max_idle_seconds": 60
+        "gaming_gpu_max_idle_seconds": 60,
+        "work_break_minutes": 30,
+        "work_break_pending_window_seconds": 300,
+        "anti_slack_min_focus_minutes": 5,
+        "anti_slack_cooldown_minutes": 15,
+        "anti_slack_pending_window_seconds": 300
       },
+      "work_break_game_invite_probability": 0.5,
       "user_app_overrides": {
         "MyCompanyApp.exe": {"category": "work", "subcategory": "office", "canonical": "MyCompanyApp"},
         "OurGameLauncher.exe": {"category": "gaming", "subcategory": "game"}
@@ -164,6 +170,13 @@ class ActivityPreferences:
     # Skip probability overrides. Keys are intensity-only ('competitive')
     # or intensity_genre ('immersive_horror'); values in [0, 1].
     skip_probability_overrides: dict[str, float] = field(default_factory=dict)
+
+    # Probability that a fired water-break reminder pivots into a "rest +
+    # mini-game invite" branch instead of the regular drink/stretch nudge.
+    # Lives outside ``thresholds`` because 0 is a meaningful value here
+    # ("disable the game-invite branch entirely") and ``_parse_thresholds``
+    # rejects non-positive numbers. None == use code default (0.5).
+    work_break_game_invite_probability: float | None = None
 
 
 # ── Module-level cache ────────────────────────────────────────────────
@@ -344,7 +357,27 @@ def _parse_activity_section(section: dict) -> ActivityPreferences:
         skip_probability_overrides=_parse_skip_overrides(
             section.get('skip_probability_overrides'),
         ),
+        work_break_game_invite_probability=_parse_unit_probability(
+            section.get('work_break_game_invite_probability'),
+        ),
     )
+
+
+def _parse_unit_probability(raw: Any) -> float | None:
+    """Probability value in [0, 1]. None / non-numeric / out-of-range → None.
+
+    Distinct from ``_parse_thresholds`` because 0 is a meaningful value
+    (disabled), so the >0 invariant doesn't apply. Returns None when the
+    user didn't supply this key, signalling "fall through to the code
+    default" rather than "disabled".
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return None
+    if not isinstance(raw, (int, float)):
+        return None
+    return max(0.0, min(1.0, float(raw)))
 
 
 def _parse_thresholds(raw: Any) -> dict[str, float]:


### PR DESCRIPTION
## Summary
- 在 user-activity-tracker 上层加两个 must-fire 提醒分支，走 proactive_chat 链路、跳 Phase 1、用极简 prompt 让 AI 自由发挥
- 喝水提醒：focused_work 累计 30min 触发，50% 概率叠成"休息+足球小游戏邀请"、共享 mini-game 24h cooldown
- 防摸鱼提醒：focused_work → casual_browsing/gaming 触发，min 5min focus 起步 + 15min 行为冷却
- 顺手把 idle 的 tone 从 concise 改成 playful——桌宠开着摸鱼时 businesslike 听着别扭

## 设计要点

**累计器规则**（[main_logic/activity/tracker.py](main_logic/activity/tracker.py)）：
- focused_work：+20s
- transitioning 且 acc>0：+20s（不打断已开始的专注，IDE↔终端↔文档的快速切换不重置）
- 其它任何状态：立即归零
- 单 tick 上限 30s（防进程挂起后 silently 给用户记一小时假专注）
- 通过 20s `_activity_guess_loop` heartbeat 同步 tick，state 变化能被及时捕获

**喝水提醒** —— 不 pin seed、不 pin 时间窗：累计跨 30min 阈值后只要 state==focused_work 必触发（`work_break_pending` 字段），AI 拿到的种子词在投递时现抽（喝水/活动/休息眼睛/伸懒腰/放松），背景带 `{minutes}` 工作时长。50% 分流走"休息+游戏邀请"组合（共享 mini-game cooldown，cooldown 期内自动让位）。

**防摸鱼提醒** —— 单一行为不需要 seed 列表，变化全靠 `{prev_app}` / `{new_app}` / `{minutes}` + AI 人设。命中状态只盯 `casual_browsing` 和 `gaming`（idle 排除——可能在思考；transitioning/voice/chatting/away/private 都排除）。

**渲染路径**（[main_routers/system_router.py](main_routers/system_router.py) `_deliver_break_reminder_via_llm`）：
- 跳 Phase 1（无 source 抓取、无 enabled_modes 解析、无 propensity 收紧）
- Phase 2 极简：character_prompt + 一段叙述式 env-notice（参照 GREETING_PROMPT_SHORT 风格），不塞 source / state_section / 历史
- 必触发分支放在 `propensity=closed` 之后、`skip_probability` 之前，绕过所有正常 gate

**i18n** —— 5 locale 全覆盖（zh/en/ja/ko/ru），分隔符按项目规约 `======以下/以上======` 对偶。

**用户可调旋钮**（`user_preferences.json::__global_conversation__::activity`）：
- `thresholds.work_break_minutes`（默认 30）
- `thresholds.anti_slack_min_focus_minutes`（默认 5）
- `thresholds.anti_slack_cooldown_minutes`（默认 15）
- `work_break_game_invite_probability`（默认 0.5，0 = 关闭游戏邀请分流）

## 文件改动

- [config/prompts_activity.py](config/prompts_activity.py): +153 行（种子表 + 3 个模板表，5 locale 全覆盖）
- [main_logic/activity/snapshot.py](main_logic/activity/snapshot.py): +55 行（`WorkBreakPending` / `AntiSlackPending` + idle→playful tone）
- [main_logic/activity/tracker.py](main_logic/activity/tracker.py): +354 行（累计器 + transition 检测 + 公共 mark API + 20s loop hook）
- [main_routers/system_router.py](main_routers/system_router.py): +452 行（4 个渲染辅助 + 极简 Phase 2 投递 + 必触发分支）
- [utils/activity_config.py](utils/activity_config.py): +35 行（probability 字段独立解析）
- [tests/test_activity_tracker_followup.py](tests/test_activity_tracker_followup.py): +234 行（12 个新测试 pin 累计器 / transition / cooldown / mark_used / 长间隔保护）

## Test plan
- [x] `tests/test_activity_tracker_followup.py` 60 tests passing（含 12 个新增）
- [x] `tests/unit/test_mini_game_invite.py` 89 tests passing（cooldown 互通无回归）
- [x] 全量 sweep: `tests/test_activity_tracker_followup.py tests/unit/test_mini_game_invite.py tests/unit/test_game_router.py tests/unit/test_proactive_action_note.py tests/unit/test_proactive_sid_guard.py tests/unit/test_session_state.py tests/unit/test_proactive_text_does_not_dehumanize.py tests/unit/test_voice_session.py` → 389 passed, 3 skipped
- [x] `scripts/check_prompt_hygiene.py` exit=0
- [x] `scripts/check_i18n.py` 通过

## 待手测（需后端拉起 + 真用户场景）
- [ ] 在 IDE 里挂 30min 后桌宠真的会主动喝水提醒，且 prompt log 里能看到种子词
- [ ] 喝水触发的 50% 命中能弹出 mini-game 三选项 popup，accept 能正常进入小游戏
- [ ] focused_work → 切去 B 站/Steam 时桌宠真的会反讽一句"摸鱼啦"
- [ ] 5 个 locale（中英日韩俄）切换后提示词都能正确渲染、AI 输出对应语言
- [ ] 防摸鱼 15min 冷却内不会重复触发（连续切两次工作软件→YouTube）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 主动工作休息提醒（饮水/伸展/护眼）与反懒散提醒（从专注切换到休闲提示回归）
  * 工作休息提醒可在部分情况下替换为“休息+迷你游戏邀请”，并记录邀请状态与冷却
  * 新偏好项支持设置迷你游戏邀请概率

* **改进**
  * 空闲/随意浏览语调调整为更具趣味性
  * 俄语活动显示增加“仅时间”格式

* **修复**
  * 迷你游戏邀请概率解析更稳健：无效或越界值视为未设置

* **测试**
  * 增加了围绕休息提醒、过渡检测与概率解析的单元测试和回归验证
<!-- end of auto-generated comment: release notes by coderabbit.ai -->