### PR TITLE
fix(memory): 7 处 LLM 终态失败的 liveness dead-letter 兜底 (#1409)

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -597,6 +597,15 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
 
     `sem`：startup replay 路径传入共享 Semaphore 限制 LLM fan-out；日常单次
     spawn 路径传 None 即不限流。
+
+    Liveness 兜底（Site 7）：handler 失败时 append_attempt 一行记录失败。
+    若同 op_id 累计 attempt 数（含本次） ≥ ``MEMORY_LIVENESS_MAX_ATTEMPTS``
+    则 append_done 当 dead-letter 放弃该 op + WARN。否则毒 op（payload 触
+    发 handler 永久 raise，例如 LLM safety filter / parse 永久失败）每次重启
+    都重跑且永远不出 pending → ``compact`` 永久阻塞 → outbox.ndjson 线性增
+    长。``op.get('_attempt_count', 0)`` 来自 ``pending_ops`` scan 时的累计，
+    日常 spawn 路径调 _run_outbox_op 时 op 是临时构造的不带这个字段，按 0
+    起算（首次失败 → attempt=1，远 < N，正常 pending 等重启重放）。
     """
     op_id = op.get('op_id')
     op_type = op.get('type')
@@ -613,7 +622,35 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
         try:
             await handler(name, payload)
         except Exception as e:
-            logger.warning(f"[Outbox] {name}/{op_type}/{op_id} 执行失败（保持 pending）: {e}")
+            from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+            prior_attempts = int(op.get('_attempt_count', 0) or 0)
+            try:
+                await outbox.aappend_attempt(name, op_id)
+            except Exception as ae:
+                logger.warning(
+                    f"[Outbox] {name}/{op_type}/{op_id}: append_attempt 失败: {ae}"
+                )
+            total_attempts = prior_attempts + 1
+            if total_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                logger.warning(
+                    f"[Outbox] {name}/{op_type}/{op_id}: handler 累计失败 "
+                    f"{total_attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，"
+                    f"dead-letter 放弃该 op（最近一次失败: {e}）。"
+                    f"Why: liveness 兜底，避免毒 payload 让重启 replay 永远卡住 + "
+                    f"compact 永久阻塞。"
+                )
+                try:
+                    await outbox.aappend_done(name, op_id)
+                except Exception as de:
+                    logger.warning(
+                        f"[Outbox] {name}/{op_type}/{op_id}: dead-letter "
+                        f"append_done 失败: {de}"
+                    )
+            else:
+                logger.warning(
+                    f"[Outbox] {name}/{op_type}/{op_id} 执行失败（保持 pending，"
+                    f"attempts={total_attempts}/{MEMORY_LIVENESS_MAX_ATTEMPTS}）: {e}"
+                )
             return
         try:
             await outbox.aappend_done(name, op_id)
@@ -945,6 +982,32 @@ async def _resolve_rebuttal_start_time(name: str, now: datetime):
     return cursor
 
 
+_rebuttal_failures: dict[str, dict[str, int]] = {}
+"""Per-character rebuttal LLM 失败计数：``{name: {cursor_iso: count}}``。
+
+In-memory only（cursor 本身落盘到 cursors.json，但 counter 重启清零）。
+Why in-memory: 重启后再试 ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 次再 dead-letter，
+避免内存 counter 错把短暂 transient 失败永久放弃；user-visible 代价 = 重启
+后多卡 N × REBUTTAL_CHECK_INTERVAL 一段时间，可接受。
+
+Liveness 兜底原因：``check_feedback_for_confirmed`` 返 None 时原代码直接
+``return`` 不动 cursor → 下轮重读相同 [cursor, now] 窗口含同样的毒 user
+msg → 仍失败 → 永久卡死 rebuttal 链路（毒窗口让 user 反驳信号永远进不来
+evidence loop）。"""
+
+
+def _rebuttal_bump_failure(name: str, cursor_key: str) -> int:
+    """Bump 失败计数，返回当前累计次数。Caller 自行判 ≥ MEMORY_LIVENESS_MAX_ATTEMPTS。"""
+    fails = _rebuttal_failures.setdefault(name, {})
+    fails[cursor_key] = int(fails.get(cursor_key, 0) or 0) + 1
+    return fails[cursor_key]
+
+
+def _rebuttal_clear_failures(name: str) -> None:
+    """Cursor 推进（成功）或 dead-letter 强推后清零 counter。"""
+    _rebuttal_failures.pop(name, None)
+
+
 async def _periodic_rebuttal_loop():
     """每 5 分钟检查 confirmed reflections 是否被近期对话反驳。
 
@@ -1015,6 +1078,7 @@ async def _periodic_rebuttal_loop():
                     await cursor_store.aset_cursor(
                         name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
                     )
+                    _rebuttal_clear_failures(name)
                     return
 
                 start_time = await _resolve_rebuttal_start_time(name, now)
@@ -1026,6 +1090,7 @@ async def _periodic_rebuttal_loop():
                     await cursor_store.aset_cursor(
                         name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
                     )
+                    _rebuttal_clear_failures(name)
                     return
 
                 # 提取 (msg, ts) 元组（ASC by ts；ts 已归一化为 datetime）
@@ -1044,6 +1109,7 @@ async def _periodic_rebuttal_loop():
                         await cursor_store.aset_cursor(
                             name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
                         )
+                    _rebuttal_clear_failures(name)
                     return
 
                 # Drain 取前 N 条 user msg。然后扩展 batch 把和 batch 末位
@@ -1072,8 +1138,34 @@ async def _periodic_rebuttal_loop():
                     name, confirmed, user_msgs,
                 )
                 if feedbacks is None:
-                    # LLM 调用失败 → 不推进游标，下次重试这批消息
-                    logger.warning(f"[Rebuttal] {name}: 反驳检查失败，保留游标待重试")
+                    # LLM 调用失败 → 不推进游标，下次重试这批消息。
+                    # Liveness 兜底：同一 cursor 反复失败 ≥
+                    # MEMORY_LIVENESS_MAX_ATTEMPTS 时强推 cursor 到 now 放弃这段
+                    # 窗口（dead-letter），避免毒 user msg 让 rebuttal 链路永久
+                    # 卡死。cursor 落盘到 cursors.json，stuck cursor 重启都不
+                    # 复活，比 in-memory 的 signal extraction cursor 更顽固。
+                    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+                    cursor_key = (
+                        start_time.isoformat(timespec='microseconds')
+                        if start_time else 'cold'
+                    )
+                    attempts = _rebuttal_bump_failure(name, cursor_key)
+                    if attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                        logger.warning(
+                            f"[Rebuttal] {name}: 反驳检查在 cursor {cursor_key!r} "
+                            f"累计失败 {attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，"
+                            f"强推 cursor 到 {now.isoformat(timespec='seconds')} "
+                            f"放弃该窗口（dead-letter）。Why: 毒窗口 liveness 兜底。"
+                        )
+                        await cursor_store.aset_cursor(
+                            name, CURSOR_REBUTTAL_CHECKED_UNTIL, now,
+                        )
+                        _rebuttal_clear_failures(name)
+                    else:
+                        logger.warning(
+                            f"[Rebuttal] {name}: 反驳检查失败，保留游标待重试 "
+                            f"({attempts}/{MEMORY_LIVENESS_MAX_ATTEMPTS})"
+                        )
                     return
 
                 # 成功才推进游标并持久化。Drain 推进规则：
@@ -1104,6 +1196,9 @@ async def _periodic_rebuttal_loop():
                 await cursor_store.aset_cursor(
                     name, CURSOR_REBUTTAL_CHECKED_UNTIL, new_cursor,
                 )
+                # Cursor 推进 → 旧 cursor key 永远不会再被命中，清空 counter
+                # 避免内存 dict 随 cursor 历史无限增长（对偶 Site 0a/0b）。
+                _rebuttal_clear_failures(name)
                 for fb in feedbacks:
                     if isinstance(fb, dict) and fb.get('feedback') == 'denied':
                         rid = fb.get('reflection_id')
@@ -1715,7 +1810,24 @@ async def _periodic_archive_sweep_loop():
 
 # ── memory-evidence-rfc §3.4.3: background signal extraction loop ───
 
-_signal_check_state: dict[str, dict] = {}  # {name: {turns_since, last_check_ts}}
+_signal_check_state: dict[str, dict] = {}
+"""Per-character signal extraction state.
+
+Schema:
+  {
+    'turns_since': int,           # turn counter since last successful check
+    'last_check_ts': str | None,  # ISO cursor for path A window start
+    'last_a_msg_ts': datetime,    # path A 实际处理过的最晚 msg ts (path B 上游边界)
+    'last_b_check_ts': datetime,  # ISO cursor for path B window start
+    'b_tick_counter': int,        # ticks since last path B trigger
+    # Liveness counters (in-memory only)：cursor key → 连续失败次数。
+    # 成功 mark_done 时清空对应 path 的 counter。重启清零是有意为之的"软兜底"
+    # ——重启后再试 MEMORY_LIVENESS_MAX_ATTEMPTS 次再 dead-letter，避免内存
+    # counter 错误地把短暂 transient 失败永久放弃。
+    'a_extract_failures': dict[str, int],  # path A cursor (last_check_ts) → fail count
+    'b_extract_failures': dict[str, int],  # path B cursor (last_b_check_ts) → fail count
+  }
+"""
 
 
 def _signal_check_should_run(name: str, now: datetime) -> bool:
@@ -1744,6 +1856,72 @@ def _signal_check_mark_done(name: str, now: datetime) -> None:
     state = _signal_check_state.setdefault(name, {'turns_since': 0, 'last_check_ts': None})
     state['turns_since'] = 0
     state['last_check_ts'] = now.isoformat()
+    # Cursor 推进 → path A 的旧 cursor key 永远不会再被命中，清空 counter
+    # 避免内存 dict 随 cursor 历史无限增长。同时把"曾经失败但靠新数据冲过去
+    # 了"的窗口归零，下次毒窗口出现按 fresh attempt 计算。
+    state['a_extract_failures'] = {}
+
+
+def _stage1_path_a_bump_failure(
+    name: str, state: dict, cursor_key: str, now: datetime,
+) -> bool:
+    """Path A Stage-1 LLM 终态失败的 liveness 兜底。
+
+    给 (cursor_key) 当前窗口 bump 失败计数；达 ``MEMORY_LIVENESS_MAX_ATTEMPTS``
+    时强推 cursor 到 now（视为放弃该窗口的 fact 抽取），返回 True；未达上限
+    返回 False（caller 走原有"保留 cursor 下轮重试"路径）。
+
+    Why: 毒 msg（safety filter / content policy / 永远 parse 不出来的畸形
+    输出）让 ``_allm_call_with_retries`` 永久耗尽，原代码捕获后直接 return
+    不动 cursor → 下轮重读同窗口 → 永远卡死该角色的 fact pipeline（类似
+    PR #1399 "26 天 0 fact" 事故的 liveness 缺口）。强推 cursor 等于
+    放弃这段窗口的 fact 抽取，代价上限 = N × interval (≈ 3 分钟)，远比
+    "永久 0 fact" 划算。
+    """
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    fails = state.setdefault('a_extract_failures', {})
+    fails[cursor_key] = int(fails.get(cursor_key, 0) or 0) + 1
+    if fails[cursor_key] < MEMORY_LIVENESS_MAX_ATTEMPTS:
+        return False
+    logger.warning(
+        f"[SignalLoop] {name}: Stage-1 path A 在 cursor {cursor_key!r} "
+        f"累计失败 {fails[cursor_key]} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，"
+        f"强推 cursor 到 {now.isoformat(timespec='seconds')} "
+        f"放弃该窗口（dead-letter）。Why: 毒窗口 liveness 兜底。"
+    )
+    _signal_check_mark_done(name, now)  # 会顺带把 a_extract_failures 清空
+    return True
+
+
+def _stage1_path_b_bump_failure(
+    name: str, state: dict, cursor_key: str, force_to: datetime,
+) -> bool:
+    """Path B Stage-1 LLM 终态失败的 liveness 兜底（path A 的对偶）。
+
+    给 (cursor_key) 当前 B 窗口 bump 失败计数；达
+    ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 时强推 ``state['last_b_check_ts']``
+    到 ``force_to`` (= last_fetched_ts)，返回 True；未达上限返回 False
+    （caller 走原有"保留 cursor 下次 trigger 重试"路径）。
+
+    Why: 跟 path A 同源问题——B 的 ``persisted is None`` 分支原代码直接
+    return 不动 ``last_b_check_ts`` → 下次 B trigger 重读 [last_b_check_ts,
+    last_a_msg_ts] 同窗口 → 仍卡。强推 cursor 到 last_fetched_ts 等于
+    放弃 AI-aware 视角下的这段窗口，代价上限 = N × B trigger 间隔。
+    """
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    fails = state.setdefault('b_extract_failures', {})
+    fails[cursor_key] = int(fails.get(cursor_key, 0) or 0) + 1
+    if fails[cursor_key] < MEMORY_LIVENESS_MAX_ATTEMPTS:
+        return False
+    logger.warning(
+        f"[PathB] {name}: Stage-1 path B 在 cursor {cursor_key!r} "
+        f"累计失败 {fails[cursor_key]} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，"
+        f"强推 last_b_check_ts 到 {force_to.isoformat(timespec='seconds')} "
+        f"放弃该窗口（dead-letter）。Why: 毒窗口 liveness 兜底。"
+    )
+    state['last_b_check_ts'] = force_to
+    state['b_extract_failures'] = {}
+    return True
 
 
 def _signal_check_window_start(name: str, now: datetime) -> datetime:
@@ -1986,6 +2164,7 @@ async def _run_path_b(name: str, state: dict) -> None:
         # 全是 system msg / 空内容。cursor 推到 last fetched（不是 last_a_msg_ts），
         # 截断时未取尾巴可能含有效 msg。
         state['last_b_check_ts'] = last_fetched_ts
+        state['b_extract_failures'] = {}
         return
 
     # 截到 user msg bracket：首条 user msg 到末条 user msg 之间（含两端）。
@@ -2001,6 +2180,7 @@ async def _run_path_b(name: str, state: dict) -> None:
             f"(纯 AI-only 内容，product thesis 跳过)"
         )
         state['last_b_check_ts'] = last_fetched_ts
+        state['b_extract_failures'] = {}
         return
 
     from utils.llm_client import convert_to_messages
@@ -2059,11 +2239,19 @@ async def _run_path_b(name: str, state: dict) -> None:
         # 重试同窗口（fact dedup hash 防双写）。区分 None vs [] 至关重要：
         # 若把失败折叠成"成功 0 抽"，失败窗口会被永久 skip（CodeRabbit / Codex
         # P1 round-2 on PR #1408）。
-        logger.warning(
-            f"[PathB] {name}: Stage-1 终态失败，保留 cursor 下次 trigger 重试 "
-            f"(window={last_b.isoformat(timespec='seconds')} → "
-            f"{last_fetched_ts.isoformat(timespec='seconds')})"
+        #
+        # Liveness 兜底（path A 的对偶）：同一 last_b_check_ts cursor 反复
+        # 失败 ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 时强推 cursor 到 last_fetched_ts，
+        # 避免毒窗口让 B pipeline 永久卡死该角色的 AI-aware fact 抽取。
+        cursor_key = (
+            last_b.isoformat(timespec='microseconds') if last_b else 'cold'
         )
+        if not _stage1_path_b_bump_failure(name, state, cursor_key, last_fetched_ts):
+            logger.warning(
+                f"[PathB] {name}: Stage-1 终态失败，保留 cursor 下次 trigger 重试 "
+                f"(window={last_b.isoformat(timespec='seconds')} → "
+                f"{last_fetched_ts.isoformat(timespec='seconds')})"
+            )
         return
     if persisted:
         logger.info(
@@ -2074,6 +2262,10 @@ async def _run_path_b(name: str, state: dict) -> None:
         )
 
     state['last_b_check_ts'] = last_fetched_ts
+    # Cursor 推进 → 旧 cursor key 永远不会再被命中，清空 path-B counter
+    # 避免内存 dict 随 cursor 历史无限增长（对偶 _signal_check_mark_done
+    # 在 path A 成功路径上清 a_extract_failures）。
+    state['b_extract_failures'] = {}
 
 
 async def _periodic_signal_extraction_loop():
@@ -2172,10 +2364,18 @@ async def _periodic_signal_extraction_loop():
                     )
                 except FactExtractionFailed as e:
                     # Stage-1 terminal failure — cursor NOT advanced, next
-                    # cycle retries the same message window (§3.4.3).
-                    logger.warning(
-                        f"[SignalLoop] {name}: Stage-1 失败保留 cursor 重试: {e}"
+                    # cycle retries the same message window (§3.4.3)。
+                    # Liveness 兜底：同一 cursor 反复失败 ≥ MEMORY_LIVENESS
+                    # _MAX_ATTEMPTS 强推 cursor 到 now，避免毒窗口让
+                    # fact pipeline 永久卡死。
+                    state = _signal_check_state.setdefault(
+                        name, {'turns_since': 0, 'last_check_ts': None},
                     )
+                    cursor_key = state.get('last_check_ts') or 'cold'
+                    if not _stage1_path_a_bump_failure(name, state, cursor_key, now):
+                        logger.warning(
+                            f"[SignalLoop] {name}: Stage-1 失败保留 cursor 重试: {e}"
+                        )
                     return
 
                 # 先 dispatch 再 mark_done：dispatch 中途有任何 aapply 失败
@@ -2351,6 +2551,7 @@ async def _amaybe_trigger_negative_keyword_hook(
 async def _run_persona_refine_for_character(character: str) -> None:
     """单角色 persona refine pass。embedding 不可用 / cluster_hash 全
     skip / 候选不足 → 整 pass no-op。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
     from memory.refine import (
         MemoryRefineEngine,
         REFINE_ENTITY_KEY,
@@ -2364,10 +2565,18 @@ async def _run_persona_refine_for_character(character: str) -> None:
     candidates_by_entity: dict[str, list[dict]] = {}
     for entity in ('master', 'neko', 'relationship'):
         section = pm._get_section_facts(persona, entity)
+        # Liveness 过滤：refine_attempts ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 的
+        # entry 不再进 cluster gather。Site 4 dead-letter——同 entry 在多
+        # cluster 反复 LLM 失败后被 frozen，避免持续占用 starvation-first
+        # ordering 名额空跑 LLM。recovery 路径：apply_refine_actions 在
+        # stamp 成功时会清回 0；或人工编辑 persona.json。
         entries = [
             annotate_entry(e, type_='persona', entity=entity)
             for e in section
-            if isinstance(e, dict) and not e.get('protected') and e.get('id')
+            if isinstance(e, dict)
+            and not e.get('protected')
+            and e.get('id')
+            and int(e.get('refine_attempts', 0) or 0) < MEMORY_LIVENESS_MAX_ATTEMPTS
         ]
         if entries:
             candidates_by_entity[entity] = entries
@@ -2385,10 +2594,14 @@ async def _run_persona_refine_for_character(character: str) -> None:
         )
         await pm.apply_refine_actions(character, ent, cluster, actions, cluster_hash)
 
+    async def _failure(cluster, cluster_hash):
+        await pm._abump_refine_attempts(character, cluster, cluster_hash)
+
     result = await engine.refine_pass(
         candidates_by_entity,
         apply_fn=_apply,
         scope_label=f"persona/{character}",
+        failure_fn=_failure,
     )
     if result['clusters_resolved'] or result['clusters_failed']:
         logger.info(
@@ -2430,6 +2643,7 @@ async def _run_reflection_refine_for_character(character: str) -> None:
     """单角色 reflection refine pass。cluster 内可混入同 entity 的
     absorbed fact 作只读信息源（fact 不可被 split/discard/modify，apply
     层代码兜底）。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
     from memory.refine import (
         MemoryRefineEngine,
         REFINE_ENTITY_KEY,
@@ -2450,10 +2664,17 @@ async def _run_reflection_refine_for_character(character: str) -> None:
 
     candidates_by_entity: dict[str, list[dict]] = {}
     for entity in ('master', 'neko', 'relationship'):
+        # Liveness 过滤：refine_attempts ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 的
+        # reflection 不再进 cluster gather（同 persona refine）。fact 不算
+        # ——fact 是 readonly 信息源，不会被 refine 改，自然不会 bump
+        # attempts。
         entity_refls = [
             annotate_entry(r, type_='reflection', entity=entity)
             for r in refls
-            if isinstance(r, dict) and r.get('entity') == entity and r.get('id')
+            if isinstance(r, dict)
+            and r.get('entity') == entity
+            and r.get('id')
+            and int(r.get('refine_attempts', 0) or 0) < MEMORY_LIVENESS_MAX_ATTEMPTS
         ]
         entity_facts = [
             annotate_entry(f, type_='fact', entity=entity)
@@ -2476,10 +2697,14 @@ async def _run_reflection_refine_for_character(character: str) -> None:
         )
         await engine_ref.apply_refine_actions(character, ent, cluster, actions, cluster_hash)
 
+    async def _failure(cluster, cluster_hash):
+        await engine_ref._abump_refine_attempts(character, cluster, cluster_hash)
+
     result = await engine.refine_pass(
         candidates_by_entity,
         apply_fn=_apply,
         scope_label=f"reflection/{character}",
+        failure_fn=_failure,
     )
     if result['clusters_resolved'] or result['clusters_failed']:
         logger.info(

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -607,13 +607,38 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
     日常 spawn 路径调 _run_outbox_op 时 op 是临时构造的不带这个字段，按 0
     起算（首次失败 → attempt=1，远 < N，正常 pending 等重启重放）。
     """
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
     op_id = op.get('op_id')
     op_type = op.get('type')
     payload = op.get('payload') or {}
+    prior_attempts = int(op.get('_attempt_count', 0) or 0)
     handler = _OUTBOX_HANDLERS.get(op_type)
     if handler is None:
         logger.warning(f"[Outbox] {name}: 未注册的 op type {op_type}, 跳过 {op_id}")
         return
+
+    # CodeRabbit: 已达 dead-letter 阈值的 op 直接补写 done，不要再跑 handler。
+    # 边缘 case：上一轮 ``aappend_attempt`` 成功把 _attempt_count 推到 N，但
+    # 紧接着 ``aappend_done`` 写盘失败（IO transient）→ op 留在 pending →
+    # 重启 replay 看到 ``_attempt_count=N`` 又进 handler 再失败再尝试 done。
+    # 对幂等 handler 只是浪费一次调用；对非幂等 handler（outbox 契约要求幂等
+    # 但不保证）就是真重复副作用。进门先短路保证"达阈值后绝不再执行"。
+    if prior_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+        logger.warning(
+            f"[Outbox] {name}/{op_type}/{op_id}: 进入时已达 dead-letter 阈值 "
+            f"({prior_attempts}/{MEMORY_LIVENESS_MAX_ATTEMPTS})，跳过 handler "
+            f"直接补写 done。Why: 上一轮 append_done 可能 IO 失败留 pending，"
+            f"避免毒 op 重复执行 + 副作用重放。"
+        )
+        try:
+            await outbox.aappend_done(name, op_id)
+        except Exception as de:
+            logger.warning(
+                f"[Outbox] {name}/{op_type}/{op_id}: dead-letter "
+                f"append_done 仍失败（保持 pending 等下次重放再补 done）: {de}"
+            )
+        return
+
     acquired = False
     if sem is not None:
         await sem.acquire()
@@ -622,8 +647,6 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
         try:
             await handler(name, payload)
         except Exception as e:
-            from config import MEMORY_LIVENESS_MAX_ATTEMPTS
-            prior_attempts = int(op.get('_attempt_count', 0) or 0)
             try:
                 await outbox.aappend_attempt(name, op_id)
                 attempt_persisted = True

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -611,7 +611,8 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
     op_id = op.get('op_id')
     op_type = op.get('type')
     payload = op.get('payload') or {}
-    prior_attempts = int(op.get('_attempt_count', 0) or 0)
+    from memory.facts import safe_int_field
+    prior_attempts = safe_int_field(op, '_attempt_count')
     handler = _OUTBOX_HANDLERS.get(op_type)
     if handler is None:
         logger.warning(f"[Outbox] {name}: 未注册的 op type {op_type}, 跳过 {op_id}")
@@ -2600,6 +2601,7 @@ async def _run_persona_refine_for_character(character: str) -> None:
     """单角色 persona refine pass。embedding 不可用 / cluster_hash 全
     skip / 候选不足 → 整 pass no-op。"""
     from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.facts import safe_int_field
     from memory.refine import (
         MemoryRefineEngine,
         REFINE_ENTITY_KEY,
@@ -2624,7 +2626,7 @@ async def _run_persona_refine_for_character(character: str) -> None:
             if isinstance(e, dict)
             and not e.get('protected')
             and e.get('id')
-            and int(e.get('refine_attempts', 0) or 0) < MEMORY_LIVENESS_MAX_ATTEMPTS
+            and safe_int_field(e, 'refine_attempts') < MEMORY_LIVENESS_MAX_ATTEMPTS
         ]
         if entries:
             candidates_by_entity[entity] = entries
@@ -2692,6 +2694,7 @@ async def _run_reflection_refine_for_character(character: str) -> None:
     absorbed fact 作只读信息源（fact 不可被 split/discard/modify，apply
     层代码兜底）。"""
     from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.facts import safe_int_field
     from memory.refine import (
         MemoryRefineEngine,
         REFINE_ENTITY_KEY,
@@ -2722,7 +2725,7 @@ async def _run_reflection_refine_for_character(character: str) -> None:
             if isinstance(r, dict)
             and r.get('entity') == entity
             and r.get('id')
-            and int(r.get('refine_attempts', 0) or 0) < MEMORY_LIVENESS_MAX_ATTEMPTS
+            and safe_int_field(r, 'refine_attempts') < MEMORY_LIVENESS_MAX_ATTEMPTS
         ]
         entity_facts = [
             annotate_entry(f, type_='fact', entity=entity)

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -626,10 +626,27 @@ async def _run_outbox_op(name: str, op: dict, sem: asyncio.Semaphore | None = No
             prior_attempts = int(op.get('_attempt_count', 0) or 0)
             try:
                 await outbox.aappend_attempt(name, op_id)
+                attempt_persisted = True
             except Exception as ae:
+                attempt_persisted = False
                 logger.warning(
                     f"[Outbox] {name}/{op_type}/{op_id}: append_attempt 失败: {ae}"
                 )
+
+            # Codex P1：不能基于"未落盘的 +1"触发 dead-letter。
+            # 如果本次 aappend_attempt 失败 + 接着 aappend_done 成功 →
+            # 重启后只看到磁盘上 prior_attempts 个 attempt 行 + 1 个 done →
+            # op 永久丢失而磁盘记录看起来"只失败了 N-1 次就 done"，违背 "≥ N
+            # 次失败才放弃" 的契约。Attempt 没落盘 → 本次失败按 transient 处理
+            # （保留 pending，下次重试自然再走一次 attempt），不进 dead-letter
+            # 判定。
+            if not attempt_persisted:
+                logger.warning(
+                    f"[Outbox] {name}/{op_type}/{op_id} 执行失败（attempt 持久化"
+                    f"失败，按 transient 保留 pending 等下次重放）: {e}"
+                )
+                return
+
             total_attempts = prior_attempts + 1
             if total_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
                 logger.warning(
@@ -2365,13 +2382,21 @@ async def _periodic_signal_extraction_loop():
                 except FactExtractionFailed as e:
                     # Stage-1 terminal failure — cursor NOT advanced, next
                     # cycle retries the same message window (§3.4.3)。
-                    # Liveness 兜底：同一 cursor 反复失败 ≥ MEMORY_LIVENESS
+                    # Liveness 兜底：同一窗口反复失败 ≥ MEMORY_LIVENESS
                     # _MAX_ATTEMPTS 强推 cursor 到 now，避免毒窗口让
                     # fact pipeline 永久卡死。
                     state = _signal_check_state.setdefault(
                         name, {'turns_since': 0, 'last_check_ts': None},
                     )
-                    cursor_key = state.get('last_check_ts') or 'cold'
+                    # CodeRabbit: 用 start_time 当 key，不要字面 'cold'。
+                    # 字面 'cold' 把所有冷启动多轮失败聚合到同一桶，
+                    # 第 N 次会强推 cursor 到当时的 now，把那段时间内进来的
+                    # 正常 msg 也跟着 dead-letter。改用 start_time（每轮
+                    # window 起点）：有稳定 cursor 时 start_time == cursor
+                    # （`_signal_check_window_start` 直接返 cursor），冷启动
+                    # 时 start_time 是 `now - IDLE_MINUTES*2`，每轮不同 →
+                    # 冷启动阶段不会错误聚合 dead-letter。
+                    cursor_key = start_time.isoformat(timespec='microseconds')
                     if not _stage1_path_a_bump_failure(name, state, cursor_key, now):
                         logger.warning(
                             f"[SignalLoop] {name}: Stage-1 失败保留 cursor 重试: {e}"

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1110,6 +1110,18 @@ MEMORY_RECHECK_MAX_ATTEMPTS = 5
 - 命中阈值的条目仍保留 schema_version<2（不静默升版洗白），但被 filter
   排除，让循环把名额匀给其它 v1 条目。dev 可读 logger.debug 看积压。"""
 
+MEMORY_LIVENESS_MAX_ATTEMPTS = 5
+"""LLM 终态失败 N 次后强推 progress marker / dead-letter 的统一上限。
+- 适用场景：所有"同点 input + 无 counter + LLM 永久失败 → 永久卡死"的后台
+  路径。包括 signal extraction path A/B、rebuttal feedback、persona
+  corrections resolve、fact dedup resolve、refine cluster、outbox handler。
+- 治理思路：参考 `MEMORY_RECHECK_MAX_ATTEMPTS` (schema 重判 dead-letter) 的
+  套路，把"同一 cursor / 队头 / cluster_hash / op 反复打 LLM"收敛掉，避免
+  毒窗口 / 毒 payload 让整条 pipeline 哑火。
+- 失败定义：LLM 返 None / 抛异常 / handler raise / parse 失败等终态。
+- 5 跟 `MEMORY_RECHECK_MAX_ATTEMPTS` 同口径——按 40s 一轮算 3 分钟级窗口，
+  跨过偶发 transient failure 够用；再多就属于真正 poison。"""
+
 # ---- Memory: followup picker (memory/reflection.py) ─
 REFLECTION_FOLLOWUP_WEIGHTED = True
 """主动搭话 followup 候选采样是否按 evidence_score 加权随机。

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -375,6 +375,7 @@ class FactDedupResolver:
             return await self._aresolve_locked(name)
 
     async def _aresolve_locked(self, name: str) -> int:
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
         from config.prompts.prompts_memory import get_fact_dedup_prompt
         from utils.language_utils import get_global_language
         from utils.llm_client import create_chat_llm
@@ -384,7 +385,18 @@ class FactDedupResolver:
         if not pending:
             return 0
 
-        batch = pending[:FACT_DEDUP_BATCH_LIMIT]
+        # Liveness：过滤已达 MEMORY_LIVENESS_MAX_ATTEMPTS 的 dead-letter pair
+        # （防御性——_abump_dedup_attempts_and_dead_letter_locked 命中阈值时直接
+        # 从 queue 删除，正常路径不会让 attempts ≥ MAX 的 entry 还留着）。
+        batch: list[dict] = []
+        for it in pending:
+            if int(it.get('resolve_attempts', 0) or 0) >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                continue
+            batch.append(it)
+            if len(batch) >= FACT_DEDUP_BATCH_LIMIT:
+                break
+        if not batch:
+            return 0
         pairs_text = "\n".join(
             f"[{i}] candidate: {item.get('candidate_text', '')}"
             f" | existing: {item.get('existing_text', '')}"
@@ -421,9 +433,18 @@ class FactDedupResolver:
                     "[FactDedup] %s: LLM 返回非数组 (%s)，跳过本轮",
                     name, type(results).__name__,
                 )
+                # Parse 失败也算 attempt（same input → same parse failure）；
+                # 跟 Exception 分支同治。
+                await self._abump_dedup_attempts_and_dead_letter_locked(name, batch)
                 return 0
         except Exception as e:
             logger.warning("[FactDedup] %s: LLM 调用失败: %s", name, e)
+            # Liveness 兜底：给本批 pair bump resolve_attempts；达
+            # MEMORY_LIVENESS_MAX_ATTEMPTS 的 entry 从 queue dead-letter
+            # 丢弃。否则毒 pair（safety filter / prompt 过长 / 永远 parse
+            # 不出来）一直占队头让 dedup 永久卡死。caller (aresolve) 已持
+            # 着 _get_alock，这里走 _locked 变体不再重复获取。
+            await self._abump_dedup_attempts_and_dead_letter_locked(name, batch)
             return 0
 
         applied, processed_keys = await self._aapply_decisions(
@@ -462,6 +483,55 @@ class FactDedupResolver:
                 name, applied, len(remaining),
             )
         return applied
+
+    async def _abump_dedup_attempts_and_dead_letter_locked(
+        self, name: str, batch_items: list[dict],
+    ) -> None:
+        """aresolve LLM 失败时的 liveness 兜底（caller MUST hold _get_alock）。
+
+        给本批 pending pair bump ``resolve_attempts``；累计 ≥
+        ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 的 pair 直接从 queue 删除并 WARN。
+
+        Why: 毒 pair（LLM 永远 parse 不出 / safety filter / prompt 过长）让
+        队头每个 tick 都被送进同样 prompt 同样失败 → 整条 dedup pipeline 永久
+        卡死该角色。caller 已持着 _get_alock，所以不再 async with；这跟
+        ``_aresolve_locked`` 里 ``_aapply_decisions`` / ``aload_pending`` /
+        ``_asave_pending`` 全在 lock 内同一规则。
+        """
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        if not batch_items:
+            return
+        bumped_keys = {
+            (it.get('candidate_id'), it.get('existing_id')) for it in batch_items
+        }
+        bumped_keys.discard((None, None))
+        if not bumped_keys:
+            return
+        current = await self.aload_pending(name)
+        kept: list[dict] = []
+        dropped = 0
+        for it in current:
+            key = (it.get('candidate_id'), it.get('existing_id'))
+            if key in bumped_keys:
+                new_attempts = int(it.get('resolve_attempts', 0) or 0) + 1
+                if new_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                    dropped += 1
+                    logger.warning(
+                        "[FactDedup] %s: dead-letter pair (%s, %s) resolve %d 次失败 ≥ %d，丢弃",
+                        name, key[0], key[1], new_attempts, MEMORY_LIVENESS_MAX_ATTEMPTS,
+                    )
+                    continue
+                it['resolve_attempts'] = new_attempts
+            kept.append(it)
+        if not await self._asave_pending(name, kept):
+            logger.debug(
+                "[FactDedup] %s: 维护态跳过 dedup attempts 写盘", name,
+            )
+        elif dropped:
+            logger.info(
+                "[FactDedup] %s: dead-letter 丢弃 %d 对 dedup pair，剩余队列 %d 条",
+                name, dropped, len(kept),
+            )
 
     # Whitelist of action vocabulary the LLM may return. Anything
     # outside this set (case mismatch, trailing whitespace, localised

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -451,6 +451,20 @@ class FactDedupResolver:
             name, batch, results,
         )
 
+        # CodeRabbit: LLM 返了 list 但 ``_aapply_decisions`` 没消费任何 pair
+        # （所有 action 都被 reject = unknown action / missing index / invalid
+        # format 等），processed_keys 为空 → 下面的 ``remaining`` filter 不会
+        # 删任何东西 → 队头同一批 pair 下次 tick 重新喂 LLM 同样输出垃圾 →
+        # 永久卡死。算 attempts 一次（跟 LLM Exception / 非 list 同治）。
+        if not processed_keys:
+            logger.warning(
+                "[FactDedup] %s: LLM 输出 %d 条 action 全部无效（unknown action / "
+                "invalid index / conflict）, batch 无任何 pair 消费，按 attempt 失败计",
+                name, len(results),
+            )
+            await self._abump_dedup_attempts_and_dead_letter_locked(name, batch)
+            return 0
+
         # Read-modify-write the queue so concurrent enqueue calls
         # that landed during the LLM call survive — same shape as
         # PersonaManager._resolve_corrections_locked's processed-keys

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -43,6 +43,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from memory.embeddings import cosine_similarity
+from memory.facts import safe_int_field
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.file_utils import (
     atomic_write_json_async,
@@ -390,7 +391,7 @@ class FactDedupResolver:
         # 从 queue 删除，正常路径不会让 attempts ≥ MAX 的 entry 还留着）。
         batch: list[dict] = []
         for it in pending:
-            if int(it.get('resolve_attempts', 0) or 0) >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+            if safe_int_field(it, 'resolve_attempts') >= MEMORY_LIVENESS_MAX_ATTEMPTS:
                 continue
             batch.append(it)
             if len(batch) >= FACT_DEDUP_BATCH_LIMIT:
@@ -527,7 +528,7 @@ class FactDedupResolver:
         for it in current:
             key = (it.get('candidate_id'), it.get('existing_id'))
             if key in bumped_keys:
-                new_attempts = int(it.get('resolve_attempts', 0) or 0) + 1
+                new_attempts = safe_int_field(it, 'resolve_attempts') + 1
                 if new_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
                     dropped += 1
                     logger.warning(

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -74,6 +74,29 @@ def safe_importance(f: dict, default: int = 5) -> int:
         return default
 
 
+def safe_int_field(d: dict, key: str, default: int = 0) -> int:
+    """Defensively coerce ``d[key]`` to int (Codex P2 on PR #1412)。
+
+    Liveness attempt counters (``refine_attempts`` / ``resolve_attempts`` /
+    ``_attempt_count``) 都从 JSON / ndjson 反序列化出来的 dict 字段读，
+    一旦 manual edit / legacy / migration noise 写进 ``""`` / ``"unknown"``
+    / list / dict 等脏值，原 ``int(d.get(key, 0) or 0)`` 会抛 ValueError /
+    TypeError 让整个 list comprehension（候选 gather）挂掉 → 那条 pass
+    永久 fail → liveness 兜底自己变了新的 liveness 缺口。
+
+    跟 ``safe_importance`` 的区别：本 helper 把 ``0`` / ``"0"`` 当合法值返回 0
+    （attempt counter 0 是合法计数），不退 default。``safe_importance`` 把
+    falsy 都退 default 是 importance-specific 语义。
+    """
+    try:
+        val = d.get(key)
+        if val is None:
+            return default
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
 class FactExtractionFailed(RuntimeError):
     """Stage-1 LLM call exhausted retries (RFC §3.4.2 末段).
 

--- a/memory/outbox.py
+++ b/memory/outbox.py
@@ -133,6 +133,24 @@ class Outbox:
         with self._get_lock(name):
             self._write_line(self._outbox_path(name), line)
 
+    def append_attempt(self, name: str, op_id: str) -> None:
+        """记录一次 handler 失败 attempt（Site 7 liveness 兜底）。
+
+        scan 时按 op_id 累计 attempt 数；caller (memory_server._run_outbox_op)
+        见累计 ≥ ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 时 append_done 当
+        dead-letter 放弃该 op。否则毒 op（payload 触发 handler 永久 raise）
+        每次重启都重跑、永远不出 pending → ``compact`` 永久阻塞 →
+        outbox.ndjson 线性增长。
+        """
+        record = {
+            'op_id': op_id,
+            'status': 'attempt',
+            'ts': datetime.now().isoformat(),
+        }
+        line = json.dumps(record, ensure_ascii=False)
+        with self._get_lock(name):
+            self._write_line(self._outbox_path(name), line)
+
     # ── scan ────────────────────────────────────────────────────
 
     def _read_all_records(self, path: str) -> list[dict]:
@@ -154,12 +172,19 @@ class Outbox:
         return records
 
     def pending_ops(self, name: str) -> list[dict]:
-        """返回 pending 且无对应 done 的 op 记录（按登记顺序）。"""
+        """返回 pending 且无对应 done 的 op 记录（按登记顺序）。
+
+        每条返回的 record 会附带非持久化字段 ``_attempt_count``（int），
+        scan 时统计的 ``status='attempt'`` 行数。caller 用它判 dead-letter
+        阈值。返回 dict 是 ``_read_all_records`` 当轮 JSON-load 出的新实例，
+        附 ``_attempt_count`` 不会污染磁盘上的 pending 行。
+        """
         path = self._outbox_path(name)
         with self._get_lock(name):
             records = self._read_all_records(path)
 
         pending: dict[str, dict] = {}
+        attempts: dict[str, int] = {}
         for rec in records:
             op_id = rec.get('op_id')
             status = rec.get('status')
@@ -172,20 +197,32 @@ class Outbox:
                 pending[op_id] = rec
             elif status == 'done':
                 pending.pop(op_id, None)
+                attempts.pop(op_id, None)
+            elif status == 'attempt':
+                attempts[op_id] = attempts.get(op_id, 0) + 1
+        for op_id, rec in pending.items():
+            rec['_attempt_count'] = attempts.get(op_id, 0)
         return list(pending.values())
 
     # ── compact ─────────────────────────────────────────────────
 
     def compact(self, name: str) -> int:
-        """重写 outbox.ndjson，只保留未完成的 pending 行。返回丢弃行数。
+        """重写 outbox.ndjson，只保留未完成的 pending 行 + 它们的 attempt 行。
+        返回丢弃行数。
 
         通过 atomic_write_text 原子替换。compact 期间被 lock 阻塞的 append
         会在 rename 完成后继续到新文件。
+
+        Attempt 行处理（Site 7 liveness）：still-pending 的 op 的 attempt
+        行保留（attempt 计数 → 决定 dead-letter 时机的依据，丢了会让重启后
+        计数器归零）；done 的 op 把它对应的 attempt 行也一并丢（done 后就
+        没有人再读 attempt 计数）。
         """
         path = self._outbox_path(name)
         with self._get_lock(name):
             records = self._read_all_records(path)
             pending: dict[str, dict] = {}
+            attempts_by_op: dict[str, list[dict]] = {}
             for rec in records:
                 op_id = rec.get('op_id')
                 status = rec.get('status')
@@ -195,9 +232,19 @@ class Outbox:
                     pending[op_id] = rec
                 elif status == 'done':
                     pending.pop(op_id, None)
+                    attempts_by_op.pop(op_id, None)
+                elif status == 'attempt':
+                    attempts_by_op.setdefault(op_id, []).append(rec)
+
+            kept_records: list[dict] = []
+            for rec in pending.values():
+                kept_records.append(rec)
+            for op_id, attempt_recs in attempts_by_op.items():
+                if op_id in pending:
+                    kept_records.extend(attempt_recs)
 
             total_lines = len(records)
-            kept = len(pending)
+            kept = len(kept_records)
             if total_lines == kept:
                 return 0  # 没有可丢弃的行，避免无用 IO
 
@@ -206,7 +253,7 @@ class Outbox:
                 atomic_write_text(path, '', encoding='utf-8')
             else:
                 body = '\n'.join(
-                    json.dumps(r, ensure_ascii=False) for r in pending.values()
+                    json.dumps(r, ensure_ascii=False) for r in kept_records
                 ) + '\n'
                 atomic_write_text(path, body, encoding='utf-8')
             return total_lines - kept
@@ -236,6 +283,9 @@ class Outbox:
 
     async def aappend_done(self, name: str, op_id: str) -> None:
         await asyncio.to_thread(self.append_done, name, op_id)
+
+    async def aappend_attempt(self, name: str, op_id: str) -> None:
+        await asyncio.to_thread(self.append_attempt, name, op_id)
 
     async def apending_ops(self, name: str) -> list[dict]:
         return await asyncio.to_thread(self.pending_ops, name)

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -1693,9 +1693,23 @@ class PersonaManager:
                 return 0
 
             # ── 短临界 2: load fresh persona + apply + save ──
-            return await self._apply_correction_results(
+            resolved = await self._apply_correction_results(
                 name, corrections, allowed_indices, results,
             )
+            # 对偶 fact_dedup：LLM 返了 list 但 ``_apply_correction_results_locked``
+            # 没消费任何 correction（全 invalid index / 全 unknown action），
+            # corrections queue 原样保留 → 队头同样 N 条下次 tick 重新喂同样
+            # prompt → 仍然 0 resolved → 永久卡死。算 attempts 一次。
+            if resolved == 0:
+                logger.warning(
+                    f"[Persona] {name}: correction model 输出 {len(results)} "
+                    f"条 action 全部无效（invalid index / unknown action），"
+                    f"batch 0 条 correction 消费，按 attempt 失败计"
+                )
+                await self._abump_correction_attempts_and_dead_letter(
+                    name, [item for _, item in pairs],
+                )
+            return resolved
 
     async def _apply_correction_results(
         self,

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -36,7 +36,7 @@ from memory.stop_names import (
     collect_stop_names,
     strip_stop_names,
 )
-from utils.cloudsave_runtime import assert_cloudsave_writable
+from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.config_manager import get_config_manager
 from utils.file_utils import (
     atomic_write_json,
@@ -1615,9 +1615,19 @@ class PersonaManager:
             # 合并所有矛盾为单个 prompt。受 PERSONA_CORRECTION_BATCH_LIMIT
             # 限制：corrections 队列可能堆积，单次只处理前 N 条，剩下的下次
             # 触发时再处理。
-            from config import PERSONA_CORRECTION_BATCH_LIMIT
+            #
+            # Liveness：过滤已达 ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 的 dead-letter
+            # entry（防御性——下面 _abump_correction_attempts_and_dead_letter
+            # 命中阈值时会直接从 queue 删除，正常路径不会让 attempts ≥ MAX 的
+            # entry 还留在 queue。这里只是 race-condition 防御 + schema 兼容）。
+            from config import (
+                MEMORY_LIVENESS_MAX_ATTEMPTS,
+                PERSONA_CORRECTION_BATCH_LIMIT,
+            )
             pairs = []
             for i, item in enumerate(corrections):
+                if int(item.get('resolve_attempts', 0) or 0) >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                    continue
                 old_text = item.get('old_text', '')
                 new_text = item.get('new_text', '')
                 if old_text and new_text:
@@ -1671,6 +1681,15 @@ class PersonaManager:
                     results = [results]
             except Exception as e:
                 logger.warning(f"[Persona] {name}: correction model 调用失败: {e}")
+                # Liveness 兜底：给本批 corrections bump resolve_attempts 字段，
+                # 达 MEMORY_LIVENESS_MAX_ATTEMPTS 的 entry 从 queue dead-letter
+                # 丢弃。否则同样的 (old_text, new_text) 队头 entry 每次 resolve
+                # tick 都被送进相同 prompt，LLM 同样失败，永久卡住后续 corrections
+                # （safety filter / 长 prompt token 超限 / 永远 parse 不出来 等
+                # 毒 payload 场景）。
+                await self._abump_correction_attempts_and_dead_letter(
+                    name, [item for _, item in pairs],
+                )
                 return 0
 
             # ── 短临界 2: load fresh persona + apply + save ──
@@ -1811,6 +1830,72 @@ class PersonaManager:
                                           indent=2, ensure_ascii=False)
             logger.info(f"[Persona] {name}: 批量审视完成 {resolved} 条矛盾，剩余 {len(remaining)} 条")
         return resolved
+
+    async def _abump_correction_attempts_and_dead_letter(
+        self, name: str, batch_items: list[dict],
+    ) -> None:
+        """resolve_corrections LLM 失败时的 liveness 兜底。
+
+        给本批 corrections 的每条 entry bump ``resolve_attempts`` 字段，
+        累计 ≥ ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 的 entry 直接从 queue
+        删除并 WARN。
+
+        Why: 队头若是毒 payload（safety filter / prompt 过长 / 永远 parse
+        不出来），resolve_corrections 每个 tick 都按 FIFO 取相同前 N 条进
+        prompt，LLM 同样失败 → 整条 corrections 链路永久卡死。这跟
+        signal extraction 的毒窗口同源——cursor 不动 + 无 counter。
+        """
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        if not batch_items:
+            return
+        bumped_keys = {
+            it.get('created_at', '') for it in batch_items if it.get('created_at')
+        }
+        if not bumped_keys:
+            return
+        async with self._get_alock(name):
+            current = await self.aload_pending_corrections(name)
+            kept: list[dict] = []
+            dropped = 0
+            for c in current:
+                key = c.get('created_at', '')
+                if key in bumped_keys:
+                    new_attempts = int(c.get('resolve_attempts', 0) or 0) + 1
+                    if new_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                        dropped += 1
+                        logger.warning(
+                            f"[Persona] {name}: correction dead-letter "
+                            f"(old={(c.get('old_text', '') or '')[:30]!r} "
+                            f"new={(c.get('new_text', '') or '')[:30]!r}) "
+                            f"resolve {new_attempts} 次失败 ≥ "
+                            f"{MEMORY_LIVENESS_MAX_ATTEMPTS}，丢弃"
+                        )
+                        continue
+                    c['resolve_attempts'] = new_attempts
+                kept.append(c)
+            try:
+                assert_cloudsave_writable(
+                    self._config_manager,
+                    operation="save",
+                    target=f"memory/{name}/persona_corrections.json",
+                )
+                await atomic_write_json_async(
+                    self._corrections_path(name), kept,
+                    indent=2, ensure_ascii=False,
+                )
+            except MaintenanceModeError as e:
+                logger.debug(
+                    f"[Persona] {name}: 维护态跳过 correction attempts 写盘: {e}"
+                )
+            except OSError as e:
+                logger.warning(
+                    f"[Persona] {name}: correction attempts 写盘失败: {e}"
+                )
+            if dropped:
+                logger.info(
+                    f"[Persona] {name}: dead-letter 丢弃 {dropped} 条 correction，"
+                    f"剩余 {len(kept)} 条"
+                )
 
     # ── refine apply (Phase A-3 MemoryRefineEngine) ──────────────────
 
@@ -2073,6 +2158,11 @@ class PersonaManager:
                 if eid in cluster_ids and eid not in consumed:
                     e['last_refine_cluster_hash'] = cluster_hash
                     e['last_refine_at'] = now_iso
+                    # 成功 stamp → 清 Site 4 liveness 计数器：之前因毒 cluster
+                    # 邻居拖累的累计 attempts 一笔勾销，让本 entry 后续可以
+                    # 重新进新 cluster 接受 LLM 判断。
+                    if e.get('refine_attempts'):
+                        e['refine_attempts'] = 0
                     stamped += 1
 
             if applied == 0 and stamped == 0:
@@ -2088,6 +2178,64 @@ class PersonaManager:
                 f"+{len(produced)} produced, -{len(consumed)} consumed)"
             )
         return applied
+
+    async def _abump_refine_attempts(
+        self, name: str, cluster: list[dict], cluster_hash: str,
+    ) -> None:
+        """Site 4 liveness 兜底：refine cluster LLM 失败时给非 fact 成员
+        bump ``refine_attempts``。达 ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 的
+        entry 在下次 ``_run_persona_refine_for_character`` 候选 gather 时
+        被过滤掉，避免毒 cluster 持续占用 starvation-first ordering 名额
+        空跑 LLM。
+
+        Recovery：成功 refine（apply_refine_actions 跑到 stamp 分支）会把
+        ``refine_attempts`` 清回 0；或人工编辑 persona.json。
+
+        Why 不 in-memory：refine stamp `last_refine_at` 本身就落盘，counter
+        也得落盘——否则重启清零让 dead-letter 失效（参考 issue #1409 "落盘
+        与否的 dual" 部分）。
+        """
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        from memory.refine import REFINE_ENTITY_KEY, REFINE_TYPE_KEY
+
+        # 按 entity 收集需要 bump 的 entry id（fact 不算——fact 是 readonly
+        # 信息源，refine 永远不会改它，自然也不应记 refine_attempts）。
+        member_ids_by_entity: dict[str, set[str]] = {}
+        for e in cluster:
+            if not isinstance(e, dict):
+                continue
+            if e.get(REFINE_TYPE_KEY) == 'fact':
+                continue
+            ent = e.get(REFINE_ENTITY_KEY)
+            eid = e.get('id')
+            if not ent or not eid:
+                continue
+            member_ids_by_entity.setdefault(ent, set()).add(eid)
+        if not member_ids_by_entity:
+            return
+
+        async with self._get_alock(name):
+            persona = await self._aensure_persona_locked(name)
+            modified = False
+            for entity, ids in member_ids_by_entity.items():
+                section = self._get_section_facts(persona, entity)
+                for e in section:
+                    if not isinstance(e, dict) or e.get('id') not in ids:
+                        continue
+                    new_attempts = int(e.get('refine_attempts', 0) or 0) + 1
+                    e['refine_attempts'] = new_attempts
+                    modified = True
+                    if new_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS:
+                        logger.warning(
+                            f"[PersonaRefine] {name}: persona entry "
+                            f"id={e.get('id')} entity={entity} "
+                            f"refine_attempts={new_attempts} ≥ "
+                            f"{MEMORY_LIVENESS_MAX_ATTEMPTS}（dead-letter，"
+                            f"cluster_hash={cluster_hash}）。下次 refine "
+                            f"gather 不再选入，避免毒 cluster 占用名额。"
+                        )
+            if modified:
+                await self.asave_persona(name, persona)
 
     # ── 提及疲劳：记录 + 更新 suppress ───────────────────────────
 

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -31,6 +31,7 @@ from config import (
     REFLECTION_RENDER_TOKEN_BUDGET,
 )
 from memory.evidence import evidence_score
+from memory.facts import safe_int_field
 from memory.stop_names import (
     acollect_stop_names,
     collect_stop_names,
@@ -1626,7 +1627,7 @@ class PersonaManager:
             )
             pairs = []
             for i, item in enumerate(corrections):
-                if int(item.get('resolve_attempts', 0) or 0) >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+                if safe_int_field(item, 'resolve_attempts') >= MEMORY_LIVENESS_MAX_ATTEMPTS:
                     continue
                 old_text = item.get('old_text', '')
                 new_text = item.get('new_text', '')
@@ -1874,7 +1875,7 @@ class PersonaManager:
             for c in current:
                 key = c.get('created_at', '')
                 if key in bumped_keys:
-                    new_attempts = int(c.get('resolve_attempts', 0) or 0) + 1
+                    new_attempts = safe_int_field(c, 'resolve_attempts') + 1
                     if new_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
                         dropped += 1
                         logger.warning(
@@ -2236,7 +2237,7 @@ class PersonaManager:
                 for e in section:
                     if not isinstance(e, dict) or e.get('id') not in ids:
                         continue
-                    new_attempts = int(e.get('refine_attempts', 0) or 0) + 1
+                    new_attempts = safe_int_field(e, 'refine_attempts') + 1
                     e['refine_attempts'] = new_attempts
                     modified = True
                     if new_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS:

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -86,6 +86,14 @@ def strip_refine_metadata(entry: dict) -> dict:
 # stamp internally; engine doesn't touch storage.
 ApplyFn = Callable[[list[dict], list[dict], str], Awaitable[set[str]]]
 
+# Manager-supplied failure callback signature.
+# Args: cluster (annotated entries), cluster_hash.
+# Triggered when ``_resolve_cluster`` returns False (LLM/parse failure) or
+# raises. Manager bumps ``refine_attempts`` on each non-fact cluster member
+# (and saves persona/reflection file), so the next refine pass can filter
+# out entries that have repeatedly failed (Site 4 liveness 兜底)。
+FailureFn = Callable[[list[dict], str], Awaitable[None]]
+
 
 class MemoryRefineEngine:
     """Stateless apart from the embedding service handle and config
@@ -104,6 +112,7 @@ class MemoryRefineEngine:
         *,
         apply_fn: ApplyFn,
         scope_label: str,  # for logging: "persona/character" etc.
+        failure_fn: FailureFn | None = None,
     ) -> dict:
         """通用 pass：候选已按 entity 切片（每条带 annotate_entry 的标签），
         engine 跑 cluster + hash skip + ranking + LLM + apply。
@@ -112,6 +121,12 @@ class MemoryRefineEngine:
                   'clusters_failed'}.
 
         Embedding 不可用 → 返回零计数，no-op。
+
+        ``failure_fn``: 可选回调，``_resolve_cluster`` 返 False / 抛异常时
+        调用，传入 ``(cluster, cluster_hash)``。Manager 在回调里 bump
+        ``refine_attempts`` 字段做 liveness 兜底——同 cluster 反复 LLM 失败
+        N 次后 manager 在下次候选 gather 时把成员过滤掉，避免毒 cluster
+        持续占用 starvation-first ordering 第一名空跑 LLM。
         """
         zero = {
             'clusters_seen': 0,
@@ -158,6 +173,7 @@ class MemoryRefineEngine:
         resolved = 0
         failed = 0
         for entity, cluster, cluster_hash in to_process:
+            cluster_failed = False
             try:
                 ok = await self._resolve_cluster(
                     entity, cluster, cluster_hash, apply_fn,
@@ -166,11 +182,21 @@ class MemoryRefineEngine:
                     resolved += 1
                 else:
                     failed += 1
+                    cluster_failed = True
             except Exception as e:  # noqa: BLE001 — refine is best-effort
                 failed += 1
+                cluster_failed = True
                 logger.warning(
                     f"[Refine] {scope_label} cluster {cluster_hash} 异常: {e}"
                 )
+            if cluster_failed and failure_fn is not None:
+                try:
+                    await failure_fn(cluster, cluster_hash)
+                except Exception as fe:  # noqa: BLE001 — failure_fn 是兜底，自己再失败也不该挂主路径
+                    logger.warning(
+                        f"[Refine] {scope_label} cluster {cluster_hash} "
+                        f"failure_fn 异常: {fe}"
+                    )
         return {
             'clusters_seen': len(all_clusters),
             'clusters_skipped': skipped,

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -173,7 +173,14 @@ class MemoryRefineEngine:
         resolved = 0
         failed = 0
         for entity, cluster, cluster_hash in to_process:
-            cluster_failed = False
+            # 只在 ``_resolve_cluster`` 返 False 时 bump refine_attempts
+            # （= LLM 输出空 / parse 失败 / 非 list 等持续性问题，跟 cluster
+            # 内容相关）。raise 路径不 bump（Codex P1）——抓不到的异常来源
+            # 不确定，可能是 ``apply_fn`` 的 manager 端持久化 transient
+            # （cloudsave 维护态 / atomic_write IO / 锁竞争）或 LLM 网络
+            # transient，把这类错算到 cluster 成员的 refine_attempts 上会
+            # 让磁盘 / 锁瞬态错误冤枉具体 entry，触发非必要 dead-letter。
+            llm_decision_failed = False
             try:
                 ok = await self._resolve_cluster(
                     entity, cluster, cluster_hash, apply_fn,
@@ -182,14 +189,14 @@ class MemoryRefineEngine:
                     resolved += 1
                 else:
                     failed += 1
-                    cluster_failed = True
+                    llm_decision_failed = True
             except Exception as e:  # noqa: BLE001 — refine is best-effort
                 failed += 1
-                cluster_failed = True
                 logger.warning(
-                    f"[Refine] {scope_label} cluster {cluster_hash} 异常: {e}"
+                    f"[Refine] {scope_label} cluster {cluster_hash} 异常"
+                    f"（按 transient 不计 refine_attempts）: {e}"
                 )
-            if cluster_failed and failure_fn is not None:
+            if llm_decision_failed and failure_fn is not None:
                 try:
                     await failure_fn(cluster, cluster_hash)
                 except Exception as fe:  # noqa: BLE001 — failure_fn 是兜底，自己再失败也不该挂主路径

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -88,9 +88,13 @@ ApplyFn = Callable[[list[dict], list[dict], str], Awaitable[set[str]]]
 
 # Manager-supplied failure callback signature.
 # Args: cluster (annotated entries), cluster_hash.
-# Triggered when ``_resolve_cluster`` returns False (LLM/parse failure) or
-# raises. Manager bumps ``refine_attempts`` on each non-fact cluster member
-# (and saves persona/reflection file), so the next refine pass can filter
+# Triggered ONLY when ``_resolve_cluster`` returns False (LLM 输出空 /
+# parse 失败 / 非 list 等 LLM-decision 持续性问题)。**Exception 路径不调**
+# ——`_resolve_cluster` 内部 `await apply_fn(...)` 的 manager 端持久化异常
+# （cloudsave 维护态 / atomic_write IO / 锁竞争）+ LLM 网络 transient
+# 都按 transient 处理，不触发该回调（Codex P1 round-3 on PR #1412）。
+# Manager bumps ``refine_attempts`` on each non-fact cluster member (and
+# saves persona/reflection file), so the next refine pass can filter
 # out entries that have repeatedly failed (Site 4 liveness 兜底)。
 FailureFn = Callable[[list[dict], str], Awaitable[None]]
 
@@ -122,8 +126,12 @@ class MemoryRefineEngine:
 
         Embedding 不可用 → 返回零计数，no-op。
 
-        ``failure_fn``: 可选回调，``_resolve_cluster`` 返 False / 抛异常时
-        调用，传入 ``(cluster, cluster_hash)``。Manager 在回调里 bump
+        ``failure_fn``: 可选回调，**仅在** ``_resolve_cluster`` 返 False（LLM
+        输出空 / parse 失败 / 非 list 等 LLM-decision 持续性问题）时调用，
+        传入 ``(cluster, cluster_hash)``。Exception 路径按 transient 不调
+        回调——apply_fn 持久化失败 (cloudsave / IO / 锁) + LLM 网络瞬态
+        都属于跟 cluster 内容无关的瞬时故障，不该让 entry refine_attempts
+        被冤枉计数 (Codex P1 round-3 on PR #1412)。Manager 在回调里 bump
         ``refine_attempts`` 字段做 liveness 兜底——同 cluster 反复 LLM 失败
         N 次后 manager 在下次候选 gather 时把成员过滤掉，避免毒 cluster
         持续占用 starvation-first ordering 第一名空跑 LLM。

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -1248,6 +1248,10 @@ class ReflectionEngine:
                 if rid in cluster_refl_ids and rid not in consumed:
                     r['last_refine_cluster_hash'] = cluster_hash
                     r['last_refine_at'] = now_iso
+                    # 成功 stamp → 清 Site 4 liveness 计数器（对偶
+                    # PersonaManager.apply_refine_actions）
+                    if r.get('refine_attempts'):
+                        r['refine_attempts'] = 0
                     stamped += 1
 
             if applied == 0 and stamped == 0:
@@ -1260,6 +1264,55 @@ class ReflectionEngine:
                 f"+{len(produced)} produced, -{len(consumed)} consumed)"
             )
         return applied
+
+    async def _abump_refine_attempts(
+        self, name: str, cluster: list[dict], cluster_hash: str,
+    ) -> None:
+        """Site 4 liveness 兜底：refine cluster LLM 失败时给非 fact 的
+        reflection 成员 bump ``refine_attempts``。对偶
+        ``PersonaManager._abump_refine_attempts``——同样治法、不同存储位
+        （reflections.json vs persona.json）。
+
+        Recovery：成功 refine（apply_refine_actions 跑到 stamp 分支）会把
+        ``refine_attempts`` 清回 0；或人工编辑 reflections.json。
+        """
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        from memory.refine import REFINE_TYPE_KEY
+
+        # fact 不计 attempts（fact 是 readonly 信息源，refine 永远不改它）；
+        # 只 bump reflection 成员。reflection 不分 entity section 单独存（全
+        # 在一个 list 里按 entity 字段区分），所以收集 set[rid] 即可。
+        member_rids: set[str] = set()
+        for e in cluster:
+            if not isinstance(e, dict):
+                continue
+            if e.get(REFINE_TYPE_KEY) == 'fact':
+                continue
+            rid = e.get('id')
+            if rid:
+                member_rids.add(rid)
+        if not member_rids:
+            return
+
+        async with self._get_alock(name):
+            reflections = await self._aload_reflections_full(name)
+            modified = False
+            for r in reflections:
+                if not isinstance(r, dict) or r.get('id') not in member_rids:
+                    continue
+                new_attempts = int(r.get('refine_attempts', 0) or 0) + 1
+                r['refine_attempts'] = new_attempts
+                modified = True
+                if new_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS:
+                    logger.warning(
+                        f"[ReflectionRefine] {name}: reflection id={r.get('id')} "
+                        f"refine_attempts={new_attempts} ≥ "
+                        f"{MEMORY_LIVENESS_MAX_ATTEMPTS}（dead-letter，"
+                        f"cluster_hash={cluster_hash}）。下次 refine gather "
+                        f"不再选入，避免毒 cluster 占用名额。"
+                    )
+            if modified:
+                await self.asave_reflections(name, reflections)
 
     # alias for backward compat (system_router calls .reflect())
     async def reflect(self, lanlan_name: str) -> dict | None:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -1312,7 +1312,17 @@ class ReflectionEngine:
                         f"不再选入，避免毒 cluster 占用名额。"
                     )
             if modified:
-                await self.asave_reflections(name, reflections)
+                # CodeRabbit: 传 active-only 给 ``asave_reflections``。
+                # ``_prepare_save_reflections`` 把 input 当 "想要存活的 active 集",
+                # all_on_disk 里 id 在 input set 中的会跳过归档判断。如果传
+                # full list（含 terminal），``to_archive`` 永远是空，老 promoted/
+                # denied 永远 archive 不掉，跟 arecord_mentions / aupdate_suppressions
+                # 走同一约定保证归档流程正常推进。
+                active = [
+                    r for r in reflections
+                    if r.get('status') not in REFLECTION_TERMINAL_STATUSES
+                ]
+                await self.asave_reflections(name, active)
 
     # alias for backward compat (system_router calls .reflect())
     async def reflect(self, lanlan_name: str) -> dict | None:

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -1277,6 +1277,7 @@ class ReflectionEngine:
         ``refine_attempts`` 清回 0；或人工编辑 reflections.json。
         """
         from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        from memory.facts import safe_int_field
         from memory.refine import REFINE_TYPE_KEY
 
         # fact 不计 attempts（fact 是 readonly 信息源，refine 永远不改它）；
@@ -1300,7 +1301,7 @@ class ReflectionEngine:
             for r in reflections:
                 if not isinstance(r, dict) or r.get('id') not in member_rids:
                     continue
-                new_attempts = int(r.get('refine_attempts', 0) or 0) + 1
+                new_attempts = safe_int_field(r, 'refine_attempts') + 1
                 r['refine_attempts'] = new_attempts
                 modified = True
                 if new_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS:

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -351,6 +351,30 @@ async def test_dedup_dead_letter_at_threshold(tmp_path):
 
 
 @pytest.mark.unit
+def test_safe_int_field_handles_dirty_values():
+    """Codex P2 regression：``refine_attempts`` / ``resolve_attempts`` / ``_attempt_count``
+    持久化字段被手改 / migration noise 写成 ``""`` / ``"unknown"`` / list / dict
+    等脏值时，``safe_int_field`` 必须兜底返 default，不让上游 list comprehension
+    挂掉整个 refine pass / resolve loop。
+    """
+    from memory.facts import safe_int_field
+
+    # 合法值原样返回
+    assert safe_int_field({'x': 5}, 'x') == 5
+    assert safe_int_field({'x': '7'}, 'x') == 7
+    assert safe_int_field({'x': 0}, 'x') == 0
+    # 缺失 / None → default
+    assert safe_int_field({}, 'x') == 0
+    assert safe_int_field({'x': None}, 'x') == 0
+    assert safe_int_field({}, 'x', default=3) == 3
+    # 脏值（manual edit / legacy / migration noise）→ default 不挂
+    for bad in ('', 'unknown', 'high', [], {}, [1, 2]):
+        assert safe_int_field({'x': bad}, 'x') == 0, (
+            f"脏值 {bad!r} 必须兜底返 default 0，不能抛 ValueError/TypeError"
+        )
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_refine_pass_failure_fn_invoked_on_resolve_false():
     """refine_pass：_resolve_cluster 返 False 时必须调 failure_fn (Site 4 兜底)。"""

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -23,8 +23,6 @@ progress marker（cursor / 队头 / cluster_hash / op state）放弃毒输入，
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -534,7 +532,7 @@ async def test_run_outbox_op_dead_letters_at_threshold(tmp_path):
     path = tmp_path / 'outbox.ndjson'
 
     with patch.object(outbox, '_outbox_path', return_value=str(path)):
-        op_id = outbox.append_pending(name, 'poison_op', {'data': 'bad'})
+        outbox.append_pending(name, 'poison_op', {'data': 'bad'})
 
     # Register a handler that always raises
     async def _poison_handler(_n, _p):

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -563,3 +563,65 @@ async def test_run_outbox_op_dead_letters_at_threshold(tmp_path):
         memory_server.outbox = original_outbox
         memory_server._OUTBOX_HANDLERS.clear()
         memory_server._OUTBOX_HANDLERS.update(original_handlers)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_outbox_op_attempt_persist_failure_keeps_pending(tmp_path):
+    """Codex P1 regression：``aappend_attempt`` 抛异常时不应触发 dead-letter。
+
+    Setup：op 已经在磁盘上有 ``MEMORY_LIVENESS_MAX_ATTEMPTS - 1`` 条 attempt
+    行（边缘 case：再失败一次就会触发 dead-letter）。让 ``aappend_attempt``
+    抛 IOError 模拟 transient 磁盘失败。
+    断言：op 仍在 pending（没被 append_done 当 dead-letter），允许下次重放
+    重新走一次 attempt。否则"未落盘的 +1" 误算成"已落盘的 N"，磁盘上看起来
+    只失败了 N-1 次就被 done 永久丢，违背契约。
+    """
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.outbox import Outbox
+
+    outbox = Outbox()
+    name = 'neko_test_outbox_persist_fail'
+    path = tmp_path / 'outbox.ndjson'
+
+    with patch.object(outbox, '_outbox_path', return_value=str(path)):
+        outbox.append_pending(name, 'poison_op', {'data': 'bad'})
+        # 预先填到 N-1 个 attempt（接下来再失败一次就该 dead-letter，正常路径下）
+        op_id_from_disk = outbox.pending_ops(name)[0]['op_id']
+        for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS - 1):
+            outbox.append_attempt(name, op_id_from_disk)
+
+    async def _poison_handler(_n, _p):
+        raise RuntimeError("simulated poison")
+
+    original_outbox = memory_server.outbox
+    original_handlers = memory_server._OUTBOX_HANDLERS.copy()
+    try:
+        memory_server.outbox = outbox
+        memory_server._OUTBOX_HANDLERS['poison_op'] = _poison_handler
+
+        # 让 aappend_attempt 抛异常（模拟磁盘 transient 失败）
+        async def _broken_append_attempt(*args, **kw):
+            raise IOError("simulated disk transient")
+
+        with patch.object(outbox, '_outbox_path', return_value=str(path)), \
+             patch.object(outbox, 'aappend_attempt', _broken_append_attempt):
+            pending = outbox.pending_ops(name)
+            assert len(pending) == 1
+            assert pending[0]['_attempt_count'] == MEMORY_LIVENESS_MAX_ATTEMPTS - 1
+            await memory_server._run_outbox_op(name, pending[0])
+
+        # 关键断言：op 仍在 pending，不该被 dead-letter
+        with patch.object(outbox, '_outbox_path', return_value=str(path)):
+            pending_after = outbox.pending_ops(name)
+        assert len(pending_after) == 1, (
+            f"aappend_attempt 失败时不应基于未落盘的 +1 触发 dead-letter, "
+            f"应保留 pending 等下次自然重放. 实际 pending: {pending_after}"
+        )
+        # 磁盘上 attempt 计数仍是 N-1（本次 attempt 没落盘）
+        assert pending_after[0]['_attempt_count'] == MEMORY_LIVENESS_MAX_ATTEMPTS - 1
+    finally:
+        memory_server.outbox = original_outbox
+        memory_server._OUTBOX_HANDLERS.clear()
+        memory_server._OUTBOX_HANDLERS.update(original_handlers)

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -403,6 +403,59 @@ async def test_refine_pass_failure_fn_invoked_on_resolve_false():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_refine_pass_exception_does_not_invoke_failure_fn():
+    """Codex P1 regression：``_resolve_cluster`` 抛异常时**不**调 failure_fn。
+
+    抛异常的可能源是 apply_fn 持久化 transient（cloudsave 维护态 / atomic
+    write IO / 锁竞争）或 LLM 网络 transient。把这类错算到 cluster 成员的
+    ``refine_attempts`` 上会冤枉具体 entry 触发非必要 dead-letter。只在
+    ``_resolve_cluster`` 明确返 False（LLM/parse 持续性问题）时 bump。
+    """
+    from memory.refine import (
+        MemoryRefineEngine,
+        REFINE_ENTITY_KEY,
+        REFINE_TYPE_KEY,
+    )
+
+    engine = MemoryRefineEngine(MagicMock())
+    fake_member = {
+        'id': 'r_x', 'text': 'x',
+        REFINE_TYPE_KEY: 'reflection',
+        REFINE_ENTITY_KEY: 'master',
+        'last_refine_at': None,
+        'last_refine_cluster_hash': None,
+    }
+    candidates = {'master': [fake_member, dict(fake_member, id='r_y')]}
+
+    engine._service.is_disabled = MagicMock(return_value=False)
+    engine._service.is_available = MagicMock(return_value=True)
+    engine._service.model_id = MagicMock(return_value='mock_model')
+
+    async def _exploding_resolve(*args, **kw):
+        raise RuntimeError("simulated apply_fn IO failure")
+
+    captured_failures: list = []
+    async def _failure_fn(cluster, cluster_hash):
+        captured_failures.append((cluster, cluster_hash))
+
+    with patch.object(engine, '_compute_clusters', return_value=[candidates['master']]), \
+         patch.object(engine, '_resolve_cluster', _exploding_resolve):
+        result = await engine.refine_pass(
+            candidates,
+            apply_fn=AsyncMock(),
+            scope_label='test/scope',
+            failure_fn=_failure_fn,
+        )
+
+    assert result['clusters_failed'] == 1, "exception 仍记 clusters_failed"
+    assert captured_failures == [], (
+        f"exception 不该触发 failure_fn（apply_fn / LLM transient 不算 cluster "
+        f"liveness failure）, 实际触发 {len(captured_failures)} 次"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_persona_abump_refine_attempts_at_threshold_warns():
     """PersonaManager._abump_refine_attempts: 第 N 次 bump 命中阈值 → WARN log。"""
     from config import MEMORY_LIVENESS_MAX_ATTEMPTS

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -1,0 +1,567 @@
+# -*- coding: utf-8 -*-
+"""Memory 模块 LLM 终态失败的 liveness dead-letter 兜底契约。
+
+Background：所有"同一 input + 反复 LLM 失败 + 无 attempt counter → 永久卡死"
+的后台路径都按 ``MEMORY_LIVENESS_MAX_ATTEMPTS`` (=5) 计数，达上限后强推
+progress marker（cursor / 队头 / cluster_hash / op state）放弃毒输入，避免
+单条毒数据让该角色整条 pipeline 哑火。详见 issue #1409。
+
+覆盖的 7 个 site：
+- Site 0a: ``_signal_check_one`` (path A Stage-1) cursor 强推到 now
+- Site 0b: ``_run_path_b`` (path B Stage-1) cursor 强推到 last_fetched_ts
+- Site 1:  ``_periodic_rebuttal_loop`` cursor 强推到 now
+- Site 2:  ``PersonaManager.resolve_corrections`` batch entry dead-letter
+- Site 3:  ``FactDedupResolver.aresolve`` batch pair dead-letter
+- Site 4:  ``MemoryRefineEngine.refine_pass`` 非 fact 成员 dead-letter
+- Site 7:  outbox handler append_done dead-letter（解锁 compact）
+
+每个 site 测：
+- 失败 N-1 次不动 progress marker
+- 第 N 次触发 dead-letter
+- 成功路径清 attempt 计数器
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 0a — _signal_check_one (path A) Stage-1 dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_path_a_bump_failure_under_threshold_returns_false():
+    """N-1 次失败：返 False（caller 走原"保留 cursor 重试"路径）。"""
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    memory_server._signal_check_state.clear()
+    state = memory_server._signal_check_state.setdefault(
+        'neko_test_a', {'turns_since': 0, 'last_check_ts': '2026-05-18T10:00:00'},
+    )
+    cursor_key = state['last_check_ts']
+    now = datetime(2026, 5, 18, 11, 0, 0)
+
+    triggered = False
+    for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS - 1):
+        triggered = memory_server._stage1_path_a_bump_failure(
+            'neko_test_a', state, cursor_key, now,
+        )
+    assert triggered is False, "未达 MAX 不该触发 dead-letter"
+    # cursor 不动
+    assert state['last_check_ts'] == '2026-05-18T10:00:00'
+    # counter 累计到 MAX-1
+    assert state['a_extract_failures'][cursor_key] == MEMORY_LIVENESS_MAX_ATTEMPTS - 1
+
+
+@pytest.mark.unit
+def test_path_a_bump_failure_at_threshold_forces_cursor():
+    """第 N 次失败：返 True 并强推 cursor 到 now + 清 counter。"""
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    memory_server._signal_check_state.clear()
+    state = memory_server._signal_check_state.setdefault(
+        'neko_test_a', {'turns_since': 0, 'last_check_ts': '2026-05-18T10:00:00'},
+    )
+    cursor_key = state['last_check_ts']
+    now = datetime(2026, 5, 18, 11, 0, 0)
+
+    for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS - 1):
+        memory_server._stage1_path_a_bump_failure(
+            'neko_test_a', state, cursor_key, now,
+        )
+    triggered = memory_server._stage1_path_a_bump_failure(
+        'neko_test_a', state, cursor_key, now,
+    )
+    assert triggered is True
+    # cursor 强推到 now
+    assert state['last_check_ts'] == now.isoformat()
+    # counter 清零（mark_done 顺带做）
+    assert state['a_extract_failures'] == {}
+
+
+@pytest.mark.unit
+def test_signal_check_mark_done_clears_path_a_failures():
+    """成功路径 mark_done 必须清 path-A counter，否则 cursor 历史拖累内存。"""
+    from app import memory_server
+
+    memory_server._signal_check_state.clear()
+    state = memory_server._signal_check_state.setdefault(
+        'neko_test_mark', {'turns_since': 5, 'last_check_ts': 'old_cursor'},
+    )
+    state['a_extract_failures'] = {'old_cursor': 3, 'older_cursor': 1}
+
+    memory_server._signal_check_mark_done('neko_test_mark', datetime(2026, 5, 18, 12, 0, 0))
+
+    assert state['a_extract_failures'] == {}, "mark_done 必须清 path-A counter"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 0b — _run_path_b Stage-1 dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_path_b_bump_failure_under_threshold_returns_false():
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    last_b_check = datetime(2026, 5, 18, 10, 0, 0)
+    last_fetched = datetime(2026, 5, 18, 10, 30, 0)
+    state = {'last_b_check_ts': last_b_check}
+    cursor_key = last_b_check.isoformat(timespec='microseconds')
+
+    triggered = False
+    for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS - 1):
+        triggered = memory_server._stage1_path_b_bump_failure(
+            'neko_test_b', state, cursor_key, last_fetched,
+        )
+    assert triggered is False
+    # cursor 不动
+    assert state['last_b_check_ts'] == last_b_check
+    assert state['b_extract_failures'][cursor_key] == MEMORY_LIVENESS_MAX_ATTEMPTS - 1
+
+
+@pytest.mark.unit
+def test_path_b_bump_failure_at_threshold_forces_cursor():
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    last_b_check = datetime(2026, 5, 18, 10, 0, 0)
+    last_fetched = datetime(2026, 5, 18, 10, 30, 0)
+    state = {'last_b_check_ts': last_b_check}
+    cursor_key = last_b_check.isoformat(timespec='microseconds')
+
+    for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+        triggered = memory_server._stage1_path_b_bump_failure(
+            'neko_test_b', state, cursor_key, last_fetched,
+        )
+
+    assert triggered is True
+    assert state['last_b_check_ts'] == last_fetched
+    assert state['b_extract_failures'] == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_path_b_persisted_none_triggers_dead_letter_at_threshold():
+    """End-to-end: _run_path_b 第 N 次 persisted=None 时强推 last_b_check_ts。"""
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    last_a_msg_ts = datetime(2026, 5, 18, 12, 0, 0)
+    last_b = last_a_msg_ts - timedelta(minutes=10)
+    state = {
+        'last_a_msg_ts': last_a_msg_ts,
+        'last_b_check_ts': last_b,
+    }
+
+    # 至少要 2 行 (user, ai) 才能过 bracket trim 进入 LLM
+    base = last_b + timedelta(seconds=10)
+    rows = [
+        (base + timedelta(seconds=0), 's', json.dumps({
+            'type': 'human', 'data': {'content': 'user msg'},
+        })),
+        (base + timedelta(seconds=10), 's', json.dumps({
+            'type': 'ai', 'data': {'content': 'ai reply'},
+        })),
+    ]
+
+    fake_time_manager = MagicMock()
+    fake_time_manager.aretrieve_original_by_timeframe = AsyncMock(return_value=rows)
+    fake_fact_store = MagicMock()
+    fake_fact_store.aload_facts = AsyncMock(return_value=[])
+    fake_fact_store.aextract_facts_with_known_pool = AsyncMock(return_value=None)
+
+    with patch.object(memory_server, 'time_manager', fake_time_manager), \
+         patch.object(memory_server, 'fact_store', fake_fact_store):
+        for i in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+            await memory_server._run_path_b('neko_test_b_e2e', state)
+
+    # 第 N 次：last_b_check_ts 强推到 last_fetched_ts (=最后一行 ts)
+    expected_force_to = base + timedelta(seconds=10)
+    assert state['last_b_check_ts'] == expected_force_to, (
+        f"第 {MEMORY_LIVENESS_MAX_ATTEMPTS} 次失败应强推 cursor 到 {expected_force_to}, "
+        f"实际 {state['last_b_check_ts']}"
+    )
+    # counter 清零
+    assert state.get('b_extract_failures', {}) == {}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 1 — rebuttal loop dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_rebuttal_bump_failure_accumulates():
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    memory_server._rebuttal_failures.clear()
+    cursor_key = '2026-05-18T10:00:00.000000'
+
+    for i in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+        attempts = memory_server._rebuttal_bump_failure('neko_test_reb', cursor_key)
+        assert attempts == i + 1
+
+
+@pytest.mark.unit
+def test_rebuttal_clear_failures_removes_name():
+    from app import memory_server
+
+    memory_server._rebuttal_failures.clear()
+    memory_server._rebuttal_bump_failure('neko_test_reb', 'cursor_a')
+    memory_server._rebuttal_bump_failure('neko_test_reb', 'cursor_b')
+    assert 'neko_test_reb' in memory_server._rebuttal_failures
+
+    memory_server._rebuttal_clear_failures('neko_test_reb')
+    assert 'neko_test_reb' not in memory_server._rebuttal_failures
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 2 — PersonaManager.resolve_corrections dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_corrections_dead_letter_at_threshold(tmp_path):
+    """resolve_corrections LLM 失败 N 次后 dead-letter 队头 corrections。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.persona import PersonaManager
+
+    pm = PersonaManager()
+    name = 'neko_test_corr'
+    corr_path = tmp_path / f'{name}_corrections.json'
+    # Seed disk first—helper reads from `aload_pending_corrections`，不读
+    # batch_items 的值，只用 batch_items 提取 ``created_at`` 当 match key。
+    seed_items = [
+        {
+            'old_text': f'old_{i}',
+            'new_text': f'new_{i}',
+            'entity': 'master',
+            'created_at': f'2026-05-18T10:00:0{i}',
+        }
+        for i in range(3)
+    ]
+    corr_path.write_text(json.dumps(seed_items), encoding='utf-8')
+    batch_keys_only = [{'created_at': it['created_at']} for it in seed_items]
+
+    with patch.object(pm, '_corrections_path', return_value=str(corr_path)):
+        # 模拟 LLM 失败 N 次（每次 LLM 看到队头同样 N 条）
+        for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+            await pm._abump_correction_attempts_and_dead_letter(name, batch_keys_only)
+
+        remaining = json.loads(corr_path.read_text(encoding='utf-8')) or []
+        # 所有 entry 都该被 dead-letter
+        assert remaining == [], (
+            f"N 次失败后 batch entry 全部 dead-letter, 实际剩余: {remaining}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_corrections_under_threshold_keeps_items(tmp_path):
+    """N-1 次失败：所有 entry 保留 + resolve_attempts 字段递增。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.persona import PersonaManager
+
+    pm = PersonaManager()
+    name = 'neko_test_corr_under'
+    corr_path = tmp_path / f'{name}_corrections.json'
+    seed_items = [
+        {
+            'old_text': 'oa', 'new_text': 'na',
+            'entity': 'master',
+            'created_at': '2026-05-18T10:00:00',
+        }
+    ]
+    corr_path.write_text(json.dumps(seed_items), encoding='utf-8')
+    batch_keys_only = [{'created_at': seed_items[0]['created_at']}]
+
+    with patch.object(pm, '_corrections_path', return_value=str(corr_path)):
+        for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS - 1):
+            await pm._abump_correction_attempts_and_dead_letter(name, batch_keys_only)
+
+        remaining = json.loads(corr_path.read_text(encoding='utf-8')) or []
+        assert len(remaining) == 1
+        assert remaining[0]['resolve_attempts'] == MEMORY_LIVENESS_MAX_ATTEMPTS - 1
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 3 — FactDedupResolver.aresolve dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dedup_dead_letter_at_threshold(tmp_path):
+    """fact_dedup LLM 失败 N 次后 pair 从 pending queue dead-letter。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.fact_dedup import FactDedupResolver
+
+    resolver = FactDedupResolver(fact_store=MagicMock())
+    name = 'neko_test_dedup'
+    pending_path = tmp_path / 'pending.json'
+
+    seed = [
+        {
+            'candidate_id': f'cand_{i}',
+            'existing_id': f'exist_{i}',
+            'candidate_text': f'c_{i}',
+            'existing_text': f'e_{i}',
+            'entity': 'master',
+            'cosine': 0.9,
+            'queued_at': '2026-05-18T10:00:00',
+        }
+        for i in range(3)
+    ]
+    pending_path.write_text(
+        json.dumps(seed, ensure_ascii=False), encoding='utf-8',
+    )
+
+    def _noop_assert(*args, **kw):
+        return None
+
+    with patch.object(resolver, '_pending_path', return_value=str(pending_path)), \
+         patch('memory.fact_dedup.assert_cloudsave_writable', _noop_assert):
+        for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+            # 模拟"每轮 LLM 失败"——batch 用 disk 上当前的 pair (dead-letter 后会缩短)
+            current = json.loads(pending_path.read_text(encoding='utf-8'))
+            if not current:
+                break
+            await resolver._abump_dedup_attempts_and_dead_letter_locked(name, current)
+
+        remaining = json.loads(pending_path.read_text(encoding='utf-8'))
+        assert remaining == [], (
+            f"N 次失败后 batch pair 全部 dead-letter, 实际剩余: {remaining}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 4 — refine cluster dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_refine_pass_failure_fn_invoked_on_resolve_false():
+    """refine_pass：_resolve_cluster 返 False 时必须调 failure_fn (Site 4 兜底)。"""
+    from memory.refine import (
+        FailureFn,
+        MemoryRefineEngine,
+        REFINE_ENTITY_KEY,
+        REFINE_TYPE_KEY,
+    )
+
+    engine = MemoryRefineEngine(MagicMock())
+
+    # Mock _compute_clusters 返回一个 cluster
+    fake_cluster_member = {
+        'id': 'r_001',
+        'text': 'sample',
+        REFINE_TYPE_KEY: 'reflection',
+        REFINE_ENTITY_KEY: 'master',
+        'last_refine_at': None,
+        'last_refine_cluster_hash': None,
+    }
+    candidates_by_entity = {'master': [fake_cluster_member, dict(fake_cluster_member, id='r_002')]}
+
+    # Mock embedding service available + cluster compute
+    engine._service.is_disabled = MagicMock(return_value=False)
+    engine._service.is_available = MagicMock(return_value=True)
+    engine._service.model_id = MagicMock(return_value='mock_model')
+
+    # Force _compute_clusters to return our cluster
+    with patch.object(engine, '_compute_clusters', return_value=[candidates_by_entity['master']]), \
+         patch.object(engine, '_resolve_cluster', AsyncMock(return_value=False)):
+        captured_failures: list[tuple] = []
+
+        async def _failure_fn(cluster, cluster_hash):
+            captured_failures.append((cluster, cluster_hash))
+
+        apply_fn = AsyncMock()
+        result = await engine.refine_pass(
+            candidates_by_entity,
+            apply_fn=apply_fn,
+            scope_label='test/scope',
+            failure_fn=_failure_fn,
+        )
+
+    assert result['clusters_failed'] == 1
+    assert len(captured_failures) == 1, "_resolve_cluster 返 False 必须触发 failure_fn"
+    cluster_arg, hash_arg = captured_failures[0]
+    assert isinstance(hash_arg, str) and len(hash_arg) > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_persona_abump_refine_attempts_at_threshold_warns():
+    """PersonaManager._abump_refine_attempts: 第 N 次 bump 命中阈值 → WARN log。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.persona import PersonaManager
+    from memory.refine import REFINE_ENTITY_KEY, REFINE_TYPE_KEY
+
+    pm = PersonaManager()
+    name = 'neko_test_refine'
+
+    persona = {
+        'master': {
+            'facts': [
+                {'id': 'p_001', 'text': 'sample', 'refine_attempts': 0},
+            ]
+        },
+    }
+
+    async def _fake_ensure(_n):
+        return persona
+
+    saved_persona: list = []
+    async def _fake_save(_n, _persona):
+        saved_persona.append(_persona)
+
+    cluster = [
+        {
+            'id': 'p_001',
+            REFINE_TYPE_KEY: 'persona',
+            REFINE_ENTITY_KEY: 'master',
+        }
+    ]
+
+    with patch.object(pm, '_aensure_persona_locked', _fake_ensure), \
+         patch.object(pm, 'asave_persona', _fake_save):
+        for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+            await pm._abump_refine_attempts(name, cluster, 'hash_1')
+
+    # 最终 refine_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS
+    assert persona['master']['facts'][0]['refine_attempts'] == MEMORY_LIVENESS_MAX_ATTEMPTS
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Site 7 — outbox dead-letter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_outbox_pending_ops_counts_attempts(tmp_path):
+    """pending_ops 应顺带把 attempt 计数附在每条返回 record 上 (Site 7 基础)。"""
+    from memory.outbox import Outbox
+
+    outbox = Outbox()
+    name = 'neko_test_outbox'
+    path = tmp_path / 'outbox.ndjson'
+
+    with patch.object(outbox, '_outbox_path', return_value=str(path)):
+        op_id = outbox.append_pending(name, 'test_op', {'foo': 'bar'})
+        outbox.append_attempt(name, op_id)
+        outbox.append_attempt(name, op_id)
+
+        pending = outbox.pending_ops(name)
+        assert len(pending) == 1
+        assert pending[0]['op_id'] == op_id
+        assert pending[0]['_attempt_count'] == 2
+
+
+@pytest.mark.unit
+def test_outbox_done_clears_attempts(tmp_path):
+    """append_done 后该 op 出 pending list；attempt 计数无意义。"""
+    from memory.outbox import Outbox
+
+    outbox = Outbox()
+    name = 'neko_test_outbox_done'
+    path = tmp_path / 'outbox.ndjson'
+
+    with patch.object(outbox, '_outbox_path', return_value=str(path)):
+        op_id = outbox.append_pending(name, 'test_op', {})
+        outbox.append_attempt(name, op_id)
+        outbox.append_attempt(name, op_id)
+        outbox.append_done(name, op_id)
+
+        pending = outbox.pending_ops(name)
+        assert pending == []
+
+
+@pytest.mark.unit
+def test_outbox_compact_preserves_attempts_for_pending(tmp_path):
+    """compact 保留 still-pending op 的 attempt 行；done 的连同 attempt 一起丢。"""
+    from memory.outbox import Outbox
+
+    outbox = Outbox()
+    name = 'neko_test_outbox_compact'
+    path = tmp_path / 'outbox.ndjson'
+
+    with patch.object(outbox, '_outbox_path', return_value=str(path)):
+        # op1：pending + 2 attempts
+        op1 = outbox.append_pending(name, 'op_type', {'k': 1})
+        outbox.append_attempt(name, op1)
+        outbox.append_attempt(name, op1)
+        # op2：pending + 1 attempt + done
+        op2 = outbox.append_pending(name, 'op_type', {'k': 2})
+        outbox.append_attempt(name, op2)
+        outbox.append_done(name, op2)
+
+        dropped = outbox.compact(name)
+        # op2 pending + attempt + done = 3 行 dropped；op1 = pending + 2 attempts 留
+        assert dropped == 3
+
+        pending = outbox.pending_ops(name)
+        assert len(pending) == 1
+        assert pending[0]['op_id'] == op1
+        assert pending[0]['_attempt_count'] == 2, (
+            "compact 后 op1 的 attempt 计数应该还在"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_outbox_op_dead_letters_at_threshold(tmp_path):
+    """end-to-end: _run_outbox_op handler 累计失败 ≥ N → append_done dead-letter。"""
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.outbox import Outbox
+
+    outbox = Outbox()
+    name = 'neko_test_outbox_e2e'
+    path = tmp_path / 'outbox.ndjson'
+
+    with patch.object(outbox, '_outbox_path', return_value=str(path)):
+        op_id = outbox.append_pending(name, 'poison_op', {'data': 'bad'})
+
+    # Register a handler that always raises
+    async def _poison_handler(_n, _p):
+        raise RuntimeError("simulated poison payload — handler always raises")
+
+    original_outbox = memory_server.outbox
+    original_handlers = memory_server._OUTBOX_HANDLERS.copy()
+    try:
+        memory_server.outbox = outbox
+        memory_server._OUTBOX_HANDLERS['poison_op'] = _poison_handler
+
+        with patch.object(outbox, '_outbox_path', return_value=str(path)):
+            # 跑 MEMORY_LIVENESS_MAX_ATTEMPTS 次模拟"每次重启都重放该 op"
+            for round_idx in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+                pending = outbox.pending_ops(name)
+                if not pending:
+                    break
+                op = pending[0]
+                await memory_server._run_outbox_op(name, op)
+
+            # 第 N 次 (i.e. attempt count 达 N) 后该 op 必须 append_done dead-letter
+            pending_after = outbox.pending_ops(name)
+            assert pending_after == [], (
+                f"达 {MEMORY_LIVENESS_MAX_ATTEMPTS} 次失败后该 op 应 dead-letter 出 pending, "
+                f"实际剩 {pending_after}"
+            )
+    finally:
+        memory_server.outbox = original_outbox
+        memory_server._OUTBOX_HANDLERS.clear()
+        memory_server._OUTBOX_HANDLERS.update(original_handlers)

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -567,6 +567,64 @@ async def test_run_outbox_op_dead_letters_at_threshold(tmp_path):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_run_outbox_op_short_circuits_when_already_dead_letter(tmp_path):
+    """CodeRabbit P1 regression：进门时 ``_attempt_count >= MAX`` → 跳 handler 直接 append_done。
+
+    Setup：op 在磁盘上已经累计了 ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 条 attempt
+    行（边缘场景：上轮 dead-letter ``aappend_done`` 失败留下的 stuck pending）。
+    断言：handler **不**被调用，直接 ``aappend_done`` 补 done。否则非幂等
+    handler 会被毒 op 重复执行造成副作用。
+    """
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.outbox import Outbox
+
+    outbox = Outbox()
+    name = 'neko_test_outbox_short_circuit'
+    path = tmp_path / 'outbox.ndjson'
+
+    with patch.object(outbox, '_outbox_path', return_value=str(path)):
+        outbox.append_pending(name, 'side_effect_op', {})
+        op_id = outbox.pending_ops(name)[0]['op_id']
+        # 把 attempt 推满 → 模拟上轮 dead-letter append_done 失败的 stuck state
+        for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS):
+            outbox.append_attempt(name, op_id)
+
+    handler_called = []
+
+    async def _side_effect_handler(_n, _p):
+        handler_called.append(True)
+        raise RuntimeError("不应该被调用：op 已达 dead-letter 阈值")
+
+    original_outbox = memory_server.outbox
+    original_handlers = memory_server._OUTBOX_HANDLERS.copy()
+    try:
+        memory_server.outbox = outbox
+        memory_server._OUTBOX_HANDLERS['side_effect_op'] = _side_effect_handler
+
+        with patch.object(outbox, '_outbox_path', return_value=str(path)):
+            pending = outbox.pending_ops(name)
+            assert len(pending) == 1
+            assert pending[0]['_attempt_count'] == MEMORY_LIVENESS_MAX_ATTEMPTS
+            await memory_server._run_outbox_op(name, pending[0])
+
+            pending_after = outbox.pending_ops(name)
+
+        assert handler_called == [], (
+            f"已达 dead-letter 阈值的 op 不该再跑 handler. 调用次数: {len(handler_called)}"
+        )
+        assert pending_after == [], (
+            f"短路 dead-letter 后该 op 必须出 pending（append_done 已补）, "
+            f"实际剩 {pending_after}"
+        )
+    finally:
+        memory_server.outbox = original_outbox
+        memory_server._OUTBOX_HANDLERS.clear()
+        memory_server._OUTBOX_HANDLERS.update(original_handlers)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_run_outbox_op_attempt_persist_failure_keeps_pending(tmp_path):
     """Codex P1 regression：``aappend_attempt`` 抛异常时不应触发 dead-letter。
 


### PR DESCRIPTION
## Summary

- 实施 issue [#1409](https://github.com/Project-N-E-K-O/N.E.K.O/issues/1409) 的方案 A：所有 memory 后台路径里"同一 input + 反复 LLM 失败 + 无 attempt counter → 永久卡死"的 7 处缺口统一加 ``MEMORY_LIVENESS_MAX_ATTEMPTS=5`` per-input attempt counter，达上限强推 progress marker / 丢 dead-letter
- 复用 ``_bump_fact_recheck_attempts`` (schema v1→v2 重判) 既有 dead-letter pattern；新加常量 `MEMORY_LIVENESS_MAX_ATTEMPTS`，跟 `MEMORY_RECHECK_MAX_ATTEMPTS` 同口径=5
- 不动已经有保护的两条参考实现（`_bump_fact_recheck_attempts` / `_apromote_with_merge` blocked dead-letter）

## 修复 site 一览

| Site | 位置 | 卡死载体 | Counter 落地 | dead-letter 动作 |
|---|---|---|---|---|
| 0a | `_signal_check_one` (path A) | `last_check_ts` cursor (in-memory) | `state['a_extract_failures']` (in-memory) | 强推 cursor 到 now |
| 0b | `_run_path_b` (path B) | `last_b_check_ts` cursor (in-memory) | `state['b_extract_failures']` (in-memory) | 强推 cursor 到 `last_fetched_ts` |
| 1 | `_periodic_rebuttal_loop` | `CURSOR_REBUTTAL_CHECKED_UNTIL` (落盘) | `_rebuttal_failures` (in-memory) | 强推 cursor 到 now |
| 2 | `PersonaManager.resolve_corrections` | corrections queue 队头 | 每条 `resolve_attempts` 字段（落盘） | 从 queue 丢 dead-letter |
| 3 | `FactDedupResolver.aresolve` | dedup pending queue 队头 | 每条 `resolve_attempts` 字段（落盘） | 从 queue 丢 dead-letter |
| 4 | refine cluster (persona + reflection) | cluster_hash starvation 第一名 | entry 上 `refine_attempts` 字段（落盘） | 下次 cluster gather 过滤掉 |
| 7 | outbox `_run_outbox_op` | op payload 完全冻结 + 重启重跑无上限 | outbox.ndjson 新 record type `status='attempt'` (落盘) | `append_done` 视为 dead-letter，顺带解锁 compact 永久阻塞 |

In-memory counter（0a/0b/1）的取舍：cursor 本身落盘但 counter 不落盘是有意的"软兜底"——重启后再试 N 次再 dead-letter，避免错把短暂 transient 失败永久放弃。落盘 counter（2/3/4/7）跟它们的 cursor 一起持久化，否则重启清零让 dead-letter 失效。

## 对偶性

- Site 0a / 0b：path A/B 完全对偶（in-memory state dict + 两个对偶 helper）
- Site 2 / 3：queue head + per-item attempt 字段对偶
- Site 4：persona / reflection `_abump_refine_attempts` + `apply_refine_actions` 清 counter 对偶
- 所有 site 均加成功路径清 counter（避免内存 / 磁盘累积 stale key）

## 不做（issue 共识收口）

- 不改 `_allm_call_with_retries` 本身（单调用 retry 已够，本 PR 处理的是"窗口/队头级"liveness）
- 不动已经 dead-letter 保护的 `arecheck_one_legacy_*` / `_apromote_with_merge`
- 不收 `recent.review_history` / `synthesize_reflections`（input 自然演进，不属本类）
- 不收 embedding worker（本地服务，OOM 罕见且 scope 不同）

## Test plan

- [x] 新增 `tests/unit/test_memory_liveness_dead_letter.py` 17 条，每 site 测：N-1 次不动 marker、N 次触发 dead-letter、成功路径清 counter（全部 PASS）
- [x] 现有 109 条 memory/signal/path-b/evidence/manager_locks 单测全部 PASS
- [x] 487 条 memory 关键字单测无回归（剩余 12 个 fail 全部为 pre-existing，与本 PR 无关，已 `git stash` 验证）
- [x] `scripts/check_async_blocking.py` / `scripts/check_i18n.py` 绿
- [ ] 集成/手动观察：production 实际触发 dead-letter WARN log 后下一轮 fact pipeline 恢复正常

Closes #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 多条后台记忆链路增加活性/死信兜底，避免反复失败导致流程（outbox、rebuttal、信号抽取、refine、去重、persona 修正等）永久卡住。
  * outbox 对失败尝试的持久化与短路逻辑改进，区分短暂和已持久化失败，防止误触发死信。

* **New Features**
  * 引入内存失败计数与阈值驱动的死信/进度推进与清理机制。
  * refine 路径新增失败回调以累积并过滤重复失败候选。

* **Tests**
  * 新增单元测试覆盖失败计数、阈值触发、死信路径及持久化异常场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->