### PR TITLE
[codex] Limit prominent notice body height

### DIFF
--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -318,6 +318,7 @@
             font-size: 15px; font-weight: 600; cursor: pointer;
             pointer-events: auto;
             transition: background 0.15s;
+            flex-shrink: 0;
         `;
 
         const icon = document.createElement('img');
@@ -338,7 +339,7 @@
             'max-height:min(54vh,420px)',
             'overflow-y:auto',
             'overflow-wrap:anywhere',
-            'padding-right:6px',
+            'padding-right:12px',
             'box-sizing:border-box',
         ].join(';');
         if (typeof window.renderMiniMarkdown === 'function') {
@@ -346,7 +347,6 @@
         } else {
             textDiv.textContent = displayText;
         }
-        btn.style.flexShrink = '0';
 
         box.appendChild(icon);
         box.appendChild(textDiv);

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -223,6 +223,24 @@
     const _prominentNoticeQueue = [];
     let _prominentNoticeActive = false;
 
+    function _prominentNoticeText(key, fallback) {
+        try {
+            if (typeof window.safeT === 'function') {
+                const translated = window.safeT(key, fallback);
+                if (typeof translated === 'string' && translated && translated !== key) {
+                    return translated;
+                }
+            }
+            if (typeof window.t === 'function') {
+                const translated = window.t(key, { defaultValue: fallback });
+                if (typeof translated === 'string' && translated && translated !== key) {
+                    return translated;
+                }
+            }
+        } catch (_) { }
+        return fallback;
+    }
+
     function _drainProminentNoticeQueue() {
         if (_prominentNoticeActive || _prominentNoticeQueue.length === 0) return;
         const { notice, resolve } = _prominentNoticeQueue.shift();
@@ -292,8 +310,8 @@
         const btn = document.createElement('button');
         const _hasMore = _prominentNoticeQueue.length > 0;
         btn.textContent = _hasMore
-            ? ((window.t && window.t('common.next')) || '下一个')
-            : ((window.t && window.t('common.confirm')) || '确认');
+            ? _prominentNoticeText('common.next', '下一个')
+            : _prominentNoticeText('common.confirm', '确认');
         btn.style.cssText = `
             background: #3b82f6; color: #fff; border: none;
             border-radius: 10px; padding: 10px 48px;

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -278,9 +278,14 @@
             border-radius: 16px;
             padding: 32px 28px 24px;
             width: 370px; max-width: 88vw;
+            max-height: min(82vh, 720px);
+            box-sizing: border-box;
             box-shadow: 0 12px 40px rgba(0,0,0,0.5);
             text-align: center;
             pointer-events: auto;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
             animation: pnBoxIn 0.3s ease;
         `;
 
@@ -300,15 +305,30 @@
         const icon = document.createElement('img');
         icon.src = '/static/icons/exclamation.png';
         icon.alt = '';
-        icon.style.cssText = 'width:36px;height:36px;margin-bottom:14px;';
+        icon.style.cssText = 'width:36px;height:36px;margin-bottom:14px;flex-shrink:0;';
 
         const textDiv = document.createElement('div');
-        textDiv.style.cssText = 'font-size:16px;font-weight:600;line-height:1.7;margin-bottom:22px;text-align:left;';
+        textDiv.style.cssText = [
+            'font-size:16px',
+            'font-weight:600',
+            'line-height:1.7',
+            'margin-bottom:22px',
+            'text-align:left',
+            'width:100%',
+            'min-height:0',
+            'flex:1 1 auto',
+            'max-height:min(54vh,420px)',
+            'overflow-y:auto',
+            'overflow-wrap:anywhere',
+            'padding-right:6px',
+            'box-sizing:border-box',
+        ].join(';');
         if (typeof window.renderMiniMarkdown === 'function') {
             textDiv.innerHTML = window.renderMiniMarkdown(displayText);
         } else {
             textDiv.textContent = displayText;
         }
+        btn.style.flexShrink = '0';
 
         box.appendChild(icon);
         box.appendChild(textDiv);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -314,7 +314,7 @@
                 'max-height:min(54vh,420px)',
                 'overflow-y:auto',
                 'overflow-wrap:anywhere',
-                'padding-right:6px',
+                'padding-right:12px',
                 'box-sizing:border-box',
             ].join(';');
             textDiv.innerHTML = miniMarkdown(displayText);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -271,18 +271,34 @@
                 'border:1px solid rgba(255,255,255,0.12)',
                 'border-radius:16px', 'padding:32px 28px 24px',
                 'width:370px', 'max-width:88vw',
+                'max-height:min(82vh, 720px)', 'box-sizing:border-box',
                 'box-shadow:0 12px 40px rgba(0,0,0,0.5)',
                 'text-align:center', 'pointer-events:auto',
+                'display:flex', 'flex-direction:column', 'align-items:center',
                 'animation:pnBoxIn 0.3s ease',
             ].join(';');
 
             var icon = document.createElement('img');
             icon.src = '/static/icons/exclamation.png';
             icon.alt = '';
-            icon.style.cssText = 'width:36px;height:36px;margin-bottom:14px;';
+            icon.style.cssText = 'width:36px;height:36px;margin-bottom:14px;flex-shrink:0;';
 
             var textDiv = document.createElement('div');
-            textDiv.style.cssText = 'font-size:16px;font-weight:600;line-height:1.7;margin-bottom:22px;text-align:left;';
+            textDiv.style.cssText = [
+                'font-size:16px',
+                'font-weight:600',
+                'line-height:1.7',
+                'margin-bottom:22px',
+                'text-align:left',
+                'width:100%',
+                'min-height:0',
+                'flex:1 1 auto',
+                'max-height:min(54vh,420px)',
+                'overflow-y:auto',
+                'overflow-wrap:anywhere',
+                'padding-right:6px',
+                'box-sizing:border-box',
+            ].join(';');
             textDiv.innerHTML = miniMarkdown(displayText);
 
             var hasMore = pnQueue.length > 0;
@@ -293,6 +309,7 @@
                 'border-radius:10px', 'padding:10px 48px',
                 'font-size:15px', 'font-weight:600', 'cursor:pointer',
                 'pointer-events:auto', 'transition:background 0.15s',
+                'flex-shrink:0',
             ].join(';');
 
             box.appendChild(icon);

--- a/templates/toast.html
+++ b/templates/toast.html
@@ -163,6 +163,24 @@
             }
         }
 
+        function translateText(key, fallback) {
+            try {
+                if (typeof window.safeT === 'function') {
+                    var safeTranslated = window.safeT(key, fallback);
+                    if (typeof safeTranslated === 'string' && safeTranslated && safeTranslated !== key) {
+                        return safeTranslated;
+                    }
+                }
+                if (typeof window.t === 'function') {
+                    var translated = window.t(key, { defaultValue: fallback });
+                    if (typeof translated === 'string' && translated && translated !== key) {
+                        return translated;
+                    }
+                }
+            } catch (_) { }
+            return fallback;
+        }
+
         // ===== Voice Ready Toast =====
         function showReadyToSpeak(message) {
             injectVoiceAnimations();
@@ -194,7 +212,7 @@
             img.alt = 'ready';
             var span = document.createElement('span');
             span.style.cssText = 'display:flex;align-items:center;';
-            span.textContent = message || window.t('app.readyToSpeak');
+            span.textContent = message || translateText('app.readyToSpeak', '可以开始说话了！');
             toast.appendChild(img);
             toast.appendChild(span);
 
@@ -303,7 +321,9 @@
 
             var hasMore = pnQueue.length > 0;
             var btn = document.createElement('button');
-            btn.textContent = hasMore ? window.t('common.next') : window.t('common.confirm');
+            btn.textContent = hasMore
+                ? translateText('common.next', '下一个')
+                : translateText('common.confirm', '确认');
             btn.style.cssText = [
                 'background:#3b82f6', 'color:#fff', 'border:none',
                 'border-radius:10px', 'padding:10px 48px',


### PR DESCRIPTION
## Summary
- Limit prominent notice dialogs to a viewport-aware maximum height.
- Make long changelog and toast notice bodies scroll internally while keeping the confirm/next button visible.
- Apply the same behavior to both the main page notice renderer and the Electron toast window renderer.

## Why
Long changelog or prominent notice content could grow beyond the visible window and push the action button out of reach.

## Validation
- `node --check static\app-ui.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **用户界面改进**
  * 优化了提示框/弹窗布局与样式，增加最大高度约束并改为列式布局，消息区域支持滚动和换行，图标与按钮保持不缩放
  * 改进了提示文本的国际化处理，新增统一翻译助手，关键按钮与提示改用安全回退翻译机制
<!-- end of auto-generated comment: release notes by coderabbit.ai -->