### PR TITLE
fix(galgame): validate context snapshot session restores

### DIFF
--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -2881,7 +2881,12 @@ class GalgamePlugin(NekoPluginBase):
     ) -> None:
         if self._cfg is None or not bool(getattr(self._cfg, "context_persist_enabled", False)):
             return
-        if bool(payload.get("degraded")):
+        if not isinstance(payload, dict):
+            return
+        fallback_used = bool(payload.get("fallback_used"))
+        if "fallback_used" not in payload:
+            fallback_used = bool(payload.get("degraded"))
+        if fallback_used:
             return
         game_id = str(context.get("game_id") or "").strip()
         session_id = str(context.get("session_id") or "").strip()
@@ -6349,7 +6354,11 @@ class GalgamePlugin(NekoPluginBase):
         local = self._snapshot_state(include_private_context=True)
         context = build_summarize_context(local, scene_id=scene_id.strip(), config=self._cfg)
         snapshot = context.get("current_snapshot") if isinstance(context.get("current_snapshot"), dict) else {}
-        if not list(context.get("recent_lines") or []) and not str(snapshot.get("text") or ""):
+        if (
+            not list(context.get("recent_lines") or [])
+            and not str(snapshot.get("text") or "")
+            and not str(context.get("context_snapshot_summary_seed") or "")
+        ):
             return Ok(
                 build_summarize_degraded_result(
                     context,

--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -2806,8 +2806,11 @@ class GalgamePlugin(NekoPluginBase):
     def _load_context_snapshot_for_game(self, current_game_id: str = "") -> dict[str, Any]:
         if self._cfg is None or not bool(getattr(self._cfg, "context_persist_enabled", False)):
             return {}
+        with self._state_lock:
+            current_session_id = str(self._state.active_session_id or "")
         snapshot = self._persist.load_context_snapshot(
             current_game_id=str(current_game_id or ""),
+            current_session_id=current_session_id,
             max_age_seconds=float(getattr(self._cfg, "context_persist_max_age_seconds", 3600.0)),
             require_game_id=bool(getattr(self._cfg, "context_persist_require_game_id", True)),
         )
@@ -2905,6 +2908,7 @@ class GalgamePlugin(NekoPluginBase):
         snapshot = {
             "scene_id": str(context.get("scene_id") or "").strip(),
             "game_id": game_id,
+            "session_id": session_id,
             "route_id": str(context.get("route_id") or "").strip(),
             "summary_seed": summary_seed,
             "stable_line_ids": stable_line_ids[-64:],
@@ -2928,6 +2932,7 @@ class GalgamePlugin(NekoPluginBase):
                 self.logger.warning(
                     "galgame context_snapshot persist skipped: stale summary context"
                 )
+                self._persist.clear_context_snapshot(snapshot)
                 return
             self._persist.persist_context_snapshot(snapshot)
             self._state.context_snapshot = json_copy(snapshot)

--- a/plugin/plugins/galgame_plugin/__init__.py
+++ b/plugin/plugins/galgame_plugin/__init__.py
@@ -2803,14 +2803,20 @@ class GalgamePlugin(NekoPluginBase):
 
         self._apply_config_overrides_from_store()
 
-    def _load_context_snapshot_for_game(self, current_game_id: str = "") -> dict[str, Any]:
+    def _load_context_snapshot_for_game(
+        self,
+        current_game_id: str = "",
+        *,
+        current_session_id: str | None = None,
+    ) -> dict[str, Any]:
         if self._cfg is None or not bool(getattr(self._cfg, "context_persist_enabled", False)):
             return {}
-        with self._state_lock:
-            current_session_id = str(self._state.active_session_id or "")
+        if current_session_id is None:
+            with self._state_lock:
+                current_session_id = str(self._state.active_session_id or "")
         snapshot = self._persist.load_context_snapshot(
             current_game_id=str(current_game_id or ""),
-            current_session_id=current_session_id,
+            current_session_id=str(current_session_id or ""),
             max_age_seconds=float(getattr(self._cfg, "context_persist_max_age_seconds", 3600.0)),
             require_game_id=bool(getattr(self._cfg, "context_persist_require_game_id", True)),
         )
@@ -2819,6 +2825,7 @@ class GalgamePlugin(NekoPluginBase):
     def _load_context_snapshot_for_state(self) -> dict[str, Any]:
         bound_game_id = str(self._state.bound_game_id or "")
         active_game_id = str(self._state.active_game_id or "")
+        active_session_id = str(self._state.active_session_id or "")
         require_game_id = bool(getattr(self._cfg, "context_persist_require_game_id", True))
         game_ids: list[str] = []
         for game_id in (bound_game_id, active_game_id):
@@ -2829,7 +2836,10 @@ class GalgamePlugin(NekoPluginBase):
         for game_id in game_ids:
             if require_game_id and not game_id:
                 continue
-            snapshot = self._load_context_snapshot_for_game(game_id)
+            snapshot = self._load_context_snapshot_for_game(
+                game_id,
+                current_session_id=active_session_id,
+            )
             if snapshot:
                 return snapshot
         return {}
@@ -2839,8 +2849,15 @@ class GalgamePlugin(NekoPluginBase):
         snapshot: object,
         *,
         current_game_id: str,
+        current_session_id: str = "",
     ) -> bool:
         if not isinstance(snapshot, dict) or not snapshot:
+            return True
+        normalized_session_id = str(current_session_id or "").strip()
+        if (
+            normalized_session_id
+            and str(snapshot.get("session_id") or "").strip() != normalized_session_id
+        ):
             return True
         if not bool(getattr(self._cfg, "context_persist_require_game_id", True)):
             return False
@@ -2863,9 +2880,9 @@ class GalgamePlugin(NekoPluginBase):
             if isinstance(latest_snapshot, dict)
             else {}
         )
-        if session_id:
-            return session_id == str(getattr(self._state, "active_session_id", "") or "")
         return (
+            (not session_id or session_id == str(getattr(self._state, "active_session_id", "") or ""))
+            and
             (not game_id or game_id == str(getattr(self._state, "active_game_id", "") or ""))
             and (
                 not snapshot["scene_id"]
@@ -4135,10 +4152,12 @@ class GalgamePlugin(NekoPluginBase):
         if self._context_snapshot_needs_reload(
             local.get("context_snapshot"),
             current_game_id=candidate.game_id,
+            current_session_id=session_id,
         ):
             local["context_snapshot"] = await asyncio.to_thread(
                 self._load_context_snapshot_for_game,
                 candidate.game_id,
+                current_session_id=session_id,
             )
 
         if warmup_needed:

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -571,66 +571,6 @@ def _split_context_line_budget(
     return stable_budget, observed_budget
 
 
-def _scene_context_windows(
-    history_lines: list[dict[str, Any]],
-    history_observed_lines: list[dict[str, Any]],
-    scene_id: str,
-    *,
-    line_limit: int,
-    extra_scene_ids: list[str] | None = None,
-    target_line: dict[str, Any] | None = None,
-    dialogue_only: bool = False,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
-    stable_candidates = _scene_lines(
-        history_lines,
-        scene_id,
-        limit=None,
-        extra_scene_ids=extra_scene_ids,
-    )
-    observed_candidates = _scene_lines(
-        history_observed_lines,
-        scene_id,
-        limit=None,
-        extra_scene_ids=extra_scene_ids,
-    )
-    if dialogue_only:
-        stable_candidates = _dialogue_context_lines(stable_candidates, limit=None)
-        observed_candidates = _dialogue_context_lines(observed_candidates, limit=None)
-    stable_budget, observed_budget = _split_context_line_budget(
-        len(stable_candidates),
-        len(observed_candidates),
-        line_limit,
-    )
-    stable_candidates = stable_candidates[-stable_budget:] if stable_budget else []
-    observed_candidates = observed_candidates[-observed_budget:] if observed_budget else []
-    tagged_stable = [
-        {**dict(item), "_context_source": "stable"}
-        for item in stable_candidates
-        if isinstance(item, dict)
-    ]
-    tagged_observed = [
-        {**dict(item), "_context_source": "observed"}
-        for item in observed_candidates
-        if isinstance(item, dict)
-    ]
-    recent_lines = _recency_ordered_context_lines(tagged_stable, tagged_observed)
-    if target_line is not None:
-        recent_lines = _append_unique_line(recent_lines, target_line, limit=line_limit)
-    else:
-        recent_lines = recent_lines[-line_limit:]
-    stable_lines = [
-        item for item in recent_lines if item.get("_context_source") == "stable"
-    ]
-    observed_lines = [
-        item for item in recent_lines if item.get("_context_source") == "observed"
-    ]
-    return (
-        _condense_context_lines(stable_lines, preserve_condensed_count=True),
-        _condense_context_lines(observed_lines, preserve_condensed_count=True),
-        _condense_context_lines(recent_lines),
-    )
-
-
 def _global_scene_context_window(
     history_lines: list[dict[str, Any]],
     history_observed_lines: list[dict[str, Any]],
@@ -1264,14 +1204,9 @@ def build_explain_context(
 
     scene_id = str(target_line.get("scene_id") or snapshot.get("scene_id") or "")
     route_id = str(target_line.get("route_id") or snapshot.get("route_id") or "")
-    history_lines = list(local_state.get("history_lines", []) or [])
-    history_observed_lines = list(local_state.get("history_observed_lines", []) or [])
-    min_limit, max_limit, target_tokens = _context_window_bounds(config)
-    line_limit = _compute_dynamic_line_limit(
-        _recency_ordered_context_lines(history_lines, history_observed_lines),
-        min_limit=min_limit,
-        max_limit=max_limit,
-        target_tokens=target_tokens,
+    history_lines, history_observed_lines, line_limit = _resolve_dynamic_line_limit(
+        local_state,
+        config,
     )
     stable_lines, observed_lines, scene_lines = _global_scene_context_window(
         history_lines,
@@ -1495,14 +1430,9 @@ def build_suggest_context(
     visible_choices = [sanitize_choice(item) for item in snapshot.get("choices", [])]
     scene_id = str(snapshot.get("scene_id") or "")
     route_id = str(snapshot.get("route_id") or "")
-    history_lines = list(local_state.get("history_lines", []) or [])
-    history_observed_lines = list(local_state.get("history_observed_lines", []) or [])
-    min_limit, max_limit, target_tokens = _context_window_bounds(config)
-    line_limit = _compute_dynamic_line_limit(
-        _recency_ordered_context_lines(history_lines, history_observed_lines),
-        min_limit=min_limit,
-        max_limit=max_limit,
-        target_tokens=target_tokens,
+    history_lines, history_observed_lines, line_limit = _resolve_dynamic_line_limit(
+        local_state,
+        config,
     )
     stable_lines, observed_lines, scene_lines = _global_scene_context_window(
         history_lines,

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -213,6 +213,22 @@ def _compute_dynamic_line_limit(
     return max(min_limit, min(max_limit, limit))
 
 
+def _resolve_dynamic_line_limit(
+    local_state: dict[str, Any],
+    config: GalgameLLMConfig | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
+    history_lines = list(local_state.get("history_lines", []) or [])
+    history_observed_lines = list(local_state.get("history_observed_lines", []) or [])
+    min_limit, max_limit, target_tokens = _context_window_bounds(config, max_floor=1)
+    line_limit = _compute_dynamic_line_limit(
+        _recency_ordered_context_lines(history_lines, history_observed_lines),
+        min_limit=min_limit,
+        max_limit=max_limit,
+        target_tokens=target_tokens,
+    )
+    return history_lines, history_observed_lines, line_limit
+
+
 def _recency_ordered_context_lines(
     stable_lines: list[dict[str, Any]],
     observed_lines: list[dict[str, Any]],
@@ -260,7 +276,7 @@ def _condense_run_key(line: dict[str, Any]) -> tuple[str, str, str, str, str]:
         str(line.get("speaker") or "").strip(),
         str(line.get("scene_id") or ""),
         str(line.get("route_id") or ""),
-        str(line.get("source") or ""),
+        str(line.get("_context_source") or line.get("source") or ""),
         str(line.get("stability") or ""),
     )
 
@@ -317,7 +333,7 @@ def _scene_lines(
     history_lines: list[dict[str, Any]],
     scene_id: str,
     *,
-    limit: int,
+    limit: int | None,
     extra_scene_ids: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     if scene_id:
@@ -331,6 +347,8 @@ def _scene_lines(
         ]
     else:
         items = [dict(item) for item in history_lines]
+    if limit is None:
+        return items
     return items[-limit:]
 
 
@@ -480,7 +498,11 @@ def _append_unique_line(
     return merged[-limit:]
 
 
-def _dialogue_context_lines(lines: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
+def _dialogue_context_lines(
+    lines: list[dict[str, Any]],
+    *,
+    limit: int | None,
+) -> list[dict[str, Any]]:
     deduped: dict[str, dict[str, Any]] = {}
     order: list[str] = []
     for item in lines:
@@ -493,7 +515,120 @@ def _dialogue_context_lines(lines: list[dict[str, Any]], *, limit: int) -> list[
         if key not in deduped:
             order.append(key)
         deduped[key] = normalized
-    return [deduped[key] for key in order][-limit:]
+    result = [deduped[key] for key in order]
+    if limit is None:
+        return result
+    return result[-limit:]
+
+
+def _strip_context_source(
+    lines: list[dict[str, Any]],
+    *,
+    preserve_condensed_count: bool = False,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            key: value
+            for key, value in item.items()
+            if key != "_context_source"
+            and key != "_condensed_line_ids"
+            and (preserve_condensed_count or key != "_condensed_count")
+        }
+        for item in lines
+    ]
+
+
+def _condense_context_lines(
+    lines: list[dict[str, Any]],
+    *,
+    preserve_condensed_count: bool = False,
+) -> list[dict[str, Any]]:
+    return _strip_context_source(
+        _condense_dialogue_batch(lines),
+        preserve_condensed_count=preserve_condensed_count,
+    )
+
+
+def _split_context_line_budget(
+    stable_count: int,
+    observed_count: int,
+    line_limit: int,
+) -> tuple[int, int]:
+    if line_limit <= 0:
+        return 0, 0
+    if stable_count <= 0:
+        return 0, line_limit
+    if observed_count <= 0:
+        return line_limit, 0
+    observed_budget = min(observed_count, max(1, line_limit // 3))
+    stable_budget = min(stable_count, max(1, line_limit - observed_budget))
+    remaining = max(0, line_limit - stable_budget - observed_budget)
+    if remaining:
+        observed_budget += min(remaining, max(0, observed_count - observed_budget))
+    remaining = max(0, line_limit - stable_budget - observed_budget)
+    if remaining:
+        stable_budget += min(remaining, max(0, stable_count - stable_budget))
+    return stable_budget, observed_budget
+
+
+def _scene_context_windows(
+    history_lines: list[dict[str, Any]],
+    history_observed_lines: list[dict[str, Any]],
+    scene_id: str,
+    *,
+    line_limit: int,
+    extra_scene_ids: list[str] | None = None,
+    target_line: dict[str, Any] | None = None,
+    dialogue_only: bool = False,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    stable_candidates = _scene_lines(
+        history_lines,
+        scene_id,
+        limit=None,
+        extra_scene_ids=extra_scene_ids,
+    )
+    observed_candidates = _scene_lines(
+        history_observed_lines,
+        scene_id,
+        limit=None,
+        extra_scene_ids=extra_scene_ids,
+    )
+    if dialogue_only:
+        stable_candidates = _dialogue_context_lines(stable_candidates, limit=None)
+        observed_candidates = _dialogue_context_lines(observed_candidates, limit=None)
+    stable_budget, observed_budget = _split_context_line_budget(
+        len(stable_candidates),
+        len(observed_candidates),
+        line_limit,
+    )
+    stable_candidates = stable_candidates[-stable_budget:] if stable_budget else []
+    observed_candidates = observed_candidates[-observed_budget:] if observed_budget else []
+    tagged_stable = [
+        {**dict(item), "_context_source": "stable"}
+        for item in stable_candidates
+        if isinstance(item, dict)
+    ]
+    tagged_observed = [
+        {**dict(item), "_context_source": "observed"}
+        for item in observed_candidates
+        if isinstance(item, dict)
+    ]
+    recent_lines = _recency_ordered_context_lines(tagged_stable, tagged_observed)
+    if target_line is not None:
+        recent_lines = _append_unique_line(recent_lines, target_line, limit=line_limit)
+    else:
+        recent_lines = recent_lines[-line_limit:]
+    stable_lines = [
+        item for item in recent_lines if item.get("_context_source") == "stable"
+    ]
+    observed_lines = [
+        item for item in recent_lines if item.get("_context_source") == "observed"
+    ]
+    return (
+        _condense_context_lines(stable_lines, preserve_condensed_count=True),
+        _condense_context_lines(observed_lines, preserve_condensed_count=True),
+        _condense_context_lines(recent_lines),
+    )
 
 
 def _global_scene_context_window(
@@ -535,6 +670,21 @@ def _global_scene_context_window(
             observed_candidates,
             limit=max(line_limit, len(observed_candidates)) if line_importance_enabled else line_limit,
         )
+        if (
+            not line_importance_enabled
+            and target_line is None
+            and not any(
+                str(item.get("ts") or "").strip()
+                for item in [*stable_candidates, *observed_candidates]
+            )
+        ):
+            stable_budget, observed_budget = _split_context_line_budget(
+                len(stable_candidates),
+                len(observed_candidates),
+                line_limit,
+            )
+            stable_candidates = stable_candidates[-stable_budget:] if stable_budget else []
+            observed_candidates = observed_candidates[-observed_budget:] if observed_budget else []
 
     ordered_lines = _recency_ordered_context_lines(stable_candidates, observed_candidates)
     if target_line is not None:
@@ -572,6 +722,15 @@ def _global_scene_context_window(
         {key: value for key, value in item.items() if key != "_context_source"}
         for item in recent_lines
     ]
+    should_condense_dialogue = dialogue_only and not any(
+        str(item.get("ts") or "").strip() for item in recent_lines
+    )
+    if should_condense_dialogue:
+        return (
+            _condense_context_lines(stable_lines, preserve_condensed_count=True),
+            _condense_context_lines(observed_lines, preserve_condensed_count=True),
+            _condense_context_lines(scene_lines),
+        )
     return stable_lines, observed_lines, scene_lines
 
 
@@ -1046,6 +1205,35 @@ def _snapshot_for_stable_summary_seed(
     return seed_snapshot
 
 
+def _restored_context_snapshot_summary_seed(
+    local_state: dict[str, Any],
+    *,
+    scene_id: str,
+    route_id: str,
+) -> str:
+    restored = local_state.get("context_snapshot")
+    if not isinstance(restored, dict):
+        return ""
+    summary_seed = str(restored.get("summary_seed") or "").strip()
+    if not summary_seed:
+        return ""
+
+    active_game_id = str(local_state.get("active_game_id") or "").strip()
+    restored_game_id = str(restored.get("game_id") or "").strip()
+    if restored_game_id and active_game_id and restored_game_id != active_game_id:
+        return ""
+
+    restored_scene_id = str(restored.get("scene_id") or "").strip()
+    if restored_scene_id and scene_id and restored_scene_id != scene_id:
+        return ""
+
+    restored_route_id = str(restored.get("route_id") or "").strip()
+    if restored_route_id and route_id and restored_route_id != route_id:
+        return ""
+
+    return summary_seed
+
+
 def build_explain_context(
     local_state: dict[str, Any],
     *,
@@ -1198,6 +1386,11 @@ def build_summarize_context(
     restored = restored if isinstance(restored, dict) else {}
     restored_scene_id = str(restored.get("scene_id") or "").strip()
     restored_route_id = str(restored.get("route_id") or "").strip()
+    live_route_id = str(
+        snapshot.get("route_id")
+        or (effective_line or {}).get("route_id")
+        or ""
+    ).strip()
     effective_scene_id = scene_id or str(
         snapshot.get("scene_id")
         or (effective_line or {}).get("scene_id")
@@ -1206,19 +1399,13 @@ def build_summarize_context(
     )
     restored_scene_matches = not restored_scene_id or restored_scene_id == effective_scene_id
     route_id = str(
-        snapshot.get("route_id")
-        or (effective_line or {}).get("route_id")
+        live_route_id
         or (restored_route_id if restored_scene_matches else "")
         or ""
     )
-    history_lines = list(local_state.get("history_lines", []) or [])
-    history_observed_lines = list(local_state.get("history_observed_lines", []) or [])
-    min_limit, max_limit, target_tokens = _context_window_bounds(config)
-    line_limit = _compute_dynamic_line_limit(
-        _recency_ordered_context_lines(history_lines, history_observed_lines),
-        min_limit=min_limit,
-        max_limit=max_limit,
-        target_tokens=target_tokens,
+    history_lines, history_observed_lines, line_limit = _resolve_dynamic_line_limit(
+        local_state,
+        config,
     )
     stable_lines, observed_lines, scene_lines = _global_scene_context_window(
         history_lines,
@@ -1247,30 +1434,38 @@ def build_summarize_context(
         line_id=str(snapshot.get("line_id") or ""),
         choice_ids=[str(choice.get("choice_id") or "") for choice in selected_choices],
     )
-    summary_seed = _cumulative_scene_summary(
+    restored_summary_seed = _restored_context_snapshot_summary_seed(
+        local_state,
         scene_id=effective_scene_id,
         route_id=route_id,
-        lines=stable_lines,
-        selected_choices=selected_choices,
-        snapshot=_snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines),
-        previous_summary=_previous_summary_from_state(
-            local_state,
-            current_game_id=str(local_state.get("active_game_id") or ""),
-            current_scene_id=effective_scene_id,
-            current_route_id=route_id,
-        ),
-        mode=_summary_mode(config),
-        llm_refined_summary=_llm_refined_summary_from_state(local_state),
-        llm_trigger_lines=int(
-            getattr(config, "context_cumulative_llm_trigger_lines", 30) or 30
-        ),
-        trigger_line_count=_scene_history_dialogue_line_count(
-            history_lines,
-            history_observed_lines,
+    )
+    if restored_summary_seed and not stable_lines:
+        summary_seed = restored_summary_seed
+    else:
+        summary_seed = _cumulative_scene_summary(
             scene_id=effective_scene_id,
             route_id=route_id,
-        ),
-    )
+            lines=stable_lines,
+            selected_choices=selected_choices,
+            snapshot=_snapshot_for_stable_summary_seed(local_state, snapshot, stable_lines),
+            previous_summary=restored_summary_seed or _previous_summary_from_state(
+                local_state,
+                current_game_id=str(local_state.get("active_game_id") or ""),
+                current_scene_id=effective_scene_id,
+                current_route_id=route_id,
+            ),
+            mode=_summary_mode(config),
+            llm_refined_summary=_llm_refined_summary_from_state(local_state),
+            llm_trigger_lines=int(
+                getattr(config, "context_cumulative_llm_trigger_lines", 30) or 30
+            ),
+            trigger_line_count=_scene_history_dialogue_line_count(
+                history_lines,
+                history_observed_lines,
+                scene_id=effective_scene_id,
+                route_id=route_id,
+            ),
+        )
     return {
         "game_id": str(local_state.get("active_game_id") or ""),
         "session_id": str(local_state.get("active_session_id") or ""),
@@ -1283,6 +1478,7 @@ def build_summarize_context(
         "recent_choices": selected_choices,
         "scene_summary_seed": summary_seed,
         "restored_context_snapshot": restored_context_snapshot,
+        "context_snapshot_summary_seed": restored_summary_seed,
         "input_source": input_source,
         "input_degraded": input_degraded,
         "degraded_reasons": degraded_reasons,

--- a/plugin/plugins/galgame_plugin/context_builder.py
+++ b/plugin/plugins/galgame_plugin/context_builder.py
@@ -1228,7 +1228,8 @@ def _restored_context_snapshot_summary_seed(
         return ""
 
     restored_route_id = str(restored.get("route_id") or "").strip()
-    if restored_route_id and route_id and restored_route_id != route_id:
+    normalized_route_id = str(route_id or "").strip()
+    if restored_route_id and restored_route_id != normalized_route_id:
         return ""
 
     return summary_seed
@@ -1385,7 +1386,6 @@ def build_summarize_context(
     restored = local_state.get("context_snapshot")
     restored = restored if isinstance(restored, dict) else {}
     restored_scene_id = str(restored.get("scene_id") or "").strip()
-    restored_route_id = str(restored.get("route_id") or "").strip()
     live_route_id = str(
         snapshot.get("route_id")
         or (effective_line or {}).get("route_id")
@@ -1397,12 +1397,7 @@ def build_summarize_context(
         or restored_scene_id
         or ""
     )
-    restored_scene_matches = not restored_scene_id or restored_scene_id == effective_scene_id
-    route_id = str(
-        live_route_id
-        or (restored_route_id if restored_scene_matches else "")
-        or ""
-    )
+    route_id = live_route_id
     history_lines, history_observed_lines, line_limit = _resolve_dynamic_line_limit(
         local_state,
         config,

--- a/plugin/plugins/galgame_plugin/game_llm_agent.py
+++ b/plugin/plugins/galgame_plugin/game_llm_agent.py
@@ -5533,8 +5533,8 @@ class GameLLMAgent:
         history_lines = list(shared.get("history_lines") or [])
         history_observed_lines = list(shared.get("history_observed_lines") or [])
         effective_line = resolve_effective_current_line(shared) or {}
-        scene_id = str(snapshot.get("scene_id") or effective_line.get("scene_id") or "")
-        route_id = str(snapshot.get("route_id") or effective_line.get("route_id") or "")
+        scene_id = str(effective_line.get("scene_id") or snapshot.get("scene_id") or "")
+        route_id = str(effective_line.get("route_id") or snapshot.get("route_id") or "")
         min_limit, max_limit, target_tokens = _context_window_bounds(
             self._context_config,
             min_floor=16,

--- a/plugin/plugins/galgame_plugin/game_llm_agent.py
+++ b/plugin/plugins/galgame_plugin/game_llm_agent.py
@@ -5532,32 +5532,30 @@ class GameLLMAgent:
         status = self._compute_status(shared)
         history_lines = list(shared.get("history_lines") or [])
         history_observed_lines = list(shared.get("history_observed_lines") or [])
-        scene_id = str(snapshot.get("scene_id") or "")
-        route_id = str(snapshot.get("route_id") or "")
+        effective_line = resolve_effective_current_line(shared) or {}
+        scene_id = str(snapshot.get("scene_id") or effective_line.get("scene_id") or "")
+        route_id = str(snapshot.get("route_id") or effective_line.get("route_id") or "")
         min_limit, max_limit, target_tokens = _context_window_bounds(
             self._context_config,
             min_floor=16,
             max_floor=16,
         )
+        def _matches_reply_scene(item: dict[str, Any]) -> bool:
+            item_scene_id = str(item.get("scene_id") or "")
+            if scene_id and item_scene_id and item_scene_id != scene_id:
+                return False
+            item_route_id = str(item.get("route_id") or "")
+            return not route_id or not item_route_id or item_route_id == route_id
+
         tagged_stable = [
             {**dict(item), "_reply_context_source": "stable"}
             for item in history_lines
-            if isinstance(item, dict)
-            and (
-                not scene_id
-                or not str(item.get("scene_id") or "")
-                or str(item.get("scene_id") or "") == scene_id
-            )
+            if isinstance(item, dict) and _matches_reply_scene(item)
         ]
         tagged_observed = [
             {**dict(item), "_reply_context_source": "observed"}
             for item in history_observed_lines
-            if isinstance(item, dict)
-            and (
-                not scene_id
-                or not str(item.get("scene_id") or "")
-                or str(item.get("scene_id") or "") == scene_id
-            )
+            if isinstance(item, dict) and _matches_reply_scene(item)
         ]
         recency_ordered = _recency_ordered_context_lines(tagged_stable, tagged_observed)
         line_limit = _compute_dynamic_line_limit(
@@ -5567,7 +5565,7 @@ class GameLLMAgent:
             target_tokens=target_tokens,
         )
         history_choices = list(shared.get("history_choices") or [])
-        scene_id = str(snapshot.get("scene_id") or "")
+
         if line_limit > 0:
             merged_recent = recency_ordered[-line_limit:]
             stable_lines = [
@@ -5605,11 +5603,7 @@ class GameLLMAgent:
                 (index, dict(item))
                 for index, item in enumerate(history_choices)
                 if isinstance(item, dict)
-                and (
-                    not scene_id
-                    or not str(item.get("scene_id") or "")
-                    or str(item.get("scene_id") or "") == scene_id
-                )
+                and _matches_reply_scene(item)
             ]
             choices_without_line_id = [
                 (index, item)
@@ -5634,7 +5628,6 @@ class GameLLMAgent:
             observed_lines = []
             recent_choices = []
             recent_lines = []
-        effective_line = resolve_effective_current_line(shared) or {}
         latest_line = ""
         if effective_line.get("text"):
             speaker = str(effective_line.get("speaker") or "Narration")

--- a/plugin/plugins/galgame_plugin/game_llm_agent.py
+++ b/plugin/plugins/galgame_plugin/game_llm_agent.py
@@ -900,6 +900,21 @@ class GameLLMAgent:
             f"{int(stable_line_count or 0)}"
         )
 
+    @staticmethod
+    def _context_line_count(lines: object) -> int:
+        if not isinstance(lines, list):
+            return 0
+        total = 0
+        for item in lines:
+            if isinstance(item, dict):
+                try:
+                    total += max(1, int(item.get("_condensed_count") or 1))
+                except (TypeError, ValueError):
+                    total += 1
+            else:
+                total += 1
+        return total
+
     def _summary_task_status_debug(self) -> dict[str, Any]:
         pending: list[dict[str, Any]] = []
         for task in list(self._summary_tasks):
@@ -5552,6 +5567,7 @@ class GameLLMAgent:
             target_tokens=target_tokens,
         )
         history_choices = list(shared.get("history_choices") or [])
+        scene_id = str(snapshot.get("scene_id") or "")
         if line_limit > 0:
             merged_recent = recency_ordered[-line_limit:]
             stable_lines = [

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -107,6 +107,23 @@ def _hash_line(line: Any) -> str:
     )
 
 
+def _near_match_current_line(context: dict[str, Any]) -> dict[str, Any]:
+    current_line = context.get("current_line")
+    if isinstance(current_line, dict):
+        return current_line
+    current_snapshot = context.get("current_snapshot")
+    if isinstance(current_snapshot, dict):
+        return current_snapshot
+    top_level = {
+        "speaker": context.get("speaker"),
+        "text": context.get("text"),
+        "line_id": context.get("line_id"),
+    }
+    if any(str(value or "") for value in top_level.values()):
+        return top_level
+    return {}
+
+
 def _line_similarity_signature(observed_lines: Any) -> str:
     if not isinstance(observed_lines, list) or not observed_lines:
         return ""
@@ -439,7 +456,7 @@ class LLMGateway:
     def _build_near_match_meta(context: dict[str, Any]) -> dict[str, Any]:
         return {
             "_stable_lines_hash": _hash_stable_lines(context.get("stable_lines")),
-            "_current_line_hash": _hash_line(context.get("current_line")),
+            "_current_line_hash": _hash_line(_near_match_current_line(context)),
             "_observed_signature": _line_similarity_signature(
                 context.get("observed_lines")
             ),
@@ -454,7 +471,7 @@ class LLMGateway:
         cached_stable_hash = meta.get("_stable_lines_hash")
         if cached_stable_hash != _hash_stable_lines(context.get("stable_lines")):
             return False
-        if meta.get("_current_line_hash") != _hash_line(context.get("current_line")):
+        if meta.get("_current_line_hash") != _hash_line(_near_match_current_line(context)):
             return False
         cached_observed = str(meta.get("_observed_signature") or "")
         current_observed = _line_similarity_signature(context.get("observed_lines"))

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 from enum import Enum
 import json
 import logging
-from difflib import SequenceMatcher
 import time
 from typing import Any, Callable, Mapping
 
@@ -25,26 +24,20 @@ from .service import (
 _EXPLAIN_EVIDENCE_TYPES = frozenset({"current_line", "history_line", "choice"})
 _KEY_POINT_TYPES = frozenset({"plot", "emotion", "decision", "reveal", "objective"})
 _LLM_RESPONSE_CACHE_MAX_ITEMS = 50
-_LLM_NEAR_MATCH_CACHE_MAX_ITEMS = 50
 _LLM_PROVIDER_BACKOFF_SECONDS = 2.0
 _LLM_PROVIDER_BACKOFF_CATEGORIES = frozenset({"busy", "gateway_unavailable", "timeout"})
-_REPEAT_GUARD_MAX_ITEMS = 8
-_NEAR_MATCH_SUPPORTED_OPERATIONS = frozenset(
-    {"explain_line", "summarize_scene", "scene_summary"}
-)
-_NEAR_MATCH_OBSERVED_SIGNATURE_MAX_CHARS = 4000
-_NEAR_MATCH_EXCLUDED_KEYS = frozenset(
+
+_NEAR_MATCH_OPERATIONS = frozenset({"explain_line", "summarize_scene", "scene_summary"})
+_NEAR_MATCH_EXCLUDED_FIELDS = frozenset(
     {
-        "current_snapshot",
+        "input_degraded",
         "degraded_reasons",
         "diagnostic",
-        "input_degraded",
-        "observed_lines",
-        "recent_lines",
         "screen_context",
+        "current_snapshot",
     }
 )
-_OBSERVED_SIMILARITY_THRESHOLD = 0.85
+_NEAR_MATCH_OBSERVED_SIMILARITY_THRESHOLD = 0.85
 
 
 class PluginErrorCategory(str, Enum):
@@ -91,161 +84,59 @@ def _stable_json_fingerprint(value: Any) -> str:
     )
 
 
-def _normalize_observed_text(value: object) -> str:
-    return " ".join(str(value or "").strip().lower().split())
+def _normalize_observed_text(value: Any) -> str:
+    return " ".join(str(value or "").split())
 
 
-def _line_similarity_signature(line: Any) -> str:
-    if isinstance(line, Mapping):
-        speaker = _normalize_observed_text(line.get("speaker"))
-        text = _normalize_observed_text(line.get("text"))
-        line_id = _normalize_observed_text(line.get("line_id"))
-        return f"{line_id}|{speaker}|{text}"
-    return _normalize_observed_text(line)
-
-
-def _ngrams(value: str, *, n: int = 3) -> set[str]:
-    if not value:
-        return set()
-    if len(value) < n:
-        return {value}
-    return {value[index:index + n] for index in range(len(value) - n + 1)}
-
-
-def _jaccard_similarity(left: str, right: str) -> float:
-    if left == right:
-        return 1.0
-    left_set = _ngrams(left)
-    right_set = _ngrams(right)
-    if not left_set or not right_set:
-        return 0.0
-    return len(left_set & right_set) / len(left_set | right_set)
-
-
-def _observed_similarity(left: list[str], right: list[str]) -> float:
-    if not left and not right:
-        return 1.0
-    if not left or not right:
-        return 0.0
-    left_text = "\n".join(left)[:_NEAR_MATCH_OBSERVED_SIGNATURE_MAX_CHARS]
-    right_text = "\n".join(right)[:_NEAR_MATCH_OBSERVED_SIGNATURE_MAX_CHARS]
-    return _jaccard_similarity(left_text, right_text)
+def _hash_stable_lines(stable_lines: Any) -> str:
+    if not isinstance(stable_lines, list):
+        return ""
+    cleaned = [
+        {"speaker": ln.get("speaker"), "text": ln.get("text")}
+        for ln in stable_lines
+        if isinstance(ln, dict)
+    ]
+    return _stable_json_fingerprint(cleaned)
 
 
 def _hash_line(line: Any) -> str:
-    if not isinstance(line, Mapping):
+    if not isinstance(line, dict):
         return ""
     return _stable_json_fingerprint(
-        {
-            "line_id": str(line.get("line_id") or ""),
-            "speaker": str(line.get("speaker") or ""),
-            "text": str(line.get("text") or ""),
-            "scene_id": str(line.get("scene_id") or ""),
-            "route_id": str(line.get("route_id") or ""),
-        }
+        {"speaker": line.get("speaker"), "text": line.get("text")}
     )
 
 
-def _hash_stable_lines(lines: Any) -> str:
-    if not isinstance(lines, list):
-        return _stable_json_fingerprint([])
-    return _stable_json_fingerprint([_hash_line(item) for item in lines if isinstance(item, Mapping)])
+def _line_similarity_signature(observed_lines: Any) -> str:
+    if not isinstance(observed_lines, list) or not observed_lines:
+        return ""
+    normalized: list[str] = []
+    for ln in observed_lines:
+        if not isinstance(ln, dict):
+            continue
+        speaker = _normalize_observed_text(ln.get("speaker"))
+        text = _normalize_observed_text(ln.get("text"))
+        if not speaker and not text:
+            continue
+        normalized.append(f"{speaker}\n{text}" if speaker else text)
+    if not normalized:
+        return ""
+    return "\n".join(normalized)
 
 
-def _context_lines(context: dict[str, Any], key: str) -> list[Any]:
-    value = context.get(key)
-    if isinstance(value, list):
-        return value
-    public_context = context.get("public_context")
-    if isinstance(public_context, Mapping):
-        value = public_context.get(key)
-        if isinstance(value, list):
-            return value
-    return []
-
-
-def _current_line_for_near_match(context: dict[str, Any]) -> dict[str, Any]:
-    if str(context.get("line_id") or "") or str(context.get("text") or ""):
-        return {
-            "line_id": str(context.get("line_id") or ""),
-            "speaker": str(context.get("speaker") or ""),
-            "text": str(context.get("text") or ""),
-            "scene_id": str(context.get("scene_id") or ""),
-            "route_id": str(context.get("route_id") or ""),
-        }
-    for key in ("current_line", "current_snapshot"):
-        value = context.get(key)
-        if isinstance(value, Mapping):
-            return dict(value)
-    public_context = context.get("public_context")
-    if isinstance(public_context, Mapping):
-        value = public_context.get("current_line")
-        if isinstance(value, Mapping):
-            return dict(value)
-    return {}
-
-
-def _near_match_context_value(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {
-            str(key): _near_match_context_value(item)
-            for key, item in value.items()
-            if str(key) not in _NEAR_MATCH_EXCLUDED_KEYS
-        }
-    if isinstance(value, (list, tuple)):
-        return [_near_match_context_value(item) for item in value]
-    return value
-
-
-def _response_similarity(left: Any, right: Any) -> float:
-    left_fingerprint = _stable_json_fingerprint(left)
-    right_fingerprint = _stable_json_fingerprint(right)
-    if left_fingerprint == right_fingerprint:
+def _observed_similarity(cached_sig: str, current_sig: str) -> float:
+    if cached_sig == current_sig:
         return 1.0
-
-    def _response_text(value: Any, fingerprint: str) -> str:
-        if isinstance(value, Mapping):
-            text = str(value.get("reply") or value.get("result") or "").strip()
-            if text:
-                return " ".join(text.lower().split())
-        return " ".join(fingerprint.lower().split())
-
-    left_text = _response_text(left, left_fingerprint)
-    right_text = _response_text(right, right_fingerprint)
-    if not left_text or not right_text:
+    if not cached_sig or not current_sig:
         return 0.0
-    return SequenceMatcher(None, left_text, right_text).ratio()
-
-
-class ResponseRepeatGuard:
-    def __init__(self, *, max_items: int = _REPEAT_GUARD_MAX_ITEMS) -> None:
-        self._max_items = max(1, int(max_items))
-        self._recent: list[dict[str, Any]] = []
-
-    def clear(self) -> None:
-        self._recent.clear()
-
-    def is_repeat(self, response: dict[str, Any], *, threshold: float) -> bool:
-        threshold = max(0.0, min(float(threshold), 1.0))
-        fingerprint = _stable_json_fingerprint(response)
-        for item in self._recent:
-            if fingerprint == str(item.get("fingerprint") or ""):
-                return True
-            previous = item.get("response")
-            if _response_similarity(response, previous) >= threshold:
-                return True
-        return False
-
-    def record(self, response: dict[str, Any]) -> None:
-        payload = _json_payload_copy(response)
-        self._recent.append(
-            {
-                "fingerprint": _stable_json_fingerprint(payload),
-                "response": payload,
-            }
-        )
-        if len(self._recent) > self._max_items:
-            del self._recent[: len(self._recent) - self._max_items]
+    n = 3
+    if len(cached_sig) < n or len(current_sig) < n:
+        return 0.0
+    set_a = {cached_sig[i : i + n] for i in range(len(cached_sig) - n + 1)}
+    set_b = {current_sig[i : i + n] for i in range(len(current_sig) - n + 1)}
+    if not set_a or not set_b:
+        return 0.0
+    return len(set_a & set_b) / len(set_a | set_b)
 
 
 class LLMGateway:
@@ -259,36 +150,28 @@ class LLMGateway:
         self._inflight: dict[str, asyncio.Task[dict[str, Any]]] = {}
         self._cache: OrderedDict[str, tuple[float, dict[str, Any], dict[str, Any]]] = OrderedDict()
         self._near_match_cache: OrderedDict[
-            str,
-            tuple[float, dict[str, Any], dict[str, Any], dict[str, Any]],
+            str, tuple[float, dict[str, Any], dict[str, Any], dict[str, Any]]
         ] = OrderedDict()
         self._provider_backoff: dict[tuple[str, str], tuple[float, str]] = {}
         self._active_calls = 0
         self._context_metrics: ContextMetricsCollector | None = None
-        self._repeat_guard = ResponseRepeatGuard()
 
     def update_config(self, config) -> None:
         old_cache_config_fingerprint = self._cache_config_fingerprint()
-        old_near_match_config_fingerprint = self._near_match_config_fingerprint()
-        old_repeat_config_fingerprint = self._repeat_config_fingerprint()
+        old_cache_policy_fingerprint = self._cache_policy_fingerprint()
+        old_near_match_enabled = self._near_match_enabled()
         self._config = config
         if not self._metrics_enabled():
             self._context_metrics = None
         if hasattr(self._backend, "_config"):
             self._backend._config = config
-        cache_config_changed = (
+        if (
             self._cache_config_fingerprint() != old_cache_config_fingerprint
-        )
-        near_match_config_changed = (
-            self._near_match_config_fingerprint()
-            != old_near_match_config_fingerprint
-        )
-        if cache_config_changed:
+            or self._cache_policy_fingerprint() != old_cache_policy_fingerprint
+            or self._near_match_enabled() != old_near_match_enabled
+        ):
             self._cache.clear()
-        if cache_config_changed or near_match_config_changed:
             self._near_match_cache.clear()
-        if self._repeat_config_fingerprint() != old_repeat_config_fingerprint:
-            self._repeat_guard.clear()
 
     @property
     def context_metrics(self) -> ContextMetricsCollector | None:
@@ -347,7 +230,6 @@ class LLMGateway:
             self._cache.clear()
             self._near_match_cache.clear()
             self._provider_backoff.clear()
-            self._repeat_guard.clear()
             self._active_calls = 0
         for task in tasks:
             task.cancel()
@@ -419,8 +301,6 @@ class LLMGateway:
         wait_task: asyncio.Task[dict[str, Any]] | None = None
         cached_payload: dict[str, Any] | None = None
         cached_prompt_metadata: dict[str, Any] | None = None
-        near_match_key = self._near_match_fingerprint(operation, context)
-        near_match_meta = self._build_near_match_meta(context)
 
         async with self._lock:
             cached = self._cache.get(fingerprint)
@@ -431,19 +311,17 @@ class LLMGateway:
             elif cached is not None:
                 self._cache.pop(fingerprint, None)
 
-            if cached_payload is None:
-                if near_match_key:
-                    near_cached = self._near_match_cache.get(near_match_key)
+            if cached_payload is None and self._near_match_enabled():
+                near_key = self._near_match_fingerprint(operation, context)
+                if near_key is not None:
+                    near_cached = self._near_match_cache.get(near_key)
                     if near_cached is not None and near_cached[0] > now:
-                        if self._validate_near_match(
-                            near_cached[3],
-                            near_match_meta,
-                        ):
-                            self._near_match_cache.move_to_end(near_match_key)
+                        if self._validate_near_match(near_cached[3], context):
+                            self._near_match_cache.move_to_end(near_key)
                             cached_payload = near_cached[1]
                             cached_prompt_metadata = near_cached[2]
                     elif near_cached is not None:
-                        self._near_match_cache.pop(near_match_key, None)
+                        self._near_match_cache.pop(near_key, None)
 
             if cached_payload is None:
                 backoff = self._active_provider_backoff_locked(provider_key, now=now)
@@ -485,6 +363,103 @@ class LLMGateway:
             return _json_payload_copy(await wait_task)
         except asyncio.CancelledError:
             return degraded("cancelled: llm request was cancelled")
+
+    def _ttl_for_operation(self, operation: str) -> float:
+        default_ttl = self._safe_float(
+            getattr(self._config, "llm_request_cache_ttl_seconds", 2.0), 2.0
+        )
+        if operation in {"summarize_scene", "scene_summary"}:
+            return self._safe_float(
+                getattr(self._config, "llm_scene_summary_cache_ttl_seconds", default_ttl),
+                default_ttl,
+            )
+        if operation == "explain_line":
+            return self._safe_float(
+                getattr(self._config, "llm_explain_cache_ttl_seconds", default_ttl),
+                default_ttl,
+            )
+        if operation == "suggest_choice":
+            return self._safe_float(
+                getattr(self._config, "llm_choice_cache_ttl_seconds", default_ttl),
+                default_ttl,
+            )
+        return default_ttl
+
+    @staticmethod
+    def _safe_float(value: Any, fallback: float) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return max(0.0, float(fallback))
+        return max(0.0, parsed)
+
+    def _near_match_enabled(self) -> bool:
+        return bool(getattr(self._config, "llm_near_match_cache_enabled", False))
+
+    def _near_match_ttl(self) -> float:
+        default_ttl = self._ttl_for_operation("explain_line")
+        return self._safe_float(
+            getattr(self._config, "llm_near_match_cache_ttl_seconds", default_ttl),
+            default_ttl,
+        )
+
+    def _cache_policy_fingerprint(self) -> str:
+        return _stable_json_fingerprint(
+            {
+                "request": self._ttl_for_operation(""),
+                "explain": self._ttl_for_operation("explain_line"),
+                "choice": self._ttl_for_operation("suggest_choice"),
+                "scene_summary": self._ttl_for_operation("scene_summary"),
+                "near_match": self._near_match_ttl(),
+            }
+        )
+
+    def _near_match_fingerprint(
+        self, operation: str, context: dict[str, Any]
+    ) -> str | None:
+        if operation not in _NEAR_MATCH_OPERATIONS:
+            return None
+        if not isinstance(context, dict):
+            return None
+        stable = {
+            key: value
+            for key, value in context.items()
+            if key not in _NEAR_MATCH_EXCLUDED_FIELDS
+            and key not in {"observed_lines", "stable_lines", "current_line"}
+        }
+        meta = self._build_near_match_meta(context)
+        stable["__stable_lines_hash__"] = meta["_stable_lines_hash"]
+        stable["__current_line_hash__"] = meta["_current_line_hash"]
+        return (
+            f"near:{operation}:{self._cache_config_fingerprint()}:"
+            f"{_stable_json_fingerprint(stable)}"
+        )
+
+    @staticmethod
+    def _build_near_match_meta(context: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "_stable_lines_hash": _hash_stable_lines(context.get("stable_lines")),
+            "_current_line_hash": _hash_line(context.get("current_line")),
+            "_observed_signature": _line_similarity_signature(
+                context.get("observed_lines")
+            ),
+        }
+
+    @staticmethod
+    def _validate_near_match(
+        meta: dict[str, Any], context: dict[str, Any]
+    ) -> bool:
+        if not isinstance(meta, dict) or not isinstance(context, dict):
+            return False
+        cached_stable_hash = meta.get("_stable_lines_hash")
+        if cached_stable_hash != _hash_stable_lines(context.get("stable_lines")):
+            return False
+        if meta.get("_current_line_hash") != _hash_line(context.get("current_line")):
+            return False
+        cached_observed = str(meta.get("_observed_signature") or "")
+        current_observed = _line_similarity_signature(context.get("observed_lines"))
+        similarity = _observed_similarity(cached_observed, current_observed)
+        return similarity >= _NEAR_MATCH_OBSERVED_SIMILARITY_THRESHOLD
 
     def _cache_config_fingerprint(self) -> str:
         mode = str(
@@ -552,76 +527,6 @@ class LLMGateway:
             f"{_stable_json_fingerprint(context)}"
         )
 
-    def _near_match_fingerprint(
-        self,
-        operation: str,
-        context: dict[str, Any],
-    ) -> str | None:
-        if operation not in _NEAR_MATCH_SUPPORTED_OPERATIONS:
-            return None
-        if not bool(getattr(self._config, "llm_near_match_cache_enabled", False)):
-            return None
-        context_view = _near_match_context_value(context)
-        return f"{operation}:{_stable_json_fingerprint(context_view)}"
-
-    @staticmethod
-    def _build_near_match_meta(context: dict[str, Any]) -> dict[str, Any]:
-        observed_lines = _context_lines(context, "observed_lines")
-        return {
-            "stable_hash": _hash_stable_lines(_context_lines(context, "stable_lines")),
-            "current_line_hash": _hash_line(_current_line_for_near_match(context)),
-            "observed_signature": [
-                _line_similarity_signature(item)
-                for item in observed_lines
-                if _line_similarity_signature(item)
-            ],
-        }
-
-    @staticmethod
-    def _validate_near_match(
-        cached_meta: dict[str, Any],
-        current_meta: dict[str, Any],
-    ) -> bool:
-        if not cached_meta or not current_meta:
-            return False
-        if str(cached_meta.get("stable_hash") or "") != str(
-            current_meta.get("stable_hash") or ""
-        ):
-            return False
-        if str(cached_meta.get("current_line_hash") or "") != str(
-            current_meta.get("current_line_hash") or ""
-        ):
-            return False
-        cached_observed = cached_meta.get("observed_signature")
-        current_observed = current_meta.get("observed_signature")
-        if not isinstance(cached_observed, list) or not isinstance(current_observed, list):
-            return False
-        return _observed_similarity(
-            [str(item) for item in cached_observed],
-            [str(item) for item in current_observed],
-        ) >= _OBSERVED_SIMILARITY_THRESHOLD
-
-    def _ttl_for_operation(self, operation: str) -> float:
-        if operation == "explain_line":
-            return self._safe_config_float("llm_explain_cache_ttl_seconds", 8.0)
-        if operation in {"scene_summary", "summarize_scene"}:
-            return self._safe_config_float("llm_scene_summary_cache_ttl_seconds", 10.0)
-        if operation == "suggest_choice":
-            return self._safe_config_float("llm_choice_cache_ttl_seconds", 4.0)
-        return self._safe_config_float("llm_request_cache_ttl_seconds", 2.0)
-
-    def _near_match_ttl(self) -> float:
-        if not bool(getattr(self._config, "llm_near_match_cache_enabled", False)):
-            return 0.0
-        return self._safe_config_float("llm_near_match_cache_ttl_seconds", 15.0)
-
-    def _safe_config_float(self, name: str, fallback: float) -> float:
-        try:
-            value = float(getattr(self._config, name, fallback))
-        except (TypeError, ValueError):
-            value = fallback
-        return max(0.0, value)
-
     async def _perform_call(
         self,
         *,
@@ -641,19 +546,19 @@ class LLMGateway:
                 validate=validate,
                 degraded=degraded,
             )
-            result = await self._maybe_retry_repeated_response(
-                operation=operation,
-                context=context,
-                result=result,
-                validate=validate,
-                degraded=degraded,
-            )
             prompt_metadata = self._consume_backend_prompt_metadata()
             total_time_ms = (time.monotonic() - start_time) * 1000.0
             ttl = self._ttl_for_operation(operation)
-            near_match_ttl = self._near_match_ttl()
-            near_match_key = self._near_match_fingerprint(operation, context)
-            near_match_meta = self._build_near_match_meta(context)
+            store_near_match = (
+                self._near_match_enabled()
+                and operation in _NEAR_MATCH_OPERATIONS
+                and not result.get("degraded")
+            )
+            near_match_key: str | None = None
+            near_match_ttl = 0.0
+            if store_near_match:
+                near_match_key = self._near_match_fingerprint(operation, context)
+                near_match_ttl = self._near_match_ttl()
             async with self._lock:
                 self._update_provider_backoff_locked(
                     provider_key,
@@ -670,18 +575,18 @@ class LLMGateway:
                     while len(self._cache) > _LLM_RESPONSE_CACHE_MAX_ITEMS:
                         self._cache.popitem(last=False)
                 if (
-                    near_match_key
+                    store_near_match
+                    and near_match_key is not None
                     and near_match_ttl > 0
-                    and not result.get("degraded")
                 ):
                     self._near_match_cache[near_match_key] = (
                         time.monotonic() + near_match_ttl,
                         _json_payload_copy(result),
                         dict(prompt_metadata),
-                        dict(near_match_meta),
+                        self._build_near_match_meta(context),
                     )
                     self._near_match_cache.move_to_end(near_match_key)
-                    while len(self._near_match_cache) > _LLM_NEAR_MATCH_CACHE_MAX_ITEMS:
+                    while len(self._near_match_cache) > _LLM_RESPONSE_CACHE_MAX_ITEMS:
                         self._near_match_cache.popitem(last=False)
             self._record_context_metric(
                 operation=operation,
@@ -695,46 +600,6 @@ class LLMGateway:
             async with self._lock:
                 self._inflight.pop(fingerprint, None)
                 self._active_calls = max(0, self._active_calls - 1)
-
-    async def _maybe_retry_repeated_response(
-        self,
-        *,
-        operation: str,
-        context: dict[str, Any],
-        result: dict[str, Any],
-        validate: Callable[[dict[str, Any]], dict[str, Any]],
-        degraded: Callable[[str], dict[str, Any]],
-    ) -> dict[str, Any]:
-        if operation != "agent_reply":
-            return result
-        if not bool(getattr(self._config, "llm_repeat_detection_enabled", False)):
-            return result
-        if bool(result.get("degraded")):
-            return result
-        try:
-            threshold = float(getattr(self._config, "llm_repeat_similarity_threshold", 0.85))
-        except (TypeError, ValueError):
-            threshold = 0.85
-        threshold = max(0.0, min(threshold, 1.0))
-        if not self._repeat_guard.is_repeat(result, threshold=threshold):
-            self._repeat_guard.record(result)
-            return result
-
-        retry_context = _json_payload_copy(context)
-        retry_context["_anti_repeat_instruction"] = (
-            "The previous agent reply was too similar to a recent reply. "
-            "Answer using the current public_context, avoid repeating the same wording, "
-            "and add only facts supported by context."
-        )
-        retry = await self._call_target(
-            operation=operation,
-            context=retry_context,
-            validate=validate,
-            degraded=degraded,
-        )
-        final = result if bool(retry.get("degraded")) else retry
-        self._repeat_guard.record(final)
-        return final
 
     def _consume_backend_prompt_metadata(self) -> dict[str, Any]:
         consume = getattr(self._backend, "consume_prompt_metadata", None)

--- a/plugin/plugins/galgame_plugin/llm_gateway.py
+++ b/plugin/plugins/galgame_plugin/llm_gateway.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import OrderedDict
+from difflib import SequenceMatcher
 from enum import Enum
 import json
 import logging
@@ -26,6 +27,7 @@ _KEY_POINT_TYPES = frozenset({"plot", "emotion", "decision", "reveal", "objectiv
 _LLM_RESPONSE_CACHE_MAX_ITEMS = 50
 _LLM_PROVIDER_BACKOFF_SECONDS = 2.0
 _LLM_PROVIDER_BACKOFF_CATEGORIES = frozenset({"busy", "gateway_unavailable", "timeout"})
+_REPEAT_GUARD_MAX_ITEMS = 8
 
 _NEAR_MATCH_OPERATIONS = frozenset({"explain_line", "summarize_scene", "scene_summary"})
 _NEAR_MATCH_EXCLUDED_FIELDS = frozenset(
@@ -156,6 +158,56 @@ def _observed_similarity(cached_sig: str, current_sig: str) -> float:
     return len(set_a & set_b) / len(set_a | set_b)
 
 
+def _response_similarity(left: Any, right: Any) -> float:
+    left_fingerprint = _stable_json_fingerprint(left)
+    right_fingerprint = _stable_json_fingerprint(right)
+    if left_fingerprint == right_fingerprint:
+        return 1.0
+
+    def _response_text(value: Any, fingerprint: str) -> str:
+        if isinstance(value, Mapping):
+            text = str(value.get("reply") or value.get("result") or "").strip()
+            if text:
+                return " ".join(text.lower().split())
+        return " ".join(fingerprint.lower().split())
+
+    left_text = _response_text(left, left_fingerprint)
+    right_text = _response_text(right, right_fingerprint)
+    if not left_text or not right_text:
+        return 0.0
+    return SequenceMatcher(None, left_text, right_text).ratio()
+
+
+class ResponseRepeatGuard:
+    def __init__(self, *, max_items: int = _REPEAT_GUARD_MAX_ITEMS) -> None:
+        self._max_items = max(1, int(max_items))
+        self._recent: list[dict[str, Any]] = []
+
+    def clear(self) -> None:
+        self._recent.clear()
+
+    def is_repeat(self, response: dict[str, Any], *, threshold: float) -> bool:
+        threshold = max(0.0, min(float(threshold), 1.0))
+        fingerprint = _stable_json_fingerprint(response)
+        for item in self._recent:
+            if fingerprint == str(item.get("fingerprint") or ""):
+                return True
+            if _response_similarity(response, item.get("response")) >= threshold:
+                return True
+        return False
+
+    def record(self, response: dict[str, Any]) -> None:
+        payload = _json_payload_copy(response)
+        self._recent.append(
+            {
+                "fingerprint": _stable_json_fingerprint(payload),
+                "response": payload,
+            }
+        )
+        if len(self._recent) > self._max_items:
+            del self._recent[: len(self._recent) - self._max_items]
+
+
 class LLMGateway:
     def __init__(self, plugin, logger, config, *, backend: GalgameLLMBackend | None = None) -> None:
         self._plugin = plugin
@@ -172,11 +224,13 @@ class LLMGateway:
         self._provider_backoff: dict[tuple[str, str], tuple[float, str]] = {}
         self._active_calls = 0
         self._context_metrics: ContextMetricsCollector | None = None
+        self._repeat_guard = ResponseRepeatGuard()
 
     def update_config(self, config) -> None:
         old_cache_config_fingerprint = self._cache_config_fingerprint()
         old_cache_policy_fingerprint = self._cache_policy_fingerprint()
         old_near_match_enabled = self._near_match_enabled()
+        old_repeat_config_fingerprint = self._repeat_config_fingerprint()
         self._config = config
         if not self._metrics_enabled():
             self._context_metrics = None
@@ -189,6 +243,8 @@ class LLMGateway:
         ):
             self._cache.clear()
             self._near_match_cache.clear()
+        if self._repeat_config_fingerprint() != old_repeat_config_fingerprint:
+            self._repeat_guard.clear()
 
     @property
     def context_metrics(self) -> ContextMetricsCollector | None:
@@ -247,6 +303,7 @@ class LLMGateway:
             self._cache.clear()
             self._near_match_cache.clear()
             self._provider_backoff.clear()
+            self._repeat_guard.clear()
             self._active_calls = 0
         for task in tasks:
             task.cancel()
@@ -563,6 +620,13 @@ class LLMGateway:
                 validate=validate,
                 degraded=degraded,
             )
+            result = await self._maybe_retry_repeated_response(
+                operation=operation,
+                context=context,
+                result=result,
+                validate=validate,
+                degraded=degraded,
+            )
             prompt_metadata = self._consume_backend_prompt_metadata()
             total_time_ms = (time.monotonic() - start_time) * 1000.0
             ttl = self._ttl_for_operation(operation)
@@ -617,6 +681,46 @@ class LLMGateway:
             async with self._lock:
                 self._inflight.pop(fingerprint, None)
                 self._active_calls = max(0, self._active_calls - 1)
+
+    async def _maybe_retry_repeated_response(
+        self,
+        *,
+        operation: str,
+        context: dict[str, Any],
+        result: dict[str, Any],
+        validate: Callable[[dict[str, Any]], dict[str, Any]],
+        degraded: Callable[[str], dict[str, Any]],
+    ) -> dict[str, Any]:
+        if operation != "agent_reply":
+            return result
+        if not bool(getattr(self._config, "llm_repeat_detection_enabled", False)):
+            return result
+        if bool(result.get("degraded")):
+            return result
+        try:
+            threshold = float(getattr(self._config, "llm_repeat_similarity_threshold", 0.85))
+        except (TypeError, ValueError):
+            threshold = 0.85
+        threshold = max(0.0, min(threshold, 1.0))
+        if not self._repeat_guard.is_repeat(result, threshold=threshold):
+            self._repeat_guard.record(result)
+            return result
+
+        retry_context = _json_payload_copy(context)
+        retry_context["_anti_repeat_instruction"] = (
+            "The previous agent reply was too similar to a recent reply. "
+            "Answer using the current public_context, avoid repeating the same wording, "
+            "and add only facts supported by context."
+        )
+        retry = await self._call_target(
+            operation=operation,
+            context=retry_context,
+            validate=validate,
+            degraded=degraded,
+        )
+        final = result if bool(retry.get("degraded")) else retry
+        self._repeat_guard.record(final)
+        return final
 
     def _consume_backend_prompt_metadata(self) -> dict[str, Any]:
         consume = getattr(self._backend, "consume_prompt_metadata", None)

--- a/plugin/plugins/galgame_plugin/store.py
+++ b/plugin/plugins/galgame_plugin/store.py
@@ -292,6 +292,7 @@ class GalgameStore:
         return {
             "scene_id": str(raw_value.get("scene_id") or "").strip(),
             "game_id": game_id,
+            "session_id": str(raw_value.get("session_id") or "").strip(),
             "route_id": str(raw_value.get("route_id") or "").strip(),
             "summary_seed": str(raw_value.get("summary_seed") or "").strip()[:4000],
             "stable_line_ids": stable_line_ids,
@@ -302,6 +303,7 @@ class GalgameStore:
         self,
         *,
         current_game_id: str = "",
+        current_session_id: str = "",
         max_age_seconds: float = 3600.0,
         require_game_id: bool = True,
     ) -> dict[str, Any]:
@@ -317,6 +319,10 @@ class GalgameStore:
             if not normalized_game_id or saved_game_id != normalized_game_id:
                 return {}
         elif require_game_id:
+            return {}
+        saved_session_id = str(snapshot.get("session_id") or "").strip()
+        normalized_session_id = str(current_session_id or "").strip()
+        if saved_session_id and saved_session_id != normalized_session_id:
             return {}
         try:
             max_age = float(max_age_seconds)
@@ -336,7 +342,14 @@ class GalgameStore:
             return
         self._write(STORE_CONTEXT_SNAPSHOT, payload)
 
-    def clear_context_snapshot(self) -> None:
+    def clear_context_snapshot(self, expected_snapshot: dict[str, Any] | None = None) -> None:
+        if expected_snapshot is not None:
+            expected = self._sanitize_context_snapshot(expected_snapshot)
+            current = self._sanitize_context_snapshot(
+                self._read(STORE_CONTEXT_SNAPSHOT, {})
+            )
+            if expected != current:
+                return
         self._write(STORE_CONTEXT_SNAPSHOT, {})
 
     @staticmethod

--- a/plugin/plugins/galgame_plugin/store.py
+++ b/plugin/plugins/galgame_plugin/store.py
@@ -322,7 +322,10 @@ class GalgameStore:
             return {}
         saved_session_id = str(snapshot.get("session_id") or "").strip()
         normalized_session_id = str(current_session_id or "").strip()
-        if saved_session_id and saved_session_id != normalized_session_id:
+        if saved_session_id:
+            if saved_session_id != normalized_session_id:
+                return {}
+        elif normalized_session_id:
             return {}
         try:
             max_age = float(max_age_seconds)

--- a/plugin/plugins/galgame_plugin/store.py
+++ b/plugin/plugins/galgame_plugin/store.py
@@ -313,11 +313,10 @@ class GalgameStore:
             return {}
         saved_game_id = str(snapshot.get("game_id") or "").strip()
         normalized_game_id = str(current_game_id or "").strip()
-        if require_game_id and not saved_game_id:
-            return {}
-        if require_game_id and not normalized_game_id:
-            return {}
-        if require_game_id and normalized_game_id and saved_game_id != normalized_game_id:
+        if saved_game_id:
+            if not normalized_game_id or saved_game_id != normalized_game_id:
+                return {}
+        elif require_game_id:
             return {}
         try:
             max_age = float(max_age_seconds)

--- a/plugin/tests/unit/plugins/_galgame_bridge_support.py
+++ b/plugin/tests/unit/plugins/_galgame_bridge_support.py
@@ -88,15 +88,6 @@ GameLLMAgent = game_llm_agent_module.GameLLMAgent
 _PLUGIN_FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "fixtures" / "galgame_plugin"
 
 
-@pytest.fixture(autouse=True)
-def _isolate_galgame_runtime_root(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(tmp_path / "runtime_data"))
-    monkeypatch.delenv("NEKO_STORAGE_ANCHOR_ROOT", raising=False)
-
-
 class _Logger:
     def info(self, *args, **kwargs):
         return None
@@ -524,6 +515,15 @@ class _BlockingSummaryGateway(_FakeLLMGateway):
 
 
 def _run_in_new_loop(awaitable):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError(
+            "_run_in_new_loop cannot run inside an existing event loop; "
+            "await the coroutine directly or use the caller's loop."
+        )
     with asyncio.Runner() as runner:
         return runner.run(awaitable)
 

--- a/plugin/tests/unit/plugins/_galgame_bridge_support.py
+++ b/plugin/tests/unit/plugins/_galgame_bridge_support.py
@@ -107,11 +107,11 @@ class _Logger:
 
 class _Ctx:
     plugin_id = "galgame_plugin"
-    metadata = {}
     bus = None
 
     def __init__(self, plugin_dir: Path, effective_config: dict[str, object]) -> None:
         self.logger = _Logger()
+        self.metadata = {}
         self.config_path = plugin_dir / "plugin.toml"
         self._effective_config = {
             "plugin": {"store": {"enabled": True}, "database": {"enabled": False}},

--- a/plugin/tests/unit/plugins/test_galgame_bridge_agent.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge_agent.py
@@ -1233,7 +1233,7 @@ def test_game_llm_agent_reply_context_bounds_all_history_by_recency_window(
 
 
 @pytest.mark.plugin_unit
-def test_game_llm_agent_reply_context_uses_effective_line_scene_when_snapshot_drops_scene(
+def test_game_llm_agent_reply_context_uses_effective_line_scene_when_snapshot_stale(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1252,7 +1252,12 @@ def test_game_llm_agent_reply_context_uses_effective_line_scene_when_snapshot_dr
         lambda *args, **kwargs: 6,
     )
     shared = _shared_state(
-        snapshot=_session_state(scene_id="", route_id="", line_id="", text=""),
+        snapshot=_session_state(
+            scene_id="scene-stale",
+            route_id="route-stale",
+            line_id="old-stable",
+            text="old scene",
+        ),
         history_lines=[
             {
                 "speaker": "A",

--- a/plugin/tests/unit/plugins/test_galgame_bridge_agent.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge_agent.py
@@ -3314,6 +3314,75 @@ async def test_game_llm_agent_pushes_scene_summary_after_eight_lines(
 
 @pytest.mark.asyncio
 @pytest.mark.plugin_unit
+async def test_game_llm_agent_scene_summary_counts_condensed_stable_lines(
+    tmp_path: Path,
+) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(plugin_dir, _make_effective_config(bridge_root))
+    plugin = GalgameBridgePlugin(ctx)
+    agent = GameLLMAgent(
+        plugin=plugin,
+        logger=_Logger(),
+        llm_gateway=_FakeLLMGateway(),
+        host_adapter=_FakeHostAdapter(),
+    )
+    shared = _shared_state(
+        mode="companion",
+        snapshot=_session_state(
+            speaker="雪乃",
+            text="第 8 句台词。",
+            scene_id="scene-a",
+            line_id="line-8",
+            ts="2026-04-21T08:33:08Z",
+        ),
+    )
+    agent._runtime_loop = asyncio.get_running_loop()
+    agent._op_lock = asyncio.Lock()
+    agent._observed_session_id = str(shared["active_session_id"])
+    agent._observed_scene_id = "scene-a"
+    agent._schedule_scene_summary_task(
+        shared=shared,
+        session_id=str(shared["active_session_id"]),
+        scene_id="scene-a",
+        route_id="",
+        snapshot=dict(shared["latest_snapshot"]),
+        context={
+            "scene_id": "scene-a",
+            "route_id": "",
+            "stable_lines": [
+                {
+                    "line_id": "line-1",
+                    "speaker": "雪乃",
+                    "text": "\n".join(f"第 {index} 句台词。" for index in range(1, 9)),
+                    "scene_id": "scene-a",
+                    "route_id": "",
+                    "ts": "2026-04-21T08:33:08Z",
+                    "_condensed_count": 8,
+                }
+            ],
+            "observed_lines": [],
+            "recent_choices": [],
+        },
+        trigger="line_count",
+        metadata={
+            "context_type": "galgame_scene_context",
+            "trigger": "line_count",
+            "scheduled_from_event_seq": 0,
+            "last_line_seq": 0,
+        },
+        update_scene_memory=False,
+        scheduled_line_count=8,
+    )
+    await _drain_agent_summary_tasks(agent)
+
+    assert ctx.pushed_messages[-1]["metadata"]["kind"] == "scene_summary"
+    assert ctx.pushed_messages[-1]["metadata"]["trigger"] == "line_count"
+    assert ctx.pushed_messages[-1]["metadata"]["stable_line_count"] == 8
+    assert ctx.pushed_messages[-1]["metadata"]["summary_delivery_key"] == "scene-a:0:8"
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
 async def test_game_llm_agent_delivers_line_count_summary_after_scene_change(
     tmp_path: Path,
 ) -> None:

--- a/plugin/tests/unit/plugins/test_galgame_bridge_agent.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge_agent.py
@@ -1233,6 +1233,89 @@ def test_game_llm_agent_reply_context_bounds_all_history_by_recency_window(
 
 
 @pytest.mark.plugin_unit
+def test_game_llm_agent_reply_context_uses_effective_line_scene_when_snapshot_drops_scene(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(plugin_dir, _make_effective_config(bridge_root))
+    plugin = GalgameBridgePlugin(ctx)
+    agent = GameLLMAgent(
+        plugin=plugin,
+        logger=_Logger(),
+        llm_gateway=_FakeLLMGateway(),
+        host_adapter=_FakeHostAdapter(),
+    )
+    monkeypatch.setattr(
+        game_llm_agent_module,
+        "_compute_dynamic_line_limit",
+        lambda *args, **kwargs: 6,
+    )
+    shared = _shared_state(
+        snapshot=_session_state(scene_id="", route_id="", line_id="", text=""),
+        history_lines=[
+            {
+                "speaker": "A",
+                "text": "old scene",
+                "line_id": "old-stable",
+                "scene_id": "scene-old",
+                "route_id": "route-old",
+                "ts": "2026-04-21T08:30:00Z",
+            },
+            {
+                "speaker": "A",
+                "text": "current stable",
+                "line_id": "current-stable",
+                "scene_id": "scene-current",
+                "route_id": "route-current",
+                "ts": "2026-04-21T08:30:01Z",
+            },
+        ],
+        history_observed_lines=[
+            {
+                "speaker": "B",
+                "text": "current observed",
+                "line_id": "current-observed",
+                "scene_id": "scene-current",
+                "route_id": "route-current",
+                "ts": "2026-04-21T08:30:02Z",
+            }
+        ],
+        history_choices=[
+            {
+                "choice_id": "old-choice",
+                "text": "old",
+                "line_id": "old-stable",
+                "scene_id": "scene-old",
+                "action": "selected",
+            },
+            {
+                "choice_id": "current-choice",
+                "text": "current",
+                "line_id": "current-observed",
+                "scene_id": "scene-current",
+                "action": "selected",
+            },
+        ],
+    )
+
+    context = agent._build_agent_reply_context(shared, prompt="status")
+    public_context = context["public_context"]
+
+    assert context["scene_id"] == "scene-current"
+    assert context["route_id"] == "route-current"
+    assert public_context["current_line"]["line_id"] == "current-observed"
+    assert public_context["current_line"]["scene_id"] == "scene-current"
+    assert [line["line_id"] for line in public_context["recent_lines"]] == [
+        "current-stable",
+        "current-observed",
+    ]
+    assert [choice["choice_id"] for choice in public_context["recent_choices"]] == [
+        "current-choice"
+    ]
+
+
+@pytest.mark.plugin_unit
 def test_game_llm_agent_reply_context_zero_line_limit_omits_history(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/plugins/test_galgame_bridge_config.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge_config.py
@@ -123,6 +123,89 @@ def test_screen_classified_event_updates_snapshot_state() -> None:
 
 
 @pytest.mark.plugin_unit
+def test_persist_context_snapshot_skips_stale_session(tmp_path: Path) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(
+        plugin_dir,
+        _make_effective_config(
+            bridge_root,
+            llm={
+                "context_persist_enabled": True,
+                "context_persist_require_game_id": True,
+            },
+        ),
+    )
+    plugin = GalgameBridgePlugin(ctx)
+    plugin._cfg = build_config(ctx._config)
+    plugin._state.active_game_id = "demo.alpha"
+    plugin._state.active_session_id = "live-session"
+    plugin._state.latest_snapshot = {
+        "scene_id": "scene-a",
+        "route_id": "route-a",
+    }
+
+    plugin._persist_context_snapshot_from_summary(
+        context={
+            "game_id": "demo.alpha",
+            "session_id": "old-session",
+            "scene_id": "scene-a",
+            "route_id": "route-a",
+            "stable_lines": [{"line_id": "line-1"}],
+        },
+        payload={"summary": "stale summary"},
+    )
+
+    assert plugin._state.context_snapshot == {}
+    assert plugin._persist.load_context_snapshot(current_game_id="demo.alpha") == {}
+
+
+@pytest.mark.plugin_unit
+def test_persist_context_snapshot_allows_semantic_degraded_summary(tmp_path: Path) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(
+        plugin_dir,
+        _make_effective_config(
+            bridge_root,
+            llm={
+                "context_persist_enabled": True,
+                "context_persist_require_game_id": True,
+            },
+        ),
+    )
+    plugin = GalgameBridgePlugin(ctx)
+    plugin._cfg = build_config(ctx._config)
+    plugin._state.active_game_id = "demo.alpha"
+    plugin._state.active_session_id = "sess-a"
+    plugin._state.latest_snapshot = {
+        "scene_id": "scene-a",
+        "route_id": "route-a",
+    }
+
+    plugin._persist_context_snapshot_from_summary(
+        context={
+            "game_id": "demo.alpha",
+            "session_id": "sess-a",
+            "scene_id": "scene-a",
+            "route_id": "route-a",
+            "stable_lines": [{"line_id": " line-1 "}],
+        },
+        payload={
+            "degraded": True,
+            "semantic_degraded": True,
+            "fallback_used": False,
+            "summary": " OCR session summary ",
+        },
+    )
+
+    assert plugin._state.context_snapshot["summary_seed"] == "OCR session summary"
+    assert plugin._state.context_snapshot["stable_line_ids"] == ["line-1"]
+    assert plugin._persist.load_context_snapshot(
+        current_game_id="demo.alpha",
+        require_game_id=True,
+    )["summary_seed"] == "OCR session summary"
+
+
+@pytest.mark.plugin_unit
 def test_expand_bridge_root_and_read_bom_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "Local"))
     expanded = expand_bridge_root("%LOCALAPPDATA%/N.E.K.O/galgame-bridge")

--- a/plugin/tests/unit/plugins/test_galgame_bridge_config.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge_config.py
@@ -17,7 +17,6 @@ from _galgame_test_support import (
     _Ctx,
     _default_bridge_root_raw,
     _event,
-    _isolate_galgame_runtime_root,  # noqa: F401
     _Logger,
     _make_effective_config,
     _make_plugin_dirs,
@@ -160,6 +159,48 @@ def test_persist_context_snapshot_skips_stale_session(tmp_path: Path) -> None:
 
 
 @pytest.mark.plugin_unit
+def test_persist_context_snapshot_skips_stale_scene_even_when_session_matches(
+    tmp_path: Path,
+) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(
+        plugin_dir,
+        _make_effective_config(
+            bridge_root,
+            llm={
+                "context_persist_enabled": True,
+                "context_persist_require_game_id": True,
+            },
+        ),
+    )
+    plugin = GalgameBridgePlugin(ctx)
+    plugin._cfg = build_config(ctx._config)
+    plugin._state.active_game_id = "demo.alpha"
+    plugin._state.active_session_id = "sess-a"
+    plugin._state.latest_snapshot = {
+        "scene_id": "scene-live",
+        "route_id": "route-a",
+    }
+
+    plugin._persist_context_snapshot_from_summary(
+        context={
+            "game_id": "demo.alpha",
+            "session_id": "sess-a",
+            "scene_id": "scene-stale",
+            "route_id": "route-a",
+            "stable_lines": [{"line_id": "line-1"}],
+        },
+        payload={"summary": "stale summary"},
+    )
+
+    assert plugin._state.context_snapshot == {}
+    assert plugin._persist.load_context_snapshot(
+        current_game_id="demo.alpha",
+        current_session_id="sess-a",
+    ) == {}
+
+
+@pytest.mark.plugin_unit
 def test_persist_context_snapshot_allows_semantic_degraded_summary(tmp_path: Path) -> None:
     plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
     ctx = _Ctx(
@@ -235,6 +276,57 @@ def test_load_context_snapshot_for_state_rejects_stored_session_mismatch(tmp_pat
 
     assert plugin._load_context_snapshot_for_state() == {}
 
+
+@pytest.mark.plugin_unit
+def test_context_snapshot_reload_uses_candidate_session(tmp_path: Path) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(
+        plugin_dir,
+        _make_effective_config(
+            bridge_root,
+            llm={
+                "context_persist_enabled": True,
+                "context_persist_require_game_id": True,
+            },
+        ),
+    )
+    plugin = GalgameBridgePlugin(ctx)
+    plugin._cfg = build_config(ctx._config)
+    plugin._state.active_session_id = "old-session"
+    plugin._persist.persist_context_snapshot(
+        {
+            "game_id": "demo.alpha",
+            "session_id": "new-session",
+            "summary_seed": "new summary",
+            "saved_at": time.time(),
+        }
+    )
+
+    assert plugin._context_snapshot_needs_reload(
+        {"game_id": "demo.alpha", "session_id": "old-session"},
+        current_game_id="demo.alpha",
+        current_session_id="new-session",
+    ) is True
+    assert plugin._load_context_snapshot_for_game(
+        "demo.alpha",
+        current_session_id="new-session",
+    )["summary_seed"] == "new summary"
+
+
+@pytest.mark.plugin_unit
+def test_bridge_test_context_metadata_is_instance_scoped(tmp_path: Path) -> None:
+    first_base = tmp_path / "first"
+    second_base = tmp_path / "second"
+    first_base.mkdir()
+    second_base.mkdir()
+    first_dir, first_root = _make_plugin_dirs(first_base)
+    second_dir, second_root = _make_plugin_dirs(second_base)
+    first = _Ctx(first_dir, _make_effective_config(first_root))
+    second = _Ctx(second_dir, _make_effective_config(second_root))
+
+    first.metadata["marker"] = "first"
+
+    assert second.metadata == {}
 
 @pytest.mark.plugin_unit
 def test_expand_bridge_root_and_read_bom_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/plugin/tests/unit/plugins/test_galgame_bridge_config.py
+++ b/plugin/tests/unit/plugins/test_galgame_bridge_config.py
@@ -198,11 +198,42 @@ def test_persist_context_snapshot_allows_semantic_degraded_summary(tmp_path: Pat
     )
 
     assert plugin._state.context_snapshot["summary_seed"] == "OCR session summary"
+    assert plugin._state.context_snapshot["session_id"] == "sess-a"
     assert plugin._state.context_snapshot["stable_line_ids"] == ["line-1"]
     assert plugin._persist.load_context_snapshot(
         current_game_id="demo.alpha",
+        current_session_id="sess-a",
         require_game_id=True,
     )["summary_seed"] == "OCR session summary"
+
+
+@pytest.mark.plugin_unit
+def test_load_context_snapshot_for_state_rejects_stored_session_mismatch(tmp_path: Path) -> None:
+    plugin_dir, bridge_root = _make_plugin_dirs(tmp_path)
+    ctx = _Ctx(
+        plugin_dir,
+        _make_effective_config(
+            bridge_root,
+            llm={
+                "context_persist_enabled": True,
+                "context_persist_require_game_id": True,
+            },
+        ),
+    )
+    plugin = GalgameBridgePlugin(ctx)
+    plugin._cfg = build_config(ctx._config)
+    plugin._state.active_game_id = "demo.alpha"
+    plugin._state.active_session_id = "live-session"
+    plugin._persist.persist_context_snapshot(
+        {
+            "game_id": "demo.alpha",
+            "session_id": "old-session",
+            "summary_seed": "old summary",
+            "saved_at": time.time(),
+        }
+    )
+
+    assert plugin._load_context_snapshot_for_state() == {}
 
 
 @pytest.mark.plugin_unit

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -968,7 +968,7 @@ def test_summarize_context_uses_restored_context_snapshot_when_history_is_empty(
         {
             "active_game_id": "demo.alpha",
             "active_session_id": "sess-a",
-            "latest_snapshot": {},
+            "latest_snapshot": {"scene_id": "scene-a", "route_id": "route-a"},
             "history_lines": [],
             "history_observed_lines": [],
             "history_choices": [],
@@ -988,6 +988,32 @@ def test_summarize_context_uses_restored_context_snapshot_when_history_is_empty(
     assert result["recent_lines"] == []
     assert result["scene_summary_seed"] == "上一轮总结：雪乃决定继续调查。"
     assert result["context_snapshot_summary_seed"] == "上一轮总结：雪乃决定继续调查。"
+
+
+def test_summarize_context_rejects_restored_route_seed_when_current_route_unknown() -> None:
+    result = context_builder.build_summarize_context(
+        {
+            "active_game_id": "demo.alpha",
+            "active_session_id": "sess-a",
+            "latest_snapshot": {"scene_id": "scene-a"},
+            "history_lines": [],
+            "history_observed_lines": [],
+            "history_choices": [],
+            "context_snapshot": {
+                "game_id": "demo.alpha",
+                "scene_id": "scene-a",
+                "route_id": "route-a",
+                "summary_seed": "route-a restored seed",
+                "stable_line_ids": ["line-1", "line-2"],
+            },
+        },
+        scene_id="",
+    )
+
+    assert result["scene_id"] == "scene-a"
+    assert result["route_id"] == ""
+    assert result["context_snapshot_summary_seed"] == ""
+    assert "route-a restored seed" not in result["scene_summary_seed"]
 
 
 def test_scene_context_hint_new_scene_no_history() -> None:

--- a/plugin/tests/unit/plugins/test_galgame_context_builder.py
+++ b/plugin/tests/unit/plugins/test_galgame_context_builder.py
@@ -412,7 +412,57 @@ def test_summarize_context_respects_small_configured_maximum() -> None:
         config=config,
     )
 
-    assert [item["line_id"] for item in result["stable_lines"]] == ["line-7", "line-8", "line-9"]
+    assert len(result["stable_lines"]) == 1
+    assert result["stable_lines"][0]["line_id"] == "line-7"
+    assert "line 7.\nline 8.\nline 9." == result["stable_lines"][0]["text"]
+    assert "_condensed_line_ids" not in result["stable_lines"][0]
+    assert result["stable_lines"][0]["_condensed_count"] == 3
+
+
+def test_summarize_context_applies_global_line_limit_before_condensing() -> None:
+    lines = [
+        {
+            "speaker": "A",
+            "text": f"stable line {index}.",
+            "scene_id": "scene-a",
+            "line_id": f"stable-{index}",
+            "stability": "stable",
+        }
+        for index in range(5)
+    ]
+    observed = [
+        {
+            "speaker": "B",
+            "text": f"observed line {index}.",
+            "scene_id": "scene-a",
+            "line_id": f"observed-{index}",
+            "stability": "tentative",
+        }
+        for index in range(5)
+    ]
+    config = GalgameLLMConfig(
+        context_explain_min_lines=1,
+        context_explain_max_lines=3,
+        context_window_target_tokens=800,
+    )
+
+    result = context_builder.build_summarize_context(
+        {
+            "latest_snapshot": {"scene_id": "scene-a"},
+            "history_lines": lines,
+            "history_observed_lines": observed,
+            "history_choices": [],
+        },
+        scene_id="scene-a",
+        config=config,
+    )
+
+    recent_text = "\n".join(str(item.get("text") or "") for item in result["recent_lines"])
+    assert len(result["recent_lines"]) == 2
+    assert "stable line 3.\nstable line 4." in recent_text
+    assert "observed line 4." in recent_text
+    assert all("_condensed_line_ids" not in item for item in result["recent_lines"])
+    assert all("_condensed_count" not in item for item in result["recent_lines"])
 
 
 def test_summarize_context_applies_line_limit_across_all_dialogue_streams() -> None:
@@ -913,6 +963,33 @@ def test_summarize_context_keeps_live_route_when_restored_scene_differs() -> Non
     assert "旧场景总结不应复用。" not in result["scene_summary_seed"]
 
 
+def test_summarize_context_uses_restored_context_snapshot_when_history_is_empty() -> None:
+    result = context_builder.build_summarize_context(
+        {
+            "active_game_id": "demo.alpha",
+            "active_session_id": "sess-a",
+            "latest_snapshot": {},
+            "history_lines": [],
+            "history_observed_lines": [],
+            "history_choices": [],
+            "context_snapshot": {
+                "game_id": "demo.alpha",
+                "scene_id": "scene-a",
+                "route_id": "route-a",
+                "summary_seed": "上一轮总结：雪乃决定继续调查。",
+                "stable_line_ids": ["line-1", "line-2"],
+            },
+        },
+        scene_id="",
+    )
+
+    assert result["scene_id"] == "scene-a"
+    assert result["route_id"] == "route-a"
+    assert result["recent_lines"] == []
+    assert result["scene_summary_seed"] == "上一轮总结：雪乃决定继续调查。"
+    assert result["context_snapshot_summary_seed"] == "上一轮总结：雪乃决定继续调查。"
+
+
 def test_scene_context_hint_new_scene_no_history() -> None:
     result = context_builder.build_summarize_context(
         {
@@ -943,3 +1020,27 @@ def test_scene_context_hint_cold_start_only_without_history() -> None:
 
     assert cold["scene_context"] == "cold_start"
     assert "scene_context" not in warm
+
+
+def test_summarize_context_drops_restored_route_when_restored_scene_differs() -> None:
+    result = context_builder.build_summarize_context(
+        {
+            "active_game_id": "demo.alpha",
+            "latest_snapshot": {"scene_id": "scene-b"},
+            "history_lines": [],
+            "history_observed_lines": [],
+            "history_choices": [],
+            "context_snapshot": {
+                "game_id": "demo.alpha",
+                "scene_id": "scene-a",
+                "route_id": "route-a",
+                "summary_seed": "旧场景总结不应复用。",
+            },
+        },
+        scene_id="",
+    )
+
+    assert result["scene_id"] == "scene-b"
+    assert result["route_id"] == ""
+    assert result["context_snapshot_summary_seed"] == ""
+    assert result["scene_summary_seed"] != "旧场景总结不应复用。"

--- a/plugin/tests/unit/plugins/test_galgame_host_agent_adapter.py
+++ b/plugin/tests/unit/plugins/test_galgame_host_agent_adapter.py
@@ -43,7 +43,9 @@ async def test_host_agent_adapter_round_trip_and_cancel(monkeypatch: pytest.Monk
         cancelled = await adapter.cancel_task("task-1")
 
     assert availability["ready"] is True
+    assert availability["reasons"] == []
     assert started["task_id"] == "task-1"
+    assert started["instruction"] == "advance once"
     assert task["status"] == "running"
     assert cancelled["status"] == "cancelled"
 
@@ -70,12 +72,14 @@ async def test_host_agent_adapter_rebuilds_client_after_closed_loop_error(monkey
             async def aclose(self):
                 self.is_closed = True
 
-        built_clients = [_BrokenSharedClient(), fallback_client]
+        broken = _BrokenSharedClient()
+        built_clients = [broken, fallback_client]
         monkeypatch.setattr(adapter, "_build_client", lambda: built_clients.pop(0))
         task = await adapter.get_task("task-1")
 
     assert task["status"] == "running"
     assert adapter._client is fallback_client
+    assert broken.is_closed is True
 
 
 @pytest.mark.plugin_unit

--- a/plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py
@@ -94,6 +94,32 @@ class _ChoiceBackend:
         return None
 
 
+class _SummarizeBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
+        assert operation == "summarize_scene"
+        self.calls += 1
+        snapshot = context.get("current_snapshot") or {}
+        return {
+            "summary": f"summary-{self.calls}: {snapshot.get('text') or ''}",
+            "key_points": [
+                {
+                    "type": "plot",
+                    "text": str(snapshot.get("text") or "no current text"),
+                    "line_id": str(snapshot.get("line_id") or ""),
+                    "speaker": str(snapshot.get("speaker") or ""),
+                    "scene_id": str(context.get("scene_id") or ""),
+                    "route_id": str(context.get("route_id") or ""),
+                }
+            ],
+        }
+
+    async def shutdown(self) -> None:
+        return None
+
+
 def _make_config(**overrides: Any) -> SimpleNamespace:
     base = {
         "llm_max_in_flight": 4,
@@ -136,6 +162,29 @@ def _explain_context(
         ],
         "screen_context": screen_context or {},
         "diagnostic": "",
+    }
+
+
+def _summarize_context(*, current_text: str = "current") -> dict[str, Any]:
+    return {
+        "scene_id": "scene-a",
+        "route_id": "route-a",
+        "current_snapshot": {
+            "line_id": "line-100",
+            "speaker": "闆箖",
+            "text": current_text,
+            "scene_id": "scene-a",
+            "route_id": "route-a",
+            "ts": "volatile",
+        },
+        "stable_lines": [
+            {"line_id": "line-1", "speaker": "闆箖", "text": "stable"},
+        ],
+        "observed_lines": [
+            {"line_id": "line-99", "speaker": "闆箖", "text": "observed"},
+        ],
+        "recent_lines": [],
+        "recent_choices": [],
     }
 
 
@@ -261,6 +310,18 @@ def test_hash_helpers_normalise_inputs() -> None:
     )
 
 
+@pytest.mark.plugin_unit
+def test_near_match_meta_uses_current_snapshot_when_current_line_absent() -> None:
+    cached = _summarize_context(current_text="new snapshot line")
+    meta = LLMGateway._build_near_match_meta(cached)
+
+    assert LLMGateway._validate_near_match(meta, cached) is True
+    assert LLMGateway._validate_near_match(
+        meta,
+        _summarize_context(current_text="different snapshot line"),
+    ) is False
+
+
 @pytest.mark.asyncio
 @pytest.mark.plugin_unit
 async def test_near_match_cache_returns_cached_payload_for_similar_context() -> None:
@@ -321,6 +382,34 @@ async def test_near_match_cache_rejects_different_scene_or_stable_lines() -> Non
     await gateway.shutdown()
 
     assert backend.calls == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_summarize_near_match_cache_rejects_changed_current_snapshot_line() -> None:
+    backend = _SummarizeBackend()
+    config = _make_config(
+        llm_near_match_cache_enabled=True,
+        llm_scene_summary_cache_ttl_seconds=0.0,
+    )
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=config,
+        backend=backend,
+    )
+
+    first = await gateway.summarize_scene(
+        _summarize_context(current_text="first on-screen line")
+    )
+    second = await gateway.summarize_scene(
+        _summarize_context(current_text="latest on-screen line")
+    )
+    await gateway.shutdown()
+
+    assert first["summary"] == "summary-1: first on-screen line"
+    assert second["summary"] == "summary-2: latest on-screen line"
+    assert backend.calls == 2
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_gateway_cache.py
@@ -1,3 +1,16 @@
+"""Phase 3 cache tests for ``LLMGateway``.
+
+Covers two new behaviours added in the Galgame plugin context optimisation
+Phase 3:
+
+* Per-operation cache TTL (``llm_explain_cache_ttl_seconds``,
+  ``llm_choice_cache_ttl_seconds`` etc.).
+* Near-match cache (``llm_near_match_cache_enabled``) — only enabled for
+  ``explain_line`` and ``summarize_scene`` and guarded by
+  ``_validate_near_match`` against stale ``stable_lines`` / ``current_line``
+  / ``observed_lines``.
+"""
+
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -7,262 +20,436 @@ import pytest
 
 from plugin.plugins.galgame_plugin.llm_gateway import (
     LLMGateway,
+    _NEAR_MATCH_OBSERVED_SIMILARITY_THRESHOLD,
     _hash_line,
+    _hash_stable_lines,
+    _line_similarity_signature,
     _observed_similarity,
 )
 
 
-class _Backend:
+class _Logger:
+    def info(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def warning(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def error(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def debug(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def exception(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _ExplainBackend:
     def __init__(self) -> None:
         self.calls = 0
 
     async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
+        assert operation == "explain_line"
         self.calls += 1
-        if operation == "explain_line":
-            return {
-                "explanation": f"explain-{self.calls}",
-                "evidence": [
-                    {
-                        "type": "current_line",
-                        "text": str(context.get("text") or "line"),
-                        "line_id": str(context.get("line_id") or "line-1"),
-                        "speaker": str(context.get("speaker") or "A"),
-                        "scene_id": str(context.get("scene_id") or "scene-a"),
-                        "route_id": "",
-                    }
-                ],
-            }
-        if operation == "summarize_scene":
-            return {
-                "summary": f"summary-{self.calls}",
-                "key_points": [
-                    {
-                        "type": "plot",
-                        "text": "plot",
-                        "line_id": "line-1",
-                        "speaker": "A",
-                        "scene_id": "scene-a",
-                        "route_id": "",
-                    }
-                ],
-            }
-        if operation == "suggest_choice":
-            return {
-                "choices": [
-                    {
-                        "choice_id": "choice-1",
-                        "text": "left",
-                        "rank": 1,
-                        "reason": "reason",
-                    }
-                ]
-            }
-        return {"reply": f"reply-{self.calls}"}
+        return {
+            "explanation": f"explanation-{self.calls}",
+            "evidence": [
+                {
+                    "type": "current_line",
+                    "text": str(context.get("current_line", {}).get("text") or ""),
+                    "line_id": str(context.get("current_line", {}).get("line_id") or ""),
+                    "speaker": str(context.get("current_line", {}).get("speaker") or ""),
+                    "scene_id": str(context.get("scene_id") or ""),
+                    "route_id": "",
+                }
+            ],
+        }
 
     async def shutdown(self) -> None:
         return None
 
 
-def _config(**overrides: Any) -> SimpleNamespace:
-    values = {
-        "llm_target_entry_ref": "",
-        "llm_call_timeout_seconds": 1.0,
-        "llm_max_in_flight": 2,
+class _ChoiceBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def invoke(self, *, operation: str, context: dict[str, Any]) -> dict[str, Any]:
+        assert operation == "suggest_choice"
+        self.calls += 1
+        visible = context.get("visible_choices") or []
+        return {
+            "choices": [
+                {
+                    "choice_id": str(item.get("choice_id") or ""),
+                    "text": str(item.get("text") or ""),
+                    "rank": idx + 1,
+                    "reason": "default",
+                }
+                for idx, item in enumerate(visible)
+            ]
+        }
+
+    async def shutdown(self) -> None:
+        return None
+
+
+def _make_config(**overrides: Any) -> SimpleNamespace:
+    base = {
+        "llm_max_in_flight": 4,
+        "llm_call_timeout_seconds": 5.0,
         "llm_request_cache_ttl_seconds": 2.0,
-        "llm_explain_cache_ttl_seconds": 8.0,
         "llm_scene_summary_cache_ttl_seconds": 10.0,
+        "llm_target_entry_ref": "",
+        "context_counting_mode": "char",
+        "context_max_tokens": 6000,
+        "context_metrics_enabled": False,
+        "llm_explain_cache_ttl_seconds": 8.0,
         "llm_choice_cache_ttl_seconds": 4.0,
         "llm_near_match_cache_enabled": False,
         "llm_near_match_cache_ttl_seconds": 15.0,
-        "context_metrics_enabled": False,
     }
-    values.update(overrides)
-    return SimpleNamespace(**values)
+    base.update(overrides)
+    return SimpleNamespace(**base)
 
 
-def _explain_context(**overrides: Any) -> dict[str, Any]:
-    context = {
-        "game_id": "game-a",
-        "session_id": "session-a",
-        "scene_id": "scene-a",
-        "route_id": "",
-        "line_id": "line-1",
-        "speaker": "A",
-        "text": "same current line",
+def _explain_context(
+    *,
+    scene_id: str = "scene-a",
+    current_text: str = "current",
+    stable_text: str = "stable",
+    observed_text: str = "observed",
+    screen_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "scene_id": scene_id,
+        "current_line": {
+            "line_id": "line-100",
+            "speaker": "雪乃",
+            "text": current_text,
+        },
         "stable_lines": [
-            {
-                "line_id": "line-1",
-                "speaker": "A",
-                "text": "same current line",
-                "scene_id": "scene-a",
-                "route_id": "",
-            }
+            {"line_id": "line-1", "speaker": "雪乃", "text": stable_text},
         ],
         "observed_lines": [
-            {
-                "line_id": "ocr-1",
-                "speaker": "A",
-                "text": "same current line",
-                "scene_id": "scene-a",
-            }
+            {"line_id": "line-99", "speaker": "雪乃", "text": observed_text},
         ],
-        "recent_lines": [],
-        "current_snapshot": {"line_id": "line-1", "text": "same current line"},
+        "screen_context": screen_context or {},
+        "diagnostic": "",
     }
-    context.update(overrides)
-    return context
 
 
-def test_llm_gateway_ttl_for_operation_uses_phase3_fields() -> None:
+@pytest.mark.plugin_unit
+def test_ttl_for_operation_returns_per_operation_values() -> None:
+    config = _make_config(
+        llm_request_cache_ttl_seconds=2.0,
+        llm_scene_summary_cache_ttl_seconds=10.0,
+        llm_explain_cache_ttl_seconds=8.0,
+        llm_choice_cache_ttl_seconds=4.0,
+    )
+    gateway = LLMGateway(plugin=SimpleNamespace(plugins=None), logger=_Logger(), config=config)
+
+    assert gateway._ttl_for_operation("explain_line") == 8.0
+    assert gateway._ttl_for_operation("summarize_scene") == 10.0
+    assert gateway._ttl_for_operation("scene_summary") == 10.0
+    assert gateway._ttl_for_operation("suggest_choice") == 4.0
+    assert gateway._ttl_for_operation("agent_reply") == 2.0
+    assert gateway._ttl_for_operation("unknown") == 2.0
+
+
+@pytest.mark.plugin_unit
+def test_ttl_for_operation_falls_back_to_request_ttl_for_invalid_values() -> None:
+    config = _make_config(
+        llm_request_cache_ttl_seconds=3.0,
+        llm_explain_cache_ttl_seconds="not-a-number",
+        llm_choice_cache_ttl_seconds=-5.0,
+    )
+    gateway = LLMGateway(plugin=SimpleNamespace(plugins=None), logger=_Logger(), config=config)
+
+    assert gateway._ttl_for_operation("explain_line") == 3.0
+    assert gateway._ttl_for_operation("suggest_choice") == 0.0
+
+
+@pytest.mark.plugin_unit
+def test_near_match_disabled_by_default() -> None:
     gateway = LLMGateway(
-        None,
-        None,
-        _config(
-            llm_explain_cache_ttl_seconds=7,
-            llm_scene_summary_cache_ttl_seconds=11,
-            llm_choice_cache_ttl_seconds=5,
-            llm_request_cache_ttl_seconds=3,
-        ),
-        backend=_Backend(),
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=_make_config(),
     )
-
-    assert gateway._ttl_for_operation("explain_line") == 7
-    assert gateway._ttl_for_operation("summarize_scene") == 11
-    assert gateway._ttl_for_operation("suggest_choice") == 5
-    assert gateway._ttl_for_operation("agent_reply") == 3
+    assert gateway._near_match_enabled() is False
 
 
-def test_repeat_config_fingerprint_preserves_zero_threshold() -> None:
-    zero_gateway = LLMGateway(
-        None,
-        None,
-        _config(llm_repeat_detection_enabled=True, llm_repeat_similarity_threshold=0.0),
-        backend=_Backend(),
+@pytest.mark.plugin_unit
+def test_near_match_fingerprint_excludes_volatile_fields() -> None:
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=_make_config(llm_near_match_cache_enabled=True),
     )
-    default_gateway = LLMGateway(
-        None,
-        None,
-        _config(llm_repeat_detection_enabled=True),
-        backend=_Backend(),
-    )
+    base = _explain_context()
+    with_screen = _explain_context(screen_context={"background": "abc"})
+    with_diagnostic = dict(base)
+    with_diagnostic["diagnostic"] = "some warning"
+    fp_base = gateway._near_match_fingerprint("explain_line", base)
+    fp_screen = gateway._near_match_fingerprint("explain_line", with_screen)
+    fp_diag = gateway._near_match_fingerprint("explain_line", with_diagnostic)
+    assert fp_base is not None
+    # screen_context and diagnostic are excluded → identical fingerprint
+    assert fp_screen == fp_base
+    assert fp_diag == fp_base
 
-    assert zero_gateway._repeat_config_fingerprint() != default_gateway._repeat_config_fingerprint()
+
+@pytest.mark.plugin_unit
+def test_near_match_fingerprint_skipped_for_unsupported_operations() -> None:
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=_make_config(llm_near_match_cache_enabled=True),
+    )
+    context = _explain_context()
+    assert gateway._near_match_fingerprint("suggest_choice", context) is None
+    assert gateway._near_match_fingerprint("agent_reply", context) is None
+
+
+@pytest.mark.plugin_unit
+def test_validate_near_match_rejects_mismatched_stable_or_current_line() -> None:
+    context = _explain_context()
+    meta = LLMGateway._build_near_match_meta(context)
+
+    assert LLMGateway._validate_near_match(meta, context) is True
+
+    other_stable = _explain_context(stable_text="different stable")
+    assert LLMGateway._validate_near_match(meta, other_stable) is False
+
+    other_current = _explain_context(current_text="different current")
+    assert LLMGateway._validate_near_match(meta, other_current) is False
+
+
+@pytest.mark.plugin_unit
+def test_validate_near_match_rejects_low_observed_similarity() -> None:
+    cached_context = _explain_context(observed_text="今天发生了一件惊天动地的大事情啊")
+    meta = LLMGateway._build_near_match_meta(cached_context)
+    diverged = _explain_context(observed_text="完全不一样的内容啦啦啦XYZ")
+    assert LLMGateway._validate_near_match(meta, diverged) is False
+
+
+@pytest.mark.plugin_unit
+def test_observed_similarity_helpers_jaccard_behaviour() -> None:
+    sig_a = _line_similarity_signature(
+        [{"speaker": "雪乃", "text": "她说：今天天气真好啊，要不要去外面散步呢？"}]
+    )
+    sig_b = _line_similarity_signature(
+        [{"speaker": "雪乃", "text": "她说：今天天气真好啊，要不要去外面散步呢。"}]
+    )
+    sig_c = _line_similarity_signature(
+        [{"speaker": "雪乃", "text": "完全不同的句子"}]
+    )
+    assert "今天天气真好" in sig_a
+    assert _observed_similarity(sig_a, sig_b) >= _NEAR_MATCH_OBSERVED_SIMILARITY_THRESHOLD
+    assert _observed_similarity(sig_a, sig_c) < _NEAR_MATCH_OBSERVED_SIMILARITY_THRESHOLD
+    assert _observed_similarity("", "anything") == 0.0
+    assert _observed_similarity("anything", "") == 0.0
+
+
+@pytest.mark.plugin_unit
+def test_hash_helpers_normalise_inputs() -> None:
+    assert _hash_stable_lines(None) == ""
+    assert _hash_line(None) == ""
+    assert _hash_line({"speaker": "a", "text": "b"}) == _hash_line(
+        {"speaker": "a", "text": "b", "ignored": "x"}
+    )
 
 
 @pytest.mark.asyncio
-async def test_llm_gateway_near_match_reuses_safe_explain_result() -> None:
-    backend = _Backend()
+@pytest.mark.plugin_unit
+async def test_near_match_cache_returns_cached_payload_for_similar_context() -> None:
+    backend = _ExplainBackend()
+    config = _make_config(
+        llm_near_match_cache_enabled=True,
+        llm_near_match_cache_ttl_seconds=30.0,
+        llm_explain_cache_ttl_seconds=0.0,  # disable exact cache to isolate near-match
+    )
     gateway = LLMGateway(
-        None,
-        None,
-        _config(llm_near_match_cache_enabled=True, llm_request_cache_ttl_seconds=0),
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=config,
         backend=backend,
     )
 
-    first = await gateway.explain_line(_explain_context())
-    second = await gateway.explain_line(
-        _explain_context(
-            current_snapshot={"line_id": "line-1", "text": "ocr jitter"},
-            observed_lines=[
-                {
-                    "line_id": "ocr-1",
-                    "speaker": "A",
-                    "text": "same current line.",
-                    "scene_id": "scene-a",
-                }
-            ],
-        )
+    first_context = _explain_context(
+        observed_text="她对春希说：今天天气真好啊，要不要去外面散步呢",
+    )
+    # Slightly edited observed text and volatile screen_context differ, but
+    # the normalized text remains similar enough for near-match reuse.
+    second_context = _explain_context(
+        observed_text="她对春希说：今天天气真好啊，要不要去外面散步呢。",
+        screen_context={"background": "different"},
     )
 
-    assert first["explanation"] == "explain-1"
-    assert second["explanation"] == "explain-1"
+    first = await gateway.explain_line(first_context)
+    second = await gateway.explain_line(second_context)
+    await gateway.shutdown()
+
+    assert first["explanation"] == "explanation-1"
+    assert second["explanation"] == "explanation-1"  # served by near-match
     assert backend.calls == 1
 
 
 @pytest.mark.asyncio
-async def test_update_config_clears_near_match_cache_on_context_budget_change() -> None:
-    backend = _Backend()
-    gateway = LLMGateway(
-        None,
-        None,
-        _config(
-            llm_near_match_cache_enabled=True,
-            llm_request_cache_ttl_seconds=0,
-            context_counting_mode="token",
-            context_max_tokens=300,
-        ),
-        backend=backend,
+@pytest.mark.plugin_unit
+async def test_near_match_cache_rejects_different_scene_or_stable_lines() -> None:
+    backend = _ExplainBackend()
+    config = _make_config(
+        llm_near_match_cache_enabled=True,
+        llm_explain_cache_ttl_seconds=0.0,
     )
-
-    try:
-        await gateway.explain_line(_explain_context())
-        assert len(gateway._near_match_cache) == 1
-
-        gateway.update_config(
-            _config(
-                llm_near_match_cache_enabled=True,
-                llm_request_cache_ttl_seconds=0,
-                context_counting_mode="token",
-                context_max_tokens=1000,
-            )
-        )
-
-        assert len(gateway._near_match_cache) == 0
-    finally:
-        await gateway.shutdown()
-
-
-@pytest.mark.asyncio
-async def test_llm_gateway_near_match_rejects_stable_line_change() -> None:
-    backend = _Backend()
     gateway = LLMGateway(
-        None,
-        None,
-        _config(llm_near_match_cache_enabled=True, llm_request_cache_ttl_seconds=0),
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=config,
         backend=backend,
     )
 
     await gateway.explain_line(_explain_context())
-    result = await gateway.explain_line(
-        _explain_context(
-            stable_lines=[
-                {
-                    "line_id": "line-2",
-                    "speaker": "A",
-                    "text": "different fact",
-                    "scene_id": "scene-a",
-                    "route_id": "",
-                }
-            ]
-        )
+    # Different scene_id → fingerprint differs → not a near-match hit
+    await gateway.explain_line(_explain_context(scene_id="scene-b"))
+    # Same fingerprint but different stable_lines → _validate_near_match
+    # rejects → fresh backend call
+    diverged = _explain_context(stable_text="完全不同的剧情")
+    await gateway.explain_line(diverged)
+    await gateway.shutdown()
+
+    assert backend.calls == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_near_match_cache_disabled_does_not_store_or_hit() -> None:
+    backend = _ExplainBackend()
+    config = _make_config(
+        llm_near_match_cache_enabled=False,
+        llm_explain_cache_ttl_seconds=0.0,
+    )
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=config,
+        backend=backend,
     )
 
-    assert result["explanation"] == "explain-2"
+    await gateway.explain_line(_explain_context())
+    await gateway.explain_line(_explain_context())
+    await gateway.shutdown()
+
+    assert backend.calls == 2
+    # Disabled: no entries added to the near-match cache.
+    assert len(gateway._near_match_cache) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_near_match_cache_does_not_apply_to_suggest_choice() -> None:
+    backend = _ChoiceBackend()
+    config = _make_config(
+        llm_near_match_cache_enabled=True,
+        llm_choice_cache_ttl_seconds=0.0,
+    )
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=config,
+        backend=backend,
+    )
+
+    visible_choices = [{"choice_id": "c1", "text": "选择一", "index": 0, "enabled": True}]
+    context_one: dict[str, Any] = {
+        "scene_id": "scene-a",
+        "visible_choices": visible_choices,
+        "current_snapshot": {"choices": visible_choices, "scene_id": "scene-a"},
+    }
+    context_two = dict(context_one)
+    context_two["screen_context"] = {"x": 1}
+
+    await gateway.suggest_choice(context_one)
+    await gateway.suggest_choice(context_two)
+    await gateway.shutdown()
+
+    # suggest_choice is intentionally excluded → both calls miss any cache
+    assert backend.calls == 2
+    assert len(gateway._near_match_cache) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_update_config_clears_near_match_cache_on_toggle() -> None:
+    backend = _ExplainBackend()
+    config = _make_config(
+        llm_near_match_cache_enabled=True,
+        llm_explain_cache_ttl_seconds=0.0,
+    )
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=config,
+        backend=backend,
+    )
+    await gateway.explain_line(_explain_context())
+    assert len(gateway._near_match_cache) == 1
+    gateway.update_config(_make_config(llm_near_match_cache_enabled=False))
+    assert len(gateway._near_match_cache) == 0
+    await gateway.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_update_config_clears_exact_cache_when_operation_ttl_changes() -> None:
+    backend = _ExplainBackend()
+    gateway = LLMGateway(
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=_make_config(llm_explain_cache_ttl_seconds=60.0),
+        backend=backend,
+    )
+
+    first = await gateway.explain_line(_explain_context())
+    assert len(gateway._cache) == 1
+
+    gateway.update_config(_make_config(llm_explain_cache_ttl_seconds=0.0))
+    assert len(gateway._cache) == 0
+
+    second = await gateway.explain_line(_explain_context())
+    await gateway.shutdown()
+
+    assert first["explanation"] == "explanation-1"
+    assert second["explanation"] == "explanation-2"
     assert backend.calls == 2
 
 
 @pytest.mark.asyncio
-async def test_llm_gateway_near_match_does_not_apply_to_suggest_choice() -> None:
-    backend = _Backend()
+@pytest.mark.plugin_unit
+async def test_update_config_clears_near_match_cache_when_ttl_changes() -> None:
+    backend = _ExplainBackend()
     gateway = LLMGateway(
-        None,
-        None,
-        _config(llm_near_match_cache_enabled=True, llm_request_cache_ttl_seconds=0),
+        plugin=SimpleNamespace(plugins=None),
+        logger=_Logger(),
+        config=_make_config(
+            llm_near_match_cache_enabled=True,
+            llm_near_match_cache_ttl_seconds=60.0,
+            llm_explain_cache_ttl_seconds=0.0,
+        ),
         backend=backend,
     )
-    context = {
-        "visible_choices": [{"choice_id": "choice-1", "text": "left"}],
-    }
 
-    await gateway.suggest_choice(context)
-    await gateway.suggest_choice({**context, "current_snapshot": {"noise": True}})
+    await gateway.explain_line(_explain_context())
+    assert len(gateway._near_match_cache) == 1
 
-    assert backend.calls == 2
-
-
-def test_near_match_helpers_hash_and_observed_similarity() -> None:
-    assert _hash_line({"line_id": "1", "text": "hello"}) == _hash_line(
-        {"line_id": "1", "text": "hello"}
+    gateway.update_config(
+        _make_config(
+            llm_near_match_cache_enabled=True,
+            llm_near_match_cache_ttl_seconds=0.0,
+            llm_explain_cache_ttl_seconds=0.0,
+        )
     )
-    assert _observed_similarity(["same current line"], ["same current line."]) >= 0.85
-    assert _observed_similarity(["same current line"], ["different plot"]) < 0.85
+    assert len(gateway._near_match_cache) == 0
+    await gateway.shutdown()

--- a/plugin/tests/unit/plugins/test_galgame_repeat_detection.py
+++ b/plugin/tests/unit/plugins/test_galgame_repeat_detection.py
@@ -81,6 +81,31 @@ async def test_repeat_guard_does_not_retry_different_response() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.plugin_unit
+async def test_repeat_guard_respects_disabled_config() -> None:
+    backend = _Backend(
+        [
+            {"reply": "The scene is quiet."},
+            {"reply": "The scene is quiet."},
+            {"reply": "The current line adds new tension."},
+        ]
+    )
+    gateway = LLMGateway(
+        None,
+        None,
+        _config(llm_repeat_detection_enabled=False),
+        backend=backend,
+    )
+
+    await gateway.agent_reply({"prompt": "status", "public_context": {}})
+    result = await gateway.agent_reply({"prompt": "status", "public_context": {}})
+
+    assert result["reply"] == "The scene is quiet."
+    assert len(backend.calls) == 2
+    assert all("_anti_repeat_instruction" not in context for _, context in backend.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
 async def test_repeat_guard_retry_failure_returns_original_response() -> None:
     backend = _Backend(
         [

--- a/plugin/tests/unit/plugins/test_galgame_store_config.py
+++ b/plugin/tests/unit/plugins/test_galgame_store_config.py
@@ -225,9 +225,31 @@ def test_galgame_store_context_snapshot_can_disable_game_id_requirement(
     )
 
     assert store.load_context_snapshot(
-        current_game_id="",
+        current_game_id="game-a",
         require_game_id=False,
     )["game_id"] == "game-a"
+
+
+def test_load_context_snapshot_rejects_mismatched_game_id_even_when_optional(
+    tmp_path: Path,
+) -> None:
+    store = _make_store(tmp_path)
+    store.persist_context_snapshot(
+        {
+            "game_id": "game-a",
+            "summary_seed": "summary",
+            "saved_at": time.time(),
+        }
+    )
+
+    assert store.load_context_snapshot(
+        current_game_id="game-b",
+        require_game_id=False,
+    ) == {}
+    assert store.load_context_snapshot(
+        current_game_id="",
+        require_game_id=False,
+    ) == {}
 
 
 def test_galgame_snapshot_state_redacts_context_snapshot_by_default() -> None:

--- a/plugin/tests/unit/plugins/test_galgame_store_config.py
+++ b/plugin/tests/unit/plugins/test_galgame_store_config.py
@@ -203,6 +203,24 @@ def test_galgame_store_context_snapshot_rejects_mismatched_session_id(tmp_path: 
     assert store.load_context_snapshot(current_game_id="game-a") == {}
 
 
+def test_galgame_store_context_snapshot_rejects_missing_session_when_current_given(
+    tmp_path: Path,
+) -> None:
+    store = _make_store(tmp_path)
+    store.persist_context_snapshot(
+        {
+            "game_id": "game-a",
+            "summary_seed": "legacy summary",
+            "saved_at": time.time(),
+        }
+    )
+
+    assert store.load_context_snapshot(
+        current_game_id="game-a",
+        current_session_id="sess-a",
+    ) == {}
+
+
 def test_galgame_store_clear_context_snapshot_checks_expected_snapshot(tmp_path: Path) -> None:
     store = _make_store(tmp_path)
     old_snapshot = {

--- a/plugin/tests/unit/plugins/test_galgame_store_config.py
+++ b/plugin/tests/unit/plugins/test_galgame_store_config.py
@@ -159,6 +159,7 @@ def test_galgame_store_context_snapshot_round_trips_and_checks_game_id(tmp_path:
     snapshot = {
         "scene_id": "scene-a",
         "game_id": "game-a",
+        "session_id": "sess-a",
         "route_id": "route-a",
         "summary_seed": "summary",
         "stable_line_ids": ["line-1", "line-2"],
@@ -167,13 +168,68 @@ def test_galgame_store_context_snapshot_round_trips_and_checks_game_id(tmp_path:
 
     store.persist_context_snapshot(snapshot)
 
-    loaded = store.load_context_snapshot(current_game_id="game-a")
+    loaded = store.load_context_snapshot(
+        current_game_id="game-a",
+        current_session_id="sess-a",
+    )
     mismatch = store.load_context_snapshot(current_game_id="game-b")
 
     assert loaded["scene_id"] == "scene-a"
+    assert loaded["session_id"] == "sess-a"
     assert loaded["summary_seed"] == "summary"
     assert loaded["stable_line_ids"] == ["line-1", "line-2"]
     assert mismatch == {}
+
+
+def test_galgame_store_context_snapshot_rejects_mismatched_session_id(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    store.persist_context_snapshot(
+        {
+            "game_id": "game-a",
+            "session_id": "sess-a",
+            "summary_seed": "summary",
+            "saved_at": time.time(),
+        }
+    )
+
+    assert store.load_context_snapshot(
+        current_game_id="game-a",
+        current_session_id="sess-a",
+    )["summary_seed"] == "summary"
+    assert store.load_context_snapshot(
+        current_game_id="game-a",
+        current_session_id="sess-b",
+    ) == {}
+    assert store.load_context_snapshot(current_game_id="game-a") == {}
+
+
+def test_galgame_store_clear_context_snapshot_checks_expected_snapshot(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    old_snapshot = {
+        "game_id": "game-a",
+        "session_id": "old-session",
+        "summary_seed": "old",
+        "saved_at": time.time(),
+    }
+    current_snapshot = {
+        "game_id": "game-a",
+        "session_id": "new-session",
+        "summary_seed": "new",
+        "saved_at": time.time(),
+    }
+    store.persist_context_snapshot(current_snapshot)
+
+    store.clear_context_snapshot(old_snapshot)
+    assert store.load_context_snapshot(
+        current_game_id="game-a",
+        current_session_id="new-session",
+    )["summary_seed"] == "new"
+
+    store.clear_context_snapshot(current_snapshot)
+    assert store.load_context_snapshot(
+        current_game_id="game-a",
+        current_session_id="new-session",
+    ) == {}
 
 
 def test_galgame_store_context_snapshot_strict_load_rejects_empty_game_id_and_expires(


### PR DESCRIPTION
Summary
- Add session-aware context snapshot restore validation.
- Clear stale context snapshots across session changes.
- Normalize route_id comparison in context restore/resolution.
- Use effective current line scene/route for reply context.
- Add regression coverage for snapshot restore and context/cache behavior.

Validation
- .\.venv\Scripts\python.exe -m pytest plugin\tests\unit\plugins\test_galgame_bridge_config.py plugin\tests\unit\plugins\test_galgame_store_config.py plugin\tests\unit\plugins\test_galgame_context_builder.py plugin\tests\unit\plugins\test_galgame_context_metrics.py plugin\tests\unit\plugins\test_galgame_llm_gateway_cache.py -q --basetemp .pytest-run-pr2-context
- .\.venv\Scripts\python.exe -m pytest plugin\tests\unit\plugins\test_galgame_llm_gateway.py plugin\tests\unit\plugins\test_galgame_bridge_agent.py -q --basetemp .pytest-run-pr2-agent-gateway

Risk
- Context restore semantics change around session boundaries.
- Main regression risk is accidentally dropping valid snapshots; tests cover matching session restore and stale session rejection.