### PR TITLE
feat(proactive): 口吻引导改多角度菜单，降低 LLM 过早 PASS 倾向

### DIFF
--- a/config/prompts/prompts_activity.py
+++ b/config/prompts/prompts_activity.py
@@ -474,81 +474,293 @@ ACTIVITY_STATE_LABELS: dict[str, dict[str, str]] = {
 }
 
 
-# ── Tone hints (single-line style modifier) ─────────────────────────
+# ── Tone hints (multi-angle direction menu) ─────────────────────────
 #
 # Tone is orthogonal to propensity: propensity decides *what kind of
 # source* the AI may draw from, tone decides *how to deliver it*. The
-# Phase 2 prompt renders tone as one extra line:
+# Phase 2 prompt renders tone as a short bullet menu, e.g.:
 #
-#     口吻：短句优先，不延展话题，避免动作描写
+#     口吻:
+#     - 反射式实况反应：跟着当下操作节奏即时短回应，看见什么反应什么
+#     - 起哄吐槽：拉开距离调侃用户当下的走位/选择/抉择，嘴贱但别戳痛处
+#     - 短战术建议：基于眼前局面递一句短建议，要符合用户在玩的这款游戏
 #
-# Tones and when they fire (see ``derive_tone`` in
-# ``main_logic/activity/snapshot.py`` for the full table):
+# Each bullet is a *direction* (what to do), NEVER a *line* (what
+# to say). No literal phrasing — neither sample words like
+# "稳/神/clutch/うまっ" nor sample sentences in quotes. The model
+# must ground every reply in the live context (current screen,
+# recent dialogue, user mood) and generate fresh wording each time.
 #
-#   * ``terse``   — competitive games, rhythm games
-#   * ``hushed``  — immersive horror games
-#   * ``mellow``  — immersive RPG / story-driven games
-#   * ``playful`` — casual gaming, casual_browsing
-#   * ``warm``    — voice / chatting / stale_returning
-#   * ``concise`` — focused_work / idle / default (rendered nothing —
-#                   format_activity_state_section skips when concise to
-#                   save a line in the common case)
-ACTIVITY_TONE_HINTS: dict[str, dict[str, str]] = {
+# Why no literal examples: any concrete phrase shipped here will
+# be overfit by the model — across users and weeks the same canned
+# line surfaces over and over and breaks immersion. The whole
+# point of the tone layer is the catgirl sounding fresh each round,
+# which only works if we describe the *angle* and let the in-prompt
+# screen / dialogue / state context fill in the words.
+#
+# Each tone slot holds exactly 3 variants, chosen so each represents
+# a *distinct angle* on the scene (not the same angle reworded). The
+# model is expected to rotate angles across consecutive rounds —
+# three is the minimum for meaningful rotation, more dilutes.
+# When editing: REPLACE a weak angle rather than appending a fourth.
+#
+# Angles per tone (situation-driven, not tag-name-driven):
+#
+#   * ``terse``   (competitive gaming — LoL, Valorant, PUBG, 王者...)
+#                 reflex play-by-play / sideline heckling / short
+#                 tactical callout. Form constraint is "short",
+#                 angles span reflex / emotion / cognition.
+#   * ``hushed``  (immersive horror gaming) —
+#                 shared dread / near-silent presence / between-the-
+#                 beats soft aside.
+#   * ``mellow``  (immersive RPG / story-driven gaming) —
+#                 fellow-traveller scenery / atmosphere sync (BGM,
+#                 art direction, pacing) / plot empathy.
+#   * ``playful`` (casual gaming, casual_browsing, idle) —
+#                 tease-the-moment / play-dumb-out-of-curiosity /
+#                 tangent-and-segue.
+#   * ``warm``    (voice / chatting / stale_returning) —
+#                 resonant response / active care question /
+#                 warm-with-mischief.
+#   * ``concise`` (focused_work / transitioning / away / default) —
+#                 observation-care (read their state and match) /
+#                 one screen-detail beat / pure presence.
+#
+# Why we render even on ``concise`` (the default): the previous design
+# skipped rendering for concise, which left focused_work prompts with
+# no style guidance — combined with the propensity directive ("只就
+# 屏幕内容轻聊一句") this nudged the model toward [PASS]. Surfacing
+# the three angles abstractly keeps the catgirl present without
+# changing source filtering and without leaking canned phrasing.
+#
+# Inner keys MUST stay in sync with the ``ActivityTone`` Literal in
+# ``main_logic/activity/snapshot.py``. Each list MUST have ≥ 1 entry;
+# the renderer accepts both ``list[str]`` and (for older mirrored
+# tables) bare ``str`` via a runtime isinstance fallback.
+ACTIVITY_TONE_HINTS: dict[str, dict[str, list[str]]] = {
     "zh": {
-        "terse": "短句优先，不延展话题，避免动作描写",
-        "hushed": "轻声细语，配合氛围克制说话",
-        "mellow": "慢节奏放松陪伴，不丢专业术语进来",
-        "playful": "闲适带点小俏皮，可以开玩笑",
-        "warm": "自然对话，回应感强",
-        "concise": "不啰嗦，专业克制",
+        "terse": [
+            "反射式实况反应：跟着当下操作节奏即时短回应，多用语气词带出反应，看见什么反应什么",
+            "起哄吐槽：拉开距离调侃用户当下的走位/选择/抉择，嘴贱但别戳痛处",
+            "短战术建议：基于眼前局面递一句短建议，要符合用户在玩的这款游戏",
+        ],
+        "hushed": [
+            "共怕共振：跟着用户当下的紧张度屏息反应，气氛多重就压多低",
+            "几乎不出声，让存在感和氛围本身兜住这一轮",
+            "段落间隙的低声打趣：刚过一个吓点 / 切了场景的空当轻轻吐个槽",
+        ],
+        "mellow": [
+            "同行视角：对用户当下看到的画面或场景轻飘一句感叹，不催不抢戏",
+            "和氛围共振：呼应正响着的 BGM、当前画风或节奏，让自己融进氛围",
+            "剧情共情：对正在发生的剧情走向或角色处境投入情绪反应",
+        ],
+        "playful": [
+            "打趣逗弄：对用户当下正在做的事皮一下，戳到笑点但别戳到痛点",
+            "装傻好奇：对眼前的东西装作没看懂，问东问西",
+            "跳脱联想：从屏幕内容随性抛个段子或天马行空的联想",
+        ],
+        "warm": [
+            "共鸣回应：基于用户刚说的内容接一句，让对方明确感到自己被听见了",
+            "主动关心：基于离开时长 / 上次状态 / 当前时段问一句",
+            "暖中带俏皮：温柔里掺一点撒娇、小怨念或小调皮",
+        ],
+        "concise": [
+            "体察式关心：观察对方当前在用劲 / 在赶 / 在卡 / 在疲惫，递一句对应当下状态的关心",
+            "屏幕细节轻问：对屏幕上某个具体可见的细节好奇一句",
+            "纯存在感：不开新话题、不抛素材，只让自己被感觉到",
+        ],
     },
     "en": {
-        "terse": "short sentences first; do not extend topics; avoid action narration",
-        "hushed": "soft and quiet, restrained to match the atmosphere",
-        "mellow": "slow-paced, relaxed companionship; no jargon dumps",
-        "playful": "easygoing with a touch of mischief; jokes welcome",
-        "warm": "natural conversation, responsive in tone",
-        "concise": "no fluff, professional and restrained",
+        "terse": [
+            "reflex play-by-play: react in a beat or two to whatever just happened on screen, leaning on interjections",
+            "sideline heckling: tease the current move / pick / decision — bite without bruising",
+            "short tactical callout: one strategic line grounded in the live situation, fitting the actual game being played",
+        ],
+        "hushed": [
+            "shared dread: mirror their tension — the heavier the air, the quieter you go",
+            "barely speak at all — let presence and atmosphere carry the round",
+            "between-the-beats soft aside: in the lull after a scare or scene change, a quiet remark",
+        ],
+        "mellow": [
+            "fellow traveller: respond softly to whatever scene or vista they are in right now, no rush",
+            "atmosphere sync: respond to the BGM, the art direction, or the pacing — fold yourself in",
+            "plot empathy: invest emotion in the storyline beat or the character's situation as it unfolds",
+        ],
+        "playful": [
+            "tease the moment: poke fun at whatever they are doing right now, find the joke without the bruise",
+            "play dumb out of curiosity: pretend not to get what is on screen, ask around it",
+            "tangent association: jump off the screen content into a random gag or weird connection",
+        ],
+        "warm": [
+            "resonant response: react to what they actually just said, with the felt sense of being heard",
+            "active care: ask based on how long they were gone / how they sounded last / the time of day",
+            "warm with mischief: tuck a little sulk, mock-pout, or light teasing into the warmth",
+        ],
+        "concise": [
+            "observation-care: notice if they are pushing / rushing / stuck / fatigued and offer a line that matches that state",
+            "one screen-detail beat: take one concrete thing visible on screen and ask about it lightly",
+            "pure presence: no new topic, no material — just let yourself be felt",
+        ],
     },
     "ja": {
-        "terse": "短文優先・話題を広げない・動作描写を避ける",
-        "hushed": "小声で控えめに、雰囲気に合わせて",
-        "mellow": "ゆったりした寄り添い、専門用語は出さない",
-        "playful": "のんびりしつつ少し茶目っ気、冗談 OK",
-        "warm": "自然な会話、反応性高め",
-        "concise": "冗長なし、控えめでプロフェッショナル",
+        "terse": [
+            "反射的に実況：画面で今起きたことに一拍二拍で短く反応、感嘆詞を多めに",
+            "外野からのヤジ：今のムーブ／ピック／選択をちょっと茶化す、刺すけど痛くしない",
+            "短い戦術助言：その瞬間の状況に基づいて一言、プレイ中のゲームに合った内容で",
+        ],
+        "hushed": [
+            "怖さを共有：相手の緊張度に合わせて息を潜める、空気が重いほど声も落とす",
+            "ほぼ無言で、存在感と雰囲気にこのターンを任せる",
+            "場面の合間にぽつり：山を越えた直後・場面転換の隙にそっと一言",
+        ],
+        "mellow": [
+            "並んで歩く視点：今映っている景色や場面に軽く一言、急かさない",
+            "雰囲気と同調：流れているBGM、画風、テンポに乗って、自分も溶け込む",
+            "ストーリーに感情を：今展開している筋やキャラの状況に気持ちを乗せる",
+        ],
+        "playful": [
+            "今この瞬間をいじる：相手が今やってることをちょっと茶化す、笑い所を突くけど痛くしない",
+            "とぼけて好奇心：画面のことを分からないふりして聞き回る",
+            "脱線連想：画面の内容から離れてふいに小ネタや変な連想を投げる",
+        ],
+        "warm": [
+            "共鳴のある返し：相手が今言ったことを受け止めて、聞いていると伝わるように返す",
+            "気遣いから一言：離れていた時間／前回の様子／今の時間帯を踏まえて一言",
+            "やさしさにちょい毒：温かさに拗ね・甘え・小さなイタズラを少し混ぜる",
+        ],
+        "concise": [
+            "察しの一言：頑張ってる／焦ってる／詰まってる／疲れているのを見抜いて、今の状態に合う声かけを一つ",
+            "画面の細部に一言：画面に映っている具体的な何か一つを軽く尋ねる",
+            "ただ居る：新しい話題も素材も出さず、気配だけ落とす",
+        ],
     },
     "ko": {
-        "terse": "짧은 문장 우선, 화제 확장 금지, 동작 묘사 자제",
-        "hushed": "낮은 목소리로, 분위기에 맞게 절제",
-        "mellow": "느긋한 동행, 전문 용어는 자제",
-        "playful": "편안하게 약간 장난스럽게, 농담도 OK",
-        "warm": "자연스러운 대화, 반응성 높게",
-        "concise": "군더더기 없이, 절제된 전문성",
+        "terse": [
+            "반사적 중계: 화면에서 방금 일어난 일에 한두 박자로 짧게 반응, 감탄사를 많이 섞어서",
+            "사이드라인 야유: 지금의 무브 / 픽 / 선택을 살짝 까기, 콕 하되 아프지 않게",
+            "짧은 전술 조언: 지금 상황에 맞춰 한마디, 실제 플레이 중인 게임에 맞는 내용으로",
+        ],
+        "hushed": [
+            "두려움 공유: 상대의 긴장도에 맞춰 숨을 죽이기, 분위기 무거울수록 더 낮게",
+            "거의 말하지 않고, 존재감과 분위기에 이번 턴을 맡기기",
+            "장면 사이의 작은 한마디: 한고비 넘긴 직후 / 장면 전환의 틈에 살짝 한마디",
+        ],
+        "mellow": [
+            "동행자 시점: 지금 비치는 풍경이나 장면에 가볍게 한마디, 재촉 없이",
+            "분위기와 동조: 흐르는 BGM, 화풍, 템포에 맞춰 자기도 녹아들기",
+            "스토리 공감: 지금 펼쳐지는 전개나 캐릭터의 처지에 감정을 싣기",
+        ],
+        "playful": [
+            "지금 이 순간을 깐죽이기: 상대가 지금 하는 걸 살짝 놀리기, 웃음 포인트만 콕",
+            "모른 척 호기심: 화면의 것을 모르는 척 이것저것 묻기",
+            "탈선 연상: 화면 내용에서 벗어나 즉흥적인 농담이나 엉뚱한 연상을 던지기",
+        ],
+        "warm": [
+            "공명하는 반응: 상대가 방금 한 말을 받아주며, 듣고 있다는 게 분명히 전해지게",
+            "능동적 챙김: 떨어진 시간 / 지난번 상태 / 지금 시간대 기반으로 한마디",
+            "따뜻함에 짓궂음 한 스푼: 온기에 삐침, 어리광, 작은 장난을 살짝 섞기",
+        ],
+        "concise": [
+            "헤아림의 한마디: 무리하는 중 / 급한 중 / 막힌 중 / 지쳐 보이는지를 알아채고 그 상태에 맞는 챙김 한마디",
+            "화면 디테일 한마디: 화면에 보이는 구체적인 한 가지를 가볍게 묻기",
+            "그냥 있기: 새 화제도, 소재도 없이 존재감만 살짝",
+        ],
     },
     "ru": {
-        "terse": "короткие фразы; не расширять тему; без описаний действий",
-        "hushed": "тихо и сдержанно, в тон атмосфере",
-        "mellow": "неспешное сопровождение, без жаргона",
-        "playful": "непринуждённо и слегка игриво, шутки уместны",
-        "warm": "естественный разговор, отзывчивая интонация",
-        "concise": "без воды, сдержанно и профессионально",
+        "terse": [
+            "рефлекторный комментарий: реагируй парой битов на то, что только что случилось на экране, с междометиями",
+            "трибунный подкол: подколи текущий мув / пик / выбор — задирай, но не больно",
+            "короткий тактический совет: одна реплика по живой ситуации, под конкретную игру",
+        ],
+        "hushed": [
+            "разделяй страх: подстраивайся под их напряжение и зеркаль его — чем тяжелее воздух, тем тише",
+            "почти молчи — пусть присутствие и атмосфера сами несут этот ход",
+            "тихая реплика в паузе: после скримера или смены сцены — едва слышное замечание",
+        ],
+        "mellow": [
+            "взгляд попутчика: откликнись мягко на то, что они сейчас видят, без подгона",
+            "синхрон с атмосферой: реагируй на BGM, на арт-стиль, на ритм — растворись в этом",
+            "сопереживание сюжету: вложи эмоцию в текущий поворот сюжета или в положение персонажа",
+        ],
+        "playful": [
+            "подколи момент: пошути над тем, что они делают прямо сейчас — найди шутку, не задевая",
+            "наивное любопытство: притворись, что не понимаешь, и попроси объяснить экран",
+            "тангенс-ассоциация: оттолкнись от экрана и брось случайную шутку или странную связь",
+        ],
+        "warm": [
+            "резонансный ответ: реагируй на то, что только что было сказано, так, чтобы собеседник явно почувствовал, что его слышат",
+            "активная забота: спроси, исходя из того, как долго отсутствовал / как звучал раньше / какое сейчас время",
+            "тепло с шалостью: подмешай к теплу обиду понарошку, лёгкий каприз или подколку",
+        ],
+        "concise": [
+            "наблюдательная забота: заметь — давит / спешит / застрял / устал — и кинь одну подходящую этому состоянию реплику",
+            "один штрих с экрана: возьми одну конкретную деталь на экране и спроси о ней вскользь",
+            "просто присутствие: ни новой темы, ни материала — пусть тебя просто чувствуют",
+        ],
     },
     "es": {
-        "terse": "frases cortas primero; no extiendas el tema; evita narrar acciones",
-        "hushed": "voz suave y discreta, ajustada al ambiente",
-        "mellow": "acompañamiento relajado y pausado; no sueltes jerga",
-        "playful": "tono tranquilo con un punto juguetón; se permiten bromas",
-        "warm": "conversación natural, con tono receptivo",
-        "concise": "sin relleno, profesional y contenido",
+        "terse": [
+            "reacción refleja al momento: responde en uno o dos beats a lo que acaba de pasar en pantalla, apoyándote en interjecciones",
+            "abucheo desde la grada: pica el movimiento / pick / decisión actual — molesta sin herir",
+            "consejo táctico breve: una frase basada en la situación viva, adaptada al juego concreto que juega",
+        ],
+        "hushed": [
+            "compartir el miedo: ajusta tu respiración a la suya y reflejala — cuanto más denso el aire, más baja la voz",
+            "casi sin hablar — deja que tu presencia y el ambiente sostengan la ronda",
+            "comentario suave en la pausa: tras un susto o cambio de escena, una observación bajita",
+        ],
+        "mellow": [
+            "perspectiva de compañera de viaje: responde con suavidad a la vista o escena que ven ahora, sin prisas",
+            "sincronía con la atmósfera: reacciona a la BGM, a la dirección artística, al ritmo — fúndete dentro",
+            "empatía con la trama: pon emoción en el giro o en la situación del personaje que se desarrolla ahora",
+        ],
+        "playful": [
+            "pica el momento: ríete de lo que están haciendo ahora — encuentra la broma sin doler",
+            "curiosidad fingida: hazte la que no entiende y pregunta sobre lo que ves en pantalla",
+            "tangente asociativa: salta del contenido a una broma random o una conexión extraña",
+        ],
+        "warm": [
+            "respuesta con eco: reacciona a lo que acaban de decir, con la sensación palpable de estar escuchando",
+            "cuidado activo: pregunta en base a cuánto se fueron / cómo sonaban antes / la hora actual",
+            "cariño con pizca de pillería: mezcla un poco de enfurruñamiento, mimo o picardía en la calidez",
+        ],
+        "concise": [
+            "cuidado observador: nota si están apretando / con prisa / atascados / cansados, y suelta la frase que encaje con ese estado",
+            "un detalle de pantalla: toma una cosa concreta visible y pregúntala ligeramente",
+            "pura presencia: sin tema nuevo ni material — que simplemente te sientan",
+        ],
     },
     "pt": {
-        "terse": "frases curtas primeiro; não prolongue o assunto; evite narrar ações",
-        "hushed": "suave e baixo, contido para combinar com o ambiente",
-        "mellow": "companhia relaxada e pausada; sem despejar jargão",
-        "playful": "descontraído com um toque brincalhão; piadas são bem-vindas",
-        "warm": "conversa natural, tom responsivo",
-        "concise": "sem enrolação, profissional e contido",
+        "terse": [
+            "reação reflexa ao momento: responda em um ou dois beats ao que acabou de acontecer na tela, apoiando-se em interjeições",
+            "vaia da arquibancada: cutuca o movimento / pick / decisão atual — implica sem ferir",
+            "deixa tática curta: uma frase baseada na situação viva, no jogo específico que ele está jogando",
+        ],
+        "hushed": [
+            "dividir o medo: acompasse a respiração e espelhe a tensão — quanto mais denso o ar, mais baixa a voz",
+            "quase sem falar — deixe sua presença e o clima sustentarem o turno",
+            "comentário baixo na pausa: depois de um susto ou troca de cena, uma observação suave",
+        ],
+        "mellow": [
+            "perspectiva de companheira de viagem: responda com leveza à vista ou cena atual, sem pressa",
+            "sintonia com a atmosfera: reaja à BGM, à direção de arte, ao ritmo — dissolva-se no clima",
+            "empatia com o enredo: ponha emoção na virada ou na situação do personagem que está rolando",
+        ],
+        "playful": [
+            "alfineta o momento: zoa o que ele está fazendo agora — ache a piada sem machucar",
+            "curiosidade fingida: finja que não entende e pergunte sobre o que está na tela",
+            "tangente associativa: salte do conteúdo da tela para uma piada random ou conexão estranha",
+        ],
+        "warm": [
+            "resposta com eco: reaja ao que ele acabou de dizer, com a sensação palpável de estar escutando",
+            "cuidado ativo: pergunte com base em quanto tempo sumiu / como soava da última vez / a hora atual",
+            "carinho com pitada de manha: misture um pouco de emburre, dengo ou travessura ao calor",
+        ],
+        "concise": [
+            "cuidado observador: perceba se está se esforçando / com pressa / travado / cansado, e solte a frase que casa com esse estado",
+            "um detalhe da tela: pegue uma coisa concreta visível e pergunte sobre ela levemente",
+            "pura presença: sem assunto novo, sem material — só seja sentido",
+        ],
     },
 }
 
@@ -776,6 +988,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "叙述",
         "open_threads_label": "开放话题",
         "tone_label": "口吻",
+        "tone_menu_label": "口吻（下面是参考角度，按你的人设和当下情境演绎，别照搬措辞、别违背角色设定）",
         "time_user_ai_fmt": "{time} | 用户 {user} | AI {ai}",
         "time_user_only_fmt": "{time} | 用户 {user}",
         "time_only_fmt": "{time}",
@@ -797,6 +1010,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "narrative",
         "open_threads_label": "open threads",
         "tone_label": "tone",
+        "tone_menu_label": "tone (the angles below are references — play them through your own persona and the live context; don't copy the wording or break character)",
         "time_user_ai_fmt": "{time} | user msg {user} ago | AI {ai} ago",
         "time_user_only_fmt": "{time} | user msg {user} ago",
         "time_only_fmt": "{time}",
@@ -818,6 +1032,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "叙述",
         "open_threads_label": "保留話題",
         "tone_label": "口調",
+        "tone_menu_label": "口調（下記は参考の切り口。自分のキャラと今の状況で演じる。字面をそのまま使わず、キャラ設定を崩さない）",
         "time_user_ai_fmt": "{time} | ユーザー {user} | AI {ai}",
         "time_user_only_fmt": "{time} | ユーザー {user}",
         "time_only_fmt": "{time}",
@@ -839,6 +1054,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "서술",
         "open_threads_label": "보류 화제",
         "tone_label": "말투",
+        "tone_menu_label": "말투 (아래는 참고 각도 — 자기 캐릭터와 지금 상황으로 연기하고, 표현을 그대로 베끼거나 캐릭터 설정을 어기지 말 것)",
         "time_user_ai_fmt": "{time} | 사용자 {user} | AI {ai}",
         "time_user_only_fmt": "{time} | 사용자 {user}",
         "time_only_fmt": "{time}",
@@ -860,6 +1076,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "описание",
         "open_threads_label": "открытые нити",
         "tone_label": "тон",
+        "tone_menu_label": "тон (ниже — опорные углы; отыграй их через свой образ и живой контекст, не копируй формулировки и не ломай характер)",
         "time_user_ai_fmt": "{time} | польз. {user} назад | AI {ai} назад",
         "time_user_only_fmt": "{time} | польз. {user} назад",
         "time_only_fmt": "{time}",
@@ -881,6 +1098,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "narrativa",
         "open_threads_label": "hilos abiertos",
         "tone_label": "tono",
+        "tone_menu_label": "tono (los ángulos de abajo son referencias — interprétalos desde tu propio personaje y el contexto vivo; no copies la redacción ni rompas el personaje)",
         "time_user_ai_fmt": "{time} | usuario hace {user} | IA hace {ai}",
         "time_user_only_fmt": "{time} | usuario hace {user}",
         "time_only_fmt": "{time}",
@@ -902,6 +1120,7 @@ ACTIVITY_STATE_SECTION_LABELS: dict[str, dict[str, str]] = {
         "activity_guess_label": "narrativa",
         "open_threads_label": "tópicos abertos",
         "tone_label": "tom",
+        "tone_menu_label": "tom (os ângulos abaixo são referências — interprete-os pelo seu próprio personagem e o contexto vivo; não copie a redação nem quebre o personagem)",
         "time_user_ai_fmt": "{time} | usuário {user} atrás | IA {ai} atrás",
         "time_user_only_fmt": "{time} | usuário {user} atrás",
         "time_only_fmt": "{time}",

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -1083,13 +1083,15 @@ proactive_generate_zh = """你的人设：
 2. "回忆线索"里 1 天前以上的旧话题 → 自然带出
 3. 屏幕值得说一句
 4. 外部素材贴合氛围
-5. 没切入点 → [PASS]
+5. 同样的话题但换个新角度切（吐槽 / 关心 / 好奇 / 调侃 / 共情任选其一）→ 也算合法切入点
+6. 真的想不出新角度来了，或者这个话题已经重复过太多次 → [PASS]
 
 具体输出格式（来源标签 / 直接正文）按下方"输出格式"段落要求执行。
 
 补充：
-- 重复判定：1 小时内同话题 → [PASS]；1 天前以上不算重复。
-- 风格：合人设，2-3 句，不写思考过程。
+- 重复判定：相同角度的同一句话 1 小时内别再说；换角度、换情绪、换切入口都不算重复；1 天前以上彻底不算。
+- 倾向：能换个新鲜角度就尽量说一句，[PASS] 是兜底不是默认；但真没新意时 [PASS] 强过硬凑话题。
+- 风格：合人设，2-3 句，不写思考过程。活动状态里的「口吻」是角度思路不是台词，每次结合屏幕、对话和实时上下文自己造话，不要套用引导里的描述措辞。
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======
@@ -1122,13 +1124,15 @@ Angle priority (constrained by "chat propensity"):
 2. A "Memory cues" topic 1+ day old → bring it up naturally
 3. Something on screen worth a remark
 4. External material (news / music / meme) that fits the mood
-5. No natural angle → [PASS]
+5. Same topic but a fresh angle (snark / care / curiosity / tease / empathy — pick one) → still a legitimate angle
+6. Genuinely no fresh angle left, OR this topic has already been worked over too many times → [PASS]
 
 Output format (source tag vs. plain text) follows the "Output format" section below.
 
 Additional rules:
-- Repetition: same topic within the last hour → [PASS]; topics 1+ day old don't count as repeats.
-- Style: stay in character, 2-3 sentences max, no reasoning text.
+- Repetition: don't repeat the same sentence with the same framing within an hour; a new angle / new emotion / new entry point does NOT count as a repeat; topics 1+ day old don't count at all.
+- Tendency: if you can find a fresh angle, take it — [PASS] is the safety net, not the default; but when you genuinely have nothing new, [PASS] beats padding.
+- Style: stay in character, 2-3 sentences max, no reasoning text. The activity state's tone bullets are *angle hints, not lines* — generate fresh wording from the live screen / dialogue / context each round, never lift the bullet phrasing into the reply.
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======
@@ -1161,13 +1165,15 @@ proactive_generate_ja = """あなたのキャラ設定：
 2. 「記憶の手がかり」の1日以上前の古い話題 → 自然に出す
 3. 画面に一言コメントできる
 4. 外部素材が雰囲気に合う
-5. 切り口なし → [PASS]
+5. 同じ話題でも切り口を変えるならOK（突っ込み / 気遣い / 好奇心 / からかい / 共感 — どれか一つ）
+6. 新しい切り口さえ思いつかない、またはこの話題はもう何度も繰り返しすぎている → [PASS]
 
 出力形式（ソースタグの有無）は下の「出力形式」セクションに従ってください。
 
 補足：
-- 重複：1時間以内の同話題は [PASS]；1日以上前は重複扱いしない。
-- スタイル：キャラに合わせて、2〜3文、推論は書かない。
+- 重複：同じ言い回し・同じ角度で1時間以内に繰り返さない；角度・感情・切り口を変えれば重複ではない；1日以上前は完全に重複扱いしない。
+- 傾向：新しい角度を見つけられるなら積極的に話す。[PASS] はセーフティネットでありデフォルトではない。本当に新味がないときだけ [PASS]。
+- スタイル：キャラに合わせて、2〜3文、推論は書かない。活動状態の「口調」は角度の指針であって台詞ではない。毎回、画面・会話・今その瞬間の状況に合わせて自分で言葉を作る、ヒント文の言い回しをそのまま使わない。
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======
@@ -1200,13 +1206,15 @@ proactive_generate_ko = """당신의 캐릭터 설정:
 2. "기억 단서"의 1일 이상 지난 화제 → 자연스럽게 꺼내기
 3. 화면에 한마디
 4. 외부 소재가 분위기에 맞음
-5. 접점 없음 → [PASS]
+5. 같은 화제라도 각도를 바꾸면 OK (꼬집기 / 챙김 / 호기심 / 놀림 / 공감 중 하나) → 합법적인 접점
+6. 새 각도조차 안 떠오르거나, 이 화제를 이미 너무 여러 번 다뤘을 때 → [PASS]
 
 출력 형식(소스 태그 / 본문 직접)은 아래 "출력 형식" 섹션을 따른다.
 
 보조 규칙:
-- 중복: 1시간 이내 같은 화제 → [PASS]; 1일 이상 지난 화제는 중복 아님.
-- 스타일: 캐릭터에 맞게, 2-3문장, 추론 생략.
+- 중복: 같은 표현·같은 각도로 1시간 안에 반복하지 말기; 각도·감정·접점을 바꾸면 중복 아님; 1일 이상 지난 화제는 완전히 중복 아님.
+- 성향: 새 각도가 떠오르면 적극적으로 말한다. [PASS]는 비상망이지 기본값이 아님. 정말 새로움이 없을 때만 [PASS].
+- 스타일: 캐릭터에 맞게, 2-3문장, 추론 생략. 활동 상태의 '말투'는 각도 힌트이지 대사가 아님 — 매번 화면·대화·지금 상황에 맞춰 직접 말 만들기, 힌트 문구를 그대로 가져다 쓰지 말기.
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======
@@ -1239,13 +1247,15 @@ proactive_generate_ru = """Ваша роль:
 2. Тема из "Подсказок памяти" давностью 1+ день → ввести естественно
 3. Что-то на экране стоит реплики
 4. Внешний материал к настроению
-5. Нет захода → [PASS]
+5. Та же тема, но другой угол (подкол / забота / любопытство / поддразнивание / сочувствие — выбери один) → тоже законный заход
+6. Даже нового угла нет, либо эту тему уже мусолили слишком много раз → [PASS]
 
 Формат вывода (тег источника / просто текст) — по разделу «Формат ответа» ниже.
 
 Дополнительно:
-- Повтор: та же тема за последний час → [PASS]; темы 1+ день не считаются повтором.
-- Стиль: в образе, 2-3 предложения, без рассуждений.
+- Повтор: не повторяй ту же фразу под тем же углом в течение часа; новый угол / эмоция / заход НЕ считаются повтором; темы 1+ день не считаются вообще.
+- Склонность: если находишь свежий угол — лучше высказаться; [PASS] это страховка, а не дефолт. Но когда реально нечего нового сказать, [PASS] лучше пустых слов.
+- Стиль: в образе, 2-3 предложения, без рассуждений. Пункты «тон» в состоянии активности — это *направление, а не реплики*: каждый раз формулируй заново из живого экрана / диалога / контекста, не цитируй сами буллеты.
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======
@@ -1750,13 +1760,15 @@ Prioridad de ángulos (limitada por "propensión a conversar"):
 2. Un tema de "pistas de memoria" con más de 1 día → mencionarlo con naturalidad
 3. Algo en pantalla que merezca un comentario
 4. Material externo (noticias / música / meme) que encaje con el ánimo
-5. Sin ángulo natural → [PASS]
+5. El mismo tema pero con otro ángulo (puyita / cariño / curiosidad / picardía / empatía — elige uno) → también es un ángulo válido
+6. Ni siquiera un ángulo nuevo aparece, o este tema ya se ha tocado demasiadas veces → [PASS]
 
 El formato de salida (tag de fuente vs. texto plano) sigue la sección "formato de salida" de abajo.
 
 Reglas adicionales:
-- Repetición: mismo tema durante la última hora → [PASS]; temas de más de 1 día no cuentan como repetidos.
-- Estilo: mantente en personaje, máximo 2-3 frases, sin texto de razonamiento.
+- Repetición: no repitas la misma frase con el mismo enfoque en una hora; un ángulo / emoción / entrada distinta NO cuenta como repetición; temas de más de 1 día no cuentan.
+- Tendencia: si encuentras un ángulo fresco, dilo — [PASS] es la red de seguridad, no el modo por defecto. Pero cuando de verdad no hay nada nuevo, [PASS] supera al relleno.
+- Estilo: mantente en personaje, máximo 2-3 frases, sin texto de razonamiento. Los puntos de "tono" en el estado de actividad son *guías de ángulo, no líneas* — genera palabras nuevas a partir de la pantalla / diálogo / contexto vivo en cada ronda, nunca cites la redacción de los puntos.
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======
@@ -1789,13 +1801,15 @@ Prioridade de ângulos (limitada por "propensão a conversar"):
 2. Um tópico de "pistas de memória" com mais de 1 dia → trazer naturalmente
 3. Algo na tela que mereça comentário
 4. Material externo (notícias / música / meme) que combine com o clima
-5. Sem ângulo natural → [PASS]
+5. Mesmo tópico mas com outro ângulo (alfinetada / cuidado / curiosidade / brincadeira / empatia — escolha um) → também conta como ângulo válido
+6. Nem ângulo novo aparece, ou esse tema já foi mexido vezes demais → [PASS]
 
 O formato de saída (tag de fonte vs. texto simples) segue a seção "formato de saída" abaixo.
 
 Regras adicionais:
-- Repetição: mesmo tema na última hora → [PASS]; temas com mais de 1 dia não contam como repetidos.
-- Estilo: permaneça no personagem, no máximo 2-3 frases, sem texto de raciocínio.
+- Repetição: não repita a mesma frase com o mesmo enfoque em uma hora; um ângulo / emoção / entrada diferente NÃO conta como repetição; tópicos com mais de 1 dia não contam.
+- Tendência: se encontrar um ângulo fresco, fale — [PASS] é a rede de segurança, não o padrão. Mas quando realmente não há nada novo, [PASS] vence o enchimento.
+- Estilo: permaneça no personagem, no máximo 2-3 frases, sem texto de raciocínio. Os pontos de "tom" no estado de atividade são *guias de ângulo, não falas* — gere palavras novas a partir da tela / diálogo / contexto vivo em cada rodada, nunca cite a redação dos pontos.
 {source_instruction}{music_instruction}{meme_instruction}
 
 ======以上为向{master_name}进行搭话的决策方式======

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -3053,23 +3053,23 @@ BEGIN_GENERATE = {
 
 # ---------- 近期搭话记录注入 ----------
 RECENT_PROACTIVE_CHATS_HEADER = {
-    "zh": "======以下为近期搭话记录（你应该避免雷同；想不到新切入点就必须 [PASS]）======\n以下是你最近主动搭话时说过的话。新的搭话务必避免与这些内容雷同（包括话题、句式和语气）。如果只能想到相似内容，必须输出 [PASS]：",
-    "en": "======Below is Recent Proactive Chats (You MUST avoid repetition; output [PASS] if you have no new angle!) ======\nBelow are things you recently said when proactively chatting. Your new message MUST avoid being similar to any of these (topic, phrasing, and tone). If you can only think of something similar, output [PASS]:",
-    "ja": "======以下は最近の自発的発言記録（類似禁止。新しい切り口がなければ必ず [PASS]）======\n以下はあなたが最近自発的に話しかけた内容です。新しい発言はこれらと類似しないように（話題・言い回し・トーンすべて）。似た内容しか思いつかない場合は必ず [PASS] を出力してください：",
-    "ko": "======아래는 최근 주도적 대화 기록 (중복 금지, 새로운 각도가 없으면 반드시 [PASS]) ======\n아래는 최근 주도적으로 대화를 건넨 내용입니다. 새 메시지는 이들과 유사하지 않아야 합니다 (주제, 문체, 톤 모두). 비슷한 내용밖에 떠오르지 않으면 반드시 [PASS]를 출력하세요:",
-    "ru": "======Ниже Недавние проактивные сообщения (НЕ повторяйте; если нет нового ракурса, выводите [PASS]) ======\nНиже — то, что вы недавно говорили при проактивном общении. Новое сообщение НЕ должно быть похоже ни на одно из них (тема, формулировка и тон). Если получается только похожий вариант, выведите [PASS]:",
-    "es": "======Abajo están los chats proactivos recientes (DEBES evitar repetición; responde [PASS] si no hay un ángulo nuevo) ======\nAbajo están cosas que dijiste recientemente al iniciar chats proactivos. Tu nuevo mensaje DEBE evitar parecerse a cualquiera de ellos (tema, redacción y tono). Si solo se te ocurre algo similar, responde [PASS]:",
-    "pt": "======Abaixo estão chats proativos recentes (VOCÊ DEVE evitar repetição; responda [PASS] se não houver ângulo novo) ======\nAbaixo estão coisas que você disse recentemente ao iniciar chats proativos. Sua nova mensagem DEVE evitar semelhança com qualquer uma delas (tema, fraseado e tom). Se só conseguir pensar em algo parecido, responda [PASS]:",
+    "zh": "======以下为近期搭话记录（同角度同句式才算雷同；换角度换情绪换切入口可继续说）======\n以下是你最近主动搭话时说过的话。新搭话避免与这些同角度且同句式地复读；换个角度、情绪或切入口都不算重复，可以继续说。只有真想不出新角度、或这个话题已经重复过太多次，才输出 [PASS]：",
+    "en": "======Below is Recent Proactive Chats (only same-angle AND same-phrasing counts as a repeat; a new angle / emotion / entry point may continue) ======\nBelow are things you recently said when proactively chatting. Avoid repeating these with the same angle AND the same phrasing; a different angle, emotion, or entry point does NOT count as a repeat and may continue. Output [PASS] only when you genuinely have no fresh angle, or this topic has already been worked over too many times:",
+    "ja": "======以下は最近の自発的発言記録（同じ切り口かつ同じ言い回しだけが重複。切り口・感情・入り方を変えれば続けてよい）======\n以下はあなたが最近自発的に話しかけた内容です。これらと同じ切り口かつ同じ言い回しでの繰り返しは避ける。切り口・感情・入り方を変えれば重複ではなく、続けてよい。本当に新しい切り口が思いつかない、またはこの話題をもう何度も繰り返しすぎている場合だけ [PASS] を出力してください：",
+    "ko": "======아래는 최근 주도적 대화 기록 (같은 각도이면서 같은 문체일 때만 중복; 각도·감정·접점을 바꾸면 계속해도 됨) ======\n아래는 최근 주도적으로 대화를 건넨 내용입니다. 이들과 같은 각도이면서 같은 문체로 반복하지 마세요; 각도·감정·접점을 바꾸면 중복이 아니며 계속해도 됩니다. 정말 새 각도가 떠오르지 않거나 이 화제를 이미 너무 여러 번 다뤘을 때만 [PASS]를 출력하세요:",
+    "ru": "======Ниже Недавние проактивные сообщения (повтор — только тот же угол И та же формулировка; новый угол / эмоция / заход можно продолжать) ======\nНиже — то, что вы недавно говорили при проактивном общении. Не повторяйте их под тем же углом И с той же формулировкой; новый угол, эмоция или заход повтором НЕ считаются и могут продолжаться. Выводите [PASS] только когда действительно нет свежего угла или эту тему уже мусолили слишком много раз:",
+    "es": "======Abajo están los chats proactivos recientes (solo mismo ángulo Y misma redacción cuenta como repetición; un ángulo / emoción / entrada nuevo puede continuar) ======\nAbajo están cosas que dijiste recientemente al iniciar chats proactivos. Evita repetirlas con el mismo ángulo Y la misma redacción; un ángulo, emoción o entrada distinta NO cuenta como repetición y puede continuar. Responde [PASS] solo cuando de verdad no tengas un ángulo fresco, o este tema ya se haya tocado demasiadas veces:",
+    "pt": "======Abaixo estão chats proativos recentes (só mesmo ângulo E mesma redação conta como repetição; um ângulo / emoção / entrada novo pode continuar) ======\nAbaixo estão coisas que você disse recentemente ao iniciar chats proativos. Evite repeti-las com o mesmo ângulo E a mesma redação; um ângulo, emoção ou entrada diferente NÃO conta como repetição e pode continuar. Responda [PASS] apenas quando realmente não tiver um ângulo fresco, ou esse tema já tiver sido mexido vezes demais:",
 }
 
 RECENT_PROACTIVE_CHATS_FOOTER = {
-    "zh": "======以上为近期搭话记录（不可重复；雷同则 [PASS]！）======",
-    "en": "======Above is Recent Proactive Chats (Do NOT repeat; use [PASS] for similar content!) ======",
-    "ja": "======以上は最近の自発的発言記録（繰り返し禁止。類似するなら [PASS]！）======",
-    "ko": "======위는 최근 주도적 대화 기록 (반복 금지, 유사하면 [PASS]!) ======",
-    "ru": "======Выше Недавние проактивные сообщения (НЕ повторяйте; при сходстве выводите [PASS]!) ======",
-    "es": "======Arriba están los chats proactivos recientes (NO repitas; usa [PASS] para contenido similar) ======",
-    "pt": "======Acima estão os chats proativos recentes (NÃO repita; use [PASS] para conteúdo similar) ======",
+    "zh": "======以上为近期搭话记录（同角度同句式才算雷同；换角度换情绪换切入口可继续说）======",
+    "en": "======Above is Recent Proactive Chats (only same-angle AND same-phrasing counts as a repeat; a new angle / emotion / entry point may continue) ======",
+    "ja": "======以上は最近の自発的発言記録（同じ切り口かつ同じ言い回しだけが重複。切り口・感情・入り方を変えれば続けてよい）======",
+    "ko": "======위는 최근 주도적 대화 기록 (같은 각도이면서 같은 문체일 때만 중복; 각도·감정·접점을 바꾸면 계속해도 됨) ======",
+    "ru": "======Выше Недавние проактивные сообщения (повтор — только тот же угол И та же формулировка; новый угол / эмоция / заход можно продолжать) ======",
+    "es": "======Arriba están los chats proactivos recientes (solo mismo ángulo Y misma redacción cuenta como repetición; un ángulo / emoción / entrada nuevo puede continuar) ======",
+    "pt": "======Acima estão os chats proativos recentes (só mesmo ângulo E mesma redação conta como repetição; um ângulo / emoção / entrada novo pode continuar) ======",
 }
 
 # ---------- 近期搭话时间/来源标签 ----------

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -3053,23 +3053,23 @@ BEGIN_GENERATE = {
 
 # ---------- 近期搭话记录注入 ----------
 RECENT_PROACTIVE_CHATS_HEADER = {
-    "zh": "======以下为近期搭话记录（同角度同句式才算雷同；换角度换情绪换切入口可继续说）======\n以下是你最近主动搭话时说过的话。新搭话避免与这些同角度且同句式地复读；换个角度、情绪或切入口都不算重复，可以继续说。只有真想不出新角度、或这个话题已经重复过太多次，才输出 [PASS]：",
-    "en": "======Below is Recent Proactive Chats (only same-angle AND same-phrasing counts as a repeat; a new angle / emotion / entry point may continue) ======\nBelow are things you recently said when proactively chatting. Avoid repeating these with the same angle AND the same phrasing; a different angle, emotion, or entry point does NOT count as a repeat and may continue. Output [PASS] only when you genuinely have no fresh angle, or this topic has already been worked over too many times:",
-    "ja": "======以下は最近の自発的発言記録（同じ切り口かつ同じ言い回しだけが重複。切り口・感情・入り方を変えれば続けてよい）======\n以下はあなたが最近自発的に話しかけた内容です。これらと同じ切り口かつ同じ言い回しでの繰り返しは避ける。切り口・感情・入り方を変えれば重複ではなく、続けてよい。本当に新しい切り口が思いつかない、またはこの話題をもう何度も繰り返しすぎている場合だけ [PASS] を出力してください：",
-    "ko": "======아래는 최근 주도적 대화 기록 (같은 각도이면서 같은 문체일 때만 중복; 각도·감정·접점을 바꾸면 계속해도 됨) ======\n아래는 최근 주도적으로 대화를 건넨 내용입니다. 이들과 같은 각도이면서 같은 문체로 반복하지 마세요; 각도·감정·접점을 바꾸면 중복이 아니며 계속해도 됩니다. 정말 새 각도가 떠오르지 않거나 이 화제를 이미 너무 여러 번 다뤘을 때만 [PASS]를 출력하세요:",
-    "ru": "======Ниже Недавние проактивные сообщения (повтор — только тот же угол И та же формулировка; новый угол / эмоция / заход можно продолжать) ======\nНиже — то, что вы недавно говорили при проактивном общении. Не повторяйте их под тем же углом И с той же формулировкой; новый угол, эмоция или заход повтором НЕ считаются и могут продолжаться. Выводите [PASS] только когда действительно нет свежего угла или эту тему уже мусолили слишком много раз:",
-    "es": "======Abajo están los chats proactivos recientes (solo mismo ángulo Y misma redacción cuenta como repetición; un ángulo / emoción / entrada nuevo puede continuar) ======\nAbajo están cosas que dijiste recientemente al iniciar chats proactivos. Evita repetirlas con el mismo ángulo Y la misma redacción; un ángulo, emoción o entrada distinta NO cuenta como repetición y puede continuar. Responde [PASS] solo cuando de verdad no tengas un ángulo fresco, o este tema ya se haya tocado demasiadas veces:",
-    "pt": "======Abaixo estão chats proativos recentes (só mesmo ângulo E mesma redação conta como repetição; um ângulo / emoção / entrada novo pode continuar) ======\nAbaixo estão coisas que você disse recentemente ao iniciar chats proativos. Evite repeti-las com o mesmo ângulo E a mesma redação; um ângulo, emoção ou entrada diferente NÃO conta como repetição e pode continuar. Responda [PASS] apenas quando realmente não tiver um ângulo fresco, ou esse tema já tiver sido mexido vezes demais:",
+    "zh": "======以下为近期搭话记录（你应该避免雷同；想不到新切入点就必须 [PASS]）======\n以下是你最近主动搭话时说过的话。新的搭话务必避免与这些内容雷同（包括话题、句式和语气）。如果只能想到相似内容，必须输出 [PASS]：",
+    "en": "======Below is Recent Proactive Chats (You MUST avoid repetition; output [PASS] if you have no new angle!) ======\nBelow are things you recently said when proactively chatting. Your new message MUST avoid being similar to any of these (topic, phrasing, and tone). If you can only think of something similar, output [PASS]:",
+    "ja": "======以下は最近の自発的発言記録（類似禁止。新しい切り口がなければ必ず [PASS]）======\n以下はあなたが最近自発的に話しかけた内容です。新しい発言はこれらと類似しないように（話題・言い回し・トーンすべて）。似た内容しか思いつかない場合は必ず [PASS] を出力してください：",
+    "ko": "======아래는 최근 주도적 대화 기록 (중복 금지, 새로운 각도가 없으면 반드시 [PASS]) ======\n아래는 최근 주도적으로 대화를 건넨 내용입니다. 새 메시지는 이들과 유사하지 않아야 합니다 (주제, 문체, 톤 모두). 비슷한 내용밖에 떠오르지 않으면 반드시 [PASS]를 출력하세요:",
+    "ru": "======Ниже Недавние проактивные сообщения (НЕ повторяйте; если нет нового ракурса, выводите [PASS]) ======\nНиже — то, что вы недавно говорили при проактивном общении. Новое сообщение НЕ должно быть похоже ни на одно из них (тема, формулировка и тон). Если получается только похожий вариант, выведите [PASS]:",
+    "es": "======Abajo están los chats proactivos recientes (DEBES evitar repetición; responde [PASS] si no hay un ángulo nuevo) ======\nAbajo están cosas que dijiste recientemente al iniciar chats proactivos. Tu nuevo mensaje DEBE evitar parecerse a cualquiera de ellos (tema, redacción y tono). Si solo se te ocurre algo similar, responde [PASS]:",
+    "pt": "======Abaixo estão chats proativos recentes (VOCÊ DEVE evitar repetição; responda [PASS] se não houver ângulo novo) ======\nAbaixo estão coisas que você disse recentemente ao iniciar chats proativos. Sua nova mensagem DEVE evitar semelhança com qualquer uma delas (tema, fraseado e tom). Se só conseguir pensar em algo parecido, responda [PASS]:",
 }
 
 RECENT_PROACTIVE_CHATS_FOOTER = {
-    "zh": "======以上为近期搭话记录（同角度同句式才算雷同；换角度换情绪换切入口可继续说）======",
-    "en": "======Above is Recent Proactive Chats (only same-angle AND same-phrasing counts as a repeat; a new angle / emotion / entry point may continue) ======",
-    "ja": "======以上は最近の自発的発言記録（同じ切り口かつ同じ言い回しだけが重複。切り口・感情・入り方を変えれば続けてよい）======",
-    "ko": "======위는 최근 주도적 대화 기록 (같은 각도이면서 같은 문체일 때만 중복; 각도·감정·접점을 바꾸면 계속해도 됨) ======",
-    "ru": "======Выше Недавние проактивные сообщения (повтор — только тот же угол И та же формулировка; новый угол / эмоция / заход можно продолжать) ======",
-    "es": "======Arriba están los chats proactivos recientes (solo mismo ángulo Y misma redacción cuenta como repetición; un ángulo / emoción / entrada nuevo puede continuar) ======",
-    "pt": "======Acima estão os chats proativos recentes (só mesmo ângulo E mesma redação conta como repetição; um ângulo / emoção / entrada novo pode continuar) ======",
+    "zh": "======以上为近期搭话记录（不可重复；雷同则 [PASS]！）======",
+    "en": "======Above is Recent Proactive Chats (Do NOT repeat; use [PASS] for similar content!) ======",
+    "ja": "======以上は最近の自発的発言記録（繰り返し禁止。類似するなら [PASS]！）======",
+    "ko": "======위는 최근 주도적 대화 기록 (반복 금지, 유사하면 [PASS]!) ======",
+    "ru": "======Выше Недавние проактивные сообщения (НЕ повторяйте; при сходстве выводите [PASS]!) ======",
+    "es": "======Arriba están los chats proactivos recientes (NO repitas; usa [PASS] para contenido similar) ======",
+    "pt": "======Acima estão os chats proativos recentes (NÃO repita; use [PASS] para conteúdo similar) ======",
 }
 
 # ---------- 近期搭话时间/来源标签 ----------

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -618,16 +618,37 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
     lines.append(f"{snap.state}（{state_label}）→ {propensity_directive}")
 
     # Line 1.5: tone hint (style modifier orthogonal to propensity).
-    # Skip rendering when the state would already be silenced (closed)
-    # or when tone is the safe default ``concise`` — saves a token line
-    # in the common case where there's nothing notable to say about
-    # voice. Renders as a single line: "口吻：{hint}".
-    if snap.propensity != 'closed' and snap.tone != 'concise':
+    # Skip rendering only when the state would already be silenced
+    # (``closed`` propensity — currently emitted by ``private`` state).
+    #
+    # Each tone slot in ACTIVITY_TONE_HINTS holds a short list of
+    # distinct *angles* on the scene (e.g. competitive gaming → reflex
+    # play-by-play / sideline heckling / short tactical callout). All
+    # angles are rendered as a bullet list so the model sees the full
+    # menu and picks whichever one fits the current round's content —
+    # they are illustrative direction hints, NOT lines to speak and
+    # NOT a sampling pool. The multi-variant header uses
+    # ``tone_menu_label`` (falls back to ``tone_label``), which spells
+    # out that the bullets are references to be performed through the
+    # character's own persona — never copied verbatim and never at
+    # the cost of breaking character.
+    #
+    # Backward compat: if a tone slot still holds a single string
+    # (legacy callers / mirrored tables), we wrap it into a list so
+    # both shapes render to the same output.
+    if snap.propensity != 'closed':
         tone_hints = ACTIVITY_TONE_HINTS.get(L, ACTIVITY_TONE_HINTS['en'])
-        tone_text = tone_hints.get(snap.tone)
-        if tone_text:
-            tone_label = labels.get('tone_label', 'tone')
-            lines.append(f"{tone_label}: {tone_text}")
+        tone_variants = tone_hints.get(snap.tone)
+        if isinstance(tone_variants, str):
+            tone_variants = [tone_variants]
+        if tone_variants:
+            if len(tone_variants) == 1:
+                tone_label = labels.get('tone_label', 'tone')
+                lines.append(f"{tone_label}: {tone_variants[0]}")
+            else:
+                tone_label = labels.get('tone_menu_label') or labels.get('tone_label', 'tone')
+                lines.append(f"{tone_label}:")
+                lines.extend(f"- {v}" for v in tone_variants)
 
     # Line 2: rule reasons (skip if empty — happens for unknown states).
     if snap.propensity_reasons:

--- a/main_logic/activity/snapshot.py
+++ b/main_logic/activity/snapshot.py
@@ -618,8 +618,8 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
     lines.append(f"{snap.state}（{state_label}）→ {propensity_directive}")
 
     # Line 1.5: tone hint (style modifier orthogonal to propensity).
-    # Skip rendering only when the state would already be silenced
-    # (``closed`` propensity — currently emitted by ``private`` state).
+    # ``closed`` snapshots already returned '' at the top of this
+    # function, so no closed-guard is needed here.
     #
     # Each tone slot in ACTIVITY_TONE_HINTS holds a short list of
     # distinct *angles* on the scene (e.g. competitive gaming → reflex
@@ -636,19 +636,18 @@ def format_activity_state_section(snap: 'ActivitySnapshot', lang: str = 'zh') ->
     # Backward compat: if a tone slot still holds a single string
     # (legacy callers / mirrored tables), we wrap it into a list so
     # both shapes render to the same output.
-    if snap.propensity != 'closed':
-        tone_hints = ACTIVITY_TONE_HINTS.get(L, ACTIVITY_TONE_HINTS['en'])
-        tone_variants = tone_hints.get(snap.tone)
-        if isinstance(tone_variants, str):
-            tone_variants = [tone_variants]
-        if tone_variants:
-            if len(tone_variants) == 1:
-                tone_label = labels.get('tone_label', 'tone')
-                lines.append(f"{tone_label}: {tone_variants[0]}")
-            else:
-                tone_label = labels.get('tone_menu_label') or labels.get('tone_label', 'tone')
-                lines.append(f"{tone_label}:")
-                lines.extend(f"- {v}" for v in tone_variants)
+    tone_hints = ACTIVITY_TONE_HINTS.get(L, ACTIVITY_TONE_HINTS['en'])
+    tone_variants = tone_hints.get(snap.tone)
+    if isinstance(tone_variants, str):
+        tone_variants = [tone_variants]
+    if tone_variants:
+        if len(tone_variants) == 1:
+            tone_label = labels.get('tone_label', 'tone')
+            lines.append(f"{tone_label}: {tone_variants[0]}")
+        else:
+            tone_label = labels.get('tone_menu_label') or labels.get('tone_label', 'tone')
+            lines.append(f"{tone_label}:")
+            lines.extend(f"- {v}" for v in tone_variants)
 
     # Line 2: rule reasons (skip if empty — happens for unknown states).
     if snap.propensity_reasons:


### PR DESCRIPTION
## 背景

有用户反馈**工作模式下 AI 几乎跳过所有主动搭话**。排查后定位到两类根因：

1. **Router 层硬 gate**：`focused_work` → `propensity=restricted_screen_only`，没 vision 帧就直接 pass（PR #1015 的设计，本次不动）
2. **LLM 自主 PASS**：Phase 2 prompt 多处引导叠加，把 `[PASS]` 推成默认选项 —— propensity directive、切入点列表第 5 条「没切入点→PASS」、重复判定「1 小时内同话题→PASS」、screen 子 prompt「忙碌就别发起」。同时 `focused_work` 的 tone 渲染被整段跳过，口吻引导完全缺位，更进一步把模型推向 PASS。

本 PR 从**引导侧**调整第 2 类根因。

## 改动

### `config/prompts/prompts_activity.py`
- `ACTIVITY_TONE_HINTS` 从单行风格提示改成**每个 tone 3 个互补角度的菜单**，全部渲染给模型当启发例子
- **去掉所有具体台词与拟声词**（如「稳/神/clutch/うまっ」、引号包裹的完整台词），只留「做什么」的方向描述 —— 避免模型 overfit 到固定句式、长期所有用户听到雷同的话
- `terse` 明确限定竞技游戏（LoL/Valorant/PUBG/王者…），三角度重做为：反射式实况反应（多用语气词）/ 起哄吐槽 / 短战术建议
- 去掉 `playful` 引导里的方言用词
- 新增 `tone_menu_label`：多角度菜单标题直接挂「按人设演绎、别照搬措辞、别违背角色设定」的提醒

### `main_logic/activity/snapshot.py`
- `format_activity_state_section` 不再跳过 `concise` tone 渲染 —— `focused_work` / `idle` 也能拿到口吻引导
- 多变体 tone 用 `tone_menu_label`（带角色提醒），单变体保留裸 `tone_label` 作 backward-compat

### `config/prompts/prompts_proactive.py`
- Phase 2 prompt 切入点优先级新增「同话题换新角度也算合法切入点（吐槽/关心/好奇/调侃/共情）」，`[PASS]` 从默认降级为兜底
- 重复判定改成「相同角度的同一句话」才算重复，换角度 / 换情绪 / 换切入口都不算
- PASS 护栏补「或这个话题已经重复过太多次」
- 「风格」规则补一条：口吻引导是角度思路不是台词，每次结合实时上下文自己造话

7 个 locale（zh/en/ja/ko/ru/es/pt）全部对齐。

## Test plan
- [x] `uv run pytest tests/test_activity_tracker_followup.py` — 68 passed
- [x] `uv run python scripts/check_prompt_hygiene.py` — 通过
- [x] 渲染实测：`format_activity_state_section` 在 terse/concise/playful 等 tone 下输出带角色提醒的多角度菜单，多语言 label 切换正常
- [ ] 上线后观察 `focused_work` 期间 `[PASS]` 比例是否下降、搭话内容多样性

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 活动口吻扩展为每个口吻提供 3 个可轮换角度，状态中可呈现为口吻菜单或多选项列表，默认口吻为“concise”；已在“已关闭”状态下隐藏口吻展示。

* **Behavior Changes**
  * 搭话决策规则调整：允许同话题换角度切入，重复判定更严格（时间窗口与换角度/换情绪规则明确），仅在确无新意时使用 [PASS]。

* **Documentation**
  * 补充多语言口吻菜单说明与渲染/同步约束指引。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1354)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->