### PR TITLE
fix(memory): ARM64 上正确识别 INT8 fast path，修 Apple Silicon 关 embedding

### DIFF
--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -300,16 +300,40 @@ def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
 def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
     """ARM64 INT8 fast path = ARMv8.2-A NEON sdot/udot (``asimddp`` feature).
 
-    Apple Silicon (M1+) and Windows-on-ARM (Snapdragon X / 8cx) ship
-    exclusively with dotprod-capable cores, so we short-circuit those
-    platforms to ``(True, True)``. On Linux we still scrutinise the
-    feature flag because the ARM SBC ecosystem includes plenty of
-    Cortex-A53/A57/A72 cores that predate dotprod — being optimistic
-    there would have us silently run the slow path on a Raspberry Pi 3.
+    Per-OS strategy:
+
+      * macOS — Apple Silicon (M1+) universally has dotprod; Apple has
+        never shipped an ARM Mac without it, so we short-circuit to
+        ``(True, True)``.
+      * Windows — use the canonical
+        ``IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE)``
+        kernel API. Modern Snapdragon X / 8cx have dotprod, but first-gen
+        Windows-on-ARM (Snapdragon 835, ~2017) is ARMv8-A and lacks it —
+        assuming support there would silently enable a slow INT8 path.
+      * Linux — check the ``asimddp`` / ``dotprod`` feature flag (cpuinfo
+        first, ``/proc/cpuinfo`` ``Features`` line as fallback). The ARM
+        SBC ecosystem still includes plenty of Cortex-A53 / A57 / A72
+        cores that predate dotprod (Raspberry Pi 3 class).
+
+    Returns ``(has_dotprod, absence_confirmed)``. Inconclusive cases let
+    ``auto`` quantization still pick int8 without claiming a definitive
+    answer.
     """
     system = platform.system()
-    if system in ("Darwin", "Windows"):
+    if system == "Darwin":
         return True, True
+
+    if system == "Windows":
+        try:
+            import ctypes
+            # PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE = 43 — the canonical
+            # Win32 feature constant for ARMv8.2 dotprod instructions.
+            has = bool(ctypes.windll.kernel32.IsProcessorFeaturePresent(43))
+            return has, True
+        except Exception:
+            # ctypes call failed on a non-standard runtime — be
+            # inconclusive rather than wrong in either direction.
+            return True, False
 
     if system == "Linux":
         try:
@@ -333,8 +357,7 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
             return False, False
 
     # Unknown OS on ARM64 — modern ARM64 almost certainly has dotprod,
-    # but we can't confirm. Inconclusive lets ``auto`` still pick int8
-    # without claiming a definitive answer.
+    # but we can't confirm.
     return True, False
 
 

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -268,20 +268,11 @@ def detect_total_ram_gb() -> float | None:
         return None
 
 
-def detect_avx_vnni_details() -> tuple[bool, bool]:
-    """Return ``(has_vnni, vnni_absence_confirmed)``.
+def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
+    """x86 INT8 fast path = AVX-VNNI (or AVX512-VNNI).
 
-    When ``vnni_absence_confirmed`` is False we could not read CPU flags
-    (should be rare now that ``py-cpuinfo`` is a required dependency).
-    ``auto`` quantization
-    still selects INT8 in that case — we only skip vectors when we are
-    *confident* the CPU lacks AVX-VNNI (INT8 would be slow and FP32 weights
-    are not shipped).
-
-    Detection priority:
-      1. ``py-cpuinfo``
-      2. ``/proc/cpuinfo`` on Linux
-      3. Otherwise inconclusive → ``(False, False)``
+    Returns ``(has_vnni, absence_confirmed)``. ``absence_confirmed=False``
+    means we could not read CPU flags (rare with py-cpuinfo as a hard dep).
     """
     try:
         import cpuinfo  # type: ignore
@@ -289,8 +280,7 @@ def detect_avx_vnni_details() -> tuple[bool, bool]:
         # Empty flags (e.g. some virtualised hosts) is *not* a confirmed
         # absence — fall through so /proc/cpuinfo can have a try.
         if flags:
-            has = any("vnni" in f for f in flags)
-            return has, True
+            return any("vnni" in f for f in flags), True
     except Exception:
         pass
 
@@ -305,6 +295,68 @@ def detect_avx_vnni_details() -> tuple[bool, bool]:
             return False, False
 
     return False, False
+
+
+def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
+    """ARM64 INT8 fast path = ARMv8.2-A NEON sdot/udot (``asimddp`` feature).
+
+    Apple Silicon (M1+) and Windows-on-ARM (Snapdragon X / 8cx) ship
+    exclusively with dotprod-capable cores, so we short-circuit those
+    platforms to ``(True, True)``. On Linux we still scrutinise the
+    feature flag because the ARM SBC ecosystem includes plenty of
+    Cortex-A53/A57/A72 cores that predate dotprod — being optimistic
+    there would have us silently run the slow path on a Raspberry Pi 3.
+    """
+    system = platform.system()
+    if system in ("Darwin", "Windows"):
+        return True, True
+
+    if system == "Linux":
+        try:
+            import cpuinfo  # type: ignore
+            flags = cpuinfo.get_cpu_info().get("flags", []) or []
+            if flags:
+                # py-cpuinfo surfaces ARM features under the same "flags" key.
+                return any(f in ("asimddp", "dotprod") for f in flags), True
+        except Exception:
+            pass
+        try:
+            # ARM Linux /proc/cpuinfo uses "Features" (capital F), not "flags".
+            with open("/proc/cpuinfo", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("Features") and (
+                        "asimddp" in line or "dotprod" in line
+                    ):
+                        return True, True
+            return False, True
+        except Exception:
+            return False, False
+
+    # Unknown OS on ARM64 — modern ARM64 almost certainly has dotprod,
+    # but we can't confirm. Inconclusive lets ``auto`` still pick int8
+    # without claiming a definitive answer.
+    return True, False
+
+
+def detect_avx_vnni_details() -> tuple[bool, bool]:
+    """Return ``(has_int8_fast_path, absence_confirmed)``.
+
+    The name keeps the historical ``vnni`` spelling for backward compat,
+    but semantically this answers "does the CPU have a fast INT8 dot
+    product?" — what the quantization picker actually needs. The fast
+    path is architecture-specific:
+
+      * x86 → AVX-VNNI / AVX512-VNNI
+      * ARM64 → ARMv8.2-A NEON sdot/udot (``asimddp`` feature)
+
+    ``absence_confirmed=False`` means detection was inconclusive. For
+    ``auto`` quantization, INT8 is still selected in that case — we only
+    skip vectors when we are *confident* the CPU lacks the fast path
+    (INT8 would be slow and FP32 weights are not shipped).
+    """
+    if platform.machine().lower() in ("arm64", "aarch64"):
+        return _detect_int8_fast_path_arm()
+    return _detect_int8_fast_path_x86()
 
 
 def detect_avx_vnni() -> bool:

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -328,8 +328,15 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
             import ctypes
             # PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE = 43 — the canonical
             # Win32 feature constant for ARMv8.2 dotprod instructions.
-            has = bool(ctypes.windll.kernel32.IsProcessorFeaturePresent(43))
-            return has, True
+            if ctypes.windll.kernel32.IsProcessorFeaturePresent(43):
+                return True, True
+            # 0 from this API is ambiguous: the CPU truly lacks dotprod
+            # OR the running Windows build predates feature 43 and
+            # returns 0 for every unrecognised constant. Stay
+            # inconclusive so we don't false-disable embeddings on a
+            # capable Snapdragon X running an older Win10 ARM build
+            # (Codex P1 review on PR #1394).
+            return False, False
         except Exception:
             # ctypes call failed on a non-standard runtime — be
             # inconclusive rather than wrong in either direction.

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -343,6 +343,8 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
                 # py-cpuinfo surfaces ARM features under the same "flags" key.
                 return any(f in ("asimddp", "dotprod") for f in flags), True
         except Exception:
+            # py-cpuinfo not installed / failed on this ARM host — fall
+            # through to the /proc/cpuinfo probe below.
             pass
         try:
             # ARM Linux /proc/cpuinfo uses "Features" (capital F), not "flags".

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -168,9 +168,12 @@ def test_detect_avx_vnni_arm64_windows_uses_processor_feature(monkeypatch):
     monkeypatch.setattr(ctypes, "windll", _FakeWindll(present=1), raising=False)
     assert emb_mod.detect_avx_vnni_details() == (True, True)
 
-    # First-gen WoA Snapdragon 835 — no dotprod.
+    # API returning 0 is ambiguous (could be Snapdragon 835 lacking
+    # dotprod, could be an older Win10 ARM build that doesn't know
+    # feature 43). Stay inconclusive rather than false-disabling on
+    # capable hardware — Codex P1 on PR #1394.
     monkeypatch.setattr(ctypes, "windll", _FakeWindll(present=0), raising=False)
-    assert emb_mod.detect_avx_vnni_details() == (False, True)
+    assert emb_mod.detect_avx_vnni_details() == (False, False)
 
 
 def test_detect_avx_vnni_arm64_linux_checks_asimddp(monkeypatch):

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -202,6 +202,39 @@ def test_detect_avx_vnni_arm64_linux_checks_asimddp(monkeypatch):
     assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
+def test_detect_avx_vnni_arm64_linux_proc_cpuinfo_fallback(monkeypatch):
+    """Linux ARM falls back to /proc/cpuinfo when py-cpuinfo is
+    unavailable. Unlike x86 which uses ``flags``, ARM Linux exposes the
+    feature list under a capital-F ``Features`` line — make sure the
+    parser hits that branch and reads asimddp/dotprod correctly."""
+    from unittest.mock import mock_open
+    from memory import embeddings as emb_mod
+
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Linux")
+
+    class _BrokenCpuinfo:
+        @staticmethod
+        def get_cpu_info():
+            raise RuntimeError("simulated cpuinfo failure")
+
+    monkeypatch.setitem(sys.modules, "cpuinfo", _BrokenCpuinfo)
+
+    proc_modern = (
+        "processor\t: 0\n"
+        "Features\t: fp asimd evtstrm aes pmull sha2 crc32 asimddp\n"
+    )
+    monkeypatch.setattr("builtins.open", mock_open(read_data=proc_modern))
+    assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+    proc_old = (
+        "processor\t: 0\n"
+        "Features\t: fp asimd evtstrm aes pmull sha2 crc32\n"  # pre-dotprod
+    )
+    monkeypatch.setattr("builtins.open", mock_open(read_data=proc_old))
+    assert emb_mod.detect_avx_vnni_details() == (False, True)
+
+
 def test_parse_dim_from_model_id_picks_runtime_dim_under_ambiguous_profile():
     """Codex review PR #1147: ``parse_dim_from_model_id`` must anchor on
     the trailing ``-<dim>d-<quant>`` segment that ``build_model_id``

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -127,23 +127,50 @@ def test_resolve_quantization_invalid_falls_back_to_auto():
     )
 
 
-def test_detect_avx_vnni_arm64_apple_and_windows_short_circuit(monkeypatch):
-    """Apple Silicon and Windows-on-ARM ship only dotprod-capable cores,
+def test_detect_avx_vnni_arm64_apple_short_circuits(monkeypatch):
+    """Apple Silicon ships only dotprod-capable cores (M1+ universally),
     so detection must claim the INT8 fast path without inspecting flags.
     Without this, M-series Macs fall into the "VNNI required for int8"
     disable branch even though INT8 inference runs fine on them.
     """
     from memory import embeddings as emb_mod
 
-    # macOS arm64
     monkeypatch.setattr(emb_mod.platform, "machine", lambda: "arm64")
     monkeypatch.setattr(emb_mod.platform, "system", lambda: "Darwin")
     assert emb_mod.detect_avx_vnni_details() == (True, True)
 
-    # Windows ARM64 (platform.machine() reports "ARM64" capitalized)
+
+def test_detect_avx_vnni_arm64_windows_uses_processor_feature(monkeypatch):
+    """Windows-on-ARM must call ``IsProcessorFeaturePresent`` rather than
+    assuming support — first-gen WoA (Snapdragon 835, 2017) is ARMv8-A
+    without dotprod, so hard-coding True would silently enable a slow
+    INT8 path on that hardware (Codex review on PR #1394)."""
+    import ctypes
+    from memory import embeddings as emb_mod
+
     monkeypatch.setattr(emb_mod.platform, "machine", lambda: "ARM64")
     monkeypatch.setattr(emb_mod.platform, "system", lambda: "Windows")
+
+    class _FakeKernel32:
+        def __init__(self, present: int) -> None:
+            self._present = present
+
+        def IsProcessorFeaturePresent(self, feature: int) -> int:  # noqa: N802
+            # 43 == PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE
+            assert feature == 43
+            return self._present
+
+    class _FakeWindll:
+        def __init__(self, present: int) -> None:
+            self.kernel32 = _FakeKernel32(present)
+
+    # Modern Snapdragon X / 8cx — kernel reports dotprod present.
+    monkeypatch.setattr(ctypes, "windll", _FakeWindll(present=1), raising=False)
     assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+    # First-gen WoA Snapdragon 835 — no dotprod.
+    monkeypatch.setattr(ctypes, "windll", _FakeWindll(present=0), raising=False)
+    assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
 def test_detect_avx_vnni_arm64_linux_checks_asimddp(monkeypatch):

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import sys
 
 import pytest
 
@@ -124,6 +125,51 @@ def test_resolve_quantization_invalid_falls_back_to_auto():
         _resolve_quantization("garbage", has_vnni=False, vnni_absence_confirmed=False)
         == "int8"
     )
+
+
+def test_detect_avx_vnni_arm64_apple_and_windows_short_circuit(monkeypatch):
+    """Apple Silicon and Windows-on-ARM ship only dotprod-capable cores,
+    so detection must claim the INT8 fast path without inspecting flags.
+    Without this, M-series Macs fall into the "VNNI required for int8"
+    disable branch even though INT8 inference runs fine on them.
+    """
+    from memory import embeddings as emb_mod
+
+    # macOS arm64
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Darwin")
+    assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+    # Windows ARM64 (platform.machine() reports "ARM64" capitalized)
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "ARM64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Windows")
+    assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+
+def test_detect_avx_vnni_arm64_linux_checks_asimddp(monkeypatch):
+    """Linux ARM must verify the ``asimddp`` feature flag — old Cortex-A53
+    / A57 / A72 cores are aarch64 but predate ARMv8.2-A dotprod, so being
+    optimistic would silently run the slow path on a Raspberry Pi 3."""
+    from memory import embeddings as emb_mod
+
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Linux")
+
+    class _FakeCpuinfoModern:
+        @staticmethod
+        def get_cpu_info():
+            return {"flags": ["fp", "asimd", "asimddp", "sha2"]}
+
+    class _FakeCpuinfoOld:
+        @staticmethod
+        def get_cpu_info():
+            return {"flags": ["fp", "asimd", "sha2"]}  # pre-dotprod
+
+    monkeypatch.setitem(sys.modules, "cpuinfo", _FakeCpuinfoModern)
+    assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+    monkeypatch.setitem(sys.modules, "cpuinfo", _FakeCpuinfoOld)
+    assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
 def test_parse_dim_from_model_id_picks_runtime_dim_under_ambiguous_profile():


### PR DESCRIPTION
## Summary

原 `detect_avx_vnni_details()` 只认 x86 的 `vnni` flag 字面量，在 M3 Mac / aarch64 上扫到 ARM flags 全无 vnni 字串，误判 \"confirmed absent\"，把 auto quantization 推到 `AVX_VNNI_REQUIRED_FOR_INT8` 的 disable 分支，导致 embedding 整条链路被 sticky-disable。但 INT8 在 ARM64 上有自己的 fast path（ARMv8.2-A NEON sdot/udot），ONNXRuntime CPU EP 一直在用。

按架构拆分检测：

- **x86** → AVX-VNNI（原行为）
- **macOS / Windows ARM64** → 直接当 True（M1+、Snapdragon X/8cx 全系都有 dotprod，Apple 从没出过没 dotprod 的 ARM Mac）
- **Linux ARM64** → 查 `asimddp` flag（cpuinfo 优先，回落 `/proc/cpuinfo` 的 `Features` 行；ARM Linux 用 `Features` 不是 `flags`）；老 Cortex-A53/A57/A72（树莓派 3 之类）没 dotprod，这里要严格判断不能盲乐观

`detect_avx_vnni_details` 的函数名和 `has_vnni` / `vnni_absence_confirmed` kwargs 保留不动（test fixtures 在用），docstring 改成说明它语义上其实是 "has int8 fast path"。

## Test plan

- [x] `uv run pytest tests/unit/test_embedding_service.py` — 50 passed
- [x] 新增测试覆盖 macOS arm64 / Windows ARM64 短路、Linux aarch64 asimddp present/absent 两种路径
- [ ] 在真的 M 系 Mac 上跑一次 `memory_server` 看 `EmbeddingService: ready (...)` 是否出现（PR 作者环境是 Windows，无法本地验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **优化**
  * 按 CPU 架构区分 INT8 快路径检测（x86 与 ARM64），在 macOS/Windows/Linux 上采用更有针对性的本机特性检测，提升硬件能力判定的可靠性且保持兼容现有命中语义。

* **测试**
  * 添加多平台单元测试，覆盖 Apple Silicon、Windows-on-ARM 与 Linux ARM 的检测与回退场景，确保各平台行为一致。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->