### PR TITLE
[codex] Suppress cancelled agent task redispatch

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -327,6 +327,13 @@ class AgentTaskTracker:
                 has_later_user_turn = latest_user_ts > cancelled_at
             else:
                 trigger_fp = record.get("trigger_user_fingerprint")
+                if not trigger_fp:
+                    # Async cancellation paths can add a second cancelled
+                    # record without trigger metadata. In timestamp-less
+                    # payloads, that record cannot prove the user did not ask
+                    # again later, so keep looking for an older authoritative
+                    # cancel record instead of blocking the retry.
+                    continue
                 has_later_user_turn = bool(
                     trigger_fp
                     and latest_user_fingerprint

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -19,6 +19,7 @@ import uuid
 import logging
 import time
 import hashlib
+import re
 from typing import Dict, Any, Optional, ClassVar, List
 from datetime import datetime, timezone
 import httpx
@@ -165,6 +166,39 @@ _task_registry_last_cleanup: float = 0.0
 # ---------------------------------------------------------------------------
 from config import AGENT_TASK_TRACKER_MAX_RECORDS as TASK_TRACKER_MAX_RECORDS
 TASK_TRACKER_TTL: float = 600.0     # 记录保留时长（秒）
+CANCELLED_TASK_BLACKLIST_TTL: float = TASK_TRACKER_TTL
+
+
+def _task_blacklist_desc_keys(desc: Any) -> set[str]:
+    text = str(desc or "").strip()
+    if not text:
+        return set()
+
+    def _norm(value: str) -> str:
+        return re.sub(r"\s+", "", value.casefold())
+
+    keys = {_norm(text)}
+    # User-plugin tracker descriptions include "plugin.entry: task".
+    # Keep a suffix key so a later analyzer result with only the natural
+    # language task text still hits the same cancelled task.
+    if ":" in text:
+        keys.add(_norm(text.split(":", 1)[1]))
+    return {key for key in keys if key}
+
+
+def _task_desc_matches_blacklist(candidate: Any, cancelled_desc: Any) -> bool:
+    candidate_keys = _task_blacklist_desc_keys(candidate)
+    cancelled_keys = _task_blacklist_desc_keys(cancelled_desc)
+    if not candidate_keys or not cancelled_keys:
+        return False
+    for left in candidate_keys:
+        for right in cancelled_keys:
+            if left == right:
+                return True
+            shorter, longer = (left, right) if len(left) <= len(right) else (right, left)
+            if len(shorter) >= 16 and shorter in longer:
+                return True
+    return False
 
 
 class AgentTaskTracker:
@@ -177,6 +211,8 @@ class AgentTaskTracker:
       - desc: 任务简述
       - detail: 可选的结果摘要
       - task_id: 对应 task_registry 的 id
+      - trigger_user_fingerprint / trigger_user_ts: 触发该任务的用户 turn，
+        用于判断取消之后是否已有新的用户消息
 
     当 analyzer 收到 messages 时，调用 inject() 方法把这些记录以
     role=system 消息的形式插入到 messages 副本中（按时间序），使 LLM
@@ -222,6 +258,8 @@ class AgentTaskTracker:
         detail: str = "",
         success: bool = True,
         cancelled: bool = False,
+        trigger_user_fingerprint: Optional[str] = None,
+        trigger_user_ts: Optional[float] = None,
     ) -> None:
         key = _normalize_lanlan_key(lanlan_name)
         records = self._ensure_key(key)
@@ -240,8 +278,70 @@ class AgentTaskTracker:
             # "tool/task result detail" 200-token group），而不是 char-slice
             "detail": _tt(detail, TASK_DETAIL_MAX_TOKENS) if detail else "",
             "task_id": task_id,
+            "trigger_user_fingerprint": trigger_user_fingerprint,
+            "trigger_user_ts": trigger_user_ts,
         })
         self._trim(records)
+
+    def find_cancelled_blacklist(
+        self,
+        lanlan_name: Optional[str],
+        *,
+        method: str,
+        desc: str,
+        latest_user_fingerprint: Optional[str] = None,
+        latest_user_ts: Optional[float] = None,
+    ) -> Optional[dict]:
+        """Return a matching cancelled task that should suppress redispatch.
+
+        A manual cancel blacklists the same task only until a later user turn
+        exists. Prefer message timestamps when present; when the frontend does
+        not provide them, fall back to the user-turn fingerprint recorded on
+        the cancelled task.
+        """
+        key = _normalize_lanlan_key(lanlan_name)
+        records = self._records.get(key)
+        if not records or not desc:
+            return None
+
+        now = time.time()
+        records[:] = [
+            r for r in records
+            if now - float(r.get("ts") or 0.0) < TASK_TRACKER_TTL
+        ]
+        if not records:
+            return None
+
+        method = str(method or "").strip()
+        for record in reversed(records):
+            if record.get("kind") != "cancelled":
+                continue
+            cancelled_at = float(record.get("ts") or 0.0)
+            if now - cancelled_at >= CANCELLED_TASK_BLACKLIST_TTL:
+                continue
+            if not _task_desc_matches_blacklist(desc, record.get("desc", "")):
+                continue
+
+            has_later_user_turn = False
+            if latest_user_ts is not None:
+                has_later_user_turn = latest_user_ts > cancelled_at
+            else:
+                trigger_fp = record.get("trigger_user_fingerprint")
+                has_later_user_turn = bool(
+                    trigger_fp
+                    and latest_user_fingerprint
+                    and latest_user_fingerprint != trigger_fp
+                )
+            if has_later_user_turn:
+                continue
+
+            if method and record.get("method") != method:
+                logger.info(
+                    "[AgentTaskTracker] Cancel blacklist matched across methods: cancelled=%s new=%s",
+                    record.get("method"), method,
+                )
+            return record
+        return None
 
     def inject(self, messages: list, lanlan_name: Optional[str]) -> list:
         """返回一份新的 messages 列表，其中按时序插入了任务跟踪记录。
@@ -296,7 +396,10 @@ class AgentTaskTracker:
                 if detail:
                     line += f" | result: {detail}"
             elif kind == "cancelled":
-                line = f"[CANCELLED] method={method} | {desc} | DO NOT retry this task unless user explicitly requests again"
+                line = (
+                    f"[CANCELLED] ts={r.get('ts')} method={method} | {desc} | "
+                    "TEMPORARY BLACKLIST: do not retry unless a later user message explicitly asks to redo"
+                )
             else:
                 line = f"[FAILED] method={method} | {desc}"
                 if detail:
@@ -1369,6 +1472,41 @@ def _build_user_turn_fingerprint(messages: Any) -> Optional[str]:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _coerce_message_timestamp(raw_ts: Any) -> Optional[float]:
+    if raw_ts is None:
+        return None
+    if isinstance(raw_ts, (int, float)):
+        ts = float(raw_ts)
+        return ts / 1000.0 if ts > 1_000_000_000_000 else ts
+    text = str(raw_ts).strip()
+    if not text:
+        return None
+    try:
+        ts = float(text)
+        return ts / 1000.0 if ts > 1_000_000_000_000 else ts
+    except ValueError:
+        pass
+    try:
+        normalized = text.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized).timestamp()
+    except ValueError:
+        return None
+
+
+def _latest_user_message_ts(messages: Any) -> Optional[float]:
+    if not isinstance(messages, list):
+        return None
+    for message in reversed(messages):
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        for key in ("timestamp", "ts", "created_at"):
+            ts = _coerce_message_timestamp(message.get(key))
+            if ts is not None:
+                return ts
+        return None
+    return None
+
+
 async def _emit_agent_status_update(lanlan_name: Optional[str] = None) -> None:
     try:
         # 先检查超时的 deferred 任务并发送 task_update 通知
@@ -1493,6 +1631,35 @@ def _get_internal_correction_context(task_info: Dict[str, Any]) -> Optional[Dict
             }
 
     return None
+
+
+def _tracker_desc_for_task_info(task_info: Dict[str, Any]) -> str:
+    task_type = str(task_info.get("type") or "")
+    params = task_info.get("params") if isinstance(task_info.get("params"), dict) else {}
+    if task_type == "user_plugin":
+        plugin_id = str(params.get("plugin_id") or "").strip()
+        entry_id = str(params.get("entry_id") or "").strip()
+        desc = str(params.get("description") or params.get("instruction") or params.get("query") or "").strip()
+        prefix = ".".join(part for part in (plugin_id, entry_id) if part)
+        return f"{prefix}: {desc}" if prefix and desc else (prefix or desc)
+    return str(
+        params.get("description")
+        or params.get("instruction")
+        or params.get("query")
+        or task_info.get("task_description")
+        or ""
+    ).strip()
+
+
+def _tracker_desc_for_result(result: Any) -> str:
+    method = str(getattr(result, "execution_method", "") or "")
+    desc = str(getattr(result, "task_description", "") or "").strip()
+    if method == "user_plugin":
+        plugin_id = str(getattr(result, "tool_name", "") or "").strip()
+        entry_id = str(getattr(result, "entry_id", "") or "").strip()
+        prefix = ".".join(part for part in (plugin_id, entry_id) if part)
+        return f"{prefix}: {desc}" if prefix and desc else (prefix or desc)
+    return desc
 
 
 def _public_task_info(task_info: Dict[str, Any]) -> Dict[str, Any]:
@@ -1752,6 +1919,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
             return
         logger.info("[AgentAnalyze] background analyze start: lanlan=%s messages=%d flags=%s analyzer_enabled=%s",
                     lanlan_name, len(messages), Modules.agent_flags, Modules.analyzer_enabled)
+        trigger_user_fingerprint = _build_user_turn_fingerprint(messages)
+        trigger_user_ts = _latest_user_message_ts(messages)
 
         # 注入任务跟踪记录，让 analyzer 知道哪些任务已经 assign / 完成，避免重复分派
         enriched_messages = _task_tracker.inject(messages, lanlan_name)
@@ -1794,6 +1963,25 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
             getattr(result, "entry_id", None),
             (getattr(result, "reason", "") or "")[:120],
         )
+
+        if result.execution_method in {"computer_use", "browser_use", "user_plugin", "openclaw", "openfang"}:
+            tracker_desc = _tracker_desc_for_result(result)
+            blocked = _task_tracker.find_cancelled_blacklist(
+                lanlan_name,
+                method=result.execution_method,
+                desc=tracker_desc,
+                latest_user_fingerprint=trigger_user_fingerprint,
+                latest_user_ts=trigger_user_ts,
+            )
+            if blocked:
+                logger.info(
+                    "[TaskExecutor] Suppressed redispatch of manually cancelled task: "
+                    "new_method=%s cancelled_task=%s cancelled_method=%s",
+                    result.execution_method,
+                    blocked.get("task_id"),
+                    blocked.get("method"),
+                )
+                return
         
         # 处理 MCP 任务（已在 DirectTaskExecutor 中执行完成）
         if result.execution_method == 'mcp':
@@ -1849,6 +2037,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                     ti = _spawn_task("computer_use", {"instruction": result.task_description, "screenshot": None})
                     ti["lanlan_name"] = lanlan_name
                     ti["session_id"] = cu_session.session_id
+                    ti["_trigger_user_fingerprint"] = trigger_user_fingerprint
+                    ti["_trigger_user_ts"] = trigger_user_ts
                     _set_internal_correction_context(ti, result)
                     _task_tracker.record_assigned(
                         lanlan_name, task_id=ti["id"], method="computer_use",
@@ -1906,6 +2096,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                     "lanlan_name": lanlan_name,
                     "result": None,
                     "error": None,
+                    "_trigger_user_fingerprint": trigger_user_fingerprint,
+                    "_trigger_user_ts": trigger_user_ts,
                 }
                 # 记录任务分派（供后续 analyzer 去重）
                 _task_tracker.record_assigned(
@@ -2273,6 +2465,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                     "conversation_id": conversation_id,
                     "result": None,
                     "error": None,
+                    "_trigger_user_fingerprint": trigger_user_fingerprint,
+                    "_trigger_user_ts": trigger_user_ts,
                 }
                 _task_tracker.record_assigned(
                     lanlan_name, task_id=result.task_id, method="openclaw",
@@ -2473,6 +2667,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                     "session_id": bu_session.session_id,
                     "result": None,
                     "error": None,
+                    "_trigger_user_fingerprint": trigger_user_fingerprint,
+                    "_trigger_user_ts": trigger_user_ts,
                 }
                 _set_internal_correction_context(bu_info, result)
                 Modules.task_registry[bu_task_id] = bu_info
@@ -2640,6 +2836,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                         "session_id": of_session.session_id,
                         "result": None,
                         "error": None,
+                        "_trigger_user_fingerprint": trigger_user_fingerprint,
+                        "_trigger_user_ts": trigger_user_ts,
                     }
                     Modules.task_registry[of_task_id] = of_info
                     _task_tracker.record_assigned(
@@ -3551,6 +3749,18 @@ async def cancel_task(task_id: str):
     # terminal guards).
     info["status"] = "cancelled"
     info["error"] = "Cancelled by user"
+    lanlan_name = info.get("lanlan_name")
+    _task_tracker.record_completed(
+        lanlan_name,
+        task_id=task_id,
+        method=str(task_type or ""),
+        desc=_tracker_desc_for_task_info(info),
+        detail="Cancelled by user",
+        success=False,
+        cancelled=True,
+        trigger_user_fingerprint=info.get("_trigger_user_fingerprint"),
+        trigger_user_ts=info.get("_trigger_user_ts"),
+    )
 
     bg = Modules.task_async_handles.get(task_id)
     if bg and not bg.done():
@@ -3599,7 +3809,6 @@ async def cancel_task(task_id: str):
                 label=f"openclaw:{task_id}",
             )
 
-    lanlan_name = info.get("lanlan_name")
     try:
         await _emit_main_event(
             "task_update", lanlan_name,

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -535,6 +535,17 @@ async def _cancel_openclaw_tasks_for_stop(
         info["error"] = "Cancelled by user"
         info["end_time"] = _now_iso()
         cancelled_task_ids.append(task_id)
+        _task_tracker.record_completed(
+            info.get("lanlan_name"),
+            task_id=task_id,
+            method="openclaw",
+            desc=_tracker_desc_for_task_info(info),
+            detail="Cancelled by user",
+            success=False,
+            cancelled=True,
+            trigger_user_fingerprint=info.get("_trigger_user_fingerprint"),
+            trigger_user_ts=info.get("_trigger_user_ts"),
+        )
 
         # Let the task coroutine emit the cancelled update when it is still
         # alive; only emit here when there is no active background handle.
@@ -2578,6 +2589,8 @@ async def _do_analyze_and_plan(messages: list[dict[str, Any]], lanlan_name: Opti
                             lanlan_name, task_id=result.task_id, method="openclaw",
                             desc=result.task_description or instruction or "",
                             detail=cancel_msg[:TASK_TRACKER_DETAIL_MAX_CHARS], success=False, cancelled=True,
+                            trigger_user_fingerprint=(_reg or {}).get("_trigger_user_fingerprint"),
+                            trigger_user_ts=(_reg or {}).get("_trigger_user_ts"),
                         )
                         try:
                             await _emit_task_result(

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -322,11 +322,14 @@ class AgentTaskTracker:
             if not _task_desc_matches_blacklist(desc, record.get("desc", "")):
                 continue
 
+            trigger_fp = record.get("trigger_user_fingerprint")
             has_later_user_turn = False
             if latest_user_ts is not None:
-                has_later_user_turn = latest_user_ts > cancelled_at
+                if trigger_fp and latest_user_fingerprint == trigger_fp:
+                    has_later_user_turn = False
+                else:
+                    has_later_user_turn = latest_user_ts > cancelled_at
             else:
-                trigger_fp = record.get("trigger_user_fingerprint")
                 if not trigger_fp:
                     # Async cancellation paths can add a second cancelled
                     # record without trigger metadata. In timestamp-less

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1244,6 +1244,80 @@ def test_agent_task_tracker_blocks_cancelled_task_until_later_user_turn():
     ) is None
 
 
+def test_agent_task_tracker_ignores_metadata_less_cancel_in_fingerprint_fallback():
+    source = Path("app/agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wanted = {
+        "_task_blacklist_desc_keys",
+        "_task_desc_matches_blacklist",
+        "AgentTaskTracker",
+    }
+    segments = [
+        ast.get_source_segment(source, node)
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in wanted
+    ]
+    assert len(segments) == len(wanted)
+
+    class _Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+    ns = {
+        "re": __import__("re"),
+        "time": __import__("time"),
+        "Dict": __import__("typing").Dict,
+        "Any": __import__("typing").Any,
+        "Optional": __import__("typing").Optional,
+        "TASK_TRACKER_TTL": 600.0,
+        "CANCELLED_TASK_BLACKLIST_TTL": 600.0,
+        "TASK_TRACKER_MAX_RECORDS": 100,
+        "TASK_DETAIL_MAX_TOKENS": 200,
+        "TASK_TRACKER_INJECT_DETAIL_MAX_CHARS": 200,
+        "_normalize_lanlan_key": lambda name: (name or "").strip() or "__default__",
+        "_tt": lambda text, limit: str(text)[:limit],
+        "logger": _Logger(),
+    }
+    exec("\n\n".join(segments), ns)
+    tracker = ns["AgentTaskTracker"]()
+
+    tracker.record_completed(
+        "lanlan",
+        task_id="cancelled-with-fp",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        detail="Cancelled by user",
+        success=False,
+        cancelled=True,
+        trigger_user_fingerprint="fp-before",
+    )
+    tracker.record_completed(
+        "lanlan",
+        task_id="cancelled-without-fp",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        detail="Task cancelled by user",
+        success=False,
+        cancelled=True,
+    )
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        latest_user_fingerprint="fp-before",
+        latest_user_ts=None,
+    )["task_id"] == "cancelled-with-fp"
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        latest_user_fingerprint="fp-after",
+        latest_user_ts=None,
+    ) is None
+
+
 def test_agent_task_tracker_matches_cancelled_user_plugin_suffix():
     source = Path("app/agent_server.py").read_text(encoding="utf-8")
     tree = ast.parse(source)

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1231,7 +1231,7 @@ def test_agent_task_tracker_blocks_cancelled_task_until_later_user_turn():
         "lanlan",
         method="browser_use",
         desc="打开天气网站并截图",
-        latest_user_fingerprint="fp-before",
+        latest_user_fingerprint="fp-after",
         latest_user_ts=cancelled_at + 1,
     ) is None
 
@@ -1242,6 +1242,65 @@ def test_agent_task_tracker_blocks_cancelled_task_until_later_user_turn():
         latest_user_fingerprint="fp-after",
         latest_user_ts=None,
     ) is None
+
+
+def test_agent_task_tracker_keeps_same_turn_blocked_with_ahead_client_clock():
+    source = Path("app/agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wanted = {
+        "_task_blacklist_desc_keys",
+        "_task_desc_matches_blacklist",
+        "AgentTaskTracker",
+    }
+    segments = [
+        ast.get_source_segment(source, node)
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in wanted
+    ]
+    assert len(segments) == len(wanted)
+
+    class _Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+    ns = {
+        "re": __import__("re"),
+        "time": __import__("time"),
+        "Dict": __import__("typing").Dict,
+        "Any": __import__("typing").Any,
+        "Optional": __import__("typing").Optional,
+        "TASK_TRACKER_TTL": 600.0,
+        "CANCELLED_TASK_BLACKLIST_TTL": 600.0,
+        "TASK_TRACKER_MAX_RECORDS": 100,
+        "TASK_DETAIL_MAX_TOKENS": 200,
+        "TASK_TRACKER_INJECT_DETAIL_MAX_CHARS": 200,
+        "_normalize_lanlan_key": lambda name: (name or "").strip() or "__default__",
+        "_tt": lambda text, limit: str(text)[:limit],
+        "logger": _Logger(),
+    }
+    exec("\n\n".join(segments), ns)
+    tracker = ns["AgentTaskTracker"]()
+
+    tracker.record_completed(
+        "lanlan",
+        task_id="cancelled-1",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        detail="Cancelled by user",
+        success=False,
+        cancelled=True,
+        trigger_user_fingerprint="fp-before",
+        trigger_user_ts=100.0,
+    )
+    cancelled_at = tracker._records["lanlan"][0]["ts"]
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        latest_user_fingerprint="fp-before",
+        latest_user_ts=cancelled_at + 3600,
+    )["task_id"] == "cancelled-1"
 
 
 def test_agent_task_tracker_ignores_metadata_less_cancel_in_fingerprint_fallback():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1377,6 +1377,21 @@ def test_agent_task_tracker_ignores_metadata_less_cancel_in_fingerprint_fallback
     ) is None
 
 
+def test_openclaw_stop_records_cancel_trigger_metadata():
+    source = Path("app/agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    segment = None
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_cancel_openclaw_tasks_for_stop":
+            segment = ast.get_source_segment(source, node)
+            break
+
+    assert segment is not None
+    assert "_task_tracker.record_completed" in segment
+    assert 'trigger_user_fingerprint=info.get("_trigger_user_fingerprint")' in segment
+    assert 'trigger_user_ts=info.get("_trigger_user_ts")' in segment
+
+
 def test_agent_task_tracker_matches_cancelled_user_plugin_suffix():
     source = Path("app/agent_server.py").read_text(encoding="utf-8")
     tree = ast.parse(source)

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1170,6 +1170,136 @@ def test_agent_server_user_turn_fingerprint_includes_attachments():
     assert image_only is not None
 
 
+def test_agent_task_tracker_blocks_cancelled_task_until_later_user_turn():
+    source = Path("app/agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wanted = {
+        "_task_blacklist_desc_keys",
+        "_task_desc_matches_blacklist",
+        "AgentTaskTracker",
+    }
+    segments = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in wanted:
+            segments.append(ast.get_source_segment(source, node))
+    assert len(segments) == len(wanted)
+
+    class _Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+    ns = {
+        "re": __import__("re"),
+        "time": __import__("time"),
+        "Dict": __import__("typing").Dict,
+        "Any": __import__("typing").Any,
+        "Optional": __import__("typing").Optional,
+        "TASK_TRACKER_TTL": 600.0,
+        "CANCELLED_TASK_BLACKLIST_TTL": 600.0,
+        "TASK_TRACKER_MAX_RECORDS": 100,
+        "TASK_DETAIL_MAX_TOKENS": 200,
+        "TASK_TRACKER_INJECT_DETAIL_MAX_CHARS": 200,
+        "_normalize_lanlan_key": lambda name: (name or "").strip() or "__default__",
+        "_tt": lambda text, limit: str(text)[:limit],
+        "logger": _Logger(),
+    }
+    exec("\n\n".join(segments), ns)
+    tracker = ns["AgentTaskTracker"]()
+
+    tracker.record_completed(
+        "lanlan",
+        task_id="cancelled-1",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        detail="Cancelled by user",
+        success=False,
+        cancelled=True,
+        trigger_user_fingerprint="fp-before",
+        trigger_user_ts=100.0,
+    )
+    cancelled_at = tracker._records["lanlan"][0]["ts"]
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        latest_user_fingerprint="fp-before",
+        latest_user_ts=cancelled_at - 1,
+    )["task_id"] == "cancelled-1"
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        latest_user_fingerprint="fp-before",
+        latest_user_ts=cancelled_at + 1,
+    ) is None
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="browser_use",
+        desc="打开天气网站并截图",
+        latest_user_fingerprint="fp-after",
+        latest_user_ts=None,
+    ) is None
+
+
+def test_agent_task_tracker_matches_cancelled_user_plugin_suffix():
+    source = Path("app/agent_server.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wanted = {
+        "_task_blacklist_desc_keys",
+        "_task_desc_matches_blacklist",
+        "AgentTaskTracker",
+    }
+    segments = [
+        ast.get_source_segment(source, node)
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in wanted
+    ]
+    assert len(segments) == len(wanted)
+
+    class _Logger:
+        def info(self, *args, **kwargs):
+            pass
+
+    ns = {
+        "re": __import__("re"),
+        "time": __import__("time"),
+        "Dict": __import__("typing").Dict,
+        "Any": __import__("typing").Any,
+        "Optional": __import__("typing").Optional,
+        "TASK_TRACKER_TTL": 600.0,
+        "CANCELLED_TASK_BLACKLIST_TTL": 600.0,
+        "TASK_TRACKER_MAX_RECORDS": 100,
+        "TASK_DETAIL_MAX_TOKENS": 200,
+        "TASK_TRACKER_INJECT_DETAIL_MAX_CHARS": 200,
+        "_normalize_lanlan_key": lambda name: (name or "").strip() or "__default__",
+        "_tt": lambda text, limit: str(text)[:limit],
+        "logger": _Logger(),
+    }
+    exec("\n\n".join(segments), ns)
+    tracker = ns["AgentTaskTracker"]()
+
+    tracker.record_completed(
+        "lanlan",
+        task_id="cancelled-plugin",
+        method="user_plugin",
+        desc="notes.run: 整理今天的会议纪要",
+        detail="Cancelled by user",
+        success=False,
+        cancelled=True,
+        trigger_user_fingerprint="fp-before",
+    )
+
+    assert tracker.find_cancelled_blacklist(
+        "lanlan",
+        method="user_plugin",
+        desc="整理今天的会议纪要",
+        latest_user_fingerprint="fp-before",
+    )["task_id"] == "cancelled-plugin"
+
+
 @pytest.mark.asyncio
 async def test_task_executor_routes_openclaw_as_independent_execution_method():
     from unittest.mock import AsyncMock, MagicMock, patch


### PR DESCRIPTION
﻿## Summary
- add a temporary blacklist for manually cancelled agent tasks in the refactored app/agent_server.py path
- record trigger user-turn fingerprint/timestamp and block analyzer redispatch until a later user message arrives
- cover timestamp-gated suppression and user_plugin suffix matching in regression tests

## Why
Manual cancellation was only terminal bookkeeping plus prompt guidance, so the analyzer could still regenerate the same task. This adds a deterministic pre-dispatch guard while preserving explicit user redo after a later message.

## Validation
- uv run pytest tests/test_agent_rewrite_regression.py -k "agent_task_tracker or user_turn_fingerprint"
- uv run python -m py_compile app/agent_server.py tests/test_agent_rewrite_regression.py
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  - 引入“临时黑名单”：手动取消的任务在短期内被屏蔽以防止重新派发，采用描述归一化与容错匹配，并结合后续用户交互的时间戳与指纹判定；取消提示更新为 “TEMPORARY BLACKLIST”。
  - 取消与停止操作会记录触发取消的时间/指纹元数据以便关联与判断。

* **测试**
  - 添加多项回归测试，覆盖时间窗、客户端时钟差、指纹回退和插件描述匹配等黑名单行为场景。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1280)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->