### PR TITLE
fix(audio): 麦克风降采样改用流式 ResampleStream，消除 chunk 边界 artifact

### DIFF
--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -414,6 +414,15 @@ class AudioProcessor:
                 self._denoiser.reset()
             except Exception as e:
                 logger.warning(f"⚠️ Failed to reset RNNoise denoiser: {e}")
+        # Flush streaming resampler's latency buffer + FIR history. After
+        # multi-second silence the buffer is already silent so this is a no-op,
+        # but on a forced mid-speech reset (interrupt / cancel turn) it prevents
+        # previous-turn tail samples from bleeding into the next turn.
+        if self._downsample_resampler is not None:
+            try:
+                self._downsample_resampler.clear()
+            except Exception as e:
+                logger.warning(f"⚠️ Failed to clear downsample resampler: {e}")
     
     def reset(self) -> None:
         """

--- a/utils/audio_processor.py
+++ b/utils/audio_processor.py
@@ -257,6 +257,21 @@ class AudioProcessor:
         self._agc_gain = 1.0
         self._agc_attack_coeff = np.exp(-1.0 / (self.AGC_ATTACK_TIME * self.RNNOISE_SAMPLE_RATE))
         self._agc_release_coeff = np.exp(-1.0 / (self.AGC_RELEASE_TIME * self.RNNOISE_SAMPLE_RATE))
+
+        # Streaming downsample resampler: maintains FIR state across chunks.
+        # Stateless soxr.resample() on 10ms chunks produces edge artifacts at every
+        # chunk boundary (perceived as 100Hz periodic clicks → "电流声"), so we use
+        # ResampleStream which carries filter state and outputs a continuous signal.
+        if self.input_sample_rate != self.output_sample_rate:
+            self._downsample_resampler = soxr.ResampleStream(
+                self.input_sample_rate,
+                self.output_sample_rate,
+                1,
+                dtype='float32',
+                quality='HQ',
+            )
+        else:
+            self._downsample_resampler = None
         
         # Debug audio buffers - 累积存储完整音频
         self._debug_audio_before: list[np.ndarray] = []
@@ -343,16 +358,11 @@ class AudioProcessor:
         if self.limiter_enabled and len(audio_int16) > 0:
             audio_int16 = self._apply_limiter(audio_int16)
         
-        # Downsample from 48kHz to 16kHz using high-quality soxr
-        if self.input_sample_rate != self.output_sample_rate and len(audio_int16) > 0:
-            # Convert to float for soxr, resample, then back to int16
+        # Downsample using streaming resampler (maintains FIR state across chunks
+        # to avoid boundary artifacts; see __init__ for context).
+        if self._downsample_resampler is not None and len(audio_int16) > 0:
             audio_float = audio_int16.astype(np.float32) / 32768.0
-            audio_float = soxr.resample(
-                audio_float, 
-                self.input_sample_rate, 
-                self.output_sample_rate, 
-                quality='HQ'
-            )
+            audio_float = self._downsample_resampler.resample_chunk(audio_float)
             audio_int16 = (audio_float * 32768.0).clip(-32768, 32767).astype(np.int16)
         return audio_int16.tobytes()
     


### PR DESCRIPTION
## Summary

- AudioProcessor 之前用 stateless `soxr.resample()` 处理每个 10ms (480 samples) PCM chunk，FIR 滤波器在每个 chunk 边界冷启动，产生周期性 ramp artifact
- 用户感知是"录音持续电流声/嗡嗡声"；把 chunk 抓出来听，本质是每 10ms 一次的微小爆音，安静段则完全干净（无 ramp 可激发）
- 改用有状态的 `soxr.ResampleStream.resample_chunk()`，filter state 跨 chunk 连续，输出回归连续信号
- 同样的写法 `tts_client.py` 输出音频路径已经在用，capture 这条路一直没跟上

## 诊断过程（简要）

走了几轮排错（关浏览器 AGC / AEC、关后端 AGC、对比 \`debug_audio_before.wav\` / \`after.wav\`），最终定位在 RNNoise 之后的降采样步骤——before/after wav 是干净的，说明 RNNoise 上游 OK；问题在 RNNoise → 16k API 之间的 stateless 重采样。

## Test plan

- [ ] 重启服务，开 voice mode 录制 → 服务端埋点听最终送 API 的 16kHz 音频，确认"滋滋/电流声"消失
- [ ] 验证语音正常段的连续性（无 10ms 周期 click）
- [ ] 验证 STT 识别准确率不下降（实测已恢复正常）
- [ ] 验证 \`debug_audio/*.wav\`（DEBUG_SAVE_AUDIO=True 时）波形干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复重采样在重置/中断时的残留尾音问题，避免上一轮音频“渗漏”到下一轮，减少点击噪音与突兀尾音。

* **改进**
  * 引入按需的流式重采样与块级处理，提升重采样的平滑性与连续性，整体音频处理更清晰流畅。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->