### PR TITLE
避免 Live2D runtime breath fallback 与 SDK 原生 Breath 重复驱动。检测模型已有原生呼吸参数时跳…

### DIFF
--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -416,6 +416,7 @@ Live2DManager.prototype._resetDerivedModelMetadata = function() {
     this._isLookAtDrivenByMotion = false;
     this._isBreathDrivenByMotion = false;
     this._motionDrivenBreathParamIds = null;
+    this._motionDrivenBreathMotionKey = null;
     this._runtimeBreathTime = 0;
     this._runtimeBreathParamIds = null;
     this._lookAtTimer = undefined;
@@ -2096,8 +2097,17 @@ Live2DManager.prototype.installMouthOverride = function() {
             this._isEyeDrivenByMotion = false;
             this._isLookAtDrivenByMotion = false;
             this._isBreathDrivenByMotion = false;
-            this._motionDrivenBreathParamIds = new Set();
-            const motionPriority = Number(internalModel.motionManager?.state?.currentPriority ?? 0);
+            const motionState = internalModel.motionManager?.state;
+            const motionPriority = Number(motionState?.currentPriority ?? 0);
+            const activeMotionKey = motionPriority > LIVE2D_MOTION_PRIORITY.NONE
+                ? [motionPriority, motionState?.currentGroup ?? '', motionState?.currentIndex ?? ''].join(':')
+                : null;
+            if (this._motionDrivenBreathMotionKey !== activeMotionKey) {
+                this._motionDrivenBreathMotionKey = activeMotionKey;
+                this._motionDrivenBreathParamIds = new Set();
+            } else if (!(this._motionDrivenBreathParamIds instanceof Set)) {
+                this._motionDrivenBreathParamIds = new Set();
+            }
             const shouldTreatEyeChangesAsAuthoritative = motionPriority > LIVE2D_MOTION_PRIORITY.IDLE;
             for (const [id, idx] of Object.entries(mouthParamIndices)) {
                 try {
@@ -2128,12 +2138,12 @@ Live2DManager.prototype.installMouthOverride = function() {
                         const postVal = coreModel.getParameterValueByIndex(idx);
                         const preVal = preUpdateParams[id];
                         if (preVal !== undefined && Math.abs(postVal - preVal) > 0.001) {
-                            this._isBreathDrivenByMotion = true;
                             this._motionDrivenBreathParamIds.add(id);
                         }
                     }
                 } catch (_) {}
             }
+            this._isBreathDrivenByMotion = this._motionDrivenBreathParamIds.size > 0;
             for (const [id, idx] of Object.entries(lookAtParamIndices)) {
                 try {
                     const postVal = coreModel.getParameterValueByIndex(idx);

--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -1060,6 +1060,35 @@ Live2DManager.prototype._resolveRuntimeBreathParams = function(coreModel) {
     return this._runtimeBreathParamIds;
 };
 
+Live2DManager.prototype._hasNativeRuntimeBreath = function(internalModel, coreModel) {
+    const breath = internalModel?.breath;
+    if (!breath || typeof breath.updateParameters !== 'function') return false;
+
+    const runtimeBreathParamIds = new Set(this._resolveRuntimeBreathParams(coreModel));
+    if (runtimeBreathParamIds.size === 0) return false;
+
+    let nativeParams = null;
+    try {
+        if (typeof breath.getParameters === 'function') {
+            nativeParams = breath.getParameters();
+        }
+    } catch (_) {}
+    if (!Array.isArray(nativeParams) && Array.isArray(breath._breathParameters)) {
+        nativeParams = breath._breathParameters;
+    }
+    if (!Array.isArray(nativeParams) || nativeParams.length === 0) return false;
+
+    return nativeParams.some(param => {
+        const id = param && (param.parameterId || param.id || param.Id);
+        if (!runtimeBreathParamIds.has(id)) return false;
+        const weight = Number(param.weight);
+        const peak = Number(param.peak);
+        if (Number.isFinite(weight) && weight === 0) return false;
+        if (Number.isFinite(peak) && peak === 0) return false;
+        return true;
+    });
+};
+
 Live2DManager.prototype._updateRuntimeBreath = function(delta) {
     const coreModel = this.currentModel?.internalModel?.coreModel;
     if (!coreModel) return;
@@ -2104,14 +2133,14 @@ Live2DManager.prototype.installMouthOverride = function() {
                 } catch (_) {}
             }
 
-            // === 注入点 1（物理引擎前）：视线微动 ===
-            // 仅当 Motion 未接管时注入，让物理引擎能看到这些变化
-            // 注意：呼吸由 SDK 原生 Breath 系统接管，无需我们干预
+            // === 注入点 1（物理引擎前）：视线微动与运行时呼吸 ===
+            // 仅当 Motion 未接管时注入，让物理引擎能看到这些变化。
+            // 呼吸 fallback 只在 SDK 原生 Breath 未覆盖同名参数时启用，避免双重叠加。
             if (!this._isLookAtDrivenByMotion && !this._mouseTrackingEnabled && !this.isAvatarPerformanceCapabilityLocked('lookAt')) {
                 const delta = (this.currentModel?.deltaTime || 16.66) / 1000;
                 this._updateRandomLookAt(delta);
             }
-            if (!this._isBreathDrivenByMotion) {
+            if (!this._isBreathDrivenByMotion && !this._hasNativeRuntimeBreath(internalModel, coreModel)) {
                 const delta = (this.currentModel?.deltaTime || 16.66) / 1000;
                 this._updateRuntimeBreath(delta);
             }

--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -1085,8 +1085,9 @@ Live2DManager.prototype._getNativeRuntimeBreathParamIds = function(internalModel
         if (!runtimeBreathParamIds.has(id)) continue;
         const weight = Number(param.weight);
         const peak = Number(param.peak);
+        const offset = Number(param.offset);
         if (Number.isFinite(weight) && weight === 0) continue;
-        if (Number.isFinite(peak) && peak === 0) continue;
+        if (Number.isFinite(peak) && peak === 0 && Number.isFinite(offset) && offset === 0) continue;
         nativeBreathParamIds.add(id);
     }
 

--- a/static/live2d-model.js
+++ b/static/live2d-model.js
@@ -415,6 +415,7 @@ Live2DManager.prototype._resetDerivedModelMetadata = function() {
     this._isEyeDrivenByMotion = false;
     this._isLookAtDrivenByMotion = false;
     this._isBreathDrivenByMotion = false;
+    this._motionDrivenBreathParamIds = null;
     this._runtimeBreathTime = 0;
     this._runtimeBreathParamIds = null;
     this._lookAtTimer = undefined;
@@ -1060,12 +1061,13 @@ Live2DManager.prototype._resolveRuntimeBreathParams = function(coreModel) {
     return this._runtimeBreathParamIds;
 };
 
-Live2DManager.prototype._hasNativeRuntimeBreath = function(internalModel, coreModel) {
+Live2DManager.prototype._getNativeRuntimeBreathParamIds = function(internalModel, coreModel) {
+    const nativeBreathParamIds = new Set();
     const breath = internalModel?.breath;
-    if (!breath || typeof breath.updateParameters !== 'function') return false;
+    if (!breath || typeof breath.updateParameters !== 'function') return nativeBreathParamIds;
 
     const runtimeBreathParamIds = new Set(this._resolveRuntimeBreathParams(coreModel));
-    if (runtimeBreathParamIds.size === 0) return false;
+    if (runtimeBreathParamIds.size === 0) return nativeBreathParamIds;
 
     let nativeParams = null;
     try {
@@ -1076,25 +1078,33 @@ Live2DManager.prototype._hasNativeRuntimeBreath = function(internalModel, coreMo
     if (!Array.isArray(nativeParams) && Array.isArray(breath._breathParameters)) {
         nativeParams = breath._breathParameters;
     }
-    if (!Array.isArray(nativeParams) || nativeParams.length === 0) return false;
+    if (!Array.isArray(nativeParams) || nativeParams.length === 0) return nativeBreathParamIds;
 
-    return nativeParams.some(param => {
+    for (const param of nativeParams) {
         const id = param && (param.parameterId || param.id || param.Id);
-        if (!runtimeBreathParamIds.has(id)) return false;
+        if (!runtimeBreathParamIds.has(id)) continue;
         const weight = Number(param.weight);
         const peak = Number(param.peak);
-        if (Number.isFinite(weight) && weight === 0) return false;
-        if (Number.isFinite(peak) && peak === 0) return false;
-        return true;
-    });
+        if (Number.isFinite(weight) && weight === 0) continue;
+        if (Number.isFinite(peak) && peak === 0) continue;
+        nativeBreathParamIds.add(id);
+    }
+
+    return nativeBreathParamIds;
 };
 
-Live2DManager.prototype._updateRuntimeBreath = function(delta) {
+Live2DManager.prototype._updateRuntimeBreath = function(delta, options = {}) {
     const coreModel = this.currentModel?.internalModel?.coreModel;
     if (!coreModel) return;
 
     const breathParamIds = this._resolveRuntimeBreathParams(coreModel);
     if (breathParamIds.length === 0) return;
+
+    const excludedParamIds = options.excludedParamIds instanceof Set
+        ? options.excludedParamIds
+        : new Set(Array.isArray(options.excludedParamIds) ? options.excludedParamIds : []);
+    const targetParamIds = breathParamIds.filter(id => !excludedParamIds.has(id));
+    if (targetParamIds.length === 0) return;
 
     const safeDelta = Math.min(Math.max(Number(delta) || 0, 0), 0.1);
     this._runtimeBreathTime = (this._runtimeBreathTime || 0) + safeDelta;
@@ -1102,7 +1112,7 @@ Live2DManager.prototype._updateRuntimeBreath = function(delta) {
     const phase = this._runtimeBreathTime * Math.PI * 2 / 3.8;
     const normalized = 0.5 + Math.sin(phase) * 0.5;
 
-    for (const id of breathParamIds) {
+    for (const id of targetParamIds) {
         try {
             const idx = coreModel.getParameterIndex(id);
             if (idx < 0) continue;
@@ -2085,6 +2095,7 @@ Live2DManager.prototype.installMouthOverride = function() {
             this._isEyeDrivenByMotion = false;
             this._isLookAtDrivenByMotion = false;
             this._isBreathDrivenByMotion = false;
+            this._motionDrivenBreathParamIds = new Set();
             const motionPriority = Number(internalModel.motionManager?.state?.currentPriority ?? 0);
             const shouldTreatEyeChangesAsAuthoritative = motionPriority > LIVE2D_MOTION_PRIORITY.IDLE;
             for (const [id, idx] of Object.entries(mouthParamIndices)) {
@@ -2117,7 +2128,7 @@ Live2DManager.prototype.installMouthOverride = function() {
                         const preVal = preUpdateParams[id];
                         if (preVal !== undefined && Math.abs(postVal - preVal) > 0.001) {
                             this._isBreathDrivenByMotion = true;
-                            break;
+                            this._motionDrivenBreathParamIds.add(id);
                         }
                     }
                 } catch (_) {}
@@ -2140,9 +2151,15 @@ Live2DManager.prototype.installMouthOverride = function() {
                 const delta = (this.currentModel?.deltaTime || 16.66) / 1000;
                 this._updateRandomLookAt(delta);
             }
-            if (!this._isBreathDrivenByMotion && !this._hasNativeRuntimeBreath(internalModel, coreModel)) {
+            {
+                const excludedBreathParamIds = this._getNativeRuntimeBreathParamIds(internalModel, coreModel);
+                if (this._motionDrivenBreathParamIds instanceof Set) {
+                    for (const id of this._motionDrivenBreathParamIds) {
+                        excludedBreathParamIds.add(id);
+                    }
+                }
                 const delta = (this.currentModel?.deltaTime || 16.66) / 1000;
-                this._updateRuntimeBreath(delta);
+                this._updateRuntimeBreath(delta, { excludedParamIds: excludedBreathParamIds });
             }
 
             try {


### PR DESCRIPTION
…过 fallback，并修正相关注释，防止已有自主呼吸模型出现双重叠加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增强呼吸参数管理：识别并排除由原生运行时或动作接管的呼吸参数，支持传入排除列表以精确控制驱动范围。
  * 动作驱动检测：跟踪并标记被动作显著影响的呼吸参数，按需切换驱动来源。

* **Bug 修复**
  * 避免同一帧重复驱动同一参数，减少冲突，提升呼吸与目光微动的自然度与稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->