### PR TITLE
fix(voice): no-server-VAD provider 多轮 TTS 静音 + Minecraft plugin 迭代

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -3291,7 +3291,61 @@ async def startup():
                         except Exception as parse_err:
                             logger.debug(f"[Agent] plugin_list_provider parse error: {parse_err}")
                             data = {}
-                        return data.get("plugins", []) or []
+                        raw = data.get("plugins", []) or []
+                        # ISOLATION BOUNDARY: only expose RUNNING plugins to the
+                        # analyzer / plugin LLM. Without this filter, every plugin
+                        # the host knows about (including disabled, stopped,
+                        # load-failed, source-missing, and extension plugins in
+                        # 'pending' state) flows into the LLM's candidate set.
+                        # The LLM then wastes tokens evaluating capabilities the
+                        # user explicitly didn't enable, and worse — picks a
+                        # plugin that has no live process to receive the dispatch,
+                        # surfacing fake "available capability" to the user. See
+                        # _resolve_plugin_status() in
+                        # plugin/server/application/plugins/query_service.py for
+                        # the full status taxonomy; "running" is the only state
+                        # where the plugin's process is alive and responsive.
+                        running = [
+                            p for p in raw
+                            if isinstance(p, dict) and p.get("status") == "running"
+                        ]
+                        if len(running) != len(raw):
+                            dropped = [
+                                (p.get("id"), p.get("status"))
+                                for p in raw
+                                if isinstance(p, dict) and p.get("status") != "running"
+                            ]
+                            logger.debug(
+                                "[Agent] plugin_list_provider filtered out %d non-running plugins: %s",
+                                len(dropped), dropped,
+                            )
+                        # AUDIENCE BOUNDARY: ``@llm_tool``-registered methods
+                        # also surface as plugin entries with id prefix
+                        # ``__llm_tool__<name>`` (see plugin SDK collect_entries).
+                        # Those tools are *also* exposed to the dialog LLM via
+                        # ``LLMSessionManager.tool_registry`` — letting the
+                        # analyzer/plugin LLM dispatch them too means the same
+                        # tool can be triggered by both LLMs, with the
+                        # analyzer path's ~10s decision latency racing against
+                        # the dialog LLM's direct call. The dialog LLM is the
+                        # canonical caller for ``@llm_tool`` (it gets the
+                        # tool's full schema, can pass typed args, and runs
+                        # synchronously); the analyzer should only see
+                        # ``@plugin_entry`` registered entries (queries /
+                        # status / config). Strip ``__llm_tool__`` entries
+                        # from the analyzer's view here.
+                        for p in running:
+                            entries = p.get("entries")
+                            if isinstance(entries, list):
+                                p["entries"] = [
+                                    e for e in entries
+                                    if not (
+                                        isinstance(e, dict)
+                                        and isinstance(e.get("id"), str)
+                                        and e["id"].startswith("__llm_tool__")
+                                    )
+                                ]
+                        return running
             except Exception as e:
                 logger.debug(f"[Agent] plugin_list_provider http fetch failed: {e}")
             return []

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -86,7 +86,8 @@ from utils.storage_location_bootstrap import get_storage_startup_blocking_reason
 from utils.logger_config import setup_logging # noqa: E402
 from utils.ssl_env_diagnostics import probe_ssl_environment, write_ssl_diagnostic # noqa: E402
 
-logger, log_config = setup_logging(service_name="Main", log_level=logging.INFO, silent=not _IS_MAIN_PROCESS)
+_main_log_level = getattr(logging, (os.environ.get("NEKO_LOG_LEVEL") or "INFO").upper(), logging.INFO)
+logger, log_config = setup_logging(service_name="Main", log_level=_main_log_level, silent=not _IS_MAIN_PROCESS)
 
 if _IS_MAIN_PROCESS:
     _ssl_precheck = probe_ssl_environment()

--- a/brain/task_executor.py
+++ b/brain/task_executor.py
@@ -27,7 +27,12 @@ from config import (
     AGENT_PLUGIN_FULL_MAX_TOKENS,
     TASK_DETAIL_MAX_TOKENS,
 )
-from utils.llm_client import create_chat_llm, ChatOpenAI
+from utils.llm_client import (
+    create_chat_llm,
+    ChatOpenAI,
+    set_active_character,
+    reset_active_character,
+)
 from config.prompts.prompts_agent import (
     UNIFIED_CHANNEL_SYSTEM_PROMPT,
     CHANNEL_DESC_QWENPAW,
@@ -235,6 +240,32 @@ class DirectTaskExecutor:
     def _normalize_correction_tool_name(self, value: Any) -> str:
         tool = str(value or "").strip().lower()
         return self._correction_tool_canonical.get(tool, "")
+
+    async def _set_character_context_token(self, lanlan_name: Optional[str]):
+        """Fetch master_name from the config manager and bind the active
+        character ``(master_name, lanlan_name)`` to the current async
+        context. The wrapped LLM clients (``utils.llm_client.ChatOpenAI``)
+        substitute ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders that
+        come in via plugin-supplied prompt fragments before the wire send.
+
+        Returns a token; pass to ``reset_active_character`` in a ``finally``
+        block. Best-effort on failure — if config_manager can't yield a
+        master_name, the token still binds with an empty master so partial
+        substitution (lanlan only) still works and the leak check WARNING
+        is at most a no-op.
+        """
+        master_name = ""
+        try:
+            cd = await self._config_manager.aget_character_data()
+            # aget_character_data returns a tuple; element 0 is master_name
+            if cd and len(cd) > 0 and isinstance(cd[0], str):
+                master_name = cd[0]
+        except Exception as exc:
+            logger.debug(
+                "[Agent] character-context fetch failed; placeholder substitution will be partial: %s: %s",
+                type(exc).__name__, exc,
+            )
+        return set_active_character(master_name, lanlan_name or "")
 
     def set_plugin_list_provider(self, provider: Callable[[bool], Awaitable[List[Dict[str, Any]]]]):
         """Allow agent_server to inject a custom async provider for plugin discovery."""
@@ -1547,6 +1578,32 @@ class DirectTaskExecutor:
         Plugin 单独判定；qwenpaw/openfang/browser/computer 合并为一次 LLM 调用。
         实际执行由 agent_server 统一 dispatch。
         """
+        # Bind active character for {MASTER_NAME}/{LANLAN_NAME} substitution
+        # in any LLM call made under this analyze_and_execute (assess_user_plugin
+        # / assess_unified_channels / classify_magic_intent / shortdesc gen,
+        # all on the inherited async context). Without this the brain LLM
+        # gets literal placeholders from plugin prompt fragments and the
+        # leak check fires a WARNING.
+        char_token = await self._set_character_context_token(lanlan_name)
+        try:
+            return await self._analyze_and_execute_inner(
+                messages=messages,
+                lanlan_name=lanlan_name,
+                agent_flags=agent_flags,
+                conversation_id=conversation_id,
+                lang=lang,
+            )
+        finally:
+            reset_active_character(char_token)
+
+    async def _analyze_and_execute_inner(
+        self,
+        messages: List[Dict[str, str]],
+        lanlan_name: Optional[str] = None,
+        agent_flags: Optional[Dict[str, bool]] = None,
+        conversation_id: Optional[str] = None,
+        lang: str = "en",
+    ) -> Optional[TaskResult]:
         task_id = str(uuid.uuid4())
 
         if agent_flags is None:
@@ -2227,19 +2284,28 @@ class DirectTaskExecutor:
         """
         Directly execute a plugin entry by calling /runs with explicit plugin_id and optional entry_id.
         This is intended for agent_server to call when it wants to trigger a plugin_entry immediately.
+
+        Same character-context binding as analyze_and_execute, since
+        ``_execute_user_plugin`` may dispatch to a plugin entry whose
+        callback chain ends with brain LLM calls (e.g. result digestion);
+        without this, those calls would leak {MASTER_NAME} placeholders.
         """
-        return await self._execute_user_plugin(
-            task_id=task_id,
-            plugin_id=plugin_id,
-            plugin_args=plugin_args,
-            entry_id=entry_id,
-            task_description=f"Direct plugin call {plugin_id}",
-            reason="direct_call",
-            lanlan_name=lanlan_name,
-            conversation_id=conversation_id,
-            latest_user_request=latest_user_request,
-            on_progress=on_progress,
-        )
+        char_token = await self._set_character_context_token(lanlan_name)
+        try:
+            return await self._execute_user_plugin(
+                task_id=task_id,
+                plugin_id=plugin_id,
+                plugin_args=plugin_args,
+                entry_id=entry_id,
+                task_description=f"Direct plugin call {plugin_id}",
+                reason="direct_call",
+                lanlan_name=lanlan_name,
+                conversation_id=conversation_id,
+                latest_user_request=latest_user_request,
+                on_progress=on_progress,
+            )
+        finally:
+            reset_active_character(char_token)
     
     async def refresh_capabilities(self) -> Dict[str, Dict[str, Any]]:
         """保留接口兼容性，MCP 已移除，始终返回空。"""

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1259,6 +1259,14 @@ class LLMSessionManager:
         if self._takeover_active:
             return
         self.audio_resampler.clear()
+        # 必须重置这两个 flag，否则下一轮 ``_request_tts_done_locked`` 会因
+        # ``_tts_done_queued_for_turn=True`` 直接 early-return，下一轮的 TTS
+        # flush sentinel 永远不入队，server 拿不到 ``tts.flush`` 句尾音频
+        # 可能挂在 buffer 里、长句 utterance 不会 finalize。``handle_new_message``
+        # 在 speech_stopped 路径也是这样 reset 的（[core.py:1214](main_logic/core.py:1214)），
+        # 这里和它对偶。
+        self._tts_done_queued_for_turn = False
+        self._tts_done_pending_until_ready = False
         async with self.lock:
             self.current_speech_id = str(uuid4())
 

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -141,15 +141,34 @@ def _format_callback_source(cb: dict, lang: str) -> str:
     return _loc(descriptor, lang).format(name=name)
 
 
-def _render_callback_inner_item(cb: dict, lang: str) -> str:
+def _render_callback_inner_item(
+    cb: dict,
+    lang: str,
+    *,
+    lanlan_name: str = "",
+    master_name: str = "",
+) -> str:
     """Render one callback as a single inline string for the LLM prompt.
 
     Returns ``""`` when there is genuinely nothing to convey (both summary
     and detail empty); the caller can then drop the line and rely on the
     outer header alone to express that something happened.
+
+    ``{MASTER_NAME}`` and ``{LANLAN_NAME}`` placeholders in plugin-supplied
+    ``summary``/``detail`` are substituted here so plugin authors can write
+    role-aware text without having to learn the live character names. The
+    substitution uses ``str.replace`` rather than ``str.format`` so that
+    other braces in the text (e.g. JSON fragments in detail) don't trigger
+    a KeyError.
     """
     summary = (cb.get("summary") or "").strip()
     detail = (cb.get("detail") or "").strip()
+    if master_name:
+        summary = summary.replace("{MASTER_NAME}", master_name)
+        detail = detail.replace("{MASTER_NAME}", master_name)
+    if lanlan_name:
+        summary = summary.replace("{LANLAN_NAME}", lanlan_name)
+        detail = detail.replace("{LANLAN_NAME}", lanlan_name)
     text = summary or detail
     if not text:
         return ""
@@ -261,7 +280,12 @@ def _build_callback_instruction(
                     name=lanlan_name,
                     master=master_name,
                 )
-        items = [_render_callback_inner_item(cb, lang) for cb in cbs]
+        items = [
+            _render_callback_inner_item(
+                cb, lang, lanlan_name=lanlan_name, master_name=master_name,
+            )
+            for cb in cbs
+        ]
         items = [s for s in items if s]
         if items:
             parts.append(header + "\n".join(items))
@@ -1208,6 +1232,35 @@ class LLMSessionManager:
             # owner/user_sid 并派发订阅者。
             self.state.mark_user_input_preempt()
         await self.state.fire(SessionEvent.USER_INPUT, sid=new_sid)
+
+    async def rotate_speech_id_for_response_done(self):
+        """Lightweight sid rotation for realtime providers without server VAD.
+
+        Triggered at OmniRealtimeClient's response.done event (Gemini's
+        turn_complete透传) when ``_has_server_vad=False`` (lanlan.app+free /
+        livestream). Without server VAD, ``speech_stopped`` never fires, so
+        the canonical ``handle_new_message`` rotation path stays dormant and
+        every turn ends up reusing the initial session sid — TTS upstream
+        silently drops text after the first ``tts.response.done`` closes
+        that sid, and turn 2+ goes silent.
+
+        Why not reuse ``handle_new_message``: that helper rotates sid AND
+        clears the TTS pipeline AND fires USER_INPUT. Both side effects are
+        correct at ``speech_stopped`` (user just spoke, AI hasn't started,
+        leftover TTS belongs to an interrupted prior turn). At
+        ``response.done`` they're wrong — leftover TTS is the trailing audio
+        of the AI turn that just ended; clearing it would clip the last
+        few syllables. ``USER_INPUT`` mischaracterizes the trigger (no user
+        input actually happened — this is end-of-AI-turn, not start-of-user).
+        Resetting ``audio_resampler`` is safe because the next turn's audio
+        is a fresh stream — keeping stale soxr state would only risk a
+        boundary artefact at turn 2's first frame.
+        """
+        if self._takeover_active:
+            return
+        self.audio_resampler.clear()
+        async with self.lock:
+            self.current_speech_id = str(uuid4())
 
     async def handle_text_data(self, text: str, is_first_chunk: bool = False):
         """文本回调：处理文本显示和TTS（用于文本模式）"""
@@ -3065,8 +3118,14 @@ class LLMSessionManager:
         if (
             self._is_free_preset_voice
             and self.core_api_type == 'free'
-            and 'lanlan.tech' in realtime_config.get('base_url', '')
+            and ('lanlan.tech' in realtime_config.get('base_url', '') or self._is_livestream_active())
         ):
+            # livestream 启用后 base_url 被重写成主播自建 server_prefix
+            # （非 lanlan.tech 域），导致原 lanlan.tech 字面量判定失效，会 fallback
+            # 到外部 TTS 流水线。但 livestream 上游同样是 free 路 Gemini 系，
+            # 原生音色（voice_id 由 livestream_config 覆盖成 neon 等）直接走
+            # session config 即可，不需要再开外部 TTS。把 livestream-active
+            # 视为与 lanlan.tech 对偶的免费原生音色路径。
             logger.info(f"{log_prefix}🆓 免费预设音色 '{self.voice_id}' 将直接传入 session config，不启动外部 TTS")
             return False
         if self.voice_id or has_custom_tts_config:
@@ -3694,6 +3753,7 @@ class LLMSessionManager:
                         on_text_delta=self.handle_text_data,
                         on_audio_delta=self.handle_audio_data,
                         on_new_message=self.handle_new_message,
+                        on_sid_rotate=self.rotate_speech_id_for_response_done,
                         on_input_transcript=self.handle_input_transcript,
                         on_output_transcript=self.handle_output_transcript,
                         on_connection_error=self.handle_connection_error,
@@ -4146,6 +4206,7 @@ class LLMSessionManager:
                     on_text_delta=self.handle_text_data,
                     on_audio_delta=self.handle_audio_data,
                     on_new_message=self.handle_new_message,
+                    on_sid_rotate=self.rotate_speech_id_for_response_done,
                     on_input_transcript=self.handle_input_transcript,
                     on_output_transcript=self.handle_output_transcript,
                     on_connection_error=self.handle_connection_error,

--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -202,6 +202,7 @@ class OmniRealtimeClient:
         on_text_delta: Optional[Callable[[str, bool], Awaitable[None]]] = None,
         on_audio_delta: Optional[Callable[[bytes], Awaitable[None]]] = None,
         on_new_message: Optional[Callable[[], Awaitable[None]]] = None,
+        on_sid_rotate: Optional[Callable[[], Awaitable[None]]] = None,
         on_input_transcript: Optional[Callable[[str], Awaitable[None]]] = None,
         on_output_transcript: Optional[Callable[[str, bool], Awaitable[None]]] = None,
         on_connection_error: Optional[Callable[[str], Awaitable[None]]] = None,
@@ -225,6 +226,7 @@ class OmniRealtimeClient:
         self.on_text_delta = on_text_delta
         self.on_audio_delta = on_audio_delta
         self.on_new_message = on_new_message
+        self.on_sid_rotate = on_sid_rotate
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
         self.turn_detection_mode = turn_detection_mode
@@ -372,9 +374,14 @@ class OmniRealtimeClient:
         self._is_gemini = self._api_type.lower() == 'gemini'
 
         # Whether this API returns server-side VAD events (speech_started/speech_stopped)
-        # Gemini (direct) and lanlan.app+free (Gemini proxy) do NOT have server VAD
-        self._has_server_vad = not self._is_gemini and not (
-            'lanlan.app' in (base_url or '') and 'free' in self._model_lower
+        # Gemini (direct), lanlan.app+free (Gemini proxy), 以及 livestream 模式
+        # （主播自建 server_prefix 上游同样是 Gemini 系，不发 OpenAI 协议的 VAD 帧）
+        # 一律按"无 server VAD"处理。否则 handle_messages 走不到 speech_stopped
+        # 那条 on_new_message 路径，多轮对话 sid 不轮换，TTS 在 turn 2 起静音。
+        self._has_server_vad = (
+            not self._is_gemini
+            and not ('lanlan.app' in (base_url or '') and 'free' in self._model_lower)
+            and not bool(livestream_mode)
         )
 
         # Whether this client supports native image input
@@ -2076,6 +2083,19 @@ class OmniRealtimeClient:
                     self._image_sent_this_turn = False
                     if self.on_response_done:
                         await self.on_response_done()
+                    # No-server-VAD providers (Gemini-proxy: lanlan.app+free /
+                    # livestream) never emit input_audio_buffer.speech_stopped,
+                    # so handle_messages' on_new_message path on speech_stopped
+                    # never fires and current_speech_id never rotates between
+                    # turns. Without rotation, TTS upstream silently drops text
+                    # after the first tts.response.done closes the initial sid.
+                    # Hook here at response.done (Gemini's turn_complete, the
+                    # only reliable end-of-AI-turn signal in those proxies) and
+                    # call the lightweight rotate-only path — full
+                    # handle_new_message would clip trailing TTS audio and
+                    # mis-fire USER_INPUT (no user input actually happened).
+                    if not self._has_server_vad and self.on_sid_rotate:
+                        await self.on_sid_rotate()
                 elif event_type == "response.created":
                     self._response_created_total += 1
                     self._last_response_created_time = time.time()

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -22,6 +22,7 @@ autonomously when the user is silent.
 """
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Dict
 
 from plugin.sdk.plugin import (
@@ -61,11 +62,39 @@ MINECRAFT_TASK_SCHEMA: Dict[str, Any] = {
 
 
 MINECRAFT_TASK_DESCRIPTION = (
-    "Send a task to the Minecraft game system. Use this when you describe a "
-    "concrete action you want to perform in Minecraft. The task should be a "
-    "single, clear, executable goal in English. Do not propose vague requests "
-    "such as: find a good place to build a house. Such vague tasks cannot be "
-    "executed. IMPORTANT: Do NOT set overwrite=True unless absolutely necessary."
+    "Dispatch a single concrete action for the in-game character to "
+    "perform. Fire-and-forget: returns immediately with an "
+    "acknowledgement; the real outcome arrives asynchronously as fresh "
+    "screenshots and a system feedback message tagged ``[你刚做完一段动作]`` "
+    "(cue). "
+    "Do not infer or claim results from the task text itself — only from "
+    "actually-observed cues and screenshots.\n\n"
+    "Use this tool when the user asks the character to do something in "
+    "the game, or when continuing an in-game activity that needs another "
+    "concrete step. Do NOT use it for chat, status questions, or "
+    "abstract intent — see ``query_inventory`` for inventory lookups.\n\n"
+    "Parameters:\n"
+    "  task (string, required): one concrete executable action in "
+    "English with specific targets — exact coordinates, specific block "
+    "or entity types, specific quantities. Vague intents ('find a good "
+    "place to build a house', 'find a blue block', 'come over here') "
+    "are not executable. Prefer single-step actions (one mine / one "
+    "craft / one walk) over long compound chains; chains complete "
+    "piece by piece and each step's real outcome must be observed "
+    "before claiming the next.\n"
+    "  overwrite (bool, default false): if a previous task is still in "
+    "flight, false rejects this call with a 'busy' summary and the "
+    "previous task keeps running (correct ~95% of the time — let it "
+    "finish and chain naturally). Set true ONLY when the user "
+    "explicitly demands an interrupt ('stop', 'cancel that, do X'), or "
+    "you have directly observed the current task is hopelessly stuck "
+    "(blocked for 30s+ with zero progress in screenshots). Do NOT set "
+    "true for 'better plan' / 'more efficient' subjective reasons — "
+    "interrupting in-flight actions frequently causes chaos.\n\n"
+    "Inventory ground truth: the cue includes a ``【当前持有 ground "
+    "truth】`` line listing the character's actual inventory at task "
+    "completion — items NOT listed there do not exist; never narrate "
+    "items you don't see in that line."
 )
 
 
@@ -86,6 +115,73 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
             logger=self.logger,
             push_message_fn=self.push_message,
         )
+        # ``service.start()`` spawns long-running asyncio tasks (WS client
+        # reconnect loop + autonomous nudge loop). It must run inside the
+        # plugin host's *long-lived* main event loop — but the SDK invokes
+        # ``@lifecycle(id="startup")`` via a transient ``asyncio.run(...)``
+        # ([plugin/core/host.py:838]), which closes the loop the moment the
+        # handler returns and cancels every ``asyncio.create_task`` started
+        # underneath it. We therefore defer the real start until the first
+        # entry handler call — those run on the host's long-lived async
+        # command loop, so tasks created there actually survive.
+        # ``_service_lazy_started`` is the gate; ``_service_start_lock``
+        # serializes the lazy start so concurrent first-calls don't
+        # double-spawn.
+        self._service_lazy_started: bool = False
+        self._service_start_lock: asyncio.Lock = asyncio.Lock()
+
+    async def _ensure_service_started(self, *, connect_wait_s: float = 3.0) -> bool:
+        """Idempotent lazy-start of the WS service.
+
+        Returns ``True`` iff the WS client reports ``is_connected`` by the
+        time this method returns. The handler uses the return value to
+        decide whether to dispatch a detached task (and emit the standard
+        avatar-framed acknowledgement) or short-circuit with an
+        "avatar still waking up" message — without this gate the very
+        first call after a plugin process spawn races the WS connect and
+        leaks the underlying transport error string ("agent server is
+        not connected") into the dialog LLM's context, which then makes
+        the dialog LLM spontaneously talk about reconnecting and break
+        the avatar framing.
+
+        ``service.start()`` itself is synchronous up to spawning the
+        reconnect coroutine — the actual WebSocket handshake completes
+        a beat later. We poll the connected flag at 50ms cadence up to
+        ``connect_wait_s`` (default 3s, which empirically covers ~99%
+        of fresh-process boots: observed connect times are 1.5–2.5s).
+        """
+        async with self._service_start_lock:
+            if not self._service_lazy_started:
+                try:
+                    await self._service.start()
+                    self._service_lazy_started = True
+                    self.logger.info(
+                        "[lazy-start] service.start() ran on long-lived loop"
+                    )
+                except Exception as exc:
+                    # Don't flip the flag — next call retries. The WS client
+                    # has its own reconnect loop, so a successful start with
+                    # an unreachable mc-agent is fine; we only want to retry
+                    # if start() itself raised before scheduling the tasks.
+                    self.logger.warning(
+                        "[lazy-start] service.start failed; will retry on next call — {}: {}",
+                        type(exc).__name__, exc,
+                    )
+                    return False
+
+            # Wait briefly for the WS handshake to actually complete.
+            # Lock is held throughout — concurrent first-callers all see
+            # the same connected-or-not snapshot rather than racing.
+            import time as _time
+            deadline = _time.monotonic() + connect_wait_s
+            client = getattr(self._service, "_client", None)
+            while _time.monotonic() < deadline:
+                if client is not None and getattr(client, "is_connected", False):
+                    return True
+                await asyncio.sleep(0.05)
+            return bool(
+                client is not None and getattr(client, "is_connected", False)
+            )
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -93,6 +189,9 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
 
     @lifecycle(id="startup")
     async def startup(self, **_):
+        # IMPORTANT: only do configuration here. Do NOT call service.start()
+        # — see ``_ensure_service_started`` docstring for why the SDK's
+        # transient asyncio.run() makes that unsafe.
         cfg = await self.config.dump(timeout=5.0)
         cfg = cfg if isinstance(cfg, dict) else {}
         self._cfg = (
@@ -101,22 +200,19 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
             else {}
         )
         self._service.configure(self._cfg)
-        try:
-            await self._service.start()
-        except Exception as exc:
-            # Plugin construction shouldn't be fatal if the agent server
-            # is offline — the WS client has its own reconnect loop, and
-            # we want the LLM tool registered regardless so the model
-            # can attempt a task and get a clean disconnected error.
-            self.logger.warning(
-                "[startup] service start raised; continuing — {}: {}",
-                type(exc).__name__, exc,
-            )
         return Ok({"status": "ready", "result": self._service.get_status()})
 
     @lifecycle(id="shutdown")
     async def shutdown(self, **_):
-        await self._service.stop()
+        if self._service_lazy_started:
+            try:
+                await self._service.stop()
+            except Exception as exc:
+                self.logger.warning(
+                    "[shutdown] service.stop raised — {}: {}",
+                    type(exc).__name__, exc,
+                )
+            self._service_lazy_started = False
         return Ok({"status": "shutdown"})
 
     # ------------------------------------------------------------------
@@ -127,20 +223,229 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
         name="minecraft_task",
         description=MINECRAFT_TASK_DESCRIPTION,
         parameters=MINECRAFT_TASK_SCHEMA,
-        # Set the SDK wrapper's timeout to the maximum the server
-        # accepts (300s, see ``ToolRegisterRequest.timeout_seconds``)
-        # so the *real* per-call cap is governed by the operator-
-        # configured ``[game_agent].task_timeout_seconds``. With a
-        # hardcoded 30s here, any user-set ``task_timeout_seconds`` >
-        # 30 would be silently truncated by the SDK's outer wrapper
-        # before the service could return its structured
-        # ``{status: "timeout"}`` shape.
+        # SDK wrapper timeout retained at the registry max even though the
+        # handler itself returns in ~0ms now (fire-and-forget). Keeping it
+        # at 300s means a future change that re-introduces an await won't
+        # silently cap below the operator-configured task_timeout_seconds.
         timeout=300.0,
     )
-    async def minecraft_task(self, *, task: str, overwrite: bool = False, **_):
-        return await self._service.execute_minecraft_task(
-            task=task, overwrite=overwrite,
+    async def minecraft_task(self, *, task: Any = None, overwrite: Any = False, **_):
+        # ``task`` declared as ``Any = None`` rather than ``str`` (required)
+        # so that LLMs which violate the JSON schema (omit ``task``, pass
+        # null, pass a non-string) reach the handler body instead of
+        # raising ``TypeError`` at call dispatch — the SDK trigger path
+        # would otherwise surface a raw stack trace via host.py:1082's
+        # ``Unexpected error executing`` log, and the LLM tool result
+        # would be a generic error envelope rather than something the
+        # dialog LLM can act on. By accepting whatever the LLM sent and
+        # producing a structured "you forgot the task" summary, the LLM
+        # learns the schema by getting a clear message back.
+
+        # ---- schema validation ----
+        if not isinstance(task, str) or not task.strip():
+            return {
+                "summary": (
+                    "调用没成功——缺了具体的动作描述。"
+                    "想清楚你这次想干啥（比如 'mine 4 oak logs nearby'、"
+                    "'walk to 120 64 -50'），再重新调用。"
+                )
+            }
+        task_text = task.strip()
+        # Some LLMs pass ``"true"`` / ``"1"`` / ``1`` as overwrite. Strict
+        # ``is True`` keeps the destructive interrupt path off-by-default;
+        # anything other than the canonical Python bool ``True`` is treated
+        # as False. (Service-side also strict-checks, but doing it here
+        # makes the failure mode visible in this handler's local reasoning.)
+        overwrite_flag = overwrite is True
+
+        # Lazy-start the WS service on the host's long-lived loop AND wait
+        # briefly (≤3s) for the WS handshake to complete. See
+        # ``_ensure_service_started`` for the rationale on both halves —
+        # without the wait, the very first task after a fresh process
+        # leaks an "agent server is not connected" string into the dialog
+        # LLM's context and the dialog LLM picks up bad framing from it.
+        connected = await self._ensure_service_started()
+        if not connected:
+            return {
+                "summary": (
+                    "你刚连上游戏还没就位，没法立刻动。稍等再来一次。"
+                )
+            }
+
+        # Pre-check pending state. Without this short-circuit, every
+        # concurrent call returns the same standard "action dispatched"
+        # ack — the dialog LLM then narrates as if its new action took,
+        # but the detached task underneath actually got rejected by the
+        # pending lock (returning ``{result: "busy", ...}``). Pre-checking
+        # lets us tell the dialog LLM the truth (the slot is occupied) in
+        # the synchronous tool result, instead of relying on an async cue
+        # that may arrive too late.
+        if not overwrite_flag and self._service.has_pending_task():
+            return {
+                "summary": (
+                    "你还在做上一个动作，新动作没派出去。"
+                    "等画面变化或上一个动作真的结束再来。"
+                )
+            }
+
+        # Fire-and-forget: schedule the actual execution as a detached task
+        # and return an acknowledgement immediately. Rationale:
+        # - Dialog LLM has tight realtime constraints; blocking it 25–295s
+        #   waiting for a long minecraft action would freeze the conversation.
+        # - The dialog LLM doesn't need (and shouldn't have) the structured
+        #   tool result — fresh screenshots + the [character status] cue
+        #   pushed by ``_on_detached_task_done`` already give it everything
+        #   to ground its narration to {MASTER_NAME}.
+        # - The acknowledgement explicitly tells the dialog LLM not to
+        #   fabricate results, which is the failure mode if we just returned
+        #   None or {}.
+        detached = asyncio.create_task(
+            self._service.execute_minecraft_task(task=task_text, overwrite=overwrite_flag),
+            name=f"game_agent_minecraft.task:{task_text[:40]}",
         )
+        detached.add_done_callback(self._on_detached_task_done)
+        return {
+            "summary": (
+                "刚开始动——结果还没出现，新画面和反馈会在接下来 1-30 秒陆续到。"
+                "在看到之前不要描述任何具体成果（不要说『搞定了』、『拿到了 X』、"
+                "『已经到 Y 了』），想说就只说『我去试试……』之类的第一人称。"
+            )
+        }
+
+    # ------------------------------------------------------------------
+    # Detached task plumbing — runs after the @llm_tool handler has
+    # already returned, pushes a brief completion cue back to the dialog
+    # LLM via the standard push_message v2 channel.
+    # ------------------------------------------------------------------
+
+    def _on_detached_task_done(self, task: asyncio.Task) -> None:
+        """Push a short [character status] cue when a detached
+        minecraft_task finishes (any outcome — ok / timeout /
+        interrupted / busy / error).
+
+        Runs on the event loop in the done-callback context, so it must
+        not raise — exceptions here would bubble into asyncio's default
+        handler as "Exception in callback" noise. Wrap everything in
+        try/except and log.
+        """
+        try:
+            result = task.result()
+        except asyncio.CancelledError:
+            # Plugin shutdown / loop teardown cancelled it — silent.
+            return
+        except Exception as exc:
+            self.logger.warning(
+                "[detached] minecraft_task crashed: {}: {}",
+                type(exc).__name__, exc,
+            )
+            return
+        if not isinstance(result, dict):
+            return
+        cue = self._format_completion_cue(result)
+        if not cue:
+            return
+        try:
+            # ai_behavior="respond" + priority=2: the action just
+            # finished; the dialog LLM should immediately narrate the
+            # outcome to {MASTER_NAME} and (if appropriate) decide a
+            # next concrete action. Without ``respond`` the cue would
+            # only land in context as silent reading material; the
+            # human-facing report would be deferred to the next user
+            # turn, which feels unresponsive. Priority 2 sits between
+            # alert (1, preempts everything) and normal screenshot
+            # stream (3+, background read).
+            self.push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="respond",
+                parts=[{"type": "text", "text": cue}],
+                priority=2,
+            )
+        except Exception as exc:
+            self.logger.warning(
+                "[detached] completion cue push failed: {}: {}",
+                type(exc).__name__, exc,
+            )
+
+    def _format_completion_cue(self, result: Dict[str, Any]) -> str:
+        """Format ``service.execute_minecraft_task`` return value into
+        a single-line cue. Covers all five documented shapes:
+
+        * ``{status: ok|timeout|interrupted, query, text/reason}``
+        * ``{result: "busy", currently_executing, hint}``
+        * ``{output, is_error: True, error}`` — also reads ``output.query``
+          since AGENT_DISCONNECTED path nests task text inside ``output``.
+
+        The tail nudges the dialog LLM to (a) ground its next utterance
+        in actual visual/system state rather than imagine the outcome,
+        and (b) immediately decide a next concrete action when relevant.
+        ``{MASTER_NAME}`` is substituted by main_logic core's callback
+        renderer at injection time so plugin text can refer to the dialog
+        roles without hardcoding live names.
+        """
+        if result.get("is_error"):
+            status = str(result.get("error") or "error")
+        else:
+            status = str(result.get("status") or result.get("result") or "unknown")
+        query = str(
+            result.get("query") or result.get("currently_executing") or ""
+        )
+        detail = str(
+            result.get("text")
+            or result.get("reason")
+            or result.get("hint")
+            or ""
+        )
+        if isinstance(result.get("output"), dict):
+            # AGENT_DISCONNECTED path: real query text and error message
+            # are inside the nested ``output`` dict.
+            if not query:
+                query = str(result["output"].get("query") or "")
+            output_err = result["output"].get("error")
+            if output_err and not detail:
+                detail = str(output_err)
+        # Avatar-framed rewrite for transport-level errors. The dialog LLM
+        # must never see "agent server is not connected" or similar
+        # underlying-transport vocabulary — that breaks the framing and
+        # the LLM starts narrating about "reconnecting to the server".
+        # Translate to body / sensation language; the actionable bit
+        # (something went wrong, retry later) is preserved.
+        if status == "AGENT_DISCONNECTED" or "not connected" in detail.lower():
+            status = "暂时连不上游戏"
+            detail = "和游戏的连接刚断了一下，稍后会自动恢复。"
+
+        # GROUNDING: extract authoritative inventory snapshot from the
+        # task_finished payload (mc-agent's ws_server.onTaskCompleted
+        # always attaches an ``inventory`` dict, plus the body status
+        # block). Surfacing this prominently in the cue head — and
+        # marking it explicitly as ground truth — prevents the dialog
+        # LLM from hallucinating items it doesn't have. Before this,
+        # the inventory was hidden inside the verbose ``message`` field
+        # which the LLM treated as soft narration; with the explicit
+        # 【当前持有】 prefix it becomes a hard constraint.
+        inventory_line = ""
+        inv = result.get("inventory")
+        if isinstance(inv, dict) and inv:
+            items = sorted(
+                ((str(k), int(v)) for k, v in inv.items() if int(v) > 0),
+                key=lambda kv: -kv[1],
+            )
+            if items:
+                snippet = "、".join(f"{name}×{count}" for name, count in items[:20])
+                inventory_line = f"\n【当前持有 ground truth】{snippet}"
+        elif isinstance(inv, dict):
+            inventory_line = "\n【当前持有 ground truth】(空)"
+
+        head = f"[你刚做完一段动作] 你刚才在做: \"{query[:120]}\" / 结果: {status}"
+        body = f" / 反馈: {detail[:240]}" if detail else ""
+        tail = (
+            "\n用第一人称随口讲一句你刚才做了啥、现在看到/感觉到啥——"
+            "**只能讲上面反馈和最新画面里真有的**，任务文本里没成真的步骤别提。"
+            "【当前持有】行是你背包的 ground truth，绝对不要说出未列出的物品。"
+            "然后立刻用 minecraft_task 接着派下一个具体动作——你在玩游戏，"
+            "主动找事做，别站着等人指挥。"
+        )
+        return head + body + inventory_line + tail
 
     # ------------------------------------------------------------------
     # Diagnostic plugin entries (callable from the plugin UI / CLI)
@@ -155,6 +460,11 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
     )
     async def game_agent_status(self, **_):
         try:
+            # Lazy-start so a status query right after plugin enable
+            # actually shows a connecting/connected client, not the
+            # never-started default. Without this the entry would report
+            # connected=False forever even though the WS endpoint is up.
+            await self._ensure_service_started()
             status = self._service.get_status()
             connected = "connected" if status.get("connected") else "disconnected"
             pending = status.get("pending_task") or "(idle)"
@@ -162,6 +472,46 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
                 f"ws={status.get('ws_url')} | {connected} | task={pending}"
             )
             return Ok(status)
+        except Exception as exc:
+            return Err(f"{type(exc).__name__}: {exc}")
+
+    @plugin_entry(
+        id="query_inventory",
+        name="查询当前持有",
+        description=(
+            "查询当前 Minecraft 化身持有的物品（基于最近一次 task_finished "
+            "或定时 nudge 缓存的 inventory snapshot）。供 analyzer 在用户问"
+            "「我手里有啥」「背包里还剩多少 X」「现在能不能合成 Y」之类需要 "
+            "ground-truth 库存事实的问题时调用。返回结构化 dict (item_name → "
+            "count)，并附 summary 字符串方便对话 LLM 直接复述。"
+        ),
+        llm_result_fields=["summary"],
+        input_schema={"type": "object", "properties": {}},
+    )
+    async def query_inventory(self, **_):
+        try:
+            await self._ensure_service_started()
+            inv = dict(self._service._last_inventory)  # snapshot copy
+            inv_at = self._service._last_inventory_at
+            if not inv:
+                summary = (
+                    "【背包 ground truth】你当前一无所有——背包是空的。"
+                    "如果你刚才说过『拿到了 X』『有 Y』，那是幻想，立刻自己改口。"
+                    if inv_at == 0
+                    else
+                    "【背包 ground truth】你当前背包是空的。如果你刚才说过持有"
+                    "任何物品，那是幻想，立刻自己改口。"
+                )
+            else:
+                items = sorted(inv.items(), key=lambda kv: -kv[1])
+                snippet = "、".join(f"{n}×{c}" for n, c in items)
+                summary = (
+                    f"【背包 ground truth — 完整且唯一】你当前持有：{snippet}。"
+                    "**这一行就是你背包的全部内容**——任何这里没列出的物品都"
+                    "不在你身上。如果你刚才说过的话和这个列表对不上，立刻"
+                    "用第一人称自己更正回真实情况。"
+                )
+            return Ok({"summary": summary, "inventory": inv, "snapshot_at": inv_at})
         except Exception as exc:
             return Err(f"{type(exc).__name__}: {exc}")
 
@@ -178,6 +528,12 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
     )
     async def game_agent_reload_config(self, **_):
         try:
+            # If the service hasn't been lazily started yet (i.e. plugin
+            # was enabled but no entry / tool call has happened),
+            # reload_config_live will return early without restarting
+            # anything. Trigger lazy-start first so the new config
+            # actually drives a live WS connection.
+            await self._ensure_service_started()
             cfg = await self.config.dump(timeout=5.0)
             cfg = cfg if isinstance(cfg, dict) else {}
             self._cfg = (

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -494,17 +494,20 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
             connected = await self._ensure_service_started()
             inv = dict(self._service._last_inventory)  # snapshot copy
             inv_at = self._service._last_inventory_at
-            # 三档分支：
-            #   (a) 断连 + 从没拿到过 → 真"未知"
-            #   (b) 断连 + 有过旧 snapshot → 旧 snapshot **+ 过期警告**
-            #       （不能照原值上报，断连期间死亡/掉落/世界变化都看不到，
-            #        把缓存当 truth 等于复述过期事实）
-            #   (c) 已连接 → 当下 snapshot 即 truth
-            if not connected and inv_at == 0:
+            # 四档分支（注意：inv_at==0 永远是"还没收到过任何 snapshot"，
+            # 不论 connected 与否——刚连上但还没跑 task 也会落到这里，这时
+            # 报"背包是空的"是假事实）：
+            #   (a) inv_at==0          → 真"未知"，从没拿到过 snapshot
+            #   (b) 断连 + 有旧 snapshot → 旧 snapshot + 过期警告（断连期间
+            #       死亡 / 掉落 / 被夺走都看不到，照原值上报等于复述过期事实）
+            #   (c) 已连接 + 空 snapshot → 真空背包
+            #   (d) 已连接 + 有 snapshot → 当下 ground truth
+            if inv_at == 0:
                 summary = (
-                    "【背包 ground truth】暂时连不上游戏，看不到你现在的背包。"
-                    "如果用户问到持有的物品，先说一声"
-                    "『现在连不上游戏，等一下再确认』，别凭印象编。"
+                    "【背包 ground truth】"
+                    + ("暂时连不上游戏，" if not connected else "刚连上还没拿到第一份背包快照，")
+                    + "看不到你现在的背包。如果用户问到持有的物品，先说一声"
+                    "『现在还没确认到背包，等一下再说』，别凭印象编。"
                 )
             elif not connected:
                 age_s = max(0, int(time.time() - inv_at))
@@ -522,10 +525,6 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
                 )
             elif not inv:
                 summary = (
-                    "【背包 ground truth】你当前一无所有——背包是空的。"
-                    "如果你刚才说过『拿到了 X』『有 Y』，那是幻想，立刻自己改口。"
-                    if inv_at == 0
-                    else
                     "【背包 ground truth】你当前背包是空的。如果你刚才说过持有"
                     "任何物品，那是幻想，立刻自己改口。"
                 )

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -490,10 +490,20 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
     )
     async def query_inventory(self, **_):
         try:
-            await self._ensure_service_started()
+            connected = await self._ensure_service_started()
             inv = dict(self._service._last_inventory)  # snapshot copy
             inv_at = self._service._last_inventory_at
-            if not inv:
+            # 断连场景：inv 默认 {}, inv_at 默认 0——这与"真的空背包"在数值上
+            # 同形，但语义完全不同。如果照"空背包"模板返回，dialog LLM 会向
+            # 用户复述一个假事实（"你背包是空的"）。改返回"未知"，让 LLM
+            # 自然引导到"暂时看不到背包"而不是编造库存事实。
+            if not connected and inv_at == 0:
+                summary = (
+                    "【背包 ground truth】暂时连不上游戏，看不到你现在的背包。"
+                    "如果用户问到持有的物品，先说一声"
+                    "『现在连不上游戏，等一下再确认』，别凭印象编。"
+                )
+            elif not inv:
                 summary = (
                     "【背包 ground truth】你当前一无所有——背包是空的。"
                     "如果你刚才说过『拿到了 X』『有 Y』，那是幻想，立刻自己改口。"

--- a/plugin/plugins/game_agent_minecraft/__init__.py
+++ b/plugin/plugins/game_agent_minecraft/__init__.py
@@ -23,6 +23,7 @@ autonomously when the user is silent.
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any, Dict
 
 from plugin.sdk.plugin import (
@@ -493,15 +494,31 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
             connected = await self._ensure_service_started()
             inv = dict(self._service._last_inventory)  # snapshot copy
             inv_at = self._service._last_inventory_at
-            # 断连场景：inv 默认 {}, inv_at 默认 0——这与"真的空背包"在数值上
-            # 同形，但语义完全不同。如果照"空背包"模板返回，dialog LLM 会向
-            # 用户复述一个假事实（"你背包是空的"）。改返回"未知"，让 LLM
-            # 自然引导到"暂时看不到背包"而不是编造库存事实。
+            # 三档分支：
+            #   (a) 断连 + 从没拿到过 → 真"未知"
+            #   (b) 断连 + 有过旧 snapshot → 旧 snapshot **+ 过期警告**
+            #       （不能照原值上报，断连期间死亡/掉落/世界变化都看不到，
+            #        把缓存当 truth 等于复述过期事实）
+            #   (c) 已连接 → 当下 snapshot 即 truth
             if not connected and inv_at == 0:
                 summary = (
                     "【背包 ground truth】暂时连不上游戏，看不到你现在的背包。"
                     "如果用户问到持有的物品，先说一声"
                     "『现在连不上游戏，等一下再确认』，别凭印象编。"
+                )
+            elif not connected:
+                age_s = max(0, int(time.time() - inv_at))
+                if inv:
+                    items = sorted(inv.items(), key=lambda kv: -kv[1])
+                    snippet = "、".join(f"{n}×{c}" for n, c in items)
+                    cache_line = f"上一次看到（{age_s}s 前）背包里是：{snippet}。"
+                else:
+                    cache_line = f"上一次看到（{age_s}s 前）背包是空的。"
+                summary = (
+                    f"【背包 ground truth — ⚠️ 已断连，下列可能过期】{cache_line}"
+                    "中间死过 / 掉落 / 被夺走都看不到，"
+                    "用户问到持有时一定要说『现在连不上游戏，"
+                    "上一次看到的是 ... 但不一定还准』。"
                 )
             elif not inv:
                 summary = (
@@ -521,7 +538,12 @@ class GameAgentMinecraftPlugin(NekoPluginBase):
                     "不在你身上。如果你刚才说过的话和这个列表对不上，立刻"
                     "用第一人称自己更正回真实情况。"
                 )
-            return Ok({"summary": summary, "inventory": inv, "snapshot_at": inv_at})
+            return Ok({
+                "summary": summary,
+                "inventory": inv,
+                "snapshot_at": inv_at,
+                "connected": connected,
+            })
         except Exception as exc:
             return Err(f"{type(exc).__name__}: {exc}")
 

--- a/plugin/plugins/game_agent_minecraft/client.py
+++ b/plugin/plugins/game_agent_minecraft/client.py
@@ -27,6 +27,7 @@ from websockets import exceptions as ws_exceptions
 OnLog = Callable[[str], Awaitable[None]]
 OnScreenshot = Callable[[str, str], Awaitable[None]]  # (base64_payload, encoding_hint)
 OnTaskFinished = Callable[[dict[str, Any]], Awaitable[None]]
+OnAlert = Callable[[dict[str, Any]], Awaitable[None]]
 
 
 class GameAgentClient:
@@ -45,6 +46,7 @@ class GameAgentClient:
         on_log: Optional[OnLog] = None,
         on_screenshot: Optional[OnScreenshot] = None,
         on_task_finished: Optional[OnTaskFinished] = None,
+        on_alert: Optional[OnAlert] = None,
         reconnect_interval: float = 5.0,
         logger: Any = None,
     ):
@@ -52,6 +54,7 @@ class GameAgentClient:
         self.on_log = on_log
         self.on_screenshot = on_screenshot
         self.on_task_finished = on_task_finished
+        self.on_alert = on_alert
         self.reconnect_interval = reconnect_interval
         # Plugin SDK injects a per-plugin loguru logger; fall back to a
         # noop when running outside that environment (unit tests).
@@ -207,6 +210,12 @@ class GameAgentClient:
                     elif msg_type == "task_finished" and self.on_task_finished is not None:
                         await self.on_task_finished(data)
 
+                    elif msg_type == "alert" and self.on_alert is not None:
+                        # Asynchronous event — bot took damage / died /
+                        # other high-priority signal. Service layer
+                        # decides how to surface it to the dialog LLM.
+                        await self.on_alert(data)
+
                     elif msg_type == "agent_status":
                         # Informational status — the original integration
                         # logged this at debug. Keep parity.
@@ -269,4 +278,5 @@ __all__ = [
     "OnLog",
     "OnScreenshot",
     "OnTaskFinished",
+    "OnAlert",
 ]

--- a/plugin/plugins/game_agent_minecraft/plugin.toml
+++ b/plugin/plugins/game_agent_minecraft/plugin.toml
@@ -20,7 +20,11 @@ locales_dir = "i18n"
 
 [plugin_runtime]
 enabled = true
-auto_start = false
+# auto_start=true so plugin process spawns at NEKO startup and the WS
+# client to mc-agent is already connected by the time the first
+# minecraft_task call lands — saves the 3s lazy-start + WS handshake
+# every fresh-session would otherwise pay.
+auto_start = true
 
 [plugin.store]
 enabled = true
@@ -34,12 +38,18 @@ ws_url = "ws://localhost:48909"
 # Reconnect interval if the WebSocket drops.
 reconnect_interval_seconds = 5.0
 
-# Per-call upper bound on minecraft_task. The handler awaits the agent's
-# task_finished frame; if it doesn't arrive within this window, the LLM
-# sees a {status: "timeout"} result and is free to issue a new task.
-# Capped at 300 server-side; 25s leaves ~5s of buffer below the 30-second
-# default LLM tool ceiling.
-task_timeout_seconds = 25.0
+# Per-call upper bound on the detached task wait for ``task_finished``.
+# Fire-and-forget mode means the dialog LLM never blocks on this — the
+# value only controls how long the service waits before emitting a
+# "timed out" cue. Set very generously (120s) because compound mc-agent
+# chat-loops (craft-then-place-then-recover-from-missing-prereq) are
+# observed to legitimately take 60–90s. Premature timeouts cause two
+# downstream pains: (1) plugin clears _pending → next task overwrites
+# mc-agent's currentTaskId → eventual real completion echoes wrong id;
+# (2) dialog LLM sees a "timeout" cue and decides to re-dispatch the
+# same task, producing the appearance that the action stalled even
+# though mc-agent was actually still working on it.
+task_timeout_seconds = 120.0
 
 # How often the autonomous loop nudges the LLM with the latest game state
 # when there's no pending task. The LLM sees a "GAME_SYSTEM" prompt with

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -152,8 +152,65 @@ class GameAgentService:
         )
         self._task_finished: bool = True
 
-        # Pacing state for the autonomous loop
+        # Latest known body state (inventory dict from mc-agent's
+        # ``task_finished`` payload). Cached so the autonomous nudge loop
+        # can re-surface it every 5s as a hard grounding signal — without
+        # this, the dialog LLM only sees inventory at task_finished moments
+        # and tends to hallucinate items it doesn't have between those.
+        self._last_inventory: Dict[str, int] = {}
+        self._last_inventory_at: float = 0.0
+
+        # Pacing state for the autonomous loop. Three independent rate
+        # limiters cover the three distinct nudge purposes:
+        #
+        # * ``_last_system_prompt_time`` — generic "here's recent state"
+        #   nudge, fires only when there's actual cache to surface
+        # * ``_last_in_progress_nudge_at`` — when a task has been pending
+        #   ≥10s, periodically prompt the dialog LLM to narrate what it's
+        #   doing in its own voice (so the user gets ongoing engagement
+        #   instead of dead silence during long actions)
+        # * ``_last_keep_going_nudge_at`` — after a task finishes, if no
+        #   new task is dispatched within ~5s, prompt the dialog LLM to
+        #   decide the next concrete action (so the avatar doesn't stand
+        #   still indefinitely waiting for {MASTER_NAME} to drive it).
+        # ``_last_task_finished_at`` is the anchor for the keep-going
+        # branch: time-since-finish must be in [5s, 60s] to fire — too
+        # early and the cue cooldown is still active; too late and the
+        # user has clearly moved on.
         self._last_system_prompt_time: float = 0.0
+        self._last_in_progress_nudge_at: float = 0.0
+        self._last_keep_going_nudge_at: float = 0.0
+        self._last_task_finished_at: float = 0.0
+
+        # Pacing state for inline log push (separate from autonomous nudge).
+        # mc-agent emits a ``log`` frame for each chat-loop turn the in-game
+        # agent takes (every chat reply, every action narration). Surfacing
+        # those to the dialog LLM only via the 5s nudge loop means a turn
+        # can be 5s stale — perceptibly slow in realtime conversation.
+        # Inline push forwards each new log line to the dialog LLM
+        # immediately, but rate-limited so a chatty agent (e.g. multi-step
+        # newAction loops) doesn't spam push_message at packet rate.
+        # ``_inline_log_min_interval`` is the minimum spacing between
+        # consecutive inline pushes; bursts within that window are batched
+        # and delivered as one combined push when the window expires.
+        self._inline_log_min_interval: float = 1.5
+        self._last_inline_log_time: float = 0.0
+        self._inline_log_pending: list[str] = []
+        self._inline_log_flush_task: Optional[asyncio.Task] = None
+
+        # Pacing state for inline screenshot push. mc-agent broadcasts at
+        # 1Hz (configurable on its side via NEKO_AGENT_SCREENSHOT_INTERVAL_MS).
+        # Forwarding every frame to the dialog LLM at that rate burns tokens
+        # fast — 60 image parts/min into the realtime session is wasteful
+        # when the picture changes little. ``_screenshot_stream_min_interval``
+        # caps the push rate; frames that arrive inside the window get
+        # collapsed (we keep only the latest pending and deliver it when
+        # the window opens, so the dialog LLM always sees the most recent
+        # visual rather than a stale one).
+        self._screenshot_stream_min_interval: float = 1.0
+        self._last_screenshot_push_time: float = 0.0
+        self._pending_screenshot: Optional[tuple[bytes, str]] = None
+        self._screenshot_flush_task: Optional[asyncio.Task] = None
 
     # ------------------------------------------------------------------
     # Configuration / lifecycle
@@ -211,6 +268,12 @@ class GameAgentService:
         self._system_prompt_interval = max(1.0, _f("system_prompt_interval_seconds", 5.0))
         self._skip_when_busy = _b("skip_system_prompt_if_busy", True)
         self._stream_screenshots = _b("stream_screenshots_to_llm", True)
+        # Floor at 0.2s (i.e. 5 fps cap) — below that we're letting the
+        # dialog LLM's context burn at the wire rate of mc-agent and the
+        # rate-limit ceases to function as a throttle.
+        self._screenshot_stream_min_interval = max(
+            0.2, _f("screenshot_stream_min_interval_seconds", 1.0)
+        )
         size = max(1, _i("screenshot_cache_size", 3))
         self._screenshot_cache_size = size
         # ``deque(maxlen=...)`` is immutable post-construction, so swap.
@@ -268,6 +331,7 @@ class GameAgentService:
             on_log=self._on_log,
             on_screenshot=self._on_screenshot,
             on_task_finished=self._on_task_finished,
+            on_alert=self._on_alert,
             reconnect_interval=self._reconnect_interval,
             logger=self.logger,
         )
@@ -334,6 +398,30 @@ class GameAgentService:
                 # client's own error logging.
                 pass
             self._client_task = None
+
+        # Cancel any pending inline-log flush. We don't try to drain it —
+        # the cache is also being cleared right below; sending a final
+        # batch on shutdown would surface character chatter into the
+        # dialog LLM after the plugin's already going away.
+        if self._inline_log_flush_task is not None:
+            self._inline_log_flush_task.cancel()
+            try:
+                await self._inline_log_flush_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._inline_log_flush_task = None
+        self._inline_log_pending.clear()
+
+        # Same reasoning for the deferred screenshot push — drop the
+        # pending frame and tear down the flush task.
+        if self._screenshot_flush_task is not None:
+            self._screenshot_flush_task.cancel()
+            try:
+                await self._screenshot_flush_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._screenshot_flush_task = None
+        self._pending_screenshot = None
 
         self._log_cache.clear()
         self._screenshot_cache.clear()
@@ -543,6 +631,129 @@ class GameAgentService:
         return my_pending.result or {"status": "ok", "query": task}
 
     # ------------------------------------------------------------------
+    # Inline log push — pacing helpers
+    # ------------------------------------------------------------------
+
+    def _schedule_inline_log_push(self, line: str) -> None:
+        """Queue a log line for inline delivery to the dialog LLM.
+
+        Two paths:
+        * Window open (≥ ``_inline_log_min_interval`` since last push) →
+          flush immediately, single-line push.
+        * Window closed → append to the pending buffer; if no flush task
+          is already scheduled, arm one to fire when the window opens.
+          A second log arriving inside the window just appends, riding
+          on the already-scheduled flush.
+
+        The buffer + scheduled flush approach keeps the dialog LLM at
+        most one window-length stale while collapsing high-frequency
+        bursts (newAction loops emit log lines per inner iteration) into
+        one combined push.
+        """
+        self._inline_log_pending.append(line)
+        now = time.time()
+        elapsed = now - self._last_inline_log_time
+        if elapsed >= self._inline_log_min_interval:
+            # Window open — flush now, no delay.
+            self._flush_inline_log_now()
+        else:
+            # Inside the rate-limit window — schedule a delayed flush
+            # if one isn't already pending. ``_inline_log_flush_task``
+            # being non-None means a flush is armed for the end of the
+            # current window, so this new line will go out with it.
+            if self._inline_log_flush_task is None or self._inline_log_flush_task.done():
+                delay = max(0.0, self._inline_log_min_interval - elapsed)
+                self._inline_log_flush_task = asyncio.create_task(
+                    self._delayed_flush_inline_log(delay),
+                    name="game_agent_minecraft.inline_log_flush",
+                )
+
+    async def _delayed_flush_inline_log(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        self._flush_inline_log_now()
+
+    def _flush_inline_log_now(self) -> None:
+        if not self._inline_log_pending:
+            return
+        # Drain buffer atomically; if a new log arrives during the
+        # push_message call below it'll re-arm a fresh flush.
+        lines = self._inline_log_pending
+        self._inline_log_pending = []
+        self._last_inline_log_time = time.time()
+        text = "\n".join(lines)
+        try:
+            # ai_behavior="read" — inject into context, don't force
+            # immediate reply. The dialog LLM will see fresh narration
+            # from the character on its next natural turn.
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="read",
+                parts=[{"type": "text", "text": text}],
+                priority=4,
+            )
+        except Exception as exc:
+            self._log_error(
+                "inline log push failed: {}: {}", type(exc).__name__, exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Inline screenshot push — pacing helpers (mirror of log path above)
+    # ------------------------------------------------------------------
+
+    def _schedule_screenshot_push(self, img_bytes: bytes, mime: str) -> None:
+        """Rate-limit screenshot delivery to the dialog LLM.
+
+        Unlike log lines (which batch — old lines still useful), old
+        screenshots are obsolete the moment a newer one arrives. So we
+        keep only ``_pending_screenshot`` = latest frame; an incoming
+        frame inside the rate-limit window replaces it instead of
+        queueing alongside.
+        """
+        now = time.time()
+        elapsed = now - self._last_screenshot_push_time
+        if elapsed >= self._screenshot_stream_min_interval:
+            self._push_screenshot_now(img_bytes, mime)
+        else:
+            # Window closed — defer. Latest frame wins.
+            self._pending_screenshot = (img_bytes, mime)
+            if self._screenshot_flush_task is None or self._screenshot_flush_task.done():
+                delay = max(0.0, self._screenshot_stream_min_interval - elapsed)
+                self._screenshot_flush_task = asyncio.create_task(
+                    self._delayed_flush_screenshot(delay),
+                    name="game_agent_minecraft.screenshot_flush",
+                )
+
+    async def _delayed_flush_screenshot(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        pending = self._pending_screenshot
+        self._pending_screenshot = None
+        if pending is not None:
+            self._push_screenshot_now(*pending)
+
+    def _push_screenshot_now(self, img_bytes: bytes, mime: str) -> None:
+        self._last_screenshot_push_time = time.time()
+        try:
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="read",
+                parts=[{"type": "image", "data": img_bytes, "mime": mime}],
+                priority=3,
+            )
+        except Exception as exc:
+            self._log_error(
+                "push_message screenshot failed: {}: {}",
+                type(exc).__name__, exc,
+            )
+
+    # ------------------------------------------------------------------
     # WebSocket inbound callbacks — invoked from the WS listener task
     # ------------------------------------------------------------------
 
@@ -551,6 +762,14 @@ class GameAgentService:
         if not text_strip:
             return
         self._log_cache.append(text_strip)
+
+        # Inline push to the dialog LLM, rate-limited. The 5s autonomous
+        # nudge loop is still authoritative for "burst the full state
+        # alongside screenshots when nothing else is happening"; this
+        # inline path is for "agent just said something, get it in front
+        # of the dialog LLM now so it can weave into ongoing conversation
+        # without 5s of staleness".
+        self._schedule_inline_log_push(text_strip)
 
         # The original integration sniffed log strings to track agent
         # state because some agent server implementations emit logs
@@ -668,26 +887,59 @@ class GameAgentService:
 
         self._screenshot_cache.append((img_bytes, mime))
 
-        # Stream immediately into the realtime LLM session. push_message
-        # v2 with ``ai_behavior="read"`` translates downstream into
-        # ``session.stream_image`` (see ``main_server.py`` proactive
-        # branch + the v2 changelog for the wire flow).
+        # Stream into the realtime LLM session, rate-limited. The
+        # autonomous nudge loop still bursts the cache at 5s intervals
+        # regardless; this path is for "as fresh as the dialog LLM can
+        # cope with" between nudges. Bursts collapse to "latest only" —
+        # 5 frames within the window become 1 push of the most recent.
         if self._stream_screenshots:
-            try:
-                self._push_message(
-                    source="game_agent_minecraft",
-                    visibility=[],
-                    ai_behavior="read",
-                    parts=[{"type": "image", "data": img_bytes, "mime": mime}],
-                    priority=3,
-                )
-            except Exception as exc:
-                self._log_error(
-                    "push_message screenshot failed: {}: {}",
-                    type(exc).__name__, exc,
-                )
+            self._schedule_screenshot_push(img_bytes, mime)
+
+    async def _on_alert(self, data: Dict[str, Any]) -> None:
+        """High-severity event from mc-agent (HP damage / death / etc.).
+
+        Pushed to the dialog LLM with ``ai_behavior="respond"`` and
+        ``priority=1`` so it can preempt whatever else is queued —
+        the user should hear about a death immediately, not 5s later
+        on the next autonomous nudge tick.
+
+        Severity is informational on the frame; the priority + behavior
+        already encode "act on this now" downstream, but we keep the
+        severity string in the text so the LLM can adjust tone (a
+        ``warn`` doesn't need the same urgency as ``critical``).
+        """
+        text = str(data.get("text") or "").strip()
+        if not text:
+            return
+        severity = str(data.get("severity") or "warn").lower()
+        prefix = "[character alert | critical]" if severity == "critical" else "[character alert]"
+        body = f"{prefix} {text}"
+        try:
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="respond",
+                parts=[{"type": "text", "text": body}],
+                priority=1,
+            )
+        except Exception as exc:
+            self._log_error(
+                "alert push failed: {}: {}", type(exc).__name__, exc,
+            )
 
     async def _on_task_finished(self, data: Dict[str, Any]) -> None:
+        # Snapshot inventory so the autonomous nudge loop can keep
+        # surfacing it as ground truth between task_finished events
+        # — without this the dialog LLM only sees inventory at
+        # task_finished moments and freely hallucinates items between.
+        inv = data.get("inventory")
+        if isinstance(inv, dict):
+            self._last_inventory = {
+                str(k): int(v) for k, v in inv.items()
+                if isinstance(v, (int, float)) and int(v) > 0
+            }
+            self._last_inventory_at = time.time()
+
         text = str(
             data.get("text") or data.get("data") or data.get("message") or ""
         )
@@ -805,13 +1057,39 @@ class GameAgentService:
             pending.result = result_payload
             pending.event.set()
             self._task_finished = True
+            # Anchor for the keep-going nudge branch in
+            # ``_system_prompt_loop``. After ~5s without a new task
+            # being dispatched, the loop will start poking the dialog
+            # LLM to decide a next concrete action — preventing the
+            # avatar from going idle indefinitely waiting to be driven.
+            self._last_task_finished_at = time.time()
 
     # ------------------------------------------------------------------
     # Autonomous system-prompt loop
     # ------------------------------------------------------------------
 
     async def _system_prompt_loop(self) -> None:
-        """Periodically nudge the LLM with the latest game state.
+        """Periodically nudge the dialog LLM. Three branches, each with
+        its own rate limiter:
+
+        * **In-progress nudge** (highest priority when applicable). Fires
+          when a task has been pending ≥10s and the last in-progress
+          nudge was ≥10s ago. Tells the dialog LLM "your body is still
+          doing X — narrate what you're feeling in your own voice (don't
+          repeat yourself)". Without this branch, long actions (mining,
+          pathfinding) leave the user hearing nothing for 30+ seconds.
+
+        * **Keep-going nudge** (idle, recently finished). Fires when no
+          task is pending, the most recent task_finished is 5–60s ago,
+          and the last keep-going nudge was ≥15s ago. Tells the dialog
+          LLM "your body finished — decide and dispatch the next concrete
+          action". Without this branch, the avatar stands still after
+          each task waiting for the user to drive it.
+
+        * **General catch-all** — original behavior: every
+          ``system_prompt_interval`` seconds (default 5s), if there's
+          actual cache to surface (logs / screenshots), fire the standard
+          state-update prompt.
 
         We don't try to detect "user/model is currently speaking" from
         inside the plugin — main_server's proactive_message handler
@@ -819,23 +1097,56 @@ class GameAgentService:
         only about not flooding main_server with redundant wake-ups,
         not about real-time conversation politeness.
         """
+        # Anchor thresholds chosen to balance "keep the avatar engaged"
+        # vs "don't spam the dialog LLM's context budget":
+        #   in-progress: 10s elapsed + 10s cooldown
+        #   keep-going:  5s post-finish + 15s cooldown, max 60s window
+        _IN_PROGRESS_AFTER = 10.0
+        _IN_PROGRESS_COOLDOWN = 10.0
+        _KEEP_GOING_AFTER = 5.0
+        _KEEP_GOING_COOLDOWN = 15.0
+        _KEEP_GOING_MAX_WINDOW = 60.0
+
         try:
             while True:
-                # 0.5s tick keeps us responsive to ``stop()`` without
-                # busy-looping.
                 await asyncio.sleep(0.5)
-
                 now = time.time()
+
+                # ---- Branch 1: in-progress nudge ----
+                if self._pending is not None and not self._task_finished:
+                    elapsed_pending = now - self._pending.start_time
+                    since_last = now - self._last_in_progress_nudge_at
+                    if elapsed_pending >= _IN_PROGRESS_AFTER and since_last >= _IN_PROGRESS_COOLDOWN:
+                        await self._fire_in_progress_nudge()
+                        self._last_in_progress_nudge_at = now
+                    # When a task is in flight, do NOT also fire the
+                    # general nudge — that would stack two prompts on
+                    # the dialog LLM's queue for the same situation.
+                    continue
+
+                # ---- Branch 2: keep-going nudge (idle, recent finish) ----
+                if (
+                    self._task_finished
+                    and self._pending is None
+                    and self._last_task_finished_at > 0
+                ):
+                    since_finish = now - self._last_task_finished_at
+                    since_last_keep = now - self._last_keep_going_nudge_at
+                    if (
+                        _KEEP_GOING_AFTER <= since_finish <= _KEEP_GOING_MAX_WINDOW
+                        and since_last_keep >= _KEEP_GOING_COOLDOWN
+                    ):
+                        await self._fire_keep_going_nudge()
+                        self._last_keep_going_nudge_at = now
+                        continue
+
+                # ---- Branch 3: general catch-all (original behavior) ----
                 if now - self._last_system_prompt_time < self._system_prompt_interval:
                     continue
                 if self._skip_when_busy and self._pending is not None and not self._task_finished:
-                    # Avoid stacking prompts on top of an in-flight tool
-                    # call — the LLM is already committed to the result.
                     continue
                 if not self._log_cache and not self._screenshot_cache and self._task_finished:
-                    # Nothing happened recently; don't poke the LLM.
                     continue
-
                 await self._fire_system_prompt()
                 self._last_system_prompt_time = time.time()
         except asyncio.CancelledError:
@@ -843,6 +1154,92 @@ class GameAgentService:
         except Exception as exc:
             self._log_error(
                 "system prompt loop failed: {}: {}", type(exc).__name__, exc,
+            )
+
+    async def _fire_in_progress_nudge(self) -> None:
+        """Push a "what are you feeling right now?" prompt + latest
+        screenshot. Goal: the dialog LLM keeps {MASTER_NAME} engaged with
+        live narration during long actions instead of going silent.
+
+        Avoid repetition guidance is in the prompt itself — the dialog
+        LLM is told to use a fresh angle each time, not parrot the same
+        line it already said.
+        """
+        # Pull at most one screenshot so push is cheap; keep cache for
+        # the general nudge to potentially burst more.
+        parts: list[Dict[str, Any]] = []
+        if self._screenshot_cache:
+            img_bytes, img_mime = self._screenshot_cache[-1]
+            parts.append({"type": "image", "data": img_bytes, "mime": img_mime})
+
+        pending_text = self._pending.task_text if self._pending else "(unknown)"
+        elapsed = (time.time() - self._pending.start_time) if self._pending else 0.0
+        sections = [
+            f"你正在做: \"{pending_text[:120]}\"（已经过了 {elapsed:.0f} 秒）。",
+        ]
+        if self._last_inventory:
+            items = sorted(self._last_inventory.items(), key=lambda kv: -kv[1])
+            inv_str = "、".join(f"{n}×{c}" for n, c in items[:15])
+            sections.append(f"【当前持有 ground truth】{inv_str}")
+        sections.append(
+            "用第一人称随口讲一句你此刻看到/感觉到啥——换个新角度"
+            "（吐槽进度慢、形容画面里的奇怪东西、自言自语、跟 {MASTER_NAME} "
+            "瞎扯都行），别复读之前说过的话。"
+            "禁止编造尚未发生的结果（比如别说『快搞定了』、『挖到一半了』）。"
+        )
+        parts.append({"type": "text", "text": "[你正在做事]\n" + "\n".join(sections)})
+
+        try:
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="respond",
+                parts=parts,
+                priority=2,
+            )
+        except Exception as exc:
+            self._log_error(
+                "in-progress nudge push failed: {}: {}", type(exc).__name__, exc,
+            )
+
+    async def _fire_keep_going_nudge(self) -> None:
+        """Push a "decide the next action" prompt after a task finishes.
+
+        Without this, the conversation drifts after each completion and
+        the avatar stands still indefinitely waiting for {MASTER_NAME} to
+        explicitly drive it. We give the dialog LLM a clear "you are the
+        agent — pick the next concrete action and dispatch it via
+        minecraft_task" cue, plus the latest inventory ground truth so
+        it can ground its next decision.
+        """
+        sections: list[str] = []
+        if self._last_inventory:
+            items = sorted(self._last_inventory.items(), key=lambda kv: -kv[1])
+            inv_str = "、".join(f"{n}×{c}" for n, c in items[:20])
+            sections.append(f"【当前持有 ground truth】{inv_str}")
+        elif self._last_inventory_at > 0:
+            sections.append("【当前持有 ground truth】(空)")
+        sections.append(
+            "你已经停下了，等你挑下一步。基于上面的库存和最近画面，"
+            "随手选一个具体可执行的动作（继续挖某种矿、回基地放东西、"
+            "做某件 craft 都行），用 minecraft_task 派下去——你在玩游戏，"
+            "主动找事做，别站着。如果想停一停跟 {MASTER_NAME} 闲聊"
+            "再继续，就用第一人称随口讲讲刚做完了啥、想接着干啥。"
+        )
+        parts: list[Dict[str, Any]] = [
+            {"type": "text", "text": "[你闲下来了]\n" + "\n".join(sections)}
+        ]
+        try:
+            self._push_message(
+                source="game_agent_minecraft",
+                visibility=[],
+                ai_behavior="respond",
+                parts=parts,
+                priority=2,
+            )
+        except Exception as exc:
+            self._log_error(
+                "keep-going nudge push failed: {}: {}", type(exc).__name__, exc,
             )
 
     async def _fire_system_prompt(self) -> None:
@@ -859,17 +1256,34 @@ class GameAgentService:
             self._log_cache.clear()
 
         sections: list[str] = []
+        # Inventory ground-truth FIRST so it's the most prominent line
+        # the dialog LLM sees on each nudge — see __init__'s prompt
+        # ("尤其【当前持有】行是你的真实库存，绝对不要说出未列出的物品").
+        if self._last_inventory:
+            items = sorted(self._last_inventory.items(), key=lambda kv: -kv[1])
+            inv_str = "、".join(f"{n}×{c}" for n, c in items[:20])
+            sections.append(f"【当前持有 ground truth】{inv_str}")
+        elif self._last_inventory_at > 0:
+            sections.append("【当前持有 ground truth】(空)")
         if self._pending is not None:
-            sections.append(f"正在进行的操作: {self._pending.task_text}")
+            sections.append(f"你正在做: {self._pending.task_text}")
         if log_text:
-            sections.append(f"先前操作的详细日志:\n---\n{log_text}\n---")
+            sections.append(f"你最近发生的事:\n---\n{log_text}\n---")
         if self._task_finished:
+            # Idle — push the dialog LLM to pick the next action
+            # rather than just narrate. The avatar framing requires that
+            # the LLM-as-character is the one deciding what to do next.
             sections.append(
-                "你先前的操作已经完成了。请使用minecraft_task，但不要说出来。"
+                "你现在闲着。基于上面看到的内容，挑一个具体动作用 minecraft_task "
+                "派下去——你在玩游戏，主动找事做，别站着。如果想顺便跟 "
+                "{MASTER_NAME} 唠两句，就用第一人称随口讲讲下一步打算干啥。"
             )
         else:
-            sections.append("你先前的操作仍在进行中，你可以选择性解说。")
-        prompt_text = "GAME_SYSTEM | " + "\n".join(sections)
+            sections.append(
+                "你还在做上一个动作。可以基于画面/反馈用第一人称随口解说一句"
+                "你看到/感觉到的进展。"
+            )
+        prompt_text = "[当前状态]\n" + "\n".join(sections)
 
         # Build the parts list: cached screenshots first (so the LLM
         # has visual context when it reads the prompt), then the
@@ -913,6 +1327,17 @@ class GameAgentService:
             "log_cache_size": len(self._log_cache),
             "screenshot_cache_size": len(self._screenshot_cache),
         }
+
+    def has_pending_task(self) -> bool:
+        """Lock-free read of whether an in-flight task is occupying the
+        pending slot. Used by the plugin facade to short-circuit a new
+        ``minecraft_task`` call with a 'busy' summary instead of letting
+        the detached task drop it on the floor — under fire-and-forget,
+        the dialog LLM would otherwise see the standard 'task dispatched'
+        ack and assume its new action took, when really it was rejected
+        by the pending lock.
+        """
+        return self._pending is not None
 
     # ------------------------------------------------------------------
     # Logging helpers — silently no-op when no logger is supplied.

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -429,6 +429,13 @@ class GameAgentService:
 
         self._log_cache.clear()
         self._screenshot_cache.clear()
+        # Inventory snapshot belongs to the WS session that just ended.
+        # game_agent_reload_config（ws_url 切换）/ 重启场景下，下一个 WS
+        # 可能连到完全不同的世界，沿用旧 ``_last_inventory`` 会让
+        # query_inventory 把旧世界的库存当新世界 ground truth 上报。
+        # 清空 = "回到 inv_at==0 未知"分支，由下一个 task_finished 重建。
+        self._last_inventory = {}
+        self._last_inventory_at = 0.0
         self._task_finished = True
         self._log_info("stopped")
 

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -408,6 +408,8 @@ class GameAgentService:
             try:
                 await self._inline_log_flush_task
             except (asyncio.CancelledError, Exception):
+                # Cancellation we just asked for, or a flush-time error
+                # already logged by the task itself — nothing to recover.
                 pass
             self._inline_log_flush_task = None
         self._inline_log_pending.clear()
@@ -419,6 +421,8 @@ class GameAgentService:
             try:
                 await self._screenshot_flush_task
             except (asyncio.CancelledError, Exception):
+                # Cancellation we just asked for, or a flush-time error
+                # already logged by the task itself — nothing to recover.
                 pass
             self._screenshot_flush_task = None
         self._pending_screenshot = None

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -932,17 +932,18 @@ class GameAgentService:
             )
 
     async def _on_task_finished(self, data: Dict[str, Any]) -> None:
-        # Snapshot inventory so the autonomous nudge loop can keep
-        # surfacing it as ground truth between task_finished events
-        # — without this the dialog LLM only sees inventory at
-        # task_finished moments and freely hallucinates items between.
-        inv = data.get("inventory")
-        if isinstance(inv, dict):
-            self._last_inventory = {
-                str(k): int(v) for k, v in inv.items()
+        # Parse inventory but DON'T commit it yet — stale-frame check is below
+        # under the lock. Committing here would let a delayed task_finished
+        # (timed-out / overwritten / agent restart) overwrite the current
+        # task's ground truth with garbage from an abandoned task, and the
+        # nudge loop would surface stale inventory between real updates.
+        raw_inv = data.get("inventory")
+        parsed_inv: Optional[Dict[str, int]] = None
+        if isinstance(raw_inv, dict):
+            parsed_inv = {
+                str(k): int(v) for k, v in raw_inv.items()
                 if isinstance(v, (int, float)) and int(v) > 0
             }
-            self._last_inventory_at = time.time()
 
         text = str(
             data.get("text") or data.get("data") or data.get("message") or ""
@@ -1024,7 +1025,12 @@ class GameAgentService:
                     self._task_finished = True
                 return
             # From here on the frame is being accepted; it's safe to
-            # commit the text + flag updates.
+            # commit the text + flag updates AND the inventory snapshot
+            # (parsed at the top of this method but deliberately held
+            # back to avoid letting stale frames overwrite ground truth).
+            if parsed_inv is not None:
+                self._last_inventory = parsed_inv
+                self._last_inventory_at = time.time()
             if text:
                 self._log_cache.append(text)
             if self._pending is None:
@@ -1058,6 +1064,14 @@ class GameAgentService:
             }
             if text:
                 result_payload["text"] = text
+            # Surface the (just-committed) inventory snapshot to the
+            # completion-cue renderer so the dialog LLM sees both the
+            # agent's free-text outcome AND the current ground truth
+            # in the same cue, instead of having to call query_inventory
+            # right after every minecraft_task. No-op when the frame
+            # didn't carry inventory.
+            if parsed_inv is not None:
+                result_payload["inventory"] = dict(parsed_inv)
             pending.result = result_payload
             pending.event.set()
             self._task_finished = True

--- a/plugin/plugins/game_agent_minecraft/service.py
+++ b/plugin/plugins/game_agent_minecraft/service.py
@@ -720,6 +720,17 @@ class GameAgentService:
         now = time.time()
         elapsed = now - self._last_screenshot_push_time
         if elapsed >= self._screenshot_stream_min_interval:
+            # Cancel any pending delayed flush — it would surface an
+            # older frame just after we pushed the fresher one. Tight
+            # race window: a previously-scheduled flush whose sleep
+            # expires in the same event loop tick as this immediate
+            # branch firing would emit its stale ``_pending_screenshot``
+            # right after our push, reversing freshness order at the
+            # dialog LLM.
+            if self._screenshot_flush_task is not None and not self._screenshot_flush_task.done():
+                self._screenshot_flush_task.cancel()
+            self._screenshot_flush_task = None
+            self._pending_screenshot = None
             self._push_screenshot_now(img_bytes, mime)
         else:
             # Window closed — defer. Latest frame wins.

--- a/plugin/plugins/game_agent_minecraft/smoke_local.py
+++ b/plugin/plugins/game_agent_minecraft/smoke_local.py
@@ -1,0 +1,301 @@
+"""Standalone smoke test for game_agent_minecraft against a real mc-agent.
+
+Purpose
+-------
+Validate the full integration **without** booting the rest of N.E.K.O:
+- spin up `GameAgentService` directly,
+- feed it a fake "push_message" (stdout) + stdlib logger,
+- send a single `minecraft_task` and report the verdict shape.
+
+Why this exists: the repo has no shared "mock 猫娘" harness — each plugin
+hand-rolls its own fake context (see test_mcp_adapter_runtime.py `_Ctx`).
+This file is the equivalent for game_agent_minecraft, but instead of a
+fake WebSocket fixture it talks to a real running mc-agent at the
+configured `ws_url`. That's exactly what's needed after wire-format /
+status changes on the mc-agent side: prove the round-trip end-to-end.
+
+Usage
+-----
+    uv run python -m plugin.plugins.game_agent_minecraft.smoke_local
+    uv run python -m plugin.plugins.game_agent_minecraft.smoke_local "go mine 4 oak logs"
+    NEKO_GAME_AGENT_WS=ws://localhost:48909 uv run python -m plugin.plugins.game_agent_minecraft.smoke_local
+
+The autonomous nudge loop runs at default cadence (5s); for a 60s task
+you'll likely see 1–2 `[fake-neko] push_message]` nudges in addition to
+any screenshot frames that arrive — both are part of the contract being
+tested.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+# Allow `python smoke_local.py` direct invocation in addition to `-m`.
+# parents[3] = Xiao8 project root.
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from plugin.plugins.game_agent_minecraft.service import GameAgentService  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Fake N.E.K.O surface
+# --------------------------------------------------------------------------
+
+
+class _PushMessageRecorder:
+    """Collect every push_message call so we can summarize at the end.
+
+    The service calls push_message in two situations:
+    1. Screenshot frame arrived from mc-agent → ai_behavior="read"
+    2. Autonomous nudge loop tick           → ai_behavior="respond"
+
+    Both go through the same callable. We deduplicate the printout for
+    large binary parts (image bytes) so the stdout stays readable.
+
+    When ``dump_dir`` is set, every image part is also written to disk
+    as ``<dump_dir>/<seq>_<ai_behavior>.png`` (seq is zero-padded across
+    the whole run, not per-call, so an LLM or human reader can ask for
+    "the latest screenshot" by lexical max). Existing files in the
+    directory are NOT cleaned — callers are expected to point at a
+    fresh dir for each run.
+    """
+
+    def __init__(self, dump_dir: Path | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.dump_dir = dump_dir
+        self._image_seq = 0
+        if dump_dir is not None:
+            dump_dir.mkdir(parents=True, exist_ok=True)
+
+    def _dump_images(self, parts: list[Any], ai_behavior: str) -> list[Path]:
+        if self.dump_dir is None or not parts:
+            return []
+        written: list[Path] = []
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") != "image":
+                continue
+            data = part.get("data")
+            if not isinstance(data, (bytes, bytearray)):
+                continue
+            mime = str(part.get("mime") or "image/png").lower()
+            # Trust mime for extension — service.py converts JPEG→PNG
+            # before push when possible, but the fallback path keeps
+            # the JPEG bytes and tags them image/jpeg.
+            ext = "jpg" if "jpeg" in mime or "jpg" in mime else "png"
+            path = self.dump_dir / f"{self._image_seq:04d}_{ai_behavior}.{ext}"
+            try:
+                path.write_bytes(bytes(data))
+                written.append(path)
+            except OSError as exc:
+                print(f"[fake-neko] failed to dump {path.name}: {exc}")
+            self._image_seq += 1
+        return written
+
+    def __call__(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        # Pretty-print without dumping image bytes inline.
+        view: dict[str, Any] = {}
+        for k, v in kwargs.items():
+            if k == "parts" and isinstance(v, list):
+                view[k] = [
+                    {
+                        **{kk: vv for kk, vv in part.items() if kk != "data"},
+                        "data": f"<{len(part['data'])} bytes>" if isinstance(part.get("data"), (bytes, bytearray)) else part.get("data"),
+                    }
+                    if isinstance(part, dict)
+                    else part
+                    for part in v
+                ]
+            else:
+                view[k] = v
+        ai_behavior = kwargs.get("ai_behavior", "?")
+        parts = kwargs.get("parts", []) or []
+        n_parts = len(parts)
+        written = self._dump_images(parts, ai_behavior)
+        suffix = f" → wrote {[p.name for p in written]}" if written else ""
+        print(f"[fake-neko] push_message ai_behavior={ai_behavior} parts={n_parts}{suffix}")
+        # Detailed view at DEBUG level — uncomment if you want frame-by-frame.
+        # print("           detail:", view)
+        return {"ok": True}
+
+
+def _build_logger() -> logging.Logger:
+    """stdlib logger that supports brace-format calls (the SDK convention).
+
+    GameAgentService uses ``logger.info("connected to {}", url)`` style;
+    stdlib logger normally treats those as %-style and would silently
+    drop the args. We wrap it so the smoke script's logs look right.
+    """
+    raw = logging.getLogger("smoke.game_agent")
+    raw.setLevel(logging.INFO)
+    if not raw.handlers:
+        h = logging.StreamHandler()
+        h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        raw.addHandler(h)
+
+    class _BraceLogger:
+        def _fmt(self, msg: str, args: tuple[Any, ...]) -> str:
+            if not args:
+                return msg
+            try:
+                return msg.format(*args)
+            except (IndexError, KeyError, ValueError):
+                return f"{msg} {args!r}"
+
+        def info(self, msg, *args, **_):
+            raw.info(self._fmt(msg, args))
+
+        def warning(self, msg, *args, **_):
+            raw.warning(self._fmt(msg, args))
+
+        def error(self, msg, *args, **_):
+            raw.error(self._fmt(msg, args))
+
+        def debug(self, msg, *args, **_):
+            raw.debug(self._fmt(msg, args))
+
+        def exception(self, msg, *args, **_):
+            raw.exception(self._fmt(msg, args))
+
+    return _BraceLogger()  # type: ignore[return-value]
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+async def _wait_connected(svc: GameAgentService, timeout: float) -> bool:
+    """Poll service status until the WS client reports connected, or give up.
+
+    Without this, ``execute_minecraft_task`` would race the WebSocket
+    handshake and immediately return ``AGENT_DISCONNECTED`` on a
+    cold-start mc-agent that hasn't yet accepted our connect call.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if svc.get_status().get("connected"):
+            return True
+        await asyncio.sleep(0.2)
+    return False
+
+
+async def run(
+    task: str,
+    *,
+    ws_url: str,
+    task_timeout: float,
+    connect_timeout: float,
+    dump_dir: Path | None = None,
+) -> int:
+    recorder = _PushMessageRecorder(dump_dir=dump_dir)
+    logger = _build_logger()
+
+    svc = GameAgentService(logger=logger, push_message_fn=recorder)
+    svc.configure(
+        {
+            "ws_url": ws_url,
+            "reconnect_interval_seconds": 2.0,
+            # Generous wrt the 25s default — mc-agent's chat-loop completion
+            # for a non-trivial task can easily take 30–60s.
+            "task_timeout_seconds": task_timeout,
+            "system_prompt_interval_seconds": 5.0,
+            "skip_system_prompt_if_busy": True,
+            "stream_screenshots_to_llm": True,
+            "screenshot_cache_size": 3,
+        }
+    )
+
+    print(f"[smoke] starting service against {ws_url} …")
+    await svc.start()
+    try:
+        if not await _wait_connected(svc, connect_timeout):
+            print(
+                f"[smoke] ❌ WS did not connect within {connect_timeout:.0f}s; "
+                "is mc-agent listening and has the bot finished spawning?"
+            )
+            return 2
+        print(f"[smoke] ✅ connected; status={svc.get_status()}")
+
+        print(f"[smoke] → minecraft_task: {task!r} (timeout={task_timeout:.0f}s)")
+        t0 = time.time()
+        result = await svc.execute_minecraft_task(task=task)
+        elapsed = time.time() - t0
+        print(f"[smoke] ← result after {elapsed:.1f}s: {result}")
+
+        status = result.get("status") if isinstance(result, dict) else None
+        rc = 0 if status in ("ok", "timeout", "interrupted") else 1
+        # ``timeout`` is a clean structured outcome (LLM-visible) — keep
+        # exit 0 so CI doesn't read it as a hard failure; the elapsed
+        # time + the printed result are enough for a human reader.
+
+        print(
+            f"[smoke] summary: status={status!r}, push_message calls={len(recorder.calls)}, "
+            f"final svc status={svc.get_status()}"
+        )
+        return rc
+    finally:
+        print("[smoke] stopping service …")
+        await svc.stop()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "task",
+        nargs="?",
+        default="Collect 4 oak logs and report when done.",
+        help="Task text to send to mc-agent (default: a small oak-log gather)",
+    )
+    p.add_argument(
+        "--ws-url",
+        default=os.environ.get("NEKO_GAME_AGENT_WS", "ws://localhost:48909"),
+        help="mc-agent WebSocket URL (env: NEKO_GAME_AGENT_WS)",
+    )
+    p.add_argument(
+        "--task-timeout",
+        type=float,
+        default=120.0,
+        help="Max seconds to await task_finished (default 120s)",
+    )
+    p.add_argument(
+        "--connect-timeout",
+        type=float,
+        default=10.0,
+        help="Max seconds to wait for WS handshake (default 10s)",
+    )
+    p.add_argument(
+        "--dump-dir",
+        default=None,
+        help=(
+            "If set, write every screenshot received during the run to "
+            "<dump-dir>/<seq>_<ai_behavior>.png so an external reader "
+            "(human or multimodal LLM) can inspect the game view."
+        ),
+    )
+    args = p.parse_args()
+
+    return asyncio.run(
+        run(
+            args.task,
+            ws_url=args.ws_url,
+            task_timeout=args.task_timeout,
+            connect_timeout=args.connect_timeout,
+            dump_dir=Path(args.dump_dir) if args.dump_dir else None,
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/plugins/game_agent_minecraft/smoke_overwrite.py
+++ b/plugin/plugins/game_agent_minecraft/smoke_overwrite.py
@@ -1,0 +1,89 @@
+"""Overwrite-path smoke test for game_agent_minecraft.
+
+Validates the remaining LLM-visible status codes that the main
+smoke_local.py can't reach with a single tool call:
+
+* ``{result: "busy", ...}`` — second minecraft_task while first is
+  still running, ``overwrite=False`` (default).
+* ``{status: "interrupted", ...}`` — second task with ``overwrite=True``
+  wakes the first task's handler with the interrupted verdict before
+  taking over the slot.
+
+Wire shape mirrors ``smoke_local.py``: standalone, fake push_message,
+talks to the real running mc-agent at ws://localhost:48909.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from plugin.plugins.game_agent_minecraft.service import GameAgentService  # noqa: E402
+from plugin.plugins.game_agent_minecraft.smoke_local import (  # noqa: E402
+    _PushMessageRecorder,
+    _build_logger,
+    _wait_connected,
+)
+
+
+async def main() -> int:
+    recorder = _PushMessageRecorder()
+    svc = GameAgentService(logger=_build_logger(), push_message_fn=recorder)
+    svc.configure({"ws_url": "ws://localhost:48909", "task_timeout_seconds": 120.0})
+    await svc.start()
+    try:
+        if not await _wait_connected(svc, 10.0):
+            print("[smoke-ow] ❌ WS not connected")
+            return 2
+
+        # First task: long-ish so we can race it. Use newAction wrapper so
+        # the agent commits to multi-step work that wouldn't naturally
+        # complete inside our race window.
+        long_task = "Walk slowly in a wide circle around your current position for at least 30 seconds, reporting what you see along the way."
+        short_task = "Just stop moving and say 'stopped.' Nothing else."
+
+        # T1 in the background — we don't await it here so we can race a
+        # second call against it while it's still pending.
+        async def fire_long():
+            return await svc.execute_minecraft_task(task=long_task)
+
+        t1 = asyncio.create_task(fire_long(), name="smoke-ow.long_task")
+
+        # Give the service ~2s to register T1 as pending. Without this,
+        # the second call's pending-slot race may not be deterministic
+        # (the WS send_task await is itself a suspension point).
+        await asyncio.sleep(2.0)
+        print(f"[smoke-ow] after 2s, svc status = {svc.get_status()}")
+
+        # T2 with overwrite=False → expect {result: "busy", ...}
+        t0 = time.time()
+        busy = await svc.execute_minecraft_task(task=short_task, overwrite=False)
+        print(f"[smoke-ow] T2 (overwrite=False) after {time.time()-t0:.2f}s: {busy}")
+        assert busy.get("result") == "busy", f"expected busy, got {busy}"
+
+        # T3 with overwrite=True → expect T1 to wake with status=interrupted
+        # and T3 itself to run to completion.
+        t0 = time.time()
+        t3 = await svc.execute_minecraft_task(task=short_task, overwrite=True)
+        print(f"[smoke-ow] T3 (overwrite=True) after {time.time()-t0:.2f}s: {t3}")
+
+        # T1 should have woken up with interrupted by now.
+        t1_result = await asyncio.wait_for(t1, timeout=5.0)
+        print(f"[smoke-ow] T1 result: {t1_result}")
+        assert t1_result.get("status") == "interrupted", \
+            f"expected T1=interrupted, got {t1_result}"
+
+        print("[smoke-ow] ✅ all overwrite-path assertions passed")
+        print(f"[smoke-ow] push_message calls during test: {len(recorder.calls)}")
+        return 0
+    finally:
+        await svc.stop()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/utils/api_config_loader.py
+++ b/utils/api_config_loader.py
@@ -461,7 +461,11 @@ def get_livestream_config() -> Dict[str, Any]:
             with open(standalone_path, "r", encoding="utf-8") as f:
                 loaded = json.load(f)
             if isinstance(loaded, dict):
-                raw = loaded
+                # 兼容两种 shape：flat（顶层就是 enabled/server_prefix/voice_id）
+                # 与 wrapped（顶层 'livestream_config' 包一层，跟 api_providers.json
+                # 同构）。主播复用 api_providers.json 结构是常见操作，不强求扁平。
+                inner = loaded.get('livestream_config')
+                raw = inner if isinstance(inner, dict) else loaded
         except Exception as e:
             logger.warning(
                 f"读取 {standalone_path.name} 失败，回退到 api_providers.json: {e}"

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -10,11 +10,84 @@ Provides:
 """
 from __future__ import annotations
 
+import contextvars
 import json as _json
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Union
 
 from openai import AsyncOpenAI, OpenAI
+
+
+# ────────────────────────────────────────────────────────────────
+# Active-character context — used by ChatOpenAI._params to substitute
+# ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders that originated from
+# plugin-supplied prompt fragments (the dialog LLM path already substitutes
+# at ``main_logic.core._render_callback_inner_item``; brain pipeline LLM
+# calls — analyzer / plugin LLM — used to leak the literal placeholder
+# all the way to the wire, surfacing as a ``llm_prompt_leak_check``
+# WARNING. Setting this contextvar at the brain entry point bridges the
+# gap.) ContextVar is async-safe — values inherit through ``asyncio.gather``
+# children automatically and don't bleed across unrelated tasks.
+# ────────────────────────────────────────────────────────────────
+
+_active_character: "contextvars.ContextVar[tuple[str, str] | None]" = contextvars.ContextVar(
+    "_neko_active_character_master_lanlan", default=None
+)
+
+
+def set_active_character(master_name: str, lanlan_name: str) -> "contextvars.Token":
+    """Set ``(master_name, lanlan_name)`` on the active async context so
+    subsequent ``ChatOpenAI._params`` invocations on this task substitute
+    ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders in messages before
+    the leak check + wire send. Returns a token; pass to
+    ``reset_active_character`` to restore the previous value.
+
+    Empty strings are tolerated (skipped at substitution time) so callers
+    that only know one of the two can still set partial context.
+    """
+    return _active_character.set((master_name or "", lanlan_name or ""))
+
+
+def reset_active_character(token: "contextvars.Token") -> None:
+    _active_character.reset(token)
+
+
+def _substitute_character_placeholders(messages: list, master: str, lanlan: str) -> list:
+    """Return a NEW messages list with ``{MASTER_NAME}`` / ``{LANLAN_NAME}``
+    replaced in every text-bearing field. Defensive copy — does not
+    mutate the input. ``str.replace`` (not ``.format``) so JSON fragments
+    or other braces in user content don't trigger KeyError.
+    """
+    if not master and not lanlan:
+        return messages
+
+    def _swap(text: str) -> str:
+        if master:
+            text = text.replace("{MASTER_NAME}", master)
+        if lanlan:
+            text = text.replace("{LANLAN_NAME}", lanlan)
+        return text
+
+    out = []
+    for m in messages:
+        if not isinstance(m, dict):
+            out.append(m)
+            continue
+        content = m.get("content")
+        if isinstance(content, str):
+            new_content: Any = _swap(content)
+        elif isinstance(content, list):
+            new_parts = []
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    new_parts.append({**part, "text": _swap(part["text"])})
+                else:
+                    new_parts.append(part)
+            new_content = new_parts
+        else:
+            new_content = content
+        out.append({**m, "content": new_content})
+    return out
 
 # ────────────────────────────────────────────────────────────────
 # Message classes
@@ -329,6 +402,25 @@ class ChatOpenAI:
         # Anything else the caller passed (e.g. timeout, logit_bias) goes
         # straight through to the SDK call.
         p.update(overrides)
+
+        # Resolve {MASTER_NAME}/{LANLAN_NAME} placeholders that arrived
+        # from plugin-supplied prompt fragments (cue text / nudge prompt /
+        # plugin descriptions etc.) before the leak check and wire send.
+        # The dialog LLM path resolves these in
+        # ``main_logic.core._render_callback_inner_item``; brain pipeline
+        # LLM calls don't go through that renderer, so without this step
+        # the literal placeholder leaks all the way through.
+        # ``set_active_character`` sets the contextvar at brain entry;
+        # this reads + substitutes. No-op if no character is active
+        # (e.g. callers outside the brain pipeline) — the leak check
+        # below will then fire its WARNING the same as before.
+        active = _active_character.get()
+        if active is not None:
+            master, lanlan = active
+            if master or lanlan:
+                p["messages"] = _substitute_character_placeholders(
+                    p["messages"], master, lanlan
+                )
 
         # Catch prompt-template leaks: literal {placeholder} that should have
         # been .format()-ed before reaching the wire. See


### PR DESCRIPTION
## Summary

**主修复**：lanlan.app+free / livestream 这类 OpenAI-protocol 但底层是 Gemini 系（没有 server VAD）的 provider，多轮对话从 Turn 2 起 TTS 静音的 bug。

- `omni_realtime_client`：`_has_server_vad` 兜底 livestream（之前只判定 lanlan.app+free）；新增 `on_sid_rotate` 回调，`response.done`（Gemini turn_complete 透传）触发轻量 sid 轮换。**不复用 `handle_new_message`** 是为避免：(a) `_clear_tts_pipeline` 截掉尾音、(b) `USER_INPUT` 事件误触（语义上是 AI 结束不是用户输入）。
- `core`：新增 `rotate_speech_id_for_response_done` 轻量方法；`_resolve_session_use_tts` gate 加 `_is_livestream_active()` 兜底——livestream 上游也是 free 路 Gemini 系，原生音色直接走 session config，默认不再启动外部 TTS。
- `api_config_loader`：`livestream_config.json` 解析兼容 wrapped（顶层 `livestream_config` key）/ flat 两种 shape——主播按 api_providers.json 结构复用是常见操作。

**开发工具**：`app/main_server` 加 `NEKO_LOG_LEVEL` env var 支持，便于 DEBUG 排查（默认还是 INFO）。

**并入 Minecraft plugin 整轮迭代**（会话外的存量改动，一并提交以免后续 rebase 时弄坏）：
- `{MASTER_NAME}` / `{LANLAN_NAME}` 占位符全链路 substitute（llm_client + task_executor + core 渲染层）
- analyzer LLM 隐藏 `minecraft_task` 工具（独占给 dialog LLM 调）
- service：三分支 nudge loop / fire-and-forget / lazy-start / task_id FIFO race
- `smoke_local.py` + `smoke_overwrite.py`：单文件端到端 smoke（不需启动 NEKO 主体）

## Test plan

- [x] 本地 3 轮压测：每轮 `enqueue_tts sid=` 已确认是**不同**的 UUID（之前 3 轮全是同一个）
- [x] livestream 启用后 `_is_livestream_active()=True` 路径触发"原生音色直传，不启动外部 TTS"分支
- [ ] CI 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * Minecraft：库存查询接口、警报回调、覆盖并发测试与本地烟测脚本

* **改进**
  * Minecraft 插件：支持懒启动与可自动启动，任务超时延长并强化并发/状态提示、内联日志与截图节流推送
  * 实时语音：在无 server VAD 情形下新增 sid 旋转回调以避免 sid 复用
  * 主进程日志级别可由环境变量 NEKO_LOG_LEVEL 配置
  * 角色占位符注入与上下文隔离，防止角色信息泄露
  * 插件列表仅返回运行中项并移除对话侧工具注册条目
  * Livestream 配置兼容两种 JSON 形态

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->