### PR TITLE
修复角色卡音色下拉中克隆音色显示为 voice_id 的问题，改为优先显示克隆前缀，并补充回归测试

### DIFF
--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -5650,6 +5650,17 @@ function _panelNormalizeVoiceGroupLabel(label) {
     return String(label || '').replace(/^[\s\-—–─]+|[\s\-—–─]+$/g, '').trim();
 }
 
+function _panelGetRegisteredVoiceDisplayName(voiceId, voiceData) {
+    if (voiceData && typeof voiceData === 'object') {
+        const prefix = String(voiceData.prefix || '').trim();
+        if (prefix) return prefix;
+
+        const name = String(voiceData.name || '').trim();
+        if (name) return name;
+    }
+    return String(voiceId || '').trim();
+}
+
 // 创建音色自定义单选下拉，原生 select 只负责表单值。
 function _panelCreateVoiceSelectUi(selectEl) {
     const container = document.createElement('div');
@@ -5912,17 +5923,11 @@ async function _loadPanelVoices(selectEl, currentVoiceId) {
             selectEl.appendChild(defaultOption);
 
             // 添加音色选项
-            const voiceOwners = data.voice_owners || {};
             Object.entries(data.voices).forEach(function ([voiceId, voiceData]) {
                 const option = document.createElement('option');
                 option.value = voiceId;
-                // 显示名称：优先用 voice_owners，其次 voiceData.name，最后 voiceId
-                let displayName = voiceId;
-                if (voiceOwners[voiceId]) {
-                    displayName = voiceOwners[voiceId] + ' - ' + voiceId;
-                } else if (voiceData && voiceData.name) {
-                    displayName = voiceData.name;
-                }
+                // 克隆音色的可读名称存在 prefix 中，不能被角色占用信息或 voice_id 覆盖。
+                const displayName = _panelGetRegisteredVoiceDisplayName(voiceId, voiceData);
                 option.textContent = displayName;
                 option.title = voiceId;
                 if (voiceId === currentVoiceId) option.selected = true;

--- a/tests/frontend/test_character_card_manager_regressions.py
+++ b/tests/frontend/test_character_card_manager_regressions.py
@@ -300,6 +300,83 @@ def test_character_card_manager_renders_subscribed_preview_image_url_fallback(
 
 
 @pytest.mark.frontend
+def test_character_card_manager_voice_dropdown_prefers_clone_prefix(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_character_card_manager(mock_page, running_server)
+
+    state = mock_page.evaluate(
+        """
+        async () => {
+            const originalFetch = window.fetch.bind(window);
+            window.fetch = async (input, init) => {
+                const url = typeof input === 'string' ? input : input.url;
+                const path = new URL(url, window.location.origin).pathname;
+
+                if (path === '/api/characters/voices') {
+                    return new Response(JSON.stringify({
+                        voices: {
+                            customabc123: {
+                                voice_id: 'customabc123',
+                                prefix: 'Sweet01',
+                                name: 'customabc123',
+                                provider: 'minimax'
+                            },
+                            customnameonly: {
+                                voice_id: 'customnameonly',
+                                name: 'Readable Name',
+                                provider: 'cosyvoice'
+                            }
+                        },
+                        free_voices: {},
+                        native_voices: {},
+                        voice_owners: {
+                            customabc123: ['缓存猫娘']
+                        }
+                    }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+
+                if (path === '/api/characters/custom_tts_voices') {
+                    return new Response(JSON.stringify({ success: true, voices: [] }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+
+                return originalFetch(input, init);
+            };
+
+            const select = document.createElement('select');
+            document.body.appendChild(select);
+            const ui = _panelCreateVoiceSelectUi(select);
+            document.body.appendChild(ui.container);
+
+            await _loadPanelVoices(select, 'customabc123');
+            ui.refresh();
+
+            const optionTexts = Array.from(select.options).map(option => ({
+                value: option.value,
+                text: option.textContent
+            }));
+
+            return {
+                selectedText: ui.container.querySelector('.voice-select-selected')?.textContent || '',
+                optionTexts
+            };
+        }
+        """
+    )
+
+    assert state["selectedText"] == "Sweet01"
+    assert {"value": "customabc123", "text": "Sweet01"} in state["optionTexts"]
+    assert {"value": "customnameonly", "text": "Readable Name"} in state["optionTexts"]
+
+
+@pytest.mark.frontend
 def test_character_card_manager_creates_tag_scroll_buttons_for_dynamic_wrapper(
     mock_page: Page,
     running_server: str,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 优化了自定义语音下拉菜单的显示名称生成逻辑，现在会优先使用克隆语音的前缀信息作为显示名称，提供更清晰的语音标识。

* **Tests**
  * 新增回归测试，验证自定义语音下拉菜单中克隆语音前缀优先显示的功能正常工作。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->