### PR TITLE
收紧免费预设音色判断逻辑，仅允许 get_free_voices() 运行时映射中的 voice_id 被识别为免费音色，移除 voice…

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -250,17 +250,16 @@ def _get_voice_preview_language(request: Request, language: object = None, i18n_
 
 
 def _is_free_preset_voice_id(voice_id: object) -> bool:
-    """判断是否为免费预设音色，兼容配置映射缺失时的 voice-tone 前缀。"""
+    """判断是否为运行时免费预设音色。"""
     normalized = str(voice_id or "").strip()
     if not normalized:
         return False
     try:
         from utils.api_config_loader import get_free_voices
-        if normalized in set((get_free_voices() or {}).values()):
-            return True
+        free_voice_ids = set((get_free_voices() or {}).values())
     except Exception:
-        pass
-    return normalized.startswith("voice-tone-")
+        return False
+    return normalized in free_voice_ids
 
 
 def _read_wav_payload(audio_bytes: bytes) -> tuple[bytes, int, int, int]:


### PR DESCRIPTION
…-tone- 前缀兜底，避免非免费供应商音色被误判

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了免费预设语音的识别机制，采用更稳定可靠的方式确定免费语音身份。此次更新提高了语音资源分类的准确性和系统异常处理能力，用户将获得更加一致和可靠的免费语音体验。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->