### PR TITLE
test: 临时禁用 input_audio_buffer.clear 发送

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -623,11 +623,14 @@ class OmniRealtimeClient:
     
     async def clear_audio_buffer(self):
         """发送 input_audio_buffer.clear 事件清空服务端缓存。"""
-        clear_event = {
-            "type": "input_audio_buffer.clear"
-        }
-        await self.send_event(clear_event)
-        logger.debug("📤 已发送 input_audio_buffer.clear 事件")
+        # TEMP: 临时禁用 input_audio_buffer.clear 发送，测试不主动清空服务端缓存的效果。
+        # 注释覆盖所有调用点（静音自动清 + prompt_ephemeral 注入 abort）。
+        # clear_event = {
+        #     "type": "input_audio_buffer.clear"
+        # }
+        # await self.send_event(clear_event)
+        # logger.debug("📤 已发送 input_audio_buffer.clear 事件")
+        return
 
     async def connect(self, instructions: str, native_audio=True) -> None:
         """Establish WebSocket connection with the Realtime API."""


### PR DESCRIPTION
## Summary
- 把 `OmniRealtimeClient.clear_audio_buffer()` 改成 no-op，临时禁用所有 `input_audio_buffer.clear` 事件发送
- 覆盖现有全部调用点：静音 4s 自动清（`_should_clear_audio_buffer_on_silence`）+ `prompt_ephemeral` 注入 abort 三处
- 仅注释，不删调用方逻辑，方便回退

## Why
临时验证不主动清空服务端音频缓存时的实际效果，看会不会有残余 chunk 触发误响应、或者反而改善多轮表现。

## Test plan
- [ ] 静音 4s+ 不再观察到 `📤 已发送 input_audio_buffer.clear 事件` debug 日志
- [ ] 多轮对话能正常进入下一轮（不会被卡住）
- [ ] prompt_ephemeral 注入被 abort 时残余 chunk 不会触发额外 AI 响应

⚠️ 此 PR 不应合并到 main，验证完直接关闭或 revert。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 调整了实时音频通信模块中的音频缓冲区清空机制，禁用了相关事件的发送功能。
* 移除了缓冲区清空操作的调试日志记录功能。
* 原有处理逻辑已保留并注释，便于后续参考和恢复使用。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->