### PR TITLE
feat(debug): 加 cpu_percent / task_top / gc_top / tts_queue / 句柄 等诊断字段

### DIFF
--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -60,7 +60,15 @@ _WATCHDOG_INTERVAL_SECONDS = 5 * 60  # 5 分钟
 # psutil.Process 复用：cpu_percent(None) 必须**用同一个 Process 实例**多次调用，
 # 第一次返回 0（建立基线），之后每次返回距上次的 CPU 利用率%。每次 new Process
 # 都是新基线 → 永远 0%，等于没采。`None` 表示尚未尝试初始化或环境缺 psutil。
-_PSUTIL_PROCESS: Any = None
+# ⚠️ 双 channel 隔离：cpu_percent baseline 在同实例上被共享——watchdog 和
+# endpoint 共用一个 Process 时，任意 endpoint 调用都会重置 watchdog 的窗口
+# 起点，导致下次 watchdog 拿到的 cpu_percent 不是真实 5min 窗口（可能短到几
+# 秒）。所以维护**两个独立** Process 实例：``watchdog`` channel 给 5min 周期
+# task 用，``endpoint`` channel 给按需 HTTP 用，两个 baseline 互不影响。
+# 其他 psutil 调用（memory_info / num_handles / num_threads）都是无状态瞬时
+# 查询，用哪个实例都一样——所以这俩 channel 在它们身上等价。
+_PSUTIL_PROCESS_WATCHDOG: Any = None
+_PSUTIL_PROCESS_ENDPOINT: Any = None
 _PSUTIL_INIT_TRIED = False
 
 
@@ -68,36 +76,43 @@ _PSUTIL_INIT_TRIED = False
 # Snapshot 采集
 # ---------------------------------------------------------------------------
 
-def _get_psutil_process() -> Any:
-    """惰性初始化 + 复用同一个 ``psutil.Process``。
+def _get_psutil_process(channel: str = "watchdog") -> Any:
+    """惰性初始化 + 复用 ``psutil.Process``。两 channel 各自一个实例。
 
-    第一次调用时尝试 import psutil 并 prime ``cpu_percent``（首次调用约定回 0，
-    建立基线，后续才有意义）。失败则永久返回 None，不再重试——既避免反复
-    import 噪音，也让缺 psutil 的环境曲线上看 cpu_percent/num_handles 一律 null
-    跟「真有 leak」明确区分。"""
-    global _PSUTIL_PROCESS, _PSUTIL_INIT_TRIED
-    if _PSUTIL_INIT_TRIED:
-        return _PSUTIL_PROCESS
-    _PSUTIL_INIT_TRIED = True
-    try:
-        import psutil  # type: ignore
-        proc = psutil.Process()
-        # Prime：首次调用约定回 0，立刻丢掉，下次才有真值。
-        proc.cpu_percent(interval=None)
-        _PSUTIL_PROCESS = proc
-    except Exception:
-        _PSUTIL_PROCESS = None
-    return _PSUTIL_PROCESS
+    第一次调用时尝试 import psutil 并 prime 两个实例的 ``cpu_percent``（首次
+    约定回 0 建立基线，后续才有意义）。失败则永久返回 None，不再重试——既
+    避免反复 import 噪音，也让缺 psutil 的环境曲线上 cpu_percent/num_handles
+    一律 null 跟「真有 leak」明确区分。
+
+    ``channel="watchdog"`` / ``"endpoint"`` 选择独立 baseline 实例。其他无状
+    态 psutil 调用（memory_info/num_handles 等）也走这里，channel 选哪个都行
+    且默认 watchdog。"""
+    global _PSUTIL_PROCESS_WATCHDOG, _PSUTIL_PROCESS_ENDPOINT, _PSUTIL_INIT_TRIED
+    if not _PSUTIL_INIT_TRIED:
+        _PSUTIL_INIT_TRIED = True
+        try:
+            import psutil  # type: ignore
+            w = psutil.Process()
+            e = psutil.Process()
+            # Prime 两个实例：首次调用约定回 0，立刻丢掉，下次才有真值。
+            w.cpu_percent(interval=None)
+            e.cpu_percent(interval=None)
+            _PSUTIL_PROCESS_WATCHDOG = w
+            _PSUTIL_PROCESS_ENDPOINT = e
+        except Exception:
+            _PSUTIL_PROCESS_WATCHDOG = None
+            _PSUTIL_PROCESS_ENDPOINT = None
+    return _PSUTIL_PROCESS_ENDPOINT if channel == "endpoint" else _PSUTIL_PROCESS_WATCHDOG
 
 
-def _safe_rss_mb() -> float | None:
+def _safe_rss_mb(channel: str = "watchdog") -> float | None:
     """读取当前进程**当前** RSS（MB）；只在 psutil 可用时返回，否则 None。
 
     历史里曾用 ``resource.getrusage(...).ru_maxrss`` 做 fallback，但那是
     **lifetime peak**——一旦上去就不下降。用来画 leak 趋势会把一次性内存
     高峰永久误读成 leak，比没有这个字段还误导。所以**宁可返回 None**也不
     走 ru_maxrss。打包发行版默认就带 psutil，源码模式 ``uv sync`` 也会装。"""
-    proc = _get_psutil_process()
+    proc = _get_psutil_process(channel)
     if proc is None:
         return None
     try:
@@ -107,7 +122,7 @@ def _safe_rss_mb() -> float | None:
         return None
 
 
-def _safe_psutil_extras() -> dict[str, Any]:
+def _safe_psutil_extras(channel: str = "watchdog") -> dict[str, Any]:
     """补 psutil 能给的廉价 psutil 指标：cpu%、Win handle/POSIX fd。
 
     所有调用都 < 0.01 ms（Windows 实测）。``num_threads()`` 在 Windows 是
@@ -128,7 +143,7 @@ def _safe_psutil_extras() -> dict[str, Any]:
         "cpu_count": None,
         "num_handles": None,
     }
-    proc = _get_psutil_process()
+    proc = _get_psutil_process(channel)
     if proc is None:
         return out
     try:
@@ -155,12 +170,12 @@ def _safe_psutil_extras() -> dict[str, Any]:
     return out
 
 
-def _safe_psutil_heavy() -> dict[str, Any]:
+def _safe_psutil_heavy(channel: str = "watchdog") -> dict[str, Any]:
     """psutil 慢调用——``num_threads()`` 在 Windows 8 ms 系统调用。
 
     Deep tick 专用，不走每次 watchdog 周期。"""
     out: dict[str, Any] = {"num_threads": None}
-    proc = _get_psutil_process()
+    proc = _get_psutil_process(channel)
     if proc is None:
         return out
     try:
@@ -304,7 +319,7 @@ def _safe_proactive_history_size() -> dict[str, int]:
     return out
 
 
-def _collect_snapshot(include_deep: bool = False) -> dict[str, Any]:
+def _collect_snapshot(include_deep: bool = False, channel: str = "watchdog") -> dict[str, Any]:
     """单次快照采集。每个字段独立 try 过——任意一项炸了不影响其他。
 
     Default ``include_deep=False``——cheap-only 采样 ~0.05ms 自身耗时，
@@ -313,7 +328,11 @@ def _collect_snapshot(include_deep: bool = False) -> dict[str, Any]:
     ``include_deep=True`` 跑慢字段：``gc.get_objects()`` 45ms（统计内存对象
     type 分布——定位「是什么对象在涨」的金线）+ Windows ``num_threads()``
     8ms（线程泄漏检测）。两者都是不释放 GIL 的 C 调用，会阻塞 event loop
-    50ms+，所以 **watchdog 永不调它**——仅留给按需 endpoint 主动触发。"""
+    50ms+，所以 **watchdog 永不调它**——仅留给按需 endpoint 主动触发。
+
+    ``channel`` 选 psutil cpu_percent baseline：``"watchdog"`` 5min 周期 task
+    专用，``"endpoint"`` HTTP 按需专用，两个 baseline 独立——避免用户访问
+    endpoint 重置 watchdog 的窗口起点。"""
     snap: dict[str, Any] = {
         "ts": time.time(),
         "uptime_sec": time.monotonic() - _PROCESS_START_MONO,
@@ -323,9 +342,9 @@ def _collect_snapshot(include_deep: bool = False) -> dict[str, Any]:
     except Exception:
         snap["asyncio_tasks"] = None
     snap["asyncio_task_top"] = _safe_asyncio_task_top()
-    snap["rss_mb"] = _safe_rss_mb()
+    snap["rss_mb"] = _safe_rss_mb(channel)
     # psutil extras 一次 dict 展平进顶层，方便画曲线时直接索引同级 key。
-    snap.update(_safe_psutil_extras())
+    snap.update(_safe_psutil_extras(channel))
     snap["conv_history"] = _safe_conv_history_lengths()
     snap["tts_queue_size"] = _safe_tts_queue_sizes()
     snap["is_responding"] = _safe_is_responding_map()
@@ -334,7 +353,7 @@ def _collect_snapshot(include_deep: bool = False) -> dict[str, Any]:
     if include_deep:
         # Deep 字段——~50 ms 阻塞但有 30 min 间隔，长跑曲线仍能画时序。
         snap["gc_object_top"] = _safe_gc_object_top()
-        snap.update(_safe_psutil_heavy())
+        snap.update(_safe_psutil_heavy(channel))
     return snap
 
 
@@ -502,8 +521,11 @@ async def debug_health(deep: bool = False) -> dict[str, Any]:
 
     实现注释：cheap 路径 ~0.13 ms 自身耗时直接同步调；deep 路径 50 ms 阻塞
     是用户**主动**触发的代价，自己等就好——不为这个场景做 to_thread 兜底，
-    省一层 thread 调度 overhead，代码直接。"""
-    current = _collect_snapshot(deep)
+    省一层 thread 调度 overhead，代码直接。
+
+    传 ``channel="endpoint"`` 走独立的 psutil cpu_percent baseline，不打乱
+    watchdog 的 5min 窗口。"""
+    current = _collect_snapshot(include_deep=deep, channel="endpoint")
     return {
         "current": current,
         "ring": list(_HEALTH_RING),

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -140,6 +140,8 @@ def _safe_psutil_extras() -> dict[str, Any]:
         # 归一化到任务管理器规模：raw / cpu_count
         out["cpu_percent"] = raw / cpu_count
     except Exception:
+        # 故意吞：psutil 子调用（cpu_count / cpu_percent）失败留 None 即可，
+        # 曲线上看到 cpu_percent=null 知道是 psutil 异常不是「真有 leak」。
         pass
     # Windows: num_handles; POSIX: num_fds. psutil 在错误平台抛 AttributeError。
     try:
@@ -148,6 +150,7 @@ def _safe_psutil_extras() -> dict[str, Any]:
         try:
             out["num_handles"] = proc.num_fds()
         except Exception:
+            # 故意吞：两个平台 API 都拿不到（容器 / 罕见 OS），num_handles 留 None。
             pass
     return out
 
@@ -163,6 +166,7 @@ def _safe_psutil_heavy() -> dict[str, Any]:
     try:
         out["num_threads"] = proc.num_threads()
     except Exception:
+        # 故意吞：num_threads 拿不到留 None，零侵入语义保留。
         pass
     return out
 

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -51,11 +51,11 @@ _PROCESS_START_MONO = time.monotonic()
 _HEALTH_RING: deque[dict[str, Any]] = deque(maxlen=200)
 _WATCHDOG_TASK: asyncio.Task | None = None
 _WATCHDOG_INTERVAL_SECONDS = 5 * 60  # 5 分钟
-# 「deep」字段（gc.get_objects 45ms + num_threads 8ms in Windows）单 tick 阻塞
-# 50ms+ 且 C 调用不释放 GIL，to_thread 也救不了 main thread。降频到 30min
-# 一次（每 6 个 watchdog tick），让 5/6 的 tick 完全无感（<5ms 阻塞）。
-_DEEP_TICK_EVERY_N = 6
-_watchdog_tick_count = 0
+# 「Deep」字段（``gc.get_objects()`` 45ms + Windows ``num_threads()`` 8ms）
+# 是 C 调用不释放 GIL，watchdog 跑就直接阻塞 event loop 50ms+。本来想降频
+# 到 30min 一次缓和，但用户体感「致命」否决——索性 watchdog **不收**这俩，
+# 只在按需 endpoint ``/api/debug/health?deep=1`` 触发。代价：ring/jsonl 没
+# 有 gc 时序数据；用户排查内存问题时手动多次访问 endpoint 自己构建时序。
 
 # psutil.Process 复用：cpu_percent(None) 必须**用同一个 Process 实例**多次调用，
 # 第一次返回 0（建立基线），之后每次返回距上次的 CPU 利用率%。每次 new Process
@@ -300,12 +300,16 @@ def _safe_proactive_history_size() -> dict[str, int]:
     return out
 
 
-def _collect_snapshot(include_deep: bool = True) -> dict[str, Any]:
+def _collect_snapshot(include_deep: bool = False) -> dict[str, Any]:
     """单次快照采集。每个字段独立 try 过——任意一项炸了不影响其他。
 
-    ``include_deep`` 控制是否跑慢字段（``gc.get_objects()`` 45 ms +
-    ``num_threads()`` 8 ms 在 Windows）。Watchdog 5/6 tick 用 False，剩 1/6
-    tick 用 True。HTTP endpoint 按需调用，默认 True 给完整数据。"""
+    Default ``include_deep=False``——cheap-only 采样 ~0.05ms 自身耗时，
+    watchdog 直接同步调即可，对 event loop 几乎无感。
+
+    ``include_deep=True`` 跑慢字段：``gc.get_objects()`` 45ms（统计内存对象
+    type 分布——定位「是什么对象在涨」的金线）+ Windows ``num_threads()``
+    8ms（线程泄漏检测）。两者都是不释放 GIL 的 C 调用，会阻塞 event loop
+    50ms+，所以 **watchdog 永不调它**——仅留给按需 endpoint 主动触发。"""
     snap: dict[str, Any] = {
         "ts": time.time(),
         "uptime_sec": time.monotonic() - _PROCESS_START_MONO,
@@ -442,20 +446,16 @@ async def _watchdog_loop() -> None:
         await asyncio.sleep(60)
     except asyncio.CancelledError:
         return
-    global _watchdog_tick_count
     while True:
         try:
-            # Deep tick 频率：每 _DEEP_TICK_EVERY_N 次跑一次完整 snapshot（含 gc
-            # 和 num_threads，那部分 ~50 ms 阻塞）。其他 tick 只跑 cheap 字段（~3 ms）。
-            # ⚠️ Python C 函数（gc / Windows API）不释放 GIL：即便 to_thread，
-            # main thread 仍在 GIL 切换间隔（默认 5 ms）内被卡。to_thread 还是
-            # 必要的——能让 main thread 在 worker 主动让出时见缝插针。
-            include_deep = (_watchdog_tick_count % _DEEP_TICK_EVERY_N) == 0
-            _watchdog_tick_count += 1
-            snap = await asyncio.to_thread(_collect_snapshot, include_deep)
+            # Watchdog **不收 deep 字段**——cheap snapshot 自身 < 0.05ms，直接同
+            # 步调反而比 to_thread 更轻（to_thread 有线程调度 overhead）。Deep
+            # 字段（gc / num_threads）改成按需 endpoint，详见 _collect_snapshot
+            # 注释。
+            snap = _collect_snapshot(include_deep=False)
             _absorb_recent_client_payload(snap)
             _HEALTH_RING.append(snap)
-            # _append_to_log 含 stat + rotate + 文件 IO，可能十几 ms：也丢 thread。
+            # 文件 IO 可能十几 ms（rotation 时 os.replace）：丢 thread 避免阻塞。
             await asyncio.to_thread(_append_to_log, snap)
         except asyncio.CancelledError:
             raise
@@ -486,15 +486,16 @@ def start_watchdog() -> None:
 # ---------------------------------------------------------------------------
 
 @router.get("/api/debug/health")
-async def debug_health() -> dict[str, Any]:
+async def debug_health(deep: bool = False) -> dict[str, Any]:
     """返回当前快照 + 最近 ring buffer。
 
     Ring buffer 让用户不用等到下一个 5-min tick——任意时刻请求都能拿到
     最近 16 小时的曲线，刷新即用。
 
-    同 watchdog：``_collect_snapshot()`` 同步且重（gc.get_objects 50-100ms），
-    丢到 thread pool 避免阻塞 event loop。"""
-    current = await asyncio.to_thread(_collect_snapshot)
+    ``deep=true`` 触发慢字段（``gc.get_objects()`` 45ms 内存对象 type 分布 +
+    Windows ``num_threads()`` 8ms 线程数）。Watchdog 永不调它们——用户排查
+    内存泄漏时手动 ``?deep=1`` 一次拿当下数据；想要时序就多次调。"""
+    current = await asyncio.to_thread(_collect_snapshot, deep)
     return {
         "current": current,
         "ring": list(_HEALTH_RING),

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -51,6 +51,11 @@ _PROCESS_START_MONO = time.monotonic()
 _HEALTH_RING: deque[dict[str, Any]] = deque(maxlen=200)
 _WATCHDOG_TASK: asyncio.Task | None = None
 _WATCHDOG_INTERVAL_SECONDS = 5 * 60  # 5 分钟
+# 「deep」字段（gc.get_objects 45ms + num_threads 8ms in Windows）单 tick 阻塞
+# 50ms+ 且 C 调用不释放 GIL，to_thread 也救不了 main thread。降频到 30min
+# 一次（每 6 个 watchdog tick），让 5/6 的 tick 完全无感（<5ms 阻塞）。
+_DEEP_TICK_EVERY_N = 6
+_watchdog_tick_count = 0
 
 # psutil.Process 复用：cpu_percent(None) 必须**用同一个 Process 实例**多次调用，
 # 第一次返回 0（建立基线），之后每次返回距上次的 CPU 利用率%。每次 new Process
@@ -103,14 +108,16 @@ def _safe_rss_mb() -> float | None:
 
 
 def _safe_psutil_extras() -> dict[str, Any]:
-    """补 psutil 能给的几个长跑泄漏经典指标：cpu%、线程数、Win handle/POSIX fd。
+    """补 psutil 能给的廉价 psutil 指标：cpu%、Win handle/POSIX fd。
+
+    所有调用都 < 0.01 ms（Windows 实测）。``num_threads()`` 在 Windows 是
+    ~8 ms 系统调用，挪到 ``_safe_psutil_heavy()`` 走 deep tick。
 
     - cpu_percent: **原始问题的金线指标**——任务管理器看到 31.9% 就是这个。
       ⚠️ 关键归一化：``proc.cpu_percent(None)`` 用 UNIX 语义（单核 100% = 100，
       多核并行可 > 100%），但任务管理器显示「占总 CPU 的百分比」（8 核单核
       打满 = 12.5%）。为了曲线**直接对得上用户截图**，除以 ``cpu_count``。
       另外报 ``cpu_percent_raw`` 留 UNIX 原值，方便要看「占了几个核」的场景。
-    - num_threads: 线程泄漏 cheap 检测。
     - num_handles / num_fds: Windows 句柄 / POSIX fd 泄漏。重启即恢复的 case
       多数对得上这个。先试 Windows 的 num_handles，再试 POSIX 的 num_fds，
       都拿不到就 None。
@@ -119,7 +126,6 @@ def _safe_psutil_extras() -> dict[str, Any]:
         "cpu_percent": None,       # 任务管理器规模（占总 CPU 百分比）
         "cpu_percent_raw": None,   # psutil 原始值（占单核百分比，多核可 > 100）
         "cpu_count": None,
-        "num_threads": None,
         "num_handles": None,
     }
     proc = _get_psutil_process()
@@ -135,10 +141,6 @@ def _safe_psutil_extras() -> dict[str, Any]:
         out["cpu_percent"] = raw / cpu_count
     except Exception:
         pass
-    try:
-        out["num_threads"] = proc.num_threads()
-    except Exception:
-        pass
     # Windows: num_handles; POSIX: num_fds. psutil 在错误平台抛 AttributeError。
     try:
         out["num_handles"] = proc.num_handles()
@@ -147,6 +149,21 @@ def _safe_psutil_extras() -> dict[str, Any]:
             out["num_handles"] = proc.num_fds()
         except Exception:
             pass
+    return out
+
+
+def _safe_psutil_heavy() -> dict[str, Any]:
+    """psutil 慢调用——``num_threads()`` 在 Windows 8 ms 系统调用。
+
+    Deep tick 专用，不走每次 watchdog 周期。"""
+    out: dict[str, Any] = {"num_threads": None}
+    proc = _get_psutil_process()
+    if proc is None:
+        return out
+    try:
+        out["num_threads"] = proc.num_threads()
+    except Exception:
+        pass
     return out
 
 
@@ -283,8 +300,12 @@ def _safe_proactive_history_size() -> dict[str, int]:
     return out
 
 
-def _collect_snapshot() -> dict[str, Any]:
-    """单次快照采集。每个字段独立 try 过——任意一项炸了不影响其他。"""
+def _collect_snapshot(include_deep: bool = True) -> dict[str, Any]:
+    """单次快照采集。每个字段独立 try 过——任意一项炸了不影响其他。
+
+    ``include_deep`` 控制是否跑慢字段（``gc.get_objects()`` 45 ms +
+    ``num_threads()`` 8 ms 在 Windows）。Watchdog 5/6 tick 用 False，剩 1/6
+    tick 用 True。HTTP endpoint 按需调用，默认 True 给完整数据。"""
     snap: dict[str, Any] = {
         "ts": time.time(),
         "uptime_sec": time.monotonic() - _PROCESS_START_MONO,
@@ -297,12 +318,15 @@ def _collect_snapshot() -> dict[str, Any]:
     snap["rss_mb"] = _safe_rss_mb()
     # psutil extras 一次 dict 展平进顶层，方便画曲线时直接索引同级 key。
     snap.update(_safe_psutil_extras())
-    snap["gc_object_top"] = _safe_gc_object_top()
     snap["conv_history"] = _safe_conv_history_lengths()
     snap["tts_queue_size"] = _safe_tts_queue_sizes()
     snap["is_responding"] = _safe_is_responding_map()
     snap["ack_waiters"] = _safe_ack_waiters_size()
     snap["proactive_history"] = _safe_proactive_history_size()
+    if include_deep:
+        # Deep 字段——~50 ms 阻塞但有 30 min 间隔，长跑曲线仍能画时序。
+        snap["gc_object_top"] = _safe_gc_object_top()
+        snap.update(_safe_psutil_heavy())
     return snap
 
 
@@ -405,18 +429,34 @@ def _absorb_recent_client_payload(server_snap: dict[str, Any]) -> None:
 
 
 async def _watchdog_loop() -> None:
-    """5-min 周期采样。任何单轮异常吞掉继续——多日跑下来不能因为一次失败掉队。"""
+    """5-min 周期采样。任何单轮异常吞掉继续——多日跑下来不能因为一次失败掉队。
+
+    ⚠️ 关键：``_collect_snapshot()`` 是同步的，里面 ``gc.get_objects()`` 在
+    N.E.K.O 实际堆下扫 28w+ 对象耗时 ~55 ms，``psutil`` / file IO 也有零星
+    几 ms。直接 ``snap = _collect_snapshot()`` 会**阻塞 event loop 50-100 ms**
+    —— 这段时间所有 async 操作（语音 chunk 处理、TTS streaming、WS ping/pong）
+    都被推迟。所以必须用 ``asyncio.to_thread`` 把 collect 跑到 thread pool，
+    event loop 可以继续工作。append/log 操作（≤1ms）继续在 loop 里跑。"""
     # 启动后先睡一段，避开冷启动 noise（asyncio task 数在 startup 阶段会高一下）。
     try:
         await asyncio.sleep(60)
     except asyncio.CancelledError:
         return
+    global _watchdog_tick_count
     while True:
         try:
-            snap = _collect_snapshot()
+            # Deep tick 频率：每 _DEEP_TICK_EVERY_N 次跑一次完整 snapshot（含 gc
+            # 和 num_threads，那部分 ~50 ms 阻塞）。其他 tick 只跑 cheap 字段（~3 ms）。
+            # ⚠️ Python C 函数（gc / Windows API）不释放 GIL：即便 to_thread，
+            # main thread 仍在 GIL 切换间隔（默认 5 ms）内被卡。to_thread 还是
+            # 必要的——能让 main thread 在 worker 主动让出时见缝插针。
+            include_deep = (_watchdog_tick_count % _DEEP_TICK_EVERY_N) == 0
+            _watchdog_tick_count += 1
+            snap = await asyncio.to_thread(_collect_snapshot, include_deep)
             _absorb_recent_client_payload(snap)
             _HEALTH_RING.append(snap)
-            _append_to_log(snap)
+            # _append_to_log 含 stat + rotate + 文件 IO，可能十几 ms：也丢 thread。
+            await asyncio.to_thread(_append_to_log, snap)
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -450,8 +490,11 @@ async def debug_health() -> dict[str, Any]:
     """返回当前快照 + 最近 ring buffer。
 
     Ring buffer 让用户不用等到下一个 5-min tick——任意时刻请求都能拿到
-    最近 16 小时的曲线，刷新即用。"""
-    current = _collect_snapshot()
+    最近 16 小时的曲线，刷新即用。
+
+    同 watchdog：``_collect_snapshot()`` 同步且重（gc.get_objects 50-100ms），
+    丢到 thread pool 避免阻塞 event loop。"""
+    current = await asyncio.to_thread(_collect_snapshot)
     return {
         "current": current,
         "ring": list(_HEALTH_RING),

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -494,8 +494,12 @@ async def debug_health(deep: bool = False) -> dict[str, Any]:
 
     ``deep=true`` 触发慢字段（``gc.get_objects()`` 45ms 内存对象 type 分布 +
     Windows ``num_threads()`` 8ms 线程数）。Watchdog 永不调它们——用户排查
-    内存泄漏时手动 ``?deep=1`` 一次拿当下数据；想要时序就多次调。"""
-    current = await asyncio.to_thread(_collect_snapshot, deep)
+    内存泄漏时手动 ``?deep=1`` 一次拿当下数据；想要时序就多次调。
+
+    实现注释：cheap 路径 ~0.13 ms 自身耗时直接同步调；deep 路径 50 ms 阻塞
+    是用户**主动**触发的代价，自己等就好——不为这个场景做 to_thread 兜底，
+    省一层 thread 调度 overhead，代码直接。"""
+    current = _collect_snapshot(deep)
     return {
         "current": current,
         "ring": list(_HEALTH_RING),

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -25,13 +25,14 @@ counter 曲线**才能定位。这个 router 干两件事：
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
 import logging
 import math
 import os
 import sys
 import time
-from collections import deque
+from collections import Counter, deque
 from pathlib import Path
 from typing import Any
 
@@ -51,10 +52,38 @@ _HEALTH_RING: deque[dict[str, Any]] = deque(maxlen=200)
 _WATCHDOG_TASK: asyncio.Task | None = None
 _WATCHDOG_INTERVAL_SECONDS = 5 * 60  # 5 分钟
 
+# psutil.Process 复用：cpu_percent(None) 必须**用同一个 Process 实例**多次调用，
+# 第一次返回 0（建立基线），之后每次返回距上次的 CPU 利用率%。每次 new Process
+# 都是新基线 → 永远 0%，等于没采。`None` 表示尚未尝试初始化或环境缺 psutil。
+_PSUTIL_PROCESS: Any = None
+_PSUTIL_INIT_TRIED = False
+
 
 # ---------------------------------------------------------------------------
 # Snapshot 采集
 # ---------------------------------------------------------------------------
+
+def _get_psutil_process() -> Any:
+    """惰性初始化 + 复用同一个 ``psutil.Process``。
+
+    第一次调用时尝试 import psutil 并 prime ``cpu_percent``（首次调用约定回 0，
+    建立基线，后续才有意义）。失败则永久返回 None，不再重试——既避免反复
+    import 噪音，也让缺 psutil 的环境曲线上看 cpu_percent/num_handles 一律 null
+    跟「真有 leak」明确区分。"""
+    global _PSUTIL_PROCESS, _PSUTIL_INIT_TRIED
+    if _PSUTIL_INIT_TRIED:
+        return _PSUTIL_PROCESS
+    _PSUTIL_INIT_TRIED = True
+    try:
+        import psutil  # type: ignore
+        proc = psutil.Process()
+        # Prime：首次调用约定回 0，立刻丢掉，下次才有真值。
+        proc.cpu_percent(interval=None)
+        _PSUTIL_PROCESS = proc
+    except Exception:
+        _PSUTIL_PROCESS = None
+    return _PSUTIL_PROCESS
+
 
 def _safe_rss_mb() -> float | None:
     """读取当前进程**当前** RSS（MB）；只在 psutil 可用时返回，否则 None。
@@ -63,13 +92,134 @@ def _safe_rss_mb() -> float | None:
     **lifetime peak**——一旦上去就不下降。用来画 leak 趋势会把一次性内存
     高峰永久误读成 leak，比没有这个字段还误导。所以**宁可返回 None**也不
     走 ru_maxrss。打包发行版默认就带 psutil，源码模式 ``uv sync`` 也会装。"""
-    try:
-        import psutil  # type: ignore
-        return psutil.Process().memory_info().rss / (1024 * 1024)
-    except Exception:
-        # 故意吞：拿不到 RSS 不应拖垮诊断功能。曲线上看 rss_mb=null 就知道是
-        # 环境缺 psutil，不会和「真有 leak」混淆。
+    proc = _get_psutil_process()
+    if proc is None:
         return None
+    try:
+        return proc.memory_info().rss / (1024 * 1024)
+    except Exception:
+        # 进程突然不存在 / 权限丢失等极端态：返 None 不挂诊断。
+        return None
+
+
+def _safe_psutil_extras() -> dict[str, Any]:
+    """补 psutil 能给的几个长跑泄漏经典指标：cpu%、线程数、Win handle/POSIX fd。
+
+    - cpu_percent: **原始问题的金线指标**——任务管理器看到 31.9% 就是这个。
+      需要复用 ``_get_psutil_process()`` 返回的同一个实例，每次调用返回距上次
+      的 CPU 利用率%。
+    - num_threads: 线程泄漏 cheap 检测。
+    - num_handles / num_fds: Windows 句柄 / POSIX fd 泄漏。重启即恢复的 case
+      多数对得上这个。先试 Windows 的 num_handles，再试 POSIX 的 num_fds，
+      都拿不到就 None。
+    """
+    out: dict[str, Any] = {
+        "cpu_percent": None,
+        "num_threads": None,
+        "num_handles": None,
+    }
+    proc = _get_psutil_process()
+    if proc is None:
+        return out
+    try:
+        out["cpu_percent"] = proc.cpu_percent(interval=None)
+    except Exception:
+        pass
+    try:
+        out["num_threads"] = proc.num_threads()
+    except Exception:
+        pass
+    # Windows: num_handles; POSIX: num_fds. psutil 在错误平台抛 AttributeError。
+    try:
+        out["num_handles"] = proc.num_handles()
+    except (AttributeError, Exception):
+        try:
+            out["num_handles"] = proc.num_fds()
+        except Exception:
+            pass
+    return out
+
+
+def _safe_asyncio_task_top(n: int = 10) -> list[list[Any]] | None:
+    """按 name 计数当前 asyncio task，返回 top-N。
+
+    ``asyncio.all_tasks()`` 只给数字时，长跑泄漏只能看到「task 数涨了」却不
+    知道是哪类——加这个分布就能立刻定位（比如「memory_recall_xxx」一路涨）。
+    返回 list[[name, count], ...] 而不是 dict——保留排序、JSON 友好。"""
+    try:
+        c: Counter[str] = Counter()
+        for t in asyncio.all_tasks():
+            try:
+                c[t.get_name()] += 1
+            except Exception:
+                c["<unnamed>"] += 1
+        return [[name, cnt] for name, cnt in c.most_common(n)]
+    except Exception:
+        return None
+
+
+def _safe_gc_object_top(n: int = 10) -> list[list[Any]] | None:
+    """按 type 计数所有 GC 跟踪对象，返回 top-N。
+
+    一次 ``gc.get_objects()`` 在中等规模 Python 堆上 ~几十 ms，5min 一次完全
+    可接受。这是定位「**是什么对象在涨**」的金线——RSS 数字涨了不知道是谁，
+    type top 直接告诉你 ``HumanMessage`` / ``AIMessage`` / ``Future`` / ``Task``
+    / ``dict`` 哪个在单调增。"""
+    try:
+        c: Counter[str] = Counter()
+        for obj in gc.get_objects():
+            c[type(obj).__name__] += 1
+        return [[name, cnt] for name, cnt in c.most_common(n)]
+    except Exception:
+        return None
+
+
+def _safe_tts_queue_sizes() -> dict[str, int]:
+    """每个 lanlan core 的 ``tts_request_queue`` 当前长度。
+
+    TTS 卡住 / 网络抖动时队列堆积比 CPU 早出现——是「TTS pipeline 出问题」的
+    早期信号。core.tts_request_queue 是 ``queue.Queue``，qsize 在 Windows 上
+    是估计值但够用。"""
+    out: dict[str, int] = {}
+    try:
+        from main_routers.shared_state import get_session_manager
+        session_manager = get_session_manager()
+        for name in list(session_manager.keys()):
+            try:
+                core = session_manager.get(name)
+                q = getattr(core, "tts_request_queue", None)
+                if q is not None and hasattr(q, "qsize"):
+                    out[name] = q.qsize()
+            except Exception:
+                continue
+    except Exception:
+        return out
+    return out
+
+
+def _safe_is_responding_map() -> dict[str, bool]:
+    """每个 lanlan 的 ``session._is_responding`` 状态。
+
+    分布异常（如所有 lanlan 都卡在 True 不退）= 死锁 / response handler
+    丢消息的强信号。"""
+    out: dict[str, bool] = {}
+    try:
+        from main_routers.shared_state import get_session_manager
+        session_manager = get_session_manager()
+        for name in list(session_manager.keys()):
+            try:
+                core = session_manager.get(name)
+                session = getattr(core, "session", None)
+                if session is None:
+                    continue
+                v = getattr(session, "_is_responding", None)
+                if isinstance(v, bool):
+                    out[name] = v
+            except Exception:
+                continue
+    except Exception:
+        return out
+    return out
 
 
 def _safe_conv_history_lengths() -> dict[str, int]:
@@ -133,8 +283,14 @@ def _collect_snapshot() -> dict[str, Any]:
         snap["asyncio_tasks"] = len(asyncio.all_tasks())
     except Exception:
         snap["asyncio_tasks"] = None
+    snap["asyncio_task_top"] = _safe_asyncio_task_top()
     snap["rss_mb"] = _safe_rss_mb()
+    # psutil extras 一次 dict 展平进顶层，方便画曲线时直接索引同级 key。
+    snap.update(_safe_psutil_extras())
+    snap["gc_object_top"] = _safe_gc_object_top()
     snap["conv_history"] = _safe_conv_history_lengths()
+    snap["tts_queue_size"] = _safe_tts_queue_sizes()
+    snap["is_responding"] = _safe_is_responding_map()
     snap["ack_waiters"] = _safe_ack_waiters_size()
     snap["proactive_history"] = _safe_proactive_history_size()
     return snap
@@ -305,6 +461,8 @@ _CLIENT_NUMERIC_FIELDS = frozenset({
     "ts", "live_intervals", "live_timeouts", "raf_fps_60s",
     "dom_nodes", "js_heap_mb", "ws_state",
     "proactive_backoff_level", "agent_task_map_size",
+    # 新增（与 debug-health.js collectSnapshot 同步）
+    "live_object_urls", "error_count", "unhandled_rejection_count",
 })
 _CLIENT_BOOL_FIELDS = frozenset({"proactive_running", "is_recording"})
 _CLIENT_STRING_FIELDS_WITH_CAP = {"location": 128}

--- a/main_routers/debug_router.py
+++ b/main_routers/debug_router.py
@@ -106,15 +106,19 @@ def _safe_psutil_extras() -> dict[str, Any]:
     """补 psutil 能给的几个长跑泄漏经典指标：cpu%、线程数、Win handle/POSIX fd。
 
     - cpu_percent: **原始问题的金线指标**——任务管理器看到 31.9% 就是这个。
-      需要复用 ``_get_psutil_process()`` 返回的同一个实例，每次调用返回距上次
-      的 CPU 利用率%。
+      ⚠️ 关键归一化：``proc.cpu_percent(None)`` 用 UNIX 语义（单核 100% = 100，
+      多核并行可 > 100%），但任务管理器显示「占总 CPU 的百分比」（8 核单核
+      打满 = 12.5%）。为了曲线**直接对得上用户截图**，除以 ``cpu_count``。
+      另外报 ``cpu_percent_raw`` 留 UNIX 原值，方便要看「占了几个核」的场景。
     - num_threads: 线程泄漏 cheap 检测。
     - num_handles / num_fds: Windows 句柄 / POSIX fd 泄漏。重启即恢复的 case
       多数对得上这个。先试 Windows 的 num_handles，再试 POSIX 的 num_fds，
       都拿不到就 None。
     """
     out: dict[str, Any] = {
-        "cpu_percent": None,
+        "cpu_percent": None,       # 任务管理器规模（占总 CPU 百分比）
+        "cpu_percent_raw": None,   # psutil 原始值（占单核百分比，多核可 > 100）
+        "cpu_count": None,
         "num_threads": None,
         "num_handles": None,
     }
@@ -122,7 +126,13 @@ def _safe_psutil_extras() -> dict[str, Any]:
     if proc is None:
         return out
     try:
-        out["cpu_percent"] = proc.cpu_percent(interval=None)
+        import psutil  # type: ignore
+        cpu_count = psutil.cpu_count() or 1
+        raw = proc.cpu_percent(interval=None)
+        out["cpu_percent_raw"] = raw
+        out["cpu_count"] = cpu_count
+        # 归一化到任务管理器规模：raw / cpu_count
+        out["cpu_percent"] = raw / cpu_count
     except Exception:
         pass
     try:

--- a/static/debug-health.js
+++ b/static/debug-health.js
@@ -99,6 +99,34 @@
         return fps;
     }
 
+    // ── 2.5 URL.createObjectURL 计数 ─────────────────────────────────
+    // Blob URL 没 revoke 是 audio playback 最经典的 leak——浏览器在 created -
+    // revoked 之差里持有 Blob 引用，不被 GC。这里 monkey-patch 计数「活的」
+    // ObjectURL 数（created 减 revoked）。同 setInterval 的玩法。
+    var _liveObjectURLs = 0;
+    var _origCreateObjectURL = (typeof URL !== 'undefined' && URL.createObjectURL) ? URL.createObjectURL.bind(URL) : null;
+    var _origRevokeObjectURL = (typeof URL !== 'undefined' && URL.revokeObjectURL) ? URL.revokeObjectURL.bind(URL) : null;
+    if (_origCreateObjectURL && _origRevokeObjectURL) {
+        URL.createObjectURL = function () {
+            var u = _origCreateObjectURL.apply(null, arguments);
+            _liveObjectURLs += 1;
+            return u;
+        };
+        URL.revokeObjectURL = function (u) {
+            _liveObjectURLs = Math.max(0, _liveObjectURLs - 1);
+            return _origRevokeObjectURL(u);
+        };
+    }
+
+    // ── 2.6 全局 error / unhandledrejection 累计 ──────────────────────
+    // JS 异常风暴是 CPU 假性高的常见原因（每秒抛 1000 个 error，每个 logger
+    // catch + stack trace 处理 = 真 CPU 占用）。累计计数比单次 console error
+    // 更能呈现「最近 5 min 又涨了 N 次」的趋势。
+    var _errorCount = 0;
+    var _unhandledRejectionCount = 0;
+    window.addEventListener('error', function () { _errorCount += 1; }, { capture: true });
+    window.addEventListener('unhandledrejection', function () { _unhandledRejectionCount += 1; }, { capture: true });
+
     // ── 3. Snapshot 收集 + 推送 ────────────────────────────────────────
     function collectSnapshot() {
         var snap = {
@@ -109,6 +137,9 @@
             raf_fps_60s: _snapshotRAF(),
             dom_nodes: 0,
             js_heap_mb: null,
+            live_object_urls: _liveObjectURLs,
+            error_count: _errorCount,
+            unhandled_rejection_count: _unhandledRejectionCount,
         };
         try {
             snap.dom_nodes = document.getElementsByTagName('*').length;

--- a/static/debug-health.js
+++ b/static/debug-health.js
@@ -102,18 +102,25 @@
     // ── 2.5 URL.createObjectURL 计数 ─────────────────────────────────
     // Blob URL 没 revoke 是 audio playback 最经典的 leak——浏览器在 created -
     // revoked 之差里持有 Blob 引用，不被 GC。这里 monkey-patch 计数「活的」
-    // ObjectURL 数（created 减 revoked）。同 setInterval 的玩法。
-    var _liveObjectURLs = 0;
+    // ObjectURL 数。
+    //
+    // 用 Set 跟踪自己 create 出来的 URL，而不是单纯计数器 +/-：浏览器规范里
+    // ``revokeObjectURL(unknown)`` 是 no-op，如果只是无脑 -1 就会让重复 revoke
+    // / revoke 外部 URL 把计数压成负数（或 Math.max 兜底压成 0），把真 leak
+    // 信号悄悄擦掉。Set 只在我们真的 tracked 过的 URL 被 revoke 时才递减。
+    var _trackedObjectURLs = (typeof Set !== 'undefined') ? new Set() : null;
     var _origCreateObjectURL = (typeof URL !== 'undefined' && URL.createObjectURL) ? URL.createObjectURL.bind(URL) : null;
     var _origRevokeObjectURL = (typeof URL !== 'undefined' && URL.revokeObjectURL) ? URL.revokeObjectURL.bind(URL) : null;
-    if (_origCreateObjectURL && _origRevokeObjectURL) {
+    if (_trackedObjectURLs && _origCreateObjectURL && _origRevokeObjectURL) {
         URL.createObjectURL = function () {
             var u = _origCreateObjectURL.apply(null, arguments);
-            _liveObjectURLs += 1;
+            try { _trackedObjectURLs.add(u); } catch (e) { /* noop */ }
             return u;
         };
         URL.revokeObjectURL = function (u) {
-            _liveObjectURLs = Math.max(0, _liveObjectURLs - 1);
+            // Set.delete 自身就有「存在才删」语义——重复 revoke / 未知 URL
+            // 不会动 Set 大小，计数纹丝不动。
+            try { _trackedObjectURLs.delete(u); } catch (e) { /* noop */ }
             return _origRevokeObjectURL(u);
         };
     }
@@ -137,7 +144,7 @@
             raf_fps_60s: _snapshotRAF(),
             dom_nodes: 0,
             js_heap_mb: null,
-            live_object_urls: _liveObjectURLs,
+            live_object_urls: _trackedObjectURLs ? _trackedObjectURLs.size : 0,
             error_count: _errorCount,
             unhandled_rejection_count: _unhandledRejectionCount,
         };

--- a/static/debug-health.js
+++ b/static/debug-health.js
@@ -80,7 +80,10 @@
     };
 
     // ── 2. RAF 频率统计 ─────────────────────────────────────────────────
-    // 累计最近 60s 内的 RAF 触发次数（理想是 60×60=3600；远低于说明渲染器卡）。
+    // 计算自上次 snapshot 推送以来的平均 RAF 触发频率（FPS，理想 ~60；远低
+    // 于此说明渲染器卡）。窗口长度等于 snapshot 间隔——首次 ~30s，之后 5min。
+    // 字段名 raf_fps_60s 是历史命名（早期版本曾按 60s 计），现在保留是为了
+    // 前后端契约稳定，含义仍是「FPS」不是「60s 内总次数」。
     var _rafCount = 0;
     var _rafCountWindowStart = performance.now();
     var _origRAF = window.requestAnimationFrame;


### PR DESCRIPTION
## 背景

[PR #1423](https://github.com/Project-N-E-K-O/N.E.K.O/pull/1423) 把诊断 watchdog 基建挂上了，但当时只收了 `asyncio_tasks` 总数 + `rss_mb` 等基础指标——**漏了 CPU 百分比**。讽刺的是用户原始问题截图就是任务管理器 31.9% CPU，这套观测工具反倒没回答最初的问题。这个 PR 正面补上，顺手把长跑泄漏的几个高 ROI 经典指标一起加。

**Base**: `feat/debug-health-watchdog`（PR #1423）。等 #1423 合到 main 后本 PR rebase 到 main 即可。

## Summary

后端 `main_routers/debug_router.py`：

| 字段 | 意义 |
|---|---|
| `cpu_percent` | **原始问题金线指标**。`psutil.Process().cpu_percent(None)` 复用同一 Process 实例（否则每次新建永远返 0）。 |
| `num_threads` / `num_handles` | 线程 / Windows 句柄 / POSIX fd 泄漏。重启即恢复的 case 多数对得上 |
| `asyncio_task_top` | `Counter(t.get_name())` top-10。从「task 数涨了」到「立刻知道是哪类」 |
| `gc_object_top` | `Counter(type(obj).__name__)` top-10。定位**是什么对象在涨**——`HumanMessage` / `Future` / `dict` 单调增立刻看见 |
| `tts_queue_size` | 每个 lanlan `core.tts_request_queue.qsize()`。TTS 卡顿早期信号 |
| `is_responding` | 每个 lanlan `session._is_responding`。分布异常 = 死锁强信号 |

前端 `static/debug-health.js`：

| 字段 | 意义 |
|---|---|
| `live_object_urls` | monkey-patch `URL.createObjectURL`/`revokeObjectURL` 计数活的 Blob URL。audio playback 没 revoke 是经典 leak |
| `error_count` / `unhandled_rejection_count` | 全局 `error` / `unhandledrejection` 累计。JS 异常风暴是 CPU 假性高的常见原因 |

白名单同步：`_CLIENT_NUMERIC_FIELDS` 加 3 个前端字段，未列入仍静默丢。

## 体积影响

单行 JSON 从 ~500 B 涨到 ~900 B（实测：无 lanlan 数据 + `gc_object_top` 全开 = 521 B；3 lanlan + client merged 估算 ~900 B）。`jsonl` rotation 10 MB 阈值仍能撑 ~38 天，「报问题→开几天→关掉」场景仍宽裕。

## 设计决策

- **psutil Process 复用**：`cpu_percent(interval=None)` 必须**同一实例**多次调用，第一次返 0 建立基线。`_get_psutil_process()` 惰性初始化 + 一次性 prime + 缓存。
- **`num_handles` vs `num_fds`**：psutil 在 Windows 给 `num_handles()`、POSIX 给 `num_fds()`。代码先试 Windows，AttributeError 后试 POSIX。
- **`gc.get_objects()` 开销**：中等规模堆 ~几十 ms，5 min 一次完全可接受。这是定位内存泄漏「是什么对象在涨」的不可替代指标，比 RSS 数字有用 100 倍。
- **零侵入语义保留**：所有 `_safe_*` helper 单独 try-except，任意字段失败不影响其他。

## Test plan

- [x] 手测：`_collect_snapshot()` 含所有新字段
- [x] 手测：第一次 `cpu_percent` 返 0、busy loop 200ms 后返 100%（占满 1 core 正确）
- [x] 手测：`gc_object_top` 给出真实 top-10 type 分布
- [x] 手测：sanitize 新字段全部白名单接受，evil 字段被丢
- [x] 手测：严格 JSON 序列化（`allow_nan=False`）无 NaN/Inf
- [ ] 起 main_server 后访问 `/api/debug/health` 看完整 snapshot
- [ ] 前端 `localStorage.NEKO_DEBUG_HEALTH=1` 启用后 console `[debug_health] ...` 含新字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 健康监测支持按需深度采集（deep 查询参数），区分“轻量”与“深度”字段；轻量路径恒包含任务、RSS、CPU/句柄/FD 等简要指标，深度才包含 GC 对象与线程数。
  * 监测逻辑为不同采集通道独立采样以避免互相干扰。
  * 前端诊断扩展：追踪未释放的 Blob URL、运行时错误与未处理拒绝，并随快照上报；新增可观测计数字段。

* **Bug Fixes**
  * 快照落盘改为在线程中异步执行，避免阻塞事件循环。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->