### PR TITLE
修复 OmniOfflineClient 中的重试逻辑，确保在关闭状态下不再重试，并更新游戏路由器以替换占位符，避免 llm_prompt_leak_check 警告

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1155,11 +1155,15 @@ class OmniOfflineClient:
                 # 断连 / session 熔断），就不再重试 —— 否则下面的 reroll while
                 # 会先把 _is_responding 重置回 True 然后对 None 调 .astream，
                 # 触发 NoneType.astream AttributeError。
+                # 同样若 cancel_response() / handle_interruption() 在 retry sleep
+                # 期间把 _is_responding 翻成 False（用户主动打断），也不该再
+                # 启动新一轮 attempt —— reroll while 会无条件 reset 回 True，
+                # 默默吞掉用户的取消意图。和 prompt_ephemeral 的守卫保持一致。
                 # 用 hasattr 守卫：单元测试用 __new__ 绕过 __init__ 不会设这个
                 # 属性，但真实代码 __init__ 必设；区分"未初始化（测试桩）"和
                 # "已关闭（生产）"两种情况。
-                if hasattr(self, "llm") and self.llm is None:
-                    logger.info("OmniOfflineClient.stream_text: client 已被 close 释放，终止 retry")
+                if (hasattr(self, "llm") and self.llm is None) or not self._is_responding:
+                    logger.info("OmniOfflineClient.stream_text: client 已 close 或响应已被取消，终止 retry")
                     break
                 try:
                     assistant_message = ""

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1150,6 +1150,17 @@ class OmniOfflineClient:
                     status_reported = True
                 return
             for attempt in range(max_retries):
+                # close() 是唯一会把 self.llm 设为 None 的路径。它若在前一次
+                # APIConnectionError 后的 retry sleep 期间触发（用户切模式 /
+                # 断连 / session 熔断），就不再重试 —— 否则下面的 reroll while
+                # 会先把 _is_responding 重置回 True 然后对 None 调 .astream，
+                # 触发 NoneType.astream AttributeError。
+                # 用 hasattr 守卫：单元测试用 __new__ 绕过 __init__ 不会设这个
+                # 属性，但真实代码 __init__ 必设；区分"未初始化（测试桩）"和
+                # "已关闭（生产）"两种情况。
+                if hasattr(self, "llm") and self.llm is None:
+                    logger.info("OmniOfflineClient.stream_text: client 已被 close 释放，终止 retry")
+                    break
                 try:
                     assistant_message = ""
                     assistant_message_total = ""
@@ -1802,6 +1813,15 @@ class OmniOfflineClient:
                 prefix_buffer = ""
                 prefix_checked = not bool(self._prefix_buffer_size)
                 emitted_any = False  # 本 attempt 是否已经向前端 emit 过文本
+
+                # close() 是唯一会把 self.llm 设为 None 的路径。它若在前一次
+                # APIConnectionError 后的 retry sleep 期间触发（用户切模式 /
+                # 断连 / session 熔断），不再做这次 attempt —— 否则会对 None
+                # 调 .astream 触发 AttributeError，且就算重试 client 也已不在。
+                # 用 hasattr 守卫：单元测试用 __new__ 绕过 __init__ 不会设这个
+                # 属性，但真实代码 __init__ 必设。
+                if (hasattr(self, "llm") and self.llm is None) or not self._is_responding:
+                    break
 
                 try:
                     # 主动搭话同样走 tool-aware streaming —— agent 注入的 stage

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1164,6 +1164,10 @@ class OmniOfflineClient:
                 # "已关闭（生产）"两种情况。
                 if (hasattr(self, "llm") and self.llm is None) or not self._is_responding:
                     logger.info("OmniOfflineClient.stream_text: client 已 close 或响应已被取消，终止 retry")
+                    # 标记 status_reported 抑制 finally 的 LLM_NO_RESPONSE 兜底：
+                    # 这是用户主动 cancel / close，不是 LLM 故障，前端不该看到
+                    # 红条错误。这里没有 status 要发，仅占位让 finally 跳过。
+                    status_reported = True
                     break
                 try:
                     assistant_message = ""

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1097,8 +1097,15 @@ def _get_character_info(lanlan_name: str | None = None) -> Dict[str, Any]:
     master_name = master_data.get('档案名', '玩家')
 
     # 获取角色人格 prompt
+    # Why: lanlan_prompt_map 存的是带 {LANLAN_NAME} / {MASTER_NAME} 占位符的原始
+    # 模板（普通会话路径在 main_server 写入 SessionManager 时才替换）。Game 流程
+    # 直接从 config_manager 拿，必须在源头补这一步替换，否则下游 _build_game_prompt
+    # / quick_lines / pregame context AI 拼出来的 prompt 会含字面占位符，触发
+    # llm_prompt_leak_check 警告并污染人设。
     _, _, _, _, _, lanlan_prompt_map, _, _, _ = config_manager.get_character_data()
-    lanlan_prompt = lanlan_prompt_map.get(current_name, '')
+    lanlan_prompt = lanlan_prompt_map.get(current_name, '') \
+        .replace('{LANLAN_NAME}', current_name) \
+        .replace('{MASTER_NAME}', master_name)
 
     # 获取对话模型配置
     conversation_config = config_manager.get_model_api_config('conversation')

--- a/main_routers/game_router.py
+++ b/main_routers/game_router.py
@@ -1094,7 +1094,10 @@ def _get_character_info(lanlan_name: str | None = None) -> Dict[str, Any]:
     current_name = str(lanlan_name or characters.get('当前猫娘', '') or '').strip()
 
     master_data = characters.get('主人', {})
-    master_name = master_data.get('档案名', '玩家')
+    # 显式 str 归一化：'档案名' 来自用户编辑的角色配置 JSON，可能是 None / 数字
+    # / 其他非字符串。下面 .replace 的第二个参数必须是 str，且 master_name 还会
+    # 直接进入返回 dict 给下游消费，统一在源头收口。
+    master_name = str(master_data.get('档案名', '玩家') or '玩家')
 
     # 获取角色人格 prompt
     # Why: lanlan_prompt_map 存的是带 {LANLAN_NAME} / {MASTER_NAME} 占位符的原始
@@ -1102,8 +1105,9 @@ def _get_character_info(lanlan_name: str | None = None) -> Dict[str, Any]:
     # 直接从 config_manager 拿，必须在源头补这一步替换，否则下游 _build_game_prompt
     # / quick_lines / pregame context AI 拼出来的 prompt 会含字面占位符，触发
     # llm_prompt_leak_check 警告并污染人设。
+    # 模板本身也用 str() 兜底：极端情况下 lanlan_prompt_map 里的值可能是 None。
     _, _, _, _, _, lanlan_prompt_map, _, _, _ = config_manager.get_character_data()
-    lanlan_prompt = lanlan_prompt_map.get(current_name, '') \
+    lanlan_prompt = str(lanlan_prompt_map.get(current_name, '') or '') \
         .replace('{LANLAN_NAME}', current_name) \
         .replace('{MASTER_NAME}', master_name)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了在应用关闭或会话被取消时的稳定性：在每次重试前检测并停止无效的流式调用，避免不必要的重试与异常。

* **功能改进**
  * 角色对话模板中的名称占位符现在会在展示前被动态替换为当前角色名与玩家名，确保对话内容显示正确。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1271)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->