### PR TITLE
fix(study-companion): 加固 PDF CJK 字体回退

### DIFF
--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -335,6 +335,14 @@ class DocExporter:
                             cjk_font_path,
                         )
                     else:
+                        missing_sample = _ttfont_missing_cjk_sample_glyphs(font)
+                        if missing_sample:
+                            _LOGGER.warning(
+                                "STUDY_PDF_CJK_FONT_PATH font from %s is missing "
+                                "_PDF_CJK_SAMPLE glyphs %s; using configured font anyway",
+                                cjk_font_path,
+                                "".join(missing_sample),
+                            )
                         pdfmetrics.registerFont(font)
                         self._registered_pdf_fonts.add(font_name)
                         _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
@@ -522,14 +530,30 @@ def _pdf_user_font_name(font_path: Path) -> str:
 
 
 # ReportLab exposes the TTFont cmap through the non-public font.face.charToGlyph
-# mapping. Guard that access with getattr so missing internals return False,
-# which safely falls back to the built-in PDF fonts instead of accepting a user
-# font that cannot render the _PDF_CJK_SAMPLE glyphs.
-def _ttfont_has_cjk_glyphs(font: object) -> bool:
+# mapping. Guard that access with getattr so missing internals return no sample
+# glyphs, which safely falls back to the built-in PDF fonts. Partial
+# _PDF_CJK_SAMPLE coverage is still allowed for explicit user fonts, with a
+# warning at registration time.
+def _ttfont_supported_cjk_sample_glyphs(font: object) -> tuple[str, ...]:
     cmap = getattr(getattr(font, "face", None), "charToGlyph", None)
     if not isinstance(cmap, dict):
-        return False
-    return all(ord(char) in cmap for char in _PDF_CJK_SAMPLE)
+        return ()
+    supported: list[str] = []
+    for char in _PDF_CJK_SAMPLE:
+        glyph = cmap.get(ord(char))
+        if glyph is None or glyph == 0 or glyph == "0" or glyph == ".notdef":
+            continue
+        supported.append(char)
+    return tuple(supported)
+
+
+def _ttfont_has_cjk_glyphs(font: object) -> bool:
+    return bool(_ttfont_supported_cjk_sample_glyphs(font))
+
+
+def _ttfont_missing_cjk_sample_glyphs(font: object) -> tuple[str, ...]:
+    supported = set(_ttfont_supported_cjk_sample_glyphs(font))
+    return tuple(char for char in _PDF_CJK_SAMPLE if char not in supported)
 
 
 def safe_utf8_truncate(text: str, max_bytes: int) -> str:

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -328,17 +328,17 @@ class DocExporter:
                     from reportlab.pdfbase.ttfonts import TTFont
 
                     font = TTFont(font_name, str(font_path))
-                    if _ttfont_has_cjk_glyphs(font):
-                        _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
-                    else:
+                    if not _ttfont_has_cjk_glyphs(font):
                         _LOGGER.warning(
-                            "PDF CJK font registered from %s but does not expose common CJK glyphs; "
-                            "CJK rendering is not guaranteed",
+                            "PDF CJK font from %s does not expose common CJK glyphs; "
+                            "falling back to built-in CJK font",
                             cjk_font_path,
                         )
-                    pdfmetrics.registerFont(font)
-                    self._registered_pdf_fonts.add(font_name)
-                    return font_name
+                    else:
+                        _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
+                        pdfmetrics.registerFont(font)
+                        self._registered_pdf_fonts.add(font_name)
+                        return font_name
                 except Exception as exc:
                     _LOGGER.warning(
                         "User CJK font registration failed (%s): %s", cjk_font_path, exc

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from io import BytesIO
 import json
 import logging
+import os
 import re
 import textwrap
 from pathlib import Path
@@ -251,6 +252,33 @@ class DocExporter:
             return self._render_xmind(markdown)
         raise ValueError(f"unsupported export format: {fmt}")
 
+    def _register_pdf_font(self) -> str:
+        from reportlab.pdfbase import pdfmetrics
+
+        cjk_font_path = os.environ.get("STUDY_PDF_CJK_FONT_PATH", "")
+        if cjk_font_path:
+            font_path = Path(cjk_font_path)
+            if font_path.is_file():
+                try:
+                    from reportlab.pdfbase.ttfonts import TTFont
+
+                    pdfmetrics.registerFont(TTFont("CJK-User", str(font_path)))
+                    _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
+                    return "CJK-User"
+                except Exception as exc:
+                    _LOGGER.warning("User CJK font registration failed (%s): %s", cjk_font_path, exc)
+            else:
+                _LOGGER.warning("STUDY_PDF_CJK_FONT_PATH set but file not found: %s", cjk_font_path)
+
+        try:
+            from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+
+            pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+            return "STSong-Light"
+        except Exception as exc:
+            _LOGGER.warning("PDF Unicode font registration failed; Chinese text may render incorrectly: %s", exc)
+            return "Helvetica"
+
     def _render_pdf(self, markdown: str) -> bytes:
         if self._config.pdf_backend != "reportlab":
             raise ValueError(f"unsupported PDF backend: {self._config.pdf_backend}")
@@ -261,17 +289,8 @@ class DocExporter:
             raise RuntimeError("PDF export requires reportlab to be installed") from exc
 
         output = BytesIO()
-        font_name = "Helvetica"
         pdf = canvas.Canvas(output, pagesize=A4)
-        try:
-            from reportlab.pdfbase import pdfmetrics
-            from reportlab.pdfbase.cidfonts import UnicodeCIDFont
-
-            pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
-            font_name = "STSong-Light"
-        except Exception as exc:
-            _LOGGER.warning("PDF Unicode font registration failed; Chinese text may render incorrectly: %s", exc)
-            font_name = "Helvetica"
+        font_name = self._register_pdf_font()
         width, height = A4
         x = 48
         y = height - 48

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import hashlib
 from io import BytesIO
 import json
 import logging
@@ -19,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 _MARKDOWN_ESCAPE_RE = re.compile(r"([\\`*_{}\[\]()#+\-.!|])")
 _MAX_TEXT_CHARS = 2000
 _MAX_MARKDOWN_CHARS = 120_000
+_PDF_CJK_SAMPLE = "中文日本語한국어"
 _CONTENT_TYPES = {
     "markdown": "text/markdown; charset=utf-8",
     "pdf": "application/pdf",
@@ -39,7 +41,9 @@ class ExportDocument:
 
 class StudyExportStore(Protocol):
     def list_interactions(self, limit: int = 20) -> list[dict[str, Any]]: ...
-    def list_topics(self, limit: int = 100, subject: str | None = None) -> list[dict[str, Any]]: ...
+    def list_topics(
+        self, limit: int = 100, subject: str | None = None
+    ) -> list[dict[str, Any]]: ...
     def list_mastery_overview(self, limit: int = 20) -> list[dict[str, Any]]: ...
     def list_wrong_questions(
         self,
@@ -51,6 +55,8 @@ class StudyExportStore(Protocol):
 
 
 class DocExporter:
+    _registered_pdf_fonts: set[str] = set()
+
     def __init__(
         self,
         store: StudyExportStore,
@@ -61,17 +67,26 @@ class DocExporter:
         self._validate_store(store)
         self._store = store
         self._config = config or DocExportConfig()
-        self._styles_dir = styles_dir or Path(__file__).resolve().parent / "data" / "export_styles"
+        self._styles_dir = (
+            styles_dir or Path(__file__).resolve().parent / "data" / "export_styles"
+        )
 
     @staticmethod
     def _validate_store(store: object) -> None:
         missing = [
             name
-            for name in ("list_interactions", "list_topics", "list_mastery_overview", "list_wrong_questions")
+            for name in (
+                "list_interactions",
+                "list_topics",
+                "list_mastery_overview",
+                "list_wrong_questions",
+            )
             if not callable(getattr(store, name, None))
         ]
         if missing:
-            raise TypeError(f"DocExporter store is missing required methods: {', '.join(missing)}")
+            raise TypeError(
+                f"DocExporter store is missing required methods: {', '.join(missing)}"
+            )
 
     def export(
         self,
@@ -97,7 +112,11 @@ class DocExporter:
             recent_limit=recent_limit,
             topic_ids=topic_ids,
         )
-        content = markdown.encode("utf-8") if effective_format == "markdown" else self._render(effective_format, markdown)
+        content = (
+            markdown.encode("utf-8")
+            if effective_format == "markdown"
+            else self._render(effective_format, markdown)
+        )
         return ExportDocument(
             content=content,
             filename=f"{slugify(title or 'study-notes')}.{extension_for_format(effective_format)}",
@@ -127,12 +146,16 @@ class DocExporter:
         requested_topic_ids = _normalized_topic_ids(topic_ids)
 
         interactions = self._store.list_interactions(limit=limit)
-        topics = self._resolve_topics(topics_limit=topics_limit, topic_ids=requested_topic_ids)
+        topics = self._resolve_topics(
+            topics_limit=topics_limit, topic_ids=requested_topic_ids
+        )
         mastery = self._store.list_mastery_overview(limit=topics_limit)
         wrong_questions = self._store.list_wrong_questions(limit=limit)
 
         now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-        heading = escape_markdown(title or style_payload.get("title") or "Study Notes", limit=120)
+        heading = escape_markdown(
+            title or style_payload.get("title") or "Study Notes", limit=120
+        )
         lines = [
             f"# {heading}",
             "",
@@ -153,9 +176,21 @@ class DocExporter:
         if interactions:
             for item in interactions:
                 kind = escape_markdown(item.get("kind"), limit=80)
-                input_text = escape_markdown(item.get("input_text"), limit=_MAX_TEXT_CHARS)
-                output_text = escape_markdown(item.get("output_text"), limit=_MAX_TEXT_CHARS)
-                lines.extend([f"### {kind or 'interaction'}", "", f"- Input: {input_text or '-'}", f"- Output: {output_text or '-'}", ""])
+                input_text = escape_markdown(
+                    item.get("input_text"), limit=_MAX_TEXT_CHARS
+                )
+                output_text = escape_markdown(
+                    item.get("output_text"), limit=_MAX_TEXT_CHARS
+                )
+                lines.extend(
+                    [
+                        f"### {kind or 'interaction'}",
+                        "",
+                        f"- Input: {input_text or '-'}",
+                        f"- Output: {output_text or '-'}",
+                        "",
+                    ]
+                )
         else:
             lines.append("_No recent interactions._")
 
@@ -166,37 +201,58 @@ class DocExporter:
                 topic_id = escape_markdown(topic.get("id"), limit=120)
                 subject = escape_markdown(topic.get("subject"), limit=80)
                 chapter = escape_markdown(topic.get("chapter"), limit=120)
-                lines.append(f"- **{name}** (`{topic_id}`) - {subject or 'general'}{f' / {chapter}' if chapter else ''}")
+                lines.append(
+                    f"- **{name}** (`{topic_id}`) - {subject or 'general'}{f' / {chapter}' if chapter else ''}"
+                )
         else:
             lines.append("_No topics found._")
 
         lines.extend(["", "## Mastery", ""])
         if mastery:
             for item in mastery[:topics_limit]:
-                topic_name = escape_markdown(item.get("topic_name") or item.get("topic_id"), limit=120)
+                topic_name = escape_markdown(
+                    item.get("topic_name") or item.get("topic_id"), limit=120
+                )
                 level = escape_markdown(item.get("level"), limit=80)
                 mastery_value = _safe_float(item.get("mastery"))
-                lines.append(f"- {topic_name}: {mastery_value:.0%} mastery{f' ({level})' if level else ''}")
+                lines.append(
+                    f"- {topic_name}: {mastery_value:.0%} mastery{f' ({level})' if level else ''}"
+                )
         else:
             lines.append("_No mastery data yet._")
 
         lines.extend(["", "## Wrong Questions", ""])
         if wrong_questions:
             for item in wrong_questions:
-                question = item.get("question") if isinstance(item.get("question"), dict) else {}
-                text = escape_markdown(question.get("question") or item.get("expected_answer") or item.get("id"), limit=_MAX_TEXT_CHARS)
+                question = (
+                    item.get("question")
+                    if isinstance(item.get("question"), dict)
+                    else {}
+                )
+                text = escape_markdown(
+                    question.get("question")
+                    or item.get("expected_answer")
+                    or item.get("id"),
+                    limit=_MAX_TEXT_CHARS,
+                )
                 error_type = escape_markdown(item.get("error_type"), limit=80)
                 status = escape_markdown(item.get("status"), limit=80)
-                lines.append(f"- {text or '-'} ({error_type or 'unknown'}, {status or 'active'})")
+                lines.append(
+                    f"- {text or '-'} ({error_type or 'unknown'}, {status or 'active'})"
+                )
         else:
             lines.append("_No wrong-question records yet._")
 
         markdown = "\n".join(lines).strip() + "\n"
         if len(markdown) > _MAX_MARKDOWN_CHARS:
-            markdown = markdown[:_MAX_MARKDOWN_CHARS].rstrip() + "\n\n...[export truncated]\n"
+            markdown = (
+                markdown[:_MAX_MARKDOWN_CHARS].rstrip() + "\n\n...[export truncated]\n"
+            )
         return markdown
 
-    def _resolve_topics(self, *, topics_limit: int, topic_ids: list[str]) -> list[dict[str, Any]]:
+    def _resolve_topics(
+        self, *, topics_limit: int, topic_ids: list[str]
+    ) -> list[dict[str, Any]]:
         if not topic_ids:
             return self._store.list_topics(limit=topics_limit)
 
@@ -253,31 +309,70 @@ class DocExporter:
         raise ValueError(f"unsupported export format: {fmt}")
 
     def _register_pdf_font(self) -> str:
-        from reportlab.pdfbase import pdfmetrics
+        try:
+            from reportlab.pdfbase import pdfmetrics
+        except Exception as exc:
+            _LOGGER.warning(
+                "PDF font registry unavailable; falling back to Helvetica: %s", exc
+            )
+            return "Helvetica"
 
         cjk_font_path = os.environ.get("STUDY_PDF_CJK_FONT_PATH", "")
         if cjk_font_path:
             font_path = Path(cjk_font_path)
             if font_path.is_file():
+                font_name = _pdf_user_font_name(font_path)
+                if self._pdf_font_registered(pdfmetrics, font_name):
+                    return font_name
                 try:
                     from reportlab.pdfbase.ttfonts import TTFont
 
-                    pdfmetrics.registerFont(TTFont("CJK-User", str(font_path)))
-                    _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
-                    return "CJK-User"
+                    font = TTFont(font_name, str(font_path))
+                    if _ttfont_has_cjk_glyphs(font):
+                        _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
+                    else:
+                        _LOGGER.warning(
+                            "PDF CJK font registered from %s but does not expose common CJK glyphs; "
+                            "CJK rendering is not guaranteed",
+                            cjk_font_path,
+                        )
+                    pdfmetrics.registerFont(font)
+                    self._registered_pdf_fonts.add(font_name)
+                    return font_name
                 except Exception as exc:
-                    _LOGGER.warning("User CJK font registration failed (%s): %s", cjk_font_path, exc)
+                    _LOGGER.warning(
+                        "User CJK font registration failed (%s): %s", cjk_font_path, exc
+                    )
             else:
-                _LOGGER.warning("STUDY_PDF_CJK_FONT_PATH set but file not found: %s", cjk_font_path)
+                _LOGGER.warning(
+                    "STUDY_PDF_CJK_FONT_PATH set but file not found: %s", cjk_font_path
+                )
 
+        if self._pdf_font_registered(pdfmetrics, "STSong-Light"):
+            return "STSong-Light"
         try:
             from reportlab.pdfbase.cidfonts import UnicodeCIDFont
 
             pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+            self._registered_pdf_fonts.add("STSong-Light")
             return "STSong-Light"
         except Exception as exc:
-            _LOGGER.warning("PDF Unicode font registration failed; Chinese text may render incorrectly: %s", exc)
+            _LOGGER.warning(
+                "PDF Unicode font registration failed; Chinese text may render incorrectly: %s",
+                exc,
+            )
             return "Helvetica"
+
+    @classmethod
+    def _pdf_font_registered(cls, pdfmetrics: Any, font_name: str) -> bool:
+        if font_name in cls._registered_pdf_fonts:
+            return True
+        try:
+            pdfmetrics.getFont(font_name)
+        except Exception:
+            return False
+        cls._registered_pdf_fonts.add(font_name)
+        return True
 
     def _render_pdf(self, markdown: str) -> bytes:
         if self._config.pdf_backend != "reportlab":
@@ -297,7 +392,9 @@ class DocExporter:
         pdf.setFont(font_name, 10)
         for raw_line in markdown.splitlines() or [""]:
             line = _pdf_safe_text(raw_line)
-            wrapped = textwrap.wrap(line, width=92, replace_whitespace=False, drop_whitespace=False) or [""]
+            wrapped = textwrap.wrap(
+                line, width=92, replace_whitespace=False, drop_whitespace=False
+            ) or [""]
             for part in wrapped:
                 if y < 48:
                     pdf.showPage()
@@ -312,7 +409,9 @@ class DocExporter:
         try:
             from docx import Document
         except ImportError as exc:
-            raise RuntimeError("DOCX export requires python-docx to be installed") from exc
+            raise RuntimeError(
+                "DOCX export requires python-docx to be installed"
+            ) from exc
 
         document = Document()
         for line in markdown.splitlines():
@@ -331,11 +430,17 @@ class DocExporter:
         return output.getvalue()
 
     def _render_xmind(self, markdown: str) -> bytes:
-        root_topic = markdown.splitlines()[0].lstrip("# ").strip() if markdown.strip() else "Study Notes"
+        root_topic = (
+            markdown.splitlines()[0].lstrip("# ").strip()
+            if markdown.strip()
+            else "Study Notes"
+        )
         children = []
         for line in markdown.splitlines():
             if line.startswith("## "):
-                children.append({"id": slugify(line[3:]) or "section", "title": line[3:].strip()})
+                children.append(
+                    {"id": slugify(line[3:]) or "section", "title": line[3:].strip()}
+                )
         content = [
             {
                 "id": "study-companion-sheet",
@@ -350,8 +455,14 @@ class DocExporter:
         output = BytesIO()
         with ZipFile(output, "w", ZIP_DEFLATED) as archive:
             archive.writestr("content.json", json.dumps(content, ensure_ascii=False))
-            archive.writestr("metadata.json", json.dumps({"creator": "study_companion"}, ensure_ascii=False))
-            archive.writestr("manifest.json", json.dumps({"file-entries": {"content.json": {}, "metadata.json": {}}}))
+            archive.writestr(
+                "metadata.json",
+                json.dumps({"creator": "study_companion"}, ensure_ascii=False),
+            )
+            archive.writestr(
+                "manifest.json",
+                json.dumps({"file-entries": {"content.json": {}, "metadata.json": {}}}),
+            )
         return output.getvalue()
 
 
@@ -405,13 +516,33 @@ def _pdf_safe_text(value: object) -> str:
     return str(value or "").replace("\t", "    ")
 
 
+def _pdf_user_font_name(font_path: Path) -> str:
+    digest = hashlib.blake2s(
+        str(font_path.resolve()).encode("utf-8"), digest_size=6
+    ).hexdigest()
+    return f"CJK-User-{digest}"
+
+
+def _ttfont_has_cjk_glyphs(font: object) -> bool:
+    cmap = getattr(getattr(font, "face", None), "charToGlyph", None)
+    if not isinstance(cmap, dict):
+        return False
+    return any(ord(char) in cmap for char in _PDF_CJK_SAMPLE)
+
+
 def safe_utf8_truncate(text: str, max_bytes: int) -> str:
     if max_bytes <= 0:
         return ""
     payload = str(text or "").encode("utf-8")
     if len(payload) <= max_bytes:
         return str(text or "")
-    return payload[:max_bytes].decode("utf-8", errors="ignore")
+    truncated = payload[:max_bytes]
+    while truncated:
+        try:
+            return truncated.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            truncated = truncated[: exc.start]
+    return ""
 
 
 __all__ = [

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -517,9 +517,7 @@ def _pdf_safe_text(value: object) -> str:
 
 
 def _pdf_user_font_name(font_path: Path) -> str:
-    digest = hashlib.blake2s(
-        str(font_path.resolve()).encode("utf-8"), digest_size=6
-    ).hexdigest()
+    digest = hashlib.blake2s(str(font_path).encode("utf-8"), digest_size=6).hexdigest()
     return f"CJK-User-{digest}"
 
 

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -529,7 +529,7 @@ def _ttfont_has_cjk_glyphs(font: object) -> bool:
     cmap = getattr(getattr(font, "face", None), "charToGlyph", None)
     if not isinstance(cmap, dict):
         return False
-    return any(ord(char) in cmap for char in _PDF_CJK_SAMPLE)
+    return all(ord(char) in cmap for char in _PDF_CJK_SAMPLE)
 
 
 def safe_utf8_truncate(text: str, max_bytes: int) -> str:

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -521,6 +521,10 @@ def _pdf_user_font_name(font_path: Path) -> str:
     return f"CJK-User-{digest}"
 
 
+# ReportLab exposes the TTFont cmap through the non-public font.face.charToGlyph
+# mapping. Guard that access with getattr so missing internals return False,
+# which safely falls back to the built-in PDF fonts instead of accepting a user
+# font that cannot render the _PDF_CJK_SAMPLE glyphs.
 def _ttfont_has_cjk_glyphs(font: object) -> bool:
     cmap = getattr(getattr(font, "face", None), "charToGlyph", None)
     if not isinstance(cmap, dict):

--- a/plugin/plugins/study_companion/doc_exporter.py
+++ b/plugin/plugins/study_companion/doc_exporter.py
@@ -335,9 +335,9 @@ class DocExporter:
                             cjk_font_path,
                         )
                     else:
-                        _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
                         pdfmetrics.registerFont(font)
                         self._registered_pdf_fonts.add(font_name)
+                        _LOGGER.info("PDF CJK font registered from %s", cjk_font_path)
                         return font_name
                 except Exception as exc:
                     _LOGGER.warning(

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -15,6 +15,20 @@ class _Logger:
         return None
 
 
+class _MinimalStore:
+    def list_interactions(self, limit: int = 20):
+        return []
+
+    def list_topics(self, limit: int = 100, subject: str | None = None):
+        return []
+
+    def list_mastery_overview(self, limit: int = 20):
+        return []
+
+    def list_wrong_questions(self, *, limit: int = 20, topic_id=None, statuses=("active", "retrying", "resolved")):
+        return []
+
+
 def _store(tmp_path: Path) -> StudyStore:
     store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
     store.open()
@@ -131,6 +145,30 @@ def test_export_pdf_preserves_unicode_text(tmp_path: Path) -> None:
         assert pdf.content.startswith(b"%PDF")
     finally:
         store.close()
+
+
+def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("reportlab")
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(tmp_path / "missing-font.ttf"))
+
+    pdf = DocExporter(_MinimalStore()).export(fmt="pdf", title="中文笔记")
+
+    assert pdf.content.startswith(b"%PDF")
+    assert _pdf_safe_text("中文笔记") == "中文笔记"
+
+
+def test_register_pdf_font_returns_string_and_env_var_controls_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("reportlab")
+    exporter = DocExporter(_MinimalStore())
+
+    monkeypatch.delenv("STUDY_PDF_CJK_FONT_PATH", raising=False)
+    assert exporter._register_pdf_font() in {"STSong-Light", "Helvetica"}
+
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(tmp_path / "missing-font.ttf"))
+    assert exporter._register_pdf_font() in {"STSong-Light", "Helvetica"}
 
 
 def test_doc_exporter_rejects_store_without_required_methods() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from zipfile import ZipFile
 
 import pytest
 
-from plugin.plugins.study_companion.doc_exporter import DocExporter, _pdf_safe_text, escape_markdown, safe_utf8_truncate
-from plugin.plugins.study_companion.models import DocExportConfig, STUDY_EXPORT_FORMATS, STUDY_EXPORT_STYLES
+from plugin.plugins.study_companion.doc_exporter import (
+    DocExporter,
+    _pdf_safe_text,
+    escape_markdown,
+    safe_utf8_truncate,
+)
+from plugin.plugins.study_companion.models import (
+    DocExportConfig,
+    STUDY_EXPORT_FORMATS,
+    STUDY_EXPORT_STYLES,
+)
 from plugin.plugins.study_companion.store import StudyStore
 
 
@@ -16,23 +26,36 @@ class _Logger:
 
 
 class _MinimalStore:
-    def list_interactions(self, limit: int = 20):
+    def list_interactions(self, limit: int = 20) -> list[dict[str, Any]]:
         return []
 
-    def list_topics(self, limit: int = 100, subject: str | None = None):
+    def list_topics(
+        self, limit: int = 100, subject: str | None = None
+    ) -> list[dict[str, Any]]:
         return []
 
-    def list_mastery_overview(self, limit: int = 20):
+    def list_mastery_overview(self, limit: int = 20) -> list[dict[str, Any]]:
         return []
 
-    def list_wrong_questions(self, *, limit: int = 20, topic_id=None, statuses=("active", "retrying", "resolved")):
+    def list_wrong_questions(
+        self,
+        *,
+        limit: int = 20,
+        topic_id: str | None = None,
+        statuses: tuple[str, ...] = ("active", "retrying", "resolved"),
+    ) -> list[dict[str, Any]]:
         return []
 
 
 def _store(tmp_path: Path) -> StudyStore:
     store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
     store.open()
-    store.ensure_topic(topic_id="photosynthesis", name="Photosynthesis", subject="biology", chapter="plants")
+    store.ensure_topic(
+        topic_id="photosynthesis",
+        name="Photosynthesis",
+        subject="biology",
+        chapter="plants",
+    )
     store.append_mastery_snapshot(
         {
             "topic_id": "photosynthesis",
@@ -59,7 +82,9 @@ def test_markdown_build_escapes_and_truncates_user_text(tmp_path: Path) -> None:
     store = _store(tmp_path)
     try:
         exporter = DocExporter(store)
-        markdown = exporter.build_markdown(title="My *Notes*", style="unknown", recent_limit=5)
+        markdown = exporter.build_markdown(
+            title="My *Notes*", style="unknown", recent_limit=5
+        )
 
         assert "# My \\*Notes\\*" in markdown
         assert "\\*\\*raw\\*\\*" in markdown
@@ -72,7 +97,9 @@ def test_markdown_build_escapes_and_truncates_user_text(tmp_path: Path) -> None:
         store.close()
 
 
-def test_topic_id_export_resolves_topics_outside_style_page_limit(tmp_path: Path) -> None:
+def test_topic_id_export_resolves_topics_outside_style_page_limit(
+    tmp_path: Path,
+) -> None:
     store = StudyStore(tmp_path / "many-topics.db", tmp_path / "seed.json", _Logger())
     store.open()
     try:
@@ -96,11 +123,15 @@ def test_topic_id_export_resolves_topics_outside_style_page_limit(tmp_path: Path
         store.close()
 
 
-def test_export_markdown_handles_empty_store_and_declared_constants(tmp_path: Path) -> None:
+def test_export_markdown_handles_empty_store_and_declared_constants(
+    tmp_path: Path,
+) -> None:
     store = StudyStore(tmp_path / "empty.db", tmp_path / "seed.json", _Logger())
     store.open()
     try:
-        exported = DocExporter(store).export(fmt="markdown", style="compact", title="Empty")
+        exported = DocExporter(store).export(
+            fmt="markdown", style="compact", title="Empty"
+        )
 
         assert exported.content.startswith(b"# Empty")
         assert exported.filename == "empty.md"
@@ -128,7 +159,9 @@ def test_export_pdf_docx_and_xmind_bytes(tmp_path: Path) -> None:
         archive_path = tmp_path / "notes.xmind"
         archive_path.write_bytes(xmind.content)
         with ZipFile(archive_path) as archive:
-            assert {"content.json", "metadata.json", "manifest.json"}.issubset(set(archive.namelist()))
+            assert {"content.json", "metadata.json", "manifest.json"}.issubset(
+                set(archive.namelist())
+            )
     finally:
         store.close()
 
@@ -138,7 +171,12 @@ def test_export_pdf_preserves_unicode_text(tmp_path: Path) -> None:
     store = StudyStore(tmp_path / "unicode.db", tmp_path / "seed.json", _Logger())
     store.open()
     try:
-        store.append_interaction(kind="concept_explain", input_text="光合作用", output_text="植物吸收光能", history_limit=10)
+        store.append_interaction(
+            kind="concept_explain",
+            input_text="光合作用",
+            output_text="植物吸收光能",
+            history_limit=10,
+        )
         pdf = DocExporter(store).export(fmt="pdf", title="中文笔记")
 
         assert _pdf_safe_text("中文笔记") == "中文笔记"
@@ -147,7 +185,9 @@ def test_export_pdf_preserves_unicode_text(tmp_path: Path) -> None:
         store.close()
 
 
-def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     pytest.importorskip("reportlab")
     monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(tmp_path / "missing-font.ttf"))
 
@@ -171,6 +211,116 @@ def test_register_pdf_font_returns_string_and_env_var_controls_path(
     assert exporter._register_pdf_font() in {"STSong-Light", "Helvetica"}
 
 
+def test_register_pdf_font_uses_distinct_cached_user_font_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
+    registered: list[str] = []
+
+    class _Face:
+        charToGlyph = {ord("中"): 1}
+
+    class _TTFont:
+        def __init__(self, name: str, path: str) -> None:
+            self.fontName = name
+            self.face = _Face()
+
+    def _register_font(font: Any) -> None:
+        registered.append(font.fontName)
+
+    monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
+    monkeypatch.setattr(pdfmetrics, "registerFont", _register_font)
+    monkeypatch.setattr(
+        pdfmetrics, "getFont", lambda name: (_ for _ in ()).throw(KeyError(name))
+    )
+
+    first_path = tmp_path / "font-a.ttf"
+    second_path = tmp_path / "font-b.ttf"
+    first_path.write_bytes(b"fake")
+    second_path.write_bytes(b"fake")
+    exporter = DocExporter(_MinimalStore())
+
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(first_path))
+    first_name = exporter._register_pdf_font()
+    second_call_name = exporter._register_pdf_font()
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(second_path))
+    second_name = exporter._register_pdf_font()
+
+    assert first_name == second_call_name
+    assert first_name != second_name
+    assert registered == [first_name, second_name]
+
+
+def test_register_pdf_font_warns_when_user_font_lacks_cjk_glyphs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    class _Face:
+        charToGlyph = {ord("A"): 1}
+
+    class _TTFont:
+        def __init__(self, name: str, path: str) -> None:
+            self.fontName = name
+            self.face = _Face()
+
+    font_path = tmp_path / "latin.ttf"
+    font_path.write_bytes(b"fake")
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
+    monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
+    monkeypatch.setattr(pdfmetrics, "registerFont", lambda font: None)
+
+    font_name = DocExporter(_MinimalStore())._register_pdf_font()
+
+    assert font_name.startswith("CJK-User-")
+    assert "does not expose common CJK glyphs" in caplog.text
+
+
+def test_register_pdf_font_falls_back_to_helvetica_when_pdfmetrics_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("reportlab")
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "reportlab.pdfbase" and args and "pdfmetrics" in (args[2] or ()):
+            raise ImportError("pdfmetrics unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    assert DocExporter(_MinimalStore())._register_pdf_font() == "Helvetica"
+
+
+def test_register_pdf_font_falls_back_to_helvetica_when_cid_font_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
+    monkeypatch.delenv("STUDY_PDF_CJK_FONT_PATH", raising=False)
+    monkeypatch.setattr(
+        pdfmetrics, "getFont", lambda name: (_ for _ in ()).throw(KeyError(name))
+    )
+    monkeypatch.setattr(
+        pdfmetrics,
+        "registerFont",
+        lambda font: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    assert DocExporter(_MinimalStore())._register_pdf_font() == "Helvetica"
+
+
 def test_doc_exporter_rejects_store_without_required_methods() -> None:
     with pytest.raises(TypeError, match="missing required methods"):
         DocExporter(object())  # type: ignore[arg-type]
@@ -180,15 +330,21 @@ def test_xmind_export_requires_explicit_enable(tmp_path: Path) -> None:
     store = _store(tmp_path)
     try:
         with pytest.raises(ValueError, match="XMind export is disabled"):
-            DocExporter(store, config=DocExportConfig(xmind_enabled=False)).export(fmt="xmind")
+            DocExporter(store, config=DocExportConfig(xmind_enabled=False)).export(
+                fmt="xmind"
+            )
     finally:
         store.close()
 
 
-def test_preview_export_uses_markdown_metadata_for_non_markdown_format(tmp_path: Path) -> None:
+def test_preview_export_uses_markdown_metadata_for_non_markdown_format(
+    tmp_path: Path,
+) -> None:
     store = _store(tmp_path)
     try:
-        exported = DocExporter(store, config=DocExportConfig(xmind_enabled=True)).export(
+        exported = DocExporter(
+            store, config=DocExportConfig(xmind_enabled=True)
+        ).export(
             fmt="xmind",
             title="Preview Notes",
             preview_only=True,

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -372,6 +372,49 @@ def test_register_pdf_font_falls_back_when_user_font_lacks_cjk_glyphs(
     assert "does not expose common CJK glyphs" in caplog.text
 
 
+def test_register_pdf_font_does_not_cache_user_font_when_registration_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
+
+    class _Face:
+        charToGlyph = {ord("中"): 1}
+
+    class _TTFont:
+        def __init__(self, name: str, path: str) -> None:
+            self.fontName = name
+            self.face = _Face()
+
+    def _get_font(name: str) -> Any:
+        if name == "STSong-Light":
+            return object()
+        raise KeyError(name)
+
+    def _register_font(font: Any) -> None:
+        if str(getattr(font, "fontName", "")).startswith("CJK-User-"):
+            raise RuntimeError("user font registration failed")
+
+    font_path = tmp_path / "cjk.ttf"
+    font_path.write_bytes(b"fake")
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
+    monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
+    monkeypatch.setattr(pdfmetrics, "getFont", _get_font)
+    monkeypatch.setattr(pdfmetrics, "registerFont", _register_font)
+
+    with caplog.at_level("INFO"):
+        font_name = DocExporter(_MinimalStore())._register_pdf_font()
+
+    assert font_name == "STSong-Light"
+    assert not any(name.startswith("CJK-User-") for name in DocExporter._registered_pdf_fonts)
+    assert "PDF CJK font registered from" not in caplog.text
+    assert "User CJK font registration failed" in caplog.text
+
+
 def test_register_pdf_font_falls_back_to_helvetica_when_pdfmetrics_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -335,13 +335,16 @@ def test_register_pdf_font_uses_distinct_cached_user_font_names(
     assert registered == [first_name, second_name]
 
 
-def test_register_pdf_font_warns_when_user_font_lacks_cjk_glyphs(
+def test_register_pdf_font_falls_back_when_user_font_lacks_cjk_glyphs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     pytest.importorskip("reportlab")
     from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
+    registered: list[str] = []
 
     class _Face:
         charToGlyph = {ord("A"): 1}
@@ -355,11 +358,17 @@ def test_register_pdf_font_warns_when_user_font_lacks_cjk_glyphs(
     font_path.write_bytes(b"fake")
     monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
     monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
-    monkeypatch.setattr(pdfmetrics, "registerFont", lambda font: None)
+    monkeypatch.setattr(
+        pdfmetrics, "getFont", lambda name: (_ for _ in ()).throw(KeyError(name))
+    )
+    monkeypatch.setattr(
+        pdfmetrics, "registerFont", lambda font: registered.append(font.fontName)
+    )
 
     font_name = DocExporter(_MinimalStore())._register_pdf_font()
 
-    assert font_name.startswith("CJK-User-")
+    assert font_name == "STSong-Light"
+    assert registered == ["STSong-Light"]
     assert "does not expose common CJK glyphs" in caplog.text
 
 

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -377,7 +377,7 @@ def test_register_pdf_font_falls_back_when_user_font_lacks_cjk_glyphs(
     assert "does not expose common CJK glyphs" in caplog.text
 
 
-def test_register_pdf_font_falls_back_when_user_font_has_partial_cjk_sample(
+def test_register_pdf_font_reuses_user_font_with_partial_cjk_sample(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -397,6 +397,45 @@ def test_register_pdf_font_falls_back_when_user_font_has_partial_cjk_sample(
             self.face = _Face()
 
     font_path = tmp_path / "partial-cjk.ttf"
+    font_path.write_bytes(b"fake")
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
+    monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
+    monkeypatch.setattr(
+        pdfmetrics, "getFont", lambda name: (_ for _ in ()).throw(KeyError(name))
+    )
+    monkeypatch.setattr(
+        pdfmetrics, "registerFont", lambda font: registered.append(font.fontName)
+    )
+
+    font_name = DocExporter(_MinimalStore())._register_pdf_font()
+
+    assert font_name.startswith("CJK-User-")
+    assert registered == [font_name]
+    assert "STUDY_PDF_CJK_FONT_PATH font from" in caplog.text
+    assert "missing _PDF_CJK_SAMPLE glyphs" in caplog.text
+    assert _PDF_CJK_SAMPLE[1:] in caplog.text
+
+
+def test_register_pdf_font_rejects_notdef_cjk_glyphs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
+    registered: list[str] = []
+
+    class _Face:
+        charToGlyph = {ord(char): 0 for char in _PDF_CJK_SAMPLE}
+
+    class _TTFont:
+        def __init__(self, name: str, path: str) -> None:
+            self.fontName = name
+            self.face = _Face()
+
+    font_path = tmp_path / "notdef-cjk.ttf"
     font_path.write_bytes(b"fake")
     monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
     monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -407,7 +407,8 @@ def test_register_pdf_font_reuses_user_font_with_partial_cjk_sample(
         pdfmetrics, "registerFont", lambda font: registered.append(font.fontName)
     )
 
-    font_name = DocExporter(_MinimalStore())._register_pdf_font()
+    with caplog.at_level("INFO"):
+        font_name = DocExporter(_MinimalStore())._register_pdf_font()
 
     assert font_name.startswith("CJK-User-")
     assert registered == [font_name]

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -186,14 +186,30 @@ def test_export_pdf_preserves_unicode_text(tmp_path: Path) -> None:
 
 
 def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     pytest.importorskip("reportlab")
+    from reportlab.pdfgen.canvas import Canvas
+
+    DocExporter._registered_pdf_fonts.clear()
+    font_names: list[str] = []
+    original_set_font = Canvas.setFont
+
+    def _set_font_spy(
+        self: Canvas, psfontname: str, size: float, leading: float | None = None
+    ) -> None:
+        font_names.append(psfontname)
+        original_set_font(self, psfontname, size, leading)
+
+    monkeypatch.setattr(Canvas, "setFont", _set_font_spy)
     monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(tmp_path / "missing-font.ttf"))
 
     pdf = DocExporter(_MinimalStore()).export(fmt="pdf", title="中文笔记")
 
     assert pdf.content.startswith(b"%PDF")
+    assert font_names[0] in {"STSong-Light", "Helvetica"}
+    assert not font_names[0].startswith("CJK-User-")
+    assert "STUDY_PDF_CJK_FONT_PATH set but file not found" in caplog.text
     assert _pdf_safe_text("中文笔记") == "中文笔记"
 
 
@@ -202,13 +218,43 @@ def test_register_pdf_font_returns_string_and_env_var_controls_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
     exporter = DocExporter(_MinimalStore())
+    registered: list[str] = []
+    ttfont_paths: list[str] = []
+
+    class _Face:
+        charToGlyph = {ord("中"): 1}
+
+    class _TTFont:
+        def __init__(self, name: str, path: str) -> None:
+            self.fontName = name
+            self.face = _Face()
+            ttfont_paths.append(path)
+
+    def _register_font(font: Any) -> None:
+        registered.append(font.fontName)
+
+    monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
+    monkeypatch.setattr(pdfmetrics, "registerFont", _register_font)
+    monkeypatch.setattr(
+        pdfmetrics, "getFont", lambda name: (_ for _ in ()).throw(KeyError(name))
+    )
 
     monkeypatch.delenv("STUDY_PDF_CJK_FONT_PATH", raising=False)
     assert exporter._register_pdf_font() in {"STSong-Light", "Helvetica"}
 
-    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(tmp_path / "missing-font.ttf"))
-    assert exporter._register_pdf_font() in {"STSong-Light", "Helvetica"}
+    font_path = tmp_path / "env-font.ttf"
+    font_path.write_bytes(b"fake")
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
+
+    font_name = exporter._register_pdf_font()
+
+    assert font_name.startswith("CJK-User-")
+    assert ttfont_paths == [str(font_path)]
+    assert registered[-1] == font_name
 
 
 def test_register_pdf_font_uses_distinct_cached_user_font_names(

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -333,6 +333,7 @@ def test_register_pdf_font_falls_back_to_helvetica_when_pdfmetrics_is_unavailabl
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pytest.importorskip("reportlab")
+    DocExporter._registered_pdf_fonts.clear()
     import builtins
 
     real_import = builtins.__import__

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -168,9 +168,20 @@ def test_export_pdf_docx_and_xmind_bytes(tmp_path: Path) -> None:
 
 def test_export_pdf_preserves_unicode_text(tmp_path: Path) -> None:
     pytest.importorskip("reportlab")
+    from reportlab.pdfgen.canvas import Canvas
+
+    DocExporter._registered_pdf_fonts.clear()
+    drawn_texts: list[str] = []
+    original_draw_string = Canvas.drawString
+
+    def _draw_string_spy(self: Canvas, x: float, y: float, text: str) -> None:
+        drawn_texts.append(text)
+        original_draw_string(self, x, y, text)
+
     store = StudyStore(tmp_path / "unicode.db", tmp_path / "seed.json", _Logger())
     store.open()
     try:
+        Canvas.drawString = _draw_string_spy
         store.append_interaction(
             kind="concept_explain",
             input_text="光合作用",
@@ -181,7 +192,10 @@ def test_export_pdf_preserves_unicode_text(tmp_path: Path) -> None:
 
         assert _pdf_safe_text("中文笔记") == "中文笔记"
         assert pdf.content.startswith(b"%PDF")
+        assert any("中文笔记" in text for text in drawn_texts)
+        assert any("光合作用" in text for text in drawn_texts)
     finally:
+        Canvas.drawString = original_draw_string
         store.close()
 
 
@@ -207,7 +221,7 @@ def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(
     pdf = DocExporter(_MinimalStore()).export(fmt="pdf", title="中文笔记")
 
     assert pdf.content.startswith(b"%PDF")
-    assert font_names[0] in {"STSong-Light", "Helvetica"}
+    assert font_names[0] == "STSong-Light"
     assert not font_names[0].startswith("CJK-User-")
     assert "STUDY_PDF_CJK_FONT_PATH set but file not found" in caplog.text
     assert _pdf_safe_text("中文笔记") == "中文笔记"
@@ -244,7 +258,7 @@ def test_register_pdf_font_returns_string_and_env_var_controls_path(
     )
 
     monkeypatch.delenv("STUDY_PDF_CJK_FONT_PATH", raising=False)
-    assert exporter._register_pdf_font() in {"STSong-Light", "Helvetica"}
+    assert exporter._register_pdf_font() == "STSong-Light"
 
     font_path = tmp_path / "env-font.ttf"
     font_path.write_bytes(b"fake")

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -203,18 +203,37 @@ def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
     from reportlab.pdfgen.canvas import Canvas
 
     DocExporter._registered_pdf_fonts.clear()
     font_names: list[str] = []
+    registered_fonts: list[str] = []
+    original_get_font = pdfmetrics.getFont
+    original_register_font = pdfmetrics.registerFont
     original_set_font = Canvas.setFont
+
+    def _get_font(name: str) -> Any:
+        if name == "STSong-Light":
+            raise KeyError(name)
+        return original_get_font(name)
+
+    def _register_font(font: Any) -> None:
+        font_name = getattr(font, "fontName", "")
+        if font_name == "STSong-Light":
+            registered_fonts.append(font_name)
+            return None
+        return original_register_font(font)
 
     def _set_font_spy(
         self: Canvas, psfontname: str, size: float, leading: float | None = None
     ) -> None:
         font_names.append(psfontname)
-        original_set_font(self, psfontname, size, leading)
+        fallback_name = "Helvetica" if psfontname == "STSong-Light" else psfontname
+        original_set_font(self, fallback_name, size, leading)
 
+    monkeypatch.setattr(pdfmetrics, "getFont", _get_font)
+    monkeypatch.setattr(pdfmetrics, "registerFont", _register_font)
     monkeypatch.setattr(Canvas, "setFont", _set_font_spy)
     monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(tmp_path / "missing-font.ttf"))
 
@@ -222,6 +241,7 @@ def test_pdf_font_falls_back_when_cjk_env_var_points_to_missing_file(
 
     assert pdf.content.startswith(b"%PDF")
     assert font_names[0] == "STSong-Light"
+    assert registered_fonts == ["STSong-Light"]
     assert not font_names[0].startswith("CJK-User-")
     assert "STUDY_PDF_CJK_FONT_PATH set but file not found" in caplog.text
     assert _pdf_safe_text("中文笔记") == "中文笔记"

--- a/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
+++ b/plugin/tests/unit/plugins/test_study_companion_doc_exporter.py
@@ -8,6 +8,7 @@ import pytest
 
 from plugin.plugins.study_companion.doc_exporter import (
     DocExporter,
+    _PDF_CJK_SAMPLE,
     _pdf_safe_text,
     escape_markdown,
     safe_utf8_truncate,
@@ -45,6 +46,10 @@ class _MinimalStore:
         statuses: tuple[str, ...] = ("active", "retrying", "resolved"),
     ) -> list[dict[str, Any]]:
         return []
+
+
+def _sample_cjk_cmap() -> dict[int, int]:
+    return {ord(char): index for index, char in enumerate(_PDF_CJK_SAMPLE, start=1)}
 
 
 def _store(tmp_path: Path) -> StudyStore:
@@ -260,7 +265,7 @@ def test_register_pdf_font_returns_string_and_env_var_controls_path(
     ttfont_paths: list[str] = []
 
     class _Face:
-        charToGlyph = {ord("中"): 1}
+        charToGlyph = _sample_cjk_cmap()
 
     class _TTFont:
         def __init__(self, name: str, path: str) -> None:
@@ -302,7 +307,7 @@ def test_register_pdf_font_uses_distinct_cached_user_font_names(
     registered: list[str] = []
 
     class _Face:
-        charToGlyph = {ord("中"): 1}
+        charToGlyph = _sample_cjk_cmap()
 
     class _TTFont:
         def __init__(self, name: str, path: str) -> None:
@@ -372,6 +377,43 @@ def test_register_pdf_font_falls_back_when_user_font_lacks_cjk_glyphs(
     assert "does not expose common CJK glyphs" in caplog.text
 
 
+def test_register_pdf_font_falls_back_when_user_font_has_partial_cjk_sample(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    pytest.importorskip("reportlab")
+    from reportlab.pdfbase import pdfmetrics
+
+    DocExporter._registered_pdf_fonts.clear()
+    registered: list[str] = []
+
+    class _Face:
+        charToGlyph = {ord(_PDF_CJK_SAMPLE[0]): 1}
+
+    class _TTFont:
+        def __init__(self, name: str, path: str) -> None:
+            self.fontName = name
+            self.face = _Face()
+
+    font_path = tmp_path / "partial-cjk.ttf"
+    font_path.write_bytes(b"fake")
+    monkeypatch.setenv("STUDY_PDF_CJK_FONT_PATH", str(font_path))
+    monkeypatch.setattr("reportlab.pdfbase.ttfonts.TTFont", _TTFont)
+    monkeypatch.setattr(
+        pdfmetrics, "getFont", lambda name: (_ for _ in ()).throw(KeyError(name))
+    )
+    monkeypatch.setattr(
+        pdfmetrics, "registerFont", lambda font: registered.append(font.fontName)
+    )
+
+    font_name = DocExporter(_MinimalStore())._register_pdf_font()
+
+    assert font_name == "STSong-Light"
+    assert registered == ["STSong-Light"]
+    assert "does not expose common CJK glyphs" in caplog.text
+
+
 def test_register_pdf_font_does_not_cache_user_font_when_registration_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -383,7 +425,7 @@ def test_register_pdf_font_does_not_cache_user_font_when_registration_fails(
     DocExporter._registered_pdf_fonts.clear()
 
     class _Face:
-        charToGlyph = {ord("中"): 1}
+        charToGlyph = _sample_cjk_cmap()
 
     class _TTFont:
         def __init__(self, name: str, path: str) -> None:


### PR DESCRIPTION
## 概要

- 为伴学插件 PDF 导出增加三级字体回退：
  - 用户通过 `STUDY_PDF_CJK_FONT_PATH` 指定的字体
  - ReportLab `STSong-Light`
  - `Helvetica`
- 缓存已注册字体，避免重复导出时反复注册 ReportLab 全局字体。
- 用户字体名改为按路径派生，避免不同字体路径共用 `CJK-User` 导致冲突。
- 用户字体注册成功但缺少常见 CJK 字形时输出 warning。
- `pdfmetrics` 不可用时优雅回退到 `Helvetica`。
- 将 UTF-8 截断改为显式回退到合法字符边界。
- 扩展文档导出测试，覆盖用户字体、缓存、缺字形警告和失败回退路径。

## 验证

- `uv run pytest plugin/tests/unit/plugins/test_study_companion_doc_exporter.py -q`
- `uv run pytest plugin/tests/unit/plugins/test_study_companion*.py -q`
- `uv run ruff check plugin/plugins/study_companion/doc_exporter.py plugin/tests/unit/plugins/test_study_companion_doc_exporter.py`
- `uv run ruff format --check plugin/plugins/study_companion/doc_exporter.py plugin/tests/unit/plugins/test_study_companion_doc_exporter.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * PDF 导出支持由环境变量指定的用户字体并对已注册字体做跨导出缓存与复用。
* **改进**
  * 优先使用内置 CJK 字体，缺失或不兼容时智能回退至常规字体以保证中文可视化；导出按行清洗并分段绘制文本。
  * UTF‑8 截断策略改为回退重试解码，失败则返回空字符串。
  * XMind 导出在归档内补写 metadata.json 与 manifest.json。
* **测试**
  * 新增多项单元测试覆盖字体注册、缓存、回退及导出渲染断言。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->