### PR TITLE
feat(debug): LLM prompt 审计加 config 开关，方便打包后调试

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -242,6 +242,15 @@ AUTOSTART_ALLOWED_ORIGINS = _build_local_allowed_origins(
     extra_origins=_read_list_env("AUTOSTART_ALLOWED_ORIGINS"),
 )
 
+# ----------------------------------------------------------------------
+# Debug flags（打包给用户调试时在源码里 flip，重新打包即可生效）
+# ----------------------------------------------------------------------
+# LLM prompt 审计：打开后每次发给 LLM 的请求体（messages、token 数、limit
+# 字段）会写到 logs/llm_prompt_audit/YYYY-MM-DD.jsonl，用于诊断 prompt
+# budget 占比。env var NEKO_LLM_PROMPT_AUDIT=1 同样可启用（任一为真即开）。
+# 生产默认 False。
+LLM_PROMPT_AUDIT_ENABLED = False
+
 # tfLink 文件上传服务配置
 TFLINK_UPLOAD_URL = 'http://47.101.214.205:8000/api/upload'
 # tfLink 允许的主机名白名单（用于 SSRF 防护）

--- a/utils/llm_prompt_audit.py
+++ b/utils/llm_prompt_audit.py
@@ -10,8 +10,9 @@ budget 占比是否合理。
 
 输出：
     logs/llm_prompt_audit/YYYY-MM-DD.jsonl
-    每行一条 JSON，messages[*].text 字段含**完整原文**（不截断），
-    图片 part 会替换成字面值 "[image]" 占位以免 base64 撑爆 log。
+    每行一条 JSON，messages[*].text 字段含 text 类 part 的**完整原文**
+    （不截断）；image/audio/video 等非 text 类 part 会被替换为
+    "[<type>]" 占位以免 base64 撑爆 log + 泄露用户截图。
 
 不要在生产默认启用——log 含完整 prompt 原文，属于隐私敏感数据。
 """
@@ -51,11 +52,24 @@ def _today_path() -> Path:
 
 
 def _content_to_text(content: Any) -> str:
-    """Flatten OpenAI message content to plain text for token counting.
+    """Flatten message content to plain text for token counting.
 
-    Handles str, list[{"type": "text", "text": "..."}], dict, etc.
-    For multimodal image_url parts, omits the base64 (we don't want to count
-    image bytes as text tokens).
+    Whitelist 策略：只有 text 类 part（``text`` / ``input_text`` /
+    ``output_text``）原文落盘，其他所有类型一律替换为 ``[<type>]`` 占位。
+
+    为什么不是黑名单——本 repo 实际用到的"图片 part"至少有 5 种形态：
+
+    * OpenAI 经典： ``{"type": "image_url", "image_url": {...}}``
+    * Anthropic 风格： ``{"type": "image", "source": {"type": "base64", ...}}``
+    * Anthropic 新： ``{"type": "input_image", ...}``
+    * Plugin schema： ``{"type": "image", "data": bytes, "mime": str}``
+    * 自家适配器： ``{"type": "image", "image_url": "..."}``
+
+    再加上 ``audio`` / ``video`` / 未来可能新增的 multimodal 类型——
+    任何不在 whitelist 里的 part 都视作可能含二进制/base64，统一替换
+    为 ``[<type>]`` 占位。既避免把用户截图原样写进 jsonl，也让函数
+    契约"flatten to plain text for token counting"保持自洽（二进制
+    本来就不是文本 token）。
     """
     if isinstance(content, str):
         return content
@@ -68,31 +82,17 @@ def _content_to_text(content: Any) -> str:
             ptype = part.get("type")
             if ptype in ("text", "input_text", "output_text"):
                 out.append(str(part.get("text") or ""))
-            elif ptype in ("image_url", "input_image"):
-                out.append("[image]")
             else:
-                # 未知 part 类型：完整 json dump，不截断（审计需要全文）。
-                # 注意 image_url/input_image 已在上面分支拦截，落不到这里。
-                # try/except 与 dict 分支对偶——单个 part 序列化失败不应
-                # 让整条 message 的 audit 跟着丢掉（外层 except 会吞整条记录）。
-                try:
-                    out.append(json.dumps(part, ensure_ascii=False))
-                except Exception:
-                    out.append(str(part))
+                # 见函数 docstring：非 text 类一律占位，不 json.dumps，
+                # 不试图细分图片/音频/视频——白名单比黑名单安全。
+                out.append(f"[{ptype or 'unknown'}]")
         return "\n".join(out)
     if isinstance(content, dict):
-        # 镜像 list 分支的类型分流：上游偶尔直接传单个 part dict（不是
-        # list 包裹），不能 json.dumps(整个 content)——否则 image_url
-        # base64 会原样落盘，既泄露用户截图也撑爆 jsonl。
+        # 镜像 list 分支：上游偶尔直接传单个 part dict（不是 list 包裹）。
         ptype = content.get("type")
         if ptype in ("text", "input_text", "output_text"):
             return str(content.get("text") or "")
-        if ptype in ("image_url", "input_image"):
-            return "[image]"
-        try:
-            return json.dumps(content, ensure_ascii=False)
-        except Exception:
-            return str(content)
+        return f"[{ptype or 'unknown'}]"
     return str(content) if content is not None else ""
 
 

--- a/utils/llm_prompt_audit.py
+++ b/utils/llm_prompt_audit.py
@@ -9,9 +9,11 @@ budget 占比是否合理。
     2) 设置环境变量 NEKO_LLM_PROMPT_AUDIT=1（适合开发期临时打开）
 
 输出：
-    logs/llm_prompt_audit/YYYY-MM-DD.jsonl  （每行一条 JSON，可能含用户原文摘要）
+    logs/llm_prompt_audit/YYYY-MM-DD.jsonl
+    每行一条 JSON，messages[*].text 字段含**完整原文**（不截断），
+    图片 part 会替换成字面值 "[image]" 占位以免 base64 撑爆 log。
 
-不要在生产默认启用——log 含 prompt 文本预览，属于隐私敏感数据。
+不要在生产默认启用——log 含完整 prompt 原文，属于隐私敏感数据。
 """
 from __future__ import annotations
 
@@ -69,7 +71,9 @@ def _content_to_text(content: Any) -> str:
             elif ptype in ("image_url", "input_image"):
                 out.append("[image]")
             else:
-                out.append(json.dumps(part, ensure_ascii=False)[:200])
+                # 未知 part 类型：完整 json dump，不截断（审计需要全文）。
+                # 注意 image_url/input_image 已在上面分支拦截，落不到这里。
+                out.append(json.dumps(part, ensure_ascii=False))
         return "\n".join(out)
     if isinstance(content, dict):
         # 镜像 list 分支的类型分流：上游偶尔直接传单个 part dict（不是
@@ -81,9 +85,9 @@ def _content_to_text(content: Any) -> str:
         if ptype in ("image_url", "input_image"):
             return "[image]"
         try:
-            return json.dumps(content, ensure_ascii=False)[:200]
+            return json.dumps(content, ensure_ascii=False)
         except Exception:
-            return str(content)[:200]
+            return str(content)
     return str(content) if content is not None else ""
 
 
@@ -168,13 +172,12 @@ def record_llm_request(
             role = str(m.get("role") or "unknown")
             text = _content_to_text(m.get("content"))
             tok = _safe_count_tokens(text)
-            preview = text[:160]
             per_message.append({
                 "idx": idx,
                 "role": role,
                 "tokens": tok,
                 "chars": len(text),
-                "preview": preview,
+                "text": text,
             })
             total += tok
             by_role[role] = by_role.get(role, 0) + tok

--- a/utils/llm_prompt_audit.py
+++ b/utils/llm_prompt_audit.py
@@ -73,7 +73,12 @@ def _content_to_text(content: Any) -> str:
             else:
                 # 未知 part 类型：完整 json dump，不截断（审计需要全文）。
                 # 注意 image_url/input_image 已在上面分支拦截，落不到这里。
-                out.append(json.dumps(part, ensure_ascii=False))
+                # try/except 与 dict 分支对偶——单个 part 序列化失败不应
+                # 让整条 message 的 audit 跟着丢掉（外层 except 会吞整条记录）。
+                try:
+                    out.append(json.dumps(part, ensure_ascii=False))
+                except Exception:
+                    out.append(str(part))
         return "\n".join(out)
     if isinstance(content, dict):
         # 镜像 list 分支的类型分流：上游偶尔直接传单个 part dict（不是

--- a/utils/llm_prompt_audit.py
+++ b/utils/llm_prompt_audit.py
@@ -1,21 +1,17 @@
-"""TEMPORARY: 临时 LLM prompt 审计日志（测完即删）。
+"""LLM prompt 审计日志（debug 工具）。
 
 目的：把每一次发给 LLM 的完整请求体（messages、model、max_completion_tokens 等）
 + 各 message 的 tiktoken token 数写到本地 jsonl，配合人工/脚本分析各 component
 budget 占比是否合理。
 
-启用方式：
-    NEKO_LLM_PROMPT_AUDIT=1 ./run.sh
+启用方式（任一为真即开）：
+    1) 源码里把 config.LLM_PROMPT_AUDIT_ENABLED 改成 True（适合打包时分发给用户调试）
+    2) 设置环境变量 NEKO_LLM_PROMPT_AUDIT=1（适合开发期临时打开）
 
 输出：
-    logs/llm_prompt_audit/YYYY-MM-DD.jsonl  （每行一条 JSON）
+    logs/llm_prompt_audit/YYYY-MM-DD.jsonl  （每行一条 JSON，可能含用户原文摘要）
 
-删除方式：
-    1. 删除本文件
-    2. utils/llm_client.py 里删除 record_llm_request 调用
-    3. 删除 logs/llm_prompt_audit/
-
-不要在生产环境启用。
+不要在生产默认启用——log 含 prompt 文本预览，属于隐私敏感数据。
 """
 from __future__ import annotations
 
@@ -28,7 +24,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-_ENABLED = os.environ.get("NEKO_LLM_PROMPT_AUDIT", "").lower() in ("1", "true", "yes")
+from config import LLM_PROMPT_AUDIT_ENABLED
+
+_ENABLED = (
+    LLM_PROMPT_AUDIT_ENABLED
+    or os.environ.get("NEKO_LLM_PROMPT_AUDIT", "").lower() in ("1", "true", "yes")
+)
 _LOG_DIR = Path("logs/llm_prompt_audit")
 _LOCK = threading.Lock()
 
@@ -127,7 +128,8 @@ def _print_banner_once() -> None:
     try:
         print(
             "[LLM_PROMPT_AUDIT] enabled — writing to "
-            f"{_LOG_DIR.resolve()} (NEKO_LLM_PROMPT_AUDIT=1)",
+            f"{_LOG_DIR.resolve()} "
+            "(config.LLM_PROMPT_AUDIT_ENABLED or NEKO_LLM_PROMPT_AUDIT=1)",
             flush=True,
         )
     except Exception:


### PR DESCRIPTION
## Summary

- `NEKO_LLM_PROMPT_AUDIT` 之前只能用环境变量启用，打包后的 .exe 让最终用户设环境变量不现实
- 新增 `config.LLM_PROMPT_AUDIT_ENABLED` 常量（默认 `False`），与 env var **取或** —— 任一为真即开
- 打包"调试版本"分发时把这个常量改成 `True` 重打即可，不破坏开发期 env var 习惯
- 顺手把 `utils/llm_prompt_audit.py` 文件头从"TEMPORARY 测完即删"升级为正式 debug 工具说明，并显式标注 log 含 prompt 文本预览（隐私敏感数据）

## Test plan

- [x] `uv run python -c "from utils import llm_prompt_audit; print(llm_prompt_audit.is_enabled())"` → `False`（默认关闭路径）
- [ ] 把 `LLM_PROMPT_AUDIT_ENABLED = True` 后再跑一次，确认变 `True` 并能写出 jsonl
- [ ] 保持常量 `False`，设 `NEKO_LLM_PROMPT_AUDIT=1` 再跑，确认 env var 路径仍 work

## Known limitation

- `_ENABLED` 还是 module-level 一次性读，**进程启动后改 config 不生效**，需要重启进程。如果以后想做"运行时热 toggle"（前端 UI 开关），需要把 `_ENABLED` 换成 `is_enabled()` 每次问 config，另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 LLM 提示审计开关与说明，默认关闭，可通过配置或环境变量启用，启动时显示审计已启用状态提示。

* **改进**
  * 启用条件扩展为配置与环境变量共同支持。
  * 审计日志更严格筛选仅保留文本类内容，其他类型以占位符替代；每日日志以 JSONL 追加存储，消息内容以完整文本记录，且日志写入失败不会影响主流程。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1302)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->