### PR TITLE
fix(frontend): spatial audio 加 pan 上限，防止贴边变纯单声道

### DIFF
--- a/static/app-spatial-audio.js
+++ b/static/app-spatial-audio.js
@@ -4,7 +4,7 @@
  * 听者锚点：主屏中心（屏幕坐标系）。
  * 声源锚点：当前模型中心（屏幕坐标系）。取不到模型 bounds 时回退到 Pet 窗口中心。
  *
- * Pan：dx / (主屏宽度 / 2)，clamp 到 [-1, 1]
+ * Pan：dx / (主屏宽度 / 2)，clamp 到 [-SPATIAL_AUDIO_MAX_PAN, +SPATIAL_AUDIO_MAX_PAN]（防止完全单声道）
  * Gain：以主屏为参考圆，主屏内全音量；越过主屏后线性衰减，floor = SPATIAL_AUDIO_MIN_GAIN
  *
  * 更新时机：
@@ -138,7 +138,8 @@
 
         var dx = sourceCenterX - primaryCenterX;
         var dy = sourceCenterY - primaryCenterY;
-        var pan = clamp(dx / refDist, -1, 1);
+        var maxPan = Number.isFinite(Number(C.SPATIAL_AUDIO_MAX_PAN)) ? Number(C.SPATIAL_AUDIO_MAX_PAN) : 1;
+        var pan = clamp(dx / refDist, -maxPan, maxPan);
 
         var dist = Math.sqrt(dx * dx + dy * dy);
         var nd = dist / refDist;

--- a/static/app-state.js
+++ b/static/app-state.js
@@ -14,6 +14,7 @@
         DEFAULT_SPEAKER_VOLUME: 100,         // 扬声器默认音量
         DEFAULT_SPATIAL_AUDIO_ENABLED: true, // 空间音频默认开启
         SPATIAL_AUDIO_MIN_GAIN: 0.4,         // 副屏远端最低音量保底（防止猫娘飞远后听不见）
+        SPATIAL_AUDIO_MAX_PAN: 0.85,         // pan 绝对值上限（防止完全单声道，另一边留 ~12% 信号）
         SPATIAL_AUDIO_FALLOFF_RATE: 0.35,    // 超出主屏后每个 refDist 衰减比例
         SPATIAL_AUDIO_RAMP_SECONDS: 0.12,    // pan/gain 平滑过渡时长，避免突变 click
         SPATIAL_AUDIO_POLL_MS: 500,          // 位置轮询周期（兜底，事件驱动为主）


### PR DESCRIPTION
## Summary
- `pan` 之前 clamp 到 `[-1, 1]`，StereoPannerNode 在边界处完全单声道，猫娘拖到屏幕一侧时另一边耳朵彻底没声音。
- 加 `SPATIAL_AUDIO_MAX_PAN = 0.85`，[computePanAndGain](static/app-spatial-audio.js:141) 把 clamp 收紧到 `±0.85`，另一边永远留约 12%（单声道源）/15%（立体声源）信号。
- 距离衰减 / floor gain 逻辑不动，只动方向 clamp。

## Test plan
- [ ] index.html 单窗口：猫娘拖到主屏最左 / 最右，确认两边耳机/喇叭都仍能听到声音
- [ ] 多屏 Electron：猫娘拖到副屏，主屏侧不再静音
- [ ] 关闭 spatial audio 开关后 passthrough 不受影响（pan=0, gain=1 分支未动）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 功能改进

* 更新了空间音频平衡范围的配置方式，增强了系统的适应性和灵活性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->