### PR TITLE
feat(tool-calling): 给 offline/realtime 注册 recall_memory pseudo 工具

### DIFF
--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -2658,3 +2658,43 @@ def get_memory_recall_rerank_prompt(lang: str = "zh") -> str:
 
 
 memory_recall_rerank_prompt = MEMORY_RECALL_RERANK_PROMPT["zh"]
+
+
+# =====================================================================
+# ======= Recall-memory tool (function/tool call) =====================
+# =====================================================================
+# 给所有文本/语音模型注册的"回忆"工具：模型决定何时调用，
+# 当前先做成 pseudo tool —— 无论传什么参数都返回"没有找到相关记忆"，
+# 等机制层在 offline / realtime 两条路径上都跑通了再接真实检索后端。
+# description / 参数说明走 _loc 按 user_language 渲染（短码：
+# zh/en/ja/ko/ru/es/pt）。
+
+RECALL_MEMORY_TOOL_DESCRIPTION = {
+    "zh": "回忆与当前对话相关的过往记忆。当你需要查阅之前的对话内容、用户偏好、过去发生的事情，或对当前话题缺少必要背景时调用此工具。",
+    "en": "Recall past memories relevant to the current conversation. Call this when you need earlier dialogue content, user preferences, things that happened before, or background context you currently lack.",
+    "ja": "現在の会話に関連する過去の記憶を呼び出します。以前の会話内容、ユーザーの好み、過去の出来事、または現在の話題に必要な背景が不足している時にこのツールを呼び出してください。",
+    "ko": "현재 대화와 관련된 과거 기억을 떠올립니다. 이전 대화 내용, 사용자 선호, 과거 있었던 일, 또는 현재 주제에 필요한 배경 정보가 부족할 때 이 도구를 호출하세요.",
+    "ru": "Вспомнить прошлые воспоминания, связанные с текущим разговором. Вызывайте, когда нужны прежние реплики, предпочтения пользователя, прошлые события или фоновый контекст, которого вам сейчас не хватает.",
+    "es": "Recordar memorias pasadas relevantes para la conversación actual. Llama a esta herramienta cuando necesites contenido previo, preferencias del usuario, cosas que pasaron antes o contexto que te falte.",
+    "pt": "Recordar memórias passadas relevantes para a conversa atual. Chame esta ferramenta quando precisar de conteúdo anterior, preferências do usuário, coisas que aconteceram antes ou contexto que esteja faltando.",
+}
+
+RECALL_MEMORY_TOOL_QUERY_DESCRIPTION = {
+    "zh": "要回忆的关键词、问题或话题。用一两句话简洁概括，例如\"上次提到的旅行计划\"或\"用户对咖啡的喜好\"。",
+    "en": "Keyword, question, or topic to recall. Keep it to a sentence or two, e.g. \"the travel plan mentioned earlier\" or \"the user's coffee preferences\".",
+    "ja": "思い出したいキーワード、質問、話題。一、二文で簡潔にまとめてください。例：「以前話した旅行計画」「ユーザーのコーヒーの好み」。",
+    "ko": "떠올리려는 키워드, 질문, 주제. 한두 문장으로 간결하게 적으세요. 예: \"이전에 언급한 여행 계획\", \"사용자의 커피 취향\".",
+    "ru": "Ключевое слово, вопрос или тема для воспоминания. Сформулируйте в одно-два предложения, например «упомянутый ранее план поездки» или «предпочтения пользователя в кофе».",
+    "es": "Palabra clave, pregunta o tema a recordar. Una o dos frases breves, p. ej. \"el plan de viaje mencionado antes\" o \"las preferencias de café del usuario\".",
+    "pt": "Palavra-chave, pergunta ou tópico a recordar. Uma ou duas frases curtas, p. ex. \"o plano de viagem mencionado antes\" ou \"as preferências de café do usuário\".",
+}
+
+RECALL_MEMORY_TOOL_NO_RESULT = {
+    "zh": "没有找到相关记忆。",
+    "en": "No relevant memory found.",
+    "ja": "関連する記憶が見つかりませんでした。",
+    "ko": "관련된 기억을 찾지 못했습니다.",
+    "ru": "Соответствующих воспоминаний не найдено.",
+    "es": "No se encontró ninguna memoria relevante.",
+    "pt": "Nenhuma memória relevante encontrada.",
+}

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -2585,16 +2585,32 @@ class LLMSessionManager:
         """``recall_memory`` 的占位 handler —— 总是返回"没有找到相关记忆"。
 
         机制验证用：让模型决定何时调用、我们能拿到 arguments、把固定
-        字符串回喂模型。日志里打 query 方便观察模型在什么场景下会去
-        recall，给后续接真实检索提供取数依据。
+        字符串回喂模型。日志同时记录 lanlan_name / input_mode / 完整
+        arguments / 命中的语言，方便：
+        - 多猫娘并发时按 name 切分 trace
+        - 验证语音（``audio``）和文本（``text``）两条路径都能触发
+        - 模型在 schema 之外塞了别的字段也不会被吞掉
+        - 给后续接真实检索提供取数依据（看模型在什么场景去 recall）。
         """
         _lang = normalize_language_code(self.user_language, format='short') or 'en'
+        args_dict = arguments if isinstance(arguments, dict) else {}
         query = ""
-        if isinstance(arguments, dict):
-            raw_query = arguments.get("query")
-            if isinstance(raw_query, str):
-                query = raw_query.strip()
-        logger.info("[recall_memory] called with query=%r → pseudo empty result", query)
+        raw_query = args_dict.get("query")
+        if isinstance(raw_query, str):
+            query = raw_query.strip()
+        # ``input_mode`` 是 manager 级别状态（start_session 时定型），handler
+        # 拿到时一定是当前 session 的真实模式；type(self.session) 兜一层
+        # 防御性日志，万一 input_mode 没设也能从 client 类型反推。
+        session_kind = type(self.session).__name__ if self.session is not None else "no-session"
+        logger.info(
+            "[recall_memory] name=%s mode=%s session=%s lang=%s args=%s query=%r → pseudo empty result",
+            self.lanlan_name,
+            self.input_mode,
+            session_kind,
+            _lang,
+            args_dict,
+            query,
+        )
         return _loc(RECALL_MEMORY_TOOL_NO_RESULT, _lang)
 
     async def _sync_tools_to_active_session(self, *, raise_on_failure: bool = False) -> None:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -69,6 +69,11 @@ from config.prompts.prompts_sys import (
     CONTEXT_SUMMARY_EVENT_HEADER, CONTEXT_SUMMARY_EVENT_FOOTER,
     RESULT_PARSER_PHRASES,
 )
+from config.prompts.prompts_memory import (
+    RECALL_MEMORY_TOOL_DESCRIPTION,
+    RECALL_MEMORY_TOOL_QUERY_DESCRIPTION,
+    RECALL_MEMORY_TOOL_NO_RESULT,
+)
 
 
 # 内部 item 渲染时的视觉标记。状态信息已在外层 SYSTEM_NOTIFICATION_TASK_ACTIVE
@@ -814,6 +819,12 @@ class LLMSessionManager:
         # sync_message_queue 控制消息更原子：meta 与 turn end 事件
         # 同生共死，不会因为两条消息的时序错乱而把 avatar 轮当成 proactive。
         self._pending_turn_meta: Optional[dict] = None
+
+        # 内置 pseudo 工具（目前只有 recall_memory）。在 __init__ 末尾注册
+        # 一份占位，此时 user_language 还可能是 None → 短码兜底回退 'en'；
+        # 真正进 session 前会再 refresh 一次，把 description 对齐到当时
+        # 已知的 user_language。
+        self._register_builtin_tools()
 
     def _fire_task(self, coro):
         """Create a background task with GC protection (prevent Python 3.11+ from collecting it)."""
@@ -2536,6 +2547,56 @@ class LLMSessionManager:
         """
         return await self.tool_registry.execute(call)
 
+    # ------------------------------------------------------------------
+    # 内置 pseudo 工具：recall_memory
+    # ------------------------------------------------------------------
+    # 机制层占位：先让 offline / realtime 两条路径都能 register、把
+    # description / parameters 推到 wire、收到模型的 tool call、回 result。
+    # handler 当前固定返回"没有找到相关记忆"，等真实记忆检索接好后只
+    # 替换 ``_handle_recall_memory_call`` 即可，不动注册 / 同步链路。
+
+    def _register_builtin_tools(self) -> None:
+        """Re-register 内置工具，description / parameter doc 走当前
+        ``user_language``。直接调 ``tool_registry.register(replace=True)``
+        而不是公共的 ``register_tool``，避免在 __init__ / start_session 等
+        热路径里 fire 不必要的 ``_sync_tools_to_active_session``——本方法的
+        调用方负责决定要不要 sync。
+        """
+        _lang = normalize_language_code(self.user_language, format='short') or 'en'
+        recall_tool = ToolDefinition(
+            name="recall_memory",
+            description=_loc(RECALL_MEMORY_TOOL_DESCRIPTION, _lang),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": _loc(RECALL_MEMORY_TOOL_QUERY_DESCRIPTION, _lang),
+                    },
+                },
+                "required": ["query"],
+            },
+            handler=self._handle_recall_memory_call,
+            metadata={"source": "builtin"},
+        )
+        self.tool_registry.register(recall_tool, replace=True)
+
+    async def _handle_recall_memory_call(self, arguments: dict) -> str:
+        """``recall_memory`` 的占位 handler —— 总是返回"没有找到相关记忆"。
+
+        机制验证用：让模型决定何时调用、我们能拿到 arguments、把固定
+        字符串回喂模型。日志里打 query 方便观察模型在什么场景下会去
+        recall，给后续接真实检索提供取数依据。
+        """
+        _lang = normalize_language_code(self.user_language, format='short') or 'en'
+        query = ""
+        if isinstance(arguments, dict):
+            raw_query = arguments.get("query")
+            if isinstance(raw_query, str):
+                query = raw_query.strip()
+        logger.info("[recall_memory] called with query=%r → pseudo empty result", query)
+        return _loc(RECALL_MEMORY_TOOL_NO_RESULT, _lang)
+
     async def _sync_tools_to_active_session(self, *, raise_on_failure: bool = False) -> None:
         """把 registry 当前状态同步给所有活跃的 client。
 
@@ -3561,6 +3622,11 @@ class LLMSessionManager:
             
                 # Create into a LOCAL variable — not self.session yet
                 new_session = None
+                # 在抓快照前先把内置工具的 description 对齐到当前
+                # user_language —— __init__ 时 user_language 可能还是 None
+                # 走的英文占位，这里 user_language 已经定型了，重新注册
+                # 一份覆盖 registry 里的旧描述，再被下面的 snapshot 读走。
+                self._register_builtin_tools()
                 # Snapshot the registry once per session create so the
                 # tools list seen by the wire matches what the registry
                 # held at connect time. ``set_tools`` keeps it live for
@@ -4013,6 +4079,9 @@ class LLMSessionManager:
             # 根据input_mode创建对应类型的pending session
             # 复用 main session 的 ToolRegistry 状态（registry 是 manager 级，
             # 跨 session 持久），保证热切换前后工具集合保持一致。
+            # 热切换可能跨语言（用户切了 user_language 后再热切换猫娘），
+            # 抓快照前 refresh 一下内置工具的 description。
+            self._register_builtin_tools()
             _pending_tool_defs = self.tool_registry.all()
             if self.input_mode == 'text':
                 # 文本模式：使用 OmniOfflineClient
@@ -6152,6 +6221,14 @@ class LLMSessionManager:
             logger.info(f"用户语言已设置为: {normalized_lang}")
 
         # 文本模式下无需额外同步改写提示语言（已移除 rewrite 逻辑）
+
+        # 内置工具的 description / 参数说明是按 user_language 渲染的，
+        # 这里换语言后重新注册一份覆盖 registry 旧描述，并 fire-and-forget
+        # 推到当前 active / pending session 的 wire 上（OmniRealtimeClient
+        # 支持 session.update 携带新 tools；OmniOfflineClient 下次 stream_text
+        # 自动用最新 _tool_definitions）。
+        self._register_builtin_tools()
+        self._fire_task(self._sync_tools_to_active_session())
     
     async def send_status(self, message: str):
         """发送状态消息到前端。message 应为 JSON 字符串 {"code": "XXX", "details": {...}}，前端通过 i18next 翻译。"""


### PR DESCRIPTION
## Summary
- 给 offline / realtime 两路模型挂一个 `recall_memory` 工具（function/tool call），让模型自己决定何时回忆
- 当前是 pseudo handler：固定返回 i18n 的"没有找到相关记忆"，先把机制层在 offline / realtime 两条路径上跑通，等真实记忆检索接好后只换 `_handle_recall_memory_call` 即可
- **复用了现有的 ToolRegistry**：和 plugin 走的是同一份 `LLMSessionManager.tool_registry`、同一条 dispatch / wire-export 链路（`to_openai_chat` / `to_openai_realtime` / `to_gemini_function_declaration`），只是 `metadata.source="builtin"` 区分插件回收时不会被一起 `clear_tools(source=...)` 掉
- 直接调 `tool_registry.register(replace=True)` 而不是公共的 `register_tool()`，避开 `__init__` / `start_session` 等热路径里 fire 不必要的 `_sync_tools_to_active_session`

## 改动
- **config/prompts/prompts_memory.py**：新增三组 i18n（zh/en/ja/ko/ru/es/pt 全覆盖）
  - `RECALL_MEMORY_TOOL_DESCRIPTION` — 工具描述
  - `RECALL_MEMORY_TOOL_QUERY_DESCRIPTION` — `query` 参数描述
  - `RECALL_MEMORY_TOOL_NO_RESULT` — 占位返回串
- **main_logic/core.py**：
  - `_register_builtin_tools()`：根据当前 `user_language` 重新注册（短码兜底 'en'）
  - `_handle_recall_memory_call()`：固定返回 i18n 的"没有找到相关记忆"，日志打 `query` 方便观察模型调用场景
  - 四个 refresh 点：
    - `__init__` 末尾（占位，让 `list_tools()` 立刻可见）
    - `start_session` 抓 `_initial_tool_defs` 前（`user_language` 此时已定型）
    - 热切换抓 `_pending_tool_defs` 前（跨语言热切换猫娘）
    - `set_user_language` 末尾（中途换语言时 fire 一次 sync，realtime session.update 跟着推）

## Test plan
- [x] `tests/unit/test_tool_calling.py` 原有 37 个用例全过
- [x] 手动 smoke：构造 stub 跑了一遍注册→export→dispatch
  - 三种 dialect（`openai_realtime` / `openai_chat` / `gemini`）都能正确导出 spec，`required: ["query"]`
  - `user_language` 从 None → 'zh-CN' → 'en' 切换后描述跟着变
  - handler 在 zh / en 下分别返回"没有找到相关记忆。" / "No relevant memory found."
  - 未注册工具走 registry 的 `is_error=True` 兜底
- [ ] 端到端：等真实 LLM 跑起来，看模型在缺背景时会不会去调 `recall_memory`，确认 wire 上能拿到 tool result 并续上对话

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加“回忆记忆”内置工具，提供多语言提示（中/英/日/韩/俄/西/葡）。
  * 工具描述随用户语言动态注册与同步，确保会话中显示正确的本地化文案。
* **改进**
  * 在会话创建与语言变更时自动刷新工具元数据，保持活动/待处理会话一致性。
* **已知行为**
  * 当前处理器为占位实现，会返回本地化的“无相关记忆”响应。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1345)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->