### PR TITLE
  feat(galgame): 接入 macOS/Linux 跨平台截图与窗口扫描

### DIFF
--- a/plugin/plugins/galgame_plugin/capture_platform.py
+++ b/plugin/plugins/galgame_plugin/capture_platform.py
@@ -1,0 +1,80 @@
+"""Platform detection and cross-platform capture dispatch for galgame_plugin.
+
+IMPORTANT: This module MUST NOT import from ocr_reader at module level
+to avoid circular imports. All ocr_reader imports are lazy (inside functions).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .ocr_reader import DetectedGameWindow
+
+def is_windows() -> bool:
+    # Read sys.platform dynamically rather than caching at module-load
+    # time so existing tests that monkeypatch sys.platform continue to
+    # exercise the cross-platform branches.
+    return sys.platform == "win32"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+def platform_name() -> str:
+    if is_windows():
+        return "windows"
+    if is_macos():
+        return "macos"
+    if is_linux():
+        return "linux"
+    return "unknown"
+
+
+def platform_supports_dxcam() -> bool:
+    return is_windows()
+
+
+def platform_supports_printwindow() -> bool:
+    return is_windows()
+
+
+_WIN32_ONLY_BACKEND_KINDS = frozenset({"dxcam", "printwindow"})
+
+
+def is_win32_only_backend_kind(kind: str) -> bool:
+    """Return True if the backend kind requires Win32 APIs."""
+    return kind in _WIN32_ONLY_BACKEND_KINDS
+
+
+def scan_windows() -> list["DetectedGameWindow"]:
+    """Cross-platform window enumeration (lazy imports to avoid cycles).
+
+    Windows: delegates to _default_window_scanner (win32gui.EnumWindows).
+    macOS:   delegates to window_scanner_macos._scan_windows_macos (Quartz).
+    Linux:   delegates to window_scanner_linux._scan_windows_linux
+             (python-xlib -> wmctrl). Wayland detection is handled
+             inside _scan_windows_linux (both tools fail naturally on
+             pure Wayland, so it returns []); we don't hard-block by
+             XDG_SESSION_TYPE at the entry layer because XWayland uses
+             the same env var but X11 tools still work.
+    """
+    if is_windows():
+        from .ocr_reader import _default_window_scanner  # noqa: PLC0415
+
+        return _default_window_scanner()
+    if is_macos():
+        from .window_scanner_macos import _scan_windows_macos  # noqa: PLC0415
+
+        return _scan_windows_macos()
+    if is_linux():
+        from .window_scanner_linux import _scan_windows_linux  # noqa: PLC0415
+
+        return _scan_windows_linux()
+    return []

--- a/plugin/plugins/galgame_plugin/capture_platform.py
+++ b/plugin/plugins/galgame_plugin/capture_platform.py
@@ -6,6 +6,7 @@ to avoid circular imports. All ocr_reader imports are lazy (inside functions).
 
 from __future__ import annotations
 
+import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -25,6 +26,15 @@ def is_macos() -> bool:
 
 def is_linux() -> bool:
     return sys.platform.startswith("linux")
+
+
+def is_linux_wayland_session() -> bool:
+    if not is_linux():
+        return False
+    session_type = str(os.environ.get("XDG_SESSION_TYPE") or "").strip().lower()
+    if session_type == "wayland":
+        return True
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and not bool(os.environ.get("DISPLAY"))
 
 
 def platform_name() -> str:

--- a/plugin/plugins/galgame_plugin/capture_platform.py
+++ b/plugin/plugins/galgame_plugin/capture_platform.py
@@ -32,9 +32,9 @@ def is_linux_wayland_session() -> bool:
     if not is_linux():
         return False
     session_type = str(os.environ.get("XDG_SESSION_TYPE") or "").strip().lower()
-    if session_type == "wayland":
-        return True
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and not bool(os.environ.get("DISPLAY"))
+    has_wayland = session_type == "wayland" or bool(os.environ.get("WAYLAND_DISPLAY"))
+    has_x11_display = bool(os.environ.get("DISPLAY"))
+    return has_wayland and not has_x11_display
 
 
 def platform_name() -> str:

--- a/plugin/plugins/galgame_plugin/electron_capture.py
+++ b/plugin/plugins/galgame_plugin/electron_capture.py
@@ -90,7 +90,6 @@ class ElectronCaptureBackend:
         )
         self._request_timeout = float(request_timeout)
         self._health_timeout = float(health_timeout)
-        self._available_cached: bool | None = None
 
     def _validated_base_url(self) -> str:
         self._base_url = _normalize_loopback_base_url(self._base_url)

--- a/plugin/plugins/galgame_plugin/electron_capture.py
+++ b/plugin/plugins/galgame_plugin/electron_capture.py
@@ -29,7 +29,6 @@ _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT_FALLBACK = 48911  # MAIN_SERVER_PORT default
 _DEFAULT_HEALTH_PATH = "/api/capture/health"
 _DEFAULT_SCREENSHOT_PATH = "/api/capture/screenshot"
-_MAX_ERROR_BODY_CHARS = 120
 _TARGET_TITLE_MAX_CHARS = 512
 _SAFE_TITLE_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
 
@@ -171,10 +170,7 @@ class ElectronCaptureBackend:
             raise RuntimeError(f"electron: http_request_failed: {exc}") from exc
 
         if resp.status_code != 200:
-            detail = (resp.text or "").strip().replace("\n", " ")
-            detail = _SAFE_TITLE_RE.sub("", detail)[:_MAX_ERROR_BODY_CHARS]
-            suffix = f": {detail}" if detail else ""
-            raise RuntimeError(f"electron: http_status_{resp.status_code}{suffix}")
+            raise RuntimeError(f"electron: http_status_{resp.status_code}")
 
         try:
             data = resp.json()

--- a/plugin/plugins/galgame_plugin/electron_capture.py
+++ b/plugin/plugins/galgame_plugin/electron_capture.py
@@ -14,10 +14,12 @@ backend appears in the chain only as a tail fallback there.
 from __future__ import annotations
 
 import base64
+import ipaddress
 import io
 import os
 import re
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from .ocr_reader import DetectedGameWindow, OcrCaptureProfile
@@ -46,8 +48,28 @@ def _resolve_default_base_url() -> str:
         port_int = int(port) if port else _DEFAULT_PORT_FALLBACK
     except (TypeError, ValueError):
         port_int = _DEFAULT_PORT_FALLBACK
+    if not 1 <= port_int <= 65535:
+        port_int = _DEFAULT_PORT_FALLBACK
     # API URLs intentionally have no trailing slash per project convention.
     return f"http://{_DEFAULT_HOST}:{port_int}"
+
+
+def _is_loopback_host(hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def _normalize_loopback_base_url(base_url: str) -> str:
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not _is_loopback_host(parsed.hostname):
+        raise ValueError("electron capture base_url must use a loopback host")
+    return base_url.rstrip("/")
 
 
 class ElectronCaptureBackend:
@@ -64,10 +86,16 @@ class ElectronCaptureBackend:
         health_timeout: float = 2.0,
     ) -> None:
         self._logger = logger
-        self._base_url = (base_url or _resolve_default_base_url()).rstrip("/")
+        self._base_url = _normalize_loopback_base_url(
+            base_url or _resolve_default_base_url()
+        )
         self._request_timeout = float(request_timeout)
         self._health_timeout = float(health_timeout)
         self._available_cached: bool | None = None
+
+    def _validated_base_url(self) -> str:
+        self._base_url = _normalize_loopback_base_url(self._base_url)
+        return self._base_url
 
     def is_available(self) -> bool:
         """Probe the Electron bridge endpoint with a short timeout.
@@ -84,7 +112,7 @@ class ElectronCaptureBackend:
         try:
             resp = httpx.request(
                 "GET",
-                f"{self._base_url}{_DEFAULT_HEALTH_PATH}",
+                f"{self._validated_base_url()}{_DEFAULT_HEALTH_PATH}",
                 timeout=self._health_timeout,
             )
             return resp.status_code == 200
@@ -131,10 +159,11 @@ class ElectronCaptureBackend:
             raise RuntimeError("electron: pillow_not_installed") from exc
 
         payload = self._target_payload(target)
+        base_url = self._validated_base_url()
         try:
             resp = httpx.request(
                 "POST",
-                f"{self._base_url}{_DEFAULT_SCREENSHOT_PATH}",
+                f"{base_url}{_DEFAULT_SCREENSHOT_PATH}",
                 json=payload,
                 timeout=self._request_timeout,
             )

--- a/plugin/plugins/galgame_plugin/electron_capture.py
+++ b/plugin/plugins/galgame_plugin/electron_capture.py
@@ -144,10 +144,10 @@ class ElectronCaptureBackend:
         Uses target.hwnd (CGWindowID on macOS / X11 Window ID / Windows hWnd)
         as the cross-platform window identifier. The Electron side maps it
         back to a desktopCapturer source. We deliberately do NOT pass a
-        rect — Electron returns the full window image, and the caller
-        crops by OcrCaptureProfile ratios. This sidesteps the HiDPI /
-        multi-monitor coordinate mismatch between Chromium physical pixels
-        and X11 logical coordinates.
+        rect — Electron returns the full window image, so this backend
+        applies OcrCaptureProfile ratios against the decoded image's own
+        pixel dimensions. This sidesteps the HiDPI / multi-monitor coordinate
+        mismatch between Chromium physical pixels and X11 logical coordinates.
         """
         try:
             import httpx  # type: ignore[import-not-found]  # noqa: PLC0415
@@ -194,6 +194,17 @@ class ElectronCaptureBackend:
             raise RuntimeError(f"electron: base64_decode_failed: {exc}") from exc
 
         try:
-            return Image.open(io.BytesIO(png_bytes)).convert("RGB")
+            image = Image.open(io.BytesIO(png_bytes)).convert("RGB")
         except Exception as exc:
             raise RuntimeError(f"electron: pil_decode_failed: {exc}") from exc
+
+        from .ocr_reader import _crop_window_image  # noqa: PLC0415
+
+        width, height = image.size
+        return _crop_window_image(
+            image,
+            window_rect=(0, 0, int(width), int(height)),
+            profile=profile,
+            backend_kind=self.kind,
+            backend_detail="selected",
+        )

--- a/plugin/plugins/galgame_plugin/electron_capture.py
+++ b/plugin/plugins/galgame_plugin/electron_capture.py
@@ -1,0 +1,170 @@
+"""Electron desktopCapturer HTTP bridge backend (Linux Wayland path).
+
+On pure Wayland, MSS/PyAutoGUI return blank frames because Wayland forbids
+cross-application screen reads. Electron's `desktopCapturer` is the only
+legitimate path because Chromium negotiates with PipeWire +
+xdg-desktop-portal, which both GNOME and KDE support. This backend asks
+the Electron renderer (via the N.E.K.O main API) to capture and returns
+the decoded PNG bytes.
+
+X11/XWayland callers should keep MSS/PyAutoGUI as the primary path; this
+backend appears in the chain only as a tail fallback there.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .ocr_reader import DetectedGameWindow, OcrCaptureProfile
+
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT_FALLBACK = 48911  # MAIN_SERVER_PORT default
+_DEFAULT_HEALTH_PATH = "/api/capture/health"
+_DEFAULT_SCREENSHOT_PATH = "/api/capture/screenshot"
+_MAX_ERROR_BODY_CHARS = 120
+_TARGET_TITLE_MAX_CHARS = 512
+_SAFE_TITLE_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _resolve_default_base_url() -> str:
+    """Pick the local N.E.K.O main server URL.
+
+    Respects NEKO_MAIN_SERVER_PORT (launcher.DEFAULT_PORTS key) so the
+    backend follows whichever port the running session chose, with a
+    fallback to the documented default 48911.
+    """
+    port = os.environ.get("NEKO_MAIN_SERVER_PORT") or os.environ.get(
+        "MAIN_SERVER_PORT"
+    )
+    try:
+        port_int = int(port) if port else _DEFAULT_PORT_FALLBACK
+    except (TypeError, ValueError):
+        port_int = _DEFAULT_PORT_FALLBACK
+    # API URLs intentionally have no trailing slash per project convention.
+    return f"http://{_DEFAULT_HOST}:{port_int}"
+
+
+class ElectronCaptureBackend:
+    """CaptureBackend protocol implementation backed by Electron renderer."""
+
+    kind = "electron"
+
+    def __init__(
+        self,
+        *,
+        logger=None,
+        base_url: str | None = None,
+        request_timeout: float = 5.0,
+        health_timeout: float = 2.0,
+    ) -> None:
+        self._logger = logger
+        self._base_url = (base_url or _resolve_default_base_url()).rstrip("/")
+        self._request_timeout = float(request_timeout)
+        self._health_timeout = float(health_timeout)
+        self._available_cached: bool | None = None
+
+    def is_available(self) -> bool:
+        """Probe the Electron bridge endpoint with a short timeout.
+
+        Caching the negative result for the lifetime of the backend would
+        starve recovery when the Electron app comes online later, so we
+        re-probe on every call. The probe itself is cheap (HTTP HEAD-like
+        GET to /api/capture/health with a 2s timeout).
+        """
+        try:
+            import httpx  # type: ignore[import-not-found]  # noqa: PLC0415
+        except ImportError:
+            return False
+        try:
+            resp = httpx.request(
+                "GET",
+                f"{self._base_url}{_DEFAULT_HEALTH_PATH}",
+                timeout=self._health_timeout,
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def describe_target(self, target: "DetectedGameWindow") -> str:
+        return f"{target.process_name}({target.pid}) {target.title}"
+
+    @staticmethod
+    def _target_payload(target: "DetectedGameWindow") -> dict[str, Any]:
+        target_id = int(getattr(target, "hwnd", 0) or 0)
+        pid = int(getattr(target, "pid", 0) or 0)
+        if target_id <= 0:
+            raise RuntimeError("electron: invalid_target_id")
+        if pid < 0:
+            raise RuntimeError("electron: invalid_target_pid")
+        title = _SAFE_TITLE_RE.sub("", str(getattr(target, "title", "") or ""))
+        title = title[:_TARGET_TITLE_MAX_CHARS]
+        return {"target_id": target_id, "pid": pid, "title": title}
+
+    def capture_frame(
+        self,
+        target: "DetectedGameWindow",
+        profile: "OcrCaptureProfile",
+    ) -> Any:
+        """Request a screenshot from Electron and return a PIL Image.
+
+        Uses target.hwnd (CGWindowID on macOS / X11 Window ID / Windows hWnd)
+        as the cross-platform window identifier. The Electron side maps it
+        back to a desktopCapturer source. We deliberately do NOT pass a
+        rect — Electron returns the full window image, and the caller
+        crops by OcrCaptureProfile ratios. This sidesteps the HiDPI /
+        multi-monitor coordinate mismatch between Chromium physical pixels
+        and X11 logical coordinates.
+        """
+        try:
+            import httpx  # type: ignore[import-not-found]  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError("electron: httpx_not_installed") from exc
+        try:
+            from PIL import Image  # type: ignore[import-not-found]  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError("electron: pillow_not_installed") from exc
+
+        payload = self._target_payload(target)
+        try:
+            resp = httpx.request(
+                "POST",
+                f"{self._base_url}{_DEFAULT_SCREENSHOT_PATH}",
+                json=payload,
+                timeout=self._request_timeout,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"electron: http_request_failed: {exc}") from exc
+
+        if resp.status_code != 200:
+            detail = (resp.text or "").strip().replace("\n", " ")
+            detail = _SAFE_TITLE_RE.sub("", detail)[:_MAX_ERROR_BODY_CHARS]
+            suffix = f": {detail}" if detail else ""
+            raise RuntimeError(f"electron: http_status_{resp.status_code}{suffix}")
+
+        try:
+            data = resp.json()
+        except Exception as exc:
+            raise RuntimeError(f"electron: invalid_json_response: {exc}") from exc
+
+        image_b64 = data.get("image") if isinstance(data, dict) else None
+        if not image_b64:
+            raise RuntimeError("electron: missing_image_field")
+        if isinstance(image_b64, str) and image_b64.startswith("data:"):
+            # Strip "data:image/png;base64," prefix if the frontend sent
+            # the raw data URL rather than just the payload.
+            _, _, image_b64 = image_b64.partition(",")
+        try:
+            png_bytes = base64.b64decode(image_b64)
+        except Exception as exc:
+            raise RuntimeError(f"electron: base64_decode_failed: {exc}") from exc
+
+        try:
+            return Image.open(io.BytesIO(png_bytes)).convert("RGB")
+        except Exception as exc:
+            raise RuntimeError(f"electron: pil_decode_failed: {exc}") from exc

--- a/plugin/plugins/galgame_plugin/memory_reader.py
+++ b/plugin/plugins/galgame_plugin/memory_reader.py
@@ -252,7 +252,9 @@ def _select_hook_codes_for_engine(
 
 
 def is_windows_platform() -> bool:
-    return os.name == "nt" or sys.platform.startswith("win")
+    from plugin.plugins.galgame_plugin.capture_platform import is_windows  # noqa: PLC0415
+
+    return is_windows()
 
 
 def utc_now_iso(now: float | None = None) -> str:

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -3274,6 +3274,7 @@ class Win32CaptureBackend:
         # background-target backend.
         from .capture_platform import (  # noqa: PLC0415
             is_linux,
+            is_linux_wayland_session,
             is_win32_only_backend_kind,
             is_windows,
         )
@@ -3291,9 +3292,17 @@ class Win32CaptureBackend:
                 if not is_win32_only_backend_kind(str(getattr(b, "kind", "")))
             ]
             if is_linux() and self._electron_backend is not None:
+                if (
+                    is_linux_wayland_session()
+                    and self.selection
+                    in {_CAPTURE_BACKEND_AUTO, _CAPTURE_BACKEND_SMART}
+                ):
+                    # On Wayland, MSS/PyAutoGUI can import successfully yet
+                    # return black frames. Prefer Electron's portal-backed
+                    # path for automatic selections instead of treating those
+                    # import probes as capture viability.
+                    return [self._electron_backend]
                 # X11/XWayland: MSS/PyAutoGUI work; Electron is a tail fallback.
-                # Pure Wayland: MSS/PyAutoGUI is_available() returns False,
-                # so Electron becomes the only live backend.
                 cross_platform.append(self._electron_backend)
             return cross_platform
 
@@ -3327,6 +3336,16 @@ class Win32CaptureBackend:
         from .capture_platform import is_windows  # noqa: PLC0415
 
         is_windows_host = is_windows()
+        window_level_backends = [
+            backend
+            for backend in self._backends
+            if str(getattr(backend, "kind", "")) == "electron"
+        ]
+        pixel_backends = [
+            backend
+            for backend in self._backends
+            if str(getattr(backend, "kind", "")) not in {"electron", _CAPTURE_BACKEND_PRINTWINDOW}
+        ]
         if self.selection == _CAPTURE_BACKEND_PRINTWINDOW:
             if not (
                 is_windows_host and self._printwindow_backend in self._backends
@@ -3351,7 +3370,11 @@ class Win32CaptureBackend:
         if bool(getattr(target, "is_minimized", False)):
             raise RuntimeError("smart: target_window_minimized_for_capture")
         if not is_windows_host:
-            return list(self._backends)
+            if bool(getattr(target, "is_foreground", False)):
+                return window_level_backends + pixel_backends
+            if window_level_backends:
+                return window_level_backends
+            raise RuntimeError("smart: background_capture_requires_window_backend")
         if bool(getattr(target, "is_foreground", False)):
             foreground_backends = {
                 id(self._dxcam_backend),
@@ -5014,11 +5037,9 @@ class OcrReaderManager:
         )
         self._custom_capture_backend = capture_backend is not None
         # Win32CaptureBackend works on all platforms: its _build_backends()
-        # filters out dxcam/printwindow on non-Windows, leaving the
-        # cross-platform chain (mss, pyautogui) plus the optional Electron
-        # bridge added below for Linux. On pure Wayland with no Electron
-        # endpoint reachable, is_available() returns False and the preflight
-        # in _tick_preflight() surfaces the unsupported state cleanly.
+        # filters out dxcam/printwindow on non-Windows. Linux X11 keeps the
+        # screen-pixel chain plus the optional Electron bridge fallback, while
+        # Wayland automatic selections use the Electron portal path directly.
         self._capture_backend = capture_backend or Win32CaptureBackend(
             logger=logger,
             selection=config.ocr_reader_capture_backend,

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import tempfile
 import threading
@@ -2430,6 +2431,19 @@ class OcrBackend(Protocol):
 
 
 def _target_window_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    from .capture_platform import is_linux, is_macos, is_windows  # noqa: PLC0415
+
+    if is_windows():
+        return _target_window_rect_win32(target)
+    if is_macos():
+        return _target_window_rect_macos(target)
+    if is_linux():
+        return _target_window_rect_linux(target)
+    raise RuntimeError(f"unsupported platform for window rect: {sys.platform}")
+
+
+def _target_window_rect_win32(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    """Windows: win32gui.GetWindowRect (original implementation, unchanged)."""
     import win32gui
 
     def _read_rect() -> tuple[int, int, int, int]:
@@ -2442,6 +2456,104 @@ def _target_window_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]
     if width <= 0 or height <= 0:
         raise RuntimeError(f"Invalid window dimensions: {width}x{height}")
     return rect
+
+
+def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    """macOS: CGWindowListCopyWindowInfo via pyobjc.
+
+    Uses kCGWindowListOptionOnScreenOnly to avoid stale coordinates from
+    windows on inactive Spaces (consistent with _scan_windows_macos).
+    Falls back to (0, 0, width, height) if Quartz is unavailable or the
+    window cannot be found by PID — the capture backend then does a
+    full-screen grab and the caller crops by profile ratios.
+    """
+    try:
+        import Quartz  # type: ignore[import-not-found]
+    except ImportError:
+        return (0, 0, int(target.width), int(target.height))
+
+    window_list = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID
+    )
+    for window in window_list:
+        if window.get(Quartz.kCGWindowOwnerPID) == int(target.pid):
+            bounds = window.get(Quartz.kCGWindowBounds)
+            if isinstance(bounds, dict):
+                x = int(bounds.get("X", 0))
+                y = int(bounds.get("Y", 0))
+                w = int(bounds.get("Width", target.width))
+                h = int(bounds.get("Height", target.height))
+                if w > 0 and h > 0:
+                    return (x, y, x + w, y + h)
+    return (0, 0, int(target.width), int(target.height))
+
+
+def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    """Linux: window rect via python-xlib (X11) or wmctrl.
+
+    Translates X11 relative coordinates to absolute screen coordinates
+    by walking up the window tree. Falls back to wmctrl subprocess and
+    finally to (0, 0, width, height) — the capture backend then does a
+    full-screen grab and the caller crops by OcrCaptureProfile ratios.
+    On pure Wayland both X11 paths fail naturally and the fallback wins.
+    """
+    logger = logging.getLogger(__name__)
+    try:
+        from Xlib import display as xdisplay  # type: ignore[import-not-found]  # noqa: PLC0415
+
+        d = xdisplay.Display()
+        root = d.screen().root
+        net_client_list = d.intern_atom("_NET_CLIENT_LIST")
+        raw = root.get_full_property(net_client_list, 0)
+        window_ids = raw.value if raw else []
+        for wid in window_ids:
+            if int(wid) == int(target.hwnd):
+                window = d.create_resource_object("window", wid)
+                geom = window.get_geometry()
+                child = window
+                abs_x, abs_y = 0, 0
+                while child is not None:
+                    g = child.get_geometry()
+                    abs_x += g.x
+                    abs_y += g.y
+                    parent = child.query_tree().parent
+                    child = parent if parent != root else None
+                w = max(0, int(geom.width))
+                h = max(0, int(geom.height))
+                if w > 0 and h > 0:
+                    return (abs_x, abs_y, abs_x + w, abs_y + h)
+    except Exception as exc:
+        logger.debug("linux xlib target rect lookup failed: %s", exc)
+
+    try:
+        import subprocess  # noqa: PLC0415
+
+        wmctrl_path = shutil.which("wmctrl")
+        if not wmctrl_path:
+            return (0, 0, int(target.width), int(target.height))
+        output = subprocess.check_output(
+            [wmctrl_path, "-lG"], text=True, timeout=5
+        )
+        for line in output.splitlines():
+            parts = line.split()
+            if len(parts) < 8:
+                continue
+            try:
+                if int(parts[0], 16) == int(target.hwnd):
+                    x, y, w, h = (
+                        int(parts[2]),
+                        int(parts[3]),
+                        int(parts[4]),
+                        int(parts[5]),
+                    )
+                    if w > 0 and h > 0:
+                        return (x, y, x + w, y + h)
+            except (ValueError, IndexError):
+                continue
+    except Exception as exc:
+        logger.debug("linux wmctrl target rect lookup failed: %s", exc)
+
+    return (0, 0, int(target.width), int(target.height))
 
 
 def _valid_screen_rect(rect: tuple[int, int, int, int]) -> bool:
@@ -2624,6 +2736,18 @@ def _run_with_thread_dpi_awareness(fn: Callable[[], tuple[int, int, int, int]]) 
 
 
 def _target_client_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    from .capture_platform import is_windows  # noqa: PLC0415
+
+    if is_windows():
+        return _target_client_rect_win32(target)
+    # macOS/Linux: most target games are borderless fullscreen or borderless
+    # windowed. Do not subtract hard-coded title-bar pixels by default; the
+    # capture path crops by OcrCaptureProfile ratios afterwards.
+    return _target_window_rect(target)
+
+
+def _target_client_rect_win32(target: DetectedGameWindow) -> tuple[int, int, int, int]:
+    """Windows: win32gui.GetClientRect + ClientToScreen (original, unchanged)."""
     import win32gui
 
     def _read_rect() -> tuple[int, int, int, int]:
@@ -2641,6 +2765,23 @@ def _target_client_rect(target: DetectedGameWindow) -> tuple[int, int, int, int]
 
 
 def _require_visible_capture_target(target: DetectedGameWindow, *, backend_kind: str) -> None:
+    from .capture_platform import is_windows  # noqa: PLC0415
+
+    if is_windows():
+        return _require_visible_capture_target_win32(target, backend_kind=backend_kind)
+    # macOS/Linux: best-effort check. PyAutoGUI/MSS can still capture
+    # windows that aren't strictly visible via Win32 semantics, so only
+    # validate the invariants we can observe portably.
+    if not target.hwnd and not target.pid:
+        raise RuntimeError(f"{backend_kind}: target_window_not_resolved_for_capture")
+    if getattr(target, "is_minimized", False):
+        raise RuntimeError(f"{backend_kind}: target_window_minimized_for_capture")
+
+
+def _require_visible_capture_target_win32(
+    target: DetectedGameWindow, *, backend_kind: str
+) -> None:
+    """Windows: existing win32gui visibility checks (unchanged from original)."""
     if not target.hwnd:
         raise RuntimeError(f"{backend_kind}: target_window_not_resolved_for_capture")
     try:
@@ -2655,7 +2796,9 @@ def _require_visible_capture_target(target: DetectedGameWindow, *, backend_kind:
     except RuntimeError:
         raise
     except Exception as exc:
-        raise RuntimeError(f"{backend_kind}: target_window_visibility_check_failed: {exc}") from exc
+        raise RuntimeError(
+            f"{backend_kind}: target_window_visibility_check_failed: {exc}"
+        ) from exc
 
 
 def _crop_window_image(
@@ -3048,6 +3191,19 @@ class Win32CaptureBackend:
         self._pyautogui_backend = PyAutoGuiCaptureBackend(logger=self._logger)
         self._printwindow_backend = PrintWindowCaptureBackend(logger=self._logger)
         self._dxcam_backend = DxcamCaptureBackend(logger=self._logger)
+        # Linux-only: HTTP bridge to Electron desktopCapturer for Wayland
+        # (and as XWayland/X11 fallback). Lazy import to avoid pulling
+        # httpx on platforms that don't need it.
+        from .capture_platform import is_linux  # noqa: PLC0415
+
+        if is_linux():
+            from .electron_capture import ElectronCaptureBackend  # noqa: PLC0415
+
+            self._electron_backend: CaptureBackend | None = ElectronCaptureBackend(
+                logger=self._logger
+            )
+        else:
+            self._electron_backend = None
         self._backends = self._build_backends()
         self._last_backend_lock = threading.RLock()
         self._last_backend_kind = ""
@@ -3077,17 +3233,56 @@ class Win32CaptureBackend:
         # backends. It's still reachable as an explicit user selection
         # (mainly for capturing occluded windows) and as the Smart-mode
         # background-target backend.
+        from .capture_platform import (  # noqa: PLC0415
+            is_linux,
+            is_win32_only_backend_kind,
+            is_windows,
+        )
+
+        def _filter(backends: list[CaptureBackend]) -> list[CaptureBackend]:
+            """Remove backends that require Win32 APIs on non-Windows hosts,
+            and append the Electron HTTP bridge as a last-resort entry on Linux
+            (needed for pure Wayland where MSS/PyAutoGUI return blank frames).
+            """
+            if is_windows():
+                return list(backends)
+            cross_platform = [
+                b
+                for b in backends
+                if not is_win32_only_backend_kind(str(getattr(b, "kind", "")))
+            ]
+            if is_linux() and self._electron_backend is not None:
+                # X11/XWayland: MSS/PyAutoGUI work; Electron is a tail fallback.
+                # Pure Wayland: MSS/PyAutoGUI is_available() returns False,
+                # so Electron becomes the only live backend.
+                cross_platform.append(self._electron_backend)
+            return cross_platform
+
         if self.selection == _CAPTURE_BACKEND_DXCAM:
-            return [self._dxcam_backend, self._mss_backend, self._pyautogui_backend]
+            return _filter([self._dxcam_backend, self._mss_backend, self._pyautogui_backend])
         if self.selection == _CAPTURE_BACKEND_MSS:
-            return [self._mss_backend, self._dxcam_backend, self._pyautogui_backend]
+            return _filter([self._mss_backend, self._dxcam_backend, self._pyautogui_backend])
         if self.selection == _CAPTURE_BACKEND_PYAUTOGUI:
-            return [self._pyautogui_backend, self._dxcam_backend, self._mss_backend]
+            return _filter([self._pyautogui_backend, self._dxcam_backend, self._mss_backend])
         if self.selection == _CAPTURE_BACKEND_PRINTWINDOW:
-            return [self._printwindow_backend, self._dxcam_backend, self._mss_backend, self._pyautogui_backend]
+            return _filter(
+                [
+                    self._printwindow_backend,
+                    self._dxcam_backend,
+                    self._mss_backend,
+                    self._pyautogui_backend,
+                ]
+            )
         if self.selection == _CAPTURE_BACKEND_SMART:
-            return [self._dxcam_backend, self._mss_backend, self._pyautogui_backend, self._printwindow_backend]
-        return [self._dxcam_backend, self._mss_backend, self._pyautogui_backend]
+            return _filter(
+                [
+                    self._dxcam_backend,
+                    self._mss_backend,
+                    self._pyautogui_backend,
+                    self._printwindow_backend,
+                ]
+            )
+        return _filter([self._dxcam_backend, self._mss_backend, self._pyautogui_backend])
 
     def _ordered_backends_for_target(self, target: DetectedGameWindow) -> list[CaptureBackend]:
         if self.selection == _CAPTURE_BACKEND_PRINTWINDOW:
@@ -3417,7 +3612,22 @@ def _default_window_scanner() -> list[DetectedGameWindow]:
 
 
 def _is_windows_platform() -> bool:
-    return os.name == "nt"
+    from .capture_platform import is_windows  # noqa: PLC0415
+
+    return is_windows()
+
+
+def _platform_scan_windows() -> list[DetectedGameWindow]:
+    """Cross-platform window enumeration entry point.
+
+    Delegates to capture_platform.scan_windows() which dispatches to the
+    correct backend per platform. Used as the non-Windows default for
+    OcrReaderManager._window_scanner. On Windows the manager keeps using
+    _default_window_scanner directly to preserve identity-based tests.
+    """
+    from .capture_platform import scan_windows  # noqa: PLC0415
+
+    return scan_windows()
 
 
 def _foreground_window_handle() -> int:
@@ -4737,9 +4947,21 @@ class OcrReaderManager:
         self._logger = logger
         self._config = config
         self._time_fn = time_fn or time.time
-        self._platform_fn = platform_fn or _is_windows_platform
-        self._window_scanner = window_scanner or _default_window_scanner
+        platform_checker = platform_fn or _is_windows_platform
+        is_windows_runtime = bool(platform_checker())
+        self._platform_fn = platform_checker
+        # Windows keeps _default_window_scanner (identity-preserving for tests).
+        # macOS/Linux use the cross-platform dispatcher in capture_platform.
+        self._window_scanner = window_scanner or (
+            _default_window_scanner if is_windows_runtime else _platform_scan_windows
+        )
         self._custom_capture_backend = capture_backend is not None
+        # Win32CaptureBackend works on all platforms: its _build_backends()
+        # filters out dxcam/printwindow on non-Windows, leaving the
+        # cross-platform chain (mss, pyautogui) plus the optional Electron
+        # bridge added below for Linux. On pure Wayland with no Electron
+        # endpoint reachable, is_available() returns False and the preflight
+        # in _tick_preflight() surfaces the unsupported state cleanly.
         self._capture_backend = capture_backend or Win32CaptureBackend(
             logger=logger,
             selection=config.ocr_reader_capture_backend,
@@ -7257,11 +7479,10 @@ class OcrReaderManager:
         *,
         force: bool = False,
     ) -> tuple[list[DetectedGameWindow], list[DetectedGameWindow]]:
-        if not self._platform_fn():
-            self._last_detected_windows = []
-            self._last_eligible_windows = []
-            self._last_excluded_windows = []
-            return [], []
+        # Window enumeration is now cross-platform via capture_platform.
+        # The injected _window_scanner dispatches per platform; non-Windows
+        # paths return [] gracefully (Wayland / missing pyobjc / etc.) so
+        # we always run the scan and let the inventory cache absorb empties.
         scanned = self._scan_raw_windows_cached(force=force)
         return self._prepare_window_inventory(scanned)
 
@@ -7288,15 +7509,31 @@ class OcrReaderManager:
             return _TickPreflightResult(result=result, should_return=True)
 
         if not self._platform_fn():
-            self._runtime = self._build_runtime(
-                status="idle",
-                detail="unsupported_platform",
-                plan=SelectedOcrBackendPlan(),
-            )
-            await self._end_session_if_needed(now)
-            result.warnings.append("ocr_reader is Windows-only")
-            result.runtime = self._runtime.to_dict()
-            return _TickPreflightResult(result=result, should_return=True)
+            # macOS / Linux: only refuse if the capture backend really
+            # has no live sub-backend. Win32CaptureBackend filters out
+            # dxcam/printwindow on these platforms and appends the
+            # Electron HTTP bridge on Linux, so is_available() reflects
+            # the actual cross-platform capability. Pure Wayland with
+            # no Electron endpoint reachable returns False here, and the
+            # user sees the documented unsupported_platform path.
+            backend = self._capture_backend
+            backend_alive = False
+            try:
+                backend_alive = bool(await asyncio.to_thread(backend.is_available))
+            except Exception:
+                backend_alive = False
+            if not backend_alive:
+                self._runtime = self._build_runtime(
+                    status="idle",
+                    detail="unsupported_platform",
+                    plan=SelectedOcrBackendPlan(),
+                )
+                await self._end_session_if_needed(now)
+                result.warnings.append(
+                    "ocr_reader: no capture backend available on this platform"
+                )
+                result.runtime = self._runtime.to_dict()
+                return _TickPreflightResult(result=result, should_return=True)
 
         backend_plan_started_at = self._time_fn()
         if self._custom_ocr_backend:
@@ -7371,7 +7608,10 @@ class OcrReaderManager:
                     should_return=True,
                 )
 
-        if not self._capture_backend.is_available():
+        capture_backend_available = await asyncio.to_thread(
+            self._capture_backend.is_available
+        )
+        if not capture_backend_available:
             self._runtime = self._build_runtime(
                 status="candidate",
                 detail="capture_backend_unavailable",

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2463,21 +2463,21 @@ def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int
 
     Uses kCGWindowListOptionOnScreenOnly to avoid stale coordinates from
     windows on inactive Spaces (consistent with _scan_windows_macos).
-    Falls back to (0, 0, width, height) if Quartz is unavailable or the
-    window cannot be identified — the capture backend then does a
-    full-screen grab and the caller crops by profile ratios.
+    Raises if Quartz cannot resolve the real absolute window bounds.
+    Returning a synthetic (0, 0, width, height) rectangle would be treated as
+    screen coordinates by pixel-based backends and silently capture the wrong
+    region for non-origin windows.
     """
-    fallback_rect = (0, 0, int(target.width), int(target.height))
     try:
         import Quartz  # type: ignore[import-not-found]
-    except ImportError:
-        return fallback_rect
+    except ImportError as exc:
+        raise RuntimeError("macos_quartz_not_available") from exc
 
     window_list = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID
     )
     if not window_list:
-        return fallback_rect
+        raise RuntimeError("macos_target_window_rect_unavailable")
 
     target_window_id = max(0, int(getattr(target, "hwnd", 0) or 0))
     target_pid = max(0, int(getattr(target, "pid", 0) or 0))
@@ -2517,7 +2517,7 @@ def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int
         if rect is not None:
             return rect
 
-    return fallback_rect
+    raise RuntimeError("macos_target_window_rect_unavailable")
 
 
 def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int, int]:
@@ -7493,7 +7493,10 @@ class OcrReaderManager:
         self,
         windows: list[DetectedGameWindow],
     ) -> tuple[list[DetectedGameWindow], list[DetectedGameWindow]]:
-        foreground_hwnd = _foreground_window_handle()
+        use_windows_foreground_api = bool(self._platform_fn())
+        foreground_hwnd = (
+            _foreground_window_handle() if use_windows_foreground_api else 0
+        )
         prepared: list[DetectedGameWindow] = []
         for window in windows:
             candidate = replace(window)
@@ -7505,8 +7508,11 @@ class OcrReaderManager:
             candidate.hwnd = max(0, int(candidate.hwnd or 0))
             candidate.area = max(0, int(candidate.area or 0))
             candidate.is_minimized = bool(candidate.is_minimized)
-            foreground_match, _ = _foreground_matches_target(foreground_hwnd, candidate)
-            candidate.is_foreground = foreground_match
+            if use_windows_foreground_api:
+                foreground_match, _ = _foreground_matches_target(foreground_hwnd, candidate)
+                candidate.is_foreground = foreground_match
+            else:
+                candidate.is_foreground = bool(candidate.is_foreground)
             candidate.score = float(max(candidate.area, 1))
             candidate = _classify_window_candidate(candidate)
             prepared.append(candidate)
@@ -10168,11 +10174,17 @@ class OcrReaderManager:
                 else "no_eligible_window"
             )
             if selection.selection_mode == "auto":
-                foreground_hwnd = _foreground_window_handle()
+                use_windows_foreground_api = bool(self._platform_fn())
+                foreground_hwnd = (
+                    _foreground_window_handle() if use_windows_foreground_api else 0
+                )
                 for candidate in excluded:
-                    if candidate.is_foreground or (
-                        foreground_hwnd and candidate.hwnd == foreground_hwnd
-                    ):
+                    candidate_foreground = (
+                        bool(foreground_hwnd and candidate.hwnd == foreground_hwnd)
+                        if use_windows_foreground_api
+                        else bool(candidate.is_foreground)
+                    )
+                    if candidate_foreground:
                         selection.selection_detail = "foreground_window_needs_manual_confirmation"
                         break
             return selection
@@ -10266,18 +10278,26 @@ class OcrReaderManager:
             if selection.selection_mode == "auto":
                 selection.selection_detail = "locked_target_unavailable"
             return selection
-        foreground_hwnd = _foreground_window_handle()
-        if foreground_hwnd:
-            for candidate in windows:
-                if candidate.hwnd == foreground_hwnd:
-                    if not _is_confident_auto_window(candidate):
-                        if selection.selection_mode == "auto":
-                            selection.selection_detail = "foreground_window_needs_manual_confirmation"
-                        return selection
-                    selection.target = candidate
-                    if selection.selection_mode == "auto":
-                        selection.selection_detail = "foreground_window"
-                    return selection
+        use_windows_foreground_api = bool(self._platform_fn())
+        foreground_hwnd = (
+            _foreground_window_handle() if use_windows_foreground_api else 0
+        )
+        for candidate in windows:
+            candidate_foreground = (
+                bool(foreground_hwnd and candidate.hwnd == foreground_hwnd)
+                if use_windows_foreground_api
+                else bool(candidate.is_foreground)
+            )
+            if not candidate_foreground:
+                continue
+            if not _is_confident_auto_window(candidate):
+                if selection.selection_mode == "auto":
+                    selection.selection_detail = "foreground_window_needs_manual_confirmation"
+                return selection
+            selection.target = candidate
+            if selection.selection_mode == "auto":
+                selection.selection_detail = "foreground_window"
+            return selection
         if len(windows) == 1:
             configured_profile = _lookup_capture_profile(
                 self._capture_profiles,

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2525,9 +2525,10 @@ def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int
 
     Translates X11 relative coordinates to absolute screen coordinates
     by walking up the window tree. Falls back to wmctrl subprocess and
-    finally to (0, 0, width, height) — the capture backend then does a
-    full-screen grab and the caller crops by OcrCaptureProfile ratios.
-    On pure Wayland both X11 paths fail naturally and the fallback wins.
+    raises if neither source can resolve the real absolute window bounds.
+    Returning a synthetic (0, 0, width, height) rectangle would be treated as
+    screen coordinates by pixel-based backends and silently capture the wrong
+    region for non-origin windows.
     """
     logger = logging.getLogger(__name__)
     try:
@@ -2568,7 +2569,7 @@ def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int
 
         wmctrl_path = shutil.which("wmctrl")
         if not wmctrl_path:
-            return (0, 0, int(target.width), int(target.height))
+            raise RuntimeError("wmctrl_not_available")
         output = subprocess.check_output(
             [wmctrl_path, "-lG"], text=True, timeout=5
         )
@@ -2591,7 +2592,7 @@ def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int
     except Exception as exc:
         logger.debug("linux wmctrl target rect lookup failed: %s", exc)
 
-    return (0, 0, int(target.width), int(target.height))
+    raise RuntimeError("linux_target_window_rect_unavailable")
 
 
 def _valid_screen_rect(rect: tuple[int, int, int, int]) -> bool:

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -3333,10 +3333,11 @@ class Win32CaptureBackend:
         return _filter([self._dxcam_backend, self._mss_backend, self._pyautogui_backend])
 
     def _ordered_backends_for_target(self, target: DetectedGameWindow) -> list[CaptureBackend]:
-        from .capture_platform import is_linux, is_windows  # noqa: PLC0415
+        from .capture_platform import is_linux, is_linux_wayland_session, is_windows  # noqa: PLC0415
 
         is_windows_host = is_windows()
         is_linux_host = is_linux()
+        is_wayland_host = is_linux_wayland_session() if is_linux_host else False
         window_level_backends = [
             backend
             for backend in self._backends
@@ -3374,6 +3375,8 @@ class Win32CaptureBackend:
             if not is_linux_host:
                 return window_level_backends + pixel_backends
             if bool(getattr(target, "is_foreground", False)):
+                return window_level_backends + pixel_backends
+            if not is_wayland_host:
                 return window_level_backends + pixel_backends
             if window_level_backends:
                 return window_level_backends

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -3333,9 +3333,10 @@ class Win32CaptureBackend:
         return _filter([self._dxcam_backend, self._mss_backend, self._pyautogui_backend])
 
     def _ordered_backends_for_target(self, target: DetectedGameWindow) -> list[CaptureBackend]:
-        from .capture_platform import is_windows  # noqa: PLC0415
+        from .capture_platform import is_linux, is_windows  # noqa: PLC0415
 
         is_windows_host = is_windows()
+        is_linux_host = is_linux()
         window_level_backends = [
             backend
             for backend in self._backends
@@ -3370,6 +3371,8 @@ class Win32CaptureBackend:
         if bool(getattr(target, "is_minimized", False)):
             raise RuntimeError("smart: target_window_minimized_for_capture")
         if not is_windows_host:
+            if not is_linux_host:
+                return window_level_backends + pixel_backends
             if bool(getattr(target, "is_foreground", False)):
                 return window_level_backends + pixel_backends
             if window_level_backends:

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2464,7 +2464,7 @@ def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int
     Uses kCGWindowListOptionOnScreenOnly to avoid stale coordinates from
     windows on inactive Spaces (consistent with _scan_windows_macos).
     Falls back to (0, 0, width, height) if Quartz is unavailable or the
-    window cannot be found by PID — the capture backend then does a
+    window cannot be identified — the capture backend then does a
     full-screen grab and the caller crops by profile ratios.
     """
     try:
@@ -2475,16 +2475,44 @@ def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int
     window_list = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID
     )
+    target_window_id = max(0, int(getattr(target, "hwnd", 0) or 0))
+    target_pid = max(0, int(getattr(target, "pid", 0) or 0))
+    target_title = _normalize_window_title(getattr(target, "title", "") or "")
+    pid_matches: list[Any] = []
+
+    def _window_rect(window: Any) -> tuple[int, int, int, int] | None:
+        bounds = window.get(Quartz.kCGWindowBounds)
+        if not isinstance(bounds, dict):
+            return None
+        x = int(bounds.get("X", 0))
+        y = int(bounds.get("Y", 0))
+        w = int(bounds.get("Width", target.width))
+        h = int(bounds.get("Height", target.height))
+        if w <= 0 or h <= 0:
+            return None
+        return (x, y, x + w, y + h)
+
     for window in window_list:
-        if window.get(Quartz.kCGWindowOwnerPID) == int(target.pid):
-            bounds = window.get(Quartz.kCGWindowBounds)
-            if isinstance(bounds, dict):
-                x = int(bounds.get("X", 0))
-                y = int(bounds.get("Y", 0))
-                w = int(bounds.get("Width", target.width))
-                h = int(bounds.get("Height", target.height))
-                if w > 0 and h > 0:
-                    return (x, y, x + w, y + h)
+        window_id = max(0, int(window.get(Quartz.kCGWindowNumber, 0) or 0))
+        if target_window_id and window_id == target_window_id:
+            rect = _window_rect(window)
+            if rect is not None:
+                return rect
+        if target_pid and window.get(Quartz.kCGWindowOwnerPID) == target_pid:
+            pid_matches.append(window)
+
+    for window in pid_matches:
+        name = _normalize_window_title(window.get(Quartz.kCGWindowName, "") or "")
+        if target_title and name == target_title:
+            rect = _window_rect(window)
+            if rect is not None:
+                return rect
+
+    if not target_window_id and len(pid_matches) == 1:
+        rect = _window_rect(pid_matches[0])
+        if rect is not None:
+            return rect
+
     return (0, 0, int(target.width), int(target.height))
 
 
@@ -3285,7 +3313,14 @@ class Win32CaptureBackend:
         return _filter([self._dxcam_backend, self._mss_backend, self._pyautogui_backend])
 
     def _ordered_backends_for_target(self, target: DetectedGameWindow) -> list[CaptureBackend]:
+        from .capture_platform import is_windows  # noqa: PLC0415
+
+        is_windows_host = is_windows()
         if self.selection == _CAPTURE_BACKEND_PRINTWINDOW:
+            if not (
+                is_windows_host and self._printwindow_backend in self._backends
+            ):
+                return list(self._backends)
             # Explicit PrintWindow selection: user is opting into the only
             # backend that can capture occluded / background windows. If we
             # silently fell through to dxcam/mss/pyautogui on a background
@@ -3304,8 +3339,19 @@ class Win32CaptureBackend:
             return list(self._backends)
         if bool(getattr(target, "is_minimized", False)):
             raise RuntimeError("smart: target_window_minimized_for_capture")
+        if not is_windows_host:
+            return list(self._backends)
         if bool(getattr(target, "is_foreground", False)):
-            return [self._dxcam_backend, self._mss_backend, self._pyautogui_backend]
+            foreground_backends = {
+                id(self._dxcam_backend),
+                id(self._mss_backend),
+                id(self._pyautogui_backend),
+            }
+            return [
+                backend
+                for backend in self._backends
+                if id(backend) in foreground_backends
+            ]
         # Background target: PrintWindow is the only backend that can plausibly
         # capture occluded windows (others read screen pixels and would grab
         # the overlapping window). Quality is unreliable; ocr_reader emits

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2530,26 +2530,32 @@ def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int
         from Xlib import display as xdisplay  # type: ignore[import-not-found]  # noqa: PLC0415
 
         d = xdisplay.Display()
-        root = d.screen().root
-        net_client_list = d.intern_atom("_NET_CLIENT_LIST")
-        raw = root.get_full_property(net_client_list, 0)
-        window_ids = raw.value if raw else []
-        for wid in window_ids:
-            if int(wid) == int(target.hwnd):
-                window = d.create_resource_object("window", wid)
-                geom = window.get_geometry()
-                child = window
-                abs_x, abs_y = 0, 0
-                while child is not None:
-                    g = child.get_geometry()
-                    abs_x += g.x
-                    abs_y += g.y
-                    parent = child.query_tree().parent
-                    child = parent if parent != root else None
-                w = max(0, int(geom.width))
-                h = max(0, int(geom.height))
-                if w > 0 and h > 0:
-                    return (abs_x, abs_y, abs_x + w, abs_y + h)
+        try:
+            root = d.screen().root
+            net_client_list = d.intern_atom("_NET_CLIENT_LIST")
+            raw = root.get_full_property(net_client_list, 0)
+            window_ids = raw.value if raw else []
+            for wid in window_ids:
+                if int(wid) == int(target.hwnd):
+                    window = d.create_resource_object("window", wid)
+                    geom = window.get_geometry()
+                    child = window
+                    abs_x, abs_y = 0, 0
+                    while child is not None:
+                        g = child.get_geometry()
+                        abs_x += g.x
+                        abs_y += g.y
+                        parent = child.query_tree().parent
+                        child = parent if parent != root else None
+                    w = max(0, int(geom.width))
+                    h = max(0, int(geom.height))
+                    if w > 0 and h > 0:
+                        return (abs_x, abs_y, abs_x + w, abs_y + h)
+        finally:
+            try:
+                d.close()
+            except Exception as exc:
+                logger.debug("linux xlib display close failed: %s", exc)
     except Exception as exc:
         logger.debug("linux xlib target rect lookup failed: %s", exc)
 

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -7732,11 +7732,15 @@ class OcrReaderManager:
         memory_reader_runtime: dict[str, Any],
         result: OcrReaderTickResult,
     ) -> _TickTargetContext:
-        foreground_hwnd_for_scan = _foreground_window_handle()
+        use_windows_foreground_api = bool(self._platform_fn())
+        foreground_hwnd_for_scan = (
+            _foreground_window_handle() if use_windows_foreground_api else 0
+        )
         force_window_scan = (
             self._last_selection.selection_detail == "locked_target_unavailable"
             or (
                 self._attached_window is not None
+                and use_windows_foreground_api
                 and foreground_hwnd_for_scan > 0
                 and not _foreground_matches_target(
                     foreground_hwnd_for_scan,

--- a/plugin/plugins/galgame_plugin/ocr_reader.py
+++ b/plugin/plugins/galgame_plugin/ocr_reader.py
@@ -2467,14 +2467,18 @@ def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int
     window cannot be identified — the capture backend then does a
     full-screen grab and the caller crops by profile ratios.
     """
+    fallback_rect = (0, 0, int(target.width), int(target.height))
     try:
         import Quartz  # type: ignore[import-not-found]
     except ImportError:
-        return (0, 0, int(target.width), int(target.height))
+        return fallback_rect
 
     window_list = Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID
     )
+    if not window_list:
+        return fallback_rect
+
     target_window_id = max(0, int(getattr(target, "hwnd", 0) or 0))
     target_pid = max(0, int(getattr(target, "pid", 0) or 0))
     target_title = _normalize_window_title(getattr(target, "title", "") or "")
@@ -2513,7 +2517,7 @@ def _target_window_rect_macos(target: DetectedGameWindow) -> tuple[int, int, int
         if rect is not None:
             return rect
 
-    return (0, 0, int(target.width), int(target.height))
+    return fallback_rect
 
 
 def _target_window_rect_linux(target: DetectedGameWindow) -> tuple[int, int, int, int]:

--- a/plugin/plugins/galgame_plugin/service.py
+++ b/plugin/plugins/galgame_plugin/service.py
@@ -633,11 +633,27 @@ def _default_bridge_root_raw() -> str:
 
 
 def _default_memory_reader_enabled() -> bool:
-    return sys.platform.startswith("win")
+    from .capture_platform import is_windows  # noqa: PLC0415
+
+    return is_windows()
 
 
 def _default_ocr_reader_enabled() -> bool:
-    return sys.platform.startswith("win")
+    # Keep OCR reader Windows-only for now; do not couple this to
+    # rapidocr_enabled because RapidOCR has its own platform checks.
+    from .capture_platform import is_windows  # noqa: PLC0415
+
+    return is_windows()
+
+
+def _default_rapidocr_enabled() -> bool:
+    # RapidOCR remains Windows-only at the default level. RapidOCR
+    # itself does its own runtime platform check; this default just
+    # mirrors the historical behavior so non-Windows users opt-in
+    # explicitly rather than getting a surprise enable.
+    from .capture_platform import is_windows  # noqa: PLC0415
+
+    return is_windows()
 
 
 def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
@@ -964,7 +980,7 @@ def build_config(raw_config: dict[str, Any]) -> GalgameConfig:
         ),
         rapidocr_enabled=_coerce_bool(
             rapidocr_obj.get("enabled"),
-            _default_ocr_reader_enabled(),
+            _default_rapidocr_enabled(),
         ),
         rapidocr_enabled_explicit="enabled" in rapidocr_obj,
         # NOTE: `rapidocr_install_manifest_url` and `rapidocr_install_timeout_seconds`

--- a/plugin/plugins/galgame_plugin/window_scanner_linux.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_linux.py
@@ -57,6 +57,9 @@ def _scan_windows_linux_xlib() -> list["DetectedGameWindow"]:
         net_wm_name = d.intern_atom("_NET_WM_NAME")
         net_wm_pid = d.intern_atom("_NET_WM_PID")
         net_wm_visible_name = d.intern_atom("_NET_WM_VISIBLE_NAME")
+        net_wm_state = d.intern_atom("_NET_WM_STATE")
+        net_wm_state_hidden = d.intern_atom("_NET_WM_STATE_HIDDEN")
+        wm_state = d.intern_atom("WM_STATE")
 
         try:
             raw = root.get_full_property(net_client_list, X.AnyPropertyType)
@@ -72,6 +75,12 @@ def _scan_windows_linux_xlib() -> list["DetectedGameWindow"]:
 
                 title = _x11_get_window_title(window, net_wm_name, net_wm_visible_name)
                 pid = _x11_get_window_pid(window, net_wm_pid)
+                is_minimized = _x11_is_window_minimized(
+                    window,
+                    net_wm_state,
+                    net_wm_state_hidden,
+                    wm_state,
+                )
 
                 if not title or len(str(title)) < 2:
                     continue
@@ -94,7 +103,7 @@ def _scan_windows_linux_xlib() -> list["DetectedGameWindow"]:
                         height=height,
                         area=area,
                         is_foreground=False,
-                        is_minimized=False,
+                        is_minimized=is_minimized,
                         score=float(area),
                     )
                 )
@@ -140,6 +149,30 @@ def _x11_get_window_pid(window: Any, net_wm_pid: Any) -> int | None:
     except Exception as exc:
         _LOGGER.debug("linux xlib pid read failed: %s", exc)
     return None
+
+
+def _x11_is_window_minimized(
+    window: Any,
+    net_wm_state: Any,
+    net_wm_state_hidden: Any,
+    wm_state: Any,
+) -> bool:
+    """Return True for X11/EWMH hidden or ICCCM iconic windows."""
+    try:
+        prop = window.get_full_property(net_wm_state, 0)
+        if prop and prop.value is not None:
+            if any(int(value) == int(net_wm_state_hidden) for value in prop.value):
+                return True
+    except Exception as exc:
+        _LOGGER.debug("linux xlib _NET_WM_STATE read failed: %s", exc)
+
+    try:
+        prop = window.get_full_property(wm_state, 0)
+        if prop and prop.value is not None and len(prop.value) > 0:
+            return int(prop.value[0]) == 3  # ICCCM IconicState
+    except Exception as exc:
+        _LOGGER.debug("linux xlib WM_STATE read failed: %s", exc)
+    return False
 
 
 def _scan_windows_linux_wmctrl() -> list["DetectedGameWindow"]:

--- a/plugin/plugins/galgame_plugin/window_scanner_linux.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_linux.py
@@ -236,17 +236,17 @@ def _linux_process_name_from_pid(pid: int) -> str:
     if pid <= 0:
         return ""
     try:
-        with open(f"/proc/{pid}/comm", "r", encoding="utf-8") as fh:
-            name = fh.read().strip()
-            if name:
-                return name
-    except OSError:
-        pass
-    try:
         exe_path = os.readlink(f"/proc/{pid}/exe")
         name = os.path.basename(exe_path).strip()
         if name:
             return name
+    except OSError:
+        pass
+    try:
+        with open(f"/proc/{pid}/comm", "r", encoding="utf-8") as fh:
+            name = fh.read().strip()
+            if name:
+                return name
     except OSError:
         pass
     return ""

--- a/plugin/plugins/galgame_plugin/window_scanner_linux.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_linux.py
@@ -13,6 +13,7 @@ under XWayland too, where the X11 tools remain available.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 from typing import TYPE_CHECKING, Any
@@ -179,27 +180,28 @@ def _scan_windows_linux_wmctrl() -> list["DetectedGameWindow"]:
     """Window enumeration via wmctrl subprocess (fallback).
 
     Requires the system wmctrl binary. Output format:
-        <window_id> <desktop> <x> <y> <w> <h> <host> <title>
+        <window_id> <desktop> <pid> <x> <y> <w> <h> <host> <title>
     """
     from .ocr_reader import DetectedGameWindow  # noqa: PLC0415
 
     wmctrl_path = shutil.which("wmctrl")
     if not wmctrl_path:
         return []
-    output = subprocess.check_output([wmctrl_path, "-lG"], text=True, timeout=5)
+    output = subprocess.check_output([wmctrl_path, "-lpG"], text=True, timeout=5)
 
     results: list[DetectedGameWindow] = []
     for line in output.splitlines():
-        parts = line.split(None, 7)
-        if len(parts) < 8:
+        parts = line.split(None, 8)
+        if len(parts) < 9:
             continue
         try:
             window_id = int(parts[0], 16)
-            x = int(parts[2])
-            y = int(parts[3])
-            w = int(parts[4])
-            h = int(parts[5])
-            title = parts[7]
+            pid = int(parts[2])
+            x = int(parts[3])
+            y = int(parts[4])
+            w = int(parts[5])
+            h = int(parts[6])
+            title = parts[8]
             if not title or len(title) < 2:
                 continue
             area = max(0, w * h)
@@ -209,8 +211,8 @@ def _scan_windows_linux_wmctrl() -> list["DetectedGameWindow"]:
                 DetectedGameWindow(
                     hwnd=window_id,
                     title=title,
-                    process_name="",
-                    pid=0,
+                    process_name=_linux_process_name_from_pid(pid),
+                    pid=max(0, pid),
                     class_name="",
                     exe_path="",
                     width=max(0, w),
@@ -226,3 +228,25 @@ def _scan_windows_linux_wmctrl() -> list["DetectedGameWindow"]:
 
     results.sort(key=lambda w: w.area, reverse=True)
     return results
+
+
+def _linux_process_name_from_pid(pid: int) -> str:
+    """Best-effort Linux process name for wmctrl's -p PID field."""
+    pid = max(0, int(pid or 0))
+    if pid <= 0:
+        return ""
+    try:
+        with open(f"/proc/{pid}/comm", "r", encoding="utf-8") as fh:
+            name = fh.read().strip()
+            if name:
+                return name
+    except OSError:
+        pass
+    try:
+        exe_path = os.readlink(f"/proc/{pid}/exe")
+        name = os.path.basename(exe_path).strip()
+        if name:
+            return name
+    except OSError:
+        pass
+    return ""

--- a/plugin/plugins/galgame_plugin/window_scanner_linux.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_linux.py
@@ -50,59 +50,65 @@ def _scan_windows_linux_xlib() -> list["DetectedGameWindow"]:
     from .ocr_reader import DetectedGameWindow  # noqa: PLC0415
 
     d = xdisplay.Display()
-    root = d.screen().root
-
-    net_client_list = d.intern_atom("_NET_CLIENT_LIST")
-    net_wm_name = d.intern_atom("_NET_WM_NAME")
-    net_wm_pid = d.intern_atom("_NET_WM_PID")
-    net_wm_visible_name = d.intern_atom("_NET_WM_VISIBLE_NAME")
-
     try:
-        raw = root.get_full_property(net_client_list, X.AnyPropertyType)
-        window_ids = raw.value if raw else []
-    except Exception:
-        return []
+        root = d.screen().root
 
-    results: list[DetectedGameWindow] = []
-    for wid in window_ids:
+        net_client_list = d.intern_atom("_NET_CLIENT_LIST")
+        net_wm_name = d.intern_atom("_NET_WM_NAME")
+        net_wm_pid = d.intern_atom("_NET_WM_PID")
+        net_wm_visible_name = d.intern_atom("_NET_WM_VISIBLE_NAME")
+
         try:
-            window = d.create_resource_object("window", wid)
-            geom = window.get_geometry()
+            raw = root.get_full_property(net_client_list, X.AnyPropertyType)
+            window_ids = raw.value if raw else []
+        except Exception:
+            return []
 
-            title = _x11_get_window_title(window, net_wm_name, net_wm_visible_name)
-            pid = _x11_get_window_pid(window, net_wm_pid)
+        results: list[DetectedGameWindow] = []
+        for wid in window_ids:
+            try:
+                window = d.create_resource_object("window", wid)
+                geom = window.get_geometry()
 
-            if not title or len(str(title)) < 2:
-                continue
+                title = _x11_get_window_title(window, net_wm_name, net_wm_visible_name)
+                pid = _x11_get_window_pid(window, net_wm_pid)
 
-            width = max(0, int(geom.width))
-            height = max(0, int(geom.height))
-            area = width * height
-            if area <= 0:
-                continue
+                if not title or len(str(title)) < 2:
+                    continue
 
-            results.append(
-                DetectedGameWindow(
-                    hwnd=int(wid),
-                    title=str(title),
-                    process_name="",
-                    pid=int(pid) if pid else 0,
-                    class_name="",
-                    exe_path="",
-                    width=width,
-                    height=height,
-                    area=area,
-                    is_foreground=False,
-                    is_minimized=False,
-                    score=float(area),
+                width = max(0, int(geom.width))
+                height = max(0, int(geom.height))
+                area = width * height
+                if area <= 0:
+                    continue
+
+                results.append(
+                    DetectedGameWindow(
+                        hwnd=int(wid),
+                        title=str(title),
+                        process_name="",
+                        pid=int(pid) if pid else 0,
+                        class_name="",
+                        exe_path="",
+                        width=width,
+                        height=height,
+                        area=area,
+                        is_foreground=False,
+                        is_minimized=False,
+                        score=float(area),
+                    )
                 )
-            )
-        except Exception as exc:
-            _LOGGER.debug("linux xlib window entry skipped: %s", exc)
-            continue
+            except Exception as exc:
+                _LOGGER.debug("linux xlib window entry skipped: %s", exc)
+                continue
 
-    results.sort(key=lambda w: w.area, reverse=True)
-    return results
+        results.sort(key=lambda w: w.area, reverse=True)
+        return results
+    finally:
+        try:
+            d.close()
+        except Exception as exc:
+            _LOGGER.debug("linux xlib display close failed: %s", exc)
 
 
 def _x11_get_window_title(

--- a/plugin/plugins/galgame_plugin/window_scanner_linux.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_linux.py
@@ -1,0 +1,189 @@
+"""Linux window scanning for galgame_plugin.
+
+Primary path: python-xlib (X11).
+Fallback path: wmctrl subprocess.
+
+Wayland is not directly supported. On pure Wayland, xlib cannot connect
+and wmctrl returns no results, so this function naturally returns [].
+XWayland sessions still work via the same xlib path. We do NOT hard-block
+by XDG_SESSION_TYPE in the entry layer because that env var is "wayland"
+under XWayland too, where the X11 tools remain available.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .ocr_reader import DetectedGameWindow
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _scan_windows_linux() -> list["DetectedGameWindow"]:
+    """Enumerate visible windows on Linux.
+
+    Tries python-xlib first, falls back to wmctrl.
+    Returns empty list if neither is available (pure Wayland, or missing deps).
+    """
+    try:
+        result = _scan_windows_linux_xlib()
+        if result:
+            return result
+    except Exception as exc:
+        _LOGGER.debug("linux xlib window scan failed: %s", exc)
+    try:
+        return _scan_windows_linux_wmctrl()
+    except Exception as exc:
+        _LOGGER.debug("linux wmctrl window scan failed: %s", exc)
+    return []
+
+
+def _scan_windows_linux_xlib() -> list["DetectedGameWindow"]:
+    """Window enumeration via python-xlib (X11/XWayland)."""
+    from Xlib import X  # type: ignore[import-not-found]  # noqa: PLC0415
+    from Xlib import display as xdisplay  # type: ignore[import-not-found]  # noqa: PLC0415
+
+    from .ocr_reader import DetectedGameWindow  # noqa: PLC0415
+
+    d = xdisplay.Display()
+    root = d.screen().root
+
+    net_client_list = d.intern_atom("_NET_CLIENT_LIST")
+    net_wm_name = d.intern_atom("_NET_WM_NAME")
+    net_wm_pid = d.intern_atom("_NET_WM_PID")
+    net_wm_visible_name = d.intern_atom("_NET_WM_VISIBLE_NAME")
+
+    try:
+        raw = root.get_full_property(net_client_list, X.AnyPropertyType)
+        window_ids = raw.value if raw else []
+    except Exception:
+        return []
+
+    results: list[DetectedGameWindow] = []
+    for wid in window_ids:
+        try:
+            window = d.create_resource_object("window", wid)
+            geom = window.get_geometry()
+
+            title = _x11_get_window_title(window, net_wm_name, net_wm_visible_name)
+            pid = _x11_get_window_pid(window, net_wm_pid)
+
+            if not title or len(str(title)) < 2:
+                continue
+
+            width = max(0, int(geom.width))
+            height = max(0, int(geom.height))
+            area = width * height
+            if area <= 0:
+                continue
+
+            results.append(
+                DetectedGameWindow(
+                    hwnd=int(wid),
+                    title=str(title),
+                    process_name="",
+                    pid=int(pid) if pid else 0,
+                    class_name="",
+                    exe_path="",
+                    width=width,
+                    height=height,
+                    area=area,
+                    is_foreground=False,
+                    is_minimized=False,
+                    score=float(area),
+                )
+            )
+        except Exception as exc:
+            _LOGGER.debug("linux xlib window entry skipped: %s", exc)
+            continue
+
+    results.sort(key=lambda w: w.area, reverse=True)
+    return results
+
+
+def _x11_get_window_title(
+    window: Any,
+    net_wm_name: Any,
+    net_wm_visible_name: Any,
+) -> str:
+    """Extract window title from _NET_WM_VISIBLE_NAME or _NET_WM_NAME."""
+    for atom in (net_wm_visible_name, net_wm_name):
+        try:
+            prop = window.get_full_property(atom, 0)
+            if prop and prop.value:
+                value = prop.value
+                if isinstance(value, bytes):
+                    return value.decode("utf-8", errors="replace")
+                return str(value)
+        except Exception as exc:
+            _LOGGER.debug("linux xlib title read failed: %s", exc)
+            continue
+    return ""
+
+
+def _x11_get_window_pid(window: Any, net_wm_pid: Any) -> int | None:
+    """Extract PID from _NET_WM_PID."""
+    try:
+        prop = window.get_full_property(net_wm_pid, 0)
+        if prop and prop.value:
+            return int(prop.value[0])
+    except Exception as exc:
+        _LOGGER.debug("linux xlib pid read failed: %s", exc)
+    return None
+
+
+def _scan_windows_linux_wmctrl() -> list["DetectedGameWindow"]:
+    """Window enumeration via wmctrl subprocess (fallback).
+
+    Requires the system wmctrl binary. Output format:
+        <window_id> <desktop> <x> <y> <w> <h> <host> <title>
+    """
+    from .ocr_reader import DetectedGameWindow  # noqa: PLC0415
+
+    wmctrl_path = shutil.which("wmctrl")
+    if not wmctrl_path:
+        return []
+    output = subprocess.check_output([wmctrl_path, "-lG"], text=True, timeout=5)
+
+    results: list[DetectedGameWindow] = []
+    for line in output.splitlines():
+        parts = line.split(None, 7)
+        if len(parts) < 8:
+            continue
+        try:
+            window_id = int(parts[0], 16)
+            x = int(parts[2])
+            y = int(parts[3])
+            w = int(parts[4])
+            h = int(parts[5])
+            title = parts[7]
+            if not title or len(title) < 2:
+                continue
+            area = max(0, w * h)
+            if area <= 0:
+                continue
+            results.append(
+                DetectedGameWindow(
+                    hwnd=window_id,
+                    title=title,
+                    process_name="",
+                    pid=0,
+                    class_name="",
+                    exe_path="",
+                    width=max(0, w),
+                    height=max(0, h),
+                    area=area,
+                    is_foreground=False,
+                    is_minimized=False,
+                    score=float(area),
+                )
+            )
+        except (ValueError, IndexError):
+            continue
+
+    results.sort(key=lambda w: w.area, reverse=True)
+    return results

--- a/plugin/plugins/galgame_plugin/window_scanner_macos.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_macos.py
@@ -1,0 +1,92 @@
+"""macOS window scanning for galgame_plugin.
+
+Primary path: Quartz / CoreGraphics via pyobjc.
+Fallback: returns empty list if pyobjc is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .ocr_reader import DetectedGameWindow
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _scan_windows_macos() -> list["DetectedGameWindow"]:
+    """Enumerate visible windows on macOS via Quartz.
+
+    Requires: pip install pyobjc-framework-Quartz.
+    Returns empty list if pyobjc is unavailable so the manager can
+    surface unsupported_platform via the preflight, rather than
+    crashing the construction path.
+    """
+    try:
+        import Quartz  # type: ignore[import-not-found]  # noqa: PLC0415
+    except ImportError:
+        return []
+
+    from .ocr_reader import DetectedGameWindow  # noqa: PLC0415
+
+    window_list = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly
+        | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID,
+    )
+
+    results: list[DetectedGameWindow] = []
+    for window in window_list:
+        try:
+            layer = window.get(Quartz.kCGWindowLayer, 999)
+            if layer != 0:
+                continue
+
+            name = window.get(Quartz.kCGWindowName, "")
+            if not name or len(str(name)) < 2:
+                continue
+
+            pid = int(window.get(Quartz.kCGWindowOwnerPID, 0))
+            owner = window.get(Quartz.kCGWindowOwnerName, "") or ""
+            bounds = window.get(Quartz.kCGWindowBounds, {})
+            if not isinstance(bounds, dict):
+                continue
+
+            x = int(bounds.get("X", 0))
+            y = int(bounds.get("Y", 0))
+            w = int(bounds.get("Width", 0))
+            h = int(bounds.get("Height", 0))
+            area = max(0, w * h)
+            if area <= 0:
+                continue
+
+            # CGWindowNumber as the platform-level identifier
+            # (macOS analogue of hwnd; stable per session).
+            window_id = int(window.get(Quartz.kCGWindowNumber, 0))
+
+            results.append(
+                DetectedGameWindow(
+                    hwnd=window_id,
+                    title=str(name),
+                    process_name=str(owner),
+                    pid=pid,
+                    class_name="",
+                    exe_path="",
+                    width=max(0, w),
+                    height=max(0, h),
+                    area=area,
+                    is_foreground=False,
+                    is_minimized=False,
+                    score=float(area),
+                )
+            )
+            # Suppress unused variable noise — x/y are not stored on
+            # DetectedGameWindow but the unpack documents intent.
+            _ = (x, y)
+        except Exception as exc:
+            _LOGGER.debug("macos quartz window entry skipped: %s", exc)
+            continue
+
+    results.sort(key=lambda w: w.area, reverse=True)
+    return results

--- a/plugin/plugins/galgame_plugin/window_scanner_macos.py
+++ b/plugin/plugins/galgame_plugin/window_scanner_macos.py
@@ -35,6 +35,8 @@ def _scan_windows_macos() -> list["DetectedGameWindow"]:
         | Quartz.kCGWindowListExcludeDesktopElements,
         Quartz.kCGNullWindowID,
     )
+    if not window_list:
+        return []
 
     results: list[DetectedGameWindow] = []
     for window in window_list:

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -560,21 +560,28 @@ def test_linux_wmctrl_scanner_uses_resolved_binary(
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(window_scanner_linux.shutil, "which", lambda name: "/usr/bin/wmctrl")
+    monkeypatch.setattr(
+        window_scanner_linux,
+        "_linux_process_name_from_pid",
+        lambda pid: "Game.exe" if pid == 4321 else "",
+    )
 
     def _fake_check_output(*args, **kwargs):
         cmd = args[0] if args else kwargs.get("cmd")
         captured["cmd"] = cmd
         captured["text"] = kwargs.get("text")
         captured["timeout"] = kwargs.get("timeout")
-        return "0x01200007  0 10 20 640 480 host Game Window\n"
+        return "0x01200007  0 4321 10 20 640 480 host Game Window\n"
 
     monkeypatch.setattr(window_scanner_linux.subprocess, "check_output", _fake_check_output)
 
     result = window_scanner_linux._scan_windows_linux_wmctrl()
 
-    assert captured["cmd"] == ["/usr/bin/wmctrl", "-lG"]
+    assert captured["cmd"] == ["/usr/bin/wmctrl", "-lpG"]
     assert len(result) == 1
     assert result[0].hwnd == int("0x01200007", 16)
+    assert result[0].pid == 4321
+    assert result[0].process_name == "Game.exe"
 
 
 # ─── Win32CaptureBackend filtering on non-Windows ────────────────────────
@@ -589,6 +596,16 @@ def _make_backend(kind: str):
             return True
 
     return _Stub(kind)
+
+
+class _StubElectronCaptureBackend:
+    kind = "electron"
+
+    def __init__(self, **_kwargs) -> None:
+        pass
+
+    def is_available(self) -> bool:  # pragma: no cover - not used here
+        return True
 
 
 @pytest.mark.parametrize("is_linux_host", [False, True])
@@ -627,3 +644,49 @@ def test_build_backends_keeps_win32_only_on_windows() -> None:
     assert "dxcam" in kinds
     assert "mss" in kinds
     assert "pyautogui" in kinds
+
+
+@pytest.mark.parametrize("selection", ["auto", "smart"])
+def test_build_backends_prefers_electron_on_linux_wayland_auto_modes(
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+) -> None:
+    """Wayland import probes are not enough; prefer portal-backed capture."""
+    from plugin.plugins.galgame_plugin import electron_capture
+    from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setattr(
+        electron_capture,
+        "ElectronCaptureBackend",
+        _StubElectronCaptureBackend,
+    )
+
+    backend = Win32CaptureBackend(selection=selection)
+
+    assert [str(getattr(b, "kind", "")) for b in backend._backends] == ["electron"]
+
+
+def test_build_backends_keeps_electron_tail_fallback_on_linux_x11(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import electron_capture
+    from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.setattr(
+        electron_capture,
+        "ElectronCaptureBackend",
+        _StubElectronCaptureBackend,
+    )
+
+    backend = Win32CaptureBackend(selection="auto")
+
+    assert [str(getattr(b, "kind", "")) for b in backend._backends] == [
+        "mss",
+        "pyautogui",
+        "electron",
+    ]

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -657,6 +657,8 @@ def test_build_backends_prefers_electron_on_linux_wayland_auto_modes(
 
     monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.delenv("DISPLAY", raising=False)
     monkeypatch.setattr(
         electron_capture,
         "ElectronCaptureBackend",
@@ -666,6 +668,31 @@ def test_build_backends_prefers_electron_on_linux_wayland_auto_modes(
     backend = Win32CaptureBackend(selection=selection)
 
     assert [str(getattr(b, "kind", "")) for b in backend._backends] == ["electron"]
+
+
+def test_build_backends_keeps_x11_chain_when_xwayland_display_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import electron_capture
+    from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(
+        electron_capture,
+        "ElectronCaptureBackend",
+        _StubElectronCaptureBackend,
+    )
+
+    backend = Win32CaptureBackend(selection="auto")
+
+    assert [str(getattr(b, "kind", "")) for b in backend._backends] == [
+        "mss",
+        "pyautogui",
+        "electron",
+    ]
 
 
 def test_build_backends_keeps_electron_tail_fallback_on_linux_x11(

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -201,6 +201,55 @@ def test_macos_target_window_rect_falls_back_to_pid_and_title(
     assert ocr_reader._target_window_rect_macos(target) == (40, 50, 680, 530)
 
 
+def test_linux_target_window_rect_closes_xlib_display_on_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import ocr_reader
+
+    class _FakeRoot:
+        def get_full_property(self, *_args):
+            return SimpleNamespace(value=[222])
+
+    root = _FakeRoot()
+
+    class _FakeWindow:
+        def get_geometry(self):
+            return SimpleNamespace(x=12, y=34, width=640, height=480)
+
+        def query_tree(self):
+            return SimpleNamespace(parent=root)
+
+    created_displays: list["_FakeDisplay"] = []
+
+    class _FakeDisplay:
+        def __init__(self) -> None:
+            self.closed = False
+            created_displays.append(self)
+
+        def screen(self):
+            return SimpleNamespace(root=root)
+
+        def intern_atom(self, name: str) -> str:
+            return name
+
+        def create_resource_object(self, _kind: str, _wid: int):
+            return _FakeWindow()
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Xlib",
+        SimpleNamespace(display=SimpleNamespace(Display=_FakeDisplay)),
+    )
+    target = DetectedGameWindow(hwnd=222, width=640, height=480)
+
+    assert ocr_reader._target_window_rect_linux(target) == (12, 34, 652, 514)
+    assert created_displays
+    assert created_displays[0].closed is True
+
+
 # ─── ElectronCaptureBackend smoke tests ──────────────────────────────────
 
 

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -1,0 +1,300 @@
+"""Tests for capture_platform.py — platform detection and dispatch.
+
+These tests are intentionally platform-aware: they verify the dispatch
+contract on whichever platform pytest runs, then use @pytest.mark.skipif
+to gate platform-specific paths.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from plugin.plugins.galgame_plugin import capture_platform as cp
+from plugin.plugins.galgame_plugin.ocr_reader import DetectedGameWindow
+
+
+# ─── Platform detection ──────────────────────────────────────────────────
+
+
+def test_is_windows_returns_bool() -> None:
+    assert isinstance(cp.is_windows(), bool)
+
+
+def test_is_macos_returns_bool() -> None:
+    assert isinstance(cp.is_macos(), bool)
+
+
+def test_is_linux_returns_bool() -> None:
+    assert isinstance(cp.is_linux(), bool)
+
+
+def test_platform_mutually_exclusive_when_known() -> None:
+    """Exactly one of is_windows/is_macos/is_linux is True on supported
+    hosts. On exotic platforms (BSD, etc.) all three may be False; in that
+    case the sum is 0 and platform_name() must say 'unknown'."""
+    flags = [cp.is_windows(), cp.is_macos(), cp.is_linux()]
+    flag_sum = sum(flags)
+    if flag_sum == 0:
+        assert cp.platform_name() == "unknown"
+    else:
+        assert flag_sum == 1
+
+
+def test_platform_name_in_expected_set() -> None:
+    assert cp.platform_name() in ("windows", "macos", "linux", "unknown")
+
+
+def test_platform_supports_dxcam_iff_windows() -> None:
+    assert cp.platform_supports_dxcam() == cp.is_windows()
+
+
+def test_platform_supports_printwindow_iff_windows() -> None:
+    assert cp.platform_supports_printwindow() == cp.is_windows()
+
+
+# ─── Backend kind classification ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        ("dxcam", True),
+        ("printwindow", True),
+        ("mss", False),
+        ("pyautogui", False),
+        ("electron", False),
+        ("", False),
+        ("unknown", False),
+    ],
+)
+def test_is_win32_only_backend_kind(kind: str, expected: bool) -> None:
+    assert cp.is_win32_only_backend_kind(kind) is expected
+
+
+# ─── scan_windows() dispatch ─────────────────────────────────────────────
+
+
+def test_scan_windows_returns_list() -> None:
+    result = cp.scan_windows()
+    assert isinstance(result, list)
+
+
+def test_scan_windows_elements_are_detected_windows() -> None:
+    """Every element returned by scan_windows must be a DetectedGameWindow.
+
+    The platform-specific scanners run in their actual environment here;
+    on unsupported hosts they return [], which still satisfies the type
+    invariant.
+    """
+    result = cp.scan_windows()
+    for window in result:
+        assert isinstance(window, DetectedGameWindow)
+
+
+def test_scan_windows_unknown_platform_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exotic platform (none of windows / macos / linux) must return []
+    without raising."""
+    monkeypatch.setattr(cp.sys, "platform", "haiku")
+    assert cp.is_windows() is False
+    assert cp.is_macos() is False
+    assert cp.is_linux() is False
+    assert cp.platform_name() == "unknown"
+    assert cp.scan_windows() == []
+
+
+# ─── Platform-specific scanners (gated) ──────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="linux only")
+def test_linux_window_scanner_returns_list() -> None:
+    from plugin.plugins.galgame_plugin.window_scanner_linux import (
+        _scan_windows_linux,
+    )
+
+    result = _scan_windows_linux()
+    assert isinstance(result, list)
+    for window in result:
+        assert isinstance(window, DetectedGameWindow)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macos only")
+def test_macos_window_scanner_returns_list() -> None:
+    from plugin.plugins.galgame_plugin.window_scanner_macos import (
+        _scan_windows_macos,
+    )
+
+    result = _scan_windows_macos()
+    assert isinstance(result, list)
+    for window in result:
+        assert isinstance(window, DetectedGameWindow)
+
+
+# ─── ElectronCaptureBackend smoke tests ──────────────────────────────────
+
+
+def test_electron_backend_is_available_when_endpoint_down() -> None:
+    """When no Electron HTTP endpoint is reachable, is_available must
+    return False rather than raising."""
+    from plugin.plugins.galgame_plugin.electron_capture import (
+        ElectronCaptureBackend,
+    )
+
+    # Point at a port that is virtually guaranteed to be closed locally.
+    backend = ElectronCaptureBackend(
+        base_url="http://127.0.0.1:1", health_timeout=0.2
+    )
+    assert backend.is_available() is False
+
+
+def test_electron_backend_resolves_default_url_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import electron_capture
+
+    monkeypatch.setenv("NEKO_MAIN_SERVER_PORT", "65432")
+    url = electron_capture._resolve_default_base_url()
+    assert url == "http://127.0.0.1:65432"
+    # API URL convention: no trailing slash
+    assert not url.endswith("/")
+
+
+def test_electron_backend_kind_is_electron() -> None:
+    from plugin.plugins.galgame_plugin.electron_capture import (
+        ElectronCaptureBackend,
+    )
+
+    backend = ElectronCaptureBackend(base_url="http://127.0.0.1:1")
+    assert backend.kind == "electron"
+
+
+def test_electron_backend_rejects_invalid_target_id() -> None:
+    from plugin.plugins.galgame_plugin.electron_capture import (
+        ElectronCaptureBackend,
+    )
+
+    backend = ElectronCaptureBackend(base_url="http://127.0.0.1:1")
+    target = DetectedGameWindow(
+        hwnd=0,
+        title="Game",
+        process_name="game.exe",
+        pid=123,
+        class_name="",
+        exe_path="",
+        width=640,
+        height=480,
+        area=640 * 480,
+    )
+    with pytest.raises(RuntimeError, match="invalid_target_id"):
+        backend.capture_frame(target, object())
+
+
+def test_electron_backend_redacts_long_error_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin.electron_capture import (
+        ElectronCaptureBackend,
+    )
+
+    def _fake_request(*args, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(status_code=500, text="secret-token-" + ("x" * 300))
+
+    monkeypatch.setattr("httpx.request", _fake_request)
+    backend = ElectronCaptureBackend(base_url="http://127.0.0.1:1")
+    target = DetectedGameWindow(
+        hwnd=42,
+        title="Game",
+        process_name="game.exe",
+        pid=123,
+        class_name="",
+        exe_path="",
+        width=640,
+        height=480,
+        area=640 * 480,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        backend.capture_frame(target, object())
+
+    message = str(excinfo.value)
+    assert "http_status_500" in message
+    assert len(message) < 180
+
+
+def test_linux_wmctrl_scanner_uses_resolved_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import window_scanner_linux
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(window_scanner_linux.shutil, "which", lambda name: "/usr/bin/wmctrl")
+
+    def _fake_check_output(cmd, *, text, timeout):
+        captured["cmd"] = cmd
+        captured["text"] = text
+        captured["timeout"] = timeout
+        return "0x01200007  0 10 20 640 480 host Game Window\n"
+
+    monkeypatch.setattr(window_scanner_linux.subprocess, "check_output", _fake_check_output)
+
+    result = window_scanner_linux._scan_windows_linux_wmctrl()
+
+    assert captured["cmd"] == ["/usr/bin/wmctrl", "-lG"]
+    assert len(result) == 1
+    assert result[0].hwnd == int("0x01200007", 16)
+
+
+# ─── Win32CaptureBackend filtering on non-Windows ────────────────────────
+
+
+def _make_backend(kind: str):
+    class _Stub:
+        def __init__(self, k: str) -> None:
+            self.kind = k
+
+        def is_available(self) -> bool:  # pragma: no cover - not used here
+            return True
+
+    return _Stub(kind)
+
+
+def test_build_backends_filters_win32_only_on_non_windows() -> None:
+    """On macOS/Linux, _build_backends() must drop dxcam/printwindow."""
+    from plugin.plugins.galgame_plugin import ocr_reader as ocr_reader_mod
+    from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
+
+    backend = Win32CaptureBackend(selection="auto")
+    with patch.object(ocr_reader_mod, "_is_windows_platform", return_value=False), patch(
+        "plugin.plugins.galgame_plugin.capture_platform.is_windows",
+        return_value=False,
+    ), patch(
+        "plugin.plugins.galgame_plugin.capture_platform.is_linux",
+        return_value=False,
+    ):
+        chain = backend._build_backends()
+
+    kinds = {str(getattr(b, "kind", "")) for b in chain}
+    assert "dxcam" not in kinds
+    assert "printwindow" not in kinds
+
+
+def test_build_backends_keeps_win32_only_on_windows() -> None:
+    """On Windows, all four win32 backends remain reachable."""
+    from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
+
+    backend = Win32CaptureBackend(selection="auto")
+    with patch(
+        "plugin.plugins.galgame_plugin.capture_platform.is_windows",
+        return_value=True,
+    ):
+        chain = backend._build_backends()
+    kinds = {str(getattr(b, "kind", "")) for b in chain}
+    # default chain includes dxcam, mss, pyautogui
+    assert "dxcam" in kinds
+    assert "mss" in kinds
+    assert "pyautogui" in kinds

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -348,6 +348,58 @@ def test_electron_backend_redacts_long_error_body(
     assert len(message) < 180
 
 
+def test_electron_backend_applies_capture_profile_crop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import base64
+    import io
+
+    from PIL import Image
+
+    from plugin.plugins.galgame_plugin.electron_capture import (
+        ElectronCaptureBackend,
+    )
+    from plugin.plugins.galgame_plugin.ocr_reader import OcrCaptureProfile
+
+    source = Image.new("RGB", (100, 80), "white")
+    buffer = io.BytesIO()
+    source.save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+
+    def _fake_request(*args, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(status_code=200, json=lambda: {"image": encoded})
+
+    monkeypatch.setattr("httpx.request", _fake_request)
+    backend = ElectronCaptureBackend(base_url="http://127.0.0.1:1")
+    target = DetectedGameWindow(
+        hwnd=42,
+        title="Game",
+        process_name="game.exe",
+        pid=123,
+        width=100,
+        height=80,
+        area=100 * 80,
+    )
+    profile = OcrCaptureProfile(
+        left_inset_ratio=0.10,
+        right_inset_ratio=0.20,
+        top_ratio=0.25,
+        bottom_inset_ratio=0.25,
+    )
+
+    cropped = backend.capture_frame(target, profile)
+
+    assert cropped.size == (70, 40)
+    assert cropped.info["galgame_capture_backend_kind"] == "electron"
+    assert cropped.info["galgame_capture_rect"] == {
+        "left": 10.0,
+        "top": 20.0,
+        "right": 80.0,
+        "bottom": 60.0,
+    }
+
+
 def test_linux_wmctrl_scanner_uses_resolved_binary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -284,6 +284,19 @@ def test_linux_target_window_rect_closes_xlib_display_on_match(
     assert created_displays[0].closed is True
 
 
+def test_linux_target_window_rect_fails_when_geometry_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import ocr_reader
+
+    monkeypatch.setitem(sys.modules, "Xlib", None)
+    monkeypatch.setattr(ocr_reader.shutil, "which", lambda _name: None)
+    target = DetectedGameWindow(hwnd=222, width=640, height=480)
+
+    with pytest.raises(RuntimeError, match="linux_target_window_rect_unavailable"):
+        ocr_reader._target_window_rect_linux(target)
+
+
 # ─── ElectronCaptureBackend smoke tests ──────────────────────────────────
 
 
@@ -379,6 +392,7 @@ def test_electron_backend_redacts_long_error_body(
 
     message = str(excinfo.value)
     assert "http_status_500" in message
+    assert "secret-token" not in message
     assert len(message) < 180
 
 
@@ -473,19 +487,20 @@ def _make_backend(kind: str):
     return _Stub(kind)
 
 
-def test_build_backends_filters_win32_only_on_non_windows() -> None:
+@pytest.mark.parametrize("is_linux_host", [False, True])
+def test_build_backends_filters_win32_only_on_non_windows(is_linux_host: bool) -> None:
     """On macOS/Linux, _build_backends() must drop dxcam/printwindow."""
     from plugin.plugins.galgame_plugin import ocr_reader as ocr_reader_mod
     from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
 
-    backend = Win32CaptureBackend(selection="auto")
     with patch.object(ocr_reader_mod, "_is_windows_platform", return_value=False), patch(
         "plugin.plugins.galgame_plugin.capture_platform.is_windows",
         return_value=False,
     ), patch(
         "plugin.plugins.galgame_plugin.capture_platform.is_linux",
-        return_value=False,
+        return_value=is_linux_host,
     ):
+        backend = Win32CaptureBackend(selection="auto")
         chain = backend._build_backends()
 
     kinds = {str(getattr(b, "kind", "")) for b in chain}
@@ -494,7 +509,7 @@ def test_build_backends_filters_win32_only_on_non_windows() -> None:
 
 
 def test_build_backends_keeps_win32_only_on_windows() -> None:
-    """On Windows, all four win32 backends remain reachable."""
+    """On Windows, the default three-backend win32 chain remains reachable."""
     from plugin.plugins.galgame_plugin.ocr_reader import Win32CaptureBackend
 
     backend = Win32CaptureBackend(selection="auto")

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -185,7 +185,7 @@ def test_macos_target_window_rect_prefers_window_number_over_pid(
     assert ocr_reader._target_window_rect_macos(target) == (100, 200, 900, 800)
 
 
-def test_macos_target_window_rect_falls_back_when_quartz_returns_none(
+def test_macos_target_window_rect_fails_when_quartz_returns_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from plugin.plugins.galgame_plugin import ocr_reader
@@ -198,7 +198,8 @@ def test_macos_target_window_rect_falls_back_when_quartz_returns_none(
     monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
     target = DetectedGameWindow(hwnd=22, title="Game", pid=123, width=800, height=600)
 
-    assert ocr_reader._target_window_rect_macos(target) == (0, 0, 800, 600)
+    with pytest.raises(RuntimeError, match="macos_target_window_rect_unavailable"):
+        ocr_reader._target_window_rect_macos(target)
 
 
 def test_macos_target_window_rect_falls_back_to_pid_and_title(
@@ -233,6 +234,35 @@ def test_macos_target_window_rect_falls_back_to_pid_and_title(
     target = DetectedGameWindow(hwnd=0, title="game", pid=123, width=640, height=480)
 
     assert ocr_reader._target_window_rect_macos(target) == (40, 50, 680, 530)
+
+
+def test_macos_target_window_rect_fails_when_target_is_unmatched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import ocr_reader
+
+    windows = [
+        {
+            "kCGWindowNumber": 11,
+            "kCGWindowOwnerPID": 321,
+            "kCGWindowName": "Other",
+            "kCGWindowBounds": {"X": 0, "Y": 0, "Width": 300, "Height": 200},
+        },
+    ]
+    fake_quartz = SimpleNamespace(
+        kCGWindowListOptionOnScreenOnly=1,
+        kCGNullWindowID=0,
+        kCGWindowNumber="kCGWindowNumber",
+        kCGWindowOwnerPID="kCGWindowOwnerPID",
+        kCGWindowName="kCGWindowName",
+        kCGWindowBounds="kCGWindowBounds",
+        CGWindowListCopyWindowInfo=lambda *_args: windows,
+    )
+    monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
+    target = DetectedGameWindow(hwnd=22, title="Game", pid=123, width=800, height=600)
+
+    with pytest.raises(RuntimeError, match="macos_target_window_rect_unavailable"):
+        ocr_reader._target_window_rect_macos(target)
 
 
 def test_linux_target_window_rect_closes_xlib_display_on_match(
@@ -295,6 +325,80 @@ def test_linux_target_window_rect_fails_when_geometry_is_unavailable(
 
     with pytest.raises(RuntimeError, match="linux_target_window_rect_unavailable"):
         ocr_reader._target_window_rect_linux(target)
+
+
+def test_linux_xlib_scanner_marks_hidden_windows_minimized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import window_scanner_linux
+
+    atoms = {
+        "_NET_CLIENT_LIST": 1,
+        "_NET_WM_NAME": 2,
+        "_NET_WM_VISIBLE_NAME": 3,
+        "_NET_WM_PID": 4,
+        "_NET_WM_STATE": 5,
+        "_NET_WM_STATE_HIDDEN": 6,
+        "WM_STATE": 7,
+    }
+
+    class _Prop:
+        def __init__(self, value):
+            self.value = value
+
+    class _FakeRoot:
+        def get_full_property(self, atom, _type):
+            if atom == atoms["_NET_CLIENT_LIST"]:
+                return _Prop([111, 222])
+            return None
+
+    root = _FakeRoot()
+
+    class _FakeWindow:
+        def __init__(self, wid: int) -> None:
+            self.wid = wid
+
+        def get_geometry(self):
+            return SimpleNamespace(width=640, height=480)
+
+        def get_full_property(self, atom, _type):
+            if atom in {atoms["_NET_WM_VISIBLE_NAME"], atoms["_NET_WM_NAME"]}:
+                return _Prop(f"Game {self.wid}")
+            if atom == atoms["_NET_WM_PID"]:
+                return _Prop([1234])
+            if atom == atoms["_NET_WM_STATE"] and self.wid == 222:
+                return _Prop([atoms["_NET_WM_STATE_HIDDEN"]])
+            if atom == atoms["WM_STATE"]:
+                return _Prop([1])
+            return None
+
+    class _FakeDisplay:
+        def screen(self):
+            return SimpleNamespace(root=root)
+
+        def intern_atom(self, name: str) -> int:
+            return atoms[name]
+
+        def create_resource_object(self, _kind: str, wid: int):
+            return _FakeWindow(int(wid))
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "Xlib",
+        SimpleNamespace(
+            X=SimpleNamespace(AnyPropertyType=0),
+            display=SimpleNamespace(Display=_FakeDisplay),
+        ),
+    )
+
+    result = window_scanner_linux._scan_windows_linux_xlib()
+    by_hwnd = {window.hwnd: window for window in result}
+
+    assert by_hwnd[111].is_minimized is False
+    assert by_hwnd[222].is_minimized is True
 
 
 # ─── ElectronCaptureBackend smoke tests ──────────────────────────────────

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -133,20 +133,94 @@ def test_macos_window_scanner_returns_list() -> None:
         assert isinstance(window, DetectedGameWindow)
 
 
+def test_macos_target_window_rect_prefers_window_number_over_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import ocr_reader
+
+    windows = [
+        {
+            "kCGWindowNumber": 11,
+            "kCGWindowOwnerPID": 123,
+            "kCGWindowName": "Launcher",
+            "kCGWindowBounds": {"X": 0, "Y": 0, "Width": 300, "Height": 200},
+        },
+        {
+            "kCGWindowNumber": 22,
+            "kCGWindowOwnerPID": 123,
+            "kCGWindowName": "Game",
+            "kCGWindowBounds": {"X": 100, "Y": 200, "Width": 800, "Height": 600},
+        },
+    ]
+    fake_quartz = SimpleNamespace(
+        kCGWindowListOptionOnScreenOnly=1,
+        kCGNullWindowID=0,
+        kCGWindowNumber="kCGWindowNumber",
+        kCGWindowOwnerPID="kCGWindowOwnerPID",
+        kCGWindowName="kCGWindowName",
+        kCGWindowBounds="kCGWindowBounds",
+        CGWindowListCopyWindowInfo=lambda *_args: windows,
+    )
+    monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
+    target = DetectedGameWindow(hwnd=22, title="Game", pid=123, width=800, height=600)
+
+    assert ocr_reader._target_window_rect_macos(target) == (100, 200, 900, 800)
+
+
+def test_macos_target_window_rect_falls_back_to_pid_and_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import ocr_reader
+
+    windows = [
+        {
+            "kCGWindowNumber": 11,
+            "kCGWindowOwnerPID": 123,
+            "kCGWindowName": "Settings",
+            "kCGWindowBounds": {"X": 0, "Y": 0, "Width": 300, "Height": 200},
+        },
+        {
+            "kCGWindowNumber": 33,
+            "kCGWindowOwnerPID": 123,
+            "kCGWindowName": "  GAME  ",
+            "kCGWindowBounds": {"X": 40, "Y": 50, "Width": 640, "Height": 480},
+        },
+    ]
+    fake_quartz = SimpleNamespace(
+        kCGWindowListOptionOnScreenOnly=1,
+        kCGNullWindowID=0,
+        kCGWindowNumber="kCGWindowNumber",
+        kCGWindowOwnerPID="kCGWindowOwnerPID",
+        kCGWindowName="kCGWindowName",
+        kCGWindowBounds="kCGWindowBounds",
+        CGWindowListCopyWindowInfo=lambda *_args: windows,
+    )
+    monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
+    target = DetectedGameWindow(hwnd=0, title="game", pid=123, width=640, height=480)
+
+    assert ocr_reader._target_window_rect_macos(target) == (40, 50, 680, 530)
+
+
 # ─── ElectronCaptureBackend smoke tests ──────────────────────────────────
 
 
-def test_electron_backend_is_available_when_endpoint_down() -> None:
+def test_electron_backend_is_available_when_endpoint_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """When no Electron HTTP endpoint is reachable, is_available must
     return False rather than raising."""
+    import httpx
+
     from plugin.plugins.galgame_plugin.electron_capture import (
         ElectronCaptureBackend,
     )
 
-    # Point at a port that is virtually guaranteed to be closed locally.
-    backend = ElectronCaptureBackend(
-        base_url="http://127.0.0.1:1", health_timeout=0.2
-    )
+    def _raise_connect_error(*args, **kwargs):
+        del args, kwargs
+        raise httpx.ConnectError("endpoint down")
+
+    monkeypatch.setattr(httpx, "request", _raise_connect_error)
+    backend = ElectronCaptureBackend(base_url="http://127.0.0.1:1")
     assert backend.is_available() is False
 
 
@@ -234,10 +308,11 @@ def test_linux_wmctrl_scanner_uses_resolved_binary(
 
     monkeypatch.setattr(window_scanner_linux.shutil, "which", lambda name: "/usr/bin/wmctrl")
 
-    def _fake_check_output(cmd, *, text, timeout):
+    def _fake_check_output(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("cmd")
         captured["cmd"] = cmd
-        captured["text"] = text
-        captured["timeout"] = timeout
+        captured["text"] = kwargs.get("text")
+        captured["timeout"] = kwargs.get("timeout")
         return "0x01200007  0 10 20 640 480 host Game Window\n"
 
     monkeypatch.setattr(window_scanner_linux.subprocess, "check_output", _fake_check_output)

--- a/plugin/tests/unit/plugins/test_galgame_capture_platform.py
+++ b/plugin/tests/unit/plugins/test_galgame_capture_platform.py
@@ -133,6 +133,24 @@ def test_macos_window_scanner_returns_list() -> None:
         assert isinstance(window, DetectedGameWindow)
 
 
+def test_macos_window_scanner_returns_empty_when_quartz_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin.window_scanner_macos import (
+        _scan_windows_macos,
+    )
+
+    fake_quartz = SimpleNamespace(
+        kCGWindowListOptionOnScreenOnly=1,
+        kCGWindowListExcludeDesktopElements=2,
+        kCGNullWindowID=0,
+        CGWindowListCopyWindowInfo=lambda *_args: None,
+    )
+    monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
+
+    assert _scan_windows_macos() == []
+
+
 def test_macos_target_window_rect_prefers_window_number_over_pid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -165,6 +183,22 @@ def test_macos_target_window_rect_prefers_window_number_over_pid(
     target = DetectedGameWindow(hwnd=22, title="Game", pid=123, width=800, height=600)
 
     assert ocr_reader._target_window_rect_macos(target) == (100, 200, 900, 800)
+
+
+def test_macos_target_window_rect_falls_back_when_quartz_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from plugin.plugins.galgame_plugin import ocr_reader
+
+    fake_quartz = SimpleNamespace(
+        kCGWindowListOptionOnScreenOnly=1,
+        kCGNullWindowID=0,
+        CGWindowListCopyWindowInfo=lambda *_args: None,
+    )
+    monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
+    target = DetectedGameWindow(hwnd=22, title="Game", pid=123, width=800, height=600)
+
+    assert ocr_reader._target_window_rect_macos(target) == (0, 0, 800, 600)
 
 
 def test_macos_target_window_rect_falls_back_to_pid_and_title(

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -2194,7 +2194,7 @@ def test_smart_capture_backend_non_windows_background_uses_filtered_chain(
     assert backend.last_backend_detail == "selected"
 
 
-def test_smart_capture_backend_non_windows_background_fails_without_window_backend(
+def test_smart_capture_backend_linux_wayland_background_fails_without_window_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _PixelBackend:
@@ -2207,6 +2207,8 @@ def test_smart_capture_backend_non_windows_background_fails_without_window_backe
             raise AssertionError("pixel backend should not capture background target")
 
     monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    monkeypatch.delenv("DISPLAY", raising=False)
     backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
     backend._backends = [_PixelBackend()]
 
@@ -2215,6 +2217,40 @@ def test_smart_capture_backend_non_windows_background_fails_without_window_backe
 
     with pytest.raises(RuntimeError, match="background_capture_requires_window_backend"):
         backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+
+def test_smart_capture_backend_linux_x11_background_allows_pixel_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Backend:
+        def __init__(self, kind: str, *, available: bool) -> None:
+            self.kind = kind
+            self.available = available
+
+        def is_available(self) -> bool:
+            return self.available
+
+        def capture_frame(self, target, profile):
+            return f"{self.kind}-frame"
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
+    backend._backends = [
+        _Backend("electron", available=False),
+        _Backend("mss", available=True),
+    ]
+
+    target = _window()[0]
+    target.is_foreground = False
+
+    frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+    assert frame == "mss-frame"
+    assert backend.last_backend_kind == "mss"
+    assert backend.last_backend_detail == "electron_unavailable_fallback"
 
 
 def test_smart_capture_backend_macos_background_allows_pixel_backend(

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -2150,29 +2150,37 @@ def test_win32_capture_backend_explicit_selection_falls_back_with_detail() -> No
 def test_smart_capture_backend_non_windows_background_uses_filtered_chain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    class _UnavailableBackend:
+    class _Backend:
         def __init__(self, kind: str) -> None:
             self.kind = kind
+            self.calls = 0
 
         def is_available(self) -> bool:
             return False
 
         def capture_frame(self, target, profile):  # pragma: no cover
+            self.calls += 1
             raise AssertionError(f"{self.kind} should not capture")
 
     class _ElectronBackend:
         kind = "electron"
 
+        def __init__(self) -> None:
+            self.calls = 0
+
         def is_available(self) -> bool:
             return True
 
         def capture_frame(self, target, profile):
+            self.calls += 1
             return "electron-frame"
 
     monkeypatch.setattr(sys, "platform", "linux")
     backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
-    backend._printwindow_backend = _UnavailableBackend("printwindow")
-    backend._backends = [_UnavailableBackend("mss"), _ElectronBackend()]
+    mss = _Backend("mss")
+    electron = _ElectronBackend()
+    backend._printwindow_backend = _Backend("printwindow")
+    backend._backends = [mss, electron]
 
     target = _window()[0]
     target.is_foreground = False
@@ -2180,8 +2188,65 @@ def test_smart_capture_backend_non_windows_background_uses_filtered_chain(
     frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
 
     assert frame == "electron-frame"
+    assert electron.calls == 1
+    assert mss.calls == 0
     assert backend.last_backend_kind == "electron"
-    assert backend.last_backend_detail == "mss_unavailable_fallback"
+    assert backend.last_backend_detail == "selected"
+
+
+def test_smart_capture_backend_non_windows_background_fails_without_window_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _PixelBackend:
+        kind = "mss"
+
+        def is_available(self) -> bool:
+            return True
+
+        def capture_frame(self, target, profile):  # pragma: no cover
+            raise AssertionError("pixel backend should not capture background target")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
+    backend._backends = [_PixelBackend()]
+
+    target = _window()[0]
+    target.is_foreground = False
+
+    with pytest.raises(RuntimeError, match="background_capture_requires_window_backend"):
+        backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+
+def test_smart_capture_backend_non_windows_foreground_prefers_window_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Backend:
+        def __init__(self, kind: str, *, available: bool) -> None:
+            self.kind = kind
+            self.available = available
+
+        def is_available(self) -> bool:
+            return self.available
+
+        def capture_frame(self, target, profile):
+            return f"{self.kind}-frame"
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
+    backend._backends = [
+        _Backend("mss", available=True),
+        _Backend("electron", available=False),
+        _Backend("pyautogui", available=True),
+    ]
+
+    target = _window()[0]
+    target.is_foreground = True
+
+    frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+    assert frame == "mss-frame"
+    assert backend.last_backend_kind == "mss"
+    assert backend.last_backend_detail == "electron_unavailable_fallback"
 
 
 def test_smart_capture_backend_windows_background_keeps_printwindow_only(

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -2217,6 +2217,31 @@ def test_smart_capture_backend_non_windows_background_fails_without_window_backe
         backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
 
 
+def test_smart_capture_backend_macos_background_allows_pixel_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _PixelBackend:
+        kind = "mss"
+
+        def is_available(self) -> bool:
+            return True
+
+        def capture_frame(self, target, profile):
+            return "mss-frame"
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
+    backend._backends = [_PixelBackend()]
+
+    target = _window()[0]
+    target.is_foreground = False
+
+    frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+    assert frame == "mss-frame"
+    assert backend.last_backend_kind == "mss"
+
+
 def test_smart_capture_backend_non_windows_foreground_prefers_window_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -3894,6 +3894,61 @@ def test_ocr_window_scan_inventory_uses_ttl_cache(tmp_path: Path) -> None:
         manager._shutdown_capture_worker()
 
 
+def test_ocr_window_inventory_preserves_non_windows_scanner_foreground(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_root = tmp_path / "bridge"
+    foreground = DetectedGameWindow(
+        hwnd=501,
+        title="Foreground Game",
+        process_name="Game.exe",
+        pid=7501,
+        width=1280,
+        height=720,
+        area=1280 * 720,
+        is_foreground=True,
+    )
+    background = DetectedGameWindow(
+        hwnd=502,
+        title="Background Game",
+        process_name="Game.exe",
+        pid=7502,
+        width=1280,
+        height=720,
+        area=1280 * 720,
+        is_foreground=False,
+    )
+
+    def fail_windows_foreground_api() -> int:
+        raise AssertionError("Windows foreground API should not run off Windows")
+
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_foreground_window_handle",
+        fail_windows_foreground_api,
+    )
+    manager = OcrReaderManager(
+        logger=_Logger(),
+        config=_make_config(bridge_root),
+        platform_fn=lambda: False,
+        window_scanner=lambda: [background, foreground],
+        capture_backend=_FakeCaptureBackend(),
+        ocr_backend=_FakeOcrBackend(),
+    )
+
+    try:
+        eligible, excluded = manager._scan_window_inventory()
+        selection = manager._select_target_window(eligible, excluded_windows=excluded)
+        assert eligible[0].hwnd == foreground.hwnd
+        assert eligible[0].is_foreground is True
+        assert selection.target is not None
+        assert selection.target.hwnd == foreground.hwnd
+        assert selection.selection_detail == "foreground_window"
+    finally:
+        manager._shutdown_capture_worker()
+
+
 def test_rapidocr_runtime_cache_reuses_loaded_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -2147,6 +2147,78 @@ def test_win32_capture_backend_explicit_selection_falls_back_with_detail() -> No
     assert backend.last_backend_detail == "printwindow_unavailable_fallback"
 
 
+def test_smart_capture_backend_non_windows_background_uses_filtered_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _UnavailableBackend:
+        def __init__(self, kind: str) -> None:
+            self.kind = kind
+
+        def is_available(self) -> bool:
+            return False
+
+        def capture_frame(self, target, profile):  # pragma: no cover
+            raise AssertionError(f"{self.kind} should not capture")
+
+    class _ElectronBackend:
+        kind = "electron"
+
+        def is_available(self) -> bool:
+            return True
+
+        def capture_frame(self, target, profile):
+            return "electron-frame"
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
+    backend._printwindow_backend = _UnavailableBackend("printwindow")
+    backend._backends = [_UnavailableBackend("mss"), _ElectronBackend()]
+
+    target = _window()[0]
+    target.is_foreground = False
+
+    frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+    assert frame == "electron-frame"
+    assert backend.last_backend_kind == "electron"
+    assert backend.last_backend_detail == "mss_unavailable_fallback"
+
+
+def test_smart_capture_backend_windows_background_keeps_printwindow_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Backend:
+        def __init__(self, kind: str, *, available: bool = True) -> None:
+            self.kind = kind
+            self.available = available
+            self.calls = 0
+
+        def is_available(self) -> bool:
+            return self.available
+
+        def capture_frame(self, target, profile):
+            self.calls += 1
+            return f"{self.kind}-frame"
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    backend = galgame_ocr_reader.Win32CaptureBackend(selection="smart")
+    printwindow = _Backend("printwindow")
+    dxcam = _Backend("dxcam")
+    backend._printwindow_backend = printwindow
+    backend._dxcam_backend = dxcam
+    backend._backends = [dxcam, _Backend("mss"), _Backend("pyautogui"), printwindow]
+
+    target = _window()[0]
+    target.is_foreground = False
+
+    frame = backend.capture_frame(target, galgame_ocr_reader.OcrCaptureProfile())
+
+    assert frame == "printwindow-frame"
+    assert printwindow.calls == 1
+    assert dxcam.calls == 0
+    assert backend.last_backend_kind == "printwindow"
+
+
 def test_dxcam_camera_creation_is_serialized(monkeypatch: pytest.MonkeyPatch) -> None:
     camera = object()
     calls = 0

--- a/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
+++ b/plugin/tests/unit/plugins/test_galgame_ocr_reader.py
@@ -4075,6 +4075,58 @@ def test_ocr_window_inventory_preserves_non_windows_scanner_foreground(
         manager._shutdown_capture_worker()
 
 
+@pytest.mark.asyncio
+async def test_ocr_reader_tick_skips_win32_foreground_probe_on_non_windows(
+    tmp_path: Path,
+    ocr_runtime_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_root = tmp_path / "bridge"
+    bridge_root.mkdir()
+    game_window = DetectedGameWindow(
+        hwnd=501,
+        title="Foreground Game",
+        process_name="Game.exe",
+        pid=7501,
+        width=1280,
+        height=720,
+        area=1280 * 720,
+        is_foreground=True,
+    )
+
+    def fail_windows_foreground_api() -> int:
+        raise AssertionError("Windows foreground API should not run off Windows")
+
+    monkeypatch.setattr(
+        galgame_ocr_reader,
+        "_foreground_window_handle",
+        fail_windows_foreground_api,
+    )
+    manager = OcrReaderManager(
+        logger=_Logger(),
+        config=_make_config(
+            bridge_root,
+            enabled=True,
+            install_target_dir=str(ocr_runtime_root),
+        ),
+        platform_fn=lambda: False,
+        window_scanner=lambda: [game_window],
+        capture_backend=_FakeCaptureBackend(),
+        ocr_backend=_FakeOcrBackend(),
+    )
+
+    try:
+        result = await manager.tick(
+            bridge_sdk_available=False,
+            memory_reader_runtime={},
+        )
+        assert result.runtime["status"] == "active"
+        assert result.runtime["process_name"] == "Game.exe"
+        assert result.runtime["target_is_foreground"] is True
+    finally:
+        manager._shutdown_capture_worker()
+
+
 def test_rapidocr_runtime_cache_reuses_loaded_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ dependencies = [
   # plugins (mss is also a candidate for brain/computer_use). Tiny (<1MB).
   "mss",
   "dxcam ; sys_platform == 'win32'",
+  # Linux X11 window enumeration / geometry for galgame_plugin
+  # (cross-platform-capture-plan). Falls back to `wmctrl` subprocess
+  # when this dependency is unavailable. Skipped on Windows/macOS
+  # to keep dev installs lean.
+  "python-xlib ; sys_platform == 'linux'",
   # NOTE: rapidocr-onnxruntime + cv2 cohort lives in [dependency-groups] galgame
   # below — it brings opencv (~109 MB on disk) which the main program does not
   # use. Build scripts (Nuitka/PyInstaller) install --group galgame explicitly

--- a/uv.lock
+++ b/uv.lock
@@ -1366,6 +1366,7 @@ dependencies = [
     { name = "pytesseract" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pywinauto", marker = "sys_platform == 'win32'" },
     { name = "pyzmq" },
@@ -1434,6 +1435,7 @@ requires-dist = [
     { name = "pytesseract" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-multipart" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pywinauto", marker = "sys_platform == 'win32'" },
     { name = "pyzmq", specifier = ">=27.1.0" },
@@ -4476,6 +4478,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", marker = "sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
+]
+
+[[package]]
 name = "python3-xlib"
 version = "0.15"
 source = { registry = "https://pypi.org/simple" }
@@ -4512,6 +4526,7 @@ version = "0.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "comtypes", marker = "sys_platform == 'win32'" },
+    { name = "python-xlib", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "six", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]


### PR DESCRIPTION
 ## 概览

  为 galgame 插件补上 macOS/Linux 的 OCR 截图与窗口扫描基础链路，同时保持 Windows 现有 DXCam/RapidOCR 路径不变。

  ## 主要改动

  - 新增 `capture_platform.py`，统一平台检测与窗口扫描分派
  - 新增 macOS Quartz 窗口扫描器
  - 新增 Linux `python-xlib -> wmctrl` 窗口扫描器
  - `ocr_reader.py` 增加截图几何平台分派：
    - Windows 保持原 Win32 路径
    - macOS 使用 Quartz bounds
    - Linux 使用 X11 坐标变换，降级到 `wmctrl`
  - 非 Windows 自动过滤 DXCam / PrintWindow，仅保留跨平台截图后端
  - Linux 追加 `ElectronCaptureBackend` 作为 Wayland / X11 兜底客户端
  - OCR preflight 不再对非 Windows 直接硬拦，改为按截图后端可用性判断
  - `memory_reader.py` / `service.py` 的平台判断委托到统一入口
  - 新增 Linux 依赖 `python-xlib`
  - 新增 `test_galgame_capture_platform.py` 覆盖平台分派、后端过滤和 Electron 客户端安全行为

  ## 验证

  - `test_galgame_capture_platform.py`: 25 passed, 2 skipped
  - `py_compile`: passed
  - `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加跨平台平台检测与窗口枚举支持（Windows/macOS/Linux），并新增基于本地服务的 Electron 远程截图后端。
* **改进**
  * 窗口几何、可见性与截图按平台路由；后端选择引入平台过滤、Wayland/X11 回退与优先策略；服务默认启用项按平台调整。
* **测试**
  * 大幅扩展单元测试，覆盖平台判定、各平台扫描、目标矩形解析、Electron 后端与后端选择逻辑。
* **文档/依赖**
  * 为 Linux 添加可选 X11 运行时依赖，缺失时回退至 wmctrl。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->