### PR TITLE
修复角色卡管理中新增设定保存后，当前页面缓存未及时同步导致关闭再展开时设定短暂消失的问题

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -2610,7 +2610,7 @@ function syncTitleDataText() {
 // 加载角色卡数据
 async function loadCharacterData() {
     try {
-        const resp = await fetch('/api/characters');
+        const resp = await fetch('/api/characters', { cache: 'no-store' });
         if (!resp.ok) {
             throw new Error(`HTTP ${resp.status}`);
         }
@@ -2630,6 +2630,122 @@ let currentCharacterCardId = null;
 
 const CHARACTER_CARD_MODEL_SCAN_RENDER_BUDGET_MS = 2500;
 let characterCardLoadSequence = 0;
+
+function getCharacterCardDescriptionFromData(data) {
+    if (!data || typeof data !== 'object') {
+        return window.t ? window.t('steam.noDescription') : '暂无描述';
+    }
+    if (data['description']) return data['description'];
+    if (data['描述']) return data['描述'];
+    if (data['角色卡描述']) return data['角色卡描述'];
+    return window.t ? window.t('steam.noDescription') : '暂无描述';
+}
+
+function getCharacterCardTagsFromData(data) {
+    if (!data || typeof data !== 'object') {
+        return [];
+    }
+    return Array.isArray(data['关键词']) ? data['关键词'] : [];
+}
+
+function buildCharacterCardEntry(name, data, id) {
+    return {
+        id: id,
+        name: name,
+        description: getCharacterCardDescriptionFromData(data),
+        tags: getCharacterCardTagsFromData(data),
+        rawData: data || {},
+        originalName: name
+    };
+}
+
+function findCharacterCardIndexByName(name) {
+    const cards = Array.isArray(window.characterCards) ? window.characterCards : [];
+    return cards.findIndex(card => String(card?.originalName || card?.name || '') === String(name));
+}
+
+function getNextCharacterCardId() {
+    const cards = Array.isArray(window.characterCards) ? window.characterCards : [];
+    let maxId = 0;
+    cards.forEach(card => {
+        const numericId = Number(card && card.id);
+        if (Number.isFinite(numericId)) {
+            maxId = Math.max(maxId, numericId);
+        }
+    });
+    return maxId + 1;
+}
+
+function buildLocalCatgirlRawData(catgirlName, submittedData) {
+    const cards = Array.isArray(window.characterCards) ? window.characterCards : [];
+    const existingIdx = findCharacterCardIndexByName(catgirlName);
+    const previousRawData = existingIdx >= 0 && cards[existingIdx]?.rawData && typeof cards[existingIdx].rawData === 'object'
+        ? cards[existingIdx].rawData
+        : {};
+    const allReservedFields = ['档案名', ...getWorkshopHiddenFields()];
+    const nextRawData = {};
+
+    // 通用编辑接口会保留系统字段，但会用本次提交的普通字段整体替换旧普通字段。
+    Object.keys(previousRawData).forEach(key => {
+        if (allReservedFields.includes(key)) {
+            nextRawData[key] = previousRawData[key];
+        }
+    });
+    Object.entries(submittedData || {}).forEach(([key, value]) => {
+        if (!key || key === '档案名' || allReservedFields.includes(key)) {
+            return;
+        }
+        if (value !== null && value !== undefined && String(value).trim() !== '') {
+            nextRawData[key] = value;
+        }
+    });
+    return nextRawData;
+}
+
+function mergeFreshCatgirlRawDataWithLocal(freshRawData, localRawData) {
+    const allReservedFields = ['档案名', ...getWorkshopHiddenFields()];
+    const merged = {};
+
+    // 本轮刚保存的普通字段优先；重新拉取的数据只用于补回模型、音色等保留字段。
+    Object.entries(localRawData || {}).forEach(([key, value]) => {
+        if (!allReservedFields.includes(key)) {
+            merged[key] = value;
+        }
+    });
+    Object.entries(localRawData || {}).forEach(([key, value]) => {
+        if (allReservedFields.includes(key)) {
+            merged[key] = value;
+        }
+    });
+    Object.entries(freshRawData || {}).forEach(([key, value]) => {
+        if (allReservedFields.includes(key)) {
+            merged[key] = value;
+        }
+    });
+    return merged;
+}
+
+function syncCharacterCardCache(catgirlName, rawData) {
+    if (!catgirlName) return;
+    if (!Array.isArray(window.characterCards)) {
+        window.characterCards = [];
+    }
+
+    const existingIdx = findCharacterCardIndexByName(catgirlName);
+    const existingCard = existingIdx >= 0 ? window.characterCards[existingIdx] : null;
+    const cardId = existingCard?.id ?? getNextCharacterCardId();
+    const updatedCard = buildCharacterCardEntry(catgirlName, rawData || {}, cardId);
+
+    if (existingIdx >= 0) {
+        window.characterCards[existingIdx] = updatedCard;
+    } else {
+        window.characterCards.push(updatedCard);
+    }
+    globalCharacterCards = window.characterCards || [];
+
+    refreshCharacterCardSelectOptions();
+    renderCharaCardsView();
+}
 
 function waitForCharacterCardModelScanBudget(scanPromise) {
     const eventual = Promise.resolve(scanPromise)
@@ -2816,31 +2932,7 @@ async function loadCharacterCards() {
     // 只处理猫娘数据，忽略其他角色类型（包括主人）
     const catgirls = characterData['猫娘'] || {};
     for (const [name, data] of Object.entries(catgirls)) {
-        // 兼容实际的数据结构 - 使用可用字段创建角色卡
-        // 只从description或角色卡描述字段获取描述信息
-        let description = window.t ? window.t('steam.noDescription') : '暂无描述';
-        if (data['description']) {
-            description = data['description'];
-        } else if (data['描述']) {
-            description = data['描述'];
-        } else if (data['角色卡描述']) {
-            description = data['角色卡描述'];
-        }
-
-        // 只从关键词字段获取标签信息，不自动生成标签
-        let tags = [];
-        if (data['关键词'] && Array.isArray(data['关键词']) && data['关键词'].length > 0) {
-            tags = data['关键词'];
-        }
-
-        window.characterCards.push({
-            id: idCounter++,
-            name: name,
-            description: description,
-            tags: tags,
-            rawData: data,  // 保存原始数据，方便详情页使用
-            originalName: name  // 保存原始键名
-        });
+        window.characterCards.push(buildCharacterCardEntry(name, data, idCounter++));
     }
 
     // 从character_cards文件夹加载角色卡
@@ -5662,6 +5754,9 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             showMessage(result.error || (window.t ? window.t('character.saveFailed') : '保存失败'), 'error');
             return;
         }
+        const localRawData = buildLocalCatgirlRawData(data['档案名'], data);
+        let savedRawDataForCache = localRawData;
+        syncCharacterCardCache(data['档案名'], localRawData);
         if (form._autoCreatedDetachedName) {
             await rollbackAutoCreatedCatgirl(form, form._autoCreatedDetachedName);
             form._autoCreated = false;
@@ -5777,14 +5872,19 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             if (cancelBtn) cancelBtn.style.display = 'none';
             try {
                 const freshData = await loadCharacterData();
-                if (freshData && freshData['猫娘'] && freshData['猫娘'][data['档案名']]) {
-                    buildCatgirlDetailForm(data['档案名'], freshData['猫娘'][data['档案名']], false, container);
-                }
+                const freshRawData = freshData && freshData['猫娘'] && freshData['猫娘'][data['档案名']]
+                    ? freshData['猫娘'][data['档案名']]
+                    : {};
+                savedRawDataForCache = mergeFreshCatgirlRawDataWithLocal(freshRawData, localRawData);
+                syncCharacterCardCache(data['档案名'], savedRawDataForCache);
+                buildCatgirlDetailForm(data['档案名'], savedRawDataForCache, false, container);
             } catch (e) {
                 console.error('重新加载猫娘数据失败:', e);
+                buildCatgirlDetailForm(data['档案名'], localRawData, false, container);
             }
         }
         await loadCharacterCards();
+        syncCharacterCardCache(data['档案名'], savedRawDataForCache);
     } catch (error) {
         console.error('保存猫娘失败:', error);
         const errorMessage = error.message || String(error);
@@ -9324,6 +9424,7 @@ async function panelAutoSaveCatgirlField(input, catgirlName) {
             body: JSON.stringify(data)
         });
         if (resp.ok) {
+            syncCharacterCardCache(catgirlName, buildLocalCatgirlRawData(catgirlName, data));
             storeOriginalValue(input);
             const allInputs = form.querySelectorAll('input, textarea');
             const sentFields = new Set(Object.keys(data));

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -415,7 +415,7 @@ def test_character_card_manager_renders_and_opens_cards_when_model_scan_never_re
                     });
                 }
 
-                if (url.endsWith('/api/characters/')) {
+                if (url.endsWith('/api/characters/') || url.endsWith('/api/characters')) {
                     return new Response(JSON.stringify({
                         '主人': {},
                         '当前猫娘': '模拟猫娘',
@@ -501,6 +501,171 @@ def test_character_card_manager_renders_and_opens_cards_when_model_scan_never_re
     assert state["panelOpen"] is True
     assert state["profileName"] == "模拟猫娘"
     assert state["saveButtonExists"] is True
+
+
+@pytest.mark.frontend
+def test_character_card_manager_saved_new_field_survives_immediate_reopen_with_stale_reload(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+            const waitFor = async (predicate, timeout = 2500) => {
+                const startedAt = Date.now();
+                while (Date.now() - startedAt < timeout) {
+                    if (predicate()) return true;
+                    await sleep(25);
+                }
+                return false;
+            };
+
+            const originalFetch = window.fetch.bind(window);
+            const staleCharacters = {
+                '主人': {},
+                '当前猫娘': '缓存猫娘',
+                '猫娘': {
+                    '缓存猫娘': {
+                        '描述': '旧描述'
+                    }
+                }
+            };
+            const savedBodies = [];
+            const characterFetchCaches = [];
+
+            window.showMessage = () => {};
+            window.showAutoSaveToast = () => {};
+            window.showPrompt = async () => '追加设定';
+            window.showAlert = async () => {};
+            window.showAlertDialog = async () => {};
+            window.fetch = async (input, init = {}) => {
+                const rawUrl = typeof input === 'string' ? input : input.url;
+                const url = new URL(rawUrl, window.location.origin);
+                const path = decodeURIComponent(url.pathname);
+                const method = String(init.method || 'GET').toUpperCase();
+
+                if (path === '/api/characters/catgirl/缓存猫娘' && method === 'PUT') {
+                    savedBodies.push(JSON.parse(init.body || '{}'));
+                    return new Response(JSON.stringify({ success: true }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters' && method === 'GET') {
+                    characterFetchCaches.push(init.cache || '');
+                    return new Response(JSON.stringify(staleCharacters), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/character-card/list') {
+                    return new Response(JSON.stringify({ success: true, character_cards: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/current_catgirl') {
+                    return new Response(JSON.stringify({ current_catgirl: '缓存猫娘' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/card-faces') {
+                    return new Response(JSON.stringify({ success: true, names: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/card-metas') {
+                    return new Response(JSON.stringify({ success: true, metas: {} }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/voices') {
+                    return new Response(JSON.stringify({ voices: {}, free_voices: {}, voice_owners: {} }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/characters/custom_tts_voices') {
+                    return new Response(JSON.stringify({ success: true, voices: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/live2d/models') {
+                    return new Response(JSON.stringify([]), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                if (path === '/api/model/vrm/models' || path === '/api/model/mmd/models') {
+                    return new Response(JSON.stringify({ success: true, models: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return originalFetch(input, init);
+            };
+
+            window.characterCards = [{
+                id: 1,
+                name: '缓存猫娘',
+                originalName: '缓存猫娘',
+                description: '旧描述',
+                tags: [],
+                rawData: { '描述': '旧描述' }
+            }];
+            window._workshopCurrentCatgirl = '缓存猫娘';
+            window._cardFaceNames = new Set();
+            window._cardMetas = {};
+            renderCharaCardsView();
+
+            document.querySelector('.chara-card-item')?.click();
+            await waitFor(() => !!document.querySelector('.catgirl-panel-overlay #panel-add-catgirl-field-btn'));
+
+            document.querySelector('.catgirl-panel-overlay #panel-add-catgirl-field-btn').click();
+            await waitFor(() => !!document.querySelector('.catgirl-panel-overlay textarea[name="追加设定"]'));
+            const newField = document.querySelector('.catgirl-panel-overlay textarea[name="追加设定"]');
+            newField.value = '保存后的内容';
+            newField.dispatchEvent(new Event('input', { bubbles: true }));
+            newField.dispatchEvent(new Event('change', { bubbles: true }));
+
+            document.querySelector('.catgirl-panel-overlay #save-button').click();
+            await waitFor(() => savedBodies.length > 0);
+            await waitFor(() => {
+                return !document.querySelector('.catgirl-panel-overlay form[data-submitting="true"]');
+            });
+
+            const valueAfterSave = document.querySelector('.catgirl-panel-overlay textarea[name="追加设定"]')?.value || '';
+            await closeCatgirlPanel();
+            await sleep(850);
+
+            document.querySelector('.chara-card-item')?.click();
+            await waitFor(() => !!document.querySelector('.catgirl-panel-overlay textarea[name="追加设定"]'));
+            const valueAfterReopen = document.querySelector('.catgirl-panel-overlay textarea[name="追加设定"]')?.value || '';
+            const cachedRawData = (window.characterCards || [])[0]?.rawData || {};
+
+            return {
+                savedBodies,
+                characterFetchCaches,
+                valueAfterSave,
+                valueAfterReopen,
+                cachedRawData
+            };
+        }
+        """
+    )
+
+    assert state["savedBodies"][0]["追加设定"] == "保存后的内容"
+    assert "no-store" in state["characterFetchCaches"]
+    assert state["valueAfterSave"] == "保存后的内容"
+    assert state["valueAfterReopen"] == "保存后的内容"
+    assert state["cachedRawData"]["追加设定"] == "保存后的内容"
 
 
 @pytest.mark.frontend


### PR DESCRIPTION
保存和自动保存成功后立即更新本地角色卡缓存，并补充回归测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复角色数据缓存问题，确保加载最新数据而非过期数据

* **New Features**
  * 保存角色信息后，修改内容在界面中即时显示，无需等待服务器重新加载
  * 角色卡片数据同步优化，重新打开时保留已保存的自定义字段

<!-- end of auto-generated comment: release notes by coderabbit.ai -->