### PR TITLE
fix(memory): hybrid_recall log 把 passed 数挂在 thresh 字段，误导调参

### DIFF
--- a/memory/hybrid_recall.py
+++ b/memory/hybrid_recall.py
@@ -545,13 +545,17 @@ async def hybrid_recall(
 
     elapsed_ms = (time.time() - start) * 1000.0
     # union pool size for observability — bm25 pool is the superset.
+    # `passed` = items surviving the per-side threshold; `thresh` is the
+    # cutoff constant. 历史上这条 log 把 `passed` 数挂在 `(>thresh %d)`
+    # 字段里，被读成"阈值=N"误导调参，所以拆成 passed + thresh 两段。
     logger.info(
-        "[hybrid_recall] %s: pool bm25=%d emb=%d | scored bm25=%d (>thresh %d) "
-        "emb=%d (>thresh %d) | fused=%d | %.0fms",
+        "[hybrid_recall] %s: pool bm25=%d emb=%d | "
+        "scored bm25=%d (passed %d, thresh=%.2f) "
+        "emb=%d (passed %d, thresh=%.2f) | fused=%d | %.0fms",
         lanlan_name,
         len(bm25_pool), len(embedding_pool),
-        len(bm25_scored), len(bm25_top),
-        len(cosine_scored), len(cosine_top),
+        len(bm25_scored), len(bm25_top), HYBRID_RECALL_BM25_THRESHOLD,
+        len(cosine_scored), len(cosine_top), HYBRID_RECALL_COSINE_THRESHOLD,
         len(results), elapsed_ms,
     )
     return {


### PR DESCRIPTION
## Summary

`memory/hybrid_recall.py` 末尾那条总览 log 把 \`(>thresh %d)\` 字段误填成 \`len(bm25_top)\` / \`len(cosine_top)\` —— 也就是**过阈值后剩下的数量**，不是阈值本身。

线上看到 \`scored bm25=0 (>thresh 0)\` 会被自然读成"阈值=0，但 0 篇打分了"，实际语义是"打分剩 0 篇，过阈值的也是 0 篇"，真正的常量 \`HYBRID_RECALL_BM25_THRESHOLD=0.1\` 完全没在 log 里出现，依赖这条 log 调参的人会被误导。

## Fix

拆成 \`passed\` + \`thresh\` 两段，过阈值数和阈值常量都显式标出来：

\`\`\`
scored bm25=72 (passed 5, thresh=0.10) emb=43 (passed 4, thresh=4.00)
\`\`\`

常量已经在文件顶部 \`from config import (...)\` 进来，零新依赖。

## Test plan

- [x] grep \`tests/\` 没有 pin 这条 log 格式
- [x] \`uv run pytest tests/unit -k hybrid_recall\` 没回归（如有 memory recall 单测）
- [ ] 等下一次实际 \`hybrid_recall\` 调用，确认新格式正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 改进了混合召回功能的日志输出。现在日志中将分别展示各个检索方法的结果数与相应阈值，并新增融合结果数量与处理耗时的记录，便于更全面地了解检索性能指标。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->