### PR TITLE
修正角色卡详情面板展开动画的起始高度，使其从完整卡面本身开始展开，避免卡面下方出现空白区域

### DIFF
--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4436,7 +4436,7 @@ margin-top: 10px;
 }
 
 .catgirl-panel-wrapper.card-only {
-    height: 65vh;
+    height: var(--panel-card-face-height);
     max-height: 80vh;
     border-radius: 12px;
     --panel-card-face-height: clamp(360px, 56vh, 560px);
@@ -4451,7 +4451,7 @@ margin-top: 10px;
 
 .catgirl-panel-wrapper.card-only.phase-center {
     width: var(--panel-card-face-width);
-    height: 65vh;
+    height: var(--panel-card-face-height);
 }
 
 .catgirl-panel-wrapper.phase-expand {
@@ -4475,6 +4475,12 @@ margin-top: 10px;
     height: 80vh;
     flex-shrink: 0;
     overflow-y: auto;
+}
+
+/* 展开动画起点只显示完整卡面，避免卡面下方露出左侧容器空白 */
+.catgirl-panel-wrapper.card-only:not(.phase-expand) .catgirl-panel-left {
+    height: var(--panel-card-face-height);
+    overflow: hidden;
 }
 
 /* phase-expand 后，左侧容器恢复正常对齐；卡面图片尺寸保持原设，

--- a/static/css/character_card_manager.css
+++ b/static/css/character_card_manager.css
@@ -4527,6 +4527,11 @@ margin-top: 10px;
         max-height: 55vh;
         overflow-y: visible;
     }
+    .catgirl-panel-wrapper.card-only:not(.phase-expand) .catgirl-panel-left {
+        height: auto;
+        max-height: 55vh;
+        overflow-y: visible;
+    }
     .catgirl-panel-wrapper.card-only .catgirl-panel-card-image,
     .catgirl-panel-wrapper.card-only.phase-center .catgirl-panel-card-image,
     .catgirl-panel-wrapper.card-only.phase-expand .catgirl-panel-card-image {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式改进**
  * 统一卡牌面板高度基准，改善未展开态与展开动画的视觉一致性。
  * 在窄屏下调整未展开态左侧容器的高度与滚动行为，提升移动端显示与交互体验。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->