### PR TITLE
[codex] Ensure free TTS language code follows global language

### DIFF
--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -195,11 +195,29 @@ _TTS_LANGUAGE_CODE_MAP = {
 def _get_tts_language_code() -> str:
     """获取 lanlan.app TTS 服务器所需的 language_code。"""
     try:
-        from utils.language_utils import get_global_language
-        lang = get_global_language()
+        from utils.language_utils import get_global_language_full, normalize_language_code
+        lang = normalize_language_code(get_global_language_full(), format='full')
     except Exception:
-        lang = 'zh'
+        lang = 'zh-CN'
     return _TTS_LANGUAGE_CODE_MAP.get(lang, 'cmn-CN')
+
+
+def _build_step_tts_create_data(sid_: str, voice_id: str, lang_hint, is_lanlan_app: bool) -> dict:
+    """根据 URL 和语言提示组装 Step/free TTS 的 tts.create data 字段。"""
+    data = {
+        "session_id": sid_,
+        "voice_id": voice_id,
+        "response_format": "wav",
+        "sample_rate": 24000,
+    }
+    if is_lanlan_app:
+        data["voice_id"] = "Leda"
+        data["language_code"] = "ja-JP" if lang_hint == "ja" else _get_tts_language_code()
+    else:
+        # lanlan.tech (free) 和自建 StepFun 协议对称，都用 voice_label。
+        if lang_hint == "ja":
+            data["voice_label"] = {"language": "日语"}
+    return data
 
 
 # ─── TTS Provider 元数据注册表 ─────────────────────────────────────────────
@@ -819,20 +837,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
             - lanlan.app: language_code（Gemini streaming-TTS 风格；命中 ja 时覆盖全局语言）
             - lanlan.tech / 自建 StepFun: 协议对称，voice_label.language="日语"（命中 ja 时）
             """
-            data = {
-                "session_id": sid_,
-                "voice_id": voice_id,
-                "response_format": "wav",
-                "sample_rate": 24000,
-            }
-            if is_lanlan_app:
-                data["voice_id"] = "Leda"
-                data["language_code"] = "ja-JP" if lang_hint == "ja" else _get_tts_language_code()
-            else:
-                # lanlan.tech (free) 和自建 StepFun (wss://api.stepfun.com/...) 共用同一协议
-                if lang_hint == "ja":
-                    data["voice_label"] = {"language": "日语"}
-            return data
+            return _build_step_tts_create_data(sid_, voice_id, lang_hint, is_lanlan_app)
 
         async def _flush_deferred_create(force: bool = False) -> bool:
             """尚未发 tts.create 时，检测语言并发送，然后把 pending 文本刷出去。

--- a/tests/unit/test_tts_language_hint.py
+++ b/tests/unit/test_tts_language_hint.py
@@ -4,6 +4,10 @@ from utils.language_utils import (
     TTS_LANG_DETECT_MIN_CHARS,
     detect_tts_language_hint,
 )
+from main_logic.tts_client import (
+    _build_step_tts_create_data,
+    _get_tts_language_code,
+)
 
 
 class TestDetectTtsLanguageHint:
@@ -71,21 +75,16 @@ class TestQwenConfigMessageBuilder:
 class TestStepTtsCreateBuilder:
     """类似地，覆盖 step_realtime_tts_worker 的 _build_tts_create_data 分支逻辑。"""
 
-    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool, fallback_lang_code: str = "zh-CN"):
-        data = {
-            "session_id": session_id,
-            "voice_id": voice_id,
-            "response_format": "wav",
-            "sample_rate": 24000,
-        }
-        if is_lanlan_app:
-            data["voice_id"] = "Leda"
-            data["language_code"] = "ja-JP" if lang_hint == "ja" else fallback_lang_code
-        else:
-            # lanlan.tech (free) 和自建 StepFun 协议对称，都用 voice_label
-            if lang_hint == "ja":
-                data["voice_label"] = {"language": "日语"}
-        return data
+    def _build(self, *, voice_id: str, session_id: str, lang_hint, is_lanlan_app: bool):
+        return _build_step_tts_create_data(session_id, voice_id, lang_hint, is_lanlan_app)
+
+    def test_tts_language_code_uses_global_language(self, monkeypatch):
+        monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "en-US")
+        assert _get_tts_language_code() == "en-US"
+
+    def test_tts_language_code_preserves_traditional_chinese(self, monkeypatch):
+        monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "zh-TW")
+        assert _get_tts_language_code() == "cmn-tw"
 
     def test_lanlan_tech_ja_adds_voice_label(self):
         data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False)
@@ -102,19 +101,20 @@ class TestStepTtsCreateBuilder:
         data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=False)
         assert data["voice_label"] == {"language": "日语"}
 
-    def test_lanlan_app_ja_uses_ja_jp_language_code(self):
+    def test_lanlan_app_ja_uses_ja_jp_language_code(self, monkeypatch):
+        monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "en-US")
         data = self._build(voice_id="v1", session_id="s1", lang_hint="ja", is_lanlan_app=True)
         assert data["language_code"] == "ja-JP"
         # lanlan.app 会强制 Leda 音色
         assert data["voice_id"] == "Leda"
         assert "voice_label" not in data
 
-    def test_lanlan_app_no_hint_uses_fallback_language_code(self):
+    def test_lanlan_app_no_hint_uses_global_language_code(self, monkeypatch):
+        monkeypatch.setattr("utils.language_utils.get_global_language_full", lambda: "ko-KR")
         data = self._build(
             voice_id="v1",
             session_id="s1",
             lang_hint=None,
             is_lanlan_app=True,
-            fallback_lang_code="zh-CN",
         )
-        assert data["language_code"] == "zh-CN"
+        assert data["language_code"] == "ko-KR"


### PR DESCRIPTION
## Summary

- Make lanlan.app free TTS derive `language_code` from the normalized global language.
- Keep the existing Japanese text hint override so kana-detected speech uses `ja-JP`.
- Share the Step/free TTS create-data builder with unit tests so the actual payload path is covered.

## Why

The international free TTS endpoint needs `language_code` to reflect the user's global language setting, with Japanese text detection as the explicit exception.

## Validation

- `uv run pytest tests/unit/test_tts_language_hint.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **改进**
  * 优化了文本转语音功能的语言识别和处理机制，现已更准确地支持多种语言变体（包括简体中文、繁体中文、日语等），提升了语言转换的准确性和兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->