### PR TITLE
fix(voice): bind default yui voice for free api

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -372,7 +372,7 @@
     "sweetLady": "voice-tone-PGLmTEeUOu",
     "frailMaiden": "voice-tone-PGLmzXEX44",
     "childishMaiden": "voice-tone-PGLnVNQn7A",
-    "yui_cn": "voice-tone-QqMv39SYSW"
+    "yui_cn": "voice-tone-R6NtLH3Hk0"
   },
   "_comment_native_tts_voice_providers": "Shape: {providerKey: {catalog_prefix, default_voice, default_male_voice, catalog_value_is_display_name, voices, aliases, inherits}}. voices maps upstream voice_id to display label. Keep this list to voices available on realtime/free TTS paths; some HTTP-only or permission-gated official voices are intentionally omitted.",
   "native_tts_voice_providers": {

--- a/config/characters/en.json
+++ b/config/characters/en.json
@@ -28,7 +28,7 @@
       ],
       "Signature Line": "Hmph, obviously this kitty has to keep an eye on Carbon-Based Lifeform, meow~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/es.json
+++ b/config/characters/es.json
@@ -28,7 +28,7 @@
       ],
       "Frase Característica": "Hmf, está claro que esta gatita tiene que vigilar a la Forma de Vida Basada en Carbono, miau~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/ja.json
+++ b/config/characters/ja.json
@@ -28,7 +28,7 @@
       ],
       "一言セリフ": "ふん、炭素生物が変なことしないよう見てるのは本にゃんだけにゃん〜",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/ko.json
+++ b/config/characters/ko.json
@@ -28,7 +28,7 @@
       ],
       "대사 한마디": "흥, 탄소 생물이 딴짓하지 않게 지켜보는 건 당연히 이 냥이다냥~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/pt.json
+++ b/config/characters/pt.json
@@ -28,7 +28,7 @@
       ],
       "Frase Característica": "Hmf, é claro que esta gatinha precisa ficar de olho na Forma de Vida Baseada em Carbono, miau~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/ru.json
+++ b/config/characters/ru.json
@@ -28,7 +28,7 @@
       ],
       "Коронная фраза": "Хмф, следить, чтобы эта Углеродная форма жизни не натворила глупостей, конечно, должна я, мяу~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/zh-CN.json
+++ b/config/characters/zh-CN.json
@@ -28,7 +28,7 @@
       ],
       "一句话台词": "哼，盯着碳基生物别乱来的，当然只有本喵啦~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/config/characters/zh-TW.json
+++ b/config/characters/zh-TW.json
@@ -28,7 +28,7 @@
       ],
       "一句話台詞": "哼，盯著碳基生物別亂來的，當然只有本喵啦~",
       "live2d": "yui-origin",
-      "voice_id": "voice-tone-QqMv39SYSW",
+      "voice_id": "voice-tone-R6NtLH3Hk0",
       "_reserved": {
         "avatar": {
           "vrm": {

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -71,6 +71,7 @@ from utils.character_memory import (
 )
 from utils.config_manager import (
     delete_reserved,
+    ensure_default_yui_voice_for_free_api,
     flatten_reserved,
     get_reserved,
     set_reserved,
@@ -3377,6 +3378,7 @@ async def clear_voice_ids():
                     cleared_count += 1
 
         await _config_manager.asave_characters(characters)
+        await ensure_default_yui_voice_for_free_api(_config_manager)
         # 自动重新加载配置
         initialize_character_data = get_initialize_character_data()
         await initialize_character_data()

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -32,7 +32,7 @@ from utils.file_utils import atomic_write_json_async, read_json_async
 from utils.preferences import aload_user_preferences, update_model_preferences, validate_model_preferences, move_model_to_top, aload_global_conversation_settings, save_global_conversation_settings, GLOBAL_CONVERSATION_KEY
 from utils.cloudsave_runtime import MaintenanceModeError
 from utils.logger_config import get_module_logger
-from utils.config_manager import get_reserved
+from utils.config_manager import ensure_default_yui_voice_for_free_api, get_reserved
 from config import (
     AUTOSTART_CSRF_TOKEN,
     CHARACTER_SYSTEM_RESERVED_FIELDS,
@@ -802,6 +802,8 @@ async def update_core_config(request: Request):
         await asyncio.to_thread(
             config_manager.save_json_config, 'core_config.json', core_cfg
         )
+
+        await ensure_default_yui_voice_for_free_api(config_manager, core_cfg)
 
         # API配置更新后，需要先通知所有客户端，再关闭session，最后重新加载配置
         logger.info("API配置已更新，准备通知客户端并重置所有session...")

--- a/tests/unit/test_yui_free_api_default_voice.py
+++ b/tests/unit/test_yui_free_api_default_voice.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from utils.config_manager import ensure_default_yui_voice_for_free_api, get_reserved
+
+
+YUI_FREE_VOICE_ID = "voice-tone-QqMv39SYSW"
+
+
+class _FakeConfigManager:
+    def __init__(self, characters: dict, core_config: dict | None = None):
+        self.characters = deepcopy(characters)
+        self.core_config = deepcopy(core_config or {})
+        self.saved_characters = None
+
+    async def aload_characters(self):
+        return deepcopy(self.characters)
+
+    async def asave_characters(self, characters):
+        self.saved_characters = deepcopy(characters)
+        self.characters = deepcopy(characters)
+
+    async def aget_core_config(self):
+        return deepcopy(self.core_config)
+
+
+def _characters_with_current_yui(*, voice_id: str = "", model_path: str = "yui-origin/yui-origin.model3.json") -> dict:
+    return {
+        "当前猫娘": "YUI",
+        "猫娘": {
+            "YUI": {
+                "昵称": "YUI",
+                "_reserved": {
+                    "voice_id": voice_id,
+                    "avatar": {
+                        "model_type": "live2d",
+                        "live2d": {
+                            "model_path": model_path,
+                        },
+                    },
+                },
+            }
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_free_api_binds_empty_current_default_yui_voice(monkeypatch):
+    monkeypatch.setattr(
+        "utils.api_config_loader.get_free_voices",
+        lambda: {"yui_cn": YUI_FREE_VOICE_ID},
+    )
+    config_manager = _FakeConfigManager(_characters_with_current_yui(voice_id=""))
+
+    changed = await ensure_default_yui_voice_for_free_api(
+        config_manager,
+        {"coreApi": "free", "assistApi": "free"},
+    )
+
+    assert changed is True
+    assert config_manager.saved_characters is not None
+    yui = config_manager.saved_characters["猫娘"]["YUI"]
+    assert get_reserved(yui, "voice_id", default="") == YUI_FREE_VOICE_ID
+
+
+@pytest.mark.asyncio
+async def test_free_api_bind_can_use_current_core_config_when_reader_entry_calls_without_payload(monkeypatch):
+    monkeypatch.setattr(
+        "utils.api_config_loader.get_free_voices",
+        lambda: {"yui_cn": YUI_FREE_VOICE_ID},
+    )
+    config_manager = _FakeConfigManager(
+        _characters_with_current_yui(voice_id=""),
+        core_config={"coreApi": "free", "assistApi": "free"},
+    )
+
+    changed = await ensure_default_yui_voice_for_free_api(config_manager)
+
+    assert changed is True
+    yui = config_manager.saved_characters["猫娘"]["YUI"]
+    assert get_reserved(yui, "voice_id", default="") == YUI_FREE_VOICE_ID
+
+
+@pytest.mark.asyncio
+async def test_non_free_api_does_not_bind_empty_yui_voice(monkeypatch):
+    monkeypatch.setattr(
+        "utils.api_config_loader.get_free_voices",
+        lambda: {"yui_cn": YUI_FREE_VOICE_ID},
+    )
+    config_manager = _FakeConfigManager(_characters_with_current_yui(voice_id=""))
+
+    changed = await ensure_default_yui_voice_for_free_api(
+        config_manager,
+        {"coreApi": "qwen", "assistApi": "qwen"},
+    )
+
+    assert changed is False
+    assert config_manager.saved_characters is None
+    yui = config_manager.characters["猫娘"]["YUI"]
+    assert get_reserved(yui, "voice_id", default="") == ""
+
+
+@pytest.mark.asyncio
+async def test_free_api_does_not_overwrite_existing_yui_voice(monkeypatch):
+    monkeypatch.setattr(
+        "utils.api_config_loader.get_free_voices",
+        lambda: {"yui_cn": YUI_FREE_VOICE_ID},
+    )
+    config_manager = _FakeConfigManager(_characters_with_current_yui(voice_id="custom-voice"))
+
+    changed = await ensure_default_yui_voice_for_free_api(
+        config_manager,
+        {"coreApi": "free", "assistApi": "free"},
+    )
+
+    assert changed is False
+    assert config_manager.saved_characters is None
+    yui = config_manager.characters["猫娘"]["YUI"]
+    assert get_reserved(yui, "voice_id", default="") == "custom-voice"
+
+
+@pytest.mark.asyncio
+async def test_free_api_does_not_bind_non_default_yui_model(monkeypatch):
+    monkeypatch.setattr(
+        "utils.api_config_loader.get_free_voices",
+        lambda: {"yui_cn": YUI_FREE_VOICE_ID},
+    )
+    config_manager = _FakeConfigManager(
+        _characters_with_current_yui(voice_id="", model_path="custom-yui/custom-yui.model3.json")
+    )
+
+    changed = await ensure_default_yui_voice_for_free_api(
+        config_manager,
+        {"coreApi": "free", "assistApi": "free"},
+    )
+
+    assert changed is False
+    assert config_manager.saved_characters is None
+    yui = config_manager.characters["猫娘"]["YUI"]
+    assert get_reserved(yui, "voice_id", default="") == ""

--- a/tests/unit/test_yui_free_api_default_voice.py
+++ b/tests/unit/test_yui_free_api_default_voice.py
@@ -9,7 +9,7 @@ import main_routers.characters_router as characters_router
 from utils.config_manager import ensure_default_yui_voice_for_free_api, get_reserved
 
 
-YUI_FREE_VOICE_ID = "voice-tone-QqMv39SYSW"
+YUI_FREE_VOICE_ID = "voice-tone-R6NtLH3Hk0"
 
 
 class _FakeConfigManager:

--- a/tests/unit/test_yui_free_api_default_voice.py
+++ b/tests/unit/test_yui_free_api_default_voice.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import json
 
 import pytest
 
+import main_routers.characters_router as characters_router
 from utils.config_manager import ensure_default_yui_voice_for_free_api, get_reserved
 
 
@@ -25,6 +27,11 @@ class _FakeConfigManager:
 
     async def aget_core_config(self):
         return deepcopy(self.core_config)
+
+
+def _parse_json_response(response):
+    body = getattr(response, "body", b"{}") or b"{}"
+    return json.loads(body.decode("utf-8"))
 
 
 def _characters_with_current_yui(*, voice_id: str = "", model_path: str = "yui-origin/yui-origin.model3.json") -> dict:
@@ -141,3 +148,51 @@ async def test_free_api_does_not_bind_non_default_yui_model(monkeypatch):
     assert config_manager.saved_characters is None
     yui = config_manager.characters["猫娘"]["YUI"]
     assert get_reserved(yui, "voice_id", default="") == ""
+
+
+@pytest.mark.asyncio
+async def test_clear_voice_ids_rebinds_default_yui_for_free_api(monkeypatch):
+    config_manager = _FakeConfigManager(
+        {
+            "当前猫娘": "YUI",
+            "猫娘": {
+                "YUI": {
+                    "昵称": "YUI",
+                    "_reserved": {
+                        "voice_id": "old-provider-voice",
+                        "avatar": {
+                            "model_type": "live2d",
+                            "live2d": {
+                                "model_path": "yui-origin/yui-origin.model3.json",
+                            },
+                        },
+                    },
+                },
+                "别的角色": {
+                    "_reserved": {
+                        "voice_id": "other-provider-voice",
+                    },
+                },
+            },
+        },
+        core_config={"coreApi": "free", "assistApi": "free"},
+    )
+
+    async def _noop_initialize():
+        return None
+
+    monkeypatch.setattr(
+        "utils.api_config_loader.get_free_voices",
+        lambda: {"yui_cn": YUI_FREE_VOICE_ID},
+    )
+    monkeypatch.setattr(characters_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(characters_router, "get_initialize_character_data", lambda: _noop_initialize)
+
+    response = await characters_router.clear_voice_ids()
+    body = _parse_json_response(response)
+
+    assert body["success"] is True
+    yui = config_manager.characters["猫娘"]["YUI"]
+    other = config_manager.characters["猫娘"]["别的角色"]
+    assert get_reserved(yui, "voice_id", default="") == YUI_FREE_VOICE_ID
+    assert get_reserved(other, "voice_id", default="") == ""

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -124,6 +124,113 @@ def set_reserved(data: dict, *path_and_value) -> bool:
     return True
 
 
+DEFAULT_YUI_LIVE2D_MODEL_PATH = "yui-origin/yui-origin.model3.json"
+
+
+def _normalize_live2d_model_path(value) -> str:
+    model_path = str(value or "").strip().replace("\\", "/").lower()
+    if model_path == "yui-origin":
+        return DEFAULT_YUI_LIVE2D_MODEL_PATH
+    return model_path
+
+
+def _is_default_yui_character(character_name: str, character_data: dict) -> bool:
+    if not isinstance(character_data, dict):
+        return False
+
+    name = str(character_name or "").strip().upper()
+    nickname = str(character_data.get("昵称") or "").strip().upper()
+    if name != "YUI" and nickname != "YUI":
+        return False
+
+    model_path = get_reserved(
+        character_data,
+        "avatar",
+        "live2d",
+        "model_path",
+        default="",
+        legacy_keys=("live2d",),
+    )
+    return _normalize_live2d_model_path(model_path) == DEFAULT_YUI_LIVE2D_MODEL_PATH
+
+
+def _get_default_yui_free_voice_id() -> str:
+    from utils.api_config_loader import get_free_voices
+    from utils.language_utils import get_global_language_full
+
+    free_voices = get_free_voices() or {}
+    try:
+        language = str(get_global_language_full() or "").strip().lower().replace("-", "_")
+    except Exception:
+        language = ""
+
+    language_aliases = {
+        "zh": "cn",
+        "zh_cn": "cn",
+        "zh_hans": "cn",
+        "zh_tw": "tw",
+        "zh_hant": "tw",
+    }
+    suffix = language_aliases.get(language, language.split("_", 1)[0] if language else "")
+    keys = []
+    if suffix:
+        keys.append(f"yui_{suffix}")
+    keys.extend(("yui_cn", "cuteGirl"))
+
+    for key in keys:
+        voice_id = str(free_voices.get(key) or "").strip()
+        if voice_id:
+            return voice_id
+    return next((str(voice_id).strip() for voice_id in free_voices.values() if str(voice_id or "").strip()), "")
+
+
+async def ensure_default_yui_voice_for_free_api(config_manager, core_cfg: dict | None = None) -> bool:
+    """Ensure the default YUI card has the free YUI voice when free API is active."""
+    if not isinstance(core_cfg, dict):
+        try:
+            core_cfg = await config_manager.aget_core_config()
+        except Exception:
+            core_cfg = {}
+    if not isinstance(core_cfg, dict):
+        return False
+    if core_cfg.get("coreApi") != "free" and core_cfg.get("assistApi") != "free" and not core_cfg.get("IS_FREE_VERSION"):
+        return False
+
+    characters = await config_manager.aload_characters()
+    if not isinstance(characters, dict):
+        return False
+
+    current_name = str(characters.get("当前猫娘") or "").strip()
+    catgirls = characters.get("猫娘")
+    if not current_name or not isinstance(catgirls, dict):
+        return False
+
+    current_character = catgirls.get(current_name)
+    if not _is_default_yui_character(current_name, current_character):
+        return False
+
+    current_voice_id = str(get_reserved(
+        current_character,
+        "voice_id",
+        default="",
+        legacy_keys=("voice_id",),
+    ) or "").strip()
+    if current_voice_id:
+        return False
+
+    yui_voice_id = _get_default_yui_free_voice_id()
+    if not yui_voice_id:
+        return False
+
+    changed = set_reserved(current_character, "voice_id", yui_voice_id)
+    if not changed:
+        return False
+
+    await config_manager.asave_characters(characters)
+    logger.info("已为 free API 下的默认 YUI 绑定音色: %s", yui_voice_id)
+    return True
+
+
 def delete_reserved(data: dict, *path) -> bool:
     """删除 `_reserved` 下的嵌套字段，并尽量清理空的中间层。"""
     if not isinstance(data, dict) or not path:


### PR DESCRIPTION
## Summary

- 在免费 API 模式下，为默认 YUI 角色自动对齐专属免费音色 `voice-tone-QqMv39SYSW`。
- 触发点放在切换 `/api/config/core_api` 后，以及角色/音色列表读取时兜底，避免角色管理页显示“未指定音色”。
- 新增单测覆盖免费 API 绑定、非免费不绑定、已有音色不覆盖、非默认 YUI 不误绑定等边界。

## Boundary

- 不修改 `config/characters/*.json` 种子文件，保持 `origin/main` 的阿里云/Qwen 默认角色配置原样。
- 不从人格选择接口传音色，不改变新手人格选择的数据结构。
- 不影响用户手动选择过的角色音色；只有默认 YUI 且当前音色为空时才补齐。
- 不修改 PC 端逻辑，本次为后端兜底修复。

## Risks

- 绑定逻辑依赖默认 YUI 的角色名/昵称和 Live2D 模型路径识别；如果后续默认角色结构大改，需要同步更新识别条件。
- 该逻辑只处理免费 API 下的默认 YUI，不扩展到其他角色或其他服务商。
- 读角色/音色接口增加了一次轻量兜底检查，正常情况下无额外写入；只有满足绑定条件时才保存角色配置。

## Test Plan

- `uv run pytest -q tests/unit/test_yui_free_api_default_voice.py tests/unit/test_api_config_manager.py -k 'not TestProviderExclusion' tests/unit/test_stepfun_tts_voices.py tests/unit/test_gemini_tts_voices.py tests/unit/test_native_voice_registry.py tests/unit/test_gemini_realtime_voice_routing.py tests/unit/test_character_persona_router.py tests/unit/test_characters_router_model_settings.py tests/unit/test_cloudsave_startup_flow.py`
  - Result: `160 passed, 5 deselected`

- Fresh-user runtime smoke test:
  - Start backend with clean temp user data.
  - Switch/check free API state.
  - Verify `/api/characters` returns default `YUI voice_id=voice-tone-QqMv39SYSW`.
  - Verify `/api/characters/voices` includes `free_voices.yui_cn=voice-tone-QqMv39SYSW` and `voice_owners` maps that voice to `YUI`.

## Known Notes

- A broader related test run surfaced existing stale expectations in `tests/unit/test_api_config_manager.py::TestProviderExclusion` around `grok` core provider and `elevenlabs` restricted status. This PR does not touch provider registry behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 在免费 API 模式下，更新或清除角色语音后，系统会自动为默认猫娘恢复适配的默认音色，避免语音配置丢失。

* **New Features**
  * 在保存配置与清除语音操作后触发自动补回默认猫娘免费音色的机制。

* **Tests**
  * 增加并扩展了针对默认猫娘与免费 API 绑定行为的单元测试，覆盖多种场景与边界情况。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->