### PR TITLE
feat(proactive): 用户明确表示要工作/勿扰时显著降低搭话频率

### DIFF
--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -1076,8 +1076,8 @@ proactive_generate_zh = """你的人设：
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ 上方"活动状态"列出"未收尾话题"时，无视基调限制直接接续。
-★ 若{master_name}近期**明确**表达过"要工作 / 在忙 / 别打扰 / 安静一会"等不希望被打扰的意愿，将其视为强约束：显著提高搭话门槛，只在确有重要或紧急切入点时才开口，否则一律 [PASS]。仅当用户明确表态时才适用，不要从"屏幕在写代码 / 在打游戏"等行为线索过度推断。
+★ 若{master_name}在本次对话中**明确**表达过"要工作 / 在忙 / 别打扰 / 安静一会"等不希望被打扰的意愿（且之后未明确撤回），将其视为最强约束（**优先于下方未收尾话题接续规则**）：显著提高搭话门槛，只在确有重要或紧急切入点时才开口，否则一律 [PASS]，未收尾话题也先放着不接。仅当用户明确表态时才适用，不要从"屏幕在写代码 / 在打游戏"等行为线索过度推断。
+★ 上方"活动状态"列出"未收尾话题"时，无视基调限制直接接续（前提：未触发上一条勿扰约束）。
 
 切入点优先级（受"搭话倾向"约束）：
 1. 上轮挂着没收尾的话题 → 接续
@@ -1118,8 +1118,8 @@ Conversation history:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ When the activity state lists an "unfinished thread", you may continue it regardless of the propensity.
-★ If {master_name} has **explicitly** said recently that they need to work / are busy / don't want to be disturbed / want quiet, treat that as a hard constraint: raise the bar significantly and only speak up when there's a genuinely important or urgent angle, otherwise return [PASS]. This only applies when the user explicitly says so — do NOT infer it from behavioral cues like "they're coding on screen" or "they're playing a game."
+★ If {master_name} has **explicitly** said in this conversation that they need to work / are busy / don't want to be disturbed / want quiet (and has not since taken it back), treat that as the strongest constraint (**this overrides the unfinished-thread continuation rule below**): raise the bar significantly and only speak up when there's a genuinely important or urgent angle, otherwise return [PASS] — even unfinished threads should sit untouched. This only applies when the user explicitly says so — do NOT infer it from behavioral cues like "they're coding on screen" or "they're playing a game."
+★ When the activity state lists an "unfinished thread", you may continue it regardless of the propensity (unless the do-not-disturb constraint above is active).
 
 Angle priority (constrained by "chat propensity"):
 1. Unfinished thread from last turn → continue it
@@ -1160,8 +1160,8 @@ proactive_generate_ja = """あなたのキャラ設定：
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ 上の活動状態に「未完話題」がある場合、傾向の制限を無視して継続してよい。
-★ {master_name}が最近「仕事中 / 忙しい / 邪魔しないで / 静かにしてほしい」などと**明確に**意思表示した場合、強い制約として扱う：話しかける基準を大きく上げ、本当に重要・緊急の切り口がある場合のみ口を開き、それ以外は [PASS]。明示的な意思表示があるときのみ適用し、「画面でコードを書いている／ゲーム中」といった行動の手がかりから過度に推測しないこと。
+★ {master_name}が今回の会話で「仕事中 / 忙しい / 邪魔しないで / 静かにしてほしい」などと**明確に**意思表示し、その後撤回していない場合、最強の制約として扱う（**下の未完話題継続ルールよりも優先**）：話しかける基準を大きく上げ、本当に重要・緊急の切り口がある場合のみ口を開き、それ以外は [PASS]。未完話題もとりあえず置いておく。明示的な意思表示があるときのみ適用し、「画面でコードを書いている／ゲーム中」といった行動の手がかりから過度に推測しないこと。
+★ 上の活動状態に「未完話題」がある場合、傾向の制限を無視して継続してよい（ただし上の邪魔しないで制約が発動していないこと）。
 
 切り口優先度（「話しかけ傾向」の制約下で）：
 1. 前回の未完スレッド → 継続
@@ -1202,8 +1202,8 @@ proactive_generate_ko = """당신의 캐릭터 설정:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ 활동 상태에 "미완 화제"가 있다면 성향 제한과 무관하게 이어가기 가능.
-★ {master_name}이 최근 "일해야 해 / 바빠 / 방해하지 마 / 조용히 좀" 등 방해받고 싶지 않다는 의사를 **명확히** 표현했다면 강한 제약으로 간주: 말 걸기 기준을 크게 올리고, 정말 중요하거나 긴급한 접점이 있을 때만 입을 열며 그 외에는 모두 [PASS]. 사용자가 명시적으로 말한 경우에만 적용하고, "화면에서 코딩 중이다 / 게임 중이다" 같은 행동 단서로 과도하게 추측하지 말 것.
+★ {master_name}이 이번 대화에서 "일해야 해 / 바빠 / 방해하지 마 / 조용히 좀" 등 방해받고 싶지 않다는 의사를 **명확히** 표현했고 이후 철회하지 않았다면 최강 제약으로 간주(**아래의 미완 화제 이어가기 규칙보다 우선**): 말 걸기 기준을 크게 올리고, 정말 중요하거나 긴급한 접점이 있을 때만 입을 열며 그 외에는 모두 [PASS], 미완 화제도 일단 두고 본다. 사용자가 명시적으로 말한 경우에만 적용하고, "화면에서 코딩 중이다 / 게임 중이다" 같은 행동 단서로 과도하게 추측하지 말 것.
+★ 활동 상태에 "미완 화제"가 있다면 성향 제한과 무관하게 이어가기 가능(단, 위의 방해 금지 제약이 발동되지 않은 경우).
 
 접점 우선순위 ("말 걸기 성향" 제약 하):
 1. 지난 대화의 미완 스레드 → 이어가기
@@ -1244,8 +1244,8 @@ proactive_generate_ru = """Ваша роль:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ Если в активности есть "незавершённая нить", разрешено продолжать её вне зависимости от настроя.
-★ Если {master_name} недавно **явно** дал понять, что ему нужно работать / он занят / просит не отвлекать / хочет тишины, это жёсткое ограничение: значительно поднимите планку и заговаривайте только при по-настоящему важном или срочном поводе, иначе возвращайте [PASS]. Это применяется только при явном высказывании пользователя — не выводите этого из косвенных признаков вроде "на экране код" или "играет в игру".
+★ Если {master_name} в этом разговоре **явно** дал понять, что ему нужно работать / он занят / просит не отвлекать / хочет тишины (и с тех пор не отменил это), это самое жёсткое ограничение (**оно важнее правила продолжения незавершённой нити ниже**): значительно поднимите планку и заговаривайте только при по-настоящему важном или срочном поводе, иначе возвращайте [PASS] — даже незавершённую нить пока не трогайте. Это применяется только при явном высказывании пользователя — не выводите этого из косвенных признаков вроде "на экране код" или "играет в игру".
+★ Если в активности есть "незавершённая нить", разрешено продолжать её вне зависимости от настроя (если не сработало ограничение выше «не отвлекать»).
 
 Приоритет подходов (с учётом "настроя к беседе"):
 1. Незавершённая нить из прошлого хода → продолжить
@@ -1758,8 +1758,8 @@ Historial de conversación:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ Cuando el estado de actividad enumere un "hilo inconcluso", puedes continuarlo sin importar la propensión.
-★ Si {master_name} ha dicho **explícitamente** hace poco que necesita trabajar / está ocupado / que no le molestes / que quiere silencio, trátalo como una restricción fuerte: sube significativamente el listón y habla solo cuando haya un ángulo realmente importante o urgente; de lo contrario, devuelve [PASS]. Solo aplica cuando el usuario lo diga de forma explícita — NO lo infieras a partir de señales como "está programando en pantalla" o "está jugando".
+★ Si {master_name} ha dicho **explícitamente** en esta conversación que necesita trabajar / está ocupado / que no le molestes / que quiere silencio (y no lo ha retirado desde entonces), trátalo como la restricción más fuerte (**prevalece sobre la regla de continuar hilo inconcluso de abajo**): sube significativamente el listón y habla solo cuando haya un ángulo realmente importante o urgente; de lo contrario, devuelve [PASS] — incluso los hilos inconclusos quedan a un lado. Solo aplica cuando el usuario lo diga de forma explícita — NO lo infieras a partir de señales como "está programando en pantalla" o "está jugando".
+★ Cuando el estado de actividad enumere un "hilo inconcluso", puedes continuarlo sin importar la propensión (siempre que la restricción de no molestar anterior no esté activa).
 
 Prioridad de ángulos (limitada por "propensión a conversar"):
 1. Hilo inconcluso del turno anterior → continuarlo
@@ -1800,8 +1800,8 @@ Histórico da conversa:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ Quando o estado de atividade listar um "fio inacabado", você pode continuá-lo independentemente da propensão.
-★ Se {master_name} disse **explicitamente** há pouco que precisa trabalhar / está ocupado / pediu para não atrapalhar / quer silêncio, trate isso como restrição forte: eleve significativamente o critério e só fale quando houver um gancho realmente importante ou urgente; caso contrário, retorne [PASS]. Aplica-se apenas quando o usuário diz explicitamente — NÃO infira a partir de sinais como "está programando na tela" ou "está jogando".
+★ Se {master_name} disse **explicitamente** nesta conversa que precisa trabalhar / está ocupado / pediu para não atrapalhar / quer silêncio (e desde então não voltou atrás), trate como a restrição mais forte (**prevalece sobre a regra de continuar fio inacabado abaixo**): eleve significativamente o critério e só fale quando houver um gancho realmente importante ou urgente; caso contrário, retorne [PASS] — mesmo os fios inacabados ficam de lado. Aplica-se apenas quando o usuário diz explicitamente — NÃO infira a partir de sinais como "está programando na tela" ou "está jogando".
+★ Quando o estado de atividade listar um "fio inacabado", você pode continuá-lo independentemente da propensão (desde que a restrição de não atrapalhar acima não esteja ativa).
 
 Prioridade de ângulos (limitada por "propensão a conversar"):
 1. Fio inacabado do último turno → continuar

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -1077,6 +1077,7 @@ proactive_generate_zh = """你的人设：
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ 上方"活动状态"列出"未收尾话题"时，无视基调限制直接接续。
+★ 若{master_name}近期**明确**表达过"要工作 / 在忙 / 别打扰 / 安静一会"等不希望被打扰的意愿，将其视为强约束：显著提高搭话门槛，只在确有重要或紧急切入点时才开口，否则一律 [PASS]。仅当用户明确表态时才适用，不要从"屏幕在写代码 / 在打游戏"等行为线索过度推断。
 
 切入点优先级（受"搭话倾向"约束）：
 1. 上轮挂着没收尾的话题 → 接续
@@ -1118,6 +1119,7 @@ Conversation history:
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ When the activity state lists an "unfinished thread", you may continue it regardless of the propensity.
+★ If {master_name} has **explicitly** said recently that they need to work / are busy / don't want to be disturbed / want quiet, treat that as a hard constraint: raise the bar significantly and only speak up when there's a genuinely important or urgent angle, otherwise return [PASS]. This only applies when the user explicitly says so — do NOT infer it from behavioral cues like "they're coding on screen" or "they're playing a game."
 
 Angle priority (constrained by "chat propensity"):
 1. Unfinished thread from last turn → continue it
@@ -1159,6 +1161,7 @@ proactive_generate_ja = """あなたのキャラ設定：
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ 上の活動状態に「未完話題」がある場合、傾向の制限を無視して継続してよい。
+★ {master_name}が最近「仕事中 / 忙しい / 邪魔しないで / 静かにしてほしい」などと**明確に**意思表示した場合、強い制約として扱う：話しかける基準を大きく上げ、本当に重要・緊急の切り口がある場合のみ口を開き、それ以外は [PASS]。明示的な意思表示があるときのみ適用し、「画面でコードを書いている／ゲーム中」といった行動の手がかりから過度に推測しないこと。
 
 切り口優先度（「話しかけ傾向」の制約下で）：
 1. 前回の未完スレッド → 継続
@@ -1200,6 +1203,7 @@ proactive_generate_ko = """당신의 캐릭터 설정:
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ 활동 상태에 "미완 화제"가 있다면 성향 제한과 무관하게 이어가기 가능.
+★ {master_name}이 최근 "일해야 해 / 바빠 / 방해하지 마 / 조용히 좀" 등 방해받고 싶지 않다는 의사를 **명확히** 표현했다면 강한 제약으로 간주: 말 걸기 기준을 크게 올리고, 정말 중요하거나 긴급한 접점이 있을 때만 입을 열며 그 외에는 모두 [PASS]. 사용자가 명시적으로 말한 경우에만 적용하고, "화면에서 코딩 중이다 / 게임 중이다" 같은 행동 단서로 과도하게 추측하지 말 것.
 
 접점 우선순위 ("말 걸기 성향" 제약 하):
 1. 지난 대화의 미완 스레드 → 이어가기
@@ -1241,6 +1245,7 @@ proactive_generate_ru = """Ваша роль:
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ Если в активности есть "незавершённая нить", разрешено продолжать её вне зависимости от настроя.
+★ Если {master_name} недавно **явно** дал понять, что ему нужно работать / он занят / просит не отвлекать / хочет тишины, это жёсткое ограничение: значительно поднимите планку и заговаривайте только при по-настоящему важном или срочном поводе, иначе возвращайте [PASS]. Это применяется только при явном высказывании пользователя — не выводите этого из косвенных признаков вроде "на экране код" или "играет в игру".
 
 Приоритет подходов (с учётом "настроя к беседе"):
 1. Незавершённая нить из прошлого хода → продолжить
@@ -1754,6 +1759,7 @@ Historial de conversación:
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ Cuando el estado de actividad enumere un "hilo inconcluso", puedes continuarlo sin importar la propensión.
+★ Si {master_name} ha dicho **explícitamente** hace poco que necesita trabajar / está ocupado / que no le molestes / que quiere silencio, trátalo como una restricción fuerte: sube significativamente el listón y habla solo cuando haya un ángulo realmente importante o urgente; de lo contrario, devuelve [PASS]. Solo aplica cuando el usuario lo diga de forma explícita — NO lo infieras a partir de señales como "está programando en pantalla" o "está jugando".
 
 Prioridad de ángulos (limitada por "propensión a conversar"):
 1. Hilo inconcluso del turno anterior → continuarlo
@@ -1795,6 +1801,7 @@ Histórico da conversa:
 ======以下为向{master_name}进行搭话的决策方式======
 
 ★ Quando o estado de atividade listar um "fio inacabado", você pode continuá-lo independentemente da propensão.
+★ Se {master_name} disse **explicitamente** há pouco que precisa trabalhar / está ocupado / pediu para não atrapalhar / quer silêncio, trate isso como restrição forte: eleve significativamente o critério e só fale quando houver um gancho realmente importante ou urgente; caso contrário, retorne [PASS]. Aplica-se apenas quando o usuário diz explicitamente — NÃO infira a partir de sinais como "está programando na tela" ou "está jogando".
 
 Prioridade de ângulos (limitada por "propensão a conversar"):
 1. Fio inacabado do último turno → continuar

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -1076,7 +1076,7 @@ proactive_generate_zh = """你的人设：
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ 若{master_name}在本次对话中**明确**表达过"要工作 / 在忙 / 别打扰 / 安静一会"等不希望被打扰的意愿（且之后未明确撤回），将其视为最强约束（**优先于下方未收尾话题接续规则**）：显著提高搭话门槛，只在确有重要或紧急切入点时才开口，否则一律 [PASS]，未收尾话题也先放着不接。仅当用户明确表态时才适用，不要从"屏幕在写代码 / 在打游戏"等行为线索过度推断。
+★ 若{master_name}在本次对话中**明确**表达过"要工作 / 在忙 / 别打扰 / 安静一会"等不希望被打扰的意愿（且之后未明确撤回）：显著提高搭话门槛，只在确有重要或紧急切入点时才开口，否则一律 [PASS]，未收尾话题也先放着不接。仅当用户明确表态时才适用，不要从"屏幕在写代码 / 在打游戏"等行为线索过度推断。
 ★ 上方"活动状态"列出"未收尾话题"时，无视基调限制直接接续（前提：未触发上一条勿扰约束）。
 
 切入点优先级（受"搭话倾向"约束）：
@@ -1118,7 +1118,7 @@ Conversation history:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ If {master_name} has **explicitly** said in this conversation that they need to work / are busy / don't want to be disturbed / want quiet (and has not since taken it back), treat that as the strongest constraint (**this overrides the unfinished-thread continuation rule below**): raise the bar significantly and only speak up when there's a genuinely important or urgent angle, otherwise return [PASS] — even unfinished threads should sit untouched. This only applies when the user explicitly says so — do NOT infer it from behavioral cues like "they're coding on screen" or "they're playing a game."
+★ If {master_name} has **explicitly** said in this conversation that they need to work / are busy / don't want to be disturbed / want quiet (and has not since taken it back): raise the bar significantly and only speak up when there's a genuinely important or urgent angle, otherwise return [PASS] — even unfinished threads should sit untouched. This only applies when the user explicitly says so — do NOT infer it from behavioral cues like "they're coding on screen" or "they're playing a game."
 ★ When the activity state lists an "unfinished thread", you may continue it regardless of the propensity (unless the do-not-disturb constraint above is active).
 
 Angle priority (constrained by "chat propensity"):
@@ -1160,7 +1160,7 @@ proactive_generate_ja = """あなたのキャラ設定：
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ {master_name}が今回の会話で「仕事中 / 忙しい / 邪魔しないで / 静かにしてほしい」などと**明確に**意思表示し、その後撤回していない場合、最強の制約として扱う（**下の未完話題継続ルールよりも優先**）：話しかける基準を大きく上げ、本当に重要・緊急の切り口がある場合のみ口を開き、それ以外は [PASS]。未完話題もとりあえず置いておく。明示的な意思表示があるときのみ適用し、「画面でコードを書いている／ゲーム中」といった行動の手がかりから過度に推測しないこと。
+★ {master_name}が今回の会話で「仕事中 / 忙しい / 邪魔しないで / 静かにしてほしい」などと**明確に**意思表示し、その後撤回していない場合：話しかける基準を大きく上げ、本当に重要・緊急の切り口がある場合のみ口を開き、それ以外は [PASS]。未完話題もとりあえず置いておく。明示的な意思表示があるときのみ適用し、「画面でコードを書いている／ゲーム中」といった行動の手がかりから過度に推測しないこと。
 ★ 上の活動状態に「未完話題」がある場合、傾向の制限を無視して継続してよい（ただし上の邪魔しないで制約が発動していないこと）。
 
 切り口優先度（「話しかけ傾向」の制約下で）：
@@ -1202,7 +1202,7 @@ proactive_generate_ko = """당신의 캐릭터 설정:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ {master_name}이 이번 대화에서 "일해야 해 / 바빠 / 방해하지 마 / 조용히 좀" 등 방해받고 싶지 않다는 의사를 **명확히** 표현했고 이후 철회하지 않았다면 최강 제약으로 간주(**아래의 미완 화제 이어가기 규칙보다 우선**): 말 걸기 기준을 크게 올리고, 정말 중요하거나 긴급한 접점이 있을 때만 입을 열며 그 외에는 모두 [PASS], 미완 화제도 일단 두고 본다. 사용자가 명시적으로 말한 경우에만 적용하고, "화면에서 코딩 중이다 / 게임 중이다" 같은 행동 단서로 과도하게 추측하지 말 것.
+★ {master_name}이 이번 대화에서 "일해야 해 / 바빠 / 방해하지 마 / 조용히 좀" 등 방해받고 싶지 않다는 의사를 **명확히** 표현했고 이후 철회하지 않았다면: 말 걸기 기준을 크게 올리고, 정말 중요하거나 긴급한 접점이 있을 때만 입을 열며 그 외에는 모두 [PASS], 미완 화제도 일단 두고 본다. 사용자가 명시적으로 말한 경우에만 적용하고, "화면에서 코딩 중이다 / 게임 중이다" 같은 행동 단서로 과도하게 추측하지 말 것.
 ★ 활동 상태에 "미완 화제"가 있다면 성향 제한과 무관하게 이어가기 가능(단, 위의 방해 금지 제약이 발동되지 않은 경우).
 
 접점 우선순위 ("말 걸기 성향" 제약 하):
@@ -1244,7 +1244,7 @@ proactive_generate_ru = """Ваша роль:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ Если {master_name} в этом разговоре **явно** дал понять, что ему нужно работать / он занят / просит не отвлекать / хочет тишины (и с тех пор не отменил это), это самое жёсткое ограничение (**оно важнее правила продолжения незавершённой нити ниже**): значительно поднимите планку и заговаривайте только при по-настоящему важном или срочном поводе, иначе возвращайте [PASS] — даже незавершённую нить пока не трогайте. Это применяется только при явном высказывании пользователя — не выводите этого из косвенных признаков вроде "на экране код" или "играет в игру".
+★ Если {master_name} в этом разговоре **явно** дал понять, что ему нужно работать / он занят / просит не отвлекать / хочет тишины (и с тех пор не отменил это): значительно поднимите планку и заговаривайте только при по-настоящему важном или срочном поводе, иначе возвращайте [PASS] — даже незавершённую нить пока не трогайте. Это применяется только при явном высказывании пользователя — не выводите этого из косвенных признаков вроде "на экране код" или "играет в игру".
 ★ Если в активности есть "незавершённая нить", разрешено продолжать её вне зависимости от настроя (если не сработало ограничение выше «не отвлекать»).
 
 Приоритет подходов (с учётом "настроя к беседе"):
@@ -1758,7 +1758,7 @@ Historial de conversación:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ Si {master_name} ha dicho **explícitamente** en esta conversación que necesita trabajar / está ocupado / que no le molestes / que quiere silencio (y no lo ha retirado desde entonces), trátalo como la restricción más fuerte (**prevalece sobre la regla de continuar hilo inconcluso de abajo**): sube significativamente el listón y habla solo cuando haya un ángulo realmente importante o urgente; de lo contrario, devuelve [PASS] — incluso los hilos inconclusos quedan a un lado. Solo aplica cuando el usuario lo diga de forma explícita — NO lo infieras a partir de señales como "está programando en pantalla" o "está jugando".
+★ Si {master_name} ha dicho **explícitamente** en esta conversación que necesita trabajar / está ocupado / que no le molestes / que quiere silencio (y no lo ha retirado desde entonces): sube significativamente el listón y habla solo cuando haya un ángulo realmente importante o urgente; de lo contrario, devuelve [PASS] — incluso los hilos inconclusos quedan a un lado. Solo aplica cuando el usuario lo diga de forma explícita — NO lo infieras a partir de señales como "está programando en pantalla" o "está jugando".
 ★ Cuando el estado de actividad enumere un "hilo inconcluso", puedes continuarlo sin importar la propensión (siempre que la restricción de no molestar anterior no esté activa).
 
 Prioridad de ángulos (limitada por "propensión a conversar"):
@@ -1800,7 +1800,7 @@ Histórico da conversa:
 
 ======以下为向{master_name}进行搭话的决策方式======
 
-★ Se {master_name} disse **explicitamente** nesta conversa que precisa trabalhar / está ocupado / pediu para não atrapalhar / quer silêncio (e desde então não voltou atrás), trate como a restrição mais forte (**prevalece sobre a regra de continuar fio inacabado abaixo**): eleve significativamente o critério e só fale quando houver um gancho realmente importante ou urgente; caso contrário, retorne [PASS] — mesmo os fios inacabados ficam de lado. Aplica-se apenas quando o usuário diz explicitamente — NÃO infira a partir de sinais como "está programando na tela" ou "está jogando".
+★ Se {master_name} disse **explicitamente** nesta conversa que precisa trabalhar / está ocupado / pediu para não atrapalhar / quer silêncio (e desde então não voltou atrás): eleve significativamente o critério e só fale quando houver um gancho realmente importante ou urgente; caso contrário, retorne [PASS] — mesmo os fios inacabados ficam de lado. Aplica-se apenas quando o usuário diz explicitamente — NÃO infira a partir de sinais como "está programando na tela" ou "está jogando".
 ★ Quando o estado de atividade listar um "fio inacabado", você pode continuá-lo independentemente da propensão (desde que a restrição de não atrapalhar acima não esteja ativa).
 
 Prioridade de ângulos (limitada por "propensão a conversar"):


### PR DESCRIPTION
## Summary
- 在 Phase 2 `proactive_generate_*` prompt 的"决策方式"段新增一条 ★ 高优先级规则：用户近期**明确**表达过"要工作 / 在忙 / 别打扰 / 安静一会"等意愿时，将其作为强约束，显著提高搭话门槛，否则 [PASS]
- 明确限定**仅在用户明确表态**时生效——不要从"屏幕在写代码 / 在打游戏"等行为线索过度推断而误伤正常使用场景
- 7 个语言变体 (zh/en/ja/ko/ru/es/pt) 同步更新

## Test plan
- [ ] 触发一次主动搭话，对话历史无勿扰意图 → 按原优先级生成搭话或 [PASS]
- [ ] 在最近一条用户消息里加 "我要写代码别打扰我" → 大多数轮次返回 [PASS]
- [ ] 仅屏幕显示代码编辑器，用户没有说勿扰 → 不会因为屏幕内容而过度抑制搭话

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 在多语言（中文/英文/日/韩/俄/西/葡）中增强“勿扰强约束”：当用户明确表示忙碌或请勿打扰时，助手显著降低主动介入频率，仅在重要或紧急情况下才介入，并避免基于屏幕行为等线索做过度推断。
  * 对“未完话题”增加例外规则：若勿扰未触发，助手可继续未完内容；若勿扰生效，则先不接续未完话题。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->