### PR TITLE
修复“请她回来”后的边缘回弹与位置保存，并限制返回球、聊天框拖动仅响应左键

### DIFF
--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -2326,6 +2326,7 @@
         if (!header) return;
 
         header.addEventListener('mousedown', function (event) {
+            if (event.button !== 0) return;
             var closeButton = $('reactChatWindowCloseButton');
             if (closeButton && closeButton.contains(event.target)) return;
             var minimizeButton = $('reactChatWindowMinimizeButton');
@@ -2525,6 +2526,7 @@
         if (!shell) return;
 
         shell.addEventListener('mousedown', function (event) {
+            if (event.button !== 0) return;
             var target = event.target;
             if (!target || !target.dataset || !target.dataset.resizeDir) return;
             startResize(event.clientX, event.clientY, target.dataset.resizeDir);

--- a/static/app-ui.js
+++ b/static/app-ui.js
@@ -1188,6 +1188,109 @@
     const MULTI_WINDOW_RETURN_BALL_DRAG_SHRINK_SIZE = 80;
     let multiWindowReturnBallDragState = null;
 
+    function waitForAnimationFrames(count) {
+        const remaining = Math.max(1, Number(count) || 1);
+        return new Promise(resolve => {
+            const step = (left) => {
+                if (left <= 0) {
+                    resolve();
+                    return;
+                }
+                requestAnimationFrame(() => step(left - 1));
+            };
+            step(remaining);
+        });
+    }
+
+    function isModelContainerVisible(containerId) {
+        const el = document.getElementById(containerId);
+        if (!el || el.classList.contains('hidden')) return false;
+        const style = window.getComputedStyle ? getComputedStyle(el) : el.style;
+        return style.display !== 'none' && style.visibility !== 'hidden';
+    }
+
+    async function saveReturnModelPosition(modelType) {
+        try {
+            if (modelType === 'mmd') {
+                const interaction = window.mmdManager && window.mmdManager.interaction;
+                if (interaction && typeof interaction._savePositionAfterInteraction === 'function') {
+                    await interaction._savePositionAfterInteraction();
+                }
+                return;
+            }
+            if (modelType === 'vrm') {
+                const interaction = window.vrmManager && window.vrmManager.interaction;
+                if (interaction && typeof interaction._savePositionAfterInteraction === 'function') {
+                    await interaction._savePositionAfterInteraction();
+                }
+                return;
+            }
+            if (window.live2dManager && typeof window.live2dManager._savePositionAfterInteraction === 'function') {
+                await window.live2dManager._savePositionAfterInteraction();
+            }
+        } catch (error) {
+            console.warn('[App] 保存回来后的模型位置失败:', error);
+        }
+    }
+
+    async function settleReturnedModelBounds(shouldSaveWhenUnchanged) {
+        // showCurrentModel 会恢复容器和 canvas；等布局提交后再读边界，避免拿到隐藏态尺寸。
+        await waitForAnimationFrames(2);
+
+        let activeModelType = null;
+        try {
+            if (window.mmdManager && window.mmdManager.currentModel && isModelContainerVisible('mmd-container')) {
+                activeModelType = 'mmd';
+                const interaction = window.mmdManager.interaction;
+                if (interaction && typeof interaction._snapModelIntoScreen === 'function') {
+                    const snapped = await interaction._snapModelIntoScreen({ animate: true });
+                    if (!snapped && shouldSaveWhenUnchanged) {
+                        await saveReturnModelPosition('mmd');
+                    }
+                } else if (shouldSaveWhenUnchanged) {
+                    await saveReturnModelPosition('mmd');
+                }
+                return;
+            }
+
+            if (window.vrmManager && window.vrmManager.currentModel && isModelContainerVisible('vrm-container')) {
+                activeModelType = 'vrm';
+                const interaction = window.vrmManager.interaction;
+                if (interaction && typeof interaction._snapModelIntoScreen === 'function') {
+                    const snapped = await interaction._snapModelIntoScreen({ animate: true });
+                    if (snapped) {
+                        // VRM 的回弹方法只负责动画，最终位置需要由外层保存。
+                        await saveReturnModelPosition('vrm');
+                    } else if (shouldSaveWhenUnchanged) {
+                        await saveReturnModelPosition('vrm');
+                    }
+                } else if (shouldSaveWhenUnchanged) {
+                    await saveReturnModelPosition('vrm');
+                }
+                return;
+            }
+
+            if (window.live2dManager) {
+                activeModelType = 'live2d';
+                const liveModel = typeof window.live2dManager.getCurrentModel === 'function'
+                    ? window.live2dManager.getCurrentModel() : null;
+                if (liveModel && !liveModel.destroyed && typeof window.live2dManager._checkAndPerformSnap === 'function') {
+                    const snapped = await window.live2dManager._checkAndPerformSnap(liveModel, { allowWhenNotReady: true });
+                    if (!snapped && shouldSaveWhenUnchanged) {
+                        await saveReturnModelPosition('live2d');
+                    }
+                } else if (shouldSaveWhenUnchanged) {
+                    await saveReturnModelPosition('live2d');
+                }
+            }
+        } catch (error) {
+            console.warn('[App] 回来后的边界回弹计算失败:', error);
+            if (shouldSaveWhenUnchanged && activeModelType) {
+                await saveReturnModelPosition(activeModelType);
+            }
+        }
+    }
+
     function cancelReturnBallReveal(container) {
         if (!container) return;
         const revealFrameId = container.__nekoReturnBallRevealFrame;
@@ -1689,7 +1792,11 @@
         }
 
         state.handleMouseDown = (event) => {
-            if (event.button !== 0) return;
+            if (event.button !== 0) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                return;
+            }
             beginDrag(event.screenX, event.screenY, event);
         };
         state.handleMouseMove = (event) => {
@@ -2197,6 +2304,7 @@
             // 如果返回按钮被拖拽到新位置，先偏移模型再显示，避免闪烁
             const returnRect = event && event.detail && event.detail.returnButtonRect;
             const savedRect = window._savedGoodbyeRect;
+            let returnModelWasMoved = false;
             if (returnRect && savedRect) {
                 const returnCenterX = returnRect.left + returnRect.width / 2;
                 const returnCenterY = returnRect.top + returnRect.height / 2;
@@ -2208,10 +2316,10 @@
                 if (Math.abs(screenDx) > 5 || Math.abs(screenDy) > 5) {
                     console.log('[App] 返回按钮被拖拽，应用屏幕偏移:', Math.round(screenDx), Math.round(screenDy));
                     if (window.vrmManager && typeof window.vrmManager.applyScreenDelta === 'function') {
-                        window.vrmManager.applyScreenDelta(screenDx, screenDy);
+                        window.vrmManager.applyScreenDelta(screenDx, screenDy, { clamp: false });
                     }
                     if (window.mmdManager && typeof window.mmdManager.applyScreenDelta === 'function') {
-                        window.mmdManager.applyScreenDelta(screenDx, screenDy);
+                        window.mmdManager.applyScreenDelta(screenDx, screenDy, { clamp: false });
                     }
                     if (window.live2dManager) {
                         const liveModel = typeof window.live2dManager.getCurrentModel === 'function'
@@ -2221,6 +2329,7 @@
                             liveModel.y += screenDy;
                         }
                     }
+                    returnModelWasMoved = true;
                 }
             }
             window._savedGoodbyeRect = null;
@@ -2235,6 +2344,8 @@
                 console.error('[App] showCurrentModel 失败:', error);
                 showLive2d();
             }
+
+            await settleReturnedModelBounds(returnModelWasMoved);
 
             // 恢复 VRM canvas 的可见性
             const vrmCanvas = document.getElementById('vrm-canvas');

--- a/static/avatar-ui-buttons.js
+++ b/static/avatar-ui-buttons.js
@@ -695,6 +695,11 @@ const AvatarButtonMixin = {
             };
 
             container.addEventListener('mousedown', (e) => {
+                if (e.button !== 0) {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                    return;
+                }
                 if (container.contains(e.target)) {
                     e.preventDefault();
                     handleStart(e.clientX, e.clientY);

--- a/static/common_ui.js
+++ b/static/common_ui.js
@@ -307,7 +307,10 @@ function setupResizableChatContainer() {
         e.preventDefault();
     };
     // 绑定调整大小启动事件（仅 handle 上绑定 mousedown/touchstart）
-    resizeHandle.addEventListener('mousedown', startResize);
+    resizeHandle.addEventListener('mousedown', (e) => {
+        if (e.button !== 0) return;
+        startResize(e);
+    });
     resizeHandle.addEventListener('touchstart', startResize, { passive: false });
 
     window.addEventListener('resize', () => {
@@ -622,6 +625,10 @@ if (toggleBtn) {
     let pendingDragClientX = 0; // 待处理的鼠标位置
     let pendingDragClientY = 0;
 
+    function isPrimaryMouseDrag(e) {
+        return !e || e.type.includes('touch') || e.button === 0;
+    }
+
     // 拖动回弹配置（多屏幕切换时使用）
     const CHAT_SNAP_CONFIG = {
         margin: 6,
@@ -784,6 +791,8 @@ if (toggleBtn) {
 
     // 开始拖动的函数
     function startDrag(e, skipPreventDefault = false) {
+        if (!isPrimaryMouseDrag(e)) return false;
+
         isDragging = true;
         hasMoved = false;
         dragStartedFromToggleBtn = (e.target === toggleBtn || toggleBtn.contains(e.target));
@@ -830,6 +839,8 @@ if (toggleBtn) {
         if (!skipPreventDefault) {
             e.preventDefault();
         }
+
+        return true;
     }
 
     // 计算边界限制后的位移量
@@ -947,6 +958,7 @@ if (toggleBtn) {
     if (chatHeader) {
         // 鼠标事件
         chatHeader.addEventListener('mousedown', (e) => {
+            if (e.button !== 0) return;
             if (!isCollapsed()) {
                 startDrag(e);
             }
@@ -964,6 +976,7 @@ if (toggleBtn) {
     if (toggleBtn) {
         // 鼠标事件
         toggleBtn.addEventListener('mousedown', (e) => {
+            if (e.button !== 0) return;
             // 使用 skipPreventDefault=true 来保留 click 事件
             startDrag(e, true);
             e.stopPropagation(); // 阻止事件冒泡到 chatContainer
@@ -982,6 +995,7 @@ if (toggleBtn) {
             !!el.closest('textarea, input, button, select, a, [contenteditable]');
 
         textInputArea.addEventListener('mousedown', (e) => {
+            if (e.button !== 0) return;
             if (!isCollapsed() && !isInteractiveTarget(e.target)) {
                 startDrag(e);
             }
@@ -996,6 +1010,7 @@ if (toggleBtn) {
 
     // 折叠状态：点击容器（除了按钮）可以拖动或展开
     chatContainer.addEventListener('mousedown', (e) => {
+        if (e.button !== 0) return;
         if (isCollapsed()) {
             // 如果点击的是切换按钮，不启动拖动
             if (e.target === toggleBtn || toggleBtn.contains(e.target)) {

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -42,6 +42,7 @@ class MMDInteraction {
         };
         this._snapAnimationFrameId = null;
         this._isSnappingModel = false;
+        this._snapResolve = null;
 
         // 防抖保存
         this._savePositionDebounceTimer = null;
@@ -579,6 +580,209 @@ class MMDInteraction {
         }
     }
 
+    /**
+     * 基于可见像素限制 MMD 模型位置。
+     * 只有模型在某个方向上几乎不可见时才拉回，避免用户主动把大模型贴边时被过度纠正。
+     */
+    clampModelPosition(position, { minVisiblePixels = 200 } = {}) {
+        const mesh = this.manager.currentModel?.mesh;
+        const camera = this.manager.camera;
+        const renderer = this.manager.renderer;
+        if (!mesh || !camera || !renderer || !THREE) {
+            return position;
+        }
+
+        try {
+            const originalPosition = mesh.position.clone();
+            mesh.position.copy(position);
+            mesh.updateMatrixWorld(true);
+
+            const box = new THREE.Box3().setFromObject(mesh);
+
+            mesh.position.copy(originalPosition);
+            mesh.updateMatrixWorld(true);
+
+            if (!box || !Number.isFinite(box.min.x) || !Number.isFinite(box.max.x)) {
+                return position;
+            }
+
+            const canvasRect = renderer.domElement.getBoundingClientRect();
+            const screenWidth = canvasRect.width > 0 ? canvasRect.width : window.innerWidth;
+            const screenHeight = canvasRect.height > 0 ? canvasRect.height : window.innerHeight;
+            if (!(screenWidth > 0) || !(screenHeight > 0)) {
+                return position;
+            }
+
+            const effectiveMinX = Math.min(minVisiblePixels, screenWidth);
+            const effectiveMinY = Math.min(minVisiblePixels, screenHeight);
+            const corners = [
+                new THREE.Vector3(box.min.x, box.min.y, box.min.z),
+                new THREE.Vector3(box.max.x, box.min.y, box.min.z),
+                new THREE.Vector3(box.min.x, box.max.y, box.min.z),
+                new THREE.Vector3(box.max.x, box.max.y, box.min.z),
+                new THREE.Vector3(box.min.x, box.min.y, box.max.z),
+                new THREE.Vector3(box.max.x, box.min.y, box.max.z),
+                new THREE.Vector3(box.min.x, box.max.y, box.max.z),
+                new THREE.Vector3(box.max.x, box.max.y, box.max.z),
+            ];
+
+            let modelMinX = Infinity, modelMaxX = -Infinity;
+            let modelMinY = Infinity, modelMaxY = -Infinity;
+            for (const corner of corners) {
+                const projected = corner.clone().project(camera);
+                const screenX = (projected.x * 0.5 + 0.5) * screenWidth;
+                const screenY = (-projected.y * 0.5 + 0.5) * screenHeight;
+                modelMinX = Math.min(modelMinX, screenX);
+                modelMaxX = Math.max(modelMaxX, screenX);
+                modelMinY = Math.min(modelMinY, screenY);
+                modelMaxY = Math.max(modelMaxY, screenY);
+            }
+
+            const visibleWidth = Math.max(0, Math.min(screenWidth, modelMaxX) - Math.max(0, modelMinX));
+            const visibleHeight = Math.max(0, Math.min(screenHeight, modelMaxY) - Math.max(0, modelMinY));
+            const needsClampH = (modelMinX < 0 || modelMaxX > screenWidth) && visibleWidth < effectiveMinX;
+            const needsClampV = (modelMinY < 0 || modelMaxY > screenHeight) && visibleHeight < effectiveMinY;
+            if (!needsClampH && !needsClampV) {
+                return position;
+            }
+
+            let moveX = 0;
+            let moveY = 0;
+            if (needsClampH) {
+                if (modelMaxX < effectiveMinX) {
+                    moveX = effectiveMinX - modelMaxX;
+                } else if (modelMinX > screenWidth - effectiveMinX) {
+                    moveX = (screenWidth - effectiveMinX) - modelMinX;
+                }
+            }
+            if (needsClampV) {
+                if (modelMaxY < effectiveMinY) {
+                    moveY = effectiveMinY - modelMaxY;
+                } else if (modelMinY > screenHeight - effectiveMinY) {
+                    moveY = (screenHeight - effectiveMinY) - modelMinY;
+                }
+            }
+
+            const cameraDistance = camera.position.distanceTo(position);
+            if (cameraDistance < 0.001) {
+                return position;
+            }
+            const fov = camera.fov * (Math.PI / 180);
+            const worldHeight = 2 * Math.tan(fov / 2) * cameraDistance;
+            const worldWidth = worldHeight * (screenWidth / screenHeight);
+            const pixelToWorldX = worldWidth / screenWidth;
+            const pixelToWorldY = worldHeight / screenHeight;
+
+            const right = new THREE.Vector3(1, 0, 0).applyQuaternion(camera.quaternion);
+            const up = new THREE.Vector3(0, 1, 0).applyQuaternion(camera.quaternion);
+            const correctedPosition = position.clone();
+            correctedPosition.add(right.multiplyScalar(moveX * pixelToWorldX));
+            correctedPosition.add(up.multiplyScalar(-moveY * pixelToWorldY));
+
+            return correctedPosition;
+        } catch (error) {
+            console.warn('[MMD] 边界检测失败，跳过限制:', error);
+            return position;
+        }
+    }
+
+    _getSnapEasingFunction() {
+        const easingType = this._snapConfig?.easingType || 'easeOutBack';
+        const easingMap = {
+            easeOutBack: (t) => {
+                const c1 = 1.70158;
+                const c3 = c1 + 1;
+                return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+            },
+            easeOutCubic: (t) => (--t) * t * t + 1
+        };
+        return easingMap[easingType] || easingMap.easeOutCubic;
+    }
+
+    _animateModelToPosition(startPosition, targetPosition) {
+        const mesh = this.manager.currentModel?.mesh;
+        if (!mesh) return Promise.resolve(false);
+        if (!Number.isFinite(targetPosition?.x) || !Number.isFinite(targetPosition?.y) || !Number.isFinite(targetPosition?.z)) {
+            return Promise.resolve(false);
+        }
+
+        if (this._snapAnimationFrameId) {
+            cancelAnimationFrame(this._snapAnimationFrameId);
+            this._snapAnimationFrameId = null;
+            if (this._snapResolve) {
+                this._snapResolve(false);
+                this._snapResolve = null;
+            }
+            this._isSnappingModel = false;
+        }
+
+        const duration = this._snapConfig?.duration || 260;
+        const easingFn = this._getSnapEasingFunction();
+        const startTime = performance.now();
+        this._isSnappingModel = true;
+
+        return new Promise((resolve) => {
+            this._snapResolve = resolve;
+            const animate = (currentTime) => {
+                const elapsed = currentTime - startTime;
+                const progress = Math.min(elapsed / duration, 1);
+                const eased = easingFn(progress);
+
+                mesh.position.set(
+                    startPosition.x + (targetPosition.x - startPosition.x) * eased,
+                    startPosition.y + (targetPosition.y - startPosition.y) * eased,
+                    startPosition.z + (targetPosition.z - startPosition.z) * eased
+                );
+
+                if (progress < 1) {
+                    this._snapAnimationFrameId = requestAnimationFrame(animate);
+                } else {
+                    mesh.position.copy(targetPosition);
+                    this._isSnappingModel = false;
+                    this._snapAnimationFrameId = null;
+                    this._snapResolve = null;
+                    resolve(true);
+                }
+            };
+
+            this._snapAnimationFrameId = requestAnimationFrame(animate);
+        });
+    }
+
+    /**
+     * 将 MMD 模型回弹到当前可见区域内。
+     * 返回 true 表示位置被修正；修正完成后会保存最终位置。
+     */
+    async _snapModelIntoScreen({ animate = true } = {}) {
+        if (this._isSnappingModel) return false;
+        const mesh = this.manager.currentModel?.mesh;
+        if (!mesh || !this.manager.camera || !this.manager.renderer || !THREE) return false;
+
+        const startPosition = mesh.position.clone();
+        const targetPosition = this.clampModelPosition(startPosition.clone());
+        if (!targetPosition || !targetPosition.isVector3) {
+            return false;
+        }
+
+        const distance = startPosition.distanceTo(targetPosition);
+        if (!Number.isFinite(distance) || distance < 0.0001) {
+            return false;
+        }
+
+        let changed = false;
+        if (animate) {
+            changed = await this._animateModelToPosition(startPosition, targetPosition);
+        } else {
+            mesh.position.copy(targetPosition);
+            changed = true;
+        }
+
+        if (changed) {
+            await this._savePositionAfterInteraction();
+        }
+        return changed;
+    }
+
     // ═══════════════════ 偏好保存 ═══════════════════
 
     async _savePositionAfterInteraction() {
@@ -660,6 +864,11 @@ class MMDInteraction {
             cancelAnimationFrame(this._snapAnimationFrameId);
             this._snapAnimationFrameId = null;
         }
+        if (this._snapResolve) {
+            this._snapResolve(false);
+            this._snapResolve = null;
+        }
+        this._isSnappingModel = false;
 
         if (this._savePositionDebounceTimer) {
             clearTimeout(this._savePositionDebounceTimer);

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -195,6 +195,10 @@ class MMDInteraction {
             if (this._snapAnimationFrameId) {
                 cancelAnimationFrame(this._snapAnimationFrameId);
                 this._snapAnimationFrameId = null;
+                if (this._snapResolve) {
+                    this._snapResolve(false);
+                    this._snapResolve = null;
+                }
                 this._isSnappingModel = false;
             }
 
@@ -592,15 +596,15 @@ class MMDInteraction {
             return position;
         }
 
+        const originalPosition = mesh.position.clone();
+        let shouldRestorePosition = false;
+
         try {
-            const originalPosition = mesh.position.clone();
             mesh.position.copy(position);
+            shouldRestorePosition = true;
             mesh.updateMatrixWorld(true);
 
             const box = new THREE.Box3().setFromObject(mesh);
-
-            mesh.position.copy(originalPosition);
-            mesh.updateMatrixWorld(true);
 
             if (!box || !Number.isFinite(box.min.x) || !Number.isFinite(box.max.x)) {
                 return position;
@@ -683,6 +687,11 @@ class MMDInteraction {
         } catch (error) {
             console.warn('[MMD] 边界检测失败，跳过限制:', error);
             return position;
+        } finally {
+            if (shouldRestorePosition) {
+                mesh.position.copy(originalPosition);
+                mesh.updateMatrixWorld(true);
+            }
         }
     }
 

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -836,7 +836,7 @@ MMDManager.prototype._startUIUpdateLoop = function() {
  * 将屏幕像素偏移量应用到 MMD 模型的世界坐标
  * 用于"请她回来"按钮被拖拽后，模型跟随出现在新位置
  */
-MMDManager.prototype.applyScreenDelta = function(screenDx, screenDy) {
+MMDManager.prototype.applyScreenDelta = function(screenDx, screenDy, options = {}) {
     const mesh = this.currentModel && this.currentModel.mesh;
     if (!mesh || !this.camera || !this.renderer) return;
 
@@ -863,4 +863,9 @@ MMDManager.prototype.applyScreenDelta = function(screenDx, screenDy) {
 
     mesh.position.add(right.clone().multiplyScalar(screenDx * pixelToWorldX));
     mesh.position.add(up.clone().multiplyScalar(-screenDy * pixelToWorldY));
+
+    if (options.clamp !== false && this.interaction && typeof this.interaction.clampModelPosition === 'function') {
+        const clamped = this.interaction.clampModelPosition(mesh.position.clone());
+        if (clamped && clamped.isVector3) mesh.position.copy(clamped);
+    }
 };

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -846,6 +846,11 @@ VRMManager.prototype._setupReturnButtonDrag = function (returnButtonContainer) {
     };
 
     returnButtonContainer.addEventListener('mousedown', (e) => {
+        if (e.button !== 0) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            return;
+        }
         if (returnButtonContainer.contains(e.target)) {
             e.preventDefault(); handleStart(e.clientX, e.clientY);
         }
@@ -913,7 +918,7 @@ VRMManager.prototype._addReturnButtonBreathingAnimation = function () {
  * 将屏幕像素偏移量应用到 VRM 模型的世界坐标
  * 用于"请她回来"按钮被拖拽后，模型跟随出现在新位置
  */
-VRMManager.prototype.applyScreenDelta = function(screenDx, screenDy) {
+VRMManager.prototype.applyScreenDelta = function(screenDx, screenDy, options = {}) {
     const scene = this.currentModel && this.currentModel.scene;
     if (!scene || !this.camera || !this.renderer) return;
 
@@ -941,7 +946,7 @@ VRMManager.prototype.applyScreenDelta = function(screenDx, screenDy) {
     scene.position.add(right.clone().multiplyScalar(screenDx * pixelToWorldX));
     scene.position.add(up.clone().multiplyScalar(-screenDy * pixelToWorldY));
 
-    if (this.interaction && typeof this.interaction.clampModelPosition === 'function') {
+    if (options.clamp !== false && this.interaction && typeof this.interaction.clampModelPosition === 'function') {
         const clamped = this.interaction.clampModelPosition(scene.position.clone());
         if (clamped && clamped.isVector3) scene.position.copy(clamped);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 阻止右键/中键误触发拖拽与调整大小，现在仅主按钮（左键）可发起交互。
  * 在开始拖拽时会取消正在进行的回弹动画，避免交互卡顿或异步挂起。

* **新功能**
  * 添加“返回”控件的回位与定界流：自动将模型约束回屏内并在必要时保存位置。
  * 为回弹提供可选的平滑动画与更精确的可见性判定，提升模型回位体验。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1293)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->