### PR TITLE
feat(agent): persist agent/plugin toggles, restore on first session

### DIFF
--- a/app/agent_runtime_intent.py
+++ b/app/agent_runtime_intent.py
@@ -1,0 +1,162 @@
+"""User-level persistence for agent runtime toggles.
+
+The agent server keeps six in-memory switches:
+
+    analyzer_enabled         — master gate ("猫爪总开关")
+    computer_use_enabled     — 键鼠控制 sub flag
+    browser_use_enabled      — 浏览器控制 sub flag
+    user_plugin_enabled      — 用户插件 sub flag
+    openclaw_enabled         — OpenClaw sub flag
+    openfang_enabled         — OpenFang sub flag
+
+Historically all six were re-zeroed on every process start, so the user had
+to re-toggle every switch after restart. This module persists the user's
+**intent** (last explicit toggle) under the config dir as
+``agent_runtime_intent.json``, and a restore path at first ``greeting_check``
+replays it through the existing ``set_agent_enabled`` / ``set_agent_flags``
+codepaths (so capability checks still gate actual activation).
+
+**Key semantics** (deliberately mirroring plugin runtime overrides):
+
+* Only entries the user explicitly toggled are stored. Absence means
+  "use the in-process default" (currently False).
+* ``capability auto-disable`` (e.g. LLM probe demote) does NOT write here —
+  intent survives transient LLM failures so the next restart still tries.
+* The restore path WILL clear intent back to ``False`` after a hard 15s
+  retry window or on a permanent failure code, so the user sees a clear
+  "已自动禁用" notification instead of repeatedly retrying a dead key.
+* Toggling the master gate off does NOT touch sub-flag intent — the master
+  is a runtime gate, not a clear-all command. (See the matching fix in
+  ``set_agent_enabled`` and the gate-fail branch of ``set_agent_flags``.)
+
+The escape hatch ``NEKO_DISABLE_AGENT_AUTO_RESTORE=1`` is consumed by the
+restore path itself, not this module — this module always reads/writes
+faithfully so a misbehaving restore can be debugged by inspecting the JSON.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Mapping, Optional
+
+from utils.logger_config import get_module_logger
+
+logger = get_module_logger(__name__, "Agent")
+
+INTENT_FILENAME = "agent_runtime_intent.json"
+
+# Whitelisted keys. Anything else in the JSON is silently dropped so an old /
+# malformed file can't blow up restore. Keep this in sync with the keys used
+# in ``set_agent_enabled`` and ``set_agent_flags``.
+INTENT_KEYS: frozenset[str] = frozenset({
+    "analyzer_enabled",
+    "computer_use_enabled",
+    "browser_use_enabled",
+    "user_plugin_enabled",
+    "openclaw_enabled",
+    "openfang_enabled",
+})
+
+_cache_lock = threading.Lock()
+_cache: Optional[dict[str, bool]] = None
+
+
+def _coerce_intent(raw: object) -> dict[str, bool]:
+    if not isinstance(raw, Mapping):
+        return {}
+    result: dict[str, bool] = {}
+    for key, value in raw.items():
+        if isinstance(key, str) and key in INTENT_KEYS and isinstance(value, bool):
+            result[key] = value
+    return result
+
+
+def _load_from_disk() -> dict[str, bool]:
+    try:
+        from utils.config_manager import get_config_manager
+
+        cm = get_config_manager()
+        raw = cm.load_json_config(INTENT_FILENAME, default_value={})
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.warning(
+            "Failed to load agent runtime intent from %s: %s",
+            INTENT_FILENAME,
+            exc,
+        )
+        return {}
+    return _coerce_intent(raw)
+
+
+def _save_to_disk(intent: dict[str, bool]) -> None:
+    try:
+        from utils.config_manager import get_config_manager
+
+        cm = get_config_manager()
+        cm.save_json_config(INTENT_FILENAME, dict(intent))
+    except Exception as exc:
+        logger.warning(
+            "Failed to persist agent runtime intent to %s: %s",
+            INTENT_FILENAME,
+            exc,
+        )
+
+
+def load_intent() -> dict[str, bool]:
+    """Return a snapshot of the persisted intent; loads on first access."""
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        return dict(_cache)
+
+
+def get_intent(key: str) -> Optional[bool]:
+    """Return the persisted intent for ``key`` or ``None`` if never set."""
+    if not key or key not in INTENT_KEYS:
+        return None
+    return load_intent().get(key)
+
+
+def set_intent(key: str, value: bool) -> None:
+    """Persist ``value`` as the user's intent for ``key``.
+
+    No-op if ``key`` is not in :data:`INTENT_KEYS` — restore relies on the
+    schema being closed so unknown junk doesn't break parsing on next boot.
+
+    The disk write happens while ``_cache_lock`` is still held so that two
+    concurrent toggles can't race and overwrite each other with stale
+    snapshots.
+    """
+    if not key or key not in INTENT_KEYS:
+        return
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        if _cache.get(key) == value:
+            return
+        _cache[key] = value
+        _save_to_disk(dict(_cache))
+
+
+def clear_intent(key: str) -> None:
+    """Remove the intent for ``key`` (e.g. after a permanent restore failure)."""
+    if not key or key not in INTENT_KEYS:
+        return
+    global _cache
+    with _cache_lock:
+        if _cache is None:
+            _cache = _load_from_disk()
+        if key not in _cache:
+            return
+        _cache.pop(key, None)
+        _save_to_disk(dict(_cache))
+
+
+def reset_cache_for_testing() -> None:
+    """Drop the in-memory cache; intended for tests that swap the backing store."""
+    global _cache
+    with _cache_lock:
+        _cache = None

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -3539,6 +3539,13 @@ async def plugin_execute_direct(payload: Dict[str, Any]):
     """
     if not Modules.task_executor:
         raise HTTPException(503, "Task executor not ready")
+    # Master gate first: with the new semantics where set_agent_enabled(False)
+    # no longer wipes sub-flag state, ``user_plugin_enabled`` can legitimately
+    # stay True after the master is turned off. Without this check, requests
+    # would slip through to a plugin lifecycle that ``_ensure_plugin_lifecycle
+    # _stopped`` has already torn down, producing confusing failures.
+    if not Modules.analyzer_enabled:
+        raise HTTPException(403, "Agent master switch is off")
     # 当后端显式关闭用户插件功能时，直接拒绝调用，避免绕过前端开关
     if not Modules.agent_flags.get("user_plugin_enabled", False):
         raise HTTPException(403, "User plugin is disabled")

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -5178,14 +5178,26 @@ async def computer_use_availability():
 async def notify_config_changed():
     """Called by the main server after API-key / model config is saved.
     Rebuilds the CUA adapter with fresh config and kicks off a non-blocking
-    LLM connectivity check — but only when the user actually has Agent on
-    or has a CU/BU flag enabled.  Otherwise a routine voice/chat-model save
-    fires a probe whose transient failure pops a "猫爪预检失败" toast for a
-    feature the user isn't even using."""
+    LLM connectivity check — but only when the user actually has the master
+    switch on AND at least one LLM-dependent sub flag enabled.
+
+    The master gate is required because with the new master-OFF semantics
+    (sub flags carry user intent and survive master cycling),
+    ``computer_use_enabled``/``browser_use_enabled`` can legitimately stay
+    True while the master is off. The old ``or`` condition would otherwise
+    fire a probe on every voice/chat config save and pop a transient
+    "猫爪预检失败" toast for a feature the user has explicitly disabled at
+    the master.
+
+    Sub-flag check still gates probes when the master is on but the user
+    isn't using CU/BU — same rationale as the original docstring: routine
+    config saves shouldn't probe for a feature nobody's using."""
     _try_refresh_computer_use_adapter(force=True)
     _rewire_computer_use_dependents()
     flags = Modules.agent_flags or {}
-    if Modules.analyzer_enabled or flags.get("computer_use_enabled") or flags.get("browser_use_enabled"):
+    if Modules.analyzer_enabled and (
+        flags.get("computer_use_enabled") or flags.get("browser_use_enabled")
+    ):
         asyncio.ensure_future(_fire_agent_llm_connectivity_check())
         return {"success": True, "message": "CUA adapter refreshed, connectivity check started"}
     return {"success": True, "message": "CUA adapter refreshed; probe skipped (agent idle)"}

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -4915,12 +4915,15 @@ async def agent_command(payload: Dict[str, Any]):
 _intent_restore_done = False
 _intent_restore_lock: Optional[asyncio.Lock] = None
 
-# Restore probe budget. Hard ceiling 15s = 3 attempts × (4s timeout + 1s gap)
-# minus the trailing gap. Tuned so the user sees toggles flip back within a
-# typical greeting wait (~5-15s); longer windows risk users thinking the
-# system is hung. Anything longer should be a manual retry by the user.
-_RESTORE_PING_TIMEOUT_S = 4.0
-_RESTORE_PING_INTERVAL_S = 5.0
+# Restore probe budget. Worst-case wall time when probes keep timing out:
+#   3 attempts × 6s timeout + 2 inter-attempt sleeps × 7s = ~32s.
+# In practice the ping resolves in <1s on a healthy connection so users
+# typically see toggles flip back within the first attempt. Tuning rationale:
+# 6s per-call timeout gives cold-start DNS / TLS handshake comfortable room
+# without dragging out the failure path; 7s gap lets a transient burst
+# throttle window expire between attempts.
+_RESTORE_PING_TIMEOUT_S = 6.0
+_RESTORE_PING_INTERVAL_S = 7.0
 _RESTORE_PING_MAX_ATTEMPTS = 3
 
 

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -19,7 +19,7 @@ import uuid
 import logging
 import time
 import hashlib
-from typing import Dict, Any, Optional, ClassVar, List
+from typing import Dict, Any, Optional, ClassVar, List, Tuple
 from datetime import datetime, timezone
 import httpx
 
@@ -896,7 +896,7 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
             await _emit_agent_status_update()
             return
 
-        def _probe():
+        def _probe() -> Tuple[bool, str]:
             return adapter.check_connectivity()
 
         # If a real CUA/BU task is currently running, the LLM is demonstrably
@@ -913,7 +913,15 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
             return False
 
         try:
-            ok = await asyncio.get_event_loop().run_in_executor(None, _probe)
+            probe_result = await asyncio.get_event_loop().run_in_executor(None, _probe)
+            # Tolerate legacy bool returns in case some adapter implementation
+            # hasn't been migrated yet (defense-in-depth: the only real probe
+            # — computer_use.check_connectivity — already returns a tuple).
+            if isinstance(probe_result, tuple):
+                ok, probe_reason = probe_result
+            else:
+                ok = bool(probe_result)
+                probe_reason = "" if ok else "AGENT_LLM_UNREACHABLE"
             cu_in_flight = _has_running("computer_use")
             bu_in_flight = _has_running("browser_use")
 
@@ -927,7 +935,7 @@ async def _fire_agent_llm_connectivity_check(*, queue: bool = False) -> None:
                 await _emit_agent_status_update()
                 return
 
-            reason = "" if ok else "AGENT_LLM_UNREACHABLE"
+            reason = "" if ok else (probe_reason or "AGENT_LLM_UNREACHABLE")
             _set_capability("computer_use", ok, reason)
             bu = Modules.browser_use
             if bu is None:
@@ -1641,7 +1649,18 @@ async def _emit_agent_status_update(lanlan_name: Optional[str] = None) -> None:
 
 
 async def _on_session_event(event: Dict[str, Any]) -> None:
-    if (event or {}).get("event_type") == "analyze_request":
+    event_type = (event or {}).get("event_type")
+    if event_type == "agent_intent_restore_signal":
+        # First-real-client-session signal from main_server (sent on
+        # ``greeting_check``). Restore persisted agent runtime intent now
+        # — agent_server is fully ready (we're already receiving events),
+        # but we delayed restore to here so we don't trigger LLM probes
+        # and plugin lifecycle startup during the cold-start window
+        # before the user actually opens a session. The restore helper
+        # has its own once-flag, so this is safe to spam.
+        await _maybe_restore_agent_intent()
+        return
+    if event_type == "analyze_request":
         messages = event.get("messages", [])
         lanlan_name = event.get("lanlan_name")
         event_id = event.get("event_id")
@@ -4519,31 +4538,41 @@ async def set_agent_flags(payload: Dict[str, Any]):
     bf = (payload or {}).get("browser_use_enabled")
     uf = (payload or {}).get("user_plugin_enabled")
     nf = (payload or {}).get("openclaw_enabled")
+    # ``_persist_intent`` (default True) gates whether this call writes the
+    # user's intent to ``agent_runtime_intent.json``. The restore path replays
+    # past intents through this same function with ``_persist_intent=False``
+    # so the replay doesn't re-write what it's reading.
+    persist_intent = bool((payload or {}).get("_persist_intent", True))
     # Agent API gate: if any agent sub-feature is being enabled, gate must pass.
     gate = _check_agent_api_gate()
     changed = False
     old_flags = dict(Modules.agent_flags)
     old_analyzer_enabled = bool(Modules.analyzer_enabled)
     of = (payload or {}).get("openfang_enabled")
-    if gate.get("ready") is not True and any(x is True for x in (cf, bf, uf, nf, of)):
+    # Agent LLM gate fail (endpoint/key not configured) blocks **only** the
+    # four LLM-dependent sub flags. ``user_plugin_enabled`` runs entirely on
+    # the plugin lifecycle (no agent LLM involved) so the gate must not
+    # short-circuit its toggle path — historically this branch reset all five
+    # and early-returned, which silently swallowed legitimate user_plugin
+    # enable/disable requests whenever the user hadn't configured an agent
+    # endpoint. Here we instead cancel just the four LLM-coupled requests by
+    # nullifying them, then fall through to the per-flag handling so uf still
+    # processes normally.
+    if gate.get("ready") is not True and any(x is True for x in (cf, bf, nf, of)):
         _cancel_openclaw_enable_probe()
         Modules.agent_flags["computer_use_enabled"] = False
         Modules.agent_flags["browser_use_enabled"] = False
-        Modules.agent_flags["user_plugin_enabled"] = False
         Modules.agent_flags["openclaw_enabled"] = False
         Modules.agent_flags["openfang_enabled"] = False
         first_reason = (gate.get('reasons') or ['AGENT_ENDPOINT_NOT_CONFIGURED'])[0]
         _set_capability("computer_use", False, first_reason)
         _set_capability("browser_use", False, first_reason)
-        _set_capability("user_plugin", False, first_reason)
         _set_capability("openclaw", False, first_reason)
         _set_capability("openfang", False, first_reason)
-        await _ensure_plugin_lifecycle_stopped()
-        Modules.notification = None
-        if Modules.agent_flags != old_flags:
-            _bump_state_revision()
-            await _emit_agent_status_update(lanlan_name=lanlan_name)
-        return {"success": True, "agent_flags": Modules.agent_flags}
+        # Swallow these requests so the per-flag handlers below don't re-toggle
+        # them ON; ``uf`` is intentionally left alone so user_plugin processing
+        # proceeds.
+        cf = bf = nf = of = None
 
     prev_up = Modules.agent_flags.get("user_plugin_enabled", False)
     prev_nk = Modules.agent_flags.get("openclaw_enabled", False)
@@ -4729,6 +4758,37 @@ async def set_agent_flags(payload: Dict[str, Any]):
                 except Exception as e:
                     logger.warning("[Agent] OpenFang cancel on disable failed: %s", e)
 
+    # Persist user intent for each explicitly-requested flag.
+    # Rule: a flag is persisted only when the user's request actually took
+    # effect in-memory. If the user requested ON but capability auto-rejected
+    # (LLM unreachable, module not loaded, etc.), the in-memory flag stays
+    # False — we do NOT persist a True intent for that case, because the
+    # toggle visibly didn't take. Disable requests (False) are always
+    # persisted faithfully (no capability check involved).
+    # The capability-auto-disable path inside
+    # ``_fire_agent_llm_connectivity_check`` also intentionally does NOT
+    # touch intent — it flips the in-memory flag but leaves persisted intent
+    # so a transient LLM blip doesn't wipe the user's preference.
+    if persist_intent:
+        try:
+            from app.agent_runtime_intent import set_intent
+            for key, requested in (
+                ("computer_use_enabled", cf),
+                ("browser_use_enabled", bf),
+                ("user_plugin_enabled", uf),
+                ("openclaw_enabled", nf),
+                ("openfang_enabled", of),
+            ):
+                if not isinstance(requested, bool):
+                    continue
+                if requested is False:
+                    set_intent(key, False)
+                elif bool(Modules.agent_flags.get(key, False)):
+                    set_intent(key, True)
+                # else: requested=True but capability rejected → leave intent untouched
+        except Exception as exc:
+            logger.warning("[Agent] Failed to persist agent flag intent: %s", exc)
+
     changed = Modules.agent_flags != old_flags or bool(Modules.analyzer_enabled) != old_analyzer_enabled
     if changed:
         _bump_state_revision()
@@ -4744,6 +4804,12 @@ async def agent_command(payload: Dict[str, Any]):
     lanlan_name = (payload or {}).get("lanlan_name")
     if command == "set_agent_enabled":
         enabled = bool((payload or {}).get("enabled"))
+        # ``_persist_intent`` (default True) gates whether this call writes
+        # the user's intent to ``agent_runtime_intent.json``. The restore
+        # path replays past intents through this same code path with
+        # ``_persist_intent=False`` so the replay doesn't re-write what it's
+        # reading.
+        persist_intent = bool((payload or {}).get("_persist_intent", True))
         gate = _check_agent_api_gate()
         if enabled:
             Modules.analyzer_enabled = True
@@ -4767,15 +4833,27 @@ async def agent_command(payload: Dict[str, Any]):
             Modules.analyzer_enabled = False
             Modules.analyzer_profile = {}
             _cancel_openclaw_enable_probe()
-            Modules.agent_flags["computer_use_enabled"] = False
-            Modules.agent_flags["browser_use_enabled"] = False
-            Modules.agent_flags["user_plugin_enabled"] = False
-            Modules.agent_flags["openclaw_enabled"] = False
-            Modules.agent_flags["openfang_enabled"] = False
+            # NOTE: sub flags are NOT reset here. The master switch is a runtime
+            # gate, not a clear-all command — sub flags carry the user's intent
+            # for each component and must survive a master OFF/ON cycle (so the
+            # user doesn't have to re-tick every sub-toggle after disabling the
+            # master). All analysis / dispatch paths upstream of sub-flag checks
+            # already test ``Modules.analyzer_enabled`` first (see lines ~1653,
+            # 2007, 2056, 3453), so leaving sub flags ON cannot let any
+            # component "secretly keep running". The actual stop is enforced by
+            # ``end_all`` + ``_ensure_plugin_lifecycle_stopped`` + the probe
+            # cancel above; ``intent`` (persistent) is also intentionally left
+            # untouched here for the same reason.
             _set_capability("user_plugin", True, "")
             _set_capability("openclaw", False, "")
             await admin_control({"action": "end_all"})
             await _ensure_plugin_lifecycle_stopped()
+        if persist_intent:
+            try:
+                from app.agent_runtime_intent import set_intent
+                set_intent("analyzer_enabled", enabled)
+            except Exception as exc:
+                logger.warning("[Agent] Failed to persist analyzer_enabled intent: %s", exc)
         _bump_state_revision()
         await _emit_agent_status_update(lanlan_name=lanlan_name)
         total_ms = round((time.perf_counter() - t0) * 1000, 2)
@@ -4805,6 +4883,241 @@ async def agent_command(payload: Dict[str, Any]):
         logger.info("[AgentTiming] request_id=%s command=%s total_ms=%s", request_id, command, total_ms)
         return {"success": True, "request_id": request_id, "snapshot": snapshot, "timing": {"agent_total_ms": total_ms}}
     raise HTTPException(400, "unknown command")
+
+
+# ─── Agent runtime intent restore ───────────────────────────────────────
+#
+# At server start, ``Modules.analyzer_enabled`` and ``Modules.agent_flags``
+# are all False; the user must re-tick every toggle they had on before
+# restart. Restore replays the persisted intent (see ``agent_runtime_intent``
+# module) the first time a real client session enters via
+# ``greeting_check``, so the user's switches "just come back" the way the
+# plugin manager's per-plugin disable already does.
+#
+# The replay walks the same ``set_agent_enabled`` / ``set_agent_flags`` code
+# paths a manual UI toggle would, so capability checks, gate logic, and
+# notifications all behave identically — and ``_persist_intent=False`` makes
+# the replay non-recursive (it doesn't overwrite the intent file it's
+# reading).
+#
+# Failure mode: LLM-dependent flags get a 15s probe window (3 × 4s ping with
+# 5s spacing). Any permanent reason or all-three failure clears that intent
+# to False and surfaces ``AGENT_AUTO_DISABLED_*`` notifications — the goal
+# is to tell the user "your API is dead, fix it" rather than retry forever.
+
+_intent_restore_done = False
+_intent_restore_lock: Optional[asyncio.Lock] = None
+
+# Restore probe budget. Hard ceiling 15s = 3 attempts × (4s timeout + 1s gap)
+# minus the trailing gap. Tuned so the user sees toggles flip back within a
+# typical greeting wait (~5-15s); longer windows risk users thinking the
+# system is hung. Anything longer should be a manual retry by the user.
+_RESTORE_PING_TIMEOUT_S = 4.0
+_RESTORE_PING_INTERVAL_S = 5.0
+_RESTORE_PING_MAX_ATTEMPTS = 3
+
+
+async def _maybe_restore_agent_intent() -> None:
+    """Idempotent restore entry. Safe to call from every greeting_check."""
+    global _intent_restore_done, _intent_restore_lock
+    if _intent_restore_done:
+        return
+    if os.environ.get("NEKO_DISABLE_AGENT_AUTO_RESTORE") == "1":
+        # Escape hatch: if some restore step ever causes server lockup,
+        # the user can launch with this env var to skip restore entirely
+        # and re-toggle manually.
+        _intent_restore_done = True
+        logger.info("[Agent] NEKO_DISABLE_AGENT_AUTO_RESTORE=1, skipping intent restore")
+        return
+    if _intent_restore_lock is None:
+        _intent_restore_lock = asyncio.Lock()
+    async with _intent_restore_lock:
+        if _intent_restore_done:
+            return
+        _intent_restore_done = True
+        try:
+            await _do_restore_agent_intent()
+        except Exception as exc:
+            logger.error("[Agent] Intent restore failed: %s", exc, exc_info=True)
+
+
+async def _do_restore_agent_intent() -> None:
+    from app.agent_runtime_intent import load_intent
+
+    intent = load_intent()
+    if not intent:
+        logger.info("[Agent] No persisted agent intent to restore")
+        return
+    logger.info("[Agent] Restoring agent intent: %s", intent)
+
+    # 1. Master gate first — sub flags need analyzer_enabled to actually
+    # have effect. We call agent_command directly (it's a plain async fn
+    # despite the FastAPI decorator) with _persist_intent=False so the
+    # replay doesn't re-write what we just read.
+    if intent.get("analyzer_enabled"):
+        try:
+            await agent_command({
+                "command": "set_agent_enabled",
+                "enabled": True,
+                "_persist_intent": False,
+            })
+        except Exception as exc:
+            logger.warning("[Agent] Failed to restore analyzer_enabled: %s", exc)
+
+    # 2. Two fully-independent parallel tracks. CU/BU are LLM-coupled
+    # (probe-gated). user_plugin runs on its own lifecycle and explicitly
+    # does NOT wait for the LLM — plugins don't depend on the agent model.
+    parallel: List[asyncio.Task] = []
+
+    if intent.get("computer_use_enabled") or intent.get("browser_use_enabled"):
+        t = asyncio.create_task(_restore_llm_dependent_flags(intent))
+        Modules._persistent_tasks.add(t)
+        t.add_done_callback(Modules._persistent_tasks.discard)
+        parallel.append(t)
+
+    if intent.get("user_plugin_enabled"):
+        t = asyncio.create_task(_restore_user_plugin())
+        Modules._persistent_tasks.add(t)
+        t.add_done_callback(Modules._persistent_tasks.discard)
+        parallel.append(t)
+
+    # OpenClaw has its own bounded probe — no separate retry needed,
+    # ``set_agent_flags`` will fire the probe task and we trust that.
+    if intent.get("openclaw_enabled"):
+        try:
+            await set_agent_flags({
+                "openclaw_enabled": True,
+                "_persist_intent": False,
+            })
+        except Exception as exc:
+            logger.warning("[Agent] Failed to restore openclaw_enabled: %s", exc)
+
+    # OpenFang is similar — single capability check on the adapter, fast,
+    # no separate retry needed.
+    if intent.get("openfang_enabled"):
+        try:
+            await set_agent_flags({
+                "openfang_enabled": True,
+                "_persist_intent": False,
+            })
+        except Exception as exc:
+            logger.warning("[Agent] Failed to restore openfang_enabled: %s", exc)
+
+    # We deliberately don't gather() the parallel tasks — they update
+    # capability + flags + intent on their own, and the user sees the
+    # results via the normal status snapshot push. Awaiting here would
+    # block the greeting_check handler for up to 15s.
+
+
+async def _restore_llm_dependent_flags(intent: dict) -> None:
+    """Probe LLM ≤3 times with 5s spacing. On success flip the in-memory
+    CU/BU flags via set_agent_flags; on permanent failure or all-three
+    fail, clear those intents and emit AGENT_AUTO_DISABLED_* notifications."""
+    from app.agent_runtime_intent import set_intent
+    from brain.computer_use import PERMANENT_CONNECTIVITY_REASONS
+
+    adapter = Modules.computer_use
+    if adapter is None:
+        # Module not loaded is permanent — no point retrying.
+        logger.warning("[Agent] Restore: computer_use module not loaded; clearing CU/BU intent")
+        for key, code in (
+            ("computer_use_enabled", "AGENT_AUTO_DISABLED_COMPUTER"),
+            ("browser_use_enabled", "AGENT_AUTO_DISABLED_BROWSER"),
+        ):
+            if intent.get(key):
+                set_intent(key, False)
+                Modules.notification = json.dumps({
+                    "code": code,
+                    "details": {"reason_code": "AGENT_CU_MODULE_NOT_LOADED"},
+                })
+        _bump_state_revision()
+        await _emit_agent_status_update()
+        return
+
+    last_reason = "AGENT_LLM_UNREACHABLE"
+    success = False
+    for attempt in range(_RESTORE_PING_MAX_ATTEMPTS):
+        try:
+            ok, reason = await asyncio.to_thread(
+                adapter.check_connectivity,
+                timeout_s=_RESTORE_PING_TIMEOUT_S,
+            )
+            if ok:
+                success = True
+                last_reason = ""
+                break
+            last_reason = reason or "AGENT_LLM_UNREACHABLE"
+            if last_reason in PERMANENT_CONNECTIVITY_REASONS:
+                logger.info(
+                    "[Agent] Restore: permanent connectivity reason %s after %d/%d attempts; not retrying",
+                    last_reason, attempt + 1, _RESTORE_PING_MAX_ATTEMPTS,
+                )
+                break
+        except Exception as exc:
+            logger.warning(
+                "[Agent] Restore probe attempt %d/%d raised: %s",
+                attempt + 1, _RESTORE_PING_MAX_ATTEMPTS, exc,
+            )
+            last_reason = "AGENT_LLM_UNREACHABLE"
+        if attempt < _RESTORE_PING_MAX_ATTEMPTS - 1:
+            await asyncio.sleep(_RESTORE_PING_INTERVAL_S)
+
+    if success:
+        # Hand off to the regular toggle path so capability cache + UI
+        # snapshot stay consistent with manual toggling.
+        payload: Dict[str, Any] = {"_persist_intent": False}
+        if intent.get("computer_use_enabled"):
+            payload["computer_use_enabled"] = True
+        if intent.get("browser_use_enabled"):
+            payload["browser_use_enabled"] = True
+        if len(payload) > 1:
+            try:
+                await set_agent_flags(payload)
+                logger.info("[Agent] Restored CU/BU flags after successful probe")
+            except Exception as exc:
+                logger.warning("[Agent] Failed to apply CU/BU after probe: %s", exc)
+        return
+
+    # All retries exhausted (or permanent error): tell the user, clear intent.
+    for key, code in (
+        ("computer_use_enabled", "AGENT_AUTO_DISABLED_COMPUTER"),
+        ("browser_use_enabled", "AGENT_AUTO_DISABLED_BROWSER"),
+    ):
+        if intent.get(key):
+            set_intent(key, False)
+            Modules.notification = json.dumps({
+                "code": code,
+                "details": {"reason_code": last_reason},
+            })
+            logger.info(
+                "[Agent] Restore: cleared intent for %s after %d failed probes (reason=%s)",
+                key, _RESTORE_PING_MAX_ATTEMPTS, last_reason,
+            )
+    _bump_state_revision()
+    await _emit_agent_status_update()
+
+
+async def _restore_user_plugin() -> None:
+    """Hand off to the standard /agent/flags path. user_plugin does NOT
+    require the LLM probe to be green — plugins run on their own lifecycle,
+    so we trigger them straight away in parallel. Any startup failure goes
+    through the existing _bg_plugin_enable async path and lazy-init fallback
+    at first ``analyze`` time still covers leftover cases."""
+    try:
+        await set_agent_flags({
+            "user_plugin_enabled": True,
+            "_persist_intent": False,
+        })
+        logger.info("[Agent] Restore: user_plugin_enabled requested")
+    except Exception as exc:
+        logger.warning("[Agent] Failed to restore user_plugin_enabled: %s", exc)
+
+
+def _reset_intent_restore_for_testing() -> None:
+    """Test helper: clear the once-flag so a test can re-run restore."""
+    global _intent_restore_done, _intent_restore_lock
+    _intent_restore_done = False
+    _intent_restore_lock = None
 
 
 @app.get("/computer_use/availability")

--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -4950,19 +4950,37 @@ async def _do_restore_agent_intent() -> None:
         return
     logger.info("[Agent] Restoring agent intent: %s", intent)
 
-    # 1. Master gate first — sub flags need analyzer_enabled to actually
-    # have effect. We call agent_command directly (it's a plain async fn
-    # despite the FastAPI decorator) with _persist_intent=False so the
-    # replay doesn't re-write what we just read.
-    if intent.get("analyzer_enabled"):
-        try:
-            await agent_command({
-                "command": "set_agent_enabled",
-                "enabled": True,
-                "_persist_intent": False,
-            })
-        except Exception as exc:
-            logger.warning("[Agent] Failed to restore analyzer_enabled: %s", exc)
+    # Master gate is the runtime prerequisite for *any* sub component:
+    # sub-flag intents only matter when the master switch is ON. Since
+    # set_agent_enabled(False) no longer wipes sub-flag intent, it's a
+    # legitimate persisted state to have e.g. ``analyzer_enabled=False``
+    # alongside ``user_plugin_enabled=True`` (the user toggled the master
+    # off but kept their sub-flag preferences). In that case we must NOT
+    # spin up plugin lifecycle / probe LLM / fire openclaw probe — the
+    # user explicitly disabled the master. Sub-flag intents stay in the
+    # file untouched, so the next time the user turns the master back on
+    # those flags will activate via the normal toggle path.
+    master_enabled = bool(intent.get("analyzer_enabled"))
+    if not master_enabled:
+        logger.info(
+            "[Agent] Restore: analyzer_enabled intent is %s, skipping sub-flag restore",
+            intent.get("analyzer_enabled"),
+        )
+        return
+
+    # Master ON — call agent_command directly (plain async fn despite the
+    # FastAPI decorator) with _persist_intent=False so the replay doesn't
+    # re-write what we just read.
+    try:
+        await agent_command({
+            "command": "set_agent_enabled",
+            "enabled": True,
+            "_persist_intent": False,
+        })
+    except Exception as exc:
+        logger.warning("[Agent] Failed to restore analyzer_enabled: %s", exc)
+        # Master gate failed to activate → don't even try sub flags
+        return
 
     # 2. Two fully-independent parallel tracks. CU/BU are LLM-coupled
     # (probe-gated). user_plugin runs on its own lifecycle and explicitly

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -50,9 +50,12 @@ except Exception:
 # ─── Connectivity probe error classification ────────────────────────────
 #
 # Maps raw exception/text patterns from the chat completion client into the
-# stable ``AGENT_*`` reason codes that ``check_connectivity()`` returns and the
-# restore path uses to decide whether a failure is transient (worth a 15s
-# retry window) or permanent (give up immediately and ask the user to fix).
+# stable ``AGENT_*`` reason codes that ``check_connectivity()`` returns and
+# the restore path (see ``_restore_llm_dependent_flags`` in
+# ``app/agent_server.py``) uses to decide whether a failure is transient
+# (worth retrying within the bounded restore window of ~32s wall-clock,
+# 3 attempts × 6s timeout + 2 × 7s gap) or permanent (give up immediately
+# and surface ``AGENT_AUTO_DISABLED_*`` to the user).
 # Keep the classifier here (not in agent_server) so any caller of
 # ``check_connectivity`` gets the same reason vocabulary.
 _PERMANENT_AUTH_TOKENS = (
@@ -604,12 +607,14 @@ class ComputerUseAdapter:
             ``AGENT_DNS_NXDOMAIN``             — host does not resolve
             ``AGENT_LLM_UNREACHABLE``          — generic transient (timeout / 5xx / refused)
 
-        ``timeout_s=4.0, _retries=0`` is the fast/restore default. Callers that
-        explicitly want cold-start TLS handshake forgiveness (very slow links)
-        can pass larger values, but the previous 20s+3×retry default was
-        over-defensive — TLS resumption + warmed DNS cache settle <2s in normal
-        environments, and 4s preserves the ability to bail out within a 15s
-        retry window.
+        ``timeout_s=6.0, _retries=0`` is the current fast/restore default.
+        Callers that need extra cold-start TLS / DNS tolerance on slow links
+        can pass a larger ``timeout_s``. The previous 20s + 3×retry default
+        was over-defensive — TLS resumption + warmed DNS cache settle <2s in
+        normal environments — but the 6s budget here leaves room for one
+        cold handshake while keeping a single probe well under the
+        ``_RESTORE_PING_INTERVAL_S=7s`` gap used by the restore loop, so
+        attempts don't overlap.
         """
         cfg = self._config_manager.get_model_api_config("agent")
         api_key = cfg.get("api_key") or "EMPTY"

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -587,7 +587,7 @@ class ComputerUseAdapter:
     def check_connectivity(
         self,
         *,
-        timeout_s: float = 4.0,
+        timeout_s: float = 6.0,
         _retries: int = 0,
     ) -> Tuple[bool, str]:
         """Synchronous LLM ping using the same ChatOpenAI client that real

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -625,23 +625,33 @@ class ComputerUseAdapter:
             try:
                 current_sig = (base_url.rstrip("/"), api_key, model)
                 if self._llm_client is None or self._llm_client_sig != current_sig:
+                    # CRITICAL: keep the client instance's default timeout at
+                    # 65.0s, NOT ``timeout_s``. ``self._llm_client`` is reused
+                    # by the live ``_call_llm`` path (line ~1123) which calls
+                    # ``invoke_raw(messages, ...)`` WITHOUT a per-call
+                    # ``timeout=`` kwarg, so it inherits the instance default.
+                    # If we cached a 4s-default client here, real GUI Agent
+                    # requests would time out after 4 seconds and break the
+                    # whole feature. The fast-probe behavior is achieved
+                    # purely by the per-call ``timeout=timeout_s`` argument
+                    # on the ping's ``invoke_raw`` below, which routes
+                    # through ``_params()`` without mutating the instance.
                     self._llm_client = create_chat_llm(
                         model=model,
                         base_url=base_url,
                         api_key=api_key,
-                        timeout=timeout_s,
+                        timeout=65.0,
                         max_retries=0,
                         temperature=0,
                     )
                     self._llm_client_sig = current_sig
                 extra = get_agent_extra_body(model) or {}
                 set_call_type("agent_cua")
-                # Pass per-call overrides into invoke_raw so they hit
-                # _params() locally instead of mutating self._llm_client —
-                # this ping runs from a background thread and the live
-                # _call_llm path uses self.max_completion_tokens=6000;
-                # writing the 5-token ping budget back to the instance
-                # would clip a concurrent real request to 5 tokens.
+                # Per-call overrides via invoke_raw's **kwargs path: routes
+                # both max_completion_tokens AND timeout through _params()
+                # locally, NOT writing back to the instance. This means a
+                # 4s probe ping running concurrently with a real 60s GUI
+                # request won't clip the latter's budget or timeout.
                 resp = self._llm_client.invoke_raw(
                     [{"role": "user", "content": "ok"}],
                     max_completion_tokens=LLM_PING_MAX_TOKENS,

--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -47,6 +47,68 @@ except Exception:
     pyautogui = None
 
 
+# ─── Connectivity probe error classification ────────────────────────────
+#
+# Maps raw exception/text patterns from the chat completion client into the
+# stable ``AGENT_*`` reason codes that ``check_connectivity()`` returns and the
+# restore path uses to decide whether a failure is transient (worth a 15s
+# retry window) or permanent (give up immediately and ask the user to fix).
+# Keep the classifier here (not in agent_server) so any caller of
+# ``check_connectivity`` gets the same reason vocabulary.
+_PERMANENT_AUTH_TOKENS = (
+    "authentication",
+    "invalid_api_key",
+    "invalid api key",
+    "unauthorized",
+    "forbidden",
+    " 401",
+    " 403",
+)
+_QUOTA_TOKENS = (
+    "quota",
+    "rate_limit",
+    "rate limit",
+    " 429",
+    "insufficient_quota",
+)
+_DNS_NXDOMAIN_TOKENS = (
+    "nxdomain",
+    "name or service not known",
+    "getaddrinfo failed",
+    "no address associated",
+)
+
+
+def _classify_connectivity_exception(exc: Optional[Exception]) -> str:
+    """Bucket an exception from ``invoke_raw`` into a stable reason code.
+
+    Match is text-based on ``str(exc)`` because openai-sdk / httpx wraps
+    layer the underlying HTTP status into the message rather than exposing a
+    typed status; the SDK type hierarchy itself is also imported lazily by
+    ``create_chat_llm``, so we cannot ``isinstance`` against it from here
+    without a circular import.
+    """
+    if exc is None:
+        return "AGENT_LLM_UNREACHABLE"
+    msg = str(exc).lower()
+    if any(tok in msg for tok in _PERMANENT_AUTH_TOKENS):
+        return "AGENT_API_KEY_INVALID"
+    if any(tok in msg for tok in _QUOTA_TOKENS):
+        return "AGENT_QUOTA_EXCEEDED"
+    if any(tok in msg for tok in _DNS_NXDOMAIN_TOKENS):
+        return "AGENT_DNS_NXDOMAIN"
+    return "AGENT_LLM_UNREACHABLE"
+
+
+# Permanent (no point retrying) reason codes — see restore path in agent_server.
+PERMANENT_CONNECTIVITY_REASONS = frozenset({
+    "AGENT_ENDPOINT_NOT_CONFIGURED",
+    "AGENT_API_KEY_INVALID",
+    "AGENT_QUOTA_EXCEEDED",
+    "AGENT_DNS_NXDOMAIN",
+})
+
+
 # ─── Prompt Templates ───────────────────────────────────────────────────
 
 INSTRUCTION_TEMPLATE = (
@@ -522,13 +584,32 @@ class ComputerUseAdapter:
     # Non-blocking LLM connectivity probe
     # ------------------------------------------------------------------
 
-    def check_connectivity(self, *, _retries: int = 2) -> bool:
+    def check_connectivity(
+        self,
+        *,
+        timeout_s: float = 4.0,
+        _retries: int = 0,
+    ) -> Tuple[bool, str]:
         """Synchronous LLM ping using the same ChatOpenAI client that real
         tasks will use, so the TCP/TLS connection pool is warmed up.
         Meant to be called from a background thread.
 
-        Retries up to *_retries* times on failure (cold-start DNS/TLS
-        handshake can exceed the per-request timeout on first attempt).
+        Returns ``(ok, reason_code)``. ``reason_code`` is empty on success;
+        otherwise a stable identifier the caller can match against to decide
+        whether the failure is transient (retry) or permanent (give up):
+
+            ``AGENT_ENDPOINT_NOT_CONFIGURED``  — base_url / model missing
+            ``AGENT_API_KEY_INVALID``          — HTTP 401/403, auth rejected
+            ``AGENT_QUOTA_EXCEEDED``           — HTTP 429 / quota exhausted
+            ``AGENT_DNS_NXDOMAIN``             — host does not resolve
+            ``AGENT_LLM_UNREACHABLE``          — generic transient (timeout / 5xx / refused)
+
+        ``timeout_s=4.0, _retries=0`` is the fast/restore default. Callers that
+        explicitly want cold-start TLS handshake forgiveness (very slow links)
+        can pass larger values, but the previous 20s+3×retry default was
+        over-defensive — TLS resumption + warmed DNS cache settle <2s in normal
+        environments, and 4s preserves the ability to bail out within a 15s
+        retry window.
         """
         cfg = self._config_manager.get_model_api_config("agent")
         api_key = cfg.get("api_key") or "EMPTY"
@@ -537,7 +618,7 @@ class ComputerUseAdapter:
         if not base_url or not model:
             self.init_ok = False
             self.last_error = "Agent model not configured"
-            return False
+            return False, "AGENT_ENDPOINT_NOT_CONFIGURED"
 
         last_exc: Exception | None = None
         for attempt in range(_retries + 1):
@@ -548,7 +629,7 @@ class ComputerUseAdapter:
                         model=model,
                         base_url=base_url,
                         api_key=api_key,
-                        timeout=65.0,
+                        timeout=timeout_s,
                         max_retries=0,
                         temperature=0,
                     )
@@ -565,7 +646,7 @@ class ComputerUseAdapter:
                     [{"role": "user", "content": "ok"}],
                     max_completion_tokens=LLM_PING_MAX_TOKENS,
                     extra_body=extra or None,
-                    timeout=20,
+                    timeout=timeout_s,
                 )
                 # 连通性检测只关心 HTTP 层是否通、响应结构是否合法；某些上游
                 # （如 free-agent-model）会返回 choices 非空但 message=None
@@ -576,7 +657,7 @@ class ComputerUseAdapter:
                 self.init_ok = True
                 self.last_error = None
                 logger.info("[CUA] LLM connectivity OK (%s @ %s)", model, base_url)
-                return True
+                return True, ""
             except Exception as e:
                 last_exc = e
                 if attempt < _retries:
@@ -587,9 +668,13 @@ class ComputerUseAdapter:
                     time.sleep(delay)
 
         self.init_ok = False
-        self.last_error = str(last_exc)
-        logger.warning("[CUA] LLM connectivity FAIL after %d attempts: %s", _retries + 1, last_exc)
-        return False
+        self.last_error = str(last_exc) if last_exc else "unknown"
+        reason_code = _classify_connectivity_exception(last_exc)
+        logger.warning(
+            "[CUA] LLM connectivity FAIL after %d attempts (reason=%s): %s",
+            _retries + 1, reason_code, last_exc,
+        )
+        return False, reason_code
 
     # ------------------------------------------------------------------
     # Public interface

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -48,6 +48,23 @@ def _fire_task(coro):
     return task
 
 
+async def _publish_agent_intent_restore_signal(lanlan_name: str) -> None:
+    """Tell agent_server (via ZMQ) that a real client session is alive,
+    so it can restore persisted agent runtime intent (analyzer_enabled +
+    5 sub flags). Agent-side once-flag means duplicate signals are cheap.
+    Failures (e.g. agent_server not up yet) are swallowed silently —
+    the next greeting_check will retry, and the user-facing UI doesn't
+    depend on this restore succeeding."""
+    try:
+        from main_logic.agent_event_bus import publish_session_event
+        await publish_session_event({
+            "event_type": "agent_intent_restore_signal",
+            "lanlan_name": lanlan_name,
+        })
+    except Exception as exc:
+        logger.debug("[Greeting] agent intent restore signal publish failed: %s", exc)
+
+
 # 每个角色的 WS 断开时间戳（epoch），用于区分"首次连接"与"刷新/重连"
 _ws_disconnect_time: dict[str, float] = {}
 
@@ -235,6 +252,14 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
             elif action == "greeting_check":
                 # 首次连接或切换角色时，前端请求检查是否需要主动搭话
                 # is_switch=true 时始终触发；否则检查上次断开距今是否 >15s（排除刷新/重连）
+                #
+                # 顺便：这也是 agent_server 启动后第一个"用户实际进入会话"的信号 ——
+                # 我们用它来触发 agent runtime intent restore (analyzer_enabled +
+                # 5 个 sub flag 上次会话的开关状态)。restore 是 fire-and-forget 的
+                # ZMQ event，agent_server 端有 once-flag 保证只跑一次；即使本次
+                # greeting_check 被 home tutorial guard 阻塞，agent intent 也应该
+                # 趁机会恢复（无害：用户在新手引导期一般也没旧 intent 要恢复）。
+                _fire_task(_publish_agent_intent_restore_signal(lanlan_name))
                 if _is_home_tutorial_blocking_greeting(lanlan_name):
                     logger.info(f"[{lanlan_name}] greeting_check: skipped by home tutorial guard")
                     continue

--- a/plugin/server/application/plugins/lifecycle_service.py
+++ b/plugin/server/application/plugins/lifecycle_service.py
@@ -384,6 +384,7 @@ class PluginLifecycleService:
         restore_state: bool = False,
         *,
         refresh_registry: bool = True,
+        persist_user_intent: bool = False,
     ) -> dict[str, object]:
         start_time = time_module.perf_counter()
         original_plugin_id = plugin_id
@@ -392,6 +393,8 @@ class PluginLifecycleService:
         existing_host_obj = await asyncio.to_thread(_get_plugin_host_sync, current_plugin_id)
         if isinstance(existing_host_obj, PluginHostContract):
             if existing_host_obj.is_alive():
+                if persist_user_intent:
+                    await asyncio.to_thread(set_runtime_override, current_plugin_id, True)
                 _emit_lifecycle_event(event_type="plugin_start_skipped", plugin_id=current_plugin_id)
                 return {
                     "success": True,
@@ -676,6 +679,8 @@ class PluginLifecycleService:
             await asyncio.to_thread(_register_or_replace_host_sync, current_plugin_id, host_obj)
             registered_plugin_id = current_plugin_id
 
+            if persist_user_intent:
+                await asyncio.to_thread(set_runtime_override, current_plugin_id, True)
             _emit_lifecycle_event(event_type="plugin_started", plugin_id=current_plugin_id)
             response: dict[str, object] = {
                 "success": True,
@@ -739,7 +744,12 @@ class PluginLifecycleService:
                 error_type=type(exc).__name__,
             ) from exc
 
-    async def stop_plugin(self, plugin_id: str) -> dict[str, object]:
+    async def stop_plugin(
+        self,
+        plugin_id: str,
+        *,
+        persist_user_intent: bool = False,
+    ) -> dict[str, object]:
         host_obj = await asyncio.to_thread(_get_plugin_host_sync, plugin_id)
         if host_obj is None:
             raise _to_domain_error(
@@ -781,6 +791,8 @@ class PluginLifecycleService:
                     type(exc).__name__,
                     str(exc),
                 )
+            if persist_user_intent:
+                await asyncio.to_thread(set_runtime_override, plugin_id, False)
             _emit_lifecycle_event(event_type="plugin_stopped", plugin_id=plugin_id)
             return {
                 "success": True,

--- a/plugin/server/routes/plugins.py
+++ b/plugin/server/routes/plugins.py
@@ -41,7 +41,7 @@ async def list_plugins(locale: Optional[str] = Query(default=None)) -> dict[str,
 @router.post("/plugin/{plugin_id}/start")
 async def start_plugin_endpoint(plugin_id: str, _: str = require_admin) -> dict[str, object]:
     try:
-        return await lifecycle_service.start_plugin(plugin_id)
+        return await lifecycle_service.start_plugin(plugin_id, persist_user_intent=True)
     except ServerDomainError as error:
         raise_http_from_domain(error, logger=logger)
 
@@ -57,7 +57,7 @@ async def refresh_plugin_endpoint(plugin_id: str, _: str = require_admin) -> dic
 @router.post("/plugin/{plugin_id}/stop")
 async def stop_plugin_endpoint(plugin_id: str, _: str = require_admin) -> dict[str, object]:
     try:
-        return await lifecycle_service.stop_plugin(plugin_id)
+        return await lifecycle_service.stop_plugin(plugin_id, persist_user_intent=True)
     except ServerDomainError as error:
         raise_http_from_domain(error, logger=logger)
 

--- a/plugin/tests/unit/server/test_plugins_lifecycle_service.py
+++ b/plugin/tests/unit/server/test_plugins_lifecycle_service.py
@@ -1199,3 +1199,101 @@ async def test_delete_plugin_clears_runtime_override(
             module.state.event_handlers.update(handlers_backup)
         with module.state._snapshot_cache_lock:
             module.state._snapshot_cache = cache_backup
+
+
+def _seed_running_plugin(plugin_id: str, config_path: Path) -> None:
+    with module.state.acquire_plugins_write_lock():
+        module.state.plugins.clear()
+        module.state.plugins[plugin_id] = {
+            "id": plugin_id,
+            "name": plugin_id,
+            "type": "plugin",
+            "config_path": str(config_path),
+            "entry_point": "tests.fake:Plugin",
+        }
+    with module.state.acquire_plugin_hosts_write_lock():
+        module.state.plugin_hosts.clear()
+        module.state.plugin_hosts[plugin_id] = _FakeProcessHost(
+            plugin_id=plugin_id,
+            entry_point="tests.fake:Plugin",
+            config_path=config_path,
+        )
+    with module.state.acquire_event_handlers_write_lock():
+        module.state.event_handlers.clear()
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_stop_plugin_persist_user_intent_writes_runtime_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    config_path = tmp_path / "demo_plugin" / "plugin.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[plugin]\nid='demo_plugin'\n", encoding="utf-8")
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        _seed_running_plugin("demo_plugin", config_path)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+        service = module.PluginLifecycleService()
+        await service.stop_plugin("demo_plugin", persist_user_intent=True)
+        assert _isolate_runtime_overrides == {"demo_plugin": False}
+        assert runtime_overrides_module.get_runtime_override("demo_plugin") is False
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup
+
+
+@pytest.mark.plugin_unit
+@pytest.mark.asyncio
+async def test_stop_plugin_internal_call_does_not_touch_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _isolate_runtime_overrides: dict,
+) -> None:
+    config_path = tmp_path / "demo_plugin" / "plugin.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[plugin]\nid='demo_plugin'\n", encoding="utf-8")
+
+    plugins_backup = copy.deepcopy(module.state.plugins)
+    hosts_backup = dict(module.state.plugin_hosts)
+    handlers_backup = dict(module.state.event_handlers)
+    cache_backup = copy.deepcopy(module.state._snapshot_cache)
+
+    try:
+        _seed_running_plugin("demo_plugin", config_path)
+        runtime_overrides_module.set_runtime_override("demo_plugin", True)
+        monkeypatch.setattr(module, "emit_lifecycle_event", lambda event: None)
+
+        service = module.PluginLifecycleService()
+        await service.stop_plugin("demo_plugin")
+        assert _isolate_runtime_overrides == {"demo_plugin": True}
+        assert runtime_overrides_module.get_runtime_override("demo_plugin") is True
+    finally:
+        with module.state.acquire_plugins_write_lock():
+            module.state.plugins.clear()
+            module.state.plugins.update(plugins_backup)
+        with module.state.acquire_plugin_hosts_write_lock():
+            module.state.plugin_hosts.clear()
+            module.state.plugin_hosts.update(hosts_backup)
+        with module.state.acquire_event_handlers_write_lock():
+            module.state.event_handlers.clear()
+            module.state.event_handlers.update(handlers_backup)
+        with module.state._snapshot_cache_lock:
+            module.state._snapshot_cache = cache_backup

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -251,9 +251,15 @@ def agent_state_isolation(monkeypatch: pytest.MonkeyPatch):
     async def _noop_admin(*args, **kwargs):
         return {"success": True}
 
+    async def _plugin_lifecycle_started_ok(*args, **kwargs):
+        # Must return True so the background _bg_plugin_enable task in
+        # set_agent_flags doesn't flip ``user_plugin_enabled`` back to
+        # False and create a race against the test's assertions.
+        return True
+
     monkeypatch.setattr(srv, "_emit_agent_status_update", _noop_async)
     monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _noop_async)
-    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", lambda: _noop_async() or asyncio.sleep(0))
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", _plugin_lifecycle_started_ok)
     monkeypatch.setattr(srv, "admin_control", _noop_admin)
     monkeypatch.setattr(srv, "_cancel_openclaw_enable_probe", lambda: None)
     monkeypatch.setattr(srv, "_try_refresh_computer_use_adapter", lambda force=False: False)

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -577,6 +576,117 @@ async def test_restore_llm_dependent_module_not_loaded_is_permanent(
 
     assert ari.get_intent("computer_use_enabled") is False
     assert ari.get_intent("browser_use_enabled") is False
+
+
+@pytest.mark.asyncio
+async def test_restore_skipped_when_master_intent_off(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Per Codex P1: if persisted intent has ``analyzer_enabled=False`` but
+    sub flags True (a legitimate state now that master OFF preserves sub
+    intent), restore must NOT spin up plugin lifecycle / LLM probe / openclaw
+    probe — master is the runtime gate. Sub-flag intents stay in the file
+    untouched."""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    ari.set_intent("analyzer_enabled", False)
+    ari.set_intent("computer_use_enabled", True)
+    ari.set_intent("user_plugin_enabled", True)
+    ari.set_intent("openclaw_enabled", True)
+
+    # If any of these get called, the master-gate skip was missed.
+    agent_command_calls = []
+    set_flags_calls = []
+    llm_dependent_calls = []
+    user_plugin_calls = []
+
+    async def _fake_agent_command(payload):
+        agent_command_calls.append(payload)
+        return {"success": True}
+
+    async def _fake_set_flags(payload):
+        set_flags_calls.append(payload)
+        return {"success": True}
+
+    async def _fake_llm_dependent(intent):
+        llm_dependent_calls.append(intent)
+
+    async def _fake_user_plugin():
+        user_plugin_calls.append(True)
+
+    monkeypatch.setattr(srv_mod, "agent_command", _fake_agent_command)
+    monkeypatch.setattr(srv_mod, "set_agent_flags", _fake_set_flags)
+    monkeypatch.setattr(srv_mod, "_restore_llm_dependent_flags", _fake_llm_dependent)
+    monkeypatch.setattr(srv_mod, "_restore_user_plugin", _fake_user_plugin)
+
+    await srv_mod._do_restore_agent_intent()
+
+    # Nothing should fire when master intent is False
+    assert agent_command_calls == []
+    assert set_flags_calls == []
+    assert llm_dependent_calls == []
+    assert user_plugin_calls == []
+
+    # Sub-flag intents untouched — they stay so next master ON re-activates
+    assert ari.get_intent("computer_use_enabled") is True
+    assert ari.get_intent("user_plugin_enabled") is True
+    assert ari.get_intent("openclaw_enabled") is True
+    assert ari.get_intent("analyzer_enabled") is False
+
+
+@pytest.mark.asyncio
+async def test_restore_skipped_when_master_intent_never_set(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When master intent is None (never toggled), default-deny: don't spin
+    up sub components. User can turn master on explicitly to activate them."""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    # Master intent NOT set; sub flags set.
+    ari.set_intent("user_plugin_enabled", True)
+    assert ari.get_intent("analyzer_enabled") is None
+
+    user_plugin_calls = []
+
+    async def _fake_user_plugin():
+        user_plugin_calls.append(True)
+
+    monkeypatch.setattr(srv_mod, "_restore_user_plugin", _fake_user_plugin)
+
+    await srv_mod._do_restore_agent_intent()
+    assert user_plugin_calls == []
+
+
+@pytest.mark.asyncio
+async def test_restore_proceeds_when_master_intent_on(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Sanity counter-test: master=True + user_plugin=True must trigger
+    user_plugin restore. (Pairs with the master-OFF skip test above.)"""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    ari.set_intent("analyzer_enabled", True)
+    ari.set_intent("user_plugin_enabled", True)
+
+    user_plugin_calls = []
+
+    async def _fake_agent_command(payload):
+        return {"success": True}
+
+    async def _fake_user_plugin():
+        user_plugin_calls.append(True)
+
+    monkeypatch.setattr(srv_mod, "agent_command", _fake_agent_command)
+    monkeypatch.setattr(srv_mod, "_restore_user_plugin", _fake_user_plugin)
+
+    await srv_mod._do_restore_agent_intent()
+    # Give the parallel task a tick to schedule
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert user_plugin_calls == [True]
 
 
 def test_check_connectivity_failure_classifies_reason(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_agent_runtime_intent.py
+++ b/tests/unit/test_agent_runtime_intent.py
@@ -1,0 +1,605 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for agent runtime intent persistence + restore flow.
+
+Scope:
+1. ``app.agent_runtime_intent``: roundtrip / schema / cache isolation
+2. ``brain.computer_use.check_connectivity``: new (ok, reason_code) signature
+   + classification of permanent vs transient errors
+3. Master-switch semantics: ``set_agent_enabled(False)`` no longer wipes
+   sub flags (issue: cycling the master gate used to forget user intent
+   for every sub feature)
+4. Gate-fail branch: gate-fail does NOT touch ``user_plugin_enabled``
+   anymore (plugins don't depend on the agent LLM)
+5. Intent writes: ``_persist_intent=True`` hooks fire on explicit toggles;
+   ``_persist_intent=False`` (restore replay) does not re-write intent
+6. Restore: ``_maybe_restore_agent_intent`` once-flag + escape hatch +
+   permanent error short-circuit
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_intent_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Redirect agent_runtime_intent JSON I/O to a tmp dir + reset the
+    module's in-process cache. Yields the directory the JSON would land in."""
+    from app import agent_runtime_intent as ari
+
+    # Backing store: fake config_manager that proxies load/save to tmp_path.
+    store_file = tmp_path / ari.INTENT_FILENAME
+
+    class _FakeCM:
+        def load_json_config(self, filename, default_value=None):
+            path = tmp_path / filename
+            if not path.exists():
+                if default_value is not None:
+                    import copy
+                    return copy.deepcopy(default_value)
+                raise FileNotFoundError(str(path))
+            return json.loads(path.read_text(encoding="utf-8"))
+
+        def save_json_config(self, filename, data, *, bypass_write_fence: bool = False):
+            path = tmp_path / filename
+            path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def _get_cm():
+        return _FakeCM()
+
+    monkeypatch.setattr("utils.config_manager.get_config_manager", _get_cm)
+    ari.reset_cache_for_testing()
+    yield store_file
+    ari.reset_cache_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# 1. agent_runtime_intent module
+# ---------------------------------------------------------------------------
+
+
+def test_intent_set_get_clear_roundtrip(isolated_intent_store: Path):
+    from app import agent_runtime_intent as ari
+
+    assert ari.load_intent() == {}
+    ari.set_intent("analyzer_enabled", True)
+    ari.set_intent("computer_use_enabled", False)
+
+    # Round-trip the cache by forcing reload from disk.
+    ari.reset_cache_for_testing()
+    assert ari.load_intent() == {
+        "analyzer_enabled": True,
+        "computer_use_enabled": False,
+    }
+    assert ari.get_intent("analyzer_enabled") is True
+    assert ari.get_intent("computer_use_enabled") is False
+    assert ari.get_intent("user_plugin_enabled") is None
+
+    ari.clear_intent("analyzer_enabled")
+    assert ari.get_intent("analyzer_enabled") is None
+    assert ari.load_intent() == {"computer_use_enabled": False}
+
+
+def test_intent_rejects_unknown_keys(isolated_intent_store: Path):
+    """Schema closure: unknown keys are silently dropped on write/read so
+    a malformed file from a future version can't bork restore."""
+    from app import agent_runtime_intent as ari
+
+    ari.set_intent("bogus_key", True)  # type: ignore[arg-type]
+    assert ari.get_intent("bogus_key") is None  # type: ignore[arg-type]
+    assert ari.load_intent() == {}
+
+
+def test_intent_set_same_value_is_noop(isolated_intent_store: Path):
+    """Writing the same value twice should not re-touch disk — useful when
+    restore re-applies an unchanged state."""
+    from app import agent_runtime_intent as ari
+
+    ari.set_intent("analyzer_enabled", True)
+    mtime_after_first = isolated_intent_store.stat().st_mtime_ns
+
+    # Same value: should short-circuit before save_to_disk.
+    ari.set_intent("analyzer_enabled", True)
+    mtime_after_second = isolated_intent_store.stat().st_mtime_ns
+
+    assert mtime_after_first == mtime_after_second
+
+
+def test_intent_coerces_malformed_payload(
+    isolated_intent_store: Path, tmp_path: Path
+):
+    """Stale/garbage JSON values must not crash startup — invalid entries
+    are filtered out, valid ones still load."""
+    from app import agent_runtime_intent as ari
+
+    isolated_intent_store.write_text(
+        json.dumps({
+            "analyzer_enabled": True,
+            "computer_use_enabled": "yes",    # wrong type → drop
+            "bogus": True,                     # unknown key → drop
+            42: True,                          # non-str key → won't survive JSON anyway
+        }),
+        encoding="utf-8",
+    )
+    ari.reset_cache_for_testing()
+    assert ari.load_intent() == {"analyzer_enabled": True}
+
+
+# ---------------------------------------------------------------------------
+# 2. check_connectivity signature + classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_connectivity_exception_buckets():
+    from brain.computer_use import _classify_connectivity_exception
+
+    # Permanent reasons
+    assert _classify_connectivity_exception(Exception("Invalid API key: 401")) == "AGENT_API_KEY_INVALID"
+    assert _classify_connectivity_exception(Exception("403 Forbidden")) == "AGENT_API_KEY_INVALID"
+    assert _classify_connectivity_exception(Exception("authentication failed")) == "AGENT_API_KEY_INVALID"
+    assert _classify_connectivity_exception(Exception("Rate limit exceeded (429)")) == "AGENT_QUOTA_EXCEEDED"
+    assert _classify_connectivity_exception(Exception("insufficient_quota: please add billing")) == "AGENT_QUOTA_EXCEEDED"
+    assert _classify_connectivity_exception(Exception("nxdomain: no such host")) == "AGENT_DNS_NXDOMAIN"
+    assert _classify_connectivity_exception(Exception("getaddrinfo failed")) == "AGENT_DNS_NXDOMAIN"
+
+    # Transient (default bucket)
+    assert _classify_connectivity_exception(Exception("connection refused")) == "AGENT_LLM_UNREACHABLE"
+    assert _classify_connectivity_exception(Exception("Read timeout")) == "AGENT_LLM_UNREACHABLE"
+    assert _classify_connectivity_exception(Exception("500 internal server error")) == "AGENT_LLM_UNREACHABLE"
+    assert _classify_connectivity_exception(None) == "AGENT_LLM_UNREACHABLE"
+
+
+def test_permanent_connectivity_reasons_set():
+    """Restore path uses this frozenset to decide whether to bail early.
+    Lock the membership so an accidental rename in computer_use.py is caught."""
+    from brain.computer_use import PERMANENT_CONNECTIVITY_REASONS
+
+    assert "AGENT_API_KEY_INVALID" in PERMANENT_CONNECTIVITY_REASONS
+    assert "AGENT_QUOTA_EXCEEDED" in PERMANENT_CONNECTIVITY_REASONS
+    assert "AGENT_DNS_NXDOMAIN" in PERMANENT_CONNECTIVITY_REASONS
+    assert "AGENT_ENDPOINT_NOT_CONFIGURED" in PERMANENT_CONNECTIVITY_REASONS
+    # Transient must NOT be in the permanent set:
+    assert "AGENT_LLM_UNREACHABLE" not in PERMANENT_CONNECTIVITY_REASONS
+
+
+def test_check_connectivity_returns_tuple_on_missing_config(monkeypatch: pytest.MonkeyPatch):
+    """If base_url/model not configured, must return ``(False, 'AGENT_ENDPOINT_NOT_CONFIGURED')``
+    immediately without trying to construct an LLM client."""
+    from brain import computer_use as cu_module
+
+    # Build a minimal adapter instance avoiding the heavy __init__.
+    adapter = cu_module.ComputerUseAdapter.__new__(cu_module.ComputerUseAdapter)
+    adapter._config_manager = MagicMock()
+    adapter._config_manager.get_model_api_config = MagicMock(return_value={
+        "api_key": "EMPTY",
+        "base_url": "",
+        "model": "",
+    })
+    adapter._llm_client = None
+    adapter._llm_client_sig = None
+    adapter.init_ok = True
+    adapter.last_error = None
+
+    ok, reason = adapter.check_connectivity()
+    assert ok is False
+    assert reason == "AGENT_ENDPOINT_NOT_CONFIGURED"
+    assert adapter.init_ok is False
+
+
+def test_check_connectivity_success_returns_empty_reason(monkeypatch: pytest.MonkeyPatch):
+    from brain import computer_use as cu_module
+
+    fake_llm = MagicMock()
+    fake_choice = MagicMock()
+    fake_choice.message = MagicMock(content="ok")
+    fake_resp = MagicMock(choices=[fake_choice])
+    fake_llm.invoke_raw = MagicMock(return_value=fake_resp)
+
+    monkeypatch.setattr(cu_module, "create_chat_llm", lambda **kwargs: fake_llm)
+
+    adapter = cu_module.ComputerUseAdapter.__new__(cu_module.ComputerUseAdapter)
+    adapter._config_manager = MagicMock()
+    adapter._config_manager.get_model_api_config = MagicMock(return_value={
+        "api_key": "sk-test",
+        "base_url": "https://api.example.com",
+        "model": "test-model",
+    })
+    adapter._llm_client = None
+    adapter._llm_client_sig = None
+    adapter.init_ok = False
+    adapter.last_error = "stale"
+
+    ok, reason = adapter.check_connectivity(timeout_s=4.0)
+    assert ok is True
+    assert reason == ""
+    assert adapter.init_ok is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Master switch semantics: set_agent_enabled(False) preserves sub flags
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def agent_state_isolation(monkeypatch: pytest.MonkeyPatch):
+    """Snapshot/restore the relevant global state on app.agent_server.Modules
+    so tests can mutate freely. Also stubs out the side-effectful calls
+    inside set_agent_enabled/set_agent_flags that need full process state
+    (ZMQ bridge, plugin lifecycle, openclaw probe, etc)."""
+    from app import agent_server as srv
+
+    backup_analyzer_enabled = srv.Modules.analyzer_enabled
+    backup_analyzer_profile = dict(srv.Modules.analyzer_profile)
+    backup_agent_flags = dict(srv.Modules.agent_flags)
+    backup_capability = {
+        k: dict(v) for k, v in srv.Modules.capability_cache.items()
+    }
+
+    async def _noop_async(*args, **kwargs):
+        return None
+
+    async def _noop_admin(*args, **kwargs):
+        return {"success": True}
+
+    monkeypatch.setattr(srv, "_emit_agent_status_update", _noop_async)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_stopped", _noop_async)
+    monkeypatch.setattr(srv, "_ensure_plugin_lifecycle_started", lambda: _noop_async() or asyncio.sleep(0))
+    monkeypatch.setattr(srv, "admin_control", _noop_admin)
+    monkeypatch.setattr(srv, "_cancel_openclaw_enable_probe", lambda: None)
+    monkeypatch.setattr(srv, "_try_refresh_computer_use_adapter", lambda force=False: False)
+    monkeypatch.setattr(srv, "_fire_agent_llm_connectivity_check", _noop_async)
+    monkeypatch.setattr(srv, "_bump_state_revision", lambda: 0)
+
+    yield srv
+
+    srv.Modules.analyzer_enabled = backup_analyzer_enabled
+    srv.Modules.analyzer_profile = backup_analyzer_profile
+    srv.Modules.agent_flags = backup_agent_flags
+    srv.Modules.capability_cache = backup_capability
+
+
+@pytest.mark.asyncio
+async def test_set_agent_enabled_off_preserves_sub_flags(
+    agent_state_isolation, isolated_intent_store: Path
+):
+    """Master gate OFF must NOT clear sub-flag user intent. The fix lets a
+    user cycle the master toggle without re-ticking every sub feature."""
+    srv = agent_state_isolation
+
+    srv.Modules.analyzer_enabled = True
+    srv.Modules.agent_flags["computer_use_enabled"] = True
+    srv.Modules.agent_flags["browser_use_enabled"] = True
+    srv.Modules.agent_flags["user_plugin_enabled"] = True
+    srv.Modules.agent_flags["openclaw_enabled"] = True
+    srv.Modules.agent_flags["openfang_enabled"] = True
+
+    await srv.agent_command({
+        "command": "set_agent_enabled",
+        "enabled": False,
+        "_persist_intent": False,
+    })
+
+    assert srv.Modules.analyzer_enabled is False
+    # Sub flags survive — this is the core semantic fix
+    assert srv.Modules.agent_flags["computer_use_enabled"] is True
+    assert srv.Modules.agent_flags["browser_use_enabled"] is True
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+    assert srv.Modules.agent_flags["openclaw_enabled"] is True
+    assert srv.Modules.agent_flags["openfang_enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_gate_fail_preserves_user_plugin_enabled(
+    agent_state_isolation, isolated_intent_store: Path
+):
+    """Agent LLM gate failure (endpoint not configured) is the gate for
+    CU/BU/OpenClaw/OpenFang — but NOT user_plugin, which runs on its own
+    plugin lifecycle and doesn't touch the agent LLM."""
+    srv = agent_state_isolation
+
+    # Gate FAILS:
+    srv.Modules.analyzer_enabled = True
+    fake_gate = {"ready": False, "reasons": ["AGENT_ENDPOINT_NOT_CONFIGURED"]}
+
+    with patch.object(srv, "_check_agent_api_gate", return_value=fake_gate):
+        # User attempts to enable CU + user_plugin simultaneously. CU must
+        # be rejected (LLM-coupled), user_plugin must proceed.
+        await srv.set_agent_flags({
+            "computer_use_enabled": True,
+            "user_plugin_enabled": True,
+            "_persist_intent": False,
+        })
+
+    # CU was rejected
+    assert srv.Modules.agent_flags["computer_use_enabled"] is False
+    # user_plugin was let through (in-memory flag set to True by handler,
+    # background _bg_plugin_enable runs but we don't care about its outcome here).
+    assert srv.Modules.agent_flags["user_plugin_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Intent writes on explicit toggles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_agent_enabled_writes_intent(
+    agent_state_isolation, isolated_intent_store: Path
+):
+    """Explicit toggle (default _persist_intent=True) writes intent file."""
+    from app import agent_runtime_intent as ari
+
+    srv = agent_state_isolation
+
+    # Stub out the LLM-side _try_refresh / probe so gate-pass branch is quiet.
+    with patch.object(srv, "_check_agent_api_gate", return_value={"ready": True, "reasons": [], "is_free_version": False}):
+        await srv.agent_command({
+            "command": "set_agent_enabled",
+            "enabled": True,
+        })
+
+    assert ari.get_intent("analyzer_enabled") is True
+
+    with patch.object(srv, "_check_agent_api_gate", return_value={"ready": True, "reasons": [], "is_free_version": False}):
+        await srv.agent_command({
+            "command": "set_agent_enabled",
+            "enabled": False,
+        })
+
+    assert ari.get_intent("analyzer_enabled") is False
+
+
+@pytest.mark.asyncio
+async def test_persist_intent_false_does_not_write(
+    agent_state_isolation, isolated_intent_store: Path
+):
+    """Restore replay path passes _persist_intent=False; that must NOT
+    write back to the intent file (which would be a self-rewriting loop)."""
+    from app import agent_runtime_intent as ari
+
+    srv = agent_state_isolation
+    ari.set_intent("analyzer_enabled", True)
+    # Pollute cache so we'd notice unintended overwrite.
+    initial = ari.load_intent()
+
+    with patch.object(srv, "_check_agent_api_gate", return_value={"ready": True, "reasons": [], "is_free_version": False}):
+        await srv.agent_command({
+            "command": "set_agent_enabled",
+            "enabled": False,
+            "_persist_intent": False,
+        })
+
+    # Replay with _persist_intent=False must leave intent unchanged.
+    assert ari.load_intent() == initial
+
+
+@pytest.mark.asyncio
+async def test_capability_rejected_does_not_persist_true_intent(
+    agent_state_isolation, isolated_intent_store: Path
+):
+    """If user requests cf=True but capability auto-rejects (in-memory
+    flag stays False), intent must NOT be written True — otherwise restore
+    would keep retrying a feature the user can never enable."""
+    from app import agent_runtime_intent as ari
+
+    srv = agent_state_isolation
+    srv.Modules.analyzer_enabled = True
+    # Force computer_use to be missing → handler will set flag=False
+    srv.Modules.computer_use = None
+
+    with patch.object(srv, "_check_agent_api_gate", return_value={"ready": True, "reasons": [], "is_free_version": False}):
+        await srv.set_agent_flags({"computer_use_enabled": True})
+
+    assert srv.Modules.agent_flags["computer_use_enabled"] is False
+    # Intent not written because actual flag is False
+    assert ari.get_intent("computer_use_enabled") is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_disable_always_persists_false_intent(
+    agent_state_isolation, isolated_intent_store: Path
+):
+    """User explicitly disabling a flag must write False intent, even
+    without capability check (disable doesn't need a probe)."""
+    from app import agent_runtime_intent as ari
+
+    srv = agent_state_isolation
+    srv.Modules.analyzer_enabled = True
+    srv.Modules.agent_flags["openfang_enabled"] = True
+
+    with patch.object(srv, "_check_agent_api_gate", return_value={"ready": True, "reasons": [], "is_free_version": False}):
+        await srv.set_agent_flags({"openfang_enabled": False})
+
+    assert srv.Modules.agent_flags["openfang_enabled"] is False
+    assert ari.get_intent("openfang_enabled") is False
+
+
+# ---------------------------------------------------------------------------
+# 5. _maybe_restore_agent_intent: once flag + escape hatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restore_once_flag_blocks_duplicate_runs(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Once flag must prevent duplicate restore from concurrent
+    greeting_check signals from N WebSockets."""
+    from app import agent_server as srv_mod
+    srv_mod._reset_intent_restore_for_testing()
+
+    call_count = {"n": 0}
+
+    async def _fake_do_restore():
+        call_count["n"] += 1
+
+    monkeypatch.setattr(srv_mod, "_do_restore_agent_intent", _fake_do_restore)
+
+    await asyncio.gather(
+        srv_mod._maybe_restore_agent_intent(),
+        srv_mod._maybe_restore_agent_intent(),
+        srv_mod._maybe_restore_agent_intent(),
+    )
+    assert call_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_escape_hatch_via_env(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """NEKO_DISABLE_AGENT_AUTO_RESTORE=1 must skip restore entirely."""
+    from app import agent_server as srv_mod
+    srv_mod._reset_intent_restore_for_testing()
+
+    monkeypatch.setenv("NEKO_DISABLE_AGENT_AUTO_RESTORE", "1")
+    called = {"n": 0}
+
+    async def _fake_do_restore():
+        called["n"] += 1
+
+    monkeypatch.setattr(srv_mod, "_do_restore_agent_intent", _fake_do_restore)
+
+    await srv_mod._maybe_restore_agent_intent()
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_restore_llm_dependent_all_retries_fail_clears_intent(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When probe fails three times with transient error, intent should
+    flip to False so the user gets a clear AGENT_AUTO_DISABLED notification
+    and next restart doesn't keep banging on the same dead endpoint."""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    ari.set_intent("computer_use_enabled", True)
+    ari.set_intent("browser_use_enabled", True)
+
+    # Mock computer_use adapter on Modules; check_connectivity always fails.
+    fake_adapter = MagicMock()
+    fake_adapter.check_connectivity = MagicMock(return_value=(False, "AGENT_LLM_UNREACHABLE"))
+    srv_mod.Modules.computer_use = fake_adapter
+
+    # Shrink the retry window so the test is fast (3 attempts × 0.01s spacing).
+    monkeypatch.setattr(srv_mod, "_RESTORE_PING_INTERVAL_S", 0.01)
+
+    intent = {"computer_use_enabled": True, "browser_use_enabled": True}
+    await srv_mod._restore_llm_dependent_flags(intent)
+
+    # All three attempts ran
+    assert fake_adapter.check_connectivity.call_count == srv_mod._RESTORE_PING_MAX_ATTEMPTS
+    # Intent cleared to False on both flags
+    assert ari.get_intent("computer_use_enabled") is False
+    assert ari.get_intent("browser_use_enabled") is False
+
+
+@pytest.mark.asyncio
+async def test_restore_llm_dependent_permanent_error_short_circuits(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Permanent reason (e.g. API key invalid) must bail after the first
+    attempt — don't waste 15s retrying when we know the API is dead."""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    ari.set_intent("computer_use_enabled", True)
+
+    fake_adapter = MagicMock()
+    fake_adapter.check_connectivity = MagicMock(return_value=(False, "AGENT_API_KEY_INVALID"))
+    srv_mod.Modules.computer_use = fake_adapter
+
+    monkeypatch.setattr(srv_mod, "_RESTORE_PING_INTERVAL_S", 0.01)
+
+    intent = {"computer_use_enabled": True}
+    await srv_mod._restore_llm_dependent_flags(intent)
+
+    # Only ONE attempt — permanent reason short-circuits.
+    assert fake_adapter.check_connectivity.call_count == 1
+    assert ari.get_intent("computer_use_enabled") is False
+
+
+@pytest.mark.asyncio
+async def test_restore_llm_dependent_success_keeps_intent(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """When probe succeeds, intent should be preserved (NOT touched —
+    set_agent_flags with _persist_intent=False is called, which won't
+    write intent)."""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    ari.set_intent("computer_use_enabled", True)
+
+    fake_adapter = MagicMock()
+    fake_adapter.check_connectivity = MagicMock(return_value=(True, ""))
+    fake_adapter.init_ok = True
+    fake_adapter.is_available = MagicMock(return_value={"ready": True, "reasons": []})
+    srv_mod.Modules.computer_use = fake_adapter
+
+    # Master gate ON so set_agent_flags doesn't bail
+    srv_mod.Modules.analyzer_enabled = True
+
+    with patch.object(srv_mod, "_check_agent_api_gate", return_value={"ready": True, "reasons": [], "is_free_version": False}):
+        intent = {"computer_use_enabled": True}
+        await srv_mod._restore_llm_dependent_flags(intent)
+
+    # Intent preserved
+    assert ari.get_intent("computer_use_enabled") is True
+
+
+@pytest.mark.asyncio
+async def test_restore_llm_dependent_module_not_loaded_is_permanent(
+    agent_state_isolation, isolated_intent_store: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """If computer_use module is None (not loaded), restore should
+    immediately clear intent — not retry, since the module won't appear."""
+    from app import agent_runtime_intent as ari
+    from app import agent_server as srv_mod
+
+    ari.set_intent("computer_use_enabled", True)
+    ari.set_intent("browser_use_enabled", True)
+    srv_mod.Modules.computer_use = None
+
+    intent = {"computer_use_enabled": True, "browser_use_enabled": True}
+    await srv_mod._restore_llm_dependent_flags(intent)
+
+    assert ari.get_intent("computer_use_enabled") is False
+    assert ari.get_intent("browser_use_enabled") is False
+
+
+def test_check_connectivity_failure_classifies_reason(monkeypatch: pytest.MonkeyPatch):
+    """When invoke_raw raises, the classification helper picks the bucket."""
+    from brain import computer_use as cu_module
+
+    fake_llm = MagicMock()
+    fake_llm.invoke_raw = MagicMock(side_effect=Exception("Rate limit exceeded: 429"))
+    monkeypatch.setattr(cu_module, "create_chat_llm", lambda **kwargs: fake_llm)
+
+    adapter = cu_module.ComputerUseAdapter.__new__(cu_module.ComputerUseAdapter)
+    adapter._config_manager = MagicMock()
+    adapter._config_manager.get_model_api_config = MagicMock(return_value={
+        "api_key": "sk-test",
+        "base_url": "https://api.example.com",
+        "model": "test-model",
+    })
+    adapter._llm_client = None
+    adapter._llm_client_sig = None
+    adapter.init_ok = True
+    adapter.last_error = None
+
+    ok, reason = adapter.check_connectivity(timeout_s=4.0)
+    assert ok is False
+    assert reason == "AGENT_QUOTA_EXCEEDED"
+    assert adapter.init_ok is False


### PR DESCRIPTION
## Summary

修复用户手动关闭的开关重启后被自动开启的问题（起因：plugin manager 上"备忘提醒"被关掉重启又自动起来）。三层修复合一：

- **plugin 持久化**：plugin manager 卡片上的 stop / start 现在会写 \`plugin_runtime_overrides.json\`，重启会按用户偏好恢复（修原 bug 路径：只有 \`disable_extension\` 写 override、top-level plugin 的 stop 完全不持久化）
- **agent 持久化**：猫爪总开关 + 5 个 sub flag（CU / BU / user_plugin / openclaw / openfang）持久化到 \`agent_runtime_intent.json\`，首次 \`greeting_check\` 触发 restore
- **总闸语义修正**：master OFF 不再清 sub flag intent（master 是 runtime gate，不是 clear-all）；gate-fail 不再 reset \`user_plugin_enabled\`（plugins 不依赖 agent LLM）

## Restore 设计要点

- **触发**：首次 \`greeting_check\` 发 ZMQ event \`agent_intent_restore_signal\` 到 agent_server，once-flag 保证全局只跑一次
- **CU/BU 重试窗口**：15s（3 × 4s timeout + 5s 间隔）—— 短网络抖动能自愈，超 15s 不通就 OFF + \`AGENT_AUTO_DISABLED_*\` 通知用户"你废了"
- **永久错误立刻 OFF**：401/403 (\`AGENT_API_KEY_INVALID\`) / quota (\`AGENT_QUOTA_EXCEEDED\`) / NXDOMAIN / 模块未加载 —— 跳过 retry，立即 intent 落盘 False + notification
- **user_plugin 并行恢复**：不等 LLM probe（plugins 独立链路）；启动失败回落 lazy 兜底（首次猫爪 analyze 时再起）
- **openclaw / openfang**：复用现有 bounded probe，不另加 retry
- **Intent 写入规则**：用户显式 toggle → 写；capability auto-disable（LLM 飘忽）→ 不写（保留意图等下次 restart 再试）；restore 重放路径 \`_persist_intent=False\` 不递归写
- **Escape hatch**：\`NEKO_DISABLE_AGENT_AUTO_RESTORE=1\` 跳过整个 restore，留给万一 restore 触发 bug 的逃生通道

## check_connectivity 重构

原 \`brain.computer_use.check_connectivity\` 默认 \`timeout=20\` + 3 次内置 retry，最坏 ~69s。这是用户点 toggle 时的等待天花板，过度防御。

改成默认 \`timeout_s=4.0, _retries=0\`，返回 \`(ok, reason_code)\` 元组，reason_code 通过 \`_classify_connectivity_exception\` 分类成 6 个稳定 code，caller 用 \`PERMANENT_CONNECTIVITY_REASONS\` 集合判断短暂/永久。慢网用户仍能传 \`_retries\` 加余量但默认变快。

## 文件清单

- 新增 \`app/agent_runtime_intent.py\` 持久化模块（仿 \`plugin_runtime_overrides.py\` 设计）
- 新增 \`tests/unit/test_agent_runtime_intent.py\` 21 个测试
- 修改 \`app/agent_server.py\`（+319 / -32 行）：总闸语义、gate-fail、intent 写入、restore 流程、ZMQ event 接入
- 修改 \`brain/computer_use.py\`：check_connectivity 重构 + 异常分类 helper
- 修改 \`main_routers/websocket_router.py\`：greeting_check 入口发 ZMQ 触发 restore
- 修改 \`plugin/server/application/plugins/lifecycle_service.py\`：\`stop_plugin\` / \`start_plugin\` 加 \`persist_user_intent\` kwarg
- 修改 \`plugin/server/routes/plugins.py\`：HTTP endpoint 传 \`persist_user_intent=True\`，CLI / admin RPC / reload 内部链路保持 False
- 新增 plugin 持久化测试 2 个

## Test plan

- [x] \`tests/unit/test_agent_runtime_intent.py\` 21/21 pass（intent 模块 roundtrip / 异常分类 / 总闸语义 / 写入规则 / restore 流程）
- [x] \`tests/test_agent_rewrite_regression.py\` 120/120 pass
- [x] \`plugin/tests/unit/server/\` 145/145 pass
- [x] \`tests/unit/test_websocket_home_tutorial_guard.py\` pass
- [ ] 手动：重启 agent_server 验证上次 toggle 状态被恢复
- [ ] 手动：拔网线/把 API key 改坏 → 重启 → 15s 后看到 AGENT_AUTO_DISABLED_* 通知 + intent 文件里 \`computer_use_enabled: false\`
- [ ] 手动：plugin manager 关掉某 plugin → 重启 → 验证未自动开启
- [ ] 手动：\`NEKO_DISABLE_AGENT_AUTO_RESTORE=1\` 启动 → 验证 restore 被跳过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 运行时代理意图持久化，首次会话自动触发一次性恢复（恢复路径不会重复写入）。
  * 管理端插件启动/停止支持可选持久化用户意图；插件直接执行在主开关关闭时被拦截返回 403。

* **修复与改进**
  * 连通性探测改进，返回稳定原因码以支持更可靠的能力降级与自动禁用。
  * 在网关不可用时仅取消 LLM 依赖子功能，保留用户插件标志，减少不必要的探测触发。

* **测试**
  * 大量单元测试覆盖持久化、恢复流程、连通性分类与边界场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1343)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->