### PR TITLE
feat(plugin): {MASTER_NAME}/{LANLAN_NAME} 占位符契约扩展到所有 plugin-text 注入点

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -883,9 +883,19 @@ async def _handle_agent_event(event: dict):
                         # return — otherwise we emit turn-end without a matching
                         # turn-start (frontend never opened the assistant
                         # lifecycle), corrupting proactive rescheduling.
+                        # Same role-placeholder contract as the direct_reply
+                        # path: blind-passthrough text reaches the chat bubble
+                        # verbatim without going through the LLM, so the
+                        # placeholder has to be expanded here or the literal
+                        # ``{MASTER_NAME}`` token would render in the bubble.
+                        passthrough_text = core.apply_role_placeholders(
+                            raw_text,
+                            lanlan_name=getattr(mgr, "lanlan_name", "") or "",
+                            master_name=getattr(mgr, "master_name", "") or "",
+                        )
                         passthrough_dispatched = bool(
                             await mgr.passthrough_to_chat_bubble(
-                                raw_text,
+                                passthrough_text,
                                 request_id=event.get("task_id") or None,
                                 source=passthrough_source,
                             )
@@ -930,9 +940,18 @@ async def _handle_agent_event(event: dict):
                     )
                 elif _is_websocket_connected(ws):
                     try:
+                        # HUD agent_notification renders verbatim to the user;
+                        # expand role placeholders so plugin authors can write
+                        # ``"通知 {MASTER_NAME}..."`` without the literal token
+                        # showing up in the toast.
+                        notif_text = core.apply_role_placeholders(
+                            text,
+                            lanlan_name=getattr(mgr, "lanlan_name", "") or "",
+                            master_name=getattr(mgr, "master_name", "") or "",
+                        )
                         notif = {
                             "type": "agent_notification",
-                            "text": text,
+                            "text": notif_text,
                             "source": "brain",
                             "status": cb_status,
                         }

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -723,6 +723,19 @@ async def _handle_agent_event(event: dict):
             if text:
                 if event.get("direct_reply"):
                     detail_text = (event.get("detail") or text).strip()
+                    # Plugin-supplied direct_reply text bypasses the LLM and
+                    # speaks/types verbatim. Plugin authors may write
+                    # ``{MASTER_NAME}``/``{LANLAN_NAME}`` placeholders since
+                    # they don't know which session their text will route to;
+                    # expand here so the placeholder doesn't reach TTS/UI
+                    # literally. (See main_logic.core.apply_role_placeholders
+                    # for the contract — same helper as the LLM-injection path
+                    # so all plugin-text exits share one spelling.)
+                    detail_text = core.apply_role_placeholders(
+                        detail_text,
+                        lanlan_name=getattr(mgr, "lanlan_name", "") or "",
+                        master_name=getattr(mgr, "master_name", "") or "",
+                    )
                     delivered = False
                     if detail_text and hasattr(mgr, "send_lanlan_response"):
                         try:

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -148,6 +148,40 @@ def _format_callback_source(cb: dict, lang: str) -> str:
     return _loc(descriptor, lang).format(name=name)
 
 
+def apply_role_placeholders(
+    text: str,
+    *,
+    lanlan_name: str = "",
+    master_name: str = "",
+) -> str:
+    """Substitute ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders in
+    plugin-supplied text at the LLM-injection boundary.
+
+    Plugin authors don't know which ``LLMSessionManager`` (and therefore which
+    ``master_name`` / ``lanlan_name`` pair) the text will route to — that's a
+    host-side visibility decision. So the canonical contract is:
+
+        plugin writes ``"向 {MASTER_NAME} 汇报…"`` →
+        host expands at the injection site, per session.
+
+    Uses ``str.replace`` rather than ``str.format`` so that other braces in
+    the text (JSON fragments, code snippets, user content containing stray
+    ``{``) don't raise ``KeyError``. Empty names short-circuit — the
+    placeholder is left in place rather than replaced with ``""``, on the
+    theory that the literal token is less misleading than an empty hole.
+
+    This is the SINGLE source of truth for the placeholder contract. New
+    plugin-text injection sites should funnel through this helper.
+    """
+    if not text:
+        return text
+    if master_name:
+        text = text.replace("{MASTER_NAME}", master_name)
+    if lanlan_name:
+        text = text.replace("{LANLAN_NAME}", lanlan_name)
+    return text
+
+
 def _render_callback_inner_item(
     cb: dict,
     lang: str,
@@ -161,21 +195,17 @@ def _render_callback_inner_item(
     and detail empty); the caller can then drop the line and rely on the
     outer header alone to express that something happened.
 
-    ``{MASTER_NAME}`` and ``{LANLAN_NAME}`` placeholders in plugin-supplied
-    ``summary``/``detail`` are substituted here so plugin authors can write
-    role-aware text without having to learn the live character names. The
-    substitution uses ``str.replace`` rather than ``str.format`` so that
-    other braces in the text (e.g. JSON fragments in detail) don't trigger
-    a KeyError.
+    Plugin-supplied ``summary``/``detail`` may contain ``{MASTER_NAME}`` /
+    ``{LANLAN_NAME}`` placeholders; see :func:`apply_role_placeholders`.
     """
-    summary = (cb.get("summary") or "").strip()
-    detail = (cb.get("detail") or "").strip()
-    if master_name:
-        summary = summary.replace("{MASTER_NAME}", master_name)
-        detail = detail.replace("{MASTER_NAME}", master_name)
-    if lanlan_name:
-        summary = summary.replace("{LANLAN_NAME}", lanlan_name)
-        detail = detail.replace("{LANLAN_NAME}", lanlan_name)
+    summary = apply_role_placeholders(
+        (cb.get("summary") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
+    detail = apply_role_placeholders(
+        (cb.get("detail") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
     text = summary or detail
     if not text:
         return ""
@@ -304,7 +334,13 @@ def _build_callback_instruction(
     return "\n\n".join(parts)
 
 
-def _format_voice_swap_item(entry: dict, lang: str) -> str:
+def _format_voice_swap_item(
+    entry: dict,
+    lang: str,
+    *,
+    lanlan_name: str = "",
+    master_name: str = "",
+) -> str:
     """Render a single voice-mode pending_extra_replies entry to a bulleted
     line for the hot-swap injection.
 
@@ -315,11 +351,22 @@ def _format_voice_swap_item(entry: dict, lang: str) -> str:
     (the voice-mode equivalent of the header-only branch in
     ``_build_callback_instruction``).
 
+    Plugin-supplied ``summary``/``detail`` may contain ``{MASTER_NAME}`` /
+    ``{LANLAN_NAME}`` placeholders; see :func:`apply_role_placeholders`. The
+    synthesized placeholder fallback uses host-side localized phrases so it
+    needs no role substitution.
+
     Returns ``""`` when the entry is genuinely empty (no body, no error, and
     a benign ``completed`` status) — caller filters those out.
     """
-    summary = (entry.get("summary") or "").strip()
-    detail = (entry.get("detail") or "").strip()
+    summary = apply_role_placeholders(
+        (entry.get("summary") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
+    detail = apply_role_placeholders(
+        (entry.get("detail") or "").strip(),
+        lanlan_name=lanlan_name, master_name=master_name,
+    )
     text = summary or detail
     status = entry.get("status") or "completed"
     emoji = _STATUS_EMOJI.get(status, "•")
@@ -400,7 +447,10 @@ def _render_pending_extra_replies_by_origin(
 
     blocks: list[str] = []
     if task_entries:
-        items = [_format_voice_swap_item(e, lang) for e in task_entries]
+        items = [
+            _format_voice_swap_item(e, lang, lanlan_name=lanlan_name, master_name=master_name)
+            for e in task_entries
+        ]
         items = [s for s in items if s]
         if items:
             blocks.append(
@@ -409,7 +459,10 @@ def _render_pending_extra_replies_by_origin(
                 + _loc(CONTEXT_SUMMARY_TASK_FOOTER, lang)
             )
     if event_entries:
-        items = [_format_voice_swap_item(e, lang) for e in event_entries]
+        items = [
+            _format_voice_swap_item(e, lang, lanlan_name=lanlan_name, master_name=master_name)
+            for e in event_entries
+        ]
         items = [s for s in items if s]
         if items:
             blocks.append(

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -175,9 +175,9 @@ def apply_role_placeholders(
     """
     if not text:
         return text
-    if master_name:
+    if isinstance(master_name, str) and master_name:
         text = text.replace("{MASTER_NAME}", master_name)
-    if lanlan_name:
+    if isinstance(lanlan_name, str) and lanlan_name:
         text = text.replace("{LANLAN_NAME}", lanlan_name)
     return text
 

--- a/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -600,6 +600,8 @@ self.push_message(parts=[{"type": "text", "text": "主人发了一条弹幕..."}
 | `finish(data={"summary": ..., "detail": ...})` | ✅ |
 | `push_message(parts=[{"type": "text", ...}])` 进 LLM 上下文 | ✅ |
 | `task_result` + `direct_reply=True`（绕过 LLM 直接 TTS） | ✅ |
+| `push_message(visibility=["chat"], ai_behavior="blind")` 直进聊天气泡 | ✅ |
+| `push_message(visibility=["hud"])` HUD toast 文本 | ✅ |
 | 静态描述字段（`plugin.toml` 的 `description`、入口的 `name` 等） | ❌ 不展开（这些是给开发者 / UI 看的，不进对话渠道） |
 
 #### LLM 结果字段过滤

--- a/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -539,6 +539,69 @@ return await self.finish(data={"summary": "..."}, delivery="silent")
 > `delivery` / `ai_behavior` 只控制时机（立即起 turn / 等下次用户开口 / 完全静默），
 > 不再决定外层 prompt 的措辞。两个轴正交，组合 6 种都合理。
 
+#### 写"角色感知文本"：`{MASTER_NAME}` / `{LANLAN_NAME}` 占位符
+
+插件通过 `finish()` 的 `data.summary` / `data.detail`、`push_message()` 的
+`parts[*].text` 等渠道把字符串塞进对话 LLM 上下文（或在 `direct_reply` 时直接进
+TTS / 聊天气泡）。这些字符串里**不要硬编码** `"用户"` / `"user"` / `"master"`
+/ `"主人"` —— 会导致两个问题：
+
+- **口吻别扭**：主 AI 看到"向用户汇报…"会原样照念"向用户继续叙述"，而不是用
+  实际的 `master_name`，听感生硬、出戏。
+- **多角色失真**：每个 `LLMSessionManager` 有自己的 `lanlan_name`；一个插件
+  广播给多个角色时，硬编码会让所有角色用同一份措辞。
+
+##### 占位符契约
+
+在 `summary` / `detail` / `parts[*].text` 里直接写：
+
+| 占位符 | 替换成 |
+|---|---|
+| `{MASTER_NAME}` | 当前会话的 `master_name`（用户起的名字） |
+| `{LANLAN_NAME}` | 当前会话的角色名 |
+
+宿主在 LLM 注入点（`main_logic.core.apply_role_placeholders`）按目标 session 展
+开。**不能在插件侧自己替换**——`push_message` 的 visibility 过滤是宿主端的，
+插件不知道这条消息最终落到哪个 session，也就拿不到正确的 name。
+
+##### 例子
+
+```python
+# ✅ 推荐：让宿主按 session 展开
+await self.finish(data={
+    "summary": "立即基于最新画面向 {MASTER_NAME} 叙述刚才发生的事",
+})
+
+self.push_message(parts=[{
+    "type": "text",
+    "text": "{MASTER_NAME} 刚刚发了一条弹幕：『...』",
+}], ai_behavior="respond")
+
+# ❌ 不推荐：硬编码，口吻泛化 + 多角色失真
+await self.finish(data={"summary": "立即向用户叙述..."})
+self.push_message(parts=[{"type": "text", "text": "主人发了一条弹幕..."}], ...)
+```
+
+##### 实现细节
+
+- **替换语义是 `str.replace`，不是 `str.format`**：`detail` 里嵌 JSON 片段 /
+  代码 / 含 `{` 的用户原文都不会触发 `KeyError`。
+- **空 name 时占位符保持字面量**：宿主拿不到 name（极少见的初始化期）时，
+  `{MASTER_NAME}` 留在原文，不会替换成空串造成"向 ... 汇报"这种破句。
+- **拼写固定**：用 **`{MASTER_NAME}` / `{LANLAN_NAME}`**（大写、下划线、单层
+  花括号）。`prompts_chara.py` 里用的也是这套；不要写 `{master_name}` /
+  `{master}` / `{MASTER}`——那些是宿主内部模板的 `.format(...)` 占位符，不跨
+  插件边界。
+
+##### 适用范围
+
+| 渠道 | 是否展开 |
+|---|---|
+| `finish(data={"summary": ..., "detail": ...})` | ✅ |
+| `push_message(parts=[{"type": "text", ...}])` 进 LLM 上下文 | ✅ |
+| `task_result` + `direct_reply=True`（绕过 LLM 直接 TTS） | ✅ |
+| 静态描述字段（`plugin.toml` 的 `description`、入口的 `name` 等） | ❌ 不展开（这些是给开发者 / UI 看的，不进对话渠道） |
+
 #### LLM 结果字段过滤
 
 通过 `llm_result_fields` 控制主 LLM 能看到结果中的哪些字段：

--- a/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/plugin/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -586,7 +586,7 @@ self.push_message(parts=[{"type": "text", "text": "主人发了一条弹幕..."}
 
 - **替换语义是 `str.replace`，不是 `str.format`**：`detail` 里嵌 JSON 片段 /
   代码 / 含 `{` 的用户原文都不会触发 `KeyError`。
-- **空 name 时占位符保持字面量**：宿主拿不到 name（极少见的初始化期）时，
+- **空 name 时占位符保持字面量**：宿主拿不到 name（极少见的初始化阶段）时，
   `{MASTER_NAME}` 留在原文，不会替换成空串造成"向 ... 汇报"这种破句。
 - **拼写固定**：用 **`{MASTER_NAME}` / `{LANLAN_NAME}`**（大写、下划线、单层
   花括号）。`prompts_chara.py` 里用的也是这套；不要写 `{master_name}` /

--- a/plugin/sdk/plugin/base.py
+++ b/plugin/sdk/plugin/base.py
@@ -147,9 +147,34 @@ class NekoPluginBase(_SharedNekoPluginBase):
         return await self.ctx.export_push(**kwargs)
 
     async def finish(self, **kwargs: Any) -> Any:
+        """Mark the current task done and hand a summary back to the host.
+
+        Role-aware text contract: ``summary`` / ``detail`` (and any text in
+        ``parts``) MAY contain ``{MASTER_NAME}`` / ``{LANLAN_NAME}``
+        placeholders. The host expands them at the LLM-injection boundary
+        (and at the verbatim ``direct_reply`` exit), per session. Plugin code
+        can't pick the right name itself — visibility filtering decides which
+        ``LLMSessionManager`` receives the text, so substitution has to be
+        host-side.
+
+        Use this for character-aware text like
+        ``"立即基于最新画面向 {MASTER_NAME} 叙述..."`` instead of hardcoded
+        ``"用户"`` / ``"master"`` / ``"主人"``, which feel generic and
+        misbehave on multi-character setups. See PLUGIN_DEVELOPMENT_GUIDE.md
+        ("Writing role-aware text") for details.
+        """
         return await self.ctx.finish(**kwargs)
 
     def push_message(self, **kwargs: Any) -> object:
+        """Stream a message from the plugin into the dialog channel.
+
+        Role-aware text contract: ``text`` / ``summary`` / ``detail`` (and
+        any text in ``parts``) MAY contain ``{MASTER_NAME}`` /
+        ``{LANLAN_NAME}`` placeholders; the host substitutes them at the
+        injection boundary, per session. See :meth:`finish` for the rationale
+        and PLUGIN_DEVELOPMENT_GUIDE.md ("Writing role-aware text") for the
+        full guide.
+        """
         return self.ctx.push_message(**kwargs)
 
     def include_router(self, router, *, prefix: str = "") -> None:

--- a/plugin/sdk/shared/core/context.py
+++ b/plugin/sdk/shared/core/context.py
@@ -363,6 +363,17 @@ class SdkContext:
               still fires).
         ``reply`` is the deprecated bool alias (``True``→proactive,
         ``False``→silent). When both are provided ``delivery`` wins.
+
+        Role-aware text contract: ``data['summary']`` / ``data['detail']``
+        (and any text field that flows into the dialog channel) MAY contain
+        ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholders. The host
+        substitutes them at the LLM-injection boundary (and at verbatim
+        ``direct_reply`` exits), per session. Plugin code can't pick the
+        right name itself — visibility filtering decides which session
+        receives the text, so substitution has to happen host-side. Prefer
+        the placeholders over hardcoded ``"用户"`` / ``"master"`` /
+        ``"主人"``. See PLUGIN_DEVELOPMENT_GUIDE.md ("Writing role-aware
+        text") for details.
         """
         normalized_data = normalize_structured_data(data)
         resolved = normalize_delivery(delivery, reply)
@@ -416,6 +427,16 @@ class SdkContext:
         ``parts`` is an ordered list of content parts (``text``,
         ``image``, ``audio``, ``video``, ``ui_action``).  See
         :mod:`plugin.sdk.shared.core.push_message_schema` for full shapes.
+
+        Role-aware text contract: any text field that ends up in the dialog
+        channel (``parts[*].text`` for ``ai_behavior="respond"|"read"`` /
+        ``visibility=["chat"]``) MAY contain ``{MASTER_NAME}`` /
+        ``{LANLAN_NAME}`` placeholders; the host expands them per session at
+        the injection boundary. Plugin code can't pick the right name
+        itself — visibility filtering happens host-side. Prefer the
+        placeholders over hardcoded ``"用户"`` / ``"master"`` / ``"主人"``.
+        See PLUGIN_DEVELOPMENT_GUIDE.md ("Writing role-aware text") for
+        details.
 
         All other parameters are deprecated and emit ``DeprecationWarning``;
         scheduled for removal in v0.9 (``docs/changelog``).

--- a/tests/unit/test_role_placeholder_substitution.py
+++ b/tests/unit/test_role_placeholder_substitution.py
@@ -1,24 +1,32 @@
 """Plugin-supplied ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholder substitution
 contract (issue #1337).
 
-Three host-side injection sites must funnel plugin-supplied text through the
+Five host-side injection sites must funnel plugin-supplied text through the
 same substitution helper:
 
 1. ``_render_callback_inner_item`` — proactive/passive callback drain into
    the LLM prompt.
 2. ``_format_voice_swap_item`` — voice-mode ``pending_extra_replies``
    hot-swap rendering into ``prime_context``.
-3. ``app/main_server.py`` direct_reply path — plugin text bypassing the LLM
-   and going verbatim to TTS / chat bubble.
+3. ``app/main_server.py`` direct_reply — plugin text bypassing the LLM and
+   going verbatim to TTS via ``send_lanlan_response``.
+4. ``app/main_server.py`` ``passthrough_to_chat_bubble`` — ``visibility=["chat"]``
+   + ``ai_behavior="blind"`` blind chat-bubble passthrough.
+5. ``app/main_server.py`` HUD ``agent_notification`` — ``visibility=["hud"]``
+   toast text.
 
 If any of these grow a new code path that bypasses ``apply_role_placeholders``,
-plugins emitting ``"向 {MASTER_NAME} 汇报…"`` style text will end up speaking
-the literal token to the user. This file is the canary.
+plugins emitting ``"向 {MASTER_NAME} 汇报…"`` style text will end up speaking /
+displaying the literal token to the user. This file is the canary.
 
 The substitution uses ``str.replace``, not ``str.format`` — JSON fragments
 or arbitrary ``{`` in user content must NOT raise ``KeyError``.
 """
 from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -172,3 +180,132 @@ def test_voice_swap_render_pipeline_plumbs_names_through():
     )
     assert "向 小明 发送了一条问候" in out
     assert "{MASTER_NAME}" not in out
+
+
+# ---------------------------------------------------------------------------
+# main_server _handle_agent_event — verbatim plugin-text exits
+# ---------------------------------------------------------------------------
+#
+# Three exits skip the LLM and render plugin text to the user directly. Each
+# must funnel through ``core.apply_role_placeholders`` before reaching TTS /
+# chat bubble / HUD; otherwise a plugin writing ``"通知 {MASTER_NAME}"`` would
+# display the literal token. These tests fake the session manager and
+# trigger _handle_agent_event end-to-end so the wiring stays covered.
+
+
+def _mgr_for_main_server(send_lanlan_return=True):
+    """Stub session manager with attributes / methods main_server reads on
+    the verbatim-exit paths."""
+    fake_mgr = MagicMock()
+    fake_mgr.lanlan_name = "兰兰"
+    fake_mgr.master_name = "小明"
+    fake_mgr.send_lanlan_response = AsyncMock(return_value=send_lanlan_return)
+    fake_mgr.handle_proactive_complete = AsyncMock()
+    fake_mgr.passthrough_to_chat_bubble = AsyncMock(return_value=True)
+    fake_mgr.enqueue_agent_callback = MagicMock()
+    fake_mgr.trigger_agent_callbacks = AsyncMock()
+    fake_mgr.websocket = MagicMock()
+    fake_mgr.websocket.send_json = AsyncMock()
+    fake_mgr._pending_agent_callback_task = None
+    return fake_mgr
+
+
+def _patch_main_server(monkeypatch, fake_mgr):
+    monkeypatch.setattr("app.main_server._get_session_manager", lambda name: fake_mgr)
+    monkeypatch.setattr("app.main_server._is_websocket_connected", lambda ws: True)
+
+
+@pytest.mark.unit
+async def test_main_server_direct_reply_substitutes_master_name(monkeypatch):
+    """task_result + direct_reply → text goes verbatim to send_lanlan_response
+    (skipping the LLM). The placeholder must be expanded at this boundary or
+    the literal token reaches TTS."""
+    from app import main_server
+
+    fake_mgr = _mgr_for_main_server()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(
+        {
+            "event_type": "task_result",
+            "lanlan_name": "兰兰",
+            "text": "ignored",
+            "detail": "搞定了，要不要跟 {MASTER_NAME} 报告一下？",
+            "direct_reply": True,
+            "channel": "plugin:demo",
+            "task_id": "t-1",
+            "media_parts": [],
+        }
+    )
+
+    fake_mgr.send_lanlan_response.assert_awaited_once()
+    sent_text = fake_mgr.send_lanlan_response.await_args.args[0]
+    assert "{MASTER_NAME}" not in sent_text
+    assert "跟 小明 报告" in sent_text
+
+
+@pytest.mark.unit
+async def test_main_server_chat_passthrough_substitutes_master_name(monkeypatch):
+    """visibility=["chat"] + ai_behavior="blind" → text goes verbatim to
+    ``passthrough_to_chat_bubble`` (skipping the LLM). Without substitution
+    the literal placeholder renders in the chat bubble. This is the codex
+    P2 finding on PR #1422."""
+    from app import main_server
+
+    fake_mgr = _mgr_for_main_server()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(
+        {
+            "event_type": "proactive_message",
+            "lanlan_name": "兰兰",
+            "text": "{MASTER_NAME} 你看一下这个",
+            "channel": "plugin:demo",
+            "task_id": "t-2",
+            "ai_behavior": "blind",
+            "visibility": ["chat"],
+            "source_kind": "plugin",
+            "source_name": "demo",
+            "media_parts": [],
+        }
+    )
+
+    fake_mgr.passthrough_to_chat_bubble.assert_awaited_once()
+    sent_text = fake_mgr.passthrough_to_chat_bubble.await_args.args[0]
+    assert "{MASTER_NAME}" not in sent_text
+    assert "小明 你看一下这个" in sent_text
+
+
+@pytest.mark.unit
+async def test_main_server_hud_notification_substitutes_master_name(monkeypatch):
+    """visibility=["hud"] toast text reaches the frontend verbatim. Without
+    substitution the placeholder shows up in the toast literal."""
+    from app import main_server
+
+    fake_mgr = _mgr_for_main_server()
+    _patch_main_server(monkeypatch, fake_mgr)
+
+    await main_server._handle_agent_event(
+        {
+            "event_type": "proactive_message",
+            "lanlan_name": "兰兰",
+            "text": "提醒 {MASTER_NAME}：番茄钟到点了",
+            "channel": "plugin:demo",
+            "task_id": "t-3",
+            "ai_behavior": "blind",
+            "visibility": ["hud"],
+            "source_kind": "plugin",
+            "source_name": "demo",
+            "media_parts": [],
+        }
+    )
+
+    hud_calls = [
+        c.args[0]
+        for c in fake_mgr.websocket.send_json.await_args_list
+        if c.args and isinstance(c.args[0], dict) and c.args[0].get("type") == "agent_notification"
+    ]
+    assert len(hud_calls) == 1
+    notif_text = hud_calls[0].get("text", "")
+    assert "{MASTER_NAME}" not in notif_text
+    assert "提醒 小明：番茄钟到点了" in notif_text

--- a/tests/unit/test_role_placeholder_substitution.py
+++ b/tests/unit/test_role_placeholder_substitution.py
@@ -1,0 +1,174 @@
+"""Plugin-supplied ``{MASTER_NAME}`` / ``{LANLAN_NAME}`` placeholder substitution
+contract (issue #1337).
+
+Three host-side injection sites must funnel plugin-supplied text through the
+same substitution helper:
+
+1. ``_render_callback_inner_item`` — proactive/passive callback drain into
+   the LLM prompt.
+2. ``_format_voice_swap_item`` — voice-mode ``pending_extra_replies``
+   hot-swap rendering into ``prime_context``.
+3. ``app/main_server.py`` direct_reply path — plugin text bypassing the LLM
+   and going verbatim to TTS / chat bubble.
+
+If any of these grow a new code path that bypasses ``apply_role_placeholders``,
+plugins emitting ``"向 {MASTER_NAME} 汇报…"`` style text will end up speaking
+the literal token to the user. This file is the canary.
+
+The substitution uses ``str.replace``, not ``str.format`` — JSON fragments
+or arbitrary ``{`` in user content must NOT raise ``KeyError``.
+"""
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------------
+# apply_role_placeholders — the single source of truth
+# ---------------------------------------------------------------------------
+
+
+def test_apply_role_placeholders_replaces_both_tokens():
+    from main_logic.core import apply_role_placeholders
+
+    out = apply_role_placeholders(
+        "向 {MASTER_NAME} 汇报：{LANLAN_NAME} 已经完成任务",
+        lanlan_name="兰兰",
+        master_name="小明",
+    )
+    assert out == "向 小明 汇报：兰兰 已经完成任务"
+
+
+def test_apply_role_placeholders_leaves_unknown_tokens_alone():
+    from main_logic.core import apply_role_placeholders
+
+    out = apply_role_placeholders(
+        "{MASTER_NAME} 喜欢 {UNKNOWN_TOKEN}",
+        lanlan_name="兰兰",
+        master_name="小明",
+    )
+    assert out == "小明 喜欢 {UNKNOWN_TOKEN}"
+
+
+def test_apply_role_placeholders_keeps_literal_braces_in_detail():
+    """Plugin ``detail`` may carry JSON fragments / code snippets with bare
+    ``{``. The helper must use ``str.replace``, not ``str.format`` — otherwise
+    these crash with KeyError before the AI ever sees them."""
+    from main_logic.core import apply_role_placeholders
+
+    text = '收到工具返回：{"status": "ok", "msg": "done"} → 通知 {MASTER_NAME}'
+    out = apply_role_placeholders(text, lanlan_name="兰兰", master_name="小明")
+    assert '{"status": "ok"' in out
+    assert "通知 小明" in out
+
+
+def test_apply_role_placeholders_empty_name_leaves_token_literal():
+    """When the host hasn't resolved a name yet (extremely early
+    initialization), the helper must leave the placeholder as-is rather than
+    replacing with the empty string and producing broken sentences like
+    '向  汇报' or 'Hi, ! Welcome.'."""
+    from main_logic.core import apply_role_placeholders
+
+    out = apply_role_placeholders(
+        "{MASTER_NAME} 在等 {LANLAN_NAME}",
+        lanlan_name="",
+        master_name="",
+    )
+    assert "{MASTER_NAME}" in out
+    assert "{LANLAN_NAME}" in out
+
+
+def test_apply_role_placeholders_empty_text_short_circuits():
+    """Empty/None text is preserved as-is (so callers don't need to
+    pre-check)."""
+    from main_logic.core import apply_role_placeholders
+
+    assert apply_role_placeholders("", lanlan_name="兰兰", master_name="小明") == ""
+
+
+# ---------------------------------------------------------------------------
+# _render_callback_inner_item — the LLM-prompt drain path
+# ---------------------------------------------------------------------------
+
+
+def test_render_callback_inner_item_substitutes_in_summary_and_detail():
+    from main_logic.core import _render_callback_inner_item
+
+    cb = {
+        "summary": "向 {MASTER_NAME} 汇报",
+        "detail": "{LANLAN_NAME} 完成了拾取任务",
+        "status": "completed",
+    }
+    out = _render_callback_inner_item(
+        cb, lang="zh", lanlan_name="兰兰", master_name="小明",
+    )
+    assert "向 小明 汇报" in out
+    assert "兰兰 完成了拾取任务" in out
+    assert "{MASTER_NAME}" not in out
+    assert "{LANLAN_NAME}" not in out
+
+
+# ---------------------------------------------------------------------------
+# _format_voice_swap_item — the voice-mode hot-swap path
+# ---------------------------------------------------------------------------
+
+
+def test_voice_swap_item_substitutes_summary():
+    from main_logic.core import _format_voice_swap_item
+
+    entry = {
+        "origin": "task_result",
+        "summary": "刚才向 {MASTER_NAME} 演示了新功能",
+        "detail": "",
+        "status": "completed",
+        "source_kind": "plugin",
+        "source_name": "demo",
+        "error_message": "",
+    }
+    out = _format_voice_swap_item(
+        entry, "zh", lanlan_name="兰兰", master_name="小明",
+    )
+    assert "向 小明 演示了新功能" in out
+    assert "{MASTER_NAME}" not in out
+
+
+def test_voice_swap_item_substitutes_detail_when_summary_empty():
+    from main_logic.core import _format_voice_swap_item
+
+    entry = {
+        "origin": "event",
+        "summary": "",
+        "detail": "{LANLAN_NAME} 收到了一条新弹幕",
+        "status": "completed",
+        "source_kind": "plugin",
+        "source_name": "bilibili_danmaku",
+        "error_message": "",
+    }
+    out = _format_voice_swap_item(
+        entry, "zh", lanlan_name="兰兰", master_name="小明",
+    )
+    assert "兰兰 收到了一条新弹幕" in out
+
+
+def test_voice_swap_render_pipeline_plumbs_names_through():
+    """Integration-style check: the full hot-swap renderer reaches its inner
+    item formatter with the names plumbed through. Pins the (caller →
+    helper) contract that was broken pre-fix."""
+    from main_logic.core import _render_pending_extra_replies_by_origin
+
+    out = _render_pending_extra_replies_by_origin(
+        [
+            {
+                "origin": "event",
+                "summary": "向 {MASTER_NAME} 发送了一条问候",
+                "detail": "",
+                "status": "completed",
+                "source_kind": "plugin",
+                "source_name": "greeter",
+                "error_message": "",
+            }
+        ],
+        lang="zh",
+        lanlan_name="兰兰",
+        master_name="小明",
+    )
+    assert "向 小明 发送了一条问候" in out
+    assert "{MASTER_NAME}" not in out


### PR DESCRIPTION
Closes #1337.

## Summary

- 抽出 `apply_role_placeholders(text, *, lanlan_name, master_name)` 作为单一替换入口（`str.replace`，不会被 plugin detail 里的 JSON 片段 KeyError）。
- 三处 plugin-text 注入点统一走它：`_render_callback_inner_item`（已有，重构）、`_format_voice_swap_item`（**新**，voice-mode hot-swap）、`app/main_server.py` direct_reply（**新**，verbatim TTS 出口）。
- SDK 侧 `push_message` / `finish` docstring 写明契约；`plugin/PLUGIN_DEVELOPMENT_GUIDE.md` 加「写『角色感知文本』」一节（拼写、做/不做示例、适用范围表）。
- 占位符拼写统一为 **`{MASTER_NAME}` / `{LANLAN_NAME}`**（单层花括号、大写下划线）；和 `prompts_chara.py` 一致。
- 单测 `tests/unit/test_role_placeholder_substitution.py`：3 个注入点 + `str.replace` 语义 + 空 name 留字面量 + 未知 token 不动。

## Out of scope（issue 也明说了）

- **聊天气泡 passthrough / HUD agent_notification**：plugin text 到用户但不进 LLM 上下文，issue scope 是 "dialog-LLM context"。后续要做可以补，本 PR 不动。
- **静态 plugin description i18n**（如 memo_reminder 工具描述里的 "用户"）：issue 显式 out of scope。
- **bilibili_danmaku 自己的 master_name fallback "主人"**：是 `feedback_no_dehumanizing_terms` 范畴的历史 bug，不在本 issue。

## Plugin audit 结论

跑了一圈 plugin 内 `finish`/`push_message` 调用点：
- `game_agent_minecraft` 已经用 `{MASTER_NAME}`（issue 的初始 patch 已经做了），现在 PLUGIN_DEVELOPMENT_GUIDE.md 把它正式作为契约。
- `bilibili_danmaku`、`memo_reminder`、`mcp_adapter` 都没有硬编码 "向用户" / "向 master" 的 LLM-facing 文本（要么用第三人称如 "观众 X 进入直播间"，要么用各自的 master_name 发现机制走自己的 LLM 调用——和 finish/push_message 注入边界不同）。

## Test plan

- [x] `tests/unit/test_role_placeholder_substitution.py` 全部通过（10 用例）
- [x] `tests/unit/test_callback_instruction_origin.py` 全部通过（既有 voice swap / origin matrix 测试没回归）
- [x] `tests/unit/test_proactive_text_does_not_dehumanize.py` 全部通过（反物化称呼护栏没回归）
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 插件输出中的 {MASTER_NAME} / {LANLAN_NAME} 占位符将在宿主注入点展开，覆盖直出/盲出、HUD 通知与语音热切换等路径，避免占位符字面量出现在前端显示或 TTS 播报。

* **文档**
  * 在插件开发指南与 SDK 文档中补充占位符使用契约、示例与不推荐用法，明确宿主负责展开规则。

* **测试**
  * 增加端到端单元测试，覆盖占位符替换规则与各渲染/直通路径的行为验证。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->