### PR TITLE
  fix(galgame): 增强 Textractor 安装诊断

### DIFF
--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -764,6 +764,18 @@ class UserActivityTracker:
         self._anti_slack_last_fired_at = ts
         self._anti_slack_pending = None
 
+    def get_work_break_game_invite_probability(self) -> float:
+        """Return the current rest+mini-game branch probability.
+
+        Keeps router code out of the tracker's state-machine internals while
+        preserving the same live preference refresh semantics as snapshots.
+        """
+        self._refresh_prefs()
+        probability = self._sm._prefs.work_break_game_invite_probability
+        if probability is None:
+            return _WORK_BREAK_GAME_INVITE_PROBABILITY
+        return probability
+
     # ── enrichment kickoff ──────────────────────────────────────
 
     def kickoff_open_threads_compute(self, lang: str = 'zh') -> None:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -126,6 +126,14 @@ from config.prompts_proactive import (
     MINI_GAME_INVITE_KEYWORDS,
     build_proactive_action_note,
 )
+from config.prompts_activity import (
+    ANTI_SLACK_REMINDER_PROMPT,
+    WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME,
+    WORK_BREAK_GENERIC_LEISURE_LABEL,
+    WORK_BREAK_GENERIC_WORK_LABEL,
+    WORK_BREAK_REMINDER_PROMPT,
+    WORK_BREAK_SEED_HINTS,
+)
 from utils.file_utils import atomic_write_json_async, read_json
 from utils.workshop_utils import get_workshop_path
 from utils.screenshot_utils import (
@@ -2061,8 +2069,7 @@ def _pick_mini_game_type() -> str | None:
     ]
     if not candidates:
         return None
-    import random as _random
-    return _random.choice(candidates)
+    return random.choice(candidates)
 
 
 def _resolve_proactive_locale(data: dict, mgr) -> str:
@@ -2205,8 +2212,7 @@ async def _maybe_deliver_mini_game_invite(
         )
 
         if not force_first:
-            import random as _random
-            if _random.random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY:
+            if random.random() >= MINI_GAME_INVITE_TRIGGER_PROBABILITY:
                 return None
 
         game_type = _pick_mini_game_type()
@@ -2346,18 +2352,13 @@ def _render_work_break_prompt(
     pinned to the snapshot) so consecutive failed-then-retried
     deliveries naturally rotate the suggested action.
     """
-    from config.prompts_activity import (
-        WORK_BREAK_REMINDER_PROMPT, WORK_BREAK_SEED_HINTS,
-        WORK_BREAK_GENERIC_WORK_LABEL,
-    )
-    import random as _random
     template = WORK_BREAK_REMINDER_PROMPT.get(
         lang, WORK_BREAK_REMINDER_PROMPT.get('en', WORK_BREAK_REMINDER_PROMPT['zh']),
     )
     seeds = WORK_BREAK_SEED_HINTS.get(
         lang, WORK_BREAK_SEED_HINTS.get('en', WORK_BREAK_SEED_HINTS['zh']),
     ) or ['']
-    seed = _random.choice(seeds)
+    seed = random.choice(seeds)
     app_label = _resolve_break_reminder_label(pending.app, lang, WORK_BREAK_GENERIC_WORK_LABEL)
     rendered = template.format(
         master=master_name or '',
@@ -2379,10 +2380,6 @@ def _render_anti_slack_prompt(
     No seed slot — single behaviour, variation comes from prev/new app
     names + minute count + AI persona. Returns the system prompt text.
     """
-    from config.prompts_activity import (
-        ANTI_SLACK_REMINDER_PROMPT,
-        WORK_BREAK_GENERIC_WORK_LABEL, WORK_BREAK_GENERIC_LEISURE_LABEL,
-    )
     template = ANTI_SLACK_REMINDER_PROMPT.get(
         lang, ANTI_SLACK_REMINDER_PROMPT.get('en', ANTI_SLACK_REMINDER_PROMPT['zh']),
     )
@@ -2409,9 +2406,6 @@ def _render_work_break_game_invite_prompt(
     the given game_type (caller falls back to the regular water-break
     branch).
     """
-    from config.prompts_activity import (
-        WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME, WORK_BREAK_GENERIC_WORK_LABEL,
-    )
     per_lang = WORK_BREAK_GAME_INVITE_PROMPTS_BY_GAME.get(game_type)
     if not per_lang:
         return None
@@ -2498,9 +2492,15 @@ async def _deliver_break_reminder_via_llm(
         HumanMessage(content=begin_text),
     ]
 
-    print(
-        f"\n{'='*60}\n[BREAK-REMINDER] channel={channel} lang={lang} model={correction_model}\n"
-        f"{'='*60}\n{system_prompt}\n{'='*60}\n"
+    logger.debug(
+        "\n%s\n[BREAK-REMINDER] channel=%s lang=%s model=%s\n%s\n%s\n%s\n",
+        '=' * 60,
+        channel,
+        lang,
+        correction_model,
+        '=' * 60,
+        system_prompt,
+        '=' * 60,
     )
 
     from utils.token_tracker import set_call_type
@@ -4428,12 +4428,7 @@ async def proactive_chat(request: Request):
             # those gates failing falls through to the regular
             # drink/stretch nudge instead of breaking the must-fire.
             water_pending = activity_snapshot.work_break_pending
-            prefs_for_break = mgr._activity_tracker._sm._prefs
-            _gi_prob = prefs_for_break.work_break_game_invite_probability
-            if _gi_prob is None:
-                # Resolved at import time — see tracker.py defaults.
-                from main_logic.activity.tracker import _WORK_BREAK_GAME_INVITE_PROBABILITY as _gi_prob_default
-                _gi_prob = _gi_prob_default
+            _gi_prob = mgr._activity_tracker.get_work_break_game_invite_probability()
             branch_game_invite = False
             chosen_game_type: str | None = None
             gi_prompt: str | None = None
@@ -4443,8 +4438,7 @@ async def proactive_chat(request: Request):
                 and not _mini_game_invite_in_cooldown(lanlan_name)
                 and _gi_prob > 0
             ):
-                import random as _random
-                if _random.random() < _gi_prob:
+                if random.random() < _gi_prob:
                     chosen_game_type = _pick_mini_game_type()
                     if chosen_game_type is not None:
                         gi_prompt = _render_work_break_game_invite_prompt(
@@ -4582,8 +4576,7 @@ async def proactive_chat(request: Request):
             and activity_snapshot.skip_probability > 0
             and activity_snapshot.unfinished_thread is None
         ):
-            import random as _random
-            if _random.random() < activity_snapshot.skip_probability:
+            if random.random() < activity_snapshot.skip_probability:
                 print(
                     f"[{lanlan_name}] skip_probability={activity_snapshot.skip_probability:.2f} "
                     f"rolled (state={activity_snapshot.state} intensity={activity_snapshot.game_intensity} "

--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -4495,6 +4495,7 @@ class GalgamePlugin(NekoPluginBase):
                 install_target_dir_raw=self._cfg.memory_reader_install_target_dir,
                 release_api_url=self._cfg.memory_reader_install_release_api_url,
                 timeout_seconds=self._cfg.memory_reader_install_timeout_seconds,
+                textractor_proxy=self._cfg.memory_reader_textractor_proxy,
                 force=bool(force),
                 task_id=current_run_id or None,
                 progress_callback=progress_callback,

--- a/plugin/plugins/galgame_plugin/models.py
+++ b/plugin/plugins/galgame_plugin/models.py
@@ -525,9 +525,10 @@ class GalgameReaderConfig:
 class GalgameMemoryReaderConfig:
     memory_reader_enabled: bool = False
     memory_reader_textractor_path: str = ""
+    memory_reader_textractor_proxy: str = ""
     memory_reader_install_release_api_url: str = ""
     memory_reader_install_target_dir: str = ""
-    memory_reader_install_timeout_seconds: float = 180.0
+    memory_reader_install_timeout_seconds: float = 300.0
     memory_reader_auto_detect: bool = True
     memory_reader_hook_codes: list[str] = field(default_factory=list)
     memory_reader_engine_hook_codes: dict[str, list[str]] = field(default_factory=dict)
@@ -636,6 +637,10 @@ class GalgameConfig:
         "reader_mode": ("reader", "reader_mode"),
         "memory_reader_enabled": ("memory_reader", "memory_reader_enabled"),
         "memory_reader_textractor_path": ("memory_reader", "memory_reader_textractor_path"),
+        "memory_reader_textractor_proxy": (
+            "memory_reader",
+            "memory_reader_textractor_proxy",
+        ),
         "memory_reader_install_release_api_url": (
             "memory_reader",
             "memory_reader_install_release_api_url",

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2376,7 +2376,8 @@ def _target_monitor_work_rects(
                 if _valid_screen_rect(work_rect):
                     work_rects.append(work_rect)
         return work_rects
-    except Exception:
+    except (ImportError, OSError):
+        _LOGGER.debug("failed to read target monitor work rects", exc_info=True)
         return []
 
 
@@ -2428,7 +2429,7 @@ def _target_content_rect(target: DetectedGameWindow) -> tuple[int, int, int, int
         if _valid_screen_rect(rect):
             return rect
     except Exception:
-        pass
+        _LOGGER.debug("_target_content_rect client rect lookup failed", exc_info=True)
     return _target_window_rect(target)
 
 

--- a/plugin/plugins/galgame_plugin/plugin.toml
+++ b/plugin/plugins/galgame_plugin/plugin.toml
@@ -62,9 +62,10 @@ max_tokens_default = 1200
 
 [memory_reader]
 textractor_path = ""
+textractor_proxy = ""
 install_release_api_url = ""
 install_target_dir = ""
-install_timeout_seconds = 180
+install_timeout_seconds = 300
 auto_detect = true
 hook_codes = []
 poll_interval_seconds = 1

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -92,7 +92,7 @@ def _cached_install_inspection(
     with _INSTALL_INSPECT_CACHE_LOCK:
         cached = _INSTALL_INSPECT_CACHE.get(key)
         if cached is not None and now - cached[0] < _INSTALL_INSPECT_CACHE_TTL_SECONDS:
-            return copy.deepcopy(cached[1])
+            return dict(cached[1])
     value = factory()
     payload = copy.deepcopy(value if isinstance(value, dict) else {})
     with _INSTALL_INSPECT_CACHE_LOCK:
@@ -100,7 +100,7 @@ def _cached_install_inspection(
         if len(_INSTALL_INSPECT_CACHE) > 32:
             for stale_key in list(_INSTALL_INSPECT_CACHE)[:-32]:
                 _INSTALL_INSPECT_CACHE.pop(stale_key, None)
-    return copy.deepcopy(payload)
+    return dict(payload)
 
 
 def clear_install_inspection_cache() -> None:

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -665,6 +665,9 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
             _default_memory_reader_enabled(),
         ),
         memory_reader_textractor_path=str(memory_reader_obj.get("textractor_path") or ""),
+        memory_reader_textractor_proxy=str(
+            memory_reader_obj.get("textractor_proxy") or ""
+        ).strip(),
         memory_reader_install_release_api_url=str(
             memory_reader_obj.get("install_release_api_url")
             or DEFAULT_TEXTRACTOR_RELEASE_API_URL
@@ -673,7 +676,7 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
             memory_reader_obj.get("install_target_dir") or ""
         ).strip(),
         memory_reader_install_timeout_seconds=_coerce_float(
-            memory_reader_obj.get("install_timeout_seconds"), 180.0, minimum=1.0
+            memory_reader_obj.get("install_timeout_seconds"), 300.0, minimum=1.0
         ),
         memory_reader_auto_detect=bool(memory_reader_obj.get("auto_detect", True)),
         memory_reader_hook_codes=_coerce_string_list(

--- a/plugin/plugins/galgame_plugin/static/main.js
+++ b/plugin/plugins/galgame_plugin/static/main.js
@@ -5428,7 +5428,18 @@ function renderTextractor(status) {
   } else if (installState && installState.status === 'failed') {
     cardStatus = 'error';
     chipText = uiT('ui.install.status.failed', '安装失败');
-    descText = installState.error || installState.message || uiT('ui.install.task_failed_retry', '后台安装任务失败，你可以再次点击按钮重试。');
+    const errorText = installState.error || installState.message || uiT('ui.install.task_failed_retry', '后台安装任务失败，你可以再次点击按钮重试。');
+    const failedPhase = installState.failed_phase || '';
+    let phaseHint = '';
+    if (failedPhase === 'fetch_release') {
+      phaseHint = '无法连接 GitHub 服务。请检查网络/GitHub 可达性，或在 plugin.toml 的 [memory_reader] 中配置 textractor_proxy 代理地址。这通常不是插件安装逻辑损坏。';
+    } else if (failedPhase === 'downloading') {
+      phaseHint = 'Textractor 下载中断、HTTP 请求失败或文件校验失败。请确认网络稳定后重试。';
+    } else if (failedPhase === 'extracting') {
+      phaseHint = 'Textractor 安装包解压或安装后验证失败。建议按下面的路径手动安装。';
+    }
+    const manualGuide = '手动安装：从 https://github.com/Artikash/Textractor/releases 下载最新 zip，解压到 %LOCALAPPDATA%\\Programs\\Textractor\\，确保 TextractorCLI.exe 位于该目录根部，然后刷新状态。';
+    descText = [errorText, phaseHint, manualGuide].filter(Boolean).join('\n');
   } else if (installState && installState.status === 'completed' && !installed) {
     cardStatus = 'neutral';
     chipText = uiT('ui.install.status.completed', '已完成');

--- a/plugin/plugins/galgame_plugin/store.py
+++ b/plugin/plugins/galgame_plugin/store.py
@@ -159,7 +159,7 @@ class GalgameStore:
 
     def _read(self, key: str, default: Any) -> Any:
         with self._locked_store():
-            self._load_values(force=True, locked=True)
+            self._load_values(locked=True)
             return self._values.get(key, default)
 
     def _write(self, key: str, value: Any) -> None:

--- a/plugin/plugins/galgame_plugin/textractor_support.py
+++ b/plugin/plugins/galgame_plugin/textractor_support.py
@@ -27,6 +27,12 @@ DEFAULT_TEXTRACTOR_RELEASE_API_URL = (
 ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
 
 
+class TextractorInstallError(RuntimeError):
+    def __init__(self, message: str, *, failed_phase: str = "unknown") -> None:
+        super().__init__(message)
+        self.failed_phase = failed_phase
+
+
 async def _emit_progress(
     progress_callback: ProgressCallback | None,
     payload: dict[str, Any],
@@ -60,6 +66,69 @@ def _compute_phase_progress(
     if phase == "failed":
         return 1.0
     return 0.0
+
+
+def _infer_textractor_failed_phase(error_message: str, *, fallback: str = "unknown") -> str:
+    lowered = str(error_message or "").lower()
+    if not lowered:
+        return fallback
+    if "fetch_release" in lowered or "release metadata" in lowered or "github api" in lowered:
+        return "fetch_release"
+    if any(
+        token in lowered
+        for token in (
+            "download",
+            "network error",
+            "connect",
+            "timeout",
+            "http ",
+            "checksum",
+            "sha256",
+        )
+    ):
+        return "downloading"
+    if any(
+        token in lowered
+        for token in (
+            "extract",
+            "archive",
+            "zip",
+            "missing after extraction",
+            "textractorcli.exe is still missing",
+        )
+    ):
+        return "extracting"
+    return fallback
+
+
+async def _mark_textractor_install_failed(
+    *,
+    task_id: str | None,
+    progress_callback: ProgressCallback | None,
+    target_dir: Path | str,
+    error_message: str,
+    failed_phase: str,
+    release_name: str = "",
+    asset_name: str = "",
+) -> None:
+    failed_payload = {
+        "status": "failed",
+        "phase": "failed",
+        "message": error_message,
+        "progress": _compute_phase_progress("failed"),
+        "downloaded_bytes": 0,
+        "total_bytes": 0,
+        "resume_from": 0,
+        "target_dir": str(target_dir),
+        "detected_path": "",
+        "release_name": release_name,
+        "asset_name": asset_name,
+        "error": error_message,
+        "failed_phase": failed_phase,
+    }
+    if task_id:
+        update_install_task_state(task_id, **failed_payload)
+    await _emit_progress(progress_callback, failed_payload)
 
 
 def _extract_total_bytes(response: httpx.Response, *, resume_from: int) -> int:
@@ -362,6 +431,7 @@ async def install_textractor(
     install_target_dir_raw: str,
     release_api_url: str,
     timeout_seconds: float,
+    textractor_proxy: str = "",
     force: bool = False,
     platform_fn: Callable[[], bool] | None = None,
     client_factory: Callable[[], Awaitable[httpx.AsyncClient] | httpx.AsyncClient] | None = None,
@@ -444,32 +514,77 @@ async def install_textractor(
     owned_client = False
     client: httpx.AsyncClient | None = None
     if client_factory is None:
-        client = httpx.AsyncClient(
-            timeout=timeout_seconds,
-            trust_env=True,
-            follow_redirects=True,
-        )
+        client_kwargs: dict[str, Any] = {
+            "timeout": timeout_seconds,
+            "trust_env": True,
+            "follow_redirects": True,
+        }
+        proxy = str(textractor_proxy or "").strip()
+        if proxy:
+            client_kwargs["proxy"] = proxy
+        client = httpx.AsyncClient(**client_kwargs)
         owned_client = True
     else:
         maybe_client = client_factory()
         client = await maybe_client if hasattr(maybe_client, "__await__") else maybe_client
 
     try:
-        release_response = await client.get(
-            release_endpoint,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "User-Agent": "N.E.K.O/galgame_plugin",
-            },
-            timeout=timeout_seconds,
-        )
-        release_response.raise_for_status()
-        release_payload = release_response.json()
-        if not isinstance(release_payload, dict):
-            raise RuntimeError("release metadata returned an invalid payload")
-        assets = _candidate_assets(release_payload)
-        if not assets:
-            raise RuntimeError("no Textractor zip assets found in release metadata")
+        try:
+            release_response = await client.get(
+                release_endpoint,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": "N.E.K.O/galgame_plugin",
+                },
+                timeout=timeout_seconds,
+            )
+            release_response.raise_for_status()
+            release_payload = release_response.json()
+            if not isinstance(release_payload, dict):
+                raise RuntimeError("release metadata returned an invalid payload")
+            assets = _candidate_assets(release_payload)
+            if not assets:
+                raise RuntimeError("no Textractor zip assets found in release metadata")
+        except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
+            error_message = f"Cannot reach GitHub API: {exc}"
+            await _mark_textractor_install_failed(
+                task_id=task_id,
+                progress_callback=progress_callback,
+                target_dir=target_dir,
+                error_message=error_message,
+                failed_phase="fetch_release",
+            )
+            raise TextractorInstallError(
+                error_message,
+                failed_phase="fetch_release",
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code if exc.response is not None else "unknown"
+            error_message = f"GitHub API returned HTTP {status_code}"
+            await _mark_textractor_install_failed(
+                task_id=task_id,
+                progress_callback=progress_callback,
+                target_dir=target_dir,
+                error_message=error_message,
+                failed_phase="fetch_release",
+            )
+            raise TextractorInstallError(
+                error_message,
+                failed_phase="fetch_release",
+            ) from exc
+        except Exception as exc:
+            error_message = f"Textractor release metadata failed: {exc}"
+            await _mark_textractor_install_failed(
+                task_id=task_id,
+                progress_callback=progress_callback,
+                target_dir=target_dir,
+                error_message=error_message,
+                failed_phase="fetch_release",
+            )
+            raise TextractorInstallError(
+                error_message,
+                failed_phase="fetch_release",
+            ) from exc
 
         release_name = str(
             release_payload.get("name")
@@ -477,12 +592,13 @@ async def install_textractor(
             or release_payload.get("html_url")
             or ""
         )
-        errors: list[str] = []
+        errors: list[tuple[str, str]] = []
         tmp_dir = Path(tempfile.mkdtemp(prefix="neko-textractor-"))
         try:
             for asset in assets:
                 asset_name = asset["name"]
                 archive_path = tmp_dir / asset_name
+                candidate_phase = "downloading"
                 try:
                     if task_id:
                         update_install_task_state(
@@ -546,6 +662,7 @@ async def install_textractor(
                         update_install_task_state(task_id, **download_progress)
                     await _emit_progress(progress_callback, download_progress)
 
+                    candidate_phase = "extracting"
                     extracting_progress = {
                         "status": "running",
                         "phase": "extracting",
@@ -642,7 +759,11 @@ async def install_textractor(
                 except Exception as exc:
                     if logger is not None:
                         logger.warning("Textractor install candidate failed: {} -> {}", asset_name, exc)
-                    errors.append(f"{asset_name}: {exc}")
+                    failed_phase = _infer_textractor_failed_phase(
+                        str(exc),
+                        fallback=candidate_phase,
+                    )
+                    errors.append((failed_phase, f"{asset_name}: {exc}"))
                     continue
         finally:
             try:
@@ -650,35 +771,17 @@ async def install_textractor(
             except Exception as exc:
                 if logger is not None:
                     logger.warning("Textractor temp cleanup failed: {}", exc)
-        error_message = "; ".join(errors) or "Textractor install failed"
-        if task_id:
-            update_install_task_state(
-                task_id,
-                status="failed",
-                phase="failed",
-                message=error_message,
-                progress=_compute_phase_progress("failed"),
-                target_dir=str(target_dir),
-                error=error_message,
-            )
-        await _emit_progress(
-            progress_callback,
-            {
-                "status": "failed",
-                "phase": "failed",
-                "message": error_message,
-                "progress": _compute_phase_progress("failed"),
-                "downloaded_bytes": 0,
-                "total_bytes": 0,
-                "resume_from": 0,
-                "target_dir": str(target_dir),
-                "detected_path": "",
-                "release_name": release_name,
-                "asset_name": "",
-                "error": error_message,
-            },
+        error_message = "; ".join(message for _, message in errors) or "Textractor install failed"
+        failed_phase = errors[0][0] if errors else "unknown"
+        await _mark_textractor_install_failed(
+            task_id=task_id,
+            progress_callback=progress_callback,
+            target_dir=target_dir,
+            error_message=error_message,
+            failed_phase=failed_phase,
+            release_name=release_name,
         )
-        raise RuntimeError(error_message)
+        raise TextractorInstallError(error_message, failed_phase=failed_phase)
     finally:
         if owned_client and client is not None:
             await client.aclose()

--- a/plugin/tests/unit/plugins/test_galgame_bridge.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge.py
@@ -3433,14 +3433,16 @@ async def test_install_textractor_entry_returns_install_result_and_refreshed_sta
             memory_reader={
                 "enabled": True,
                 "install_target_dir": str(install_root),
+                "textractor_proxy": "http://127.0.0.1:7890",
             },
         ),
     )
     plugin = GalgameBridgePlugin(ctx)
     await plugin.startup()
+    captured_install_kwargs: dict[str, object] = {}
 
     async def _fake_install_textractor(**kwargs):
-        del kwargs
+        captured_install_kwargs.update(kwargs)
         install_root.mkdir(parents=True, exist_ok=True)
         (install_root / "TextractorCLI.exe").write_text("", encoding="utf-8")
         return {
@@ -3471,6 +3473,7 @@ async def test_install_textractor_entry_returns_install_result_and_refreshed_sta
     assert result.value["status"]["textractor"]["detected_path"] == str(
         install_root / "TextractorCLI.exe"
     )
+    assert captured_install_kwargs["textractor_proxy"] == "http://127.0.0.1:7890"
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_memory_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_memory_reader.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from plugin.plugins.galgame_plugin import memory_reader as galgame_memory_reader
+from plugin.plugins.galgame_plugin import textractor_support as galgame_textractor_support
 from plugin.plugins.galgame_plugin.memory_reader import (
     DetectedGameProcess,
     MemoryReaderBridgeWriter,
@@ -18,6 +19,7 @@ from plugin.plugins.galgame_plugin.memory_reader import (
 from plugin.plugins.galgame_plugin.reader import read_session_json, tail_events_jsonl
 from plugin.plugins.galgame_plugin.service import build_config
 from plugin.plugins.galgame_plugin.textractor_support import (
+    TextractorInstallError,
     _download_file,
     inspect_textractor_installation,
     install_textractor,
@@ -150,6 +152,30 @@ def _make_config(
             "memory_reader": memory_reader_config,
         }
     )
+
+
+def test_textractor_install_error_carries_failed_phase() -> None:
+    explicit = TextractorInstallError("Cannot reach GitHub", failed_phase="fetch_release")
+    default = TextractorInstallError("something went wrong")
+
+    assert explicit.failed_phase == "fetch_release"
+    assert "Cannot reach GitHub" in str(explicit)
+    assert isinstance(explicit, RuntimeError)
+    assert default.failed_phase == "unknown"
+
+
+def test_memory_reader_config_reads_textractor_proxy(tmp_path: Path) -> None:
+    config = build_config(
+        {
+            "galgame": {"bridge_root": str(tmp_path / "bridge")},
+            "memory_reader": {
+                "textractor_proxy": " http://127.0.0.1:7890 ",
+            },
+        }
+    )
+
+    assert config.memory_reader_textractor_proxy == "http://127.0.0.1:7890"
+    assert config.memory_reader_install_timeout_seconds == 300.0
 
 
 @pytest.mark.asyncio
@@ -1226,6 +1252,108 @@ def test_inspect_textractor_installation_reports_custom_install_target(tmp_path:
     assert status["installed"] is True
     assert status["detected_path"] == str(executable)
     assert status["target_dir"] == str(install_root)
+
+
+@pytest.mark.asyncio
+async def test_install_textractor_release_connect_timeout_sets_failed_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FailingReleaseClient:
+        async def get(self, *args, **kwargs):
+            del args, kwargs
+            raise httpx.ConnectTimeout("timed out")
+
+    updates: list[dict[str, object]] = []
+    progress_payloads: list[dict[str, object]] = []
+
+    def _capture_update(task_id: str, **changes):
+        del task_id
+        updates.append(dict(changes))
+        return dict(changes)
+
+    monkeypatch.setattr(
+        galgame_textractor_support,
+        "update_install_task_state",
+        _capture_update,
+    )
+
+    with pytest.raises(TextractorInstallError) as excinfo:
+        await install_textractor(
+            logger=_Logger(),
+            configured_path="",
+            install_target_dir_raw=str(tmp_path / "TextractorInstalled"),
+            release_api_url="https://example.test/latest",
+            timeout_seconds=5.0,
+            platform_fn=lambda: True,
+            client_factory=lambda: _FailingReleaseClient(),
+            task_id="task-fetch-release",
+            progress_callback=progress_payloads.append,
+        )
+
+    failed_updates = [item for item in updates if item.get("status") == "failed"]
+    assert excinfo.value.failed_phase == "fetch_release"
+    assert failed_updates[-1]["failed_phase"] == "fetch_release"
+    assert progress_payloads[-1]["failed_phase"] == "fetch_release"
+
+
+@pytest.mark.asyncio
+async def test_install_textractor_asset_download_failure_sets_failed_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_payload = {
+        "name": "Textractor v1.0.0",
+        "assets": [
+            {
+                "name": "Textractor-x64.zip",
+                "browser_download_url": "https://example.test/Textractor-x64.zip",
+            }
+        ],
+    }
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if str(request.url) == "https://example.test/latest":
+            return httpx.Response(200, json=release_payload)
+        if str(request.url) == "https://example.test/Textractor-x64.zip":
+            raise httpx.ConnectError("download connection failed", request=request)
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    updates: list[dict[str, object]] = []
+    progress_payloads: list[dict[str, object]] = []
+
+    def _capture_update(task_id: str, **changes):
+        del task_id
+        updates.append(dict(changes))
+        return dict(changes)
+
+    monkeypatch.setattr(
+        galgame_textractor_support,
+        "update_install_task_state",
+        _capture_update,
+    )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    try:
+        with pytest.raises(TextractorInstallError) as excinfo:
+            await install_textractor(
+                logger=_Logger(),
+                configured_path="",
+                install_target_dir_raw=str(tmp_path / "TextractorInstalled"),
+                release_api_url="https://example.test/latest",
+                timeout_seconds=5.0,
+                platform_fn=lambda: True,
+                client_factory=lambda: client,
+                task_id="task-download",
+                progress_callback=progress_payloads.append,
+            )
+    finally:
+        await client.aclose()
+
+    failed_updates = [item for item in updates if item.get("status") == "failed"]
+    assert excinfo.value.failed_phase == "downloading"
+    assert failed_updates[-1]["failed_phase"] == "downloading"
+    assert progress_payloads[-1]["failed_phase"] == "downloading"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

  当前 Galgame 插件在安装 Textractor 时，遇到 GitHub Release 查询失败、资源下载失败或网络代理问题时，诊断信息不够明确，用户难以判断失败阶段和处理方式。

  本 PR 增强 Textractor 安装链路的错误诊断、状态上报和前端提示，并补充相关测试。

  ## 改动内容

  - 增强 Textractor 安装流程的分阶段错误诊断。
  - 安装失败时记录更明确的 failed_phase 和错误详情。
  - 新增 memory_reader.textractor_proxy 配置，用于显式指定 Textractor 下载代理。
  - 延长 Textractor 安装超时时间，降低慢网络下误失败概率。
  - 前端安装状态展示补充失败阶段、进度和错误信息。
  - 调整 Galgame store 为文件路径持久化，避免继续依赖插件 store。
  - 修复 Galgame store 读取路径的性能问题，避免每次读取都强制重新加载 JSON。
  - 补充 Textractor 安装失败场景的单元测试。

  ## 架构边界

  - Textractor / Galgame 专属逻辑仍保留在 plugin/plugins/galgame_plugin/ 内。
  - 本 PR 已移除 main_logic/activity/tracker.py 和 main_routers/system_router.py 的改动。
  - 不引入 main 侧对 Galgame 插件的反向依赖，符合插件边界要求。

  ## 验证

  已执行过针对性检查：

  - uv run python -m py_compile ...
  - git diff --check
  - Galgame OCR 截图矩形相关测试
  - Galgame store 缓存读取断言

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本更新说明

* **新功能**
  * 为文本提取工具增加了代理配置支持。
  * 安装失败时提供更详细的错误信息反馈，包括阶段性提示和手动安装指南。

* **改进**
  * 提升了文本提取工具的安装超时时间（从180秒至300秒）。
  * 增强了安装过程中的错误诊断和日志记录功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->