### PR TITLE
feat(telemetry): branch / locale / timezone / distribution + 防原文泄漏

### DIFF
--- a/local_server/telemetry_server/models.py
+++ b/local_server/telemetry_server/models.py
@@ -72,6 +72,14 @@ class TelemetryEvent(BaseModel):
     """客户端上报的遥测负载。"""
     device_id: str = Field(..., min_length=16, max_length=128)
     app_version: str = Field(default="unknown", max_length=64)
+    # 三个用户维度字段。`branch` 在客户端首次启动时随机抽签后落盘，后续保持稳
+    # 定，用于 A/B test 分流；`locale` / `timezone` 每次上报取实时值，同设备
+    # 不同 locale/tz 仍视为同一 device，server 端覆写最新值即可。
+    branch: str = Field(default="unknown", max_length=64)
+    locale: str = Field(default="unknown", max_length=32)
+    timezone: str = Field(default="unknown", max_length=64)
+    # 发行渠道：steam（Steam 启动）/ release（编译版直启）/ source（源码运行）/ unknown
+    distribution: str = Field(default="unknown", max_length=32)
     daily_stats: Dict[str, DailyStats] = Field(default_factory=dict)
     recent_records: List[RecentRecord] = Field(default_factory=list)
 

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -134,6 +134,10 @@ async def submit_telemetry(request: Request):
             payload_json=payload_json,
             daily_stats=daily_stats_dict,
             batch_id=batch_id,
+            branch=submission.payload.branch,
+            locale=submission.payload.locale,
+            timezone=submission.payload.timezone,
+            distribution=submission.payload.distribution,
         )
     except Exception as e:
         logger.error(f"Store failed for {device_id[:8]}...: {e}")

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -182,9 +182,12 @@ class TelemetryStorage:
                         bucket.get("total_tokens", 0), bucket.get("cached_tokens", 0),
                         bucket.get("call_count", 0), 0,
                     )
-            # branch 在客户端首次启动后落盘并保持稳定，所以理论上同一 device 只
-            # 该看到一个非 unknown 值；这里仍允许覆写 —— 万一用户清盘后客户端重新
-            # 抽签，新值就是当前真值。locale / timezone 每次取最新值同样覆写。
+            # branch 在客户端首次启动后落盘并保持稳定，理论上同一 device 只该
+            # 看到一个非 unknown 值；非 unknown 时直接覆写（清盘重抽时也只会是
+            # 新真值）。locale / timezone / distribution 每次取实时值，同样仅当
+            # 非 unknown 才覆写 —— 老客户端没带这些字段时 Pydantic 默认 'unknown'，
+            # 或新客户端临时检测失败（例如 tzlocal 抛错）时，都不应该把上一次
+            # 已知的好值抹成 'unknown'。
             conn.execute("""
                 INSERT INTO devices (device_id, app_version, branch, locale, timezone, distribution,
                                      first_seen, last_seen, event_count)
@@ -193,10 +196,10 @@ class TelemetryStorage:
                         strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'), 1)
                 ON CONFLICT(device_id) DO UPDATE SET
                     app_version  = excluded.app_version,
-                    branch       = excluded.branch,
-                    locale       = excluded.locale,
-                    timezone     = excluded.timezone,
-                    distribution = excluded.distribution,
+                    branch       = CASE WHEN excluded.branch       = 'unknown' THEN devices.branch       ELSE excluded.branch       END,
+                    locale       = CASE WHEN excluded.locale       = 'unknown' THEN devices.locale       ELSE excluded.locale       END,
+                    timezone     = CASE WHEN excluded.timezone     = 'unknown' THEN devices.timezone     ELSE excluded.timezone     END,
+                    distribution = CASE WHEN excluded.distribution = 'unknown' THEN devices.distribution ELSE excluded.distribution END,
                     last_seen = strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'),
                     event_count = event_count + 1
             """, (device_id, app_version, branch, locale, timezone, distribution))

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -112,14 +112,24 @@ class TelemetryStorage:
             # 老库 devices 表上线时还没有 branch/locale/timezone/distribution 列。
             # CREATE TABLE IF NOT EXISTS 不会动已存在的 schema，所以这里显式补列；
             # ALTER ADD COLUMN 在 SQLite 上是 O(1)，已有行的列值用 DEFAULT 填。
+            # try/except 是必要的：多进程部署（gunicorn workers / 多副本）首次
+            # 启动时会同时跑迁移，PRAGMA + ALTER 不是原子的，一个 worker ALTER
+            # 成功后第二个 worker 仍按陈旧的 PRAGMA 结果尝试 ALTER，会撞
+            # "duplicate column name"。捕获并忽略让迁移在并发下幂等。
             existing_cols = {
                 r[1] for r in conn.execute("PRAGMA table_info(devices)").fetchall()
             }
             for col_name in ("branch", "locale", "timezone", "distribution"):
-                if col_name not in existing_cols:
+                if col_name in existing_cols:
+                    continue
+                try:
                     conn.execute(
                         f"ALTER TABLE devices ADD COLUMN {col_name} TEXT NOT NULL DEFAULT 'unknown'"
                     )
+                except sqlite3.OperationalError as e:
+                    # 只吞 "duplicate column name"，其它 schema 错误照常往上抛。
+                    if "duplicate column name" not in str(e).lower():
+                        raise
             conn.commit()
             self._initialized = True
 

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -95,6 +95,10 @@ class TelemetryStorage:
                 CREATE TABLE IF NOT EXISTS devices (
                     device_id    TEXT PRIMARY KEY,
                     app_version  TEXT    NOT NULL DEFAULT 'unknown',
+                    branch       TEXT    NOT NULL DEFAULT 'unknown',
+                    locale       TEXT    NOT NULL DEFAULT 'unknown',
+                    timezone     TEXT    NOT NULL DEFAULT 'unknown',
+                    distribution TEXT    NOT NULL DEFAULT 'unknown',
                     first_seen   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
                     last_seen    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
                     event_count  INTEGER NOT NULL DEFAULT 0
@@ -105,6 +109,17 @@ class TelemetryStorage:
                     received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'))
                 );
             """)
+            # 老库 devices 表上线时还没有 branch/locale/timezone/distribution 列。
+            # CREATE TABLE IF NOT EXISTS 不会动已存在的 schema，所以这里显式补列；
+            # ALTER ADD COLUMN 在 SQLite 上是 O(1)，已有行的列值用 DEFAULT 填。
+            existing_cols = {
+                r[1] for r in conn.execute("PRAGMA table_info(devices)").fetchall()
+            }
+            for col_name in ("branch", "locale", "timezone", "distribution"):
+                if col_name not in existing_cols:
+                    conn.execute(
+                        f"ALTER TABLE devices ADD COLUMN {col_name} TEXT NOT NULL DEFAULT 'unknown'"
+                    )
             conn.commit()
             self._initialized = True
 
@@ -119,7 +134,9 @@ class TelemetryStorage:
         return row is not None
 
     def store_event(self, device_id: str, app_version: str, payload_json: str,
-                    daily_stats: dict, batch_id: str | None = None):
+                    daily_stats: dict, batch_id: str | None = None,
+                    branch: str = "unknown", locale: str = "unknown",
+                    timezone: str = "unknown", distribution: str = "unknown"):
         today = date.today().isoformat()
         with self._transaction() as conn:
             if batch_id:
@@ -155,14 +172,24 @@ class TelemetryStorage:
                         bucket.get("total_tokens", 0), bucket.get("cached_tokens", 0),
                         bucket.get("call_count", 0), 0,
                     )
+            # branch 在客户端首次启动后落盘并保持稳定，所以理论上同一 device 只
+            # 该看到一个非 unknown 值；这里仍允许覆写 —— 万一用户清盘后客户端重新
+            # 抽签，新值就是当前真值。locale / timezone 每次取最新值同样覆写。
             conn.execute("""
-                INSERT INTO devices (device_id, app_version, first_seen, last_seen, event_count)
-                VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'), strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'), 1)
+                INSERT INTO devices (device_id, app_version, branch, locale, timezone, distribution,
+                                     first_seen, last_seen, event_count)
+                VALUES (?, ?, ?, ?, ?, ?,
+                        strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'),
+                        strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'), 1)
                 ON CONFLICT(device_id) DO UPDATE SET
-                    app_version = excluded.app_version,
+                    app_version  = excluded.app_version,
+                    branch       = excluded.branch,
+                    locale       = excluded.locale,
+                    timezone     = excluded.timezone,
+                    distribution = excluded.distribution,
                     last_seen = strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'),
                     event_count = event_count + 1
-            """, (device_id, app_version))
+            """, (device_id, app_version, branch, locale, timezone, distribution))
 
     @staticmethod
     def _upsert_aggregate(conn, device_id, stat_date, model, call_type,

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -2426,7 +2426,10 @@ def cogtts_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
                     )
                     return
 
-                _record_tts_telemetry("cogtts", len(text))
+                # CogTTS payload 实际只发了 text[:1024]（行 2407 的硬截断，上游
+                # API 限制 1024 字符）。telemetry 记 min 而不是 len(text)，否则超
+                # 长输入会高估实际计费/上行的字符数。
+                _record_tts_telemetry("cogtts", min(len(text), 1024))
                 buffer = ""
                 first_audio_received = False
 

--- a/main_logic/tts_client.py
+++ b/main_logic/tts_client.py
@@ -43,15 +43,19 @@ logger = get_module_logger(__name__, "Main")
 TTS_SHUTDOWN_SENTINEL = "__shutdown__"
 
 
-def _record_tts_telemetry(model_name: str, text: str):
+def _record_tts_telemetry(model_name: str, char_count: int):
     """Record TTS usage telemetry via TokenTracker.
 
     TTS providers (CosyVoice, CogTTS, GPT-SoVITS, etc.) bill per character,
     not per token, so we report the input length on the dedicated
     `prompt_chars` field instead of squatting in `prompt_tokens`. Token
     aggregates stay clean for actual LLM usage tracking.
+
+    Telemetry hard rule: this helper takes a count only. Never pass synthesized
+    text or any substring of it — only ``len(text)``. Sending raw content into
+    the tracker risks leaking user utterances through the remote uploader.
     """
-    if not text or not text.strip():
+    if char_count <= 0:
         return
     try:
         from utils.token_tracker import TokenTracker
@@ -61,7 +65,7 @@ def _record_tts_telemetry(model_name: str, text: str):
             completion_tokens=0,
             total_tokens=0,
             call_type='tts',
-            prompt_chars=len(text),
+            prompt_chars=int(char_count),
         )
     except Exception:
         pass
@@ -934,7 +938,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         "type": "tts.text.delta",
                         "data": {"session_id": session_id, "text": pending_text_buffer},
                     }))
-                    _record_tts_telemetry("stepfun", pending_text_buffer)
+                    _record_tts_telemetry("stepfun", len(pending_text_buffer))
                 except Exception as e:
                     # delta 发失败时连接多半已断，调用方不能继续发 tts.text.done；
                     # 返回 False 让 sid=None/文本发送路径都走 continue 触发重连。
@@ -1256,7 +1260,7 @@ def step_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         }
                     }
                     await ws.send(json.dumps(text_event))
-                    _record_tts_telemetry("stepfun", tts_text)
+                    _record_tts_telemetry("stepfun", len(tts_text))
                 except Exception as e:
                     logger.error(f"发送TTS文本失败: {e}")
                     # 连接已关闭，标记为无效以便下次重连
@@ -1605,7 +1609,7 @@ def grok_streaming_tts_worker(request_queue, response_queue, audio_api_key, voic
                     # 按到达顺序处理，多 delta 等价单 delta。
                     for delta in _grok_chunk_text_delta(payload_text):
                         await ws.send(json.dumps({"type": "text.delta", "delta": delta}))
-                    _record_tts_telemetry("grok", payload_text)
+                    _record_tts_telemetry("grok", len(payload_text))
                 except Exception as e:
                     logger.error(f"发送 text.delta 失败: {type(e).__name__}: {e}")
                     # send 失败时把内容放回 pending（绑定当前 sid），等下次重连后重发。
@@ -1725,7 +1729,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         "event_id": f"event_{int(time.time() * 1000)}",
                         "text": pending_text_buffer,
                     }))
-                    _record_tts_telemetry("qwen", pending_text_buffer)
+                    _record_tts_telemetry("qwen", len(pending_text_buffer))
                 except Exception as e:
                     # append 发失败时连接多半已断，调用方不能继续发 commit；
                     # 返回 False 让 sid=None/文本路径走 continue 触发重连。
@@ -1999,7 +2003,7 @@ def qwen_realtime_tts_worker(request_queue, response_queue, audio_api_key, voice
                         "event_id": f"event_{int(time.time() * 1000)}",
                         "text": tts_text
                     }))
-                    _record_tts_telemetry("qwen", tts_text)
+                    _record_tts_telemetry("qwen", len(tts_text))
                 except Exception as e:
                     logger.error(f"发送TTS文本失败: {e}")
                     # 连接已关闭，标记为无效以便下次重连
@@ -2198,7 +2202,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
             synthesizer = _create_synthesizer(detected_lang)
             callback.accepted_speech_id = current_speech_id
         synthesizer.streaming_call(char_buffer)
-        _record_tts_telemetry("cosyvoice", char_buffer)
+        _record_tts_telemetry("cosyvoice", len(char_buffer))
         last_streaming_call_time = time.time()
         char_buffer = ""
 
@@ -2321,7 +2325,7 @@ def cosyvoice_vc_tts_worker(request_queue, response_queue, audio_api_key, voice_
                 synthesizer = _create_synthesizer(detected_lang)
                 callback.accepted_speech_id = current_speech_id
                 synthesizer.streaming_call(char_buffer)
-                _record_tts_telemetry("cosyvoice", char_buffer)
+                _record_tts_telemetry("cosyvoice", len(char_buffer))
                 last_streaming_call_time = time.time()
                 char_buffer = ""
             except Exception as e:
@@ -2422,7 +2426,7 @@ def cogtts_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
                     )
                     return
 
-                _record_tts_telemetry("cogtts", text[:1024])
+                _record_tts_telemetry("cogtts", len(text))
                 buffer = ""
                 first_audio_received = False
 
@@ -2638,7 +2642,7 @@ def gemini_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
                         raise
 
             if audio_data:
-                _record_tts_telemetry("gemini", text)
+                _record_tts_telemetry("gemini", len(text))
                 audio_array = np.frombuffer(audio_data, dtype=np.int16)
                 resampled_bytes = _resample_audio(audio_array, 24000, 48000)
                 response_queue.put(resampled_bytes)
@@ -2694,7 +2698,7 @@ def openai_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
                 input=text,
                 response_format="pcm",
             ) as response:
-                _record_tts_telemetry("gpt-4o-mini-tts", text)
+                _record_tts_telemetry("gpt-4o-mini-tts", len(text))
                 async for chunk in response.iter_bytes(chunk_size=4096):
                     if chunk:
                         audio_array = np.frombuffer(chunk, dtype=np.int16)
@@ -2963,7 +2967,7 @@ def gptsovits_tts_worker(request_queue, response_queue, audio_api_key, voice_id)
                 if _ws_is_open(ws):
                     try:
                         await ws.send(json.dumps({"cmd": "append", "data": tts_text}))
-                        _record_tts_telemetry("gptsovits", tts_text)
+                        _record_tts_telemetry("gptsovits", len(tts_text))
                         # TTS 文本原文不写 logger
                         logger.debug(f"[GPT-SoVITS v3] append (len={len(tts_text)} chars)")
                         print(f"[GPT-SoVITS v3] append: {tts_text[:30]}...")
@@ -3092,7 +3096,7 @@ async def _minimax_sse_synthesize(
                 _enqueue_error(response_queue, f"MiniMax TTS API错误 ({resp.status_code}): {error_text[:300]}")
                 return
 
-            _record_tts_telemetry("minimax", text)
+            _record_tts_telemetry("minimax", len(text))
 
             content_type = resp.headers.get("content-type", "").lower()
 
@@ -3262,6 +3266,10 @@ def dummy_tts_worker(request_queue, response_queue, audio_api_key, voice_id):
             # sid is None 是 end-of-utterance 信号，dummy 不做任何处理
             if sid == "__interrupt__" or sid is None:
                 continue
+            # 即便不合成音频也上报字符数 + 调用次数，方便分析"配置成无 TTS"
+            # 的用户产生了多少假装合成的请求；只传 len()，不传原文。
+            if tts_text:
+                _record_tts_telemetry("dummy", len(tts_text))
         except Exception as e:
             logger.error(f"Dummy TTS Worker 错误: {e}")
             break
@@ -3655,7 +3663,7 @@ def local_cosyvoice_worker(request_queue, response_queue, audio_api_key, voice_i
             if ws:
                 try:
                     await ws.send(json.dumps({"text": tts_text}))
-                    _record_tts_telemetry("local_cosyvoice", tts_text)
+                    _record_tts_telemetry("local_cosyvoice", len(tts_text))
                     # TTS 文本原文不写 logger
                     logger.debug(f"发送合成片段 (len={len(tts_text)} chars)")
                     print(f"发送合成片段: {tts_text}")

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -517,22 +517,26 @@ def _get_telemetry_timezone() -> str:
     except Exception:
         pass
     try:
-        local_tz = datetime.now().astimezone().tzinfo
+        now_local = datetime.now().astimezone()
+        local_tz = now_local.tzinfo
         if local_tz is not None:
             name = str(local_tz)
             # Windows 上 astimezone 可能给出 "China Standard Time" 这类非 IANA 字串，
             # 没有 '/' 时退到 offset 表示，避免污染按 IANA 切片的分析。
             if name and "/" in name:
                 return name[:64]
+        # 取实际 UTC 偏移（aware datetime 反映当前 DST 状态）。time.altzone /
+        # time.daylight 不行：time.daylight 只表示"locale 有没有 DST 制度"，
+        # 不是"现在是不是 DST"，在有 DST 的时区会全年报 DST 偏移。
+        offset = now_local.utcoffset()
+        if offset is not None:
+            total_sec = int(offset.total_seconds())
+            sign = "+" if total_sec >= 0 else "-"
+            abs_sec = abs(total_sec)
+            return f"{sign}{abs_sec // 3600:02d}:{(abs_sec % 3600) // 60:02d}"
     except Exception:
         pass
-    try:
-        offset_sec = time.altzone if time.daylight else time.timezone
-        sign = "-" if offset_sec > 0 else "+"
-        abs_sec = abs(int(offset_sec))
-        return f"{sign}{abs_sec // 3600:02d}:{(abs_sec % 3600) // 60:02d}"
-    except Exception:
-        return "unknown"
+    return "unknown"
 
 
 def _compute_telemetry_signature(payload_json: str, timestamp: float) -> str:

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -27,6 +27,7 @@ import hmac
 import json
 import logging
 import os
+import secrets
 import threading
 import time
 import urllib.request
@@ -360,6 +361,180 @@ def _get_anonymous_device_id() -> str:
     return _get_legacy_device_id()
 
 
+# ---------------------------------------------------------------------------
+# A/B test 分支 / 用户 locale / 时区
+#
+# 三者都是描述「这台机器/这个用户当前是谁」的副字段：
+#   - branch：首次启动时随机抽签后落盘，后续启动只读不改，保证同一设备稳定。
+#             当前 _TELEMETRY_BRANCHES 只有一个值，将来扩展元组即可触发 split；
+#             已经落盘的老用户继续读到旧分支，新用户随机进新池。
+#   - locale / timezone：每次上报时取当下值；同一设备换语言/换时区都视为同
+#             一个 device_id，server 端按 "latest seen" 覆写即可。
+# ---------------------------------------------------------------------------
+
+_TELEMETRY_BRANCH_FILE = ".telemetry_branch"
+_TELEMETRY_BRANCHES: tuple = ("main",)
+
+
+def _get_telemetry_branch(config_dir: Path) -> str:
+    """读取或抽签生成 A/B test 分支标识，持久化在 config_dir 下。"""
+    try:
+        p = config_dir / _TELEMETRY_BRANCH_FILE
+        if p.exists():
+            value = p.read_text(encoding="utf-8").strip()
+            if value and len(value) <= 64:
+                return value
+    except Exception:
+        pass
+
+    branch = secrets.choice(_TELEMETRY_BRANCHES) if _TELEMETRY_BRANCHES else "main"
+    try:
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / _TELEMETRY_BRANCH_FILE).write_text(branch, encoding="utf-8")
+    except Exception as e:
+        # 写盘失败不致命：单次进程内继续用抽到的分支上报，下次启动会再抽。
+        # 同一设备多次抽签可能落到不同分支，但只要 _TELEMETRY_BRANCHES 只有一项
+        # 就不会有偏差；将来扩展时若写盘长期失败，server 看到的将是分布噪声而非
+        # 错误数据。
+        logger.debug(f"Token tracker: failed to persist telemetry branch: {e}")
+    return branch
+
+
+def _get_telemetry_locale() -> str:
+    """获取用户 UI locale (zh-CN / en-US / ja-JP …)。
+
+    优先用 language_utils.get_global_language_full —— 它先看 Steam 设置再 fallback
+    到系统语言，是 codebase 里 "用户真正在用的 UI 语言" 的真值。失败回退到
+    stdlib locale。
+    """
+    try:
+        from utils.language_utils import get_global_language_full
+        loc = get_global_language_full()
+        if loc:
+            return str(loc)[:32]
+    except Exception:
+        pass
+    try:
+        import locale as _locale
+        sys_locale = _locale.getlocale()[0]
+        if sys_locale:
+            return str(sys_locale)[:32]
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _is_release_build() -> bool:
+    """是否打包过 —— PyInstaller (``sys.frozen``) 或 Nuitka (``__compiled__`` /
+    ``__nuitka_binary_dir``)。两种打包器都要识别：PyInstaller 走 spec 链路，
+    Nuitka 走 build_nuitka.bat 链路。"""
+    import sys
+
+    if getattr(sys, "frozen", False):
+        return True
+    # Nuitka 在每个编译模块的 globals 里注入 __compiled__；主模块还有
+    # __nuitka_binary_dir。先看当前模块 globals，再兜底主模块属性，确保 standalone
+    # 和 onefile 两种 Nuitka 模式都能识别。
+    if "__compiled__" in globals() or "__nuitka_binary_dir" in globals():
+        return True
+    main_mod = sys.modules.get("__main__")
+    if main_mod is not None and (
+        hasattr(main_mod, "__nuitka_binary_dir") or hasattr(main_mod, "__compiled__")
+    ):
+        return True
+    return False
+
+
+def _is_steam_sdk_engaged() -> bool:
+    """Steam SDK 是否拿到/缓存过 user id 或 工坊订阅。
+
+    任一信号为真即认为是 Steam 版：
+    1. 当前进程 Steamworks SDK 实例的 ``Users.GetSteamID()`` 返回非零 —— 真
+       的从 Steam 客户端拿到了登录用户。
+    2. ``Workshop.GetNumSubscribedItems()`` 大于 0 —— 用户订阅过工坊内容。
+    3. ``config_dir/workshop_config.json`` 存在 —— 之前任何一次会话写过工坊
+       配置，足以证明这台机器跑过 Steam 版（cloudsave 会把它打包带走，所以
+       即使本次会话 Steam 客户端没开，文件仍在就算）。
+
+    1/2 是实时探测，覆盖正常 Steam session；3 是磁盘兜底，覆盖"上次跑过 Steam
+    本次断网/客户端没开"的场景。
+    """
+    try:
+        from utils.steam_state import get_steamworks
+        sw = get_steamworks()
+        if sw is not None:
+            try:
+                if int(sw.Users.GetSteamID() or 0) > 0:
+                    return True
+            except Exception:
+                pass
+            try:
+                if int(sw.Workshop.GetNumSubscribedItems() or 0) > 0:
+                    return True
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    try:
+        from utils.config_manager import get_config_manager
+        cm = get_config_manager()
+        if (cm.config_dir / "workshop_config.json").exists():
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _get_telemetry_distribution() -> str:
+    """识别发行渠道：steam / release / source。
+
+    判定顺序：
+    1. 先看是否 release build（PyInstaller ``sys.frozen`` 或 Nuitka
+       ``__compiled__`` / ``__nuitka_binary_dir``）。**只有 release 才可能是
+       Steam 版** —— 源码运行哪怕开着 Steam 客户端也算 source。
+    2. release + Steam SDK 拿到/缓存过 user id 或工坊订阅 → ``steam``。
+    3. release 但 SDK 没动 → ``release``（独立发行版）。
+    4. 非 release → ``source``（开源/开发模式）。
+    """
+    if not _is_release_build():
+        return "source"
+    if _is_steam_sdk_engaged():
+        return "steam"
+    return "release"
+
+
+def _get_telemetry_timezone() -> str:
+    """获取本地时区。优先 IANA (Asia/Shanghai)，回退到 UTC 偏移 (+08:00)。"""
+    try:
+        import tzlocal
+        tz = tzlocal.get_localzone()
+        if tz is not None:
+            name = str(tz)
+            if name:
+                return name[:64]
+    except Exception:
+        pass
+    try:
+        local_tz = datetime.now().astimezone().tzinfo
+        if local_tz is not None:
+            name = str(local_tz)
+            # Windows 上 astimezone 可能给出 "China Standard Time" 这类非 IANA 字串，
+            # 没有 '/' 时退到 offset 表示，避免污染按 IANA 切片的分析。
+            if name and "/" in name:
+                return name[:64]
+    except Exception:
+        pass
+    try:
+        offset_sec = time.altzone if time.daylight else time.timezone
+        sign = "-" if offset_sec > 0 else "+"
+        abs_sec = abs(int(offset_sec))
+        return f"{sign}{abs_sec // 3600:02d}:{(abs_sec % 3600) // 60:02d}"
+    except Exception:
+        return "unknown"
+
+
 def _compute_telemetry_signature(payload_json: str, timestamp: float) -> str:
     """计算遥测上报的 HMAC-SHA256 签名。"""
     body_hash = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
@@ -411,6 +586,7 @@ class TokenTracker:
 
         # 远程遥测上报
         self._device_id: str = ""  # 延迟生成
+        self._branch: str = ""  # 延迟生成（首次上报时读盘/抽签）
         self._last_report_time: float = 0.0
         self._report_interval = _TELEMETRY_REPORT_INTERVAL
         self._unsent_daily: dict = {}  # 尚未成功上报到服务器的增量
@@ -852,8 +1028,13 @@ class TokenTracker:
         try:
             if not self._device_id:
                 self._device_id = _get_anonymous_device_id()
+            if not self._branch:
+                self._branch = _get_telemetry_branch(self._config_manager.config_dir)
 
             app_version = _get_app_version_from_changelog()
+            telemetry_locale = _get_telemetry_locale()
+            telemetry_timezone = _get_telemetry_timezone()
+            telemetry_distribution = _get_telemetry_distribution()
 
             payload = {
                 "device_id": self._device_id,
@@ -864,6 +1045,10 @@ class TokenTracker:
                 # server 端验签会自动覆盖到，不需要任何调整。
                 "device_id_legacy": _get_legacy_device_id(),
                 "app_version": app_version,
+                "branch": self._branch,
+                "locale": telemetry_locale,
+                "timezone": telemetry_timezone,
+                "distribution": telemetry_distribution,
                 "daily_stats": send_daily,
                 "recent_records": send_records,
             }

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -377,27 +377,59 @@ _TELEMETRY_BRANCHES: tuple = ("main",)
 
 
 def _get_telemetry_branch(config_dir: Path) -> str:
-    """读取或抽签生成 A/B test 分支标识，持久化在 config_dir 下。"""
-    try:
-        p = config_dir / _TELEMETRY_BRANCH_FILE
-        if p.exists():
-            value = p.read_text(encoding="utf-8").strip()
-            if value and len(value) <= 64:
-                return value
-    except Exception:
-        pass
+    """读取或抽签生成 A/B test 分支标识，持久化在 config_dir 下。
+
+    多进程冷启动安全：用 ``O_CREAT | O_EXCL`` 原子创建保证只有一个进程能写入；
+    其它并发进程拿到 FileExistsError 后回读同一文件，确保 device-stable
+    cohorting（同 device 不同 worker 不会落到不同 branch）。同款模式见
+    _file_lock 的实现。
+    """
+    p = config_dir / _TELEMETRY_BRANCH_FILE
+
+    def _read() -> Optional[str]:
+        try:
+            if p.exists():
+                value = p.read_text(encoding="utf-8").strip()
+                if value and len(value) <= 64:
+                    return value
+        except Exception:
+            pass
+        return None
+
+    # Fast path：文件已存在直接读
+    cached = _read()
+    if cached is not None:
+        return cached
 
     branch = secrets.choice(_TELEMETRY_BRANCHES) if _TELEMETRY_BRANCHES else "main"
     try:
         config_dir.mkdir(parents=True, exist_ok=True)
-        (config_dir / _TELEMETRY_BRANCH_FILE).write_text(branch, encoding="utf-8")
+    except Exception as e:
+        logger.debug(f"Token tracker: failed to create config dir for branch file: {e}")
+
+    # Slow path：原子创建。两个进程同时走到这里只有一个成功，另一个回读拿到
+    # 同一 branch，保证 device-stable。
+    try:
+        fd = os.open(str(p), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        try:
+            os.write(fd, branch.encode("utf-8"))
+        finally:
+            os.close(fd)
+        return branch
+    except FileExistsError:
+        # 另一个进程抢先写了 —— 回读它写的值，确保两个进程返回同一 branch
+        peer = _read()
+        if peer is not None:
+            return peer
+        # 回读失败兜底：返回本进程抽到的值。短期不一致总比拒绝上报好；下次
+        # 启动 fast path 会读到磁盘上的固化值，最终收敛。
+        return branch
     except Exception as e:
         # 写盘失败不致命：单次进程内继续用抽到的分支上报，下次启动会再抽。
-        # 同一设备多次抽签可能落到不同分支，但只要 _TELEMETRY_BRANCHES 只有一项
-        # 就不会有偏差；将来扩展时若写盘长期失败，server 看到的将是分布噪声而非
-        # 错误数据。
+        # 当前 _TELEMETRY_BRANCHES 只有一项，写失败不会有可观偏差；扩展后若
+        # 写盘长期失败，server 看到的将是分布噪声而非错误数据。
         logger.debug(f"Token tracker: failed to persist telemetry branch: {e}")
-    return branch
+        return branch
 
 
 def _get_telemetry_locale() -> str:


### PR DESCRIPTION
## Summary

- 遥测新增 4 个用户维度字段：`branch` / `locale` / `timezone` / `distribution`
- TTS 遥测改成只传 `char_count`，从函数签名层面杜绝原文泄漏；顺手补上 dummy worker 的字符数 + 调用次数
- Server 端 schema + 老库自动迁移

## 字段语义

| 字段 | 来源 | 稳定性 |
|---|---|---|
| `branch` | 首次启动随机抽签后落盘 `config_dir/.telemetry_branch` | 设备级稳定（A/B 分流用，当前只有 `main`，扩展元组即可触发 split） |
| `locale` | `language_utils.get_global_language_full()`（Steam > 系统） | 每次上报取当下值，server 端覆写最新值 |
| `timezone` | `tzlocal` 优先 IANA（`Asia/Shanghai`），回退 UTC offset | 同上 |
| `distribution` | `steam` / `release` / `source` | 同上 |

`distribution` 判定逻辑（拆成 `_is_release_build` + `_is_steam_sdk_engaged`）：
- **release**：PyInstaller (`sys.frozen`) 或 Nuitka (`__compiled__` / `__nuitka_binary_dir`，当前模块 globals + 主模块属性双查，覆盖 standalone 和 onefile)
- **steam**：release **且** Steam SDK 有动静——任一为真即可：
  - 实时 `Users.GetSteamID() > 0`
  - 实时 `Workshop.GetNumSubscribedItems() > 0`
  - 磁盘兜底 `config_dir/workshop_config.json` 存在（cloudsave 会打包带走，断网/Steam 客户端没开时仍算）
- **source**：其它一律 source —— 源码运行哪怕开着 Steam 客户端也算 source

## TTS 防原文泄漏

- `_record_tts_telemetry(model, text)` → `_record_tts_telemetry(model, char_count: int)`，签名层面拒收原文
- 13 个调用点全部改成传 `len(...)`，并修掉 cogtts 之前 `text[:1024]` 的截断 bug
- dummy_tts_worker 也接上遥测，记录配置成无 TTS 的用户产生了多少假装合成请求

## Server

- `TelemetryEvent` 增 4 个字段，全部 `default='unknown'`，兼容老客户端
- `devices` 表加 4 列；`_ensure_tables` 里用 `PRAGMA table_info` + `ALTER TABLE ADD COLUMN` 自动迁移老库
- `INSERT OR ON CONFLICT DO UPDATE` 时覆写 `branch` / `locale` / `timezone` / `distribution` 为最新值
- HMAC 覆盖完整 payload 自动覆盖新字段；`batch_id` 故意不变（保持重试幂等）

## Test plan

- [x] `ast.parse` 4 个改动文件全部通过
- [x] 4 种 build × steam 组合验证 distribution 判定（release+steam=steam / release+no=release / source+steam=source / source+no=source）
- [x] 老库迁移（无 4 列 → ALTER TABLE 补列 → 老行填 unknown → upsert 覆写）
- [x] 全部 13 处 TTS telemetry 调用点确认传 `len(...)` 而非字符串
- [ ] 部署到测试服务器后验证客户端 → server 真实链路（部署侧操作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 遥测事件新增四项用户维度：分支、地区、时区、发行版，随上报发送，默认值为“unknown”。

* **改进**
  * 存储层升级以持久化并向后兼容新增设备属性，启动时自动补齐缺失列并安全处理并发情况。
  * 采集端改为上报字符计数并延迟/限制原始文本上传以增强隐私。
  * 上报逻辑自动填充并发送新增元数据以丰富统计与导出分析。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1329)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->