### PR TITLE
fix(tts): GSV worker 不再误丢单标点 chunk

### DIFF
--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -382,6 +382,36 @@ TTS_PROVIDER_REGISTRY: dict[str, TTSProviderMeta] = {
 }
 
 
+# GSV worker 的"句标点"白名单。判据：
+# - 含字母 / 数字（Unicode 字母含 CJK / 假名 / 韩文 / 希腊 / 西里尔 /
+#   阿拉伯 letter）→ 真内容，放行
+# - 无字母数字但全是白名单标点（不限个数）→ LLM 真实标点 chunk（`，` `。`
+#   `？` 等，可能也含罕见的 `。。。` `？！`），放行让 server TextBuffer 切句
+# - 无字母数字且含任何非白名单符号 → kaomoji（`=。=` `(╯°□°）╯` `^_^`），丢
+#
+# 标点集刻意覆盖多语言（CJK / ASCII / Arabic / Spanish），但**不放** `(` `)`
+# `[` `]` `{` `}` `「」` `《》` `"` `'` `~` `^` `*` `_` `-` 等 kaomoji 高发字符。
+_GSV_ALLOWED_PUNCT = frozenset('。！？；：，、…—．.!?;:,¿¡،؟؛')
+
+
+def _gsv_should_drop_chunk(text: str) -> bool:
+    """True = chunk 是 kaomoji / 怪符号堆，丢；False = 放行。
+
+    扫完所有字符再判：任何 alnum 都让 chunk 立刻放行（含 letter 的 kaomoji
+    如 `T_T` / `\\(^o^)/` 走这条路过——server clean 完还有字母，不会触发
+    empty error）；无 alnum 时只看有没有非白名单符号。
+    """
+    has_unsanctioned = False
+    for c in text:
+        if c.isspace():
+            continue
+        if c.isalnum():
+            return False
+        if c not in _GSV_ALLOWED_PUNCT:
+            has_unsanctioned = True
+    return has_unsanctioned
+
+
 # ─── 非流式输入 TTS 公共基础设施 ───────────────────────────────────────────
 
 
@@ -2923,7 +2953,10 @@ def gptsovits_tts_worker(request_queue, response_queue, audio_api_key, voice_id)
                 if not tts_text or not tts_text.strip():
                     continue
 
-                if not re.sub(r'\W+', '', tts_text.strip()):
+                # kaomoji / 颜文字兜底：见 _GSV_ALLOWED_PUNCT 注释。
+                # `=。=` `(╯°□°）╯` `^_^` 这类丢；单标点 `，` `。` `？` 放过让
+                # server TextBuffer 触发切句。
+                if _gsv_should_drop_chunk(tts_text):
                     continue
 
                 # 用 append 累积碎片文本，v3 TextBuffer 自动按标点切句推理


### PR DESCRIPTION
## Summary

- GSV TTS worker 之前用 `re.sub(r'\W+', '', text)` 判断"是否纯非字内容"，但 Py3 unicode 模式下 `\W` 把中文 / ASCII 标点也算进去，导致流式 LLM 输出里单独成 chunk 的 `，` `。` `？` 全被静默丢弃。GSV server 收到的文本因此没有内部标点，TextBuffer 无法按句切分，整段被当一句推理，首句延迟高、节奏崩。
- 改用按字符判据的白名单：含字母数字（CJK / 假名 / 韩文 / 希腊 / 西里尔 / 阿拉伯 letter） → 放；纯白名单句标点（`，` `。` `？！` 多语言变体，含 ASCII / Arabic / Spanish） → 放；含任何非白名单符号（`=` `(` `^` `_` `>` 等 kaomoji 标志） → 丢。
- 仍能正确拦住 #890 原本想拦的 kaomoji（`=。=` `(╯°□°）╯` `^_^` `:-)`），且"含字母的 kaomoji" `T_T` `\(^o^)/` 走"alnum 立即放行"过——server clean 完有字母，不触发 empty error。

## Affected workers

仅 GSV worker。grep 全文 `\W+` filter 只命中 [`tts_client.py`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/main_logic/tts_client.py) 这一处；CosyVoice / MiniMax / Step / Grok / Qwen / Gemini / OpenAI / CogTTS 各自的 worker 都只有 `.strip()` 判空，标点 chunk 正常下传，**不受此 bug 影响**。

## Test plan

- [x] 模块级单元测试覆盖 41 个 case（含 CJK / ASCII / 多语言字母、单/多标点、各类 kaomoji、Unicode emoji、混入字母的 kaomoji 等），全部通过
- [ ] 实测：用 Gemini Live realtime + GSV TTS 跑一段含 `，` `？` `！` 的中文回复，确认 GSV server log 里 `切分文本` 段保留内部标点，`切句后` 返回多段而非单段
- [ ] 实测：触发含 emoji / kaomoji 的回复，确认 GSV 仍不报 empty text 错

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug 修复**
  * 改进了文本转语音的输入处理机制，现可准确过滤包含特殊符号和表情符号的文本段落，提升了系统处理特殊字符文本时的稳定性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1317)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->