### PR TITLE
聊天框图片导入支持自动格式转换，并仅在超过 10MB 限制时压缩，避免不合规图片被静默丢弃

### DIFF
--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -105,7 +105,11 @@
         context.fillStyle = '#fff';
         context.fillRect(0, 0, width, height);
         context.drawImage(image, 0, 0, width, height);
-        return canvas.toDataURL('image/jpeg', quality);
+        var dataUrl = canvas.toDataURL('image/jpeg', quality);
+        if (!/^data:image\/[a-z0-9.+-]+;base64,/i.test(dataUrl)) {
+            throw new Error('IMAGE_ENCODE_FAILED');
+        }
+        return dataUrl;
     }
 
     function getDataUrlEncodedBytes(dataUrl) {

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -214,6 +214,7 @@
         var normalized = await mod.normalizeImageDataUrlForPendingList(img.src);
         if (normalized && normalized !== img.src) {
             img.src = normalized;
+            delete item.dataset.avatarPosition;
         }
         return normalized;
     };
@@ -231,6 +232,7 @@
             var normalized = await mod.normalizePendingAttachmentItem(items[i]);
             urls.push(normalized);
             if (before && normalized && before !== normalized) {
+                delete items[i].dataset.avatarPosition;
                 changed = true;
             }
         }

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -12,6 +12,9 @@
     const S = window.appState;
     const C = window.appConst;
     const U = window.appUtils;
+    const PENDING_IMAGE_MAX_ENCODED_BYTES = 10 * 1024 * 1024;
+    const PENDING_IMAGE_MIN_LONG_SIDE = 320;
+    const PENDING_IMAGE_JPEG_QUALITIES = [0.92, 0.86, 0.78, 0.7, 0.62, 0.52, 0.42, 0.32];
 
     function isHomeTutorialInteractionLocked() {
         try {
@@ -30,6 +33,213 @@
             );
         }
     }
+
+    function getImageNaturalSize(image) {
+        return {
+            width: image.naturalWidth || image.width || 0,
+            height: image.naturalHeight || image.height || 0
+        };
+    }
+
+    function loadImageFromSource(src) {
+        return new Promise(function (resolve, reject) {
+            var image = new Image();
+            var settled = false;
+            var finish = function (callback, value) {
+                if (settled) return;
+                settled = true;
+                callback(value);
+            };
+
+            image.onload = function () {
+                var size = getImageNaturalSize(image);
+                if (!size.width || !size.height) {
+                    finish(reject, new Error('INVALID_IMAGE_SIZE'));
+                    return;
+                }
+                finish(resolve, image);
+            };
+            image.onerror = function () {
+                finish(reject, new Error('INVALID_IMAGE_TYPE'));
+            };
+            image.src = src;
+        });
+    }
+
+    function loadImageFromBlob(blob) {
+        return new Promise(function (resolve, reject) {
+            var objectUrl = URL.createObjectURL(blob);
+            loadImageFromSource(objectUrl)
+                .then(resolve, reject)
+                .finally(function () {
+                    URL.revokeObjectURL(objectUrl);
+                });
+        });
+    }
+
+    function readBlobAsDataUrl(blob, mimeType) {
+        return new Promise(function (resolve, reject) {
+            var reader = new FileReader();
+            reader.onload = function () {
+                resolve(String(reader.result || ''));
+            };
+            reader.onerror = function () {
+                reject(reader.error || new Error('READ_IMAGE_FAILED'));
+            };
+
+            var sourceBlob = mimeType ? new Blob([blob], { type: mimeType }) : blob;
+            reader.readAsDataURL(sourceBlob);
+        });
+    }
+
+    function drawImageToJpegDataUrl(image, width, height, quality) {
+        var canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        var context = canvas.getContext('2d');
+        if (!context) {
+            throw new Error('CANVAS_UNAVAILABLE');
+        }
+
+        // JPEG 没有透明通道，先铺白底，避免透明 PNG/WebP 转换后变成黑底。
+        context.fillStyle = '#fff';
+        context.fillRect(0, 0, width, height);
+        context.drawImage(image, 0, 0, width, height);
+        return canvas.toDataURL('image/jpeg', quality);
+    }
+
+    function getDataUrlEncodedBytes(dataUrl) {
+        var text = String(dataUrl || '');
+        var commaIndex = text.indexOf(',');
+        if (commaIndex < 0) {
+            return text.length;
+        }
+
+        var base64Text = text.slice(commaIndex + 1).replace(/\s/g, '');
+        var padding = base64Text.endsWith('==') ? 2 : (base64Text.endsWith('=') ? 1 : 0);
+        return Math.max(0, Math.floor(base64Text.length * 3 / 4) - padding);
+    }
+
+    function compressLoadedImageToPendingDataUrl(image) {
+        var natural = getImageNaturalSize(image);
+        if (!natural.width || !natural.height) {
+            throw new Error('INVALID_IMAGE_SIZE');
+        }
+
+        var width = natural.width;
+        var height = natural.height;
+        var bestDataUrl = '';
+
+        for (var pass = 0; pass < 6; pass += 1) {
+            for (var i = 0; i < PENDING_IMAGE_JPEG_QUALITIES.length; i += 1) {
+                var dataUrl = drawImageToJpegDataUrl(image, width, height, PENDING_IMAGE_JPEG_QUALITIES[i]);
+                bestDataUrl = dataUrl;
+                if (getDataUrlEncodedBytes(dataUrl) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+                    return dataUrl;
+                }
+            }
+
+            var ratio = Math.sqrt(PENDING_IMAGE_MAX_ENCODED_BYTES / Math.max(getDataUrlEncodedBytes(bestDataUrl), 1)) * 0.92;
+            var longSide = Math.max(width, height);
+            var nextLongSide = Math.max(PENDING_IMAGE_MIN_LONG_SIDE, Math.floor(longSide * ratio));
+            var nextScale = nextLongSide / Math.max(longSide, 1);
+            var nextWidth = Math.max(1, Math.floor(width * nextScale));
+            var nextHeight = Math.max(1, Math.floor(height * nextScale));
+            if (nextWidth >= width && nextHeight >= height) {
+                break;
+            }
+            width = nextWidth;
+            height = nextHeight;
+        }
+
+        if (getDataUrlEncodedBytes(bestDataUrl) > PENDING_IMAGE_MAX_ENCODED_BYTES) {
+            throw new Error('IMAGE_TOO_LARGE');
+        }
+        return bestDataUrl;
+    }
+
+    function isLikelyImageFile(file) {
+        if (!file || typeof file !== 'object') return false;
+        if (/^image\//i.test(file.type || '')) return true;
+        var name = String(file.name || '').toLowerCase();
+        return /\.(avif|bmp|gif|heic|heif|ico|jpe?g|png|tiff?|webp)$/i.test(name);
+    }
+
+    function isLikelyJpegBlob(blob) {
+        if (!blob || typeof blob !== 'object') return false;
+        if (/^image\/jpe?g$/i.test(blob.type || '')) return true;
+        var name = String(blob.name || '').toLowerCase();
+        return /\.(jpe?g)$/i.test(name);
+    }
+
+    mod.normalizeImageBlobForPendingList = async function normalizeImageBlobForPendingList(blob) {
+        if (!(blob instanceof Blob)) {
+            throw new Error('INVALID_FILE');
+        }
+
+        if (isLikelyJpegBlob(blob) && blob.size <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+            var originalDataUrl = await readBlobAsDataUrl(blob, 'image/jpeg');
+            await loadImageFromSource(originalDataUrl);
+            return originalDataUrl;
+        }
+
+        var image = await loadImageFromBlob(blob);
+        return compressLoadedImageToPendingDataUrl(image);
+    };
+
+    mod.normalizeImageDataUrlForPendingList = async function normalizeImageDataUrlForPendingList(dataUrl) {
+        var src = String(dataUrl || '');
+        if (!/^data:image\//i.test(src)) {
+            throw new Error('INVALID_IMAGE_DATA_URL');
+        }
+
+        var image = await loadImageFromSource(src);
+        if (/^data:image\/jpe?g;base64,/i.test(src)
+                && getDataUrlEncodedBytes(src) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+            return src;
+        }
+        return compressLoadedImageToPendingDataUrl(image);
+    };
+
+    mod.normalizePendingAttachmentItem = async function normalizePendingAttachmentItem(item) {
+        if (!item || !item.querySelector) {
+            throw new Error('INVALID_ATTACHMENT_ITEM');
+        }
+
+        var img = item.querySelector('.screenshot-thumbnail');
+        if (!img || !img.src) {
+            throw new Error('INVALID_ATTACHMENT_IMAGE');
+        }
+
+        var normalized = await mod.normalizeImageDataUrlForPendingList(img.src);
+        if (normalized && normalized !== img.src) {
+            img.src = normalized;
+        }
+        return normalized;
+    };
+
+    mod.normalizeAllPendingComposerAttachments = async function normalizeAllPendingComposerAttachments() {
+        var screenshotsList = S.dom.screenshotsList;
+        if (!screenshotsList) return [];
+
+        var items = Array.from(screenshotsList.children);
+        var urls = [];
+        var changed = false;
+        for (var i = 0; i < items.length; i += 1) {
+            var img = items[i].querySelector('.screenshot-thumbnail');
+            var before = img && img.src ? img.src : '';
+            var normalized = await mod.normalizePendingAttachmentItem(items[i]);
+            urls.push(normalized);
+            if (before && normalized && before !== normalized) {
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            mod.syncPendingComposerAttachments();
+        }
+        return urls;
+    };
 
     // ======================== Screenshot helpers ========================
 
@@ -165,7 +375,7 @@
             input = document.createElement('input');
             input.id = 'reactChatWindowImportImageInput';
             input.type = 'file';
-            input.accept = 'image/*';
+            input.accept = 'image/*,.avif,.bmp,.gif,.heic,.heif,.ico,.jpg,.jpeg,.png,.tif,.tiff,.webp';
             input.multiple = true;
             input.hidden = true;
             document.body.appendChild(input);
@@ -183,10 +393,12 @@
             Promise.allSettled(files.map(mod.importImageFileToPendingList))
                 .then(function (results) {
                     var succeeded = 0;
+                    var failed = 0;
                     for (var i = 0; i < results.length; i++) {
                         if (results[i].status === 'fulfilled') {
                             succeeded++;
                         } else {
+                            failed++;
                             console.error('[导入图片] 单张处理失败:', results[i].reason);
                         }
                     }
@@ -195,7 +407,8 @@
                             window.t ? window.t('app.importImageAdded', { count: succeeded }) : '已添加 ' + succeeded + ' 张图片，发送时会一并带上',
                             3000
                         );
-                    } else {
+                    }
+                    if (failed > 0) {
                         window.showStatusToast(
                             window.t ? window.t('app.importImageFailed') : '导入图片失败',
                             4000
@@ -212,31 +425,19 @@
     };
 
     mod.importImageFileToPendingList = function importImageFileToPendingList(file) {
-        return new Promise(function (resolve, reject) {
-            if (!(file instanceof File)) {
-                reject(new Error('INVALID_FILE'));
-                return;
-            }
+        if (!(file instanceof File)) {
+            return Promise.reject(new Error('INVALID_FILE'));
+        }
 
-            if (!/^image\//i.test(file.type || '')) {
-                reject(new Error('INVALID_IMAGE_TYPE'));
-                return;
-            }
+        if (file.type && !/^image\//i.test(file.type) && !isLikelyImageFile(file)) {
+            return Promise.reject(new Error('INVALID_IMAGE_TYPE'));
+        }
 
-            var reader = new FileReader();
-            reader.onload = function () {
-                try {
-                    mod.addScreenshotToList(String(reader.result || ''));
-                    resolve(reader.result);
-                } catch (error) {
-                    reject(error);
-                }
-            };
-            reader.onerror = function () {
-                reject(reader.error || new Error('READ_IMAGE_FAILED'));
-            };
-            reader.readAsDataURL(file);
-        });
+        return mod.normalizeImageBlobForPendingList(file)
+            .then(function (dataUrl) {
+                mod.addScreenshotToList(dataUrl);
+                return dataUrl;
+            });
     };
 
     mod.openImageImportPicker = function openImageImportPicker() {
@@ -1572,6 +1773,22 @@
                 showHomeTutorialLockedToast();
                 return false;
             }
+
+            if (hasScreenshots) {
+                try {
+                    await mod.normalizeAllPendingComposerAttachments();
+                    hasScreenshots = screenshotsList.children.length > 0;
+                } catch (error) {
+                    console.error('[Chat] 待发送图片处理失败:', error);
+                    window.showStatusToast(
+                        window.t ? window.t('app.importImageFailed') : '导入图片失败',
+                        4000
+                    );
+                    return false;
+                }
+                if (!text && !hasScreenshots) return false;
+            }
+
             var requestId = (typeof options.requestId === 'string' && options.requestId)
                 ? options.requestId
                 : ('req-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8));
@@ -2479,20 +2696,21 @@
                     e.preventDefault();
                     var blob = items[i].getAsFile();
                     if (!blob) continue;
-                    var reader = new FileReader();
-                    reader.onload = function (ev) {
-                        if (ev.target && ev.target.result) {
-                            mod.addScreenshotToList(ev.target.result);
+                    mod.normalizeImageBlobForPendingList(blob)
+                        .then(function (dataUrl) {
+                            mod.addScreenshotToList(dataUrl);
                             window.showStatusToast(
                                 window.t ? window.t('app.screenshotAdded') : '\u622A\u56FE\u5DF2\u6DFB\u52A0\uFF0C\u70B9\u51FB\u53D1\u9001\u4E00\u8D77\u53D1\u9001',
                                 3000
                             );
-                        }
-                    };
-                    reader.onerror = function () {
-                        console.warn('[粘贴] 读取剪贴板图片失败');
-                    };
-                    reader.readAsDataURL(blob);
+                        })
+                        .catch(function (error) {
+                            console.warn('[粘贴] 图片处理失败:', error);
+                            window.showStatusToast(
+                                window.t ? window.t('app.importImageFailed') : '导入图片失败',
+                                4000
+                            );
+                        });
                     break;
                 }
             }

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -105,7 +105,12 @@
         context.fillStyle = '#fff';
         context.fillRect(0, 0, width, height);
         context.drawImage(image, 0, 0, width, height);
-        var dataUrl = canvas.toDataURL('image/jpeg', quality);
+        var dataUrl = '';
+        try {
+            dataUrl = canvas.toDataURL('image/jpeg', quality);
+        } catch (_) {
+            throw new Error('IMAGE_ENCODE_FAILED');
+        }
         if (!/^data:image\/[a-z0-9.+-]+;base64,/i.test(dataUrl)) {
             throw new Error('IMAGE_ENCODE_FAILED');
         }

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -220,6 +220,47 @@ def test_import_image_without_mime_converts_to_jpeg_attachment(
 
 
 @pytest.mark.frontend
+def test_import_rejects_canvas_data_url_encode_fallback(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
+            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const file = new File([bytes], 'tiny-image', { type: '' });
+            const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+            let rejected = false;
+            let errorMessage = '';
+            try {
+                HTMLCanvasElement.prototype.toDataURL = function () {
+                    return 'data:,';
+                };
+                await window.appButtons.importImageFileToPendingList(file);
+            } catch (error) {
+                rejected = true;
+                errorMessage = String(error && error.message ? error.message : error);
+            } finally {
+                HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+            }
+            const state = window.reactChatWindowHost.getState();
+            return {
+                rejected,
+                errorMessage,
+                attachmentCount: state.composerAttachments.length
+            };
+        }"""
+    )
+
+    assert result["rejected"] is True
+    assert result["errorMessage"] == "IMAGE_ENCODE_FAILED"
+    assert result["attachmentCount"] == 0
+
+
+@pytest.mark.frontend
 def test_import_jpeg_under_limit_keeps_original_data(
     mock_page: Page,
     running_server: str,

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -261,6 +261,47 @@ def test_import_rejects_canvas_data_url_encode_fallback(
 
 
 @pytest.mark.frontend
+def test_import_rejects_canvas_encode_throw(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
+            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const file = new File([bytes], 'tiny-image', { type: '' });
+            const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+            let rejected = false;
+            let errorMessage = '';
+            try {
+                HTMLCanvasElement.prototype.toDataURL = function () {
+                    throw new Error('canvas encode exploded');
+                };
+                await window.appButtons.importImageFileToPendingList(file);
+            } catch (error) {
+                rejected = true;
+                errorMessage = String(error && error.message ? error.message : error);
+            } finally {
+                HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+            }
+            const state = window.reactChatWindowHost.getState();
+            return {
+                rejected,
+                errorMessage,
+                attachmentCount: state.composerAttachments.length
+            };
+        }"""
+    )
+
+    assert result["rejected"] is True
+    assert result["errorMessage"] == "IMAGE_ENCODE_FAILED"
+    assert result["attachmentCount"] == 0
+
+
+@pytest.mark.frontend
 def test_import_jpeg_under_limit_keeps_original_data(
     mock_page: Page,
     running_server: str,
@@ -295,6 +336,78 @@ def test_import_jpeg_under_limit_keeps_original_data(
 
     assert result["attachmentCount"] == 1
     assert result["imported"] == result["original"]
+
+
+@pytest.mark.frontend
+def test_import_jpeg_over_limit_compresses_attachment(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const limitBytes = 10 * 1024 * 1024;
+            const dataUrlBytes = (dataUrl) => {
+                const b64 = String(dataUrl || '').split(',')[1] || '';
+                const padding = b64.endsWith('==') ? 2 : (b64.endsWith('=') ? 1 : 0);
+                return Math.max(0, Math.floor(b64.length * 3 / 4) - padding);
+            };
+            const makeNoisyJpeg = (size) => {
+                const canvas = document.createElement('canvas');
+                canvas.width = size;
+                canvas.height = size;
+                const context = canvas.getContext('2d');
+                const imageData = context.createImageData(size, size);
+                const pixels = imageData.data;
+                for (let y = 0; y < size; y += 1) {
+                    for (let x = 0; x < size; x += 1) {
+                        const offset = (y * size + x) * 4;
+                        const value = (x * 17 + y * 31 + ((x ^ y) * 13)) & 255;
+                        pixels[offset] = value;
+                        pixels[offset + 1] = (value * 7 + x) & 255;
+                        pixels[offset + 2] = (value * 13 + y) & 255;
+                        pixels[offset + 3] = 255;
+                    }
+                }
+                context.putImageData(imageData, 0, 0);
+                return canvas.toDataURL('image/jpeg', 1);
+            };
+
+            let original = makeNoisyJpeg(3072);
+            if (dataUrlBytes(original) <= limitBytes) {
+                original = makeNoisyJpeg(4096);
+            }
+            const originalBytes = dataUrlBytes(original);
+            if (originalBytes <= limitBytes) {
+                throw new Error(`Expected source JPEG to exceed 10MB, got ${originalBytes}`);
+            }
+
+            const response = await fetch(original);
+            const blob = await response.blob();
+            const file = new File([blob], 'big.jpg', { type: 'image/jpeg' });
+            await window.appButtons.importImageFileToPendingList(file);
+            const state = window.reactChatWindowHost.getState();
+            if (state.composerAttachments.length !== 1) {
+                throw new Error(`Expected one composer attachment, got ${state.composerAttachments.length}`);
+            }
+            const imported = state.composerAttachments[0] && state.composerAttachments[0].url;
+            return {
+                attachmentCount: state.composerAttachments.length,
+                originalBytes,
+                importedBytes: dataUrlBytes(imported),
+                importedChanged: imported !== original,
+                importedIsJpeg: String(imported || '').startsWith('data:image/jpeg;base64,')
+            };
+        }"""
+    )
+
+    assert result["attachmentCount"] == 1
+    assert result["originalBytes"] > 10 * 1024 * 1024
+    assert result["importedBytes"] <= 10 * 1024 * 1024
+    assert result["importedChanged"] is True
+    assert result["importedIsJpeg"] is True
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -200,17 +200,22 @@ def test_import_image_without_mime_converts_to_jpeg_attachment(
     _open_react_chat_page(mock_page, running_server)
     _install_chat_send_harness(mock_page)
 
-    attachment_url = mock_page.evaluate(
+    import_result = mock_page.evaluate(
         """async () => {
             const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
             const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
             const file = new File([bytes], 'tiny-image', { type: '' });
             await window.appButtons.importImageFileToPendingList(file);
             const state = window.reactChatWindowHost.getState();
-            return state.composerAttachments[0] && state.composerAttachments[0].url;
+            return {
+                attachmentCount: state.composerAttachments.length,
+                attachmentUrl: state.composerAttachments[0] && state.composerAttachments[0].url
+            };
         }"""
     )
 
+    assert import_result["attachmentCount"] == 1
+    attachment_url = import_result["attachmentUrl"]
     assert attachment_url.startswith("data:image/jpeg;base64,")
 
 
@@ -236,14 +241,52 @@ def test_import_jpeg_under_limit_keeps_original_data(
             const file = new File([bytes], 'tiny.jpg', { type: 'image/jpeg' });
             await window.appButtons.importImageFileToPendingList(file);
             const state = window.reactChatWindowHost.getState();
+            if (state.composerAttachments.length !== 1) {
+                throw new Error(`Expected one composer attachment, got ${state.composerAttachments.length}`);
+            }
             return {
                 original,
+                attachmentCount: state.composerAttachments.length,
                 imported: state.composerAttachments[0] && state.composerAttachments[0].url
             };
         }"""
     )
 
+    assert result["attachmentCount"] == 1
     assert result["imported"] == result["original"]
+
+
+@pytest.mark.frontend
+def test_normalized_pending_image_clears_stale_avatar_position(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    result = mock_page.evaluate(
+        """async () => {
+            window.appButtons.addScreenshotToList(
+                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=',
+                { left: 10, top: 20, width: 30, height: 40 }
+            );
+            const item = document.querySelector('#screenshots-list').children[0];
+            const hadAvatarPositionBefore = Object.prototype.hasOwnProperty.call(item.dataset, 'avatarPosition');
+            await window.appButtons.normalizeAllPendingComposerAttachments();
+            const state = window.reactChatWindowHost.getState();
+            return {
+                attachmentCount: state.composerAttachments.length,
+                hadAvatarPositionBefore,
+                hasAvatarPositionAfter: Object.prototype.hasOwnProperty.call(item.dataset, 'avatarPosition'),
+                attachmentUrl: state.composerAttachments[0] && state.composerAttachments[0].url
+            };
+        }"""
+    )
+
+    assert result["attachmentCount"] == 1
+    assert result["hadAvatarPositionBefore"] is True
+    assert result["hasAvatarPositionAfter"] is False
+    assert result["attachmentUrl"].startswith("data:image/jpeg;base64,")
 
 
 @pytest.mark.frontend

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -193,6 +193,60 @@ def test_react_composer_text_submit_uses_single_stable_user_message(
 
 
 @pytest.mark.frontend
+def test_import_image_without_mime_converts_to_jpeg_attachment(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    attachment_url = mock_page.evaluate(
+        """async () => {
+            const b64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=';
+            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const file = new File([bytes], 'tiny-image', { type: '' });
+            await window.appButtons.importImageFileToPendingList(file);
+            const state = window.reactChatWindowHost.getState();
+            return state.composerAttachments[0] && state.composerAttachments[0].url;
+        }"""
+    )
+
+    assert attachment_url.startswith("data:image/jpeg;base64,")
+
+
+@pytest.mark.frontend
+def test_import_jpeg_under_limit_keeps_original_data(
+    mock_page: Page,
+    running_server: str,
+):
+    _open_react_chat_page(mock_page, running_server)
+    _install_chat_send_harness(mock_page)
+
+    result = mock_page.evaluate(
+        """async () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 2;
+            canvas.height = 2;
+            const context = canvas.getContext('2d');
+            context.fillStyle = '#336699';
+            context.fillRect(0, 0, 2, 2);
+            const original = canvas.toDataURL('image/jpeg', 0.92);
+            const b64 = original.split(',')[1];
+            const bytes = Uint8Array.from(atob(b64), (char) => char.charCodeAt(0));
+            const file = new File([bytes], 'tiny.jpg', { type: 'image/jpeg' });
+            await window.appButtons.importImageFileToPendingList(file);
+            const state = window.reactChatWindowHost.getState();
+            return {
+                original,
+                imported: state.composerAttachments[0] && state.composerAttachments[0].url
+            };
+        }"""
+    )
+
+    assert result["imported"] == result["original"]
+
+
+@pytest.mark.frontend
 def test_react_composer_text_and_screenshot_submit_keeps_single_combined_message(
     mock_page: Page,
     running_server: str,
@@ -236,8 +290,14 @@ def test_react_composer_text_and_screenshot_submit_keeps_single_combined_message
                 textBlocks: message && Array.isArray(message.blocks)
                     ? message.blocks.filter((block) => block.type === 'text').map((block) => block.text)
                     : [],
+                imageBlocks: message && Array.isArray(message.blocks)
+                    ? message.blocks.filter((block) => block.type === 'image').map((block) => block.url)
+                    : [],
                 composerAttachmentCount: state.composerAttachments.length,
-                userDomRows: document.querySelectorAll('article[data-message-role="user"]').length
+                userDomRows: document.querySelectorAll('article[data-message-role="user"]').length,
+                sentImages: window.__chatTest.sentPayloads
+                    .filter((payload) => payload.action === 'stream_data' && payload.input_type === 'screen')
+                    .map((payload) => payload.data)
             };
         }"""
     )
@@ -247,6 +307,10 @@ def test_react_composer_text_and_screenshot_submit_keeps_single_combined_message
     assert snapshot["author"] == "Alice"
     assert snapshot["blockTypes"] == ["text", "image"]
     assert snapshot["textBlocks"] == ["Look at this"]
+    assert len(snapshot["imageBlocks"]) == 1
+    assert snapshot["imageBlocks"][0].startswith("data:image/jpeg;base64,")
+    assert len(snapshot["sentImages"]) == 1
+    assert snapshot["sentImages"][0].startswith("data:image/jpeg;base64,")
     assert snapshot["composerAttachmentCount"] == 0
     assert snapshot["userDomRows"] == 1
 

--- a/tests/frontend/test_chat_user_message_dedup.py
+++ b/tests/frontend/test_chat_user_message_dedup.py
@@ -264,12 +264,21 @@ def test_normalized_pending_image_clears_stale_avatar_position(
     _open_react_chat_page(mock_page, running_server)
     _install_chat_send_harness(mock_page)
 
-    result = mock_page.evaluate(
-        """async () => {
+    mock_page.evaluate(
+        """() => {
             window.appButtons.addScreenshotToList(
                 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO9Wj3sAAAAASUVORK5CYII=',
                 { left: 10, top: 20, width: 30, height: 40 }
             );
+        }"""
+    )
+    mock_page.wait_for_function(
+        "() => document.querySelector('#screenshots-list')"
+        " && document.querySelector('#screenshots-list').children.length === 1"
+    )
+
+    result = mock_page.evaluate(
+        """async () => {
             const item = document.querySelector('#screenshots-list').children[0];
             const hadAvatarPositionBefore = Object.prototype.hasOwnProperty.call(item.dataset, 'avatarPosition');
             await window.appButtons.normalizeAllPendingComposerAttachments();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为待发送图片新增逐项与全量归一化/压缩流程：按大小和编码限制尝试转为 JPEG、按多档质量与比例重试、必要时更新缩略图并清理过期元数据；发送前会先归一化所有附件，归一化失败会中止发送并提示“导入图片失败”。
  * 扩展导入与粘贴支持的图片格式：粘贴与导入改为先归一化 Blob/DataURL 后入列，记录并提示批量导入失败数。

* **测试**
  * 新增前端用例，覆盖无 MIME 转换为 JPEG、Canvas 编码失败情形、超限压缩与保留原始 JPEG、以及归一化清理过期字段，并相应更新快照断言。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->