### PR TITLE
 fix(galgame): 优化 OCR 截图噪声过滤与 RapidOCR 状态处理

### DIFF
--- a/plugin/plugins/galgame_plugin/models.py
+++ b/plugin/plugins/galgame_plugin/models.py
@@ -586,12 +586,10 @@ class GalgameRapidOcrConfig:
     # deleted runtime install machinery.
     rapidocr_install_target_dir: str = ""
     rapidocr_engine_type: str = "onnxruntime"
-    # Default lang `japan` and version `PP-OCRv4` reflect galgame_plugin's
-    # primary use case (Japanese visual novels) and bundled-no-download
-    # constraint (v4 + japan rec is downloadable; v5 + japan has no upstream
-    # rec model). Existing configs that explicitly set other values are
-    # preserved by the loader; only unset values fall through to defaults.
-    rapidocr_lang_type: str = "japan"
+    # Default to the bundled Chinese PP-OCRv4 model. Japanese games can opt
+    # back into `japan`; existing configs that explicitly set other values are
+    # preserved by the loader.
+    rapidocr_lang_type: str = "ch"
     rapidocr_model_type: str = "mobile"
     rapidocr_ocr_version: str = "PP-OCRv4"
 

--- a/plugin/plugins/galgame_plugin/ocr_chrome_noise.py
+++ b/plugin/plugins/galgame_plugin/ocr_chrome_noise.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+
+ASCII_ID_RE = re.compile(r"[a-z0-9]+")
+TEMPERATURE_STATUS_RE = re.compile(
+    r"^\s*[+-]?\d{1,2}\s*(?:\N{DEGREE SIGN}\s*[cC\N{DEGREE CELSIUS}]?|\N{DEGREE CELSIUS})\s*$"
+)
+
+WINDOW_TITLE_TOP_MAX_RATIO = 0.06
+TEMPERATURE_STATUS_BOTTOM_MIN_RATIO = 0.95
+TEMPERATURE_STATUS_LEFT_MAX_RATIO = 0.20
+
+
+def compact_ascii_id(value: str) -> str:
+    return "".join(ASCII_ID_RE.findall(str(value or "").casefold()))
+
+
+def looks_like_window_title_line(line: str, window_title: str) -> bool:
+    title_key = compact_ascii_id(window_title)
+    if len(title_key) < 4:
+        return False
+    line_key = compact_ascii_id(line)
+    if not line_key:
+        return False
+    if line_key == title_key:
+        return True
+    return title_key.startswith(line_key) and len(title_key) <= len(line_key) + 3
+
+
+def looks_like_temperature_status_line(line: str) -> bool:
+    return bool(TEMPERATURE_STATUS_RE.match(str(line or "")))

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -61,6 +61,10 @@ from .models import (
     sanitize_screen_ui_elements,
     parse_ocr_capture_profile_bucket_key,
 )
+from .ocr_chrome_noise import (
+    looks_like_temperature_status_line as _looks_like_temperature_status_line,
+    looks_like_window_title_line as _looks_like_window_title_line,
+)
 from .aihong_state import (
     AIHONG_CHOICES_REGION_PRESET as _AIHONG_CHOICES_REGION_PRESET,
     AIHONG_DIALOGUE_CAPTURE_PROFILE_PRESET as _AIHONG_DIALOGUE_CAPTURE_PROFILE_PRESET,
@@ -285,10 +289,6 @@ _OCR_TRAILING_GARBAGE_AFTER_DASH_RE = re.compile(
 _OCR_STABILITY_IGNORED_CHARS_RE = re.compile(
     r"[\s　\-_.,，。:：;；!！?？…~～'\"“”‘’「」『』()\[\]［］【】]+"
 )
-_OCR_TEMPERATURE_STATUS_RE = re.compile(
-    r"^\s*[+-]?\d{1,2}\s*(?:°\s*[cC℃]?|℃)\s*$"
-)
-_OCR_ASCII_ID_RE = re.compile(r"[a-z0-9]+")
 _OCR_FOLLOWUP_CONFIRM_DELAY_SECONDS = 0.18
 _OCR_CAPTURE_TIMEOUT_SECONDS = 12.0
 _OCR_MAX_ABANDONED_CAPTURE_WORKERS = 1
@@ -526,22 +526,6 @@ def _clean_ocr_dialogue_text(text: str) -> str:
     return cleaned
 
 
-def _compact_ocr_ascii_id(value: str) -> str:
-    return "".join(_OCR_ASCII_ID_RE.findall(str(value or "").casefold()))
-
-
-def _looks_like_window_title_ocr_line(line: str, window_title: str) -> bool:
-    title_key = _compact_ocr_ascii_id(window_title)
-    if len(title_key) < 4:
-        return False
-    line_key = _compact_ocr_ascii_id(line)
-    if not line_key:
-        return False
-    if line_key == title_key:
-        return True
-    return title_key.startswith(line_key) and len(title_key) <= len(line_key) + 3
-
-
 def _drop_ocr_chrome_noise_lines(text: str, *, window_title: str = "") -> str:
     lines = [line.strip() for line in str(text or "").splitlines()]
     meaningful = [line for line in lines if line]
@@ -550,8 +534,8 @@ def _drop_ocr_chrome_noise_lines(text: str, *, window_title: str = "") -> str:
     filtered = [
         line
         for line in meaningful
-        if not _OCR_TEMPERATURE_STATUS_RE.match(line)
-        and not _looks_like_window_title_ocr_line(line, window_title)
+        if not _looks_like_temperature_status_line(line)
+        and not _looks_like_window_title_line(line, window_title)
     ]
     if filtered and len(filtered) < len(meaningful):
         return "\n".join(filtered)

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -539,7 +539,7 @@ def _looks_like_window_title_ocr_line(line: str, window_title: str) -> bool:
         return False
     if line_key == title_key:
         return True
-    return line_key.startswith(title_key) and len(line_key) <= len(title_key) + 3
+    return title_key.startswith(line_key) and len(title_key) <= len(line_key) + 3
 
 
 def _drop_ocr_chrome_noise_lines(text: str, *, window_title: str = "") -> str:
@@ -2695,15 +2695,11 @@ class PrintWindowCaptureBackend:
 
     def capture_frame(self, target: DetectedGameWindow, profile: OcrCaptureProfile) -> Any:
         _require_visible_capture_target(target, backend_kind=self.kind)
-        window_rect = _target_window_rect(target)
-        rect = _target_content_rect(target)
-        image = self._capture_full_window(target.hwnd, window_rect)
-        if rect != window_rect:
-            image = _crop_image_to_screen_rect(
-                image,
-                image_rect=window_rect,
-                crop_rect=rect,
-            )
+        try:
+            rect = _target_screen_capture_rect(target)
+        except Exception:
+            rect = _target_content_rect(target)
+        image = self._capture_full_window(target.hwnd, rect)
         return _crop_window_image(
             image,
             window_rect=rect,
@@ -6571,6 +6567,23 @@ class OcrReaderManager:
         state.last_block_reason = ""
         return True
 
+    def _ocr_window_title_for_noise_filter(self) -> str:
+        return str(
+            (self._attached_window.title if self._attached_window is not None else "")
+            or self._runtime.effective_window_title
+            or self._runtime.window_title
+            or ""
+        )
+
+    def _clean_ocr_dialogue_for_emit(self, raw_text: str) -> tuple[str, str]:
+        content_text = _drop_ocr_chrome_noise_lines(
+            raw_text,
+            window_title=self._ocr_window_title_for_noise_filter(),
+        )
+        cleaned_text = _clean_ocr_dialogue_text(content_text)
+        cleaned_text = _fix_ocr_punctuation_confusion(cleaned_text)
+        return content_text, cleaned_text
+
     def _emit_line_from_ocr_text(
         self,
         raw_text: str,
@@ -6582,17 +6595,7 @@ class OcrReaderManager:
         ocr_confidence: float | None = None,
         text_source: str = "bottom_region",
     ) -> bool:
-        content_text = _drop_ocr_chrome_noise_lines(
-            raw_text,
-            window_title=str(
-                (self._attached_window.title if self._attached_window is not None else "")
-                or self._runtime.effective_window_title
-                or self._runtime.window_title
-                or ""
-            ),
-        )
-        cleaned_text = _clean_ocr_dialogue_text(content_text)
-        cleaned_text = _fix_ocr_punctuation_confusion(cleaned_text)
+        content_text, cleaned_text = self._clean_ocr_dialogue_for_emit(raw_text)
         if (
             _looks_like_noise_normalized_text(cleaned_text)
             or _looks_like_game_overlay_normalized_text(cleaned_text)
@@ -6688,13 +6691,14 @@ class OcrReaderManager:
             choice_bounds_metadata=choice_bounds_metadata,
         )
 
-    @staticmethod
     def _should_attempt_followup_confirm(
+        self,
         raw_text: str,
         *,
         state: _StableOcrTextState,
     ) -> bool:
-        cleaned = normalize_text(_clean_ocr_dialogue_text(raw_text)).strip()
+        _, cleaned_text = self._clean_ocr_dialogue_for_emit(raw_text)
+        cleaned = normalize_text(cleaned_text).strip()
         if not cleaned:
             return False
         cleaned_key = _ocr_stability_key(cleaned)

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2335,6 +2335,51 @@ def _intersect_screen_rect(
     return rect if _valid_screen_rect(rect) else None
 
 
+def _bounding_screen_rect(
+    rects: Iterable[tuple[int, int, int, int]],
+) -> tuple[int, int, int, int] | None:
+    valid_rects = [rect for rect in rects if _valid_screen_rect(rect)]
+    if not valid_rects:
+        return None
+    return (
+        min(int(rect[0]) for rect in valid_rects),
+        min(int(rect[1]) for rect in valid_rects),
+        max(int(rect[2]) for rect in valid_rects),
+        max(int(rect[3]) for rect in valid_rects),
+    )
+
+
+def _target_monitor_work_rects(
+    rect: tuple[int, int, int, int],
+) -> list[tuple[int, int, int, int]]:
+    try:
+        import win32api
+
+        enum_display_monitors = getattr(win32api, "EnumDisplayMonitors", None)
+        if not callable(enum_display_monitors):
+            return []
+        try:
+            monitors = enum_display_monitors(None, tuple(int(value) for value in rect))
+        except TypeError:
+            monitors = enum_display_monitors()
+
+        work_rects: list[tuple[int, int, int, int]] = []
+        for monitor_info in monitors:
+            monitor = monitor_info[0]
+            try:
+                info = win32api.GetMonitorInfo(monitor)
+            except Exception:
+                continue
+            work = info.get("Work") if isinstance(info, dict) else None
+            if isinstance(work, tuple) and len(work) == 4:
+                work_rect = tuple(int(value) for value in work)
+                if _valid_screen_rect(work_rect):
+                    work_rects.append(work_rect)
+        return work_rects
+    except Exception:
+        return []
+
+
 def _target_monitor_work_rect(target: DetectedGameWindow) -> tuple[int, int, int, int] | None:
     try:
         import win32api
@@ -2348,6 +2393,22 @@ def _target_monitor_work_rect(target: DetectedGameWindow) -> tuple[int, int, int
     except Exception:
         return None
     return None
+
+
+def _target_work_area_capture_rect(
+    target: DetectedGameWindow,
+    rect: tuple[int, int, int, int],
+) -> tuple[int, int, int, int] | None:
+    work_rects = _target_monitor_work_rects(rect)
+    if not work_rects:
+        work_rect = _target_monitor_work_rect(target)
+        work_rects = [work_rect] if work_rect is not None else []
+    intersections = (
+        intersection
+        for work_rect in work_rects
+        if (intersection := _intersect_screen_rect(rect, work_rect)) is not None
+    )
+    return _bounding_screen_rect(intersections)
 
 
 def _target_window_uses_overlapped_chrome(target: DetectedGameWindow) -> bool:
@@ -2375,10 +2436,7 @@ def _target_screen_capture_rect(target: DetectedGameWindow) -> tuple[int, int, i
     rect = _target_content_rect(target)
     if not _target_window_uses_overlapped_chrome(target):
         return rect
-    work_rect = _target_monitor_work_rect(target)
-    if work_rect is None:
-        return rect
-    clipped = _intersect_screen_rect(rect, work_rect)
+    clipped = _target_work_area_capture_rect(target, rect)
     return clipped or rect
 
 

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -285,6 +285,10 @@ _OCR_TRAILING_GARBAGE_AFTER_DASH_RE = re.compile(
 _OCR_STABILITY_IGNORED_CHARS_RE = re.compile(
     r"[\s　\-_.,，。:：;；!！?？…~～'\"“”‘’「」『』()\[\]［］【】]+"
 )
+_OCR_TEMPERATURE_STATUS_RE = re.compile(
+    r"^\s*[+-]?\d{1,2}\s*(?:°\s*[cC℃]?|℃)\s*$"
+)
+_OCR_ASCII_ID_RE = re.compile(r"[a-z0-9]+")
 _OCR_FOLLOWUP_CONFIRM_DELAY_SECONDS = 0.18
 _OCR_CAPTURE_TIMEOUT_SECONDS = 12.0
 _OCR_MAX_ABANDONED_CAPTURE_WORKERS = 1
@@ -520,6 +524,38 @@ def _clean_ocr_dialogue_text(text: str) -> str:
     cleaned = _OCR_TRAILING_GARBAGE_AFTER_BRACKET_RE.sub(r"\1", cleaned).strip()
     cleaned = _OCR_TRAILING_GARBAGE_AFTER_DASH_RE.sub(r"\1", cleaned).strip()
     return cleaned
+
+
+def _compact_ocr_ascii_id(value: str) -> str:
+    return "".join(_OCR_ASCII_ID_RE.findall(str(value or "").casefold()))
+
+
+def _looks_like_window_title_ocr_line(line: str, window_title: str) -> bool:
+    title_key = _compact_ocr_ascii_id(window_title)
+    if len(title_key) < 4:
+        return False
+    line_key = _compact_ocr_ascii_id(line)
+    if not line_key:
+        return False
+    if line_key == title_key:
+        return True
+    return line_key.startswith(title_key) and len(line_key) <= len(title_key) + 3
+
+
+def _drop_ocr_chrome_noise_lines(text: str, *, window_title: str = "") -> str:
+    lines = [line.strip() for line in str(text or "").splitlines()]
+    meaningful = [line for line in lines if line]
+    if len(meaningful) < 2:
+        return str(text or "")
+    filtered = [
+        line
+        for line in meaningful
+        if not _OCR_TEMPERATURE_STATUS_RE.match(line)
+        and not _looks_like_window_title_ocr_line(line, window_title)
+    ]
+    if filtered and len(filtered) < len(meaningful):
+        return "\n".join(filtered)
+    return str(text or "")
 
 
 def _ocr_stability_key(text: str) -> str:
@@ -825,6 +861,21 @@ def _score_ocr_text(text: str) -> tuple[float, int, int]:
         - (isolated_ascii_tokens * 2.0)
     )
     return (score, cjk_count + kana_count, significant_chars)
+
+
+_PUNCTUATION_CONFUSION_FIXES = [
+    (re.compile(r"(?<=[^\x00-\x7F])\.(?![\x00-\x7F])"), "。"),
+    (re.compile(r"(?<=[^\x00-\x7F])\s*,\s*(?=[^\x00-\x7F])"), "、"),
+    (re.compile(r"(?<=[^\x00-\x7F])!(?![\x00-\x7F])"), "！"),
+    (re.compile(r"(?<=[^\x00-\x7F])\?(?![\x00-\x7F])"), "？"),
+]
+
+
+def _fix_ocr_punctuation_confusion(text: str) -> str:
+    value = str(text or "")
+    for pattern, replacement in _PUNCTUATION_CONFUSION_FIXES:
+        value = pattern.sub(replacement, value)
+    return value
 
 
 def _significant_char_count(text: str) -> int:
@@ -2284,6 +2335,69 @@ def _target_window_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]
     return rect
 
 
+def _valid_screen_rect(rect: tuple[int, int, int, int]) -> bool:
+    return int(rect[2] - rect[0]) > 0 and int(rect[3] - rect[1]) > 0
+
+
+def _intersect_screen_rect(
+    first: tuple[int, int, int, int],
+    second: tuple[int, int, int, int],
+) -> tuple[int, int, int, int] | None:
+    left = max(int(first[0]), int(second[0]))
+    top = max(int(first[1]), int(second[1]))
+    right = min(int(first[2]), int(second[2]))
+    bottom = min(int(first[3]), int(second[3]))
+    rect = (left, top, right, bottom)
+    return rect if _valid_screen_rect(rect) else None
+
+
+def _target_monitor_work_rect(target: DetectedGameWindow) -> tuple[int, int, int, int] | None:
+    try:
+        import win32api
+
+        monitor = win32api.MonitorFromWindow(int(target.hwnd), 2)
+        info = win32api.GetMonitorInfo(monitor)
+        work = info.get("Work") if isinstance(info, dict) else None
+        if isinstance(work, tuple) and len(work) == 4:
+            rect = tuple(int(value) for value in work)
+            return rect if _valid_screen_rect(rect) else None
+    except Exception:
+        return None
+    return None
+
+
+def _target_window_uses_overlapped_chrome(target: DetectedGameWindow) -> bool:
+    try:
+        import win32con
+        import win32gui
+
+        style = int(win32gui.GetWindowLong(int(target.hwnd), win32con.GWL_STYLE))
+        return bool(style & (win32con.WS_CAPTION | win32con.WS_THICKFRAME))
+    except Exception:
+        return False
+
+
+def _target_content_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    try:
+        rect = _target_client_rect(target)
+        if _valid_screen_rect(rect):
+            return rect
+    except Exception:
+        pass
+    return _target_window_rect(target)
+
+
+def _target_screen_capture_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    rect = _target_content_rect(target)
+    if not _target_window_uses_overlapped_chrome(target):
+        return rect
+    work_rect = _target_monitor_work_rect(target)
+    if work_rect is None:
+        return rect
+    clipped = _intersect_screen_rect(rect, work_rect)
+    return clipped or rect
+
+
 def _target_window_capture_state(target: DetectedGameWindow | None) -> tuple[bool, bool, bool, str]:
     if target is None:
         return False, False, False, "target_missing"
@@ -2432,6 +2546,21 @@ def _crop_window_image(
     return cropped
 
 
+def _crop_image_to_screen_rect(
+    image: Any,
+    *,
+    image_rect: tuple[int, int, int, int],
+    crop_rect: tuple[int, int, int, int],
+) -> Any:
+    crop_left = max(0, int(crop_rect[0] - image_rect[0]))
+    crop_top = max(0, int(crop_rect[1] - image_rect[1]))
+    crop_right = min(int(image.size[0]), int(crop_rect[2] - image_rect[0]))
+    crop_bottom = min(int(image.size[1]), int(crop_rect[3] - image_rect[1]))
+    if crop_right <= crop_left or crop_bottom <= crop_top:
+        raise RuntimeError("Crop region outside source image")
+    return image.crop((crop_left, crop_top, crop_right, crop_bottom))
+
+
 class MssCaptureBackend:
     kind = _CAPTURE_BACKEND_MSS
 
@@ -2463,7 +2592,7 @@ class MssCaptureBackend:
         from PIL import Image
 
         _require_visible_capture_target(target, backend_kind=self.kind)
-        rect = _target_window_rect(target)
+        rect = _target_screen_capture_rect(target)
         left, top, right, bottom = rect
         monitor = {
             "left": int(left),
@@ -2526,7 +2655,7 @@ class PyAutoGuiCaptureBackend:
         from PIL import ImageGrab
 
         _require_visible_capture_target(target, backend_kind=self.kind)
-        rect = _target_window_rect(target)
+        rect = _target_screen_capture_rect(target)
         left, top, right, bottom = rect
         # all_screens=True is Windows-only in Pillow but harmlessly ignored
         # on macOS/Linux — covers multi-monitor layouts including secondary
@@ -2566,8 +2695,15 @@ class PrintWindowCaptureBackend:
 
     def capture_frame(self, target: DetectedGameWindow, profile: OcrCaptureProfile) -> Any:
         _require_visible_capture_target(target, backend_kind=self.kind)
-        rect = _target_window_rect(target)
-        image = self._capture_full_window(target.hwnd, rect)
+        window_rect = _target_window_rect(target)
+        rect = _target_content_rect(target)
+        image = self._capture_full_window(target.hwnd, window_rect)
+        if rect != window_rect:
+            image = _crop_image_to_screen_rect(
+                image,
+                image_rect=window_rect,
+                crop_rect=rect,
+            )
         return _crop_window_image(
             image,
             window_rect=rect,
@@ -2692,7 +2828,7 @@ class DxcamCaptureBackend:
         from PIL import Image
 
         _require_visible_capture_target(target, backend_kind=self.kind)
-        rect = _target_window_rect(target)
+        rect = _target_screen_capture_rect(target)
         frame = None
         with self._camera_lock:
             now = time.monotonic()
@@ -6159,6 +6295,22 @@ class OcrReaderManager:
         if backend_plan is not None and not backend_plan.primary.available:
             raise ValueError("当前 OCR backend 不可用，无法自动重校准对白区")
 
+        min_top_ratio = 0.04
+        try:
+            client_rect = _target_client_rect(target)
+            client_height = int(client_rect[3] - client_rect[1])
+            if client_height > 0 and image_height > client_height:
+                title_bar_height = image_height - client_height
+                min_top_ratio = max(
+                    min_top_ratio,
+                    round(title_bar_height / image_height + 0.02, 2),
+                )
+        except Exception:
+            pass
+        top_values = [value for value in top_values if value >= min_top_ratio]
+        if not top_values:
+            top_values = [min_top_ratio]
+
         best_candidate: dict[str, Any] | None = None
         current_distance_basis = (
             round(base_profile.top_ratio, 2),
@@ -6430,14 +6582,24 @@ class OcrReaderManager:
         ocr_confidence: float | None = None,
         text_source: str = "bottom_region",
     ) -> bool:
-        cleaned_text = _clean_ocr_dialogue_text(raw_text)
+        content_text = _drop_ocr_chrome_noise_lines(
+            raw_text,
+            window_title=str(
+                (self._attached_window.title if self._attached_window is not None else "")
+                or self._runtime.effective_window_title
+                or self._runtime.window_title
+                or ""
+            ),
+        )
+        cleaned_text = _clean_ocr_dialogue_text(content_text)
+        cleaned_text = _fix_ocr_punctuation_confusion(cleaned_text)
         if (
             _looks_like_noise_normalized_text(cleaned_text)
             or _looks_like_game_overlay_normalized_text(cleaned_text)
             or not _looks_like_ocr_dialogue_normalized_text(cleaned_text)
         ):
             return False
-        self._record_accepted_ocr_text(raw_text)
+        self._record_accepted_ocr_text(content_text)
         speaker, text = OcrReaderBridgeWriter._split_speaker_text(cleaned_text)
         had_pending_visual_scene = bool(self._pending_visual_scene_hash)
         if self._pending_visual_scene_hash:
@@ -8475,16 +8637,20 @@ class OcrReaderManager:
                 if callable(extract_with_boxes):
                     try:
                         text, boxes = extract_with_boxes(image)
-                        if not str(text or "").strip() and not isinstance(
-                            descriptor.backend,
-                            RapidOcrBackend,
-                        ):
-                            extract_text = getattr(descriptor.backend, "extract_text", None)
-                            if callable(extract_text):
-                                fallback_text = extract_text(image)
-                                if str(fallback_text or "").strip():
-                                    text = fallback_text
-                                    boxes = []
+                        if not str(text or "").strip():
+                            if not isinstance(descriptor.backend, RapidOcrBackend):
+                                extract_text = getattr(descriptor.backend, "extract_text", None)
+                                if callable(extract_text):
+                                    fallback_text = extract_text(image)
+                                    if str(fallback_text or "").strip():
+                                        text = fallback_text
+                                        boxes = []
+                            elif index == 0:
+                                warnings.append(
+                                    f"ocr_reader {descriptor.kind} returned empty text "
+                                    "(confidence filtering may have discarded all tokens)"
+                                )
+                                continue
                     except Exception as boxes_exc:
                         extract_text = getattr(descriptor.backend, "extract_text", None)
                         if not callable(extract_text):

--- a/plugin/plugins/galgame_plugin/plugin.toml
+++ b/plugin/plugins/galgame_plugin/plugin.toml
@@ -116,11 +116,10 @@ install_manifest_url = ""
 install_target_dir = ""
 install_timeout_seconds = 180
 engine_type = "onnxruntime"
-# Default `japan` rec + `PP-OCRv4` matches the primary use case (Japanese
-# visual novels). v4 + ch is bundled in the wheel; v4 + japan triggers an
-# explicit user-confirmed model download on first run (see install_routes
-# /rapidocr-models/download).
-lang_type = "japan"
+# Default to the bundled Chinese model for better Chinese VN OCR. Japanese
+# games can switch this back to `japan`; discrete GPUs may prefer
+# `model_type = "server"` for higher accuracy at higher latency.
+lang_type = "ch"
 model_type = "mobile"
 ocr_version = "PP-OCRv4"
 

--- a/plugin/plugins/galgame_plugin/rapidocr_support.py
+++ b/plugin/plugins/galgame_plugin/rapidocr_support.py
@@ -22,11 +22,9 @@ from .memory_reader import is_windows_platform
 
 RAPIDOCR_PACKAGE_NAME = "rapidocr_onnxruntime"
 DEFAULT_RAPIDOCR_ENGINE_TYPE = "onnxruntime"
-# galgame_plugin's primary use case is Japanese visual novels — `japan` rec
-# is the right product default. The bundled wheel ships only ch+v4 models, so
-# the first run with `japan` will land on the `missing_model_files` flow and
-# offer the user an explicit, opt-in download (see download_rapidocr_models).
-DEFAULT_RAPIDOCR_LANG_TYPE = "japan"
+# Default to the bundled Chinese PP-OCRv4 model so minimal/older configs take
+# the no-download path. Japanese games can still opt into `japan` explicitly.
+DEFAULT_RAPIDOCR_LANG_TYPE = "ch"
 DEFAULT_RAPIDOCR_MODEL_TYPE = "mobile"
 # PP-OCRv4 keeps the bundled-no-download path working for ch+v4. v5 has
 # better quality but requires a download for everything (no bundled v5).
@@ -737,7 +735,7 @@ def inspect_rapidocr_installation(
             detail = "installed"
             # Same missing-models check as the bundled branch above. Without
             # this, an upgrade user on a legacy plugin-isolated install with
-            # `lang_type=japan` (default) would land on `installed` even when
+            # explicit `lang_type=japan` would land on `installed` even when
             # `japan_PP-OCRv4_rec_mobile.onnx` is absent — `can_download_models`
             # would stay False and OCR would silently fall back to the
             # bundled ch model with no UI affordance to fix it.

--- a/plugin/plugins/galgame_plugin/screen_classifier.py
+++ b/plugin/plugins/galgame_plugin/screen_classifier.py
@@ -39,6 +39,8 @@ _DIALOGUE_COLON_RE = re.compile(r"^[^:：]{1,40}[:：]\s*.+\S$")
 _SPEAKER_QUOTE_RE = re.compile(r"^[^「」『』:：]{1,40}[「『].+[」』]$")
 _BRACKET_SPEAKER_RE = re.compile(r"^[【\[][^\]】]{1,40}[\]】]\s*.+\S$")
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_TEMPERATURE_STATUS_RE = re.compile(r"^\s*[+-]?\d{1,2}\s*(?:°\s*[cC℃]?|℃)\s*$")
+_ASCII_ID_RE = re.compile(r"[a-z0-9]+")
 _LOGGER = logging.getLogger(__name__)
 _DEFAULT_MODEL_FEATURE_SCALES = {
     "mean_luminance": 255.0,
@@ -265,12 +267,23 @@ def classify_screen_from_ocr(
     )
     lines = _merged_ocr_lines(regions)
     ui_elements = _merged_screen_ui_elements(regions, lines=lines)
+    ui_elements, filtered_count = _filter_chrome_noise_ui_elements(
+        ui_elements,
+        window_title=str((template_context or {}).get("window_title") or ""),
+    )
+    if filtered_count > 0:
+        lines = _dedupe_preserve_order(
+            _clean_line(str(element.get("text") or ""))
+            for element in ui_elements
+            if _clean_line(str(element.get("text") or ""))
+        )
     visual = dict(visual_features or {})
     layout = _layout_features(ui_elements)
     debug: dict[str, Any] = {
         "sources": [region.source for region in regions if region.source],
         "line_count": len(lines),
         "ui_element_count": len(ui_elements),
+        "chrome_filtered_count": filtered_count,
         "visual": _bounded_debug_value(visual),
         "layout": layout,
         "reason": "",
@@ -679,6 +692,52 @@ def _ocr_lines(ocr_text: str, *, boxes: Iterable[Any] | None) -> list[str]:
         return _dedupe_preserve_order(lines)
     box_lines = [_clean_line(_box_text(box)) for box in list(boxes or [])]
     return _dedupe_preserve_order(line for line in box_lines if line)
+
+
+def _compact_ascii_id(value: str) -> str:
+    return "".join(_ASCII_ID_RE.findall(str(value or "").casefold()))
+
+
+def _looks_like_window_title_line(line: str, window_title: str) -> bool:
+    title_key = _compact_ascii_id(window_title)
+    if len(title_key) < 4:
+        return False
+    line_key = _compact_ascii_id(line)
+    if not line_key:
+        return False
+    if line_key == title_key:
+        return True
+    return line_key.startswith(title_key) and len(line_key) <= len(title_key) + 3
+
+
+def _filter_chrome_noise_ui_elements(
+    elements: list[dict[str, Any]],
+    *,
+    window_title: str,
+) -> tuple[list[dict[str, Any]], int]:
+    filtered: list[dict[str, Any]] = []
+    removed = 0
+    for element in elements:
+        text = _clean_line(str(element.get("text") or ""))
+        bounds = element.get("normalized_bounds")
+        if not isinstance(bounds, dict):
+            filtered.append(element)
+            continue
+        try:
+            top = float(bounds.get("top"))
+            bottom = float(bounds.get("bottom"))
+            left = float(bounds.get("left"))
+        except (TypeError, ValueError):
+            filtered.append(element)
+            continue
+        if top <= 0.06 and _looks_like_window_title_line(text, window_title):
+            removed += 1
+            continue
+        if bottom >= 0.95 and left <= 0.20 and _TEMPERATURE_STATUS_RE.match(text):
+            removed += 1
+            continue
+        filtered.append(element)
+    return filtered, removed
 
 
 def _screen_ui_elements(

--- a/plugin/plugins/galgame_plugin/screen_classifier.py
+++ b/plugin/plugins/galgame_plugin/screen_classifier.py
@@ -6,6 +6,13 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Iterable
 
+from .ocr_chrome_noise import (
+    TEMPERATURE_STATUS_BOTTOM_MIN_RATIO,
+    TEMPERATURE_STATUS_LEFT_MAX_RATIO,
+    WINDOW_TITLE_TOP_MAX_RATIO,
+    looks_like_temperature_status_line,
+    looks_like_window_title_line,
+)
 from .models import (
     MENU_PREFIX_RE as _MENU_PREFIX_RE,
     OCR_CAPTURE_PROFILE_STAGE_CONFIG,
@@ -39,8 +46,6 @@ _DIALOGUE_COLON_RE = re.compile(r"^[^:：]{1,40}[:：]\s*.+\S$")
 _SPEAKER_QUOTE_RE = re.compile(r"^[^「」『』:：]{1,40}[「『].+[」』]$")
 _BRACKET_SPEAKER_RE = re.compile(r"^[【\[][^\]】]{1,40}[\]】]\s*.+\S$")
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-_TEMPERATURE_STATUS_RE = re.compile(r"^\s*[+-]?\d{1,2}\s*(?:°\s*[cC℃]?|℃)\s*$")
-_ASCII_ID_RE = re.compile(r"[a-z0-9]+")
 _LOGGER = logging.getLogger(__name__)
 _DEFAULT_MODEL_FEATURE_SCALES = {
     "mean_luminance": 255.0,
@@ -694,22 +699,6 @@ def _ocr_lines(ocr_text: str, *, boxes: Iterable[Any] | None) -> list[str]:
     return _dedupe_preserve_order(line for line in box_lines if line)
 
 
-def _compact_ascii_id(value: str) -> str:
-    return "".join(_ASCII_ID_RE.findall(str(value or "").casefold()))
-
-
-def _looks_like_window_title_line(line: str, window_title: str) -> bool:
-    title_key = _compact_ascii_id(window_title)
-    if len(title_key) < 4:
-        return False
-    line_key = _compact_ascii_id(line)
-    if not line_key:
-        return False
-    if line_key == title_key:
-        return True
-    return line_key.startswith(title_key) and len(line_key) <= len(title_key) + 3
-
-
 def _filter_chrome_noise_ui_elements(
     elements: list[dict[str, Any]],
     *,
@@ -730,10 +719,14 @@ def _filter_chrome_noise_ui_elements(
         except (TypeError, ValueError):
             filtered.append(element)
             continue
-        if top <= 0.06 and _looks_like_window_title_line(text, window_title):
+        if top <= WINDOW_TITLE_TOP_MAX_RATIO and looks_like_window_title_line(text, window_title):
             removed += 1
             continue
-        if bottom >= 0.95 and left <= 0.20 and _TEMPERATURE_STATUS_RE.match(text):
+        if (
+            bottom >= TEMPERATURE_STATUS_BOTTOM_MIN_RATIO
+            and left <= TEMPERATURE_STATUS_LEFT_MAX_RATIO
+            and looks_like_temperature_status_line(text)
+        ):
             removed += 1
             continue
         filtered.append(element)

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -573,12 +573,7 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
     rapidocr = raw_config.get("rapidocr")
     rapidocr_obj = rapidocr if isinstance(rapidocr, dict) else {}
     rapidocr_lang_type_raw = str(rapidocr_obj.get("lang_type") or "").strip()
-    if not rapidocr_lang_type_raw:
-        _logger.warning(
-            'galgame_plugin rapidocr.lang_type is not set; set rapidocr.lang_type = "japan" '
-            "explicitly for Japanese games if you rely on Japanese OCR models."
-        )
-    elif rapidocr_lang_type_raw == "ch":
+    if rapidocr_lang_type_raw == "ch":
         _logger.warning(
             'galgame_plugin RapidOCR is using lang_type = "ch"; if this came from the '
             'packaged default, set rapidocr.lang_type = "japan" explicitly for Japanese games.'

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -572,6 +572,17 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
     ocr_reader_obj = ocr_reader if isinstance(ocr_reader, dict) else {}
     rapidocr = raw_config.get("rapidocr")
     rapidocr_obj = rapidocr if isinstance(rapidocr, dict) else {}
+    rapidocr_lang_type_raw = str(rapidocr_obj.get("lang_type") or "").strip()
+    if not rapidocr_lang_type_raw:
+        _logger.warning(
+            'galgame_plugin rapidocr.lang_type is not set; set rapidocr.lang_type = "japan" '
+            "explicitly for Japanese games if you rely on Japanese OCR models."
+        )
+    elif rapidocr_lang_type_raw == "ch":
+        _logger.warning(
+            'galgame_plugin RapidOCR is using lang_type = "ch"; if this came from the '
+            'packaged default, set rapidocr.lang_type = "japan" explicitly for Japanese games.'
+        )
 
     default_mode_obj = galgame_obj.get("default_mode")
     default_mode = (
@@ -826,10 +837,7 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
             rapidocr_obj.get("engine_type") or DEFAULT_RAPIDOCR_ENGINE_TYPE
         ).strip()
         or DEFAULT_RAPIDOCR_ENGINE_TYPE,
-        rapidocr_lang_type=str(
-            rapidocr_obj.get("lang_type") or DEFAULT_RAPIDOCR_LANG_TYPE
-        ).strip()
-        or DEFAULT_RAPIDOCR_LANG_TYPE,
+        rapidocr_lang_type=rapidocr_lang_type_raw or DEFAULT_RAPIDOCR_LANG_TYPE,
         rapidocr_model_type=str(
             rapidocr_obj.get("model_type") or DEFAULT_RAPIDOCR_MODEL_TYPE
         ).strip()

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -1824,7 +1824,7 @@ function buildFirstRunSteps(status = {}) {
         'ui.first_run.install_ocr.pending_models',
         '所选语言模型 ({lang} + {version}) 未下载。点击「立即下载模型」按钮，从 ModelScope 拉取约 {size} MB 的模型文件。',
         {
-          lang: rapidocr.lang_type || 'japan',
+          lang: rapidocr.lang_type || 'ch',
           version: rapidocr.ocr_version || 'PP-OCRv4',
           size: sizeMb,
         },
@@ -1837,7 +1837,7 @@ function buildFirstRunSteps(status = {}) {
         'ui.first_run.install_ocr.pending_models_manual',
         '所选语言模型 ({lang} + {version}) 未下载。当前环境不能自动下载，请按下方 RapidOCR 横幅说明手动放置模型后再刷新状态。',
         {
-          lang: rapidocr.lang_type || 'japan',
+          lang: rapidocr.lang_type || 'ch',
           version: rapidocr.ocr_version || 'PP-OCRv4',
         },
       );

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -2517,10 +2517,23 @@ function dependencySummaryItem(kind, status = {}) {
       && taskState?.state === 'installed'
       && hasMissingRapidOcrModelFiles(rapidocr);
     if (taskState && rapidocrModelsStillMissing && !taskCompletedButModelsMissing) {
+      const displayTaskState = kind === 'rapidocr' && taskState.state === 'running'
+        ? {
+            ...taskState,
+            labelText: uiT('ui.install.rapidocr.download_models.running', '后台下载模型中...'),
+            needsAttention: false,
+          }
+        : kind === 'rapidocr' && taskState.state === 'failed' && shouldOfferRapidOcrModelsDownload(rapidocr)
+          ? {
+              ...taskState,
+              labelText: uiT('ui.install.rapidocr.download_models.retry', '重试下载模型'),
+              needsAttention: true,
+            }
+          : taskState;
       return {
         kind,
         label: kind === 'rapidocr' ? 'RapidOCR' : getInstallConfig(taskKind).label,
-        ...taskState,
+        ...displayTaskState,
       };
     }
   }
@@ -5728,7 +5741,7 @@ function renderAgentStatus(payload) {
   const panelSummary = document.getElementById('agentPanelSummary');
   if (panelSummary) {
     const mode = latestStatus?.mode || 'companion';
-    const modeText = uiT(`ui.mode.${mode}`, mode);
+    const modeText = modeLabel(mode, mode);
     const inbound = payload.inbound_queue_size || 0;
     const outbound = payload.outbound_queue_size || 0;
     panelSummary.textContent = `${modeText} | in=${inbound} out=${outbound}`;

--- a/plugin/tests/unit/plugins/test_galgame_bridge.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge.py
@@ -4402,6 +4402,53 @@ def test_auto_recalibrate_ocr_dialogue_profile_selects_best_candidate_and_return
 
 
 @pytest.mark.plugin_unit
+def test_auto_recalibrate_ocr_dialogue_profile_excludes_title_bar(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_client_rect",
+        lambda target: (0, 50, target.width, target.height),
+    )
+    manager = OcrReaderManager(
+        logger=_Logger(),
+        config=build_config(
+            _make_effective_config(
+                bridge_root,
+                ocr_reader={
+                    "enabled": True,
+                    "top_ratio": 0.02,
+                    "bottom_inset_ratio": 0.58,
+                },
+            )
+        ),
+        platform_fn=lambda: True,
+        window_scanner=lambda: [],
+        capture_backend=_FakeImageCaptureBackend(size=(1000, 500)),
+        ocr_backend=_CropAwareOcrBackend(
+            lambda image: "这是排除标题栏后的对白文本。"
+            if getattr(image, "crop_box", (0, 0, 0, 0))[1] >= 60
+            else "the lamenting geese"
+        ),
+    )
+    manager._attached_window = DetectedGameWindow(
+        hwnd=503,
+        title="Demo Window",
+        process_name="DemoGame.exe",
+        pid=7103,
+        width=1000,
+        height=500,
+    )
+
+    payload = manager.auto_recalibrate_dialogue_profile()
+
+    assert payload["capture_profile"]["top_ratio"] >= 0.12
+    assert payload["sample_text"] == "这是排除标题栏后的对白文本。"
+
+
+@pytest.mark.plugin_unit
 def test_auto_recalibrate_aihong_dialogue_profile_can_escape_stale_narrow_bucket(
     tmp_path: Path,
 ) -> None:

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -39,6 +39,7 @@ from plugin.plugins.galgame_plugin.models import (
 )
 from plugin.plugins.galgame_plugin.ocr_reader import (
     DetectedGameWindow,
+    OcrBackendDescriptor,
     OcrCaptureProfile,
     OcrExtractionResult,
     OcrReaderBridgeWriter,
@@ -596,6 +597,38 @@ def test_screen_classifier_merges_full_frame_ocr_regions() -> None:
     assert classified.ui_elements[0]["text_source"] == "full_frame"
     assert classified.ui_elements[0]["normalized_bounds"]["left"] == pytest.approx(120.0 / 1280.0)
     assert classified.debug["sources"] == ["bottom_region", "full_frame"]
+
+
+def test_screen_classifier_filters_window_chrome_noise_from_regions() -> None:
+    boxes = [
+        OcrTextBox("TheLamentingGeese口×", 12.0, 4.0, 1260.0, 28.0, 0.9),
+        OcrTextBox("有人是猪马牛羊，有人是虎豹豺狼。", 140.0, 734.0, 780.0, 760.0, 0.96),
+        OcrTextBox("16°℃", 40.0, 980.0, 74.0, 996.0, 0.88),
+    ]
+
+    classified = classify_screen_from_ocr(
+        "",
+        ocr_regions=[
+            {
+                "source": "full_frame",
+                "text": "\n".join(box.text for box in boxes),
+                "boxes": boxes,
+                "bounds_metadata": {
+                    "bounds_coordinate_space": "capture",
+                    "source_size": {"width": 1296.0, "height": 999.0},
+                    "capture_rect": {"left": 5.0, "top": 61.0, "right": 1301.0, "bottom": 1060.0},
+                    "window_rect": {"left": 5.0, "top": 61.0, "right": 1301.0, "bottom": 1060.0},
+                },
+            }
+        ],
+        template_context={"window_title": "TheLamentingGeese"},
+    )
+
+    assert classified.raw_ocr_text == ["有人是猪马牛羊，有人是虎豹豺狼。"]
+    assert [element["text"] for element in classified.ui_elements] == [
+        "有人是猪马牛羊，有人是虎豹豺狼。"
+    ]
+    assert classified.debug["chrome_filtered_count"] == 2
 
 
 def test_screen_classifier_detects_blank_visual_transition_without_ocr() -> None:
@@ -1957,6 +1990,67 @@ def test_background_hash_excludes_bottom_dialogue_region() -> None:
         cropped_first.info["galgame_source_background_hash"]
         == cropped_second.info["galgame_source_background_hash"]
     )
+
+
+def test_screen_capture_rect_uses_client_area_and_clips_taskbar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _window()[0]
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_client_rect",
+        lambda _target: (5, 92, 1301, 1060),
+    )
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_window_uses_overlapped_chrome",
+        lambda _target: True,
+    )
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_monitor_work_rect",
+        lambda _target: (0, 0, 1920, 1040),
+    )
+
+    rect = galgame_ocr_reader._target_screen_capture_rect(target)
+
+    assert rect == (5, 92, 1301, 1040)
+
+
+def test_printwindow_client_crop_keeps_profile_coordinates_in_client_space() -> None:
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (120, 100), (0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 119, 19), fill=(255, 0, 0))
+    draw.rectangle((0, 20, 119, 99), fill=(0, 255, 0))
+
+    client_image = galgame_ocr_reader._crop_image_to_screen_rect(
+        image,
+        image_rect=(10, 10, 130, 110),
+        crop_rect=(10, 30, 130, 110),
+    )
+    cropped = galgame_ocr_reader._crop_window_image(
+        client_image,
+        window_rect=(10, 30, 130, 110),
+        profile=galgame_ocr_reader.OcrCaptureProfile(
+            left_inset_ratio=0.0,
+            right_inset_ratio=0.0,
+            top_ratio=0.0,
+            bottom_inset_ratio=0.0,
+        ),
+        backend_kind="test",
+        backend_detail="test",
+    )
+
+    assert cropped.size == (120, 80)
+    assert cropped.getpixel((0, 0)) == (0, 255, 0)
+    assert cropped.info["galgame_window_rect"] == {
+        "left": 10.0,
+        "top": 30.0,
+        "right": 130.0,
+        "bottom": 110.0,
+    }
 
 
 def test_ocr_capture_samples_dialogue_background_hash_at_low_frequency(tmp_path: Path) -> None:
@@ -5091,6 +5185,29 @@ def test_rapidocr_text_adapter_groups_lines_and_filters_low_confidence() -> None
     assert _rapidocr_text_from_output(output) == "雪乃Hello\n今天回家"
 
 
+def test_fix_ocr_punctuation_confusion_for_cjk_dialogue() -> None:
+    assert galgame_ocr_reader._fix_ocr_punctuation_confusion("这是对白.") == "这是对白。"
+    assert galgame_ocr_reader._fix_ocr_punctuation_confusion("但是, 另一个") == "但是、另一个"
+    assert galgame_ocr_reader._fix_ocr_punctuation_confusion("真的吗?") == "真的吗？"
+    assert galgame_ocr_reader._fix_ocr_punctuation_confusion("对白。") == "对白。"
+
+
+def test_ocr_dialogue_detection_accepts_fixed_cjk_punctuation() -> None:
+    fixed = galgame_ocr_reader._fix_ocr_punctuation_confusion("这是对白.")
+    assert galgame_ocr_reader._looks_like_ocr_dialogue_normalized_text(fixed)
+
+
+def test_drop_ocr_chrome_noise_lines_keeps_dialogue() -> None:
+    raw_text = "TheLamentingGeese\n有人是猪马牛羊，有人是虎豹豺狼。\n16°℃"
+
+    filtered = galgame_ocr_reader._drop_ocr_chrome_noise_lines(
+        raw_text,
+        window_title="TheLamentingGeese",
+    )
+
+    assert filtered == "有人是猪马牛羊，有人是虎豹豺狼。"
+
+
 @pytest.mark.asyncio
 async def test_ocr_reader_manager_auto_mode_prefers_rapidocr_when_available(
     tmp_path: Path,
@@ -5227,6 +5344,53 @@ async def test_ocr_reader_manager_falls_back_to_tesseract_after_rapidocr_runtime
     assert second.runtime["backend_kind"] == "tesseract"
     assert second.runtime["backend_detail"] == "fallback_after_runtime_error"
     assert any("rapidocr failed" in warning for warning in second.warnings)
+
+
+def test_extract_text_from_image_falls_back_when_rapidocr_boxes_are_empty(tmp_path: Path) -> None:
+    bridge_root = tmp_path / "bridge"
+    bridge_root.mkdir()
+
+    class _EmptyRapidOcrBackend(galgame_ocr_reader.RapidOcrBackend):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def extract_text_with_boxes(self, image):
+            del image
+            self.calls += 1
+            return "", []
+
+    rapidocr = _EmptyRapidOcrBackend()
+    tesseract = _FakeOcrBackend(["雪乃：你好。"])
+    manager = OcrReaderManager(
+        logger=_Logger(),
+        config=_make_config(bridge_root, enabled=True),
+        platform_fn=lambda: True,
+        window_scanner=_window,
+        capture_backend=_FakeCaptureBackend(),
+    )
+    plan = SelectedOcrBackendPlan(
+        primary=OcrBackendDescriptor(
+            kind="rapidocr",
+            backend=rapidocr,
+            available=True,
+            detail="selected_primary",
+        ),
+        fallback=OcrBackendDescriptor(
+            kind="tesseract",
+            backend=tesseract,
+            available=True,
+            detail="auto_fallback_from_rapidocr",
+        ),
+    )
+
+    result = manager._extract_text_from_image("image", plan=plan)
+
+    assert result.text == "雪乃：你好。"
+    assert result.backend.kind == "tesseract"
+    assert result.backend_detail == "fallback_after_runtime_error"
+    assert rapidocr.calls == 1
+    assert tesseract.calls == 1
+    assert any("rapidocr returned empty text" in warning for warning in result.warnings)
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -1582,7 +1582,7 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
             self.calls += 1
             if self.calls == 1:
                 started.set()
-                release.wait(timeout=2.0)
+                release.wait(timeout=0.5)
             return "雪乃：恢复后的台词。"
 
     backend = _BlockingOcrBackend()
@@ -1614,7 +1614,7 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
 
     try:
         first = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
-        assert started.wait(timeout=2.0) is True
+        assert started.wait(timeout=0.5) is True
         assert first.runtime["detail"] == "capture_failed"
         assert "timed out" in first.runtime["last_capture_error"]
 
@@ -2148,8 +2148,11 @@ def test_win32_capture_backend_explicit_selection_falls_back_with_detail() -> No
 
     backend = galgame_ocr_reader.Win32CaptureBackend(selection="printwindow")
     backend._backends = [_SelectedBackend(), _FallbackBackend()]
+    backend._printwindow_backend = backend._backends[0]
 
-    frame = backend.capture_frame(_window()[0], galgame_ocr_reader.OcrCaptureProfile())
+    target = _window()[0]
+    target.is_foreground = True
+    frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
 
     assert frame == "fallback-frame"
     assert backend.last_backend_kind == "dxcam"
@@ -3233,8 +3236,11 @@ def test_followup_confirm_uses_cleaned_dialogue_text() -> None:
         stable_text="王生：旧台词。",
     )
 
+    manager = object.__new__(OcrReaderManager)
+    manager._attached_window = None
+    manager._runtime = OcrReaderRuntime()
     assert (
-        OcrReaderManager._should_attempt_followup_confirm(
+        manager._should_attempt_followup_confirm(
             "王生：新\n台词。",
             state=state,
         )

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -75,6 +75,8 @@ from plugin.plugins.galgame_plugin.tesseract_support import (
 
 pytestmark = pytest.mark.plugin_unit
 
+TEST_WAIT_TIMEOUT = 1.0
+
 
 class _Logger:
     def info(self, *args, **kwargs):
@@ -1582,7 +1584,7 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
             self.calls += 1
             if self.calls == 1:
                 started.set()
-                release.wait(timeout=0.5)
+                release.wait(timeout=TEST_WAIT_TIMEOUT)
             return "雪乃：恢复后的台词。"
 
     backend = _BlockingOcrBackend()
@@ -1614,7 +1616,7 @@ async def test_ocr_reader_capture_timeout_skips_stuck_worker_immediately(
 
     try:
         first = await manager.tick(bridge_sdk_available=False, memory_reader_runtime={})
-        assert started.wait(timeout=0.5) is True
+        assert started.wait(timeout=TEST_WAIT_TIMEOUT) is True
         assert first.runtime["detail"] == "capture_failed"
         assert "timed out" in first.runtime["last_capture_error"]
 
@@ -2008,6 +2010,11 @@ def test_screen_capture_rect_uses_client_area_and_clips_taskbar(
     )
     monkeypatch.setattr(
         galgame_ocr_reader,
+        "_target_monitor_work_rects",
+        lambda _rect: [],
+    )
+    monkeypatch.setattr(
+        galgame_ocr_reader,
         "_target_monitor_work_rect",
         lambda _target: (0, 0, 1920, 1040),
     )
@@ -2015,6 +2022,36 @@ def test_screen_capture_rect_uses_client_area_and_clips_taskbar(
     rect = galgame_ocr_reader._target_screen_capture_rect(target)
 
     assert rect == (5, 92, 1301, 1040)
+
+
+def test_screen_capture_rect_spanning_monitors_keeps_other_display(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _window()[0]
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_client_rect",
+        lambda _target: (1800, 100, 2600, 1060),
+    )
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_window_uses_overlapped_chrome",
+        lambda _target: True,
+    )
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_monitor_work_rects",
+        lambda _rect: [(0, 0, 1920, 1040), (1920, 0, 3840, 1080)],
+    )
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_target_monitor_work_rect",
+        lambda _target: (0, 0, 1920, 1040),
+    )
+
+    rect = galgame_ocr_reader._target_screen_capture_rect(target)
+
+    assert rect == (1800, 100, 2600, 1060)
 
 
 def test_printwindow_client_crop_keeps_profile_coordinates_in_client_space() -> None:
@@ -4072,9 +4109,8 @@ def test_inspect_rapidocr_installation_reports_legacy_target_when_used(
     # Force the bundled-spec branch off so the legacy plugin-isolated path
     # is exercised. In a uv-synced dev env rapidocr_onnxruntime is bundled
     # and would shadow the legacy fixture; we want to test the fallback
-    # specifically. Also pin lang to "ch" so the (now-japan) default
-    # doesn't flip the result to `missing_model_files` for an unrelated
-    # reason — this test is about legacy path detection, not models.
+    # specifically. Pin lang to "ch" so this test stays about legacy path
+    # detection rather than any future model-default change.
     monkeypatch.setattr(
         galgame_rapidocr_support.importlib.util,
         "find_spec",

--- a/plugin/tests/unit/plugins/test_galgame_rapidocr_support.py
+++ b/plugin/tests/unit/plugins/test_galgame_rapidocr_support.py
@@ -123,6 +123,16 @@ def test_rapidocr_kwargs_omits_model_paths_when_configured_model_is_missing(tmp_
     assert kwargs == {"engine_type": "onnxruntime"}
 
 
+def test_required_rapidocr_model_files_defaults_to_bundled_ch(tmp_path: Path) -> None:
+    files = rapidocr_support.required_rapidocr_model_files(
+        install_target_dir_raw=str(tmp_path / "RapidOCR"),
+        lang_type="",
+        ocr_version="",
+    )
+
+    assert files == []
+
+
 def test_load_rapidocr_runtime_uses_imported_package_models_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/plugins/test_galgame_service.py
+++ b/plugin/tests/unit/plugins/test_galgame_service.py
@@ -146,6 +146,13 @@ def test_build_config_defaults_ocr_poll_interval_to_fast_capture() -> None:
     assert cfg.ocr_reader_poll_interval_seconds == 0.5
 
 
+def test_build_config_defaults_rapidocr_lang_type_to_bundled_ch() -> None:
+    cfg = galgame_service.build_config({})
+
+    assert cfg.rapidocr_lang_type == "ch"
+    assert cfg.rapidocr_lang_type == galgame_service.DEFAULT_RAPIDOCR_LANG_TYPE
+
+
 def _candidate(
     tmp_path,
     *,


### PR DESCRIPTION
 ## 概要

  本 PR 优化 galgame 插件的 OCR 截图、窗口噪声过滤、文本稳定确认，以及 RapidOCR 模型配置和安装状态展示。

  ## 主要改动

  - OCR 截图链路优先使用更准确的窗口内容/屏幕捕获区域，减少标题栏、任务栏等窗口 chrome 被截入 OCR。
  - 增加并统一 OCR chrome 噪声过滤逻辑：
    - 过滤窗口标题行，包括被 OCR 截断的标题片段。
    - 过滤底部温度/状态栏类文本。
    - 将重复的标题/温度识别逻辑提取到共享模块 `ocr_chrome_noise.py`。
  - 修正 PrintWindow 截图后端的捕获区域，使其与其它截图后端的几何行为更一致。
  - OCR follow-up confirmation 复用与正式文本发送相同的清洗流程，避免稳定 key 不一致导致漏确认。
  - RapidOCR 默认语言变更相关逻辑补充提示：
    - 当前默认配置偏向 `lang_type = "ch"`。
    - 日文游戏用户会被提示显式设置 `rapidocr.lang_type = "japan"`。
  - RapidOCR 摘要状态优先展示 `rapidocr_models` 下载任务状态，使 summary chip 与任务卡/按钮保持一致。
  - agent 状态面板的模式文案改用共享 `modeLabel()`，避免部分语言下显示 raw i18n key。
  - 补充/调整相关单元测试，覆盖截图区域、chrome 噪声过滤、RapidOCR fallback、follow-up confirmation 等场景。

  ## 验证

  已执行：

  - `python -m py_compile` 覆盖相关 galgame 插件 Python 文件
  - `python -m pytest N.E.K.O/plugin/tests/unit/plugins/test_galgame_ocr_reader.py -q`
  - `node --check N.E.K.O/plugin/plugins/galgame_plugin/static/main.js`
  - `git diff --check`

  结果：

  - `test_galgame_ocr_reader.py`: `164 passed, 1 warning`
  - warning 为既有 `plugin.settings.PLUGIN_CONFIG_ROOT` deprecation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加OCR噪音过滤，自动识别并移除窗口标题栏、温度等非对话元素。
* **改进**
  * 默认OCR语言由日文切换为中文，提升中文视觉小说识别表现。
  * 改善对话文本预处理、屏幕裁切与捕获几何、以及后备识别回退与提示。
  * 前端面板与安装状态展示更健壮，空态显示改进。
* **测试**
  * 增补多项单元测试覆盖噪音过滤、裁切与RapidOCR回退行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->