### PR TITLE
fix(frontend): proactive gate 卡死 30s 兜底 + skip 日志带 state dump

### DIFF
--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -25,9 +25,17 @@
 
     const ASSISTANT_TURN_COMPLETION_FALLBACK_MS = 700;
     const ASSISTANT_AUDIO_HEADER_STALL_MS = 1800;
+    // 最后兜底：如果 turn-end 包压根没到（server 漏发 / packet 掉），
+    // maybeFinalizeAssistantSpeech 永远 skip_completion_mismatch，
+    // S.isPlaying / S.assistantSpeechActiveTurnId 没人清，proactive gate
+    // 和 mic focus gate 都会卡死。此处守门：所有音频队列空了且 flag
+    // 还粘着，30s 后强制 cancel 收尾。比 ASSISTANT_TURN_COMPLETION_FALLBACK_MS
+    // 长一个数量级——前者覆盖正常 race，后者覆盖 server 漏包。
+    const STUCK_SPEAKING_FALLBACK_MS = 30000;
     let _assistantTurnCompletionFallbackTimer = 0;
     let _assistantTurnCompletionFallbackTurnId = null;
     let _pendingAudioMetaStallTimer = 0;
+    let _stuckSpeakingFallbackTimer = 0;
     const SPEECH_PLAYBACK_STATE_KEY = 'neko_speech_playback_state';
     const SPEECH_PLAYBACK_CHANNEL_NAME = 'neko_speech_playback_channel';
     const SPEECH_PLAYBACK_STATE_HEARTBEAT_MS = 200;
@@ -286,6 +294,7 @@
         S.assistantSpeechActiveTurnId = normalizedTurnId;
         S.assistantSpeechStartedTurnId = normalizedTurnId;
         clearAssistantTurnCompletionFallback();
+        clearStuckSpeakingFallback();
         logAudioLifecycle('dispatchAssistantSpeechStart', {
             turnId: normalizedTurnId
         });
@@ -304,6 +313,7 @@
             return;
         }
         S.assistantSpeechActiveTurnId = null;
+        clearStuckSpeakingFallback();
         logAudioLifecycle('dispatchAssistantSpeechEnd', {
             turnId: normalizedTurnId
         });
@@ -371,6 +381,7 @@
             return;
         }
         S.assistantSpeechActiveTurnId = null;
+        clearStuckSpeakingFallback();
         logAudioLifecycle('dispatchAssistantSpeechCancel', {
             turnId: normalizedTurnId,
             source: source || 'audio_playback'
@@ -387,6 +398,77 @@
             _assistantTurnCompletionFallbackTimer = 0;
         }
         _assistantTurnCompletionFallbackTurnId = null;
+    }
+
+    function clearStuckSpeakingFallback() {
+        if (_stuckSpeakingFallbackTimer) {
+            clearTimeout(_stuckSpeakingFallbackTimer);
+            _stuckSpeakingFallbackTimer = 0;
+        }
+    }
+
+    // 兜底：所有音频队列空了且 isPlaying / assistantSpeechActiveTurnId 还粘着
+    // → STUCK_SPEAKING_FALLBACK_MS 后强制走 cancel 路径收尾。
+    // 触发点是 source.onended（最后一段音频刚播完，maybeFinalizeAssistantSpeech
+    // 因为没收到 turn-end 而 skip 的那一刻），fire 时再 re-check 一次，
+    // 期间如果新音频进来或正常 finalize 走完，会被 clearStuckSpeakingFallback 撤掉。
+    function maybeArmStuckSpeakingFallback() {
+        if (_stuckSpeakingFallbackTimer) return;
+        var queuesEmpty = (
+            S.scheduledSources.length === 0 &&
+            S.audioBufferQueue.length === 0 &&
+            S.incomingAudioBlobQueue.length === 0
+        );
+        var flagsSet = !!(S.isPlaying || S.assistantSpeechActiveTurnId);
+        if (!queuesEmpty || !flagsSet) return;
+
+        logAudioLifecycle('stuckSpeakingFallback:armed', {
+            isPlaying: S.isPlaying,
+            assistantSpeechActiveTurnId: S.assistantSpeechActiveTurnId,
+            assistantTurnId: S.assistantTurnId,
+            assistantTurnCompletedId: S.assistantTurnCompletedId,
+            delayMs: STUCK_SPEAKING_FALLBACK_MS
+        });
+
+        _stuckSpeakingFallbackTimer = window.setTimeout(function () {
+            _stuckSpeakingFallbackTimer = 0;
+            var queuesStillEmpty = (
+                S.scheduledSources.length === 0 &&
+                S.audioBufferQueue.length === 0 &&
+                S.incomingAudioBlobQueue.length === 0
+            );
+            var flagsStillSet = !!(S.isPlaying || S.assistantSpeechActiveTurnId);
+            if (!queuesStillEmpty || !flagsStillSet) {
+                logAudioLifecycle('stuckSpeakingFallback:skip_resolved', {
+                    queuesStillEmpty: queuesStillEmpty,
+                    flagsStillSet: flagsStillSet
+                });
+                return;
+            }
+            var snapshot = {
+                isPlaying: S.isPlaying,
+                assistantSpeechActiveTurnId: S.assistantSpeechActiveTurnId,
+                assistantTurnId: S.assistantTurnId,
+                assistantTurnCompletedId: S.assistantTurnCompletedId,
+                assistantTurnStartedAt: S.assistantTurnStartedAt,
+                scheduledSources: S.scheduledSources.length,
+                audioBufferQueue: S.audioBufferQueue.length,
+                incomingAudioBlobQueue: S.incomingAudioBlobQueue.length
+            };
+            console.warn('[Audio] sticky speaking flag detected, force-resetting via cancel after ' +
+                STUCK_SPEAKING_FALLBACK_MS + 'ms with empty queues', snapshot);
+            logAudioLifecycle('stuckSpeakingFallback:fire', snapshot);
+            // 走 cancel 通道：dispatchAssistantSpeechCancel 会清 assistantSpeechActiveTurnId
+            // 并 dispatch neko-assistant-speech-cancel，下方 handler 会清 isPlaying。
+            try { dispatchAssistantSpeechCancel('stuck_speaking_fallback'); } catch (_) { /* noop */ }
+            // 双保险：上面任一步没把 isPlaying 抹掉就强清。
+            if (S.isPlaying) {
+                S.isPlaying = false;
+            }
+            if (S.assistantSpeechActiveTurnId) {
+                S.assistantSpeechActiveTurnId = null;
+            }
+        }, STUCK_SPEAKING_FALLBACK_MS);
     }
 
     function clearAssistantTurnCompletion() {
@@ -606,6 +688,7 @@
 
         window.addEventListener('neko-assistant-speech-cancel', function () {
             clearAssistantTurnCompletion();
+            clearStuckSpeakingFallback();
             // [BUGFIX] 切换猫娘后语音模式 mic 永远 skip=focus 的根因：
             // 原来只清 turn-tracking 标志，S.isPlaying 留在 true。
             // 切换瞬间 emitAssistantSpeechCancel('character_switch') 被调，
@@ -912,7 +995,11 @@
                                 speechId: S.currentPlayingSpeechId || src._nekoSpeechId || null,
                                 turnId: src._nekoAssistantTurnId || null
                             });
-                            maybeFinalizeAssistantSpeech(src._nekoAssistantTurnId);
+                            var finalized = maybeFinalizeAssistantSpeech(src._nekoAssistantTurnId);
+                            // 兜底：finalize 没走通（多半是 turn-end 没到），队列已空但 flag 还粘着 → 30s 后强制收尾。
+                            if (!finalized) {
+                                maybeArmStuckSpeakingFallback();
+                            }
                         };
                     })(source);
 

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -288,13 +288,18 @@
 
     function dispatchAssistantSpeechStart(turnId) {
         var normalizedTurnId = normalizeAssistantTurnId(turnId);
+        // 新 chunk 入队 = 真实音频活动，无论是不是同一 turn 都要撤掉 stuck watchdog。
+        // 否则 choppy stream 里：第一段播完 arm 表 → 第二段到来仍是同一 turn 早 return →
+        // 表不撤 → 30s 到点时如果刚好在第 N 段间隙 → 误 fire cancel。
+        if (normalizedTurnId) {
+            clearStuckSpeakingFallback();
+        }
         if (!normalizedTurnId || S.assistantSpeechActiveTurnId === normalizedTurnId) {
             return;
         }
         S.assistantSpeechActiveTurnId = normalizedTurnId;
         S.assistantSpeechStartedTurnId = normalizedTurnId;
         clearAssistantTurnCompletionFallback();
-        clearStuckSpeakingFallback();
         logAudioLifecycle('dispatchAssistantSpeechStart', {
             turnId: normalizedTurnId
         });

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -407,6 +407,21 @@
         }
     }
 
+    // 与 isAssistantTurnPlaybackDrained 的 4-queue 判断对齐：少查 pendingAudioChunkMetaQueue
+    // 会在 header 到了 blob 还没到的 race 窗口里误判"空"——3 个队列是空的，
+    // 但 meta 还在排队等 blob。filter shouldSkip 是因为上游可能 mark 跳过项。
+    function _hasPendingAudioWork() {
+        var pendingMeta = S.pendingAudioChunkMetaQueue.some(function (item) {
+            return item && !item.shouldSkip;
+        });
+        return (
+            S.scheduledSources.length > 0 ||
+            S.audioBufferQueue.length > 0 ||
+            pendingMeta ||
+            S.incomingAudioBlobQueue.length > 0
+        );
+    }
+
     // 兜底：所有音频队列空了且 isPlaying / assistantSpeechActiveTurnId 还粘着
     // → STUCK_SPEAKING_FALLBACK_MS 后强制走 cancel 路径收尾。
     // 触发点是 source.onended（最后一段音频刚播完，maybeFinalizeAssistantSpeech
@@ -414,13 +429,8 @@
     // 期间如果新音频进来或正常 finalize 走完，会被 clearStuckSpeakingFallback 撤掉。
     function maybeArmStuckSpeakingFallback() {
         if (_stuckSpeakingFallbackTimer) return;
-        var queuesEmpty = (
-            S.scheduledSources.length === 0 &&
-            S.audioBufferQueue.length === 0 &&
-            S.incomingAudioBlobQueue.length === 0
-        );
         var flagsSet = !!(S.isPlaying || S.assistantSpeechActiveTurnId);
-        if (!queuesEmpty || !flagsSet) return;
+        if (_hasPendingAudioWork() || !flagsSet) return;
 
         logAudioLifecycle('stuckSpeakingFallback:armed', {
             isPlaying: S.isPlaying,
@@ -432,15 +442,11 @@
 
         _stuckSpeakingFallbackTimer = window.setTimeout(function () {
             _stuckSpeakingFallbackTimer = 0;
-            var queuesStillEmpty = (
-                S.scheduledSources.length === 0 &&
-                S.audioBufferQueue.length === 0 &&
-                S.incomingAudioBlobQueue.length === 0
-            );
+            var hasPending = _hasPendingAudioWork();
             var flagsStillSet = !!(S.isPlaying || S.assistantSpeechActiveTurnId);
-            if (!queuesStillEmpty || !flagsStillSet) {
+            if (hasPending || !flagsStillSet) {
                 logAudioLifecycle('stuckSpeakingFallback:skip_resolved', {
-                    queuesStillEmpty: queuesStillEmpty,
+                    hasPendingAudioWork: hasPending,
                     flagsStillSet: flagsStillSet
                 });
                 return;
@@ -453,6 +459,7 @@
                 assistantTurnStartedAt: S.assistantTurnStartedAt,
                 scheduledSources: S.scheduledSources.length,
                 audioBufferQueue: S.audioBufferQueue.length,
+                pendingAudioChunkMetaQueue: S.pendingAudioChunkMetaQueue.length,
                 incomingAudioBlobQueue: S.incomingAudioBlobQueue.length
             };
             console.warn('[Audio] sticky speaking flag detected, force-resetting via cancel after ' +

--- a/static/app-audio-playback.js
+++ b/static/app-audio-playback.js
@@ -407,9 +407,14 @@
         }
     }
 
-    // 与 isAssistantTurnPlaybackDrained 的 4-queue 判断对齐：少查 pendingAudioChunkMetaQueue
-    // 会在 header 到了 blob 还没到的 race 窗口里误判"空"——3 个队列是空的，
-    // 但 meta 还在排队等 blob。filter shouldSkip 是因为上游可能 mark 跳过项。
+    // 4 个队列 + 3 个 in-flight async flag，覆盖所有"音频还在路上"的状态。
+    // - 4 queue 对齐 isAssistantTurnPlaybackDrained（少查 pendingAudioChunkMetaQueue
+    //   会在 header 到了 blob 还没到的窗口里误判空）
+    // - 3 async flag 对齐 publishSpeechPlaybackState:86-92 的 pendingAudioWork：
+    //   processIncomingAudioBlobQueue 会先 shift 出 blob 再 await handleAudioBlob，
+    //   shift 之后 incomingAudioBlobQueue.length 是 0 但解码还在跑；decoder reset
+    //   同理是个 Promise 在 flight。这些都属于"未真正 idle"，arm watchdog 就是误伤。
+    // filter shouldSkip 是因为上游可能 mark 跳过项。
     function _hasPendingAudioWork() {
         var pendingMeta = S.pendingAudioChunkMetaQueue.some(function (item) {
             return item && !item.shouldSkip;
@@ -418,7 +423,10 @@
             S.scheduledSources.length > 0 ||
             S.audioBufferQueue.length > 0 ||
             pendingMeta ||
-            S.incomingAudioBlobQueue.length > 0
+            S.incomingAudioBlobQueue.length > 0 ||
+            !!S.pendingDecoderReset ||
+            !!S.decoderResetPromise ||
+            !!S.isProcessingIncomingAudioBlob
         );
     }
 
@@ -460,7 +468,10 @@
                 scheduledSources: S.scheduledSources.length,
                 audioBufferQueue: S.audioBufferQueue.length,
                 pendingAudioChunkMetaQueue: S.pendingAudioChunkMetaQueue.length,
-                incomingAudioBlobQueue: S.incomingAudioBlobQueue.length
+                incomingAudioBlobQueue: S.incomingAudioBlobQueue.length,
+                pendingDecoderReset: !!S.pendingDecoderReset,
+                decoderResetPromise: !!S.decoderResetPromise,
+                isProcessingIncomingAudioBlob: !!S.isProcessingIncomingAudioBlob
             };
             console.warn('[Audio] sticky speaking flag detected, force-resetting via cancel after ' +
                 STUCK_SPEAKING_FALLBACK_MS + 'ms with empty queues', snapshot);

--- a/static/app-proactive.js
+++ b/static/app-proactive.js
@@ -364,6 +364,29 @@
     }
     mod._isAssistantSpeaking = _isAssistantSpeaking;
 
+    // 给 proactive skip 日志带上 _isAssistantSpeaking 用到的全部输入 + 音频队列长度。
+    // gate 卡死时直接看 log 就能判断哪个 flag 粘住、队列是不是真的空，
+    // 不用让用户手动到 DevTools 抓快照（手动解锁前一刷新就把证据擦了）。
+    function _dumpSpeakingGateState() {
+        try {
+            if (!S) return { snapshot: 'no_state' };
+            return {
+                isPlaying: S.isPlaying,
+                assistantSpeechActiveTurnId: S.assistantSpeechActiveTurnId,
+                assistantTurnId: S.assistantTurnId,
+                assistantTurnCompletedId: S.assistantTurnCompletedId,
+                assistantTurnStartedAt: S.assistantTurnStartedAt || null,
+                elapsedSinceStartMs: S.assistantTurnStartedAt ? Date.now() - S.assistantTurnStartedAt : null,
+                scheduledSources: (S.scheduledSources && S.scheduledSources.length) || 0,
+                audioBufferQueue: (S.audioBufferQueue && S.audioBufferQueue.length) || 0,
+                incomingAudioBlobQueue: (S.incomingAudioBlobQueue && S.incomingAudioBlobQueue.length) || 0
+            };
+        } catch (e) {
+            return { snapshot: 'error', error: String(e) };
+        }
+    }
+    mod._dumpSpeakingGateState = _dumpSpeakingGateState;
+
     // C: 判断用户是否最近在发声。仅在 voice 模式下使用（文本模式没有麦克风打点），
     // 用来在前端层面拦住 proactive tick，与后端 prompt_ephemeral 的
     // _user_recent_activity_time 防线形成对称冗余。
@@ -485,7 +508,7 @@
                 // （没真发请求就不算无回复），但仍然 scheduleProactiveChat() 推进下一 tick。
                 // 结果：播放完成到下一次 nudge 的等待 ∈ [0, interval)，带随机感，更自然。
                 if (_isAssistantSpeaking()) {
-                    console.log('[ProactiveChat] 语音模式：AI 正在播放语音，本次 nudge 跳过（不计数），继续下一 tick');
+                    console.log('[ProactiveChat] 语音模式：AI 正在播放语音，本次 nudge 跳过（不计数），继续下一 tick', _dumpSpeakingGateState());
                     scheduleProactiveChat();
                     return;
                 }
@@ -642,7 +665,7 @@
             // （没真发请求就不算一次尝试），但仍然 scheduleProactiveChat() 推进下一 tick。
             // 结果：播放完成到下一次 nudge 的等待 ∈ [0, interval)，带随机感，更自然。
             if (_isAssistantSpeaking()) {
-                console.log('[ProactiveChat] 文本模式：AI 正在播放语音，本次跳过（不累加退避），继续下一 tick');
+                console.log('[ProactiveChat] 文本模式：AI 正在播放语音，本次跳过（不累加退避），继续下一 tick', _dumpSpeakingGateState());
                 scheduleProactiveChat();
                 return;
             }


### PR DESCRIPTION
## 背景
log 反复出现 `[ProactiveChat] 文本模式：AI 正在播放语音，本次跳过（不累加退避），继续下一 tick`，但实际 AI 并没有在播——`_isAssistantSpeaking()` 因为 `S.isPlaying` 或 `S.assistantSpeechActiveTurnId` 粘着永远返 true，proactive 锁死、mic focus gate 也连带卡死（[app-proactive.js:350](static/app-proactive.js#L350) 一次返 true 就一直 skip）。

## 根因猜测
`source.onended` → `maybeFinalizeAssistantSpeech` 有两道闸门 ([app-audio-playback.js:528](static/app-audio-playback.js#L528))：
1. `S.assistantTurnCompletedId === turnId`（必须先收到 `neko-assistant-turn-end`）
2. `isAssistantTurnPlaybackDrained(turnId)`

闸门 1 在 server 漏发 turn-end / 包乱序 / 被新 turn-start 抹掉 completedId 的情况下会永远过不去，两个 flag 没人清。现有 `scheduleAssistantTurnCompletionFallback`(700ms) 只覆盖"turn-end 到了但 speech 没 drain"，不覆盖"turn-end 压根没来"。

## 改动
### 1. 30s 看门狗（兜底）
[app-audio-playback.js](static/app-audio-playback.js) 新增 `STUCK_SPEAKING_FALLBACK_MS = 30000`：
- `source.onended` 发现 `maybeFinalizeAssistantSpeech` 返 false → 调 `maybeArmStuckSpeakingFallback()`
- arm 时 re-check"队列全空 + flag 还粘着"，否则不 arm
- 30s 后 re-check 一次，仍卡住就走 `dispatchAssistantSpeechCancel('stuck_speaking_fallback')` 收尾（清 `assistantSpeechActiveTurnId` + dispatch `neko-assistant-speech-cancel`，下游 handler 清 `isPlaying`）；双保险手动兜底两个 flag
- 正常路径（`dispatchAssistantSpeechStart/End/Cancel` + `neko-assistant-speech-cancel` 事件）都 `clearStuckSpeakingFallback`，避免空跑

数量级上比既有 `ASSISTANT_TURN_COMPLETION_FALLBACK_MS = 700` 长 ~40x——前者覆盖正常 race，后者覆盖 server 漏包。

### 2. proactive skip 日志带 state dump
[app-proactive.js](static/app-proactive.js) 加 `_dumpSpeakingGateState()`，两条 skip 日志都带上 8 个相关 flag 的快照。下次再卡死，log 直接告诉你哪个 flag 粘住、队列是不是真空，不用手动到 DevTools 抓——之前用户每次手动 `window.appState.isPlaying = false` 解锁，刷新就把证据擦了。

## Test plan
- [ ] node --check 通过 ✅（本地已跑）
- [ ] 触发 proactive 卡死场景：jukebox 切歌 / 切角色等已知漏 turn-end 的路径；观察 30s 后是否自动恢复，console 是否打出 `[Audio] sticky speaking flag detected, force-resetting via cancel`
- [ ] 正常对话 1-2 轮，确认 `dispatchAssistantSpeechEnd` 路径走通时不误触发兜底（无 `stuckSpeakingFallback:armed` 日志）
- [ ] proactive skip 日志正常带上 `{isPlaying, assistantSpeechActiveTurnId, ...}` 快照

## 注意事项
- 这个 bug 非确定性（依赖 server 漏包 / race），无法 deterministic repro；改动以"日志可观测 + 自愈"为目标，不是"消除根因"
- 真根因是为什么 turn-end 没到——下次复现时 dump 日志能定位是哪条 server 路径漏发

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了语音播放“卡住”恢复机制：当播放队列异常为空但播放状态仍被占用时，新增超时回退并强制终止与清理播放状态，减少语音无法结束或重复占用的情况。

* **改进**
  * 增强了语音相关调试信息捕获，新增可调用的调试快照接口，便于在控制台直接查看播放/跳过判定时的状态以加速定位与诊断。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->