### PR TITLE
refactor(memory): outbox extract-facts 符号重命名为 post-turn-signals (#1346 follow-up)

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -27,7 +27,7 @@ from memory.event_log import (
     EVIDENCE_SOURCE_MIGRATION_SEED,
 )
 from memory.evidence_handlers import register_evidence_handlers as _register_evidence_handlers
-from memory.outbox import Outbox, OP_EXTRACT_FACTS
+from memory.outbox import Outbox, OP_POST_TURN_SIGNALS
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import PlainTextResponse, JSONResponse
 import json
@@ -617,16 +617,18 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
             sem.release()
 
 
-async def _spawn_outbox_extract_facts(lanlan_name: str, messages: list) -> asyncio.Task:
-    """把 extract_facts+feedback 背景任务登记到 outbox 并 spawn。
+async def _spawn_outbox_post_turn_signals(lanlan_name: str, messages: list) -> asyncio.Task:
+    """把 per-turn signals 背景任务登记到 outbox 并 spawn。
 
+    "per-turn signals" = counter bump（给 batch loop 计数）+ 复读嗅探 +
+    check_feedback + OFF-mode Stage-1 fallback，见 ``_run_post_turn_signals``。
     登记的 payload 包含 messages_to_dict 序列化后的整轮对话，重启时可重放。
     """
     from utils.llm_client import messages_to_dict
 
     payload = {'messages': messages_to_dict(messages)}
     try:
-        op_id = await outbox.aappend_pending(lanlan_name, OP_EXTRACT_FACTS, payload)
+        op_id = await outbox.aappend_pending(lanlan_name, OP_POST_TURN_SIGNALS, payload)
     except Exception as e:
         # Outbox 写失败不能阻塞主流程，降级为一次性任务（与重构前行为一致）
         logger.warning(
@@ -634,9 +636,9 @@ async def _spawn_outbox_extract_facts(lanlan_name: str, messages: list) -> async
             f"{type(e).__name__}: {e}"
         )
         return _spawn_background_task(
-            _extract_facts_and_check_feedback(messages, lanlan_name)
+            _run_post_turn_signals(messages, lanlan_name)
         )
-    op = {'op_id': op_id, 'type': OP_EXTRACT_FACTS, 'payload': payload}
+    op = {'op_id': op_id, 'type': OP_POST_TURN_SIGNALS, 'payload': payload}
     return _spawn_background_task(_run_outbox_op(lanlan_name, op))
 
 
@@ -2543,22 +2545,27 @@ async def api_record_surfaced(request: Request, lanlan_name: str):
     return {"ok": True}
 
 
-async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
-    """后台异步：counter bump + 复读嗅探 + 反馈检查。失败静默跳过。
+async def _run_post_turn_signals(messages: list, lanlan_name: str):
+    """后台异步：每轮 turn end 的 per-turn signals。失败静默跳过。
 
-    认知框架：Facts → Reflection(pending→confirmed→promoted) → Persona
-    memory-evidence-rfc 接入点：
-      - 每轮 tick 给 signal-extraction loop 的 turn counter +1
-      - check_feedback 的 confirmed/denied/ignored 三值分别派 evidence 信号
-      - 如果 user message 命中 NEGATIVE_KEYWORDS，触发快速 LLM target check
+    职责（按 step 顺序）：
+      0. counter bump —— 给 ``_periodic_signal_extraction_loop`` 的 turn
+         counter +1，让 batch loop 在累积 10 turn 时触发 Stage-1+Stage-2
+      1. OFF-mode Stage-1 fallback —— powerful_memory 关闭时 batch loop 整段
+         停，per-turn ``fact_store.extract_facts`` 是 fact extraction 唯一
+         兜底（ON-mode 不跑，交给 batch loop）
+      2. 复读嗅探 —— 本地 BM25，§2.6 5h 窗口 suppress
+      3. check_feedback —— 用户对 surfaced reflection 的反馈检测（LLM 仅在
+         surfaced 有 pending 时跑）+ NEGATIVE_KEYWORDS 命中触发 LLM target check
 
-    历史 — 函数名带 ``extract_facts`` 是 PR-1 (RFC #928) 引入时的命名，
-    当时 step 1 还跑 ``fact_store.extract_facts`` (Stage-1) 兼容 legacy
-    "每轮抽 fact" 体验。RFC §3.4.3 标题原话："**不**在对话主路径上每轮
-    运行 extract_facts——太贵。改为背景调度"，因此 Stage-1+Stage-2 batch
-    抽取从一开始就有专职 background loop ``_periodic_signal_extraction_loop``
-    负责，per-turn 这条本来就是过渡期 legacy。step 1 已于本次 commit
-    迁完，函数名留作历史以减少 outbox handler 注册路径的重命名波及。
+    命名史 — 本函数 PR-1 (RFC #928) 引入时叫 ``_extract_facts_and_check_feedback``，
+    当时 step 1 还是无条件每轮跑 ``fact_store.extract_facts`` (Stage-1)。
+    RFC §3.4.3 原话："**不**在对话主路径上每轮运行 extract_facts——太贵。
+    改为背景调度"——PR #1346 把 ON-mode Stage-1 剥离到
+    ``_periodic_signal_extraction_loop``，step 1 退化为 OFF-mode fallback，
+    本 follow-up 把符号名（含 outbox spawn helper / handler / op 常量）统一
+    改成 ``post_turn_signals`` 以匹配实际语义。``OP_POST_TURN_SIGNALS`` 的
+    **字符串值**仍是 ``"extract_facts"``（outbox.ndjson wire-format 不可变）。
     """
     user_msgs = _extract_user_messages(messages)
 
@@ -2708,12 +2715,13 @@ async def _extract_facts_and_check_feedback(messages: list, lanlan_name: str):
             logger.warning(f"[MemoryServer] 矛盾审视失败: {e}")
 
 
-async def _outbox_extract_facts_handler(lanlan_name: str, payload: dict) -> None:
-    """OP_EXTRACT_FACTS 的 outbox handler：从 payload 还原 messages 再跑常规流程。
+async def _outbox_post_turn_signals_handler(lanlan_name: str, payload: dict) -> None:
+    """OP_POST_TURN_SIGNALS 的 outbox handler：从 payload 还原 messages 再跑
+    ``_run_post_turn_signals``。
 
     幂等性来源：
-      - fact_store.extract_facts 内部靠 SHA-256 对事实去重，重复提取不会
-        产生重复 fact。
+      - fact_store.extract_facts（OFF-mode fallback）内部靠 SHA-256 对事实
+        去重，重复提取不会产生重复 fact。
       - arecord_mentions 是单调累加计数，重放会小幅抬高提及次数（可接受的
         at-least-once 语义）。
       - check_feedback 下次自然回补——reflection 的 surfaced/feedback
@@ -2728,10 +2736,10 @@ async def _outbox_extract_facts_handler(lanlan_name: str, payload: dict) -> None
     messages = messages_from_dict(raw)
     if not messages:
         return
-    await _extract_facts_and_check_feedback(messages, lanlan_name)
+    await _run_post_turn_signals(messages, lanlan_name)
 
 
-register_outbox_handler(OP_EXTRACT_FACTS, _outbox_extract_facts_handler)
+register_outbox_handler(OP_POST_TURN_SIGNALS, _outbox_post_turn_signals_handler)
 
 
 @app.post("/cache/{lanlan_name}")
@@ -2757,7 +2765,7 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
     "短期行为不变"暂留的 Stage-1 per-turn fact_extract（``legacy flow``）
     一并迁完——RFC 原本就计划只让 ``_periodic_signal_extraction_loop`` 跑
     fact extraction。``astore_conversation`` 是 SQLite INSERT（~ms 量级），
-    ``_spawn_outbox_extract_facts`` 现内部只跑 counter bump + 本地复读嗅探
+    ``_spawn_outbox_post_turn_signals`` 现内部只跑 counter bump + 本地复读嗅探
     + check_feedback（LLM 仅在 surfaced 有 pending 时才跑），是 ndjson
     append + spawn background task（不阻塞响应）。``cache`` 保持"前台无
     LLM 延迟"的轻量语义，**且比 PR-1 实现更轻**——单 turn fact_extract
@@ -2780,7 +2788,7 @@ async def cache_conversation(request: HistoryRequest, lanlan_name: str):
             await time_manager.astore_conversation(uid, input_history, lanlan_name)
         # outbox 登记走锁外——它会 spawn background task 跑 LLM，长持锁会
         # 阻塞下一轮 /cache 写盘。
-        await _spawn_outbox_extract_facts(lanlan_name, input_history)
+        await _spawn_outbox_post_turn_signals(lanlan_name, input_history)
         return {"status": "cached", "count": len(input_history)}
     except Exception as e:
         logger.error(f"[MemoryServer] cache 失败: {e}", exc_info=True)
@@ -2820,7 +2828,7 @@ async def process_conversation(request: HistoryRequest, lanlan_name: str):
         await time_manager.astore_conversation(uid, input_history, lanlan_name)
 
         # 异步事实提取（不阻塞返回，失败静默跳过）
-        await _spawn_outbox_extract_facts(lanlan_name, input_history)
+        await _spawn_outbox_post_turn_signals(lanlan_name, input_history)
 
         # Phase C: 不再 cancel-and-restart review；让 maybe_spawn_review 在新消息
         # 门 + min_interval + in-flight 多重 gate 后决定起或不起。在跑的 review
@@ -2863,7 +2871,7 @@ async def process_conversation_for_renew(request: HistoryRequest, lanlan_name: s
 
         # 以下操作在锁外执行，不阻塞 /new_dialog
         # 异步事实提取
-        await _spawn_outbox_extract_facts(lanlan_name, input_history)
+        await _spawn_outbox_post_turn_signals(lanlan_name, input_history)
 
         # Phase C: 见 /process 的注释——不再 cancel-and-restart。
         await maybe_spawn_review(lanlan_name)
@@ -2897,7 +2905,7 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
             await recent_history_manager.update_history([], lanlan_name, detailed=True)
 
         if input_history:
-            await _spawn_outbox_extract_facts(lanlan_name, input_history)
+            await _spawn_outbox_post_turn_signals(lanlan_name, input_history)
 
         # Phase C: 见 /process 的注释——不再 cancel-and-restart。
         await maybe_spawn_review(lanlan_name)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6385,7 +6385,7 @@ async def proactive_chat(request: Request):
                 print(f"[{lanlan_name}] 记录 surfaced 反思: {len(_surfaced_reflection_ids)} 条")
 
             # 记录 persona 提及次数（疲劳跟踪） — persona 文件由 memory_server 管理
-            # record_mentions 已在 memory_server 的 _extract_facts_and_check_feedback 中调用
+            # record_mentions 已在 memory_server 的 _run_post_turn_signals 中调用
         except Exception as e:
             logger.debug(f"[{lanlan_name}] 长期记忆后处理失败（不影响主流程）: {e}")
 

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -946,7 +946,7 @@ class FactStore:
         """Stage-1-only backward-compat entry.
 
         Kept for callers that predate the evidence mechanism
-        (memory_server's _extract_facts_and_check_feedback flow transitively
+        (memory_server's _run_post_turn_signals OFF-mode fallback transitively
         calls this, plus outbox replay). Emits only new facts and skips
         signal detection — downstream `_periodic_signal_extraction_loop`
         runs Stage-1+Stage-2 together.

--- a/memory/outbox.py
+++ b/memory/outbox.py
@@ -38,8 +38,16 @@ from utils.logger_config import get_module_logger
 logger = get_module_logger(__name__, "Memory")
 
 
-# op_type 常量，避免魔法字符串散落
-OP_EXTRACT_FACTS = "extract_facts"
+# op_type 常量，避免魔法字符串散落。
+#
+# 字符串值是 outbox.ndjson 里持久化的 op_type 字面值——视为不可变 wire-format
+# schema id（同数据库列名），重命名 Python 符号时**不能**改值，否则旧机器上
+# 残留的 pending op 在 replay 时 ``_OUTBOX_HANDLERS.get(op_type)`` 拿不到 handler
+# 会被静默 skip。``OP_POST_TURN_SIGNALS`` 的值仍是 ``"extract_facts"``：PR-1
+# 引入时 handler 主操作是 Stage-1 fact 抽取，PR #1346 把 Stage-1（ON-mode）剥离
+# 到 ``_periodic_signal_extraction_loop`` 后，handler 实际只做 counter bump +
+# 复读嗅探 + check_feedback + OFF-mode Stage-1 fallback——符号名随之更新，值保留。
+OP_POST_TURN_SIGNALS = "extract_facts"
 OP_SYNTH_REFLECTION = "synth_reflection"
 OP_CHECK_FEEDBACK = "check_feedback"
 OP_RESOLVE_CORRECTIONS = "resolve_corrections"

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -138,7 +138,7 @@ class PersonaManager:
         self._alocks: dict[str, asyncio.Lock] = {}
         self._alocks_guard = threading.Lock()
         # 独立的 resolve_corrections 串行锁——只为防多入口（IdleMaint subtask 2
-        # 与 _extract_facts_and_check_feedback）并发触发同名角色的 LLM 重叠
+        # 与 _run_post_turn_signals）并发触发同名角色的 LLM 重叠
         # 应用导致重复处理同一批 corrections。本锁与 _alocks (data lock)
         # 完全分开，所以 LLM 期间 aadd_fact / arecord_mentions / aapply_signal
         # 仍能正常拿 _alocks 推进（不再卡 /process 路径）。
@@ -1581,7 +1581,7 @@ class PersonaManager:
         C4 重构 + thinking：LLM 调用在 data lock 外。data lock 仅在 LLM
         前后短暂借用（load corrections / load persona + apply + save）。
         独立的 _resolve_alock 串行同名角色的 resolve_corrections 调用，
-        防多入口（IdleMaint subtask 2 与 _extract_facts_and_check_feedback）
+        防多入口（IdleMaint subtask 2 与 _run_post_turn_signals）
         并发触发同一批 corrections 被重复处理（特别是 keep_new 没有 dedup
         会导致重复 append）。
 

--- a/tests/unit/test_memory_server_cache_settle.py
+++ b/tests/unit/test_memory_server_cache_settle.py
@@ -3,7 +3,7 @@
 History — commit cba377c5 (2026-03-29 "Fix/memory hotswap timing") introduced
 the /settle endpoint to cover the "cross_server cached everything → renew
 session arrives with msgs=0" case, but only the review LLM was wired into the
-msgs=0 path. ``store_conversation`` and ``_spawn_outbox_extract_facts`` were
+msgs=0 path. ``store_conversation`` and ``_spawn_outbox_post_turn_signals`` were
 gated behind ``if input_history``, so:
 
   - ``time_indexed.db`` was never written (time perception broken — gap
@@ -60,7 +60,7 @@ async def test_cache_endpoint_writes_time_indexed_db():
 
     with patch.object(memory_server, "time_manager", fake_time_manager), \
          patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
-         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox), \
+         patch.object(memory_server, "_spawn_outbox_post_turn_signals", fake_spawn_outbox), \
          patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)):
         result = await memory_server.cache_conversation(request, "测试角色")
 
@@ -79,10 +79,11 @@ async def test_cache_endpoint_spawns_outbox_post_turn_signals():
     """/cache 端点必须登记 outbox op，让 events.ndjson / outbox.ndjson 这条
     链能动起来——op handler 跑 counter bump + 复读嗅探 + check_feedback。
 
-    注：op type 仍叫 ``OP_EXTRACT_FACTS`` 是历史命名（PR-1 引入时 handler
-    里跑过 Stage-1 fact_extract），但 Stage-1 per-turn 抽取已按 RFC §3.4.3
-    迁到 ``_periodic_signal_extraction_loop``——见
-    ``test_extract_facts_and_check_feedback_does_not_run_stage1_legacy``。
+    注：``OP_POST_TURN_SIGNALS`` 的字符串值仍是 ``"extract_facts"``——
+    outbox.ndjson wire-format 不可变（见 memory/outbox.py 注释）。Stage-1
+    per-turn 抽取已按 RFC §3.4.3 迁到 ``_periodic_signal_extraction_loop``，
+    ON-mode 不再 per-turn 跑——见
+    ``test_run_post_turn_signals_skips_stage1_when_powerful_memory_on``。
 
     Regression: 旧 cache 完全跳过 outbox，evidence-RFC 链路全空转。
     """
@@ -102,7 +103,7 @@ async def test_cache_endpoint_spawns_outbox_post_turn_signals():
 
     with patch.object(memory_server, "time_manager", fake_time_manager), \
          patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
-         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox), \
+         patch.object(memory_server, "_spawn_outbox_post_turn_signals", fake_spawn_outbox), \
          patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)):
         await memory_server.cache_conversation(request, "测试角色")
 
@@ -114,7 +115,7 @@ async def test_cache_endpoint_spawns_outbox_post_turn_signals():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_extract_facts_and_check_feedback_skips_stage1_when_powerful_memory_on():
+async def test_run_post_turn_signals_skips_stage1_when_powerful_memory_on():
     """powerful_memory ON 模式：Stage-1 per-turn fact_extract 已按 RFC §3.4.3
     迁到 ``_periodic_signal_extraction_loop`` 做 batch 抽取，per-turn 主路径
     不应再调 ``fact_store.extract_facts``。
@@ -148,7 +149,7 @@ async def test_extract_facts_and_check_feedback_skips_stage1_when_powerful_memor
          patch.object(memory_server, "reflection_engine", fake_reflection_engine), \
          patch.object(memory_server, "_signal_check_record_turn", MagicMock(return_value=None)), \
          patch.object(memory_server, "_ais_powerful_memory_enabled", AsyncMock(return_value=True)):
-        await memory_server._extract_facts_and_check_feedback(payload_messages, "测试角色")
+        await memory_server._run_post_turn_signals(payload_messages, "测试角色")
 
     # ON-mode 下 Stage-1 per-turn fact_extract 一定不能被调（交给 batch loop）
     fake_fact_store.extract_facts.assert_not_awaited()
@@ -160,7 +161,7 @@ async def test_extract_facts_and_check_feedback_skips_stage1_when_powerful_memor
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_extract_facts_and_check_feedback_keeps_stage1_when_powerful_memory_off():
+async def test_run_post_turn_signals_keeps_stage1_when_powerful_memory_off():
     """powerful_memory OFF 模式：``_periodic_signal_extraction_loop`` 整段停
     （见 ``if not powerful_enabled: continue``），per-turn Stage-1 是 fact
     extraction 的唯一兜底路径，必须保留——否则 OFF 模式用户的 facts.json
@@ -189,7 +190,7 @@ async def test_extract_facts_and_check_feedback_keeps_stage1_when_powerful_memor
          patch.object(memory_server, "reflection_engine", fake_reflection_engine), \
          patch.object(memory_server, "_signal_check_record_turn", MagicMock(return_value=None)), \
          patch.object(memory_server, "_ais_powerful_memory_enabled", AsyncMock(return_value=False)):
-        await memory_server._extract_facts_and_check_feedback(payload_messages, "测试角色")
+        await memory_server._run_post_turn_signals(payload_messages, "测试角色")
 
     # OFF-mode 下 batch loop 不跑——per-turn Stage-1 必须 fallback
     fake_fact_store.extract_facts.assert_awaited_once()
@@ -214,7 +215,7 @@ async def test_cache_endpoint_empty_payload_short_circuits():
 
     with patch.object(memory_server, "time_manager", fake_time_manager), \
          patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
-         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox):
+         patch.object(memory_server, "_spawn_outbox_post_turn_signals", fake_spawn_outbox):
         result = await memory_server.cache_conversation(request, "测试角色")
 
     assert result == {"status": "cached", "count": 0}
@@ -272,7 +273,7 @@ async def test_cache_endpoint_serialises_recent_and_store_under_settle_lock():
 
     with patch.object(memory_server, "time_manager", fake_time_manager), \
          patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
-         patch.object(memory_server, "_spawn_outbox_extract_facts", AsyncMock(side_effect=_fake_spawn)), \
+         patch.object(memory_server, "_spawn_outbox_post_turn_signals", AsyncMock(side_effect=_fake_spawn)), \
          patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)), \
          patch.object(memory_server, "_get_settle_lock", MagicMock(return_value=observable_lock)):
         await memory_server.cache_conversation(request, "测试角色")
@@ -309,7 +310,7 @@ async def test_settle_endpoint_msgs_zero_still_runs_review():
 
     with patch.object(memory_server, "time_manager", fake_time_manager), \
          patch.object(memory_server, "recent_history_manager", fake_recent_history_manager), \
-         patch.object(memory_server, "_spawn_outbox_extract_facts", fake_spawn_outbox), \
+         patch.object(memory_server, "_spawn_outbox_post_turn_signals", fake_spawn_outbox), \
          patch.object(memory_server, "_aclear_review_clean", AsyncMock(return_value=None)), \
          patch.object(memory_server, "maybe_spawn_review", fake_maybe_spawn_review):
         result = await memory_server.settle_conversation(request, "测试角色")

--- a/tests/unit/test_outbox_wiring.py
+++ b/tests/unit/test_outbox_wiring.py
@@ -3,7 +3,7 @@
 P1.c integration tests: outbox wiring inside memory_server.
 
 Verifies:
-  - _spawn_outbox_extract_facts appends a pending op, runs handler, marks done
+  - _spawn_outbox_post_turn_signals appends a pending op, runs handler, marks done
   - _replay_pending_outbox picks up unfinished ops and re-runs handler
   - Handler not executing (e.g. no registered handler) → op remains pending
 """
@@ -45,7 +45,7 @@ async def test_spawn_outbox_happy_path_marks_done(tmp_path):
     """Handler 成功完成 → outbox pending_ops 为空。"""
     ob, _ = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
-    from memory.outbox import OP_EXTRACT_FACTS
+    from memory.outbox import OP_POST_TURN_SIGNALS
 
     calls: list[tuple[str, dict]] = []
 
@@ -54,11 +54,11 @@ async def test_spawn_outbox_happy_path_marks_done(tmp_path):
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _fake_handler},
+        {OP_POST_TURN_SIGNALS: _fake_handler},
         clear=False,
     ):
         msgs = [HumanMessage(content="喵"), AIMessage(content="mrrp")]
-        task = await memory_server._spawn_outbox_extract_facts("小天", msgs)
+        task = await memory_server._spawn_outbox_post_turn_signals("小天", msgs)
         await task
 
     assert len(calls) == 1
@@ -78,24 +78,24 @@ async def test_handler_failure_keeps_op_pending(tmp_path):
     """Handler raises → op stays pending (next startup replays it)."""
     ob, _ = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
-    from memory.outbox import OP_EXTRACT_FACTS
+    from memory.outbox import OP_POST_TURN_SIGNALS
 
     async def _bad_handler(name: str, payload: dict):
         raise RuntimeError("simulated LLM crash mid-call")
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _bad_handler},
+        {OP_POST_TURN_SIGNALS: _bad_handler},
         clear=False,
     ):
-        task = await memory_server._spawn_outbox_extract_facts(
+        task = await memory_server._spawn_outbox_post_turn_signals(
             "小天", [HumanMessage(content="hi")]
         )
         await task
 
     pending = await ob.apending_ops("小天")
     assert len(pending) == 1
-    assert pending[0]["type"] == OP_EXTRACT_FACTS
+    assert pending[0]["type"] == OP_POST_TURN_SIGNALS
 
 
 @pytest.mark.asyncio
@@ -103,12 +103,12 @@ async def test_replay_reinvokes_pending_handler(tmp_path):
     """模拟进程重启场景：上一跑 outbox 里有 pending，启动 replay 应重跑 handler。"""
     ob, _ = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
-    from memory.outbox import OP_EXTRACT_FACTS
+    from memory.outbox import OP_POST_TURN_SIGNALS
     from utils.llm_client import messages_to_dict
 
     # 场景：上一跑在 append_pending 后崩溃，没跑完 handler
     payload = {"messages": messages_to_dict([HumanMessage(content="反驳：不喜欢咖啡")])}
-    await ob.aappend_pending("小天", OP_EXTRACT_FACTS, payload)
+    await ob.aappend_pending("小天", OP_POST_TURN_SIGNALS, payload)
 
     replay_calls: list[tuple[str, dict]] = []
 
@@ -117,7 +117,7 @@ async def test_replay_reinvokes_pending_handler(tmp_path):
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _replay_handler},
+        {OP_POST_TURN_SIGNALS: _replay_handler},
         clear=False,
     ):
         # _replay_pending_outbox 直接返回 spawn 的 task 列表，无需扫
@@ -158,11 +158,11 @@ async def test_replay_respects_concurrency_semaphore(tmp_path):
     """启动补跑不应无限 fan-out：_REPLAY_CONCURRENCY=4 应限制同时在飞 handler 数。"""
     ob, _ = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
-    from memory.outbox import OP_EXTRACT_FACTS
+    from memory.outbox import OP_POST_TURN_SIGNALS
 
     # 登记 10 个 pending op
     for i in range(10):
-        await ob.aappend_pending("小天", OP_EXTRACT_FACTS, {"i": i})
+        await ob.aappend_pending("小天", OP_POST_TURN_SIGNALS, {"i": i})
 
     in_flight = 0
     max_in_flight = 0
@@ -178,7 +178,7 @@ async def test_replay_respects_concurrency_semaphore(tmp_path):
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _slow_handler},
+        {OP_POST_TURN_SIGNALS: _slow_handler},
         clear=False,
     ):
         spawned = await memory_server._replay_pending_outbox()
@@ -194,10 +194,10 @@ async def test_replay_scans_disk_for_characters_not_in_config(tmp_path):
     """Codex PR#905 P2: 角色从 config 移除但 outbox 还有 pending → 必须仍补跑。"""
     ob, mock_cm = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
-    from memory.outbox import OP_EXTRACT_FACTS
+    from memory.outbox import OP_POST_TURN_SIGNALS
 
     # 登记一条 pending op（在 "小天" 的 outbox 里）
-    await ob.aappend_pending("小天", OP_EXTRACT_FACTS, {"i": 1})
+    await ob.aappend_pending("小天", OP_POST_TURN_SIGNALS, {"i": 1})
 
     # 模拟 config 被改成不再包含小天（但磁盘上的 outbox 还在）
     _empty_characters = {"猫娘": {}, "当前猫娘": None}
@@ -211,7 +211,7 @@ async def test_replay_scans_disk_for_characters_not_in_config(tmp_path):
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _handler},
+        {OP_POST_TURN_SIGNALS: _handler},
         clear=False,
     ):
         spawned = await memory_server._replay_pending_outbox()
@@ -228,7 +228,7 @@ async def test_end_to_end_kill_then_replay_persists_side_effect(tmp_path):
     新进程加载 outbox → 重跑 → side effect 最终落盘。"""
     ob, _ = _install_fresh_memory_state(str(tmp_path))
     from app import memory_server
-    from memory.outbox import OP_EXTRACT_FACTS
+    from memory.outbox import OP_POST_TURN_SIGNALS
 
     # 第一跑：handler 写"fact"到 side-effect 状态但在 append_done 前进程死
     side_effect_log: list[str] = []
@@ -239,10 +239,10 @@ async def test_end_to_end_kill_then_replay_persists_side_effect(tmp_path):
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _handler_run1},
+        {OP_POST_TURN_SIGNALS: _handler_run1},
         clear=False,
     ):
-        await ob.aappend_pending("小天", OP_EXTRACT_FACTS, {"tag": "rebuttal_msg"})
+        await ob.aappend_pending("小天", OP_POST_TURN_SIGNALS, {"tag": "rebuttal_msg"})
         # 直接触发一次 replay 模拟 "崩溃发生在第一次 replay 调用期间"
         spawned = await memory_server._replay_pending_outbox()
         await asyncio.gather(*spawned, return_exceptions=True)
@@ -260,7 +260,7 @@ async def test_end_to_end_kill_then_replay_persists_side_effect(tmp_path):
 
     with patch.dict(
         memory_server._OUTBOX_HANDLERS,
-        {OP_EXTRACT_FACTS: _handler_run2},
+        {OP_POST_TURN_SIGNALS: _handler_run2},
         clear=False,
     ):
         spawned = await memory_server._replay_pending_outbox()
@@ -284,10 +284,10 @@ async def test_append_pending_failure_falls_back_to_in_memory(tmp_path):
 
     ob.aappend_pending = _boom  # type: ignore[assignment]
 
-    # 同时 patch _extract_facts_and_check_feedback 成 noop，避免真 LLM 调用
+    # 同时 patch _run_post_turn_signals 成 noop，避免真 LLM 调用
     noop = AsyncMock(return_value=None)
-    with patch("app.memory_server._extract_facts_and_check_feedback", noop):
-        task = await memory_server._spawn_outbox_extract_facts(
+    with patch("app.memory_server._run_post_turn_signals", noop):
+        task = await memory_server._spawn_outbox_post_turn_signals(
             "小天", [HumanMessage(content="hi")]
         )
         await task


### PR DESCRIPTION
## Summary

PR #1346 的命名清理 follow-up。

#1346 把 ON-mode 的 Stage-1 fact 抽取从 per-turn 主路径剥离到 `_periodic_signal_extraction_loop` 后，per-turn outbox op 实际只做 **counter bump + 复读嗅探 + check_feedback + OFF-mode Stage-1 fallback**——但符号名还停留在 PR-1 时代的 `extract_facts` 命名，描述不准、误导后人。#1346 的 commit message 里也明说"函数名留作历史以减少 outbox handler 注册路径的重命名波及"，本 PR 把这个尾巴清掉。

## 重命名清单

| 旧名 | 新名 |
|------|------|
| `OP_EXTRACT_FACTS` | `OP_POST_TURN_SIGNALS` |
| `_spawn_outbox_extract_facts` | `_spawn_outbox_post_turn_signals` |
| `_outbox_extract_facts_handler` | `_outbox_post_turn_signals_handler` |
| `_extract_facts_and_check_feedback` | `_run_post_turn_signals` |

两个测试函数 `test_extract_facts_and_check_feedback_*` 随之改名为 `test_run_post_turn_signals_*`。

## 关键约束：`OP_POST_TURN_SIGNALS` 的字符串值**不变**

```python
OP_POST_TURN_SIGNALS = "extract_facts"  # ← 值保留
```

`"extract_facts"` 是 `outbox.ndjson` 里持久化的 op_type **字面值**，是不可变的 wire-format schema id（类比数据库列名）。如果改值：旧机器上重启前残留的 pending op（`type: "extract_facts"`）在 replay 时 `_OUTBOX_HANDLERS.get(op_type)` 会拿不到 handler → 被静默 skip。

所以**只重命名 Python 符号，字符串值保留 `"extract_facts"`**，并在 `memory/outbox.py` 加注释固化这层约束。这也意味着本 PR 对线上已有 outbox 数据**零兼容风险**——纯符号重命名，wire format 不动。

## 改动范围

- `memory/outbox.py` — 常量重命名 + wire-format 约束注释
- `app/memory_server.py` — spawn helper / handler / 函数 / import / 4 个调用点；**命名史注释保留旧名字**（讲述改名前历史）
- `memory/facts.py` / `memory/persona.py` / `main_routers/system_router.py` — 源码注释里的旧函数名引用同步更新
- `tests/unit/test_memory_server_cache_settle.py` / `tests/unit/test_outbox_wiring.py` — 测试引用 + 测试函数名同步更新

## Test plan

- [x] `test_outbox_wiring.py` + `test_memory_server_cache_settle.py` 15 个 case 全过
- [x] 广义扫描 536 个 memory / outbox / persona / facts / reflection / cloudsave / timeindex 相关 case 全过（唯一 pre-existing fail `test_main_server_manual_startup_performs_fallback_import_and_continues_boot` 跟本机 env 路径相关，#1346 那轮已确认与代码无关，纯符号重命名不可能引入 startup fail）
- [x] `grep -rn "OP_EXTRACT_FACTS\|_spawn_outbox_extract_facts\|_outbox_extract_facts_handler\|_extract_facts_and_check_feedback"` 全仓只剩命名史注释一处（特意保留）

## Refs

- PR #1346 `fix(memory): 修三处 silent-write-loss bug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **重构与优化**
  * 优化内存系统后台处理流程架构，提升记忆维护的可靠性和一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1353)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->