### PR TITLE
修复 PC 独立 React Chat 最小化成小球后，在“请她离开/请她回来”切换时被旧的窗口高度同步逻辑误触发 setBounds，导…

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -818,6 +818,16 @@
             if (att) return MIN_H_ATTACHMENTS;
             return MIN_H_BASE;
         }
+        function isReactElectronCollapsed() {
+            var shell = document.getElementById('react-chat-window-shell');
+            return !!(shell && (
+                shell.classList.contains('neko-e-collapsed') ||
+                shell.classList.contains('neko-e-animating') ||
+                shell.classList.contains('is-minimized') ||
+                shell.classList.contains('is-collapsing') ||
+                shell.classList.contains('is-expanding')
+            ));
+        }
         Object.defineProperty(window, '__nekoChatMinH', {
             get: currentMinH,
             configurable: true
@@ -826,11 +836,13 @@
         // GalGame 模式开/关、或附件 0↔N 切换时，若当前窗口高度小于新最小值，
         // 主动 setBounds 撑高，否则切到 ON / 贴上附件后会看到内容被窗口裁掉。
         function syncWindowToMinH() {
-            if (collapsed || resizing || animating) return;
+            if (collapsed || resizing || animating || isReactElectronCollapsed()) return;
             var minH = currentMinH();
             try {
                 W.getBounds().then(function(b) {
                     if (!b) return;
+                    if (isReactElectronCollapsed()) return;
+                    if (b.width <= BALL + 4 && b.height <= BALL + 4) return;
                     if (b.height >= minH) return;
                     W.setBounds(b.x, b.y, b.width, minH);
                 });


### PR DESCRIPTION
…致小球窗口被撑高、视觉位置下移的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了聊天窗口在折叠、展开和动画状态下的高度调整逻辑，防止在窗口状态转换期间出现不期望的尺寸变化。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1366)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->