### PR TITLE
初始人设选择流程调用 /api/characters/persona-presets 和保存人设选择时，没有把前端当前界面语言传给后端

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -86,7 +86,7 @@ from utils.voice_clone import (
 )
 from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.frontend_utils import find_models, find_model_directory, is_user_imported_model
-from utils.language_utils import normalize_language_code
+from utils.language_utils import is_supported_language_code, normalize_language_code
 from utils.logger_config import get_module_logger
 from utils.new_character_greeting_state import (
     mark_pending as mark_new_character_greeting_pending,
@@ -179,6 +179,25 @@ def _build_persona_selection_payload(character_payload: dict) -> dict:
         "selected_at": str(override.get("selected_at") or "").strip(),
         "profile": dict(profile) if isinstance(profile, dict) else {},
     }
+
+
+def _normalize_persona_request_language(raw_language: object) -> str | None:
+    """归一化人格选择请求携带的界面语言，无效值保持 None 让下游使用现有兜底。"""
+    raw = str(raw_language or "").strip()
+    if not raw or not is_supported_language_code(raw):
+        return None
+    return normalize_language_code(raw, format="full")
+
+
+def _get_persona_request_language(request: Request) -> str | None:
+    """从查询参数或 Accept-Language 里提取人格预设语言。"""
+    language = request.query_params.get("language") or request.query_params.get("i18n_language")
+    if language:
+        return _normalize_persona_request_language(language)
+    accept_lang = request.headers.get("Accept-Language", "")
+    if accept_lang:
+        return _normalize_persona_request_language(accept_lang.split(",")[0].split(";")[0].strip())
+    return None
 
 
 def _has_generated_persona_selection_prompt(prompt_text: object) -> bool:
@@ -2034,10 +2053,10 @@ async def get_current_catgirl():
 
 
 @router.get('/persona-presets')
-async def list_persona_presets_route():
+async def list_persona_presets_route(request: Request):
     return _json_no_store_response({
         "success": True,
-        "presets": list_persona_presets(),
+        "presets": list_persona_presets(lang=_get_persona_request_language(request)),
     })
 
 
@@ -2132,10 +2151,14 @@ async def update_character_persona_selection(name: str, request: Request):
         return JSONResponse({'success': False, 'error': '角色不存在'}, status_code=404)
 
     selected_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    request_language = _normalize_persona_request_language(
+        (payload or {}).get("i18n_language") or (payload or {}).get("language")
+    )
     override_payload = build_persona_override_payload(
         preset_id,
         source=source,
         selected_at=selected_at,
+        lang=request_language,
     )
     if override_payload is None:
         return JSONResponse({'success': False, 'error': '无效的人格预设'}, status_code=400)

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -193,11 +193,28 @@ def _get_persona_request_language(request: Request) -> str | None:
     """从查询参数或 Accept-Language 里提取人格预设语言。"""
     language = request.query_params.get("language") or request.query_params.get("i18n_language")
     if language:
-        return _normalize_persona_request_language(language)
+        normalized = _normalize_persona_request_language(language)
+        if normalized is not None:
+            return normalized
     accept_lang = request.headers.get("Accept-Language", "")
     if accept_lang:
-        return _normalize_persona_request_language(accept_lang.split(",")[0].split(";")[0].strip())
+        for language_part in accept_lang.split(","):
+            normalized = _normalize_persona_request_language(language_part.split(";")[0].strip())
+            if normalized is not None:
+                return normalized
     return None
+
+
+def _get_persona_payload_request_language(payload: object, request: Request) -> str | None:
+    """优先使用请求体语言；无效或缺失时回退到查询参数和请求头。"""
+    body_language = None
+    if isinstance(payload, dict):
+        body_language = payload.get("i18n_language") or payload.get("language")
+    if body_language:
+        normalized = _normalize_persona_request_language(body_language)
+        if normalized is not None:
+            return normalized
+    return _get_persona_request_language(request)
 
 
 def _has_generated_persona_selection_prompt(prompt_text: object) -> bool:
@@ -2151,9 +2168,7 @@ async def update_character_persona_selection(name: str, request: Request):
         return JSONResponse({'success': False, 'error': '角色不存在'}, status_code=404)
 
     selected_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    request_language = _normalize_persona_request_language(
-        (payload or {}).get("i18n_language") or (payload or {}).get("language")
-    )
+    request_language = _get_persona_payload_request_language(payload, request)
     override_payload = build_persona_override_payload(
         preset_id,
         source=source,

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -44,6 +44,29 @@
         return payload;
     }
 
+    function getCurrentLanguage() {
+        try {
+            if (window.i18next && typeof window.i18next.language === 'string' && window.i18next.language) {
+                return window.i18next.language;
+            }
+            if (window.i18n && typeof window.i18n.language === 'string' && window.i18n.language) {
+                return window.i18n.language;
+            }
+            if (typeof localStorage !== 'undefined') {
+                const cached = localStorage.getItem('i18nextLng');
+                if (cached) {
+                    return cached;
+                }
+            }
+            if (typeof navigator !== 'undefined' && navigator.language) {
+                return navigator.language;
+            }
+        } catch (_) {
+            return '';
+        }
+        return '';
+    }
+
     function ensureStyles() {
         if (document.getElementById(STYLE_ID)) {
             return;
@@ -373,7 +396,11 @@
         }
 
         async fetchPresets() {
-            const payload = await requestJson('/api/characters/persona-presets');
+            const language = getCurrentLanguage();
+            const url = language
+                ? `/api/characters/persona-presets?language=${encodeURIComponent(language)}`
+                : '/api/characters/persona-presets';
+            const payload = await requestJson(url);
             return Array.isArray(payload.presets) ? payload.presets : [];
         }
 
@@ -952,6 +979,7 @@
                             body: JSON.stringify({
                                 preset_id: selectedPresetId,
                                 source: openReason,
+                                i18n_language: getCurrentLanguage(),
                             }),
                         }
                     );

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -109,6 +109,7 @@
             this.restoreBodyPointerEventsNeeded = false;
             this.originalBodyPointerEvents = '';
             this.openReason = 'onboarding';
+            this.currentLanguage = '';
             this.typewriterRunId = 0;
             this.typewriterTimer = null;
             this.lastTutorialPromptState = null;
@@ -178,7 +179,8 @@
             await this.waitForTutorialFlowToSettle();
             this.openReason = 'settings';
             this.currentCharacterName = String(characterName || '').trim() || await this.fetchCurrentCharacterName();
-            this.presets = await this.fetchPresets();
+            this.currentLanguage = getCurrentLanguage();
+            this.presets = await this.fetchPresets(this.currentLanguage);
             this.ensureOverlay();
             this.renderStageOne();
             this.showOverlay();
@@ -361,7 +363,8 @@
             }
 
             this.openReason = 'manual_reselect';
-            this.presets = await this.fetchPresets();
+            this.currentLanguage = getCurrentLanguage();
+            this.presets = await this.fetchPresets(this.currentLanguage);
             if (!this.presets.length) {
                 return false;
             }
@@ -380,7 +383,8 @@
 
             this.openReason = 'onboarding';
             this.currentCharacterName = await this.fetchCurrentCharacterName();
-            this.presets = await this.fetchPresets();
+            this.currentLanguage = getCurrentLanguage();
+            this.presets = await this.fetchPresets(this.currentLanguage);
             if (!this.currentCharacterName || !this.presets.length) {
                 return;
             }
@@ -395,10 +399,10 @@
             return String(payload.current_catgirl || '').trim();
         }
 
-        async fetchPresets() {
-            const language = getCurrentLanguage();
-            const url = language
-                ? `/api/characters/persona-presets?language=${encodeURIComponent(language)}`
+        async fetchPresets(language) {
+            const requestLanguage = String(language || '').trim();
+            const url = requestLanguage
+                ? `/api/characters/persona-presets?language=${encodeURIComponent(requestLanguage)}`
                 : '/api/characters/persona-presets';
             const payload = await requestJson(url);
             return Array.isArray(payload.presets) ? payload.presets : [];
@@ -787,7 +791,7 @@
                 );
                 card.appendChild(quote);
 
-                card.addEventListener('click', () => this.renderStageTwo(preset));
+                card.addEventListener('click', () => this.renderStageTwo(preset, this.currentLanguage));
                 grid.appendChild(card);
             });
 
@@ -821,11 +825,12 @@
             stageTwo.hidden = true;
         }
 
-        renderStageTwo(preset) {
+        renderStageTwo(preset, language) {
             if (!this.overlay || !preset) {
                 return;
             }
 
+            const requestLanguage = String(language || '').trim();
             this.selectedPresetId = preset.preset_id;
 
             const stageOne = this.overlay.querySelector('.character-personality-stage-one');
@@ -979,7 +984,7 @@
                             body: JSON.stringify({
                                 preset_id: selectedPresetId,
                                 source: openReason,
-                                i18n_language: getCurrentLanguage(),
+                                i18n_language: requestLanguage,
                             }),
                         }
                     );

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -10,6 +11,10 @@ Page = playwright_sync_api.Page
 expect = playwright_sync_api.expect
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def new_url_pathname(raw_url: str) -> str:
+    return urlparse(str(raw_url)).path
 
 
 def _bootstrap_page(mock_page: Page) -> None:
@@ -827,7 +832,14 @@ def test_onboarding_skip_persists_state_and_closes_overlay(mock_page: Page):
 @pytest.mark.frontend
 def test_onboarding_confirm_dispatches_character_update_event(mock_page: Page):
     _bootstrap_page(mock_page)
-    mock_page.evaluate("() => { window.universalTutorialManager.isTutorialRunning = false; }")
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.i18next = { language: 'zh-CN' };
+        }
+        """
+    )
     mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
 
     mock_page.evaluate(
@@ -853,12 +865,23 @@ def test_onboarding_confirm_dispatches_character_update_event(mock_page: Page):
     }
 
     request_log = mock_page.evaluate("() => window.__requestLog")
-    assert sum(
-        1
+    preset_entries = [
+        entry
+        for entry in request_log
+        if new_url_pathname(entry["url"]) == "/api/characters/persona-presets"
+    ]
+    assert preset_entries
+    preset_language = parse_qs(urlparse(preset_entries[-1]["url"]).query).get("language", [""])[0]
+    assert preset_language == "zh-CN"
+
+    put_entries = [
+        entry
         for entry in request_log
         if entry["url"] == "/api/characters/character/%E5%B0%8F%E5%A4%A9/persona-selection"
         and entry["method"] == "PUT"
-    ) == 1
+    ]
+    assert len(put_entries) == 1
+    assert put_entries[0]["body"]["i18n_language"] == preset_language
     assert not any(
         entry["url"] == "/api/characters/persona-onboarding-state"
         and entry["method"] == "POST"

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -92,7 +92,7 @@ def _bootstrap_page(mock_page: Page) -> None:
                     });
                 }
 
-                if (requestUrl === '/api/characters/persona-presets') {
+                if (new URL(requestUrl, window.location.origin).pathname === '/api/characters/persona-presets') {
                     return new Response(JSON.stringify({
                         success: true,
                         presets: [{

--- a/tests/unit/test_character_persona_router.py
+++ b/tests/unit/test_character_persona_router.py
@@ -314,6 +314,22 @@ async def test_character_persona_routes_save_clear_and_track_onboarding_state():
             ja_presets_body = _parse_json_response(ja_presets_response)
             assert "煮干しのご褒美" in ja_presets_body["presets"][0]["prompt_guidance"]
 
+            ja_header_presets_response = await router_module.list_persona_presets_route(
+                _DummyRequest({}, headers={"Accept-Language": "ja-JP"}),
+            )
+            ja_header_presets_body = _parse_json_response(ja_header_presets_response)
+            assert "煮干しのご褒美" in ja_header_presets_body["presets"][0]["prompt_guidance"]
+
+            invalid_query_with_header_response = await router_module.list_persona_presets_route(
+                _DummyRequest(
+                    {},
+                    query_params={"language": "cimode"},
+                    headers={"Accept-Language": "ja-JP"},
+                ),
+            )
+            invalid_query_with_header_body = _parse_json_response(invalid_query_with_header_response)
+            assert "煮干しのご褒美" in invalid_query_with_header_body["presets"][0]["prompt_guidance"]
+
             current_name = config_manager.load_characters()["当前猫娘"]
             save_result = await router_module.update_character_persona_selection(
                 current_name,
@@ -330,6 +346,18 @@ async def test_character_persona_routes_save_clear_and_track_onboarding_state():
             override = characters["猫娘"][current_name]["_reserved"]["persona_override"]
             assert override["preset_id"] == "classic_genki"
             assert "小鱼干奖励喵" in override["prompt_guidance"]
+
+            header_save_result = await router_module.update_character_persona_selection(
+                current_name,
+                _DummyRequest(
+                    {"preset_id": "classic_genki", "source": "manual_reselect"},
+                    headers={"Accept-Language": "ja-JP"},
+                ),
+            )
+            assert header_save_result["success"] is True
+            characters = config_manager.load_characters()
+            override = characters["猫娘"][current_name]["_reserved"]["persona_override"]
+            assert "煮干しのご褒美" in override["prompt_guidance"]
 
             selection_response = await router_module.get_character_persona_selection(current_name)
             selection_body = _parse_json_response(selection_response)

--- a/tests/unit/test_character_persona_router.py
+++ b/tests/unit/test_character_persona_router.py
@@ -43,8 +43,10 @@ def _make_config_manager(tmp_root: Path) -> ConfigManager:
 
 
 class _DummyRequest:
-    def __init__(self, payload):
+    def __init__(self, payload, *, query_params=None, headers=None):
         self._payload = payload
+        self.query_params = query_params or {}
+        self.headers = headers or {}
 
     async def json(self):
         return self._payload
@@ -297,7 +299,7 @@ async def test_character_persona_routes_save_clear_and_track_onboarding_state():
 
             router_module = importlib.reload(importlib.import_module("main_routers.characters_router"))
 
-            presets_response = await router_module.list_persona_presets_route()
+            presets_response = await router_module.list_persona_presets_route(_DummyRequest({}))
             presets_body = _parse_json_response(presets_response)
             assert presets_body["success"] is True
             assert [preset["preset_id"] for preset in presets_body["presets"]] == [
@@ -306,10 +308,20 @@ async def test_character_persona_routes_save_clear_and_track_onboarding_state():
                 "elegant_butler",
             ]
 
+            ja_presets_response = await router_module.list_persona_presets_route(
+                _DummyRequest({}, query_params={"language": "ja-JP"}),
+            )
+            ja_presets_body = _parse_json_response(ja_presets_response)
+            assert "煮干しのご褒美" in ja_presets_body["presets"][0]["prompt_guidance"]
+
             current_name = config_manager.load_characters()["当前猫娘"]
             save_result = await router_module.update_character_persona_selection(
                 current_name,
-                _DummyRequest({"preset_id": "classic_genki", "source": "onboarding"}),
+                _DummyRequest({
+                    "preset_id": "classic_genki",
+                    "source": "onboarding",
+                    "i18n_language": "zh-CN",
+                }),
             )
             assert save_result["success"] is True
             assert save_result["selection"]["mode"] == "override"
@@ -317,6 +329,7 @@ async def test_character_persona_routes_save_clear_and_track_onboarding_state():
             characters = config_manager.load_characters()
             override = characters["猫娘"][current_name]["_reserved"]["persona_override"]
             assert override["preset_id"] == "classic_genki"
+            assert "小鱼干奖励喵" in override["prompt_guidance"]
 
             selection_response = await router_module.get_character_persona_selection(current_name)
             selection_body = _parse_json_response(selection_response)


### PR DESCRIPTION
后端只能使用自己的语言兜底逻辑来生成预设内容，在部分环境下会落到英文，导致中文界面选择后复制/保存的人设仍是英文。现在前端会携带当前 i18n 语言，后端按请求语言返回并写入对应本地化人设内容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 角色预设现在基于请求语言返回本地化内容。
  * 在角色个性设置中保存并提交用户语言偏好，使持久化的预设成为语言感知的。

* **测试**
  * 增强前端/后端测试以覆盖语言检测、预设加载和保存流程，验证多语言场景与回退行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->