### PR TITLE
 feat(galgame): 添加上下文缓存持久化与可配置上下文窗口

### DIFF
--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -2847,6 +2847,33 @@ class GalgamePlugin(NekoPluginBase):
         with self._state_lock:
             return str(self._state.active_game_id or "")
 
+    def _context_snapshot_liveness_matches(
+        self,
+        *,
+        snapshot: dict[str, Any],
+        game_id: str,
+        session_id: str,
+    ) -> bool:
+        latest_snapshot = getattr(self._state, "latest_snapshot", {})
+        live_snapshot = (
+            latest_snapshot
+            if isinstance(latest_snapshot, dict)
+            else {}
+        )
+        if session_id:
+            return session_id == str(getattr(self._state, "active_session_id", "") or "")
+        return (
+            (not game_id or game_id == str(getattr(self._state, "active_game_id", "") or ""))
+            and (
+                not snapshot["scene_id"]
+                or snapshot["scene_id"] == str(live_snapshot.get("scene_id") or "")
+            )
+            and (
+                not snapshot["route_id"]
+                or snapshot["route_id"] == str(live_snapshot.get("route_id") or "")
+            )
+        )
+
     def _persist_context_snapshot_from_summary(
         self,
         context: dict[str, Any],
@@ -2857,6 +2884,7 @@ class GalgamePlugin(NekoPluginBase):
         if bool(payload.get("degraded")):
             return
         game_id = str(context.get("game_id") or "").strip()
+        session_id = str(context.get("session_id") or "").strip()
         if not game_id:
             game_id = self._active_game_id_for_context_persist().strip()
         if not game_id and bool(
@@ -2877,8 +2905,26 @@ class GalgamePlugin(NekoPluginBase):
             "stable_line_ids": stable_line_ids[-64:],
             "saved_at": time.time(),
         }
-        self._persist.persist_context_snapshot(snapshot)
         with self._state_lock:
+            live_matches = self._context_snapshot_liveness_matches(
+                snapshot=snapshot,
+                game_id=game_id,
+                session_id=session_id,
+            )
+        if not live_matches:
+            self.logger.warning("galgame context_snapshot persist skipped: stale summary context")
+            return
+        with self._state_lock:
+            if not self._context_snapshot_liveness_matches(
+                snapshot=snapshot,
+                game_id=game_id,
+                session_id=session_id,
+            ):
+                self.logger.warning(
+                    "galgame context_snapshot persist skipped: stale summary context"
+                )
+                return
+            self._persist.persist_context_snapshot(snapshot)
             self._state.context_snapshot = json_copy(snapshot)
             self._state_dirty = True
             self._cached_snapshot = None

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -158,6 +158,7 @@ def _significant_char_count(text: object) -> int:
 def _context_window_bounds(
     config: GalgameLLMConfig | None,
     *,
+    min_floor: int = 1,
     max_floor: int = 1,
 ) -> tuple[int, int, int]:
     try:
@@ -177,8 +178,9 @@ def _context_window_bounds(
         )
     except (TypeError, ValueError):
         target_tokens = _DYNAMIC_WINDOW_DEFAULT_TARGET_TOKENS
-    min_limit = max(1, min_limit)
-    max_limit = max(1, max(max_limit, max_floor))
+    min_floor = max(1, min_floor)
+    min_limit = max(1, min_limit, min_floor)
+    max_limit = max(1, max(max_limit, max_floor, min_floor))
     if min_limit > max_limit:
         min_limit, max_limit = max_limit, min_limit
     return min_limit, max_limit, max(1, target_tokens)
@@ -216,6 +218,7 @@ def _recency_ordered_context_lines(
     observed_lines: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     indexed: list[tuple[int, str, int, int, int, dict[str, Any]]] = []
+    total_count = len(stable_lines) + len(observed_lines)
     for source_order, (source, items) in enumerate(
         (("stable", stable_lines), ("observed", observed_lines))
     ):
@@ -223,11 +226,7 @@ def _recency_ordered_context_lines(
             line = dict(item) if isinstance(item, dict) else {}
             line.setdefault("source", source)
             ts = str(line.get("ts") or "").strip()
-            fallback_index = (
-                source_index
-                if ts
-                else source_order * (len(stable_lines) + len(observed_lines)) + source_index
-            )
+            fallback_index = source_index if ts else source_order * total_count + source_index
             indexed.append((1 if ts else 0, ts, fallback_index, source_order, source_index, line))
     indexed.sort(key=lambda item: (item[0], item[1], item[2], item[3], item[4]))
     return [item[5] for item in indexed]
@@ -1195,10 +1194,23 @@ def build_summarize_context(
     """Build the prompt context used by the summarize-scene LLM operation."""
     snapshot = sanitize_snapshot_state(local_state.get("latest_snapshot", {}))
     effective_line = resolve_effective_current_line(local_state)
+    restored = local_state.get("context_snapshot")
+    restored = restored if isinstance(restored, dict) else {}
+    restored_scene_id = str(restored.get("scene_id") or "").strip()
+    restored_route_id = str(restored.get("route_id") or "").strip()
     effective_scene_id = scene_id or str(
-        snapshot.get("scene_id") or (effective_line or {}).get("scene_id") or ""
+        snapshot.get("scene_id")
+        or (effective_line or {}).get("scene_id")
+        or restored_scene_id
+        or ""
     )
-    route_id = str(snapshot.get("route_id") or (effective_line or {}).get("route_id") or "")
+    restored_scene_matches = not restored_scene_id or restored_scene_id == effective_scene_id
+    route_id = str(
+        snapshot.get("route_id")
+        or (effective_line or {}).get("route_id")
+        or (restored_route_id if restored_scene_matches else "")
+        or ""
+    )
     history_lines = list(local_state.get("history_lines", []) or [])
     history_observed_lines = list(local_state.get("history_observed_lines", []) or [])
     min_limit, max_limit, target_tokens = _context_window_bounds(config)

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -766,6 +766,86 @@ def build_local_scene_summary(
     return summary
 
 
+def _matching_context_snapshot(
+    local_state: dict[str, Any],
+    *,
+    scene_id: str,
+    route_id: str,
+) -> dict[str, Any]:
+    context_snapshot = local_state.get("context_snapshot")
+    if not isinstance(context_snapshot, dict):
+        return {}
+
+    summary_seed = str(context_snapshot.get("summary_seed") or "").strip()
+    stable_line_ids_raw = context_snapshot.get("stable_line_ids")
+    stable_line_ids = (
+        [str(item).strip() for item in stable_line_ids_raw if str(item).strip()]
+        if isinstance(stable_line_ids_raw, list)
+        else []
+    )
+    if not summary_seed and not stable_line_ids:
+        return {}
+
+    active_game_id = str(local_state.get("active_game_id") or "").strip()
+    snapshot_game_id = str(context_snapshot.get("game_id") or "").strip()
+    if active_game_id and snapshot_game_id and active_game_id != snapshot_game_id:
+        return {}
+
+    snapshot_scene_id = str(context_snapshot.get("scene_id") or "").strip()
+    normalized_scene_id = str(scene_id or "").strip()
+    if normalized_scene_id and snapshot_scene_id and normalized_scene_id != snapshot_scene_id:
+        return {}
+
+    snapshot_route_id = str(context_snapshot.get("route_id") or "").strip()
+    normalized_route_id = str(route_id or "").strip()
+    if normalized_route_id and snapshot_route_id and normalized_route_id != snapshot_route_id:
+        return {}
+
+    return {
+        "scene_id": snapshot_scene_id,
+        "game_id": snapshot_game_id,
+        "route_id": snapshot_route_id,
+        "summary_seed": summary_seed,
+        "stable_line_ids": stable_line_ids,
+    }
+
+
+def _scene_summary_seed_with_restored_context(
+    local_state: dict[str, Any],
+    *,
+    scene_id: str,
+    route_id: str,
+    lines: list[dict[str, Any]],
+    selected_choices: list[dict[str, Any]],
+    snapshot: dict[str, Any],
+    restored_context_snapshot: dict[str, Any] | None = None,
+) -> str:
+    if restored_context_snapshot is None:
+        restored_context_snapshot = _matching_context_snapshot(
+            local_state,
+            scene_id=scene_id,
+            route_id=route_id,
+        )
+    summary_seed = str((restored_context_snapshot or {}).get("summary_seed") or "").strip()
+    if not lines and summary_seed:
+        summary = f"Restored previous scene summary: {summary_seed}"
+        stable_line_ids = list((restored_context_snapshot or {}).get("stable_line_ids") or [])
+        if stable_line_ids:
+            summary += f" Restored stable line ids: {', '.join(stable_line_ids[-6:])}."
+        if route_id:
+            summary += f" Route {route_id}."
+        if selected_choices:
+            summary += f" {len(selected_choices)} confirmed choices are available."
+        return summary
+    return build_local_scene_summary(
+        scene_id=scene_id,
+        route_id=route_id,
+        lines=lines,
+        selected_choices=selected_choices,
+        snapshot=snapshot,
+    )
+
+
 def _summary_mode(config: GalgameLLMConfig | None) -> str:
     mode = str(getattr(config, "context_scene_summary_mode", "rolling") or "rolling").strip()
     if mode in {"rolling", "cumulative_light", "cumulative_llm"}:
@@ -842,6 +922,7 @@ def _context_snapshot_summary_seed(
     local_state: dict[str, Any],
     *,
     current_game_id: str,
+    current_scene_id: str = "",
     current_route_id: str,
 ) -> str:
     context_snapshot = local_state.get("context_snapshot")
@@ -860,6 +941,11 @@ def _context_snapshot_summary_seed(
         if snapshot_game_id != normalized_game_id:
             return ""
 
+    snapshot_scene_id = str(context_snapshot.get("scene_id") or "").strip()
+    normalized_scene_id = str(current_scene_id or "").strip()
+    if snapshot_scene_id and normalized_scene_id and snapshot_scene_id != normalized_scene_id:
+        return ""
+
     snapshot_route_id = str(context_snapshot.get("route_id") or "").strip()
     normalized_route_id = str(current_route_id or "").strip()
     if snapshot_route_id != normalized_route_id:
@@ -872,6 +958,7 @@ def _previous_summary_from_state(
     local_state: dict[str, Any],
     *,
     current_game_id: str = "",
+    current_scene_id: str = "",
     current_route_id: str = "",
 ) -> str:
     for key in ("previous_scene_summary", "scene_summary_seed", "scene_summary"):
@@ -887,6 +974,7 @@ def _previous_summary_from_state(
     return _context_snapshot_summary_seed(
         local_state,
         current_game_id=current_game_id,
+        current_scene_id=current_scene_id,
         current_route_id=current_route_id,
     )
 
@@ -1012,6 +1100,11 @@ def build_explain_context(
         scene_id,
         limit=6,
     )
+    restored_context_snapshot = _matching_context_snapshot(
+        local_state,
+        scene_id=scene_id,
+        route_id=route_id,
+    )
 
     evidence: list[dict[str, Any]] = []
     snapshot_line = _current_line_entry(snapshot)
@@ -1070,6 +1163,16 @@ def build_explain_context(
         "stable_lines": stable_lines,
         "observed_lines": observed_lines,
         "recent_choices": selected_choices,
+        "scene_summary_seed": _scene_summary_seed_with_restored_context(
+            local_state,
+            scene_id=scene_id,
+            route_id=route_id,
+            lines=scene_lines,
+            selected_choices=selected_choices,
+            snapshot=snapshot,
+            restored_context_snapshot=restored_context_snapshot,
+        ),
+        "restored_context_snapshot": restored_context_snapshot,
         "evidence": evidence,
         "input_source": input_source,
         "input_degraded": input_degraded,
@@ -1121,6 +1224,11 @@ def build_summarize_context(
         effective_scene_id,
         limit=12,
     )
+    restored_context_snapshot = _matching_context_snapshot(
+        local_state,
+        scene_id=effective_scene_id,
+        route_id=route_id,
+    )
     input_source, input_degraded, degraded_reasons = _build_input_degraded_context(
         local_state,
         scene_id=effective_scene_id,
@@ -1136,6 +1244,7 @@ def build_summarize_context(
         previous_summary=_previous_summary_from_state(
             local_state,
             current_game_id=str(local_state.get("active_game_id") or ""),
+            current_scene_id=effective_scene_id,
             current_route_id=route_id,
         ),
         mode=_summary_mode(config),
@@ -1161,6 +1270,7 @@ def build_summarize_context(
         "observed_lines": observed_lines,
         "recent_choices": selected_choices,
         "scene_summary_seed": summary_seed,
+        "restored_context_snapshot": restored_context_snapshot,
         "input_source": input_source,
         "input_degraded": input_degraded,
         "degraded_reasons": degraded_reasons,

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -1247,30 +1247,42 @@ def build_summarize_context(
         line_id=str(snapshot.get("line_id") or ""),
         choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
     )
-    summary_seed = _cumulative_scene_summary(
-        scene_id=effective_scene_id,
-        route_id=route_id,
-        lines=stable_lines,
-        selected_choices=selected_choices,
-        snapshot=_snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines),
-        previous_summary=_previous_summary_from_state(
+    seed_snapshot = _snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines)
+    if not stable_lines and restored_context_snapshot:
+        summary_seed = _scene_summary_seed_with_restored_context(
             local_state,
-            current_game_id=str(local_state.get("active_game_id") or ""),
-            current_scene_id=effective_scene_id,
-            current_route_id=route_id,
-        ),
-        mode=_summary_mode(config),
-        llm_refined_summary=_llm_refined_summary_from_state(local_state),
-        llm_trigger_lines=int(
-            getattr(config, "context_cumulative_llm_trigger_lines", 30) or 30
-        ),
-        trigger_line_count=_scene_history_dialogue_line_count(
-            history_lines,
-            history_observed_lines,
             scene_id=effective_scene_id,
             route_id=route_id,
-        ),
-    )
+            lines=stable_lines,
+            selected_choices=selected_choices,
+            snapshot=seed_snapshot,
+            restored_context_snapshot=restored_context_snapshot,
+        )
+    else:
+        summary_seed = _cumulative_scene_summary(
+            scene_id=effective_scene_id,
+            route_id=route_id,
+            lines=stable_lines,
+            selected_choices=selected_choices,
+            snapshot=seed_snapshot,
+            previous_summary=_previous_summary_from_state(
+                local_state,
+                current_game_id=str(local_state.get("active_game_id") or ""),
+                current_scene_id=effective_scene_id,
+                current_route_id=route_id,
+            ),
+            mode=_summary_mode(config),
+            llm_refined_summary=_llm_refined_summary_from_state(local_state),
+            llm_trigger_lines=int(
+                getattr(config, "context_cumulative_llm_trigger_lines", 30) or 30
+            ),
+            trigger_line_count=_scene_history_dialogue_line_count(
+                history_lines,
+                history_observed_lines,
+                scene_id=effective_scene_id,
+                route_id=route_id,
+            ),
+        )
     return {
         "game_id": str(local_state.get("active_game_id") or ""),
         "session_id": str(local_state.get("active_session_id") or ""),

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -1247,42 +1247,30 @@ def build_summarize_context(
         line_id=str(snapshot.get("line_id") or ""),
         choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
     )
-    seed_snapshot = _snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines)
-    if not stable_lines and restored_context_snapshot:
-        summary_seed = _scene_summary_seed_with_restored_context(
+    summary_seed = _cumulative_scene_summary(
+        scene_id=effective_scene_id,
+        route_id=route_id,
+        lines=stable_lines,
+        selected_choices=selected_choices,
+        snapshot=_snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines),
+        previous_summary=_previous_summary_from_state(
             local_state,
+            current_game_id=str(local_state.get("active_game_id") or ""),
+            current_scene_id=effective_scene_id,
+            current_route_id=route_id,
+        ),
+        mode=_summary_mode(config),
+        llm_refined_summary=_llm_refined_summary_from_state(local_state),
+        llm_trigger_lines=int(
+            getattr(config, "context_cumulative_llm_trigger_lines", 30) or 30
+        ),
+        trigger_line_count=_scene_history_dialogue_line_count(
+            history_lines,
+            history_observed_lines,
             scene_id=effective_scene_id,
             route_id=route_id,
-            lines=stable_lines,
-            selected_choices=selected_choices,
-            snapshot=seed_snapshot,
-            restored_context_snapshot=restored_context_snapshot,
-        )
-    else:
-        summary_seed = _cumulative_scene_summary(
-            scene_id=effective_scene_id,
-            route_id=route_id,
-            lines=stable_lines,
-            selected_choices=selected_choices,
-            snapshot=seed_snapshot,
-            previous_summary=_previous_summary_from_state(
-                local_state,
-                current_game_id=str(local_state.get("active_game_id") or ""),
-                current_scene_id=effective_scene_id,
-                current_route_id=route_id,
-            ),
-            mode=_summary_mode(config),
-            llm_refined_summary=_llm_refined_summary_from_state(local_state),
-            llm_trigger_lines=int(
-                getattr(config, "context_cumulative_llm_trigger_lines", 30) or 30
-            ),
-            trigger_line_count=_scene_history_dialogue_line_count(
-                history_lines,
-                history_observed_lines,
-                scene_id=effective_scene_id,
-                route_id=route_id,
-            ),
-        )
+        ),
+    )
     return {
         "game_id": str(local_state.get("active_game_id") or ""),
         "session_id": str(local_state.get("active_session_id") or ""),

--- a/plugin/plugins/galgame_plugin/game_llm_agent.py
+++ b/plugin/plugins/galgame_plugin/game_llm_agent.py
@@ -11,7 +11,9 @@ from .host_agent_adapter import HostAgentAdapter, HostAgentError
 from .context_builder import (
     _compute_dynamic_line_limit,
     _context_window_bounds,
+    _matching_context_snapshot,
     _recency_ordered_context_lines,
+    _scene_summary_seed_with_restored_context,
 )
 from .local_input_actuator import (
     VIRTUAL_MOUSE_DIALOGUE_CANDIDATES,
@@ -5498,32 +5500,34 @@ class GameLLMAgent:
         status = self._compute_status(shared)
         history_lines = list(shared.get("history_lines") or [])
         history_observed_lines = list(shared.get("history_observed_lines") or [])
+        scene_id = str(snapshot.get("scene_id") or "")
+        route_id = str(snapshot.get("route_id") or "")
         min_limit, max_limit, target_tokens = _context_window_bounds(
             self._context_config,
             max_floor=16,
         )
+        tagged_stable = [
+            {**dict(item), "_reply_context_source": "stable"}
+            for item in history_lines
+            if isinstance(item, dict)
+            and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+        ]
+        tagged_observed = [
+            {**dict(item), "_reply_context_source": "observed"}
+            for item in history_observed_lines
+            if isinstance(item, dict)
+            and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+        ]
+        recency_ordered = _recency_ordered_context_lines(tagged_stable, tagged_observed)
         line_limit = _compute_dynamic_line_limit(
-            _recency_ordered_context_lines(history_lines, history_observed_lines),
+            recency_ordered,
             min_limit=min_limit,
             max_limit=max_limit,
             target_tokens=target_tokens,
         )
         history_choices = list(shared.get("history_choices") or [])
         if line_limit > 0:
-            tagged_stable = [
-                {**dict(item), "_reply_context_source": "stable"}
-                for item in history_lines
-                if isinstance(item, dict)
-            ]
-            tagged_observed = [
-                {**dict(item), "_reply_context_source": "observed"}
-                for item in history_observed_lines
-                if isinstance(item, dict)
-            ]
-            merged_recent = _recency_ordered_context_lines(
-                tagged_stable,
-                tagged_observed,
-            )[-line_limit:]
+            merged_recent = recency_ordered[-line_limit:]
             stable_lines = [
                 {key: value for key, value in item.items() if key != "_reply_context_source"}
                 for item in merged_recent
@@ -5543,11 +5547,29 @@ class GameLLMAgent:
                 for item in recent_lines
                 if str(item.get("line_id") or "")
             }
-            recent_choices = [
-                dict(item)
-                for item in history_choices
+            matching_history_choices = [
+                (index, dict(item))
+                for index, item in enumerate(history_choices)
                 if isinstance(item, dict)
+                and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+            ]
+            choices_without_line_id = [
+                (index, item)
+                for index, item in matching_history_choices
+                if not str(item.get("line_id") or "").strip()
+            ]
+            choices_with_recent_line_id = [
+                (index, item)
+                for index, item in matching_history_choices
+                if str(item.get("line_id") or "").strip()
                 and str(item.get("line_id") or "") in recent_line_ids
+            ]
+            recent_choices = [
+                item
+                for _index, item in sorted(
+                    [*choices_without_line_id, *choices_with_recent_line_id],
+                    key=lambda pair: pair[0],
+                )
             ][-line_limit:]
         else:
             stable_lines = []
@@ -5562,13 +5584,18 @@ class GameLLMAgent:
                 f"{speaker}: "
                 f"{str(effective_line.get('text') or '')}"
             )
+        restored_context_snapshot = _matching_context_snapshot(
+            shared,
+            scene_id=scene_id,
+            route_id=route_id,
+        )
         public_context = {
             "current_line": {
                 "speaker": str(effective_line.get("speaker") or ""),
                 "text": str(effective_line.get("text") or ""),
                 "line_id": str(effective_line.get("line_id") or ""),
-                "scene_id": str(effective_line.get("scene_id") or snapshot.get("scene_id") or ""),
-                "route_id": str(effective_line.get("route_id") or snapshot.get("route_id") or ""),
+                "scene_id": str(effective_line.get("scene_id") or scene_id),
+                "route_id": str(effective_line.get("route_id") or route_id),
                 "source": str(effective_line.get("source") or ""),
                 "stability": str(effective_line.get("stability") or ""),
             },
@@ -5577,13 +5604,16 @@ class GameLLMAgent:
             "stable_lines": json_copy(stable_lines),
             "observed_lines": json_copy(observed_lines),
             "recent_choices": json_copy(recent_choices),
-            "scene_summary_seed": build_local_scene_summary(
-                scene_id=str(snapshot.get("scene_id") or ""),
-                route_id=str(snapshot.get("route_id") or ""),
+            "scene_summary_seed": _scene_summary_seed_with_restored_context(
+                shared,
+                scene_id=scene_id,
+                route_id=route_id,
                 lines=recent_lines,
                 selected_choices=recent_choices,
                 snapshot=snapshot,
+                restored_context_snapshot=restored_context_snapshot,
             ),
+            "restored_context_snapshot": json_copy(restored_context_snapshot),
             "diagnostic": self._target_window_focus_diagnostic(shared)
             or self._ocr_capture_diagnostic
             or "",
@@ -5593,8 +5623,8 @@ class GameLLMAgent:
             "prompt": prompt,
             "game_id": str(shared.get("active_game_id") or ""),
             "session_id": str(shared.get("active_session_id") or ""),
-            "scene_id": str(snapshot.get("scene_id") or ""),
-            "route_id": str(snapshot.get("route_id") or ""),
+            "scene_id": scene_id,
+            "route_id": route_id,
             "public_context": public_context,
             "status": status,
             "agent_user_status": self._agent_user_status(shared, status=status),

--- a/plugin/plugins/galgame_plugin/game_llm_agent.py
+++ b/plugin/plugins/galgame_plugin/game_llm_agent.py
@@ -5504,19 +5504,28 @@ class GameLLMAgent:
         route_id = str(snapshot.get("route_id") or "")
         min_limit, max_limit, target_tokens = _context_window_bounds(
             self._context_config,
+            min_floor=16,
             max_floor=16,
         )
         tagged_stable = [
             {**dict(item), "_reply_context_source": "stable"}
             for item in history_lines
             if isinstance(item, dict)
-            and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+            and (
+                not scene_id
+                or not str(item.get("scene_id") or "")
+                or str(item.get("scene_id") or "") == scene_id
+            )
         ]
         tagged_observed = [
             {**dict(item), "_reply_context_source": "observed"}
             for item in history_observed_lines
             if isinstance(item, dict)
-            and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+            and (
+                not scene_id
+                or not str(item.get("scene_id") or "")
+                or str(item.get("scene_id") or "") == scene_id
+            )
         ]
         recency_ordered = _recency_ordered_context_lines(tagged_stable, tagged_observed)
         line_limit = _compute_dynamic_line_limit(
@@ -5529,17 +5538,29 @@ class GameLLMAgent:
         if line_limit > 0:
             merged_recent = recency_ordered[-line_limit:]
             stable_lines = [
-                {key: value for key, value in item.items() if key != "_reply_context_source"}
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key != "_reply_context_source" and not str(key).startswith("_condensed_")
+                }
                 for item in merged_recent
                 if item.get("_reply_context_source") == "stable"
             ]
             observed_lines = [
-                {key: value for key, value in item.items() if key != "_reply_context_source"}
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key != "_reply_context_source" and not str(key).startswith("_condensed_")
+                }
                 for item in merged_recent
                 if item.get("_reply_context_source") == "observed"
             ]
             recent_lines = [
-                {key: value for key, value in item.items() if key != "_reply_context_source"}
+                {
+                    key: value
+                    for key, value in item.items()
+                    if key != "_reply_context_source" and not str(key).startswith("_condensed_")
+                }
                 for item in merged_recent
             ]
             recent_line_ids = {
@@ -5551,7 +5572,11 @@ class GameLLMAgent:
                 (index, dict(item))
                 for index, item in enumerate(history_choices)
                 if isinstance(item, dict)
-                and (not scene_id or str(item.get("scene_id") or "") == scene_id)
+                and (
+                    not scene_id
+                    or not str(item.get("scene_id") or "")
+                    or str(item.get("scene_id") or "") == scene_id
+                )
             ]
             choices_without_line_id = [
                 (index, item)

--- a/plugin/plugins/galgame_plugin/game_llm_agent.py
+++ b/plugin/plugins/galgame_plugin/game_llm_agent.py
@@ -121,6 +121,22 @@ def _bounded_choice_instruction_text(value: object) -> str:
     return f"{text[:_CHOICE_INSTRUCTION_TEXT_MAX_CHARS]}\n...[truncated {omitted} chars]"
 
 
+def _context_line_count(lines: object) -> int:
+    if not isinstance(lines, list):
+        return 0
+    total = 0
+    for item in lines:
+        if not isinstance(item, dict):
+            total += 1
+            continue
+        try:
+            count = int(item.get("_condensed_count") or 1)
+        except (TypeError, ValueError):
+            count = 1
+        total += max(1, count)
+    return total
+
+
 class AgentMessageRouter:
     def __init__(self, *, now_factory: Callable[[], str], limit: int = 100) -> None:
         self._now_factory = now_factory
@@ -4619,7 +4635,7 @@ class GameLLMAgent:
             context_payload = dict(context)
             metadata_payload = dict(metadata)
         scheduled_seq = int(metadata_payload.get("scheduled_from_event_seq") or 0)
-        stable_line_count = len(list(context_payload.get("stable_lines") or []))
+        stable_line_count = _context_line_count(context_payload.get("stable_lines"))
         last_line_seq = int(metadata_payload.get("last_line_seq") or scheduled_seq or 0)
         delivery_key = str(metadata_payload.get("summary_delivery_key") or "")
         if not delivery_key:
@@ -5082,6 +5098,7 @@ class GameLLMAgent:
             if scene_id == self._pending_cross_scene_primary:
                 self._pending_cross_scene_primary = ""
             stable_lines = list(context.get("stable_lines") or [])
+            stable_line_count = _context_line_count(stable_lines)
             if not stable_lines:
                 self._summary_debug["gate_blocked"] = {
                     "gate": "empty_stable_lines",
@@ -5103,7 +5120,7 @@ class GameLLMAgent:
                 scene_id=scene_id,
                 scheduled_seq=scheduled_seq,
                 last_line_seq=scheduled_seq,
-                stable_line_count=len(stable_lines),
+                stable_line_count=stable_line_count,
             )
             if delivery_key and delivery_key == self._last_delivered_summary_key:
                 self._summary_debug["last_skip"] = {
@@ -5126,7 +5143,7 @@ class GameLLMAgent:
                 "line_interval": self._scene_summary_push_line_interval,
                 "scheduled_from_event_seq": scheduled_seq,
                 "last_line_seq": scheduled_seq,
-                "stable_line_count": len(stable_lines),
+                "stable_line_count": stable_line_count,
                 "summary_delivery_key": delivery_key,
                 "current_scene_id_at_schedule": current_scene_id,
             }
@@ -5156,7 +5173,7 @@ class GameLLMAgent:
                     "scheduled_from_event_seq": scheduled_seq,
                     "summary_delivery_key": delivery_key,
                     "current_scene_id_at_schedule": current_scene_id,
-                    "stable_line_count": len(stable_lines),
+                    "stable_line_count": stable_line_count,
                 }
             )
 
@@ -5541,7 +5558,7 @@ class GameLLMAgent:
                 {
                     key: value
                     for key, value in item.items()
-                    if key != "_reply_context_source" and not str(key).startswith("_condensed_")
+                    if key != "_reply_context_source"
                 }
                 for item in merged_recent
                 if item.get("_reply_context_source") == "stable"
@@ -5550,7 +5567,7 @@ class GameLLMAgent:
                 {
                     key: value
                     for key, value in item.items()
-                    if key != "_reply_context_source" and not str(key).startswith("_condensed_")
+                    if key != "_reply_context_source"
                 }
                 for item in merged_recent
                 if item.get("_reply_context_source") == "observed"

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -490,8 +490,16 @@ class LLMGateway:
         mode = str(
             getattr(self._config, "context_counting_mode", "char") or "char"
         ).strip().lower()
+        semantic_compression = bool(
+            getattr(self._config, "context_semantic_compression", False)
+        )
         if mode != "token":
-            return _stable_json_fingerprint({"context_counting_mode": "char"})
+            return _stable_json_fingerprint(
+                {
+                    "context_counting_mode": "char",
+                    "context_semantic_compression": semantic_compression,
+                }
+            )
         try:
             budget = int(getattr(self._config, "context_max_tokens", 6000))
         except (TypeError, ValueError):
@@ -500,6 +508,7 @@ class LLMGateway:
             {
                 "context_counting_mode": "token",
                 "context_max_tokens": max(1, budget),
+                "context_semantic_compression": semantic_compression,
             }
         )
 

--- a/plugin/plugins/galgame_plugin/llm_prompts.py
+++ b/plugin/plugins/galgame_plugin/llm_prompts.py
@@ -156,7 +156,7 @@ def _strip_condense_metadata(value: Any) -> Any:
         return {
             key: item
             for key, item in value.items()
-            if key not in {"_condensed_line_ids", "_condensed_count"}
+            if not str(key).startswith("_condensed_")
         }
     return value
 

--- a/plugin/tests/unit/plugins/test_galgame_bridge.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge.py
@@ -515,7 +515,12 @@ def test_persist_context_snapshot_allows_missing_game_id_when_not_required() -> 
         context_persist_enabled=True,
         context_persist_require_game_id=False,
     )
-    plugin._state = SimpleNamespace(active_game_id="", context_snapshot={})
+    plugin._state = SimpleNamespace(
+        active_game_id="",
+        active_session_id="",
+        latest_snapshot={"scene_id": "scene-a", "route_id": ""},
+        context_snapshot={},
+    )
     plugin._state_lock = threading.Lock()
     plugin._state_dirty = False
     plugin._cached_snapshot = {"stale": True}
@@ -537,6 +542,63 @@ def test_persist_context_snapshot_allows_missing_game_id_when_not_required() -> 
     assert plugin._state.context_snapshot["summary_seed"] == "summary without game id"
     assert plugin._state_dirty is True
     assert plugin._cached_snapshot is None
+
+
+def test_persist_context_snapshot_skips_write_when_session_turns_stale() -> None:
+    saved: list[dict[str, object]] = []
+
+    class _Persist:
+        def persist_context_snapshot(self, snapshot: dict[str, object]) -> None:
+            saved.append(dict(snapshot))
+
+    class _Logger:
+        def warning(self, *_: object, **__: object) -> None:
+            return None
+
+    plugin = GalgameBridgePlugin.__new__(GalgameBridgePlugin)
+    plugin._cfg = SimpleNamespace(
+        context_persist_enabled=True,
+        context_persist_require_game_id=True,
+    )
+    plugin._state = SimpleNamespace(
+        active_game_id="demo.alpha",
+        active_session_id="sess-a",
+        latest_snapshot={"scene_id": "scene-a", "route_id": "route-a"},
+        context_snapshot={},
+    )
+    plugin._state_lock = threading.Lock()
+    plugin._state_dirty = False
+    plugin._cached_snapshot = {"stale": True}
+    plugin._persist = _Persist()
+    plugin.logger = _Logger()
+
+    checks = 0
+    original_liveness = plugin._context_snapshot_liveness_matches
+
+    def _flip_session_after_first_check(**kwargs: object) -> bool:
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            plugin._state.active_session_id = "sess-b"
+        return original_liveness(**kwargs)  # type: ignore[arg-type]
+
+    plugin._context_snapshot_liveness_matches = _flip_session_after_first_check  # type: ignore[method-assign]
+
+    plugin._persist_context_snapshot_from_summary(
+        {
+            "game_id": "demo.alpha",
+            "session_id": "sess-a",
+            "scene_id": "scene-a",
+            "route_id": "route-a",
+            "stable_lines": [{"line_id": "line-1"}],
+        },
+        {"summary": "stale during write"},
+    )
+
+    assert checks == 2
+    assert saved == []
+    assert plugin._state.context_snapshot == {}
+    assert plugin._state_dirty is False
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_bridge.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge.py
@@ -8977,6 +8977,58 @@ def test_game_llm_agent_reply_context_choices_follow_recent_line_window(
 
 
 @pytest.mark.plugin_unit
+def test_game_llm_agent_reply_context_keeps_condensed_count_for_internal_line_counts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(plugin_dir, _make_effective_config(bridge_root))
+    plugin = GalgameBridgePlugin(ctx)
+    agent = GameLLMAgent(
+        plugin=plugin,
+        logger=_Logger(),
+        llm_gateway=_FakeLLMGateway(),
+        host_adapter=_FakeHostAdapter(),
+    )
+    monkeypatch.setattr(
+        game_llm_agent_module,
+        "_compute_dynamic_line_limit",
+        lambda *args, **kwargs: 2,
+    )
+    shared = _shared_state(
+        snapshot=_session_state(scene_id="scene-a", line_id="line-current"),
+        history_lines=[
+            {
+                "speaker": "雪乃",
+                "text": "第一句\n第二句\n第三句",
+                "line_id": "s1",
+                "scene_id": "scene-a",
+                "_condensed_line_ids": ["s1", "s2", "s3"],
+                "_condensed_count": 3,
+            }
+        ],
+        history_observed_lines=[
+            {
+                "speaker": "雪乃",
+                "text": "候选一句\n候选二句",
+                "line_id": "o1",
+                "scene_id": "scene-a",
+                "_condensed_line_ids": ["o1", "o2"],
+                "_condensed_count": 2,
+            }
+        ],
+    )
+
+    public_context = agent._build_agent_reply_context(shared, prompt="status")["public_context"]
+
+    assert public_context["stable_lines"][0]["_condensed_count"] == 3
+    assert public_context["observed_lines"][0]["_condensed_count"] == 2
+    assert game_llm_agent_module._context_line_count(public_context["stable_lines"]) == 3
+    assert all("_condensed_count" not in line for line in public_context["recent_lines"])
+    assert all("_condensed_line_ids" not in line for line in public_context["recent_lines"])
+
+
+@pytest.mark.plugin_unit
 def test_game_llm_agent_reply_context_keeps_recent_line_when_limit_is_one(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -11088,6 +11140,76 @@ async def test_game_llm_agent_pushes_scene_summary_after_eight_lines(
     assert status["scene_summary_line_interval"] == 8
     assert status["debug"]["summary"]["last_delivered_summary_key"] == "scene-a:0:8"
     assert status["debug"]["summary"]["pending_summary_task_count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_game_llm_agent_scene_summary_counts_condensed_stable_lines(
+    tmp_path: Path,
+) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(plugin_dir, _make_effective_config(bridge_root))
+    plugin = GalgameBridgePlugin(ctx)
+    agent = GameLLMAgent(
+        plugin=plugin,
+        logger=_Logger(),
+        llm_gateway=_FakeLLMGateway(),
+        host_adapter=_FakeHostAdapter(),
+    )
+    shared = _shared_state(
+        mode="companion",
+        snapshot=_session_state(
+            speaker="雪乃",
+            text="第 8 句台词。",
+            scene_id="scene-a",
+            line_id="line-8",
+            ts="2026-04-21T08:33:08Z",
+        ),
+    )
+    agent._runtime_loop = asyncio.get_running_loop()
+    agent._op_lock = asyncio.Lock()
+    agent._observed_session_id = str(shared["active_session_id"])
+    agent._observed_scene_id = "scene-a"
+    agent._schedule_scene_summary_task(
+        shared=shared,
+        session_id=str(shared["active_session_id"]),
+        scene_id="scene-a",
+        route_id="",
+        snapshot=dict(shared["latest_snapshot"]),
+        context={
+            "scene_id": "scene-a",
+            "route_id": "",
+            "stable_lines": [
+                {
+                    "line_id": "line-1",
+                    "speaker": "雪乃",
+                    "text": "\n".join(f"第 {index} 句台词。" for index in range(1, 9)),
+                    "scene_id": "scene-a",
+                    "route_id": "",
+                    "ts": "2026-04-21T08:33:08Z",
+                    "_condensed_line_ids": [f"line-{index}" for index in range(1, 9)],
+                    "_condensed_count": 8,
+                }
+            ],
+            "observed_lines": [],
+            "recent_choices": [],
+        },
+        trigger="line_count",
+        metadata={
+            "context_type": "galgame_scene_context",
+            "trigger": "line_count",
+            "scheduled_from_event_seq": 0,
+            "last_line_seq": 0,
+        },
+        update_scene_memory=False,
+        scheduled_line_count=8,
+    )
+    await _drain_agent_summary_tasks(agent)
+
+    assert ctx.pushed_messages[-1]["metadata"]["kind"] == "scene_summary"
+    assert ctx.pushed_messages[-1]["metadata"]["trigger"] == "line_count"
+    assert ctx.pushed_messages[-1]["metadata"]["stable_line_count"] == 8
+    assert ctx.pushed_messages[-1]["metadata"]["summary_delivery_key"] == "scene-a:0:8"
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_bridge.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge.py
@@ -6993,13 +6993,13 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
             session_id=session_id,
             last_seq=2,
             state=_session_state(
-                speaker="é›ªä¹ƒ",
-                text="è¿™æ˜¯ OCR è¯»å–æ¥çš„å°è¯ã€‚",
+                speaker="雪乃",
+                text="这是 OCR 读取来的台词。",
                 scene_id="ocr:scene-a",
                 line_id="ocr:line-1",
                 choices=[
-                    {"choice_id": "ocr:line-1#choice0", "text": "åŽ»æ•™å®¤", "index": 0, "enabled": True},
-                    {"choice_id": "ocr:line-1#choice1", "text": "åŽ»å¤©å°", "index": 1, "enabled": True},
+                    {"choice_id": "ocr:line-1#choice0", "text": "去教室", "index": 0, "enabled": True},
+                    {"choice_id": "ocr:line-1#choice1", "text": "去天台", "index": 1, "enabled": True},
                 ],
                 is_menu_open=True,
                 ts="2026-04-21T08:31:00Z",
@@ -7012,8 +7012,8 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
                 session_id=session_id,
                 game_id=game_id,
                 payload={
-                    "speaker": "é›ªä¹ƒ",
-                    "text": "è¿™æ˜¯ OCR è¯»å–æ¥çš„å°è¯ã€‚",
+                    "speaker": "雪乃",
+                    "text": "这是 OCR 读取来的台词。",
                     "line_id": "ocr:line-1",
                     "scene_id": "ocr:scene-a",
                     "route_id": "",
@@ -7030,8 +7030,8 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
                     "scene_id": "ocr:scene-a",
                     "route_id": "",
                     "choices": [
-                        {"choice_id": "ocr:line-1#choice0", "text": "åŽ»æ•™å®¤", "index": 0, "enabled": True},
-                        {"choice_id": "ocr:line-1#choice1", "text": "åŽ»å¤©å°", "index": 1, "enabled": True},
+                        {"choice_id": "ocr:line-1#choice0", "text": "去教室", "index": 0, "enabled": True},
+                        {"choice_id": "ocr:line-1#choice1", "text": "去天台", "index": 1, "enabled": True},
                     ],
                 },
                 ts="2026-04-21T08:31:01Z",
@@ -7052,11 +7052,11 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
         params = kwargs.get("params") or {}
         operation = params.get("operation")
         if operation == "explain_line":
-            return {"explanation": "è¿™æ˜¯å¯¹ OCR å°è¯çš„è§£é‡Šã€‚", "evidence": []}
+            return {"explanation": "这是对 OCR 台词的解释。", "evidence": []}
         if operation == "summarize_scene":
             return {
-                "summary": "è¿™æ˜¯å¯¹ OCR åœºæ™¯çš„æ€»ç»“ã€‚",
-                "key_points": [{"type": "plot", "text": "OCR ä¸»çº¿å¯ç”¨ã€‚"}],
+                "summary": "这是对 OCR 场景的总结。",
+                "key_points": [{"type": "plot", "text": "OCR 主线可用。"}],
             }
         if operation == "suggest_choice":
             context = params.get("context") or {}
@@ -7067,7 +7067,7 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
                         "choice_id": visible_choices[0]["choice_id"],
                         "text": visible_choices[0]["text"],
                         "rank": 1,
-                        "reason": "OCR ä¸‹ä¼˜å…ˆç»§ç»­ä¸»çº¿ã€‚",
+                        "reason": "OCR 下优先继续主线。",
                     }
                 ]
             }
@@ -7117,7 +7117,7 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
     assert explain.value["semantic_degraded"] is True
     assert explain.value["fallback_used"] is False
     assert "ocr_reader_input" in explain.value["diagnostic"]
-    assert explain.value["explanation"] == "è¿™æ˜¯å¯¹ OCR å°è¯çš„è§£é‡Šã€‚"
+    assert explain.value["explanation"] == "这是对 OCR 台词的解释。"
 
     assert isinstance(summarize, Ok)
     assert summarize.value["degraded"] is True
@@ -7125,7 +7125,7 @@ async def test_phase2_entries_mark_ocr_reader_input_as_degraded_even_when_llm_su
     assert summarize.value["semantic_degraded"] is True
     assert summarize.value["fallback_used"] is False
     assert "ocr_reader_input" in summarize.value["diagnostic"]
-    assert summarize.value["summary"] == "è¿™æ˜¯å¯¹ OCR åœºæ™¯çš„æ€»ç»“ã€‚"
+    assert summarize.value["summary"] == "这是对 OCR 场景的总结。"
 
     assert isinstance(suggest, Ok)
     assert suggest.value["degraded"] is True
@@ -8734,10 +8734,16 @@ def test_game_llm_agent_reply_context_uses_dynamic_window_config(tmp_path: Path)
     context = agent._build_agent_reply_context(shared, prompt="status")
     public_context = context["public_context"]
 
-    assert public_context["stable_lines"] == []
-    assert [line["line_id"] for line in public_context["observed_lines"]] == ["o3", "o4", "o5"]
-    assert [line["line_id"] for line in public_context["recent_lines"]] == ["o3", "o4", "o5"]
-    assert len(public_context["recent_lines"]) == 3
+    assert [line["line_id"] for line in public_context["stable_lines"]] == [
+        f"s{index}" for index in range(6)
+    ]
+    assert [line["line_id"] for line in public_context["observed_lines"]] == [
+        f"o{index}" for index in range(6)
+    ]
+    assert [line["line_id"] for line in public_context["recent_lines"]] == [
+        *[f"s{index}" for index in range(6)],
+        *[f"o{index}" for index in range(6)],
+    ]
 
 
 @pytest.mark.plugin_unit
@@ -11102,8 +11108,8 @@ async def test_game_llm_agent_delivers_line_count_summary_after_scene_change(
     lines = [
         {
             "line_id": f"line-{index}",
-            "speaker": "é›ªä¹ƒ",
-            "text": f"ç¬¬ {index} å¥å°è¯ã€‚",
+            "speaker": "雪乃",
+            "text": f"第 {index} 句台词。",
             "scene_id": "scene-a",
             "route_id": "",
             "ts": f"2026-04-21T08:33:{index:02d}Z",
@@ -11113,8 +11119,8 @@ async def test_game_llm_agent_delivers_line_count_summary_after_scene_change(
     shared_scene_a = _shared_state(
         mode="companion",
         snapshot=_session_state(
-            speaker="é›ªä¹ƒ",
-            text="ç¬¬ 8 å¥å°è¯ã€‚",
+            speaker="雪乃",
+            text="第 8 句台词。",
             scene_id="scene-a",
             line_id="line-8",
             ts="2026-04-21T08:33:08Z",
@@ -11125,8 +11131,8 @@ async def test_game_llm_agent_delivers_line_count_summary_after_scene_change(
         mode="companion",
         push_notifications=False,
         snapshot=_session_state(
-            speaker="é›ªä¹ƒ",
-            text="ä¸‹ä¸€å¹•ã€‚",
+            speaker="雪乃",
+            text="下一幕。",
             scene_id="scene-b",
             line_id="line-9",
             ts="2026-04-21T08:34:00Z",
@@ -11134,8 +11140,8 @@ async def test_game_llm_agent_delivers_line_count_summary_after_scene_change(
         history_lines=[
             {
                 "line_id": "line-9",
-                "speaker": "é›ªä¹ƒ",
-                "text": "ä¸‹ä¸€å¹•ã€‚",
+                "speaker": "雪乃",
+                "text": "下一幕。",
                 "scene_id": "scene-b",
                 "route_id": "",
                 "ts": "2026-04-21T08:34:00Z",

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -890,32 +890,6 @@ def test_summarize_context_does_not_reuse_persisted_seed_across_game_or_route() 
     assert "旧游戏旧路线摘要" not in result["scene_summary_seed"]
 
 
-def test_summarize_context_uses_restored_seed_when_history_is_empty() -> None:
-    result = context_builder.build_summarize_context(
-        {
-            "active_game_id": "demo.alpha",
-            "latest_snapshot": {"scene_id": "scene-a", "route_id": "route-a"},
-            "history_lines": [],
-            "history_observed_lines": [],
-            "history_choices": [],
-            "context_snapshot": {
-                "game_id": "demo.alpha",
-                "scene_id": "scene-a",
-                "route_id": "route-a",
-                "summary_seed": "雪乃已经决定继续调查旧校舍。",
-                "stable_line_ids": ["line-1", "line-2"],
-            },
-        },
-        scene_id="scene-a",
-    )
-
-    assert result["scene_id"] == "scene-a"
-    assert result["route_id"] == "route-a"
-    assert result["stable_lines"] == []
-    assert "雪乃已经决定继续调查旧校舍。" in result["scene_summary_seed"]
-    assert "Restored stable line ids: line-1, line-2." in result["scene_summary_seed"]
-
-
 def test_summarize_context_keeps_live_route_when_restored_scene_differs() -> None:
     result = context_builder.build_summarize_context(
         {

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -374,6 +374,16 @@ def test_context_window_bounds_default_respects_small_configured_maximum() -> No
     assert context_builder._context_window_bounds(config) == (2, 3, 64)
 
 
+def test_context_window_bounds_min_floor_raises_minimum_and_maximum() -> None:
+    config = GalgameLLMConfig(
+        context_explain_min_lines=2,
+        context_explain_max_lines=3,
+        context_window_target_tokens=64,
+    )
+
+    assert context_builder._context_window_bounds(config, min_floor=16) == (16, 16, 64)
+
+
 def test_summarize_context_respects_small_configured_maximum() -> None:
     lines = [
         {
@@ -452,7 +462,6 @@ def test_summarize_context_applies_line_limit_across_all_dialogue_streams() -> N
         "observed-4",
         "observed-5",
     ]
-
 
 def test_suggest_context_applies_line_limit_across_all_dialogue_streams() -> None:
     stable_lines = [
@@ -540,6 +549,43 @@ def test_explain_context_applies_line_limit_across_all_dialogue_streams() -> Non
 
     assert len(result["recent_lines"]) == 4
     assert len(result["stable_lines"]) + len(result["observed_lines"]) == 4
+
+
+def test_explain_context_exposes_matching_restored_snapshot() -> None:
+    result = context_builder.build_explain_context(
+        {
+            "active_game_id": "demo.alpha",
+            "latest_snapshot": {
+                "scene_id": "scene-a",
+                "route_id": "route-a",
+                "line_id": "line-1",
+                "speaker": "A",
+                "text": "current line.",
+            },
+            "history_lines": [
+                {
+                    "scene_id": "scene-a",
+                    "route_id": "route-a",
+                    "line_id": "line-1",
+                    "speaker": "A",
+                    "text": "current line.",
+                }
+            ],
+            "history_observed_lines": [],
+            "history_choices": [],
+            "context_snapshot": {
+                "game_id": "demo.alpha",
+                "scene_id": "scene-a",
+                "route_id": "route-a",
+                "summary_seed": "restored summary",
+                "stable_line_ids": ["line-0"],
+            },
+        },
+        line_id="line-1",
+    )
+
+    assert result["restored_context_snapshot"]["summary_seed"] == "restored summary"
+    assert result["restored_context_snapshot"]["stable_line_ids"] == ["line-0"]
 
 
 def test_line_importance_score_rewards_plot_and_route_signals() -> None:

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -801,6 +801,17 @@ def test_previous_summary_accepts_context_snapshot_when_both_game_ids_missing() 
     )
 
 
+def test_matching_context_snapshot_ignores_non_dict_values() -> None:
+    assert (
+        context_builder._matching_context_snapshot(
+            {"context_snapshot": "broken"},
+            scene_id="scene-a",
+            route_id="route-a",
+        )
+        == {}
+    )
+
+
 def test_summarize_context_does_not_reuse_persisted_seed_across_game_or_route() -> None:
     config = GalgameLLMConfig(context_scene_summary_mode="cumulative_light")
     state = {
@@ -837,7 +848,7 @@ def test_summarize_context_keeps_live_route_when_restored_scene_differs() -> Non
     result = context_builder.build_summarize_context(
         {
             "active_game_id": "demo.alpha",
-            "latest_snapshot": {"scene_id": "scene-b", "route_id": "route-b"},
+            "latest_snapshot": {"scene_id": "scene-b", "route_id": "route-a"},
             "history_lines": [],
             "history_observed_lines": [],
             "history_choices": [],
@@ -852,7 +863,7 @@ def test_summarize_context_keeps_live_route_when_restored_scene_differs() -> Non
     )
 
     assert result["scene_id"] == "scene-b"
-    assert result["route_id"] == "route-b"
+    assert result["route_id"] == "route-a"
     assert "旧场景总结不应复用。" not in result["scene_summary_seed"]
 
 

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -890,6 +890,32 @@ def test_summarize_context_does_not_reuse_persisted_seed_across_game_or_route() 
     assert "旧游戏旧路线摘要" not in result["scene_summary_seed"]
 
 
+def test_summarize_context_uses_restored_seed_when_history_is_empty() -> None:
+    result = context_builder.build_summarize_context(
+        {
+            "active_game_id": "demo.alpha",
+            "latest_snapshot": {"scene_id": "scene-a", "route_id": "route-a"},
+            "history_lines": [],
+            "history_observed_lines": [],
+            "history_choices": [],
+            "context_snapshot": {
+                "game_id": "demo.alpha",
+                "scene_id": "scene-a",
+                "route_id": "route-a",
+                "summary_seed": "雪乃已经决定继续调查旧校舍。",
+                "stable_line_ids": ["line-1", "line-2"],
+            },
+        },
+        scene_id="scene-a",
+    )
+
+    assert result["scene_id"] == "scene-a"
+    assert result["route_id"] == "route-a"
+    assert result["stable_lines"] == []
+    assert "雪乃已经决定继续调查旧校舍。" in result["scene_summary_seed"]
+    assert "Restored stable line ids: line-1, line-2." in result["scene_summary_seed"]
+
+
 def test_summarize_context_keeps_live_route_when_restored_scene_differs() -> None:
     result = context_builder.build_summarize_context(
         {

--- a/plugin/tests/unit/plugins/test_galgame_context_metrics.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_metrics.py
@@ -12,6 +12,7 @@ from plugin.plugins.galgame_plugin.context_metrics import (
 from plugin.plugins.galgame_plugin.llm_backend import GalgameLLMBackend
 from plugin.plugins.galgame_plugin import llm_gateway as llm_gateway_module
 from plugin.plugins.galgame_plugin.llm_gateway import LLMGateway
+from plugin.plugins.galgame_plugin.llm_prompts import build_prompt_messages_with_metadata
 
 
 class _Backend:
@@ -68,12 +69,48 @@ class _ConfigAwareBackend:
         return {}
 
 
-class _RealPromptBackend(GalgameLLMBackend):
-    async def _call_model(self, *, operation: str, messages):
-        self.last_messages = messages
+class _SemanticCompressionAwareBackend:
+    def __init__(self, config: SimpleNamespace) -> None:
+        self._config = config
+        self.calls = 0
+
+    async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
+        del context
+        self.calls += 1
+        assert operation == "summarize_scene"
+        return {
+            "summary": f"semantic:{bool(self._config.context_semantic_compression)}",
+            "key_points": [],
+        }
+
+    async def shutdown(self) -> None:
+        return None
+
+    def consume_prompt_metadata(self) -> dict[str, Any]:
+        return {}
+
+
+class _RealPromptBackend:
+    def __init__(self, config: SimpleNamespace) -> None:
+        self._config = config
+        self._prompt_metadata: dict[str, Any] = {}
+        self.last_messages: list[dict[str, str]] = []
+
+    async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
         assert operation == "agent_reply"
-        assert "context:" in messages[-1]["content"]
-        return '{"reply": "ok"}'
+        prompt = build_prompt_messages_with_metadata(operation, context, self._config)
+        self.last_messages = prompt.messages
+        self._prompt_metadata = dict(prompt.metadata)
+        assert "context:" in self.last_messages[-1]["content"]
+        return {"reply": "ok"}
+
+    async def shutdown(self) -> None:
+        return None
+
+    def consume_prompt_metadata(self) -> dict[str, Any]:
+        metadata = dict(self._prompt_metadata)
+        self._prompt_metadata.clear()
+        return metadata
 
 
 def _config(**overrides: Any) -> SimpleNamespace:
@@ -84,6 +121,7 @@ def _config(**overrides: Any) -> SimpleNamespace:
         "llm_request_cache_ttl_seconds": 0.0,
         "llm_scene_summary_cache_ttl_seconds": 0.0,
         "context_metrics_enabled": False,
+        "context_semantic_compression": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -294,8 +332,43 @@ async def test_llm_gateway_cache_is_scoped_to_prompt_budget_config() -> None:
 
 
 @pytest.mark.asyncio
+async def test_llm_gateway_cache_is_scoped_to_semantic_compression_config() -> None:
+    config = _config(
+        context_semantic_compression=False,
+        llm_request_cache_ttl_seconds=60.0,
+        llm_scene_summary_cache_ttl_seconds=60.0,
+    )
+    backend = _SemanticCompressionAwareBackend(config)
+    gateway = LLMGateway(None, None, config, backend=backend)
+    context = {"scene_id": "scene-a", "recent_lines": [{"text": "same input"}]}
+
+    first = await gateway.summarize_scene(context)
+    cached = await gateway.summarize_scene(context)
+    assert first["summary"] == "semantic:False"
+    assert cached["summary"] == "semantic:False"
+    assert backend.calls == 1
+
+    next_config = _config(
+        context_semantic_compression=True,
+        llm_request_cache_ttl_seconds=60.0,
+        llm_scene_summary_cache_ttl_seconds=60.0,
+    )
+    gateway.update_config(next_config)
+
+    after_update = await gateway.summarize_scene(context)
+
+    assert after_update["summary"] == "semantic:True"
+    assert backend.calls == 2
+
+
+@pytest.mark.asyncio
 async def test_llm_gateway_records_real_prompt_metadata_end_to_end() -> None:
-    backend = _RealPromptBackend(logger=None, config=_config(context_metrics_enabled=True))
+    backend_config = _config(
+        context_metrics_enabled=True,
+        context_counting_mode="token",
+        context_max_tokens=1000,
+    )
+    backend = _RealPromptBackend(backend_config)
     gateway = LLMGateway(
         None,
         None,

--- a/plugin/tests/unit/plugins/test_galgame_service.py
+++ b/plugin/tests/unit/plugins/test_galgame_service.py
@@ -269,6 +269,7 @@ def test_context_builder_forwards_context_builders_without_behavior_change(
     summarize_result = {"sentinel": "summarize"}
     explain_result = {"sentinel": "explain"}
     suggest_result = {"sentinel": "suggest"}
+    config_sentinel = object()
     calls: dict[str, object] = {}
 
     def fake_build_summarize_context(
@@ -318,13 +319,23 @@ def test_context_builder_forwards_context_builders_without_behavior_change(
         local_state,
         scene_id="ocr:game:scene-0001",
         merge_from_scene_ids=merge_from_scene_ids,
+        config=config_sentinel,
     ) is summarize_result
-    assert build_explain_context(local_state, line_id="ocr:line-stable") is explain_result
-    assert build_suggest_context(local_state) is suggest_result
+    assert build_explain_context(
+        local_state,
+        line_id="ocr:line-stable",
+        config=config_sentinel,
+    ) is explain_result
+    assert build_suggest_context(local_state, config=config_sentinel) is suggest_result
     assert calls == {
-        "summarize": (local_state, "ocr:game:scene-0001", merge_from_scene_ids, None),
-        "explain": (local_state, "ocr:line-stable", None),
-        "suggest": (local_state, None),
+        "summarize": (
+            local_state,
+            "ocr:game:scene-0001",
+            merge_from_scene_ids,
+            config_sentinel,
+        ),
+        "explain": (local_state, "ocr:line-stable", config_sentinel),
+        "suggest": (local_state, config_sentinel),
     }
 
 


### PR DESCRIPTION
## 概要

  - 为 galgame 插件添加上下文快照持久化，支持插件重启后恢复场景/上下文状态。
  - 添加可配置、动态的 LLM 上下文窗口限制，并按时间新近度组织对话上下文。
  - 改进 galgame 上下文压缩容错：压缩失败时降级使用未压缩上下文，避免整体 prompt 构建失败。
  - 为 RapidOCR 模型下载和语言切换补充 6 个 locale 的 i18n 文案。
  - 修复 galgame public surface 中 `bound_game_id` fallback 和缺失 entry 的回归。

  ## 说明

  - 当前分支已经没有额外混入的 galgame test 优化修改。
  - test 优化相关改动已移到 `codex/galgame-test-optimization` 分支。

  ## 测试

  - 分支清理后未重新跑完整测试。
  - 在移出 test 优化改动前，galgame 相关验证通过：
    - `uv run pytest plugin/tests/unit/plugins -k galgame -q`
    - `uv run pytest plugin/tests/unit/plugins plugin/tests/integration -k galgame --durations=20 -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 动态上下文窗口与快照恢复：在会话中暴露已恢复的场景摘要快照以提升连贯性

* **改进**
  * 场景摘要触发使用兼容凝缩计数的稳健行数口径
  * 缓存指纹纳入语义压缩配置，缓存范围更精确
  * 元数据剥离统一移除所有凝缩前缀字段
  * 上下文构建接口支持传入配置参数以增强可控性

* **测试**
  * 扩展/新增单元测试，覆盖动态窗口、快照恢复、语义压缩与缓存行为

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1349)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->