### PR TITLE
修复-模型边缘回弹

### DIFF
--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -4,7 +4,7 @@
 
 // ===== 自动吸附功能配置 =====
 const SNAP_CONFIG = {
-    // 兼容旧配置入口；当前拖拽回弹按 margin 触发，不再等模型绝大部分出屏
+    // 吸附阈值：模型在屏幕内剩余的像素小于此值时触发吸附（即模型绝大部分超出屏幕）
     threshold: 200,
     // 吸附边距：吸附后距离屏幕边缘的最小距离
     margin: 5,
@@ -47,7 +47,7 @@ const EasingFunctions = {
  * 检测模型是否超出当前屏幕边界，并计算吸附目标位置
  * @param {PIXI.DisplayObject} model - Live2D 模型对象
  * @param {Object} options - 可选参数
- * @param {boolean} options.afterDisplaySwitch - 兼容旧调用；当前主屏/副屏统一按安全边距吸附
+ * @param {boolean} options.afterDisplaySwitch - 是否为屏幕切换后的吸附（使用更宽松的条件：超出即吸附）
  * @param {number} options.threshold - 可选吸附阈值；初始摆放等旧调用可传入更宽松阈值
  * @returns {Object|null} 返回吸附信息，如果不需要吸附则返回 null
  */
@@ -95,16 +95,34 @@ Live2DManager.prototype._checkSnapRequired = async function (model, options = {}
         let overflowTop = screenTop - modelTop;          // 上边超出
         let overflowBottom = modelBottom - screenBottom; // 下边超出
 
+        const threshold = customThreshold ?? SNAP_CONFIG.threshold;
         const margin = SNAP_CONFIG.margin;
-        const snapThreshold = typeof customThreshold === 'number'
-            ? Math.max(0, customThreshold)
-            : margin;
+        const isDesktopPetWindow = Boolean(
+            window.electronScreen && typeof window.electronScreen.getCurrentDisplay === 'function'
+        );
 
-        // 与普通窗口一致：主屏/副屏都按安全边距回弹，而不是等模型几乎消失才吸附。
-        const needsSnapLeft = overflowLeft > snapThreshold;
-        const needsSnapRight = overflowRight > snapThreshold;
-        const needsSnapTop = overflowTop > snapThreshold;
-        const needsSnapBottom = overflowBottom > snapThreshold;
+        // 计算模型在屏幕内剩余的像素数
+        const visibleLeft = Math.max(modelLeft, screenLeft);
+        const visibleRight = Math.min(modelRight, screenRight);
+        const visibleWidth = Math.max(0, visibleRight - visibleLeft);
+        const visibleTop = Math.max(modelTop, screenTop);
+        const visibleBottom = Math.min(modelBottom, screenBottom);
+        const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+
+        let needsSnapLeft, needsSnapRight, needsSnapTop, needsSnapBottom;
+        if (afterDisplaySwitch || isDesktopPetWindow) {
+            needsSnapLeft = overflowLeft > margin;
+            needsSnapRight = overflowRight > margin;
+            needsSnapTop = overflowTop > margin;
+            needsSnapBottom = overflowBottom > margin;
+        } else {
+            const needsSnapHorizontal = visibleWidth < threshold && (overflowLeft > 0 || overflowRight > 0);
+            const needsSnapVertical = visibleHeight < threshold && (overflowTop > 0 || overflowBottom > 0);
+            needsSnapLeft = overflowLeft > 0 && needsSnapHorizontal;
+            needsSnapRight = overflowRight > 0 && needsSnapHorizontal;
+            needsSnapTop = overflowTop > 0 && needsSnapVertical;
+            needsSnapBottom = overflowBottom > 0 && needsSnapVertical;
+        }
 
         if (!needsSnapLeft && !needsSnapRight && !needsSnapTop && !needsSnapBottom) {
             return null; // 不需要吸附

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -330,13 +330,21 @@ class MMDInteraction {
                     : false;
 
                 if (!displaySwitched) {
-                    // 拖拽结束后：若超出屏幕范围，执行回弹；否则保存当前位置。
-                    const snapped = await this._snapModelIntoScreen({ animate: true });
-                    if (!snapped) {
+                    const isDesktopPetWindow = Boolean(
+                        window.electronScreen && typeof window.electronScreen.getCurrentDisplay === 'function'
+                    );
+                    if (isDesktopPetWindow) {
+                        // 桌宠窗口需要边缘回弹，避免模型被拖出透明窗口后找不回来。
+                        const snapped = await this._snapModelIntoScreen({ animate: true });
+                        if (!snapped) {
+                            this._savePositionAfterInteraction();
+                        } else if (window.NekoAvatarMultiScreenDragHint &&
+                            typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
+                            window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('mmd');
+                        }
+                    } else {
+                        // 网页端保留普通保存，不做贴边回弹。
                         this._savePositionAfterInteraction();
-                    } else if (window.NekoAvatarMultiScreenDragHint &&
-                        typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
-                        window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('mmd');
                     }
                 }
             }

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -65,14 +65,13 @@ def test_multiscreen_drag_hint_uses_top_center_project_popup_style():
     assert ".avatar-multiscreen-drag-hint-visible" in source
 
 
-def test_model_interactions_report_edge_bounce_and_display_switch_success():
+def test_model_interactions_report_supported_bounces_and_display_switch_success():
     live2d = _source("static/live2d-interaction.js")
     mmd = _source("static/mmd-interaction.js")
     vrm = _source("static/vrm-interaction.js")
 
     assert "recordEdgeBounce('live2d')" in live2d
     assert "markDisplaySwitchSuccess('live2d')" in live2d
-    assert "recordEdgeBounce('mmd')" in mmd
     assert "markDisplaySwitchSuccess('mmd')" in mmd
     assert "recordEdgeBounce('vrm')" in vrm
     assert "markDisplaySwitchSuccess('vrm')" in vrm

--- a/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
+++ b/tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py
@@ -72,6 +72,7 @@ def test_model_interactions_report_supported_bounces_and_display_switch_success(
 
     assert "recordEdgeBounce('live2d')" in live2d
     assert "markDisplaySwitchSuccess('live2d')" in live2d
+    assert "recordEdgeBounce('mmd')" in mmd
     assert "markDisplaySwitchSuccess('mmd')" in mmd
     assert "recordEdgeBounce('vrm')" in vrm
     assert "markDisplaySwitchSuccess('vrm')" in vrm

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -8,16 +8,25 @@ def _live2d_source() -> str:
     return (PROJECT_ROOT / "static/live2d-interaction.js").read_text(encoding="utf-8")
 
 
-def test_live2d_drag_snap_uses_window_style_edge_margin():
+def test_live2d_web_drag_snap_keeps_visible_area_threshold():
     source = _live2d_source()
 
-    assert "snapThreshold = typeof customThreshold === 'number'" in source
-    assert "needsSnapLeft = overflowLeft > snapThreshold;" in source
-    assert "needsSnapRight = overflowRight > snapThreshold;" in source
-    assert "needsSnapTop = overflowTop > snapThreshold;" in source
-    assert "needsSnapBottom = overflowBottom > snapThreshold;" in source
-    assert "visibleWidth < threshold" not in source
-    assert "visibleHeight < threshold" not in source
+    assert "const isDesktopPetWindow = Boolean(" in source
+    assert "const visibleWidth = Math.max(0, visibleRight - visibleLeft);" in source
+    assert "const visibleHeight = Math.max(0, visibleBottom - visibleTop);" in source
+    assert "const needsSnapHorizontal = visibleWidth < threshold && (overflowLeft > 0 || overflowRight > 0);" in source
+    assert "const needsSnapVertical = visibleHeight < threshold && (overflowTop > 0 || overflowBottom > 0);" in source
+    assert "needsSnapBottom = overflowBottom > 0 && needsSnapVertical;" in source
+
+
+def test_live2d_desktop_drag_snap_uses_edge_margin():
+    source = _live2d_source()
+
+    assert "if (afterDisplaySwitch || isDesktopPetWindow) {" in source
+    assert "needsSnapLeft = overflowLeft > margin;" in source
+    assert "needsSnapRight = overflowRight > margin;" in source
+    assert "needsSnapTop = overflowTop > margin;" in source
+    assert "needsSnapBottom = overflowBottom > margin;" in source
 
 
 def test_live2d_snap_keeps_explicit_threshold_override_for_initial_placement():

--- a/tests/unit/test_mmd_interaction_static_contracts.py
+++ b/tests/unit/test_mmd_interaction_static_contracts.py
@@ -8,11 +8,22 @@ def _mmd_source() -> str:
     return (PROJECT_ROOT / "static/mmd-interaction.js").read_text(encoding="utf-8")
 
 
-def test_mmd_pan_drag_snaps_to_screen_before_saving_position():
+def test_mmd_web_pan_drag_preserves_existing_save_without_forced_snap():
     source = _mmd_source()
+    pan_drag_section = source.split("if (!displaySwitched) {", 1)[1].split("// 鼠标离开", 1)[0]
 
-    assert "const snapped = await this._snapModelIntoScreen({ animate: true });" in source
-    assert "if (!snapped) {\n                        this._savePositionAfterInteraction();" in source
+    assert "const isDesktopPetWindow = Boolean(" in source
+    assert "this._savePositionAfterInteraction();" in pan_drag_section
+
+
+def test_mmd_desktop_pan_drag_snaps_before_saving_position():
+    source = _mmd_source()
+    pan_drag_section = source.split("if (!displaySwitched) {", 1)[1].split("// 鼠标离开", 1)[0]
+
+    assert "if (isDesktopPetWindow) {" in pan_drag_section
+    assert "const snapped = await this._snapModelIntoScreen({ animate: true });" in pan_drag_section
+    assert "if (!snapped) {" in pan_drag_section
+    assert "this._savePositionAfterInteraction();" in pan_drag_section
 
 
 def test_mmd_display_switch_snaps_to_target_screen_before_saving_position():


### PR DESCRIPTION
## 改动内容

修复模型拖到屏幕底部/边缘时的回弹行为差异。

- 网页端：恢复按“可见面积阈值”判断，模型只是贴边时不再立刻回弹。
- PC/Electron 桌宠窗口：保留边缘安全回弹，避免模型被拖出透明窗口后找不回来。
- 多屏切换后：继续保留强制吸回当前窗口内，避免跨屏后模型丢失。
- 补充 Live2D / MMD / 多屏拖拽提示相关契约测试。

## 背景

#1442 引入多屏拖拽提示后，Live2D 的普通拖拽吸附从“可见面积不足才吸回”变成了“超过边缘 margin 就吸回”，导致网页端模型一触底就回弹。  
但 PC 桌宠窗口仍然需要回弹保护，所以这里按运行环境拆分行为。

## 验证

- `git diff --check`
- `node --check static/live2d-interaction.js && node --check static/mmd-interaction.js && node --check static/vrm-interaction.js && node --check static/avatar-multiscreen-drag-hint.js`
- `uv run python -m pytest tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py tests/unit/test_live2d_interaction_static_contracts.py tests/unit/test_mmd_interaction_static_contracts.py`

结果：15 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 精细化模型吸附判定：在不同场景（屏幕切换、桌宠窗口、网页）分别采用可见区域阈值与溢出方向的组合条件，保留用户自定义阈值覆盖能力，并在桌宠/切换场景使用固定边距吸附规则。
  * 拖拽结束行为区分桌宠与网页：桌宠场景会尝试回弹并记录贴边回弹事件，网页场景直接保存位置不强制回弹。

* **测试**
  * 重组并新增静态合约测试，覆盖上述吸附与回弹差异及阈值/边距行为。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->