### PR TITLE
fix(ci): gate steamworks native libs by RUNNER_OS to fix macOS Nuitka build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -362,18 +362,23 @@ jobs:
           # Steam files (include if present in repo).
           # PR #1264 moved native libs into steamworks/; runtime still loads them
           # from the exe sibling dir (see steamworks/__init__.py), so dest stays at root.
+          # Gate by RUNNER_OS: all platforms' libs are checked into the repo, but
+          # feeding a Linux ELF .so to a macOS Nuitka build trips an arch-mismatch FATAL.
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steam_appid.txt=steam_appid.txt"
-          if [ -f "steamworks/libsteam_api.dylib" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.dylib=libsteam_api.dylib"
-          fi
-          if [ -f "steamworks/SteamworksPy.dylib" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.dylib=SteamworksPy.dylib"
-          fi
-          if [ -f "steamworks/libsteam_api.so" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.so=libsteam_api.so"
-          fi
-          if [ -f "steamworks/SteamworksPy.so" ]; then
-            NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.so=SteamworksPy.so"
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            if [ -f "steamworks/libsteam_api.dylib" ]; then
+              NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.dylib=libsteam_api.dylib"
+            fi
+            if [ -f "steamworks/SteamworksPy.dylib" ]; then
+              NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.dylib=SteamworksPy.dylib"
+            fi
+          elif [[ "$RUNNER_OS" == "Linux" ]]; then
+            if [ -f "steamworks/libsteam_api.so" ]; then
+              NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.so=libsteam_api.so"
+            fi
+            if [ -f "steamworks/SteamworksPy.so" ]; then
+              NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.so=SteamworksPy.so"
+            fi
           fi
 
           echo "=== Nuitka options ==="


### PR DESCRIPTION
## Summary

Nightly desktop build [run 25647861208](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/25647861208) — first nightly after #1285 merged — failed on both macOS jobs (mac-x64 + mac-arm64) with:

```
FATAL: Error, cannot use file '.../steamworks/SteamworksPy.so'
(ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), ...)
to build arch 'arm64' result
```

#1285 added `if -f` existence guards on the steamworks `--include-data-files` block, but only checked file presence. All platforms' native libs (`*.dylib`, `*.so`, `*.dll`) are checked into [steamworks/](steamworks/), so on macOS runners the four `if -f` checks all pass and the Linux ELF `.so` gets fed to Nuitka alongside the `.dylib`s. Nuitka then aborts during link with an arch mismatch. Linux/Windows weren't affected because they only see matching libs (the Linux runner has no `.dylib` to misuse; the Windows branch uses a separate cmd block that only runs on Windows).

## Fix

Wrap the `.dylib` includes in `[[ \"$RUNNER_OS\" == \"macOS\" ]]` and the `.so` includes in `Linux`. Inner `if -f` guards are kept so missing libs in a fork still degrade gracefully rather than failing the build.

## Test plan
- [ ] Trigger \`Build Desktop App\` workflow on this branch (workflow_dispatch) and verify both macOS matrix jobs complete \`Build with Nuitka (Unix)\`
- [ ] Confirm Linux + Windows jobs still pass (no behavior change for them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了非Windows系统的构建流程，改进了Steamworks原生库的平台适配机制，防止架构不匹配导致的构建失败，提升跨平台编译的稳定性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1303)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->