### PR TITLE
fix: polish character manager tutorial

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -118,6 +118,42 @@ body .page-title-bar {
     justify-content: center;
 }
 
+.master-profile-arrow-bubble {
+    width: 20px;
+    height: 20px;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 20px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(218, 246, 255, 0.82));
+    border: 1px solid rgba(75, 212, 253, 0.48);
+    box-shadow: 0 4px 10px rgba(64, 197, 241, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.88);
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.master-profile-arrow-symbol {
+    width: 7px;
+    height: 7px;
+    border-right: 2px solid #40C5F1;
+    border-bottom: 2px solid #40C5F1;
+    transform: rotate(-45deg);
+    transition: transform 0.2s ease;
+}
+
+.master-profile-header:hover .master-profile-arrow-bubble {
+    background: linear-gradient(180deg, #ffffff, #cff4ff);
+    box-shadow: 0 6px 14px rgba(64, 197, 241, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.96);
+}
+
+.master-profile-header.open .master-profile-arrow-bubble {
+    transform: translateY(1px);
+}
+
+.master-profile-header.open .master-profile-arrow-symbol {
+    transform: rotate(45deg) translate(-1px, -1px);
+}
+
 .page-title-bar .close-btn img {
     width: 32px;
     height: 32px;
@@ -3246,11 +3282,11 @@ color: #40C5F1;
 .sidebar-cloudsave-btn {
     display: flex;
     align-items: center;
-    justify-content: center;
-    gap: 6px;
+    justify-content: flex-start;
+    gap: 8px;
     width: 100%;
     margin-top: 12px;
-    padding: 8px 12px;
+    padding: 7px 10px;
     border: 1px solid #40C5F1;
     border-radius: 10px;
     background: linear-gradient(135deg, #e3f4ff, #ffffff);
@@ -3261,10 +3297,26 @@ color: #40C5F1;
     transition: background 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
-.sidebar-cloudsave-btn svg {
-    width: 16px;
-    height: 16px;
+.sidebar-cloudsave-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     flex-shrink: 0;
+    color: #40C5F1;
+    background: rgba(255, 255, 255, 0.78);
+    border: 1px solid rgba(64, 197, 241, 0.34);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), 0 3px 8px rgba(64, 197, 241, 0.14);
+    transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.sidebar-cloudsave-icon svg {
+    width: 15px;
+    height: 15px;
+    fill: none !important;
+    stroke: currentColor;
 }
 
 .sidebar-cloudsave-btn:hover {
@@ -3272,6 +3324,18 @@ color: #40C5F1;
     color: #fff;
     box-shadow: 0 4px 12px rgba(64, 197, 241, 0.28);
     transform: translateY(-1px);
+}
+
+.sidebar-cloudsave-btn:hover .sidebar-cloudsave-icon {
+    color: #23a4d7;
+    background: rgba(255, 255, 255, 0.95);
+    transform: translateY(-1px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 1), 0 4px 10px rgba(18, 125, 170, 0.18);
+}
+
+.sidebar-cloudsave-btn:focus-visible {
+    outline: 2px solid rgba(64, 197, 241, 0.42);
+    outline-offset: 2px;
 }
 
 .sidebar-cloudsave-btn:active {
@@ -5793,6 +5857,16 @@ margin-top: 10px;
     color: #7dd3fc;
 }
 
+[data-theme="dark"] .master-profile-arrow-bubble {
+    background: linear-gradient(180deg, rgba(36, 58, 75, 0.96), rgba(24, 42, 56, 0.96));
+    border-color: rgba(125, 211, 252, 0.44);
+    box-shadow: 0 5px 12px rgba(0, 0, 0, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="dark"] .master-profile-arrow-symbol {
+    border-color: #7dd3fc;
+}
+
 [data-theme="dark"] .master-profile-content .field-row,
 [data-theme="dark"] .master-profile-content .field-row input,
 [data-theme="dark"] .master-profile-content .field-row textarea,
@@ -5837,11 +5911,18 @@ margin-top: 10px;
     color: #ffffff !important;
 }
 
+[data-theme="dark"] .sidebar-cloudsave-icon {
+    color: #7dd3fc !important;
+    background: rgba(15, 35, 48, 0.76);
+    border-color: rgba(125, 211, 252, 0.34);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
 [data-theme="dark"] .sidebar-cloudsave-btn svg,
 [data-theme="dark"] .api-key-toolbar-btn svg,
 [data-theme="dark"] .chara-add-btn svg {
-    color: #ffffff !important;
-    fill: currentColor;
+    color: currentColor !important;
+    fill: none;
 }
 
 [data-theme="dark"] .sidebar-cloudsave-btn:hover,

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -78,6 +78,12 @@ class UniversalTutorialManager {
         this._teardownPromise = null;
         this._tutorialViewportPlacementResizeHandler = null;
         this._tutorialViewportPlacementResizeTimer = null;
+        this._tutorialScrollBlockHandler = this.blockTutorialScrollEvent.bind(this);
+        this._tutorialScrollBlockOptions = { capture: true, passive: false };
+        this._isTutorialScrollBlocked = false;
+        this._tutorialPointerBlockHandler = this.blockTutorialPointerEvent.bind(this);
+        this._tutorialPointerBlockOptions = { capture: true, passive: false };
+        this._isTutorialPointerBlocked = false;
         this._isDestroyed = false;
 
         // 刷新延迟常量
@@ -1559,7 +1565,7 @@ class UniversalTutorialManager {
         }
 
         // 角色管理
-        if (path.includes('chara_manager')) {
+        if (path.includes('character_card_manager') || path.includes('chara_manager')) {
             return 'chara_manager';
         }
 
@@ -2703,24 +2709,45 @@ class UniversalTutorialManager {
     getCharaManagerSteps() {
         return [
             {
-                element: '#master-section',
+                element: '#master-profile-section',
                 popover: {
                     title: this.t('tutorial.chara_manager.step1.title', '👤 主人档案'),
-                    description: this.t('tutorial.chara_manager.step1.desc', '这是您的主人档案。填写您的信息后，猫娘会根据这些信息来称呼您。'),
+                    description: this.t('tutorial.chara_manager.step1.desc', '这是您的主人档案。档案名是必填项，其他信息（性别、昵称等）都是可选的。这些信息会影响猫娘对您的称呼和态度。'),
                 }
             },
             {
-                element: '#catgirl-section',
+                element: '#character-cards-content',
                 popover: {
                     title: this.t('tutorial.chara_manager.step6.title', '🐱 猫娘档案'),
-                    description: this.t('tutorial.chara_manager.step6.desc', '这里可以创建和管理多个猫娘角色。每个角色都有独特的性格设定。'),
+                    description: this.t('tutorial.chara_manager.step6.desc', '这里可以创建和管理多个猫娘角色。每个角色都有独特的性格、Live2D 形象和语音设定。您可以在不同的角色之间切换。'),
                 }
             },
             {
-                element: '.catgirl-block:first-child button[id^="switch-btn-"]',
+                element: '.chara-add-btn',
+                popover: {
+                    title: this.t('tutorial.chara_manager.step7.title', '➕ 新增猫娘'),
+                    description: this.t('tutorial.chara_manager.step7.desc', '点击这个按钮创建一个新的猫娘角色。您可以为她设置名字、性格、形象和语音。每个角色都是独立的，有自己的记忆和性格。'),
+                }
+            },
+            {
+                element: '.chara-card-item:first-child, .chara-list-item:first-child',
+                popover: {
+                    title: this.t('tutorial.chara_manager.step8.title', '📋 猫娘卡片'),
+                    description: this.t('tutorial.chara_manager.step8.desc', '点击猫娘名称可以展开或折叠详细信息。每个猫娘都有独立的设定，包括基础信息和进阶配置。'),
+                }
+            },
+            {
+                element: '.chara-card-item:first-child .card-action-btn.switch-btn, .chara-list-item:first-child .list-action-btn.switch-btn',
                 popover: {
                     title: this.t('tutorial.chara_manager.step11.title', '🔄 切换猫娘'),
                     description: this.t('tutorial.chara_manager.step11.desc', '点击此按钮可以将这个猫娘设为当前活跃角色。切换后，主页会使用该角色的形象和性格。'),
+                }
+            },
+            {
+                element: '#api-key-settings-btn',
+                popover: {
+                    title: this.t('tutorial.chara_manager.step5.title', '🔑 API Key 设置'),
+                    description: this.t('tutorial.chara_manager.step5.desc', '点击这里配置 AI 服务的 API Key。这是猫娘能够进行对话的必要配置。'),
                 }
             }
         ];
@@ -3232,16 +3259,77 @@ class UniversalTutorialManager {
         if (this._isBodyLocked) return;
         this._originalBodyOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';
+        this.blockTutorialScroll();
+        this.blockTutorialPointerEvents();
         this._isBodyLocked = true;
         console.log('[Tutorial] 禁用页面滚动');
     }
 
     unlockBodyScroll() {
         if (!this._isBodyLocked) return;
+        this.unblockTutorialPointerEvents();
+        this.unblockTutorialScroll();
         document.body.style.overflow = this._originalBodyOverflow ?? '';
         this._originalBodyOverflow = undefined;
         this._isBodyLocked = false;
         console.log('[Tutorial] 恢复页面滚动');
+    }
+
+    blockTutorialScrollEvent(event) {
+        if (!this.isTutorialRunning && !window.isInTutorial) return;
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+    }
+
+    blockTutorialScroll() {
+        if (this._isTutorialScrollBlocked) return;
+        window.addEventListener('wheel', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions);
+        window.addEventListener('touchmove', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions);
+        this._isTutorialScrollBlocked = true;
+    }
+
+    unblockTutorialScroll() {
+        if (!this._isTutorialScrollBlocked) return;
+        window.removeEventListener('wheel', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions);
+        window.removeEventListener('touchmove', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions);
+        this._isTutorialScrollBlocked = false;
+    }
+
+    isTutorialControlEventTarget(target) {
+        if (!target || typeof target.closest !== 'function') return false;
+        return !!target.closest('.driver-popover, #neko-tutorial-skip-btn');
+    }
+
+    blockTutorialPointerEvent(event) {
+        if (!this.isTutorialRunning && !window.isInTutorial) return;
+        if (this.isTutorialControlEventTarget(event && event.target)) return;
+        if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+        }
+        if (event && typeof event.stopImmediatePropagation === 'function') {
+            event.stopImmediatePropagation();
+        } else if (event && typeof event.stopPropagation === 'function') {
+            event.stopPropagation();
+        }
+    }
+
+    blockTutorialPointerEvents() {
+        if (this._isTutorialPointerBlocked) return;
+        window.addEventListener('pointerdown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        window.addEventListener('mousedown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        window.addEventListener('click', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        window.addEventListener('touchstart', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        this._isTutorialPointerBlocked = true;
+    }
+
+    unblockTutorialPointerEvents() {
+        if (!this._isTutorialPointerBlocked) return;
+        window.removeEventListener('pointerdown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        window.removeEventListener('mousedown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        window.removeEventListener('click', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        window.removeEventListener('touchstart', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions);
+        this._isTutorialPointerBlocked = false;
     }
 
     restoreTutorialInteractionState() {
@@ -3999,8 +4087,8 @@ class UniversalTutorialManager {
             const startTime = Date.now();
 
             const checkCatgirlCards = () => {
-                const catgirlList = document.getElementById('catgirl-list');
-                const firstCatgirl = document.querySelector('.catgirl-block:first-child');
+                const catgirlList = document.getElementById('chara-cards-container');
+                const firstCatgirl = document.querySelector('.chara-card-item, .chara-list-item');
 
                 if (catgirlList && firstCatgirl) {
                     console.log('[Tutorial] 猫娘卡片已创建');

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -4117,7 +4117,7 @@ class UniversalTutorialManager {
      * 优先选择第一个，如果不存在则返回 null
      */
     getTargetCatgirlBlock() {
-        const catgirlBlocks = document.querySelectorAll('.catgirl-block');
+        const catgirlBlocks = document.querySelectorAll('.chara-card-item, .chara-list-item');
         if (catgirlBlocks.length === 0) {
             console.warn('[Tutorial] 没有找到任何猫娘卡片');
             return null;
@@ -4134,26 +4134,8 @@ class UniversalTutorialManager {
     async ensureCatgirlExpanded(catgirlBlock) {
         if (!catgirlBlock) return false;
 
-        const expandBtn = catgirlBlock.querySelector('.catgirl-expand');
-        const detailsDiv = catgirlBlock.querySelector('.catgirl-details');
-
-        if (!expandBtn || !detailsDiv) {
-            console.warn('[Tutorial] 猫娘卡片结构不完整');
-            return false;
-        }
-
-        // 检查是否已展开 - 通过检查 detailsDiv 的 display 样式
-        const isExpanded = detailsDiv.style.display === 'block';
-        console.log(`[Tutorial] 猫娘卡片展开状态: ${isExpanded}`);
-
-        if (!isExpanded) {
-            console.log('[Tutorial] 展开猫娘卡片');
-            expandBtn.click();
-            // 等待展开动画完成
-            await new Promise(resolve => setTimeout(resolve, 500));
-        }
-
-        return true;
+        // 当前角色管理页的卡片详情改为独立面板，不再有内联展开区域。
+        return this.isElementVisible(catgirlBlock);
     }
 
     /**
@@ -4224,19 +4206,10 @@ class UniversalTutorialManager {
             }
         });
 
-        // 2. 再关闭所有"猫娘卡片" (.catgirl-block)
-        const allCatgirlBlocks = document.querySelectorAll('.catgirl-block');
-        allCatgirlBlocks.forEach(block => {
-            const details = block.querySelector('.catgirl-details');
-            const expandBtn = block.querySelector('.catgirl-expand');
-
-            // 检查内容区域是否可见
-            if (details && expandBtn) {
-                const style = window.getComputedStyle(details);
-                if (style.display !== 'none') {
-                    console.log('[Tutorial] 检测到猫娘卡片已展开，正在关闭...');
-                    expandBtn.click(); // 点击折叠按钮关闭它
-                }
+        // 2. 当前角色管理页的卡片详情使用独立面板；教程只需要确认卡片列表处于可见稳定态。
+        document.querySelectorAll('.chara-card-item, .chara-list-item').forEach(block => {
+            if (!this.isElementVisible(block)) {
+                console.log('[Tutorial] 检测到不可见的猫娘卡片，跳过预处理');
             }
         });
 
@@ -4558,9 +4531,9 @@ class UniversalTutorialManager {
                 // 角色管理页面：进入进阶设定相关步骤前，确保猫娘卡片和进阶设定都已展开
                 if (this.currentPage === 'chara_manager') {
                     const needsAdvancedSettings = [
-                        '.catgirl-block:first-child .fold-toggle',
-                        '.catgirl-block:first-child .live2d-link',
-                        '.catgirl-block:first-child select[name="voice_id"]'
+                        '.chara-card-item:first-child .fold-toggle, .chara-list-item:first-child .fold-toggle',
+                        '.chara-card-item:first-child .live2d-link, .chara-list-item:first-child .live2d-link',
+                        '.chara-card-item:first-child select[name="voice_id"], .chara-list-item:first-child select[name="voice_id"]'
                     ].includes(currentStepConfig.element);
 
                     if (needsAdvancedSettings) {
@@ -4644,29 +4617,19 @@ class UniversalTutorialManager {
                                 console.log(`[Tutorial] 执行自动点击: ${currentStepConfig.element}`);
 
                                 // 1. 找到要点击的元素
-                                const innerTrigger = element.querySelector('.catgirl-expand, .fold-toggle');
+                                const innerTrigger = element.querySelector('.fold-toggle');
                                 const clickTarget = innerTrigger || element;
 
                                 // 2. 检查是否是折叠类元素，如果已展开则不点击
                                 let shouldClick = true;
                                 if (clickTarget.classList.contains('fold-toggle')) {
                                     // 检查进阶设定是否已展开
-                                    const foldContainer = clickTarget.closest('.catgirl-block')?.querySelector('.fold');
+                                    const foldContainer = clickTarget.closest('.chara-card-item, .chara-list-item, .catgirl-panel-wrapper')?.querySelector('.fold');
                                     if (foldContainer) {
                                         const isExpanded = foldContainer.classList.contains('open') ||
                                             window.getComputedStyle(foldContainer).display !== 'none';
                                         if (isExpanded) {
                                             console.log('[Tutorial] 进阶设定已展开，跳过点击');
-                                            shouldClick = false;
-                                        }
-                                    }
-                                } else if (clickTarget.classList.contains('catgirl-expand')) {
-                                    // 检查猫娘卡片是否已展开
-                                    const details = clickTarget.closest('.catgirl-block')?.querySelector('.catgirl-details');
-                                    if (details) {
-                                        const isExpanded = window.getComputedStyle(details).display !== 'none';
-                                        if (isExpanded) {
-                                            console.log('[Tutorial] 猫娘卡片已展开，跳过点击');
                                             shouldClick = false;
                                         }
                                     }
@@ -5114,28 +5077,18 @@ class UniversalTutorialManager {
             console.log(`[Tutorial] _ensureCharaManagerExpanded: 尝试 ${attempts}/${maxAttempts}`);
 
             // 1. 找到第一个猫娘卡片
-            const targetBlock = document.querySelector('.catgirl-block:first-child');
+            const targetBlock = document.querySelector('.chara-card-item:first-child, .chara-list-item:first-child');
             if (!targetBlock) {
                 console.warn('[Tutorial] _ensureCharaManagerExpanded: 未找到目标猫娘卡片，重试中...');
                 await this.sleep(300);
                 continue;
             }
 
-            // 2. 确保猫娘卡片详情区域已展开
-            const details = targetBlock.querySelector('.catgirl-details');
-            const expandBtn = targetBlock.querySelector('.catgirl-expand');
-            if (details && expandBtn) {
-                const detailsStyle = window.getComputedStyle(details);
-                if (detailsStyle.display === 'none') {
-                    console.log('[Tutorial] 猫娘卡片详情未展开，正在点击展开按钮...');
-                    expandBtn.click();
-                    // 等待卡片展开动画完成
-                    await this.sleep(600);
-                    continue; // 重新进入循环以验证展开结果
-                }
-            } else {
-                console.warn('[Tutorial] _ensureCharaManagerExpanded: 猫娘卡片结构异常，缺少详情或展开按钮');
-                return false;
+            // 2. 当前角色管理页卡片详情是独立面板，不再需要展开内联详情区域。
+            if (!this.isElementVisible(targetBlock)) {
+                console.warn('[Tutorial] _ensureCharaManagerExpanded: 目标猫娘卡片不可见，重试中...');
+                await this.sleep(300);
+                continue;
             }
 
             // 3. 确保“进阶设定”折叠区域已展开
@@ -5143,8 +5096,8 @@ class UniversalTutorialManager {
             const foldToggle = targetBlock.querySelector('.fold-toggle');
 
             if (!foldContainer || !foldToggle) {
-                console.warn('[Tutorial] _ensureCharaManagerExpanded: 未找到进阶设定折叠区域或开关');
-                return false;
+                console.log('[Tutorial] _ensureCharaManagerExpanded: 当前卡片无内联进阶设定，跳过展开');
+                return true;
             }
 
             const isExpanded = foldContainer.classList.contains('open') ||

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -3277,6 +3277,7 @@ class UniversalTutorialManager {
 
     blockTutorialScrollEvent(event) {
         if (!this.isTutorialRunning && !window.isInTutorial) return;
+        if (this.currentPage !== 'chara_manager') return;
         if (event && typeof event.preventDefault === 'function') {
             event.preventDefault();
         }
@@ -3303,6 +3304,7 @@ class UniversalTutorialManager {
 
     blockTutorialPointerEvent(event) {
         if (!this.isTutorialRunning && !window.isInTutorial) return;
+        if (this.currentPage !== 'chara_manager') return;
         if (this.isTutorialControlEventTarget(event && event.target)) return;
         if (event && typeof event.preventDefault === 'function') {
             event.preventDefault();

--- a/templates/character_card_manager.html
+++ b/templates/character_card_manager.html
@@ -126,14 +126,6 @@
             width: 100%;
             text-align: left;
         }
-        .master-profile-header .arrow {
-            transition: transform 0.2s ease;
-            width: 20px;
-            height: 20px;
-        }
-        .master-profile-header.open .arrow {
-            transform: rotate(90deg);
-        }
         .master-profile-content {
             position: absolute;
             left: 0;
@@ -455,7 +447,9 @@
 <p data-i18n="steam.pageDescription">通过此页面，您可以浏览、修改、上传、导入导出角色卡和管理Steam创意工坊中的Live2D模型和声音</p>
 </div>
 <button type="button" class="btn sm sidebar-cloudsave-btn" id="open-cloudsave-manager-btn" data-i18n-title="character.openCloudsaveManager" title="云存档管理">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 17.58A5 5 0 0 0 18 8h-1.26A8 8 0 1 0 4 16.25"/><path d="M8 16l4 4 4-4"/><path d="M12 12v8"/></svg>
+    <span class="sidebar-cloudsave-icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.15" stroke-linecap="round" stroke-linejoin="round"><path d="M19.5 17.5A4.5 4.5 0 0 0 18 8.8h-1.2A7 7 0 1 0 4.5 16.6"/><path d="M12 12.5v6"/><path d="m9.5 16 2.5 2.5 2.5-2.5"/></svg>
+    </span>
     <span data-i18n="character.openCloudsaveManager">云存档管理</span>
 </button>
 </div>
@@ -463,7 +457,9 @@
 <!-- 主人档案区域 -->
 <div class="menu-section master-profile-section" id="master-profile-section">
     <button type="button" class="master-profile-header" id="master-profile-header" onclick="toggleMasterSection()" aria-expanded="false">
-        <img src="/static/icons/dropdown_arrow.png" class="arrow" alt="" style="width:20px;height:20px;">
+        <span class="master-profile-arrow-bubble" aria-hidden="true">
+            <span class="master-profile-arrow-symbol"></span>
+        </span>
         <span data-i18n="character.masterProfileTitle">主人档案</span>
     </button>
     <div class="master-profile-content" id="master-profile-content" style="display:none;">

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -566,6 +566,114 @@ def test_universal_tutorial_manager_normalizes_api_key_handoff_and_resume_scene_
         assert expected in source
 
 
+def test_character_card_manager_tutorial_uses_current_page_and_targets():
+    source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+    steps_start = source.index("    getCharaManagerSteps() {")
+    steps_end = source.index("getSettingsSteps()", steps_start)
+    steps_source = source[steps_start:steps_end]
+    wait_start = source.index("waitForCatgirlCards(")
+    wait_end = source.index("getTargetCatgirlBlock()", wait_start)
+    wait_source = source[wait_start:wait_end]
+
+    for expected in (
+        "path.includes('character_card_manager') || path.includes('chara_manager')",
+    ):
+        assert expected in source
+
+    for expected in (
+        "element: '#master-profile-section'",
+        "element: '#character-cards-content'",
+        "element: '.chara-add-btn'",
+        "element: '.chara-card-item:first-child, .chara-list-item:first-child'",
+        "element: '.chara-card-item:first-child .card-action-btn.switch-btn, .chara-list-item:first-child .list-action-btn.switch-btn'",
+    ):
+        assert expected in steps_source
+
+    for expected in (
+        "document.getElementById('chara-cards-container')",
+        "document.querySelector('.chara-card-item, .chara-list-item')",
+    ):
+        assert expected in wait_source
+
+    for obsolete in (
+        "element: '#master-section'",
+        "element: '#catgirl-section'",
+    ):
+        assert obsolete not in steps_source
+
+    for obsolete in (
+        "document.getElementById('catgirl-list')",
+        "document.querySelector('.catgirl-block:first-child')",
+    ):
+        assert obsolete not in wait_source
+
+
+def test_universal_tutorial_manager_blocks_user_scroll_during_tutorial():
+    source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+
+    for expected in (
+        "_tutorialScrollBlockOptions = { capture: true, passive: false }",
+        "blockTutorialScrollEvent(event)",
+        "event.preventDefault();",
+        "window.addEventListener('wheel', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions)",
+        "window.addEventListener('touchmove', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions)",
+        "window.removeEventListener('wheel', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions)",
+        "window.removeEventListener('touchmove', this._tutorialScrollBlockHandler, this._tutorialScrollBlockOptions)",
+    ):
+        assert expected in source
+
+
+def test_universal_tutorial_manager_blocks_page_clicks_during_tutorial():
+    source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+
+    for expected in (
+        "blockTutorialPointerEvent(event)",
+        "isTutorialControlEventTarget(target)",
+        "target.closest('.driver-popover, #neko-tutorial-skip-btn')",
+        "event.stopImmediatePropagation();",
+        "window.addEventListener('pointerdown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.addEventListener('mousedown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.addEventListener('click', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.addEventListener('touchstart', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.removeEventListener('pointerdown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.removeEventListener('mousedown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.removeEventListener('click', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+        "window.removeEventListener('touchstart', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
+    ):
+        assert expected in source
+
+
+def test_character_card_manager_master_profile_arrow_uses_bubble_style():
+    template_source = Path("templates/character_card_manager.html").read_text(encoding="utf-8")
+    css_source = Path("static/css/character_card_manager.css").read_text(encoding="utf-8")
+
+    for expected in (
+        "class=\"master-profile-arrow-bubble\"",
+        "class=\"master-profile-arrow-symbol\"",
+    ):
+        assert expected in template_source
+
+    for expected in (
+        ".master-profile-arrow-bubble",
+        ".master-profile-arrow-symbol",
+        ".master-profile-header.open .master-profile-arrow-bubble",
+    ):
+        assert expected in css_source
+
+
+def test_character_card_manager_cloudsave_button_uses_icon_badge():
+    template_source = Path("templates/character_card_manager.html").read_text(encoding="utf-8")
+    css_source = Path("static/css/character_card_manager.css").read_text(encoding="utf-8")
+
+    assert "class=\"sidebar-cloudsave-icon\"" in template_source
+    for expected in (
+        ".sidebar-cloudsave-icon",
+        ".sidebar-cloudsave-btn:focus-visible",
+        "[data-theme=\"dark\"] .sidebar-cloudsave-icon",
+    ):
+        assert expected in css_source
+
+
 def test_home_yui_guide_avatar_override_does_not_persist_tutorial_model():
     tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
     interpage_source = Path("static/app-interpage.js").read_text(encoding="utf-8")

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -608,6 +608,29 @@ def test_character_card_manager_tutorial_uses_current_page_and_targets():
         assert obsolete not in wait_source
 
 
+def test_character_card_manager_tutorial_prepare_helpers_use_current_card_selectors():
+    source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+    prepare_start = source.index("async prepareCharaManagerForTutorial()")
+    prepare_end = source.index("cleanupCharaManagerTutorialIds()", prepare_start)
+    prepare_source = source[prepare_start:prepare_end]
+    ensure_start = source.index("async _ensureCharaManagerExpanded()")
+    ensure_end = source.index("createHelpButton()", ensure_start)
+    ensure_source = source[ensure_start:ensure_end]
+    step_change_start = source.index("async onStepChange()")
+    step_change_end = source.index("onTutorialEnd()", step_change_start)
+    step_change_source = source[step_change_start:step_change_end]
+
+    for helper_source in (prepare_source, ensure_source):
+        assert ".chara-card-item" in helper_source
+        assert ".chara-list-item" in helper_source
+        assert ".catgirl-block" not in helper_source
+        assert ".catgirl-details" not in helper_source
+        assert ".catgirl-expand" not in helper_source
+
+    assert ".chara-card-item:first-child, .chara-list-item:first-child" in ensure_source
+    assert ".catgirl-block:first-child" not in step_change_source
+
+
 def test_universal_tutorial_manager_blocks_user_scroll_during_tutorial():
     source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -629,6 +629,7 @@ def test_universal_tutorial_manager_blocks_page_clicks_during_tutorial():
     for expected in (
         "blockTutorialPointerEvent(event)",
         "isTutorialControlEventTarget(target)",
+        "if (this.currentPage !== 'chara_manager') return;",
         "target.closest('.driver-popover, #neko-tutorial-skip-btn')",
         "event.stopImmediatePropagation();",
         "window.addEventListener('pointerdown', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
@@ -641,6 +642,19 @@ def test_universal_tutorial_manager_blocks_page_clicks_during_tutorial():
         "window.removeEventListener('touchstart', this._tutorialPointerBlockHandler, this._tutorialPointerBlockOptions)",
     ):
         assert expected in source
+
+
+def test_universal_tutorial_manager_limits_input_blockers_to_chara_manager_page():
+    source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+    scroll_start = source.index("blockTutorialScrollEvent(event)")
+    scroll_end = source.index("blockTutorialScroll()", scroll_start)
+    scroll_source = source[scroll_start:scroll_end]
+    pointer_start = source.index("blockTutorialPointerEvent(event)")
+    pointer_end = source.index("blockTutorialPointerEvents()", pointer_start)
+    pointer_source = source[pointer_start:pointer_end]
+
+    assert "if (this.currentPage !== 'chara_manager') return;" in scroll_source
+    assert "if (this.currentPage !== 'chara_manager') return;" in pointer_source
 
 
 def test_character_card_manager_master_profile_arrow_uses_bubble_style():


### PR DESCRIPTION
## 变更说明

为角色管理页补齐现有通用教程体系下的页面内引导，并顺手优化教程期间的交互锁定和局部 UI 细节。

本次调整后：

1. `/character_card_manager` 会被识别为角色管理页教程页面。
2. 角色管理页教程改用当前页面真实 DOM 结构：
   - 主人档案区域***
   - 角色卡列表区域
   - 新增猫娘按钮
   - 第一张角色卡
   - 角色切换按钮
   - API 设置入口
3. 教程运行期间禁用页面滚动，避免高亮框和实际目标错位。
4. 教程运行期间阻止鼠标点击穿透到底层页面，但保留教程气泡和跳过按钮可点击。
5. 优化主人档案下拉标和云存档按钮图标样式。

## 边界

本次改动只处理角色管理页的教程接入和少量局部样式，不改变业务流程。

不修改：

- 角色卡新增、删除、保存、导入、导出逻辑
- 角色切换逻辑本身
- Steam 创意工坊订阅、同步、卡面识别逻辑
- API Key 的保存、校验、连通性测试逻辑
- 初始人格选择流程
- 首页教程、Yui-only 教程、模型管理教程、情感管理教程等其它页面教程流程
- 字幕、TTS、聊天、翻译、主动搭话等主流程

教程文案继续复用已有 `tutorial.chara_manager.*` i18n key，没有新增硬编码教程文案。

页面滚动和鼠标点击拦截只限定在角色管理页教程中生效，不作用于其它页面教程。

## 风险

- 角色管理页教程依赖当前页面 DOM 结构，例如 `.chara-card-item`、`.chara-list-item`、`.chara-add-btn`、`#api-key-settings-btn` 等；如果后续角色管理页结构大改，需要同步更新教程选择器。
- 当前教程依赖页面至少有一张角色卡。如果完全没有角色卡，相关步骤会等待卡片渲染后再启动。
- 教程期间会拦截角色管理页的页面滚动和底层点击，目的是避免高亮错位和误操作；因此教程文案中的“点击”更偏说明，不代表教程过程中必须实际点击页面控件。
- 如果未来要把角色管理页教程改成“用户必须实际点击按钮才能进入下一步”的交互式教程，需要额外为对应控件做放行。
- 局部视觉优化只覆盖角色管理页里的主人档案下拉标和云存档按钮，不承诺其它页面同类按钮视觉同步。

## 测试

- `pytest -q tests/test_agent_rewrite_regression.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 主配置文件新增可展开/收起的箭头“气泡”交互与视觉反馈

* **改进**
  * 教程期间阻止页面滚动与指针事件，避免干扰教程流程
  * 侧边云保存按钮新增独立图标徽章、悬停与可见聚焦样式，提升可访问性
  * 深色模式下图标与控件的渲染行为一致性优化（使用 currentColor 渲染、移除内置填充）

* **测试**
  * 添加回归测试覆盖教程阻断、教程目标定位与上述 UI 变更

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1255)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->