### PR TITLE
fix(monitor): 修复字幕同步崩溃 / viewer 偏好 405 / 多 viewer 广播队头阻塞

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -274,32 +274,14 @@ async def broadcast_subtitle():
         # 给一个短暂的延迟让清空动画完成
         await asyncio.sleep(0.3)
 
-    clients = subtitle_clients.copy()
-    for client in clients:
-        try:
-            await client.send_json({
-                "type": "subtitle",
-                "text": current_subtitle
-            })
-        except Exception as e:
-            print(f"字幕广播错误: {e}")
-            subtitle_clients.discard(client)
+    await broadcast_subtitle_text(current_subtitle)
 
 
 # 清空字幕
 async def clear_subtitle():
     global current_subtitle
     current_subtitle = ""
-
-    clients = subtitle_clients.copy()
-    for client in clients:
-        try:
-            await client.send_json({
-                "type": "clear"
-            })
-        except Exception as e:
-            print(f"清空字幕错误: {e}")
-            subtitle_clients.discard(client)
+    await _broadcast(subtitle_clients, lambda client: client.send_json({"type": "clear"}), "SUBTITLE")
 
 # 主服务器连接端点
 @app.websocket("/sync/{lanlan_name}")
@@ -334,16 +316,7 @@ async def sync_endpoint(websocket: WebSocket, lanlan_name:str):
                             # 翻译未实现/失败时返回 None，保留原文，避免 current_subtitle 被置空后下一轮 += 崩溃
                             if translated_text:
                                 current_subtitle = translated_text
-                                clients = subtitle_clients.copy()
-                                for client in clients:
-                                    try:
-                                        await client.send_json({
-                                            "type": "subtitle",
-                                            "text": translated_text
-                                        })
-                                    except Exception as e:
-                                        print(f"翻译字幕广播错误: {e}")
-                                        subtitle_clients.discard(client)
+                                await broadcast_subtitle_text(translated_text)
 
                     # 清空字幕区域，准备下一条
                     global should_clear_next
@@ -422,8 +395,8 @@ async def _send_to_client(client, sender, label):
         return client, False
 
 
-async def _broadcast(sender, label, success_msg):
-    clients = connected_clients.copy()
+async def _broadcast(client_set, sender, label, success_msg=None):
+    clients = client_set.copy()
     if not clients:
         return
 
@@ -436,22 +409,27 @@ async def _broadcast(sender, label, success_msg):
 
     # 移除所有断开/超时的客户端
     for client in disconnected_clients:
-        connected_clients.discard(client)
+        client_set.discard(client)
         print(f"🗑️ [{label}] 移除断开的客户端: {client.client}")
 
     fail_count = len(disconnected_clients)
-    if success_count > 0:
+    if success_msg and success_count > 0:
         print(success_msg.format(success_count) + (f", 失败并移除 {fail_count} 个" if fail_count > 0 else ""))
+
+
+# 广播字幕到字幕客户端（并发，与主广播共用超时 fan-out，避免某个字幕客户端卡住拖住 sync_endpoint）
+async def broadcast_subtitle_text(text):
+    await _broadcast(subtitle_clients, lambda client: client.send_json({"type": "subtitle", "text": text}), "SUBTITLE")
 
 
 # 广播消息到所有客户端
 async def broadcast_message(message):
-    await _broadcast(lambda client: client.send_json(message), "BROADCAST", "✅ [BROADCAST] 成功广播到 {} 个客户端")
+    await _broadcast(connected_clients, lambda client: client.send_json(message), "BROADCAST", "✅ [BROADCAST] 成功广播到 {} 个客户端")
 
 
 # 广播二进制数据到所有客户端
 async def broadcast_binary(data):
-    await _broadcast(lambda client: client.send_bytes(data), "BINARY BROADCAST", "✅ [BINARY BROADCAST] 成功广播音频到 {} 个客户端")
+    await _broadcast(connected_clients, lambda client: client.send_bytes(data), "BINARY BROADCAST", "✅ [BINARY BROADCAST] 成功广播音频到 {} 个客户端")
 
 
 # 防止 fire-and-forget 任务被 Python 3.11+ GC 回收

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -331,17 +331,19 @@ async def sync_endpoint(websocket: WebSocket, lanlan_name:str):
                         # 检查是否为日文，如果是则翻译
                         if is_japanese(current_subtitle):
                             translated_text = await translate_japanese_to_chinese(current_subtitle)
-                            current_subtitle = translated_text
-                            clients = subtitle_clients.copy()
-                            for client in clients:
-                                try:
-                                    await client.send_json({
-                                        "type": "subtitle",
-                                        "text": translated_text
-                                    })
-                                except Exception as e:
-                                    print(f"翻译字幕广播错误: {e}")
-                                    subtitle_clients.discard(client)
+                            # 翻译未实现/失败时返回 None，保留原文，避免 current_subtitle 被置空后下一轮 += 崩溃
+                            if translated_text:
+                                current_subtitle = translated_text
+                                clients = subtitle_clients.copy()
+                                for client in clients:
+                                    try:
+                                        await client.send_json({
+                                            "type": "subtitle",
+                                            "text": translated_text
+                                        })
+                                    except Exception as e:
+                                        print(f"翻译字幕广播错误: {e}")
+                                        subtitle_clients.discard(client)
 
                     # 清空字幕区域，准备下一条
                     global should_clear_next
@@ -409,54 +411,47 @@ async def websocket_endpoint(websocket: WebSocket, lanlan_name:str):
         print(f"🗑️ [CLIENT] 已移除客户端，当前剩余: {len(connected_clients)}")
 
 
-# 广播消息到所有客户端
-async def broadcast_message(message):
+# 单个客户端发送（带超时），供并发广播复用
+# 串行 await 会被慢客户端拖住整条管线（队头阻塞），并发 fan-out + 超时让慢的不再拖快的
+async def _send_to_client(client, sender, label):
+    try:
+        await asyncio.wait_for(sender(client), timeout=2.0)
+        return client, True
+    except Exception as e:
+        print(f"❌ [{label}] 广播错误到 {client.client}: {e}")
+        return client, False
+
+
+async def _broadcast(sender, label, success_msg):
     clients = connected_clients.copy()
-    success_count = 0
-    fail_count = 0
-    disconnected_clients = []
-    
-    for client in clients:
-        try:
-            await client.send_json(message)
-            success_count += 1
-        except Exception as e:
-            print(f"❌ [BROADCAST] 广播错误到 {client.client}: {e}")
-            fail_count += 1
-            disconnected_clients.append(client)
-    
-    # 移除所有断开的客户端
+    if not clients:
+        return
+
+    results = await asyncio.gather(*(
+        _send_to_client(client, sender, label) for client in clients
+    ))
+
+    success_count = sum(1 for _, ok in results if ok)
+    disconnected_clients = [client for client, ok in results if not ok]
+
+    # 移除所有断开/超时的客户端
     for client in disconnected_clients:
         connected_clients.discard(client)
-        print(f"🗑️ [BROADCAST] 移除断开的客户端: {client.client}")
-    
+        print(f"🗑️ [{label}] 移除断开的客户端: {client.client}")
+
+    fail_count = len(disconnected_clients)
     if success_count > 0:
-        print(f"✅ [BROADCAST] 成功广播到 {success_count} 个客户端" + (f", 失败并移除 {fail_count} 个" if fail_count > 0 else ""))
+        print(success_msg.format(success_count) + (f", 失败并移除 {fail_count} 个" if fail_count > 0 else ""))
+
+
+# 广播消息到所有客户端
+async def broadcast_message(message):
+    await _broadcast(lambda client: client.send_json(message), "BROADCAST", "✅ [BROADCAST] 成功广播到 {} 个客户端")
 
 
 # 广播二进制数据到所有客户端
 async def broadcast_binary(data):
-    clients = connected_clients.copy()
-    success_count = 0
-    fail_count = 0
-    disconnected_clients = []
-    
-    for client in clients:
-        try:
-            await client.send_bytes(data)
-            success_count += 1
-        except Exception as e:
-            print(f"❌ [BINARY BROADCAST] 二进制广播错误到 {client.client}: {e}")
-            fail_count += 1
-            disconnected_clients.append(client)
-    
-    # 移除所有断开的客户端
-    for client in disconnected_clients:
-        connected_clients.discard(client)
-        print(f"🗑️ [BINARY BROADCAST] 移除断开的客户端: {client.client}")
-    
-    if success_count > 0:
-        print(f"✅ [BINARY BROADCAST] 成功广播音频到 {success_count} 个客户端" + (f", 失败并移除 {fail_count} 个" if fail_count > 0 else ""))
+    await _broadcast(lambda client: client.send_bytes(data), "BINARY BROADCAST", "✅ [BINARY BROADCAST] 成功广播音频到 {} 个客户端")
 
 
 # 防止 fire-and-forget 任务被 Python 3.11+ GC 回收

--- a/static/live2d-core.js
+++ b/static/live2d-core.js
@@ -578,6 +578,10 @@ class Live2DManager {
     // 保存用户偏好
     async saveUserPreferences(modelPath, position, scale, parameters, display, viewport) {
         try {
+            // 观看模式只读：viewer 不应把本地拖动覆盖到全局模型布局（也避免向 monitor 的只读端点 POST 触发 405）
+            if (window.isViewerMode) {
+                return false;
+            }
             // 验证位置和缩放值是否为有效的有限数值
             if (!isValidModelPreferences(scale, position)) {
                 console.error('位置或缩放值无效:', { scale, position });

--- a/static/mmd-core.js
+++ b/static/mmd-core.js
@@ -1173,6 +1173,10 @@ class MMDCore {
 
     async saveUserPreferences(modelPath, position, scale, rotation, display, viewport, cameraPosition) {
         try {
+            // 观看模式只读：viewer 不应把本地拖动覆盖到全局模型布局（也避免向 monitor 的只读端点 POST 触发 405）
+            if (window.isViewerMode) {
+                return false;
+            }
             if (!position || typeof position !== 'object' ||
                 !Number.isFinite(position.x) || !Number.isFinite(position.y) || !Number.isFinite(position.z)) {
                 console.error('[MMD] 位置值无效:', position);

--- a/static/vrm-core.js
+++ b/static/vrm-core.js
@@ -1273,6 +1273,10 @@ class VRMCore {
      */
     async saveUserPreferences(modelPath, position, scale, rotation, display, viewport, cameraPosition) {
         try {
+            // 观看模式只读：viewer 不应把本地拖动覆盖到全局模型布局（也避免向 monitor 的只读端点 POST 触发 405）
+            if (window.isViewerMode) {
+                return false;
+            }
             // 验证位置值
             if (!position || typeof position !== 'object' ||
                 !Number.isFinite(position.x) || !Number.isFinite(position.y) || !Number.isFinite(position.z)) {


### PR DESCRIPTION
## 背景

monitor 服务日志里同时暴露三个问题，本 PR 一并修复。

## 改动

### 1. 字幕同步端点崩溃（NoneType += str）
`app/monitor.py` 的 `translate_japanese_to_chinese` 是占位 stub，函数体只有 `pass`，返回 `None`。日文字幕走 `turn end` 分支时把全局 `current_subtitle` 置成 `None`，下一条 `gemini_response` 执行 `current_subtitle += subtitle_text` 直接抛 `TypeError`。

改为翻译返回为空时**保留原文**，不再把 `current_subtitle` 置空（日文也至少能显示原文）。

### 2. 多 viewer 并行时单个 viewer 明显延迟（队头阻塞）
`broadcast_message` / `broadcast_binary` 原本串行 `await client.send_json/send_bytes`，只要一个 viewer 网络慢、TCP 发送缓冲区没腾空，`await` 就卡在它身上，**后面所有 viewer 排队等它**；而 `sync_endpoint` 又是 `await broadcast_*` 之后才读主服务器下一条消息，于是一个慢 viewer 拖慢整条同步管线（高频音频二进制广播尤其明显）。

抽出 `_broadcast` helper，fan-out 改为 `asyncio.gather` 并发 + 每客户端 2s `wait_for` 超时：慢的不再拖快的，卡死的客户端直接踢掉。

### 3. `POST /api/config/preferences` 405 刷屏
monitor 只有 `@app.get`，前端拖动模型后会自动 `saveUserPreferences` POST，于是 viewer 里一拖就刷 405。viewer 是远程只读旁观窗，不应把本地拖动覆盖全局模型布局。

在三个模型 core（live2d / mmd / vrm）的 `saveUserPreferences` 入口加 `window.isViewerMode` 早退（该标志 viewer.html 已设置，UI 按钮也已用它做门禁）。viewer 仍可通过 GET 读取布局，只是不再写。

## 测试
- `python -m py_compile app/monitor.py` ✅
- `node --check` live2d-core / mmd-core / vrm-core ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修正日文字幕翻译逻辑：仅在翻译结果有效时替换并广播字幕，避免无效翻译导致后续追加/广播异常。
  * 在观看模式下禁用保存用户偏好，防止 viewer 端尝试提交位置/缩放等设置。

* **Refactor**
  * 客户端广播改为并发 fan-out 发送，增强广播性能与故障统计，改进断线客户端移除时序。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->