### PR TITLE
fix(voice): livestream 任意 voice 一律跳外部 TTS（补 PR #1369 漏的 AND）

### DIFF
--- a/main_logic/core.py
+++ b/main_logic/core.py
@@ -3291,6 +3291,19 @@ class LLMSessionManager:
 
         if input_mode == 'text':
             return True
+        # Livestream 上游是 free 路 Gemini 系，服务端始终承担原生 TTS。客户端
+        # 角色卡的 voice_id 不论是不是 free preset，都不应该再开外部 TTS——
+        # 否则文本会被客户端按整句喂给 tts_proxy，丢掉服务端 Gemini → core_proxy
+        # → CV3 那条真 bistream 路径的首音频延迟优势。
+        #
+        # PR #1369 在原 free-preset gate 第三个条件里 OR 了 livestream-active，
+        # 但前两个 AND（_is_free_preset_voice / core_api_type='free'）没拆，
+        # 导致 livestream + 非 free preset 音色（克隆 / 空 voice_id / 主播
+        # 自定义未识别为 preset）仍会 fallback 到外部 TTS。这里独立早退兜底。
+        # _is_livestream_active 内部已经 gate 了 core_api_type='free'。
+        if self._is_livestream_active():
+            logger.info(f"{log_prefix}🎙️ livestream 模式：使用服务端原生语音，跳过外部 TTS")
+            return False
         base_url = realtime_config.get('base_url', '')
         if should_block_free_native_voice(
             self.core_api_type, self.voice_id, base_url,
@@ -3309,14 +3322,8 @@ class LLMSessionManager:
         if (
             self._is_free_preset_voice
             and self.core_api_type == 'free'
-            and ('lanlan.tech' in realtime_config.get('base_url', '') or self._is_livestream_active())
+            and 'lanlan.tech' in realtime_config.get('base_url', '')
         ):
-            # livestream 启用后 base_url 被重写成主播自建 server_prefix
-            # （非 lanlan.tech 域），导致原 lanlan.tech 字面量判定失效，会 fallback
-            # 到外部 TTS 流水线。但 livestream 上游同样是 free 路 Gemini 系，
-            # 原生音色（voice_id 由 livestream_config 覆盖成 neon 等）直接走
-            # session config 即可，不需要再开外部 TTS。把 livestream-active
-            # 视为与 lanlan.tech 对偶的免费原生音色路径。
             logger.info(f"{log_prefix}🆓 免费预设音色 '{self.voice_id}' 将直接传入 session config，不启动外部 TTS")
             return False
         if self.voice_id or has_custom_tts_config:

--- a/tests/unit/test_gemini_realtime_voice_routing.py
+++ b/tests/unit/test_gemini_realtime_voice_routing.py
@@ -279,6 +279,85 @@ def test_voice_mode_gemini_native_uses_realtime_audio_not_external_tts():
     )
 
 
+def test_livestream_skips_external_tts_regardless_of_voice_preset(monkeypatch):
+    """Livestream 上游是 free 路 Gemini 系，无论角色卡 voice_id 是不是 free preset，
+    都应跳过外部 TTS 走服务端原生语音。PR #1369 的 free-preset gate 漏掉了
+    "livestream + 非 preset 音色"（克隆 / 空 voice_id）这条路径——本测试守门。"""
+    monkeypatch.setattr(
+        "main_logic.core.is_livestream_active",
+        lambda: True,
+    )
+    realtime_config = {"base_url": "wss://主播自建.example.com/realtime"}
+    core_config = {
+        "ENABLE_CUSTOM_API": True,
+        "TTS_MODEL_URL": "http://localhost:9880",
+        "GPTSOVITS_ENABLED": True,
+    }
+
+    # 角色卡是克隆音色（非 free preset）
+    mgr_clone = _make_mgr("voice-clone-abc")
+    mgr_clone.core_api_type = "free"
+    mgr_clone._is_free_preset_voice = False
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr_clone, "audio", realtime_config, core_config,
+        )
+        is False
+    )
+
+    # 角色卡 voice_id 为空
+    mgr_empty = _make_mgr("")
+    mgr_empty.core_api_type = "free"
+    mgr_empty._is_free_preset_voice = False
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr_empty, "audio", realtime_config, core_config,
+        )
+        is False
+    )
+
+    # 文本模式仍然启用 TTS（没有 realtime audio 通道兜底）
+    mgr_text = _make_mgr("voice-clone-abc")
+    mgr_text.core_api_type = "free"
+    mgr_text._is_free_preset_voice = False
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr_text, "text", realtime_config, core_config,
+        )
+        is True
+    )
+
+
+def test_non_livestream_free_preset_still_skips_tts_only_on_lanlan_tech(monkeypatch):
+    """回归 PR #1369 原 gate 的窄路径：非 livestream 时，free preset 仅在
+    base_url 指向 lanlan.tech 域时跳 TTS，其他域照旧 fallback 外部 TTS。"""
+    monkeypatch.setattr(
+        "main_logic.core.is_livestream_active",
+        lambda: False,
+    )
+    core_config = {
+        "ENABLE_CUSTOM_API": True,
+        "TTS_MODEL_URL": "http://localhost:9880",
+        "GPTSOVITS_ENABLED": True,
+    }
+    mgr = _make_mgr("qingchunshaonv")
+    mgr.core_api_type = "free"
+    mgr._is_free_preset_voice = True
+
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr, "audio", {"base_url": "wss://lanlan.tech/realtime"}, core_config,
+        )
+        is False
+    )
+    assert (
+        LLMSessionManager._resolve_session_use_tts(
+            mgr, "audio", {"base_url": "wss://lanlan.app/realtime"}, core_config,
+        )
+        is True
+    )
+
+
 def test_custom_tts_config_requires_gptsovits_enabled():
     mgr = _make_mgr("")
     realtime_config = {"base_url": "https://generativelanguage.googleapis.com"}


### PR DESCRIPTION
## Summary

PR [#1369](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1369) 给 `_resolve_session_use_tts` 的 free-preset gate 在第三个 OR 条件里加了 `_is_livestream_active()` 兜底，commit message 里写的是"_resolve_session_use_tts gate 加 livestream 兜底，默认走原生音色不开外部 TTS"。

但 diff 只动了第三个 OR，前两个 AND（`_is_free_preset_voice` / `core_api_type='free'`）没拆：

```python
if (
    self._is_free_preset_voice                 # ← AND 没拆
    and self.core_api_type == 'free'           # ← AND 没拆
    and ('lanlan.tech' in base_url or self._is_livestream_active())  # ← 只动了这条
):
    return False
```

后果：livestream + 非 free preset 音色（克隆 / 空 voice_id / 主播自定义未被识别为 preset）→ 第一个 AND fail → gate 不触发 → 还是开外部 TTS → 客户端把整句喂给 tts_proxy → 丢掉 `Gemini → core_proxy → CV3` 那条真 bistream 路径的首音频延迟优势。

## 修法

在 `_resolve_session_use_tts` 入口（紧跟 text 模式判定后）加 livestream 独立早退。`_is_livestream_active` 内部已 gate `core_api_type='free'`，无需再判 base_url——livestream 上游就是 free 路 Gemini 系，服务端原生 TTS 永远能用。

原 free-preset gate 里的 livestream OR 分支因此变 dead code，顺手拆回 lanlan.tech-only 形态，避免两条路径表达同一意图引人误读。

## Test plan

- [x] 新增 `test_livestream_skips_external_tts_regardless_of_voice_preset`：克隆音色 / 空 voice_id 在 livestream 下都跳 TTS；text 模式仍开 TTS
- [x] 新增 `test_non_livestream_free_preset_still_skips_tts_only_on_lanlan_tech`：回归 PR #1369 原 free-preset gate 在 lanlan.tech 域下的窄路径
- [x] `uv run pytest tests/unit/test_gemini_realtime_voice_routing.py` 16 pass（1 pre-existing fail 与本改无关）
- [ ] CI 通过
- [ ] 主播 livestream 端实测：单轮内首音频延迟应回归 core_proxy 那条路径，不再听到"等整句生成完才出声"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug 修复**
  * 改进了直播场景下的文本转语音路由逻辑，确保使用服务端原生语音，防止音频路径错误。
  * 优化了免费语音预设的条件判断，提高了语音行为的一致性。

* **测试**
  * 新增单元测试，验证直播场景下的语音路由行为。
  * 新增单元测试，验证非直播场景下的预设语音处理逻辑。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->