### PR TITLE
fix(memory): 替换 AVX-VNNI CPUID shellcode 为 family/model 查表，并在 embeddings.py 被杀软删除时优雅降级

### DIFF
--- a/memory/embedding_worker.py
+++ b/memory/embedding_worker.py
@@ -38,12 +38,27 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from memory.embeddings import (
-    clear_embedding_fields,
-    get_embedding_service,
-    is_cached_embedding_valid,
-    stamp_embedding_fields,
-)
+try:
+    from memory.embeddings import (
+        clear_embedding_fields,
+        get_embedding_service,
+        is_cached_embedding_valid,
+        stamp_embedding_fields,
+    )
+except ImportError:
+    # ``memory/embeddings.py`` is missing (typically because an antivirus
+    # quarantined it — historically as ``Trojan/Python.ShellLoader.i``).
+    # Fall back to disabled stubs so the warmup/backfill loop still
+    # imports; the loop's own ``is_available()`` short-circuit then
+    # turns the whole worker into a one-shot no-op.
+    from memory.embeddings_fallback import (
+        clear_embedding_fields,
+        get_embedding_service,
+        is_cached_embedding_valid,
+        stamp_embedding_fields,
+        _warn_once,
+    )
+    _warn_once(__name__)
 
 # Type annotations on `__init__` use string forward refs — keeping the
 # TYPE_CHECKING imports earned a lint warning for "unused" because the

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -281,7 +281,36 @@ def detect_total_ram_gb() -> float | None:
 _INTEL_VNNI_MIN_MODEL_FAMILY_6 = 0x97  # Alder Lake — also covers Raptor,
                                        # Meteor, Arrow, Lunar, Panther
                                        # Lake; Sapphire/Emerald Rapids.
-_AMD_VNNI_MIN_FAMILY = 0x19            # Zen 4 (and Zen 5 at Family 0x1A).
+
+# AMD Family 0x19 is shared between Zen 3 (no AVX-VNNI) and Zen 4 (yes), so
+# family alone is not enough — gate on the documented Zen 4 model ranges
+# instead. Zen 5 lives on Family 0x1A and every shipped part has VNNI, so
+# Family >= 0x1A is a straight yes; Family < 0x19 is a straight no
+# (Zen 1 / Zen 2 at 0x17, older microarchitectures at 0x15 / 0x16).
+_AMD_ZEN4_MODEL_RANGES_FAMILY_19 = (
+    (0x10, 0x1F),  # Genoa / Bergamo / Storm Peak (Zen 4 server, EPYC 9004,
+                   # Threadripper 7000)
+    (0x60, 0x6F),  # Raphael / Dragon Range (Zen 4 desktop / mobile HX,
+                   # Ryzen 7000 / 7045)
+    (0x70, 0x7F),  # Phoenix / Phoenix 2 / Hawk Point (Zen 4 mobile,
+                   # Ryzen 7040 / 8040)
+    (0xA0, 0xAF),  # Zen 4c derivatives reserved by AMD's CPUID
+                   # documentation; included for forward compat so a
+                   # future Family-19h Zen-4c part isn't false-negatived.
+)
+
+# Zen 3 model ranges on Family 0x19 — definitively no AVX-VNNI. Listed
+# explicitly so we can answer ``(False, True)`` (confirmed-no) for them
+# rather than ``(False, False)`` (inconclusive), which would let
+# ``auto`` quantization optimistically pick int8 on a CPU that genuinely
+# can not run it well.
+_AMD_ZEN3_MODEL_RANGES_FAMILY_19 = (
+    (0x00, 0x0F),  # Milan EPYC / Vermeer (Ryzen 5000 desktop)
+    (0x20, 0x2F),  # Cezanne / Lucienne / Barceló (Ryzen 5000G/U APU)
+    (0x30, 0x3F),  # Milan-X / Trento (EPYC 7003X)
+    (0x40, 0x4F),  # Rembrandt (Ryzen 6000 mobile, Zen 3+)
+    (0x50, 0x5F),  # Barceló-R refresh
+)
 
 
 def _read_cpu_family_model() -> tuple[str, int, int] | None:
@@ -317,6 +346,10 @@ def _read_cpu_family_model() -> tuple[str, int, int] | None:
                         try:
                             family = int(line.split(":", 1)[1].strip())
                         except ValueError:
+                            # Malformed numeric field — keep scanning;
+                            # the surrounding ``vendor/family/model``
+                            # presence check below treats a missing
+                            # field as "no answer" and returns None.
                             pass
                     # ``model name`` shares the prefix; check ``model`` first
                     # but skip when the line is actually ``model name``.
@@ -324,6 +357,9 @@ def _read_cpu_family_model() -> tuple[str, int, int] | None:
                         try:
                             model = int(line.split(":", 1)[1].strip())
                         except ValueError:
+                            # Same fallthrough as above — better to
+                            # answer "I don't know" than to crash CPU
+                            # detection on an exotic /proc/cpuinfo.
                             pass
                     if vendor and family is not None and model is not None:
                         break
@@ -363,12 +399,27 @@ def _vnni_via_family_model() -> tuple[bool, bool]:
         if family == 6 and model >= _INTEL_VNNI_MIN_MODEL_FAMILY_6:
             return True, True
     elif vendor == "AuthenticAMD":
-        # Zen 4 (Family 0x19) introduced AVX-VNNI on AMD; Zen 5
-        # (Family 0x1A) keeps it. Earlier Zen lines don't have it, so
-        # Family < 0x19 is a definitive "no" — we avoid the optimistic
-        # int8 fallback silently selecting a slow path on Zen 1/2/3.
-        if family >= _AMD_VNNI_MIN_FAMILY:
+        # Zen 5 (Family 0x1A, and any later family AMD ships) — every
+        # part has AVX-VNNI.
+        if family >= 0x1A:
             return True, True
+        # Family 0x19 is shared between Zen 3 (no VNNI) and Zen 4 (yes),
+        # so we have to look at the model. The Zen-4 ranges below are
+        # AMD's documented CPUID model groupings.
+        if family == 0x19:
+            for lo, hi in _AMD_ZEN4_MODEL_RANGES_FAMILY_19:
+                if lo <= model <= hi:
+                    return True, True
+            for lo, hi in _AMD_ZEN3_MODEL_RANGES_FAMILY_19:
+                if lo <= model <= hi:
+                    return False, True
+            # An unmapped Family-19h model (e.g. a future stepping not
+            # yet covered by AMD's published groupings) stays
+            # inconclusive so py-cpuinfo's flag list can have a try
+            # instead of silently picking the wrong path.
+            return False, False
+        # Family < 0x19 covers Zen 1 / Zen 2 (0x17), Excavator (0x15) and
+        # earlier — none have AVX-VNNI, so the answer is definitive.
         return False, True
     return False, False
 

--- a/memory/embeddings.py
+++ b/memory/embeddings.py
@@ -268,144 +268,132 @@ def detect_total_ram_gb() -> float | None:
         return None
 
 
-def _probe_avx_vnni_via_cpuid() -> bool | None:
-    """Direct CPUID probe for AVX-VNNI / AVX-512_VNNI — Windows x86_64 only.
+# Known-good thresholds for CPU microarchitectures that ship AVX-VNNI.
+# Family/model is a stable hardware identifier readable from
+# ``HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0\Identifier`` on
+# Windows and ``/proc/cpuinfo`` on Linux — no executable-page allocation,
+# no inline machine code, no AV heuristic match.
+#
+# Conservative: a "yes" from the table is authoritative (confirmed=True);
+# an "I don't know" falls through to py-cpuinfo / /proc/cpuinfo flags so
+# brand-new microarchitectures aren't false-negatived just because the
+# table predates them.
+_INTEL_VNNI_MIN_MODEL_FAMILY_6 = 0x97  # Alder Lake — also covers Raptor,
+                                       # Meteor, Arrow, Lunar, Panther
+                                       # Lake; Sapphire/Emerald Rapids.
+_AMD_VNNI_MIN_FAMILY = 0x19            # Zen 4 (and Zen 5 at Family 0x1A).
 
-    Returns:
-      * True  — AVX-VNNI or AVX-512_VNNI is present
-      * False — neither bit set (CPU truly lacks the int8 fast path)
-      * None  — probe was not attempted (non-Windows, non-x86_64,
-        32-bit Python, OS refused executable allocation)
 
-    Why Windows-only: the bug this fixes is py-cpuinfo's Windows backend
-    silently omitting ``avx_vnni`` from its flag list — every Alder Lake
-    onwards Intel (and Zen 4+ AMD) box on Windows gets misread as
-    "no VNNI" and the embedding stack sticky-disables. Windows also
-    exposes no ``PF_AVX_VNNI_INSTRUCTIONS_AVAILABLE`` constant via
-    ``IsProcessorFeaturePresent``, so a raw CPUID is the only authoritative
-    answer on that platform.
+def _read_cpu_family_model() -> tuple[str, int, int] | None:
+    """Return ``(vendor, family, model)`` from a non-shellcode source,
+    or None when neither the Windows registry nor ``/proc/cpuinfo``
+    answered.
 
-    Why not Linux / macOS:
-
-      * Linux 5.17+ exposes ``avx_vnni`` in ``/proc/cpuinfo`` flags, which
-        both py-cpuinfo and our text-parse fallback already handle.
-        Running CPUID on Linux is also unsafe in the general case —
-        ``arch_prctl(ARCH_SET_CPUID, 0)`` (rr debugger, some
-        sandboxes) makes ``cpuid`` deliver SIGSEGV, which Python's
-        try/except cannot catch and would hard-kill the process (Codex
-        P1 review on PR #1402).
-      * macOS Intel topped out at Ice Lake (pre-AVX-VNNI), so no Intel
-        Mac in the wild has the fast path to detect — and hardened
-        runtime makes PROT_EXEC pages unreliable on recent macOS.
-
-    CPUID feature bits used:
-      * leaf 7 subleaf 0, ECX bit 11 → AVX-512_VNNI (Cascade Lake+ /
-        Zen 4 server parts)
-      * leaf 7 subleaf 1, EAX bit 4  → AVX-VNNI (Alder Lake+, Zen 4+)
-
-    All allocation / execution is wrapped in try/except — any failure
-    returns ``None`` so the caller falls back to py-cpuinfo without
-    changing behaviour for DEP-locked sandboxes.
+    Vendor strings are normalised to the CPUID brand strings
+    (``GenuineIntel`` / ``AuthenticAMD``) so the lookup table is indexed
+    identically across OSes.
     """
-    if platform.system() != "Windows":
-        return None
-    if platform.machine().lower() not in ("amd64", "x86_64"):
-        return None
-    # platform.machine reflects the host arch even under 32-bit Python
-    # (WoW64 reports AMD64). Our shellcode is 64-bit only — gate on the
-    # pointer size of the *running* interpreter to avoid mis-decoding it
-    # under a 32-bit Python on a 64-bit OS.
-    import struct
-    if struct.calcsize("P") != 8:
-        return None
-
+    system = platform.system()
     try:
-        import ctypes
-        # Microsoft x64 ABI: leaf=RCX, subleaf=RDX, out ptr=R8.
-        shellcode = bytes([
-            0x89, 0xC8,                         # mov  eax, ecx     ; leaf
-            0x89, 0xD1,                         # mov  ecx, edx     ; subleaf
-            0x53,                               # push rbx          ; nonvolatile
-            0x0F, 0xA2,                         # cpuid
-            0x41, 0x89, 0x00,                   # mov  [r8],    eax
-            0x41, 0x89, 0x58, 0x04,             # mov  [r8+4],  ebx
-            0x41, 0x89, 0x48, 0x08,             # mov  [r8+8],  ecx
-            0x41, 0x89, 0x50, 0x0C,             # mov  [r8+12], edx
-            0x5B,                               # pop  rbx
-            0xC3,                               # ret
-        ])
-        k32 = ctypes.windll.kernel32
-        k32.VirtualAlloc.restype = ctypes.c_void_p
-        k32.VirtualAlloc.argtypes = [
-            ctypes.c_void_p, ctypes.c_size_t,
-            ctypes.c_uint32, ctypes.c_uint32,
-        ]
-        k32.VirtualFree.argtypes = [
-            ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint32,
-        ]
-        PAGE_EXECUTE_READWRITE = 0x40
-        MEM_COMMIT_RESERVE = 0x3000
-        MEM_RELEASE = 0x8000
-        addr = k32.VirtualAlloc(
-            None, len(shellcode), MEM_COMMIT_RESERVE, PAGE_EXECUTE_READWRITE,
-        )
-        if not addr:
-            return None
-        try:
-            ctypes.memmove(addr, shellcode, len(shellcode))
-            cpuid_fn = ctypes.CFUNCTYPE(
-                None, ctypes.c_uint32, ctypes.c_uint32,
-                ctypes.POINTER(ctypes.c_uint32 * 4),
-            )(addr)
-            return _check_vnni_via_cpuid(cpuid_fn)
-        finally:
-            k32.VirtualFree(addr, 0, MEM_RELEASE)
+        if system == "Windows":
+            import winreg
+            with winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                r"HARDWARE\DESCRIPTION\System\CentralProcessor\0",
+            ) as k:
+                vendor = winreg.QueryValueEx(k, "VendorIdentifier")[0]
+                ident = winreg.QueryValueEx(k, "Identifier")[0]
+            m = re.search(r"Family (\d+) Model (\d+)", ident)
+            if not m:
+                return None
+            return vendor, int(m.group(1)), int(m.group(2))
+        if system == "Linux":
+            vendor, family, model = None, None, None
+            with open("/proc/cpuinfo", encoding="utf-8") as f:
+                for line in f:
+                    if line.startswith("vendor_id"):
+                        vendor = line.split(":", 1)[1].strip()
+                    elif line.startswith("cpu family"):
+                        try:
+                            family = int(line.split(":", 1)[1].strip())
+                        except ValueError:
+                            pass
+                    # ``model name`` shares the prefix; check ``model`` first
+                    # but skip when the line is actually ``model name``.
+                    elif line.startswith("model") and not line.startswith("model name"):
+                        try:
+                            model = int(line.split(":", 1)[1].strip())
+                        except ValueError:
+                            pass
+                    if vendor and family is not None and model is not None:
+                        break
+            if vendor is None or family is None or model is None:
+                return None
+            return vendor, family, model
     except Exception:
         return None
+    return None
 
 
-def _check_vnni_via_cpuid(cpuid_fn) -> bool:
-    """Issue the two CPUID leaves that carry the int8 fast-path bits.
+def _vnni_via_family_model() -> tuple[bool, bool]:
+    """Authoritative VNNI answer via CPU family/model lookup.
 
-    Split out from :func:`_probe_avx_vnni_via_cpuid` so the platform-
-    specific allocation wrapper can stay focused on memory management;
-    keeping the bit math here also makes the leaf/bit references
-    greppable from a single location.
+    Returns ``(has_vnni, confirmed)``. ``confirmed=True`` means the
+    family/model fell inside (or strictly below) a known range and the
+    answer is final. ``(False, False)`` means the table doesn't know —
+    let the caller fall through to py-cpuinfo / ``/proc/cpuinfo``.
+
+    Replaces the deleted CPUID shellcode probe. Strictly less precise
+    in one direction (brand-new microarchitectures that ship before the
+    table is updated stay inconclusive instead of authoritative), but
+    the consumer's ``auto`` quantization path treats inconclusive as
+    "pick int8 optimistically" — the same behaviour the CPUID probe
+    produced for sandboxes that refused executable allocation.
     """
-    import ctypes
-    out = (ctypes.c_uint32 * 4)()
-    cpuid_fn(0, 0, ctypes.byref(out))
-    max_basic = out[0]
-    if max_basic < 7:
-        return False
-    cpuid_fn(7, 0, ctypes.byref(out))
-    max_sub = out[0]
-    if out[2] & (1 << 11):       # ECX bit 11 → AVX-512_VNNI
-        return True
-    if max_sub < 1:
-        return False
-    cpuid_fn(7, 1, ctypes.byref(out))
-    return bool(out[0] & (1 << 4))  # EAX bit 4 → AVX-VNNI
+    info = _read_cpu_family_model()
+    if info is None:
+        return False, False
+    vendor, family, model = info
+    if vendor == "GenuineIntel":
+        # All Intel client microarchitectures shipping AVX-VNNI live in
+        # Family 6 with model >= Alder Lake's 0x97. Earlier Family-6
+        # parts that carry AVX512-VNNI (Ice Lake server, Tiger/Rocket
+        # Lake, Sapphire Rapids) are detected by py-cpuinfo's
+        # ``avx512_vnni`` flag and don't need enumeration here.
+        if family == 6 and model >= _INTEL_VNNI_MIN_MODEL_FAMILY_6:
+            return True, True
+    elif vendor == "AuthenticAMD":
+        # Zen 4 (Family 0x19) introduced AVX-VNNI on AMD; Zen 5
+        # (Family 0x1A) keeps it. Earlier Zen lines don't have it, so
+        # Family < 0x19 is a definitive "no" — we avoid the optimistic
+        # int8 fallback silently selecting a slow path on Zen 1/2/3.
+        if family >= _AMD_VNNI_MIN_FAMILY:
+            return True, True
+        return False, True
+    return False, False
 
 
 def _detect_int8_fast_path_x86() -> tuple[bool, bool]:
     """x86 INT8 fast path = AVX-VNNI (or AVX512-VNNI).
 
-    Detection order:
-      1. Direct CPUID probe (:func:`_probe_avx_vnni_via_cpuid`) —
-         Windows x86_64 only; the bug being fixed is py-cpuinfo's
-         Windows backend omitting ``avx_vnni`` from its flag list.
-      2. ``py-cpuinfo`` flags — primary path on Linux / macOS, and the
-         fallback on Windows when the CPUID probe could not run.
+    Detection order (no-shellcode):
+      1. CPU family/model lookup (:func:`_vnni_via_family_model`) — the
+         only path that authoritatively answers for Alder-Lake+ Intel
+         client CPUs on Windows, where py-cpuinfo's backend silently
+         omits ``avx_vnni`` from its flag list.
+      2. ``py-cpuinfo`` flags — primary path on Linux / macOS and the
+         fallback on Windows for AVX512-VNNI parts (Cascade / Ice
+         Lake-server / Sapphire Rapids) which py-cpuinfo handles
+         correctly.
       3. ``/proc/cpuinfo`` on Linux — text parse if py-cpuinfo failed.
 
     Returns ``(has_vnni, absence_confirmed)``. ``absence_confirmed=False``
     means no path could read CPU flags — the caller stays optimistic and
     picks INT8 in that case (consistent with the ARM branch).
     """
-    probed = _probe_avx_vnni_via_cpuid()
-    if probed is not None:
-        return probed, True
+    has_vnni, confirmed = _vnni_via_family_model()
+    if confirmed:
+        return has_vnni, True
 
     try:
         import cpuinfo  # type: ignore
@@ -503,6 +491,48 @@ def _detect_int8_fast_path_arm() -> tuple[bool, bool]:
     return True, False
 
 
+# Per-process one-shot flag so we log the "no INT8 fast path" outcome
+# exactly once at startup, with the vendor/family/model that drove the
+# decision. Reset by :func:`reset_embedding_service_for_tests` so unit
+# tests can re-trigger the log under monkeypatched detection.
+_VNNI_DECISION_LOGGED = False
+
+
+def _log_int8_fast_path_decision(has_vnni: bool, confirmed: bool) -> None:
+    """Emit one warning per process when no INT8 fast path is detected.
+
+    Triaging "why are my vectors disabled?" needs to know whether
+    detection was authoritative (the family/model table or a CPU that
+    truly lacks VNNI) or just inconclusive (sandboxed host, missing
+    py-cpuinfo, exotic arch). Including the vendor/family/model in the
+    log lets us extend the lookup table for future microarchitectures
+    based on real reports instead of guesses.
+
+    We stay silent on the positive path — every successful boot would
+    just add noise to the log."""
+    global _VNNI_DECISION_LOGGED
+    if _VNNI_DECISION_LOGGED:
+        return
+    _VNNI_DECISION_LOGGED = True
+    if has_vnni:
+        return
+    info = _read_cpu_family_model()
+    if info is None:
+        vendor, family_str, model_str = "?", "?", "?"
+    else:
+        vendor, family, model = info
+        family_str = f"0x{family:X}"
+        model_str = f"0x{model:X}"
+    logger.warning(
+        "EmbeddingService: no INT8 fast path detected on this CPU "
+        "(vendor=%s family=%s model=%s arch=%s confirmed=%s). "
+        "`auto` quantization will %s; set VECTORS_QUANTIZATION=int8 or =fp32 "
+        "to override after consulting docs/embedding-quantization.md.",
+        vendor, family_str, model_str, platform.machine() or "?", confirmed,
+        "disable local vectors" if confirmed else "optimistically pick int8",
+    )
+
+
 def detect_avx_vnni_details() -> tuple[bool, bool]:
     """Return ``(has_int8_fast_path, absence_confirmed)``.
 
@@ -520,8 +550,11 @@ def detect_avx_vnni_details() -> tuple[bool, bool]:
     (INT8 would be slow and FP32 weights are not shipped).
     """
     if platform.machine().lower() in ("arm64", "aarch64"):
-        return _detect_int8_fast_path_arm()
-    return _detect_int8_fast_path_x86()
+        result = _detect_int8_fast_path_arm()
+    else:
+        result = _detect_int8_fast_path_x86()
+    _log_int8_fast_path_decision(*result)
+    return result
 
 
 def detect_avx_vnni() -> bool:
@@ -1097,9 +1130,14 @@ def get_embedding_service() -> EmbeddingService:
 
 def reset_embedding_service_for_tests() -> None:
     """Test-only: drop the singleton so the next ``get_embedding_service``
-    call rebuilds with whatever monkeypatched config / RAM the test set up."""
-    global _SERVICE
+    call rebuilds with whatever monkeypatched config / RAM the test set up.
+
+    Also clears :data:`_VNNI_DECISION_LOGGED` so a test that monkeypatches
+    detection can verify the warning is emitted on its synthetic boot.
+    """
+    global _SERVICE, _VNNI_DECISION_LOGGED
     _SERVICE = None
+    _VNNI_DECISION_LOGGED = False
 
 
 def _build_default_service() -> EmbeddingService:

--- a/memory/embeddings_fallback.py
+++ b/memory/embeddings_fallback.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""Import-time fallback stubs for :mod:`memory.embeddings`.
+
+This module exists so that if ``memory/embeddings.py`` is quarantined or
+deleted by an external actor (over-eager antivirus has done both: the
+historical CPUID probe was flagged ``Trojan/Python.ShellLoader.i`` and
+the file was removed on disk while N.E.K.O was running), the memory
+subsystem still imports successfully and degrades to the pre-vector code
+path instead of crashing with ``ImportError`` at module load.
+
+The signatures mirror the real ``memory.embeddings`` module's public
+surface. Every function answers exactly the way the real implementation
+would answer when its :class:`EmbeddingService` is in the sticky
+``DISABLED`` state — that path is already covered by the existing
+"vectors disabled → no-op" branches in the rest of the memory
+pipeline, so consumers don't need any extra ``hasattr`` guards.
+
+Kept intentionally pure-Python with no imports beyond ``logging`` and no
+ctypes / VirtualAlloc / inline machine code, so AV heuristic scanners
+have nothing to latch onto here.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── service stub ──────────────────────────────────────────────────────
+
+
+class _DisabledEmbeddingService:
+    """Permanently-disabled twin of :class:`memory.embeddings.EmbeddingService`.
+
+    Every consumer reaches into the service via ``is_available()`` first
+    (the gate documented at the top of ``embeddings.py``), so as long as
+    that returns ``False`` everything downstream takes the pre-vector
+    fallback path. The other methods are present so a stray call site
+    we missed still gets a safe answer instead of ``AttributeError``.
+    """
+
+    _DISABLE_REASON = "embeddings_module_missing"
+
+    def is_available(self) -> bool:
+        return False
+
+    def is_disabled(self) -> bool:
+        return True
+
+    def disable_reason(self) -> str:
+        return self._DISABLE_REASON
+
+    def model_id(self) -> str | None:
+        return None
+
+    def dim(self) -> int | None:
+        return None
+
+    def quantization(self) -> str | None:
+        return None
+
+    def ram_gb(self) -> float | None:
+        return None
+
+    def has_vnni(self) -> bool:
+        return False
+
+    async def request_load(self) -> bool:
+        return False
+
+    async def embed(self, text: str) -> list[float] | None:
+        return None
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float] | None]:
+        return [None] * len(texts) if texts else []
+
+
+_SERVICE_SINGLETON = _DisabledEmbeddingService()
+
+
+def get_embedding_service() -> _DisabledEmbeddingService:
+    return _SERVICE_SINGLETON
+
+
+def reset_embedding_service_for_tests() -> None:  # pragma: no cover — stub
+    """No-op in the stub: there's nothing to reset and tests targeting
+    the real module won't import this file."""
+    return None
+
+
+# ── cache-helper stubs ────────────────────────────────────────────────
+
+
+def clear_embedding_fields(entry: dict) -> None:
+    if not isinstance(entry, dict):
+        return
+    entry["embedding"] = None
+    entry["embedding_text_sha256"] = None
+    entry["embedding_model_id"] = None
+
+
+def stamp_embedding_fields(  # pragma: no cover — never reached without service
+    entry: dict, vector, text: str, model_id: str,
+) -> None:
+    """No-op: the disabled service never produces a vector to stamp."""
+    return None
+
+
+def is_cached_embedding_valid(
+    entry: dict, current_text: str, current_model_id: str | None,
+) -> bool:
+    return False
+
+
+# ── decode helpers ────────────────────────────────────────────────────
+
+
+def decode_embedding(emb: Any):
+    """Always returns ``None`` — without the real encoder we can't tell
+    a valid base64 fp16 payload from a legacy ``list[float]`` row, so
+    we refuse to decode and let the cosine path treat the candidate as
+    unembedded."""
+    return None
+
+
+def cosine_similarity(a: Any, b: Any) -> float:  # noqa: ARG001
+    """Always 0.0 — consumers fall back to non-vector ranking signals."""
+    return 0.0
+
+
+def parse_dim_from_model_id(model_id: str | None) -> int | None:  # noqa: ARG001
+    """The real implementation parses a stamped model_id back to its
+    dim; with no real service nothing should ever carry a usable
+    model_id, so we always return ``None`` here."""
+    return None
+
+
+def _warn_once(consumer_module: str) -> None:
+    """Helper for the four top-level import sites to log a single
+    warning when they fall back to this stub. Importers call this from
+    inside their ``except ImportError`` block; the gate avoids spamming
+    on every reload of the consuming module."""
+    if getattr(_warn_once, "_seen", None) is None:
+        _warn_once._seen = set()  # type: ignore[attr-defined]
+    seen: set = _warn_once._seen  # type: ignore[attr-defined]
+    if consumer_module in seen:
+        return
+    seen.add(consumer_module)
+    logger.warning(
+        "memory.embeddings is unavailable; %s falling back to disabled "
+        "stub — local vector recall, fact dedup and refine clustering "
+        "will skip the embedding path until the real module is restored "
+        "(check antivirus quarantine if the file vanished from disk)",
+        consumer_module,
+    )

--- a/memory/fact_dedup.py
+++ b/memory/fact_dedup.py
@@ -42,7 +42,15 @@ import threading
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from memory.embeddings import cosine_similarity
+try:
+    from memory.embeddings import cosine_similarity
+except ImportError:
+    # See ``embedding_worker`` for context on the fallback path. With a
+    # 0.0-cosine stub the resolver's pending queue stays empty and the
+    # legacy hash + FTS5 dedup is the entire pipeline — same shape as
+    # ``is_available() == False`` in the real module.
+    from memory.embeddings_fallback import cosine_similarity, _warn_once
+    _warn_once(__name__)
 from memory.facts import safe_int_field
 from utils.cloudsave_runtime import MaintenanceModeError, assert_cloudsave_writable
 from utils.file_utils import (

--- a/memory/recall.py
+++ b/memory/recall.py
@@ -48,12 +48,26 @@ from __future__ import annotations
 import logging
 import re
 
-from memory.embeddings import (
-    decode_embedding,
-    get_embedding_service,
-    is_cached_embedding_valid,
-    parse_dim_from_model_id,
-)
+try:
+    from memory.embeddings import (
+        decode_embedding,
+        get_embedding_service,
+        is_cached_embedding_valid,
+        parse_dim_from_model_id,
+    )
+except ImportError:
+    # See ``embedding_worker`` for context. With the disabled-service
+    # stub, ``MemoryRecallReranker`` keeps working but skips the cosine
+    # prefilter (decode_embedding returns None for every candidate) —
+    # callers already handle that path via ``rerank=False`` semantics.
+    from memory.embeddings_fallback import (
+        decode_embedding,
+        get_embedding_service,
+        is_cached_embedding_valid,
+        parse_dim_from_model_id,
+        _warn_once,
+    )
+    _warn_once(__name__)
 
 logger = logging.getLogger(__name__)
 

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -32,12 +32,27 @@ from config import (
     MEMORY_REFINE_REVISIT_AFTER_DAYS,
     MEMORY_REFINE_TOPK_PER_ENTRY,
 )
-from memory.embeddings import (
-    decode_embedding,
-    get_embedding_service,
-    is_cached_embedding_valid,
-    parse_dim_from_model_id,
-)
+try:
+    from memory.embeddings import (
+        decode_embedding,
+        get_embedding_service,
+        is_cached_embedding_valid,
+        parse_dim_from_model_id,
+    )
+except ImportError:
+    # See ``embedding_worker`` for context. With the disabled-service
+    # stub, ``MemoryRefineEngine`` sees ``is_available() == False`` on
+    # every pass and short-circuits the cluster scan — the module
+    # docstring already calls out the "embedding unavailable → no-op"
+    # contract.
+    from memory.embeddings_fallback import (
+        decode_embedding,
+        get_embedding_service,
+        is_cached_embedding_valid,
+        parse_dim_from_model_id,
+        _warn_once,
+    )
+    _warn_once(__name__)
 from utils.logger_config import get_module_logger
 from utils.token_tracker import set_call_type
 

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -235,12 +235,12 @@ def test_detect_avx_vnni_arm64_linux_proc_cpuinfo_fallback(monkeypatch):
     assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
-def test_detect_avx_vnni_x86_cpuid_probe_is_authoritative(monkeypatch):
-    """When the direct CPUID probe returns a definitive answer, x86
+def test_detect_avx_vnni_x86_family_model_lookup_is_authoritative(monkeypatch):
+    """When the family/model lookup returns a definitive answer, x86
     detection MUST trust it and never fall back to py-cpuinfo. py-cpuinfo
     on Windows silently omits ``avx_vnni`` from its flag list (Alder Lake
     onwards on Intel, Zen 4+ on AMD), so consulting it after a positive
-    CPUID would let the stale absence overwrite the correct answer and
+    lookup would let the stale absence overwrite the correct answer and
     re-introduce the sticky-disable that #1395 fixed.
     """
     from memory import embeddings as emb_mod
@@ -248,35 +248,40 @@ def test_detect_avx_vnni_x86_cpuid_probe_is_authoritative(monkeypatch):
     monkeypatch.setattr(emb_mod.platform, "machine", lambda: "AMD64")
     monkeypatch.setattr(emb_mod.platform, "system", lambda: "Windows")
 
-    # Force a py-cpuinfo result that disagrees with the probe, so the
-    # test fails loudly if the fallback ever runs ahead of the probe.
+    # Force a py-cpuinfo result that disagrees with the lookup, so the
+    # test fails loudly if the fallback ever runs ahead of the lookup.
     class _CpuinfoNoVnni:
         @staticmethod
         def get_cpu_info():
             return {"flags": ["avx", "avx2"]}
 
     monkeypatch.setitem(sys.modules, "cpuinfo", _CpuinfoNoVnni)
+    # Each detect call lazily re-reads the log gate; clear it so the
+    # warning logic is exercised on the positive and negative branch.
+    emb_mod.reset_embedding_service_for_tests()
 
-    monkeypatch.setattr(emb_mod, "_probe_avx_vnni_via_cpuid", lambda: True)
+    monkeypatch.setattr(emb_mod, "_vnni_via_family_model", lambda: (True, True))
     assert emb_mod.detect_avx_vnni_details() == (True, True)
 
-    monkeypatch.setattr(emb_mod, "_probe_avx_vnni_via_cpuid", lambda: False)
+    emb_mod.reset_embedding_service_for_tests()
+    monkeypatch.setattr(emb_mod, "_vnni_via_family_model", lambda: (False, True))
     assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
-def test_detect_avx_vnni_x86_falls_back_to_cpuinfo_when_probe_unavailable(
+def test_detect_avx_vnni_x86_falls_back_to_cpuinfo_when_lookup_inconclusive(
     monkeypatch,
 ):
-    """Sandboxes that block executable allocations make the CPUID probe
-    return None. In that case the existing py-cpuinfo / /proc/cpuinfo
-    chain must still drive the decision so we don't lose detection on
-    runtimes that worked before #1395.
+    """Brand-new microarchitectures predate the family/model table and
+    return ``(False, False)`` from the lookup. In that case the existing
+    py-cpuinfo / /proc/cpuinfo chain must still drive the decision so we
+    don't lose detection on runtimes that worked before this PR.
     """
     from memory import embeddings as emb_mod
 
     monkeypatch.setattr(emb_mod.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(emb_mod.platform, "system", lambda: "Linux")
-    monkeypatch.setattr(emb_mod, "_probe_avx_vnni_via_cpuid", lambda: None)
+    monkeypatch.setattr(emb_mod, "_vnni_via_family_model", lambda: (False, False))
+    emb_mod.reset_embedding_service_for_tests()
 
     class _CpuinfoWithVnni:
         @staticmethod
@@ -292,31 +297,104 @@ def test_detect_avx_vnni_x86_falls_back_to_cpuinfo_when_probe_unavailable(
             return {"flags": ["avx", "avx2"]}
 
     monkeypatch.setitem(sys.modules, "cpuinfo", _CpuinfoNoVnni)
+    emb_mod.reset_embedding_service_for_tests()
     assert emb_mod.detect_avx_vnni_details() == (False, True)
 
 
-def test_probe_avx_vnni_skips_non_windows_and_non_x86(monkeypatch):
-    """The probe is scoped to Windows x86_64. On Linux it must NOT issue
-    CPUID — ``arch_prctl(ARCH_SET_CPUID, 0)`` (rr debugger, certain
-    sandboxes) turns ``cpuid`` into SIGSEGV, which Python's try/except
-    cannot catch and would hard-kill the process (Codex P1 on #1402).
-    On macOS Intel there is no chip in the wild with AVX-VNNI anyway,
-    and hardened runtime breaks PROT_EXEC. ARM hosts are handled by the
-    sibling :func:`_detect_int8_fast_path_arm` and must not enter the
-    x86 shellcode path.
+def test_vnni_via_family_model_recognises_known_microarchitectures(monkeypatch):
+    """The lookup table replaces the deleted CPUID shellcode probe. It
+    MUST answer authoritatively for Alder Lake+ Intel client CPUs (the
+    class that py-cpuinfo's Windows backend silently misreports) and
+    for Zen 4+ AMD CPUs, and stay inconclusive on older / unknown
+    vendors so the py-cpuinfo fallback can still try.
     """
     from memory import embeddings as emb_mod
 
+    # Arrow Lake — the chip class that originally motivated #1402 and
+    # broke when CPUID was removed without this lookup.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("GenuineIntel", 6, 0xC6),
+    )
+    assert emb_mod._vnni_via_family_model() == (True, True)
+
+    # Skylake — Family 6 but pre-Alder, ambiguous (might have
+    # AVX512-VNNI as on Cascade Lake-X, might not on plain Skylake).
+    # Lookup stays inconclusive so py-cpuinfo's avx512_vnni flag drives.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("GenuineIntel", 6, 0x55),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, False)
+
+    # Zen 4 (Family 0x19) → confirmed VNNI.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x61),
+    )
+    assert emb_mod._vnni_via_family_model() == (True, True)
+
+    # Zen 3 (Family 0x19? — note Zen 3 is also Family 0x19 in some
+    # parts; the table's MIN_FAMILY=0x19 means we conservatively say
+    # "yes" for the whole family. Use Zen 2 / Family 0x17 to verify the
+    # confirmed-no branch instead.)
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x17, 0x71),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, True)
+
+    # Unknown vendor (Hygon, Centaur, qemu-tcg, ...) — inconclusive.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("HygonGenuine", 0x18, 0),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, False)
+
+    # No reader could answer at all (locked-down host) — inconclusive.
+    monkeypatch.setattr(emb_mod, "_read_cpu_family_model", lambda: None)
+    assert emb_mod._vnni_via_family_model() == (False, False)
+
+
+def test_log_int8_fast_path_decision_emits_once_per_process(monkeypatch, caplog):
+    """When the chosen CPU lacks the INT8 fast path, the service must
+    log exactly one warning naming the vendor/family/model so triage
+    can recognise the CPU and decide whether to extend the lookup
+    table or raise VECTORS_QUANTIZATION explicitly.
+    """
+    import logging
+
+    from memory import embeddings as emb_mod
+
+    emb_mod.reset_embedding_service_for_tests()
     monkeypatch.setattr(emb_mod.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(emb_mod.platform, "system", lambda: "Linux")
-    assert emb_mod._probe_avx_vnni_via_cpuid() is None
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("GenuineIntel", 6, 0x55),
+    )
+    monkeypatch.setattr(emb_mod, "_vnni_via_family_model", lambda: (False, True))
 
-    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Darwin")
-    assert emb_mod._probe_avx_vnni_via_cpuid() is None
+    class _CpuinfoNoVnni:
+        @staticmethod
+        def get_cpu_info():
+            return {"flags": ["avx", "avx2"]}
 
-    monkeypatch.setattr(emb_mod.platform, "machine", lambda: "aarch64")
-    monkeypatch.setattr(emb_mod.platform, "system", lambda: "Windows")
-    assert emb_mod._probe_avx_vnni_via_cpuid() is None
+    monkeypatch.setitem(sys.modules, "cpuinfo", _CpuinfoNoVnni)
+
+    with caplog.at_level(logging.WARNING, logger=emb_mod.logger.name):
+        emb_mod.detect_avx_vnni_details()
+        emb_mod.detect_avx_vnni_details()  # second call must not log again.
+
+    no_fast_path = [
+        r for r in caplog.records if "no INT8 fast path" in r.getMessage()
+    ]
+    assert len(no_fast_path) == 1, no_fast_path
+    msg = no_fast_path[0].getMessage()
+    assert "vendor=GenuineIntel" in msg
+    assert "family=0x6" in msg
+    assert "model=0x55" in msg
+    assert "confirmed=True" in msg
 
 
 def test_parse_dim_from_model_id_picks_runtime_dim_under_ambiguous_profile():

--- a/tests/unit/test_embedding_service.py
+++ b/tests/unit/test_embedding_service.py
@@ -327,17 +327,70 @@ def test_vnni_via_family_model_recognises_known_microarchitectures(monkeypatch):
     )
     assert emb_mod._vnni_via_family_model() == (False, False)
 
-    # Zen 4 (Family 0x19) → confirmed VNNI.
+    # Zen 4 desktop — Raphael (Ryzen 7000), Family 0x19 Model 0x61.
+    # Has AVX-VNNI, must be confirmed True.
     monkeypatch.setattr(
         emb_mod, "_read_cpu_family_model",
         lambda: ("AuthenticAMD", 0x19, 0x61),
     )
     assert emb_mod._vnni_via_family_model() == (True, True)
 
-    # Zen 3 (Family 0x19? — note Zen 3 is also Family 0x19 in some
-    # parts; the table's MIN_FAMILY=0x19 means we conservatively say
-    # "yes" for the whole family. Use Zen 2 / Family 0x17 to verify the
-    # confirmed-no branch instead.)
+    # Zen 4 mobile — Phoenix (Ryzen 7040), Family 0x19 Model 0x74.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x74),
+    )
+    assert emb_mod._vnni_via_family_model() == (True, True)
+
+    # Zen 4 server — Genoa (EPYC 9004), Family 0x19 Model 0x11.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x11),
+    )
+    assert emb_mod._vnni_via_family_model() == (True, True)
+
+    # Zen 3 desktop — Vermeer (Ryzen 5000), Family 0x19 Model 0x01.
+    # Codex P1: pre-fix code returned (True, True) because the gate was
+    # family-only; correct behaviour is confirmed-no so ``auto``
+    # quantization disables vectors instead of running a slow INT8 path
+    # on a CPU that lacks AVX-VNNI.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x01),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, True)
+
+    # Zen 3 APU — Cezanne (Ryzen 5000G/U), Family 0x19 Model 0x21.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x21),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, True)
+
+    # Zen 3+ — Rembrandt (Ryzen 6000 mobile), Family 0x19 Model 0x44.
+    # Still no AVX-VNNI despite the architectural ``+``.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x44),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, True)
+
+    # Zen 5 (Family 0x1A) — every shipped part has VNNI.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x1A, 0x44),
+    )
+    assert emb_mod._vnni_via_family_model() == (True, True)
+
+    # Unmapped Family-19h model (future stepping not yet in AMD's
+    # documented ranges) — inconclusive so py-cpuinfo can have a try.
+    monkeypatch.setattr(
+        emb_mod, "_read_cpu_family_model",
+        lambda: ("AuthenticAMD", 0x19, 0x80),
+    )
+    assert emb_mod._vnni_via_family_model() == (False, False)
+
+    # Zen 2 (Family 0x17) — no AVX-VNNI, confirmed.
     monkeypatch.setattr(
         emb_mod, "_read_cpu_family_model",
         lambda: ("AuthenticAMD", 0x17, 0x71),

--- a/tests/unit/test_embeddings_fallback.py
+++ b/tests/unit/test_embeddings_fallback.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for memory.embeddings_fallback — the import-time stub
+that keeps the memory pipeline alive when ``memory/embeddings.py`` is
+quarantined by antivirus.
+
+These tests don't require numpy / onnxruntime / tokenizers, so they run
+on every developer workstation regardless of the embedding model bundle
+state — that matters because the whole point of the fallback is to keep
+working when the heavyweight deps are unreachable.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def fallback():
+    """Return a freshly-imported fallback module per test, so the
+    per-process ``_warn_once`` cache doesn't leak across cases."""
+    if "memory.embeddings_fallback" in sys.modules:
+        del sys.modules["memory.embeddings_fallback"]
+    mod = importlib.import_module("memory.embeddings_fallback")
+    yield mod
+
+
+def test_disabled_service_reports_unavailable(fallback):
+    svc = fallback.get_embedding_service()
+    assert svc.is_available() is False
+    assert svc.is_disabled() is True
+    assert svc.disable_reason() == "embeddings_module_missing"
+    assert svc.model_id() is None
+    assert svc.dim() is None
+    assert svc.quantization() is None
+    assert svc.ram_gb() is None
+    assert svc.has_vnni() is False
+
+
+def test_disabled_service_embed_methods_return_safe_values(fallback):
+    svc = fallback.get_embedding_service()
+    assert asyncio.run(svc.embed("hello")) is None
+    assert asyncio.run(svc.embed_batch(["a", "b", "c"])) == [None, None, None]
+    assert asyncio.run(svc.embed_batch([])) == []
+    # request_load() must report failure so any cold-start poller exits
+    # cleanly instead of spinning expecting eventual READY.
+    assert asyncio.run(svc.request_load()) is False
+
+
+def test_cache_stubs_round_trip_safely(fallback):
+    entry = {
+        "embedding": "AAAA",
+        "embedding_text_sha256": "abc",
+        "embedding_model_id": "any",
+    }
+    fallback.clear_embedding_fields(entry)
+    assert entry == {
+        "embedding": None,
+        "embedding_text_sha256": None,
+        "embedding_model_id": None,
+    }
+    # Non-dict input is tolerated — mirrors the real impl's guard so a
+    # stray legacy row shape can't crash the caller.
+    fallback.clear_embedding_fields("not-a-dict")  # type: ignore[arg-type]
+
+    # stamp is a no-op; nothing should change on the entry.
+    fallback.stamp_embedding_fields(entry, [0.1, 0.2], "hello", "id")
+    assert entry["embedding"] is None
+    assert entry["embedding_text_sha256"] is None
+
+    assert fallback.is_cached_embedding_valid(entry, "hello", "id") is False
+    assert fallback.is_cached_embedding_valid({}, "", None) is False
+
+
+def test_decode_helpers_always_inert(fallback):
+    assert fallback.decode_embedding(None) is None
+    assert fallback.decode_embedding("AAAA") is None
+    assert fallback.decode_embedding([0.1, 0.2]) is None
+    assert fallback.cosine_similarity("a", "b") == 0.0
+    assert fallback.parse_dim_from_model_id("foo-256d-int8") is None
+    assert fallback.parse_dim_from_model_id(None) is None
+
+
+def test_warn_once_emits_at_most_once_per_consumer(fallback, caplog):
+    """A consumer module that falls back should log exactly one
+    warning per consumer-module name — repeated reloads must not
+    spam the log."""
+    with caplog.at_level(logging.WARNING, logger=fallback.logger.name):
+        fallback._warn_once("memory.embedding_worker")
+        fallback._warn_once("memory.embedding_worker")  # duplicate
+        fallback._warn_once("memory.fact_dedup")        # new consumer
+
+    msgs = [r.getMessage() for r in caplog.records]
+    worker_hits = [m for m in msgs if "memory.embedding_worker falling back" in m]
+    dedup_hits = [m for m in msgs if "memory.fact_dedup falling back" in m]
+    assert len(worker_hits) == 1, msgs
+    assert len(dedup_hits) == 1, msgs
+    # All warnings carry the AV-quarantine triage hint so operators
+    # know where to look without grepping the source tree.
+    assert all("antivirus quarantine" in m for m in worker_hits + dedup_hits)
+
+
+def test_top_level_consumers_import_when_embeddings_missing():
+    """If ``memory.embeddings`` blows up at import time the four
+    top-level consumers MUST still be importable. We simulate the
+    quarantine by pinning ``sys.modules['memory.embeddings'] = None``
+    — Python's import system treats that sentinel as a definitive
+    "module already failed to import", which is exactly what happens
+    after antivirus deletes the .py from disk and Python's cache
+    sees the prior ImportError.
+
+    We deliberately don't use pytest's ``monkeypatch.setitem`` here:
+    its undo runs *after* this function returns, and would re-clobber
+    the snapshot we restore in ``finally`` (the undo sees the snapshot
+    cache, not the original test entry state). Hand-rolling the dance
+    keeps the restore order under our control so the rest of the suite
+    sees the cache it expected.
+    """
+    saved = {k: sys.modules[k] for k in list(sys.modules) if k.startswith("memory")}
+    try:
+        for k in saved:
+            del sys.modules[k]
+        sys.modules["memory.embeddings"] = None  # type: ignore[assignment]
+
+        from memory import embedding_worker, fact_dedup, recall, refine
+
+        svc = embedding_worker.get_embedding_service()
+        assert svc.is_available() is False
+        assert svc.disable_reason() == "embeddings_module_missing"
+
+        assert fact_dedup.cosine_similarity("a", "b") == 0.0
+        assert recall.decode_embedding("anything") is None
+        assert refine.parse_dim_from_model_id("local-text-retrieval-v1-256d-int8") is None
+    finally:
+        # Drop the four consumer modules we just imported under the
+        # poisoned cache — they hold references to the fallback stubs,
+        # not the real ones, and would shadow the originals if any
+        # later test in the same process did ``from memory.X import Y``.
+        for k in list(sys.modules):
+            if k.startswith("memory"):
+                del sys.modules[k]
+        sys.modules.update(saved)


### PR DESCRIPTION
## 背景

火绒（Huorong）会把 `memory/embeddings.py` 删掉，报毒名 `Trojan/Python.ShellLoader.i`。

定位到原因在 PR #1402 引入的 AVX-VNNI CPUID 探测分支 `_probe_avx_vnni_via_cpuid`：

1. `VirtualAlloc(PAGE_EXECUTE_READWRITE)` 申请可执行可读写内存
2. 写入硬编码 x86_64 机器码字节（含 `0x0F, 0xA2` CPUID 指令）
3. `ctypes.CFUNCTYPE` 把字节流转成函数指针并调用

这三件套是 Python shellcode loader 的经典模式，启发式扫描器看 API 模式而非实际指令，火绒的签名名字直接就叫 \"ShellLoader\"。代码本身完全无害（只是为了绕过 py-cpuinfo Windows 后端漏报 `avx_vnni` 的 bug），但 AV 不会区分。

## 改动

需要两件事一起做才能彻底解决：

### A. 去除 shellcode：用 family/model 查表替代 CPUID 探测

`_vnni_via_family_model()` 从稳定的操作系统接口读 CPU vendor/family/model：

| OS | 来源 |
|---|---|
| Windows | `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0\Identifier`（注册表） |
| Linux | `/proc/cpuinfo` 的 `vendor_id` / `cpu family` / `model` 三行 |

然后查一张小表：

| Vendor | 已知有 AVX-VNNI |
|---|---|
| Intel Family 6 | Model ≥ 0x97（Alder/Raptor/Meteor/Arrow/Lunar/Panther Lake、Sapphire/Emerald Rapids） |
| AMD | Family ≥ 0x19（Zen 4 / Zen 5） |

较旧的 Family-6 Intel 有 AVX512-VNNI（Cascade/Ice Lake-server、Tiger/Rocket Lake、Sapphire Rapids），这些 py-cpuinfo 在 Windows 上**能**正常识别（漏报的只是 `avx_vnni`），所以不需要进入表里。

未知 vendor / 未识别的 family/model → 保留为 inconclusive，让 py-cpuinfo / `/proc/cpuinfo` 接手；`auto` quantization 在 inconclusive 时仍乐观选 int8，跟原 CPUID 探测在 DEP 锁定沙箱下的行为一致。

### B. 即使 embeddings.py 被删，记忆系统也不崩

新增 `memory/embeddings_fallback.py`，提供 `EmbeddingService` 公开接口的 disabled-stub 实现。四个顶级 import 站点（`embedding_worker` / `fact_dedup` / `recall` / `refine`）用 try/except 包起来，缺失时降级到 fallback。

降级后 `is_available() == False`，全管线的 \"vectors disabled → pre-vector 路径\" 分支接管：本地向量召回、fact 去重 paraphrase 检测、refine cluster 扫描全部跳过，记忆系统继续工作。

Fallback 模块本身是纯 Python，无 ctypes / VirtualAlloc / 内联字节，AV 启发式扫描器没东西可咬。

### C. 启动诊断：首次判定无 INT8 fast path 时 warning 一次

`_log_int8_fast_path_decision()` 进程内只触发一次，包含 `vendor / family / model / arch / confirmed`：

```
WARNING memory.embeddings: EmbeddingService: no INT8 fast path detected on this CPU
  (vendor=GenuineIntel family=0x6 model=0x55 arch=x86_64 confirmed=True).
  `auto` quantization will disable local vectors; set VECTORS_QUANTIZATION=int8
  or =fp32 to override after consulting docs/embedding-quantization.md.
```

未来再有用户反馈 \"我这台机器 vectors 被禁了\"，第一时间能从日志看到是 lookup 表没收录还是 CPU 真的不支持。

## 验证

Smoke 在用户机器（Intel Core Ultra 7 265KF，Arrow Lake，Family 6 Model 198）：

```
_read_cpu_family_model()     = ('GenuineIntel', 6, 198)
_vnni_via_family_model()     = (True, True)      ← 精确识别，跟 CPUID 探测一致
_detect_int8_fast_path_x86() = (True, True)
detect_avx_vnni_details()    = (True, True)      ← 第一次有 log，第二次不再 log
```

模拟 `sys.modules['memory.embeddings'] = None`（杀软删除场景）：

```
all four consumers imported
service.is_available()       = False
service.disable_reason()     = embeddings_module_missing
cosine_similarity('x','y')   = 0.0
decode_embedding('abc')      = None
await svc.embed('hello')     = None
```

## 测试

- `test_vnni_via_family_model_recognises_known_microarchitectures` — Arrow Lake / Zen 4 confirmed True；Zen 2 confirmed False；Skylake & 未知 vendor inconclusive
- `test_log_int8_fast_path_decision_emits_once_per_process` — 无 fast path 时正好一条 warning，包含 vendor/family/model
- `test_detect_avx_vnni_x86_family_model_lookup_is_authoritative` — py-cpuinfo 永不覆盖正向 lookup 结果
- `test_detect_avx_vnni_x86_falls_back_to_cpuinfo_when_lookup_inconclusive` — lookup 不确认时回退 py-cpuinfo / `/proc/cpuinfo`
- `test_top_level_consumers_import_when_embeddings_missing` — poison `sys.modules['memory.embeddings']`，验证 4 个 consumer 模块仍能 import 并暴露 disabled stub
- `tests/unit/test_embeddings_fallback.py` — 完整覆盖 stub 契约（is_available / embed / cache helpers / warn_once）

**125 / 125** 相关测试在 Windows x86_64 + Python 3.13 全部通过。剩下 3 个 main 上预先存在的 flake（`test_per_query_topk_*`、`test_happy_path_renders_watermarked_block`）与此改动无关，stash 我的改动后跑同样失败。

## Test plan

- [ ] CI 通过
- [ ] 在已删除 `embeddings.py` 的机器上启动 N.E.K.O，确认进程不崩，日志能看到 fallback warning
- [ ] 在 Alder Lake 之前的 Intel CPU 上（如 Skylake 普通客户端）启动，确认 `auto` quantization 进入 inconclusive → int8 路径，并产生一条 \"no INT8 fast path\" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 在嵌入式服务不可用时改进降级路径，避免导入失败导致进程中断，确保功能可继续运行（退化为不可用语义）。

* **Improvements**
  * 优化 x86 INT8/向量加速检测，采用更可靠的硬件识别与一次性诊断日志，减少误判并提供可读提示。
  * 多处模块导入改为安全降级以提升稳健性。

* **Tests**
  * 新增与调整单元测试，覆盖降级行为、检测逻辑与一次性告警。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->