### PR TITLE
fix(agent): 堵住 plugin description 里 @llm_tool 名字泄给 analyzer 的口子

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -56,6 +56,7 @@ try:
     from brain.openfang_adapter import OpenFangAdapter
     from brain.deduper import TaskDeduper
     from brain.task_executor import DirectTaskExecutor
+    from brain.plugin_analyzer_view import sanitize_plugins_for_analyzer
     from brain.agent_session import get_session_manager
     from utils.result_parser import (
         parse_computer_use_result,
@@ -3292,23 +3293,12 @@ async def startup():
                             logger.debug(f"[Agent] plugin_list_provider parse error: {parse_err}")
                             data = {}
                         raw = data.get("plugins", []) or []
-                        # ISOLATION BOUNDARY: only expose RUNNING plugins to the
-                        # analyzer / plugin LLM. Without this filter, every plugin
-                        # the host knows about (including disabled, stopped,
-                        # load-failed, source-missing, and extension plugins in
-                        # 'pending' state) flows into the LLM's candidate set.
-                        # The LLM then wastes tokens evaluating capabilities the
-                        # user explicitly didn't enable, and worse — picks a
-                        # plugin that has no live process to receive the dispatch,
-                        # surfacing fake "available capability" to the user. See
-                        # _resolve_plugin_status() in
-                        # plugin/server/application/plugins/query_service.py for
-                        # the full status taxonomy; "running" is the only state
-                        # where the plugin's process is alive and responsive.
-                        running = [
-                            p for p in raw
-                            if isinstance(p, dict) and p.get("status") == "running"
-                        ]
+                        # Lifecycle + caller-role boundary live in
+                        # brain.plugin_analyzer_view — see that module's
+                        # docstring for why ``__llm_tool__*`` entries are
+                        # stripped and why a boundary marker is appended
+                        # to the plugin description when names leak there.
+                        running = sanitize_plugins_for_analyzer(raw)
                         if len(running) != len(raw):
                             dropped = [
                                 (p.get("id"), p.get("status"))
@@ -3319,32 +3309,6 @@ async def startup():
                                 "[Agent] plugin_list_provider filtered out %d non-running plugins: %s",
                                 len(dropped), dropped,
                             )
-                        # AUDIENCE BOUNDARY: ``@llm_tool``-registered methods
-                        # also surface as plugin entries with id prefix
-                        # ``__llm_tool__<name>`` (see plugin SDK collect_entries).
-                        # Those tools are *also* exposed to the dialog LLM via
-                        # ``LLMSessionManager.tool_registry`` — letting the
-                        # analyzer/plugin LLM dispatch them too means the same
-                        # tool can be triggered by both LLMs, with the
-                        # analyzer path's ~10s decision latency racing against
-                        # the dialog LLM's direct call. The dialog LLM is the
-                        # canonical caller for ``@llm_tool`` (it gets the
-                        # tool's full schema, can pass typed args, and runs
-                        # synchronously); the analyzer should only see
-                        # ``@plugin_entry`` registered entries (queries /
-                        # status / config). Strip ``__llm_tool__`` entries
-                        # from the analyzer's view here.
-                        for p in running:
-                            entries = p.get("entries")
-                            if isinstance(entries, list):
-                                p["entries"] = [
-                                    e for e in entries
-                                    if not (
-                                        isinstance(e, dict)
-                                        and isinstance(e.get("id"), str)
-                                        and e["id"].startswith("__llm_tool__")
-                                    )
-                                ]
                         return running
             except Exception as e:
                 logger.debug(f"[Agent] plugin_list_provider http fetch failed: {e}")

--- a/brain/plugin_analyzer_view.py
+++ b/brain/plugin_analyzer_view.py
@@ -121,8 +121,13 @@ def sanitize_plugins_for_analyzer(raw_plugins: Any) -> List[Dict[str, Any]]:
        system prompt (``USER_PLUGIN_SYSTEM_PROMPT``) carries the
        behavioral rule explaining how the LLM should treat the marker.
 
-    The result is a fresh list of fresh dicts — callers may mutate
-    further without disturbing the input payload.
+    The result is a fresh list of shallow per-plugin dict copies with
+    ``entries`` rebuilt as a fresh list; other nested values (metadata
+    blocks, schema dicts, etc.) may still share references with the
+    input payload. Today's only caller — the HTTP plugin provider —
+    consumes the projection read-only, so a full deep copy is not
+    worth the cost; if a future caller needs to mutate nested fields,
+    it should clone those itself.
     """
     sanitized: List[Dict[str, Any]] = []
     for p in raw_plugins or []:

--- a/brain/plugin_analyzer_view.py
+++ b/brain/plugin_analyzer_view.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""
+Analyzer-facing view of the running plugin registry.
+
+The analyzer / plugin-routing LLM consumes a *projection* of the host's
+plugin registry — not the raw payload. Two audience boundaries live
+here:
+
+1. **Lifecycle boundary** — only plugins whose process is currently
+   ``running`` are exposed; disabled / stopped / load-failed / pending
+   entries are filtered out (the analyzer would otherwise route to a
+   capability that has no live process to receive the dispatch).
+
+2. **Caller-role boundary** — methods decorated with the plugin SDK's
+   ``@llm_tool`` surface as entries with id prefix
+   ``__llm_tool__<name>`` (see ``plugin.sdk.plugin.llm_tool``). Those
+   are the *dialog* LLM's tools, called synchronously with the full
+   schema. Letting the analyzer also dispatch them means the same
+   tool can be triggered through two competing code paths, with the
+   analyzer's ~10 s decision latency racing the dialog LLM's direct
+   call. The analyzer must only see ``@plugin_entry``-registered
+   entries (status / config / queries).
+
+The original audience filter only stripped ``__llm_tool__*`` entries
+but left the plugin's ``description`` text untouched. Plugin authors
+naturally write descriptions like ``"... AI 通过 minecraft_task 工具
+下达指令 ..."`` referencing those very LLM-direct tools, and the
+analyzer LLM happily picked the leaked name as an ``entry_id``,
+collided with strict matching, retried, and then judged
+``has_task=false`` — wasting two LLM round-trips per request.
+
+The sanitizer below appends an explicit, machine-recognizable boundary
+marker listing the stripped tool names, so the analyzer's system
+prompt can teach the LLM to recognize the marker and refuse to propose
+any of those names as an entry. The marker token
+(:data:`LLM_DIRECT_BOUNDARY_MARKER`) is intentionally locale-agnostic
+— the per-language explanation lives in
+``USER_PLUGIN_SYSTEM_PROMPT`` so each language renders its own
+instruction.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+__all__ = [
+    "LLM_TOOL_ENTRY_PREFIX",
+    "LLM_DIRECT_BOUNDARY_MARKER",
+    "sanitize_plugins_for_analyzer",
+    "extract_llm_direct_tool_names",
+]
+
+
+# Reserved id prefix used by the plugin SDK when materializing an
+# ``@llm_tool`` registration as an entry; kept in sync with
+# ``plugin.sdk.plugin.llm_tool`` / ``NekoPluginBase`` (see
+# ``test_base_auto_registers_decorated_methods`` for the contract).
+LLM_TOOL_ENTRY_PREFIX = "__llm_tool__"
+
+# Stable marker the analyzer prompt teaches the LLM to recognize.
+# Placed at the END of a sanitized plugin's ``description`` field, in
+# the form:
+#     <original description> <marker>: name1, name2
+# The capitalized English token is intentional — it stays
+# recognizable regardless of the analyzer's UI locale, and the per-
+# language behavioral rule lives in USER_PLUGIN_SYSTEM_PROMPT.
+LLM_DIRECT_BOUNDARY_MARKER = "[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]"
+
+
+def _is_llm_tool_entry(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    eid = entry.get("id")
+    return isinstance(eid, str) and eid.startswith(LLM_TOOL_ENTRY_PREFIX)
+
+
+def extract_llm_direct_tool_names(entries: Iterable[Any]) -> List[str]:
+    """Return the bare tool names of ``__llm_tool__*`` entries.
+
+    Strips the ``__llm_tool__`` prefix and preserves the encounter
+    order. Non-dict / non-prefixed entries are silently skipped so
+    the helper is safe to call on raw plugin payloads.
+    """
+    out: List[str] = []
+    for entry in entries or []:
+        if not _is_llm_tool_entry(entry):
+            continue
+        eid = entry["id"]
+        name = eid[len(LLM_TOOL_ENTRY_PREFIX):]
+        if name:
+            out.append(name)
+    return out
+
+
+def _annotate_description(description: Any, llm_tool_names: List[str]) -> str:
+    """Append the boundary marker + tool list to a plugin description.
+
+    Empty ``llm_tool_names`` returns the description verbatim — plugins
+    with no ``@llm_tool`` exposure don't carry the boundary risk and
+    shouldn't pay the prompt tokens.
+    """
+    desc = description if isinstance(description, str) else ""
+    if not llm_tool_names:
+        return desc
+    names = ", ".join(llm_tool_names)
+    suffix = f"{LLM_DIRECT_BOUNDARY_MARKER}: {names}"
+    return f"{desc} {suffix}".strip() if desc else suffix
+
+
+def sanitize_plugins_for_analyzer(raw_plugins: Any) -> List[Dict[str, Any]]:
+    """Return the analyzer-safe projection of the raw plugin registry.
+
+    Steps, in order:
+
+    1. Drop anything that isn't a ``dict`` or whose ``status`` is not
+       ``"running"`` (lifecycle boundary — see module docstring).
+    2. For each running plugin, strip ``__llm_tool__*``-prefixed
+       entries from ``entries`` (caller-role boundary).
+    3. When stripping removed at least one tool, append the
+       :data:`LLM_DIRECT_BOUNDARY_MARKER` and the list of stripped
+       tool names to that plugin's ``description``. The analyzer
+       system prompt (``USER_PLUGIN_SYSTEM_PROMPT``) carries the
+       behavioral rule explaining how the LLM should treat the marker.
+
+    The result is a fresh list of fresh dicts — callers may mutate
+    further without disturbing the input payload.
+    """
+    sanitized: List[Dict[str, Any]] = []
+    for p in raw_plugins or []:
+        if not isinstance(p, dict) or p.get("status") != "running":
+            continue
+        clone = dict(p)
+        entries = clone.get("entries")
+        if isinstance(entries, list):
+            stripped_names = extract_llm_direct_tool_names(entries)
+            clone["entries"] = [e for e in entries if not _is_llm_tool_entry(e)]
+            if stripped_names:
+                clone["description"] = _annotate_description(
+                    clone.get("description"), stripped_names,
+                )
+        sanitized.append(clone)
+    return sanitized

--- a/config/prompts/prompts_agent.py
+++ b/config/prompts/prompts_agent.py
@@ -344,6 +344,7 @@ USER_PLUGIN_SYSTEM_PROMPT = {
 - 如果 has_task 和 can_execute 都为 true，entry_id 是必需的。
 - 如果 has_task/can_execute 为 true 时 entry_id 缺失或为 null，响应将被视为不可执行。
 - 严格匹配：plugin_id 和 entry_id 是代码标识符。你必须从上面的可用插件列表中原样复制它们（区分大小写、逐字符匹配）。不要发明、缩写或改写它们。如果找不到完全匹配，设置 can_execute=false。
+- 工具边界：如果某个工具名出现在插件的 description 文本里，但不在该插件的 entries 列表里，把它视为 analyzer 无法调用的 LLM-direct 工具。插件 description 末尾可能带有 `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: 名称1, 名称2` 标记，明确列出这类名字。不要把这些名字作为 entry_id，即使 description 文本提到它们；如果用户请求只能由这类工具完成，设置 can_execute=false。
 - 如果入口有 args(...) 信息，在 plugin_args 中使用那些字段名。只包含 schema 中列出的字段。
 - 当入口 schema 需要用户文本字段（例如 command/message/query/objective）时，必须复制用户最新消息原文；不要翻译、摘要、改写或补全。
 - 如果用户的意图与任何插件的描述功能不明确匹配，设置 has_task=false。
@@ -388,6 +389,7 @@ VERY IMPORTANT:
 - If has_task and can_execute are true, entry_id is REQUIRED.
 - If entry_id is missing or null when has_task/can_execute are true, the response will be treated as non-executable.
 - STRICT MATCHING: plugin_id and entry_id are code identifiers. You MUST copy them EXACTLY (case-sensitive, character-for-character) from the AVAILABLE PLUGINS list above. Do NOT invent, abbreviate, or paraphrase them. If you cannot find an exact match, set can_execute=false.
+- TOOL BOUNDARY: if a tool name appears in a plugin's description text but is NOT in that plugin's entries list, treat it as an LLM-direct tool that this analyzer CANNOT invoke. A plugin's description may end with the marker `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: name1, name2` listing such names explicitly. Do NOT propose any of those names as entry_id even if the description text mentions them; if the user's request can only be served by such a tool, set can_execute=false.
 - If an entry has args(...) info, use those field names in plugin_args. Only include fields listed in the schema.
 - When an entry schema needs a user text field (for example command/message/query/objective), copy the user's latest message verbatim; do not translate, summarize, rewrite, or complete it.
 - If the user's intent does not clearly match any plugin's described functionality, set has_task=false.
@@ -432,6 +434,7 @@ Return only the JSON object, nothing else.""",
 - has_task と can_execute が true の場合、entry_id は必須です。
 - has_task/can_execute が true なのに entry_id が欠落または null の場合、レスポンスは実行不可として扱われます。
 - 厳密マッチング：plugin_id と entry_id はコード識別子です。上記の利用可能プラグインリストからそのまま（大文字小文字区別、文字ごと）コピーしてください。発明、省略、言い換えをしないでください。完全一致が見つからない場合は can_execute=false を設定してください。
+- ツール境界：あるツール名がプラグインの description テキストに現れていても、そのプラグインの entries 一覧に無い場合は、analyzer が呼び出せない LLM-direct ツールとして扱ってください。プラグインの description の末尾に `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: 名前1, 名前2` というマーカーが付いてそのような名前を明示することがあります。description テキストでそれらが言及されていても、決して entry_id として提案しないでください。ユーザーのリクエストがそのようなツールでしか実現できない場合は can_execute=false にしてください。
 - エントリに args(...) 情報がある場合、plugin_args でそのフィールド名を使用してください。schema にリストされたフィールドのみ含めてください。
 - エントリの schema にユーザーテキストフィールド（例: command/message/query/objective）が必要な場合、ユーザーの最新メッセージを逐語的にコピーしてください。翻訳・要約・書き換え・補完は行わないでください。
 - ユーザーの意図がどのプラグインの機能とも明確に一致しない場合、has_task=false を設定してください。
@@ -476,6 +479,7 @@ JSONオブジェクトのみ返してください。""",
 - has_task와 can_execute가 true이면 entry_id는 필수입니다.
 - has_task/can_execute가 true인데 entry_id가 누락되거나 null이면 응답은 실행 불가능으로 처리됩니다.
 - 엄격한 매칭: plugin_id와 entry_id는 코드 식별자입니다. 위의 사용 가능한 플러그인 목록에서 정확히(대소문자 구분, 문자 단위) 복사해야 합니다. 만들거나 축약하거나 바꿔 말하지 마세요. 정확한 일치를 찾을 수 없으면 can_execute=false로 설정하세요.
+- 도구 경계: 어떤 도구 이름이 플러그인의 description 텍스트에는 나오지만 해당 플러그인의 entries 목록에는 없으면, analyzer가 호출할 수 없는 LLM-direct 도구로 취급하세요. 플러그인 description 끝에 `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: 이름1, 이름2` 형태의 마커가 붙어 그런 이름들을 명시할 수 있습니다. description 텍스트가 이러한 이름을 언급하더라도 절대로 entry_id로 제안하지 마세요. 사용자의 요청이 이러한 도구로만 처리될 수 있다면 can_execute=false로 설정하세요.
 - 엔트리에 args(...) 정보가 있으면 plugin_args에서 해당 필드 이름을 사용하세요. schema에 나열된 필드만 포함하세요.
 - 엔트리 schema에 사용자 텍스트 필드(예: command/message/query/objective)가 필요한 경우, 사용자의 최신 메시지를 그대로 복사하세요. 번역, 요약, 다시 쓰기, 보완하지 마세요.
 - 사용자의 의도가 어떤 플러그인의 설명된 기능과 명확히 일치하지 않으면 has_task=false로 설정하세요.
@@ -520,6 +524,7 @@ JSON 객체만 반환하세요.""",
 - Если has_task и can_execute равны true, entry_id ОБЯЗАТЕЛЕН.
 - Если entry_id отсутствует или равен null при has_task/can_execute=true, ответ будет считаться невыполнимым.
 - СТРОГОЕ СООТВЕТСТВИЕ: plugin_id и entry_id — это кодовые идентификаторы. Вы ДОЛЖНЫ скопировать их ТОЧНО (с учётом регистра, посимвольно) из списка доступных плагинов выше. НЕ придумывайте, не сокращайте и не перефразируйте. Если точное совпадение не найдено, установите can_execute=false.
+- ГРАНИЦА ИНСТРУМЕНТОВ: если имя инструмента встречается в тексте description плагина, но отсутствует в списке entries этого плагина, считайте его LLM-direct инструментом, который этот analyzer вызвать НЕ может. В конце description плагина может быть маркер `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: имя1, имя2`, явно перечисляющий такие имена. НЕ предлагайте эти имена как entry_id, даже если description упоминает их. Если запрос пользователя может быть выполнен только таким инструментом, установите can_execute=false.
 - Если у точки входа есть информация args(...), используйте эти имена полей в plugin_args. Включайте только поля, указанные в схеме.
 - Если в схеме точки входа есть текстовое поле пользователя (например, command/message/query/objective), скопируйте последнее сообщение пользователя дословно; не переводите, не резюмируйте, не перефразируйте и не дополняйте.
 - Если намерение пользователя явно не соответствует описанной функциональности ни одного плагина, установите has_task=false.
@@ -564,6 +569,7 @@ MUY IMPORTANTE:
 - Si has_task y can_execute son true, entry_id es OBLIGATORIO.
 - Si entry_id falta o es null cuando has_task/can_execute son true, la respuesta se tratará como no ejecutable.
 - COINCIDENCIA ESTRICTA: plugin_id y entry_id son identificadores de código. Cópialos EXACTAMENTE de la lista de PLUGINS DISPONIBLES (sensible a mayúsculas, carácter por carácter). No los inventes, abrevies ni parafrasees. Si no hay coincidencia exacta, establece can_execute=false.
+- LÍMITE DE HERRAMIENTAS: si un nombre de herramienta aparece en el texto de description de un plugin pero NO está en la lista de entries de ese plugin, trátalo como una herramienta LLM-direct que este analyzer NO puede invocar. La description del plugin puede terminar con el marcador `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: nombre1, nombre2` enumerando esos nombres explícitamente. NO propongas ninguno de esos nombres como entry_id aunque la description los mencione; si la solicitud del usuario solo puede cumplirse con una de esas herramientas, establece can_execute=false.
 - Si una entrada tiene información args(...), usa esos nombres de campo en plugin_args. Incluye solo campos listados en el schema.
 - Cuando el schema necesite un campo de texto del usuario (por ejemplo command/message/query/objective), copia el último mensaje del usuario literalmente; no traduzcas, resumas, reescribas ni completes.
 - Si la intención del usuario no coincide claramente con la funcionalidad descrita de ningún plugin, establece has_task=false.
@@ -608,6 +614,7 @@ MUITO IMPORTANTE:
 - Se has_task e can_execute forem true, entry_id é OBRIGATÓRIO.
 - Se entry_id estiver ausente ou null quando has_task/can_execute forem true, a resposta será tratada como não executável.
 - CORRESPONDÊNCIA ESTRITA: plugin_id e entry_id são identificadores de código. Copie-os EXATAMENTE da lista de PLUGINS DISPONÍVEIS (sensível a maiúsculas, caractere por caractere). Não invente, abrevie ou parafraseie. Se não encontrar correspondência exata, defina can_execute=false.
+- LIMITE DE FERRAMENTAS: se um nome de ferramenta aparecer no texto de description de um plugin mas NÃO estiver na lista de entries desse plugin, trate-o como uma ferramenta LLM-direct que este analyzer NÃO pode invocar. A description do plugin pode terminar com o marcador `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: nome1, nome2` listando esses nomes explicitamente. NÃO proponha nenhum desses nomes como entry_id mesmo que a description os mencione; se a solicitação do usuário só puder ser atendida por uma dessas ferramentas, defina can_execute=false.
 - Se uma entrada tiver informação args(...), use esses nomes de campo em plugin_args. Inclua apenas campos listados no schema.
 - Quando o schema exigir um campo de texto do usuário (por exemplo command/message/query/objective), copie literalmente a última mensagem do usuário; não traduza, resuma, reescreva ou complete.
 - Se a intenção do usuário não corresponder claramente à funcionalidade descrita de nenhum plugin, defina has_task=false.

--- a/tests/unit/test_plugin_analyzer_view.py
+++ b/tests/unit/test_plugin_analyzer_view.py
@@ -268,7 +268,7 @@ def test_build_plugin_desc_lines_never_yields_callable_llm_tool_entry():
     # entry as ``{id}: {desc}`` so the unambiguous tell-tale is
     # ``minecraft_task`` appearing at the *start* of a ``;``-separated
     # chunk inside the ``entries: [ ... ]`` segment.
-    entries_segment = rendered.split("entries:", 1)[1]
+    entries_segment = rendered.split("| entries:", 1)[1]
     callable_chunks = [c.strip() for c in entries_segment.lstrip(" [").split(";")]
     assert not any(c.startswith("minecraft_task") for c in callable_chunks), (
         f"minecraft_task leaked as a callable entry: {callable_chunks}"

--- a/tests/unit/test_plugin_analyzer_view.py
+++ b/tests/unit/test_plugin_analyzer_view.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the analyzer-facing plugin payload view.
+
+Covers the audience-boundary contract described in
+``brain/plugin_analyzer_view.py``:
+
+* Only ``running`` plugins reach the analyzer.
+* ``__llm_tool__*``-prefixed entries are stripped.
+* When a plugin's description literally references one of its
+  ``@llm_tool`` names (the original ``minecraft_task`` leak), the
+  sanitizer appends a stable boundary marker the analyzer prompt
+  teaches the LLM to honor.
+* The analyzer system prompt carries the rule in every supported
+  language so the marker is interpretable regardless of UI locale.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# sanitize_plugins_for_analyzer
+# ---------------------------------------------------------------------------
+
+
+def _minecraft_like_plugin(status: str = "running") -> dict:
+    """A payload mirroring the real game_agent_minecraft leak case.
+
+    The description text literally names ``minecraft_task`` (the
+    plugin author wrote it to guide the dialog LLM) AND the entries
+    list contains an ``__llm_tool__minecraft_task`` registration plus
+    real ``@plugin_entry`` queries the analyzer is supposed to see.
+    """
+    return {
+        "id": "game_agent_minecraft",
+        "status": status,
+        "description": (
+            "桥接本地 Minecraft Agent (WebSocket)，让 AI 通过 minecraft_task "
+            "工具下达指令并实时观看游戏画面进行解说。"
+        ),
+        "entries": [
+            {"id": "__llm_tool__minecraft_task", "description": "LLM-direct tool"},
+            {"id": "game_agent_reload_config", "description": "reload"},
+            {"id": "game_agent_status", "description": "status"},
+            {"id": "query_inventory", "description": "inventory"},
+        ],
+    }
+
+
+def test_drops_non_running_plugins():
+    from brain.plugin_analyzer_view import sanitize_plugins_for_analyzer
+
+    raw = [
+        {"id": "running_one", "status": "running", "entries": [{"id": "a"}]},
+        {"id": "stopped_one", "status": "stopped", "entries": [{"id": "a"}]},
+        {"id": "pending_one", "status": "pending", "entries": [{"id": "a"}]},
+        {"id": "no_status", "entries": [{"id": "a"}]},  # missing status
+        "not-a-dict",
+        None,
+    ]
+    out = sanitize_plugins_for_analyzer(raw)
+    assert [p["id"] for p in out] == ["running_one"]
+
+
+def test_strips_llm_tool_entries_from_visible_entries():
+    from brain.plugin_analyzer_view import sanitize_plugins_for_analyzer
+
+    out = sanitize_plugins_for_analyzer([_minecraft_like_plugin()])
+    assert len(out) == 1
+    entry_ids = [e["id"] for e in out[0]["entries"]]
+    # All __llm_tool__ entries gone; @plugin_entry entries preserved
+    # in original order.
+    assert "__llm_tool__minecraft_task" not in entry_ids
+    assert entry_ids == [
+        "game_agent_reload_config",
+        "game_agent_status",
+        "query_inventory",
+    ]
+
+
+def test_appends_boundary_marker_when_llm_tools_were_stripped():
+    from brain.plugin_analyzer_view import (
+        LLM_DIRECT_BOUNDARY_MARKER,
+        sanitize_plugins_for_analyzer,
+    )
+
+    out = sanitize_plugins_for_analyzer([_minecraft_like_plugin()])
+    desc = out[0]["description"]
+    # The original Chinese description text is preserved verbatim.
+    assert "minecraft_task" in desc  # original text + marker list both contain it
+    assert "桥接本地 Minecraft Agent" in desc
+    # The marker appears AFTER the original description.
+    marker_pos = desc.find(LLM_DIRECT_BOUNDARY_MARKER)
+    text_pos = desc.find("桥接本地 Minecraft Agent")
+    assert marker_pos > text_pos > -1
+    # And it carries the bare tool name (no ``__llm_tool__`` prefix).
+    assert f"{LLM_DIRECT_BOUNDARY_MARKER}: minecraft_task" in desc
+
+
+def test_no_marker_when_plugin_has_no_llm_tools():
+    """Plugins without ``@llm_tool`` exposure shouldn't pay the prompt
+    tokens for a marker that has nothing to say."""
+    from brain.plugin_analyzer_view import (
+        LLM_DIRECT_BOUNDARY_MARKER,
+        sanitize_plugins_for_analyzer,
+    )
+
+    raw = [{
+        "id": "calendar",
+        "status": "running",
+        "description": "calendar plugin does meeting scheduling",
+        "entries": [
+            {"id": "list_events"},
+            {"id": "create_event"},
+        ],
+    }]
+    out = sanitize_plugins_for_analyzer(raw)
+    assert LLM_DIRECT_BOUNDARY_MARKER not in out[0]["description"]
+    assert out[0]["description"] == "calendar plugin does meeting scheduling"
+
+
+def test_handles_missing_or_empty_description():
+    from brain.plugin_analyzer_view import (
+        LLM_DIRECT_BOUNDARY_MARKER,
+        sanitize_plugins_for_analyzer,
+    )
+
+    raw = [
+        {
+            "id": "p1",
+            "status": "running",
+            # no description field at all
+            "entries": [{"id": "__llm_tool__solo"}, {"id": "real"}],
+        },
+        {
+            "id": "p2",
+            "status": "running",
+            "description": "",
+            "entries": [{"id": "__llm_tool__solo"}, {"id": "real"}],
+        },
+    ]
+    out = sanitize_plugins_for_analyzer(raw)
+    for plugin in out:
+        # When the original description is missing/empty, the marker
+        # still lands so the analyzer learns about the boundary; the
+        # marker is the entire description.
+        assert plugin["description"].startswith(LLM_DIRECT_BOUNDARY_MARKER)
+        assert plugin["description"].endswith(": solo")
+
+
+def test_multiple_llm_tools_listed_in_order():
+    from brain.plugin_analyzer_view import (
+        LLM_DIRECT_BOUNDARY_MARKER,
+        sanitize_plugins_for_analyzer,
+    )
+
+    raw = [{
+        "id": "multi",
+        "status": "running",
+        "description": "multi-tool plugin",
+        "entries": [
+            {"id": "__llm_tool__alpha"},
+            {"id": "real_entry"},
+            {"id": "__llm_tool__beta"},
+            {"id": "__llm_tool__gamma"},
+        ],
+    }]
+    out = sanitize_plugins_for_analyzer(raw)
+    expected_suffix = f"{LLM_DIRECT_BOUNDARY_MARKER}: alpha, beta, gamma"
+    assert out[0]["description"].endswith(expected_suffix)
+    assert [e["id"] for e in out[0]["entries"]] == ["real_entry"]
+
+
+def test_returns_fresh_copies_input_untouched():
+    """The sanitizer is called inside the HTTP provider — callers must
+    not see the input mutated, otherwise repeated invocations would
+    keep stacking marker suffixes on the same description string."""
+    from brain.plugin_analyzer_view import sanitize_plugins_for_analyzer
+
+    raw = [_minecraft_like_plugin()]
+    raw_desc_before = raw[0]["description"]
+    raw_entries_before = list(raw[0]["entries"])
+
+    out = sanitize_plugins_for_analyzer(raw)
+
+    # Input is intact: caller can still trust the original payload.
+    assert raw[0]["description"] == raw_desc_before
+    assert raw[0]["entries"] == raw_entries_before
+    # And the output is a *different* dict object.
+    assert out[0] is not raw[0]
+    assert out[0]["entries"] is not raw[0]["entries"]
+
+
+def test_idempotent_under_repeated_invocation():
+    """Calling twice on the *output* of the first call shouldn't keep
+    growing the description (defense-in-depth against double-stacking
+    if the wiring ever re-routes the sanitized payload back through
+    the helper)."""
+    from brain.plugin_analyzer_view import (
+        LLM_DIRECT_BOUNDARY_MARKER,
+        sanitize_plugins_for_analyzer,
+    )
+
+    once = sanitize_plugins_for_analyzer([_minecraft_like_plugin()])
+    twice = sanitize_plugins_for_analyzer(once)
+    assert once[0]["description"] == twice[0]["description"]
+    # And we still only see ONE marker (no double-appended boundary).
+    assert twice[0]["description"].count(LLM_DIRECT_BOUNDARY_MARKER) == 1
+
+
+def test_handles_non_list_entries_field_gracefully():
+    from brain.plugin_analyzer_view import sanitize_plugins_for_analyzer
+
+    raw = [{
+        "id": "weird",
+        "status": "running",
+        "description": "broken entries shape",
+        "entries": "not-a-list",
+    }]
+    out = sanitize_plugins_for_analyzer(raw)
+    # Non-list entries pass through untouched; no marker because no
+    # __llm_tool__ entries could be extracted.
+    assert out[0]["entries"] == "not-a-list"
+    assert out[0]["description"] == "broken entries shape"
+
+
+def test_empty_and_none_input():
+    from brain.plugin_analyzer_view import sanitize_plugins_for_analyzer
+
+    assert sanitize_plugins_for_analyzer([]) == []
+    assert sanitize_plugins_for_analyzer(None) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration with _build_plugin_desc_lines (the actual analyzer prompt
+# assembly path). This is the original regression case: the analyzer
+# LLM must not be able to derive a callable ``entry_id=minecraft_task``
+# from what reaches its prompt.
+# ---------------------------------------------------------------------------
+
+
+def test_build_plugin_desc_lines_never_yields_callable_llm_tool_entry():
+    """End-to-end: the sanitized payload + the existing entry-list
+    renderer together produce a prompt where ``minecraft_task`` is
+    *only* present inside the boundary marker — never as a comma-
+    separated callable entry like ``minecraft_task: ...``."""
+    from brain.plugin_analyzer_view import (
+        LLM_DIRECT_BOUNDARY_MARKER,
+        sanitize_plugins_for_analyzer,
+    )
+    from brain.task_executor import DirectTaskExecutor
+
+    sanitized = sanitize_plugins_for_analyzer([_minecraft_like_plugin()])
+    executor = object.__new__(DirectTaskExecutor)
+    lines = executor._build_plugin_desc_lines(sanitized)
+    assert len(lines) == 1
+    rendered = lines[0]
+
+    # The entries: [...] block must NOT contain a callable
+    # minecraft_task entry. _build_plugin_desc_lines formats each
+    # entry as ``{id}: {desc}`` so the unambiguous tell-tale is
+    # ``minecraft_task`` appearing at the *start* of a ``;``-separated
+    # chunk inside the ``entries: [ ... ]`` segment.
+    entries_segment = rendered.split("entries:", 1)[1]
+    callable_chunks = [c.strip() for c in entries_segment.lstrip(" [").split(";")]
+    assert not any(c.startswith("minecraft_task") for c in callable_chunks), (
+        f"minecraft_task leaked as a callable entry: {callable_chunks}"
+    )
+
+    # The boundary marker (which lives in the description, before
+    # ``| entries:``) tells the analyzer this name is off-limits.
+    desc_segment = rendered.split("| entries:", 1)[0]
+    assert LLM_DIRECT_BOUNDARY_MARKER in desc_segment
+    assert "minecraft_task" in desc_segment
+
+
+# ---------------------------------------------------------------------------
+# Prompt template carries the rule in every supported locale
+# ---------------------------------------------------------------------------
+
+
+def test_user_plugin_prompt_contains_boundary_rule_in_every_locale():
+    """If a locale forgets the rule, the analyzer LLM in that locale
+    silently regresses to the old behavior. Pin every supported
+    language."""
+    from brain.plugin_analyzer_view import LLM_DIRECT_BOUNDARY_MARKER
+    from config.prompts.prompts_agent import USER_PLUGIN_SYSTEM_PROMPT
+
+    expected_langs = {"zh", "en", "ja", "ko", "ru", "es", "pt"}
+    assert expected_langs.issubset(USER_PLUGIN_SYSTEM_PROMPT.keys())
+    for lang in expected_langs:
+        template = USER_PLUGIN_SYSTEM_PROMPT[lang]
+        # The marker token itself must appear so the LLM has an
+        # exact-string anchor to recognize.
+        assert LLM_DIRECT_BOUNDARY_MARKER in template, (
+            f"locale {lang!r} missing the LLM-direct boundary marker"
+        )


### PR DESCRIPTION
## Summary
- 抽出 `brain/plugin_analyzer_view.sanitize_plugins_for_analyzer`，把 `_http_plugin_provider` 里原本内联的 running-filter + `__llm_tool__` entry 过滤搬过去，并新增第二道防线：剥掉 entry 后给 plugin description 末尾追加 `[LLM-DIRECT TOOLS NOT CALLABLE FROM ANALYZER]: name1, name2` 标记
- `config/prompts/prompts_agent.py` 七种语言的 `USER_PLUGIN_SYSTEM_PROMPT` 都加一条 "TOOL BOUNDARY" 规则，明确告诉 analyzer LLM：如果 description 里出现某工具名但不在 entries 列表里 / 出现在该标记里，**禁止**当成 entry_id 调用，必要时 `can_execute=false`
- 新增 `tests/unit/test_plugin_analyzer_view.py`（12 个用例），覆盖 sanitizer 行为 + 端到端验证（用真实 minecraft 描述跑过 `_build_plugin_desc_lines`，确认 `minecraft_task` 只出现在 boundary 标记里、不会成为可调用 entry）+ 七语种 prompt 标记锚点检测

## Why
之前 analyzer LLM 能从 `plugin/plugins/game_agent_minecraft/plugin.toml` 顶层 description 里读到 \"通过 minecraft_task 工具下达指令\"，把 `minecraft_task` 当 entry_id 调用，被 `_http_plugin_provider` 既有的严格匹配拒掉，retry 一轮后判 `has_task=false` —— 两条 LLM 推理 + retry 整体浪费 ~10s，且降低用户请求成功率。原来的 `__llm_tool__*` entry 过滤是 audience boundary 的一半，另一半是 description 文本里的字面提及，这次补上。

## Test plan
- [x] `uv run pytest tests/unit/test_plugin_analyzer_view.py` — 12 passed
- [x] `uv run pytest tests/unit/test_plugin_llm_tool_sdk.py tests/unit/test_user_plugin_stage1_filtering.py tests/unit/test_game_agent_minecraft_plugin.py tests/unit/test_agent_runtime_intent.py` — 101 passed
- [x] `uv run pytest tests/unit -k \"plugin or agent or prompt\"` — 284 passed（1 个 `test_soccer_game_prompts_follow_user_language` 失败与本 PR 无关，已在 main 上预存在）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了分析器与对话侧工具并发触发导致的调用冲突，减少误用风险。

* **改进**
  * 统一清洗并呈现插件的“分析器视图”，仅暴露运行中且安全可用的插件，并在描述中标注不可由分析器直接调用的工具边界。
  * 系统提示中新增多语言的工具边界约束说明。

* **测试**
  * 新增覆盖清洗逻辑、边界注入与多语言提示的完整单元与回归测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->