### PR TITLE
feat(telemetry): upload Steam64 user_id when Steamworks SDK provides it

### DIFF
--- a/local_server/telemetry_server/models.py
+++ b/local_server/telemetry_server/models.py
@@ -80,6 +80,10 @@ class TelemetryEvent(BaseModel):
     timezone: str = Field(default="unknown", max_length=64)
     # 发行渠道：steam（Steam 启动）/ release（编译版直启）/ source（源码运行）/ unknown
     distribution: str = Field(default="unknown", max_length=32)
+    # Steam64 user id（string，避免 u64 在 JS 等消费方精度丢失）。仅在
+    # Steamworks SDK 起来 + 拿到 Users.GetSteamID 时填值，否则为空 string。
+    # max_length=24 给 u64 十进制（20 位）留余量，防止异常长串攻击。
+    steam_user_id: str = Field(default="", max_length=24)
     daily_stats: Dict[str, DailyStats] = Field(default_factory=dict)
     recent_records: List[RecentRecord] = Field(default_factory=list)
 

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -125,11 +125,17 @@ async def submit_telemetry(request: Request):
     if storage.is_duplicate_batch(batch_id):
         return SubmitResponse(ok=True, message="duplicate, skipped")
 
-    # steam_user_id 边界校验：Steam64 是 u64，十进制最多 20 位。HMAC secret
-    # 在开源客户端里可读，被泄露后伪造请求是有概率事件；空值或非纯数字 / 超
-    # 长串都视作无效，落库前归零，防止异常值污染下游 join 维度。
+    # steam_user_id 边界校验：Steam64 是 u64，十进制最多 20 位且非零。HMAC
+    # secret 在开源客户端里可读，被泄露后伪造请求是有概率事件；空值 / 非纯
+    # 数字 / 超长串 / 数值零（"0" / "00" 等 Steamworks "无用户" sentinel）都
+    # 视作无效，落库前归零。否则伪造请求可用 "0" 把已存在的合法 steam_user_id
+    # 覆盖（UPSERT preserve-known 只挡空 string）。
     steam_user_id = submission.payload.steam_user_id
-    if steam_user_id and (not steam_user_id.isdigit() or len(steam_user_id) > 20):
+    if steam_user_id and not (
+        steam_user_id.isdigit()
+        and len(steam_user_id) <= 20
+        and int(steam_user_id) > 0
+    ):
         steam_user_id = ""
 
     # 存储

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -125,19 +125,25 @@ async def submit_telemetry(request: Request):
     if storage.is_duplicate_batch(batch_id):
         return SubmitResponse(ok=True, message="duplicate, skipped")
 
-    # steam_user_id 边界校验：Steam64 是 u64，合法范围 1..2^64-1。HMAC
-    # secret 在开源客户端里可读，被泄露后伪造请求是有概率事件；空值 / 非纯
-    # 数字 / 超长串 / 数值零（"0" / "00" 等 Steamworks "无用户" sentinel）/
-    # 超 u64 上限（20 位数最大 99..9 远超 2^64-1）都视作无效，落库前归零。
-    # 否则伪造请求可用 "0" 或 "99999999999999999999" 把已存在的合法
-    # steam_user_id 覆盖（UPSERT preserve-known 只挡空 string）。
+    # steam_user_id 边界校验 + 归一化：
+    # - Steam64 是 u64，合法范围 1..2^64-1。HMAC secret 在开源客户端里可读，
+    #   被泄露后伪造请求是有概率事件。
+    # - 空值 / 非纯数字 / 超长串 / 数值零（"0" / "00" 等 Steamworks "无用户"
+    #   sentinel）/ 超 u64 上限（"99999999999999999999" 等）都视作无效，归零。
+    # - 通过校验后用 ``str(int(...))`` 归一化为 canonical 十进制，否则伪造
+    #   请求可送 "00076561198000000000" 把同账号 string-based join 拆成两个
+    #   不同的 device↔account 维度。
+    # len<=20 是 cheap pre-check 避免对超长 isdigit 串做大整数转换（DoS guard）。
     steam_user_id = submission.payload.steam_user_id
-    if steam_user_id and not (
-        steam_user_id.isdigit()
-        and len(steam_user_id) <= 20
-        and 0 < int(steam_user_id) < (1 << 64)
-    ):
-        steam_user_id = ""
+    if steam_user_id:
+        if (
+            steam_user_id.isdigit()
+            and len(steam_user_id) <= 20
+            and 0 < int(steam_user_id) < (1 << 64)
+        ):
+            steam_user_id = str(int(steam_user_id))
+        else:
+            steam_user_id = ""
 
     # 存储
     try:

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -138,6 +138,7 @@ async def submit_telemetry(request: Request):
             locale=submission.payload.locale,
             timezone=submission.payload.timezone,
             distribution=submission.payload.distribution,
+            steam_user_id=submission.payload.steam_user_id,
         )
     except Exception as e:
         logger.error(f"Store failed for {device_id[:8]}...: {e}")

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -125,6 +125,13 @@ async def submit_telemetry(request: Request):
     if storage.is_duplicate_batch(batch_id):
         return SubmitResponse(ok=True, message="duplicate, skipped")
 
+    # steam_user_id 边界校验：Steam64 是 u64，十进制最多 20 位。HMAC secret
+    # 在开源客户端里可读，被泄露后伪造请求是有概率事件；空值或非纯数字 / 超
+    # 长串都视作无效，落库前归零，防止异常值污染下游 join 维度。
+    steam_user_id = submission.payload.steam_user_id
+    if steam_user_id and (not steam_user_id.isdigit() or len(steam_user_id) > 20):
+        steam_user_id = ""
+
     # 存储
     try:
         daily_stats_dict = {k: model_to_dict(v) for k, v in submission.payload.daily_stats.items()}
@@ -138,7 +145,7 @@ async def submit_telemetry(request: Request):
             locale=submission.payload.locale,
             timezone=submission.payload.timezone,
             distribution=submission.payload.distribution,
-            steam_user_id=submission.payload.steam_user_id,
+            steam_user_id=steam_user_id,
         )
     except Exception as e:
         logger.error(f"Store failed for {device_id[:8]}...: {e}")

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -125,16 +125,17 @@ async def submit_telemetry(request: Request):
     if storage.is_duplicate_batch(batch_id):
         return SubmitResponse(ok=True, message="duplicate, skipped")
 
-    # steam_user_id 边界校验：Steam64 是 u64，十进制最多 20 位且非零。HMAC
+    # steam_user_id 边界校验：Steam64 是 u64，合法范围 1..2^64-1。HMAC
     # secret 在开源客户端里可读，被泄露后伪造请求是有概率事件；空值 / 非纯
-    # 数字 / 超长串 / 数值零（"0" / "00" 等 Steamworks "无用户" sentinel）都
-    # 视作无效，落库前归零。否则伪造请求可用 "0" 把已存在的合法 steam_user_id
-    # 覆盖（UPSERT preserve-known 只挡空 string）。
+    # 数字 / 超长串 / 数值零（"0" / "00" 等 Steamworks "无用户" sentinel）/
+    # 超 u64 上限（20 位数最大 99..9 远超 2^64-1）都视作无效，落库前归零。
+    # 否则伪造请求可用 "0" 或 "99999999999999999999" 把已存在的合法
+    # steam_user_id 覆盖（UPSERT preserve-known 只挡空 string）。
     steam_user_id = submission.payload.steam_user_id
     if steam_user_id and not (
         steam_user_id.isdigit()
         and len(steam_user_id) <= 20
-        and int(steam_user_id) > 0
+        and 0 < int(steam_user_id) < (1 << 64)
     ):
         steam_user_id = ""
 

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -93,15 +93,16 @@ class TelemetryStorage:
                 CREATE INDEX IF NOT EXISTS idx_agg_date   ON daily_aggregates(stat_date);
 
                 CREATE TABLE IF NOT EXISTS devices (
-                    device_id    TEXT PRIMARY KEY,
-                    app_version  TEXT    NOT NULL DEFAULT 'unknown',
-                    branch       TEXT    NOT NULL DEFAULT 'unknown',
-                    locale       TEXT    NOT NULL DEFAULT 'unknown',
-                    timezone     TEXT    NOT NULL DEFAULT 'unknown',
-                    distribution TEXT    NOT NULL DEFAULT 'unknown',
-                    first_seen   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
-                    last_seen    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
-                    event_count  INTEGER NOT NULL DEFAULT 0
+                    device_id     TEXT PRIMARY KEY,
+                    app_version   TEXT    NOT NULL DEFAULT 'unknown',
+                    branch        TEXT    NOT NULL DEFAULT 'unknown',
+                    locale        TEXT    NOT NULL DEFAULT 'unknown',
+                    timezone      TEXT    NOT NULL DEFAULT 'unknown',
+                    distribution  TEXT    NOT NULL DEFAULT 'unknown',
+                    steam_user_id TEXT    NOT NULL DEFAULT '',
+                    first_seen    TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
+                    last_seen     TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
+                    event_count   INTEGER NOT NULL DEFAULT 0
                 );
 
                 CREATE TABLE IF NOT EXISTS seen_batches (
@@ -109,9 +110,9 @@ class TelemetryStorage:
                     received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'))
                 );
             """)
-            # 老库 devices 表上线时还没有 branch/locale/timezone/distribution 列。
-            # CREATE TABLE IF NOT EXISTS 不会动已存在的 schema，所以这里显式补列；
-            # ALTER ADD COLUMN 在 SQLite 上是 O(1)，已有行的列值用 DEFAULT 填。
+            # 老库 devices 表上线时还没有 branch/locale/timezone/distribution/steam_user_id
+            # 列。CREATE TABLE IF NOT EXISTS 不会动已存在的 schema，所以这里显式
+            # 补列；ALTER ADD COLUMN 在 SQLite 上是 O(1)，已有行的列值用 DEFAULT 填。
             # try/except 是必要的：多进程部署（gunicorn workers / 多副本）首次
             # 启动时会同时跑迁移，PRAGMA + ALTER 不是原子的，一个 worker ALTER
             # 成功后第二个 worker 仍按陈旧的 PRAGMA 结果尝试 ALTER，会撞
@@ -119,12 +120,22 @@ class TelemetryStorage:
             existing_cols = {
                 r[1] for r in conn.execute("PRAGMA table_info(devices)").fetchall()
             }
-            for col_name in ("branch", "locale", "timezone", "distribution"):
+            # (列名, 默认 sentinel) —— 分类字段缺失为 'unknown'，
+            # steam_user_id 是 ID 字段缺失为空 string，server 端 UPSERT 用对应
+            # sentinel 做 preserve-known 判断。
+            _new_cols = (
+                ("branch", "unknown"),
+                ("locale", "unknown"),
+                ("timezone", "unknown"),
+                ("distribution", "unknown"),
+                ("steam_user_id", ""),
+            )
+            for col_name, default in _new_cols:
                 if col_name in existing_cols:
                     continue
                 try:
                     conn.execute(
-                        f"ALTER TABLE devices ADD COLUMN {col_name} TEXT NOT NULL DEFAULT 'unknown'"
+                        f"ALTER TABLE devices ADD COLUMN {col_name} TEXT NOT NULL DEFAULT '{default}'"
                     )
                 except sqlite3.OperationalError as e:
                     # 只吞 "duplicate column name"，其它 schema 错误照常往上抛。
@@ -146,7 +157,8 @@ class TelemetryStorage:
     def store_event(self, device_id: str, app_version: str, payload_json: str,
                     daily_stats: dict, batch_id: str | None = None,
                     branch: str = "unknown", locale: str = "unknown",
-                    timezone: str = "unknown", distribution: str = "unknown"):
+                    timezone: str = "unknown", distribution: str = "unknown",
+                    steam_user_id: str = ""):
         today = date.today().isoformat()
         with self._transaction() as conn:
             if batch_id:
@@ -188,21 +200,26 @@ class TelemetryStorage:
             # 非 unknown 才覆写 —— 老客户端没带这些字段时 Pydantic 默认 'unknown'，
             # 或新客户端临时检测失败（例如 tzlocal 抛错）时，都不应该把上一次
             # 已知的好值抹成 'unknown'。
+            # branch/locale/timezone/distribution 缺失 sentinel 是 'unknown'，
+            # steam_user_id 是空 string（ID 字段不该用 'unknown' 占位 —— 它会
+            # 被下游 join 当成合法 ID）。两种 sentinel 都走 preserve-known：
+            # incoming 是 sentinel 时不覆写历史。
             conn.execute("""
-                INSERT INTO devices (device_id, app_version, branch, locale, timezone, distribution,
+                INSERT INTO devices (device_id, app_version, branch, locale, timezone, distribution, steam_user_id,
                                      first_seen, last_seen, event_count)
-                VALUES (?, ?, ?, ?, ?, ?,
+                VALUES (?, ?, ?, ?, ?, ?, ?,
                         strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'),
                         strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'), 1)
                 ON CONFLICT(device_id) DO UPDATE SET
-                    app_version  = excluded.app_version,
-                    branch       = CASE WHEN excluded.branch       = 'unknown' THEN devices.branch       ELSE excluded.branch       END,
-                    locale       = CASE WHEN excluded.locale       = 'unknown' THEN devices.locale       ELSE excluded.locale       END,
-                    timezone     = CASE WHEN excluded.timezone     = 'unknown' THEN devices.timezone     ELSE excluded.timezone     END,
-                    distribution = CASE WHEN excluded.distribution = 'unknown' THEN devices.distribution ELSE excluded.distribution END,
+                    app_version   = excluded.app_version,
+                    branch        = CASE WHEN excluded.branch        = 'unknown' THEN devices.branch        ELSE excluded.branch        END,
+                    locale        = CASE WHEN excluded.locale        = 'unknown' THEN devices.locale        ELSE excluded.locale        END,
+                    timezone      = CASE WHEN excluded.timezone      = 'unknown' THEN devices.timezone      ELSE excluded.timezone      END,
+                    distribution  = CASE WHEN excluded.distribution  = 'unknown' THEN devices.distribution  ELSE excluded.distribution  END,
+                    steam_user_id = CASE WHEN excluded.steam_user_id = ''        THEN devices.steam_user_id ELSE excluded.steam_user_id END,
                     last_seen = strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'),
                     event_count = event_count + 1
-            """, (device_id, app_version, branch, locale, timezone, distribution))
+            """, (device_id, app_version, branch, locale, timezone, distribution, steam_user_id))
 
     @staticmethod
     def _upsert_aggregate(conn, device_id, stat_date, model, call_type,

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -519,6 +519,32 @@ def _is_steam_sdk_engaged() -> bool:
     return False
 
 
+def _get_telemetry_steam_user_id() -> str:
+    """读取当前会话的 Steam64 user id，作为字符串返回。
+
+    返回非空 string 表示 Steamworks SDK 真的从 Steam 客户端拿到了登录用户；
+    返回空 string 表示 SDK 没起来 / Steam 客户端没开 / 源码模式没初始化
+    SDK 等情形。
+
+    用 string 而非 int 上报，避免 Steam64（u64，常超过 2^53）在某些 JSON
+    消费方（JS / 部分 SDK）里精度丢失。
+    """
+    try:
+        from utils.steam_state import get_steamworks
+        sw = get_steamworks()
+        if sw is None:
+            return ""
+        try:
+            sid = int(sw.Users.GetSteamID() or 0)
+        except Exception:
+            return ""
+        if sid > 0:
+            return str(sid)
+    except Exception:
+        pass
+    return ""
+
+
 def _get_telemetry_distribution() -> str:
     """识别发行渠道：steam / release / source。
 
@@ -1071,6 +1097,7 @@ class TokenTracker:
             telemetry_locale = _get_telemetry_locale()
             telemetry_timezone = _get_telemetry_timezone()
             telemetry_distribution = _get_telemetry_distribution()
+            telemetry_steam_user_id = _get_telemetry_steam_user_id()
 
             payload = {
                 "device_id": self._device_id,
@@ -1085,6 +1112,9 @@ class TokenTracker:
                 "locale": telemetry_locale,
                 "timezone": telemetry_timezone,
                 "distribution": telemetry_distribution,
+                # 仅在 Steamworks SDK 起来 + 拿到 Steam64 时填值，其它情况为
+                # 空 string。server 端按 preserve-known 处理：空值不覆写历史。
+                "steam_user_id": telemetry_steam_user_id,
                 "daily_stats": send_daily,
                 "recent_records": send_records,
             }


### PR DESCRIPTION
## Summary

接 #1329。telemetry payload 新增 `steam_user_id` 字段：当 Steamworks SDK 已加载且 `Users.GetSteamID()` 返回非零时，把 Steam64 一起上报；否则为空 string。

`steam_user_id` 与 `device_id` 不替换关系，二者独立：
- `device_id` 是硬件指纹（每设备稳定，账号无关）
- `steam_user_id` 是账号身份（每 Steam 用户稳定，跨设备）

同账号多设备 / 同设备多账号都能在分析端 join 出来。

## 实现细节

**Client** [utils/token_tracker.py](utils/token_tracker.py)
- `_get_telemetry_steam_user_id() -> str`：复用 `utils.steam_state.get_steamworks()` 单例，`int(sw.Users.GetSteamID())` 转 string 上报
- 用 string 而非 int 上报：Steam64 是 u64，常超过 `2^53`，JS / 部分 JSON 消费方会精度丢失

**Server**
- [models.py](local_server/telemetry_server/models.py)：`TelemetryEvent.steam_user_id: str = Field(default="", max_length=24)` —— u64 十进制 20 位 + 余量，挡异常长串
- [storage.py](local_server/telemetry_server/storage.py)：`devices.steam_user_id TEXT NOT NULL DEFAULT ''`，自动 `ALTER TABLE ADD COLUMN` 迁移老库，UPSERT 用 preserve-known（incoming `''` 不覆写历史）—— Steam session 偶尔被无 SDK session 接力时不丢 Steam64
- [server.py](local_server/telemetry_server/server.py)：透传

ID 字段的 sentinel 用空 string 而非 `'unknown'`（避免下游 join 把 `'unknown'` 当合法 ID）。

## Test plan

- [x] ast.parse 4 文件
- [x] 新库：写入带 steam_user_id → 写入空 string → 保留历史 → 写入新 steam_user_id 覆盖
- [x] 老库迁移：缺 steam_user_id 列 → ALTER 补列 → 老行默认空 string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 遥测系统新增 steam_user_id 字段以记录 Steam64 用户标识。
  * 提交端对该标识进行数字性与长度校验，不合规值或缺失将规范为空字符串。
  * 服务端在处理链路中保留并传递该字段以便后续使用。
  * 存储层持久化该标识，且空值不会覆盖已有非空值。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1330)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->