### PR TITLE
feat(tts): switch StepFun realtime to stepaudio-2.5-realtime + linjiameimei default voice

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -669,7 +669,7 @@ DEFAULT_CORE_API_PROFILES = {
     },
     'step': {
         'CORE_URL': "wss://api.stepfun.com/v1/realtime",
-        'CORE_MODEL': "step-audio-2",
+        'CORE_MODEL': "stepaudio-2.5-realtime",
     },
     'gemini': {
         # Gemini 使用 google-genai SDK，而非原生 WebSocket

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -33,7 +33,7 @@
     "step": {
       "key": "step",
       "name": "Step-2（阶跃星辰）",
-      "description": "目前完全免费，内置联网搜索功能",
+      "description": "目前完全免费",
       "core_url": "wss://api.stepfun.com/v1/realtime",
       "core_model": "stepaudio-2.5-realtime"
     },

--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -35,7 +35,7 @@
       "name": "Step-2（阶跃星辰）",
       "description": "目前完全免费，内置联网搜索功能",
       "core_url": "wss://api.stepfun.com/v1/realtime",
-      "core_model": "step-audio-2"
+      "core_model": "stepaudio-2.5-realtime"
     },
     "gemini": {
       "key": "gemini",
@@ -373,7 +373,7 @@
   "native_tts_voice_providers": {
     "step": {
       "catalog_prefix": "StepFun",
-      "default_voice": "qingchunshaonv",
+      "default_voice": "linjiameimei",
       "default_male_voice": "cixingnansheng",
       "catalog_value_is_display_name": true,
       "voices": {
@@ -410,13 +410,13 @@
         "huolinvsheng": "活力女声"
       },
       "aliases": {
-        "default": "qingchunshaonv",
-        "默认": "qingchunshaonv",
-        "female": "qingchunshaonv",
-        "woman": "qingchunshaonv",
-        "女": "qingchunshaonv",
-        "女声": "qingchunshaonv",
-        "中文女": "qingchunshaonv",
+        "default": "linjiameimei",
+        "默认": "linjiameimei",
+        "female": "linjiameimei",
+        "woman": "linjiameimei",
+        "女": "linjiameimei",
+        "女声": "linjiameimei",
+        "中文女": "linjiameimei",
         "male": "cixingnansheng",
         "man": "cixingnansheng",
         "男": "cixingnansheng",

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -477,22 +477,12 @@ class OmniRealtimeClient:
             logger.info("apply_tools_to_session: Gemini Live does not support mid-session tools update — ignoring")
             return
         api = self._api_type.lower()
-        if api == 'step':
-            # stepaudio-2.5-realtime 不再依赖客户端注入 web_search，与
+        if api == 'step' or api == 'free':
+            # stepaudio-2.5-realtime 不再支持内置 web_search，与
             # update_session 初始化路径保持一致：只发 caller 注册的
             # function tools。
             tools_payload: List[Dict[str, Any]] = self._tools_for_step()
             await self.update_session({"tools": tools_payload})
-        elif api == 'free':
-            # free (lanlan.tech 代理) 当前仍把内置 web_search 当作 tools
-            # 协议的一部分；与 update_session 初始化路径对齐，mid-session
-            # 重同步时也把它再发一次，避免被服务端当成 disable 撤销。
-            free_tools_payload: List[Dict[str, Any]] = [
-                {"type": "web_search",
-                 "function": {"description": "这个web_search用来搜索互联网的信息"}}
-            ]
-            free_tools_payload.extend(self._tools_for_step())
-            await self.update_session({"tools": free_tools_payload})
         elif api == 'gpt':
             payload: Dict[str, Any] = {"tools": self._tools_for_openai_realtime()}
             if self.has_tools():
@@ -837,14 +827,7 @@ class OmniRealtimeClient:
                     "type": "server_vad"
                 },
             }
-            free_tools: List[Dict[str, Any]] = [
-                {
-                    "type": "web_search",
-                    "function": {
-                        "description": "这个web_search用来搜索互联网的信息"
-                    }
-                }
-            ]
+            free_tools: List[Dict[str, Any]] = []
             if self.has_tools():
                 free_tools.extend(self._tools_for_step())
             free_session["tools"] = free_tools

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -795,17 +795,7 @@ class OmniRealtimeClient:
                     "type": "server_vad"
                 },
             }
-            # Always keep the built-in web_search; append custom tools
-            # (StepFun supports both type:"web_search" and type:"function"
-            # in the same array — see official docs).
-            step_tools: List[Dict[str, Any]] = [
-                {
-                    "type": "web_search",
-                    "function": {
-                        "description": "这个web_search用来搜索互联网的信息"
-                    }
-                }
-            ]
+            step_tools: List[Dict[str, Any]] = []
             if self.has_tools():
                 step_tools.extend(self._tools_for_step())
             step_session["tools"] = step_tools

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -477,15 +477,22 @@ class OmniRealtimeClient:
             logger.info("apply_tools_to_session: Gemini Live does not support mid-session tools update — ignoring")
             return
         api = self._api_type.lower()
-        if api == 'step' or api == 'free':
-            # StepFun / 自由路 keep the built-in web_search tool alongside
-            # any custom tools — server expects the full list each update.
-            tools_payload: List[Dict[str, Any]] = [
+        if api == 'step':
+            # stepaudio-2.5-realtime 不再依赖客户端注入 web_search，与
+            # update_session 初始化路径保持一致：只发 caller 注册的
+            # function tools。
+            tools_payload: List[Dict[str, Any]] = self._tools_for_step()
+            await self.update_session({"tools": tools_payload})
+        elif api == 'free':
+            # free (lanlan.tech 代理) 当前仍把内置 web_search 当作 tools
+            # 协议的一部分；与 update_session 初始化路径对齐，mid-session
+            # 重同步时也把它再发一次，避免被服务端当成 disable 撤销。
+            free_tools_payload: List[Dict[str, Any]] = [
                 {"type": "web_search",
                  "function": {"description": "这个web_search用来搜索互联网的信息"}}
             ]
-            tools_payload.extend(self._tools_for_step())
-            await self.update_session({"tools": tools_payload})
+            free_tools_payload.extend(self._tools_for_step())
+            await self.update_session({"tools": free_tools_payload})
         elif api == 'gpt':
             payload: Dict[str, Any] = {"tools": self._tools_for_openai_realtime()}
             if self.has_tools():

--- a/scripts/test_tts_websocket_probe.py
+++ b/scripts/test_tts_websocket_probe.py
@@ -343,7 +343,7 @@ def main() -> None:
     p.add_argument("--wait-connection", type=float, default=8.0, help="Wait for tts.connection.done")
     p.add_argument("--wait-session", type=float, default=5.0, help="Wait for tts.response.created")
     p.add_argument("--protocol-roundtrip", action="store_true", help="After handshake, send tts.create (+ optional text)")
-    p.add_argument("--voice-id", default="qingchunshaonv", help="voice_id only if --url is not lanlan.app")
+    p.add_argument("--voice-id", default="linjiameimei", help="voice_id only if --url is not lanlan.app")
     p.add_argument("--language-code", default="cmn-CN", help="language_code for lanlan.app (matches app default map)")
     p.add_argument("--text", default="", help="If set with --protocol-roundtrip, send this as tts.text.delta")
     p.add_argument(

--- a/tests/unit/test_gemini_realtime_voice_routing.py
+++ b/tests/unit/test_gemini_realtime_voice_routing.py
@@ -175,11 +175,11 @@ def test_step_native_preview_provider_respects_custom_voice_collision():
     colliding_mgr = _FakeCharactersRouterConfigManager(
         "free",
         "wss://lanlan.tech/realtime",
-        stored_voice_ids={"qingchunshaonv"},
+        stored_voice_ids={"linjiameimei"},
     )
 
     assert characters_router._get_active_native_preview_provider(native_mgr, "中文女") == "free"
-    assert characters_router._get_active_native_preview_provider(colliding_mgr, "qingchunshaonv") is None
+    assert characters_router._get_active_native_preview_provider(colliding_mgr, "linjiameimei") is None
     assert characters_router._get_active_native_preview_provider(colliding_mgr, "中文女") is None
 
 

--- a/tests/unit/test_stepfun_tts_voices.py
+++ b/tests/unit/test_stepfun_tts_voices.py
@@ -24,8 +24,8 @@ from utils.stepfun_tts_voices import (
 
 
 def test_stepfun_and_free_catalogs_are_registered():
-    assert STEPFUN_TTS_DEFAULT_VOICE == "qingchunshaonv"
-    assert FALLBACK_STEPFUN_TTS_DEFAULT_VOICE == "qingchunshaonv"
+    assert STEPFUN_TTS_DEFAULT_VOICE == "linjiameimei"
+    assert FALLBACK_STEPFUN_TTS_DEFAULT_VOICE == "linjiameimei"
     assert STEPFUN_TTS_DEFAULT_MALE_VOICE == "cixingnansheng"
     assert is_native_voice(STEPFUN_TTS_DEFAULT_VOICE, provider_key="step") is True
     assert is_native_voice(STEPFUN_TTS_DEFAULT_VOICE, provider_key="free") is True
@@ -82,9 +82,9 @@ def test_stepfun_ui_catalog_exposes_provider_label():
     assert STEPFUN_TTS_DEFAULT_VOICE in catalog
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider"] == "step"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider_label"] == "StepFun"
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "清纯少女"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "邻家妹妹"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["gender"] == ""
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "清纯少女"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "邻家妹妹"
 
 
 def test_free_ui_catalog_uses_voice_label_without_provider_prefix():
@@ -92,9 +92,9 @@ def test_free_ui_catalog_uses_voice_label_without_provider_prefix():
     assert catalog is not None
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider"] == "free"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider_label"] == "免费 API"
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "清纯少女"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "邻家妹妹"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["gender"] == ""
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "清纯少女"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "邻家妹妹"
     assert catalog[STEPFUN_TTS_DEFAULT_MALE_VOICE]["prefix"] == "磁性男声"
 
 
@@ -102,7 +102,7 @@ def test_stepfun_catalog_is_loaded_from_api_providers_config():
     step_cfg = get_native_tts_voice_provider_config("step")
     free_cfg = get_native_tts_voice_provider_config("free")
 
-    assert step_cfg["voices"][STEPFUN_TTS_DEFAULT_VOICE] == "清纯少女"
+    assert step_cfg["voices"][STEPFUN_TTS_DEFAULT_VOICE] == "邻家妹妹"
     assert step_cfg["default_voice"] == STEPFUN_TTS_DEFAULT_VOICE
     assert step_cfg["default_male_voice"] == STEPFUN_TTS_DEFAULT_MALE_VOICE
     assert free_cfg["voices"] == step_cfg["voices"]

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1663,11 +1663,12 @@ async def test_realtime_apply_tools_to_session_qwen_disables_enable_search():
 
 
 @pytest.mark.asyncio
-async def test_realtime_apply_tools_to_session_step_keeps_web_search():
-    """StepFun apply_tools 必须保留内置 web_search 工具，否则 server 会把
-    用户 disable web_search 的状态当作 mid-session 撤销，影响其他对话功能。"""
+async def test_realtime_apply_tools_to_session_step_emits_function_tools_only():
+    """stepaudio-2.5-realtime 不再依赖客户端注入内置 web_search；
+    apply_tools_to_session 只发送 caller 注册的 function tools，与
+    update_session 初始化路径保持一致。"""
     client, sent = _make_rt_client("step")
     await client.apply_tools_to_session()
     tools = sent[0]["session"]["tools"]
-    assert any(t.get("type") == "web_search" for t in tools)
+    assert all(t.get("type") != "web_search" for t in tools)
     assert any(t.get("type") == "function" for t in tools)

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1664,7 +1664,7 @@ async def test_realtime_apply_tools_to_session_qwen_disables_enable_search():
 
 @pytest.mark.asyncio
 async def test_realtime_apply_tools_to_session_step_emits_function_tools_only():
-    """stepaudio-2.5-realtime 不再依赖客户端注入内置 web_search；
+    """stepaudio-2.5-realtime 不再支持内置 web_search；
     apply_tools_to_session 只发送 caller 注册的 function tools，与
     update_session 初始化路径保持一致。"""
     client, sent = _make_rt_client("step")

--- a/utils/stepfun_tts_voices.py
+++ b/utils/stepfun_tts_voices.py
@@ -14,7 +14,7 @@ from utils.native_voice_registry import (
     register_provider,
 )
 
-FALLBACK_STEPFUN_TTS_DEFAULT_VOICE = "qingchunshaonv"
+FALLBACK_STEPFUN_TTS_DEFAULT_VOICE = "linjiameimei"
 FALLBACK_STEPFUN_TTS_DEFAULT_MALE_VOICE = "cixingnansheng"
 
 


### PR DESCRIPTION
## Summary

三件事打包一起，都是围绕 StepFun realtime 走 stepaudio-2.5-realtime 的连锁改动：

1. **core_model bump**：StepFun realtime `step-audio-2` → `stepaudio-2.5-realtime`（[config/api_providers.json](config/api_providers.json) `realtime_audio_providers.step.core_model`）。
2. **默认音色** `qingchunshaonv`（清纯少女）→ `linjiameimei`（邻家妹妹）：
   - `native_tts_voice_providers.step.default_voice` 翻 + `default / 默认 / female / woman / 女 / 女声 / 中文女` 七个语义上等价于"默认女声"的 alias 同步。`default_male_voice` / male 系列别名保持 `cixingnansheng`。`free` provider 通过 `inherits:"step"` 自动跟随。
   - [utils/stepfun_tts_voices.py:17](utils/stepfun_tts_voices.py:17) 的 `FALLBACK_STEPFUN_TTS_DEFAULT_VOICE` 兜底常量同步，避免配置加载失败时仍指向旧默认。
   - 主程序 [omni_realtime_client.py](main_logic/omni_realtime_client.py) / [tts_client.py](main_logic/tts_client.py) 已经走 `get_stepfun_tts_default_voice('step'/'free')`，本 PR 不改这些路径，只翻配置 + 兜底常量，单一真相源仍在 `api_providers.json`。
   - [scripts/test_tts_websocket_probe.py](scripts/test_tts_websocket_probe.py) probe `--voice-id` 默认值同步。
3. **剥掉 step_tools 内置 web_search**：stepaudio-2.5-realtime 不再依赖客户端注入 `type:"web_search"` tool。custom function tools 通过 `self._tools_for_step()` 照常注入，自定义工具行为不变。顺手删了已经过时的 "Always keep the built-in web_search" 注释。

## Test plan

- [x] `uv run pytest tests/unit/test_stepfun_tts_voices.py tests/unit/test_native_voice_registry.py tests/unit/test_gemini_realtime_voice_routing.py tests/unit/test_gemini_tts_voices.py` 全绿（77 passed）
- [ ] 切到 `Step-2（阶跃星辰）`，新建角色卡不指定 voice，确认 realtime 端走 `linjiameimei` 音色
- [ ] 切到免费 API（`lanlan.tech`），同样验证默认音色继承到 linjiameimei
- [ ] 选 `中文女 / 默认` 等 alias 也命中 linjiameimei
- [ ] 男声路径（`中文男 / male` 等）仍解析到 `cixingnansheng` 未受影响
- [ ] 实际跑一遍 StepFun realtime 对话，确认 stepaudio-2.5-realtime 在没有内置 web_search tool 的情况下正常握手 + 出音

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 升级 Step 语音模型至 stepaudio-2.5-realtime。
  * 默认 TTS 语音切换为“邻家妹妹”，改善中文语音与语音预览体验。

* **Bug Fixes**
  * 实时会话工具更新：不再自动内置网页搜索工具，确保用户自定义工具生效。
  * 调整命令行语音探测工具的默认语音 ID，以匹配新的默认 TTS 行为。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1321)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->