### PR TITLE
首启隐私模式默认关闭挂到 A/B test branch (privacy_default_off_v1)

### DIFF
--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -412,7 +412,12 @@ async def get_conversation_settings():
             from utils.token_tracker import get_telemetry_branch
             telemetry_branch = await asyncio.to_thread(get_telemetry_branch)
         except Exception:
-            telemetry_branch = "main"
+            # 故意返回 None：前端只在 telemetryBranch 是字符串时清掉首启 pending
+            # marker；如果这里 fallback 到 "main"，瞬时报错会被当成「控制组分流
+            # 已决议」永久锁住，下次也不会重试。返 None 让前端保留 pending、
+            # 下次 fetch 成功再决议
+            logger.exception("解析 telemetry branch 失败，返回 null 让前端保留 pending marker")
+            telemetry_branch = None
         return {"success": True, "settings": settings, "telemetryBranch": telemetry_branch}
     except Exception as e:
         logger.exception(f"获取对话设置失败: {e}")

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -400,10 +400,20 @@ async def set_preferred_model(request: Request):
 
 @router.get("/conversation-settings")
 async def get_conversation_settings():
-    """获取全局对话设置（从 user_preferences.json 同步备份中读取）"""
+    """获取全局对话设置（从 user_preferences.json 同步备份中读取）
+
+    顺手回带遥测 A/B test 分支，让前端在 first-launch 时按分支选择默认行为，
+    与 token tracker 上报的 branch 一致——同一台设备永远落到同一组，避免
+    控制组/实验组在客户端跟 server 端出现不一致。
+    """
     try:
         settings = await aload_global_conversation_settings()
-        return {"success": True, "settings": settings}
+        try:
+            from utils.token_tracker import get_telemetry_branch
+            telemetry_branch = await asyncio.to_thread(get_telemetry_branch)
+        except Exception:
+            telemetry_branch = "main"
+        return {"success": True, "settings": settings, "telemetryBranch": telemetry_branch}
     except Exception as e:
         logger.exception(f"获取对话设置失败: {e}")
         return {"success": False, "error": "Internal server error", "settings": {}}

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -565,12 +565,18 @@
                         window.scheduleProactiveChat();
                     }
                 }
+            }).finally(() => {
+                // 必须等 GET 解析后再起 periodic sync：否则 60s 间隔的 POST 可能
+                // 比 GET 先到，把首启控制组默认值写到服务器；GET 回来读到自家 echo
+                // 误判「云端已有偏好」，让 A/B 实验组覆写永久跳过 + marker 还落上，
+                // cohort 直接污染。GET 走 finally 后周期同步才安全
+                startPeriodicSync();
             });
-
-            // 启动定期同步到服务器
-            startPeriodicSync();
         } catch (error) {
             console.error('服务器设置同步启动失败:', error);
+            // GET 链路本身就挂了，至少把 periodic sync 起来兜底，
+            // 避免用户的本地修改永远上不了服务器
+            startPeriodicSync();
         }
     }
 

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -17,11 +17,11 @@
     let _syncTimerId = null;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
-    // first-launch 标记：让服务器返回 telemetryBranch 后，能识别这次是不是首启，
-    // 决定要不要对实验组追加「隐私模式默认关闭」覆写
-    let _isFirstLaunch = false;
     // 隐私模式 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）
     const _PRIVACY_OFF_BRANCH = 'privacy_default_off_v1';
+    // localStorage marker：记下「上次成功观察到的 telemetryBranch」。让 offline 首启
+    // 错过 branch 后续启动时还能补回覆写，否则实验组用户会被永远锁在控制组默认值上
+    const _BRANCH_OBSERVED_KEY = '_neko_telemetry_branch_observed';
 
     /**
      * 获取对话相关设置（仅包含需要同步到服务器的设置）
@@ -429,7 +429,6 @@
                 // 地区默认关闭）。实验组（privacy_default_off_v1）的「一律默认关闭」
                 // 由 loadSettingsFromServer 拿到 telemetryBranch 后追加覆写，见下方
                 // 异步合并块。
-                _isFirstLaunch = true;
                 if (_isUserRegionChina()) {
                     S.proactiveVisionEnabled = true;
                 }
@@ -476,6 +475,12 @@
         S.userLanguage = subtitleState ? subtitleState.userLanguage : (localStorage.getItem('userLanguage') || null);
 
         // 异步：从服务器加载对话设置并合并（不阻塞 UI）
+        // 捕获 fetch 发起时的 vision 值：若用户在 fetch 返回前手动切了 toggle，
+        // 后续 A/B 覆写就跳过，避免把用户的显式选择刷掉
+        const _visionAtFetchStart = S.proactiveVisionEnabled;
+        const _branchAlreadyObserved = (() => {
+            try { return localStorage.getItem(_BRANCH_OBSERVED_KEY); } catch (_) { return null; }
+        })();
         try {
             loadSettingsFromServer().then(serverResult => {
                 if (!serverResult) return;
@@ -483,17 +488,28 @@
                 const telemetryBranch = serverResult.telemetryBranch;
                 let hasUpdate = false;
 
-                // A/B test 覆写：首启 + 实验组 + 服务器没有用户既有偏好时，
-                // 把隐私模式默认关闭（proactiveVisionEnabled = true）。已有云端
-                // 偏好的用户和控制组保持各自原状不动。
+                // A/B test 覆写：分支 = 实验组 + 本机还没观察并落定过这个分支 +
+                // 服务器没有用户既有 vision 偏好 + 用户没在 fetch 间隙手动切 toggle，
+                // 才把隐私模式默认关掉。用 localStorage marker 跨启动幂等：offline
+                // 首启错过覆写时，下次在线再补；marker 写入后不再重复覆写。
                 const noServerVisionPref = !serverSettings ||
                     serverSettings.proactiveVisionEnabled === undefined;
-                if (_isFirstLaunch && telemetryBranch === _PRIVACY_OFF_BRANCH && noServerVisionPref) {
+                const userToggledDuringFetch = S.proactiveVisionEnabled !== _visionAtFetchStart;
+                const branchAlreadyApplied = _branchAlreadyObserved === telemetryBranch;
+                if (telemetryBranch === _PRIVACY_OFF_BRANCH
+                        && !branchAlreadyApplied
+                        && noServerVisionPref
+                        && !userToggledDuringFetch) {
                     if (S.proactiveVisionEnabled !== true) {
                         S.proactiveVisionEnabled = true;
                         hasUpdate = true;
                         console.log('[app-settings] A/B 实验组', telemetryBranch, '：隐私模式默认关闭');
                     }
+                }
+                // 不论是否触发覆写，只要 server 给了 branch 就落 marker，保证
+                // 下次启动不再尝试，控制组用户也只查一次
+                if (telemetryBranch && !branchAlreadyApplied) {
+                    try { localStorage.setItem(_BRANCH_OBSERVED_KEY, telemetryBranch); } catch (_) {}
                 }
 
                 if (serverSettings) {

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -153,8 +153,14 @@
     /**
      * 将当前设置保存到 localStorage
      * 从 window 全局变量读取最新值（确保同步 live2d.js 中的更改）
+     *
+     * @param {{ skipServerSync?: boolean }} [options] 传 skipServerSync 跳过 POST，
+     *   首启分支用——避免在 loadSettingsFromServer 拿到 telemetryBranch 之前
+     *   就把控制组默认值写到服务器、回头被自己的 GET 当成「云端已有偏好」从而
+     *   永远跳过 A/B 实验组覆写
      */
-    function saveSettings() {
+    function saveSettings(options) {
+        const skipServerSync = !!(options && options.skipServerSync);
         // 从全局变量读取最新值（确保同步 live2d.js 中的更改）
         const currentProactive = typeof window.proactiveChatEnabled !== 'undefined'
             ? window.proactiveChatEnabled
@@ -289,8 +295,10 @@
             });
         }
 
-        // 同步到服务器（异步，不阻塞）
-        syncSettingsToServer();
+        // 同步到服务器（异步，不阻塞）；首启走 skipServerSync 等 branch 解析后再 POST
+        if (!skipServerSync) {
+            syncSettingsToServer();
+        }
     }
 
     // ======================== loadSettings ========================
@@ -448,8 +456,11 @@
                 window.humanoidLocalTrackingEnabled = false;
                 window.lockedHoverFadeEnabled = true;
 
-                // 持久化首次启动设置，避免每次重新检测
-                saveSettings();
+                // 持久化首次启动设置到 localStorage，避免每次重新检测。注意：故意跳过
+                // 服务器 POST——loadSettingsFromServer GET 还没拿到 telemetryBranch，
+                // 这时把控制组默认值上行会被自家 GET 当作「云端已有偏好」回读，让 A/B
+                // 实验组覆写永远跳过。等 branch 解析后再做一次完整 saveSettings 推送
+                saveSettings({ skipServerSync: true });
             }
 
         } catch (error) {

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -19,9 +19,11 @@
     const SYNC_INTERVAL_MS = 60000;
     // 隐私模式 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）
     const _PRIVACY_OFF_BRANCH = 'privacy_default_off_v1';
-    // localStorage marker：记下「上次成功观察到的 telemetryBranch」。让 offline 首启
-    // 错过 branch 后续启动时还能补回覆写，否则实验组用户会被永远锁在控制组默认值上
-    const _BRANCH_OBSERVED_KEY = '_neko_telemetry_branch_observed';
+    // 「首启等 branch 决议」专属 marker：只有 localStorage 走过本 PR 的首启分支才会写
+    // 「1」，branch 决议后清掉。用 marker 在不在判断「应不应该套 A/B 覆写」，避免拿
+    // 「没见过 branch 」当首启代名——升级用户也都没见过 branch，那个口径会误伤他们的
+    // 既有偏好。offline 首启错过 branch 时 marker 留着，下次在线再补
+    const _FIRST_LAUNCH_PENDING_KEY = '_neko_first_launch_branch_pending';
 
     /**
      * 获取对话相关设置（仅包含需要同步到服务器的设置）
@@ -456,6 +458,9 @@
                 window.humanoidLocalTrackingEnabled = false;
                 window.lockedHoverFadeEnabled = true;
 
+                // 首启专属 marker：告诉下方异步合并块「这次需要等 branch 决议后套 A/B
+                // 覆写」。升级用户走的是 if (saved) 分支不会写这个，于是不会被误覆写
+                try { localStorage.setItem(_FIRST_LAUNCH_PENDING_KEY, '1'); } catch (_) {}
                 // 持久化首次启动设置到 localStorage，避免每次重新检测。注意：故意跳过
                 // 服务器 POST——loadSettingsFromServer GET 还没拿到 telemetryBranch，
                 // 这时把控制组默认值上行会被自家 GET 当作「云端已有偏好」回读，让 A/B
@@ -489,8 +494,8 @@
         // 捕获 fetch 发起时的 vision 值：若用户在 fetch 返回前手动切了 toggle，
         // 后续 A/B 覆写就跳过，避免把用户的显式选择刷掉
         const _visionAtFetchStart = S.proactiveVisionEnabled;
-        const _branchAlreadyObserved = (() => {
-            try { return localStorage.getItem(_BRANCH_OBSERVED_KEY); } catch (_) { return null; }
+        const _firstLaunchPending = (() => {
+            try { return localStorage.getItem(_FIRST_LAUNCH_PENDING_KEY) === '1'; } catch (_) { return false; }
         })();
         try {
             loadSettingsFromServer().then(serverResult => {
@@ -499,16 +504,15 @@
                 const telemetryBranch = serverResult.telemetryBranch;
                 let hasUpdate = false;
 
-                // A/B test 覆写：分支 = 实验组 + 本机还没观察并落定过这个分支 +
-                // 服务器没有用户既有 vision 偏好 + 用户没在 fetch 间隙手动切 toggle，
-                // 才把隐私模式默认关掉。用 localStorage marker 跨启动幂等：offline
-                // 首启错过覆写时，下次在线再补；marker 写入后不再重复覆写。
+                // A/B test 覆写：必须是本 PR 之后真·首启（_FIRST_LAUNCH_PENDING_KEY 存在）+
+                // 分支 = 实验组 + 服务器没有云端 vision 偏好 + 用户没在 fetch 间隙
+                // 手动切 toggle，才把隐私模式默认关掉。升级用户没有 pending marker
+                // 不会被误覆写；offline 首启把 marker 留在 localStorage，下次在线启动再补
                 const noServerVisionPref = !serverSettings ||
                     serverSettings.proactiveVisionEnabled === undefined;
                 const userToggledDuringFetch = S.proactiveVisionEnabled !== _visionAtFetchStart;
-                const branchAlreadyApplied = _branchAlreadyObserved === telemetryBranch;
-                if (telemetryBranch === _PRIVACY_OFF_BRANCH
-                        && !branchAlreadyApplied
+                if (_firstLaunchPending
+                        && telemetryBranch === _PRIVACY_OFF_BRANCH
                         && noServerVisionPref
                         && !userToggledDuringFetch) {
                     if (S.proactiveVisionEnabled !== true) {
@@ -517,10 +521,11 @@
                         console.log('[app-settings] A/B 实验组', telemetryBranch, '：隐私模式默认关闭');
                     }
                 }
-                // 不论是否触发覆写，只要 server 给了 branch 就落 marker，保证
-                // 下次启动不再尝试，控制组用户也只查一次
-                if (telemetryBranch && !branchAlreadyApplied) {
-                    try { localStorage.setItem(_BRANCH_OBSERVED_KEY, telemetryBranch); } catch (_) {}
+                // 只要 server 给了 branch，本次决议就算完成（不管控制组还是实验组、
+                // 不管是否实际触发覆写），清掉 pending marker；下次启动不再尝试。
+                // GET 失败则 marker 留着，下次在线启动重新决议
+                if (telemetryBranch && _firstLaunchPending) {
+                    try { localStorage.removeItem(_FIRST_LAUNCH_PENDING_KEY); } catch (_) {}
                 }
 
                 if (serverSettings) {

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -524,8 +524,14 @@
                 // 只要 server 给了 branch，本次决议就算完成（不管控制组还是实验组、
                 // 不管是否实际触发覆写），清掉 pending marker；下次启动不再尝试。
                 // GET 失败则 marker 留着，下次在线启动重新决议
-                if (telemetryBranch && _firstLaunchPending) {
+                const branchResolutionFinalized = !!(telemetryBranch && _firstLaunchPending);
+                if (branchResolutionFinalized) {
                     try { localStorage.removeItem(_FIRST_LAUNCH_PENDING_KEY); } catch (_) {}
+                    // 首启 branch 决议完后强制 POST 一次：控制组没有 server merge、也没
+                    // 触发 A/B 覆写时 hasUpdate 仍是 false，若用户在 60s periodic 之前关掉
+                    // app，首启的本地默认值就永远到不了服务器。这里 hasUpdate=true 让下方
+                    // saveSettings 走完整路径推一次
+                    hasUpdate = true;
                 }
 
                 if (serverSettings) {

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -116,10 +116,20 @@
 
     /**
      * 启动定期同步到服务器
+     *
+     * branch 决议未完成（_FIRST_LAUNCH_PENDING_KEY 还在）时跳过 periodic POST：
+     * 否则会把首启控制组默认值推到服务器，下次 GET 拿到 branch 后读到自家 echo
+     * 误判「云端已有偏好」，让 A/B 实验组覆写永久跳过 + marker 清掉。用户主动改
+     * 设置走的 saveSettings 不受影响（那条路径就是要持久化用户显式选择）。
      */
     function startPeriodicSync() {
         if (_syncTimerId !== null) return; // 防止重复启动
         _syncTimerId = setInterval(() => {
+            try {
+                if (localStorage.getItem(_FIRST_LAUNCH_PENDING_KEY) === '1') {
+                    return;
+                }
+            } catch (_) { /* localStorage 不可用就当 pending 没 set，照常 sync */ }
             syncSettingsToServer();
         }, SYNC_INTERVAL_MS);
         console.log('[app-settings] 已启动定期同步到服务器，间隔', SYNC_INTERVAL_MS / 1000, '秒');

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -415,11 +415,9 @@
                     focusModeDesc: S.focusModeEnabled ? 'AI说话时自动静音麦克风（不允许打断）' : '允许打断AI说话'
                 });
             } else {
-                // 首次启动：检查用户地区，中国用户自动开启自主视觉
-                if (_isUserRegionChina()) {
-                    S.proactiveVisionEnabled = true;
-                    console.log('首次启动：检测到中国地区用户，已自动开启自主视觉');
-                }
+                // 首次启动：隐私模式一律默认关闭（即 proactiveVisionEnabled 默认开启），
+                // 不再按用户语言/地区区分
+                S.proactiveVisionEnabled = true;
 
                 // 首次启动默认开启音乐/meme搭话 + mini-game 邀请
                 S.proactiveMusicEnabled = true;

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -17,6 +17,11 @@
     let _syncTimerId = null;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
+    // first-launch 标记：让服务器返回 telemetryBranch 后，能识别这次是不是首启，
+    // 决定要不要对实验组追加「隐私模式默认关闭」覆写
+    let _isFirstLaunch = false;
+    // 隐私模式 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）
+    const _PRIVACY_OFF_BRANCH = 'privacy_default_off_v1';
 
     /**
      * 获取对话相关设置（仅包含需要同步到服务器的设置）
@@ -59,9 +64,14 @@
             });
             if (!response.ok) return null;
             const data = await response.json();
-            if (data.success && data.settings && Object.keys(data.settings).length > 0) {
-                return data.settings;
-            }
+            if (!data.success) return null;
+            const hasSettings = data.settings && Object.keys(data.settings).length > 0;
+            const telemetryBranch = (typeof data.telemetryBranch === 'string' && data.telemetryBranch) || null;
+            if (!hasSettings && !telemetryBranch) return null;
+            return {
+                settings: hasSettings ? data.settings : null,
+                telemetryBranch
+            };
         } catch (e) {
             console.warn('[app-settings] 从服务器加载设置失败:', e);
         }
@@ -415,9 +425,14 @@
                     focusModeDesc: S.focusModeEnabled ? 'AI说话时自动静音麦克风（不允许打断）' : '允许打断AI说话'
                 });
             } else {
-                // 首次启动：隐私模式一律默认关闭（即 proactiveVisionEnabled 默认开启），
-                // 不再按用户语言/地区区分
-                S.proactiveVisionEnabled = true;
+                // 首次启动：默认按 A/B 控制组行为——隐私模式按用户地区分流（仅中国
+                // 地区默认关闭）。实验组（privacy_default_off_v1）的「一律默认关闭」
+                // 由 loadSettingsFromServer 拿到 telemetryBranch 后追加覆写，见下方
+                // 异步合并块。
+                _isFirstLaunch = true;
+                if (_isUserRegionChina()) {
+                    S.proactiveVisionEnabled = true;
+                }
 
                 // 首次启动默认开启音乐/meme搭话 + mini-game 邀请
                 S.proactiveMusicEnabled = true;
@@ -462,10 +477,27 @@
 
         // 异步：从服务器加载对话设置并合并（不阻塞 UI）
         try {
-            loadSettingsFromServer().then(serverSettings => {
+            loadSettingsFromServer().then(serverResult => {
+                if (!serverResult) return;
+                const serverSettings = serverResult.settings;
+                const telemetryBranch = serverResult.telemetryBranch;
+                let hasUpdate = false;
+
+                // A/B test 覆写：首启 + 实验组 + 服务器没有用户既有偏好时，
+                // 把隐私模式默认关闭（proactiveVisionEnabled = true）。已有云端
+                // 偏好的用户和控制组保持各自原状不动。
+                const noServerVisionPref = !serverSettings ||
+                    serverSettings.proactiveVisionEnabled === undefined;
+                if (_isFirstLaunch && telemetryBranch === _PRIVACY_OFF_BRANCH && noServerVisionPref) {
+                    if (S.proactiveVisionEnabled !== true) {
+                        S.proactiveVisionEnabled = true;
+                        hasUpdate = true;
+                        console.log('[app-settings] A/B 实验组', telemetryBranch, '：隐私模式默认关闭');
+                    }
+                }
+
                 if (serverSettings) {
                     // 用服务器设置覆盖本地设置
-                    let hasUpdate = false;
                     for (const key of Object.keys(serverSettings)) {
                         if (serverSettings[key] !== undefined && S[key] !== serverSettings[key]) {
                             S[key] = serverSettings[key];
@@ -479,30 +511,31 @@
                     if (serverSettings.userLanguage !== undefined && window.subtitleBridge) {
                         window.subtitleBridge.setUserLanguage(serverSettings.userLanguage);
                     }
-                    if (hasUpdate) {
-                        console.log('[app-settings] 已从服务器合并对话设置');
-                        // 同步 window 镜像变量，防止 saveSettings() 回滚
-                        window.proactiveChatEnabled = S.proactiveChatEnabled;
-                        window.proactiveVisionEnabled = S.proactiveVisionEnabled;
-                        window.proactiveVisionChatEnabled = S.proactiveVisionChatEnabled;
-                        window.proactiveNewsChatEnabled = S.proactiveNewsChatEnabled;
-                        window.proactiveVideoChatEnabled = S.proactiveVideoChatEnabled;
-                        window.proactivePersonalChatEnabled = S.proactivePersonalChatEnabled;
-                        window.proactiveMusicEnabled = S.proactiveMusicEnabled;
-                        window.mergeMessagesEnabled = S.mergeMessagesEnabled;
-                        window.focusModeEnabled = S.focusModeEnabled;
-                        window.avatarReactionBubbleEnabled = S.avatarReactionBubbleEnabled;
-                        window.proactiveChatInterval = S.proactiveChatInterval;
-                        window.proactiveVisionInterval = S.proactiveVisionInterval;
-                        window.textGuardMaxLength = S.textGuardMaxLength;
-                        // 同步回 localStorage
-                        saveSettings();
-                        // 重新初始化主动搭话调度器（使用最新标志）
-                        if (typeof window.appProactive !== 'undefined' && window.appProactive.scheduleProactiveChat) {
-                            window.appProactive.scheduleProactiveChat();
-                        } else if (typeof window.scheduleProactiveChat === 'function') {
-                            window.scheduleProactiveChat();
-                        }
+                }
+
+                if (hasUpdate) {
+                    console.log('[app-settings] 已从服务器合并对话设置');
+                    // 同步 window 镜像变量，防止 saveSettings() 回滚
+                    window.proactiveChatEnabled = S.proactiveChatEnabled;
+                    window.proactiveVisionEnabled = S.proactiveVisionEnabled;
+                    window.proactiveVisionChatEnabled = S.proactiveVisionChatEnabled;
+                    window.proactiveNewsChatEnabled = S.proactiveNewsChatEnabled;
+                    window.proactiveVideoChatEnabled = S.proactiveVideoChatEnabled;
+                    window.proactivePersonalChatEnabled = S.proactivePersonalChatEnabled;
+                    window.proactiveMusicEnabled = S.proactiveMusicEnabled;
+                    window.mergeMessagesEnabled = S.mergeMessagesEnabled;
+                    window.focusModeEnabled = S.focusModeEnabled;
+                    window.avatarReactionBubbleEnabled = S.avatarReactionBubbleEnabled;
+                    window.proactiveChatInterval = S.proactiveChatInterval;
+                    window.proactiveVisionInterval = S.proactiveVisionInterval;
+                    window.textGuardMaxLength = S.textGuardMaxLength;
+                    // 同步回 localStorage
+                    saveSettings();
+                    // 重新初始化主动搭话调度器（使用最新标志）
+                    if (typeof window.appProactive !== 'undefined' && window.appProactive.scheduleProactiveChat) {
+                        window.appProactive.scheduleProactiveChat();
+                    } else if (typeof window.scheduleProactiveChat === 'function') {
+                        window.scheduleProactiveChat();
                     }
                 }
             });

--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -506,15 +506,22 @@
 
                 // A/B test 覆写：必须是本 PR 之后真·首启（_FIRST_LAUNCH_PENDING_KEY 存在）+
                 // 分支 = 实验组 + 服务器没有云端 vision 偏好 + 用户没在 fetch 间隙
-                // 手动切 toggle，才把隐私模式默认关掉。升级用户没有 pending marker
-                // 不会被误覆写；offline 首启把 marker 留在 localStorage，下次在线启动再补
+                // 手动切 toggle + 本地 vision 值仍等于控制组默认（即用户也没在之前的
+                // offline session 里改过），才把隐私模式默认关掉。升级用户没有 pending
+                // marker 不会被误覆写；offline 首启把 marker 留在 localStorage，下次
+                // 在线启动再补；offline 期间用户改过 toggle 时本地值跟控制组默认会拉
+                // 开差距，保留用户选择
                 const noServerVisionPref = !serverSettings ||
                     serverSettings.proactiveVisionEnabled === undefined;
                 const userToggledDuringFetch = S.proactiveVisionEnabled !== _visionAtFetchStart;
+                const controlGroupDefaultVision = _isUserRegionChina();
+                const localVisionMatchesControlDefault =
+                    S.proactiveVisionEnabled === controlGroupDefaultVision;
                 if (_firstLaunchPending
                         && telemetryBranch === _PRIVACY_OFF_BRANCH
                         && noServerVisionPref
-                        && !userToggledDuringFetch) {
+                        && !userToggledDuringFetch
+                        && localVisionMatchesControlDefault) {
                     if (S.proactiveVisionEnabled !== true) {
                         S.proactiveVisionEnabled = true;
                         hasUpdate = true;

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -405,17 +405,19 @@ def _get_telemetry_branch(config_dir: Path) -> str:
     p = config_dir / _TELEMETRY_BRANCH_FILE
 
     def _read() -> Optional[str]:
-        # 严格校验：只接受已知 branch 值。文件被截断/损坏成任意字符串时直接当
-        # 「没文件」处理，让 slow path 重新抽签写入；否则进程级缓存会固化脏值，
-        # 前端首启分流和遥测 cohort 全跟着错。append-only 池下迁移期老分支也
-        # 该保留在 _TELEMETRY_BRANCHES 里，所以这里不会误杀历史值。
-        try:
-            if p.exists():
-                value = p.read_text(encoding="utf-8").strip()
-                if value in _TELEMETRY_BRANCHES:
-                    return value
-        except Exception:
-            pass
+        # 返 None 只表示「文件不存在 / 内容非法」两种确定状态；transient I/O 错误
+        # 故意向上冒泡。否则老设备一次读盘失败会被吞成 None，slow path 把
+        # FileExistsError 当成「文件存在但内容坏」走自愈覆盖，静默把设备改组。
+        # 让 OSError 透出，让 `/conversation-settings` 的 except 把 telemetryBranch
+        # 返 None，前端保留 pending marker，下次启动 fast path 读到合法值收敛。
+        #
+        # 严格校验：append-only 池下迁移期老分支也该保留在 _TELEMETRY_BRANCHES
+        # 里，所以这里不会误杀历史值。
+        if not p.exists():
+            return None
+        value = p.read_text(encoding="utf-8").strip()
+        if value in _TELEMETRY_BRANCHES:
+            return value
         return None
 
     # Fast path：文件已存在直接读

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -443,8 +443,16 @@ def _get_telemetry_branch(config_dir: Path) -> str:
         peer = _read()
         if peer is not None:
             return _telemetry_branch_cache.setdefault(cache_key, peer)
-        # 回读失败兜底：返回本进程抽到的值。短期不一致总比拒绝上报好；下次
-        # 启动 fast path 会读到磁盘上的固化值，最终收敛。
+        # peer 是 None 说明文件存在但内容不在 _TELEMETRY_BRANCHES 里（截断/损坏/
+        # 跨版本残留）。这种情况下若只返回本进程抽到的值不修盘，下次进程重启会
+        # 再走一次「读到坏值 → fast path miss → slow path 拿到 FileExistsError →
+        # 重抽」，cohort 在多次启动间反复翻滚。覆盖修盘保证只有这一次重抽，
+        # 之后就稳定。
+        try:
+            with open(p, "w", encoding="utf-8") as f:
+                f.write(branch)
+        except Exception as e:
+            logger.debug(f"Token tracker: failed to heal corrupt branch file: {e}")
         return _telemetry_branch_cache.setdefault(cache_key, branch)
     except Exception as e:
         # 写盘失败不致命：进程级缓存 setdefault 保证同一进程后续所有调用方拿到

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -405,10 +405,14 @@ def _get_telemetry_branch(config_dir: Path) -> str:
     p = config_dir / _TELEMETRY_BRANCH_FILE
 
     def _read() -> Optional[str]:
+        # 严格校验：只接受已知 branch 值。文件被截断/损坏成任意字符串时直接当
+        # 「没文件」处理，让 slow path 重新抽签写入；否则进程级缓存会固化脏值，
+        # 前端首启分流和遥测 cohort 全跟着错。append-only 池下迁移期老分支也
+        # 该保留在 _TELEMETRY_BRANCHES 里，所以这里不会误杀历史值。
         try:
             if p.exists():
                 value = p.read_text(encoding="utf-8").strip()
-                if value and len(value) <= 64:
+                if value in _TELEMETRY_BRANCHES:
                     return value
         except Exception:
             pass

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -378,6 +378,12 @@ _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
 #   - "privacy_default_off_v1"：实验组，隐私模式一律默认关闭
 _TELEMETRY_BRANCHES: tuple = ("main", "privacy_default_off_v1")
 
+# 进程级缓存：keyed by str(config_dir)。写盘失败的环境下（只读 FS / 权限拒绝），
+# 不缓存就每次 secrets.choice 重抽，导致同一 install 的 TokenTracker 上报和
+# 前端 `/conversation-settings` 拿到不同分支，A/B 归因被打散。dict.setdefault
+# 在 CPython GIL 下是原子的，足以扛住模块内的并发首抽。
+_telemetry_branch_cache: dict = {}
+
 
 def _get_telemetry_branch(config_dir: Path) -> str:
     """读取或抽签生成 A/B test 分支标识，持久化在 config_dir 下。
@@ -386,7 +392,16 @@ def _get_telemetry_branch(config_dir: Path) -> str:
     其它并发进程拿到 FileExistsError 后回读同一文件，确保 device-stable
     cohorting（同 device 不同 worker 不会落到不同 branch）。同款模式见
     _file_lock 的实现。
+
+    进程级缓存：首次 resolve 后落 `_telemetry_branch_cache`，后续调用直接命中。
+    主要为只读 FS / 权限错误等持久化失败的环境兜底——多 cohort 下没有这层缓存，
+    每次 `secrets.choice` 都会重抽，同一进程内不同调用方会观察到不同分支。
     """
+    cache_key = str(config_dir)
+    cached_proc = _telemetry_branch_cache.get(cache_key)
+    if cached_proc is not None:
+        return cached_proc
+
     p = config_dir / _TELEMETRY_BRANCH_FILE
 
     def _read() -> Optional[str]:
@@ -402,7 +417,7 @@ def _get_telemetry_branch(config_dir: Path) -> str:
     # Fast path：文件已存在直接读
     cached = _read()
     if cached is not None:
-        return cached
+        return _telemetry_branch_cache.setdefault(cache_key, cached)
 
     branch = secrets.choice(_TELEMETRY_BRANCHES) if _TELEMETRY_BRANCHES else "main"
     try:
@@ -418,21 +433,22 @@ def _get_telemetry_branch(config_dir: Path) -> str:
             os.write(fd, branch.encode("utf-8"))
         finally:
             os.close(fd)
-        return branch
+        return _telemetry_branch_cache.setdefault(cache_key, branch)
     except FileExistsError:
         # 另一个进程抢先写了 —— 回读它写的值，确保两个进程返回同一 branch
         peer = _read()
         if peer is not None:
-            return peer
+            return _telemetry_branch_cache.setdefault(cache_key, peer)
         # 回读失败兜底：返回本进程抽到的值。短期不一致总比拒绝上报好；下次
         # 启动 fast path 会读到磁盘上的固化值，最终收敛。
-        return branch
+        return _telemetry_branch_cache.setdefault(cache_key, branch)
     except Exception as e:
-        # 写盘失败不致命：单次进程内继续用抽到的分支上报，下次启动会再抽。
-        # 当前 _TELEMETRY_BRANCHES 只有一项，写失败不会有可观偏差；扩展后若
-        # 写盘长期失败，server 看到的将是分布噪声而非错误数据。
+        # 写盘失败不致命：进程级缓存 setdefault 保证同一进程后续所有调用方拿到
+        # 相同分支，TokenTracker 上报和前端 API 不会互相打架。下次进程重启时若
+        # 写盘仍然失败，缓存重新随机抽——按设计这就是 server 端看到的分布噪声
+        # 来源，不构成「同一 install 多个分支」的错误数据。
         logger.debug(f"Token tracker: failed to persist telemetry branch: {e}")
-        return branch
+        return _telemetry_branch_cache.setdefault(cache_key, branch)
 
 
 def get_telemetry_branch() -> str:

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -373,7 +373,10 @@ def _get_anonymous_device_id() -> str:
 # ---------------------------------------------------------------------------
 
 _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
-_TELEMETRY_BRANCHES: tuple = ("main",)
+# A/B 池：
+#   - "main"：控制组，沿用历史默认（隐私模式按用户地区分流，仅中国地区默认关闭）
+#   - "privacy_default_off_v1"：实验组，隐私模式一律默认关闭
+_TELEMETRY_BRANCHES: tuple = ("main", "privacy_default_off_v1")
 
 
 def _get_telemetry_branch(config_dir: Path) -> str:
@@ -430,6 +433,16 @@ def _get_telemetry_branch(config_dir: Path) -> str:
         # 写盘长期失败，server 看到的将是分布噪声而非错误数据。
         logger.debug(f"Token tracker: failed to persist telemetry branch: {e}")
         return branch
+
+
+def get_telemetry_branch() -> str:
+    """对外暴露的 A/B test 分支读取入口。
+
+    `_get_telemetry_branch` 是内部实现（参数化 config_dir，方便测试）；本函数从
+    全局 config_manager 取 config_dir 后转发。前端通过 API 拿到 branch 后可在
+    首次启动时按分支选择默认行为，与 token tracker 自身上报的 branch 保持一致。
+    """
+    return _get_telemetry_branch(get_config_manager().config_dir)
 
 
 def _get_telemetry_locale() -> str:


### PR DESCRIPTION
## Summary

把首启「隐私模式默认关闭」挂到 #1329 落地的 A/B test branch 框架上，控制组保留 #1328 之前的中国地区分流行为，实验组（`privacy_default_off_v1`）走「所有用户一律默认关闭」。telemetry 上报 branch 后 server 端可直接按分支切分指标。

## Changes

**`utils/token_tracker.py`**
- `_TELEMETRY_BRANCHES = ("main", "privacy_default_off_v1")`：新设备 `secrets.choice` 50/50 抽签，老设备已落盘的 `.telemetry_branch` 文件维持原值不动（device-stable 承诺）
- 新增模块级 `get_telemetry_branch()`：转发到内部 `_get_telemetry_branch(config_dir)`，给非 TokenTracker 调用者用

**`main_routers/config_router.py`**
- `GET /api/config/conversation-settings` 响应里追加 `telemetryBranch` 字段，避免前端单独再发一个 fetch

**`static/app-settings.js`**
- First-launch sync 路径恢复 #1328 之前的中国地区分流（控制组行为）
- `loadSettingsFromServer()` 返回值从 settings dict 改为 `{ settings, telemetryBranch }`
- 在 server 返回后的异步合并块里：若 first-launch + 分支为 `privacy_default_off_v1` + 服务器没有云端 `proactiveVisionEnabled` 偏好，追加覆写为 `true` 并 `saveSettings()`。已有云端偏好的用户和控制组都不动

## 验证局限

改动效果只在 localStorage 为空 + `.telemetry_branch` 未落盘的真·首启场景下显现，preview 没法快速复现两组对照。本地已经验过：
- `uv run python -c "from utils.token_tracker import get_telemetry_branch, _TELEMETRY_BRANCHES; ..."` 返回 `('main', 'privacy_default_off_v1')` 和实际抽到的 branch
- 改动文件全部通过 `ast.parse` / `new Function()` 语法检查
- `from main_routers.config_router import router` 干净 import

## Test plan

- [x] Python 端 `_TELEMETRY_BRANCHES` 扩展后 `get_telemetry_branch()` 正常返回
- [x] `/api/config/conversation-settings` GET 响应包含 `telemetryBranch`
- [ ] 清空 localStorage 和 `.telemetry_branch` 后多次首启，验证 50/50 分流 + 实验组覆写到 `proactiveVisionEnabled=true`
- [ ] 已有 `project_neko_settings` 的老用户重启后偏好不被覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能调整**
  * 启动流程新增“首次启动挂起”标记；在初次配置合并时按服务端返回的遥测分支有条件地应用隐私分支覆盖并持久化。
  * 保存设置新增可选跳过服务器同步（首次仅写本地）；合并后会同步并更新全局状态与主动对话调度。
  * 周期性服务器同步在初次分支决策完成前会跳过上报。

* **修复/稳固性**
  * 遥测分支解析与进程级缓存增强，提升分支一致性、并发恢复与错误处理能力。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1328)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->