### PR TITLE
修复启动期工坊角色卡后台同步与初始人格选择的竞态，避免用户快速选择人格后，persona_override 被旧的 characters.…

### DIFF
--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -4156,6 +4156,16 @@ async def sync_workshop_character_cards() -> dict:
                             # 已存在则跳过（当前设计：仅填充缺失角色卡，不覆盖已有数据；
                             # 如需支持创意工坊更新覆写本地数据，可添加 allow_workshop_overwrite 配置项）
                             if chara_name in characters['猫娘']:
+                                if chara_name in pending_added_catgirls:
+                                    # 同一次扫描内的重复同名卡仍处于待合并状态，不能按已存在角色补写封面；
+                                    # 最终是否导入要等保存前用最新版 characters.json 再判定。
+                                    skipped_count += 1
+                                    logger.info(
+                                        "sync_workshop_character_cards: 跳过重复待添加角色 '%s'（物品 %s）",
+                                        chara_name,
+                                        item_id,
+                                    )
+                                    continue
                                 existing_data = characters['猫娘'].get(chara_name) or {}
                                 if _is_matching_workshop_character(existing_data, item_id):
                                     try:

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -4317,11 +4317,32 @@ async def sync_workshop_character_cards() -> dict:
                     # 避免用扫描前的旧快照整包覆盖用户刚写入的字段。
                     latest_characters = await config_mgr.aload_characters()
                     if not isinstance(latest_characters, dict):
-                        latest_characters = {}
+                        logger.warning(
+                            "sync_workshop_character_cards: 保存前检测到 characters.json 根对象结构无效（%s），取消本轮同步保存",
+                            type(latest_characters).__name__,
+                        )
+                        added_count = 0
+                        error_count += 1
+                        return {
+                            "added": added_count,
+                            "backfilled_faces": backfilled_face_count,
+                            "skipped": skipped_count,
+                            "errors": error_count,
+                        }
                     latest_catgirls = latest_characters.get('猫娘')
                     if not isinstance(latest_catgirls, dict):
-                        latest_catgirls = {}
-                        latest_characters['猫娘'] = latest_catgirls
+                        logger.warning(
+                            "sync_workshop_character_cards: 保存前检测到 characters.json 猫娘字段结构无效（%s），取消本轮同步保存",
+                            type(latest_catgirls).__name__,
+                        )
+                        added_count = 0
+                        error_count += 1
+                        return {
+                            "added": added_count,
+                            "backfilled_faces": backfilled_face_count,
+                            "skipped": skipped_count,
+                            "errors": error_count,
+                        }
 
                     latest_deleted_character_names = _load_deleted_character_names(config_mgr)
                     actually_added_count = 0

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -4113,6 +4113,7 @@ async def sync_workshop_character_cards() -> dict:
             
             need_save = False
             pending_added_catgirls = {}
+            pending_card_face_writes = {}
             
             # 2. 遍历所有已安装的物品
             for item in subscribed_items:
@@ -4274,50 +4275,13 @@ async def sync_workshop_character_cards() -> dict:
                             
                             characters['猫娘'][chara_name] = catgirl_data
                             pending_added_catgirls[chara_name] = catgirl_data
+                            pending_card_face_writes[chara_name] = {
+                                'preview_image_path': preview_image_path,
+                                'item': item,
+                            }
                             need_save = True
                             added_count += 1
-                            logger.info(f"sync_workshop_character_cards: 添加角色卡 '{chara_name}' (来自物品 {item_id})")
-
-                            # 同步生成本地卡面和 sidecar，前端封面只认 card_faces/{name}.png
-                            try:
-                                blocked_result = _abort_if_write_fence_active(
-                                    f"sync_workshop_character_cards: 生成角色卡封面前检测到维护态写围栏，跳过本轮同步并等待后续重试（角色 {chara_name}，物品 {item_id}）"
-                                )
-                                if blocked_result is not None:
-                                    return blocked_result
-                                face_created = await asyncio.to_thread(
-                                    _ensure_workshop_card_face_from_preview,
-                                    config_mgr,
-                                    chara_name,
-                                    preview_image_path,
-                                    item,
-                                )
-                                if face_created:
-                                    logger.info(
-                                        "sync_workshop_character_cards: 已生成角色卡封面 '%s' (来自物品 %s)",
-                                        chara_name,
-                                        item_id,
-                                    )
-                                elif item:
-                                    blocked_result = _abort_if_write_fence_active(
-                                        f"sync_workshop_character_cards: 补写角色卡封面元数据前检测到维护态写围栏，跳过本轮同步并等待后续重试（角色 {chara_name}，物品 {item_id}）"
-                                    )
-                                    if blocked_result is not None:
-                                        return blocked_result
-                                    await asyncio.to_thread(
-                                        _ensure_workshop_card_face_meta,
-                                        config_mgr,
-                                        chara_name,
-                                        item,
-                                    )
-                            except Exception as face_meta_err:
-                                error_count += 1
-                                logger.warning(
-                                    "sync_workshop_character_cards: 补写角色卡封面或元数据失败 %s (物品 %s): %s",
-                                    chara_name,
-                                    item_id,
-                                    face_meta_err,
-                                )
+                            logger.info(f"sync_workshop_character_cards: 发现待添加角色卡 '{chara_name}' (来自物品 {item_id})")
                             
                         except Exception as e:
                             logger.warning(f"sync_workshop_character_cards: 处理文件 {chara_file_path} 失败: {e}")
@@ -4336,6 +4300,7 @@ async def sync_workshop_character_cards() -> dict:
                     return blocked_result
 
                 characters_to_save = characters
+                actually_added_names = []
                 if pending_added_catgirls:
                     # 启动期工坊同步是后台任务：扫描可能很慢，期间用户可能已经修改了角色卡
                     # 或完成初始人格选择。保存前必须重新读取最新配置，只把本轮新增角色合入，
@@ -4357,6 +4322,7 @@ async def sync_workshop_character_cards() -> dict:
                             continue
                         latest_catgirls[pending_name] = pending_payload
                         actually_added_count += 1
+                        actually_added_names.append(pending_name)
 
                     added_count = actually_added_count
                     skipped_count += skipped_due_to_race_count
@@ -4375,6 +4341,52 @@ async def sync_workshop_character_cards() -> dict:
                         return _write_fence_blocked_result()
 
                     logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡，回填 {backfilled_face_count} 个封面")
+
+                    for added_name in actually_added_names:
+                        write_info = pending_card_face_writes.get(added_name) or {}
+                        write_item = write_info.get('item') if isinstance(write_info, dict) else None
+                        write_item_id = write_item.get('publishedFileId', '') if isinstance(write_item, dict) else ''
+                        if is_write_fence_active(config_mgr):
+                            logger.info(
+                                "sync_workshop_character_cards: 角色已保存，但维护态写围栏已开启，跳过角色卡封面生成（角色 %s）",
+                                added_name,
+                            )
+                            continue
+                        try:
+                            face_created = await asyncio.to_thread(
+                                _ensure_workshop_card_face_from_preview,
+                                config_mgr,
+                                added_name,
+                                write_info.get('preview_image_path') if isinstance(write_info, dict) else None,
+                                write_item,
+                            )
+                            if face_created:
+                                logger.info(
+                                    "sync_workshop_character_cards: 已生成角色卡封面 '%s' (来自物品 %s)",
+                                    added_name,
+                                    write_item_id,
+                                )
+                            elif write_item:
+                                if is_write_fence_active(config_mgr):
+                                    logger.info(
+                                        "sync_workshop_character_cards: 角色已保存，但维护态写围栏已开启，跳过角色卡封面元数据补写（角色 %s）",
+                                        added_name,
+                                    )
+                                    continue
+                                await asyncio.to_thread(
+                                    _ensure_workshop_card_face_meta,
+                                    config_mgr,
+                                    added_name,
+                                    write_item,
+                                )
+                        except Exception as face_meta_err:
+                            error_count += 1
+                            logger.warning(
+                                "sync_workshop_character_cards: 补写角色卡封面或元数据失败 %s (物品 %s): %s",
+                                added_name,
+                                write_item_id,
+                                face_meta_err,
+                            )
                 
                 try:
                     initialize_character_data = get_initialize_character_data()

--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -4112,6 +4112,7 @@ async def sync_workshop_character_cards() -> dict:
             deleted_character_names = _load_deleted_character_names(config_mgr)
             
             need_save = False
+            pending_added_catgirls = {}
             
             # 2. 遍历所有已安装的物品
             for item in subscribed_items:
@@ -4272,6 +4273,7 @@ async def sync_workshop_character_cards() -> dict:
                                     set_reserved(catgirl_data, 'avatar', 'mmd', 'model_path', subscriber_model_ref)
                             
                             characters['猫娘'][chara_name] = catgirl_data
+                            pending_added_catgirls[chara_name] = catgirl_data
                             need_save = True
                             added_count += 1
                             logger.info(f"sync_workshop_character_cards: 添加角色卡 '{chara_name}' (来自物品 {item_id})")
@@ -4333,13 +4335,46 @@ async def sync_workshop_character_cards() -> dict:
                 if blocked_result is not None:
                     return blocked_result
 
-                try:
-                    await config_mgr.asave_characters(characters)
-                except MaintenanceModeError:
-                    logger.info("sync_workshop_character_cards: 保存时进入维护态写围栏，跳过本轮同步并等待后续重试")
-                    return _write_fence_blocked_result()
+                characters_to_save = characters
+                if pending_added_catgirls:
+                    # 启动期工坊同步是后台任务：扫描可能很慢，期间用户可能已经修改了角色卡
+                    # 或完成初始人格选择。保存前必须重新读取最新配置，只把本轮新增角色合入，
+                    # 避免用扫描前的旧快照整包覆盖用户刚写入的字段。
+                    latest_characters = await config_mgr.aload_characters()
+                    if not isinstance(latest_characters, dict):
+                        latest_characters = {}
+                    latest_catgirls = latest_characters.get('猫娘')
+                    if not isinstance(latest_catgirls, dict):
+                        latest_catgirls = {}
+                        latest_characters['猫娘'] = latest_catgirls
 
-                logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡，回填 {backfilled_face_count} 个封面")
+                    latest_deleted_character_names = _load_deleted_character_names(config_mgr)
+                    actually_added_count = 0
+                    skipped_due_to_race_count = 0
+                    for pending_name, pending_payload in pending_added_catgirls.items():
+                        if pending_name in latest_deleted_character_names or pending_name in latest_catgirls:
+                            skipped_due_to_race_count += 1
+                            continue
+                        latest_catgirls[pending_name] = pending_payload
+                        actually_added_count += 1
+
+                    added_count = actually_added_count
+                    skipped_count += skipped_due_to_race_count
+                    if actually_added_count <= 0:
+                        need_save = False
+                    else:
+                        if not latest_characters.get('当前猫娘') and latest_catgirls:
+                            latest_characters['当前猫娘'] = next(iter(latest_catgirls), '')
+                        characters_to_save = latest_characters
+
+                if need_save:
+                    try:
+                        await config_mgr.asave_characters(characters_to_save)
+                    except MaintenanceModeError:
+                        logger.info("sync_workshop_character_cards: 保存时进入维护态写围栏，跳过本轮同步并等待后续重试")
+                        return _write_fence_blocked_result()
+
+                    logger.info(f"sync_workshop_character_cards: 已保存，新增 {added_count} 个角色卡，回填 {backfilled_face_count} 个封面")
                 
                 try:
                     initialize_character_data = get_initialize_character_data()

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -840,6 +840,12 @@ async def test_sync_workshop_character_cards_does_not_write_orphan_face_when_pen
                 json.dumps({"档案名": "并发工坊角色", "昵称": "来自工坊"}, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
+            duplicate_dir = installed_folder / "duplicate"
+            duplicate_dir.mkdir()
+            (duplicate_dir / "重复角色卡.chara.json").write_text(
+                json.dumps({"档案名": "并发工坊角色", "昵称": "重复工坊卡"}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
             preview_path = installed_folder / "preview.png"
             Image.new("RGBA", (1024, 1024), (80, 160, 220, 255)).save(preview_path)
 

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -761,7 +761,7 @@ async def test_sync_workshop_character_cards_preserves_persona_override_written_
 
             current_name = cm.load_characters()["当前猫娘"]
 
-            def _write_persona_override_before_sync_save(*args, **kwargs):
+            def _write_persona_override_during_scan(_installed_folder):
                 latest = cm.load_characters()
                 latest["猫娘"][current_name].setdefault("_reserved", {})["persona_override"] = {
                     "preset_id": "classic_genki",
@@ -773,7 +773,7 @@ async def test_sync_workshop_character_cards_preserves_persona_override_written_
                     },
                 }
                 cm.save_characters(latest, bypass_write_fence=True)
-                return False
+                return None
 
             with (
                 patch.object(
@@ -793,8 +793,8 @@ async def test_sync_workshop_character_cards_preserves_persona_override_written_
                 ),
                 patch.object(
                     workshop_router_module,
-                    "_ensure_workshop_card_face_from_preview",
-                    side_effect=_write_persona_override_before_sync_save,
+                    "find_preview_image_in_folder",
+                    side_effect=_write_persona_override_during_scan,
                 ),
             ):
                 sync_result = await workshop_router_module.sync_workshop_character_cards()
@@ -804,6 +804,81 @@ async def test_sync_workshop_character_cards_preserves_persona_override_written_
             assert "启动竞态工坊角色" in saved_characters.get("猫娘", {})
             saved_override = saved_characters["猫娘"][current_name].get("_reserved", {}).get("persona_override")
             assert saved_override["preset_id"] == "classic_genki"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_workshop_character_cards_does_not_write_orphan_face_when_pending_add_is_skipped():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            workshop_router_module = reload_module("main_routers.workshop_router")
+
+            installed_folder = Path(td) / "mock_workshop_orphan_face_item"
+            installed_folder.mkdir(parents=True, exist_ok=True)
+            (installed_folder / "角色卡.chara.json").write_text(
+                json.dumps({"档案名": "并发工坊角色", "昵称": "来自工坊"}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            preview_path = installed_folder / "preview.png"
+            Image.new("RGBA", (1024, 1024), (80, 160, 220, 255)).save(preview_path)
+
+            def _create_same_character_during_scan(_installed_folder):
+                latest = cm.load_characters()
+                latest.setdefault("猫娘", {})["并发工坊角色"] = {"昵称": "并发创建"}
+                cm.save_characters(latest, bypass_write_fence=True)
+                return str(preview_path)
+
+            with (
+                patch.object(
+                    workshop_router_module,
+                    "get_subscribed_workshop_items",
+                    AsyncMock(
+                        return_value={
+                            "success": True,
+                            "items": [
+                                {
+                                    "publishedFileId": "123456",
+                                    "installedFolder": str(installed_folder),
+                                }
+                            ],
+                        }
+                    ),
+                ),
+                patch.object(
+                    workshop_router_module,
+                    "find_preview_image_in_folder",
+                    side_effect=_create_same_character_during_scan,
+                ),
+            ):
+                sync_result = await workshop_router_module.sync_workshop_character_cards()
+
+            assert sync_result["added"] == 0
+            assert sync_result["skipped"] >= 1
+            saved_characters = cm.load_characters()
+            assert saved_characters["猫娘"]["并发工坊角色"]["昵称"] == "并发创建"
+            assert not (cm.card_faces_dir / "并发工坊角色.png").exists()
+            assert not cm.card_face_meta_path("并发工坊角色").exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -726,6 +726,88 @@ async def test_sync_workshop_character_cards_skips_save_when_maintenance_fence_t
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_sync_workshop_character_cards_preserves_persona_override_written_during_scan():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            workshop_router_module = reload_module("main_routers.workshop_router")
+
+            installed_folder = Path(td) / "mock_workshop_persona_race_item"
+            installed_folder.mkdir(parents=True, exist_ok=True)
+            (installed_folder / "角色卡.chara.json").write_text(
+                json.dumps({"档案名": "启动竞态工坊角色", "昵称": "来自工坊"}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+            current_name = cm.load_characters()["当前猫娘"]
+
+            def _write_persona_override_before_sync_save(*args, **kwargs):
+                latest = cm.load_characters()
+                latest["猫娘"][current_name].setdefault("_reserved", {})["persona_override"] = {
+                    "preset_id": "classic_genki",
+                    "source": "onboarding",
+                    "selected_at": "2026-05-08T12:00:00Z",
+                    "prompt_guidance": "保持测试人格",
+                    "profile": {
+                        "性格原型": "经典元气猫娘",
+                    },
+                }
+                cm.save_characters(latest, bypass_write_fence=True)
+                return False
+
+            with (
+                patch.object(
+                    workshop_router_module,
+                    "get_subscribed_workshop_items",
+                    AsyncMock(
+                        return_value={
+                            "success": True,
+                            "items": [
+                                {
+                                    "publishedFileId": "123456",
+                                    "installedFolder": str(installed_folder),
+                                }
+                            ],
+                        }
+                    ),
+                ),
+                patch.object(
+                    workshop_router_module,
+                    "_ensure_workshop_card_face_from_preview",
+                    side_effect=_write_persona_override_before_sync_save,
+                ),
+            ):
+                sync_result = await workshop_router_module.sync_workshop_character_cards()
+
+            assert sync_result["added"] == 1
+            saved_characters = cm.load_characters()
+            assert "启动竞态工坊角色" in saved_characters.get("猫娘", {})
+            saved_override = saved_characters["猫娘"][current_name].get("_reserved", {}).get("persona_override")
+            assert saved_override["preset_id"] == "classic_genki"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_sync_workshop_character_cards_skips_face_writes_when_maintenance_fence_turns_on_mid_scan():
     with TemporaryDirectory() as td:
         cm = _make_config_manager(Path(td))

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -889,6 +889,72 @@ async def test_sync_workshop_character_cards_does_not_write_orphan_face_when_pen
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_sync_workshop_character_cards_aborts_when_latest_catgirl_map_is_malformed():
+    with TemporaryDirectory() as td:
+        cm = _make_config_manager(Path(td))
+        bootstrap_local_cloudsave_environment(cm)
+
+        async def _noop_init():
+            return None
+
+        async def _noop_any(*args, **kwargs):
+            return None
+
+        with patch("utils.config_manager._config_manager", cm):
+            init_shared_state(
+                role_state={},
+                steamworks=None,
+                templates=None,
+                config_manager=cm,
+                logger=None,
+                initialize_character_data=_noop_init,
+                switch_current_catgirl_fast=_noop_any,
+                init_one_catgirl=_noop_any,
+                remove_one_catgirl=_noop_any,
+            )
+
+            workshop_router_module = reload_module("main_routers.workshop_router")
+
+            installed_folder = Path(td) / "mock_workshop_bad_latest_characters"
+            installed_folder.mkdir(parents=True, exist_ok=True)
+            (installed_folder / "角色卡.chara.json").write_text(
+                json.dumps({"档案名": "坏结构保护角色", "昵称": "来自工坊"}, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+            initial_characters = cm.load_characters()
+            malformed_latest = {**initial_characters, "猫娘": []}
+            save_mock = AsyncMock()
+
+            with (
+                patch.object(
+                    workshop_router_module,
+                    "get_subscribed_workshop_items",
+                    AsyncMock(
+                        return_value={
+                            "success": True,
+                            "items": [
+                                {
+                                    "publishedFileId": "123456",
+                                    "installedFolder": str(installed_folder),
+                                }
+                            ],
+                        }
+                    ),
+                ),
+                patch.object(cm, "aload_characters", AsyncMock(side_effect=[initial_characters, malformed_latest])),
+                patch.object(cm, "asave_characters", save_mock),
+            ):
+                sync_result = await workshop_router_module.sync_workshop_character_cards()
+
+            assert sync_result["added"] == 0
+            assert sync_result["errors"] == 1
+            save_mock.assert_not_awaited()
+            assert "坏结构保护角色" not in cm.load_characters().get("猫娘", {})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_sync_workshop_character_cards_skips_face_writes_when_maintenance_fence_turns_on_mid_scan():
     with TemporaryDirectory() as td:
         cm = _make_config_manager(Path(td))


### PR DESCRIPTION
…json 快照覆盖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进工作坊角色卡同步与保存：避免重复添加相同角色、在保存前合并最新数据并仅写入实际合并的角色，推迟卡面/预览生成以降低冲突，修复扫描与并发修改导致的数据覆盖或不一致，保留已有的人物自定义设置（如人物覆盖）。

* **Tests**
  * 新增单元测试，验证扫描期间并发写入场景下自定义设置能被正确保留与合并。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->