### PR TITLE
适配角色卡展开面板的小窗口 Steam 标签布局：切到 Steam 时自动收起左侧卡面释放空间，切回设定时使用整面板转场恢复卡面，并刷新模…

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4529,6 +4529,37 @@ margin-top: 10px;
     }
 }
 
+/* 窄窗口切到 Steam 时收起左侧卡面，把宽度留给上传配置与模型预览 */
+.catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .catgirl-panel-left {
+    width: 0;
+    min-width: 0;
+    flex-basis: 0;
+    padding: 0;
+    border-right: 0;
+    opacity: 0;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .catgirl-panel-card-image,
+.catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .card-meta-block,
+.catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .card-panel-actions {
+    opacity: 0;
+    transform: translateX(-12px);
+}
+
+.catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .panel-header-bar {
+    border-radius: 12px 12px 0 0;
+}
+
+@media (max-width: 768px) {
+    .catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .catgirl-panel-left {
+        width: 100%;
+        height: 0;
+        max-height: 0;
+    }
+}
+
 .catgirl-panel-wrapper.card-only.phase-expand .catgirl-panel-right {
     flex: 1 1 auto;
     min-width: 0;
@@ -4709,6 +4740,10 @@ margin-top: 10px;
     z-index: 30;
     pointer-events: none;
     overflow: hidden;
+}
+
+.panel-transition-curtain.full-panel {
+    border-radius: inherit;
 }
 
 /* 主幕布色块 - 默认从左到右扫过（点击右侧 tab） */
@@ -4894,6 +4929,7 @@ margin-top: 10px;
     gap: 12px;
     border-right: 1px solid #f0f0f0;
     background: #fafcff;
+    transition: width 0.32s ease, flex-basis 0.32s ease, padding 0.32s ease, opacity 0.24s ease, border-color 0.32s ease;
 }
 
 
@@ -4909,7 +4945,7 @@ margin-top: 10px;
     overflow: hidden;
     cursor: pointer;
     position: relative;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.24s ease;
 }
 
 .catgirl-panel-card-image:hover {
@@ -5887,6 +5923,7 @@ margin-top: 10px;
     overscroll-behavior: contain;
     scrollbar-width: thin;
     scrollbar-color: rgba(64, 197, 241, 0.55) rgba(179, 229, 252, 0.3);
+    transition: opacity 0.24s ease, transform 0.24s ease;
 }
 
 .card-meta-block::-webkit-scrollbar {
@@ -6003,6 +6040,7 @@ margin-top: 10px;
     gap: 6px;
     box-sizing: border-box;
     flex-shrink: 0;
+    transition: opacity 0.24s ease, transform 0.24s ease;
 }
 
 /* 新建猫娘面板（card-only 无 phase-expand）时，左侧只有卡面，不占位 */

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4531,11 +4531,14 @@ margin-top: 10px;
 
 /* 窄窗口切到 Steam 时收起左侧卡面，把宽度留给上传配置与模型预览 */
 .catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .catgirl-panel-left {
-    width: 0;
-    min-width: 0;
-    flex-basis: 0;
-    padding: 0;
-    border-right: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    transform: scaleX(0);
+    transform-origin: left center;
+    border-color: transparent;
     opacity: 0;
     pointer-events: none;
     overflow: hidden;
@@ -4554,9 +4557,7 @@ margin-top: 10px;
 
 @media (max-width: 768px) {
     .catgirl-panel-wrapper.card-only.phase-expand.steam-compact-card-hidden .catgirl-panel-left {
-        width: 100%;
-        height: 0;
-        max-height: 0;
+        transform-origin: left top;
     }
 }
 
@@ -4929,7 +4930,9 @@ margin-top: 10px;
     gap: 12px;
     border-right: 1px solid #f0f0f0;
     background: #fafcff;
-    transition: width 0.32s ease, flex-basis 0.32s ease, padding 0.32s ease, opacity 0.24s ease, border-color 0.32s ease;
+    transform: scaleX(1);
+    transform-origin: left center;
+    transition: transform 0.28s ease, opacity 0.24s ease, border-color 0.28s ease;
 }
 
 

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -4202,6 +4202,64 @@ function renderCharaCardsList(container, cards, currentCatgirl, hiddenKeys) {
 // ===== 角色卡详情面板 =====
 
 let _catgirlPanelOpen = false;
+const CATGIRL_PANEL_STEAM_COMPACT_WIDTH = 1280;
+let _catgirlPanelSteamLayoutRaf = null;
+
+function isCatgirlPanelSteamCompactWindow() {
+    const width = window.innerWidth || document.documentElement.clientWidth || 0;
+    return width > 0 && width < CATGIRL_PANEL_STEAM_COMPACT_WIDTH;
+}
+
+function refreshSteamPreviewAfterPanelLayoutChange() {
+    requestAnimationFrame(function () {
+        if (typeof buildPreviewRing === 'function') buildPreviewRing();
+        if (live2dPreviewManager && live2dPreviewManager.pixi_app) {
+            const l2dContainer = document.getElementById('live2d-preview-content');
+            if (l2dContainer && l2dContainer.clientWidth > 0 && l2dContainer.clientHeight > 0) {
+                live2dPreviewManager.pixi_app.renderer.resize(l2dContainer.clientWidth, l2dContainer.clientHeight);
+                if (live2dPreviewManager.currentModel) {
+                    live2dPreviewManager.applyModelSettings(live2dPreviewManager.currentModel, {});
+                    live2dPreviewManager.pixi_app.renderer.render(live2dPreviewManager.pixi_app.stage);
+                }
+            }
+        }
+        syncWorkshop3DPreviewSize(workshopVrmManager, 'vrm-preview-canvas');
+        syncWorkshop3DPreviewSize(workshopMmdManager, 'mmd-preview-canvas');
+    });
+}
+
+function updateCatgirlPanelSteamCardLayout(wrapper) {
+    const panel = wrapper || document.getElementById('catgirl-panel-wrapper');
+    if (!panel) return;
+
+    const activeTab = panel.querySelector('.panel-tab.active');
+    const shouldHideCardFace = !!(
+        activeTab
+        && activeTab.dataset.tab === 'steam'
+        && isCatgirlPanelSteamCompactWindow()
+    );
+    const wasHidden = panel.classList.contains('steam-compact-card-hidden');
+    panel.classList.toggle('steam-compact-card-hidden', shouldHideCardFace);
+    const indicator = panel.querySelector('.panel-tabs-indicator');
+    if (activeTab && indicator) {
+        indicator.style.left = activeTab.offsetLeft + 'px';
+        indicator.style.width = activeTab.offsetWidth + 'px';
+    }
+    const changed = wasHidden !== shouldHideCardFace;
+    if (changed) {
+        setTimeout(refreshSteamPreviewAfterPanelLayoutChange, 430);
+    }
+}
+
+function scheduleCatgirlPanelSteamCardLayoutUpdate() {
+    if (_catgirlPanelSteamLayoutRaf) cancelAnimationFrame(_catgirlPanelSteamLayoutRaf);
+    _catgirlPanelSteamLayoutRaf = requestAnimationFrame(function () {
+        _catgirlPanelSteamLayoutRaf = null;
+        updateCatgirlPanelSteamCardLayout();
+    });
+}
+
+window.addEventListener('resize', scheduleCatgirlPanelSteamCardLayoutUpdate);
 
 function openCatgirlPanel(card, originEl) {
     if (_catgirlPanelOpen) return;
@@ -4479,9 +4537,11 @@ function openCatgirlPanel(card, originEl) {
             '/static/icons/star.png',
             '/static/icons/paw_ui.png'
         ];
-        const spawnCurtainTransition = function (targetTabName, reverse) {
+        const spawnCurtainTransition = function (targetTabName, reverse, fullPanel) {
             const curtain = document.createElement('div');
-            curtain.className = 'panel-transition-curtain' + (reverse ? ' curtain-reverse' : '');
+            curtain.className = 'panel-transition-curtain'
+                + (reverse ? ' curtain-reverse' : '')
+                + (fullPanel ? ' full-panel' : '');
 
             // 幕布色块
             const sweep = document.createElement('div');
@@ -4521,7 +4581,8 @@ function openCatgirlPanel(card, originEl) {
             centerIcon.style.animationDelay = '0.18s';
             curtain.appendChild(centerIcon);
 
-            rightSection.appendChild(curtain);
+            const curtainHost = fullPanel ? wrapper : rightSection;
+            curtainHost.appendChild(curtain);
             setTimeout(function () { curtain.remove(); }, 900);
         };
 
@@ -4545,11 +4606,17 @@ function openCatgirlPanel(card, originEl) {
                 const currentIdx = currentActiveTabBtn ? allTabs.indexOf(currentActiveTabBtn) : -1;
                 const targetIdx = allTabs.indexOf(this);
                 const reverseDirection = (currentIdx >= 0 && targetIdx >= 0 && targetIdx < currentIdx);
+                const needsFullPanelCurtain = wrapper.classList.contains('steam-compact-card-hidden')
+                    || (targetTab === 'steam' && isCatgirlPanelSteamCompactWindow());
 
                 _tabSwitching = true;
                 headerBar.querySelectorAll('.panel-tab').forEach(t => t.classList.remove('active'));
                 this.classList.add('active');
                 updateIndicator();
+
+                // 小窗口 Steam 切换会联动左侧卡面，幕布先覆盖整个面板再更新布局。
+                spawnCurtainTransition(targetTab, reverseDirection, needsFullPanelCurtain);
+                updateCatgirlPanelSteamCardLayout(wrapper);
 
                 // 根据当前激活状态切换设定齿轮图标 on/off
                 if (settingsIcon) {
@@ -4557,9 +4624,6 @@ function openCatgirlPanel(card, originEl) {
                         ? '/static/icons/set_on.png'
                         : '/static/icons/set_off.png';
                 }
-
-                // 播放幕布转场
-                spawnCurtainTransition(targetTab, reverseDirection);
 
                 // 退出当前页 — absolute定位防止撑高容器
                 if (currentActive) {
@@ -4623,6 +4687,7 @@ function openCatgirlPanel(card, originEl) {
 
     overlay.appendChild(wrapper);
     document.body.appendChild(overlay);
+    updateCatgirlPanelSteamCardLayout(wrapper);
 
     // 动画 Phase 1: 卡面移动到中间
     requestAnimationFrame(() => {


### PR DESCRIPTION
…型预览尺寸

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 在窄视口下自动启用紧凑布局，左侧卡牌面板折叠并隐藏为主要右侧视图。
  * 切换标签时支持覆盖整个面板的过渡遮罩。

* **改进**
  * 平滑扩展了面板子区域的淡入/淡出与位移动画。
  * 切换与窗口尺寸变更后会触发预览刷新，修正预览渲染与大小。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1305)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->