### PR TITLE
fix(offline): cap retained images in conversation history to last 2 turns

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1217,14 +1217,16 @@ class OmniOfflineClient:
             
             user_message = HumanMessage(content=content)
             logger.info(f"Sending multi-modal message with {len(self._pending_images)} images")
-            
+
             # Clear pending images after using them
             self._pending_images.clear()
         else:
             # Text-only message
             user_message = HumanMessage(content=text.strip())
-        
+
         self._conversation_history.append(user_message)
+        if has_images:
+            self._evict_old_images()
         
         # Callback for user input
         if self.on_input_transcript:
@@ -1793,6 +1795,37 @@ class OmniOfflineClient:
     def has_pending_images(self) -> bool:
         """Check if there are pending images waiting to be sent."""
         return len(self._pending_images) > 0
+
+    def _evict_old_images(self, keep_turns: int = 2) -> None:
+        # 只保留最近 keep_turns 个含图 HumanMessage 的图片，更早的剥掉 image_url
+        # 仅留文本。base64 图片在 vision tokenizer 下约 1.5k~3k tokens/张，
+        # 多轮累积会把 input 推到 128k+。
+        image_turn_indices = [
+            idx for idx, msg in enumerate(self._conversation_history)
+            if isinstance(msg, HumanMessage) and isinstance(msg.content, list)
+            and any(isinstance(item, dict) and item.get("type") == "image_url" for item in msg.content)
+        ]
+        if len(image_turn_indices) <= keep_turns:
+            return
+
+        evicted_imgs = 0
+        for idx in image_turn_indices[:-keep_turns]:
+            old = self._conversation_history[idx]
+            kept_parts = []
+            for item in old.content:
+                if isinstance(item, dict) and item.get("type") == "image_url":
+                    evicted_imgs += 1
+                else:
+                    kept_parts.append(item)
+            if len(kept_parts) == 1 and isinstance(kept_parts[0], dict) and kept_parts[0].get("type") == "text":
+                self._conversation_history[idx] = HumanMessage(content=kept_parts[0].get("text", ""))
+            else:
+                self._conversation_history[idx] = HumanMessage(content=kept_parts)
+
+        logger.info(
+            f"🖼️ Evicted {evicted_imgs} image(s) from {len(image_turn_indices) - keep_turns} older turn(s); "
+            f"kept images in last {keep_turns} turn(s)"
+        )
     
     # ------------------------------------------------------------------
     # LLM message injection channels


### PR DESCRIPTION
## 背景

近期统计显示 128k<input<=256k 区间的 token 量显著抬升（05/17 单日 ~15.4M）。排查后确认结构性根因是 vision 路径下 `_conversation_history` 里的 base64 图片**无上限累积**：

- `main_logic/omni_offline_client.py:1204-1227` 把 `_pending_images` 的每张 base64 以 `image_url` part 形式塞进 `HumanMessage` 后 append 到 `_conversation_history`，**永久驻留**
- 代码注释自己写了 "image data remains in conversation history"，且 vision model 一旦切换不会切回
- 单张高清截图在 vision tokenizer 下约 1.5k~3k tokens；galgame / computer use / game_agent_minecraft 多轮使用后几轮就能把 input 推到 100k+

memory 侧的 reflection RELATED_CONTEXT / MemoryRefineEngine / recall_memory tool 都查过了，单次合计 < 2k tokens，不是主因。

## 改动

- 新增 `OmniOfflineClient._evict_old_images(keep_turns=2)`：扫 `_conversation_history`，把除最近 2 个含图 turn 之外、更早的 HumanMessage 里的 `image_url` part 剥掉，仅保留文本；文本若只剩一项则 collapse 回 string，让 history 形态保持规整
- 仅在 image-bearing append 后触发（非 image 轮零开销）
- 全文件唯一 `image_url` 写入点就在 L1206，hook 一处即可覆盖

## Test plan

- [ ] 跑一轮 galgame / computer-use，确认 vision 模型仍正常工作
- [ ] 验证连续 >2 次贴图后，日志出现 `🖼️ Evicted N image(s) from M older turn(s)`
- [ ] 验证更早的图片轮次只剩文本，最近 2 轮图片完整保留
- [ ] 单元/集成测试若有 history 序列化相关 case，跑一遍确保 collapse 逻辑不破

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化离线客户端在多轮对话中的图片数据管理，现自动清理较早轮次的图片以控制内存占用。
  * 改进了多模态消息（文字+图片）的状态维护顺序，确保对话历史的一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->