### PR TITLE
fix(callback): push_message 事件流不再误套"任务已完成，请汇报"模板

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -776,8 +776,25 @@ async def _handle_agent_event(event: dict):
                     else:
                         source_kind = "system"
                 event_metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+                # origin is a STRUCTURAL fact derived from event_type:
+                #   "task_result"      → real task completion (agent_server._emit_task_result):
+                #                        Computer Use / Browser Use / plugin entry / MCP tool result
+                #   "proactive_message" → plugin push_message stream (proactive_bridge):
+                #                        danmaku / gift / external notification
+                # Plugin authors cannot influence this — it's determined by which
+                # SDK method they call (finish() vs push_message()) and which host
+                # path it flows through. _build_callback_instruction uses this to
+                # pick the right wrapper template (task "汇报" vs event "回应").
+                if event_type == "task_result":
+                    origin = "task_result"
+                else:
+                    # event_type == "proactive_message" (or any future event-stream
+                    # producer that lands on this branch); see the (event_type in
+                    # {"task_result", "proactive_message"}) gate above.
+                    origin = "event"
                 callback = {
                     "event": "agent_task_callback",
+                    "origin": origin,
                     "task_id": event.get("task_id") or "",
                     "channel": _channel,
                     "status": cb_status,

--- a/config/prompts/prompts_sys.py
+++ b/config/prompts/prompts_sys.py
@@ -461,6 +461,31 @@ CONTEXT_SUMMARY_TASK_FOOTER = {
     'pt': '\nDepois do relato, retome a conversa normal.======\n',
 }
 
+# ---------- 前情概要 + 事件回应（voice hot-swap 用 origin="event" 路径）----------
+# 跟 CONTEXT_SUMMARY_TASK_HEADER/FOOTER 对偶：voice mode 热切换时如果
+# pending_extra_replies 里有 origin="event" 的条目（push_message 推过来的弹幕 /
+# 礼物 / 外部事件等），就用这一组 wrapper 而不是任务汇报版——措辞强调"按内容自然
+# 回应"，不出现"任务"/"汇报"字样，避免兰兰把观众弹幕误读成"我刚才执行的任务"。
+CONTEXT_SUMMARY_EVENT_HEADER = {
+    'zh': '\n======以上为前情概要。请{name}先用自然、简洁的口吻根据下方新消息回应{master}：\n',
+    'en': '\n======End of context summary. Please have {name} first respond to {master} naturally and briefly based on the new messages below:\n',
+    'ja': '\n======以上が前回までのあらすじです。{name}はまず自然に簡潔な口調で、下記の新しいメッセージに応じて{master}に返答してください：\n',
+    'ko': '\n======이상이 이전 대화 요약입니다. {name}은 먼저 자연스럽고 간결한 어조로 아래의 새 메시지에 따라 {master}에게 답변하세요：\n',
+    'ru': '\n======Конец краткого содержания. Пожалуйста, {name} сначала кратко и естественно ответьте {master} на новые сообщения ниже:\n',
+    'es': '\n======Fin del resumen de contexto. Haz que {name} primero responda a {master} de forma breve y natural según los nuevos mensajes a continuación:\n',
+    'pt': '\n======Fim do resumo de contexto. Faça {name} primeiro responder a {master} de forma breve e natural conforme as novas mensagens abaixo:\n',
+}
+
+CONTEXT_SUMMARY_EVENT_FOOTER = {
+    'zh': '\n完成上述回应后，再恢复正常对话。======\n',
+    'en': '\nAfter responding, resume normal conversation.======\n',
+    'ja': '\n返答を終えたら、通常の会話に戻ってください。======\n',
+    'ko': '\n응답을 마친 후 일반 대화로 돌아오세요.======\n',
+    'ru': '\nПосле ответа возобновите обычный разговор.======\n',
+    'es': '\nDespués de responder, vuelve a la conversación normal.======\n',
+    'pt': '\nDepois de responder, retome a conversa normal.======\n',
+}
+
 # ---------- Vision: Avatar 截图注解（叠加在发给视觉模型的截图上，用户不可见） ----------
 AVATAR_ANNOTATION_TEXT = {
     'zh':    ('这是{name}在桌面上的虚拟形象,', '请{name}不要主动提及'),

--- a/config/prompts/prompts_sys.py
+++ b/config/prompts/prompts_sys.py
@@ -373,8 +373,16 @@ TASK_ACTION_PHRASES = {
     },
 }
 
-# ---------- 系统通知：主动汇报型（task_result 默认走这条，要求 AI 立即起 turn）----------
-SYSTEM_NOTIFICATION_PROACTIVE = {
+# ---------- 系统通知模板：按 (origin × passive) 二维选择 ----------
+# origin 由 host 在 EventBus → callback 边界根据 event_type 派生：
+#   event_type == "task_result"      → origin = "task_result"
+#   event_type == "proactive_message" → origin = "event"
+# 插件作者无法干预这个分类——他们只能选 ai_behavior / delivery（控制时机），
+# 不能伪装"事件流"为"任务完成"。
+#
+# task_result + active：真任务完成（@plugin_entry 跑完 / Computer Use 跑完 /
+# Browser Use 跑完 / MCP tool 返回），要求 AI 立即起 turn 汇报结果。
+SYSTEM_NOTIFICATION_TASK_ACTIVE = {
     'zh': '======[系统通知] 来自{source}的任务{status_phrase}，请{name}先用自然、简洁的口吻向{master}{action_phrase}，再恢复正常对话======\n',
     'en': '======[System Notice] A task from {source} {status_phrase}. Please have {name} briefly and naturally {action_phrase} to {master} first, then resume normal conversation.======\n',
     'ja': '======[システム通知] {source}からのタスクが{status_phrase}。{name}はまず自然に簡潔な口調で{master}に{action_phrase}し、その後通常の会話に戻ってください。======\n',
@@ -384,9 +392,34 @@ SYSTEM_NOTIFICATION_PROACTIVE = {
     'pt': '======[Aviso do sistema] Uma tarefa de {source} {status_phrase}. Faça {name} primeiro {action_phrase} para {master} de forma breve e natural, depois retome a conversa normal.======\n',
 }
 
-# ---------- 系统通知：被动捎带型（push_message / delivery="passive" 走这条，
-# 仅写入上下文，不要求 AI 立即起 turn——下一次用户发言时被自然带入 prompt）----------
-SYSTEM_NOTIFICATION_PASSIVE = {
+# task_result + passive：任务完成但 delivery="passive"——结果进上下文不打断，
+# 下一次用户开口时由 AI 自然提及。
+SYSTEM_NOTIFICATION_TASK_PASSIVE = {
+    'zh': '======[系统通知] 来自{source}的任务结果======\n',
+    'en': '======[System Notice] Task result from {source}======\n',
+    'ja': '======[システム通知] {source}からのタスク結果======\n',
+    'ko': '======[시스템 알림] {source}의 작업 결과======\n',
+    'ru': '======[Системное уведомление] Результат задачи от {source}======\n',
+    'es': '======[Aviso del sistema] Resultado de tarea de {source}======\n',
+    'pt': '======[Aviso do sistema] Resultado de tarefa de {source}======\n',
+}
+
+# event + active：插件 push_message 推过来的事件流（弹幕 / 礼物 / 定时提醒 /
+# 外部系统通知等），AI 应该"回应这个事件本身"，**不**是"汇报做完了什么"。
+# 措辞刻意避开"任务"/"汇报"——它们在事件场景下会误导模型。
+SYSTEM_NOTIFICATION_EVENT_ACTIVE = {
+    'zh': '======[系统通知] 来自{source}的新消息，请{name}先用自然、简洁的口吻根据内容回应{master}，再恢复正常对话======\n',
+    'en': '======[System Notice] New message from {source}. Please have {name} briefly and naturally respond to {master} based on the content first, then resume normal conversation.======\n',
+    'ja': '======[システム通知] {source}からの新しいメッセージ。{name}はまず自然に簡潔な口調で内容に応じて{master}に返答し、その後通常の会話に戻ってください。======\n',
+    'ko': '======[시스템 알림] {source}의 새 메시지. {name}은 먼저 자연스럽고 간결한 어조로 내용에 따라 {master}에게 답변한 뒤 일반 대화로 돌아오세요.======\n',
+    'ru': '======[Системное уведомление] Новое сообщение от {source}. Пожалуйста, {name} сначала кратко и естественно ответьте {master} по содержанию, затем возобновите обычный разговор.======\n',
+    'es': '======[Aviso del sistema] Nuevo mensaje de {source}. Haz que {name} primero responda a {master} de forma breve y natural según el contenido, y luego vuelva a la conversación normal.======\n',
+    'pt': '======[Aviso do sistema] Nova mensagem de {source}. Faça {name} primeiro responder a {master} de forma breve e natural conforme o conteúdo, depois retome a conversa normal.======\n',
+}
+
+# event + passive：事件流的被动版（push_message ai_behavior="read"），
+# 仅写入上下文，下一次用户开口时被自然带入 prompt。
+SYSTEM_NOTIFICATION_EVENT_PASSIVE = {
     'zh': '======[系统通知] 来自{source}的消息======\n',
     'en': '======[System Notice] Message from {source}======\n',
     'ja': '======[システム通知] {source}からのメッセージ======\n',
@@ -395,6 +428,17 @@ SYSTEM_NOTIFICATION_PASSIVE = {
     'es': '======[Aviso del sistema] Mensaje de {source}======\n',
     'pt': '======[Aviso do sistema] Mensagem de {source}======\n',
 }
+
+# ---------- 向后兼容别名 ----------
+# 旧代码 / 测试还在用这两个名字；保留指向以避免破坏性变更。新代码请使用
+# 上面带 TASK_/EVENT_ 前缀的命名，让 origin 维度显式起来。
+#
+# 注意：旧 SYSTEM_NOTIFICATION_PASSIVE 的文案是 '来自{source}的消息'（中性、
+# 不带"任务"字样），同时被用于真任务被动汇报 AND 事件流被动写入。新设计把
+# 它拆成两个，旧名字保持原文案以避免破坏 testbench 等已知的字符串断言——
+# 旧别名指向 EVENT_PASSIVE（保留原 '消息' 措辞）。
+SYSTEM_NOTIFICATION_PROACTIVE = SYSTEM_NOTIFICATION_TASK_ACTIVE
+SYSTEM_NOTIFICATION_PASSIVE = SYSTEM_NOTIFICATION_EVENT_PASSIVE
 
 # ---------- 前情概要 + 任务汇报 ----------
 CONTEXT_SUMMARY_TASK_HEADER = {

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -273,6 +273,49 @@ def _build_callback_instruction(
     return "\n\n".join(parts)
 
 
+def _format_voice_swap_item(entry: dict, lang: str) -> str:
+    """Render a single voice-mode pending_extra_replies entry to a bulleted
+    line for the hot-swap injection.
+
+    Priority: ``summary`` → ``detail`` → synthesized "{status_phrase} from
+    {source}[: error_message]" placeholder. The placeholder path matters for
+    failure callbacks whose body is empty — without it, "执行失败 / 来自插件
+    X / Connection refused" header information would be silently dropped
+    (the voice-mode equivalent of the header-only branch in
+    ``_build_callback_instruction``).
+
+    Returns ``""`` when the entry is genuinely empty (no body, no error, and
+    a benign ``completed`` status) — caller filters those out.
+    """
+    summary = (entry.get("summary") or "").strip()
+    detail = (entry.get("detail") or "").strip()
+    text = summary or detail
+    status = entry.get("status") or "completed"
+    emoji = _STATUS_EMOJI.get(status, "•")
+
+    if text:
+        return f"- {emoji} {text}"
+
+    # No body text — synthesize from header info so the failure status
+    # doesn't disappear silently.
+    error_message = (entry.get("error_message") or "").strip()
+    source_name = (entry.get("source_name") or "").strip()
+    if not error_message and not source_name and status == "completed":
+        # Truly nothing to convey; drop. (enqueue_agent_callback already
+        # filters these out, but be defensive against legacy entries.)
+        return ""
+
+    source_text = _format_callback_source(entry, lang)
+    status_phrase = _loc(
+        TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
+        lang,
+    )
+    line = f"- {emoji} {source_text} {status_phrase}"
+    if error_message:
+        line += f"：{error_message}"
+    return line
+
+
 def _render_pending_extra_replies_by_origin(
     entries,
     *,
@@ -283,11 +326,13 @@ def _render_pending_extra_replies_by_origin(
     """Render voice-mode ``pending_extra_replies`` into the hot-swap injection
     string, grouped by ``origin``.
 
-    Each entry should be ``{"origin": "task_result"|"event", "text": str}``.
-    Legacy plain-string elements (from pre-migration code paths) are tolerated
-    and treated as ``origin="event"`` — the safer default since "汇报先前执行
-    的任务的结果" framing on what may actually be an event push is the bug
-    this refactor fixes.
+    Each entry should be a structured dict with at least ``origin``;
+    ``summary``/``detail``/``status``/``source_kind``/``source_name``/
+    ``error_message`` are consumed by :func:`_format_voice_swap_item`. Legacy
+    plain-string entries (pre-migration code paths) are tolerated and
+    treated as ``origin="event"`` event-stream content — the safer default,
+    since "汇报先前执行的任务的结果" framing on what may actually be a push
+    event is the bug this refactor fixes.
 
     Returns a single string suitable for appending to ``final_prime_text``.
     Order: task block first (if any), then event block — matches the original
@@ -296,39 +341,51 @@ def _render_pending_extra_replies_by_origin(
     if not entries:
         return ""
 
-    task_items: list[str] = []
-    event_items: list[str] = []
+    task_entries: list[dict] = []
+    event_entries: list[dict] = []
     for entry in entries:
         if isinstance(entry, dict):
-            txt = (entry.get("text") or "").strip()
-            if not txt:
-                continue
-            origin = entry.get("origin")
+            normalized = dict(entry)
+            origin = normalized.get("origin")
+            if origin not in ("task_result", "event"):
+                normalized["origin"] = "event"  # fail-safe
+                origin = "event"
             if origin == "task_result":
-                task_items.append(txt)
+                task_entries.append(normalized)
             else:
-                # event, missing, or unknown — group as event (fail-safe).
-                event_items.append(txt)
+                event_entries.append(normalized)
         elif isinstance(entry, str):
             stripped = entry.strip()
             if stripped:
-                event_items.append(stripped)
+                event_entries.append({
+                    "origin": "event",
+                    "summary": stripped,
+                    "detail": "",
+                    "status": "completed",
+                    "source_kind": "unknown",
+                    "source_name": "",
+                    "error_message": "",
+                })
 
     blocks: list[str] = []
-    if task_items:
-        items_text = "\n".join(f"- {t}" for t in task_items)
-        blocks.append(
-            _loc(CONTEXT_SUMMARY_TASK_HEADER, lang).format(name=lanlan_name, master=master_name)
-            + items_text
-            + _loc(CONTEXT_SUMMARY_TASK_FOOTER, lang)
-        )
-    if event_items:
-        items_text = "\n".join(f"- {t}" for t in event_items)
-        blocks.append(
-            _loc(CONTEXT_SUMMARY_EVENT_HEADER, lang).format(name=lanlan_name, master=master_name)
-            + items_text
-            + _loc(CONTEXT_SUMMARY_EVENT_FOOTER, lang)
-        )
+    if task_entries:
+        items = [_format_voice_swap_item(e, lang) for e in task_entries]
+        items = [s for s in items if s]
+        if items:
+            blocks.append(
+                _loc(CONTEXT_SUMMARY_TASK_HEADER, lang).format(name=lanlan_name, master=master_name)
+                + "\n".join(items)
+                + _loc(CONTEXT_SUMMARY_TASK_FOOTER, lang)
+            )
+    if event_entries:
+        items = [_format_voice_swap_item(e, lang) for e in event_entries]
+        items = [s for s in items if s]
+        if items:
+            blocks.append(
+                _loc(CONTEXT_SUMMARY_EVENT_HEADER, lang).format(name=lanlan_name, master=master_name)
+                + "\n".join(items)
+                + _loc(CONTEXT_SUMMARY_EVENT_FOOTER, lang)
+            )
     return "".join(blocks)
 
 
@@ -5071,27 +5128,51 @@ class LLMSessionManager:
         Voice mode: also appended to pending_extra_replies for hot-swap
         injection via prime_context().
 
-        Each pending_extra_replies element carries ``origin`` so the hot-swap
-        renderer can pick TASK vs EVENT wrapper at drain time — without this
-        the voice-mode path would wrap event-stream pushes (push_message) in
-        the "请汇报先前执行的任务的结果" template that only applies to real
-        task completions. The two queues stay independent (text-mode drain
-        and voice-mode hot-swap fire at different lifecycle points).
+        Voice queue element shape is structured (not flat text) so the
+        hot-swap renderer can:
+          1. Pick TASK vs EVENT wrapper from ``origin``.
+          2. Recover status / source phrasing when both ``summary`` and
+             ``detail`` are empty — typical for failure callbacks where
+             the meaning lives in the header (e.g. ``status="failed"`` +
+             ``error_message="Connection refused"``).
+
+        ``summary`` and ``detail`` are normalized **independently** (strip
+        each, then prefer summary → detail), so a blank-whitespace
+        ``summary`` doesn't shadow a real ``detail`` via the legacy
+        ``summary or detail`` chain.
+
+        The two queues stay independent (text-mode drain and voice-mode
+        hot-swap fire at different lifecycle points).
         """
         try:
             self.pending_agent_callbacks.append(callback)
-            text = (callback.get("summary") or callback.get("detail") or "").strip()
-            if text:
-                origin = callback.get("origin")
-                if origin not in ("task_result", "event"):
-                    # Fail-safe: missing/unknown origin defaults to event so
-                    # the hot-swap renderer does not fabricate "我完成了任务"
-                    # for what may actually be an external event push.
-                    origin = "event"
-                self.pending_extra_replies.append({
-                    "origin": origin,
-                    "text": text,
-                })
+            summary = str(callback.get("summary") or "").strip()
+            detail = str(callback.get("detail") or "").strip()
+            error_message = str(callback.get("error_message") or "").strip()
+            source_name = str(callback.get("source_name") or "").strip()
+            status = callback.get("status") or "completed"
+            origin = callback.get("origin")
+            if origin not in ("task_result", "event"):
+                # Fail-safe: missing/unknown origin defaults to event so the
+                # hot-swap renderer does not fabricate "我完成了任务" for what
+                # may actually be an external event push.
+                origin = "event"
+            # Skip enqueue only when there is *truly* nothing to convey:
+            # no body text, no error context, no identifiable source, and a
+            # benign completed status. Anything else (failed/cancelled/blocked,
+            # an error message, or a named source) carries meaning even with
+            # empty summary/detail and must survive into the hot-swap output.
+            if not summary and not detail and not error_message and not source_name and status == "completed":
+                return
+            self.pending_extra_replies.append({
+                "origin": origin,
+                "summary": summary,
+                "detail": detail,
+                "status": status,
+                "source_kind": callback.get("source_kind") or "unknown",
+                "source_name": source_name,
+                "error_message": error_message,
+            })
         except Exception:
             pass
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -66,6 +66,7 @@ from config.prompts.prompts_sys import (
     TASK_STATUS_PHRASES,
     TASK_ACTION_PHRASES,
     CONTEXT_SUMMARY_TASK_HEADER, CONTEXT_SUMMARY_TASK_FOOTER,
+    CONTEXT_SUMMARY_EVENT_HEADER, CONTEXT_SUMMARY_EVENT_FOOTER,
     RESULT_PARSER_PHRASES,
 )
 
@@ -270,6 +271,67 @@ def _build_callback_instruction(
             # the joined output is clean.
             parts.append(header.rstrip())
     return "\n\n".join(parts)
+
+
+def _render_pending_extra_replies_by_origin(
+    entries,
+    *,
+    lang: str,
+    lanlan_name: str,
+    master_name: str,
+) -> str:
+    """Render voice-mode ``pending_extra_replies`` into the hot-swap injection
+    string, grouped by ``origin``.
+
+    Each entry should be ``{"origin": "task_result"|"event", "text": str}``.
+    Legacy plain-string elements (from pre-migration code paths) are tolerated
+    and treated as ``origin="event"`` — the safer default since "汇报先前执行
+    的任务的结果" framing on what may actually be an event push is the bug
+    this refactor fixes.
+
+    Returns a single string suitable for appending to ``final_prime_text``.
+    Order: task block first (if any), then event block — matches the original
+    single-block placement where everything followed the cache dump.
+    """
+    if not entries:
+        return ""
+
+    task_items: list[str] = []
+    event_items: list[str] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            txt = (entry.get("text") or "").strip()
+            if not txt:
+                continue
+            origin = entry.get("origin")
+            if origin == "task_result":
+                task_items.append(txt)
+            else:
+                # event, missing, or unknown — group as event (fail-safe).
+                event_items.append(txt)
+        elif isinstance(entry, str):
+            stripped = entry.strip()
+            if stripped:
+                event_items.append(stripped)
+
+    blocks: list[str] = []
+    if task_items:
+        items_text = "\n".join(f"- {t}" for t in task_items)
+        blocks.append(
+            _loc(CONTEXT_SUMMARY_TASK_HEADER, lang).format(name=lanlan_name, master=master_name)
+            + items_text
+            + _loc(CONTEXT_SUMMARY_TASK_FOOTER, lang)
+        )
+    if event_items:
+        items_text = "\n".join(f"- {t}" for t in event_items)
+        blocks.append(
+            _loc(CONTEXT_SUMMARY_EVENT_HEADER, lang).format(name=lanlan_name, master=master_name)
+            + items_text
+            + _loc(CONTEXT_SUMMARY_EVENT_FOOTER, lang)
+        )
+    return "".join(blocks)
+
+
 from config.prompts.prompts_avatar_interaction import (
     _normalize_avatar_interaction_payload,
     _build_avatar_interaction_instruction,
@@ -558,8 +620,15 @@ class LLMSessionManager:
         self.final_swap_task = None
         self.receive_task = None
         self.message_handler_task = None
-        # 任务完成后的额外回复队列（将在下一次切换时统一汇报，语音模式使用）
-        self.pending_extra_replies = []
+        # Voice-mode-only callback queue, drained on hot-swap via
+        # ``_perform_final_swap_sequence`` into ``prime_context`` for the new
+        # session. Each element is a dict ``{"origin": "task_result"|"event",
+        # "text": str}`` — swap-time rendering groups by origin so event-stream
+        # pushes (push_message) get the EVENT hot-swap wrapper, not the TASK
+        # one. Kept independent from ``pending_agent_callbacks``: the two are
+        # consumed at different lifecycle points (text mode = next stream_text,
+        # voice mode = next hot-swap) and must not share state.
+        self.pending_extra_replies: list[dict] = []
         # 结构化 agent 任务回调队列（用于按会话类型注入）
         self.pending_agent_callbacks: list[dict] = []
         # 防止 trigger_agent_callbacks 和 finish_proactive_delivery 并发写 WS/sync_message_queue
@@ -5001,12 +5070,28 @@ class LLMSessionManager:
         prompt_ephemeral(), OR proactively via trigger_agent_callbacks().
         Voice mode: also appended to pending_extra_replies for hot-swap
         injection via prime_context().
+
+        Each pending_extra_replies element carries ``origin`` so the hot-swap
+        renderer can pick TASK vs EVENT wrapper at drain time — without this
+        the voice-mode path would wrap event-stream pushes (push_message) in
+        the "请汇报先前执行的任务的结果" template that only applies to real
+        task completions. The two queues stay independent (text-mode drain
+        and voice-mode hot-swap fire at different lifecycle points).
         """
         try:
             self.pending_agent_callbacks.append(callback)
             text = (callback.get("summary") or callback.get("detail") or "").strip()
             if text:
-                self.pending_extra_replies.append(text)
+                origin = callback.get("origin")
+                if origin not in ("task_result", "event"):
+                    # Fail-safe: missing/unknown origin defaults to event so
+                    # the hot-swap renderer does not fabricate "我完成了任务"
+                    # for what may actually be an external event push.
+                    origin = "event"
+                self.pending_extra_replies.append({
+                    "origin": origin,
+                    "text": text,
+                })
         except Exception:
             pass
 
@@ -5077,15 +5162,12 @@ class LLMSessionManager:
 
             # 若存在需要植入的额外提示，则指示模型忽略上一条消息，并在下一次响应中统一向用户补充这些提示
             if self.pending_extra_replies and len(self.pending_extra_replies) > 0:
-                try:
-                    items = "\n".join([f"- {txt}" for txt in self.pending_extra_replies if isinstance(txt, str) and txt.strip()])
-                except Exception:
-                    items = ""
                 _lang = normalize_language_code(self.user_language, format='short')
-                final_prime_text += (
-                    _loc(CONTEXT_SUMMARY_TASK_HEADER, _lang).format(name=self.lanlan_name, master=self.master_name)
-                    + items
-                    + _loc(CONTEXT_SUMMARY_TASK_FOOTER, _lang)
+                final_prime_text += _render_pending_extra_replies_by_origin(
+                    self.pending_extra_replies,
+                    lang=_lang,
+                    lanlan_name=self.lanlan_name,
+                    master_name=self.master_name,
                 )
                 # 清空队列，避免重复注入
                 self.pending_extra_replies.clear()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5145,7 +5145,6 @@ class LLMSessionManager:
         hot-swap fire at different lifecycle points).
         """
         try:
-            self.pending_agent_callbacks.append(callback)
             summary = str(callback.get("summary") or "").strip()
             detail = str(callback.get("detail") or "").strip()
             error_message = str(callback.get("error_message") or "").strip()
@@ -5157,13 +5156,20 @@ class LLMSessionManager:
                 # hot-swap renderer does not fabricate "我完成了任务" for what
                 # may actually be an external event push.
                 origin = "event"
-            # Skip enqueue only when there is *truly* nothing to convey:
-            # no body text, no error context, no identifiable source, and a
-            # benign completed status. Anything else (failed/cancelled/blocked,
-            # an error message, or a named source) carries meaning even with
-            # empty summary/detail and must survive into the hot-swap output.
+            # Skip enqueue (BOTH queues) only when there is *truly* nothing
+            # to convey: no body text, no error context, no identifiable
+            # source, and a benign completed status. Anything else
+            # (failed/cancelled/blocked, an error message, or a named source)
+            # carries meaning even with empty summary/detail and must survive
+            # into the hot-swap output.
+            #
+            # The two queues must filter consistently — otherwise text mode
+            # (which drains pending_agent_callbacks) would inject a garbage
+            # header-only block for callbacks the voice mode already
+            # discarded.
             if not summary and not detail and not error_message and not source_name and status == "completed":
                 return
+            self.pending_agent_callbacks.append(callback)
             self.pending_extra_replies.append({
                 "origin": origin,
                 "summary": summary,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -58,8 +58,10 @@ from config.prompts.prompts_sys import (
     AGENT_TASK_STATUS_RUNNING, AGENT_TASK_STATUS_QUEUED,
     AGENT_TASKS_HEADER, AGENT_TASKS_NOTICE,
     CONTEXT_SUMMARY_READY,
-    SYSTEM_NOTIFICATION_PROACTIVE,
-    SYSTEM_NOTIFICATION_PASSIVE,
+    SYSTEM_NOTIFICATION_TASK_ACTIVE,
+    SYSTEM_NOTIFICATION_TASK_PASSIVE,
+    SYSTEM_NOTIFICATION_EVENT_ACTIVE,
+    SYSTEM_NOTIFICATION_EVENT_PASSIVE,
     SOURCE_DESCRIPTORS,
     TASK_STATUS_PHRASES,
     TASK_ACTION_PHRASES,
@@ -68,7 +70,7 @@ from config.prompts.prompts_sys import (
 )
 
 
-# 内部 item 渲染时的视觉标记。状态信息已在外层 SYSTEM_NOTIFICATION_PROACTIVE
+# 内部 item 渲染时的视觉标记。状态信息已在外层 SYSTEM_NOTIFICATION_TASK_ACTIVE
 # 表达，emoji 仅作快速视觉识别用。
 _STATUS_EMOJI = {
     "completed": "✅",
@@ -169,9 +171,36 @@ def _build_callback_instruction(
 ) -> str:
     """Render a list of agent_task_callbacks into the LLM injection string.
 
-    Groups by ``(delivery_mode/passive flag, status, source_kind, source_name)``
-    so each group can pick the right outer template (PROACTIVE vs PASSIVE)
-    and slot in the right status/action phrases.
+    Each callback carries an ``origin`` tag stamped by the host at the
+    EventBus → callback boundary:
+      - ``"task_result"`` — real task completion (agent_server._emit_task_result),
+        e.g. Computer Use / Browser Use / plugin entry / MCP tool result.
+      - ``"event"`` — plugin push_message stream (proactive_bridge),
+        e.g. danmaku / gift / external notification.
+
+    Plugin authors cannot set ``origin``; it is derived structurally from
+    which SDK method they called (``finish()`` vs ``push_message()``) by
+    way of the event_type the upstream producer emitted.
+
+    Two axes (origin × passive) pick one of four outer templates:
+
+    +--------------+----------------------+-----------------------------+
+    | origin       | active (proactive)   | passive                     |
+    +==============+======================+=============================+
+    | task_result  | TASK_ACTIVE          | TASK_PASSIVE                |
+    |              | ("已完成，请汇报")   | ("任务结果")                |
+    +--------------+----------------------+-----------------------------+
+    | event        | EVENT_ACTIVE         | EVENT_PASSIVE               |
+    |              | ("新消息，请回应")   | ("消息")                    |
+    +--------------+----------------------+-----------------------------+
+
+    Unknown origin defaults to ``"event"`` + warning. Rationale: rather
+    have the AI naturally react than fabricate "I completed a task".
+
+    Callbacks are grouped by (passive, origin, status, source) so each
+    group can pick the right outer template and (for task_result+active)
+    slot in the right status/action phrases. Event templates ignore
+    status/action — the concept doesn't apply to passive event streams.
     """
     if not callbacks:
         return ""
@@ -182,8 +211,18 @@ def _build_callback_instruction(
         # passive=True call = drain path; treat all as passive regardless
         # of per-callback delivery_mode.
         cb_passive = passive or (cb.get("delivery_mode") == "passive")
+        origin = cb.get("origin")
+        if origin not in ("task_result", "event"):
+            if origin:
+                logger.warning(
+                    "[callback_instruction] unknown origin=%r, falling back to 'event'; "
+                    "source=%s/%s",
+                    origin, cb.get("source_kind"), cb.get("source_name"),
+                )
+            origin = "event"
         key = (
             cb_passive,
+            origin,
             cb.get("status") or "completed",
             cb.get("source_kind") or "unknown",
             (cb.get("source_name") or ""),
@@ -191,26 +230,36 @@ def _build_callback_instruction(
         grouped.setdefault(key, []).append(cb)
 
     parts: list[str] = []
-    for (cb_passive, status, _src_kind, _src_name), cbs in grouped.items():
+    for (cb_passive, origin, status, _src_kind, _src_name), cbs in grouped.items():
         source_text = _format_callback_source(cbs[0], lang)
-        if cb_passive:
-            header = _loc(SYSTEM_NOTIFICATION_PASSIVE, lang).format(source=source_text)
-        else:
-            status_phrase = _loc(
-                TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
-                lang,
-            )
-            action_phrase = _loc(
-                TASK_ACTION_PHRASES.get(status) or TASK_ACTION_PHRASES["completed"],
-                lang,
-            )
-            header = _loc(SYSTEM_NOTIFICATION_PROACTIVE, lang).format(
-                source=source_text,
-                status_phrase=status_phrase,
-                action_phrase=action_phrase,
-                name=lanlan_name,
-                master=master_name,
-            )
+        if origin == "task_result":
+            if cb_passive:
+                header = _loc(SYSTEM_NOTIFICATION_TASK_PASSIVE, lang).format(source=source_text)
+            else:
+                status_phrase = _loc(
+                    TASK_STATUS_PHRASES.get(status) or TASK_STATUS_PHRASES["completed"],
+                    lang,
+                )
+                action_phrase = _loc(
+                    TASK_ACTION_PHRASES.get(status) or TASK_ACTION_PHRASES["completed"],
+                    lang,
+                )
+                header = _loc(SYSTEM_NOTIFICATION_TASK_ACTIVE, lang).format(
+                    source=source_text,
+                    status_phrase=status_phrase,
+                    action_phrase=action_phrase,
+                    name=lanlan_name,
+                    master=master_name,
+                )
+        else:  # origin == "event"
+            if cb_passive:
+                header = _loc(SYSTEM_NOTIFICATION_EVENT_PASSIVE, lang).format(source=source_text)
+            else:
+                header = _loc(SYSTEM_NOTIFICATION_EVENT_ACTIVE, lang).format(
+                    source=source_text,
+                    name=lanlan_name,
+                    master=master_name,
+                )
         items = [_render_callback_inner_item(cb, lang) for cb in cbs]
         items = [s for s in items if s]
         if items:

--- a/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -514,6 +514,31 @@ return await self.finish(data={"summary": "..."}, delivery="silent")
 > 两条独立轴（见上面 `push_message(**kwargs) -> object` 节）。旧 `delivery=`
 > / `reply=` 仍能用但会 emit DeprecationWarning，v0.9 移除。
 
+#### "任务汇报"vs"事件回应"：宿主自动分类
+
+主 AI 在被通知时会被套上一层外层 prompt。**外层 prompt 的措辞分两类**——
+插件作者**不能也无需指定**，宿主根据你调用的 SDK 方法自动判定：
+
+| 你调用 | 宿主分类 | AI 收到的外层 prompt 大意 |
+|---|---|---|
+| `await self.finish(...)` | `task_result` | "来自{你的插件}的任务已完成，请向主人**汇报**..." |
+| `self.push_message(...)` | `event` | "来自{你的插件}的**新消息**，请按内容**回应**主人..." |
+
+设计原因——"任务汇报"和"事件流"是两种完全不同的语义：
+- 任务汇报：插件被调用后跑完，AI 应该告诉主人"我做了什么、结果怎样"
+- 事件流：插件持续监听外部事件（弹幕、IM 消息、定时器），AI 应该**回应这个事件本身**，
+  而不是叙述成"我刚刚处理了一下…"
+
+旧版本曾经把所有 `ai_behavior="respond"` 的 push 也套上"任务已完成"模板，导致
+弹幕插件让兰兰用"我刚才处理了一下弹幕"这种汇报型口吻回观众——这是 bug，已修复。
+
+> **关键**：宿主从 `event_type`（`task_result` 还是 `proactive_message`）派生
+> 这个分类，源头在 `agent_server._emit_task_result()` vs `proactive_bridge` 两条
+> 入站路径。插件作者既不会，也无法把"事件流"伪装成"任务完成"。
+>
+> `delivery` / `ai_behavior` 只控制时机（立即起 turn / 等下次用户开口 / 完全静默），
+> 不再决定外层 prompt 的措辞。两个轴正交，组合 6 种都合理。
+
 #### LLM 结果字段过滤
 
 通过 `llm_result_fields` 控制主 LLM 能看到结果中的哪些字段：

--- a/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -516,7 +516,7 @@ return await self.finish(data={"summary": "..."}, delivery="silent")
 
 #### "任务汇报"vs"事件回应"：宿主自动分类
 
-主 AI 在被通知时会被套上一层外层 prompt。**外层 prompt 的措辞分两类**——
+主 AI 在收到通知时，会被套上一层外层 prompt。**外层 prompt 的措辞分两类**——
 插件作者**不能也无需指定**，宿主根据你调用的 SDK 方法自动判定：
 
 | 你调用 | 宿主分类 | AI 收到的外层 prompt 大意 |

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -889,6 +889,7 @@ def test_callback_instruction_renders_blocked_plugin_result_as_not_executed():
     output = _build_callback_instruction(
         [
             {
+                "origin": "task_result",
                 "status": "blocked",
                 "source_kind": "plugin",
                 "source_name": "示例插件",

--- a/tests/unit/test_callback_instruction_origin.py
+++ b/tests/unit/test_callback_instruction_origin.py
@@ -1,0 +1,293 @@
+"""Unit tests for _build_callback_instruction's (origin × passive) routing.
+
+The host derives ``origin`` from upstream ``event_type``:
+- ``event_type == "task_result"`` (agent_server._emit_task_result):
+  real task completion → ``origin="task_result"`` → TASK_* templates
+  ("任务已完成，请汇报" semantics).
+- ``event_type == "proactive_message"`` (proactive_bridge from
+  plugin push_message): event stream → ``origin="event"`` → EVENT_*
+  templates ("新消息，请回应" semantics; **no** "任务"/"汇报" wording).
+
+Plugin authors cannot influence ``origin``; it is a structural fact of
+which SDK method they called (``finish()`` vs ``push_message()``) and
+which host path the event flowed through.
+
+These tests pin both the active/passive split and the cross-axis
+guarantees:
+- TASK ACTIVE renders status_phrase + action_phrase ("已完成 / 汇报").
+- EVENT ACTIVE renders neutral wording with no "任务"/"汇报".
+- Missing origin falls back to "event" + emits a warning (fail-safe:
+  better to omit the "汇报" framing than fabricate "I did a task").
+"""
+from __future__ import annotations
+
+import logging
+
+
+def _build(callbacks, *, passive: bool = False):
+    from main_logic.core import _build_callback_instruction
+
+    return _build_callback_instruction(
+        callbacks,
+        lang="zh",
+        lanlan_name="兰兰",
+        master_name="主人",
+        passive=passive,
+    )
+
+
+# ---------------------------------------------------------------------------
+# origin × passive matrix
+# ---------------------------------------------------------------------------
+
+
+def test_task_active_renders_task_report_wrapper():
+    out = _build(
+        [
+            {
+                "origin": "task_result",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "pomodoro",
+                "summary": "番茄钟到点了",
+                "detail": "番茄钟到点了",
+                "delivery_mode": "proactive",
+            }
+        ],
+    )
+    # Task wrapper requires "任务" + "汇报" (and status_phrase "已完成").
+    assert "任务" in out
+    assert "已完成" in out
+    assert "汇报" in out
+    assert "番茄钟到点了" in out
+    # Event wrapper marker MUST NOT appear.
+    assert "新消息" not in out
+
+
+def test_task_passive_renders_neutral_task_result_wrapper():
+    out = _build(
+        [
+            {
+                "origin": "task_result",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "search_plugin",
+                "summary": "搜索完成",
+                "detail": "找到 5 条结果",
+                "delivery_mode": "passive",
+            }
+        ],
+    )
+    # Passive task wrapper says "任务结果" — neutral, no "汇报" verb.
+    assert "任务结果" in out
+    assert "汇报" not in out
+    assert "找到 5 条结果" in out
+
+
+def test_event_active_omits_task_and_report_wording():
+    """The bilidanmu fix anchor: a plugin push_message → origin=event →
+    EVENT_ACTIVE wrapper. Must NOT include "任务" or "汇报" — those
+    framings caused 兰兰 to narrate "我刚才处理了一下弹幕" instead of
+    actually reacting to the danmaku content.
+    """
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "bilibili_danmaku",
+                "summary": "弹幕 3 条",
+                "detail": "💬 [大佬]观众A: 好可爱",
+                "delivery_mode": "proactive",
+            }
+        ],
+    )
+    # Event ACTIVE template — should prompt the AI to respond to content.
+    assert "新消息" in out
+    assert "回应" in out
+    # Critical: no task / report framing.
+    assert "任务" not in out
+    assert "汇报" not in out
+    assert "已完成" not in out
+    # Content still gets carried in.
+    assert "好可爱" in out
+
+
+def test_event_passive_renders_minimal_neutral_wrapper():
+    out = _build(
+        [
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "ambient_notifier",
+                "summary": "环境提示",
+                "detail": "外面下雨了",
+                "delivery_mode": "passive",
+            }
+        ],
+    )
+    assert "消息" in out
+    assert "任务" not in out
+    assert "回应" not in out  # passive doesn't push a turn
+    assert "外面下雨了" in out
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe behavior for missing / unknown origin
+# ---------------------------------------------------------------------------
+
+
+def test_missing_origin_falls_back_to_event_silently():
+    """If a callback arrives without origin (older callsite / test stub /
+    pre-migration code), we default to the EVENT template — never the TASK
+    one. Rationale: we'd rather have the AI react naturally than fabricate
+    "我做完了一个任务" for an event that wasn't actually a task.
+
+    Missing-key path stays silent (no warning) because it's the legitimate
+    pre-migration fallback. An explicit but unknown value, by contrast,
+    does warn (see test_unknown_origin_value_warns_and_falls_back).
+    """
+    out = _build(
+        [
+            {
+                # no origin key
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "unknown_emitter",
+                "summary": "事件 A",
+                "detail": "事件 A",
+                "delivery_mode": "proactive",
+            }
+        ],
+    )
+    assert "事件 A" in out
+    # Should render the EVENT wrapper, not TASK.
+    assert "新消息" in out
+    assert "任务" not in out
+
+
+def test_unknown_origin_value_warns_and_falls_back():
+    """An explicit but unrecognized origin value should warn and fall
+    back to 'event'. Distinct from the missing-key path: this signals a
+    typo or a producer using an unsupported value.
+    """
+    # Trigger module import so the logger exists; then attach a handler
+    # directly to the project-prefixed logger name (the project sets
+    # ``propagate=False`` on its logger hierarchy in some paths, so
+    # ``caplog`` cannot reliably observe these records — it depends on
+    # whether ``_ensure_shared_parent_logger`` has run, which is
+    # order-dependent across tests).
+    from main_logic.core import _build_callback_instruction  # noqa: F401
+
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.setLevel(logging.WARNING)
+    handler.emit = lambda r: records.append(r)
+    target_logger = logging.getLogger("N.E.K.O.Main.main_logic.core")
+    prior_level = target_logger.level
+    target_logger.addHandler(handler)
+    if prior_level > logging.WARNING or prior_level == logging.NOTSET:
+        target_logger.setLevel(logging.WARNING)
+    try:
+        out = _build(
+            [
+                {
+                    "origin": "nonsense_kind",
+                    "status": "completed",
+                    "source_kind": "plugin",
+                    "source_name": "buggy_plugin",
+                    "summary": "x",
+                    "detail": "x",
+                    "delivery_mode": "proactive",
+                }
+            ],
+        )
+    finally:
+        target_logger.removeHandler(handler)
+        target_logger.setLevel(prior_level)
+
+    # Should fall back to EVENT wrapper.
+    assert "新消息" in out
+    assert "任务" not in out
+    # And should warn about the unrecognized origin (carrying the bad value
+    # so triage can find the producer).
+    assert any(
+        "unknown origin" in r.getMessage() and "nonsense_kind" in r.getMessage()
+        for r in records
+    ), [r.getMessage() for r in records]
+
+
+# ---------------------------------------------------------------------------
+# Grouping behavior is preserved across origins
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_origins_render_separate_blocks():
+    """Same source_name but different origin must NOT collapse into one
+    group — the wrappers are semantically different.
+    """
+    out = _build(
+        [
+            {
+                "origin": "task_result",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "demo",
+                "summary": "完成搜索",
+                "detail": "完成搜索",
+                "delivery_mode": "proactive",
+            },
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "demo",
+                "summary": "新事件",
+                "detail": "新事件",
+                "delivery_mode": "proactive",
+            },
+        ],
+    )
+    # Both wrappers should appear.
+    assert "任务" in out and "汇报" in out  # TASK_ACTIVE
+    assert "新消息" in out and "回应" in out  # EVENT_ACTIVE
+    assert "完成搜索" in out
+    assert "新事件" in out
+
+
+def test_passive_drain_path_forces_passive_for_all_origins():
+    """Calling with passive=True (the drain-on-next-user-turn path) must
+    select the PASSIVE wrapper for every origin, regardless of each
+    callback's own delivery_mode.
+    """
+    out = _build(
+        [
+            {
+                "origin": "task_result",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "search",
+                "summary": "结果 1",
+                "detail": "结果 1",
+                "delivery_mode": "proactive",  # would normally pick ACTIVE
+            },
+            {
+                "origin": "event",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "danmaku",
+                "summary": "弹幕",
+                "detail": "弹幕",
+                "delivery_mode": "proactive",
+            },
+        ],
+        passive=True,
+    )
+    # No "请...汇报"/"请...回应" verbs in passive mode.
+    assert "汇报" not in out
+    assert "回应" not in out
+    # But each origin still picks its own passive wrapper.
+    assert "任务结果" in out
+    assert "消息" in out

--- a/tests/unit/test_callback_instruction_origin.py
+++ b/tests/unit/test_callback_instruction_origin.py
@@ -151,27 +151,52 @@ def test_missing_origin_falls_back_to_event_silently():
     one. Rationale: we'd rather have the AI react naturally than fabricate
     "我做完了一个任务" for an event that wasn't actually a task.
 
-    Missing-key path stays silent (no warning) because it's the legitimate
-    pre-migration fallback. An explicit but unknown value, by contrast,
-    does warn (see test_unknown_origin_value_warns_and_falls_back).
+    Missing-key path stays **silent** (no warning) because it's the
+    legitimate pre-migration fallback. An explicit but unknown value, by
+    contrast, does warn (see test_unknown_origin_value_warns_and_falls_back).
+
+    Pins both halves of that contract: the fallback behavior AND the
+    no-warning invariant. Without the second assertion a future drift that
+    started warning on missing-key (turning every legacy callsite noisy)
+    would silently slip in.
     """
-    out = _build(
-        [
-            {
-                # no origin key
-                "status": "completed",
-                "source_kind": "plugin",
-                "source_name": "unknown_emitter",
-                "summary": "事件 A",
-                "detail": "事件 A",
-                "delivery_mode": "proactive",
-            }
-        ],
-    )
+    from main_logic.core import _build_callback_instruction  # noqa: F401
+
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.setLevel(logging.WARNING)
+    handler.emit = lambda r: records.append(r)
+    target_logger = logging.getLogger("N.E.K.O.Main.main_logic.core")
+    prior_level = target_logger.level
+    target_logger.addHandler(handler)
+    if prior_level > logging.WARNING or prior_level == logging.NOTSET:
+        target_logger.setLevel(logging.WARNING)
+    try:
+        out = _build(
+            [
+                {
+                    # no origin key
+                    "status": "completed",
+                    "source_kind": "plugin",
+                    "source_name": "unknown_emitter",
+                    "summary": "事件 A",
+                    "detail": "事件 A",
+                    "delivery_mode": "proactive",
+                }
+            ],
+        )
+    finally:
+        target_logger.removeHandler(handler)
+        target_logger.setLevel(prior_level)
+
     assert "事件 A" in out
     # Should render the EVENT wrapper, not TASK.
     assert "新消息" in out
     assert "任务" not in out
+    # Critically: NO "unknown origin" warning (pin the silent contract).
+    assert not any("unknown origin" in r.getMessage() for r in records), [
+        r.getMessage() for r in records
+    ]
 
 
 def test_unknown_origin_value_warns_and_falls_back():
@@ -321,6 +346,21 @@ def _render_swap(entries):
     )
 
 
+def _voice_entry(origin, *, summary="", detail="", status="completed",
+                 source_kind="plugin", source_name="", error_message=""):
+    """Helper: build a voice swap entry matching the shape enqueue_agent_callback
+    produces. Lets each test focus on the dimensions it cares about."""
+    return {
+        "origin": origin,
+        "summary": summary,
+        "detail": detail,
+        "status": status,
+        "source_kind": source_kind,
+        "source_name": source_name,
+        "error_message": error_message,
+    }
+
+
 def test_voice_swap_event_entries_use_event_wrapper():
     """The bilidanmu voice-mode fix anchor. push_message events queued via
     ``enqueue_agent_callback`` end up in ``pending_extra_replies`` with
@@ -329,8 +369,8 @@ def test_voice_swap_event_entries_use_event_wrapper():
     """
     out = _render_swap(
         [
-            {"origin": "event", "text": "💬 [大佬]观众A: 好可爱"},
-            {"origin": "event", "text": "🎁 观众B 送了 1个 小心心"},
+            _voice_entry("event", summary="💬 [大佬]观众A: 好可爱", source_name="bilibili_danmaku"),
+            _voice_entry("event", summary="🎁 观众B 送了 1个 小心心", source_name="bilibili_danmaku"),
         ]
     )
     # Event wrapper: "请...根据下方新消息回应..."
@@ -350,7 +390,7 @@ def test_voice_swap_task_entries_use_task_wrapper():
     behavior the refactor must preserve."""
     out = _render_swap(
         [
-            {"origin": "task_result", "text": "番茄钟到点了"},
+            _voice_entry("task_result", summary="番茄钟到点了", source_name="pomodoro"),
         ]
     )
     assert "汇报" in out
@@ -365,9 +405,9 @@ def test_voice_swap_mixed_origins_render_separate_blocks():
     """
     out = _render_swap(
         [
-            {"origin": "task_result", "text": "搜索完成"},
-            {"origin": "event", "text": "弹幕来了"},
-            {"origin": "task_result", "text": "音乐播放完毕"},
+            _voice_entry("task_result", summary="搜索完成", source_name="search"),
+            _voice_entry("event", summary="弹幕来了", source_name="bilibili_danmaku"),
+            _voice_entry("task_result", summary="音乐播放完毕", source_name="music"),
         ]
     )
     # Both wrappers present.
@@ -379,6 +419,54 @@ def test_voice_swap_mixed_origins_render_separate_blocks():
     assert "音乐播放完毕" in out
     # Task block precedes event block (matches helper docstring).
     assert out.index("搜索完成") < out.index("弹幕来了")
+
+
+def test_voice_swap_failure_callback_without_body_still_surfaces():
+    """Header-only failure callback: summary/detail empty but status="failed"
+    and error_message carries the diagnostic. The v1 voice fix flattened
+    these to "" and dropped them entirely; v2 must synthesize a status+source
+    placeholder so the failure doesn't disappear silently before the next
+    hot-swap injects context into the new session.
+    """
+    out = _render_swap(
+        [
+            {
+                "origin": "task_result",
+                "summary": "",
+                "detail": "",
+                "status": "failed",
+                "source_kind": "plugin",
+                "source_name": "pomodoro",
+                "error_message": "Connection refused",
+            }
+        ]
+    )
+    # Wrapper: TASK (this is a real task failure).
+    assert "汇报" in out
+    # Status emoji + source phrase + error message all in the placeholder line.
+    assert "❌" in out
+    assert "pomodoro" in out
+    assert "执行失败" in out
+    assert "Connection refused" in out
+
+
+def test_voice_swap_whitespace_summary_does_not_shadow_detail():
+    """``summary = "   "`` must NOT block the renderer from picking up
+    ``detail``. The legacy ``summary or detail`` chain treated whitespace
+    summary as truthy and dropped detail — fixed in this refactor by
+    stripping each independently before falling through.
+    """
+    out = _render_swap(
+        [
+            _voice_entry(
+                "event",
+                summary="   ",
+                detail="真正的内容在 detail 里",
+                source_name="ambient",
+            ),
+        ]
+    )
+    assert "真正的内容在 detail 里" in out
 
 
 def test_voice_swap_legacy_string_entries_treated_as_event():
@@ -396,13 +484,15 @@ def test_voice_swap_legacy_string_entries_treated_as_event():
 def test_voice_swap_missing_origin_falls_back_to_event():
     """Dict entries without ``origin`` key — same fail-safe as
     ``_build_callback_instruction``: render as event."""
-    out = _render_swap([{"text": "无 origin 条目"}])
+    out = _render_swap([{"summary": "无 origin 条目", "source_kind": "plugin", "source_name": "x"}])
     assert "新消息" in out
     assert "汇报" not in out
     assert "无 origin 条目" in out
 
 
 def test_voice_swap_empty_input_returns_empty_string():
+    """Both genuinely empty input and entries that filter to nothing
+    (completed status with no body, no error, no source) collapse to ""."""
     assert _render_swap([]) == ""
-    assert _render_swap([{"origin": "event", "text": ""}]) == ""  # all blank
-    assert _render_swap([{"origin": "event", "text": "   "}]) == ""
+    assert _render_swap([_voice_entry("event")]) == ""  # all blank
+    assert _render_swap([_voice_entry("event", summary="   ", detail="   ")]) == ""

--- a/tests/unit/test_callback_instruction_origin.py
+++ b/tests/unit/test_callback_instruction_origin.py
@@ -16,8 +16,14 @@ These tests pin both the active/passive split and the cross-axis
 guarantees:
 - TASK ACTIVE renders status_phrase + action_phrase ("已完成 / 汇报").
 - EVENT ACTIVE renders neutral wording with no "任务"/"汇报".
-- Missing origin falls back to "event" + emits a warning (fail-safe:
-  better to omit the "汇报" framing than fabricate "I did a task").
+- Missing origin silently falls back to "event" (pre-migration compat).
+- Explicitly unknown origin values fall back to "event" + warn (signals
+  a typo or a producer using an unsupported value, worth surfacing).
+
+Also covers the voice-mode hot-swap renderer
+(``_render_pending_extra_replies_by_origin``): the swap path bypasses
+``_build_callback_instruction`` entirely and uses CONTEXT_SUMMARY_*
+wrappers, so the origin routing must be re-asserted there.
 """
 from __future__ import annotations
 
@@ -291,3 +297,112 @@ def test_passive_drain_path_forces_passive_for_all_origins():
     # But each origin still picks its own passive wrapper.
     assert "任务结果" in out
     assert "消息" in out
+
+
+# ---------------------------------------------------------------------------
+# Voice-mode hot-swap renderer
+# ---------------------------------------------------------------------------
+#
+# In voice mode, callbacks are not drained through ``_build_callback_instruction``
+# — they sit in ``pending_extra_replies`` until the next session hot-swap, then
+# get rendered into ``prime_context`` via ``_render_pending_extra_replies_by_origin``.
+# This is a SECOND rendering path that has to honor the same origin distinction;
+# otherwise event-stream pushes get the "汇报先前执行的任务的结果" framing.
+
+
+def _render_swap(entries):
+    from main_logic.core import _render_pending_extra_replies_by_origin
+
+    return _render_pending_extra_replies_by_origin(
+        entries,
+        lang="zh",
+        lanlan_name="兰兰",
+        master_name="主人",
+    )
+
+
+def test_voice_swap_event_entries_use_event_wrapper():
+    """The bilidanmu voice-mode fix anchor. push_message events queued via
+    ``enqueue_agent_callback`` end up in ``pending_extra_replies`` with
+    ``origin="event"``. The hot-swap renderer must wrap them with
+    CONTEXT_SUMMARY_EVENT_HEADER/FOOTER — NOT the task wrapper.
+    """
+    out = _render_swap(
+        [
+            {"origin": "event", "text": "💬 [大佬]观众A: 好可爱"},
+            {"origin": "event", "text": "🎁 观众B 送了 1个 小心心"},
+        ]
+    )
+    # Event wrapper: "请...根据下方新消息回应..."
+    assert "新消息" in out
+    assert "回应" in out
+    # Critical: NO "汇报先前执行的任务" framing.
+    assert "汇报" not in out
+    assert "先前执行的任务" not in out
+    # Content carried.
+    assert "好可爱" in out
+    assert "小心心" in out
+
+
+def test_voice_swap_task_entries_use_task_wrapper():
+    """Real task completions (e.g. finish(delivery="proactive") from
+    pomodoro / sts2) keep the "汇报" framing — this is the pre-existing
+    behavior the refactor must preserve."""
+    out = _render_swap(
+        [
+            {"origin": "task_result", "text": "番茄钟到点了"},
+        ]
+    )
+    assert "汇报" in out
+    assert "番茄钟到点了" in out
+    # Should not pick up the event wrapper.
+    assert "新消息" not in out
+
+
+def test_voice_swap_mixed_origins_render_separate_blocks():
+    """Task and event entries in the same drain produce TWO blocks, each
+    with its own wrapper — they do not collapse into one.
+    """
+    out = _render_swap(
+        [
+            {"origin": "task_result", "text": "搜索完成"},
+            {"origin": "event", "text": "弹幕来了"},
+            {"origin": "task_result", "text": "音乐播放完毕"},
+        ]
+    )
+    # Both wrappers present.
+    assert "汇报" in out  # TASK_HEADER
+    assert "回应" in out  # EVENT_HEADER
+    # All content carried.
+    assert "搜索完成" in out
+    assert "弹幕来了" in out
+    assert "音乐播放完毕" in out
+    # Task block precedes event block (matches helper docstring).
+    assert out.index("搜索完成") < out.index("弹幕来了")
+
+
+def test_voice_swap_legacy_string_entries_treated_as_event():
+    """Defensive: if any old code path enqueues a plain string (pre-
+    migration shape), treat it as event — the safer fallback, since
+    fabricating "我刚才执行了任务" for what may actually be a push event
+    is exactly the bug this PR fixes.
+    """
+    out = _render_swap(["遗留字符串条目"])
+    assert "新消息" in out
+    assert "汇报" not in out
+    assert "遗留字符串条目" in out
+
+
+def test_voice_swap_missing_origin_falls_back_to_event():
+    """Dict entries without ``origin`` key — same fail-safe as
+    ``_build_callback_instruction``: render as event."""
+    out = _render_swap([{"text": "无 origin 条目"}])
+    assert "新消息" in out
+    assert "汇报" not in out
+    assert "无 origin 条目" in out
+
+
+def test_voice_swap_empty_input_returns_empty_string():
+    assert _render_swap([]) == ""
+    assert _render_swap([{"origin": "event", "text": ""}]) == ""  # all blank
+    assert _render_swap([{"origin": "event", "text": "   "}]) == ""


### PR DESCRIPTION
## 问题

插件通过 `push_message` 推送弹幕、礼物、外部消息等**事件流**时，外层 prompt 被强制套上 `来自{插件}的任务已完成，请向主人汇报`——兰兰收到的指令是"汇报刚才执行的任务"，而事件内容里却是 `观众A: 弹幕内容`。两层 prompt 打架，兰兰最终用"我刚才处理了一下弹幕"这种**汇报口吻**回应观众，而不是直接回应事件内容。

最显眼的受害者是 `bilibili_danmaku`，但 `memo_reminder` / `galgame_plugin` 等所有用 `push_message(ai_behavior="respond")` 的插件都有同样问题。

## 根因

`_build_callback_instruction` 只按 `passive` / `proactive` 一维选模板，`SYSTEM_NOTIFICATION_PROACTIVE` 一个模板涵盖了两种本质不同的语义：

- **真任务完成**：`agent_server._emit_task_result()` 发出，来源是 `@plugin_entry` / `@llm_tool` / Computer Use / Browser Use / MCP tool 跑完。AI **应该**汇报"我做了什么、结果怎样"。
- **事件流**：`proactive_bridge` 把插件 `push_message` 转成 EventBus 事件。来源是观众弹幕、礼物、外部 IM 消息等。AI **应该**回应事件本身，而**不是**叙述成"我刚刚处理了…"。

下游 `_build_callback_instruction` 把两类合流，丢掉了 `event_type` 字段里本来就携带的语义差异。

## 修复

**核心思路**：`origin` 是结构性事实，由 host 在 EventBus→callback 边界根据 `event_type` 派生，插件作者**无法干预**：

```
event_type == "task_result"       → origin = "task_result"
event_type == "proactive_message" → origin = "event"
```

插件作者选 `finish()` 还是 `push_message()`，`origin` 就锁死了。

`_build_callback_instruction` 改为按 `(origin × passive)` 二维选 4 个模板：

| | active (proactive) | passive |
|---|---|---|
| **task_result** | TASK_ACTIVE ("已完成，请汇报") | TASK_PASSIVE ("任务结果") |
| **event** | EVENT_ACTIVE ("新消息，请回应") | EVENT_PASSIVE ("消息") |

未知 `origin` 默认 `event` + warn（fail-safe：宁可让 AI 自然回应，也不让它编造"我做完了一个任务"）。

## 改动范围

| 文件 | 改动 |
|---|---|
| `config/prompts/prompts_sys.py` | 拆 4 个模板（7 个语种），旧名字作 alias 保留 |
| `main_logic/core.py` | `_build_callback_instruction` 按 `(origin, passive)` 二维选模板 |
| `app/main_server.py` | callback 构造处加 `origin = "task_result" if event_type == "task_result" else "event"` |
| `tests/unit/test_callback_instruction_origin.py` | 新增 8 个测试覆盖 `(origin × passive)` 矩阵 + fallback 语义 |
| `tests/test_agent_rewrite_regression.py` | 现有 blocked-plugin 测试显式设 `origin="task_result"` |
| `plugin/PLUGIN_DEVELOPMENT_GUIDE.md` | 新增"任务汇报 vs 事件回应"小节，解释 origin 由 host 自动判定 |

**零插件代码改动**：bilidanmu / memo_reminder / galgame 等所有用 `push_message` 的插件自动从 TASK_ACTIVE 切到 EVENT_ACTIVE；真任务完成路径（`finish()` / Computer Use / Browser Use / MCP）保持 TASK_ACTIVE 语义不变。

## 测试

- 新增 `tests/unit/test_callback_instruction_origin.py`：8 个测试覆盖 `(origin × passive)` 矩阵 + missing/unknown origin fail-safe + 跨 origin 的分组 + drain-path passive 强制
- 现有 `tests/test_agent_rewrite_regression.py::test_callback_instruction_renders_blocked_plugin_result_as_not_executed` 显式标 `origin="task_result"`，断言保持
- 周边相关测试（`test_passthrough_to_chat_bubble` / `test_proactive_*`）146 个全通过

## Test plan

- [x] 9 个新增 + 现有 callback 测试通过
- [x] 146 个周边 unit test 通过
- [ ] 手动 / 集成：跑一次 bilidanmu，确认兰兰回弹幕的口吻不再是"我刚才处理了…"
- [ ] 手动 / 集成：跑一次 pomodoro / sts2 / 任意 `finish(delivery="proactive")` 插件，确认"汇报"措辞保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **系统改进**
  * 通知呈现现区分来源（任务结果 vs 事件）与发送模式（主动 vs 被动），外层措辞分别针对任务汇报或事件回应调整。
  * 挂起回复在语音热切换时按来源分块渲染，保留任务与事件的语义与顺序，旧式字符串队列兼容为事件类处理。

* **文档更新**
  * 插件开发指南新增宿主自动分类说明，明确插件无法伪装来源、发送时机与措辞分离。

* **测试**
  * 新增/更新单元与回归测试，覆盖来源×被动矩阵、热切换与降级处理。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1310)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->