### PR TITLE
fix(memory): 修三处 silent-write-loss bug (readonly marker / db drift / cache+settle gap)

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2532,17 +2532,27 @@ async def api_record_surfaced(request: Request, lanlan_name: str):
 
 
 async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
-    """后台异步：事实提取 + 反馈检查 + 复读嗅探。失败静默跳过。
+    """后台异步：counter bump + 复读嗅探 + 反馈检查。失败静默跳过。
 
     认知框架：Facts → Reflection(pending→confirmed→promoted) → Persona
     memory-evidence-rfc 接入点：
       - 每轮 tick 给 signal-extraction loop 的 turn counter +1
       - check_feedback 的 confirmed/denied/ignored 三值分别派 evidence 信号
       - 如果 user message 命中 NEGATIVE_KEYWORDS，触发快速 LLM target check
+
+    历史 — 函数名带 ``extract_facts`` 是 PR-1 (RFC #928) 引入时的命名，
+    当时 step 1 还跑 ``fact_store.extract_facts`` (Stage-1) 兼容 legacy
+    "每轮抽 fact" 体验。RFC §3.4.3 标题原话："**不**在对话主路径上每轮
+    运行 extract_facts——太贵。改为背景调度"，因此 Stage-1+Stage-2 batch
+    抽取从一开始就有专职 background loop ``_periodic_signal_extraction_loop``
+    负责，per-turn 这条本来就是过渡期 legacy。step 1 已于本次 commit
+    迁完，函数名留作历史以减少 outbox handler 注册路径的重命名波及。
     """
     user_msgs = _extract_user_messages(messages)
 
-    # 本轮算入 signal-extraction 触发计数器（RFC §3.4.3）
+    # 本轮算入 signal-extraction 触发计数器（RFC §3.4.3）—— batch loop
+    # 靠这个 counter 在累积 10 turn 时触发 Stage-1+Stage-2，所以 per-turn
+    # bump 是 RFC 设计意图保留下来的，不能省。
     try:
         if user_msgs:
             _signal_check_record_turn(lanlan_name)
@@ -2555,17 +2565,20 @@ async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
     # corrections）。check_feedback 自身仍跑（主动搭话回应是核心 channel）。
     powerful_enabled = await _ais_powerful_memory_enabled()
 
-    try:
-        # 1. 事实提取（legacy flow；真正的 Stage-1+Stage-2 走
-        #    _periodic_signal_extraction_loop。这里保留 Stage-1-only 以便
-        #    短期行为不变，facts.json 在每轮对话后仍及时更新。）
-        await fact_store.extract_facts(messages, lanlan_name)
-    except Exception as e:
-        logger.warning(f"[MemoryServer] 事实提取失败: {e}")
+    # NOTE: 历史 step 1 (fact_store.extract_facts Stage-1 per-turn 抽取)
+    # 已剥离——RFC §3.4.3 明确"per-turn extract_facts 太贵，改为背景调度"，
+    # 单 turn 输入 2-4 条消息抽 fact yield 极低且无上下文；batch 路径在
+    # `_periodic_signal_extraction_loop` 里从 ``time_indexed.db`` 拉过去
+    # 窗口的全部 user messages 跑 Stage-1+Stage-2，质量和成本都更好。
+    # PR-1 当时为"短期行为不变 / facts.json 每轮及时更新"暂留 step 1；
+    # PR cba377c5（"hotswap timing"）的 /cache+/settle bug 让 step 1 已经
+    # 46 天没跑过，借这次回收 cache 端点落 db 的机会一起完成 RFC 迁移。
 
     try:
         # 2. 全局复读嗅探：扫描 AI 回复中是否重复提及 persona 条目 +
-        #    confirmed reflection（§2.6 5h 窗口 suppress 机制，两者正交）
+        #    confirmed reflection（§2.6 5h 窗口 suppress 机制，两者正交）。
+        #    本地 BM25，无 LLM 调用，per-turn 跑是必要的——5h 窗口逻辑
+        #    依赖即时更新。
         ai_response = _extract_ai_response(messages)
         if ai_response:
             await persona_manager.arecord_mentions(lanlan_name, ai_response)
@@ -2704,8 +2717,33 @@ register_outbox_handler(OP_EXTRACT_FACTS, _outbox_extract_facts_handler)
 
 @app.post("/cache/{lanlan_name}")
 async def cache_conversation(request: HistoryRequest, lanlan_name: str):
-    """轻量级缓存：仅将新消息追加到 recent history，不触发 time_manager / review 等 LLM 操作。
-    供 cross_server 在每轮 turn end 时调用，保持 memory_browser 实时可见。"""
+    """每轮 turn end 的"轻量持久化"端点：写 recent.json + 落 time_indexed.db
+    + 登记 per-turn signals outbox op（counter bump + 本地复读嗅探 +
+    check_feedback）。**不**跑 Stage-1 fact_extract LLM——RFC §3.4.3
+    明确"per-turn extract_facts 太贵，改为背景调度"，batch 抽取由
+    ``_periodic_signal_extraction_loop`` 在累积 10 turn 或 5 min idle 时
+    从 ``time_indexed.db`` 拉窗口跑 Stage-1+Stage-2；也**不**跑 review LLM
+    重写历史（那一类仍由 /settle 在 renew session 时跑）。
+
+    历史 — commit cba377c5（"Fix/memory hotswap timing"，2026-03-29）引入
+    /settle 时把"补完 cache 留下的 LLM 后续操作"全 gate 在 ``if input_history``
+    后面，但 cross_server 的标准节奏是"turn end /cache → renew session
+    /settle(msgs=0)"，settle 永远收 msgs=0，于是 ``store_conversation`` 和
+    outbox extract 都被静默跳过：``time_indexed.db`` 永不创建（time
+    perception 失效）+ ``outbox.ndjson`` / ``events.ndjson`` / ``facts.json``
+    全部不建（长期记忆 + evidence-RFC 链路完全空转），**且 batch loop 依赖
+    db 拉历史也一并瘫痪**。
+
+    修法把 store + post-turn signals 搬回 cache 端点；同时 PR-1 当时为
+    "短期行为不变"暂留的 Stage-1 per-turn fact_extract（``legacy flow``）
+    一并迁完——RFC 原本就计划只让 ``_periodic_signal_extraction_loop`` 跑
+    fact extraction。``astore_conversation`` 是 SQLite INSERT（~ms 量级），
+    ``_spawn_outbox_extract_facts`` 现内部只跑 counter bump + 本地复读嗅探
+    + check_feedback（LLM 仅在 surfaced 有 pending 时才跑），是 ndjson
+    append + spawn background task（不阻塞响应）。``cache`` 保持"前台无
+    LLM 延迟"的轻量语义，**且比 PR-1 实现更轻**——单 turn fact_extract
+    LLM 浪费已彻底去除。
+    """
     lanlan_name = validate_lanlan_name(lanlan_name)
     _touch_activity()
     try:
@@ -2715,11 +2753,18 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
         if _has_human_messages(input_history):
             await _aclear_review_clean(lanlan_name)
         logger.info(f"[MemoryServer] cache: {lanlan_name} +{len(input_history)} 条消息")
+        uid = str(uuid4())
         async with _get_settle_lock(lanlan_name):
             await recent_history_manager.update_history(input_history, lanlan_name, compress=False)
+            # store_conversation 必须在 lock 内、与 update_history 串行：和
+            # /process / /renew 路径对偶，确保单角色 db 写顺序一致。
+            await time_manager.astore_conversation(uid, input_history, lanlan_name)
+        # outbox 登记走锁外——它会 spawn background task 跑 LLM，长持锁会
+        # 阻塞下一轮 /cache 写盘。
+        await _spawn_outbox_extract_facts(lanlan_name, input_history)
         return {"status": "cached", "count": len(input_history)}
     except Exception as e:
-        logger.error(f"[MemoryServer] cache 失败: {e}")
+        logger.error(f"[MemoryServer] cache 失败: {e}", exc_info=True)
         return {"status": "error", "message": str(e)}
 
 

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2565,14 +2565,21 @@ async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
     # corrections）。check_feedback 自身仍跑（主动搭话回应是核心 channel）。
     powerful_enabled = await _ais_powerful_memory_enabled()
 
-    # NOTE: 历史 step 1 (fact_store.extract_facts Stage-1 per-turn 抽取)
-    # 已剥离——RFC §3.4.3 明确"per-turn extract_facts 太贵，改为背景调度"，
-    # 单 turn 输入 2-4 条消息抽 fact yield 极低且无上下文；batch 路径在
-    # `_periodic_signal_extraction_loop` 里从 ``time_indexed.db`` 拉过去
-    # 窗口的全部 user messages 跑 Stage-1+Stage-2，质量和成本都更好。
-    # PR-1 当时为"短期行为不变 / facts.json 每轮及时更新"暂留 step 1；
-    # PR cba377c5（"hotswap timing"）的 /cache+/settle bug 让 step 1 已经
-    # 46 天没跑过，借这次回收 cache 端点落 db 的机会一起完成 RFC 迁移。
+    # Step 1 — per-turn Stage-1 fact extraction：只在 powerful_memory **关闭**
+    # 时跑（OFF-mode baseline fallback）。ON-mode 下 fact extraction 完全交给
+    # ``_periodic_signal_extraction_loop`` 跑 batch Stage-1+Stage-2（RFC §3.4.3
+    # 设计意图："不在对话主路径上每轮运行 extract_facts——太贵。改为背景调度"，
+    # batch 路径带上下文、质量更高、cost 更低）。
+    #
+    # OFF-mode 下 batch loop 整段停（见 _periodic_signal_extraction_loop 的
+    # `if not powerful_enabled: continue` 分支），如果这里也跳过，facts.json
+    # 就完全无路径更新——这是 chatgpt-codex-connector PR #1346 抓到的 regression。
+    # OFF-mode 保留 legacy per-turn Stage-1，let user 仍能拿到基础 fact 累积。
+    if not powerful_enabled:
+        try:
+            await fact_store.extract_facts(messages, lanlan_name)
+        except Exception as e:
+            logger.warning(f"[MemoryServer] OFF-mode 事实提取失败: {e}")
 
     try:
         # 2. 全局复读嗅探：扫描 AI 回复中是否重复提及 persona 条目 +

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -41,6 +41,34 @@ class TimeIndexedMemory:
             os.makedirs(db_dir, exist_ok=True)
         return normalized_db_path, f"sqlite:///{uri_path}"
 
+    def _resolve_expected_db_path(self, lanlan_name: str, *, readonly: bool) -> str | None:
+        """计算当前 memory_dir 下该角色 db 的目标路径。
+
+        time_store 优先（允许角色把 db 显式登记到 memory_dir 之外），否则
+        回退到 ``memory_dir/{name}/time_indexed.db``。每次调用都重读
+        ``config_manager.memory_dir``，让 ``_ensure_engine_exists`` 的
+        path-drift 自检能感知到 in-process memory_dir 漂移。
+        """
+        try:
+            _, _, _, _, _, _, time_store, _, _ = get_config_manager().get_character_data()
+        except Exception as exc:
+            logger.warning("[TimeIndexedMemory] get_character_data 失败，回退默认 db_path: %s", exc)
+            time_store = {}
+        if lanlan_name in time_store:
+            return time_store[lanlan_name]
+        config_mgr = get_config_manager()
+        if readonly:
+            return os.path.join(str(config_mgr.memory_dir), lanlan_name, "time_indexed.db")
+        from memory import ensure_character_dir
+        return os.path.join(ensure_character_dir(config_mgr.memory_dir, lanlan_name), 'time_indexed.db')
+
+    @staticmethod
+    def _db_paths_equivalent(left: str, right: str) -> bool:
+        try:
+            return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+        except Exception:
+            return left == right
+
     def _ensure_engine_exists(
         self,
         lanlan_name: str,
@@ -54,7 +82,30 @@ class TimeIndexedMemory:
             cached_engine = self.engines[lanlan_name]
             cached_db_path = str(self.db_paths[lanlan_name])
             cached_readonly = bool(self._engine_readonly_flags.get(lanlan_name, False))
-            if not readonly and cached_readonly and lanlan_name not in self._writable_bootstrapped:
+
+            # Path-drift defense: 罕见但可能——/reload 期间 storage_policy
+            # 重写 selected_root，新实例已经 reload 过但旧实例还在被某条
+            # async path 持有；或测试场景里 monkeypatch 了 memory_dir。
+            # 一旦 cached db_path 与当前 memory_dir 推导出的目标不一致，
+            # 老 SQLAlchemy engine 会继续往旧文件写，前端表象就是 db 永远
+            # 不更新（/process 的 except Exception 又把 SQL 错误吞掉）。
+            # 嗅探到漂移就 dispose 让下面的新建分支用 expected 重建。
+            expected_db_path = db_path
+            if expected_db_path is None:
+                try:
+                    expected_db_path = self._resolve_expected_db_path(lanlan_name, readonly=readonly)
+                except Exception as exc:
+                    logger.debug("[TimeIndexedMemory] 解析 expected db_path 失败，跳过 drift 检查: %s", exc)
+                    expected_db_path = None
+            if expected_db_path and not self._db_paths_equivalent(expected_db_path, cached_db_path):
+                logger.warning(
+                    "[TimeIndexedMemory] 角色 %s 的 db_path 漂移，dispose 重建：cached=%s expected=%s",
+                    lanlan_name, cached_db_path, expected_db_path,
+                )
+                self.dispose_engine(lanlan_name)
+                db_path = expected_db_path
+                # 落到下面"新建 engine"分支
+            elif not readonly and cached_readonly and lanlan_name not in self._writable_bootstrapped:
                 logger.info("[TimeIndexedMemory] 角色 %s 当前为只读引擎，切换为可写引擎后再执行迁移", lanlan_name)
                 self.dispose_engine(lanlan_name)
                 if not db_path:
@@ -81,17 +132,10 @@ class TimeIndexedMemory:
         connection_string = None
         try:
             if not db_path:
-                _, _, _, _, _, _, time_store, _, _ = get_config_manager().get_character_data()
-                if lanlan_name in time_store:
-                    db_path = time_store[lanlan_name]
-                else:
-                    config_mgr = get_config_manager()
-                    if readonly:
-                        db_path = os.path.join(config_mgr.memory_dir, lanlan_name, "time_indexed.db")
-                    else:
-                        from memory import ensure_character_dir
-                        db_path = os.path.join(ensure_character_dir(config_mgr.memory_dir, lanlan_name), 'time_indexed.db')
-                    logger.info(f"[TimeIndexedMemory] 角色 '{lanlan_name}' 不在配置中，使用默认路径: {db_path}")
+                db_path = self._resolve_expected_db_path(lanlan_name, readonly=readonly)
+                if not db_path:
+                    logger.error(f"[TimeIndexedMemory] 角色 '{lanlan_name}' 无法解析 db_path")
+                    return False
 
             normalized_db_path, connection_string = self._build_sqlite_connection_string(
                 db_path,

--- a/memory/timeindex.py
+++ b/memory/timeindex.py
@@ -193,9 +193,15 @@ class TimeIndexedMemory:
             return False
 
     async def _aensure_engine_exists(self, lanlan_name: str, db_path: str | None = None) -> bool:
-        """异步版本：把阻塞的 engine 创建丢到线程池。"""
-        if lanlan_name in self.engines and lanlan_name in self.db_paths:
-            return True
+        """异步版本：把阻塞的 engine 创建丢到线程池。
+
+        以前在这里有个 ``if lanlan_name in self.engines and lanlan_name in self.db_paths:
+        return True`` 的早期短路，把 cache hit 的判定挡在 sync 实现之外——这条
+        路径会绕过 ``_ensure_engine_exists`` 新增的 path-drift 自检（cached db_path
+        vs 当前 memory_dir 推导出的 expected 不一致时 dispose 重建）。当前没有
+        async 调用方走这条入口，但为了避免未来加进来后 drift 检测被静默废掉，
+        删掉短路统一委托给 sync 实现。
+        """
         return await asyncio.to_thread(self._ensure_engine_exists, lanlan_name, db_path)
 
     def dispose_engine(self, lanlan_name: str):

--- a/tests/unit/test_character_memory_regression.py
+++ b/tests/unit/test_character_memory_regression.py
@@ -2071,3 +2071,139 @@ def test_timeindexed_readonly_open_still_runs_writable_bootstrap_on_first_write(
     assert manager._ensure_engine_exists("测试角色", db_path=str(db_path), readonly=False) is True
     assert ensure_calls == [("测试角色", writable_engine)]
     assert migrate_calls == [("测试角色", writable_engine)]
+
+
+def test_timeindexed_dispose_and_rebuild_when_memory_dir_drifts(monkeypatch, tmp_path):
+    """``TimeIndexedMemory.db_paths`` 是 per-character path cache，cache 命中后
+    短路 return 不会重新校核当前 ``memory_dir``。罕见但可能：``/reload``
+    期间底层 ``storage_policy`` 被改写，或测试 monkeypatch 了 memory_dir，
+    cached 路径就和实际目标分叉。老 SQLAlchemy engine 还连着旧文件，新
+    数据全飘到老位置——``/process`` 的 ``except Exception`` 又把 SQL
+    错误吞掉，表象是 db 永远不更新（time perception 错乱）。
+
+    本用例验证 ``_ensure_engine_exists`` 检测到 cached vs expected 漂移
+    后会 dispose 旧 engine + 用 expected 路径重建。
+    """
+    from memory.timeindex import TimeIndexedMemory
+
+    class _DummyEngine:
+        def __init__(self, name):
+            self.name = name
+            self.dispose_calls = 0
+
+        def dispose(self):
+            self.dispose_calls += 1
+
+    old_db_path = (tmp_path / "old" / "测试角色" / "time_indexed.db").resolve()
+    old_db_path.parent.mkdir(parents=True, exist_ok=True)
+    old_db_path.write_text("", encoding="utf-8")
+    new_db_path = (tmp_path / "new" / "测试角色" / "time_indexed.db").resolve()
+    new_db_path.parent.mkdir(parents=True, exist_ok=True)
+    new_db_path.write_text("", encoding="utf-8")
+
+    old_engine = _DummyEngine("old")
+    new_engine = _DummyEngine("new")
+    created_engines = [old_engine, new_engine]
+    ensure_calls: list = []
+    migrate_calls: list = []
+
+    # 受控的 time_store——第一次返 old，第二次返 new，模拟 memory_dir 漂移。
+    current_time_store = {"测试角色": str(old_db_path)}
+
+    def _fake_character_data():
+        return ({}, {}, {}, {}, {}, {}, dict(current_time_store), {}, {})
+
+    fake_config_manager = SimpleNamespace(get_character_data=_fake_character_data)
+    monkeypatch.setattr("memory.timeindex.get_config_manager", lambda: fake_config_manager)
+    monkeypatch.setattr(
+        "memory.timeindex.create_engine",
+        lambda _connection_string: created_engines.pop(0),
+    )
+
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    monkeypatch.setattr(manager, "_assert_timeindex_writable", lambda _lanlan_name: None)
+    monkeypatch.setattr(
+        manager,
+        "_ensure_tables_exist_with",
+        lambda _engine, _connection_string, _lanlan_name: ensure_calls.append((_lanlan_name, _engine)),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_check_and_migrate_schema",
+        lambda _engine, _lanlan_name: migrate_calls.append((_lanlan_name, _engine)),
+    )
+
+    # 第一次初始化：从 time_store 解析到 old_db_path，engine 缓存
+    assert manager._ensure_engine_exists("测试角色") is True
+    assert manager.engines["测试角色"] is old_engine
+    assert os.path.normcase(str(manager.db_paths["测试角色"])) == os.path.normcase(str(old_db_path))
+    assert old_engine.dispose_calls == 0
+
+    # 模拟 memory_dir 漂移——time_store 现在指向 new_db_path
+    current_time_store["测试角色"] = str(new_db_path)
+
+    # 第二次 _ensure_engine_exists：cache 命中但 expected 已变；应 dispose + 重建
+    assert manager._ensure_engine_exists("测试角色") is True
+    assert old_engine.dispose_calls == 1
+    assert manager.engines["测试角色"] is new_engine
+    assert os.path.normcase(str(manager.db_paths["测试角色"])) == os.path.normcase(str(new_db_path))
+    # 新 engine 走完整 writable 初始化（确保表结构在新文件里就位）
+    assert ensure_calls[-1] == ("测试角色", new_engine)
+    assert migrate_calls[-1] == ("测试角色", new_engine)
+
+
+def test_timeindexed_short_circuits_when_memory_dir_unchanged(monkeypatch, tmp_path):
+    """对偶用例：cached 与 expected 一致时 drift 检测不该误伤——cache 命中
+    应仍然短路，不重建 engine。
+    """
+    from memory.timeindex import TimeIndexedMemory
+
+    class _DummyEngine:
+        def __init__(self):
+            self.dispose_calls = 0
+
+        def dispose(self):
+            self.dispose_calls += 1
+
+    db_path = (tmp_path / "测试角色" / "time_indexed.db").resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_text("", encoding="utf-8")
+
+    engine = _DummyEngine()
+    created_engines = [engine]
+    create_calls: list = []
+    ensure_calls: list = []
+    migrate_calls: list = []
+
+    fake_config_manager = SimpleNamespace(
+        get_character_data=lambda: ({}, {}, {}, {}, {}, {}, {"测试角色": str(db_path)}, {}, {}),
+    )
+    monkeypatch.setattr("memory.timeindex.get_config_manager", lambda: fake_config_manager)
+
+    def _fake_create_engine(connection_string):
+        create_calls.append(connection_string)
+        return created_engines.pop(0)
+
+    monkeypatch.setattr("memory.timeindex.create_engine", _fake_create_engine)
+
+    manager = TimeIndexedMemory(recent_history_manager=None)
+    monkeypatch.setattr(manager, "_assert_timeindex_writable", lambda _lanlan_name: None)
+    monkeypatch.setattr(
+        manager,
+        "_ensure_tables_exist_with",
+        lambda _engine, _connection_string, _lanlan_name: ensure_calls.append(_lanlan_name),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_check_and_migrate_schema",
+        lambda _engine, _lanlan_name: migrate_calls.append(_lanlan_name),
+    )
+
+    assert manager._ensure_engine_exists("测试角色") is True
+    assert manager._ensure_engine_exists("测试角色") is True
+    assert manager._ensure_engine_exists("测试角色") is True
+    # 仅第一次创建 engine + bootstrap，后续短路
+    assert len(create_calls) == 1
+    assert ensure_calls == ["测试角色"]
+    assert migrate_calls == ["测试角色"]
+    assert engine.dispose_calls == 0

--- a/tests/unit/test_cloudsave_runtime.py
+++ b/tests/unit/test_cloudsave_runtime.py
@@ -647,6 +647,43 @@ def test_write_blocking_recovery_fails_closed_when_migration_checkpoint_cannot_l
 
 
 @pytest.mark.unit
+def test_bootstrap_heals_orphan_restart_pending_marker(tmp_path):
+    """``restart_pending:`` marker 残留 + 没有真 pending 的 storage_migration.json
+    时，bootstrap 必须把 mode 自愈回 normal——否则用户撞到 fire-and-forget
+    shutdown / launcher 接力失败 / 强杀 等任一场景就会被永久钉在 readonly，
+    memory server 所有写盘静默失败（见 time_indexed.db 不更新导致 gap 永远算成
+    3 天以上的 bug 报告）。
+
+    与 ``test_bootstrap_preserves_restart_pending_maintenance_mode`` 对偶：那个
+    用例创建了真 pending 的 migration checkpoint，本用例只留 marker。
+    """
+    cm = _make_config_manager(tmp_path)
+    anchor_base = tmp_path / "anchor-base"
+    anchor_base.mkdir(parents=True, exist_ok=True)
+    cm._get_standard_data_directory_candidates = lambda: [anchor_base]
+
+    from utils.cloudsave_runtime import (
+        ROOT_MODE_MAINTENANCE_READONLY,
+        ROOT_MODE_NORMAL,
+        bootstrap_local_cloudsave_environment,
+        set_root_mode,
+    )
+
+    set_root_mode(
+        cm,
+        ROOT_MODE_MAINTENANCE_READONLY,
+        last_migration_source=str(cm.app_docs_dir),
+        last_migration_result=f"restart_pending:{tmp_path / 'orphan-target'}",
+    )
+
+    result = bootstrap_local_cloudsave_environment(cm)
+
+    assert result["root_state"]["mode"] == ROOT_MODE_NORMAL
+    # _recover_stale_write_blocking_mode 写入的标记，方便运维从日志/state 追溯
+    assert result["root_state"]["last_migration_result"].startswith("recovered_stale_mode:")
+
+
+@pytest.mark.unit
 def test_should_write_root_mode_normal_after_startup_only_when_mode_is_normal():
     from utils.cloudsave_runtime import (
         ROOT_MODE_DEFERRED_INIT,

--- a/tests/unit/test_memory_server_cache_settle.py
+++ b/tests/unit/test_memory_server_cache_settle.py
@@ -114,15 +114,15 @@ async def test_cache_endpoint_spawns_outbox_post_turn_signals():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_extract_facts_and_check_feedback_does_not_run_stage1_legacy():
-    """Stage-1 per-turn fact_extract 已按 RFC §3.4.3 迁移到
-    ``_periodic_signal_extraction_loop``——``_extract_facts_and_check_feedback``
+async def test_extract_facts_and_check_feedback_skips_stage1_when_powerful_memory_on():
+    """powerful_memory ON 模式：Stage-1 per-turn fact_extract 已按 RFC §3.4.3
+    迁到 ``_periodic_signal_extraction_loop`` 做 batch 抽取，per-turn 主路径
     不应再调 ``fact_store.extract_facts``。
 
-    Pin 这条不变量：任何后续 refactor 不小心把 Stage-1 加回去（出于"保留
-    PR-1 时的 facts.json per-turn 及时更新"理由），都会被这个用例抓到。
-    Per-turn 重新跑 Stage-1 等同于回退到 RFC 之前的设计——每 turn 浪费一
-    次 yield 极低、无上下文的 LLM 抽取（详见 RFC §3.4.3 + 3.4.5 cost 估算）。
+    Pin 这条不变量：任何后续 refactor 把 ON-mode 的 Stage-1 加回 per-turn
+    主路径（出于"保留 PR-1 时 facts.json 每轮及时更新"理由），都会被这个用例
+    抓到——每 turn 浪费一次 yield 极低、无上下文的 LLM 抽取（详见 RFC
+    §3.4.3 + 3.4.5 cost 估算）。
 
     本用例仍允许 counter bump + 复读嗅探 + check_feedback——它们是 RFC
     设计内明确保留的 per-turn 操作。
@@ -150,12 +150,52 @@ async def test_extract_facts_and_check_feedback_does_not_run_stage1_legacy():
          patch.object(memory_server, "_ais_powerful_memory_enabled", AsyncMock(return_value=True)):
         await memory_server._extract_facts_and_check_feedback(payload_messages, "测试角色")
 
-    # Stage-1 per-turn fact_extract 一定不能被调
+    # ON-mode 下 Stage-1 per-turn fact_extract 一定不能被调（交给 batch loop）
     fake_fact_store.extract_facts.assert_not_awaited()
     # 但复读嗅探 + surfaced 检查仍必须 per-turn 跑
     fake_persona_manager.arecord_mentions.assert_awaited()
     fake_reflection_engine.arecord_mentions.assert_awaited()
     fake_reflection_engine.aload_surfaced.assert_awaited_once_with("测试角色")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_facts_and_check_feedback_keeps_stage1_when_powerful_memory_off():
+    """powerful_memory OFF 模式：``_periodic_signal_extraction_loop`` 整段停
+    （见 ``if not powerful_enabled: continue``），per-turn Stage-1 是 fact
+    extraction 的唯一兜底路径，必须保留——否则 OFF 模式用户的 facts.json
+    完全停止更新（chatgpt-codex-connector PR #1346 抓到的 regression）。
+
+    本用例钉住 ON/OFF 不对称：ON 委托给 batch loop，OFF 跑 legacy per-turn。
+    """
+    from app import memory_server
+
+    fake_fact_store = MagicMock()
+    fake_fact_store.extract_facts = AsyncMock(return_value=[])
+    fake_persona_manager = MagicMock()
+    fake_persona_manager.arecord_mentions = AsyncMock(return_value=None)
+    fake_reflection_engine = MagicMock()
+    fake_reflection_engine.arecord_mentions = AsyncMock(return_value=None)
+    fake_reflection_engine.aload_surfaced = AsyncMock(return_value=[])
+
+    from utils.llm_client import HumanMessage, AIMessage
+    payload_messages = [
+        HumanMessage(content="测试用户消息"),
+        AIMessage(content="测试回复"),
+    ]
+
+    with patch.object(memory_server, "fact_store", fake_fact_store), \
+         patch.object(memory_server, "persona_manager", fake_persona_manager), \
+         patch.object(memory_server, "reflection_engine", fake_reflection_engine), \
+         patch.object(memory_server, "_signal_check_record_turn", MagicMock(return_value=None)), \
+         patch.object(memory_server, "_ais_powerful_memory_enabled", AsyncMock(return_value=False)):
+        await memory_server._extract_facts_and_check_feedback(payload_messages, "测试角色")
+
+    # OFF-mode 下 batch loop 不跑——per-turn Stage-1 必须 fallback
+    fake_fact_store.extract_facts.assert_awaited_once()
+    # 复读嗅探仍 per-turn 跑（与 ON-mode 同款）
+    fake_persona_manager.arecord_mentions.assert_awaited()
+    fake_reflection_engine.arecord_mentions.assert_awaited()
 
 
 @pytest.mark.unit
@@ -190,12 +230,25 @@ async def test_cache_endpoint_serialises_recent_and_store_under_settle_lock():
     持锁内串行——和 /process / /renew / /settle 对偶，避免并发 cache 把
     db 写顺序打乱（同时也防止 cache 和 settle 抢着写同一份 recent.json）。
 
-    具体校验：astore_conversation 一定在 update_history 之后被 await，
-    且整个流程内 settle_lock 是被锁住的。
+    显式校验 lock observability：patch ``_get_settle_lock`` 成可观测的 async
+    context manager，断言 lock-enter 在 update_history / astore_conversation
+    之前发生、lock-exit 在它们之后但在 spawn_outbox 之前发生。否则未来如果
+    有人把前两步移到 ``async with`` 外面但保留顺序，纯顺序断言会漏检。
     """
     from app import memory_server
 
     order: list[str] = []
+
+    class _ObservableLock:
+        async def __aenter__(self):
+            order.append("lock_enter")
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            order.append("lock_exit")
+            return None
+
+    observable_lock = _ObservableLock()
 
     async def _fake_update_history(*args, **kwargs):
         order.append("update_history")
@@ -220,12 +273,19 @@ async def test_cache_endpoint_serialises_recent_and_store_under_settle_lock():
     with patch.object(memory_server, "time_manager", fake_time_manager), \
          patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
          patch.object(memory_server, "_spawn_outbox_extract_facts", AsyncMock(side_effect=_fake_spawn)), \
-         patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)):
+         patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)), \
+         patch.object(memory_server, "_get_settle_lock", MagicMock(return_value=observable_lock)):
         await memory_server.cache_conversation(request, "测试角色")
 
-    # update_history → astore_conversation 严格串行（同一 settle lock 内）
-    # spawn_outbox 在 lock 外，但仍然在前两个之后
-    assert order == ["update_history", "astore_conversation", "spawn_outbox"]
+    # 严格契约：lock-enter → update_history → astore_conversation → lock-exit → spawn_outbox
+    # 前 4 步必须夹在 enter/exit 之间（串行 + lock 内），spawn_outbox 在 lock 外。
+    assert order == [
+        "lock_enter",
+        "update_history",
+        "astore_conversation",
+        "lock_exit",
+        "spawn_outbox",
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_memory_server_cache_settle.py
+++ b/tests/unit/test_memory_server_cache_settle.py
@@ -1,0 +1,266 @@
+"""Regression tests for the /cache + /settle persistence contract.
+
+History — commit cba377c5 (2026-03-29 "Fix/memory hotswap timing") introduced
+the /settle endpoint to cover the "cross_server cached everything → renew
+session arrives with msgs=0" case, but only the review LLM was wired into the
+msgs=0 path. ``store_conversation`` and ``_spawn_outbox_extract_facts`` were
+gated behind ``if input_history``, so:
+
+  - ``time_indexed.db`` was never written (time perception broken — gap
+    always None → trigger_greeting silently skipped).
+  - ``outbox.ndjson`` / ``events.ndjson`` / ``facts.json`` were never created
+    (fact extraction + evidence-RFC pipeline totally idle).
+
+These tests pin down the new contract on /cache (turn-end "light
+persistence" — recent.json + time_indexed.db + outbox extract spawn), so any
+future refactor that re-introduces the gap fails loudly here instead of in
+the field 46 days later.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _build_history_request_payload(messages: list[dict]) -> str:
+    """Serialise a list of role/content dicts to the payload /cache expects.
+
+    Mirrors the cross_server-side ``messages_to_dict`` shape — see
+    ``cache_conversation`` → ``convert_to_messages(json.loads(...))``.
+    """
+    payload = []
+    for msg in messages:
+        payload.append({"type": msg["role"], "data": {"content": msg["content"]}})
+    return json.dumps(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_endpoint_writes_time_indexed_db():
+    """/cache 端点必须把消息落到 ``time_indexed.db``（通过 astore_conversation）。
+
+    Regression: commit cba377c5 之后 cache 只 update_history，store 全靠
+    /settle——而 cross_server 标准节奏让 settle 永远拿 msgs=0，db 永不被建。
+    """
+    from app import memory_server
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.astore_conversation = AsyncMock(return_value=None)
+    fake_recent_history_manager = MagicMock()
+    fake_recent_history_manager.update_history = AsyncMock(return_value=None)
+    fake_spawn_outbox = AsyncMock(return_value=None)
+
+    payload = _build_history_request_payload([
+        {"role": "human", "content": "你好"},
+        {"role": "ai", "content": "你好喵~"},
+    ])
+    request = memory_server.HistoryRequest(input_history=payload)
+
+    with patch.object(memory_server, "time_manager", fake_time_manager), \
+         patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
+         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox), \
+         patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)):
+        result = await memory_server.cache_conversation(request, "测试角色")
+
+    assert result["status"] == "cached"
+    assert result["count"] == 2
+    fake_time_manager.astore_conversation.assert_awaited_once()
+    awaited_args = fake_time_manager.astore_conversation.await_args
+    # astore_conversation(uid, messages, lanlan_name) — 顺序由 store_conversation 签名定
+    assert awaited_args.args[2] == "测试角色"
+    assert len(awaited_args.args[1]) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_endpoint_spawns_outbox_post_turn_signals():
+    """/cache 端点必须登记 outbox op，让 events.ndjson / outbox.ndjson 这条
+    链能动起来——op handler 跑 counter bump + 复读嗅探 + check_feedback。
+
+    注：op type 仍叫 ``OP_EXTRACT_FACTS`` 是历史命名（PR-1 引入时 handler
+    里跑过 Stage-1 fact_extract），但 Stage-1 per-turn 抽取已按 RFC §3.4.3
+    迁到 ``_periodic_signal_extraction_loop``——见
+    ``test_extract_facts_and_check_feedback_does_not_run_stage1_legacy``。
+
+    Regression: 旧 cache 完全跳过 outbox，evidence-RFC 链路全空转。
+    """
+    from app import memory_server
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.astore_conversation = AsyncMock(return_value=None)
+    fake_recent_history_manager = MagicMock()
+    fake_recent_history_manager.update_history = AsyncMock(return_value=None)
+    fake_spawn_outbox = AsyncMock(return_value=None)
+
+    payload = _build_history_request_payload([
+        {"role": "human", "content": "我喜欢吃草莓"},
+        {"role": "ai", "content": "记下来啦~"},
+    ])
+    request = memory_server.HistoryRequest(input_history=payload)
+
+    with patch.object(memory_server, "time_manager", fake_time_manager), \
+         patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
+         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox), \
+         patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)):
+        await memory_server.cache_conversation(request, "测试角色")
+
+    fake_spawn_outbox.assert_awaited_once()
+    spawn_args = fake_spawn_outbox.await_args
+    assert spawn_args.args[0] == "测试角色"
+    assert len(spawn_args.args[1]) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_facts_and_check_feedback_does_not_run_stage1_legacy():
+    """Stage-1 per-turn fact_extract 已按 RFC §3.4.3 迁移到
+    ``_periodic_signal_extraction_loop``——``_extract_facts_and_check_feedback``
+    不应再调 ``fact_store.extract_facts``。
+
+    Pin 这条不变量：任何后续 refactor 不小心把 Stage-1 加回去（出于"保留
+    PR-1 时的 facts.json per-turn 及时更新"理由），都会被这个用例抓到。
+    Per-turn 重新跑 Stage-1 等同于回退到 RFC 之前的设计——每 turn 浪费一
+    次 yield 极低、无上下文的 LLM 抽取（详见 RFC §3.4.3 + 3.4.5 cost 估算）。
+
+    本用例仍允许 counter bump + 复读嗅探 + check_feedback——它们是 RFC
+    设计内明确保留的 per-turn 操作。
+    """
+    from app import memory_server
+
+    fake_fact_store = MagicMock()
+    fake_fact_store.extract_facts = AsyncMock(return_value=[])
+    fake_persona_manager = MagicMock()
+    fake_persona_manager.arecord_mentions = AsyncMock(return_value=None)
+    fake_reflection_engine = MagicMock()
+    fake_reflection_engine.arecord_mentions = AsyncMock(return_value=None)
+    fake_reflection_engine.aload_surfaced = AsyncMock(return_value=[])  # no pending → check_feedback 跳过
+
+    from utils.llm_client import HumanMessage, AIMessage
+    payload_messages = [
+        HumanMessage(content="测试用户消息"),
+        AIMessage(content="测试回复"),
+    ]
+
+    with patch.object(memory_server, "fact_store", fake_fact_store), \
+         patch.object(memory_server, "persona_manager", fake_persona_manager), \
+         patch.object(memory_server, "reflection_engine", fake_reflection_engine), \
+         patch.object(memory_server, "_signal_check_record_turn", MagicMock(return_value=None)), \
+         patch.object(memory_server, "_ais_powerful_memory_enabled", AsyncMock(return_value=True)):
+        await memory_server._extract_facts_and_check_feedback(payload_messages, "测试角色")
+
+    # Stage-1 per-turn fact_extract 一定不能被调
+    fake_fact_store.extract_facts.assert_not_awaited()
+    # 但复读嗅探 + surfaced 检查仍必须 per-turn 跑
+    fake_persona_manager.arecord_mentions.assert_awaited()
+    fake_reflection_engine.arecord_mentions.assert_awaited()
+    fake_reflection_engine.aload_surfaced.assert_awaited_once_with("测试角色")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_endpoint_empty_payload_short_circuits():
+    """空 payload 直接返回，不调任何 persistence 路径——避免空 outbox op 污染。"""
+    from app import memory_server
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.astore_conversation = AsyncMock(return_value=None)
+    fake_recent_history_manager = MagicMock()
+    fake_recent_history_manager.update_history = AsyncMock(return_value=None)
+    fake_spawn_outbox = AsyncMock(return_value=None)
+
+    request = memory_server.HistoryRequest(input_history=json.dumps([]))
+
+    with patch.object(memory_server, "time_manager", fake_time_manager), \
+         patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
+         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox):
+        result = await memory_server.cache_conversation(request, "测试角色")
+
+    assert result == {"status": "cached", "count": 0}
+    fake_time_manager.astore_conversation.assert_not_awaited()
+    fake_spawn_outbox.assert_not_awaited()
+    fake_recent_history_manager.update_history.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cache_endpoint_serialises_recent_and_store_under_settle_lock():
+    """``update_history`` 和 ``astore_conversation`` 必须在 ``_get_settle_lock``
+    持锁内串行——和 /process / /renew / /settle 对偶，避免并发 cache 把
+    db 写顺序打乱（同时也防止 cache 和 settle 抢着写同一份 recent.json）。
+
+    具体校验：astore_conversation 一定在 update_history 之后被 await，
+    且整个流程内 settle_lock 是被锁住的。
+    """
+    from app import memory_server
+
+    order: list[str] = []
+
+    async def _fake_update_history(*args, **kwargs):
+        order.append("update_history")
+
+    async def _fake_astore(*args, **kwargs):
+        order.append("astore_conversation")
+
+    async def _fake_spawn(*args, **kwargs):
+        order.append("spawn_outbox")
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.astore_conversation = AsyncMock(side_effect=_fake_astore)
+    fake_recent_history_manager = MagicMock()
+    fake_recent_history_manager.update_history = AsyncMock(side_effect=_fake_update_history)
+
+    payload = _build_history_request_payload([
+        {"role": "human", "content": "test"},
+        {"role": "ai", "content": "ok"},
+    ])
+    request = memory_server.HistoryRequest(input_history=payload)
+
+    with patch.object(memory_server, "time_manager", fake_time_manager), \
+         patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
+         patch.object(memory_server, "_spawn_outbox_extract_facts", AsyncMock(side_effect=_fake_spawn)), \
+         patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)):
+        await memory_server.cache_conversation(request, "测试角色")
+
+    # update_history → astore_conversation 严格串行（同一 settle lock 内）
+    # spawn_outbox 在 lock 外，但仍然在前两个之后
+    assert order == ["update_history", "astore_conversation", "spawn_outbox"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_settle_endpoint_msgs_zero_still_runs_review():
+    """/settle msgs=0 时仍需触发 ``update_history([], detailed=True)`` 跑 review
+    LLM——这是 /settle 在新分工下的剩余职责（cache 已经负责 store + outbox）。
+
+    不变量：不管 msgs 是否为空，settle 必须调一次 update_history([], detailed=True)。
+    """
+    from app import memory_server
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.astore_conversation = AsyncMock(return_value=None)
+    fake_recent_history_manager = MagicMock()
+    fake_recent_history_manager.update_history = AsyncMock(return_value=None)
+    fake_spawn_outbox = AsyncMock(return_value=None)
+    fake_maybe_spawn_review = AsyncMock(return_value=None)
+
+    request = memory_server.HistoryRequest(input_history=json.dumps([]))
+
+    with patch.object(memory_server, "time_manager", fake_time_manager), \
+         patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
+         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox), \
+         patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)), \
+         patch.object(memory_server, "maybe_spawn_review", fake_maybe_spawn_review):
+        result = await memory_server.settle_conversation(request, "测试角色")
+
+    assert result["status"] == "settled"
+    # msgs=0：review LLM 仍跑，但 store / outbox 不重复跑（因为 cache 已经做了）
+    fake_recent_history_manager.update_history.assert_awaited_once()
+    call = fake_recent_history_manager.update_history.await_args
+    assert call.args[0] == []
+    assert call.kwargs.get("detailed") is True
+    fake_time_manager.astore_conversation.assert_not_awaited()
+    fake_spawn_outbox.assert_not_awaited()
+    fake_maybe_spawn_review.assert_awaited_once_with("测试角色")

--- a/tests/unit/test_memory_server_cache_settle.py
+++ b/tests/unit/test_memory_server_cache_settle.py
@@ -18,7 +18,6 @@ the field 46 days later.
 """
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/utils/cloudsave_runtime.py
+++ b/utils/cloudsave_runtime.py
@@ -4067,10 +4067,13 @@ def _should_preserve_write_blocking_mode(config_manager, root_state: dict[str, A
     if current_mode != ROOT_MODE_MAINTENANCE_READONLY:
         return False
 
-    last_migration_result = str(root_state.get("last_migration_result") or "").strip()
-    if last_migration_result.startswith("restart_pending:"):
-        return True
-
+    # 真相源是 storage_migration.json 的 pending 状态：迁移真在跑就保留 readonly，
+    # 否则视为孤儿态自愈。``last_migration_result`` 字段（含 ``restart_pending:``
+    # 前缀）只是描述上一次操作意图，不该被当作"还在进行中"的硬证据——marker
+    # 在 launcher 接力跑完迁移时才会被覆盖，任何让 launcher 跑不到那一步的事件
+    # （shutdown fire-and-forget 后 launcher 被绕过 / 半途强杀 / 迁移文件已被
+    # 善后删除）都会让 marker 残留，配合旧逻辑就把进程永久钉在 readonly 上、
+    # memory server 所有写盘静默失败。
     try:
         from utils.storage_migration import is_storage_migration_pending, load_storage_migration
 


### PR DESCRIPTION
## Summary

诊断起点：一位用户报"猫娘算出 gap=3 天 5 小时但实际就一晚没上线"——顺藤摸到 **3 个独立但都属于"写盘失败但前端无感"家族**的 bug。

| # | Bug | 文件 | 影响 |
|---|-----|------|------|
| A | `restart_pending:` marker 让 mode 永久卡 readonly | `utils/cloudsave_runtime.py` | bootstrap 自愈失效，memory server 所有写盘静默被 `assert_cloudsave_writable` 拦截 |
| B | TimeIndexedMemory db_paths cache 无 drift 检测 | `memory/timeindex.py` | 罕见：`/reload` + storage_policy 重写后老 SQLAlchemy engine 还连着旧文件 |
| C | `/cache` 端点漏写 db + outbox（commit cba377c5 引入，46 天） | `app/memory_server.py` | `time_indexed.db` 永不创建，evidence-RFC 链路全空转 |

## Bug A — `restart_pending:` marker 永久卡 readonly

**根因**：`_should_preserve_write_blocking_mode` 看到 `last_migration_result` 以 `restart_pending:` 开头就 short-circuit `return True`，不再检查 `storage_migration.json` 是否真的还 pending。

POST `/api/storage-location/restart` 写完 marker 后调 `_request_app_shutdown`（fire-and-forget `asyncio.create_task`，立即返回）。任何让 launcher 跑不到 `set_root_mode(NORMAL, "completed:...")` 的事件（shutdown 没真关进程 / 用户强杀 / migration 文件被善后删除）都会让 marker 残留，永久卡 readonly。

**修法**：删 startswith 短路，统一以 `storage_migration.json` 的 pending 状态作为"是否还在迁移中"的真相源。marker 单独残留视为孤儿态，自愈回 normal，`last_migration_result` 改写为 `recovered_stale_mode:maintenance_readonly` 留下追溯线索。

## Bug B — TimeIndexedMemory path drift

**根因**：`_ensure_engine_exists` cache 命中后短路 `return True`，不重新校核当前 `memory_dir`。`/reload` + storage_policy 重写、或测试 monkeypatch 了 memory_dir 时，cached db_path 和实际目标分叉，老 SQLAlchemy engine 还连着旧文件——新数据全飘到老位置。

**修法**：提取 `_resolve_expected_db_path` helper（drift 检测和新建路径共用），cache 命中时先比对 expected vs cached，漂移就 dispose 重建。

## Bug C — `/cache` + `/settle(msgs=0)` 漏写 db + outbox（核心 bug）

**根因**：commit cba377c5（"Fix/memory hotswap timing", 2026-03-29）引入 `/settle` 时把"补完 cache 留下的 LLM 后续操作"全 gate 在 `if input_history` 后面。但 cross_server 标准节奏是：

\`\`\`
turn end → /cache(messages)        ← 只写 recent.json
…
renew session → /settle(msgs=0)    ← settle 收到空 input_history, gate 跳过 store + outbox
\`\`\`

结果：
- ❌ `time_indexed.db` 永不创建 → time perception 失效（trigger_greeting 因 gap=-1 而 skip，用户连"距上次 X 小时"提示都看不到）
- ❌ `outbox.ndjson` / `events.ndjson` / `facts.json` 全部不建 → 长期记忆 + evidence-RFC 链路全空转
- ❌ `_periodic_signal_extraction_loop` 依赖 db 拉历史，**batch fact extraction 也整段瘫痪**

**触发条件**：cache 全程不失败 + 模型回话不被打断——即"标准 / 温柔用户"场景。重度用户因为偶尔 cache 失败 / 中途打断模型反而能时不时救一次 db 写入。

**修法 + RFC 对齐**：把 store + post-turn signals 搬回 `/cache` 端点；**同时**按 RFC #928 §3.4.3 的设计意图（"不在对话主路径上每轮运行 extract_facts——太贵。改为背景调度"）剥离 PR-1 当时为"短期行为不变"暂留的 Stage-1 per-turn fact 抽取 legacy。

\`\`\`python
# /cache 端点新职责
async with _get_settle_lock(lanlan_name):
    await recent_history_manager.update_history(...)   # recent.json
    await time_manager.astore_conversation(...)         # time_indexed.db
await _spawn_outbox_extract_facts(...)                  # counter bump + 复读嗅探 + check_feedback
# Stage-1 fact LLM 不再 per-turn 跑 - 交给 batch loop
\`\`\`

**LLM cost 变化**：per-turn fact extract LLM **减少**（每轮一次 → 每 10 turn 或 5min 一次 batch）。batch 路径带上下文 + Stage-2 signal detection，质量更高。check_feedback / 复读嗅探 / counter bump 这些 user-facing 必须 per-turn 的操作保留。

## 用户侧自愈路径

部署后重启即可，不需要手动操作：

1. **Bug A 用户**：bootstrap → `_recover_stale_write_blocking_mode` 自动把 orphan readonly 翻回 normal
2. **Bug B 用户**：cache 命中时检测 db_path drift，dispose 老 engine 重建
3. **Bug C 用户**：cache 端点开始落 db → batch loop 拿到数据 → 全链路从下一轮对话起恢复填充

已丢失的 46 天历史数据按设计 punt 掉，**不回填**——recent.json 里有消息但没 timestamp 锚点，反推不可靠；从下一轮对话起重建 db 即可。trigger_greeting 在新 db 为空时 fallback 到 `gap=-1 → skip`（不会有"3 天 5 小时"那种异常显示）。

## Test plan

- [x] 7 个直接相关测试文件 197 个 case 全过
- [x] 广义扫描 657 个 memory / storage / cloudsave / persona / reflection / fact 相关 case 全过（唯一 pre-existing fail `test_main_server_manual_startup_performs_fallback_import_and_continues_boot` 跟 env 路径相关，main 上也 fail）
- [x] 新增 8 个 regression 用例：
  - `test_bootstrap_heals_orphan_restart_pending_marker`
  - `test_timeindexed_dispose_and_rebuild_when_memory_dir_drifts`
  - `test_timeindexed_short_circuits_when_memory_dir_unchanged`
  - `test_cache_endpoint_writes_time_indexed_db`
  - `test_cache_endpoint_spawns_outbox_post_turn_signals`
  - `test_cache_endpoint_empty_payload_short_circuits`
  - `test_cache_endpoint_serialises_recent_and_store_under_settle_lock`
  - `test_settle_endpoint_msgs_zero_still_runs_review`
  - `test_extract_facts_and_check_feedback_does_not_run_stage1_legacy`

## Refs

- [docs/design/memory-evidence-rfc.md](docs/design/memory-evidence-rfc.md) §3.4.3 / §3.4.5
- commit cba377c5 "Fix/memory hotswap timing" (#575) ← Bug C 引入点
- commit a313d02bf "feat(memory): 三层记忆架构" (#563) ← Stage-1 legacy 引入点

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复孤立重启标记恢复逻辑，避免误判并正确保留写阻断模式
  * 检测并自动重建因 time-index/存储路径漂移导致的缓存引擎，防止使用过期连接
  * /cache 接口改为轻量化“回合末”持久化：不在请求路径执行重型提取，改为在锁外异步触发出箱提取；增强错误日志

* **Tests**
  * 新增多项回归/单元测试，覆盖缓存/settle 流程、时间索引路径漂移与恢复、提取阶段行为与云保存恢复场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1346)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->