### PR TITLE
fix(ci): mac Nuitka 构建前清掉 steamworks/ 里的非 mac native libs

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -364,8 +364,13 @@ jobs:
           # from the exe sibling dir (see steamworks/__init__.py), so dest stays at root.
           # Gate by RUNNER_OS: all platforms' libs are checked into the repo, but
           # feeding a Linux ELF .so to a macOS Nuitka build trips an arch-mismatch FATAL.
+          # The --include-package=steamworks above also makes Nuitka pick up every
+          # native lib in steamworks/ as package data, so strip the wrong-platform
+          # copies from the source tree before invoking nuitka.
           NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steam_appid.txt=steam_appid.txt"
           if [[ "$RUNNER_OS" == "macOS" ]]; then
+            rm -f steamworks/SteamworksPy.so steamworks/libsteam_api.so \
+                  steamworks/SteamworksPy64.dll steamworks/steam_api64.dll steamworks/steam_api64.lib
             if [ -f "steamworks/libsteam_api.dylib" ]; then
               NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.dylib=libsteam_api.dylib"
             fi
@@ -373,6 +378,8 @@ jobs:
               NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/SteamworksPy.dylib=SteamworksPy.dylib"
             fi
           elif [[ "$RUNNER_OS" == "Linux" ]]; then
+            rm -f steamworks/SteamworksPy.dylib steamworks/libsteam_api.dylib \
+                  steamworks/SteamworksPy64.dll steamworks/steam_api64.dll steamworks/steam_api64.lib
             if [ -f "steamworks/libsteam_api.so" ]; then
               NUITKA_OPTS="$NUITKA_OPTS --include-data-files=steamworks/libsteam_api.so=libsteam_api.so"
             fi
@@ -437,6 +444,10 @@ jobs:
           rem from the exe sibling dir (see steamworks/__init__.py), so dest stays at root.
           rem Guard with `if exist` to mirror the Unix branch — keeps the build
           rem soft on incidental missing libs instead of fataling in Nuitka.
+          rem --include-package=steamworks pulls in every native lib in steamworks/
+          rem as package data; strip the non-Windows copies so Nuitka can't trip
+          rem an arch check on them (mirrors the Unix branch's rm step).
+          del /q steamworks\SteamworksPy.so steamworks\libsteam_api.so steamworks\SteamworksPy.dylib steamworks\libsteam_api.dylib 2>nul
           if exist "steamworks\steam_api64.dll" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.dll=steam_api64.dll
           if exist "steamworks\steam_api64.lib" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/steam_api64.lib=steam_api64.lib
           if exist "steamworks\SteamworksPy64.dll" set NUITKA_OPTS=%NUITKA_OPTS% --include-data-files=steamworks/SteamworksPy64.dll=SteamworksPy64.dll


### PR DESCRIPTION
## 起因

[Build Desktop App run 25775309295](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/25775309295) 里两个 mac 构建（arm64 / x64）都在 Nuitka 链接阶段 FATAL：

\`\`\`
FATAL: Error, cannot use file '.../steamworks/SteamworksPy.so'
(ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), ...)
to build arch 'arm64' result
\`\`\`

## 根因

\`build-desktop.yml\` 用 \`--include-package=steamworks\` 把整个包拽进去，Nuitka 自然会把 \`steamworks/\` 目录下所有 native binary 当 package data 一起 bundle。但 repo 里 [PR #1264](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1264) 之后三平台的 native lib（\`SteamworksPy.so\` / \`.dylib\` / \`.dll\`，\`libsteam_api.so\` / \`.dylib\`，\`steam_api64.dll\` / \`.lib\`）全 checked-in，mac 构建碰到 Linux ELF 直接 arch-mismatch FATAL。

之前 [PR #1303](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1303) 给 \`--include-data-files\` 加了 \`RUNNER_OS\` gate，但管不住 \`--include-package\` 自动 traverse 包目录的行为。

## 修法

在 nuitka 跑之前，按本平台直接 \`rm\` 掉 \`steamworks/\` 里其他平台的 native libs：

- macOS：删 \`.so\` / \`.dll\` / \`.lib\`
- Linux：删 \`.dylib\` / \`.dll\` / \`.lib\`
- Windows：删 \`.so\` / \`.dylib\`

只动 CI 工作目录，不影响 repo 和开发树。Linux/Win 之前没炸但同类隐患存在（Nuitka 哪天收紧检查就一起翻车），顺手补对偶。

## Test plan

- [ ] Build Desktop App 三个 build-python job 都过
- [ ] mac arm64 / x64 artifact 里 \`steamworks\` 目录只有本平台 native（\`.dylib\`），且能起 Steam init
- [ ] linux artifact 里只有 \`.so\`
- [ ] win artifact 里只有 \`.dll\` / \`.lib\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化了跨平台桌面构建流程，确保在不同操作系统上构建时不会混入其他平台的库文件，提高了构建的稳定性和一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->