### PR TITLE
Fix Linux desktop package missing default Live2D model assets

### DIFF
--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -210,12 +210,7 @@ jobs:
       - name: Build all frontend projects
         shell: bash
         run: |
-          cd frontend/plugin-manager
-          npm ci
-          npm run build-only
-          cd ../react-neko-chat
-          npm ci
-          npm run build
+          ./build_frontend.sh
 
       # --- Build with Nuitka ---
       - name: Build with Nuitka

--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -211,7 +211,7 @@ jobs:
         shell: bash
         run: |
           ./build_frontend.sh
-          test -f static/yui-origin/yui-origin.model3.json
+          bash scripts/verify_frontend_build.sh
 
       # --- Build with Nuitka ---
       - name: Build with Nuitka

--- a/.github/workflows/build-desktop-linux.yml
+++ b/.github/workflows/build-desktop-linux.yml
@@ -211,6 +211,7 @@ jobs:
         shell: bash
         run: |
           ./build_frontend.sh
+          test -f static/yui-origin/yui-origin.model3.json
 
       # --- Build with Nuitka ---
       - name: Build with Nuitka

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -251,7 +251,7 @@ jobs:
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             ./build_frontend.sh
-            test -f static/yui-origin/yui-origin.model3.json
+            bash scripts/verify_frontend_build.sh
             exit 0
           fi
           cd frontend/plugin-manager

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -249,6 +249,10 @@ jobs:
       - name: Build all frontend projects
         shell: bash
         run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            ./build_frontend.sh
+            exit 0
+          fi
           cd frontend/plugin-manager
           npm ci
           npm run build-only

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -251,6 +251,7 @@ jobs:
         run: |
           if [[ "$RUNNER_OS" == "Linux" ]]; then
             ./build_frontend.sh
+            test -f static/yui-origin/yui-origin.model3.json
             exit 0
           fi
           cd frontend/plugin-manager

--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -1762,6 +1762,17 @@ async def get_current_live2d_model(catgirl_name: str = "", item_id: str = ""):
         if model_info and isinstance(model_info.get('path'), str):
             model_info['path'] = encode_url_path(model_info['path'])
 
+        if not model_info or not model_info.get('path'):
+            error_message = f"默认Live2D模型 {DEFAULT_LIVE2D_MODEL_NAME} 不可用"
+            logger.error(error_message)
+            return JSONResponse(content={
+                'success': False,
+                'catgirl_name': catgirl_name,
+                'model_name': live2d_model_name or DEFAULT_LIVE2D_MODEL_NAME,
+                'model_info': None,
+                'error': error_message,
+            })
+
         return JSONResponse(content={
             'success': True,
             'catgirl_name': catgirl_name,

--- a/main_routers/config_router.py
+++ b/main_routers/config_router.py
@@ -284,7 +284,7 @@ async def get_page_config(response: Response, lanlan_name: str = ""):
             # 提取JSONResponse中的内容
             model_data = model_response.body.decode('utf-8')
             model_json = json.loads(model_data)
-            model_info = model_json.get('model_info', {})
+            model_info = model_json.get('model_info') or {}
             model_path = model_info.get('path', '')
         
         result = {

--- a/scripts/verify_frontend_build.sh
+++ b/scripts/verify_frontend_build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Verify frontend build outputs that are required by packaged desktop builds.
+set -euo pipefail
+
+REQUIRED_MODEL_FILE="static/yui-origin/yui-origin.model3.json"
+
+if [ ! -f "$REQUIRED_MODEL_FILE" ]; then
+  echo "ERROR: missing $REQUIRED_MODEL_FILE after build_frontend.sh" >&2
+  exit 1
+fi

--- a/static/app-character.js
+++ b/static/app-character.js
@@ -73,6 +73,30 @@
         }
     }
 
+    function isMainUIHiddenByModelManager() {
+        if (typeof window.isMainUIHiddenByModelManager === 'function') {
+            return window.isMainUIHiddenByModelManager();
+        }
+        return window.__NEKO_MAIN_UI_HIDDEN_BY_MODEL_MANAGER === true;
+    }
+
+    function rehideMainUIIfModelManagerOwnsVisibility(reason) {
+        if (!isMainUIHiddenByModelManager()) return false;
+        if (typeof window.handleHideMainUI === 'function') {
+            window.handleHideMainUI({ preserveHiddenState: true, reason: reason || 'character-switch' });
+        }
+        return true;
+    }
+
+    function restoreChatComposerUnlessModelManagerHidden(chatContainer, textInputArea) {
+        if (isMainUIHiddenByModelManager()) return;
+        if (chatContainer) chatContainer.classList.remove('minimized');
+        if (textInputArea) textInputArea.classList.remove('hidden');
+        if (typeof window.syncVoiceChatComposerHidden === 'function') {
+            window.syncVoiceChatComposerHidden(false);
+        }
+    }
+
     function supportsLocalModelRuntime() {
         return !/^\/chat(?:\/|$)/.test(window.location.pathname || '');
     }
@@ -744,7 +768,7 @@
             if (!supportsLocalModelRuntime()) {
                 console.log('[猫娘切换] 当前页面不加载本地模型，跳过模型热切换');
                 // chat.html 不走模型分支，在此显式恢复 composer（兜底 onclose 路径）
-                if (typeof window.syncVoiceChatComposerHidden === 'function') {
+                if (!isMainUIHiddenByModelManager() && typeof window.syncVoiceChatComposerHidden === 'function') {
                     window.syncVoiceChatComposerHidden(false);
                 }
             } else if (effectiveModelType === 'vrm') {
@@ -1135,17 +1159,14 @@
                 const chatContainerVrm = document.getElementById('chat-container');
                 const textInputArea = document.getElementById('text-input-area');
                 console.log('[猫娘切换] VRM - 恢复对话框 - chatContainer存在:', !!chatContainerVrm, '当前类:', chatContainerVrm ? chatContainerVrm.className : 'N/A');
-                if (chatContainerVrm) chatContainerVrm.classList.remove('minimized');
-                if (textInputArea) textInputArea.classList.remove('hidden');
-                if (typeof window.syncVoiceChatComposerHidden === 'function') {
-                    window.syncVoiceChatComposerHidden(false);
-                }
+                restoreChatComposerUnlessModelManagerHidden(chatContainerVrm, textInputArea);
                 console.log('[猫娘切换] VRM - 对话框已恢复，当前类:', chatContainerVrm ? chatContainerVrm.className : 'N/A');
 
                 // 确保 VRM 按钮和锁图标可见
                 setTimeout(() => {
                     // fire-and-forget 延迟回调：用户在 300ms 内切到别角色时旧回调会重建错类型按钮
                     if (!isStillActiveSwitchTarget()) return;
+                    if (rehideMainUIIfModelManagerOwnsVisibility('character-switch-vrm-delay')) return;
                     const vrmButtons = document.getElementById('vrm-floating-buttons');
                     console.log('[猫娘切换] VRM按钮检查 - 存在:', !!vrmButtons);
                     if (vrmButtons) {
@@ -1368,15 +1389,12 @@
 
                 const chatContainerMmd = document.getElementById('chat-container');
                 const textInputAreaMmd = document.getElementById('text-input-area');
-                if (chatContainerMmd) chatContainerMmd.classList.remove('minimized');
-                if (textInputAreaMmd) textInputAreaMmd.classList.remove('hidden');
-                if (typeof window.syncVoiceChatComposerHidden === 'function') {
-                    window.syncVoiceChatComposerHidden(false);
-                }
+                restoreChatComposerUnlessModelManagerHidden(chatContainerMmd, textInputAreaMmd);
 
                 // 延时显示 MMD 浮动按钮和锁图标
                 setTimeout(() => {
                     if (!isStillActiveSwitchTarget()) return;
+                    if (rehideMainUIIfModelManagerOwnsVisibility('character-switch-mmd-delay')) return;
                     const mmdButtons = document.getElementById('mmd-floating-buttons');
                     if (mmdButtons) {
                         mmdButtons.style.removeProperty('display');
@@ -1556,15 +1574,12 @@
 
                 const chatContainerL2d = document.getElementById('chat-container');
                 const textInputAreaL2d = document.getElementById('text-input-area');
-                if (chatContainerL2d) chatContainerL2d.classList.remove('minimized');
-                if (textInputAreaL2d) textInputAreaL2d.classList.remove('hidden');
-                if (typeof window.syncVoiceChatComposerHidden === 'function') {
-                    window.syncVoiceChatComposerHidden(false);
-                }
+                restoreChatComposerUnlessModelManagerHidden(chatContainerL2d, textInputAreaL2d);
 
                 // 延时重启 Ticker 和显示按钮（双重保险）
                 setTimeout(() => {
                     if (!isStillActiveSwitchTarget()) return;
+                    if (rehideMainUIIfModelManagerOwnsVisibility('character-switch-live2d-delay')) return;
 
                     window.dispatchEvent(new Event('resize'));
 
@@ -1645,6 +1660,7 @@
                 Promise.resolve(window.resetAgentUiForCharacterSwitch(newCatgirl))
                     .catch(err => console.warn('[猫娘切换] 刷新猫爪状态失败:', err));
             }
+            rehideMainUIIfModelManagerOwnsVisibility('character-switch-commit');
             showStatusToast(window.t ? window.t('app.switchedCatgirl', { name: newCatgirl }) : `已切换到 ${newCatgirl}`, 3000);
 
             // 【成就】解锁换肤成就

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -1187,7 +1187,8 @@
     function handleHideMainUI(options) {
         if (!_isModelHostPage()) return;
         options = options || {};
-        if (!options.skipHiddenStateUpdate) {
+        var skipHiddenStateUpdate = options.skipHiddenStateUpdate || options.preserveHiddenState;
+        if (!skipHiddenStateUpdate) {
             setMainUIHiddenByModelManager(true);
         }
         console.log('[UI] 隐藏主界面并暂停渲染');

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -24,6 +24,7 @@
     const mod = {};
     const S = window.appState;
     // const C = window.appConst;  // not used in this module currently
+    const MAIN_UI_HIDDEN_BY_MODEL_MANAGER_KEY = '__NEKO_MAIN_UI_HIDDEN_BY_MODEL_MANAGER';
 
     // =====================================================================
     // Message deduplication (BC + postMessage deliver the same message twice)
@@ -41,6 +42,51 @@
         _processedMsgKeys[key] = true;
         setTimeout(function () { delete _processedMsgKeys[key]; }, 5000);
         return false;
+    }
+
+    function isMainUIHiddenByModelManager() {
+        return window[MAIN_UI_HIDDEN_BY_MODEL_MANAGER_KEY] === true;
+    }
+
+    function ensureMainUIHiddenStyle() {
+        if (document.getElementById('neko-main-ui-hidden-by-model-manager-style')) return;
+        var style = document.createElement('style');
+        style.id = 'neko-main-ui-hidden-by-model-manager-style';
+        style.textContent = [
+            'body.neko-main-ui-hidden-by-model-manager #live2d-container,',
+            'body.neko-main-ui-hidden-by-model-manager #vrm-container,',
+            'body.neko-main-ui-hidden-by-model-manager #mmd-container,',
+            'body.neko-main-ui-hidden-by-model-manager #live2d-canvas,',
+            'body.neko-main-ui-hidden-by-model-manager #vrm-canvas,',
+            'body.neko-main-ui-hidden-by-model-manager #mmd-canvas,',
+            'body.neko-main-ui-hidden-by-model-manager #live2d-floating-buttons,',
+            'body.neko-main-ui-hidden-by-model-manager #vrm-floating-buttons,',
+            'body.neko-main-ui-hidden-by-model-manager #mmd-floating-buttons,',
+            'body.neko-main-ui-hidden-by-model-manager #live2d-lock-icon,',
+            'body.neko-main-ui-hidden-by-model-manager #vrm-lock-icon,',
+            'body.neko-main-ui-hidden-by-model-manager #mmd-lock-icon,',
+            'body.neko-main-ui-hidden-by-model-manager #live2d-return-button-container,',
+            'body.neko-main-ui-hidden-by-model-manager #vrm-return-button-container,',
+            'body.neko-main-ui-hidden-by-model-manager #mmd-return-button-container {',
+            '  display: none !important;',
+            '  visibility: hidden !important;',
+            '  pointer-events: none !important;',
+            '}'
+        ].join('\n');
+        (document.head || document.documentElement).appendChild(style);
+    }
+
+    function setMainUIHiddenByModelManager(hidden) {
+        window[MAIN_UI_HIDDEN_BY_MODEL_MANAGER_KEY] = !!hidden;
+        ensureMainUIHiddenStyle();
+        if (document.body) {
+            document.body.classList.toggle('neko-main-ui-hidden-by-model-manager', !!hidden);
+        }
+        try {
+            window.dispatchEvent(new CustomEvent('neko:main-ui-hidden-by-model-manager-changed', {
+                detail: { hidden: !!hidden }
+            }));
+        } catch (_) {}
     }
 
     function applyTutorialChatIdentityOverride(payload) {
@@ -892,6 +938,13 @@
             window._modelReloadInFlight = false;
             resolveReload();
 
+            // If the model manager is still open, keep the Pet UI hidden even
+            // though the reload path briefly re-created containers/buttons.
+            if (isMainUIHiddenByModelManager()) {
+                console.log('[Model] 主界面处于模型管理隐藏状态，模型重载完成后重新隐藏 UI');
+                handleHideMainUI({ preserveHiddenState: true });
+            }
+
             // Process any queued reload request
             if (window._pendingModelReload) {
                 console.log('[Model] 执行待处理的模型重载请求');
@@ -1131,8 +1184,12 @@
     /**
      * Hide main-page model rendering (entering model manager).
      */
-    function handleHideMainUI() {
+    function handleHideMainUI(options) {
         if (!_isModelHostPage()) return;
+        options = options || {};
+        if (!options.skipHiddenStateUpdate) {
+            setMainUIHiddenByModelManager(true);
+        }
         console.log('[UI] 隐藏主界面并暂停渲染');
 
         try {
@@ -1206,13 +1263,15 @@
                 '#live2d-lock-icon, #vrm-lock-icon, #mmd-lock-icon, ' +
                 '#live2d-return-button-container, #vrm-return-button-container, #mmd-return-button-container'
             ).forEach(function (el) {
-                var computedDisplay = '';
-                try {
-                    computedDisplay = window.getComputedStyle(el).display || '';
-                } catch (_) {}
-                el.dataset.nekoPreHideDisplay = computedDisplay && computedDisplay !== 'none'
-                    ? computedDisplay
-                    : (el.style.display || 'none');
+                if (!el.dataset.nekoPreHideDisplay) {
+                    var computedDisplay = '';
+                    try {
+                        computedDisplay = window.getComputedStyle(el).display || '';
+                    } catch (_) {}
+                    el.dataset.nekoPreHideDisplay = computedDisplay && computedDisplay !== 'none'
+                        ? computedDisplay
+                        : (el.style.display || 'none');
+                }
                 el.style.display = 'none';
             });
         } catch (error) {
@@ -1225,6 +1284,7 @@
      */
     function handleShowMainUI() {
         if (!_isModelHostPage()) return;
+        setMainUIHiddenByModelManager(false);
         // 模型重载进行中时跳过：handleModelReload 自己会正确切换容器，
         // 此时 lanlan_config.model_type 尚未更新，handleShowMainUI 会
         // 错误地恢复旧模型类型的容器，导致需要切换两次才能成功。
@@ -2277,6 +2337,7 @@
     mod.resetToDefaultModel = resetToDefaultModel;
     mod.handleHideMainUI = handleHideMainUI;
     mod.handleShowMainUI = handleShowMainUI;
+    mod.isMainUIHiddenByModelManager = isMainUIHiddenByModelManager;
     mod.handleMemoryEdited = handleMemoryEdited;
     mod.cleanupLive2DOverlayUI = cleanupLive2DOverlayUI;
     mod.cleanupVRMOverlayUI = cleanupVRMOverlayUI;
@@ -2292,6 +2353,7 @@
     window.resetToDefaultModel = resetToDefaultModel;
     window.handleHideMainUI = handleHideMainUI;
     window.handleShowMainUI = handleShowMainUI;
+    window.isMainUIHiddenByModelManager = isMainUIHiddenByModelManager;
     window.cleanupLive2DOverlayUI = cleanupLive2DOverlayUI;
     window.cleanupVRMOverlayUI = cleanupVRMOverlayUI;
     window.cleanupMMDOverlayUI = cleanupMMDOverlayUI;

--- a/static/js/model_manager.js
+++ b/static/js/model_manager.js
@@ -9490,6 +9490,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const currentModelData = await RequestHelper.fetchJson(apiUrl);
 
                 if (!currentModelData.success) {
+                    showStatus(currentModelData.error || t('live2d.loadCurrentModelFailed', '加载当前角色模型失败'));
                     return;
                 }
 

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -226,6 +226,37 @@ async def test_switching_self_created_character_to_workshop_model_marks_current_
     assert get_reserved(saved_catgirl, 'character_origin', 'source_id', default='') == ''
 
 
+@pytest.mark.asyncio
+async def test_current_live2d_model_reports_failure_when_default_fallback_is_missing(monkeypatch):
+    characters = {
+        '当前猫娘': '测试角色',
+        '猫娘': {
+            '测试角色': {
+                '_reserved': {
+                    'avatar': {
+                        'live2d': {
+                            'model_path': '',
+                        },
+                    },
+                },
+            },
+        },
+    }
+    config_manager = DummyConfigManager(characters)
+
+    monkeypatch.setattr(characters_router_module, 'get_config_manager', lambda: config_manager)
+    monkeypatch.setattr(characters_router_module, 'find_models', lambda: [])
+    monkeypatch.setattr(characters_router_module, 'find_model_directory', lambda _name: (None, ''))
+
+    response = await characters_router_module.get_current_live2d_model('测试角色')
+    body = json.loads(response.body)
+
+    assert body['success'] is False
+    assert body['model_name'] == characters_router_module.DEFAULT_LIVE2D_MODEL_NAME
+    assert body['model_info'] is None
+    assert '默认Live2D模型' in body['error']
+
+
 def test_live3d_sub_type_prefers_persisted_active_sub_type_when_both_paths_exist():
     catgirl = _build_characters_fixture()['猫娘']['测试角色']
 


### PR DESCRIPTION
## 变更内容

- 修复 Linux 桌面端打包时未解包默认 Live2D 模型资源的问题。
- Linux workflow 现在复用现有的 `build_frontend.sh` 构建入口，确保 `assets/yui-origin.tar.gz` 会在打包前解包到 `static/yui-origin`。
- Windows/macOS 构建路径保持不变，避免影响当前正常的平台。
- 修复 `/api/config/page_config` 在 `model_info` 为 `null` 时可能崩溃的问题。

## 问题原因

Linux 打包流程之前直接执行前端 npm 构建，没有经过 `build_frontend.sh`，因此没有触发现有的 `yui-origin` 解包逻辑。最终 `.deb` 包中缺少 `static/yui-origin/yui-origin.model3.json` 等默认模型文件，导致打包版本启动后模型无法正常交互。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复模型切换/热重载时主界面被误恢复可见的问题，保持隐藏状态一致性，避免延迟回调错误地显示对话框与浮动按钮
  * 当前角色模型加载失败时，前端会在状态栏显示后端错误信息或更明确的提示，减少无效加载导致的异常显示

* **Chores**
  * 精简并统一桌面构建流程，新增构建产物校验以提升发布稳定性

* **Tests**
  * 新增单元测试以覆盖默认 Live2D 回退缺失时的错误报告行为

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->