### PR TITLE
Fix galgame plugin local storage path

### DIFF
--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -781,7 +781,10 @@ class GalgamePlugin(NekoPluginBase):
             push_notifications=True,
             advance_speed=ADVANCE_SPEED_MEDIUM,
         )
-        self._persist = GalgameStore(self.store, self.logger)
+        self._persist = GalgameStore(
+            self.data_path("galgame_store.json"),
+            self.logger,
+        )
         self._config_service = GalgamePluginConfigService(self)
         self._host_agent_adapter: HostAgentAdapter | None = None
         self._llm_gateway: LLMGateway | None = None

--- a/plugin/plugins/galgame_plugin/install_routes.py
+++ b/plugin/plugins/galgame_plugin/install_routes.py
@@ -20,7 +20,6 @@ from plugin.plugins.galgame_plugin.install_tasks import (
     load_latest_install_task_state,
     update_install_task_state,
 )
-from plugin.sdk.shared.storage import PluginStore
 from plugin.server.application.runs import RunService
 from plugin.server.domain.errors import ServerDomainError
 from plugin.server.infrastructure.error_mapping import raise_http_from_domain
@@ -548,13 +547,10 @@ def _tutorial_store() -> GalgameStore:
     if _tutorial_store_instance is not None:
         return _tutorial_store_instance
     plugin_dir = Path(__file__).resolve().parent
-    plugin_store = PluginStore(
-        plugin_id="galgame_plugin",
-        plugin_dir=plugin_dir,
-        logger=logger,
-        enabled=True,
+    _tutorial_store_instance = GalgameStore(
+        plugin_dir / "data" / "galgame_store.json",
+        logger,
     )
-    _tutorial_store_instance = GalgameStore(plugin_store, logger)
     return _tutorial_store_instance
 
 

--- a/plugin/plugins/galgame_plugin/plugin.toml
+++ b/plugin/plugins/galgame_plugin/plugin.toml
@@ -25,7 +25,7 @@ recommended = ">=0.1.0,<0.2.0"
 supported = ">=0.1.0,<0.3.0"
 
 [plugin.store]
-enabled = true
+enabled = false
 
 [plugin_runtime]
 enabled = true

--- a/plugin/plugins/galgame_plugin/store.py
+++ b/plugin/plugins/galgame_plugin/store.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+import threading
+from pathlib import Path
 from typing import Any
 
 from .models import (
@@ -39,19 +43,68 @@ from .models import (
 
 
 class GalgameStore:
-    def __init__(self, plugin_store, logger) -> None:
-        self._store = plugin_store
+    _file_lock = threading.RLock()
+
+    def __init__(self, store_path: Path, logger) -> None:
+        self._store_path = Path(store_path)
         self._logger = logger
+        self._loaded = False
+        self._values: dict[str, Any] = {}
+
+    @staticmethod
+    def _is_json_value(value: Any) -> bool:
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return True
+        if isinstance(value, list):
+            return all(GalgameStore._is_json_value(item) for item in value)
+        if isinstance(value, dict):
+            return all(
+                isinstance(key, str) and GalgameStore._is_json_value(item)
+                for key, item in value.items()
+            )
+        return False
+
+    def _load_values(self, *, force: bool = False) -> None:
+        if self._loaded and not force:
+            return
+        values: dict[str, Any] = {}
+        if self._store_path.exists():
+            try:
+                raw = json.loads(self._store_path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    values = {
+                        str(key): value
+                        for key, value in raw.items()
+                        if isinstance(key, str) and self._is_json_value(value)
+                    }
+                else:
+                    self._logger.warning("galgame store json ignored: root is not an object")
+            except Exception as exc:
+                self._logger.warning("failed to read galgame store json {}: {}", self._store_path, exc)
+        self._values = values
+        self._loaded = True
+
+    def _save_values(self) -> None:
+        self._store_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._store_path.with_name(f"{self._store_path.name}.tmp")
+        tmp_path.write_text(
+            json.dumps(self._values, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        os.replace(tmp_path, self._store_path)
 
     def _read(self, key: str, default: Any) -> Any:
-        if not getattr(self._store, "enabled", False):
-            return default
-        return self._store._read_value(key, default)  # type: ignore[attr-defined]
+        with self._file_lock:
+            self._load_values(force=True)
+            return self._values.get(key, default)
 
     def _write(self, key: str, value: Any) -> None:
-        if not getattr(self._store, "enabled", False):
-            return
-        self._store._write_value(key, value)  # type: ignore[attr-defined]
+        if not self._is_json_value(value):
+            raise TypeError("value must be JSON-compatible")
+        with self._file_lock:
+            self._load_values(force=True)
+            self._values[key] = value
+            self._save_values()
 
     def load_config_overrides(self) -> dict[str, Any]:
         raw_backend = self._read(STORE_OCR_BACKEND_SELECTION, None)

--- a/plugin/plugins/galgame_plugin/store.py
+++ b/plugin/plugins/galgame_plugin/store.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import json
 import os
 import threading
+import time
+import uuid
 from pathlib import Path
 from typing import Any
+
+import portalocker
 
 from .models import (
     ADVANCE_SPEEDS,
@@ -43,7 +48,7 @@ from .models import (
 
 
 class GalgameStore:
-    _file_lock = threading.RLock()
+    _thread_lock = threading.RLock()
 
     def __init__(self, store_path: Path, logger) -> None:
         self._store_path = Path(store_path)
@@ -64,47 +69,106 @@ class GalgameStore:
             )
         return False
 
-    def _load_values(self, *, force: bool = False) -> None:
+    def _lock_path(self) -> Path:
+        return self._store_path.with_name(f"{self._store_path.name}.lock")
+
+    def _backup_path(self) -> Path:
+        return self._store_path.with_name(f"{self._store_path.name}.bak")
+
+    def _unique_tmp_path(self, suffix: str) -> Path:
+        token = f"{os.getpid()}.{time.time_ns()}.{uuid.uuid4().hex}"
+        return self._store_path.with_name(f".{self._store_path.name}.{token}.{suffix}")
+
+    @contextmanager
+    def _locked_store(self):
+        self._store_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._thread_lock, portalocker.Lock(str(self._lock_path()), mode="a+", timeout=10):
+            yield
+
+    def _read_values_from_path(self, path: Path) -> dict[str, Any]:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("galgame store json root is not an object")
+        return {
+            str(key): value
+            for key, value in raw.items()
+            if isinstance(key, str) and self._is_json_value(value)
+        }
+
+    def _load_values(self, *, force: bool = False, locked: bool = False) -> None:
         if self._loaded and not force:
             return
-        values: dict[str, Any] = {}
+        if not locked:
+            with self._locked_store():
+                self._load_values(force=force, locked=True)
+            return
+
         if self._store_path.exists():
             try:
-                raw = json.loads(self._store_path.read_text(encoding="utf-8"))
-                if isinstance(raw, dict):
-                    values = {
-                        str(key): value
-                        for key, value in raw.items()
-                        if isinstance(key, str) and self._is_json_value(value)
-                    }
-                else:
-                    self._logger.warning("galgame store json ignored: root is not an object")
+                values = self._read_values_from_path(self._store_path)
             except Exception as exc:
                 self._logger.warning("failed to read galgame store json {}: {}", self._store_path, exc)
-        self._values = values
+                backup_path = self._backup_path()
+                if not backup_path.exists():
+                    raise
+                try:
+                    values = self._read_values_from_path(backup_path)
+                except Exception as backup_exc:
+                    self._logger.warning(
+                        "failed to recover galgame store json from backup {}: {}",
+                        backup_path,
+                        backup_exc,
+                    )
+                    raise
+                self._logger.warning(
+                    "recovered galgame store values from backup {} after read failure",
+                    backup_path,
+                )
+            self._values = values
+        else:
+            self._values = {}
         self._loaded = True
 
-    def _save_values(self) -> None:
-        self._store_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = self._store_path.with_name(f"{self._store_path.name}.tmp")
-        tmp_path.write_text(
-            json.dumps(self._values, ensure_ascii=False, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
-        os.replace(tmp_path, self._store_path)
+    def _refresh_backup(self) -> None:
+        if not self._store_path.exists():
+            return
+        backup_tmp_path = self._unique_tmp_path("bak.tmp")
+        try:
+            backup_tmp_path.write_bytes(self._store_path.read_bytes())
+            os.replace(backup_tmp_path, self._backup_path())
+        finally:
+            backup_tmp_path.unlink(missing_ok=True)
+
+    def _save_values(self, *, locked: bool = False) -> None:
+        if not locked:
+            with self._locked_store():
+                self._save_values(locked=True)
+            return
+
+        tmp_path = self._unique_tmp_path("tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as tmp_file:
+                json.dump(self._values, tmp_file, ensure_ascii=False, indent=2, sort_keys=True)
+                tmp_file.write("\n")
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+            self._refresh_backup()
+            os.replace(tmp_path, self._store_path)
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
     def _read(self, key: str, default: Any) -> Any:
-        with self._file_lock:
-            self._load_values(force=True)
+        with self._locked_store():
+            self._load_values(force=True, locked=True)
             return self._values.get(key, default)
 
     def _write(self, key: str, value: Any) -> None:
         if not self._is_json_value(value):
             raise TypeError("value must be JSON-compatible")
-        with self._file_lock:
-            self._load_values(force=True)
+        with self._locked_store():
+            self._load_values(force=True, locked=True)
             self._values[key] = value
-            self._save_values()
+            self._save_values(locked=True)
 
     def load_config_overrides(self) -> dict[str, Any]:
         raw_backend = self._read(STORE_OCR_BACKEND_SELECTION, None)


### PR DESCRIPTION
问题：galgame_plugin 之前启用 SDK PluginStore，会在插件目录下生成 store.db，当前参照 bilibili_danmaku、mijia 使用插件 data 目录保存运行时状态。（先单独更改，没有动sdk）

修改：关闭 plugin.store，将 GalgameStore 改为写入 data/galgame_store.json；主插件入口使用 self.data_path(...)；教程进度接口复用同一 JSON 状态文件；不保留旧 store.db 迁移逻辑。

验证：通过 py_compile、ruff check，并用 uv run python 做 JSON store 多实例读写冒烟测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **重构**
  * 改进了插件的数据持久化：切换为本地文件存储，增强写入原子性与备份恢复机制，提升数据一致性与可靠性。
* **修复**
  * 优化了读取/写入异常处理与恢复流程，减少数据损坏风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->