### PR TITLE
feat(memory): AI-aware Stage-1 (path B) + source trust-tier

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1889,6 +1889,29 @@ async def _run_path_b(name: str, state: dict) -> None:
         # 死循环）。正常路径不触发——rows[-1][0] 是 SQLite 返回的 ts 字符串。
         last_fetched_ts = last_a_msg_ts
 
+    # 同 ts 簇 LIMIT 截断死循环防御（Codex P2 round-3 on PR #1408）：
+    # aretrieve_original_by_timeframe 用 inclusive `BETWEEN`，若窗口里
+    # > MAX_AI_AWARE_WINDOW_MSGS 行共享同一 ts（极端情况：bulk import 或
+    # store_conversation 给一次请求里所有 row 写同 ts），那么 LIMIT 切出
+    # 的最早 N 行全在同 ts，cursor 推到 last_fetched_ts 后下次 BETWEEN
+    # 仍把这批 row 全部捞回来 → 无限循环、该 ts 簇后面的 row 永远 skip。
+    # 检测：LIMIT 拉满 AND 所有 fetched row 同 ts → cursor +1μs 越过该 ts。
+    # 代价：该 ts 簇 LIMIT 之后的 tail row 被 skip（罕见——一次正常对话
+    # turn 写 2~5 行，远 < MAX_AI_AWARE_WINDOW_MSGS=200）。无更便宜的修法
+    # 除非把 cursor 改成 (ts, rowid) 复合键、改写 SQL，太重不划算。
+    first_fetched_ts = _coerce_db_ts(rows[0][0])
+    if (
+        len(rows) >= MAX_AI_AWARE_WINDOW_MSGS
+        and first_fetched_ts is not None
+        and last_fetched_ts == first_fetched_ts
+    ):
+        logger.warning(
+            f"[PathB] {name}: 同 ts 簇 {first_fetched_ts.isoformat(timespec='microseconds')} "
+            f"行数 ≥ LIMIT ({MAX_AI_AWARE_WINDOW_MSGS})，cursor +1μs 越过避免死循环；"
+            f"该 ts 簇 LIMIT 之后的 tail row 会被 skip"
+        )
+        last_fetched_ts = last_fetched_ts + timedelta(microseconds=1)
+
     message_dicts = _extract_role_tagged_messages_from_rows(rows)
     if not message_dicts:
         # 全是 system msg / 空内容。cursor 推到 last fetched（不是 last_a_msg_ts），
@@ -2019,9 +2042,36 @@ async def _periodic_signal_extraction_loop():
                 if not rows:
                     _signal_check_mark_done(name, now)
                     return
+
+                # AI-only 窗口（proactive 触发的 AI 自我发起 / tool turn 等没有
+                # human msg）也要给 path B 跑——path B 设计目的就是拣回 AI 自我
+                # 披露和 grounded fact。这里把 last_a_msg_ts 推进 + b_tick_counter
+                # bump + maybe B trigger 提到 user_msgs 检查之前，保证 AI-only
+                # 窗口不被 path A 的 user-only Stage-1 早 return 漏掉
+                # （Codex P1 round-3 on PR #1408）。
+                state = _signal_check_state.setdefault(
+                    name, {'turns_since': 0, 'last_check_ts': None},
+                )
+                last_msg_ts = _coerce_db_ts(rows[-1][0])
+                if last_msg_ts is not None:
+                    state['last_a_msg_ts'] = last_msg_ts
+
                 user_msgs_text = _extract_user_messages_from_rows(rows)
                 if not user_msgs_text:
+                    # 没 user msg → path A 跑不了 user-observation 抽取，但 A
+                    # 已经"看过"这窗口（cursor 推进）。bump B counter，达 N 触发
+                    # B 把这段 AI-only 内容拣回来。
                     _signal_check_mark_done(name, now)
+                    state['b_tick_counter'] = state.get('b_tick_counter', 0) + 1
+                    if state['b_tick_counter'] >= EVIDENCE_AI_AWARE_EVERY_N_A_TICKS:
+                        state['b_tick_counter'] = 0
+                        try:
+                            await _run_path_b(name, state)
+                        except Exception as e:
+                            logger.warning(
+                                f"[PathB] {name}: AI-only 窗口 B 触发失败 "
+                                f"(skip 本轮): {e}"
+                            )
                     return
 
                 # 组装成 BaseMessage-like 结构给 extract_facts 使用
@@ -2087,19 +2137,10 @@ async def _periodic_signal_extraction_loop():
                     logger.debug(f"[SignalLoop] {name}: auto_promote_stale 失败: {e}")
 
                 # Stage-1 + dispatch 都跨过了，cursor 推进。
+                # 注意：last_a_msg_ts 已经在 user_msgs 检查之前更新过
+                # （AI-only 窗口分支共享同一段逻辑），这里只 bump b_tick_counter
+                # 准备触发 path B。
                 _signal_check_mark_done(name, now)
-
-                # 记录 A 实际处理过的最晚 msg ts，给 path B 当下游边界用
-                # （rows 已 ORDER BY ts ASC，最后一行就是 window 内最晚 msg）。
-                # 用真实 msg ts 而不是 wall-clock now：保证 path B 看到的
-                # 消息严格被 path A 看过，避免"A scan SQL 完成那一刻之后才入
-                # SQLite 的 msg 被 B 抢先处理"的 race。
-                state = _signal_check_state.setdefault(
-                    name, {'turns_since': 0, 'last_check_ts': None},
-                )
-                last_msg_ts = _coerce_db_ts(rows[-1][0])
-                if last_msg_ts is not None:
-                    state['last_a_msg_ts'] = last_msg_ts
 
                 # Path B trigger：A 成功跑完后 bump counter；达 N 触发
                 # _run_path_b（AI-aware Stage-1 only，详见函数 docstring）。

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -42,6 +42,9 @@ from config import (
     EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
     EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES,
     EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS,
+    EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+    MAX_AI_AWARE_WINDOW_MSGS,
+    MAX_KNOWN_POOL_FACTS,
     MEMORY_REFLECTION_SYNTHESIS_INTERVAL_SECONDS,
     IGNORED_REINFORCEMENT_DELTA,
     MEMORY_RECHECK_ENABLED,
@@ -811,6 +814,55 @@ def _extract_user_messages_from_rows(rows: list) -> list[str]:
         except (json.JSONDecodeError, TypeError):
             continue
     return user_msgs
+
+
+def _extract_role_tagged_messages_from_rows(rows: list) -> list[dict]:
+    """Path B 用的全消息提取——保留 user + ai 两种 type，输出 message_dict
+    list 直接喂 ``convert_to_messages``。
+
+    跟 ``_extract_user_messages_from_rows`` 的区别：
+    - 收 type ∈ {'human', 'ai'} 两种（不再仅 human）
+    - 返回 [{'type': 'human'|'ai', 'data': {'content': str}}, ...] 而不是
+      纯 str list，让下游 ``convert_to_messages`` 还原成 HumanMessage/AIMessage
+      让 ``FactStore._format_conversation`` 渲染时按 type → name_mapping 出
+      "{MASTER_NAME} | xxx" / "{LANLAN_NAME} | xxx" 形式，path B prompt 据此
+      判每条 fact 的 source 归属（user_observation / ai_disclosure）
+
+    PR #1399 的教训：这里返回 list[dict] 让 caller 拼 message_dicts 后用
+    ``convert_to_messages(message_dicts)`` 直接转——**不要** ``json.dumps``
+    包一层（convert_to_messages 只接 list，str 会被静默吞成 []）。
+    """
+    out: list[dict] = []
+    for _, _, msg_json in rows:
+        try:
+            msg = json.loads(msg_json) if isinstance(msg_json, str) else msg_json
+            if not isinstance(msg, dict):
+                continue
+            msg_type = msg.get('type')
+            if msg_type not in ('human', 'ai'):
+                continue
+            content = msg.get('data', {}).get('content', '')
+            # content 归一化：内部可能是 str 或 [{type:'text', text:'...'}, ...]
+            # 后者拼回单个 str（path B prompt 不需要细粒度 part 结构，
+            # FactStore._format_conversation 把 list content 拼成 ''.join 也是
+            # 同样语义）。
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, list):
+                parts = [
+                    p.get('text', '')
+                    for p in content
+                    if isinstance(p, dict) and p.get('type') == 'text'
+                ]
+                text = ''.join(parts)
+            else:
+                continue
+            if not text.strip():
+                continue
+            out.append({'type': msg_type, 'data': {'content': text}})
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return out
 
 
 async def _resolve_rebuttal_start_time(name: str, now: datetime):
@@ -1760,6 +1812,113 @@ async def _adispatch_evidence_signals(
     return all_ok
 
 
+async def _run_path_b(name: str, state: dict) -> None:
+    """Path B: AI-aware Stage-1 only（不进 Stage-2 evidence loop）。
+
+    Piggyback 在 path A 循环里，每 ``EVIDENCE_AI_AWARE_EVERY_N_A_TICKS`` 次 A
+    tick 触发一次。窗口下游边界用 path A 实际处理过的最晚 msg ts，保证 B
+    看到的消息严格被 A 看过——避免"A scan SQL 完成那一刻之后才入 SQLite 的
+    msg 被 B 抢先处理"的 race。
+
+    设计要点：
+      1. 窗口 = [last_b_check_ts, last_a_msg_ts]。cold start last_b 推算 =
+         last_a_msg_ts - N × IDLE_MINUTES（保守覆盖 A 已经处理过的范围）
+      2. SQL 层 LIMIT MAX_AI_AWARE_WINDOW_MSGS 防极端长窗口爆 prompt
+      3. 已知 fact 池：从 facts.json 拉 created_at ∈ window 的 fact，按
+         importance DESC 取前 MAX_KNOWN_POOL_FACTS 塞 prompt，让 LLM 输出
+         层主动去重 path A 已抽内容
+      4. 落盘 default_source='ai_disclosure'；LLM 显式 source 字段优先
+      5. 失败时 last_b_check_ts 不推进，下次 trigger 重试同窗口（fact
+         dedup 防双写）
+
+    与 path A 区别：
+    - 不进 Stage-2 evidence loop（_apersist_new_facts 写 signal_processed=True
+      + aextract_facts_and_detect_signals 内部 source filter 双重防御）
+    - Stage-1 失败 swallow（path A 自己的 FactExtractionFailed 有独立 retry
+      路径，B 是补抓性质不该阻塞）
+    """
+    last_a_msg_ts = state.get('last_a_msg_ts')
+    if last_a_msg_ts is None:
+        # A 还没成功处理过任何 batch，B 无源可看
+        return
+
+    last_b = state.get('last_b_check_ts')
+    if last_b is None:
+        # Cold start：B 第一次 trigger 时已等了 EVIDENCE_AI_AWARE_EVERY_N_A_TICKS
+        # 个 A tick。每个 A tick 平均覆盖 EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES 分钟
+        # （idle gate 阈值），所以 A 已覆盖范围 ≈ N × IDLE_MINUTES 分钟。
+        # 用这个推算作为 B 第一次窗口起点。
+        estimated_a_coverage = timedelta(
+            minutes=EVIDENCE_AI_AWARE_EVERY_N_A_TICKS * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
+        )
+        last_b = last_a_msg_ts - estimated_a_coverage
+
+    if last_b >= last_a_msg_ts:
+        # 窗口为空（B 已追上 A）
+        return
+
+    try:
+        rows = await time_manager.aretrieve_original_by_timeframe(
+            name, last_b, last_a_msg_ts,
+            limit_rows=MAX_AI_AWARE_WINDOW_MSGS,
+        )
+    except Exception as e:
+        logger.warning(f"[PathB] {name}: 读取窗口失败: {e}")
+        return
+    if not rows:
+        # 窗口内无 msg（A 处理过但都是空白？少见但可能）。推 cursor 跳过。
+        state['last_b_check_ts'] = last_a_msg_ts
+        return
+
+    message_dicts = _extract_role_tagged_messages_from_rows(rows)
+    if not message_dicts:
+        # 全是 system msg / 空内容。推 cursor 跳过。
+        state['last_b_check_ts'] = last_a_msg_ts
+        return
+
+    from utils.llm_client import convert_to_messages
+    messages = convert_to_messages(message_dicts)
+
+    # 已知 fact 池：拉 created_at ∈ window 的 fact（这些是 path A 这段时间
+    # 内抽出的，给 path B prompt 当 do-not-repeat 提示）。按 importance
+    # DESC 取前 MAX_KNOWN_POOL_FACTS。
+    try:
+        all_facts = await fact_store.aload_facts(name)
+    except Exception as e:
+        logger.debug(f"[PathB] {name}: aload_facts 失败，known pool 留空: {e}")
+        all_facts = []
+
+    known_pool: list[dict] = []
+    for f in all_facts:
+        if not isinstance(f, dict):
+            continue
+        created_at_raw = f.get('created_at') or ''
+        try:
+            created_at = datetime.fromisoformat(created_at_raw[:19])
+        except (ValueError, TypeError):
+            continue
+        if last_b <= created_at <= last_a_msg_ts:
+            known_pool.append(f)
+    known_pool.sort(
+        key=lambda f: -int(f.get('importance', 5) or 5),
+    )
+    known_pool = known_pool[:MAX_KNOWN_POOL_FACTS]
+
+    persisted = await fact_store.aextract_facts_with_known_pool(
+        name, messages, known_pool,
+    )
+    if persisted:
+        logger.info(
+            f"[PathB] {name}: AI-aware Stage-1 抽出 {len(persisted)} 条新 fact "
+            f"(window={last_b.isoformat(timespec='seconds')} → "
+            f"{last_a_msg_ts.isoformat(timespec='seconds')}, "
+            f"known_pool={len(known_pool)})"
+        )
+
+    # 成功跑完（无论抽出 0 还是 N 条），推进 B cursor 到 A 处理过的最晚点
+    state['last_b_check_ts'] = last_a_msg_ts
+
+
 async def _periodic_signal_extraction_loop():
     """每 EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS 轮询，满足触发条件时对每个
     catgirl 跑 Stage-1 + Stage-2 + signal dispatch（RFC §3.4.3）。
@@ -1890,6 +2049,34 @@ async def _periodic_signal_extraction_loop():
 
                 # Stage-1 + dispatch 都跨过了，cursor 推进。
                 _signal_check_mark_done(name, now)
+
+                # 记录 A 实际处理过的最晚 msg ts，给 path B 当下游边界用
+                # （rows 已 ORDER BY ts ASC，最后一行就是 window 内最晚 msg）。
+                # 用真实 msg ts 而不是 wall-clock now：保证 path B 看到的
+                # 消息严格被 path A 看过，避免"A scan SQL 完成那一刻之后才入
+                # SQLite 的 msg 被 B 抢先处理"的 race。
+                state = _signal_check_state.setdefault(
+                    name, {'turns_since': 0, 'last_check_ts': None},
+                )
+                last_msg_ts = _coerce_db_ts(rows[-1][0])
+                if last_msg_ts is not None:
+                    state['last_a_msg_ts'] = last_msg_ts
+
+                # Path B trigger：A 成功跑完后 bump counter；达 N 触发
+                # _run_path_b（AI-aware Stage-1 only，详见函数 docstring）。
+                state['b_tick_counter'] = state.get('b_tick_counter', 0) + 1
+                if state['b_tick_counter'] >= EVIDENCE_AI_AWARE_EVERY_N_A_TICKS:
+                    state['b_tick_counter'] = 0
+                    try:
+                        await _run_path_b(name, state)
+                    except Exception as e:
+                        # B 失败完全不应该影响 A 路径（A 已经在 mark_done 之
+                        # 后了）；只 log warning。下次 b_tick_counter 又满 N
+                        # 时 B 自动重试，cursor 是 last_b_check_ts 推进的，
+                        # 失败时不推 cursor → 下次 B 重新覆盖同窗口。
+                        logger.warning(
+                            f"[PathB] {name}: AI-aware Stage-1 失败 (skip 本轮，下次 B trigger 重试): {e}"
+                        )
             except Exception as e:
                 logger.debug(f"[SignalLoop] {name}: 处理失败: {e}")
 

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1874,8 +1874,20 @@ async def _run_path_b(name: str, state: dict) -> None:
         logger.warning(f"[PathB] {name}: 读取窗口失败: {e}")
         return
     if not rows:
-        # 窗口内无 msg（A 处理过但都是空白？少见但可能）。推 cursor 跳过。
-        state['last_b_check_ts'] = last_a_msg_ts
+        # `aretrieve_original_by_timeframe` 在 SQL exception / engine init 失败
+        # / 维护态等情况下都 swallow + 返 []（见 timeindex.py 实现），从 caller
+        # 端无法区分"真空窗口"vs"transient 读失败"。保守起见 cursor 不推：
+        # - 真空窗口：A 刚成功处理了同段范围，B 这里几乎不可能真空（除非
+        #   A 的 SQL 看到 row 但 B 的 SQL 同段读不到——意味着 SQL 层异常）。
+        #   下次 B trigger 再 query 一次 0 rows 也是常数代价（SQLite 空范围
+        #   scan 极快）。
+        # - Transient 失败：保留 cursor 让下次 trigger 重试该窗口，避免把整段
+        #   [last_b, last_a_msg_ts] 永久 skip（Codex P1 round-5 on PR #1408）。
+        logger.debug(
+            f"[PathB] {name}: 窗口 {last_b.isoformat(timespec='seconds')} → "
+            f"{last_a_msg_ts.isoformat(timespec='seconds')} 取回 0 rows "
+            f"(可能 SQL transient 失败 swallow 成 []), 保留 cursor 下次 trigger 复查"
+        )
         return
 
     # 解析 SQL 实际取到的最后一行 ts —— 后续所有 cursor 推进点都用这个值，

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1824,18 +1824,26 @@ async def _run_path_b(name: str, state: dict) -> None:
       1. 窗口 = [last_b_check_ts, last_a_msg_ts]。cold start last_b 推算 =
          last_a_msg_ts - N × IDLE_MINUTES（保守覆盖 A 已经处理过的范围）
       2. SQL 层 LIMIT MAX_AI_AWARE_WINDOW_MSGS 防极端长窗口爆 prompt
-      3. 已知 fact 池：从 facts.json 拉 created_at ∈ window 的 fact，按
-         importance DESC 取前 MAX_KNOWN_POOL_FACTS 塞 prompt，让 LLM 输出
-         层主动去重 path A 已抽内容
+      3. 已知 fact 池：从 facts.json 拉 created_at ≥ last_b 的 fact（不设
+         上界——A idle delay 让最新一批 A facts 的 created_at 略晚于
+         last_a_msg_ts，设上界会把它们整批漏掉），按 importance DESC 取
+         前 MAX_KNOWN_POOL_FACTS 塞 prompt，让 LLM 输出层主动去重 path A
+         已抽内容
       4. 落盘 default_source='ai_disclosure'；LLM 显式 source 字段优先
-      5. 失败时 last_b_check_ts 不推进，下次 trigger 重试同窗口（fact
-         dedup 防双写）
+      5. Cursor 推进规则：
+         - SQL 返 0 rows → 推到 last_a_msg_ts（窗口确实空）
+         - SQL 返 N rows 但全 system/空 msg → 推到 last fetched row ts
+           （未取尾巴可能有内容）
+         - Stage-1 LLM 终态失败（aextract_facts_with_known_pool 返 None）
+           → cursor 不推进，下次 trigger 重试同窗口（fact dedup 防双写）
+         - 其它正常路径 → 推到 last fetched row ts（截断时 < last_a_msg_ts）
 
     与 path A 区别：
     - 不进 Stage-2 evidence loop（_apersist_new_facts 写 signal_processed=True
       + aextract_facts_and_detect_signals 内部 source filter 双重防御）
-    - Stage-1 失败 swallow（path A 自己的 FactExtractionFailed 有独立 retry
-      路径，B 是补抓性质不该阻塞）
+    - Stage-1 失败 swallow 不抛（path A 自己的 FactExtractionFailed 有独立
+      retry 路径，B 是补抓性质不该阻塞），但 cursor 必须保留——失败窗口
+      下次 trigger 重试，不能折叠成"成功 0 抽"静默 skip
     """
     last_a_msg_ts = state.get('last_a_msg_ts')
     if last_a_msg_ts is None:
@@ -1870,18 +1878,35 @@ async def _run_path_b(name: str, state: dict) -> None:
         state['last_b_check_ts'] = last_a_msg_ts
         return
 
+    # 解析 SQL 实际取到的最后一行 ts —— 后续所有 cursor 推进点都用这个值，
+    # 不能用 last_a_msg_ts。差别只在窗口被 MAX_AI_AWARE_WINDOW_MSGS LIMIT
+    # 截断时显现：截断时 last_fetched_ts < last_a_msg_ts，未取到的尾巴留
+    # 给下次 B trigger 继续处理；若推到 last_a_msg_ts 会让尾巴永久 skip
+    # （Codex P1 round-1 on PR #1408, P2 round-2 covers filtered-empty case）。
+    last_fetched_ts = _coerce_db_ts(rows[-1][0])
+    if last_fetched_ts is None:
+        # 防御：_coerce_db_ts 解析失败退回 last_a_msg_ts（避免 cursor 不动
+        # 死循环）。正常路径不触发——rows[-1][0] 是 SQLite 返回的 ts 字符串。
+        last_fetched_ts = last_a_msg_ts
+
     message_dicts = _extract_role_tagged_messages_from_rows(rows)
     if not message_dicts:
-        # 全是 system msg / 空内容。推 cursor 跳过。
-        state['last_b_check_ts'] = last_a_msg_ts
+        # 全是 system msg / 空内容。cursor 推到 last fetched（不是 last_a_msg_ts），
+        # 截断时未取尾巴可能含有效 msg。
+        state['last_b_check_ts'] = last_fetched_ts
         return
 
     from utils.llm_client import convert_to_messages
     messages = convert_to_messages(message_dicts)
 
-    # 已知 fact 池：拉 created_at ∈ window 的 fact（这些是 path A 这段时间
-    # 内抽出的，给 path B prompt 当 do-not-repeat 提示）。按 importance
-    # DESC 取前 MAX_KNOWN_POOL_FACTS。
+    # 已知 fact 池：用 path A 在本 B 窗口内 / 之后写的 fact 当 do-not-repeat 提示。
+    # 只设下界 ``created_at >= last_b``、不设上界（CodeRabbit on PR #1408）：
+    # A 的 idle/polling 延迟让"刚扫完本 B 窗口"那批 fact 的 created_at 普遍
+    # 略晚于 last_a_msg_ts，若用 created_at <= last_a_msg_ts 过滤会把最新一
+    # 批 A facts 整批排除——known_pool 对"刚被 A 抽过的内容"失效，path B 更
+    # 容易和 A 重复抽同一窗口。多包含一些"窗口后"的 A fact 是安全的：known
+    # _pool 只是 LLM 的提示，多余条目至多让 B 多抑制少量新 fact，且 Stage-1
+    # dedup hash 仍是兜底。按 importance DESC 取前 MAX_KNOWN_POOL_FACTS。
     try:
         all_facts = await fact_store.aload_facts(name)
     except Exception as e:
@@ -1891,7 +1916,7 @@ async def _run_path_b(name: str, state: dict) -> None:
     # Importance 用 safe_importance 兜底——legacy/手改 facts.json 里可能
     # 有 'importance': "high" / None / list 等脏值，raw int(...) cast 会
     # ValueError 把整个 B 跑挂、下次 trigger 又同样脏值同样挂，path B 对该
-    # 角色永久哑火（Codex P2 on PR #1408）。
+    # 角色永久哑火（Codex P2 round-1 on PR #1408）。
     from memory.facts import safe_importance
 
     known_pool: list[dict] = []
@@ -1903,7 +1928,7 @@ async def _run_path_b(name: str, state: dict) -> None:
             created_at = datetime.fromisoformat(created_at_raw[:19])
         except (ValueError, TypeError):
             continue
-        if last_b <= created_at <= last_a_msg_ts:
+        if created_at >= last_b:
             known_pool.append(f)
     known_pool.sort(key=lambda f: -safe_importance(f))
     known_pool = known_pool[:MAX_KNOWN_POOL_FACTS]
@@ -1911,24 +1936,25 @@ async def _run_path_b(name: str, state: dict) -> None:
     persisted = await fact_store.aextract_facts_with_known_pool(
         name, messages, known_pool,
     )
+    if persisted is None:
+        # Stage-1 LLM 终态失败（重试耗尽）。cursor 保留不推进，下次 B trigger
+        # 重试同窗口（fact dedup hash 防双写）。区分 None vs [] 至关重要：
+        # 若把失败折叠成"成功 0 抽"，失败窗口会被永久 skip（CodeRabbit / Codex
+        # P1 round-2 on PR #1408）。
+        logger.warning(
+            f"[PathB] {name}: Stage-1 终态失败，保留 cursor 下次 trigger 重试 "
+            f"(window={last_b.isoformat(timespec='seconds')} → "
+            f"{last_fetched_ts.isoformat(timespec='seconds')})"
+        )
+        return
     if persisted:
         logger.info(
             f"[PathB] {name}: AI-aware Stage-1 抽出 {len(persisted)} 条新 fact "
             f"(window={last_b.isoformat(timespec='seconds')} → "
-            f"{last_a_msg_ts.isoformat(timespec='seconds')}, "
+            f"{last_fetched_ts.isoformat(timespec='seconds')}, "
             f"known_pool={len(known_pool)})"
         )
 
-    # 推进 B cursor 到 SQL **实际取到的最后一行 ts**，不是 window 原本的下
-    # 游边界。当窗口包含 > MAX_AI_AWARE_WINDOW_MSGS 行（burst / 挂机后回来）
-    # 时 SQL 的 ORDER BY ts ASC + LIMIT 只取最早 N 行，剩下的尾巴留给下次
-    # B trigger 继续处理。若 cursor 推到 last_a_msg_ts 会让未取到的尾巴永
-    # 久 skip——path B 对那段 burst 静默失明（Codex P1 on PR #1408）。
-    last_fetched_ts = _coerce_db_ts(rows[-1][0])
-    if last_fetched_ts is None:
-        # 防御：_coerce_db_ts 解析失败时退回 last_a_msg_ts（避免 cursor 不动
-        # 死循环）。正常路径不会触发——rows[-1][0] 是 SQLite 返回的 ts 字符串。
-        last_fetched_ts = last_a_msg_ts
     state['last_b_check_ts'] = last_fetched_ts
 
 

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2016,6 +2016,14 @@ async def _run_path_b(name: str, state: dict) -> None:
             created_at = datetime.fromisoformat(created_at_raw)
         except (ValueError, TypeError):
             continue
+        # 防御：本仓库 `_apersist_new_facts` 写的 `created_at` 都是 naive
+        # datetime.now().isoformat()，但若 import/migration 路径写入了 TZ-aware
+        # 值（如 "...+00:00"），跟 naive 的 last_b 比较会抛 TypeError 让
+        # `_run_path_b` 一直 fail，path B 对该角色永久哑火（Codex P1 round-7
+        # on PR #1408）。比较口径上把 aware 当 naive 处理——绝大多数场景就是
+        # 同一 wall-clock 时间，时区差异不应让 fact 抽取整段挂掉。
+        if created_at.tzinfo is not None:
+            created_at = created_at.replace(tzinfo=None)
         if created_at >= last_b:
             known_pool.append(f)
     known_pool.sort(key=lambda f: -safe_importance(f))

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2010,7 +2010,10 @@ async def _run_path_b(name: str, state: dict) -> None:
             continue
         created_at_raw = f.get('created_at') or ''
         try:
-            created_at = datetime.fromisoformat(created_at_raw[:19])
+            # 完整 ISO 解析（含微秒）—— `created_at` 是 datetime.now().isoformat()
+            # 写盘的，截到 [:19] 会丢微秒，让 created_at == last_b + 0.x 秒的
+            # fact 在 `>= last_b` 比较里被误判出窗口（CodeRabbit on PR #1408）。
+            created_at = datetime.fromisoformat(created_at_raw)
         except (ValueError, TypeError):
             continue
         if created_at >= last_b:

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3072,11 +3072,18 @@ async def _run_post_turn_signals(messages: list, lanlan_name: str):
     user_msgs = _extract_user_messages(messages)
 
     # 本轮算入 signal-extraction 触发计数器（RFC §3.4.3）—— batch loop
-    # 靠这个 counter 在累积 10 turn 时触发 Stage-1+Stage-2，所以 per-turn
-    # bump 是 RFC 设计意图保留下来的，不能省。
+    # 靠这个 counter 在累积 N 轮时触发 _signal_check_one。
+    # 历史上这里 `if user_msgs:` 只在 user 发声时 bump，path A 时代没问题
+    # （Stage-1 抽的是 user_observation fact，AI-only 轮没料）。引入 path B
+    # 后该 gate 把纯 proactive / AI-only session 的所有 turn 全屏蔽掉，
+    # _signal_check_should_run 永远返 False，_signal_check_one 不跑，
+    # 进而 _run_path_b 永远不 trigger——AI 自我披露在 AI-only session 里
+    # 永久 skip（CodeRabbit P1 round-4 on PR #1408）。
+    # 修法：无条件 bump。代价：AI-only burst 会让 idle gate 提前到，
+    # _signal_check_one 多跑几次；但内部对 `user_msgs_text` 为空有早 return，
+    # Stage-1 LLM 不会白白跑——只多一次 SQL 读 + path B 触发判定。
     try:
-        if user_msgs:
-            _signal_check_record_turn(lanlan_name)
+        _signal_check_record_turn(lanlan_name)
     except Exception as e:
         # Best-effort counter bump; a failure here only delays the next
         # signal-extraction cycle — not worth interrupting conversation flow.

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -738,23 +738,34 @@ REBUTTAL_SQL_ROW_LIMIT = 200
 
 
 def _coerce_db_ts(ts) -> datetime | None:
-    """归一化 SQL 行里的 timestamp 字段为 datetime。
+    """归一化 SQL 行里的 timestamp 字段为 **naive** datetime。
 
     SQLAlchemy + SQLite 在某些 driver 配置下返回字符串而非 datetime；与
     memory/timeindex.py:get_last_conversation_time 同款归一化。返回 None
     表示无法解析（caller 应跳过此行而不是把 None 写进 cursor）。
+
+    若解析出 TZ-aware datetime（import / migration 路径写入 "...+00:00"
+    之类），强制 `replace(tzinfo=None)` 转 naive——本文件所有 cursor /
+    比较都按 naive 语义工作（last_b_check_ts / last_a_msg_ts / facts.json
+    `created_at` 全是 naive `datetime.now().isoformat()`），aware 跟 naive
+    比较会抛 TypeError 让 caller 永久哑火（Codex P1+P2 round-7/8 on PR
+    #1408 双侧 case）。
     """
     if isinstance(ts, datetime):
-        return ts
-    if isinstance(ts, str):
+        result = ts
+    elif isinstance(ts, str):
         try:
-            return datetime.fromisoformat(ts)
+            result = datetime.fromisoformat(ts)
         except ValueError:
             try:
-                return datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")
+                result = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")
             except ValueError:
                 return None
-    return None
+    else:
+        return None
+    if result.tzinfo is not None:
+        result = result.replace(tzinfo=None)
+    return result
 
 
 def _extract_user_messages_with_ts_from_rows(rows: list) -> list[tuple[str, datetime]]:
@@ -1874,8 +1885,19 @@ async def _run_path_b(name: str, state: dict) -> None:
     if last_a_msg_ts is None:
         # A 还没成功处理过任何 batch，B 无源可看
         return
+    # 防御性 TZ normalize：`_coerce_db_ts` 已经在写入 state 时归一化成 naive
+    # 是主路径保护，但外部 state injection / 升级前残留的 aware 值仍可能漏进
+    # 来——下面所有 cursor 比较 + known_pool created_at 比较都按 naive 工作，
+    # 这里再 strip 一遍把整个 _run_path_b 变成自包含 naive-only 域（Codex P2
+    # round-8 on PR #1408 双侧 case）。
+    if last_a_msg_ts.tzinfo is not None:
+        last_a_msg_ts = last_a_msg_ts.replace(tzinfo=None)
+        state['last_a_msg_ts'] = last_a_msg_ts
 
     last_b = state.get('last_b_check_ts')
+    if last_b is not None and last_b.tzinfo is not None:
+        last_b = last_b.replace(tzinfo=None)
+        state['last_b_check_ts'] = last_b
     if last_b is None:
         # Cold start lookback：B 第一次 trigger 时 last_b 无值，需要估个起点。
         # A tick 不一定按 IDLE gate 节律走——也可能被 turn-count gate

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -865,6 +865,27 @@ def _extract_role_tagged_messages_from_rows(rows: list) -> list[dict]:
     return out
 
 
+def _trim_to_user_msg_bracket(message_dicts: list[dict]) -> list[dict]:
+    """只保留首条 human msg 到末条 human msg 之间（含两端）的消息。
+
+    Product thesis 防廉价层污染：AI 在首条 user msg **之前**的内容是 user
+    还没印证的 proactive 试探，AI 在末条 user msg **之后**的内容是 user
+    还没回应过的独白——两段都是廉价层，不该当 fact 沉淀。只有夹在两条
+    user msg 中间的 AI 内容才意味着 "user 看到了 / 认可了这段对话上下
+    文"，才有资格被 path B 拣回当 ai_disclosure fact。
+
+    完全无 human msg → 返 []（caller 视作 AI-only 窗口跳过）。
+    只有一条 human msg → 返该条（bracket 退化为单点，仍合法：那条本身
+    就是 user 发声，path B 可借 known_pool 看相邻 AI 上下文）。
+    """
+    human_indices = [
+        i for i, m in enumerate(message_dicts) if m.get('type') == 'human'
+    ]
+    if not human_indices:
+        return []
+    return message_dicts[human_indices[0]:human_indices[-1] + 1]
+
+
 async def _resolve_rebuttal_start_time(name: str, now: datetime):
     """决定 rebuttal_loop 本轮查询的起始时间。
 
@@ -1831,6 +1852,9 @@ async def _run_path_b(name: str, state: dict) -> None:
          前 MAX_KNOWN_POOL_FACTS 塞 prompt，让 LLM 输出层主动去重 path A
          已抽内容
       4. 落盘 default_source='ai_disclosure'；LLM 显式 source 字段优先
+         注：喂给 Stage-1 的消息会先 trim 到 user-msg-bracket（首条 user msg
+         到末条 user msg 之间，含两端）——product thesis 防廉价层污染，
+         首尾的 AI 残段不该被 path B 当 fact 沉淀
       5. Cursor 推进规则：
          - SQL 返 0 rows → 推到 last_a_msg_ts（窗口确实空）
          - SQL 返 N rows 但全 system/空 msg → 推到 last fetched row ts
@@ -1939,6 +1963,21 @@ async def _run_path_b(name: str, state: dict) -> None:
     if not message_dicts:
         # 全是 system msg / 空内容。cursor 推到 last fetched（不是 last_a_msg_ts），
         # 截断时未取尾巴可能含有效 msg。
+        state['last_b_check_ts'] = last_fetched_ts
+        return
+
+    # 截到 user msg bracket：首条 user msg 到末条 user msg 之间（含两端）。
+    # Product thesis 防廉价层污染——首尾的 AI 残段（user 没印证过的试探 /
+    # user 没回应过的独白）不该当 fact 沉淀。
+    message_dicts = _trim_to_user_msg_bracket(message_dicts)
+    if not message_dicts:
+        # 窗口内完全无 user msg → AI-only 廉价层，故意 skip。cursor 照常推
+        # 进，下次 B trigger 不会再来覆盖这段。
+        logger.debug(
+            f"[PathB] {name}: 窗口 {last_b.isoformat(timespec='seconds')} → "
+            f"{last_fetched_ts.isoformat(timespec='seconds')} 无 user msg bracket "
+            f"(纯 AI-only 内容，product thesis 跳过)"
+        )
         state['last_b_check_ts'] = last_fetched_ts
         return
 

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1888,6 +1888,12 @@ async def _run_path_b(name: str, state: dict) -> None:
         logger.debug(f"[PathB] {name}: aload_facts 失败，known pool 留空: {e}")
         all_facts = []
 
+    # Importance 用 safe_importance 兜底——legacy/手改 facts.json 里可能
+    # 有 'importance': "high" / None / list 等脏值，raw int(...) cast 会
+    # ValueError 把整个 B 跑挂、下次 trigger 又同样脏值同样挂，path B 对该
+    # 角色永久哑火（Codex P2 on PR #1408）。
+    from memory.facts import safe_importance
+
     known_pool: list[dict] = []
     for f in all_facts:
         if not isinstance(f, dict):
@@ -1899,9 +1905,7 @@ async def _run_path_b(name: str, state: dict) -> None:
             continue
         if last_b <= created_at <= last_a_msg_ts:
             known_pool.append(f)
-    known_pool.sort(
-        key=lambda f: -int(f.get('importance', 5) or 5),
-    )
+    known_pool.sort(key=lambda f: -safe_importance(f))
     known_pool = known_pool[:MAX_KNOWN_POOL_FACTS]
 
     persisted = await fact_store.aextract_facts_with_known_pool(
@@ -1915,8 +1919,17 @@ async def _run_path_b(name: str, state: dict) -> None:
             f"known_pool={len(known_pool)})"
         )
 
-    # 成功跑完（无论抽出 0 还是 N 条），推进 B cursor 到 A 处理过的最晚点
-    state['last_b_check_ts'] = last_a_msg_ts
+    # 推进 B cursor 到 SQL **实际取到的最后一行 ts**，不是 window 原本的下
+    # 游边界。当窗口包含 > MAX_AI_AWARE_WINDOW_MSGS 行（burst / 挂机后回来）
+    # 时 SQL 的 ORDER BY ts ASC + LIMIT 只取最早 N 行，剩下的尾巴留给下次
+    # B trigger 继续处理。若 cursor 推到 last_a_msg_ts 会让未取到的尾巴永
+    # 久 skip——path B 对那段 burst 静默失明（Codex P1 on PR #1408）。
+    last_fetched_ts = _coerce_db_ts(rows[-1][0])
+    if last_fetched_ts is None:
+        # 防御：_coerce_db_ts 解析失败时退回 last_a_msg_ts（避免 cursor 不动
+        # 死循环）。正常路径不会触发——rows[-1][0] 是 SQLite 返回的 ts 字符串。
+        last_fetched_ts = last_a_msg_ts
+    state['last_b_check_ts'] = last_fetched_ts
 
 
 async def _periodic_signal_extraction_loop():

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2065,36 +2065,18 @@ async def _periodic_signal_extraction_loop():
                 if not rows:
                     _signal_check_mark_done(name, now)
                     return
-
-                # AI-only 窗口（proactive 触发的 AI 自我发起 / tool turn 等没有
-                # human msg）也要给 path B 跑——path B 设计目的就是拣回 AI 自我
-                # 披露和 grounded fact。这里把 last_a_msg_ts 推进 + b_tick_counter
-                # bump + maybe B trigger 提到 user_msgs 检查之前，保证 AI-only
-                # 窗口不被 path A 的 user-only Stage-1 早 return 漏掉
-                # （Codex P1 round-3 on PR #1408）。
-                state = _signal_check_state.setdefault(
-                    name, {'turns_since': 0, 'last_check_ts': None},
-                )
-                last_msg_ts = _coerce_db_ts(rows[-1][0])
-                if last_msg_ts is not None:
-                    state['last_a_msg_ts'] = last_msg_ts
-
                 user_msgs_text = _extract_user_messages_from_rows(rows)
                 if not user_msgs_text:
-                    # 没 user msg → path A 跑不了 user-observation 抽取，但 A
-                    # 已经"看过"这窗口（cursor 推进）。bump B counter，达 N 触发
-                    # B 把这段 AI-only 内容拣回来。
+                    # 窗口里没 user msg —— 纯 proactive / AI 自言自语 / tool
+                    # turn。这种内容**故意**不进 memory：
+                    # 1. Path A 抽 user_observation fact 需要 user 发声当源
+                    # 2. Path B 拣 AI 自我披露**也**只在 user 有 engagement
+                    #    的窗口里跑（B 是 piggyback A，不是独立路径）
+                    # 设计原则：用户不搭理 = 内容廉价层 ("90% 没心没肺"
+                    # product thesis)，不该被自动当 fact 沉淀污染 memory。
+                    # cursor 照常推进、计数清零，让下次有 user msg 的窗口
+                    # 直接进入正常 A+B 流程。
                     _signal_check_mark_done(name, now)
-                    state['b_tick_counter'] = state.get('b_tick_counter', 0) + 1
-                    if state['b_tick_counter'] >= EVIDENCE_AI_AWARE_EVERY_N_A_TICKS:
-                        state['b_tick_counter'] = 0
-                        try:
-                            await _run_path_b(name, state)
-                        except Exception as e:
-                            logger.warning(
-                                f"[PathB] {name}: AI-only 窗口 B 触发失败 "
-                                f"(skip 本轮): {e}"
-                            )
                     return
 
                 # 组装成 BaseMessage-like 结构给 extract_facts 使用
@@ -2160,10 +2142,19 @@ async def _periodic_signal_extraction_loop():
                     logger.debug(f"[SignalLoop] {name}: auto_promote_stale 失败: {e}")
 
                 # Stage-1 + dispatch 都跨过了，cursor 推进。
-                # 注意：last_a_msg_ts 已经在 user_msgs 检查之前更新过
-                # （AI-only 窗口分支共享同一段逻辑），这里只 bump b_tick_counter
-                # 准备触发 path B。
                 _signal_check_mark_done(name, now)
+
+                # 记录 A 实际处理过的最晚 msg ts，给 path B 当下游边界用
+                # （rows 已 ORDER BY ts ASC，最后一行就是 window 内最晚 msg）。
+                # 用真实 msg ts 而不是 wall-clock now：保证 path B 看到的
+                # 消息严格被 path A 看过，避免"A scan SQL 完成那一刻之后才入
+                # SQLite 的 msg 被 B 抢先处理"的 race。
+                state = _signal_check_state.setdefault(
+                    name, {'turns_since': 0, 'last_check_ts': None},
+                )
+                last_msg_ts = _coerce_db_ts(rows[-1][0])
+                if last_msg_ts is not None:
+                    state['last_a_msg_ts'] = last_msg_ts
 
                 # Path B trigger：A 成功跑完后 bump counter；达 N 触发
                 # _run_path_b（AI-aware Stage-1 only，详见函数 docstring）。
@@ -3096,17 +3087,15 @@ async def _run_post_turn_signals(messages: list, lanlan_name: str):
 
     # 本轮算入 signal-extraction 触发计数器（RFC §3.4.3）—— batch loop
     # 靠这个 counter 在累积 N 轮时触发 _signal_check_one。
-    # 历史上这里 `if user_msgs:` 只在 user 发声时 bump，path A 时代没问题
-    # （Stage-1 抽的是 user_observation fact，AI-only 轮没料）。引入 path B
-    # 后该 gate 把纯 proactive / AI-only session 的所有 turn 全屏蔽掉，
-    # _signal_check_should_run 永远返 False，_signal_check_one 不跑，
-    # 进而 _run_path_b 永远不 trigger——AI 自我披露在 AI-only session 里
-    # 永久 skip（CodeRabbit P1 round-4 on PR #1408）。
-    # 修法：无条件 bump。代价：AI-only burst 会让 idle gate 提前到，
-    # _signal_check_one 多跑几次；但内部对 `user_msgs_text` 为空有早 return，
-    # Stage-1 LLM 不会白白跑——只多一次 SQL 读 + path B 触发判定。
+    # 只在 user 有发声时 bump，**故意不**算 AI-only / proactive turn：
+    # path A 抽的是 user_observation fact，没 user 发声就抽不出料；
+    # path B 是 piggyback A 的 trigger 跑（不独立调度），也跟着只在 user
+    # 有 engagement 的窗口里跑。这是 product thesis 的"90% 没心没肺"——
+    # AI 自言自语 + user 不搭理的内容是廉价层，不该自动当 fact 沉淀污染
+    # memory；只有 user 印证过的才升级到神明降临层。
     try:
-        _signal_check_record_turn(lanlan_name)
+        if user_msgs:
+            _signal_check_record_turn(lanlan_name)
     except Exception as e:
         # Best-effort counter bump; a failure here only delays the next
         # signal-extraction cycle — not worth interrupting conversation flow.

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -1822,7 +1822,8 @@ async def _run_path_b(name: str, state: dict) -> None:
 
     设计要点：
       1. 窗口 = [last_b_check_ts, last_a_msg_ts]。cold start last_b 推算 =
-         last_a_msg_ts - N × IDLE_MINUTES（保守覆盖 A 已经处理过的范围）
+         last_a_msg_ts - max(N_TICKS, N_TURNS) × IDLE_MINUTES（取两种 A 触发
+         节律的较保守值，cover sparse turn 场景）
       2. SQL 层 LIMIT MAX_AI_AWARE_WINDOW_MSGS 防极端长窗口爆 prompt
       3. 已知 fact 池：从 facts.json 拉 created_at ≥ last_b 的 fact（不设
          上界——A idle delay 让最新一批 A facts 的 created_at 略晚于
@@ -1852,12 +1853,22 @@ async def _run_path_b(name: str, state: dict) -> None:
 
     last_b = state.get('last_b_check_ts')
     if last_b is None:
-        # Cold start：B 第一次 trigger 时已等了 EVIDENCE_AI_AWARE_EVERY_N_A_TICKS
-        # 个 A tick。每个 A tick 平均覆盖 EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES 分钟
-        # （idle gate 阈值），所以 A 已覆盖范围 ≈ N × IDLE_MINUTES 分钟。
-        # 用这个推算作为 B 第一次窗口起点。
+        # Cold start lookback：B 第一次 trigger 时 last_b 无值，需要估个起点。
+        # A tick 不一定按 IDLE gate 节律走——也可能被 turn-count gate
+        # (EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS 累积) 触发，或在 sparse turn
+        # 场景（user 间歇性发声、turn 间隔 >> IDLE_MIN）下两 tick 之间跨度
+        # 远超 IDLE_MIN。只按 piggyback 估算 (N_TICKS × IDLE_MIN) 会让 cold
+        # start 起点落在 A 真正处理过的范围之内，B 永久 skip 那段之前的
+        # AI-only msg（Codex P2 round-6 on PR #1408）。
+        # 修法：取 max(piggyback 节律, turn-count 节律) × IDLE_MIN 当估算
+        # 上限。默认下 max(3, 10) × 10min = 100min。LIMIT 兜底防爆 prompt，
+        # Stage-1 dedup hash 防双写——overshoot 是安全的。
+        cold_start_ticks_estimate = max(
+            EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+            EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
+        )
         estimated_a_coverage = timedelta(
-            minutes=EVIDENCE_AI_AWARE_EVERY_N_A_TICKS * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
+            minutes=cold_start_ticks_estimate * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
         )
         last_b = last_a_msg_ts - estimated_a_coverage
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -881,6 +881,29 @@ EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES = 5           # 或空闲 N 分钟触发
 EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS = 40      # 轮询间隔（与 IDLE_CHECK_INTERVAL 对齐）
 EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS = 30    # Stage-2 LLM rerank 后进 prompt 的 obs 上限（减少 NxM 配对决策点）
 
+# ── AI-aware Stage-1 (path B) ─────────────────────────────────────────
+# 原 SignalLoop (path A) 只看 user 消息，导致 PR #1346 之后 AI 自我披露 + proactive
+# 引入的屏幕/活动上下文全失明。Path B 走每 N 个 A tick 触发一次的 piggyback
+# 节奏：A 跑完后 b_tick_counter++，达到 N 就跑 B；窗口下游边界用 A 实际处理过
+# 的最晚 msg ts（不是 wall-clock now）保证 B 看的消息严格被 A 看过。
+EVIDENCE_AI_AWARE_EVERY_N_A_TICKS = 3
+"""Path B 每 N 次 A tick 触发一次（piggyback 在 A 循环里，不维护独立 wall-clock cadence）。
+- 选 3：A 平均 5 min 一次 tick → B 平均 15 min 一次。tempo 跟着对话强度自适应——
+  用户聊得越多 B 越频繁，符合"对话量大才需要补抓 AI fact"的直觉
+- B cold start lookback 自动 = N × EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES = 15 min"""
+
+MAX_AI_AWARE_WINDOW_MSGS = 200
+"""Path B 单次窗口 SQL LIMIT 上限。挂机后重启 / 长 idle 突发 burst 可能让
+[last_b_check_ts, last_a_msg_ts] 窗口跨越数小时百余条消息——cap 住防 prompt
+爆炸。LIMIT 在 SQL 层执行（aretrieve_original_by_timeframe 的 limit_rows 参数），
+ORDER BY ts ASC 取最早 N 条而不是最新（保 cursor 单调推进）。"""
+
+MAX_KNOWN_POOL_FACTS = 30
+"""Path B prompt 里塞的"已知 fact 池"上限（按 importance DESC 取前 N）。
+- 30 × ~30 tok = ~900 tok overhead，控制在 prompt 总 budget 的 ~20%
+- 作用：让 path B 的 LLM 知道哪些 fact 已被 path A 抽出，主动避免重抽 user 段
+  内容；命中的 fact 通常带 source='user_observation'"""
+
 # §3.5 / §6.5 Gate 4：归档扫描背景循环间隔
 # 1 小时一次：sub_zero_days 计数本身按"自然日"防抖（每天最多 +1），
 # 所以扫描频率 ≥ 一天即可保证不漏；选 1h 是为了让"score 跌穿 0 当天"
@@ -1870,6 +1893,9 @@ __all__ = [
     'EVIDENCE_SIGNAL_CHECK_ENABLED',
     'EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS',
     'EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES',
+    'EVIDENCE_AI_AWARE_EVERY_N_A_TICKS',
+    'MAX_AI_AWARE_WINDOW_MSGS',
+    'MAX_KNOWN_POOL_FACTS',
     'EVIDENCE_SIGNAL_CHECK_INTERVAL_SECONDS',
     'EVIDENCE_DETECT_SIGNALS_MAX_OBSERVATIONS',
     'EVIDENCE_ARCHIVE_SWEEP_INTERVAL_SECONDS',

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -1280,6 +1280,245 @@ def get_fact_extraction_prompt(lang: str = "zh") -> str:
     return _loc(FACT_EXTRACTION_PROMPT, lang)
 
 
+# ---------- fact_extraction_ai_aware_prompt → i18n dict ----------
+# Path B (AI-aware Stage-1) 专用 prompt：相比基础 FACT_EXTRACTION_PROMPT 多了
+#   1. {KNOWN_POOL} 块——path A 在同窗口已抽过的 fact 列表，让 LLM 输出层主动去重
+#   2. trust-tier 指导段——明确 user 段是 ground truth、ai 段是 self-disclosure
+#   3. 输出 schema 加 source 字段（'user_observation' / 'ai_disclosure'）
+# 输入侧（{CONVERSATION}）由 _format_conversation 渲染成 "博士 | xxx" / "悠怡 | xxx"
+# 的 role-tagged 形式，LLM 据此判 source 归属。
+#
+# 单独建一个 prompt（而不是给基础 prompt 加 optional placeholder）是为了：
+# - 保护 path A 行为不被新字段污染（path A 不需要 source 字段，省 ~10 tok/fact 输出）
+# - 易于回退（删 prompt + 一个调用方法即可）
+# - 让 review 一眼看出 path B 的 prompt 改动范围
+
+FACT_EXTRACTION_AI_AWARE_PROMPT = {
+    "zh": """从以下对话中提取关于 {LANLAN_NAME} 和 {MASTER_NAME} 的重要事实信息。
+
+⚠️ 本次抽取的特殊点（与基础抽取不同）：
+- 对话包含 {MASTER_NAME} 和 {LANLAN_NAME} 双方发言，形如 "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..."
+- 另一通路已经从 {MASTER_NAME} 单边发言抽过一遍 fact（见下面"已知事实池"），**请只补抓那一通路漏掉的内容**——特别是 {LANLAN_NAME} 自己披露的特征、{LANLAN_NAME} 引入的屏幕/活动上下文 grounded fact
+- 每条 fact 必须输出 `source` 字段标注 trust-tier：
+  - `"user_observation"`：主要从 {MASTER_NAME} 的发言推出（如果发现"已知池"漏抓的，归这一类）
+  - `"ai_disclosure"`：主要从 {LANLAN_NAME} 自己的发言推出，且 {MASTER_NAME} 在邻近 turn 内没明确反对/否认。例："{LANLAN_NAME} | 我今天突然觉得自己挺喜欢秋天的" → fact text "{LANLAN_NAME} 觉得自己挺喜欢秋天" + source=ai_disclosure
+
+要求：
+- 只提取重要且明确的事实（偏好、习惯、身份、关系动态等）
+- 忽略闲聊、寒暄、模糊的内容
+- 忽略AI幻觉、胡言乱语(gibberish)、无意义的编造内容，只提取对话中有真实依据的事实
+- 每条事实必须是一个独立的原子陈述
+- entity 标注为 "master"(关于{MASTER_NAME})、"neko"(关于{LANLAN_NAME})或 "relationship"(关于两人关系)
+- importance 1-10，规则与基础抽取一致（10 = 关键长期信息；8-9 = 长期稳定核心；6-7 = 普通偏好/日常；5 = 次要观察；1-4 = 弱相关线索）
+- event_when 可选，相对时间格式 `{"start": {"offset": <int>, "unit": "<unit>"}, "end": {...}}`；无时间线索写 null
+
+======以下为已知事实池（已被另一通路抽取，避免重复抽取相同内容）======
+{KNOWN_POOL}
+======以上为已知事实池======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+请以 JSON 数组格式返回（如果没有值得补抓的事实，返回空数组 []）：
+[
+  {"text": "事实描述", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "事实描述", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    "en": """Extract important factual information about {LANLAN_NAME} and {MASTER_NAME} from the following conversation.
+
+⚠️ Special notes for this extraction pass (differs from base extraction):
+- The conversation contains both {MASTER_NAME} and {LANLAN_NAME} speaking, formatted as "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..."
+- Another extraction pass has already covered facts grounded in {MASTER_NAME}'s own statements (see "Known facts pool" below). **Focus on facts that pass missed** — especially {LANLAN_NAME}'s self-disclosure or screen/activity context {LANLAN_NAME} introduced
+- Each fact MUST output a `source` field marking its trust-tier:
+  - `"user_observation"`: grounded primarily in {MASTER_NAME}'s statements (use this for any facts the "known pool" missed)
+  - `"ai_disclosure"`: grounded primarily in {LANLAN_NAME}'s own self-statements, with no clear contradiction from {MASTER_NAME} in nearby turns. Example: "{LANLAN_NAME} | I suddenly realized I really like autumn" → fact text "{LANLAN_NAME} likes autumn" + source=ai_disclosure
+
+Requirements:
+- Only extract important and clear facts (preferences, habits, identity, relationship dynamics)
+- Ignore small talk, greetings, vague content, AI hallucinations / gibberish
+- Each fact is an independent atomic statement
+- entity ∈ "master" / "neko" / "relationship"
+- importance 1-10, same rubric as base extraction
+- event_when optional, relative time format; null if no time cue
+
+======Known facts pool (already extracted by another pass, do NOT re-extract)======
+{KNOWN_POOL}
+======End known facts pool======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+Return as a JSON array (empty array if nothing worth additionally extracting):
+[
+  {"text": "fact description", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "fact description", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    "ja": """以下の会話から {LANLAN_NAME} と {MASTER_NAME} に関する重要な事実情報を抽出してください。
+
+⚠️ この抽出パスの特殊事項（基本抽出と異なる）：
+- 会話には {MASTER_NAME} と {LANLAN_NAME} の両方の発言が含まれ、"{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..." の形式
+- 別のパスが既に {MASTER_NAME} の発言から事実を抽出済み（下記「既知事実プール」参照）。**そのパスが見逃した内容に焦点を当ててください** —— 特に {LANLAN_NAME} 自身の自己開示、{LANLAN_NAME} が持ち込んだ画面/活動コンテキストに基づく事実
+- 各事実は trust-tier を示す `source` フィールドを必須で出力：
+  - `"user_observation"`: 主に {MASTER_NAME} の発言から推測（既知プールが見逃した場合はこれ）
+  - `"ai_disclosure"`: 主に {LANLAN_NAME} 自身の発言から推測、近隣ターンに {MASTER_NAME} の明確な否定がない場合
+
+要件：
+- 重要かつ明確な事実のみ抽出（好み、習慣、アイデンティティ、関係の動態など）
+- 雑談、挨拶、曖昧な内容、AI 幻覚は無視
+- 各事実は独立した原子的な文
+- entity ∈ "master" / "neko" / "relationship"
+- importance 1-10（基本抽出と同じ基準）
+- event_when は任意、相対時間形式、時間の手がかりがなければ null
+
+======既知事実プール（別パスで抽出済み、重複抽出しないこと）======
+{KNOWN_POOL}
+======既知事実プール終わり======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+以下の形式の JSON 配列で返してください（補抓する事実がなければ空配列 [] を返す）：
+[
+  {"text": "事実の説明", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "事実の説明", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    "ko": """다음 대화에서 {LANLAN_NAME}과 {MASTER_NAME}에 대한 중요한 사실 정보를 추출해 주세요.
+
+⚠️ 이번 추출의 특수 사항 (기본 추출과 다름):
+- 대화에는 {MASTER_NAME}과 {LANLAN_NAME}의 발언이 모두 포함되며, "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..." 형식
+- 다른 통로가 이미 {MASTER_NAME}의 발언에서 사실을 추출함 (아래 "기지 사실 풀" 참조). **그 통로가 놓친 부분에 집중해 주세요** — 특히 {LANLAN_NAME} 자신의 자기 개시, {LANLAN_NAME}이 도입한 화면/활동 컨텍스트 grounded 사실
+- 각 사실은 trust-tier를 표시하는 `source` 필드를 필수로 출력:
+  - `"user_observation"`: 주로 {MASTER_NAME}의 발언에서 추론 (기지 풀이 놓친 경우 이것)
+  - `"ai_disclosure"`: 주로 {LANLAN_NAME} 자신의 발언에서 추론, 근접 턴에 {MASTER_NAME}의 명확한 반대가 없음
+
+요구사항:
+- 중요하고 명확한 사실만 추출
+- 잡담, 인사, 모호한 내용, AI 환각 무시
+- 각 사실은 독립적인 원자적 진술
+- entity ∈ "master" / "neko" / "relationship"
+- importance 1-10 (기본 추출과 동일 기준)
+- event_when 선택, 상대 시간 형식, 시간 단서 없으면 null
+
+======기지 사실 풀 (다른 통로에서 추출됨, 중복 추출하지 마세요)======
+{KNOWN_POOL}
+======기지 사실 풀 끝======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+다음 형식의 JSON 배열로 반환해 주세요 (보충 추출할 사실이 없으면 빈 배열 [] 반환):
+[
+  {"text": "사실 설명", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "사실 설명", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    "ru": """Извлеките важную фактическую информацию о {LANLAN_NAME} и {MASTER_NAME} из следующей беседы.
+
+⚠️ Особенности этого прохода извлечения (отличается от базового):
+- Беседа содержит реплики и {MASTER_NAME}, и {LANLAN_NAME}, форматированные как "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..."
+- Другой проход уже извлёк факты из реплик {MASTER_NAME} (см. «Пул известных фактов» ниже). **Сосредоточьтесь на том, что тот проход пропустил** — особенно на самораскрытии {LANLAN_NAME} и фактах из экранного/активного контекста, который {LANLAN_NAME} ввёл
+- Каждый факт ОБЯЗАН содержать поле `source`, отмечающее его trust-tier:
+  - `"user_observation"`: основан главным образом на репликах {MASTER_NAME} (используйте это для фактов, пропущенных пулом)
+  - `"ai_disclosure"`: основан главным образом на собственных репликах {LANLAN_NAME}, без явного возражения {MASTER_NAME} в соседних ходах
+
+Требования:
+- Извлекайте только важные и чёткие факты
+- Игнорируйте болтовню, приветствия, расплывчатое содержание, галлюцинации ИИ
+- Каждый факт — независимое атомарное утверждение
+- entity ∈ "master" / "neko" / "relationship"
+- importance 1-10 (те же критерии, что и базовое извлечение)
+- event_when необязательно, относительное время; null если нет временного маркера
+
+======Пул известных фактов (уже извлечено другим проходом, не повторяйте)======
+{KNOWN_POOL}
+======Конец пула известных фактов======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+Верните в формате JSON-массива (пустой массив, если нечего дополнительно извлечь):
+[
+  {"text": "описание факта", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "описание факта", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    "es": """Extrae información factual importante sobre {LANLAN_NAME} y {MASTER_NAME} de la siguiente conversación.
+
+⚠️ Notas especiales para esta extracción (difiere de la extracción base):
+- La conversación contiene intervenciones de {MASTER_NAME} y {LANLAN_NAME}, con formato "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..."
+- Otra pasada ya extrajo hechos basados en las declaraciones de {MASTER_NAME} (ver "Reserva de hechos conocidos" abajo). **Concéntrate en lo que esa pasada se perdió** — especialmente la autorrevelación de {LANLAN_NAME} o hechos basados en contexto de pantalla/actividad introducido por {LANLAN_NAME}
+- Cada hecho DEBE incluir un campo `source` que marque su trust-tier:
+  - `"user_observation"`: basado principalmente en declaraciones de {MASTER_NAME} (úsalo para hechos que la reserva se perdió)
+  - `"ai_disclosure"`: basado principalmente en las propias declaraciones de {LANLAN_NAME}, sin contradicción clara de {MASTER_NAME} en turnos cercanos
+
+Requisitos:
+- Extrae solo hechos importantes y claros
+- Ignora charla casual, saludos, contenido vago, alucinaciones de IA
+- Cada hecho es una declaración atómica independiente
+- entity ∈ "master" / "neko" / "relationship"
+- importance 1-10 (mismo baremo que extracción base)
+- event_when opcional, tiempo relativo; null si no hay pista temporal
+
+======Reserva de hechos conocidos (ya extraídos por otra pasada, NO re-extraer)======
+{KNOWN_POOL}
+======Fin de la reserva de hechos conocidos======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+Devuelve un array JSON (si no hay hechos adicionales que extraer, devuelve []):
+[
+  {"text": "descripción del hecho", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "descripción del hecho", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+    "pt": """Extraia informações factuais importantes sobre {LANLAN_NAME} e {MASTER_NAME} da conversa abaixo.
+
+⚠️ Notas especiais para esta extração (difere da extração base):
+- A conversa contém falas de {MASTER_NAME} e {LANLAN_NAME}, formatadas como "{MASTER_NAME} | ..." / "{LANLAN_NAME} | ..."
+- Outra passagem já extraiu fatos baseados nas falas de {MASTER_NAME} (veja "Pool de fatos conhecidos" abaixo). **Concentre-se no que essa passagem perdeu** — especialmente autorrevelação de {LANLAN_NAME} ou fatos baseados em contexto de tela/atividade que {LANLAN_NAME} introduziu
+- Cada fato DEVE incluir um campo `source` marcando seu trust-tier:
+  - `"user_observation"`: baseado principalmente em falas de {MASTER_NAME} (use isto para fatos que o pool perdeu)
+  - `"ai_disclosure"`: baseado principalmente em falas próprias de {LANLAN_NAME}, sem contradição clara de {MASTER_NAME} em turnos próximos
+
+Requisitos:
+- Extraia apenas fatos importantes e claros
+- Ignore conversa casual, cumprimentos, conteúdo vago, alucinações de IA
+- Cada fato é uma declaração atômica independente
+- entity ∈ "master" / "neko" / "relationship"
+- importance 1-10 (mesmo critério da extração base)
+- event_when opcional, tempo relativo; null se não houver pista temporal
+
+======Pool de fatos conhecidos (já extraídos por outra passagem, NÃO re-extrair)======
+{KNOWN_POOL}
+======Fim do pool de fatos conhecidos======
+
+======以下为对话======
+{CONVERSATION}
+======以上为对话======
+
+Retorne um array JSON (se não houver fatos adicionais a extrair, retorne []):
+[
+  {"text": "descrição do fato", "importance": 7, "entity": "master", "event_when": null, "source": "user_observation"},
+  {"text": "descrição do fato", "importance": 7, "entity": "neko", "event_when": null, "source": "ai_disclosure"},
+  ...
+]""",
+}
+
+
+def get_fact_extraction_ai_aware_prompt(lang: str = "zh") -> str:
+    return _loc(FACT_EXTRACTION_AI_AWARE_PROMPT, lang)
+
+
 # backward compat
 fact_extraction_prompt = FACT_EXTRACTION_PROMPT["zh"]
 

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -450,15 +450,45 @@ class FactStore:
             return []
         return extracted
 
+    # Source-tier 白名单。'user_observation' = path A 抽出的 user msg ground truth；
+    # 'ai_disclosure' = path B 抽出的 AI 自我披露/屏幕上下文（trust-tier 较低）。
+    # 老 fact 没 source 字段时按 'user_observation' 回退（向后兼容——pre-#PR
+    # 时代所有 fact 都源自 user msg）。
+    _SOURCE_VALUES = frozenset({'user_observation', 'ai_disclosure'})
+    _SOURCE_DEFAULT = 'user_observation'
+
     async def _apersist_new_facts(
         self, lanlan_name: str, extracted: list[dict],
+        *,
+        default_source: str = 'user_observation',
     ) -> list[dict]:
         """Dedup (SHA-256 + FTS5) + persist. importance < 5 facts are KEPT
         (RFC §3.1.3)—downstream `get_unabsorbed_facts(min_importance=5)`
-        filters at read time."""
+        filters at read time.
+
+        ``default_source``：当 LLM 输出的 fact dict 没有 ``source`` 字段时
+        的回退值。Path A 调用方传 ``'user_observation'``（也是默认），
+        path B 调用方传 ``'ai_disclosure'`` —— LLM 显式输出的 source 字段
+        优先于 default。
+
+        Monotonic source upgrade：SHA-256 命中既有 fact 时，正常 skip 不写。
+        **唯一例外**：既有 fact 的 source 是 'ai_disclosure'、新 fact 的
+        source 是 'user_observation' → in-place 升级 existing.source +
+        重置 signal_processed=False 让 Stage-2 重新评估。反向（user→ai）
+        永不降级——user 印证不可逆。
+        """
+        if default_source not in self._SOURCE_VALUES:
+            default_source = self._SOURCE_DEFAULT
+
         new_facts: list[dict] = []
+        upgraded_count = 0
         existing_facts = await self.aload_facts(lanlan_name)
         existing_hashes = {f.get('hash') for f in existing_facts if f.get('hash')}
+        # hash → fact 的快查表（仅 upgrade 路径用）。aload_facts 已经 in-place
+        # 缓存了 list，这里读不复制。
+        hash_to_existing = {
+            f.get('hash'): f for f in existing_facts if f.get('hash')
+        }
 
         for fact in extracted:
             if not isinstance(fact, dict):
@@ -494,9 +524,27 @@ class FactStore:
                 )
                 entity = 'master'
 
-            # Stage 1: SHA-256 exact dedup
+            # Source resolution: LLM 显式 source 优先 + 白名单 + default fallback
+            raw_source = fact.get('source')
+            if raw_source in self._SOURCE_VALUES:
+                source = raw_source
+            else:
+                source = default_source
+
+            # Stage 1: SHA-256 exact dedup（+ source monotonic upgrade）
             content_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
             if content_hash in existing_hashes:
+                existing = hash_to_existing.get(content_hash)
+                if (
+                    existing is not None
+                    and existing.get('source', self._SOURCE_DEFAULT) == 'ai_disclosure'
+                    and source == 'user_observation'
+                ):
+                    # Path A 用 user msg 印证了之前 path B 写过的 ai_disclosure fact
+                    # → 升级 source + 重新进 Stage-2 evidence loop
+                    existing['source'] = 'user_observation'
+                    existing['signal_processed'] = False
+                    upgraded_count += 1
                 continue
 
             # Stage 2: FTS5 semantic dedup (lightweight, no LLM)
@@ -528,6 +576,10 @@ class FactStore:
                 'text': text,
                 'importance': importance,
                 'entity': entity,
+                # Trust-tier source（path A 写 'user_observation'，path B 写
+                # 'ai_disclosure'）。Stage-2 / 其他 evidence-loop 消费者按需 filter。
+                # 老 fact 缺该字段时读侧默认 'user_observation' 向后兼容。
+                'source': source,
                 # RFC §2.7: tags 字段保留位但新 fact 默认写空，LLM 不再填
                 'tags': [],
                 'hash': content_hash,
@@ -546,7 +598,11 @@ class FactStore:
                 # without this key are read with default=True (i.e. treated as
                 # already processed) so an upgrade doesn't replay months of
                 # history through Stage-2.
-                'signal_processed': False,
+                #
+                # ⚠️ source='ai_disclosure' fact：写盘时直接置 True，让 Stage-2
+                # 永不取它。配合 aextract_facts_and_detect_signals 内部的
+                # source filter 做双重防御，防漏。
+                'signal_processed': (source == 'ai_disclosure'),
                 # Vector-embedding cache (memory-enhancements P2 — see
                 # memory/embeddings.py). Written as None so /process
                 # returns immediately without blocking on embedding;
@@ -567,15 +623,25 @@ class FactStore:
                     lanlan_name, fact_entry['id'], text,
                 )
 
-        if new_facts:
+        # Save if we either added new facts OR upgraded existing ones'
+        # source field. Without the upgrade path: A 后 B 跑时撞到 hash 但
+        # 上下源不同会丢 in-place 改的字段，下次启动 reload facts.json 就
+        # 把升级 wipe 了。
+        if new_facts or upgraded_count:
             await self.asave_facts(lanlan_name)
+        if new_facts:
             logger.info(
                 f"[FactStore] {lanlan_name}: 提取了 {len(new_facts)} 条新事实"
             )
             for nf in new_facts:
                 logger.debug(
-                    f"   - [{nf.get('entity','?')}] {nf.get('text','')[:80]}"
+                    f"   - [{nf.get('entity','?')}/{nf.get('source','?')}] {nf.get('text','')[:80]}"
                 )
+        if upgraded_count:
+            logger.info(
+                f"[FactStore] {lanlan_name}: 升级 {upgraded_count} 条 ai_disclosure → user_observation "
+                f"(user 印证后重入 Stage-2 evidence loop)"
+            )
 
         return new_facts
 
@@ -910,10 +976,18 @@ class FactStore:
         # Drain：拉所有 signal_processed=False 的 facts（含历史尾部 + 本轮新增）。
         # 老 facts 没这个字段时 default=True，避免升级后把几个月历史 fact
         # 一起重跑 Stage-2。
+        #
+        # ⚠️ Source filter：排除 source='ai_disclosure'——AI 自我披露的 fact
+        # 不进 evidence loop（防自我强化死循环：AI 说"我喜欢 X" → 抽出 → Stage-2
+        # 给 reflection "neko likes X" 涨分 → AI 更频繁说"我喜欢 X" → ...）。
+        # path B 写盘时已经把 signal_processed 置 True 兜底（_apersist_new_facts），
+        # 此处 source filter 做双重防御，防新加路径忘了置 signal_processed。
+        # 老 fact 缺 source 字段时按 'user_observation' 回退（向后兼容）。
         all_facts = await self.aload_facts(lanlan_name)
         unprocessed = [
             f for f in all_facts
             if not f.get('signal_processed', True)
+            and f.get('source', self._SOURCE_DEFAULT) != 'ai_disclosure'
         ]
         if not unprocessed:
             return persisted_this_round, [], []
@@ -986,6 +1060,82 @@ class FactStore:
         if not extracted:
             return []
         return await self._apersist_new_facts(lanlan_name, extracted)
+
+    async def aextract_facts_with_known_pool(
+        self,
+        lanlan_name: str,
+        messages: list,
+        known_pool: list[dict],
+    ) -> list[dict]:
+        """AI-aware Stage-1 (path B) extraction —— 输入是 role-tagged user+ai
+        全消息，prompt 里塞 ``known_pool``（path A 在同窗口已抽过的 fact）
+        作为 "do-not-repeat" 列表，让 LLM 在输出层主动去重。
+
+        与 ``extract_facts`` 区别：
+        - 用新 prompt (``FACT_EXTRACTION_AI_AWARE_PROMPT``) 而不是基础 prompt
+        - prompt 多了 known pool 段 + trust-tier 指导 + source 字段输出要求
+        - 落盘 default_source='ai_disclosure'（LLM 显式输出的 source 仍优先）
+        - Stage-2 不走（path B 设计就不进 evidence loop）
+
+        Stage-1 失败时返 [] 而非 raise——path B 是补抓性质，失败不该阻塞
+        后续 A tick（A 自己的 Stage-1 失败有独立的 FactExtractionFailed 处理）。
+        """
+        extracted = await self._allm_extract_facts_with_known_pool(
+            lanlan_name, messages, known_pool,
+        )
+        if not extracted:
+            return []
+        return await self._apersist_new_facts(
+            lanlan_name, extracted, default_source='ai_disclosure',
+        )
+
+    async def _allm_extract_facts_with_known_pool(
+        self,
+        lanlan_name: str,
+        messages: list,
+        known_pool: list[dict],
+    ) -> list[dict] | None:
+        """Stage-1 LLM call for path B: role-tagged conversation + known pool。
+
+        Returns raw LLM-extracted list, or None on terminal failure
+        (caller swallows in aextract_facts_with_known_pool)."""
+        from config.prompts.prompts_memory import get_fact_extraction_ai_aware_prompt
+
+        _, _, _, _, name_mapping, _, _, _, _ = await self._config_manager.aget_character_data()
+        name_mapping['ai'] = lanlan_name
+        conversation_text = self._format_conversation(messages, name_mapping)
+
+        # Known pool 段渲染：按 importance DESC 排（最重要的在最前，给 LLM
+        # 最强信号）。cap 已经在 caller 端做过，这里不重复。
+        known_lines = []
+        for f in known_pool:
+            text = f.get('text', '') or ''
+            if not text:
+                continue
+            imp = f.get('importance', 5)
+            known_lines.append(f"- {text} (importance: {imp})")
+        known_block = "\n".join(known_lines) if known_lines else "(none)"
+
+        prompt = get_fact_extraction_ai_aware_prompt(get_global_language()) \
+            .replace('{CONVERSATION}', conversation_text) \
+            .replace('{KNOWN_POOL}', known_block) \
+            .replace('{LANLAN_NAME}', lanlan_name) \
+            .replace('{MASTER_NAME}', name_mapping.get('human', '主人'))
+
+        extracted = await self._allm_call_with_retries(
+            prompt, lanlan_name,
+            tier=EVIDENCE_EXTRACT_FACTS_MODEL_TIER,
+            call_type="memory_fact_extraction_ai_aware",
+        )
+        if extracted is None:
+            return None
+        if not isinstance(extracted, list):
+            logger.warning(
+                f"[FactStore] {lanlan_name}: path-B Stage-1 返回非数组 "
+                f"{type(extracted).__name__}，当作空列表处理"
+            )
+            return []
+        return extracted
 
     # ── query helpers ────────────────────────────────────────────────
 

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1078,15 +1078,17 @@ class FactStore:
         - Stage-2 不走（path B 设计就不进 evidence loop）
 
         Returns:
-            - ``None``: Stage-1 LLM 终态失败（重试耗尽）。caller 应保留 cursor
-              下次 trigger 重试同窗口。
-            - ``[]``: Stage-1 成功但 LLM 判窗口内 0 条新 fact（已 dedupe 完）。
+            - ``None``: Stage-1 终态失败——重试耗尽 / LLM 返非数组（如
+              ``{"facts": [...]}`` 包了一层）。caller 应保留 cursor 下次
+              trigger 重试同窗口。
+            - ``[]``: Stage-1 成功且 LLM 判窗口内 0 条新 fact（已 dedupe 完）。
               caller 可正常推进 cursor。
             - ``list[dict]``: 成功且抽到 N 条新 fact，已 persist。
 
             None / [] 的区分至关重要：若把 None 折叠成 []，path B 会在 LLM
-            transient failure 时把失败窗口当作"成功 0 抽"推进 cursor，导致
-            消息永久 skip（CodeRabbit / Codex P1 round-2 on PR #1408）。
+            transient failure / 错形态 payload 时把失败窗口当作"成功 0 抽"
+            推进 cursor，导致消息永久 skip（CodeRabbit / Codex P1 round-2 +
+            Codex P1 round-9 on PR #1408）。
         """
         extracted = await self._allm_extract_facts_with_known_pool(
             lanlan_name, messages, known_pool,
@@ -1140,11 +1142,15 @@ class FactStore:
         if extracted is None:
             return None
         if not isinstance(extracted, list):
+            # 非数组 payload（如 `{"facts": [...]}` 包了一层、或 LLM 偶发瞎写）
+            # 等同 Stage-1 terminal failure 处理——返 None 让 `_run_path_b`
+            # 保留 cursor 下次 trigger 重试同窗口，而不是当成"成功 0 抽"推
+            # cursor 永久 skip 这段消息（Codex P1 round-9 on PR #1408）。
             logger.warning(
                 f"[FactStore] {lanlan_name}: path-B Stage-1 返回非数组 "
-                f"{type(extracted).__name__}，当作空列表处理"
+                f"{type(extracted).__name__}，按 terminal failure 处理 (cursor 不推进)"
             )
-            return []
+            return None
         return extracted
 
     # ── query helpers ────────────────────────────────────────────────

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -616,6 +616,13 @@ class FactStore:
             }
             existing_facts.append(fact_entry)
             existing_hashes.add(content_hash)
+            # 同步更新 hash_to_existing：若本 batch 后续还有同 text 的 fact
+            # 出现（如 LLM 偶发重复 / 同 batch 跨段抽到同一观察），下一轮命
+            # 中 `content_hash in existing_hashes` 时能拿到本轮刚写入的
+            # fact_entry 走 monotonic upgrade 路径。否则 hash_to_existing.
+            # get() 返 None → 跳过 upgrade，新观察的 user_observation 升级被
+            # 静默丢弃 (Codex P2 round-10 on PR #1408)。
+            hash_to_existing[content_hash] = fact_entry
             new_facts.append(fact_entry)
 
             if self._time_indexed is not None:

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1066,7 +1066,7 @@ class FactStore:
         lanlan_name: str,
         messages: list,
         known_pool: list[dict],
-    ) -> list[dict]:
+    ) -> list[dict] | None:
         """AI-aware Stage-1 (path B) extraction —— 输入是 role-tagged user+ai
         全消息，prompt 里塞 ``known_pool``（path A 在同窗口已抽过的 fact）
         作为 "do-not-repeat" 列表，让 LLM 在输出层主动去重。
@@ -1077,12 +1077,22 @@ class FactStore:
         - 落盘 default_source='ai_disclosure'（LLM 显式输出的 source 仍优先）
         - Stage-2 不走（path B 设计就不进 evidence loop）
 
-        Stage-1 失败时返 [] 而非 raise——path B 是补抓性质，失败不该阻塞
-        后续 A tick（A 自己的 Stage-1 失败有独立的 FactExtractionFailed 处理）。
+        Returns:
+            - ``None``: Stage-1 LLM 终态失败（重试耗尽）。caller 应保留 cursor
+              下次 trigger 重试同窗口。
+            - ``[]``: Stage-1 成功但 LLM 判窗口内 0 条新 fact（已 dedupe 完）。
+              caller 可正常推进 cursor。
+            - ``list[dict]``: 成功且抽到 N 条新 fact，已 persist。
+
+            None / [] 的区分至关重要：若把 None 折叠成 []，path B 会在 LLM
+            transient failure 时把失败窗口当作"成功 0 抽"推进 cursor，导致
+            消息永久 skip（CodeRabbit / Codex P1 round-2 on PR #1408）。
         """
         extracted = await self._allm_extract_facts_with_known_pool(
             lanlan_name, messages, known_pool,
         )
+        if extracted is None:
+            return None
         if not extracted:
             return []
         return await self._apersist_new_facts(

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -443,7 +443,7 @@ async def test_apersist_monotonic_source_upgrade_within_same_batch():
         },
     ]
 
-    out = await fs._apersist_new_facts(
+    await fs._apersist_new_facts(
         '悠怡', extracted, default_source='ai_disclosure',
     )
 

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -974,6 +974,54 @@ async def test_path_b_truncated_window_all_filtered_advances_to_last_fetched():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_path_b_known_pool_preserves_microsecond_precision_at_boundary():
+    """Regression (CodeRabbit on PR #1408)：known_pool 的 created_at 解析必
+    须保留微秒精度。先前 `datetime.fromisoformat(created_at_raw[:19])` 截
+    到秒会让"`created_at` 比 `last_b` 晚 0.x 秒"的 fact 被误判出窗口。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 10, 0)  # 整秒
+    # last_b 故意带微秒小数
+    last_b = datetime(2026, 5, 18, 12, 0, 0, 500_000)  # T+0.5s
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 关键 fact: created_at 比 last_b 晚 200ms（仍 >= last_b 应该进 pool）
+    # 若截秒，fact 会被解析成 T+0.000，比 last_b T+0.500 早 → 误排
+    on_boundary_fact = {
+        'id': 'just_after_last_b',
+        'text': 'created_at 比 last_b 晚 200ms',
+        'importance': 8,
+        'created_at': (last_b + timedelta(microseconds=200_000)).isoformat(),
+    }
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(seconds=1), 's', json.dumps({
+            'type': 'human', 'data': {'content': '占位'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[on_boundary_fact])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    fake_fact_store.aextract_facts_with_known_pool.assert_awaited_once()
+    captured_pool = fake_fact_store.aextract_facts_with_known_pool.await_args.args[2]
+    pool_ids = {f['id'] for f in captured_pool}
+    assert 'just_after_last_b' in pool_ids, (
+        "微秒精度边界 fact (created_at = last_b + 0.2s) 应入 known_pool，"
+        "实际被排除——`[:19]` 截秒回归了"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_path_b_known_pool_includes_just_written_a_facts_despite_clock_skew():
     """Regression (CodeRabbit on PR #1408)：A 的 idle/polling 延迟让"刚扫
     完本 B 窗口"那批 A facts 的 created_at 普遍略晚于 last_a_msg_ts。known

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -882,6 +882,64 @@ async def test_path_b_known_pool_sort_tolerates_malformed_importance():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_allm_extract_known_pool_returns_none_on_non_list_payload():
+    """Regression (Codex P1 round-9 on PR #1408)：
+    `_allm_extract_facts_with_known_pool` 收到非 list payload (如
+    `{"facts": [...]}`、纯 str、int 等) 必须返 None 等同 terminal failure，
+    不能折叠成 []——否则 `aextract_facts_with_known_pool` 会再继续返 []，
+    `_run_path_b` 把它当成"成功 0 抽"推 cursor，那段窗口永久 skip。
+    """
+    from memory.facts import FactStore
+    from unittest.mock import AsyncMock, MagicMock
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._config_manager.aget_character_data = AsyncMock(return_value=(
+        None, None, None, None, {'ai': 'lan', 'human': 'usr'}, None, None, None, None,
+    ))
+    fs._format_conversation = MagicMock(return_value='对话占位')
+
+    # 各种 LLM 错形态 payload
+    for bad_payload in [
+        {'facts': [{'text': 'wrapped', 'importance': 5}]},  # 对象包一层
+        'random string output',                              # 纯字符串
+        42,                                                  # 数字
+        {},                                                  # 空对象
+        True,                                                # bool
+    ]:
+        fs._allm_call_with_retries = AsyncMock(return_value=bad_payload)
+        out = await fs._allm_extract_facts_with_known_pool('lan', [], [])
+        assert out is None, (
+            f"非 list payload ({type(bad_payload).__name__}: {bad_payload!r}) "
+            f"必须返 None 等同 terminal failure，实际返 {out!r}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_aextract_facts_with_known_pool_propagates_none_from_bad_shape():
+    """End-to-end 配套：bad-shape payload → `_allm_extract_facts_with_known
+    _pool` 返 None → `aextract_facts_with_known_pool` 也返 None →
+    `_run_path_b` 保留 cursor 下次 trigger 重试。"""
+    from memory.facts import FactStore
+    from unittest.mock import AsyncMock, MagicMock
+
+    fs = FactStore.__new__(FactStore)
+    # `_allm_extract_facts_with_known_pool` 直接 mock，验证 wrapper 透传 None
+    fs._allm_extract_facts_with_known_pool = AsyncMock(return_value=None)
+    fs._apersist_new_facts = AsyncMock(return_value=[])  # 不该被调
+
+    out = await fs.aextract_facts_with_known_pool('lan', [], [])
+    assert out is None, (
+        f"_allm_extract_facts_with_known_pool 返 None 时 wrapper 必须透传 None，"
+        f"实际返 {out!r}"
+    )
+    # persist 不该被调（失败时 fact 不该落盘）
+    fs._apersist_new_facts.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_path_b_stage1_terminal_failure_preserves_cursor():
     """Regression (CodeRabbit + Codex P1 round-2 on PR #1408)：
     ``aextract_facts_with_known_pool`` 返 None 表示 Stage-1 LLM 终态失败

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1,0 +1,535 @@
+# -*- coding: utf-8 -*-
+"""AI-aware Stage-1 (path B) — 端到端不变量与 contract pin。
+
+设计 background：path A 已有的 SignalLoop 只看 user msgs（PR #1346 之后
+ON-mode 唯一 fact 抽取路径），导致 AI 自我披露 + proactive 引入的屏幕/活动
+上下文 grounded fact 全失明。path B 在 A 循环里 piggyback 触发，跑 AI-aware
+Stage-1（含 user+ai 全消息 + known pool 提示），fact 标 source='ai_disclosure'
+不进 Stage-2 evidence loop。
+
+测试覆盖：
+1. ``_extract_role_tagged_messages_from_rows``：收 user + ai 双 type，
+   渲染 list[dict] 而非 list[str]
+2. ``_apersist_new_facts``：source 字段持久化 + ai_disclosure 写盘时
+   signal_processed=True（防卡池）
+3. ``_apersist_new_facts``：monotonic source upgrade（ai_disclosure
+   → user_observation 不可逆 + 重置 signal_processed=False 让 Stage-2
+   重新评估）
+4. ``aextract_facts_and_detect_signals``：unprocessed pool filter
+   ``source != 'ai_disclosure'`` 双重防御
+5. Path B trigger cadence：每 ``EVIDENCE_AI_AWARE_EVERY_N_A_TICKS``
+   次 A tick 触发一次
+6. Path B cold-start lookback：从 ``EVIDENCE_AI_AWARE_EVERY_N_A_TICKS
+   × EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES`` 推算，不要新魔法常数
+
+测不到的部分（留 manual / e2e）：
+- 实际 LLM 是否正确分配 source（依赖 prompt + 模型）
+- known_pool 是否真起到 do-not-repeat 效果（依赖 LLM 听话程度）
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+def test_extract_role_tagged_messages_keeps_user_and_ai():
+    """跟 _extract_user_messages_from_rows 形成对偶：path B 必须收 ai msg。"""
+    from app.memory_server import _extract_role_tagged_messages_from_rows
+
+    rows = [
+        (datetime(2026, 5, 18, 10, 0, 0), 'sess1', json.dumps({
+            'type': 'human', 'data': {'content': '主人说的话'},
+        })),
+        (datetime(2026, 5, 18, 10, 0, 5), 'sess1', json.dumps({
+            'type': 'ai', 'data': {'content': '猫娘自己的话'},
+        })),
+        (datetime(2026, 5, 18, 10, 0, 10), 'sess1', json.dumps({
+            'type': 'system', 'data': {'content': '系统消息不应该收'},
+        })),
+        (datetime(2026, 5, 18, 10, 0, 15), 'sess1', json.dumps({
+            'type': 'ai', 'data': {'content': [
+                {'type': 'text', 'text': 'part1 '},
+                {'type': 'text', 'text': 'part2'},
+            ]},
+        })),
+    ]
+    out = _extract_role_tagged_messages_from_rows(rows)
+    assert len(out) == 3, f"应收 2 human + 1 ai = 3 条，实际 {len(out)}"
+    types = [m['type'] for m in out]
+    assert types == ['human', 'ai', 'ai']  # system 被滤
+    assert out[0]['data']['content'] == '主人说的话'
+    assert out[1]['data']['content'] == '猫娘自己的话'
+    # content list 形态拼成单 str
+    assert out[2]['data']['content'] == 'part1 part2'
+
+
+@pytest.mark.unit
+def test_extract_role_tagged_messages_skips_empty_content():
+    """空白 content 不该入 list，防 prompt 渲染出空行。"""
+    from app.memory_server import _extract_role_tagged_messages_from_rows
+
+    rows = [
+        (datetime(2026, 5, 18, 10, 0, 0), 'sess1', json.dumps({
+            'type': 'human', 'data': {'content': '   '},  # 纯空白
+        })),
+        (datetime(2026, 5, 18, 10, 0, 5), 'sess1', json.dumps({
+            'type': 'human', 'data': {'content': '有内容'},
+        })),
+    ]
+    out = _extract_role_tagged_messages_from_rows(rows)
+    assert len(out) == 1
+    assert out[0]['data']['content'] == '有内容'
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apersist_writes_source_field_default_user_observation():
+    """path A 调用方不传 default_source → 落盘 source='user_observation'，
+    signal_processed=False（正常进 Stage-2）。"""
+    from memory.facts import FactStore
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {'悠怡': []}
+    fs._locks = {}
+    import threading
+    fs._locks_guard = threading.Lock()
+    fs.aload_facts = AsyncMock(return_value=[])
+    fs.asave_facts = AsyncMock(return_value=None)
+
+    extracted = [
+        {'text': '博士喜欢三文鱼', 'importance': 8, 'entity': 'master'},
+    ]
+    with patch.object(fs, 'aload_facts', AsyncMock(return_value=[])):
+        new_facts = await fs._apersist_new_facts('悠怡', extracted)
+
+    assert len(new_facts) == 1
+    assert new_facts[0]['source'] == 'user_observation'
+    assert new_facts[0]['signal_processed'] is False, (
+        "user_observation fact 必须 signal_processed=False 让 Stage-2 取它"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apersist_writes_source_ai_disclosure_with_signal_processed_true():
+    """path B 调用方传 default_source='ai_disclosure' → 落盘 source 字段
+    一致，signal_processed=True（不进 Stage-2 evidence loop）。"""
+    from memory.facts import FactStore
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {'悠怡': []}
+    fs._locks = {}
+    import threading
+    fs._locks_guard = threading.Lock()
+    fs.asave_facts = AsyncMock(return_value=None)
+
+    extracted = [
+        {'text': '悠怡觉得自己挺喜欢秋天', 'importance': 6, 'entity': 'neko'},
+    ]
+    with patch.object(fs, 'aload_facts', AsyncMock(return_value=[])):
+        new_facts = await fs._apersist_new_facts(
+            '悠怡', extracted, default_source='ai_disclosure',
+        )
+
+    assert len(new_facts) == 1
+    assert new_facts[0]['source'] == 'ai_disclosure'
+    assert new_facts[0]['signal_processed'] is True, (
+        "ai_disclosure fact 必须写盘时 signal_processed=True 防卡 Stage-2 池"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apersist_llm_source_field_overrides_default():
+    """LLM 显式输出的 source 字段优先于 default_source（trust LLM 的
+    per-fact 判断）。"""
+    from memory.facts import FactStore
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {'悠怡': []}
+    fs._locks = {}
+    import threading
+    fs._locks_guard = threading.Lock()
+    fs.asave_facts = AsyncMock(return_value=None)
+
+    # LLM 输出 source='user_observation'，但 caller 传 default='ai_disclosure'
+    # 模拟 LLM 判断"虽然在 ai_aware pass 里，但这条 fact 实际靠 user msg
+    # 印证的"——这种情况 LLM 标 user_observation 应该被尊重
+    extracted = [
+        {'text': '博士喜欢咖啡', 'importance': 7, 'entity': 'master',
+         'source': 'user_observation'},
+    ]
+    with patch.object(fs, 'aload_facts', AsyncMock(return_value=[])):
+        new_facts = await fs._apersist_new_facts(
+            '悠怡', extracted, default_source='ai_disclosure',
+        )
+    assert new_facts[0]['source'] == 'user_observation'
+    # 又因为 source 是 user_observation，signal_processed 应该 False
+    assert new_facts[0]['signal_processed'] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apersist_monotonic_source_upgrade_ai_to_user():
+    """SHA-256 撞已有 ai_disclosure fact + 新 fact source=user_observation
+    → in-place 升级 existing.source + 重置 signal_processed=False。"""
+    from memory.facts import FactStore
+    import hashlib
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {'悠怡': []}
+    fs._locks = {}
+    import threading
+    fs._locks_guard = threading.Lock()
+
+    text = '博士喜欢三文鱼'
+    content_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
+    existing_fact = {
+        'id': 'fact_old', 'text': text, 'hash': content_hash,
+        'source': 'ai_disclosure', 'signal_processed': True,
+        'importance': 6, 'entity': 'master',
+    }
+    existing_facts_list = [existing_fact]
+
+    fs.asave_facts = AsyncMock(return_value=None)
+    extracted = [
+        {'text': text, 'importance': 8, 'entity': 'master',
+         'source': 'user_observation'},
+    ]
+    with patch.object(fs, 'aload_facts',
+                      AsyncMock(return_value=existing_facts_list)):
+        new_facts = await fs._apersist_new_facts(
+            '悠怡', extracted, default_source='user_observation',
+        )
+
+    # 不返新 fact（SHA-256 撞了 skip 写），但 in-place 升级了 existing
+    assert new_facts == []
+    assert existing_fact['source'] == 'user_observation', "user 印证后应升级"
+    assert existing_fact['signal_processed'] is False, (
+        "升级后必须重置 signal_processed=False 让 Stage-2 重新评估"
+    )
+    fs.asave_facts.assert_awaited_once_with('悠怡')
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apersist_no_downgrade_user_to_ai():
+    """反向：撞已有 user_observation fact + 新 fact source=ai_disclosure
+    → existing 不动（user 印证不可逆退回 ai_disclosure）。"""
+    from memory.facts import FactStore
+    import hashlib
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {'悠怡': []}
+    fs._locks = {}
+    import threading
+    fs._locks_guard = threading.Lock()
+
+    text = '博士喜欢三文鱼'
+    content_hash = hashlib.sha256(text.encode()).hexdigest()[:16]
+    existing_fact = {
+        'id': 'fact_old', 'text': text, 'hash': content_hash,
+        'source': 'user_observation', 'signal_processed': True,
+        'importance': 8, 'entity': 'master',
+    }
+    fs.asave_facts = AsyncMock(return_value=None)
+
+    extracted = [
+        {'text': text, 'importance': 6, 'entity': 'master',
+         'source': 'ai_disclosure'},
+    ]
+    with patch.object(fs, 'aload_facts',
+                      AsyncMock(return_value=[existing_fact])):
+        await fs._apersist_new_facts(
+            '悠怡', extracted, default_source='ai_disclosure',
+        )
+
+    # 不能降级
+    assert existing_fact['source'] == 'user_observation'
+    # signal_processed 也不该被乱动
+    assert existing_fact['signal_processed'] is True
+    # 没改任何东西 → 不该 save
+    fs.asave_facts.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stage2_filters_out_ai_disclosure_facts():
+    """Stage-2 unprocessed pool 必须 filter ``source='ai_disclosure'``。
+    双重防御（写盘 signal_processed=True 是第一层；这是第二层）。"""
+    from memory.facts import FactStore
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {}
+    fs._locks = {}
+    import threading
+    fs._locks_guard = threading.Lock()
+
+    # 模拟 facts.json 三条 fact：一条 user_observation 未处理（应入 Stage-2 池），
+    # 一条 ai_disclosure 未处理（**不该**入池，即使 signal_processed=False bug），
+    # 一条无 source 字段未处理（老数据，default user_observation 视图，应入池）
+    fake_facts = [
+        {'id': 'a', 'source': 'user_observation', 'signal_processed': False,
+         'importance': 8, 'created_at': '2026-05-18T10:00:00'},
+        {'id': 'b', 'source': 'ai_disclosure', 'signal_processed': False,
+         'importance': 7, 'created_at': '2026-05-18T10:00:01'},
+        {'id': 'c', 'signal_processed': False,  # 无 source 字段（老数据）
+         'importance': 6, 'created_at': '2026-05-18T10:00:02'},
+    ]
+
+    fs._allm_extract_facts = AsyncMock(return_value=[])  # 不产生新 fact
+    fs._apersist_new_facts = AsyncMock(return_value=[])
+    fs.aload_facts = AsyncMock(return_value=fake_facts)
+    fs._aload_signal_targets = AsyncMock(return_value=[
+        {'id': 'obs1', 'text': '观察', 'target_type': 'reflection'},
+    ])
+    fs._allm_detect_signals = AsyncMock(return_value=[])  # signals=[] but ran
+
+    # _allm_detect_signals 被调用时传的 batch 就是过 filter 后的 unprocessed
+    persisted, signals, batch_ids = await fs.aextract_facts_and_detect_signals(
+        '悠怡', messages=[],
+    )
+
+    # 验证 _allm_detect_signals 被调，且其 batch 参数里**没有** b（ai_disclosure）
+    fs._allm_detect_signals.assert_awaited_once()
+    actual_batch = fs._allm_detect_signals.await_args.args[1]
+    actual_ids = {f['id'] for f in actual_batch}
+    assert 'a' in actual_ids, "user_observation fact 必须入 Stage-2"
+    assert 'c' in actual_ids, "无 source 字段的老 fact 默认按 user_observation 入池"
+    assert 'b' not in actual_ids, (
+        "ai_disclosure fact 必须被 source filter 排除，"
+        "防止 path B 抽出的 AI 自我披露进 evidence loop 形成自我强化"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_cold_start_lookback_derived_from_constants():
+    """B cold start 时 last_b 推算 = last_a_msg_ts - N×IDLE_MIN，
+    不需要独立的 LOOKBACK_MINUTES config。"""
+    from app import memory_server
+    from config import (
+        EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+        EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES,
+    )
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    state = {'last_a_msg_ts': last_a_msg_ts}  # 没有 last_b_check_ts
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 验证 aretrieve_original_by_timeframe 被调，start_time 正好是
+    # last_a_msg_ts - N × IDLE_MINUTES（cold-start lookback 推算）
+    fake_time_manager.aretrieve_original_by_timeframe.assert_awaited_once()
+    call_kwargs = fake_time_manager.aretrieve_original_by_timeframe.await_args
+    start_time = call_kwargs.args[1]
+    end_time = call_kwargs.args[2]
+    expected_lookback = timedelta(
+        minutes=EVIDENCE_AI_AWARE_EVERY_N_A_TICKS * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
+    )
+    assert start_time == last_a_msg_ts - expected_lookback, (
+        f"cold start lookback 必须 = N×IDLE_MIN = {expected_lookback}, "
+        f"实际 start={start_time}, end={end_time}, last_a={last_a_msg_ts}"
+    )
+    assert end_time == last_a_msg_ts, (
+        "B 窗口下游边界必须是 last_a_msg_ts（A 实际处理过的最晚 msg），"
+        "不是 wall-clock now"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_skips_when_a_never_ran():
+    """A 还没成功处理过任何 batch（last_a_msg_ts is None）时 B 无源可看，
+    应直接返回不报错。"""
+    from app import memory_server
+
+    state = {}  # 完全空 state（cold launcher start）
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 无 last_a_msg_ts → B 不该读 SQL
+    fake_time_manager.aretrieve_original_by_timeframe.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_advances_cursor_to_last_a_msg_ts():
+    """B 成功跑完后，last_b_check_ts 必须推进到 last_a_msg_ts。
+    防 B 反复跑同一窗口（cursor 单调推进语义）。"""
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_a_msg_ts - timedelta(minutes=20),
+    }
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(minutes=5), 's', json.dumps({
+            'type': 'human', 'data': {'content': '测试消息'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    assert state['last_b_check_ts'] == last_a_msg_ts, (
+        f"B cursor 必须推到 last_a_msg_ts={last_a_msg_ts}，"
+        f"实际 last_b_check_ts={state['last_b_check_ts']}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_window_empty_still_advances_cursor():
+    """B 窗口内无 msg（A 处理过但都是 system msg 之类）时，cursor 也要推进。
+    否则下次 B trigger 又会扫同窗口（永远空跑）。"""
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_a_msg_ts - timedelta(minutes=20),
+    }
+
+    fake_time_manager = MagicMock()
+    # 窗口完全空
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager):
+        await memory_server._run_path_b('悠怡', state)
+
+    assert state['last_b_check_ts'] == last_a_msg_ts
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_filters_known_pool_by_window_and_caps():
+    """已知池：只取 created_at ∈ [last_b, last_a_msg_ts] 的 fact，
+    按 importance DESC，cap 到 MAX_KNOWN_POOL_FACTS。"""
+    from app import memory_server
+    from config import MAX_KNOWN_POOL_FACTS
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=20)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 构造 35 条窗口内 fact（间隔 30s 把全部塞进 20-min 窗口）+ 20 条窗口外
+    in_window_facts = [
+        {'id': f'in_{i}', 'text': f'fact in {i}',
+         'importance': i % 10 + 1,
+         'created_at': (last_b + timedelta(seconds=i * 30)).isoformat()}
+        for i in range(35)  # 35 条 in window > MAX_KNOWN_POOL_FACTS (30)
+    ]
+    out_window_facts = [
+        {'id': f'out_{i}', 'text': f'fact out {i}',
+         'importance': 10,  # 高 importance 但不在窗口
+         'created_at': (last_b - timedelta(hours=2 + i)).isoformat()}
+        for i in range(20)
+    ]
+    all_facts = in_window_facts + out_window_facts
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(minutes=3), 's', json.dumps({
+            'type': 'human', 'data': {'content': '测试'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=all_facts)
+    captured_known_pool = []
+
+    async def capture_extract(name, messages, known_pool):
+        captured_known_pool.extend(known_pool)
+        return []
+
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(
+        side_effect=capture_extract,
+    )
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 1. cap 生效（最多 MAX_KNOWN_POOL_FACTS = 30 条）
+    assert len(captured_known_pool) == MAX_KNOWN_POOL_FACTS
+
+    # 2. 全部来自窗口内（id 都是 in_*）
+    for f in captured_known_pool:
+        assert f['id'].startswith('in_'), (
+            f"out-of-window fact 不该入池，命中: {f['id']}"
+        )
+
+    # 3. 按 importance DESC（前几个 importance 最高）
+    importances = [f['importance'] for f in captured_known_pool]
+    assert importances == sorted(importances, reverse=True), (
+        f"已知池必须按 importance DESC 排，实际: {importances}"
+    )
+
+
+@pytest.mark.unit
+def test_b_tick_counter_threshold_constant_sane():
+    """N_A_TICKS 必须 >= 1（不能 0 否则每 A tick 都触发 B，退化成无 piggyback）。"""
+    from config import (
+        EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+        MAX_AI_AWARE_WINDOW_MSGS,
+        MAX_KNOWN_POOL_FACTS,
+    )
+    assert EVIDENCE_AI_AWARE_EVERY_N_A_TICKS >= 1
+    assert MAX_AI_AWARE_WINDOW_MSGS >= 10  # 极端值防呆
+    assert MAX_KNOWN_POOL_FACTS >= 1
+
+
+@pytest.mark.unit
+def test_signal_check_one_triggers_path_b_after_n_ticks():
+    """源码扫描：``_signal_check_one`` 必须在 A 成功跑完后 bump b_tick_counter
+    并在达 N 时调 ``_run_path_b``。"""
+    import inspect
+    from app import memory_server
+
+    src = inspect.getsource(memory_server._periodic_signal_extraction_loop)
+    assert 'b_tick_counter' in src, "signal loop 内必须维护 b_tick_counter"
+    assert 'EVIDENCE_AI_AWARE_EVERY_N_A_TICKS' in src, (
+        "signal loop 必须用 EVIDENCE_AI_AWARE_EVERY_N_A_TICKS 阈值判 B trigger"
+    )
+    assert '_run_path_b' in src, "signal loop 必须调 _run_path_b"
+    assert 'last_a_msg_ts' in src, (
+        "signal loop 必须记录 last_a_msg_ts 给 B 当窗口下游边界，"
+        "不能用 wall-clock now（race 风险）"
+    )

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -447,8 +447,10 @@ async def test_path_b_window_empty_still_advances_cursor():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_path_b_filters_known_pool_by_window_and_caps():
-    """已知池：只取 created_at ∈ [last_b, last_a_msg_ts] 的 fact，
-    按 importance DESC，cap 到 MAX_KNOWN_POOL_FACTS。"""
+    """已知池：只看 ``created_at >= last_b`` 下界（不设上界——见
+    `test_path_b_known_pool_includes_just_written_a_facts_despite_clock_skew`
+    的 clock-skew 契约），按 importance DESC，cap 到 MAX_KNOWN_POOL_FACTS。
+    """
     from app import memory_server
     from config import MAX_KNOWN_POOL_FACTS
 
@@ -915,6 +917,42 @@ async def test_path_b_truncated_but_diverse_ts_does_not_epsilon_bump():
         f"diverse ts 截断时 cursor 应 = last fetched ({expected_last_ts}) "
         f"无 epsilon bump，实际: {state['last_b_check_ts']}"
     )
+
+
+@pytest.mark.unit
+def test_post_turn_signals_bumps_counter_for_ai_only_turn():
+    """Regression (CodeRabbit P1 round-4 on PR #1408)：``_run_post_turn_signals``
+    必须无条件 bump ``_signal_check_record_turn``，不能再用 ``if user_msgs:`` gate
+    挡掉 AI-only turn——否则 turns_since 在纯 proactive / AI-only session 里
+    永远 0，``_signal_check_should_run`` 永远返 False，``_signal_check_one`` 不
+    跑 → AI-only 分支里那段 path B trigger 永久不可达（前一轮 round-3 fix
+    形同虚设）。
+    """
+    import inspect
+    from app import memory_server
+
+    src = inspect.getsource(memory_server._run_post_turn_signals)
+
+    # `_signal_check_record_turn` 调用必须存在
+    assert "_signal_check_record_turn" in src, (
+        "_run_post_turn_signals 必须 bump signal-check counter"
+    )
+
+    # 不能再被 `if user_msgs` 包裹（旧 bug）。扫源码截取 record_turn 调用
+    # 前面那段，禁出现 `if user_msgs` 紧贴它（允许全文件其他地方有
+    # user_msgs 条件，只要不 gate counter bump 即可）。
+    record_idx = src.find("_signal_check_record_turn(lanlan_name)")
+    assert record_idx > 0
+    # 往前看 4 行，检查没有 `if user_msgs:` 紧 gate 这次调用
+    preceding = src[max(0, record_idx - 200):record_idx]
+    # 把行拆开，找最近的非空 `if ...` 行
+    lines = [ln.strip() for ln in preceding.split("\n") if ln.strip()]
+    for ln in reversed(lines):
+        if ln.startswith("if "):
+            assert "user_msgs" not in ln, (
+                f"counter bump 不能再被 user_msgs gate 挡掉，紧上方 if: {ln!r}"
+            )
+            break
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -423,25 +423,39 @@ async def test_path_b_full_window_advances_cursor_to_last_fetched_eq_last_a_msg_
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_path_b_window_empty_still_advances_cursor():
-    """B 窗口内无 msg（A 处理过但都是 system msg 之类）时，cursor 也要推进。
-    否则下次 B trigger 又会扫同窗口（永远空跑）。"""
+async def test_path_b_empty_rows_preserves_cursor_for_retry():
+    """Regression (Codex P1 round-5 on PR #1408)：
+    `aretrieve_original_by_timeframe` 在 SQL exception / engine init 失败 /
+    维护态都 swallow + 返 []，从 caller 端无法区分"真空窗口"vs"transient
+    读失败"。如果在 rows 空时把 cursor 推到 last_a_msg_ts，整段 [last_b,
+    last_a_msg_ts] 会在 SQL transient 失败下被永久 skip → path B 静默丢
+    fact。保守做法：rows 空时 cursor 不推，下次 trigger 重试同窗口。
+
+    代价：真正的空窗口下次 B trigger 还会再 query 一次空（SQLite 空范围
+    scan 极快，常数代价）；A 推进 last_a_msg_ts 后窗口范围会增长但被
+    MAX_AI_AWARE_WINDOW_MSGS LIMIT 兜底。
+    """
     from app import memory_server
 
     last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    original_last_b = last_a_msg_ts - timedelta(minutes=20)
     state = {
         'last_a_msg_ts': last_a_msg_ts,
-        'last_b_check_ts': last_a_msg_ts - timedelta(minutes=20),
+        'last_b_check_ts': original_last_b,
     }
 
     fake_time_manager = MagicMock()
-    # 窗口完全空
+    # 模拟 SQL transient 失败（time_manager swallow 返 []，跟真空窗口同形态）
     fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[])
 
     with patch.object(memory_server, 'time_manager', fake_time_manager):
         await memory_server._run_path_b('悠怡', state)
 
-    assert state['last_b_check_ts'] == last_a_msg_ts
+    # 关键契约：cursor 必须保持原值，下次 B trigger 重试该窗口
+    assert state['last_b_check_ts'] == original_last_b, (
+        f"rows 空时 cursor 必须保留原值 {original_last_b} (transient SQL 失败保护)，"
+        f"实际推到 {state['last_b_check_ts']}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -321,11 +321,17 @@ async def test_stage2_filters_out_ai_disclosure_facts():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_path_b_cold_start_lookback_derived_from_constants():
-    """B cold start 时 last_b 推算 = last_a_msg_ts - N×IDLE_MIN，
-    不需要独立的 LOOKBACK_MINUTES config。"""
+    """B cold start 时 last_b 推算 = last_a_msg_ts - max(N_TICKS, N_TURNS)×IDLE_MIN，
+    不需要独立的 LOOKBACK_MINUTES config。
+    取 max 而不是单 N_TICKS 是为了 cover sparse turn 场景下 A 两 tick 跨度
+    >> IDLE_MIN 的情况——若只看 N_TICKS×IDLE_MIN，cold start last_b 会落在
+    A 真正处理过的范围之内，B 永久 skip 那段前的 AI-only msg（Codex P2
+    round-6 on PR #1408）。
+    """
     from app import memory_server
     from config import (
         EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+        EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
         EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES,
     )
 
@@ -343,21 +349,79 @@ async def test_path_b_cold_start_lookback_derived_from_constants():
         await memory_server._run_path_b('悠怡', state)
 
     # 验证 aretrieve_original_by_timeframe 被调，start_time 正好是
-    # last_a_msg_ts - N × IDLE_MINUTES（cold-start lookback 推算）
+    # last_a_msg_ts - max(N_TICKS, N_TURNS) × IDLE_MIN（cold-start lookback）
     fake_time_manager.aretrieve_original_by_timeframe.assert_awaited_once()
     call_kwargs = fake_time_manager.aretrieve_original_by_timeframe.await_args
     start_time = call_kwargs.args[1]
     end_time = call_kwargs.args[2]
+    expected_n = max(
+        EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+        EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
+    )
     expected_lookback = timedelta(
-        minutes=EVIDENCE_AI_AWARE_EVERY_N_A_TICKS * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
+        minutes=expected_n * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
     )
     assert start_time == last_a_msg_ts - expected_lookback, (
-        f"cold start lookback 必须 = N×IDLE_MIN = {expected_lookback}, "
-        f"实际 start={start_time}, end={end_time}, last_a={last_a_msg_ts}"
+        f"cold start lookback 必须 = max(N_TICKS, N_TURNS)×IDLE_MIN = "
+        f"{expected_lookback}, 实际 start={start_time}, end={end_time}, "
+        f"last_a={last_a_msg_ts}"
     )
     assert end_time == last_a_msg_ts, (
         "B 窗口下游边界必须是 last_a_msg_ts（A 实际处理过的最晚 msg），"
         "不是 wall-clock now"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_cold_start_uses_max_of_ticks_and_turns():
+    """Regression (Codex P2 round-6 on PR #1408)：cold-start lookback 必须
+    取 max(N_TICKS, N_TURNS) × IDLE_MIN，而不能只用 N_TICKS。否则在 sparse
+    turn 场景（turn-count gate 触发的 A tick 跨度 >> piggyback 估算）下，
+    cold start last_b 落在 A 真正处理范围之内 → B 永久 skip 那段前的
+    AI-only msg。
+
+    用 N_TURNS 远大于 N_TICKS（默认 10 vs 3）来锁死这个语义：若实现只用
+    N_TICKS，本测试会失败。
+    """
+    from app import memory_server
+    from config import (
+        EVIDENCE_AI_AWARE_EVERY_N_A_TICKS,
+        EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS,
+        EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES,
+    )
+
+    # 仅在默认配置 N_TURNS > N_TICKS 时此 regression 才有意义
+    assert EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS > EVIDENCE_AI_AWARE_EVERY_N_A_TICKS, (
+        "本 test 依赖默认 N_TURNS > N_TICKS，否则 max 两者退化、测不出区别"
+    )
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    state = {'last_a_msg_ts': last_a_msg_ts}
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager):
+        await memory_server._run_path_b('悠怡', state)
+
+    start_time = fake_time_manager.aretrieve_original_by_timeframe.await_args.args[1]
+    # 关键：实际用的 lookback 必须 >= N_TURNS × IDLE_MIN（严格 > N_TICKS × IDLE_MIN）
+    n_turns_lookback = timedelta(
+        minutes=EVIDENCE_SIGNAL_CHECK_EVERY_N_TURNS * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
+    )
+    n_ticks_lookback = timedelta(
+        minutes=EVIDENCE_AI_AWARE_EVERY_N_A_TICKS * EVIDENCE_SIGNAL_CHECK_IDLE_MINUTES
+    )
+    actual_lookback = last_a_msg_ts - start_time
+    assert actual_lookback >= n_turns_lookback, (
+        f"cold-start lookback ({actual_lookback}) 必须 >= N_TURNS×IDLE_MIN "
+        f"({n_turns_lookback}) 才能 cover sparse turn 场景"
+    )
+    assert actual_lookback > n_ticks_lookback, (
+        f"cold-start lookback ({actual_lookback}) 必须严格 > N_TICKS×IDLE_MIN "
+        f"({n_ticks_lookback})——否则等于只看了 piggyback 估算，sparse "
+        f"turn 场景下 A 真处理范围更老的 AI-only msg 会永久 skip"
     )
 
 

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -860,41 +860,35 @@ async def test_path_b_known_pool_includes_just_written_a_facts_despite_clock_ske
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_path_b_triggered_for_ai_only_window_no_user_msgs():
-    """Regression (Codex P1 round-3 on PR #1408)：proactive / AI-only 触发的
-    窗口没有 human msg 时，path A 的 `_extract_user_messages_from_rows` 返
-    空 → 早 return + mark_done。但 path B 的存在意义就是补抓 AI 自我披露，
-    必须在 user_msgs 为空的早 return 路径里也 bump b_tick_counter 并在达
-    N 时跑 _run_path_b——否则 AI-only session 永远进不了 B，等于把 B 的
-    主要使命阉了。
+async def test_path_b_skipped_for_ai_only_window_no_user_msgs():
+    """Design pin：纯 proactive / AI-only 窗口（没 human msg）**故意**不
+    触发 path B。Path B 是 piggyback path A 的 trigger 跑（不独立调度），
+    user 没参与的窗口里 A 不抽 user_observation，B 也跟着不拣 AI 自我披露。
+
+    Product thesis："90% 没心没肺 + 10% 神明降临"——AI 自言自语 + user
+    不搭理的内容是廉价层，不该自动当 fact 沉淀污染 memory。
+
+    源码扫描钉死：``if not user_msgs_text:`` 分支只 mark_done + return，
+    禁止在该分支调 _run_path_b / bump b_tick_counter。
     """
     import inspect
     from app import memory_server
 
-    # 用源码扫描代替 mock 整套 _signal_check_one（依赖太多）：确认 user_msgs
-    # 检查之前已经记 last_a_msg_ts，user_msgs 空分支里有 b_tick_counter
-    # bump + _run_path_b trigger。
     src = inspect.getsource(memory_server._periodic_signal_extraction_loop)
 
-    # 1. last_a_msg_ts 在 user_msgs 检查之前更新（state 共享给 AI-only 分支）
     user_check_idx = src.find("if not user_msgs_text:")
-    last_a_set_idx = src.find("state['last_a_msg_ts']")
-    assert 0 < last_a_set_idx < user_check_idx, (
-        "last_a_msg_ts 必须在 `if not user_msgs_text:` 之前更新，"
-        "否则 AI-only 窗口的 B trigger 拿不到正确的下游边界"
-    )
+    assert user_check_idx > 0
+    # 截到下一个 return（该早 return 分支的边界）
+    branch_end = src.find("return", user_check_idx)
+    branch_src = src[user_check_idx:branch_end + len("return")]
 
-    # 2. user_msgs_text 为空的分支里必须能触发 path B
-    # 截取 `if not user_msgs_text:` 到下一个 return 之间的块
-    branch_start = user_check_idx
-    branch_end = src.find("return", branch_start)
-    branch_src = src[branch_start:branch_end + len("return")]
-    assert "b_tick_counter" in branch_src, (
-        "AI-only 早 return 路径里必须 bump b_tick_counter，"
-        "否则 B 在 AI-only session 里永远不 trigger"
+    assert "_run_path_b" not in branch_src, (
+        "AI-only 早 return 路径里**禁止**调 _run_path_b——product thesis "
+        "明确这是廉价层，不该触发 fact 抽取"
     )
-    assert "_run_path_b" in branch_src, (
-        "AI-only 早 return 路径里必须能 await _run_path_b 拣回 AI 自我披露"
+    assert "b_tick_counter" not in branch_src, (
+        "AI-only 早 return 路径里**禁止** bump b_tick_counter——counter "
+        "只应在 user 有 engagement 时累积"
     )
 
 
@@ -998,39 +992,36 @@ async def test_path_b_truncated_but_diverse_ts_does_not_epsilon_bump():
 
 
 @pytest.mark.unit
-def test_post_turn_signals_bumps_counter_for_ai_only_turn():
-    """Regression (CodeRabbit P1 round-4 on PR #1408)：``_run_post_turn_signals``
-    必须无条件 bump ``_signal_check_record_turn``，不能再用 ``if user_msgs:`` gate
-    挡掉 AI-only turn——否则 turns_since 在纯 proactive / AI-only session 里
-    永远 0，``_signal_check_should_run`` 永远返 False，``_signal_check_one`` 不
-    跑 → AI-only 分支里那段 path B trigger 永久不可达（前一轮 round-3 fix
-    形同虚设）。
+def test_post_turn_signals_only_bumps_counter_for_user_turn():
+    """Design pin：``_signal_check_record_turn`` 只在 user 发声时 bump，
+    AI-only / proactive turn 故意不算——counter 是 user engagement 信号，
+    不是消息总数。Product thesis："90% 没心没肺 + 10% 神明降临"，没有
+    user 印证的内容是廉价层，不该触发 fact 抽取 batch。
+
+    源码扫描钉死：``_signal_check_record_turn`` 调用必须被 ``if user_msgs:``
+    gate 包裹。
     """
     import inspect
     from app import memory_server
 
     src = inspect.getsource(memory_server._run_post_turn_signals)
 
-    # `_signal_check_record_turn` 调用必须存在
-    assert "_signal_check_record_turn" in src, (
-        "_run_post_turn_signals 必须 bump signal-check counter"
-    )
-
-    # 不能再被 `if user_msgs` 包裹（旧 bug）。扫源码截取 record_turn 调用
-    # 前面那段，禁出现 `if user_msgs` 紧贴它（允许全文件其他地方有
-    # user_msgs 条件，只要不 gate counter bump 即可）。
     record_idx = src.find("_signal_check_record_turn(lanlan_name)")
-    assert record_idx > 0
-    # 往前看 4 行，检查没有 `if user_msgs:` 紧 gate 这次调用
+    assert record_idx > 0, "_signal_check_record_turn 调用必须存在"
+
+    # 往前找最近的非空 `if ...` 行：必须是 `if user_msgs:`
     preceding = src[max(0, record_idx - 200):record_idx]
-    # 把行拆开，找最近的非空 `if ...` 行
     lines = [ln.strip() for ln in preceding.split("\n") if ln.strip()]
+    last_if = None
     for ln in reversed(lines):
         if ln.startswith("if "):
-            assert "user_msgs" not in ln, (
-                f"counter bump 不能再被 user_msgs gate 挡掉，紧上方 if: {ln!r}"
-            )
+            last_if = ln
             break
+    assert last_if is not None, "counter bump 紧上方必须有 if 条件"
+    assert "user_msgs" in last_if, (
+        f"counter bump 必须被 `if user_msgs:` gate——只算 user engagement，"
+        f"不算 AI-only turn。当前 if: {last_if!r}"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -779,6 +779,145 @@ async def test_path_b_known_pool_includes_just_written_a_facts_despite_clock_ske
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_triggered_for_ai_only_window_no_user_msgs():
+    """Regression (Codex P1 round-3 on PR #1408)：proactive / AI-only 触发的
+    窗口没有 human msg 时，path A 的 `_extract_user_messages_from_rows` 返
+    空 → 早 return + mark_done。但 path B 的存在意义就是补抓 AI 自我披露，
+    必须在 user_msgs 为空的早 return 路径里也 bump b_tick_counter 并在达
+    N 时跑 _run_path_b——否则 AI-only session 永远进不了 B，等于把 B 的
+    主要使命阉了。
+    """
+    import inspect
+    from app import memory_server
+
+    # 用源码扫描代替 mock 整套 _signal_check_one（依赖太多）：确认 user_msgs
+    # 检查之前已经记 last_a_msg_ts，user_msgs 空分支里有 b_tick_counter
+    # bump + _run_path_b trigger。
+    src = inspect.getsource(memory_server._periodic_signal_extraction_loop)
+
+    # 1. last_a_msg_ts 在 user_msgs 检查之前更新（state 共享给 AI-only 分支）
+    user_check_idx = src.find("if not user_msgs_text:")
+    last_a_set_idx = src.find("state['last_a_msg_ts']")
+    assert 0 < last_a_set_idx < user_check_idx, (
+        "last_a_msg_ts 必须在 `if not user_msgs_text:` 之前更新，"
+        "否则 AI-only 窗口的 B trigger 拿不到正确的下游边界"
+    )
+
+    # 2. user_msgs_text 为空的分支里必须能触发 path B
+    # 截取 `if not user_msgs_text:` 到下一个 return 之间的块
+    branch_start = user_check_idx
+    branch_end = src.find("return", branch_start)
+    branch_src = src[branch_start:branch_end + len("return")]
+    assert "b_tick_counter" in branch_src, (
+        "AI-only 早 return 路径里必须 bump b_tick_counter，"
+        "否则 B 在 AI-only session 里永远不 trigger"
+    )
+    assert "_run_path_b" in branch_src, (
+        "AI-only 早 return 路径里必须能 await _run_path_b 拣回 AI 自我披露"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_same_ts_cluster_overflow_advances_cursor_by_epsilon():
+    """Regression (Codex P2 round-3 on PR #1408)：
+    aretrieve_original_by_timeframe 用 inclusive BETWEEN，若窗口里
+    >= MAX_AI_AWARE_WINDOW_MSGS 行全在同一 ts（store_conversation 给一次
+    请求所有 row 同 ts，bulk import 等），cursor 推到 last_fetched_ts 后
+    下次 BETWEEN 仍把这批 row 全捞回来 → 无限循环。
+    检测：LIMIT 拉满 AND 所有 fetched row 同 ts → cursor +1μs 越过该 ts。
+    """
+    from app import memory_server
+    from config import MAX_AI_AWARE_WINDOW_MSGS
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=20)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 构造 MAX_AI_AWARE_WINDOW_MSGS 行全在同一 ts T（远早于 last_a_msg_ts，
+    # 模拟 bulk import / 同 batch 写入）
+    cluster_ts = last_b + timedelta(minutes=2)
+    same_ts_rows = [
+        (cluster_ts, f'sess_{i}', json.dumps({
+            'type': 'human', 'data': {'content': f'msg {i}'},
+        }))
+        for i in range(MAX_AI_AWARE_WINDOW_MSGS)
+    ]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(
+        return_value=same_ts_rows,
+    )
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 关键断言：cursor 严格 > cluster_ts，下次 BETWEEN 不会再捞同 ts 簇
+    assert state['last_b_check_ts'] > cluster_ts, (
+        f"同 ts 簇 LIMIT 截断时 cursor 必须 +1μs 越过该 ts ({cluster_ts})，"
+        f"否则下次 BETWEEN inclusive 再捞同批 → 死循环。"
+        f"实际 cursor: {state['last_b_check_ts']}"
+    )
+    # 且只越过 1 微秒（不滥推到 last_a_msg_ts，否则中间正常的 ts 也被 skip）
+    assert state['last_b_check_ts'] == cluster_ts + timedelta(microseconds=1), (
+        f"epsilon 必须刚好 +1μs，实际推到 {state['last_b_check_ts']}"
+    )
+    assert state['last_b_check_ts'] < last_a_msg_ts, (
+        "epsilon bump 仍应远小于 last_a_msg_ts，让中间窗口正常被下次 B 处理"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_truncated_but_diverse_ts_does_not_epsilon_bump():
+    """对偶 test：LIMIT 拉满但 rows 跨多个 ts 时，cursor 推到 last fetched 即可
+    （不该 +1μs 越过——否则会 skip 掉刚好在 last_fetched_ts 的 tail row）。
+    """
+    from app import memory_server
+    from config import MAX_AI_AWARE_WINDOW_MSGS
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=30)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # MAX_AI_AWARE_WINDOW_MSGS 行，ts 均匀分布（不同 ts，模拟正常截断）
+    rows = [
+        (last_b + timedelta(seconds=i), f'sess_{i}', json.dumps({
+            'type': 'human', 'data': {'content': f'msg {i}'},
+        }))
+        for i in range(MAX_AI_AWARE_WINDOW_MSGS)
+    ]
+    expected_last_ts = rows[-1][0]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=rows)
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 不该 epsilon bump——cursor 必须恰好 = last fetched ts
+    assert state['last_b_check_ts'] == expected_last_ts, (
+        f"diverse ts 截断时 cursor 应 = last fetched ({expected_last_ts}) "
+        f"无 epsilon bump，实际: {state['last_b_check_ts']}"
+    )
+
+
+@pytest.mark.unit
 def test_b_tick_counter_threshold_constant_sane():
     """N_A_TICKS 必须 >= 1（不能 0 否则每 A tick 都触发 B，退化成无 piggyback）。"""
     from config import (

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -413,6 +413,56 @@ async def test_apersist_monotonic_source_upgrade_ai_to_user():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_apersist_monotonic_source_upgrade_within_same_batch():
+    """Regression (Codex P2 round-10 on PR #1408)：同一次 Stage-1 extracted
+    payload 里若同 text 出现两次（先 ai_disclosure 后 user_observation），
+    `hash_to_existing` 必须在第一次写入后同步更新——否则第二次命中
+    `content_hash in existing_hashes` 时 `hash_to_existing.get()` 返 None，
+    monotonic upgrade 路径被跳过，user_observation 升级被静默丢弃。
+    """
+    from memory.facts import FactStore
+
+    fs = FactStore.__new__(FactStore)
+    fs._config_manager = MagicMock()
+    fs._time_indexed = None
+    fs._facts = {'悠怡': []}
+    fs._locks = {}
+    import threading
+    fs._locks['悠怡'] = threading.RLock()
+    fs.asave_facts = AsyncMock()
+
+    # 模拟单次 Stage-1 payload 包含同 text 两条：先 ai_disclosure 后 user_observation
+    extracted = [
+        {
+            'text': '主人喜欢猫', 'importance': 7, 'entity': 'master',
+            'source': 'ai_disclosure',
+        },
+        {
+            'text': '主人喜欢猫', 'importance': 7, 'entity': 'master',
+            'source': 'user_observation',
+        },
+    ]
+
+    out = await fs._apersist_new_facts(
+        '悠怡', extracted, default_source='ai_disclosure',
+    )
+
+    # 落盘只有 1 条（dedup 生效），且 source 升级到 user_observation
+    persisted = fs._facts['悠怡']
+    assert len(persisted) == 1, (
+        f"同 text 两条应 dedup 成 1 条，实际 {len(persisted)} 条"
+    )
+    assert persisted[0]['source'] == 'user_observation', (
+        f"第二次 user_observation 必须升级第一次的 ai_disclosure，"
+        f"实际 source={persisted[0]['source']!r}（说明 hash_to_existing 没在 batch 内同步）"
+    )
+    assert persisted[0]['signal_processed'] is False, (
+        "升级后 signal_processed 必须 reset 成 False 让 Stage-2 重新评估"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_apersist_no_downgrade_user_to_ai():
     """反向：撞已有 user_observation fact + 新 fact source=ai_disclosure
     → existing 不动（user 印证不可逆退回 ai_disclosure）。"""

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -301,8 +301,9 @@ async def test_stage2_filters_out_ai_disclosure_facts():
     ])
     fs._allm_detect_signals = AsyncMock(return_value=[])  # signals=[] but ran
 
-    # _allm_detect_signals 被调用时传的 batch 就是过 filter 后的 unprocessed
-    persisted, signals, batch_ids = await fs.aextract_facts_and_detect_signals(
+    # _allm_detect_signals 被调用时传的 batch 就是过 filter 后的 unprocessed。
+    # 三元 return 故意全用 _ 前缀——测试关心的是 mock call 参数，不是返回值。
+    _persisted, _signals, _batch_ids = await fs.aextract_facts_and_detect_signals(
         '悠怡', messages=[],
     )
 
@@ -381,9 +382,13 @@ async def test_path_b_skips_when_a_never_ran():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_path_b_advances_cursor_to_last_a_msg_ts():
-    """B 成功跑完后，last_b_check_ts 必须推进到 last_a_msg_ts。
-    防 B 反复跑同一窗口（cursor 单调推进语义）。"""
+async def test_path_b_full_window_advances_cursor_to_last_fetched_eq_last_a_msg_ts():
+    """无截断（rows 全部覆盖到 last_a_msg_ts）时 cursor = last fetched 恰好 =
+    last_a_msg_ts。语义上等价"推到 A 处理过的最晚点"。
+
+    （跟 test_path_b_truncated_window_... 形成对偶：那条覆盖截断情况，
+    cursor 推到 last fetched < last_a_msg_ts；这条覆盖无截断情况。）
+    """
     from app import memory_server
 
     last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
@@ -393,9 +398,13 @@ async def test_path_b_advances_cursor_to_last_a_msg_ts():
     }
 
     fake_time_manager = MagicMock()
+    # 最后一行 ts 就是 last_a_msg_ts（无截断的正常情况）
     fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
         (last_a_msg_ts - timedelta(minutes=5), 's', json.dumps({
-            'type': 'human', 'data': {'content': '测试消息'},
+            'type': 'human', 'data': {'content': '中间消息'},
+        })),
+        (last_a_msg_ts, 's', json.dumps({
+            'type': 'ai', 'data': {'content': '最后消息恰是 A 边界'},
         })),
     ])
     fake_fact_store = MagicMock()
@@ -406,8 +415,9 @@ async def test_path_b_advances_cursor_to_last_a_msg_ts():
          patch.object(memory_server, 'fact_store', fake_fact_store):
         await memory_server._run_path_b('悠怡', state)
 
+    # 无截断时 last fetched == last_a_msg_ts，cursor 推到此值
     assert state['last_b_check_ts'] == last_a_msg_ts, (
-        f"B cursor 必须推到 last_a_msg_ts={last_a_msg_ts}，"
+        f"无截断时 cursor (= last fetched) 应等于 last_a_msg_ts={last_a_msg_ts}，"
         f"实际 last_b_check_ts={state['last_b_check_ts']}"
     )
 
@@ -501,6 +511,106 @@ async def test_path_b_filters_known_pool_by_window_and_caps():
     assert importances == sorted(importances, reverse=True), (
         f"已知池必须按 importance DESC 排，实际: {importances}"
     )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_truncated_window_advances_cursor_to_last_fetched_row():
+    """Regression (Codex P1 PR #1408)：当窗口里消息数 > MAX_AI_AWARE_WINDOW_MSGS
+    时 SQL LIMIT 只取最早 N 行，cursor 必须推到**实际取到的最后一行 ts**，
+    不是 window 原本的 last_a_msg_ts。否则未取到的尾巴永久 skip → path B
+    对那段 burst 静默失明。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=30)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 模拟 SQL 返回截断的 rows：只到 last_a_msg_ts - 10 min（实际窗口是
+    # 30 min，但 LIMIT 把 ts 最早的部分截到 10 min 处就停了）
+    truncation_boundary = last_a_msg_ts - timedelta(minutes=10)
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_b + timedelta(seconds=10), 's', json.dumps({
+            'type': 'human', 'data': {'content': '早消息'},
+        })),
+        (truncation_boundary, 's', json.dumps({
+            'type': 'ai', 'data': {'content': '截断边界'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    assert state['last_b_check_ts'] == truncation_boundary, (
+        f"cursor 必须推到 last fetched row ts ({truncation_boundary}), "
+        f"不是 last_a_msg_ts ({last_a_msg_ts}). 实际: {state['last_b_check_ts']}"
+    )
+    # 关键：下次 B trigger 必须能从这里继续 = 还没追上 last_a_msg_ts
+    assert state['last_b_check_ts'] < last_a_msg_ts, (
+        "truncated 窗口 + 未取尾巴 → cursor 不该追上 A，下次 B 继续处理"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_known_pool_sort_tolerates_malformed_importance():
+    """Regression (Codex P2 PR #1408)：legacy / 手改 facts.json 里
+    'importance': "high" / None / list 等脏值不该让整个 path B sort 挂
+    （raw int(...) cast → ValueError → path B 对该角色永久哑火）。
+    用 safe_importance 兜底。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=20)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 构造一批脏 importance（每种异常类型混入）
+    dirty_facts = [
+        {'id': 'normal', 'text': 't', 'importance': 8,
+         'created_at': (last_b + timedelta(minutes=1)).isoformat()},
+        {'id': 'str_high', 'text': 't', 'importance': "high",  # ❌ ValueError
+         'created_at': (last_b + timedelta(minutes=2)).isoformat()},
+        {'id': 'none_imp', 'text': 't', 'importance': None,
+         'created_at': (last_b + timedelta(minutes=3)).isoformat()},
+        {'id': 'list_imp', 'text': 't', 'importance': [1, 2, 3],  # ❌ TypeError
+         'created_at': (last_b + timedelta(minutes=4)).isoformat()},
+        {'id': 'missing_imp', 'text': 't',  # 字段缺失
+         'created_at': (last_b + timedelta(minutes=5)).isoformat()},
+    ]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(minutes=1), 's', json.dumps({
+            'type': 'human', 'data': {'content': '测试'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=dirty_facts)
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        # 不该抛 ValueError / TypeError
+        await memory_server._run_path_b('悠怡', state)
+
+    # 验证 aextract_facts_with_known_pool 被调（说明 sort 没挂）
+    fake_fact_store.aextract_facts_with_known_pool.assert_awaited_once()
+    captured_known_pool = fake_fact_store.aextract_facts_with_known_pool.await_args.args[2]
+    # 5 条脏 fact 全在窗口内，都应该进 pool（脏值不丢，只是排序 fallback）
+    assert len(captured_known_pool) == 5
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1022,6 +1022,65 @@ async def test_path_b_known_pool_preserves_microsecond_precision_at_boundary():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_path_b_known_pool_normalizes_tz_aware_created_at():
+    """Regression (Codex P1 round-7 on PR #1408)：facts.json 里若被 import/
+    migration 写入了 TZ-aware `created_at`（如 "...+00:00"），跟 naive 的
+    last_b 比较会抛 TypeError 让 _run_path_b 永久 fail → path B 对该角色
+    哑火。`_run_path_b` 必须把 aware 转 naive 再比较。
+    """
+    from app import memory_server
+    from datetime import timezone
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=10)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 三条 TZ-aware fact，在窗口内（utcnow 视角）。若实现不 normalize，
+    # `>= last_b` 立即抛 TypeError。
+    tz_aware_facts = [
+        {
+            'id': f'imported_{i}',
+            'text': f'TZ-aware imported fact {i}',
+            'importance': 7,
+            'created_at': (
+                (last_b + timedelta(minutes=1 + i))
+                .replace(tzinfo=timezone.utc)
+                .isoformat()
+            ),
+        }
+        for i in range(3)
+    ]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(seconds=1), 's', json.dumps({
+            'type': 'human', 'data': {'content': '占位 user msg'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=tz_aware_facts)
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        # 不该抛 TypeError
+        await memory_server._run_path_b('悠怡', state)
+
+    # Stage-1 被调（说明 created_at 比较没炸）
+    fake_fact_store.aextract_facts_with_known_pool.assert_awaited_once()
+    captured_pool = fake_fact_store.aextract_facts_with_known_pool.await_args.args[2]
+    pool_ids = {f['id'] for f in captured_pool}
+    # 3 条 TZ-aware fact（wall-clock 视角在窗口内）都应该进 pool
+    assert len(pool_ids) == 3, (
+        f"TZ-aware fact 应该 normalize 后入 pool，实际 {len(pool_ids)}: {pool_ids}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_path_b_known_pool_includes_just_written_a_facts_despite_clock_skew():
     """Regression (CodeRabbit on PR #1408)：A 的 idle/polling 延迟让"刚扫
     完本 B 窗口"那批 A facts 的 created_at 普遍略晚于 last_a_msg_ts。known

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -86,6 +86,194 @@ def test_extract_role_tagged_messages_skips_empty_content():
 
 
 @pytest.mark.unit
+def test_trim_to_user_msg_bracket_strips_leading_and_trailing_ai():
+    """Product thesis pin：path B 喂给 Stage-1 的消息必须先 trim 到
+    首条 user msg → 末条 user msg 之间（含两端）。首尾的 AI 残段是
+    "user 没印证 / 没回应过的廉价层"，不该入 fact。
+    """
+    from app.memory_server import _trim_to_user_msg_bracket
+
+    # 典型 case：[ai, ai, human, ai, human, ai] → 留 [human, ai, human]
+    msgs = [
+        {'type': 'ai', 'data': {'content': 'AI proactive 试探'}},
+        {'type': 'ai', 'data': {'content': '还是 AI'}},
+        {'type': 'human', 'data': {'content': 'user 终于发声'}},
+        {'type': 'ai', 'data': {'content': 'AI 中间回应'}},
+        {'type': 'human', 'data': {'content': 'user 再发声'}},
+        {'type': 'ai', 'data': {'content': 'AI 末尾独白 (user 没回应)'}},
+    ]
+    out = _trim_to_user_msg_bracket(msgs)
+    assert len(out) == 3
+    assert out[0]['data']['content'] == 'user 终于发声'
+    assert out[1]['data']['content'] == 'AI 中间回应'
+    assert out[2]['data']['content'] == 'user 再发声'
+
+
+@pytest.mark.unit
+def test_trim_to_user_msg_bracket_all_ai_returns_empty():
+    """纯 AI-only 窗口（无 human msg）→ 完全 trim 空。
+    Caller 视作廉价层 skip。"""
+    from app.memory_server import _trim_to_user_msg_bracket
+
+    msgs = [
+        {'type': 'ai', 'data': {'content': '独白 1'}},
+        {'type': 'ai', 'data': {'content': '独白 2'}},
+    ]
+    assert _trim_to_user_msg_bracket(msgs) == []
+
+
+@pytest.mark.unit
+def test_trim_to_user_msg_bracket_single_human_returns_self():
+    """只有一条 human msg → bracket 退化为单点。仍然合法（user 有发声）。"""
+    from app.memory_server import _trim_to_user_msg_bracket
+
+    msgs = [
+        {'type': 'ai', 'data': {'content': '前置 AI'}},
+        {'type': 'human', 'data': {'content': '唯一 user msg'}},
+        {'type': 'ai', 'data': {'content': '后置 AI'}},
+    ]
+    out = _trim_to_user_msg_bracket(msgs)
+    assert len(out) == 1
+    assert out[0]['type'] == 'human'
+    assert out[0]['data']['content'] == '唯一 user msg'
+
+
+@pytest.mark.unit
+def test_trim_to_user_msg_bracket_already_user_to_user_unchanged():
+    """首尾本就是 human msg → 不变。"""
+    from app.memory_server import _trim_to_user_msg_bracket
+
+    msgs = [
+        {'type': 'human', 'data': {'content': 'u1'}},
+        {'type': 'ai', 'data': {'content': 'a1'}},
+        {'type': 'human', 'data': {'content': 'u2'}},
+    ]
+    out = _trim_to_user_msg_bracket(msgs)
+    assert out == msgs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_trims_to_user_bracket_before_stage1():
+    """End-to-end pin：_run_path_b 喂给 aextract_facts_with_known_pool
+    的 messages 必须已经被 user-msg-bracket trim 过。
+
+    构造窗口：前 2 条 AI + 中间 [user, ai, user] + 后 2 条 AI。
+    断言 Stage-1 收到的 messages 只有中间 3 条。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=10)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    base = last_b + timedelta(seconds=10)
+    rows = [
+        (base + timedelta(seconds=0), 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'AI 试探 1 (user 未印证)'},
+        })),
+        (base + timedelta(seconds=10), 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'AI 试探 2 (user 未印证)'},
+        })),
+        (base + timedelta(seconds=20), 's', json.dumps({
+            'type': 'human', 'data': {'content': 'user 第一句'},
+        })),
+        (base + timedelta(seconds=30), 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'AI 中间回应 (有 user 包夹)'},
+        })),
+        (base + timedelta(seconds=40), 's', json.dumps({
+            'type': 'human', 'data': {'content': 'user 最后一句'},
+        })),
+        (base + timedelta(seconds=50), 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'AI 末尾独白 (user 未回应)'},
+        })),
+        (base + timedelta(seconds=60), 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'AI 又一条独白'},
+        })),
+    ]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=rows)
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 验证 Stage-1 被调，且 messages 只含 bracket 内 3 条
+    fake_fact_store.aextract_facts_with_known_pool.assert_awaited_once()
+    sent_messages = fake_fact_store.aextract_facts_with_known_pool.await_args.args[1]
+    assert len(sent_messages) == 3, (
+        f"bracket trim 后应剩 3 条 (user, ai, user)，"
+        f"实际 {len(sent_messages)}: {[type(m).__name__ for m in sent_messages]}"
+    )
+    contents = [
+        m.content if hasattr(m, 'content') else m.get('data', {}).get('content', '')
+        for m in sent_messages
+    ]
+    # 首尾必须是 user msg
+    assert 'user 第一句' in contents[0]
+    assert 'user 最后一句' in contents[2]
+    # 首尾 AI 残段必须被剥掉
+    full_text = '\n'.join(contents)
+    assert 'AI 试探' not in full_text, (
+        f"首部 AI 试探不该入 Stage-1（user 未印证），实际 content: {full_text!r}"
+    )
+    assert 'AI 末尾独白' not in full_text and 'AI 又一条独白' not in full_text, (
+        f"尾部 AI 独白不该入 Stage-1（user 未回应），实际 content: {full_text!r}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_no_user_msg_in_window_skips_extraction():
+    """End-to-end pin：窗口里完全无 user msg → bracket trim 后为空 →
+    path B 不调 Stage-1（廉价层 skip），cursor 仍照常推进避免反复扫同窗口。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=10)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    rows = [
+        (last_b + timedelta(seconds=10), 's', json.dumps({
+            'type': 'ai', 'data': {'content': '纯 AI 独白 1'},
+        })),
+        (last_b + timedelta(seconds=20), 's', json.dumps({
+            'type': 'ai', 'data': {'content': '纯 AI 独白 2'},
+        })),
+    ]
+    last_row_ts = rows[-1][0]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=rows)
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # Stage-1 不该被调
+    fake_fact_store.aextract_facts_with_known_pool.assert_not_awaited()
+    # cursor 推到 last fetched row ts（避免下次反复扫同窗口）
+    assert state['last_b_check_ts'] == last_row_ts, (
+        f"AI-only 窗口跳过后 cursor 应推到 last fetched ({last_row_ts})，"
+        f"实际 {state['last_b_check_ts']}"
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_apersist_writes_source_field_default_user_observation():
     """path A 调用方不传 default_source → 落盘 source='user_observation'，

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -1021,6 +1021,88 @@ async def test_path_b_known_pool_preserves_microsecond_precision_at_boundary():
 
 
 @pytest.mark.unit
+def test_coerce_db_ts_strips_tz_to_naive():
+    """Regression (Codex P2 round-8 on PR #1408)：`_coerce_db_ts` 必须把
+    TZ-aware datetime / "...+00:00" 字符串都归一化成 naive。
+    所有 cursor / 比较都按 naive 语义工作，aware 出来会让 last_b /
+    last_a_msg_ts 也 aware，跟 naive facts.json `created_at` 比较时
+    抛 TypeError 永久哑火 path B。
+    """
+    from datetime import timezone
+    from app.memory_server import _coerce_db_ts
+
+    # Case 1: TZ-aware datetime 对象输入
+    aware_dt = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+    out = _coerce_db_ts(aware_dt)
+    assert out is not None and out.tzinfo is None, (
+        f"TZ-aware datetime 输入必须返 naive，实际 tzinfo={out.tzinfo!r}"
+    )
+    # 时钟值不变（口径上当 naive 处理）
+    assert out == datetime(2026, 5, 18, 12, 0, 0)
+
+    # Case 2: ISO 字符串带 offset 输入
+    out = _coerce_db_ts('2026-05-18T12:00:00+00:00')
+    assert out is not None and out.tzinfo is None, (
+        f"TZ-aware ISO 字符串必须返 naive，实际 tzinfo={out.tzinfo!r}"
+    )
+
+    # Case 3: naive ISO 字符串保持 naive（无回归）
+    out = _coerce_db_ts('2026-05-18T12:00:00.123456')
+    assert out is not None and out.tzinfo is None
+    assert out == datetime(2026, 5, 18, 12, 0, 0, 123456)
+
+    # Case 4: naive datetime 对象保持 naive
+    naive_dt = datetime(2026, 5, 18, 12, 0, 0)
+    assert _coerce_db_ts(naive_dt) == naive_dt
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_handles_tz_aware_db_rows_without_typeerror():
+    """End-to-end pin (Codex P2 round-8)：若 SQL row ts 是 TZ-aware，
+    `_coerce_db_ts` 归一化后 last_a_msg_ts / last_b 都是 naive，跟 naive
+    facts.json created_at 比较不抛 TypeError。
+    """
+    from datetime import timezone
+    from app import memory_server
+
+    # state.last_a_msg_ts 故意构造成 aware（模拟旧代码遗留 state）
+    aware_anchor = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+    state = {'last_a_msg_ts': aware_anchor}
+
+    # SQL row ts 也是 aware
+    aware_row_ts = aware_anchor - timedelta(seconds=30)
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (aware_row_ts, 's', json.dumps({
+            'type': 'human', 'data': {'content': '占位'},
+        })),
+    ])
+    # facts.json: naive created_at
+    fake_facts = [{
+        'id': 'naive_fact',
+        'text': 'naive created_at fact',
+        'importance': 5,
+        'created_at': (aware_anchor.replace(tzinfo=None) - timedelta(minutes=1)).isoformat(),
+    }]
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=fake_facts)
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        # 不该抛 TypeError
+        await memory_server._run_path_b('悠怡', state)
+
+    # Stage-1 被调说明 cursor 比较 + known_pool 构建都没炸
+    fake_fact_store.aextract_facts_with_known_pool.assert_awaited_once()
+    # 推进后的 cursor 必须是 naive（避免 state 里残留 aware 继续污染）
+    assert state['last_b_check_ts'].tzinfo is None, (
+        f"last_b_check_ts 必须是 naive，实际 tzinfo={state['last_b_check_ts'].tzinfo!r}"
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_path_b_known_pool_normalizes_tz_aware_created_at():
     """Regression (Codex P1 round-7 on PR #1408)：facts.json 里若被 import/

--- a/tests/unit/test_ai_aware_stage1_path_b.py
+++ b/tests/unit/test_ai_aware_stage1_path_b.py
@@ -302,10 +302,9 @@ async def test_stage2_filters_out_ai_disclosure_facts():
     fs._allm_detect_signals = AsyncMock(return_value=[])  # signals=[] but ran
 
     # _allm_detect_signals 被调用时传的 batch 就是过 filter 后的 unprocessed。
-    # 三元 return 故意全用 _ 前缀——测试关心的是 mock call 参数，不是返回值。
-    _persisted, _signals, _batch_ids = await fs.aextract_facts_and_detect_signals(
-        '悠怡', messages=[],
-    )
+    # 这里直接 await 不绑变量——测试只关心 mock call 参数，不关心三元 return
+    # （CodeQL 对 `_xxx` 前缀仍判 unused，故彻底不绑）。
+    await fs.aextract_facts_and_detect_signals('悠怡', messages=[])
 
     # 验证 _allm_detect_signals 被调，且其 batch 参数里**没有** b（ai_disclosure）
     fs._allm_detect_signals.assert_awaited_once()
@@ -611,6 +610,172 @@ async def test_path_b_known_pool_sort_tolerates_malformed_importance():
     captured_known_pool = fake_fact_store.aextract_facts_with_known_pool.await_args.args[2]
     # 5 条脏 fact 全在窗口内，都应该进 pool（脏值不丢，只是排序 fallback）
     assert len(captured_known_pool) == 5
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_stage1_terminal_failure_preserves_cursor():
+    """Regression (CodeRabbit + Codex P1 round-2 on PR #1408)：
+    ``aextract_facts_with_known_pool`` 返 None 表示 Stage-1 LLM 终态失败
+    （重试耗尽 / network / JSON parse 等），cursor 必须保留不推进。
+    若把 None 折叠成 [] 当成"成功 0 抽"，失败窗口会被永久 skip，那批
+    msg 的 AI-aware fact 永远抓不到。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    original_last_b = last_a_msg_ts - timedelta(minutes=20)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': original_last_b,
+    }
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(minutes=5), 's', json.dumps({
+            'type': 'human', 'data': {'content': '会话有内容'},
+        })),
+        (last_a_msg_ts, 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'AI 回应'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    # Stage-1 LLM 终态失败 → 返 None（不是 []）
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=None)
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    # 关键契约：失败时 cursor 必须保持原值，下次 B trigger 重试同窗口
+    assert state['last_b_check_ts'] == original_last_b, (
+        f"Stage-1 失败时 cursor 必须保留原值 {original_last_b}，"
+        f"实际推到 {state['last_b_check_ts']}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_truncated_window_all_filtered_advances_to_last_fetched():
+    """Regression (Codex P2 round-2 on PR #1408)：
+    SQL LIMIT 截断 + 取到的 rows 全是 system msg / 空 content（被
+    ``_extract_role_tagged_messages_from_rows`` 过滤光）时，cursor 必须只
+    推到 last fetched row ts，不能跳到 last_a_msg_ts——否则截断后未取
+    到的尾巴里若有有效 human/ai msg 会被永久 skip。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=30)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 模拟 SQL 截断：返 2 行但都是 system msg，最后一行 ts < last_a_msg_ts
+    truncation_boundary = last_a_msg_ts - timedelta(minutes=10)
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_b + timedelta(seconds=10), 's', json.dumps({
+            'type': 'system', 'data': {'content': '系统消息1'},
+        })),
+        (truncation_boundary, 's', json.dumps({
+            'type': 'system', 'data': {'content': '系统消息2'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    assert state['last_b_check_ts'] == truncation_boundary, (
+        f"截断 + 过滤全空时 cursor 必须 = last fetched ({truncation_boundary})，"
+        f"不能跳到 last_a_msg_ts ({last_a_msg_ts})。"
+        f"实际: {state['last_b_check_ts']}"
+    )
+    assert state['last_b_check_ts'] < last_a_msg_ts, (
+        "截断尾巴未读到，下次 B 必须能继续覆盖"
+    )
+    # 而且不该调 LLM（没消息可抽）
+    fake_fact_store.aextract_facts_with_known_pool.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_path_b_known_pool_includes_just_written_a_facts_despite_clock_skew():
+    """Regression (CodeRabbit on PR #1408)：A 的 idle/polling 延迟让"刚扫
+    完本 B 窗口"那批 A facts 的 created_at 普遍略晚于 last_a_msg_ts。known
+    _pool 不该用 ``created_at <= last_a_msg_ts`` 做上界过滤，否则最新一批
+    A facts 整批被排除 → B 容易和 A 重复抽同一窗口。
+
+    本测试构造：window=[last_b, last_a_msg_ts]，但 A 在 last_a_msg_ts +
+    30s 才写完那批 fact（created_at 比 last_a_msg_ts 晚），断言这些 fact
+    必须进 known_pool。
+    """
+    from app import memory_server
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=20)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 关键场景：A 写入延迟 → created_at 在 last_a_msg_ts 之后
+    a_written_after_msg_ts = [
+        {'id': f'a_late_{i}', 'text': f'A 在 idle 后才写的 fact {i}',
+         'importance': 8,
+         # 写入延迟 30s ~ 90s（普通 idle gate / LLM call 时长）
+         'created_at': (last_a_msg_ts + timedelta(seconds=30 + i * 20)).isoformat()}
+        for i in range(3)
+    ]
+    # 对照组：窗口内正常时间写的 fact，必须也在
+    a_in_window = [
+        {'id': 'a_in', 'text': '窗口内写的 A fact', 'importance': 7,
+         'created_at': (last_b + timedelta(minutes=5)).isoformat()},
+    ]
+    # 对照组：窗口前的 old fact，不该在（下界过滤）
+    a_pre_window = [
+        {'id': 'a_old', 'text': 'pre-window fact', 'importance': 10,
+         'created_at': (last_b - timedelta(hours=1)).isoformat()},
+    ]
+    all_facts = a_written_after_msg_ts + a_in_window + a_pre_window
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=[
+        (last_a_msg_ts - timedelta(minutes=1), 's', json.dumps({
+            'type': 'human', 'data': {'content': '测试'},
+        })),
+    ])
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=all_facts)
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=[])
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        await memory_server._run_path_b('悠怡', state)
+
+    fake_fact_store.aextract_facts_with_known_pool.assert_awaited_once()
+    captured_pool = fake_fact_store.aextract_facts_with_known_pool.await_args.args[2]
+    pool_ids = {f['id'] for f in captured_pool}
+
+    # 关键断言：A 写入延迟产生的 facts（created_at > last_a_msg_ts）必须在
+    for f in a_written_after_msg_ts:
+        assert f['id'] in pool_ids, (
+            f"A idle-delay fact {f['id']} (created_at > last_a_msg_ts) 被错误排除——"
+            f"会让 known_pool 对最新一批 A 抽取失效，B 重复抽同窗口。"
+            f"实际 pool ids: {pool_ids}"
+        )
+    # 窗口内正常 fact 也在
+    assert 'a_in' in pool_ids
+    # 窗口前 old fact 仍被下界过滤掉
+    assert 'a_old' not in pool_ids, (
+        "下界 created_at >= last_b 必须保留，否则会拉入很多无关老 fact 挤掉 pool 名额"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- 引入 **path B**：piggyback 在现有 SignalLoop (path A) 循环里、每 3 次 A tick 触发一次的 AI-aware Stage-1 only 通路。**抢回 PR #1346 之后失明的 entity=neko / proactive 屏幕上下文 grounded fact**
- fact schema 加 `source` ∈ {`'user_observation'`, `'ai_disclosure'`}；trust-tier 隔离：ai_disclosure fact **不进 Stage-2 evidence loop**（防 AI 自我披露触发 reflection reinforce 形成自我强化死循环）
- **Monotonic source upgrade**：user 印证后 ai_disclosure fact 可升级到 user_observation 并重入 Stage-2；反向永不降级
- 15 个新 regression test + 79 个 adjacent suite test 全过

## Root cause

PR #1346 (5-13) 把 ON-mode 的 per-turn fact extraction 整段砍掉（"per-turn 太贵，全交 batch"），但 SignalLoop 从 PR #929 起就只看 user msg（`_extract_user_messages_from_rows` 硬编码 `type=='human'`）。结果 ON-mode 唯一活路径完全失明 AI msg → entity=neko 类 fact 永不入库。

实测今日 facts.json：5 条 today's facts **全是 entity=master**（"博士 likes salmon / prefers sashimi / loves writing code..."），零条关于悠怡自己 / 零条 grounded 在 AI 引入的屏幕上下文。

## 设计要点（thread 拍板）

| Dimension | 选择 | 理由 |
|---|---|---|
| **D1** Sequencing | A→B | 避免 source 字段方向错（B 先写 ai_disclosure，A 后撞会丢 user_observation 升级语义） |
| **D2** B input | role-tagged 全消息 + prompt 塞 A 已抽 fact 作"已知池" | 让 LLM 输出层主动去重 path A 已抽内容 |
| **D3** source 处理 | A wins 单调升级 | user 印证不可逆 |
| **D4** B cadence | piggyback 在 A 循环里，每 N=3 次 A tick 触发；窗口下游边界用 `last_a_msg_ts`（A 实际处理过的最晚 msg）避免 race | tempo 跟着对话强度；不需要独立 wall-clock cadence；cold-start lookback 从 N×IDLE_MIN 推算 |
| **D5** Stage-2 input | `source != 'ai_disclosure'` filter，AI fact 写盘时 `signal_processed=True` 双重防御 | 干净隔离自我强化死循环 |
| **D6** reflection synthesis | 不 filter | ai_disclosure 可入合成池，但 evidence 涨分仍只靠 user_observation（confirmed 仍需 user 印证） |

## 成本

| | A 单 call | B 单 call | 日 cost |
|---|---|---|---|
| input tok | ~4300 | ~3700-7300 | A: 12×4300=52k；B: 2-4×~5500=16k；总 ~68k/天 (+~30% vs A-only) |
| LLM calls | 24 | 2-4 | 总 26-28 vs A-only 24 |

月成本（summary tier 中端模型）：~$1.5-4/月 vs A-only $1-3/月，**净增量 < $1/月** 单角色。

## Test plan

- [x] 新增 `tests/unit/test_ai_aware_stage1_path_b.py` (15 cases): role-tagged 提取 / source 持久化 / LLM 显式 source 优先 / monotonic upgrade（ai→user 升级 + 重置 signal_processed；user→ai 永不降级）/ Stage-2 unprocessed pool 排除 ai_disclosure / cold-start lookback 从 N×IDLE_MIN 推算 / A 未跑过时 B 跳过 / B cursor 单调推进 / 已知池过滤+cap+排序 / 源码扫描 wiring 不变量
- [x] `uv run pytest tests/unit/test_ai_aware_stage1_path_b.py -q` → 15 passed
- [x] adjacent suite (`evidence_extraction / memory_server_cache_settle / reflection_synthesis_loop / memory_recall / signal_loop_message_wire / reflection_idempotent / reflection_filters`) 79 passed, 无回归
- [ ] **本地手动验证**：跑 launcher、跟猫娘聊几轮含 AI 自我披露的对话、看 `[PathB] {name}: AI-aware Stage-1 抽出 N 条新 fact` 日志、看 facts.json 出现 `source='ai_disclosure'` 的 entity=neko fact

## Follow-up issues（不在本 PR scope）

- FactDedupResolver merge/replace 应该 archive-style 而不是物理删除（pre-existing inconsistency，dedup 命中后原文从 hybrid_recall 池消失。本 PR 不动）
- review_history 路径耦合：曾考虑作为 AI-aware 触发点，最终因 race / compress 边界 / 重复抽取风险被否决

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加 AI‑感知的补抓流程（Path B），按角色抽取并裁剪为首尾用户发言区间；新增本地化 AI‑感知事实抽取提示；事实记录新增来源层级（user_observation / ai_disclosure）。

* **改进**
  * 可配置触发节奏、窗口消息上限与已知 fact 池上限；来源单向升级与重试保留语义；时区归一为 naive；微秒级游标推进避免死循环；AI 自我披露被排除于证据循环；仅在有用户发言时触发 Path B。

* **测试**
  * 新增大量单元测试覆盖消息抽取、窗口裁剪、来源持久化、游标/时区/微秒边界与触发节奏。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->