### PR TITLE
fix(steamworks): 补齐 Steam SDK callback struct 的 pack 对齐

### DIFF
--- a/steamworks/structs.py
+++ b/steamworks/structs.py
@@ -11,6 +11,9 @@ _STEAM_CALLBACK_PACK = 8 if sys.platform == 'win32' else 4
 
 class FindLeaderboardResult_t(Structure):
     """ Represents the STEAMWORKS LeaderboardFindResult_t call result type """
+    # u64 在 offset 0 — 当前布局两种 pack 一致；显式声明仅为与其它
+    # callback struct 对偶，匹配 SDK 的 VALVE_CALLBACK_PACK_SMALL/LARGE。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("leaderboardHandle", c_uint64),
         ("leaderboardFound", c_uint32)
@@ -18,6 +21,9 @@ class FindLeaderboardResult_t(Structure):
 
 
 class CreateItemResult_t(Structure):
+    # int + u64 + bool：pack=8 时 u64@8（4 字节 padding），pack=4 时 u64@4。
+    # Linux/macOS 需显式 _pack_=4 才能正确读到 publishedFileId。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("result", c_int),
         ("publishedFileId", c_uint64),
@@ -26,6 +32,10 @@ class CreateItemResult_t(Structure):
 
 
 class SubmitItemUpdateResult_t(Structure):
+    # int + bool + u64：bool 后的 padding 让 u64 在 pack=4/8 下都落在 offset 8，
+    # 当前布局凑巧两边一致；显式 _pack_ 保持与其它 callback struct 对偶，
+    # 避免日后调整字段顺序时再次踩坑。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("result", c_int),
         ("userNeedsToAcceptWorkshopLegalAgreement", c_bool),
@@ -34,6 +44,8 @@ class SubmitItemUpdateResult_t(Structure):
 
 
 class ItemInstalled_t(Structure):
+    # u32 + u64：pack=8 时 u64@8，pack=4 时 u64@4。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("appId", c_uint32),
         ("publishedFileId", c_uint64)
@@ -41,6 +53,8 @@ class ItemInstalled_t(Structure):
 
 
 class SubscriptionResult(Structure):
+    # i32 + u64：pack=8 时 u64@8，pack=4 时 u64@4。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("result", c_int32),
         ("publishedFileId", c_uint64)
@@ -48,6 +62,8 @@ class SubscriptionResult(Structure):
 
 
 class SteamUGCQueryCompleted_t(Structure):
+    # u64 在 offset 0 — 当前布局两种 pack 一致；显式声明仅为对偶。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("handle", c_uint64),
         ("result", c_int),
@@ -100,6 +116,8 @@ class SteamUGCDetails_t(Structure):
 
 
 class MicroTxnAuthorizationResponse_t(Structure):
+    # u32 + u64 + bool：pack=8 时 u64@8，pack=4 时 u64@4。
+    _pack_ = _STEAM_CALLBACK_PACK
     _fields_ = [
         ("appId", c_uint32),
         ("orderId", c_uint64),


### PR DESCRIPTION
## Summary

跟进 #1430 — 上次 PR 只给 `SteamUGCDetails_t` 加了 `_pack_ = _STEAM_CALLBACK_PACK`，但同文件里另外 6 个 callback struct 同样源自 Steam SDK 的 VALVE_CALLBACK_PACK_SMALL/LARGE，遗漏会让 Linux/macOS 上的 `publishedFileId` / `orderId` 等 uint64 字段读偏 4 字节。

按字段布局逐个核对，本次提交把 `_pack_` 显式下沉到所有 callback struct：

| Struct | 字段 | Linux/macOS 错位？ |
|---|---|---|
| `CreateItemResult_t` | int + **u64** + bool | ❌ |
| `ItemInstalled_t` | u32 + **u64** | ❌ |
| `SubscriptionResult` | i32 + **u64** | ❌ |
| `MicroTxnAuthorizationResponse_t` | u32 + **u64** + bool | ❌ |
| `SubmitItemUpdateResult_t` | int + bool + **u64** | 当前布局凑巧一致 |
| `FindLeaderboardResult_t` | u64 + u32 | u64@0 无差 |
| `SteamUGCQueryCompleted_t` | u64 + ... | u64@0 无差 |

后三个目前没暴露 bug，但加上保持对偶 + 防字段顺序调整时复发。

### 影响

- 错位的几个回调里 `publishedFileId` 才是真正读偏的字段。Windows 用户不受影响（ctypes 默认 8 字节对齐 = SDK 的 LARGE pack）。Linux/macOS 用户在跑「发布工坊条目」/「订阅成功回调」/「物品安装完成回调」时拿到的 ID 都是错的，只是项目目前没 Linux/macOS 用户走完整发布订阅链路，所以没人报障。
- 零逻辑变更，仅声明 `_pack_`。

### 验证

ctypes 验证：

```
pack=4: CreateItemResult_t.publishedFileId offset = 4  ✓ 匹配 Linux/macOS SDK
pack=8: CreateItemResult_t.publishedFileId offset = 8  ✓ 匹配 Windows SDK
```

## Test plan

- [ ] CI 通过
- [ ] Windows 上 Steam 工坊发布 / 订阅链路无 regression（字段偏移与改前一致）
- [ ] （可选）Linux 上 Steam 工坊发布 / 订阅链路拿到的 `publishedFileId` 与 Steam 网页端实际 ID 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

* 修复了 Steam 功能在 Windows、Linux 和 macOS 等不同操作系统上的数据兼容性问题，增强了跨平台的稳定性和可靠性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->