### PR TITLE
feat(memory): 后端跑 reflection synthesis，砍掉前端 /reflect 耦合

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -380,7 +380,7 @@ _INITIAL_DELAY_AUTO_PROMOTE = 150    # Auto-promote 首次 (原 300s, 错开 reb
 _INITIAL_DELAY_ARCHIVE = 250         # Archive sweep 首次 (原 3600s, 大幅前移确保短会话用户也能跑到)
 _INITIAL_DELAY_PERSONA_REFINE = 400  # PERSONA_REFINE 首次（与 reflection refine 错峰 100s）
 _INITIAL_DELAY_REFLECTION_REFINE = 500  # REFLECTION_REFINE 首次
-_INITIAL_DELAY_REFLECTION_SYNTHESIS = 700  # REFLECTION_SYNTHESIS 首次（错开 REFINE 200s）
+_INITIAL_DELAY_REFLECTION_SYNTHESIS = 200  # REFLECTION_SYNTHESIS 首次（错过 AUTO_PROMOTE 150 与 ARCHIVE 250，给 SignalLoop 60s + 一两次实际 fact 产出留余地）
 
 # ── 持久化维护状态（跨重启保留 review_clean 标记） ──────────────────
 _maint_state: dict[str, dict] = {}   # {角色名: {"review_clean": bool, "last_review_ts": str}}

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -42,6 +42,7 @@ from config import (
     EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
     EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES,
     EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS,
+    MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS,
     IGNORED_REINFORCEMENT_DELTA,
     MEMORY_RECHECK_ENABLED,
     MEMORY_RECHECK_INITIAL_DELAY_SECONDS,
@@ -379,6 +380,7 @@ _INITIAL_DELAY_AUTO_PROMOTE = 150    # Auto-promote 首次 (原 300s, 错开 reb
 _INITIAL_DELAY_ARCHIVE = 250         # Archive sweep 首次 (原 3600s, 大幅前移确保短会话用户也能跑到)
 _INITIAL_DELAY_PERSONA_REFINE = 400  # PERSONA_REFINE 首次（与 reflection refine 错峰 100s）
 _INITIAL_DELAY_REFLECTION_REFINE = 500  # REFLECTION_REFINE 首次
+_INITIAL_DELAY_REFLECTION_SYNTHESIS = 700  # REFLECTION_SYNTHESIS 首次（错开 REFINE 200s）
 
 # ── 持久化维护状态（跨重启保留 review_clean 标记） ──────────────────
 _maint_state: dict[str, dict] = {}   # {角色名: {"review_clean": bool, "last_review_ts": str}}
@@ -2154,6 +2156,58 @@ async def _periodic_reflection_refine_loop():
         await asyncio.sleep(interval)
 
 
+async def _periodic_reflection_synthesis_loop():
+    """每 N 秒对每个角色跑一轮 reflection 合成。
+
+    与其他 9 条 ``_periodic_*_loop`` 对偶——signal_extraction 把对话抽成 fact，
+    本循环把 unabsorbed fact 综合成 pending reflection，auto_promote_loop 再把
+    pending 推到 confirmed/promoted。整条链路全部在 memory_server 进程内长跑，
+    不依赖 ``/api/proactive_chat`` HTTP trigger（也就不再依赖前端浏览器开着）。
+
+    历史背景（为啥要这条循环）：reflection 合成原本只挂在
+    ``main_routers/system_router.py`` 的 proactive_chat handler 里
+    （``_mem_client.post('/reflect/{name}')``，PR #1015 顺手塞的），导致：
+      - 前端关 / proactive 不触发 / 任一 frontend gate false → ``/reflect``
+        永不被调 → ``reflections.json`` 永不增长
+      - reflection 生命周期实际上跟前端 setTimeout 强耦合，违背"长跑后端服务
+        自己保证记忆生态"的设计意图
+
+    Gate 全靠 ``reflection_engine.synthesize_reflections`` 内置：
+      - ``len(unabsorbed) < MIN_FACTS_FOR_REFLECTION (=5)`` → 直接返回 []
+      - 同批 source_fact_ids → 同 rid 幂等 short-circuit，无新 fact 时 LLM 不调
+      - ``REFLECTION_SYNTHESIS_FACTS_MAX (=20)`` cap 单次输入规模
+    所以本循环只做调度，不重复加 gate；间隔常量
+    ``MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS`` 控制最大调用频率。
+
+    与 powerful_memory 开关：synthesize_reflections 不在 evidence-RFC 引入的
+    新 LLM 路径里——它是 RFC 之前就存在的合成机制（pending reflection 是 RFC
+    前就有的，evidence 只是给它做了状态推进），所以**不**受 powerful_memory 关
+    闭影响。这跟 refine / signal_extraction 不一样，对齐 idle_maintenance 里
+    "history 压缩 / review" 那两个子任务的处理。
+    """
+    await asyncio.sleep(_INITIAL_DELAY_REFLECTION_SYNTHESIS)
+    interval = MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS
+    while True:
+        try:
+            character_data = await _config_manager.aload_characters()
+            catgirl_names = list(character_data.get('猫娘', {}).keys())
+        except Exception as e:
+            logger.debug(f"[ReflectionSynth] 加载角色列表失败: {e}")
+            await asyncio.sleep(interval)
+            continue
+        for name in catgirl_names:
+            try:
+                results = await reflection_engine.synthesize_reflections(name)
+                if results:
+                    logger.info(
+                        f"[ReflectionSynth] {name}: 合成 {len(results)} 条新 pending reflection"
+                    )
+            except Exception as e:
+                # 单角色合成失败不阻塞其他角色 / 下轮重试
+                logger.warning(f"[ReflectionSynth] {name} 合成异常: {e}")
+        await asyncio.sleep(interval)
+
+
 async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
     global recent_history_manager, settings_manager, time_manager, fact_store
     global persona_manager, reflection_engine, cursor_store, outbox, event_log, reconciler
@@ -2295,6 +2349,7 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
             # Phase A-4 / A-5: MemoryRefineEngine cron 接入
             _spawn_background_task(_periodic_persona_refine_loop())
             _spawn_background_task(_periodic_reflection_refine_loop())
+            _spawn_background_task(_periodic_reflection_synthesis_loop())
             _memory_background_tasks_started = True
 
         # memory-enhancements P2: vector embedding warmup + backfill worker.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -998,14 +998,19 @@ REFLECTION_SYNTHESIS_FACTS_MAX = 20
   当前没数量限制，所以这层是唯一保护。
 - 设计依据：30 条 × 平均 50 token = 1500 token，留给 LLM 综合处理够用。"""
 
-MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS = 600
+MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS = 180
 """``_periodic_reflection_synthesis_loop`` 每轮轮询间隔（秒）。
 - 用途：后端定期对每个角色调 ``reflection_engine.synthesize_reflections``。
 - 设计依据：synthesize_reflections 内部对"同批 source_fact_ids → 同 rid"做
   幂等 short-circuit，无新 unabsorbed fact 时 LLM 不会被调，所以这层只是
-  调度频率上限。10 min 在 auto_promote (180s) 和 refine cron (1800s) 之间，
-  贴近 EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES (5 min) 的两倍——给上游 SignalLoop
-  足够时间在窗口里抽完 facts 再合成。
+  调度频率上限。**真 LLM 调用频率约等于"用户在 N 秒内新积了 ≥5 条 unabsorbed
+  fact 的次数"**，与 SignalLoop 实际产出速率绑死、与本常量解耦——把间隔从
+  600s 缩到 180s 不会按比例加 LLM 成本。
+- 选 180s：对齐 ``AUTO_PROMOTE_CHECK_INTERVAL = 180s``。两条 loop 一个产
+  pending、一个把 pending 推 confirmed，节奏对齐让 user-visible 状态机延迟
+  最短（合成 → 下一 tick 内就能被 promote 看到）。也跟
+  ``EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES * 60 = 300s`` 错峰，让 SignalLoop 抽
+  完一批 fact 后 1-2 个 reflection tick 内能消化掉。
 - 历史：以前 reflection 合成挂在 ``/api/proactive_chat`` handler 里（PR #1015
   顺手塞的，见 main_routers/system_router.py 历史 blame），整套合成链路与
   前端 setTimeout 强耦合——前端不开 / proactive 不触发 → reflection 永远不

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1018,16 +1018,29 @@ MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS = 180
   loop（rebuttal / auto_promote / idle_maint / signal_extraction / archive /
   refine 等）对偶。"""
 
-REFLECTION_RELATED_RECALL_K = 6
-"""Reflection synthesis 时通过 embedding 召回的 absorbed fact 数量。
-- 用途：synthesize_reflections 在调 LLM 前用 unabsorbed 文本作 multi-query，
-  从已 absorbed fact 池里 cosine 召回 top K 作为 {RELATED_CONTEXT_BLOCK}
-  喂给 prompt，让 LLM 知道"远期相关 fact 长啥样"。
-- 上游：absorbed=True 的 fact 池（已被前轮 reflection 吸收过的素材）。
-- 设计依据：K 约等于 SYNTHESIS_FACTS_MAX 的 1/3，再多会稀释 prompt 焦点；
-  embedding 不可用 / 池为空 / 召回为空 → block 整段省略，prompt 与改造前一致。
-- 远期 fact 仅作参考，不进 source_fact_ids、不 mark_absorbed，幂等性靠
-  unabsorbed 集合的 rid hash 保证。"""
+REFLECTION_RELATED_PER_QUERY_K = 3
+"""Reflection synthesis 时，每条 unabsorbed fact 单独 query 召回的 absorbed
+fact 数量上限。
+- 上游：synthesize_reflections 调 ``MemoryRecallReranker.aretrieve_per_query_topk``
+  时按本常量给每条 query 配独立预算。
+- 设计依据（PR #1401 thread 拍板）：原先用 max-pool top-K (=6 全局预算)，
+  20 条 unabsorbed 主题分散时冷门主题会被高频主题挤掉冷板凳。改成 per-query
+  K=3 + 全局 cap，保证每条 unabsorbed 至少能拿到自己的 top-3 锚（除非这条
+  query embed 失败 / 候选池没语义匹配）。
+- 单条 query 拿 3 条而不是 1 条：考虑到主题边界模糊（用户聊 MC 同时聊到
+  红石和挖矿，cosine top-1 可能只命中其中一条），多给两条让 LLM 能看出
+  "主题群"的轮廓。"""
+
+REFLECTION_RELATED_TOTAL_CAP = 20
+"""``aretrieve_per_query_topk`` 跨 query union+dedup 后的最终上限。
+- 设计依据：与 ``REFLECTION_SYNTHESIS_FACTS_MAX`` (=20) 同档，让 anchor 集
+  最坏也能跟 source 集等量——但实际命中通常远小于此（query 间 nearest
+  neighbor 大量重叠 + dedup）。典型 batch 10 条 unabsorbed × per_query=3
+  = 30 候选 → dedup 后落在 ~10-15 anchor。
+- 上界用于防御性截断：极端"20 条全主题不重叠"假设下，per_query=3 × 20 = 60
+  候选，dedup 不能去重时砍到 20，避免 prompt token 爆。
+- prompt 实际成本：20 × ~50 tok ≈ 1000 tok anchor + 20 × ~50 tok ≈ 1000 tok
+  source = 2k 上限，summary tier 模型完全吃得下。"""
 
 # ---- Memory: temporal scope (memory/temporal.py) ─────────────────────
 # Reflection 用 4 档 temporal_scope（pattern / state / episode / past）做时间
@@ -1872,7 +1885,8 @@ __all__ = [
     'REFLECTION_SURFACE_TOP_K',
     'REFLECTION_SYNTHESIS_FACTS_MAX',
     'MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS',
-    'REFLECTION_RELATED_RECALL_K',
+    'REFLECTION_RELATED_PER_QUERY_K',
+    'REFLECTION_RELATED_TOTAL_CAP',
     'PERSONA_MERGE_POOL_MAX_TOKENS',
     'PERSONA_CORRECTION_BATCH_LIMIT',
     'PERSONA_VERSION_HISTORY_MAX',

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -998,6 +998,21 @@ REFLECTION_SYNTHESIS_FACTS_MAX = 20
   当前没数量限制，所以这层是唯一保护。
 - 设计依据：30 条 × 平均 50 token = 1500 token，留给 LLM 综合处理够用。"""
 
+MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS = 600
+"""``_periodic_reflection_synthesis_loop`` 每轮轮询间隔（秒）。
+- 用途：后端定期对每个角色调 ``reflection_engine.synthesize_reflections``。
+- 设计依据：synthesize_reflections 内部对"同批 source_fact_ids → 同 rid"做
+  幂等 short-circuit，无新 unabsorbed fact 时 LLM 不会被调，所以这层只是
+  调度频率上限。10 min 在 auto_promote (180s) 和 refine cron (1800s) 之间，
+  贴近 EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES (5 min) 的两倍——给上游 SignalLoop
+  足够时间在窗口里抽完 facts 再合成。
+- 历史：以前 reflection 合成挂在 ``/api/proactive_chat`` handler 里（PR #1015
+  顺手塞的，见 main_routers/system_router.py 历史 blame），整套合成链路与
+  前端 setTimeout 强耦合——前端不开 / proactive 不触发 → reflection 永远不
+  增长。本常量配套的后端 loop 把合成从 HTTP/前端解耦，与其他 9 条 periodic
+  loop（rebuttal / auto_promote / idle_maint / signal_extraction / archive /
+  refine 等）对偶。"""
+
 REFLECTION_RELATED_RECALL_K = 6
 """Reflection synthesis 时通过 embedding 召回的 absorbed fact 数量。
 - 用途：synthesize_reflections 在调 LLM 前用 unabsorbed 文本作 multi-query，
@@ -1851,6 +1866,7 @@ __all__ = [
     'REFLECTION_TEXT_MAX_TOKENS',
     'REFLECTION_SURFACE_TOP_K',
     'REFLECTION_SYNTHESIS_FACTS_MAX',
+    'MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS',
     'REFLECTION_RELATED_RECALL_K',
     'PERSONA_MERGE_POOL_MAX_TOKENS',
     'PERSONA_CORRECTION_BATCH_LIMIT',

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -5022,24 +5022,18 @@ async def proactive_chat(request: Request):
         )
         if not _allow_reminiscence:
             print(f"[{lanlan_name}] propensity=restricted_screen_only, 跳过反思/回忆话题获取")
-        # 复用 internal_http_client 单例：proactive_chat 每次主动搭话都走此路径
+        # 复用 internal_http_client 单例：proactive_chat 每次主动搭话都走此路径。
+        # 仅 read：取 followup_topics 候选用于本轮 prompt 注入。
+        # 历史上这一段还前置调过 POST /reflect/{name}（"自动状态迁移 + 反思合成"），
+        # 已删除——合成迁到 ``_periodic_reflection_synthesis_loop`` 后端循环、
+        # auto_promote 早就由 ``_periodic_auto_promote_loop`` 每 180s 跑。把
+        # mutation 留在 proactive 关键路径上既拖延 ~15s response、又让整个
+        # reflection 生命周期跟前端 setTimeout 强耦合（前端不开 → 永不合成）。
         if _allow_reminiscence:
             try:
                 from utils.internal_http_client import get_internal_http_client
                 _mem_base = f"http://127.0.0.1:{MEMORY_SERVER_PORT}"
                 _mem_client = get_internal_http_client()
-                # 1. 自动状态迁移 + 反思合成（集中在 memory_server 进程内执行）
-                _reflect_resp = await _mem_client.post(
-                    f"{_mem_base}/reflect/{lanlan_name}", timeout=15.0,
-                )
-                if _reflect_resp.status_code == 200:
-                    _reflect_data = _reflect_resp.json()
-                    if _reflect_data.get('auto_transitions'):
-                        print(f"[{lanlan_name}] 自动迁移 {_reflect_data['auto_transitions']} 条反思状态")
-                    if _reflect_data.get('reflection'):
-                        print(f"[{lanlan_name}] 反思完成(pending): {_reflect_data['reflection']['text'][:50]}...")
-
-                # 2. 获取回调话题候选
                 _topics_resp = await _mem_client.get(
                     f"{_mem_base}/followup_topics/{lanlan_name}", timeout=5.0,
                 )
@@ -5053,11 +5047,11 @@ async def proactive_chat(request: Request):
                                 _surfaced_reflection_ids.append(topic['id'])
                         print(f"[{lanlan_name}] 回调话题候选: {len(_followup_topics)} 条")
             except Exception as e:
-                logger.debug(f"[{lanlan_name}] 反思/回调话题获取失败（不影响主流程）: {e}")
+                logger.debug(f"[{lanlan_name}] 回调话题获取失败（不影响主流程）: {e}")
 
-        # Phase 1 preempt check：reflection POST(15s) + followup GET(5s) 是又一段
-        # 可能拖很久的 await 串，整段裸跑会让用户打断后继续跑完 LLM 配置和
-        # 后续步骤，再到 pre-LLM check 才识破。这里补一刀。
+        # Phase 1 preempt check：followup GET(5s) 是一段可能拖久的 await，
+        # 整段裸跑会让用户打断后继续跑完 LLM 配置和后续步骤，再到 pre-LLM
+        # check 才识破。这里补一刀。
         if mgr.state.is_proactive_preempted():
             return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_reflect")))
 

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -497,26 +497,42 @@ class MemoryRecallReranker:
         # (N, D) @ (D, Q) → (N, Q)
         scores_mat = candidate_matrix @ query_matrix.T
 
-        # Per-query top-K + union dedup + total cap. 保留 "first-seen" 顺序——
-        # query 顺序 × within-query rank → 重要 query 的高分 anchor 在前。
         n_candidates = scores_mat.shape[0]
         effective_k = max(0, min(per_query_k, n_candidates))
-        if effective_k == 0:
+        if effective_k == 0 or total_cap <= 0:
             return []
 
-        seen_ids: set[str] = set()
-        result: list[dict] = []
+        # Stage A：先把每条 query 的 top-K 候选 doc index 列表算出来——只算不截断，
+        # 不参与 cap 决策（cap 留给 stage B round-robin 时统一执行）。
+        per_query_picks: list[list[int]] = []  # 每元素是 list[survivor_idx]
         for q_idx in range(scores_mat.shape[1]):
             col = scores_mat[:, q_idx]
             if effective_k >= n_candidates:
                 top_idx = np.argsort(-col)
             else:
-                # argpartition O(N) 拿到无序 top-K，再对这 K 个排序
+                # argpartition O(N) 拿无序 top-K，再对这 K 个 argsort
                 unsorted_top = np.argpartition(-col, effective_k - 1)[:effective_k]
                 top_idx = unsorted_top[np.argsort(-col[unsorted_top])]
-            for idx in top_idx:
-                cand_idx = cand_survivor_indices[int(idx)]
-                doc = survivors[cand_idx]
+            per_query_picks.append([cand_survivor_indices[int(i)] for i in top_idx])
+
+        # Stage B：round-robin 取每轮每个 query 的第 r 名 → dedup 入池 → 满 cap
+        # 退出。fairness 关键点：cap 截断**只能发生在 round-robin 之后**，绝不
+        # 在 per-query 内部 early-return——否则前几个 query 会吃光全部 slot、
+        # 后面 query 一条 anchor 都拿不到，退化成 max-pool 那种 cold-topic
+        # 饥饿（PR #1401 thread 用户原话："必须最后统一去 cap，不然便宜了先
+        # 判定的 fact"）。
+        #
+        # round-robin 之后 dedup 入池的 ordering（query 内 #1 → query 间 #1 →
+        # query 内 #2 → ...）也跟"first-seen = query 顺序 × within-query rank"
+        # 的老语义不一样：现在的 ordering 是 "每条 query 的 #1 先于任何 query
+        # 的 #2"，更贴近 prompt 里"每条 unabsorbed 平等享有 anchor"的设计意图。
+        seen_ids: set[str] = set()
+        result: list[dict] = []
+        for rank in range(effective_k):
+            for picks in per_query_picks:
+                if rank >= len(picks):
+                    continue
+                doc = survivors[picks[rank]]
                 doc_id = doc.get('id')
                 if not doc_id or doc_id in seen_ids:
                     continue

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -400,6 +400,133 @@ class MemoryRecallReranker:
             result.extend(tail)
         return result[:k]
 
+    # ── per-query top-K recall（reflection synthesis 用） ────────────────
+
+    async def aretrieve_per_query_topk(
+        self,
+        observations: list[dict],
+        query_texts: list[str],
+        *,
+        per_query_k: int,
+        total_cap: int,
+    ) -> list[dict]:
+        """Per-query top-K cosine recall, union+dedup at most ``total_cap``。
+
+        与 ``aretrieve_candidates`` 的全局 max-pool top-K 不同：这里**每条
+        query 各自享有 ``per_query_k`` 的独立配额**，结果按 id dedup 合并，
+        总数截到 ``total_cap``。
+
+        Use case：reflection synthesis 的 ``{RELATED_CONTEXT_BLOCK}``——20 条
+        unabsorbed fact 主题分散时，max-pool 会让冷门主题被高频主题挤掉，
+        per-query 配额规避这点（PR #1401 thread 拍板）。
+
+        Perf：单次 ``embed_batch`` 拼所有 query，candidates decode 一次成 (N, D)
+        矩阵，一次 ``candidate_matrix @ query_matrix.T`` 算出 (N, Q) 分数矩
+        阵，per-column ``argpartition`` 取 top-K。整体复杂度 O(N·D·Q + N·Q·log K)，
+        BLAS 自带 SIMD/多线程，等同于"并行"per-query 调用但不付 N 次嵌入
+        服务往返。
+
+        Fallback 与主路径不同：embedding 不可用 / 无 model_id / 候选无 valid
+        embedding → **直接返回 []**，**不**退化到 evidence_score 排序。理由：
+        本方法的消费者（``_build_related_context_block``）拿结果是当
+        "semantic anchor" 注入 LLM prompt 用的，没真 semantic 关联的"高分历史
+        fact"当锚反而是注意力污染——宁可空 anchor。
+
+        ⚠️ 代码重用：candidate matrix build / query decode 与 ``_coarse_rank``
+        基本一致；当前两份接受少量重复，等出现第三个 caller 时再抽
+        ``_build_score_matrix`` 私有 helper。
+        """
+        if not observations or not query_texts:
+            return []
+
+        survivors = self._hard_filter(observations)
+        if not survivors:
+            return []
+
+        if not self._service.is_available():
+            return []
+        model_id = self._service.model_id()
+        if model_id is None:
+            return []
+
+        cleaned_queries = [
+            t.strip() for t in query_texts
+            if isinstance(t, str) and t.strip()
+        ]
+        if not cleaned_queries:
+            return []
+
+        query_vectors_raw = await self._service.embed_batch(cleaned_queries)
+        query_vectors_raw = [v for v in query_vectors_raw if v is not None]
+        if not query_vectors_raw:
+            return []
+
+        target_dim = parse_dim_from_model_id(model_id)
+
+        # Decode candidate embeddings once, build (N, D)
+        indexed_decoded: list[tuple[int, "np.ndarray"]] = []
+        for i, o in enumerate(survivors):
+            text = o.get('text', '')
+            if not is_cached_embedding_valid(o, text, model_id):
+                continue
+            cvec = decode_embedding(o.get('embedding'))
+            if cvec is None or cvec.size == 0:
+                continue
+            if target_dim is None:
+                target_dim = int(cvec.size)
+            elif cvec.size != target_dim:
+                continue
+            indexed_decoded.append((i, cvec))
+
+        if not indexed_decoded:
+            return []
+
+        import numpy as np
+        candidate_matrix = np.stack([cvec for _, cvec in indexed_decoded])
+        cand_survivor_indices = [i for i, _ in indexed_decoded]
+
+        query_rows = []
+        for qv in query_vectors_raw:
+            qvec = decode_embedding(qv)
+            if qvec is not None and qvec.size == target_dim:
+                query_rows.append(qvec)
+        if not query_rows:
+            return []
+        query_matrix = np.stack(query_rows)  # (Q, D)
+
+        # (N, D) @ (D, Q) → (N, Q)
+        scores_mat = candidate_matrix @ query_matrix.T
+
+        # Per-query top-K + union dedup + total cap. 保留 "first-seen" 顺序——
+        # query 顺序 × within-query rank → 重要 query 的高分 anchor 在前。
+        n_candidates = scores_mat.shape[0]
+        effective_k = max(0, min(per_query_k, n_candidates))
+        if effective_k == 0:
+            return []
+
+        seen_ids: set[str] = set()
+        result: list[dict] = []
+        for q_idx in range(scores_mat.shape[1]):
+            col = scores_mat[:, q_idx]
+            if effective_k >= n_candidates:
+                top_idx = np.argsort(-col)
+            else:
+                # argpartition O(N) 拿到无序 top-K，再对这 K 个排序
+                unsorted_top = np.argpartition(-col, effective_k - 1)[:effective_k]
+                top_idx = unsorted_top[np.argsort(-col[unsorted_top])]
+            for idx in top_idx:
+                cand_idx = cand_survivor_indices[int(idx)]
+                doc = survivors[cand_idx]
+                doc_id = doc.get('id')
+                if not doc_id or doc_id in seen_ids:
+                    continue
+                seen_ids.add(doc_id)
+                result.append(doc)
+                if len(result) >= total_cap:
+                    return result
+
+        return result
+
     # ── phase 3: LLM rerank ──────────────────────────────────────────
 
     async def _fine_rank(

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -929,13 +929,20 @@ class ReflectionEngine:
 
         try:
             from memory.recall import MemoryRecallReranker
-            from config import REFLECTION_RELATED_RECALL_K
+            from config import (
+                REFLECTION_RELATED_PER_QUERY_K,
+                REFLECTION_RELATED_TOTAL_CAP,
+            )
             reranker = MemoryRecallReranker()
-            related = await reranker.aretrieve_candidates(
+            # Per-query top-K（每条 unabsorbed fact 单独享 ``PER_QUERY_K`` 配额，
+            # union dedup 后截到 ``TOTAL_CAP``），不走 max-pool 全局预算。详见
+            # ``aretrieve_per_query_topk`` docstring 和 PR #1401 thread：max-pool
+            # 在 unabsorbed 主题分散时会让冷门主题挤不进 anchor，per-query 配
+            # 额保证每条 unabsorbed 至少能拿自己的近邻。
+            related = await reranker.aretrieve_per_query_topk(
                 absorbed_pool, query_texts,
-                budget=REFLECTION_RELATED_RECALL_K,
-                config_manager=self._config_manager,
-                rerank=False,
+                per_query_k=REFLECTION_RELATED_PER_QUERY_K,
+                total_cap=REFLECTION_RELATED_TOTAL_CAP,
             )
         except Exception as e:
             logger.warning(f"[Reflection] related context 召回失败: {e}")

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -765,6 +765,16 @@
                         mini_game_invite_enabled: !!S.proactiveMiniGameInviteEnabled
                     })
                 });
+                // HTTP 409 = server try_start_proactive 因并发拒绝（AI 还在响应上一轮 /
+                // 另一路 proactive 已占坑，见 main_routers/system_router.py:4241-4247）。
+                // 本次请求**根本没真正发起**一次 proactive，标 'pass' 走上游"不计数"
+                // 分支自行 schedule，否则 _voiceProactiveNoResponseCount 会被白白消耗
+                // 一格、最坏 5 次 server 忙就触发"连续 5 轮无回复，停止主动搭话"。
+                if (resp.status === 409) {
+                    console.log('[ProactiveChat] 语音模式 server 并发拒绝 (409)，不消耗 attempt');
+                    S._voiceProactiveLastResult = 'pass';
+                    return false;
+                }
                 requestSent = true;
                 var result = await resp.json();
                 S._voiceProactiveLastResult = result.action || 'unknown';
@@ -1023,6 +1033,19 @@
                 },
                 body: JSON.stringify(requestBody)
             });
+            // HTTP 409 = server try_start_proactive 因并发拒绝（AI 还在响应上一轮 /
+            // 另一路 proactive 已占坑，见 main_routers/system_router.py:4241-4247）。
+            // 本次请求**根本没真正发起**一次 proactive——server 在 claim 那一步就早退
+            // 了，没跑过 phase 1/2 LLM、没消耗任何上下文资源。若返 true 让上游
+            // scheduleProactiveChat 的 `if (triggered)` 判定通过、把 backoffLevel++，
+            // 等于"server 一忙就被前端误判成 attempt 用掉一格"，惩罚性升级 backoff 把
+            // 节奏整体往后拉，跟 server 实际状态正交、用户体验上变成"server 越忙、AI
+            // 越沉默"。这里 requestSent 故意不翻 true、return false 让上游识别为"没
+            // 真发"、下一轮按 base interval 重排，不动 level。
+            if (response.status === 409) {
+                console.log('[ProactiveChat] server 并发拒绝 (409)，不消耗 backoff attempt');
+                return false;
+            }
             requestSent = true;
 
             var result = await response.json();

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -499,17 +499,25 @@
                     return;
                 }
                 S.isProactiveChatRunning = true;
+                var voiceTriggered = false;
                 try {
-                    await triggerProactiveChat();
+                    voiceTriggered = await triggerProactiveChat();
                 } finally {
                     S.isProactiveChatRunning = false;
                 }
-                S._voiceProactiveNoResponseCount = (S._voiceProactiveNoResponseCount || 0) + 1;
+                // server 并发拒绝（HTTP 409）时 triggerProactiveChat 返回 false 表示
+                // "根本没真正发起一次 proactive"——不消耗 no-response quota，否则连续
+                // 409 会按 >=10 阈值熔断语音 nudge 直到下次 user 触发 reset。等同
+                // _isAssistantSpeaking / _isUserRecentlySpeaking 这两个 frontend
+                // guard 走的"跳过不计数"分支。Codex review on PR #1401。
+                if (voiceTriggered) {
+                    S._voiceProactiveNoResponseCount = (S._voiceProactiveNoResponseCount || 0) + 1;
+                }
                 // 不在这里 scheduleProactiveChat()——等 AI turn end 后再调度下一次，
                 // 避免 AI 还在说话就被下一次 nudge 打断。
                 // turn end handler 中会对语音模式调用 scheduleProactiveChat()。
-                // 如果本次 nudge 被 guard 跳过（pass），AI 不会响应也不会有 turn end，
-                // 所以 pass 时仍需自行调度。
+                // 如果本次 nudge 被 guard 跳过（pass）/ 被 server 409 拒绝，
+                // AI 不会响应也不会有 turn end，所以这两种情况仍需自行调度。
                 if (S._voiceProactiveLastResult === 'pass') {
                     scheduleProactiveChat();
                 }

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -815,3 +815,205 @@ async def test_aload_signal_targets_suppress_filter_applies_when_vectors_disable
     # The whole point: even with vectors DISABLED, hard_filter ran
     # and dropped the suppressed reflection.
     assert "reflection.r_silent" not in result_ids
+
+
+# ── per-query top-K recall (reflection synthesis 用) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_each_query_gets_independent_k():
+    """20 unabsorbed 主题分散时，max-pool 会让冷门主题挤不进 anchor；
+    per-query 配额保证每条 unabsorbed 至少能拿自己的 top-K。
+
+    Setup: 3 query 各指向独立方向；候选池里每个方向有 2 条高分 + 1 条
+    低分；per_query_k=2 → 每条 query 应该拿到自己方向的 2 条 top（共 6
+    条 union，无重叠 dedup 不触发）。
+    """
+    qmap = {
+        "q_topic_A": [1.0, 0.0, 0.0],
+        "q_topic_B": [0.0, 1.0, 0.0],
+        "q_topic_C": [0.0, 0.0, 1.0],
+    }
+    svc = _FakeService(
+        available=True,
+        model_id="fake-3d-int8",
+        vector_factory=lambda text: qmap.get(text, [0.0, 0.0, 0.0]),
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("A_high1", "ta1", embedding=[1.0, 0.0, 0.0], model_id="fake-3d-int8"),
+        _obs("A_high2", "ta2", embedding=[0.95, 0.05, 0.0], model_id="fake-3d-int8"),
+        _obs("A_low",   "ta3", embedding=[0.3, 0.3, 0.3], model_id="fake-3d-int8"),
+        _obs("B_high1", "tb1", embedding=[0.0, 1.0, 0.0], model_id="fake-3d-int8"),
+        _obs("B_high2", "tb2", embedding=[0.05, 0.95, 0.0], model_id="fake-3d-int8"),
+        _obs("B_low",   "tb3", embedding=[0.3, 0.3, 0.3], model_id="fake-3d-int8"),
+        _obs("C_high1", "tc1", embedding=[0.0, 0.0, 1.0], model_id="fake-3d-int8"),
+        _obs("C_high2", "tc2", embedding=[0.0, 0.05, 0.95], model_id="fake-3d-int8"),
+        _obs("C_low",   "tc3", embedding=[0.3, 0.3, 0.3], model_id="fake-3d-int8"),
+    ]
+    out = await r.aretrieve_per_query_topk(
+        obs, ["q_topic_A", "q_topic_B", "q_topic_C"],
+        per_query_k=2, total_cap=20,
+    )
+    ids = {o["id"] for o in out}
+    # 每个主题的 high1 + high2 都应该入选（per-query top-2 各 2 条 × 3 query
+    # = 6 条，主题间互不重叠）。max-pool 全局 top-6 也会得到同样结果——但
+    # 把 total_cap 缩到 3 时差异就体现出来（见下个测试）。
+    assert {"A_high1", "A_high2", "B_high1", "B_high2", "C_high1", "C_high2"} <= ids
+    # 三个 _low 都不该被任何 query 的 top-2 选中
+    assert "A_low" not in ids and "B_low" not in ids and "C_low" not in ids
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_vs_maxpool_protects_minority_topics():
+    """关键差异点：max-pool 会被高频主题挤掉冷门主题；per-query 不会。
+
+    Setup: query_A 重复 5 次（高频），query_B 1 次（冷门）。total_cap=3
+    时——
+    - max-pool（``aretrieve_candidates``）会把 3 个 slot 全给 A 方向
+      （因为 A 方向有 5 个 query 各贡献最高分）；
+    - per-query top-1（本方法）保证 A 拿 1 + B 拿 1，至少 union >= 2。
+    """
+    qmap = {"q_A": [1.0, 0.0], "q_B": [0.0, 1.0]}
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: qmap.get(text, [0.0, 0.0]),
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("A_anchor", "ta", embedding=[1.0, 0.0]),
+        _obs("B_anchor", "tb", embedding=[0.0, 1.0]),
+        _obs("noise",    "tn", embedding=[0.5, 0.5]),
+    ]
+    # 5 个 A 类 query + 1 个 B 类 query
+    queries = ["q_A"] * 5 + ["q_B"]
+
+    out = await r.aretrieve_per_query_topk(
+        obs, queries, per_query_k=1, total_cap=3,
+    )
+    ids = {o["id"] for o in out}
+    # B_anchor 必须在结果里——这是 per-query 配额的核心保证
+    assert "B_anchor" in ids
+    assert "A_anchor" in ids
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_dedups_across_queries():
+    """同一个候选被多条 query 都选中时，结果里只出现一次。"""
+    qmap = {"q1": [1.0, 0.0], "q2": [0.99, 0.01]}  # 两个 query 都指向 a
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: qmap.get(text, [0.0, 0.0]),
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "ta", embedding=[1.0, 0.0]),
+        _obs("b", "tb", embedding=[0.7, 0.7]),
+    ]
+    out = await r.aretrieve_per_query_topk(
+        obs, ["q1", "q2"], per_query_k=2, total_cap=20,
+    )
+    ids = [o["id"] for o in out]
+    # a 不能出现两次；只 2 条候选 → union 后 ≤ 2 条结果
+    assert ids.count("a") == 1
+    assert set(ids) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_respects_total_cap():
+    """total_cap 截断生效——即使 per_query_k × Q > total_cap。
+
+    Setup: 5 query 各指向 5 个互相正交的方向（5D one-hot），每条 query 对应
+    2 个候选（同方向）。per_query_k=2 → 每条 query 各拿自己方向的 2 条
+    candidates → union 后 10 条（无重叠）→ total_cap=4 截到 4。
+    """
+    def _onehot(dim, idx):
+        v = [0.0] * dim
+        v[idx] = 1.0
+        return v
+
+    qmap = {f"q{i}": _onehot(5, i) for i in range(5)}
+    svc = _FakeService(
+        available=True,
+        model_id="fake-5d-int8",
+        vector_factory=lambda text: qmap.get(text, [0.0] * 5),
+    )
+    r = _make_reranker(svc)
+    obs = []
+    for i in range(5):
+        # 2 个高分候选指向方向 i
+        obs.append(_obs(
+            f"c{i}_h1", f"t{i}_h1",
+            embedding=_onehot(5, i), model_id="fake-5d-int8",
+        ))
+        # 第二个加点噪声但仍主要指向 i，跟 q{i} cosine ≈ 0.98
+        v = _onehot(5, i)
+        v[(i + 1) % 5] = 0.2
+        obs.append(_obs(
+            f"c{i}_h2", f"t{i}_h2",
+            embedding=v, model_id="fake-5d-int8",
+        ))
+    out = await r.aretrieve_per_query_topk(
+        obs, [f"q{i}" for i in range(5)],
+        per_query_k=2, total_cap=4,
+    )
+    assert len(out) == 4, f"total_cap=4 没截断；实际返回 {len(out)} 条"
+    # First-seen 顺序：q0 的 top-2 应该最先入选
+    ids = [o["id"] for o in out]
+    assert ids[0] == "c0_h1" and ids[1] == "c0_h2"
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_returns_empty_when_service_unavailable():
+    """关键 fallback 语义：vector 不可用时**直接返 []**，不退化到
+    evidence_score 排序——见 docstring 解释（"远期 anchor" 角色对
+    semantic 关联要求高，random anchor 比无 anchor 更糟）。"""
+    svc = _FakeService(available=False)
+    r = _make_reranker(svc)
+    obs = [
+        _obs("a", "ta", score=10.0, embedding=[1.0, 0.0]),
+        _obs("b", "tb", score=5.0, embedding=[0.0, 1.0]),
+    ]
+    out = await r.aretrieve_per_query_topk(
+        obs, ["q"], per_query_k=2, total_cap=20,
+    )
+    assert out == [], "vector 不可用时本方法必须返 []，不能按 evidence_score 兜底"
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_empty_inputs_short_circuit():
+    """无 observations / 无 query / 全是空字符串 query → 立即 []。"""
+    svc = _FakeService(available=True)
+    r = _make_reranker(svc)
+    assert await r.aretrieve_per_query_topk([], ["q"], per_query_k=2, total_cap=20) == []
+    assert await r.aretrieve_per_query_topk(
+        [_obs("a", "ta", embedding=[1.0, 0.0])],
+        [],
+        per_query_k=2, total_cap=20,
+    ) == []
+    assert await r.aretrieve_per_query_topk(
+        [_obs("a", "ta", embedding=[1.0, 0.0])],
+        ["", "   ", None],  # type: ignore[list-item]
+        per_query_k=2, total_cap=20,
+    ) == []
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_skips_candidates_without_valid_embedding():
+    """No-embedding 候选不进 matrix——本方法**不**像 _coarse_rank 那样
+    保留 unembedded 候选作 LLM rerank 兜底（本方法没有 rerank 阶段）。"""
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: [1.0, 0.0],
+    )
+    r = _make_reranker(svc)
+    obs = [
+        _obs("with_embed", "ta", embedding=[1.0, 0.0]),
+        # No embedding field at all — should be skipped silently
+        _obs("no_embed", "tb"),
+    ]
+    out = await r.aretrieve_per_query_topk(
+        obs, ["q"], per_query_k=2, total_cap=20,
+    )
+    ids = {o["id"] for o in out}
+    assert ids == {"with_embed"}

--- a/tests/unit/test_memory_recall.py
+++ b/tests/unit/test_memory_recall.py
@@ -958,9 +958,86 @@ async def test_per_query_topk_respects_total_cap():
         per_query_k=2, total_cap=4,
     )
     assert len(out) == 4, f"total_cap=4 没截断；实际返回 {len(out)} 条"
-    # First-seen 顺序：q0 的 top-2 应该最先入选
+    # Round-robin 顺序：先每条 query 各出 #1，所以截到 4 时拿到的是
+    # q0~q3 的 #1（c0_h1, c1_h1, c2_h1, c3_h1）——q0 的 #2 (c0_h2) 必须
+    # 留给下一轮，但 cap 在 round 0 内就触发 → c0_h2 不该出现。
     ids = [o["id"] for o in out]
-    assert ids[0] == "c0_h1" and ids[1] == "c0_h2"
+    assert ids == ["c0_h1", "c1_h1", "c2_h1", "c3_h1"], (
+        f"round-robin ordering 违约；实际: {ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_cap_does_not_starve_late_queries():
+    """fairness regression：``total_cap`` 截断**只能**发生在 round-robin
+    之后，不能在 per-query 内部 early-return。否则前几个 query 吃光所有
+    slot，后面 query 一条 anchor 都拿不到——退化成 max-pool 那种 cold-
+    topic 饥饿。PR #1401 thread 用户原话："必须最后统一去 cap，不然便宜
+    了先判定的 fact"。
+
+    Setup: 5 query 各指向独立方向，每方向 2 个 candidate（high1, high2）。
+    per_query_k=2 + total_cap=5 → 期望 round-robin 拿到 5 个 query 各自
+    的 #1（c0_h1..c4_h1），任何 _h2 都不该出现（cap 在 round 0 就满了）。
+    """
+    def _onehot(dim, idx):
+        v = [0.0] * dim
+        v[idx] = 1.0
+        return v
+
+    qmap = {f"q{i}": _onehot(5, i) for i in range(5)}
+    svc = _FakeService(
+        available=True,
+        model_id="fake-5d-int8",
+        vector_factory=lambda text: qmap.get(text, [0.0] * 5),
+    )
+    r = _make_reranker(svc)
+    obs = []
+    for i in range(5):
+        obs.append(_obs(
+            f"c{i}_h1", f"t{i}_h1",
+            embedding=_onehot(5, i), model_id="fake-5d-int8",
+        ))
+        v = _onehot(5, i)
+        v[(i + 1) % 5] = 0.2
+        obs.append(_obs(
+            f"c{i}_h2", f"t{i}_h2",
+            embedding=v, model_id="fake-5d-int8",
+        ))
+
+    out = await r.aretrieve_per_query_topk(
+        obs, [f"q{i}" for i in range(5)],
+        per_query_k=2, total_cap=5,
+    )
+    ids = [o["id"] for o in out]
+    # 每个 query 至少出 1 条 anchor（fairness 核心保证）
+    for i in range(5):
+        assert f"c{i}_h1" in ids, (
+            f"q{i} 在 cap=5 + 5 queries 下被饿死；ids={ids}。"
+            f"这就是用户在 PR #1401 thread 抓到的 fairness 退化——'便宜了先"
+            f"判定的 fact'。"
+        )
+    # _h2 都还在等下一轮，不该出现
+    for i in range(5):
+        assert f"c{i}_h2" not in ids
+
+
+@pytest.mark.asyncio
+async def test_per_query_topk_total_cap_zero_returns_empty():
+    """``total_cap <= 0`` 时必须直接返 []，不能因为先 append 后 check 而
+    漏出 1 条结果（CodeRabbit Minor on PR #1401）。"""
+    qmap = {"q": [1.0, 0.0]}
+    svc = _FakeService(
+        available=True,
+        vector_factory=lambda text: qmap.get(text, [0.0, 0.0]),
+    )
+    r = _make_reranker(svc)
+    obs = [_obs("a", "ta", embedding=[1.0, 0.0])]
+    assert await r.aretrieve_per_query_topk(
+        obs, ["q"], per_query_k=2, total_cap=0,
+    ) == []
+    assert await r.aretrieve_per_query_topk(
+        obs, ["q"], per_query_k=2, total_cap=-5,
+    ) == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_reflection_synthesis_loop.py
+++ b/tests/unit/test_reflection_synthesis_loop.py
@@ -198,3 +198,38 @@ def test_proactive_chat_handler_no_longer_posts_reflect():
         # 因为这个直觉负担，加括号杜绝同类困惑）
         f"匹配到: {(post_to_reflect.group(0) if post_to_reflect else '')!r}"
     )
+
+
+@pytest.mark.unit
+def test_proactive_chat_concurrent_rejection_returns_http_409():
+    """``proactive_chat`` handler 因 ``try_start_proactive`` 拒绝时必须返回
+    HTTP 409，且 response body 是 ``{"success": False, "error": <str>}``——
+    这是前端 ``app-proactive.js`` ``triggerProactiveChat`` 用来识别"server
+    并发忙、本次 attempt 不消耗 backoff"的 wire 契约。
+
+    任何把这条改成 status_code=200 / 不同 body shape 的 refactor 都会让前端
+    的 ``if (response.status === 409) return false`` guard 失效，server 一忙
+    就被前端误判成一次有效 attempt → 升级 backoff → 节奏整体往后拉，跟 server
+    实际状态正交。
+
+    用源码扫描而非 runtime call：handler 太重（依赖 MEMORY_SERVER_PORT / WS
+    / activity tracker / async LLM client 等等），跑完整 startup 不划算。这里
+    只钉静态保证。
+    """
+    import inspect
+    import main_routers.system_router as system_router
+
+    src = inspect.getsource(system_router.proactive_chat)
+
+    # try_start_proactive 失败那一段必须有 status_code=409
+    assert "try_start_proactive" in src, (
+        "proactive_chat 必须用 try_start_proactive 做并发占坑（PR #1015 引入的"
+        "原子 check+claim）；refactor 改成无锁 can_start_proactive 双查会重新"
+        "引入 PR #1015 修过的双进 PHASE1 race"
+    )
+    # 拒绝路径必须 409 + success=False（前端契约）
+    assert "status_code=409" in src, (
+        "proactive_chat 并发拒绝时必须 HTTP 409 —— 前端 "
+        "app-proactive.js triggerProactiveChat 据此跳过 backoff++。若改成 "
+        "200/500 等其他 status，前端会把 server 忙误算成 attempt 消耗"
+    )

--- a/tests/unit/test_reflection_synthesis_loop.py
+++ b/tests/unit/test_reflection_synthesis_loop.py
@@ -192,5 +192,9 @@ def test_proactive_chat_handler_no_longer_posts_reflect():
         "proactive_chat handler 里不能再 POST /reflect/{name} —— 合成已迁到 "
         "_periodic_reflection_synthesis_loop 后端循环；这条 mutation 放在 "
         "proactive 关键路径上会拖延 ~15s + 让 reflection 增长依赖前端。"
-        f"匹配到: {post_to_reflect.group(0) if post_to_reflect else ''!r}"
+        # 显式括号让 !r 应用范围一眼可见，省 reader 心算 conditional-expr +
+        # conversion-spec 的 precedence（PEP 498 已经定义了行为，但 future
+        # reader 一眼看不出来——CodeRabbit PR #1401 误报为 SyntaxError 就是
+        # 因为这个直觉负担，加括号杜绝同类困惑）
+        f"匹配到: {(post_to_reflect.group(0) if post_to_reflect else '')!r}"
     )

--- a/tests/unit/test_reflection_synthesis_loop.py
+++ b/tests/unit/test_reflection_synthesis_loop.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""Reflection synthesis 后端循环 - regression test.
+
+Pin 两条不变量：
+
+1. ``_periodic_reflection_synthesis_loop`` 存在，且按 ``MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS``
+   每轮对所有 catgirl 调一次 ``reflection_engine.synthesize_reflections(name)``。
+   单角色失败不阻塞其余 + 不让循环退出。
+
+2. ``main_routers/system_router.py`` 的 ``proactive_chat`` handler 不再
+   ``POST /reflect/{name}``。这条 mutation 之前挂在 frontend-driven 关键路径
+   上（PR #1015 顺手塞的），会让"前端关 / proactive 不触发 → reflection 永
+   不增长"。现在合成只在后端循环里走，**任何**把 ``/reflect`` POST 加回
+   ``proactive_chat`` handler 的 refactor 都会被这里抓到——前端解耦是设计意图。
+
+测不到的部分（留 manual / e2e）：
+- 实际 LLM 是否生成 valid reflection（``synthesize_reflections`` 自身已有
+  ``tests/unit/test_reflection_*`` 覆盖）
+- frontend ``/api/proactive_chat`` setTimeout 是否触发（本来就是 frontend issue，
+  不在本 PR scope；本 PR 的 fix 是"即使 proactive 永远不触发，reflection 也
+  会持续生长"）
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reflection_synthesis_loop_calls_synthesize_for_each_character():
+    """每轮循环对所有 catgirl 各调一次 synthesize_reflections。
+
+    用 patched asyncio.sleep 做开关：第二次 sleep（loop tail）被 raise CancelledError
+    打断，让 loop 只跑一轮就退出。第一次 sleep（_INITIAL_DELAY_REFLECTION_SYNTHESIS）
+    立即返回。
+    """
+    from app import memory_server
+
+    fake_engine = MagicMock()
+    fake_engine.synthesize_reflections = AsyncMock(return_value=[])
+
+    fake_cm = MagicMock()
+    fake_cm.aload_characters = AsyncMock(return_value={
+        '猫娘': {'悠怡': {}, '喵酱': {}, '小八': {}}
+    })
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        # 首次 (initial delay) + tail sleep 都让出，第二次 tail sleep 砍掉 loop
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError
+
+    with patch.object(memory_server, "reflection_engine", fake_engine), \
+         patch.object(memory_server, "_config_manager", fake_cm), \
+         patch("app.memory_server.asyncio.sleep", new=fake_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            await memory_server._periodic_reflection_synthesis_loop()
+
+    # 每个 catgirl 各被调一次
+    assert fake_engine.synthesize_reflections.await_count == 3
+    called_names = {call.args[0] for call in fake_engine.synthesize_reflections.await_args_list}
+    assert called_names == {'悠怡', '喵酱', '小八'}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reflection_synthesis_loop_single_character_failure_does_not_abort_others():
+    """悠怡 synthesize 抛异常，喵酱 / 小八 仍然各被调一次。"""
+    from app import memory_server
+
+    fake_engine = MagicMock()
+
+    async def _synth(name):
+        if name == '悠怡':
+            raise RuntimeError("simulated LLM crash")
+        return []
+
+    fake_engine.synthesize_reflections = AsyncMock(side_effect=_synth)
+
+    fake_cm = MagicMock()
+    fake_cm.aload_characters = AsyncMock(return_value={
+        '猫娘': {'悠怡': {}, '喵酱': {}, '小八': {}}
+    })
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError
+
+    with patch.object(memory_server, "reflection_engine", fake_engine), \
+         patch.object(memory_server, "_config_manager", fake_cm), \
+         patch("app.memory_server.asyncio.sleep", new=fake_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            await memory_server._periodic_reflection_synthesis_loop()
+
+    assert fake_engine.synthesize_reflections.await_count == 3
+    called_names = [call.args[0] for call in fake_engine.synthesize_reflections.await_args_list]
+    assert '悠怡' in called_names
+    assert '喵酱' in called_names
+    assert '小八' in called_names
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reflection_synthesis_loop_load_characters_failure_skips_round_does_not_abort():
+    """aload_characters 抛异常时本轮跳过、loop 不挂；下一轮 sleep 后再试。"""
+    from app import memory_server
+
+    fake_engine = MagicMock()
+    fake_engine.synthesize_reflections = AsyncMock(return_value=[])
+
+    call_count = {'n': 0}
+
+    async def _fail_then_succeed():
+        call_count['n'] += 1
+        if call_count['n'] == 1:
+            raise RuntimeError("simulated disk read fail")
+        return {'猫娘': {'悠怡': {}}}
+
+    fake_cm = MagicMock()
+    fake_cm.aload_characters = AsyncMock(side_effect=_fail_then_succeed)
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        # 让 loop 跑两轮（initial delay + 第一轮失败后 sleep + 第二轮成功后 sleep）
+        if len(sleep_calls) >= 3:
+            raise asyncio.CancelledError
+
+    with patch.object(memory_server, "reflection_engine", fake_engine), \
+         patch.object(memory_server, "_config_manager", fake_cm), \
+         patch("app.memory_server.asyncio.sleep", new=fake_sleep):
+        with pytest.raises(asyncio.CancelledError):
+            await memory_server._periodic_reflection_synthesis_loop()
+
+    # 第一轮 aload_characters 失败 → 0 次 synthesize
+    # 第二轮成功 → 悠怡 被调 1 次
+    assert fake_engine.synthesize_reflections.await_count == 1
+    assert fake_engine.synthesize_reflections.await_args.args[0] == '悠怡'
+
+
+@pytest.mark.unit
+def test_reflection_synthesis_loop_registered_in_background_tasks():
+    """``ensure_memory_server_runtime_initialized`` 必须把
+    ``_periodic_reflection_synthesis_loop`` 注册到 ``_spawn_background_task``。
+
+    用源码扫描而非 runtime instrumentation：这里要钉的是"loop 被挂上去"这件事
+    本身（regression：删除注册行是单字符级别的、容易疏漏的退化），不需要也不
+    应该跑完整 server startup。
+    """
+    import inspect
+    from app import memory_server
+
+    src = inspect.getsource(memory_server.ensure_memory_server_runtime_initialized)
+    assert "_periodic_reflection_synthesis_loop()" in src, (
+        "ensure_memory_server_runtime_initialized 必须 _spawn_background_task("
+        "_periodic_reflection_synthesis_loop()) —— 没有它，pending reflection 增长会停摆"
+    )
+
+
+@pytest.mark.unit
+def test_proactive_chat_handler_no_longer_posts_reflect():
+    """``main_routers/system_router.proactive_chat`` 必须不再 POST /reflect。
+
+    在 PR #1015 之后，reflection 合成 + auto_transitions 都迁到了 memory_server
+    自己的两条后端循环（synthesis loop + auto_promote loop），proactive_chat
+    关键路径上保留这条 mutation 只会拖响应时间 + 让 reflection 生命周期与
+    frontend setTimeout 强耦合。任何把这行加回去的 refactor 必须先解释为
+    什么 backend loop 不够。
+    """
+    import inspect
+    import re
+    import main_routers.system_router as system_router
+
+    src = inspect.getsource(system_router.proactive_chat)
+    # 精确匹配 "POST 到 /reflect 端点" 这件事——而不是单纯出现 "/reflect/" 字面，
+    # 因为说明 backend 已经迁走的注释里允许有路径名（历史 trace）。
+    # 任何能形成 HTTP POST 到 /reflect 的代码会包含 .post(...reflect...)。
+    post_to_reflect = re.search(
+        r"""\.post\s*\(\s*[^)]*?["']\S*?/reflect/""",
+        src,
+    )
+    assert post_to_reflect is None, (
+        "proactive_chat handler 里不能再 POST /reflect/{name} —— 合成已迁到 "
+        "_periodic_reflection_synthesis_loop 后端循环；这条 mutation 放在 "
+        "proactive 关键路径上会拖延 ~15s + 让 reflection 增长依赖前端。"
+        f"匹配到: {post_to_reflect.group(0) if post_to_reflect else ''!r}"
+    )


### PR DESCRIPTION
## Summary

- 加 `_periodic_reflection_synthesis_loop`：与现有 9 条 `_periodic_*_loop` 对偶，每 600s 对每个 catgirl 调一次 `reflection_engine.synthesize_reflections(name)`，gate 全靠 synthesize_reflections 自身内置（`MIN_FACTS_FOR_REFLECTION=5` + 幂等 id dedup + `REFLECTION_SYNTHESIS_FACTS_MAX=20`）
- 删 `main_routers/system_router.proactive_chat` handler 里的 `POST /reflect/{name}`：mutation 不该挂在 frontend-driven 关键路径上，~15s timeout 拖延 phase1 响应，且整套 reflection 生命周期跟前端 setTimeout 强耦合
- 加 5 个 regression test 钉住"每轮跑 / 单角色失败不阻塞 / 注册到 spawn 列表 / proactive_chat 不再 POST /reflect"
- 无回归（adjacent suites + memory_server / reflection / proactive_sm 共 34 + 10 + 5 = 49 通过；全仓 2463 通过、12 失败全是 main 已存在的 pre-existing fail —— api_config / cloudsave / galgame / stepfun_tts，跟本 PR 无关）

## Root cause

reflection 合成原本只挂在 [`main_routers/system_router.py`](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/main_routers/system_router.py) 的 `proactive_chat` handler 里（PR #1015 顺手塞的，整 PR 5000+ 字 commit message 没解释为什么放这），导致：

- 前端 setTimeout 不调 `/api/proactive_chat` → 后端 `/reflect` 永远不被调
- 浏览器关 / 标签隐藏 / 任一 frontend gate（`gameRouteActive` / `proactiveChatEnabled` / `canTriggerProactively` / leader election）false → `reflections.json` 完全停止增长
- proactive 关键路径上多一次 mutation，~15s timeout 拖延 phase1 响应（commit 注释 [system_router.py:5058](https://github.com/Project-N-E-K-O/N.E.K.O/blob/main/main_routers/system_router.py#L5058) 也自己提到这是"又一段可能拖很久的 await 串"）

线上实测：长跑测试 53+ 小时 0 条新 reflection——前端 proactive 调度某条 gate 早退，整套合成停摆，hybrid_recall 召回池里 reflection tier 永远只有那 4 条老的。

## Why backend loop

按对偶性，memory_server 已经跑 9 条 `_periodic_*_loop`：
- `_periodic_rebuttal_loop`
- `_periodic_auto_promote_loop`（pending → confirmed/promoted）
- `_periodic_idle_maintenance_loop`（history compress / persona corrections / review）
- `_periodic_signal_extraction_loop`（Stage-1+Stage-2 fact extraction）
- `_periodic_archive_sweep_loop`
- `_periodic_new_dialog_qps_log_loop`
- `_periodic_slow_memory_recheck_loop`
- `_periodic_persona_refine_loop`
- `_periodic_reflection_refine_loop`（refine 已有 reflection）

唯独 **合成** 这一步缺循环，靠前端 HTTP 触发——不合理。本 PR 把这个缺口补上，跟其它 9 条一样长跑在 memory_server 进程内，跟前端解耦。

## Why safe to spam

`synthesize_reflections` 自带：
1. `len(unabsorbed) < 5 → return []`
2. 同批 source_fact_ids → 同 reflection id → 已存在则跳 LLM 仅补跑 `mark_absorbed`

所以 10 min 一轮就算频繁也大多数 short-circuit，正常 LLM 调用频率 ≈ "用户在 10 min 内新积了 ≥5 条 unabsorbed fact 的次数"，受 user activity gating。

## auto_promote / followup_topics 的处理

- **auto_promote**（pending → confirmed）：早就由 `_periodic_auto_promote_loop` 每 180s 跑，proactive 里那次 fire-and-forget `_spawn_background_task(_safe_auto_promote(name))` 本来就只是 redundant trigger，删了不影响
- **followup_topics GET**：保留——这是 read-only query，proactive prompt 真正需要的话题候选

## Test plan

- [x] `uv run pytest tests/unit/test_reflection_synthesis_loop.py -v` → 5 passed
- [x] `uv run pytest tests/unit/test_memory_server_cache_settle.py tests/unit/test_reflection_idempotent.py tests/unit/test_reflection_filters.py tests/unit/test_evidence_extraction.py tests/unit/test_proactive_sm_integration.py -q` → 44 passed
- [x] 全仓 `uv run pytest tests/unit/` → 2463 passed, 12 pre-existing main fails（api_config / cloudsave / galgame / stepfun_tts，与本 PR 无关）
- [ ] 手动验证：跑 launcher 11+ min → 期待看到 `[ReflectionSynth] {name}: 合成 N 条新 pending reflection` 日志（前端浏览器**不开**也能看到）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加常驻后台调度，按可配置间隔定期为角色合成反思内容。

* **改进**
  * 将反思相关召回改为“每条查询独立配额 + 总上限”，提升冷门主题保护与去重效果；替换旧召回配置为新的 per-query/total 参数并导出默认值。
  * 移除请求路径中的同步反思触发，降低潜在响应延迟。
  * 前端在并发拒绝（HTTP 409）时短路，避免误计或推进退避逻辑。

* **测试**
  * 新增回归测试，覆盖调度行为、异常隔离、召回策略和 409 处理。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->