### PR TITLE
Fix/home tutorial reset backend state

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1101,10 +1101,6 @@ async def post_tutorial_prompt_decision(request: Request):
 @router.post("/tutorial-prompt/reset")
 async def post_tutorial_prompt_reset(request: Request):
     """重置主页新手引导状态，供记忆浏览的手动重置入口调用。"""
-    validation_error = _validate_local_mutation_request(request)
-    if validation_error is not None:
-        return validation_error
-
     return reset_tutorial_prompt_state(config_manager=get_config_manager())
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1101,6 +1101,10 @@ async def post_tutorial_prompt_decision(request: Request):
 @router.post("/tutorial-prompt/reset")
 async def post_tutorial_prompt_reset(request: Request):
     """重置主页新手引导状态，供记忆浏览的手动重置入口调用。"""
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     return reset_tutorial_prompt_state(config_manager=get_config_manager())
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -158,6 +158,7 @@ from utils.tutorial_prompt_state import (
     record_tutorial_prompt_decision,
     record_tutorial_started,
     record_tutorial_completed,
+    reset_tutorial_prompt_state,
 )
 from utils.storage_location_bootstrap import build_storage_location_bootstrap_payload
 from utils.config_manager import get_config_manager as get_runtime_config_manager
@@ -1095,6 +1096,16 @@ async def post_tutorial_prompt_decision(request: Request):
         return record_tutorial_prompt_decision(payload, config_manager=get_config_manager())
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"ok": False, "error": str(exc)})
+
+
+@router.post("/tutorial-prompt/reset")
+async def post_tutorial_prompt_reset(request: Request):
+    """重置主页新手引导状态，供记忆浏览的手动重置入口调用。"""
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
+    return reset_tutorial_prompt_state(config_manager=get_config_manager())
 
 
 @router.get("/autostart-prompt/state")

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -871,6 +871,34 @@
         return state.tutorialRunToken;
     }
 
+    async function persistHomeTutorialCompletion(event, flowStep, persistedStep) {
+        const source = event.detail.source || 'manual';
+        const tutorialRunToken = await waitForTutorialRunToken(2000);
+        logFlow(flowStep, {
+            source: source,
+            promptToken: shortPromptToken(state.promptDrivenTutorialToken),
+            tutorialRunToken: shortTutorialRunToken(tutorialRunToken),
+        });
+
+        if (!tutorialRunToken) {
+            logFlow(`${flowStep}-skipped`, {
+                source: source,
+                reason: 'missing_run_token',
+            });
+            state.promptDrivenTutorialToken = null;
+            return;
+        }
+
+        await persistTutorialLifecycle('/api/tutorial-prompt/tutorial-completed', {
+            page: 'home',
+            source: source,
+            tutorial_run_token: tutorialRunToken,
+        }, persistedStep, {
+            clearRunTokenOnSuccess: true,
+        });
+        state.promptDrivenTutorialToken = null;
+    }
+
     function takeHeartbeatSnapshot() {
         const snapshot = {
             foregroundMsDelta: consumeForegroundDelta(),
@@ -1334,31 +1362,11 @@
             endHomeTutorialFeatureSuppression('tutorial-completed');
             emitHomeTutorialLockIfChanged('tutorial-completed');
             void (async function () {
-                const source = event.detail.source || 'manual';
-                const tutorialRunToken = await waitForTutorialRunToken(2000);
-                logFlow('tutorial-completed', {
-                    source: source,
-                    promptToken: shortPromptToken(state.promptDrivenTutorialToken),
-                    tutorialRunToken: shortTutorialRunToken(tutorialRunToken),
-                });
-
-                if (!tutorialRunToken) {
-                    logFlow('tutorial-completed-skipped', {
-                        source: source,
-                        reason: 'missing_run_token',
-                    });
-                    state.promptDrivenTutorialToken = null;
-                    return;
-                }
-
-                await persistTutorialLifecycle('/api/tutorial-prompt/tutorial-completed', {
-                    page: 'home',
-                    source: source,
-                    tutorial_run_token: tutorialRunToken,
-                }, 'tutorial-completed-persisted', {
-                    clearRunTokenOnSuccess: true,
-                });
-                state.promptDrivenTutorialToken = null;
+                await persistHomeTutorialCompletion(
+                    event,
+                    'tutorial-completed',
+                    'tutorial-completed-persisted'
+                );
             })();
             scheduleFastHeartbeat();
         });
@@ -1416,8 +1424,19 @@
             }
             state.tutorialRunning = false;
             state.tutorialStartRequested = false;
+            state.tutorialStarted = true;
+            state.homeTutorialCompleted = true;
+            markHomeTutorialStorageSeen();
             endHomeTutorialFeatureSuppression('tutorial-skipped');
             emitHomeTutorialLockIfChanged('tutorial-skipped');
+            void (async function () {
+                await persistHomeTutorialCompletion(
+                    event,
+                    'tutorial-skipped',
+                    'tutorial-skipped-persisted'
+                );
+            })();
+            scheduleFastHeartbeat();
         });
 
         // Keep this recovery bridge paired with handlePromptAcceptance:

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -239,6 +239,7 @@
                 const cleanup = () => {
                     window.removeEventListener('neko:tutorial-completed', handleCompleted);
                     window.removeEventListener('neko:tutorial-skipped', handleSkipped);
+                    window.removeEventListener('neko:tutorial-ended-without-completion', handleEndedWithoutCompletion);
                 };
                 const finish = () => {
                     if (settled) {
@@ -250,8 +251,10 @@
                 };
                 const handleCompleted = () => finish();
                 const handleSkipped = () => finish();
+                const handleEndedWithoutCompletion = () => finish();
                 window.addEventListener('neko:tutorial-completed', handleCompleted, { once: true });
                 window.addEventListener('neko:tutorial-skipped', handleSkipped, { once: true });
+                window.addEventListener('neko:tutorial-ended-without-completion', handleEndedWithoutCompletion, { once: true });
             });
         }
 

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -29,10 +29,36 @@ function logTutorialPromptFlow(step, details = {}) {
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
 }
 
+async function getTutorialMutationHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    const helper = window.nekoLocalMutationSecurity;
+    if (helper && typeof helper.getMutationHeaders === 'function') {
+        try {
+            return Object.assign(headers, await helper.getMutationHeaders());
+        } catch (error) {
+            console.warn('[Tutorial] 获取本地写入安全头失败，尝试直接读取页面配置:', error);
+        }
+    }
+
+    try {
+        const response = await fetch('/api/config/page_config', { cache: 'no-store' });
+        if (!response.ok) {
+            return headers;
+        }
+        const data = await response.json();
+        if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
+            headers['X-CSRF-Token'] = data.autostart_csrf_token;
+        }
+    } catch (error) {
+        console.warn('[Tutorial] 读取页面配置失败，继续使用基础请求头:', error);
+    }
+    return headers;
+}
+
 async function postTutorialPromptReset(reason) {
     const response = await fetch('/api/tutorial-prompt/reset', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: await getTutorialMutationHeaders(),
         body: JSON.stringify({ reason }),
     });
     if (!response.ok) {

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -29,36 +29,10 @@ function logTutorialPromptFlow(step, details = {}) {
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
 }
 
-async function getTutorialMutationHeaders() {
-    const headers = { 'Content-Type': 'application/json' };
-    const helper = window.nekoLocalMutationSecurity;
-    if (helper && typeof helper.getMutationHeaders === 'function') {
-        try {
-            return Object.assign(headers, await helper.getMutationHeaders());
-        } catch (error) {
-            console.warn('[Tutorial] 获取本地写入安全头失败，尝试直接读取页面配置:', error);
-        }
-    }
-
-    try {
-        const response = await fetch('/api/config/page_config', { cache: 'no-store' });
-        if (!response.ok) {
-            return headers;
-        }
-        const data = await response.json();
-        if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
-            headers['X-CSRF-Token'] = data.autostart_csrf_token;
-        }
-    } catch (error) {
-        console.warn('[Tutorial] 读取页面配置失败，继续使用基础请求头:', error);
-    }
-    return headers;
-}
-
 async function postTutorialPromptReset(reason) {
     const response = await fetch('/api/tutorial-prompt/reset', {
         method: 'POST',
-        headers: await getTutorialMutationHeaders(),
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reason }),
     });
     if (!response.ok) {
@@ -5217,11 +5191,11 @@ class UniversalTutorialManager {
     }
 
     async resetAllTutorials() {
+        await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         TUTORIAL_PAGES.forEach(page => {
             this.getStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
         });
         this.markTutorialManualStartIntent('home');
-        await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         console.log('[Tutorial] 已重置所有页面引导');
         this.notifyTutorialResetForCurrentPageIfNeeded('all');
     } 
@@ -5235,6 +5209,10 @@ class UniversalTutorialManager {
             return;
         }
 
+        if (pageKey === 'home') {
+            await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
+        }
+
         this.getStorageKeysForPage(pageKey).forEach((storageKey) => {
             const oldVal = localStorage.getItem(storageKey);
             localStorage.removeItem(storageKey);
@@ -5243,7 +5221,6 @@ class UniversalTutorialManager {
 
         if (pageKey === 'home') {
             this.markTutorialManualStartIntent('home');
-            await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
         }
 
         console.log('[Tutorial] 已重置页面引导:', pageKey);
@@ -5373,9 +5350,9 @@ async function resetAllTutorials() {
         await window.universalTutorialManager.resetAllTutorials();
     } else {
         // 如果管理器未初始化，直接清除 localStorage
+        await postTutorialPromptReset('manual_all_tutorial_reset');
         TUTORIAL_PAGES.forEach(page => { localStorage.removeItem(getTutorialStorageKeyForPage(page)); });
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
-        await postTutorialPromptReset('manual_all_tutorial_reset');
     }
     alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
 }
@@ -5427,6 +5404,9 @@ async function resetTutorialForPage(pageKey) {
     if (window.universalTutorialManager) {
         await window.universalTutorialManager.resetPageTutorial(pageKey);
     } else {
+        if (pageKey === 'home') {
+            await postTutorialPromptReset('manual_home_tutorial_reset');
+        }
         if (pageKey === 'model_manager') {
             localStorage.removeItem(getTutorialStorageKeyForPage('model_manager'));
             localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_live2d'));
@@ -5438,7 +5418,6 @@ async function resetTutorialForPage(pageKey) {
         }
         if (pageKey === 'home') {
             localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
-            await postTutorialPromptReset('manual_home_tutorial_reset');
         }
     }
 

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -4791,6 +4791,13 @@ class UniversalTutorialManager {
         this._teardownTutorialUI();
 
         if (endMeta.reason === 'destroy') {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-ended-without-completion', {
+                detail: {
+                    page: this.currentPage,
+                    source: completedSource,
+                    reason: endMeta.rawReason
+                }
+            }));
             this.logPromptFlow('tutorial-ended-without-completion', {
                 page: this.currentPage,
                 source: completedSource,

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -29,6 +29,44 @@ function logTutorialPromptFlow(step, details = {}) {
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
 }
 
+async function getTutorialMutationHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    const helper = window.nekoLocalMutationSecurity;
+    if (helper && typeof helper.getMutationHeaders === 'function') {
+        try {
+            return Object.assign(headers, await helper.getMutationHeaders());
+        } catch (error) {
+            console.warn('[Tutorial] 获取本地写入安全头失败，尝试直接读取页面配置:', error);
+        }
+    }
+
+    try {
+        const response = await fetch('/api/config/page_config', { cache: 'no-store' });
+        if (!response.ok) {
+            return headers;
+        }
+        const data = await response.json();
+        if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
+            headers['X-CSRF-Token'] = data.autostart_csrf_token;
+        }
+    } catch (error) {
+        console.warn('[Tutorial] 读取页面配置失败，继续使用基础请求头:', error);
+    }
+    return headers;
+}
+
+async function postTutorialPromptReset(reason) {
+    const response = await fetch('/api/tutorial-prompt/reset', {
+        method: 'POST',
+        headers: await getTutorialMutationHeaders(),
+        body: JSON.stringify({ reason }),
+    });
+    if (!response.ok) {
+        throw new Error(`tutorial prompt reset failed: ${response.status}`);
+    }
+    return response.json();
+}
+
 window.getTutorialStorageKeyForPage = getTutorialStorageKeyForPage;
 window.getTutorialManualIntentKeyForPage = getTutorialManualIntentKeyForPage;
 window.logTutorialPromptFlow = logTutorialPromptFlow;
@@ -4735,6 +4773,17 @@ class UniversalTutorialManager {
 
         this._teardownTutorialUI();
 
+        if (endMeta.reason === 'destroy') {
+            this.logPromptFlow('tutorial-ended-without-completion', {
+                page: this.currentPage,
+                source: completedSource,
+                reason: endMeta.reason,
+                rawReason: endMeta.rawReason
+            });
+            console.log('[Tutorial] 引导未完成即结束，页面:', this.currentPage, 'reason:', endMeta.rawReason);
+            return;
+        }
+
         // 标记用户已看过该页面的引导
         const storageKey = this.getStorageKey();
         localStorage.setItem(storageKey, 'true');
@@ -4742,6 +4791,24 @@ class UniversalTutorialManager {
             const commonStorageKey = getTutorialStorageKeyForPage('model_manager_common');
             localStorage.setItem(commonStorageKey, 'true');
             console.log('[Tutorial] 已标记模型管理通用步骤为已看过');
+        }
+
+        if (endMeta.reason === 'skip') {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: {
+                    page: this.currentPage,
+                    source: completedSource,
+                    reason: endMeta.rawReason
+                }
+            }));
+            this.logPromptFlow('tutorial-skipped', {
+                page: this.currentPage,
+                source: completedSource,
+                reason: endMeta.reason,
+                rawReason: endMeta.rawReason
+            });
+            console.log('[Tutorial] 引导已跳过并标记看过，页面:', this.currentPage);
+            return;
         }
 
         window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
@@ -5145,11 +5212,16 @@ class UniversalTutorialManager {
     /** 
      * 重置所有页面的引导状态 
      */ 
-    resetAllTutorials() {
+    async resetHomeTutorialPromptState(reason = 'manual_home_tutorial_reset') {
+        return postTutorialPromptReset(reason);
+    }
+
+    async resetAllTutorials() {
         TUTORIAL_PAGES.forEach(page => {
             this.getStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
         });
         this.markTutorialManualStartIntent('home');
+        await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         console.log('[Tutorial] 已重置所有页面引导');
         this.notifyTutorialResetForCurrentPageIfNeeded('all');
     } 
@@ -5157,9 +5229,9 @@ class UniversalTutorialManager {
     /**
      * 重置指定页面的引导状态
      */
-    resetPageTutorial(pageKey) {
+    async resetPageTutorial(pageKey) {
         if (pageKey === 'all') {
-            this.resetAllTutorials();
+            await this.resetAllTutorials();
             return;
         }
 
@@ -5171,6 +5243,7 @@ class UniversalTutorialManager {
 
         if (pageKey === 'home') {
             this.markTutorialManualStartIntent('home');
+            await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
         }
 
         console.log('[Tutorial] 已重置页面引导:', pageKey);
@@ -5295,13 +5368,14 @@ async function initUniversalTutorialManager() {
  * 全局函数：重置所有引导
  * 供 HTML 按钮调用
  */
-function resetAllTutorials() {
+async function resetAllTutorials() {
     if (window.universalTutorialManager) {
-        window.universalTutorialManager.resetAllTutorials();
+        await window.universalTutorialManager.resetAllTutorials();
     } else {
         // 如果管理器未初始化，直接清除 localStorage
         TUTORIAL_PAGES.forEach(page => { localStorage.removeItem(getTutorialStorageKeyForPage(page)); });
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+        await postTutorialPromptReset('manual_all_tutorial_reset');
     }
     alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
 }
@@ -5310,12 +5384,12 @@ function resetAllTutorials() {
  * 全局函数：重置指定页面的引导
  * 供下拉菜单调用
  */
-function resetTutorialForPage(pageKey) {
+async function resetTutorialForPage(pageKey) {
     if (!pageKey) return;
     console.log('%c[Tutorial] resetTutorialForPage 被调用, pageKey:', 'color: red; font-weight: bold', pageKey);
 
     if (pageKey === 'all') {
-        resetAllTutorials();
+        await resetAllTutorials();
         return;
     }
 
@@ -5351,7 +5425,7 @@ function resetTutorialForPage(pageKey) {
     }
 
     if (window.universalTutorialManager) {
-        window.universalTutorialManager.resetPageTutorial(pageKey);
+        await window.universalTutorialManager.resetPageTutorial(pageKey);
     } else {
         if (pageKey === 'model_manager') {
             localStorage.removeItem(getTutorialStorageKeyForPage('model_manager'));
@@ -5364,6 +5438,7 @@ function resetTutorialForPage(pageKey) {
         }
         if (pageKey === 'home') {
             localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+            await postTutorialPromptReset('manual_home_tutorial_reset');
         }
     }
 

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -56,11 +56,28 @@ async function getTutorialMutationHeaders() {
 }
 
 async function postTutorialPromptReset(reason) {
-    const response = await fetch('/api/tutorial-prompt/reset', {
+    const body = JSON.stringify({ reason });
+    const sendResetRequest = async () => fetch('/api/tutorial-prompt/reset', {
         method: 'POST',
         headers: await getTutorialMutationHeaders(),
-        body: JSON.stringify({ reason }),
+        body,
     });
+
+    let response = await sendResetRequest();
+    if (response.status === 403 && window.nekoLocalMutationSecurity &&
+        typeof window.nekoLocalMutationSecurity.refreshToken === 'function') {
+        let shouldRetry = false;
+        try {
+            const payload = await response.clone().json();
+            shouldRetry = payload && payload.error_code === 'csrf_validation_failed';
+        } catch (_) {
+            shouldRetry = false;
+        }
+        if (shouldRetry) {
+            await window.nekoLocalMutationSecurity.refreshToken();
+            response = await sendResetRequest();
+        }
+    }
     if (!response.ok) {
         throw new Error(`tutorial prompt reset failed: ${response.status}`);
     }

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -762,6 +762,135 @@ def test_tutorial_started_event_retries_failed_sync_on_heartbeat(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_skip_persists_completion_state(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__tutorialStartedBodies = [];
+            window.__tutorialCompletedBodies = [];
+            window.getTutorialStorageKeyForPage = function(page) {
+                return page === 'home' ? 'neko_tutorial_home_yui_v1' : 'neko_tutorial_' + page;
+            };
+            window.universalTutorialManager = {
+                currentPage: 'home',
+                isTutorialRunning: false,
+                hasSeenTutorial: function() {
+                    return false;
+                },
+                logPromptFlow: function() {},
+                requestTutorialStart: async function() {
+                    return false;
+                },
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-started') {
+                window.__tutorialStartedBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    tutorial_run_token: 'skip-run-token',
+                    state: {
+                        status: 'started',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-completed') {
+                window.__tutorialCompletedBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'completed',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: {
+                    page: 'home',
+                    source: 'manual',
+                },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__tutorialStartedBodies.length === 1",
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: {
+                    page: 'home',
+                    source: 'manual',
+                },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__tutorialCompletedBodies.length === 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            completedBodies: window.__tutorialCompletedBodies.slice(),
+            preferredSeen: window.localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: window.localStorage.getItem('neko_tutorial_home'),
+        })
+        """
+    )
+
+    assert result["completedBodies"][0]["source"] == "manual"
+    assert result["completedBodies"][0]["tutorial_run_token"] == "skip-run-token"
+    assert result["preferredSeen"] == "true"
+    assert result["legacySeen"] == "true"
+
+
+@pytest.mark.frontend
 def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
     mock_page: Page,
 ):

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -891,6 +891,86 @@ def test_home_tutorial_skip_persists_completion_state(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_refreshes_stale_csrf_token_once(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'stale-token',
+            });
+            window.__pageConfigFetchCount = 0;
+            window.__resetTokens = [];
+            window.__resetBodies = [];
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            const csrfToken = headers['X-CSRF-Token'] || headers['x-csrf-token'] || '';
+            if (requestUrl === '/api/config/page_config') {
+                window.__pageConfigFetchCount += 1;
+                return jsonResponse({
+                    success: true,
+                    autostart_csrf_token: 'fresh-token',
+                    model_path: '',
+                    model_type: 'live2d',
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                window.__resetTokens.push(csrfToken);
+                window.__resetBodies.push(body);
+                if (csrfToken !== 'fresh-token') {
+                    return jsonResponse({
+                        ok: false,
+                        error_code: 'csrf_validation_failed',
+                    }, 403);
+                }
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            localStorage.setItem('neko_tutorial_home', 'true');
+            await resetTutorialForPage('home');
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            pageConfigFetchCount: window.__pageConfigFetchCount,
+            resetTokens: window.__resetTokens.slice(),
+            resetBodies: window.__resetBodies.slice(),
+            homeSeen: localStorage.getItem('neko_tutorial_home'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["pageConfigFetchCount"] >= 1
+    assert result["resetTokens"] == ["stale-token", "fresh-token"]
+    assert result["resetBodies"][0]["reason"] == "manual_home_tutorial_reset"
+    assert result["resetBodies"][1]["reason"] == "manual_home_tutorial_reset"
+    assert result["homeSeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
 def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
     mock_page: Page,
 ):

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -246,7 +246,11 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
         () => {
             const originalAdd = window.addEventListener.bind(window);
             const originalRemove = window.removeEventListener.bind(window);
-            const trackedTypes = new Set(['neko:tutorial-completed', 'neko:tutorial-skipped']);
+            const trackedTypes = new Set([
+                'neko:tutorial-completed',
+                'neko:tutorial-skipped',
+                'neko:tutorial-ended-without-completion',
+            ]);
             const tracked = [];
 
             const sameCapture = (left, right) => Boolean(left) === Boolean(right);
@@ -297,6 +301,7 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
             window.__tutorialListenerCounts = () => ({
                 completed: activeCount('neko:tutorial-completed'),
                 skipped: activeCount('neko:tutorial-skipped'),
+                endedWithoutCompletion: activeCount('neko:tutorial-ended-without-completion'),
             });
         }
         """
@@ -322,13 +327,16 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
         () => {
             const counts = window.__tutorialListenerCounts();
             const before = window.__tutorialCountsBeforeWait;
-            return counts.completed === before.completed + 1 && counts.skipped === before.skipped + 1;
+            return counts.completed === before.completed + 1 &&
+                counts.skipped === before.skipped + 1 &&
+                counts.endedWithoutCompletion === before.endedWithoutCompletion + 1;
         }
         """
     )
     counts_during_wait = mock_page.evaluate("() => window.__tutorialListenerCounts()")
     assert counts_during_wait["completed"] == counts_before_wait["completed"] + 1
     assert counts_during_wait["skipped"] == counts_before_wait["skipped"] + 1
+    assert counts_during_wait["endedWithoutCompletion"] == counts_before_wait["endedWithoutCompletion"] + 1
 
     mock_page.evaluate(
         """
@@ -343,6 +351,35 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
 
     counts_after = mock_page.evaluate("() => window.__tutorialListenerCounts()")
     assert counts_after == counts_before_wait
+
+
+@pytest.mark.frontend
+def test_onboarding_wait_for_tutorial_completion_resolves_on_destroy_terminal_event(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialWaitDone = false;
+            window.CharacterPersonalityOnboarding.waitForTutorialCompletion().then(() => {
+                window.__tutorialWaitDone = true;
+            });
+        }
+        """
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-ended-without-completion', {
+                detail: { page: 'home', reason: 'page-changed' }
+            }));
+        }
+        """
+    )
+
+    mock_page.wait_for_function("() => window.__tutorialWaitDone === true")
 
 
 @pytest.mark.frontend

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -563,7 +563,7 @@ def test_tutorial_destroy_does_not_mark_seen_but_skip_does():
 
     assert "if (endMeta.reason === 'destroy')" in tutorial_source
     assert "if (endMeta.reason === 'skip')" in tutorial_source
-    assert "neko:tutorial-ended-without-completion" not in tutorial_source
+    assert "neko:tutorial-ended-without-completion" in tutorial_source
     assert "neko:tutorial-skipped" in tutorial_source
 
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -552,6 +552,21 @@ def test_home_yui_guide_does_not_route_to_steam_workshop():
     assert "#${p}-menu-steam-workshop" not in tutorial_source
 
 
+def test_home_tutorial_reset_also_clears_backend_prompt_state():
+    tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+
+    assert "/api/tutorial-prompt/reset" in tutorial_source
+
+
+def test_tutorial_destroy_does_not_mark_seen_but_skip_does():
+    tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+
+    assert "if (endMeta.reason === 'destroy')" in tutorial_source
+    assert "if (endMeta.reason === 'skip')" in tutorial_source
+    assert "neko:tutorial-ended-without-completion" not in tutorial_source
+    assert "neko:tutorial-skipped" in tutorial_source
+
+
 def test_universal_tutorial_manager_normalizes_api_key_handoff_and_resume_scene_mappings():
     source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
 

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -132,17 +132,15 @@ def test_tutorial_prompt_reset_route_clears_completed_state(tutorial_prompt_clie
 
 
 @pytest.mark.unit
-def test_tutorial_prompt_reset_route_allows_remote_frontend_without_local_csrf(unauthenticated_prompt_client):
+def test_tutorial_prompt_reset_route_rejects_request_without_csrf_and_origin(unauthenticated_prompt_client):
     client, _config = unauthenticated_prompt_client
 
     response = client.post("/api/tutorial-prompt/reset", json={
         "reason": "manual_home_tutorial_reset",
     })
 
-    assert response.status_code == 200
-    body = response.json()
-    assert body["ok"] is True
-    assert body["state"]["status"] == "observing"
+    assert response.status_code == 403
+    assert response.json().get("error_code") == "csrf_validation_failed"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -132,6 +132,20 @@ def test_tutorial_prompt_reset_route_clears_completed_state(tutorial_prompt_clie
 
 
 @pytest.mark.unit
+def test_tutorial_prompt_reset_route_allows_remote_frontend_without_local_csrf(unauthenticated_prompt_client):
+    client, _config = unauthenticated_prompt_client
+
+    response = client.post("/api/tutorial-prompt/reset", json={
+        "reason": "manual_home_tutorial_reset",
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["state"]["status"] == "observing"
+
+
+@pytest.mark.unit
 def test_yui_guide_handoff_token_is_backend_authoritative_and_single_use(tutorial_prompt_client):
     client, _config = tutorial_prompt_client
 

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -100,6 +100,38 @@ def test_heartbeat_route_rejects_request_with_wrong_csrf_token(unauthenticated_p
 
 
 @pytest.mark.unit
+def test_tutorial_prompt_reset_route_clears_completed_state(tutorial_prompt_client):
+    client, config = tutorial_prompt_client
+
+    started = client.post("/api/tutorial-prompt/tutorial-started", json={
+        "page": "home",
+        "source": "manual",
+    })
+    assert started.status_code == 200
+    completed = client.post("/api/tutorial-prompt/tutorial-completed", json={
+        "page": "home",
+        "source": "manual",
+        "tutorial_run_token": started.json()["tutorial_run_token"],
+    })
+    assert completed.status_code == 200
+
+    response = client.post("/api/tutorial-prompt/reset", json={
+        "reason": "manual_home_tutorial_reset",
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["state"]["status"] == "observing"
+    assert body["state"]["home_tutorial_completed"] is False
+    assert body["state"]["manual_home_tutorial_viewed"] is False
+
+    state = load_tutorial_prompt_state(config)
+    assert state["completed_at"] == 0
+    assert state["started_at"] == 0
+
+
+@pytest.mark.unit
 def test_yui_guide_handoff_token_is_backend_authoritative_and_single_use(tutorial_prompt_client):
     client, _config = tutorial_prompt_client
 

--- a/tests/unit/test_tutorial_prompt_state.py
+++ b/tests/unit/test_tutorial_prompt_state.py
@@ -24,6 +24,7 @@ from utils.tutorial_prompt_state import (
     record_tutorial_prompt_decision,
     record_tutorial_started,
     record_tutorial_completed,
+    reset_tutorial_prompt_state,
     save_tutorial_prompt_state,
 )
 
@@ -74,6 +75,39 @@ def test_prompt_triggers_immediately_on_first_open(tmp_path):
     assert state["active_prompt_token"] == response["prompt_token"]
     assert state["last_shown_at"] == 0
     assert state["recent_heartbeat_tokens"] == []
+
+
+@pytest.mark.unit
+def test_reset_tutorial_prompt_state_clears_completed_home_prompt_state(tmp_path):
+    config = DummyConfig(tmp_path)
+    started = record_tutorial_started(
+        {"page": "home", "source": "manual"},
+        config_manager=config,
+        now_ms=1_000,
+    )
+    record_tutorial_completed(
+        {
+            "page": "home",
+            "source": "manual",
+            "tutorial_run_token": started["tutorial_run_token"],
+        },
+        config_manager=config,
+        now_ms=2_000,
+    )
+
+    reset = reset_tutorial_prompt_state(config_manager=config)
+
+    assert reset["ok"] is True
+    assert reset["state"]["status"] == "observing"
+    assert reset["state"]["home_tutorial_completed"] is False
+    assert reset["state"]["manual_home_tutorial_viewed"] is False
+
+    state = load_tutorial_prompt_state(config)
+    assert state["completed_at"] == 0
+    assert state["started_at"] == 0
+    assert state["home_tutorial_completed"] is False
+    assert state["manual_home_tutorial_viewed"] is False
+    assert state["active_tutorial_run_token"] == ""
 
 
 @pytest.mark.unit

--- a/utils/tutorial_prompt_state.py
+++ b/utils/tutorial_prompt_state.py
@@ -41,6 +41,7 @@ from utils.prompt_state_core import (
     mark_prompt_decision_token as _mark_prompt_decision_token,
     normalize_prompt_flow_state,
     now_ms as _now_ms,
+    reset_successful_prompt_flow_state as _reset_successful_prompt_flow_state,
 )
 
 TUTORIAL_PROMPT_CONFIG_FILENAME = "tutorial_prompt_config.json"
@@ -973,6 +974,40 @@ def record_tutorial_completed(
     return {
         "ok": True,
         "ignored": False,
+        "state": build_public_tutorial_prompt_snapshot(state),
+    }
+
+
+def reset_tutorial_prompt_state(
+    *,
+    config_manager=None,
+) -> dict[str, Any]:
+    with _STATE_LOCK:
+        state = load_tutorial_prompt_state(config_manager)
+        changed = _reset_successful_prompt_flow_state(state, reset_prompt_history=True)
+
+        for field, empty_value in (
+            ("home_tutorial_completed", False),
+            ("manual_home_tutorial_viewed", False),
+            ("manual_home_tutorial_viewed_at", 0),
+            ("active_tutorial_run_token", ""),
+            ("active_tutorial_run_source", ""),
+            ("active_tutorial_run_started_at", 0),
+            ("never_remind", False),
+        ):
+            if state.get(field) != empty_value:
+                state[field] = empty_value
+                changed = True
+
+        if state.get("status") != "observing":
+            state["status"] = "observing"
+            changed = True
+
+        if changed:
+            state = save_tutorial_prompt_state(state, config_manager)
+
+    return {
+        "ok": True,
         "state": build_public_tutorial_prompt_snapshot(state),
     }
 


### PR DESCRIPTION
## 变更说明

修复首页教程从记忆浏览页重置后，有概率不重新触发的问题，并补齐教程跳过后的后端状态同步。

本次调整后：

1. 记忆浏览页重置首页教程 / 重置全部教程时，会同步重置后端 `tutorial_prompt` 状态。
2. 重置顺序改为：先请求后端 reset 成功，再清理前端 localStorage，避免出现“前端已清、后端没清”的半重置状态。
3. 首页教程正常完成和用户点击跳过，都会把后端教程状态同步为完成。
4. 内部 destroy 不再被当成教程完成，避免误写“已看过”状态。
5. `/api/tutorial-prompt/reset` 和其它教程写接口保持一致，继续使用本地 CSRF/origin 校验。
6. 前端 reset 请求会优先通过 `nekoLocalMutationSecurity` 获取安全请求头；如果当前页面没有加载该 helper，则 fallback 请求 `/api/config/page_config`，读取 `autostart_csrf_token` 后再调用 reset。

## 边界

本次只处理首页教程状态重置和教程结束状态同步，不修改：

- 首页教程步骤内容
- 初始人格选择流程和文案
- 记忆内容、角色卡、角色人格数据
- 聊天、TTS、字幕、主动提示逻辑
- 其它页面教程的步骤和选择器
- 现有 tutorial/autostart 其它写接口的校验策略

## 架构说明

当前实现选择与项目已有教程 mutation 接口保持一致：

- `tutorial-prompt/heartbeat`
- `tutorial-prompt/shown`
- `tutorial-prompt/decision`
- `tutorial-prompt/tutorial-started`
- `tutorial-prompt/tutorial-completed`
- `tutorial-prompt/reset`

这些写接口都要求本地 CSRF/origin 校验。

如果是前后端分离部署，服务器需要正确配置允许的前端 origin，并确保前端可以从 `/api/config/page_config` 获取 `autostart_csrf_token`。这属于项目现有本地 mutation 校验体系的部署前提，不是本次 reset 单独新增的特殊规则。

## 风险

- reset 接口现在和其它教程写接口一样要求 CSRF/origin；如果服务器部署没有配置前端 origin/token 下发，reset 请求可能返回 403。
- 跳过教程现在会同步为后端完成状态，符合“用户主动跳过后不应再次自动弹出”的预期。
- 内部 destroy 不再标记完成，如果后续代码错误依赖 destroy 表示完成，需要改为显式触发完成或跳过事件。
- 前端 fallback 读取 `/api/config/page_config` 只用于获取已有 token，不改变其它业务状态。

## 测试

已执行：

- `node --check static/universal-tutorial-manager.js`
- `node --check static/app-tutorial-prompt.js`
- `uv run pytest -q tests/unit/test_tutorial_prompt_state.py tests/unit/test_tutorial_prompt_router.py tests/test_agent_rewrite_regression.py -q`
- `uv run pytest -q tests/frontend/test_home_prompt_flow.py tests/frontend/test_initial_personality_onboarding.py tests/frontend/test_memory_browser.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加服务器端的主页教程重置能力，可将首页教程提示状态恢复至初始观察状态。

* **改进**
  * 重构教程完成/跳过的持久化流程，统一等待运行令牌后再持久化并复用逻辑。
  * 重置流程支持异步并与服务端同步：主页/全部重置会先调用后端再清理本地状态。
  * 明确区分销毁与跳过：销毁不标记为已查看，跳过会记录为已完成。

* **测试**
  * 新增多项单元与前端测试，覆盖重置、跳过、销毁及持久化行为验证。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1291)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->