### PR TITLE
刷新Agent启用时的能力预检状态

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -806,6 +806,10 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
     async with _llm_check_lock:
         adapter = Modules.computer_use
         if adapter is None:
+            _set_capability("computer_use", False, "AGENT_CU_MODULE_NOT_LOADED")
+            _set_capability("browser_use", False, "AGENT_CU_MODULE_NOT_LOADED")
+            _bump_state_revision()
+            await _emit_agent_status_update()
             return
 
         def _probe():
@@ -4457,10 +4461,14 @@ async def agent_command(payload: Dict[str, Any]):
             Modules.analyzer_enabled = True
             Modules.analyzer_profile = (payload or {}).get("profile", {}) or {}
             if gate.get("ready") is True:
-                _try_refresh_computer_use_adapter(force=True)
-                _set_capability("computer_use", False, "AGENT_PRECHECK_PENDING")
-                _set_capability("browser_use", False, "AGENT_PRECHECK_PENDING")
-                asyncio.ensure_future(_fire_agent_llm_connectivity_check(queue=True))
+                adapter_refreshed = _try_refresh_computer_use_adapter(force=True)
+                if adapter_refreshed and Modules.computer_use is not None:
+                    _set_capability("computer_use", False, "AGENT_PRECHECK_PENDING")
+                    _set_capability("browser_use", False, "AGENT_PRECHECK_PENDING")
+                    asyncio.ensure_future(_fire_agent_llm_connectivity_check(queue=True))
+                else:
+                    _set_capability("computer_use", False, "AGENT_CU_MODULE_NOT_LOADED")
+                    _set_capability("browser_use", False, "AGENT_CU_MODULE_NOT_LOADED")
             else:
                 first_reason = (gate.get("reasons") or ["AGENT_ENDPOINT_NOT_CONFIGURED"])[0]
                 _set_capability("computer_use", False, first_reason)

--- a/agent_server.py
+++ b/agent_server.py
@@ -842,7 +842,9 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
             reason = "" if ok else "AGENT_LLM_UNREACHABLE"
             _set_capability("computer_use", ok, reason)
             bu = Modules.browser_use
-            if bu is not None:
+            if bu is None:
+                _set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")
+            else:
                 if not ok:
                     _set_capability("browser_use", False, reason)
                 elif not getattr(bu, "_ready_import", False):
@@ -4459,6 +4461,10 @@ async def agent_command(payload: Dict[str, Any]):
                 _set_capability("computer_use", False, "AGENT_PRECHECK_PENDING")
                 _set_capability("browser_use", False, "AGENT_PRECHECK_PENDING")
                 asyncio.ensure_future(_fire_agent_llm_connectivity_check(queue=True))
+            else:
+                first_reason = (gate.get("reasons") or ["AGENT_ENDPOINT_NOT_CONFIGURED"])[0]
+                _set_capability("computer_use", False, first_reason)
+                _set_capability("browser_use", False, first_reason)
         else:
             Modules.analyzer_enabled = False
             Modules.analyzer_profile = {}

--- a/agent_server.py
+++ b/agent_server.py
@@ -4462,7 +4462,9 @@ async def agent_command(payload: Dict[str, Any]):
             Modules.analyzer_profile = (payload or {}).get("profile", {}) or {}
             if gate.get("ready") is True:
                 adapter_refreshed = _try_refresh_computer_use_adapter(force=True)
-                if adapter_refreshed and Modules.computer_use is not None:
+                if not adapter_refreshed and Modules.computer_use is not None:
+                    logger.info("[Agent] ComputerUse adapter refresh failed; falling back to existing adapter")
+                if Modules.computer_use is not None:
                     _set_capability("computer_use", False, "AGENT_PRECHECK_PENDING")
                     _set_capability("browser_use", False, "AGENT_PRECHECK_PENDING")
                     asyncio.ensure_future(_fire_agent_llm_connectivity_check(queue=True))

--- a/agent_server.py
+++ b/agent_server.py
@@ -4450,9 +4450,15 @@ async def agent_command(payload: Dict[str, Any]):
     lanlan_name = (payload or {}).get("lanlan_name")
     if command == "set_agent_enabled":
         enabled = bool((payload or {}).get("enabled"))
+        gate = _check_agent_api_gate()
         if enabled:
             Modules.analyzer_enabled = True
             Modules.analyzer_profile = (payload or {}).get("profile", {}) or {}
+            if gate.get("ready") is True:
+                _try_refresh_computer_use_adapter(force=True)
+                _set_capability("computer_use", False, "AGENT_PRECHECK_PENDING")
+                _set_capability("browser_use", False, "AGENT_PRECHECK_PENDING")
+                asyncio.ensure_future(_fire_agent_llm_connectivity_check(queue=True))
         else:
             Modules.analyzer_enabled = False
             Modules.analyzer_profile = {}
@@ -4470,7 +4476,13 @@ async def agent_command(payload: Dict[str, Any]):
         await _emit_agent_status_update(lanlan_name=lanlan_name)
         total_ms = round((time.perf_counter() - t0) * 1000, 2)
         logger.info("[AgentTiming] request_id=%s command=%s total_ms=%s", request_id, command, total_ms)
-        return {"success": True, "request_id": request_id, "timing": {"agent_total_ms": total_ms}}
+        return {
+            "success": True,
+            "request_id": request_id,
+            "is_free_version": bool(gate.get("is_free_version")),
+            "agent_api_gate": gate,
+            "timing": {"agent_total_ms": total_ms},
+        }
     if command == "set_flag":
         key = (payload or {}).get("key")
         value = bool((payload or {}).get("value"))

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -400,7 +400,14 @@
             render('command');
             try {
                 const cmdResult = await sendCommand('set_agent_enabled', { enabled });
-                if (enabled && cmdResult && cmdResult.is_free_version && window.showAlert) {
+                const isFreeVersion = !!(
+                    cmdResult && (
+                        cmdResult.is_free_version ||
+                        (cmdResult.agent_api_gate && cmdResult.agent_api_gate.is_free_version) ||
+                        (cmdResult.snapshot && cmdResult.snapshot.gate && cmdResult.snapshot.gate.is_free_version)
+                    )
+                );
+                if (enabled && isFreeVersion && window.showAlert) {
                     const msg = window.t
                         ? window.t('agent.status.freeModelWarning')
                         : '由于限额问题，免费模型使用Agent模式容易阻塞，建议您切换至自费模型。\n\n如果您已经配置好自费API，请尝试重启NEKO。';

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API not configured",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui not installed",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use not installed",
+            "AGENT_CU_MODULE_NOT_LOADED": "Computer Use module not loaded",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use module not loaded",
             "AGENT_NOT_INITIALIZED": "NekoClaw initialization failed",
             "AGENT_LLM_UNREACHABLE": "NekoClaw LLM unreachable",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API not configured",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui not installed",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use not installed",
+            "AGENT_BU_MODULE_NOT_LOADED": "Browser Use module not loaded",
             "AGENT_NOT_INITIALIZED": "NekoClaw initialization failed",
             "AGENT_LLM_UNREACHABLE": "NekoClaw LLM unreachable",
             "AGENT_MODEL_NOT_CONFIGURED": "NekoClaw model not configured",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "API del agente no configurada",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui no instalado",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "uso del navegador no instalado",
+            "AGENT_CU_MODULE_NOT_LOADED": "módulo Computer Use no cargado",
             "AGENT_BU_MODULE_NOT_LOADED": "módulo Browser Use no cargado",
             "AGENT_NOT_INITIALIZED": "La inicialización de NekoClaw falló",
             "AGENT_LLM_UNREACHABLE": "NekoClaw LLM inalcanzable",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "API del agente no configurada",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui no instalado",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "uso del navegador no instalado",
+            "AGENT_BU_MODULE_NOT_LOADED": "módulo Browser Use no cargado",
             "AGENT_NOT_INITIALIZED": "La inicialización de NekoClaw falló",
             "AGENT_LLM_UNREACHABLE": "NekoClaw LLM inalcanzable",
             "AGENT_MODEL_NOT_CONFIGURED": "Modelo NekoClaw no configurado",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API が設定されていません",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui がインストールされていません",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use がインストールされていません",
+            "AGENT_BU_MODULE_NOT_LOADED": "Browser Use モジュールが読み込まれていません",
             "AGENT_NOT_INITIALIZED": "ネコクローの初期化に失敗",
             "AGENT_LLM_UNREACHABLE": "ネコクロー LLM に接続できません",
             "AGENT_MODEL_NOT_CONFIGURED": "ネコクローモデルが設定されていません",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API が設定されていません",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui がインストールされていません",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use がインストールされていません",
+            "AGENT_CU_MODULE_NOT_LOADED": "Computer Use モジュールが読み込まれていません",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use モジュールが読み込まれていません",
             "AGENT_NOT_INITIALIZED": "ネコクローの初期化に失敗",
             "AGENT_LLM_UNREACHABLE": "ネコクロー LLM に接続できません",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API가 구성되지 않았습니다",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui가 설치되지 않았습니다",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use가 설치되지 않았습니다",
+            "AGENT_CU_MODULE_NOT_LOADED": "Computer Use 모듈이 로드되지 않았습니다",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 모듈이 로드되지 않았습니다",
             "AGENT_NOT_INITIALIZED": "네코클로 초기화 실패",
             "AGENT_LLM_UNREACHABLE": "네코클로 LLM에 연결할 수 없습니다",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API가 구성되지 않았습니다",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui가 설치되지 않았습니다",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use가 설치되지 않았습니다",
+            "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 모듈이 로드되지 않았습니다",
             "AGENT_NOT_INITIALIZED": "네코클로 초기화 실패",
             "AGENT_LLM_UNREACHABLE": "네코클로 LLM에 연결할 수 없습니다",
             "AGENT_MODEL_NOT_CONFIGURED": "네코클로 모델이 구성되지 않았습니다",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "API do agente não configurada",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui não instalado",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "uso do navegador não instalado",
+            "AGENT_CU_MODULE_NOT_LOADED": "módulo Computer Use não carregado",
             "AGENT_BU_MODULE_NOT_LOADED": "módulo Browser Use não carregado",
             "AGENT_NOT_INITIALIZED": "Falha na inicialização do NekoClaw",
             "AGENT_LLM_UNREACHABLE": "NekoClaw LLM inacessível",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "API do agente não configurada",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui não instalado",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "uso do navegador não instalado",
+            "AGENT_BU_MODULE_NOT_LOADED": "módulo Browser Use não carregado",
             "AGENT_NOT_INITIALIZED": "Falha na inicialização do NekoClaw",
             "AGENT_LLM_UNREACHABLE": "NekoClaw LLM inacessível",
             "AGENT_MODEL_NOT_CONFIGURED": "Modelo NekoClaw não configurado",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API не настроен",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui не установлен",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use не установлен",
+            "AGENT_BU_MODULE_NOT_LOADED": "модуль Browser Use не загружен",
             "AGENT_NOT_INITIALIZED": "Ошибка инициализации Лапки Неко",
             "AGENT_LLM_UNREACHABLE": "LLM Лапки Неко недоступен",
             "AGENT_MODEL_NOT_CONFIGURED": "Модель Лапки Неко не настроена",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API не настроен",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui не установлен",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use не установлен",
+            "AGENT_CU_MODULE_NOT_LOADED": "модуль Computer Use не загружен",
             "AGENT_BU_MODULE_NOT_LOADED": "модуль Browser Use не загружен",
             "AGENT_NOT_INITIALIZED": "Ошибка инициализации Лапки Неко",
             "AGENT_LLM_UNREACHABLE": "LLM Лапки Неко недоступен",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API 未配置",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui 未安装",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use 未安装",
+            "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 模块未加载",
             "AGENT_NOT_INITIALIZED": "猫爪初始化失败",
             "AGENT_LLM_UNREACHABLE": "猫爪 LLM 连接失败",
             "AGENT_MODEL_NOT_CONFIGURED": "猫爪模型未配置",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API 未配置",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui 未安装",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use 未安装",
+            "AGENT_CU_MODULE_NOT_LOADED": "Computer Use 模块未加载",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 模块未加载",
             "AGENT_NOT_INITIALIZED": "猫爪初始化失败",
             "AGENT_LLM_UNREACHABLE": "猫爪 LLM 连接失败",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API 未配置",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui 未安裝",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use 未安裝",
+            "AGENT_CU_MODULE_NOT_LOADED": "Computer Use 模組未載入",
             "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 模組未載入",
             "AGENT_NOT_INITIALIZED": "貓爪初始化失敗",
             "AGENT_LLM_UNREACHABLE": "貓爪 LLM 連接失敗",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -2426,6 +2426,7 @@
             "AGENT_ENDPOINT_NOT_CONFIGURED": "Agent API 未配置",
             "AGENT_PYAUTOGUI_NOT_INSTALLED": "pyautogui 未安裝",
             "AGENT_BROWSER_USE_NOT_INSTALLED": "browser-use 未安裝",
+            "AGENT_BU_MODULE_NOT_LOADED": "Browser Use 模組未載入",
             "AGENT_NOT_INITIALIZED": "貓爪初始化失敗",
             "AGENT_LLM_UNREACHABLE": "貓爪 LLM 連接失敗",
             "AGENT_MODEL_NOT_CONFIGURED": "貓爪模型未配置",

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1368,7 +1368,9 @@ def test_agent_command_set_agent_enabled_reports_free_version_and_refreshes_capa
     assert 'command == "set_agent_enabled"' in func_src
     assert "gate = _check_agent_api_gate()" in func_src
     assert "adapter_refreshed = _try_refresh_computer_use_adapter(force=True)" in func_src
-    assert "if adapter_refreshed and Modules.computer_use is not None:" in func_src
+    assert "if not adapter_refreshed and Modules.computer_use is not None:" in func_src
+    assert "falling back to existing adapter" in func_src
+    assert "if Modules.computer_use is not None:" in func_src
     assert '_fire_agent_llm_connectivity_check(queue=True)' in func_src
     assert '_set_capability("computer_use", False, "AGENT_CU_MODULE_NOT_LOADED")' in func_src
     assert '_set_capability("browser_use", False, "AGENT_CU_MODULE_NOT_LOADED")' in func_src

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1369,8 +1369,27 @@ def test_agent_command_set_agent_enabled_reports_free_version_and_refreshes_capa
     assert "gate = _check_agent_api_gate()" in func_src
     assert '_try_refresh_computer_use_adapter(force=True)' in func_src
     assert '_fire_agent_llm_connectivity_check(queue=True)' in func_src
+    assert 'first_reason = (gate.get("reasons") or ["AGENT_ENDPOINT_NOT_CONFIGURED"])[0]' in func_src
+    assert '_set_capability("computer_use", False, first_reason)' in func_src
+    assert '_set_capability("browser_use", False, first_reason)' in func_src
     assert '"is_free_version": bool(gate.get("is_free_version"))' in func_src
     assert '"agent_api_gate": gate' in func_src
+
+
+def test_agent_llm_check_marks_browser_use_unloaded_instead_of_pending():
+    source = Path("agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_fire_agent_llm_connectivity_check":
+            func = node
+            break
+    assert func is not None
+    func_src = ast.get_source_segment(source, func) or ""
+
+    assert "bu = Modules.browser_use" in func_src
+    assert "if bu is None:" in func_src
+    assert '_set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")' in func_src
 
 
 def test_agent_ui_v2_free_warning_accepts_command_gate_shape():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1367,8 +1367,11 @@ def test_agent_command_set_agent_enabled_reports_free_version_and_refreshes_capa
 
     assert 'command == "set_agent_enabled"' in func_src
     assert "gate = _check_agent_api_gate()" in func_src
-    assert '_try_refresh_computer_use_adapter(force=True)' in func_src
+    assert "adapter_refreshed = _try_refresh_computer_use_adapter(force=True)" in func_src
+    assert "if adapter_refreshed and Modules.computer_use is not None:" in func_src
     assert '_fire_agent_llm_connectivity_check(queue=True)' in func_src
+    assert '_set_capability("computer_use", False, "AGENT_CU_MODULE_NOT_LOADED")' in func_src
+    assert '_set_capability("browser_use", False, "AGENT_CU_MODULE_NOT_LOADED")' in func_src
     assert 'first_reason = (gate.get("reasons") or ["AGENT_ENDPOINT_NOT_CONFIGURED"])[0]' in func_src
     assert '_set_capability("computer_use", False, first_reason)' in func_src
     assert '_set_capability("browser_use", False, first_reason)' in func_src
@@ -1387,6 +1390,10 @@ def test_agent_llm_check_marks_browser_use_unloaded_instead_of_pending():
     assert func is not None
     func_src = ast.get_source_segment(source, func) or ""
 
+    assert "adapter = Modules.computer_use" in func_src
+    assert "if adapter is None:" in func_src
+    assert '_set_capability("computer_use", False, "AGENT_CU_MODULE_NOT_LOADED")' in func_src
+    assert '_set_capability("browser_use", False, "AGENT_CU_MODULE_NOT_LOADED")' in func_src
     assert "bu = Modules.browser_use" in func_src
     assert "if bu is None:" in func_src
     assert '_set_capability("browser_use", False, "AGENT_BU_MODULE_NOT_LOADED")' in func_src

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1354,6 +1354,34 @@ def test_is_agent_api_ready_reports_missing_fields(agent_api, expected_reason):
     assert expected_reason in reasons
 
 
+def test_agent_command_set_agent_enabled_reports_free_version_and_refreshes_capabilities():
+    source = Path("agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "agent_command":
+            func = node
+            break
+    assert func is not None
+    func_src = ast.get_source_segment(source, func) or ""
+
+    assert 'command == "set_agent_enabled"' in func_src
+    assert "gate = _check_agent_api_gate()" in func_src
+    assert '_try_refresh_computer_use_adapter(force=True)' in func_src
+    assert '_fire_agent_llm_connectivity_check(queue=True)' in func_src
+    assert '"is_free_version": bool(gate.get("is_free_version"))' in func_src
+    assert '"agent_api_gate": gate' in func_src
+
+
+def test_agent_ui_v2_free_warning_accepts_command_gate_shape():
+    source = Path("static/js/agent_ui_v2.js").read_text(encoding="utf-8")
+
+    assert "const isFreeVersion" in source
+    assert "cmdResult.is_free_version" in source
+    assert "cmdResult.agent_api_gate && cmdResult.agent_api_gate.is_free_version" in source
+    assert "window.showAlert(msg, title)" in source
+
+
 def test_get_model_api_config_agent_uses_agent_fields_without_custom_switch():
     manager = object.__new__(ConfigManager)
     manager.get_core_config = lambda: {


### PR DESCRIPTION
开启 Agent 时返回 API gate 和免费版本信息
gate 可用时触发 CU/BU 能力预检
gate 不可用时清理旧的 CU/BU capability 状态
BrowserUse 未加载时明确标记为模块未加载，避免一直 pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 启用代理时会先检查就绪条件，避免错误刷新与探测排队；在不可用时会显示具体的未加载/失败原因
  * 预检逻辑：缺失浏览器模块时显示“未加载”状态而非挂起
  * 切换时的响应现在包含是否为免费版本和完整的网关信息以便前端显示

* **用户界面**
  * 主开关启用时更可靠地检测并展示“免费版本”警告（支持多种返回格式）

* **文档**
  * 为浏览器/计算模块未加载新增多语言提示（en/es/ja/ko/pt/ru/zh-CN/zh-TW）

* **测试**
  * 新增回归测试覆盖启用流程、预检行为和前端免费版本提示逻辑

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1257)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->