### PR TITLE
提升插件管理页全局消息提示层级，避免刷新成功、插件启动成功等 ElMessage 提示被窗口标题栏遮挡

### DIFF
--- a/frontend/plugin-manager/src/assets/main.css
+++ b/frontend/plugin-manager/src/assets/main.css
@@ -39,3 +39,7 @@ html, body {
   margin: 0;
   padding: 0;
 }
+
+.el-message {
+  z-index: 10050 !important;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复了消息通知可能被其他用户界面元素遮挡的问题，确保通知消息始终正确显示在界面最上层

<!-- end of auto-generated comment: release notes by coderabbit.ai -->