### PR TITLE
fix(providers): 给 qwen3.6-plus-2026-04-02 补 extra_body 映射

### DIFF
--- a/config/providers.py
+++ b/config/providers.py
@@ -39,6 +39,7 @@ MODELS_EXTRA_BODY_MAP: dict[str, dict] = {
     "qwen3-vl-flash": EXTRA_BODY_OPENAI,
     "qwen3.5-plus": EXTRA_BODY_OPENAI,
     "qwen3.6-plus": EXTRA_BODY_OPENAI,
+    "qwen3.6-plus-2026-04-02": EXTRA_BODY_OPENAI,
     "qwen-plus": EXTRA_BODY_OPENAI,
     # GLM 系列
     "glm-4.5-air": EXTRA_BODY_CLAUDE,


### PR DESCRIPTION
## Summary
- `providers.py` 的 `MODELS_EXTRA_BODY_MAP` 之前只给 `qwen3.6-plus` 加了 `EXTRA_BODY_OPENAI`，漏了带日期版本的别名 `qwen3.6-plus-2026-04-02`，导致用该别名时不会自动关 thinking。
- 补上对应映射。

## Test plan
- [ ] 用 `qwen3.6-plus-2026-04-02` 走 agent 调用，确认 extra_body 带上 `{"enable_thinking": False}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增了对特定 AI 模型的配置支持，完善了模型参数映射机制，确保该模型版本能够获得对应的完整服务配置和正确的参数设置。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->