### PR TITLE
fix(galgame): retry repeated agent replies

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -630,14 +630,11 @@ class OmniRealtimeClient:
     
     async def clear_audio_buffer(self):
         """发送 input_audio_buffer.clear 事件清空服务端缓存。"""
-        # TEMP: 临时禁用 input_audio_buffer.clear 发送，测试不主动清空服务端缓存的效果。
-        # 注释覆盖所有调用点（静音自动清 + prompt_ephemeral 注入 abort）。
-        # clear_event = {
-        #     "type": "input_audio_buffer.clear"
-        # }
-        # await self.send_event(clear_event)
-        # logger.debug("📤 已发送 input_audio_buffer.clear 事件")
-        return
+        if self._is_gemini:
+            logger.debug("Gemini mode: no WebSocket input_audio_buffer.clear event")
+            return
+        await self.send_event({"type": "input_audio_buffer.clear"})
+        logger.debug("📤 已发送 input_audio_buffer.clear 事件")
 
     async def connect(self, instructions: str, native_audio=True) -> None:
         """Establish WebSocket connection with the Realtime API."""

--- a/plugin/tests/unit/plugins/test_galgame_repeat_detection.py
+++ b/plugin/tests/unit/plugins/test_galgame_repeat_detection.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from plugin.plugins.galgame_plugin.llm_gateway import LLMGateway, _response_similarity
+from plugin.sdk.shared.models import Ok
 
 
 class _Backend:
@@ -23,6 +24,22 @@ class _Backend:
 
     async def shutdown(self) -> None:
         return None
+
+
+class _TargetEntries:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def call_entry(
+        self,
+        entry_ref: str,
+        *,
+        params: dict[str, Any],
+        timeout: float,
+    ) -> Ok[dict[str, Any]]:
+        self.calls.append({"entry_ref": entry_ref, "params": params, "timeout": timeout})
+        return Ok(self.responses.pop(0))
 
 
 def _config(**overrides: Any) -> SimpleNamespace:
@@ -63,6 +80,29 @@ async def test_repeat_guard_retries_identical_agent_reply_once() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.plugin_unit
+async def test_repeat_guard_retries_identical_agent_reply_from_target_entry() -> None:
+    target = _TargetEntries(
+        [
+            {"reply": "The scene is quiet."},
+            {"reply": "The scene is quiet."},
+            {"reply": "The current line adds new tension."},
+        ]
+    )
+    plugin = SimpleNamespace(plugins=target)
+    gateway = LLMGateway(plugin, None, _config(llm_target_entry_ref="fake_llm:run"))
+
+    first = await gateway.agent_reply({"prompt": "status", "public_context": {}})
+    second = await gateway.agent_reply({"prompt": "status", "public_context": {}})
+
+    assert first["reply"] == "The scene is quiet."
+    assert second["reply"] == "The current line adds new tension."
+    assert len(target.calls) == 3
+    retry_context = target.calls[2]["params"]["context"]
+    assert "_anti_repeat_instruction" in retry_context
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
 async def test_repeat_guard_does_not_retry_different_response() -> None:
     backend = _Backend(
         [
@@ -77,6 +117,31 @@ async def test_repeat_guard_does_not_retry_different_response() -> None:
 
     assert result["reply"] == "A new choice has appeared."
     assert len(backend.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.plugin_unit
+async def test_repeat_guard_respects_disabled_config() -> None:
+    backend = _Backend(
+        [
+            {"reply": "The scene is quiet."},
+            {"reply": "The scene is quiet."},
+            {"reply": "The current line adds new tension."},
+        ]
+    )
+    gateway = LLMGateway(
+        None,
+        None,
+        _config(llm_repeat_detection_enabled=False),
+        backend=backend,
+    )
+
+    await gateway.agent_reply({"prompt": "status", "public_context": {}})
+    result = await gateway.agent_reply({"prompt": "status", "public_context": {}})
+
+    assert result["reply"] == "The scene is quiet."
+    assert len(backend.calls) == 2
+    assert all("_anti_repeat_instruction" not in context for _, context in backend.calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_voice_session.py
+++ b/tests/unit/test_voice_session.py
@@ -143,6 +143,40 @@ async def test_stream_audio(realtime_client):
 
 
 @pytest.mark.unit
+async def test_clear_audio_buffer_sends_websocket_clear_event():
+    client = _make_manual_client(model="qwen-omni-turbo-realtime", api_type="qwen")
+    sent: list[dict] = []
+
+    async def fake_send(payload):
+        sent.append(json.loads(payload))
+
+    client.ws = AsyncMock()
+    client.ws.send = AsyncMock(side_effect=fake_send)
+
+    await client.clear_audio_buffer()
+
+    assert [event["type"] for event in sent] == ["input_audio_buffer.clear"]
+
+
+@pytest.mark.unit
+async def test_silence_reset_flushes_buffer_before_next_audio_append():
+    client = _make_manual_client(model="qwen-omni-turbo-realtime", api_type="qwen")
+    sent: list[dict] = []
+
+    async def fake_send(payload):
+        sent.append(json.loads(payload))
+
+    client.ws = AsyncMock()
+    client.ws.send = AsyncMock(side_effect=fake_send)
+    client._silence_reset_pending = True
+
+    await client.stream_audio(DUMMY_AUDIO_CHUNK)
+
+    types_sent = [event["type"] for event in sent]
+    assert types_sent[:2] == ["input_audio_buffer.clear", "input_audio_buffer.append"]
+
+
+@pytest.mark.unit
 async def test_receive_text_delta(realtime_client):
     """Test handling of incoming text delta events via handle_messages."""
     # Simulate a sequence of WebSocket messages that includes text deltas


### PR DESCRIPTION
Summary
- Retry/fallback when agent replies repeat previous content.
- Add regression coverage for repeated reply handling.

Validation
- .\.venv\Scripts\python.exe -m pytest plugin\tests\unit\plugins\test_galgame_repeat_detection.py plugin\tests\unit\plugins\test_galgame_llm_gateway.py plugin\tests\unit\plugins\test_galgame_bridge_agent.py -q --basetemp .pytest-run-pr3-repeat

Risk
- Retry behavior changes agent response flow when repeated content is detected.
- Main regression risk is over-triggering retry on legitimate repeated wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复音频缓冲区清空功能，在不同模式下工作更加可靠。

* **Tests**
  * 补充音频处理和内容重复检测相关的单元测试用例，提升代码覆盖质量。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->