### PR TITLE
feat(memory): summary 较久前段强制 `---` 分隔 + memo browser 拆段渲染

### DIFF
--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1920,25 +1920,53 @@ def render_past_memory_block(
 
 SUMMARY_STALE_HINT = {
     "zh": """======以下为时间衰减提醒======
-距上次记忆压缩已过去 {GAP} 小时。请在 summary 中，把已过时的内容（已结束的事件、已变化的状态、不再相关的近况）单独放到 summary 文末的"较久前"段落，用"X 时间前曾经..."的中性叙事；当前仍持续或重要的内容保留在 summary 主体。本提醒只影响本次 summary 生成，不进入长期记忆。
+距上次记忆压缩已过去 {GAP} 小时。请在 summary 中，把已过时的内容（已结束的事件、已变化的状态、不再相关的近况）单独放到 summary 文末的"较久前"段落，用"X 时间前曾经..."的中性叙事；当前仍持续或重要的内容保留在 summary 主体。
+
+[格式硬约束] 主体段与"较久前"段之间，必须用单独一行 `---`（三个英文连字符）作分界，前后各空一行。整段 summary 里只能出现这一处 `---`；如果没有过时内容需要写"较久前"段，则**不要**输出 `---`。
+
+本提醒只影响本次 summary 生成，不进入长期记忆。
 ======以上为时间衰减提醒======""",
     "en": """======Below is time decay notice======
-{GAP} hours have passed since the last memory compression. In the summary, move clearly outdated content (ended events, changed states, no-longer-relevant updates) into a separate "older" paragraph at the end of the summary using neutral narration like "some time ago, X used to...". Keep currently ongoing or important content in the summary body. This notice only affects the current summary generation; it does not enter long-term memory.
+{GAP} hours have passed since the last memory compression. In the summary, move clearly outdated content (ended events, changed states, no-longer-relevant updates) into a separate "older" paragraph at the end of the summary using neutral narration like "some time ago, X used to...". Keep currently ongoing or important content in the summary body.
+
+[Format constraint] Between the main body and the "older" paragraph, you MUST insert a single line containing only `---` (three ASCII hyphens), surrounded by blank lines above and below. This `---` may appear at most once in the entire summary; if there is no outdated content to write an "older" paragraph for, do NOT emit `---`.
+
+This notice only affects the current summary generation; it does not enter long-term memory.
 ======Above is time decay notice======""",
     "ja": """======以下は時間経過リマインダー======
-前回のメモリ圧縮から {GAP} 時間が経過しています。summary では明らかに古くなった内容（終了したイベント、変化した状態、関連性の薄れた近況）を summary 末尾の「以前」段落にまとめ、「以前 X だった」のような中立的な語りで記述してください。現在も継続中・重要な内容は summary 本体に残します。この通知は今回の summary 生成にのみ影響し、長期記憶には入りません。
+前回のメモリ圧縮から {GAP} 時間が経過しています。summary では明らかに古くなった内容（終了したイベント、変化した状態、関連性の薄れた近況）を summary 末尾の「以前」段落にまとめ、「以前 X だった」のような中立的な語りで記述してください。現在も継続中・重要な内容は summary 本体に残します。
+
+[フォーマット制約] 本体段落と「以前」段落の間には、必ず単独行 `---`（半角ハイフン3つ）を区切りとして挿入し、その上下を空行で囲んでください。`---` は summary 全体で1回までしか現れません。書くべき「以前」段落がなければ `---` を**出力しないで**ください。
+
+この通知は今回の summary 生成にのみ影響し、長期記憶には入りません。
 ======以上は時間経過リマインダー======""",
     "ko": """======아래는 시간 경과 알림======
-지난 메모리 압축으로부터 {GAP} 시간이 지났습니다. summary에서 명백히 오래된 내용(이미 끝난 사건, 바뀐 상태, 더 이상 관련 없는 근황)은 summary 끝의 "이전" 단락으로 옮기고, "예전에 X였다" 같은 중립적 서술로 작성하세요. 현재 진행 중이거나 중요한 내용은 summary 본문에 남깁니다. 이 알림은 이번 summary 생성에만 영향을 주며, 장기 기억에는 들어가지 않습니다.
+지난 메모리 압축으로부터 {GAP} 시간이 지났습니다. summary에서 명백히 오래된 내용(이미 끝난 사건, 바뀐 상태, 더 이상 관련 없는 근황)은 summary 끝의 "이전" 단락으로 옮기고, "예전에 X였다" 같은 중립적 서술로 작성하세요. 현재 진행 중이거나 중요한 내용은 summary 본문에 남깁니다.
+
+[형식 제약] 본문 단락과 "이전" 단락 사이에는 반드시 `---`(ASCII 하이픈 3개)만 들어간 단독 줄을 구분선으로 넣고, 그 위아래에 빈 줄을 둡니다. 전체 summary 안에서 `---`는 최대 1회만 등장합니다. 작성할 "이전" 단락이 없으면 `---`를 **출력하지 마세요**.
+
+이 알림은 이번 summary 생성에만 영향을 주며, 장기 기억에는 들어가지 않습니다.
 ======위는 시간 경과 알림======""",
     "ru": """======Ниже напоминание о времени======
-С последнего сжатия памяти прошло {GAP} часов. В summary вынесите явно устаревшие пункты (завершившиеся события, изменившиеся состояния, неактуальные новости) в отдельный абзац «ранее» в конце summary, описывая их нейтрально («ранее X было...»). Актуальное и важное оставьте в основной части summary. Это напоминание влияет только на текущую генерацию summary и не попадает в долговременную память.
+С последнего сжатия памяти прошло {GAP} часов. В summary вынесите явно устаревшие пункты (завершившиеся события, изменившиеся состояния, неактуальные новости) в отдельный абзац «ранее» в конце summary, описывая их нейтрально («ранее X было...»). Актуальное и важное оставьте в основной части summary.
+
+[Жёсткий формат] Между основным абзацем и абзацем «ранее» обязательно вставьте отдельную строку, содержащую только `---` (три ASCII-дефиса), с пустыми строками сверху и снизу. Во всём summary `---` может встретиться не более одного раза. Если устаревшего контента для абзаца «ранее» нет, **не выводите** `---`.
+
+Это напоминание влияет только на текущую генерацию summary и не попадает в долговременную память.
 ======Выше напоминание о времени======""",
     "es": """======Abajo aviso de decaimiento temporal======
-Han pasado {GAP} horas desde la última compresión de memoria. En el summary, mueve el contenido claramente obsoleto (eventos terminados, estados cambiados, actualizaciones ya no relevantes) a un párrafo "antes" al final del summary, con narración neutra como "tiempo atrás X solía...". Mantén el contenido actualmente en curso o importante en el cuerpo del summary. Este aviso solo afecta la generación actual del summary; no entra en memoria de largo plazo.
+Han pasado {GAP} horas desde la última compresión de memoria. En el summary, mueve el contenido claramente obsoleto (eventos terminados, estados cambiados, actualizaciones ya no relevantes) a un párrafo "antes" al final del summary, con narración neutra como "tiempo atrás X solía...". Mantén el contenido actualmente en curso o importante en el cuerpo del summary.
+
+[Restricción de formato] Entre el cuerpo principal y el párrafo "antes" debes insertar una línea aislada que contenga únicamente `---` (tres guiones ASCII), rodeada por líneas vacías arriba y abajo. En todo el summary `---` puede aparecer como máximo una vez. Si no hay contenido obsoleto para un párrafo "antes", **no emitas** `---`.
+
+Este aviso solo afecta la generación actual del summary; no entra en memoria de largo plazo.
 ======Arriba aviso de decaimiento temporal======""",
     "pt": """======Abaixo aviso de decaimento temporal======
-Passaram-se {GAP} horas desde a última compressão de memória. No summary, mova o conteúdo claramente desatualizado (eventos terminados, estados alterados, atualizações já irrelevantes) para um parágrafo "antes" no final do summary, com narração neutra como "tempos atrás, X costumava...". Mantenha o conteúdo atualmente em andamento ou importante no corpo do summary. Este aviso afeta apenas a geração atual do summary; não entra na memória de longo prazo.
+Passaram-se {GAP} horas desde a última compressão de memória. No summary, mova o conteúdo claramente desatualizado (eventos terminados, estados alterados, atualizações já irrelevantes) para um parágrafo "antes" no final do summary, com narração neutra como "tempos atrás, X costumava...". Mantenha o conteúdo atualmente em andamento ou importante no corpo do summary.
+
+[Restrição de formato] Entre o corpo principal e o parágrafo "antes" você deve inserir uma linha isolada contendo apenas `---` (três hifens ASCII), cercada por linhas em branco acima e abaixo. Em todo o summary `---` pode aparecer no máximo uma vez. Se não houver conteúdo desatualizado para um parágrafo "antes", **não emita** `---`.
+
+Este aviso afeta apenas a geração atual do summary; não entra na memória de longo prazo.
 ======Acima aviso de decaimento temporal======""",
 }
 

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1921,51 +1921,37 @@ def render_past_memory_block(
 SUMMARY_STALE_HINT = {
     "zh": """======以下为时间衰减提醒======
 距上次记忆压缩已过去 {GAP} 小时。请在 summary 中，把已过时的内容（已结束的事件、已变化的状态、不再相关的近况）单独放到 summary 文末的"较久前"段落，用"X 时间前曾经..."的中性叙事；当前仍持续或重要的内容保留在 summary 主体。
-
 [格式硬约束] 主体段与"较久前"段之间，必须用单独一行 `---`（三个英文连字符）作分界，前后各空一行。整段 summary 里只能出现这一处 `---`；如果没有过时内容需要写"较久前"段，则**不要**输出 `---`。
-
 本提醒只影响本次 summary 生成，不进入长期记忆。
 ======以上为时间衰减提醒======""",
     "en": """======Below is time decay notice======
 {GAP} hours have passed since the last memory compression. In the summary, move clearly outdated content (ended events, changed states, no-longer-relevant updates) into a separate "older" paragraph at the end of the summary using neutral narration like "some time ago, X used to...". Keep currently ongoing or important content in the summary body.
-
 [Format constraint] Between the main body and the "older" paragraph, you MUST insert a single line containing only `---` (three ASCII hyphens), surrounded by blank lines above and below. This `---` may appear at most once in the entire summary; if there is no outdated content to write an "older" paragraph for, do NOT emit `---`.
-
 This notice only affects the current summary generation; it does not enter long-term memory.
 ======Above is time decay notice======""",
     "ja": """======以下は時間経過リマインダー======
 前回のメモリ圧縮から {GAP} 時間が経過しています。summary では明らかに古くなった内容（終了したイベント、変化した状態、関連性の薄れた近況）を summary 末尾の「以前」段落にまとめ、「以前 X だった」のような中立的な語りで記述してください。現在も継続中・重要な内容は summary 本体に残します。
-
 [フォーマット制約] 本体段落と「以前」段落の間には、必ず単独行 `---`（半角ハイフン3つ）を区切りとして挿入し、その上下を空行で囲んでください。`---` は summary 全体で1回までしか現れません。書くべき「以前」段落がなければ `---` を**出力しないで**ください。
-
 この通知は今回の summary 生成にのみ影響し、長期記憶には入りません。
 ======以上は時間経過リマインダー======""",
     "ko": """======아래는 시간 경과 알림======
 지난 메모리 압축으로부터 {GAP} 시간이 지났습니다. summary에서 명백히 오래된 내용(이미 끝난 사건, 바뀐 상태, 더 이상 관련 없는 근황)은 summary 끝의 "이전" 단락으로 옮기고, "예전에 X였다" 같은 중립적 서술로 작성하세요. 현재 진행 중이거나 중요한 내용은 summary 본문에 남깁니다.
-
 [형식 제약] 본문 단락과 "이전" 단락 사이에는 반드시 `---`(ASCII 하이픈 3개)만 들어간 단독 줄을 구분선으로 넣고, 그 위아래에 빈 줄을 둡니다. 전체 summary 안에서 `---`는 최대 1회만 등장합니다. 작성할 "이전" 단락이 없으면 `---`를 **출력하지 마세요**.
-
 이 알림은 이번 summary 생성에만 영향을 주며, 장기 기억에는 들어가지 않습니다.
 ======위는 시간 경과 알림======""",
     "ru": """======Ниже напоминание о времени======
 С последнего сжатия памяти прошло {GAP} часов. В summary вынесите явно устаревшие пункты (завершившиеся события, изменившиеся состояния, неактуальные новости) в отдельный абзац «ранее» в конце summary, описывая их нейтрально («ранее X было...»). Актуальное и важное оставьте в основной части summary.
-
 [Жёсткий формат] Между основным абзацем и абзацем «ранее» обязательно вставьте отдельную строку, содержащую только `---` (три ASCII-дефиса), с пустыми строками сверху и снизу. Во всём summary `---` может встретиться не более одного раза. Если устаревшего контента для абзаца «ранее» нет, **не выводите** `---`.
-
 Это напоминание влияет только на текущую генерацию summary и не попадает в долговременную память.
 ======Выше напоминание о времени======""",
     "es": """======Abajo aviso de decaimiento temporal======
 Han pasado {GAP} horas desde la última compresión de memoria. En el summary, mueve el contenido claramente obsoleto (eventos terminados, estados cambiados, actualizaciones ya no relevantes) a un párrafo "antes" al final del summary, con narración neutra como "tiempo atrás X solía...". Mantén el contenido actualmente en curso o importante en el cuerpo del summary.
-
 [Restricción de formato] Entre el cuerpo principal y el párrafo "antes" debes insertar una línea aislada que contenga únicamente `---` (tres guiones ASCII), rodeada por líneas vacías arriba y abajo. En todo el summary `---` puede aparecer como máximo una vez. Si no hay contenido obsoleto para un párrafo "antes", **no emitas** `---`.
-
 Este aviso solo afecta la generación actual del summary; no entra en memoria de largo plazo.
 ======Arriba aviso de decaimiento temporal======""",
     "pt": """======Abaixo aviso de decaimento temporal======
 Passaram-se {GAP} horas desde a última compressão de memória. No summary, mova o conteúdo claramente desatualizado (eventos terminados, estados alterados, atualizações já irrelevantes) para um parágrafo "antes" no final do summary, com narração neutra como "tempos atrás, X costumava...". Mantenha o conteúdo atualmente em andamento ou importante no corpo do summary.
-
 [Restrição de formato] Entre o corpo principal e o parágrafo "antes" você deve inserir uma linha isolada contendo apenas `---` (três hifens ASCII), cercada por linhas em branco acima e abaixo. Em todo o summary `---` pode aparecer no máximo uma vez. Se não houver conteúdo desatualizado para um parágrafo "antes", **não emita** `---`.
-
 Este aviso afeta apenas a geração atual do summary; não entra na memória de longo prazo.
 ======Acima aviso de decaimento temporal======""",
 }

--- a/static/css/dark-mode.css
+++ b/static/css/dark-mode.css
@@ -1336,6 +1336,16 @@ html #chat-container {
   color: #4aa3df;
 }
 
+[data-theme="dark"] .memo-older-label {
+  color: #6a8a9d;
+}
+
+[data-theme="dark"] .memo-textarea--older {
+  background: #1f1f1f;
+  color: #b8b8b8;
+  border-color: #3a3a3a;
+}
+
 [data-theme="dark"] .chat-time {
   color: #666;
 }

--- a/static/css/memory_browser.css
+++ b/static/css/memory_browser.css
@@ -1115,6 +1115,26 @@ html.neko-window-maximized .chat-item + .chat-item:hover::before {
     box-shadow: 0 0 0 3px rgba(64, 197, 241, 0.1);
 }
 
+/* "较久前"尾段：视觉上比主体降一档，让阅读时第一眼就能看出这是 LLM 已归档的旧
+ * 事件。前置 label + 缩小字号 + 轻量背景；编辑功能保持完整。 */
+.memo-older-label {
+    display: block;
+    margin-top: 14px;
+    margin-bottom: 6px;
+    font-size: 0.85rem;
+    color: #7fb8d4;
+    letter-spacing: 0.02em;
+}
+
+.memo-textarea--older {
+    min-height: 80px;
+    font-size: 0.92rem;
+    color: #5a9fbf;
+    background: #f6fbff;
+    border-style: dashed;
+    border-color: #cfe6f3;
+}
+
 .chat-bubble {
     background: #f0f9ff;
     color: #40C5F1;

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -881,11 +881,43 @@
                 label.textContent = memoPrefix;
                 contentWrapper.appendChild(label);
 
+                // LLM 在压缩时按 SUMMARY_STALE_HINT 要求，把"较久前"段用单独
+                // 一行 `---` 与主体分隔。这里识别该分隔符并拆成两块独立 textarea
+                // 渲染，让阅读 / 编辑时能清楚区分"当前进行中"和"已归档"。
+                // 保存时再用 composeMemo 拼回 `\n\n---\n\n` 单一规范形式。
+                let bodyValue;
+                let olderValue;
+                ({ body: bodyValue, older: olderValue } = splitMemoOnDivider(text));
+                const commitMemo = function () {
+                    updateSystemContent(i, composeMemo(bodyValue, olderValue));
+                };
+
                 const ta = document.createElement('textarea');
                 ta.className = 'memo-textarea';
-                ta.value = text;
-                ta.addEventListener('change', function () { updateSystemContent(i, this.value); });
+                ta.value = bodyValue;
+                ta.addEventListener('change', function () {
+                    bodyValue = this.value;
+                    commitMemo();
+                });
                 contentWrapper.appendChild(ta);
+
+                if (olderValue) {
+                    const olderLabel = document.createElement('span');
+                    olderLabel.className = 'memo-older-label';
+                    olderLabel.textContent = window.t
+                        ? window.t('memory.olderSection', '较久前')
+                        : '较久前';
+                    contentWrapper.appendChild(olderLabel);
+
+                    const olderTa = document.createElement('textarea');
+                    olderTa.className = 'memo-textarea memo-textarea--older';
+                    olderTa.value = olderValue;
+                    olderTa.addEventListener('change', function () {
+                        olderValue = this.value;
+                        commitMemo();
+                    });
+                    contentWrapper.appendChild(olderTa);
+                }
             } else if (msg.role === 'ai') {
                 // 提取时间戳和正文，健壮处理
                 const m = msg.text.match(/^(\[[^\]]+\])([\s\S]*)$/);
@@ -965,6 +997,29 @@
             chatData[idx].text = value;
         }
     }
+    // 备忘录正文里 LLM 按 SUMMARY_STALE_HINT 约定，用 `---` 单独占行的分隔符
+    // 把"较久前"尾段从主体切开。这里识别"前后各空一行 + 仅含三个及以上连字符
+    // 的单行"——容忍 LLM 偶尔多输 / 少输空行 / 多输几个连字符的变体——并切成
+    // body / older 两段；如果整段里出现多次匹配（违反 prompt 约束），只取第一次。
+    const MEMO_DIVIDER_RE = /\r?\n[ \t]*\r?\n[ \t]*-{3,}[ \t]*\r?\n[ \t]*\r?\n/;
+
+    function splitMemoOnDivider(text) {
+        const src = String(text == null ? '' : text);
+        const m = MEMO_DIVIDER_RE.exec(src);
+        if (!m) return { body: src, older: '' };
+        return {
+            body: src.slice(0, m.index),
+            older: src.slice(m.index + m[0].length),
+        };
+    }
+
+    function composeMemo(body, older) {
+        const cleanBody = String(body == null ? '' : body).replace(/\s+$/, '');
+        const cleanOlder = String(older == null ? '' : older).replace(/^\s+/, '');
+        if (!cleanOlder) return cleanBody;
+        return cleanBody + '\n\n---\n\n' + cleanOlder;
+    }
+
     function updateSystemContent(idx, value) {
         // 存储时先移除任何现有的前缀，然后加上当前语言的前缀
         // 定义已知的备忘录前缀列表

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -998,10 +998,11 @@
         }
     }
     // 备忘录正文里 LLM 按 SUMMARY_STALE_HINT 约定，用 `---` 单独占行的分隔符
-    // 把"较久前"尾段从主体切开。这里识别"前后各空一行 + 仅含三个及以上连字符
-    // 的单行"——容忍 LLM 偶尔多输 / 少输空行 / 多输几个连字符的变体——并切成
-    // body / older 两段；如果整段里出现多次匹配（违反 prompt 约束），只取第一次。
-    const MEMO_DIVIDER_RE = /\r?\n[ \t]*\r?\n[ \t]*-{3,}[ \t]*\r?\n[ \t]*\r?\n/;
+    // 把"较久前"尾段从主体切开。这里识别"`---` 单独成行（前后都换行了）"——
+    // 前后空行数量都不强求，吃下 LLM 漏空行 / 多空行 / 多输几个连字符的常见漂移；
+    // 切成 body / older 两段后 composeMemo 再统一拼回规范 `\n\n---\n\n`。
+    // 整段里出现多次匹配（违反 prompt 约束）只取第一次。
+    const MEMO_DIVIDER_RE = /(?:\r?\n)+[ \t]*-{3,}[ \t]*(?:\r?\n)+/;
 
     function splitMemoOnDivider(text) {
         const src = String(text == null ? '' : text);

--- a/static/js/memory_browser.js
+++ b/static/js/memory_browser.js
@@ -1015,8 +1015,12 @@
     }
 
     function composeMemo(body, older) {
-        const cleanBody = String(body == null ? '' : body).replace(/\s+$/, '');
-        const cleanOlder = String(older == null ? '' : older).replace(/^\s+/, '');
+        // body 的尾部 / older 的首部都只去掉"整行空白"——也就是 trailing blank
+        // lines / leading blank lines——保留段内有意义的前导缩进（用户在 older
+        // textarea 里手写嵌套列表 / 代码片段时不被吃）。
+        // 拼回时再用规范 `\n\n---\n\n` 形式，splitter 端会容忍换行漂移。
+        const cleanBody = String(body == null ? '' : body).replace(/(?:[ \t]*\r?\n)+$/, '');
+        const cleanOlder = String(older == null ? '' : older).replace(/^(?:[ \t]*\r?\n)+/, '');
         if (!cleanOlder) return cleanBody;
         return cleanBody + '\n\n---\n\n' + cleanOlder;
     }

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "Load failed",
         "noChatContent": "No chat content",
         "previousMemo": "Previous conversation memo: ",
+        "olderSection": "Earlier",
         "memoNone": "None.",
         "delete": "Delete",
         "me": "Me:",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "Error de carga",
         "noChatContent": "Sin contenido de chat",
         "previousMemo": "Nota de conversación anterior:",
+        "olderSection": "Antes",
         "memoNone": "Ninguno.",
         "delete": "Borrar",
         "me": "A mí:",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "読み込み失敗",
         "noChatContent": "チャットコンテンツなし",
         "previousMemo": "前回の会話メモ: ",
+        "olderSection": "以前",
         "memoNone": "なし。",
         "delete": "削除",
         "me": "私:",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "로드 실패",
         "noChatContent": "채팅 콘텐츠 없음",
         "previousMemo": "이전 대화 메모:",
+        "olderSection": "이전",
         "memoNone": "없음.",
         "delete": "삭제",
         "me": "나:",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "Falha no carregamento",
         "noChatContent": "Nenhum conteúdo de bate-papo",
         "previousMemo": "Memorando de conversa anterior:",
+        "olderSection": "Antes",
         "memoNone": "Nenhum.",
         "delete": "Excluir",
         "me": "Meu:",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "Ошибка загрузки",
         "noChatContent": "Нет содержимого чата",
         "previousMemo": "Заметка из предыдущего разговора: ",
+        "olderSection": "Ранее",
         "memoNone": "Нет.",
         "delete": "Удалить",
         "me": "Я:",

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "加载失败",
         "noChatContent": "无聊天内容",
         "previousMemo": "先前对话的备忘录: ",
+        "olderSection": "较久前",
         "memoNone": "无。",
         "delete": "删除",
         "me": "我：",

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -1552,6 +1552,7 @@
         "loadFailed": "加載失敗",
         "noChatContent": "無聊天內容",
         "previousMemo": "先前對話的備忘錄: ",
+        "olderSection": "較久前",
         "memoNone": "無。",
         "delete": "刪除",
         "me": "我：",

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -365,8 +365,11 @@ def test_memory_browser_splits_non_canonical_divider_spacing(
     older_ta = mock_page.locator(".memo-textarea--older")
     expect(older_ta).to_have_count(1, timeout=5000)
     body_ta = mock_page.locator(".memo-textarea:not(.memo-textarea--older)")
-    assert _BODY_SENTENCE in body_ta.input_value()
-    assert "-" not in body_ta.input_value(), "body 不应残留任何 dash"
+    body_value = body_ta.input_value()
+    assert _BODY_SENTENCE in body_value
+    # 收紧到只查"≥3 连字符"的分隔符形态——单/双连字符在正文里可能合法
+    # （日期、复合词），不该被这条断言误伤。
+    assert "---" not in body_value, "body 不应残留分隔符"
     assert _OLDER_SENTENCE in older_ta.input_value()
 
 

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -243,10 +243,15 @@ def test_memory_browser_select_file(mock_page: Page, running_server: str, seed_m
     expect(mock_page.locator("#save-row")).to_be_visible()
 
 
-@pytest.fixture
-def seed_memory_file_with_older_divider(clean_user_data_dir, running_server):
-    """种子文件：memo 里含 `\\n\\n---\\n\\n` 分界，模拟 LLM 按 SUMMARY_STALE_HINT
-    新规约产出的"主体段 + 较久前段"形态。"""
+_BODY_SENTENCE = "博士正在和小猫娘一起挖铁矿，刚找到一批可以做铁镐。"
+_OLDER_SENTENCE = "几天前两人养过一株窗台幼苗，并烤了草莓蛋糕。"
+
+
+def _write_memo_seed(clean_user_data_dir, divider: str):
+    """种子一个 recent.json，memo body + 指定形态的 `---` 分隔符 + older。
+
+    `divider` 是 body 与 older 之间的完整分隔片段（包含前后换行），让用例
+    覆盖 LLM 实际可能漂移的几种间距（漏空行 / 多空行 / 多个连字符）。"""
     app_root = Path(clean_user_data_dir) / "N.E.K.O"
     save_storage_policy(
         None,
@@ -260,12 +265,7 @@ def seed_memory_file_with_older_divider(clean_user_data_dir, running_server):
     catgirl_dir = memory_dir / "测试猫娘"
     catgirl_dir.mkdir(parents=True, exist_ok=True)
 
-    memo_text = (
-        "先前对话的备忘录: "
-        "博士正在和小猫娘一起挖铁矿，刚找到一批可以做铁镐。"
-        "\n\n---\n\n"
-        "几天前两人养过一株窗台幼苗，并烤了草莓蛋糕。"
-    )
+    memo_text = f"先前对话的备忘录: {_BODY_SENTENCE}{divider}{_OLDER_SENTENCE}"
     test_data = [
         {
             "type": "system",
@@ -284,6 +284,12 @@ def seed_memory_file_with_older_divider(clean_user_data_dir, running_server):
     memory_file = catgirl_dir / "recent.json"
     atomic_write_json(memory_file, test_data, ensure_ascii=False, indent=2)
     return memory_file
+
+
+@pytest.fixture
+def seed_memory_file_with_older_divider(clean_user_data_dir, running_server):
+    """种子文件：memo 用规范 `\\n\\n---\\n\\n` 分界（LLM 严格遵守 prompt 的形态）。"""
+    return _write_memo_seed(clean_user_data_dir, "\n\n---\n\n")
 
 
 @pytest.mark.frontend
@@ -322,6 +328,46 @@ def test_memory_browser_renders_older_section_when_divider_present(
     older_value = older_ta.input_value()
     assert "草莓蛋糕" in older_value
     assert "正在和小猫娘一起挖铁矿" not in older_value
+
+
+@pytest.mark.frontend
+@pytest.mark.parametrize(
+    "divider",
+    [
+        pytest.param("\n---\n", id="single_newline_each_side"),
+        pytest.param("\n\n---\n", id="blank_before_only"),
+        pytest.param("\n---\n\n", id="blank_after_only"),
+        pytest.param("\n\n\n---\n\n", id="extra_blank_before"),
+        pytest.param("\n\n----\n\n", id="four_dashes"),
+        pytest.param("\n\n-----\n\n", id="five_dashes"),
+    ],
+)
+def test_memory_browser_splits_non_canonical_divider_spacing(
+    mock_page: Page,
+    running_server: str,
+    clean_user_data_dir,
+    divider,
+):
+    """LLM 实际输出经常漂移：漏空行、多空行、多输连字符——splitter 都得切得开。
+
+    Regression for codex review on PR #1358 catching that the original regex
+    强制要求 `---` 前后各一行空行，少一行就识别不到，导致尾段还是塞回 body
+    textarea。修后正则只要求 `---` 单独成行（前后至少各一个换行）。"""
+    mock_page.on("console", lambda msg: print(f"Browser Console: {msg.text}"))
+    memory_file = _write_memo_seed(clean_user_data_dir, divider)
+    _install_ready_memory_browser_routes(mock_page, memory_file)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-file-list button.cat-btn", state="attached", timeout=10000)
+    mock_page.locator("#memory-file-list button.cat-btn", has_text="测试猫娘").first.click()
+    mock_page.wait_for_selector("#memory-chat-edit .chat-item", timeout=5000)
+
+    older_ta = mock_page.locator(".memo-textarea--older")
+    expect(older_ta).to_have_count(1, timeout=5000)
+    body_ta = mock_page.locator(".memo-textarea:not(.memo-textarea--older)")
+    assert _BODY_SENTENCE in body_ta.input_value()
+    assert "-" not in body_ta.input_value(), "body 不应残留任何 dash"
+    assert _OLDER_SENTENCE in older_ta.input_value()
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -243,6 +243,191 @@ def test_memory_browser_select_file(mock_page: Page, running_server: str, seed_m
     expect(mock_page.locator("#save-row")).to_be_visible()
 
 
+@pytest.fixture
+def seed_memory_file_with_older_divider(clean_user_data_dir, running_server):
+    """种子文件：memo 里含 `\\n\\n---\\n\\n` 分界，模拟 LLM 按 SUMMARY_STALE_HINT
+    新规约产出的"主体段 + 较久前段"形态。"""
+    app_root = Path(clean_user_data_dir) / "N.E.K.O"
+    save_storage_policy(
+        None,
+        selected_root=app_root,
+        anchor_root=app_root,
+        selection_source="test",
+    )
+
+    memory_dir = app_root / "memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    catgirl_dir = memory_dir / "测试猫娘"
+    catgirl_dir.mkdir(parents=True, exist_ok=True)
+
+    memo_text = (
+        "先前对话的备忘录: "
+        "博士正在和小猫娘一起挖铁矿，刚找到一批可以做铁镐。"
+        "\n\n---\n\n"
+        "几天前两人养过一株窗台幼苗，并烤了草莓蛋糕。"
+    )
+    test_data = [
+        {
+            "type": "system",
+            "data": {
+                "content": memo_text,
+                "additional_kwargs": {},
+                "response_metadata": {},
+                "type": "system",
+                "name": None,
+                "id": None,
+                "example": False,
+            },
+        }
+    ]
+
+    memory_file = catgirl_dir / "recent.json"
+    atomic_write_json(memory_file, test_data, ensure_ascii=False, indent=2)
+    return memory_file
+
+
+@pytest.mark.frontend
+def test_memory_browser_renders_older_section_when_divider_present(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file_with_older_divider,
+):
+    """memo 含 `\\n\\n---\\n\\n` 时，前端必须把"较久前"段拆成独立 textarea 渲染，
+    并出现一个 `memo-older-label` 提示。
+
+    这是 SUMMARY_STALE_HINT 硬分隔约定的落地点——LLM 输出端 + 前端识别端
+    之间的契约就靠这条端到端测。
+    """
+    mock_page.on("console", lambda msg: print(f"Browser Console: {msg.text}"))
+    _install_ready_memory_browser_routes(mock_page, seed_memory_file_with_older_divider)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-file-list button.cat-btn", state="attached", timeout=10000)
+    mock_page.locator("#memory-file-list button.cat-btn", has_text="测试猫娘").first.click()
+    mock_page.wait_for_selector("#memory-chat-edit .chat-item", timeout=5000)
+
+    # 主体 textarea：不包含 `---`，也不包含尾段文本
+    body_ta = mock_page.locator(".memo-textarea:not(.memo-textarea--older)")
+    expect(body_ta).to_have_count(1, timeout=5000)
+    body_value = body_ta.input_value()
+    assert "正在和小猫娘一起挖铁矿" in body_value
+    assert "---" not in body_value, "主体段不应含分隔符——已被 splitter 切掉"
+    assert "草莓蛋糕" not in body_value, "尾段文本应只出现在 older textarea"
+
+    # 较久前 label + 独立 textarea
+    older_label = mock_page.locator(".memo-older-label")
+    expect(older_label).to_have_count(1, timeout=5000)
+    older_ta = mock_page.locator(".memo-textarea--older")
+    expect(older_ta).to_have_count(1, timeout=5000)
+    older_value = older_ta.input_value()
+    assert "草莓蛋糕" in older_value
+    assert "正在和小猫娘一起挖铁矿" not in older_value
+
+
+@pytest.mark.frontend
+def test_memory_browser_saves_memo_with_divider_roundtrip(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file_with_older_divider,
+):
+    """编辑任一 textarea 后保存，发往后端的 payload 必须重新拼回 `\\n\\n---\\n\\n`
+    规范形式——不能漏掉尾段、也不能改用别的分隔符。"""
+    mock_page.on("console", lambda msg: print(f"Browser Console: {msg.text}"))
+
+    saved_payloads: list[dict] = []
+
+    app_root = seed_memory_file_with_older_divider.parents[2]
+
+    def handle_bootstrap(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={
+                "current_root": str(app_root),
+                "recommended_root": str(app_root),
+                "legacy_sources": [],
+                "selection_required": False,
+                "migration_pending": False,
+                "recovery_required": False,
+                "blocking_reason": "",
+            },
+        )
+
+    def handle_recent_files(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={"files": ["recent_测试猫娘.json"]},
+        )
+
+    def handle_current_catgirl(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={"current_catgirl": "测试猫娘"},
+        )
+
+    def handle_recent_file(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={"content": seed_memory_file_with_older_divider.read_text(encoding="utf-8")},
+        )
+
+    def handle_review_config(route):
+        route.fulfill(status=200, content_type="application/json", json={"enabled": True})
+
+    def handle_save(route):
+        saved_payloads.append(_request_json(route))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={"success": True, "need_refresh": False},
+        )
+
+    mock_page.route("**/api/storage/location/bootstrap", handle_bootstrap)
+    mock_page.route("**/api/memory/recent_files", handle_recent_files)
+    mock_page.route("**/api/characters/current_catgirl", handle_current_catgirl)
+    mock_page.route("**/api/memory/recent_file?**", handle_recent_file)
+    mock_page.route("**/api/memory/review_config", handle_review_config)
+    mock_page.route("**/api/memory/recent_file/save", handle_save)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-file-list button.cat-btn", state="attached", timeout=10000)
+    mock_page.locator("#memory-file-list button.cat-btn", has_text="测试猫娘").first.click()
+    mock_page.wait_for_selector(".memo-textarea--older", timeout=5000)
+
+    # 改写尾段并 commit（textarea 的 `change` 事件靠 blur 触发）
+    older_ta = mock_page.locator(".memo-textarea--older").first
+    older_ta.fill("几天前的旧事件——已归档。")
+    # 把焦点挪走触发 change
+    mock_page.locator(".memo-textarea:not(.memo-textarea--older)").first.click()
+
+    with mock_page.expect_response(
+        lambda r: "/api/memory/recent_file/save" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ):
+        mock_page.locator("#save-memory-btn").click()
+
+    assert len(saved_payloads) == 1
+    chat = saved_payloads[0]["chat"]
+    system_msgs = [m for m in chat if m.get("role") == "system"]
+    assert len(system_msgs) == 1
+    saved_text = system_msgs[0]["text"]
+
+    # 1) 仍以本地化前缀打头
+    assert saved_text.startswith("先前对话的备忘录: ")
+    # 2) 主体段保留
+    assert "正在和小猫娘一起挖铁矿" in saved_text
+    # 3) 尾段被改写
+    assert "几天前的旧事件——已归档。" in saved_text
+    # 4) 分隔符是规范的 `\n\n---\n\n`
+    assert "\n\n---\n\n" in saved_text
+    # 5) 整段里 `---` 只出现一次
+    assert saved_text.count("\n---\n") == 1
+
+
 @pytest.mark.frontend
 def test_memory_browser_auto_review_toggle(mock_page: Page, running_server: str, seed_memory_file):
     """Test that the auto-review toggle works and persists."""

--- a/tests/frontend/test_memory_browser.py
+++ b/tests/frontend/test_memory_browser.py
@@ -475,6 +475,91 @@ def test_memory_browser_saves_memo_with_divider_roundtrip(
 
 
 @pytest.mark.frontend
+def test_memory_browser_preserves_leading_indent_in_older_section(
+    mock_page: Page,
+    running_server: str,
+    seed_memory_file_with_older_divider,
+):
+    """Regression for codex review on PR #1358: composeMemo 不能把 older 段首字符
+    的有意义缩进当 noise 削掉——只能削整行空白。比如用户在 older textarea 里
+    手写一个嵌套列表（前导 2 空格 / tab），保存后必须 byte-for-byte 留住。"""
+    mock_page.on("console", lambda msg: print(f"Browser Console: {msg.text}"))
+
+    saved_payloads: list[dict] = []
+    app_root = seed_memory_file_with_older_divider.parents[2]
+
+    def handle_bootstrap(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={
+                "current_root": str(app_root),
+                "recommended_root": str(app_root),
+                "legacy_sources": [],
+                "selection_required": False,
+                "migration_pending": False,
+                "recovery_required": False,
+                "blocking_reason": "",
+            },
+        )
+
+    def handle_recent_files(route):
+        route.fulfill(status=200, content_type="application/json", json={"files": ["recent_测试猫娘.json"]})
+
+    def handle_current_catgirl(route):
+        route.fulfill(status=200, content_type="application/json", json={"current_catgirl": "测试猫娘"})
+
+    def handle_recent_file(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            json={"content": seed_memory_file_with_older_divider.read_text(encoding="utf-8")},
+        )
+
+    def handle_review_config(route):
+        route.fulfill(status=200, content_type="application/json", json={"enabled": True})
+
+    def handle_save(route):
+        saved_payloads.append(_request_json(route))
+        route.fulfill(status=200, content_type="application/json", json={"success": True, "need_refresh": False})
+
+    mock_page.route("**/api/storage/location/bootstrap", handle_bootstrap)
+    mock_page.route("**/api/memory/recent_files", handle_recent_files)
+    mock_page.route("**/api/characters/current_catgirl", handle_current_catgirl)
+    mock_page.route("**/api/memory/recent_file?**", handle_recent_file)
+    mock_page.route("**/api/memory/review_config", handle_review_config)
+    mock_page.route("**/api/memory/recent_file/save", handle_save)
+
+    mock_page.goto(f"{running_server}/memory_browser")
+    mock_page.wait_for_selector("#memory-file-list button.cat-btn", state="attached", timeout=10000)
+    mock_page.locator("#memory-file-list button.cat-btn", has_text="测试猫娘").first.click()
+    mock_page.wait_for_selector(".memo-textarea--older", timeout=5000)
+
+    # 写一段首字符就有 2 空格缩进 + 后续行 4 空格缩进的内容（模拟嵌套列表）
+    indented_older = "  顶层条目一\n    子条目 a\n    子条目 b"
+    older_ta = mock_page.locator(".memo-textarea--older").first
+    older_ta.fill(indented_older)
+    mock_page.locator(".memo-textarea:not(.memo-textarea--older)").first.click()
+
+    with mock_page.expect_response(
+        lambda r: "/api/memory/recent_file/save" in r.url
+        and r.request.method == "POST"
+        and r.status == 200
+    ):
+        mock_page.locator("#save-memory-btn").click()
+
+    assert len(saved_payloads) == 1
+    saved_text = next(
+        m["text"] for m in saved_payloads[0]["chat"] if m.get("role") == "system"
+    )
+
+    # 关键断言：分隔符之后立刻是 `  顶层条目一`，前导 2 空格没有被吃掉
+    assert "\n\n---\n\n  顶层条目一\n    子条目 a\n    子条目 b" in saved_text, (
+        f"older 段前导缩进被吞掉了，实际保存：{saved_text!r}"
+    )
+
+
+@pytest.mark.frontend
 def test_memory_browser_auto_review_toggle(mock_page: Page, running_server: str, seed_memory_file):
     """Test that the auto-review toggle works and persists."""
     mock_page.on("console", lambda msg: print(f"Browser Console: {msg.text}"))

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -245,58 +245,74 @@ def test_unicode_numeric_prefixes_not_stripped(raw):
         robust_json_loads(raw)
 
 
-# ── over-escaped newlines normalization (divider-fingerprint trigger) ──
-# 触发条件：字符串里出现 ``\n[空白]?---[空白]?\n``（字面量，过度转义的 ``---``
-# 分隔符指纹）。这是 summary 整段 over-escape 时唯一可靠的故障签名——其它含
-# 字面量 ``\n`` 的合法场景（Windows 路径、regex meta-char、tool args 代码）
-# 在 ``\n`` 周围不会出现 ``---``，所以不会被触发。
+# ── over-escaped `---` divider normalization (region-scoped) ───────────
+# 触发：字符串里出现 1+ 字面量换行类 escape (``\n`` / ``\r\n`` / ``\r``)
+# 紧贴 ``---`` 行。匹配到时只把这一段 divider 区域换成规范 ``\n\n---\n\n``——
+# **同字符串里其它位置的字面量 escape 一律不动**，避免误伤 Windows 路径 /
+# regex / code 片段等合法场景。
 
 
 @pytest.mark.unit
-def test_overescaped_divider_normalizes_whole_summary():
-    """LLM 把整段 over-escape 时（JSON 源 ``\\\\n``，解码后字面量 ``\\n``）
-    且 divider 也被波及：归一化整段，恢复真换行。"""
+def test_overescaped_divider_replaced_with_canonical_form():
+    """LLM 把 divider 整体 over-escape：``body\\n\\n---\\n\\nolder`` 全字面量
+    → divider 区域归一化成真 ``\\n\\n---\\n\\n``。"""
     raw = '{"summary": "body\\\\n\\\\n---\\\\n\\\\nolder"}'
     parsed = robust_json_loads(raw)
     assert parsed["summary"] == "body\n\n---\n\nolder"
 
 
 @pytest.mark.unit
-def test_overescaped_divider_normalizes_tab_in_same_string():
-    """指纹命中后，同字符串里的字面量 ``\\t`` 一并归一化——LLM 整段 over-escape
-    通常波及所有控制字符。"""
-    raw = '{"summary": "col1\\\\tcol2\\\\n\\\\n---\\\\n\\\\nolder"}'
-    parsed = robust_json_loads(raw)
-    assert parsed["summary"] == "col1\tcol2\n\n---\n\nolder"
-
-
-@pytest.mark.unit
-def test_overescaped_divider_with_crlf_fingerprint():
-    """`\\r\\n` 形态的 over-escape 也走通。"""
-    # JSON 源 ``"body\\r\\n\\r\\n---\\r\\n\\r\\nolder"`` 解析后字面量
+def test_overescaped_divider_crlf_form():
+    """CRLF over-escape：``\\r\\n\\r\\n---\\r\\n\\r\\n`` 也走通。"""
     raw = '{"summary": "body\\\\r\\\\n\\\\r\\\\n---\\\\r\\\\n\\\\r\\\\nolder"}'
     parsed = robust_json_loads(raw)
+    # divider 区域归一为规范形态
     assert "\n\n---\n\n" in parsed["summary"]
+    # 整段没有残留任何字面量 escape，因为本 case 字符串里只有 divider 区域含 escape
     assert "\\r" not in parsed["summary"]
     assert "\\n" not in parsed["summary"]
 
 
 @pytest.mark.unit
+def test_divider_normalized_but_unrelated_literals_preserved():
+    """关键 P2 反向 case（codex / coderabbit）：同字段里既有 over-escape divider
+    又有合法字面量 escape（Windows 路径里的 ``\\new``）——只动 divider 区域，
+    路径完整保留。"""
+    raw = (
+        '{"summary": "see C:\\\\new_folder for context'
+        '\\\\n\\\\n---\\\\n\\\\nolder content"}'
+    )
+    parsed = robust_json_loads(raw)
+    # divider 部分被规范化
+    assert "\n\n---\n\n" in parsed["summary"]
+    # Windows 路径里的 `\new_folder` 字面量原样保留，**不能**变成 `[NL]ew_folder`
+    assert r"C:\new_folder" in parsed["summary"]
+
+
+@pytest.mark.unit
+def test_divider_normalized_but_tab_literal_preserved():
+    """同字段里既有 divider 又有合法 ``\\t`` 字面量——``\\t`` 保留。"""
+    raw = '{"summary": "header\\\\tdata\\\\n\\\\n---\\\\n\\\\nolder"}'
+    parsed = robust_json_loads(raw)
+    # divider 区域归一化
+    assert "\n\n---\n\n" in parsed["summary"]
+    # `\t` 字面量不被波及
+    assert r"header\tdata" in parsed["summary"]
+
+
+@pytest.mark.unit
 def test_windows_path_with_literal_backslash_n_preserved():
-    """关键反向 case（codex / coderabbit P1）：Windows 路径 ``C:\\new_folder``
-    JSON 源 ``"C:\\\\new_folder"`` 解析后是字面量 ``C:\\new_folder``，
-    含 ``\\n`` 字面量但不是 over-escape，绝不能改成换行。"""
+    """字符串无 divider 指纹：Windows 路径 ``C:\\new_folder`` 完整透传。"""
     raw = r'{"path": "C:\\new_folder\\notes.txt"}'
     parsed = robust_json_loads(raw)
     assert parsed["path"] == r"C:\new_folder\notes.txt"
-    # 字面量 backslash 完整保留
     assert "\n" not in parsed["path"]
 
 
 @pytest.mark.unit
 def test_regex_with_literal_backslash_n_preserved():
-    """另一个反向 case：regex 模式 ``\\n+`` 在 JSON 源里是 ``"\\\\n+"``，
-    解析后字面量 ``\\n+``。LLM 工具调用经常这样传 regex——绝不能动。"""
+    """regex 模式 ``\\n+`` 在 JSON 源里 ``"\\\\n+"`` → 解析后字面量 ``\\n+``。
+    无 divider 指纹，不动。"""
     raw = r'{"pattern": "\\n+"}'
     parsed = robust_json_loads(raw)
     assert parsed["pattern"] == r"\n+"
@@ -304,8 +320,7 @@ def test_regex_with_literal_backslash_n_preserved():
 
 @pytest.mark.unit
 def test_isolated_literal_backslash_n_outside_divider_preserved():
-    """字面量 ``\\n`` 不在 ``---`` 附近时一律不动——指纹保守原则。"""
-    # 含 `\n` 字面量但无 `---`：常见于代码片段、日志行、转义说明等
+    """无 divider 指纹时 ``\\n`` 字面量一律保留——常见于代码片段、日志、文档。"""
     raw = '{"code": "print(\\"hello\\\\nworld\\")"}'
     parsed = robust_json_loads(raw)
     assert parsed["code"] == 'print("hello\\nworld")'
@@ -314,7 +329,7 @@ def test_isolated_literal_backslash_n_outside_divider_preserved():
 
 @pytest.mark.unit
 def test_isolated_literal_backslash_t_preserved():
-    """单独 ``\\t``（不带 divider 指纹）不动——LLM 可能有意保留。"""
+    """单独 ``\\t``（无 divider 指纹）不动。"""
     raw = '{"code": "say\\\\thi"}'
     parsed = robust_json_loads(raw)
     assert parsed["code"] == "say\\thi"
@@ -322,15 +337,13 @@ def test_isolated_literal_backslash_t_preserved():
 
 @pytest.mark.unit
 def test_nested_structures_walked_only_when_fingerprint_matches():
-    """递归访问 dict / list；每个 string 单独看自己的指纹，互不影响。"""
+    """递归 dict / list；每个 string 单独看自己的指纹，互不影响。"""
     raw = (
         '{"summary": "body\\\\n\\\\n---\\\\n\\\\nolder", '
         '"path": "C:\\\\new"}'
     )
     parsed = robust_json_loads(raw)
-    # summary 命中指纹，归一化
     assert parsed["summary"] == "body\n\n---\n\nolder"
-    # path 没命中，保持字面量
     assert parsed["path"] == r"C:\new"
 
 

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -245,74 +245,93 @@ def test_unicode_numeric_prefixes_not_stripped(raw):
         robust_json_loads(raw)
 
 
-# ── over-escaped newlines normalization ───────────────────────────────
+# ── over-escaped newlines normalization (divider-fingerprint trigger) ──
+# 触发条件：字符串里出现 ``\n[空白]?---[空白]?\n``（字面量，过度转义的 ``---``
+# 分隔符指纹）。这是 summary 整段 over-escape 时唯一可靠的故障签名——其它含
+# 字面量 ``\n`` 的合法场景（Windows 路径、regex meta-char、tool args 代码）
+# 在 ``\n`` 周围不会出现 ``---``，所以不会被触发。
 
 
 @pytest.mark.unit
-def test_overescaped_newlines_normalized_when_no_real_newlines():
-    """LLM 把整段 over-escape 时（JSON 源 ``\\\\n``，解码后字面量 ``\\n``）应当
-    还原成真换行——summary 含 `---` 分隔符的场景实测会出。"""
-    # JSON 源里的 `\\n` 解码出来是字面量两字符 (backslash + n)
+def test_overescaped_divider_normalizes_whole_summary():
+    """LLM 把整段 over-escape 时（JSON 源 ``\\\\n``，解码后字面量 ``\\n``）
+    且 divider 也被波及：归一化整段，恢复真换行。"""
     raw = '{"summary": "body\\\\n\\\\n---\\\\n\\\\nolder"}'
     parsed = robust_json_loads(raw)
     assert parsed["summary"] == "body\n\n---\n\nolder"
 
 
 @pytest.mark.unit
-def test_overescaped_tab_normalized_alongside_newline():
-    """``\\t`` 跟 ``\\n`` 一起出现时（典型 over-escape 故障）顺手归一化。
-    单独 ``\\t``（无 ``\\n`` 信号）保守起见不动——见
-    `test_isolated_literal_backslash_t_preserved`。"""
-    raw = '{"line": "a\\\\nb\\\\tc"}'
+def test_overescaped_divider_normalizes_tab_in_same_string():
+    """指纹命中后，同字符串里的字面量 ``\\t`` 一并归一化——LLM 整段 over-escape
+    通常波及所有控制字符。"""
+    raw = '{"summary": "col1\\\\tcol2\\\\n\\\\n---\\\\n\\\\nolder"}'
     parsed = robust_json_loads(raw)
-    assert parsed["line"] == "a\nb\tc"
+    assert parsed["summary"] == "col1\tcol2\n\n---\n\nolder"
+
+
+@pytest.mark.unit
+def test_overescaped_divider_with_crlf_fingerprint():
+    """`\\r\\n` 形态的 over-escape 也走通。"""
+    # JSON 源 ``"body\\r\\n\\r\\n---\\r\\n\\r\\nolder"`` 解析后字面量
+    raw = '{"summary": "body\\\\r\\\\n\\\\r\\\\n---\\\\r\\\\n\\\\r\\\\nolder"}'
+    parsed = robust_json_loads(raw)
+    assert "\n\n---\n\n" in parsed["summary"]
+    assert "\\r" not in parsed["summary"]
+    assert "\\n" not in parsed["summary"]
+
+
+@pytest.mark.unit
+def test_windows_path_with_literal_backslash_n_preserved():
+    """关键反向 case（codex / coderabbit P1）：Windows 路径 ``C:\\new_folder``
+    JSON 源 ``"C:\\\\new_folder"`` 解析后是字面量 ``C:\\new_folder``，
+    含 ``\\n`` 字面量但不是 over-escape，绝不能改成换行。"""
+    raw = r'{"path": "C:\\new_folder\\notes.txt"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["path"] == r"C:\new_folder\notes.txt"
+    # 字面量 backslash 完整保留
+    assert "\n" not in parsed["path"]
+
+
+@pytest.mark.unit
+def test_regex_with_literal_backslash_n_preserved():
+    """另一个反向 case：regex 模式 ``\\n+`` 在 JSON 源里是 ``"\\\\n+"``，
+    解析后字面量 ``\\n+``。LLM 工具调用经常这样传 regex——绝不能动。"""
+    raw = r'{"pattern": "\\n+"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["pattern"] == r"\n+"
+
+
+@pytest.mark.unit
+def test_isolated_literal_backslash_n_outside_divider_preserved():
+    """字面量 ``\\n`` 不在 ``---`` 附近时一律不动——指纹保守原则。"""
+    # 含 `\n` 字面量但无 `---`：常见于代码片段、日志行、转义说明等
+    raw = '{"code": "print(\\"hello\\\\nworld\\")"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["code"] == 'print("hello\\nworld")'
+    assert "\\n" in parsed["code"]
 
 
 @pytest.mark.unit
 def test_isolated_literal_backslash_t_preserved():
-    """单独的 ``\\t`` 字面量（不带 ``\\n`` 信号）视为 LLM 有意为之，不改。
-
-    触发条件以 ``\\n``+无真换行作为故障指纹——避免误伤 tool args 里
-    意图保留字面量 ``\\t`` 的代码/正则字符串。
-    """
+    """单独 ``\\t``（不带 divider 指纹）不动——LLM 可能有意保留。"""
     raw = '{"code": "say\\\\thi"}'
     parsed = robust_json_loads(raw)
     assert parsed["code"] == "say\\thi"
 
 
 @pytest.mark.unit
-def test_overescaped_crlf_normalized():
-    """``\\r\\n`` 也走通——优先匹配避免变成 ``\\n\\r``。"""
-    raw = '{"s": "a\\\\r\\\\nb"}'
-    parsed = robust_json_loads(raw)
-    assert parsed["s"] == "a\nb"
-
-
-@pytest.mark.unit
-def test_literal_backslash_n_preserved_when_real_newlines_exist():
-    """保守触发：string 已含真换行时，字面量 ``\\n`` 视为 LLM 有意为之，不改。
-
-    保护 tool args / code 字符串场景：``code: "print('hello\\n')"`` 这种希望
-    保留字面量 ``\\n`` 让运行时再 decode 一次的用法。
-    """
-    # 源里既有真换行 (`\n` decoded to newline) 又有字面量 (`\\n` decoded to \n)
-    raw = '{"code": "line1\\nprint(\\"hello\\\\n\\")"}'
-    parsed = robust_json_loads(raw)
-    assert parsed["code"] == 'line1\nprint("hello\\n")'
-    # 字面量 backslash-n 保留
-    assert '\\n' in parsed["code"]
-
-
-@pytest.mark.unit
-def test_nested_structures_walked():
-    """字典 / 列表里的字符串都要被递归归一化。"""
+def test_nested_structures_walked_only_when_fingerprint_matches():
+    """递归访问 dict / list；每个 string 单独看自己的指纹，互不影响。"""
     raw = (
-        '{"outer": {"inner": "a\\\\nb"}, '
-        '"items": ["x\\\\ny", "z"]}'
+        '{"summary": "body\\\\n\\\\n---\\\\n\\\\nolder", '
+        '"path": "C:\\\\new"}'
     )
     parsed = robust_json_loads(raw)
-    assert parsed["outer"]["inner"] == "a\nb"
-    assert parsed["items"] == ["x\ny", "z"]
+    # summary 命中指纹，归一化
+    assert parsed["summary"] == "body\n\n---\n\nolder"
+    # path 没命中，保持字面量
+    assert parsed["path"] == r"C:\new"
 
 
 @pytest.mark.unit
@@ -325,7 +344,7 @@ def test_non_string_values_unchanged():
 
 @pytest.mark.unit
 def test_clean_string_passes_through_unchanged():
-    """既没真换行也没字面量 ``\\n`` 的普通字符串完全不动。"""
+    """没字面量 escape 的普通字符串完全不动。"""
     raw = '{"s": "hello world"}'
     parsed = robust_json_loads(raw)
     assert parsed["s"] == "hello world"

--- a/tests/unit/test_robust_json_loads.py
+++ b/tests/unit/test_robust_json_loads.py
@@ -243,3 +243,89 @@ def test_unicode_numeric_prefixes_not_stripped(raw):
     """
     with pytest.raises(json.JSONDecodeError):
         robust_json_loads(raw)
+
+
+# ── over-escaped newlines normalization ───────────────────────────────
+
+
+@pytest.mark.unit
+def test_overescaped_newlines_normalized_when_no_real_newlines():
+    """LLM 把整段 over-escape 时（JSON 源 ``\\\\n``，解码后字面量 ``\\n``）应当
+    还原成真换行——summary 含 `---` 分隔符的场景实测会出。"""
+    # JSON 源里的 `\\n` 解码出来是字面量两字符 (backslash + n)
+    raw = '{"summary": "body\\\\n\\\\n---\\\\n\\\\nolder"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["summary"] == "body\n\n---\n\nolder"
+
+
+@pytest.mark.unit
+def test_overescaped_tab_normalized_alongside_newline():
+    """``\\t`` 跟 ``\\n`` 一起出现时（典型 over-escape 故障）顺手归一化。
+    单独 ``\\t``（无 ``\\n`` 信号）保守起见不动——见
+    `test_isolated_literal_backslash_t_preserved`。"""
+    raw = '{"line": "a\\\\nb\\\\tc"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["line"] == "a\nb\tc"
+
+
+@pytest.mark.unit
+def test_isolated_literal_backslash_t_preserved():
+    """单独的 ``\\t`` 字面量（不带 ``\\n`` 信号）视为 LLM 有意为之，不改。
+
+    触发条件以 ``\\n``+无真换行作为故障指纹——避免误伤 tool args 里
+    意图保留字面量 ``\\t`` 的代码/正则字符串。
+    """
+    raw = '{"code": "say\\\\thi"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["code"] == "say\\thi"
+
+
+@pytest.mark.unit
+def test_overescaped_crlf_normalized():
+    """``\\r\\n`` 也走通——优先匹配避免变成 ``\\n\\r``。"""
+    raw = '{"s": "a\\\\r\\\\nb"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["s"] == "a\nb"
+
+
+@pytest.mark.unit
+def test_literal_backslash_n_preserved_when_real_newlines_exist():
+    """保守触发：string 已含真换行时，字面量 ``\\n`` 视为 LLM 有意为之，不改。
+
+    保护 tool args / code 字符串场景：``code: "print('hello\\n')"`` 这种希望
+    保留字面量 ``\\n`` 让运行时再 decode 一次的用法。
+    """
+    # 源里既有真换行 (`\n` decoded to newline) 又有字面量 (`\\n` decoded to \n)
+    raw = '{"code": "line1\\nprint(\\"hello\\\\n\\")"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["code"] == 'line1\nprint("hello\\n")'
+    # 字面量 backslash-n 保留
+    assert '\\n' in parsed["code"]
+
+
+@pytest.mark.unit
+def test_nested_structures_walked():
+    """字典 / 列表里的字符串都要被递归归一化。"""
+    raw = (
+        '{"outer": {"inner": "a\\\\nb"}, '
+        '"items": ["x\\\\ny", "z"]}'
+    )
+    parsed = robust_json_loads(raw)
+    assert parsed["outer"]["inner"] == "a\nb"
+    assert parsed["items"] == ["x\ny", "z"]
+
+
+@pytest.mark.unit
+def test_non_string_values_unchanged():
+    """non-str value 不动（int/bool/None/float）。"""
+    raw = '{"n": 1, "b": true, "x": null, "f": 1.5}'
+    parsed = robust_json_loads(raw)
+    assert parsed == {"n": 1, "b": True, "x": None, "f": 1.5}
+
+
+@pytest.mark.unit
+def test_clean_string_passes_through_unchanged():
+    """既没真换行也没字面量 ``\\n`` 的普通字符串完全不动。"""
+    raw = '{"s": "hello world"}'
+    parsed = robust_json_loads(raw)
+    assert parsed["s"] == "hello world"

--- a/tests/unit/test_summary_stale_hint_divider.py
+++ b/tests/unit/test_summary_stale_hint_divider.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""SUMMARY_STALE_HINT 必须告知 LLM 用 `\n\n---\n\n` 作为主体与"较久前"段的硬分界。
+
+机制：[memory/recent.py](memory/recent.py) 在 `gap_hours >= RECENT_SUMMARY_STALE_HOURS`
+时把该 hint 注入 summary prompt 头部。下游 memo 注入 + [memory_browser
+renderChatEdit](static/js/memory_browser.js) 都按这个 divider 切段渲染。
+任一 locale 漏掉 `---` 指示会破坏前端 splitter 的语义约定，所以全 7 语言都要锚。
+"""
+from __future__ import annotations
+
+import pytest
+
+from config.prompts.prompts_memory import (
+    SUMMARY_STALE_HINT,
+    get_summary_stale_hint,
+)
+
+
+_LOCALES = ("zh", "en", "ja", "ko", "ru", "es", "pt")
+
+
+@pytest.mark.parametrize("lang", _LOCALES)
+def test_stale_hint_mentions_triple_dash_divider(lang: str) -> None:
+    """每条 locale 都要明确告诉 LLM 用 ``---`` 作分界。
+
+    检查字面 `---`（三个 ASCII 连字符）出现在 prompt 文本里——这是前端
+    splitter / 下次 round 注入时识别"较久前"段的唯一线索。
+    """
+    hint = SUMMARY_STALE_HINT[lang]
+    assert "---" in hint, f"{lang} hint 未提到 `---` 分界符"
+
+
+@pytest.mark.parametrize("lang", _LOCALES)
+def test_get_summary_stale_hint_substitutes_gap(lang: str) -> None:
+    """`{GAP}` 占位符必须被替换，且 `---` 指示仍在最终字符串里。"""
+    rendered = get_summary_stale_hint(lang, 2.5)
+    assert "{GAP}" not in rendered
+    assert "2.5" in rendered
+    assert "---" in rendered
+
+
+@pytest.mark.parametrize("lang", _LOCALES)
+def test_stale_hint_keeps_six_equal_wrapper(lang: str) -> None:
+    """六等号 below/above 对偶分隔符保留——这是 PR #1316 安全水印约定。
+
+    `---` 是 hint **内容**里给 LLM 的指令；外层 wrapper 仍按
+    `feedback_prompt_delimiters_above_below.md` 走六等号对偶。
+    """
+    hint = SUMMARY_STALE_HINT[lang]
+    six_eq_count = hint.count("======")
+    assert six_eq_count >= 2, f"{lang} hint 应保留 below/above 六等号 wrapper"

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -231,32 +231,27 @@ def _normalize_quotes(s: str) -> str:
     return ''.join(out)
 
 
-# 故障指纹：字面量 ``\n`` 紧贴一个 `---` 分隔符行（前后都是字面量换行）。
-# LLM 把 summary 整段 over-escape 后会在 ``body\n\n---\n\nolder``（全字面量）
-# 里留下这个签名。比"无真换行 ∧ 含 \\n"更严格——避开 Windows 路径
-# ``C:\new_folder``、regex meta-char ``\n``、tool args 里有意的字面量 escape
-# 等极其常见的合法场景（那些场景里 ``\n`` 周围不会有 ``---`` 行）。
-_OVERESCAPED_DIVIDER_RE = re.compile(r'(?:\\r\\n|\\r|\\n)[ \t]*-{3,}[ \t]*(?:\\r\\n|\\r|\\n)')
+# 故障指纹：1+ 个字面量换行类 escape + 一个 `---` 分隔符行 + 1+ 个字面量
+# 换行类 escape。匹配到此处时，把这一段 over-escape 的 divider 区域替换成
+# 规范 `\n\n---\n\n`——只动 divider 本身，**不碰**字符串里其它地方的字面量
+# escape。这样即使同字段里同时存在合法的 ``C:\new_folder`` / regex / 代码
+# 片段，它们的 ``\n`` / ``\t`` 字面量也不会被误改。
+_OVERESCAPED_DIVIDER_RE = re.compile(
+    r'(?:\\r\\n|\\r|\\n)+[ \t]*-{3,}[ \t]*(?:\\r\\n|\\r|\\n)+'
+)
 
 
 def _normalize_overescaped_newlines(obj: Any) -> Any:
     """LLM 把 ``\\n`` 在 JSON 源里再转义一遍时，解析后字符串里就是字面量
-    backslash-n（2 字符）而非真换行。这里只在能找到**过度转义的 ``---`` 分隔符
-    指纹**时把这一类 escape 还原成真换行 / 制表——其它含字面量 ``\\n`` 的字符串
-    （Windows 路径、regex、code 片段、tool args）一律不动。
+    backslash-n（2 字符）而非真换行。这里只把**过度转义的 ``---`` 分隔符区域**
+    替换成规范的 ``\\n\\n---\\n\\n``——同字符串里其它位置的字面量 escape
+    （Windows 路径、regex、code 片段、tool args 等）一字不动。
 
-    只处理换行 / 回车 / 制表（``\\n`` / ``\\r\\n`` / ``\\r`` / ``\\t``）——
-    `\\u` 编码、自定义 escape 等不在范围。
+    取舍：如果 body / older 段内部还有字面量段落分隔，本函数不管它们——
+    保留字面量比静默改写合法数据更安全；UI 侧最多就是看到几个 ``\\n`` 字面量。
     """
     if isinstance(obj, str):
-        if _OVERESCAPED_DIVIDER_RE.search(obj):
-            return (
-                obj.replace('\\r\\n', '\n')
-                .replace('\\n', '\n')
-                .replace('\\r', '\n')
-                .replace('\\t', '\t')
-            )
-        return obj
+        return _OVERESCAPED_DIVIDER_RE.sub('\n\n---\n\n', obj)
     if isinstance(obj, dict):
         return {k: _normalize_overescaped_newlines(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -276,14 +271,15 @@ def robust_json_loads(raw: str) -> Any:
     （如 ``"True"`` / ``"x,]"``）静默改坏。
 
     Parse 成功后还会跑一次 ``_normalize_overescaped_newlines`` 后处理：当某条
-    string value **完全没有真换行 ∧ 含字面量 ``\\n``** 时，说明 LLM 把整段
-    over-escape 了，归一化成真换行 / 制表。这条只针对换行类 escape，code/regex
-    里有意的字面量 ``\\n`` 因为伴随真换行而被保留。
+    string value 里出现"过度转义的 ``---`` 分隔符指纹"——即 1+ 字面量换行类
+    escape (``\\n`` / ``\\r\\n`` / ``\\r``) 紧贴 ``---`` 行——就把这一段
+    替换成规范的 ``\\n\\n---\\n\\n``。同字符串里其它位置的字面量 escape
+    （Windows 路径、regex、code 片段等）一字不动。
 
     Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
     single-quoted strings (including mixed-quote scenarios), stray hallucinated
     chars between structural tokens (e.g. ``,결{`` → ``,{``), and over-escaped
-    newline / tab in string values.
+    ``---`` memo dividers in string values.
     """
     parsed, ok = _try_json_loads(raw)
     if ok:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -231,24 +231,59 @@ def _normalize_quotes(s: str) -> str:
     return ''.join(out)
 
 
+def _normalize_overescaped_newlines(obj: Any) -> Any:
+    """LLM 偶尔会把 `\\n` 在 JSON 源里再转义一遍，导致解析出来是字面量
+    backslash-n（2 字符）而非真换行。这里递归把 string value 里的过度转义还原。
+
+    保守触发：**完全没有真换行 ∧ 含字面量 ``\\n``**，才动手。
+    - 全字面量是 LLM 整段过度转义的典型故障，归一化绝对安全。
+    - 真换行已存在说明 LLM 知道用 newline 转义，那剩下的字面量 ``\\n`` 可能是
+      它有意为之（罕见但要尊重），不动。
+
+    只处理换行 / 回车 / 制表（``\\n`` / ``\\r\\n`` / ``\\r`` / ``\\t``）—— 其它
+    ``\\X``（如 ``\\u`` 编码、自定义 escape 在 code/regex 字符串里）一律不动，
+    避免误伤 tool call args 等以字面量传递的代码/正则。
+    """
+    if isinstance(obj, str):
+        if '\n' not in obj and '\\n' in obj:
+            return (
+                obj.replace('\\r\\n', '\n')
+                .replace('\\n', '\n')
+                .replace('\\r', '\n')
+                .replace('\\t', '\t')
+            )
+        return obj
+    if isinstance(obj, dict):
+        return {k: _normalize_overescaped_newlines(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_normalize_overescaped_newlines(v) for v in obj]
+    return obj
+
+
 def robust_json_loads(raw: str) -> Any:
     """json.loads with fallback for common LLM JSON quirks.
 
-    原始输入若能直接 parse，无条件返回原结果（绝不预先 transform）。否则按
-    fallback pipeline 逐步修补 —— 每步 transform 后立即 try parse，能 parse
-    即停，避免后续步骤（尤其是 scanner）在不必要时动文本。
+    原始输入若能直接 parse，无条件返回原结果。否则按 fallback pipeline 逐步
+    修补 —— 每步 transform 后立即 try parse，能 parse 即停，避免后续步骤
+    （尤其是 scanner）在不必要时动文本。
 
     所有"纯文本替换" transform（Python 字面量、`{{}}`、尾逗号、无引号 key）
     都通过 ``_apply_outside_strings`` 包装，仅在字符串外生效，避免把字符串值
     （如 ``"True"`` / ``"x,]"``）静默改坏。
 
+    Parse 成功后还会跑一次 ``_normalize_overescaped_newlines`` 后处理：当某条
+    string value **完全没有真换行 ∧ 含字面量 ``\\n``** 时，说明 LLM 把整段
+    over-escape 了，归一化成真换行 / 制表。这条只针对换行类 escape，code/regex
+    里有意的字面量 ``\\n`` 因为伴随真换行而被保留。
+
     Handles: unquoted keys, trailing commas, ``{{ }}``, Python ``True/False/None``,
-    single-quoted strings (including mixed-quote scenarios), and stray hallucinated
-    chars between structural tokens (e.g. ``,결{`` → ``,{``).
+    single-quoted strings (including mixed-quote scenarios), stray hallucinated
+    chars between structural tokens (e.g. ``,결{`` → ``,{``), and over-escaped
+    newline / tab in string values.
     """
     parsed, ok = _try_json_loads(raw)
     if ok:
-        return parsed
+        return _normalize_overescaped_newlines(parsed)
 
     transforms = (
         # {{ }} → { }  (LLM 模仿 prompt 模板转义)；段感知
@@ -275,8 +310,8 @@ def robust_json_loads(raw: str) -> Any:
         s = transform(s)
         parsed, ok = _try_json_loads(s)
         if ok:
-            return parsed
-    return json.loads(s)  # 让最终错误带完整上下文抛出
+            return _normalize_overescaped_newlines(parsed)
+    return _normalize_overescaped_newlines(json.loads(s))  # 让最终错误带完整上下文抛出
 
 
 def atomic_write_text(path: str | os.PathLike[str], content: str, *, encoding: str = "utf-8") -> None:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -231,21 +231,25 @@ def _normalize_quotes(s: str) -> str:
     return ''.join(out)
 
 
+# 故障指纹：字面量 ``\n`` 紧贴一个 `---` 分隔符行（前后都是字面量换行）。
+# LLM 把 summary 整段 over-escape 后会在 ``body\n\n---\n\nolder``（全字面量）
+# 里留下这个签名。比"无真换行 ∧ 含 \\n"更严格——避开 Windows 路径
+# ``C:\new_folder``、regex meta-char ``\n``、tool args 里有意的字面量 escape
+# 等极其常见的合法场景（那些场景里 ``\n`` 周围不会有 ``---`` 行）。
+_OVERESCAPED_DIVIDER_RE = re.compile(r'(?:\\r\\n|\\r|\\n)[ \t]*-{3,}[ \t]*(?:\\r\\n|\\r|\\n)')
+
+
 def _normalize_overescaped_newlines(obj: Any) -> Any:
-    """LLM 偶尔会把 `\\n` 在 JSON 源里再转义一遍，导致解析出来是字面量
-    backslash-n（2 字符）而非真换行。这里递归把 string value 里的过度转义还原。
+    """LLM 把 ``\\n`` 在 JSON 源里再转义一遍时，解析后字符串里就是字面量
+    backslash-n（2 字符）而非真换行。这里只在能找到**过度转义的 ``---`` 分隔符
+    指纹**时把这一类 escape 还原成真换行 / 制表——其它含字面量 ``\\n`` 的字符串
+    （Windows 路径、regex、code 片段、tool args）一律不动。
 
-    保守触发：**完全没有真换行 ∧ 含字面量 ``\\n``**，才动手。
-    - 全字面量是 LLM 整段过度转义的典型故障，归一化绝对安全。
-    - 真换行已存在说明 LLM 知道用 newline 转义，那剩下的字面量 ``\\n`` 可能是
-      它有意为之（罕见但要尊重），不动。
-
-    只处理换行 / 回车 / 制表（``\\n`` / ``\\r\\n`` / ``\\r`` / ``\\t``）—— 其它
-    ``\\X``（如 ``\\u`` 编码、自定义 escape 在 code/regex 字符串里）一律不动，
-    避免误伤 tool call args 等以字面量传递的代码/正则。
+    只处理换行 / 回车 / 制表（``\\n`` / ``\\r\\n`` / ``\\r`` / ``\\t``）——
+    `\\u` 编码、自定义 escape 等不在范围。
     """
     if isinstance(obj, str):
-        if '\n' not in obj and '\\n' in obj:
+        if _OVERESCAPED_DIVIDER_RE.search(obj):
             return (
                 obj.replace('\\r\\n', '\n')
                 .replace('\\n', '\n')


### PR DESCRIPTION
## Summary
- 之前 `SUMMARY_STALE_HINT` 只软引导 LLM 把过时内容放到 summary 文末，输出零边界——memo 注入 / [memory_browser renderChatEdit](static/js/memory_browser.js:843) 都把整段当散文一坨渲染，人眼分不出"当前任务"和"已归档旧事件"
- 7 locale prompt 补硬约束："主体段与'较久前'段之间必须用单独一行 \`---\` 作分界（前后各空一行，整段 summary 最多一次；无过时内容则不输出）"
- 前端按 \`\n\n---\n\n\` 容忍正则切段：body 走原 textarea，older 段独立 textarea + `memo-older-label`，CSS 降一档视觉权重（虚线边框 + 缩小字号 + 灰蓝调，dark mode 配套）；commit 时统一拼回规范 \`\n\n---\n\n\`
- 新 i18n key `memory.olderSection`（zh/zh-TW/en/ja/ko/ru/es/pt 全覆盖）

## Why
跟进 [#1316](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1316) 设计：当时 `PAST_MEMORY_BLOCK`（长期反思的 `past` 块）已用六等号 below/above 对偶分隔，但 recent-history summary 的"较久前"尾段只设计成软提示，没有 output marker。结果 LLM 真的把"几天前的旧事"和"当前正在挖铁矿"挤在一坨散文里，前端也只能整段塞 textarea。这次补齐尾段的机器可解析分界，视觉上保持"硬分隔但不硬格式"（不用 `======X======` box wrapper，单行 `---` 已够）。

## 设计选择 tradeoff
- 选纯符号 \`---\`（markdown 水平线）而非 locale-aware 标签（如 \`〔较久前〕\`）：i18n 免疫、视觉最轻、LLM 输出最稳；locale 文案靠前端 `memory.olderSection` label 渲染时拼回
- 容忍式正则 \`/\r?\n[ \t]*\r?\n[ \t]*-{3,}[ \t]*\r?\n[ \t]*\r?\n/\`：吃下 LLM 偶尔多输 / 少输空行 / 多输几个连字符的变体
- 没有过时内容时 prompt 明确禁止输出 \`---\`，避免空尾段

## Test plan
- [x] 新 `tests/unit/test_summary_stale_hint_divider.py` 21 个 case：每 locale 都含 `---` 指令、`{GAP}` 占位被正确替换、六等号 wrapper 保留
- [x] `tests/unit/test_memory_temporal.py` + `test_review_history_memo_preservation.py` 全绿
- [x] memory 相关 264 个单测全绿（no regression）
- [x] `scripts/check_i18n.py` + `check_i18n_sync.py` + `check_prompt_hygiene.py` 退出码全 0
- [x] 新 `tests/frontend/test_memory_browser.py` 两个 Playwright 用例：含 `---` 的 memo 拆成 body + older 两个 textarea；编辑 older 后保存 payload 仍按 `\n\n---\n\n` 规范拼回
- [ ] 实机：等下一次实际触发 stale hint 的 compress（gap >1h），看 summary 是否真的产出 `---` 分界
- [ ] 实机：在 memory browser 编辑尾段并保存，确认 round-trip 正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 备忘录支持分段编辑，可将内容分为“当前”与“较久前”两部分并独立编辑/保存，采用单行分隔符 `---` 作为规范分界（仅出现一次且上下需空行）。
* **样式**
  * 为“较久前”分段新增专属视觉样式，并补充暗色模式样式调整。
* **本地化**
  * 为多语言界面新增“较久前”分段文案翻译。
* **测试**
  * 新增端到端与单元测试，覆盖分段识别、保存回写、非规范分隔识别与缩进保留。
* **改进**
  * 摘要提示文本拆分并加入格式约束；增强 JSON 解析对过度转义换行/分隔符的归一化处理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1358)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->