### PR TITLE
fix(ci): align Nuitka data-file paths with config/prompts and steamworks/ moves

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -276,8 +276,6 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.zh-CN.json=config/characters.zh-CN.json"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/characters.zh-TW.json=config/characters.zh-TW.json"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/core_config.json=config/core_config.json"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/prompts_chara.py=config/prompts_chara.py"
-          NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/prompts_sys.py=config/prompts_sys.py"
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=config/user_preferences.json=config/user_preferences.json"
 
           # Data directories
@@ -361,19 +359,21 @@ jobs:
           NUITKA_OPTS="$NUITKA_OPTS --enable-plugin=dill-compat"
           NUITKA_OPTS="$NUITKA_OPTS --assume-yes-for-downloads"
 
-          # Steam files (include if present in repo)
+          # Steam files (include if present in repo).
+          # PR #1264 moved native libs into steamworks/; runtime still loads them
+          # from the exe sibling dir (see steamworks/__init__.py), so dest stays at root.
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steam_appid.txt=steam_appid.txt"
-          if [ -f "libsteam_api.dylib" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=libsteam_api.dylib=libsteam_api.dylib"
+          if [ -f "steamworks/libsteam_api.dylib" ]; then
+            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.dylib=libsteam_api.dylib"
           fi
-          if [ -f "SteamworksPy.dylib" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=SteamworksPy.dylib=SteamworksPy.dylib"
+          if [ -f "steamworks/SteamworksPy.dylib" ]; then
+            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.dylib=SteamworksPy.dylib"
           fi
-          if [ -f "libsteam_api.so" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=libsteam_api.so=libsteam_api.so"
+          if [ -f "steamworks/libsteam_api.so" ]; then
+            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.so=libsteam_api.so"
           fi
-          if [ -f "SteamworksPy.so" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=SteamworksPy.so=SteamworksPy.so"
+          if [ -f "steamworks/SteamworksPy.so" ]; then
+            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.so=SteamworksPy.so"
           fi
 
           echo "=== Nuitka options ==="
@@ -402,8 +402,6 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.zh-CN.json=config/characters.zh-CN.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/characters.zh-TW.json=config/characters.zh-TW.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/core_config.json=config/core_config.json
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/prompts_chara.py=config/prompts_chara.py
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/prompts_sys.py=config/prompts_sys.py
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=config/user_preferences.json=config/user_preferences.json
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=assets=assets
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-dir=templates=templates
@@ -430,9 +428,11 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=plugin.plugins
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=utils
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=steamworks
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steam_api64.dll=steam_api64.dll
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steam_api64.lib=steam_api64.lib
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=SteamworksPy64.dll=SteamworksPy64.dll
+          rem PR #1264 moved native libs into steamworks/; runtime still loads them
+          rem from the exe sibling dir (see steamworks/__init__.py), so dest stays at root.
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.dll=steam_api64.dll
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.lib=steam_api64.lib
+          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/SteamworksPy64.dll=SteamworksPy64.dll
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steam_appid.txt=steam_appid.txt
           set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=audiolab
           set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=pyrnnoise

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -430,9 +430,11 @@ jobs:
           set NUITKA_OPTS=%NUITKA_OPTS% --include-package=steamworks
           rem PR #1264 moved native libs into steamworks/; runtime still loads them
           rem from the exe sibling dir (see steamworks/__init__.py), so dest stays at root.
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.dll=steam_api64.dll
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.lib=steam_api64.lib
-          set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/SteamworksPy64.dll=SteamworksPy64.dll
+          rem Guard with `if exist` to mirror the Unix branch — keeps the build
+          rem soft on incidental missing libs instead of fataling in Nuitka.
+          if exist "steamworks\steam_api64.dll" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.dll=steam_api64.dll
+          if exist "steamworks\steam_api64.lib" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.lib=steam_api64.lib
+          if exist "steamworks\SteamworksPy64.dll" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/SteamworksPy64.dll=SteamworksPy64.dll
           set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steam_appid.txt=steam_appid.txt
           set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=audiolab
           set NUITKA_OPTS=%NUITKA_OPTS% --nofollow-import-to=pyrnnoise


### PR DESCRIPTION
## Summary

Nightly desktop build [run 25617990704](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/25617990704) failed on all four platforms with:

\`\`\`
FATAL: Error, 'config/prompts_chara.py' does not match any files.
\`\`\`

Two recent refactors moved files but didn't update [.github/workflows/build-desktop.yml](.github/workflows/build-desktop.yml):

- **#1268** moved \`config/prompts_chara.py\` & \`config/prompts_sys.py\` into the \`config/prompts/\` subpackage. Workflow still listed the old root paths as \`--include-data-files\`.
- **#1264** moved Steam native libs (\`steam_api64.dll\`, \`libsteam_api.so\`, \`SteamworksPy.*\`, etc.) into \`steamworks/\`. Workflow still listed bare top-level filenames; Windows had no \`if exist\` guard so it would have hit the same fatal once #1268 was fixed.

## Fix

- Drop the two \`config/prompts_{chara,sys}.py\` data-file lines — they're regular Python modules now, picked up by \`--include-package=config\` (which recurses into \`config.prompts\`).
- Repoint Steam lib source paths to \`steamworks/<file>\`; keep dest at the dist root (the exe sibling), since [steamworks/__init__.py](steamworks/__init__.py) loads them from \`app_root\` at runtime.

Both Unix bash branch and Windows cmd branch updated.

## Test plan
- [ ] Manually trigger \`Build Desktop App\` workflow (workflow_dispatch) and verify all four matrix jobs complete the \`Build with Nuitka\` step
- [ ] Verify \`scripts/check_nuitka_dist.py\` invariants still pass on the resulting \`dist/Xiao8/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新了桌面应用构建流程：从打包产物中排除了部分配置文件，减少不必要的内置文件。
  * 调整了原生 Steam 库的打包来源与映射：改为从专用子目录按平台条件包含并映射运行时预期的库文件位置。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1285)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->