### PR TITLE
fix(memory): SignalLoop Stage-1 对话段为空导致 fact 零增长

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1830,7 +1830,12 @@ async def _periodic_signal_extraction_loop():
                     {'type': 'human', 'data': {'content': m}}
                     for m in user_msgs_text
                 ]
-                messages = convert_to_messages(json.dumps(message_dicts))
+                # convert_to_messages 只接 list，不再解 JSON 字符串（PR #547 以来的契约）；
+                # 这里之前的 json.dumps 让函数走 isinstance(data, list)==False 分支直接返回 []，
+                # → messages=[] → _format_conversation render 出空字符串 → Stage-1 prompt
+                # 里 ======以下为对话====== 跟 ======以上为对话====== 之间为空 → LLM 合理
+                # 返回 []，整套 fact 抽取 + 后续 Stage-2 evidence 都被静默跳过。
+                messages = convert_to_messages(message_dicts)
 
                 try:
                     persisted, signals, batch_fact_ids = await fact_store.aextract_facts_and_detect_signals(

--- a/tests/unit/test_signal_loop_message_wire.py
+++ b/tests/unit/test_signal_loop_message_wire.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Regression: SignalLoop's user_msgs_text → convert_to_messages wire.
+
+PR #929 added ``_periodic_signal_extraction_loop._signal_check_one`` and
+wrapped the list of message dicts with ``json.dumps()`` before handing it
+to ``utils.llm_client.convert_to_messages``. The helper has only ever
+accepted lists (PR #547), so the JSON-string input took the silent
+``return []`` fallback. ``messages`` ended up empty, ``_format_conversation``
+rendered an empty string, and the Stage-1 LLM prompt had
+``======以下为对话======`` followed by nothing — LLM consistently returned
+``[]``. PR #1346 later stripped the per-turn OFF-mode ``extract_facts``
+fallback for ON-mode users, at which point new-fact growth froze entirely
+once the Stage-2 ``signal_processed=False`` backlog drained (~2026-05-15).
+
+These tests pin down the wire path so a future refactor can't reintroduce
+the same mistake without it lighting up red immediately.
+"""
+from utils.llm_client import convert_to_messages
+
+
+def test_signal_loop_wire_yields_human_messages_with_content():
+    """Mirror SignalLoop's `_signal_check_one` message-building. The
+    transformation must yield a list of BaseMessage with .content set —
+    not an empty list."""
+    user_msgs_text = ["主人喜欢吃鱼", "今天天气不错"]
+    message_dicts = [
+        {'type': 'human', 'data': {'content': m}}
+        for m in user_msgs_text
+    ]
+    # convert_to_messages must receive a list directly — wrapping with
+    # json.dumps() (the PR #929 mistake) silently returns [].
+    messages = convert_to_messages(message_dicts)
+    assert len(messages) == 2, "wire path dropped messages"
+    assert messages[0].type == 'human'
+    assert messages[0].content == "主人喜欢吃鱼"
+    assert messages[1].content == "今天天气不错"
+
+
+def test_convert_to_messages_silently_drops_str_input():
+    """Document the existing helper contract: string inputs (the shape
+    PR #929 accidentally produced) collapse to []. If a future refactor
+    changes convert_to_messages to also accept str, this test will fail
+    loudly — the author should then audit every call site to make sure
+    nobody is relying on the silent-drop behaviour."""
+    assert convert_to_messages("[]") == []
+    assert convert_to_messages('[{"type": "human", "data": {"content": "x"}}]') == []


### PR DESCRIPTION
## Summary

- `_periodic_signal_extraction_loop` 给 Stage-1 LLM 的 prompt 里 `======以下为对话====== ... ======以上为对话======` 之间一直是空的，原因是 `convert_to_messages(json.dumps(message_dicts))` 多了一层 `json.dumps`——helper 只接 list，str 输入走 `isinstance` 兜底返回 `[]`
- 这条路径自 PR #929 (2026-04-22) 引入就坏，被 PR #1346 (2026-05-13) 删掉的 per-turn OFF-mode fallback 一直遮着；fallback 死掉后 + Stage-2 的 `signal_processed=False` 库存 drain 完（约 5-15 14:47）→ 所有猫娘 facts / reflections 持续零增长直到此修复

## Root cause trace

- PR #929 (4-22): SignalLoop 引入时写成 `convert_to_messages(json.dumps(message_dicts))`
- PR #547 起 `convert_to_messages` 的契约：只接 list，str → 走 `return []`
- PR #997 (4-27): `powerful_memory_enabled` 开关引入，默认 True (ON-mode)
- PR #1346 (5-13): 按 RFC §3.4.3 把 ON-mode 的 per-turn `fact_store.extract_facts` 砍掉
- 5-15 14:47: 最后一次 Stage-2 dispatch 9 signals 把 `signal_processed=False` 库存清空
- 之后稳态：Stage-1 喂空 conversation → LLM 返空 list → 0 fact，Stage-2 没库存 → 0 signal

## Test plan

- [x] 新增 `tests/unit/test_signal_loop_message_wire.py` 钉住 wire 契约 + `convert_to_messages` 的 str-drop 行为
- [x] `uv run pytest tests/unit/test_signal_loop_message_wire.py -v` 通过
- [x] `uv run pytest tests/unit/test_evidence_extraction.py tests/unit/test_memory_server_cache_settle.py -v` 无回归
- [x] 本地手动验证：跑 launcher、聊几句、看 `[STAGE1] LLM extracted N fact candidates` 从 0 变成 >0、`[PERSIST] persisted=N` >0、facts.json 落盘

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 修复了事实提取与证据分发在特定处理阶段被意外跳过的问题，确保相关处理流程正常执行。

* **Tests**
  * 新增单元测试用例，验证消息转换流程的正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->