### PR TITLE
fix: restore chat visibility after model manager

### DIFF
--- a/scripts/verify_frontend_build.sh
+++ b/scripts/verify_frontend_build.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 REQUIRED_MODEL_FILE="static/yui-origin/yui-origin.model3.json"
 
-if [ ! -f "$REQUIRED_MODEL_FILE" ]; then
-  echo "ERROR: missing $REQUIRED_MODEL_FILE after build_frontend.sh" >&2
+if [ ! -s "$REQUIRED_MODEL_FILE" ]; then
+  echo "ERROR: missing or empty $REQUIRED_MODEL_FILE after build_frontend.sh" >&2
   exit 1
 fi

--- a/static/app-interpage.js
+++ b/static/app-interpage.js
@@ -59,6 +59,8 @@
             'body.neko-main-ui-hidden-by-model-manager #live2d-canvas,',
             'body.neko-main-ui-hidden-by-model-manager #vrm-canvas,',
             'body.neko-main-ui-hidden-by-model-manager #mmd-canvas,',
+            'body.neko-main-ui-hidden-by-model-manager #chat-container,',
+            'body.neko-main-ui-hidden-by-model-manager #react-chat-window-overlay,',
             'body.neko-main-ui-hidden-by-model-manager #live2d-floating-buttons,',
             'body.neko-main-ui-hidden-by-model-manager #vrm-floating-buttons,',
             'body.neko-main-ui-hidden-by-model-manager #mmd-floating-buttons,',

--- a/static/app-react-chat-window.js
+++ b/static/app-react-chat-window.js
@@ -2153,13 +2153,34 @@
         });
     }
 
+    function isMainUIHiddenByModelManager() {
+        try {
+            if (typeof window.isMainUIHiddenByModelManager === 'function') {
+                return window.isMainUIHiddenByModelManager();
+            }
+        } catch (_) {}
+        return !!(document.body && document.body.classList.contains('neko-main-ui-hidden-by-model-manager'));
+    }
+
+    var pendingOpenAfterModelManagerHidden = false;
+
     function openWindow() {
+        if (!isElectronChatWindow() && isMainUIHiddenByModelManager()) {
+            pendingOpenAfterModelManagerHidden = true;
+            return;
+        }
+        pendingOpenAfterModelManagerHidden = false;
+
         var overlay = getOverlay();
         if (!overlay) return;
 
         prewarmUserDisplayName();
         ensureBundleLoaded()
             .then(function () {
+                if (!isElectronChatWindow() && isMainUIHiddenByModelManager()) {
+                    pendingOpenAfterModelManagerHidden = true;
+                    return;
+                }
                 if (!mountWindow()) {
                     showToast(getI18nText('chat.reactWindowMountFailed', '聊天框挂载失败'), 3000);
                     return;
@@ -2208,6 +2229,7 @@
     function closeWindow() {
         var overlay = getOverlay();
         if (!overlay) return;
+        pendingOpenAfterModelManagerHidden = false;
         // Closing the overlay should also abort any in-flight GalGame fetch
         // (parity with setGalgameModeEnabled(false) / setMessages /
         // clearMessages). Without this, a request that lands after close
@@ -2248,6 +2270,14 @@
             timestamp: Date.now()
         });
     }
+
+    window.addEventListener('neko:main-ui-hidden-by-model-manager-changed', function(event) {
+        if (isElectronChatWindow()) return;
+        var hidden = !!(event && event.detail && event.detail.hidden);
+        if (hidden || !pendingOpenAfterModelManagerHidden) return;
+        pendingOpenAfterModelManagerHidden = false;
+        openWindow();
+    });
 
     var CLICK_THRESHOLD = 5; // px – 移动距离低于此值视为点击
 


### PR DESCRIPTION
Keep chat hidden while the model manager owns main UI visibility, then replay pending React chat opens once the hidden state clears. Also hide legacy and React chat overlays under the model-manager hidden body state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了主界面被隐藏时聊天相关容器的隐藏行为，与其它界面组件保持一致
  * 改进了聊天窗口的打开/关闭逻辑，支持在主界面被隐藏时延迟打开，并在恢复可见时自动弹出；关闭时会取消待打开标记

* **Chores**
  * 构建校验改为验证产物为非空文件，提升构建产物检查准确性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->