### PR TITLE
fix(memory): x86 CPUID 直接探测 AVX-VNNI，修 Windows Alder Lake+ embedding 被误关

### DIFF
--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -268,12 +268,168 @@ def detect_total_ram_gb() -> float | None:
         return None
 
 
+def _probe_avx_vnni_via_cpuid() -> bool | None:
+    """Direct CPUID probe for AVX-VNNI / AVX-512_VNNI on x86_64.
+
+    Returns:
+      * True  — AVX-VNNI or AVX-512_VNNI is present
+      * False — neither bit set (CPU truly lacks the int8 fast path)
+      * None  — probe could not be performed (32-bit Python, non-x86_64,
+        OS refused executable allocation, CPUID itself faulted)
+
+    Why this exists: py-cpuinfo's Windows backend never surfaces the
+    ``avx_vnni`` flag, even on chips that have it (Alder Lake → Arrow
+    Lake on Intel, Zen 4+ on AMD), and Windows exposes no
+    ``PF_AVX_VNNI_INSTRUCTIONS_AVAILABLE`` constant via
+    ``IsProcessorFeaturePresent``. Without this probe every modern x86
+    Windows user gets sticky-disabled embeddings, the x86 mirror of the
+    Apple Silicon bug fixed in PR #1394.
+
+    CPUID feature bits used:
+      * leaf 7 subleaf 0, ECX bit 11 → AVX-512_VNNI (Cascade Lake+ /
+        Zen 4 server parts)
+      * leaf 7 subleaf 1, EAX bit 4  → AVX-VNNI (Alder Lake+, Zen 4+)
+
+    All allocation / execution paths are wrapped in try/except — any
+    failure returns ``None`` so the caller falls back to py-cpuinfo /
+    /proc/cpuinfo without changing behaviour for unsupported runtimes
+    (DEP-locked sandboxes, hardened-runtime macOS, etc.).
+    """
+    if platform.machine().lower() not in ("amd64", "x86_64"):
+        return None
+    # platform.machine reflects the host arch even under 32-bit Python
+    # (WoW64 reports AMD64). Our shellcode is 64-bit only — gate on the
+    # pointer size of the *running* interpreter to avoid mis-decoding it
+    # under a 32-bit Python on a 64-bit OS.
+    import struct
+    if struct.calcsize("P") != 8:
+        return None
+
+    try:
+        import ctypes
+        system = platform.system()
+        if system == "Windows":
+            # Microsoft x64 ABI: leaf=RCX, subleaf=RDX, out ptr=R8.
+            shellcode = bytes([
+                0x89, 0xC8,                         # mov  eax, ecx     ; leaf
+                0x89, 0xD1,                         # mov  ecx, edx     ; subleaf
+                0x53,                               # push rbx          ; nonvolatile
+                0x0F, 0xA2,                         # cpuid
+                0x41, 0x89, 0x00,                   # mov  [r8],    eax
+                0x41, 0x89, 0x58, 0x04,             # mov  [r8+4],  ebx
+                0x41, 0x89, 0x48, 0x08,             # mov  [r8+8],  ecx
+                0x41, 0x89, 0x50, 0x0C,             # mov  [r8+12], edx
+                0x5B,                               # pop  rbx
+                0xC3,                               # ret
+            ])
+            k32 = ctypes.windll.kernel32
+            k32.VirtualAlloc.restype = ctypes.c_void_p
+            k32.VirtualAlloc.argtypes = [
+                ctypes.c_void_p, ctypes.c_size_t,
+                ctypes.c_uint32, ctypes.c_uint32,
+            ]
+            k32.VirtualFree.argtypes = [
+                ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint32,
+            ]
+            PAGE_EXECUTE_READWRITE = 0x40
+            MEM_COMMIT_RESERVE = 0x3000
+            MEM_RELEASE = 0x8000
+            addr = k32.VirtualAlloc(
+                None, len(shellcode), MEM_COMMIT_RESERVE, PAGE_EXECUTE_READWRITE,
+            )
+            if not addr:
+                return None
+            try:
+                ctypes.memmove(addr, shellcode, len(shellcode))
+                cpuid_fn = ctypes.CFUNCTYPE(
+                    None, ctypes.c_uint32, ctypes.c_uint32,
+                    ctypes.POINTER(ctypes.c_uint32 * 4),
+                )(addr)
+                return _check_vnni_via_cpuid(cpuid_fn)
+            finally:
+                k32.VirtualFree(addr, 0, MEM_RELEASE)
+
+        if system in ("Linux", "Darwin"):
+            # SysV x86_64 ABI: leaf=RDI, subleaf=RSI, out ptr=RDX. RDX
+            # is also clobbered by CPUID, so the prologue moves it to
+            # R8 (volatile, free to use) before calling.
+            shellcode = bytes([
+                0x89, 0xF8,                         # mov  eax, edi     ; leaf
+                0x89, 0xF1,                         # mov  ecx, esi     ; subleaf
+                0x49, 0x89, 0xD0,                   # mov  r8,  rdx     ; preserve out ptr
+                0x53,                               # push rbx
+                0x0F, 0xA2,                         # cpuid
+                0x41, 0x89, 0x00,                   # mov  [r8],    eax
+                0x41, 0x89, 0x58, 0x04,             # mov  [r8+4],  ebx
+                0x41, 0x89, 0x48, 0x08,             # mov  [r8+8],  ecx
+                0x41, 0x89, 0x50, 0x0C,             # mov  [r8+12], edx
+                0x5B,                               # pop  rbx
+                0xC3,                               # ret
+            ])
+            import mmap
+            buf = mmap.mmap(
+                -1, len(shellcode),
+                prot=mmap.PROT_READ | mmap.PROT_WRITE | mmap.PROT_EXEC,
+            )
+            try:
+                buf.write(shellcode)
+                addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+                cpuid_fn = ctypes.CFUNCTYPE(
+                    None, ctypes.c_uint32, ctypes.c_uint32,
+                    ctypes.POINTER(ctypes.c_uint32 * 4),
+                )(addr)
+                return _check_vnni_via_cpuid(cpuid_fn)
+            finally:
+                buf.close()
+
+        return None
+    except Exception:
+        return None
+
+
+def _check_vnni_via_cpuid(cpuid_fn) -> bool:
+    """Issue the two CPUID leaves that carry the int8 fast-path bits.
+
+    Split out from :func:`_probe_avx_vnni_via_cpuid` so the platform-
+    specific allocation wrapper can stay focused on memory management;
+    keeping the bit math here also makes the leaf/bit references
+    greppable from a single location.
+    """
+    import ctypes
+    out = (ctypes.c_uint32 * 4)()
+    cpuid_fn(0, 0, ctypes.byref(out))
+    max_basic = out[0]
+    if max_basic < 7:
+        return False
+    cpuid_fn(7, 0, ctypes.byref(out))
+    max_sub = out[0]
+    if out[2] & (1 << 11):       # ECX bit 11 → AVX-512_VNNI
+        return True
+    if max_sub < 1:
+        return False
+    cpuid_fn(7, 1, ctypes.byref(out))
+    return bool(out[0] & (1 << 4))  # EAX bit 4 → AVX-VNNI
+
+
 def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
     """x86 INT8 fast path = AVX-VNNI (or AVX512-VNNI).
 
+    Detection order:
+      1. Direct CPUID probe (:func:`_probe_avx_vnni_via_cpuid`) —
+         OS-independent and authoritative when it runs.
+      2. ``py-cpuinfo`` flags — kept as a fallback for runtimes that
+         block executable memory.
+      3. ``/proc/cpuinfo`` on Linux — last-ditch text parse if even
+         ``py-cpuinfo`` failed to import or returned nothing.
+
     Returns ``(has_vnni, absence_confirmed)``. ``absence_confirmed=False``
-    means we could not read CPU flags (rare with py-cpuinfo as a hard dep).
+    means no path could read CPU flags — the caller stays optimistic and
+    picks INT8 in that case (consistent with the ARM branch).
     """
+    probed = _probe_avx_vnni_via_cpuid()
+    if probed is not None:
+        return probed, True
+
     try:
         import cpuinfo  # type: ignore
         flags = cpuinfo.get_cpu_info().get("flags", []) or []

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -269,32 +269,46 @@ def detect_total_ram_gb() -> float | None:
 
 
 def _probe_avx_vnni_via_cpuid() -> bool | None:
-    """Direct CPUID probe for AVX-VNNI / AVX-512_VNNI on x86_64.
+    """Direct CPUID probe for AVX-VNNI / AVX-512_VNNI — Windows x86_64 only.
 
     Returns:
       * True  — AVX-VNNI or AVX-512_VNNI is present
       * False — neither bit set (CPU truly lacks the int8 fast path)
-      * None  — probe could not be performed (32-bit Python, non-x86_64,
-        OS refused executable allocation, CPUID itself faulted)
+      * None  — probe was not attempted (non-Windows, non-x86_64,
+        32-bit Python, OS refused executable allocation)
 
-    Why this exists: py-cpuinfo's Windows backend never surfaces the
-    ``avx_vnni`` flag, even on chips that have it (Alder Lake → Arrow
-    Lake on Intel, Zen 4+ on AMD), and Windows exposes no
-    ``PF_AVX_VNNI_INSTRUCTIONS_AVAILABLE`` constant via
-    ``IsProcessorFeaturePresent``. Without this probe every modern x86
-    Windows user gets sticky-disabled embeddings, the x86 mirror of the
-    Apple Silicon bug fixed in PR #1394.
+    Why Windows-only: the bug this fixes is py-cpuinfo's Windows backend
+    silently omitting ``avx_vnni`` from its flag list — every Alder Lake
+    onwards Intel (and Zen 4+ AMD) box on Windows gets misread as
+    "no VNNI" and the embedding stack sticky-disables. Windows also
+    exposes no ``PF_AVX_VNNI_INSTRUCTIONS_AVAILABLE`` constant via
+    ``IsProcessorFeaturePresent``, so a raw CPUID is the only authoritative
+    answer on that platform.
+
+    Why not Linux / macOS:
+
+      * Linux 5.17+ exposes ``avx_vnni`` in ``/proc/cpuinfo`` flags, which
+        both py-cpuinfo and our text-parse fallback already handle.
+        Running CPUID on Linux is also unsafe in the general case —
+        ``arch_prctl(ARCH_SET_CPUID, 0)`` (rr debugger, some
+        sandboxes) makes ``cpuid`` deliver SIGSEGV, which Python's
+        try/except cannot catch and would hard-kill the process (Codex
+        P1 review on PR #1402).
+      * macOS Intel topped out at Ice Lake (pre-AVX-VNNI), so no Intel
+        Mac in the wild has the fast path to detect — and hardened
+        runtime makes PROT_EXEC pages unreliable on recent macOS.
 
     CPUID feature bits used:
       * leaf 7 subleaf 0, ECX bit 11 → AVX-512_VNNI (Cascade Lake+ /
         Zen 4 server parts)
       * leaf 7 subleaf 1, EAX bit 4  → AVX-VNNI (Alder Lake+, Zen 4+)
 
-    All allocation / execution paths are wrapped in try/except — any
-    failure returns ``None`` so the caller falls back to py-cpuinfo /
-    /proc/cpuinfo without changing behaviour for unsupported runtimes
-    (DEP-locked sandboxes, hardened-runtime macOS, etc.).
+    All allocation / execution is wrapped in try/except — any failure
+    returns ``None`` so the caller falls back to py-cpuinfo without
+    changing behaviour for DEP-locked sandboxes.
     """
+    if platform.system() != "Windows":
+        return None
     if platform.machine().lower() not in ("amd64", "x86_64"):
         return None
     # platform.machine reflects the host arch even under 32-bit Python
@@ -307,82 +321,45 @@ def _probe_avx_vnni_via_cpuid() -> bool | None:
 
     try:
         import ctypes
-        system = platform.system()
-        if system == "Windows":
-            # Microsoft x64 ABI: leaf=RCX, subleaf=RDX, out ptr=R8.
-            shellcode = bytes([
-                0x89, 0xC8,                         # mov  eax, ecx     ; leaf
-                0x89, 0xD1,                         # mov  ecx, edx     ; subleaf
-                0x53,                               # push rbx          ; nonvolatile
-                0x0F, 0xA2,                         # cpuid
-                0x41, 0x89, 0x00,                   # mov  [r8],    eax
-                0x41, 0x89, 0x58, 0x04,             # mov  [r8+4],  ebx
-                0x41, 0x89, 0x48, 0x08,             # mov  [r8+8],  ecx
-                0x41, 0x89, 0x50, 0x0C,             # mov  [r8+12], edx
-                0x5B,                               # pop  rbx
-                0xC3,                               # ret
-            ])
-            k32 = ctypes.windll.kernel32
-            k32.VirtualAlloc.restype = ctypes.c_void_p
-            k32.VirtualAlloc.argtypes = [
-                ctypes.c_void_p, ctypes.c_size_t,
-                ctypes.c_uint32, ctypes.c_uint32,
-            ]
-            k32.VirtualFree.argtypes = [
-                ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint32,
-            ]
-            PAGE_EXECUTE_READWRITE = 0x40
-            MEM_COMMIT_RESERVE = 0x3000
-            MEM_RELEASE = 0x8000
-            addr = k32.VirtualAlloc(
-                None, len(shellcode), MEM_COMMIT_RESERVE, PAGE_EXECUTE_READWRITE,
-            )
-            if not addr:
-                return None
-            try:
-                ctypes.memmove(addr, shellcode, len(shellcode))
-                cpuid_fn = ctypes.CFUNCTYPE(
-                    None, ctypes.c_uint32, ctypes.c_uint32,
-                    ctypes.POINTER(ctypes.c_uint32 * 4),
-                )(addr)
-                return _check_vnni_via_cpuid(cpuid_fn)
-            finally:
-                k32.VirtualFree(addr, 0, MEM_RELEASE)
-
-        if system in ("Linux", "Darwin"):
-            # SysV x86_64 ABI: leaf=RDI, subleaf=RSI, out ptr=RDX. RDX
-            # is also clobbered by CPUID, so the prologue moves it to
-            # R8 (volatile, free to use) before calling.
-            shellcode = bytes([
-                0x89, 0xF8,                         # mov  eax, edi     ; leaf
-                0x89, 0xF1,                         # mov  ecx, esi     ; subleaf
-                0x49, 0x89, 0xD0,                   # mov  r8,  rdx     ; preserve out ptr
-                0x53,                               # push rbx
-                0x0F, 0xA2,                         # cpuid
-                0x41, 0x89, 0x00,                   # mov  [r8],    eax
-                0x41, 0x89, 0x58, 0x04,             # mov  [r8+4],  ebx
-                0x41, 0x89, 0x48, 0x08,             # mov  [r8+8],  ecx
-                0x41, 0x89, 0x50, 0x0C,             # mov  [r8+12], edx
-                0x5B,                               # pop  rbx
-                0xC3,                               # ret
-            ])
-            import mmap
-            buf = mmap.mmap(
-                -1, len(shellcode),
-                prot=mmap.PROT_READ | mmap.PROT_WRITE | mmap.PROT_EXEC,
-            )
-            try:
-                buf.write(shellcode)
-                addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
-                cpuid_fn = ctypes.CFUNCTYPE(
-                    None, ctypes.c_uint32, ctypes.c_uint32,
-                    ctypes.POINTER(ctypes.c_uint32 * 4),
-                )(addr)
-                return _check_vnni_via_cpuid(cpuid_fn)
-            finally:
-                buf.close()
-
-        return None
+        # Microsoft x64 ABI: leaf=RCX, subleaf=RDX, out ptr=R8.
+        shellcode = bytes([
+            0x89, 0xC8,                         # mov  eax, ecx     ; leaf
+            0x89, 0xD1,                         # mov  ecx, edx     ; subleaf
+            0x53,                               # push rbx          ; nonvolatile
+            0x0F, 0xA2,                         # cpuid
+            0x41, 0x89, 0x00,                   # mov  [r8],    eax
+            0x41, 0x89, 0x58, 0x04,             # mov  [r8+4],  ebx
+            0x41, 0x89, 0x48, 0x08,             # mov  [r8+8],  ecx
+            0x41, 0x89, 0x50, 0x0C,             # mov  [r8+12], edx
+            0x5B,                               # pop  rbx
+            0xC3,                               # ret
+        ])
+        k32 = ctypes.windll.kernel32
+        k32.VirtualAlloc.restype = ctypes.c_void_p
+        k32.VirtualAlloc.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t,
+            ctypes.c_uint32, ctypes.c_uint32,
+        ]
+        k32.VirtualFree.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint32,
+        ]
+        PAGE_EXECUTE_READWRITE = 0x40
+        MEM_COMMIT_RESERVE = 0x3000
+        MEM_RELEASE = 0x8000
+        addr = k32.VirtualAlloc(
+            None, len(shellcode), MEM_COMMIT_RESERVE, PAGE_EXECUTE_READWRITE,
+        )
+        if not addr:
+            return None
+        try:
+            ctypes.memmove(addr, shellcode, len(shellcode))
+            cpuid_fn = ctypes.CFUNCTYPE(
+                None, ctypes.c_uint32, ctypes.c_uint32,
+                ctypes.POINTER(ctypes.c_uint32 * 4),
+            )(addr)
+            return _check_vnni_via_cpuid(cpuid_fn)
+        finally:
+            k32.VirtualFree(addr, 0, MEM_RELEASE)
     except Exception:
         return None
 
@@ -416,11 +393,11 @@ def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
 
     Detection order:
       1. Direct CPUID probe (:func:`_probe_avx_vnni_via_cpuid`) —
-         OS-independent and authoritative when it runs.
-      2. ``py-cpuinfo`` flags — kept as a fallback for runtimes that
-         block executable memory.
-      3. ``/proc/cpuinfo`` on Linux — last-ditch text parse if even
-         ``py-cpuinfo`` failed to import or returned nothing.
+         Windows x86_64 only; the bug being fixed is py-cpuinfo's
+         Windows backend omitting ``avx_vnni`` from its flag list.
+      2. ``py-cpuinfo`` flags — primary path on Linux / macOS, and the
+         fallback on Windows when the CPUID probe could not run.
+      3. ``/proc/cpuinfo`` on Linux — text parse if py-cpuinfo failed.
 
     Returns ``(has_vnni, absence_confirmed)``. ``absence_confirmed=False``
     means no path could read CPU flags — the caller stays optimistic and

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -235,6 +235,78 @@ def test_detect_avx_vnni_arm64_linux_proc_cpuinfo_fallback(monkeypatch):
     assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
+def test_detect_avx_vnni_x86_cpuid_probe_is_authoritative(monkeypatch):
+    """When the direct CPUID probe returns a definitive answer, x86
+    detection MUST trust it and never fall back to py-cpuinfo. py-cpuinfo
+    on Windows silently omits ``avx_vnni`` from its flag list (Alder Lake
+    onwards on Intel, Zen 4+ on AMD), so consulting it after a positive
+    CPUID would let the stale absence overwrite the correct answer and
+    re-introduce the sticky-disable that #1395 fixed.
+    """
+    from memory import embeddings as emb_mod
+
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "AMD64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Windows")
+
+    # Force a py-cpuinfo result that disagrees with the probe, so the
+    # test fails loudly if the fallback ever runs ahead of the probe.
+    class _CpuinfoNoVnni:
+        @staticmethod
+        def get_cpu_info():
+            return {"flags": ["avx", "avx2"]}
+
+    monkeypatch.setitem(sys.modules, "cpuinfo", _CpuinfoNoVnni)
+
+    monkeypatch.setattr(emb_mod, "_probe_avx_vnni_via_cpuid", lambda: True)
+    assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+    monkeypatch.setattr(emb_mod, "_probe_avx_vnni_via_cpuid", lambda: False)
+    assert emb_mod.detect_avx_vnni_details() == (False, True)
+
+
+def test_detect_avx_vnni_x86_falls_back_to_cpuinfo_when_probe_unavailable(
+    monkeypatch,
+):
+    """Sandboxes that block executable allocations make the CPUID probe
+    return None. In that case the existing py-cpuinfo / /proc/cpuinfo
+    chain must still drive the decision so we don't lose detection on
+    runtimes that worked before #1395.
+    """
+    from memory import embeddings as emb_mod
+
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(emb_mod, "_probe_avx_vnni_via_cpuid", lambda: None)
+
+    class _CpuinfoWithVnni:
+        @staticmethod
+        def get_cpu_info():
+            return {"flags": ["avx", "avx2", "avx_vnni"]}
+
+    monkeypatch.setitem(sys.modules, "cpuinfo", _CpuinfoWithVnni)
+    assert emb_mod.detect_avx_vnni_details() == (True, True)
+
+    class _CpuinfoNoVnni:
+        @staticmethod
+        def get_cpu_info():
+            return {"flags": ["avx", "avx2"]}
+
+    monkeypatch.setitem(sys.modules, "cpuinfo", _CpuinfoNoVnni)
+    assert emb_mod.detect_avx_vnni_details() == (False, True)
+
+
+def test_probe_avx_vnni_skips_non_x86():
+    """The probe targets the x86_64 CPUID encoding — on aarch64 / arm64
+    it must short-circuit to ``None`` so the ARM detector remains in
+    charge of those hosts.
+    """
+    from memory import embeddings as emb_mod
+    import unittest.mock as mock
+
+    with mock.patch.object(emb_mod.platform, "machine", return_value="aarch64"):
+        assert emb_mod._probe_avx_vnni_via_cpuid() is None
+
+
 def test_parse_dim_from_model_id_picks_runtime_dim_under_ambiguous_profile():
     """Codex review PR #1147: ``parse_dim_from_model_id`` must anchor on
     the trailing ``-<dim>d-<quant>`` segment that ``build_model_id``

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -295,16 +295,28 @@ def test_detect_avx_vnni_x86_falls_back_to_cpuinfo_when_probe_unavailable(
     assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
-def test_probe_avx_vnni_skips_non_x86():
-    """The probe targets the x86_64 CPUID encoding — on aarch64 / arm64
-    it must short-circuit to ``None`` so the ARM detector remains in
-    charge of those hosts.
+def test_probe_avx_vnni_skips_non_windows_and_non_x86(monkeypatch):
+    """The probe is scoped to Windows x86_64. On Linux it must NOT issue
+    CPUID — ``arch_prctl(ARCH_SET_CPUID, 0)`` (rr debugger, certain
+    sandboxes) turns ``cpuid`` into SIGSEGV, which Python's try/except
+    cannot catch and would hard-kill the process (Codex P1 on #1402).
+    On macOS Intel there is no chip in the wild with AVX-VNNI anyway,
+    and hardened runtime breaks PROT_EXEC. ARM hosts are handled by the
+    sibling :func:`_detect_int8_fast_path_arm` and must not enter the
+    x86 shellcode path.
     """
     from memory import embeddings as emb_mod
-    import unittest.mock as mock
 
-    with mock.patch.object(emb_mod.platform, "machine", return_value="aarch64"):
-        assert emb_mod._probe_avx_vnni_via_cpuid() is None
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Linux")
+    assert emb_mod._probe_avx_vnni_via_cpuid() is None
+
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Darwin")
+    assert emb_mod._probe_avx_vnni_via_cpuid() is None
+
+    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Windows")
+    assert emb_mod._probe_avx_vnni_via_cpuid() is None
 
 
 def test_parse_dim_from_model_id_picks_runtime_dim_under_ambiguous_profile():


### PR DESCRIPTION
## Summary

`_detect_int8_fast_path_x86()` 一直在 Windows 上误关 embedding —— `py-cpuinfo` 的 Windows backend **不把 `avx_vnni` 列进 flags**，Arrow Lake (Core Ultra 7 265KF) 实测只看到 `['avx', 'avx2']`，于是被判 `confirmed absent`，`_resolve_quantization('auto', ...)` 走 `return None`，整条链 sticky-disable 成 `AVX_VNNI_REQUIRED_FOR_INT8`。Windows 也没 `PF_AVX_VNNI` 常量能让 `IsProcessorFeaturePresent` 兜底。

Intel 自 Alder Lake (12 代)、AMD 自 Zen 4 起，所有 x86 Windows 用户都中招 —— 这是 ARM Apple Silicon 同类 bug 的 x86 镜像（#1394 修了 ARM 那一侧）。

## 修法

加 `_probe_avx_vnni_via_cpuid()`，用 ctypes + 自分配可执行内存直接发 CPUID：

- **Windows x64** → `VirtualAlloc(PAGE_EXECUTE_READWRITE)` + MS x64 ABI shellcode
- **Linux / macOS x86_64** → `mmap(PROT_READ|PROT_WRITE|PROT_EXEC)` + SysV ABI shellcode
- CPUID leaf 7,0 ECX bit 11 → AVX-512_VNNI；leaf 7,1 EAX bit 4 → AVX-VNNI
- 32-bit Python / 非 x86_64 / 任一系统调用失败 → 返 `None`

`_detect_int8_fast_path_x86()` 把 probe 提到第一顺位，py-cpuinfo / `/proc/cpuinfo` 退到 fallback —— DEP-locked sandbox、硬化 runtime 等场景保持原行为不变。

## Test plan

- [x] `uv run pytest tests/unit/test_embedding_service.py` — **55 passed** (含原有 ARM64 detect 测试)
- [x] 新增 3 测试：probe 权威优先于 py-cpuinfo (即使 cpuinfo 没报 vnni)、probe 返 None 时 fallback 链路不变、ARM 上 probe short-circuit None
- [x] 现场在 Core Ultra 7 265KF (Arrow Lake) 上 boot EmbeddingService：

  ```
  before: vectors disabled (avx_vnni_required_for_int8_bundle)
  after:  has_vnni=True / quantization=int8 / dim=256
          model_id=local-text-retrieval-v1-256d-int8 / disable_reason=none
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 在 Windows x86_64 上新增更精确的运行时 CPU 特性探测路径，用于判断 AVX-VNNI/AVX-512_VNNI 支持，保持对旧回退机制的兼容性与跨平台稳定性。
  * 更新检测流程说明，提升检测顺序与失败回退的可预测性。

* **测试**
  * 新增单元测试覆盖各种平台与探测结果场景，确保探测为真/假/不可用时行为符合预期。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->