### PR TITLE
fix(tool-calling): plugin 崩溃后自动驱逐其残留工具

### DIFF
--- a/main_routers/tool_router.py
+++ b/main_routers/tool_router.py
@@ -168,6 +168,95 @@ class ToolClearRequest(BaseModel):
 # Remote dispatcher — issued when ToolRegistry.execute() runs a remote tool
 # ---------------------------------------------------------------------------
 
+# 死插件自动驱逐：插件进程崩了之后，main_server 的 registry 里还挂着指向
+# 死端点的工具，model 还能在 schema 里看到它们并调用，每次都会撞 connection
+# refused。优雅 shutdown 走 /api/tools/clear，崩溃（kill -9）没机会触发，
+# 所以这里在 dispatch 路径上做反应式清理：同一个 plugin source 连续
+# ``_EVICTION_FAILURE_THRESHOLD`` 次"连接级"失败 → 把该 source 的所有工具
+# 从所有 session manager 的 registry 里扫掉，并推 fresh session.update 上 wire。
+#
+# 只算"端点不可达"——ReadTimeout（插件慢）、HTTP 4xx/5xx（插件活着但有 bug）、
+# body 解析失败、callback 业务上回 ``is_error=True``，这些都是工具/插件 bug，
+# 不是 lifecycle 问题，不计入也不会触发驱逐。任何一次 HTTP 交换成功（不管
+# 业务结果）就重置该 source 的计数器，所以"偶发 connection refused"不会
+# 在长期里累积成误杀。
+_EVICTION_FAILURE_THRESHOLD = 3
+_consecutive_connect_failures: Dict[str, int] = {}
+
+
+def _is_plugin_source(source: str) -> bool:
+    """只有 ``plugin:<id>`` 形态的 source 会参与自动驱逐。builtin 永远豁免；
+    其它自定义 source（如 agent_server、external）现阶段也不参与——它们的
+    生命周期不一定走 plugin 进程模型，复活机制也不一样。"""
+    return bool(source) and source.startswith("plugin:")
+
+
+def _is_connection_level_failure(exc: BaseException) -> bool:
+    """是否属于"插件端点不可达"。只认 ``ConnectError`` / ``ConnectTimeout``——
+    ``ReadTimeout`` 可能只是工具慢，HTTP 5xx 是插件活着但 bug，都不算
+    lifecycle 失败。"""
+    return isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout))
+
+
+def _note_dispatch_outcome(source: str, *, connection_failed: bool) -> None:
+    """更新某 source 的连续连接失败计数。成功一次（任何 HTTP status）就清零；
+    连续达到阈值则触发 ``_evict_dead_plugin_source``。"""
+    if not _is_plugin_source(source):
+        return
+    if not connection_failed:
+        _consecutive_connect_failures.pop(source, None)
+        return
+    cnt = _consecutive_connect_failures.get(source, 0) + 1
+    _consecutive_connect_failures[source] = cnt
+    if cnt >= _EVICTION_FAILURE_THRESHOLD:
+        _evict_dead_plugin_source(source)
+
+
+def _evict_dead_plugin_source(source: str) -> None:
+    """把指定 source 的工具从每个 session manager 的 registry 里扫掉，
+    并触发该 manager 的 session.update 推送，让模型在下次 list_tools()
+    时看不到这些工具。
+
+    注意走 ``mgr.clear_tools(...)`` 而不是直接 ``mgr.tool_registry.clear(...)``：
+    前者会 fire 一次 ``_sync_tools_to_active_session``，把变更推到 wire 上
+    活跃的 OpenAI Realtime / GLM / Qwen session；只动 registry 不推 wire
+    的话，模型还是会看到旧 schema 直到 session 重启。"""
+    _consecutive_connect_failures.pop(source, None)
+    try:
+        session_manager = get_session_manager()
+    except Exception as e:
+        # session_manager 未初始化（极早期 dispatch / 单测裸调用）。
+        # 静默 return —— 没有 manager 就没法 sweep，下次再试。
+        logger.debug(
+            "auto-eviction skipped (session_manager unavailable): %s: %s",
+            type(e).__name__, e,
+        )
+        return
+    total = 0
+    affected: List[str] = []
+    for mgr in list(session_manager.values()):
+        if mgr is None:
+            continue
+        try:
+            n = mgr.clear_tools(source=source)
+        except Exception as e:
+            logger.warning(
+                "auto-eviction sweep on mgr=%s source=%s failed: %s: %s",
+                getattr(mgr, "lanlan_name", "?"), source,
+                type(e).__name__, e,
+            )
+            continue
+        if n:
+            total += n
+            affected.append(getattr(mgr, "lanlan_name", "?"))
+    if total:
+        logger.warning(
+            "auto-evicted %d tool(s) for plugin source %s across roles=%s "
+            "after %d consecutive connect failures — plugin endpoint "
+            "unreachable (process likely crashed without graceful shutdown)",
+            total, source, affected, _EVICTION_FAILURE_THRESHOLD,
+        )
+
 
 async def _remote_dispatch(call: ToolCall, metadata: Dict[str, Any]) -> ToolResult:
     """POST the tool call to the plugin's callback URL and translate the
@@ -176,7 +265,13 @@ async def _remote_dispatch(call: ToolCall, metadata: Dict[str, Any]) -> ToolResu
         request body  → {"name": "...", "arguments": {...}, "call_id": "..."}
         response body → {"output": <any JSON>, "is_error": false}
                      or {"error": "...", "is_error": true}
+
+    Also runs the dead-plugin auto-eviction tracker on every outcome:
+    consecutive connection-level failures for a ``plugin:*`` source cross
+    the threshold → the source's tools get swept from every session
+    manager's registry. See ``_note_dispatch_outcome`` for details.
     """
+    source = str(metadata.get("source") or "")
     callback_url = metadata.get("callback_url")
     if not callback_url:
         msg = "remote tool registered without callback_url"
@@ -197,10 +292,15 @@ async def _remote_dispatch(call: ToolCall, metadata: Dict[str, Any]) -> ToolResu
     except Exception as e:
         err = f"remote tool callback HTTP failure: {type(e).__name__}: {e}"
         logger.warning("remote tool '%s' dispatch failed: %s", call.name, err)
+        _note_dispatch_outcome(source, connection_failed=_is_connection_level_failure(e))
         return ToolResult(
             call_id=call.call_id, name=call.name,
             output={"error": err}, is_error=True, error_message=err,
         )
+    # HTTP exchange completed (any status code) → endpoint is reachable,
+    # reset the consecutive-failure counter. Application-level errors
+    # (4xx/5xx or ``is_error=True`` in body) are NOT lifecycle failures.
+    _note_dispatch_outcome(source, connection_failed=False)
     if resp.status_code >= 400:
         err = f"remote tool callback returned HTTP {resp.status_code}: {resp.text[:200]}"
         return ToolResult(

--- a/main_routers/tool_router.py
+++ b/main_routers/tool_router.py
@@ -50,7 +50,7 @@ enforced by ``scripts/check_api_trailing_slash.py``.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import ipaddress
 from urllib.parse import urlparse
@@ -171,17 +171,40 @@ class ToolClearRequest(BaseModel):
 # 死插件自动驱逐：插件进程崩了之后，main_server 的 registry 里还挂着指向
 # 死端点的工具，model 还能在 schema 里看到它们并调用，每次都会撞 connection
 # refused。优雅 shutdown 走 /api/tools/clear，崩溃（kill -9）没机会触发，
-# 所以这里在 dispatch 路径上做反应式清理：同一个 plugin source 连续
-# ``_EVICTION_FAILURE_THRESHOLD`` 次"连接级"失败 → 把该 source 的所有工具
-# 从所有 session manager 的 registry 里扫掉，并推 fresh session.update 上 wire。
+# 所以这里在 dispatch 路径上做反应式清理。
+#
+# 按 ``(source, callback_origin)`` 而不是单按 ``source`` 聚合失败计数——
+# ``/api/tools/register`` 允许同一 plugin source 下每个工具有不同 callback_url，
+# 单按 source 累计会把"一个端点死了"误升级成"整个 plugin 全死"，扫掉同 source
+# 其他健康端点的工具。按 (source, origin) 双维聚合后，单端点不可达只清掉
+# 该端点的工具，sibling endpoints 不受影响。
+# （Codex review on PR #1382 提出的 endpoint-local outage 风险。）
 #
 # 只算"端点不可达"——ReadTimeout（插件慢）、HTTP 4xx/5xx（插件活着但有 bug）、
 # body 解析失败、callback 业务上回 ``is_error=True``，这些都是工具/插件 bug，
 # 不是 lifecycle 问题，不计入也不会触发驱逐。任何一次 HTTP 交换成功（不管
-# 业务结果）就重置该 source 的计数器，所以"偶发 connection refused"不会
-# 在长期里累积成误杀。
+# 业务结果）就重置该 (source, origin) 的计数器，所以"偶发 connection refused"
+# 不会在长期里累积成误杀。
 _EVICTION_FAILURE_THRESHOLD = 3
-_consecutive_connect_failures: Dict[str, int] = {}
+_consecutive_connect_failures: Dict[Tuple[str, str], int] = {}
+
+
+def _callback_origin(url: str) -> str:
+    """把 ``callback_url`` 归一为 ``scheme://host:port`` 作为驱逐 bucket key。
+    parse 不出来就回退到原字符串，保证 counter key 在异常输入下也稳定
+    （不会让 key collision 把一个 key 当多个 key）。"""
+    if not url:
+        return "<unknown>"
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return url
+    if not parsed.scheme or not parsed.hostname:
+        return url
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme == "https" else 80
+    return f"{parsed.scheme}://{parsed.hostname}:{port}"
 
 
 def _is_plugin_source(source: str) -> bool:
@@ -198,30 +221,33 @@ def _is_connection_level_failure(exc: BaseException) -> bool:
     return isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout))
 
 
-def _note_dispatch_outcome(source: str, *, connection_failed: bool) -> None:
-    """更新某 source 的连续连接失败计数。成功一次（任何 HTTP status）就清零；
-    连续达到阈值则触发 ``_evict_dead_plugin_source``。"""
+def _note_dispatch_outcome(source: str, callback_url: str, *, connection_failed: bool) -> None:
+    """更新某 ``(source, callback_origin)`` 的连续连接失败计数。成功一次
+    （任何 HTTP status）就清零；连续达到阈值则触发
+    ``_evict_dead_callback_origin``。"""
     if not _is_plugin_source(source):
         return
+    key = (source, _callback_origin(callback_url))
     if not connection_failed:
-        _consecutive_connect_failures.pop(source, None)
+        _consecutive_connect_failures.pop(key, None)
         return
-    cnt = _consecutive_connect_failures.get(source, 0) + 1
-    _consecutive_connect_failures[source] = cnt
+    cnt = _consecutive_connect_failures.get(key, 0) + 1
+    _consecutive_connect_failures[key] = cnt
     if cnt >= _EVICTION_FAILURE_THRESHOLD:
-        _evict_dead_plugin_source(source)
+        _evict_dead_callback_origin(source, key[1])
 
 
-def _evict_dead_plugin_source(source: str) -> None:
-    """把指定 source 的工具从每个 session manager 的 registry 里扫掉，
-    并触发该 manager 的 session.update 推送，让模型在下次 list_tools()
-    时看不到这些工具。
+def _evict_dead_callback_origin(source: str, origin: str) -> None:
+    """把指定 ``(source, origin)`` 的工具从每个 session manager 的 registry
+    里扫掉，并触发 ``_sync_tools_to_active_session`` 把 wire 上活跃的 OpenAI
+    Realtime / GLM / Qwen schema 刷新——只动 registry 不推 wire 的话，模型
+    还是会看到旧 schema 直到 session 重启。
 
-    注意走 ``mgr.clear_tools(...)`` 而不是直接 ``mgr.tool_registry.clear(...)``：
-    前者会 fire 一次 ``_sync_tools_to_active_session``，把变更推到 wire 上
-    活跃的 OpenAI Realtime / GLM / Qwen session；只动 registry 不推 wire
-    的话，模型还是会看到旧 schema 直到 session 重启。"""
-    _consecutive_connect_failures.pop(source, None)
+    只扫匹配 origin 的工具：同 source 下其它 origin 的 sibling 工具保留。
+    覆盖 plugin 进程整体崩溃的常见 case（同 plugin 通常一个 server，所有
+    tool 的 callback_url 同 origin → 一起扫），也避免单端点配错时误伤
+    其它健康端点。"""
+    _consecutive_connect_failures.pop((source, origin), None)
     try:
         session_manager = get_session_manager()
     except Exception as e:
@@ -238,23 +264,36 @@ def _evict_dead_plugin_source(source: str) -> None:
         if mgr is None:
             continue
         try:
-            n = mgr.clear_tools(source=source)
+            to_drop = [
+                t.name for t in mgr.tool_registry.all()
+                if t.metadata.get("source") == source
+                and _callback_origin(t.metadata.get("callback_url") or "") == origin
+            ]
+            if not to_drop:
+                continue
+            for name in to_drop:
+                mgr.tool_registry.unregister(name)
+            # 复用 mgr 已有的 fire-and-forget sync 通道（与 register_tool /
+            # clear_tools 同一条路径），把 fresh session.update 推到 wire。
+            # 直接访问 ``_fire_task`` / ``_sync_tools_to_active_session`` 是
+            # 因为没有"按谓词过滤"的公共 API；新加一个只服务于本驱逐通道
+            # 的方法属于过度抽象。
+            mgr._fire_task(mgr._sync_tools_to_active_session())  # noqa: SLF001
         except Exception as e:
             logger.warning(
-                "auto-eviction sweep on mgr=%s source=%s failed: %s: %s",
-                getattr(mgr, "lanlan_name", "?"), source,
+                "auto-eviction sweep on mgr=%s (source=%s origin=%s) failed: %s: %s",
+                getattr(mgr, "lanlan_name", "?"), source, origin,
                 type(e).__name__, e,
             )
             continue
-        if n:
-            total += n
-            affected.append(getattr(mgr, "lanlan_name", "?"))
+        total += len(to_drop)
+        affected.append(getattr(mgr, "lanlan_name", "?"))
     if total:
         logger.warning(
-            "auto-evicted %d tool(s) for plugin source %s across roles=%s "
-            "after %d consecutive connect failures — plugin endpoint "
-            "unreachable (process likely crashed without graceful shutdown)",
-            total, source, affected, _EVICTION_FAILURE_THRESHOLD,
+            "auto-evicted %d tool(s) for plugin source %s callback origin %s "
+            "across roles=%s after %d consecutive connect failures — endpoint "
+            "unreachable (plugin process or sub-endpoint likely down)",
+            total, source, origin, affected, _EVICTION_FAILURE_THRESHOLD,
         )
 
 
@@ -292,7 +331,10 @@ async def _remote_dispatch(call: ToolCall, metadata: Dict[str, Any]) -> ToolResu
     except Exception as e:
         err = f"remote tool callback HTTP failure: {type(e).__name__}: {e}"
         logger.warning("remote tool '%s' dispatch failed: %s", call.name, err)
-        _note_dispatch_outcome(source, connection_failed=_is_connection_level_failure(e))
+        _note_dispatch_outcome(
+            source, str(callback_url or ""),
+            connection_failed=_is_connection_level_failure(e),
+        )
         return ToolResult(
             call_id=call.call_id, name=call.name,
             output={"error": err}, is_error=True, error_message=err,
@@ -300,7 +342,7 @@ async def _remote_dispatch(call: ToolCall, metadata: Dict[str, Any]) -> ToolResu
     # HTTP exchange completed (any status code) → endpoint is reachable,
     # reset the consecutive-failure counter. Application-level errors
     # (4xx/5xx or ``is_error=True`` in body) are NOT lifecycle failures.
-    _note_dispatch_outcome(source, connection_failed=False)
+    _note_dispatch_outcome(source, str(callback_url or ""), connection_failed=False)
     if resp.status_code >= 400:
         err = f"remote tool callback returned HTTP {resp.status_code}: {resp.text[:200]}"
         return ToolResult(

--- a/main_routers/tool_router.py
+++ b/main_routers/tool_router.py
@@ -191,20 +191,25 @@ _consecutive_connect_failures: Dict[Tuple[str, str], int] = {}
 
 def _callback_origin(url: str) -> str:
     """把 ``callback_url`` 归一为 ``scheme://host:port`` 作为驱逐 bucket key。
-    parse 不出来就回退到原字符串，保证 counter key 在异常输入下也稳定
-    （不会让 key collision 把一个 key 当多个 key）。"""
+    parse 不出来或 port 不合法（``http://127.0.0.1:abc/cb`` 之类的畸形 URL
+    会让 ``ParseResult.port`` 抛 ``ValueError``——loopback validator 没管端口
+    语法）就回退到原字符串，保证：
+    - counter key 在异常输入下不抛，dispatch 路径仍然能返回结构化 ToolResult
+    - 同一畸形 URL 始终映射到同一 key（驱逐计数仍然能累加，不会因为
+      每次重新尝试 parse 又失败而 key collision 退化）
+    （Codex review on PR #1382: malformed callback URLs.）"""
     if not url:
         return "<unknown>"
     try:
         parsed = urlparse(url)
-    except Exception:
+        if not parsed.scheme or not parsed.hostname:
+            return url
+        port = parsed.port  # 可能抛 ValueError（非数字端口）
+        if port is None:
+            port = 443 if parsed.scheme == "https" else 80
+        return f"{parsed.scheme}://{parsed.hostname}:{port}"
+    except (ValueError, TypeError):
         return url
-    if not parsed.scheme or not parsed.hostname:
-        return url
-    port = parsed.port
-    if port is None:
-        port = 443 if parsed.scheme == "https" else 80
-    return f"{parsed.scheme}://{parsed.hostname}:{port}"
 
 
 def _is_plugin_source(source: str) -> bool:

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -1075,6 +1075,56 @@ def test_callback_origin_normalizes_to_scheme_host_port():
     assert _callback_origin("https://127.0.0.1/cb") == "https://127.0.0.1:443"
     # 异常输入兜底：空 / 不可 parse → 不抛
     assert _callback_origin("") == "<unknown>"
+    # 畸形端口（非数字）会让 ParseResult.port 抛 ValueError——
+    # loopback validator 没拦端口语法，所以 dispatch 路径必须自己兜住，
+    # 否则会破坏 ToolResult 结构化错误 + 驱逐 bookkeeping。
+    # （Codex review on PR #1382）
+    bad_port = "http://127.0.0.1:abc/cb"
+    assert _callback_origin(bad_port) == bad_port  # 回退到原串、不抛
+    # 同一畸形 URL 必须映射到同一 key——不然失败计数会因为 key collision
+    # 退化，永远到不了阈值。
+    assert _callback_origin(bad_port) == _callback_origin(bad_port)
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_survives_malformed_callback_url(
+    monkeypatch, _reset_eviction_counter,
+):
+    """``ToolRegisterRequest`` 的 loopback validator 不管端口语法，畸形
+    端口（``http://127.0.0.1:abc/cb``）可以通过注册。``_callback_origin``
+    必须不抛——否则 dispatch 路径会被破坏：原本应该返回结构化 ToolResult
+    error，结果上抛到 ToolRegistry.execute 的兜底 catch，错误消息丢精度。
+
+    回归保护：Codex review on PR #1382."""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    bad_url = "http://127.0.0.1:abc/cb"
+    mgr = _make_eviction_stub_mgr("Solo")
+    mgr.tool_registry.register(ToolDefinition(
+        name="malformed_tool", description="", handler=None,
+        metadata={"source": "plugin:malformed", "callback_url": bad_url},
+    ))
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: {"Solo": mgr})
+
+    class _DeadClient:
+        async def post(self, *_a, **_kw):
+            raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _DeadClient())
+
+    call = ToolCall(name="malformed_tool", arguments={}, call_id="c")
+    metadata = {"source": "plugin:malformed", "callback_url": bad_url, "timeout_seconds": 5}
+
+    # 不能抛——必须每次回结构化 ToolResult(is_error=True)。
+    for _ in range(_tr._EVICTION_FAILURE_THRESHOLD):
+        result = await _tr._remote_dispatch(call, metadata)
+        assert result.is_error is True
+        assert "HTTP failure" in result.error_message
+
+    # 即使 URL 畸形，eviction bookkeeping 仍应正常工作——3 次后扫掉。
+    assert mgr.tool_registry.names() == []
+    assert mgr.fire_task_count >= 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -710,21 +710,26 @@ async def test_unregister_tool_router_isolates_per_role_failures():
 
 
 def _make_eviction_stub_mgr(name: str):
-    """造一个能配合 _evict_dead_plugin_source 的最小 mgr：只需要
-    ``tool_registry`` 和同步版本的 ``clear_tools(source=...)``。后者直接
-    委托给 registry，不 fire session.update task（单测里没 active session）。"""
+    """造一个能配合 _evict_dead_callback_origin 的最小 mgr：暴露
+    ``tool_registry`` + 私有的 ``_fire_task`` / ``_sync_tools_to_active_session``
+    （驱逐通道用它们触发 wire 同步，跟 register_tool / clear_tools 走同一条
+    路径）。``_fire_task`` 直接 close 掉 coro 避免"coroutine was never awaited"
+    告警，单测只需要验证它被调用过了。"""
     from main_logic.tool_calling import ToolRegistry
 
     class _StubMgr:
         def __init__(self, lanlan_name: str):
             self.lanlan_name = lanlan_name
             self.tool_registry = ToolRegistry()
-            self.clear_calls: list = []
+            self.fire_task_count = 0
 
-        def clear_tools(self, *, source=None):
-            n = self.tool_registry.clear(source=source)
-            self.clear_calls.append((source, n))
-            return n
+        async def _sync_tools_to_active_session(self):
+            # 单测里没有 active session，wire 同步是 noop。
+            return None
+
+        def _fire_task(self, coro):
+            self.fire_task_count += 1
+            coro.close()
 
     return _StubMgr(name)
 
@@ -798,14 +803,15 @@ async def test_remote_dispatch_evicts_dead_plugin_after_three_connect_failures(
             f"mgr {mgr.lanlan_name}: plugin tools should be evicted, "
             f"builtin should remain; got {names}"
         )
-        # 每个 mgr 都该被 clear 调用过一次，source 精确指向死插件。
-        assert mgr.clear_calls == [("plugin:dead_foo", 2)], (
-            f"mgr {mgr.lanlan_name}: clear_tools should have been called "
-            f"exactly once with the dead plugin source; got {mgr.clear_calls}"
+        # 驱逐必须 fire 一次 wire 同步，让模型在 schema 上也看不到死工具。
+        assert mgr.fire_task_count >= 1, (
+            f"mgr {mgr.lanlan_name}: eviction must fire session.update sync; "
+            f"got fire_task_count={mgr.fire_task_count}"
         )
 
     # 计数器在驱逐后清零，避免下次 1 次失败就触发误杀。
-    assert "plugin:dead_foo" not in _tr._consecutive_connect_failures
+    dead_origin = _tr._callback_origin("http://127.0.0.1:9999/cb")
+    assert ("plugin:dead_foo", dead_origin) not in _tr._consecutive_connect_failures
 
 
 @pytest.mark.asyncio
@@ -850,9 +856,10 @@ async def test_remote_dispatch_business_error_does_not_evict(
 
     # 工具仍在 registry 里——业务错不是 lifecycle 错。
     assert mgr.tool_registry.names() == ["buggy_tool"]
-    assert mgr.clear_calls == []
+    assert mgr.fire_task_count == 0
     # 计数器从未累加（每次成功 HTTP 都清零）。
-    assert "plugin:buggy" not in _tr._consecutive_connect_failures
+    buggy_origin = _tr._callback_origin("http://127.0.0.1:9999/cb")
+    assert ("plugin:buggy", buggy_origin) not in _tr._consecutive_connect_failures
 
 
 @pytest.mark.asyncio
@@ -901,8 +908,9 @@ async def test_remote_dispatch_success_resets_failure_counter(
 
     # 工具还在，counter 累计但没超阈值。
     assert mgr.tool_registry.names() == ["flaky"]
-    assert mgr.clear_calls == []
-    assert _tr._consecutive_connect_failures.get("plugin:flaky") == 2
+    assert mgr.fire_task_count == 0
+    flaky_origin = _tr._callback_origin("http://127.0.0.1:9999/cb")
+    assert _tr._consecutive_connect_failures.get(("plugin:flaky", flaky_origin)) == 2
 
 
 @pytest.mark.asyncio
@@ -936,8 +944,9 @@ async def test_remote_dispatch_builtin_source_never_evicted(
 
     # 工具仍在 registry，计数器从未被建。
     assert mgr.tool_registry.names() == ["recall_memory"]
-    assert mgr.clear_calls == []
-    assert "builtin" not in _tr._consecutive_connect_failures
+    assert mgr.fire_task_count == 0
+    # builtin source 永远不进 counter dict
+    assert not any(src == "builtin" for src, _origin in _tr._consecutive_connect_failures)
 
 
 @pytest.mark.asyncio
@@ -970,8 +979,102 @@ async def test_remote_dispatch_read_timeout_does_not_evict(
 
     # 工具不动：ReadTimeout 不算 connection-level，counter 也没累加。
     assert mgr.tool_registry.names() == ["slow"]
-    assert mgr.clear_calls == []
-    assert "plugin:slow" not in _tr._consecutive_connect_failures
+    assert mgr.fire_task_count == 0
+    slow_origin = _tr._callback_origin("http://127.0.0.1:9999/cb")
+    assert ("plugin:slow", slow_origin) not in _tr._consecutive_connect_failures
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_endpoint_local_outage_preserves_sibling_endpoints(
+    monkeypatch, _reset_eviction_counter,
+):
+    """同一 plugin source 下若注册的工具指向不同 callback origin（不同 port），
+    单端点不可达只能扫掉该端点的工具，不能把同 source 的其他健康端点工具
+    一起带走。
+
+    回归保护：Codex review on PR #1382——单按 source 聚合会把"一个端点
+    死了"误升级成"整个 plugin 全死"。"""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    mgr = _make_eviction_stub_mgr("Solo")
+    # 同一 plugin source，两个工具指向不同 port。
+    mgr.tool_registry.register(ToolDefinition(
+        name="tool_on_dead_port", description="", handler=None,
+        metadata={"source": "plugin:multi_port", "callback_url": "http://127.0.0.1:9001/cb"},
+    ))
+    mgr.tool_registry.register(ToolDefinition(
+        name="tool_on_live_port", description="", handler=None,
+        metadata={"source": "plugin:multi_port", "callback_url": "http://127.0.0.1:9002/cb"},
+    ))
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: {"Solo": mgr})
+
+    # 只有 port 9001 不可达；9002 正常。
+    class _OkResp:
+        status_code = 200
+        text = '{"output": "ok"}'
+        def json(self): return {"output": "ok"}
+
+    class _PortSelectiveClient:
+        async def post(self, url, *_a, **_kw):
+            if ":9001" in url:
+                raise httpx.ConnectError("Connection refused on 9001")
+            return _OkResp()
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _PortSelectiveClient())
+
+    dead_call = ToolCall(name="tool_on_dead_port", arguments={}, call_id="d")
+    dead_metadata = {
+        "source": "plugin:multi_port",
+        "callback_url": "http://127.0.0.1:9001/cb",
+        "timeout_seconds": 5,
+    }
+    # 3 次撞死端口 → 触发驱逐
+    for _ in range(_tr._EVICTION_FAILURE_THRESHOLD):
+        await _tr._remote_dispatch(dead_call, dead_metadata)
+
+    # 关键断言：只有指向 9001 的工具被扫，9002 的 sibling 工具完好。
+    names = sorted(mgr.tool_registry.names())
+    assert names == ["tool_on_live_port"], (
+        f"endpoint-local outage on 9001 must NOT evict sibling tool on 9002; "
+        f"got remaining={names}"
+    )
+
+    # 活端口的 counter 应当从未建立——它没失败过。
+    live_origin = _tr._callback_origin("http://127.0.0.1:9002/cb")
+    assert ("plugin:multi_port", live_origin) not in _tr._consecutive_connect_failures
+
+    # 健康端点继续可调用、保持 schema 中可见。
+    live_call = ToolCall(name="tool_on_live_port", arguments={}, call_id="L")
+    live_metadata = {
+        "source": "plugin:multi_port",
+        "callback_url": "http://127.0.0.1:9002/cb",
+        "timeout_seconds": 5,
+    }
+    result = await _tr._remote_dispatch(live_call, live_metadata)
+    assert result.is_error is False
+    assert result.output == "ok"
+
+
+def test_callback_origin_normalizes_to_scheme_host_port():
+    """``_callback_origin`` 必须把 (scheme, host, port) 折叠成同一 bucket key——
+    path / query / fragment 不能让同一 server 的不同 URL 被当成不同 endpoint。
+    """
+    from main_routers.tool_router import _callback_origin
+
+    base = _callback_origin("http://127.0.0.1:9000/api/cb")
+    # 同 origin 不同 path / query → 同一 key
+    assert _callback_origin("http://127.0.0.1:9000/api/cb") == base
+    assert _callback_origin("http://127.0.0.1:9000/other/path") == base
+    assert _callback_origin("http://127.0.0.1:9000/api/cb?x=1") == base
+    # 不同 port → 不同 key
+    assert _callback_origin("http://127.0.0.1:9001/api/cb") != base
+    # 默认端口要显式化（http→80, https→443），避免 ``http://h/`` 和
+    # ``http://h:80/`` 被当成两个 endpoint
+    assert _callback_origin("http://127.0.0.1/cb") == "http://127.0.0.1:80"
+    assert _callback_origin("https://127.0.0.1/cb") == "https://127.0.0.1:443"
+    # 异常输入兜底：空 / 不可 parse → 不抛
+    assert _callback_origin("") == "<unknown>"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -18,6 +18,7 @@ import json
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 
 # Ensure the project root is importable when pytest is invoked from
@@ -699,6 +700,278 @@ async def test_unregister_tool_router_isolates_per_role_failures():
     assert "fake sync failure" in result["failed_roles"][0]["error"]
     # 一个成功 + 一个失败 → ok=True（部分成功）
     assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# 死插件自动驱逐：_remote_dispatch 在同一 plugin source 连续 N 次"连接级"失败
+# 后扫除该 source 的所有工具。覆盖 kill -9 杀插件进程后 main_server registry
+# 里残留死端点工具的场景——优雅 shutdown 走 /api/tools/clear，崩溃没机会触发。
+# ---------------------------------------------------------------------------
+
+
+def _make_eviction_stub_mgr(name: str):
+    """造一个能配合 _evict_dead_plugin_source 的最小 mgr：只需要
+    ``tool_registry`` 和同步版本的 ``clear_tools(source=...)``。后者直接
+    委托给 registry，不 fire session.update task（单测里没 active session）。"""
+    from main_logic.tool_calling import ToolRegistry
+
+    class _StubMgr:
+        def __init__(self, lanlan_name: str):
+            self.lanlan_name = lanlan_name
+            self.tool_registry = ToolRegistry()
+            self.clear_calls: list = []
+
+        def clear_tools(self, *, source=None):
+            n = self.tool_registry.clear(source=source)
+            self.clear_calls.append((source, n))
+            return n
+
+    return _StubMgr(name)
+
+
+@pytest.fixture
+def _reset_eviction_counter():
+    """每个 eviction 测试前后都把模块级失败计数清空，避免跨测试污染。"""
+    from main_routers import tool_router as _tr
+    _tr._consecutive_connect_failures.clear()
+    yield
+    _tr._consecutive_connect_failures.clear()
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_evicts_dead_plugin_after_three_connect_failures(
+    monkeypatch, _reset_eviction_counter,
+):
+    """插件 kill -9 之后，model 连撞 3 次 connect refused → 该 plugin 的
+    所有工具从所有 session manager 的 registry 里清除；builtin 工具不动。
+
+    回归保护：lifecycle 审计发现 plugin 崩溃没有清理路径。"""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    # 准备一个 stub session_manager，挂两个"角色"，每个 mgr 都有同一个 plugin
+    # 的两个工具（模拟 role=None 的全局注册）和一个 builtin。
+    mgr_a = _make_eviction_stub_mgr("Alpha")
+    mgr_b = _make_eviction_stub_mgr("Beta")
+    for mgr in (mgr_a, mgr_b):
+        mgr.tool_registry.register(ToolDefinition(
+            name="weather", description="", handler=None,
+            metadata={"source": "plugin:dead_foo", "callback_url": "http://127.0.0.1:9999/cb"},
+        ))
+        mgr.tool_registry.register(ToolDefinition(
+            name="search", description="", handler=None,
+            metadata={"source": "plugin:dead_foo", "callback_url": "http://127.0.0.1:9999/cb"},
+        ))
+        mgr.tool_registry.register(ToolDefinition(
+            name="recall_memory", description="", handler=lambda _: "",
+            metadata={"source": "builtin"},
+        ))
+
+    fake_session_manager = {"Alpha": mgr_a, "Beta": mgr_b}
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: fake_session_manager)
+
+    # 让 httpx client 永远 ConnectError —— 模拟插件进程已经死了。
+    class _DeadClient:
+        async def post(self, *_a, **_kw):
+            raise httpx.ConnectError("Connection refused")
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _DeadClient())
+
+    # 模型走 dispatch 3 次（任意角色都会触发 module-level 计数，跨 mgr 共享）。
+    call = ToolCall(name="weather", arguments={}, call_id="c")
+    metadata = {
+        "source": "plugin:dead_foo",
+        "callback_url": "http://127.0.0.1:9999/cb",
+        "timeout_seconds": 5,
+    }
+    for _ in range(_tr._EVICTION_FAILURE_THRESHOLD):
+        result = await _tr._remote_dispatch(call, metadata)
+        # 单次 dispatch 失败必须仍然回 ToolResult（不抛异常），
+        # 让模型看到结构化错误而不是 client 崩。
+        assert result.is_error is True
+
+    # 阈值后：两个 mgr 上所有 plugin:dead_foo 的工具都该被扫掉，
+    # builtin 工具留下。
+    for mgr in (mgr_a, mgr_b):
+        names = sorted(mgr.tool_registry.names())
+        assert names == ["recall_memory"], (
+            f"mgr {mgr.lanlan_name}: plugin tools should be evicted, "
+            f"builtin should remain; got {names}"
+        )
+        # 每个 mgr 都该被 clear 调用过一次，source 精确指向死插件。
+        assert mgr.clear_calls == [("plugin:dead_foo", 2)], (
+            f"mgr {mgr.lanlan_name}: clear_tools should have been called "
+            f"exactly once with the dead plugin source; got {mgr.clear_calls}"
+        )
+
+    # 计数器在驱逐后清零，避免下次 1 次失败就触发误杀。
+    assert "plugin:dead_foo" not in _tr._consecutive_connect_failures
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_business_error_does_not_evict(
+    monkeypatch, _reset_eviction_counter,
+):
+    """插件 callback 业务上返回 ``is_error=True``（或 HTTP 5xx）说明插件是活的，
+    只是工具内部出错——这是工具 bug 不是 lifecycle bug，不能算驱逐计数。"""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    mgr = _make_eviction_stub_mgr("Solo")
+    mgr.tool_registry.register(ToolDefinition(
+        name="buggy_tool", description="", handler=None,
+        metadata={"source": "plugin:buggy", "callback_url": "http://127.0.0.1:9999/cb"},
+    ))
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: {"Solo": mgr})
+
+    # 模拟插件活着（200 + is_error=true body）。
+    class _AliveButBuggyResp:
+        status_code = 200
+        text = '{"is_error": true, "error": "tool blew up"}'
+        def json(self):
+            return {"is_error": True, "error": "tool blew up"}
+
+    class _AliveClient:
+        async def post(self, *_a, **_kw):
+            return _AliveButBuggyResp()
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _AliveClient())
+
+    call = ToolCall(name="buggy_tool", arguments={}, call_id="c")
+    metadata = {
+        "source": "plugin:buggy",
+        "callback_url": "http://127.0.0.1:9999/cb",
+        "timeout_seconds": 5,
+    }
+    # 比阈值多调几次。
+    for _ in range(_tr._EVICTION_FAILURE_THRESHOLD + 2):
+        result = await _tr._remote_dispatch(call, metadata)
+        assert result.is_error is True  # 业务错误透传
+
+    # 工具仍在 registry 里——业务错不是 lifecycle 错。
+    assert mgr.tool_registry.names() == ["buggy_tool"]
+    assert mgr.clear_calls == []
+    # 计数器从未累加（每次成功 HTTP 都清零）。
+    assert "plugin:buggy" not in _tr._consecutive_connect_failures
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_success_resets_failure_counter(
+    monkeypatch, _reset_eviction_counter,
+):
+    """连续 2 次 connect failure（还不到阈值）后一次成功 → 计数器清零，
+    后续再失败要从 1 重新计起。防止"偶发 connection refused"长期累积成误杀。"""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    mgr = _make_eviction_stub_mgr("Solo")
+    mgr.tool_registry.register(ToolDefinition(
+        name="flaky", description="", handler=None,
+        metadata={"source": "plugin:flaky", "callback_url": "http://127.0.0.1:9999/cb"},
+    ))
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: {"Solo": mgr})
+
+    class _OkResp:
+        status_code = 200
+        text = '{"output": "ok"}'
+        def json(self): return {"output": "ok"}
+
+    fail_then_ok = [
+        httpx.ConnectError("refused"),
+        httpx.ConnectError("refused"),
+        _OkResp(),
+        httpx.ConnectError("refused"),
+        httpx.ConnectError("refused"),
+    ]
+    class _SwitchingClient:
+        async def post(self, *_a, **_kw):
+            item = fail_then_ok.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _SwitchingClient())
+
+    call = ToolCall(name="flaky", arguments={}, call_id="c")
+    metadata = {"source": "plugin:flaky", "callback_url": "http://127.0.0.1:9999/cb", "timeout_seconds": 5}
+
+    # fail, fail (counter=2), ok (counter=0), fail, fail (counter=2) — 仍未到阈值
+    for _ in range(5):
+        await _tr._remote_dispatch(call, metadata)
+
+    # 工具还在，counter 累计但没超阈值。
+    assert mgr.tool_registry.names() == ["flaky"]
+    assert mgr.clear_calls == []
+    assert _tr._consecutive_connect_failures.get("plugin:flaky") == 2
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_builtin_source_never_evicted(
+    monkeypatch, _reset_eviction_counter,
+):
+    """``source="builtin"`` 永远不进入驱逐计数——builtin 工具是 in-process
+    handler，通常根本不走 _remote_dispatch；万一被错配成 remote，也不能因为
+    "连续失败"就把内置工具扫掉。"""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    mgr = _make_eviction_stub_mgr("Solo")
+    # 病态注册：builtin 但 handler=None，硬走 remote 路径。
+    mgr.tool_registry.register(ToolDefinition(
+        name="recall_memory", description="", handler=None,
+        metadata={"source": "builtin", "callback_url": "http://127.0.0.1:9999/cb"},
+    ))
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: {"Solo": mgr})
+
+    class _DeadClient:
+        async def post(self, *_a, **_kw):
+            raise httpx.ConnectError("Connection refused")
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _DeadClient())
+
+    call = ToolCall(name="recall_memory", arguments={}, call_id="c")
+    metadata = {"source": "builtin", "callback_url": "http://127.0.0.1:9999/cb", "timeout_seconds": 5}
+    for _ in range(_tr._EVICTION_FAILURE_THRESHOLD + 3):
+        await _tr._remote_dispatch(call, metadata)
+
+    # 工具仍在 registry，计数器从未被建。
+    assert mgr.tool_registry.names() == ["recall_memory"]
+    assert mgr.clear_calls == []
+    assert "builtin" not in _tr._consecutive_connect_failures
+
+
+@pytest.mark.asyncio
+async def test_remote_dispatch_read_timeout_does_not_evict(
+    monkeypatch, _reset_eviction_counter,
+):
+    """ReadTimeout 表示插件接住了请求但执行慢——是工具实现问题，不是
+    "端点不可达"。只有 ConnectError/ConnectTimeout 才算 lifecycle 失败。"""
+    from main_logic.tool_calling import ToolCall, ToolDefinition
+    from main_routers import tool_router as _tr
+
+    mgr = _make_eviction_stub_mgr("Solo")
+    mgr.tool_registry.register(ToolDefinition(
+        name="slow", description="", handler=None,
+        metadata={"source": "plugin:slow", "callback_url": "http://127.0.0.1:9999/cb"},
+    ))
+    monkeypatch.setattr(_tr, "get_session_manager", lambda: {"Solo": mgr})
+
+    class _SlowClient:
+        async def post(self, *_a, **_kw):
+            raise httpx.ReadTimeout("tool ran past deadline")
+
+    monkeypatch.setattr(_tr, "_get_http_client", lambda: _SlowClient())
+
+    call = ToolCall(name="slow", arguments={}, call_id="c")
+    metadata = {"source": "plugin:slow", "callback_url": "http://127.0.0.1:9999/cb", "timeout_seconds": 5}
+    for _ in range(_tr._EVICTION_FAILURE_THRESHOLD + 2):
+        result = await _tr._remote_dispatch(call, metadata)
+        assert result.is_error is True  # 超时仍透传给模型作为错误
+
+    # 工具不动：ReadTimeout 不算 connection-level，counter 也没累加。
+    assert mgr.tool_registry.names() == ["slow"]
+    assert mgr.clear_calls == []
+    assert "plugin:slow" not in _tr._consecutive_connect_failures
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Lifecycle 审计发现 plugin 进程崩溃（kill -9 / OOM / segfault）后，main_server 的 `ToolRegistry` 里残留指向死端点的工具——模型在 schema 里还能看到并选用，每次都撞 connection refused。优雅 shutdown 走 `clear_plugin_llm_tools` 没问题，崩溃没机会触发。
- 在 `_remote_dispatch` ([main_routers/tool_router.py](https://github.com/Project-N-E-K-O/N.E.K.O/blob/claude/charming-villani-627a01/main_routers/tool_router.py)) 加反应式自动驱逐：同一 `plugin:*` source 连续 3 次"连接级"失败 → 扫掉该 source 在所有 session manager 上的工具，并推 `session.update` 同步 wire schema。
- 任何一次 HTTP 交换成功（含 4xx/5xx、`is_error=True`）都重置该 source 的计数器，避免偶发抖动累积成误杀。

## Tradeoff

- **反应式 vs proactive heartbeat**：选反应式。代价是模型至少要撞 1 次才发现死插件，但省了背景轮询的 task 生命周期 + 空 ping。模型撞死插件是廉价的（拿 ToolResult error 就会换别的工具）。
- **只认 `ConnectError`/`ConnectTimeout`**：`ReadTimeout`（插件慢）、HTTP 4xx/5xx（活着但 bug）、`is_error=True`（业务错）全不算 lifecycle 失败。代价：插件 hang 死（端口开但永不响应）不会被自动清，但 hang 死本身是 plugin bug，硬规则区分不开"慢"和"hang"，宁可漏报不要误杀。
- **builtin source 永远豁免**，即便被错配成 `handler=None` 也不会被扫。
- 不动 `register_tool` / `unregister_tool` 公共 API；不加 proactive ping；不碰 `ToolRegistry`（保持 transport-agnostic）。

## Test plan

- [x] 5 个新单测全部 PASSED（`tests/unit/test_tool_calling.py`）：
  - `test_remote_dispatch_evicts_dead_plugin_after_three_connect_failures` —— 2 个 mgr × 2 plugin 工具 + 1 builtin；3 次 `ConnectError` 后 plugin 工具全清、builtin 保留
  - `test_remote_dispatch_business_error_does_not_evict` —— `is_error=true` body 不计数
  - `test_remote_dispatch_success_resets_failure_counter` —— fail/fail/ok/fail/fail，counter=2，未驱逐
  - `test_remote_dispatch_builtin_source_never_evicted` —— builtin source 永远豁免
  - `test_remote_dispatch_read_timeout_does_not_evict` —— `ReadTimeout` 不算 connection-level
- [x] `tests/unit/test_tool_calling.py` 全 45 个 case 通过（40 原有 + 5 新）
- [ ] 手动验证：起一个真实 plugin，注册若干工具 → `kill -9` 插件进程 → 在对话里让模型调用该工具 3 次 → 检查 `/api/tools` 返回里这些工具已消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增“死插件自动驱逐”机制：按 plugin source + callback origin 跟踪连续连接级失败（仅计连接错误类异常），达到阈值后从会话管理器中移除对应工具并同步刷新；成功响应或业务错误重置计数；builtin 源不参与驱逐；对 callback origin 做归一化处理。

* **Tests**
  * 新增单元测试覆盖驱逐触发与不触发场景、计数重置、多端口隔离、origin 归一化及畸形 callback_url 情形。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->