### PR TITLE
docs(telemetry): correct stale 10-min report-interval claim to match 60s implementation

### DIFF
--- a/local_server/telemetry_server/README.md
+++ b/local_server/telemetry_server/README.md
@@ -56,15 +56,15 @@ record()             即时写入内存，零 I/O
     ↓
 save() [每 60s]      本地 JSON 落盘 → 然后调用 _report_to_server()
     ↓
-_report_to_server()  检查距上次上报是否 ≥ 600s（10分钟）
+_report_to_server()  检查距上次上报是否 ≥ 60s（1分钟）
     ├── 否 → 累积到 _unsent_daily，跳过
     └── 是 → POST /api/v1/telemetry
               ├── 成功 → 清除 _unsent，更新时间戳
               └── 失败 → 放回 _unsent，下次重试
 
-∴ 每进程最多 1 req / 10min
-  3 个 server 进程 = 18 req/h/device
-  20k DAU × 18 × 8h ≈ 2.88M req/day ≈ 33 req/s peak
+∴ 每进程最多 1 req / 1min
+  3 个 server 进程 = 180 req/h/device
+  20k DAU × 180 × 8h ≈ 28.8M req/day ≈ 333 req/s peak
   SQLite WAL ~500 write/s → 单实例够用
 ```
 

--- a/local_server/telemetry_server/README.md
+++ b/local_server/telemetry_server/README.md
@@ -63,9 +63,9 @@ _report_to_server()  检查距上次上报是否 ≥ 60s（1分钟）
               └── 失败 → 放回 _unsent，下次重试
 
 ∴ 每进程最多 1 req / 1min
-  3 个 server 进程 = 180 req/h/device
-  20k DAU × 180 × 8h ≈ 28.8M req/day ≈ 333 req/s peak
-  SQLite WAL ~500 write/s → 单实例够用
+  3 个 server 进程 = 180 req/h/device 上限（实际由服务端 120 req/h 削顶，超出返回 429 累积到下次）
+  20k DAU × 180 × 8h ≈ 28.8M req/day ≈ 333 req/s 日均（活跃窗口峰值 ~1000 req/s）
+  SQLite WAL ~500 write/s → 日均够用
 ```
 
 ## 管理端

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -183,7 +183,7 @@ _DO_NOT_TRACK = any(
     for v in ("NEKO_DO_NOT_TRACK", "DO_NOT_TRACK")
 )
 
-# 上报间隔（3 分钟）
+# 上报间隔（60 秒）
 # 节流设计：
 #   record() → 即时写入内存（零 I/O）
 #   save()   → 每 60s 本地落盘，然后调用 _report_to_server()


### PR DESCRIPTION
## Summary

- `local_server/telemetry_server/README.md` 的"节流设计"段把每进程上报节流写成 ≥600s（10分钟）、18 req/h/device，但 `utils/token_tracker.py` 里 `_TELEMETRY_REPORT_INTERVAL = 60`，实际是每进程每 60s 一次。更新示例算式为 180 req/h/device、`20k DAU × 180 × 8h ≈ 28.8M req/day ≈ 333 req/s peak`。
- `utils/token_tracker.py` 里 `_TELEMETRY_REPORT_INTERVAL = 60` 上方那行 header 注释"上报间隔（3 分钟）"与下方"每 60s"以及"60 req/h/device"细则自相矛盾，改成"60 秒"。

## Context

在 PR #1447 review 中修主 README 时发现这处 sub-doc / 注释 还在传播旧的 10 分钟数字。主 README 已在 #1447 里修过，这里只动 upstream 文档与注释，不改任何运行时行为。

## Test plan

- [ ] 浏览 `local_server/telemetry_server/README.md` 的"节流设计"段，确认 60s / 180 req/h/device / 28.8M req/day / 333 req/s 与 `_TELEMETRY_REPORT_INTERVAL = 60` 一致。
- [ ] 浏览 `utils/token_tracker.py` `_TELEMETRY_REPORT_INTERVAL` 上方注释，确认 header 与下方"每 60s"无矛盾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新遥测上报间隔说明：将示例上报间隔从 10 分钟/3 分钟说明改为 60 秒（1 分钟）。
  * 相应调整了文档中关于每进程/设备上报频率及日活与峰值请求量估算的数值说明，以反映更高的上报频率。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->