### PR TITLE
[codex] Block repeated proactive chat

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -5803,7 +5803,8 @@ async def proactive_chat(request: Request):
             # （handle_new_message 或 text stream_text 入口）会 fire USER_INPUT，
             # 在 PHASE2 阶段 sticky 把 _preempted 翻到 True；同时 current_speech_id
             # 被轮换，proactive_sid != 新 sid 兜底覆盖竞态窗口。
-            # feed_tts_chunk 下面还有 lock 内 expected_speech_id 二次校验。
+            # TTS 不在流式阶段输出：先缓冲全文，等相似度/数据级硬拦截都通过后
+            # 再一次性 feed。否则重复文本会在 guard 命中前已经被用户听到。
             if mgr.state.is_proactive_preempted(proactive_sid):
                 print(f"[{lanlan_name}] Phase 2 检测到用户接管（state 抢占），abort")
                 aborted = True
@@ -5822,7 +5823,6 @@ async def proactive_chat(request: Request):
                 aborted = True
                 return True
             full_text += text
-            await mgr.feed_tts_chunk(text, expected_speech_id=proactive_sid)
             return False
         
         try:
@@ -6050,6 +6050,7 @@ async def proactive_chat(request: Request):
             language=proactive_lang,
             master_name=master_name_current,
         )
+        await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
         committed = await mgr.finish_proactive_delivery(
             response_text,
             expected_speech_id=proactive_sid,

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1285,7 +1285,7 @@ _proactive_chat_totals_lock = asyncio.Lock()
 _proactive_chat_totals_loaded = False
 
 _RECENT_CHAT_MAX_AGE_SECONDS = 3600  # 1小时内的搭话记录
-_PROACTIVE_SIMILARITY_THRESHOLD = 0.94  # 高阈值，尽量避免误杀
+_PROACTIVE_SIMILARITY_THRESHOLD = 0.90  # 保守硬拦截阈值：90% 以上重复直接放弃本轮
 _PHASE1_FETCH_PER_SOURCE = PROACTIVE_PHASE1_FETCH_PER_SOURCE  # Phase 1 每个信息源固定抓取条数
 _PHASE1_TOTAL_TOPIC_TARGET = PROACTIVE_PHASE1_TOTAL_TOPICS  # Phase 1 输入给筛选模型的总候选目标条数
 
@@ -5943,6 +5943,28 @@ async def proactive_chat(request: Request):
         # 完整原文通过 print 给开发者本地查看。
         logger.debug(f"[{lanlan_name}] Phase 2 流式完成 (vision={phase2_use_vision}, len={len(response_text)} chars)")
         print(f"\n[PROACTIVE-DEBUG] Phase 2 STREAM output: {response_text[:200]}...\n")
+
+        is_duplicate, similarity_score = _is_similar_to_recent_proactive_chat(lanlan_name, response_text)
+        if is_duplicate:
+            logger.info(
+                "[%s] proactive repeat guard blocked Phase 2 output (similarity=%.3f threshold=%.2f)",
+                lanlan_name, similarity_score, _PROACTIVE_SIMILARITY_THRESHOLD,
+            )
+            print(
+                f"[{lanlan_name}] 主动搭话重复度过高，已拦截 "
+                f"(similarity={similarity_score:.3f}, threshold={_PROACTIVE_SIMILARITY_THRESHOLD:.2f})"
+            )
+            if not mgr.state.is_proactive_preempted(proactive_sid):
+                await mgr.handle_new_message()
+            else:
+                logger.info("[%s] repeat guard hit but user already took over; skip TTS cleanup", lanlan_name)
+            return await _end_proactive(JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": "主动搭话重复度过高，已拦截",
+                "similarity": similarity_score,
+                "threshold": _PROACTIVE_SIMILARITY_THRESHOLD,
+            }))
 
         has_music_topic = 'music' in active_channels
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6050,12 +6050,24 @@ async def proactive_chat(request: Request):
             language=proactive_lang,
             master_name=master_name_current,
         )
-        await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
-        committed = await mgr.finish_proactive_delivery(
-            response_text,
-            expected_speech_id=proactive_sid,
-            action_note=action_note,
-        )
+        try:
+            await mgr.feed_tts_chunk(response_text, expected_speech_id=proactive_sid)
+            committed = await mgr.finish_proactive_delivery(
+                response_text,
+                expected_speech_id=proactive_sid,
+                action_note=action_note,
+            )
+        except Exception as exc:
+            logger.warning("[%s] buffered proactive delivery failed: %s", lanlan_name, exc)
+            if not mgr.state.is_proactive_preempted(proactive_sid):
+                await mgr.handle_new_message()
+            else:
+                logger.info("[%s] buffered delivery failed after user takeover; skip TTS cleanup", lanlan_name)
+            return await _end_proactive(JSONResponse({
+                "success": True,
+                "action": "pass",
+                "message": "Phase 2 buffered delivery failed",
+            }))
         if not committed:
             # Proactive 内容未真正落库（用户已接管本轮），所有下游副作用必须跳过：
             # 否则 _record_proactive_chat 会把未送达内容计入去重历史、topic usage

--- a/tests/unit/test_proactive_phase1_pass.py
+++ b/tests/unit/test_proactive_phase1_pass.py
@@ -85,3 +85,47 @@ def test_recent_proactive_prompt_has_strong_paired_boundaries():
     assert "想不到新切入点就必须 [PASS]" in rendered
     assert "======以上为近期搭话记录" in rendered
     assert "雷同则 [PASS]" in rendered
+
+
+def test_recent_proactive_similarity_blocks_at_90_percent():
+    lanlan = "测试娘-repeat"
+    snapshot = sr._proactive_chat_history.get(lanlan)
+    sr._proactive_chat_history[lanlan] = deque(
+        [(sr.time.time(), "最近别太累啦，记得喝口水休息一下。", "chat")],
+        maxlen=10,
+    )
+    old_threshold = sr._PROACTIVE_SIMILARITY_THRESHOLD
+    sr._PROACTIVE_SIMILARITY_THRESHOLD = 0.90
+    try:
+        is_duplicate, score = sr._is_similar_to_recent_proactive_chat(
+            lanlan,
+            "最近别太累啦，记得喝口水休息一下!",
+        )
+    finally:
+        sr._PROACTIVE_SIMILARITY_THRESHOLD = old_threshold
+        if snapshot is None:
+            sr._proactive_chat_history.pop(lanlan, None)
+        else:
+            sr._proactive_chat_history[lanlan] = snapshot
+
+    assert is_duplicate is True
+    assert score >= 0.90
+
+
+def test_recent_proactive_similarity_ignores_expired_history():
+    lanlan = "测试娘-expired"
+    snapshot = sr._proactive_chat_history.get(lanlan)
+    sr._proactive_chat_history[lanlan] = deque(
+        [(sr.time.time() - sr._RECENT_CHAT_MAX_AGE_SECONDS - 1, "同一句话", "chat")],
+        maxlen=10,
+    )
+    try:
+        is_duplicate, score = sr._is_similar_to_recent_proactive_chat(lanlan, "同一句话")
+    finally:
+        if snapshot is None:
+            sr._proactive_chat_history.pop(lanlan, None)
+        else:
+            sr._proactive_chat_history[lanlan] = snapshot
+
+    assert is_duplicate is False
+    assert score == 0.0


### PR DESCRIPTION
## Summary
- lower the proactive repeat similarity guard threshold to 90%
- block Phase 2 proactive output before delivery when it closely repeats recent proactive chat
- add unit coverage for the threshold and expired-history behavior

## Validation
- `uv run pytest tests/unit/test_proactive_phase1_pass.py`
- `uv run ruff check main_routers/system_router.py tests/unit/test_proactive_phase1_pass.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 变更说明

* **Bug 修复**
  * 将主动提示重复检测阈值从 0.94 调整到 0.90，增强重复防护：若生成文本与近期主动消息相似度超过阈值，则返回早期“pass”响应并包含相似度/阈值元数据；在未被用户抢先时仅在适当时清除待处理语音。
  * 主动消息第二阶段改为先缓冲完整文本，流结束后统一进行语音发送与交付失败处理。

* **测试**
  * 新增单元测试覆盖相似度检测阈值与历史时间窗口行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->