### PR TITLE
将 Qwen 国际服与 MiniMax 国际服标记为大陆地区受限，避免在不适用地区默认显示；同步处理声音注册/参考语音相关入口的服务商可见…

### DIFF
--- a/config/api_providers.json
+++ b/config/api_providers.json
@@ -300,7 +300,7 @@
     },
     "qwen_intl": {
       "config_field": "assistApiKeyQwenIntl",
-      "restricted": false
+      "restricted": true
     },
     "openai": {
       "config_field": "assistApiKeyOpenai",
@@ -340,7 +340,7 @@
     },
     "minimax_intl": {
       "config_field": "assistApiKeyMinimaxIntl",
-      "restricted": false
+      "restricted": true
     },
     "elevenlabs": {
       "config_field": "assistApiKeyElevenlabs",

--- a/static/js/api_key_settings.js
+++ b/static/js/api_key_settings.js
@@ -697,6 +697,33 @@ function toggleKeyBook() {
     }
 }
 
+function expandAndScrollToKeyBook(options = {}) {
+    const keyBookOptions = document.getElementById('key-book-options');
+    const keyBookButton = document.getElementById('key-book-toggle-btn');
+    if (keyBookOptions && keyBookOptions.style.display === 'none') {
+        keyBookOptions.style.display = 'block';
+        if (keyBookButton) keyBookButton.classList.add('rotated');
+    }
+
+    const section = document.getElementById('key-book-section');
+    if (section) {
+        section.scrollIntoView({
+            behavior: options.instant ? 'auto' : 'smooth',
+            block: 'center'
+        });
+    }
+}
+
+function shouldFocusKeyBookFromLocation() {
+    try {
+        const params = new URLSearchParams(window.location.search || '');
+        const focus = (params.get('focus') || params.get('target') || '').toLowerCase();
+        if (focus === 'key_book' || focus === 'key-book' || focus === 'keybook') return true;
+    } catch (_) { }
+    const hash = String(window.location.hash || '').toLowerCase();
+    return hash === '#key-book' || hash === '#key_book' || hash === '#keybook';
+}
+
 /**
  * 从 Key Book 读取某个 provider 的 key。
  * 返回 null 表示该 provider 的输入框不存在（如被 restricted 隐藏），
@@ -911,15 +938,7 @@ function ensureKeyBookLink(input) {
     link.style.cssText = 'font-size: 0.85em; color: #40C5F1; cursor: pointer; margin-left: 8px; white-space: nowrap;';
     link.addEventListener('click', (e) => {
         e.preventDefault();
-        // 展开 Key Book 区域并滚动到它
-        const options = document.getElementById('key-book-options');
-        const btn = document.getElementById('key-book-toggle-btn');
-        if (options && options.style.display === 'none') {
-            options.style.display = 'block';
-            if (btn) btn.classList.add('rotated');
-        }
-        const section = document.getElementById('key-book-section');
-        if (section) section.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        expandAndScrollToKeyBook();
     });
     parent.appendChild(link);
 }
@@ -3992,6 +4011,12 @@ async function initializePage() {
             toggleCustomApi(true);
         }, 0);
 
+        if (shouldFocusKeyBookFromLocation()) {
+            setTimeout(() => {
+                expandAndScrollToKeyBook();
+            }, 80);
+        }
+
         // Task 6.3: Auto-test removed per maintainer feedback (Wehos).
         // Manual test buttons are sufficient; auto-test on page load could
         // consume tokens without user consent and /models doesn't reliably
@@ -4013,6 +4038,13 @@ async function initializePage() {
 
 // 页面加载完成后开始初始化
 document.addEventListener('DOMContentLoaded', initializePage);
+
+window.addEventListener('message', event => {
+    if (event.origin !== window.location.origin) return;
+    if (event.data && event.data.type === 'focus_api_key_book') {
+        expandAndScrollToKeyBook();
+    }
+});
 
 // 兼容性：防止在某些情况下DOMContentLoaded不触发
 window.addEventListener('load', () => {

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -90,9 +90,122 @@ function notifyVoiceConfigSwitching(lanlanName, active, opId) {
     }
 }
 
+const WORKSHOP_VOICE_PROVIDER_REGISTRY_KEYS = Object.freeze({
+    cosyvoice: 'qwen',
+    cosyvoice_intl: 'qwen_intl',
+    minimax: 'minimax',
+    minimax_intl: 'minimax_intl',
+});
+const workshopVoiceProviderRestrictionState = {
+    loaded: false,
+    loadingPromise: null,
+    isMainlandChinaUser: false,
+    apiKeyRegistry: {},
+};
+
+function getWorkshopVoiceProviderRegistryKey(provider) {
+    return WORKSHOP_VOICE_PROVIDER_REGISTRY_KEYS[provider] || provider;
+}
+
+async function checkWorkshopVoiceMainlandChinaUser() {
+    try {
+        const response = await fetch('/api/config/steam_language', {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        if (!response.ok) return false;
+        const data = await response.json();
+        return data && data.is_mainland_china === true;
+    } catch (error) {
+        console.warn('参考语音区域检测失败，使用默认显示策略:', error);
+        return false;
+    }
+}
+
+async function loadWorkshopVoiceProviderRestrictionState() {
+    if (workshopVoiceProviderRestrictionState.loaded) {
+        return workshopVoiceProviderRestrictionState;
+    }
+    if (workshopVoiceProviderRestrictionState.loadingPromise) {
+        return workshopVoiceProviderRestrictionState.loadingPromise;
+    }
+
+    workshopVoiceProviderRestrictionState.loadingPromise = (async () => {
+        const [isMainlandChinaUser, providersResponse] = await Promise.all([
+            checkWorkshopVoiceMainlandChinaUser(),
+            fetch('/api/config/api_providers')
+        ]);
+        let apiKeyRegistry = {};
+        if (providersResponse.ok) {
+            const providersData = await providersResponse.json();
+            if (providersData && providersData.success) {
+                apiKeyRegistry = providersData.api_key_registry || {};
+            }
+        }
+        workshopVoiceProviderRestrictionState.isMainlandChinaUser = !!isMainlandChinaUser;
+        workshopVoiceProviderRestrictionState.apiKeyRegistry = apiKeyRegistry;
+        workshopVoiceProviderRestrictionState.loaded = true;
+        return workshopVoiceProviderRestrictionState;
+    })().catch(error => {
+        console.warn('参考语音服务商地区配置加载失败，使用默认显示策略:', error);
+        workshopVoiceProviderRestrictionState.loaded = true;
+        return workshopVoiceProviderRestrictionState;
+    }).finally(() => {
+        workshopVoiceProviderRestrictionState.loadingPromise = null;
+    });
+
+    return workshopVoiceProviderRestrictionState.loadingPromise;
+}
+
+function isWorkshopVoiceProviderRestricted(provider) {
+    if (!workshopVoiceProviderRestrictionState.isMainlandChinaUser) return false;
+    const registryKey = getWorkshopVoiceProviderRegistryKey(provider);
+    const entry = workshopVoiceProviderRestrictionState.apiKeyRegistry[registryKey];
+    return !!(entry && entry.restricted === true);
+}
+
+function getFirstAvailableWorkshopVoiceProviderValue(providerSelect) {
+    if (!providerSelect) return '';
+    const options = Array.from(providerSelect.options || []);
+    const availableOption = options.find(option => !option.disabled && !option.hidden && option.style.display !== 'none');
+    return availableOption ? availableOption.value : '';
+}
+
+function applyWorkshopVoiceProviderRestrictions(providerSelect) {
+    if (!providerSelect) return false;
+    const previousValue = providerSelect.value;
+    Array.from(providerSelect.options || []).forEach(option => {
+        const restricted = isWorkshopVoiceProviderRestricted(option.value);
+        option.disabled = restricted;
+        option.hidden = restricted;
+        option.style.display = restricted ? 'none' : '';
+    });
+
+    const selectedOption = providerSelect.options[providerSelect.selectedIndex];
+    if (selectedOption && !selectedOption.disabled && !selectedOption.hidden && selectedOption.style.display !== 'none') {
+        return false;
+    }
+
+    const fallbackValue = getFirstAvailableWorkshopVoiceProviderValue(providerSelect);
+    if (fallbackValue) {
+        providerSelect.value = fallbackValue;
+    }
+    return providerSelect.value !== previousValue;
+}
+
+async function initWorkshopVoiceProviderRestrictions() {
+    await loadWorkshopVoiceProviderRestrictionState();
+    const providerSelect = document.getElementById('voice-reference-provider-hint');
+    applyWorkshopVoiceProviderRestrictions(providerSelect);
+    return workshopVoiceProviderRestrictionState;
+}
+
 // 顶部 tab 按钮初始化（旧版自定义 tooltip 因为文本与按钮文字重复且定位有误已移除）
 document.addEventListener('DOMContentLoaded', function () {
     void loadCharacterReservedFieldsConfig();
+    initWorkshopVoiceProviderRestrictions().catch(error => {
+        console.warn('初始化参考语音服务商地区过滤失败:', error);
+    });
 
     // 云存档管理按钮
     const openCloudsaveManagerBtn = document.getElementById('open-cloudsave-manager-btn');
@@ -1372,7 +1485,10 @@ function resetWorkshopVoiceReferenceFields(defaultTitle = '') {
     if (displayNameInput) displayNameInput.value = defaultTitle || '';
     if (prefixInput) prefixInput.value = sanitizeWorkshopVoicePrefix(defaultTitle, 'voice');
     if (languageSelect) languageSelect.value = 'ch';
-    if (providerSelect) providerSelect.value = 'cosyvoice';
+    if (providerSelect) {
+        providerSelect.value = 'cosyvoice';
+        applyWorkshopVoiceProviderRestrictions(providerSelect);
+    }
 }
 
 async function uploadWorkshopReferenceAudio(contentFolder, defaultTitle) {
@@ -1395,7 +1511,8 @@ async function uploadWorkshopReferenceAudio(contentFolder, defaultTitle) {
     formData.append('prefix', prefix);
     formData.append('display_name', displayNameInput?.value.trim() || defaultTitle || prefix);
     formData.append('ref_language', languageSelect?.value || 'ch');
-    formData.append('provider_hint', providerSelect?.value || 'cosyvoice');
+    applyWorkshopVoiceProviderRestrictions(providerSelect);
+    formData.append('provider_hint', providerSelect?.value || getFirstAvailableWorkshopVoiceProviderValue(providerSelect) || 'cosyvoice');
 
     showMessage('正在写入参考语音...', 'info');
     const response = await fetch('/api/steam/workshop/upload-reference-audio', {
@@ -1632,6 +1749,7 @@ function uploadItem() {
                     }
                 });
                 clearReferenceAudioSelection();
+                applyWorkshopVoiceProviderRestrictions(document.getElementById('voice-reference-provider-hint'));
 
                 // 清空标签
                 const tagsContainer = document.getElementById('tags-container');
@@ -7973,8 +8091,9 @@ function registerVoice() {
     formData.append('file', fileInput.files[0]);
     formData.append('prefix', prefix);
     const providerSelect = document.getElementById('voice-reference-provider-hint');
+    applyWorkshopVoiceProviderRestrictions(providerSelect);
     const providerValue = providerSelect && providerSelect.value ? providerSelect.value.trim() : '';
-    formData.append('provider', providerValue || 'cosyvoice');
+    formData.append('provider', providerValue || getFirstAvailableWorkshopVoiceProviderValue(providerSelect) || 'cosyvoice');
 
     fetch('/api/characters/voice_clone', {
         method: 'POST',

--- a/static/js/character_card_manager.js
+++ b/static/js/character_card_manager.js
@@ -102,24 +102,50 @@ const workshopVoiceProviderRestrictionState = {
     isMainlandChinaUser: false,
     apiKeyRegistry: {},
 };
+const WORKSHOP_VOICE_PROVIDER_FETCH_TIMEOUT_MS = 5000;
+const WORKSHOP_VOICE_PROVIDER_FETCH_ATTEMPTS = 3;
+const WORKSHOP_VOICE_PROVIDER_FETCH_BACKOFF_MS = 250;
+
+function sleepWorkshopVoiceProviderRetry(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchWorkshopVoiceProviderJson(url, options = {}) {
+    let lastError = null;
+    for (let attempt = 1; attempt <= WORKSHOP_VOICE_PROVIDER_FETCH_ATTEMPTS; attempt += 1) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), WORKSHOP_VOICE_PROVIDER_FETCH_TIMEOUT_MS);
+        try {
+            const response = await fetch(url, {
+                ...options,
+                signal: controller.signal,
+            });
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return data;
+        } catch (error) {
+            lastError = error;
+            if (attempt >= WORKSHOP_VOICE_PROVIDER_FETCH_ATTEMPTS) break;
+            await sleepWorkshopVoiceProviderRetry(WORKSHOP_VOICE_PROVIDER_FETCH_BACKOFF_MS * attempt);
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+    throw lastError || new Error('请求失败');
+}
 
 function getWorkshopVoiceProviderRegistryKey(provider) {
     return WORKSHOP_VOICE_PROVIDER_REGISTRY_KEYS[provider] || provider;
 }
 
 async function checkWorkshopVoiceMainlandChinaUser() {
-    try {
-        const response = await fetch('/api/config/steam_language', {
-            method: 'GET',
-            headers: { 'Content-Type': 'application/json' }
-        });
-        if (!response.ok) return false;
-        const data = await response.json();
-        return data && data.is_mainland_china === true;
-    } catch (error) {
-        console.warn('参考语音区域检测失败，使用默认显示策略:', error);
-        return false;
-    }
+    const data = await fetchWorkshopVoiceProviderJson('/api/config/steam_language', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
+    });
+    return data && data.is_mainland_china === true;
 }
 
 async function loadWorkshopVoiceProviderRestrictionState() {
@@ -133,21 +159,16 @@ async function loadWorkshopVoiceProviderRestrictionState() {
     workshopVoiceProviderRestrictionState.loadingPromise = (async () => {
         const [isMainlandChinaUser, providersResponse] = await Promise.all([
             checkWorkshopVoiceMainlandChinaUser(),
-            fetch('/api/config/api_providers')
+            fetchWorkshopVoiceProviderJson('/api/config/api_providers')
         ]);
         let apiKeyRegistry = {};
-        if (providersResponse.ok) {
-            const providersData = await providersResponse.json();
-            if (providersData && providersData.success) {
-                apiKeyRegistry = providersData.api_key_registry || {};
-            }
+        if (providersResponse && providersResponse.success) {
+            apiKeyRegistry = providersResponse.api_key_registry || {};
+        } else {
+            throw new Error('api_providers config unavailable');
         }
         workshopVoiceProviderRestrictionState.isMainlandChinaUser = !!isMainlandChinaUser;
         workshopVoiceProviderRestrictionState.apiKeyRegistry = apiKeyRegistry;
-        workshopVoiceProviderRestrictionState.loaded = true;
-        return workshopVoiceProviderRestrictionState;
-    })().catch(error => {
-        console.warn('参考语音服务商地区配置加载失败，使用默认显示策略:', error);
         workshopVoiceProviderRestrictionState.loaded = true;
         return workshopVoiceProviderRestrictionState;
     }).finally(() => {
@@ -155,6 +176,15 @@ async function loadWorkshopVoiceProviderRestrictionState() {
     });
 
     return workshopVoiceProviderRestrictionState.loadingPromise;
+}
+
+async function ensureWorkshopVoiceProviderRestrictionsLoaded() {
+    try {
+        await loadWorkshopVoiceProviderRestrictionState();
+    } catch (error) {
+        console.warn('参考语音服务商地区配置加载失败，使用默认显示策略:', error);
+    }
+    return workshopVoiceProviderRestrictionState;
 }
 
 function isWorkshopVoiceProviderRestricted(provider) {
@@ -171,7 +201,8 @@ function getFirstAvailableWorkshopVoiceProviderValue(providerSelect) {
     return availableOption ? availableOption.value : '';
 }
 
-function applyWorkshopVoiceProviderRestrictions(providerSelect) {
+async function applyWorkshopVoiceProviderRestrictions(providerSelect) {
+    await ensureWorkshopVoiceProviderRestrictionsLoaded();
     if (!providerSelect) return false;
     const previousValue = providerSelect.value;
     Array.from(providerSelect.options || []).forEach(option => {
@@ -194,9 +225,8 @@ function applyWorkshopVoiceProviderRestrictions(providerSelect) {
 }
 
 async function initWorkshopVoiceProviderRestrictions() {
-    await loadWorkshopVoiceProviderRestrictionState();
     const providerSelect = document.getElementById('voice-reference-provider-hint');
-    applyWorkshopVoiceProviderRestrictions(providerSelect);
+    await applyWorkshopVoiceProviderRestrictions(providerSelect);
     return workshopVoiceProviderRestrictionState;
 }
 
@@ -1475,7 +1505,7 @@ function selectReferenceAudio() {
     fileInput.click();
 }
 
-function resetWorkshopVoiceReferenceFields(defaultTitle = '') {
+async function resetWorkshopVoiceReferenceFields(defaultTitle = '') {
     const displayNameInput = document.getElementById('voice-reference-display-name');
     const prefixInput = document.getElementById('voice-reference-prefix');
     const languageSelect = document.getElementById('voice-reference-language');
@@ -1487,7 +1517,7 @@ function resetWorkshopVoiceReferenceFields(defaultTitle = '') {
     if (languageSelect) languageSelect.value = 'ch';
     if (providerSelect) {
         providerSelect.value = 'cosyvoice';
-        applyWorkshopVoiceProviderRestrictions(providerSelect);
+        await applyWorkshopVoiceProviderRestrictions(providerSelect);
     }
 }
 
@@ -1511,7 +1541,7 @@ async function uploadWorkshopReferenceAudio(contentFolder, defaultTitle) {
     formData.append('prefix', prefix);
     formData.append('display_name', displayNameInput?.value.trim() || defaultTitle || prefix);
     formData.append('ref_language', languageSelect?.value || 'ch');
-    applyWorkshopVoiceProviderRestrictions(providerSelect);
+    await applyWorkshopVoiceProviderRestrictions(providerSelect);
     formData.append('provider_hint', providerSelect?.value || getFirstAvailableWorkshopVoiceProviderValue(providerSelect) || 'cosyvoice');
 
     showMessage('正在写入参考语音...', 'info');
@@ -1663,7 +1693,7 @@ function uploadItem() {
             }
             return data;
         })
-        .then(data => {
+        .then(async data => {
             // 恢复按钮状态
             if (uploadButton) {
                 uploadButton.textContent = originalText;
@@ -1749,7 +1779,7 @@ function uploadItem() {
                     }
                 });
                 clearReferenceAudioSelection();
-                applyWorkshopVoiceProviderRestrictions(document.getElementById('voice-reference-provider-hint'));
+                await applyWorkshopVoiceProviderRestrictions(document.getElementById('voice-reference-provider-hint'));
 
                 // 清空标签
                 const tagsContainer = document.getElementById('tags-container');
@@ -7679,7 +7709,7 @@ async function performUpload(data) {
                 }
                 return response.json();
             })
-            .then(result => {
+            .then(async result => {
                 if (result.success) {
                     // 不再显示"上传准备完成"消息，模态框弹出本身就表明准备工作已完成
 
@@ -7712,7 +7742,7 @@ async function performUpload(data) {
                         previewImageInput.value = result.preview_image;
                         previewImageInput.classList.remove('error');
                     }
-                    resetWorkshopVoiceReferenceFields(cardName);
+                    await resetWorkshopVoiceReferenceFields(cardName);
 
                     // 添加角色卡标签到上传标签（允许用户编辑）
                     if (tagsContainer) {
@@ -8052,7 +8082,7 @@ function setFormDisabled(disabled) {
     if (registerBtn) registerBtn.disabled = disabled;
 }
 
-function registerVoice() {
+async function registerVoice() {
     const fileInput = document.getElementById('audioFile');
     const prefix = document.getElementById('prefix').value.trim();
     const resultDiv = document.getElementById('voice-register-result');
@@ -8091,7 +8121,7 @@ function registerVoice() {
     formData.append('file', fileInput.files[0]);
     formData.append('prefix', prefix);
     const providerSelect = document.getElementById('voice-reference-provider-hint');
-    applyWorkshopVoiceProviderRestrictions(providerSelect);
+    await applyWorkshopVoiceProviderRestrictions(providerSelect);
     const providerValue = providerSelect && providerSelect.value ? providerSelect.value.trim() : '';
     formData.append('provider', providerValue || getFirstAvailableWorkshopVoiceProviderValue(providerSelect) || 'cosyvoice');
 

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -7,19 +7,65 @@ let providerTouchedByUser = false;
 let suppressProviderTouchedTracking = false;
 // 防止并发应用音色的可重入守卫
 let isApplyingVoice = false;
+const VOICE_CLONE_PROVIDER_REGISTRY_KEYS = Object.freeze({
+    cosyvoice: 'qwen',
+    cosyvoice_intl: 'qwen_intl',
+    minimax: 'minimax',
+    minimax_intl: 'minimax_intl',
+    elevenlabs: 'elevenlabs',
+});
+const VOICE_CLONE_PROVIDER_KEY_FIELDS = Object.freeze([
+    ['cosyvoice', 'assistApiKeyQwen'],
+    ['cosyvoice_intl', 'assistApiKeyQwenIntl'],
+    ['minimax', 'assistApiKeyMinimax'],
+    ['minimax_intl', 'assistApiKeyMinimaxIntl'],
+    ['elevenlabs', 'assistApiKeyElevenlabs'],
+]);
+const voiceCloneProviderRestrictionState = {
+    loaded: false,
+    loadingPromise: null,
+    isMainlandChinaUser: false,
+    apiKeyRegistry: {},
+};
+const voiceCloneApiConfigState = {
+    loaded: false,
+    loadingPromise: null,
+    cfg: null,
+    isLocalTts: false,
+};
+
+function notifyApiSettingsKeyBookFocus(win) {
+    if (!win) return;
+    [250, 800, 1500].forEach(delay => {
+        setTimeout(() => {
+            try {
+                win.postMessage({ type: 'focus_api_key_book' }, window.location.origin);
+            } catch (_) { }
+        }, delay);
+    });
+}
 
 // 打开API设置页（带弹窗拦截回退）
-function openApiSettings() {
+function openApiSettings(options = {}) {
+    const focusKeyBook = !!(options && options.focusKeyBook);
+    const url = focusKeyBook ? '/api_key?focus=key_book' : '/api_key';
     const features = 'width=820,height=700,scrollbars=yes,resizable=yes';
     const win = typeof window.openOrFocusWindow === 'function'
-        ? window.openOrFocusWindow('/api_key', 'apiSettings', features)
-        : window.open('/api_key', 'apiSettings', features);
+        ? window.openOrFocusWindow(url, 'apiSettings', features)
+        : window.open(url, 'apiSettings', features);
     if (win) {
         const modal = document.getElementById('noApiModal');
         if (modal) modal.style.display = 'none';
+        if (focusKeyBook) {
+            notifyApiSettingsKeyBookFocus(win);
+        }
     } else {
-        location.href = '/api_key';
+        location.href = url;
     }
+}
+
+function openApiSettingsKeyBook() {
+    openApiSettings({ focusKeyBook: true });
 }
 
 // 安全地解析 fetch 响应：当后端/反向代理返回 HTML（404/502/504/网关错误等）时
@@ -331,14 +377,212 @@ function isMiniMaxProvider(provider) {
     return provider === 'minimax' || provider === 'minimax_intl';
 }
 
+function getVoiceCloneProviderKeyField(provider) {
+    const entry = VOICE_CLONE_PROVIDER_KEY_FIELDS.find(([providerKey]) => providerKey === provider);
+    return entry ? entry[1] : '';
+}
+
+function getVoiceCloneProviderRegistryKey(provider) {
+    return VOICE_CLONE_PROVIDER_REGISTRY_KEYS[provider] || provider;
+}
+
+function isLocalVoiceCloneServerConfigured(cfg) {
+    if (!cfg || typeof cfg !== 'object') return false;
+    const ttsUrl = String(cfg.ttsModelUrl || '');
+    return !!(cfg.enableCustomApi && (ttsUrl.startsWith('ws://') || ttsUrl.startsWith('wss://')));
+}
+
+async function loadVoiceCloneApiConfigState(options = {}) {
+    const force = !!(options && options.force);
+    if (voiceCloneApiConfigState.loaded && !force) {
+        return voiceCloneApiConfigState;
+    }
+    if (voiceCloneApiConfigState.loadingPromise && !force) {
+        return voiceCloneApiConfigState.loadingPromise;
+    }
+
+    voiceCloneApiConfigState.loadingPromise = (async () => {
+        const resp = await fetch('/api/config/core_api');
+        if (!resp.ok) {
+            throw new Error(`API returned ${resp.status}`);
+        }
+        const cfg = await resp.json();
+        if (!cfg || cfg.success === false) {
+            throw new Error((cfg && cfg.error) || 'core_api config unavailable');
+        }
+        voiceCloneApiConfigState.cfg = cfg;
+        voiceCloneApiConfigState.isLocalTts = isLocalVoiceCloneServerConfigured(cfg);
+        voiceCloneApiConfigState.loaded = true;
+        return voiceCloneApiConfigState;
+    })().catch(error => {
+        console.warn('检查克隆API Key失败:', error);
+        voiceCloneApiConfigState.cfg = null;
+        voiceCloneApiConfigState.isLocalTts = false;
+        voiceCloneApiConfigState.loaded = true;
+        return voiceCloneApiConfigState;
+    }).finally(() => {
+        voiceCloneApiConfigState.loadingPromise = null;
+    });
+
+    return voiceCloneApiConfigState.loadingPromise;
+}
+
+function hasVoiceCloneProviderApi(provider) {
+    if (voiceCloneApiConfigState.isLocalTts) return true;
+    const cfg = voiceCloneApiConfigState.cfg;
+    const fieldName = getVoiceCloneProviderKeyField(provider);
+    return !!(cfg && fieldName && cfg[fieldName]);
+}
+
+async function checkVoiceCloneMainlandChinaUser() {
+    try {
+        const response = await fetch('/api/config/steam_language', {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        if (!response.ok) return false;
+        const data = await response.json();
+        return data && data.is_mainland_china === true;
+    } catch (error) {
+        console.warn('声音克隆区域检测失败，使用默认显示策略:', error);
+        return false;
+    }
+}
+
+async function loadVoiceCloneProviderRestrictionState() {
+    if (voiceCloneProviderRestrictionState.loaded) {
+        return voiceCloneProviderRestrictionState;
+    }
+    if (voiceCloneProviderRestrictionState.loadingPromise) {
+        return voiceCloneProviderRestrictionState.loadingPromise;
+    }
+
+    voiceCloneProviderRestrictionState.loadingPromise = (async () => {
+        const [isMainlandChinaUser, providersResponse] = await Promise.all([
+            checkVoiceCloneMainlandChinaUser(),
+            fetch('/api/config/api_providers')
+        ]);
+        let apiKeyRegistry = {};
+        if (providersResponse.ok) {
+            const providersData = await providersResponse.json();
+            if (providersData && providersData.success) {
+                apiKeyRegistry = providersData.api_key_registry || {};
+            }
+        }
+        voiceCloneProviderRestrictionState.isMainlandChinaUser = !!isMainlandChinaUser;
+        voiceCloneProviderRestrictionState.apiKeyRegistry = apiKeyRegistry;
+        voiceCloneProviderRestrictionState.loaded = true;
+        return voiceCloneProviderRestrictionState;
+    })().catch(error => {
+        console.warn('声音克隆服务商地区配置加载失败，使用默认显示策略:', error);
+        voiceCloneProviderRestrictionState.loaded = true;
+        return voiceCloneProviderRestrictionState;
+    }).finally(() => {
+        voiceCloneProviderRestrictionState.loadingPromise = null;
+    });
+
+    return voiceCloneProviderRestrictionState.loadingPromise;
+}
+
+function isVoiceCloneProviderRestricted(provider) {
+    if (!voiceCloneProviderRestrictionState.isMainlandChinaUser) return false;
+    const registryKey = getVoiceCloneProviderRegistryKey(provider);
+    const entry = voiceCloneProviderRestrictionState.apiKeyRegistry[registryKey];
+    return !!(entry && entry.restricted === true);
+}
+
+function getFirstAvailableVoiceCloneProviderValue(providerSelect) {
+    if (!providerSelect) return '';
+    const options = Array.from(providerSelect.options || []);
+    const availableOption = options.find(option => !option.disabled && !option.hidden && option.style.display !== 'none');
+    return availableOption ? availableOption.value : '';
+}
+
+function applyVoiceCloneProviderRestrictions(providerSelect) {
+    if (!providerSelect) return false;
+    const previousValue = providerSelect.value;
+    Array.from(providerSelect.options || []).forEach(option => {
+        const restricted = isVoiceCloneProviderRestricted(option.value);
+        option.disabled = restricted;
+        option.hidden = restricted;
+        option.style.display = restricted ? 'none' : '';
+    });
+
+    const selectedOption = providerSelect.options[providerSelect.selectedIndex];
+    if (selectedOption && !selectedOption.disabled && !selectedOption.hidden && selectedOption.style.display !== 'none') {
+        return false;
+    }
+
+    const fallbackValue = getFirstAvailableVoiceCloneProviderValue(providerSelect);
+    if (fallbackValue) {
+        providerSelect.value = fallbackValue;
+    }
+    return providerSelect.value !== previousValue;
+}
+
+async function initVoiceCloneProviderRestrictions() {
+    await loadVoiceCloneProviderRestrictionState();
+    const providerSelect = document.getElementById('voiceProvider');
+    const changed = applyVoiceCloneProviderRestrictions(providerSelect);
+    if (changed && providerSelect) {
+        suppressProviderTouchedTracking = true;
+        providerSelect.dispatchEvent(new Event('change'));
+        suppressProviderTouchedTracking = false;
+    }
+    return voiceCloneProviderRestrictionState;
+}
+
 function getPreferredCloneProviderFromConfig(cfg) {
     if (!cfg || typeof cfg !== 'object') return '';
-    if (cfg.assistApiKeyQwen) return 'cosyvoice';
-    if (cfg.assistApiKeyQwenIntl) return 'cosyvoice_intl';
-    if (cfg.assistApiKeyMinimax) return 'minimax';
-    if (cfg.assistApiKeyMinimaxIntl) return 'minimax_intl';
-    if (cfg.assistApiKeyElevenlabs) return 'elevenlabs';
+    for (const [provider, fieldName] of VOICE_CLONE_PROVIDER_KEY_FIELDS) {
+        if (cfg[fieldName] && !isVoiceCloneProviderRestricted(provider)) {
+            return provider;
+        }
+    }
     return '';
+}
+
+function hasUsableCloneApiFromConfig(cfg, isLocalTts) {
+    if (isLocalTts) return true;
+    if (!cfg || typeof cfg !== 'object') return false;
+    return VOICE_CLONE_PROVIDER_KEY_FIELDS.some(([provider, fieldName]) => (
+        !!cfg[fieldName] && !isVoiceCloneProviderRestricted(provider)
+    ));
+}
+
+function updateVoiceCloneProviderNoticeText(noticeDiv, provider) {
+    const span = noticeDiv ? noticeDiv.querySelector('span') : null;
+    if (!span) return;
+
+    const keyMap = {
+        'cosyvoice_intl': 'voice.alibabaIntlApiRequired',
+        'minimax': 'voice.minimaxApiRequired',
+        'minimax_intl': 'voice.minimaxIntlApiRequired',
+        'elevenlabs': 'voice.elevenlabsApiRequired',
+    };
+    const fallbackMap = {
+        'cosyvoice_intl': '请先在 API 设置中填写阿里国际版 API Key',
+        'elevenlabs': '请先在 API 设置中填写 ElevenLabs API Key',
+    };
+    const i18nKey = keyMap[provider] || 'voice.alibabaApiRequired';
+    span.setAttribute('data-i18n', i18nKey);
+    if (window.t) {
+        const translated = window.t(i18nKey);
+        span.textContent = (translated && translated !== i18nKey) ? translated : (fallbackMap[provider] || translated);
+    } else if (fallbackMap[provider]) {
+        span.textContent = fallbackMap[provider];
+    }
+    // 若 window.t 不可用，保留 HTML 中的原始文本，不覆盖
+}
+
+async function refreshVoiceCloneProviderNotice(providerSelect, noticeDiv) {
+    if (!providerSelect || !noticeDiv) return;
+    updateVoiceCloneProviderNoticeText(noticeDiv, providerSelect.value);
+    noticeDiv.style.display = 'none';
+    await loadVoiceCloneApiConfigState();
+    const provider = providerSelect.value || 'cosyvoice';
+    updateVoiceCloneProviderNoticeText(noticeDiv, provider);
+    noticeDiv.style.display = hasVoiceCloneProviderApi(provider) ? 'none' : '';
 }
 
 function sanitizeMiniMaxPrefix(prefix) {
@@ -399,6 +643,7 @@ function applyWorkshopProviderHint(providerHint) {
     const providerSelect = document.getElementById('voiceProvider');
     if (!providerSelect || !providerHint) return;
     if (providerTouchedByUser) return;
+    if (isVoiceCloneProviderRestricted(providerHint)) return;
     if (providerSelect.value !== 'cosyvoice') return;
 
     suppressProviderTouchedTracking = true;
@@ -457,6 +702,9 @@ function updateFileDisplay() {
 
 // 监听文件选择变化
 document.addEventListener('DOMContentLoaded', () => {
+    initVoiceCloneProviderRestrictions().catch(error => {
+        console.warn('初始化声音克隆服务商地区过滤失败:', error);
+    });
     const audioFile = document.getElementById('audioFile');
     if (audioFile) {
         audioFile.addEventListener('change', updateFileDisplay);
@@ -622,34 +870,28 @@ if (window.i18n && window.i18n.isInitialized) {
         }
     }
 
-    // 检查是否已设置可用于克隆的API Key
-    try {
-        const resp = await fetch('/api/config/core_api');
-        if (resp.ok) {
-            const cfg = await resp.json();
-            if (!cfg || cfg.success === false) {
-                console.warn('获取核心配置失败:', cfg?.error);
-            } else {
-                // 本地TTS服务器(ws/wss协议)不需要云端API Key
-                const ttsUrl = cfg.ttsModelUrl || '';
-                const isLocalTts = cfg.enableCustomApi && (ttsUrl.startsWith('ws://') || ttsUrl.startsWith('wss://'));
-                const hasCloneApi = isLocalTts || !!(cfg.assistApiKeyQwen || cfg.assistApiKeyQwenIntl || cfg.assistApiKeyMinimax || cfg.assistApiKeyMinimaxIntl || cfg.assistApiKeyElevenlabs);
-                const preferredProvider = getPreferredCloneProviderFromConfig(cfg);
-                const providerSelect = document.getElementById('voiceProvider');
-                if (!providerTouchedByUser && preferredProvider && providerSelect && providerSelect.value === 'cosyvoice') {
-                    suppressProviderTouchedTracking = true;
-                    providerSelect.value = preferredProvider;
-                    providerSelect.dispatchEvent(new Event('change'));
-                    suppressProviderTouchedTracking = false;
-                }
-                if (!hasCloneApi) {
-                    const modal = document.getElementById('noApiModal');
-                    if (modal) modal.style.display = 'flex';
-                }
-            }
+    await initVoiceCloneProviderRestrictions();
+
+    const apiConfigState = await loadVoiceCloneApiConfigState({ force: true });
+    const cfg = apiConfigState.cfg;
+    if (cfg) {
+        const hasCloneApi = hasUsableCloneApiFromConfig(cfg, apiConfigState.isLocalTts);
+        const preferredProvider = getPreferredCloneProviderFromConfig(cfg);
+        const providerSelect = document.getElementById('voiceProvider');
+        if (!providerTouchedByUser && preferredProvider && providerSelect && providerSelect.value === 'cosyvoice') {
+            suppressProviderTouchedTracking = true;
+            providerSelect.value = preferredProvider;
+            providerSelect.dispatchEvent(new Event('change'));
+            suppressProviderTouchedTracking = false;
         }
-    } catch (e) {
-        console.warn('检查克隆API Key失败:', e);
+        if (!hasCloneApi) {
+            const modal = document.getElementById('noApiModal');
+            if (modal) modal.style.display = 'flex';
+        }
+        await refreshVoiceCloneProviderNotice(
+            document.getElementById('voiceProvider'),
+            document.getElementById('provider-notice')
+        );
     }
 
     await initWorkshopVoiceReference();
@@ -662,37 +904,22 @@ document.addEventListener('DOMContentLoaded', function initProviderSwitch() {
     const prefixInput = document.getElementById('prefix');
     if (!providerSelect || !noticeDiv) return;
 
-    function updateNotice() {
-        const provider = providerSelect.value;
-        const span = noticeDiv.querySelector('span');
-        if (!span) return;
-
-        const keyMap = {
-            'cosyvoice_intl': 'voice.alibabaIntlApiRequired',
-            'minimax': 'voice.minimaxApiRequired',
-            'minimax_intl': 'voice.minimaxIntlApiRequired',
-            'elevenlabs': 'voice.elevenlabsApiRequired',
-        };
-        const fallbackMap = {
-            'cosyvoice_intl': '请先在 API 设置中填写阿里国际版 API Key',
-            'elevenlabs': '请先在 API 设置中填写 ElevenLabs API Key',
-        };
-        const i18nKey = keyMap[provider] || 'voice.alibabaApiRequired';
-        span.setAttribute('data-i18n', i18nKey);
-        if (window.t) {
-            const translated = window.t(i18nKey);
-            span.textContent = (translated && translated !== i18nKey) ? translated : (fallbackMap[provider] || translated);
-        } else if (fallbackMap[provider]) {
-            span.textContent = fallbackMap[provider];
+    noticeDiv.setAttribute('role', 'button');
+    noticeDiv.setAttribute('tabindex', '0');
+    noticeDiv.style.cursor = 'pointer';
+    noticeDiv.addEventListener('click', openApiSettingsKeyBook);
+    noticeDiv.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            openApiSettingsKeyBook();
         }
-        // 若 window.t 不可用，保留 HTML 中的原始文本，不覆盖
-    }
+    });
 
     providerSelect.addEventListener('change', () => {
         if (!suppressProviderTouchedTracking) {
             providerTouchedByUser = true;
         }
-        updateNotice();
+        refreshVoiceCloneProviderNotice(providerSelect, noticeDiv);
         normalizePrefixInputForProvider();
     });
     if (prefixInput) {
@@ -700,7 +927,7 @@ document.addEventListener('DOMContentLoaded', function initProviderSwitch() {
             normalizePrefixInputForProvider();
         });
     }
-    updateNotice();
+    refreshVoiceCloneProviderNotice(providerSelect, noticeDiv);
     normalizePrefixInputForProvider();
 });
 
@@ -1044,6 +1271,12 @@ window.addEventListener('message', function (event) {
     if (event.data.type === 'api_key_changed') {
         // API Key已更改，可以在这里添加其他需要的处理逻辑
         console.log('API Key已更改，音色注册页面已收到通知');
+        loadVoiceCloneApiConfigState({ force: true }).then(() => {
+            refreshVoiceCloneProviderNotice(
+                document.getElementById('voiceProvider'),
+                document.getElementById('provider-notice')
+            );
+        });
         // 刷新音色列表
         loadVoices();
     }

--- a/static/js/voice_clone.js
+++ b/static/js/voice_clone.js
@@ -33,6 +33,54 @@ const voiceCloneApiConfigState = {
     cfg: null,
     isLocalTts: false,
 };
+const VOICE_CLONE_LOADER_FETCH_TIMEOUT_MS = 5000;
+const VOICE_CLONE_LOADER_FETCH_ATTEMPTS = 3;
+const VOICE_CLONE_LOADER_FETCH_BACKOFF_MS = 250;
+
+function sleepVoiceCloneLoaderRetry(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchVoiceCloneLoaderResponse(url, options = {}) {
+    let lastError = null;
+    for (let attempt = 1; attempt <= VOICE_CLONE_LOADER_FETCH_ATTEMPTS; attempt += 1) {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), VOICE_CLONE_LOADER_FETCH_TIMEOUT_MS);
+        try {
+            const response = await fetch(url, {
+                ...options,
+                signal: controller.signal,
+            });
+            if (response.ok || response.status < 500 || attempt >= VOICE_CLONE_LOADER_FETCH_ATTEMPTS) {
+                return response;
+            }
+            lastError = new Error(`API returned ${response.status}`);
+        } catch (error) {
+            lastError = error;
+            if (attempt >= VOICE_CLONE_LOADER_FETCH_ATTEMPTS) break;
+        } finally {
+            clearTimeout(timeoutId);
+        }
+        await sleepVoiceCloneLoaderRetry(VOICE_CLONE_LOADER_FETCH_BACKOFF_MS * attempt);
+    }
+    throw lastError || new Error('请求失败');
+}
+
+async function fetchVoiceCloneLoaderJson(url, options = {}) {
+    const response = await fetchVoiceCloneLoaderResponse(url, options);
+    let data = null;
+    try {
+        data = await response.json();
+    } catch (error) {
+        if (response.ok) {
+            throw error;
+        }
+    }
+    if (!response.ok) {
+        throw new Error(`API returned ${response.status}`);
+    }
+    return data;
+}
 
 function notifyApiSettingsKeyBookFocus(win) {
     if (!win) return;
@@ -268,7 +316,7 @@ async function getCurrentCharacterVoiceId() {
     const lanlanName = (lanlanInput && lanlanInput.value ? lanlanInput.value : '').trim();
     if (!lanlanName) return '';
 
-    const resp = await fetch('/api/characters?language=zh-CN', { cache: 'no-store' });
+    const resp = await fetchVoiceCloneLoaderResponse('/api/characters?language=zh-CN', { cache: 'no-store' });
     const { data, nonJson, text } = await safeReadResponse(resp);
     if (!resp.ok) {
         if (data && (data.error || data.detail)) {
@@ -402,11 +450,7 @@ async function loadVoiceCloneApiConfigState(options = {}) {
     }
 
     voiceCloneApiConfigState.loadingPromise = (async () => {
-        const resp = await fetch('/api/config/core_api');
-        if (!resp.ok) {
-            throw new Error(`API returned ${resp.status}`);
-        }
-        const cfg = await resp.json();
+        const cfg = await fetchVoiceCloneLoaderJson('/api/config/core_api');
         if (!cfg || cfg.success === false) {
             throw new Error((cfg && cfg.error) || 'core_api config unavailable');
         }
@@ -414,17 +458,23 @@ async function loadVoiceCloneApiConfigState(options = {}) {
         voiceCloneApiConfigState.isLocalTts = isLocalVoiceCloneServerConfigured(cfg);
         voiceCloneApiConfigState.loaded = true;
         return voiceCloneApiConfigState;
-    })().catch(error => {
-        console.warn('检查克隆API Key失败:', error);
-        voiceCloneApiConfigState.cfg = null;
-        voiceCloneApiConfigState.isLocalTts = false;
-        voiceCloneApiConfigState.loaded = true;
-        return voiceCloneApiConfigState;
     }).finally(() => {
         voiceCloneApiConfigState.loadingPromise = null;
     });
 
     return voiceCloneApiConfigState.loadingPromise;
+}
+
+async function ensureVoiceCloneApiConfigState(options = {}) {
+    try {
+        await loadVoiceCloneApiConfigState(options);
+    } catch (error) {
+        console.warn('检查克隆API Key失败:', error);
+        voiceCloneApiConfigState.cfg = null;
+        voiceCloneApiConfigState.isLocalTts = false;
+        voiceCloneApiConfigState.loaded = false;
+    }
+    return voiceCloneApiConfigState;
 }
 
 function hasVoiceCloneProviderApi(provider) {
@@ -435,18 +485,11 @@ function hasVoiceCloneProviderApi(provider) {
 }
 
 async function checkVoiceCloneMainlandChinaUser() {
-    try {
-        const response = await fetch('/api/config/steam_language', {
-            method: 'GET',
-            headers: { 'Content-Type': 'application/json' }
-        });
-        if (!response.ok) return false;
-        const data = await response.json();
-        return data && data.is_mainland_china === true;
-    } catch (error) {
-        console.warn('声音克隆区域检测失败，使用默认显示策略:', error);
-        return false;
-    }
+    const data = await fetchVoiceCloneLoaderJson('/api/config/steam_language', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' }
+    });
+    return data && data.is_mainland_china === true;
 }
 
 async function loadVoiceCloneProviderRestrictionState() {
@@ -458,23 +501,18 @@ async function loadVoiceCloneProviderRestrictionState() {
     }
 
     voiceCloneProviderRestrictionState.loadingPromise = (async () => {
-        const [isMainlandChinaUser, providersResponse] = await Promise.all([
+        const [isMainlandChinaUser, providersData] = await Promise.all([
             checkVoiceCloneMainlandChinaUser(),
-            fetch('/api/config/api_providers')
+            fetchVoiceCloneLoaderJson('/api/config/api_providers')
         ]);
         let apiKeyRegistry = {};
-        if (providersResponse.ok) {
-            const providersData = await providersResponse.json();
-            if (providersData && providersData.success) {
-                apiKeyRegistry = providersData.api_key_registry || {};
-            }
+        if (providersData && providersData.success) {
+            apiKeyRegistry = providersData.api_key_registry || {};
+        } else {
+            throw new Error('api_providers config unavailable');
         }
         voiceCloneProviderRestrictionState.isMainlandChinaUser = !!isMainlandChinaUser;
         voiceCloneProviderRestrictionState.apiKeyRegistry = apiKeyRegistry;
-        voiceCloneProviderRestrictionState.loaded = true;
-        return voiceCloneProviderRestrictionState;
-    })().catch(error => {
-        console.warn('声音克隆服务商地区配置加载失败，使用默认显示策略:', error);
         voiceCloneProviderRestrictionState.loaded = true;
         return voiceCloneProviderRestrictionState;
     }).finally(() => {
@@ -482,6 +520,15 @@ async function loadVoiceCloneProviderRestrictionState() {
     });
 
     return voiceCloneProviderRestrictionState.loadingPromise;
+}
+
+async function ensureVoiceCloneProviderRestrictionsLoaded() {
+    try {
+        await loadVoiceCloneProviderRestrictionState();
+    } catch (error) {
+        console.warn('声音克隆服务商地区配置加载失败，使用默认显示策略:', error);
+    }
+    return voiceCloneProviderRestrictionState;
 }
 
 function isVoiceCloneProviderRestricted(provider) {
@@ -521,7 +568,7 @@ function applyVoiceCloneProviderRestrictions(providerSelect) {
 }
 
 async function initVoiceCloneProviderRestrictions() {
-    await loadVoiceCloneProviderRestrictionState();
+    await ensureVoiceCloneProviderRestrictionsLoaded();
     const providerSelect = document.getElementById('voiceProvider');
     const changed = applyVoiceCloneProviderRestrictions(providerSelect);
     if (changed && providerSelect) {
@@ -579,7 +626,7 @@ async function refreshVoiceCloneProviderNotice(providerSelect, noticeDiv) {
     if (!providerSelect || !noticeDiv) return;
     updateVoiceCloneProviderNoticeText(noticeDiv, providerSelect.value);
     noticeDiv.style.display = 'none';
-    await loadVoiceCloneApiConfigState();
+    await ensureVoiceCloneApiConfigState();
     const provider = providerSelect.value || 'cosyvoice';
     updateVoiceCloneProviderNoticeText(noticeDiv, provider);
     noticeDiv.style.display = hasVoiceCloneProviderApi(provider) ? 'none' : '';
@@ -845,11 +892,7 @@ if (window.i18n && window.i18n.isInitialized) {
 
         // 如果 URL 中没有，从 API 获取
         if (!lanlanName) {
-            const response = await fetch('/api/config/page_config');
-            if (!response.ok) {
-                throw new Error(`API returned ${response.status}`);
-            }
-            const data = await response.json();
+            const data = await fetchVoiceCloneLoaderJson('/api/config/page_config');
             if (data.success) {
                 lanlanName = data.lanlan_name || "";
             }
@@ -872,7 +915,7 @@ if (window.i18n && window.i18n.isInitialized) {
 
     await initVoiceCloneProviderRestrictions();
 
-    const apiConfigState = await loadVoiceCloneApiConfigState({ force: true });
+    const apiConfigState = await ensureVoiceCloneApiConfigState({ force: true });
     const cfg = apiConfigState.cfg;
     if (cfg) {
         const hasCloneApi = hasUsableCloneApiFromConfig(cfg, apiConfigState.isLocalTts);
@@ -992,7 +1035,7 @@ async function initWorkshopVoiceReference() {
     setWorkshopVoiceSourceStatus(t('voice.workshopSourceLoading', 'Loading workshop reference voice...'));
 
     try {
-        const manifestResponse = await fetch(`/api/steam/workshop/voice-reference/${encodeURIComponent(workshopItemId)}`);
+        const manifestResponse = await fetchVoiceCloneLoaderResponse(`/api/steam/workshop/voice-reference/${encodeURIComponent(workshopItemId)}`);
         const manifestData = await manifestResponse.json();
         if (!manifestResponse.ok) {
             throw new Error(manifestData.error || `HTTP ${manifestResponse.status}`);
@@ -1001,7 +1044,7 @@ async function initWorkshopVoiceReference() {
             throw new Error(t('voice.workshopSourceUnavailable', 'This workshop item has no available reference voice.'));
         }
 
-        const audioResponse = await fetch(`/api/steam/workshop/voice-reference/${encodeURIComponent(workshopItemId)}/audio`);
+        const audioResponse = await fetchVoiceCloneLoaderResponse(`/api/steam/workshop/voice-reference/${encodeURIComponent(workshopItemId)}/audio`);
         if (!audioResponse.ok) {
             const errorData = await audioResponse.json().catch(() => ({}));
             throw new Error(errorData.error || `HTTP ${audioResponse.status}`);
@@ -1066,18 +1109,22 @@ function setFormDisabled(disabled) {
     }
 }
 
-function registerVoice() {
+async function registerVoice() {
     const fileInput = document.getElementById('audioFile');
     const directLinkUrl = document.getElementById('directLinkUrl');
     const refLanguage = document.getElementById('refLanguage').value;
     const resultDiv = document.getElementById('result');
-    const effectiveAudioFile = getEffectiveAudioFile();
-    const provider = (document.getElementById('voiceProvider') || {}).value || 'cosyvoice';
-    const prefix = normalizePrefixInputForProvider();
 
     // 清空现有内容并重置类名
     resultDiv.textContent = '';
     resultDiv.className = 'result';
+
+    const effectiveAudioFile = getEffectiveAudioFile();
+    const providerSelect = document.getElementById('voiceProvider');
+    await ensureVoiceCloneProviderRestrictionsLoaded();
+    applyVoiceCloneProviderRestrictions(providerSelect);
+    const provider = (providerSelect || {}).value || 'cosyvoice';
+    const prefix = normalizePrefixInputForProvider();
 
     // 根据克隆方式验证输入
     if (currentCloneMethod === 'file') {
@@ -1271,7 +1318,7 @@ window.addEventListener('message', function (event) {
     if (event.data.type === 'api_key_changed') {
         // API Key已更改，可以在这里添加其他需要的处理逻辑
         console.log('API Key已更改，音色注册页面已收到通知');
-        loadVoiceCloneApiConfigState({ force: true }).then(() => {
+        ensureVoiceCloneApiConfigState({ force: true }).then(() => {
             refreshVoiceCloneProviderNotice(
                 document.getElementById('voiceProvider'),
                 document.getElementById('provider-notice')
@@ -1314,7 +1361,7 @@ async function playPreview(voiceId, btn) {
 
         if (!audioSrc) {
             // 如果本地没有缓存，则从服务器获取
-            const response = await fetch(
+            const response = await fetchVoiceCloneLoaderResponse(
                 `/api/characters/voice_preview?voice_id=${encodeURIComponent(voiceId)}&language=${encodeURIComponent(previewLanguage)}`
             );
             const { data, nonJson, text } = await safeReadResponse(response);
@@ -1392,7 +1439,7 @@ async function loadVoices() {
             console.warn('获取当前角色音色失败:', error);
             return '';
         });
-        const response = await fetch('/api/characters/voices');
+        const response = await fetchVoiceCloneLoaderResponse('/api/characters/voices');
         const { data, nonJson, text } = await safeReadResponse(response);
         if (!response.ok) {
             if (data && (data.error || data.detail)) {

--- a/templates/voice_clone.html
+++ b/templates/voice_clone.html
@@ -46,7 +46,7 @@
                         <option value="elevenlabs" data-i18n="voice.provider.elevenlabs">ElevenLabs</option>
                     </select>
                 </div>
-                <div id="provider-notice" class="alibaba-api-notice">
+                <div id="provider-notice" class="alibaba-api-notice" style="display: none;">
                     <span data-i18n="voice.alibabaApiRequired">此功能只支持特定语音模型，请在API密钥设置页中保存对应API Key（不要求启用辅助API）或配置本地语音服务器</span>
                 </div>
                 <div id="workshopVoiceSource" class="workshop-source-card" style="display: none;">

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -413,7 +413,16 @@ class TestProviderExclusion:
         data = get_config()
         registry = data.get('api_key_registry', {})
 
-        expected_restricted = {'openai', 'gemini', 'grok', 'claude', 'openrouter', 'elevenlabs'}
+        expected_restricted = {
+            'openai',
+            'gemini',
+            'grok',
+            'claude',
+            'openrouter',
+            'elevenlabs',
+            'qwen_intl',
+            'minimax_intl',
+        }
         for pk, entry in registry.items():
             if pk in expected_restricted:
                 assert entry.get('restricted') is True, \


### PR DESCRIPTION
…性。声音注册页的黄色 API 提示改为仅在当前克隆服务商缺少对应 Key 时显示，并支持点击后打开 API 设置页，自动展开并滚动到 API 管理簿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 通过链接/参数或窗口消息可自动定位并展开 API 密钥管理界面（Key Book）。
* **改进**
  * 语音服务商选项会根据地区与配置自动过滤/回退，避免用户选择不可用或受限的服务商。
  * 语音克隆相关提示与设置在展示与刷新时更智能地响应可用性和密钥状态。
* **修复**
  * 默认隐藏部分提供商提示以避免误导用户。
* **测试**
  * 单元测试已更新以覆盖新增的受限提供商情况。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->