### PR TITLE
Fix/home tutorial reset backend state

### DIFF
--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1101,10 +1101,6 @@ async def post_tutorial_prompt_decision(request: Request):
 @router.post("/tutorial-prompt/reset")
 async def post_tutorial_prompt_reset(request: Request):
     """重置主页新手引导状态，供记忆浏览的手动重置入口调用。"""
-    validation_error = _validate_local_mutation_request(request)
-    if validation_error is not None:
-        return validation_error
-
     return reset_tutorial_prompt_state(config_manager=get_config_manager())
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1101,6 +1101,10 @@ async def post_tutorial_prompt_decision(request: Request):
 @router.post("/tutorial-prompt/reset")
 async def post_tutorial_prompt_reset(request: Request):
     """重置主页新手引导状态，供记忆浏览的手动重置入口调用。"""
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
     return reset_tutorial_prompt_state(config_manager=get_config_manager())
 
 

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -158,6 +158,7 @@ from utils.tutorial_prompt_state import (
     record_tutorial_prompt_decision,
     record_tutorial_started,
     record_tutorial_completed,
+    reset_tutorial_prompt_state,
 )
 from utils.storage_location_bootstrap import build_storage_location_bootstrap_payload
 from utils.config_manager import get_config_manager as get_runtime_config_manager
@@ -1095,6 +1096,16 @@ async def post_tutorial_prompt_decision(request: Request):
         return record_tutorial_prompt_decision(payload, config_manager=get_config_manager())
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"ok": False, "error": str(exc)})
+
+
+@router.post("/tutorial-prompt/reset")
+async def post_tutorial_prompt_reset(request: Request):
+    """重置主页新手引导状态，供记忆浏览的手动重置入口调用。"""
+    validation_error = _validate_local_mutation_request(request)
+    if validation_error is not None:
+        return validation_error
+
+    return reset_tutorial_prompt_state(config_manager=get_config_manager())
 
 
 @router.get("/autostart-prompt/state")

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -871,6 +871,34 @@
         return state.tutorialRunToken;
     }
 
+    async function persistHomeTutorialCompletion(event, flowStep, persistedStep) {
+        const source = event.detail.source || 'manual';
+        const tutorialRunToken = await waitForTutorialRunToken(2000);
+        logFlow(flowStep, {
+            source: source,
+            promptToken: shortPromptToken(state.promptDrivenTutorialToken),
+            tutorialRunToken: shortTutorialRunToken(tutorialRunToken),
+        });
+
+        if (!tutorialRunToken) {
+            logFlow(`${flowStep}-skipped`, {
+                source: source,
+                reason: 'missing_run_token',
+            });
+            state.promptDrivenTutorialToken = null;
+            return;
+        }
+
+        await persistTutorialLifecycle('/api/tutorial-prompt/tutorial-completed', {
+            page: 'home',
+            source: source,
+            tutorial_run_token: tutorialRunToken,
+        }, persistedStep, {
+            clearRunTokenOnSuccess: true,
+        });
+        state.promptDrivenTutorialToken = null;
+    }
+
     function takeHeartbeatSnapshot() {
         const snapshot = {
             foregroundMsDelta: consumeForegroundDelta(),
@@ -1334,31 +1362,11 @@
             endHomeTutorialFeatureSuppression('tutorial-completed');
             emitHomeTutorialLockIfChanged('tutorial-completed');
             void (async function () {
-                const source = event.detail.source || 'manual';
-                const tutorialRunToken = await waitForTutorialRunToken(2000);
-                logFlow('tutorial-completed', {
-                    source: source,
-                    promptToken: shortPromptToken(state.promptDrivenTutorialToken),
-                    tutorialRunToken: shortTutorialRunToken(tutorialRunToken),
-                });
-
-                if (!tutorialRunToken) {
-                    logFlow('tutorial-completed-skipped', {
-                        source: source,
-                        reason: 'missing_run_token',
-                    });
-                    state.promptDrivenTutorialToken = null;
-                    return;
-                }
-
-                await persistTutorialLifecycle('/api/tutorial-prompt/tutorial-completed', {
-                    page: 'home',
-                    source: source,
-                    tutorial_run_token: tutorialRunToken,
-                }, 'tutorial-completed-persisted', {
-                    clearRunTokenOnSuccess: true,
-                });
-                state.promptDrivenTutorialToken = null;
+                await persistHomeTutorialCompletion(
+                    event,
+                    'tutorial-completed',
+                    'tutorial-completed-persisted'
+                );
             })();
             scheduleFastHeartbeat();
         });
@@ -1416,8 +1424,19 @@
             }
             state.tutorialRunning = false;
             state.tutorialStartRequested = false;
+            state.tutorialStarted = true;
+            state.homeTutorialCompleted = true;
+            markHomeTutorialStorageSeen();
             endHomeTutorialFeatureSuppression('tutorial-skipped');
             emitHomeTutorialLockIfChanged('tutorial-skipped');
+            void (async function () {
+                await persistHomeTutorialCompletion(
+                    event,
+                    'tutorial-skipped',
+                    'tutorial-skipped-persisted'
+                );
+            })();
+            scheduleFastHeartbeat();
         });
 
         // Keep this recovery bridge paired with handlePromptAcceptance:

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -5,6 +5,9 @@
     const FAST_HEARTBEAT_DELAY_MS = 1200;
     const HOME_TUTORIAL_START_WAIT_TIMEOUT_MS = 15000;
     const HOME_TUTORIAL_STORAGE_KEY_FALLBACK = 'neko_tutorial_home';
+    const HOME_TUTORIAL_RESET_EVENT = 'neko:home-tutorial-reset';
+    const HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY = 'neko_home_tutorial_reset_event';
+    const HOME_TUTORIAL_RESET_CHANNEL = 'neko_tutorial_events';
     const HEARTBEAT_ENDPOINT = '/api/tutorial-prompt/heartbeat';
     const TUTORIAL_PROMPT_COORDINATION_KEY = 'home-tutorial-prompt';
     const TUTORIAL_PROMPT_PRIORITY = 200;
@@ -633,6 +636,12 @@
         });
     }
 
+    function clearHomeTutorialStorageSeen() {
+        getHomeTutorialStorageKeys().forEach(function (storageKey) {
+            localStorage.removeItem(storageKey);
+        });
+    }
+
     function isHomeTutorialSeen() {
         return getHomeTutorialStorageKeys().some(function (storageKey) {
             return localStorage.getItem(storageKey) === 'true';
@@ -680,6 +689,18 @@
 
     mod.isHomeTutorialInteractionLocked = computeHomeTutorialInteractionLocked;
     mod.isHomeTutorialBlockingGreeting = computeHomeTutorialInteractionLocked;
+    mod.shouldSuppressAutomaticHomeTutorialStart = function () {
+        return !!(
+            state.promptDisplayPending
+            || state.promptOpen
+            || state.tutorialStartRequested
+            || state.tutorialRunning
+            || state.lastPromptTokenSeen
+            || state.homeTutorialCompleted
+            || state.neverRemind
+            || state.deferredUntil > Date.now()
+        );
+    };
     window.isNekoHomeTutorialInteractionLocked = computeHomeTutorialInteractionLocked;
     window.isNekoHomeTutorialBlockingGreeting = computeHomeTutorialInteractionLocked;
 
@@ -949,6 +970,36 @@
         return hasReplaySensitiveHeartbeatMetrics(snapshot)
             || snapshot.homeTutorialCompleted
             || snapshot.manualHomeTutorialViewed;
+    }
+
+    function resetHomeTutorialClientState(reason) {
+        const snapshot = state.inFlightHeartbeatSnapshot;
+        if (snapshot) {
+            snapshot.homeTutorialCompleted = false;
+            snapshot.manualHomeTutorialViewed = false;
+        }
+
+        state.homeTutorialCompleted = false;
+        state.manualHomeTutorialViewed = false;
+        state.tutorialStarted = false;
+        state.neverRemind = false;
+        state.deferredUntil = 0;
+        state.promptDrivenTutorialToken = null;
+        state.tutorialRunToken = null;
+        state.pendingTutorialStartPayload = null;
+        clearHomeTutorialStorageSeen();
+        logFlow('home-tutorial-reset', {
+            reason: reason || 'unknown',
+        });
+    }
+
+    function handleHomeTutorialResetDetail(detail) {
+        const payload = detail && typeof detail === 'object' ? detail : {};
+        const page = String(payload.page || '').trim();
+        if (page && page !== 'home' && page !== 'all') {
+            return;
+        }
+        resetHomeTutorialClientState(String(payload.source || payload.reason || '').trim());
     }
 
     function buildHeartbeatPayload(snapshot) {
@@ -1453,6 +1504,36 @@
                 endHomeTutorialFeatureSuppression(detail.reason || 'lock-released');
             }
         });
+
+        window.addEventListener(HOME_TUTORIAL_RESET_EVENT, function (event) {
+            handleHomeTutorialResetDetail(event && event.detail ? event.detail : {});
+        });
+
+        window.addEventListener('storage', function (event) {
+            if (!event || event.key !== HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY || !event.newValue) {
+                return;
+            }
+            try {
+                handleHomeTutorialResetDetail(JSON.parse(event.newValue));
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to parse home tutorial reset storage event:', error);
+            }
+        });
+
+        if (typeof BroadcastChannel === 'function') {
+            try {
+                const resetChannel = new BroadcastChannel(HOME_TUTORIAL_RESET_CHANNEL);
+                resetChannel.addEventListener('message', function (event) {
+                    const message = event && event.data ? event.data : {};
+                    if (!message || message.type !== HOME_TUTORIAL_RESET_EVENT) {
+                        return;
+                    }
+                    handleHomeTutorialResetDetail(message.detail || {});
+                });
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to listen for home tutorial reset broadcasts:', error);
+            }
+        }
 
         window.addEventListener('beforeunload', flushHeartbeatOnUnload);
     }

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -239,6 +239,7 @@
                 const cleanup = () => {
                     window.removeEventListener('neko:tutorial-completed', handleCompleted);
                     window.removeEventListener('neko:tutorial-skipped', handleSkipped);
+                    window.removeEventListener('neko:tutorial-ended-without-completion', handleEndedWithoutCompletion);
                 };
                 const finish = () => {
                     if (settled) {
@@ -250,8 +251,10 @@
                 };
                 const handleCompleted = () => finish();
                 const handleSkipped = () => finish();
+                const handleEndedWithoutCompletion = () => finish();
                 window.addEventListener('neko:tutorial-completed', handleCompleted, { once: true });
                 window.addEventListener('neko:tutorial-skipped', handleSkipped, { once: true });
+                window.addEventListener('neko:tutorial-ended-without-completion', handleEndedWithoutCompletion, { once: true });
             });
         }
 

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -113,6 +113,7 @@
             this.typewriterRunId = 0;
             this.typewriterTimer = null;
             this.lastTutorialPromptState = null;
+            this.homeTutorialCompletedInSession = false;
             // bootstrap 超时 fallthrough 时拉这个旗子，让 waitForTutorialFlowToSettle 的轮询循环退出，
             // 避免后台每 120ms 一次的 /api/tutorial-prompt/state 永久泄漏。
             this._tutorialFlowAborted = false;
@@ -157,8 +158,13 @@
                     }),
                 ]);
                 if (!tutorialSettled) {
-                    this._tutorialFlowAborted = true;
-                    console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out, fallthrough');
+                    if (this.isHomeTutorialInteractionLocked()) {
+                        console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out while home tutorial is locked, keep waiting');
+                        await this.waitForTutorialFlowToSettle();
+                    } else {
+                        this._tutorialFlowAborted = true;
+                        console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out, fallthrough');
+                    }
                 }
                 if (await this.openIfManualReselectPending()) {
                     return;
@@ -258,6 +264,43 @@
             });
         }
 
+        isHomeTutorialInteractionLocked() {
+            if (!this.shouldRespectHomeTutorialGate()) {
+                return false;
+            }
+
+            const manager = window.universalTutorialManager || null;
+            if (window.isInTutorial === true
+                || (manager && manager.currentPage === 'home' && manager.isTutorialRunning)) {
+                return true;
+            }
+
+            const lockReaders = [
+                window.isNekoHomeTutorialInteractionLocked,
+                window.isNekoHomeTutorialBlockingGreeting,
+                window.appTutorialPrompt && window.appTutorialPrompt.isHomeTutorialInteractionLocked,
+                window.appTutorialPrompt && window.appTutorialPrompt.isHomeTutorialBlockingGreeting,
+            ];
+            return lockReaders.some((reader) => {
+                if (typeof reader !== 'function') {
+                    return false;
+                }
+                try {
+                    return reader() === true;
+                } catch (_) {
+                    return false;
+                }
+            });
+        }
+
+        async waitForHomeTutorialInteractionUnlock() {
+            while (this.isHomeTutorialInteractionLocked()) {
+                await new Promise((resolve) => {
+                    window.setTimeout(resolve, TUTORIAL_PROMPT_POLL_INTERVAL_MS);
+                });
+            }
+        }
+
         async fetchTutorialPromptState() {
             try {
                 const payload = await requestJson('/api/tutorial-prompt/state', {
@@ -284,11 +327,71 @@
             return String(state.user_cohort || '').trim().toLowerCase();
         }
 
+        hasHomeTutorialCompletionMarker() {
+            if (this.homeTutorialCompletedInSession) {
+                return true;
+            }
+
+            const manager = window.universalTutorialManager || null;
+            if (manager && typeof manager.hasSeenTutorial === 'function') {
+                try {
+                    if (manager.hasSeenTutorial('home')) {
+                        return true;
+                    }
+                } catch (_) {}
+            }
+
+            try {
+                return localStorage.getItem('neko_tutorial_home_yui_v1') === 'true'
+                    || localStorage.getItem('neko_tutorial_home') === 'true';
+            } catch (_) {
+                return false;
+            }
+        }
+
+        shouldWaitForHomeTutorialCompletion(state) {
+            if (!this.shouldRespectHomeTutorialGate() || this.hasHomeTutorialCompletionMarker()) {
+                return false;
+            }
+            if (!state || typeof state !== 'object') {
+                return false;
+            }
+
+            if (state.home_tutorial_completed === true || state.manual_home_tutorial_viewed === true) {
+                return false;
+            }
+
+            const userCohort = this.normalizeTutorialPromptUserCohort(state);
+            if (userCohort === 'new') {
+                return true;
+            }
+            if (userCohort !== 'existing') {
+                return false;
+            }
+
+            const chatTurns = Number(state.chat_turns || 0);
+            const voiceSessions = Number(state.voice_sessions || 0);
+            const shownCount = Number(state.shown_count || 0);
+            return (!Number.isFinite(chatTurns) || chatTurns <= 0)
+                && (!Number.isFinite(voiceSessions) || voiceSessions <= 0)
+                && (!Number.isFinite(shownCount) || shownCount <= 0);
+        }
+
         isTutorialPromptSettled(state) {
             if (!state || typeof state !== 'object') {
                 return false;
             }
             const status = this.normalizeTutorialPromptStatus(state);
+            if (this.shouldWaitForHomeTutorialCompletion(state) && (
+                status === 'completed'
+                || status === 'deferred'
+                || status === 'never'
+                || status === 'error'
+                || status === 'observing'
+                || status === 'prompted'
+            )) {
+                return false;
+            }
             if (status === 'completed' || status === 'deferred' || status === 'never' || status === 'error') {
                 return true;
             }
@@ -314,6 +417,10 @@
             while (true) {
                 if (this._tutorialFlowAborted) {
                     return;
+                }
+                if (this.isHomeTutorialInteractionLocked()) {
+                    await this.waitForHomeTutorialInteractionUnlock();
+                    continue;
                 }
                 if (window.universalTutorialManager && window.universalTutorialManager.isTutorialRunning) {
                     await this.waitForTutorialCompletion();
@@ -455,6 +562,13 @@
         }
 
         bindTutorialLifecycleEvents() {
+            const markHomeTutorialCompleted = (event) => {
+                if (!event || !event.detail || event.detail.page !== 'home') {
+                    return;
+                }
+                this.homeTutorialCompletedInSession = true;
+            };
+
             const queueResume = (event) => {
                 if (!event || !event.detail || event.detail.page !== 'home') {
                     return;
@@ -501,6 +615,8 @@
             };
 
             window.addEventListener('neko:tutorial-started', queueResume);
+            window.addEventListener('neko:tutorial-completed', markHomeTutorialCompleted);
+            window.addEventListener('neko:tutorial-skipped', markHomeTutorialCompleted);
             window.addEventListener('neko:tutorial-completed', resumeIfNeeded);
             window.addEventListener('neko:tutorial-skipped', resumeIfNeeded);
         }

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -29,10 +29,36 @@ function logTutorialPromptFlow(step, details = {}) {
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
 }
 
+async function getTutorialMutationHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    const helper = window.nekoLocalMutationSecurity;
+    if (helper && typeof helper.getMutationHeaders === 'function') {
+        try {
+            return Object.assign(headers, await helper.getMutationHeaders());
+        } catch (error) {
+            console.warn('[Tutorial] 获取本地写入安全头失败，尝试直接读取页面配置:', error);
+        }
+    }
+
+    try {
+        const response = await fetch('/api/config/page_config', { cache: 'no-store' });
+        if (!response.ok) {
+            return headers;
+        }
+        const data = await response.json();
+        if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
+            headers['X-CSRF-Token'] = data.autostart_csrf_token;
+        }
+    } catch (error) {
+        console.warn('[Tutorial] 读取页面配置失败，继续使用基础请求头:', error);
+    }
+    return headers;
+}
+
 async function postTutorialPromptReset(reason) {
     const response = await fetch('/api/tutorial-prompt/reset', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: await getTutorialMutationHeaders(),
         body: JSON.stringify({ reason }),
     });
     if (!response.ok) {

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -29,36 +29,10 @@ function logTutorialPromptFlow(step, details = {}) {
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
 }
 
-async function getTutorialMutationHeaders() {
-    const headers = { 'Content-Type': 'application/json' };
-    const helper = window.nekoLocalMutationSecurity;
-    if (helper && typeof helper.getMutationHeaders === 'function') {
-        try {
-            return Object.assign(headers, await helper.getMutationHeaders());
-        } catch (error) {
-            console.warn('[Tutorial] 获取本地写入安全头失败，尝试直接读取页面配置:', error);
-        }
-    }
-
-    try {
-        const response = await fetch('/api/config/page_config', { cache: 'no-store' });
-        if (!response.ok) {
-            return headers;
-        }
-        const data = await response.json();
-        if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
-            headers['X-CSRF-Token'] = data.autostart_csrf_token;
-        }
-    } catch (error) {
-        console.warn('[Tutorial] 读取页面配置失败，继续使用基础请求头:', error);
-    }
-    return headers;
-}
-
 async function postTutorialPromptReset(reason) {
     const response = await fetch('/api/tutorial-prompt/reset', {
         method: 'POST',
-        headers: await getTutorialMutationHeaders(),
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reason }),
     });
     if (!response.ok) {
@@ -5217,11 +5191,11 @@ class UniversalTutorialManager {
     }
 
     async resetAllTutorials() {
+        await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         TUTORIAL_PAGES.forEach(page => {
             this.getStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
         });
         this.markTutorialManualStartIntent('home');
-        await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         console.log('[Tutorial] 已重置所有页面引导');
         this.notifyTutorialResetForCurrentPageIfNeeded('all');
     } 
@@ -5235,6 +5209,10 @@ class UniversalTutorialManager {
             return;
         }
 
+        if (pageKey === 'home') {
+            await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
+        }
+
         this.getStorageKeysForPage(pageKey).forEach((storageKey) => {
             const oldVal = localStorage.getItem(storageKey);
             localStorage.removeItem(storageKey);
@@ -5243,7 +5221,6 @@ class UniversalTutorialManager {
 
         if (pageKey === 'home') {
             this.markTutorialManualStartIntent('home');
-            await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
         }
 
         console.log('[Tutorial] 已重置页面引导:', pageKey);
@@ -5373,9 +5350,9 @@ async function resetAllTutorials() {
         await window.universalTutorialManager.resetAllTutorials();
     } else {
         // 如果管理器未初始化，直接清除 localStorage
+        await postTutorialPromptReset('manual_all_tutorial_reset');
         TUTORIAL_PAGES.forEach(page => { localStorage.removeItem(getTutorialStorageKeyForPage(page)); });
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
-        await postTutorialPromptReset('manual_all_tutorial_reset');
     }
     alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
 }
@@ -5427,6 +5404,9 @@ async function resetTutorialForPage(pageKey) {
     if (window.universalTutorialManager) {
         await window.universalTutorialManager.resetPageTutorial(pageKey);
     } else {
+        if (pageKey === 'home') {
+            await postTutorialPromptReset('manual_home_tutorial_reset');
+        }
         if (pageKey === 'model_manager') {
             localStorage.removeItem(getTutorialStorageKeyForPage('model_manager'));
             localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_live2d'));
@@ -5438,7 +5418,6 @@ async function resetTutorialForPage(pageKey) {
         }
         if (pageKey === 'home') {
             localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
-            await postTutorialPromptReset('manual_home_tutorial_reset');
         }
     }
 

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -4791,6 +4791,13 @@ class UniversalTutorialManager {
         this._teardownTutorialUI();
 
         if (endMeta.reason === 'destroy') {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-ended-without-completion', {
+                detail: {
+                    page: this.currentPage,
+                    source: completedSource,
+                    reason: endMeta.rawReason
+                }
+            }));
             this.logPromptFlow('tutorial-ended-without-completion', {
                 page: this.currentPage,
                 source: completedSource,

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -12,6 +12,9 @@ const TUTORIAL_PROMPT_FLOW_PREFIX = '[TutorialPromptFlow]';
 const TUTORIAL_YUI_LIVE2D_MODEL_NAME = 'yui-origin';
 const TUTORIAL_YUI_LIVE2D_MODEL_PATH = '/static/yui-origin/yui-origin.model3.json';
 const TUTORIAL_AVATAR_OVERRIDE_TIMEOUT_MS = 8000;
+const HOME_TUTORIAL_RESET_EVENT = 'neko:home-tutorial-reset';
+const HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY = 'neko_home_tutorial_reset_event';
+const HOME_TUTORIAL_RESET_CHANNEL = 'neko_tutorial_events';
 
 function getTutorialStorageKeyForPage(pageKey) {
     return TUTORIAL_STORAGE_KEY_PREFIX + pageKey;
@@ -21,12 +24,61 @@ function getTutorialManualIntentKeyForPage(pageKey) {
     return getTutorialStorageKeyForPage(pageKey) + '_manual_intent';
 }
 
+function getTutorialStorageKeysForPageFallback(pageKey) {
+    if (pageKey === 'model_manager') {
+        return ['model_manager', 'model_manager_live2d', 'model_manager_vrm', 'model_manager_mmd', 'model_manager_common']
+            .map(getTutorialStorageKeyForPage);
+    }
+
+    if (pageKey === 'home') {
+        return [
+            getTutorialStorageKeyForPage('home_yui_v1'),
+            getTutorialStorageKeyForPage('home'),
+        ];
+    }
+
+    return [getTutorialStorageKeyForPage(pageKey)];
+}
+
 function logTutorialPromptFlow(step, details = {}) {
     // 默认关闭高频引导流程日志，避免 heartbeat 等调试信息刷屏。
     if (localStorage.getItem('neko_tutorial_prompt_flow_debug') !== '1') {
         return;
     }
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
+}
+
+function dispatchHomeTutorialResetEvent(pageKey, source) {
+    if (pageKey !== 'home' && pageKey !== 'all') {
+        return;
+    }
+    const detail = {
+        page: pageKey,
+        source: source || 'manual_home_tutorial_reset',
+        nonce: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    };
+
+    window.dispatchEvent(new CustomEvent(HOME_TUTORIAL_RESET_EVENT, { detail }));
+
+    if (typeof BroadcastChannel === 'function') {
+        try {
+            const channel = new BroadcastChannel(HOME_TUTORIAL_RESET_CHANNEL);
+            channel.postMessage({
+                type: HOME_TUTORIAL_RESET_EVENT,
+                detail,
+            });
+            channel.close();
+        } catch (error) {
+            console.warn('[Tutorial] 广播首页教程重置事件失败:', error);
+        }
+    }
+
+    try {
+        localStorage.setItem(HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY, JSON.stringify(detail));
+        localStorage.removeItem(HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY);
+    } catch (error) {
+        console.warn('[Tutorial] 写入首页教程重置同步事件失败:', error);
+    }
 }
 
 async function getTutorialMutationHeaders() {
@@ -771,6 +823,13 @@ class UniversalTutorialManager {
         const launchTutorial = () => {
             setTimeout(() => {
                 this._pendingI18nStart = false;
+                if (this.shouldSkipAutomaticHomeTutorialStart()) {
+                    this.logPromptFlow('home-auto-start-skipped', {
+                        page: this.currentPage,
+                        reason: 'prompt-flow-active',
+                    });
+                    return;
+                }
                 this.startTutorial();
             }, delayMs);
         };
@@ -813,6 +872,26 @@ class UniversalTutorialManager {
             cleanup();
             launchTutorial();
         }, 5000);
+    }
+
+    shouldSkipAutomaticHomeTutorialStart() {
+        if (this.currentPage !== 'home') {
+            return false;
+        }
+        const source = this.peekTutorialStartSource('home') || 'auto';
+        if (source !== 'auto') {
+            return false;
+        }
+        const prompt = window.appTutorialPrompt || null;
+        if (!prompt || typeof prompt.shouldSuppressAutomaticHomeTutorialStart !== 'function') {
+            return false;
+        }
+        try {
+            return prompt.shouldSuppressAutomaticHomeTutorialStart() === true;
+        } catch (error) {
+            console.warn('[Tutorial] 检查主页自动教程启动抑制状态失败:', error);
+            return false;
+        }
     }
 
     /**
@@ -5246,6 +5325,7 @@ class UniversalTutorialManager {
             this.getStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
         });
         this.markTutorialManualStartIntent('home');
+        dispatchHomeTutorialResetEvent('all', 'manual_all_tutorial_reset');
         console.log('[Tutorial] 已重置所有页面引导');
         this.notifyTutorialResetForCurrentPageIfNeeded('all');
     } 
@@ -5271,6 +5351,7 @@ class UniversalTutorialManager {
 
         if (pageKey === 'home') {
             this.markTutorialManualStartIntent('home');
+            dispatchHomeTutorialResetEvent('home', 'manual_home_tutorial_reset');
         }
 
         console.log('[Tutorial] 已重置页面引导:', pageKey);
@@ -5401,8 +5482,11 @@ async function resetAllTutorials() {
     } else {
         // 如果管理器未初始化，直接清除 localStorage
         await postTutorialPromptReset('manual_all_tutorial_reset');
-        TUTORIAL_PAGES.forEach(page => { localStorage.removeItem(getTutorialStorageKeyForPage(page)); });
+        TUTORIAL_PAGES.forEach(page => {
+            getTutorialStorageKeysForPageFallback(page).forEach(key => localStorage.removeItem(key));
+        });
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+        dispatchHomeTutorialResetEvent('all', 'manual_all_tutorial_reset');
     }
     alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
 }
@@ -5458,16 +5542,13 @@ async function resetTutorialForPage(pageKey) {
             await postTutorialPromptReset('manual_home_tutorial_reset');
         }
         if (pageKey === 'model_manager') {
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_live2d'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_vrm'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_mmd'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_common'));
+            getTutorialStorageKeysForPageFallback('model_manager').forEach(key => localStorage.removeItem(key));
         } else {
-            localStorage.removeItem(getTutorialStorageKeyForPage(pageKey));
+            getTutorialStorageKeysForPageFallback(pageKey).forEach(key => localStorage.removeItem(key));
         }
         if (pageKey === 'home') {
             localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+            dispatchHomeTutorialResetEvent('home', 'manual_home_tutorial_reset');
         }
     }
 

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -29,6 +29,44 @@ function logTutorialPromptFlow(step, details = {}) {
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
 }
 
+async function getTutorialMutationHeaders() {
+    const headers = { 'Content-Type': 'application/json' };
+    const helper = window.nekoLocalMutationSecurity;
+    if (helper && typeof helper.getMutationHeaders === 'function') {
+        try {
+            return Object.assign(headers, await helper.getMutationHeaders());
+        } catch (error) {
+            console.warn('[Tutorial] 获取本地写入安全头失败，尝试直接读取页面配置:', error);
+        }
+    }
+
+    try {
+        const response = await fetch('/api/config/page_config', { cache: 'no-store' });
+        if (!response.ok) {
+            return headers;
+        }
+        const data = await response.json();
+        if (data && typeof data.autostart_csrf_token === 'string' && data.autostart_csrf_token) {
+            headers['X-CSRF-Token'] = data.autostart_csrf_token;
+        }
+    } catch (error) {
+        console.warn('[Tutorial] 读取页面配置失败，继续使用基础请求头:', error);
+    }
+    return headers;
+}
+
+async function postTutorialPromptReset(reason) {
+    const response = await fetch('/api/tutorial-prompt/reset', {
+        method: 'POST',
+        headers: await getTutorialMutationHeaders(),
+        body: JSON.stringify({ reason }),
+    });
+    if (!response.ok) {
+        throw new Error(`tutorial prompt reset failed: ${response.status}`);
+    }
+    return response.json();
+}
+
 window.getTutorialStorageKeyForPage = getTutorialStorageKeyForPage;
 window.getTutorialManualIntentKeyForPage = getTutorialManualIntentKeyForPage;
 window.logTutorialPromptFlow = logTutorialPromptFlow;
@@ -4735,6 +4773,17 @@ class UniversalTutorialManager {
 
         this._teardownTutorialUI();
 
+        if (endMeta.reason === 'destroy') {
+            this.logPromptFlow('tutorial-ended-without-completion', {
+                page: this.currentPage,
+                source: completedSource,
+                reason: endMeta.reason,
+                rawReason: endMeta.rawReason
+            });
+            console.log('[Tutorial] 引导未完成即结束，页面:', this.currentPage, 'reason:', endMeta.rawReason);
+            return;
+        }
+
         // 标记用户已看过该页面的引导
         const storageKey = this.getStorageKey();
         localStorage.setItem(storageKey, 'true');
@@ -4742,6 +4791,24 @@ class UniversalTutorialManager {
             const commonStorageKey = getTutorialStorageKeyForPage('model_manager_common');
             localStorage.setItem(commonStorageKey, 'true');
             console.log('[Tutorial] 已标记模型管理通用步骤为已看过');
+        }
+
+        if (endMeta.reason === 'skip') {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: {
+                    page: this.currentPage,
+                    source: completedSource,
+                    reason: endMeta.rawReason
+                }
+            }));
+            this.logPromptFlow('tutorial-skipped', {
+                page: this.currentPage,
+                source: completedSource,
+                reason: endMeta.reason,
+                rawReason: endMeta.rawReason
+            });
+            console.log('[Tutorial] 引导已跳过并标记看过，页面:', this.currentPage);
+            return;
         }
 
         window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
@@ -5145,11 +5212,16 @@ class UniversalTutorialManager {
     /** 
      * 重置所有页面的引导状态 
      */ 
-    resetAllTutorials() {
+    async resetHomeTutorialPromptState(reason = 'manual_home_tutorial_reset') {
+        return postTutorialPromptReset(reason);
+    }
+
+    async resetAllTutorials() {
         TUTORIAL_PAGES.forEach(page => {
             this.getStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
         });
         this.markTutorialManualStartIntent('home');
+        await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         console.log('[Tutorial] 已重置所有页面引导');
         this.notifyTutorialResetForCurrentPageIfNeeded('all');
     } 
@@ -5157,9 +5229,9 @@ class UniversalTutorialManager {
     /**
      * 重置指定页面的引导状态
      */
-    resetPageTutorial(pageKey) {
+    async resetPageTutorial(pageKey) {
         if (pageKey === 'all') {
-            this.resetAllTutorials();
+            await this.resetAllTutorials();
             return;
         }
 
@@ -5171,6 +5243,7 @@ class UniversalTutorialManager {
 
         if (pageKey === 'home') {
             this.markTutorialManualStartIntent('home');
+            await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
         }
 
         console.log('[Tutorial] 已重置页面引导:', pageKey);
@@ -5295,13 +5368,14 @@ async function initUniversalTutorialManager() {
  * 全局函数：重置所有引导
  * 供 HTML 按钮调用
  */
-function resetAllTutorials() {
+async function resetAllTutorials() {
     if (window.universalTutorialManager) {
-        window.universalTutorialManager.resetAllTutorials();
+        await window.universalTutorialManager.resetAllTutorials();
     } else {
         // 如果管理器未初始化，直接清除 localStorage
         TUTORIAL_PAGES.forEach(page => { localStorage.removeItem(getTutorialStorageKeyForPage(page)); });
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+        await postTutorialPromptReset('manual_all_tutorial_reset');
     }
     alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
 }
@@ -5310,12 +5384,12 @@ function resetAllTutorials() {
  * 全局函数：重置指定页面的引导
  * 供下拉菜单调用
  */
-function resetTutorialForPage(pageKey) {
+async function resetTutorialForPage(pageKey) {
     if (!pageKey) return;
     console.log('%c[Tutorial] resetTutorialForPage 被调用, pageKey:', 'color: red; font-weight: bold', pageKey);
 
     if (pageKey === 'all') {
-        resetAllTutorials();
+        await resetAllTutorials();
         return;
     }
 
@@ -5351,7 +5425,7 @@ function resetTutorialForPage(pageKey) {
     }
 
     if (window.universalTutorialManager) {
-        window.universalTutorialManager.resetPageTutorial(pageKey);
+        await window.universalTutorialManager.resetPageTutorial(pageKey);
     } else {
         if (pageKey === 'model_manager') {
             localStorage.removeItem(getTutorialStorageKeyForPage('model_manager'));
@@ -5364,6 +5438,7 @@ function resetTutorialForPage(pageKey) {
         }
         if (pageKey === 'home') {
             localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+            await postTutorialPromptReset('manual_home_tutorial_reset');
         }
     }
 

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -56,11 +56,28 @@ async function getTutorialMutationHeaders() {
 }
 
 async function postTutorialPromptReset(reason) {
-    const response = await fetch('/api/tutorial-prompt/reset', {
+    const body = JSON.stringify({ reason });
+    const sendResetRequest = async () => fetch('/api/tutorial-prompt/reset', {
         method: 'POST',
         headers: await getTutorialMutationHeaders(),
-        body: JSON.stringify({ reason }),
+        body,
     });
+
+    let response = await sendResetRequest();
+    if (response.status === 403 && window.nekoLocalMutationSecurity &&
+        typeof window.nekoLocalMutationSecurity.refreshToken === 'function') {
+        let shouldRetry = false;
+        try {
+            const payload = await response.clone().json();
+            shouldRetry = payload && payload.error_code === 'csrf_validation_failed';
+        } catch (_) {
+            shouldRetry = false;
+        }
+        if (shouldRetry) {
+            await window.nekoLocalMutationSecurity.refreshToken();
+            response = await sendResetRequest();
+        }
+    }
     if (!response.ok) {
         throw new Error(`tutorial prompt reset failed: ${response.status}`);
     }

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -762,6 +762,135 @@ def test_tutorial_started_event_retries_failed_sync_on_heartbeat(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_skip_persists_completion_state(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__tutorialStartedBodies = [];
+            window.__tutorialCompletedBodies = [];
+            window.getTutorialStorageKeyForPage = function(page) {
+                return page === 'home' ? 'neko_tutorial_home_yui_v1' : 'neko_tutorial_' + page;
+            };
+            window.universalTutorialManager = {
+                currentPage: 'home',
+                isTutorialRunning: false,
+                hasSeenTutorial: function() {
+                    return false;
+                },
+                logPromptFlow: function() {},
+                requestTutorialStart: async function() {
+                    return false;
+                },
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-started') {
+                window.__tutorialStartedBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    tutorial_run_token: 'skip-run-token',
+                    state: {
+                        status: 'started',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-completed') {
+                window.__tutorialCompletedBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'completed',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: {
+                    page: 'home',
+                    source: 'manual',
+                },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__tutorialStartedBodies.length === 1",
+        timeout=5000,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: {
+                    page: 'home',
+                    source: 'manual',
+                },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__tutorialCompletedBodies.length === 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            completedBodies: window.__tutorialCompletedBodies.slice(),
+            preferredSeen: window.localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: window.localStorage.getItem('neko_tutorial_home'),
+        })
+        """
+    )
+
+    assert result["completedBodies"][0]["source"] == "manual"
+    assert result["completedBodies"][0]["tutorial_run_token"] == "skip-run-token"
+    assert result["preferredSeen"] == "true"
+    assert result["legacySeen"] == "true"
+
+
+@pytest.mark.frontend
 def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
     mock_page: Page,
 ):

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -891,6 +891,86 @@ def test_home_tutorial_skip_persists_completion_state(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_refreshes_stale_csrf_token_once(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'stale-token',
+            });
+            window.__pageConfigFetchCount = 0;
+            window.__resetTokens = [];
+            window.__resetBodies = [];
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            const csrfToken = headers['X-CSRF-Token'] || headers['x-csrf-token'] || '';
+            if (requestUrl === '/api/config/page_config') {
+                window.__pageConfigFetchCount += 1;
+                return jsonResponse({
+                    success: true,
+                    autostart_csrf_token: 'fresh-token',
+                    model_path: '',
+                    model_type: 'live2d',
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                window.__resetTokens.push(csrfToken);
+                window.__resetBodies.push(body);
+                if (csrfToken !== 'fresh-token') {
+                    return jsonResponse({
+                        ok: false,
+                        error_code: 'csrf_validation_failed',
+                    }, 403);
+                }
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            localStorage.setItem('neko_tutorial_home', 'true');
+            await resetTutorialForPage('home');
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            pageConfigFetchCount: window.__pageConfigFetchCount,
+            resetTokens: window.__resetTokens.slice(),
+            resetBodies: window.__resetBodies.slice(),
+            homeSeen: localStorage.getItem('neko_tutorial_home'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["pageConfigFetchCount"] >= 1
+    assert result["resetTokens"] == ["stale-token", "fresh-token"]
+    assert result["resetBodies"][0]["reason"] == "manual_home_tutorial_reset"
+    assert result["resetBodies"][1]["reason"] == "manual_home_tutorial_reset"
+    assert result["homeSeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
 def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
     mock_page: Page,
 ):

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -971,6 +971,278 @@ def test_home_tutorial_reset_refreshes_stale_csrf_token_once(mock_page: Page):
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_without_manager_clears_versioned_home_key(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'test-token',
+            });
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            window.universalTutorialManager = null;
+            localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            localStorage.setItem('neko_tutorial_home', 'true');
+            await resetTutorialForPage('home');
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_event_prevents_stale_completion_heartbeat(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__heartbeatBodies = [];
+            Object.defineProperty(navigator, 'sendBeacon', {
+                configurable: true,
+                value: null,
+            });
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => localStorage.getItem('neko_tutorial_home') === 'true'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+            window.dispatchEvent(new Event('beforeunload'));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__heartbeatBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            homeSeen: localStorage.getItem('neko_tutorial_home'),
+            latestHeartbeat: window.__heartbeatBodies[window.__heartbeatBodies.length - 1],
+        })
+        """
+    )
+
+    assert result["homeSeen"] is None
+    assert result["latestHeartbeat"]["home_tutorial_completed"] is False
+    assert result["latestHeartbeat"]["manual_home_tutorial_viewed"] is False
+
+
+@pytest.mark.frontend
+def test_cross_window_home_tutorial_reset_event_prevents_stale_completion_heartbeat(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__heartbeatBodies = [];
+            Object.defineProperty(navigator, 'sendBeacon', {
+                configurable: true,
+                value: null,
+            });
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => localStorage.getItem('neko_tutorial_home') === 'true'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'neko_home_tutorial_reset_event',
+                newValue: JSON.stringify({
+                    page: 'home',
+                    source: 'manual_home_tutorial_reset',
+                    nonce: 'from-memory-browser-window',
+                }),
+            }));
+            window.dispatchEvent(new Event('beforeunload'));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__heartbeatBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            homeSeen: localStorage.getItem('neko_tutorial_home'),
+            latestHeartbeat: window.__heartbeatBodies[window.__heartbeatBodies.length - 1],
+        })
+        """
+    )
+
+    assert result["homeSeen"] is None
+    assert result["latestHeartbeat"]["home_tutorial_completed"] is False
+    assert result["latestHeartbeat"]["manual_home_tutorial_viewed"] is False
+
+
+@pytest.mark.frontend
+def test_all_tutorial_reset_without_manager_clears_versioned_home_key(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'test-token',
+            });
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            window.universalTutorialManager = null;
+            localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            localStorage.setItem('neko_tutorial_home', 'true');
+            localStorage.setItem('neko_tutorial_model_manager_mmd', 'true');
+            await resetAllTutorials();
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            modelManagerMmdSeen: localStorage.getItem('neko_tutorial_model_manager_mmd'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["modelManagerMmdSeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
 def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
     mock_page: Page,
 ):
@@ -1314,6 +1586,50 @@ def test_tutorial_heartbeat_does_not_report_completed_while_tutorial_is_running(
 
     assert result["manual_home_tutorial_viewed"] is True
     assert result["home_tutorial_completed"] is False
+
+
+@pytest.mark.frontend
+def test_started_manual_home_tutorial_does_not_suppress_reload_auto_start(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.universalTutorialManager = {
+                currentPage: 'home',
+                isTutorialRunning: false,
+                hasSeenTutorial: function() {
+                    return false;
+                },
+                logPromptFlow: function() {},
+                requestTutorialStart: async function() {
+                    return false;
+                },
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'started',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => window.appTutorialPrompt && window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart",
+        timeout=5000,
+    )
+
+    assert mock_page.evaluate(
+        "() => window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart()"
+    ) is False
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -246,7 +246,11 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
         () => {
             const originalAdd = window.addEventListener.bind(window);
             const originalRemove = window.removeEventListener.bind(window);
-            const trackedTypes = new Set(['neko:tutorial-completed', 'neko:tutorial-skipped']);
+            const trackedTypes = new Set([
+                'neko:tutorial-completed',
+                'neko:tutorial-skipped',
+                'neko:tutorial-ended-without-completion',
+            ]);
             const tracked = [];
 
             const sameCapture = (left, right) => Boolean(left) === Boolean(right);
@@ -297,6 +301,7 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
             window.__tutorialListenerCounts = () => ({
                 completed: activeCount('neko:tutorial-completed'),
                 skipped: activeCount('neko:tutorial-skipped'),
+                endedWithoutCompletion: activeCount('neko:tutorial-ended-without-completion'),
             });
         }
         """
@@ -322,13 +327,16 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
         () => {
             const counts = window.__tutorialListenerCounts();
             const before = window.__tutorialCountsBeforeWait;
-            return counts.completed === before.completed + 1 && counts.skipped === before.skipped + 1;
+            return counts.completed === before.completed + 1 &&
+                counts.skipped === before.skipped + 1 &&
+                counts.endedWithoutCompletion === before.endedWithoutCompletion + 1;
         }
         """
     )
     counts_during_wait = mock_page.evaluate("() => window.__tutorialListenerCounts()")
     assert counts_during_wait["completed"] == counts_before_wait["completed"] + 1
     assert counts_during_wait["skipped"] == counts_before_wait["skipped"] + 1
+    assert counts_during_wait["endedWithoutCompletion"] == counts_before_wait["endedWithoutCompletion"] + 1
 
     mock_page.evaluate(
         """
@@ -343,6 +351,35 @@ def test_wait_for_tutorial_completion_removes_sibling_listener_after_completion(
 
     counts_after = mock_page.evaluate("() => window.__tutorialListenerCounts()")
     assert counts_after == counts_before_wait
+
+
+@pytest.mark.frontend
+def test_onboarding_wait_for_tutorial_completion_resolves_on_destroy_terminal_event(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialWaitDone = false;
+            window.CharacterPersonalityOnboarding.waitForTutorialCompletion().then(() => {
+                window.__tutorialWaitDone = true;
+            });
+        }
+        """
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-ended-without-completion', {
+                detail: { page: 'home', reason: 'page-changed' }
+            }));
+        }
+        """
+    )
+
+    mock_page.wait_for_function("() => window.__tutorialWaitDone === true")
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -486,12 +486,224 @@ def test_onboarding_does_not_preempt_new_user_tutorial_prompt_flow(mock_page: Pa
 
 
 @pytest.mark.frontend
+def test_onboarding_waits_for_home_tutorial_storage_completion_even_if_prompt_state_completed(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.universalTutorialManager.hasSeenTutorial = function(page) {
+                return page === 'home'
+                    && window.localStorage.getItem('neko_tutorial_home_yui_v1') === 'true';
+            };
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(350)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            window.localStorage.setItem('neko_tutorial_home', 'true');
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_does_not_timeout_while_home_tutorial_is_running(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            const realSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, delay, ...args) => {
+                if (delay === 15000) {
+                    return realSetTimeout(callback, 20, ...args);
+                }
+                return realSetTimeout(callback, delay, ...args);
+            };
+            window.universalTutorialManager.isTutorialRunning = true;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(120)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_does_not_open_while_home_tutorial_start_is_locked(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            const realSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, delay, ...args) => {
+                if (delay === 15000) {
+                    return realSetTimeout(callback, 20, ...args);
+                }
+                return realSetTimeout(callback, delay, ...args);
+            };
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__homeTutorialLocked = true;
+            window.isNekoHomeTutorialInteractionLocked = () => window.__homeTutorialLocked;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(120)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__homeTutorialLocked = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_waits_when_default_character_makes_new_user_look_existing(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: 'observing',
+                shown_count: 0,
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: false,
+                manual_home_tutorial_viewed: false,
+                chat_turns: 0,
+                voice_sessions: 0,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(350)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                shown_count: 0,
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                chat_turns: 0,
+                voice_sessions: 0,
+                user_cohort: 'existing',
+            };
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
 def test_onboarding_ignores_stale_auto_home_tutorial_start_after_prompt_completed(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(
         """
         () => {
             window.universalTutorialManager.isTutorialRunning = false;
+            window.localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
             window.__tutorialPromptStatePayload = {
                 status: 'completed',
                 deferred_until: 0,
@@ -533,6 +745,7 @@ def test_onboarding_hides_overlay_when_real_auto_tutorial_starts_after_overlay(m
         """
         () => {
             window.universalTutorialManager.isTutorialRunning = false;
+            window.localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
             window.__tutorialPromptStatePayload = {
                 status: 'completed',
                 deferred_until: 0,
@@ -588,7 +801,7 @@ def test_onboarding_does_not_treat_tutorial_prompt_fetch_failure_as_settled(mock
         """
         () => {
             window.universalTutorialManager.isTutorialRunning = false;
-            window.__tutorialPromptFetchFailuresRemaining = 2;
+            window.__tutorialPromptFetchFailuresRemaining = 5;
             window.__tutorialPromptState = 'completed';
         }
         """

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -563,7 +563,7 @@ def test_tutorial_destroy_does_not_mark_seen_but_skip_does():
 
     assert "if (endMeta.reason === 'destroy')" in tutorial_source
     assert "if (endMeta.reason === 'skip')" in tutorial_source
-    assert "neko:tutorial-ended-without-completion" not in tutorial_source
+    assert "neko:tutorial-ended-without-completion" in tutorial_source
     assert "neko:tutorial-skipped" in tutorial_source
 
 

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -552,6 +552,21 @@ def test_home_yui_guide_does_not_route_to_steam_workshop():
     assert "#${p}-menu-steam-workshop" not in tutorial_source
 
 
+def test_home_tutorial_reset_also_clears_backend_prompt_state():
+    tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+
+    assert "/api/tutorial-prompt/reset" in tutorial_source
+
+
+def test_tutorial_destroy_does_not_mark_seen_but_skip_does():
+    tutorial_source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
+
+    assert "if (endMeta.reason === 'destroy')" in tutorial_source
+    assert "if (endMeta.reason === 'skip')" in tutorial_source
+    assert "neko:tutorial-ended-without-completion" not in tutorial_source
+    assert "neko:tutorial-skipped" in tutorial_source
+
+
 def test_universal_tutorial_manager_normalizes_api_key_handoff_and_resume_scene_mappings():
     source = Path("static/universal-tutorial-manager.js").read_text(encoding="utf-8")
 

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -132,17 +132,15 @@ def test_tutorial_prompt_reset_route_clears_completed_state(tutorial_prompt_clie
 
 
 @pytest.mark.unit
-def test_tutorial_prompt_reset_route_allows_remote_frontend_without_local_csrf(unauthenticated_prompt_client):
+def test_tutorial_prompt_reset_route_rejects_request_without_csrf_and_origin(unauthenticated_prompt_client):
     client, _config = unauthenticated_prompt_client
 
     response = client.post("/api/tutorial-prompt/reset", json={
         "reason": "manual_home_tutorial_reset",
     })
 
-    assert response.status_code == 200
-    body = response.json()
-    assert body["ok"] is True
-    assert body["state"]["status"] == "observing"
+    assert response.status_code == 403
+    assert response.json().get("error_code") == "csrf_validation_failed"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -132,6 +132,20 @@ def test_tutorial_prompt_reset_route_clears_completed_state(tutorial_prompt_clie
 
 
 @pytest.mark.unit
+def test_tutorial_prompt_reset_route_allows_remote_frontend_without_local_csrf(unauthenticated_prompt_client):
+    client, _config = unauthenticated_prompt_client
+
+    response = client.post("/api/tutorial-prompt/reset", json={
+        "reason": "manual_home_tutorial_reset",
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["state"]["status"] == "observing"
+
+
+@pytest.mark.unit
 def test_yui_guide_handoff_token_is_backend_authoritative_and_single_use(tutorial_prompt_client):
     client, _config = tutorial_prompt_client
 

--- a/tests/unit/test_tutorial_prompt_router.py
+++ b/tests/unit/test_tutorial_prompt_router.py
@@ -100,6 +100,38 @@ def test_heartbeat_route_rejects_request_with_wrong_csrf_token(unauthenticated_p
 
 
 @pytest.mark.unit
+def test_tutorial_prompt_reset_route_clears_completed_state(tutorial_prompt_client):
+    client, config = tutorial_prompt_client
+
+    started = client.post("/api/tutorial-prompt/tutorial-started", json={
+        "page": "home",
+        "source": "manual",
+    })
+    assert started.status_code == 200
+    completed = client.post("/api/tutorial-prompt/tutorial-completed", json={
+        "page": "home",
+        "source": "manual",
+        "tutorial_run_token": started.json()["tutorial_run_token"],
+    })
+    assert completed.status_code == 200
+
+    response = client.post("/api/tutorial-prompt/reset", json={
+        "reason": "manual_home_tutorial_reset",
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["state"]["status"] == "observing"
+    assert body["state"]["home_tutorial_completed"] is False
+    assert body["state"]["manual_home_tutorial_viewed"] is False
+
+    state = load_tutorial_prompt_state(config)
+    assert state["completed_at"] == 0
+    assert state["started_at"] == 0
+
+
+@pytest.mark.unit
 def test_yui_guide_handoff_token_is_backend_authoritative_and_single_use(tutorial_prompt_client):
     client, _config = tutorial_prompt_client
 

--- a/tests/unit/test_tutorial_prompt_state.py
+++ b/tests/unit/test_tutorial_prompt_state.py
@@ -24,6 +24,7 @@ from utils.tutorial_prompt_state import (
     record_tutorial_prompt_decision,
     record_tutorial_started,
     record_tutorial_completed,
+    reset_tutorial_prompt_state,
     save_tutorial_prompt_state,
 )
 
@@ -74,6 +75,39 @@ def test_prompt_triggers_immediately_on_first_open(tmp_path):
     assert state["active_prompt_token"] == response["prompt_token"]
     assert state["last_shown_at"] == 0
     assert state["recent_heartbeat_tokens"] == []
+
+
+@pytest.mark.unit
+def test_reset_tutorial_prompt_state_clears_completed_home_prompt_state(tmp_path):
+    config = DummyConfig(tmp_path)
+    started = record_tutorial_started(
+        {"page": "home", "source": "manual"},
+        config_manager=config,
+        now_ms=1_000,
+    )
+    record_tutorial_completed(
+        {
+            "page": "home",
+            "source": "manual",
+            "tutorial_run_token": started["tutorial_run_token"],
+        },
+        config_manager=config,
+        now_ms=2_000,
+    )
+
+    reset = reset_tutorial_prompt_state(config_manager=config)
+
+    assert reset["ok"] is True
+    assert reset["state"]["status"] == "observing"
+    assert reset["state"]["home_tutorial_completed"] is False
+    assert reset["state"]["manual_home_tutorial_viewed"] is False
+
+    state = load_tutorial_prompt_state(config)
+    assert state["completed_at"] == 0
+    assert state["started_at"] == 0
+    assert state["home_tutorial_completed"] is False
+    assert state["manual_home_tutorial_viewed"] is False
+    assert state["active_tutorial_run_token"] == ""
 
 
 @pytest.mark.unit

--- a/utils/tutorial_prompt_state.py
+++ b/utils/tutorial_prompt_state.py
@@ -41,6 +41,7 @@ from utils.prompt_state_core import (
     mark_prompt_decision_token as _mark_prompt_decision_token,
     normalize_prompt_flow_state,
     now_ms as _now_ms,
+    reset_successful_prompt_flow_state as _reset_successful_prompt_flow_state,
 )
 
 TUTORIAL_PROMPT_CONFIG_FILENAME = "tutorial_prompt_config.json"
@@ -973,6 +974,40 @@ def record_tutorial_completed(
     return {
         "ok": True,
         "ignored": False,
+        "state": build_public_tutorial_prompt_snapshot(state),
+    }
+
+
+def reset_tutorial_prompt_state(
+    *,
+    config_manager=None,
+) -> dict[str, Any]:
+    with _STATE_LOCK:
+        state = load_tutorial_prompt_state(config_manager)
+        changed = _reset_successful_prompt_flow_state(state, reset_prompt_history=True)
+
+        for field, empty_value in (
+            ("home_tutorial_completed", False),
+            ("manual_home_tutorial_viewed", False),
+            ("manual_home_tutorial_viewed_at", 0),
+            ("active_tutorial_run_token", ""),
+            ("active_tutorial_run_source", ""),
+            ("active_tutorial_run_started_at", 0),
+            ("never_remind", False),
+        ):
+            if state.get(field) != empty_value:
+                state[field] = empty_value
+                changed = True
+
+        if state.get("status") != "observing":
+            state["status"] = "observing"
+            changed = True
+
+        if changed:
+            state = save_tutorial_prompt_state(state, config_manager)
+
+    return {
+        "ok": True,
         "state": build_public_tutorial_prompt_snapshot(state),
     }
 


### PR DESCRIPTION
## 变更说明

在 PR #1291 已修复后端教程 reset 状态的基础上，本次补齐前端侧的首页教程重置同步和新用户弹窗串行逻辑。

本次主要解决两个前端时序问题：

1. 从记忆浏览页重置首页教程或全部教程后，页面刷新 / 重载时，旧窗口或旧本地状态可能继续影响首页教程启动，导致首页教程偶发不弹。
2. 新用户首次选择完存储位置后，初始人格选择弹窗可能先于首页教程弹出，随后又被首页教程覆盖，弹窗顺序不稳定。

本次调整后：

- 首页教程 reset 会同步通知当前窗口和其他窗口清理本地首页教程完成标记。
- 首页教程自动启动前会避开正在展示的教程提示、运行中的教程、已完成、不再提醒、稍后提醒等明确状态。
- 初始人格选择会等待首页教程完成或用户跳过后再弹出。
- 教程运行期间刷新页面时，未完成的首页教程仍有机会重新触发，不会因为本地旧标记直接跳过。
- 补充前端回归测试覆盖 reset、刷新、首页教程自动启动、人设选择等待等场景。

## 和 PR #1291 的区别

PR #1291 主要处理后端教程状态 reset、接口安全、远程前端请求兼容，以及 heartbeat / teardown 不应误写 completed 的问题。

本 PR 不重复修改后端 reset 接口和状态存储逻辑，重点只补前端侧：

- reset 事件同步
- localStorage 首页教程标记清理
- 首页教程自动启动抑制判断
- 初始人格选择与首页教程的弹窗顺序控制

## 边界

本次改动只涉及首页教程和初始人格选择之间的前端时序，不修改：

- 聊天主流程
- 字幕翻译
- TTS
- API Key / 模型配置
- 角色卡管理
- Steam 创意工坊订阅
- 存储位置选择的保存逻辑
- 记忆内容读写逻辑
- 其他页面教程的步骤和文案
- PR #1291 中已有的后端 reset 接口逻辑

本次没有新增硬编码教程文案，也没有修改 i18n 文案内容。

## 风险

- 本次修复依赖前端事件同步和 localStorage 状态清理，如果后续首页教程状态字段继续调整，需要同步检查这些判断条件。
- 初始人格选择现在会等待首页教程完成或跳过后再弹，如果产品后续要求人格选择优先于首页教程，需要重新调整弹窗优先级。
- 多窗口场景下，reset 事件通过 BroadcastChannel 和 storage event 同步；极老浏览器可能只走 storage event 兜底。
- 本 PR 是基于 PR #1291 之上的前端补充修复，如果 PR #1291 的后端 reset 逻辑发生较大变化，需要重新确认本 PR 的前端状态判断是否仍匹配。

## 测试

已跑本分支波及范围测试：

```bash
node --check static/app-tutorial-prompt.js
node --check static/universal-tutorial-manager.js
node --check static/js/character_personality_onboarding.js
uv run pytest -q tests/frontend/test_home_prompt_flow.py tests/frontend/test_initial_personality_onboarding.py tests/frontend/test_memory_browser.py tests/frontend/test_storage_location_startup.py tests/unit/test_tutorial_prompt_state.py tests/unit/test_tutorial_prompt_router.py tests/unit/test_websocket_home_tutorial_guard.py tests/test_agent_rewrite_regression.py tests/unit/test_system_status_router.py tests/unit/test_storage_location_bootstrap.py tests/unit/test_storage_location_router.py tests/e2e/test_home_prompt_flow.py -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加教程提示重置功能，支持通过新的API端点重置教程状态
  * 实现跨标签页和跨上下文的教程重置同步，支持DOM事件、本地存储和消息广播

* **改进**
  * 增强主页教程完成状态的追踪和管理机制
  * 优化教程自动启动的条件判断逻辑
  * 改进性格化引导流程与教程状态的协调

* **测试**
  * 新增前端和单元测试覆盖教程重置功能

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1294)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->