### PR TITLE
fix: stabilize home tutorial reset flow

### DIFF
--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -80,6 +80,8 @@
         resetGeneration: 0,
         resetBroadcastChannel: null,
         pendingResetAfterHeartbeatReason: '',
+        pendingResetAfterCompletionReason: '',
+        inFlightCompletionLifecycleCount: 0,
         userCohort: 'unknown',
         mobileResizeRetryBound: false,
         featureSuppression: {
@@ -827,9 +829,19 @@
         }
     }
 
+    function isHomeTutorialCompletionLifecycle(url, payload) {
+        return url === '/api/tutorial-prompt/tutorial-completed'
+            && payload
+            && payload.page === 'home';
+    }
+
     async function persistTutorialLifecycle(url, payload, flowStep, options) {
         const requestOptions = options || {};
         const requestResetGeneration = state.resetGeneration;
+        const isCompletionLifecycle = isHomeTutorialCompletionLifecycle(url, payload);
+        if (isCompletionLifecycle) {
+            state.inFlightCompletionLifecycleCount += 1;
+        }
         try {
             const response = requestOptions.fireAndForget
                 ? await fireAndForgetJson(url, payload)
@@ -842,6 +854,11 @@
                 logFlow('lifecycle-stale-ignored', {
                     source: flowStep || 'unknown',
                 });
+                if (isCompletionLifecycle && state.pendingResetAfterCompletionReason) {
+                    const resetReason = state.pendingResetAfterCompletionReason;
+                    state.pendingResetAfterCompletionReason = '';
+                    await persistResetAfterStaleMutation(resetReason, 'reset-after-stale-completion');
+                }
                 return response;
             }
             if (response && response.state) {
@@ -868,6 +885,13 @@
         } catch (error) {
             console.warn('[TutorialPrompt] failed to persist lifecycle event:', error);
             return null;
+        } finally {
+            if (isCompletionLifecycle) {
+                state.inFlightCompletionLifecycleCount = Math.max(
+                    0,
+                    state.inFlightCompletionLifecycleCount - 1
+                );
+            }
         }
     }
 
@@ -1028,6 +1052,9 @@
         ) {
             state.pendingResetAfterHeartbeatReason = resetReason;
         }
+        if (state.inFlightCompletionLifecycleCount > 0) {
+            state.pendingResetAfterCompletionReason = resetReason;
+        }
         if (snapshot) {
             snapshot.homeTutorialCompleted = false;
             snapshot.manualHomeTutorialViewed = false;
@@ -1125,7 +1152,8 @@
         state.resetBroadcastChannel = null;
     }
 
-    async function persistResetAfterStaleHeartbeat(reason) {
+    async function persistResetAfterStaleMutation(reason, flowStep) {
+        const source = flowStep || 'reset-after-stale-mutation';
         const requestResetGeneration = state.resetGeneration;
         try {
             const response = await requestJson('/api/tutorial-prompt/reset', {
@@ -1135,13 +1163,13 @@
                 },
             });
             if (response && response.state) {
-                applyServerState(response.state, 'reset-after-stale-heartbeat', requestResetGeneration);
+                applyServerState(response.state, source, requestResetGeneration);
             }
-            logFlow('reset-after-stale-heartbeat', {
+            logFlow(source, {
                 reason: reason || 'manual_home_tutorial_reset',
             });
         } catch (error) {
-            console.warn('[TutorialPrompt] failed to re-apply reset after stale heartbeat:', error);
+            console.warn('[TutorialPrompt] failed to re-apply reset after stale mutation:', error);
         }
     }
 
@@ -1220,7 +1248,7 @@
             }
             state.requestInFlight = false;
             if (shouldReapplyReset) {
-                await persistResetAfterStaleHeartbeat(resetReason);
+                await persistResetAfterStaleMutation(resetReason, 'reset-after-stale-heartbeat');
             }
             if (state.pendingHeartbeatAfterFlight) {
                 state.pendingHeartbeatAfterFlight = false;

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -5,9 +5,14 @@
     const FAST_HEARTBEAT_DELAY_MS = 1200;
     const HOME_TUTORIAL_START_WAIT_TIMEOUT_MS = 15000;
     const HOME_TUTORIAL_STORAGE_KEY_FALLBACK = 'neko_tutorial_home';
+    const HOME_TUTORIAL_RESET_EVENT = 'neko:home-tutorial-reset';
+    const HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY = 'neko_home_tutorial_reset_event';
+    const HOME_TUTORIAL_RESET_CHANNEL = 'neko_tutorial_events';
+    const HOME_TUTORIAL_PROMPT_SEEN_FLAG = '__nekoHomeTutorialPromptSeenInTab';
     const HEARTBEAT_ENDPOINT = '/api/tutorial-prompt/heartbeat';
     const TUTORIAL_PROMPT_COORDINATION_KEY = 'home-tutorial-prompt';
     const TUTORIAL_PROMPT_PRIORITY = 200;
+    const LOCAL_PROMPT_LATER_SUPPRESS_MS = 60 * 60 * 1000;
     const HOME_TUTORIAL_AGENT_RESTORE_STORAGE_KEY = 'neko.homeTutorial.agentRestoreSnapshot.v1';
     const HOME_TUTORIAL_AGENT_FLAG_KEYS = Object.freeze([
         'agent_enabled',
@@ -66,11 +71,14 @@
         tutorialStarted: false,
         neverRemind: false,
         deferredUntil: 0,
+        localPromptSuppressedUntil: 0,
         lastPromptTokenSeen: null,
         promptDrivenTutorialToken: null,
         tutorialRunToken: null,
         pendingTutorialStartPersistence: null,
         pendingTutorialStartPayload: null,
+        resetGeneration: 0,
+        resetBroadcastChannel: null,
         userCohort: 'unknown',
         mobileResizeRetryBound: false,
         featureSuppression: {
@@ -633,6 +641,12 @@
         });
     }
 
+    function clearHomeTutorialStorageSeen() {
+        getHomeTutorialStorageKeys().forEach(function (storageKey) {
+            localStorage.removeItem(storageKey);
+        });
+    }
+
     function isHomeTutorialSeen() {
         return getHomeTutorialStorageKeys().some(function (storageKey) {
             return localStorage.getItem(storageKey) === 'true';
@@ -678,8 +692,29 @@
         return locked;
     }
 
+    function isPromptSuppressedInThisTab() {
+        const now = Date.now();
+        return state.deferredUntil > now || state.localPromptSuppressedUntil > now;
+    }
+
+    function hasPromptBeenSeenInThisTab() {
+        return window[HOME_TUTORIAL_PROMPT_SEEN_FLAG] === true || !!state.lastPromptTokenSeen;
+    }
+
     mod.isHomeTutorialInteractionLocked = computeHomeTutorialInteractionLocked;
     mod.isHomeTutorialBlockingGreeting = computeHomeTutorialInteractionLocked;
+    mod.shouldSuppressAutomaticHomeTutorialStart = function () {
+        return !!(
+            state.promptDisplayPending
+            || state.promptOpen
+            || state.tutorialStartRequested
+            || state.tutorialRunning
+            || hasPromptBeenSeenInThisTab()
+            || state.homeTutorialCompleted
+            || state.neverRemind
+            || isPromptSuppressedInThisTab()
+        );
+    };
     window.isNekoHomeTutorialInteractionLocked = computeHomeTutorialInteractionLocked;
     window.isNekoHomeTutorialBlockingGreeting = computeHomeTutorialInteractionLocked;
 
@@ -689,9 +724,20 @@
         }
     }
 
-    function applyServerState(serverState, source) {
+    function isStaleAfterClientReset(requestResetGeneration) {
+        return typeof requestResetGeneration === 'number'
+            && requestResetGeneration !== state.resetGeneration;
+    }
+
+    function applyServerState(serverState, source, requestResetGeneration) {
         if (!serverState || typeof serverState !== 'object') {
-            return;
+            return false;
+        }
+        if (isStaleAfterClientReset(requestResetGeneration)) {
+            logFlow('state-sync-stale-ignored', {
+                source: source || 'unknown',
+            });
+            return false;
         }
 
         const previous = {
@@ -720,7 +766,15 @@
         if (serverState.never_remind === true) {
             state.neverRemind = true;
         }
-        state.deferredUntil = deferredUntil;
+        const preserveLocalDeferred = (source === 'heartbeat' || source === 'shown')
+            && previous.deferredUntil > Date.now()
+            && deferredUntil <= Date.now()
+            && status !== 'deferred'
+            && status !== 'never'
+            && status !== 'completed';
+        if (!preserveLocalDeferred) {
+            state.deferredUntil = deferredUntil;
+        }
         if (status === 'started' || status === 'completed' || startedAt > 0 || completedAt > 0) {
             state.tutorialStarted = true;
         }
@@ -755,15 +809,17 @@
                 meaningfulActionTaken: state.meaningfulActionTaken,
             });
         }
+        return true;
     }
 
     async function loadInitialServerState() {
+        const requestResetGeneration = state.resetGeneration;
         try {
             const response = await requestJson('/api/tutorial-prompt/state', {
                 cache: 'no-store',
             });
             if (response && response.state) {
-                applyServerState(response.state, 'initial-state');
+                applyServerState(response.state, 'initial-state', requestResetGeneration);
             }
         } catch (error) {
             console.warn('[TutorialPrompt] failed to load initial state:', error);
@@ -772,6 +828,7 @@
 
     async function persistTutorialLifecycle(url, payload, flowStep, options) {
         const requestOptions = options || {};
+        const requestResetGeneration = state.resetGeneration;
         try {
             const response = requestOptions.fireAndForget
                 ? await fireAndForgetJson(url, payload)
@@ -780,8 +837,14 @@
                     json: payload,
                     keepalive: !!requestOptions.keepalive,
                 });
+            if (isStaleAfterClientReset(requestResetGeneration)) {
+                logFlow('lifecycle-stale-ignored', {
+                    source: flowStep || 'unknown',
+                });
+                return response;
+            }
             if (response && response.state) {
-                applyServerState(response.state, flowStep);
+                applyServerState(response.state, flowStep, requestResetGeneration);
             }
             if (response && response.tutorial_run_token) {
                 state.tutorialRunToken = response.tutorial_run_token;
@@ -808,13 +871,14 @@
     }
 
     async function postDecision(payload) {
+        const requestResetGeneration = state.resetGeneration;
         try {
             const response = await requestJson('/api/tutorial-prompt/decision', {
                 method: 'POST',
                 json: payload,
             });
             if (response && response.state) {
-                applyServerState(response.state, 'decision');
+                applyServerState(response.state, 'decision', requestResetGeneration);
             }
             logFlow('decision', {
                 decision: payload && payload.decision,
@@ -829,13 +893,14 @@
 
     async function postShownAck(promptToken) {
         if (!promptToken) return;
+        const requestResetGeneration = state.resetGeneration;
         try {
             const response = await requestJson('/api/tutorial-prompt/shown', {
                 method: 'POST',
                 json: { prompt_token: promptToken },
             });
             if (response && response.state) {
-                applyServerState(response.state, 'shown');
+                applyServerState(response.state, 'shown', requestResetGeneration);
             }
             logFlow('shown', {
                 token: shortPromptToken(promptToken),
@@ -951,6 +1016,40 @@
             || snapshot.manualHomeTutorialViewed;
     }
 
+    function resetHomeTutorialClientState(reason) {
+        state.resetGeneration += 1;
+        const snapshot = state.inFlightHeartbeatSnapshot;
+        if (snapshot) {
+            snapshot.homeTutorialCompleted = false;
+            snapshot.manualHomeTutorialViewed = false;
+        }
+
+        state.homeTutorialCompleted = false;
+        state.manualHomeTutorialViewed = false;
+        state.tutorialStarted = false;
+        state.neverRemind = false;
+        state.deferredUntil = 0;
+        state.localPromptSuppressedUntil = 0;
+        state.lastPromptTokenSeen = null;
+        window[HOME_TUTORIAL_PROMPT_SEEN_FLAG] = false;
+        state.promptDrivenTutorialToken = null;
+        state.tutorialRunToken = null;
+        state.pendingTutorialStartPayload = null;
+        clearHomeTutorialStorageSeen();
+        logFlow('home-tutorial-reset', {
+            reason: reason || 'unknown',
+        });
+    }
+
+    function handleHomeTutorialResetDetail(detail) {
+        const payload = detail && typeof detail === 'object' ? detail : {};
+        const page = String(payload.page || '').trim();
+        if (page && page !== 'home' && page !== 'all') {
+            return;
+        }
+        resetHomeTutorialClientState(String(payload.source || payload.reason || '').trim());
+    }
+
     function buildHeartbeatPayload(snapshot) {
         const payload = {
             heartbeat_token: snapshot.heartbeatToken,
@@ -1007,6 +1106,16 @@
         snapshotsToFlush.forEach(queueHeartbeatSnapshotForUnload);
     }
 
+    function closeResetBroadcastChannel() {
+        if (!state.resetBroadcastChannel) {
+            return;
+        }
+        try {
+            state.resetBroadcastChannel.close();
+        } catch (_) {}
+        state.resetBroadcastChannel = null;
+    }
+
     async function sendHeartbeat() {
         if (!state.initialized) return;
         if (state.requestInFlight) {
@@ -1015,6 +1124,7 @@
         }
 
         state.requestInFlight = true;
+        const requestResetGeneration = state.resetGeneration;
         const snapshot = takeHeartbeatSnapshot();
         const payload = buildHeartbeatPayload(snapshot);
         state.inFlightHeartbeatSnapshot = snapshot;
@@ -1045,7 +1155,7 @@
                 keepalive: true,
             });
             if (data && data.state) {
-                applyServerState(data.state, 'heartbeat');
+                applyServerState(data.state, 'heartbeat', requestResetGeneration);
             }
             logFlow('heartbeat', {
                 foregroundMsDelta: snapshot.foregroundMsDelta,
@@ -1064,7 +1174,7 @@
         }
 
         try {
-            if (data && data.should_prompt) {
+            if (!isStaleAfterClientReset(requestResetGeneration) && data && data.should_prompt) {
                 await maybeShowPrompt(data.prompt_token);
             }
         } catch (error) {
@@ -1095,8 +1205,9 @@
             || state.tutorialStarted
             || state.homeTutorialCompleted
             || state.manualHomeTutorialViewed
+            || hasPromptBeenSeenInThisTab()
             || state.neverRemind
-            || state.deferredUntil > Date.now()
+            || isPromptSuppressedInThisTab()
             || state.userCohort === 'existing';
     }
 
@@ -1219,9 +1330,11 @@
     }
 
     async function showPrompt(promptToken) {
+        const promptResetGeneration = state.resetGeneration;
         state.promptOpen = true;
         emitHomeTutorialLockIfChanged('prompt-open');
         state.lastPromptTokenSeen = promptToken;
+        window[HOME_TUTORIAL_PROMPT_SEEN_FLAG] = true;
         logFlow('prompt-open', { token: shortPromptToken(promptToken) });
         try {
             const decision = await window.showDecisionPrompt({
@@ -1258,15 +1371,48 @@
                     }
                 ]
             });
+            if (isStaleAfterClientReset(promptResetGeneration)) {
+                logFlow('prompt-decision-stale-ignored', {
+                    token: shortPromptToken(promptToken),
+                    decision: decision || null,
+                });
+                return;
+            }
 
             if (decision === 'never') {
+                const decisionResetGeneration = state.resetGeneration;
                 state.promptDrivenTutorialToken = null;
+                state.neverRemind = true;
+                state.deferredUntil = 0;
+                state.localPromptSuppressedUntil = 0;
+                emitHomeTutorialLockIfChanged('prompt-never-local');
                 await postDecision({ decision: 'never', prompt_token: promptToken });
+                if (isStaleAfterClientReset(decisionResetGeneration)) {
+                    return;
+                }
+                state.neverRemind = true;
+                state.deferredUntil = 0;
+                state.localPromptSuppressedUntil = 0;
+                emitHomeTutorialLockIfChanged('prompt-never-local-confirmed');
                 return;
             }
             if (decision === 'later') {
+                const decisionResetGeneration = state.resetGeneration;
                 state.promptDrivenTutorialToken = null;
+                const localSuppressUntil = Date.now() + LOCAL_PROMPT_LATER_SUPPRESS_MS;
+                state.deferredUntil = localSuppressUntil;
+                state.localPromptSuppressedUntil = localSuppressUntil;
+                emitHomeTutorialLockIfChanged('prompt-later-local');
                 await postDecision({ decision: 'later', prompt_token: promptToken });
+                if (isStaleAfterClientReset(decisionResetGeneration)) {
+                    return;
+                }
+                if (!isPromptSuppressedInThisTab()) {
+                    const confirmedSuppressUntil = Date.now() + LOCAL_PROMPT_LATER_SUPPRESS_MS;
+                    state.deferredUntil = confirmedSuppressUntil;
+                    state.localPromptSuppressedUntil = confirmedSuppressUntil;
+                    emitHomeTutorialLockIfChanged('prompt-later-local-confirmed');
+                }
                 return;
             }
             if (decision === 'accept') {
@@ -1454,6 +1600,37 @@
             }
         });
 
+        window.addEventListener(HOME_TUTORIAL_RESET_EVENT, function (event) {
+            handleHomeTutorialResetDetail(event && event.detail ? event.detail : {});
+        });
+
+        window.addEventListener('storage', function (event) {
+            if (!event || event.key !== HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY || !event.newValue) {
+                return;
+            }
+            try {
+                handleHomeTutorialResetDetail(JSON.parse(event.newValue));
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to parse home tutorial reset storage event:', error);
+            }
+        });
+
+        if (typeof BroadcastChannel === 'function') {
+            try {
+                state.resetBroadcastChannel = new BroadcastChannel(HOME_TUTORIAL_RESET_CHANNEL);
+                state.resetBroadcastChannel.addEventListener('message', function (event) {
+                    const message = event && event.data ? event.data : {};
+                    if (!message || message.type !== HOME_TUTORIAL_RESET_EVENT) {
+                        return;
+                    }
+                    handleHomeTutorialResetDetail(message.detail || {});
+                });
+            } catch (error) {
+                console.warn('[TutorialPrompt] failed to listen for home tutorial reset broadcasts:', error);
+            }
+        }
+
+        window.addEventListener('beforeunload', closeResetBroadcastChannel);
         window.addEventListener('beforeunload', flushHeartbeatOnUnload);
     }
 

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -79,6 +79,7 @@
         pendingTutorialStartPayload: null,
         resetGeneration: 0,
         resetBroadcastChannel: null,
+        pendingResetAfterHeartbeatReason: '',
         userCohort: 'unknown',
         mobileResizeRetryBound: false,
         featureSuppression: {
@@ -1019,6 +1020,14 @@
     function resetHomeTutorialClientState(reason) {
         state.resetGeneration += 1;
         const snapshot = state.inFlightHeartbeatSnapshot;
+        const resetReason = reason || 'manual_home_tutorial_reset';
+        if (
+            state.requestInFlight
+            && snapshot
+            && (snapshot.homeTutorialCompleted || snapshot.manualHomeTutorialViewed)
+        ) {
+            state.pendingResetAfterHeartbeatReason = resetReason;
+        }
         if (snapshot) {
             snapshot.homeTutorialCompleted = false;
             snapshot.manualHomeTutorialViewed = false;
@@ -1037,7 +1046,7 @@
         state.pendingTutorialStartPayload = null;
         clearHomeTutorialStorageSeen();
         logFlow('home-tutorial-reset', {
-            reason: reason || 'unknown',
+            reason: resetReason,
         });
     }
 
@@ -1116,6 +1125,26 @@
         state.resetBroadcastChannel = null;
     }
 
+    async function persistResetAfterStaleHeartbeat(reason) {
+        const requestResetGeneration = state.resetGeneration;
+        try {
+            const response = await requestJson('/api/tutorial-prompt/reset', {
+                method: 'POST',
+                json: {
+                    reason: reason || 'manual_home_tutorial_reset',
+                },
+            });
+            if (response && response.state) {
+                applyServerState(response.state, 'reset-after-stale-heartbeat', requestResetGeneration);
+            }
+            logFlow('reset-after-stale-heartbeat', {
+                reason: reason || 'manual_home_tutorial_reset',
+            });
+        } catch (error) {
+            console.warn('[TutorialPrompt] failed to re-apply reset after stale heartbeat:', error);
+        }
+    }
+
     async function sendHeartbeat() {
         if (!state.initialized) return;
         if (state.requestInFlight) {
@@ -1180,10 +1209,19 @@
         } catch (error) {
             console.warn('[TutorialPrompt] failed to render tutorial prompt:', error);
         } finally {
+            const shouldReapplyReset = isStaleAfterClientReset(requestResetGeneration)
+                && !!state.pendingResetAfterHeartbeatReason;
+            const resetReason = state.pendingResetAfterHeartbeatReason;
+            if (shouldReapplyReset) {
+                state.pendingResetAfterHeartbeatReason = '';
+            }
             if (state.inFlightHeartbeatSnapshot === snapshot) {
                 state.inFlightHeartbeatSnapshot = null;
             }
             state.requestInFlight = false;
+            if (shouldReapplyReset) {
+                await persistResetAfterStaleHeartbeat(resetReason);
+            }
             if (state.pendingHeartbeatAfterFlight) {
                 state.pendingHeartbeatAfterFlight = false;
                 scheduleFastHeartbeat();

--- a/static/app-tutorial-prompt.js
+++ b/static/app-tutorial-prompt.js
@@ -80,8 +80,8 @@
         resetGeneration: 0,
         resetBroadcastChannel: null,
         pendingResetAfterHeartbeatReason: '',
-        pendingResetAfterCompletionReason: '',
-        inFlightCompletionLifecycleCount: 0,
+        pendingResetAfterLifecycleReason: '',
+        inFlightResetSensitiveLifecycleCount: 0,
         userCohort: 'unknown',
         mobileResizeRetryBound: false,
         featureSuppression: {
@@ -829,8 +829,9 @@
         }
     }
 
-    function isHomeTutorialCompletionLifecycle(url, payload) {
-        return url === '/api/tutorial-prompt/tutorial-completed'
+    function isHomeTutorialResetSensitiveLifecycle(url, payload) {
+        return (url === '/api/tutorial-prompt/tutorial-started'
+                || url === '/api/tutorial-prompt/tutorial-completed')
             && payload
             && payload.page === 'home';
     }
@@ -838,9 +839,9 @@
     async function persistTutorialLifecycle(url, payload, flowStep, options) {
         const requestOptions = options || {};
         const requestResetGeneration = state.resetGeneration;
-        const isCompletionLifecycle = isHomeTutorialCompletionLifecycle(url, payload);
-        if (isCompletionLifecycle) {
-            state.inFlightCompletionLifecycleCount += 1;
+        const isResetSensitiveLifecycle = isHomeTutorialResetSensitiveLifecycle(url, payload);
+        if (isResetSensitiveLifecycle) {
+            state.inFlightResetSensitiveLifecycleCount += 1;
         }
         try {
             const response = requestOptions.fireAndForget
@@ -854,10 +855,10 @@
                 logFlow('lifecycle-stale-ignored', {
                     source: flowStep || 'unknown',
                 });
-                if (isCompletionLifecycle && state.pendingResetAfterCompletionReason) {
-                    const resetReason = state.pendingResetAfterCompletionReason;
-                    state.pendingResetAfterCompletionReason = '';
-                    await persistResetAfterStaleMutation(resetReason, 'reset-after-stale-completion');
+                if (isResetSensitiveLifecycle && state.pendingResetAfterLifecycleReason) {
+                    const resetReason = state.pendingResetAfterLifecycleReason;
+                    state.pendingResetAfterLifecycleReason = '';
+                    await persistResetAfterStaleMutation(resetReason, 'reset-after-stale-lifecycle');
                 }
                 return response;
             }
@@ -886,10 +887,10 @@
             console.warn('[TutorialPrompt] failed to persist lifecycle event:', error);
             return null;
         } finally {
-            if (isCompletionLifecycle) {
-                state.inFlightCompletionLifecycleCount = Math.max(
+            if (isResetSensitiveLifecycle) {
+                state.inFlightResetSensitiveLifecycleCount = Math.max(
                     0,
-                    state.inFlightCompletionLifecycleCount - 1
+                    state.inFlightResetSensitiveLifecycleCount - 1
                 );
             }
         }
@@ -1052,8 +1053,8 @@
         ) {
             state.pendingResetAfterHeartbeatReason = resetReason;
         }
-        if (state.inFlightCompletionLifecycleCount > 0) {
-            state.pendingResetAfterCompletionReason = resetReason;
+        if (state.inFlightResetSensitiveLifecycleCount > 0) {
+            state.pendingResetAfterLifecycleReason = resetReason;
         }
         if (snapshot) {
             snapshot.homeTutorialCompleted = false;
@@ -1063,6 +1064,8 @@
         state.homeTutorialCompleted = false;
         state.manualHomeTutorialViewed = false;
         state.tutorialStarted = false;
+        state.tutorialRunning = false;
+        state.tutorialStartRequested = false;
         state.neverRemind = false;
         state.deferredUntil = 0;
         state.localPromptSuppressedUntil = 0;
@@ -1071,6 +1074,8 @@
         state.promptDrivenTutorialToken = null;
         state.tutorialRunToken = null;
         state.pendingTutorialStartPayload = null;
+        endHomeTutorialFeatureSuppression('home-tutorial-reset');
+        emitHomeTutorialLockIfChanged('home-tutorial-reset');
         clearHomeTutorialStorageSeen();
         logFlow('home-tutorial-reset', {
             reason: resetReason,

--- a/static/js/character_personality_onboarding.js
+++ b/static/js/character_personality_onboarding.js
@@ -5,6 +5,9 @@
     const TUTORIAL_PROMPT_POLL_INTERVAL_MS = 120;
     const TYPEWRITER_BASE_DELAY_MS = 18;
     const TYPEWRITER_PUNCTUATION_DELAY_MS = 110;
+    const HOME_TUTORIAL_RESET_EVENT = 'neko:home-tutorial-reset';
+    const HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY = 'neko_home_tutorial_reset_event';
+    const HOME_TUTORIAL_RESET_CHANNEL = 'neko_tutorial_events';
 
     function interpolateTemplate(template, options) {
         return String(template || '').replace(/{{\s*(\w+)\s*}}/g, (_, name) => {
@@ -113,6 +116,8 @@
             this.typewriterRunId = 0;
             this.typewriterTimer = null;
             this.lastTutorialPromptState = null;
+            this.homeTutorialCompletedInSession = false;
+            this.resetBroadcastChannel = null;
             // bootstrap 超时 fallthrough 时拉这个旗子，让 waitForTutorialFlowToSettle 的轮询循环退出，
             // 避免后台每 120ms 一次的 /api/tutorial-prompt/state 永久泄漏。
             this._tutorialFlowAborted = false;
@@ -157,8 +162,13 @@
                     }),
                 ]);
                 if (!tutorialSettled) {
-                    this._tutorialFlowAborted = true;
-                    console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out, fallthrough');
+                    if (this.isHomeTutorialInteractionLocked()) {
+                        console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out while home tutorial is locked, keep waiting');
+                        await this.waitForTutorialFlowToSettle();
+                    } else {
+                        this._tutorialFlowAborted = true;
+                        console.warn('[CharacterPersonalityOnboarding] tutorial flow settle timed out, fallthrough');
+                    }
                 }
                 if (await this.openIfManualReselectPending()) {
                     return;
@@ -258,6 +268,43 @@
             });
         }
 
+        isHomeTutorialInteractionLocked() {
+            if (!this.shouldRespectHomeTutorialGate()) {
+                return false;
+            }
+
+            const manager = window.universalTutorialManager || null;
+            if (window.isInTutorial === true
+                || (manager && manager.currentPage === 'home' && manager.isTutorialRunning)) {
+                return true;
+            }
+
+            const lockReaders = [
+                window.isNekoHomeTutorialInteractionLocked,
+                window.isNekoHomeTutorialBlockingGreeting,
+                window.appTutorialPrompt && window.appTutorialPrompt.isHomeTutorialInteractionLocked,
+                window.appTutorialPrompt && window.appTutorialPrompt.isHomeTutorialBlockingGreeting,
+            ];
+            return lockReaders.some((reader) => {
+                if (typeof reader !== 'function') {
+                    return false;
+                }
+                try {
+                    return reader() === true;
+                } catch (_) {
+                    return false;
+                }
+            });
+        }
+
+        async waitForHomeTutorialInteractionUnlock() {
+            while (this.isHomeTutorialInteractionLocked()) {
+                await new Promise((resolve) => {
+                    window.setTimeout(resolve, TUTORIAL_PROMPT_POLL_INTERVAL_MS);
+                });
+            }
+        }
+
         async fetchTutorialPromptState() {
             try {
                 const payload = await requestJson('/api/tutorial-prompt/state', {
@@ -284,11 +331,69 @@
             return String(state.user_cohort || '').trim().toLowerCase();
         }
 
+        hasHomeTutorialCompletionMarker() {
+            if (this.homeTutorialCompletedInSession) {
+                return true;
+            }
+
+            const manager = window.universalTutorialManager || null;
+            if (manager && typeof manager.hasSeenTutorial === 'function') {
+                try {
+                    if (manager.hasSeenTutorial('home')) {
+                        return true;
+                    }
+                } catch (_) {}
+            }
+
+            try {
+                return localStorage.getItem('neko_tutorial_home_yui_v1') === 'true'
+                    || localStorage.getItem('neko_tutorial_home') === 'true';
+            } catch (_) {
+                return false;
+            }
+        }
+
+        shouldWaitForHomeTutorialCompletion(state) {
+            if (!this.shouldRespectHomeTutorialGate() || this.hasHomeTutorialCompletionMarker()) {
+                return false;
+            }
+            if (!state || typeof state !== 'object') {
+                return false;
+            }
+
+            if (state.home_tutorial_completed === true || state.manual_home_tutorial_viewed === true) {
+                return false;
+            }
+
+            const userCohort = this.normalizeTutorialPromptUserCohort(state);
+            if (userCohort === 'new') {
+                return true;
+            }
+            if (userCohort !== 'existing') {
+                return false;
+            }
+
+            const chatTurns = Number(state.chat_turns || 0);
+            const voiceSessions = Number(state.voice_sessions || 0);
+            const shownCount = Number(state.shown_count || 0);
+            return (!Number.isFinite(chatTurns) || chatTurns <= 0)
+                && (!Number.isFinite(voiceSessions) || voiceSessions <= 0)
+                && (!Number.isFinite(shownCount) || shownCount <= 0);
+        }
+
         isTutorialPromptSettled(state) {
             if (!state || typeof state !== 'object') {
                 return false;
             }
             const status = this.normalizeTutorialPromptStatus(state);
+            if (this.shouldWaitForHomeTutorialCompletion(state) && (
+                status === 'completed'
+                || status === 'error'
+                || status === 'observing'
+                || status === 'prompted'
+            )) {
+                return false;
+            }
             if (status === 'completed' || status === 'deferred' || status === 'never' || status === 'error') {
                 return true;
             }
@@ -314,6 +419,10 @@
             while (true) {
                 if (this._tutorialFlowAborted) {
                     return;
+                }
+                if (this.isHomeTutorialInteractionLocked()) {
+                    await this.waitForHomeTutorialInteractionUnlock();
+                    continue;
                 }
                 if (window.universalTutorialManager && window.universalTutorialManager.isTutorialRunning) {
                     await this.waitForTutorialCompletion();
@@ -455,6 +564,22 @@
         }
 
         bindTutorialLifecycleEvents() {
+            const resetHomeTutorialCompleted = (event) => {
+                const detail = event && event.detail && typeof event.detail === 'object' ? event.detail : {};
+                const page = String(detail.page || '').trim();
+                if (page && page !== 'home' && page !== 'all') {
+                    return;
+                }
+                this.homeTutorialCompletedInSession = false;
+            };
+
+            const markHomeTutorialCompleted = (event) => {
+                if (!event || !event.detail || event.detail.page !== 'home') {
+                    return;
+                }
+                this.homeTutorialCompletedInSession = true;
+            };
+
             const queueResume = (event) => {
                 if (!event || !event.detail || event.detail.page !== 'home') {
                     return;
@@ -500,9 +625,49 @@
                 void this.openIfPending();
             };
 
+            const resetHomeTutorialCompletedFromStorage = (event) => {
+                if (!event || event.key !== HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY || !event.newValue) {
+                    return;
+                }
+                try {
+                    resetHomeTutorialCompleted({ detail: JSON.parse(event.newValue) });
+                } catch (error) {
+                    console.warn('[CharacterPersonalityOnboarding] failed to parse home tutorial reset storage event:', error);
+                }
+            };
+
+            window.addEventListener(HOME_TUTORIAL_RESET_EVENT, resetHomeTutorialCompleted);
+            window.addEventListener('storage', resetHomeTutorialCompletedFromStorage);
             window.addEventListener('neko:tutorial-started', queueResume);
+            window.addEventListener('neko:tutorial-completed', markHomeTutorialCompleted);
+            window.addEventListener('neko:tutorial-skipped', markHomeTutorialCompleted);
             window.addEventListener('neko:tutorial-completed', resumeIfNeeded);
             window.addEventListener('neko:tutorial-skipped', resumeIfNeeded);
+
+            if (typeof BroadcastChannel === 'function') {
+                try {
+                    this.resetBroadcastChannel = new BroadcastChannel(HOME_TUTORIAL_RESET_CHANNEL);
+                    this.resetBroadcastChannel.addEventListener('message', (event) => {
+                        const message = event && event.data ? event.data : {};
+                        if (!message || message.type !== HOME_TUTORIAL_RESET_EVENT) {
+                            return;
+                        }
+                        resetHomeTutorialCompleted({ detail: message.detail || {} });
+                    });
+                } catch (error) {
+                    console.warn('[CharacterPersonalityOnboarding] failed to listen for home tutorial reset broadcasts:', error);
+                }
+            }
+
+            window.addEventListener('beforeunload', () => {
+                if (!this.resetBroadcastChannel) {
+                    return;
+                }
+                try {
+                    this.resetBroadcastChannel.close();
+                } catch (_) {}
+                this.resetBroadcastChannel = null;
+            });
         }
 
         getEyebrowText() {

--- a/static/universal-tutorial-manager.js
+++ b/static/universal-tutorial-manager.js
@@ -12,6 +12,9 @@ const TUTORIAL_PROMPT_FLOW_PREFIX = '[TutorialPromptFlow]';
 const TUTORIAL_YUI_LIVE2D_MODEL_NAME = 'yui-origin';
 const TUTORIAL_YUI_LIVE2D_MODEL_PATH = '/static/yui-origin/yui-origin.model3.json';
 const TUTORIAL_AVATAR_OVERRIDE_TIMEOUT_MS = 8000;
+const HOME_TUTORIAL_RESET_EVENT = 'neko:home-tutorial-reset';
+const HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY = 'neko_home_tutorial_reset_event';
+const HOME_TUTORIAL_RESET_CHANNEL = 'neko_tutorial_events';
 
 function getTutorialStorageKeyForPage(pageKey) {
     return TUTORIAL_STORAGE_KEY_PREFIX + pageKey;
@@ -21,12 +24,63 @@ function getTutorialManualIntentKeyForPage(pageKey) {
     return getTutorialStorageKeyForPage(pageKey) + '_manual_intent';
 }
 
+function getTutorialStorageKeysForPageFallback(pageKey) {
+    if (pageKey === 'model_manager') {
+        return ['model_manager', 'model_manager_live2d', 'model_manager_vrm', 'model_manager_mmd', 'model_manager_common']
+            .map(getTutorialStorageKeyForPage);
+    }
+
+    if (pageKey === 'home') {
+        return [
+            getTutorialStorageKeyForPage('home_yui_v1'),
+            getTutorialStorageKeyForPage('home'),
+        ];
+    }
+
+    return [getTutorialStorageKeyForPage(pageKey)];
+}
+
 function logTutorialPromptFlow(step, details = {}) {
     // 默认关闭高频引导流程日志，避免 heartbeat 等调试信息刷屏。
     if (localStorage.getItem('neko_tutorial_prompt_flow_debug') !== '1') {
         return;
     }
     console.log(TUTORIAL_PROMPT_FLOW_PREFIX + ' ' + step, details);
+}
+
+function dispatchHomeTutorialResetEvent(pageKey, source) {
+    if (pageKey !== 'home' && pageKey !== 'all') {
+        return;
+    }
+    const detail = {
+        page: pageKey,
+        source: source || 'manual_home_tutorial_reset',
+        nonce: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    };
+
+    if (typeof window.dispatchEvent === 'function' && typeof CustomEvent === 'function') {
+        window.dispatchEvent(new CustomEvent(HOME_TUTORIAL_RESET_EVENT, { detail }));
+    }
+
+    if (typeof BroadcastChannel === 'function') {
+        try {
+            const channel = new BroadcastChannel(HOME_TUTORIAL_RESET_CHANNEL);
+            channel.postMessage({
+                type: HOME_TUTORIAL_RESET_EVENT,
+                detail,
+            });
+            channel.close();
+        } catch (error) {
+            console.warn('[Tutorial] 广播首页教程重置事件失败:', error);
+        }
+    }
+
+    try {
+        localStorage.setItem(HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY, JSON.stringify(detail));
+        localStorage.removeItem(HOME_TUTORIAL_RESET_STORAGE_EVENT_KEY);
+    } catch (error) {
+        console.warn('[Tutorial] 写入首页教程重置同步事件失败:', error);
+    }
 }
 
 async function getTutorialMutationHeaders() {
@@ -771,6 +825,13 @@ class UniversalTutorialManager {
         const launchTutorial = () => {
             setTimeout(() => {
                 this._pendingI18nStart = false;
+                if (this.shouldSkipAutomaticHomeTutorialStart()) {
+                    this.logPromptFlow('home-auto-start-skipped', {
+                        page: this.currentPage,
+                        reason: 'prompt-flow-active',
+                    });
+                    return;
+                }
                 this.startTutorial();
             }, delayMs);
         };
@@ -813,6 +874,26 @@ class UniversalTutorialManager {
             cleanup();
             launchTutorial();
         }, 5000);
+    }
+
+    shouldSkipAutomaticHomeTutorialStart() {
+        if (this.currentPage !== 'home') {
+            return false;
+        }
+        const source = this.peekTutorialStartSource('home') || 'auto';
+        if (source !== 'auto') {
+            return false;
+        }
+        const prompt = window.appTutorialPrompt || null;
+        if (!prompt || typeof prompt.shouldSuppressAutomaticHomeTutorialStart !== 'function') {
+            return false;
+        }
+        try {
+            return prompt.shouldSuppressAutomaticHomeTutorialStart() === true;
+        } catch (error) {
+            console.warn('[Tutorial] 检查主页自动教程启动抑制状态失败:', error);
+            return false;
+        }
     }
 
     /**
@@ -1920,6 +2001,13 @@ class UniversalTutorialManager {
         }
 
         return Array.from(new Set(pageKeys)).map(getTutorialStorageKeyForPage);
+    }
+
+    getResetStorageKeysForPage(page) {
+        return Array.from(new Set([
+            ...this.getStorageKeysForPage(page),
+            ...getTutorialStorageKeysForPageFallback(page),
+        ]));
     }
 
     getManualStartIntentKey(page = null) {
@@ -5243,9 +5331,10 @@ class UniversalTutorialManager {
     async resetAllTutorials() {
         await this.resetHomeTutorialPromptState('manual_all_tutorial_reset');
         TUTORIAL_PAGES.forEach(page => {
-            this.getStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
+            this.getResetStorageKeysForPage(page).forEach(key => localStorage.removeItem(key));
         });
         this.markTutorialManualStartIntent('home');
+        dispatchHomeTutorialResetEvent('all', 'manual_all_tutorial_reset');
         console.log('[Tutorial] 已重置所有页面引导');
         this.notifyTutorialResetForCurrentPageIfNeeded('all');
     } 
@@ -5263,7 +5352,7 @@ class UniversalTutorialManager {
             await this.resetHomeTutorialPromptState('manual_home_tutorial_reset');
         }
 
-        this.getStorageKeysForPage(pageKey).forEach((storageKey) => {
+        this.getResetStorageKeysForPage(pageKey).forEach((storageKey) => {
             const oldVal = localStorage.getItem(storageKey);
             localStorage.removeItem(storageKey);
             if (oldVal) console.log('[Tutorial] 重置: 移除', storageKey, '(旧值:', oldVal, ')');
@@ -5271,6 +5360,7 @@ class UniversalTutorialManager {
 
         if (pageKey === 'home') {
             this.markTutorialManualStartIntent('home');
+            dispatchHomeTutorialResetEvent('home', 'manual_home_tutorial_reset');
         }
 
         console.log('[Tutorial] 已重置页面引导:', pageKey);
@@ -5401,8 +5491,11 @@ async function resetAllTutorials() {
     } else {
         // 如果管理器未初始化，直接清除 localStorage
         await postTutorialPromptReset('manual_all_tutorial_reset');
-        TUTORIAL_PAGES.forEach(page => { localStorage.removeItem(getTutorialStorageKeyForPage(page)); });
+        TUTORIAL_PAGES.forEach(page => {
+            getTutorialStorageKeysForPageFallback(page).forEach(key => localStorage.removeItem(key));
+        });
         localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+        dispatchHomeTutorialResetEvent('all', 'manual_all_tutorial_reset');
     }
     alert(window.t ? window.t('memory.tutorialResetSuccess', '已重置所有引导，下次进入各页面时将重新显示引导。') : '已重置所有引导，下次进入各页面时将重新显示引导。');
 }
@@ -5439,8 +5532,8 @@ async function resetTutorialForPage(pageKey) {
             }
 
             const successMessage = window.t
-                ? window.t('memory.currentPersonalityResetSuccess', '已记录当前角色的人格重选请求，请回到主页刷新后继续。')
-                : '已记录当前角色的人格重选请求，请回到主页刷新后继续。';
+                ? window.t('memory.currentPersonalityResetSuccess', '已记录当前角色的性格重选请求，请回到主页刷新后继续。')
+                : '已记录当前角色的性格重选请求，请回到主页刷新后继续。';
             alert(successMessage);
         }).catch(() => {
             const fallbackError = window.t
@@ -5458,16 +5551,13 @@ async function resetTutorialForPage(pageKey) {
             await postTutorialPromptReset('manual_home_tutorial_reset');
         }
         if (pageKey === 'model_manager') {
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_live2d'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_vrm'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_mmd'));
-            localStorage.removeItem(getTutorialStorageKeyForPage('model_manager_common'));
+            getTutorialStorageKeysForPageFallback('model_manager').forEach(key => localStorage.removeItem(key));
         } else {
-            localStorage.removeItem(getTutorialStorageKeyForPage(pageKey));
+            getTutorialStorageKeysForPageFallback(pageKey).forEach(key => localStorage.removeItem(key));
         }
         if (pageKey === 'home') {
             localStorage.setItem(getTutorialManualIntentKeyForPage('home'), 'true');
+            dispatchHomeTutorialResetEvent('home', 'manual_home_tutorial_reset');
         }
     }
 

--- a/tests/e2e/test_home_prompt_flow.py
+++ b/tests/e2e/test_home_prompt_flow.py
@@ -236,13 +236,24 @@ def _install_tutorial_heartbeat_stall(page: Page) -> None:
     )
 
 
-def _expect_prompt_title(page: Page, title: str) -> None:
-    expect(page.locator(".modal-title")).to_have_text(title, timeout=15_000)
+def _expect_prompt_title(page: Page, title: str, *, timeout: int = 15_000) -> None:
+    expect(page.locator(".modal-title")).to_have_text(title, timeout=timeout)
     expect(page.locator(".modal-overlay")).to_have_count(1)
 
 
 def _dismiss_prompt_with_later(page: Page) -> None:
+    previous_title = page.locator(".modal-overlay .modal-title").inner_text(timeout=5_000)
     page.locator(".modal-overlay").get_by_role("button", name=LATER_BUTTON_TEXT).click()
+    page.wait_for_function(
+        """
+        (oldTitle) => {
+            const titleNode = document.querySelector('.modal-overlay .modal-title');
+            return !titleNode || titleNode.textContent.trim() !== oldTitle;
+        }
+        """,
+        arg=previous_title,
+        timeout=5_000,
+    )
 
 
 @pytest.mark.e2e
@@ -260,7 +271,7 @@ def test_home_serializes_tutorial_and_autostart_prompts(mock_page: Page, running
     _expect_prompt_title(page, TUTORIAL_PROMPT_TITLE)
     _dismiss_prompt_with_later(page)
 
-    _expect_prompt_title(page, AUTOSTART_PROMPT_TITLE)
+    _expect_prompt_title(page, AUTOSTART_PROMPT_TITLE, timeout=30_000)
     _dismiss_prompt_with_later(page)
 
     expect(page.locator(".modal-overlay")).to_have_count(0, timeout=10_000)

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -1541,6 +1541,121 @@ def test_home_tutorial_reset_event_re_resets_after_inflight_completion_lifecycle
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_event_re_resets_after_inflight_started_lifecycle(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__startedBodies = [];
+            window.__resetBodies = [];
+            window.__resolveStarted = null;
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-started') {
+                window.__startedBodies.push(body);
+                return new Promise((resolve) => {
+                    window.__resolveStarted = () => resolve(jsonResponse({
+                        ok: true,
+                        tutorial_run_token: 'stale-start-token',
+                        state: {
+                            status: 'started',
+                            never_remind: false,
+                            deferred_until: 0,
+                            manual_home_tutorial_viewed: true,
+                            home_tutorial_completed: false,
+                        },
+                    }));
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                window.__resetBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: { page: 'home', source: 'manual' },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__startedBodies.length === 1 && typeof window.__resolveStarted === 'function'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+            window.__resolveStarted();
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__resetBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            startedBodies: window.__startedBodies.slice(),
+            resetBodies: window.__resetBodies.slice(),
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            suppressAutoStart: window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart(),
+        })
+        """
+    )
+
+    assert result["startedBodies"][0]["source"] == "manual"
+    assert result["resetBodies"][0]["reason"] == "manual_home_tutorial_reset"
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["suppressAutoStart"] is False
+
+
+@pytest.mark.frontend
 def test_home_tutorial_reset_event_ignores_stale_initial_state_response(mock_page: Page):
     _bootstrap_tutorial_prompt_page(
         mock_page,

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -353,6 +353,143 @@ def test_home_prompt_queue_serializes_tutorial_and_autostart_prompts(
 
 
 @pytest.mark.frontend
+def test_home_prompt_later_locally_suppresses_repeat_before_autostart_prompt(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        include_common_dialogs=True,
+        include_autostart_prompt=True,
+        setup_js="""
+            window.__requestLog = [];
+            window.nekoAutostartProvider = {
+                getStatus: async function() {
+                    return {
+                        ok: true,
+                        supported: true,
+                        enabled: false,
+                        authoritative: true,
+                        provider: 'backend',
+                    };
+                },
+                enable: async function() {
+                    return {
+                        ok: true,
+                        supported: true,
+                        enabled: true,
+                        authoritative: true,
+                        provider: 'backend',
+                    };
+                },
+            };
+        """,
+        fetch_js="""
+            window.__requestLog.push({
+                url: requestUrl,
+                method: method,
+                body: body,
+            });
+
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: true,
+                    prompt_reason: 'idle_timeout',
+                    prompt_token: 'tutorial-token',
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/shown') {
+                return jsonResponse({
+                    ok: true,
+                    already_acknowledged: false,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/decision') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/autostart-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        autostart_enabled: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/autostart-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: true,
+                    prompt_reason: 'usage_timeout',
+                    prompt_token: 'autostart-token',
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        autostart_enabled: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/autostart-prompt/shown') {
+                return jsonResponse({
+                    ok: true,
+                    already_acknowledged: false,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        autostart_enabled: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    prompt_title = mock_page.locator(".modal-title")
+    expect(prompt_title).to_have_text("要不要开始主页新手引导？", timeout=5000)
+
+    mock_page.get_by_role("button", name="稍后再说").click()
+
+    expect(prompt_title).to_have_text("要不要让 N.E.K.O 开机自动启动？", timeout=5000)
+    assert mock_page.evaluate("window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart()") is True
+
+
+@pytest.mark.frontend
 def test_completed_home_tutorial_server_state_marks_all_home_storage_keys_seen(
     mock_page: Page,
 ):
@@ -971,6 +1108,716 @@ def test_home_tutorial_reset_refreshes_stale_csrf_token_once(mock_page: Page):
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_without_manager_clears_versioned_home_key(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'test-token',
+            });
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            window.universalTutorialManager = null;
+            localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            localStorage.setItem('neko_tutorial_home', 'true');
+            await resetTutorialForPage('home');
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_still_clears_state_without_custom_event(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'test-token',
+            });
+            Object.defineProperty(window, 'CustomEvent', {
+                configurable: true,
+                value: undefined,
+            });
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            localStorage.setItem('neko_tutorial_home', 'true');
+            await resetTutorialForPage('home');
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_event_prevents_stale_completion_heartbeat(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__heartbeatBodies = [];
+            Object.defineProperty(navigator, 'sendBeacon', {
+                configurable: true,
+                value: null,
+            });
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        """
+        () => (
+            localStorage.getItem('neko_tutorial_home_yui_v1') === 'true'
+            || localStorage.getItem('neko_tutorial_home') === 'true'
+        )
+        """,
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+            window.dispatchEvent(new Event('beforeunload'));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__heartbeatBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            homeSeen: localStorage.getItem('neko_tutorial_home'),
+            latestHeartbeat: window.__heartbeatBodies[window.__heartbeatBodies.length - 1],
+        })
+        """
+    )
+
+    assert result["homeSeen"] is None
+    assert result["latestHeartbeat"]["home_tutorial_completed"] is False
+    assert result["latestHeartbeat"]["manual_home_tutorial_viewed"] is False
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_event_ignores_stale_initial_state_response(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__resolveInitialTutorialState = null;
+            window.__initialTutorialStateResolved = false;
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return new Promise((resolve) => {
+                    window.__resolveInitialTutorialState = () => {
+                        window.__initialTutorialStateResolved = true;
+                        resolve(jsonResponse({
+                            state: {
+                                status: 'completed',
+                                never_remind: false,
+                                deferred_until: 0,
+                                manual_home_tutorial_viewed: true,
+                                home_tutorial_completed: true,
+                            },
+                        }));
+                    };
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => typeof window.__resolveInitialTutorialState === 'function'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+            window.__resolveInitialTutorialState();
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__initialTutorialStateResolved === true",
+        timeout=5000,
+    )
+    mock_page.wait_for_timeout(100)
+
+    assert mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            suppressAutoStart: window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart(),
+        })
+        """
+    ) == {
+        "versionedSeen": None,
+        "legacySeen": None,
+        "suppressAutoStart": False,
+    }
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_event_clears_seen_prompt_token(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        include_common_dialogs=True,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: true,
+                    prompt_reason: 'idle_timeout',
+                    prompt_token: 'repeat-token',
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/shown') {
+                return jsonResponse({
+                    ok: true,
+                    already_acknowledged: false,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/decision') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'started',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    expect(mock_page.locator(".modal-title")).to_have_text("要不要开始主页新手引导？", timeout=5000)
+    mock_page.get_by_role("button", name="稍后再说").click()
+    expect(mock_page.locator(".modal-overlay")).to_have_count(0, timeout=5000)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+        }
+        """
+    )
+
+    mock_page.wait_for_function(
+        "() => window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart() === false",
+        timeout=5000,
+    )
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_event_ignores_open_prompt_decision(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        include_common_dialogs=True,
+        setup_js="""
+            window.__decisionBodies = [];
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: true,
+                    prompt_reason: 'idle_timeout',
+                    prompt_token: 'stale-open-token',
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/shown') {
+                return jsonResponse({
+                    ok: true,
+                    already_acknowledged: false,
+                    state: {
+                        status: 'prompted',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/decision') {
+                window.__decisionBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'deferred',
+                        never_remind: false,
+                        deferred_until: Date.now() + 60000,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    expect(mock_page.locator(".modal-title")).to_have_text("要不要开始主页新手引导？", timeout=5000)
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+        }
+        """
+    )
+    mock_page.get_by_role("button", name="稍后再说").click()
+    expect(mock_page.locator(".modal-overlay")).to_have_count(0, timeout=5000)
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            suppressAutoStart: window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart(),
+            decisionBodies: window.__decisionBodies.slice(),
+        })
+        """
+    )
+
+    assert result["suppressAutoStart"] is False
+    assert result["decisionBodies"] == []
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_broadcast_channel_is_closed_on_unload(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__resetBroadcastChannels = [];
+            window.BroadcastChannel = class {
+                constructor(name) {
+                    this.name = name;
+                    this.closed = false;
+                    this.listeners = {};
+                    window.__resetBroadcastChannels.push(this);
+                }
+                addEventListener(type, listener) {
+                    this.listeners[type] = listener;
+                }
+                close() {
+                    this.closed = true;
+                }
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new Event('beforeunload'));
+            return {
+                count: window.__resetBroadcastChannels.length,
+                closed: window.__resetBroadcastChannels[0] && window.__resetBroadcastChannels[0].closed,
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "count": 1,
+        "closed": True,
+    }
+
+
+@pytest.mark.frontend
+def test_cross_window_home_tutorial_reset_event_prevents_stale_completion_heartbeat(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__heartbeatBodies = [];
+            Object.defineProperty(navigator, 'sendBeacon', {
+                configurable: true,
+                value: null,
+            });
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => localStorage.getItem('neko_tutorial_home') === 'true'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'neko_home_tutorial_reset_event',
+                newValue: JSON.stringify({
+                    page: 'home',
+                    source: 'manual_home_tutorial_reset',
+                    nonce: 'from-memory-browser-window',
+                }),
+            }));
+            window.dispatchEvent(new Event('beforeunload'));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__heartbeatBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            homeSeen: localStorage.getItem('neko_tutorial_home'),
+            latestHeartbeat: window.__heartbeatBodies[window.__heartbeatBodies.length - 1],
+        })
+        """
+    )
+
+    assert result["homeSeen"] is None
+    assert result["latestHeartbeat"]["home_tutorial_completed"] is False
+    assert result["latestHeartbeat"]["manual_home_tutorial_viewed"] is False
+
+
+@pytest.mark.frontend
+def test_all_tutorial_reset_without_manager_clears_versioned_home_key(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'test-token',
+            });
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            window.universalTutorialManager = null;
+            localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            localStorage.setItem('neko_tutorial_home', 'true');
+            localStorage.setItem('neko_tutorial_model_manager_mmd', 'true');
+            await resetAllTutorials();
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            modelManagerMmdSeen: localStorage.getItem('neko_tutorial_model_manager_mmd'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["modelManagerMmdSeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
+def test_home_tutorial_reset_with_manager_clears_versioned_home_key(mock_page: Page):
+    _bootstrap_page(
+        mock_page,
+        setup_js="""
+            window.pageConfigReady = Promise.resolve({
+                success: true,
+                autostart_csrf_token: 'test-token',
+            });
+            window.alert = function(message) {
+                window.__lastAlert = String(message || '');
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+        script_names=("app-prompt-shared.js", "universal-tutorial-manager.js"),
+    )
+
+    mock_page.evaluate(
+        """
+        async () => {
+            await initUniversalTutorialManager();
+            window.universalTutorialManager.getYuiGuideVersionedPageKey = () => null;
+            localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            localStorage.setItem('neko_tutorial_home', 'true');
+            await resetTutorialForPage('home');
+        }
+        """
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            manualIntent: localStorage.getItem('neko_tutorial_home_manual_intent'),
+        })
+        """
+    )
+
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["manualIntent"] == "true"
+
+
+@pytest.mark.frontend
 def test_home_tutorial_skip_restores_temporarily_disabled_galgame_mode(
     mock_page: Page,
 ):
@@ -1314,6 +2161,50 @@ def test_tutorial_heartbeat_does_not_report_completed_while_tutorial_is_running(
 
     assert result["manual_home_tutorial_viewed"] is True
     assert result["home_tutorial_completed"] is False
+
+
+@pytest.mark.frontend
+def test_started_manual_home_tutorial_does_not_suppress_reload_auto_start(
+    mock_page: Page,
+):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.universalTutorialManager = {
+                currentPage: 'home',
+                isTutorialRunning: false,
+                hasSeenTutorial: function() {
+                    return false;
+                },
+                logPromptFlow: function() {},
+                requestTutorialStart: async function() {
+                    return false;
+                },
+            };
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'started',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => window.appTutorialPrompt && window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart",
+        timeout=5000,
+    )
+
+    assert mock_page.evaluate(
+        "() => window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart()"
+    ) is False
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -1304,6 +1304,101 @@ def test_home_tutorial_reset_event_prevents_stale_completion_heartbeat(mock_page
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_event_re_resets_after_inflight_completed_heartbeat(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__heartbeatBodies = [];
+            window.__resetBodies = [];
+            window.__resolveHeartbeat = null;
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'completed',
+                        completed_at: 1234,
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: true,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatBodies.push(body);
+                return new Promise((resolve) => {
+                    window.__resolveHeartbeat = () => resolve(jsonResponse({
+                        ok: true,
+                        should_prompt: false,
+                        prompt_reason: '',
+                        prompt_token: null,
+                        state: {
+                            status: 'completed',
+                            never_remind: false,
+                            deferred_until: 0,
+                            manual_home_tutorial_viewed: true,
+                            home_tutorial_completed: true,
+                        },
+                    }));
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                window.__resetBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.wait_for_function(
+        "() => window.__heartbeatBodies.length >= 1 && typeof window.__resolveHeartbeat === 'function'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+            window.__resolveHeartbeat();
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__resetBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            staleHeartbeat: window.__heartbeatBodies[0],
+            resetBodies: window.__resetBodies.slice(),
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            suppressAutoStart: window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart(),
+        })
+        """
+    )
+
+    assert result["staleHeartbeat"]["home_tutorial_completed"] is True
+    assert result["staleHeartbeat"]["manual_home_tutorial_viewed"] is True
+    assert result["resetBodies"][0]["reason"] == "manual_home_tutorial_reset"
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["suppressAutoStart"] is False
+
+
+@pytest.mark.frontend
 def test_home_tutorial_reset_event_ignores_stale_initial_state_response(mock_page: Page):
     _bootstrap_tutorial_prompt_page(
         mock_page,
@@ -1386,6 +1481,9 @@ def test_home_tutorial_reset_event_clears_seen_prompt_token(mock_page: Page):
     _bootstrap_tutorial_prompt_page(
         mock_page,
         include_common_dialogs=True,
+        setup_js="""
+            window.__heartbeatCount = 0;
+        """,
         fetch_js="""
             if (requestUrl === '/api/tutorial-prompt/state') {
                 return jsonResponse({
@@ -1399,6 +1497,22 @@ def test_home_tutorial_reset_event_clears_seen_prompt_token(mock_page: Page):
                 });
             }
             if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                window.__heartbeatCount += 1;
+                if (window.__heartbeatCount > 1) {
+                    return jsonResponse({
+                        ok: true,
+                        should_prompt: false,
+                        prompt_reason: '',
+                        prompt_token: null,
+                        state: {
+                            status: 'started',
+                            never_remind: false,
+                            deferred_until: 0,
+                            manual_home_tutorial_viewed: true,
+                            home_tutorial_completed: false,
+                        },
+                    });
+                }
                 return jsonResponse({
                     ok: true,
                     should_prompt: true,
@@ -1434,21 +1548,6 @@ def test_home_tutorial_reset_event_clears_seen_prompt_token(mock_page: Page):
                         never_remind: false,
                         deferred_until: 0,
                         manual_home_tutorial_viewed: false,
-                        home_tutorial_completed: false,
-                    },
-                });
-            }
-            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
-                return jsonResponse({
-                    ok: true,
-                    should_prompt: false,
-                    prompt_reason: '',
-                    prompt_token: null,
-                    state: {
-                        status: 'started',
-                        never_remind: false,
-                        deferred_until: 0,
-                        manual_home_tutorial_viewed: true,
                         home_tutorial_completed: false,
                     },
                 });

--- a/tests/frontend/test_home_prompt_flow.py
+++ b/tests/frontend/test_home_prompt_flow.py
@@ -1399,6 +1399,148 @@ def test_home_tutorial_reset_event_re_resets_after_inflight_completed_heartbeat(
 
 
 @pytest.mark.frontend
+def test_home_tutorial_reset_event_re_resets_after_inflight_completion_lifecycle(mock_page: Page):
+    _bootstrap_tutorial_prompt_page(
+        mock_page,
+        setup_js="""
+            window.__startedBodies = [];
+            window.__completedBodies = [];
+            window.__resetBodies = [];
+            window.__resolveCompletion = null;
+        """,
+        fetch_js="""
+            if (requestUrl === '/api/tutorial-prompt/state') {
+                return jsonResponse({
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/heartbeat') {
+                return jsonResponse({
+                    ok: true,
+                    should_prompt: false,
+                    prompt_reason: '',
+                    prompt_token: null,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-started') {
+                window.__startedBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    tutorial_run_token: 'tutorial-run-token',
+                    state: {
+                        status: 'started',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: true,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/tutorial-completed') {
+                window.__completedBodies.push(body);
+                return new Promise((resolve) => {
+                    window.__resolveCompletion = () => resolve(jsonResponse({
+                        ok: true,
+                        state: {
+                            status: 'completed',
+                            never_remind: false,
+                            deferred_until: 0,
+                            manual_home_tutorial_viewed: true,
+                            home_tutorial_completed: true,
+                        },
+                    }));
+                });
+            }
+            if (requestUrl === '/api/tutorial-prompt/reset') {
+                window.__resetBodies.push(body);
+                return jsonResponse({
+                    ok: true,
+                    state: {
+                        status: 'observing',
+                        never_remind: false,
+                        deferred_until: 0,
+                        manual_home_tutorial_viewed: false,
+                        home_tutorial_completed: false,
+                    },
+                });
+            }
+        """,
+    )
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-started', {
+                detail: { page: 'home', source: 'manual' },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__startedBodies.length === 1",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-completed', {
+                detail: { page: 'home', source: 'manual' },
+            }));
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__completedBodies.length === 1 && typeof window.__resolveCompletion === 'function'",
+        timeout=5000,
+    )
+    mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' },
+            }));
+            window.__resolveCompletion();
+        }
+        """
+    )
+    mock_page.wait_for_function(
+        "() => window.__resetBodies.length >= 1",
+        timeout=5000,
+    )
+
+    result = mock_page.evaluate(
+        """
+        () => ({
+            completedBodies: window.__completedBodies.slice(),
+            resetBodies: window.__resetBodies.slice(),
+            versionedSeen: localStorage.getItem('neko_tutorial_home_yui_v1'),
+            legacySeen: localStorage.getItem('neko_tutorial_home'),
+            suppressAutoStart: window.appTutorialPrompt.shouldSuppressAutomaticHomeTutorialStart(),
+        })
+        """
+    )
+
+    assert result["completedBodies"][0]["tutorial_run_token"] == "tutorial-run-token"
+    assert result["resetBodies"][0]["reason"] == "manual_home_tutorial_reset"
+    assert result["versionedSeen"] is None
+    assert result["legacySeen"] is None
+    assert result["suppressAutoStart"] is False
+
+
+@pytest.mark.frontend
 def test_home_tutorial_reset_event_ignores_stale_initial_state_response(mock_page: Page):
     _bootstrap_tutorial_prompt_page(
         mock_page,

--- a/tests/frontend/test_initial_personality_onboarding.py
+++ b/tests/frontend/test_initial_personality_onboarding.py
@@ -486,12 +486,363 @@ def test_onboarding_does_not_preempt_new_user_tutorial_prompt_flow(mock_page: Pa
 
 
 @pytest.mark.frontend
+@pytest.mark.parametrize("prompt_status", ["deferred", "never"])
+def test_onboarding_respects_declined_new_user_tutorial_prompt_decision(
+    mock_page: Page,
+    prompt_status: str,
+):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        (promptStatus) => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: promptStatus,
+                deferred_until: promptStatus === 'deferred' ? Date.now() + 60000 : 0,
+                never_remind: promptStatus === 'never',
+                user_cohort: 'new',
+            };
+        }
+        """,
+        prompt_status,
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible(timeout=1000)
+
+
+@pytest.mark.frontend
+def test_onboarding_waits_for_home_tutorial_storage_completion_even_if_prompt_state_completed(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.universalTutorialManager.hasSeenTutorial = function(page) {
+                return page === 'home'
+                    && window.localStorage.getItem('neko_tutorial_home_yui_v1') === 'true';
+            };
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                user_cohort: 'new',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(350)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
+            window.localStorage.setItem('neko_tutorial_home', 'true');
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_clears_session_completion_marker_on_home_tutorial_reset(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    result = mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+            const markedCompleted = window.CharacterPersonalityOnboarding.homeTutorialCompletedInSession;
+            window.dispatchEvent(new CustomEvent('neko:home-tutorial-reset', {
+                detail: { page: 'home', source: 'manual_home_tutorial_reset' }
+            }));
+            return {
+                markedCompleted,
+                afterReset: window.CharacterPersonalityOnboarding.homeTutorialCompletedInSession,
+            };
+        }
+        """
+    )
+
+    assert result["markedCompleted"] is True
+    assert result["afterReset"] is False
+
+
+@pytest.mark.frontend
+def test_onboarding_clears_session_completion_marker_on_cross_window_home_tutorial_reset(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    result = mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+            const markedCompleted = window.CharacterPersonalityOnboarding.homeTutorialCompletedInSession;
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: 'neko_home_tutorial_reset_event',
+                newValue: JSON.stringify({
+                    page: 'home',
+                    source: 'manual_home_tutorial_reset',
+                    nonce: 'from-memory-browser-window',
+                }),
+            }));
+            return {
+                markedCompleted,
+                afterReset: window.CharacterPersonalityOnboarding.homeTutorialCompletedInSession,
+            };
+        }
+        """
+    )
+
+    assert result["markedCompleted"] is True
+    assert result["afterReset"] is False
+
+
+@pytest.mark.frontend
+def test_onboarding_reset_broadcast_channel_is_closed_on_unload(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.__resetBroadcastChannels = [];
+            window.BroadcastChannel = class {
+                constructor(name) {
+                    this.name = name;
+                    this.closed = false;
+                    this.listeners = {};
+                    window.__resetBroadcastChannels.push(this);
+                }
+                addEventListener(type, listener) {
+                    this.listeners[type] = listener;
+                }
+                close() {
+                    this.closed = true;
+                }
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    result = mock_page.evaluate(
+        """
+        () => {
+            window.dispatchEvent(new Event('beforeunload'));
+            return {
+                count: window.__resetBroadcastChannels.length,
+                closed: window.__resetBroadcastChannels[0] && window.__resetBroadcastChannels[0].closed,
+                managerCleared: window.CharacterPersonalityOnboarding.resetBroadcastChannel === null,
+            };
+        }
+        """
+    )
+
+    assert result == {
+        "count": 1,
+        "closed": True,
+        "managerCleared": True,
+    }
+
+
+@pytest.mark.frontend
+def test_onboarding_does_not_timeout_while_home_tutorial_is_running(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            const realSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, delay, ...args) => {
+                if (delay === 15000) {
+                    return realSetTimeout(callback, 20, ...args);
+                }
+                return realSetTimeout(callback, delay, ...args);
+            };
+            window.universalTutorialManager.isTutorialRunning = true;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(120)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_does_not_open_while_home_tutorial_start_is_locked(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            const realSetTimeout = window.setTimeout.bind(window);
+            window.setTimeout = (callback, delay, ...args) => {
+                if (delay === 15000) {
+                    return realSetTimeout(callback, 20, ...args);
+                }
+                return realSetTimeout(callback, delay, ...args);
+            };
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__homeTutorialLocked = true;
+            window.isNekoHomeTutorialInteractionLocked = () => window.__homeTutorialLocked;
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(120)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__homeTutorialLocked = false;
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
+def test_onboarding_waits_when_default_character_makes_new_user_look_existing(mock_page: Page):
+    _bootstrap_page(mock_page)
+    mock_page.evaluate(
+        """
+        () => {
+            window.universalTutorialManager.isTutorialRunning = false;
+            window.__tutorialPromptStatePayload = {
+                status: 'observing',
+                shown_count: 0,
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: false,
+                manual_home_tutorial_viewed: false,
+                chat_turns: 0,
+                voice_sessions: 0,
+                user_cohort: 'existing',
+            };
+        }
+        """
+    )
+    mock_page.add_script_tag(path=str(PROJECT_ROOT / "static" / "js" / "character_personality_onboarding.js"))
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.CharacterPersonalityOnboarding.bootstrap();
+        }
+        """
+    )
+
+    mock_page.wait_for_timeout(350)
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_have_count(0)
+
+    mock_page.evaluate(
+        """
+        () => {
+            window.__tutorialPromptStatePayload = {
+                status: 'completed',
+                shown_count: 0,
+                deferred_until: 0,
+                never_remind: false,
+                home_tutorial_completed: true,
+                manual_home_tutorial_viewed: true,
+                chat_turns: 0,
+                voice_sessions: 0,
+                user_cohort: 'existing',
+            };
+            window.dispatchEvent(new CustomEvent('neko:tutorial-skipped', {
+                detail: { page: 'home', source: 'auto' }
+            }));
+        }
+        """
+    )
+
+    expect(mock_page.locator("[data-testid='character-personality-overlay']")).to_be_visible()
+
+
+@pytest.mark.frontend
 def test_onboarding_ignores_stale_auto_home_tutorial_start_after_prompt_completed(mock_page: Page):
     _bootstrap_page(mock_page)
     mock_page.evaluate(
         """
         () => {
             window.universalTutorialManager.isTutorialRunning = false;
+            window.localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
             window.__tutorialPromptStatePayload = {
                 status: 'completed',
                 deferred_until: 0,
@@ -533,6 +884,7 @@ def test_onboarding_hides_overlay_when_real_auto_tutorial_starts_after_overlay(m
         """
         () => {
             window.universalTutorialManager.isTutorialRunning = false;
+            window.localStorage.setItem('neko_tutorial_home_yui_v1', 'true');
             window.__tutorialPromptStatePayload = {
                 status: 'completed',
                 deferred_until: 0,
@@ -588,7 +940,7 @@ def test_onboarding_does_not_treat_tutorial_prompt_fetch_failure_as_settled(mock
         """
         () => {
             window.universalTutorialManager.isTutorialRunning = false;
-            window.__tutorialPromptFetchFailuresRemaining = 2;
+            window.__tutorialPromptFetchFailuresRemaining = 5;
             window.__tutorialPromptState = 'completed';
         }
         """


### PR DESCRIPTION
## 变更说明

在 PR #1291 已修复后端教程 reset 状态的基础上，本次补齐前端侧的首页教程重置同步和新用户弹窗串行逻辑。

本次主要解决两个前端时序问题：

1. 从记忆浏览页重置首页教程或全部教程后，页面刷新 / 重载时，旧窗口或旧本地状态可能继续影响首页教程启动，导致首页教程偶发不弹。
2. 新用户首次选择完存储位置后，初始人格选择弹窗可能先于首页教程弹出，随后又被首页教程覆盖，弹窗顺序不稳定。

本次调整后：

- 首页教程 reset 会同步通知当前窗口和其他窗口清理本地首页教程完成标记。
- 首页教程自动启动前会避开正在展示的教程提示、运行中的教程、已完成、不再提醒、稍后提醒等明确状态。
- 初始人格选择会等待首页教程完成或用户跳过后再弹出。
- 教程运行期间刷新页面时，未完成的首页教程仍有机会重新触发，不会因为本地旧标记直接跳过。
- 补充前端回归测试覆盖 reset、刷新、首页教程自动启动、人设选择等待等场景。

## 和 PR #1291 的区别

PR #1291 主要处理后端教程状态 reset、接口安全、远程前端请求兼容，以及 heartbeat / teardown 不应误写 completed 的问题。

本 PR 不重复修改后端 reset 接口和状态存储逻辑，重点只补前端侧：

- reset 事件同步
- localStorage 首页教程标记清理
- 首页教程自动启动抑制判断
- 初始人格选择与首页教程的弹窗顺序控制

## 边界

本次改动只涉及首页教程和初始人格选择之间的前端时序，不修改：

- 聊天主流程
- 字幕翻译
- TTS
- API Key / 模型配置
- 角色卡管理
- Steam 创意工坊订阅
- 存储位置选择的保存逻辑
- 记忆内容读写逻辑
- 其他页面教程的步骤和文案
- PR #1291 中已有的后端 reset 接口逻辑

本次没有新增硬编码教程文案，也没有修改 i18n 文案内容。

## 风险

- 本次修复依赖前端事件同步和 localStorage 状态清理，如果后续首页教程状态字段继续调整，需要同步检查这些判断条件。
- 初始人格选择现在会等待首页教程完成或跳过后再弹，如果产品后续要求人格选择优先于首页教程，需要重新调整弹窗优先级。
- 多窗口场景下，reset 事件通过 BroadcastChannel 和 storage event 同步；极老浏览器可能只走 storage event 兜底。
- 本 PR 是基于 PR #1291 之上的前端补充修复，如果 PR #1291 的后端 reset 逻辑发生较大变化，需要重新确认本 PR 的前端状态判断是否仍匹配。

## 测试

已跑本分支波及范围测试：

```bash
node --check static/app-tutorial-prompt.js
node --check static/universal-tutorial-manager.js
node --check static/js/character_personality_onboarding.js
uv run pytest -q tests/frontend/test_home_prompt_flow.py tests/frontend/test_initial_personality_onboarding.py tests/frontend/test_memory_browser.py tests/frontend/test_storage_location_startup.py tests/unit/test_tutorial_prompt_state.py tests/unit/test_tutorial_prompt_router.py tests/unit/test_websocket_home_tutorial_guard.py tests/test_agent_rewrite_regression.py tests/unit/test_system_status_router.py tests/unit/test_storage_location_bootstrap.py tests/unit/test_storage_location_router.py tests/e2e/test_home_prompt_flow.py -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 完善主页面教程的跨窗口/选项卡重置与同步（CustomEvent/localStorage/BroadcastChannel），加入每标签“已见”与本地“稍后/永不”抑制、重置代数与自动启动阻塞/等待解锁逻辑。
  * 导出用于阻止自动启动的本地抑制检测。

* **错误修复**
  * 处理心跳与服务端竞态：忽略陈旧响应、在重置/并发流程中防止错误展示或保留抑制。

* **测试**
  * 扩展前端与端到端测试，覆盖抑制、重置、跨窗口同步、已见标记与展示时序与时机鲁棒性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1296)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->