### PR TITLE
Abstract native voice routing into provider-agnostic registry

### DIFF
--- a/.agent/rules/neko-guide.md
+++ b/.agent/rules/neko-guide.md
@@ -80,6 +80,32 @@ CI 守门：
 
 检测方法：在 `main_routers/` 等跨模块代码里 `grep -nE "足球|比分|射门|乌龙|抢断|进球"`，结果应该全部落在带 module 名的函数（`_*_soccer_*`）或 module-specific 路径里。
 
+## 架构：core API native voice 走 native_voice_registry
+
+每个 core API 自带的 native TTS voice catalog（Gemini Puck/Leda、未来的 OpenAI/Qwen native voices 等）必须通过 `utils/native_voice_registry.py` 注册和查询。**禁止**在 cross-cutting 文件里新增 `if core_api_type == 'X'` 分支——这是 PR #1262 把 4 处 Gemini 专属分支抽成 registry 的直接动机，再加分支等于把 refactor 撤回。
+
+加新 native voice provider 只动 3 处：
+
+1. **新建 adapter `utils/<provider>_tts_voices.py`**：定义 catalog（canonical voice → gender）、aliases（casefolded 用户输入 → canonical）、default_voice / default_male_voice，构造 `NativeVoiceProvider(key=..., catalog=..., ...)` 并 `register_provider(...)`。`key` 必须等于 codebase 已有的 `core_api_type` / realtime `api_type` 字符串（'gemini' / 'qwen' / ...），registry 按这个 key 路由。可选保留 `normalize_<provider>_tts_voice` / `is_<provider>_tts_voice` thin wrapper 给该 provider 自己的 wire-format 路径用。
+2. **`utils/native_voice_registry.py` 的 `_BUILTIN_PROVIDER_MODULES` tuple 加一行**：写新 adapter 模块的 dotted 名。registry 在自己 import 末尾自举把这些 provider 加载进来，cross-cutting 文件不需要 side-effect import。
+3. **`main_logic/tts_client.py` 注册 worker resolver**：定义 `<provider>_tts_worker(...)` 后，写一个 `_resolve_<provider>_native_tts_worker(cm)` 返回 `(worker, api_key)`，调用 `register_tts_worker_resolver('<key>', _resolve_<provider>_native_tts_worker)`。两阶段注册：metadata 在轻量 adapter 里注册，worker callable（带 httpx/soxr 等重依赖）在 tts_client 里注册，避免循环 import。
+
+不该动的 cross-cutting 文件：
+
+- `utils/config_manager.py` 的 `validate_voice_id` / `validate_voice_id_for_api_key`：用 `get_active_realtime_native_provider(self) + is_native_voice(voice_id, provider)`，自动认识新 provider
+- `main_routers/characters_router.py` 的 `get_voices` endpoint：用 `get_active_realtime_native_provider + get_native_voice_catalog_for_ui`
+- `main_logic/core.py` 的 `_has_custom_tts` / `_resolve_session_use_tts` / `_resolve_realtime_voice` 三处：用 `resolve_native_voice_for_routing(core_api_type, voice_id, voice_id_exists)`，generic
+- `main_logic/tts_client.py` 的 `get_tts_worker` dispatcher：用 `get_native_tts_worker(core_api_type, cm, voice_id)` 短路
+
+wire-format 路径例外：provider 自家的 worker 内部（如 `gemini_tts_worker` 调 `normalize_gemini_tts_voice`）和该 provider 的 realtime client 内部（如 `omni_realtime_client.py:869` 调 `normalize_gemini_tts_voice` 拼 `speech_config`）继续直接调 provider 的 normalize 函数 OK——那些代码本来就 provider-bound，绕 registry 是 purity for purity's sake。
+
+理由：
+1. 把"加 native voice provider"的 cost 从"改 5 个文件 + 4 处 if-branch"降到"加 3 处（全是新增，不改既有逻辑）"。
+2. cross-cutting 文件不再随 provider 数量膨胀，符合"core 层必须是 general 接口"的代码风格规则。
+3. registry 自举（`_BUILTIN_PROVIDER_MODULES` + 模块尾部 `ensure_builtin_native_voice_providers_loaded()`）保证任何 import registry 的代码都看到 populated 表，cross-cutting caller 不可能漏 bootstrap 触发空 registry 静默 fall-through 到外部 TTS。
+
+检测方法：在 `utils/config_manager.py` / `main_routers/characters_router.py` / `main_logic/core.py` / `main_logic/tts_client.py` 里 grep `core_api_type ==` 或 `api_type ==`，结果不应该出现 native voice provider 的 key（'gemini' / 'qwen' / ...）作为 RHS——除非是注册 worker resolver 那行（tts_client 注册时写字面量是必须的）。
+
 ## 架构：单进程 + 事件循环零阻塞
 
 `main_server` / `memory_server` / `agent_server` 三子系统已合并进同一个 FastAPI 进程，共享事件循环。任何会阻塞事件循环超过数十毫秒的调用都会把另外两个子系统也拖慢，因此在 async 路径（`async def` 函数、FastAPI 路由、`asyncio.create_task` 后台任务、WebSocket handler）里禁止以下操作：

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -233,7 +233,7 @@ from config.prompts.prompts_avatar_interaction import (
 # )
 from utils.config_manager import get_config_manager, get_reserved
 from utils.logger_config import get_module_logger
-import utils.gemini_tts_voices  # noqa: F401  — registers Gemini provider into native_voice_registry
+from utils import gemini_tts_voices  # noqa: F401  — import for side effect: registers Gemini provider into native_voice_registry
 from utils.native_voice_registry import resolve_native_voice_for_routing
 from utils.api_config_loader import (
     get_free_voices,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -233,7 +233,6 @@ from config.prompts.prompts_avatar_interaction import (
 # )
 from utils.config_manager import get_config_manager, get_reserved
 from utils.logger_config import get_module_logger
-from utils import gemini_tts_voices  # noqa: F401  — import for side effect: registers Gemini provider into native_voice_registry
 from utils.native_voice_registry import resolve_native_voice_for_routing
 from utils.api_config_loader import (
     get_free_voices,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -233,7 +233,8 @@ from config.prompts.prompts_avatar_interaction import (
 # )
 from utils.config_manager import get_config_manager, get_reserved
 from utils.logger_config import get_module_logger
-from utils.gemini_tts_voices import resolve_gemini_native_voice_for_routing
+import utils.gemini_tts_voices  # noqa: F401  — registers Gemini provider into native_voice_registry
+from utils.native_voice_registry import resolve_native_voice_for_routing
 from utils.api_config_loader import (
     get_free_voices,
     get_livestream_config,
@@ -2531,7 +2532,7 @@ class LLMSessionManager:
     def _has_custom_tts(self) -> bool:
         """判断当前会话是否使用自定义 TTS（克隆音色或自定义 TTS URL）。"""
         core_config = self._config_manager.get_core_config()
-        _, uses_provider_native_voice = resolve_gemini_native_voice_for_routing(
+        _, uses_provider_native_voice = resolve_native_voice_for_routing(
             self.core_api_type,
             self.voice_id,
             self._config_manager.voice_id_exists_in_any_storage,
@@ -2869,13 +2870,13 @@ class LLMSessionManager:
 
         if input_mode == 'text':
             return True
-        _, uses_provider_native_voice = resolve_gemini_native_voice_for_routing(
+        _, uses_provider_native_voice = resolve_native_voice_for_routing(
             self.core_api_type,
             self.voice_id,
             self._config_manager.voice_id_exists_in_any_storage,
         )
         if uses_provider_native_voice:
-            logger.info(f"{log_prefix}🔊 Gemini 原生音色 '{self.voice_id}' 将直接传入 RealtimeClient")
+            logger.info(f"{log_prefix}🔊 {self.core_api_type} 原生音色 '{self.voice_id}' 将直接传入 RealtimeClient")
             return False
         if (
             self._is_free_preset_voice
@@ -2914,14 +2915,15 @@ class LLMSessionManager:
         """决定 OmniRealtimeClient 传给 server/provider 的 voice。
 
         优先级：
-        1. Gemini 原生音色（Puck / 中文男 等）→ 规范化后传入 Gemini Live。
+        1. core_api_type 注册了 native voice provider，且 voice_id 命中其 catalog
+           （Gemini Puck / 中文男 等）→ 规范化后由 provider client 直接消费。
         2. livestream 子模式启用且配置了 voice_id → 用 livestream voice_id
            （绕过 free_voices preset gate，base_url 已被派生不含 lanlan.tech）
         3. 否则保留原逻辑：仅在角色 voice 是 free preset、core_api_type='free'
            且 base_url 仍指向 lanlan.tech 域时下发，避免把 preset id 透给非
            lanlan 服务（lanlan.app 的屏蔽由 _should_block_free_preset_voice 兜底）
         """
-        voice_name, uses_provider_native_voice = resolve_gemini_native_voice_for_routing(
+        voice_name, uses_provider_native_voice = resolve_native_voice_for_routing(
             self.core_api_type,
             self.voice_id,
             self._config_manager.voice_id_exists_in_any_storage,

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -20,10 +20,13 @@ from utils.aiohttp_proxy_utils import aiohttp_session_kwargs_for_url
 from utils.config_manager import get_config_manager
 from utils.gemini_tts_voices import (
     GEMINI_TTS_MODEL,
-    is_gemini_tts_voice,
     normalize_gemini_tts_voice,
 )
 from utils.logger_config import get_module_logger
+from utils.native_voice_registry import (
+    get_native_tts_worker,
+    register_tts_worker_resolver,
+)
 
 logger = get_module_logger(__name__, "Main")
 
@@ -2237,6 +2240,18 @@ def gemini_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
     _run_sentence_tts_worker(request_queue, response_queue, setup, label="Gemini TTS")
 
 
+def _resolve_gemini_native_tts_worker(cm):
+    """Native voice registry resolver for Gemini's TTS worker.
+
+    Gemini's native voices are billed against CORE_API_KEY (the same key the
+    realtime/LLM endpoint uses), not the optional custom TTS api_key.
+    """
+    return gemini_tts_worker, (cm.get_core_config() or {}).get('CORE_API_KEY', '')
+
+
+register_tts_worker_resolver('gemini', _resolve_gemini_native_tts_worker)
+
+
 def openai_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
     """OpenAI TTS worker — 按句切分合成，流式接收音频。"""
     try:
@@ -2893,20 +2908,17 @@ def get_tts_worker(core_api_type='qwen', has_custom_voice=False, voice_id=''):
             worker = partial(minimax_tts_worker, base_url=base_url)
             return worker, api_key, 'minimax'
 
-    # core=gemini + 选了 Gemini 原生声线 (Puck/Leda/中文男 等) 时优先走 Gemini，
-    # 不能被 has_custom_voice=False 的 GPT-SoVITS / local CosyVoice fallthrough 拦截 ——
-    # _has_custom_tts 已经判断 voice_id 不是用户克隆音色，这里 has_custom_voice 必为 False，
-    # 是用户显式选择的 Gemini 原生路径，应当尊重该选择喵。
-    # 同时显式返回 CORE_API_KEY：当 ENABLE_CUSTOM_API + TTS_MODEL_URL 配了的时候，
-    # 调用方 fallback 的 get_model_api_config('tts_default') 会返回自定义 TTS 的 key
-    # (config_manager.py 自定义分支)，会拿 GSV/local TTS key 去打 Gemini，必失败。
-    if (
-        not has_custom_voice
-        and core_api_type == 'gemini'
-        and is_gemini_tts_voice(voice_id)
-    ):
-        core_api_key = (cm.get_core_config() or {}).get('CORE_API_KEY', '')
-        return gemini_tts_worker, core_api_key, 'gemini'
+    # core_api_type 命中 native voice provider + 用户选了该 provider 的原生声线
+    # (e.g. Gemini Puck/Leda/中文男) 时优先走原生 worker，不能被 has_custom_voice=False
+    # 的 GPT-SoVITS / local CosyVoice fallthrough 拦截 —— _has_custom_tts 已经判断
+    # voice_id 不是用户克隆音色，这里 has_custom_voice 必为 False，是用户显式选择的
+    # 原生路径，应当尊重该选择喵。api_key 由 provider 注册的 resolver 提供
+    # (Gemini 用 CORE_API_KEY；若 fallback 到 get_model_api_config('tts_default')
+    # 会拿到自定义 TTS 的 key，鉴权必失败)。
+    if not has_custom_voice:
+        native = get_native_tts_worker(core_api_type, cm, voice_id)
+        if native is not None:
+            return native
 
     try:
         tts_config = cm.get_model_api_config('tts_custom')

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -65,7 +65,10 @@ from utils.config_manager import (
     set_reserved,
     strip_generated_persona_selection_prompt,
 )
-from utils.gemini_tts_voices import get_gemini_tts_voices
+from utils.native_voice_registry import (
+    get_active_realtime_native_provider,
+    get_native_voice_catalog_for_ui,
+)
 from utils.audio import normalize_voice_clone_api_audio, validate_audio_file
 from utils.character_name import PROFILE_NAME_MAX_UNITS, validate_character_name
 from utils.initial_personality_state import (
@@ -3053,8 +3056,9 @@ async def get_voices():
     result = {"voices": _config_manager.get_voices_for_current_api()}
     
     core_config = await _config_manager.aget_core_config()
-    if _config_manager.is_gemini_realtime_api_active():
-        result["native_voices"] = get_gemini_tts_voices()
+    active_native_provider = get_active_realtime_native_provider(_config_manager)
+    if active_native_provider:
+        result["native_voices"] = get_native_voice_catalog_for_ui(active_native_provider)
 
     if core_config.get('IS_FREE_VERSION'):
         core_url = core_config.get('CORE_URL', '')

--- a/tests/unit/test_gemini_realtime_voice_routing.py
+++ b/tests/unit/test_gemini_realtime_voice_routing.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"
 import main_routers.characters_router as characters_router
 from main_logic.core import LLMSessionManager
 from utils.config_manager import ConfigManager
-from utils.gemini_tts_voices import resolve_gemini_native_voice_for_routing
+from utils.native_voice_registry import resolve_native_voice_for_routing
 
 
 class _FakeConfigManager:
@@ -24,6 +24,9 @@ class _FakeConfigManager:
 
 
 class _FakeCharactersRouterConfigManager:
+    """Mimics the ConfigManager surface used by characters_router.get_voices
+    plus the registry's get_active_realtime_native_provider lookup."""
+
     def __init__(self, realtime_api_type):
         self._realtime_api_type = realtime_api_type
 
@@ -33,8 +36,11 @@ class _FakeCharactersRouterConfigManager:
     async def aget_core_config(self):
         return {"CORE_API_TYPE": "gemini"}
 
-    def is_gemini_realtime_api_active(self):
-        return self._realtime_api_type == "gemini"
+    def get_model_api_config(self, model_type):
+        return {"api_type": self._realtime_api_type}
+
+    def get_core_config(self):
+        return {"CORE_API_TYPE": "gemini"}
 
     async def aload_characters(self):
         return {"猫娘": {}}
@@ -61,7 +67,7 @@ def test_gemini_alias_checks_canonical_voice_collision():
     config_manager = _FakeConfigManager(stored_voice_ids={"Puck"})
 
     assert (
-        resolve_gemini_native_voice_for_routing(
+        resolve_native_voice_for_routing(
             "gemini",
             "中文男",
             config_manager.voice_id_exists_in_any_storage,
@@ -74,7 +80,7 @@ def test_gemini_alias_checks_canonical_voice_collision_case_insensitively():
     config_manager = _FakeConfigManager(stored_voice_ids={"puck"})
 
     assert (
-        resolve_gemini_native_voice_for_routing(
+        resolve_native_voice_for_routing(
             "gemini",
             "中文男",
             config_manager.voice_id_exists_in_any_storage,
@@ -88,7 +94,7 @@ def test_gemini_alias_without_collision_uses_native_realtime_voice():
     config_manager = _FakeConfigManager()
 
     assert (
-        resolve_gemini_native_voice_for_routing(
+        resolve_native_voice_for_routing(
             "gemini",
             "中文男",
             config_manager.voice_id_exists_in_any_storage,

--- a/tests/unit/test_gemini_tts_voices.py
+++ b/tests/unit/test_gemini_tts_voices.py
@@ -8,13 +8,14 @@ import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
 from utils.gemini_tts_voices import (
+    GEMINI_PROVIDER,
     GEMINI_TTS_DEFAULT_MALE_VOICE,
     GEMINI_TTS_DEFAULT_VOICE,
     GEMINI_TTS_VOICE_GENDERS,
-    get_gemini_tts_voices,
     is_gemini_tts_voice,
     normalize_gemini_tts_voice,
 )
+from utils.native_voice_registry import get_native_voice_catalog_for_ui
 
 
 @pytest.mark.parametrize(
@@ -92,8 +93,9 @@ def test_is_gemini_tts_voice_matches_recognized():
     assert is_gemini_tts_voice("   ") is False
 
 
-def test_get_gemini_tts_voices_shape():
-    voices = get_gemini_tts_voices()
+def test_gemini_voice_catalog_for_ui_shape():
+    voices = get_native_voice_catalog_for_ui("gemini")
+    assert voices is not None
     assert set(voices.keys()) == set(GEMINI_TTS_VOICE_GENDERS.keys())
     for voice_name, meta in voices.items():
         assert meta["provider"] == "gemini"
@@ -101,6 +103,13 @@ def test_get_gemini_tts_voices_shape():
         assert meta["gender"] == GEMINI_TTS_VOICE_GENDERS[voice_name]
         assert voice_name in meta["prefix"]
         assert meta["gender"] in meta["prefix"]
+
+
+def test_gemini_provider_registered_with_expected_metadata():
+    assert GEMINI_PROVIDER.key == "gemini"
+    assert GEMINI_PROVIDER.default_voice == GEMINI_TTS_DEFAULT_VOICE
+    assert GEMINI_PROVIDER.default_male_voice == GEMINI_TTS_DEFAULT_MALE_VOICE
+    assert GEMINI_PROVIDER.catalog_prefix == "Gemini"
 
 
 def test_default_voices_are_in_catalog():

--- a/tests/unit/test_native_voice_registry.py
+++ b/tests/unit/test_native_voice_registry.py
@@ -172,3 +172,38 @@ def test_get_provider_returns_none_for_falsy_key():
     assert get_provider(None) is None
     assert get_provider("") is None
     assert get_provider("__test_synth__") is _SYNTHETIC_PROVIDER
+
+
+def test_builtin_providers_auto_loaded_on_registry_import():
+    """Importing the registry alone (no explicit provider import) must give a
+    populated registry — otherwise cross-cutting code that runs before any
+    TTS/realtime client has loaded a provider would query an empty list and
+    silently fall through to external TTS routing.
+
+    Spawn a fresh subprocess so we observe a clean Python startup, not the
+    state already polluted by previous imports in this test session.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from utils.native_voice_registry import "
+                "list_providers, is_native_voice; "
+                "providers = list_providers(); "
+                "assert 'gemini' in providers, providers; "
+                "assert is_native_voice('Puck') is True; "
+                "print('OK')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")),
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert result.stdout.strip() == "OK"

--- a/tests/unit/test_native_voice_registry.py
+++ b/tests/unit/test_native_voice_registry.py
@@ -1,0 +1,174 @@
+"""Provider-agnostic invariants of utils.native_voice_registry.
+
+Tests use a synthetic provider so they keep passing even if the Gemini
+catalog changes; Gemini-specific behavior is covered in
+test_gemini_tts_voices.py.
+"""
+import os
+import sys
+
+import pytest
+
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from utils.native_voice_registry import (
+    NativeVoiceProvider,
+    get_active_realtime_native_provider,
+    get_native_tts_worker,
+    get_native_voice_catalog_for_ui,
+    get_provider,
+    is_native_voice,
+    normalize_native_voice,
+    register_provider,
+    register_tts_worker_resolver,
+    resolve_native_voice_for_routing,
+)
+
+
+_SYNTHETIC_PROVIDER = NativeVoiceProvider(
+    key="__test_synth__",
+    catalog={"Alpha": "Female", "Beta": "Male"},
+    aliases={"a": "Alpha", "b": "Beta", "女": "Alpha"},
+    default_voice="Alpha",
+    default_male_voice="Beta",
+    catalog_prefix="Synth",
+)
+
+
+@pytest.fixture(autouse=True)
+def _register_synthetic():
+    register_provider(_SYNTHETIC_PROVIDER)
+    yield
+    # 不显式 deregister —— 注册表设计为幂等覆盖，重跑 fixture 即可重置；
+    # 同时其他测试不会依赖 __test_synth__ 不存在。
+
+
+def test_is_native_voice_per_provider():
+    assert is_native_voice("Alpha", provider_key="__test_synth__") is True
+    assert is_native_voice("alpha", provider_key="__test_synth__") is True
+    assert is_native_voice("女", provider_key="__test_synth__") is True
+    assert is_native_voice("Puck", provider_key="__test_synth__") is False
+
+
+def test_is_native_voice_across_any_provider():
+    """无 provider_key 时跨注册表查询，至少能命中合成 provider 与 Gemini。"""
+    assert is_native_voice("Alpha") is True
+    assert is_native_voice("Puck") is True  # Gemini 在 import 时注册
+    assert is_native_voice("definitely-not-a-voice-id") is False
+
+
+def test_normalize_unknown_provider_raises():
+    with pytest.raises(KeyError):
+        normalize_native_voice("__nope__", "Alpha")
+
+
+def test_get_native_voice_catalog_for_ui_returns_none_for_unknown():
+    assert get_native_voice_catalog_for_ui(None) is None
+    assert get_native_voice_catalog_for_ui("__nope__") is None
+
+
+def test_get_native_voice_catalog_for_ui_shape():
+    catalog = get_native_voice_catalog_for_ui("__test_synth__")
+    assert catalog is not None
+    assert set(catalog.keys()) == {"Alpha", "Beta"}
+    for name, meta in catalog.items():
+        assert meta["provider"] == "__test_synth__"
+        assert meta["builtin"] is True
+        assert "Synth" in meta["prefix"]
+        assert name in meta["prefix"]
+
+
+def test_resolve_for_routing_unknown_core_returns_no_native():
+    """core_api_type 不在注册表里时 use_native=False，调用方走 custom TTS。"""
+    voice, use_native = resolve_native_voice_for_routing("nonexistent", "Alpha", None)
+    assert use_native is False
+    assert voice == "Alpha"
+
+
+def test_resolve_for_routing_collision_disables_native():
+    """同名克隆 voice 应该把 native routing 让给 custom TTS。"""
+    stored = {"alpha"}
+    voice, use_native = resolve_native_voice_for_routing(
+        "__test_synth__",
+        "a",  # alias → Alpha
+        lambda vid: vid.casefold() in stored,
+    )
+    assert voice == "Alpha"
+    assert use_native is False
+
+
+def test_resolve_for_routing_no_collision_uses_native():
+    voice, use_native = resolve_native_voice_for_routing(
+        "__test_synth__",
+        "a",
+        lambda vid: False,
+    )
+    assert (voice, use_native) == ("Alpha", True)
+
+
+def test_active_realtime_uses_realtime_config_first():
+    class _CM:
+        def get_model_api_config(self, model_type):
+            assert model_type == "realtime"
+            return {"api_type": "__test_synth__"}
+
+        def get_core_config(self):
+            return {"CORE_API_TYPE": "gemini"}
+
+    assert get_active_realtime_native_provider(_CM()) == "__test_synth__"
+
+
+def test_active_realtime_falls_back_to_core_when_realtime_unavailable():
+    class _CM:
+        def get_model_api_config(self, model_type):
+            raise RuntimeError("no realtime config")
+
+        def get_core_config(self):
+            return {"CORE_API_TYPE": "__test_synth__"}
+
+    assert get_active_realtime_native_provider(_CM()) == "__test_synth__"
+
+
+def test_active_realtime_returns_none_for_unregistered_provider():
+    class _CM:
+        def get_model_api_config(self, model_type):
+            return {"api_type": "some_other_provider"}
+
+        def get_core_config(self):
+            return {"CORE_API_TYPE": "some_other_provider"}
+
+    assert get_active_realtime_native_provider(_CM()) is None
+
+
+def test_get_native_tts_worker_requires_voice_match_and_resolver():
+    """worker resolver 注册前 → None；voice 不在 catalog → None；都满足才返回 tuple。"""
+
+    class _CM:
+        def get_core_config(self):
+            return {"CORE_API_KEY": "synthetic-key"}
+
+    cm = _CM()
+
+    # voice 不在 catalog
+    assert get_native_tts_worker("__test_synth__", cm, "not-a-voice") is None
+    # 还没注册 resolver
+    assert get_native_tts_worker("__test_synth__", cm, "Alpha") is None
+
+    sentinel_worker = object()
+
+    def _resolver(cm):
+        return sentinel_worker, cm.get_core_config().get("CORE_API_KEY", "")
+
+    register_tts_worker_resolver("__test_synth__", _resolver)
+    result = get_native_tts_worker("__test_synth__", cm, "Alpha")
+    assert result == (sentinel_worker, "synthetic-key", "__test_synth__")
+
+    # core_api_type 不匹配 provider → None（即使 voice 同名）
+    assert get_native_tts_worker("nonexistent", cm, "Alpha") is None
+
+
+def test_get_provider_returns_none_for_falsy_key():
+    assert get_provider(None) is None
+    assert get_provider("") is None
+    assert get_provider("__test_synth__") is _SYNTHETIC_PROVIDER

--- a/tests/unit/test_native_voice_registry.py
+++ b/tests/unit/test_native_voice_registry.py
@@ -86,6 +86,25 @@ def test_resolve_for_routing_unknown_core_returns_no_native():
     assert voice == "Alpha"
 
 
+def test_resolve_for_routing_unrecognized_voice_preserves_original_input():
+    """provider 命中但 voice 不在 catalog 时返回原始输入（strip 后），
+    与 unknown-core 分支对偶；不能把用户输入悄悄替换成 default_voice，否则
+    将来 caller 想在 use_native=False 分支用返回值时会被误导喵。"""
+    voice, use_native = resolve_native_voice_for_routing(
+        "__test_synth__",
+        "  my_custom_clone  ",
+        None,
+    )
+    assert (voice, use_native) == ("my_custom_clone", False)
+
+
+def test_resolve_for_routing_empty_input_preserves_emptiness():
+    voice, use_native = resolve_native_voice_for_routing("__test_synth__", "", None)
+    assert (voice, use_native) == ("", False)
+    voice, use_native = resolve_native_voice_for_routing("__test_synth__", None, None)
+    assert (voice, use_native) == ("", False)
+
+
 def test_resolve_for_routing_collision_disables_native():
     """同名克隆 voice 应该把 native routing 让给 custom TTS。"""
     stored = {"alpha"}

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -33,7 +33,7 @@ from utils.api_config_loader import (
 )
 from utils.custom_tts_adapter import check_custom_tts_voice_allowed
 from utils.file_utils import atomic_write_json
-import utils.gemini_tts_voices  # noqa: F401  — registers Gemini provider into native_voice_registry
+from utils import gemini_tts_voices  # noqa: F401  — import for side effect: registers Gemini provider into native_voice_registry
 from utils.logger_config import get_module_logger
 from utils.native_voice_registry import (
     get_active_realtime_native_provider,

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -33,7 +33,6 @@ from utils.api_config_loader import (
 )
 from utils.custom_tts_adapter import check_custom_tts_voice_allowed
 from utils.file_utils import atomic_write_json
-from utils import gemini_tts_voices  # noqa: F401  — import for side effect: registers Gemini provider into native_voice_registry
 from utils.logger_config import get_module_logger
 from utils.native_voice_registry import (
     get_active_realtime_native_provider,

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -33,8 +33,12 @@ from utils.api_config_loader import (
 )
 from utils.custom_tts_adapter import check_custom_tts_voice_allowed
 from utils.file_utils import atomic_write_json
-from utils.gemini_tts_voices import is_gemini_tts_voice
+import utils.gemini_tts_voices  # noqa: F401  — registers Gemini provider into native_voice_registry
 from utils.logger_config import get_module_logger
+from utils.native_voice_registry import (
+    get_active_realtime_native_provider,
+    is_native_voice,
+)
 from utils.persona_presets import PERSONA_OVERRIDE_FIELDS
 
 # Workshop配置相关常量 - 将在ConfigManager实例化时使用self.workshop_dir
@@ -2342,7 +2346,8 @@ class ConfigManager:
         if voice_id in voices:
             return True
 
-        if self.is_gemini_realtime_api_active() and is_gemini_tts_voice(voice_id):
+        active_native_provider = get_active_realtime_native_provider(self)
+        if active_native_provider and is_native_voice(voice_id, active_native_provider):
             return True
 
         # 免费预设音色允许豁免保存校验，运行时再由 core.py 按当前线路动态判断可用性
@@ -2367,7 +2372,8 @@ class ConfigManager:
         if voice_id in voices:
             return True
 
-        if self.is_gemini_realtime_api_active() and is_gemini_tts_voice(voice_id):
+        active_native_provider = get_active_realtime_native_provider(self)
+        if active_native_provider and is_native_voice(voice_id, active_native_provider):
             return True
 
         from utils.api_config_loader import get_free_voices
@@ -2376,14 +2382,6 @@ class ConfigManager:
             return True
 
         return False
-
-    def is_gemini_realtime_api_active(self) -> bool:
-        """Return True when the active realtime provider can accept Gemini native voices."""
-        try:
-            realtime_config = self.get_model_api_config('realtime')
-        except Exception:
-            return self.get_core_config().get('CORE_API_TYPE') == 'gemini'
-        return realtime_config.get('api_type') == 'gemini'
 
     def cleanup_invalid_voice_ids(self):
         """清理 characters.json 中无效的 voice_id。

--- a/utils/gemini_tts_voices.py
+++ b/utils/gemini_tts_voices.py
@@ -1,9 +1,19 @@
-"""Gemini TTS voice catalog shared by validation, UI, and synthesis.
+"""Gemini TTS adapter: catalog metadata + thin wrappers for wire-format paths.
+
+The cross-cutting decision logic (catalog membership, routing, UI catalog,
+realtime active-provider lookup, worker dispatch) lives in
+`utils.native_voice_registry`. This module just wires Gemini into that
+registry and keeps a couple of short aliases for code that's already
+Gemini-bound by virtue of speaking Gemini's wire format (the
+`gemini_tts_worker` HTTP call and the Gemini Live `speech_config` setup).
 
 Voice list reference: https://ai.google.dev/gemini-api/docs/speech-generation
 """
 
-from collections.abc import Callable
+from utils.native_voice_registry import (
+    NativeVoiceProvider,
+    register_provider,
+)
 
 GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 GEMINI_TTS_DEFAULT_VOICE = "Leda"
@@ -42,11 +52,7 @@ GEMINI_TTS_VOICE_GENDERS: dict[str, str] = {
     "Zubenelgenubi": "Male",
 }
 
-_GEMINI_TTS_VOICE_LOOKUP = {
-    voice_name.casefold(): voice_name for voice_name in GEMINI_TTS_VOICE_GENDERS
-}
-
-_GEMINI_TTS_VOICE_ALIASES = {
+_GEMINI_TTS_VOICE_ALIASES: dict[str, str] = {
     "male": GEMINI_TTS_DEFAULT_MALE_VOICE,
     "man": GEMINI_TTS_DEFAULT_MALE_VOICE,
     "masculine": GEMINI_TTS_DEFAULT_MALE_VOICE,
@@ -61,67 +67,23 @@ _GEMINI_TTS_VOICE_ALIASES = {
     "中文女": GEMINI_TTS_DEFAULT_VOICE,
 }
 
+GEMINI_PROVIDER = NativeVoiceProvider(
+    key="gemini",
+    catalog=GEMINI_TTS_VOICE_GENDERS,
+    aliases=_GEMINI_TTS_VOICE_ALIASES,
+    default_voice=GEMINI_TTS_DEFAULT_VOICE,
+    default_male_voice=GEMINI_TTS_DEFAULT_MALE_VOICE,
+    catalog_prefix="Gemini",
+)
+
+register_provider(GEMINI_PROVIDER)
+
 
 def normalize_gemini_tts_voice(voice_id: str | None) -> tuple[str, bool]:
-    """Return a supported Gemini voice and whether the input was recognized.
-
-    Empty / whitespace input is treated as unrecognized so callers can tell
-    "user explicitly chose a Gemini voice" apart from "we picked the default".
-    """
-    normalized = (voice_id or "").strip()
-    if not normalized:
-        return GEMINI_TTS_DEFAULT_VOICE, False
-
-    exact_match = _GEMINI_TTS_VOICE_LOOKUP.get(normalized.casefold())
-    if exact_match:
-        return exact_match, True
-
-    alias_match = _GEMINI_TTS_VOICE_ALIASES.get(normalized.casefold())
-    if alias_match:
-        return alias_match, True
-
-    return GEMINI_TTS_DEFAULT_VOICE, False
+    """Wire-format helper for Gemini-bound code paths (gemini_tts_worker,
+    omni_realtime_client). Cross-cutting code should go through the registry."""
+    return GEMINI_PROVIDER.normalize(voice_id)
 
 
 def is_gemini_tts_voice(voice_id: str | None) -> bool:
-    """Return True when the voice is a Gemini TTS voice or supported alias."""
-    return normalize_gemini_tts_voice(voice_id)[1]
-
-
-def resolve_gemini_native_voice_for_routing(
-    core_api_type: str | None,
-    voice_id: str | None,
-    voice_id_exists: Callable[[str], bool] | None = None,
-) -> tuple[str, bool]:
-    """Return the Gemini Live voice and whether it should use native routing.
-
-    A user-cloned voice with the same raw or canonical voice id wins over the
-    Gemini built-in voice, so the caller can keep custom TTS routing intact.
-    """
-    normalized_voice, recognized = normalize_gemini_tts_voice(voice_id)
-    if core_api_type != "gemini" or not recognized:
-        return normalized_voice, False
-
-    if voice_id_exists is None:
-        return normalized_voice, True
-
-    candidates = {voice_id, normalized_voice}
-    has_custom_collision = any(
-        voice_id_exists(candidate)
-        for candidate in candidates
-        if candidate
-    )
-    return normalized_voice, not has_custom_collision
-
-
-def get_gemini_tts_voices() -> dict[str, dict[str, str | bool]]:
-    """Return Gemini voices in the shape expected by the character UI."""
-    return {
-        voice_name: {
-            "prefix": f"Gemini {voice_name} ({gender})",
-            "provider": "gemini",
-            "gender": gender,
-            "builtin": True,
-        }
-        for voice_name, gender in GEMINI_TTS_VOICE_GENDERS.items()
-    }
+    return GEMINI_PROVIDER.is_voice(voice_id)

--- a/utils/native_voice_registry.py
+++ b/utils/native_voice_registry.py
@@ -216,6 +216,32 @@ def get_active_realtime_native_provider(cm: "ConfigManager") -> str | None:
     return api_type if api_type in _PROVIDERS else None
 
 
+_BUILTIN_PROVIDER_MODULES: tuple[str, ...] = (
+    "utils.gemini_tts_voices",
+)
+
+
+def ensure_builtin_native_voice_providers_loaded() -> None:
+    """Force-import built-in provider adapters so their `register_provider`
+    side effects fire before any registry query.
+
+    Called once when this module is imported (see bottom of file). The reason
+    auto-bootstrap lives here, not in cross-cutting callers: a callsite that
+    runs before any TTS/realtime client has imported a provider module would
+    otherwise query an empty registry, and the failure mode (silent
+    fall-through to external TTS) is non-obvious.
+
+    To add a new built-in provider: write the adapter module (it must call
+    `register_provider(...)` at import time) and append its dotted name to
+    `_BUILTIN_PROVIDER_MODULES`. No edits in `config_manager` / `core` /
+    `characters_router` / `tts_client` are required for the metadata side.
+    """
+    import importlib
+
+    for module_name in _BUILTIN_PROVIDER_MODULES:
+        importlib.import_module(module_name)
+
+
 def get_native_tts_worker(
     core_api_type: str | None,
     cm: "ConfigManager",
@@ -240,3 +266,14 @@ def get_native_tts_worker(
         return None
     worker, api_key = resolver(cm)
     return worker, api_key, core_api_type
+
+
+# Auto-bootstrap on module import: any consumer of this registry gets a
+# populated provider list without each cross-cutting file having to remember a
+# `from utils import gemini_tts_voices  # noqa: F401` side-effect import.
+# Trades a one-line coupling (registry knows the dotted module names of its
+# built-in providers via `_BUILTIN_PROVIDER_MODULES`) for "no caller can forget
+# to bootstrap." Adapter modules import this registry to call
+# `register_provider`, so by the time we reach this line the registry's public
+# API is fully defined and the circular import resolves cleanly.
+ensure_builtin_native_voice_providers_loaded()

--- a/utils/native_voice_registry.py
+++ b/utils/native_voice_registry.py
@@ -96,14 +96,25 @@ class NativeVoiceProvider:
         voice_id: str | None,
         voice_id_exists: VoiceIdExists | None = None,
     ) -> tuple[str, bool]:
-        """Return (canonical_voice, use_native).
+        """Return (voice, use_native).
 
-        A user-cloned voice with the same raw or canonical voice id wins over
-        the built-in voice, so the caller keeps custom TTS routing intact.
+        When the input is not in this provider's catalog, the returned
+        `voice` is the caller's stripped input verbatim — symmetric with
+        the module-level `resolve_native_voice_for_routing` helper (which
+        returns the input as-is when no native provider matches the
+        `core_api_type`). That keeps the "use_native=False" contract
+        consistent: callers that inspect `voice` in the False branch see
+        the original id, not a fallback default they never asked for.
+
+        Collision branch behaves differently on purpose: when the input
+        canonicalizes to a voice the user has cloned, we return the
+        canonical name with use_native=False, so callers can route to that
+        clone by canonical id (e.g. user typed alias "中文男", clone is
+        stored as "Puck" — caller wants "Puck", not "中文男").
         """
         normalized_voice, recognized = self.normalize(voice_id)
         if not recognized:
-            return normalized_voice, False
+            return (voice_id or "").strip(), False
 
         if voice_id_exists is None:
             return normalized_voice, True

--- a/utils/native_voice_registry.py
+++ b/utils/native_voice_registry.py
@@ -1,0 +1,242 @@
+"""Provider-agnostic registry for core API native voice catalogs.
+
+Each `core_api_type` that ships built-in TTS voices (e.g. Gemini's Puck/Leda,
+future OpenAI/Qwen native voices) registers a `NativeVoiceProvider` here.
+Cross-cutting code (config validation, character UI, TTS worker dispatch,
+realtime voice routing) consults the registry instead of hard-coding
+`if core_api_type == 'gemini'` branches, so adding a second provider is one
+adapter file plus one worker registration — not edits in five places.
+
+Two-phase registration avoids circular imports:
+  1. The provider metadata module (e.g. `utils/gemini_tts_voices.py`) creates
+     and registers a `NativeVoiceProvider` at import time — pure data.
+  2. The TTS worker module (`main_logic/tts_client.py`) registers the worker
+     callable + api-key resolver after defining the worker, since the worker
+     pulls in heavy deps (httpx, soxr, etc.) the metadata module must not.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from utils.config_manager import ConfigManager
+
+
+VoiceIdExists = Callable[[str], bool]
+TTSWorkerResolver = Callable[["ConfigManager"], "tuple[Callable[..., Any], str]"]
+
+
+@dataclass(frozen=True)
+class NativeVoiceProvider:
+    """Metadata for one core API's built-in TTS voice catalog.
+
+    `key` matches the `core_api_type` / realtime `api_type` string used
+    elsewhere in the codebase (e.g. "gemini"). `catalog` maps canonical voice
+    names (case-sensitive as the upstream API expects) to a gender label;
+    `aliases` maps casefolded user-friendly inputs (e.g. "中文男", "female")
+    to canonical voice names so users can type either form.
+    """
+
+    key: str
+    catalog: Mapping[str, str]
+    aliases: Mapping[str, str]
+    default_voice: str
+    default_male_voice: str
+    catalog_prefix: str
+    _voice_lookup: dict[str, str] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_voice_lookup",
+            {name.casefold(): name for name in self.catalog},
+        )
+
+    def normalize(self, voice_id: str | None) -> tuple[str, bool]:
+        """Return (canonical_voice_name, recognized).
+
+        Empty / whitespace input is treated as unrecognized so callers can
+        tell "user explicitly chose a native voice" apart from "we picked the
+        default."
+        """
+        normalized = (voice_id or "").strip()
+        if not normalized:
+            return self.default_voice, False
+
+        exact = self._voice_lookup.get(normalized.casefold())
+        if exact:
+            return exact, True
+
+        alias = self.aliases.get(normalized.casefold())
+        if alias:
+            return alias, True
+
+        return self.default_voice, False
+
+    def is_voice(self, voice_id: str | None) -> bool:
+        return self.normalize(voice_id)[1]
+
+    def voice_catalog_for_ui(self) -> dict[str, dict[str, str | bool]]:
+        """Return the voice list in the shape the character UI expects."""
+        return {
+            voice_name: {
+                "prefix": f"{self.catalog_prefix} {voice_name} ({gender})",
+                "provider": self.key,
+                "gender": gender,
+                "builtin": True,
+            }
+            for voice_name, gender in self.catalog.items()
+        }
+
+    def resolve_for_routing(
+        self,
+        voice_id: str | None,
+        voice_id_exists: VoiceIdExists | None = None,
+    ) -> tuple[str, bool]:
+        """Return (canonical_voice, use_native).
+
+        A user-cloned voice with the same raw or canonical voice id wins over
+        the built-in voice, so the caller keeps custom TTS routing intact.
+        """
+        normalized_voice, recognized = self.normalize(voice_id)
+        if not recognized:
+            return normalized_voice, False
+
+        if voice_id_exists is None:
+            return normalized_voice, True
+
+        candidates = {voice_id, normalized_voice}
+        has_collision = any(
+            voice_id_exists(candidate)
+            for candidate in candidates
+            if candidate
+        )
+        return normalized_voice, not has_collision
+
+
+_PROVIDERS: dict[str, NativeVoiceProvider] = {}
+_TTS_WORKER_RESOLVERS: dict[str, TTSWorkerResolver] = {}
+
+
+def register_provider(provider: NativeVoiceProvider) -> None:
+    """Register a provider's voice catalog. Idempotent: re-registering the
+    same key replaces the previous entry (useful for tests / hot-reload)."""
+    _PROVIDERS[provider.key] = provider
+
+
+def register_tts_worker_resolver(
+    provider_key: str,
+    resolver: TTSWorkerResolver,
+) -> None:
+    """Register the TTS worker callable + api-key resolver for a provider.
+
+    The resolver is invoked with the active ConfigManager and returns
+    (worker_callable, api_key) — `get_native_tts_worker` packages this with
+    the provider key for the dispatcher.
+    """
+    _TTS_WORKER_RESOLVERS[provider_key] = resolver
+
+
+def get_provider(key: str | None) -> NativeVoiceProvider | None:
+    if not key:
+        return None
+    return _PROVIDERS.get(key)
+
+
+def list_providers() -> list[str]:
+    return list(_PROVIDERS.keys())
+
+
+def is_native_voice(
+    voice_id: str | None,
+    provider_key: str | None = None,
+) -> bool:
+    """Check catalog membership.
+
+    With `provider_key`, check that provider only. Without, check whether the
+    voice belongs to *any* registered provider (used by validators that don't
+    know which provider the voice came from).
+    """
+    if provider_key is not None:
+        provider = _PROVIDERS.get(provider_key)
+        return bool(provider and provider.is_voice(voice_id))
+    return any(provider.is_voice(voice_id) for provider in _PROVIDERS.values())
+
+
+def normalize_native_voice(
+    provider_key: str,
+    voice_id: str | None,
+) -> tuple[str, bool]:
+    """Normalize through a specific provider. Raises KeyError if unknown."""
+    return _PROVIDERS[provider_key].normalize(voice_id)
+
+
+def get_native_voice_catalog_for_ui(
+    provider_key: str | None,
+) -> dict[str, dict[str, str | bool]] | None:
+    provider = get_provider(provider_key)
+    if provider is None:
+        return None
+    return provider.voice_catalog_for_ui()
+
+
+def resolve_native_voice_for_routing(
+    core_api_type: str | None,
+    voice_id: str | None,
+    voice_id_exists: VoiceIdExists | None = None,
+) -> tuple[str, bool]:
+    """Look up provider by core_api_type, then delegate to its resolver.
+
+    Returns (voice_or_input, use_native). When core_api_type isn't a
+    registered native-voice provider, returns the stripped input verbatim
+    with use_native=False so callers fall through to custom TTS routing.
+    """
+    provider = get_provider(core_api_type)
+    if provider is None:
+        return (voice_id or "").strip(), False
+    return provider.resolve_for_routing(voice_id, voice_id_exists)
+
+
+def get_active_realtime_native_provider(cm: "ConfigManager") -> str | None:
+    """Return provider key when the active realtime API ships native voices.
+
+    Falls back to core_api_type when realtime config is unavailable, matching
+    the behavior of the previous `is_gemini_realtime_api_active` helper.
+    Returns None when neither realtime nor core api type is a registered
+    native-voice provider.
+    """
+    try:
+        realtime_config = cm.get_model_api_config('realtime')
+        api_type = realtime_config.get('api_type')
+    except Exception:
+        api_type = (cm.get_core_config() or {}).get('CORE_API_TYPE')
+    return api_type if api_type in _PROVIDERS else None
+
+
+def get_native_tts_worker(
+    core_api_type: str | None,
+    cm: "ConfigManager",
+    voice_id: str | None,
+) -> tuple[Callable[..., Any], str, str] | None:
+    """Resolve (worker, api_key, provider_key) when the user has selected a
+    native voice for an active native-voice provider, else None.
+
+    Used by `tts_client.get_tts_worker` to short-circuit the worker dispatch
+    when the user explicitly picked a built-in voice (e.g. Gemini "Puck"):
+    we must use the provider's native worker even if no voice clone exists,
+    otherwise the fallthrough would route to GPT-SoVITS or local CosyVoice
+    with the wrong api key.
+    """
+    if not core_api_type:
+        return None
+    provider = _PROVIDERS.get(core_api_type)
+    if provider is None or not provider.is_voice(voice_id):
+        return None
+    resolver = _TTS_WORKER_RESOLVERS.get(core_api_type)
+    if resolver is None:
+        return None
+    worker, api_key = resolver(cm)
+    return worker, api_key, core_api_type


### PR DESCRIPTION
## Summary

- 抽象 core API native voice 决策点（catalog/validator/UI/worker dispatch/realtime routing）到 `utils/native_voice_registry.py`，4 个 `if provider == 'gemini'` 分支统一收口
- `utils/gemini_tts_voices.py` 瘦身成 Gemini adapter（保留 `GEMINI_TTS_VOICE_GENDERS` / `normalize_gemini_tts_voice` / `is_gemini_tts_voice` 给 wire-format 路径），import 时把 `GEMINI_PROVIDER` 注册进 registry
- 两阶段注册避免循环依赖：metadata 在 `gemini_tts_voices.py` 注册（轻），worker callable 在 `tts_client.py` 定义后注册（重依赖）
- 删除 `is_gemini_realtime_api_active` / `resolve_gemini_native_voice_for_routing` / `get_gemini_tts_voices` 三个 provider-name 绑死的辅助；callers 改用 `get_active_realtime_native_provider` / `resolve_native_voice_for_routing` / `get_native_voice_catalog_for_ui`
- `tts_client.get_tts_worker` 的 Gemini 短路改用 `get_native_tts_worker(core_api_type, cm, voice_id)`，api_key resolver 由 provider 自己注册（Gemini 走 `CORE_API_KEY`）
- core.py log/docstring 从 `Gemini 原生音色 ...` 改成 `{core_api_type} 原生音色 ...`，generic 化

## 后续接入第二个 native voice provider 的成本

新增 `utils/openai_tts_voices.py`（catalog + `register_provider`）+ 在 `tts_client.py` 加一行 `register_tts_worker_resolver('openai', ...)`。`config_manager` / `characters_router` / `core.py` / `tts_client.get_tts_worker` 这 4 个 cross-cutting site 不再需要动。

## Test plan

- [x] `tests/unit/test_native_voice_registry.py`（新增，13 用例）覆盖 registry 不变量：合成 provider 隔离 Gemini-specific 行为，验证 catalog 查询、unknown provider raises、collision-aware routing、realtime → core fallback、worker resolver 顺序约束
- [x] `tests/unit/test_gemini_tts_voices.py` 改成验证 Gemini adapter 注册结果 + UI shape（30 用例）
- [x] `tests/unit/test_gemini_realtime_voice_routing.py` fake CM 改成 `get_model_api_config` + `get_core_config` 形状（8 用例）
- [x] `uv run pytest tests/unit -k "voice or tts or config_manager or character"` → 443 passed / 3 skipped 无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 引入通用的原生 TTS 语音注册表：界面可显示活动提供商的语音目录，核心可基于注册表选取原生语音与对应 worker。

* **重构**
  * 将原生语音识别、路由与选择逻辑从单一提供商迁移到注册表驱动的跨提供商流程；配置校验与实时提供商选择已通用化。

* **测试**
  * 扩展/新增单元测试，覆盖注册表加载、目录格式、别名与冲突处理、路由与 worker 解析。

* **文档**
  * 新增指南，说明如何为新提供商注册原生语音及相关约定。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1262)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->