### PR TITLE
fix(galgame): 统一 JSON 修正提示并新增 locale 检查工具

### DIFF
--- a/plugin/plugins/galgame_plugin/i18n/en.json
+++ b/plugin/plugins/galgame_plugin/i18n/en.json
@@ -7,6 +7,8 @@
   "entries.galgame_install_textractor.description": "Detect, download, and install TextractorCLI.exe, then refresh the galgame_plugin bridge and memory reader status.",
   "entries.galgame_download_rapidocr_models.name": "Download RapidOCR models",
   "entries.galgame_download_rapidocr_models.description": "Download missing model files for the current RapidOCR language and OCR version into the plugin model cache.",
+  "entries.galgame_set_rapidocr_lang.name": "Set RapidOCR language",
+  "entries.galgame_set_rapidocr_lang.description": "Switch the RapidOCR text recognition language model and OCR version. Manual language changes disable automatic detection.",
   "entries.galgame_install_dxcam.name": "Install DXcam",
   "entries.galgame_install_dxcam.description": "Detect and install the DXcam screenshot dependency, then refresh the galgame_plugin OCR capture backend status.",
   "entries.galgame_get_snapshot.name": "Get galgame snapshot",

--- a/plugin/plugins/galgame_plugin/i18n/ja.json
+++ b/plugin/plugins/galgame_plugin/i18n/ja.json
@@ -7,6 +7,8 @@
   "entries.galgame_install_textractor.description": "TextractorCLI.exe を検出・ダウンロード・インストールし、ギャルゲームプラグインのブリッジとメモリリーダー状態を更新する。",
   "entries.galgame_download_rapidocr_models.name": "RapidOCR モデルをダウンロード",
   "entries.galgame_download_rapidocr_models.description": "現在の RapidOCR 言語と OCR バージョンに不足しているモデルファイルをプラグインのモデルキャッシュへダウンロードする。",
+  "entries.galgame_set_rapidocr_lang.name": "RapidOCR 言語を設定",
+  "entries.galgame_set_rapidocr_lang.description": "RapidOCR のテキスト認識言語モデルと OCR バージョンを切り替える。手動で言語を変更すると自動検出は無効になる。",
   "entries.galgame_install_dxcam.name": "DXcam をインストール",
   "entries.galgame_install_dxcam.description": "DXcam スクリーンショット依存を検出・インストールし、ギャルゲームプラグインの OCR キャプチャバックエンド状態を更新する。",
   "entries.galgame_get_snapshot.name": "ギャルゲームスナップショットを取得",

--- a/plugin/plugins/galgame_plugin/i18n/ko.json
+++ b/plugin/plugins/galgame_plugin/i18n/ko.json
@@ -7,6 +7,8 @@
   "entries.galgame_install_textractor.description": "TextractorCLI.exe를 감지, 다운로드, 설치한 후 갈게임 플러그인 브리지와 메모리 리더 상태를 갱신한다.",
   "entries.galgame_download_rapidocr_models.name": "RapidOCR 모델 다운로드",
   "entries.galgame_download_rapidocr_models.description": "현재 RapidOCR 언어와 OCR 버전에 필요한 누락 모델 파일을 플러그인 모델 캐시에 다운로드한다.",
+  "entries.galgame_set_rapidocr_lang.name": "RapidOCR 언어 설정",
+  "entries.galgame_set_rapidocr_lang.description": "RapidOCR 텍스트 인식 언어 모델과 OCR 버전을 전환한다. 언어를 수동으로 변경하면 자동 감지가 비활성화된다.",
   "entries.galgame_install_dxcam.name": "DXcam 설치",
   "entries.galgame_install_dxcam.description": "DXcam 스크린샷 의존성을 감지, 설치한 후 갈게임 플러그인 OCR 캡처 백엔드 상태를 갱신한다.",
   "entries.galgame_get_snapshot.name": "갈게임 스냅샷 조회",

--- a/plugin/plugins/galgame_plugin/i18n/ru.json
+++ b/plugin/plugins/galgame_plugin/i18n/ru.json
@@ -7,6 +7,8 @@
   "entries.galgame_install_textractor.description": "Обнаружить, загрузить и установить TextractorCLI.exe, затем обновить статус моста и считывателя памяти galgame_plugin.",
   "entries.galgame_download_rapidocr_models.name": "Скачать модели RapidOCR",
   "entries.galgame_download_rapidocr_models.description": "Скачать недостающие файлы моделей для текущего языка RapidOCR и версии OCR в кэш моделей плагина.",
+  "entries.galgame_set_rapidocr_lang.name": "Сменить язык RapidOCR",
+  "entries.galgame_set_rapidocr_lang.description": "Переключить языковую модель распознавания текста RapidOCR и версию OCR. Ручная смена языка отключает автоопределение.",
   "entries.galgame_install_dxcam.name": "Установить DXcam",
   "entries.galgame_install_dxcam.description": "Обнаружить и установить зависимость DXcam для скриншотов, затем обновить статус бэкенда захвата OCR galgame_plugin.",
   "entries.galgame_get_snapshot.name": "Снимок Galgame",

--- a/plugin/plugins/galgame_plugin/i18n/zh-CN.json
+++ b/plugin/plugins/galgame_plugin/i18n/zh-CN.json
@@ -7,6 +7,8 @@
   "entries.galgame_install_textractor.description": "检测并下载安装 TextractorCLI.exe，随后刷新 galgame_plugin 的桥接与读内存状态。",
   "entries.galgame_download_rapidocr_models.name": "下载 RapidOCR 模型",
   "entries.galgame_download_rapidocr_models.description": "为当前 RapidOCR 语言和 OCR 版本下载缺失的模型文件到插件模型缓存目录。",
+  "entries.galgame_set_rapidocr_lang.name": "切换 RapidOCR 语言",
+  "entries.galgame_set_rapidocr_lang.description": "切换 RapidOCR 文本识别语言模型和 OCR 版本；手动切换语言会关闭自动检测。",
   "entries.galgame_install_dxcam.name": "安装 DXcam",
   "entries.galgame_install_dxcam.description": "检测并安装 DXcam 截图依赖，随后刷新 galgame_plugin 的 OCR 截图后端状态。",
   "entries.galgame_get_snapshot.name": "获取 galgame 快照",

--- a/plugin/plugins/galgame_plugin/i18n/zh-TW.json
+++ b/plugin/plugins/galgame_plugin/i18n/zh-TW.json
@@ -7,6 +7,8 @@
   "entries.galgame_install_textractor.description": "檢測並下載安裝 TextractorCLI.exe，隨後重新整理 galgame_plugin 的橋接與讀記憶體狀態。",
   "entries.galgame_download_rapidocr_models.name": "下載 RapidOCR 模型",
   "entries.galgame_download_rapidocr_models.description": "為目前 RapidOCR 語言和 OCR 版本下載缺失的模型檔案到外掛模型快取目錄。",
+  "entries.galgame_set_rapidocr_lang.name": "切換 RapidOCR 語言",
+  "entries.galgame_set_rapidocr_lang.description": "切換 RapidOCR 文字識別語言模型和 OCR 版本；手動切換語言會關閉自動偵測。",
   "entries.galgame_install_dxcam.name": "安裝 DXcam",
   "entries.galgame_install_dxcam.description": "檢測並安裝 DXcam 截圖依賴，隨後重新整理 galgame_plugin 的 OCR 截圖後端狀態。",
   "entries.galgame_get_snapshot.name": "取得 galgame 快照",

--- a/plugin/plugins/galgame_plugin/llm_backend.py
+++ b/plugin/plugins/galgame_plugin/llm_backend.py
@@ -335,7 +335,7 @@ class GalgameLLMBackend:
             {
                 "role": "user",
                 "content": (
-                    f"JSON 修正请求 {attempt}/{max_attempts}, operation={operation}.\n"
+                    f"JSON correction attempt {attempt}/{max_attempts}, operation={operation}.\n"
                     f"Parse error: {bounded_error}\n"
                     "Your last response was not a valid JSON object. "
                     "Reply with ONLY a valid JSON object — "

--- a/plugin/tests/unit/plugins/test_galgame_i18n.py
+++ b/plugin/tests/unit/plugins/test_galgame_i18n.py
@@ -7,6 +7,7 @@ _EXPECTED_ENTRY_IDS = [
     "galgame_get_status",
     "galgame_install_textractor",
     "galgame_download_rapidocr_models",
+    "galgame_set_rapidocr_lang",
     "galgame_install_dxcam",
     "galgame_get_snapshot",
     "galgame_get_history",

--- a/plugin/tests/unit/plugins/test_galgame_llm_backend.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_backend.py
@@ -77,7 +77,7 @@ def test_llm_backend_prompt_message_contracts_are_stable() -> None:
     }
     text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     assert hashlib.sha256(text.encode("utf-8")).hexdigest() == (
-        "7d32bddc399b7480b1471cad3e2b31cabaac894757d23b5b6246678c175b2ad6"
+        "f63025f0087981c3adf3cd5eff0f428744397990bb2a2eeb738349cc6c238821"
     )
 
 

--- a/plugin/tests/unit/plugins/test_galgame_llm_json_correction.py
+++ b/plugin/tests/unit/plugins/test_galgame_llm_json_correction.py
@@ -117,7 +117,7 @@ async def test_json_correction_prompt_bounds_bad_output_and_succeeds() -> None:
     assert len(assistant_bad_output) < len(bad_output)
     assert "TAIL_SHOULD_NOT_BE_INCLUDED" not in assistant_bad_output
     assert "...[truncated " in assistant_bad_output
-    assert "JSON 修正请求 1/1" in correction_prompt
+    assert "JSON correction attempt 1/1" in correction_prompt
     assert "operation=agent_reply" in correction_prompt
 
 

--- a/plugin/tools/compare_locales.py
+++ b/plugin/tools/compare_locales.py
@@ -11,13 +11,11 @@ from typing import Any
 
 EXPECTED_LOCALES = ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "es", "pt")
 PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
-_REQUIRED_LOCALE_DIRS = frozenset(
-    {
-        "static/locales",
-        "plugin/plugins/galgame_plugin/i18n",
-        "plugin/plugins/galgame_plugin/locales",
-    }
+_REQUIRED_LOCALE_DIRS = (
+    "static/locales",
+    "plugin/plugins/galgame_plugin/i18n",
 )
+_REQUIRED_LOCALE_DIR_SET = frozenset(_REQUIRED_LOCALE_DIRS)
 
 
 def _repo_root() -> Path:
@@ -25,17 +23,16 @@ def _repo_root() -> Path:
 
 
 def _default_locale_dirs(root: Path) -> list[Path]:
-    dirs: list[Path] = []
-    project_locale_dir = root / "static" / "locales"
-    if project_locale_dir.exists():
-        dirs.append(project_locale_dir)
+    dirs = [root / relative for relative in _REQUIRED_LOCALE_DIRS]
+    seen = set(dirs)
     plugins_root = root / "plugin" / "plugins"
     if plugins_root.exists():
         for plugin_dir in sorted(path for path in plugins_root.iterdir() if path.is_dir()):
             for name in ("locales", "i18n"):
                 locale_dir = plugin_dir / name
-                if locale_dir.exists():
+                if locale_dir.exists() and locale_dir not in seen:
                     dirs.append(locale_dir)
+                    seen.add(locale_dir)
     return dirs
 
 
@@ -158,7 +155,7 @@ def _is_default_required_dir(root: Path, locale_dir: Path) -> bool:
         # User-supplied directories outside the repo should fail strictly instead of
         # being downgraded to warnings by the default plugin allowlist.
         return True
-    return relative in _REQUIRED_LOCALE_DIRS
+    return relative in _REQUIRED_LOCALE_DIR_SET
 
 
 def _report_results(
@@ -216,7 +213,7 @@ def main() -> int:
     skipped: list[Path] = []
     for locale_dir in locale_dirs:
         if not locale_dir.exists():
-            if custom_locale_dirs:
+            if custom_locale_dirs or _is_default_required_dir(root, locale_dir):
                 errors.append(f"{locale_dir}: directory does not exist")
             else:
                 skipped.append(locale_dir)

--- a/plugin/tools/compare_locales.py
+++ b/plugin/tools/compare_locales.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_LOCALES = ("en", "ja", "ko", "zh-CN", "zh-TW", "ru", "es", "pt")
+PLACEHOLDER_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_REQUIRED_LOCALE_DIRS = frozenset(
+    {
+        "static/locales",
+        "plugin/plugins/galgame_plugin/i18n",
+        "plugin/plugins/galgame_plugin/locales",
+    }
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_locale_dirs(root: Path) -> list[Path]:
+    dirs: list[Path] = []
+    project_locale_dir = root / "static" / "locales"
+    if project_locale_dir.exists():
+        dirs.append(project_locale_dir)
+    plugins_root = root / "plugin" / "plugins"
+    if plugins_root.exists():
+        for plugin_dir in sorted(path for path in plugins_root.iterdir() if path.is_dir()):
+            for name in ("locales", "i18n"):
+                locale_dir = plugin_dir / name
+                if locale_dir.exists():
+                    dirs.append(locale_dir)
+    return dirs
+
+
+def _format_keys(keys: list[str], *, limit: int = 20) -> str:
+    shown = keys[:limit]
+    message = ", ".join(shown)
+    if len(keys) > limit:
+        message += f", ... and {len(keys) - limit} more"
+    return message
+
+
+def _merge_flattened_keys(
+    flattened: dict[str, str],
+    child_values: dict[str, str],
+) -> None:
+    collisions = sorted(set(flattened).intersection(child_values))
+    if collisions:
+        raise RuntimeError(
+            "flattened key collision(s): " + _format_keys(collisions)
+        )
+    flattened.update(child_values)
+
+
+def _flatten_json(value: Any, *, prefix: str = "") -> dict[str, str]:
+    if isinstance(value, dict):
+        flattened: dict[str, str] = {}
+        for key, item in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            _merge_flattened_keys(
+                flattened,
+                _flatten_json(item, prefix=child_prefix),
+            )
+        return flattened
+    if isinstance(value, list):
+        flattened = {}
+        for index, item in enumerate(value):
+            child_prefix = f"{prefix}.{index}" if prefix else str(index)
+            _merge_flattened_keys(
+                flattened,
+                _flatten_json(item, prefix=child_prefix),
+            )
+        return flattened
+    if not isinstance(value, str):
+        raise RuntimeError(
+            f"{prefix}: locale value must be a string, got {type(value).__name__}"
+        )
+    return {prefix: value}
+
+
+def _load_locale_file(path: Path) -> dict[str, str]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{path}: failed to read JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{path}: locale file must contain a JSON object")
+    try:
+        return _flatten_json(payload)
+    except RuntimeError as exc:
+        raise RuntimeError(f"{path}: {exc}") from exc
+
+
+def _placeholder_counter(text: str) -> Counter[str]:
+    return Counter(PLACEHOLDER_RE.findall(text))
+
+
+def _compare_locale_dir(locale_dir: Path) -> list[str]:
+    errors: list[str] = []
+    locale_maps = {
+        locale: _load_locale_file(locale_dir / f"{locale}.json")
+        for locale in EXPECTED_LOCALES
+    }
+    all_keys = set().union(*(set(values) for values in locale_maps.values()))
+    for locale, values in locale_maps.items():
+        missing = sorted(all_keys - set(values))
+        if missing:
+            errors.append(
+                f"{locale_dir}: {locale} missing {len(missing)} key(s): "
+                + _format_keys(missing)
+            )
+
+    for key in sorted(all_keys):
+        placeholder_by_locale: dict[str, Counter[str]] = {}
+        for locale, values in locale_maps.items():
+            if key in values:
+                placeholder_by_locale[locale] = _placeholder_counter(values[key])
+        if "en" in placeholder_by_locale:
+            expected = placeholder_by_locale["en"]
+        else:
+            expected = next(iter(placeholder_by_locale.values()))
+        mismatched = {
+            locale: placeholders
+            for locale, placeholders in placeholder_by_locale.items()
+            if placeholders != expected
+        }
+        if mismatched:
+            detail = "; ".join(
+                f"{locale}={dict(placeholders)}"
+                for locale, placeholders in sorted(mismatched.items())
+            )
+            errors.append(
+                f"{locale_dir}: placeholder mismatch for {key}: "
+                f"expected={dict(expected)}; {detail}"
+            )
+    return errors
+
+
+def _missing_locale_files(locale_dir: Path) -> list[str]:
+    return [
+        f"{locale}.json"
+        for locale in EXPECTED_LOCALES
+        if not (locale_dir / f"{locale}.json").is_file()
+    ]
+
+
+def _is_default_required_dir(root: Path, locale_dir: Path) -> bool:
+    try:
+        relative = locale_dir.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        # User-supplied directories outside the repo should fail strictly instead of
+        # being downgraded to warnings by the default plugin allowlist.
+        return True
+    return relative in _REQUIRED_LOCALE_DIRS
+
+
+def _report_results(
+    *,
+    checked: list[Path],
+    skipped: list[Path],
+    warnings: list[str],
+    errors: list[str],
+) -> int:
+    for locale_dir in skipped:
+        print(f"SKIP {locale_dir}")
+    for warning in warnings:
+        print(f"WARNING {warning}")
+    for error in errors:
+        print(f"ERROR {error}")
+    print(f"Checked {len(checked)} locale directories; skipped {len(skipped)}.")
+    if errors:
+        print(f"Locale comparison failed with {len(errors)} error(s).")
+        return 1
+    if warnings:
+        print(
+            f"Locale comparison passed with {len(warnings)} warning(s). "
+            "Use --strict-all to fail on every scanned plugin locale directory."
+        )
+        return 0
+    print("Locale comparison passed.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare key and placeholder consistency across locale JSON files.",
+    )
+    parser.add_argument(
+        "locale_dirs",
+        nargs="*",
+        help="Optional locale directories. Defaults to static/locales and plugin locale/i18n dirs.",
+    )
+    parser.add_argument(
+        "--strict-all",
+        action="store_true",
+        help="Fail for every scanned locale directory, including non-Galgame plugins.",
+    )
+    args = parser.parse_args()
+
+    root = _repo_root()
+    custom_locale_dirs = bool(args.locale_dirs)
+    locale_dirs = [Path(path).resolve() for path in args.locale_dirs]
+    if not locale_dirs:
+        locale_dirs = _default_locale_dirs(root)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked: list[Path] = []
+    skipped: list[Path] = []
+    for locale_dir in locale_dirs:
+        if not locale_dir.exists():
+            if custom_locale_dirs:
+                errors.append(f"{locale_dir}: directory does not exist")
+            else:
+                skipped.append(locale_dir)
+            continue
+        missing_files = _missing_locale_files(locale_dir)
+        if missing_files:
+            issue = (
+                f"{locale_dir}: missing expected locale file(s): "
+                + _format_keys(missing_files)
+            )
+            if args.strict_all or custom_locale_dirs or _is_default_required_dir(root, locale_dir):
+                errors.append(issue)
+            else:
+                warnings.append(issue)
+            continue
+        checked.append(locale_dir)
+        try:
+            issues = _compare_locale_dir(locale_dir)
+        except RuntimeError as exc:
+            issues = [f"{locale_dir}: {exc}"]
+        if args.strict_all or custom_locale_dirs or _is_default_required_dir(root, locale_dir):
+            errors.extend(issues)
+        else:
+            warnings.extend(issues)
+
+    return _report_results(
+        checked=checked,
+        skipped=skipped,
+        warnings=warnings,
+        errors=errors,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 变更内容

本 PR 按 `galgame-pr6-misc-fixes` 实施 3 项独立小修：

1. 统一 JSON 修正提示词语言
   - 将 `llm_backend.py` 中 `"JSON 修正请求"` 改为 `"JSON correction attempt"`
   - 同步更新相关测试断言与 prompt contract hash

2. 新增 locale 一致性检查工具
   - 新增 `plugin/tools/compare_locales.py`
   - 默认扫描 `static/locales/`、`plugin/plugins/*/locales/`、`plugin/plugins/*/i18n/`
   - 检查 8 个 locale 的 key 同步与 `{placeholder}` 一致性
   - 对 galgame locale 严格失败，对既有非目标插件 locale 债务默认 warning
   - 修复扁平化 key 冲突、非字符串叶子值、placeholder 基线等审查问题

3. 补充安装端点安全说明
   - README 中声明插件安装类端点必须启用认证/授权，或仅绑定 `localhost`

## 额外修复

- 补齐 `galgame_set_rapidocr_lang` 在 6 个 locale 中缺失的 i18n 文案
- 将该入口加入 galgame i18n 单测覆盖

## 验证

- `uv run python -m py_compile plugin/tools/compare_locales.py`
- `uv run python plugin/tools/compare_locales.py`
- `uv run python plugin/tools/compare_locales.py plugin/plugins/galgame_plugin/i18n`
- `uv run python -m pytest plugin/tests/unit/plugins/test_galgame_i18n.py plugin/tests/unit/plugins/test_galgame_llm_backend.py plugin/tests/unit/plugins/test_galgame_llm_json_correction.py -q`

结果：相关测试 `29 passed`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为 RapidOCR 识别语言添加界面文案，支持手动切换识别语言模型与 OCR 版本（手动切换会禁用自动检测），已覆盖中/英/日/韩/俄/繁体等语言。
* **测试**
  * 更新国际化相关测试与与消息文案稳定性相关的断言，确保新文案在各语言中一致。
* **Chores**
  * 新增命令行工具用于比较与校验多语言资源的键完整性与占位符一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->