### PR TITLE
feat(proactive): mini-game 邀请 cooldown 按 accept/decline 拆 (2h/5h)

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1612,13 +1612,20 @@ MINI_GAME_INVITE_TRIGGER_PROBABILITY = 0.12
 - 取值约定：[0.0, 1.0]，0.0=禁用（等价于 ENABLED=False），1.0=每次都邀请。
 - 上游：random.random() < 此值 → 命中 → 走邀请短路。"""
 
-MINI_GAME_INVITE_COOLDOWN_SECONDS = 3600
-"""一次邀请被回应后的最小静默秒数（默认 1h）。
+MINI_GAME_INVITE_COOLDOWN_AFTER_ACCEPT_SECONDS = 2 * 3600
+"""accept 后的最小静默秒数（默认 2h）。
 - 配合 MINI_GAME_INVITE_COOLDOWN_CHATS：两条件都跨过才允许下次掷骰。
-- 上游：_mini_game_invite_in_cooldown 时间侧判定。
-- 历史：原 24h，PR follow-up #1 改成 1h —— 24h 太长、用户日常重启或重新打开
-  app 都可能跨进过该窗口又被首次打开计数器骗回 force-trigger，体感邀请密度
-  反而抖动；1h 是「一次会话内不重复打扰」的合理平衡。"""
+- 上游：_mini_game_invite_in_cooldown 时间侧判定（state.last_response_choice='accept'）。
+- 历史：原统一 1h（PR follow-up #1 从 24h 降下来），后再拆成 accept/decline 双
+  阈值——accept 体感"刚玩完一局"短一些（2h），decline 表达"不感兴趣"延长到 5h
+  避免短期复扰；之间没有 chats 门差异，10 条仍共用。"""
+
+MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS = 5 * 3600
+"""decline 后的最小静默秒数（默认 5h）。
+- 配合 MINI_GAME_INVITE_COOLDOWN_CHATS：两条件都跨过才允许下次掷骰。
+- 上游：_mini_game_invite_in_cooldown 时间侧判定（state.last_response_choice='decline'）。
+- 比 accept 长是因为 decline 是明确"不想玩"信号，短期复扰体感差；5h 跨过一般
+  的"刚拒绝完几分钟又问"窗口，又不至于一整天彻底沉默。"""
 
 MINI_GAME_INVITE_NEW_USER_FORCE_AT = 4
 """新用户在第 N 次「成功投递的主动搭话」时强制触发 mini-game 邀请。
@@ -1640,7 +1647,8 @@ MINI_GAME_INVITE_AVAILABLE_GAMES: tuple[str, ...] = ("soccer",)
 
 MINI_GAME_INVITE_COOLDOWN_CHATS = 10
 """一次邀请被回应后，需要再经过的"成功投递的主动搭话"次数。
-- 与 MINI_GAME_INVITE_COOLDOWN_SECONDS 同时满足才解禁；任一不满足都继续抑制。
+- 与 MINI_GAME_INVITE_COOLDOWN_AFTER_{ACCEPT,DECLINE}_SECONDS 同时满足才解禁；
+  任一不满足都继续抑制。chats 门 accept/decline 共用，不按 choice 拆。
 - 上游：_mini_game_invite_in_cooldown 计数侧判定。"""
 
 MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS = 5 * 60
@@ -1987,7 +1995,8 @@ __all__ = [
     'PROACTIVE_CHAT_HISTORY_MAX',
     'MINI_GAME_INVITE_ENABLED',
     'MINI_GAME_INVITE_TRIGGER_PROBABILITY',
-    'MINI_GAME_INVITE_COOLDOWN_SECONDS',
+    'MINI_GAME_INVITE_COOLDOWN_AFTER_ACCEPT_SECONDS',
+    'MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS',
     'MINI_GAME_INVITE_COOLDOWN_CHATS',
     'MINI_GAME_INVITE_NEW_USER_FORCE_AT',
     'MINI_GAME_INVITE_AVAILABLE_GAMES',

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -81,7 +81,8 @@ from config import (
     MINI_GAME_INVITE_ENABLED,
     MINI_GAME_INVITE_FORCE_GAME_TYPE,
     MINI_GAME_INVITE_TRIGGER_PROBABILITY,
-    MINI_GAME_INVITE_COOLDOWN_SECONDS,
+    MINI_GAME_INVITE_COOLDOWN_AFTER_ACCEPT_SECONDS,
+    MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS,
     MINI_GAME_INVITE_COOLDOWN_CHATS,
     MINI_GAME_INVITE_NEW_USER_FORCE_AT,
     MINI_GAME_INVITE_AVAILABLE_GAMES,
@@ -1262,18 +1263,22 @@ _proactive_chat_history: dict[str, deque] = {}
 # {lanlan_name: {'delivered_at': float|None,
 #                'responded_at': float|None,
 #                'chats_since_response': int,
-#                'last_game_type': str|None}}
+#                'last_game_type': str|None,
+#                'last_response_choice': 'accept'|'decline'|None}}
 # - delivered_at: 上次成功投递邀请的时间戳。None=从未发过。
 # - responded_at: 投递后被用户回应（任何用户消息时间戳 > delivered_at）的时间。
 #   pending（delivered_at!=None and responded_at=None）期间一律抑制掷骰，避免
 #   邀请挂着不响应又再发第二次。
 # - chats_since_response: responded_at 设上后成功投递的"普通主动搭话"次数。
-#   两条件（>= COOLDOWN_SECONDS 且 >= COOLDOWN_CHATS）都跨过才允许下次掷骰。
-#   冷却跨 game_type 共享——每角色一个全局冷却，一次邀请 → 1h 内全部 mini-game
+#   两条件（time-by-choice 且 >= COOLDOWN_CHATS）都跨过才允许下次掷骰。
+#   冷却跨 game_type 共享——每角色一个全局冷却，一次邀请 → 冷却窗内全部 mini-game
 #   静默；spec 没说邀请要密集，多游戏只是丰富选项不是加密。
 # - last_game_type: 上次邀请发的是哪个游戏（从 MINI_GAME_INVITE_AVAILABLE_GAMES
 #   里 random.choice 出来的）；用于 PR-B 按钮判断"打开哪个游戏"。
-# 进程内 dict，重启清零——1h+10 chats 是软冷却，重启后多发一次邀请的代价远小
+# - last_response_choice: 上次回应是 accept 还是 decline；用于 cooldown 函数按
+#   choice 取不同 SECONDS 阈值（accept=2h、decline=5h）。later/隐式 dismiss 走
+#   reset 路径不会落到这里。None = 从未回应过（pending or 全新）。
+# 进程内 dict，重启清零——时间+10 chats 是软冷却，重启后多发一次邀请的代价远小
 # 于持久化存储引依赖的代价；与 _proactive_chat_history 同样是内存。
 _mini_game_invite_state: dict[str, dict[str, Any]] = {}
 
@@ -1835,7 +1840,9 @@ def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
 # restricted_screen_only 几道门之后调 _maybe_deliver_mini_game_invite。命中
 # 即静态 i18n 模板 → feed_tts_chunk + finish_proactive_delivery 直投递；不走
 # Phase 1/2 LLM。冷却语义：一次邀请被回应后，必须同时跨过
-#   ``time.time() - responded_at >= MINI_GAME_INVITE_COOLDOWN_SECONDS``
+#   ``time.time() - responded_at >= threshold_by_choice``
+#     其中 threshold = MINI_GAME_INVITE_COOLDOWN_AFTER_ACCEPT_SECONDS (2h) 若
+#     last_response_choice='accept'，否则 ..._AFTER_DECLINE_SECONDS (5h)；
 # 与
 #   ``chats_since_response >= MINI_GAME_INVITE_COOLDOWN_CHATS``
 # 才允许下次掷骰。pending（投递了但还没被回应）期间一律抑制，避免邀请挂着
@@ -1856,6 +1863,10 @@ def _mini_game_invite_get_state(lanlan_name: str) -> dict[str, Any]:
             # D2「回头再说」短期抑制：reset 后不允许下一次 proactive 立刻又掷骰。
             # _in_cooldown 多查一道这个 gate。秒级 epoch；None = 不抑制。
             'suppressed_until': None,
+            # accept/decline 走不同 cooldown 阈值。later/隐式 dismiss reset 时
+            # 清回 None。pending 期间也是 None；cooldown 函数只在 responded_at
+            # !=None 时读它。
+            'last_response_choice': None,
         }
         _mini_game_invite_state[lanlan_name] = state
     return state
@@ -2037,8 +2048,11 @@ def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:
     覆盖：
       - D2「回头再说」短期抑制（suppressed_until > now）→ True
       - pending（投递了但 responded_at=None）→ True
-      - 已回应但 1h 或 10 chats 任一未跨过 → True
+      - 已回应但 时间(by choice) 或 10 chats 任一未跨过 → True
       - 从未投递 / 已完整跨过两道 → False
+
+    时间阈值按 last_response_choice 分：accept=2h、decline=5h。fallback 取 accept
+    阈值（短），避免遗留 state 没该字段时把用户卡到长 cooldown。
     """
     state = _mini_game_invite_state.get(lanlan_name)
     if not state:
@@ -2051,8 +2065,12 @@ def _mini_game_invite_in_cooldown(lanlan_name: str) -> bool:
     if state['responded_at'] is None:
         return True
     elapsed = time.time() - state['responded_at']
+    if state.get('last_response_choice') == 'decline':
+        time_threshold = MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS
+    else:
+        time_threshold = MINI_GAME_INVITE_COOLDOWN_AFTER_ACCEPT_SECONDS
     return (
-        elapsed < MINI_GAME_INVITE_COOLDOWN_SECONDS
+        elapsed < time_threshold
         or state['chats_since_response'] < MINI_GAME_INVITE_COOLDOWN_CHATS
     )
 
@@ -2068,6 +2086,7 @@ def _mini_game_invite_record_delivered(lanlan_name: str, session_id: str) -> Non
     state['responded_at'] = None
     state['chats_since_response'] = 0
     state['pending_session_id'] = session_id
+    state['last_response_choice'] = None
     # 新邀请投递清掉 D2 的 short-suppression：本来是「上次回头再说」的窗口，
     # 既然现在又投了新邀请说明那个窗口已过期，没必要保留。
     state['suppressed_until'] = None
@@ -6482,8 +6501,8 @@ def _apply_mini_game_invite_choice(
     """处理 mini-game 邀请的三选项 state 转换。返回结构化结果给 endpoint /
     keyword matcher 共用。
 
-    - accept：mark responded（启动 1h+10 chats 冷却）+ 返回 game_url
-    - decline：mark responded（同上冷却，但不开游戏）
+    - accept：mark responded（启动 2h+10 chats 冷却）+ 返回 game_url
+    - decline：mark responded（启动 5h+10 chats 冷却，但不开游戏）
     - later (D2)：reset state（delivered_at=None，让 force-first / 普通 10% 都
       恢复正常）+ 加 ``suppressed_until = now + 5min`` 防止下一次 proactive
       立刻又掷骰
@@ -6500,6 +6519,7 @@ def _apply_mini_game_invite_choice(
     if choice == 'accept':
         state['responded_at'] = now
         state['chats_since_response'] = 0
+        state['last_response_choice'] = 'accept'
         # session_id 既进 game_url query，又作为 result 顶层字段返回——keyword 路径
         # core.py 要把它放进 mini_game_launch WS payload，前端 dedupe 才能跨路径
         # 共享 key（codex P2 review 指出：缺这个 dedupe 就失效，同 invite 多路径
@@ -6535,6 +6555,7 @@ def _apply_mini_game_invite_choice(
         decline_session_id = state.get('pending_session_id') or ''
         state['responded_at'] = now
         state['chats_since_response'] = 0
+        state['last_response_choice'] = 'decline'
         logger.info(
             "[%s] mini-game invite declined via %s; cooldown started",
             lanlan_name, source,
@@ -6549,6 +6570,7 @@ def _apply_mini_game_invite_choice(
         state['responded_at'] = None
         state['chats_since_response'] = 0
         state['pending_session_id'] = None
+        state['last_response_choice'] = None
         state['suppressed_until'] = now + MINI_GAME_INVITE_LATER_SUPPRESS_SECONDS
         logger.info(
             "[%s] mini-game invite deferred via %s; suppressed for %.0fs",

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -213,6 +213,21 @@ def test_in_cooldown_decline_releases_past_decline_threshold():
     assert sr._mini_game_invite_in_cooldown(LANLAN) is False
 
 
+def test_in_cooldown_legacy_state_falls_back_to_accept_threshold():
+    """last_response_choice 缺失 / None → 走 accept (2h) 阈值，不会被无端拉到 5h。
+
+    pin 住「遗留 state（升级前已有 responded_at 但没 last_response_choice 字段）
+    现网生效后不会因为 fallback 选 decline 阈值而把已经过了 2h 的用户继续卡 3h」
+    的契约。如果未来 fallback 改成 decline，这条会红。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    long_ago = time.time() - 3 * 3600
+    state['delivered_at'] = long_ago
+    state['responded_at'] = long_ago
+    state['chats_since_response'] = sr.MINI_GAME_INVITE_COOLDOWN_CHATS
+    state['last_response_choice'] = None
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # _mini_game_invite_advance_response
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_mini_game_invite.py
+++ b/tests/unit/test_mini_game_invite.py
@@ -136,7 +136,7 @@ def test_in_cooldown_true_when_pending():
 
 
 def test_in_cooldown_true_when_responded_within_24h_and_under_10_chats():
-    """已回应但 24h 没到 + 10 次没到 → cooldown。"""
+    """已回应但时间没到 + 10 次没到 → cooldown。"""
     state = sr._mini_game_invite_get_state(LANLAN)
     state['delivered_at'] = time.time() - 60
     state['responded_at'] = time.time() - 60
@@ -145,16 +145,20 @@ def test_in_cooldown_true_when_responded_within_24h_and_under_10_chats():
 
 
 def test_in_cooldown_true_when_only_time_elapsed_chats_short():
-    """24h 已过但 chats 没到 10 次 → 仍 cooldown（AND 语义）。"""
+    """时间阈值已过但 chats 没到 10 次 → 仍 cooldown（AND 语义）。
+
+    用 DECLINE 阈值的 offset 保证不论走 accept(2h) 还是 decline(5h) fallback 都已超时。
+    """
     state = sr._mini_game_invite_get_state(LANLAN)
-    state['delivered_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
-    state['responded_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
+    long_ago = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS - 100
+    state['delivered_at'] = long_ago
+    state['responded_at'] = long_ago
     state['chats_since_response'] = 3
     assert sr._mini_game_invite_in_cooldown(LANLAN) is True
 
 
 def test_in_cooldown_true_when_only_chats_done_time_short():
-    """chats 跨过 10 但 24h 没到 → 仍 cooldown（AND 语义）。"""
+    """chats 跨过 10 但时间没到 → 仍 cooldown（AND 语义）。"""
     state = sr._mini_game_invite_get_state(LANLAN)
     state['delivered_at'] = time.time() - 600
     state['responded_at'] = time.time() - 600
@@ -163,11 +167,49 @@ def test_in_cooldown_true_when_only_chats_done_time_short():
 
 
 def test_in_cooldown_false_when_both_thresholds_passed():
-    """24h 和 10 chats 都过了 → 解禁，下次掷骰。"""
+    """时间阈值和 10 chats 都过了 → 解禁，下次掷骰。
+
+    用 DECLINE 阈值确保 accept/decline 任一阈值都超过。"""
     state = sr._mini_game_invite_get_state(LANLAN)
-    state['delivered_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
-    state['responded_at'] = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_SECONDS - 100
+    long_ago = time.time() - sr.MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS - 100
+    state['delivered_at'] = long_ago
+    state['responded_at'] = long_ago
     state['chats_since_response'] = sr.MINI_GAME_INVITE_COOLDOWN_CHATS
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
+
+
+def test_in_cooldown_accept_uses_2h_threshold():
+    """accept 后 elapsed=3h 且 chats 够 → 解禁（accept 阈值 2h）。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    long_ago = time.time() - 3 * 3600
+    state['delivered_at'] = long_ago
+    state['responded_at'] = long_ago
+    state['chats_since_response'] = sr.MINI_GAME_INVITE_COOLDOWN_CHATS
+    state['last_response_choice'] = 'accept'
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is False
+
+
+def test_in_cooldown_decline_holds_past_accept_threshold():
+    """decline 后 elapsed=3h（>accept 但 <decline）+ chats 够 → 仍 cooldown。
+
+    防回归：拒绝必须比 accept 锁更久，避免短期复扰。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    long_ago = time.time() - 3 * 3600
+    state['delivered_at'] = long_ago
+    state['responded_at'] = long_ago
+    state['chats_since_response'] = sr.MINI_GAME_INVITE_COOLDOWN_CHATS
+    state['last_response_choice'] = 'decline'
+    assert sr._mini_game_invite_in_cooldown(LANLAN) is True
+
+
+def test_in_cooldown_decline_releases_past_decline_threshold():
+    """decline 后 elapsed=6h（>decline 5h）+ chats 够 → 解禁。"""
+    state = sr._mini_game_invite_get_state(LANLAN)
+    long_ago = time.time() - 6 * 3600
+    state['delivered_at'] = long_ago
+    state['responded_at'] = long_ago
+    state['chats_since_response'] = sr.MINI_GAME_INVITE_COOLDOWN_CHATS
+    state['last_response_choice'] = 'decline'
     assert sr._mini_game_invite_in_cooldown(LANLAN) is False
 
 
@@ -885,9 +927,14 @@ async def test_invite_skipped_when_no_game_available(monkeypatch):
     assert LANLAN not in sr._mini_game_invite_state
 
 
-def test_cooldown_is_1h_by_default():
-    """spec 改动：24h → 1h。常量值是后续 PR 调整的锚点，pin 住避免回归。"""
-    assert sr.MINI_GAME_INVITE_COOLDOWN_SECONDS == 3600
+def test_cooldown_accept_is_2h_by_default():
+    """spec：accept 后 cooldown = 2h。pin 住避免回归（曾从 24h→1h→2h）。"""
+    assert sr.MINI_GAME_INVITE_COOLDOWN_AFTER_ACCEPT_SECONDS == 2 * 3600
+
+
+def test_cooldown_decline_is_5h_by_default():
+    """spec：decline 后 cooldown = 5h（>accept，"拒绝"信号需更久静默）。"""
+    assert sr.MINI_GAME_INVITE_COOLDOWN_AFTER_DECLINE_SECONDS == 5 * 3600
 
 
 def test_new_user_force_at_is_4_by_default():


### PR DESCRIPTION
## Summary

- 把 mini-game 邀请的统一冷却拆成按用户回应分支：**accept → 2h**、**decline → 5h**。chats 门（10 条主动搭话）保持不变，accept/decline 共用。
- 原本 `MINI_GAME_INVITE_COOLDOWN_SECONDS=1h` 不区分 choice，体感上"刚 decline 又被问"。decline 5h 表达"明确不感兴趣需要更久静默"，accept 2h 因为"刚玩完一局"短一些就够了。
- state 新增 `last_response_choice` 字段；遗留 state（字段缺失）fallback 走短的 accept 阈值，避免现有用户被无端拉到 5h。

## Changes

- `config/__init__.py`: `MINI_GAME_INVITE_COOLDOWN_SECONDS` → 拆成 `_AFTER_ACCEPT_SECONDS = 2*3600` + `_AFTER_DECLINE_SECONDS = 5*3600`，`__all__` 同步。
- `main_routers/system_router.py`:
  - `_mini_game_invite_in_cooldown` 按 `state.last_response_choice` 取阈值（None / 缺失 → accept 短阈值兜底）。
  - `_apply_mini_game_invite_choice` accept/decline 分支各自写 `last_response_choice`；later 路径 + `_record_delivered` 清回 `None`。
  - state 结构注释更新。
- `tests/unit/test_mini_game_invite.py`:
  - 旧 pin `test_cooldown_is_1h_by_default` 拆成 `_accept_is_2h` + `_decline_is_5h`。
  - 既有 4 个 cooldown AND-语义测试改用 `_AFTER_DECLINE_SECONDS` 做 long-ago offset（保持原断言意图）。
  - 新增 3 条覆盖：accept 走 2h 阈值、decline 在 3h 时仍 cooldown、decline 6h 后解禁。

## Test plan

- [x] `uv run pytest tests/unit/test_mini_game_invite.py` —— 87 passed
- [ ] CI: lint / typecheck / 全量 pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 优化了小游戏邀请的冷却机制：根据您上次对邀请的响应应用不同冷却时长——接受后为 2 小时，拒绝后为 5 小时；缺失历史响应时回退到接受的阈值。邀请状态会相应更新以保证冷却规则生效。
* **测试**
  * 更新并新增单元测试以覆盖上述冷却分支与默认值断言。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->