### PR TITLE
chore(yui-motions): apply strict mouth-smoothing profile to all motions

### DIFF
--- a/scripts/smooth_yui_mouth.py
+++ b/scripts/smooth_yui_mouth.py
@@ -31,16 +31,13 @@ TARGET_IDS = ("ParamMouthForm", "ParamMouthOpenY")
 NEUTRAL = {"ParamMouthForm": 0.0, "ParamMouthOpenY": 0.0}
 SAMPLE_HZ = 60      # internal sampling rate for smoothing
 
-# Default profile for non-idle motions.
-SIGMA_S = 3.0       # Gaussian width
-OUT_HZ = 2          # Linear-segment output rate
-FADE_S = 1.0        # boundary fade window (smoothstep)
-
-# Idle motions (filename prefix `idle`) need stricter filtering: long loops
-# in the background, no lipsync, want near-flat mouth.
-IDLE_SIGMA_S = 6.0
-IDLE_OUT_HZ = 1
-IDLE_FADE_S = 1.5
+# All motions are background animation without lipsync, so apply the strict
+# profile uniformly. (Previously idle* used these stricter values and the rest
+# used a softer profile, but the softer one still left visible jitter on
+# non-idle motions.)
+SIGMA_S = 6.0       # Gaussian width
+OUT_HZ = 1          # Linear-segment output rate
+FADE_S = 1.5        # boundary fade window (smoothstep)
 
 PAY = {0: 2, 1: 6, 2: 2, 3: 2}
 POINTS_PER_CMD = {0: 1, 1: 3, 2: 1, 3: 1}
@@ -173,23 +170,15 @@ def walk_curve(seg):
     return segments, points
 
 
-def profile_for(path: Path):
-    """idle* motions get the stricter profile; everything else uses defaults."""
-    if path.name.lower().startswith("idle"):
-        return IDLE_SIGMA_S, IDLE_OUT_HZ, IDLE_FADE_S
-    return SIGMA_S, OUT_HZ, FADE_S
-
-
 def process(path: Path):
     data = json.loads(path.read_text(encoding="utf-8"))
-    sigma_s, out_hz, fade_s = profile_for(path)
     stats = {}
     for curve in data["Curves"]:
         cid = curve.get("Id")
         if cid not in TARGET_IDS:
             continue
         before = extract_keys(curve["Segments"])
-        after = smooth_curve(before, NEUTRAL[cid], sigma_s, out_hz, fade_s)
+        after = smooth_curve(before, NEUTRAL[cid], SIGMA_S, OUT_HZ, FADE_S)
         curve["Segments"] = keys_to_linear_segments(after)
         stats[cid] = (len(before), len(after))
 
@@ -208,13 +197,10 @@ def process(path: Path):
 
 
 def main():
-    print(f"default: sigma={SIGMA_S}s  out={OUT_HZ}Hz  fade={FADE_S}s")
-    print(f"idle*:   sigma={IDLE_SIGMA_S}s  out={IDLE_OUT_HZ}Hz  fade={IDLE_FADE_S}s")
-    print(f"sample={SAMPLE_HZ}Hz")
+    print(f"sigma={SIGMA_S}s  out={OUT_HZ}Hz  fade={FADE_S}s  sample={SAMPLE_HZ}Hz")
     for f in sorted(ROOT.glob("*.motion3.json")):
         s = process(f)
-        tag = "[idle]" if f.name.lower().startswith("idle") else "      "
-        line = f"{tag} {f.name:<28}"
+        line = f"{f.name:<28}"
         for tid in TARGET_IDS:
             b, a = s.get(tid, (0, 0))
             line += f" {tid.replace('Param', '')[:6]}: {b:>3} -> {a:<3}   "


### PR DESCRIPTION
## Summary

- `scripts/smooth_yui_mouth.py` had two profiles: softer default (sigma=3s/out=2Hz/fade=1s) for non-idle motions and stricter (sigma=6s/out=1Hz/fade=1.5s) for `idle*` only. Visible mouth jitter still remained on the non-idle motions, so collapse to a single strict profile and apply it everywhere.
- Re-ran the script against `static/yui-origin/` and repacked `assets/yui-origin.tar.gz` (40 motion files updated, mouth keyframe counts dropped to 7 for short clips and 16 for idle loops).

## Test plan

- [ ] Verify mouth no longer flickers during `angry*` / `happy*` / `neutral*` / `sad*` / `surprised*` clips in-app.
- [ ] Confirm `idle*` smoothness is unchanged (profile was already this strict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 统一了嘴部动画的平滑处理方式，现采用一致的平滑参数应用于所有嘴部运动
  * 简化了动画处理流程，移除了基于文件名的条件逻辑
  * 改进了处理日志输出格式，清晰展示活跃的平滑参数设置

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->