### PR TITLE
fix(chat): 同轮多 response item 时拆 bubble 而非清状态

### DIFF
--- a/static/app-audio-capture.js
+++ b/static/app-audio-capture.js
@@ -1110,6 +1110,7 @@
         window._realisticGeminiQueue = [];
         window._realisticGeminiBuffer = '';
         window._geminiTurnFullText = '';
+        window._geminiTurnEndSealed = false;
         window._pendingMusicCommand = '';
         window._realisticGeminiVersion = (window._realisticGeminiVersion || 0) + 1;
         window.currentTurnGeminiBubbles = [];

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -680,6 +680,7 @@
             // 重置聊天相关的全局状态
             window.currentGeminiMessage = null;
             window._geminiTurnFullText = '';
+            window._geminiTurnEndSealed = false;
             window.currentTurnGeminiBubbles = [];
             window.currentTurnGeminiAttachments = [];
             // 清空realistic synthesis队列和缓冲区，防止旧角色的语音继续播放
@@ -1847,6 +1848,7 @@
 
         window.currentGeminiMessage = null;
         window._geminiTurnFullText = '';
+        window._geminiTurnEndSealed = false;
         window.currentTurnGeminiBubbles = [];
         window.currentTurnGeminiAttachments = [];
         window._realisticGeminiQueue = [];

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -532,6 +532,14 @@
     function appendMessage(text, sender, isNewMessage, options) {
         if (typeof isNewMessage === 'undefined') isNewMessage = true;
         options = options || {};
+        // Set by app-websocket.js when an `isNewMessage=true` chunk carries
+        // the same `turn_id` as the still-open turn — i.e. a second/third
+        // response item the realtime LLM emitted within the same dialog
+        // turn. We must still open a fresh bubble (each response item is a
+        // distinct utterance) but must not wipe turn-scoped tracking that
+        // groups all bubbles of the dialog turn together (used by
+        // response_discarded / activity cancel cleanup).
+        var midTurnRestart = !!options.midTurnRestart;
 
         var host = getHost();
         var bubbleCountBefore = window.currentTurnGeminiBubbles ? window.currentTurnGeminiBubbles.length : 0;
@@ -549,18 +557,56 @@
                 window._pendingMusicCommand = '';
                 window._structuredGeminiStreaming = false;
                 window._turnIsStructured = false;
-                window.currentTurnGeminiBubbles = [];
-                window.currentTurnGeminiAttachments = [];
-                // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
-                // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
-                // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
-                // 闸门，否则上一轮结束留下的 true 会把本轮首个 chunk 吞掉。
-                if (typeof window.beginSubtitleTurn === 'function') {
-                    window.beginSubtitleTurn();
+                // 新轮开始：重置 post-seal 跟踪（详见下方 _geminiTurnEndSealed 注释）
+                window._geminiTurnEndSealed = false;
+                window._geminiPostSealBubbleStart = 0;
+                if (!midTurnRestart) {
+                    // Genuinely new dialog turn → reset turn-scoped tracking.
+                    // For a mid-turn new response item we keep the existing
+                    // bubble refs so the dialog-turn cleanup paths
+                    // (response_discarded, user-activity-cancel) still know
+                    // about every bubble created in this turn.
+                    window.currentTurnGeminiBubbles = [];
+                    window.currentTurnGeminiAttachments = [];
+                    // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
+                    // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
+                    // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
+                    // 闸门，否则上一轮结束留下的 true 会把本轮首个 chunk 吞掉。
+                    if (typeof window.beginSubtitleTurn === 'function') {
+                        window.beginSubtitleTurn();
+                    }
                 }
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);
+
+            // ── Post-seal 续写检测（multi-response-item in same dialog turn）──
+            //
+            // 触发场景：同一 dialog turn 内 LLM 发了 N 段 audio + 文本（典型
+            // case：tool 调用前后两段台词；或 Gemini Live "late continuation"
+            // — turn_complete 后 _ai_recent_activity_window 内又来内容）。
+            // 第 1 段 audio 播完 → main_server 发 turn_end #1（前端把当前气泡
+            // status 置为 'sent'）。然后第 2 段 text deltas 继续过来，但
+            // is_first_chunk 仍是 False（因为服务端不重置它），前端拿到的是
+            // isNewMessage=false → 落进 Scenario B（merge）/ realistic queue。
+            // 老逻辑会把整轮累积文本（段 1+段 2）一起更新到段 1 那个**已封口**
+            // 的气泡，但 React StreamingText 在 status sent→streaming 切换时
+            // 会重 mount，settledLen 复位看上去像段 2 文本闪没了。
+            //
+            // 此处把 turn_end 后的首个 chunk 当作"新气泡的起点"：
+            //   - 清掉 currentGeminiMessage 让 merge Scenario B 落到 Scenario A
+            //     去新建气泡；
+            //   - 记录此时的 _geminiTurnFullText 长度（_geminiPostSealBubbleStart），
+            //     之后 Scenario B 用 _geminiTurnFullText.slice(start) 喂给气泡，
+            //     保证段 2 的气泡只展示段 2 的文本，不和段 1 重复。
+            //   - realistic 模式不受影响：每个句子本来就是独立气泡。
+            // turn_end handler (app-websocket.js) 负责设 _geminiTurnEndSealed。
+            if (window._geminiTurnEndSealed && !isNewMessage) {
+                window._geminiTurnEndSealed = false;
+                window._geminiPostSealBubbleStart = prevFull.length;
+                // 让 merge Scenario B 走到 Scenario A 的新建气泡分支
+                window.currentGeminiMessage = null;
+            }
 
             // 常驻字幕流式写入（adapter 是生产常驻路径；PR #777 漏了这段，导致 React
             // 聊天窗口下字幕只能等 turn_end 才首次出现，视觉上像"一口气显示"）。
@@ -661,8 +707,12 @@
         } else if (sender === 'gemini' && isMergeMessagesEnabled()) {
             var cleanText = cleanMusicFromChunk(text);
 
-            // 场景 A: 本轮尚无气泡
-            if (!window.currentTurnGeminiBubbles || window.currentTurnGeminiBubbles.length === 0) {
+            // 场景 A: 本轮尚无气泡，或 post-seal 后 currentGeminiMessage 已被
+            // 清空（adapter 上方 _geminiTurnEndSealed 处理把 currentGeminiMessage
+            // 置 null，逼这里走"新建气泡"分支以避免往封口气泡追加）。
+            // currentTurnGeminiBubbles 可能仍含上一段气泡，所以要看
+            // currentGeminiMessage 而不是数组长度。
+            if (!window.currentGeminiMessage) {
                 if (cleanText.trim() && host) {
                     var newId = nextReactMessageId('assistant');
                     var newTime = getCurrentTimeString();
@@ -683,7 +733,14 @@
             }
             // 场景 B: 气泡已存在，追加更新
             else if (window.currentGeminiMessage && host) {
-                var fullMergeText = (window._geminiTurnFullText || '').replace(/\[play_music:[^\]]*(\]|$)/g, '');
+                // post-seal: 同一 dialog turn 里 turn_end 之后新建的气泡只展示
+                // post-seal 区段，避免和上一个已封口气泡重复。
+                var postSealStart = window._geminiPostSealBubbleStart || 0;
+                var rawTurnText = window._geminiTurnFullText || '';
+                var rawBubbleText = postSealStart > 0 && postSealStart < rawTurnText.length
+                    ? rawTurnText.slice(postSealStart)
+                    : rawTurnText;
+                var fullMergeText = rawBubbleText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
                 var existingId = window.currentGeminiMessage.dataset.reactChatMessageId;
                 var stableTime = window.currentGeminiMessage._stableTime || getCurrentTimeString();
                 var updatedMsg = buildMessage(existingId, 'assistant', getCurrentAssistantName(), stableTime, fullMergeText, 'streaming');

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -568,13 +568,16 @@
                     // about every bubble created in this turn.
                     window.currentTurnGeminiBubbles = [];
                     window.currentTurnGeminiAttachments = [];
-                    // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
-                    // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
-                    // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
-                    // 闸门，否则上一轮结束留下的 true 会把本轮首个 chunk 吞掉。
-                    if (typeof window.beginSubtitleTurn === 'function') {
-                        window.beginSubtitleTurn();
-                    }
+                }
+                // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
+                // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
+                // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
+                // 闸门，否则上一轮（或同轮上一段 turn_end 后的 translateAndShowSubtitle）
+                // 留下的 true 会把本段首个 chunk 吞掉。midTurnRestart 也必须走这条
+                // —— bubble 跟踪要跨段保留，但 subtitle 闸门是 per-segment 的，
+                // 不重置就会让 seg2 的流式字幕直到 finalization 都不显示。
+                if (typeof window.beginSubtitleTurn === 'function') {
+                    window.beginSubtitleTurn();
                 }
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -532,84 +532,69 @@
     function appendMessage(text, sender, isNewMessage, options) {
         if (typeof isNewMessage === 'undefined') isNewMessage = true;
         options = options || {};
-        // Set by app-websocket.js when an `isNewMessage=true` chunk carries
-        // the same `turn_id` as the still-open turn — i.e. a second/third
-        // response item the realtime LLM emitted within the same dialog
-        // turn. We must still open a fresh bubble (each response item is a
-        // distinct utterance) but must not wipe turn-scoped tracking that
-        // groups all bubbles of the dialog turn together (used by
-        // response_discarded / activity cancel cleanup).
-        var midTurnRestart = !!options.midTurnRestart;
+        // Note: `options.midTurnRestart` is set by app-websocket.js but the
+        // adapter no longer consumes it directly — it's used only by the
+        // websocket handler to avoid double-emitting assistantTurn lifecycle
+        // events. The adapter treats each response item as a fresh segment
+        // (see `startNewSegment` below).
 
         var host = getHost();
         var bubbleCountBefore = window.currentTurnGeminiBubbles ? window.currentTurnGeminiBubbles.length : 0;
         var createdVisibleBubble = false;
 
-        // 维护"本轮 AI 回复"的完整文本（emotion analysis / subtitle 需要）
+        // 维护"本段 AI 回复"的完整文本（emotion analysis / subtitle 需要）
         if (sender === 'gemini') {
-            if (isNewMessage) {
-                // 修复：新一轮开始前，同步渲染旧队列中所有待处理句子，
-                // 防止 processRealisticQueue 的 async 循环因 version 变更而
-                // 静默丢弃队列中剩余的句子（语音打断时的高频触发场景）。
+            // ── Segment boundary detection ──────────────────────────────────
+            // 一个 dialog turn 内可能出现多段独立的 AI 回复，每段都是一个
+            // 完整的 utterance（独立音频、独立 turn_end、独立 emotion）：
+            //
+            //   Path A (multi-response-item)：realtime LLM 同一对话轮里连发
+            //     N 次 response.created，服务端 omni_realtime_client 每次都
+            //     把 _is_first_text_chunk 复位为 True，所以 seg2 首 chunk
+            //     也以 isNewMessage=true 抵达。turn_end_1 一定在 seg2 chunks
+            //     之前发出（handle_response_complete 同步 await）。
+            //
+            //   Path B (late continuation)：Gemini Live 在 response.done 之后
+            //     的 _ai_recent_activity_window 内还能来 chunk（典型 case：
+            //     tool 调用前后两段台词）。服务端不重置 _is_first_text_chunk，
+            //     前端拿到的是 isNewMessage=false。但 turn_end 已经发过且
+            //     adapter 已把上一段气泡置 'sent' —— React StreamingText
+            //     会在 status sent→streaming 切换时 re-mount + settledLen
+            //     复位，导致 seg2 文字视觉上闪没。
+            //
+            // turn_end handler (app-websocket.js) 在两条路径之间都设
+            // window._geminiTurnEndSealed = true。本段第一个 chunk 看到
+            // sealed && !isNewMessage 即为 Path B 的虚拟"段起点"，与
+            // Path A 的 isNewMessage=true 统一走同一套 per-segment reset。
+            var startNewSegment = isNewMessage || !!window._geminiTurnEndSealed;
+            if (startNewSegment) {
+                // 同步渲染旧队列中所有待处理句子，防止 processRealisticQueue
+                // 的 async 循环因 version 变更而静默丢弃队列中剩余的句子。
                 _flushPendingRealisticQueue();
                 window._realisticGeminiVersion = (window._realisticGeminiVersion || 0) + 1;
                 window._geminiTurnFullText = '';
                 window._pendingMusicCommand = '';
                 window._structuredGeminiStreaming = false;
                 window._turnIsStructured = false;
-                // 新轮开始：重置 post-seal 跟踪（详见下方 _geminiTurnEndSealed 注释）
                 window._geminiTurnEndSealed = false;
-                window._geminiPostSealBubbleStart = 0;
-                if (!midTurnRestart) {
-                    // Genuinely new dialog turn → reset turn-scoped tracking.
-                    // For a mid-turn new response item we keep the existing
-                    // bubble refs so the dialog-turn cleanup paths
-                    // (response_discarded, user-activity-cancel) still know
-                    // about every bubble created in this turn.
-                    window.currentTurnGeminiBubbles = [];
-                    window.currentTurnGeminiAttachments = [];
-                }
-                // 提前复位字幕 turn 状态：neko-assistant-turn-start 事件要等
-                // 首个可见气泡创建后才发，而 updateSubtitleStreamingText 在
-                // 首个 chunk 就会被调用，必须在此解锁 isCurrentTurnFinalized
-                // 闸门，否则上一轮（或同轮上一段 turn_end 后的 translateAndShowSubtitle）
-                // 留下的 true 会把本段首个 chunk 吞掉。midTurnRestart 也必须走这条
-                // —— bubble 跟踪要跨段保留，但 subtitle 闸门是 per-segment 的，
-                // 不重置就会让 seg2 的流式字幕直到 finalization 都不显示。
+                // Per-segment scoping for cleanup. response_discarded /
+                // user-activity-cancel 都只针对当前 in-flight response item，
+                // 不应跨段抹掉已经完成的上一段气泡 —— per-segment 才对。
+                // currentGeminiMessage 也显式置 null，防止
+                // renderStructuredGeminiMessage 把上一段气泡误当成"当前段
+                // 已建气泡"走 collapse + upgrade 把它覆盖掉。
+                window.currentTurnGeminiBubbles = [];
+                window.currentTurnGeminiAttachments = [];
+                window.currentGeminiMessage = null;
+                // 字幕闸门 reset：上一段 turn_end 触发的 translateAndShowSubtitle
+                // 会把 isCurrentTurnFinalized 置 true；不重置就会把本段首个
+                // chunk 的 updateSubtitleStreamingText 静默丢弃。
                 if (typeof window.beginSubtitleTurn === 'function') {
                     window.beginSubtitleTurn();
                 }
             }
             var prevFull = typeof window._geminiTurnFullText === 'string' ? window._geminiTurnFullText : '';
             window._geminiTurnFullText = prevFull + normalizeGeminiText(text);
-
-            // ── Post-seal 续写检测（multi-response-item in same dialog turn）──
-            //
-            // 触发场景：同一 dialog turn 内 LLM 发了 N 段 audio + 文本（典型
-            // case：tool 调用前后两段台词；或 Gemini Live "late continuation"
-            // — turn_complete 后 _ai_recent_activity_window 内又来内容）。
-            // 第 1 段 audio 播完 → main_server 发 turn_end #1（前端把当前气泡
-            // status 置为 'sent'）。然后第 2 段 text deltas 继续过来，但
-            // is_first_chunk 仍是 False（因为服务端不重置它），前端拿到的是
-            // isNewMessage=false → 落进 Scenario B（merge）/ realistic queue。
-            // 老逻辑会把整轮累积文本（段 1+段 2）一起更新到段 1 那个**已封口**
-            // 的气泡，但 React StreamingText 在 status sent→streaming 切换时
-            // 会重 mount，settledLen 复位看上去像段 2 文本闪没了。
-            //
-            // 此处把 turn_end 后的首个 chunk 当作"新气泡的起点"：
-            //   - 清掉 currentGeminiMessage 让 merge Scenario B 落到 Scenario A
-            //     去新建气泡；
-            //   - 记录此时的 _geminiTurnFullText 长度（_geminiPostSealBubbleStart），
-            //     之后 Scenario B 用 _geminiTurnFullText.slice(start) 喂给气泡，
-            //     保证段 2 的气泡只展示段 2 的文本，不和段 1 重复。
-            //   - realistic 模式不受影响：每个句子本来就是独立气泡。
-            // turn_end handler (app-websocket.js) 负责设 _geminiTurnEndSealed。
-            if (window._geminiTurnEndSealed && !isNewMessage) {
-                window._geminiTurnEndSealed = false;
-                window._geminiPostSealBubbleStart = prevFull.length;
-                // 让 merge Scenario B 走到 Scenario A 的新建气泡分支
-                window.currentGeminiMessage = null;
-            }
 
             // 常驻字幕流式写入（adapter 是生产常驻路径；PR #777 漏了这段，导致 React
             // 聊天窗口下字幕只能等 turn_end 才首次出现，视觉上像"一口气显示"）。
@@ -629,7 +614,7 @@
 
         // ---------- gemini + realistic 模式 ----------
         if (sender === 'gemini' && !isMergeMessagesEnabled()) {
-            if (isNewMessage) {
+            if (startNewSegment) {
                 window._realisticGeminiBuffer = '';
                 window._realisticGeminiQueue = [];
                 window._lastBubbleTime = 0;
@@ -681,8 +666,8 @@
                 createdVisibleBubble = (window.currentTurnGeminiBubbles ? window.currentTurnGeminiBubbles.length : 0) > bubbleCountBefore;
             }
 
-        // ---------- gemini + merge 模式 + 新轮 ----------
-        } else if (sender === 'gemini' && isMergeMessagesEnabled() && isNewMessage) {
+        // ---------- gemini + merge 模式 + 新段（含 isNewMessage 与 post-seal） ----------
+        } else if (sender === 'gemini' && isMergeMessagesEnabled() && startNewSegment) {
             window._realisticGeminiBuffer = '';
             window._realisticGeminiQueue = [];
             window._lastBubbleTime = 0;
@@ -706,16 +691,14 @@
                 window.currentGeminiMessage = null;
             }
 
-        // ---------- gemini + merge 模式 + 续写 ----------
+        // ---------- gemini + merge 模式 + 段内续写 ----------
         } else if (sender === 'gemini' && isMergeMessagesEnabled()) {
             var cleanText = cleanMusicFromChunk(text);
 
-            // 场景 A: 本轮尚无气泡，或 post-seal 后 currentGeminiMessage 已被
-            // 清空（adapter 上方 _geminiTurnEndSealed 处理把 currentGeminiMessage
-            // 置 null，逼这里走"新建气泡"分支以避免往封口气泡追加）。
-            // currentTurnGeminiBubbles 可能仍含上一段气泡，所以要看
-            // currentGeminiMessage 而不是数组长度。
-            if (!window.currentGeminiMessage) {
+            // 场景 A: 本段尚无气泡（每个 startNewSegment 都已把
+            // currentTurnGeminiBubbles 清空 + currentGeminiMessage 置 null，
+            // 所以两个判断等价；保留 length===0 作为主条件与历史代码对齐）。
+            if (!window.currentTurnGeminiBubbles || window.currentTurnGeminiBubbles.length === 0) {
                 if (cleanText.trim() && host) {
                     var newId = nextReactMessageId('assistant');
                     var newTime = getCurrentTimeString();
@@ -734,16 +717,10 @@
                     window.currentGeminiMessage = null;
                 }
             }
-            // 场景 B: 气泡已存在，追加更新
+            // 场景 B: 气泡已存在，追加更新（_geminiTurnFullText 是 per-segment
+            // 累积，已在 startNewSegment 处重置过，不需要再 slice）。
             else if (window.currentGeminiMessage && host) {
-                // post-seal: 同一 dialog turn 里 turn_end 之后新建的气泡只展示
-                // post-seal 区段，避免和上一个已封口气泡重复。
-                var postSealStart = window._geminiPostSealBubbleStart || 0;
-                var rawTurnText = window._geminiTurnFullText || '';
-                var rawBubbleText = postSealStart > 0 && postSealStart < rawTurnText.length
-                    ? rawTurnText.slice(postSealStart)
-                    : rawTurnText;
-                var fullMergeText = rawBubbleText.replace(/\[play_music:[^\]]*(\]|$)/g, '');
+                var fullMergeText = (window._geminiTurnFullText || '').replace(/\[play_music:[^\]]*(\]|$)/g, '');
                 var existingId = window.currentGeminiMessage.dataset.reactChatMessageId;
                 var stableTime = window.currentGeminiMessage._stableTime || getCurrentTimeString();
                 var updatedMsg = buildMessage(existingId, 'assistant', getCurrentAssistantName(), stableTime, fullMergeText, 'streaming');

--- a/static/app-chat-adapter.js
+++ b/static/app-chat-adapter.js
@@ -532,11 +532,6 @@
     function appendMessage(text, sender, isNewMessage, options) {
         if (typeof isNewMessage === 'undefined') isNewMessage = true;
         options = options || {};
-        // Note: `options.midTurnRestart` is set by app-websocket.js but the
-        // adapter no longer consumes it directly — it's used only by the
-        // websocket handler to avoid double-emitting assistantTurn lifecycle
-        // events. The adapter treats each response item as a fresh segment
-        // (see `startNewSegment` below).
 
         var host = getHost();
         var bubbleCountBefore = window.currentTurnGeminiBubbles ? window.currentTurnGeminiBubbles.length : 0;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1189,12 +1189,7 @@
                     }
                     var createdVisibleBubble = false;
                     if (typeof window.appendMessage === 'function') {
-                        createdVisibleBubble = window.appendMessage(
-                            response.text,
-                            'gemini',
-                            isNewMessage,
-                            { midTurnRestart: !!isMidTurnRestart }
-                        ) === true;
+                        createdVisibleBubble = window.appendMessage(response.text, 'gemini', isNewMessage) === true;
                     }
                     if (createdVisibleBubble && response.request_id) {
                         if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1148,11 +1148,22 @@
                     // can no longer reach segment 1's bubble. Symptom: the
                     // second segment's text fails to render (or briefly
                     // renders and is then evicted) while its audio plays.
+                    //
+                    // Detection signal: compare incoming turn_id against
+                    // `window.realisticGeminiCurrentTurnId`, which is written
+                    // by THIS handler on every chunk (line below) and only
+                    // cleared by character switch / response_discarded — it
+                    // survives ensureAssistantTurnStarted (which nukes
+                    // S.assistantPendingTurnServerId via
+                    // clearPendingAssistantTurnStart the moment seg1's first
+                    // bubble opens, so that field is null by the time seg2
+                    // arrives and is NOT a usable signal here).
                     var normalizedNewTurnId = normalizeAssistantTurnId(response.turn_id);
+                    var normalizedOpenTurnId = normalizeAssistantTurnId(window.realisticGeminiCurrentTurnId);
                     var isMidTurnRestart = isNewMessage
                         && normalizedNewTurnId
-                        && S.assistantPendingTurnServerId
-                        && normalizedNewTurnId === S.assistantPendingTurnServerId
+                        && normalizedOpenTurnId
+                        && normalizedNewTurnId === normalizedOpenTurnId
                         && S.assistantTurnId;
                     if (isNewMessage && !isMidTurnRestart) {
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1136,23 +1136,29 @@
                         var gameEvent = gameMeta.event || {};
                         console.log(`[GameMirror] 主聊天栏收到游戏台词 | game=${gameMeta.game_type || '-'} session=${gameMeta.session_id || '-'} kind=${gameEvent.kind || '-'} round=${gameEvent.round || '-'} source=${response.metadata.source || '-'}`);
                     }
+                    // adapter 用 startNewSegment 抽象统一把每段独立 utterance 处理
+                    // （path A: isNewMessage=true 多 response item；path B: turn_end
+                    // 后的 late continuation, sealed && !isNewMessage）。lifecycle
+                    // 这边也对偶：两条路径都重置 assistantTurn lifecycle 并 emit
+                    // 新的 neko-assistant-turn-start，让 avatar-reaction-bubble /
+                    // subtitle / audio-playback 等 listeners 都拿到独立通知。
+                    //
+                    // path B 尤其关键：avatar-reaction-bubble 的 handleTurnEnd 在
+                    // text-only 段会 schedule fallback hide 定时器，没新 turn-start
+                    // 取消的话 seg2 typing 期间表情气泡会被隐掉。
+                    var sealedContinuation = !isNewMessage && !!window._geminiTurnEndSealed;
                     if (isNewMessage) {
-                        // 同一 dialog turn 内 LLM 也可能再开一段新的 response item
-                        // （realtime LLM 的 response.created 每次都把
-                        // _is_first_text_chunk 复位为 True，所以 seg2 首 chunk
-                        // 也以 isNewMessage=true 抵达，turn_id 跟 seg1 相同）。
-                        // adapter 用 startNewSegment 抽象统一把每段当独立 utterance
-                        // 处理，这里 lifecycle 也对偶 per-segment：每段重发
-                        // neko-assistant-turn-start，让 avatar-reaction-bubble /
-                        // subtitle / audio-playback 等 listeners 都拿到独立通知，
-                        // 客户端 turn id 也跟着换。
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...
+                        // 仅 isNewMessage 走这条 voice-msg fix，sealed continuation
+                        // 是同 dialog turn 延续，无新用户语音消息要修。
                         if (S.lastVoiceUserMessage && S.lastVoiceUserMessage.isConnected &&
                             !S.lastVoiceUserMessage.textContent.trim()) {
                             S.lastVoiceUserMessage.textContent = '...';
                         }
                         S.lastVoiceUserMessage = null;
                         S.lastVoiceUserMessageTime = 0;
+                    }
+                    if (isNewMessage || sealedContinuation) {
                         S.assistantTurnId = null;
                         S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
                         S.assistantTurnAwaitingBubble = true;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1136,36 +1136,16 @@
                         var gameEvent = gameMeta.event || {};
                         console.log(`[GameMirror] 主聊天栏收到游戏台词 | game=${gameMeta.game_type || '-'} session=${gameMeta.session_id || '-'} kind=${gameEvent.kind || '-'} round=${gameEvent.round || '-'} source=${response.metadata.source || '-'}`);
                     }
-                    // Detect "mid-turn new response item": realtime LLM can emit
-                    // multiple `response.created` within a single dialog turn
-                    // (so `_is_first_text_chunk` flips True again on the server
-                    // and we receive a second `isNewMessage=true` carrying the
-                    // SAME `turn_id` as the still-open turn). Treating that as
-                    // a brand-new dialog turn destructively resets bubble /
-                    // attachment tracking that should span the whole turn —
-                    // segment 2's bubble gets created in isolation, segment 1's
-                    // tracking is orphaned, and `response_discarded` cleanup
-                    // can no longer reach segment 1's bubble. Symptom: the
-                    // second segment's text fails to render (or briefly
-                    // renders and is then evicted) while its audio plays.
-                    //
-                    // Detection signal: compare incoming turn_id against
-                    // `window.realisticGeminiCurrentTurnId`, which is written
-                    // by THIS handler on every chunk (line below) and only
-                    // cleared by character switch / response_discarded — it
-                    // survives ensureAssistantTurnStarted (which nukes
-                    // S.assistantPendingTurnServerId via
-                    // clearPendingAssistantTurnStart the moment seg1's first
-                    // bubble opens, so that field is null by the time seg2
-                    // arrives and is NOT a usable signal here).
-                    var normalizedNewTurnId = normalizeAssistantTurnId(response.turn_id);
-                    var normalizedOpenTurnId = normalizeAssistantTurnId(window.realisticGeminiCurrentTurnId);
-                    var isMidTurnRestart = isNewMessage
-                        && normalizedNewTurnId
-                        && normalizedOpenTurnId
-                        && normalizedNewTurnId === normalizedOpenTurnId
-                        && S.assistantTurnId;
-                    if (isNewMessage && !isMidTurnRestart) {
+                    if (isNewMessage) {
+                        // 同一 dialog turn 内 LLM 也可能再开一段新的 response item
+                        // （realtime LLM 的 response.created 每次都把
+                        // _is_first_text_chunk 复位为 True，所以 seg2 首 chunk
+                        // 也以 isNewMessage=true 抵达，turn_id 跟 seg1 相同）。
+                        // adapter 用 startNewSegment 抽象统一把每段当独立 utterance
+                        // 处理，这里 lifecycle 也对偶 per-segment：每段重发
+                        // neko-assistant-turn-start，让 avatar-reaction-bubble /
+                        // subtitle / audio-playback 等 listeners 都拿到独立通知，
+                        // 客户端 turn id 也跟着换。
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...
                         if (S.lastVoiceUserMessage && S.lastVoiceUserMessage.isConnected &&
                             !S.lastVoiceUserMessage.textContent.trim()) {
@@ -1174,13 +1154,8 @@
                         S.lastVoiceUserMessage = null;
                         S.lastVoiceUserMessageTime = 0;
                         S.assistantTurnId = null;
-                        S.assistantPendingTurnServerId = normalizedNewTurnId;
+                        S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
                         S.assistantTurnAwaitingBubble = true;
-                    } else if (isMidTurnRestart) {
-                        logAssistantLifecycle('ws:gemini_response:mid_turn_restart', {
-                            turnId: normalizedNewTurnId,
-                            clientTurnId: S.assistantTurnId
-                        });
                     }
                     if (!S.assistantTurnId
                             && S.assistantTurnAwaitingBubble

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1274,6 +1274,9 @@
 
                     window._geminiTurnFullText = '';
                     window._pendingMusicCommand = '';
+                    // discard 后清掉 turn_end seal flag，避免残留导致下一个 chunk
+                    // 被误判为 sealedContinuation 触发不该触发的 lifecycle reset。
+                    window._geminiTurnEndSealed = false;
 
                     // 推进 epoch 并清空入站音频队列，防止在途 TTS blob 被消费播放
                     S.incomingAudioEpoch += 1;

--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -1136,7 +1136,25 @@
                         var gameEvent = gameMeta.event || {};
                         console.log(`[GameMirror] 主聊天栏收到游戏台词 | game=${gameMeta.game_type || '-'} session=${gameMeta.session_id || '-'} kind=${gameEvent.kind || '-'} round=${gameEvent.round || '-'} source=${response.metadata.source || '-'}`);
                     }
-                    if (isNewMessage) {
+                    // Detect "mid-turn new response item": realtime LLM can emit
+                    // multiple `response.created` within a single dialog turn
+                    // (so `_is_first_text_chunk` flips True again on the server
+                    // and we receive a second `isNewMessage=true` carrying the
+                    // SAME `turn_id` as the still-open turn). Treating that as
+                    // a brand-new dialog turn destructively resets bubble /
+                    // attachment tracking that should span the whole turn —
+                    // segment 2's bubble gets created in isolation, segment 1's
+                    // tracking is orphaned, and `response_discarded` cleanup
+                    // can no longer reach segment 1's bubble. Symptom: the
+                    // second segment's text fails to render (or briefly
+                    // renders and is then evicted) while its audio plays.
+                    var normalizedNewTurnId = normalizeAssistantTurnId(response.turn_id);
+                    var isMidTurnRestart = isNewMessage
+                        && normalizedNewTurnId
+                        && S.assistantPendingTurnServerId
+                        && normalizedNewTurnId === S.assistantPendingTurnServerId
+                        && S.assistantTurnId;
+                    if (isNewMessage && !isMidTurnRestart) {
                         // voice chat 中，AI 新消息到来时若上一条人类消息为纯空白则替换为 ...
                         if (S.lastVoiceUserMessage && S.lastVoiceUserMessage.isConnected &&
                             !S.lastVoiceUserMessage.textContent.trim()) {
@@ -1145,8 +1163,13 @@
                         S.lastVoiceUserMessage = null;
                         S.lastVoiceUserMessageTime = 0;
                         S.assistantTurnId = null;
-                        S.assistantPendingTurnServerId = normalizeAssistantTurnId(response.turn_id);
+                        S.assistantPendingTurnServerId = normalizedNewTurnId;
                         S.assistantTurnAwaitingBubble = true;
+                    } else if (isMidTurnRestart) {
+                        logAssistantLifecycle('ws:gemini_response:mid_turn_restart', {
+                            turnId: normalizedNewTurnId,
+                            clientTurnId: S.assistantTurnId
+                        });
                     }
                     if (!S.assistantTurnId
                             && S.assistantTurnAwaitingBubble
@@ -1155,7 +1178,12 @@
                     }
                     var createdVisibleBubble = false;
                     if (typeof window.appendMessage === 'function') {
-                        createdVisibleBubble = window.appendMessage(response.text, 'gemini', isNewMessage) === true;
+                        createdVisibleBubble = window.appendMessage(
+                            response.text,
+                            'gemini',
+                            isNewMessage,
+                            { midTurnRestart: !!isMidTurnRestart }
+                        ) === true;
                     }
                     if (createdVisibleBubble && response.request_id) {
                         if (window.reactChatWindowHost && typeof window.reactChatWindowHost.clearPendingRollbackDraft === 'function') {
@@ -1977,6 +2005,8 @@
                         if (typeof window.setReactMessageStatus === 'function' && window.currentGeminiMessage) {
                             window.setReactMessageStatus(window.currentGeminiMessage, 'assistant', 'sent');
                         }
+                        // 同 'turn end' 路径：标记封口，让后续 chunk 在 adapter 里新建气泡
+                        window._geminiTurnEndSealed = true;
                         window._pendingMusicCommand = '';
                         if (window._structuredGeminiStreaming) {
                             window._realisticGeminiBuffer = '';
@@ -2065,6 +2095,13 @@
                         if (typeof window.setReactMessageStatus === 'function' && window.currentGeminiMessage) {
                             window.setReactMessageStatus(window.currentGeminiMessage, 'assistant', 'sent');
                         }
+                        // 标记本气泡已封口：若同一 dialog turn 内还有后续 chunk
+                        // （Gemini Live late-continuation 或 tool 后续段台词），
+                        // app-chat-adapter.js 的 appendMessage 会据此新建一个气泡，
+                        // 而不是继续往封口气泡追加（封口气泡的 React StreamingText
+                        // 会在 status sent→streaming 切换时重 mount，导致追加文字
+                        // 视觉丢失）。详见 adapter 里的 _geminiTurnEndSealed 注释。
+                        window._geminiTurnEndSealed = true;
                         window._pendingMusicCommand = '';
                         if (window._structuredGeminiStreaming) {
                             window._realisticGeminiBuffer = '';


### PR DESCRIPTION
## Summary

修一个 N.E.K.O 聊天气泡在 dialog LLM 一个对话回合里输出**两个独立 response items**（两次 \`turn_end\`）时**只渲染第一段文字**、第二段音频正常播但气泡不出字的 bug。

- **根因**：realtime LLM 一个 turn 可以连发多次 \`response.created\`（fire-and-forget cue 触发的"先叙述、再纠正"模式、tool-use 后第二段语音等场景）。\`omni_realtime_client.py:2085\` 每次 \`response.created\` 都把 \`_is_first_text_chunk=True\` 复位，segment 2 的首 chunk 也以 \`isNewMessage=true\` 打到前端，但 \`turn_id\` 跟 segment 1 是同一个（\`current_speech_id\` 只在 \`handle_new_message\` 用户输入时换）。前端 \`appendMessage\` 把"protocol 层新 response item"误当成"全新 dialog turn"，破坏性 reset \`currentTurnGeminiBubbles\` / \`currentTurnGeminiAttachments\` / \`beginSubtitleTurn\` / \`assistantTurnId\`，segment 1 的气泡跟踪被孤立，segment 2 落进失序状态机，字最终没刷到任何 bubble。
- **修法**：\`app-websocket.js\` 比对 \`response.turn_id\` 和 \`S.assistantPendingTurnServerId\`，命中且 \`S.assistantTurnId\` 还活着 → 标记 \`midTurnRestart\`，跳过 \`assistantTurn*\` lifecycle 清理并把 flag 透传 \`appendMessage\`。\`app-chat-adapter.js\` 在 \`midTurnRestart\` 时跳过那 3 处破坏性 reset，per-segment 的 buffer / version / \`_geminiTurnFullText\` 仍照常重置 → 每段独立 bubble、独立 emotion analysis，但整轮的 \`response_discarded\` / 用户打断 cleanup 仍能覆盖所有 bubble。

走的是 issue 描述里给的两种 fix 方向中的 **option 2**（拆成两个 bubble），因为每个 response item 在语义上就是独立 utterance（独立 audio 段、独立 \`turn_end\`、独立 emotion analysis）。

## Test plan

- [x] \`node -c\` 两个文件语法 OK
- [x] \`tests/unit/test_app_websocket_static.py\` + \`tests/unit/test_passthrough_to_chat_bubble.py\` 27 passed
- [ ] **Live repro**（CI 验不了，需要本地）：\`uv run python launcher.py\` + 触发 Minecraft game_agent fire-and-forget cue（猫娘"先叙述、再纠正"），看气泡里两段文字是否都出现
- [ ] 普通单段回复 / 用户打断 / \`response_discarded\` 回归不破

注：\`tests/frontend/test_chat_*.py\` 的 Playwright 测试在本 worktree 因为 \`static/js/react-neko-chat/\` 没编译产物而失败，是环境问题不是回归（\`git stash\` 后未改动状态下同样 fail）。React bundle 没改动，不需要重跑 \`build_frontend.bat\`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复已封口对话段在后续续写时仍被追加到已封口气泡的问题：后续续写将按新段处理，重置段内显示状态、清空当前气泡与附件，避免重复或错位展示。
  * 在相关结束/丢弃分支与录音/切换流程中确保封口状态被正确初始化或清除，防止残留影响后续显示与字幕流式。

* **New Features**
  * 统一对同一对话轮内中途重启/续写的段级生命周期处理，在多种展示模式下按段触发相应行为，同时保持外部接口不变。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->