### PR TITLE
修复新角色首次卡面制作关闭后可能缺失卡面的问题，并在模型加载期间锁定卡面制作交互，避免保存无模型卡片

### DIFF
--- a/static/css/card_maker.css
+++ b/static/css/card_maker.css
@@ -525,6 +525,15 @@ body {
 .btn-primary:active { transform: translateY(1px) scale(0.98); }
 .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
+#control-panel button:disabled,
+#control-panel input:disabled,
+#control-panel select:disabled,
+#control-panel textarea:disabled,
+.page-title-bar button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
 .btn-secondary {
     background: rgba(64, 197, 241, 0.12);
     color: #40C5F1;

--- a/static/css/card_maker.css
+++ b/static/css/card_maker.css
@@ -523,8 +523,9 @@ body {
 
 .btn-primary:hover { background: #35b0d8; transform: translateY(-1px); box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1); }
 .btn-primary:active { transform: translateY(1px) scale(0.98); }
-.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 
+.btn-primary:disabled,
+.btn-secondary:disabled,
 #control-panel button:disabled,
 #control-panel input:disabled,
 #control-panel select:disabled,
@@ -997,6 +998,18 @@ body {
 [data-theme="dark"] #control-panel {
     background: #16213e;
     border-left-color: #0f3460;
+}
+
+[data-theme="dark"] .btn-primary:disabled,
+[data-theme="dark"] .btn-secondary:disabled,
+[data-theme="dark"] #control-panel button:disabled,
+[data-theme="dark"] #control-panel input:disabled,
+[data-theme="dark"] #control-panel select:disabled,
+[data-theme="dark"] #control-panel textarea:disabled,
+[data-theme="dark"] .page-title-bar button:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+    filter: grayscale(0.6);
 }
 
 [data-theme="dark"] .btn-icon {

--- a/static/css/window_controls.css
+++ b/static/css/window_controls.css
@@ -69,6 +69,15 @@
     opacity: 0.9;
 }
 
+.neko-window-control-btn:disabled,
+.neko-window-controls .close-btn:disabled,
+.neko-window-controls .close-page-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+    transform: none;
+    pointer-events: none;
+}
+
 .neko-window-minimize-icon {
     display: block;
     width: 16px;

--- a/static/js/card_maker.js
+++ b/static/js/card_maker.js
@@ -76,14 +76,13 @@
     let pendingFallbackDefaultSave = false;
     let fallbackDefaultListenersRegistered = false;
 
-    updateCardMakerInteractivity(true);
-
     initModelSaveFallbackDefaultCardFace();
 
     // ====== 初始化 ======
     document.addEventListener('DOMContentLoaded', async () => {
         // 禁用鼠标跟踪（导出页面不需要）
         window.mouseTrackingEnabled = false;
+        showLoading(true);
 
         // 设置标题和按钮（maker 模式与导出模式使用不同文案）
         const titleEl = document.querySelector('.page-title-bar h2');
@@ -964,9 +963,6 @@
         try {
             resetComposition();
             clearAllStickers();
-            primaryActionBusy = true;
-            updatePrimaryActionAvailability();
-            exportFullBtn.textContent = t('cardExport.autoSavingDefaultCardFace', '正在生成默认卡面...');
             await waitForCondition(() => isModelLoaded, 10000, '模型加载');
             await new Promise(resolve => setTimeout(resolve, 300));
             await doSaveCardFace({
@@ -976,8 +972,6 @@
             });
         } catch (e) {
             console.error('[CardMaker] 自动生成默认卡面失败:', e);
-            primaryActionBusy = false;
-            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.autoSaveDefaultCardFaceFailed', '默认卡面生成失败');
         }
     }

--- a/static/js/card_maker.js
+++ b/static/js/card_maker.js
@@ -15,6 +15,8 @@
     let currentCharaName = '';
     let currentModelType = '';   // 'live2d' | 'vrm' | 'mmd'
     let isModelLoaded = false;
+    let isModelLoading = false;
+    let primaryActionBusy = false;
     let previewLoopId = null;     // requestAnimationFrame ID
     let lastPreviewTime = 0;      // 上次预览渲染时间戳
 
@@ -74,6 +76,8 @@
     let pendingFallbackDefaultSave = false;
     let fallbackDefaultListenersRegistered = false;
 
+    updateCardMakerInteractivity(true);
+
     initModelSaveFallbackDefaultCardFace();
 
     // ====== 初始化 ======
@@ -120,6 +124,8 @@
                 pendingFallbackDefaultSave = false;
                 await doAutoSaveDefaultCardFace();
             }
+        } else {
+            showLoading(false);
         }
     });
 
@@ -154,6 +160,10 @@
         backBtn.addEventListener('click', () => {
             closeCardMakerPage();
         });
+        window.nekoBeforeWindowClose = async () => {
+            await closeCardMakerPage();
+            return { handled: true };
+        };
 
         // 标签页切换
         document.querySelectorAll('.panel-tab').forEach(tab => {
@@ -237,6 +247,7 @@
     }
 
     async function closeCardMakerPage() {
+        if (isModelLoading) return;
         try {
             await saveModelSaveFallbackDefaultCardFace('card-maker-close', {
                 maxWait: 1200,
@@ -411,6 +422,7 @@
         currentCharaName = name;
         cardName.textContent = name;
 
+        isModelLoaded = false;
         showLoading(true);
         resetComposition();
 
@@ -445,6 +457,7 @@
         } catch (e) {
             console.error('[CardExport] 加载角色模型失败:', e);
             showLoading(false);
+            updatePrimaryActionAvailability();
         }
     }
 
@@ -484,6 +497,7 @@
         } catch (e) {
             console.error('[CardExport] 模型加载异常:', e);
             showLoading(false);
+            updatePrimaryActionAvailability();
         }
     }
 
@@ -823,11 +837,16 @@
     // ====== 导出 ======
     async function doExport(type) {
         if (!currentCharaName) return;
+        if (!isModelLoaded) {
+            alert(t('cardExport.modelStillLoading', '模型仍在加载，请稍后再保存'));
+            return;
+        }
 
         try {
             let response;
 
-            exportFullBtn.disabled = true;
+            primaryActionBusy = true;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.exporting', '导出中...');
 
             // 用调整后的构图参数渲染最终立绘
@@ -849,7 +868,8 @@
                 );
             }
 
-            exportFullBtn.disabled = false;
+            primaryActionBusy = false;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.exportFull', '导出角色卡');
 
             if (!response.ok) {
@@ -863,7 +883,8 @@
         } catch (e) {
             console.error('[CardExport] 导出失败:', e);
             alert(t('cardExport.exportError', '导出失败: ') + e.message);
-            exportFullBtn.disabled = false;
+            primaryActionBusy = false;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.exportFull', '导出角色卡');
         }
     }
@@ -871,9 +892,17 @@
     // ====== 保存卡面（maker 模式专用） ======
     async function doSaveCardFace(options = {}) {
         if (!currentCharaName) return;
+        if (!isModelLoaded) {
+            const message = t('cardExport.modelStillLoading', '模型仍在加载，请稍后再保存');
+            if (!options.silent) {
+                alert(message);
+            }
+            throw new Error(message);
+        }
 
         try {
-            exportFullBtn.disabled = true;
+            primaryActionBusy = true;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = options.statusText || t('cardExport.savingCardFace', '保存中...');
 
             const cardBlob = await renderFullCard(options.renderOptions || {});
@@ -897,7 +926,8 @@
             const respJson = await response.json().catch(() => ({}));
             if (respJson.partial_success) {
                 exportFullBtn.textContent = t('cardExport.saveCardFacePartialSuccess', 'PNG 已保存，但元数据写入失败: {{error}}', { error: respJson.error || '' });
-                exportFullBtn.disabled = false;
+                primaryActionBusy = false;
+                updatePrimaryActionAvailability();
                 cardFaceSaved = true;
                 notifyCardFaceUpdated(currentCharaName);
                 return { status: 'partial', error: respJson.error || '' };
@@ -913,7 +943,8 @@
                 return saveResult;
             }
             setTimeout(() => {
-                exportFullBtn.disabled = false;
+                primaryActionBusy = false;
+                updatePrimaryActionAvailability();
                 exportFullBtn.textContent = t('cardExport.saveCardFace', '保存卡面');
             }, 1500);
             return saveResult;
@@ -922,7 +953,8 @@
             if (!options.silent) {
                 alert(t('cardExport.saveCardFaceFailed', '保存失败: ' + e.message, { error: e.message }));
             }
-            exportFullBtn.disabled = false;
+            primaryActionBusy = false;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.saveCardFace', '保存卡面');
             throw e;
         }
@@ -932,7 +964,8 @@
         try {
             resetComposition();
             clearAllStickers();
-            exportFullBtn.disabled = true;
+            primaryActionBusy = true;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.autoSavingDefaultCardFace', '正在生成默认卡面...');
             await waitForCondition(() => isModelLoaded, 10000, '模型加载');
             await new Promise(resolve => setTimeout(resolve, 300));
@@ -943,7 +976,8 @@
             });
         } catch (e) {
             console.error('[CardMaker] 自动生成默认卡面失败:', e);
-            exportFullBtn.disabled = false;
+            primaryActionBusy = false;
+            updatePrimaryActionAvailability();
             exportFullBtn.textContent = t('cardExport.autoSaveDefaultCardFaceFailed', '默认卡面生成失败');
         }
     }
@@ -1591,12 +1625,35 @@
         return Math.min(max, Math.max(min, v));
     }
 
+    function updatePrimaryActionAvailability() {
+        if (!exportFullBtn) return;
+        exportFullBtn.disabled = primaryActionBusy || isModelLoading || !isModelLoaded;
+    }
+
+    function updateCardMakerInteractivity(locked) {
+        const isLocked = !!locked;
+        document.body?.classList.toggle('card-maker-loading', isLocked);
+
+        const controls = document.querySelectorAll(
+            '#control-panel button, #control-panel input, #control-panel select, #control-panel textarea, ' +
+            '.page-title-bar button, [data-neko-window-control]'
+        );
+        controls.forEach(control => {
+            if (control === exportFullBtn) return;
+            control.disabled = isLocked;
+            control.setAttribute('aria-disabled', isLocked ? 'true' : 'false');
+        });
+        updatePrimaryActionAvailability();
+    }
+
     function showLoading(show) {
+        isModelLoading = !!show;
         if (show) {
             loadingOverlay.classList.remove('hidden');
         } else {
             loadingOverlay.classList.add('hidden');
         }
+        updateCardMakerInteractivity(show);
     }
 
     function resetComposition() {

--- a/static/js/card_maker.js
+++ b/static/js/card_maker.js
@@ -17,6 +17,10 @@
     let isModelLoaded = false;
     let isModelLoading = false;
     let primaryActionBusy = false;
+    const MODEL_LOADING_CLOSE_FALLBACK_MS = 8000;
+    let modelLoadingStartedAt = 0;
+    let allowCloseWhileLoading = false;
+    let loadingCloseFallbackTimer = null;
     let previewLoopId = null;     // requestAnimationFrame ID
     let lastPreviewTime = 0;      // 上次预览渲染时间戳
 
@@ -160,8 +164,8 @@
             closeCardMakerPage();
         });
         window.nekoBeforeWindowClose = async () => {
-            await closeCardMakerPage();
-            return { handled: true };
+            const handled = await closeCardMakerPage();
+            return handled ? { handled: true } : undefined;
         };
 
         // 标签页切换
@@ -246,7 +250,11 @@
     }
 
     async function closeCardMakerPage() {
-        if (isModelLoading) return;
+        if (isModelLoading && !canCloseWhileLoading()) return false;
+        if (isModelLoading) {
+            closeCardMakerWindow();
+            return true;
+        }
         try {
             await saveModelSaveFallbackDefaultCardFace('card-maker-close', {
                 maxWait: 1200,
@@ -255,10 +263,14 @@
             });
         } catch (error) {
             console.error('[CardMaker] 关闭前默认卡面兜底失败:', error);
-        } finally {
-            if (window.opener) { window.close(); }
-            else { window.history.back(); }
         }
+        closeCardMakerWindow();
+        return true;
+    }
+
+    function closeCardMakerWindow() {
+        if (window.opener) { window.close(); }
+        else { window.history.back(); }
     }
 
     function shouldSaveFallbackDefaultCardFace() {
@@ -1624,8 +1636,37 @@
         exportFullBtn.disabled = primaryActionBusy || isModelLoading || !isModelLoaded;
     }
 
+    function canCloseWhileLoading() {
+        if (!isModelLoading) return true;
+        if (allowCloseWhileLoading) return true;
+        return modelLoadingStartedAt > 0 &&
+            Date.now() - modelLoadingStartedAt >= MODEL_LOADING_CLOSE_FALLBACK_MS;
+    }
+
+    function scheduleLoadingCloseFallback() {
+        if (loadingCloseFallbackTimer) {
+            window.clearTimeout(loadingCloseFallbackTimer);
+        }
+        loadingCloseFallbackTimer = window.setTimeout(() => {
+            loadingCloseFallbackTimer = null;
+            if (!isModelLoading) return;
+            allowCloseWhileLoading = true;
+            updateCardMakerInteractivity(true);
+        }, MODEL_LOADING_CLOSE_FALLBACK_MS);
+    }
+
+    function clearLoadingCloseFallback() {
+        if (loadingCloseFallbackTimer) {
+            window.clearTimeout(loadingCloseFallbackTimer);
+            loadingCloseFallbackTimer = null;
+        }
+        modelLoadingStartedAt = 0;
+        allowCloseWhileLoading = false;
+    }
+
     function updateCardMakerInteractivity(locked) {
         const isLocked = !!locked;
+        const allowLoadingClose = isLocked && canCloseWhileLoading();
         document.body?.classList.toggle('card-maker-loading', isLocked);
 
         const controls = document.querySelectorAll(
@@ -1634,14 +1675,25 @@
         );
         controls.forEach(control => {
             if (control === exportFullBtn) return;
-            control.disabled = isLocked;
-            control.setAttribute('aria-disabled', isLocked ? 'true' : 'false');
+            const isCloseControl = control === backBtn ||
+                control.getAttribute('data-neko-window-control') === 'close';
+            const shouldDisable = isLocked && !(allowLoadingClose && isCloseControl);
+            control.disabled = shouldDisable;
+            control.setAttribute('aria-disabled', shouldDisable ? 'true' : 'false');
         });
         updatePrimaryActionAvailability();
     }
 
     function showLoading(show) {
-        isModelLoading = !!show;
+        const nextLoading = !!show;
+        if (nextLoading && !isModelLoading) {
+            modelLoadingStartedAt = Date.now();
+            allowCloseWhileLoading = false;
+            scheduleLoadingCloseFallback();
+        } else if (!nextLoading) {
+            clearLoadingCloseFallback();
+        }
+        isModelLoading = nextLoading;
         if (show) {
             loadingOverlay.classList.remove('hidden');
         } else {

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -5754,7 +5754,12 @@ async function saveCatgirlFromPanel(form, originalName, isNew) {
             const catgirlName = data['档案名'];
             const hasCardFace = window._cardFaceNames && window._cardFaceNames.has(catgirlName);
             if (!hasCardFace) {
-                const makerUrl = `/card_maker?name=${encodeURIComponent(catgirlName)}&mode=maker`;
+                const makerParams = new URLSearchParams({
+                    name: catgirlName,
+                    mode: 'maker',
+                    fallback_default_on_close: '1'
+                });
+                const makerUrl = `/card_maker?${makerParams.toString()}`;
                 const makerWindow = openManagedPopup(
                     makerUrl,
                     CHARACTER_MANAGER_CARD_MAKER_WINDOW_NAME,

--- a/static/js/window_controls.js
+++ b/static/js/window_controls.js
@@ -57,6 +57,7 @@
         if (!minimizeButton || minimizeButton.dataset.nekoWindowControlBound === '1') return;
         minimizeButton.dataset.nekoWindowControlBound = '1';
         minimizeButton.addEventListener('click', async () => {
+            if (minimizeButton.disabled) return;
             const api = window.nekoWindowControl;
             if (!api || typeof api.minimize !== 'function') return;
             try {
@@ -72,6 +73,7 @@
         if (!maximizeButton || maximizeButton.dataset.nekoWindowControlBound === '1') return;
         maximizeButton.dataset.nekoWindowControlBound = '1';
         maximizeButton.addEventListener('click', async () => {
+            if (maximizeButton.disabled) return;
             const api = window.nekoWindowControl;
             if (!api || typeof api.maximize !== 'function') return;
             try {
@@ -85,7 +87,7 @@
         });
     }
 
-    function closeCurrentWindow() {
+    function defaultCloseCurrentWindow() {
         try {
             window.close();
         } catch (error) {
@@ -101,13 +103,28 @@
         }, 120);
     }
 
+    async function closeCurrentWindow() {
+        try {
+            if (typeof window.nekoBeforeWindowClose === 'function') {
+                const result = await window.nekoBeforeWindowClose();
+                if (result === false || (result && result.handled === true)) {
+                    return;
+                }
+            }
+        } catch (error) {
+            // 页面自定义关闭逻辑失败时回退到默认关闭
+        }
+        defaultCloseCurrentWindow();
+    }
+
     function bindCloseButton() {
         const closeButton = document.querySelector(`${CONTROL_SELECTOR}[data-neko-window-control="close"]`);
         if (!closeButton || closeButton.dataset.nekoWindowControlBound === '1') return;
         closeButton.dataset.nekoWindowControlBound = '1';
         closeButton.addEventListener('click', (event) => {
             event.preventDefault();
-            closeCurrentWindow();
+            if (closeButton.disabled) return;
+            void closeCurrentWindow();
         });
     }
 

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "Card Face Maker",
-        "loadingModel": "Loading model...",
+        "loadingModel": "Loading model. You can save or close after loading finishes.",
         "selectCharacter": "Select Character",
         "selectCharacterHint": "-- Select a character --",
         "loading": "Loading...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "Saving...",
         "autoSavingDefaultCardFace": "Generating default card face...",
         "autoSaveDefaultCardFaceFailed": "Failed to generate default card face",
+        "modelStillLoading": "The model is still loading. Please save after it finishes loading.",
         "saveCardFaceSuccess": "Saved successfully!",
         "saveCardFaceFailed": "Save failed: {{error}}",
         "saveCardFacePartialSuccess": "PNG saved, but metadata write failed: {{error}}",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "Exportación de tarjetas de personaje",
-        "loadingModel": "Cargando modelo...",
+        "loadingModel": "Cargando modelo. Podrás guardar o cerrar cuando termine la carga.",
         "selectCharacter": "Seleccionar personaje",
         "selectCharacterHint": "-- Selecciona un personaje --",
         "loading": "Cargando...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "Guardando...",
         "autoSavingDefaultCardFace": "Generando cara predeterminada...",
         "autoSaveDefaultCardFaceFailed": "No se pudo generar la cara predeterminada",
+        "modelStillLoading": "El modelo aún se está cargando. Guarda después de que termine de cargarse.",
         "saveCardFaceSuccess": "¡Guardado correctamente!",
         "saveCardFaceFailed": "Error al guardar: {{error}}",
         "saveCardFacePartialSuccess": "PNG guardado, pero la escritura de metadatos falló: {{error}}",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "カードフェイスメーカー",
-        "loadingModel": "モデルを読み込み中...",
+        "loadingModel": "モデルを読み込み中です。読み込み完了後に保存または閉じることができます。",
         "selectCharacter": "キャラクターを選択",
         "selectCharacterHint": "-- キャラクターを選択 --",
         "loading": "読み込み中...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "保存中...",
         "autoSavingDefaultCardFace": "既定のカードフェイスを生成中...",
         "autoSaveDefaultCardFaceFailed": "既定のカードフェイスを生成できませんでした",
+        "modelStillLoading": "モデルを読み込み中です。読み込み完了後に保存してください。",
         "saveCardFaceSuccess": "保存しました！",
         "saveCardFaceFailed": "保存に失敗しました: {{error}}",
         "saveCardFacePartialSuccess": "PNGは保存されましたが、メタデータの書き込みに失敗しました: {{error}}",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "카드 이미지 메이커",
-        "loadingModel": "모델 로딩 중...",
+        "loadingModel": "모델을 불러오는 중입니다. 로드가 끝난 뒤 저장하거나 닫을 수 있습니다.",
         "selectCharacter": "캐릭터 선택",
         "selectCharacterHint": "-- 캐릭터를 선택하세요 --",
         "loading": "로딩 중...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "저장 중...",
         "autoSavingDefaultCardFace": "기본 카드 이미지를 생성 중...",
         "autoSaveDefaultCardFaceFailed": "기본 카드 이미지 생성 실패",
+        "modelStillLoading": "모델을 아직 불러오는 중입니다. 로드가 끝난 뒤 저장해 주세요.",
         "saveCardFaceSuccess": "저장 성공!",
         "saveCardFaceFailed": "저장 실패: {{error}}",
         "saveCardFacePartialSuccess": "PNG는 저장되었지만 메타데이터 쓰기에 실패했습니다: {{error}}",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "Exportação de cartão de personagem",
-        "loadingModel": "Carregando modelo...",
+        "loadingModel": "Carregando modelo. Você poderá salvar ou fechar quando o carregamento terminar.",
         "selectCharacter": "Selecione o personagem",
         "selectCharacterHint": "-- Selecione um personagem --",
         "loading": "Carregando...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "Salvando...",
         "autoSavingDefaultCardFace": "Gerando rosto padrão do cartão...",
         "autoSaveDefaultCardFaceFailed": "Falha ao gerar o rosto padrão do cartão",
+        "modelStillLoading": "O modelo ainda está carregando. Salve depois que o carregamento terminar.",
         "saveCardFaceSuccess": "Salvo com sucesso!",
         "saveCardFaceFailed": "Falha ao salvar: {{error}}",
         "saveCardFacePartialSuccess": "PNG salvo, mas a escrita de metadados falhou: {{error}}",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3722,7 +3722,7 @@
         "savingCardFace": "Сохранение...",
         "autoSavingDefaultCardFace": "Создание обложки по умолчанию...",
         "autoSaveDefaultCardFaceFailed": "Не удалось создать обложку по умолчанию",
-        "modelStillLoading": "Модель все еще загружается. Сохраните после завершения загрузки.",
+        "modelStillLoading": "Модель всё ещё загружается. Сохраните после завершения загрузки.",
         "saveCardFaceSuccess": "Сохранено успешно!",
         "saveCardFaceFailed": "Ошибка сохранения: {{error}}",
         "saveCardFacePartialSuccess": "PNG сохранён, но запись метаданных не удалась: {{error}}",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "Создание обложки карточки",
-        "loadingModel": "Загрузка модели...",
+        "loadingModel": "Модель загружается. Сохранить или закрыть можно после завершения загрузки.",
         "selectCharacter": "Выбрать персонажа",
         "selectCharacterHint": "-- Выберите персонажа --",
         "loading": "Загрузка...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "Сохранение...",
         "autoSavingDefaultCardFace": "Создание обложки по умолчанию...",
         "autoSaveDefaultCardFaceFailed": "Не удалось создать обложку по умолчанию",
+        "modelStillLoading": "Модель все еще загружается. Сохраните после завершения загрузки.",
         "saveCardFaceSuccess": "Сохранено успешно!",
         "saveCardFaceFailed": "Ошибка сохранения: {{error}}",
         "saveCardFacePartialSuccess": "PNG сохранён, но запись метаданных не удалась: {{error}}",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "卡面制作",
-        "loadingModel": "正在加载模型...",
+        "loadingModel": "正在加载模型，加载完成后才能保存或关闭",
         "selectCharacter": "选择角色",
         "selectCharacterHint": "-- 请选择角色 --",
         "loading": "加载中...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "保存中...",
         "autoSavingDefaultCardFace": "正在生成默认卡面...",
         "autoSaveDefaultCardFaceFailed": "默认卡面生成失败",
+        "modelStillLoading": "模型仍在加载，请加载完成后再保存",
         "saveCardFaceSuccess": "保存成功！",
         "saveCardFaceFailed": "保存失败: {{error}}",
         "saveCardFacePartialSuccess": "PNG 已保存，但元数据写入失败: {{error}}",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -3679,7 +3679,7 @@
     },
     "cardExport": {
         "title": "卡面製作",
-        "loadingModel": "正在載入模型...",
+        "loadingModel": "正在載入模型，載入完成後才能儲存或關閉",
         "selectCharacter": "選擇角色",
         "selectCharacterHint": "-- 請選擇角色 --",
         "loading": "載入中...",
@@ -3722,6 +3722,7 @@
         "savingCardFace": "儲存中...",
         "autoSavingDefaultCardFace": "正在生成預設卡面...",
         "autoSaveDefaultCardFaceFailed": "預設卡面生成失敗",
+        "modelStillLoading": "模型仍在載入，請載入完成後再儲存",
         "saveCardFaceSuccess": "儲存成功！",
         "saveCardFaceFailed": "儲存失敗: {{error}}",
         "saveCardFacePartialSuccess": "PNG 已儲存，但中繼資料寫入失敗: {{error}}",

--- a/templates/card_maker.html
+++ b/templates/card_maker.html
@@ -78,7 +78,7 @@
         </div>
         <div id="model-loading-overlay">
             <div class="loading-spinner"></div>
-            <div class="loading-text" data-i18n="cardExport.loadingModel">正在加载模型...</div>
+            <div class="loading-text" data-i18n="cardExport.loadingModel">正在加载模型，加载完成后才能保存或关闭</div>
         </div>
     </div>
 

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -415,7 +415,7 @@ def test_character_card_manager_renders_and_opens_cards_when_model_scan_never_re
                     });
                 }
 
-                if (url.endsWith('/api/characters/')) {
+                if (url.endsWith('/api/characters/') || url.endsWith('/api/characters')) {
                     return new Response(JSON.stringify({
                         '主人': {},
                         '当前猫娘': '模拟猫娘',

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -27,6 +27,10 @@ def test_card_maker_locks_controls_until_model_loads_and_guards_save():
     assert "if (!isModelLoaded) {" in script
     assert "cardExport.modelStillLoading" in script
     assert "window.nekoBeforeWindowClose" in script
+    assert "MODEL_LOADING_CLOSE_FALLBACK_MS = 8000" in script
+    assert "return handled ? { handled: true } : undefined;" in script
+    assert "if (isModelLoading && !canCloseWhileLoading()) return false;" in script
+    assert "allowLoadingClose && isCloseControl" in script
 
 
 def test_window_controls_support_page_close_hook():

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 
@@ -19,7 +20,7 @@ def test_new_character_auto_card_maker_enables_default_face_fallback_only_for_au
 def test_card_maker_locks_controls_until_model_loads_and_guards_save():
     script = CARD_MAKER_JS.read_text(encoding="utf-8")
 
-    assert "updateCardMakerInteractivity(true);" in script
+    assert "showLoading(true);" in script
     assert "updateCardMakerInteractivity(show);" in script
     assert "'.page-title-bar button, [data-neko-window-control]'" in script
     assert "exportFullBtn.disabled = primaryActionBusy || isModelLoading || !isModelLoaded;" in script
@@ -41,8 +42,9 @@ def test_window_controls_support_page_close_hook():
 def test_card_maker_model_loading_message_exists_in_all_locales():
     missing = []
     for locale_path in sorted(LOCALE_DIR.glob("*.json")):
-        payload = locale_path.read_text(encoding="utf-8")
-        if '"modelStillLoading"' not in payload:
+        payload = json.loads(locale_path.read_text(encoding="utf-8"))
+        card_export = payload.get("cardExport")
+        if not isinstance(card_export, dict) or "modelStillLoading" not in card_export:
             missing.append(locale_path.name)
 
-    assert missing == []
+    assert missing == [], f"Missing cardExport.modelStillLoading in locale files: {', '.join(missing)}"

--- a/tests/unit/test_card_maker_static_contracts.py
+++ b/tests/unit/test_card_maker_static_contracts.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CARD_MAKER_JS = PROJECT_ROOT / "static" / "js" / "card_maker.js"
+CHARACTER_CARD_MANAGER_JS = PROJECT_ROOT / "static" / "js" / "character_card_manager.js"
+WINDOW_CONTROLS_JS = PROJECT_ROOT / "static" / "js" / "window_controls.js"
+LOCALE_DIR = PROJECT_ROOT / "static" / "locales"
+
+
+def test_new_character_auto_card_maker_enables_default_face_fallback_only_for_auto_popup():
+    script = CHARACTER_CARD_MANAGER_JS.read_text(encoding="utf-8")
+
+    assert "fallback_default_on_close: '1'" in script
+    assert "const makerUrl = `/card_maker?${makerParams.toString()}`;" in script
+    assert "const makerUrl = `/card_maker?name=${encodeURIComponent(currentName)}&mode=maker`;" in script
+
+
+def test_card_maker_locks_controls_until_model_loads_and_guards_save():
+    script = CARD_MAKER_JS.read_text(encoding="utf-8")
+
+    assert "updateCardMakerInteractivity(true);" in script
+    assert "updateCardMakerInteractivity(show);" in script
+    assert "'.page-title-bar button, [data-neko-window-control]'" in script
+    assert "exportFullBtn.disabled = primaryActionBusy || isModelLoading || !isModelLoaded;" in script
+    assert "if (!isModelLoaded) {" in script
+    assert "cardExport.modelStillLoading" in script
+    assert "window.nekoBeforeWindowClose" in script
+
+
+def test_window_controls_support_page_close_hook():
+    script = WINDOW_CONTROLS_JS.read_text(encoding="utf-8")
+
+    assert "window.nekoBeforeWindowClose" in script
+    assert "result === false || (result && result.handled === true)" in script
+    assert "if (minimizeButton.disabled) return;" in script
+    assert "if (maximizeButton.disabled) return;" in script
+    assert "if (closeButton.disabled) return;" in script
+
+
+def test_card_maker_model_loading_message_exists_in_all_locales():
+    missing = []
+    for locale_path in sorted(LOCALE_DIR.glob("*.json")):
+        payload = locale_path.read_text(encoding="utf-8")
+        if '"modelStillLoading"' not in payload:
+            missing.append(locale_path.name)
+
+    assert missing == []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增强卡片制作器的加载/保存保护与页面关闭挂钩，保存/导出在模型未就绪或忙碌时被阻止；新增关闭前钩子处理逻辑。
  * 保存弹窗 URL 增加关闭回退参数以改善关闭行为。

* **样式**
  * 统一并扩展禁用控件的视觉与交互样式（含深色模式），窗口控件禁用时禁止交互。

* **本地化**
  * 更新并新增多语言加载提示，明确提示加载完成后可保存或关闭。

* **测试**
  * 新增静态合约与本地化覆盖测试，并修正前端测试的请求匹配。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->