### PR TITLE
fix(memory): Stage-2 target_type 修正 log 合并去重，按 (猜→实际) 计数

### DIFF
--- a/memory/facts.py
+++ b/memory/facts.py
@@ -922,8 +922,12 @@ class FactStore:
             if obs['target_type'] != ttype:
                 # LLM 说的 target_type 与实际不符 → 以实际为准（修正）。
                 # 不在 loop 里 log，循环结束统一汇总输出。
-                target_type_fixes[(ttype, obs['target_type'])] = (
-                    target_type_fixes.get((ttype, obs['target_type']), 0) + 1
+                # ttype 来自 LLM JSON，理论上是 str/None；hallucinate 成
+                # list/dict 时直接进 dict key 会 TypeError 把整个 Stage-2 拖崩
+                # （codex review #1414）。用 repr 把非 hashable 值兜成 str。
+                key_ttype = ttype if ttype is None or isinstance(ttype, str) else repr(ttype)
+                target_type_fixes[(key_ttype, obs['target_type'])] = (
+                    target_type_fixes.get((key_ttype, obs['target_type']), 0) + 1
                 )
             validated.append({
                 'source_fact_id': s.get('source_fact_id'),

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -883,6 +883,12 @@ class FactStore:
         # source 落到 evidence 计数器更新里。
         new_fact_ids = {f['id'] for f in new_facts if f.get('id')}
         validated: list[dict] = []
+        # 单次 Stage-2 调用可能返回 N 条 signal 都对同一 reflection 报告
+        # target_type 不一致——LLM 在猜命名规范（"persona.relationship"
+        # vs "persona" vs "persona.relationship.prom"），看到啥前缀就抄啥。
+        # 兜底逻辑一直按设计在跑，但每条一行 log 会刷屏；按 (LLM值→实际值)
+        # 去重计数，循环结束后一行汇总，方便看出"哪种猜法在被反复纠"。
+        target_type_fixes: dict[tuple[str | None, str], int] = {}
         for s in raw_signals:
             if not isinstance(s, dict):
                 continue
@@ -914,11 +920,10 @@ class FactStore:
                     continue
             obs = id_to_obs[candidate_full]
             if obs['target_type'] != ttype:
-                # LLM 说的 target_type 与实际不符 → 以实际为准（修正），
-                # 但仍记录原值便于 debug
-                logger.info(
-                    f"[FactStore] {lanlan_name}: Stage-2 target_type 修正 "
-                    f"{ttype}→{obs['target_type']} for {candidate_full}"
+                # LLM 说的 target_type 与实际不符 → 以实际为准（修正）。
+                # 不在 loop 里 log，循环结束统一汇总输出。
+                target_type_fixes[(ttype, obs['target_type'])] = (
+                    target_type_fixes.get((ttype, obs['target_type']), 0) + 1
                 )
             validated.append({
                 'source_fact_id': s.get('source_fact_id'),
@@ -929,6 +934,16 @@ class FactStore:
                 'signal': signal,
                 'reason': s.get('reason', ''),
             })
+        if target_type_fixes:
+            summary = ", ".join(
+                f"{src!r}→{dst}×{n}" if n > 1 else f"{src!r}→{dst}"
+                for (src, dst), n in sorted(
+                    target_type_fixes.items(), key=lambda kv: -kv[1]
+                )
+            )
+            logger.info(
+                f"[FactStore] {lanlan_name}: Stage-2 target_type 修正 {summary}"
+            )
         return validated
 
     async def aextract_facts_and_detect_signals(


### PR DESCRIPTION
## Summary

Stage-2 LLM 一次调用经常返回 N 条 signal 都对同一 reflection 报告 \`target_type\` 不一致——LLM 在猜命名规范（看到 id 是 \`persona.relationship.prom_ref_xxx\` 就抄前缀，每次猜的颗粒度不同：\`persona\` / \`persona.relationship\` / \`persona.relationship.prom\` 都见过）。

[memory/facts.py:919-922](memory/facts.py) 的兜底逻辑一直按设计在跑（**以 obs 实际 type 为准 append 到 validated，不丢数据**），但每条 signal 单独一行 log 在 review 高峰会刷屏：

\`\`\`
[FactStore] 悠怡: Stage-2 target_type 修正 persona.relationship→persona for persona.relationship.prom_ref_3cb5cd1e075e053c
[FactStore] 悠怡: Stage-2 target_type 修正 persona.relationship→persona for persona.relationship.prom_ref_3cb5cd1e075e053c
[FactStore] 悠怡: Stage-2 target_type 修正 persona.relationship→persona for persona.relationship.prom_ref_3cb5cd1e075e053c
\`\`\`

## Fix

按 \`(LLM 报的 → obs 实际)\` 去重计数，循环结束统一一行汇总：

\`\`\`
[FactStore] 悠怡: Stage-2 target_type 修正 'persona.relationship'→persona×3
\`\`\`

多种猜法并存时也能一行表达：

\`\`\`
[FactStore] 悠怡: Stage-2 target_type 修正 'persona.relationship'→persona×3, 'persona.relationship.prom'→reflection
\`\`\`

按计数降序排，方便看出"哪种猜法在被反复纠"。

## 等价性

- 兜底依旧以 \`obs['target_type']\` 为准 append 到 \`validated\`，输出**完全等价**
- 丢失"对哪个具体 target_id"的信息——但那对调"为啥 LLM 猜错"没用，真正的可观测信号是 \"(猜法→实际类型)\" 对，这版反而更聚焦
- \`target_full_id\` 仍然进 \`validated\` 不丢

## Test plan

- [x] grep \`tests/\` 没有 pin 这条 log 格式
- [x] \`uv run pytest tests/unit -k stage2 -k signal\` 没回归
- [ ] 下一次 \`review\` 触发时确认新格式

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 日志输出由逐条记录改为按不一致类型累计统计并在循环结束时输出汇总行，提高日志清晰度与可读性；其余校验与验证追加逻辑保持不变。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->