### PR TITLE
将 memo_reminder、proactive_controller、game_agent_minecraft、lifekit 改为手…

### DIFF
--- a/plugin/plugins/game_agent_minecraft/plugin.toml
+++ b/plugin/plugins/game_agent_minecraft/plugin.toml
@@ -20,11 +20,8 @@ locales_dir = "i18n"
 
 [plugin_runtime]
 enabled = true
-# auto_start=true so plugin process spawns at NEKO startup and the WS
-# client to mc-agent is already connected by the time the first
-# minecraft_task call lands — saves the 3s lazy-start + WS handshake
-# every fresh-session would otherwise pay.
-auto_start = true
+# 手动启动，避免用户插件开启时默认拉起 Minecraft 代理。
+auto_start = false
 
 [plugin.store]
 enabled = true

--- a/plugin/plugins/lifekit/plugin.toml
+++ b/plugin/plugins/lifekit/plugin.toml
@@ -43,7 +43,7 @@ permissions = [
 
 [plugin_runtime]
 enabled = true
-auto_start = true
+auto_start = false
 
 [plugin.store]
 enabled = true

--- a/plugin/plugins/memo_reminder/plugin.toml
+++ b/plugin/plugins/memo_reminder/plugin.toml
@@ -20,7 +20,7 @@ locales_dir = "i18n"
 
 [plugin_runtime]
 enabled = true
-auto_start = true
+auto_start = false
 
 [plugin.store]
 enabled = true

--- a/plugin/plugins/proactive_controller/plugin.toml
+++ b/plugin/plugins/proactive_controller/plugin.toml
@@ -20,7 +20,7 @@ locales_dir = "i18n"
 
 [plugin_runtime]
 enabled = true
-auto_start = true
+auto_start = false
 
 [proactive_controller]
 default_mode_on_first_run = "off"


### PR DESCRIPTION
…动启动，避免用户插件开启时默认自动拉起

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **配置变更**
  * 调整了游戏代理、生活工具、备忘提醒和主动控制等多个插件的初始启动配置策略
  * 这些配置变更会影响相关功能模块的启动初始化行为

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->