### PR TITLE
fix(linux): repair HUD input regions and workshop fallback semantics

### DIFF
--- a/main_routers/workshop_router.py
+++ b/main_routers/workshop_router.py
@@ -2229,6 +2229,53 @@ def _build_ugc_details_unsupported_item_response(steamworks, item_id_int: int, i
     }
 
 
+def _is_known_item_when_ugc_details_unsupported(steamworks, item_id_int: int, item_state: int) -> bool:
+    """Return whether an item is known without rich UGC details.
+
+    Linux wrappers can lack UGC details query methods, but that degradation must
+    not turn arbitrary numeric IDs into fake successful items. Only return a
+    partial response when Steam still exposes local/subscription state for the
+    item through the non-UGC-detail APIs.
+    """
+    known_state_bits = (
+        _ITEM_STATE_SUBSCRIBED
+        | _ITEM_STATE_INSTALLED
+        | _ITEM_STATE_NEEDS_UPDATE
+        | _ITEM_STATE_DOWNLOADING
+        | _ITEM_STATE_DOWNLOAD_PENDING
+    )
+    if item_state & known_state_bits:
+        return True
+
+    try:
+        subscribed_items = steamworks.Workshop.GetSubscribedItems()
+        parsed_subscribed_items = set()
+        for raw_item_id in subscribed_items or []:
+            try:
+                parsed_subscribed_items.add(int(raw_item_id))
+            except (TypeError, ValueError):
+                continue
+        if item_id_int in parsed_subscribed_items:
+            return True
+    except Exception as exc:
+        logger.debug(f"GetSubscribedItems fallback for {item_id_int} failed: {exc}")
+
+    folder = _safe_get_workshop_install_folder(steamworks, item_id_int)
+    if folder and os.path.isdir(folder):
+        return True
+
+    try:
+        download_info = steamworks.Workshop.GetItemDownloadInfo(item_id_int) or {}
+    except Exception as exc:
+        logger.debug(f"GetItemDownloadInfo({item_id_int}) fallback failed: {exc}")
+        download_info = {}
+    if isinstance(download_info, dict):
+        return int(download_info.get("total", 0) or 0) > 0
+    if isinstance(download_info, tuple) and len(download_info) >= 2:
+        return int(download_info[1] or 0) > 0
+    return False
+
+
 @router.get('/item/{item_id}/path')
 def get_workshop_item_path(item_id: str):
     """
@@ -2441,6 +2488,13 @@ async def get_workshop_item_details(item_id: str):
         try:
             ugc_results = await _query_ugc_details_batch(steamworks, [item_id_int], max_retries=2)
         except UnsupportedUGCDetailsError:
+            if not _is_known_item_when_ugc_details_unsupported(steamworks, item_id_int, item_state):
+                return JSONResponse({
+                    "success": False,
+                    "error": "获取物品详情失败，未找到物品",
+                    "detailsAvailable": False,
+                    "detailsUnavailableReason": "ugc_details_query_unsupported",
+                }, status_code=404)
             return _build_ugc_details_unsupported_item_response(steamworks, item_id_int, item_state)
         result = ugc_results.get(item_id_int)
         
@@ -4429,7 +4483,11 @@ def _publish_workshop_item(steamworks, title, description, content_folder, previ
                 # 增强的Steam连接状态验证
                 # 基础连接状态检查
                 is_steam_running = steamworks.IsSteamRunning()
-                is_overlay_enabled = steamworks.IsOverlayEnabled()
+                try:
+                    is_overlay_enabled = steamworks.IsOverlayEnabled()
+                except Exception as overlay_error:
+                    is_overlay_enabled = None
+                    logger.warning(f"Steam覆盖层启用状态检查不可用: {overlay_error}")
                 is_logged_on = steamworks.Users.LoggedOn()
                 steam_id = steamworks.Users.GetSteamID()
             
@@ -4440,7 +4498,10 @@ def _publish_workshop_item(steamworks, title, description, content_folder, previ
             
                 # 记录详细的连接状态
                 logger.info(f"Steam客户端运行状态: {is_steam_running}")
-                logger.info(f"Steam覆盖层启用状态: {is_overlay_enabled}")
+                logger.info(
+                    "Steam覆盖层启用状态: "
+                    + ("不可用" if is_overlay_enabled is None else str(is_overlay_enabled))
+                )
                 logger.info(f"用户登录状态: {is_logged_on}")
                 logger.info(f"用户SteamID: {steam_id}")
                 logger.info(f"应用ID {app_id} 安装状态: {app_owned}")

--- a/static/Jukebox.js
+++ b/static/Jukebox.js
@@ -3827,6 +3827,8 @@ window.Jukebox = {
     document.addEventListener('touchmove', onMouseMove, { passive: false });
     document.addEventListener('mouseup', onMouseUp);
     document.addEventListener('touchend', onMouseUp);
+    document.addEventListener('touchcancel', onMouseUp);
+    window.addEventListener('blur', onMouseUp);
 
     // 保存引用，方便 destroy 时清理
     Jukebox.State._dragCleanup = () => {
@@ -3834,6 +3836,8 @@ window.Jukebox = {
       document.removeEventListener('touchmove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
       document.removeEventListener('touchend', onMouseUp);
+      document.removeEventListener('touchcancel', onMouseUp);
+      window.removeEventListener('blur', onMouseUp);
       Jukebox.State.isDragging = false;
       document.body.classList.remove('jukebox-dragging');
     };
@@ -3932,6 +3936,7 @@ window.Jukebox = {
         document.removeEventListener('touchmove', onPointerMove);
         document.removeEventListener('mouseup', cleanup);
         document.removeEventListener('touchend', cleanup);
+        document.removeEventListener('touchcancel', cleanup);
         window.removeEventListener('blur', cleanup);
         Jukebox.State._resizeCleanup = null;
       };
@@ -3943,6 +3948,7 @@ window.Jukebox = {
       document.addEventListener('touchmove', onPointerMove, { passive: false });
       document.addEventListener('mouseup', cleanup);
       document.addEventListener('touchend', cleanup);
+      document.addEventListener('touchcancel', cleanup);
       // 窗口失焦时清理，防止监听泄漏
       window.addEventListener('blur', cleanup);
     };
@@ -4015,12 +4021,16 @@ window.Jukebox = {
     document.addEventListener('touchmove', onMouseMove, { passive: false });
     document.addEventListener('mouseup', onMouseUp);
     document.addEventListener('touchend', onMouseUp);
+    document.addEventListener('touchcancel', onMouseUp);
+    window.addEventListener('blur', onMouseUp);
     
     Jukebox.SongActionManager._panelDragCleanup = () => {
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('touchmove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
       document.removeEventListener('touchend', onMouseUp);
+      document.removeEventListener('touchcancel', onMouseUp);
+      window.removeEventListener('blur', onMouseUp);
       isDragging = false;
       document.body.classList.remove('sam-panel-dragging');
     };

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -6,6 +6,12 @@
 window.AgentHUD = window.AgentHUD || {};
 
 var PLUGIN_DASHBOARD_REDIRECT_URL = '/api/agent/user_plugin/dashboard';
+const STANDALONE_HUD_POSITION = Object.freeze({
+    top: '0',
+    left: '0',
+    right: 'auto',
+    transform: 'none'
+});
 
 function appendPluginDashboardOpenerOrigin(url) {
     const target = new URL(url, document.baseURI || window.location.href);
@@ -387,7 +393,7 @@ window.AgentHUD.createAgentTaskHUD = function () {
     let position = { top: '50%', right: '20px', transform: 'translateY(-50%)' };
 
     if (standaloneAgentHud) {
-        position = { top: '0', left: '0', right: 'auto', transform: 'none' };
+        position = STANDALONE_HUD_POSITION;
     }
 
     if (!standaloneAgentHud && savedPos) {
@@ -701,10 +707,10 @@ window.AgentHUD.showAgentTaskHUD = function () {
     const standaloneAgentHud = isStandaloneAgentHudPage();
     const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');
     if (standaloneAgentHud) {
-        hud.style.left = '0';
-        hud.style.top = '0';
-        hud.style.right = 'auto';
-        hud.style.transform = 'none';
+        hud.style.left = STANDALONE_HUD_POSITION.left;
+        hud.style.top = STANDALONE_HUD_POSITION.top;
+        hud.style.right = STANDALONE_HUD_POSITION.right;
+        hud.style.transform = STANDALONE_HUD_POSITION.transform;
     } else if (savedPos) {
         try {
             const parsed = JSON.parse(savedPos);
@@ -738,10 +744,10 @@ window.AgentHUD.hideAgentTaskHUD = function () {
     const standaloneAgentHud = isStandaloneAgentHudPage();
     const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');
     if (standaloneAgentHud) {
-        hud.style.left = '0';
-        hud.style.top = '0';
-        hud.style.right = 'auto';
-        hud.style.transform = 'none';
+        hud.style.left = STANDALONE_HUD_POSITION.left;
+        hud.style.top = STANDALONE_HUD_POSITION.top;
+        hud.style.right = STANDALONE_HUD_POSITION.right;
+        hud.style.transform = STANDALONE_HUD_POSITION.transform;
     } else if (!savedPos) {
         hud.style.transform = 'translateY(-50%) translateX(20px)';
     }

--- a/static/common-ui-hud.js
+++ b/static/common-ui-hud.js
@@ -24,6 +24,25 @@ function appendCacheBuster(url) {
     return `${url}${separator}v=${Date.now()}`;
 }
 
+function isStandaloneAgentHudPage() {
+    try {
+        return !!(document.body && document.body.classList.contains('agent-hud-standalone-page'));
+    } catch (_) {
+        return false;
+    }
+}
+
+function setAgentHudDraggingState(active) {
+    try {
+        if (document.body) {
+            document.body.classList.toggle('neko-agent-hud-dragging', !!active);
+        }
+        window.dispatchEvent(new CustomEvent('neko-agent-hud-drag-state', {
+            detail: { dragging: !!active }
+        }));
+    } catch (_) {}
+}
+
 /**
  * 精简 AI 生成的冗长任务描述为用户友好的短文本
  * 例: "设置一个15分钟后的一次性提醒，内容为'起来活动'" → "15分钟后 起来活动"
@@ -363,10 +382,15 @@ window.AgentHUD.createAgentTaskHUD = function () {
     hud.id = 'agent-task-hud';
 
     // 获取保存的位置或使用默认位置
-    const savedPos = localStorage.getItem('agent-task-hud-position');
+    const standaloneAgentHud = isStandaloneAgentHudPage();
+    const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');
     let position = { top: '50%', right: '20px', transform: 'translateY(-50%)' };
 
-    if (savedPos) {
+    if (standaloneAgentHud) {
+        position = { top: '0', left: '0', right: 'auto', transform: 'none' };
+    }
+
+    if (!standaloneAgentHud && savedPos) {
         try {
             const parsed = JSON.parse(savedPos);
             position = {
@@ -382,8 +406,9 @@ window.AgentHUD.createAgentTaskHUD = function () {
 
     Object.assign(hud.style, {
         position: 'fixed',
-        width: '320px',
-        maxHeight: '60vh',
+        width: standaloneAgentHud ? '100%' : '320px',
+        maxHeight: standaloneAgentHud ? '100vh' : '60vh',
+        height: standaloneAgentHud ? '100%' : '',
         background: 'var(--neko-popup-bg, rgba(255, 255, 255, 0.65))',
         backdropFilter: 'saturate(180%) blur(20px)',
         WebkitBackdropFilter: 'saturate(180%) blur(20px)',
@@ -401,7 +426,7 @@ window.AgentHUD.createAgentTaskHUD = function () {
         pointerEvents: 'auto',
         overflowY: 'auto',
         transition: 'opacity 0.4s cubic-bezier(0.16, 1, 0.3, 1), transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), box-shadow 0.3s ease, width 0.4s cubic-bezier(0.16, 1, 0.3, 1), padding 0.4s ease, max-height 0.4s ease',
-        cursor: 'move',
+        cursor: standaloneAgentHud ? 'default' : 'move',
         userSelect: 'none',
         willChange: 'transform, width',
         contain: 'layout style paint'
@@ -415,6 +440,7 @@ window.AgentHUD.createAgentTaskHUD = function () {
 
     // HUD 标题栏
     const header = document.createElement('div');
+    header.id = 'agent-task-hud-header';
     Object.assign(header.style, {
         display: 'flex',
         alignItems: 'center',
@@ -585,7 +611,7 @@ window.AgentHUD.createAgentTaskHUD = function () {
             taskList.style.opacity = '0';
             minimizeBtn.style.transform = 'rotate(-90deg)';
         } else {
-            hud.style.width = '320px';
+            hud.style.width = standaloneAgentHud ? '100%' : '320px';
             hud.style.gap = '12px'; 
             
             header.style.padding = '12px 16px';
@@ -672,8 +698,14 @@ window.AgentHUD.showAgentTaskHUD = function () {
     }
     hud.style.display = 'flex';
     hud.style.opacity = '1';
-    const savedPos = localStorage.getItem('agent-task-hud-position');
-    if (savedPos) {
+    const standaloneAgentHud = isStandaloneAgentHudPage();
+    const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');
+    if (standaloneAgentHud) {
+        hud.style.left = '0';
+        hud.style.top = '0';
+        hud.style.right = 'auto';
+        hud.style.transform = 'none';
+    } else if (savedPos) {
         try {
             const parsed = JSON.parse(savedPos);
             if (parsed.top) hud.style.top = parsed.top;
@@ -703,8 +735,14 @@ window.AgentHUD.hideAgentTaskHUD = function () {
 
     console.log('[AgentHUD] hideAgentTaskHUD: starting fade out');
     hud.style.opacity = '0';
-    const savedPos = localStorage.getItem('agent-task-hud-position');
-    if (!savedPos) {
+    const standaloneAgentHud = isStandaloneAgentHudPage();
+    const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');
+    if (standaloneAgentHud) {
+        hud.style.left = '0';
+        hud.style.top = '0';
+        hud.style.right = 'auto';
+        hud.style.transform = 'none';
+    } else if (!savedPos) {
         hud.style.transform = 'translateY(-50%) translateX(20px)';
     }
 
@@ -1307,9 +1345,30 @@ window.AgentHUD._createTaskCard = function (task) {
 
 // 设置HUD全局拖拽功能
 window.AgentHUD._setupDragging = function (hud) {
+    if (isStandaloneAgentHudPage()) {
+        hud.addEventListener('dragstart', (e) => e.preventDefault());
+        this._cleanupDragging = () => {};
+        return;
+    }
+
     let isDragging = false;
     let dragOffsetX = 0;
     let dragOffsetY = 0;
+
+    const resetDragVisualState = () => {
+        hud.style.cursor = 'move';
+        hud.style.boxShadow = 'var(--neko-popup-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.08), 0 16px 32px rgba(0,0,0,0.04))';
+        hud.style.opacity = '1';
+        hud.style.transition = 'opacity 0.3s ease, transform 0.3s ease, box-shadow 0.2s ease, width 0.3s ease, padding 0.3s ease, max-height 0.3s ease';
+    };
+
+    const cancelDragState = () => {
+        if (!isDragging && !touchDragging) return;
+        isDragging = false;
+        touchDragging = false;
+        setAgentHudDraggingState(false);
+        resetDragVisualState();
+    };
 
     // 高性能拖拽函数
     const performDrag = (clientX, clientY) => {
@@ -1347,6 +1406,7 @@ window.AgentHUD._setupDragging = function (hud) {
         if (isInteractive) return;
 
         isDragging = true;
+        setAgentHudDraggingState(true);
 
         // 视觉反馈
         hud.style.cursor = 'grabbing';
@@ -1379,12 +1439,10 @@ window.AgentHUD._setupDragging = function (hud) {
         if (!isDragging) return;
 
         isDragging = false;
+        setAgentHudDraggingState(false);
 
         // 恢复视觉状态
-        hud.style.cursor = 'move';
-        hud.style.boxShadow = 'var(--neko-popup-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.08), 0 16px 32px rgba(0,0,0,0.04))';
-        hud.style.opacity = '1';
-        hud.style.transition = 'opacity 0.3s ease, transform 0.3s ease, box-shadow 0.2s ease, width 0.3s ease, padding 0.3s ease, max-height 0.3s ease';
+        resetDragVisualState();
 
         // 最终位置校准（多屏幕支持）
         requestAnimationFrame(() => {
@@ -1450,6 +1508,7 @@ window.AgentHUD._setupDragging = function (hud) {
 
         touchDragging = true;
         isDragging = true;  // 让performDrag函数能正常工作
+        setAgentHudDraggingState(true);
 
         // 视觉反馈
         hud.style.boxShadow = '0 12px 48px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255, 255, 255, 0.2)';
@@ -1481,11 +1540,10 @@ window.AgentHUD._setupDragging = function (hud) {
 
         touchDragging = false;
         isDragging = false;  // 确保performDrag函数停止工作
+        setAgentHudDraggingState(false);
 
         // 恢复视觉状态
-        hud.style.boxShadow = 'var(--neko-popup-shadow, 0 2px 4px rgba(0,0,0,0.04), 0 8px 16px rgba(0,0,0,0.08), 0 16px 32px rgba(0,0,0,0.04))';
-        hud.style.opacity = '1';
-        hud.style.transition = 'opacity 0.3s ease, transform 0.3s ease, box-shadow 0.2s ease, width 0.3s ease, padding 0.3s ease, max-height 0.3s ease';
+        resetDragVisualState();
 
         // 最终位置校准（多屏幕支持）
         requestAnimationFrame(() => {
@@ -1533,6 +1591,9 @@ window.AgentHUD._setupDragging = function (hud) {
     hud.addEventListener('touchstart', handleTouchStart, { passive: false });
     document.addEventListener('touchmove', handleTouchMove, { passive: false });
     document.addEventListener('touchend', handleTouchEnd, { passive: false });
+    document.addEventListener('touchcancel', cancelDragState, { passive: true });
+    window.addEventListener('blur', cancelDragState);
+    window.addEventListener('pointercancel', cancelDragState, true);
 
     // 窗口大小变化时重新校准位置（多屏幕支持）
     const handleResize = async () => {
@@ -1591,12 +1652,16 @@ window.AgentHUD._setupDragging = function (hud) {
 
     // 清理函数
     this._cleanupDragging = () => {
+        setAgentHudDraggingState(false);
         hud.removeEventListener('mousedown', handleMouseDown);
         document.removeEventListener('mousemove', handleMouseMove);
         document.removeEventListener('mouseup', handleMouseUp);
         hud.removeEventListener('touchstart', handleTouchStart);
         document.removeEventListener('touchmove', handleTouchMove);
         document.removeEventListener('touchend', handleTouchEnd);
+        document.removeEventListener('touchcancel', cancelDragState);
+        window.removeEventListener('blur', cancelDragState);
+        window.removeEventListener('pointercancel', cancelDragState, true);
         window.removeEventListener('resize', handleResize);
     };
 };

--- a/templates/agenthud.html
+++ b/templates/agenthud.html
@@ -20,22 +20,28 @@
         #agent-hud-root {
             width: 100%; height: 100%;
         }
-        /* 窗口拖拽 */
-        .agent-hud-title-bar {
-            -webkit-app-region: drag;
-            height: 28px;
-            background: rgba(0,0,0,0.3);
-            display: flex;
-            align-items: center;
-            padding: 0 10px;
-            user-select: none;
+        /* 独立 AgentHUD 窗口：拖拽交给 Electron 原生窗口区域处理。 */
+        body.agent-hud-standalone-page #agent-task-hud {
+            -webkit-app-region: no-drag;
         }
-        .agent-hud-title-bar * {
+        body.agent-hud-standalone-page #agent-task-hud-header {
+            -webkit-app-region: drag;
+            cursor: grab;
+        }
+        body.agent-hud-standalone-page #agent-task-hud-header:active {
+            cursor: grabbing;
+        }
+        body.agent-hud-standalone-page #agent-task-list,
+        body.agent-hud-standalone-page #agent-task-list *,
+        body.agent-hud-standalone-page #agent-task-hud-minimize,
+        body.agent-hud-standalone-page #agent-task-hud-cancel,
+        body.agent-hud-standalone-page .task-card,
+        body.agent-hud-standalone-page .task-card * {
             -webkit-app-region: no-drag;
         }
     </style>
 </head>
-<body>
+<body class="agent-hud-standalone-page">
     <div id="agent-hud-root">
         <!-- common-ui-hud.js 的 DOM 将在此注入 -->
     </div>

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -1,6 +1,7 @@
 import ast
 import asyncio
 import json
+import re
 from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -243,6 +244,24 @@ def test_home_page_opens_plugin_dashboard_through_backend_redirect_for_handoff()
     assert "getQueryOpenerOrigin()" in plugin_runtime_source
     assert "isLoopbackOrigin(origin)" in plugin_runtime_source
     assert "var PLUGIN_DASHBOARD_REDIRECT_URL = 'http://127.0.0.1:48916/ui';" not in hud_source
+
+
+def test_standalone_agent_hud_hide_keeps_origin_position():
+    hud_source = Path("static/common-ui-hud.js").read_text(encoding="utf-8")
+    hide_match = re.search(
+        r"window\.AgentHUD\.hideAgentTaskHUD = function \(\) \{(?P<body>[\s\S]*?)\n\};",
+        hud_source,
+    )
+
+    assert hide_match is not None
+    hide_body = hide_match.group("body")
+    assert "const standaloneAgentHud = isStandaloneAgentHudPage();" in hide_body
+    assert "const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');" in hide_body
+    assert "hud.style.left = '0';" in hide_body
+    assert "hud.style.top = '0';" in hide_body
+    assert "hud.style.right = 'auto';" in hide_body
+    assert "hud.style.transform = 'none';" in hide_body
+    assert "translateY(-50%) translateX(20px)" in hide_body
 
 
 def test_agent_server_expected_event_driven_endpoints_exist():

--- a/tests/test_agent_rewrite_regression.py
+++ b/tests/test_agent_rewrite_regression.py
@@ -246,21 +246,33 @@ def test_home_page_opens_plugin_dashboard_through_backend_redirect_for_handoff()
     assert "var PLUGIN_DASHBOARD_REDIRECT_URL = 'http://127.0.0.1:48916/ui';" not in hud_source
 
 
-def test_standalone_agent_hud_hide_keeps_origin_position():
+def test_standalone_agent_hud_show_hide_keeps_origin_position():
     hud_source = Path("static/common-ui-hud.js").read_text(encoding="utf-8")
+    show_match = re.search(
+        r"window\.AgentHUD\.showAgentTaskHUD = function \(\) \{(?P<body>[\s\S]*?)\n\};",
+        hud_source,
+    )
     hide_match = re.search(
         r"window\.AgentHUD\.hideAgentTaskHUD = function \(\) \{(?P<body>[\s\S]*?)\n\};",
         hud_source,
     )
 
+    assert "const STANDALONE_HUD_POSITION = Object.freeze({" in hud_source
+    assert "position = STANDALONE_HUD_POSITION;" in hud_source
+    assert show_match is not None
     assert hide_match is not None
+    show_body = show_match.group("body")
     hide_body = hide_match.group("body")
-    assert "const standaloneAgentHud = isStandaloneAgentHudPage();" in hide_body
-    assert "const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');" in hide_body
-    assert "hud.style.left = '0';" in hide_body
-    assert "hud.style.top = '0';" in hide_body
-    assert "hud.style.right = 'auto';" in hide_body
-    assert "hud.style.transform = 'none';" in hide_body
+
+    for body in (show_body, hide_body):
+        assert "const standaloneAgentHud = isStandaloneAgentHudPage();" in body
+        assert "const savedPos = standaloneAgentHud ? null : localStorage.getItem('agent-task-hud-position');" in body
+        assert "hud.style.left = STANDALONE_HUD_POSITION.left;" in body
+        assert "hud.style.top = STANDALONE_HUD_POSITION.top;" in body
+        assert "hud.style.right = STANDALONE_HUD_POSITION.right;" in body
+        assert "hud.style.transform = STANDALONE_HUD_POSITION.transform;" in body
+
+    assert "translateY(-50%) translateX(0)" in show_body
     assert "translateY(-50%) translateX(20px)" in hide_body
 
 

--- a/tests/unit/test_workshop_router_ugc_details.py
+++ b/tests/unit/test_workshop_router_ugc_details.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -6,11 +7,17 @@ from main_routers import workshop_router
 
 
 class _FakeWorkshop:
-    def __init__(self, download_info=None):
+    def __init__(self, download_info=None, item_state=None, subscribed_items=None):
         self._download_info = download_info or {}
+        self._item_state = (
+            workshop_router._ITEM_STATE_SUBSCRIBED
+            if item_state is None
+            else item_state
+        )
+        self._subscribed_items = [123456] if subscribed_items is None else subscribed_items
 
     def GetItemState(self, item_id):
-        return workshop_router._ITEM_STATE_SUBSCRIBED
+        return self._item_state
 
     def GetItemInstallInfo(self, item_id):
         return {}
@@ -19,10 +26,10 @@ class _FakeWorkshop:
         return self._download_info
 
     def GetNumSubscribedItems(self):
-        return 1
+        return len(self._subscribed_items)
 
     def GetSubscribedItems(self):
-        return [123456]
+        return self._subscribed_items
 
 
 @pytest.fixture
@@ -57,6 +64,36 @@ async def test_workshop_item_details_unsupported_uses_download_tuple_order(monke
     assert progress["bytesDownloaded"] == 25
     assert progress["bytesTotal"] == 100
     assert progress["percentage"] == 25
+
+
+@pytest.mark.asyncio
+async def test_workshop_item_details_unsupported_preserves_not_found_for_unknown_id(monkeypatch):
+    steamworks = SimpleNamespace(Workshop=_FakeWorkshop(item_state=0, subscribed_items=[]))
+    monkeypatch.setattr(workshop_router, "get_steamworks", lambda: steamworks)
+
+    response = await workshop_router.get_workshop_item_details("999999")
+
+    assert response.status_code == 404
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["success"] is False
+    assert payload["detailsUnavailableReason"] == "ugc_details_query_unsupported"
+
+
+@pytest.mark.asyncio
+async def test_workshop_item_details_unsupported_tolerates_dirty_subscribed_items(monkeypatch):
+    steamworks = SimpleNamespace(
+        Workshop=_FakeWorkshop(
+            item_state=0,
+            subscribed_items=[None, "not-a-number", "123456"],
+        )
+    )
+    monkeypatch.setattr(workshop_router, "get_steamworks", lambda: steamworks)
+
+    response = await workshop_router.get_workshop_item_details("123456")
+
+    assert response["success"] is True
+    assert response["partial"] is True
+    assert response["item"]["publishedFileId"] == 123456
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
修复 Linux 桌面端透明窗口下部分浮层的点击/拖拽问题，补齐 Agent HUD、Jukebox、Profiler/MMD 调试面板等浮层的输入区域上报和拖拽状态清理，避免点击穿透或拖动残留。

同时修复 Steam Workshop 在 Linux Steamworks UGC 详情查询不可用时的降级语义：未知物品继续返回 404，不再伪造 partial success；并将 Steam overlay 状态检查降级为非关键诊断，避免影响上传前的 Steam 运行/登录状态校验。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Agent HUD 新增独立窗口模式：固定左上布局、全屏约束与可控拖拽区域。

* **错误修复**
  * Workshop 项目详情查询：未知 ID 现在返回 404，避免误报部分详情。
  * 修复拖拽/缩放在触摸取消与窗口失焦时的监听/状态残留问题（移动端和面板交互更稳健）。
  * 当无法读取 Steam 覆层状态时改进处理与日志记录，避免异常影响后续行为。

* **测试**
  * 增补 Workshop 与 Agent HUD 的回归与异常场景测试。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->