### PR TITLE
fix(docker): repair Docker Build pipeline after #1292 + scope CI to release

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,42 @@
+name: Docker Image Cleanup
+
+# 定期清理 GHCR 上的旧 container 版本，避免 ci-{hash}-* / pr-{N}-ci-* 标签
+# 长期堆积。保留：浮动别名（latest, ci-standard 等）+ release 版本 + 最近 N 个版本。
+#
+# 触发方式：
+#   - 每周日 03:00 UTC 定时跑
+#   - 也可通过 Actions 页面手动 dispatch，调整 min_versions_to_keep
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      min_versions_to_keep:
+        description: '保留最近 N 个版本（按上传时间），其他不在 ignore-versions 里的版本会被删'
+        required: false
+        default: '30'
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  cleanup-ghcr:
+    if: github.repository == 'Project-N-E-K-O/N.E.K.O'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old container versions
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: project-n-e-k-o
+          package-name: 'n.e.k.o'
+          package-type: 'container'
+          min-versions-to-keep: ${{ github.event.inputs.min_versions_to_keep || 30 }}
+          # 保护：浮动别名 + release 版本号 + standard/full 主版本族。
+          # 匹配 version 的任一 tag 命中即保留整个 version。
+          #   latest, latest-full
+          #   v1.2.3 / 1.2.3 / 1.2.3-standard / 1.2.3-full
+          #   ci-standard, ci-full
+          #   pr-ci-standard, pr-ci-full（PR 触发若未来恢复时仍会浮动）
+          ignore-versions: '^(latest(-full)?|v?\d+\.\d+\.\d+(-(standard|full))?|(pr-)?ci-(standard|full))$'

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -33,10 +33,19 @@ jobs:
           package-name: 'n.e.k.o'
           package-type: 'container'
           min-versions-to-keep: ${{ github.event.inputs.min_versions_to_keep || 30 }}
-          # 保护：浮动别名 + release 版本号 + standard/full 主版本族。
+          # 保护：浮动别名 + release 版本号 + standard/full 主版本族，
+          # 以及它们的 per-arch 子 manifest（`-linux-{amd64,arm64}` 后缀）。
           # 匹配 version 的任一 tag 命中即保留整个 version。
-          #   latest, latest-full
+          #
+          # 关键点：multi-arch manifest list（如 `latest-standard`、`0.8.0-full`、
+          # `ci-standard`）通过 digest 引用 per-arch 子 manifest（如
+          # `0.8.0-standard-linux-amd64`）。如果只保护 manifest list 而让
+          # 子 manifest 被回收，list 会指向不存在的 digest，pull 会挂在某个架构上。
+          # 所以下面的正则结尾允许可选的 `-linux-(amd64|arm64)` 后缀。
+          #
+          # 覆盖（含 per-arch 变体）：
+          #   latest, latest-standard, latest-full
           #   v1.2.3 / 1.2.3 / 1.2.3-standard / 1.2.3-full
           #   ci-standard, ci-full
           #   pr-ci-standard, pr-ci-full（PR 触发若未来恢复时仍会浮动）
-          ignore-versions: '^(latest(-full)?|v?\d+\.\d+\.\d+(-(standard|full))?|(pr-)?ci-(standard|full))$'
+          ignore-versions: '^(latest(-(standard|full))?|v?\d+\.\d+\.\d+(-(standard|full))?|(pr-)?ci-(standard|full))(-linux-(amd64|arm64))?$'

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -3,16 +3,16 @@ name: Docker Build
 on:
   push:
     branches:
-      - main # 主分支有新 commit 时触发
+      - main # 主分支有新 commit 时触发（合并 PR 后的 squash commit 在这里验）
     tags:
       - 'v*' # 匹配 v 开头的标签，例如 v1.0.0
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.gitignore'
-  pull_request:
-    types: [opened, synchronize, reopened, labeled]
-    branches: [main]
+  # PR 触发刻意不开：单个 PR 的多次 commit 会触发多次 multi-arch build，
+  # 200 PR/月 × N commit 占满 runner 队列；让 squash 进 main 的那次 push 来验证即可。
+  # 单 PR 想手动验，用 workflow_dispatch + ci 模式即可。
   workflow_dispatch:
     inputs:
       build_mode:
@@ -78,15 +78,16 @@ jobs:
       - name: Calculate skip_dockerhub flag
         id: calc_skip
         run: |
-          # For manual dispatch, use the input value; for PR builds and tag push, default to false
+          # 策略：Docker Hub 只发 release（tag push）和手动 dispatch（按 input）。
+          # 主线 commit / PR（如果重新启用）只推 GHCR，避免主线滚动版污染对外 channel。
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "SKIP_DOCKERHUB=${{ github.event.inputs.skip_dockerhub || 'false' }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # PR builds: skip DockerHub only if credentials are missing
-            # If credentials exist, push to both GHCR and DockerHub
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            # Release tag: 推 Docker Hub 作为对外公开发布 channel
             echo "SKIP_DOCKERHUB=false" >> $GITHUB_OUTPUT
           else
-            echo "SKIP_DOCKERHUB=false" >> $GITHUB_OUTPUT
+            # 其他（main push / PR 等）: 只推 GHCR
+            echo "SKIP_DOCKERHUB=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Calculate Docker image version

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -396,43 +396,39 @@ jobs:
         run: |
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push multi-arch manifest for standard version (DockerHub)
         if: needs.build-standard.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
         run: |
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
 
       - name: Create and push multi-arch manifest for full version (GHCR)
         run: |
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
 
       - name: Create and push multi-arch manifest for full version (DockerHub)
         if: needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
         run: |
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-arm64
 
       - name: Create and push CI short tags - standard (GHCR)
         if: needs.calculate-version.outputs.is_main_commit == 'true' && needs.build-standard.outputs.skipped != 'true'
@@ -440,11 +436,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # GHCR - ci-standard (without hash)
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:ci-standard \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:ci-standard
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:ci-standard \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push CI short tags - full (GHCR)
         if: needs.calculate-version.outputs.is_main_commit == 'true'
@@ -452,11 +447,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # GHCR - ci-full (without hash)
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:ci-full \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:ci-full
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:ci-full \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
 
       - name: Create and push CI short tags - standard (DockerHub)
         if: needs.calculate-version.outputs.is_main_commit == 'true' && needs.build-standard.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -464,11 +458,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # DockerHub - ci-standard (without hash)
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:ci-standard \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:ci-standard
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:ci-standard \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
 
       - name: Create and push CI short tags - full (DockerHub)
         if: needs.calculate-version.outputs.is_main_commit == 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -476,11 +469,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # DockerHub - ci-full (without hash)
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:ci-full \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:ci-full
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:ci-full \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-arm64
 
       - name: Create and push PR short tags - standard (GHCR)
         if: github.event_name == 'pull_request' && needs.build-standard.outputs.skipped != 'true'
@@ -488,11 +480,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # GHCR - pr-ci-standard (without PR number)
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-standard \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-standard
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-standard \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push PR short tags - full (GHCR)
         if: github.event_name == 'pull_request'
@@ -500,11 +491,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # GHCR - pr-ci-full (without PR number)
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-full \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-full
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:pr-ci-full \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
 
       - name: Create and push latest manifests - standard (GHCR)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true' && needs.build-standard.outputs.skipped != 'true'
@@ -512,18 +502,16 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # GHCR - latest (traditional alias pointing to standard)
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:latest \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:latest
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:latest \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
 
           # GHCR - latest-standard
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:latest-standard \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:latest-standard
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:latest-standard \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-standard-linux-arm64
 
       - name: Create and push latest manifests - full (GHCR)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true'
@@ -531,11 +519,10 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # GHCR - latest-full
-          docker manifest create \
-            ghcr.io/${{ env.IMAGE_NAME }}:latest-full \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
-            --amend ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
-          docker manifest push ghcr.io/${{ env.IMAGE_NAME }}:latest-full
+          docker buildx imagetools create \
+            -t ghcr.io/${{ env.IMAGE_NAME }}:latest-full \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-amd64 \
+            ghcr.io/${{ env.IMAGE_NAME }}:${VERSION}-full-linux-arm64
 
       - name: Create and push latest manifests - standard (DockerHub)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true' && needs.build-standard.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -543,18 +530,16 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # DockerHub - latest (traditional alias pointing to standard)
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
 
           # DockerHub - latest-standard
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest-standard \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest-standard
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest-standard \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-standard-linux-arm64
 
       - name: Create and push latest manifests - full (DockerHub)
         if: github.event_name != 'pull_request' && needs.calculate-version.outputs.is_main_commit != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -562,8 +547,7 @@ jobs:
           VERSION=${{ needs.calculate-version.outputs.image_version }}
 
           # DockerHub - latest-full
-          docker manifest create \
-            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest-full \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-amd64 \
-            --amend ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-arm64
-          docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest-full
+          docker buildx imagetools create \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:latest-full \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-amd64 \
+            ${{ secrets.DOCKERHUB_USERNAME }}/n.e.k.o:${VERSION}-full-linux-arm64

--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -210,13 +210,13 @@ jobs:
             suffix=-${{ matrix.platform }}
           tags: |
             # PR builds: pr-{number}-ci-standard-linux-amd64/arm64 AND pr-ci-standard-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             type=raw,value=pr-ci-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             # CI builds: ci-{hash}-standard-linux-amd64/arm64 AND ci-standard-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             type=raw,value=ci-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             # Other builds (manual/tag): use version as-is
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-standard,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-standard,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
 
       - name: Extract metadata for Docker (both registries)
         if: steps.check-dockerfile.outputs.skipped != 'true' && needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -230,13 +230,13 @@ jobs:
             suffix=-${{ matrix.platform }}
           tags: |
             # PR builds: pr-{number}-ci-standard-linux-amd64/arm64 AND pr-ci-standard-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             type=raw,value=pr-ci-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             # CI builds: ci-{hash}-standard-linux-amd64/arm64 AND ci-standard-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             type=raw,value=ci-standard,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             # Other builds (manual/tag): use version as-is
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-standard,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-standard,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
 
       - name: Build and push standard image
         if: steps.check-dockerfile.outputs.skipped != 'true'
@@ -314,13 +314,13 @@ jobs:
             suffix=-${{ matrix.platform }}
           tags: |
             # PR builds: pr-{number}-ci-full-linux-amd64/arm64 AND pr-ci-full-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             type=raw,value=pr-ci-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             # CI builds: ci-{hash}-full-linux-amd64/arm64 AND ci-full-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             type=raw,value=ci-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             # Other builds (manual/tag): use version as-is
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-full,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-full,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
 
       - name: Extract metadata for Docker (both registries)
         if: needs.calculate-version.outputs.skip_dockerhub != 'true' && steps.check_dockerhub.outputs.has_credentials == 'true'
@@ -334,13 +334,13 @@ jobs:
             suffix=-${{ matrix.platform }}
           tags: |
             # PR builds: pr-{number}-ci-full-linux-amd64/arm64 AND pr-ci-full-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             type=raw,value=pr-ci-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'pr-') }}
             # CI builds: ci-{hash}-full-linux-amd64/arm64 AND ci-full-linux-amd64/arm64
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             type=raw,value=ci-full,enable=${{ startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
             # Other builds (manual/tag): use version as-is
-            type=raw,value=${{ needs.calculate-version.outputs.image_version }},suffix=-full,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
+            type=raw,value=${{ needs.calculate-version.outputs.image_version }}-full,enable=${{ !startsWith(needs.calculate-version.outputs.image_version, 'pr-') && !startsWith(needs.calculate-version.outputs.image_version, 'ci-') }}
 
       - name: Build and push full image
         uses: docker/build-push-action@v5

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,8 +111,11 @@ RUN mkdir -p /root/.config/uv && \
 COPY --chown=neko:neko . /app
 
 # 7. Copy frontend build artifacts
+# Note: react-neko-chat's vite.config.ts writes to outDir `../../static/react/neko-chat`
+# (relative to its package root), so the actual build output lives at
+# /src/static/react/neko-chat — NOT /src/frontend/react-neko-chat/dist.
 COPY --from=frontend-builder /src/frontend/plugin-manager/dist /app/frontend/plugin-manager/dist
-COPY --from=frontend-builder /src/frontend/react-neko-chat/dist /app/static/react/neko-chat
+COPY --from=frontend-builder /src/static/react/neko-chat /app/static/react/neko-chat
 
 # 7b. Extract yui-origin Live2D model (assets/yui-origin.tar.gz → static/yui-origin/)
 RUN cd /app && tar -xzmf assets/yui-origin.tar.gz -C static/ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,13 @@ WORKDIR /src
 COPY frontend/plugin-manager /src/frontend/plugin-manager
 COPY frontend/react-neko-chat /src/frontend/react-neko-chat
 
+# Shared static assets bundled into plugin-manager at build time.
+# yui-guide-runtime.ts imports tutorial PNGs and shared icons via
+# `../../../static/...`; keep these COPY paths in sync with that file
+# (currently: static/assets/tutorial/{ghost-cursor,highlight}, static/icons).
+COPY static/assets/tutorial /src/static/assets/tutorial
+COPY static/icons /src/static/icons
+
 WORKDIR /src/frontend/plugin-manager
 RUN npm ci && npm run build-only
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -22,6 +22,13 @@ WORKDIR /src
 COPY frontend/plugin-manager /src/frontend/plugin-manager
 COPY frontend/react-neko-chat /src/frontend/react-neko-chat
 
+# Shared static assets bundled into plugin-manager at build time.
+# yui-guide-runtime.ts imports tutorial PNGs and shared icons via
+# `../../../static/...`; keep these COPY paths in sync with that file
+# (currently: static/assets/tutorial/{ghost-cursor,highlight}, static/icons).
+COPY static/assets/tutorial /src/static/assets/tutorial
+COPY static/icons /src/static/icons
+
 WORKDIR /src/frontend/plugin-manager
 RUN npm ci && npm run build-only
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -183,8 +183,11 @@ RUN mkdir -p /root/.config/uv && \
 COPY --chown=neko:neko . /app
 
 # 7. Copy frontend build artifacts
+# Note: react-neko-chat's vite.config.ts writes to outDir `../../static/react/neko-chat`
+# (relative to its package root), so the actual build output lives at
+# /src/static/react/neko-chat — NOT /src/frontend/react-neko-chat/dist.
 COPY --from=frontend-builder /src/frontend/plugin-manager/dist /app/frontend/plugin-manager/dist
-COPY --from=frontend-builder /src/frontend/react-neko-chat/dist /app/static/react/neko-chat
+COPY --from=frontend-builder /src/static/react/neko-chat /app/static/react/neko-chat
 
 # 7b. 解压 yui-origin Live2D 模型（assets/yui-origin.tar.gz → static/yui-origin/）
 #     dev 用 build_frontend.{sh,bat} 解压；docker 路径绕过那两个脚本，单独解压一次

--- a/docker/README_Docker.md
+++ b/docker/README_Docker.md
@@ -98,24 +98,26 @@ docker/
 
 ## 📦 镜像版本选择
 
-N.E.K.O. 镜像同时发布到 GHCR 和 Docker Hub，两边 tag 完全一致：
+N.E.K.O. 镜像发布到两个 registry：
 
-- **GHCR**：`ghcr.io/project-n-e-k-o/n.e.k.o:<tag>`
-- **Docker Hub**：`projectneko/n.e.k.o:<tag>`
+- **GHCR**：`ghcr.io/project-n-e-k-o/n.e.k.o:<tag>` — 所有 tag 都在（含主线 `ci-*` 滚动版）
+- **Docker Hub**：`projectneko/n.e.k.o:<tag>` — **仅 release**（`latest`、`0.8.0-*` 等），避免主线 commit 污染对外 channel
 - **镜像代理**（中国大陆建议优先）：`docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:<tag>`
 
 ### tag 流向一览
 
-| tag | 何时更新 | 适用场景 |
-|---|---|---|
-| `latest` / `latest-full` | 仅在 git tag `v*` push 时移动 | **默认推荐**，跟最新 release |
-| `0.8.0-standard` / `0.8.0-full` | 该 release 打 tag 后定型 | 钉死某个 release，最稳 |
-| `ci-standard` / `ci-full` | 每次 main commit 都会移动 | 跟主线，**内测专用** |
-| `ci-{commit}-standard` / `-full` | 该 main commit 打完后定型 | 复现某个历史 main 版本 |
-| `pr-{N}-ci-standard` / `-full` | 该 PR 每推一次 commit 就重新打 | reviewer 拉下来手验产物 |
-| `pr-ci-standard` / `-full` | **任意** PR 触发都会被覆盖 | 不要用，会被随便哪个 PR 顶掉 |
+| tag | 何时更新 | 发到哪 | 适用场景 |
+|---|---|---|---|
+| `latest` / `latest-full` | 仅在 git tag `v*` push 时移动 | GHCR + Docker Hub | **默认推荐**，跟最新 release |
+| `0.8.0-standard` / `0.8.0-full` | 该 release 打 tag 后定型 | GHCR + Docker Hub | 钉死某个 release，最稳 |
+| `ci-standard` / `ci-full` | 每次 main commit 都会移动 | 仅 GHCR | 跟主线，**内测专用** |
+| `ci-{commit}-standard` / `-full` | 该 main commit 打完后定型 | 仅 GHCR | 复现某个历史 main 版本 |
+| `pr-{N}-ci-standard` / `-full` | （当前 PR 触发已关，仅在 workflow_dispatch 中可手动产） | 仅 GHCR | reviewer 拉下来手验产物 |
+| `pr-ci-standard` / `-full` | 同上，且**任意** PR 触发都会被覆盖 | 仅 GHCR | 不要用，会被随便哪个 PR 顶掉 |
 
 `standard`（~1.5GB）首次启动时下载 Chromium；`full`（~2.5GB）构建时已包含，开箱即用。
+
+> 📦 **GHCR 自动清理**：[docker-cleanup.yml](../.github/workflows/docker-cleanup.yml) 每周清理一次，保留最近 30 个版本 + 上述浮动别名 + 所有 release 版本。`ci-{hash}-*` 和 `pr-{N}-ci-*` 这些一次性 tag 会被陆续回收。
 
 ### 推荐拉取方式
 

--- a/docker/README_Docker.md
+++ b/docker/README_Docker.md
@@ -96,6 +96,47 @@ docker/
 }
 ```
 
+## 📦 镜像版本选择
+
+N.E.K.O. 镜像同时发布到 GHCR 和 Docker Hub，两边 tag 完全一致：
+
+- **GHCR**：`ghcr.io/project-n-e-k-o/n.e.k.o:<tag>`
+- **Docker Hub**：`projectneko/n.e.k.o:<tag>`
+- **镜像代理**（中国大陆建议优先）：`docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:<tag>`
+
+### tag 流向一览
+
+| tag | 何时更新 | 适用场景 |
+|---|---|---|
+| `latest` / `latest-full` | 仅在 git tag `v*` push 时移动 | **默认推荐**，跟最新 release |
+| `0.8.0-standard` / `0.8.0-full` | 该 release 打 tag 后定型 | 钉死某个 release，最稳 |
+| `ci-standard` / `ci-full` | 每次 main commit 都会移动 | 跟主线，**内测专用** |
+| `ci-{commit}-standard` / `-full` | 该 main commit 打完后定型 | 复现某个历史 main 版本 |
+| `pr-{N}-ci-standard` / `-full` | 该 PR 每推一次 commit 就重新打 | reviewer 拉下来手验产物 |
+| `pr-ci-standard` / `-full` | **任意** PR 触发都会被覆盖 | 不要用，会被随便哪个 PR 顶掉 |
+
+`standard`（~1.5GB）首次启动时下载 Chromium；`full`（~2.5GB）构建时已包含，开箱即用。
+
+### 推荐拉取方式
+
+```bash
+# 99% 的用户：跟最新 release（standard 版）
+docker pull docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest
+
+# 要预装 Chromium 的 full 版
+docker pull docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:latest-full
+
+# 钉死某个 release（生产环境推荐）
+docker pull docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:0.8.0-standard
+
+# 跟主线（开发者 / 内测）
+docker pull docker.gh-proxy.org/ghcr.io/project-n-e-k-o/n.e.k.o:ci-standard
+```
+
+`docker-compose up` 默认就是 `latest`（即最新 release），不会被 main commit 或 PR 影响。要跟主线，在 `.env` 里设 `NEKO_IMAGE_VERSION=ci-standard` 或 `ci-full`。
+
+> ⚠️ **警告**：`ci-*` 和 `pr-*` 是滚动 tag，每次合并 main / 推 PR 都会被覆盖。生产环境一律用 `latest` 或具体的 `{version}-*`。
+
 ## 🚀 快速开始
 
 ### 1. 使用 docker-compose（推荐）


### PR DESCRIPTION
## Summary

修复 [#1292](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1292) 合并后 Docker Build 流水线连环挂的 4 个 bug，并附带收紧 trigger / 推送策略 / 加自动清理：

1. **plugin-manager 跨边界 import 没在 builder 上下文里**（[原报错链接](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/25673897766/job/75366357706)）
2. **react-neko-chat 的 runtime COPY 路径不对**
3. **manifest amend 找不到带平台后缀的 PR/CI tag**
4. **`docker manifest create` 撑不住嵌套 manifest list**（attestation 让单架构 build 也变 OCI image index）
5. **docs**：README_Docker.md 加 "镜像版本选择" 一节，说明各 tag 的更新时机和推荐拉法
6. **policy**：砍 PR 触发器；Docker Hub 只在 release 推；GHCR 加自动清理 workflow

前 4 个都是 #1292 把 `git clone` 模式换成 sub-context `COPY` 时的隐式假设错误的衍生症状。

## Bug 1: plugin-manager 找不到 `static/` 资源

#1292 里 commit [b5f8f00940](https://github.com/Project-N-E-K-O/N.E.K.O/commit/b5f8f00940) 把 `frontend-builder` 阶段从

```dockerfile
RUN git clone --depth 1 --branch main https://github.com/Project-N-E-K-O/N.E.K.O.git .
```

改成

```dockerfile
COPY frontend/plugin-manager /src/frontend/plugin-manager
COPY frontend/react-neko-chat /src/frontend/react-neko-chat
```

而 [`frontend/plugin-manager/src/yui-guide-runtime.ts`](frontend/plugin-manager/src/yui-guide-runtime.ts#L1-L7) 自 2026-04-17 起有 7 个 `../../../static/...` 的 Vite 资源 import。这些路径解析到 `/src/static/...`，但 #1292 后 builder 阶段只有 `/src/frontend/...`，Rollup 报：

```
Could not resolve "../../../static/assets/tutorial/ghost-cursor/default-ghost-cursor.png"
  from "src/yui-guide-runtime.ts"
```

**修法**：补 2 行精确 COPY，把 plugin-manager 实际需要的两个子树（`static/assets/tutorial` + `static/icons`）拉进 builder。

## Bug 2: react-neko-chat 产物路径错配

#1292 把 runtime 阶段的 COPY 从 `/src/static/react/neko-chat` 改成 `/src/frontend/react-neko-chat/dist`，但 [`frontend/react-neko-chat/vite.config.ts`](frontend/react-neko-chat/vite.config.ts#L18) 里 `outDir: '../../static/react/neko-chat'` 没动，产物落在 `/src/static/react/neko-chat`，不是 `/src/frontend/react-neko-chat/dist`。

buildx 报：

```
ERROR: failed to calculate checksum of ref ...: "/src/frontend/react-neko-chat/dist": not found
```

**修法**：把 runtime COPY 改回 vite 真正的输出位置，加注释说明 outDir 是相对 package 根的。

## Bug 3: manifest 找不到带平台后缀的 PR/CI tag

build 阶段实际推：`pr-1307-ci-standard`（无平台后缀）+ `pr-ci-standard-linux-amd64`（短别名带平台后缀）。manifest 步骤却要 `pr-1307-ci-standard-linux-amd64`——从未被推过。

成因：[`docker/metadata-action`](https://github.com/docker/metadata-action) 的 `type=raw,...,suffix=-standard` **覆盖**全局 flavor 的 `suffix=-${{ matrix.platform }}`，不是叠加。

**修法**：把 `-standard` / `-full` 从 `type=raw` 的 `suffix=` 参数挪进 `value=`，让全局 flavor 的 `-linux-{amd64,arm64}` 继续叠在末尾。共 12 行同 pattern 改动。

## Bug 4: `docker manifest create` 不懂嵌套 manifest list

Bug 3 修完之后才暴露：

```
ghcr.io/project-n-e-k-o/n.e.k.o:pr-1307-ci-standard-linux-amd64 is a manifest list
```

`docker/build-push-action` 默认开 `provenance: true`，即便单架构 build 推出来的 tag 也是个 OCI image index（image + attestation 两条），不是扁平 manifest。`docker manifest create` 是过时的 v1 API，遇到嵌套就抓瞎。

**修法**：换成 v2 工具 `docker buildx imagetools create -t TARGET SRC1 SRC2`，OCI-aware，能正确合并子 manifest 包括 attestation；同时去掉独立的 `docker manifest push`（imagetools 在 create 时已经推过）。共 16 个 manifest step 转换。

## Docs: 镜像版本选择说明

[docker/README_Docker.md](docker/README_Docker.md) 新增 "📦 镜像版本选择" 一节：

- 三个 registry 入口（GHCR / Docker Hub / 镜像代理）
- tag 流向表：每种 tag 的更新时机 + 发到哪个 registry + 适用场景
- 4 条针对不同用户的 `docker pull` 示例
- 滚动 tag 警告 + GHCR 自动清理说明

## Policy: 收紧 trigger + 推送策略 + 加 retention

- **删 `pull_request` 触发器**：200+ PR/月 × 多次 commit × multi-arch 矩阵会塞满 runner 队列，绝大多数 PR 不动 docker。改为 main push（含 squash commit）/ tag push / workflow_dispatch 手动触发。
- **Docker Hub 只在 release 时推**：`SKIP_DOCKERHUB` 默认改 true，仅 tag push 取 false。主线 commit 之后只推 GHCR，避免 `ci-{hash}-*` 污染对外 channel。
- **新增 `.github/workflows/docker-cleanup.yml`**：每周日 03:00 UTC 跑 `actions/delete-package-versions@v5`，保留最近 30 个版本 + 浮动别名 + release 版本族；其他一次性 tag 陆续回收。

## 为什么之前没人发现 Bug 3 + 4

| 触发源 | 现象 |
|---|---|
| Fork PR（grok 等） | `build-*` job 因 `head.repo.full_name != github.repository` 直接 skip，create-manifests 又依赖 `build-full.result == 'success'` 也 skip，整 workflow 看起来 success |
| 同源 PR | #1292 后第一发就是这个 PR，所以第一次真正触发就被我们撞到 |
| Main push | 全部死在 Bug 1（static/）的更早阶段，没爬到 manifest 步 |

## Test plan

- [x] amd64+arm64 × standard+full 四个 build job 全绿（[run 25682433626](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/25682433626)）
- [x] `create-manifests` 通过（[同上](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/25682433626/job/75399063097)）
- [ ] 合并到 main 后，main push 触发 build → 推 GHCR `ci-{hash}-*` + `ci-{standard,full}`、不推 Docker Hub
- [ ] 之后某次打 v 标签的 release 触发 build → 推 GHCR + Docker Hub 完整 release tag set
- [ ] PR 不再触发 Docker Build（其他 lint/conventions/analyze workflow 不受影响）

## Follow-up（未在本 PR）

- arm64 multi-arch build 在 main push 时仍跑（每次 ~12 min × QEMU emulate），如果 ci-* 用得少可以考虑只 build amd64
- 单 PR 想手验时的 workflow_dispatch UX 略不友好，可考虑加一个 PR 评论触发器

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 优化镜像构建：前端构建阶段纳入共享静态资源并修正运行时构建产物拷贝与相关注释，确保前端构建输出被正确打包。
  * 更新发布流程：调整 CI 触发与镜像推送决策、统一标准/完整版镜像标签生成逻辑，并改为使用 buildx imagetools 创建多架构清单以改进镜像发布。
  * 新增定期镜像清理工作流，自动保留规则化管理旧版镜像。

* **Documentation**
  * 新增镜像版本说明：补充 tag 含义、使用场景、拉取示例与滚动 tag 警示。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->