### PR TITLE
feat(debug): /api/debug/health 长跑观测 watchdog + 前端 timer/RAF 计数

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -1491,6 +1491,7 @@ from main_routers.websocket_router import router as websocket_router # noqa
 from main_routers.workshop_router import router as workshop_router # noqa
 from main_routers.cookies_login_router import router as cookies_login_router # noqa
 from main_routers.game_router import router as game_router # noqa
+from main_routers.debug_router import router as debug_router, start_watchdog as _start_debug_health_watchdog # noqa
 from main_routers.shared_state import init_shared_state # noqa
 
 
@@ -1541,6 +1542,7 @@ app.include_router(music_router)
 app.include_router(galgame_router)
 app.include_router(game_router)
 app.include_router(cookies_login_router) # Cookies登录相关路由，放在最后以避免与其他API路由冲突
+app.include_router(debug_router)  # 诊断观测：/api/debug/health（轻量、零侵入，详见 debug_router.py 头注释）
 app.include_router(pages_router)  # 兜底路由需最后挂载
 
 # 后台预加载任务
@@ -2027,6 +2029,14 @@ async def on_startup():
                     _last = _now
             asyncio.create_task(_event_loop_heartbeat())
             logger.info("[asyncio] heartbeat enabled (stalls > 300ms will be logged)")
+
+        # 诊断观测 watchdog：5-min 周期采集 counter 写内存 ring buffer，
+        # NEKO_DEBUG_HEALTH_LOG=1 时同时落盘 jsonl。详见 main_routers/debug_router.py。
+        # 无条件启动 —— 单 task + 5-min 周期，开销远低于 heartbeat。
+        try:
+            _start_debug_health_watchdog()
+        except Exception as _e:
+            logger.debug(f"[debug_health] start watchdog failed: {_e}")
 
         blocking_reason = get_storage_startup_blocking_reason(_config_manager)
         if blocking_reason:

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -1332,6 +1332,9 @@ _MAIN_LIMITED_MODE_ALLOWED_PAGE_PATHS = {
 _MAIN_LIMITED_MODE_ALLOWED_PREFIXES = (
     "/static/",
     "/api/storage/location/",
+    # 诊断观测：limited-mode 本身就是要排查的故障形态之一（启动阻断），
+    # 这时候反而最需要 /api/debug/health 能读到 ring + watchdog 落盘。
+    "/api/debug/",
 )
 
 

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import sys
 import time
@@ -299,8 +300,19 @@ def _sanitize_client_payload(raw: Any) -> dict[str, Any]:
     out: dict[str, Any] = {}
     for k, v in raw.items():
         if k in _CLIENT_NUMERIC_FIELDS:
-            if v is None or isinstance(v, (int, float)) and not isinstance(v, bool):
+            if v is None:
                 out[k] = v
+            elif isinstance(v, (int, float)) and not isinstance(v, bool):
+                # 拒 NaN / Infinity / 1e10000：stdlib json 默认会输出 "NaN" /
+                # "Infinity" 字面量（非标准 JSON），前端 JSON.parse / 第三方
+                # jsonl 工具直接挂。try-except 同时兜超大 int（10**500 等）：
+                # math.isfinite 内部把 int 转 float 时会 OverflowError，那种
+                # 数字在「只记计数」语义里也不该出现，一并丢。
+                try:
+                    if math.isfinite(v):
+                        out[k] = v
+                except (OverflowError, TypeError):
+                    pass
         elif k in _CLIENT_BOOL_FIELDS:
             if isinstance(v, bool):
                 out[k] = v

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+"""诊断观测：长跑健康指标采集。
+
+背景
+----
+现场偶发有用户反馈「N.E.K.O 开了两三天后 CPU 慢慢涨到 30%+」。这类「多日
+累积、静置触发」的 leak 仅凭静态读代码命中率个位数，必须**复现时拿到运行时
+counter 曲线**才能定位。这个 router 干两件事：
+
+1. ``GET /api/debug/health``：返回当前关键 counter 的快照（asyncio 任务数、
+   各 lanlan core 的对话历史长度、agent_event_bus._ack_waiters 大小、
+   proactive_chat_history 大小、进程 RSS、uptime）。
+2. 启动一个 5-min 周期的后台 watchdog 任务，把同样的快照写进一个内存
+   ring buffer（保留最近 ~16 小时 = 200 条）。当 ``NEKO_DEBUG_HEALTH_LOG=1``
+   时还落盘到 ``<user_data>/debug_health.jsonl``，方便用户把文件发回来画曲线。
+
+设计原则
+--------
+- **零侵入**：所有 counter 都用 getattr / try-except 容错，本模块挂了不影响主功能。
+- **默认开**：endpoint + 内存 ring buffer 永远在跑，单次代价 ~ms 级；文件落盘默认关，
+  靠 env 显式开启。后续用户报问题时不需要再发新版本——已有数据可直接捞。
+- **不抓隐私**：snapshot 只数大小不读内容；jsonl 里没有任何对话原文（遵循 CLAUDE.md
+  「原始对话只能 print 不能 logger」的规则）。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# 模块级状态
+# ---------------------------------------------------------------------------
+
+_PROCESS_START_MONO = time.monotonic()
+# Ring buffer：~16 小时（5min × 200）。重启即丢，这是诊断而非审计，可接受。
+_HEALTH_RING: deque[dict[str, Any]] = deque(maxlen=200)
+_WATCHDOG_TASK: asyncio.Task | None = None
+_WATCHDOG_INTERVAL_SECONDS = 5 * 60  # 5 分钟
+
+
+# ---------------------------------------------------------------------------
+# Snapshot 采集
+# ---------------------------------------------------------------------------
+
+def _safe_rss_mb() -> float | None:
+    """读取当前进程 RSS（MB）。psutil 优先，失败回退 resource（POSIX）。
+
+    Windows 没有 ``resource.getrusage`` 的 RSS 字段，所以纯打包发行版
+    （Nuitka 不带 psutil 的话）这里会返回 None——不致命。"""
+    try:
+        import psutil  # type: ignore
+        return psutil.Process().memory_info().rss / (1024 * 1024)
+    except Exception:
+        pass
+    try:
+        import resource  # type: ignore  # POSIX-only
+        # ru_maxrss 在 macOS 是 bytes，在 Linux 是 KB——我们粗略当 KB 处理，
+        # macOS 上数值会偏大 1024 倍，但用户绝大多数是 Windows，不影响主用例。
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+    except Exception:
+        return None
+
+
+def _safe_conv_history_lengths() -> dict[str, int]:
+    """枚举所有 lanlan core 的 _conversation_history 长度。
+
+    任何一个 lanlan 抓不到都跳过——shared_state 在启动早期可能还没 ready。"""
+    out: dict[str, int] = {}
+    try:
+        from main_routers.shared_state import get_session_manager
+        session_manager = get_session_manager()
+        # session_manager 是 _RoleStateFieldView，dict-like
+        for name in list(session_manager.keys()):
+            try:
+                core = session_manager.get(name)
+                session = getattr(core, "session", None)
+                history = getattr(session, "_conversation_history", None)
+                if history is not None:
+                    out[name] = len(history)
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return out
+
+
+def _safe_ack_waiters_size() -> int | None:
+    try:
+        from main_logic.agent_event_bus import _ack_waiters
+        return len(_ack_waiters)
+    except Exception:
+        return None
+
+
+def _safe_proactive_history_size() -> dict[str, int]:
+    out: dict[str, int] = {}
+    try:
+        from main_routers.system_router import _proactive_chat_history
+        for name, dq in list(_proactive_chat_history.items()):
+            try:
+                out[name] = len(dq)
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return out
+
+
+def _collect_snapshot() -> dict[str, Any]:
+    """单次快照采集。每个字段独立 try 过——任意一项炸了不影响其他。"""
+    snap: dict[str, Any] = {
+        "ts": time.time(),
+        "uptime_sec": time.monotonic() - _PROCESS_START_MONO,
+    }
+    try:
+        snap["asyncio_tasks"] = len(asyncio.all_tasks())
+    except Exception:
+        snap["asyncio_tasks"] = None
+    snap["rss_mb"] = _safe_rss_mb()
+    snap["conv_history"] = _safe_conv_history_lengths()
+    snap["ack_waiters"] = _safe_ack_waiters_size()
+    snap["proactive_history"] = _safe_proactive_history_size()
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# 文件落盘（默认关）
+# ---------------------------------------------------------------------------
+
+def _resolve_log_path() -> Path | None:
+    """返回 jsonl 落盘路径；未启用时返回 None。
+
+    启用条件：env ``NEKO_DEBUG_HEALTH_LOG`` 为真值。
+    路径：config_manager 提供的用户配置目录 / ``debug_health.jsonl``；
+    拿不到 config_manager 时退到 sys.executable 同目录。"""
+    if os.environ.get("NEKO_DEBUG_HEALTH_LOG", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return None
+    try:
+        from main_routers.shared_state import get_config_manager
+        cm = get_config_manager()
+        config_dir = getattr(cm, "config_dir", None)
+        if config_dir:
+            return Path(config_dir) / "debug_health.jsonl"
+    except Exception:
+        pass
+    # 兜底：launcher 旁
+    try:
+        return Path(sys.argv[0]).resolve().parent / "debug_health.jsonl"
+    except Exception:
+        return None
+
+
+def _append_to_log(snap: dict[str, Any]) -> None:
+    path = _resolve_log_path()
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(snap, ensure_ascii=False) + "\n")
+    except Exception as e:
+        # 文件写失败不抛——诊断功能不能拖垮主程序
+        logger.debug("debug_health: append jsonl failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Watchdog 后台任务
+# ---------------------------------------------------------------------------
+
+async def _watchdog_loop() -> None:
+    """5-min 周期采样。任何单轮异常吞掉继续——多日跑下来不能因为一次失败掉队。"""
+    # 启动后先睡一段，避开冷启动 noise（asyncio task 数在 startup 阶段会高一下）。
+    try:
+        await asyncio.sleep(60)
+    except asyncio.CancelledError:
+        return
+    while True:
+        try:
+            snap = _collect_snapshot()
+            _HEALTH_RING.append(snap)
+            _append_to_log(snap)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.debug("debug_health watchdog single tick error: %s", e)
+        try:
+            await asyncio.sleep(_WATCHDOG_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            return
+
+
+def start_watchdog() -> None:
+    """由 main_server startup 调用。幂等：重复调用不会创建第二个 task。"""
+    global _WATCHDOG_TASK
+    if _WATCHDOG_TASK is not None and not _WATCHDOG_TASK.done():
+        return
+    try:
+        _WATCHDOG_TASK = asyncio.create_task(_watchdog_loop(), name="debug_health_watchdog")
+        logger.info("debug_health watchdog started (interval=%ds, log_file=%s)",
+                    _WATCHDOG_INTERVAL_SECONDS, _resolve_log_path())
+    except RuntimeError:
+        # 没有 running loop——startup 路径不该走到这里
+        logger.warning("debug_health: no running loop, watchdog NOT started")
+
+
+# ---------------------------------------------------------------------------
+# HTTP 端点
+# ---------------------------------------------------------------------------
+
+@router.get("/api/debug/health")
+async def debug_health() -> dict[str, Any]:
+    """返回当前快照 + 最近 ring buffer。
+
+    Ring buffer 让用户不用等到下一个 5-min tick——任意时刻请求都能拿到
+    最近 16 小时的曲线，刷新即用。"""
+    current = _collect_snapshot()
+    return {
+        "current": current,
+        "ring": list(_HEALTH_RING),
+        "ring_capacity": _HEALTH_RING.maxlen,
+        "watchdog_interval_sec": _WATCHDOG_INTERVAL_SECONDS,
+        "log_path": str(_resolve_log_path()) if _resolve_log_path() else None,
+    }
+
+
+@router.post("/api/debug/health/client")
+async def debug_health_client(payload: dict[str, Any]) -> dict[str, Any]:
+    """前端 ``debug-health.js`` POST 上来的浏览器侧快照。
+
+    我们不做存储——只是把它合进下一轮 watchdog snapshot 的 ``client`` 字段，
+    或者直接 echo 进 ring buffer 末项。这样后端 ring 同时记录服务端 + 浏览器侧
+    counter，导出一个文件即可看到完整曲线。"""
+    try:
+        # 把 client snapshot 挂在最近一条服务端 snapshot 上；没有就单独占一条。
+        entry = {
+            "ts": time.time(),
+            "client": payload,
+        }
+        _HEALTH_RING.append(entry)
+        _append_to_log(entry)
+        return {"ok": True}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -56,21 +56,18 @@ _WATCHDOG_INTERVAL_SECONDS = 5 * 60  # 5 分钟
 # ---------------------------------------------------------------------------
 
 def _safe_rss_mb() -> float | None:
-    """读取当前进程 RSS（MB）。psutil 优先，失败回退 resource（POSIX）。
+    """读取当前进程**当前** RSS（MB）；只在 psutil 可用时返回，否则 None。
 
-    Windows 没有 ``resource.getrusage`` 的 RSS 字段，所以纯打包发行版
-    （Nuitka 不带 psutil 的话）这里会返回 None——不致命。"""
+    历史里曾用 ``resource.getrusage(...).ru_maxrss`` 做 fallback，但那是
+    **lifetime peak**——一旦上去就不下降。用来画 leak 趋势会把一次性内存
+    高峰永久误读成 leak，比没有这个字段还误导。所以**宁可返回 None**也不
+    走 ru_maxrss。打包发行版默认就带 psutil，源码模式 ``uv sync`` 也会装。"""
     try:
         import psutil  # type: ignore
         return psutil.Process().memory_info().rss / (1024 * 1024)
     except Exception:
-        pass
-    try:
-        import resource  # type: ignore  # POSIX-only
-        # ru_maxrss 在 macOS 是 bytes，在 Linux 是 KB——我们粗略当 KB 处理，
-        # macOS 上数值会偏大 1024 倍，但用户绝大多数是 Windows，不影响主用例。
-        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-    except Exception:
+        # 故意吞：拿不到 RSS 不应拖垮诊断功能。曲线上看 rss_mb=null 就知道是
+        # 环境缺 psutil，不会和「真有 leak」混淆。
         return None
 
 
@@ -91,9 +88,12 @@ def _safe_conv_history_lengths() -> dict[str, int]:
                 if history is not None:
                     out[name] = len(history)
             except Exception:
+                # 单 lanlan 失败不影响其他：可能正在 end_session / hot-swap，
+                # core / session 暂态为 None，下一轮自然恢复。
                 continue
     except Exception:
-        pass
+        # shared_state 启动早期可能还没 ready；故意吞，零侵入。
+        return out
     return out
 
 
@@ -102,6 +102,7 @@ def _safe_ack_waiters_size() -> int | None:
         from main_logic.agent_event_bus import _ack_waiters
         return len(_ack_waiters)
     except Exception:
+        # 故意吞：agent_event_bus 模块未加载 / 重构改名都允许优雅降级。
         return None
 
 
@@ -113,9 +114,11 @@ def _safe_proactive_history_size() -> dict[str, int]:
             try:
                 out[name] = len(dq)
             except Exception:
+                # 单条 deque 取 len 失败极小概率：跳过不让整轮废。
                 continue
     except Exception:
-        pass
+        # 故意吞：system_router 未加载 / 内部命名变更都允许优雅降级。
+        return out
     return out
 
 
@@ -155,6 +158,8 @@ def _resolve_log_path() -> Path | None:
         if config_dir:
             return Path(config_dir) / "debug_health.jsonl"
     except Exception:
+        # shared_state 没 ready / config_manager 未注入：落到下面 sys.argv[0]
+        # 兜底路径。本身就是诊断文件，写哪里都比不写好。
         pass
     # 兜底：launcher 旁
     try:
@@ -240,17 +245,38 @@ async def debug_health() -> dict[str, Any]:
 async def debug_health_client(payload: dict[str, Any]) -> dict[str, Any]:
     """前端 ``debug-health.js`` POST 上来的浏览器侧快照。
 
-    我们不做存储——只是把它合进下一轮 watchdog snapshot 的 ``client`` 字段，
-    或者直接 echo 进 ring buffer 末项。这样后端 ring 同时记录服务端 + 浏览器侧
-    counter，导出一个文件即可看到完整曲线。"""
+    Merge 语义（不是 append）：服务端 watchdog 和前端 debug-health.js 都是
+    5-min 周期，如果直接 append 一条新 entry，ring 实际保留窗口就被砍半
+    （200 条 ÷ 2 = 100 个采样周期），跟头注释里写的「~16 小时」对不上。
+    这里改成：找最近一条**还没绑过 client** 的 server entry，若 ts 距今 <
+    watchdog 间隔则把 payload 挂到它的 ``client`` 字段；找不到才单独 append。
+    这样一行 jsonl = 一个采样周期内的 server+client 完整状态，画图更直观。"""
     try:
-        # 把 client snapshot 挂在最近一条服务端 snapshot 上；没有就单独占一条。
-        entry = {
-            "ts": time.time(),
-            "client": payload,
-        }
-        _HEALTH_RING.append(entry)
-        _append_to_log(entry)
-        return {"ok": True}
+        now = time.time()
+        merged = False
+        if _HEALTH_RING:
+            # 倒序找：最常见路径是命中 ring 末项（server tick 刚过 + client 推送）
+            for i in range(len(_HEALTH_RING) - 1, -1, -1):
+                cand = _HEALTH_RING[i]
+                # 判定「server entry」：有 asyncio_tasks 字段（即使 None 也算，
+                # 这是 _collect_snapshot 永远写的键）。client-only 条目没有它。
+                if "asyncio_tasks" not in cand:
+                    continue
+                if cand.get("client") is not None:
+                    # 这条已经绑过 client，再往前找；保持 1:1 配对
+                    continue
+                if now - float(cand.get("ts") or 0) > _WATCHDOG_INTERVAL_SECONDS:
+                    # 距今超过一个周期：已经是上一轮的 entry，不再 merge 避免
+                    # 跨周期错配。直接走 append 分支。
+                    break
+                cand["client"] = payload
+                _append_to_log(cand)
+                merged = True
+                break
+        if not merged:
+            entry = {"ts": now, "client": payload}
+            _HEALTH_RING.append(entry)
+            _append_to_log(entry)
+        return {"ok": True, "merged": merged}
     except Exception as e:
         return {"ok": False, "error": str(e)}

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -185,6 +185,34 @@ def _append_to_log(snap: dict[str, Any]) -> None:
 # Watchdog 后台任务
 # ---------------------------------------------------------------------------
 
+def _absorb_recent_client_payload(server_snap: dict[str, Any]) -> None:
+    """Server tick 时回头吸收最近一条 client-only entry（如果在窗口内）。
+
+    时序约束：debug-health.js 首次 POST 在 t=30s，watchdog 首次 tick 在 t=60s，
+    之后两边都按 5min 节奏跑——所以 client POST 通常落在「下一个」server tick
+    **之前** 30s 左右。client POST 端选择 append client-only entry 暂存；server
+    tick 此处主动吸收：把暂存的 client payload merge 到当前 server snapshot，
+    并把暂存条目从 ring 里 pop 掉（避免砍半 ring 保留期）。
+
+    若 client 没启用（用户没开 localStorage），这里啥也不做，ring 全是
+    server-only entry，~200 条 ≈ 16 小时不变。"""
+    if not _HEALTH_RING:
+        return
+    last = _HEALTH_RING[-1]
+    # 「client-only」标识：缺 asyncio_tasks 键（server snapshot 永远有）
+    if "asyncio_tasks" in last:
+        return
+    client_payload = last.get("client")
+    if client_payload is None:
+        return
+    # 吸收窗口：一个 watchdog 间隔。本应只有 ~30s 距离，但容忍 client 启动晚
+    # / 浏览器 throttle 等导致的偏移。再远就放过，避免吸收上上轮的残留。
+    if float(server_snap.get("ts") or 0) - float(last.get("ts") or 0) > _WATCHDOG_INTERVAL_SECONDS:
+        return
+    server_snap["client"] = client_payload
+    _HEALTH_RING.pop()
+
+
 async def _watchdog_loop() -> None:
     """5-min 周期采样。任何单轮异常吞掉继续——多日跑下来不能因为一次失败掉队。"""
     # 启动后先睡一段，避开冷启动 noise（asyncio task 数在 startup 阶段会高一下）。
@@ -195,6 +223,7 @@ async def _watchdog_loop() -> None:
     while True:
         try:
             snap = _collect_snapshot()
+            _absorb_recent_client_payload(snap)
             _HEALTH_RING.append(snap)
             _append_to_log(snap)
         except asyncio.CancelledError:
@@ -245,38 +274,15 @@ async def debug_health() -> dict[str, Any]:
 async def debug_health_client(payload: dict[str, Any]) -> dict[str, Any]:
     """前端 ``debug-health.js`` POST 上来的浏览器侧快照。
 
-    Merge 语义（不是 append）：服务端 watchdog 和前端 debug-health.js 都是
-    5-min 周期，如果直接 append 一条新 entry，ring 实际保留窗口就被砍半
-    （200 条 ÷ 2 = 100 个采样周期），跟头注释里写的「~16 小时」对不上。
-    这里改成：找最近一条**还没绑过 client** 的 server entry，若 ts 距今 <
-    watchdog 间隔则把 payload 挂到它的 ``client`` 字段；找不到才单独 append。
-    这样一行 jsonl = 一个采样周期内的 server+client 完整状态，画图更直观。"""
+    简单 append client-only entry——**不要**往前往回 merge 已存在的 server
+    snapshot（曾尝试过，被 codex 指出会把 client sample 绑到 4.5 分钟之前的
+    server tick，时间轴错位）。正确语义：client POST 暂存条目，等下一次
+    server tick 在 _absorb_recent_client_payload 里把它吸收 + pop，合成一条
+    完整的 server+client entry。这样既不错配时间，也不砍 ring 保留期。"""
     try:
-        now = time.time()
-        merged = False
-        if _HEALTH_RING:
-            # 倒序找：最常见路径是命中 ring 末项（server tick 刚过 + client 推送）
-            for i in range(len(_HEALTH_RING) - 1, -1, -1):
-                cand = _HEALTH_RING[i]
-                # 判定「server entry」：有 asyncio_tasks 字段（即使 None 也算，
-                # 这是 _collect_snapshot 永远写的键）。client-only 条目没有它。
-                if "asyncio_tasks" not in cand:
-                    continue
-                if cand.get("client") is not None:
-                    # 这条已经绑过 client，再往前找；保持 1:1 配对
-                    continue
-                if now - float(cand.get("ts") or 0) > _WATCHDOG_INTERVAL_SECONDS:
-                    # 距今超过一个周期：已经是上一轮的 entry，不再 merge 避免
-                    # 跨周期错配。直接走 append 分支。
-                    break
-                cand["client"] = payload
-                _append_to_log(cand)
-                merged = True
-                break
-        if not merged:
-            entry = {"ts": now, "client": payload}
-            _HEALTH_RING.append(entry)
-            _append_to_log(entry)
-        return {"ok": True, "merged": merged}
+        entry = {"ts": time.time(), "client": payload}
+        _HEALTH_RING.append(entry)
+        _append_to_log(entry)
+        return {"ok": True}
     except Exception as e:
         return {"ok": False, "error": str(e)}

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -169,12 +169,29 @@ def _resolve_log_path() -> Path | None:
         return None
 
 
+# 单文件大小上限。超过则 rotate 到 .1（覆盖旧 .1），总占用硬封 ~20MB。
+# 算下来：3 个 lanlan + client merged 行 ≈ 500B，10MB ≈ 21000 行 ≈ 73 天数据，
+# 触发 rotation 后还能再写 73 天到新文件——对「报完问题忘关 env」场景完全够用。
+_LOG_ROTATE_BYTES = 10 * 1024 * 1024
+
+
 def _append_to_log(snap: dict[str, Any]) -> None:
     path = _resolve_log_path()
     if path is None:
         return
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
+        # Rotate：超阈值则 os.replace 到 .1。os.replace 在 Windows / POSIX 都
+        # 原子，且会原子覆盖已有 .1——所以总占用 = current + .1 ≤ 2×10MB。
+        # 用 path.name + ".1" 而不是 with_suffix('.1')——后者会把 .jsonl 替成
+        # .1 得到 debug_health.1，丢了 .jsonl 后缀。
+        try:
+            if path.exists() and path.stat().st_size > _LOG_ROTATE_BYTES:
+                os.replace(path, path.parent / (path.name + ".1"))
+        except OSError as e:
+            # rotation 失败不挂主路径，让 append 照旧写——大不了文件继续涨
+            # 一阵子，下次 tick 还会再试。
+            logger.debug("debug_health: rotate failed: %s", e)
         with path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(snap, ensure_ascii=False) + "\n")
     except Exception as e:

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -312,6 +312,8 @@ def _sanitize_client_payload(raw: Any) -> dict[str, Any]:
                     if math.isfinite(v):
                         out[k] = v
                 except (OverflowError, TypeError):
+                    # 故意丢：超大 int / 异常 numeric subtype 进不来 isfinite。
+                    # 「只记计数」语义里本来不该出现，丢弃即可，不影响其他字段。
                     pass
         elif k in _CLIENT_BOOL_FIELDS:
             if isinstance(v, bool):

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -194,23 +194,30 @@ def _absorb_recent_client_payload(server_snap: dict[str, Any]) -> None:
     tick 此处主动吸收：把暂存的 client payload merge 到当前 server snapshot，
     并把暂存条目从 ring 里 pop 掉（避免砍半 ring 保留期）。
 
+    多条 client-only：同一周期内可能有多条 client POST（多标签页 / beforeunload
+    补发 + 定时上报）。while 循环把尾部连续 client-only 全部 pop，避免落下孤儿；
+    最终只保留**最新**一条 payload merge 进 server snapshot——最新 = 最后到达
+    = 最贴近 server tick 时点，诊断价值最高。
+
     若 client 没启用（用户没开 localStorage），这里啥也不做，ring 全是
     server-only entry，~200 条 ≈ 16 小时不变。"""
-    if not _HEALTH_RING:
-        return
-    last = _HEALTH_RING[-1]
-    # 「client-only」标识：缺 asyncio_tasks 键（server snapshot 永远有）
-    if "asyncio_tasks" in last:
-        return
-    client_payload = last.get("client")
-    if client_payload is None:
-        return
-    # 吸收窗口：一个 watchdog 间隔。本应只有 ~30s 距离，但容忍 client 启动晚
-    # / 浏览器 throttle 等导致的偏移。再远就放过，避免吸收上上轮的残留。
-    if float(server_snap.get("ts") or 0) - float(last.get("ts") or 0) > _WATCHDOG_INTERVAL_SECONDS:
-        return
-    server_snap["client"] = client_payload
-    _HEALTH_RING.pop()
+    absorbed_client: dict[str, Any] | None = None
+    server_ts = float(server_snap.get("ts") or 0)
+    # 倒序消化尾部连续 client-only 条目；保留最新（第一次循环取到的）payload。
+    while _HEALTH_RING:
+        last = _HEALTH_RING[-1]
+        # 「client-only」标识：缺 asyncio_tasks 键（server snapshot 永远有）
+        if "asyncio_tasks" in last:
+            break
+        # 超出吸收窗口的属于「上上轮残留」，不动它（也不吸收 payload）让 ring
+        # 自然按 maxlen 排出，避免强行 pop 破坏历史顺序。
+        if server_ts - float(last.get("ts") or 0) > _WATCHDOG_INTERVAL_SECONDS:
+            break
+        if absorbed_client is None and last.get("client") is not None:
+            absorbed_client = last["client"]
+        _HEALTH_RING.pop()
+    if absorbed_client is not None:
+        server_snap["client"] = absorbed_client
 
 
 async def _watchdog_loop() -> None:
@@ -270,19 +277,59 @@ async def debug_health() -> dict[str, Any]:
     }
 
 
+# 端点接受的客户端 payload 白名单。HTTP 边界做这层约束有两个理由：
+# (1) 协议契约——「只记计数」必须在边界强制而不是依赖前端自觉，否则任何调用方
+#     都能往 ring/jsonl 写入大对象或敏感字段；
+# (2) 文件占用——单次 payload bound 住，长跑 jsonl 不会被异常调用爆出 GB 级。
+# 字段名跟 static/debug-health.js 的 ``collectSnapshot()`` 同步。新增字段时
+# 两边一起改，未在白名单的会被静默丢弃。
+_CLIENT_NUMERIC_FIELDS = frozenset({
+    "ts", "live_intervals", "live_timeouts", "raf_fps_60s",
+    "dom_nodes", "js_heap_mb", "ws_state",
+    "proactive_backoff_level", "agent_task_map_size",
+})
+_CLIENT_BOOL_FIELDS = frozenset({"proactive_running", "is_recording"})
+_CLIENT_STRING_FIELDS_WITH_CAP = {"location": 128}
+
+
+def _sanitize_client_payload(raw: Any) -> dict[str, Any]:
+    """裁剪客户端 payload 到白名单字段；非预期类型 / 超长字符串丢弃或截断。"""
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for k, v in raw.items():
+        if k in _CLIENT_NUMERIC_FIELDS:
+            if v is None or isinstance(v, (int, float)) and not isinstance(v, bool):
+                out[k] = v
+        elif k in _CLIENT_BOOL_FIELDS:
+            if isinstance(v, bool):
+                out[k] = v
+        elif k in _CLIENT_STRING_FIELDS_WITH_CAP:
+            if isinstance(v, str):
+                cap = _CLIENT_STRING_FIELDS_WITH_CAP[k]
+                out[k] = v[:cap]
+        # 其余字段静默丢弃——「只记计数」契约由这里强制
+    return out
+
+
 @router.post("/api/debug/health/client")
 async def debug_health_client(payload: dict[str, Any]) -> dict[str, Any]:
     """前端 ``debug-health.js`` POST 上来的浏览器侧快照。
 
-    简单 append client-only entry——**不要**往前往回 merge 已存在的 server
-    snapshot（曾尝试过，被 codex 指出会把 client sample 绑到 4.5 分钟之前的
-    server tick，时间轴错位）。正确语义：client POST 暂存条目，等下一次
-    server tick 在 _absorb_recent_client_payload 里把它吸收 + pop，合成一条
-    完整的 server+client entry。这样既不错配时间，也不砍 ring 保留期。"""
+    流程：
+    - 边界白名单裁剪（``_sanitize_client_payload``），强制「只记计数」契约。
+    - Append client-only entry 到内存 ring 暂存——**不**立刻写 jsonl，避免
+      下次 server tick 吸收时 jsonl 出现「暂存 + 合并」双行污染时间轴。
+    - 写 jsonl 的责任完全交给 watchdog：吸收成功就一条 merged 行，吸收
+      不到（窗口外或 server 未启）也会被 ring 自然 drop。
+
+    错配修复历史：曾尝试在这里倒序找 server entry merge，被 codex 指出会
+    把 client sample 绑到 4.5min 前的旧 snapshot，时间轴错位 270s。所以
+    改成「server tick 反向吸收」，详见 ``_absorb_recent_client_payload``。"""
     try:
-        entry = {"ts": time.time(), "client": payload}
+        sanitized = _sanitize_client_payload(payload)
+        entry = {"ts": time.time(), "client": sanitized}
         _HEALTH_RING.append(entry)
-        _append_to_log(entry)
         return {"ok": True}
     except Exception as e:
         return {"ok": False, "error": str(e)}

--- a/static/debug-health.js
+++ b/static/debug-health.js
@@ -1,0 +1,162 @@
+/**
+ * 诊断观测（前端侧）—— 配合 main_routers/debug_router.py 一起用。
+ *
+ * 背景：用户报「N.E.K.O 开了两三天后变卡」，光看后端 counter 不够——很多
+ * leak 在 renderer（Live2D RAF、setInterval 残留、DOM 节点增长、JS 堆）。
+ * 本脚本周期性把这些 counter 通过 POST /api/debug/health/client 推回后端，
+ * 后端会跟服务端 snapshot 一起写进同一份 ring buffer / jsonl，导出一个文件
+ * 就能看到完整曲线。
+ *
+ * 默认关 —— 避免给所有用户加任何 console 噪音 / 网络请求。
+ * 开启方法（在 Electron devtools / 浏览器 console 跑）：
+ *   localStorage.setItem('NEKO_DEBUG_HEALTH', '1');
+ *   location.reload();
+ * 关闭方法：
+ *   localStorage.removeItem('NEKO_DEBUG_HEALTH');
+ *   location.reload();
+ *
+ * 这个文件必须**尽早加载**——它 monkey-patch window.setInterval / setTimeout
+ * 来计数活跃 timer。在业务代码之后加载就抓不到早期注册的那些。
+ */
+(function () {
+    'use strict';
+
+    var ENABLED = false;
+    try {
+        ENABLED = (window.localStorage && window.localStorage.getItem('NEKO_DEBUG_HEALTH') === '1');
+    } catch (e) {
+        // SecurityError / disabled storage —— 静默退出，不影响主功能
+        return;
+    }
+    if (!ENABLED) return;
+
+    // ── 1. Monkey-patch setInterval / setTimeout 计数 ─────────────────────
+    // 注意：必须在所有业务代码加载前先 patch，否则前期注册的 timer 漏抓。
+    // 我们记录的是「当前还活着的 timer id 集合」大小，不是历史总数。
+    var _liveIntervals = new Set();
+    var _liveTimeouts = new Set();
+    var _origSetInterval = window.setInterval;
+    var _origClearInterval = window.clearInterval;
+    var _origSetTimeout = window.setTimeout;
+    var _origClearTimeout = window.clearTimeout;
+
+    window.setInterval = function () {
+        var id = _origSetInterval.apply(window, arguments);
+        _liveIntervals.add(id);
+        return id;
+    };
+    window.clearInterval = function (id) {
+        _liveIntervals.delete(id);
+        return _origClearInterval.call(window, id);
+    };
+    window.setTimeout = function () {
+        var args = Array.prototype.slice.call(arguments);
+        var origCb = args[0];
+        // 如果不是函数（极少见，setTimeout 接受字符串），直接透传不计数
+        if (typeof origCb !== 'function') {
+            return _origSetTimeout.apply(window, args);
+        }
+        var idHolder = { id: 0 };
+        args[0] = function () {
+            _liveTimeouts.delete(idHolder.id);
+            try { return origCb.apply(this, arguments); } catch (e) { throw e; }
+        };
+        var id = _origSetTimeout.apply(window, args);
+        idHolder.id = id;
+        _liveTimeouts.add(id);
+        return id;
+    };
+    window.clearTimeout = function (id) {
+        _liveTimeouts.delete(id);
+        return _origClearTimeout.call(window, id);
+    };
+
+    // ── 2. RAF 频率统计 ─────────────────────────────────────────────────
+    // 累计最近 60s 内的 RAF 触发次数（理想是 60×60=3600；远低于说明渲染器卡）。
+    var _rafCount = 0;
+    var _rafCountWindowStart = performance.now();
+    var _origRAF = window.requestAnimationFrame;
+    var _trackedRAF = function (cb) {
+        _rafCount += 1;
+        return _origRAF.call(window, cb);
+    };
+    window.requestAnimationFrame = _trackedRAF;
+
+    function _snapshotRAF() {
+        var now = performance.now();
+        var elapsedMs = Math.max(1, now - _rafCountWindowStart);
+        var fps = _rafCount * 1000 / elapsedMs;
+        _rafCount = 0;
+        _rafCountWindowStart = now;
+        return fps;
+    }
+
+    // ── 3. Snapshot 收集 + 推送 ────────────────────────────────────────
+    function collectSnapshot() {
+        var snap = {
+            ts: Date.now() / 1000,
+            location: location.pathname,
+            live_intervals: _liveIntervals.size,
+            live_timeouts: _liveTimeouts.size,
+            raf_fps_60s: _snapshotRAF(),
+            dom_nodes: 0,
+            js_heap_mb: null,
+        };
+        try {
+            snap.dom_nodes = document.getElementsByTagName('*').length;
+        } catch (e) { /* noop */ }
+        try {
+            // Chromium-only：performance.memory.usedJSHeapSize
+            if (performance && performance.memory && performance.memory.usedJSHeapSize) {
+                snap.js_heap_mb = performance.memory.usedJSHeapSize / (1024 * 1024);
+            }
+        } catch (e) { /* noop */ }
+        // 各 lanlan 的 ws / proactive 状态：尽量抓但绝不能抛
+        try {
+            if (window.S) {
+                snap.ws_state = window.S.socket ? window.S.socket.readyState : null;
+                snap.proactive_backoff_level = window.S.proactiveChatBackoffLevel;
+                snap.proactive_running = !!window.S.isProactiveChatRunning;
+                snap.is_recording = !!window.S.isRecording;
+            }
+        } catch (e) { /* noop */ }
+        try {
+            if (window._agentTaskMap && typeof window._agentTaskMap.size === 'number') {
+                snap.agent_task_map_size = window._agentTaskMap.size;
+            }
+        } catch (e) { /* noop */ }
+        return snap;
+    }
+
+    function pushSnapshot() {
+        var snap;
+        try { snap = collectSnapshot(); } catch (e) { return; }
+        try {
+            console.log('[debug_health]', JSON.stringify(snap));
+        } catch (e) { /* noop */ }
+        try {
+            fetch('/api/debug/health/client', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(snap),
+                // keepalive 让快关窗口时最后一发也能送出
+                keepalive: true,
+            }).catch(function () { /* 失败不重试——下一轮再说 */ });
+        } catch (e) { /* noop */ }
+    }
+
+    // ── 4. 周期触发 ──────────────────────────────────────────────────
+    // 5 分钟节奏，跟后端 watchdog 对齐。首次延迟 30s——给业务代码 warm up
+    // 时间，避免抓到全是 0 / N/A 的首屏快照。
+    setTimeout(function () {
+        pushSnapshot();
+        setInterval(pushSnapshot, 5 * 60 * 1000);
+    }, 30 * 1000);
+
+    // 关窗口前再补一发（keepalive）——长会话最后一刻的状态最值钱
+    window.addEventListener('beforeunload', function () {
+        try { pushSnapshot(); } catch (e) { /* noop */ }
+    });
+
+    console.log('[debug_health] enabled (set localStorage.NEKO_DEBUG_HEALTH=0 + reload to disable)');
+})();

--- a/static/debug-health.js
+++ b/static/debug-health.js
@@ -33,6 +33,12 @@
     // ── 1. Monkey-patch setInterval / setTimeout 计数 ─────────────────────
     // 注意：必须在所有业务代码加载前先 patch，否则前期注册的 timer 漏抓。
     // 我们记录的是「当前还活着的 timer id 集合」大小，不是历史总数。
+    //
+    // 双清：浏览器 timer id 池在多数实现里 setInterval / setTimeout 共享，
+    // 且本仓库已有 cross-clear 用法（static/app-ui.js: setTimeout 拿 id →
+    // clearInterval(id) 清掉）。所以两个 clear wrapper 都必须同时从两个 set
+    // 删——否则 cross-clear 会让对应 set 里残留死 id，counter 假性单调涨，
+    // 反过来污染本来要诊断的 leak 信号。
     var _liveIntervals = new Set();
     var _liveTimeouts = new Set();
     var _origSetInterval = window.setInterval;
@@ -47,6 +53,7 @@
     };
     window.clearInterval = function (id) {
         _liveIntervals.delete(id);
+        _liveTimeouts.delete(id);  // 见上：cross-clear 兼容
         return _origClearInterval.call(window, id);
     };
     window.setTimeout = function () {
@@ -68,6 +75,7 @@
     };
     window.clearTimeout = function (id) {
         _liveTimeouts.delete(id);
+        _liveIntervals.delete(id);  // 见上：cross-clear 兼容
         return _origClearTimeout.call(window, id);
     };
 

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -8,6 +8,8 @@
 
     <!-- VRM 光照默认值：从后端注入，保证在所有 JS 之前同步可用 -->
     <script>window.VRM_DEFAULT_LIGHTING=Object.freeze({{ vrm_defaults | tojson }});</script>
+    <!-- 诊断观测：必须最早加载（与 index.html 同序）。详见 static/debug-health.js。 -->
+    <script src="/static/debug-health.js?v={{ static_asset_version }}"></script>
     <!-- 与 index.html 相同的基础 CSS/JS -->
     <script src="/static/i18n-i18next.js?v={{ static_asset_version }}"></script>
     <script src="/static/common_dialogs.js?v={{ static_asset_version }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,10 @@
     <title data-i18n="app.title">Project N.E.K.O.</title>
     <!-- VRM 光照默认值：从后端注入，保证在所有 JS 之前同步可用 -->
     <script>window.VRM_DEFAULT_LIGHTING=Object.freeze({{ vrm_defaults | tojson }});</script>
+    <!-- 诊断观测：必须最早加载——内部 monkey-patch setInterval/setTimeout 计数活跃
+         timer，业务代码之后加载就抓不到早期注册的那些。默认关，靠
+         localStorage.NEKO_DEBUG_HEALTH=1 + 刷新启用。详见 static/debug-health.js。 -->
+    <script src="/static/debug-health.js?v={{ static_asset_version }}"></script>
     <!-- i18next 加载器（统一处理 CDN 加载和初始化） -->
     <script src="/static/i18n-i18next.js?v={{ static_asset_version }}"></script>
     <script src="/static/common_dialogs.js?v={{ static_asset_version }}"></script>


### PR DESCRIPTION
## 背景

有用户反馈『N.E.K.O 开两三天后 CPU 慢慢涨到 30%+』，**静置时触发**（互动驱动的怀疑——对话历史增长、特效计时器、模型切换叠加——都对不上）、**多日累积**。这类 leak 光静态读代码命中率个位数，必须复现时拿到运行时 counter 曲线才能定位。

之前会话已排查了一轮，没找到 100% 能判定的静态 bug：多数 setTimeout 不平衡是 fire-and-forget；少数有问题的（如 `game-audio-system.js` 中途切歌漏 timer）只在游戏场景触发，对得上『静置』不成立。所以这个 PR 不修任何怀疑点，只把**观测基建**铺好——下次有用户报问题时直接拿数据。

## Summary

- **后端** `main_routers/debug_router.py`（256 行）
  - `GET /api/debug/health` 端点：任意时刻返回当前 snapshot + 内存 ring（最近 ~16 小时）
  - 5-min 周期 watchdog，无条件启动（单 task，开销远低于 heartbeat）
  - 采集：`asyncio_tasks`、`rss_mb`、各 lanlan 的 `_conversation_history` 长度、`_ack_waiters`、`_proactive_chat_history`
  - 所有访问 getattr/try-except 容错——本模块挂了不影响主功能
  - 不抓隐私：snapshot 只数大小不读内容（遵守 CLAUDE.md 原始对话只 print 不 logger 的规则）
  - `NEKO_DEBUG_HEALTH_LOG=1` 时同时落盘 `<user_config>/debug_health.jsonl`，方便用户发回来

- **前端** `static/debug-health.js`（162 行）
  - monkey-patch `setInterval/setTimeout` 计数活跃 timer（leak 最直接的指标）
  - 统计 RAF FPS（Live2D 渲染退化）、DOM 节点、JS heap、proactive backoff level、ws state
  - POST 到 `/api/debug/health/client` 合进后端 ring，导出一个文件就有完整曲线
  - 默认关，靠 `localStorage.setItem('NEKO_DEBUG_HEALTH','1')` + 刷新启用，**对未排查用户零侵入**
  - 必须最早加载（业务代码后 patch 抓不到早期 timer），插在 `index.html`/`chat.html` 的 i18next 之前

- **挂载**：`app/main_server.py` import + `include_router` + startup 启 watchdog（共 10 行）

## 设计原则

| | |
|---|---|
| 默认开 | endpoint + 内存 ring buffer（轻量，单 task / 5min） |
| 默认关 | 前端 console 噪音 + 网络请求；后端 jsonl 落盘 |
| 不需要发新版本 | 用户报问题时让 ta 跑两行 localStorage 即可开前端；后端 ring 已经在跑 |
| 不抓隐私 | 只数 `len(history)` 不读 history 内容 |

## 用法

复现时给用户的话术：
1. 浏览器/Electron devtools 跑 `localStorage.setItem('NEKO_DEBUG_HEALTH','1'); location.reload();`
2. 让 ta 用一段时间后访问 `http://localhost:48911/api/debug/health` 复制 JSON 发回来（或开 `NEKO_DEBUG_HEALTH_LOG=1` 拿 jsonl 文件）
3. 画曲线看哪条 counter 在涨：
   - `asyncio_tasks` 单调涨 → 后端 task 泄露
   - `live_intervals/live_timeouts` 单调涨 → 前端 timer 没 clear
   - `raf_fps_60s` 单调降 → Live2D / VRM 渲染累积
   - `dom_nodes` / `js_heap_mb` 单调涨 → renderer 内存
   - `_ack_waiters` 单调涨 → event_bus future 泄露
   - 各 `conv_history` 单调涨 → idle reset 没触发到（虽然静置场景应该不涨）

## 打包

`--include-package=main_routers` 已覆盖新文件，`build_nuitka.bat` 无需改。`_REQUIRED_ASSETS` 也不需要新增（不是新目录）。

## Test plan

- [x] `from main_routers.debug_router import router, start_watchdog, _collect_snapshot` 冷启动跑通，snapshot 字段齐全（RSS=203MB，其他空但不抛）
- [x] `app/main_server.py` syntax check pass
- [ ] 本地起 main_server 后访问 `/api/debug/health` 拿到非空 ring
- [ ] 前端 `localStorage.NEKO_DEBUG_HEALTH=1` + 刷新后 console 每 5 min 出 `[debug_health] ...`
- [ ] 设 `NEKO_DEBUG_HEALTH_LOG=1` 启动后 `<user_config>/debug_health.jsonl` 有数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加服务器端诊断接口：实时健康快照、历史环形缓冲、后台周期采样与可选落盘，提供查询与客户端上报能力。
  * 增加可选前端诊断脚本（由 localStorage 开启）：统计计时器/RAF/DOM/堆内存等并定期向后端上报，已在页面最早位置注入加载。
* **稳定性**
  * 启动流程调整：受限模式下仍允许访问诊断路径；后台采样或 watchdog 启动失败仅记录日志，不中断主流程。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->