### PR TITLE
修复React聊天框在gal模式下高度约束不一致的问题

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -2331,7 +2331,14 @@
 
     var MIN_WIDTH = 320;
     var MIN_HEIGHT = 280;
+    var GALGAME_MIN_HEIGHT = 420;
     var RESIZE_DIRECTIONS = ['n', 's', 'w', 'e', 'nw', 'ne', 'sw', 'se'];
+
+    function getDesktopMinHeight() {
+        if (!state.galgameModeEnabled) return MIN_HEIGHT;
+        // 与 CSS 的 galgame min-height 对齐，避免拖拽时 JS 先把高度压到 280px。
+        return Math.min(GALGAME_MIN_HEIGHT, Math.max(MIN_HEIGHT, window.innerHeight - 22));
+    }
 
     function createResizeEdges() {
         var shell = getShell();
@@ -2404,11 +2411,13 @@
                 newLeft = resizeState.origLeft + resizeState.origWidth - MIN_WIDTH;
             }
         }
+        var desktopMinHeight = getDesktopMinHeight();
+
         if (!mobile && dir.indexOf('s') !== -1) {
-            newHeight = Math.max(MIN_HEIGHT, resizeState.origHeight + dy);
+            newHeight = Math.max(desktopMinHeight, resizeState.origHeight + dy);
         }
         if (dir.indexOf('n') !== -1) {
-            var minH = mobile ? MOBILE_MIN_HEIGHT : MIN_HEIGHT;
+            var minH = mobile ? MOBILE_MIN_HEIGHT : desktopMinHeight;
             var proposedHeight = resizeState.origHeight - dy;
             if (proposedHeight >= minH) {
                 newHeight = proposedHeight;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -384,7 +384,7 @@
             min-height: 320px !important;
         }
         body.galgame-mode-enabled {
-            min-height: 320px !important;
+            min-height: 385px !important;
         }
 
         /* Electron 独立窗口始终显示全部工具按钮（覆盖 index.css 768px 媒体查询隐藏） */
@@ -775,7 +775,9 @@
         var MIN_H_BASE = 200;
         // GalGame 模式开启时输入框需要额外 ~110px 容纳 A/B/C 选项 + 间距，
         // 否则用户首次进入会看到选项被裁切到 send 按钮下方。
-        var MIN_H_GALGAME = 320;
+        // GAL 模式的 320px 是内容壳最低高度；独立窗口还有 top/bottom inset，
+        // 需要把外层窗口最小高度抬高，否则压扁后输入区底部会被窗口裁掉。
+        var MIN_H_GALGAME = 385;
         function isGalgameModeOn() {
             return !!(document.body && document.body.classList.contains('galgame-mode-enabled'));
         }


### PR DESCRIPTION
同步页面与前端 resize 的 GAL 最小高度，避免压扁聊天框时输入区或选项区域被裁切

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug 修复**
  * 改进了启用 GalGame 模式时聊天窗口的调整大小行为，防止在拖动时窗口意外缩小。
  * 增加了 GalGame 模式下的最小高度限制，确保输入区域在扩展/调整大小后不会被裁剪。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->