### PR TITLE
fix(steamworks): 后台重试静默化，避免无 Steam 环境刷 ERROR 日志

### DIFF
--- a/app/main_server.py
+++ b/app/main_server.py
@@ -130,7 +130,17 @@ template_dir = _get_app_root()
 
 templates = Jinja2Templates(directory=template_dir)
 
-def initialize_steamworks():
+def initialize_steamworks(*, quiet: bool = False):
+    # quiet=True 供后台静默重试使用：无 Steam 环境（如远端服务器部署）下，
+    # 前端轮询会每隔几秒触发一次重试，若按 ERROR/print 输出会无限刷屏。静默
+    # 模式把进度与失败日志统一降到 DEBUG，只有首次启动的尝试保持可见。
+    def _trace(msg: str) -> None:
+        if quiet:
+            if 'logger' in globals():
+                logger.debug(msg)
+        else:
+            print(msg)
+
     try:
         # 明确读取steam_appid.txt文件以获取应用ID
         app_id = None
@@ -138,18 +148,18 @@ def initialize_steamworks():
         if os.path.exists(app_id_file):
             with open(app_id_file, 'r') as f:
                 app_id = f.read().strip()
-            print(f"从steam_appid.txt读取到应用ID: {app_id}")
+            _trace(f"从steam_appid.txt读取到应用ID: {app_id}")
         
         # 创建并初始化Steamworks实例
         from steamworks import STEAMWORKS
         steamworks = STEAMWORKS()
         # 显示Steamworks初始化过程的详细日志
-        print("正在初始化Steamworks...")
+        _trace("正在初始化Steamworks...")
         steamworks.initialize()
         steamworks.UserStats.RequestCurrentStats()
         # 初始化后再次获取应用ID以确认
         actual_app_id = steamworks.app_id
-        print(f"Steamworks初始化完成，实际使用的应用ID: {actual_app_id}")
+        _trace(f"Steamworks初始化完成，实际使用的应用ID: {actual_app_id}")
         
         # 检查全局logger是否已初始化，如果已初始化则记录成功信息
         if 'logger' in globals():
@@ -164,7 +174,10 @@ def initialize_steamworks():
     except Exception as e:
         # 检查全局logger是否已初始化，如果已初始化则记录错误，否则使用print
         error_msg = f"初始化Steamworks失败: {e}"
-        if 'logger' in globals():
+        if quiet:
+            if 'logger' in globals():
+                logger.debug(error_msg)
+        elif 'logger' in globals():
             logger.error(error_msg)
         else:
             print(error_msg)
@@ -177,8 +190,8 @@ def ensure_steamworks_initialized():
     if steamworks is not None:
         return steamworks
 
-    logger.info("尝试重新初始化 Steamworks...")
-    steamworks = initialize_steamworks()
+    logger.debug("尝试重新初始化 Steamworks...")
+    steamworks = initialize_steamworks(quiet=True)
     try:
         from main_routers.shared_state import set_steamworks
 


### PR DESCRIPTION
## Summary
- 远端服务器部署没有 Steam 客户端，前端轮询 cloudsave/config 端点会每隔几秒触发一次 `ensure_steamworks` 重试。改前每次重试失败都按 `ERROR` + 裸 `print` 输出，无限刷屏，淹没真实错误。
- 给 `initialize_steamworks` 加 `quiet` 开关：重试路径（`ensure_steamworks_initialized`）传 `quiet=True`，进度与失败日志统一降到 `DEBUG`；那条每次都打的 `"尝试重新初始化 Steamworks..."` 也从 `INFO` 降到 `DEBUG`。
- **启动首次尝试不变**（`quiet=False`），失败仍打一条 `ERROR`，方便判断"这台机器没 Steam"。
- 纯日志级别调整：`initialize_steamworks` 返回值（None / 实例）与所有调用方的降级逻辑完全没碰，Steam 功能开关行为不变。

## 改完后日志行为
| 路径 | 改前 | 改后 |
|---|---|---|
| 启动首次失败 | ERROR + print | ERROR + print（保留可见） |
| 之后每 ~10s 的重试失败 | ERROR + print 刷屏 | 全 DEBUG，默认看不到 |
| 重试成功 | INFO | INFO（保留） |

> 注：远端日志里那段 traceback 不是本仓库 main 打的（except 块一直是 `logger.error` 不带 `exc_info`），是旧版/分叉构建带的；升级到含本改动的版本后 ERROR 行降级 + traceback 一并消失。

## Test plan
- [x] `py_compile app/main_server.py` 通过
- [x] `pytest tests/unit/test_cloudsave_lifecycle_flow.py` — 22 passed；本改动相关断言（`initialize_steamworks` 调用、降级路径）全过
- [ ] ⚠️ 已知预存失败：`test_main_server_manual_startup_performs_fallback_import_and_continues_boot`（`set_steamworks` 被调 2 次）。**在本分支基线上即已失败，与本改动无关**，属另一处问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了Steam初始化过程的日志输出行为，在无Steam环境下的重试过程中减少不必要的控制台刷屏，提升用户体验的清晰度。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->