### PR TITLE
fix(galgame): 增加选项生成的最大令牌数和超时时间，优化部分解析逻辑以支持从后备填充选项

### DIFF
--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -14,6 +14,7 @@ URL convention: routes declared WITHOUT trailing slash. See the project
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from typing import Any
 
@@ -109,6 +110,21 @@ def _strip_code_fence(text: str) -> str:
     return text.strip()
 
 
+def _take_label_map(obj: Any) -> dict[str, str]:
+    """Pull canonical A/B/C label→text entries out of a dict, if any."""
+    if not isinstance(obj, dict):
+        return {}
+    collected: dict[str, str] = {}
+    for label in GALGAME_OPTION_LABELS:
+        # Accept both upper and lower-case keys ("a"/"A").
+        value = obj.get(label)
+        if not isinstance(value, str):
+            value = obj.get(label.lower())
+        if isinstance(value, str) and value.strip():
+            collected[label] = value.strip()
+    return collected
+
+
 def _normalize_options(parsed: Any) -> dict[str, str]:
     """Best-effort parse: return whatever label→text mappings the model produced.
 
@@ -116,9 +132,25 @@ def _normalize_options(parsed: Any) -> dict[str, str]:
     keyed by canonical labels (A/B/C). Callers fill missing labels from
     fallback rather than throwing the whole batch away — preserves any
     on-style replies the model did manage to generate.
+
+    Accepted shapes (in priority order):
+      * ``{"A": "...", "B": "...", "C": "..."}`` (top-level label map)
+      * ``{"options": {"A": "...", ...}}`` (nested label map)
+      * ``{"options": [{"label": "A", "text": "..."}, ...]}`` (canonical list)
+      * ``{"options": ["serious", "warm", "wild"]}`` (positional list)
+      * Top-level list of either dict or string entries
     """
+    # Shape 1: top-level dict is already a label map.
+    direct = _take_label_map(parsed)
+    if direct:
+        return direct
+
     if isinstance(parsed, dict):
         candidates = parsed.get('options') or parsed.get('candidates') or parsed.get('replies')
+        # Shape 2: the inner container is itself a label map.
+        nested = _take_label_map(candidates)
+        if nested:
+            return nested
     else:
         candidates = parsed
     if not isinstance(candidates, list):
@@ -270,15 +302,19 @@ async def generate_galgame_options(request: Request):
             parse_error = type(exc).__name__
 
     if not parsed_map:
-        # Log a single-line head of the raw output so future failures can be
-        # diagnosed without forcing DEBUG. Truncate to keep PII / long output
-        # out of the log file.
-        snippet = re.sub(r'\s+', ' ', raw_text)[:200]
+        # The raw output is generated from recent chat context and can carry
+        # PII (names, personal disclosures). Keep INFO logs content-free —
+        # only the parse-error class and total length — and stash the
+        # truncated snippet under DEBUG so deeper diagnosis still works when
+        # an operator deliberately opts into NEKO_LOG_LEVEL=DEBUG.
         logger.info(
             "GalGame model output unparseable, using fallback "
-            "(parse_error=%s raw_head=%r raw_len=%d)",
-            parse_error, snippet, len(raw_text),
+            "(parse_error=%s raw_len=%d)",
+            parse_error, len(raw_text),
         )
+        if logger.isEnabledFor(logging.DEBUG):
+            snippet = re.sub(r'\s+', ' ', raw_text)[:200]
+            logger.debug("GalGame unparseable raw_head: %r", snippet)
         return JSONResponse({
             "success": True,
             "options": _fallback_options(lang),

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -43,8 +43,8 @@ logger = get_module_logger(__name__, "GalGame")
 
 GALGAME_MAX_HISTORY = 8
 GALGAME_MAX_TEXT_PER_TURN = 240
-GALGAME_OPTION_MAX_TOKENS = 360
-GALGAME_OPTION_TIMEOUT_SECONDS = 5.0
+GALGAME_OPTION_MAX_TOKENS = 600
+GALGAME_OPTION_TIMEOUT_SECONDS = 10.0
 GALGAME_OPTION_LABELS = ("A", "B", "C")
 
 
@@ -109,13 +109,20 @@ def _strip_code_fence(text: str) -> str:
     return text.strip()
 
 
-def _normalize_options(parsed: Any) -> list[dict[str, str]]:
+def _normalize_options(parsed: Any) -> dict[str, str]:
+    """Best-effort parse: return whatever label→text mappings the model produced.
+
+    Returns an empty dict if nothing salvageable, otherwise a 1-3 entry dict
+    keyed by canonical labels (A/B/C). Callers fill missing labels from
+    fallback rather than throwing the whole batch away — preserves any
+    on-style replies the model did manage to generate.
+    """
     if isinstance(parsed, dict):
         candidates = parsed.get('options') or parsed.get('candidates') or parsed.get('replies')
     else:
         candidates = parsed
     if not isinstance(candidates, list):
-        return []
+        return {}
 
     by_label: dict[str, str] = {}
     leftover: list[str] = []
@@ -139,15 +146,11 @@ def _normalize_options(parsed: Any) -> list[dict[str, str]]:
         else:
             leftover.append(text)
 
-    options: list[dict[str, str]] = []
     for label in GALGAME_OPTION_LABELS:
-        text = by_label.get(label)
-        if text is None and leftover:
-            text = leftover.pop(0)
-        if text is None:
-            return []
-        options.append({'label': label, 'text': text})
-    return options
+        if label in by_label or not leftover:
+            continue
+        by_label[label] = leftover.pop(0)
+    return by_label
 
 
 def _fallback_options(lang: str) -> list[dict[str, str]]:
@@ -257,19 +260,52 @@ async def generate_galgame_options(request: Request):
 
     raw_text = (getattr(result, 'content', '') or '').strip()
     cleaned = _strip_code_fence(raw_text)
-    options: list[dict[str, str]] = []
+    parsed_map: dict[str, str] = {}
+    parse_error: str | None = None
     if cleaned:
         try:
             parsed = robust_json_loads(cleaned)
-            options = _normalize_options(parsed)
-        except Exception:
-            options = []
-    if not options:
-        logger.info("GalGame model output unparseable, using fallback")
+            parsed_map = _normalize_options(parsed)
+        except Exception as exc:
+            parse_error = type(exc).__name__
+
+    if not parsed_map:
+        # Log a single-line head of the raw output so future failures can be
+        # diagnosed without forcing DEBUG. Truncate to keep PII / long output
+        # out of the log file.
+        snippet = re.sub(r'\s+', ' ', raw_text)[:200]
+        logger.info(
+            "GalGame model output unparseable, using fallback "
+            "(parse_error=%s raw_head=%r raw_len=%d)",
+            parse_error, snippet, len(raw_text),
+        )
         return JSONResponse({
             "success": True,
             "options": _fallback_options(lang),
             "fallback": True,
+        })
+
+    fallback_texts = get_galgame_fallback_options(lang)
+    options: list[dict[str, str]] = []
+    missing_labels: list[str] = []
+    for label, fb_text in zip(GALGAME_OPTION_LABELS, fallback_texts):
+        text = parsed_map.get(label)
+        if text:
+            options.append({'label': label, 'text': text})
+        else:
+            options.append({'label': label, 'text': fb_text})
+            missing_labels.append(label)
+
+    if missing_labels:
+        logger.info(
+            "GalGame partial parse: model returned %d/3 options; filled %s from fallback",
+            3 - len(missing_labels), missing_labels,
+        )
+        return JSONResponse({
+            "success": True,
+            "options": options,
+            "partial": True,
+            "missing_labels": missing_labels,
         })
 
     return JSONResponse({"success": True, "options": options})

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -180,10 +180,17 @@ def _normalize_options(parsed: Any) -> dict[str, str]:
             if not text:
                 continue
             normalized_label = str(label).strip().upper() if label else ''
-            if normalized_label in GALGAME_OPTION_LABELS and normalized_label not in by_label:
-                by_label[normalized_label] = text
-            else:
-                leftover.append(text)
+            if normalized_label in GALGAME_OPTION_LABELS:
+                # Recognised label. Take it only if no stronger source
+                # (top-level / nested map / earlier list entry) already
+                # provided this slot. Never push a labeled-but-duplicate
+                # entry into leftover — the model intended this text for
+                # one specific style, and reusing it as a positional fill
+                # for a different label mis-attributes that style.
+                if normalized_label not in by_label:
+                    by_label[normalized_label] = text
+                continue
+            leftover.append(text)
 
         for label in GALGAME_OPTION_LABELS:
             if label in by_label or not leftover:

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -133,55 +133,63 @@ def _normalize_options(parsed: Any) -> dict[str, str]:
     fallback rather than throwing the whole batch away — preserves any
     on-style replies the model did manage to generate.
 
-    Accepted shapes (in priority order):
+    All recognised shapes are *merged*, not selected, so mixed payloads
+    like ``{"A": "topA", "options": [{"label":"B","text":"..."}, ...]}``
+    keep both the top-level label and the nested list candidates instead
+    of one source silently shadowing the other. First write wins on
+    same-label conflicts (top-level > nested-map > list).
+
+    Accepted shapes:
       * ``{"A": "...", "B": "...", "C": "..."}`` (top-level label map)
       * ``{"options": {"A": "...", ...}}`` (nested label map)
       * ``{"options": [{"label": "A", "text": "..."}, ...]}`` (canonical list)
       * ``{"options": ["serious", "warm", "wild"]}`` (positional list)
       * Top-level list of either dict or string entries
+      * Any mix of the above
     """
-    # Shape 1: top-level dict is already a label map.
-    direct = _take_label_map(parsed)
-    if direct:
-        return direct
+    by_label: dict[str, str] = {}
+
+    # Shape 1: top-level dict carries A/B/C directly.
+    by_label.update(_take_label_map(parsed))
 
     if isinstance(parsed, dict):
         candidates = parsed.get('options') or parsed.get('candidates') or parsed.get('replies')
-        # Shape 2: the inner container is itself a label map.
-        nested = _take_label_map(candidates)
-        if nested:
-            return nested
     else:
         candidates = parsed
-    if not isinstance(candidates, list):
-        return {}
 
-    by_label: dict[str, str] = {}
-    leftover: list[str] = []
-    for entry in candidates:
-        if isinstance(entry, dict):
-            text = entry.get('text') or entry.get('content') or entry.get('reply')
-            label = entry.get('label')
-        elif isinstance(entry, str):
-            text = entry
-            label = None
-        else:
-            continue
-        if not isinstance(text, str):
-            continue
-        text = text.strip()
-        if not text:
-            continue
-        normalized_label = str(label).strip().upper() if label else ''
-        if normalized_label in GALGAME_OPTION_LABELS and normalized_label not in by_label:
-            by_label[normalized_label] = text
-        else:
-            leftover.append(text)
+    # Shape 2: the inner container is itself a label map. Don't clobber any
+    # top-level entry — first write wins.
+    for label, text in _take_label_map(candidates).items():
+        by_label.setdefault(label, text)
 
-    for label in GALGAME_OPTION_LABELS:
-        if label in by_label or not leftover:
-            continue
-        by_label[label] = leftover.pop(0)
+    # Shape 3/4/5: list of dict (with `label`) or string entries.
+    if isinstance(candidates, list):
+        leftover: list[str] = []
+        for entry in candidates:
+            if isinstance(entry, dict):
+                text = entry.get('text') or entry.get('content') or entry.get('reply')
+                label = entry.get('label')
+            elif isinstance(entry, str):
+                text = entry
+                label = None
+            else:
+                continue
+            if not isinstance(text, str):
+                continue
+            text = text.strip()
+            if not text:
+                continue
+            normalized_label = str(label).strip().upper() if label else ''
+            if normalized_label in GALGAME_OPTION_LABELS and normalized_label not in by_label:
+                by_label[normalized_label] = text
+            else:
+                leftover.append(text)
+
+        for label in GALGAME_OPTION_LABELS:
+            if label in by_label or not leftover:
+                continue
+            by_label[label] = leftover.pop(0)
+
     return by_label
 
 

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import sys
 from types import SimpleNamespace
@@ -172,6 +173,63 @@ async def test_galgame_option_generation_timeout_returns_fallback(monkeypatch):
     }
 
 
+@pytest.mark.parametrize(
+    "model_output, expected",
+    [
+        # Shape A: top-level label-keyed dict
+        (
+            {"A": "先确认你刚才说的重点。", "B": "我在这里陪你慢慢说。", "C": "那就把它变成月亮地图吧。"},
+            ["先确认你刚才说的重点。", "我在这里陪你慢慢说。", "那就把它变成月亮地图吧。"],
+        ),
+        # Shape B: nested label-keyed dict under "options"
+        (
+            {"options": {"A": "认真听。", "B": "陪着你。", "C": "幻想一下。"}},
+            ["认真听。", "陪着你。", "幻想一下。"],
+        ),
+    ],
+    ids=["top_level_label_map", "nested_label_map"],
+)
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_galgame_accepts_dict_shaped_options(model_output, expected, monkeypatch):
+    """Some models emit option maps instead of canonical lists. Don't discard them."""
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+
+    class MapLLM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def ainvoke(self, messages):
+            return SimpleNamespace(content=json.dumps(model_output, ensure_ascii=False))
+
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: MapLLM())
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
+                "language": "zh-CN",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert data["success"] is True
+    assert "fallback" not in data
+    assert "partial" not in data
+    assert _option_texts(data) == expected
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_galgame_partial_options_filled_from_fallback(monkeypatch):
@@ -226,8 +284,10 @@ async def test_galgame_partial_options_filled_from_fallback(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_galgame_unparseable_output_returns_fallback(monkeypatch):
-    """Garbage output → full fallback, and the warning carries a raw_head snippet."""
+async def test_galgame_unparseable_output_returns_fallback(monkeypatch, caplog):
+    """Garbage output → full fallback. INFO log must carry metadata only,
+    never the raw model text (privacy: the raw output is generated from
+    recent chat context)."""
     config_manager = FakeConfigManager(
         {
             "model": "local-summary",
@@ -235,6 +295,8 @@ async def test_galgame_unparseable_output_returns_fallback(monkeypatch):
             "api_key": "",
         }
     )
+
+    raw_content = "抱歉，我不太理解你的问题。"
 
     class GarbageLLM:
         async def __aenter__(self):
@@ -244,24 +306,38 @@ async def test_galgame_unparseable_output_returns_fallback(monkeypatch):
             return None
 
         async def ainvoke(self, messages):
-            return SimpleNamespace(content="抱歉，我不太理解你的问题。")
+            return SimpleNamespace(content=raw_content)
 
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
     monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: GarbageLLM())
 
-    response = await galgame_router.generate_galgame_options(
-        FakeRequest(
-            {
-                "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
-                "language": "zh-CN",
-            }
+    with caplog.at_level(logging.INFO, logger=galgame_router.logger.name):
+        response = await galgame_router.generate_galgame_options(
+            FakeRequest(
+                {
+                    "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
+                    "language": "zh-CN",
+                }
+            )
         )
-    )
 
     data = _decode_response(response)
     assert data["success"] is True
     assert data["fallback"] is True
     assert _option_texts(data) == list(get_galgame_fallback_options("zh"))
+
+    # The INFO-level fallback log records parse_error + raw_len, but must NOT
+    # leak the raw model output (it can carry conversational PII).
+    info_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.INFO and "unparseable" in record.getMessage()
+    ]
+    assert info_messages, "expected an INFO log entry on unparseable output"
+    joined = " ".join(info_messages)
+    assert "raw_len=" in joined
+    assert "parse_error=" in joined
+    assert raw_content not in joined
 
 
 @pytest.mark.unit

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -186,8 +186,37 @@ async def test_galgame_option_generation_timeout_returns_fallback(monkeypatch):
             {"options": {"A": "认真听。", "B": "陪着你。", "C": "幻想一下。"}},
             ["认真听。", "陪着你。", "幻想一下。"],
         ),
+        # Shape C: mixed — top-level provides A only, nested list provides B+C.
+        # All three sources must be merged (regression guard for the early-return bug).
+        (
+            {
+                "A": "先确认你刚才说的重点。",
+                "options": [
+                    {"label": "B", "text": "我在这里陪你慢慢说。"},
+                    {"label": "C", "text": "那就把它变成月亮地图吧。"},
+                ],
+            },
+            ["先确认你刚才说的重点。", "我在这里陪你慢慢说。", "那就把它变成月亮地图吧。"],
+        ),
+        # Shape D: top-level wins on same-label conflicts.
+        (
+            {
+                "A": "顶层 A 才是真正发送的。",
+                "options": [
+                    {"label": "A", "text": "嵌套 A 应当被忽略。"},
+                    {"label": "B", "text": "嵌套 B 正常使用。"},
+                    {"label": "C", "text": "嵌套 C 正常使用。"},
+                ],
+            },
+            ["顶层 A 才是真正发送的。", "嵌套 B 正常使用。", "嵌套 C 正常使用。"],
+        ),
     ],
-    ids=["top_level_label_map", "nested_label_map"],
+    ids=[
+        "top_level_label_map",
+        "nested_label_map",
+        "mixed_top_level_and_nested_list",
+        "top_level_wins_on_conflict",
+    ],
 )
 @pytest.mark.unit
 @pytest.mark.asyncio

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -261,6 +261,65 @@ async def test_galgame_accepts_dict_shaped_options(model_output, expected, monke
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_galgame_duplicate_labeled_entry_does_not_leak_to_other_labels(monkeypatch):
+    """A labeled entry whose slot is already filled must NOT be reused as positional
+    fill for a different label — the model intended that text for one specific style,
+    re-attributing it would mislabel the user-visible option."""
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+
+    class DupLLM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def ainvoke(self, messages):
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "A": "top",
+                        "options": [{"label": "A", "text": "dup"}],
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: DupLLM())
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "What do you think?"}],
+                "language": "en",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert data["success"] is True
+    assert data["partial"] is True
+    assert data["missing_labels"] == ["B", "C"]
+    texts = _option_texts(data)
+    fb = get_galgame_fallback_options("en")
+    assert texts[0] == "top"
+    # Critical: "dup" was labeled A — it must NEVER appear at B or C.
+    assert "dup" not in texts[1]
+    assert "dup" not in texts[2]
+    # Missing labels should be filled from the canonical fallback set.
+    assert texts[1] == fb[1]
+    assert texts[2] == fb[2]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_galgame_partial_options_filled_from_fallback(monkeypatch):
     """Model returned only A and B — C must be filled from fallback, not the whole batch discarded."""
     config_manager = FakeConfigManager(

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -174,6 +174,98 @@ async def test_galgame_option_generation_timeout_returns_fallback(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_galgame_partial_options_filled_from_fallback(monkeypatch):
+    """Model returned only A and B — C must be filled from fallback, not the whole batch discarded."""
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+
+    class PartialLLM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def ainvoke(self, messages):
+            return SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "options": [
+                            {"label": "A", "text": "先确认你刚才说的重点。"},
+                            {"label": "B", "text": "我在这里陪你慢慢说。"},
+                        ]
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: PartialLLM())
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
+                "language": "zh-CN",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert data["success"] is True
+    assert data["partial"] is True
+    assert data["missing_labels"] == ["C"]
+    fb = get_galgame_fallback_options("zh")
+    assert _option_texts(data) == ["先确认你刚才说的重点。", "我在这里陪你慢慢说。", fb[2]]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_galgame_unparseable_output_returns_fallback(monkeypatch):
+    """Garbage output → full fallback, and the warning carries a raw_head snippet."""
+    config_manager = FakeConfigManager(
+        {
+            "model": "local-summary",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "api_key": "",
+        }
+    )
+
+    class GarbageLLM:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def ainvoke(self, messages):
+            return SimpleNamespace(content="抱歉，我不太理解你的问题。")
+
+    monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
+    monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: GarbageLLM())
+
+    response = await galgame_router.generate_galgame_options(
+        FakeRequest(
+            {
+                "messages": [{"role": "assistant", "text": "刚才那件事你怎么看？"}],
+                "language": "zh-CN",
+            }
+        )
+    )
+
+    data = _decode_response(response)
+    assert data["success"] is True
+    assert data["fallback"] is True
+    assert _option_texts(data) == list(get_galgame_fallback_options("zh"))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_galgame_missing_model_base_url_returns_fallback(monkeypatch):
     monkeypatch.setattr(
         galgame_router,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能增强**
  * 提高 GalGame 选项生成的输出长度与超时，支持按标签解析并在部分成功时返回 partial 与 missing_labels；不可解析时返回 fallback 并包含 error 信息。

* **日志**
  * 增强解析失败时的结构化日志元信息（如错误类型与原始长度），同时避免泄露原始模型输出文本内容。

* **测试**
  * 新增并完善针对字典型输出、标签合并、部分填充与不可解析回退的单元测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->