### PR TITLE
fix(i18n): 补齐 ElevenLabs 在 api.keyBook 和 assistProviderNames 的 i18n 标签

### DIFF
--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -943,6 +943,7 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Intl)",
+            "elevenlabs": "ElevenLabs (Voice Cloning)",
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (Model Aggregator)"
@@ -978,6 +979,7 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Intl)",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter"

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -943,6 +943,7 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Int.)",
+            "elevenlabs": "ElevenLabs (clonación de voz)",
             "claude": "Claude (antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (agregador de modelos)"
@@ -978,6 +979,7 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Int.)",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude (antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "enrutador abierto"

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -943,6 +943,7 @@
             "doubao": "ByteDance（Doubao）",
             "minimax": "MiniMax（中国版）",
             "minimax_intl": "MiniMax（国際版）",
+            "elevenlabs": "ElevenLabs（音声クローン）",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（モデルアグリゲーター）"
@@ -978,6 +979,7 @@
             "doubao": "ByteDance（Doubao）",
             "minimax": "MiniMax（中国版）",
             "minimax_intl": "MiniMax（国際版）",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter"

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -943,6 +943,7 @@
             "doubao": "ByteDance(Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax(국제 서버)",
+            "elevenlabs": "ElevenLabs(음성 클로닝)",
             "claude": "Claude(Anthropic)",
             "grok": "Grok(xAI)",
             "openrouter": "OpenRouter(모델 통합 플랫폼)"
@@ -978,6 +979,7 @@
             "doubao": "ByteDance(Doubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax(국제 서버)",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude(Anthropic)",
             "grok": "Grok(xAI)",
             "openrouter": "OpenRouter"

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -943,6 +943,7 @@
             "doubao": "ByteDance (Dubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Internacional)",
+            "elevenlabs": "ElevenLabs (clonagem de voz)",
             "claude": "Claude (Antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (agregador de modelo)"
@@ -978,6 +979,7 @@
             "doubao": "ByteDance (Dubao)",
             "minimax": "MiniMax (China)",
             "minimax_intl": "MiniMax (Internacional)",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude (Antrópico)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter"

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -943,6 +943,7 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (Китай)",
             "minimax_intl": "MiniMax (международный)",
+            "elevenlabs": "ElevenLabs (клонирование голоса)",
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter (агрегатор моделей)"
@@ -978,6 +979,7 @@
             "doubao": "ByteDance (Doubao)",
             "minimax": "MiniMax (Китай)",
             "minimax_intl": "MiniMax (международный)",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude (Anthropic)",
             "grok": "Grok (xAI)",
             "openrouter": "OpenRouter"

--- a/static/locales/zh-CN.json
+++ b/static/locales/zh-CN.json
@@ -943,6 +943,7 @@
             "doubao": "豆包（字节跳动）",
             "minimax": "MiniMax（国服）",
             "minimax_intl": "MiniMax（国际服）",
+            "elevenlabs": "ElevenLabs（语音克隆，国内无法使用）",
             "claude": "Claude（Anthropic，国内无法使用）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（模型聚合，国内无法使用）"
@@ -978,6 +979,7 @@
             "doubao": "豆包（字节跳动）",
             "minimax": "MiniMax（国服）",
             "minimax_intl": "MiniMax（国际服）",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter"

--- a/static/locales/zh-TW.json
+++ b/static/locales/zh-TW.json
@@ -943,6 +943,7 @@
             "doubao": "豆包（字節跳動）",
             "minimax": "MiniMax（中國）",
             "minimax_intl": "MiniMax（國際服）",
+            "elevenlabs": "ElevenLabs（語音克隆，國內無法使用）",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter（模型聚合，國內無法使用）"
@@ -978,6 +979,7 @@
             "doubao": "豆包（字節跳動）",
             "minimax": "MiniMax（中國）",
             "minimax_intl": "MiniMax（國際服）",
+            "elevenlabs": "ElevenLabs",
             "claude": "Claude（Anthropic）",
             "grok": "Grok（xAI）",
             "openrouter": "OpenRouter"


### PR DESCRIPTION
## Summary

- `elevenlabs` 在 [config/api_providers.json](config/api_providers.json) 的 `assist_api_providers` / `assist_api_key_fields` / `api_key_registry` 中已注册，但 8 个 locale 的 `api.keyBook` 和 `api.assistProviderNames` 缺少对应 i18n 条目
- 缺失会导致 API 管理簿和辅助 API 服务商下拉中 ElevenLabs 项渲染成 key 字面量（`elevenlabs`）而非可读名称
- 补齐 zh-CN / zh-TW / en / ja / ko / ru / es / pt 两处共 16 行；位置插在 `minimax_intl` 与 `claude` 之间，与 registry 顺序一致

## Test plan

- [ ] 打开 API 密钥设置页，确认管理簿中 ElevenLabs 行显示本地化名称
- [ ] 辅助 API 服务商下拉选到 ElevenLabs，确认显示完整描述（如中文"ElevenLabs（语音克隆，国内无法使用）"）
- [ ] 切换 8 种语言各检查一次，无 `elevenlabs` 字面量裸露

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增对ElevenLabs语音克隆服务提供商的多语言支持，覆盖英语、西班牙语、日语、韩语、葡萄牙语、俄语、简体中文和繁体中文，用户可在对应语言界面中使用该服务。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->