### PR TITLE
fix(config): core=free 不再强制覆盖辅助 API 选择

### DIFF
--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -1462,18 +1462,13 @@ function toggleCustomApi(skipAutoFill) {
     const isFreeVersion = coreApiSelect && coreApiSelect.value === 'free';
 
     // 禁用或启用相关控件
+    // core=free 时只锁核心 API Key 输入（free-access 不需要用户填），
+    // 辅助 API 选择器和辅助 Key 输入保持可用，让用户能搭「免费 realtime + 付费 assist」。
     const assistApiKeyInput = document.getElementById('assistApiKeyInput');
-    if (isFreeVersion) {
-        if (assistApiSelect) assistApiSelect.disabled = true;
-        if (apiKeyInput) apiKeyInput.disabled = true;
-        if (assistApiKeyInput) assistApiKeyInput.disabled = true;
-        if (coreApiSelect) coreApiSelect.disabled = false;
-    } else {
-        if (coreApiSelect) coreApiSelect.disabled = false;
-        if (assistApiSelect) assistApiSelect.disabled = false;
-        if (apiKeyInput) apiKeyInput.disabled = false;
-        if (assistApiKeyInput) assistApiKeyInput.disabled = false;
-    }
+    if (coreApiSelect) coreApiSelect.disabled = false;
+    if (assistApiSelect) assistApiSelect.disabled = false;
+    if (assistApiKeyInput) assistApiKeyInput.disabled = false;
+    if (apiKeyInput) apiKeyInput.disabled = isFreeVersion;
 
     // 控制自定义API容器的折叠状态
     const customApiContainer = document.getElementById('custom-api-container');
@@ -1981,17 +1976,26 @@ function updateAssistApiRecommendation() {
             apiKeyInput.required = false;
             apiKeyInput.value = window.t ? window.t('api.freeVersionNoApiKey') : '免费版无需API Key';
         }
+        // 辅助 API 与核心 API 解耦：core=free 仅锁核心 API Key（免费 realtime 不需要 key），
+        // 辅助 API 选择器和辅助 Key 输入保持可用，允许「免费 realtime + 付费 assist/Agent」组合。
         if (assistApiKeyInput) {
-            assistApiKeyInput.disabled = true;
-            assistApiKeyInput.value = '';
+            assistApiKeyInput.disabled = false;
         }
         if (freeVersionHint) {
             freeVersionHint.style.display = 'inline';
         }
 
-        // 禁用辅助API选择框，强制为免费版
-        assistApiSelect.disabled = true;
-        assistApiSelect.value = 'free';
+        assistApiSelect.disabled = false;
+        // free 选项保持可用——core=free 时它是合理默认；用户也能切换到其它 provider。
+        const freeOption = assistApiSelect.querySelector('option[value="free"]');
+        if (freeOption) {
+            freeOption.disabled = false;
+            freeOption.textContent = window.t ? window.t('api.freeVersion') : '免费版';
+        }
+        // 用户未显式选择 assist 时默认填 'free'，保持原免费版一键到位体验。
+        if (!assistApiSelect.value) {
+            assistApiSelect.value = 'free';
+        }
         // Directly recompute follow_assist slots instead of dispatching a change
         // event, which would re-enter updateAssistApiRecommendation() recursively.
         autoFillAssistApiKey();

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -250,22 +250,38 @@ class TestCustomApiToggle:
 
 
 # ---------------------------------------------------------------------------
-# 3. Assist follows core when free
+# 3. Assist / Core 独立选择
 # ---------------------------------------------------------------------------
 class TestAssistFollowsCore:
 
     @pytest.mark.unit
-    def test_free_core_forces_free_assist(self, config_manager):
-        """coreApi=free → assistApi forced to free regardless of saved value."""
+    def test_free_core_defaults_assist_to_free_when_empty(self, config_manager):
+        """coreApi=free + assistApi='' → 空值兜底为 free（保持免费版一键到位体验）。"""
         _write_core_config(config_manager, {
             'coreApiKey': 'free-access',
             'coreApi': 'free',
-            'assistApi': 'qwen',  # User saved qwen, but core is free
+            'assistApi': '',
         })
         cfg = config_manager.get_core_config()
 
-        assert cfg['assistApi'] == 'free', \
-            'When core is free, assist must be forced to free'
+        assert cfg['assistApi'] == 'free'
+        assert cfg.get('IS_FREE_VERSION') is True
+
+    @pytest.mark.unit
+    def test_free_core_honors_explicit_assist(self, config_manager):
+        """coreApi=free + assistApi=silicon → 显式选择被保留，agent/text 走 silicon。"""
+        _write_core_config(config_manager, {
+            'coreApiKey': 'free-access',
+            'coreApi': 'free',
+            'assistApi': 'silicon',
+            'assistApiKeySilicon': 'sk-silicon-test',
+        })
+        cfg = config_manager.get_core_config()
+
+        assert cfg['assistApi'] == 'silicon', \
+            'core=free 不应强制覆盖用户显式选择的 assist'
+        assert cfg['OPENROUTER_URL'] == 'https://api.siliconflow.cn/v1'
+        # core profile 仍然给到 IS_FREE_VERSION=True（realtime 是免费的）
         assert cfg.get('IS_FREE_VERSION') is True
 
     @pytest.mark.unit

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3051,11 +3051,14 @@ class ConfigManager:
             config.update(core_profile)
 
         # Assist API profile
+        # 显式选择的 assistApi 一律被尊重，即使 coreApi=free。这样用户可以组合
+        # 「免费实时（core=free）+ 付费文本/Agent（assist=qwen 等）」——免费 realtime
+        # 端点和付费 assist 端点是独立的两条链路，没有理由把后者绑死在 free 上。
+        # 仅当用户没有显式选 assist 时，沿用 coreApi 的偏好做默认：core=free 默认 free，
+        # 其他默认 qwen。
         assist_api_value = core_cfg.get('assistApi')
-        if core_api_value == 'free':
-            assist_api_value = 'free'
         if not assist_api_value:
-            assist_api_value = 'qwen'
+            assist_api_value = 'free' if core_api_value == 'free' else 'qwen'
 
         config['assistApi'] = assist_api_value
 


### PR DESCRIPTION
## Summary

- `coreApi=free` 时不再把 `assistApi` 硬覆盖成 `free`：用户显式选的百炼 / silicon / glm 等被尊重，agent 槽位走对应 provider 而非 `free-agent-model`
- 前端 `coreApi=free` 时只锁核心 API Key 输入，辅助 API 选择器与辅助 Key 输入保持可用；`free` 选项保留为合理默认
- 旧行为下，配置里写了 `assistApi=silicon` 也会被吞，导致猫爪面板里的 `computer_use` / `browser_use` 跟着 free 端点跑而非用户实际付费的 provider；现在断了这条耦合

## 改动

- [utils/config_manager.py](utils/config_manager.py): 去掉 `if core_api_value == 'free': assist_api_value = 'free'` 硬覆盖，仅当 assistApi 为空时按 core 偏好兜底
- [static/js/api_key_settings.js](static/js/api_key_settings.js): `toggleCustomApi` / `updateAssistApiRecommendation` 不再因 `core=free` 禁用辅助选择器
- [tests/unit/test_api_config_manager.py](tests/unit/test_api_config_manager.py): 把 `test_free_core_forces_free_assist` 替换为 `test_free_core_honors_explicit_assist` + `test_free_core_defaults_assist_to_free_when_empty` 覆盖新语义

## Test plan

- [x] `pytest tests/unit/test_api_config_manager.py::TestAssistFollowsCore` 三个用例通过
- [ ] UI 手动验证：API 设置页选 core=free，确认辅助 API 下拉可点；切到 silicon/qwen 后保存，看猫爪键鼠/浏览器开关是否切到对应 provider
- [ ] 已有 `coreApi=free + assistApi=free` 的免费版用户启动后行为不变（assist 仍走 free 端点）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

**改进**
- 优化了自定义 API 配置的灵活性：当使用免费核心 API 时，辅助 API 不再被强制锁定为免费版本，允许用户自由选择和组合不同的 API 方案。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->