### PR TITLE
修正 #1244 工坊角色卡同步竞态回归测试中的 mock 参数签名，使测试与真实 find_preview_image_in_folde…

### DIFF
--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -761,7 +761,7 @@ async def test_sync_workshop_character_cards_preserves_persona_override_written_
 
             current_name = cm.load_characters()["当前猫娘"]
 
-            def _write_persona_override_during_scan(_installed_folder):
+            def _write_persona_override_during_scan(_installed_folder, _chara_name=None, _chara_file_stem=None):
                 latest = cm.load_characters()
                 latest["猫娘"][current_name].setdefault("_reserved", {})["persona_override"] = {
                     "preset_id": "classic_genki",
@@ -849,7 +849,7 @@ async def test_sync_workshop_character_cards_does_not_write_orphan_face_when_pen
             preview_path = installed_folder / "preview.png"
             Image.new("RGBA", (1024, 1024), (80, 160, 220, 255)).save(preview_path)
 
-            def _create_same_character_during_scan(_installed_folder):
+            def _create_same_character_during_scan(_installed_folder, _chara_name=None, _chara_file_stem=None):
                 latest = cm.load_characters()
                 latest.setdefault("猫娘", {})["并发工坊角色"] = {"昵称": "并发创建"}
                 cm.save_characters(latest, bypass_write_fence=True)


### PR DESCRIPTION
…r 调用保持一致，避免 CI 因测试自身错误失败

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 更新了单元测试中的模拟函数签名，以支持扫描过程中的可选参数。

**注意：** 本更新为仅涉及测试的改动，不包含面向用户的功能变更或公开 API 修改。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->