### PR TITLE
perf(catgirl): 剩余 7 个单角色编辑端点迁到 fast path (follow-up #856)

### DIFF
--- a/main_routers/characters_router.py
+++ b/main_routers/characters_router.py
@@ -2018,9 +2018,9 @@ async def update_catgirl_l2d(name: str, request: Request):
 
         # 保存配置
         await _config_manager.asave_characters(characters)
-        # 自动重新加载配置
-        initialize_character_data = get_initialize_character_data()
-        await initialize_character_data()
+        # Fast path：只刷新被编辑角色的 session_manager（avatar 配置），不遍历其它 N-1 个。
+        init_one_catgirl = get_init_one_catgirl()
+        await init_one_catgirl(name, is_new=False)
 
 
         if model_type_str == 'live3d':
@@ -2102,9 +2102,10 @@ async def update_catgirl_touch_set(name: str, request: Request):
         set_reserved(characters['猫娘'][name], 'touch_set', existing_touch_set)
         await _config_manager.asave_characters(characters)
 
-        initialize_character_data = get_initialize_character_data()
-        if initialize_character_data:
-            await initialize_character_data()
+        # Fast path：只刷新被编辑角色的 session_manager（touch_set），不遍历其它 N-1 个。
+        init_one_catgirl = get_init_one_catgirl()
+        if init_one_catgirl:
+            await init_one_catgirl(name, is_new=False)
 
         logger.debug(f"已更新角色 {name} 模型 {model_name} 的触摸配置")
 
@@ -2220,12 +2221,13 @@ async def update_catgirl_lighting(name: str, request: Request):
         await _config_manager.asave_characters(characters)
 
         if apply_runtime:
-            initialize_character_data = get_initialize_character_data()
-            if initialize_character_data:
-                await initialize_character_data()
-                logger.info(f"已执行完整配置重载（角色 {name} 的打光配置）")
+            # Fast path：只刷新被编辑角色的 session_manager（lighting），不遍历其它 N-1 个。
+            init_one_catgirl = get_init_one_catgirl()
+            if init_one_catgirl:
+                await init_one_catgirl(name, is_new=False)
+                logger.info(f"已应用到运行时（角色 {name} 的打光配置）")
         else:
-            logger.debug("跳过完整配置重载（apply_runtime=False），配置已保存到磁盘，需要刷新页面或调用重载才能生效")
+            logger.debug("跳过运行时刷新（apply_runtime=False），配置已保存到磁盘，需要刷新页面或调用重载才能生效")
 
         if apply_runtime:
             message = f'已保存角色 {name} 的打光配置并已应用到运行时'
@@ -2449,15 +2451,17 @@ async def update_catgirl_voice_id(name: str, request: Request):
             # 这条 SessionManager 实例还会被旧失败计数 / 熔断继续静默拦截。
             session_manager[name].reset_session_start_circuit()
 
-    # 方案3：条件性重新加载 - 只有当前猫娘才重新加载配置
+    # Fast path：只刷新被编辑角色的 session_manager（voice_id），不遍历其它 N-1 个。
+    # 非当前角色分支也要显式刷 session_manager[name]：以前靠下次 switch 的全量 init 顺带
+    # rescue，但 set_current_catgirl 已切到 switch_current_catgirl_fast，rescue 不再发生，
+    # 必须在这里就把 voice_id 写进 session_manager[name]（init_one_catgirl 只写该 key，
+    # 不会影响当前 session）。
+    init_one_catgirl = get_init_one_catgirl()
+    await init_one_catgirl(name, is_new=False)
     if is_current_catgirl:
-        # 3. 重新加载配置，让新的voice_id生效
-        initialize_character_data = get_initialize_character_data()
-        await initialize_character_data()
         logger.info("配置已重新加载，新的voice_id已生效")
     else:
-        # 不是当前猫娘，跳过重新加载，避免影响当前猫娘的session
-        logger.info(f"切换的是其他猫娘 {name} 的音色，跳过重新加载以避免影响当前猫娘的session")
+        logger.info(f"非当前猫娘 {name} 的音色已更新并同步到 session_manager")
 
     return {"success": True, "session_restarted": session_ended, "voice_id_changed": True}
 
@@ -2603,9 +2607,12 @@ async def rename_catgirl(old_name: str, request: Request):
                 characters['当前猫娘'] = new_name
             await _config_manager.asave_characters(characters)
 
-            # 自动重新加载配置
-            initialize_character_data = get_initialize_character_data()
-            await initialize_character_data()
+            # Fast path：移除旧名 + 以新名启动一个 catgirl slot。
+            # 等价于"删除旧 + 新增新"，不遍历其它 N-1 个。
+            remove_one_catgirl = get_remove_one_catgirl()
+            init_one_catgirl = get_init_one_catgirl()
+            await remove_one_catgirl(old_name)
+            await init_one_catgirl(new_name, is_new=True)
 
             # 迁移卡面 PNG 与 sidecar JSON（纳入同一事务）
             from datetime import datetime as _dt
@@ -2744,10 +2751,11 @@ async def unregister_voice(name: str):
                 # 否则 reload 后新 start_session 会被旧熔断静默拦截。
                 session_manager[name].reset_session_start_circuit()
 
-        # 自动重新加载配置
-        if is_current_catgirl:
-            initialize_character_data = get_initialize_character_data()
-            await initialize_character_data()
+        # Fast path：只刷新被编辑角色的 session_manager（voice_id），不遍历其它 N-1 个。
+        # 非当前角色分支也要走 init_one_catgirl：以前靠下次 switch 的全量 init 顺带 rescue，
+        # 但 set_current_catgirl 已切到 switch_current_catgirl_fast，rescue 不再发生。
+        init_one_catgirl = get_init_one_catgirl()
+        await init_one_catgirl(name, is_new=False)
 
         logger.info(f"已解除猫娘 '{name}' 的声音注册")
         return {"success": True, "message": "声音注册已解除", "session_restarted": session_ended, "voice_id_changed": True}
@@ -3610,9 +3618,8 @@ async def set_microphone(request: Request):
 
         # 保存配置
         await _config_manager.asave_characters(characters_data)
-        # 自动重新加载配置
-        initialize_character_data = get_initialize_character_data()
-        await initialize_character_data()
+        # 麦克风 ID 是纯前端读取的字段（仅 get_microphone 读），不影响任何 catgirl
+        # 的 prompt / voice_id / session_manager，无需触发任何 init。
 
         return {"success": True}
     except Exception as e:

--- a/tests/unit/test_characters_router_model_settings.py
+++ b/tests/unit/test_characters_router_model_settings.py
@@ -73,8 +73,12 @@ async def _call_update(monkeypatch, payload, characters=None):
     async def _noop_initialize():
         return None
 
+    async def _noop_init_one(name, *, is_new=False):
+        return None
+
     monkeypatch.setattr(characters_router_module, 'get_config_manager', lambda: config_manager)
     monkeypatch.setattr(characters_router_module, 'get_initialize_character_data', lambda: _noop_initialize)
+    monkeypatch.setattr(characters_router_module, 'get_init_one_catgirl', lambda: _noop_init_one)
 
     response = await characters_router_module.update_catgirl_l2d(
         '测试角色',


### PR DESCRIPTION
## Summary

Follow-up #856 收尾：把 A 部分列出的 **7 个只改单个 catgirl 的端点**全部从全量 \`initialize_character_data()\` 迁到 PR #855 的 fast path / 删掉冗余 init。

每次全量 init = deepcopy 整 characters.json + 串行扫所有 N 个 catgirl，N=20 时事件循环阻塞 ~100ms。本 PR 替换后单端点墙钟 ~3ms / 阻塞 ~0ms（参考 #855 同款收益）。

## 改动

| Endpoint | 改动 |
|---|---|
| \`update_catgirl_l2d\` | → \`init_one_catgirl(name, is_new=False)\` |
| \`update_catgirl_touch_set\` | 同上 |
| \`update_catgirl_lighting\` | 同上（apply_runtime 分支） |
| \`update_catgirl_voice_id\` | 同上 + **非当前角色分支也走 fast path**（见下） |
| \`unregister_voice\` | 同上 + **非当前角色分支也走 fast path** |
| \`rename_catgirl\` | → \`remove_one_catgirl(old) + init_one_catgirl(new, is_new=True)\` |
| \`set_microphone\` | 直接删 init —— \`当前麦克风\` 字段只有 \`get_microphone\` 一处读取，纯前端选择，跟 catgirl 任何状态无关 |

测试 mock 同步：\`tests/unit/test_characters_router_model_settings.py::_call_update\` 补 \`get_init_one_catgirl\` monkeypatch。

## 关于"非当前角色分支" rescue 失效

PR #855 的 CodeRabbit review 指出过：原来 \`update_catgirl_voice_id\` / \`unregister_voice\` 的 \"非当前猫娘跳过 reload\" 分支，靠下次 \`set_current_catgirl\` 走全量 \`initialize_character_data()\` 顺带 rescue 把 voice_id 同步进 \`session_manager[name]\`。

PR #855 把 \`set_current_catgirl\` 切到 \`switch_current_catgirl_fast()\` 之后，那次 rescue 不再发生 —— 非当前角色的 \`session_manager[name].voice_id\` 会一直停在旧值，直到下一次全量 init（启动 / 主人名编辑 / 批量导入）。

本 PR 把这两个端点的非当前分支也显式调 \`init_one_catgirl(name, is_new=False)\`，它只写 \`session_manager[name]\` 的 prompt / voice_id，不碰当前 session，跟 PR #855 已对 \`update_catgirl\` 做的处理一致（\`characters_router.py:3354\`）。

## 保留全量 init 的地方

- \`_rollback_character_operation\` —— 回滚语义本来就要把所有状态恢复到快照一致，不是单角色操作，保留正确。
- B 部分（\`update_master\` / \`clear_voice_ids\` / \`delete_voice\` / \`update_core_config\` / 工坊批量同步 / \`reload_character_config\` 等）—— issue 明确说不迁，跨 catgirl 影响。

## Test plan

- [x] \`scripts/check_async_blocking.py\` exit 0
- [x] \`tests/unit/test_characters_router_model_settings.py\`: 11 passed
- [x] \`tests/unit/test_character_memory_regression.py\`: 34 passed（覆盖 rename_catgirl 各回滚 / 维护模式 / 503 路径）
- [x] AST 扫描确认 7 个端点函数体内已无 \`initialize_character_data()\` 残留
- [x] 手动验证：编辑 Live2D / VRM / MMD 模型，模型生效
- [ ] 手动验证：编辑触摸 touch_set，新触摸动画生效
- [x] 手动验证：编辑 VRM 打光（apply_runtime=true / false 两种）
- [ ] 手动验证：编辑非当前猫娘 voice_id，当前 session 不受影响 + 切到那只猫娘后新 voice_id 立刻生效
- [ ] 手动验证：unregister_voice 同上
- [x] 手动验证：重命名当前猫娘 / 非当前猫娘均能切换+刷新成功
- [ ] 手动验证：set_microphone 保存后 get_microphone 读到新值

Closes #856

---
Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化**
  * 改进了角色设置更新的处理机制。编辑单个角色的模型、配置或音色设置时，系统现在仅刷新该角色的运行状态，不再影响其他角色的正常运行。
  * 优化了角色重命名和麦克风配置的处理流程，提升了操作效率。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->