### PR TITLE
fix(voice): proactive callback 主动 inject + response.create，不再 silent drop

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5578,8 +5578,47 @@ class LLMSessionManager:
                 passive=False,
             )
             voice_snapshot = list(proactive_cbs)
+
+            # Server-side rejection of ``response.create`` (e.g.
+            # ``response_already_active`` from a VAD race winning between
+            # our gate check and our send) is delivered asynchronously as
+            # an ``error`` event, not via this call's return value or an
+            # exception. Without a rejection callback, the optimistic prune
+            # below would silently drop the cb. Re-enqueue the snapshot on
+            # rejection so the next ``_finalize_turn_after_emit`` retry
+            # picks it up cleanly.
+            lanlan_name_snapshot = self.lanlan_name
+
+            def _on_voice_inject_rejected(error_msg: str, _snapshot=voice_snapshot, _lanlan=lanlan_name_snapshot) -> None:
+                logger.warning(
+                    "[%s] voice proactive inject rejected by server: %s; re-enqueuing %d cb(s) for retry",
+                    _lanlan, error_msg, len(_snapshot),
+                )
+                # Only re-add cbs whose delivery_id is not currently in either
+                # queue — guards against double-add if the caller's exception
+                # branch also restored them (defensive; the inject_*
+                # implementation drops the rejection handler on synchronous
+                # send failure so this path only fires for server-side errors).
+                existing_ids = {
+                    cb.get("_callback_delivery_id")
+                    for cb in self.pending_agent_callbacks
+                    if cb.get("_callback_delivery_id")
+                }
+                existing_ids.update(
+                    extra.get("_callback_delivery_id")
+                    for extra in self.pending_extra_replies
+                    if extra.get("_callback_delivery_id")
+                )
+                for cb in _snapshot:
+                    cb_id = cb.get("_callback_delivery_id")
+                    if cb_id and cb_id in existing_ids:
+                        continue
+                    self.pending_agent_callbacks.append(cb)
+
             try:
-                await voice_sess.inject_text_and_request_response(instruction)
+                await voice_sess.inject_text_and_request_response(
+                    instruction, on_rejected=_on_voice_inject_rejected
+                )
             except NotImplementedError:
                 # Provider doesn't support manual inject (Gemini Live / Qwen).
                 # Fall through to the legacy hot-swap path: drop the proactive

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5620,7 +5620,7 @@ class LLMSessionManager:
                     instruction, on_rejected=_on_voice_inject_rejected
                 )
             except NotImplementedError:
-                # Provider doesn't support manual inject (Gemini Live / Qwen).
+                # Provider doesn't support manual inject (Gemini Live).
                 # Fall through to the legacy hot-swap path: drop the proactive
                 # cbs so they don't loop forever, but keep ``pending_extra_replies``
                 # populated for the next user-turn prime_context() drain.

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5620,10 +5620,15 @@ class LLMSessionManager:
                     instruction, on_rejected=_on_voice_inject_rejected
                 )
             except NotImplementedError:
-                # Provider doesn't support manual inject (Gemini Live).
-                # Fall through to the legacy hot-swap path: drop the proactive
-                # cbs so they don't loop forever, but keep ``pending_extra_replies``
-                # populated for the next user-turn prime_context() drain.
+                # Defensive fallback. As of now every realtime provider
+                # (OpenAI / GLM / Step / free / GPT / Qwen / Grok via
+                # conversation.item.create, Gemini via send_client_content)
+                # supports manual inject, so this branch is unreachable in
+                # practice — kept so a hypothetical future provider that
+                # raises NotImplementedError degrades to hot-swap instead of
+                # losing the cb. Drop the proactive cbs so they don't loop
+                # forever, but keep ``pending_extra_replies`` populated for the
+                # next user-turn prime_context() drain.
                 voice_ids = {id(cb) for cb in voice_snapshot}
                 self.pending_agent_callbacks = [
                     cb for cb in self.pending_agent_callbacks

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -793,6 +793,17 @@ class LLMSessionManager:
         self.pending_agent_callbacks: list[dict] = []
         # 防止 trigger_agent_callbacks 和 finish_proactive_delivery 并发写 WS/sync_message_queue
         self._proactive_write_lock = asyncio.Lock()
+        # Serializes the voice-mode proactive inject path. trigger_agent_callbacks
+        # is fired via asyncio.create_task from multiple sites (EventBus per-
+        # callback scheduling, _finalize_turn_after_emit, start_session), so two
+        # tasks can race: both pass the (phase / is_active_response) gate before
+        # either sends, then both inject the SAME snapshot → duplicate
+        # conversation.item.create and a response_already_active on the second
+        # response.create. The voice branch holds this lock across
+        # gate-check → render → inject → prune and re-filters the queue inside,
+        # making check-and-claim atomic. (Text mode uses the SM's
+        # try_start_proactive claim instead; voice deliberately bypasses the SM.)
+        self._voice_proactive_inject_lock = asyncio.Lock()
         # ── Session takeover ──────────────────────────────────────────
         # 当某个外部 controller 接管这个 session 时，本地 chat LLM 的输出
         # （text/audio delta、output transcript、response.complete、
@@ -5559,143 +5570,177 @@ class LLMSessionManager:
         # _finalize_turn_after_emit 在 response.done 之后重新调用本函数重试。
         if isinstance(self.session, OmniRealtimeClient):
             voice_sess = self.session
-            if self.state.phase is not ProactivePhase.IDLE or voice_sess.is_active_response():
-                logger.debug(
-                    "[%s] trigger_agent_callbacks: voice session busy (phase=%s, active_response=%s); deferring proactive (n=%d)",
-                    self.lanlan_name,
-                    self.state.phase.value,
-                    voice_sess.is_active_response(),
-                    len(proactive_cbs),
+            # Serialize the whole check-and-claim against concurrent trigger
+            # tasks (see ``_voice_proactive_inject_lock``). Hold the lock across
+            # gate → render → inject → prune; a second task blocks here and,
+            # once it acquires, re-filters the (now-pruned) queue and finds
+            # nothing left to send.
+            async with self._voice_proactive_inject_lock:
+                # Re-filter inside the lock: a concurrent task may have already
+                # injected+pruned these cbs while we waited on the lock.
+                proactive_cbs = [
+                    cb for cb in self.pending_agent_callbacks
+                    if cb.get("delivery_mode") != "passive"
+                ]
+                if not proactive_cbs:
+                    return
+                if self.state.phase is not ProactivePhase.IDLE or voice_sess.is_active_response():
+                    logger.debug(
+                        "[%s] trigger_agent_callbacks: voice session busy (phase=%s, active_response=%s); deferring proactive (n=%d)",
+                        self.lanlan_name,
+                        self.state.phase.value,
+                        voice_sess.is_active_response(),
+                        len(proactive_cbs),
+                    )
+                    return
+
+                _lang = normalize_language_code(self.user_language, format='short')
+                instruction = _build_callback_instruction(
+                    proactive_cbs,
+                    lang=_lang,
+                    lanlan_name=self.lanlan_name,
+                    master_name=self.master_name,
+                    passive=False,
                 )
-                return
-
-            _lang = normalize_language_code(self.user_language, format='short')
-            instruction = _build_callback_instruction(
-                proactive_cbs,
-                lang=_lang,
-                lanlan_name=self.lanlan_name,
-                master_name=self.master_name,
-                passive=False,
-            )
-            voice_snapshot = list(proactive_cbs)
-
-            # Server-side rejection of ``response.create`` (e.g.
-            # ``response_already_active`` from a VAD race winning between
-            # our gate check and our send) is delivered asynchronously as
-            # an ``error`` event, not via this call's return value or an
-            # exception. Without a rejection callback, the optimistic prune
-            # below would silently drop the cb. Re-enqueue the snapshot on
-            # rejection so the next ``_finalize_turn_after_emit`` retry
-            # picks it up cleanly.
-            lanlan_name_snapshot = self.lanlan_name
-
-            def _on_voice_inject_rejected(error_msg: str, _snapshot=voice_snapshot, _lanlan=lanlan_name_snapshot) -> None:
-                logger.warning(
-                    "[%s] voice proactive inject rejected by server: %s; re-enqueuing %d cb(s) for retry",
-                    _lanlan, error_msg, len(_snapshot),
-                )
-                # Only re-add cbs whose delivery_id is not currently in either
-                # queue — guards against double-add if the caller's exception
-                # branch also restored them (defensive; the inject_*
-                # implementation drops the rejection handler on synchronous
-                # send failure so this path only fires for server-side errors).
-                existing_ids = {
+                voice_snapshot = list(proactive_cbs)
+                # Snapshot the paired extras entries NOW (before prune) so the
+                # rejection handler can restore BOTH queues if the server
+                # rejects asynchronously.
+                delivered_ids = {
                     cb.get("_callback_delivery_id")
-                    for cb in self.pending_agent_callbacks
+                    for cb in voice_snapshot
                     if cb.get("_callback_delivery_id")
                 }
-                existing_ids.update(
-                    extra.get("_callback_delivery_id")
-                    for extra in self.pending_extra_replies
-                    if extra.get("_callback_delivery_id")
-                )
-                for cb in _snapshot:
-                    cb_id = cb.get("_callback_delivery_id")
-                    if cb_id and cb_id in existing_ids:
-                        continue
-                    self.pending_agent_callbacks.append(cb)
+                voice_extra_snapshot = [
+                    extra for extra in self.pending_extra_replies
+                    if extra.get("_callback_delivery_id") in delivered_ids
+                ]
 
-            try:
-                await voice_sess.inject_text_and_request_response(
-                    instruction, on_rejected=_on_voice_inject_rejected
-                )
-            except NotImplementedError:
-                # Defensive fallback. As of now every realtime provider
-                # (OpenAI / GLM / Step / free / GPT / Qwen / Grok via
-                # conversation.item.create, Gemini via send_client_content)
-                # supports manual inject, so this branch is unreachable in
-                # practice — kept so a hypothetical future provider that
-                # raises NotImplementedError degrades to hot-swap instead of
-                # losing the cb. Drop the proactive cbs so they don't loop
-                # forever, but keep ``pending_extra_replies`` populated for the
-                # next user-turn prime_context() drain.
-                voice_ids = {id(cb) for cb in voice_snapshot}
+                # Server-side rejection of ``response.create`` (e.g.
+                # ``response_already_active`` from a VAD race winning between
+                # our gate check and our send) is delivered asynchronously as
+                # an ``error`` event, not via this call's return value or an
+                # exception. Without a rejection callback, the optimistic prune
+                # below would silently drop the cb. Re-enqueue the snapshot on
+                # rejection so a retry picks it up.
+                lanlan_name_snapshot = self.lanlan_name
+
+                def _on_voice_inject_rejected(
+                    error_msg: str,
+                    _snapshot=voice_snapshot,
+                    _extra_snapshot=voice_extra_snapshot,
+                    _lanlan=lanlan_name_snapshot,
+                ) -> None:
+                    logger.warning(
+                        "[%s] voice proactive inject rejected by server: %s; re-enqueuing %d cb(s) for retry",
+                        _lanlan, error_msg, len(_snapshot),
+                    )
+                    # Restore BOTH queues in lockstep — only entries whose
+                    # delivery_id is not already present (guards against
+                    # double-add). Restoring ``pending_extra_replies`` keeps the
+                    # hot-swap prime copy alive if a later fallback path runs.
+                    existing_cb_ids = {
+                        cb.get("_callback_delivery_id")
+                        for cb in self.pending_agent_callbacks
+                        if cb.get("_callback_delivery_id")
+                    }
+                    existing_extra_ids = {
+                        extra.get("_callback_delivery_id")
+                        for extra in self.pending_extra_replies
+                        if extra.get("_callback_delivery_id")
+                    }
+                    for cb in _snapshot:
+                        cb_id = cb.get("_callback_delivery_id")
+                        if cb_id and cb_id in existing_cb_ids:
+                            continue
+                        self.pending_agent_callbacks.append(cb)
+                    for extra in _extra_snapshot:
+                        extra_id = extra.get("_callback_delivery_id")
+                        if extra_id and extra_id in existing_extra_ids:
+                            continue
+                        self.pending_extra_replies.append(extra)
+                    # The reject can land AFTER the response.done that would
+                    # otherwise re-fire trigger via _finalize_turn_after_emit;
+                    # if the session is idle now, re-fire immediately so the
+                    # restored cb doesn't sit until the next unrelated turn.
+                    if (
+                        self.state.phase is ProactivePhase.IDLE
+                        and isinstance(self.session, OmniRealtimeClient)
+                        and not self.session.is_active_response()
+                    ):
+                        self._fire_task(self.trigger_agent_callbacks())
+
+                try:
+                    await voice_sess.inject_text_and_request_response(
+                        instruction, on_rejected=_on_voice_inject_rejected
+                    )
+                except NotImplementedError:
+                    # Defensive fallback. As of now every realtime provider
+                    # (OpenAI / GLM / Step / free / GPT / Qwen / Grok via
+                    # conversation.item.create, Gemini via send_client_content)
+                    # supports manual inject, so this branch is unreachable in
+                    # practice — kept so a hypothetical future provider that
+                    # raises NotImplementedError degrades to hot-swap instead of
+                    # losing the cb. Drop the proactive cbs so they don't loop
+                    # forever, but keep ``pending_extra_replies`` populated for
+                    # the next user-turn prime_context() drain.
+                    voice_ids = {id(cb) for cb in voice_snapshot}
+                    self.pending_agent_callbacks = [
+                        cb for cb in self.pending_agent_callbacks
+                        if id(cb) not in voice_ids
+                    ]
+                    logger.info(
+                        "[%s] trigger_agent_callbacks: voice provider does not support manual inject; falling back to hot-swap (n=%d)",
+                        self.lanlan_name, len(voice_snapshot),
+                    )
+                    return
+                except Exception as exc:
+                    # WS error / fatal / response_already_active race — keep cbs
+                    # in the queue so the next phase-idle hook retries them.
+                    logger.warning(
+                        "[%s] trigger_agent_callbacks: voice proactive inject failed: %s; keeping cbs for retry",
+                        self.lanlan_name, exc,
+                    )
+                    return
+
+                # Inject succeeded. Drop the cbs we delivered from BOTH queues:
+                # ``pending_agent_callbacks`` (text-mode drain + proactive
+                # trigger) AND the matching ``pending_extra_replies`` entries
+                # (voice hot-swap prime channel). Leaving the extras intact would
+                # have two concrete bad consequences:
+                #   1. ``_finalize_turn_after_emit`` gates immediate session
+                #      preparation on ``bool(pending_extra_replies)`` — stale
+                #      entries trigger needless background hot-swap prep.
+                #   2. The eventual hot-swap re-primes the new session with cbs
+                #      the AI already spoke about, producing duplicate
+                #      announcements.
+                # Match by the stable ``_callback_delivery_id`` stamped on both
+                # entries by ``enqueue_agent_callback``. Length-based alignment
+                # would be unsafe — ``drain_agent_callbacks_for_llm`` clears
+                # ``pending_agent_callbacks`` while leaving
+                # ``pending_extra_replies`` intact, so the queues legitimately
+                # drift apart across user turns.
+                # Object-identity fallback for pending_agent_callbacks: defense
+                # in depth against any future code path that appends a cb
+                # without going through ``enqueue_agent_callback`` (the only
+                # stamper of ``_callback_delivery_id``). extras dicts are fresh
+                # objects so there is no id() link — extras rely on the
+                # delivery_id contract.
+                voice_obj_ids = {id(cb) for cb in voice_snapshot}
                 self.pending_agent_callbacks = [
                     cb for cb in self.pending_agent_callbacks
-                    if id(cb) not in voice_ids
+                    if cb.get("_callback_delivery_id") not in delivered_ids
+                    and id(cb) not in voice_obj_ids
+                ]
+                self.pending_extra_replies = [
+                    extra for extra in self.pending_extra_replies
+                    if extra.get("_callback_delivery_id") not in delivered_ids
                 ]
                 logger.info(
-                    "[%s] trigger_agent_callbacks: voice provider does not support manual inject; falling back to hot-swap (n=%d)",
+                    "[%s] trigger_agent_callbacks: voice proactive inject sent (n=%d)",
                     self.lanlan_name, len(voice_snapshot),
                 )
                 return
-            except Exception as exc:
-                # WS error / fatal / response_already_active race — keep cbs in
-                # the queue so the next phase-idle hook retries them.
-                logger.warning(
-                    "[%s] trigger_agent_callbacks: voice proactive inject failed: %s; keeping cbs for retry",
-                    self.lanlan_name, exc,
-                )
-                return
-
-            # Inject succeeded. Drop the cbs we delivered from BOTH queues:
-            # ``pending_agent_callbacks`` (text-mode drain + proactive trigger)
-            # AND the matching ``pending_extra_replies`` entries (voice
-            # hot-swap prime channel). Leaving the extras intact would have
-            # two concrete bad consequences:
-            #   1. ``_finalize_turn_after_emit`` gates immediate session
-            #      preparation on ``bool(pending_extra_replies)`` — stale
-            #      entries trigger needless background hot-swap prep.
-            #   2. The eventual hot-swap re-primes the new session with cbs
-            #      the AI already spoke about, producing duplicate
-            #      announcements.
-            # Match by the stable ``_callback_delivery_id`` stamped on both
-            # entries by ``enqueue_agent_callback``. Length-based alignment
-            # would be unsafe — ``drain_agent_callbacks_for_llm`` clears
-            # ``pending_agent_callbacks`` while leaving ``pending_extra_replies``
-            # intact, so the queues legitimately drift apart across user turns
-            # and a "queues are aligned iff len matches" check would skip
-            # extras cleanup whenever a drain ran beforehand.
-            delivered_ids = {
-                cb.get("_callback_delivery_id")
-                for cb in voice_snapshot
-                if cb.get("_callback_delivery_id")
-            }
-            # Object-identity fallback for pending_agent_callbacks: defense
-            # in depth against any future code path that appends a cb
-            # without going through ``enqueue_agent_callback`` (which is
-            # the only stamper of ``_callback_delivery_id``). All current
-            # production callers route through it, but matching by Python
-            # ``id()`` lets us still prune unstamped snapshot entries here
-            # rather than have them re-deliver on every retry. extras dicts
-            # are constructed fresh in ``enqueue_agent_callback`` so there
-            # is no object link from voice_snapshot → extras; extras must
-            # rely on the delivery_id contract.
-            voice_obj_ids = {id(cb) for cb in voice_snapshot}
-            self.pending_agent_callbacks = [
-                cb for cb in self.pending_agent_callbacks
-                if cb.get("_callback_delivery_id") not in delivered_ids
-                and id(cb) not in voice_obj_ids
-            ]
-            self.pending_extra_replies = [
-                extra for extra in self.pending_extra_replies
-                if extra.get("_callback_delivery_id") not in delivered_ids
-            ]
-            logger.info(
-                "[%s] trigger_agent_callbacks: voice proactive inject sent (n=%d)",
-                self.lanlan_name, len(voice_snapshot),
-            )
-            return
 
         _lang = normalize_language_code(self.user_language, format='short')
         # Render via _build_callback_instruction on the proactive subset only.

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5569,13 +5569,21 @@ class LLMSessionManager:
         # 流水线在跑，也跳。两条都不满足时 callbacks 留在队列，等
         # _finalize_turn_after_emit 在 response.done 之后重新调用本函数重试。
         if isinstance(self.session, OmniRealtimeClient):
-            voice_sess = self.session
             # Serialize the whole check-and-claim against concurrent trigger
             # tasks (see ``_voice_proactive_inject_lock``). Hold the lock across
             # gate → render → inject → prune; a second task blocks here and,
             # once it acquires, re-filters the (now-pruned) queue and finds
             # nothing left to send.
             async with self._voice_proactive_inject_lock:
+                # Read the session INSIDE the lock — start_session / end_session
+                # / hot-swap may have swapped or torn it down while we waited
+                # for the lock. Re-check the type; if it's no longer a voice
+                # session, bail (a text-mode path / no session shouldn't be
+                # driven from this branch). Using the lock-time instance for
+                # gate + inject avoids injecting into a closing old session.
+                voice_sess = self.session
+                if not isinstance(voice_sess, OmniRealtimeClient):
+                    return
                 # Re-filter inside the lock: a concurrent task may have already
                 # injected+pruned these cbs while we waited on the lock.
                 proactive_cbs = [

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5695,17 +5695,19 @@ class LLMSessionManager:
                         if extra_id and extra_id in existing_extra_ids:
                             continue
                         self.pending_extra_replies.append(extra)
-                    # If we re-added (case b, queues were already pruned) and the
-                    # session is idle now, re-fire so the restored cb doesn't sit
-                    # until the next unrelated turn. (Case a stays in-queue and
-                    # is retried via _finalize_turn_after_emit / the lock-blocked
-                    # task scheduled below.)
-                    if (
-                        self.state.phase is ProactivePhase.IDLE
-                        and isinstance(self.session, OmniRealtimeClient)
-                        and not self.session.is_active_response()
-                    ):
-                        self._fire_task(self.trigger_agent_callbacks())
+                    # Do NOT immediately re-fire trigger here. The dominant
+                    # rejection is ``response_already_active``, which by
+                    # definition means an active response exists — but the
+                    # client may not have processed its ``response.created``
+                    # yet, so ``is_active_response()`` reads a STALE False. A
+                    # re-fire on that stale state would re-inject → re-reject →
+                    # tight loop until state flips (Codex P1). Instead rely on
+                    # the retry guaranteed by that active response's
+                    # ``response.done`` → ``handle_response_complete`` →
+                    # ``_finalize_turn_after_emit`` (which re-calls this when
+                    # ``pending_agent_callbacks`` is non-empty). The cb is kept
+                    # queued above, so the retry is not lost — just deferred to
+                    # the loop-free turn-end hook.
 
                 try:
                     await voice_sess.inject_text_and_request_response(

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5604,14 +5604,40 @@ class LLMSessionManager:
                 )
                 return
 
-            # Inject succeeded. Remove just the cbs we delivered — preserve
-            # passive cbs (and any proactive cbs another task enqueued during
-            # the ``await inject_text_and_request_response`` window).
+            # Inject succeeded. Drop the cbs we delivered from BOTH queues:
+            # ``pending_agent_callbacks`` (text-mode drain + proactive trigger)
+            # AND the matching ``pending_extra_replies`` entries (voice
+            # hot-swap prime channel). Leaving the extras intact would have
+            # two concrete bad consequences:
+            #   1. ``_finalize_turn_after_emit`` gates immediate session
+            #      preparation on ``bool(pending_extra_replies)`` — stale
+            #      entries trigger needless background hot-swap prep.
+            #   2. The eventual hot-swap re-primes the new session with cbs
+            #      the AI already spoke about, producing duplicate
+            #      announcements.
+            # ``enqueue_agent_callback`` appends both queues in lockstep
+            # (one extras entry per cb), so they're 1:1 at enqueue time.
+            # If a racing caller (``drain_agent_callbacks_for_llm`` /
+            # ``_perform_final_swap_sequence``) bulk-cleared one queue during
+            # our ``await inject_*`` window, alignment is broken — fall back
+            # to id-only drop on ``pending_agent_callbacks`` and leave the
+            # racing caller's view of ``pending_extra_replies`` alone.
             voice_ids = {id(cb) for cb in voice_snapshot}
-            self.pending_agent_callbacks = [
-                cb for cb in self.pending_agent_callbacks
-                if id(cb) not in voice_ids
-            ]
+            pac = self.pending_agent_callbacks
+            extras = self.pending_extra_replies
+            if len(pac) == len(extras):
+                new_pac: list[dict] = []
+                new_extras: list[dict] = []
+                for cb, extra in zip(pac, extras):
+                    if id(cb) not in voice_ids:
+                        new_pac.append(cb)
+                        new_extras.append(extra)
+                self.pending_agent_callbacks = new_pac
+                self.pending_extra_replies = new_extras
+            else:
+                self.pending_agent_callbacks = [
+                    cb for cb in pac if id(cb) not in voice_ids
+                ]
             logger.info(
                 "[%s] trigger_agent_callbacks: voice proactive inject sent (n=%d)",
                 self.lanlan_name, len(voice_snapshot),

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5666,9 +5666,21 @@ class LLMSessionManager:
                 for cb in voice_snapshot
                 if cb.get("_callback_delivery_id")
             }
+            # Object-identity fallback for pending_agent_callbacks: defense
+            # in depth against any future code path that appends a cb
+            # without going through ``enqueue_agent_callback`` (which is
+            # the only stamper of ``_callback_delivery_id``). All current
+            # production callers route through it, but matching by Python
+            # ``id()`` lets us still prune unstamped snapshot entries here
+            # rather than have them re-deliver on every retry. extras dicts
+            # are constructed fresh in ``enqueue_agent_callback`` so there
+            # is no object link from voice_snapshot → extras; extras must
+            # rely on the delivery_id contract.
+            voice_obj_ids = {id(cb) for cb in voice_snapshot}
             self.pending_agent_callbacks = [
                 cb for cb in self.pending_agent_callbacks
                 if cb.get("_callback_delivery_id") not in delivered_ids
+                and id(cb) not in voice_obj_ids
             ]
             self.pending_extra_replies = [
                 extra for extra in self.pending_extra_replies

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5620,25 +5620,39 @@ class LLMSessionManager:
                 # ``response_already_active`` from a VAD race winning between
                 # our gate check and our send) is delivered asynchronously as
                 # an ``error`` event, not via this call's return value or an
-                # exception. Without a rejection callback, the optimistic prune
-                # below would silently drop the cb. Re-enqueue the snapshot on
-                # rejection so a retry picks it up.
+                # exception — and ``handle_messages`` can dispatch it WHILE we
+                # are still awaiting ``inject_text_and_request_response`` (i.e.
+                # BEFORE the optimistic prune below runs). The handler must
+                # survive both orderings:
+                #   (a) reject fires DURING the await (cb still in the queue):
+                #       set ``_rejected`` so the post-await code SKIPS the prune
+                #       — otherwise the success prune would delete a cb the
+                #       server refused. Do NOT re-add here (it's still present).
+                #   (b) reject fires AFTER the trigger returned + pruned (cb
+                #       gone): re-add to BOTH queues by id (dedup-guarded) and,
+                #       if idle, re-fire trigger so it doesn't wait for the next
+                #       unrelated response.done.
+                # The dedup-by-presence check distinguishes the two: present →
+                # case (a) (skip re-add, rely on skip-prune); absent → case (b).
                 lanlan_name_snapshot = self.lanlan_name
+                _reject_state = {"rejected": False}
 
                 def _on_voice_inject_rejected(
                     error_msg: str,
                     _snapshot=voice_snapshot,
                     _extra_snapshot=voice_extra_snapshot,
                     _lanlan=lanlan_name_snapshot,
+                    _state=_reject_state,
                 ) -> None:
+                    _state["rejected"] = True
                     logger.warning(
                         "[%s] voice proactive inject rejected by server: %s; re-enqueuing %d cb(s) for retry",
                         _lanlan, error_msg, len(_snapshot),
                     )
                     # Restore BOTH queues in lockstep — only entries whose
-                    # delivery_id is not already present (guards against
-                    # double-add). Restoring ``pending_extra_replies`` keeps the
-                    # hot-swap prime copy alive if a later fallback path runs.
+                    # delivery_id is not already present. Present means the
+                    # optimistic prune hasn't run yet (case a): leave them and
+                    # let the post-await ``_rejected`` check skip the prune.
                     existing_cb_ids = {
                         cb.get("_callback_delivery_id")
                         for cb in self.pending_agent_callbacks
@@ -5659,10 +5673,11 @@ class LLMSessionManager:
                         if extra_id and extra_id in existing_extra_ids:
                             continue
                         self.pending_extra_replies.append(extra)
-                    # The reject can land AFTER the response.done that would
-                    # otherwise re-fire trigger via _finalize_turn_after_emit;
-                    # if the session is idle now, re-fire immediately so the
-                    # restored cb doesn't sit until the next unrelated turn.
+                    # If we re-added (case b, queues were already pruned) and the
+                    # session is idle now, re-fire so the restored cb doesn't sit
+                    # until the next unrelated turn. (Case a stays in-queue and
+                    # is retried via _finalize_turn_after_emit / the lock-blocked
+                    # task scheduled below.)
                     if (
                         self.state.phase is ProactivePhase.IDLE
                         and isinstance(self.session, OmniRealtimeClient)
@@ -5700,6 +5715,21 @@ class LLMSessionManager:
                     logger.warning(
                         "[%s] trigger_agent_callbacks: voice proactive inject failed: %s; keeping cbs for retry",
                         self.lanlan_name, exc,
+                    )
+                    return
+
+                # If the server rejected asynchronously DURING the await above
+                # (case a — ``_on_voice_inject_rejected`` already fired while
+                # the cbs were still in the queue), the cbs were intentionally
+                # left in place. Pruning now would delete a cb the server
+                # refused → silent loss. Skip the prune; the cbs stay queued and
+                # are retried via _finalize_turn_after_emit (or the re-fire the
+                # handler scheduled). The active response that caused the
+                # rejection will fire response.done and trigger the retry.
+                if _reject_state["rejected"]:
+                    logger.info(
+                        "[%s] trigger_agent_callbacks: voice proactive inject rejected during await; keeping %d cb(s) queued for retry",
+                        self.lanlan_name, len(voice_snapshot),
                     )
                     return
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -39,7 +39,7 @@ from main_logic.tool_calling import (
     ToolResult,
 )
 from utils.llm_client import AIMessage
-from main_logic.session_state import SessionStateMachine, SessionEvent
+from main_logic.session_state import SessionStateMachine, SessionEvent, ProactivePhase
 from main_logic.agent_event_bus import (
     dispatch_text_user_message,
     dispatch_user_utterance,
@@ -5548,14 +5548,74 @@ class LLMSessionManager:
             )
             return
 
-        # Voice mode 走 hot-swap，不进 SM proactive 流水线。Drop only the
-        # proactive cbs from the queue; passive cbs stay for the next drain.
+        # Voice mode：直接 conversation.item.create(role=system) + response.create，
+        # 让 LLM 立即用本角色嗓音主动回应 proactive callback，不等用户开口。
+        #
+        # Gate：realtime API 同一时刻只允许一个 active response。如果 user 正在
+        # 说话（server-VAD 触发 → 自动 response.create）或上一个 response 还
+        # 没结束（含 prompt_ephemeral 走的 fudge response），client 再发
+        # response.create 会被 reject。phase != IDLE 时说明 text-mode proactive
+        # 流水线在跑，也跳。两条都不满足时 callbacks 留在队列，等
+        # _finalize_turn_after_emit 在 response.done 之后重新调用本函数重试。
         if isinstance(self.session, OmniRealtimeClient):
+            voice_sess = self.session
+            if self.state.phase is not ProactivePhase.IDLE or voice_sess.is_active_response():
+                logger.debug(
+                    "[%s] trigger_agent_callbacks: voice session busy (phase=%s, active_response=%s); deferring proactive (n=%d)",
+                    self.lanlan_name,
+                    self.state.phase.value,
+                    voice_sess.is_active_response(),
+                    len(proactive_cbs),
+                )
+                return
+
+            _lang = normalize_language_code(self.user_language, format='short')
+            instruction = _build_callback_instruction(
+                proactive_cbs,
+                lang=_lang,
+                lanlan_name=self.lanlan_name,
+                master_name=self.master_name,
+                passive=False,
+            )
+            voice_snapshot = list(proactive_cbs)
+            try:
+                await voice_sess.inject_text_and_request_response(instruction)
+            except NotImplementedError:
+                # Provider doesn't support manual inject (Gemini Live / Qwen).
+                # Fall through to the legacy hot-swap path: drop the proactive
+                # cbs so they don't loop forever, but keep ``pending_extra_replies``
+                # populated for the next user-turn prime_context() drain.
+                voice_ids = {id(cb) for cb in voice_snapshot}
+                self.pending_agent_callbacks = [
+                    cb for cb in self.pending_agent_callbacks
+                    if id(cb) not in voice_ids
+                ]
+                logger.info(
+                    "[%s] trigger_agent_callbacks: voice provider does not support manual inject; falling back to hot-swap (n=%d)",
+                    self.lanlan_name, len(voice_snapshot),
+                )
+                return
+            except Exception as exc:
+                # WS error / fatal / response_already_active race — keep cbs in
+                # the queue so the next phase-idle hook retries them.
+                logger.warning(
+                    "[%s] trigger_agent_callbacks: voice proactive inject failed: %s; keeping cbs for retry",
+                    self.lanlan_name, exc,
+                )
+                return
+
+            # Inject succeeded. Remove just the cbs we delivered — preserve
+            # passive cbs (and any proactive cbs another task enqueued during
+            # the ``await inject_text_and_request_response`` window).
+            voice_ids = {id(cb) for cb in voice_snapshot}
             self.pending_agent_callbacks = [
                 cb for cb in self.pending_agent_callbacks
-                if cb.get("delivery_mode") == "passive"
+                if id(cb) not in voice_ids
             ]
-            logger.debug("[%s] trigger_agent_callbacks: voice mode, deferring to hot-swap", self.lanlan_name)
+            logger.info(
+                "[%s] trigger_agent_callbacks: voice proactive inject sent (n=%d)",
+                self.lanlan_name, len(voice_snapshot),
+            )
             return
 
         _lang = normalize_language_code(self.user_language, format='short')

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5548,7 +5548,7 @@ class LLMSessionManager:
             )
             return
 
-        # Voice mode：直接 conversation.item.create(role=system) + response.create，
+        # Voice mode：直接 conversation.item.create(role=user) + response.create，
         # 让 LLM 立即用本角色嗓音主动回应 proactive callback，不等用户开口。
         #
         # Gate：realtime API 同一时刻只允许一个 active response。如果 user 正在

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5615,29 +5615,26 @@ class LLMSessionManager:
             #   2. The eventual hot-swap re-primes the new session with cbs
             #      the AI already spoke about, producing duplicate
             #      announcements.
-            # ``enqueue_agent_callback`` appends both queues in lockstep
-            # (one extras entry per cb), so they're 1:1 at enqueue time.
-            # If a racing caller (``drain_agent_callbacks_for_llm`` /
-            # ``_perform_final_swap_sequence``) bulk-cleared one queue during
-            # our ``await inject_*`` window, alignment is broken — fall back
-            # to id-only drop on ``pending_agent_callbacks`` and leave the
-            # racing caller's view of ``pending_extra_replies`` alone.
-            voice_ids = {id(cb) for cb in voice_snapshot}
-            pac = self.pending_agent_callbacks
-            extras = self.pending_extra_replies
-            if len(pac) == len(extras):
-                new_pac: list[dict] = []
-                new_extras: list[dict] = []
-                for cb, extra in zip(pac, extras):
-                    if id(cb) not in voice_ids:
-                        new_pac.append(cb)
-                        new_extras.append(extra)
-                self.pending_agent_callbacks = new_pac
-                self.pending_extra_replies = new_extras
-            else:
-                self.pending_agent_callbacks = [
-                    cb for cb in pac if id(cb) not in voice_ids
-                ]
+            # Match by the stable ``_callback_delivery_id`` stamped on both
+            # entries by ``enqueue_agent_callback``. Length-based alignment
+            # would be unsafe — ``drain_agent_callbacks_for_llm`` clears
+            # ``pending_agent_callbacks`` while leaving ``pending_extra_replies``
+            # intact, so the queues legitimately drift apart across user turns
+            # and a "queues are aligned iff len matches" check would skip
+            # extras cleanup whenever a drain ran beforehand.
+            delivered_ids = {
+                cb.get("_callback_delivery_id")
+                for cb in voice_snapshot
+                if cb.get("_callback_delivery_id")
+            }
+            self.pending_agent_callbacks = [
+                cb for cb in self.pending_agent_callbacks
+                if cb.get("_callback_delivery_id") not in delivered_ids
+            ]
+            self.pending_extra_replies = [
+                extra for extra in self.pending_extra_replies
+                if extra.get("_callback_delivery_id") not in delivered_ids
+            ]
             logger.info(
                 "[%s] trigger_agent_callbacks: voice proactive inject sent (n=%d)",
                 self.lanlan_name, len(voice_snapshot),
@@ -6079,8 +6076,17 @@ class LLMSessionManager:
             # discarded.
             if not summary and not detail and not error_message and not source_name and status == "completed":
                 return
+            # Stable delivery id so the voice inject success path can
+            # precisely drop the matching extras entry from
+            # ``pending_extra_replies``. Length-based alignment is unsafe:
+            # ``drain_agent_callbacks_for_llm`` clears
+            # ``pending_agent_callbacks`` while leaving
+            # ``pending_extra_replies`` intact, so the queues legitimately
+            # drift apart across user turns.
+            delivery_id = callback.setdefault("_callback_delivery_id", uuid4().hex)
             self.pending_agent_callbacks.append(callback)
             self.pending_extra_replies.append({
+                "_callback_delivery_id": delivery_id,
                 "origin": origin,
                 "summary": summary,
                 "detail": detail,

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -5666,6 +5666,14 @@ class LLMSessionManager:
                         for cb in self.pending_agent_callbacks
                         if cb.get("_callback_delivery_id")
                     }
+                    # Object-identity fallback, symmetric with the success-path
+                    # prune: an unstamped cb (no _callback_delivery_id, e.g. a
+                    # future caller bypassing enqueue_agent_callback) would
+                    # otherwise fail the id-based dedup and get re-appended even
+                    # when it's still in the queue (case a) — then skip-prune
+                    # keeps both copies → double-delivery on retry. Dedup such
+                    # entries by Python id().
+                    existing_cb_obj_ids = {id(cb) for cb in self.pending_agent_callbacks}
                     existing_extra_ids = {
                         extra.get("_callback_delivery_id")
                         for extra in self.pending_extra_replies
@@ -5673,9 +5681,15 @@ class LLMSessionManager:
                     }
                     for cb in _snapshot:
                         cb_id = cb.get("_callback_delivery_id")
-                        if cb_id and cb_id in existing_cb_ids:
+                        if (cb_id and cb_id in existing_cb_ids) or (
+                            not cb_id and id(cb) in existing_cb_obj_ids
+                        ):
                             continue
                         self.pending_agent_callbacks.append(cb)
+                        if cb_id:
+                            existing_cb_ids.add(cb_id)
+                        else:
+                            existing_cb_obj_ids.add(id(cb))
                     for extra in _extra_snapshot:
                         extra_id = extra.get("_callback_delivery_id")
                         if extra_id and extra_id in existing_extra_ids:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1666,15 +1666,14 @@ class OmniRealtimeClient:
         it to put the optimistically-pruned cb back in the queue.
 
         Provider dispatch:
-          - **OpenAI / GLM / Step / free / GPT**: ``conversation.item.create``
-            (role=user, input_text) + ``response.create``. Uses user role
-            rather than system to avoid permanent drift of session
-            instruction context — the rendered body already self-identifies
-            as a system notification via its ``======[系统通知]======``
-            header wrapper.
-          - **Qwen**: does not accept ``conversation.item.create`` — raises
-            ``NotImplementedError`` so the caller can fall back to the
-            hot-swap path.
+          - **OpenAI / GLM / Step / free / GPT / Qwen**:
+            ``conversation.item.create`` (role=user, input_text) +
+            ``response.create``. Uses user role rather than system to avoid
+            permanent drift of session instruction context — the rendered
+            body already self-identifies as a system notification via its
+            ``======[系统通知]======`` header wrapper. (Qwen included: the
+            Aliyun doc claiming function_call_output-only is stale for
+            qwen3.5-omni-flash-realtime; verified live.)
           - **Gemini Live**: protocol does not model a "fire response now
             without a user turn" primitive cleanly — raises
             ``NotImplementedError`` so the caller can fall back.
@@ -1689,11 +1688,13 @@ class OmniRealtimeClient:
                 "Gemini Live does not support proactive inject_text_and_request_response; "
                 "fall back to hot-swap"
             )
-        if "qwen" in self._model_lower:
-            raise NotImplementedError(
-                "Qwen Realtime does not accept conversation.item.create; "
-                "fall back to hot-swap"
-            )
+        # NOTE on Qwen: the Aliyun realtime doc states conversation.item.create
+        # "currently only supports function_call_output items". That is stale
+        # for qwen3.5-omni-flash-realtime — empirically it accepts a
+        # ``role=user`` ``input_text`` message item and responds to it (no
+        # error event), identical to OpenAI / GLM / Step. Verified live against
+        # the dashscope realtime endpoint. So Qwen takes the same path below;
+        # do NOT re-add a Qwen exclusion without re-checking the live API.
         if self.ws is None:
             raise RuntimeError("realtime websocket is not connected")
 

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1644,7 +1644,7 @@ class OmniRealtimeClient:
         *,
         on_rejected: Optional[Callable[[str], None]] = None,
     ) -> None:
-        """Inject a system-role text item and explicitly trigger a response.
+        """Inject a user-role text item and explicitly trigger a response.
 
         Used by the voice-mode proactive path (agent task callbacks /
         plugin push_message ai_behavior="respond") to surface a rendered
@@ -1667,7 +1667,11 @@ class OmniRealtimeClient:
 
         Provider dispatch:
           - **OpenAI / GLM / Step / free / GPT**: ``conversation.item.create``
-            (role=system, input_text) + ``response.create``.
+            (role=user, input_text) + ``response.create``. Uses user role
+            rather than system to avoid permanent drift of session
+            instruction context — the rendered body already self-identifies
+            as a system notification via its ``======[系统通知]======``
+            header wrapper.
           - **Qwen**: does not accept ``conversation.item.create`` — raises
             ``NotImplementedError`` so the caller can fall back to the
             hot-swap path.
@@ -1693,11 +1697,23 @@ class OmniRealtimeClient:
         if self.ws is None:
             raise RuntimeError("realtime websocket is not connected")
 
+        # Role choice: ``user`` (not ``system``).
+        # OpenAI Realtime persists conversation items as part of session
+        # history. ``role="system"`` items are treated as high-priority
+        # instructions that influence every subsequent turn — accumulating
+        # several proactive callbacks under system role causes prompt
+        # drift (model starts repeating meta-behavior or interpreting
+        # stale callback text as standing orders for unrelated turns).
+        # ``role="user"`` keeps the inject in dialog-weight context, and
+        # ``_build_callback_instruction`` already wraps the body in a
+        # ``======[系统通知] ...======`` header that makes the model
+        # treat it as a one-shot system notification rather than user
+        # speech. Matches the existing ``create_response`` precedent.
         item_event = {
             "type": "conversation.item.create",
             "item": {
                 "type": "message",
-                "role": "system",
+                "role": "user",
                 "content": [
                     {
                         "type": "input_text",

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1103,7 +1103,11 @@ class OmniRealtimeClient:
         if not self.ws:
             return
         
-        event['event_id'] = "event_" + str(int(time.time() * 1000))
+        # Use setdefault so callers that explicitly stamp an event_id
+        # (e.g. proactive inject paths matching server-side
+        # ``error.event_id`` echoes for rejection callbacks) keep theirs.
+        # Otherwise fall back to the legacy timestamp-based id.
+        event.setdefault('event_id', "event_" + str(int(time.time() * 1000)))
         async with self._send_semaphore:  # 限制并发发送数量
             try:
                 if not self.ws:

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -473,6 +473,15 @@ class OmniRealtimeClient:
         # was optimistically pruned after send. Entries also self-expire to
         # avoid leaks if the server never acks.
         self._inject_rejection_handlers: Dict[str, Callable[[str], None]] = {}
+        # One-shot gate for the no-event_id content fallback in
+        # ``_route_inject_rejection``. True only between "a proactive inject
+        # just sent its ``response.create``" and "that inject's outcome was
+        # observed" (rejection fired, or a response lifecycle event arrived).
+        # Without this, a no-id ``response_already_active`` from a DIFFERENT
+        # ``response.create`` sender (create_response / tool-result /
+        # signal_user_activity_end) could content-match a lingering — already
+        # succeeded — proactive handler and wrongly re-enqueue its cb.
+        self._proactive_inject_awaiting_outcome = False
 
     def _fire_task(self, coro):
         """Create a background task with GC protection."""
@@ -1771,6 +1780,11 @@ class OmniRealtimeClient:
             # under transient backpressure is still caught (Codex P2).
             self._fire_task(self._expire_inject_rejection_handler(item_event_id, 30.0))
             self._fire_task(self._expire_inject_rejection_handler(create_event_id, 30.0))
+            # Open the no-id content-fallback window for THIS inject. Closed
+            # when its outcome is observed (rejection fired, or the next
+            # response lifecycle event / done sweep) — see
+            # _route_inject_rejection.
+            self._proactive_inject_awaiting_outcome = True
 
         item_event: Dict[str, Any] = {
             "type": "conversation.item.create",
@@ -1889,11 +1903,21 @@ class OmniRealtimeClient:
             # belongs to some other request's rejection — not ours.
             handler = self._inject_rejection_handlers.pop(err_event_id, None)
             if handler is not None:
+                self._proactive_inject_awaiting_outcome = False
                 _fire(handler)
             return
 
-        # No client-correlation id at all — fall back to content matching.
-        if self._looks_like_response_conflict(error_msg):
+        # No client-correlation id at all — fall back to content matching,
+        # but ONLY while a proactive inject is genuinely awaiting its outcome
+        # (one-shot window). This excludes a no-id response-conflict raised by
+        # a DIFFERENT response.create sender (create_response / tool-result /
+        # signal_user_activity_end) from hitting a lingering, already-succeeded
+        # proactive handler.
+        if (
+            self._proactive_inject_awaiting_outcome
+            and self._looks_like_response_conflict(error_msg)
+        ):
+            self._proactive_inject_awaiting_outcome = False
             for handler in list(self._inject_rejection_handlers.values()):
                 _fire(handler)
             self._inject_rejection_handlers.clear()
@@ -1918,6 +1942,9 @@ class OmniRealtimeClient:
         in the dict belongs to an inject that SUCCEEDED (no rejection coming)
         — exactly the leak the fixed TTL was meant to clean, now reaped
         promptly and lifecycle-tied instead of on a wall clock."""
+        # The inject's outcome has been observed (a response completed), so
+        # close the no-id content-fallback window too.
+        self._proactive_inject_awaiting_outcome = False
         if self._inject_rejection_handlers:
             self._inject_rejection_handlers.clear()
 
@@ -2465,6 +2492,12 @@ class OmniRealtimeClient:
                 elif event_type == "response.created":
                     self._response_created_total += 1
                     self._last_response_created_time = time.time()
+                    # A response started — our proactive inject's response.create
+                    # was either accepted (this IS its response) or a different
+                    # response is now active; either way close the no-id
+                    # content-fallback window so a later unrelated no-id
+                    # conflict can't fire a lingering (accepted) inject handler.
+                    self._proactive_inject_awaiting_outcome = False
                     self._current_response_id = event.get("response", {}).get("id")
                     self._is_responding = True
                     self._interrupted = False  # Clear interruption flag on new response

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1829,6 +1829,62 @@ class OmniRealtimeClient:
             return
         self._inject_rejection_handlers.pop(event_id, None)
 
+    @staticmethod
+    def _looks_like_response_conflict(error_msg: str) -> bool:
+        """Heuristic: does this ``error`` message look like the server
+        rejecting a ``response.create`` because a response is already active?
+
+        That ``response_already_active`` class is the ONLY async rejection a
+        proactive inject can provoke (our inject is the only client-issued
+        ``response.create`` on the voice path). Matching its content lets us
+        route the rejection even when the provider's error doesn't echo our
+        client ``event_id``. Kept deliberately broad across phrasings /
+        providers but still scoped to response-conflict wording so unrelated
+        errors (auth / quota / 503 / idle-timeout) don't trip it."""
+        low = error_msg.lower()
+        if "response_already_active" in low:
+            return True
+        return "response" in low and any(
+            k in low for k in ("already", "active", "in progress", "in_progress", "exists", "ongoing")
+        )
+
+    def _route_inject_rejection(self, err_event_id, error_msg: str) -> None:
+        """Deliver a server rejection to the matching proactive-inject
+        ``on_rejected`` handler so the caller re-enqueues the cb.
+
+        Two correlation paths:
+          1. **By id (precise)** — OpenAI Realtime (and any provider that
+             echoes the offending client ``event_id``): pop and fire the exact
+             handler.
+          2. **By content (fallback)** — providers that reject without a
+             client-correlated id: if the error looks like a response-conflict
+             (``_looks_like_response_conflict``) and handlers are pending, fire
+             them all. Injects are serialized by
+             ``_voice_proactive_inject_lock`` so there's effectively one logical
+             pending inject; ``_reject_once`` + the caller's delivery-id dedup
+             make a spurious fire cost at most a bounded duplicate re-add, which
+             is strictly better than a silent drop (Codex P1)."""
+        if not self._inject_rejection_handlers:
+            return
+
+        def _fire(handler) -> None:
+            try:
+                handler(error_msg)
+            except Exception as cb_exc:
+                logger.warning("proactive inject rejection handler raised: %s", cb_exc)
+
+        if err_event_id and err_event_id in self._inject_rejection_handlers:
+            handler = self._inject_rejection_handlers.pop(err_event_id, None)
+            if handler is not None:
+                _fire(handler)
+            return
+
+        # No id correlation — fall back to content matching.
+        if self._looks_like_response_conflict(error_msg):
+            for handler in list(self._inject_rejection_handlers.values()):
+                _fire(handler)
+            self._inject_rejection_handlers.clear()
+
     def _sweep_inject_rejection_handlers(self) -> None:
         """Drop all pending inject rejection handlers on a ``response.done``
         lifecycle boundary.
@@ -2221,26 +2277,16 @@ class OmniRealtimeClient:
                     error_msg = str(event.get('error', ''))
                     logger.error(f"API Error: {error_msg}")
 
-                    # If this error is the server rejecting a proactive
-                    # ``response.create`` we stamped with a tracked event_id
-                    # (e.g. ``response_already_active`` from a VAD race),
-                    # invoke the per-inject rejection handler so the caller
-                    # can re-enqueue the optimistically-pruned cb. ``error``
-                    # events normally echo the offending client event_id at
-                    # ``error.event_id``; fall back to the top-level
-                    # ``event_id`` for providers that put it there instead.
+                    # Route server rejections of a proactive inject's
+                    # ``response.create`` / ``conversation.item.create`` back to
+                    # the caller so it can re-enqueue the optimistically-pruned
+                    # cb (see _route_inject_rejection). ``error`` events
+                    # normally echo the offending client event_id at
+                    # ``error.event_id``; some providers put it top-level or
+                    # omit it entirely — the helper handles all three.
                     err_obj = event.get('error') if isinstance(event.get('error'), dict) else {}
                     err_event_id = err_obj.get('event_id') or event.get('event_id')
-                    if err_event_id:
-                        handler = self._inject_rejection_handlers.pop(err_event_id, None)
-                        if handler is not None:
-                            try:
-                                handler(error_msg)
-                            except Exception as cb_exc:
-                                logger.warning(
-                                    "proactive inject rejection handler raised: %s",
-                                    cb_exc,
-                                )
+                    self._route_inject_rejection(err_event_id, error_msg)
 
                     # 检测503过载错误，触发backpressure节流
                     if '503' in error_msg or 'overloaded' in error_msg.lower():

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1729,7 +1729,44 @@ class OmniRealtimeClient:
         # ``======[系统通知] ...======`` header that makes the model
         # treat it as a one-shot system notification rather than user
         # speech. Matches the existing ``create_response`` precedent.
-        item_event = {
+        # Stamp stable client event_ids on BOTH events so the server's
+        # ``error.event_id`` can be matched back to this specific request
+        # whichever event it rejects (the item itself, or the
+        # ``response.create`` — e.g. ``response_already_active`` from a VAD
+        # race). ``send_event()`` would otherwise overwrite a missing
+        # event_id with its own timestamp-based string — fine for routing but
+        # useless for rejection matching since the caller has no view of it.
+        # A single ``_reject_once`` wrapper fires ``on_rejected`` at most once
+        # even if both event_ids somehow error, and unregisters both handlers.
+        item_event_id: Optional[str] = None
+        create_event_id: Optional[str] = None
+        if on_rejected is not None:
+            item_event_id = f"event_inject_item_{uuid.uuid4().hex}"
+            create_event_id = f"event_inject_resp_{uuid.uuid4().hex}"
+
+            _fired = False
+
+            def _reject_once(error_msg: str) -> None:
+                nonlocal _fired
+                # Unregister both regardless so neither lingers.
+                self._inject_rejection_handlers.pop(item_event_id, None)
+                self._inject_rejection_handlers.pop(create_event_id, None)
+                if _fired:
+                    return
+                _fired = True
+                on_rejected(error_msg)
+
+            self._inject_rejection_handlers[item_event_id] = _reject_once
+            self._inject_rejection_handlers[create_event_id] = _reject_once
+            # The realtime API echoes our event_id on ``error`` but NOT on
+            # ``response.created`` — so a successful inject leaves the handlers
+            # registered with no natural cleanup signal. TTL-expire both after
+            # 3s (well beyond any realistic server round-trip) to keep the
+            # dict from growing per proactive cb over the session.
+            self._fire_task(self._expire_inject_rejection_handler(item_event_id, 3.0))
+            self._fire_task(self._expire_inject_rejection_handler(create_event_id, 3.0))
+
+        item_event: Dict[str, Any] = {
             "type": "conversation.item.create",
             "item": {
                 "type": "message",
@@ -1742,49 +1779,35 @@ class OmniRealtimeClient:
                 ],
             },
         }
+        if item_event_id is not None:
+            item_event["event_id"] = item_event_id
+
         # send_event() silently returns when ws drops to None or fatal flag
         # flips mid-flight (it does not raise). Without the post-send checks,
         # a connection lost in the brief await window between the entry guard
         # and the actual send would look like a successful inject — caller
         # would prune the cb but nothing reached the model. Re-check after
         # each send and raise so the caller's exception branch keeps the cb
-        # for retry.
-        await self.send_event(item_event)
-        if self._fatal_error_occurred or self.ws is None:
-            raise RuntimeError(
-                "realtime connection lost after proactive conversation.item.create"
-            )
-        # Stamp a stable client event_id on response.create so the server's
-        # ``error.event_id`` can be matched back to this specific request if
-        # the realtime API rejects it (e.g. ``response_already_active`` from
-        # a VAD race winning between the caller's gate check and our send).
-        # ``send_event()`` would otherwise overwrite a missing event_id with
-        # its own timestamp-based string — fine for routing but useless for
-        # rejection matching since the caller has no view of it.
-        create_event_id: Optional[str] = None
-        if on_rejected is not None:
-            create_event_id = f"event_inject_{uuid.uuid4().hex}"
-            self._inject_rejection_handlers[create_event_id] = on_rejected
-            # The realtime API echoes our event_id on ``error`` but NOT on
-            # ``response.created`` — so a successful inject leaves the handler
-            # registered with no natural cleanup signal. TTL-expire it after
-            # 3s (well beyond any realistic server round-trip) to keep the
-            # dict from growing one entry per proactive cb over the session.
-            self._fire_task(self._expire_inject_rejection_handler(create_event_id, 3.0))
-        create_event: Dict[str, Any] = {"type": "response.create"}
-        if create_event_id is not None:
-            create_event["event_id"] = create_event_id
+        # for retry. On any synchronous send failure, drop both rejection
+        # handlers so the caller's ``except`` path is the single source of
+        # truth and a late error event can't double-fire the re-queue.
         try:
+            await self.send_event(item_event)
+            if self._fatal_error_occurred or self.ws is None:
+                raise RuntimeError(
+                    "realtime connection lost after proactive conversation.item.create"
+                )
+            create_event: Dict[str, Any] = {"type": "response.create"}
+            if create_event_id is not None:
+                create_event["event_id"] = create_event_id
             await self.send_event(create_event)
             if self._fatal_error_occurred or self.ws is None:
                 raise RuntimeError(
                     "realtime connection lost after proactive response.create"
                 )
         except Exception:
-            # Send itself blew up — drop the rejection handler so the caller's
-            # synchronous ``except`` path is the single source of truth and we
-            # don't double-fire (re-queue via except AND via a late error
-            # event that arrives after WS recovery).
+            if item_event_id is not None:
+                self._inject_rejection_handlers.pop(item_event_id, None)
             if create_event_id is not None:
                 self._inject_rejection_handlers.pop(create_event_id, None)
             raise

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1678,8 +1678,23 @@ class OmniRealtimeClient:
                 ],
             },
         }
+        # send_event() silently returns when ws drops to None or fatal flag
+        # flips mid-flight (it does not raise). Without the post-send checks,
+        # a connection lost in the brief await window between the entry guard
+        # and the actual send would look like a successful inject — caller
+        # would prune the cb but nothing reached the model. Re-check after
+        # each send and raise so the caller's exception branch keeps the cb
+        # for retry.
         await self.send_event(item_event)
+        if self._fatal_error_occurred or self.ws is None:
+            raise RuntimeError(
+                "realtime connection lost after proactive conversation.item.create"
+            )
         await self.send_event({"type": "response.create"})
+        if self._fatal_error_occurred or self.ws is None:
+            raise RuntimeError(
+                "realtime connection lost after proactive response.create"
+            )
 
     async def prompt_ephemeral(
         self,

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1830,8 +1830,13 @@ class OmniRealtimeClient:
         self._inject_rejection_handlers.pop(event_id, None)
 
     def _sweep_inject_rejection_handlers(self) -> None:
-        """Drop all pending inject rejection handlers on a response lifecycle
-        boundary (``response.done`` / Gemini turn-complete).
+        """Drop all pending inject rejection handlers on a ``response.done``
+        lifecycle boundary.
+
+        (Only the WS-realtime ``response.done`` path calls this — the Gemini
+        branch of ``inject_text_and_request_response`` returns early via
+        ``_gemini_send_user_turn`` and never registers rejection handlers, so
+        Gemini's turn-complete has nothing to sweep.)
 
         Safe because a server rejection of our ``response.create`` /
         ``conversation.item.create`` is emitted the instant the server

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1600,29 +1600,41 @@ class OmniRealtimeClient:
         logger.info("Creating response with user message")
         await self.send_event({"type": "response.create"})
     
+    async def _gemini_send_user_turn(self, text: str) -> None:
+        """Inject ``text`` as a Gemini user turn and trigger a response via
+        ``send_client_content(turn_complete=True)``.
+
+        This is Gemini Live's idiomatic equivalent of OpenAI-Realtime's
+        ``conversation.item.create(role=user) + response.create``. Shared by
+        ``_create_response_gemini`` (hot-swap priming — tolerates errors) and
+        ``inject_text_and_request_response`` (proactive — must propagate
+        errors so the caller can re-queue). Errors propagate here; callers
+        that need to swallow wrap it.
+        """
+        from google.genai import types as genai_types
+
+        content = genai_types.Content(
+            parts=[genai_types.Part(text=text)],
+            role="user",
+        )
+        await self._gemini_session.send_client_content(
+            turns=[content],
+            turn_complete=True,
+        )
+
     async def _create_response_gemini(self, instructions: str) -> None:
         """Send text content to Gemini and trigger response."""
         if not self._gemini_session:
             logger.warning("Gemini session not available for create_response")
             return
-        
+
         # 跳过空内容的发送，避免预热时污染 Gemini 对话历史
         if not instructions or not instructions.strip():
             logger.info("Gemini: skipping empty content (warmup or empty message)")
             return
-        
-        try:
-            # Gemini 使用 send_client_content 发送文本
-            from google.genai import types as genai_types
 
-            content = genai_types.Content(
-                parts=[genai_types.Part(text=instructions)],
-                role="user"
-            )
-            await self._gemini_session.send_client_content(
-                turns=[content],
-                turn_complete=True
-            )
+        try:
+            await self._gemini_send_user_turn(instructions)
             logger.info("Gemini: sent client content, waiting for response")
         except Exception as e:
             logger.error(f"Error sending client content to Gemini: {e}")
@@ -1665,8 +1677,9 @@ class OmniRealtimeClient:
         client-side id we stamp on ``response.create``. The caller can use
         it to put the optimistically-pruned cb back in the queue.
 
-        Provider dispatch:
-          - **OpenAI / GLM / Step / free / GPT / Qwen**:
+        Provider dispatch (all realtime providers supported — symmetric with
+        ``create_response``):
+          - **OpenAI / GLM / Step / free / GPT / Qwen / Grok**:
             ``conversation.item.create`` (role=user, input_text) +
             ``response.create``. Uses user role rather than system to avoid
             permanent drift of session instruction context — the rendered
@@ -1674,9 +1687,11 @@ class OmniRealtimeClient:
             ``======[系统通知]======`` header wrapper. (Qwen included: the
             Aliyun doc claiming function_call_output-only is stale for
             qwen3.5-omni-flash-realtime; verified live.)
-          - **Gemini Live**: protocol does not model a "fire response now
-            without a user turn" primitive cleanly — raises
-            ``NotImplementedError`` so the caller can fall back.
+          - **Gemini Live**: ``send_client_content(turn_complete=True)`` via
+            the shared ``_gemini_send_user_turn`` helper — Gemini's idiomatic
+            inject+trigger. No ``on_rejected`` async ack (Gemini has no
+            ``response.create`` error-event channel); failures raise
+            synchronously here so the caller's ``except`` branch re-queues.
         """
         if self._fatal_error_occurred:
             raise RuntimeError("realtime session has fatal_error_occurred set")
@@ -1684,10 +1699,14 @@ class OmniRealtimeClient:
             return
 
         if self._is_gemini:
-            raise NotImplementedError(
-                "Gemini Live does not support proactive inject_text_and_request_response; "
-                "fall back to hot-swap"
-            )
+            # Symmetric with create_response → _create_response_gemini.
+            # send_client_content(turn_complete=True) injects a user turn and
+            # triggers a response. Errors propagate (unlike the swallowing
+            # _create_response_gemini wrapper) so the caller keeps the cb.
+            if self._gemini_session is None:
+                raise RuntimeError("Gemini session not available for proactive inject")
+            await self._gemini_send_user_turn(text)
+            return
         # NOTE on Qwen: the Aliyun realtime doc states conversation.item.create
         # "currently only supports function_call_output items". That is stale
         # for qwen3.5-omni-flash-realtime — empirically it accepts a

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1,6 +1,7 @@
 # -- coding: utf-8 --
 
 import asyncio
+import uuid
 import websockets
 import json
 import base64
@@ -462,6 +463,16 @@ class OmniRealtimeClient:
         # GLM: track response_id+output_index → synthesized call_id since
         # GLM's function_call_arguments.done lacks an explicit call_id field.
         self._glm_tool_index_to_id: Dict[str, str] = {}
+
+        # Proactive inject rejection handlers, keyed by the client-side
+        # event_id we stamp on ``response.create``. When the server rejects
+        # the request (e.g. ``response_already_active`` from a VAD race), it
+        # emits an ``error`` event whose ``error.event_id`` echoes our id —
+        # the message loop pops the matching handler and invokes it so the
+        # caller (core.trigger_agent_callbacks) can re-enqueue the cb that
+        # was optimistically pruned after send. Entries also self-expire to
+        # avoid leaks if the server never acks.
+        self._inject_rejection_handlers: Dict[str, Callable[[str], None]] = {}
 
     def _fire_task(self, coro):
         """Create a background task with GC protection."""
@@ -1623,7 +1634,12 @@ class OmniRealtimeClient:
         """
         return bool(self._is_responding)
 
-    async def inject_text_and_request_response(self, text: str) -> None:
+    async def inject_text_and_request_response(
+        self,
+        text: str,
+        *,
+        on_rejected: Optional[Callable[[str], None]] = None,
+    ) -> None:
         """Inject a system-role text item and explicitly trigger a response.
 
         Used by the voice-mode proactive path (agent task callbacks /
@@ -1636,6 +1652,14 @@ class OmniRealtimeClient:
         (see ``is_active_response``) — the realtime API only allows one
         in-flight response at a time and will reject a second
         ``response.create`` with ``response_already_active``.
+
+        Server-side rejection (e.g. VAD races in between the caller's gate
+        check and our ``response.create``) does not raise here because the
+        server delivers it asynchronously via an ``error`` event. Pass
+        ``on_rejected=cb(error_msg)`` to receive that rejection — the
+        message loop will invoke it when ``error.event_id`` matches the
+        client-side id we stamp on ``response.create``. The caller can use
+        it to put the optimistically-pruned cb back in the queue.
 
         Provider dispatch:
           - **OpenAI / GLM / Step / free / GPT**: ``conversation.item.create``
@@ -1690,11 +1714,49 @@ class OmniRealtimeClient:
             raise RuntimeError(
                 "realtime connection lost after proactive conversation.item.create"
             )
-        await self.send_event({"type": "response.create"})
-        if self._fatal_error_occurred or self.ws is None:
-            raise RuntimeError(
-                "realtime connection lost after proactive response.create"
-            )
+        # Stamp a stable client event_id on response.create so the server's
+        # ``error.event_id`` can be matched back to this specific request if
+        # the realtime API rejects it (e.g. ``response_already_active`` from
+        # a VAD race winning between the caller's gate check and our send).
+        # ``send_event()`` would otherwise overwrite a missing event_id with
+        # its own timestamp-based string — fine for routing but useless for
+        # rejection matching since the caller has no view of it.
+        create_event_id: Optional[str] = None
+        if on_rejected is not None:
+            create_event_id = f"event_inject_{uuid.uuid4().hex}"
+            self._inject_rejection_handlers[create_event_id] = on_rejected
+            # The realtime API echoes our event_id on ``error`` but NOT on
+            # ``response.created`` — so a successful inject leaves the handler
+            # registered with no natural cleanup signal. TTL-expire it after
+            # 3s (well beyond any realistic server round-trip) to keep the
+            # dict from growing one entry per proactive cb over the session.
+            self._fire_task(self._expire_inject_rejection_handler(create_event_id, 3.0))
+        create_event: Dict[str, Any] = {"type": "response.create"}
+        if create_event_id is not None:
+            create_event["event_id"] = create_event_id
+        try:
+            await self.send_event(create_event)
+            if self._fatal_error_occurred or self.ws is None:
+                raise RuntimeError(
+                    "realtime connection lost after proactive response.create"
+                )
+        except Exception:
+            # Send itself blew up — drop the rejection handler so the caller's
+            # synchronous ``except`` path is the single source of truth and we
+            # don't double-fire (re-queue via except AND via a late error
+            # event that arrives after WS recovery).
+            if create_event_id is not None:
+                self._inject_rejection_handlers.pop(create_event_id, None)
+            raise
+
+    async def _expire_inject_rejection_handler(self, event_id: str, ttl: float) -> None:
+        """TTL-cleanup for the inject rejection handler dict (see
+        ``inject_text_and_request_response``)."""
+        try:
+            await asyncio.sleep(ttl)
+        except asyncio.CancelledError:
+            return
+        self._inject_rejection_handlers.pop(event_id, None)
 
     async def prompt_ephemeral(
         self,
@@ -2064,7 +2126,28 @@ class OmniRealtimeClient:
                 if event_type == "error":
                     error_msg = str(event.get('error', ''))
                     logger.error(f"API Error: {error_msg}")
-                    
+
+                    # If this error is the server rejecting a proactive
+                    # ``response.create`` we stamped with a tracked event_id
+                    # (e.g. ``response_already_active`` from a VAD race),
+                    # invoke the per-inject rejection handler so the caller
+                    # can re-enqueue the optimistically-pruned cb. ``error``
+                    # events normally echo the offending client event_id at
+                    # ``error.event_id``; fall back to the top-level
+                    # ``event_id`` for providers that put it there instead.
+                    err_obj = event.get('error') if isinstance(event.get('error'), dict) else {}
+                    err_event_id = err_obj.get('event_id') or event.get('event_id')
+                    if err_event_id:
+                        handler = self._inject_rejection_handlers.pop(err_event_id, None)
+                        if handler is not None:
+                            try:
+                                handler(error_msg)
+                            except Exception as cb_exc:
+                                logger.warning(
+                                    "proactive inject rejection handler raised: %s",
+                                    cb_exc,
+                                )
+
                     # 检测503过载错误，触发backpressure节流
                     if '503' in error_msg or 'overloaded' in error_msg.lower():
                         self._is_throttled = True

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1856,14 +1856,25 @@ class OmniRealtimeClient:
           1. **By id (precise)** — OpenAI Realtime (and any provider that
              echoes the offending client ``event_id``): pop and fire the exact
              handler.
-          2. **By content (fallback)** — providers that reject without a
-             client-correlated id: if the error looks like a response-conflict
+          2. **By content (fallback)** — ONLY when the provider omits a
+             client-correlation id entirely (``err_event_id`` falsy): if the
+             error looks like a response-conflict
              (``_looks_like_response_conflict``) and handlers are pending, fire
              them all. Injects are serialized by
              ``_voice_proactive_inject_lock`` so there's effectively one logical
              pending inject; ``_reject_once`` + the caller's delivery-id dedup
              make a spurious fire cost at most a bounded duplicate re-add, which
-             is strictly better than a silent drop (Codex P1)."""
+             is strictly better than a silent drop (Codex P1).
+
+        Critically, the content fallback is gated on ``err_event_id`` being
+        absent. If the error DOES carry a client event_id that simply isn't
+        ours, the rejection belongs to a different ``response.create`` (e.g.
+        ``create_response`` hot-swap priming / tool-result continuation /
+        ``signal_user_activity_end`` — all of which get a timestamp event_id
+        from ``send_event``'s setdefault), NOT our inject. Firing our handlers
+        on those would re-enqueue callbacks the model actually accepted →
+        duplicate announcements. So a present-but-non-matching id means "not
+        ours; do nothing"."""
         if not self._inject_rejection_handlers:
             return
 
@@ -1873,13 +1884,15 @@ class OmniRealtimeClient:
             except Exception as cb_exc:
                 logger.warning("proactive inject rejection handler raised: %s", cb_exc)
 
-        if err_event_id and err_event_id in self._inject_rejection_handlers:
+        if err_event_id:
+            # Id present: fire ONLY on an exact match. A non-matching id
+            # belongs to some other request's rejection — not ours.
             handler = self._inject_rejection_handlers.pop(err_event_id, None)
             if handler is not None:
                 _fire(handler)
             return
 
-        # No id correlation — fall back to content matching.
+        # No client-correlation id at all — fall back to content matching.
         if self._looks_like_response_conflict(error_msg):
             for handler in list(self._inject_rejection_handlers.values()):
                 _fire(handler)

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1760,11 +1760,17 @@ class OmniRealtimeClient:
             self._inject_rejection_handlers[create_event_id] = _reject_once
             # The realtime API echoes our event_id on ``error`` but NOT on
             # ``response.created`` — so a successful inject leaves the handlers
-            # registered with no natural cleanup signal. TTL-expire both after
-            # 3s (well beyond any realistic server round-trip) to keep the
-            # dict from growing per proactive cb over the session.
-            self._fire_task(self._expire_inject_rejection_handler(item_event_id, 3.0))
-            self._fire_task(self._expire_inject_rejection_handler(create_event_id, 3.0))
+            # registered with no natural cleanup signal. Primary cleanup is
+            # lifecycle-based: ``response.done`` sweeps the dict (see
+            # ``_sweep_inject_rejection_handlers`` — a rejection is always
+            # emitted before the blocking response completes, so any pending
+            # rejection has already fired by any response.done). This TTL is
+            # only a backstop for the pathological "no response.done ever"
+            # case (session hangs); 30s is generous vs the sub-second
+            # rejection latency, so a real ``response_already_active`` reject
+            # under transient backpressure is still caught (Codex P2).
+            self._fire_task(self._expire_inject_rejection_handler(item_event_id, 30.0))
+            self._fire_task(self._expire_inject_rejection_handler(create_event_id, 30.0))
 
         item_event: Dict[str, Any] = {
             "type": "conversation.item.create",
@@ -1813,13 +1819,33 @@ class OmniRealtimeClient:
             raise
 
     async def _expire_inject_rejection_handler(self, event_id: str, ttl: float) -> None:
-        """TTL-cleanup for the inject rejection handler dict (see
-        ``inject_text_and_request_response``)."""
+        """TTL backstop cleanup for the inject rejection handler dict (see
+        ``inject_text_and_request_response``). Primary cleanup is the
+        lifecycle sweep in ``_sweep_inject_rejection_handlers``; this only
+        catches the pathological "no response.done ever" case."""
         try:
             await asyncio.sleep(ttl)
         except asyncio.CancelledError:
             return
         self._inject_rejection_handlers.pop(event_id, None)
+
+    def _sweep_inject_rejection_handlers(self) -> None:
+        """Drop all pending inject rejection handlers on a response lifecycle
+        boundary (``response.done`` / Gemini turn-complete).
+
+        Safe because a server rejection of our ``response.create`` /
+        ``conversation.item.create`` is emitted the instant the server
+        receives a request it can't honor — and the only reason it can't
+        honor a ``response.create`` is that another response is already
+        active. That blocking response's ``response.done`` is therefore
+        strictly LATER than the rejection. So by the time ANY response.done
+        arrives, every pending rejection for a prior send has already fired
+        (and its handler self-removed via ``_reject_once``). Whatever remains
+        in the dict belongs to an inject that SUCCEEDED (no rejection coming)
+        — exactly the leak the fixed TTL was meant to clean, now reaped
+        promptly and lifecycle-tied instead of on a wall clock."""
+        if self._inject_rejection_handlers:
+            self._inject_rejection_handlers.clear()
 
     async def prompt_ephemeral(
         self,
@@ -2316,6 +2342,11 @@ class OmniRealtimeClient:
                 elif event_type == "response.done":
                     self._response_done_total += 1
                     self._last_response_done_time = time.time()
+                    # Lifecycle cleanup of proactive inject rejection handlers
+                    # (see _sweep_inject_rejection_handlers): any pending
+                    # rejection has already fired by now, so the remaining
+                    # entries belong to injects that succeeded — reap them.
+                    self._sweep_inject_rejection_handlers()
                     # 解析实时 API 返回的 token 用量
                     try:
                         resp_data = event.get("response", {})

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -1599,7 +1599,7 @@ class OmniRealtimeClient:
         try:
             # Gemini 使用 send_client_content 发送文本
             from google.genai import types as genai_types
-            
+
             content = genai_types.Content(
                 parts=[genai_types.Part(text=instructions)],
                 role="user"
@@ -1611,6 +1611,75 @@ class OmniRealtimeClient:
             logger.info("Gemini: sent client content, waiting for response")
         except Exception as e:
             logger.error(f"Error sending client content to Gemini: {e}")
+
+    def is_active_response(self) -> bool:
+        """Return True iff the realtime session is currently producing a response.
+
+        Tracks ``response.created`` → ``response.done`` (OpenAI / GLM / Step /
+        free / GPT) and Gemini's ``turn_complete`` lifecycle via the shared
+        ``_is_responding`` flag, so callers can gate "manual inject + request
+        response" against the realtime API's "one active response at a time"
+        constraint.
+        """
+        return bool(self._is_responding)
+
+    async def inject_text_and_request_response(self, text: str) -> None:
+        """Inject a system-role text item and explicitly trigger a response.
+
+        Used by the voice-mode proactive path (agent task callbacks /
+        plugin push_message ai_behavior="respond") to surface a rendered
+        instruction to the realtime model and have it speak the result
+        immediately — without waiting for the next user turn (which is what
+        the hot-swap pending_extra_replies channel does).
+
+        Caller is responsible for gating against active-response races
+        (see ``is_active_response``) — the realtime API only allows one
+        in-flight response at a time and will reject a second
+        ``response.create`` with ``response_already_active``.
+
+        Provider dispatch:
+          - **OpenAI / GLM / Step / free / GPT**: ``conversation.item.create``
+            (role=system, input_text) + ``response.create``.
+          - **Qwen**: does not accept ``conversation.item.create`` — raises
+            ``NotImplementedError`` so the caller can fall back to the
+            hot-swap path.
+          - **Gemini Live**: protocol does not model a "fire response now
+            without a user turn" primitive cleanly — raises
+            ``NotImplementedError`` so the caller can fall back.
+        """
+        if self._fatal_error_occurred:
+            raise RuntimeError("realtime session has fatal_error_occurred set")
+        if not text or not text.strip():
+            return
+
+        if self._is_gemini:
+            raise NotImplementedError(
+                "Gemini Live does not support proactive inject_text_and_request_response; "
+                "fall back to hot-swap"
+            )
+        if "qwen" in self._model_lower:
+            raise NotImplementedError(
+                "Qwen Realtime does not accept conversation.item.create; "
+                "fall back to hot-swap"
+            )
+        if self.ws is None:
+            raise RuntimeError("realtime websocket is not connected")
+
+        item_event = {
+            "type": "conversation.item.create",
+            "item": {
+                "type": "message",
+                "role": "system",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": text,
+                    }
+                ],
+            },
+        }
+        await self.send_event(item_event)
+        await self.send_event({"type": "response.create"})
 
     async def prompt_ephemeral(
         self,

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -462,6 +462,46 @@ async def test_sweep_inject_rejection_handlers_clears_dict():
     assert sess._inject_rejection_handlers == {}
 
 
+async def test_route_inject_rejection_id_match():
+    """精确路径：error 携带我们 stamp 的 client event_id → 命中并 fire 对应 handler。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    fired = []
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._inject_rejection_handlers = {"event_inject_resp_x": lambda msg: fired.append(msg)}
+    sess._route_inject_rejection("event_inject_resp_x", "response_already_active")
+    assert fired == ["response_already_active"]
+    assert sess._inject_rejection_handlers == {}  # popped
+
+
+async def test_route_inject_rejection_content_fallback_no_id():
+    """fallback 路径（Codex P1）：provider 拒绝 response.create 但 error 不带
+    client event_id。只要内容像 response-conflict 就 fire 所有 pending handler，
+    避免静默丢失。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    fired = []
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._inject_rejection_handlers = {"k1": lambda msg: fired.append(msg)}
+    # err_event_id 缺失 / 不匹配，但消息是 response-conflict
+    sess._route_inject_rejection(None, "Conversation already has an active response")
+    assert len(fired) == 1
+    assert sess._inject_rejection_handlers == {}
+
+
+async def test_route_inject_rejection_unrelated_error_does_not_fire():
+    """无 id 匹配 + 错误不像 response-conflict（如 503/quota）→ 不应 fire，
+    避免把无关错误误当成 inject 拒绝、错误回补造成重复投递。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    fired = []
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._inject_rejection_handlers = {"k1": lambda msg: fired.append(msg)}
+    sess._route_inject_rejection(None, "503 service overloaded, try again later")
+    assert fired == []
+    assert sess._inject_rejection_handlers == {"k1": sess._inject_rejection_handlers["k1"]}
+
+
 async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     """Voice 模式（inject 抛非 NotImplementedError）：cb 留在队列等重试。"""
     sess = _make_voice_sess()

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -84,8 +84,12 @@ def _make_mgr(session=None) -> LLMSessionManager:
 # trigger_agent_callbacks
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def test_voice_mode_idle_injects_and_drops_cbs():
-    """Voice 模式（idle）：调 inject_text_and_request_response 并清 pending，
+async def test_voice_mode_idle_injects_and_drops_paired_cbs_and_extras():
+    """Voice 模式（idle）：调 inject_text_and_request_response，并把 cb 从
+    pending_agent_callbacks **和** 配对的 pending_extra_replies 同步剔除——
+    后者必须清，否则 _finalize_turn_after_emit 看到 pending_extra_replies 非空
+    会触发 _trigger_immediate_preparation_for_extra 的无谓 hot-swap 准备，并在
+    下次 hot-swap 时 prime 出已经播过的内容造成重复投递。
     不 fire SM 任何事件（voice 走 realtime API 直接 inject，不进 SM 流水线）。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
@@ -102,7 +106,10 @@ async def test_voice_mode_idle_injects_and_drops_cbs():
 
     sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
-    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "task done"}]
+    cb = {"status": "completed", "summary": "task done"}
+    extra = {"origin": "task_result", "summary": "task done", "status": "completed"}
+    mgr.pending_agent_callbacks = [cb]
+    mgr.pending_extra_replies = [extra]
 
     events: list[SessionEvent] = []
     mgr.state.subscribe(None, lambda ev, p: events.append(ev))
@@ -110,10 +117,46 @@ async def test_voice_mode_idle_injects_and_drops_cbs():
     await LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
-    assert len(sess.injected) == 1  # 主动 inject 已调
+    assert len(sess.injected) == 1
     assert mgr.pending_agent_callbacks == []
+    # 关键回归：matching extras 同步剔除
+    assert mgr.pending_extra_replies == []
     assert mgr.state.phase is ProactivePhase.IDLE
-    assert events == []  # 未走 SM 任何事件
+    assert events == []
+
+
+async def test_voice_mode_inject_preserves_passive_cb_and_its_extra():
+    """Voice 模式：inject 只删 proactive cb 配对的 extras 项，
+    passive cb 及其 extras 必须原封不动留下 —— 它们要走 user-turn drain。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+            self.injected: list[str] = []
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str) -> None:
+            self.injected.append(text)
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    passive_cb = {"status": "completed", "summary": "passive note", "delivery_mode": "passive"}
+    proactive_cb = {"status": "completed", "summary": "ping user now"}
+    passive_extra = {"origin": "event", "summary": "passive note"}
+    proactive_extra = {"origin": "task_result", "summary": "ping user now"}
+    # enqueue_agent_callback appends both queues in lockstep — same order
+    mgr.pending_agent_callbacks = [passive_cb, proactive_cb]
+    mgr.pending_extra_replies = [passive_extra, proactive_extra]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    assert len(sess.injected) == 1
+    assert mgr.pending_agent_callbacks == [passive_cb]
+    assert mgr.pending_extra_replies == [passive_extra]
 
 
 async def test_voice_mode_busy_defers_cbs_for_retry():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -106,8 +106,8 @@ async def test_voice_mode_idle_injects_and_drops_paired_cbs_and_extras():
 
     sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
-    cb = {"status": "completed", "summary": "task done"}
-    extra = {"origin": "task_result", "summary": "task done", "status": "completed"}
+    cb = {"_callback_delivery_id": "id-task-done", "status": "completed", "summary": "task done"}
+    extra = {"_callback_delivery_id": "id-task-done", "origin": "task_result", "summary": "task done", "status": "completed"}
     mgr.pending_agent_callbacks = [cb]
     mgr.pending_extra_replies = [extra]
 
@@ -143,11 +143,23 @@ async def test_voice_mode_inject_preserves_passive_cb_and_its_extra():
 
     sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
-    passive_cb = {"status": "completed", "summary": "passive note", "delivery_mode": "passive"}
-    proactive_cb = {"status": "completed", "summary": "ping user now"}
-    passive_extra = {"origin": "event", "summary": "passive note"}
-    proactive_extra = {"origin": "task_result", "summary": "ping user now"}
-    # enqueue_agent_callback appends both queues in lockstep — same order
+    passive_cb = {
+        "_callback_delivery_id": "id-passive",
+        "status": "completed", "summary": "passive note", "delivery_mode": "passive",
+    }
+    proactive_cb = {
+        "_callback_delivery_id": "id-proactive",
+        "status": "completed", "summary": "ping user now",
+    }
+    passive_extra = {
+        "_callback_delivery_id": "id-passive",
+        "origin": "event", "summary": "passive note",
+    }
+    proactive_extra = {
+        "_callback_delivery_id": "id-proactive",
+        "origin": "task_result", "summary": "ping user now",
+    }
+    # enqueue_agent_callback stamps both queues with the same _callback_delivery_id
     mgr.pending_agent_callbacks = [passive_cb, proactive_cb]
     mgr.pending_extra_replies = [passive_extra, proactive_extra]
 
@@ -185,6 +197,45 @@ async def test_voice_mode_busy_defers_cbs_for_retry():
     assert sess.injected == []  # 没 inject
     assert mgr.pending_agent_callbacks == original  # cb 保留
     assert mgr.state.phase is ProactivePhase.IDLE
+
+
+async def test_voice_mode_drop_uses_id_match_not_length_alignment():
+    """Voice 模式：成功 inject 后按 ``_callback_delivery_id`` 精确剔除两队列里
+    匹配的项 —— 即使 ``drain_agent_callbacks_for_llm`` 先前清空了
+    pending_agent_callbacks 把两队列长度搞错位，extras 里 stale 项也必须被清。
+    锁死 CodeRabbit r3248967092：长度相等 != 队列对齐这条不变式。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+            self.injected: list[str] = []
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str) -> None:
+            self.injected.append(text)
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    # 模拟"队列错位"：旧的两条 cb 因为 user turn 走了 drain_agent_callbacks_for_llm
+    # 清空 pending_agent_callbacks，但 pending_extra_replies 仍然保留它们；
+    # 然后一条新的 proactive cb 进来 —— pac=1, extras=3。
+    stale_extra_a = {"_callback_delivery_id": "stale-A", "origin": "task_result", "summary": "old A"}
+    stale_extra_b = {"_callback_delivery_id": "stale-B", "origin": "task_result", "summary": "old B"}
+    new_cb = {"_callback_delivery_id": "new", "status": "completed", "summary": "fresh"}
+    new_extra = {"_callback_delivery_id": "new", "origin": "task_result", "summary": "fresh"}
+    mgr.pending_agent_callbacks = [new_cb]
+    mgr.pending_extra_replies = [stale_extra_a, stale_extra_b, new_extra]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    assert len(sess.injected) == 1
+    assert mgr.pending_agent_callbacks == []
+    # 关键：new_extra 必须被清，stale 的两条不归本次 inject 管，保留给 hot-swap
+    assert mgr.pending_extra_replies == [stale_extra_a, stale_extra_b]
 
 
 async def test_voice_mode_not_implemented_falls_back_to_hot_swap():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -74,9 +74,12 @@ def _make_mgr(session=None) -> LLMSessionManager:
 
     def _fake_fire(coro):
         mgr._fired_tasks.append(coro)
+        # Close the coroutine so it doesn't run / warn "never awaited". Only
+        # the cleanup-related errors are expected here; anything else should
+        # surface rather than be silently swallowed.
         try:
             coro.close()
-        except Exception:
+        except (RuntimeError, AttributeError):
             pass
     mgr._fire_task = _fake_fire
     mgr.current_speech_id = None
@@ -379,7 +382,9 @@ async def test_voice_mode_concurrent_triggers_inject_once():
     for _ in range(5):
         await asyncio.sleep(0)
     release.set()
-    await asyncio.gather(t1, t2)
+    # 本地超时：若 _voice_proactive_inject_lock 以后回归成死等，这里快速失败
+    # 而不是挂到 CI 全局超时。
+    await asyncio.wait_for(asyncio.gather(t1, t2), timeout=5)
 
     # 关键：只 inject 一次，没有重复播报
     assert sess.inject_calls == 1

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -316,16 +316,17 @@ async def test_voice_mode_reject_during_await_not_pruned():
 
     class _VoiceSess(OmniRealtimeClient):
         def __init__(self):
-            self._is_responding = True  # 模拟 VAD 抢跑：拒绝时已有 active response
+            self._is_responding = False  # gate 时 idle，让 inject 启动
             self.inject_calls = 0
 
         def is_active_response(self) -> bool:
-            # gate 检查时返回 False（让 inject 启动），inject 内再翻 True 模拟竞态
-            return False
+            return self._is_responding
 
         async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             self.inject_calls += 1
-            # 模拟 server error 事件在 await 期间到达（prune 之前）
+            # 模拟 VAD 抢跑：reject 到达时 server 已经有 active response（busy），
+            # 且发生在 await 期间（prune 之前）。
+            self._is_responding = True
             if on_rejected is not None:
                 on_rejected("response_already_active")
             # inject 本身正常返回（拒绝是异步事件，不是异常）
@@ -346,6 +347,9 @@ async def test_voice_mode_reject_during_await_not_pruned():
     assert mgr.pending_agent_callbacks[0]["_callback_delivery_id"] == "id-toctou"
     assert len(mgr.pending_extra_replies) == 1
     assert mgr.pending_extra_replies[0]["_callback_delivery_id"] == "id-toctou"
+    # busy（is_active_response True）时 handler 不应立即 re-fire —— 留给
+    # response.done 后的 _finalize_turn_after_emit 重试，避免 response_already_active 死循环。
+    assert mgr._fired_tasks == []
 
 
 async def test_voice_mode_concurrent_triggers_inject_once():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -286,8 +286,10 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
 
 
 async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
-    """Voice 模式（Gemini/Qwen 抛 NotImplementedError）：drop proactive cb，
-    走现有 hot-swap 路径（pending_extra_replies 保留供下一 hot-swap 注入）。"""
+    """Voice 模式（Gemini Live 抛 NotImplementedError）：drop proactive cb，
+    走现有 hot-swap 路径（pending_extra_replies 保留供下一 hot-swap 注入）。
+    注：Qwen 经实测支持 conversation.item.create 文本注入，已不再走此 fallback；
+    Gemini Live 用独立 SDK（send_client_content）仍走这里。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     class _VoiceSess(OmniRealtimeClient):

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -489,6 +489,24 @@ async def test_route_inject_rejection_content_fallback_no_id():
     assert sess._inject_rejection_handlers == {}
 
 
+async def test_route_inject_rejection_nonmatching_id_does_not_fire_fallback():
+    """Codex P1：error 带了 client event_id 但不匹配我们任何 pending handler
+    → 说明这是别的 response.create（create_response / tool-result 续传 /
+    signal_user_activity_end，都被 send_event setdefault 打了时间戳 id）的拒绝，
+    不是我们的 inject。即使消息文本像 response_already_active 也**不能** fire，
+    否则会把模型其实已接受的 cb 误回补造成重复播报。content fallback 只在完全
+    没有 client id 时才走。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    fired = []
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._inject_rejection_handlers = {"event_inject_resp_ours": lambda msg: fired.append(msg)}
+    # 别的请求的 event_id + response-conflict 文本
+    sess._route_inject_rejection("event_create_response_other", "response_already_active")
+    assert fired == []
+    assert "event_inject_resp_ours" in sess._inject_rejection_handlers  # 未动
+
+
 async def test_route_inject_rejection_unrelated_error_does_not_fire():
     """无 id 匹配 + 错误不像 response-conflict（如 503/quota）→ 不应 fire，
     避免把无关错误误当成 inject 拒绝、错误回补造成重复投递。"""

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -67,6 +67,18 @@ def _make_mgr(session=None) -> LLMSessionManager:
     mgr.websocket = None
     mgr.lock = asyncio.Lock()
     mgr._proactive_write_lock = asyncio.Lock()
+    mgr._voice_proactive_inject_lock = asyncio.Lock()
+    # Record _fire_task calls (e.g. the rejection-path re-trigger) and close
+    # the coroutine so it doesn't run recursively / warn "never awaited".
+    mgr._fired_tasks = []
+
+    def _fake_fire(coro):
+        mgr._fired_tasks.append(coro)
+        try:
+            coro.close()
+        except Exception:
+            pass
+    mgr._fire_task = _fake_fire
     mgr.current_speech_id = None
     mgr._tts_done_queued_for_turn = False
     mgr.pending_agent_callbacks = []
@@ -283,6 +295,54 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
     # cb 被 on_rejected 回到 pending_agent_callbacks，等下次 trigger 重投
     assert len(mgr.pending_agent_callbacks) == 1
     assert mgr.pending_agent_callbacks[0]["_callback_delivery_id"] == "id-race"
+    # 配对的 extras 也必须被回补（否则后续 hot-swap fallback 会丢补报内容）
+    assert len(mgr.pending_extra_replies) == 1
+    assert mgr.pending_extra_replies[0]["_callback_delivery_id"] == "id-race"
+    # reject 可能晚于 response.done 到达，handler 在 idle 时应主动 re-fire 一次
+    # trigger（否则 cb 会挂到下次无关 turn）。session idle → 应已调度。
+    assert len(mgr._fired_tasks) == 1
+
+
+async def test_voice_mode_concurrent_triggers_inject_once():
+    """并发回归（Codex P1）：两个 trigger_agent_callbacks task 同时进 voice
+    分支，_voice_proactive_inject_lock 必须把 check-and-claim 串起来——只有
+    一个真正 inject，另一个拿到锁后重新过滤发现队列已空、不再重复 inject。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    release = asyncio.Event()
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+            self.inject_calls = 0
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
+            self.inject_calls += 1
+            # 卡住第一个 inject，给第二个 task 机会抢同一 snapshot
+            await release.wait()
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    cb = {"_callback_delivery_id": "id-concurrent", "status": "completed", "summary": "once"}
+    extra = {"_callback_delivery_id": "id-concurrent", "origin": "task_result", "summary": "once"}
+    mgr.pending_agent_callbacks = [cb]
+    mgr.pending_extra_replies = [extra]
+
+    t1 = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
+    t2 = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
+    # 让两个 task 都跑起来：t1 拿锁卡在 inject，t2 阻塞在锁上
+    for _ in range(5):
+        await asyncio.sleep(0)
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    # 关键：只 inject 一次，没有重复播报
+    assert sess.inject_calls == 1
+    assert mgr.pending_agent_callbacks == []
+    assert mgr.pending_extra_replies == []
 
 
 async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
@@ -307,13 +367,15 @@ async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
     sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "hot-swap fallback"}]
-    mgr.pending_extra_replies = [{"summary": "hot-swap fallback"}]
+    original_extras = [{"summary": "hot-swap fallback"}]
+    mgr.pending_extra_replies = list(original_extras)
 
     await LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
     assert mgr.pending_agent_callbacks == []  # proactive cb dropped
-    assert mgr.pending_extra_replies  # hot-swap channel preserved
+    # 精确相等而非 truthy：锁死 fallback 不会误改/重复 pending_extra_replies
+    assert mgr.pending_extra_replies == original_extras  # hot-swap channel preserved
 
 
 async def test_inject_gemini_routes_through_send_client_content():
@@ -371,11 +433,13 @@ async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     class _VoiceSess(OmniRealtimeClient):
         def __init__(self):
             self._is_responding = False
+            self.inject_calls = 0
 
         def is_active_response(self) -> bool:
             return False
 
         async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
+            self.inject_calls += 1
             raise RuntimeError("ws boom")
 
     sess = _VoiceSess()
@@ -386,6 +450,8 @@ async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     await LLMSessionManager.trigger_agent_callbacks(mgr)
     await asyncio.sleep(0)
 
+    # inject 确实被调用过一次（证明走的是 inject-异常分支，而非更早的 guard 早退）
+    assert sess.inject_calls == 1
     assert mgr.pending_agent_callbacks == original
 
 

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -83,6 +83,8 @@ def _make_mgr(session=None) -> LLMSessionManager:
         try:
             coro.close()
         except (RuntimeError, AttributeError):
+            # Coroutine already closed/started or not a coroutine — there is
+            # nothing to clean up; intentionally ignored in this test shim.
             pass
     mgr._fire_task = _fake_fire
     mgr.current_speech_id = None

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -485,6 +485,24 @@ async def test_inject_gemini_missing_session_raises():
         await OmniRealtimeClient.inject_text_and_request_response(sess, "x")
 
 
+async def test_sweep_inject_rejection_handlers_clears_dict():
+    """``response.done`` lifecycle sweep 清空 inject rejection handler 字典
+    （取代固定 3s TTL 作为主清理）。锁死 Codex P2：late reject 不该因 TTL 过期
+    丢失——主清理改成 response.done 触发的 sweep，TTL 只是 hang 兜底。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._inject_rejection_handlers = {
+        "event_inject_item_x": lambda msg: None,
+        "event_inject_resp_x": lambda msg: None,
+    }
+    sess._sweep_inject_rejection_handlers()
+    assert sess._inject_rejection_handlers == {}
+    # 空字典再 sweep 不报错（idempotent）
+    sess._sweep_inject_rejection_handlers()
+    assert sess._inject_rejection_handlers == {}
+
+
 async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     """Voice 模式（inject 抛非 NotImplementedError）：cb 留在队列等重试。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -476,31 +476,50 @@ async def test_route_inject_rejection_id_match():
 
 async def test_route_inject_rejection_content_fallback_no_id():
     """fallback 路径（Codex P1）：provider 拒绝 response.create 但 error 不带
-    client event_id。只要内容像 response-conflict 就 fire 所有 pending handler，
-    避免静默丢失。"""
+    client event_id。proactive inject 正等待 outcome（flag True）且内容像
+    response-conflict 时 fire 所有 pending handler，避免静默丢失。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     fired = []
     sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
     sess._inject_rejection_handlers = {"k1": lambda msg: fired.append(msg)}
-    # err_event_id 缺失 / 不匹配，但消息是 response-conflict
+    sess._proactive_inject_awaiting_outcome = True  # inject 刚发出，正等 outcome
+    # err_event_id 缺失，但消息是 response-conflict
     sess._route_inject_rejection(None, "Conversation already has an active response")
     assert len(fired) == 1
     assert sess._inject_rejection_handlers == {}
+    assert sess._proactive_inject_awaiting_outcome is False  # 窗口已消费
+
+
+async def test_route_inject_rejection_no_id_but_not_awaiting_does_not_fire():
+    """CodeRabbit Major：无 id 的 response-conflict，但当前没有 proactive inject
+    在等 outcome（flag False，例如 handler 是上一次成功 inject 的残留，或这条
+    冲突来自 create_response / tool-result / signal_user_activity_end 等别的
+    response.create 发送方）→ 绝不能 fire，否则把已接受的 cb 误回补造成重复。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    fired = []
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._inject_rejection_handlers = {"k1": lambda msg: fired.append(msg)}
+    sess._proactive_inject_awaiting_outcome = False  # 没有 inject 在等
+    sess._route_inject_rejection(None, "response_already_active")
+    assert fired == []
+    assert "k1" in sess._inject_rejection_handlers  # 未动
 
 
 async def test_route_inject_rejection_nonmatching_id_does_not_fire_fallback():
     """Codex P1：error 带了 client event_id 但不匹配我们任何 pending handler
     → 说明这是别的 response.create（create_response / tool-result 续传 /
     signal_user_activity_end，都被 send_event setdefault 打了时间戳 id）的拒绝，
-    不是我们的 inject。即使消息文本像 response_already_active 也**不能** fire，
-    否则会把模型其实已接受的 cb 误回补造成重复播报。content fallback 只在完全
-    没有 client id 时才走。"""
+    不是我们的 inject。即使消息文本像 response_already_active、即使有 inject 在
+    等 outcome，也**不能** fire（id present 只精确匹配），否则把模型其实已接受的
+    cb 误回补造成重复播报。content fallback 只在完全没有 client id 时才走。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     fired = []
     sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
     sess._inject_rejection_handlers = {"event_inject_resp_ours": lambda msg: fired.append(msg)}
+    sess._proactive_inject_awaiting_outcome = True  # 即便在等，也不能被别人的 id 触发
     # 别的请求的 event_id + response-conflict 文本
     sess._route_inject_rejection("event_create_response_other", "response_already_active")
     assert fired == []
@@ -515,6 +534,7 @@ async def test_route_inject_rejection_unrelated_error_does_not_fire():
     fired = []
     sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
     sess._inject_rejection_handlers = {"k1": lambda msg: fired.append(msg)}
+    sess._proactive_inject_awaiting_outcome = True
     sess._route_inject_rejection(None, "503 service overloaded, try again later")
     assert fired == []
     assert sess._inject_rejection_handlers == {"k1": sess._inject_rejection_handlers["k1"]}

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -2,7 +2,10 @@
 ``SessionStateMachine`` 之后的关键行为契约。
 
 覆盖点：
-1. Voice 模式走 hot-swap，**不**触碰 SM（不 fire PROACTIVE_START，清 callbacks）
+1. Voice 模式主路径是 realtime inject（conversation.item.create + response.create），
+   **不**进 SM proactive 流水线（不 fire PROACTIVE_START）；只有 provider 抛
+   NotImplementedError 才回退 hot-swap。serialize / reject 回补 / TOCTOU 等竞态见
+   下面 voice_mode_* 用例。
 2. Text 模式在 SM 被另一路 proactive 占用时拒绝投递，callbacks 保留重试
 3. Text 模式在 ``session._is_responding == True`` 时 SM 拒绝，callbacks 保留
 4. 正常 text 投递：IDLE → PHASE1（claim）→ CLAIM → PHASE2 → DONE 事件序列
@@ -361,6 +364,7 @@ async def test_voice_mode_concurrent_triggers_inject_once():
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     release = asyncio.Event()
+    entered_inject = asyncio.Event()
 
     class _VoiceSess(OmniRealtimeClient):
         def __init__(self):
@@ -372,7 +376,9 @@ async def test_voice_mode_concurrent_triggers_inject_once():
 
         async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             self.inject_calls += 1
-            # 卡住第一个 inject，给第二个 task 机会抢同一 snapshot
+            # 标记第一个 inject 真正进入临界区（持锁中），再卡住，给第二个 task
+            # 确定性地去抢锁——不靠固定 tick 数赌时序。
+            entered_inject.set()
             await release.wait()
 
     sess = _VoiceSess()
@@ -384,9 +390,10 @@ async def test_voice_mode_concurrent_triggers_inject_once():
 
     t1 = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
     t2 = asyncio.create_task(LLMSessionManager.trigger_agent_callbacks(mgr))
-    # 让两个 task 都跑起来：t1 拿锁卡在 inject，t2 阻塞在锁上
-    for _ in range(5):
-        await asyncio.sleep(0)
+    # 等第一个 inject 真的进入持锁段，再给第二个 task 一个调度点去阻塞在锁上，
+    # 然后才放行——确保「两个 task 竞争同一 snapshot」这个场景真的发生。
+    await asyncio.wait_for(entered_inject.wait(), timeout=5)
+    await asyncio.sleep(0)
     release.set()
     # 本地超时：若 _voice_proactive_inject_lock 以后回归成死等，这里快速失败
     # 而不是挂到 CI 全局超时。

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -286,10 +286,12 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
 
 
 async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
-    """Voice 模式（Gemini Live 抛 NotImplementedError）：drop proactive cb，
-    走现有 hot-swap 路径（pending_extra_replies 保留供下一 hot-swap 注入）。
-    注：Qwen 经实测支持 conversation.item.create 文本注入，已不再走此 fallback；
-    Gemini Live 用独立 SDK（send_client_content）仍走这里。"""
+    """Voice 模式 defensive fallback：若某 provider 抛 NotImplementedError，
+    drop proactive cb，走现有 hot-swap 路径（pending_extra_replies 保留供下一
+    hot-swap 注入）。注：现役 provider 全部支持 manual inject（含 Qwen 走
+    conversation.item.create、Gemini 走 send_client_content），此分支实际已
+    unreachable，仅为未来 provider 兜底——用一个显式抛 NotImplementedError 的
+    假 session 验证兜底逻辑仍正确。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     class _VoiceSess(OmniRealtimeClient):
@@ -312,6 +314,54 @@ async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
 
     assert mgr.pending_agent_callbacks == []  # proactive cb dropped
     assert mgr.pending_extra_replies  # hot-swap channel preserved
+
+
+async def test_inject_gemini_routes_through_send_client_content():
+    """对偶性回归：inject_text_and_request_response 对 Gemini 也支持（走
+    send_client_content(turn_complete=True)），与 create_response →
+    _create_response_gemini 对称，不再抛 NotImplementedError。直接调真实
+    OmniRealtimeClient.inject_text_and_request_response（绕过 SM），验证它
+    把文本作为 user turn 注入并 turn_complete=True 触发响应。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    sent = {}
+
+    class _FakeGeminiSession:
+        async def send_client_content(self, *, turns, turn_complete):
+            sent["turns"] = turns
+            sent["turn_complete"] = turn_complete
+
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._fatal_error_occurred = False
+    sess._is_gemini = True
+    sess._gemini_session = _FakeGeminiSession()
+
+    # google.genai types 在测试环境不一定可用 —— 若缺则跳过（CI 装了 SDK 会跑）
+    try:
+        import google.genai  # noqa: F401
+    except Exception:
+        import pytest
+        pytest.skip("google-genai SDK not installed in this env")
+
+    await OmniRealtimeClient.inject_text_and_request_response(sess, "（系统通知）任务完成了。")
+
+    assert sent.get("turn_complete") is True
+    assert sent.get("turns") is not None
+
+
+async def test_inject_gemini_missing_session_raises():
+    """Gemini session 不可用时 inject 必须 raise（让 caller 保留 cb），
+    不能静默成功。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._fatal_error_occurred = False
+    sess._is_gemini = True
+    sess._gemini_session = None
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        await OmniRealtimeClient.inject_text_and_request_response(sess, "x")
 
 
 async def test_voice_mode_inject_exception_keeps_cbs_for_retry():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -337,6 +337,40 @@ async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     assert mgr.pending_agent_callbacks == original
 
 
+async def test_voice_mode_unstamped_cb_still_pruned_via_object_id_fallback():
+    """Defense in depth：production 路径都过 ``enqueue_agent_callback`` 标
+    ``_callback_delivery_id``，但 voice 成功 inject 的 pac 清理还有一条
+    object ``id()`` 兜底，确保任何未来直接 append 没标 id 的 cb 也不会被
+    后续 retry 重复投递。锁死 Codex r3249183511。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+            self.injected: list[str] = []
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
+            self.injected.append(text)
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    # 故意构造没有 _callback_delivery_id 的 cb（模拟绕过 enqueue_agent_callback 的入口）
+    unstamped_cb = {"status": "completed", "summary": "unstamped"}
+    mgr.pending_agent_callbacks = [unstamped_cb]
+    # 这里 extras 用空，因为没走 enqueue → 没配对 entries 是合理状态
+    mgr.pending_extra_replies = []
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    assert len(sess.injected) == 1
+    # 关键：unstamped cb 也被通过 id() 兜底剔除，下次 retry 不会重投
+    assert mgr.pending_agent_callbacks == []
+
+
 async def test_send_event_preserves_caller_stamped_event_id():
     """``send_event`` 必须保留 caller 显式标的 ``event_id``，不能拿时间戳覆盖。
     这是 ``inject_text_and_request_response`` 的 ``on_rejected`` 路径能工作的

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -101,7 +101,7 @@ async def test_voice_mode_idle_injects_and_drops_paired_cbs_and_extras():
         def is_active_response(self) -> bool:
             return self._is_responding
 
-        async def inject_text_and_request_response(self, text: str) -> None:
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             self.injected.append(text)
 
     sess = _VoiceSess()
@@ -138,7 +138,7 @@ async def test_voice_mode_inject_preserves_passive_cb_and_its_extra():
         def is_active_response(self) -> bool:
             return False
 
-        async def inject_text_and_request_response(self, text: str) -> None:
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             self.injected.append(text)
 
     sess = _VoiceSess()
@@ -183,7 +183,7 @@ async def test_voice_mode_busy_defers_cbs_for_retry():
         def is_active_response(self) -> bool:
             return self._is_responding
 
-        async def inject_text_and_request_response(self, text: str) -> None:
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             self.injected.append(text)
 
     sess = _VoiceSess()
@@ -214,7 +214,7 @@ async def test_voice_mode_drop_uses_id_match_not_length_alignment():
         def is_active_response(self) -> bool:
             return False
 
-        async def inject_text_and_request_response(self, text: str) -> None:
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             self.injected.append(text)
 
     sess = _VoiceSess()
@@ -238,6 +238,53 @@ async def test_voice_mode_drop_uses_id_match_not_length_alignment():
     assert mgr.pending_extra_replies == [stale_extra_a, stale_extra_b]
 
 
+async def test_voice_mode_server_rejection_re_enqueues_cb():
+    """Voice 模式：``response.create`` 被 server 拒（``response_already_active``
+    等 VAD 抢跑场景）通过 error 事件异步回来，``inject_text_and_request_response``
+    本身已经 return 了。我们注册的 ``on_rejected`` 回调必须把那条已乐观剔除
+    的 cb 重新塞回 ``pending_agent_callbacks``，让 ``_finalize_turn_after_emit``
+    在下一次 response.done 后的 retry 把它捡起来。锁死 Codex r3249012424。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    captured_rejection: list = []
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+            self.injected: list[str] = []
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
+            self.injected.append(text)
+            # 不在这里 fire；测试模拟 inject 已返回，但 cb 尚未在 server 端被处理
+            captured_rejection.append(on_rejected)
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    cb = {"_callback_delivery_id": "id-race", "status": "completed", "summary": "race-cb"}
+    extra = {"_callback_delivery_id": "id-race", "origin": "task_result", "summary": "race-cb"}
+    mgr.pending_agent_callbacks = [cb]
+    mgr.pending_extra_replies = [extra]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    # 乐观剔除：两条队列都空
+    assert mgr.pending_agent_callbacks == []
+    assert mgr.pending_extra_replies == []
+    assert len(captured_rejection) == 1
+    assert captured_rejection[0] is not None
+
+    # 模拟 server 异步抛回 response_already_active
+    captured_rejection[0]("response_already_active")
+
+    # cb 被 on_rejected 回到 pending_agent_callbacks，等下次 trigger 重投
+    assert len(mgr.pending_agent_callbacks) == 1
+    assert mgr.pending_agent_callbacks[0]["_callback_delivery_id"] == "id-race"
+
+
 async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
     """Voice 模式（Gemini/Qwen 抛 NotImplementedError）：drop proactive cb，
     走现有 hot-swap 路径（pending_extra_replies 保留供下一 hot-swap 注入）。"""
@@ -250,7 +297,7 @@ async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
         def is_active_response(self) -> bool:
             return False
 
-        async def inject_text_and_request_response(self, text: str) -> None:
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             raise NotImplementedError("test provider: no manual inject")
 
     sess = _VoiceSess()
@@ -276,7 +323,7 @@ async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
         def is_active_response(self) -> bool:
             return False
 
-        async def inject_text_and_request_response(self, text: str) -> None:
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
             raise RuntimeError("ws boom")
 
     sess = _VoiceSess()

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -301,9 +301,11 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
     # 配对的 extras 也必须被回补（否则后续 hot-swap fallback 会丢补报内容）
     assert len(mgr.pending_extra_replies) == 1
     assert mgr.pending_extra_replies[0]["_callback_delivery_id"] == "id-race"
-    # reject 可能晚于 response.done 到达，handler 在 idle 时应主动 re-fire 一次
-    # trigger（否则 cb 会挂到下次无关 turn）。session idle → 应已调度。
-    assert len(mgr._fired_tasks) == 1
+    # handler 不立即 re-fire trigger（Codex P1）：response_already_active 时
+    # is_active_response() 可能读到 stale False，立即 re-fire 会 re-inject→
+    # re-reject 死循环。retry 交给那个 active response 的 response.done →
+    # _finalize_turn_after_emit。所以这里不应有立即调度。
+    assert mgr._fired_tasks == []
 
 
 async def test_voice_mode_reject_during_await_not_pruned():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -303,6 +303,48 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
     assert len(mgr._fired_tasks) == 1
 
 
+async def test_voice_mode_reject_during_await_not_pruned():
+    """TOCTOU 回归（Codex P1）：error 事件可能在 inject 仍 await 期间由
+    handle_messages 派发 on_rejected——此时 cb 还在队列里（乐观 prune 还没跑）。
+    旧逻辑 handler 按"已存在"跳过 re-add，随后 success 路径又按 delivered_ids
+    把它 prune 掉 → 静默丢失。修法：handler 置 _rejected 标志，await 返回后
+    若 rejected 则跳过 prune，cb 留在队列等重试。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = True  # 模拟 VAD 抢跑：拒绝时已有 active response
+            self.inject_calls = 0
+
+        def is_active_response(self) -> bool:
+            # gate 检查时返回 False（让 inject 启动），inject 内再翻 True 模拟竞态
+            return False
+
+        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
+            self.inject_calls += 1
+            # 模拟 server error 事件在 await 期间到达（prune 之前）
+            if on_rejected is not None:
+                on_rejected("response_already_active")
+            # inject 本身正常返回（拒绝是异步事件，不是异常）
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    cb = {"_callback_delivery_id": "id-toctou", "status": "completed", "summary": "keep me"}
+    extra = {"_callback_delivery_id": "id-toctou", "origin": "task_result", "summary": "keep me"}
+    mgr.pending_agent_callbacks = [cb]
+    mgr.pending_extra_replies = [extra]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    # 关键：cb 没被 prune 掉，两队列都还在，等下次 retry
+    assert sess.inject_calls == 1
+    assert len(mgr.pending_agent_callbacks) == 1
+    assert mgr.pending_agent_callbacks[0]["_callback_delivery_id"] == "id-toctou"
+    assert len(mgr.pending_extra_replies) == 1
+    assert mgr.pending_extra_replies[0]["_callback_delivery_id"] == "id-toctou"
+
+
 async def test_voice_mode_concurrent_triggers_inject_once():
     """并发回归（Codex P1）：两个 trigger_agent_callbacks task 同时进 voice
     分支，_voice_proactive_inject_lock 必须把 check-and-claim 串起来——只有

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -398,12 +398,11 @@ async def test_inject_gemini_routes_through_send_client_content():
     sess._is_gemini = True
     sess._gemini_session = _FakeGeminiSession()
 
-    # google.genai types 在测试环境不一定可用 —— 若缺则跳过（CI 装了 SDK 会跑）
-    try:
-        import google.genai  # noqa: F401
-    except Exception:
-        import pytest
-        pytest.skip("google-genai SDK not installed in this env")
+    # google.genai 在测试环境不一定装了 —— 缺则跳过（CI 装了 SDK 会跑）。
+    # 用 importorskip 而非 try/except Exception：只在 ImportError 时 skip，
+    # SDK 真实运行时错误仍会冒出来，不会被误吞成 skip 掩盖回归。
+    import pytest
+    pytest.importorskip("google.genai")
 
     await OmniRealtimeClient.inject_text_and_request_response(sess, "（系统通知）任务完成了。")
 

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -84,27 +84,116 @@ def _make_mgr(session=None) -> LLMSessionManager:
 # trigger_agent_callbacks
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def test_voice_mode_does_not_touch_sm():
-    """Voice 模式：清 pending，不 fire SM 任何事件。"""
+async def test_voice_mode_idle_injects_and_drops_cbs():
+    """Voice 模式（idle）：调 inject_text_and_request_response 并清 pending，
+    不 fire SM 任何事件（voice 走 realtime API 直接 inject，不进 SM 流水线）。"""
     from main_logic.omni_realtime_client import OmniRealtimeClient
 
     class _VoiceSess(OmniRealtimeClient):
         def __init__(self):
-            pass  # 跳过父类初始化
+            self._is_responding = False
+            self.injected: list[str] = []
 
-    mgr = _make_mgr(session=_VoiceSess())
+        def is_active_response(self) -> bool:
+            return self._is_responding
+
+        async def inject_text_and_request_response(self, text: str) -> None:
+            self.injected.append(text)
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "task done"}]
 
     events: list[SessionEvent] = []
     mgr.state.subscribe(None, lambda ev, p: events.append(ev))
 
     await LLMSessionManager.trigger_agent_callbacks(mgr)
-    # 异步订阅派发 —— 让 event loop 转一圈
     await asyncio.sleep(0)
 
+    assert len(sess.injected) == 1  # 主动 inject 已调
     assert mgr.pending_agent_callbacks == []
     assert mgr.state.phase is ProactivePhase.IDLE
     assert events == []  # 未走 SM 任何事件
+
+
+async def test_voice_mode_busy_defers_cbs_for_retry():
+    """Voice 模式（session 正在回复）：cb 留在队列等下次 response.done 后重试。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = True
+            self.injected: list[str] = []
+
+        def is_active_response(self) -> bool:
+            return self._is_responding
+
+        async def inject_text_and_request_response(self, text: str) -> None:
+            self.injected.append(text)
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    original = [{"status": "completed", "summary": "deferred"}]
+    mgr.pending_agent_callbacks = list(original)
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    assert sess.injected == []  # 没 inject
+    assert mgr.pending_agent_callbacks == original  # cb 保留
+    assert mgr.state.phase is ProactivePhase.IDLE
+
+
+async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
+    """Voice 模式（Gemini/Qwen 抛 NotImplementedError）：drop proactive cb，
+    走现有 hot-swap 路径（pending_extra_replies 保留供下一 hot-swap 注入）。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str) -> None:
+            raise NotImplementedError("test provider: no manual inject")
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    mgr.pending_agent_callbacks = [{"status": "completed", "summary": "hot-swap fallback"}]
+    mgr.pending_extra_replies = [{"summary": "hot-swap fallback"}]
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    assert mgr.pending_agent_callbacks == []  # proactive cb dropped
+    assert mgr.pending_extra_replies  # hot-swap channel preserved
+
+
+async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
+    """Voice 模式（inject 抛非 NotImplementedError）：cb 留在队列等重试。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _VoiceSess(OmniRealtimeClient):
+        def __init__(self):
+            self._is_responding = False
+
+        def is_active_response(self) -> bool:
+            return False
+
+        async def inject_text_and_request_response(self, text: str) -> None:
+            raise RuntimeError("ws boom")
+
+    sess = _VoiceSess()
+    mgr = _make_mgr(session=sess)
+    original = [{"status": "completed", "summary": "retry on ws err"}]
+    mgr.pending_agent_callbacks = list(original)
+
+    await LLMSessionManager.trigger_agent_callbacks(mgr)
+    await asyncio.sleep(0)
+
+    assert mgr.pending_agent_callbacks == original
 
 
 async def test_text_mode_sm_denied_when_phase_active():

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -100,6 +100,46 @@ def _make_mgr(session=None) -> LLMSessionManager:
     return mgr
 
 
+def _make_voice_sess(*, is_responding=False, inject=None):
+    """Build an ``OmniRealtimeClient`` test double via ``__new__`` (NOT a
+    subclass).
+
+    The code under test branches on ``isinstance(session, OmniRealtimeClient)``,
+    so the fake must be a real instance — but the heavy ``__init__`` (real
+    base_url / api_key / model / WebSocket plumbing) is irrelevant to these SM
+    contract tests. ``__new__`` yields an instance without running ``__init__``;
+    and because there's no ``__init__``-overriding subclass, CodeQL's
+    "missing super().__init__" check has nothing to flag.
+
+    Behaviour is attached as instance attributes (invoked WITHOUT ``self`` —
+    instance-attribute callables aren't bound methods — which matches how the
+    production code calls ``voice_sess.is_active_response()`` /
+    ``voice_sess.inject_text_and_request_response(text, on_rejected=...)``):
+      - ``is_active_response()`` → current ``_is_responding``.
+      - ``inject_text_and_request_response`` → ``inject`` if given, else a
+        default that bumps ``inject_calls`` and records ``injected``.
+    Tests needing bespoke inject behaviour can reassign
+    ``sess.inject_text_and_request_response`` after construction (the closure
+    can capture ``sess``).
+    """
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._is_responding = is_responding
+    sess.injected = []
+    sess.inject_calls = 0
+    sess.is_active_response = lambda: sess._is_responding
+
+    if inject is None:
+        async def _default_inject(text, *, on_rejected=None):
+            sess.inject_calls += 1
+            sess.injected.append(text)
+        sess.inject_text_and_request_response = _default_inject
+    else:
+        sess.inject_text_and_request_response = inject
+    return sess
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # trigger_agent_callbacks
 # ─────────────────────────────────────────────────────────────────────────────
@@ -111,20 +151,7 @@ async def test_voice_mode_idle_injects_and_drops_paired_cbs_and_extras():
     会触发 _trigger_immediate_preparation_for_extra 的无谓 hot-swap 准备，并在
     下次 hot-swap 时 prime 出已经播过的内容造成重复投递。
     不 fire SM 任何事件（voice 走 realtime API 直接 inject，不进 SM 流水线）。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.injected: list[str] = []
-
-        def is_active_response(self) -> bool:
-            return self._is_responding
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.injected.append(text)
-
-    sess = _VoiceSess()
+    sess = _make_voice_sess()
     mgr = _make_mgr(session=sess)
     cb = {"_callback_delivery_id": "id-task-done", "status": "completed", "summary": "task done"}
     extra = {"_callback_delivery_id": "id-task-done", "origin": "task_result", "summary": "task done", "status": "completed"}
@@ -148,20 +175,7 @@ async def test_voice_mode_idle_injects_and_drops_paired_cbs_and_extras():
 async def test_voice_mode_inject_preserves_passive_cb_and_its_extra():
     """Voice 模式：inject 只删 proactive cb 配对的 extras 项，
     passive cb 及其 extras 必须原封不动留下 —— 它们要走 user-turn drain。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.injected: list[str] = []
-
-        def is_active_response(self) -> bool:
-            return False
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.injected.append(text)
-
-    sess = _VoiceSess()
+    sess = _make_voice_sess()
     mgr = _make_mgr(session=sess)
     passive_cb = {
         "_callback_delivery_id": "id-passive",
@@ -193,20 +207,7 @@ async def test_voice_mode_inject_preserves_passive_cb_and_its_extra():
 
 async def test_voice_mode_busy_defers_cbs_for_retry():
     """Voice 模式（session 正在回复）：cb 留在队列等下次 response.done 后重试。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = True
-            self.injected: list[str] = []
-
-        def is_active_response(self) -> bool:
-            return self._is_responding
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.injected.append(text)
-
-    sess = _VoiceSess()
+    sess = _make_voice_sess(is_responding=True)
     mgr = _make_mgr(session=sess)
     original = [{"status": "completed", "summary": "deferred"}]
     mgr.pending_agent_callbacks = list(original)
@@ -224,20 +225,7 @@ async def test_voice_mode_drop_uses_id_match_not_length_alignment():
     匹配的项 —— 即使 ``drain_agent_callbacks_for_llm`` 先前清空了
     pending_agent_callbacks 把两队列长度搞错位，extras 里 stale 项也必须被清。
     锁死 CodeRabbit r3248967092：长度相等 != 队列对齐这条不变式。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.injected: list[str] = []
-
-        def is_active_response(self) -> bool:
-            return False
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.injected.append(text)
-
-    sess = _VoiceSess()
+    sess = _make_voice_sess()
     mgr = _make_mgr(session=sess)
     # 模拟"队列错位"：旧的两条 cb 因为 user turn 走了 drain_agent_callbacks_for_llm
     # 清空 pending_agent_callbacks，但 pending_extra_replies 仍然保留它们；
@@ -264,24 +252,17 @@ async def test_voice_mode_server_rejection_re_enqueues_cb():
     本身已经 return 了。我们注册的 ``on_rejected`` 回调必须把那条已乐观剔除
     的 cb 重新塞回 ``pending_agent_callbacks``，让 ``_finalize_turn_after_emit``
     在下一次 response.done 后的 retry 把它捡起来。锁死 Codex r3249012424。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
     captured_rejection: list = []
 
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.injected: list[str] = []
+    sess = _make_voice_sess()
 
-        def is_active_response(self) -> bool:
-            return False
+    async def _inject(text, *, on_rejected=None):
+        sess.inject_calls += 1
+        sess.injected.append(text)
+        # 不在这里 fire；测试模拟 inject 已返回，但 cb 尚未在 server 端被处理
+        captured_rejection.append(on_rejected)
+    sess.inject_text_and_request_response = _inject
 
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.injected.append(text)
-            # 不在这里 fire；测试模拟 inject 已返回，但 cb 尚未在 server 端被处理
-            captured_rejection.append(on_rejected)
-
-    sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
     cb = {"_callback_delivery_id": "id-race", "status": "completed", "summary": "race-cb"}
     extra = {"_callback_delivery_id": "id-race", "origin": "task_result", "summary": "race-cb"}
@@ -319,26 +300,18 @@ async def test_voice_mode_reject_during_await_not_pruned():
     旧逻辑 handler 按"已存在"跳过 re-add，随后 success 路径又按 delivered_ids
     把它 prune 掉 → 静默丢失。修法：handler 置 _rejected 标志，await 返回后
     若 rejected 则跳过 prune，cb 留在队列等重试。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
+    sess = _make_voice_sess()  # is_active_response()→_is_responding，init False
 
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False  # gate 时 idle，让 inject 启动
-            self.inject_calls = 0
+    async def _inject(text, *, on_rejected=None):
+        sess.inject_calls += 1
+        # 模拟 VAD 抢跑：reject 到达时 server 已经有 active response（busy），
+        # 且发生在 await 期间（prune 之前）。
+        sess._is_responding = True
+        if on_rejected is not None:
+            on_rejected("response_already_active")
+        # inject 本身正常返回（拒绝是异步事件，不是异常）
+    sess.inject_text_and_request_response = _inject
 
-        def is_active_response(self) -> bool:
-            return self._is_responding
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.inject_calls += 1
-            # 模拟 VAD 抢跑：reject 到达时 server 已经有 active response（busy），
-            # 且发生在 await 期间（prune 之前）。
-            self._is_responding = True
-            if on_rejected is not None:
-                on_rejected("response_already_active")
-            # inject 本身正常返回（拒绝是异步事件，不是异常）
-
-    sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
     cb = {"_callback_delivery_id": "id-toctou", "status": "completed", "summary": "keep me"}
     extra = {"_callback_delivery_id": "id-toctou", "origin": "task_result", "summary": "keep me"}
@@ -363,27 +336,18 @@ async def test_voice_mode_concurrent_triggers_inject_once():
     """并发回归（Codex P1）：两个 trigger_agent_callbacks task 同时进 voice
     分支，_voice_proactive_inject_lock 必须把 check-and-claim 串起来——只有
     一个真正 inject，另一个拿到锁后重新过滤发现队列已空、不再重复 inject。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
     release = asyncio.Event()
     entered_inject = asyncio.Event()
 
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.inject_calls = 0
+    sess = _make_voice_sess()
 
-        def is_active_response(self) -> bool:
-            return False
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.inject_calls += 1
-            # 标记第一个 inject 真正进入临界区（持锁中），再卡住，给第二个 task
-            # 确定性地去抢锁——不靠固定 tick 数赌时序。
-            entered_inject.set()
-            await release.wait()
-
-    sess = _VoiceSess()
+    async def _inject(text, *, on_rejected=None):
+        sess.inject_calls += 1
+        # 标记第一个 inject 真正进入临界区（持锁中），再卡住，给第二个 task
+        # 确定性地去抢锁——不靠固定 tick 数赌时序。
+        entered_inject.set()
+        await release.wait()
+    sess.inject_text_and_request_response = _inject
     mgr = _make_mgr(session=sess)
     cb = {"_callback_delivery_id": "id-concurrent", "status": "completed", "summary": "once"}
     extra = {"_callback_delivery_id": "id-concurrent", "origin": "task_result", "summary": "once"}
@@ -414,19 +378,12 @@ async def test_voice_mode_not_implemented_falls_back_to_hot_swap():
     conversation.item.create、Gemini 走 send_client_content），此分支实际已
     unreachable，仅为未来 provider 兜底——用一个显式抛 NotImplementedError 的
     假 session 验证兜底逻辑仍正确。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
+    sess = _make_voice_sess()
 
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
+    async def _inject(text, *, on_rejected=None):
+        raise NotImplementedError("test provider: no manual inject")
+    sess.inject_text_and_request_response = _inject
 
-        def is_active_response(self) -> bool:
-            return False
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            raise NotImplementedError("test provider: no manual inject")
-
-    sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
     mgr.pending_agent_callbacks = [{"status": "completed", "summary": "hot-swap fallback"}]
     original_extras = [{"summary": "hot-swap fallback"}]
@@ -507,21 +464,13 @@ async def test_sweep_inject_rejection_handlers_clears_dict():
 
 async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     """Voice 模式（inject 抛非 NotImplementedError）：cb 留在队列等重试。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
+    sess = _make_voice_sess()
 
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.inject_calls = 0
+    async def _inject(text, *, on_rejected=None):
+        sess.inject_calls += 1
+        raise RuntimeError("ws boom")
+    sess.inject_text_and_request_response = _inject
 
-        def is_active_response(self) -> bool:
-            return False
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.inject_calls += 1
-            raise RuntimeError("ws boom")
-
-    sess = _VoiceSess()
     mgr = _make_mgr(session=sess)
     original = [{"status": "completed", "summary": "retry on ws err"}]
     mgr.pending_agent_callbacks = list(original)
@@ -539,20 +488,7 @@ async def test_voice_mode_unstamped_cb_still_pruned_via_object_id_fallback():
     ``_callback_delivery_id``，但 voice 成功 inject 的 pac 清理还有一条
     object ``id()`` 兜底，确保任何未来直接 append 没标 id 的 cb 也不会被
     后续 retry 重复投递。锁死 Codex r3249183511。"""
-    from main_logic.omni_realtime_client import OmniRealtimeClient
-
-    class _VoiceSess(OmniRealtimeClient):
-        def __init__(self):
-            self._is_responding = False
-            self.injected: list[str] = []
-
-        def is_active_response(self) -> bool:
-            return False
-
-        async def inject_text_and_request_response(self, text: str, *, on_rejected=None) -> None:
-            self.injected.append(text)
-
-    sess = _VoiceSess()
+    sess = _make_voice_sess()
     mgr = _make_mgr(session=sess)
     # 故意构造没有 _callback_delivery_id 的 cb（模拟绕过 enqueue_agent_callback 的入口）
     unstamped_cb = {"status": "completed", "summary": "unstamped"}

--- a/tests/unit/test_proactive_sm_integration.py
+++ b/tests/unit/test_proactive_sm_integration.py
@@ -337,6 +337,42 @@ async def test_voice_mode_inject_exception_keeps_cbs_for_retry():
     assert mgr.pending_agent_callbacks == original
 
 
+async def test_send_event_preserves_caller_stamped_event_id():
+    """``send_event`` 必须保留 caller 显式标的 ``event_id``，不能拿时间戳覆盖。
+    这是 ``inject_text_and_request_response`` 的 ``on_rejected`` 路径能工作的
+    前提：server ``error.event_id`` 必须能 echo 回 caller 注册的 id 才会命中
+    ``_inject_rejection_handlers``。锁死 Codex r3249069126。"""
+    from main_logic.omni_realtime_client import OmniRealtimeClient
+
+    class _CapturingWS:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, payload: str) -> None:
+            self.sent.append(payload)
+
+    sess = OmniRealtimeClient.__new__(OmniRealtimeClient)
+    sess._fatal_error_occurred = False
+    sess._is_throttled = False
+    sess._throttle_until = 0.0
+    sess._is_gemini = False
+    sess._send_semaphore = asyncio.Semaphore(25)
+    sess.on_connection_error = None
+    sess._bg_tasks = set()
+    ws = _CapturingWS()
+    sess.ws = ws
+
+    explicit_id = "event_inject_test_preserve_me"
+    await OmniRealtimeClient.send_event(
+        sess, {"type": "response.create", "event_id": explicit_id}
+    )
+
+    assert len(ws.sent) == 1
+    import json as _json
+    payload = _json.loads(ws.sent[0])
+    assert payload["event_id"] == explicit_id
+
+
 async def test_text_mode_sm_denied_when_phase_active():
     """另一路 proactive 已占 phase1 时，text 投递不应清 callbacks。"""
     sess = _FakeOmniOffline()


### PR DESCRIPTION
## Root cause

`main_logic/core.py::trigger_agent_callbacks` 的 voice 分支对 `OmniRealtimeClient` session 直接把 proactive callback 从 `pending_agent_callbacks` 删掉，等价丢弃。注释说"voice 模式走 hot-swap"，但 hot-swap 用的 `pending_extra_replies` 只在 user 下次开口前的 `prime_context()` drain —— plugin 推的 `ai_behavior=respond` callback（任务完成 cue / keep-going nudge / alert）在 voice 模式下永远不会主动触发 LLM reply，只能等用户开口才被动捎带，主动性消失。

text 模式（`OmniOfflineClient`）走 `prompt_ephemeral()` 主动激活 LLM，正常工作。

## Fix

给 voice 模式加等价的"主动注入 + 触发 LLM 回应"路径，用 OpenAI Realtime API 协议：`conversation.item.create`（role=`system`）+ `response.create`。

**`main_logic/omni_realtime_client.py`**
- 新增 `is_active_response()`：暴露 `_is_responding` flag 供外部 gate。
- 新增 `async inject_text_and_request_response(text)`：
  - OpenAI / GLM / Step / free / GPT：发 `conversation.item.create`(role=system, input_text) + `response.create`。
  - Gemini Live / Qwen：raise `NotImplementedError` 让 caller 走 hot-swap fallback。
  - WS 已断 / fatal：raise `RuntimeError`。

**`main_logic/core.py::trigger_agent_callbacks` voice 分支**

1. **Gate**：`state.phase != ProactivePhase.IDLE` 或 `session.is_active_response()` → cb 留队列等 retry（realtime API 同一时刻只允许一个 active response，gate 必须卡住避免 `response_already_active`）。
2. 渲染 + 调 `inject_text_and_request_response`：
   - `NotImplementedError` → drop proactive cb（hot-swap 路径仍由 `pending_extra_replies` 兜底）。
   - 其他 Exception → 保留 cb 等下轮重试。
   - 成功 → 用 `id()` 精确剔除本次 deliver 的 cb 实例（不会误删并发 enqueue 的新 cb），不动 passive cb / `pending_extra_replies`。

**重试**：现有 `_finalize_turn_after_emit`（core.py:1462-1463）在每次 `response.done` 后自动重 fire `trigger_agent_callbacks`，gate 拦下的 cb 会在 active response 结束后立刻被重新尝试。

## Before / After

**Before**：voice 模式 plugin 推 `ai_behavior=respond` callback → 进 voice 分支 → 从 `pending_agent_callbacks` 删掉但不投递 → 用户永远收不到 AI 主动 reply，必须先开口。

**After**：相同 callback → gate 检查 idle / no active response → `conversation.item.create`(role=system) + `response.create` 发到 realtime session → LLM 立刻用本角色嗓音主动 reply。busy 场景下 cb 保留队列，由 response.done 后的 `_finalize_turn_after_emit` 重试。

## Tests

`tests/unit/test_proactive_sm_integration.py` 旧 `test_voice_mode_does_not_touch_sm` 编码 silent-drop 旧契约，替换为 4 个新用例：

- `test_voice_mode_idle_injects_and_drops_cbs`：idle 时正确调 inject + 清队列。
- `test_voice_mode_busy_defers_cbs_for_retry`：`_is_responding=True` 时 cb 保留。
- `test_voice_mode_not_implemented_falls_back_to_hot_swap`：Gemini/Qwen 走 hot-swap fallback。
- `test_voice_mode_inject_exception_keeps_cbs_for_retry`：WS 错误 cb 保留重试。

`tests/unit/test_proactive_sm_integration.py` → 13/13 pass。
`tests/unit/` 全跑 → 231 passed, 1 pre-existing failure（`test_core_only_has_realtime_providers`，main 上同样 fail，`grok` provider 加进 core 但测试没同步更新，与本 PR 无关）。

## Test plan

- [ ] 启 N.E.K.O，前端切语音模式。
- [ ] 触发 game_agent_minecraft 任务完成 5s 后的 keep-going nudge（plugin 推 `ai_behavior=respond`）。
- [ ] 验证 user 没开口的情况下 AI 主动用本角色嗓音回应 callback 内容。
- [ ] 触发 user 正在说话期间的 callback push → 验证 gate 工作，cb 不被吞，等 user 这一轮 response.done 后 LLM 接着主动回应。
- [ ] Gemini / Qwen line：验证不报错且走老 hot-swap fallback（next user turn 携带）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 语音注入串行化并引入稳定 delivery id；新增注入拒绝回调路由与过期清理；SDK 注入路径支持通过发送用户回合完成注入，保留调用方自定义 event_id。

* **Bug Fixes**
  * 改进注入与拒绝场景的去重与匹配，按拒绝/异常类型决定保留或重试队列；增强生命周期清理以避免残留处理器；并发下防止重复注入。

* **Tests**
  * 扩展语音注入回归测试，覆盖 idle/mixed/busy、并发、拒绝、降级与 event_id 行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->