### PR TITLE
feat(galgame): 完成上下文优化 Phase 1 

### DIFF
--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from . import service as _service
 from .models import (
     DATA_SOURCE_BRIDGE_SDK,
     DATA_SOURCE_MEMORY_READER,
@@ -13,6 +12,103 @@ from .models import (
     sanitize_choice,
     sanitize_snapshot_state,
 )
+from .reader import normalize_text
+
+_OCR_OVERLAY_TEXT_GUARD_SUBSTRINGS = (
+    ".agent",
+    ".codex",
+    ".codex_tmp",
+    ".codex_pytest_tmp",
+    "__pycache__",
+    "-pycache_",
+    "codex_tmp",
+    "documents\\code\\n.e.k.o",
+    "galgame plugin",
+    "n.e.k.o",
+    "plugin manager",
+    "plugin.plugins.galgame_plugin",
+    "uv run python",
+    "launcher.py",
+    "powershell",
+    "ps c:",
+    "插件设置",
+    "ocr 目标窗口",
+    "截图校准",
+)
+_DIALOGUE_PUNCTUATION_RE = re.compile(r"[。！？!?…]|[.](?:\s|$)|——|「|」|『|』|“|”")
+_DIALOGUE_WEAK_PUNCTUATION_RE = re.compile(r"[，,、：:]")
+_NON_DIALOGUE_CONTEXT_TOKENS = (
+    "agent",
+    "capture_failed",
+    "context_state=",
+    "dxcam:",
+    "galgame_",
+    "gateway_unavailable",
+    "http://",
+    "https://",
+    "last_error=",
+    "ocr_context_unavailable",
+    "plugin/",
+    "plugin\\",
+    "powershell",
+    "status=",
+    "stability",
+    "当前快照",
+    "场景 id",
+    "场景id",
+    "会话 id",
+    "会话id",
+    "游戏 id",
+    "游戏id",
+    "菜单是否打开",
+    "台词 id",
+    "台词id",
+    "路线 id",
+    "路线id",
+    "快照时间",
+    "是否过期",
+    "退出全屏",
+    "收起",
+    "全屏",
+    "ocr 诊断",
+    "recent raw ocr",
+    "最近 raw ocr",
+)
+
+
+def _looks_like_ocr_overlay_text(text: object) -> bool:
+    normalized = normalize_text(str(text or "")).strip().lower()
+    if not normalized:
+        return False
+    return any(token in normalized for token in _OCR_OVERLAY_TEXT_GUARD_SUBSTRINGS)
+
+
+def _significant_char_count(text: object) -> int:
+    return sum(1 for ch in str(text or "") if not ch.isspace())
+
+
+def _looks_like_game_dialogue_context_line(line: dict[str, Any]) -> bool:
+    if not isinstance(line, dict) or bool(line.get("is_diagnostic")):
+        return False
+    text = normalize_text(str(line.get("text") or "")).strip()
+    if not text or _looks_like_ocr_overlay_text(text):
+        return False
+    lowered = text.lower()
+    if any(token in lowered for token in _NON_DIALOGUE_CONTEXT_TOKENS):
+        return False
+    if text.startswith("{") or text.startswith("[") or ("{" in text and "}" in text):
+        return False
+    significant_chars = _significant_char_count(text)
+    if significant_chars < 2 or significant_chars > 220:
+        return False
+    has_dialogue_punctuation = bool(_DIALOGUE_PUNCTUATION_RE.search(text))
+    has_weak_dialogue_punctuation = bool(_DIALOGUE_WEAK_PUNCTUATION_RE.search(text))
+    has_speaker = bool(str(line.get("speaker") or "").strip())
+    if has_speaker:
+        return True
+    if has_dialogue_punctuation:
+        return True
+    return has_weak_dialogue_punctuation and significant_chars >= 8
 
 
 def _scene_lines(
@@ -85,7 +181,7 @@ def _dialogue_context_lines(lines: list[dict[str, Any]], *, limit: int) -> list[
     deduped: dict[str, dict[str, Any]] = {}
     order: list[str] = []
     for item in lines:
-        if not _service._looks_like_game_dialogue_context_line(item):
+        if not _looks_like_game_dialogue_context_line(item):
             continue
         normalized = dict(item)
         key = _dialogue_line_dedupe_key(normalized)
@@ -134,7 +230,7 @@ def _build_input_degraded_context(
 
 
 def _resolve_target_line(local_state: dict[str, Any], *, line_id: str) -> dict[str, Any] | None:
-    snapshot_line = _service._current_line_entry(local_state.get("latest_snapshot", {}))
+    snapshot_line = _current_line_entry(local_state.get("latest_snapshot", {}))
     if snapshot_line and str(snapshot_line.get("line_id") or "") == line_id:
         return snapshot_line
     for item in reversed(local_state.get("history_lines", [])):
@@ -144,6 +240,147 @@ def _resolve_target_line(local_state: dict[str, Any], *, line_id: str) -> dict[s
         if str(item.get("line_id") or "") == line_id:
             return dict(item)
     return None
+
+
+def _current_line_entry(snapshot: dict[str, Any]) -> dict[str, Any] | None:
+    normalized = sanitize_snapshot_state(snapshot)
+    if not normalized.get("line_id") or not normalized.get("text"):
+        return None
+    if _looks_like_ocr_overlay_text(normalized.get("text")):
+        return None
+    entry = {
+        "line_id": str(normalized.get("line_id") or ""),
+        "speaker": str(normalized.get("speaker") or ""),
+        "text": str(normalized.get("text") or ""),
+        "scene_id": str(normalized.get("scene_id") or ""),
+        "route_id": str(normalized.get("route_id") or ""),
+        "stability": str(normalized.get("stability") or ""),
+        "source": "snapshot",
+        "ts": str(normalized.get("ts") or ""),
+    }
+    if not _looks_like_game_dialogue_context_line(entry):
+        return None
+    return entry
+
+
+def resolve_effective_current_line(local_state: dict[str, Any]) -> dict[str, Any] | None:
+    snapshot_line = _current_line_entry(local_state.get("latest_snapshot", {}))
+    if snapshot_line is not None:
+        return snapshot_line
+    for source_key, source_label in (
+        ("history_observed_lines", "observed"),
+        ("history_lines", "stable"),
+    ):
+        for item in reversed(local_state.get(source_key, [])):
+            if not isinstance(item, dict):
+                continue
+            text = str(item.get("text") or "")
+            line_id = str(item.get("line_id") or "")
+            if not text or not line_id:
+                continue
+            result = dict(item)
+            result["source"] = source_label
+            result["stability"] = str(
+                result.get("stability")
+                or ("stable" if source_label == "stable" else "tentative")
+            )
+            return result
+    return None
+
+
+def build_ocr_context_diagnostic(local_state: dict[str, Any]) -> str:
+    runtime = local_state.get("ocr_reader_runtime")
+    runtime_obj = runtime if isinstance(runtime, dict) else {}
+    parts = ["ocr_context_unavailable"]
+    context_state = str(runtime_obj.get("ocr_context_state") or "").strip()
+    detail = str(runtime_obj.get("detail") or "").strip()
+    status = str(runtime_obj.get("status") or "").strip()
+    target_selection_detail = str(runtime_obj.get("target_selection_detail") or "").strip()
+    last_exclude_reason = str(runtime_obj.get("last_exclude_reason") or "").strip()
+    if (
+        target_selection_detail == "memory_reader_window_minimized"
+        or last_exclude_reason == "excluded_minimized_window"
+    ):
+        parts.append("游戏窗口已最小化，OCR 不能截图。请恢复游戏窗口后继续。")
+    if context_state:
+        parts.append(f"context_state={context_state}")
+    if status:
+        parts.append(f"status={status}")
+    if detail:
+        parts.append(f"detail={detail}")
+    if target_selection_detail:
+        parts.append(f"target_selection_detail={target_selection_detail}")
+    if last_exclude_reason:
+        parts.append(f"last_exclude_reason={last_exclude_reason}")
+    backend = str(runtime_obj.get("backend_kind") or "").strip()
+    if backend:
+        parts.append(f"backend={backend}")
+    capture_backend = str(runtime_obj.get("capture_backend_kind") or "").strip()
+    if capture_backend:
+        parts.append(f"capture_backend={capture_backend}")
+    capture_detail = str(runtime_obj.get("capture_backend_detail") or "").strip()
+    if capture_detail:
+        parts.append(f"capture_detail={capture_detail}")
+    if runtime_obj.get("stale_capture_backend"):
+        parts.append("stale_capture_backend=true")
+    same_frames = int(runtime_obj.get("consecutive_same_capture_frames") or 0)
+    if same_frames:
+        parts.append(f"same_capture_frames={same_frames}")
+    image_hash = str(runtime_obj.get("last_capture_image_hash") or "").strip()
+    if image_hash:
+        parts.append(f"capture_hash={image_hash}")
+    error = str(runtime_obj.get("last_capture_error") or "").strip()
+    if error:
+        parts.append(f"last_capture_error={error}")
+    raw_text = str(runtime_obj.get("last_raw_ocr_text") or "").strip()
+    if raw_text:
+        parts.append(f"last_raw_ocr_text={raw_text[:80]}")
+    profile = runtime_obj.get("capture_profile")
+    if profile:
+        parts.append(f"profile={profile}")
+    target = str(
+        runtime_obj.get("effective_process_name")
+        or runtime_obj.get("process_name")
+        or ""
+    ).strip()
+    if target:
+        parts.append(f"target={target}")
+    last_error = local_state.get("last_error")
+    if isinstance(last_error, dict) and str(last_error.get("message") or ""):
+        parts.append(f"last_error={str(last_error.get('message') or '')}")
+    return " | ".join(parts)
+
+
+def build_local_scene_summary(
+    *,
+    scene_id: str,
+    route_id: str,
+    lines: list[dict[str, Any]],
+    selected_choices: list[dict[str, Any]],
+    snapshot: dict[str, Any],
+) -> str:
+    normalized_snapshot = sanitize_snapshot_state(snapshot)
+    if lines:
+        recent_parts = []
+        for item in lines[-6:]:
+            speaker = str(item.get("speaker") or "旁白").strip() or "旁白"
+            text = str(item.get("text") or "").strip()
+            if text:
+                recent_parts.append(f"{speaker}：{text}")
+        summary = f"场景 {scene_id or '(unknown)'} 的近期上下文是："
+        summary += "；".join(recent_parts) if recent_parts else "暂时只有零散台词。"
+    elif normalized_snapshot.get("text"):
+        summary = (
+            f"场景 {scene_id or '(unknown)'} 目前停留在"
+            f"「{str(normalized_snapshot.get('speaker') or '旁白')}：{str(normalized_snapshot.get('text') or '')}」。"
+        )
+    else:
+        summary = f"场景 {scene_id or '(unknown)'} 暂时没有足够台词上下文。"
+    if route_id:
+        summary += f" 路线 {route_id}。"
+    if selected_choices:
+        summary += f" 已发生 {len(selected_choices)} 次选项确认。"
+    return summary
 
 
 def _snapshot_for_stable_summary_seed(
@@ -181,12 +418,12 @@ def _snapshot_for_stable_summary_seed(
 def build_explain_context(local_state: dict[str, Any], *, line_id: str) -> dict[str, Any]:
     """Build the prompt context used by the explain-line LLM operation."""
     snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
-    effective_line = _service.resolve_effective_current_line(local_state)
+    effective_line = resolve_effective_current_line(local_state)
     effective_line_id = line_id or str(
         (effective_line or {}).get("line_id") or snapshot.get("line_id") or ""
     )
     if not effective_line_id:
-        raise ValueError(_service.build_ocr_context_diagnostic(local_state))
+        raise ValueError(build_ocr_context_diagnostic(local_state))
 
     target_line = (
         dict(effective_line)
@@ -197,7 +434,7 @@ def build_explain_context(local_state: dict[str, Any], *, line_id: str) -> dict[
     if target_line is None:
         raise ValueError(
             f"unknown line_id: {effective_line_id}; "
-            f"{_service.build_ocr_context_diagnostic(local_state)}"
+            f"{build_ocr_context_diagnostic(local_state)}"
         )
 
     scene_id = str(target_line.get("scene_id") or snapshot.get("scene_id") or "")
@@ -216,7 +453,7 @@ def build_explain_context(local_state: dict[str, Any], *, line_id: str) -> dict[
     )
 
     evidence: list[dict[str, Any]] = []
-    snapshot_line = _service._current_line_entry(snapshot)
+    snapshot_line = _current_line_entry(snapshot)
     if snapshot_line and str(snapshot_line.get("line_id") or "") == effective_line_id:
         evidence.append(
             {
@@ -287,7 +524,7 @@ def build_summarize_context(
 ) -> dict[str, Any]:
     """Build the prompt context used by the summarize-scene LLM operation."""
     snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
-    effective_line = _service.resolve_effective_current_line(local_state)
+    effective_line = resolve_effective_current_line(local_state)
     effective_scene_id = scene_id or str(
         snapshot.get("scene_id") or (effective_line or {}).get("scene_id") or ""
     )
@@ -328,7 +565,7 @@ def build_summarize_context(
         "stable_lines": stable_lines,
         "observed_lines": observed_lines,
         "recent_choices": selected_choices,
-        "scene_summary_seed": _service.build_local_scene_summary(
+        "scene_summary_seed": build_local_scene_summary(
             scene_id=effective_scene_id,
             route_id=route_id,
             lines=stable_lines,
@@ -379,7 +616,7 @@ def build_suggest_context(local_state: dict[str, Any]) -> dict[str, Any]:
         "stable_lines": stable_lines,
         "observed_lines": observed_lines,
         "recent_choices": selected_choices,
-        "scene_summary": _service.build_local_scene_summary(
+        "scene_summary": build_local_scene_summary(
             scene_id=scene_id,
             route_id=route_id,
             lines=scene_lines,

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -1,0 +1,392 @@
+"""Context construction helpers for galgame LLM operations."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from . import service as _service
+from .models import (
+    DATA_SOURCE_BRIDGE_SDK,
+    DATA_SOURCE_MEMORY_READER,
+    DATA_SOURCE_OCR_READER,
+    sanitize_choice,
+    sanitize_snapshot_state,
+)
+
+
+def _scene_lines(
+    history_lines: list[dict[str, Any]],
+    scene_id: str,
+    *,
+    limit: int,
+    extra_scene_ids: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    if scene_id:
+        match_ids = {scene_id}
+        if extra_scene_ids:
+            match_ids.update(str(sid) for sid in extra_scene_ids if sid)
+        items = [
+            dict(item)
+            for item in history_lines
+            if str(item.get("scene_id") or "") in match_ids
+        ]
+    else:
+        items = [dict(item) for item in history_lines]
+    return items[-limit:]
+
+
+def _scene_selected_choices(
+    history_choices: list[dict[str, Any]],
+    scene_id: str,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    items = [
+        dict(item)
+        for item in history_choices
+        if str(item.get("action") or "") == "selected"
+        and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+    ]
+    return items[-limit:]
+
+
+def _dialogue_line_dedupe_key(item: dict[str, Any]) -> str:
+    text = re.sub(r"\s+", " ", str(item.get("text") or "")).strip()
+    if text:
+        return "::".join(
+            [
+                str(item.get("scene_id") or "").strip(),
+                str(item.get("speaker") or "").strip(),
+                text,
+            ]
+        )
+    return str(item.get("line_id") or "").strip()
+
+
+def _append_unique_line(
+    lines: list[dict[str, Any]],
+    line: dict[str, Any] | None,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    if not line:
+        return lines[-limit:]
+    normalized = dict(line)
+    target_key = _dialogue_line_dedupe_key(normalized)
+    exists = any(_dialogue_line_dedupe_key(item) == target_key for item in lines)
+    if exists:
+        return lines[-limit:]
+    merged = list(lines) + [normalized]
+    return merged[-limit:]
+
+
+def _dialogue_context_lines(lines: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
+    deduped: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    for item in lines:
+        if not _service._looks_like_game_dialogue_context_line(item):
+            continue
+        normalized = dict(item)
+        key = _dialogue_line_dedupe_key(normalized)
+        if not key:
+            continue
+        if key not in deduped:
+            order.append(key)
+        deduped[key] = normalized
+    return [deduped[key] for key in order][-limit:]
+
+
+def _is_memory_reader_identifier(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("mem:")
+
+
+def _is_ocr_reader_identifier(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("ocr:")
+
+
+def _build_input_degraded_context(
+    local_state: dict[str, Any],
+    *,
+    scene_id: str,
+    line_id: str,
+    choice_ids: list[str],
+) -> tuple[str, bool, list[str]]:
+    input_source = str(local_state.get("active_data_source") or DATA_SOURCE_BRIDGE_SDK)
+    reasons: list[str] = []
+    if input_source == DATA_SOURCE_MEMORY_READER:
+        reasons.append("memory_reader_source")
+    if input_source == DATA_SOURCE_OCR_READER:
+        reasons.append("ocr_reader_source")
+    if _is_memory_reader_identifier(scene_id):
+        reasons.append("memory_reader_scene")
+    if _is_ocr_reader_identifier(scene_id):
+        reasons.append("ocr_reader_scene")
+    if _is_memory_reader_identifier(line_id):
+        reasons.append("memory_reader_line")
+    if _is_ocr_reader_identifier(line_id):
+        reasons.append("ocr_reader_line")
+    if any(_is_memory_reader_identifier(choice_id) for choice_id in choice_ids):
+        reasons.append("memory_reader_choice")
+    if any(_is_ocr_reader_identifier(choice_id) for choice_id in choice_ids):
+        reasons.append("ocr_reader_choice")
+    return input_source, bool(reasons), reasons
+
+
+def _resolve_target_line(local_state: dict[str, Any], *, line_id: str) -> dict[str, Any] | None:
+    snapshot_line = _service._current_line_entry(local_state.get("latest_snapshot", {}))
+    if snapshot_line and str(snapshot_line.get("line_id") or "") == line_id:
+        return snapshot_line
+    for item in reversed(local_state.get("history_lines", [])):
+        if str(item.get("line_id") or "") == line_id:
+            return dict(item)
+    for item in reversed(local_state.get("history_observed_lines", [])):
+        if str(item.get("line_id") or "") == line_id:
+            return dict(item)
+    return None
+
+
+def _snapshot_for_stable_summary_seed(
+    local_state: dict[str, Any],
+    snapshot: dict[str, Any],
+    stable_lines: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if str(local_state.get("active_data_source") or "") != DATA_SOURCE_OCR_READER:
+        return snapshot
+    if str(snapshot.get("stability") or "") == "stable":
+        return snapshot
+    snapshot_line_id = str(snapshot.get("line_id") or "")
+    snapshot_text = str(snapshot.get("text") or "")
+    snapshot_speaker = str(snapshot.get("speaker") or "")
+    for line in stable_lines:
+        if not isinstance(line, dict):
+            continue
+        line_id = str(line.get("line_id") or "")
+        if snapshot_line_id and line_id and snapshot_line_id == line_id:
+            return snapshot
+        if (
+            snapshot_text
+            and snapshot_text == str(line.get("text") or "")
+            and snapshot_speaker == str(line.get("speaker") or "")
+        ):
+            return snapshot
+    seed_snapshot = dict(snapshot)
+    seed_snapshot["speaker"] = ""
+    seed_snapshot["text"] = ""
+    seed_snapshot["line_id"] = ""
+    seed_snapshot["stability"] = ""
+    return seed_snapshot
+
+
+def build_explain_context(local_state: dict[str, Any], *, line_id: str) -> dict[str, Any]:
+    """Build the prompt context used by the explain-line LLM operation."""
+    snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
+    effective_line = _service.resolve_effective_current_line(local_state)
+    effective_line_id = line_id or str(
+        (effective_line or {}).get("line_id") or snapshot.get("line_id") or ""
+    )
+    if not effective_line_id:
+        raise ValueError(_service.build_ocr_context_diagnostic(local_state))
+
+    target_line = (
+        dict(effective_line)
+        if effective_line is not None
+        and str(effective_line.get("line_id") or "") == effective_line_id
+        else _resolve_target_line(local_state, line_id=effective_line_id)
+    )
+    if target_line is None:
+        raise ValueError(
+            f"unknown line_id: {effective_line_id}; "
+            f"{_service.build_ocr_context_diagnostic(local_state)}"
+        )
+
+    scene_id = str(target_line.get("scene_id") or snapshot.get("scene_id") or "")
+    route_id = str(target_line.get("route_id") or snapshot.get("route_id") or "")
+    stable_lines = _scene_lines(local_state.get("history_lines", []), scene_id, limit=8)
+    observed_lines = _scene_lines(
+        local_state.get("history_observed_lines", []),
+        scene_id,
+        limit=8,
+    )
+    scene_lines = _append_unique_line([*stable_lines, *observed_lines], target_line, limit=8)
+    selected_choices = _scene_selected_choices(
+        local_state.get("history_choices", []),
+        scene_id,
+        limit=6,
+    )
+
+    evidence: list[dict[str, Any]] = []
+    snapshot_line = _service._current_line_entry(snapshot)
+    if snapshot_line and str(snapshot_line.get("line_id") or "") == effective_line_id:
+        evidence.append(
+            {
+                "type": "current_line",
+                "text": str(snapshot_line.get("text") or ""),
+                "line_id": effective_line_id,
+                "speaker": str(snapshot_line.get("speaker") or ""),
+                "scene_id": str(snapshot_line.get("scene_id") or ""),
+                "route_id": str(snapshot_line.get("route_id") or ""),
+            }
+        )
+    for item in scene_lines[-4:]:
+        if str(item.get("line_id") or "") == effective_line_id:
+            continue
+        evidence.append(
+            {
+                "type": "history_line",
+                "text": str(item.get("text") or ""),
+                "line_id": str(item.get("line_id") or ""),
+                "speaker": str(item.get("speaker") or ""),
+                "scene_id": str(item.get("scene_id") or ""),
+                "route_id": str(item.get("route_id") or ""),
+            }
+        )
+    for choice in selected_choices[-2:]:
+        evidence.append(
+            {
+                "type": "choice",
+                "text": str(choice.get("text") or ""),
+                "line_id": str(choice.get("line_id") or ""),
+                "speaker": "",
+                "scene_id": str(choice.get("scene_id") or ""),
+                "route_id": str(choice.get("route_id") or ""),
+            }
+        )
+    input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
+        local_state,
+        scene_id=scene_id,
+        line_id=effective_line_id,
+        choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
+    )
+
+    return {
+        "game_id": str(local_state.get("active_game_id") or ""),
+        "session_id": str(local_state.get("active_session_id") or ""),
+        "scene_id": scene_id,
+        "route_id": route_id,
+        "line_id": effective_line_id,
+        "speaker": str(target_line.get("speaker") or ""),
+        "text": str(target_line.get("text") or ""),
+        "current_snapshot": snapshot,
+        "recent_lines": scene_lines,
+        "stable_lines": stable_lines,
+        "observed_lines": observed_lines,
+        "recent_choices": selected_choices,
+        "evidence": evidence,
+        "input_source": input_source,
+        "input_degraded": input_degraded,
+        "degraded_reasons": degraded_reasons,
+    }
+
+
+def build_summarize_context(
+    local_state: dict[str, Any],
+    *,
+    scene_id: str,
+    merge_from_scene_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build the prompt context used by the summarize-scene LLM operation."""
+    snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
+    effective_line = _service.resolve_effective_current_line(local_state)
+    effective_scene_id = scene_id or str(
+        snapshot.get("scene_id") or (effective_line or {}).get("scene_id") or ""
+    )
+    route_id = str(snapshot.get("route_id") or (effective_line or {}).get("route_id") or "")
+    stable_lines = _scene_lines(
+        local_state.get("history_lines", []),
+        effective_scene_id,
+        limit=20,
+        extra_scene_ids=merge_from_scene_ids,
+    )
+    observed_lines = _scene_lines(
+        local_state.get("history_observed_lines", []),
+        effective_scene_id,
+        limit=20,
+        extra_scene_ids=merge_from_scene_ids,
+    )
+    stable_lines = _dialogue_context_lines(stable_lines, limit=20)
+    observed_lines = _dialogue_context_lines(observed_lines, limit=20)
+    scene_lines = _dialogue_context_lines([*stable_lines, *observed_lines], limit=20)
+    selected_choices = _scene_selected_choices(
+        local_state.get("history_choices", []),
+        effective_scene_id,
+        limit=12,
+    )
+    input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
+        local_state,
+        scene_id=effective_scene_id,
+        line_id=str(snapshot.get("line_id") or ""),
+        choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
+    )
+    return {
+        "game_id": str(local_state.get("active_game_id") or ""),
+        "session_id": str(local_state.get("active_session_id") or ""),
+        "scene_id": effective_scene_id,
+        "route_id": route_id,
+        "current_snapshot": snapshot,
+        "recent_lines": scene_lines,
+        "stable_lines": stable_lines,
+        "observed_lines": observed_lines,
+        "recent_choices": selected_choices,
+        "scene_summary_seed": _service.build_local_scene_summary(
+            scene_id=effective_scene_id,
+            route_id=route_id,
+            lines=stable_lines,
+            selected_choices=selected_choices,
+            snapshot=_snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines),
+        ),
+        "input_source": input_source,
+        "input_degraded": input_degraded,
+        "degraded_reasons": degraded_reasons,
+    }
+
+
+def build_suggest_context(local_state: dict[str, Any]) -> dict[str, Any]:
+    """Build the prompt context used by the suggest-choice LLM operation."""
+    snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
+    visible_choices = [sanitize_choice(item) for item in snapshot.get("choices", [])]
+    scene_id = str(snapshot.get("scene_id") or "")
+    route_id = str(snapshot.get("route_id") or "")
+    stable_lines = _scene_lines(local_state.get("history_lines", []), scene_id, limit=8)
+    observed_lines = _scene_lines(
+        local_state.get("history_observed_lines", []),
+        scene_id,
+        limit=8,
+    )
+    scene_lines = [*stable_lines, *observed_lines][-8:]
+    selected_choices = _scene_selected_choices(
+        local_state.get("history_choices", []),
+        scene_id,
+        limit=8,
+    )
+    input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
+        local_state,
+        scene_id=scene_id,
+        line_id=str(snapshot.get("line_id") or ""),
+        choice_ids=[
+            str(choice.get("choice_id") or "")
+            for choice in [*visible_choices, *selected_choices]
+        ],
+    )
+    return {
+        "game_id": str(local_state.get("active_game_id") or ""),
+        "session_id": str(local_state.get("active_session_id") or ""),
+        "scene_id": scene_id,
+        "route_id": route_id,
+        "current_snapshot": snapshot,
+        "visible_choices": visible_choices,
+        "recent_lines": scene_lines,
+        "stable_lines": stable_lines,
+        "observed_lines": observed_lines,
+        "recent_choices": selected_choices,
+        "scene_summary": _service.build_local_scene_summary(
+            scene_id=scene_id,
+            route_id=route_id,
+            lines=scene_lines,
+            selected_choices=selected_choices,
+            snapshot=snapshot,
+        ),
+        "input_source": input_source,
+        "input_degraded": input_degraded,
+        "degraded_reasons": degraded_reasons,
+    }

--- a/plugin/plugins/galgame_plugin/context_metrics.py
+++ b/plugin/plugins/galgame_plugin/context_metrics.py
@@ -1,0 +1,66 @@
+"""Lightweight in-memory metrics for galgame prompt context compaction."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ContextMetric:
+    """One prompt-context size sample recorded around an LLM request."""
+
+    operation: str
+    raw_tokens: int
+    compacted_tokens: int
+    raw_chars: int
+    compacted_chars: int
+    compression_level: int
+    cache_hit: bool
+    total_time_ms: float
+
+
+class ContextMetricsCollector:
+    """Bounded ring buffer and aggregate statistics for context metrics."""
+
+    def __init__(self, max_records: int = 500) -> None:
+        self._records: deque[ContextMetric] = deque(maxlen=max(1, int(max_records)))
+
+    def record(self, metric: ContextMetric) -> None:
+        """Append one metric, evicting the oldest item when the buffer is full."""
+        self._records.append(metric)
+
+    def records(self) -> list[ContextMetric]:
+        """Return a stable snapshot of buffered metrics."""
+        return list(self._records)
+
+    def summary_stats(self) -> dict[str, dict[str, Any]]:
+        """Return average size and cache-hit statistics grouped by operation."""
+        grouped: dict[str, list[ContextMetric]] = {}
+        for metric in list(self._records):
+            grouped.setdefault(metric.operation, []).append(metric)
+
+        summary: dict[str, dict[str, Any]] = {}
+        for operation, records in grouped.items():
+            count = len(records)
+            if count == 0:
+                continue
+            cache_hits = sum(1 for item in records if item.cache_hit)
+            summary[operation] = {
+                "count": count,
+                "avg_raw_tokens": sum(item.raw_tokens for item in records) / count,
+                "avg_compacted_tokens": (
+                    sum(item.compacted_tokens for item in records) / count
+                ),
+                "avg_raw_chars": sum(item.raw_chars for item in records) / count,
+                "avg_compacted_chars": sum(item.compacted_chars for item in records)
+                / count,
+                "avg_compression_level": (
+                    sum(item.compression_level for item in records) / count
+                ),
+                "cache_hits": cache_hits,
+                "cache_hit_rate": cache_hits / count,
+                "avg_total_time_ms": sum(item.total_time_ms for item in records) / count,
+            }
+        return summary

--- a/plugin/plugins/galgame_plugin/context_tokens.py
+++ b/plugin/plugins/galgame_plugin/context_tokens.py
@@ -1,0 +1,44 @@
+"""Heuristic token estimates for galgame prompt context budgeting."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+
+def _is_cjk(ch: str) -> bool:
+    code = ord(ch)
+    return (
+        0x3400 <= code <= 0x4DBF
+        or 0x4E00 <= code <= 0x9FFF
+        or 0xF900 <= code <= 0xFAFF
+        or 0x3040 <= code <= 0x30FF
+        or 0xAC00 <= code <= 0xD7AF
+    )
+
+
+def count_tokens_heuristic(text: str) -> int:
+    """Estimate token count from character classes without external tokenizers.
+
+    The weights intentionally bias CJK and non-ASCII text upward for prompt
+    safety: CJK characters count as about 1.5 tokens, ASCII as about 0.25
+    tokens, and other Unicode characters as 1 token.
+    """
+    if not text:
+        return 0
+    total = 0.0
+    for ch in text:
+        if _is_cjk(ch):
+            total += 1.5
+        elif ord(ch) < 128:
+            total += 0.25
+        else:
+            total += 1.0
+    return int(math.ceil(total))
+
+
+def estimate_context_tokens(context: dict[str, Any]) -> int:
+    """Estimate tokens for a context dict using the prompt JSON representation."""
+    rendered = json.dumps(context, ensure_ascii=False, indent=2, default=str)
+    return count_tokens_heuristic(rendered)

--- a/plugin/plugins/galgame_plugin/llm_backend.py
+++ b/plugin/plugins/galgame_plugin/llm_backend.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import ContextVar
 import hashlib
+import logging
 import re
 from typing import Any, Protocol
 
 from plugin.sdk.plugin import SdkError
 
-from .llm_prompts import build_prompt_messages
+from .llm_prompts import build_prompt_messages_with_metadata
 from utils.config_manager import get_config_manager
 from utils.file_utils import robust_json_loads
 from utils.llm_client import ChatOpenAI, create_chat_llm
@@ -24,6 +26,10 @@ _JSON_CORRECTION_BAD_OUTPUT_MAX_CHARS = 12000
 _JSON_CORRECTION_ERROR_MAX_CHARS = 600
 _LLM_CALL_MAX_ATTEMPTS = 3
 _LLM_CALL_RETRY_BASE_DELAY_SECONDS = 0.25
+_PROMPT_METADATA: ContextVar[dict[str, Any] | None] = ContextVar(
+    "galgame_prompt_metadata",
+    default=None,
+)
 
 
 class LoggerLike(Protocol):
@@ -215,6 +221,11 @@ class GalgameLLMBackend:
             except Exception:
                 pass
 
+    def consume_prompt_metadata(self) -> dict[str, Any]:
+        metadata = _PROMPT_METADATA.get()
+        _PROMPT_METADATA.set(None)
+        return dict(metadata) if isinstance(metadata, dict) else {}
+
     async def shutdown(self) -> None:
         async with self._cache_lock():
             llms = list(self._llm_cache.values())
@@ -314,7 +325,7 @@ class GalgameLLMBackend:
             {
                 "role": "user",
                 "content": (
-                    f"JSON correction request {attempt}/{max_attempts}, operation={operation}.\n"
+                    f"JSON 修正请求 {attempt}/{max_attempts}, operation={operation}.\n"
                     f"Parse error: {bounded_error}\n"
                     "Your last response was not a valid JSON object. "
                     "Reply with ONLY a valid JSON object — "
@@ -403,7 +414,10 @@ class GalgameLLMBackend:
                         exc,
                     )
                 except Exception:
-                    pass
+                    logging.getLogger(__name__).warning(
+                        "galgame logger.warning failed during LLM retry logging",
+                        exc_info=True,
+                    )
                 await asyncio.sleep(delay)
         raise last_exc or RuntimeError("galgame LLM call failed")
 
@@ -437,7 +451,9 @@ class GalgameLLMBackend:
         operation: str,
         context: dict[str, Any],
     ) -> list[dict[str, str]]:
-        return build_prompt_messages(operation, context)
+        result = build_prompt_messages_with_metadata(operation, context, self._config)
+        _PROMPT_METADATA.set(dict(result.metadata))
+        return result.messages
 
     def _parse_json_object(self, raw_text: str) -> dict[str, Any]:
         text = _strip_code_fences(raw_text)

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -87,11 +87,14 @@ class LLMGateway:
         self._context_metrics: ContextMetricsCollector | None = None
 
     def update_config(self, config) -> None:
+        old_cache_config_fingerprint = self._cache_config_fingerprint()
         self._config = config
         if not self._metrics_enabled():
             self._context_metrics = None
         if hasattr(self._backend, "_config"):
             self._backend._config = config
+        if self._cache_config_fingerprint() != old_cache_config_fingerprint:
+            self._cache.clear()
 
     @property
     def context_metrics(self) -> ContextMetricsCollector | None:
@@ -209,7 +212,11 @@ class LLMGateway:
         degraded: Callable[[str], dict[str, Any]],
     ) -> dict[str, Any]:
         self._ensure_loop_affinity()
-        fingerprint = self._cache_fingerprint(operation, context)
+        fingerprint = self._cache_fingerprint(
+            operation,
+            context,
+            self._cache_config_fingerprint(),
+        )
         provider_key = self._provider_backoff_key()
         now = time.monotonic()
         start_time = now
@@ -267,9 +274,33 @@ class LLMGateway:
         except asyncio.CancelledError:
             return degraded("cancelled: llm request was cancelled")
 
+    def _cache_config_fingerprint(self) -> str:
+        mode = str(
+            getattr(self._config, "context_counting_mode", "char") or "char"
+        ).strip().lower()
+        if mode != "token":
+            return _stable_json_fingerprint({"context_counting_mode": "char"})
+        try:
+            budget = int(getattr(self._config, "context_max_tokens", 6000))
+        except (TypeError, ValueError):
+            budget = 6000
+        return _stable_json_fingerprint(
+            {
+                "context_counting_mode": "token",
+                "context_max_tokens": max(1, budget),
+            }
+        )
+
     @staticmethod
-    def _cache_fingerprint(operation: str, context: dict[str, Any]) -> str:
-        return f"{operation}:{_stable_json_fingerprint(context)}"
+    def _cache_fingerprint(
+        operation: str,
+        context: dict[str, Any],
+        config_fingerprint: str = "",
+    ) -> str:
+        return (
+            f"{operation}:{config_fingerprint}:"
+            f"{_stable_json_fingerprint(context)}"
+        )
 
     async def _perform_call(
         self,

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Mapping
 from plugin.sdk.shared.models import Err
 
 from .context_metrics import ContextMetric, ContextMetricsCollector
-from .context_tokens import estimate_context_tokens
+from .context_tokens import count_tokens_heuristic
 from .llm_backend import GalgameLLMBackend
 from .models import json_copy
 from .service import (
@@ -214,46 +214,53 @@ class LLMGateway:
         now = time.monotonic()
         start_time = now
         wait_task: asyncio.Task[dict[str, Any]] | None = None
+        cached_payload: dict[str, Any] | None = None
+        cached_prompt_metadata: dict[str, Any] | None = None
 
         async with self._lock:
             cached = self._cache.get(fingerprint)
             if cached is not None and cached[0] > now:
                 self._cache.move_to_end(fingerprint)
-                self._record_context_metric(
-                    operation=operation,
-                    context=context,
-                    prompt_metadata=cached[2],
-                    cache_hit=True,
-                    total_time_ms=(time.monotonic() - start_time) * 1000.0,
-                )
-                return _json_payload_copy(cached[1])
-            if cached is not None:
+                cached_payload = cached[1]
+                cached_prompt_metadata = cached[2]
+            elif cached is not None:
                 self._cache.pop(fingerprint, None)
 
-            backoff = self._active_provider_backoff_locked(provider_key, now=now)
-            if backoff is not None:
-                _category, diagnostic = backoff
-                return degraded(diagnostic)
+            if cached_payload is None:
+                backoff = self._active_provider_backoff_locked(provider_key, now=now)
+                if backoff is not None:
+                    _category, diagnostic = backoff
+                    return degraded(diagnostic)
 
-            in_flight = self._inflight.get(fingerprint)
-            if in_flight is not None:
-                wait_task = in_flight
-            else:
-                if self._active_calls >= int(self._config.llm_max_in_flight):
-                    return degraded("busy: throttled by llm_max_in_flight")
+                in_flight = self._inflight.get(fingerprint)
+                if in_flight is not None:
+                    wait_task = in_flight
+                else:
+                    if self._active_calls >= int(self._config.llm_max_in_flight):
+                        return degraded("busy: throttled by llm_max_in_flight")
 
-                self._active_calls += 1
-                wait_task = asyncio.create_task(
-                    self._perform_call(
-                        fingerprint=fingerprint,
-                        provider_key=provider_key,
-                        operation=operation,
-                        context=context,
-                        validate=validate,
-                        degraded=degraded,
+                    self._active_calls += 1
+                    wait_task = asyncio.create_task(
+                        self._perform_call(
+                            fingerprint=fingerprint,
+                            provider_key=provider_key,
+                            operation=operation,
+                            context=context,
+                            validate=validate,
+                            degraded=degraded,
+                        )
                     )
-                )
-                self._inflight[fingerprint] = wait_task
+                    self._inflight[fingerprint] = wait_task
+
+        if cached_payload is not None:
+            self._record_context_metric(
+                operation=operation,
+                context=context,
+                prompt_metadata=cached_prompt_metadata or {},
+                cache_hit=True,
+                total_time_ms=(time.monotonic() - start_time) * 1000.0,
+            )
+            return _json_payload_copy(cached_payload)
 
         try:
             return _json_payload_copy(await wait_task)
@@ -354,15 +361,18 @@ class LLMGateway:
     def _metadata_int(
         metadata: dict[str, Any],
         key: str,
-        fallback: int,
+        fallback: int | Callable[[], int],
     ) -> int:
+        def fallback_value() -> int:
+            return fallback() if callable(fallback) else fallback
+
         value = metadata.get(key)
         if value is None:
-            return fallback
+            return fallback_value()
         try:
             return int(value)
         except (TypeError, ValueError):
-            return fallback
+            return fallback_value()
 
     def _record_context_metric(
         self,
@@ -376,13 +386,25 @@ class LLMGateway:
         collector = self._metrics_collector()
         if collector is None:
             return
-        raw_text = json.dumps(context, ensure_ascii=False, indent=2, default=str)
+
+        raw_text: str | None = None
+
+        def rendered_context() -> str:
+            nonlocal raw_text
+            if raw_text is None:
+                raw_text = json.dumps(context, ensure_ascii=False, indent=2, default=str)
+            return raw_text
+
         raw_tokens = self._metadata_int(
             prompt_metadata,
             "raw_tokens",
-            estimate_context_tokens(context),
+            lambda: count_tokens_heuristic(rendered_context()),
         )
-        raw_chars = self._metadata_int(prompt_metadata, "raw_chars", len(raw_text))
+        raw_chars = self._metadata_int(
+            prompt_metadata,
+            "raw_chars",
+            lambda: len(rendered_context()),
+        )
         compacted_tokens = self._metadata_int(
             prompt_metadata,
             "compacted_tokens",

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -10,6 +10,8 @@ from typing import Any, Callable, Mapping
 
 from plugin.sdk.shared.models import Err
 
+from .context_metrics import ContextMetric, ContextMetricsCollector
+from .context_tokens import estimate_context_tokens
 from .llm_backend import GalgameLLMBackend
 from .models import json_copy
 from .service import (
@@ -79,14 +81,31 @@ class LLMGateway:
         self._runtime_loop: asyncio.AbstractEventLoop | None = None
         self._lock: asyncio.Lock | None = None
         self._inflight: dict[str, asyncio.Task[dict[str, Any]]] = {}
-        self._cache: OrderedDict[str, tuple[float, dict[str, Any]]] = OrderedDict()
+        self._cache: OrderedDict[str, tuple[float, dict[str, Any], dict[str, Any]]] = OrderedDict()
         self._provider_backoff: dict[tuple[str, str], tuple[float, str]] = {}
         self._active_calls = 0
+        self._context_metrics: ContextMetricsCollector | None = None
 
     def update_config(self, config) -> None:
         self._config = config
+        if not self._metrics_enabled():
+            self._context_metrics = None
         if hasattr(self._backend, "_config"):
             self._backend._config = config
+
+    @property
+    def context_metrics(self) -> ContextMetricsCollector | None:
+        return getattr(self, "_context_metrics", None)
+
+    def _metrics_enabled(self) -> bool:
+        return bool(getattr(self._config, "context_metrics_enabled", False))
+
+    def _metrics_collector(self) -> ContextMetricsCollector | None:
+        if not self._metrics_enabled():
+            return None
+        if getattr(self, "_context_metrics", None) is None:
+            self._context_metrics = ContextMetricsCollector()
+        return self._context_metrics
 
     def _ensure_loop_affinity(self) -> None:
         loop = asyncio.get_running_loop()
@@ -193,12 +212,20 @@ class LLMGateway:
         fingerprint = self._cache_fingerprint(operation, context)
         provider_key = self._provider_backoff_key()
         now = time.monotonic()
+        start_time = now
         wait_task: asyncio.Task[dict[str, Any]] | None = None
 
         async with self._lock:
             cached = self._cache.get(fingerprint)
             if cached is not None and cached[0] > now:
                 self._cache.move_to_end(fingerprint)
+                self._record_context_metric(
+                    operation=operation,
+                    context=context,
+                    prompt_metadata=cached[2],
+                    cache_hit=True,
+                    total_time_ms=(time.monotonic() - start_time) * 1000.0,
+                )
                 return _json_payload_copy(cached[1])
             if cached is not None:
                 self._cache.pop(fingerprint, None)
@@ -247,6 +274,8 @@ class LLMGateway:
         validate: Callable[[dict[str, Any]], dict[str, Any]],
         degraded: Callable[[str], dict[str, Any]],
     ) -> dict[str, Any]:
+        start_time = time.monotonic()
+        prompt_metadata: dict[str, Any] = {}
         try:
             result = await self._call_target(
                 operation=operation,
@@ -254,6 +283,8 @@ class LLMGateway:
                 validate=validate,
                 degraded=degraded,
             )
+            prompt_metadata = self._consume_backend_prompt_metadata()
+            total_time_ms = (time.monotonic() - start_time) * 1000.0
             if operation in {"scene_summary", "summarize_scene"}:
                 ttl = max(
                     0.0,
@@ -274,15 +305,107 @@ class LLMGateway:
                     now=time.monotonic(),
                 )
                 if ttl > 0 and not result.get("degraded"):
-                    self._cache[fingerprint] = (time.monotonic() + ttl, _json_payload_copy(result))
+                    self._cache[fingerprint] = (
+                        time.monotonic() + ttl,
+                        _json_payload_copy(result),
+                        dict(prompt_metadata),
+                    )
                     self._cache.move_to_end(fingerprint)
                     while len(self._cache) > _LLM_RESPONSE_CACHE_MAX_ITEMS:
                         self._cache.popitem(last=False)
+            self._record_context_metric(
+                operation=operation,
+                context=context,
+                prompt_metadata=prompt_metadata,
+                cache_hit=False,
+                total_time_ms=total_time_ms,
+            )
             return result
         finally:
             async with self._lock:
                 self._inflight.pop(fingerprint, None)
                 self._active_calls = max(0, self._active_calls - 1)
+
+    def _consume_backend_prompt_metadata(self) -> dict[str, Any]:
+        consume = getattr(self._backend, "consume_prompt_metadata", None)
+        if not callable(consume):
+            return {}
+        try:
+            metadata = consume()
+        except Exception as exc:
+            self._log_warning("galgame prompt metadata consume failed: {}", exc)
+            return {}
+        return dict(metadata) if isinstance(metadata, dict) else {}
+
+    def _log_warning(self, message: str, *args: Any) -> None:
+        logger = getattr(self, "_logger", None)
+        warning = getattr(logger, "warning", None)
+        if not callable(warning):
+            return
+        try:
+            warning(message, *args)
+        except Exception:
+            logging.getLogger(__name__).warning(
+                "galgame logger.warning failed",
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _metadata_int(
+        metadata: dict[str, Any],
+        key: str,
+        fallback: int,
+    ) -> int:
+        value = metadata.get(key)
+        if value is None:
+            return fallback
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return fallback
+
+    def _record_context_metric(
+        self,
+        *,
+        operation: str,
+        context: dict[str, Any],
+        prompt_metadata: dict[str, Any],
+        cache_hit: bool,
+        total_time_ms: float,
+    ) -> None:
+        collector = self._metrics_collector()
+        if collector is None:
+            return
+        raw_text = json.dumps(context, ensure_ascii=False, indent=2, default=str)
+        raw_tokens = self._metadata_int(
+            prompt_metadata,
+            "raw_tokens",
+            estimate_context_tokens(context),
+        )
+        raw_chars = self._metadata_int(prompt_metadata, "raw_chars", len(raw_text))
+        compacted_tokens = self._metadata_int(
+            prompt_metadata,
+            "compacted_tokens",
+            raw_tokens,
+        )
+        compacted_chars = self._metadata_int(
+            prompt_metadata,
+            "compacted_chars",
+            raw_chars,
+        )
+        compression_level = self._metadata_int(prompt_metadata, "compression_level", 0)
+        collector.record(
+            ContextMetric(
+                operation=operation,
+                raw_tokens=raw_tokens,
+                compacted_tokens=compacted_tokens,
+                raw_chars=raw_chars,
+                compacted_chars=compacted_chars,
+                compression_level=compression_level,
+                cache_hit=cache_hit,
+                total_time_ms=max(0.0, float(total_time_ms)),
+            )
+        )
 
     def _provider_backoff_key(self) -> str:
         target_entry_ref = str(self._config.llm_target_entry_ref or "").strip()

--- a/plugin/plugins/galgame_plugin/llm_prompts.py
+++ b/plugin/plugins/galgame_plugin/llm_prompts.py
@@ -1,9 +1,34 @@
+"""Prompt construction and context budgeting for galgame LLM calls."""
+
 from __future__ import annotations
 
 import json
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .context_tokens import estimate_context_tokens
 
 _PROMPT_CONTEXT_MAX_CHARS = 12000
+_PROMPT_CONTEXT_DEFAULT_MAX_TOKENS = 6000
+_PROMPT_COMPACTION_LEVELS = (
+    # (list items kept, max string chars, max dict keys) for the legacy 3-level compactor.
+    (16, 1000, 64),
+    (8, 500, 32),
+    (4, 240, 16),
+)
+
+
+class PromptBudgetConfig(Protocol):
+    context_counting_mode: str
+    context_max_tokens: int
+
+
+@dataclass(frozen=True, slots=True)
+class PromptContextResult:
+    """Rendered context plus size metadata used by gateway metrics."""
+
+    text: str
+    metadata: dict[str, Any]
 
 
 def _json_dump(value: object) -> str:
@@ -61,14 +86,42 @@ def _compact_prompt_value(
     return value
 
 
-def _context_json_for_prompt(context: dict[str, Any]) -> str:
+def _context_budget(config: PromptBudgetConfig | None) -> tuple[str, int]:
+    mode = str(getattr(config, "context_counting_mode", "char") or "char").strip().lower()
+    if mode != "token":
+        return "char", _PROMPT_CONTEXT_MAX_CHARS
+    try:
+        budget = int(getattr(config, "context_max_tokens", _PROMPT_CONTEXT_DEFAULT_MAX_TOKENS))
+    except (TypeError, ValueError):
+        budget = _PROMPT_CONTEXT_DEFAULT_MAX_TOKENS
+    return "token", max(1, budget)
+
+
+def _context_json_result_for_prompt(
+    context: dict[str, Any],
+    config: PromptBudgetConfig | None = None,
+) -> PromptContextResult:
+    mode, budget = _context_budget(config)
     raw = _json_dump(context)
-    if len(raw) <= _PROMPT_CONTEXT_MAX_CHARS:
-        return raw
-    for list_limit, string_limit, dict_key_limit in (
-        (16, 1000, 64),
-        (8, 500, 32),
-        (4, 240, 16),
+    raw_chars = len(raw)
+    raw_tokens = estimate_context_tokens(context)
+    raw_size = raw_tokens if mode == "token" else raw_chars
+    if raw_size <= budget:
+        return PromptContextResult(
+            text=raw,
+            metadata={
+                "counting_mode": mode,
+                "budget": budget,
+                "raw_tokens": raw_tokens,
+                "compacted_tokens": raw_tokens,
+                "raw_chars": raw_chars,
+                "compacted_chars": raw_chars,
+                "compression_level": 0,
+            },
+        )
+    for compression_level, (list_limit, string_limit, dict_key_limit) in enumerate(
+        _PROMPT_COMPACTION_LEVELS,
+        start=1,
     ):
         compact = _compact_prompt_value(
             context,
@@ -79,14 +132,43 @@ def _context_json_for_prompt(context: dict[str, Any]) -> str:
         if isinstance(compact, dict):
             compact = {"_prompt_truncated": True, **compact}
         rendered = _json_dump(compact)
-        if len(rendered) <= _PROMPT_CONTEXT_MAX_CHARS:
-            return rendered
-    excerpt = raw[: max(0, _PROMPT_CONTEXT_MAX_CHARS - 200)]
-    return _json_dump(
-        {
-            "_prompt_truncated": True,
-            "context_excerpt": f"{excerpt}\n...[truncated {len(raw) - len(excerpt)} chars]",
-        }
+        compacted_tokens = estimate_context_tokens(compact if isinstance(compact, dict) else {})
+        rendered_size = compacted_tokens if mode == "token" else len(rendered)
+        if rendered_size <= budget:
+            return PromptContextResult(
+                text=rendered,
+                metadata={
+                    "counting_mode": mode,
+                    "budget": budget,
+                    "raw_tokens": raw_tokens,
+                    "compacted_tokens": compacted_tokens,
+                    "raw_chars": raw_chars,
+                    "compacted_chars": len(rendered),
+                    "compression_level": compression_level,
+                },
+            )
+    excerpt_limit = (
+        max(0, _PROMPT_CONTEXT_MAX_CHARS - 200)
+        if mode == "char"
+        else max(0, budget * 4 - 200)
+    )
+    excerpt = raw[:excerpt_limit]
+    fallback = {
+        "_prompt_truncated": True,
+        "context_excerpt": f"{excerpt}\n...[truncated {len(raw) - len(excerpt)} chars]",
+    }
+    rendered = _json_dump(fallback)
+    return PromptContextResult(
+        text=rendered,
+        metadata={
+            "counting_mode": mode,
+            "budget": budget,
+            "raw_tokens": raw_tokens,
+            "compacted_tokens": estimate_context_tokens(fallback),
+            "raw_chars": raw_chars,
+            "compacted_chars": len(rendered),
+            "compression_level": len(_PROMPT_COMPACTION_LEVELS) + 1,
+        },
     )
 
 
@@ -221,14 +303,36 @@ _EXAMPLES = {
 
 
 def build_prompt_messages(operation: str, context: dict[str, Any]) -> list[dict[str, str]]:
+    """Build chat messages for an operation without exposing metadata."""
+    return build_prompt_messages_with_metadata(operation, context).messages
+
+
+@dataclass(frozen=True, slots=True)
+class PromptMessagesResult:
+    """Prompt messages plus context-size metadata from prompt construction."""
+
+    messages: list[dict[str, str]]
+    metadata: dict[str, Any]
+
+
+def build_prompt_messages_with_metadata(
+    operation: str,
+    context: dict[str, Any],
+    config: PromptBudgetConfig | None = None,
+) -> PromptMessagesResult:
+    """Build chat messages and return prompt context metadata for telemetry."""
     system_prompt = _SYSTEM_PROMPTS[operation]
+    context_result = _context_json_result_for_prompt(context, config)
     user_prompt = (
         _USER_PROMPT_PREFIXES[operation]
         + f"{_json_dump(_EXAMPLES[operation])}\n\n"
         + "context:\n"
-        + _context_json_for_prompt(context)
+        + context_result.text
     )
-    return [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": user_prompt},
-    ]
+    return PromptMessagesResult(
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        metadata=dict(context_result.metadata),
+    )

--- a/plugin/plugins/galgame_plugin/llm_prompts.py
+++ b/plugin/plugins/galgame_plugin/llm_prompts.py
@@ -97,6 +97,58 @@ def _context_budget(config: PromptBudgetConfig | None) -> tuple[str, int]:
     return "token", max(1, budget)
 
 
+def _fallback_context_from_excerpt(raw: str, excerpt: str) -> dict[str, Any]:
+    return {
+        "_prompt_truncated": True,
+        "context_excerpt": f"{excerpt}\n...[truncated {len(raw) - len(excerpt)} chars]",
+    }
+
+
+def _token_budgeted_fallback_context(raw: str, budget: int) -> dict[str, Any]:
+    """Build a hard fallback whose full rendered JSON fits the token budget.
+
+    The old token-mode fallback used ``budget * 4`` as a one-shot char
+    estimate. That under-counted CJK-heavy excerpts because the wrapper JSON
+    itself was never re-measured. Measure the complete fallback object instead
+    and shrink the excerpt until the final rendered JSON is within budget. If
+    the configured budget is too small to fit even the marker JSON, preserve the
+    explicit truncation payload rather than returning an ambiguous empty object.
+    """
+    initial_limit = min(len(raw), max(0, budget * 4 - 200))
+    candidate = _fallback_context_from_excerpt(raw, raw[:initial_limit])
+    if estimate_context_tokens(candidate) <= budget:
+        return candidate
+
+    best_excerpt: str | None = None
+    low = 0
+    high = initial_limit
+    while low <= high:
+        mid = (low + high) // 2
+        excerpt = raw[:mid]
+        candidate = _fallback_context_from_excerpt(raw, excerpt)
+        if estimate_context_tokens(candidate) <= budget:
+            best_excerpt = excerpt
+            low = mid + 1
+        else:
+            high = mid - 1
+
+    if best_excerpt is None:
+        # Extremely small budgets cannot fit even the marker JSON. Preserve the
+        # public contract that fallback payloads are explicit about truncation.
+        return _fallback_context_from_excerpt(raw, "")
+
+    # The omitted-char suffix changes as the excerpt length changes. Binary
+    # search should already be within budget, but keep a defensive trim loop so
+    # future suffix changes cannot leak past the token cap.
+    best = _fallback_context_from_excerpt(raw, best_excerpt)
+    while estimate_context_tokens(best) > budget:
+        if not best_excerpt:
+            break
+        best_excerpt = best_excerpt[:-1]
+        best = _fallback_context_from_excerpt(raw, best_excerpt)
+    return best
+
+
 def _context_json_result_for_prompt(
     context: dict[str, Any],
     config: PromptBudgetConfig | None = None,
@@ -147,16 +199,12 @@ def _context_json_result_for_prompt(
                     "compression_level": compression_level,
                 },
             )
-    excerpt_limit = (
-        max(0, _PROMPT_CONTEXT_MAX_CHARS - 200)
-        if mode == "char"
-        else max(0, budget * 4 - 200)
-    )
-    excerpt = raw[:excerpt_limit]
-    fallback = {
-        "_prompt_truncated": True,
-        "context_excerpt": f"{excerpt}\n...[truncated {len(raw) - len(excerpt)} chars]",
-    }
+    if mode == "token":
+        fallback = _token_budgeted_fallback_context(raw, budget)
+    else:
+        excerpt_limit = max(0, _PROMPT_CONTEXT_MAX_CHARS - 200)
+        excerpt = raw[:excerpt_limit]
+        fallback = _fallback_context_from_excerpt(raw, excerpt)
     rendered = _json_dump(fallback)
     return PromptContextResult(
         text=rendered,

--- a/plugin/plugins/galgame_plugin/models.py
+++ b/plugin/plugins/galgame_plugin/models.py
@@ -520,6 +520,9 @@ class GalgameLLMConfig:
     llm_temperature_default: float = 0.0
     llm_max_tokens_agent_reply: int = 900
     llm_max_tokens_default: int = 1200
+    context_max_tokens: int = 6000
+    context_metrics_enabled: bool = False
+    context_counting_mode: str = "char"
 
 
 @dataclass(slots=True)
@@ -642,6 +645,9 @@ class GalgameConfig:
         "llm_temperature_default": ("llm", "llm_temperature_default"),
         "llm_max_tokens_agent_reply": ("llm", "llm_max_tokens_agent_reply"),
         "llm_max_tokens_default": ("llm", "llm_max_tokens_default"),
+        "context_max_tokens": ("llm", "context_max_tokens"),
+        "context_metrics_enabled": ("llm", "context_metrics_enabled"),
+        "context_counting_mode": ("llm", "context_counting_mode"),
         "reader_mode": ("reader", "reader_mode"),
         "memory_reader_enabled": ("memory_reader", "memory_reader_enabled"),
         "memory_reader_textractor_path": ("memory_reader", "memory_reader_textractor_path"),

--- a/plugin/plugins/galgame_plugin/plugin.toml
+++ b/plugin/plugins/galgame_plugin/plugin.toml
@@ -59,6 +59,9 @@ temperature_agent_reply = 0.2
 temperature_default = 0.0
 max_tokens_agent_reply = 900
 max_tokens_default = 1200
+context_max_tokens = 6000
+context_counting_mode = "char"
+context_metrics_enabled = false
 
 [memory_reader]
 textractor_path = ""

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -541,6 +541,13 @@ def _coerce_reader_mode(value: object, default: str = READER_MODE_AUTO) -> str:
     return default
 
 
+def _coerce_context_counting_mode(value: object, default: str = "char") -> str:
+    normalized = str(value or default).strip().lower()
+    if normalized in {"char", "token"}:
+        return normalized
+    return default
+
+
 def _default_bridge_root_raw() -> str:
     if sys.platform.startswith("win"):
         return "%LOCALAPPDATA%/N.E.K.O/galgame-bridge"
@@ -658,6 +665,15 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
         ),
         llm_max_tokens_default=_coerce_int(
             llm_obj.get("max_tokens_default"), 1200, minimum=1
+        ),
+        context_max_tokens=_coerce_int(
+            llm_obj.get("context_max_tokens"), 6000, minimum=1
+        ),
+        context_metrics_enabled=_coerce_bool(
+            llm_obj.get("context_metrics_enabled"), False
+        ),
+        context_counting_mode=_coerce_context_counting_mode(
+            llm_obj.get("context_counting_mode")
         ),
         reader_mode=_coerce_reader_mode(galgame_obj.get("reader_mode")),
         memory_reader_enabled=_coerce_bool(
@@ -2772,124 +2788,6 @@ def build_ocr_context_diagnostic(local_state: dict[str, Any]) -> str:
     return " | ".join(parts)
 
 
-def _scene_lines(
-    history_lines: list[dict[str, Any]],
-    scene_id: str,
-    *,
-    limit: int,
-    extra_scene_ids: list[str] | None = None,
-) -> list[dict[str, Any]]:
-    if scene_id:
-        match_ids = {scene_id}
-        if extra_scene_ids:
-            match_ids.update(str(sid) for sid in extra_scene_ids if sid)
-        items = [
-            dict(item)
-            for item in history_lines
-            if str(item.get("scene_id") or "") in match_ids
-        ]
-    else:
-        items = [dict(item) for item in history_lines]
-    return items[-limit:]
-
-
-def _scene_selected_choices(
-    history_choices: list[dict[str, Any]],
-    scene_id: str,
-    *,
-    limit: int,
-) -> list[dict[str, Any]]:
-    items = [
-        dict(item)
-        for item in history_choices
-        if str(item.get("action") or "") == "selected"
-        and (not scene_id or str(item.get("scene_id") or "") == scene_id)
-    ]
-    return items[-limit:]
-
-
-def _append_unique_line(
-    lines: list[dict[str, Any]],
-    line: dict[str, Any] | None,
-    *,
-    limit: int,
-) -> list[dict[str, Any]]:
-    if not line:
-        return lines[-limit:]
-    normalized = dict(line)
-    target_key = _dialogue_line_dedupe_key(normalized)
-    exists = any(_dialogue_line_dedupe_key(item) == target_key for item in lines)
-    if exists:
-        return lines[-limit:]
-    merged = list(lines) + [normalized]
-    return merged[-limit:]
-
-
-def _dialogue_line_dedupe_key(item: dict[str, Any]) -> str:
-    text = re.sub(r"\s+", " ", str(item.get("text") or "")).strip()
-    if text:
-        return "::".join(
-            [
-                str(item.get("scene_id") or "").strip(),
-                str(item.get("speaker") or "").strip(),
-                text,
-            ]
-        )
-    return str(item.get("line_id") or "").strip()
-
-
-def _dialogue_context_lines(lines: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
-    deduped: dict[str, dict[str, Any]] = {}
-    order: list[str] = []
-    for item in lines:
-        if not _looks_like_game_dialogue_context_line(item):
-            continue
-        normalized = dict(item)
-        key = _dialogue_line_dedupe_key(normalized)
-        if not key:
-            continue
-        if key not in deduped:
-            order.append(key)
-        deduped[key] = normalized
-    return [deduped[key] for key in order][-limit:]
-
-
-def _is_memory_reader_identifier(value: object) -> bool:
-    return isinstance(value, str) and value.startswith("mem:")
-
-
-def _is_ocr_reader_identifier(value: object) -> bool:
-    return isinstance(value, str) and value.startswith("ocr:")
-
-
-def _build_input_degraded_context(
-    local_state: dict[str, Any],
-    *,
-    scene_id: str,
-    line_id: str,
-    choice_ids: list[str],
-) -> tuple[str, bool, list[str]]:
-    input_source = str(local_state.get("active_data_source") or DATA_SOURCE_BRIDGE_SDK)
-    reasons: list[str] = []
-    if input_source == DATA_SOURCE_MEMORY_READER:
-        reasons.append("memory_reader_source")
-    if input_source == DATA_SOURCE_OCR_READER:
-        reasons.append("ocr_reader_source")
-    if _is_memory_reader_identifier(scene_id):
-        reasons.append("memory_reader_scene")
-    if _is_ocr_reader_identifier(scene_id):
-        reasons.append("ocr_reader_scene")
-    if _is_memory_reader_identifier(line_id):
-        reasons.append("memory_reader_line")
-    if _is_ocr_reader_identifier(line_id):
-        reasons.append("ocr_reader_line")
-    if any(_is_memory_reader_identifier(choice_id) for choice_id in choice_ids):
-        reasons.append("memory_reader_choice")
-    if any(_is_ocr_reader_identifier(choice_id) for choice_id in choice_ids):
-        reasons.append("ocr_reader_choice")
-    return input_source, bool(reasons), reasons
-
-
 def _input_degraded_diagnostic(context: dict[str, Any]) -> str:
     reasons = list(context.get("degraded_reasons") or [])
     if not reasons:
@@ -2932,19 +2830,6 @@ def apply_input_degraded_result(
     return next_payload
 
 
-def _resolve_target_line(local_state: dict[str, Any], *, line_id: str) -> dict[str, Any] | None:
-    snapshot_line = _current_line_entry(local_state.get("latest_snapshot", {}))
-    if snapshot_line and str(snapshot_line.get("line_id") or "") == line_id:
-        return snapshot_line
-    for item in reversed(local_state.get("history_lines", [])):
-        if str(item.get("line_id") or "") == line_id:
-            return dict(item)
-    for item in reversed(local_state.get("history_observed_lines", [])):
-        if str(item.get("line_id") or "") == line_id:
-            return dict(item)
-    return None
-
-
 def build_local_scene_summary(
     *,
     scene_id: str,
@@ -2977,133 +2862,10 @@ def build_local_scene_summary(
     return summary
 
 
-def _snapshot_for_stable_summary_seed(
-    local_state: dict[str, Any],
-    snapshot: dict[str, Any],
-    stable_lines: list[dict[str, Any]],
-) -> dict[str, Any]:
-    if str(local_state.get("active_data_source") or "") != DATA_SOURCE_OCR_READER:
-        return snapshot
-    if str(snapshot.get("stability") or "") == "stable":
-        return snapshot
-    snapshot_line_id = str(snapshot.get("line_id") or "")
-    snapshot_text = str(snapshot.get("text") or "")
-    snapshot_speaker = str(snapshot.get("speaker") or "")
-    for line in stable_lines:
-        if not isinstance(line, dict):
-            continue
-        line_id = str(line.get("line_id") or "")
-        if snapshot_line_id and line_id and snapshot_line_id == line_id:
-            return snapshot
-        if (
-            snapshot_text
-            and snapshot_text == str(line.get("text") or "")
-            and snapshot_speaker == str(line.get("speaker") or "")
-        ):
-            return snapshot
-    seed_snapshot = dict(snapshot)
-    seed_snapshot["speaker"] = ""
-    seed_snapshot["text"] = ""
-    seed_snapshot["line_id"] = ""
-    seed_snapshot["stability"] = ""
-    return seed_snapshot
-
-
 def build_explain_context(local_state: dict[str, Any], *, line_id: str) -> dict[str, Any]:
-    snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
-    effective_line = resolve_effective_current_line(local_state)
-    effective_line_id = line_id or str(
-        (effective_line or {}).get("line_id") or snapshot.get("line_id") or ""
-    )
-    if not effective_line_id:
-        raise ValueError(build_ocr_context_diagnostic(local_state))
+    from .context_builder import build_explain_context as _build_explain_context
 
-    target_line = (
-        dict(effective_line)
-        if effective_line is not None
-        and str(effective_line.get("line_id") or "") == effective_line_id
-        else _resolve_target_line(local_state, line_id=effective_line_id)
-    )
-    if target_line is None:
-        raise ValueError(f"unknown line_id: {effective_line_id}; {build_ocr_context_diagnostic(local_state)}")
-
-    scene_id = str(target_line.get("scene_id") or snapshot.get("scene_id") or "")
-    route_id = str(target_line.get("route_id") or snapshot.get("route_id") or "")
-    stable_lines = _scene_lines(local_state.get("history_lines", []), scene_id, limit=8)
-    observed_lines = _scene_lines(
-        local_state.get("history_observed_lines", []),
-        scene_id,
-        limit=8,
-    )
-    scene_lines = _append_unique_line([*stable_lines, *observed_lines], target_line, limit=8)
-    selected_choices = _scene_selected_choices(
-        local_state.get("history_choices", []),
-        scene_id,
-        limit=6,
-    )
-
-    evidence: list[dict[str, Any]] = []
-    snapshot_line = _current_line_entry(snapshot)
-    if snapshot_line and str(snapshot_line.get("line_id") or "") == effective_line_id:
-        evidence.append(
-            {
-                "type": "current_line",
-                "text": str(snapshot_line.get("text") or ""),
-                "line_id": effective_line_id,
-                "speaker": str(snapshot_line.get("speaker") or ""),
-                "scene_id": str(snapshot_line.get("scene_id") or ""),
-                "route_id": str(snapshot_line.get("route_id") or ""),
-            }
-        )
-    for item in scene_lines[-4:]:
-        if str(item.get("line_id") or "") == effective_line_id:
-            continue
-        evidence.append(
-            {
-                "type": "history_line",
-                "text": str(item.get("text") or ""),
-                "line_id": str(item.get("line_id") or ""),
-                "speaker": str(item.get("speaker") or ""),
-                "scene_id": str(item.get("scene_id") or ""),
-                "route_id": str(item.get("route_id") or ""),
-            }
-        )
-    for choice in selected_choices[-2:]:
-        evidence.append(
-            {
-                "type": "choice",
-                "text": str(choice.get("text") or ""),
-                "line_id": str(choice.get("line_id") or ""),
-                "speaker": "",
-                "scene_id": str(choice.get("scene_id") or ""),
-                "route_id": str(choice.get("route_id") or ""),
-            }
-        )
-    input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
-        local_state,
-        scene_id=scene_id,
-        line_id=effective_line_id,
-        choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
-    )
-
-    return {
-        "game_id": str(local_state.get("active_game_id") or ""),
-        "session_id": str(local_state.get("active_session_id") or ""),
-        "scene_id": scene_id,
-        "route_id": route_id,
-        "line_id": effective_line_id,
-        "speaker": str(target_line.get("speaker") or ""),
-        "text": str(target_line.get("text") or ""),
-        "current_snapshot": snapshot,
-        "recent_lines": scene_lines,
-        "stable_lines": stable_lines,
-        "observed_lines": observed_lines,
-        "recent_choices": selected_choices,
-        "evidence": evidence,
-        "input_source": input_source,
-        "input_degraded": input_degraded,
-        "degraded_reasons": degraded_reasons,
-    }
+    return _build_explain_context(local_state, line_id=line_id)
 
 
 def build_summarize_context(
@@ -3112,111 +2874,19 @@ def build_summarize_context(
     scene_id: str,
     merge_from_scene_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
-    effective_line = resolve_effective_current_line(local_state)
-    effective_scene_id = scene_id or str(
-        snapshot.get("scene_id") or (effective_line or {}).get("scene_id") or ""
-    )
-    route_id = str(snapshot.get("route_id") or (effective_line or {}).get("route_id") or "")
-    stable_lines = _scene_lines(
-        local_state.get("history_lines", []),
-        effective_scene_id,
-        limit=20,
-        extra_scene_ids=merge_from_scene_ids,
-    )
-    observed_lines = _scene_lines(
-        local_state.get("history_observed_lines", []),
-        effective_scene_id,
-        limit=20,
-        extra_scene_ids=merge_from_scene_ids,
-    )
-    stable_lines = _dialogue_context_lines(stable_lines, limit=20)
-    observed_lines = _dialogue_context_lines(observed_lines, limit=20)
-    scene_lines = _dialogue_context_lines([*stable_lines, *observed_lines], limit=20)
-    selected_choices = _scene_selected_choices(
-        local_state.get("history_choices", []),
-        effective_scene_id,
-        limit=12,
-    )
-    input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
+    from .context_builder import build_summarize_context as _build_summarize_context
+
+    return _build_summarize_context(
         local_state,
-        scene_id=effective_scene_id,
-        line_id=str(snapshot.get("line_id") or ""),
-        choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
+        scene_id=scene_id,
+        merge_from_scene_ids=merge_from_scene_ids,
     )
-    return {
-        "game_id": str(local_state.get("active_game_id") or ""),
-        "session_id": str(local_state.get("active_session_id") or ""),
-        "scene_id": effective_scene_id,
-        "route_id": route_id,
-        "current_snapshot": snapshot,
-        "recent_lines": scene_lines,
-        "stable_lines": stable_lines,
-        "observed_lines": observed_lines,
-        "recent_choices": selected_choices,
-        "scene_summary_seed": build_local_scene_summary(
-            scene_id=effective_scene_id,
-            route_id=route_id,
-            lines=stable_lines,
-            selected_choices=selected_choices,
-            snapshot=_snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines),
-        ),
-        "input_source": input_source,
-        "input_degraded": input_degraded,
-        "degraded_reasons": degraded_reasons,
-    }
 
 
 def build_suggest_context(local_state: dict[str, Any]) -> dict[str, Any]:
-    snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
-    visible_choices = [
-        sanitize_choice(item) for item in snapshot.get("choices", [])
-    ]
-    scene_id = str(snapshot.get("scene_id") or "")
-    route_id = str(snapshot.get("route_id") or "")
-    stable_lines = _scene_lines(local_state.get("history_lines", []), scene_id, limit=8)
-    observed_lines = _scene_lines(
-        local_state.get("history_observed_lines", []),
-        scene_id,
-        limit=8,
-    )
-    scene_lines = [*stable_lines, *observed_lines][-8:]
-    selected_choices = _scene_selected_choices(
-        local_state.get("history_choices", []),
-        scene_id,
-        limit=8,
-    )
-    input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
-        local_state,
-        scene_id=scene_id,
-        line_id=str(snapshot.get("line_id") or ""),
-        choice_ids=[
-            str(choice.get("choice_id") or "")
-            for choice in [*visible_choices, *selected_choices]
-        ],
-    )
-    return {
-        "game_id": str(local_state.get("active_game_id") or ""),
-        "session_id": str(local_state.get("active_session_id") or ""),
-        "scene_id": scene_id,
-        "route_id": route_id,
-        "current_snapshot": snapshot,
-        "visible_choices": visible_choices,
-        "recent_lines": scene_lines,
-        "stable_lines": stable_lines,
-        "observed_lines": observed_lines,
-        "recent_choices": selected_choices,
-        "scene_summary": build_local_scene_summary(
-            scene_id=scene_id,
-            route_id=route_id,
-            lines=scene_lines,
-            selected_choices=selected_choices,
-            snapshot=snapshot,
-        ),
-        "input_source": input_source,
-        "input_degraded": input_degraded,
-        "degraded_reasons": degraded_reasons,
-    }
+    from .context_builder import build_suggest_context as _build_suggest_context
+
+    return _build_suggest_context(local_state)
 
 
 def build_explain_degraded_result(

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from plugin.plugins.galgame_plugin import context_builder
+from plugin.plugins.galgame_plugin.models import DATA_SOURCE_OCR_READER
+
+
+def test_scene_lines_filters_scene_and_keeps_tail() -> None:
+    lines = [
+        {"scene_id": "a", "line_id": "1"},
+        {"scene_id": "b", "line_id": "2"},
+        {"scene_id": "a", "line_id": "3"},
+        {"scene_id": "c", "line_id": "4"},
+    ]
+
+    result = context_builder._scene_lines(
+        lines,
+        "a",
+        limit=3,
+        extra_scene_ids=["c"],
+    )
+
+    assert [item["line_id"] for item in result] == ["1", "3", "4"]
+    assert result[0] is not lines[0]
+
+
+def test_scene_selected_choices_filters_action_and_scene() -> None:
+    choices = [
+        {"action": "shown", "scene_id": "a", "choice_id": "shown"},
+        {"action": "selected", "scene_id": "b", "choice_id": "other"},
+        {"action": "selected", "scene_id": "a", "choice_id": "first"},
+        {"action": "selected", "scene_id": "a", "choice_id": "second"},
+    ]
+
+    result = context_builder._scene_selected_choices(choices, "a", limit=1)
+
+    assert result == [{"action": "selected", "scene_id": "a", "choice_id": "second"}]
+
+
+def test_append_unique_line_dedupes_by_scene_speaker_text() -> None:
+    existing = [{"scene_id": "s", "speaker": "A", "text": "hello", "line_id": "1"}]
+
+    same = context_builder._append_unique_line(
+        existing,
+        {"scene_id": "s", "speaker": "A", "text": "hello", "line_id": "2"},
+        limit=4,
+    )
+    new = context_builder._append_unique_line(
+        existing,
+        {"scene_id": "s", "speaker": "B", "text": "hello", "line_id": "3"},
+        limit=4,
+    )
+
+    assert same == existing
+    assert [item["line_id"] for item in new] == ["1", "3"]
+
+
+def test_dialogue_context_lines_filters_diagnostics_and_dedupes() -> None:
+    lines = [
+        {"speaker": "A", "text": "hello", "scene_id": "s", "line_id": "1"},
+        {"speaker": "A", "text": "hello", "scene_id": "s", "line_id": "2"},
+        {"speaker": "", "text": "{\"debug\": true}", "scene_id": "s", "line_id": "debug"},
+        {"speaker": "B", "text": "world", "scene_id": "s", "line_id": "3"},
+    ]
+
+    result = context_builder._dialogue_context_lines(lines, limit=10)
+
+    assert [item["line_id"] for item in result] == ["2", "3"]
+
+
+def test_build_input_degraded_context_marks_ocr_identifiers() -> None:
+    source, degraded, reasons = context_builder._build_input_degraded_context(
+        {"active_data_source": DATA_SOURCE_OCR_READER},
+        scene_id="ocr:scene",
+        line_id="ocr:line",
+        choice_ids=["ocr:choice"],
+    )
+
+    assert source == DATA_SOURCE_OCR_READER
+    assert degraded is True
+    assert reasons == [
+        "ocr_reader_source",
+        "ocr_reader_scene",
+        "ocr_reader_line",
+        "ocr_reader_choice",
+    ]
+
+
+def test_resolve_target_line_prefers_history_matches() -> None:
+    result = context_builder._resolve_target_line(
+        {
+            "latest_snapshot": {},
+            "history_lines": [{"line_id": "stable", "text": "stable text"}],
+            "history_observed_lines": [{"line_id": "observed", "text": "observed text"}],
+        },
+        line_id="observed",
+    )
+
+    assert result == {"line_id": "observed", "text": "observed text"}
+
+
+def test_snapshot_for_stable_summary_seed_blanks_unstable_ocr_snapshot() -> None:
+    snapshot = {
+        "speaker": "A",
+        "text": "unstable",
+        "line_id": "line-1",
+        "stability": "tentative",
+    }
+
+    result = context_builder._snapshot_for_stable_summary_seed(
+        {"active_data_source": DATA_SOURCE_OCR_READER},
+        snapshot,
+        stable_lines=[],
+    )
+
+    assert result["speaker"] == ""
+    assert result["text"] == ""
+    assert result["line_id"] == ""
+    assert result["stability"] == ""

--- a/plugin/tests/unit/plugins/test_galgame_context_metrics.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_metrics.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from plugin.plugins.galgame_plugin.context_metrics import (
+    ContextMetric,
+    ContextMetricsCollector,
+)
+from plugin.plugins.galgame_plugin.llm_backend import GalgameLLMBackend
+from plugin.plugins.galgame_plugin.llm_gateway import LLMGateway
+
+
+class _Backend:
+    async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
+        del operation, context
+        return {
+            "summary": "ok",
+            "key_points": [
+                {
+                    "type": "plot",
+                    "text": "ok",
+                    "line_id": "",
+                    "speaker": "",
+                    "scene_id": "",
+                    "route_id": "",
+                }
+            ],
+        }
+
+    async def shutdown(self) -> None:
+        return None
+
+    def consume_prompt_metadata(self) -> dict[str, Any]:
+        return {
+            "raw_tokens": 100,
+            "compacted_tokens": 40,
+            "raw_chars": 200,
+            "compacted_chars": 80,
+            "compression_level": 2,
+        }
+
+
+class _RealPromptBackend(GalgameLLMBackend):
+    async def _call_model(self, *, operation: str, messages):
+        self.last_messages = messages
+        assert operation == "agent_reply"
+        assert "context:" in messages[-1]["content"]
+        return '{"reply": "ok"}'
+
+
+def _config(**overrides: Any) -> SimpleNamespace:
+    values = {
+        "llm_target_entry_ref": "",
+        "llm_call_timeout_seconds": 1.0,
+        "llm_max_in_flight": 2,
+        "llm_request_cache_ttl_seconds": 0.0,
+        "llm_scene_summary_cache_ttl_seconds": 0.0,
+        "context_metrics_enabled": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_context_metrics_collector_uses_ring_buffer() -> None:
+    collector = ContextMetricsCollector()
+    for index in range(510):
+        collector.record(
+            ContextMetric(
+                operation="op",
+                raw_tokens=index,
+                compacted_tokens=index,
+                raw_chars=index,
+                compacted_chars=index,
+                compression_level=0,
+                cache_hit=False,
+                total_time_ms=1.0,
+            )
+        )
+
+    records = collector.records()
+    assert len(records) == 500
+    assert records[0].raw_tokens == 10
+
+
+def test_context_metrics_summary_stats_groups_by_operation() -> None:
+    collector = ContextMetricsCollector()
+    collector.record(ContextMetric("explain", 100, 50, 200, 100, 1, False, 10.0))
+    collector.record(ContextMetric("explain", 300, 150, 600, 300, 3, True, 30.0))
+    collector.record(ContextMetric("summarize", 10, 10, 20, 20, 0, False, 5.0))
+
+    summary = collector.summary_stats()
+
+    assert summary["explain"]["count"] == 2
+    assert summary["explain"]["avg_raw_tokens"] == 200
+    assert summary["explain"]["avg_compression_level"] == 2
+    assert summary["explain"]["cache_hits"] == 1
+    assert summary["explain"]["cache_hit_rate"] == 0.5
+    assert summary["summarize"]["count"] == 1
+
+
+def test_llm_gateway_metric_recording_preserves_zero_metadata_values() -> None:
+    gateway = LLMGateway(
+        None,
+        None,
+        _config(context_metrics_enabled=True),
+        backend=_Backend(),
+    )
+
+    gateway._record_context_metric(
+        operation="agent_reply",
+        context={},
+        prompt_metadata={
+            "raw_tokens": 0,
+            "compacted_tokens": 0,
+            "raw_chars": 0,
+            "compacted_chars": 0,
+            "compression_level": 0,
+        },
+        cache_hit=False,
+        total_time_ms=0.0,
+    )
+
+    assert gateway.context_metrics is not None
+    record = gateway.context_metrics.records()[0]
+    assert record.raw_tokens == 0
+    assert record.compacted_tokens == 0
+    assert record.raw_chars == 0
+    assert record.compacted_chars == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_gateway_does_not_create_metrics_collector_when_disabled() -> None:
+    gateway = LLMGateway(None, None, _config(), backend=_Backend())
+
+    result = await gateway.summarize_scene({"scene_id": "scene-a", "recent_lines": []})
+
+    assert result["degraded"] is False
+    assert gateway.context_metrics is None
+
+
+@pytest.mark.asyncio
+async def test_llm_gateway_records_metrics_for_call_and_cache_hit() -> None:
+    gateway = LLMGateway(
+        None,
+        None,
+        _config(
+            context_metrics_enabled=True,
+            llm_request_cache_ttl_seconds=60.0,
+            llm_scene_summary_cache_ttl_seconds=60.0,
+        ),
+        backend=_Backend(),
+    )
+
+    context = {"scene_id": "scene-a", "recent_lines": []}
+    await gateway.summarize_scene(context)
+    await gateway.summarize_scene(context)
+
+    assert gateway.context_metrics is not None
+    records = gateway.context_metrics.records()
+    assert len(records) == 2
+    assert records[0].cache_hit is False
+    assert records[0].raw_tokens == 100
+    assert records[0].compacted_tokens == 40
+    assert records[1].cache_hit is True
+
+
+@pytest.mark.asyncio
+async def test_llm_gateway_records_real_prompt_metadata_end_to_end() -> None:
+    backend = _RealPromptBackend(logger=None, config=_config(context_metrics_enabled=True))
+    gateway = LLMGateway(
+        None,
+        None,
+        _config(
+            context_metrics_enabled=True,
+            context_counting_mode="token",
+            context_max_tokens=1000,
+            llm_request_cache_ttl_seconds=60.0,
+        ),
+        backend=backend,
+    )
+
+    result = await gateway.agent_reply({"prompt": "status", "public_context": {}})
+
+    assert result["reply"] == "ok"
+    assert gateway.context_metrics is not None
+    record = gateway.context_metrics.records()[0]
+    assert record.operation == "agent_reply"
+    assert record.cache_hit is False
+    assert record.raw_tokens > 0
+    assert record.compacted_tokens > 0

--- a/plugin/tests/unit/plugins/test_galgame_context_metrics.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_metrics.py
@@ -44,6 +44,30 @@ class _Backend:
         }
 
 
+class _ConfigAwareBackend:
+    def __init__(self, config: SimpleNamespace) -> None:
+        self._config = config
+        self.calls = 0
+
+    async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
+        del context
+        self.calls += 1
+        assert operation == "summarize_scene"
+        return {
+            "summary": (
+                f"{self._config.context_counting_mode}:"
+                f"{self._config.context_max_tokens}"
+            ),
+            "key_points": [],
+        }
+
+    async def shutdown(self) -> None:
+        return None
+
+    def consume_prompt_metadata(self) -> dict[str, Any]:
+        return {}
+
+
 class _RealPromptBackend(GalgameLLMBackend):
     async def _call_model(self, *, operation: str, messages):
         self.last_messages = messages
@@ -235,6 +259,38 @@ async def test_llm_gateway_records_cache_hit_metrics_outside_lock() -> None:
         False,
         True,
     ]
+
+
+@pytest.mark.asyncio
+async def test_llm_gateway_cache_is_scoped_to_prompt_budget_config() -> None:
+    config = _config(
+        context_counting_mode="token",
+        context_max_tokens=300,
+        llm_request_cache_ttl_seconds=60.0,
+        llm_scene_summary_cache_ttl_seconds=60.0,
+    )
+    backend = _ConfigAwareBackend(config)
+    gateway = LLMGateway(None, None, config, backend=backend)
+    context = {"scene_id": "scene-a", "recent_lines": [{"text": "same input"}]}
+
+    first = await gateway.summarize_scene(context)
+    cached = await gateway.summarize_scene(context)
+    assert first["summary"] == "token:300"
+    assert cached["summary"] == "token:300"
+    assert backend.calls == 1
+
+    next_config = _config(
+        context_counting_mode="token",
+        context_max_tokens=1000,
+        llm_request_cache_ttl_seconds=60.0,
+        llm_scene_summary_cache_ttl_seconds=60.0,
+    )
+    gateway.update_config(next_config)
+
+    after_update = await gateway.summarize_scene(context)
+
+    assert after_update["summary"] == "token:1000"
+    assert backend.calls == 2
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_context_metrics.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_metrics.py
@@ -10,6 +10,7 @@ from plugin.plugins.galgame_plugin.context_metrics import (
     ContextMetricsCollector,
 )
 from plugin.plugins.galgame_plugin.llm_backend import GalgameLLMBackend
+from plugin.plugins.galgame_plugin import llm_gateway as llm_gateway_module
 from plugin.plugins.galgame_plugin.llm_gateway import LLMGateway
 
 
@@ -131,6 +132,41 @@ def test_llm_gateway_metric_recording_preserves_zero_metadata_values() -> None:
     assert record.compacted_chars == 0
 
 
+def test_llm_gateway_metric_recording_does_not_render_context_with_complete_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = LLMGateway(
+        None,
+        None,
+        _config(context_metrics_enabled=True),
+        backend=_Backend(),
+    )
+
+    def fail_json_dumps(*args: Any, **kwargs: Any) -> str:
+        raise AssertionError("context should not be rendered when metadata is complete")
+
+    monkeypatch.setattr(llm_gateway_module.json, "dumps", fail_json_dumps)
+
+    gateway._record_context_metric(
+        operation="agent_reply",
+        context={"large": ["x"] * 100},
+        prompt_metadata={
+            "raw_tokens": 100,
+            "compacted_tokens": 40,
+            "raw_chars": 200,
+            "compacted_chars": 80,
+            "compression_level": 2,
+        },
+        cache_hit=True,
+        total_time_ms=1.0,
+    )
+
+    assert gateway.context_metrics is not None
+    record = gateway.context_metrics.records()[0]
+    assert record.raw_tokens == 100
+    assert record.raw_chars == 200
+
+
 @pytest.mark.asyncio
 async def test_llm_gateway_does_not_create_metrics_collector_when_disabled() -> None:
     gateway = LLMGateway(None, None, _config(), backend=_Backend())
@@ -165,6 +201,40 @@ async def test_llm_gateway_records_metrics_for_call_and_cache_hit() -> None:
     assert records[0].raw_tokens == 100
     assert records[0].compacted_tokens == 40
     assert records[1].cache_hit is True
+
+
+@pytest.mark.asyncio
+async def test_llm_gateway_records_cache_hit_metrics_outside_lock() -> None:
+    class _LockAssertingGateway(LLMGateway):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self.metric_lock_states: list[bool] = []
+
+        def _record_context_metric(self, **kwargs: Any) -> None:
+            self.metric_lock_states.append(bool(self._lock and self._lock.locked()))
+            super()._record_context_metric(**kwargs)
+
+    gateway = _LockAssertingGateway(
+        None,
+        None,
+        _config(
+            context_metrics_enabled=True,
+            llm_request_cache_ttl_seconds=60.0,
+            llm_scene_summary_cache_ttl_seconds=60.0,
+        ),
+        backend=_Backend(),
+    )
+
+    context = {"scene_id": "scene-a", "recent_lines": []}
+    await gateway.summarize_scene(context)
+    await gateway.summarize_scene(context)
+
+    assert gateway.metric_lock_states == [False, False]
+    assert gateway.context_metrics is not None
+    assert [record.cache_hit for record in gateway.context_metrics.records()] == [
+        False,
+        True,
+    ]
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_context_tokens.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_tokens.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from plugin.plugins.galgame_plugin.context_tokens import (
+    count_tokens_heuristic,
+    estimate_context_tokens,
+)
+
+
+def test_count_tokens_heuristic_handles_empty_text() -> None:
+    assert count_tokens_heuristic("") == 0
+
+
+def test_count_tokens_heuristic_counts_ascii_compactly() -> None:
+    assert count_tokens_heuristic("abcd") == 1
+    assert count_tokens_heuristic("a" * 100) == 25
+
+
+def test_count_tokens_heuristic_counts_cjk_conservatively() -> None:
+    assert count_tokens_heuristic("中文") == 3
+
+
+def test_count_tokens_heuristic_counts_mixed_text() -> None:
+    assert count_tokens_heuristic("abc中文") == 4
+
+
+def test_estimate_context_tokens_uses_prompt_json_rendering() -> None:
+    context = {"text": "中文", "items": ["abc", {"nested": "かな"}]}
+
+    first = estimate_context_tokens(context)
+    second = estimate_context_tokens(dict(context))
+
+    assert first > count_tokens_heuristic("中文")
+    assert first == second
+
+
+def test_count_tokens_heuristic_handles_long_text() -> None:
+    text = ("abc123" * 1000) + ("日本語" * 1000)
+
+    assert count_tokens_heuristic(text) > count_tokens_heuristic("abc123" * 1000)

--- a/plugin/tests/unit/plugins/test_galgame_llm_backend.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_backend.py
@@ -77,7 +77,7 @@ def test_llm_backend_prompt_message_contracts_are_stable() -> None:
     }
     text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     assert hashlib.sha256(text.encode("utf-8")).hexdigest() == (
-        "ca7a55754459201032758f180bdd85f15d3a0b39831cec328105522f976a9f81"
+        "7d32bddc399b7480b1471cad3e2b31cabaac894757d23b5b6246678c175b2ad6"
     )
 
 

--- a/plugin/tests/unit/plugins/test_galgame_llm_prompts.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_prompts.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from plugin.plugins.galgame_plugin.llm_prompts import (
+    build_prompt_messages,
+    build_prompt_messages_with_metadata,
+)
+
+
+def _cfg(**overrides):
+    values = {
+        "context_counting_mode": "char",
+        "context_max_tokens": 6000,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _rendered_context(result) -> str:
+    return result.messages[1]["content"].split("context:\n", 1)[1]
+
+
+def test_prompt_context_keeps_default_char_mode_behavior() -> None:
+    context = {"text": "x" * 13000}
+
+    default_rendered = _rendered_context(build_prompt_messages_with_metadata("agent_reply", context))
+    configured_rendered = _rendered_context(build_prompt_messages_with_metadata(
+        "agent_reply",
+        context,
+        _cfg(context_counting_mode="char", context_max_tokens=1),
+    ))
+
+    assert default_rendered == configured_rendered
+    assert len(default_rendered) <= 12000
+    assert json.loads(default_rendered)["_prompt_truncated"] is True
+
+
+def test_token_mode_allows_long_ascii_context_past_char_budget() -> None:
+    context = {"text": "a" * 20000}
+
+    rendered = _rendered_context(build_prompt_messages_with_metadata(
+        "agent_reply",
+        context,
+        _cfg(context_counting_mode="token", context_max_tokens=6000),
+    ))
+
+    assert len(rendered) > 12000
+    assert json.loads(rendered)["text"] == "a" * 20000
+
+
+def test_token_mode_compacts_cjk_context_earlier() -> None:
+    context = {"text": "日" * 5000}
+
+    result = build_prompt_messages_with_metadata(
+        "agent_reply",
+        context,
+        _cfg(context_counting_mode="token", context_max_tokens=2000),
+    )
+
+    assert result.metadata["compression_level"] == 1
+    assert result.metadata["compacted_tokens"] <= result.metadata["raw_tokens"]
+    assert "context:" in result.messages[1]["content"]
+
+
+def test_token_mode_hard_fallback_reports_level_four() -> None:
+    context = {"items": [{"text": "日" * 1000, "extra": list(range(100))} for _ in range(50)]}
+
+    result = build_prompt_messages_with_metadata(
+        "agent_reply",
+        context,
+        _cfg(context_counting_mode="token", context_max_tokens=1),
+    )
+
+    assert result.metadata["compression_level"] == 4
+    assert json.loads(_rendered_context(result))["_prompt_truncated"] is True
+
+
+def test_build_prompt_messages_public_contract_returns_message_list() -> None:
+    messages = build_prompt_messages("agent_reply", {"prompt": "status"})
+
+    assert isinstance(messages, list)
+    assert [message["role"] for message in messages] == ["system", "user"]

--- a/plugin/tests/unit/plugins/test_galgame_llm_prompts.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_prompts.py
@@ -77,6 +77,22 @@ def test_token_mode_hard_fallback_reports_level_four() -> None:
     assert json.loads(_rendered_context(result))["_prompt_truncated"] is True
 
 
+def test_token_mode_hard_fallback_trims_excerpt_to_token_budget() -> None:
+    context = {"items": [{"text": "日" * 5000, "extra": list(range(100))} for _ in range(50)]}
+
+    result = build_prompt_messages_with_metadata(
+        "agent_reply",
+        context,
+        _cfg(context_counting_mode="token", context_max_tokens=300),
+    )
+    rendered_context = json.loads(_rendered_context(result))
+
+    assert result.metadata["compression_level"] == 4
+    assert result.metadata["compacted_tokens"] <= result.metadata["budget"]
+    assert rendered_context["_prompt_truncated"] is True
+    assert "context_excerpt" in rendered_context
+
+
 def test_build_prompt_messages_public_contract_returns_message_list() -> None:
     messages = build_prompt_messages("agent_reply", {"prompt": "status"})
 

--- a/plugin/tests/unit/plugins/test_galgame_service.py
+++ b/plugin/tests/unit/plugins/test_galgame_service.py
@@ -181,20 +181,65 @@ def test_build_config_reads_context_optimization_fields() -> None:
     assert invalid.context_counting_mode == "char"
 
 
-def test_context_builder_forwards_context_builders_without_behavior_change() -> None:
+def test_context_builder_forwards_context_builders_without_behavior_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     local_state = _local_state()
+    merge_from_scene_ids = ["ocr:game:scene-0000"]
+    summarize_result = {"sentinel": "summarize"}
+    explain_result = {"sentinel": "explain"}
+    suggest_result = {"sentinel": "suggest"}
+    calls: dict[str, object] = {}
 
-    assert galgame_context_builder.build_summarize_context(
+    def fake_build_summarize_context(
+        received_local_state: dict[str, object],
+        *,
+        scene_id: str,
+        merge_from_scene_ids: list[str] | None = None,
+    ) -> dict[str, str]:
+        calls["summarize"] = (received_local_state, scene_id, merge_from_scene_ids)
+        return summarize_result
+
+    def fake_build_explain_context(
+        received_local_state: dict[str, object],
+        *,
+        line_id: str,
+    ) -> dict[str, str]:
+        calls["explain"] = (received_local_state, line_id)
+        return explain_result
+
+    def fake_build_suggest_context(received_local_state: dict[str, object]) -> dict[str, str]:
+        calls["suggest"] = (received_local_state,)
+        return suggest_result
+
+    monkeypatch.setattr(
+        galgame_context_builder,
+        "build_summarize_context",
+        fake_build_summarize_context,
+    )
+    monkeypatch.setattr(
+        galgame_context_builder,
+        "build_explain_context",
+        fake_build_explain_context,
+    )
+    monkeypatch.setattr(
+        galgame_context_builder,
+        "build_suggest_context",
+        fake_build_suggest_context,
+    )
+
+    assert build_summarize_context(
         local_state,
         scene_id="ocr:game:scene-0001",
-    ) == build_summarize_context(local_state, scene_id="ocr:game:scene-0001")
-    assert galgame_context_builder.build_explain_context(
-        local_state,
-        line_id="ocr:line-stable",
-    ) == build_explain_context(local_state, line_id="ocr:line-stable")
-    assert galgame_context_builder.build_suggest_context(local_state) == build_suggest_context(
-        local_state
-    )
+        merge_from_scene_ids=merge_from_scene_ids,
+    ) is summarize_result
+    assert build_explain_context(local_state, line_id="ocr:line-stable") is explain_result
+    assert build_suggest_context(local_state) is suggest_result
+    assert calls == {
+        "summarize": (local_state, "ocr:game:scene-0001", merge_from_scene_ids),
+        "explain": (local_state, "ocr:line-stable"),
+        "suggest": (local_state,),
+    }
 
 
 def _candidate(

--- a/plugin/tests/unit/plugins/test_galgame_service.py
+++ b/plugin/tests/unit/plugins/test_galgame_service.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from plugin.plugins.galgame_plugin import service as galgame_service
+from plugin.plugins.galgame_plugin import context_builder as galgame_context_builder
 from plugin.plugins.galgame_plugin.models import (
     DATA_SOURCE_BRIDGE_SDK,
     DATA_SOURCE_MEMORY_READER,
@@ -17,6 +18,7 @@ from plugin.plugins.galgame_plugin.models import (
 )
 from plugin.plugins.galgame_plugin.service import (
     build_explain_context,
+    build_suggest_context,
     build_summarize_context,
     choose_candidate,
     filter_ocr_reader_candidates,
@@ -157,6 +159,42 @@ def test_build_config_defaults_rapidocr_lang_type_to_bundled_ch() -> None:
 
     assert cfg.rapidocr_lang_type == "ch"
     assert cfg.rapidocr_lang_type == galgame_service.DEFAULT_RAPIDOCR_LANG_TYPE
+
+
+def test_build_config_reads_context_optimization_fields() -> None:
+    cfg = galgame_service.build_config(
+        {
+            "llm": {
+                "context_max_tokens": 4096,
+                "context_metrics_enabled": True,
+                "context_counting_mode": "token",
+            }
+        }
+    )
+    invalid = galgame_service.build_config(
+        {"llm": {"context_counting_mode": "words"}}
+    )
+
+    assert cfg.context_max_tokens == 4096
+    assert cfg.context_metrics_enabled is True
+    assert cfg.context_counting_mode == "token"
+    assert invalid.context_counting_mode == "char"
+
+
+def test_context_builder_forwards_context_builders_without_behavior_change() -> None:
+    local_state = _local_state()
+
+    assert galgame_context_builder.build_summarize_context(
+        local_state,
+        scene_id="ocr:game:scene-0001",
+    ) == build_summarize_context(local_state, scene_id="ocr:game:scene-0001")
+    assert galgame_context_builder.build_explain_context(
+        local_state,
+        line_id="ocr:line-stable",
+    ) == build_explain_context(local_state, line_id="ocr:line-stable")
+    assert galgame_context_builder.build_suggest_context(local_state) == build_suggest_context(
+        local_state
+    )
 
 
 def _candidate(


### PR DESCRIPTION
 - 新增 `context_tokens.py`，提供启发式 token 估算
  - 新增 `context_metrics.py`，提供上下文指标与 500 条环形缓冲
  - 新增 `context_builder.py`，承接 explain / summarize / suggest 的上下文构建逻辑
  - `service.py` 保留兼容入口，并转发到 `context_builder.py`
  - `llm_prompts.py` 增加 prompt metadata 构建路径
  - `llm_backend.py` 使用 `ContextVar` 暴露 prompt metadata
  - `llm_gateway.py` 在 metrics 开启时记录正常调用和缓存命中指标
  - 新增 `[llm]` 配置：
    - `context_max_tokens = 6000`
    - `context_counting_mode = "char"`
    - `context_metrics_enabled = false`

  ## 兼容性

  默认保持旧行为：
  - `context_counting_mode = "char"`
  - `context_metrics_enabled = false`
  - 仍使用旧 12000 字符预算和旧三级压缩参数
  - 不改变现有 LLM cache fingerprint / TTL 行为
  - `90 passed, 1 warning`
  - LLM gateway bridge 聚焦回归：`6 passed, 1 warning`
  - `compileall` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为 galgame 新增可生成的场景上下文（解释/总结/选项建议），包含 OCR 诊断、对话去重与稳定摘要
  * 提示构建返回计量元数据，支持可配置的上下文预算与多级压缩/回退
  * 后端可导出提示元数据以供度量记录

* **性能/度量**
  * 增加轻量上下文度量采集与汇总，网关记录缓存命中与调用时长

* **配置**
  * 新增上下文相关配置：计数模式、最大上下文令牌与度量开关

* **测试**
  * 大量新增单元测试覆盖上下文构建、令牌估算与度量收集

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1322)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->