### PR TITLE
feat(telemetry): D2-D7 流失诊断埋点 SDK + gzip 上报全链路

### DIFF
--- a/app/agent_server.py
+++ b/app/agent_server.py
@@ -3148,7 +3148,8 @@ async def startup():
         from utils.token_tracker import TokenTracker, install_hooks
         install_hooks()
         TokenTracker.get_instance().start_periodic_save()
-        TokenTracker.get_instance().record_app_start()
+        # process 字段进 session_start / session_end 维度，跨进程诊断必须区分
+        TokenTracker.get_instance().record_app_start(process="agent_server")
     except Exception as e:
         logger.warning(f"[Agent] Token tracker init failed: {e}")
 

--- a/app/main_server.py
+++ b/app/main_server.py
@@ -1915,7 +1915,8 @@ async def _ensure_main_server_runtime_initialized(*, reason: str) -> bool:
 
                 install_hooks()
                 TokenTracker.get_instance().start_periodic_save()
-                TokenTracker.get_instance().record_app_start()
+                # process 字段进 session_start / session_end 维度，跨进程诊断必须区分
+                TokenTracker.get_instance().record_app_start(process="main_server")
                 logger.info("Token usage tracker initialized")
             except Exception as e:
                 logger.warning(f"Token tracker initialization failed (non-critical): {e}")

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2889,7 +2889,8 @@ async def ensure_memory_server_runtime_initialized(*, reason: str = "") -> bool:
 
             install_hooks()
             TokenTracker.get_instance().start_periodic_save()
-            TokenTracker.get_instance().record_app_start()
+            # process 字段进 session_start / session_end 维度，跨进程诊断必须区分
+            TokenTracker.get_instance().record_app_start(process="memory_server")
         except Exception as e:
             logger.warning(f"[Memory] Token tracker init failed: {e}")
 

--- a/local_server/telemetry_server/models.py
+++ b/local_server/telemetry_server/models.py
@@ -8,7 +8,7 @@ Telemetry Server — 数据模型
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 # Pydantic v1/v2 兼容
 PYDANTIC_V2 = int(getattr(__import__('pydantic'), 'VERSION', '1.0').split('.')[0]) >= 2
@@ -68,6 +68,32 @@ class RecentRecord(BaseModel):
     ok: bool = True
 
 
+class HistogramStat(BaseModel):
+    """单个 histogram 指标的桶分布。"""
+    count: int = 0
+    sum: float = 0.0
+    buckets: List[int] = Field(default_factory=list)
+
+
+class InstrumentSnapshot(BaseModel):
+    """客户端 utils/instrument 的 60s 窗口 snapshot。
+
+    counters / histograms 的 key 是 ``name`` 或 ``name|k1=v1,k2=v2``。
+    bounds 是 histogram 桶边界数组，len == 任一 histogram.buckets 长度 - 1
+    （多出来的那个桶是溢出桶）。
+
+    服务端当前不强 schema 化（events.payload 列原样保存 JSON），dashboard /
+    aggregation 是后续 Batch 的工作。这里声明只是为了让 server 代码能从
+    submission.payload.instruments 类型安全地访问字段，不被当成 unknown
+    field 静默忽略。
+    """
+    window_start: float = 0.0
+    window_end: float = 0.0
+    bounds: List[float] = Field(default_factory=list)
+    counters: Dict[str, float] = Field(default_factory=dict)
+    histograms: Dict[str, HistogramStat] = Field(default_factory=dict)
+
+
 class TelemetryEvent(BaseModel):
     """客户端上报的遥测负载。"""
     device_id: str = Field(..., min_length=16, max_length=128)
@@ -86,6 +112,9 @@ class TelemetryEvent(BaseModel):
     steam_user_id: str = Field(default="", max_length=24)
     daily_stats: Dict[str, DailyStats] = Field(default_factory=dict)
     recent_records: List[RecentRecord] = Field(default_factory=list)
+    # 通用 counter / histogram 累积窗口（utils/instrument）。Optional —
+    # 客户端只在窗口非空时发送，老客户端完全不会带这个字段。
+    instruments: Optional[InstrumentSnapshot] = None
 
 
 class TelemetrySubmission(BaseModel):

--- a/local_server/telemetry_server/models.py
+++ b/local_server/telemetry_server/models.py
@@ -8,7 +8,7 @@ Telemetry Server — 数据模型
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 # Pydantic v1/v2 兼容
 PYDANTIC_V2 = int(getattr(__import__('pydantic'), 'VERSION', '1.0').split('.')[0]) >= 2
@@ -89,6 +89,10 @@ class InstrumentSnapshot(BaseModel):
     """
     window_start: float = 0.0
     window_end: float = 0.0
+    # 客户端本地日历天（``YYYY-MM-DD``）。服务端按这个落 stat_date，跟
+    # ``daily_stats`` 的 key 同口径；老客户端缺失时服务端按 window_end
+    # 时间戳回退（见 storage.py ``_apply_instruments``）。
+    stat_date: str = ""
     bounds: List[float] = Field(default_factory=list)
     counters: Dict[str, float] = Field(default_factory=dict)
     histograms: Dict[str, HistogramStat] = Field(default_factory=dict)

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import gzip
 import html
+import io
 import json
 import logging
 import os
@@ -42,7 +44,10 @@ from storage import TelemetryStorage
 HMAC_SECRET = os.getenv("TELEMETRY_HMAC_SECRET", DEFAULT_HMAC_SECRET)
 DB_PATH = os.getenv("TELEMETRY_DB_PATH", "./data/telemetry.db")
 ADMIN_TOKEN = os.getenv("TELEMETRY_ADMIN_TOKEN", "")
-MAX_BODY_SIZE = 512 * 1024  # 512 KB
+MAX_BODY_SIZE = 512 * 1024  # 512 KB（线路上的字节上限，gzip 后通常 ≤50KB）
+# 解压后的字节上限。客户端典型 payload 5-50KB raw，未来加埋点也压得住 1MB；
+# 设 2MB 给余量，同时挡 zip bomb（gzip 比 1:1000 也只能撑到 2MB）。
+MAX_DECOMPRESSED_SIZE = 2 * 1024 * 1024
 
 # ---------------------------------------------------------------------------
 # 初始化
@@ -62,6 +67,34 @@ app = FastAPI(
     redoc_url=None,
 )
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["POST", "GET"], allow_headers=["*"])
+
+
+def _decompress_if_gzip(body_bytes: bytes, content_encoding: str) -> bytes:
+    """按 ``Content-Encoding`` header 解压请求体。
+
+    向下兼容：header 缺失或为 'identity' 时透传原始 bytes，让老客户端
+    （v1 一直发的是裸 JSON）继续工作。
+
+    防 zip bomb：流式 read，看到超过 MAX_DECOMPRESSED_SIZE 立刻拒绝，
+    不让 gzip.decompress 在内存里展开任意大小的数据。
+    """
+    enc = (content_encoding or "").strip().lower()
+    if enc in ("", "identity"):
+        return body_bytes
+    if enc != "gzip":
+        raise HTTPException(415, f"Unsupported Content-Encoding: {enc}")
+    try:
+        with gzip.GzipFile(fileobj=io.BytesIO(body_bytes), mode="rb") as gz:
+            # 多读 1 字节用来判定是否超过 cap —— 超了直接 413，省得把整个
+            # bomb 解到内存里。
+            decompressed = gz.read(MAX_DECOMPRESSED_SIZE + 1)
+        if len(decompressed) > MAX_DECOMPRESSED_SIZE:
+            raise HTTPException(413, "Decompressed payload too large")
+        return decompressed
+    except HTTPException:
+        raise
+    except (OSError, EOFError, gzip.BadGzipFile) as e:
+        raise HTTPException(400, f"Invalid gzip body: {e}")
 
 
 def _extract_token(request: Request) -> str:
@@ -89,11 +122,14 @@ def require_admin(request: Request):
 
 @app.post("/api/v1/telemetry", response_model=SubmitResponse)
 async def submit_telemetry(request: Request):
-    """接收遥测数据。验证流程：body 大小 → 时间戳 → HMAC 签名 → 速率限制 → 存储。"""
-    # Body 大小
+    """接收遥测数据。验证流程：body 大小 → 解压 → 时间戳 → HMAC 签名 → 速率限制 → 存储。"""
+    # Body 大小（wire size，gzip 后通常 ≤50KB，给 512KB 余量）
     body_bytes = await request.body()
     if len(body_bytes) > MAX_BODY_SIZE:
         raise HTTPException(413, "Payload too large")
+
+    # 解压（如 Content-Encoding: gzip）；老客户端不带 header 直接透传
+    body_bytes = _decompress_if_gzip(body_bytes, request.headers.get("Content-Encoding", ""))
 
     try:
         body_json = body_bytes.decode("utf-8")
@@ -148,6 +184,13 @@ async def submit_telemetry(request: Request):
     # 存储
     try:
         daily_stats_dict = {k: model_to_dict(v) for k, v in submission.payload.daily_stats.items()}
+        # instruments 是 Optional —— 老客户端不带这个字段时 submission.payload.instruments
+        # 为 None。Pydantic v1/v2 兼容：用 model_to_dict 拆掉嵌套 model。
+        instruments_dict = (
+            model_to_dict(submission.payload.instruments)
+            if submission.payload.instruments is not None
+            else None
+        )
         storage.store_event(
             device_id=device_id,
             app_version=submission.payload.app_version,
@@ -159,6 +202,7 @@ async def submit_telemetry(request: Request):
             timezone=submission.payload.timezone,
             distribution=submission.payload.distribution,
             steam_user_id=steam_user_id,
+            instruments=instruments_dict,
         )
     except Exception as e:
         logger.error(f"Store failed for {device_id[:8]}...: {e}")
@@ -231,6 +275,8 @@ async def admin_dashboard(request: Request, days: int = 30):
     stats = storage.get_global_stats(days=days)
     devices = storage.get_active_devices(days=7, limit=20)
     user_metrics = storage.get_user_metrics(days=days)
+    top_counters = storage.get_top_counters(days=days, limit=30)
+    histograms = storage.get_histogram_summary(days=days, limit=30)
 
     # 传递 token 到导出链接（URL-encode 防止特殊字符截断查询串）
     tk = quote(_extract_token(request), safe="")
@@ -325,6 +371,35 @@ async def admin_dashboard(request: Request, days: int = 30):
             <td>{d['recent_tokens']:,}</td>
         </tr>"""
 
+    # Instrument tables —— counter / histogram 跨设备汇总
+    counter_rows = ""
+    for c in top_counters:
+        counter_rows += f"""<tr>
+            <td>{esc(c['metric_key'])}</td>
+            <td>{int(c['total']):,}</td>
+            <td>{c['devices']:,}</td>
+        </tr>"""
+    if not counter_rows:
+        counter_rows = '<tr><td colspan="3" style="color:#484f58">No counter data yet</td></tr>'
+
+    histogram_rows = ""
+    for h in histograms:
+        p50 = h['p50_bucket']
+        p95 = h['p95_bucket']
+        p50_txt = (f"≤{p50['upper_bound']}" if p50['upper_bound'] is not None
+                   else f"bucket#{p50['bucket_index']}+")
+        p95_txt = (f"≤{p95['upper_bound']}" if p95['upper_bound'] is not None
+                   else f"bucket#{p95['bucket_index']}+")
+        histogram_rows += f"""<tr>
+            <td>{esc(h['metric_key'])}</td>
+            <td>{h['count']:,}</td>
+            <td>{h['avg']:,}</td>
+            <td>{p50_txt}</td>
+            <td>{p95_txt}</td>
+        </tr>"""
+    if not histogram_rows:
+        histogram_rows = '<tr><td colspan="5" style="color:#484f58">No histogram data yet</td></tr>'
+
     page_html = f"""<!DOCTYPE html>
 <html><head>
 <meta charset="utf-8"><title>N.E.K.O Telemetry Dashboard</title>
@@ -406,6 +481,18 @@ async def admin_dashboard(request: Request, days: int = 30):
 <table>
   <tr><th>Device</th><th>Version</th><th>Last Seen</th><th>Calls</th><th>Tokens</th></tr>
   {device_rows}
+</table>
+
+<h2>Top Counters (last {days} days)</h2>
+<table>
+  <tr><th>Metric</th><th>Total</th><th>Devices</th></tr>
+  {counter_rows}
+</table>
+
+<h2>Histograms — p50 / p95 (last {days} days)</h2>
+<table>
+  <tr><th>Metric</th><th>Count</th><th>Avg</th><th>p50 bucket</th><th>p95 bucket</th></tr>
+  {histogram_rows}
 </table>
 
 </body></html>"""

--- a/local_server/telemetry_server/server.py
+++ b/local_server/telemetry_server/server.py
@@ -239,9 +239,11 @@ async def admin_devices(days: int = 7):
 
 @app.post("/api/v1/admin/prune", dependencies=[Depends(require_admin)])
 async def admin_prune(max_days: int = 180):
-    """清理旧事件日志（聚合数据保留）。"""
-    deleted = storage.prune_old_events(max_days=max(max_days, 30))
-    return {"deleted_events": deleted}
+    """清理旧事件日志 + instrument 聚合（daily_aggregates 永久保留）。"""
+    days = max(max_days, 30)
+    deleted_events = storage.prune_old_events(max_days=days)
+    deleted_instruments = storage.prune_old_instruments(max_days=days)
+    return {"deleted_events": deleted_events, "deleted_instruments": deleted_instruments}
 
 
 # ---------------------------------------------------------------------------

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -55,6 +55,23 @@ def _bucket_quantile(buckets: list, bounds: list, q: float) -> dict:
     return {"upper_bound": None, "bucket_index": len(buckets) - 1}
 
 
+def _as_int_count(x) -> int | None:
+    """把整数计数语义的值归一化成 int；非整数 / NaN / Inf / bool 返回 None。
+
+    histogram 的 count 和 bucket 必须是整数计数。接受 int 或整数值 float
+    （如 ``4.0``，跨序列化器容差），拒 ``4.5`` / NaN / Inf / True/False。
+    归一化后再做 sum==count 校验和写库，避免 ``int()`` 截断造成不一致。
+    """
+    if isinstance(x, bool):
+        return None
+    if isinstance(x, int):
+        return x
+    if isinstance(x, float):
+        if math.isfinite(x) and x.is_integer():
+            return int(x)
+    return None
+
+
 class TelemetryStorage:
     """线程安全的 SQLite 遥测存储。"""
 
@@ -415,17 +432,29 @@ class TelemetryStorage:
                 continue
             count = h.get("count", 0)
             hsum = h.get("sum", 0.0)
-            buckets = h.get("buckets") or []
-            if not isinstance(count, (int, float)) or not isinstance(hsum, (int, float)):
+            raw_buckets = h.get("buckets") or []
+            if not isinstance(raw_buckets, list):
                 continue
-            # 同 counter：拒 NaN / Inf 防 NULL→IntegrityError 整批回滚（Codex P2）。
-            if not math.isfinite(count) or not math.isfinite(hsum):
+            # count 和 bucket 是**整数计数**语义：归一化成 int（接受 int 或
+            # 整数值 float 如 4.0），非整数值 / NaN / Inf / bool 一律 reject。
+            # 否则后面写库 int(count) 截断会让 count 与 buckets 落库后不一致
+            # （如 count=0.5, buckets=[0.5] 能过 sum==count 浮点校验，但写库
+            # int(0.5)=0 而 buckets 存 [0.5]，dashboard 分位数算错）（CodeRabbit）。
+            count = _as_int_count(count)
+            if count is None:
                 continue
-            if not isinstance(buckets, list):
+            buckets = []
+            _bucket_ok = True
+            for b in raw_buckets:
+                bi = _as_int_count(b)
+                if bi is None:
+                    _bucket_ok = False
+                    break
+                buckets.append(bi)
+            if not _bucket_ok:
                 continue
-            # bucket 元素也要全是 finite 数字——非有限值进 json.dumps 会产出
-            # 非法 "NaN" token，下游解析/合并出问题。
-            if not all(isinstance(b, (int, float)) and math.isfinite(b) for b in buckets):
+            # hsum 是观测值之和，可以是小数（如延迟求和），只要 finite 非 bool。
+            if isinstance(hsum, bool) or not isinstance(hsum, (int, float)) or not math.isfinite(hsum):
                 continue
             # 形状自洽校验（防伪造 / 损坏 payload 把 dashboard 静默带歪）：
             # get_histogram_summary 的 avg 用 count、p50/p95 用 buckets，count 与

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -330,10 +330,19 @@ class TelemetryStorage:
         #   3) fallback_stat_date（一般是 today.isoformat()）— 兜底。
         stat_date = fallback_stat_date or date.today().isoformat()
         client_date = instruments.get("stat_date")
-        if (isinstance(client_date, str)
-                and len(client_date) == 10
-                and client_date[4] == "-"
-                and client_date[7] == "-"):
+        # 真 ISO 校验，不能只看长度+dash 位置：HMAC 密钥在开源客户端里可读，
+        # 伪造 payload 可塞 "9999-99-99" / "abcd-ef-gh"——这类坏值长度和 dash
+        # 位置都过，但落库后 retention 的字典序比较（stat_date < cutoff）永远
+        # prune 不掉，还会在 dashboard 凭空多出垃圾分区。date.fromisoformat
+        # 解析失败就走 window_end / fallback 回退（Codex 指出）。
+        valid_client_date = False
+        if isinstance(client_date, str) and len(client_date) == 10:
+            try:
+                date.fromisoformat(client_date)
+                valid_client_date = True
+            except ValueError:
+                valid_client_date = False
+        if valid_client_date:
             stat_date = client_date
         else:
             try:

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -780,5 +780,24 @@ class TelemetryStorage:
             conn.execute("DELETE FROM seen_batches WHERE received_at < ?", (cutoff,))
             return result.rowcount
 
+    def prune_old_instruments(self, max_days: int = 180) -> int:
+        """清理超期的 instrument_counters / instrument_histograms 行。
+
+        这两张表按 (device_id, stat_date, metric_key) 累加，不清理会随时间
+        无限增长。对齐 events 表的 180 天 retention。stat_date 是
+        ``YYYY-MM-DD`` 字符串（客户端本地日历天），可直接字典序比较。
+
+        返回两张表删除的总行数。
+        """
+        cutoff = (date.today() - timedelta(days=max_days)).isoformat()
+        with self._transaction() as conn:
+            r1 = conn.execute(
+                "DELETE FROM instrument_counters WHERE stat_date < ?", (cutoff,)
+            )
+            r2 = conn.execute(
+                "DELETE FROM instrument_histograms WHERE stat_date < ?", (cutoff,)
+            )
+            return r1.rowcount + r2.rowcount
+
     def vacuum(self):
         self._get_conn().execute("VACUUM")

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -240,10 +240,17 @@ class TelemetryStorage:
         today = date.today().isoformat()
         with self._transaction() as conn:
             if batch_id:
-                conn.execute(
+                cur = conn.execute(
                     "INSERT OR IGNORE INTO seen_batches (batch_id) VALUES (?)",
                     (batch_id,),
                 )
+                # 真幂等闸：rowcount==0 = batch_id 已存在（server.py 预检与本次
+                # 写入之间的 TOCTOU / 并发重试）。配合 _transaction 的 BEGIN
+                # IMMEDIATE 写锁，此检查与下游写入原子——第二个并发请求在这里
+                # 短路，不再继续写 events / daily_aggregates / instrument_*，
+                # 避免双写双计（CodeRabbit）。
+                if cur.rowcount == 0:
+                    return
             conn.execute(
                 "INSERT INTO events (device_id, app_version, payload, event_date) VALUES (?, ?, ?, ?)",
                 (device_id, app_version, payload_json, today),
@@ -419,6 +426,16 @@ class TelemetryStorage:
             # bucket 元素也要全是 finite 数字——非有限值进 json.dumps 会产出
             # 非法 "NaN" token，下游解析/合并出问题。
             if not all(isinstance(b, (int, float)) and math.isfinite(b) for b in buckets):
+                continue
+            # 形状自洽校验（防伪造 / 损坏 payload 把 dashboard 静默带歪）：
+            # get_histogram_summary 的 avg 用 count、p50/p95 用 buckets，count 与
+            # buckets 不一致就会让两个数字打架。要求 count 非负、bucket 非负、
+            # bounds 长度匹配（len==buckets-1，溢出桶）、且 sum(buckets)==count。
+            if count < 0 or any(b < 0 for b in buckets):
+                continue
+            if bounds and len(bounds) != len(buckets) - 1:
+                continue
+            if sum(buckets) != count:
                 continue
 
             # SQL 不擅长 array element-wise 加；读出现有 buckets，

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -322,16 +322,29 @@ class TelemetryStorage:
         if not instruments or not isinstance(instruments, dict):
             return
 
-        # stat_date 选 window_end 那天（窗口末尾决定归属，避免跨午夜把
-        # 第二天初的事件算到第一天）。失败回退到 fallback_stat_date。
+        # stat_date 选取优先级（CodeRabbit 反馈正解）：
+        #   1) 客户端 snapshot 里的 ``stat_date``（客户端本地日历天） —
+        #      跟客户端的 ``daily_stats`` key 完全同口径，跨时区设备
+        #      在午夜附近上报不会被服务端本地时区误拆到两天。
+        #   2) window_end 时间戳按服务端时区落天 — 老客户端兼容回退。
+        #   3) fallback_stat_date（一般是 today.isoformat()）— 兜底。
         stat_date = fallback_stat_date or date.today().isoformat()
-        try:
-            window_end = instruments.get("window_end")
-            if isinstance(window_end, (int, float)) and window_end > 0:
-                from datetime import datetime as _dt
-                stat_date = _dt.fromtimestamp(window_end).date().isoformat()
-        except (TypeError, ValueError, OSError):
-            pass
+        client_date = instruments.get("stat_date")
+        if (isinstance(client_date, str)
+                and len(client_date) == 10
+                and client_date[4] == "-"
+                and client_date[7] == "-"):
+            stat_date = client_date
+        else:
+            try:
+                window_end = instruments.get("window_end")
+                if isinstance(window_end, (int, float)) and window_end > 0:
+                    from datetime import datetime as _dt
+                    stat_date = _dt.fromtimestamp(window_end).date().isoformat()
+            except (TypeError, ValueError, OSError):
+                # fromtimestamp 失败（数值越界 / OS 时间错乱）：保持上面的
+                # fallback_stat_date / today，不让一条坏 payload 整批回滚。
+                pass
 
         counters = instruments.get("counters") or {}
         histograms = instruments.get("histograms") or {}
@@ -682,6 +695,8 @@ class TelemetryStorage:
                     if isinstance(bnd, list):
                         slot["bounds"] = bnd
                 except (json.JSONDecodeError, TypeError):
+                    # bounds 列损坏（极少见）：保留 slot["bounds"] = None，
+                    # 下个有效行有机会再设；查询端 p50/p95 计算允许 bounds 为空。
                     pass
 
         out = []

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -364,39 +364,40 @@ class TelemetryStorage:
         #      在午夜附近上报不会被服务端本地时区误拆到两天。
         #   2) window_end 时间戳按服务端时区落天 — 老客户端兼容回退。
         #   3) fallback_stat_date（一般是 today.isoformat()）— 兜底。
+        # 兜底：fallback_stat_date（一般 today）。下面按优先级求一个 candidate
+        # 日期，但**两条来源都必须过同一个 recency 校验**才采用。
         stat_date = fallback_stat_date or date.today().isoformat()
+        today = date.today()
+        candidate: date | None = None
+
+        # 来源 1：客户端 snapshot 的 stat_date（客户端本地日历天，跟 daily_stats
+        # 同口径）。HMAC 密钥在开源客户端可读，伪造 payload 可塞
+        # "9999-99-99"/"abcd-ef-gh"（解析失败）或 "9999-12-31"（能解析但越界）。
         client_date = instruments.get("stat_date")
-        # 真 ISO 校验，不能只看长度+dash 位置：HMAC 密钥在开源客户端里可读，
-        # 伪造 payload 可塞 "9999-99-99" / "abcd-ef-gh"——这类坏值长度和 dash
-        # 位置都过，但落库后 retention 的字典序比较（stat_date < cutoff）永远
-        # prune 不掉，还会在 dashboard 凭空多出垃圾分区。date.fromisoformat
-        # 解析失败就走 window_end / fallback 回退（Codex 指出）。
-        valid_client_date = False
         if isinstance(client_date, str) and len(client_date) == 10:
             try:
-                _parsed = date.fromisoformat(client_date)
-                # 范围约束：instrument 是实时窗口（snapshot clear-on-read，不会
-                # 从 unsent 队列补发历史），stat_date 应该≈服务端今天。客户端
-                # 时区最多 ±14h + 时钟偏差，放宽到 ±2 天。像 "9999-12-31" 这种
-                # 能过 fromisoformat 但越界的伪造未来日期同样会绕过
-                # prune_old_instruments 的字典序清理、污染 dashboard 分区，所以
-                # 越界一律回退（CodeRabbit）。
-                if abs((_parsed - date.today()).days) <= 2:
-                    valid_client_date = True
+                candidate = date.fromisoformat(client_date)
             except ValueError:
-                valid_client_date = False
-        if valid_client_date:
-            stat_date = client_date
-        else:
-            try:
-                window_end = instruments.get("window_end")
-                if isinstance(window_end, (int, float)) and window_end > 0:
+                candidate = None
+
+        # 来源 2：window_end 时间戳按服务端时区落天（老客户端 / client_date 缺失
+        # 时回退）。同样要过下面的 recency 校验——偏斜时钟或伪造的 window_end
+        # 也能造远期 stat_date 逃过 retention（Codex）。
+        if candidate is None:
+            window_end = instruments.get("window_end")
+            if isinstance(window_end, (int, float)) and window_end > 0:
+                try:
                     from datetime import datetime as _dt
-                    stat_date = _dt.fromtimestamp(window_end).date().isoformat()
-            except (TypeError, ValueError, OSError):
-                # fromtimestamp 失败（数值越界 / OS 时间错乱）：保持上面的
-                # fallback_stat_date / today，不让一条坏 payload 整批回滚。
-                pass
+                    candidate = _dt.fromtimestamp(window_end).date()
+                except (TypeError, ValueError, OSError, OverflowError):
+                    candidate = None
+
+        # 统一 recency 校验：instrument 是实时窗口（snapshot clear-on-read，不从
+        # unsent 队列补发历史），stat_date 必≈服务端今天。客户端时区最多 ±14h +
+        # 时钟偏差，放宽到 ±2 天。越界（伪造未来日期 / 时钟错乱）一律走 fallback，
+        # 否则字典序 retention（stat_date < cutoff）永远 prune 不掉、污染 dashboard。
+        if candidate is not None and abs((candidate - today).days) <= 2:
+            stat_date = candidate.isoformat()
 
         counters = instruments.get("counters") or {}
         histograms = instruments.get("histograms") or {}

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -366,17 +366,21 @@ class TelemetryStorage:
         #   3) fallback_stat_date（一般是 today.isoformat()）— 兜底。
         # 兜底：fallback_stat_date（一般 today）。下面按优先级求一个 candidate
         # 日期，但**两条来源都必须过同一个 recency 校验**才采用。
-        stat_date = fallback_stat_date or date.today().isoformat()
+        today = date.today()
+        stat_date = today.isoformat()
         # recency anchor：在线实时上报锚到今天；但 store_instruments 文档承诺支持
         # 离线导入 / 跨表回填——调用方显式传了 fallback_stat_date 时，就拿它当
-        # anchor 校验历史样本，否则合法的历史快照会被压回今天打歪导入分区
-        # （CodeRabbit）。live 路径传的 fallback 就是 today，行为不变。
-        recency_anchor = date.today()
+        # anchor 校验历史样本，否则合法的历史快照会被压回今天打歪导入分区。
+        # live 路径传的 fallback 就是 today，行为不变。
+        # **只有解析成功才把 fallback 回填进 stat_date** —— 否则像 "foo" 这种
+        # 无效 fallback 会被原样落库污染 retention 分区（CodeRabbit）。
+        recency_anchor = today
         if fallback_stat_date:
             try:
                 recency_anchor = date.fromisoformat(fallback_stat_date)
+                stat_date = recency_anchor.isoformat()
             except ValueError:
-                recency_anchor = date.today()
+                recency_anchor = today
         candidate: date | None = None
 
         # 来源 1：客户端 snapshot 的 stat_date（客户端本地日历天，跟 daily_stats

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -367,7 +367,16 @@ class TelemetryStorage:
         # 兜底：fallback_stat_date（一般 today）。下面按优先级求一个 candidate
         # 日期，但**两条来源都必须过同一个 recency 校验**才采用。
         stat_date = fallback_stat_date or date.today().isoformat()
-        today = date.today()
+        # recency anchor：在线实时上报锚到今天；但 store_instruments 文档承诺支持
+        # 离线导入 / 跨表回填——调用方显式传了 fallback_stat_date 时，就拿它当
+        # anchor 校验历史样本，否则合法的历史快照会被压回今天打歪导入分区
+        # （CodeRabbit）。live 路径传的 fallback 就是 today，行为不变。
+        recency_anchor = date.today()
+        if fallback_stat_date:
+            try:
+                recency_anchor = date.fromisoformat(fallback_stat_date)
+            except ValueError:
+                recency_anchor = date.today()
         candidate: date | None = None
 
         # 来源 1：客户端 snapshot 的 stat_date（客户端本地日历天，跟 daily_stats
@@ -396,7 +405,7 @@ class TelemetryStorage:
         # unsent 队列补发历史），stat_date 必≈服务端今天。客户端时区最多 ±14h +
         # 时钟偏差，放宽到 ±2 天。越界（伪造未来日期 / 时钟错乱）一律走 fallback，
         # 否则字典序 retention（stat_date < cutoff）永远 prune 不掉、污染 dashboard。
-        if candidate is not None and abs((candidate - today).days) <= 2:
+        if candidate is not None and abs((candidate - recency_anchor).days) <= 2:
             stat_date = candidate.isoformat()
 
         counters = instruments.get("counters") or {}

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -18,11 +18,40 @@ from __future__ import annotations
 
 import csv
 import io
+import json
+import logging
 import sqlite3
 import threading
 from contextlib import contextmanager
 from datetime import date, timedelta
 from pathlib import Path
+
+_logger = logging.getLogger("telemetry.storage")
+
+
+def _bucket_quantile(buckets: list, bounds: list, q: float) -> dict:
+    """近似分位数：找累计样本数首次 >= q*total 的桶，返回该桶上界。
+
+    Args:
+        buckets: 桶 count 列表，最后一个是溢出桶（>最右 bound）
+        bounds: 桶上界列表，len(bounds) == len(buckets) - 1
+        q: 分位数（0~1）
+
+    Returns:
+        {"upper_bound": 数值或 None, "bucket_index": int}
+        upper_bound None 表示落在溢出桶（无上界）。
+    """
+    total = sum(buckets) if buckets else 0
+    if total <= 0:
+        return {"upper_bound": None, "bucket_index": -1}
+    target = q * total
+    cum = 0
+    for i, c in enumerate(buckets):
+        cum += c
+        if cum >= target:
+            upper = bounds[i] if i < len(bounds) else None
+            return {"upper_bound": upper, "bucket_index": i}
+    return {"upper_bound": None, "bucket_index": len(buckets) - 1}
 
 
 class TelemetryStorage:
@@ -109,6 +138,42 @@ class TelemetryStorage:
                     batch_id    TEXT PRIMARY KEY,
                     received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'))
                 );
+
+                -- ---- Instrument aggregates ----
+                -- Counter：按 (天, 设备, metric_key) 唯一，value 累加。metric_key
+                -- 是客户端 utils/instrument._make_key 的产物，形如 "name" 或
+                -- "name|dim1=v1,dim2=v2"。维度切片靠 dashboard 端 SQL LIKE
+                -- 或后续加专门的 dims 列做拆分。
+                CREATE TABLE IF NOT EXISTS instrument_counters (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    stat_date  TEXT    NOT NULL,
+                    device_id  TEXT    NOT NULL,
+                    metric_key TEXT    NOT NULL,
+                    value      REAL    NOT NULL DEFAULT 0,
+                    updated_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
+                    UNIQUE(stat_date, device_id, metric_key)
+                );
+                CREATE INDEX IF NOT EXISTS idx_ic_date ON instrument_counters(stat_date);
+                CREATE INDEX IF NOT EXISTS idx_ic_key  ON instrument_counters(metric_key);
+
+                -- Histogram：count / sum / buckets（JSON 数组）累加。bounds
+                -- 在客户端固定（utils/instrument._HIST_BOUNDS），后续若改
+                -- 需要数据迁移；当前用 ON CONFLICT 简单覆盖最新 bounds，
+                -- 历史 buckets 维度不一致时由查询端按 metric_key 自检。
+                CREATE TABLE IF NOT EXISTS instrument_histograms (
+                    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    stat_date  TEXT    NOT NULL,
+                    device_id  TEXT    NOT NULL,
+                    metric_key TEXT    NOT NULL,
+                    count      INTEGER NOT NULL DEFAULT 0,
+                    sum        REAL    NOT NULL DEFAULT 0,
+                    buckets    TEXT    NOT NULL DEFAULT '[]',
+                    bounds     TEXT    NOT NULL DEFAULT '[]',
+                    updated_at TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')),
+                    UNIQUE(stat_date, device_id, metric_key)
+                );
+                CREATE INDEX IF NOT EXISTS idx_ih_date ON instrument_histograms(stat_date);
+                CREATE INDEX IF NOT EXISTS idx_ih_key  ON instrument_histograms(metric_key);
             """)
             # 老库 devices 表上线时还没有 branch/locale/timezone/distribution/steam_user_id
             # 列。CREATE TABLE IF NOT EXISTS 不会动已存在的 schema，所以这里显式
@@ -158,7 +223,8 @@ class TelemetryStorage:
                     daily_stats: dict, batch_id: str | None = None,
                     branch: str = "unknown", locale: str = "unknown",
                     timezone: str = "unknown", distribution: str = "unknown",
-                    steam_user_id: str = ""):
+                    steam_user_id: str = "",
+                    instruments: dict | None = None):
         today = date.today().isoformat()
         with self._transaction() as conn:
             if batch_id:
@@ -220,6 +286,126 @@ class TelemetryStorage:
                     last_seen = strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours'),
                     event_count = event_count + 1
             """, (device_id, app_version, branch, locale, timezone, distribution, steam_user_id))
+
+            # Instrument 累加（同事务内）：失败回滚整批，daily_stats 不会
+            # 在 instruments 失败时半截入库。
+            if instruments:
+                self._apply_instruments(conn, device_id, instruments, fallback_stat_date=today)
+
+    def store_instruments(self, device_id: str, instruments: dict | None,
+                          fallback_stat_date: str | None = None) -> None:
+        """累加 instrument snapshot 的独立入口（自己开 transaction）。
+
+        通常由 store_event 在自己的事务里调 _apply_instruments；此入口给
+        独立测试 / 离线导入 / 跨表回填等场景用。
+        """
+        if not instruments:
+            return
+        with self._transaction() as conn:
+            self._apply_instruments(conn, device_id, instruments, fallback_stat_date)
+
+    def _apply_instruments(self, conn, device_id: str, instruments: dict | None,
+                           fallback_stat_date: str | None = None) -> None:
+        """累加 instrument snapshot（counter + histogram）。须在已开 transaction 的 conn 上调用。
+
+        Args:
+            conn: 调用方持有的事务连接
+            device_id: 上报设备
+            instruments: 客户端 utils/instrument.Instrument.snapshot() 的产物，
+                结构: {window_start, window_end, bounds, counters, histograms}
+            fallback_stat_date: 若 instruments 不带时间窗口或解析失败，用此值
+                作 stat_date（一般传 'today'）。
+
+        失败处理：单条 metric 解析失败不影响其它，整段失败抛 sqlite3 异常
+        由调用方 transaction 回滚。
+        """
+        if not instruments or not isinstance(instruments, dict):
+            return
+
+        # stat_date 选 window_end 那天（窗口末尾决定归属，避免跨午夜把
+        # 第二天初的事件算到第一天）。失败回退到 fallback_stat_date。
+        stat_date = fallback_stat_date or date.today().isoformat()
+        try:
+            window_end = instruments.get("window_end")
+            if isinstance(window_end, (int, float)) and window_end > 0:
+                from datetime import datetime as _dt
+                stat_date = _dt.fromtimestamp(window_end).date().isoformat()
+        except (TypeError, ValueError, OSError):
+            pass
+
+        counters = instruments.get("counters") or {}
+        histograms = instruments.get("histograms") or {}
+        bounds = instruments.get("bounds") or []
+        bounds_json = json.dumps(bounds, ensure_ascii=False)
+
+        # ---- counters ----
+        for metric_key, value in counters.items():
+            if not isinstance(metric_key, str) or not isinstance(value, (int, float)):
+                continue
+            if len(metric_key) > 256:
+                # 防御：客户端误传超长 key。截断不合并 —— 截断后可能跟
+                # 已有 key 冲突 UPSERT，污染数据。直接丢。
+                continue
+            conn.execute("""
+                INSERT INTO instrument_counters (stat_date, device_id, metric_key, value)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(stat_date, device_id, metric_key) DO UPDATE SET
+                    value      = value + excluded.value,
+                    updated_at = strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')
+            """, (stat_date, device_id, metric_key, float(value)))
+
+        # ---- histograms ----
+        for metric_key, h in histograms.items():
+            if not isinstance(metric_key, str) or not isinstance(h, dict):
+                continue
+            if len(metric_key) > 256:
+                continue
+            count = h.get("count", 0)
+            hsum = h.get("sum", 0.0)
+            buckets = h.get("buckets") or []
+            if not isinstance(count, (int, float)) or not isinstance(hsum, (int, float)):
+                continue
+            if not isinstance(buckets, list):
+                continue
+
+            # SQL 不擅长 array element-wise 加；读出现有 buckets，
+            # Python 端合并，再写回。同一 transaction 内保证一致性。
+            row = conn.execute(
+                "SELECT buckets FROM instrument_histograms "
+                "WHERE stat_date = ? AND device_id = ? AND metric_key = ?",
+                (stat_date, device_id, metric_key),
+            ).fetchone()
+
+            merged_buckets = list(buckets)
+            if row is not None:
+                try:
+                    existing = json.loads(row["buckets"])
+                    if isinstance(existing, list):
+                        # 长度不一致时取 max 并 zero-pad —— 给客户端
+                        # 改桶定义留缓冲（迁移期混合数据不爆炸）。
+                        n = max(len(existing), len(buckets))
+                        merged_buckets = [
+                            (existing[i] if i < len(existing) else 0)
+                            + (buckets[i] if i < len(buckets) else 0)
+                            for i in range(n)
+                        ]
+                except (json.JSONDecodeError, TypeError, ValueError) as e:
+                    _logger.debug(f"storage: histogram bucket merge fallback for {metric_key}: {e}")
+                    merged_buckets = list(buckets)
+
+            buckets_json = json.dumps(merged_buckets, ensure_ascii=False)
+            conn.execute("""
+                INSERT INTO instrument_histograms
+                    (stat_date, device_id, metric_key, count, sum, buckets, bounds)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(stat_date, device_id, metric_key) DO UPDATE SET
+                    count      = count + excluded.count,
+                    sum        = sum   + excluded.sum,
+                    buckets    = excluded.buckets,
+                    bounds     = excluded.bounds,
+                    updated_at = strftime('%Y-%m-%dT%H:%M:%f+08:00', 'now', '+8 hours')
+            """, (stat_date, device_id, metric_key, int(count), float(hsum),
+                  buckets_json, bounds_json))
 
     @staticmethod
     def _upsert_aggregate(conn, device_id, stat_date, model, call_type,
@@ -432,6 +618,91 @@ class TelemetryStorage:
             "dau_trend": dau_trend,
             "new_device_trend": new_trend,
         }
+
+    # ----- Instrument 查询 -----
+
+    def get_top_counters(self, days: int = 7, limit: int = 50) -> list[dict]:
+        """跨设备汇总最近 N 天的 counter 总量，按总量降序。
+
+        返回 [{"metric_key": ..., "total": ..., "devices": ...}]。
+        """
+        conn = self._get_conn()
+        cutoff = (date.today() - timedelta(days=days)).isoformat()
+        rows = conn.execute("""
+            SELECT metric_key,
+                   SUM(value) as total,
+                   COUNT(DISTINCT device_id) as devices
+            FROM instrument_counters
+            WHERE stat_date >= ?
+            GROUP BY metric_key
+            ORDER BY total DESC
+            LIMIT ?
+        """, (cutoff, limit)).fetchall()
+        return [{"metric_key": r["metric_key"], "total": r["total"], "devices": r["devices"]}
+                for r in rows]
+
+    def get_histogram_summary(self, days: int = 7, limit: int = 50) -> list[dict]:
+        """跨设备汇总最近 N 天的 histogram。
+
+        返回 [{"metric_key", "count", "sum", "avg", "p50_bucket", "p95_bucket", "bounds"}]。
+        p50/p95 桶用累积桶 + 桶数除以总样本数定位，精度受桶粒度限制 —— 用于
+        监控趋势够用，要精确分位数请查原始 events 表。
+        """
+        conn = self._get_conn()
+        cutoff = (date.today() - timedelta(days=days)).isoformat()
+        # 同一 metric_key 不同设备的 buckets 合并：拿出原始行后 Python 端 sum。
+        rows = conn.execute("""
+            SELECT metric_key, count, sum, buckets, bounds
+            FROM instrument_histograms
+            WHERE stat_date >= ?
+        """, (cutoff,)).fetchall()
+
+        agg: dict = {}
+        for r in rows:
+            key = r["metric_key"]
+            slot = agg.setdefault(key, {"count": 0, "sum": 0.0, "buckets": [], "bounds": None})
+            slot["count"] += r["count"] or 0
+            slot["sum"] += r["sum"] or 0.0
+            try:
+                bk = json.loads(r["buckets"]) if r["buckets"] else []
+            except (json.JSONDecodeError, TypeError):
+                bk = []
+            if not isinstance(bk, list):
+                bk = []
+            # 长度对齐合并（同 _apply_instruments 的策略）
+            n = max(len(slot["buckets"]), len(bk))
+            slot["buckets"] = [
+                (slot["buckets"][i] if i < len(slot["buckets"]) else 0)
+                + (bk[i] if i < len(bk) else 0)
+                for i in range(n)
+            ]
+            if slot["bounds"] is None and r["bounds"]:
+                try:
+                    bnd = json.loads(r["bounds"])
+                    if isinstance(bnd, list):
+                        slot["bounds"] = bnd
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+        out = []
+        for key, slot in agg.items():
+            count = slot["count"]
+            avg = (slot["sum"] / count) if count > 0 else 0.0
+            buckets = slot["buckets"]
+            bounds = slot["bounds"] or []
+            p50 = _bucket_quantile(buckets, bounds, 0.5)
+            p95 = _bucket_quantile(buckets, bounds, 0.95)
+            out.append({
+                "metric_key": key,
+                "count": count,
+                "sum": slot["sum"],
+                "avg": round(avg, 2),
+                "p50_bucket": p50,
+                "p95_bucket": p95,
+                "bounds": bounds,
+            })
+        out.sort(key=lambda x: -x["count"])
+        return out[:limit]
 
     # ----- 导出 -----
 

--- a/local_server/telemetry_server/storage.py
+++ b/local_server/telemetry_server/storage.py
@@ -20,6 +20,7 @@ import csv
 import io
 import json
 import logging
+import math
 import sqlite3
 import threading
 from contextlib import contextmanager
@@ -71,12 +72,23 @@ class TelemetryStorage:
             conn.execute("PRAGMA synchronous=NORMAL")
             conn.execute("PRAGMA busy_timeout=10000")
             conn.row_factory = sqlite3.Row
+            # 关掉 Python 的隐式事务管理，改由 _transaction 手动 BEGIN IMMEDIATE。
+            # 默认 deferred 事务在 WAL 下读不取写锁，histogram 的 read-merge-write
+            # 中间会被并发写者插入 → 丢更新。
+            conn.isolation_level = None
             self._local.conn = conn
         return self._local.conn
 
     @contextmanager
     def _transaction(self):
         conn = self._get_conn()
+        # BEGIN IMMEDIATE：事务一开始就取 SQLite 写锁，让 store_event 里
+        # histogram 的"读旧 buckets → Python 合并 → 写回"对并发写者（多 worker /
+        # 多进程，各自独立连接，甚至同一 device 的 main/agent/memory 三进程同时
+        # POST）串行化。否则两个请求都读到同一份旧 buckets、各自合并、后写者
+        # 覆盖前写者，bucket 分布与 count/sum 漂移（Codex P1）。busy_timeout=10000
+        # 让并发写者阻塞等待而非立刻 "database is locked"。
+        conn.execute("BEGIN IMMEDIATE")
         try:
             yield conn
             conn.commit()
@@ -338,8 +350,15 @@ class TelemetryStorage:
         valid_client_date = False
         if isinstance(client_date, str) and len(client_date) == 10:
             try:
-                date.fromisoformat(client_date)
-                valid_client_date = True
+                _parsed = date.fromisoformat(client_date)
+                # 范围约束：instrument 是实时窗口（snapshot clear-on-read，不会
+                # 从 unsent 队列补发历史），stat_date 应该≈服务端今天。客户端
+                # 时区最多 ±14h + 时钟偏差，放宽到 ±2 天。像 "9999-12-31" 这种
+                # 能过 fromisoformat 但越界的伪造未来日期同样会绕过
+                # prune_old_instruments 的字典序清理、污染 dashboard 分区，所以
+                # 越界一律回退（CodeRabbit）。
+                if abs((_parsed - date.today()).days) <= 2:
+                    valid_client_date = True
             except ValueError:
                 valid_client_date = False
         if valid_client_date:
@@ -364,6 +383,11 @@ class TelemetryStorage:
         for metric_key, value in counters.items():
             if not isinstance(metric_key, str) or not isinstance(value, (int, float)):
                 continue
+            # 拒 NaN / Inf：SQLite REAL NOT NULL 收到 NaN 会被 Python binding
+            # 映射成 NULL → IntegrityError → 整个 store_event 事务回滚，连带
+            # 合法的 daily_stats 一起丢。跳过单个坏样本而非炸整批（Codex P2）。
+            if not math.isfinite(value):
+                continue
             if len(metric_key) > 256:
                 # 防御：客户端误传超长 key。截断不合并 —— 截断后可能跟
                 # 已有 key 冲突 UPSERT，污染数据。直接丢。
@@ -387,7 +411,14 @@ class TelemetryStorage:
             buckets = h.get("buckets") or []
             if not isinstance(count, (int, float)) or not isinstance(hsum, (int, float)):
                 continue
+            # 同 counter：拒 NaN / Inf 防 NULL→IntegrityError 整批回滚（Codex P2）。
+            if not math.isfinite(count) or not math.isfinite(hsum):
+                continue
             if not isinstance(buckets, list):
+                continue
+            # bucket 元素也要全是 finite 数字——非有限值进 json.dumps 会产出
+            # 非法 "NaN" token，下游解析/合并出问题。
+            if not all(isinstance(b, (int, float)) and math.isfinite(b) for b in buckets):
                 continue
 
             # SQL 不擅长 array element-wise 加；读出现有 buckets，

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1952,6 +1952,7 @@ class LLMSessionManager:
                     from utils.token_tracker import TokenTracker as _TT
                     _TT.get_instance().note_first_user_message("voice")
                 except Exception:
+                    # 埋点 best-effort，绝不阻塞语音转录消息处理（同文本路径）。
                     pass
                 # 与 on_user_message 对偶：把"用户原话"推到插件总线 user-context
                 # bucket。文本路径在 _process_stream_data_internal 已自行调用，
@@ -6031,6 +6032,8 @@ class LLMSessionManager:
                         from utils.token_tracker import TokenTracker as _TT
                         _TT.get_instance().note_first_user_message("text")
                     except Exception:
+                        # 埋点 best-effort，绝不阻塞用户消息处理；note_first_user_message
+                        # 自身幂等，丢一次也不影响 D1 漏斗统计。
                         pass
                     # 与 on_user_message 对偶：把"用户原话"推到插件总线 user-context
                     # bucket。语音路径在 handle_input_transcript 里发布，这里只覆盖
@@ -6781,6 +6784,7 @@ class LLMSessionManager:
                             from utils.instrument import counter as _instr_counter
                             _instr_counter("tts_error", code=str(self._last_tts_error_code or "unknown")[:32])
                         except Exception:
+                            # 埋点 best-effort，绝不影响 TTS 错误的重试/上报主流程。
                             pass
                         # 可重试的错误：前2次静默重试，第3次失败时上报前端
                         if self._last_tts_error_code not in IMMEDIATE_REPORT_TTS_CODES:
@@ -6801,6 +6805,8 @@ class LLMSessionManager:
                             from utils.token_tracker import TokenTracker as _TT
                             _TT.get_instance().note_core_loop_completed()
                         except Exception:
+                            # 埋点 best-effort，绝不影响音频投递主流程；
+                            # note_core_loop_completed 自身幂等。
                             pass
                     else:
                         self._discard_pending_ai_voice_echo()

--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -1947,6 +1947,12 @@ class LLMSessionManager:
             if transcript_text:
                 self._activity_tracker.on_user_message(text=transcript)
                 self._session_turn_count += 1
+                # Telemetry：D1 漏斗——本进程首条用户消息（语音路径）。
+                try:
+                    from utils.token_tracker import TokenTracker as _TT
+                    _TT.get_instance().note_first_user_message("voice")
+                except Exception:
+                    pass
                 # 与 on_user_message 对偶：把"用户原话"推到插件总线 user-context
                 # bucket。文本路径在 _process_stream_data_internal 已自行调用，
                 # 这里只覆盖语音路径，避免 openclaw handoff（is_voice_source=False）
@@ -6020,6 +6026,12 @@ class LLMSessionManager:
                     # main_routers/system_router.py），那不算用户活动。
                     # text 进 buffer 给 emotion-tier 用。
                     self._activity_tracker.on_user_message(text=data if isinstance(data, str) else None)
+                    # Telemetry：D1 漏斗——本进程首条用户消息（lazy import 防循环）。
+                    try:
+                        from utils.token_tracker import TokenTracker as _TT
+                        _TT.get_instance().note_first_user_message("text")
+                    except Exception:
+                        pass
                     # 与 on_user_message 对偶：把"用户原话"推到插件总线 user-context
                     # bucket。语音路径在 handle_input_transcript 里发布，这里只覆盖
                     # 文本路径，避免 openclaw handoff（会再走一次 handle_input_transcript
@@ -6762,6 +6774,14 @@ class LLMSessionManager:
                             else:
                                 user_msg = json.dumps({"code": "TTS_CONNECTION_FAILED", "details": {"msg": error_msg_text}})
                                 self._last_tts_error_code = 'TTS_CONNECTION_FAILED'
+                        # Telemetry：TTS 失败。code 是已归一化的低基数枚举
+                        # （API_ARREARS / API_KEY_REJECTED / TTS_CONNECTION_FAILED ...）。
+                        # 首日听不到语音是核心体验断裂，D1 流失重要信号。
+                        try:
+                            from utils.instrument import counter as _instr_counter
+                            _instr_counter("tts_error", code=str(self._last_tts_error_code or "unknown")[:32])
+                        except Exception:
+                            pass
                         # 可重试的错误：前2次静默重试，第3次失败时上报前端
                         if self._last_tts_error_code not in IMMEDIATE_REPORT_TTS_CODES:
                             self._tts_retry_notify_count += 1
@@ -6774,6 +6794,14 @@ class LLMSessionManager:
                     _, speech_id, audio_payload = data
                     if await self.send_speech(audio_payload, speech_id=speech_id):
                         self._confirm_pending_ai_voice_echo(speech_id)
+                        # Telemetry：音频成功投递 = 用户听到了角色的声音。配合
+                        # note_core_loop_completed 的"用户已开口"前置，构成 D1
+                        # 核心 loop 完成信号（每进程一次，内部幂等）。
+                        try:
+                            from utils.token_tracker import TokenTracker as _TT
+                            _TT.get_instance().note_core_loop_completed()
+                        except Exception:
+                            pass
                     else:
                         self._discard_pending_ai_voice_echo()
                     continue

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1325,6 +1325,7 @@ class OmniOfflineClient:
                                     from utils.instrument import histogram as _instr_h
                                     _instr_h("llm_ttft_ms", max(0.0, (time.time() - _ttft_start) * 1000.0))
                                 except Exception:
+                                    # 埋点 best-effort，绝不打断流式响应主路径。
                                     pass
                             if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
                                 chunk_usage = chunk.usage_metadata
@@ -1723,6 +1724,7 @@ class OmniOfflineClient:
                         if is_api_key_rejected:
                             _instr_counter("api_key_invalid")
                     except Exception:
+                        # 埋点 best-effort，绝不掩盖/打断原始 LLM 错误的处理路径。
                         pass
                     if is_api_key_rejected:
                         status_error_payload = {"code": "API_KEY_REJECTED"}

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1282,6 +1282,11 @@ class OmniOfflineClient:
                     assistant_message = ""
                     assistant_message_total = ""
                     guard_attempt = 0
+                    # Telemetry：TTFT（首 token 延迟）。从这里到第一个 chunk 到达
+                    # 的时长，D1 流失里"响应太慢"的关键信号。只记一次（首 attempt
+                    # 首 chunk）；reroll 不重置，反映用户真实等待体感。
+                    _ttft_start = time.time()
+                    _ttft_recorded = False
                     while guard_attempt <= self.max_response_rerolls:
                         self._is_responding = True
                         assistant_message = ""           # 仅最后一段未持久化的 text，用于 final AIMessage append
@@ -1314,6 +1319,13 @@ class OmniOfflineClient:
                         # shape as raw ``self.llm.astream``, so the existing
                         # prefix/fence/length-guard logic below is untouched.
                         async for chunk in self._astream_with_tools(self._conversation_history):
+                            if not _ttft_recorded:
+                                _ttft_recorded = True
+                                try:
+                                    from utils.instrument import histogram as _instr_h
+                                    _instr_h("llm_ttft_ms", max(0.0, (time.time() - _ttft_start) * 1000.0))
+                                except Exception:
+                                    pass
                             if hasattr(chunk, 'usage_metadata') and chunk.usage_metadata:
                                 chunk_usage = chunk.usage_metadata
                                 logger.debug(f"🔍 [Usage] {chunk_usage}")
@@ -1702,6 +1714,16 @@ class OmniOfflineClient:
                         break
                 except Exception as e:
                     is_api_key_rejected = _is_api_key_rejected_error(e)
+                    # Telemetry：D1 流失里 LLM 调用失败是大头。error_class 低基数
+                    # （exception 类名）；api_key_invalid 单独计——首日配错 key
+                    # 是源码版用户的常见流失坑。
+                    try:
+                        from utils.instrument import counter as _instr_counter
+                        _instr_counter("llm_error", error_class=type(e).__name__[:48])
+                        if is_api_key_rejected:
+                            _instr_counter("api_key_invalid")
+                    except Exception:
+                        pass
                     if is_api_key_rejected:
                         status_error_payload = {"code": "API_KEY_REJECTED"}
                         discard_error_payload = status_error_payload

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1667,15 +1667,30 @@ class OmniOfflineClient:
                     is_internal_error = isinstance(e, InternalServerError)
                     logger.info(f"ℹ️ 捕获到 {error_type} 错误")
 
+                    def _count_llm_error(api_key_rejected: bool = False):
+                        # D1 失败诊断：typed API 错误（连接/认证/限流/欠费/配额/
+                        # key 拒绝）的**终态**也要计入 llm_error。只在给上的 break
+                        # 路径调，不在 retry-continue 调（重试中不算失败）。generic
+                        # except 与本块互斥，不会双计（Codex）。
+                        try:
+                            from utils.instrument import counter as _ic
+                            _ic("llm_error", error_class=error_type[:48])
+                            if api_key_rejected:
+                                _ic("api_key_invalid")
+                        except Exception:
+                            pass
+
                     # 欠费/API Key 错误立即上报并终止；配额错误上报但继续重试
                     if '欠费' in error_str_lower or 'standing' in error_str_lower:
                         logger.error(f"OmniOfflineClient: 检测到欠费错误，直接上报: {e}")
+                        _count_llm_error()
                         if self.on_status_message:
                             await self.on_status_message(json.dumps({"code": "API_ARREARS"}))
                             status_reported = True
                         break
                     elif _is_api_key_rejected_error(e):
                         logger.error(f"OmniOfflineClient: 检测到 API Key 错误，直接上报: {e}")
+                        _count_llm_error(api_key_rejected=True)
                         if self.on_status_message:
                             await self.on_status_message(json.dumps({"code": "API_KEY_REJECTED"}))
                             status_reported = True
@@ -1706,6 +1721,7 @@ class OmniOfflineClient:
                     else:
                         error_msg = f"💥 LLM连接失败（{error_type}），已重试{max_retries}次: {e}"
                         logger.error(error_msg)
+                        _count_llm_error()  # 重试耗尽 = 终态失败，计入 llm_error
                         if self.on_status_message:
                             if is_internal_error:
                                 await self.on_status_message(json.dumps({"code": "LLM_UPSTREAM_ERROR"}))

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -1678,6 +1678,7 @@ class OmniOfflineClient:
                             if api_key_rejected:
                                 _ic("api_key_invalid")
                         except Exception:
+                            # 埋点 best-effort，绝不影响错误上报 / 重试主流程。
                             pass
 
                     # 欠费/API Key 错误立即上报并终止；配额错误上报但继续重试

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2802,6 +2802,8 @@ async def set_persona_onboarding_state(request: Request):
         _instr_event("onboarding_step", status=status_in[:32])
         _instr_counter("onboarding_step", status=status_in[:32])
     except Exception:
+        # 埋点失败绝不影响 onboarding endpoint —— 一条 telemetry 走丢比让
+        # 用户卡在角色选择失败重要多了。日志也省，防 import 故障刷屏。
         pass
     return {
         "success": True,

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2788,11 +2788,21 @@ async def set_persona_onboarding_state(request: Request):
     if error_response is not None:
         return error_response
     config_manager = get_config_manager()
+    status_in = str((payload or {}).get("status") or "").strip()
     state = await asyncio.to_thread(
         mark_initial_personality_state,
-        str((payload or {}).get("status") or "").strip(),
+        status_in,
         config_manager=config_manager,
     )
+    # Telemetry：onboarding 漏斗的关键节点。status 是低基数 enum
+    # （pending / persona_chosen / completed 等），event 记录每步完成 +
+    # counter 用于跨用户的步骤完成率比较。诊断 D1 流失的核心数据。
+    try:
+        from utils.instrument import event as _instr_event, counter as _instr_counter
+        _instr_event("onboarding_step", status=status_in[:32])
+        _instr_counter("onboarding_step", status=status_in[:32])
+    except Exception:
+        pass
     return {
         "success": True,
         "state": state,

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2794,13 +2794,17 @@ async def set_persona_onboarding_state(request: Request):
         status_in,
         config_manager=config_manager,
     )
-    # Telemetry：onboarding 漏斗的关键节点。status 是低基数 enum
-    # （pending / persona_chosen / completed 等），event 记录每步完成 +
-    # counter 用于跨用户的步骤完成率比较。诊断 D1 流失的核心数据。
+    # Telemetry：onboarding 漏斗的关键节点。**用归一化后的 state["status"]**
+    # 而非请求体原值 status_in：mark_initial_personality_state 会把状态收敛成
+    # 小枚举（pending / completed / skipped 等），客户端可以传任意 status 字符串
+    # 但存储 fallback 成 pending。直接用 raw 会让任意输入变成不同的
+    # onboarding_step dim，污染 funnel 切片 + 吃 instrument key 预算（同
+    # lanlan_name 教训：raw 客户端输入不进 dim）（Codex）。
+    _norm_status = (state.get("status") if isinstance(state, dict) else None) or "unknown"
     try:
         from utils.instrument import event as _instr_event, counter as _instr_counter
-        _instr_event("onboarding_step", status=status_in[:32])
-        _instr_counter("onboarding_step", status=status_in[:32])
+        _instr_event("onboarding_step", status=str(_norm_status)[:32])
+        _instr_counter("onboarding_step", status=str(_norm_status)[:32])
     except Exception:
         # 埋点失败绝不影响 onboarding endpoint —— 一条 telemetry 走丢比让
         # 用户卡在角色选择失败重要多了。日志也省，防 import 故障刷屏。

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -228,6 +228,16 @@ async def generate_galgame_options(request: Request):
     if not isinstance(data, dict):
         return JSONResponse({"success": False, "error": "invalid_payload"}, status_code=400)
 
+    # Telemetry：galgame 是 feature 之一，counter 用于"哪些功能被实际触发 +
+    # 多频繁"。lanlan_name 维度可看不同角色的功能使用差异。
+    try:
+        from utils.instrument import counter as _instr_counter
+        _instr_counter("feature_invoked",
+                       feature="galgame_options",
+                       lanlan_name=str(data.get("lanlan_name") or "default")[:32])
+    except Exception:
+        pass
+
     messages = _coerce_messages(data.get('messages'))
     if not messages or messages[-1]['role'] != 'assistant':
         return JSONResponse(

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -236,6 +236,7 @@ async def generate_galgame_options(request: Request):
                        feature="galgame_options",
                        lanlan_name=str(data.get("lanlan_name") or "default")[:32])
     except Exception:
+        # 埋点失败不能挡 galgame endpoint —— 静默继续，不打日志防刷屏。
         pass
 
     messages = _coerce_messages(data.get('messages'))

--- a/main_routers/galgame_router.py
+++ b/main_routers/galgame_router.py
@@ -229,12 +229,10 @@ async def generate_galgame_options(request: Request):
         return JSONResponse({"success": False, "error": "invalid_payload"}, status_code=400)
 
     # Telemetry：galgame 是 feature 之一，counter 用于"哪些功能被实际触发 +
-    # 多频繁"。lanlan_name 维度可看不同角色的功能使用差异。
+    # 多频繁"。**不**带 lanlan_name（用户自定义角色名，PII + 高基数）。
     try:
         from utils.instrument import counter as _instr_counter
-        _instr_counter("feature_invoked",
-                       feature="galgame_options",
-                       lanlan_name=str(data.get("lanlan_name") or "default")[:32])
+        _instr_counter("feature_invoked", feature="galgame_options")
     except Exception:
         # 埋点失败不能挡 galgame endpoint —— 静默继续，不打日志防刷屏。
         pass

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -1829,6 +1829,22 @@ def _record_proactive_chat(lanlan_name: str, message: str, channel: str = ''):
         _proactive_chat_history[lanlan_name] = deque(maxlen=PROACTIVE_CHAT_HISTORY_MAX)
     _proactive_chat_history[lanlan_name].append((time.time(), message, channel))
 
+    # Telemetry：主动搭话实际投递。channel 是低基数 enum（vision/news/video/
+    # personal/music/meme/mini_game/...），截断防意外高基数。配合 settings_state
+    # 的 proactive 配置档，能看深度用户每天实际被主动搭话几次。
+    #
+    # 不在这里做 responded 回应率配对：用户消息分发在 core.py（main_logic 层），
+    # 主动搭话在 main_routers 层，module-layering CI 禁止 core.py 反向 import
+    # system_router；跨层共享"上次投递时刻"状态会破坏分层。回应率由 server 端
+    # 用 proactive_fired 时刻与用户消息活动 timestamp 关联粗估即可，要精确配对
+    # 再单独开 PR。
+    try:
+        from utils.instrument import counter as _instr_counter
+        _instr_counter("proactive_fired", channel=(str(channel) or "default")[:24])
+    except Exception:
+        # 埋点失败不能影响主动搭话投递
+        pass
+
 
 # ---------- Mini-game 邀请短路状态管理 ----------
 # 入口在 proactive_chat 内部、过完 propensity / skip_probability /

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -155,6 +155,13 @@ def _handle_ws_telemetry(message: dict, *, lanlan_name: str) -> None:
                 val = 1  # 缺失 / 非数字 → 默认 +1（事件发生了）
             elif not math.isfinite(val):
                 return  # NaN / Inf：reject 整条，不污染 counter
+            elif isinstance(val, float):
+                # counter 是整数计数：storage 只收整数（4.0 可、1.5 不可），
+                # 非整数 float 这里不挡的话会先聚合进内存、上传时被静默丢
+                # 整窗（CodeRabbit）。整数值 float 归一化成 int。
+                if not val.is_integer():
+                    return
+                val = int(val)
             _c(name, val, **dims)
         elif kind == "histogram":
             val = message.get("value")

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -96,7 +96,9 @@ _TELEM_MAX_DIMS = 8
 _TELEM_KEY_MAX = 32
 _TELEM_VAL_MAX = 64
 _TELEM_NAME_MAX = 64
-_TELEM_EVENT_FIELDS_MAX = 16
+# event fields 的 value 比 counter dims 宽松（128B vs 64B），允许 hash / 短
+# stack signature 之类略长的标识进 event 但不进 counter map。fields **数量**
+# 仍受 _TELEM_MAX_DIMS=8 限制 —— event 也不该塞高基数 payload。
 _TELEM_EVENT_VAL_MAX = 128
 
 

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -15,6 +15,7 @@ enforced by ``scripts/check_api_trailing_slash.py``.
 """
 
 import json
+import math
 import uuid
 import asyncio
 import time
@@ -143,14 +144,22 @@ def _handle_ws_telemetry(message: dict, *, lanlan_name: str) -> None:
 
         from utils.instrument import counter as _c, histogram as _h, event as _e
 
+        # 前端是 untrusted 输入：Python JSON 解析接受 NaN/Infinity token，
+        # 必须在这里挡掉非有限值。否则 NaN 会毒化 client 端 in-memory counter
+        # （nan + n = nan），上传时被 storage 的 isfinite 守卫整条丢弃 → 静默
+        # 丢掉该 counter 的整个窗口（Codex）。与 storage 端守卫对称。
         if kind == "counter":
             dims = _sanitize_dims(message.get("dims"), _TELEM_VAL_MAX)
             val = message.get("value", 1)
-            val = val if isinstance(val, (int, float)) else 1
+            if isinstance(val, bool) or not isinstance(val, (int, float)):
+                val = 1  # 缺失 / 非数字 → 默认 +1（事件发生了）
+            elif not math.isfinite(val):
+                return  # NaN / Inf：reject 整条，不污染 counter
             _c(name, val, **dims)
         elif kind == "histogram":
             val = message.get("value")
-            if not isinstance(val, (int, float)):
+            if (not isinstance(val, (int, float)) or isinstance(val, bool)
+                    or not math.isfinite(val)):
                 return
             dims = _sanitize_dims(message.get("dims"), _TELEM_VAL_MAX)
             _h(name, val, **dims)

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -127,7 +127,13 @@ def _sanitize_dims(d, value_max: int) -> dict:
 
 
 def _handle_ws_telemetry(message: dict, *, lanlan_name: str) -> None:
-    """把前端 WS telemetry message 转交 utils.instrument。"""
+    """把前端 WS telemetry message 转交 utils.instrument。
+
+    ``lanlan_name`` 参数保留只为日志 / 上下文，**不**作为 dim 写入埋点 ——
+    那是用户自定义的 character 名，进 dim 会把 raw 用户字符串泄到 telemetry
+    DB 且让 metric_key 基数爆炸。需要 character 维度时业务侧应自己定义一个
+    bounded enum（如 is_default / character_class）显式传 dim。
+    """
     try:
         kind = message.get("kind")
         name = message.get("name")
@@ -135,12 +141,10 @@ def _handle_ws_telemetry(message: dict, *, lanlan_name: str) -> None:
             return
         name = name[:_TELEM_NAME_MAX]
 
-        # lanlan_name 是后端权威值，强制写入 dim，覆盖前端可能伪造的字段
         from utils.instrument import counter as _c, histogram as _h, event as _e
 
         if kind == "counter":
             dims = _sanitize_dims(message.get("dims"), _TELEM_VAL_MAX)
-            dims["lanlan_name"] = lanlan_name
             val = message.get("value", 1)
             val = val if isinstance(val, (int, float)) else 1
             _c(name, val, **dims)
@@ -149,12 +153,9 @@ def _handle_ws_telemetry(message: dict, *, lanlan_name: str) -> None:
             if not isinstance(val, (int, float)):
                 return
             dims = _sanitize_dims(message.get("dims"), _TELEM_VAL_MAX)
-            dims["lanlan_name"] = lanlan_name
             _h(name, val, **dims)
         elif kind == "event":
             fields = _sanitize_dims(message.get("fields"), _TELEM_EVENT_VAL_MAX)
-            # event fields 可以多一点
-            fields["lanlan_name"] = lanlan_name
             _e(name, **fields)
         # 其它 kind 静默丢弃
     except Exception as e:
@@ -166,11 +167,14 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
     _config_manager = get_config_manager()
     session_manager = get_session_manager()
     await websocket.accept()
-    # Telemetry：WS 连接计数。lanlan_name 是用户在用哪个角色（低基数，最多
-    # 几个固定值），保留作为 dim 用于"哪个角色最被打开"分析。
+    # Telemetry：WS 连接计数。**不带** lanlan_name dim —— 那是用户自定义的
+    # character 名（characters_router 接受 user-controlled new_name），直接进
+    # dim 会把 raw 用户字符串泄到远程 telemetry DB，同时让 metric_key 基数
+    # 按 (用户数 × 角色数) 爆炸。诊断"哪个角色被打开"对 D2-D7 流失意义有限，
+    # 不值得这两个风险。需要时由业务侧显式埋一个 bounded enum 维度。
     try:
         from utils.instrument import counter as _instr_counter
-        _instr_counter("ws_connect", lanlan_name=lanlan_name)
+        _instr_counter("ws_connect")
     except Exception:
         # 埋点失败绝不阻塞 WS 业务路径 —— 计数丢一条比让用户连不上服务严重程度
         # 差几个数量级。imports 失败的可能性主要在打包环境下 utils 不齐时。
@@ -410,12 +414,13 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
     finally:
         # Telemetry：连接生命周期。reason 是低基数 enum，duration 进 histogram
         # 看用户实际停留时长（D2-D7 流失诊断的关键指标之一）。
+        # lanlan_name 不进 dim —— 见 accept 处 ws_connect 同样原因（PII + 高基数）。
         try:
             from utils.instrument import counter as _instr_counter, histogram as _instr_histogram
             _ws_dur = time.time() - _ws_connect_ts
-            _instr_counter("ws_disconnect", lanlan_name=lanlan_name, reason=_ws_disconnect_reason)
+            _instr_counter("ws_disconnect", reason=_ws_disconnect_reason)
             if _ws_dur > 0:
-                _instr_histogram("ws_session_sec", _ws_dur, lanlan_name=lanlan_name)
+                _instr_histogram("ws_session_sec", _ws_dur)
         except Exception:
             # finally 阶段 telemetry 失败不能再 raise —— 已经在 cleanup 路径上，
             # 抛异常会污染调用栈让真正的 WS error 看不到。

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -85,11 +85,93 @@ def _is_home_tutorial_blocking_greeting(lanlan_name: str) -> bool:
     return bool(blocking)
 
 
+# ---- Telemetry helpers ----
+
+# Dim 字段安全限制 —— 前端是 untrusted 输入，必须挡掉：
+# - 高基数维度（如把消息内容塞进 dim）会污染 instrument counter map
+# - 超长 key / value 浪费上报带宽
+# 32B key / 64B value 对所有合理的 enum 标签都够用；超的截断而不是丢，
+# 保留 prefix 至少能切片诊断（如果某个错误 dim 反复触发，前缀也能看出来源）。
+_TELEM_MAX_DIMS = 8
+_TELEM_KEY_MAX = 32
+_TELEM_VAL_MAX = 64
+_TELEM_NAME_MAX = 64
+_TELEM_EVENT_FIELDS_MAX = 16
+_TELEM_EVENT_VAL_MAX = 128
+
+
+def _sanitize_dims(d, value_max: int) -> dict:
+    """把前端传入的 dims dict 过滤成 instrument 能吃的安全形式。
+
+    丢弃：非 dict / 非字符串 key / 非 (str/int/float/bool) value / 超量 key。
+    截断：超长 string value。
+    """
+    out: dict = {}
+    if not isinstance(d, dict):
+        return out
+    for k, v in d.items():
+        if len(out) >= _TELEM_MAX_DIMS:
+            break
+        if not isinstance(k, str) or len(k) == 0 or len(k) > _TELEM_KEY_MAX:
+            continue
+        if isinstance(v, bool):
+            out[k] = v
+        elif isinstance(v, (int, float)):
+            out[k] = v
+        elif isinstance(v, str):
+            out[k] = v[:value_max]
+        # 其它类型（list / dict / None）丢弃
+    return out
+
+
+def _handle_ws_telemetry(message: dict, *, lanlan_name: str) -> None:
+    """把前端 WS telemetry message 转交 utils.instrument。"""
+    try:
+        kind = message.get("kind")
+        name = message.get("name")
+        if not isinstance(name, str) or not name:
+            return
+        name = name[:_TELEM_NAME_MAX]
+
+        # lanlan_name 是后端权威值，强制写入 dim，覆盖前端可能伪造的字段
+        from utils.instrument import counter as _c, histogram as _h, event as _e
+
+        if kind == "counter":
+            dims = _sanitize_dims(message.get("dims"), _TELEM_VAL_MAX)
+            dims["lanlan_name"] = lanlan_name
+            val = message.get("value", 1)
+            val = val if isinstance(val, (int, float)) else 1
+            _c(name, val, **dims)
+        elif kind == "histogram":
+            val = message.get("value")
+            if not isinstance(val, (int, float)):
+                return
+            dims = _sanitize_dims(message.get("dims"), _TELEM_VAL_MAX)
+            dims["lanlan_name"] = lanlan_name
+            _h(name, val, **dims)
+        elif kind == "event":
+            fields = _sanitize_dims(message.get("fields"), _TELEM_EVENT_VAL_MAX)
+            # event fields 可以多一点
+            fields["lanlan_name"] = lanlan_name
+            _e(name, **fields)
+        # 其它 kind 静默丢弃
+    except Exception as e:
+        logger.debug(f"WS telemetry handler error (non-critical): {e}")
+
+
 @router.websocket("/ws/{lanlan_name}")
 async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
     _config_manager = get_config_manager()
     session_manager = get_session_manager()
     await websocket.accept()
+    # Telemetry：WS 连接计数。lanlan_name 是用户在用哪个角色（低基数，最多
+    # 几个固定值），保留作为 dim 用于"哪个角色最被打开"分析。
+    try:
+        from utils.instrument import counter as _instr_counter
+        _instr_counter("ws_connect", lanlan_name=lanlan_name)
+    except Exception:
+        pass
+    _ws_connect_ts = time.time()
 
     # 检查角色是否存在，如果不存在则通知前端并关闭连接
     if lanlan_name not in session_manager:
@@ -134,6 +216,9 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
         logger.info(f"[{lanlan_name}] websocket reconnect: {len(mgr.pending_agent_callbacks)} pending callbacks, scheduling delivery")
         _fire_task(mgr.trigger_agent_callbacks())
 
+    # finally 块要在所有路径上能读到这个变量，包括 BaseException 抢断
+    # try-else 链的情形（SystemExit / KeyboardInterrupt 都不走 else）。
+    _ws_disconnect_reason = "unknown"
     try:
         while True:
             data = await websocket.receive_text()
@@ -148,14 +233,22 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
                 break
             message = json.loads(data)
             action = message.get("action")
-            
+
             # 处理语言设置（可以在任何消息中携带）
             if "language" in message:
                 user_language = message.get("language")
                 session_manager[lanlan_name].set_user_language(user_language)
                 logger.info(f"收到用户语言设置: {user_language}")
-            
+
             # logger.debug(f"WebSocket received action: {action}") # Optional debug log
+
+            # ── Telemetry dispatch（前端 counter / histogram / event 通道）──
+            # 前端 static/app-telemetry.js 通过 action="telemetry" 投递数据；
+            # 这里转交 utils.instrument，跟 Python 端发出去的走同一上报通道。
+            # 早返回避免污染下面的业务 dispatch；不需要 session_manager 状态。
+            if action == "telemetry":
+                _handle_ws_telemetry(message, lanlan_name=lanlan_name)
+                continue
 
             if action == "start_session":
                 session_manager[lanlan_name].active_session_is_idle = False
@@ -296,15 +389,31 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
 
     except WebSocketDisconnect:
         logger.info(f"WebSocket disconnected: {websocket.client}")
+        _ws_disconnect_reason = "client_disconnect"
     except Exception as e:
         error_message = f"WebSocket handler error: {e}"
         logger.error(f"💥 {error_message}")
+        _ws_disconnect_reason = "handler_error"
         try:
             if lanlan_name in session_manager:
                 await session_manager[lanlan_name].send_status(json.dumps({"code": "SERVER_ERROR"}))
         except: # noqa
             pass
+    else:
+        # 进 finally 时既不是 disconnect 也不是异常 —— 实际上 while True 循环
+        # 内只有 break 才到这；break 路径上面都设过 reason；这里兜底防 NameError。
+        _ws_disconnect_reason = "normal_break"
     finally:
+        # Telemetry：连接生命周期。reason 是低基数 enum，duration 进 histogram
+        # 看用户实际停留时长（D2-D7 流失诊断的关键指标之一）。
+        try:
+            from utils.instrument import counter as _instr_counter, histogram as _instr_histogram
+            _ws_dur = time.time() - _ws_connect_ts
+            _instr_counter("ws_disconnect", lanlan_name=lanlan_name, reason=_ws_disconnect_reason)
+            if _ws_dur > 0:
+                _instr_histogram("ws_session_sec", _ws_dur, lanlan_name=lanlan_name)
+        except Exception:
+            pass
         logger.info(f"Cleaning up WebSocket resources: {websocket.client}")
         # 记录 WS 断开时间，供下次连接时判断是否为"刷新/重连"
         _ws_disconnect_time[lanlan_name] = time.time()

--- a/main_routers/websocket_router.py
+++ b/main_routers/websocket_router.py
@@ -172,6 +172,8 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
         from utils.instrument import counter as _instr_counter
         _instr_counter("ws_connect", lanlan_name=lanlan_name)
     except Exception:
+        # 埋点失败绝不阻塞 WS 业务路径 —— 计数丢一条比让用户连不上服务严重程度
+        # 差几个数量级。imports 失败的可能性主要在打包环境下 utils 不齐时。
         pass
     _ws_connect_ts = time.time()
 
@@ -415,6 +417,8 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name: str):
             if _ws_dur > 0:
                 _instr_histogram("ws_session_sec", _ws_dur, lanlan_name=lanlan_name)
         except Exception:
+            # finally 阶段 telemetry 失败不能再 raise —— 已经在 cleanup 路径上，
+            # 抛异常会污染调用栈让真正的 WS error 看不到。
             pass
         logger.info(f"Cleaning up WebSocket resources: {websocket.client}")
         # 记录 WS 断开时间，供下次连接时判断是否为"刷新/重连"

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -106,6 +106,8 @@ class MemoryRecallReranker:
                 from utils.instrument import counter as _instr_counter
                 _instr_counter("memory_recall_invoke", returned_empty=True)
             except Exception:
+                # 埋点失败不能让 recall 路径报错 —— memory pipeline 是
+                # response 关键路径，宁可少一条统计也不让它 crash。
                 pass
             return []
         # Telemetry：每次 recall 算一次 invoke，无论后续是 coarse-only 还是
@@ -115,6 +117,7 @@ class MemoryRecallReranker:
             from utils.instrument import counter as _instr_counter
             _instr_counter("memory_recall_invoke", returned_empty=False)
         except Exception:
+            # 同上：埋点失败静默，不影响 recall 主路径。
             pass
 
         # Normalise query_texts up-front so phase 2 (coarse) and phase 3

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -100,7 +100,22 @@ class MemoryRecallReranker:
         directly.
         """
         if not observations:
+            # 即使空召回也算一次 invoke，差值 = "想 recall 但没素材"，对
+            # 评估 memory pipeline 健康度有意义。
+            try:
+                from utils.instrument import counter as _instr_counter
+                _instr_counter("memory_recall_invoke", returned_empty=True)
+            except Exception:
+                pass
             return []
+        # Telemetry：每次 recall 算一次 invoke，无论后续是 coarse-only 还是
+        # 走 LLM rerank。histogram 记返回 fact 数量分布；对比 invoke 次数和
+        # 返回 0 的比例可看 memory pipeline 是否在"起作用"。
+        try:
+            from utils.instrument import counter as _instr_counter
+            _instr_counter("memory_recall_invoke", returned_empty=False)
+        except Exception:
+            pass
 
         # Normalise query_texts up-front so phase 2 (coarse) and phase 3
         # (LLM rerank) see the same shape: drop None/empty/whitespace

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+"""
+Telemetry end-to-end smoke test.
+
+跑法：
+    uv run python scripts/telemetry_smoke.py
+
+会做：
+  1) 起 telemetry_server（uvicorn 后台）+ 临时 SQLite DB
+  2) 用 utils/instrument + utils/event_logger 在本进程灌一些埋点
+  3) 直接调 TokenTracker._report_to_server 投递到 server（含 gzip）
+  4) 也直接构造一份"模拟前端 WS 转发"的客户端 payload，POST 上去
+  5) 查 SQLite + dashboard HTML，断言关键数据齐了
+"""
+from __future__ import annotations
+
+import gzip
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+HMAC_SECRET = "neko-v1-a3f8b2c1d4e5f6789012345678abcdef"
+PORT = 18099  # 临时端口，避开生产 8099
+SERVER_URL = f"http://127.0.0.1:{PORT}"
+
+
+def _http(method, path, body=None, headers=None, timeout=5.0):
+    h = dict(headers or {})
+    data = None
+    if body is not None:
+        if isinstance(body, (dict, list)):
+            data = json.dumps(body).encode("utf-8")
+            h.setdefault("Content-Type", "application/json")
+        else:
+            data = body
+    req = urllib.request.Request(f"{SERVER_URL}{path}", data=data, headers=h, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def _sign_and_submit(payload: dict, gzip_it: bool = True, batch_id: str | None = None):
+    """构造 HMAC 信封并 POST 到 server。"""
+    payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    ts = time.time()
+    body_hash = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+    sig = hmac.new(
+        HMAC_SECRET.encode(), f"{ts}|{body_hash}".encode(), hashlib.sha256
+    ).hexdigest()
+    submission = {"timestamp": ts, "signature": sig, "payload": payload, "batch_id": batch_id}
+    body = json.dumps(submission, ensure_ascii=False).encode("utf-8")
+
+    headers = {"Content-Type": "application/json"}
+    if gzip_it:
+        body = gzip.compress(body, compresslevel=6, mtime=0)
+        headers["Content-Encoding"] = "gzip"
+
+    status, resp = _http("POST", "/api/v1/telemetry", body=body, headers=headers)
+    return status, resp
+
+
+def _wait_for_health(timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            status, _ = _http("GET", "/health", timeout=1.0)
+            if status == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(0.2)
+    return False
+
+
+def main():
+    print("=" * 70)
+    print("TELEMETRY SMOKE TEST")
+    print("=" * 70)
+
+    tmpdir = tempfile.mkdtemp(prefix="neko_telemetry_smoke_")
+    db_path = os.path.join(tmpdir, "telemetry.db")
+    print(f"Temp dir: {tmpdir}")
+    print(f"DB: {db_path}")
+
+    env = dict(os.environ)
+    env["TELEMETRY_HMAC_SECRET"] = HMAC_SECRET
+    env["TELEMETRY_DB_PATH"] = db_path
+    env["TELEMETRY_ADMIN_TOKEN"] = "smoke-test-admin"
+
+    server_cwd = str(PROJECT_ROOT / "local_server" / "telemetry_server")
+    cmd = [sys.executable, "server.py", "--host", "127.0.0.1", "--port", str(PORT)]
+    print(f"\n[1/5] Starting server: {' '.join(cmd)}")
+    proc = subprocess.Popen(
+        cmd,
+        cwd=server_cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    try:
+        if not _wait_for_health():
+            print("FAIL: server did not become healthy in 10s")
+            # 顺手 dump output
+            try:
+                proc.terminate()
+                out, _ = proc.communicate(timeout=2)
+                print("--- server output ---")
+                print(out[-4000:])
+            except Exception:
+                pass
+            return 1
+        print("✓ server healthy")
+
+        # --------------------------------------------------------------
+        # [2/5] 通过 utils/instrument 在 smoke 进程灌埋点，触发上报
+        # --------------------------------------------------------------
+        print("\n[2/5] Generating instrument data via SDK...")
+
+        # 让 TokenTracker 上报到本地 server
+        import utils.token_tracker as tt_mod
+        tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
+        tt_mod._TELEMETRY_HMAC_SECRET = HMAC_SECRET
+
+        from utils.token_tracker import TokenTracker
+        from utils.instrument import counter, histogram, event, Instrument
+        from utils.event_logger import EventLogger
+
+        # 重置单例确保隔离
+        TokenTracker._instance = None
+        Instrument._instance = None
+        EventLogger._instance = None
+
+        # 模拟一些埋点
+        for _ in range(5):
+            counter("user_message_sent", 1, surface="pet_widget")
+        for _ in range(3):
+            counter("user_message_sent", 1, surface="chat_window")
+        counter("feature_invoked", 1, feature="galgame")
+        counter("session_start", 1, process="main_server")
+
+        histogram("ttft_ms", 234)
+        histogram("ttft_ms", 412)
+        histogram("ttft_ms", 156)
+        histogram("ws_session_sec", 850.5, lanlan_name="hibiki")
+
+        event("session_start", process="main_server")
+        event("crash", error_class="ValueError", traceback_hash="deadbeef")
+        event("onboarding_step", status="persona_chosen")
+
+        tracker = TokenTracker.get_instance()
+        # 也加一点 LLM token 数据
+        tracker.record(model="gpt-4o-mini", prompt_tokens=100, completion_tokens=50,
+                       total_tokens=150, cached_tokens=20, call_type="conversation")
+        tracker.record(model="gpt-4o-mini", prompt_tokens=200, completion_tokens=80,
+                       total_tokens=280, cached_tokens=50, call_type="conversation")
+
+        # 强制上报：清掉 _last_report_time 节流
+        tracker._last_report_time = 0
+        tracker.save()  # 触发 _report_to_server
+        print("✓ SDK report attempted")
+
+        # --------------------------------------------------------------
+        # [3/5] 模拟"前端 WS 转发上来的 telemetry"—— 直接构造另一份 payload
+        # --------------------------------------------------------------
+        print("\n[3/5] Simulating frontend-originated counter via additional payload...")
+
+        # 这里其实跟 SDK 内部走的是同一路径，只是构造手工，验证 server 在
+        # 老客户端 (无 instruments) / 新客户端 (有 instruments) 两种 payload
+        # 上都能工作。
+        old_payload = {
+            "device_id": "b" * 64,
+            "app_version": "1.0.0",
+            "branch": "main",
+            "locale": "ja-JP",
+            "timezone": "Asia/Tokyo",
+            "distribution": "release",
+            "steam_user_id": "",
+            "daily_stats": {
+                time.strftime("%Y-%m-%d"): {
+                    "total_prompt_tokens": 500, "total_completion_tokens": 100,
+                    "total_tokens": 600, "cached_tokens": 50,
+                    "call_count": 3, "error_count": 0,
+                    "by_model": {"gpt-4o": {"prompt_tokens": 500, "completion_tokens": 100,
+                                            "total_tokens": 600, "cached_tokens": 50, "call_count": 3}},
+                    "by_call_type": {"conversation": {"prompt_tokens": 500, "completion_tokens": 100,
+                                                       "total_tokens": 600, "cached_tokens": 50, "call_count": 3}},
+                }
+            },
+            "recent_records": [],
+        }
+        status, resp = _sign_and_submit(old_payload, gzip_it=False, batch_id="smoke-old-1")
+        print(f"  old client (raw JSON, no instruments): HTTP {status} {resp[:100]!r}")
+        assert status == 200, f"old payload submit failed: {status}"
+
+        new_payload = {
+            "device_id": "c" * 64,
+            "app_version": "2.0.0",
+            "branch": "privacy_default_off_v1",
+            "locale": "en-US",
+            "timezone": "America/New_York",
+            "distribution": "steam",
+            "steam_user_id": "76561198000000001",
+            "daily_stats": {},
+            "recent_records": [],
+            "instruments": {
+                "window_start": time.time() - 60,
+                "window_end": time.time(),
+                "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+                "counters": {
+                    "user_message_sent|surface=index_wide": 42,
+                    "live2d_touched": 17,
+                },
+                "histograms": {
+                    "client_render_ms": {
+                        "count": 10, "sum": 1234.5,
+                        "buckets": [0, 0, 0, 2, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0]
+                    },
+                },
+            },
+        }
+        status, resp = _sign_and_submit(new_payload, gzip_it=True, batch_id="smoke-new-1")
+        print(f"  new client (gzip + instruments): HTTP {status} {resp[:100]!r}")
+        assert status == 200, f"new payload submit failed: {status}"
+
+        # 同一 batch_id 重发 —— 应该 dedupe
+        status, resp = _sign_and_submit(new_payload, gzip_it=True, batch_id="smoke-new-1")
+        print(f"  same batch_id replay: HTTP {status} {resp[:120]!r}")
+        assert status == 200
+
+        # --------------------------------------------------------------
+        # [4/5] 直查 SQLite 看数据落了
+        # --------------------------------------------------------------
+        print("\n[4/5] Inspecting SQLite directly...")
+        import sqlite3
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+
+        def _table_count(name):
+            return conn.execute(f"SELECT COUNT(*) FROM {name}").fetchone()[0]
+
+        events_n = _table_count("events")
+        daily_n = _table_count("daily_aggregates")
+        devices_n = _table_count("devices")
+        batches_n = _table_count("seen_batches")
+        counters_n = _table_count("instrument_counters")
+        hist_n = _table_count("instrument_histograms")
+        print(f"  events={events_n} daily_aggregates={daily_n} devices={devices_n}")
+        print(f"  seen_batches={batches_n} instrument_counters={counters_n} instrument_histograms={hist_n}")
+
+        assert events_n >= 2, "expected >=2 events stored (1 SDK + 2 manual; dedupe collapses 1)"
+        assert devices_n >= 2, "expected >=2 devices"
+        assert counters_n >= 2, f"expected counters table populated, got {counters_n}"
+        assert hist_n >= 1, f"expected histogram table populated, got {hist_n}"
+
+        # 打印 sample 数据
+        print("\n  --- sample counters ---")
+        for r in conn.execute(
+            "SELECT stat_date, metric_key, value FROM instrument_counters "
+            "ORDER BY value DESC LIMIT 8"
+        ).fetchall():
+            print(f"    {r['stat_date']} {r['metric_key']:50s} value={r['value']}")
+
+        print("\n  --- sample histograms ---")
+        for r in conn.execute(
+            "SELECT stat_date, metric_key, count, sum, buckets FROM instrument_histograms LIMIT 5"
+        ).fetchall():
+            print(f"    {r['stat_date']} {r['metric_key']:30s} count={r['count']} sum={r['sum']}")
+            print(f"      buckets={r['buckets']}")
+
+        # 验证去重 —— same batch_id 没让 counter 双倍
+        new_dev_counter = conn.execute(
+            "SELECT value FROM instrument_counters "
+            "WHERE device_id = ? AND metric_key = 'live2d_touched'",
+            ("c" * 64,),
+        ).fetchone()
+        assert new_dev_counter is not None
+        assert new_dev_counter["value"] == 17.0, \
+            f"dedupe broken: expected 17, got {new_dev_counter['value']}"
+        print(f"  ✓ idempotency: live2d_touched = {new_dev_counter['value']} (not doubled)")
+
+        conn.close()
+
+        # --------------------------------------------------------------
+        # [5/5] dashboard 能返回 + 含 instrument 表
+        # --------------------------------------------------------------
+        print("\n[5/5] Fetching dashboard HTML...")
+        status, body = _http(
+            "GET", "/api/v1/admin/dashboard?days=30&token=smoke-test-admin"
+        )
+        assert status == 200, f"dashboard HTTP {status}"
+        text = body.decode("utf-8", errors="replace")
+        # 关键标记
+        for marker in (
+            "N.E.K.O Telemetry Dashboard",
+            "DAU (Today)",
+            "Top Counters",
+            "Histograms",
+            "live2d_touched",  # 我们存的 counter key 应在 HTML 里
+            "client_render_ms",  # histogram key
+        ):
+            assert marker in text, f"dashboard missing marker: {marker!r}"
+        print(f"  ✓ dashboard returned {len(text)} bytes with all expected markers")
+
+        # 测试 health / global stats
+        status, body = _http("GET", "/api/v1/admin/stats?days=30&token=smoke-test-admin")
+        assert status == 200
+        stats = json.loads(body)
+        print(f"  global stats: total_devices={stats['total_devices']} "
+              f"total_events={stats['total_events']}")
+        assert stats["total_devices"] >= 2
+
+        print("\n" + "=" * 70)
+        print("✓ ALL SMOKE TESTS PASSED")
+        print("=" * 70)
+        return 0
+
+    finally:
+        print("\nShutting down server...")
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        # 临时目录留在磁盘上方便事后查（不删）
+        print(f"(Leftover temp dir for inspection: {tmpdir})")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -84,6 +84,8 @@ def _wait_for_health(timeout: float = 10.0) -> bool:
             if status == 200:
                 return True
         except Exception:
+            # health probe 在 server 启动期会反复抛连接拒绝，这是预期 —— 继续
+            # poll 直到 deadline。
             pass
         time.sleep(0.2)
     return False
@@ -126,6 +128,8 @@ def main():
                 print("--- server output ---")
                 print(out[-4000:])
             except Exception:
+                # 终止 server 进程或读它的 output 本身失败：我们正要 return 1
+                # 退出 smoke，再 raise 没意义。
                 pass
             return 1
         print("✓ server healthy")
@@ -310,7 +314,6 @@ def main():
         # 都将为空）。如果 batch_id 不含 instruments，两次 snapshot 算出同一
         # hash → 第二次会被 seen_batches dedupe，server 端只看到第一次的数据。
         tracker_d = TokenTracker.get_instance()
-        seen_before = set()
         for batch_n in range(2):
             counter("window_only_counter", 1, surface="index_wide", batch_n=batch_n)
             # 强行触发上报：把节流计时重置
@@ -381,6 +384,119 @@ def main():
         # 把 URL 重新启用，下面的 [5/5] dashboard 测试还要用
         tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
         print("  ✓ session_end counter + duration histogram both reached server")
+
+        # --------------------------------------------------------------
+        # [4d] Regression: Codex P1 round-2 — daily 重传幂等
+        #
+        # 网络 timeout（server commit 了 client 没收到 200）场景：client 用
+        # 同一个 batch_seq 重传，server seen_batches 必须 dedupe，daily 不能
+        # 被双倍计数。手动构造两份 batch_id 完全相同的 payload 验证 server
+        # 行为；同时单独检查 client 在失败时 _pending_batch_seq 不被清空。
+        # --------------------------------------------------------------
+        print("\n[4d] Regression: daily retry idempotency (batch_seq stability)...")
+        Instrument._instance = None
+        TokenTracker._instance = None
+        tracker_f = TokenTracker.get_instance()
+        # Step A: 用 bad URL 让首次上报失败，验证 _pending_batch_seq 保留
+        good_url = tt_mod._TELEMETRY_SERVER_URL
+        tt_mod._TELEMETRY_SERVER_URL = "http://127.0.0.1:1"
+        tracker_f.record(model="gpt-4o-mini", prompt_tokens=111,
+                         completion_tokens=22, total_tokens=133,
+                         cached_tokens=0, call_type="conversation")
+        tracker_f._last_report_time = 0
+        tracker_f.save()
+        time.sleep(0.3)
+        seq_after_fail = tracker_f._pending_batch_seq
+        assert seq_after_fail is not None, (
+            "P1 round-2 regression: _pending_batch_seq must persist after failure"
+        )
+        print(f"  ✓ failure preserved batch_seq = {seq_after_fail[:12]}...")
+        # Step B: 恢复 URL，重传应成功并清 batch_seq
+        tt_mod._TELEMETRY_SERVER_URL = good_url
+        tracker_f._last_report_time = 0
+        tracker_f.save()
+        time.sleep(0.3)
+        assert tracker_f._pending_batch_seq is None, (
+            "P1 round-2 regression: _pending_batch_seq must clear after success"
+        )
+        print("  ✓ success cleared batch_seq")
+
+        # Step C: 模拟"server commit 但 client 没收到 200，client 重发"。
+        # 手动 POST 两次 batch_id 完全相同的 payload，验证 server dedupe 工作。
+        dev_f = "f" * 64
+        seq_test = "deadbeef12345678"
+        bc = {"device_id": dev_f, "app_version": "retry-test", "batch_seq": seq_test}
+        bid_test = hashlib.sha256(
+            json.dumps(bc, ensure_ascii=False, sort_keys=True).encode()
+        ).hexdigest()[:32]
+        today_iso = time.strftime("%Y-%m-%d")
+        daily_f = {
+            today_iso: {
+                "total_prompt_tokens": 7777, "total_completion_tokens": 100,
+                "total_tokens": 7877, "cached_tokens": 0,
+                "call_count": 1, "error_count": 0,
+                "by_model": {}, "by_call_type": {},
+            }
+        }
+        payload_f = {
+            "device_id": dev_f, "app_version": "retry-test",
+            "branch": "main", "locale": "zh-CN", "timezone": "UTC",
+            "distribution": "source", "steam_user_id": "",
+            "daily_stats": daily_f, "recent_records": [],
+        }
+        s1, _ = _sign_and_submit(payload_f, gzip_it=False, batch_id=bid_test)
+        s2, r2 = _sign_and_submit(payload_f, gzip_it=False, batch_id=bid_test)
+        print(f"  first POST: HTTP {s1} | retry (same batch_id): HTTP {s2} {r2[:80]!r}")
+        assert s1 == 200 and s2 == 200
+        assert b"duplicate" in r2, (
+            "P1 round-2 regression: server must dedupe same batch_id"
+        )
+        conn_f = sqlite3.connect(db_path)
+        row_f = conn_f.execute(
+            "SELECT total_tokens FROM daily_aggregates "
+            "WHERE device_id=? AND model='_total' AND call_type='_total'",
+            (dev_f,),
+        ).fetchone()
+        conn_f.close()
+        assert row_f is not None
+        assert row_f[0] == 7877, (
+            f"P1 round-2 regression: daily double-counted on retry — "
+            f"got {row_f[0]}, expected 7877"
+        )
+        print(f"  ✓ daily NOT double-counted on retry: total_tokens={row_f[0]}")
+
+        # --------------------------------------------------------------
+        # [4e] Regression: Codex P2 round-2 — short-session atexit bypass throttle
+        # --------------------------------------------------------------
+        print("\n[4e] Regression: short-session atexit bypasses throttle...")
+        Instrument._instance = None
+        TokenTracker._instance = None
+        tracker_g = TokenTracker.get_instance()
+        tracker_g.record_app_start(process="smoke_short_session")
+        tracker_g._session_start_ts = time.time() - 2.0  # 2s 短 session
+        # 先一次成功上报，让 _last_report_time = now（throttle 窗口刚开始）
+        counter("short_session_anchor", 1)
+        tracker_g._last_report_time = 0
+        tracker_g.save()
+        time.sleep(0.3)
+        assert tracker_g._last_report_time > 0, "anchor save should set _last_report_time"
+        # 此刻距下次允许还差 60s。如果 _atexit_save 不 bypass throttle，
+        # session_end emit 之后的 save() 会被 throttle gate 挡掉。
+        tracker_g._atexit_save()
+        time.sleep(0.3)
+        conn_g = sqlite3.connect(db_path)
+        rows_g = conn_g.execute(
+            "SELECT metric_key, value FROM instrument_counters "
+            "WHERE metric_key LIKE 'session_end%smoke_short_session%'"
+        ).fetchall()
+        conn_g.close()
+        assert len(rows_g) >= 1, (
+            "P2 round-2 regression: session_end missing from short-session atexit "
+            "— throttle bypass not working"
+        )
+        print(f"  ✓ short-session session_end reached server: {rows_g}")
+        # 恢复 URL 给后续 [5/5] 用
+        tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
 
         # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -833,6 +833,10 @@ def main():
                 "stat_date": time.strftime("%Y-%m-%d"),
                 "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
                 "counters": {},
+                # 注：fractional count/bucket（如 0.5）在 Pydantic HistogramStat
+                # (count:int, buckets:List[int]) 层就被拒成 400，到不了 storage；
+                # storage 的整数归一化是 defense-in-depth。所以这里只用整数值的
+                # 形状不自洽 case 测 storage 跳过逻辑。
                 "histograms": {
                     "bad_shape_hist": {  # count=100 但 buckets 只加起来 =2
                         "count": 100, "sum": 50.0,

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -787,6 +787,38 @@ def main():
         )
         print("  ✓ out-of-range stat_date rejected, fell back to a valid date")
 
+        # 第三个 case：client_date 无效（走 window_end fallback）但 window_end
+        # 是远期时间戳。fallback 路径也必须过同一 recency 校验，否则偏斜时钟/
+        # 伪造 window_end 能造远期分区逃过 retention（Codex P2）。
+        we_payload = {
+            "device_id": "p" * 64, "app_version": "2.0.0", "branch": "main",
+            "locale": "en-US", "timezone": "UTC", "distribution": "source",
+            "steam_user_id": "", "daily_stats": {}, "recent_records": [],
+            "instruments": {
+                "window_start": time.time(),
+                "window_end": time.time() + 5 * 365 * 86400,  # ~5 年后
+                "stat_date": "not-a-valid-date",  # len!=10 → 跳过 client_date，走 window_end
+                "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+                "counters": {"we_fallback_counter": 1},
+                "histograms": {},
+            },
+        }
+        s_we, _ = _sign_and_submit(we_payload, gzip_it=False, batch_id="smoke-wedate-1")
+        assert s_we == 200, f"window_end-fallback payload should be accepted (HTTP {s_we})"
+        time.sleep(0.3)
+        conn_we = sqlite3.connect(db_path)
+        we_dates = [r[0] for r in conn_we.execute(
+            "SELECT stat_date FROM instrument_counters WHERE metric_key='we_fallback_counter'"
+        ).fetchall()]
+        conn_we.close()
+        _today = time.strftime("%Y-%m-%d")
+        print(f"  window_end-fallback counter landed under stat_date(s): {we_dates}")
+        assert we_dates and all(d == _today for d in we_dates), (
+            "Codex P2 regression: far-future window_end bypassed recency guard — "
+            f"landed under {we_dates} instead of today {_today}"
+        )
+        print("  ✓ far-future window_end fallback rejected, fell back to today")
+
         # NaN counter 不能炸整批：含 NaN 的 payload 仍 200，NaN 样本被跳过，
         # 同批的合法 counter 照常入库（Codex P2）。
         nan_payload = {

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -544,6 +544,56 @@ def main():
         print(f"  ✓ new window after failure landed: {rows_h}")
 
         # --------------------------------------------------------------
+        # [4g] Regression: Codex P2 round-4 — periodic loop wakes for instrument-only
+        #
+        # 纯前端互动用户 _dirty 永远是 False。如果 _periodic_save_loop 只在
+        # _dirty=True 时调 save()，instrument 数据只能等 atexit 才发，不是
+        # 设计的 60s 节奏。loop 必须同时检查 instrument.has_data。
+        # --------------------------------------------------------------
+        print("\n[4g] Regression: periodic loop wakes for instrument-only data...")
+        import asyncio as _asyncio
+
+        async def _periodic_wake_test():
+            Instrument._instance = None
+            TokenTracker._instance = None
+            tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
+            tracker_i = TokenTracker.get_instance()
+            # 加速 loop：500ms 一个 tick 让 smoke 不用等 60s
+            tracker_i._save_interval = 0.5
+            tracker_i._last_report_time = 0
+            tracker_i.start_periodic_save()
+
+            # 只灌 counter（不触发 _dirty） —— 模拟纯前端互动
+            counter("periodic_wake_test", 1, scenario="instrument_only")
+
+            # 等够 2 个 tick 让 loop 至少跑一次
+            await _asyncio.sleep(1.3)
+
+            # 停 task 防泄漏（smoke 进程下来还要做后续步骤）
+            task = tracker_i._save_task
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except _asyncio.CancelledError:
+                    pass
+
+        _asyncio.run(_periodic_wake_test())
+
+        conn_i = sqlite3.connect(db_path)
+        rows_i = conn_i.execute(
+            "SELECT metric_key, value FROM instrument_counters "
+            "WHERE metric_key LIKE 'periodic_wake_test%'"
+        ).fetchall()
+        conn_i.close()
+        assert len(rows_i) >= 1, (
+            "P2 round-4 regression: periodic loop did not wake for "
+            "instrument-only data; counter never reached server. "
+            "loop must check instrument.has_data() not just self._dirty"
+        )
+        print(f"  ✓ periodic loop picked up instrument-only: {rows_i}")
+
+        # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表
         # --------------------------------------------------------------
         print("\n[5/5] Fetching dashboard HTML...")

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -499,6 +499,51 @@ def main():
         tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
 
         # --------------------------------------------------------------
+        # [4f] Regression: Codex P1 round-3 — instrument-only 失败清 stale seq
+        #
+        # 场景：instrument-only payload server commit 了但 client timeout。
+        # instruments 已 clear-on-read 没东西放回。如果失败时不清 batch_seq，
+        # 下一个新窗口（不同数据）会复用 stale seq → server seen_batches
+        # 命中旧 commit → 返回 "duplicate, skipped" → 新数据被静默丢弃。
+        # --------------------------------------------------------------
+        print("\n[4f] Regression: instrument-only failure clears stale batch_seq...")
+        Instrument._instance = None
+        TokenTracker._instance = None
+        tracker_h = TokenTracker.get_instance()
+        # Step A: instrument-only 失败
+        counter("h_only_counter_A", 1, surface="index_wide")
+        good_url = tt_mod._TELEMETRY_SERVER_URL
+        tt_mod._TELEMETRY_SERVER_URL = "http://127.0.0.1:1"
+        tracker_h._last_report_time = 0
+        tracker_h.save()
+        time.sleep(0.3)
+        # 关键断言：instrument-only 失败必须清 batch_seq（had_unsent_payload=False）
+        assert tracker_h._pending_batch_seq is None, (
+            "P1 round-3 regression: instrument-only failure left stale "
+            f"_pending_batch_seq = {tracker_h._pending_batch_seq!r}"
+        )
+        print("  ✓ instrument-only failure cleared batch_seq")
+
+        # Step B: 恢复 URL，发新 counter（B），应该用全新 seq 成功上报
+        tt_mod._TELEMETRY_SERVER_URL = good_url
+        counter("h_only_counter_B", 1, surface="index_wide")
+        tracker_h._last_report_time = 0
+        tracker_h.save()
+        time.sleep(0.5)
+        # 直查 server: h_only_counter_B 必须在库（说明不被 stale seq 误伤）
+        conn_h = sqlite3.connect(db_path)
+        rows_h = conn_h.execute(
+            "SELECT metric_key, value FROM instrument_counters "
+            "WHERE metric_key LIKE 'h_only_counter_B%'"
+        ).fetchall()
+        conn_h.close()
+        assert len(rows_h) >= 1, (
+            "P1 round-3 regression: new counter after instrument-only failure "
+            "was dropped — stale batch_seq still in effect"
+        )
+        print(f"  ✓ new window after failure landed: {rows_h}")
+
+        # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表
         # --------------------------------------------------------------
         print("\n[5/5] Fetching dashboard HTML...")

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -300,6 +300,89 @@ def main():
         conn.close()
 
         # --------------------------------------------------------------
+        # [4b] Regression: Codex P1 — instrument-only 上报 batch_id 必须不同
+        # --------------------------------------------------------------
+        print("\n[4b] Regression: instrument-only batch_id uniqueness...")
+        # 重置单例确保是干净的 instrument 累积
+        Instrument._instance = None
+        TokenTracker._instance = None
+        # 设备 D：只灌前端 counter，不动 LLM token（daily_stats / recent_records
+        # 都将为空）。如果 batch_id 不含 instruments，两次 snapshot 算出同一
+        # hash → 第二次会被 seen_batches dedupe，server 端只看到第一次的数据。
+        tracker_d = TokenTracker.get_instance()
+        seen_before = set()
+        for batch_n in range(2):
+            counter("window_only_counter", 1, surface="index_wide", batch_n=batch_n)
+            # 强行触发上报：把节流计时重置
+            tracker_d._last_report_time = 0
+            tracker_d.save()
+            time.sleep(0.5)
+
+        # 直查 SQLite：window_only_counter 必须是 2（两次窗口都被入库）
+        conn2 = sqlite3.connect(db_path)
+        rows = conn2.execute(
+            "SELECT metric_key, value FROM instrument_counters "
+            "WHERE metric_key LIKE 'window_only_counter%' "
+            "ORDER BY metric_key"
+        ).fetchall()
+        conn2.close()
+        keys = [r[0] for r in rows]
+        vals = [r[1] for r in rows]
+        print(f"  metric_keys seen: {keys}")
+        print(f"  values:           {vals}")
+        # batch_n=0 和 batch_n=1 各 1 次 → 两个独立 key
+        assert len(rows) == 2, (
+            f"P1 regression: expected 2 distinct metric_keys (one per window), "
+            f"got {len(rows)} — second instrument-only batch likely dedupe-dropped"
+        )
+        assert all(v == 1.0 for v in vals), (
+            f"P1 regression: each counter should be 1.0 (one increment per window), "
+            f"got {vals}"
+        )
+        print("  ✓ both instrument-only windows landed (batch_id includes instruments)")
+
+        # --------------------------------------------------------------
+        # [4c] Regression: Codex P2 — _atexit_save 顺序，session_end 必须上报
+        # --------------------------------------------------------------
+        print("\n[4c] Regression: _atexit_save emits session_end before save()...")
+        # 新设备 E + record_app_start → 模拟 atexit
+        Instrument._instance = None
+        TokenTracker._instance = None
+        # device_id 在 TokenTracker 是 OS-derived，多次实例共享；只能靠 process
+        # 维度区分 session_end 的 emitter。换一个 process 名让 instrument key 唯一。
+        tracker_e = TokenTracker.get_instance()
+        tracker_e.record_app_start(process="smoke_atexit_test")
+        # 让 session_duration > 0 以触发 histogram
+        tracker_e._session_start_ts = time.time() - 5.0
+        # _atexit_save 内部调 save() → _report_to_server → instrument snapshot →
+        # 远程上报。session_end emit 在 save 之前，所以应该被带上。
+        tracker_e._atexit_save()
+        time.sleep(0.5)
+
+        conn3 = sqlite3.connect(db_path)
+        session_end_rows = conn3.execute(
+            "SELECT metric_key, value FROM instrument_counters "
+            "WHERE metric_key LIKE 'session_end%process=smoke_atexit_test%'"
+        ).fetchall()
+        session_dur_rows = conn3.execute(
+            "SELECT metric_key, count, sum FROM instrument_histograms "
+            "WHERE metric_key LIKE 'session_duration_sec%process=smoke_atexit_test%'"
+        ).fetchall()
+        conn3.close()
+        print(f"  session_end counter rows: {session_end_rows}")
+        print(f"  session_duration_sec rows: {session_dur_rows}")
+        assert len(session_end_rows) >= 1, (
+            "P2 regression: session_end counter missing — _atexit_save must "
+            "emit before save() so the snapshot picks it up"
+        )
+        assert len(session_dur_rows) >= 1, (
+            "P2 regression: session_duration_sec histogram missing"
+        )
+        # 把 URL 重新启用，下面的 [5/5] dashboard 测试还要用
+        tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
+        print("  ✓ session_end counter + duration histogram both reached server")
+
+        # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表
         # --------------------------------------------------------------
         print("\n[5/5] Fetching dashboard HTML...")

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -717,6 +717,44 @@ def main():
         print("  ✓ all new D1 + settings + proactive telemetry reached server")
 
         # --------------------------------------------------------------
+        # [4j] Regression: Codex P2 — 伪造坏 stat_date 不能落成垃圾分区
+        #
+        # HMAC 密钥在开源客户端可读，伪造 payload 能塞 "9999-99-99" 这类长度
+        # 和 dash 位置都过、但非法的日期。server 必须 date.fromisoformat 校验，
+        # 坏值回退到 window_end/今天，否则字典序 retention 永远 prune 不掉。
+        # --------------------------------------------------------------
+        print("\n[4j] Regression: malformed stat_date rejected...")
+        bad_payload = {
+            "device_id": "j" * 64, "app_version": "2.0.0", "branch": "main",
+            "locale": "en-US", "timezone": "UTC", "distribution": "source",
+            "steam_user_id": "", "daily_stats": {}, "recent_records": [],
+            "instruments": {
+                "window_start": time.time() - 60, "window_end": time.time(),
+                "stat_date": "9999-99-99",  # 伪造的非法日期
+                "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+                "counters": {"forged_stat_date_counter": 1},
+                "histograms": {},
+            },
+        }
+        s_bad, _ = _sign_and_submit(bad_payload, gzip_it=False, batch_id="smoke-baddate-1")
+        assert s_bad == 200, f"bad-date payload should still be accepted (HTTP {s_bad})"
+        time.sleep(0.3)
+        conn_bad = sqlite3.connect(db_path)
+        bad_rows = conn_bad.execute(
+            "SELECT stat_date FROM instrument_counters "
+            "WHERE metric_key = 'forged_stat_date_counter'"
+        ).fetchall()
+        conn_bad.close()
+        landed_dates = [r[0] for r in bad_rows]
+        print(f"  forged counter landed under stat_date(s): {landed_dates}")
+        assert landed_dates, "forged counter should still be stored (under fallback date)"
+        assert "9999-99-99" not in landed_dates, (
+            "Codex P2 regression: malformed stat_date '9999-99-99' was persisted "
+            "as a real partition key — date.fromisoformat validation not working"
+        )
+        print("  ✓ malformed stat_date rejected, fell back to a valid date")
+
+        # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表
         # --------------------------------------------------------------
         print("\n[5/5] Fetching dashboard HTML...")

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -802,8 +802,8 @@ def main():
                 "histograms": {},
             },
         }
-        nan_body = json.dumps(nan_payload)  # 默认 allow_nan=True，产出 NaN token
-        # 复用 _sign_and_submit 需要 dict；直接走它，签名基于 canonical json
+        # _sign_and_submit 内部 json.dumps（默认 allow_nan=True）会把 NaN 序列化
+        # 成 'NaN' token，server json.loads 默认接受 → 进 storage 被 isfinite 拦下。
         s_nan, _ = _sign_and_submit(nan_payload, gzip_it=False, batch_id="smoke-nan-1")
         assert s_nan == 200, f"NaN payload should be accepted, bad sample skipped (HTTP {s_nan})"
         time.sleep(0.3)

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -678,9 +678,11 @@ def main():
         # D1 漏斗
         tracker_k.note_first_user_message("text")
         tracker_k.note_core_loop_completed()
-        # settings + proactive + D1 错误（直接走 instrument，模拟各 hook 点）
-        counter("settings_state", 1, proactive="on", interval="10-30s",
-                privacy="off", vision_chat="on")
+        # settings_state 走**真正的** record_settings_state（读 preferences +
+        # 分桶 + privacy 取反逻辑），而不是手写 counter——否则分桶/取反/读盘
+        # 逻辑坏了 smoke 也发现不了（CodeRabbit 指出）。
+        tt_mod.record_settings_state()
+        # proactive + D1 错误（直接走 instrument，模拟各 hook 点）
         counter("proactive_fired", 1, channel="vision")
         counter("llm_error", 1, error_class="TimeoutError")
         counter("api_key_invalid", 1)

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -749,10 +749,78 @@ def main():
         print(f"  forged counter landed under stat_date(s): {landed_dates}")
         assert landed_dates, "forged counter should still be stored (under fallback date)"
         assert "9999-99-99" not in landed_dates, (
-            "Codex P2 regression: malformed stat_date '9999-99-99' was persisted "
+            "regression: malformed stat_date '9999-99-99' was persisted "
             "as a real partition key — date.fromisoformat validation not working"
         )
         print("  ✓ malformed stat_date rejected, fell back to a valid date")
+
+        # 第二个 case：parse-pass 但越界的未来日期（9999-12-31）。fromisoformat
+        # 接受它，但 ±2 天范围约束必须拦下，否则字典序 retention 永远 prune
+        # 不掉（CodeRabbit）。
+        oor_payload = {
+            "device_id": "k" * 64, "app_version": "2.0.0", "branch": "main",
+            "locale": "en-US", "timezone": "UTC", "distribution": "source",
+            "steam_user_id": "", "daily_stats": {}, "recent_records": [],
+            "instruments": {
+                "window_start": time.time() - 60, "window_end": time.time(),
+                "stat_date": "9999-12-31",  # 可解析但越界的未来日期
+                "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+                "counters": {"oor_stat_date_counter": 1},
+                "histograms": {},
+            },
+        }
+        s_oor, _ = _sign_and_submit(oor_payload, gzip_it=False, batch_id="smoke-oordate-1")
+        assert s_oor == 200, f"out-of-range-date payload should still be accepted (HTTP {s_oor})"
+        time.sleep(0.3)
+        conn_oor = sqlite3.connect(db_path)
+        oor_rows = conn_oor.execute(
+            "SELECT stat_date FROM instrument_counters "
+            "WHERE metric_key = 'oor_stat_date_counter'"
+        ).fetchall()
+        conn_oor.close()
+        oor_dates = [r[0] for r in oor_rows]
+        print(f"  out-of-range counter landed under stat_date(s): {oor_dates}")
+        assert oor_dates, "oor counter should still be stored (under fallback date)"
+        assert "9999-12-31" not in oor_dates, (
+            "regression: out-of-range stat_date '9999-12-31' was persisted as a "
+            "real partition key — range check (±2 days) not working"
+        )
+        print("  ✓ out-of-range stat_date rejected, fell back to a valid date")
+
+        # NaN counter 不能炸整批：含 NaN 的 payload 仍 200，NaN 样本被跳过，
+        # 同批的合法 counter 照常入库（Codex P2）。
+        nan_payload = {
+            "device_id": "m" * 64, "app_version": "2.0.0", "branch": "main",
+            "locale": "en-US", "timezone": "UTC", "distribution": "source",
+            "steam_user_id": "", "daily_stats": {}, "recent_records": [],
+            "instruments": {
+                "window_start": time.time() - 60, "window_end": time.time(),
+                "stat_date": time.strftime("%Y-%m-%d"),
+                "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+                # NaN 通过 JSON 'NaN' token 传入（Python json 默认接受）
+                "counters": {"nan_counter": float("nan"), "good_counter_beside_nan": 7},
+                "histograms": {},
+            },
+        }
+        nan_body = json.dumps(nan_payload)  # 默认 allow_nan=True，产出 NaN token
+        # 复用 _sign_and_submit 需要 dict；直接走它，签名基于 canonical json
+        s_nan, _ = _sign_and_submit(nan_payload, gzip_it=False, batch_id="smoke-nan-1")
+        assert s_nan == 200, f"NaN payload should be accepted, bad sample skipped (HTTP {s_nan})"
+        time.sleep(0.3)
+        conn_nan = sqlite3.connect(db_path)
+        good_beside = conn_nan.execute(
+            "SELECT value FROM instrument_counters WHERE metric_key = 'good_counter_beside_nan'"
+        ).fetchone()
+        nan_landed = conn_nan.execute(
+            "SELECT COUNT(*) FROM instrument_counters WHERE metric_key = 'nan_counter'"
+        ).fetchone()[0]
+        conn_nan.close()
+        assert good_beside is not None and good_beside[0] == 7, (
+            "Codex P2 regression: NaN sample rolled back the whole batch — "
+            "valid counter beside it was lost"
+        )
+        assert nan_landed == 0, "NaN counter should have been skipped, not stored"
+        print("  ✓ NaN counter skipped, valid counter in same batch survived")
 
         # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -664,6 +664,57 @@ def main():
         print(f"  ✓ fresh counter landed in next window: {rows_j}")
 
         # --------------------------------------------------------------
+        # [4i] 新增业务埋点端到端：D1 信号 + settings_state + proactive_fired
+        #
+        # 验证 note_first_user_message / note_core_loop_completed /
+        # record_settings_state 产出的 counter/histogram 走完整通道到 server。
+        # --------------------------------------------------------------
+        print("\n[4i] New telemetry: D1 signals + settings_state...")
+        Instrument._instance = None
+        TokenTracker._instance = None
+        tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
+        tracker_k = TokenTracker.get_instance()
+        tracker_k._session_start_ts = time.time() - 8.0
+        # D1 漏斗
+        tracker_k.note_first_user_message("text")
+        tracker_k.note_core_loop_completed()
+        # settings + proactive + D1 错误（直接走 instrument，模拟各 hook 点）
+        counter("settings_state", 1, proactive="on", interval="10-30s",
+                privacy="off", vision_chat="on")
+        counter("proactive_fired", 1, channel="vision")
+        counter("llm_error", 1, error_class="TimeoutError")
+        counter("api_key_invalid", 1)
+        counter("tts_error", 1, code="API_KEY_REJECTED")
+        histogram("llm_ttft_ms", 850.0)
+        tracker_k._last_report_time = 0
+        tracker_k.save()
+        time.sleep(0.5)
+
+        conn_k = sqlite3.connect(db_path)
+        ic = {r[0]: r[1] for r in conn_k.execute(
+            "SELECT metric_key, value FROM instrument_counters WHERE metric_key IN "
+            "('first_message_sent|input_type=text','core_loop_completed',"
+            "'proactive_fired|channel=vision','llm_error|error_class=TimeoutError',"
+            "'api_key_invalid','tts_error|code=API_KEY_REJECTED') "
+            "OR metric_key LIKE 'settings_state|%'"
+        ).fetchall()}
+        ih = {r[0]: r[1] for r in conn_k.execute(
+            "SELECT metric_key, count FROM instrument_histograms "
+            "WHERE metric_key LIKE 'llm_ttft_ms%' OR metric_key LIKE 'time_to_first_message_sec%'"
+        ).fetchall()}
+        conn_k.close()
+        print(f"  counters landed: {sorted(ic.keys())}")
+        print(f"  histograms landed: {sorted(ih.keys())}")
+        for need in ("first_message_sent|input_type=text", "core_loop_completed",
+                     "proactive_fired|channel=vision", "llm_error|error_class=TimeoutError",
+                     "api_key_invalid", "tts_error|code=API_KEY_REJECTED"):
+            assert need in ic, f"new telemetry counter missing: {need}"
+        assert any(k.startswith("settings_state|") for k in ic), "settings_state missing"
+        assert any(k.startswith("llm_ttft_ms") for k in ih), "llm_ttft_ms missing"
+        assert any(k.startswith("time_to_first_message_sec") for k in ih), "time_to_first_message_sec missing"
+        print("  ✓ all new D1 + settings + proactive telemetry reached server")
+
+        # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表
         # --------------------------------------------------------------
         print("\n[5/5] Fetching dashboard HTML...")

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -822,6 +822,49 @@ def main():
         assert nan_landed == 0, "NaN counter should have been skipped, not stored"
         print("  ✓ NaN counter skipped, valid counter in same batch survived")
 
+        # 形状不自洽的 histogram（count=100 但 sum(buckets)=2）必须被跳过，
+        # 否则 dashboard 的 avg(用 count) 与 p50/p95(用 buckets) 打架（CodeRabbit）。
+        shape_payload = {
+            "device_id": "n" * 64, "app_version": "2.0.0", "branch": "main",
+            "locale": "en-US", "timezone": "UTC", "distribution": "source",
+            "steam_user_id": "", "daily_stats": {}, "recent_records": [],
+            "instruments": {
+                "window_start": time.time() - 60, "window_end": time.time(),
+                "stat_date": time.strftime("%Y-%m-%d"),
+                "bounds": [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000],
+                "counters": {},
+                "histograms": {
+                    "bad_shape_hist": {  # count=100 但 buckets 只加起来 =2
+                        "count": 100, "sum": 50.0,
+                        "buckets": [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    },
+                    "good_shape_hist": {  # 自洽：sum(buckets)=3=count
+                        "count": 3, "sum": 18.0,
+                        "buckets": [0, 0, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    },
+                },
+            },
+        }
+        s_shape, _ = _sign_and_submit(shape_payload, gzip_it=False, batch_id="smoke-shape-1")
+        assert s_shape == 200, f"shape payload should be accepted, bad hist skipped (HTTP {s_shape})"
+        time.sleep(0.3)
+        conn_shape = sqlite3.connect(db_path)
+        bad_hist = conn_shape.execute(
+            "SELECT COUNT(*) FROM instrument_histograms WHERE metric_key='bad_shape_hist'"
+        ).fetchone()[0]
+        good_hist = conn_shape.execute(
+            "SELECT count FROM instrument_histograms WHERE metric_key='good_shape_hist'"
+        ).fetchone()
+        conn_shape.close()
+        assert bad_hist == 0, (
+            "CodeRabbit regression: inconsistent histogram (sum(buckets)!=count) "
+            "was stored — shape validation not working"
+        )
+        assert good_hist is not None and good_hist[0] == 3, (
+            "self-consistent histogram in same batch should still be stored"
+        )
+        print("  ✓ inconsistent histogram skipped, consistent one in same batch stored")
+
         # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表
         # --------------------------------------------------------------

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -576,6 +576,7 @@ def main():
                 try:
                     await task
                 except _asyncio.CancelledError:
+                    # 期望路径 —— cancel 主动制造的 CancelledError，吞掉是 idiomatic
                     pass
 
         _asyncio.run(_periodic_wake_test())
@@ -592,6 +593,73 @@ def main():
             "loop must check instrument.has_data() not just self._dirty"
         )
         print(f"  ✓ periodic loop picked up instrument-only: {rows_i}")
+
+        # --------------------------------------------------------------
+        # [4h] Regression: Codex P2 round-5 — retry 不能拖走新 instrument
+        #
+        # 场景：daily-bearing payload server commit 但 client timeout
+        # → _pending_batch_seq=A 保留供 retry。期间新 counter 累积 (Y2)。
+        # 如果 retry 把 Y2 一起塞进 payload，batch_id=A 已经在 server
+        # seen_batches，整个 batch 被 dedupe，Y2 跟着丢（已 clear-on-read）。
+        # 修复：retry 不 snapshot instrument，Y2 留在 buffer 等下窗口。
+        # --------------------------------------------------------------
+        print("\n[4h] Regression: retry doesn't drag fresh instruments...")
+        Instrument._instance = None
+        TokenTracker._instance = None
+        tracker_j = TokenTracker.get_instance()
+
+        # Step A: daily-bearing 失败 → batch_seq 保留
+        tt_mod._TELEMETRY_SERVER_URL = "http://127.0.0.1:1"
+        tracker_j.record(model="gpt-4o-mini", prompt_tokens=222,
+                         completion_tokens=33, total_tokens=255,
+                         cached_tokens=0, call_type="conversation")
+        tracker_j._last_report_time = 0
+        tracker_j.save()
+        time.sleep(0.3)
+        retained_seq = tracker_j._pending_batch_seq
+        assert retained_seq is not None, "daily failure must preserve batch_seq"
+        print(f"  daily failed, batch_seq retained = {retained_seq[:12]}...")
+
+        # Step B: 灌新 counter 到 buffer
+        counter("fresh_after_retry", 1, surface="index_wide")
+        inst_j = Instrument.get_instance()
+        assert inst_j.has_data(), "fresh counter should be in buffer"
+
+        # Step C: 恢复 URL，触发 retry（buffer 里有 fresh counter）
+        tt_mod._TELEMETRY_SERVER_URL = SERVER_URL
+        tracker_j._last_report_time = 0
+        tracker_j.save()
+        time.sleep(0.5)
+
+        # 关键断言：retry 跑完后 fresh counter **必须仍在 buffer**
+        # 如果 retry 把它 snapshot 拿走，server dedupe 返 duplicate，fresh
+        # counter 永远不会到 server。
+        assert inst_j.has_data(), (
+            "P2 round-5 regression: fresh counter consumed by retry snapshot. "
+            "Retry must skip instrument snapshot to avoid dedupe-induced loss."
+        )
+        # 而且 batch_seq 应该被清了（retry 成功）
+        assert tracker_j._pending_batch_seq is None, (
+            "retry should succeed (server hasn't actually seen this batch_id "
+            "in our test setup) and clear batch_seq"
+        )
+        print("  ✓ retry kept fresh counter in buffer")
+
+        # Step D: 下一窗口（新 batch_seq）发 fresh counter
+        tracker_j._last_report_time = 0
+        tracker_j.save()
+        time.sleep(0.5)
+        conn_j = sqlite3.connect(db_path)
+        rows_j = conn_j.execute(
+            "SELECT metric_key, value FROM instrument_counters "
+            "WHERE metric_key LIKE 'fresh_after_retry%'"
+        ).fetchall()
+        conn_j.close()
+        assert len(rows_j) >= 1, (
+            "P2 round-5 regression: fresh counter never reached server even "
+            "in the window after retry"
+        )
+        print(f"  ✓ fresh counter landed in next window: {rows_j}")
 
         # --------------------------------------------------------------
         # [5/5] dashboard 能返回 + 含 instrument 表

--- a/scripts/telemetry_smoke.py
+++ b/scripts/telemetry_smoke.py
@@ -164,7 +164,9 @@ def main():
         histogram("ttft_ms", 234)
         histogram("ttft_ms", 412)
         histogram("ttft_ms", 156)
-        histogram("ws_session_sec", 850.5, lanlan_name="hibiki")
+        # 用 surface dim 而不是 lanlan_name —— 后者是用户自定义 character
+        # 名（PII + 高基数），生产代码已经不传，smoke 也不该示范坏 pattern。
+        histogram("ws_session_sec", 850.5, surface="pet_widget")
 
         event("session_start", process="main_server")
         event("crash", error_class="ValueError", traceback_hash="deadbeef")

--- a/static/app-telemetry.js
+++ b/static/app-telemetry.js
@@ -56,6 +56,13 @@
         }
     }
 
+    // surface 系统注入字段必须**最后**写入，避免业务侧传 dims/fields 时
+    // 不小心带了 'surface' key 把真值覆盖掉、污染分面统计。
+    // 参数顺序记忆：dims/fields 在前，系统字段在后 = 后者赢。
+    function _withSurface(userDims) {
+        return Object.assign({}, userDims || {}, {surface: _surface()});
+    }
+
     /**
      * 累加一个计数器。
      *
@@ -67,13 +74,12 @@
      * 用例：appTelemetry.counter('chat_message_sent', 1, {input_type: 'text'})
      */
     function counter(name, value, dims) {
-        var d = Object.assign({surface: _surface()}, dims || {});
         return _send({
             action: 'telemetry',
             kind: 'counter',
             name: String(name || ''),
             value: (typeof value === 'number') ? value : 1,
-            dims: d,
+            dims: _withSurface(dims),
         });
     }
 
@@ -89,13 +95,12 @@
     function histogram(name, value, dims) {
         var v = Number(value);
         if (!isFinite(v)) return false;
-        var d = Object.assign({surface: _surface()}, dims || {});
         return _send({
             action: 'telemetry',
             kind: 'histogram',
             name: String(name || ''),
             value: v,
-            dims: d,
+            dims: _withSurface(dims),
         });
     }
 
@@ -108,12 +113,11 @@
      * 用例：appTelemetry.event('persona_picker_opened')
      */
     function event(name, fields) {
-        var f = Object.assign({surface: _surface()}, fields || {});
         return _send({
             action: 'telemetry',
             kind: 'event',
             name: String(name || ''),
-            fields: f,
+            fields: _withSurface(fields),
         });
     }
 

--- a/static/app-telemetry.js
+++ b/static/app-telemetry.js
@@ -1,0 +1,126 @@
+/**
+ * app-telemetry.js -- 前端埋点 SDK
+ *
+ * 业务侧通过 ``window.appTelemetry.counter(name, value, dims)`` 等三 API 投递
+ * 数据；本模块把它们打成 WS message（action="telemetry"）发回 Python 后端，
+ * 由 main_routers/websocket_router.py 的 _handle_ws_telemetry 转交
+ * utils.instrument。最终跟 Python 端自己发的 counter 走同一条 HTTP 上报通道。
+ *
+ * 设计取舍：
+ *   - WS 不通时静默丢（buffering 复杂，且 telemetry 不能反过来阻塞业务）。
+ *     真正关键的事件（crash、onboarding）该用 HTTP POST 保证投递，本模块
+ *     不负责。
+ *   - 维度（dims/fields）必须是低基数 enum；后端会过滤掉非 string/number/bool
+ *     值，并限制 key/value 长度（见 websocket_router._sanitize_dims）。
+ *   - surface 字段自动注入（区分 index 宽屏 / 移动版 / chat.html follower
+ *     窗口），调用方无需关心。
+ *
+ * 依赖：window.appState（提供 S.socket）。在 app-state.js / app-websocket.js
+ * 之后加载。
+ */
+(function () {
+    'use strict';
+
+    const S = window.appState;
+
+    /**
+     * 当前 surface 名 —— 区分三个上下文（记忆 feedback_chat_three_contexts）：
+     *   - chat_window: chat.html follower 窗口
+     *   - index_mobile: 手机/平板视图的 index.html
+     *   - index_wide: 桌面宽屏 index.html
+     * 调用方任何 counter/histogram/event 都会带上这个字段。
+     */
+    function _surface() {
+        try {
+            var p = (window.location.pathname || '').toLowerCase();
+            if (p.indexOf('chat.html') >= 0) return 'chat_window';
+        } catch (_) {}
+        try {
+            var ua = (navigator && navigator.userAgent) || '';
+            if (/mobi|android|iphone|ipad/i.test(ua)) return 'index_mobile';
+        } catch (_) {}
+        return 'index_wide';
+    }
+
+    function _wsReady() {
+        return !!(S && S.socket && S.socket.readyState === 1 /* OPEN */);
+    }
+
+    function _send(payload) {
+        if (!_wsReady()) return false;
+        try {
+            S.socket.send(JSON.stringify(payload));
+            return true;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    /**
+     * 累加一个计数器。
+     *
+     * @param {string} name - 指标名（snake_case）
+     * @param {number} [value=1] - 增量
+     * @param {object} [dims] - 维度（低基数 enum）
+     * @returns {boolean} 是否成功投递到 WS（不代表服务端收到）
+     *
+     * 用例：appTelemetry.counter('chat_message_sent', 1, {input_type: 'text'})
+     */
+    function counter(name, value, dims) {
+        var d = Object.assign({surface: _surface()}, dims || {});
+        return _send({
+            action: 'telemetry',
+            kind: 'counter',
+            name: String(name || ''),
+            value: (typeof value === 'number') ? value : 1,
+            dims: d,
+        });
+    }
+
+    /**
+     * 记录一个分布型测量。
+     *
+     * @param {string} name - 指标名（如 'click_response_ms'）
+     * @param {number} value - 测量值（数字）
+     * @param {object} [dims] - 维度
+     *
+     * 用例：appTelemetry.histogram('avatar_load_ms', performance.now() - t0)
+     */
+    function histogram(name, value, dims) {
+        var v = Number(value);
+        if (!isFinite(v)) return false;
+        var d = Object.assign({surface: _surface()}, dims || {});
+        return _send({
+            action: 'telemetry',
+            kind: 'histogram',
+            name: String(name || ''),
+            value: v,
+            dims: d,
+        });
+    }
+
+    /**
+     * 记录一个稀疏带 context 事件。
+     *
+     * @param {string} name - 事件名
+     * @param {object} [fields] - 事件字段（同样要低基数）
+     *
+     * 用例：appTelemetry.event('persona_picker_opened')
+     */
+    function event(name, fields) {
+        var f = Object.assign({surface: _surface()}, fields || {});
+        return _send({
+            action: 'telemetry',
+            kind: 'event',
+            name: String(name || ''),
+            fields: f,
+        });
+    }
+
+    window.appTelemetry = {
+        counter: counter,
+        histogram: histogram,
+        event: event,
+        surface: _surface,
+    };
+})();

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -759,6 +759,7 @@
     <script src="/static/app-agent.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-character.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-websocket.js?v={{ static_asset_version }}"></script>
+    <script src="/static/app-telemetry.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-buttons.js?v={{ static_asset_version }}"></script>
     <script src="/static/app.js?v={{ static_asset_version }}"></script>
     <script src="/static/subtitle.js?v={{ static_asset_version }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -356,6 +356,7 @@
     <script src="/static/app-agent.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-character.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-websocket.js?v={{ static_asset_version }}"></script>
+    <script src="/static/app-telemetry.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-buttons.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-prompt-shared.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-autostart-provider.js?v={{ static_asset_version }}"></script>

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -234,4 +234,6 @@ def test_snapshot_empty_still_advances_window():
     import time
     time.sleep(0.01)
     inst.snapshot()  # 空
-    assert inst._window_start >= w0
+    # 严格 > ：空 snapshot 也必须推进 window_start，否则空窗口会一直挂着。
+    # 用 >= 的话即使实现完全不更新也会通过，兜不住回归。
+    assert inst._window_start > w0

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -50,6 +50,23 @@ def test_make_key_value_types():
     assert _make_key("e", {"s": "x", "n": 3, "b": True}) == "e|b=True,n=3,s=x"
 
 
+def test_make_key_escapes_delimiters_no_collision():
+    # 含分隔符的值不能让不同 dim 组合塌缩成同一 key（Codex P2）
+    k1 = _make_key("e", {"a": "x,b=y"})       # 单个 dim，值里带 , 和 =
+    k2 = _make_key("e", {"a": "x", "b": "y"})  # 两个 dim
+    assert k1 != k2, f"delimiter collision: {k1!r} == {k2!r}"
+
+
+def test_make_key_escape_is_injective():
+    # "a,b" 和 "a=b" 转义后必须区分（简单 replace 成 _ 会塌缩，escape 不会）
+    assert _make_key("e", {"k": "a,b"}) != _make_key("e", {"k": "a=b"})
+
+
+def test_make_key_pipe_escaped():
+    # 值里的 | 也转义，不破坏 name|dims 结构
+    assert _make_key("e", {"k": "a|b"}) == "e|k=a\\|b"
+
+
 # ---------------------------------------------------------------------------
 # counter
 # ---------------------------------------------------------------------------

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -67,6 +67,17 @@ def test_make_key_pipe_escaped():
     assert _make_key("e", {"k": "a|b"}) == "e|k=a\\|b"
 
 
+def test_make_key_escapes_name_no_collision():
+    # untrusted name 含分隔符不能跟 name+dims 组合碰撞（Codex）
+    assert _make_key("foo|a=1", {}) != _make_key("foo", {"a": "1"})
+
+
+def test_make_key_clean_name_unchanged():
+    # 合法 snake_case name 无分隔符，转义是 no-op，key 不变
+    assert _make_key("session_start", {}) == "session_start"
+    assert _make_key("ws_connect", {"reason": "x"}) == "ws_connect|reason=x"
+
+
 # ---------------------------------------------------------------------------
 # counter
 # ---------------------------------------------------------------------------

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""utils/instrument.py 单元测试。
+
+覆盖 counter / histogram / event 三 API、snapshot clear-on-read、has_data
+peek、容量保护、_make_key 字典序、histogram 桶边界。
+
+集成层（counter → token_tracker 上报 → server 落库）由
+scripts/telemetry_smoke.py 端到端验证，这里只测 SDK 自身行为。
+"""
+import pytest
+
+from utils.instrument import (
+    Instrument,
+    _make_key,
+    _HIST_BOUNDS,
+    _HIST_NUM_BUCKETS,
+    _MAX_COUNTER_KEYS,
+    _MAX_HISTOGRAM_KEYS,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_instrument():
+    """每个 test 用干净的单例，避免跨 test 累积污染。"""
+    Instrument._instance = None
+    yield
+    Instrument._instance = None
+
+
+def _inst():
+    return Instrument.get_instance()
+
+
+# ---------------------------------------------------------------------------
+# _make_key
+# ---------------------------------------------------------------------------
+
+def test_make_key_no_dims():
+    assert _make_key("foo", {}) == "foo"
+
+
+def test_make_key_sorts_dims():
+    # dims 必须按 key 字典序拼，保证同一组 dims 不论传入顺序都得到同一 key
+    k1 = _make_key("evt", {"b": 2, "a": 1})
+    k2 = _make_key("evt", {"a": 1, "b": 2})
+    assert k1 == k2 == "evt|a=1,b=2"
+
+
+def test_make_key_value_types():
+    assert _make_key("e", {"s": "x", "n": 3, "b": True}) == "e|b=True,n=3,s=x"
+
+
+# ---------------------------------------------------------------------------
+# counter
+# ---------------------------------------------------------------------------
+
+def test_counter_accumulates():
+    inst = _inst()
+    inst.counter("msg", 1)
+    inst.counter("msg", 1)
+    inst.counter("msg", 3)
+    snap = inst.snapshot()
+    assert snap["counters"]["msg"] == 5
+
+
+def test_counter_dim_separates_keys():
+    inst = _inst()
+    inst.counter("msg", 1, surface="pet")
+    inst.counter("msg", 1, surface="chat")
+    inst.counter("msg", 1, surface="pet")
+    snap = inst.snapshot()
+    assert snap["counters"]["msg|surface=pet"] == 2
+    assert snap["counters"]["msg|surface=chat"] == 1
+
+
+def test_counter_ignores_empty_name():
+    inst = _inst()
+    inst.counter("", 1)
+    assert not inst.has_data()
+
+
+def test_counter_ignores_non_numeric_value():
+    inst = _inst()
+    inst.counter("msg", "not a number")  # type: ignore[arg-type]
+    assert not inst.has_data()
+
+
+def test_counter_cap_protection():
+    inst = _inst()
+    # 灌超过 cap 的唯一 key，超出的被丢弃
+    for i in range(_MAX_COUNTER_KEYS + 100):
+        inst.counter("c", 1, dim=str(i))
+    assert len(inst._counters) == _MAX_COUNTER_KEYS
+    assert inst._cap_warned_counter is True
+
+
+def test_counter_cap_still_accumulates_existing():
+    # 容量满后，已存在的 key 仍能继续累加（只是不收新 key）
+    inst = _inst()
+    for i in range(_MAX_COUNTER_KEYS):
+        inst.counter("c", 1, dim=str(i))
+    inst.counter("c", 5, dim="0")  # 已存在
+    inst.counter("c", 1, dim="overflow")  # 新 key，被丢
+    assert inst._counters["c|dim=0"] == 6
+    assert "c|dim=overflow" not in inst._counters
+
+
+# ---------------------------------------------------------------------------
+# histogram
+# ---------------------------------------------------------------------------
+
+def test_histogram_count_and_sum():
+    inst = _inst()
+    inst.histogram("lat", 100)
+    inst.histogram("lat", 200)
+    snap = inst.snapshot()
+    h = snap["histograms"]["lat"]
+    assert h["count"] == 2
+    assert h["sum"] == 300
+
+
+def test_histogram_bucket_placement():
+    # bisect_left(_HIST_BOUNDS, v) 决定桶 index
+    # _HIST_BOUNDS = (1,2,5,10,20,50,100,200,500,1000,2000,5000,10000)
+    inst = _inst()
+    inst.histogram("h", 156)   # 100<156<=200 -> idx 7
+    inst.histogram("h", 234)   # 200<234<=500 -> idx 8
+    inst.histogram("h", 412)   # idx 8
+    inst.histogram("h", 8500)  # 5000<8500<=10000 -> idx 12
+    snap = inst.snapshot()
+    buckets = snap["histograms"]["h"]["buckets"]
+    assert len(buckets) == _HIST_NUM_BUCKETS
+    assert buckets[7] == 1
+    assert buckets[8] == 2
+    assert buckets[12] == 1
+
+
+def test_histogram_overflow_bucket():
+    # 超过最右边界进溢出桶（最后一个）
+    inst = _inst()
+    inst.histogram("h", 999999)
+    snap = inst.snapshot()
+    buckets = snap["histograms"]["h"]["buckets"]
+    assert buckets[-1] == 1
+
+
+def test_histogram_boundary_inclusive_left():
+    # bisect_left: value == bound 落到该 bound 的 index（左侧桶）
+    inst = _inst()
+    inst.histogram("h", 100)  # ==bound[6]=100 -> bisect_left=6
+    snap = inst.snapshot()
+    assert snap["histograms"]["h"]["buckets"][6] == 1
+
+
+def test_histogram_ignores_non_numeric():
+    inst = _inst()
+    inst.histogram("h", "nope")  # type: ignore[arg-type]
+    assert not inst.has_data()
+
+
+def test_histogram_cap_protection():
+    inst = _inst()
+    for i in range(_MAX_HISTOGRAM_KEYS + 50):
+        inst.histogram("h", 1, dim=str(i))
+    assert len(inst._histograms) == _MAX_HISTOGRAM_KEYS
+    assert inst._cap_warned_histogram is True
+
+
+# ---------------------------------------------------------------------------
+# event（转发 event_logger）
+# ---------------------------------------------------------------------------
+
+def test_event_forwards_to_event_logger(monkeypatch):
+    captured = []
+    monkeypatch.setattr(
+        "utils.instrument._event_emit",
+        lambda name, **fields: captured.append((name, fields)),
+    )
+    _inst().event("crash", module="agent_router", hash="abc")
+    assert captured == [("crash", {"module": "agent_router", "hash": "abc"})]
+
+
+def test_event_does_not_touch_counters():
+    # event 走 event_logger，不进 counter/histogram map
+    inst = _inst()
+    inst.event("e", k="v")
+    assert not inst._counters
+    assert not inst._histograms
+
+
+# ---------------------------------------------------------------------------
+# snapshot / has_data
+# ---------------------------------------------------------------------------
+
+def test_has_data_peek_does_not_consume():
+    inst = _inst()
+    inst.counter("c", 1)
+    assert inst.has_data() is True
+    assert inst.has_data() is True  # peek 不消费
+    assert inst._counters  # 仍在
+
+
+def test_snapshot_clears_on_read():
+    inst = _inst()
+    inst.counter("c", 1)
+    inst.histogram("h", 5)
+    snap1 = inst.snapshot()
+    assert snap1["counters"] and snap1["histograms"]
+    # 第二次 snapshot 应该是空（clear-on-read）
+    snap2 = inst.snapshot()
+    assert snap2 == {}
+    assert not inst.has_data()
+
+
+def test_snapshot_empty_returns_empty_dict():
+    assert _inst().snapshot() == {}
+
+
+def test_snapshot_includes_stat_date_and_bounds():
+    inst = _inst()
+    inst.counter("c", 1)
+    snap = inst.snapshot()
+    # stat_date 是客户端本地日历天 YYYY-MM-DD
+    assert "stat_date" in snap
+    assert len(snap["stat_date"]) == 10 and snap["stat_date"][4] == "-"
+    assert snap["bounds"] == list(_HIST_BOUNDS)
+    assert "window_start" in snap and "window_end" in snap
+
+
+def test_snapshot_empty_still_advances_window():
+    # 空 snapshot 也更新 window_start，避免空窗口一直挂着
+    inst = _inst()
+    w0 = inst._window_start
+    import time
+    time.sleep(0.01)
+    inst.snapshot()  # 空
+    assert inst._window_start >= w0

--- a/utils/event_logger.py
+++ b/utils/event_logger.py
@@ -27,7 +27,6 @@
 from __future__ import annotations
 
 import json
-import os
 import threading
 import time
 from collections import deque
@@ -169,10 +168,22 @@ class EventLogger:
                     day = self._day_of(rec["ts"])
                     by_day.setdefault(day, []).append(rec)
 
+                # 写盘失败的 day 数据要回到 buffer 重试；写成功的 day 已经
+                # 持久化、不能 push_back（否则下次 flush 重复落地）。区分
+                # 两种 _append_day 返回路径：raise = IO 失败，return 0 =
+                # sealed/empty 正常丢弃。
+                unwritten: list = []
                 for day, recs in by_day.items():
                     if day in self._sealed_days:
                         continue  # 本天已封板（爆量保护），丢弃新事件
-                    written += self._append_day(day, recs)
+                    try:
+                        written += self._append_day(day, recs)
+                    except OSError:
+                        # _append_day 内已经走过 _log_fail 节流日志，这里
+                        # 不再重复 log；只把数据丢回 buffer 等下次重试。
+                        unwritten.extend(recs)
+                if unwritten:
+                    self._push_back(unwritten)
 
         if should_cleanup:
             self._cleanup()
@@ -225,7 +236,10 @@ class EventLogger:
             return 0
 
         payload = b"".join(lines)
-        # append-only：依赖 OS 的 O_APPEND 原子性，每行 < 4KB 时单次 write 是原子的
+        # append-only：依赖 OS 的 O_APPEND 原子性，每行 < 4KB 时单次 write 是原子的。
+        # IO 失败 raise OSError 让 caller (flush) 把 recs push_back 重试；用
+        # raise 而不是 return 0 是为了跟 sealed/empty 路径区分 —— 后者是"按
+        # 设计丢弃"，不该 push_back 占 buffer。
         try:
             with open(path, "ab") as f:
                 f.write(payload)
@@ -233,7 +247,7 @@ class EventLogger:
             return len(lines)
         except OSError as e:
             self._log_fail(f"event_logger: write failed for {path.name}: {e}")
-            return 0
+            raise
 
     def _push_back(self, recs: list) -> None:
         """写盘失败时把事件丢回 buffer。尊重 maxlen，老数据自动出队。"""

--- a/utils/event_logger.py
+++ b/utils/event_logger.py
@@ -1,0 +1,335 @@
+# -*- coding: utf-8 -*-
+"""
+稀疏事件日志（sparse-event JSONL writer）
+
+用途：记录 session_start / crash / onboarding_step / app_exit 等数量稀少但
+单条信息量高的事件。与 token_tracker 的 daily aggregates（counter / histogram
+类）互补 —— 后者是数字汇总，本模块是带 context 的离散事件。
+
+存储设计：
+- events-YYYYMMDD.jsonl，每行一个 JSON event，按天分片
+- append-only：写入永不修改已有行，只追加
+- Retention：删除 > 7 天的分片
+- 单文件硬上限 500 KB（超了拒收新事件，防单天爆量打挂磁盘）
+- 目录总硬上限 20 MB（超了强删最老分片，防 disk full）
+
+开销保证：
+- emit() 进 in-memory deque，纳秒级，不阻塞主路径
+- flush() 由 TokenTracker 60s 定时调用一次，单次写盘 < 50 KB
+- cleanup() 顺便在 flush 时跑，成本是 listdir + 几个 stat
+
+线程安全：进程内用 _lock 串行；多进程不严格同步，依赖每行 jsonl < 4KB 时
+单 write 系统调用的原子性（POSIX O_APPEND / Windows append mode 都保证）。
+
+不持久化哪些字段：消息内容、用户名、master_name、prompt 文本。本模块的事件
+应该是"什么发生了"+"哪个 surface"+ 几个 enum 标签，不要塞业务数据。
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from collections import deque
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from utils.config_manager import get_config_manager
+from utils.logger_config import get_module_logger
+
+logger = get_module_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 配置常量
+# ---------------------------------------------------------------------------
+
+_DIR_NAME = "telemetry_events"
+_FILE_PREFIX = "events-"
+_FILE_SUFFIX = ".jsonl"
+
+# Retention：超过 N 天的分片删除（cleanup 触发）
+_RETENTION_DAYS = 7
+
+# 单文件硬上限：超了不再写新事件，防单天异常爆量
+_FILE_SIZE_CAP = 500 * 1024  # 500 KB
+
+# 目录总硬上限：超了强删最老分片，防 disk full
+_DIR_SIZE_CAP = 20 * 1024 * 1024  # 20 MB
+
+# 内存 buffer 上限：flush 任务卡死时也不让无限增长（保留最新的）
+_BUFFER_MAX = 1000
+
+# Cleanup 节流：连续多次 flush 没必要每次都 listdir/stat，攒一段时间跑一次
+_CLEANUP_MIN_INTERVAL = 5 * 60  # 5 min
+
+
+# ---------------------------------------------------------------------------
+# EventLogger 单例
+# ---------------------------------------------------------------------------
+
+
+class EventLogger:
+    """进程内单例的稀疏事件 JSONL writer。
+
+    典型用法：
+        EventLogger.get_instance().emit("session_start", surface="pet_widget")
+
+    flush() 由 TokenTracker 的 periodic_save_loop 顺手调用，调用方不用关心。
+    """
+
+    _instance: Optional["EventLogger"] = None
+    _init_lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "EventLogger":
+        if cls._instance is None:
+            with cls._init_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._buffer: deque = deque(maxlen=_BUFFER_MAX)
+        self._last_cleanup_ts: float = 0.0
+        # 写盘失败计数：连续失败 N 次就静默（写日志只在 transition 上记一次，
+        # 避免磁盘满 / 权限错误期间日志被刷爆）
+        self._fail_count: int = 0
+        # 单天分片 sealed 标记：超 _FILE_SIZE_CAP 后本天不再写，下天滚动
+        self._sealed_days: set = set()
+
+    # ---- 路径 ----
+
+    @property
+    def _dir(self) -> Path:
+        return get_config_manager().config_dir / _DIR_NAME
+
+    def _file_for(self, day: str) -> Path:
+        return self._dir / f"{_FILE_PREFIX}{day}{_FILE_SUFFIX}"
+
+    # ---- 公开 API ----
+
+    def emit(self, name: str, **fields) -> None:
+        """记录一个稀疏事件。线程安全，非阻塞。
+
+        Args:
+            name: 事件名（snake_case，建议 < 32 chars）
+            **fields: 业务字段。不要塞消息内容 / PII / master_name。
+
+        实现：append 到内存 deque，flush() 时一次性写盘。emit() 本身不做
+        I/O，所以即使每秒调用几百次也不会有可感知开销。
+        """
+        if not name:
+            return
+        rec = {"ts": time.time(), "name": name}
+        # fields 直接平铺进 rec；冲突时 ts/name 优先（防 caller 覆盖语义字段）
+        if fields:
+            for k, v in fields.items():
+                if k in ("ts", "name"):
+                    continue
+                rec[k] = v
+        with self._lock:
+            self._buffer.append(rec)
+
+    def flush(self) -> int:
+        """落盘 buffer + 顺便清理过期分片。线程安全。
+
+        Returns:
+            实际写入磁盘的事件数。0 表示 buffer 为空或写盘失败。
+
+        调用时机：由 TokenTracker._periodic_save_loop 每 60s 调用一次。
+        atexit 时也会被 token_tracker 的 _atexit_save 间接触发（如果接上的话）。
+        """
+        # 锁内只做：取 buffer + 决定是否要 cleanup。所有 I/O 放到锁外，
+        # emit() 不会被磁盘 I/O 阻塞。
+        with self._lock:
+            buf = list(self._buffer)
+            self._buffer.clear()
+            now_mono = time.monotonic()
+            should_cleanup = (now_mono - self._last_cleanup_ts) >= _CLEANUP_MIN_INTERVAL
+            if should_cleanup:
+                self._last_cleanup_ts = now_mono
+
+        written = 0
+        if buf:
+            try:
+                self._dir.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                self._log_fail(f"event_logger: mkdir failed: {e}")
+                # 写盘失败：丢回 buffer，下次重试。deque maxlen 保证长期故障
+                # 下 buffer 自动退化（最老的事件被挤掉），不会无限增长。
+                self._push_back(buf)
+                # 仍走 cleanup —— 也许是 disk full，清掉老分片可能腾出空间。
+            else:
+                # 按 day key 分组（跨午夜的 flush 可能含多天事件）
+                by_day: dict = {}
+                for rec in buf:
+                    day = self._day_of(rec["ts"])
+                    by_day.setdefault(day, []).append(rec)
+
+                for day, recs in by_day.items():
+                    if day in self._sealed_days:
+                        continue  # 本天已封板（爆量保护），丢弃新事件
+                    written += self._append_day(day, recs)
+
+        if should_cleanup:
+            self._cleanup()
+
+        return written
+
+    # ---- 内部：写盘 ----
+
+    @staticmethod
+    def _day_of(ts: float) -> str:
+        """时间戳→ YYYYMMDD（本地时区，与 token_usage.json 的 date.today 对齐）。"""
+        return datetime.fromtimestamp(ts).strftime("%Y%m%d")
+
+    def _append_day(self, day: str, recs: list) -> int:
+        """把 recs 追加到 day 对应分片。返回实际写入条数。"""
+        path = self._file_for(day)
+
+        # 单文件 cap：超了 seal 当天，剩余事件丢弃
+        try:
+            current_size = path.stat().st_size if path.exists() else 0
+        except OSError:
+            current_size = 0
+        if current_size >= _FILE_SIZE_CAP:
+            self._sealed_days.add(day)
+            logger.info(
+                f"event_logger: sealed {path.name} (size={current_size} >= cap), dropping {len(recs)} events"
+            )
+            return 0
+
+        # 拼接 jsonl 字节
+        # ensure_ascii=False：日志里允许中文/日文事件名和字段值，节省字节
+        lines = []
+        remaining = _FILE_SIZE_CAP - current_size
+        for rec in recs:
+            try:
+                line = json.dumps(rec, ensure_ascii=False, separators=(",", ":")) + "\n"
+                b = line.encode("utf-8")
+            except (TypeError, ValueError) as e:
+                # 不可序列化字段 —— 静默丢弃单条，不连累其它事件
+                logger.debug(f"event_logger: drop unserializable event {rec.get('name')}: {e}")
+                continue
+            if remaining < len(b):
+                self._sealed_days.add(day)
+                logger.info(f"event_logger: sealing {path.name} mid-batch (would exceed cap)")
+                break
+            lines.append(b)
+            remaining -= len(b)
+
+        if not lines:
+            return 0
+
+        payload = b"".join(lines)
+        # append-only：依赖 OS 的 O_APPEND 原子性，每行 < 4KB 时单次 write 是原子的
+        try:
+            with open(path, "ab") as f:
+                f.write(payload)
+            self._fail_count = 0
+            return len(lines)
+        except OSError as e:
+            self._log_fail(f"event_logger: write failed for {path.name}: {e}")
+            return 0
+
+    def _push_back(self, recs: list) -> None:
+        """写盘失败时把事件丢回 buffer。尊重 maxlen，老数据自动出队。"""
+        with self._lock:
+            # 老的在前，新的在后：deque.extendleft 是逆序的，所以用普通 extend
+            # 但要先把当前 buffer 内容（更新）挪到后面
+            current = list(self._buffer)
+            self._buffer.clear()
+            for r in recs:
+                self._buffer.append(r)
+            for r in current:
+                self._buffer.append(r)
+
+    def _log_fail(self, msg: str) -> None:
+        """连续失败时只在 transition 上记日志，防日志被刷爆。"""
+        self._fail_count += 1
+        if self._fail_count == 1:
+            logger.warning(msg)
+        elif self._fail_count % 100 == 0:
+            logger.warning(f"{msg} (×{self._fail_count} since last log)")
+
+    # ---- 内部：清理 ----
+
+    def _cleanup(self) -> None:
+        """删 > 7 天的分片；目录总大小超 20MB 时强删最老。
+
+        触发频率：5min 节流（_CLEANUP_MIN_INTERVAL）。即使每 60s flush 也只
+        会真正 listdir 一次/5min，成本可忽略。
+        """
+        try:
+            if not self._dir.exists():
+                return
+            # 列出所有分片，按文件名（天）排序，老的在前
+            cutoff_day = (date.today() - timedelta(days=_RETENTION_DAYS)).strftime("%Y%m%d")
+            entries: list = []
+            for entry in self._dir.iterdir():
+                name = entry.name
+                if not (name.startswith(_FILE_PREFIX) and name.endswith(_FILE_SUFFIX)):
+                    continue
+                day_key = name[len(_FILE_PREFIX): -len(_FILE_SUFFIX)]
+                # 校验是 8 位数字，防误删
+                if len(day_key) != 8 or not day_key.isdigit():
+                    continue
+                try:
+                    size = entry.stat().st_size
+                except OSError:
+                    continue
+                entries.append((day_key, entry, size))
+
+            entries.sort(key=lambda x: x[0])  # 老的在前
+
+            # 第一轮：按 retention 删
+            kept: list = []
+            for day_key, path, size in entries:
+                if day_key < cutoff_day:
+                    try:
+                        path.unlink()
+                        logger.debug(f"event_logger: pruned {path.name} (age > {_RETENTION_DAYS}d)")
+                    except OSError as e:
+                        logger.debug(f"event_logger: failed to prune {path.name}: {e}")
+                        kept.append((day_key, path, size))
+                else:
+                    kept.append((day_key, path, size))
+
+            # 第二轮：目录总 cap，超了从最老开始删
+            total = sum(s for _, _, s in kept)
+            while total > _DIR_SIZE_CAP and kept:
+                day_key, path, size = kept.pop(0)
+                try:
+                    path.unlink()
+                    total -= size
+                    logger.info(
+                        f"event_logger: force-pruned {path.name} (dir size > {_DIR_SIZE_CAP}B)"
+                    )
+                except OSError as e:
+                    logger.debug(f"event_logger: failed to force-prune {path.name}: {e}")
+                    break  # 删不掉也别死循环
+
+            # 清理 sealed_days 里已经过期的天，让重新进入下一周期时可写
+            today_key = date.today().strftime("%Y%m%d")
+            self._sealed_days = {d for d in self._sealed_days if d == today_key}
+
+        except Exception as e:
+            logger.debug(f"event_logger: cleanup error (non-critical): {e}")
+
+
+# ---------------------------------------------------------------------------
+# 便捷模块级函数
+# ---------------------------------------------------------------------------
+
+
+def emit(name: str, **fields) -> None:
+    """记录一个稀疏事件。等价于 EventLogger.get_instance().emit(name, **fields)。"""
+    EventLogger.get_instance().emit(name, **fields)
+
+
+def flush() -> int:
+    """落盘 buffer。由 TokenTracker periodic save 调用，业务代码一般不用。"""
+    return EventLogger.get_instance().flush()

--- a/utils/instrument.py
+++ b/utils/instrument.py
@@ -242,17 +242,35 @@ class Instrument:
 # ---------------------------------------------------------------------------
 
 
+def _esc_dim(s) -> str:
+    r"""转义 metric_key 分隔符（``\`` ``|`` ``,`` ``=``）。
+
+    前端 WS telemetry 接受任意字符串 dim 值，若值里含 ``,`` 或 ``=``，未转义
+    拼接会让不同 dim 组合塌缩成同一 metric_key（如 ``{a:"x,b=y"}`` 与
+    ``{a:"x", b:"y"}`` 都拼成 ``a=x,b=y``），静默混淆 dashboard 切片。反斜杠
+    转义保证单射：不同 (k,v) 集合永远产出不同 key（Codex）。``\`` 先转，
+    避免二次转义把别的转义序列再escape。
+    """
+    return (
+        str(s)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace(",", "\\,")
+        .replace("=", "\\=")
+    )
+
+
 def _make_key(name: str, dims: dict) -> str:
     """把 (name, dims) 拼成一个稳定的 flat key。
 
-    格式：``name`` 或 ``name|k1=v1,k2=v2``（dims 按 key 字典序拼）。
-    没有 dims 时省略 ``|``，保持简单 case 的 key 短。
+    格式：``name`` 或 ``name|k1=v1,k2=v2``（dims 按 key 字典序拼，k/v 都过
+    _esc_dim 转义分隔符）。没有 dims 时省略 ``|``，保持简单 case 的 key 短。
 
     值会用 ``str()`` 转换 —— 调用方有义务只传可序列化的低基数维度。
     """
     if not dims:
         return name
-    parts = [f"{k}={dims[k]}" for k in sorted(dims.keys())]
+    parts = [f"{_esc_dim(k)}={_esc_dim(dims[k])}" for k in sorted(dims.keys())]
     return f"{name}|{','.join(parts)}"
 
 

--- a/utils/instrument.py
+++ b/utils/instrument.py
@@ -193,8 +193,12 @@ class Instrument:
         """取出当前累积值 + 清零 + 返回。由 TokenTracker 上报通道调用。
 
         Returns:
-            dict with keys "window_start", "window_end", "counters",
-            "histograms"，或者空 dict（无任何累积）。
+            dict with keys "window_start", "window_end", "stat_date",
+            "bounds", "counters", "histograms"，或者空 dict（无任何累积）。
+
+            ``stat_date`` 是**客户端本地**日历日（``YYYY-MM-DD``），跟
+            ``daily_stats`` 用同一口径。服务端按它落 SQL 行，避免因为服务端
+            时区不同把跨时区客户端的同一天 usage / instrument 拆到两天。
 
         失败处理：返回的 snapshot 一旦丢给 token_tracker，instrument 内部
         立刻清零。如果上报失败，60s 窗口的 counter / histogram 数据丢失 —
@@ -202,6 +206,7 @@ class Instrument:
         counter / histogram 是聚合数据，丢一个窗口对趋势分析影响小，不值得
         为它再维护一份 unsent 队列。daily_stats（LLM tokens）才需要不丢。
         """
+        from datetime import date as _date  # 局部 import 防进程启动时早调用环
         with self._lock:
             if not self._counters and not self._histograms:
                 # 即使空也更新 window_start，避免下次 snapshot 把空窗口
@@ -223,6 +228,9 @@ class Instrument:
         return {
             "window_start": window_start,
             "window_end": self._window_start,
+            # 客户端本地日历天 —— 服务端必须按这个落 stat_date，否则跨时区
+            # 设备午夜前后上报会把同一天的 usage 和 instrument 拆到两天。
+            "stat_date": _date.today().isoformat(),
             "bounds": list(_HIST_BOUNDS),
             "counters": counters,
             "histograms": hist_out,

--- a/utils/instrument.py
+++ b/utils/instrument.py
@@ -1,0 +1,275 @@
+# -*- coding: utf-8 -*-
+"""
+通用埋点 SDK（counter / histogram / event）
+
+业务侧只需 import 三个函数 —— ``counter`` / ``histogram`` / ``event`` —— 不
+关心 buffering / snapshot / 上报通道。所有数据由 TokenTracker 的 60s
+periodic save 顺手收走，跟 daily_stats 同一条 HTTP 通道、同一个 device_id、
+同一份 HMAC 签名走出去。
+
+数据通道选择（什么用什么）：
+
+================= ================================ ============================
+通道              何时用                            后端展现
+================= ================================ ============================
+counter           累加型计数：消息条数 / 点击次数  汇总成"周期内总数 + 维度切片"
+histogram         分布型测量：延迟 / FPS / size    桶分布 + count + sum
+event             稀疏带 context：crash / step     原样存事件流（events.jsonl）
+================= ================================ ============================
+
+何时**不要**用：
+- 不要每次 mouse move / scroll 都 counter()。挑有意义的事件（消息发出、按
+  钮按下、功能首次使用），不然就是 noise。
+- 不要把消息内容 / persona text / master_name 放进 fields。维度只能是 enum
+  类标签（surface、feature_name、error_class 等）。
+
+开销：
+- counter / histogram：进程内 lock + dict op，~300ns / 次
+- event：转交 event_logger，纳秒级 deque.append
+- snapshot：每 60s 一次，clear-on-read，无累积
+"""
+from __future__ import annotations
+
+import bisect
+import threading
+import time
+from typing import Optional
+
+from utils.event_logger import emit as _event_emit
+from utils.logger_config import get_module_logger
+
+logger = get_module_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 配置常量
+# ---------------------------------------------------------------------------
+
+# Histogram 桶边界（毫秒/数值通用）。覆盖 1ms~10s 主要分布范围；超出最右边
+# 界的样本进溢出桶。固定桶让服务端 schema 稳定，跨版本对比直接做。
+#
+# 选这组边界的理由：
+# - 1/2/5/10/... 的"1-2-5 序列"是 logarithmic 但保留整数可读
+# - 覆盖 TTFT (~100-2000ms)、FPS 倒数 (~16ms)、startup time (~1-30s) 主要范围
+# - 9 个边界 = 10 个桶，序列化后 ~40B/histogram，便宜
+_HIST_BOUNDS: tuple = (1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000)
+_HIST_NUM_BUCKETS = len(_HIST_BOUNDS) + 1  # 最右边界右侧多一个溢出桶
+
+# Counter / histogram 内存上限。理论上 key 是 (name, dims tuple)，不该爆，
+# 但万一业务把高基数维度（如 user_id / 消息内容）塞进 dims，要兜底防内存
+# 泄漏。超过此值丢弃新 key（保留已有的累积值），并打一次 warning。
+_MAX_COUNTER_KEYS = 5000
+_MAX_HISTOGRAM_KEYS = 1000
+
+
+# ---------------------------------------------------------------------------
+# Instrument 单例
+# ---------------------------------------------------------------------------
+
+
+class Instrument:
+    """进程内单例的 counter + histogram 累积器。
+
+    snapshot() 由 TokenTracker.save 顺手在 60s 周期里调用。业务代码用模块
+    级 ``counter`` / ``histogram`` / ``event`` 即可，不直接动这个类。
+    """
+
+    _instance: Optional["Instrument"] = None
+    _init_lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "Instrument":
+        if cls._instance is None:
+            with cls._init_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # key 是 string："name|k1=v1,k2=v2"（dims 已经按 key 字典序拼好）。
+        # value 是数字。flat dict 比嵌套 dict-of-dict 序列化更友好，服务端
+        # 也更容易索引。
+        self._counters: dict = {}
+        # 同样的 key 结构，value 是 [count, sum, [bucket_counts...]]
+        self._histograms: dict = {}
+        # snapshot 窗口起点（每次 snapshot 重置）
+        self._window_start: float = time.time()
+        # 高基数告警节流
+        self._cap_warned_counter: bool = False
+        self._cap_warned_histogram: bool = False
+
+    # ---- 公开 API ----
+
+    def counter(self, name: str, value: int = 1, **dims) -> None:
+        """累加一个计数器。
+
+        Args:
+            name: 指标名（snake_case，e.g. "user_message_sent"）
+            value: 增量，默认 1。允许负数（减），但通常用不上。
+            **dims: 维度标签。值必须是 string / int / bool 等可哈希简单类型。
+                不要传消息内容、user_id 之类的高基数值。
+
+        Example:
+            counter("user_message_sent", 1, surface="pet_widget")
+            counter("feature_invoked", 1, feature="galgame", first_use=True)
+        """
+        if not name or not isinstance(value, (int, float)):
+            return
+        key = _make_key(name, dims)
+        with self._lock:
+            if key in self._counters:
+                self._counters[key] += value
+            elif len(self._counters) < _MAX_COUNTER_KEYS:
+                self._counters[key] = value
+            else:
+                # 容量保护：满了就静默丢，避免业务方误用高基数维度炸内存
+                if not self._cap_warned_counter:
+                    logger.warning(
+                        f"instrument: counter map full ({_MAX_COUNTER_KEYS} keys), "
+                        f"dropping new keys. Check if any dim has high cardinality."
+                    )
+                    self._cap_warned_counter = True
+
+    def histogram(self, name: str, value: float, **dims) -> None:
+        """记录一个分布型测量。
+
+        Args:
+            name: 指标名（snake_case，e.g. "ttft_ms"、"live2d_fps"）
+            value: 测量值（数字）。会被分桶到 _HIST_BOUNDS 对应的 bucket。
+            **dims: 同 counter，维度标签必须是低基数。
+
+        Example:
+            histogram("ttft_ms", 234)
+            histogram("live2d_fps", 58.5, surface="pet_widget")
+        """
+        if not name or not isinstance(value, (int, float)):
+            return
+        # bisect_left：value <= bound 落到该桶；超过最右边界进溢出桶
+        bucket_idx = bisect.bisect_left(_HIST_BOUNDS, value)
+        key = _make_key(name, dims)
+        with self._lock:
+            entry = self._histograms.get(key)
+            if entry is None:
+                if len(self._histograms) >= _MAX_HISTOGRAM_KEYS:
+                    if not self._cap_warned_histogram:
+                        logger.warning(
+                            f"instrument: histogram map full ({_MAX_HISTOGRAM_KEYS} keys), "
+                            f"dropping new keys. Check if any dim has high cardinality."
+                        )
+                        self._cap_warned_histogram = True
+                    return
+                entry = [0, 0.0, [0] * _HIST_NUM_BUCKETS]
+                self._histograms[key] = entry
+            entry[0] += 1
+            entry[1] += value
+            entry[2][bucket_idx] += 1
+
+    def event(self, name: str, **fields) -> None:
+        """记录一个稀疏带 context 事件（直接转 event_logger）。
+
+        与 counter 的区别：event 是离散事件流（"在 ts=X 发生了 name"），
+        会被一条条原样保留；counter 是聚合数字（"窗口内 name 发生了 N 次"）。
+
+        Example:
+            event("crash", traceback_hash="a3f8", module="agent_router")
+            event("onboarding_step", step="persona_selected", duration_ms=1500)
+        """
+        _event_emit(name, **fields)
+
+    # ---- snapshot ----
+
+    def has_data(self) -> bool:
+        """是否有累积数据等着 snapshot。给上报通道在决定是否发请求时 peek 用。
+
+        TokenTracker 在 daily_stats 为空时本来会跳过上报，但 instrument 自己
+        可能有 counter/histogram 等着发；这个方法让上报通道在不消费数据的
+        前提下判断"是否值得发一次请求"。
+        """
+        with self._lock:
+            return bool(self._counters or self._histograms)
+
+    def snapshot(self) -> dict:
+        """取出当前累积值 + 清零 + 返回。由 TokenTracker 上报通道调用。
+
+        Returns:
+            dict with keys "window_start", "window_end", "counters",
+            "histograms"，或者空 dict（无任何累积）。
+
+        失败处理：返回的 snapshot 一旦丢给 token_tracker，instrument 内部
+        立刻清零。如果上报失败，60s 窗口的 counter / histogram 数据丢失 —
+        这是设计取舍：sparse_event 走 event_logger 有本地 jsonl 兜底，
+        counter / histogram 是聚合数据，丢一个窗口对趋势分析影响小，不值得
+        为它再维护一份 unsent 队列。daily_stats（LLM tokens）才需要不丢。
+        """
+        with self._lock:
+            if not self._counters and not self._histograms:
+                # 即使空也更新 window_start，避免下次 snapshot 把空窗口
+                # 一直挂着 —— 否则前 30 min 没埋点活动、第 31 min 有一条，
+                # 上报的 window 会显示 31min 而不是 1min。
+                self._window_start = time.time()
+                return {}
+            counters = self._counters
+            histograms = self._histograms
+            window_start = self._window_start
+            self._counters = {}
+            self._histograms = {}
+            self._window_start = time.time()
+            # warning 标志保留 —— 反复打日志比反复 warn 更烦
+        # 序列化在锁外，让 emit() 不被阻塞
+        hist_out = {}
+        for k, v in histograms.items():
+            hist_out[k] = {"count": v[0], "sum": v[1], "buckets": list(v[2])}
+        return {
+            "window_start": window_start,
+            "window_end": self._window_start,
+            "bounds": list(_HIST_BOUNDS),
+            "counters": counters,
+            "histograms": hist_out,
+        }
+
+
+# ---------------------------------------------------------------------------
+# 辅助：key 序列化
+# ---------------------------------------------------------------------------
+
+
+def _make_key(name: str, dims: dict) -> str:
+    """把 (name, dims) 拼成一个稳定的 flat key。
+
+    格式：``name`` 或 ``name|k1=v1,k2=v2``（dims 按 key 字典序拼）。
+    没有 dims 时省略 ``|``，保持简单 case 的 key 短。
+
+    值会用 ``str()`` 转换 —— 调用方有义务只传可序列化的低基数维度。
+    """
+    if not dims:
+        return name
+    parts = [f"{k}={dims[k]}" for k in sorted(dims.keys())]
+    return f"{name}|{','.join(parts)}"
+
+
+# ---------------------------------------------------------------------------
+# 模块级便捷函数（业务侧首选入口）
+# ---------------------------------------------------------------------------
+
+
+def counter(name: str, value: int = 1, **dims) -> None:
+    Instrument.get_instance().counter(name, value, **dims)
+
+
+def histogram(name: str, value: float, **dims) -> None:
+    Instrument.get_instance().histogram(name, value, **dims)
+
+
+def event(name: str, **fields) -> None:
+    Instrument.get_instance().event(name, **fields)
+
+
+def snapshot() -> dict:
+    """供 TokenTracker 调用，业务代码一般不用。"""
+    return Instrument.get_instance().snapshot()
+
+
+def has_data() -> bool:
+    """供 TokenTracker peek 用，业务代码一般不用。"""
+    return Instrument.get_instance().has_data()

--- a/utils/instrument.py
+++ b/utils/instrument.py
@@ -267,11 +267,15 @@ def _make_key(name: str, dims: dict) -> str:
     _esc_dim 转义分隔符）。没有 dims 时省略 ``|``，保持简单 case 的 key 短。
 
     值会用 ``str()`` 转换 —— 调用方有义务只传可序列化的低基数维度。
+
+    name 也要 _esc_dim 转义：untrusted WS 客户端能发含 ``|`` ``,`` ``=`` 的
+    name（如 ``foo|a=1``）跟合法的 ``name=foo,dims={a:1}`` 碰撞，静默混淆
+    counter/histogram（Codex）。合法 name（snake_case）无分隔符，转义是 no-op。
     """
     if not dims:
-        return name
+        return _esc_dim(name)
     parts = [f"{_esc_dim(k)}={_esc_dim(dims[k])}" for k in sorted(dims.keys())]
-    return f"{name}|{','.join(parts)}"
+    return f"{_esc_dim(name)}|{','.join(parts)}"
 
 
 # ---------------------------------------------------------------------------

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -459,9 +459,17 @@ def save_global_conversation_settings(settings: Dict[str, Any]) -> bool:
             data.append(global_pref)
 
         atomic_write_json(PREFERENCES_FILE, data, ensure_ascii=False, indent=2)
+        # 设置变更后打一个 settings_state telemetry 快照（变更后的新值）。
+        # lazy import 防 token_tracker ↔ preferences 循环依赖。埋点失败不能
+        # 影响 save 的成功返回。
+        try:
+            from utils.token_tracker import record_settings_state
+            record_settings_state()
+        except Exception:
+            pass
         return True
     except MaintenanceModeError:
         raise
     except Exception as e:
         print(f"保存全局对话设置失败: {e}")
-        return False 
+        return False

--- a/utils/preferences.py
+++ b/utils/preferences.py
@@ -459,14 +459,12 @@ def save_global_conversation_settings(settings: Dict[str, Any]) -> bool:
             data.append(global_pref)
 
         atomic_write_json(PREFERENCES_FILE, data, ensure_ascii=False, indent=2)
-        # 设置变更后打一个 settings_state telemetry 快照（变更后的新值）。
-        # lazy import 防 token_tracker ↔ preferences 循环依赖。埋点失败不能
-        # 影响 save 的成功返回。
-        try:
-            from utils.token_tracker import record_settings_state
-            record_settings_state()
-        except Exception:
-            pass
+        # 注意：settings_state telemetry **不**在这里打。instrument_counters 按
+        # (stat_date, device_id, metric_key) 累加 UPSERT，若每次 save 都打点，
+        # 同一设备一天内切几次设置就会给多个 settings_state|... key 各 +1，
+        # dashboard 看到的是"观测次数"而非"用户当前/惯用设置"（CodeRabbit 指出）。
+        # 改为只在 record_app_start 打一次启动快照——"用户本次启动时的设置"，
+        # 跨多次启动按 device 看 mode 即可反推惯用档，语义干净得多。
         return True
     except MaintenanceModeError:
         raise

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -1256,6 +1256,9 @@ class TokenTracker:
             if self._pending_batch_seq is None:
                 self._pending_batch_seq = secrets.token_hex(8)
             batch_seq = self._pending_batch_seq
+        # 标记这次发送是否带 daily/records —— instrument-only 失败后清
+        # stale batch_seq 时要用（见 except 路径注释）。
+        had_unsent_payload = bool(send_daily or send_records)
 
         # 现在确定要发，clear-on-read 拿 instrument snapshot。如果上报失败，
         # 这部分数据丢失（设计取舍：counter / histogram 是窗口聚合，丢一个
@@ -1367,9 +1370,15 @@ class TokenTracker:
 
         except Exception as e:
             logger.debug(f"Token tracker: telemetry report failed (non-critical): {e}")
-            # 发送失败：放回 unsent + 持久化。**不清** _pending_batch_seq ——
-            # 下次重试用同一 seq，让 server seen_batches dedupe "网络 timeout
-            # 但 server 已经 commit" 的不确定成败重传。
+            # 发送失败：放回 unsent + 持久化。daily-bearing 失败时**不清**
+            # _pending_batch_seq —— 下次重试用同一 seq，让 server seen_batches
+            # dedupe "网络 timeout 但 server 已经 commit" 的不确定成败重传。
+            #
+            # 但 instrument-only 失败（send_daily 和 send_records 都空，
+            # had_unsent_payload=False）必须清 batch_seq：instruments 是
+            # clear-on-read 没东西放回，留着 stale seq 会让**下一个新窗口**
+            # 复用它算出与已 commit 的 batch_id 相同的 hash，server 直接
+            # 返回 "duplicate, skipped"，新窗口的数据被静默丢弃。
             with self._lock:
                 for day_key, day_delta in send_daily.items():
                     if day_key not in self._unsent_daily:
@@ -1378,6 +1387,9 @@ class TokenTracker:
                         _merge_day_stats(self._unsent_daily[day_key], day_delta)
                 restored = send_records + self._unsent_records
                 self._unsent_records = restored[-200:]
+                if not had_unsent_payload:
+                    # 没有真要重传的内容 —— 防 stale seq 误伤下一窗口
+                    self._pending_batch_seq = None
             self._save_unsent_queue()
 
     @staticmethod

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -1461,12 +1461,18 @@ class TokenTracker:
             # （含进程 kill 后重启）保留同一 seq，成功 200 后清空。把 seq 放进
             # hash，daily / records / instruments 自己不需要进 hash —— 尤其
             # instruments 是 clear-on-read、不会在重传中复现，把它进 hash 反而
-            # 破坏 (a)。device_id_legacy 也不进：它依赖 uuid.getnode()，多网卡
-            # 机器枚举顺序不稳定，进 hash 会让重传变成新 batch 被累加。
-            # 签名 (HMAC) 仍覆盖完整 payload。
+            # 破坏 (a)。
+            #
+            # batch_core **只用 retry-stable 字段**：device_id + batch_seq。
+            # app_version 故意不进 —— 它在每次上报时实时读 changelog，重试之间
+            # 若用户更新了 app，同一份 unsent batch 会算出不同 batch_id；
+            # timeout-after-commit 后在新版本上重启重传就绕过 seen_batches、
+            # 把已 commit 的 daily_stats 重复计（Codex P1）。device_id_legacy
+            # 同理也不进（依赖 uuid.getnode()，多网卡枚举顺序不稳）。
+            # batch_seq 已是 per-window 唯一 + 跨重试稳定，device_id 保证跨设备
+            # 不撞，二者足够。签名 (HMAC) 仍覆盖完整 payload（含 app_version）。
             batch_core = {
                 "device_id": payload["device_id"],
-                "app_version": payload["app_version"],
                 "batch_seq": batch_seq,
             }
             batch_id = hashlib.sha256(

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -1416,7 +1416,23 @@ class TokenTracker:
     async def _periodic_save_loop(self):
         while True:
             await asyncio.sleep(self._save_interval)
-            if self._dirty:
+            # 两种触发 save() 的条件：
+            #   (a) self._dirty —— 有 LLM token delta 要本地写盘 + 远程上报
+            #   (b) instrument has_data —— 纯前端互动（前端 ws telemetry /
+            #       ws_connect / 各种 feature counter）不会让 _dirty=True，
+            #       但 instrument 已经累积了一窗口需要 60s 节奏上报
+            # save() 内部对 (b) 走 report-only path（跳过本地 write，只调
+            # _report_to_server）；对 (a) 走完整 write + report。
+            need_save = self._dirty
+            if not need_save:
+                try:
+                    from utils.instrument import has_data as _instrument_has_data
+                    need_save = _instrument_has_data()
+                except Exception:
+                    # has_data 在锁内只做 dict bool 检查，正常不会抛；
+                    # import 失败 fall through，本轮跳过，下轮重试。
+                    pass
+            if need_save:
                 await asyncio.to_thread(self.save)
             # 顺手让 event_logger 落地稀疏事件 buffer + 跑 retention 清理。
             # 即使本周期 token_tracker 没有 dirty，event_logger 也可能有

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -22,6 +22,7 @@ import atexit
 import asyncio
 import copy
 import functools
+import gzip
 import hashlib
 import hmac
 import json
@@ -193,6 +194,12 @@ _TELEMETRY_REPORT_INTERVAL = 60
 
 # 上报超时
 _TELEMETRY_TIMEOUT = 10  # 秒
+
+# Gzip 上报阈值：< 1KB 的 payload 不压缩。gzip 头 + CRC 有 ~20B 固定开销，
+# 小 payload 压缩比往往 < 2x，不值得。典型 daily_stats payload 5-50KB raw，
+# gzip 后通常压到 1/5-1/10。服务端 v2 起支持 Content-Encoding: gzip；老服
+# 务端不解析就直接 415，故首次发布要 server 先升级再开客户端 gzip。
+_TELEMETRY_GZIP_THRESHOLD = 1024
 
 
 def _get_app_version_from_changelog() -> str:
@@ -697,6 +704,8 @@ class TokenTracker:
         self._unsent_daily: dict = {}  # 尚未成功上报到服务器的增量
         self._unsent_records: list = []
         self._has_recorded_app_start: bool = False  # 🔒 app_start 单次上报锁
+        self._session_start_ts: float = 0.0  # session_end 计算 duration 用
+        self._session_process: str = "unknown"
 
         # 首次启动：迁移旧版 per-instance 文件
         self._migrate_legacy_files()
@@ -744,6 +753,34 @@ class TokenTracker:
             # (best-effort final push). Then disable remote URL so no further
             # network calls happen during interpreter teardown.
             self.save()
+        except Exception:
+            pass
+        # 在 flush 之前把 session_end 落进 buffer。同步 counter + histogram
+        # 走远程聚合：counter 用于"启动了多少次 / 结束了多少次"配对（差值 =
+        # 异常退出数），histogram 用于 session_duration 分布看用户停留时长。
+        try:
+            from utils.instrument import (
+                event as _instr_event,
+                counter as _instr_counter,
+                histogram as _instr_histogram,
+            )
+            duration = (time.time() - self._session_start_ts) if self._session_start_ts > 0 else 0.0
+            _instr_event(
+                "session_end",
+                process=self._session_process,
+                duration_sec=round(duration, 1),
+            )
+            _instr_counter("session_end", process=self._session_process)
+            if duration > 0:
+                # 直接传秒；instrument bounds 是数字通用，没绑定单位
+                _instr_histogram("session_duration_sec", duration, process=self._session_process)
+        except Exception:
+            pass
+        # 顺手 flush 稀疏事件 —— 这里如果丢，下次启动就没法恢复（event_logger
+        # 没有自己的 unsent queue），所以哪怕 save() 失败也单独尝试。
+        try:
+            from utils.event_logger import EventLogger
+            EventLogger.get_instance().flush()
         except Exception:
             pass
         finally:
@@ -996,16 +1033,32 @@ class TokenTracker:
 
         return {"date": today, "stats": merged}
 
-    def record_app_start(self):
+    def record_app_start(self, process: str = "main_server"):
         """记录客户端启动事件（app_start）。
 
         用于统计 DAU，与 LLM 调用分开计数。
         保证在单次进程生命周期内只上报一次（线程安全）。
+
+        除了沿用老的 ``record(call_type='app_start')`` 路径（dashboard 的
+        by_call_type 还在用），同时打一个 instrument 事件 ``session_start``，
+        以及把启动时刻塞进 self 让 _atexit_save 能算 session_end 的 duration。
         """
         with self._lock:
             if self._has_recorded_app_start:
                 return
             self._has_recorded_app_start = True
+            self._session_start_ts = time.time()
+            self._session_process = process
+
+        # 新埋点：sparse event 走本地 events.jsonl（诊断），同时打 counter
+        # 走远程聚合通道（dashboard 看 DAU / session 总数）。event 因为带
+        # context 字段、暂未集成进远程上报；counter 是聚合数字、走 60s 通道。
+        try:
+            from utils.instrument import event as _instr_event, counter as _instr_counter
+            _instr_event("session_start", process=process)
+            _instr_counter("session_start", process=process)
+        except Exception:
+            pass
 
         self.record(
             model="app_start",
@@ -1121,14 +1174,32 @@ class TokenTracker:
         if now - self._last_report_time < self._report_interval:
             return
 
+        # peek instrument 累积 —— 即使 daily_stats 是空的（用户没触发 LLM 调
+        # 用，但有前端互动 counter），只要 instrument 里有东西，就值得发一次。
+        try:
+            from utils.instrument import has_data as _instrument_has_data
+            has_instruments = _instrument_has_data()
+        except Exception:
+            has_instruments = False
+
         # 取出待发送数据
         with self._lock:
-            if not self._unsent_daily:
+            if not self._unsent_daily and not has_instruments:
                 return
             send_daily = self._unsent_daily
             send_records = self._unsent_records
             self._unsent_daily = {}
             self._unsent_records = []
+
+        # 现在确定要发，clear-on-read 拿 instrument snapshot。如果上报失败，
+        # 这部分数据丢失（设计取舍：counter / histogram 是窗口聚合，丢一个
+        # 60s 窗口对趋势影响小，不值得维护 unsent 队列）。
+        instruments_snapshot: dict = {}
+        try:
+            from utils.instrument import snapshot as _instrument_snapshot
+            instruments_snapshot = _instrument_snapshot()
+        except Exception as e:
+            logger.debug(f"Token tracker: instrument snapshot failed (non-critical): {e}")
 
         try:
             if not self._device_id:
@@ -1161,6 +1232,11 @@ class TokenTracker:
                 "daily_stats": send_daily,
                 "recent_records": send_records,
             }
+            # instrument snapshot 走 optional 字段：老 server 不识别会 ignore，
+            # 新 server 原样存进 events.payload，dashboard 端可后续解析。HMAC
+            # 签名覆盖整个 payload dict，所以加字段不影响验签。
+            if instruments_snapshot:
+                payload["instruments"] = instruments_snapshot
             payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
 
             ts = time.time()
@@ -1187,11 +1263,19 @@ class TokenTracker:
                 "batch_id": batch_id,
             }
             body = json.dumps(submission, ensure_ascii=False).encode("utf-8")
+            headers = {"Content-Type": "application/json"}
+
+            # >= 1KB 才 gzip：小 payload 不划算（见 _TELEMETRY_GZIP_THRESHOLD 注释）。
+            # mtime=0 让同一 body 总是产出相同压缩字节，便于 diff 调试和 fuzzing
+            # 期不会因为时间戳差异看起来像两次上报。
+            if len(body) >= _TELEMETRY_GZIP_THRESHOLD:
+                body = gzip.compress(body, compresslevel=6, mtime=0)
+                headers["Content-Encoding"] = "gzip"
 
             req = urllib.request.Request(
                 f"{_TELEMETRY_SERVER_URL}/api/v1/telemetry",
                 data=body,
-                headers={"Content-Type": "application/json"},
+                headers=headers,
                 method="POST",
             )
             with urllib.request.urlopen(req, timeout=_TELEMETRY_TIMEOUT) as resp:
@@ -1243,6 +1327,17 @@ class TokenTracker:
             await asyncio.sleep(self._save_interval)
             if self._dirty:
                 await asyncio.to_thread(self.save)
+            # 顺手让 event_logger 落地稀疏事件 buffer + 跑 retention 清理。
+            # 即使本周期 token_tracker 没有 dirty，event_logger 也可能有
+            # session/crash 之类的事件等着写 —— 不挂在 self._dirty 后面，避免
+            # 纯前端互动（不触发 LLM 调用）的事件被一直憋在内存里。
+            # event_logger.flush 自带节流（cleanup 5min 一次），nothing-to-do
+            # 路径 ~微秒级。
+            try:
+                from utils.event_logger import EventLogger
+                await asyncio.to_thread(EventLogger.get_instance().flush)
+            except Exception as e:
+                logger.debug(f"Token tracker: event_logger flush failed (non-critical): {e}")
 
     # ---- helpers ----
 
@@ -1465,11 +1560,61 @@ def _add_to_blocklist(base_url: str):
         logger.info(f"Token tracker: added base_url to stream_options blocklist: {base_url[:60]}...")
 
 
+def _install_crash_excepthook():
+    """注入全局 sys.excepthook，把 unhandled exception 打成 crash 事件。
+
+    用 chain 模式：保留原 hook（系统默认会把 traceback 打到 stderr），自己
+    只在最前面加一层 telemetry 上报。这样不破坏现有的 logging / 错误显示
+    逻辑，只是顺便记一笔。
+
+    幂等：install 多次只生效一次（避免 main_server / memory_server 都 import
+    时多套 chain 套娃）。
+    """
+    import sys
+    if getattr(sys, "_neko_crash_hook_installed", False):
+        return
+    _orig_excepthook = sys.excepthook
+
+    def _crash_excepthook(exc_type, exc_value, exc_tb):
+        try:
+            # KeyboardInterrupt 是用户主动 ctrl-c，不算 crash
+            if not issubclass(exc_type, KeyboardInterrupt):
+                import traceback as _tb
+                import hashlib as _hl
+                from utils.instrument import event as _e, counter as _c
+                tb_text = "".join(_tb.format_exception(exc_type, exc_value, exc_tb))
+                # traceback_hash 是 12 字符摘要：足以 dedupe 同源 crash，不
+                # 反向还原 stack（隐私）。dashboard 看哪个 hash 最频繁即可。
+                tb_hash = _hl.sha256(tb_text.encode("utf-8", errors="replace")).hexdigest()[:12]
+                _e("crash", error_class=exc_type.__name__, traceback_hash=tb_hash)
+                _c("crash", error_class=exc_type.__name__)
+                # 强制 flush event_logger —— 进程接下来可能立刻 die，不 flush
+                # 就丢了。flush 自身有 try/except 不会再抛。
+                from utils.event_logger import EventLogger
+                EventLogger.get_instance().flush()
+        except Exception:
+            pass
+        # 让默认 hook 继续打 stack —— 不打断现有行为
+        try:
+            _orig_excepthook(exc_type, exc_value, exc_tb)
+        except Exception:
+            pass
+
+    sys.excepthook = _crash_excepthook
+    sys._neko_crash_hook_installed = True
+    logger.info("Token tracker: crash excepthook installed")
+
+
 def install_hooks():
     """
     安装 OpenAI SDK monkey-patch，自动追踪所有 chat.completions.create 调用的 token 用量。
     同时覆盖 LangChain 底层调用（因为 LangChain ChatOpenAI 底层调用 OpenAI SDK）。
+
+    顺便：装 sys.excepthook 抓 unhandled exception 打 crash 事件。
     """
+    # crash hook 跟 openai 库无关，独立装；幂等。
+    _install_crash_excepthook()
+
     try:
         from openai.resources.chat.completions import Completions, AsyncCompletions
     except ImportError:

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -686,9 +686,18 @@ def _bucket_proactive_interval(seconds) -> str:
 def record_settings_state() -> None:
     """读当前主动搭话 / 隐私模式设置，打一个 settings_state counter。
 
-    触发时机：
-    - app 启动（record_app_start，仅 main_server 进程）
-    - 用户改设置（preferences.save_global_conversation_settings 成功后）
+    触发时机：**仅** app 启动（record_app_start，仅 main_server 进程）。
+
+    语义说明（CodeRabbit 反馈后定型）：server 端 instrument_counters 按
+    (stat_date, device_id, metric_key) 累加 UPSERT。本函数只在启动打点，
+    所以一条记录 = "用户本次启动时的设置组合"。每天每设备启动几次就 +几，
+    是**观测次数**而非 gauge 式"当前最终状态"——但对"深度用户惯用什么档"
+    的分析够用：按 device 取计数最高的 combo 即其惯用档。
+
+    刻意**不**在 save_global_conversation_settings 里打点：那样用户一天内
+    每切一次设置就给一个新 combo +1，把分布污染成"切换轨迹"。要精确的
+    per-device-per-day 最终状态需要 server 端 gauge/overwrite 语义，当前
+    instrument 管道不支持，且对本分析非必要。
 
     用途：server 端按 device 活跃天数 / event_count 切出深度用户，再看他们
     settings_state 各 dim 组合的分布 —— 即"深度用户把主动搭话 / 隐私模式
@@ -1232,6 +1241,8 @@ class TokenTracker:
             from utils.instrument import counter as _c
             _c("core_loop_completed")
         except Exception:
+            # 埋点 best-effort；前面已置位 _core_loop_recorded，丢一次计数
+            # 不影响幂等，也不该影响调用方（音频投递路径）。
             pass
 
     # ---- 持久化 ----

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -834,6 +834,9 @@ class TokenTracker:
         session_start 看得见、session_end 永远缺失，dashboard 上"异常退出
         率"会被误算成 100%。event 单独通过 event_logger.flush 走本地 jsonl。
         """
+        # global 声明提到函数开头：下面 3b 步骤会读 _TELEMETRY_SERVER_URL，
+        # Python 要求 global 声明先于任何使用（否则 SyntaxError）。
+        global _TELEMETRY_SERVER_URL
         # ── 1) session_end 先落 instrument buffer，让随后的 save() 带上 ──
         try:
             from utils.instrument import (
@@ -877,6 +880,23 @@ class TokenTracker:
             # 下次进程启动会重传。
             pass
 
+        # ── 3b) 若第一次 save 是「重传」（进程带着早先失败遗留的 _pending_batch_seq），
+        # _report_to_server 会按 is_retry 跳过 instrument snapshot，刚 emit 的
+        # session_end / session_duration_sec 仍留在 buffer。常见"网络早先挂、
+        # 退出前恢复"场景下重传会成功并清掉 batch_seq，但没有第二次发送，
+        # session 指标就在关 URL 前静默丢了（Codex）。所以这里检查：instrument
+        # 还有数据 + batch_seq 已清（说明重传成功、下次是 fresh 窗口会 snapshot）
+        # → 再 bypass throttle 发一次。
+        try:
+            from utils.instrument import has_data as _instrument_has_data
+            if (_instrument_has_data() and self._pending_batch_seq is None
+                    and _TELEMETRY_SERVER_URL and not _DO_NOT_TRACK):
+                with self._lock:
+                    self._last_report_time = 0.0
+                self.save()
+        except Exception:
+            pass
+
         # ── 4) flush event_logger —— event 不走远程 instrument 通道，本地 jsonl 兜底 ──
         try:
             from utils.event_logger import EventLogger
@@ -887,7 +907,6 @@ class TokenTracker:
             # 发出去了，这里失败影响的只是诊断细节，不阻塞 atexit。
             pass
         finally:
-            global _TELEMETRY_SERVER_URL
             _TELEMETRY_SERVER_URL = ""
 
     def _load_unsent_queue(self):

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -1243,9 +1243,14 @@ class TokenTracker:
         except Exception:
             has_instruments = False
 
-        # 取出待发送数据。同时分配/复用 batch_seq —— 失败重传保留同一 seq
-        # 才能让 server seen_batches dedupe；新窗口（_pending_batch_seq=None）
-        # 才分配新值，保证不同窗口 batch_id 不会相撞。
+        # 取出待发送数据。同时区分两种状态：
+        #   is_retry=False：新窗口，分配新 batch_seq，正常带 instrument snapshot
+        #   is_retry=True ：上次失败遗留下来的重传，复用同一 batch_seq，**不**
+        #                   附带任何新 instrument —— retry 的 batch_id 已经
+        #                   在 server seen_batches 里，整个 batch 会被 dedupe
+        #                   返回 duplicate，跟进去的 instrument 会被一起静默
+        #                   丢掉。把新 instrument 留在 buffer，下个新窗口
+        #                   （新 batch_seq）单独发出去。
         with self._lock:
             if not self._unsent_daily and not has_instruments:
                 return
@@ -1253,6 +1258,7 @@ class TokenTracker:
             send_records = self._unsent_records
             self._unsent_daily = {}
             self._unsent_records = []
+            is_retry = self._pending_batch_seq is not None
             if self._pending_batch_seq is None:
                 self._pending_batch_seq = secrets.token_hex(8)
             batch_seq = self._pending_batch_seq
@@ -1260,15 +1266,14 @@ class TokenTracker:
         # stale batch_seq 时要用（见 except 路径注释）。
         had_unsent_payload = bool(send_daily or send_records)
 
-        # 现在确定要发，clear-on-read 拿 instrument snapshot。如果上报失败，
-        # 这部分数据丢失（设计取舍：counter / histogram 是窗口聚合，丢一个
-        # 60s 窗口对趋势影响小，不值得维护 unsent 队列）。
+        # 仅新窗口才 snapshot instrument。重传时跳过保留 buffer 等下窗口。
         instruments_snapshot: dict = {}
-        try:
-            from utils.instrument import snapshot as _instrument_snapshot
-            instruments_snapshot = _instrument_snapshot()
-        except Exception as e:
-            logger.debug(f"Token tracker: instrument snapshot failed (non-critical): {e}")
+        if not is_retry:
+            try:
+                from utils.instrument import snapshot as _instrument_snapshot
+                instruments_snapshot = _instrument_snapshot()
+            except Exception as e:
+                logger.debug(f"Token tracker: instrument snapshot failed (non-critical): {e}")
 
         try:
             if not self._device_id:

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -703,6 +703,11 @@ class TokenTracker:
         self._report_interval = _TELEMETRY_REPORT_INTERVAL
         self._unsent_daily: dict = {}  # 尚未成功上报到服务器的增量
         self._unsent_records: list = []
+        # batch_seq：当前正在上报或重传中的窗口标识。新窗口首次进入 _report_to_server
+        # 时分配一次（secrets.token_hex），失败重传时保留同一个值，让 server
+        # seen_batches 能 dedupe "网络 timeout 但 server 已经 commit" 的重传。
+        # 成功 200 后清空，下次窗口再分配新 seq。跟 _unsent_daily 一起持久化。
+        self._pending_batch_seq: Optional[str] = None
         self._has_recorded_app_start: bool = False  # 🔒 app_start 单次上报锁
         self._session_start_ts: float = 0.0  # session_end 计算 duration 用
         self._session_process: str = "unknown"
@@ -773,22 +778,39 @@ class TokenTracker:
                 # 直接传秒；instrument bounds 是数字通用，没绑定单位
                 _instr_histogram("session_duration_sec", duration, process=self._session_process)
         except Exception:
+            # instrument import / emit 失败不能让进程退出卡住 —— 实在丢一条
+            # 也比 atexit 抛出强（atexit 异常会让 SIGTERM 退出码变化）。
             pass
 
-        # ── 2) save() 把 daily_stats + 上面刚 emit 的 instrument snapshot 一起发 ──
+        # ── 2) Bypass 60s throttle —— atexit 是最后机会，错过没下次 ──
+        # _report_to_server 内部 ``now - self._last_report_time < interval``
+        # 在短 session（启动后不到 60s 就退出）下会阻止上报，让刚 emit 的
+        # session_end counter / histogram 永远留在 instrument buffer。这里
+        # 显式归零让那条 if 一定不命中。会带来一个理论副作用：如果 atexit
+        # 之前距上次成功上报 < 60s，这次再发一份；server seen_batches 靠
+        # batch_seq dedupe，所以不会双倍计数。
+        with self._lock:
+            self._last_report_time = 0.0
+
+        # ── 3) save() 把 daily_stats + 上面刚 emit 的 instrument snapshot 一起发 ──
         try:
             # save() first: persists delta to disk and attempts remote report
             # (best-effort final push). Then disable remote URL so no further
             # network calls happen during interpreter teardown.
             self.save()
         except Exception:
+            # save 失败不抛进 atexit（同上）。失败时 unsent 已经被持久化，
+            # 下次进程启动会重传。
             pass
 
-        # ── 3) flush event_logger —— event 不走远程 instrument 通道，本地 jsonl 兜底 ──
+        # ── 4) flush event_logger —— event 不走远程 instrument 通道，本地 jsonl 兜底 ──
         try:
             from utils.event_logger import EventLogger
             EventLogger.get_instance().flush()
         except Exception:
+            # event_logger flush 失败丢的是本地 jsonl 的稀疏事件，下次启动
+            # 没有恢复路径 —— 但 counter/histogram 已经走 instrument 通道
+            # 发出去了，这里失败影响的只是诊断细节，不阻塞 atexit。
             pass
         finally:
             global _TELEMETRY_SERVER_URL
@@ -808,6 +830,7 @@ class TokenTracker:
                 return
             loaded_daily = data.get("daily", {})
             loaded_records = data.get("records", [])
+            loaded_batch_seq = data.get("batch_seq")
             if loaded_daily:
                 with self._lock:
                     for day_key, day_val in loaded_daily.items():
@@ -818,6 +841,11 @@ class TokenTracker:
                     self._unsent_records.extend(loaded_records)
                     if len(self._unsent_records) > 200:
                         self._unsent_records = self._unsent_records[-200:]
+                    # 恢复 batch_seq：进程上次没发出去的窗口，重启后下次上报
+                    # 仍用同一 seq，让 server seen_batches 能 dedupe 那次的
+                    # 不确定成败（client 进程被 kill 时 server 可能已 commit）。
+                    if isinstance(loaded_batch_seq, str) and loaded_batch_seq:
+                        self._pending_batch_seq = loaded_batch_seq
                 logger.debug(f"Token tracker: loaded {len(loaded_daily)} days of unsent telemetry from disk")
             # 加载成功后删除文件，避免下次重复加载
             p.unlink(missing_ok=True)
@@ -830,6 +858,9 @@ class TokenTracker:
         调用时机：
         1. save() 成功后，如果有 unsent 数据等待远程上报
         2. atexit 兜底时（通过 save → _report_to_server → 失败 → 持久化）
+
+        持久化 batch_seq 一起：失败 + 进程崩 + 重启后 → 重传用同一 seq，
+        让 server seen_batches dedupe 不确定成败的 commit。
         """
         if _DO_NOT_TRACK or not _TELEMETRY_SERVER_URL:
             return
@@ -842,6 +873,7 @@ class TokenTracker:
                 data = {
                     "daily": copy.deepcopy(self._unsent_daily),
                     "records": list(self._unsent_records[-200:]),
+                    "batch_seq": self._pending_batch_seq,
                     "saved_at": time.time(),
                 }
             atomic_write_json(self._unsent_queue_path, data)
@@ -1065,6 +1097,8 @@ class TokenTracker:
             _instr_event("session_start", process=process)
             _instr_counter("session_start", process=process)
         except Exception:
+            # 埋点失败不能挡 app 启动 —— 老 record() 路径下面已经跑过，
+            # DAU 仍能从 by_call_type='app_start' 统计出来，不会丢用户。
             pass
 
         self.record(
@@ -1112,7 +1146,10 @@ class TokenTracker:
             try:
                 self._report_to_server(delta_daily, delta_records)
             except Exception:
-                pass  # 远程失败不影响 idle path
+                # 远程失败不影响 idle path —— 已经没本地数据要写，错误就是
+                # 纯网络的，下次 60s 周期或 atexit 会再试。_report_to_server
+                # 自己内部已有失败 unsent 持久化逻辑，这里不重复打日志。
+                pass
             return
 
         try:
@@ -1206,7 +1243,9 @@ class TokenTracker:
         except Exception:
             has_instruments = False
 
-        # 取出待发送数据
+        # 取出待发送数据。同时分配/复用 batch_seq —— 失败重传保留同一 seq
+        # 才能让 server seen_batches dedupe；新窗口（_pending_batch_seq=None）
+        # 才分配新值，保证不同窗口 batch_id 不会相撞。
         with self._lock:
             if not self._unsent_daily and not has_instruments:
                 return
@@ -1214,6 +1253,9 @@ class TokenTracker:
             send_records = self._unsent_records
             self._unsent_daily = {}
             self._unsent_records = []
+            if self._pending_batch_seq is None:
+                self._pending_batch_seq = secrets.token_hex(8)
+            batch_seq = self._pending_batch_seq
 
         # 现在确定要发，clear-on-read 拿 instrument snapshot。如果上报失败，
         # 这部分数据丢失（设计取舍：counter / histogram 是窗口聚合，丢一个
@@ -1266,25 +1308,25 @@ class TokenTracker:
             ts = time.time()
             sig = _compute_telemetry_signature(payload_json, ts)
 
-            # batch_id 用于 server seen_batches 幂等去重，必须在"同一份重试数据"
-            # 上稳定。device_id_legacy 依赖 uuid.getnode()，在多网卡机器上枚举
-            # 顺序不保证，重试期间可能漂；如果把它纳入 batch_id 计算，原本应该
-            # 被 dedupe 的重发会变成新 batch 被累加，daily_aggregates 双倍计数。
-            # 因此 batch_id 只覆盖核心幂等字段，签名仍覆盖完整 payload。
+            # batch_id 用于 server seen_batches 幂等去重，必须满足两个目标：
+            #   (a) 失败重传 / 网络 timeout（server commit 了 client 没收到 200）
+            #       下次重发同一份 daily 时 batch_id 必须**不变**，让 server
+            #       识别重复 commit 并跳过。
+            #   (b) 不同窗口（含纯 instrument-only 窗口、daily 都空时）的
+            #       batch_id 必须**唯一**，否则被前一窗口的 seen_batches dedupe
+            #       误伤，后续 instrument 数据全丢。
             #
-            # instruments 也必须入 hash —— 当 daily_stats 和 recent_records 都空
-            # （纯前端 counter 触发的窗口），少了它 batch_core 对同一设备每个
-            # 窗口都算出同一个 hash，server seen_batches 一旦记录就把所有后续
-            # instrument-only 上报全部 dedupe 掉。instruments 是 clear-on-read
-            # 不会在重试中复现，所以加入 hash 不会破坏失败重传的 dedupe（重传
-            # 时 instruments 为空，hash 自然不同；而首次上报的 instruments 内容
-            # 也不会跟其它窗口相同，保证每个窗口的 hash 都唯一）。
+            # batch_seq 同时满足：进程内首次进入此窗口时分配新值，失败重传
+            # （含进程 kill 后重启）保留同一 seq，成功 200 后清空。把 seq 放进
+            # hash，daily / records / instruments 自己不需要进 hash —— 尤其
+            # instruments 是 clear-on-read、不会在重传中复现，把它进 hash 反而
+            # 破坏 (a)。device_id_legacy 也不进：它依赖 uuid.getnode()，多网卡
+            # 机器枚举顺序不稳定，进 hash 会让重传变成新 batch 被累加。
+            # 签名 (HMAC) 仍覆盖完整 payload。
             batch_core = {
                 "device_id": payload["device_id"],
                 "app_version": payload["app_version"],
-                "daily_stats": payload["daily_stats"],
-                "recent_records": payload["recent_records"],
-                "instruments": payload.get("instruments"),
+                "batch_seq": batch_seq,
             }
             batch_id = hashlib.sha256(
                 json.dumps(batch_core, ensure_ascii=False, sort_keys=True).encode()
@@ -1314,7 +1356,9 @@ class TokenTracker:
             with urllib.request.urlopen(req, timeout=_TELEMETRY_TIMEOUT) as resp:
                 if resp.status == 200:
                     self._last_report_time = now
-                    # 发送成功，删除 unsent 队列文件
+                    # 发送成功：清 batch_seq，下次窗口重新分配；清 unsent 文件。
+                    with self._lock:
+                        self._pending_batch_seq = None
                     self._unsent_queue_path.unlink(missing_ok=True)
                     logger.debug("Token tracker: telemetry reported successfully")
                     return
@@ -1323,7 +1367,9 @@ class TokenTracker:
 
         except Exception as e:
             logger.debug(f"Token tracker: telemetry report failed (non-critical): {e}")
-            # 发送失败，放回 unsent 数据 + 持久化
+            # 发送失败：放回 unsent + 持久化。**不清** _pending_batch_seq ——
+            # 下次重试用同一 seq，让 server seen_batches dedupe "网络 timeout
+            # 但 server 已经 commit" 的不确定成败重传。
             with self._lock:
                 for day_key, day_delta in send_daily.items():
                     if day_key not in self._unsent_daily:

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -1684,11 +1684,15 @@ def _install_crash_excepthook():
                 from utils.event_logger import EventLogger
                 EventLogger.get_instance().flush()
         except Exception:
+            # crash hook 自己绝不能 raise —— 否则原始 traceback 被它的异常
+            # 替换，用户看不到真正 crash 在哪。telemetry 失败相比之下不值一提。
             pass
         # 让默认 hook 继续打 stack —— 不打断现有行为
         try:
             _orig_excepthook(exc_type, exc_value, exc_tb)
         except Exception:
+            # 原 hook 自己崩了（罕见，比如 sys.stderr 已经被关）—— 这种情况
+            # 我们没什么能做的，最多让进程退出，原 traceback 已经丢了。
             pass
 
     sys.excepthook = _crash_excepthook

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -659,6 +659,69 @@ def _compute_telemetry_signature(payload_json: str, timestamp: float) -> str:
 
 
 # ---------------------------------------------------------------------------
+# 主动搭话 / 隐私模式设置快照埋点
+# ---------------------------------------------------------------------------
+
+def _bucket_proactive_interval(seconds) -> str:
+    """把 proactiveChatInterval（1-3600 秒）分桶成低基数 enum。
+
+    **不上报 raw 秒数** —— 那是连续值，进 dim 会让 metric_key 基数爆炸
+    （跟之前 lanlan_name 同类教训）。分 5 桶覆盖典型配置区间。
+    """
+    try:
+        s = float(seconds)
+    except (TypeError, ValueError):
+        return "unknown"
+    if s < 10:
+        return "<10s"
+    if s < 30:
+        return "10-30s"
+    if s < 60:
+        return "30-60s"
+    if s < 300:
+        return "60-300s"
+    return ">=300s"
+
+
+def record_settings_state() -> None:
+    """读当前主动搭话 / 隐私模式设置，打一个 settings_state counter。
+
+    触发时机：
+    - app 启动（record_app_start，仅 main_server 进程）
+    - 用户改设置（preferences.save_global_conversation_settings 成功后）
+
+    用途：server 端按 device 活跃天数 / event_count 切出深度用户，再看他们
+    settings_state 各 dim 组合的分布 —— 即"深度用户把主动搭话 / 隐私模式
+    定在什么档"。
+
+    dim 全是低基数 enum，interval 分桶不发 raw 秒数：
+    - proactive: on / off（proactiveChatEnabled）
+    - interval: <10s / 10-30s / ... / >=300s（off 时为 "off"）
+    - vision_chat: on / off（proactiveVisionChatEnabled）
+    - privacy: on / off（隐私模式 = proactiveVisionEnabled 反面，默认关）
+    """
+    if _DO_NOT_TRACK:
+        return
+    try:
+        from utils.preferences import load_global_conversation_settings
+        from utils.instrument import counter as _c
+        s = load_global_conversation_settings()
+        proactive_on = bool(s.get("proactiveChatEnabled", False))
+        _c(
+            "settings_state", 1,
+            proactive="on" if proactive_on else "off",
+            interval=(_bucket_proactive_interval(s.get("proactiveChatInterval", 0))
+                      if proactive_on else "off"),
+            vision_chat="on" if s.get("proactiveVisionChatEnabled", False) else "off",
+            # 隐私模式 = proactiveVisionEnabled 的反面（default True → 默认隐私关）
+            privacy="on" if not s.get("proactiveVisionEnabled", True) else "off",
+        )
+    except Exception:
+        # 埋点失败不影响业务，静默
+        pass
+
+
+# ---------------------------------------------------------------------------
 # TokenTracker 单例
 # ---------------------------------------------------------------------------
 
@@ -711,6 +774,8 @@ class TokenTracker:
         self._has_recorded_app_start: bool = False  # 🔒 app_start 单次上报锁
         self._session_start_ts: float = 0.0  # session_end 计算 duration 用
         self._session_process: str = "unknown"
+        self._first_user_message_recorded: bool = False  # 🔒 首条用户消息单次锁
+        self._core_loop_recorded: bool = False  # 🔒 首次完成核心 loop 单次锁
 
         # 首次启动：迁移旧版 per-instance 文件
         self._migrate_legacy_files()
@@ -1111,6 +1176,63 @@ class TokenTracker:
             source="",
             success=True,
         )
+
+        # 启动快照：当前主动搭话 / 隐私设置。只在 main_server 打，避免多进程
+        # （agent/memory_server 也跑 record_app_start）把同一份设置重复计 3 次。
+        # settings 是 user-facing 概念，跟 main 进程绑定最自然。
+        if process == "main_server":
+            record_settings_state()
+
+    def note_first_user_message(self, input_type: str = "text"):
+        """记录本进程内用户的第一条消息（D1 漏斗关键里程碑）。
+
+        每个进程生命周期内只记一次（线程安全）。区分两类 D1 流失：
+        - first_message_sent counter：用户真的"开口"了——没这条 = 装了打开
+          没说话就走（onboarding / 配置障碍）
+        - time_to_first_message_sec histogram：app 启动→首条消息的时长。卡在
+          配置 / 选角色 / 麦克风授权 = 长；秒级 = 顺畅上手
+
+        input_type: text / voice（低基数）
+        """
+        with self._lock:
+            if self._first_user_message_recorded:
+                return
+            self._first_user_message_recorded = True
+            anchor = self._session_start_ts
+
+        try:
+            from utils.instrument import counter as _c, histogram as _h
+            _c("first_message_sent", input_type=input_type)
+            if anchor > 0:
+                _h("time_to_first_message_sec", max(0.0, time.time() - anchor))
+        except Exception:
+            # 埋点失败不能挡用户消息处理
+            pass
+
+    def note_core_loop_completed(self):
+        """用户完成一轮核心体验：发消息→收回复→听到语音。每进程记一次。
+
+        只在用户已经发过消息（_first_user_message_recorded=True）后才算 —— 纯
+        proactive 触发的语音不算"用户主动体验到核心 loop"。
+
+        D1 流失分析的关键区分信号：
+        - 有 first_message_sent 但没 core_loop_completed = 用户开口了但没听到
+          回复（卡在 LLM 失败 / TTS 失败 / 太慢）→ 首次体验障碍型流失
+        - 有 core_loop_completed = 完整体验过产品核心，之后流失更可能是
+          "玩了不喜欢"（产品价值问题）→ 两类流失的运营动作完全不同
+        """
+        with self._lock:
+            if self._core_loop_recorded:
+                return
+            if not self._first_user_message_recorded:
+                return  # 用户还没开口，不算用户发起的核心 loop
+            self._core_loop_recorded = True
+
+        try:
+            from utils.instrument import counter as _c
+            _c("core_loop_completed")
+        except Exception:
+            pass
 
     # ---- 持久化 ----
 

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -747,17 +747,15 @@ class TokenTracker:
 
         覆盖场景：SIGTERM / 未捕获异常 / 正常退出 / sys.exit()
         不覆盖：SIGKILL (kill -9) / 断电 — 此时最多丢 60s 数据
+
+        顺序要点：先 emit session_end 到 instrument buffer，再 save()。
+        save() → _report_to_server 会 snapshot 走 instrument，所以 emit
+        必须先发生；否则 session_end 的 counter/histogram 进了 buffer 但
+        没机会被 snapshot，远程 dashboard 看不到 session_end —— 配对的
+        session_start 看得见、session_end 永远缺失，dashboard 上"异常退出
+        率"会被误算成 100%。event 单独通过 event_logger.flush 走本地 jsonl。
         """
-        try:
-            # save() first: persists delta to disk and attempts remote report
-            # (best-effort final push). Then disable remote URL so no further
-            # network calls happen during interpreter teardown.
-            self.save()
-        except Exception:
-            pass
-        # 在 flush 之前把 session_end 落进 buffer。同步 counter + histogram
-        # 走远程聚合：counter 用于"启动了多少次 / 结束了多少次"配对（差值 =
-        # 异常退出数），histogram 用于 session_duration 分布看用户停留时长。
+        # ── 1) session_end 先落 instrument buffer，让随后的 save() 带上 ──
         try:
             from utils.instrument import (
                 event as _instr_event,
@@ -776,8 +774,17 @@ class TokenTracker:
                 _instr_histogram("session_duration_sec", duration, process=self._session_process)
         except Exception:
             pass
-        # 顺手 flush 稀疏事件 —— 这里如果丢，下次启动就没法恢复（event_logger
-        # 没有自己的 unsent queue），所以哪怕 save() 失败也单独尝试。
+
+        # ── 2) save() 把 daily_stats + 上面刚 emit 的 instrument snapshot 一起发 ──
+        try:
+            # save() first: persists delta to disk and attempts remote report
+            # (best-effort final push). Then disable remote URL so no further
+            # network calls happen during interpreter teardown.
+            self.save()
+        except Exception:
+            pass
+
+        # ── 3) flush event_logger —— event 不走远程 instrument 通道，本地 jsonl 兜底 ──
         try:
             from utils.event_logger import EventLogger
             EventLogger.get_instance().flush()
@@ -1080,16 +1087,33 @@ class TokenTracker:
         1. 线程锁内取出 delta 快照并清空（swap 模式）
         2. 文件锁内做 read-merge-write
         3. 如果写入失败，将 delta 放回内存
+
+        Not-dirty 仍要触发远程上报：纯前端互动（counter/histogram，无 LLM 调用）
+        的用户 self._dirty 永远是 False，老逻辑直接 return 会让 instrument
+        累积窗口永远发不出去。跳过本地写盘但 _report_to_server 仍要调，让它
+        内部按 has_data() 决定是否真的 POST。
         """
         with self._lock:
             if not self._dirty:
-                return
-            # 取出 delta（swap 模式：先取出，成功后不放回）
-            delta_daily = self._delta_daily
-            delta_records = list(self._delta_records)
-            self._delta_daily = {}
-            self._delta_records.clear()
-            self._dirty = False
+                report_only = True
+                delta_daily: dict = {}
+                delta_records: list = []
+            else:
+                report_only = False
+                # 取出 delta（swap 模式：先取出，成功后不放回）
+                delta_daily = self._delta_daily
+                delta_records = list(self._delta_records)
+                self._delta_daily = {}
+                self._delta_records.clear()
+                self._dirty = False
+
+        if report_only:
+            # 没 LLM 数据写盘，只问问 instrument 有没有要发的
+            try:
+                self._report_to_server(delta_daily, delta_records)
+            except Exception:
+                pass  # 远程失败不影响 idle path
+            return
 
         try:
             self._storage_dir.mkdir(parents=True, exist_ok=True)
@@ -1247,11 +1271,20 @@ class TokenTracker:
             # 顺序不保证，重试期间可能漂；如果把它纳入 batch_id 计算，原本应该
             # 被 dedupe 的重发会变成新 batch 被累加，daily_aggregates 双倍计数。
             # 因此 batch_id 只覆盖核心幂等字段，签名仍覆盖完整 payload。
+            #
+            # instruments 也必须入 hash —— 当 daily_stats 和 recent_records 都空
+            # （纯前端 counter 触发的窗口），少了它 batch_core 对同一设备每个
+            # 窗口都算出同一个 hash，server seen_batches 一旦记录就把所有后续
+            # instrument-only 上报全部 dedupe 掉。instruments 是 clear-on-read
+            # 不会在重试中复现，所以加入 hash 不会破坏失败重传的 dedupe（重传
+            # 时 instruments 为空，hash 自然不同；而首次上报的 instruments 内容
+            # 也不会跟其它窗口相同，保证每个窗口的 hash 都唯一）。
             batch_core = {
                 "device_id": payload["device_id"],
                 "app_version": payload["app_version"],
                 "daily_stats": payload["daily_stats"],
                 "recent_records": payload["recent_records"],
+                "instruments": payload.get("instruments"),
             }
             batch_id = hashlib.sha256(
                 json.dumps(batch_core, ensure_ascii=False, sort_keys=True).encode()


### PR DESCRIPTION
## Summary
- 新增 client SDK (`utils/instrument`)：`counter` / `histogram` / `event` 三 API，in-memory 聚合，60s 跟 TokenTracker daily_stats 同条 HTTP 通道走出去
- HTTP 上报加 gzip（>=1KB body），19KB 真实 payload 实测 **省 96% 带宽**；server 端 `_decompress_if_gzip` 解压 + 2MB cap 挡 zip bomb；老 server 不带 header 透传，向下兼容
- 服务端落库 + dashboard：新增 `instrument_counters` / `instrument_histograms` 两张表，按 (天, 设备, metric_key) UPSERT；dashboard 加 Top Counters / Histograms p50-p95 两个视图
- 后端埋点示范：`session_start/end + duration`、`crash`（全局 `sys.excepthook`）、`ws_connect/disconnect + ws_session_sec`、`feature_invoked`、`onboarding_step`、`memory_recall_invoke` — 直接解锁 D2-D7 流失诊断核心信号
- 前端 WS 通道：`window.appTelemetry.{counter,histogram,event}` 自动注入 surface 维度（`chat_window` / `index_mobile` / `index_wide`），后端 dispatch 加 `_sanitize_dims` 限 8 dim / 32B key / 64B value 挡 untrusted 输入
- 稀疏事件本地兜底：`utils/event_logger` 按天分片 JSONL，7d retention、单文件 500KB / 目录 20MB 强制清理防 disk full
- 端到端 smoke test：`scripts/telemetry_smoke.py` 起临时 server + 双客户端 mock 全链验证

## 开销实测

| | 改前 | 改后 | 用户感知 |
|---|---|---|---|
| 单次上报 (19KB payload) | 19,347 B | 729 B | 网络省 96% |
| counter/histogram 调用 | — | ~300ns | 0 |
| 内存 buffer | 80KB | +150KB | 0 |
| events.jsonl 单天 | — | < 500KB（cap） | 0 |

## D2-D7 流失诊断现在能回答

| 问题 | 数据源 |
|---|---|
| 启动了多少次？正常退出多少？ | `session_start` vs `session_end` counter（差值 = crash/kill）|
| 每个 session 多长？ | `session_duration_sec` histogram p50/p95 |
| Crash 集中在哪类错误？ | `crash` counter 按 `error_class` 切片 |
| Onboarding 哪步流失最严重？ | `onboarding_step` counter 按 status 切片 |
| 哪个 surface 留人？ | counter 按 `surface` 切片 |
| Memory recall 在起作用吗？ | `memory_recall_invoke` 的 `returned_empty=true` 比例 |
| 渲染慢不慢？ | `client_render_ms` histogram p95 |

## 部署顺序提醒
**Server 必须先 deploy 再发新客户端**。老服务端不认 `Content-Encoding: gzip` 会直接 415；新服务端对老 payload 完全兼容。

## Test plan
- [x] `uv run python scripts/telemetry_smoke.py` 全链路通过：counters=6 / histograms=3 / batch dedupe 工作 / dashboard 含所有期望标记
- [x] gzip roundtrip + zip bomb 防护（3MB raw → 3KB 压缩 → server 413）
- [x] Pydantic 老 payload（无 `instruments`）解析为 None 不报错
- [x] counter cap 5000 / histogram cap 1000 高基数防护触发 warning
- [x] histogram 桶分布命中：234ms → idx 8, 156ms → idx 7, 412ms → idx 8 与 `bisect_left` 期望一致
- [ ] 灰度小流量验证服务端 SQLite 写入 throughput（180 req/h/device × N device 仍 < 500 write/s 的 WAL 限）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 客户端按 60s 窗口上报 instruments（counters/histograms）；服务端聚合入库并在管理端新增“Top Counters / Histograms（p50/p95）”可视化，清理接口返回已删除统计数
  * WebSocket 增加前端 telemetry 通道，并记录连接/断开原因与会话时长
* **兼容性 / 网络**
  * 支持 gzip 流式上报，超限/解析错误返回明确状态码
* **工具**
  * 新增前端埋点 SDK（window.appTelemetry）并注入页面；新增本地聚合与事件落盘器，改进上报幂等与重传机制
* **测试**
  * 新增端到端遥测冒烟测试覆盖上报、幂等与健壮性场景

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->