### PR TITLE
将展开后的角色卡卡面点击行为改为打开模型管理页，保留“编辑卡面”按钮进入卡面制作页

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -4285,10 +4285,15 @@ function openCatgirlPanel(card, originEl) {
         openManagedPopup(makerUrl, CHARACTER_MANAGER_CARD_MAKER_WINDOW_NAME, 'width=1200,height=800');
     };
 
-    // 点击卡面主体或右侧按钮打开角色卡制作页面
-    cardImage.addEventListener('click', (event) => {
+    const openCardModelManager = async () => {
+        const form = cardImage.closest('.catgirl-panel-wrapper')?.querySelector('form');
+        await openModelManagerForCharacterForm(form, name);
+    };
+
+    // 点击卡面主体打开模型管理；编辑卡面按钮仍进入角色卡制作页面。
+    cardImage.addEventListener('click', async (event) => {
         if (event.target.closest('.catgirl-panel-card-action')) return;
-        openCardMaker();
+        await openCardModelManager();
     });
     editCardFaceAction.addEventListener('click', (event) => {
         event.stopPropagation();
@@ -4296,8 +4301,7 @@ function openCatgirlPanel(card, originEl) {
     });
     modelSettingsAction.addEventListener('click', async (event) => {
         event.stopPropagation();
-        const form = cardImage.closest('.catgirl-panel-wrapper')?.querySelector('form');
-        await openModelManagerForCharacterForm(form, name);
+        await openCardModelManager();
     });
 
     // 监听角色卡制作页面的保存消息


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 用户界面改进

* **功能调整**
  * 点击卡牌图像现在打开模型管理器，提供更一致的工作流程
  * "编辑卡面"按钮保持原有的卡面编辑功能
  * "模型设置"按钮采用统一的模型管理器处理方式

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1300)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->