### PR TITLE
fix(game_agent_minecraft): plugin description 别再骗 analyzer 调 minecraft_task

### DIFF
--- a/plugin/plugins/game_agent_minecraft/plugin.toml
+++ b/plugin/plugins/game_agent_minecraft/plugin.toml
@@ -1,7 +1,7 @@
 [plugin]
 id = "game_agent_minecraft"
 name = "Minecraft 游戏代理"
-description = "桥接本地 Minecraft Agent (WebSocket)，让 AI 通过 minecraft_task 工具下达指令并实时观看游戏画面进行解说。"
+description = "桥接本地 Minecraft Agent，可查询游戏状态、查询库存、热更配置。"
 short_description = "Minecraft autonomous gameplay with voice commentary."
 keywords = ["minecraft", "game-agent", "autonomous"]
 version = "0.1.0"


### PR DESCRIPTION
## Summary
把 [plugin/plugins/game_agent_minecraft/plugin.toml](plugin/plugins/game_agent_minecraft/plugin.toml#L4) 顶层 `description` 改成纯 routing 用语，去掉"让 AI 通过 minecraft_task 工具下达指令"那句。

## Why
原文写「让 AI 通过 minecraft_task 工具下达指令并实时观看游戏画面进行解说」—— 这是 dialog-LLM 用语，写错了字段：

- `plugin.toml` 顶层 `description` 事实上是 **analyzer-only**：[main_logic/core.py:4161-4194](main_logic/core.py:4161) 的 `_fetch_plugin_summary_prompt()` 直接 `return ""`（产品决策：do not include plugin IDs in agent prompt），dialog LLM 只通过 `ToolDefinition`（来自 `@llm_tool(description=...)` 装饰器，[main_logic/tool_calling.py:38](main_logic/tool_calling.py:38)）看到 tool 自己的 description。所以 dialog LLM 看不到 plugin.toml 这条 description，写在这里给 dialog 用是无效的。
- analyzer 看见了又调不了 `minecraft_task`（它是 `@llm_tool` 注册的，被 `_http_plugin_provider` 的 entry 层过滤剥掉）。结果 analyzer LLM 读 description 里的字面 `minecraft_task` → 当 entry_id 拍出去 → 严格匹配拒掉 → retry → 第二轮判 `has_task=false` → 用户请求被丢，~10s 浪费 + 成功率下降。

最小修复：单 plugin patch，改这一行。dialog-LLM 那侧的语义提示已经在 `@llm_tool(description=MINECRAFT_TASK_DESCRIPTION)`（[__init__.py:225](plugin/plugins/game_agent_minecraft/__init__.py#L225)）里，无需补。

## Test plan
- [x] toml 解析 OK（只改了一行字符串值）
- [ ] 手验：开启 user_plugin、跑一句"我饿了找点吃的"，确认 analyzer 不再误调 `minecraft_task`

## 历史
此前 [#1386](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1386) 把这当 plugin 系统边界 bug，加了 description sanitize + 七语种 prompt 规则，方向错了 —— 已 close。问题就是 plugin 作者把 dialog 用语写错了字段，单 plugin 改一行就完。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了 Minecraft Agent 插件的描述信息，强调了支持本地 Agent 桥接、游戏状态查询、库存检查和配置热更新等功能。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->