### PR TITLE
fix(workshop): detect non-standard card face previews

### DIFF
--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -81,6 +81,15 @@ WORKSHOP_CARD_FACE_PADDING = 48
 WORKSHOP_CARD_FACE_RATIO_TOLERANCE = 0.02
 WORKSHOP_CARD_FACE_MARKER_KEY = 'neko_workshop_card_face'
 WORKSHOP_CARD_FACE_MARKER_VALUE = 'steam_preview_v1'
+WORKSHOP_STANDARD_PREVIEW_STEMS = ('preview', 'thumbnail', 'icon', 'header')
+WORKSHOP_STANDARD_PREVIEW_EXTENSIONS = ('.jpg', '.png', '.jpeg', '.webp')
+WORKSHOP_PREVIEW_IMAGE_NAMES = tuple(
+    f'{stem}{ext}'
+    for stem in WORKSHOP_STANDARD_PREVIEW_STEMS
+    for ext in WORKSHOP_STANDARD_PREVIEW_EXTENSIONS
+)
+WORKSHOP_IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.webp'}
+WORKSHOP_MODEL_TEXTURE_DIR_NAMES = {'texture', 'textures'}
 
 
 async def cancel_background_tasks(*, timeout: float = 5.0) -> None:
@@ -642,17 +651,187 @@ def get_folder_size(folder_path):
     return total_size
 
 
-def find_preview_image_in_folder(folder_path):
-    """在文件夹中查找预览图片，只查找指定的8个图片名称"""
-    preview_image_names = ['preview.jpg', 'preview.png', 'thumbnail.jpg', 'thumbnail.png', 
-                         'icon.jpg', 'icon.png', 'header.jpg', 'header.png']
-    
-    for image_name in preview_image_names:
+def _collect_workshop_character_name_hints(folder_path: str) -> set[str]:
+    hints: set[str] = set()
+    try:
+        for root, _dirs, filenames in os.walk(folder_path):
+            for filename in filenames:
+                if not filename.endswith('.chara.json'):
+                    continue
+                stem = filename[:-11].strip()
+                if stem:
+                    hints.add(stem)
+                chara_path = os.path.join(root, filename)
+                try:
+                    with open(chara_path, 'r', encoding='utf-8') as f:
+                        chara_data = json.load(f)
+                    if isinstance(chara_data, dict):
+                        chara_name = str(chara_data.get('档案名') or chara_data.get('name') or '').strip()
+                        if chara_name:
+                            hints.add(chara_name)
+                except Exception:
+                    continue
+    except Exception:
+        return hints
+    return hints
+
+
+def _collect_workshop_model_image_references(folder_path: str) -> set[str]:
+    references: set[str] = set()
+
+    def _walk_json_values(value, base_dir: str) -> None:
+        if isinstance(value, dict):
+            for item in value.values():
+                _walk_json_values(item, base_dir)
+            return
+        if isinstance(value, list):
+            for item in value:
+                _walk_json_values(item, base_dir)
+            return
+        if not isinstance(value, str):
+            return
+
+        normalized = value.replace('\\', '/').strip()
+        if not normalized:
+            return
+        ext = os.path.splitext(normalized)[1].lower()
+        if ext not in WORKSHOP_IMAGE_EXTENSIONS:
+            return
+        references.add(os.path.realpath(os.path.join(base_dir, normalized)))
+
+    try:
+        for root, _dirs, filenames in os.walk(folder_path):
+            for filename in filenames:
+                lower_name = filename.lower()
+                if not (
+                    lower_name.endswith('.model3.json')
+                    or lower_name == 'model.json'
+                    or lower_name.endswith('.model.json')
+                ):
+                    continue
+                model_path = os.path.join(root, filename)
+                try:
+                    with open(model_path, 'r', encoding='utf-8') as f:
+                        model_data = json.load(f)
+                    _walk_json_values(model_data, root)
+                except Exception:
+                    continue
+    except Exception:
+        return references
+    return references
+
+
+def _score_workshop_preview_candidate(
+    image_path: str,
+    folder_path: str,
+    character_name_hints: set[str],
+    model_image_references: set[str],
+) -> int:
+    rel_path = os.path.relpath(image_path, folder_path)
+    path_parts = Path(rel_path).parts
+    lower_name = os.path.basename(image_path).lower()
+    stem = os.path.splitext(os.path.basename(image_path))[0].strip()
+    depth = max(0, len(path_parts) - 1)
+    score = 0
+
+    if lower_name in WORKSHOP_PREVIEW_IMAGE_NAMES:
+        score += 120
+    if depth == 0:
+        score += 80
+    else:
+        score -= min(depth * 12, 48)
+
+    if any(part.startswith('.') for part in path_parts):
+        score -= 80
+    if any(part.lower() in WORKSHOP_MODEL_TEXTURE_DIR_NAMES for part in path_parts[:-1]):
+        score -= 120
+    if os.path.realpath(image_path) in model_image_references:
+        score -= 120
+
+    if stem:
+        for hint in character_name_hints:
+            if stem == hint:
+                score += 100
+                break
+            if stem in hint or hint in stem:
+                score += 40
+                break
+
+    try:
+        file_size = os.path.getsize(image_path)
+        if file_size <= 0:
+            score -= 200
+        elif file_size >= 8 * 1024:
+            score += 8
+    except OSError:
+        score -= 200
+
+    try:
+        from PIL import Image as PILImage
+        with PILImage.open(image_path) as img:
+            width, height = img.size
+        if width < 128 or height < 128:
+            score -= 80
+        else:
+            score += 12
+    except Exception:
+        score -= 160
+
+    return score
+
+
+def find_preview_image_in_folder(
+    folder_path,
+    character_name: str | None = None,
+    character_file_stem: str | None = None,
+):
+    """在 Workshop 内容目录中查找最适合作为预览/卡面的图片。"""
+    for image_name in WORKSHOP_PREVIEW_IMAGE_NAMES:
         image_path = os.path.join(folder_path, image_name)
         if os.path.exists(image_path) and os.path.isfile(image_path):
             return image_path
-    
-    return None
+
+    if character_name or character_file_stem:
+        character_name_hints = {
+            hint
+            for hint in (str(character_name or '').strip(), str(character_file_stem or '').strip())
+            if hint
+        }
+    else:
+        character_name_hints = _collect_workshop_character_name_hints(folder_path)
+    model_image_references = _collect_workshop_model_image_references(folder_path)
+    candidates: list[tuple[int, int, str]] = []
+
+    try:
+        for root, dirs, filenames in os.walk(folder_path):
+            dirs[:] = [dirname for dirname in dirs if not dirname.startswith('.')]
+            for filename in filenames:
+                if filename.startswith('.'):
+                    continue
+                ext = os.path.splitext(filename)[1].lower()
+                if ext not in WORKSHOP_IMAGE_EXTENSIONS:
+                    continue
+                image_path = os.path.join(root, filename)
+                if not os.path.isfile(image_path):
+                    continue
+                score = _score_workshop_preview_candidate(
+                    image_path,
+                    folder_path,
+                    character_name_hints,
+                    model_image_references,
+                )
+                depth = max(0, len(Path(os.path.relpath(image_path, folder_path)).parts) - 1)
+                candidates.append((score, -depth, image_path))
+    except Exception:
+        return None
+
+    if not candidates:
+        return None
+
+    best_score, _depth_score, best_path = max(candidates, key=lambda item: (item[0], item[1], item[2]))
+    if best_score <= 0:
+        return None
+    return best_path
 
 
 def _build_workshop_card_face_meta(item: dict) -> dict:
@@ -4120,7 +4299,6 @@ async def sync_workshop_character_cards() -> dict:
                     continue
                 
                 item_id = item.get('publishedFileId', '')
-                preview_image_path = find_preview_image_in_folder(installed_folder)
                 
                 # 3. 扫描 .chara.json 文件（递归遍历子目录）
                 try:
@@ -4150,6 +4328,12 @@ async def sync_workshop_character_cards() -> dict:
                                     item_id,
                                 )
                                 continue
+                            chara_file_stem = Path(chara_file_path).name[:-11]
+                            preview_image_path = find_preview_image_in_folder(
+                                installed_folder,
+                                chara_name,
+                                chara_file_stem,
+                            )
                             
                             # 已存在则跳过（当前设计：仅填充缺失角色卡，不覆盖已有数据；
                             # 如需支持创意工坊更新覆写本地数据，可添加 allow_workshop_overwrite 配置项）

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -930,6 +930,81 @@ async def test_sync_workshop_character_cards_counts_errors_when_existing_face_ba
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_sync_workshop_character_cards_uses_character_specific_preview_in_multi_card_item():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            workshop_router_module = reload_module("main_routers.workshop_router")
+
+            installed_folder = Path(td) / "mock_workshop_multi_card_item"
+            installed_folder.mkdir(parents=True, exist_ok=True)
+            (installed_folder / "Alice.chara.json").write_text(
+                json.dumps({"档案名": "Alice", "昵称": "from workshop"}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            (installed_folder / "Bob.chara.json").write_text(
+                json.dumps({"档案名": "Bob", "昵称": "from workshop"}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            Image.new("RGBA", (1024, 1024), (80, 160, 220, 255)).save(installed_folder / "Alice.png")
+            Image.new("RGBA", (1024, 1024), (120, 80, 180, 255)).save(installed_folder / "Bob.png")
+
+            preview_by_character = {}
+
+            def _capture_preview(_config_mgr, chara_name, preview_image_path, _item):
+                preview_by_character[chara_name] = Path(preview_image_path).name if preview_image_path else None
+                return True
+
+            with patch.object(
+                workshop_router_module,
+                "get_subscribed_workshop_items",
+                AsyncMock(
+                    return_value={
+                        "success": True,
+                        "items": [
+                            {
+                                "publishedFileId": "123456",
+                                "installedFolder": str(installed_folder),
+                            }
+                        ],
+                    }
+                ),
+            ), patch.object(
+                workshop_router_module,
+                "_ensure_workshop_card_face_from_preview",
+                side_effect=_capture_preview,
+            ):
+                sync_result = await workshop_router_module.sync_workshop_character_cards()
+
+            assert sync_result["added"] == 2
+            assert preview_by_character == {
+                "Alice": "Alice.png",
+                "Bob": "Bob.png",
+            }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_sync_workshop_character_cards_persists_character_origin_metadata():
     with TemporaryDirectory() as td:
         cm = _make_config_manager(Path(td))

--- a/tests/unit/test_workshop_card_face_refresh.py
+++ b/tests/unit/test_workshop_card_face_refresh.py
@@ -9,7 +9,9 @@ from main_routers import workshop_router
 
 def _write_image(path: Path, size: tuple[int, int]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    Image.new("RGBA", size, (80, 160, 220, 255)).save(path)
+    mode = "RGB" if path.suffix.lower() in {".jpg", ".jpeg"} else "RGBA"
+    color = (80, 160, 220) if mode == "RGB" else (80, 160, 220, 255)
+    Image.new(mode, size, color).save(path)
 
 
 def _write_meta(path: Path, origin: str) -> None:
@@ -161,3 +163,42 @@ def test_ensure_workshop_card_face_meta_skips_user_owned_png_without_marker(tmp_
 
     assert created is False
     assert config_mgr.card_face_meta_path("demo").exists() is False
+
+
+@pytest.mark.unit
+def test_find_preview_image_uses_top_level_character_image_when_standard_preview_missing(tmp_path: Path):
+    item_dir = tmp_path / "workshop_item"
+    model_dir = item_dir / "独角兽-天使的 My Night"
+
+    item_dir.mkdir(parents=True, exist_ok=True)
+    (item_dir / "独角兽.chara.json").write_text("{}", encoding="utf-8")
+    _write_image(model_dir / "textures" / "texture_00.png", (2048, 2048))
+    _write_image(item_dir / "独角兽.png", (1024, 1024))
+
+    assert workshop_router.find_preview_image_in_folder(str(item_dir)) == str(item_dir / "独角兽.png")
+
+
+@pytest.mark.unit
+def test_find_preview_image_recognizes_standard_preview_jpeg_and_webp(tmp_path: Path):
+    item_dir = tmp_path / "workshop_item"
+
+    item_dir.mkdir(parents=True, exist_ok=True)
+    _write_image(item_dir / "zzz.png", (1024, 1024))
+    _write_image(item_dir / "preview.webp", (1024, 1024))
+
+    assert workshop_router.find_preview_image_in_folder(str(item_dir)) == str(item_dir / "preview.webp")
+
+
+@pytest.mark.unit
+def test_find_preview_image_accepts_character_file_stem_hint(tmp_path: Path):
+    item_dir = tmp_path / "workshop_item"
+
+    item_dir.mkdir(parents=True, exist_ok=True)
+    _write_image(item_dir / "zzz.png", (1024, 1024))
+    _write_image(item_dir / "CardA.png", (1024, 1024))
+
+    assert workshop_router.find_preview_image_in_folder(
+        str(item_dir),
+        "展示名A",
+        "CardA",
+    ) == str(item_dir / "CardA.png")


### PR DESCRIPTION
## 变更说明

修复 Steam 创意工坊订阅角色卡在缺少标准预览图时，本地角色卡卡面无法生成的问题。

原逻辑只识别固定名称的预览图，例如：

- `preview.jpg`
- `preview.png`
- `thumbnail.jpg`
- `thumbnail.png`
- `icon.jpg`
- `icon.png`
- `header.jpg`
- `header.png`

如果工坊包里没有这些文件，例如只有 `独角兽.png`，角色卡数据本身可以同步成功，但后端无法找到可用预览图，因此不会生成本地 `card_faces/{角色名}.png`，前端会显示无卡面占位。

本次调整后：

1. **仍然优先使用标准预览图。**
   如果目录中存在 `preview.* / thumbnail.* / icon.* / header.*`，会直接使用这些显式预览图，不会再用角色名去猜其它图片。

2. **只有在没有标准预览图时，才进入兜底扫描。**
   兜底逻辑会扫描模组目录中的图片候选，用于兼容轻度不规范的工坊包。

3. **兜底选择会参考角色名和角色卡文件名。**
   例如 `独角兽.chara.json` 搭配 `独角兽.png` 时，会优先选择这张图片作为卡面来源。

4. **尽量避开模型贴图。**
   Live2D `textures` 目录下的图片、以及被模型 JSON 引用的图片会被降权，降低把 `texture_00.png` 误当成角色卡面的概率。

5. **多角色工坊包只在缺少标准预览图时按角色兜底。**
   如果一个工坊包内包含多个 `.chara.json`，且没有标准 `preview.*`，会尽量按当前角色名或当前 `.chara.json` 文件名选择对应图片。
   如果存在标准 `preview.*`，仍然统一尊重标准预览图。

## 适用范围

本修复主要覆盖“轻度不规范”的创意工坊包，例如：

```text
模组目录/
├── 独角兽.chara.json
├── 独角兽.png
└── 模型目录/
    ├── xxx.model3.json
    └── textures/
        └── texture_00.png
