### PR TITLE
修复切换角色卡后猫爪状态继承旧角色、以及浮动按钮重建后 Agent 开关失去后端事件绑定的问题

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -563,6 +563,7 @@ async def _handle_agent_event(event: dict):
             payload = {
                 "type": "agent_status_update",
                 "snapshot": event.get("snapshot", {}),
+                "lanlan_name": lanlan or "",
             }
             mgr_for_status = _get_session_manager(lanlan)
             if lanlan and mgr_for_status is not None:

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -15,6 +15,7 @@ enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import time
+import uuid
 from pathlib import Path
 from urllib.parse import urlencode, urlparse
 
@@ -44,6 +45,53 @@ _OPENCLAW_GUIDE_LANG_FILES = {
     "ko": _OPENCLAW_GUIDE_DIR / "openclaw_guide.ko.md",
     "ru": _OPENCLAW_GUIDE_DIR / "openclaw_guide.ru.md",
 }
+
+_AGENT_OFF_FLAGS = {
+    "agent_enabled": False,
+    "computer_use_enabled": False,
+    "browser_use_enabled": False,
+    "user_plugin_enabled": False,
+    "openclaw_enabled": False,
+    "openfang_enabled": False,
+}
+
+
+async def force_disable_agent_for_character_switch(current_lanlan: str, previous_lanlan: str | None = None) -> bool:
+    """角色切换后强制关闭猫爪，避免工具服务的全局旧状态串到新角色。"""
+    names = {
+        str(name or "").strip()
+        for name in (current_lanlan, previous_lanlan)
+        if str(name or "").strip()
+    }
+    session_manager = get_session_manager()
+    for name in names:
+        mgr = session_manager.get(name)
+        if mgr:
+            mgr.update_agent_flags(dict(_AGENT_OFF_FLAGS))
+
+    if not current_lanlan:
+        return False
+
+    try:
+        client = _get_http_client()
+        payload = {
+            "request_id": f"character-switch-agent-off-{uuid.uuid4().hex[:8]}",
+            "command": "set_agent_enabled",
+            "enabled": False,
+            "lanlan_name": current_lanlan,
+        }
+        # 工具服务会先落关闭状态再收尾任务，短超时避免角色切换被长任务清理拖住。
+        response = await client.post(f"{TOOL_SERVER_BASE}/agent/command", json=payload, timeout=1.2)
+        if response.is_success:
+            return True
+        logger.warning(
+            "角色切换关闭猫爪失败: lanlan=%s status=%s",
+            current_lanlan,
+            response.status_code,
+        )
+    except Exception as exc:
+        logger.warning("角色切换关闭猫爪异常: lanlan=%s err=%s", current_lanlan, exc)
+    return False
 
 
 def _is_loopback_origin(value: str) -> bool:

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -53,6 +53,7 @@ from .shared_state import (
 )
 from .workshop_router import _ugc_sync_lock
 from main_logic.tts_client import get_custom_tts_voices, CustomTTSVoiceFetchError
+from .agent_router import force_disable_agent_for_character_switch
 from utils.character_memory import (
     delete_character_memory_storage,
     list_character_memory_paths,
@@ -2436,6 +2437,11 @@ async def set_current_catgirl(request: Request):
     # 只需刷新 globals 即可。N=20 只猫娘时从 O(N) 降到 O(1)。
     switch_current_catgirl_fast = get_switch_current_catgirl_fast()
     await switch_current_catgirl_fast()
+
+    # 角色卡切换会复用同一个前端猫爪面板和工具服务全局状态。
+    # 这里先把旧状态归零，避免新角色刷新后继承上一张卡的开关状态。
+    if old_catgirl != catgirl_name:
+        await force_disable_agent_for_character_switch(catgirl_name, old_catgirl)
 
     # B8: if the previous character had an active game route, finalize it
     # immediately. Otherwise the heartbeat-based timeout (10-60s) would

--- a/static/app-agent.js
+++ b/static/app-agent.js
@@ -1757,15 +1757,18 @@
     // ====================================================================
     // Floating buttons ready => bind agent checkbox listeners
     // ====================================================================
+    let agentReadyAutoOpenHandled = false;
     window.addEventListener('live2d-floating-buttons-ready', () => {
         console.log('[App] \u6536\u5230\u6d6e\u52a8\u6309\u94ae\u5c31\u7eea\u4e8b\u4ef6\uff0c\u5f00\u59cb\u7ed1\u5b9aAgent\u5f00\u5173');
         setupAgentCheckboxListeners();
+        if (agentReadyAutoOpenHandled) return;
+        agentReadyAutoOpenHandled = true;
         setTimeout(() => {
             if (typeof window.openAgentStatusPopupWhenEnabled === 'function') {
                 window.openAgentStatusPopupWhenEnabled();
             }
         }, 400);
-    }, { once: true });
+    });
 
     // ====================================================================
     // Expose module

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -1637,6 +1637,11 @@
             // commit 之后再 dispose 延后保留的旧 MMD 实例（MMD→非 MMD 路径）。
             // commit 前 dispose 会让中途失败的 rollback 没法恢复旧 MMD（容器没渲染 + 实例已销毁）。
             _disposeDeferredMmd();
+            // 角色卡切换后猫爪必须重新归零并拉取新快照，防止工具服务的旧全局状态污染新角色。
+            if (typeof window.resetAgentUiForCharacterSwitch === 'function') {
+                Promise.resolve(window.resetAgentUiForCharacterSwitch(newCatgirl))
+                    .catch(err => console.warn('[猫娘切换] 刷新猫爪状态失败:', err));
+            }
             showStatusToast(window.t ? window.t('app.switchedCatgirl', { name: newCatgirl }) : `已切换到 ${newCatgirl}`, 3000);
 
             // 【成就】解锁换肤成就

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1763,6 +1763,11 @@
                 // -------- agent_status_update --------
                 } else if (response.type === 'agent_status_update') {
                     var snapshot = response.snapshot || {};
+                    var snapshotMeta = { sourceCharacter: response.lanlan_name || '' };
+                    if (typeof window.isAgentStatusSnapshotCurrent === 'function'
+                        && !window.isAgentStatusSnapshotCurrent(snapshotMeta)) {
+                        return;
+                    }
                     window._agentStatusSnapshot = snapshot;
                     var serverOnline = snapshot.server_online !== false;
                     var flags = snapshot.flags || {};
@@ -1773,7 +1778,7 @@
                         window.agentStateMachine.updateCache(serverOnline, flags);
                     }
                     if (typeof window.applyAgentStatusSnapshotToUI === 'function') {
-                        window.applyAgentStatusSnapshotToUI(snapshot);
+                        window.applyAgentStatusSnapshotToUI(snapshot, snapshotMeta);
                     }
                     try {
                         var masterOn = !!flags.agent_enabled;

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -19,6 +19,7 @@
         busyTimer: null,
         openclawReady: null,
         openclawReason: '',
+        globalEventsBound: false,
     };
     
     // 暴露状态供 app.js 等外部脚本使用乐观更新检测
@@ -54,6 +55,15 @@
     const setStatus = (msg) => {
         const { status } = el();
         status.forEach(s => { if (s) s.textContent = msg || ''; });
+    };
+    const currentLanlanName = () => {
+        const fromConfig = window.lanlan_config && typeof window.lanlan_config.lanlan_name === 'string'
+            ? window.lanlan_config.lanlan_name
+            : '';
+        const fromAppState = window.appState && typeof window.appState.lanlan_name === 'string'
+            ? window.appState.lanlan_name
+            : '';
+        return String(fromConfig || fromAppState || '').trim();
     };
     const setGlobalBusy = (busy, statusText) => {
         state.globalBusy = !!busy;
@@ -148,22 +158,32 @@
         }
     }
 
-    async function fetchSnapshot() {
+    async function fetchSnapshotRaw() {
         const r = await fetch('/api/agent/state');
         if (!r.ok) throw new Error(`state status ${r.status}`);
         const j = await r.json();
         if (!j || j.success !== true || !j.snapshot) throw new Error('invalid state payload');
-        applySnapshot(j.snapshot, 'http');
         return j.snapshot;
+    }
+
+    async function fetchSnapshot() {
+        const snapshot = await fetchSnapshotRaw();
+        applySnapshot(snapshot, 'http');
+        return snapshot;
     }
 
     async function sendCommand(command, payload) {
         const requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const t0 = performance.now();
+        const body = { request_id: requestId, command, ...(payload || {}) };
+        if (!body.lanlan_name) {
+            const lanlanName = currentLanlanName();
+            if (lanlanName) body.lanlan_name = lanlanName;
+        }
         const r = await fetch('/api/agent/command', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ request_id: requestId, command, ...(payload || {}) }),
+            body: JSON.stringify(body),
         });
         if (!r.ok) throw new Error(`command status ${r.status}`);
         const j = await r.json();
@@ -171,6 +191,39 @@
         const roundtrip = Number((performance.now() - t0).toFixed(2));
         console.log('[AgentUIv2Timing]', { requestId, command, roundtrip_ms: roundtrip, timing: j.timing || {} });
         return j;
+    }
+
+    function applyLocalAgentOff(reason) {
+        const base = state.snapshot && typeof state.snapshot === 'object' ? state.snapshot : {};
+        const snapshot = {
+            ...base,
+            server_online: base.server_online !== false,
+            analyzer_enabled: false,
+            flags: {
+                agent_enabled: false,
+                computer_use_enabled: false,
+                browser_use_enabled: false,
+                user_plugin_enabled: false,
+                openclaw_enabled: false,
+                openfang_enabled: false,
+            },
+            active_tasks: [],
+            notification: null,
+            updated_at: new Date().toISOString(),
+        };
+        state.pending.clear();
+        state.optimistic = {};
+        state.openclawReady = null;
+        state.openclawReason = '';
+        setGlobalBusy(false);
+        state.snapshot = snapshot;
+        // 本地快照只用于立即收起 UI，下一次权威快照必须能覆盖它。
+        state.revision = -1;
+        window._agentStatusSnapshot = snapshot;
+        if (typeof window.stopAgentTaskPolling === 'function') {
+            window.stopAgentTaskPolling();
+        }
+        render(reason || 'agent-off-local');
     }
 
     function applySnapshot(snapshot, source = 'ws') {
@@ -378,6 +431,18 @@
     function bindEvents() {
         const { master, keyboard, browser, userPlugin, openfang, openclaw } = el();
         if (!master.length) return;
+        const bindChangeOnce = (cb, key, handler) => {
+            if (!cb) return;
+            if (!cb.__agentUiV2BoundKeys) {
+                Object.defineProperty(cb, '__agentUiV2BoundKeys', {
+                    value: {},
+                    configurable: true,
+                });
+            }
+            if (cb.__agentUiV2BoundKeys[key]) return;
+            cb.__agentUiV2BoundKeys[key] = true;
+            cb.addEventListener('change', handler);
+        };
         const clearProcessing = (cbs) => {
             (Array.isArray(cbs) ? cbs : [cbs]).forEach(cb => {
                 if (!cb) return;
@@ -447,12 +512,12 @@
                 render('command');
             }
         };
-        master.forEach(m => m.addEventListener('change', onMasterChange));
+        master.forEach(m => bindChangeOnce(m, 'master', onMasterChange));
 
         const bindFlag = (cbs, key) => {
             if (!cbs || !cbs.length) return;
             cbs.forEach(cb => {
-                cb.addEventListener('change', async (e) => {
+                bindChangeOnce(cb, `flag:${key}`, async (e) => {
                     if (state.suppressChange) {
                         clearProcessing(cbs);
                         return;
@@ -493,7 +558,7 @@
         bindFlag(openfang, 'openfang_enabled');
 
         openclaw.forEach(cb => {
-            cb.addEventListener('change', async (e) => {
+            bindChangeOnce(cb, 'flag:openclaw_enabled', async (e) => {
                 if (state.suppressChange) { clearProcessing(openclaw); return; }
                 const value = !!e.target.checked;
                 const openclawName = window.t ? window.t('settings.toggles.openclawConnect') : 'OpenClaw';
@@ -523,6 +588,9 @@
             });
         });
 
+        if (state.globalEventsBound) return;
+        state.globalEventsBound = true;
+
         window.addEventListener('neko-popup-opening', async () => {
             state.popupOpen = true;
             render('popup');
@@ -543,11 +611,33 @@
         applySnapshot(snapshot, 'ws');
     };
 
+    window.resetAgentUiForCharacterSwitch = async function resetAgentUiForCharacterSwitch() {
+        const resetMasterSeq = state.masterOpSeq;
+        applyLocalAgentOff('character-switch-local');
+        try {
+            const snapshot = await fetchSnapshotRaw();
+            // 用户已经手动打开猫爪时，不允许切换后的慢刷新覆盖乐观开关状态。
+            if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0) {
+                applySnapshot(snapshot, 'character-switch-refresh');
+            }
+        } catch (e) {
+            if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0) {
+                render('character-switch-refresh-failed');
+            }
+        }
+        if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0) {
+            await refreshOpenClawAvailability().catch(() => {});
+        }
+    };
+
     window.initAgentUiV2 = function initAgentUiV2() {
-        if (state.inited) return true;
+        const firstInit = !state.inited;
         state.inited = true;
         bindEvents();
-        fetchSnapshot().catch(() => render('init'));
+        if (state.snapshot) {
+            render(firstInit ? 'init-render' : 'rebind');
+        }
+        fetchSnapshot().catch(() => render(firstInit ? 'init' : 'rebind'));
         return true;
     };
 })();

--- a/static/js/agent_ui_v2.js
+++ b/static/js/agent_ui_v2.js
@@ -14,6 +14,8 @@
         suppressChange: false,
         inited: false,
         masterOpSeq: 0,
+        snapshotGeneration: 0,
+        expectedCharacter: '',
         globalBusy: false,
         optimistic: {},
         busyTimer: null,
@@ -64,6 +66,21 @@
             ? window.appState.lanlan_name
             : '';
         return String(fromConfig || fromAppState || '').trim();
+    };
+    const expectedCharacterName = () => String(state.expectedCharacter || currentLanlanName() || '').trim();
+    const makeSnapshotToken = () => ({
+        generation: state.snapshotGeneration,
+        expectedCharacter: expectedCharacterName(),
+    });
+    const isSnapshotTokenCurrent = (token) => {
+        if (!token) return true;
+        if (token.generation !== undefined && token.generation !== state.snapshotGeneration) return false;
+        const expected = expectedCharacterName();
+        const tokenCharacter = String(token.expectedCharacter || '').trim();
+        if (expected && tokenCharacter && tokenCharacter !== expected) return false;
+        const sourceCharacter = String(token.sourceCharacter || '').trim();
+        if (expected && sourceCharacter && sourceCharacter !== expected) return false;
+        return true;
     };
     const setGlobalBusy = (busy, statusText) => {
         state.globalBusy = !!busy;
@@ -167,8 +184,9 @@
     }
 
     async function fetchSnapshot() {
+        const token = makeSnapshotToken();
         const snapshot = await fetchSnapshotRaw();
-        applySnapshot(snapshot, 'http');
+        applySnapshot(snapshot, 'http', token);
         return snapshot;
     }
 
@@ -226,8 +244,9 @@
         render(reason || 'agent-off-local');
     }
 
-    function applySnapshot(snapshot, source = 'ws') {
+    function applySnapshot(snapshot, source = 'ws', token) {
         if (!snapshot || typeof snapshot !== 'object') return;
+        if (!isSnapshotTokenCurrent(token)) return;
         const rev = Number(snapshot.revision ?? -1);
         if (Number.isFinite(rev) && rev <= state.revision) return;
 
@@ -485,7 +504,7 @@
                     const ts = performance.now();
                     await fetchSnapshot().catch(() => { });
                     console.log('[AgentUIv2Timing]', { phase: 'fetch_snapshot_after_master', ms: Number((performance.now() - ts).toFixed(2)) });
-                    if (enabled) {
+                    if (opSeq === state.masterOpSeq && enabled) {
                         const openclawTs = performance.now();
                         await refreshOpenClawAvailability();
                         console.log('[AgentUIv2Timing]', { phase: 'refresh_openclaw_after_master', ms: Number((performance.now() - openclawTs).toFixed(2)) });
@@ -523,16 +542,19 @@
                         return;
                     }
                     const value = !!e.target.checked;
+                    const opToken = makeSnapshotToken();
                     state.pending.add(key);
                     state.optimistic[key] = value;
                     setGlobalBusy(true, window.t ? window.t('settings.toggles.checking') : '已接受操作，切换中...');
                     render('command');
                     try {
                         await sendCommand('set_flag', { key, value });
+                        if (!isSnapshotTokenCurrent(opToken)) return;
                         const ts = performance.now();
                         await fetchSnapshot().catch(() => { });
                         console.log('[AgentUIv2Timing]', { phase: 'fetch_snapshot_after_flag', key, ms: Number((performance.now() - ts).toFixed(2)) });
                     } catch (err) {
+                        if (!isSnapshotTokenCurrent(opToken)) return;
                         state.pending.delete(key);
                         state.optimistic = {};
                         setGlobalBusy(false);
@@ -544,6 +566,7 @@
                     } finally {
                         clearProcessing(cbs);
                     }
+                    if (!isSnapshotTokenCurrent(opToken)) return;
                     state.pending.delete(key);
                     state.optimistic = {};
                     setGlobalBusy(false);
@@ -561,6 +584,7 @@
             bindChangeOnce(cb, 'flag:openclaw_enabled', async (e) => {
                 if (state.suppressChange) { clearProcessing(openclaw); return; }
                 const value = !!e.target.checked;
+                const opToken = makeSnapshotToken();
                 const openclawName = window.t ? window.t('settings.toggles.openclawConnect') : 'OpenClaw';
                 state.pending.add('openclaw_enabled');
                 state.optimistic['openclaw_enabled'] = value;
@@ -568,8 +592,10 @@
                 render('command');
                 try {
                     await sendCommand('set_flag', { key: 'openclaw_enabled', value });
+                    if (!isSnapshotTokenCurrent(opToken)) return;
                     await fetchSnapshot().catch(() => {});
                 } catch (err) {
+                    if (!isSnapshotTokenCurrent(opToken)) return;
                     state.pending.delete('openclaw_enabled');
                     state.optimistic = {};
                     setGlobalBusy(false);
@@ -581,6 +607,7 @@
                 } finally {
                     clearProcessing(openclaw);
                 }
+                if (!isSnapshotTokenCurrent(opToken)) return;
                 state.pending.delete('openclaw_enabled');
                 state.optimistic = {};
                 setGlobalBusy(false);
@@ -607,25 +634,29 @@
         });
     }
 
-    window.applyAgentStatusSnapshotToUI = (snapshot) => {
-        applySnapshot(snapshot, 'ws');
+    window.applyAgentStatusSnapshotToUI = (snapshot, meta) => {
+        applySnapshot(snapshot, 'ws', meta);
     };
+    window.isAgentStatusSnapshotCurrent = (meta) => isSnapshotTokenCurrent(meta);
 
     window.resetAgentUiForCharacterSwitch = async function resetAgentUiForCharacterSwitch() {
-        const resetMasterSeq = state.masterOpSeq;
+        const resetMasterSeq = ++state.masterOpSeq;
+        state.snapshotGeneration += 1;
+        state.expectedCharacter = currentLanlanName();
+        const resetToken = makeSnapshotToken();
         applyLocalAgentOff('character-switch-local');
         try {
             const snapshot = await fetchSnapshotRaw();
             // 用户已经手动打开猫爪时，不允许切换后的慢刷新覆盖乐观开关状态。
-            if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0) {
-                applySnapshot(snapshot, 'character-switch-refresh');
+            if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0 && isSnapshotTokenCurrent(resetToken)) {
+                applySnapshot(snapshot, 'character-switch-refresh', resetToken);
             }
         } catch (e) {
-            if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0) {
+            if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0 && isSnapshotTokenCurrent(resetToken)) {
                 render('character-switch-refresh-failed');
             }
         }
-        if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0) {
+        if (resetMasterSeq === state.masterOpSeq && state.pending.size === 0 && isSnapshotTokenCurrent(resetToken)) {
             await refreshOpenClawAvailability().catch(() => {});
         }
     };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 切换角色时强制禁用旧角色的代理执行，避免代理在切换后继续运行。

* **改进**
  * 角色切换时本地立即重置代理 UI 并安全拉取权威快照，防止过期快照覆盖当前状态。
  * 快照应用增加基于令牌的时效保护，WebSocket 消息携带角色信息以避免错位更新。
  * 优化事件绑定，防止重复绑定与重复自动打开行为。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1286)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->