### PR TITLE
feat: Phase 6 学习习惯系统（打卡 + 番茄钟 + 监督）

### DIFF
--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -877,8 +877,9 @@ class StudyCompanionPlugin(NekoPluginBase):
     async def study_pomodoro_status(self, **_):
         try:
             _, _, timer, supervision = self._require_habit_components()
-            before_state = str(timer.status().get("state") or "")
-            status = timer.tick()
+            before_status = await asyncio.to_thread(timer.status)
+            before_state = str(before_status.get("state") or "")
+            status = await asyncio.to_thread(timer.tick)
             after_state = str(status.get("state") or "")
             if before_state == "focusing" and after_state in {
                 "short_break",

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -123,6 +123,7 @@ class StudyCompanionPlugin(NekoPluginBase):
                 self._habit_store,
                 config=self._cfg.pomodoro,
                 auto_derive_from_session=self._cfg.checkin.auto_derive_from_session,
+                checkin_timezone=self._cfg.checkin.streak_timezone,
             )
             self._supervision = SupervisionController(self._cfg.supervision)
             restored = await asyncio.to_thread(
@@ -909,14 +910,26 @@ class StudyCompanionPlugin(NekoPluginBase):
     ):
         try:
             habits, _, timer, supervision = self._require_habit_components()
-            status = timer.start(goal_id=goal_id, focus_minutes=focus_minutes)
-            goal = habits.get_goal(str(goal_id or "")) if goal_id else {}
-            supervision.on_focus_start(
-                goal=goal or {},
-                planned_minutes=float(
-                    status.get("config", {}).get("focus_minutes") or focus_minutes or 0
-                ),
+            before_status = timer.status()
+            before_session_id = str(
+                before_status.get("current_focus_session", {}).get("id") or ""
             )
+            status = timer.start(goal_id=goal_id, focus_minutes=focus_minutes)
+            after_session_id = str(
+                status.get("current_focus_session", {}).get("id") or ""
+            )
+            if (
+                str(status.get("state") or "") == "focusing"
+                and after_session_id
+                and after_session_id != before_session_id
+            ):
+                goal = habits.get_goal(str(goal_id or "")) if goal_id else {}
+                supervision.on_focus_start(
+                    goal=goal or {},
+                    planned_minutes=float(
+                        status.get("config", {}).get("focus_minutes") or focus_minutes or 0
+                    ),
+                )
             return Ok(build_pomodoro_status_payload(status))
         except Exception as exc:
             return Err(SdkError(str(exc)))

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -910,11 +910,13 @@ class StudyCompanionPlugin(NekoPluginBase):
     ):
         try:
             habits, _, timer, supervision = self._require_habit_components()
-            before_status = timer.status()
+            before_status = await asyncio.to_thread(timer.status)
             before_session_id = str(
                 before_status.get("current_focus_session", {}).get("id") or ""
             )
-            status = timer.start(goal_id=goal_id, focus_minutes=focus_minutes)
+            status = await asyncio.to_thread(
+                timer.start, goal_id=goal_id, focus_minutes=focus_minutes
+            )
             after_session_id = str(
                 status.get("current_focus_session", {}).get("id") or ""
             )
@@ -923,7 +925,11 @@ class StudyCompanionPlugin(NekoPluginBase):
                 and after_session_id
                 and after_session_id != before_session_id
             ):
-                goal = habits.get_goal(str(goal_id or "")) if goal_id else {}
+                goal = (
+                    await asyncio.to_thread(habits.get_goal, str(goal_id or ""))
+                    if goal_id
+                    else {}
+                )
                 supervision.on_focus_start(
                     goal=goal or {},
                     planned_minutes=float(

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -882,13 +882,19 @@ class StudyCompanionPlugin(NekoPluginBase):
             before_state = str(before_status.get("state") or "")
             status = await asyncio.to_thread(timer.tick)
             after_state = str(status.get("state") or "")
+            reminder: dict[str, Any] = {}
             if before_state == "focusing" and after_state in {
                 "short_break",
                 "long_break",
                 "completed",
             }:
                 supervision.on_focus_end()
-            return Ok(build_pomodoro_status_payload(status))
+            elif after_state == "focusing":
+                reminder = supervision.due_reminder()
+            payload = build_pomodoro_status_payload(status)
+            if reminder:
+                payload["supervision_reminder"] = reminder
+            return Ok(payload)
         except Exception as exc:
             return Err(SdkError(str(exc)))
 
@@ -1450,6 +1456,12 @@ class StudyCompanionPlugin(NekoPluginBase):
             return Err(SdkError("study OCR pipeline is not initialized"))
         snapshot = await asyncio.to_thread(self._ocr_pipeline.capture_snapshot)
         payload = build_ocr_payload(snapshot)
+        if self._supervision is not None:
+            sensor_available = snapshot.status in {"ok", "empty"}
+            payload["supervision"] = self._supervision.observe_activity(
+                ocr_text=snapshot.text,
+                sensor_available=sensor_available,
+            )
         if snapshot.text.strip():
             with self._lock:
                 self._state.last_ocr_text = snapshot.text

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import threading
 import time
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from plugin.sdk.plugin import (
     Err,
@@ -294,21 +295,7 @@ class StudyCompanionPlugin(NekoPluginBase):
         history = self._store.list_interactions(limit=10)
         is_first_run = not bool(self._store.list_interactions(limit=1))
         today = self._today()
-        habit_payload: dict[str, Any] = {}
-        if (
-            self._habit_store is not None
-            and self._checkin_manager is not None
-            and self._pomodoro_timer is not None
-        ):
-            habit_payload = build_habit_dashboard_payload(
-                goals=self._habit_store.list_goals(date=today),
-                checkin=self._checkin_manager.checkin_status(date=today, today=today),
-                pomodoro=self._pomodoro_timer.status(),
-                summary=self._checkin_manager.daily_summary(date=today),
-                supervision=self._supervision.status()
-                if self._supervision is not None
-                else {},
-            )
+        habit_payload = self._habit_status_payload(today)
         knowledge = {
             "knowledge_summary": self._knowledge_tracker.get_status_summary(limit=8),
             "knowledge_quality_summary": self._knowledge_tracker.quality.status_summary(
@@ -327,9 +314,40 @@ class StudyCompanionPlugin(NekoPluginBase):
             is_first_run=is_first_run,
         )
 
-    @staticmethod
-    def _today() -> str:
-        return datetime.now().date().isoformat()
+    def _habit_status_payload(self, today: str) -> dict[str, Any]:
+        if (
+            self._habit_store is None
+            or self._checkin_manager is None
+            or self._pomodoro_timer is None
+        ):
+            return {
+                "available": False,
+                "error": "study habit system is not initialized",
+            }
+        try:
+            payload = build_habit_dashboard_payload(
+                goals=self._habit_store.list_goals(date=today),
+                checkin=self._checkin_manager.checkin_status(date=today, today=today),
+                pomodoro=self._pomodoro_timer.status(),
+                summary=self._checkin_manager.daily_summary(date=today),
+                supervision=self._supervision.status()
+                if self._supervision is not None
+                else {},
+            )
+            payload["available"] = True
+            return payload
+        except Exception as exc:
+            self.logger.warning("study habit status payload degraded: {}", exc)
+            return {"available": False, "error": str(exc)}
+
+    def _today(self) -> str:
+        timezone_name = str(self._cfg.checkin.streak_timezone or "local").strip()
+        if timezone_name and timezone_name.lower() != "local":
+            try:
+                return datetime.now(ZoneInfo(timezone_name)).date().isoformat()
+            except ZoneInfoNotFoundError:
+                self.logger.warning("invalid study checkin timezone: {}", timezone_name)
+        return datetime.now().astimezone().date().isoformat()
 
     def _sync_doc_export_entry(self) -> None:
         self.unregister_dynamic_entry("study_export_notes")
@@ -1067,8 +1085,8 @@ class StudyCompanionPlugin(NekoPluginBase):
     async def study_goal_delete(self, goal_id: str, **_):
         try:
             _, manager, _, _ = self._require_habit_components()
-            await asyncio.to_thread(manager.delete_goal, goal_id)
-            return Ok({"deleted": True, "goal_id": goal_id})
+            deleted = await asyncio.to_thread(manager.delete_goal, goal_id)
+            return Ok({"deleted": bool(deleted), "goal_id": goal_id})
         except Exception as exc:
             return Err(SdkError(str(exc)))
 

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -120,7 +120,9 @@ class StudyCompanionPlugin(NekoPluginBase):
                 makeup_window_days=self._cfg.checkin.makeup_window_days,
             )
             self._pomodoro_timer = PomodoroTimer(
-                self._habit_store, config=self._cfg.pomodoro
+                self._habit_store,
+                config=self._cfg.pomodoro,
+                auto_derive_from_session=self._cfg.checkin.auto_derive_from_session,
             )
             self._supervision = SupervisionController(self._cfg.supervision)
             restored = await asyncio.to_thread(
@@ -629,7 +631,7 @@ class StudyCompanionPlugin(NekoPluginBase):
         metadata: dict[str, Any],
         extra_context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        self._record_tutor_result(operation, reply)
+        self._record_tutor_result(operation, reply, extra=extra_context)
         diagnostic = str(reply.diagnostic or "")
         if diagnostic and reply.degraded:
             with self._lock:
@@ -874,8 +876,17 @@ class StudyCompanionPlugin(NekoPluginBase):
     )
     async def study_pomodoro_status(self, **_):
         try:
-            _, _, timer, _ = self._require_habit_components()
-            return Ok(build_pomodoro_status_payload(timer.tick()))
+            _, _, timer, supervision = self._require_habit_components()
+            before_state = str(timer.status().get("state") or "")
+            status = timer.tick()
+            after_state = str(status.get("state") or "")
+            if before_state == "focusing" and after_state in {
+                "short_break",
+                "long_break",
+                "completed",
+            }:
+                supervision.on_focus_end()
+            return Ok(build_pomodoro_status_payload(status))
         except Exception as exc:
             return Err(SdkError(str(exc)))
 
@@ -1104,7 +1115,13 @@ class StudyCompanionPlugin(NekoPluginBase):
         try:
             _, manager, _, _ = self._require_habit_components()
             target_date = str(date or self._today())[:10]
-            return Ok(manager.checkin_status(date=target_date, today=self._today()))
+            return Ok(
+                await asyncio.to_thread(
+                    manager.checkin_status,
+                    date=target_date,
+                    today=self._today(),
+                )
+            )
         except Exception as exc:
             return Err(SdkError(str(exc)))
 
@@ -1151,7 +1168,12 @@ class StudyCompanionPlugin(NekoPluginBase):
     async def study_session_summary(self, date: str = "", **_):
         try:
             _, manager, _, _ = self._require_habit_components()
-            return Ok(manager.daily_summary(date=str(date or self._today())[:10]))
+            return Ok(
+                await asyncio.to_thread(
+                    manager.daily_summary,
+                    date=str(date or self._today())[:10],
+                )
+            )
         except Exception as exc:
             return Err(SdkError(str(exc)))
 
@@ -1183,6 +1205,8 @@ class StudyCompanionPlugin(NekoPluginBase):
     async def study_supervision_toggle(self, enabled: bool, **_):
         try:
             _, _, _, supervision = self._require_habit_components()
+            if not bool(enabled) and not self._cfg.supervision.allow_disable_by_chat:
+                return Err(SdkError("study supervision disable is blocked by config"))
             return Ok(supervision.set_enabled(bool(enabled)))
         except Exception as exc:
             return Err(SdkError(str(exc)))

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from datetime import datetime
 from pathlib import Path
 import threading
 import time
 from typing import Any
 
-from plugin.sdk.plugin import Err, NekoPluginBase, Ok, SdkError, lifecycle, neko_plugin, plugin_entry, tr
+from plugin.sdk.plugin import (
+    Err,
+    NekoPluginBase,
+    Ok,
+    SdkError,
+    lifecycle,
+    neko_plugin,
+    plugin_entry,
+    tr,
+)
 
 from .constants import (
     LLM_OPERATION_ANSWER_EVALUATE,
@@ -20,6 +30,8 @@ from .constants import (
     MODE_TEACHING,
 )
 from .doc_exporter import DocExporter, normalize_format
+from .checkin_manager import CheckinManager
+from .pomodoro_timer import PomodoroTimer
 from .screen_classifier import classify_screen_from_ocr
 from .models import (
     MODE_CONCEPT_EXPLAIN,
@@ -39,16 +51,24 @@ from .service import (
     build_status_payload,
     build_tutor_payload,
 )
-from .mode_manager import ModeManager, build_transition_phrase, handle_user_intent, normalize_mode
+from .mode_manager import (
+    ModeManager,
+    build_transition_phrase,
+    handle_user_intent,
+    normalize_mode,
+)
 from .knowledge_contribution import PublicGraphContributionBuilder
 from .knowledge_tracker import KnowledgeTracker
 from .state import build_initial_state
 from .store import StudyStore
+from .study_habit_store import StudyHabitStore
 from .study_ocr_pipeline import StudyOcrPipeline
+from .supervision import SupervisionController
 from .tutor_llm_agent import TutorLLMAgent
 from .tutor_llm_agent import diagnostic_code_for_exception
 from .ui_api import build_open_ui_payload
 from .ui_api import build_contribution_settings_payload, build_knowledge_map_payload
+from .ui_api import build_habit_dashboard_payload, build_pomodoro_status_payload
 
 
 @neko_plugin
@@ -76,6 +96,10 @@ class StudyCompanionPlugin(NekoPluginBase):
             retention_target=self._cfg.fsrs_retention_target,
             logger=self.logger,
         )
+        self._habit_store: StudyHabitStore | None = None
+        self._checkin_manager: CheckinManager | None = None
+        self._pomodoro_timer: PomodoroTimer | None = None
+        self._supervision: SupervisionController | None = None
 
     @lifecycle(id="startup")
     async def startup(self, **_):
@@ -89,11 +113,24 @@ class StudyCompanionPlugin(NekoPluginBase):
                 retention_target=self._cfg.fsrs_retention_target,
                 logger=self.logger,
             )
-            restored = await asyncio.to_thread(self._store.load_state, build_initial_state(mode=self._cfg.mode))
+            self._habit_store = StudyHabitStore(self._store)
+            self._checkin_manager = CheckinManager(
+                self._habit_store,
+                makeup_window_days=self._cfg.checkin.makeup_window_days,
+            )
+            self._pomodoro_timer = PomodoroTimer(
+                self._habit_store, config=self._cfg.pomodoro
+            )
+            self._supervision = SupervisionController(self._cfg.supervision)
+            restored = await asyncio.to_thread(
+                self._store.load_state, build_initial_state(mode=self._cfg.mode)
+            )
             with self._lock:
                 self._state = restored
                 self._state.status = STATUS_READY
-                self._state.active_mode = normalize_mode(self._state.active_mode or self._cfg.mode)
+                self._state.active_mode = normalize_mode(
+                    self._state.active_mode or self._cfg.mode
+                )
                 self._state.mode_started_at = float(self._state.mode_started_at or 0.0)
                 self._state.mode_lock_until = float(self._state.mode_lock_until or 0.0)
                 self._cfg.mode = self._state.active_mode
@@ -108,7 +145,7 @@ class StudyCompanionPlugin(NekoPluginBase):
                         "session_suggestions": self._state.session_suggestions,
                         "mode_lock_until": self._state.mode_lock_until,
                     }
-            )
+                )
             self._ocr_pipeline = StudyOcrPipeline(logger=self.logger, config=self._cfg)
             self._agent = TutorLLMAgent(logger=self.logger, config=self._cfg)
             await asyncio.to_thread(self._refresh_dependency_status)
@@ -157,7 +194,9 @@ class StudyCompanionPlugin(NekoPluginBase):
             try:
                 await agent.shutdown()
             except Exception as exc:
-                self.logger.warning("study startup cleanup agent shutdown failed: {}", exc)
+                self.logger.warning(
+                    "study startup cleanup agent shutdown failed: {}", exc
+                )
         try:
             await asyncio.to_thread(self._store.close)
         except Exception as exc:
@@ -187,7 +226,9 @@ class StudyCompanionPlugin(NekoPluginBase):
         await asyncio.to_thread(self._store.save_config, self._cfg)
         await asyncio.to_thread(self._store.save_state, self._state)
 
-    async def _apply_mode_switch(self, mode: str, reason: str, *, language: str | None = None) -> dict[str, Any]:
+    async def _apply_mode_switch(
+        self, mode: str, reason: str, *, language: str | None = None
+    ) -> dict[str, Any]:
         with self._lock:
             self._mode_manager.restore(
                 {
@@ -199,14 +240,38 @@ class StudyCompanionPlugin(NekoPluginBase):
                     "mode_lock_until": self._state.mode_lock_until,
                 }
             )
-            result = self._mode_manager.switch_to(mode, reason, language=language or self._cfg.language)
-            checkpoint = result.get("checkpoint") if isinstance(result.get("checkpoint"), dict) else {}
-            self._state.active_mode = str(result.get("new_mode") or self._state.active_mode)
-            self._state.mode_started_at = float(checkpoint.get("mode_started_at") or self._state.mode_started_at or 0.0)
-            self._state.recent_mode_switches = checkpoint.get("recent_mode_switches") if isinstance(checkpoint.get("recent_mode_switches"), list) else self._state.recent_mode_switches
-            self._state.suggestion_cooldowns = checkpoint.get("suggestion_cooldowns") if isinstance(checkpoint.get("suggestion_cooldowns"), dict) else self._state.suggestion_cooldowns
-            self._state.session_suggestions = checkpoint.get("session_suggestions") if isinstance(checkpoint.get("session_suggestions"), list) else self._state.session_suggestions
-            self._state.mode_lock_until = float(checkpoint.get("mode_lock_until") or self._state.mode_lock_until or 0.0)
+            result = self._mode_manager.switch_to(
+                mode, reason, language=language or self._cfg.language
+            )
+            checkpoint = (
+                result.get("checkpoint")
+                if isinstance(result.get("checkpoint"), dict)
+                else {}
+            )
+            self._state.active_mode = str(
+                result.get("new_mode") or self._state.active_mode
+            )
+            self._state.mode_started_at = float(
+                checkpoint.get("mode_started_at") or self._state.mode_started_at or 0.0
+            )
+            self._state.recent_mode_switches = (
+                checkpoint.get("recent_mode_switches")
+                if isinstance(checkpoint.get("recent_mode_switches"), list)
+                else self._state.recent_mode_switches
+            )
+            self._state.suggestion_cooldowns = (
+                checkpoint.get("suggestion_cooldowns")
+                if isinstance(checkpoint.get("suggestion_cooldowns"), dict)
+                else self._state.suggestion_cooldowns
+            )
+            self._state.session_suggestions = (
+                checkpoint.get("session_suggestions")
+                if isinstance(checkpoint.get("session_suggestions"), list)
+                else self._state.session_suggestions
+            )
+            self._state.mode_lock_until = float(
+                checkpoint.get("mode_lock_until") or self._state.mode_lock_until or 0.0
+            )
             self._state.checkpoint = {
                 **checkpoint,
                 "changed": bool(result.get("changed")),
@@ -228,9 +293,27 @@ class StudyCompanionPlugin(NekoPluginBase):
     def _status_payload(self) -> dict[str, Any]:
         history = self._store.list_interactions(limit=10)
         is_first_run = not bool(self._store.list_interactions(limit=1))
+        today = self._today()
+        habit_payload: dict[str, Any] = {}
+        if (
+            self._habit_store is not None
+            and self._checkin_manager is not None
+            and self._pomodoro_timer is not None
+        ):
+            habit_payload = build_habit_dashboard_payload(
+                goals=self._habit_store.list_goals(date=today),
+                checkin=self._checkin_manager.checkin_status(date=today, today=today),
+                pomodoro=self._pomodoro_timer.status(),
+                summary=self._checkin_manager.daily_summary(date=today),
+                supervision=self._supervision.status()
+                if self._supervision is not None
+                else {},
+            )
         knowledge = {
             "knowledge_summary": self._knowledge_tracker.get_status_summary(limit=8),
-            "knowledge_quality_summary": self._knowledge_tracker.quality.status_summary(limit=8),
+            "knowledge_quality_summary": self._knowledge_tracker.quality.status_summary(
+                limit=8
+            ),
             "anonymous_knowledge_stats_summary": self._store.anonymous_knowledge_stats_summary(),
             "review_queue": self._knowledge_tracker.get_review_queue(limit=8),
             "weak_topics": self._knowledge_tracker.get_weak_topics(limit=8),
@@ -240,9 +323,13 @@ class StudyCompanionPlugin(NekoPluginBase):
             config=self._cfg,
             state=self._state,
             history=history,
-            knowledge=knowledge,
+            knowledge={**knowledge, "habit": habit_payload},
             is_first_run=is_first_run,
         )
+
+    @staticmethod
+    def _today() -> str:
+        return datetime.now().date().isoformat()
 
     def _sync_doc_export_entry(self) -> None:
         self.unregister_dynamic_entry("study_export_notes")
@@ -262,7 +349,11 @@ class StudyCompanionPlugin(NekoPluginBase):
             input_schema={
                 "type": "object",
                 "properties": {
-                    "fmt": {"type": "string", "enum": export_formats, "default": "markdown"},
+                    "fmt": {
+                        "type": "string",
+                        "enum": export_formats,
+                        "default": "markdown",
+                    },
                     "style": {
                         "type": "string",
                         "enum": ["neko", "academic", "compact"],
@@ -272,11 +363,21 @@ class StudyCompanionPlugin(NekoPluginBase):
                     "preview_only": {"type": "boolean", "default": False},
                     "time_range": {"type": "string", "default": "recent"},
                     "recent_limit": {"type": "integer", "default": 30},
-                    "topic_ids": {"type": "array", "items": {"type": "string"}, "default": []},
+                    "topic_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "default": [],
+                    },
                 },
             },
             timeout=75.0,
-            llm_result_fields=["filename", "content_type", "format", "style", "markdown"],
+            llm_result_fields=[
+                "filename",
+                "content_type",
+                "format",
+                "style",
+                "markdown",
+            ],
         )
 
     async def _study_export_notes_entry(
@@ -292,7 +393,9 @@ class StudyCompanionPlugin(NekoPluginBase):
     ):
         try:
             if not bool(self._cfg.doc_export.enabled):
-                return Err(SdkError("study note export is disabled by doc_export.enabled"))
+                return Err(
+                    SdkError("study note export is disabled by doc_export.enabled")
+                )
             normalize_format(fmt)
             exporter = DocExporter(self._store, config=self._cfg.doc_export)
             exported = await asyncio.to_thread(
@@ -334,7 +437,9 @@ class StudyCompanionPlugin(NekoPluginBase):
         current["event_count"] = int(current.get("event_count") or 0) + 1
         current["last_operation"] = operation
         current["last_updated_at"] = utc_now_iso()
-        screen_type = str(payload.get("screen_type") or current.get("last_screen_type") or "").strip()
+        screen_type = str(
+            payload.get("screen_type") or current.get("last_screen_type") or ""
+        ).strip()
         if screen_type:
             current["last_screen_type"] = screen_type
         if operation == LLM_OPERATION_QUESTION_GENERATE:
@@ -346,7 +451,9 @@ class StudyCompanionPlugin(NekoPluginBase):
                 verdict_counts = dict(current.get("verdict_counts") or {})
                 verdict_counts[verdict] = int(verdict_counts.get(verdict) or 0) + 1
                 current["verdict_counts"] = verdict_counts
-            weak_points = [item for item in payload.get("weak_points") or [] if str(item).strip()]
+            weak_points = [
+                item for item in payload.get("weak_points") or [] if str(item).strip()
+            ]
             if weak_points:
                 current["weak_points"] = weak_points[:6]
         elif operation == LLM_OPERATION_CONCEPT_EXPLAIN:
@@ -358,7 +465,9 @@ class StudyCompanionPlugin(NekoPluginBase):
         topic = str(payload.get("topic") or "").strip()
         if topic:
             current["last_topic"] = topic
-        weak_points = [item for item in payload.get("weak_points") or [] if str(item).strip()]
+        weak_points = [
+            item for item in payload.get("weak_points") or [] if str(item).strip()
+        ]
         if weak_points:
             current["weak_points"] = weak_points[:6]
         return current
@@ -367,14 +476,18 @@ class StudyCompanionPlugin(NekoPluginBase):
         with self._lock:
             return dict(self._state.last_screen_classification)
 
-    def _update_screen_classification(self, text: str, *, window_title: str = "", update_empty: bool = True) -> dict[str, Any]:
+    def _update_screen_classification(
+        self, text: str, *, window_title: str = "", update_empty: bool = True
+    ) -> dict[str, Any]:
         normalized = str(text or "").strip()
         if not normalized and not update_empty:
             with self._lock:
                 return dict(self._state.last_screen_classification)
         with self._lock:
             recent = list(self._state.recent_screen_classifications)
-        classification = classify_screen_from_ocr(normalized, window_title=window_title, recent_classifications=recent)
+        classification = classify_screen_from_ocr(
+            normalized, window_title=window_title, recent_classifications=recent
+        )
         payload = classification.to_payload()
         with self._lock:
             if normalized or update_empty:
@@ -405,11 +518,16 @@ class StudyCompanionPlugin(NekoPluginBase):
             "language": self._cfg.language,
             "mode": snapshot.get("active_mode") or self._cfg.mode,
             "screen_classification": snapshot.get("last_screen_classification") or {},
-            "recent_screen_classifications": snapshot.get("recent_screen_classifications") or [],
+            "recent_screen_classifications": snapshot.get(
+                "recent_screen_classifications"
+            )
+            or [],
             "current_question": snapshot.get("current_question") or {},
             "last_answer_evaluation": snapshot.get("last_answer_evaluation") or {},
             "session_summary_seed": snapshot.get("session_summary_seed") or {},
-            "recent_learning_events": (snapshot.get("recent_learning_events") or [])[-8:],
+            "recent_learning_events": (snapshot.get("recent_learning_events") or [])[
+                -8:
+            ],
             "last_ocr_text": snapshot.get("last_ocr_text") or "",
             "last_ocr_at": snapshot.get("last_ocr_at") or "",
             "history": history,
@@ -435,7 +553,9 @@ class StudyCompanionPlugin(NekoPluginBase):
             context.update(extra)
         return context
 
-    def _record_tutor_result(self, operation: str, reply: TutorReply, *, extra: dict[str, Any] | None = None) -> None:
+    def _record_tutor_result(
+        self, operation: str, reply: TutorReply, *, extra: dict[str, Any] | None = None
+    ) -> None:
         payload = dict(reply.payload or {})
         summary = str(reply.reply or "").strip()
         event = {
@@ -447,12 +567,21 @@ class StudyCompanionPlugin(NekoPluginBase):
             "diagnostic": reply.diagnostic,
             "at": time.time(),
             "created_at": reply.created_at or utc_now_iso(),
-            "screen_type": str(payload.get("screen_type") or (extra or {}).get("screen_type") or self._screen_classification_context().get("screen_type") or ""),
+            "screen_type": str(
+                payload.get("screen_type")
+                or (extra or {}).get("screen_type")
+                or self._screen_classification_context().get("screen_type")
+                or ""
+            ),
         }
         with self._lock:
-            seed = self._merge_session_summary_seed(operation, payload=payload, seed=self._state.session_summary_seed)
+            seed = self._merge_session_summary_seed(
+                operation, payload=payload, seed=self._state.session_summary_seed
+            )
             self._state.session_summary_seed = seed
-            self._state.recent_learning_events = (self._state.recent_learning_events + [event])[-16:]
+            self._state.recent_learning_events = (
+                self._state.recent_learning_events + [event]
+            )[-16:]
             if operation != LLM_OPERATION_KNOWLEDGE_TRACK:
                 self._state.last_reply = summary
                 self._state.last_reply_at = reply.created_at or utc_now_iso()
@@ -462,10 +591,16 @@ class StudyCompanionPlugin(NekoPluginBase):
                         self._state.last_question_at = reply.created_at or utc_now_iso()
                 elif operation == LLM_OPERATION_ANSWER_EVALUATE:
                     self._state.last_answer_evaluation = dict(payload)
-                    self._state.last_answer_evaluated_at = reply.created_at or utc_now_iso()
+                    self._state.last_answer_evaluated_at = (
+                        reply.created_at or utc_now_iso()
+                    )
                 elif operation == LLM_OPERATION_SUMMARIZE_SESSION:
-                    self._state.last_session_summary = str(payload.get("summary") or "").strip()
-                    self._state.last_session_summary_at = reply.created_at or utc_now_iso()
+                    self._state.last_session_summary = str(
+                        payload.get("summary") or ""
+                    ).strip()
+                    self._state.last_session_summary_at = (
+                        reply.created_at or utc_now_iso()
+                    )
 
     async def _finalize_tutor_call(
         self,
@@ -516,7 +651,9 @@ class StudyCompanionPlugin(NekoPluginBase):
                     **(extra_context or {}),
                 },
             )
-            track_reply = await self._agent.knowledge_track(mode=self._state.active_mode, context=track_context)
+            track_reply = await self._agent.knowledge_track(
+                mode=self._state.active_mode, context=track_context
+            )
         except Exception as exc:
             self.logger.warning("study knowledge track failed: {}", exc)
             track_reply = TutorReply(
@@ -529,7 +666,10 @@ class StudyCompanionPlugin(NekoPluginBase):
                     "confidence": 0.35,
                     "weak_points": [],
                     "next_steps": [],
-                    "screen_type": self._screen_classification_context().get("screen_type") or "",
+                    "screen_type": self._screen_classification_context().get(
+                        "screen_type"
+                    )
+                    or "",
                 },
                 degraded=True,
                 diagnostic=diagnostic_code_for_exception(exc),
@@ -537,7 +677,9 @@ class StudyCompanionPlugin(NekoPluginBase):
             )
         self._record_tutor_result(LLM_OPERATION_KNOWLEDGE_TRACK, track_reply)
         if operation == LLM_OPERATION_ANSWER_EVALUATE:
-            await self._record_answer_knowledge(reply, track_reply, extra_context=extra_context)
+            await self._record_answer_knowledge(
+                reply, track_reply, extra_context=extra_context
+            )
 
     async def _record_answer_knowledge(
         self,
@@ -551,9 +693,19 @@ class StudyCompanionPlugin(NekoPluginBase):
         eval_payload = dict(eval_reply.payload or {})
         current_question = dict(context.get("current_question") or {})
         question_payload = dict(context.get("question_payload") or current_question)
-        question_text = str(context.get("question") or question_payload.get("question") or current_question.get("question") or "").strip()
+        question_text = str(
+            context.get("question")
+            or question_payload.get("question")
+            or current_question.get("question")
+            or ""
+        ).strip()
         question_payload["question"] = question_text
-        question_payload["answer"] = str(context.get("expected_answer") or question_payload.get("answer") or current_question.get("answer") or "")
+        question_payload["answer"] = str(
+            context.get("expected_answer")
+            or question_payload.get("answer")
+            or current_question.get("answer")
+            or ""
+        )
         topic = str(
             question_payload.get("topic")
             or track_payload.get("topic")
@@ -567,13 +719,16 @@ class StudyCompanionPlugin(NekoPluginBase):
             "topic": topic,
             "track": track_payload,
         }
-        session_id = str(
-            context.get("session_id")
-            or context.get("run_id")
-            or getattr(self._state, "run_id", "")
-            or getattr(self.ctx, "run_id", "")
+        session_id = (
+            str(
+                context.get("session_id")
+                or context.get("run_id")
+                or getattr(self._state, "run_id", "")
+                or getattr(self.ctx, "run_id", "")
+                or "default"
+            ).strip()
             or "default"
-        ).strip() or "default"
+        )
         try:
             await asyncio.to_thread(
                 self._knowledge_tracker.on_answer,
@@ -594,7 +749,9 @@ class StudyCompanionPlugin(NekoPluginBase):
         if topic:
             return topic
         text = str(reply.input_text or "").strip()
-        first_line = next((line.strip() for line in text.splitlines() if line.strip()), "")
+        first_line = next(
+            (line.strip() for line in text.splitlines() if line.strip()), ""
+        )
         return first_line[:48] or "general"
 
     def _resolve_current_run_id(self, extra_args: dict[str, Any] | None = None) -> str:
@@ -638,46 +795,425 @@ class StudyCompanionPlugin(NekoPluginBase):
     @plugin_entry(
         id="study_open_ui",
         name=tr("entries.open_ui.name", default="Open Study Companion UI"),
-        description=tr("entries.open_ui.description", default="Return the static UI path for study_companion."),
+        description=tr(
+            "entries.open_ui.description",
+            default="Return the static UI path for study_companion.",
+        ),
         input_schema={"type": "object", "properties": {}},
         llm_result_fields=["available", "path", "message_key"],
     )
     async def study_open_ui(self, **_):
-        return Ok(build_open_ui_payload(plugin_id=self.plugin_id, available=self.get_static_ui_config() is not None))
+        return Ok(
+            build_open_ui_payload(
+                plugin_id=self.plugin_id,
+                available=self.get_static_ui_config() is not None,
+            )
+        )
 
     @plugin_entry(
         id="study_status",
         name=tr("entries.status.name", default="Study Companion Status"),
-        description=tr("entries.status.description", default="Return runtime status, dependencies, and recent study interactions."),
+        description=tr(
+            "entries.status.description",
+            default="Return runtime status, dependencies, and recent study interactions.",
+        ),
         input_schema={"type": "object", "properties": {}},
-        llm_result_fields=["status", "active_mode", "screen_classification", "current_question", "last_answer_evaluation"],
+        llm_result_fields=[
+            "status",
+            "active_mode",
+            "screen_classification",
+            "current_question",
+            "last_answer_evaluation",
+        ],
     )
     async def study_status(self, **_):
         payload = await asyncio.to_thread(self._status_payload)
         return Ok(payload)
 
+    def _require_habit_components(
+        self,
+    ) -> tuple[StudyHabitStore, CheckinManager, PomodoroTimer, SupervisionController]:
+        if (
+            self._habit_store is None
+            or self._checkin_manager is None
+            or self._pomodoro_timer is None
+            or self._supervision is None
+        ):
+            raise RuntimeError("study habit system is not initialized")
+        return (
+            self._habit_store,
+            self._checkin_manager,
+            self._pomodoro_timer,
+            self._supervision,
+        )
+
+    @plugin_entry(
+        id="study_pomodoro_status",
+        name="Study Pomodoro Status",
+        description="Return the current Study Companion pomodoro timer status.",
+        input_schema={"type": "object", "properties": {}},
+        llm_result_fields=["state", "mode", "remaining_seconds", "session_count"],
+    )
+    async def study_pomodoro_status(self, **_):
+        try:
+            _, _, timer, _ = self._require_habit_components()
+            return Ok(build_pomodoro_status_payload(timer.tick()))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_pomodoro_start",
+        name="Start Study Pomodoro",
+        description="Start a focus pomodoro for an optional daily goal.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "focus_minutes": {"type": "integer"},
+                "goal_id": {"type": "string", "default": ""},
+            },
+        },
+        llm_result_fields=["state", "remaining_seconds", "goal_id"],
+    )
+    async def study_pomodoro_start(
+        self, focus_minutes: int | None = None, goal_id: str = "", **_
+    ):
+        try:
+            habits, _, timer, supervision = self._require_habit_components()
+            status = timer.start(goal_id=goal_id, focus_minutes=focus_minutes)
+            goal = habits.get_goal(str(goal_id or "")) if goal_id else {}
+            supervision.on_focus_start(
+                goal=goal or {},
+                planned_minutes=float(
+                    status.get("config", {}).get("focus_minutes") or focus_minutes or 0
+                ),
+            )
+            return Ok(build_pomodoro_status_payload(status))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_pomodoro_pause",
+        name="Pause Study Pomodoro",
+        description="Pause the active focus pomodoro.",
+        input_schema={"type": "object", "properties": {}},
+        llm_result_fields=["state", "remaining_seconds"],
+    )
+    async def study_pomodoro_pause(self, **_):
+        try:
+            _, _, timer, _ = self._require_habit_components()
+            return Ok(build_pomodoro_status_payload(timer.pause()))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_pomodoro_resume",
+        name="Resume Study Pomodoro",
+        description="Resume a paused focus pomodoro.",
+        input_schema={"type": "object", "properties": {}},
+        llm_result_fields=["state", "remaining_seconds"],
+    )
+    async def study_pomodoro_resume(self, **_):
+        try:
+            _, _, timer, _ = self._require_habit_components()
+            return Ok(build_pomodoro_status_payload(timer.resume()))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_pomodoro_stop",
+        name="Stop Study Pomodoro",
+        description="Stop the active focus or break timer.",
+        input_schema={"type": "object", "properties": {}},
+        llm_result_fields=["state", "current_focus_session"],
+    )
+    async def study_pomodoro_stop(self, **_):
+        try:
+            _, _, timer, supervision = self._require_habit_components()
+            status = timer.stop()
+            supervision.on_focus_end()
+            return Ok(build_pomodoro_status_payload(status))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_pomodoro_skip_break",
+        name="Skip Study Pomodoro Break",
+        description="Skip the current short or long break when allowed.",
+        input_schema={"type": "object", "properties": {}},
+        llm_result_fields=["state", "remaining_seconds"],
+    )
+    async def study_pomodoro_skip_break(self, **_):
+        try:
+            _, _, timer, _ = self._require_habit_components()
+            return Ok(build_pomodoro_status_payload(timer.skip_break()))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_goals",
+        name="Study Daily Goals",
+        description="Return daily study habit goals for a date.",
+        input_schema={
+            "type": "object",
+            "properties": {"date": {"type": "string", "default": ""}},
+        },
+        llm_result_fields=["goals"],
+    )
+    async def study_goals(self, date: str = "", **_):
+        try:
+            habits, _, _, _ = self._require_habit_components()
+            target_date = str(date or self._today())[:10]
+            return Ok(
+                {
+                    "date": target_date,
+                    "goals": await asyncio.to_thread(
+                        habits.list_goals, date=target_date
+                    ),
+                }
+            )
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_goal_create",
+        name="Create Study Daily Goal",
+        description="Create a local daily study goal.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "date": {"type": "string", "default": ""},
+                "target_type": {"type": "string", "default": "custom"},
+                "target_id": {"type": "string", "default": ""},
+                "subject": {"type": "string", "default": ""},
+                "target_amount": {"type": "number", "default": 1},
+                "unit": {"type": "string", "default": "task"},
+            },
+        },
+        llm_result_fields=["goal"],
+    )
+    async def study_goal_create(
+        self,
+        date: str = "",
+        target_type: str = "custom",
+        target_id: str = "",
+        subject: str = "",
+        target_amount: float = 1,
+        unit: str = "task",
+        **_,
+    ):
+        try:
+            _, manager, _, _ = self._require_habit_components()
+            goal = await asyncio.to_thread(
+                manager.create_goal,
+                date=str(date or self._today())[:10],
+                target_type=target_type,
+                target_id=target_id,
+                subject=subject,
+                target_amount=target_amount,
+                unit=unit,
+            )
+            return Ok({"goal": goal})
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_goal_update",
+        name="Update Study Daily Goal",
+        description="Update a local daily study goal.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "goal_id": {"type": "string"},
+                "target_amount": {"type": "number"},
+                "progress_amount": {"type": "number"},
+                "status": {"type": "string"},
+            },
+            "required": ["goal_id"],
+        },
+        llm_result_fields=["goal"],
+    )
+    async def study_goal_update(
+        self,
+        goal_id: str,
+        target_amount: float | None = None,
+        progress_amount: float | None = None,
+        status: str | None = None,
+        **_,
+    ):
+        try:
+            _, manager, _, _ = self._require_habit_components()
+            goal = await asyncio.to_thread(
+                manager.update_goal,
+                goal_id,
+                target_amount=target_amount,
+                progress_amount=progress_amount,
+                status=status,
+            )
+            return Ok({"goal": goal})
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_goal_delete",
+        name="Delete Study Daily Goal",
+        description="Delete a local daily study goal and associated focus sessions.",
+        input_schema={
+            "type": "object",
+            "properties": {"goal_id": {"type": "string"}},
+            "required": ["goal_id"],
+        },
+        llm_result_fields=["deleted"],
+    )
+    async def study_goal_delete(self, goal_id: str, **_):
+        try:
+            _, manager, _, _ = self._require_habit_components()
+            await asyncio.to_thread(manager.delete_goal, goal_id)
+            return Ok({"deleted": True, "goal_id": goal_id})
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_checkin_status",
+        name="Study Check-In Status",
+        description="Return current check-in status and streak.",
+        input_schema={
+            "type": "object",
+            "properties": {"date": {"type": "string", "default": ""}},
+        },
+        llm_result_fields=["checked_in", "streak_days"],
+    )
+    async def study_checkin_status(self, date: str = "", **_):
+        try:
+            _, manager, _, _ = self._require_habit_components()
+            target_date = str(date or self._today())[:10]
+            return Ok(manager.checkin_status(date=target_date, today=self._today()))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_checkin_manual",
+        name="Manual Study Check-In",
+        description="Record a manual study check-in or makeup check-in.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "date": {"type": "string", "default": ""},
+                "note": {"type": "string", "default": ""},
+            },
+        },
+        llm_result_fields=["checkin"],
+    )
+    async def study_checkin_manual(self, date: str = "", note: str = "", **_):
+        try:
+            _, manager, _, _ = self._require_habit_components()
+            checkin = await asyncio.to_thread(
+                manager.manual_checkin,
+                date=str(date or self._today())[:10],
+                today=self._today(),
+                note=note,
+            )
+            return Ok({"checkin": checkin})
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_session_summary",
+        name="Study Habit Session Summary",
+        description="Return the daily habit summary for focus minutes and goal completion.",
+        input_schema={
+            "type": "object",
+            "properties": {"date": {"type": "string", "default": ""}},
+        },
+        llm_result_fields=[
+            "total_focus_minutes",
+            "completed_goal_count",
+            "incomplete_goal_count",
+        ],
+    )
+    async def study_session_summary(self, date: str = "", **_):
+        try:
+            _, manager, _, _ = self._require_habit_components()
+            return Ok(manager.daily_summary(date=str(date or self._today())[:10]))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_supervision_status",
+        name="Study Supervision Status",
+        description="Return focus supervision state and sensor availability.",
+        input_schema={"type": "object", "properties": {}},
+        llm_result_fields=["enabled", "sensor_available", "reminder_level"],
+    )
+    async def study_supervision_status(self, **_):
+        try:
+            _, _, _, supervision = self._require_habit_components()
+            return Ok(supervision.status())
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
+    @plugin_entry(
+        id="study_supervision_toggle",
+        name="Toggle Study Supervision",
+        description="Enable or disable low-frequency focus supervision reminders.",
+        input_schema={
+            "type": "object",
+            "properties": {"enabled": {"type": "boolean"}},
+            "required": ["enabled"],
+        },
+        llm_result_fields=["enabled", "reminder_level"],
+    )
+    async def study_supervision_toggle(self, enabled: bool, **_):
+        try:
+            _, _, _, supervision = self._require_habit_components()
+            return Ok(supervision.set_enabled(bool(enabled)))
+        except Exception as exc:
+            return Err(SdkError(str(exc)))
+
     @plugin_entry(
         id="study_knowledge_quality_status",
-        name=tr("entries.knowledge_quality_status.name", default="Study Knowledge Quality Status"),
-        description=tr("entries.knowledge_quality_status.description", default="Return candidate knowledge quality counts and recent evidence."),
-        input_schema={"type": "object", "properties": {"limit": {"type": "integer", "default": 20}}},
+        name=tr(
+            "entries.knowledge_quality_status.name",
+            default="Study Knowledge Quality Status",
+        ),
+        description=tr(
+            "entries.knowledge_quality_status.description",
+            default="Return candidate knowledge quality counts and recent evidence.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "default": 20}},
+        },
         llm_result_fields=["total", "by_status", "recent_evidence"],
     )
     async def study_knowledge_quality_status(self, limit: int = 20, **_):
-        payload = await asyncio.to_thread(self._knowledge_tracker.quality.status_summary, limit=max(1, int(limit or 20)))
+        payload = await asyncio.to_thread(
+            self._knowledge_tracker.quality.status_summary,
+            limit=max(1, int(limit or 20)),
+        )
         return Ok(payload)
 
     @plugin_entry(
         id="study_anonymous_knowledge_preview",
-        name=tr("entries.anonymous_knowledge_preview.name", default="Study Anonymous Knowledge Preview"),
-        description=tr("entries.anonymous_knowledge_preview.description", default="Build and return a local anonymized knowledge contribution preview. Phase 4 does not upload it."),
-        input_schema={"type": "object", "properties": {"limit": {"type": "integer", "default": 100}}},
+        name=tr(
+            "entries.anonymous_knowledge_preview.name",
+            default="Study Anonymous Knowledge Preview",
+        ),
+        description=tr(
+            "entries.anonymous_knowledge_preview.description",
+            default="Build and return a local anonymized knowledge contribution preview. Phase 4 does not upload it.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "default": 100}},
+        },
         llm_result_fields=["summary", "stats", "opt_in"],
     )
     async def study_anonymous_knowledge_preview(self, limit: int = 100, **_):
         try:
             builder = PublicGraphContributionBuilder(self._store, self._cfg)
-            payload = await asyncio.to_thread(builder.preview, limit=max(1, int(limit or 100)))
+            payload = await asyncio.to_thread(
+                builder.preview, limit=max(1, int(limit or 100))
+            )
             return Ok(payload)
         except Exception as exc:
             return Err(SdkError(str(exc)))
@@ -685,8 +1221,14 @@ class StudyCompanionPlugin(NekoPluginBase):
     @plugin_entry(
         id="study_knowledge_map",
         name=tr("entries.knowledge_map.name", default="Study Knowledge Map"),
-        description=tr("entries.knowledge_map.description", default="Return topics, relationships, mastery, weak topics, and wrong-question summaries for the study knowledge map."),
-        input_schema={"type": "object", "properties": {"limit": {"type": "integer", "default": 200}}},
+        description=tr(
+            "entries.knowledge_map.description",
+            default="Return topics, relationships, mastery, weak topics, and wrong-question summaries for the study knowledge map.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "default": 200}},
+        },
         llm_result_fields=["summary", "nodes", "edges"],
     )
     async def study_knowledge_map(self, limit: int = 200, **_):
@@ -695,8 +1237,12 @@ class StudyCompanionPlugin(NekoPluginBase):
             topics, mastery, weak_topics, wrong_questions = await asyncio.gather(
                 asyncio.to_thread(self._store.list_topics, safe_limit),
                 asyncio.to_thread(self._store.list_mastery_overview, safe_limit),
-                asyncio.to_thread(self._knowledge_tracker.get_weak_topics, limit=min(50, safe_limit)),
-                asyncio.to_thread(self._store.list_wrong_questions, limit=min(50, safe_limit)),
+                asyncio.to_thread(
+                    self._knowledge_tracker.get_weak_topics, limit=min(50, safe_limit)
+                ),
+                asyncio.to_thread(
+                    self._store.list_wrong_questions, limit=min(50, safe_limit)
+                ),
             )
             return Ok(
                 build_knowledge_map_payload(
@@ -711,8 +1257,14 @@ class StudyCompanionPlugin(NekoPluginBase):
 
     @plugin_entry(
         id="study_set_knowledge_contribution_opt_in",
-        name=tr("entries.set_knowledge_contribution_opt_in.name", default="Set Study Knowledge Contribution Opt-In"),
-        description=tr("entries.set_knowledge_contribution_opt_in.description", default="Enable or disable local opt-in for anonymous study knowledge contribution queueing."),
+        name=tr(
+            "entries.set_knowledge_contribution_opt_in.name",
+            default="Set Study Knowledge Contribution Opt-In",
+        ),
+        description=tr(
+            "entries.set_knowledge_contribution_opt_in.description",
+            default="Enable or disable local opt-in for anonymous study knowledge contribution queueing.",
+        ),
         input_schema={
             "type": "object",
             "properties": {"opt_in": {"type": "boolean", "default": False}},
@@ -729,14 +1281,24 @@ class StudyCompanionPlugin(NekoPluginBase):
             preview = await asyncio.to_thread(builder.preview, limit=100)
             self._cfg.knowledge_contribution_opt_in = desired_opt_in
             await self._persist_state()
-            return Ok(build_contribution_settings_payload(opt_in=desired_opt_in, preview=preview))
+            return Ok(
+                build_contribution_settings_payload(
+                    opt_in=desired_opt_in, preview=preview
+                )
+            )
         except Exception as exc:
             return Err(SdkError(str(exc)))
 
     @plugin_entry(
         id="study_clear_knowledge_contribution_queue",
-        name=tr("entries.clear_knowledge_contribution_queue.name", default="Clear Study Knowledge Contribution Queue"),
-        description=tr("entries.clear_knowledge_contribution_queue.description", default="Clear the local anonymous knowledge contribution queue."),
+        name=tr(
+            "entries.clear_knowledge_contribution_queue.name",
+            default="Clear Study Knowledge Contribution Queue",
+        ),
+        description=tr(
+            "entries.clear_knowledge_contribution_queue.description",
+            default="Clear the local anonymous knowledge contribution queue.",
+        ),
         input_schema={"type": "object", "properties": {}},
         llm_result_fields=["cleared_count"],
     )
@@ -751,8 +1313,14 @@ class StudyCompanionPlugin(NekoPluginBase):
     @plugin_entry(
         id="study_detect_mode_intent",
         name=tr("entries.detect_mode_intent.name", default="Detect Study Mode Intent"),
-        description=tr("entries.detect_mode_intent.description", default="Detect whether a text snippet contains a study mode switch intent."),
-        input_schema={"type": "object", "properties": {"text": {"type": "string", "default": ""}}},
+        description=tr(
+            "entries.detect_mode_intent.description",
+            default="Detect whether a text snippet contains a study mode switch intent.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"text": {"type": "string", "default": ""}},
+        },
         llm_result_fields=["mode", "pure_switch", "transition_phrase"],
     )
     async def study_detect_mode_intent(self, text: str = "", **_):
@@ -761,11 +1329,17 @@ class StudyCompanionPlugin(NekoPluginBase):
     @plugin_entry(
         id="study_set_mode",
         name=tr("entries.set_mode.name", default="Set Study Mode"),
-        description=tr("entries.set_mode.description", default="Switch the study companion between companion, interactive, and teaching modes."),
+        description=tr(
+            "entries.set_mode.description",
+            default="Switch the study companion between companion, interactive, and teaching modes.",
+        ),
         input_schema={
             "type": "object",
             "properties": {
-                "mode": {"type": "string", "enum": [MODE_COMPANION, MODE_INTERACTIVE, MODE_TEACHING]},
+                "mode": {
+                    "type": "string",
+                    "enum": [MODE_COMPANION, MODE_INTERACTIVE, MODE_TEACHING],
+                },
                 "reason": {"type": "string", "default": "ui"},
             },
             "required": ["mode"],
@@ -774,15 +1348,22 @@ class StudyCompanionPlugin(NekoPluginBase):
     )
     async def study_set_mode(self, mode: str, reason: str = "ui", **_):
         try:
-            result = await self._apply_mode_switch(mode, reason, language=self._cfg.language)
+            result = await self._apply_mode_switch(
+                mode, reason, language=self._cfg.language
+            )
         except ValueError as exc:
             return Err(SdkError(str(exc)))
         return Ok(result)
 
     @plugin_entry(
         id="study_dependency_status",
-        name=tr("entries.dependency_status.name", default="Study OCR Dependency Status"),
-        description=tr("entries.dependency_status.description", default="Inspect RapidOCR, Tesseract, and capture dependencies used by study_companion."),
+        name=tr(
+            "entries.dependency_status.name", default="Study OCR Dependency Status"
+        ),
+        description=tr(
+            "entries.dependency_status.description",
+            default="Inspect RapidOCR, Tesseract, and capture dependencies used by study_companion.",
+        ),
         input_schema={"type": "object", "properties": {}},
         llm_result_fields=["missing_installable"],
     )
@@ -794,7 +1375,10 @@ class StudyCompanionPlugin(NekoPluginBase):
     @plugin_entry(
         id="study_ocr_snapshot",
         name=tr("entries.ocr_snapshot.name", default="Study OCR Snapshot"),
-        description=tr("entries.ocr_snapshot.description", default="Run a lightweight OCR snapshot. Phase 1 attempts fullscreen capture and returns diagnostics on failure."),
+        description=tr(
+            "entries.ocr_snapshot.description",
+            default="Run a lightweight OCR snapshot. Phase 1 attempts fullscreen capture and returns diagnostics on failure.",
+        ),
         input_schema={"type": "object", "properties": {}},
         timeout=45.0,
         llm_result_fields=["summary", "status", "diagnostic"],
@@ -808,16 +1392,23 @@ class StudyCompanionPlugin(NekoPluginBase):
             with self._lock:
                 self._state.last_ocr_text = snapshot.text
                 self._state.last_ocr_at = snapshot.captured_at
-            payload["screen_classification"] = self._update_screen_classification(snapshot.text, update_empty=False)
+            payload["screen_classification"] = self._update_screen_classification(
+                snapshot.text, update_empty=False
+            )
         elif snapshot.status == "empty":
-            payload["screen_classification"] = self._update_screen_classification("", update_empty=True)
+            payload["screen_classification"] = self._update_screen_classification(
+                "", update_empty=True
+            )
         await self._persist_state()
         return Ok(payload)
 
     @plugin_entry(
         id="study_explain_text",
         name=tr("entries.explain_text.name", default="Explain Study Text"),
-        description=tr("entries.explain_text.description", default="Explain a concept from supplied text, or use the latest OCR text if text is omitted."),
+        description=tr(
+            "entries.explain_text.description",
+            default="Explain a concept from supplied text, or use the latest OCR text if text is omitted.",
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -832,18 +1423,35 @@ class StudyCompanionPlugin(NekoPluginBase):
             return Err(SdkError("study tutor agent is not initialized"))
         raw_text = str(text or "").strip()
         # Phase 1: detect an explicit mode intent and switch first when present.
-        intent = handle_user_intent(raw_text, language=self._cfg.language) if raw_text else {"matched": False, "pure_switch": False, "mode": "", "remaining_text": ""}
+        intent = (
+            handle_user_intent(raw_text, language=self._cfg.language)
+            if raw_text
+            else {
+                "matched": False,
+                "pure_switch": False,
+                "mode": "",
+                "remaining_text": "",
+            }
+        )
         with self._lock:
             active_mode = self._state.active_mode
         mode_switch: dict[str, Any] = {}
         if intent.get("matched") and intent.get("kind") == "mode_switch":
             try:
-                mode_switch = await self._apply_mode_switch(str(intent.get("mode") or MODE_COMPANION), f"intent:{intent.get('keyword') or 'text'}", language=self._cfg.language)
+                mode_switch = await self._apply_mode_switch(
+                    str(intent.get("mode") or MODE_COMPANION),
+                    f"intent:{intent.get('keyword') or 'text'}",
+                    language=self._cfg.language,
+                )
                 active_mode = str(mode_switch.get("new_mode") or active_mode)
             except ValueError as exc:
                 return Err(SdkError(str(exc)))
             if intent.get("pure_switch"):
-                transition_phrase = str(mode_switch.get("transition_phrase") or intent.get("transition_phrase") or "")
+                transition_phrase = str(
+                    mode_switch.get("transition_phrase")
+                    or intent.get("transition_phrase")
+                    or ""
+                )
                 return Ok(
                     {
                         **mode_switch,
@@ -869,7 +1477,9 @@ class StudyCompanionPlugin(NekoPluginBase):
             LLM_OPERATION_CONCEPT_EXPLAIN,
             input_text=source_text,
             extra={
-                "source": "ocr_snapshot" if used_ocr_fallback or not raw_text else "manual",
+                "source": "ocr_snapshot"
+                if used_ocr_fallback or not raw_text
+                else "manual",
                 "mode": active_mode,
                 "mode_switch": bool(mode_switch.get("changed")),
                 "source_text": source_text,
@@ -890,7 +1500,8 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "mode": active_mode,
                 "mode_switch": mode_switch,
                 "intent": intent,
-                "screen_classification": tutor_context.get("screen_classification") or {},
+                "screen_classification": tutor_context.get("screen_classification")
+                or {},
             },
             extra_context=tutor_context,
         )
@@ -899,13 +1510,20 @@ class StudyCompanionPlugin(NekoPluginBase):
         if intent.get("matched"):
             payload["intent"] = intent
             if intent.get("pure_switch"):
-                payload["transition_phrase"] = str(mode_switch.get("transition_phrase") or intent.get("transition_phrase") or "")
+                payload["transition_phrase"] = str(
+                    mode_switch.get("transition_phrase")
+                    or intent.get("transition_phrase")
+                    or ""
+                )
         return Ok(payload)
 
     @plugin_entry(
         id="study_generate_question",
         name=tr("entries.generate_question.name", default="Generate Study Question"),
-        description=tr("entries.generate_question.description", default="Generate one study question from supplied text or the latest OCR text."),
+        description=tr(
+            "entries.generate_question.description",
+            default="Generate one study question from supplied text or the latest OCR text.",
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -914,7 +1532,14 @@ class StudyCompanionPlugin(NekoPluginBase):
             },
         },
         timeout=60.0,
-        llm_result_fields=["summary", "question", "answer", "hint", "difficulty", "topic"],
+        llm_result_fields=[
+            "summary",
+            "question",
+            "answer",
+            "hint",
+            "difficulty",
+            "topic",
+        ],
     )
     async def study_generate_question(self, text: str = "", topic: str = "", **_):
         if self._agent is None:
@@ -937,7 +1562,9 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "mode": active_mode,
             },
         )
-        reply = await self._agent.question_generate(source_text, mode=active_mode, context=tutor_context)
+        reply = await self._agent.question_generate(
+            source_text, mode=active_mode, context=tutor_context
+        )
         payload = await self._finalize_tutor_call(
             LLM_OPERATION_QUESTION_GENERATE,
             reply,
@@ -946,17 +1573,23 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "degraded": reply.degraded,
                 "diagnostic": reply.diagnostic,
                 "payload": reply.payload,
-                "screen_classification": tutor_context.get("screen_classification") or {},
+                "screen_classification": tutor_context.get("screen_classification")
+                or {},
             },
             extra_context=tutor_context,
         )
-        payload["screen_classification"] = tutor_context.get("screen_classification") or {}
+        payload["screen_classification"] = (
+            tutor_context.get("screen_classification") or {}
+        )
         return Ok(payload)
 
     @plugin_entry(
         id="study_evaluate_answer",
         name=tr("entries.evaluate_answer.name", default="Evaluate Study Answer"),
-        description=tr("entries.evaluate_answer.description", default="Evaluate an answer against the current generated question or a supplied question."),
+        description=tr(
+            "entries.evaluate_answer.description",
+            default="Evaluate an answer against the current generated question or a supplied question.",
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -966,9 +1599,18 @@ class StudyCompanionPlugin(NekoPluginBase):
             },
         },
         timeout=60.0,
-        llm_result_fields=["summary", "verdict", "score", "error_type", "feedback", "next_action"],
+        llm_result_fields=[
+            "summary",
+            "verdict",
+            "score",
+            "error_type",
+            "feedback",
+            "next_action",
+        ],
     )
-    async def study_evaluate_answer(self, answer: str = "", question: str = "", expected_answer: str = "", **kwargs):
+    async def study_evaluate_answer(
+        self, answer: str = "", question: str = "", expected_answer: str = "", **kwargs
+    ):
         if self._agent is None:
             return Err(SdkError("study tutor agent is not initialized"))
         with self._lock:
@@ -982,10 +1624,14 @@ class StudyCompanionPlugin(NekoPluginBase):
         if not resolved_question:
             return Err(SdkError("study tutor requires a question to evaluate against"))
         resolved_expected = supplied_expected
-        if not resolved_expected and (not supplied_question or supplied_question == state_question):
+        if not resolved_expected and (
+            not supplied_question or supplied_question == state_question
+        ):
             resolved_expected = state_expected
         answer_text = str(answer or "").strip()
-        using_current_question = not supplied_question or supplied_question == state_question
+        using_current_question = (
+            not supplied_question or supplied_question == state_question
+        )
         question_payload = dict(current_question) if using_current_question else {}
         question_payload.update(
             {
@@ -1004,7 +1650,9 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "answer": answer_text,
                 "current_question": current_question if using_current_question else {},
                 "question_payload": question_payload,
-                "question_source": "current_question" if using_current_question else "supplied",
+                "question_source": "current_question"
+                if using_current_question
+                else "supplied",
                 "run_id": run_id,
                 "session_id": session_id,
                 "mode": active_mode,
@@ -1027,28 +1675,45 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "degraded": reply.degraded,
                 "diagnostic": reply.diagnostic,
                 "payload": reply.payload,
-                "screen_classification": tutor_context.get("screen_classification") or {},
+                "screen_classification": tutor_context.get("screen_classification")
+                or {},
             },
             extra_context=tutor_context,
         )
         payload["question"] = resolved_question
-        payload["screen_classification"] = tutor_context.get("screen_classification") or {}
+        payload["screen_classification"] = (
+            tutor_context.get("screen_classification") or {}
+        )
         return Ok(payload)
 
     @plugin_entry(
         id="study_summarize_session",
         name=tr("entries.summarize_session.name", default="Summarize Study Session"),
-        description=tr("entries.summarize_session.description", default="Summarize recent study interactions into compact study notes."),
-        input_schema={"type": "object", "properties": {"focus": {"type": "string", "default": ""}}},
+        description=tr(
+            "entries.summarize_session.description",
+            default="Summarize recent study interactions into compact study notes.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"focus": {"type": "string", "default": ""}},
+        },
         timeout=75.0,
-        llm_result_fields=["summary", "markdown", "highlights", "weak_points", "next_actions"],
+        llm_result_fields=[
+            "summary",
+            "markdown",
+            "highlights",
+            "weak_points",
+            "next_actions",
+        ],
     )
     async def study_summarize_session(self, focus: str = "", **_):
         if self._agent is None:
             return Err(SdkError("study tutor agent is not initialized"))
         with self._lock:
             active_mode = self._state.active_mode
-        history = await asyncio.to_thread(self._store.list_interactions, max(5, min(30, self._cfg.history_limit)))
+        history = await asyncio.to_thread(
+            self._store.list_interactions, max(5, min(30, self._cfg.history_limit))
+        )
         tutor_context = await self._build_learning_context(
             LLM_OPERATION_SUMMARIZE_SESSION,
             input_text="session",
@@ -1058,7 +1723,9 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "mode": active_mode,
             },
         )
-        reply = await self._agent.summarize_session(history, mode=active_mode, context=tutor_context)
+        reply = await self._agent.summarize_session(
+            history, mode=active_mode, context=tutor_context
+        )
         payload = await self._finalize_tutor_call(
             LLM_OPERATION_SUMMARIZE_SESSION,
             reply,
@@ -1067,17 +1734,28 @@ class StudyCompanionPlugin(NekoPluginBase):
                 "degraded": reply.degraded,
                 "diagnostic": reply.diagnostic,
                 "payload": reply.payload,
-                "screen_classification": tutor_context.get("screen_classification") or {},
+                "screen_classification": tutor_context.get("screen_classification")
+                or {},
             },
         )
-        payload["screen_classification"] = tutor_context.get("screen_classification") or {}
+        payload["screen_classification"] = (
+            tutor_context.get("screen_classification") or {}
+        )
         return Ok(payload)
 
     @plugin_entry(
         id="study_install_tesseract",
-        name=tr("entries.install_tesseract.name", default="Install Tesseract for Study OCR"),
-        description=tr("entries.install_tesseract.description", default="Install local Tesseract OCR for study_companion and refresh dependency status."),
-        input_schema={"type": "object", "properties": {"force": {"type": "boolean", "default": False}}},
+        name=tr(
+            "entries.install_tesseract.name", default="Install Tesseract for Study OCR"
+        ),
+        description=tr(
+            "entries.install_tesseract.description",
+            default="Install local Tesseract OCR for study_companion and refresh dependency status.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"force": {"type": "boolean", "default": False}},
+        },
         timeout=300.0,
         llm_result_fields=["summary"],
     )
@@ -1104,7 +1782,12 @@ class StudyCompanionPlugin(NekoPluginBase):
             )
             self._refresh_dependency_status()
             await self._persist_state()
-            return Ok({"summary": str(result.get("summary") or "Tesseract is ready"), "install_result": result})
+            return Ok(
+                {
+                    "summary": str(result.get("summary") or "Tesseract is ready"),
+                    "install_result": result,
+                }
+            )
         except Exception as exc:
             return Err(SdkError(f"Tesseract install failed: {exc}"))
         finally:
@@ -1113,9 +1796,18 @@ class StudyCompanionPlugin(NekoPluginBase):
 
     @plugin_entry(
         id="study_download_rapidocr_models",
-        name=tr("entries.download_rapidocr_models.name", default="Download RapidOCR Models for Study OCR"),
-        description=tr("entries.download_rapidocr_models.description", default="Download missing RapidOCR model files for the configured study_companion OCR language."),
-        input_schema={"type": "object", "properties": {"force": {"type": "boolean", "default": False}}},
+        name=tr(
+            "entries.download_rapidocr_models.name",
+            default="Download RapidOCR Models for Study OCR",
+        ),
+        description=tr(
+            "entries.download_rapidocr_models.description",
+            default="Download missing RapidOCR model files for the configured study_companion OCR language.",
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {"force": {"type": "boolean", "default": False}},
+        },
         timeout=600.0,
         llm_result_fields=["summary"],
     )
@@ -1126,7 +1818,9 @@ class StudyCompanionPlugin(NekoPluginBase):
             self._rapidocr_models_in_progress = True
         run_id = self._resolve_current_run_id(kwargs)
         try:
-            from plugin.plugins.galgame_plugin.rapidocr_support import download_rapidocr_models
+            from plugin.plugins.galgame_plugin.rapidocr_support import (
+                download_rapidocr_models,
+            )
 
             result = await download_rapidocr_models(
                 logger=self.logger,

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -984,7 +984,7 @@ class StudyCompanionPlugin(NekoPluginBase):
     async def study_pomodoro_stop(self, **_):
         try:
             _, _, timer, supervision = self._require_habit_components()
-            status = timer.stop()
+            status = await asyncio.to_thread(timer.stop)
             supervision.on_focus_end()
             return Ok(build_pomodoro_status_payload(status))
         except Exception as exc:

--- a/plugin/plugins/study_companion/checkin_manager.py
+++ b/plugin/plugins/study_companion/checkin_manager.py
@@ -41,8 +41,8 @@ class CheckinManager:
     def update_goal(self, goal_id: str, **updates: Any) -> dict[str, Any]:
         return self._habits.update_goal(goal_id, **updates)
 
-    def delete_goal(self, goal_id: str) -> None:
-        self._habits.delete_goal(goal_id)
+    def delete_goal(self, goal_id: str) -> bool:
+        return self._habits.delete_goal(goal_id)
 
     def manual_checkin(
         self, *, date: str, today: str, note: str = ""

--- a/plugin/plugins/study_companion/checkin_manager.py
+++ b/plugin/plugins/study_companion/checkin_manager.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import date as date_type, datetime, timedelta
+from typing import Any
+
+from .study_habit_store import StudyHabitStore
+
+
+def _parse_date(value: str) -> date_type:
+    return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+
+
+def _date_text(value: date_type) -> str:
+    return value.isoformat()
+
+
+class CheckinManager:
+    def __init__(self, habits: StudyHabitStore, *, makeup_window_days: int = 3) -> None:
+        self._habits = habits
+        self.makeup_window_days = max(0, min(7, int(makeup_window_days)))
+
+    def create_goal(
+        self,
+        *,
+        date: str,
+        target_type: str,
+        subject: str,
+        target_amount: float,
+        unit: str,
+        target_id: str = "",
+    ) -> dict[str, Any]:
+        return self._habits.create_goal(
+            date=date,
+            target_type=target_type,
+            subject=subject,
+            target_amount=target_amount,
+            unit=unit,
+            target_id=target_id,
+        )
+
+    def update_goal(self, goal_id: str, **updates: Any) -> dict[str, Any]:
+        return self._habits.update_goal(goal_id, **updates)
+
+    def delete_goal(self, goal_id: str) -> None:
+        self._habits.delete_goal(goal_id)
+
+    def manual_checkin(
+        self, *, date: str, today: str, note: str = ""
+    ) -> dict[str, Any]:
+        checkin_date = _parse_date(date)
+        today_date = _parse_date(today)
+        delta_days = (today_date - checkin_date).days
+        if delta_days < 0:
+            raise ValueError("cannot check in for a future date")
+        if delta_days > self.makeup_window_days:
+            raise ValueError("checkin date is outside makeup window")
+        status = "checked_in" if delta_days == 0 else "makeup"
+        return self._habits.record_checkin(
+            date=date, status=status, source="manual", note=note
+        )
+
+    def apply_session_progress(
+        self,
+        *,
+        date: str,
+        duration_minutes: float,
+        question_count: int,
+        subject: str = "",
+    ) -> dict[str, Any]:
+        duration = max(0.0, float(duration_minutes or 0.0))
+        questions = max(0, int(question_count or 0))
+        matched_goals = []
+        for goal in self._habits.list_goals(date=date):
+            if subject and goal.get("subject") and str(goal["subject"]) != str(subject):
+                continue
+            unit = str(goal.get("unit") or "")
+            delta = 0.0
+            if unit in {"minute", "minutes"}:
+                delta = duration
+            elif unit in {"question", "questions"}:
+                delta = float(questions)
+            elif unit in {"task", "pomodoro"} and duration > 0:
+                delta = 1.0
+            if delta <= 0:
+                continue
+            matched_goals.append(
+                self._habits.update_goal(str(goal["id"]), progress_delta=delta)
+            )
+        if duration > 0:
+            focus = self._habits.create_focus_session(
+                goal_id=str(matched_goals[0]["id"]) if matched_goals else "",
+                mode="focus",
+                planned_minutes=duration,
+                started_at=f"{date[:10]}T00:00:00",
+            )
+            self._habits.finish_focus_session(
+                str(focus["id"]),
+                ended_at=f"{date[:10]}T00:00:00",
+                actual_minutes=duration,
+                status="completed",
+            )
+        checkin = self._habits.record_checkin(
+            date=date, status="checked_in", source="session_derived"
+        )
+        return {"goals": matched_goals, "checkin": checkin}
+
+    def checkin_status(self, *, date: str, today: str | None = None) -> dict[str, Any]:
+        target = _parse_date(date)
+        today_date = _parse_date(today or date)
+        checked_dates = self._habits.checked_dates(through_date=_date_text(target))
+        streak = 0
+        cursor = target
+        while _date_text(cursor) in checked_dates:
+            streak += 1
+            cursor -= timedelta(days=1)
+        checkins = self._habits.list_checkins(date=date)
+        return {
+            "date": date[:10],
+            "checked_in": any(
+                item["status"] in {"checked_in", "makeup"} for item in checkins
+            ),
+            "checkins": checkins,
+            "streak_days": streak,
+            "makeup_window_days": self.makeup_window_days,
+            "makeup_available_dates": [
+                _date_text(today_date - timedelta(days=offset))
+                for offset in range(1, self.makeup_window_days + 1)
+            ],
+        }
+
+    def daily_summary(self, *, date: str) -> dict[str, Any]:
+        goals = self._habits.list_goals(date=date)
+        completed = [goal for goal in goals if goal.get("status") == "completed"]
+        incomplete = [goal for goal in goals if goal.get("status") == "active"]
+        total_focus = self._habits.focus_minutes_for_date(date)
+        return {
+            "date": date[:10],
+            "total_focus_minutes": total_focus,
+            "goals": goals,
+            "completed_goals": completed,
+            "incomplete_goals": incomplete,
+            "completed_goal_count": len(completed),
+            "incomplete_goal_count": len(incomplete),
+            "weak_points": [],
+            "phase7_memory": {"enabled": False, "items": []},
+        }

--- a/plugin/plugins/study_companion/models.py
+++ b/plugin/plugins/study_companion/models.py
@@ -4,7 +4,13 @@ from dataclasses import asdict, dataclass, field
 import math
 from typing import Any, Literal, TypedDict
 
-from .constants import MODE_COMPANION, MODE_CONCEPT_EXPLAIN, MODE_INTERACTIVE, MODE_TEACHING, SUPPORTED_MODES
+from .constants import (
+    MODE_COMPANION,
+    MODE_CONCEPT_EXPLAIN,
+    MODE_INTERACTIVE,
+    MODE_TEACHING,
+    SUPPORTED_MODES,
+)
 from .json_utils import json_copy
 from .mode_manager import normalize_mode
 
@@ -69,6 +75,7 @@ class TutorReplyPayload(TypedDict, total=False):
     next_actions: list[str]
     markdown: str
 
+
 STATUS_READY = "ready"
 STATUS_STOPPED = "stopped"
 STATUS_ERROR = "error"
@@ -96,6 +103,101 @@ class DocExportConfig:
         style = str(self.default_style or "neko").strip().lower() or "neko"
         self.default_style = style if style in STUDY_EXPORT_STYLES else "neko"
         self.xmind_enabled = bool(self.xmind_enabled)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PomodoroConfig:
+    focus_minutes: int = 25
+    short_break_minutes: int = 5
+    long_break_minutes: int = 15
+    long_break_interval: int = 4
+    allow_skip_break: bool = True
+    allow_custom_duration: bool = True
+
+    def __post_init__(self) -> None:
+        self.focus_minutes = self._range_or_default(self.focus_minutes, 1, 120, 25)
+        self.short_break_minutes = self._range_or_default(
+            self.short_break_minutes, 1, 30, 5
+        )
+        self.long_break_minutes = self._range_or_default(
+            self.long_break_minutes, 1, 60, 15
+        )
+        self.long_break_interval = self._range_or_default(
+            self.long_break_interval, 1, 10, 4
+        )
+        self.allow_skip_break = bool(self.allow_skip_break)
+        self.allow_custom_duration = bool(self.allow_custom_duration)
+
+    @staticmethod
+    def _range_or_default(
+        value: object, minimum: int, maximum: int, default: int
+    ) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return default
+        return number if minimum <= number <= maximum else default
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class SupervisionConfig:
+    enabled: bool = True
+    remind_interval_minutes: int = 10
+    inactivity_timeout_minutes: int = 5
+    allow_disable_by_chat: bool = True
+
+    def __post_init__(self) -> None:
+        self.enabled = bool(self.enabled)
+        self.remind_interval_minutes = self._range_or_default(
+            self.remind_interval_minutes, 1, 60, 10
+        )
+        self.inactivity_timeout_minutes = self._range_or_default(
+            self.inactivity_timeout_minutes, 1, 30, 5
+        )
+        self.allow_disable_by_chat = bool(self.allow_disable_by_chat)
+
+    @staticmethod
+    def _range_or_default(
+        value: object, minimum: int, maximum: int, default: int
+    ) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return default
+        return number if minimum <= number <= maximum else default
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class CheckinConfig:
+    streak_timezone: str = "local"
+    makeup_window_days: int = 3
+    auto_derive_from_session: bool = True
+
+    def __post_init__(self) -> None:
+        self.streak_timezone = str(self.streak_timezone or "local").strip() or "local"
+        self.makeup_window_days = self._range_or_default(
+            self.makeup_window_days, 0, 7, 3
+        )
+        self.auto_derive_from_session = bool(self.auto_derive_from_session)
+
+    @staticmethod
+    def _range_or_default(
+        value: object, minimum: int, maximum: int, default: int
+    ) -> int:
+        try:
+            number = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return default
+        return number if minimum <= number <= maximum else default
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -130,27 +232,66 @@ class StudyConfig:
     knowledge_contribution_opt_in: bool = False
     knowledge_contribution_min_sample_count: int = 3
     doc_export: DocExportConfig = field(default_factory=DocExportConfig)
+    pomodoro: PomodoroConfig = field(default_factory=PomodoroConfig)
+    supervision: SupervisionConfig = field(default_factory=SupervisionConfig)
+    checkin: CheckinConfig = field(default_factory=CheckinConfig)
 
     def __post_init__(self) -> None:
         self.mode = normalize_mode(self.mode)
         self.default_mode = normalize_mode(self.default_mode or self.mode)
         self.language = str(self.language or "zh-CN").strip() or "zh-CN"
         self.history_limit = max(1, self._coerce_int(self.history_limit, 50))
-        self.ocr_install_timeout_seconds = self._clamp_float(self.ocr_install_timeout_seconds, 1.0, 3600.0, 300.0)
-        self.ocr_left_inset_ratio = self._clamp_float(self.ocr_left_inset_ratio, 0.0, 1.0, 0.03)
-        self.ocr_right_inset_ratio = self._clamp_float(self.ocr_right_inset_ratio, 0.0, 1.0, 0.03)
+        self.ocr_install_timeout_seconds = self._clamp_float(
+            self.ocr_install_timeout_seconds, 1.0, 3600.0, 300.0
+        )
+        self.ocr_left_inset_ratio = self._clamp_float(
+            self.ocr_left_inset_ratio, 0.0, 1.0, 0.03
+        )
+        self.ocr_right_inset_ratio = self._clamp_float(
+            self.ocr_right_inset_ratio, 0.0, 1.0, 0.03
+        )
         self.ocr_top_ratio = self._clamp_float(self.ocr_top_ratio, 0.0, 1.0, 0.0)
-        self.ocr_bottom_inset_ratio = self._clamp_float(self.ocr_bottom_inset_ratio, 0.0, 1.0, 0.0)
-        self.llm_call_timeout_seconds = self._clamp_float(self.llm_call_timeout_seconds, 1.0, 3600.0, 30.0)
-        self.fsrs_retention_target = self._clamp_float(self.fsrs_retention_target, 0.1, 0.99, 0.90)
-        self.fsrs_auto_optimize_interval_days = max(1, self._coerce_int(self.fsrs_auto_optimize_interval_days, 30))
+        self.ocr_bottom_inset_ratio = self._clamp_float(
+            self.ocr_bottom_inset_ratio, 0.0, 1.0, 0.0
+        )
+        self.llm_call_timeout_seconds = self._clamp_float(
+            self.llm_call_timeout_seconds, 1.0, 3600.0, 30.0
+        )
+        self.fsrs_retention_target = self._clamp_float(
+            self.fsrs_retention_target, 0.1, 0.99, 0.90
+        )
+        self.fsrs_auto_optimize_interval_days = max(
+            1, self._coerce_int(self.fsrs_auto_optimize_interval_days, 30)
+        )
         self.knowledge_contribution_opt_in = bool(self.knowledge_contribution_opt_in)
         self.knowledge_contribution_min_sample_count = max(
             1,
             self._coerce_int(self.knowledge_contribution_min_sample_count, 3),
         )
         if not isinstance(self.doc_export, DocExportConfig):
-            self.doc_export = DocExportConfig(**self.doc_export) if isinstance(self.doc_export, dict) else DocExportConfig()
+            self.doc_export = (
+                DocExportConfig(**self.doc_export)
+                if isinstance(self.doc_export, dict)
+                else DocExportConfig()
+            )
+        if not isinstance(self.pomodoro, PomodoroConfig):
+            self.pomodoro = (
+                PomodoroConfig(**self.pomodoro)
+                if isinstance(self.pomodoro, dict)
+                else PomodoroConfig()
+            )
+        if not isinstance(self.supervision, SupervisionConfig):
+            self.supervision = (
+                SupervisionConfig(**self.supervision)
+                if isinstance(self.supervision, dict)
+                else SupervisionConfig()
+            )
+        if not isinstance(self.checkin, CheckinConfig):
+            self.checkin = (
+                CheckinConfig(**self.checkin)
+                if isinstance(self.checkin, dict)
+                else CheckinConfig()
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -163,7 +304,9 @@ class StudyConfig:
             return default
 
     @staticmethod
-    def _clamp_float(value: object, minimum: float, maximum: float, default: float) -> float:
+    def _clamp_float(
+        value: object, minimum: float, maximum: float, default: float
+    ) -> float:
         try:
             number = float(value)
         except (TypeError, ValueError, OverflowError):
@@ -171,6 +314,7 @@ class StudyConfig:
         if not math.isfinite(number):
             number = default
         return max(minimum, min(maximum, number))
+
 
 @dataclass(slots=True)
 class StudyState:
@@ -240,36 +384,62 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
     ocr = raw.get("ocr_reader") if isinstance(raw.get("ocr_reader"), dict) else {}
     rapidocr = raw.get("rapidocr") if isinstance(raw.get("rapidocr"), dict) else {}
     fsrs = raw.get("fsrs") if isinstance(raw.get("fsrs"), dict) else {}
-    contribution = raw.get("knowledge_contribution") if isinstance(raw.get("knowledge_contribution"), dict) else {}
-    doc_export = raw.get("doc_export") if isinstance(raw.get("doc_export"), dict) else {}
+    contribution = (
+        raw.get("knowledge_contribution")
+        if isinstance(raw.get("knowledge_contribution"), dict)
+        else {}
+    )
+    doc_export = (
+        raw.get("doc_export") if isinstance(raw.get("doc_export"), dict) else {}
+    )
+    pomodoro = study.get("pomodoro") if isinstance(study.get("pomodoro"), dict) else {}
+    supervision = (
+        study.get("supervision") if isinstance(study.get("supervision"), dict) else {}
+    )
+    checkin = study.get("checkin") if isinstance(study.get("checkin"), dict) else {}
 
-    def _raw(section: dict[str, Any], key: str, default: Any, flat_key: str | None = None) -> Any:
+    def _raw(
+        section: dict[str, Any], key: str, default: Any, flat_key: str | None = None
+    ) -> Any:
         if key in section:
             return section.get(key, default)
         if flat_key and flat_key in raw:
             return raw.get(flat_key, default)
         return default
 
-    def _str(section: dict[str, Any], key: str, default: str, flat_key: str | None = None) -> str:
+    def _str(
+        section: dict[str, Any], key: str, default: str, flat_key: str | None = None
+    ) -> str:
         return str(_raw(section, key, default, flat_key) or default)
 
-    def _bool(section: dict[str, Any], key: str, default: bool, flat_key: str | None = None) -> bool:
+    def _bool(
+        section: dict[str, Any], key: str, default: bool, flat_key: str | None = None
+    ) -> bool:
         value = _raw(section, key, default, flat_key)
         return value if isinstance(value, bool) else default
 
-    def _int(section: dict[str, Any], key: str, default: int, flat_key: str | None = None) -> int:
+    def _int(
+        section: dict[str, Any], key: str, default: int, flat_key: str | None = None
+    ) -> int:
         try:
             return int(_raw(section, key, default, flat_key))
         except (TypeError, ValueError):
             return default
 
-    def _float(section: dict[str, Any], key: str, default: float, flat_key: str | None = None) -> float:
+    def _float(
+        section: dict[str, Any], key: str, default: float, flat_key: str | None = None
+    ) -> float:
         try:
             return float(_raw(section, key, default, flat_key))
         except (TypeError, ValueError):
             return default
 
-    def _float_alias(section: dict[str, Any], keys: tuple[str, ...], default: float, flat_key: str | None = None) -> float:
+    def _float_alias(
+        section: dict[str, Any],
+        keys: tuple[str, ...],
+        default: float,
+        flat_key: str | None = None,
+    ) -> float:
         for key in keys:
             if key in section:
                 try:
@@ -288,7 +458,15 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
             value = default
         return max(minimum, min(maximum, value))
 
-    default_mode = _str(study, "default_mode", _str(study, "mode", MODE_COMPANION, "mode"), "default_mode").strip() or MODE_COMPANION
+    default_mode = (
+        _str(
+            study,
+            "default_mode",
+            _str(study, "mode", MODE_COMPANION, "mode"),
+            "default_mode",
+        ).strip()
+        or MODE_COMPANION
+    )
     default_mode = normalize_mode(default_mode)
     mode = normalize_mode(_str(study, "mode", default_mode, "mode"))
 
@@ -298,37 +476,85 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
         language=_str(study, "language", "zh-CN", "language"),
         history_limit=max(1, _int(study, "history_limit", 50, "history_limit")),
         ocr_enabled=_bool(ocr, "enabled", True, "ocr_enabled"),
-        ocr_backend_selection=_str(ocr, "backend_selection", "rapidocr", "ocr_backend_selection"),
+        ocr_backend_selection=_str(
+            ocr, "backend_selection", "rapidocr", "ocr_backend_selection"
+        ),
         ocr_capture_backend=_str(ocr, "capture_backend", "auto", "ocr_capture_backend"),
         ocr_tesseract_path=_str(ocr, "tesseract_path", "", "ocr_tesseract_path"),
-        ocr_install_manifest_url=_str(ocr, "install_manifest_url", "", "ocr_install_manifest_url"),
-        ocr_install_target_dir=_str(ocr, "install_target_dir", "", "ocr_install_target_dir"),
+        ocr_install_manifest_url=_str(
+            ocr, "install_manifest_url", "", "ocr_install_manifest_url"
+        ),
+        ocr_install_target_dir=_str(
+            ocr, "install_target_dir", "", "ocr_install_target_dir"
+        ),
         ocr_install_timeout_seconds=_clamp(
-            _float(ocr, "install_timeout_seconds", 300.0, "ocr_install_timeout_seconds"),
+            _float(
+                ocr, "install_timeout_seconds", 300.0, "ocr_install_timeout_seconds"
+            ),
             1.0,
             3600.0,
             300.0,
         ),
         ocr_languages=_str(ocr, "languages", "chi_sim+jpn+eng", "ocr_languages"),
-        ocr_left_inset_ratio=_clamp(_float(ocr, "left_inset_ratio", 0.03, "ocr_left_inset_ratio"), 0.0, 1.0, 0.03),
-        ocr_right_inset_ratio=_clamp(_float(ocr, "right_inset_ratio", 0.03, "ocr_right_inset_ratio"), 0.0, 1.0, 0.03),
-        ocr_top_ratio=_clamp(_float(ocr, "top_ratio", 0.0, "ocr_top_ratio"), 0.0, 1.0, 0.0),
-        ocr_bottom_inset_ratio=_clamp(_float(ocr, "bottom_inset_ratio", 0.0, "ocr_bottom_inset_ratio"), 0.0, 1.0, 0.0),
-        rapidocr_install_target_dir=_str(rapidocr, "install_target_dir", "", "rapidocr_install_target_dir"),
-        rapidocr_engine_type=_str(rapidocr, "engine_type", "onnxruntime", "rapidocr_engine_type"),
+        ocr_left_inset_ratio=_clamp(
+            _float(ocr, "left_inset_ratio", 0.03, "ocr_left_inset_ratio"),
+            0.0,
+            1.0,
+            0.03,
+        ),
+        ocr_right_inset_ratio=_clamp(
+            _float(ocr, "right_inset_ratio", 0.03, "ocr_right_inset_ratio"),
+            0.0,
+            1.0,
+            0.03,
+        ),
+        ocr_top_ratio=_clamp(
+            _float(ocr, "top_ratio", 0.0, "ocr_top_ratio"), 0.0, 1.0, 0.0
+        ),
+        ocr_bottom_inset_ratio=_clamp(
+            _float(ocr, "bottom_inset_ratio", 0.0, "ocr_bottom_inset_ratio"),
+            0.0,
+            1.0,
+            0.0,
+        ),
+        rapidocr_install_target_dir=_str(
+            rapidocr, "install_target_dir", "", "rapidocr_install_target_dir"
+        ),
+        rapidocr_engine_type=_str(
+            rapidocr, "engine_type", "onnxruntime", "rapidocr_engine_type"
+        ),
         rapidocr_lang_type=_str(rapidocr, "lang_type", "ch", "rapidocr_lang_type"),
-        rapidocr_model_type=_str(rapidocr, "model_type", "mobile", "rapidocr_model_type"),
-        rapidocr_ocr_version=_str(rapidocr, "ocr_version", "PP-OCRv4", "rapidocr_ocr_version"),
+        rapidocr_model_type=_str(
+            rapidocr, "model_type", "mobile", "rapidocr_model_type"
+        ),
+        rapidocr_ocr_version=_str(
+            rapidocr, "ocr_version", "PP-OCRv4", "rapidocr_ocr_version"
+        ),
         llm_call_timeout_seconds=_clamp(
-            _float_alias(llm, ("call_timeout_seconds", "llm_call_timeout_seconds"), 30.0, "llm_call_timeout_seconds"),
+            _float_alias(
+                llm,
+                ("call_timeout_seconds", "llm_call_timeout_seconds"),
+                30.0,
+                "llm_call_timeout_seconds",
+            ),
             1.0,
             3600.0,
             30.0,
         ),
-        fsrs_retention_target=_clamp(_float(fsrs, "retention_target", 0.90, "fsrs_retention_target"), 0.1, 0.99, 0.90),
+        fsrs_retention_target=_clamp(
+            _float(fsrs, "retention_target", 0.90, "fsrs_retention_target"),
+            0.1,
+            0.99,
+            0.90,
+        ),
         fsrs_auto_optimize_interval_days=max(
             1,
-            _int(fsrs, "auto_optimize_interval_days", 30, "fsrs_auto_optimize_interval_days"),
+            _int(
+                fsrs,
+                "auto_optimize_interval_days",
+                30,
+                "fsrs_auto_optimize_interval_days",
+            ),
         ),
         knowledge_contribution_opt_in=_bool(
             contribution,
@@ -347,8 +573,70 @@ def build_config(raw: dict[str, Any]) -> StudyConfig:
         ),
         doc_export=DocExportConfig(
             enabled=_bool(doc_export, "enabled", False, "doc_export_enabled"),
-            pdf_backend=_str(doc_export, "pdf_backend", "reportlab", "doc_export_pdf_backend"),
-            default_style=_str(doc_export, "default_style", "neko", "doc_export_default_style"),
-            xmind_enabled=_bool(doc_export, "xmind_enabled", False, "doc_export_xmind_enabled"),
+            pdf_backend=_str(
+                doc_export, "pdf_backend", "reportlab", "doc_export_pdf_backend"
+            ),
+            default_style=_str(
+                doc_export, "default_style", "neko", "doc_export_default_style"
+            ),
+            xmind_enabled=_bool(
+                doc_export, "xmind_enabled", False, "doc_export_xmind_enabled"
+            ),
+        ),
+        pomodoro=PomodoroConfig(
+            focus_minutes=_int(pomodoro, "focus_minutes", 25, "pomodoro_focus_minutes"),
+            short_break_minutes=_int(
+                pomodoro, "short_break_minutes", 5, "pomodoro_short_break_minutes"
+            ),
+            long_break_minutes=_int(
+                pomodoro, "long_break_minutes", 15, "pomodoro_long_break_minutes"
+            ),
+            long_break_interval=_int(
+                pomodoro, "long_break_interval", 4, "pomodoro_long_break_interval"
+            ),
+            allow_skip_break=_bool(
+                pomodoro, "allow_skip_break", True, "pomodoro_allow_skip_break"
+            ),
+            allow_custom_duration=_bool(
+                pomodoro,
+                "allow_custom_duration",
+                True,
+                "pomodoro_allow_custom_duration",
+            ),
+        ),
+        supervision=SupervisionConfig(
+            enabled=_bool(supervision, "enabled", True, "supervision_enabled"),
+            remind_interval_minutes=_int(
+                supervision,
+                "remind_interval_minutes",
+                10,
+                "supervision_remind_interval_minutes",
+            ),
+            inactivity_timeout_minutes=_int(
+                supervision,
+                "inactivity_timeout_minutes",
+                5,
+                "supervision_inactivity_timeout_minutes",
+            ),
+            allow_disable_by_chat=_bool(
+                supervision,
+                "allow_disable_by_chat",
+                True,
+                "supervision_allow_disable_by_chat",
+            ),
+        ),
+        checkin=CheckinConfig(
+            streak_timezone=_str(
+                checkin, "streak_timezone", "local", "checkin_streak_timezone"
+            ),
+            makeup_window_days=_int(
+                checkin, "makeup_window_days", 3, "checkin_makeup_window_days"
+            ),
+            auto_derive_from_session=_bool(
+                checkin,
+                "auto_derive_from_session",
+                True,
+                "checkin_auto_derive_from_session",
+            ),
         ),
     )

--- a/plugin/plugins/study_companion/models.py
+++ b/plugin/plugins/study_companion/models.py
@@ -90,6 +90,14 @@ def utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _range_or_default(value: object, minimum: int, maximum: int, default: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return number if minimum <= number <= maximum else default
+
+
 @dataclass(slots=True)
 class DocExportConfig:
     enabled: bool = False
@@ -118,28 +126,12 @@ class PomodoroConfig:
     allow_custom_duration: bool = True
 
     def __post_init__(self) -> None:
-        self.focus_minutes = self._range_or_default(self.focus_minutes, 1, 120, 25)
-        self.short_break_minutes = self._range_or_default(
-            self.short_break_minutes, 1, 30, 5
-        )
-        self.long_break_minutes = self._range_or_default(
-            self.long_break_minutes, 1, 60, 15
-        )
-        self.long_break_interval = self._range_or_default(
-            self.long_break_interval, 1, 10, 4
-        )
+        self.focus_minutes = _range_or_default(self.focus_minutes, 1, 120, 25)
+        self.short_break_minutes = _range_or_default(self.short_break_minutes, 1, 30, 5)
+        self.long_break_minutes = _range_or_default(self.long_break_minutes, 1, 60, 15)
+        self.long_break_interval = _range_or_default(self.long_break_interval, 1, 10, 4)
         self.allow_skip_break = bool(self.allow_skip_break)
         self.allow_custom_duration = bool(self.allow_custom_duration)
-
-    @staticmethod
-    def _range_or_default(
-        value: object, minimum: int, maximum: int, default: int
-    ) -> int:
-        try:
-            number = int(value)
-        except (TypeError, ValueError, OverflowError):
-            return default
-        return number if minimum <= number <= maximum else default
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -154,23 +146,13 @@ class SupervisionConfig:
 
     def __post_init__(self) -> None:
         self.enabled = bool(self.enabled)
-        self.remind_interval_minutes = self._range_or_default(
+        self.remind_interval_minutes = _range_or_default(
             self.remind_interval_minutes, 1, 60, 10
         )
-        self.inactivity_timeout_minutes = self._range_or_default(
+        self.inactivity_timeout_minutes = _range_or_default(
             self.inactivity_timeout_minutes, 1, 30, 5
         )
         self.allow_disable_by_chat = bool(self.allow_disable_by_chat)
-
-    @staticmethod
-    def _range_or_default(
-        value: object, minimum: int, maximum: int, default: int
-    ) -> int:
-        try:
-            number = int(value)
-        except (TypeError, ValueError, OverflowError):
-            return default
-        return number if minimum <= number <= maximum else default
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -184,20 +166,8 @@ class CheckinConfig:
 
     def __post_init__(self) -> None:
         self.streak_timezone = str(self.streak_timezone or "local").strip() or "local"
-        self.makeup_window_days = self._range_or_default(
-            self.makeup_window_days, 0, 7, 3
-        )
+        self.makeup_window_days = _range_or_default(self.makeup_window_days, 0, 7, 3)
         self.auto_derive_from_session = bool(self.auto_derive_from_session)
-
-    @staticmethod
-    def _range_or_default(
-        value: object, minimum: int, maximum: int, default: int
-    ) -> int:
-        try:
-            number = int(value)
-        except (TypeError, ValueError, OverflowError):
-            return default
-        return number if minimum <= number <= maximum else default
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/plugin/plugins/study_companion/plugin.toml
+++ b/plugin/plugins/study_companion/plugin.toml
@@ -33,6 +33,25 @@ default_mode = "companion"
 language = "zh-CN"
 history_limit = 50
 
+[study.pomodoro]
+focus_minutes = 25
+short_break_minutes = 5
+long_break_minutes = 15
+long_break_interval = 4
+allow_skip_break = true
+allow_custom_duration = true
+
+[study.supervision]
+enabled = true
+remind_interval_minutes = 10
+inactivity_timeout_minutes = 5
+allow_disable_by_chat = true
+
+[study.checkin]
+streak_timezone = "local"
+makeup_window_days = 3
+auto_derive_from_session = true
+
 [llm]
 llm_call_timeout_seconds = 30
 
@@ -97,6 +116,30 @@ permissions = ["state:read", "action:call", "config:write"]
 id = "note-exporter"
 title = "Note Exporter"
 entry = "surfaces/note_exporter.tsx"
+permissions = ["state:read", "action:call"]
+
+[[plugin.ui.guide]]
+id = "habit-dashboard"
+title = "Habit Dashboard"
+entry = "surfaces/habit_dashboard.tsx"
+permissions = ["state:read", "action:call"]
+
+[[plugin.ui.guide]]
+id = "pomodoro-panel"
+title = "Pomodoro Panel"
+entry = "surfaces/pomodoro_panel.tsx"
+permissions = ["state:read", "action:call"]
+
+[[plugin.ui.guide]]
+id = "daily-goal-editor"
+title = "Daily Goal Editor"
+entry = "surfaces/daily_goal_editor.tsx"
+permissions = ["state:read", "action:call"]
+
+[[plugin.ui.guide]]
+id = "session-summary"
+title = "Session Summary"
+entry = "surfaces/session_summary.tsx"
 permissions = ["state:read", "action:call"]
 
 [[plugin.ui.guide]]

--- a/plugin/plugins/study_companion/pomodoro_timer.py
+++ b/plugin/plugins/study_companion/pomodoro_timer.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+import time
+from typing import Any, Callable
+
+from .study_habit_store import StudyHabitStore
+
+
+@dataclass(slots=True)
+class PomodoroConfig:
+    focus_minutes: int = 25
+    short_break_minutes: int = 5
+    long_break_minutes: int = 15
+    long_break_interval: int = 4
+    allow_skip_break: bool = True
+    allow_custom_duration: bool = True
+
+    def __post_init__(self) -> None:
+        self.focus_minutes = _range_or_default(self.focus_minutes, 1, 120, 25)
+        self.short_break_minutes = _range_or_default(self.short_break_minutes, 1, 30, 5)
+        self.long_break_minutes = _range_or_default(self.long_break_minutes, 1, 60, 15)
+        self.long_break_interval = _range_or_default(self.long_break_interval, 1, 10, 4)
+        self.allow_skip_break = bool(self.allow_skip_break)
+        self.allow_custom_duration = bool(self.allow_custom_duration)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _range_or_default(value: object, minimum: int, maximum: int, default: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return number if minimum <= number <= maximum else default
+
+
+def _iso_from_timestamp(value: float) -> str:
+    return datetime.fromtimestamp(float(value)).isoformat()
+
+
+class PomodoroTimer:
+    def __init__(
+        self,
+        habits: StudyHabitStore,
+        *,
+        config: PomodoroConfig | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._habits = habits
+        self.config = config or PomodoroConfig()
+        self._clock = clock or time.time
+        self._state = "idle"
+        self._mode = "focus"
+        self._deadline = 0.0
+        self._remaining_on_pause = 0.0
+        self._started_at = 0.0
+        self._active_started_at = 0.0
+        self._active_elapsed_seconds = 0.0
+        self._planned_minutes = 0.0
+        self._goal_id = ""
+        self._focus_session: dict[str, Any] | None = None
+        self._session_count = 0
+        self._pause_count = 0
+        self._interrupt_count = 0
+
+    def start(
+        self, *, goal_id: str = "", focus_minutes: int | None = None
+    ) -> dict[str, Any]:
+        if self._state in {"focusing", "paused", "short_break", "long_break"}:
+            return self.status()
+        minutes = self.config.focus_minutes
+        if self.config.allow_custom_duration and focus_minutes is not None:
+            minutes = _range_or_default(
+                focus_minutes, 1, 120, self.config.focus_minutes
+            )
+        now = self._clock()
+        self._state = "focusing"
+        self._mode = "focus"
+        self._goal_id = str(goal_id or "")
+        self._started_at = now
+        self._active_started_at = now
+        self._active_elapsed_seconds = 0.0
+        self._planned_minutes = float(minutes)
+        self._deadline = now + minutes * 60
+        self._remaining_on_pause = 0.0
+        self._pause_count = 0
+        self._interrupt_count = 0
+        self._focus_session = self._habits.create_focus_session(
+            goal_id=self._goal_id,
+            mode="focus",
+            planned_minutes=minutes,
+            started_at=_iso_from_timestamp(now),
+        )
+        return self.status()
+
+    def pause(self) -> dict[str, Any]:
+        if self._state != "focusing":
+            return self.status()
+        now = self._clock()
+        self._active_elapsed_seconds += max(0.0, now - self._active_started_at)
+        self._remaining_on_pause = max(0.0, self._deadline - now)
+        self._state = "paused"
+        self._pause_count += 1
+        return self.status()
+
+    def resume(self) -> dict[str, Any]:
+        if self._state != "paused":
+            return self.status()
+        now = self._clock()
+        self._active_started_at = now
+        self._deadline = now + max(0.0, self._remaining_on_pause)
+        self._state = "focusing"
+        return self.status()
+
+    def stop(self) -> dict[str, Any]:
+        if self._state in {"focusing", "paused"} and self._focus_session is not None:
+            now = self._clock()
+            elapsed_seconds = self._active_elapsed_seconds
+            if self._state == "focusing":
+                elapsed_seconds += max(0.0, now - self._active_started_at)
+            elapsed = max(
+                0.0,
+                min(self._planned_minutes, elapsed_seconds / 60.0),
+            )
+            self._focus_session = self._habits.finish_focus_session(
+                str(self._focus_session["id"]),
+                ended_at=_iso_from_timestamp(now),
+                actual_minutes=elapsed,
+                status="cancelled",
+                pause_count=self._pause_count,
+                interrupt_count=self._interrupt_count,
+            )
+        self._state = "cancelled"
+        self._deadline = self._clock()
+        return self.status()
+
+    def skip_break(self) -> dict[str, Any]:
+        if (
+            self._state not in {"short_break", "long_break"}
+            or not self.config.allow_skip_break
+        ):
+            return self.status()
+        self._state = "completed"
+        self._deadline = self._clock()
+        return self.status()
+
+    def tick(self) -> dict[str, Any]:
+        if self._state == "focusing" and self._clock() >= self._deadline:
+            return self._complete_focus()
+        if (
+            self._state in {"short_break", "long_break"}
+            and self._clock() >= self._deadline
+        ):
+            self._state = "completed"
+            self._deadline = self._clock()
+        return self.status()
+
+    def _complete_focus(self) -> dict[str, Any]:
+        now = self._clock()
+        if self._focus_session is not None:
+            self._focus_session = self._habits.finish_focus_session(
+                str(self._focus_session["id"]),
+                ended_at=_iso_from_timestamp(now),
+                actual_minutes=self._planned_minutes,
+                status="completed",
+                pause_count=self._pause_count,
+                interrupt_count=self._interrupt_count,
+            )
+            self._apply_completed_focus_progress(self._focus_session)
+        self._session_count += 1
+        if self._session_count % self.config.long_break_interval == 0:
+            self._state = "long_break"
+            self._mode = "long_break"
+            self._deadline = now + self.config.long_break_minutes * 60
+        else:
+            self._state = "short_break"
+            self._mode = "short_break"
+            self._deadline = now + self.config.short_break_minutes * 60
+        return self.status()
+
+    def _apply_completed_focus_progress(self, focus: dict[str, Any]) -> None:
+        focus_date = str(focus.get("date") or _iso_from_timestamp(self._started_at))[
+            :10
+        ]
+        if self._goal_id:
+            goal = self._habits.get_goal(self._goal_id)
+            if goal is not None:
+                unit = str(goal.get("unit") or "").strip().lower()
+                delta = 0.0
+                if unit in {"minute", "minutes"}:
+                    delta = self._planned_minutes
+                elif unit in {"pomodoro", "task"}:
+                    delta = 1.0
+                if delta > 0:
+                    self._habits.update_goal(self._goal_id, progress_delta=delta)
+        self._habits.record_checkin(
+            date=focus_date, status="checked_in", source="session_derived"
+        )
+
+    def status(self) -> dict[str, Any]:
+        now = self._clock()
+        if self._state == "paused":
+            remaining = self._remaining_on_pause
+        elif self._state in {"focusing", "short_break", "long_break"}:
+            remaining = max(0.0, self._deadline - now)
+        else:
+            remaining = 0.0
+        return {
+            "state": self._state,
+            "mode": self._mode,
+            "remaining_seconds": int(round(remaining)),
+            "session_count": self._session_count,
+            "goal_id": self._goal_id,
+            "date": _iso_from_timestamp(self._started_at or now)[:10],
+            "pause_count": self._pause_count,
+            "interrupt_count": self._interrupt_count,
+            "current_focus_session": dict(self._focus_session or {}),
+            "config": self.config.to_dict(),
+        }

--- a/plugin/plugins/study_companion/pomodoro_timer.py
+++ b/plugin/plugins/study_companion/pomodoro_timer.py
@@ -55,6 +55,7 @@ class PomodoroTimer:
         self._session_count = 0
         self._pause_count = 0
         self._interrupt_count = 0
+        self._progress_applied_session_id = ""
 
     def start(
         self, *, goal_id: str = "", focus_minutes: int | None = None
@@ -86,6 +87,7 @@ class PomodoroTimer:
         self._pause_count = 0
         self._interrupt_count = 0
         self._focus_session = focus_session
+        self._progress_applied_session_id = ""
         return self.status()
 
     def pause(self) -> dict[str, Any]:
@@ -110,6 +112,8 @@ class PomodoroTimer:
     def stop(self) -> dict[str, Any]:
         if self._state not in {"focusing", "paused", "short_break", "long_break"}:
             return self.status()
+        if self._state == "focusing" and self._clock() >= self._deadline:
+            return self._complete_focus()
         if self._state in {"focusing", "paused"} and self._focus_session is not None:
             now = self._clock()
             elapsed_seconds = self._active_elapsed_seconds
@@ -156,7 +160,7 @@ class PomodoroTimer:
         now = self._clock()
         completed_focus: dict[str, Any] | None = None
         if self._focus_session is not None:
-            self._focus_session = self._habits.finish_focus_session(
+            completed_focus = self._habits.finish_focus_session(
                 str(self._focus_session["id"]),
                 ended_at=_iso_from_timestamp(now, self.checkin_timezone),
                 actual_minutes=self._planned_minutes,
@@ -164,7 +168,8 @@ class PomodoroTimer:
                 pause_count=self._pause_count,
                 interrupt_count=self._interrupt_count,
             )
-            completed_focus = self._focus_session
+            self._apply_completed_focus_progress(completed_focus)
+            self._focus_session = completed_focus
         self._session_count += 1
         if self._session_count % self.config.long_break_interval == 0:
             self._state = "long_break"
@@ -174,14 +179,13 @@ class PomodoroTimer:
             self._state = "short_break"
             self._mode = "short_break"
             self._deadline = now + self.config.short_break_minutes * 60
-        if completed_focus is not None:
-            self._apply_completed_focus_progress(completed_focus)
         return self.status()
 
     def _apply_completed_focus_progress(self, focus: dict[str, Any]) -> None:
         focus_date = str(
             focus.get("date") or _date_from_timestamp(self._started_at, self.checkin_timezone)
         )[:10]
+        session_id = str(focus.get("id") or "")
         if self._goal_id:
             goal = self._habits.get_goal(self._goal_id)
             if goal is not None:
@@ -191,8 +195,11 @@ class PomodoroTimer:
                     delta = self._planned_minutes
                 elif unit in {"pomodoro", "task"}:
                     delta = 1.0
-                if delta > 0:
+                if delta > 0 and (
+                    not session_id or session_id != self._progress_applied_session_id
+                ):
                     self._habits.update_goal(self._goal_id, progress_delta=delta)
+                    self._progress_applied_session_id = session_id
         if self.auto_derive_from_session:
             self._habits.record_checkin(
                 date=focus_date, status="checked_in", source="session_derived"

--- a/plugin/plugins/study_companion/pomodoro_timer.py
+++ b/plugin/plugins/study_companion/pomodoro_timer.py
@@ -1,15 +1,30 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 from typing import Any, Callable
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .models import PomodoroConfig, _range_or_default
 from .study_habit_store import StudyHabitStore
 
 
-def _iso_from_timestamp(value: float) -> str:
-    return datetime.fromtimestamp(float(value)).isoformat()
+def _datetime_from_timestamp(value: float, timezone_name: str = "local") -> datetime:
+    zone_name = str(timezone_name or "local").strip()
+    if zone_name and zone_name.lower() != "local":
+        try:
+            return datetime.fromtimestamp(float(value), ZoneInfo(zone_name))
+        except ZoneInfoNotFoundError:
+            pass
+    return datetime.fromtimestamp(float(value), timezone.utc).astimezone()
+
+
+def _iso_from_timestamp(value: float, timezone_name: str = "local") -> str:
+    return _datetime_from_timestamp(value, timezone_name).isoformat()
+
+
+def _date_from_timestamp(value: float, timezone_name: str = "local") -> str:
+    return _datetime_from_timestamp(value, timezone_name).date().isoformat()
 
 
 class PomodoroTimer:
@@ -20,11 +35,13 @@ class PomodoroTimer:
         config: PomodoroConfig | None = None,
         clock: Callable[[], float] | None = None,
         auto_derive_from_session: bool = True,
+        checkin_timezone: str = "local",
     ) -> None:
         self._habits = habits
         self.config = config or PomodoroConfig()
         self._clock = clock or time.time
         self.auto_derive_from_session = bool(auto_derive_from_session)
+        self.checkin_timezone = str(checkin_timezone or "local").strip() or "local"
         self._state = "idle"
         self._mode = "focus"
         self._deadline = 0.0
@@ -55,7 +72,7 @@ class PomodoroTimer:
             goal_id=goal_key,
             mode="focus",
             planned_minutes=minutes,
-            started_at=_iso_from_timestamp(now),
+            started_at=_iso_from_timestamp(now, self.checkin_timezone),
         )
         self._state = "focusing"
         self._mode = "focus"
@@ -91,6 +108,8 @@ class PomodoroTimer:
         return self.status()
 
     def stop(self) -> dict[str, Any]:
+        if self._state not in {"focusing", "paused", "short_break", "long_break"}:
+            return self.status()
         if self._state in {"focusing", "paused"} and self._focus_session is not None:
             now = self._clock()
             elapsed_seconds = self._active_elapsed_seconds
@@ -102,7 +121,7 @@ class PomodoroTimer:
             )
             self._focus_session = self._habits.finish_focus_session(
                 str(self._focus_session["id"]),
-                ended_at=_iso_from_timestamp(now),
+                ended_at=_iso_from_timestamp(now, self.checkin_timezone),
                 actual_minutes=elapsed,
                 status="cancelled",
                 pause_count=self._pause_count,
@@ -135,16 +154,17 @@ class PomodoroTimer:
 
     def _complete_focus(self) -> dict[str, Any]:
         now = self._clock()
+        completed_focus: dict[str, Any] | None = None
         if self._focus_session is not None:
             self._focus_session = self._habits.finish_focus_session(
                 str(self._focus_session["id"]),
-                ended_at=_iso_from_timestamp(now),
+                ended_at=_iso_from_timestamp(now, self.checkin_timezone),
                 actual_minutes=self._planned_minutes,
                 status="completed",
                 pause_count=self._pause_count,
                 interrupt_count=self._interrupt_count,
             )
-            self._apply_completed_focus_progress(self._focus_session)
+            completed_focus = self._focus_session
         self._session_count += 1
         if self._session_count % self.config.long_break_interval == 0:
             self._state = "long_break"
@@ -154,12 +174,14 @@ class PomodoroTimer:
             self._state = "short_break"
             self._mode = "short_break"
             self._deadline = now + self.config.short_break_minutes * 60
+        if completed_focus is not None:
+            self._apply_completed_focus_progress(completed_focus)
         return self.status()
 
     def _apply_completed_focus_progress(self, focus: dict[str, Any]) -> None:
-        focus_date = str(focus.get("date") or _iso_from_timestamp(self._started_at))[
-            :10
-        ]
+        focus_date = str(
+            focus.get("date") or _date_from_timestamp(self._started_at, self.checkin_timezone)
+        )[:10]
         if self._goal_id:
             goal = self._habits.get_goal(self._goal_id)
             if goal is not None:
@@ -190,7 +212,7 @@ class PomodoroTimer:
             "remaining_seconds": int(round(remaining)),
             "session_count": self._session_count,
             "goal_id": self._goal_id,
-            "date": _iso_from_timestamp(self._started_at or now)[:10],
+            "date": _date_from_timestamp(self._started_at or now, self.checkin_timezone),
             "pause_count": self._pause_count,
             "interrupt_count": self._interrupt_count,
             "current_focus_session": dict(self._focus_session or {}),

--- a/plugin/plugins/study_companion/pomodoro_timer.py
+++ b/plugin/plugins/study_companion/pomodoro_timer.py
@@ -1,40 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
 from datetime import datetime
 import time
 from typing import Any, Callable
 
+from .models import PomodoroConfig, _range_or_default
 from .study_habit_store import StudyHabitStore
-
-
-@dataclass(slots=True)
-class PomodoroConfig:
-    focus_minutes: int = 25
-    short_break_minutes: int = 5
-    long_break_minutes: int = 15
-    long_break_interval: int = 4
-    allow_skip_break: bool = True
-    allow_custom_duration: bool = True
-
-    def __post_init__(self) -> None:
-        self.focus_minutes = _range_or_default(self.focus_minutes, 1, 120, 25)
-        self.short_break_minutes = _range_or_default(self.short_break_minutes, 1, 30, 5)
-        self.long_break_minutes = _range_or_default(self.long_break_minutes, 1, 60, 15)
-        self.long_break_interval = _range_or_default(self.long_break_interval, 1, 10, 4)
-        self.allow_skip_break = bool(self.allow_skip_break)
-        self.allow_custom_duration = bool(self.allow_custom_duration)
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-def _range_or_default(value: object, minimum: int, maximum: int, default: int) -> int:
-    try:
-        number = int(value)
-    except (TypeError, ValueError, OverflowError):
-        return default
-    return number if minimum <= number <= maximum else default
 
 
 def _iso_from_timestamp(value: float) -> str:
@@ -77,9 +48,16 @@ class PomodoroTimer:
                 focus_minutes, 1, 120, self.config.focus_minutes
             )
         now = self._clock()
+        goal_key = str(goal_id or "")
+        focus_session = self._habits.create_focus_session(
+            goal_id=goal_key,
+            mode="focus",
+            planned_minutes=minutes,
+            started_at=_iso_from_timestamp(now),
+        )
         self._state = "focusing"
         self._mode = "focus"
-        self._goal_id = str(goal_id or "")
+        self._goal_id = goal_key
         self._started_at = now
         self._active_started_at = now
         self._active_elapsed_seconds = 0.0
@@ -88,12 +66,7 @@ class PomodoroTimer:
         self._remaining_on_pause = 0.0
         self._pause_count = 0
         self._interrupt_count = 0
-        self._focus_session = self._habits.create_focus_session(
-            goal_id=self._goal_id,
-            mode="focus",
-            planned_minutes=minutes,
-            started_at=_iso_from_timestamp(now),
-        )
+        self._focus_session = focus_session
         return self.status()
 
     def pause(self) -> dict[str, Any]:

--- a/plugin/plugins/study_companion/pomodoro_timer.py
+++ b/plugin/plugins/study_companion/pomodoro_timer.py
@@ -19,10 +19,12 @@ class PomodoroTimer:
         *,
         config: PomodoroConfig | None = None,
         clock: Callable[[], float] | None = None,
+        auto_derive_from_session: bool = True,
     ) -> None:
         self._habits = habits
         self.config = config or PomodoroConfig()
         self._clock = clock or time.time
+        self.auto_derive_from_session = bool(auto_derive_from_session)
         self._state = "idle"
         self._mode = "focus"
         self._deadline = 0.0
@@ -169,9 +171,10 @@ class PomodoroTimer:
                     delta = 1.0
                 if delta > 0:
                     self._habits.update_goal(self._goal_id, progress_delta=delta)
-        self._habits.record_checkin(
-            date=focus_date, status="checked_in", source="session_derived"
-        )
+        if self.auto_derive_from_session:
+            self._habits.record_checkin(
+                date=focus_date, status="checked_in", source="session_derived"
+            )
 
     def status(self) -> dict[str, Any]:
         now = self._clock()

--- a/plugin/plugins/study_companion/service.py
+++ b/plugin/plugins/study_companion/service.py
@@ -52,8 +52,13 @@ def build_status_payload(
         "checkpoint": json_copy(state.checkpoint),
         "dependencies": json_copy(state.dependency_status),
         "knowledge_summary": knowledge_payload.get("knowledge_summary") or {},
-        "knowledge_quality_summary": knowledge_payload.get("knowledge_quality_summary") or {},
-        "anonymous_knowledge_stats_summary": knowledge_payload.get("anonymous_knowledge_stats_summary") or {},
+        "knowledge_quality_summary": knowledge_payload.get("knowledge_quality_summary")
+        or {},
+        "anonymous_knowledge_stats_summary": knowledge_payload.get(
+            "anonymous_knowledge_stats_summary"
+        )
+        or {},
+        "habit": knowledge_payload.get("habit") or {},
         "review_queue": knowledge_payload.get("review_queue") or [],
         "weak_topics": knowledge_payload.get("weak_topics") or [],
         "mastery_overview": knowledge_payload.get("mastery_overview") or [],
@@ -73,7 +78,9 @@ def build_dependency_status(config: StudyConfig) -> dict[str, Any]:
             "tesseract": tesseract,
             "dxcam": dxcam,
         }.items()
-        if isinstance(status, dict) and status.get("installed") is False and status.get("can_install")
+        if isinstance(status, dict)
+        and status.get("installed") is False
+        and status.get("can_install")
     ]
     return {
         "rapidocr": rapidocr,
@@ -91,7 +98,9 @@ def _inspect_rapidocr(config: StudyConfig) -> dict[str, Any]:
         "install_supported": sys.platform == "win32",
         "installed": installed,
         "can_install": False,
-        "can_download_models": installed and (config.rapidocr_lang_type, config.rapidocr_ocr_version) != ("ch", "PP-OCRv4"),
+        "can_download_models": installed
+        and (config.rapidocr_lang_type, config.rapidocr_ocr_version)
+        != ("ch", "PP-OCRv4"),
         "detected_path": str(Path(origin).resolve().parent) if origin else "",
         "target_dir": config.rapidocr_install_target_dir,
         "engine_type": config.rapidocr_engine_type,
@@ -112,7 +121,9 @@ def _inspect_tesseract(config: StudyConfig) -> dict[str, Any]:
     )
 
 
-def _available_tesseract_languages(detected: Path | None, target_dir: Path | None) -> set[str]:
+def _available_tesseract_languages(
+    detected: Path | None, target_dir: Path | None
+) -> set[str]:
     tessdata_dirs = []
     if detected is not None:
         try:
@@ -124,11 +135,14 @@ def _available_tesseract_languages(detected: Path | None, target_dir: Path | Non
                 timeout=5.0,
                 creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
-            output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+            output = "\n".join(
+                part for part in (completed.stdout, completed.stderr) if part
+            )
             languages = {
                 line.strip()
                 for line in output.splitlines()
-                if line.strip() and not line.lower().startswith("list of available languages")
+                if line.strip()
+                and not line.lower().startswith("list of available languages")
             }
             if completed.returncode != 0:
                 _LOGGER.warning(
@@ -138,9 +152,15 @@ def _available_tesseract_languages(detected: Path | None, target_dir: Path | Non
             if languages:
                 return languages
         except subprocess.TimeoutExpired as exc:
-            _LOGGER.warning("tesseract --list-langs timed out, falling back to filesystem scan: %s", exc)
+            _LOGGER.warning(
+                "tesseract --list-langs timed out, falling back to filesystem scan: %s",
+                exc,
+            )
         except OSError as exc:
-            _LOGGER.warning("tesseract --list-langs failed, falling back to filesystem scan: %s", exc)
+            _LOGGER.warning(
+                "tesseract --list-langs failed, falling back to filesystem scan: %s",
+                exc,
+            )
     if target_dir is not None:
         tessdata_dirs.append(target_dir / "tessdata")
     if detected is not None:
@@ -165,7 +185,9 @@ def _inspect_dxcam() -> dict[str, Any]:
         "detected_path": origin,
         "package_name": "dxcam",
         "target_dir": "current_python_environment",
-        "detail": "installed" if installed else ("missing" if supported else "unsupported_platform"),
+        "detail": "installed"
+        if installed
+        else ("missing" if supported else "unsupported_platform"),
         "runtime_error": "",
     }
 

--- a/plugin/plugins/study_companion/study_habit_store.py
+++ b/plugin/plugins/study_companion/study_habit_store.py
@@ -286,13 +286,14 @@ class StudyHabitStore:
             raise StudyHabitStoreError("daily goal update failed")
         return updated
 
-    def delete_goal(self, goal_id: str) -> None:
+    def delete_goal(self, goal_id: str) -> bool:
         key = str(goal_id or "")
         with self._store._lock:  # noqa: SLF001
             conn = self._conn()
-            conn.execute("DELETE FROM focus_sessions WHERE goal_id = ?", (key,))
-            conn.execute("DELETE FROM daily_goals WHERE id = ?", (key,))
-            conn.commit()
+            with conn:
+                conn.execute("DELETE FROM focus_sessions WHERE goal_id = ?", (key,))
+                cursor = conn.execute("DELETE FROM daily_goals WHERE id = ?", (key,))
+            return cursor.rowcount > 0
 
     def record_checkin(
         self,

--- a/plugin/plugins/study_companion/study_habit_store.py
+++ b/plugin/plugins/study_companion/study_habit_store.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import sqlite3
+import uuid
+from typing import Any
+
+from .store import StudyStore, safe_float, safe_int
+
+
+GOAL_TARGET_TYPES = {"subject", "deck", "passage", "custom"}
+GOAL_STATUSES = {"active", "completed", "cancelled"}
+CHECKIN_STATUSES = {"checked_in", "missed", "makeup"}
+CHECKIN_SOURCES = {"manual", "session_derived"}
+FOCUS_MODES = {"focus", "short_break", "long_break"}
+FOCUS_STATUSES = {"active", "paused", "completed", "cancelled"}
+
+
+class StudyHabitStoreError(RuntimeError):
+    pass
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _date_from_timestamp(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return _now_iso()[:10]
+    return text.split("T", 1)[0][:10]
+
+
+class StudyHabitStore:
+    """Phase 6 local habit tables stored in the user's StudyStore database."""
+
+    def __init__(self, store: StudyStore) -> None:
+        self._store = store
+        self.ensure_tables()
+
+    def _conn(self) -> sqlite3.Connection:
+        try:
+            return self._store._require_conn()  # noqa: SLF001 - plugin-local store extension.
+        except Exception as exc:  # pragma: no cover - defensive wrapper
+            raise StudyHabitStoreError(
+                f"study habit database unavailable: {exc}"
+            ) from exc
+
+    def ensure_tables(self) -> None:
+        with self._store._lock:  # noqa: SLF001 - share StudyStore connection lock.
+            conn = self._conn()
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS daily_goals (
+                    id TEXT PRIMARY KEY,
+                    date TEXT NOT NULL,
+                    target_type TEXT NOT NULL,
+                    target_id TEXT,
+                    subject TEXT,
+                    target_amount REAL NOT NULL,
+                    progress_amount REAL NOT NULL DEFAULT 0,
+                    unit TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS checkins (
+                    id TEXT PRIMARY KEY,
+                    date TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    note TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS focus_sessions (
+                    id TEXT PRIMARY KEY,
+                    goal_id TEXT,
+                    mode TEXT NOT NULL,
+                    planned_minutes REAL NOT NULL,
+                    actual_minutes REAL NOT NULL DEFAULT 0,
+                    started_at TEXT NOT NULL,
+                    ended_at TEXT,
+                    pause_count INTEGER NOT NULL DEFAULT 0,
+                    interrupt_count INTEGER NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_daily_goals_date ON daily_goals(date, status)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_checkins_date ON checkins(date, status)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_focus_sessions_started ON focus_sessions(started_at, status)"
+            )
+            conn.commit()
+
+    @staticmethod
+    def _goal_from_row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": str(row["id"]),
+            "date": str(row["date"]),
+            "target_type": str(row["target_type"]),
+            "target_id": str(row["target_id"] or ""),
+            "subject": str(row["subject"] or ""),
+            "target_amount": safe_float(row["target_amount"], 0.0),
+            "progress_amount": safe_float(row["progress_amount"], 0.0),
+            "unit": str(row["unit"] or ""),
+            "status": str(row["status"] or ""),
+            "created_at": str(row["created_at"] or ""),
+            "updated_at": str(row["updated_at"] or ""),
+        }
+
+    @staticmethod
+    def _checkin_from_row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": str(row["id"]),
+            "date": str(row["date"]),
+            "status": str(row["status"]),
+            "source": str(row["source"]),
+            "note": str(row["note"] or ""),
+            "created_at": str(row["created_at"] or ""),
+        }
+
+    @staticmethod
+    def _focus_from_row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": str(row["id"]),
+            "goal_id": str(row["goal_id"] or ""),
+            "mode": str(row["mode"]),
+            "planned_minutes": safe_float(row["planned_minutes"], 0.0),
+            "actual_minutes": safe_float(row["actual_minutes"], 0.0),
+            "started_at": str(row["started_at"]),
+            "ended_at": str(row["ended_at"] or ""),
+            "date": _date_from_timestamp(str(row["started_at"])),
+            "pause_count": safe_int(row["pause_count"], 0),
+            "interrupt_count": safe_int(row["interrupt_count"], 0),
+            "status": str(row["status"]),
+        }
+
+    def create_goal(
+        self,
+        *,
+        date: str,
+        target_type: str,
+        subject: str,
+        target_amount: float,
+        unit: str,
+        target_id: str = "",
+    ) -> dict[str, Any]:
+        target_type = str(target_type or "custom").strip()
+        if target_type not in GOAL_TARGET_TYPES:
+            target_type = "custom"
+        goal_id = str(uuid.uuid4())
+        now = _now_iso()
+        with self._store._lock:  # noqa: SLF001
+            conn = self._conn()
+            conn.execute(
+                """
+                INSERT INTO daily_goals (
+                    id, date, target_type, target_id, subject, target_amount,
+                    progress_amount, unit, status, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, 0, ?, 'active', ?, ?)
+                """,
+                (
+                    goal_id,
+                    str(date or _now_iso()[:10])[:10],
+                    target_type,
+                    str(target_id or ""),
+                    str(subject or ""),
+                    max(0.0, float(target_amount or 0.0)),
+                    str(unit or "task"),
+                    now,
+                    now,
+                ),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM daily_goals WHERE id = ?", (goal_id,)
+            ).fetchone()
+        goal = self._goal_from_row(row)
+        if goal is None:
+            raise StudyHabitStoreError("failed to create daily goal")
+        return goal
+
+    def get_goal(self, goal_id: str) -> dict[str, Any] | None:
+        with self._store._lock:  # noqa: SLF001
+            row = (
+                self._conn()
+                .execute(
+                    "SELECT * FROM daily_goals WHERE id = ?", (str(goal_id or ""),)
+                )
+                .fetchone()
+            )
+        return self._goal_from_row(row)
+
+    def list_goals(
+        self, *, date: str | None = None, include_cancelled: bool = False
+    ) -> list[dict[str, Any]]:
+        params: list[Any] = []
+        clauses: list[str] = []
+        if date:
+            clauses.append("date = ?")
+            params.append(str(date)[:10])
+        if not include_cancelled:
+            clauses.append("status != 'cancelled'")
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        with self._store._lock:  # noqa: SLF001
+            rows = (
+                self._conn()
+                .execute(
+                    f"""
+                SELECT *
+                FROM daily_goals
+                {where}
+                ORDER BY date DESC, created_at ASC
+                """,
+                    tuple(params),
+                )
+                .fetchall()
+            )
+        return [
+            goal
+            for goal in (self._goal_from_row(row) for row in rows)
+            if goal is not None
+        ]
+
+    def update_goal(
+        self,
+        goal_id: str,
+        *,
+        target_amount: float | None = None,
+        progress_amount: float | None = None,
+        progress_delta: float | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        current = self.get_goal(goal_id)
+        if current is None:
+            raise StudyHabitStoreError("daily goal not found")
+        new_target = (
+            current["target_amount"]
+            if target_amount is None
+            else max(0.0, float(target_amount))
+        )
+        if progress_amount is not None:
+            new_progress = max(0.0, float(progress_amount))
+        else:
+            new_progress = max(
+                0.0, float(current["progress_amount"]) + float(progress_delta or 0.0)
+            )
+        new_status = str(status or current["status"])
+        if new_status not in GOAL_STATUSES:
+            new_status = current["status"]
+        if new_status == "active" and new_target > 0 and new_progress >= new_target:
+            new_status = "completed"
+        with self._store._lock:  # noqa: SLF001
+            conn = self._conn()
+            conn.execute(
+                """
+                UPDATE daily_goals
+                SET target_amount = ?, progress_amount = ?, status = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (new_target, new_progress, new_status, _now_iso(), str(goal_id)),
+            )
+            conn.commit()
+        updated = self.get_goal(goal_id)
+        if updated is None:
+            raise StudyHabitStoreError("daily goal update failed")
+        return updated
+
+    def delete_goal(self, goal_id: str) -> None:
+        key = str(goal_id or "")
+        with self._store._lock:  # noqa: SLF001
+            conn = self._conn()
+            conn.execute("DELETE FROM focus_sessions WHERE goal_id = ?", (key,))
+            conn.execute("DELETE FROM daily_goals WHERE id = ?", (key,))
+            conn.commit()
+
+    def record_checkin(
+        self,
+        *,
+        date: str,
+        status: str = "checked_in",
+        source: str = "manual",
+        note: str = "",
+    ) -> dict[str, Any]:
+        status = status if status in CHECKIN_STATUSES else "checked_in"
+        source = source if source in CHECKIN_SOURCES else "manual"
+        checkin_id = str(uuid.uuid4())
+        with self._store._lock:  # noqa: SLF001
+            conn = self._conn()
+            conn.execute(
+                """
+                INSERT INTO checkins (id, date, status, source, note, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    checkin_id,
+                    str(date or _now_iso()[:10])[:10],
+                    status,
+                    source,
+                    str(note or ""),
+                    _now_iso(),
+                ),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM checkins WHERE id = ?", (checkin_id,)
+            ).fetchone()
+        checkin = self._checkin_from_row(row)
+        if checkin is None:
+            raise StudyHabitStoreError("failed to record checkin")
+        return checkin
+
+    def list_checkins(
+        self, *, date: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        params: list[Any] = []
+        where = ""
+        if date:
+            where = "WHERE date = ?"
+            params.append(str(date)[:10])
+        params.append(max(1, int(limit)))
+        with self._store._lock:  # noqa: SLF001
+            rows = (
+                self._conn()
+                .execute(
+                    f"""
+                SELECT *
+                FROM checkins
+                {where}
+                ORDER BY date DESC, created_at DESC
+                LIMIT ?
+                """,
+                    tuple(params),
+                )
+                .fetchall()
+            )
+        return [
+            item
+            for item in (self._checkin_from_row(row) for row in rows)
+            if item is not None
+        ]
+
+    def checked_dates(self, *, through_date: str, limit: int = 400) -> set[str]:
+        with self._store._lock:  # noqa: SLF001
+            rows = (
+                self._conn()
+                .execute(
+                    """
+                SELECT DISTINCT date
+                FROM checkins
+                WHERE date <= ?
+                  AND status IN ('checked_in', 'makeup')
+                ORDER BY date DESC
+                LIMIT ?
+                """,
+                    (str(through_date)[:10], max(1, int(limit))),
+                )
+                .fetchall()
+            )
+        return {str(row["date"]) for row in rows}
+
+    def create_focus_session(
+        self,
+        *,
+        goal_id: str = "",
+        mode: str,
+        planned_minutes: float,
+        started_at: str,
+    ) -> dict[str, Any]:
+        mode = mode if mode in FOCUS_MODES else "focus"
+        session_id = str(uuid.uuid4())
+        with self._store._lock:  # noqa: SLF001
+            conn = self._conn()
+            conn.execute(
+                """
+                INSERT INTO focus_sessions (
+                    id, goal_id, mode, planned_minutes, actual_minutes,
+                    started_at, ended_at, pause_count, interrupt_count, status
+                )
+                VALUES (?, ?, ?, ?, 0, ?, '', 0, 0, 'active')
+                """,
+                (
+                    session_id,
+                    str(goal_id or ""),
+                    mode,
+                    max(0.0, float(planned_minutes or 0.0)),
+                    str(started_at),
+                ),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM focus_sessions WHERE id = ?", (session_id,)
+            ).fetchone()
+        focus = self._focus_from_row(row)
+        if focus is None:
+            raise StudyHabitStoreError("failed to create focus session")
+        return focus
+
+    def finish_focus_session(
+        self,
+        session_id: str,
+        *,
+        ended_at: str,
+        actual_minutes: float,
+        status: str,
+        pause_count: int = 0,
+        interrupt_count: int = 0,
+    ) -> dict[str, Any]:
+        status = status if status in FOCUS_STATUSES else "completed"
+        with self._store._lock:  # noqa: SLF001
+            conn = self._conn()
+            conn.execute(
+                """
+                UPDATE focus_sessions
+                SET ended_at = ?,
+                    actual_minutes = ?,
+                    pause_count = ?,
+                    interrupt_count = ?,
+                    status = ?
+                WHERE id = ?
+                """,
+                (
+                    str(ended_at),
+                    max(0.0, float(actual_minutes or 0.0)),
+                    max(0, int(pause_count or 0)),
+                    max(0, int(interrupt_count or 0)),
+                    status,
+                    str(session_id or ""),
+                ),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT * FROM focus_sessions WHERE id = ?", (str(session_id or ""),)
+            ).fetchone()
+        focus = self._focus_from_row(row)
+        if focus is None:
+            raise StudyHabitStoreError("focus session not found")
+        return focus
+
+    def list_focus_sessions(
+        self, *, date: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        params: list[Any] = []
+        clauses = []
+        if date:
+            clauses.append("substr(started_at, 1, 10) = ?")
+            params.append(str(date)[:10])
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(max(1, int(limit)))
+        with self._store._lock:  # noqa: SLF001
+            rows = (
+                self._conn()
+                .execute(
+                    f"""
+                SELECT *
+                FROM focus_sessions
+                {where}
+                ORDER BY started_at DESC
+                LIMIT ?
+                """,
+                    tuple(params),
+                )
+                .fetchall()
+            )
+        return [
+            item
+            for item in (self._focus_from_row(row) for row in rows)
+            if item is not None
+        ]
+
+    def focus_minutes_for_date(self, date: str) -> float:
+        with self._store._lock:  # noqa: SLF001
+            row = (
+                self._conn()
+                .execute(
+                    """
+                SELECT COALESCE(SUM(actual_minutes), 0) AS total
+                FROM focus_sessions
+                WHERE substr(started_at, 1, 10) = ?
+                  AND mode = 'focus'
+                  AND status = 'completed'
+                """,
+                    (str(date)[:10],),
+                )
+                .fetchone()
+            )
+        return safe_float(row["total"] if row is not None else 0.0, 0.0)

--- a/plugin/plugins/study_companion/study_habit_store.py
+++ b/plugin/plugins/study_companion/study_habit_store.py
@@ -361,20 +361,25 @@ class StudyHabitStore:
             if item is not None
         ]
 
-    def checked_dates(self, *, through_date: str, limit: int = 400) -> set[str]:
+    def checked_dates(self, *, through_date: str, limit: int | None = None) -> set[str]:
+        limit_clause = ""
+        params: list[Any] = [str(through_date)[:10]]
+        if limit is not None:
+            limit_clause = "LIMIT ?"
+            params.append(max(1, int(limit)))
         with self._store._lock:  # noqa: SLF001
             rows = (
                 self._conn()
                 .execute(
-                    """
+                    f"""
                 SELECT DISTINCT date
                 FROM checkins
                 WHERE date <= ?
                   AND status IN ('checked_in', 'makeup')
                 ORDER BY date DESC
-                LIMIT ?
+                {limit_clause}
                 """,
-                    (str(through_date)[:10], max(1, int(limit))),
+                    tuple(params),
                 )
                 .fetchall()
             )

--- a/plugin/plugins/study_companion/supervision.py
+++ b/plugin/plugins/study_companion/supervision.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import time
+from typing import Any, Callable
+
+
+@dataclass(slots=True)
+class SupervisionConfig:
+    enabled: bool = True
+    remind_interval_minutes: int = 10
+    inactivity_timeout_minutes: int = 5
+    allow_disable_by_chat: bool = True
+
+    def __post_init__(self) -> None:
+        self.enabled = bool(self.enabled)
+        self.remind_interval_minutes = _range_or_default(
+            self.remind_interval_minutes, 1, 60, 10
+        )
+        self.inactivity_timeout_minutes = _range_or_default(
+            self.inactivity_timeout_minutes, 1, 30, 5
+        )
+        self.allow_disable_by_chat = bool(self.allow_disable_by_chat)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _range_or_default(value: object, minimum: int, maximum: int, default: int) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return number if minimum <= number <= maximum else default
+
+
+class SupervisionController:
+    def __init__(
+        self,
+        config: SupervisionConfig | None = None,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.config = config or SupervisionConfig()
+        self._clock = clock or time.time
+        self._enabled = bool(self.config.enabled)
+        self._focus_active = False
+        self._last_reminder_at = 0.0
+        self._last_activity_at = 0.0
+        self._last_ocr_text = ""
+        self._sensor_available = False
+        self._reminder_level = "idle"
+
+    def on_focus_start(
+        self,
+        *,
+        goal: dict[str, Any] | None,
+        planned_minutes: float,
+        now: float | None = None,
+    ) -> dict[str, Any]:
+        current = self._clock() if now is None else float(now)
+        self._focus_active = True
+        self._last_reminder_at = current
+        self._last_activity_at = current
+        self._reminder_level = "start"
+        return {
+            "enabled": self._enabled,
+            "reminder_level": self._reminder_level,
+            "message": "focus_started",
+            "goal": dict(goal or {}),
+            "planned_minutes": planned_minutes,
+        }
+
+    def on_focus_end(self, *, now: float | None = None) -> dict[str, Any]:
+        self._focus_active = False
+        self._reminder_level = "end"
+        return self.status(now=now)
+
+    def set_enabled(self, enabled: bool) -> dict[str, Any]:
+        self._enabled = bool(enabled)
+        if not self._enabled:
+            self._reminder_level = "disabled"
+        return self.status()
+
+    def due_reminder(self, *, now: float | None = None) -> dict[str, Any]:
+        current = self._clock() if now is None else float(now)
+        due = (
+            self._enabled
+            and self._focus_active
+            and current - self._last_reminder_at
+            >= self.config.remind_interval_minutes * 60
+        )
+        if due:
+            self._last_reminder_at = current
+            self._reminder_level = "low_frequency"
+        return {"due": bool(due), **self.status(now=current)}
+
+    def observe_activity(
+        self,
+        *,
+        ocr_text: str,
+        sensor_available: bool,
+        now: float | None = None,
+    ) -> dict[str, Any]:
+        current = self._clock() if now is None else float(now)
+        self._sensor_available = bool(sensor_available)
+        if not self._sensor_available:
+            return {
+                **self.status(now=current),
+                "inactivity_detected": False,
+                "suggested_action": "",
+            }
+        text = str(ocr_text or "")
+        if text != self._last_ocr_text:
+            self._last_ocr_text = text
+            self._last_activity_at = current
+            return {
+                **self.status(now=current),
+                "inactivity_detected": False,
+                "suggested_action": "",
+            }
+        inactive = (
+            self._enabled
+            and self._focus_active
+            and current - self._last_activity_at
+            >= self.config.inactivity_timeout_minutes * 60
+        )
+        if inactive:
+            self._reminder_level = "inactivity"
+        return {
+            **self.status(now=current),
+            "inactivity_detected": bool(inactive),
+            "suggested_action": "pause_or_switch" if inactive else "",
+        }
+
+    def status(self, *, now: float | None = None) -> dict[str, Any]:
+        return {
+            "enabled": self._enabled,
+            "focus_active": self._focus_active,
+            "sensor_available": self._sensor_available,
+            "reminder_level": self._reminder_level,
+            "last_activity_at": self._last_activity_at,
+            "last_reminder_at": self._last_reminder_at,
+            "config": self.config.to_dict(),
+        }

--- a/plugin/plugins/study_companion/supervision.py
+++ b/plugin/plugins/study_companion/supervision.py
@@ -86,6 +86,8 @@ class SupervisionController:
         if text != self._last_ocr_text:
             self._last_ocr_text = text
             self._last_activity_at = current
+            if self._reminder_level == "inactivity":
+                self._reminder_level = "active"
             return {
                 **self.status(now=current),
                 "inactivity_detected": False,

--- a/plugin/plugins/study_companion/supervision.py
+++ b/plugin/plugins/study_companion/supervision.py
@@ -1,37 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
 import time
 from typing import Any, Callable
 
-
-@dataclass(slots=True)
-class SupervisionConfig:
-    enabled: bool = True
-    remind_interval_minutes: int = 10
-    inactivity_timeout_minutes: int = 5
-    allow_disable_by_chat: bool = True
-
-    def __post_init__(self) -> None:
-        self.enabled = bool(self.enabled)
-        self.remind_interval_minutes = _range_or_default(
-            self.remind_interval_minutes, 1, 60, 10
-        )
-        self.inactivity_timeout_minutes = _range_or_default(
-            self.inactivity_timeout_minutes, 1, 30, 5
-        )
-        self.allow_disable_by_chat = bool(self.allow_disable_by_chat)
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-def _range_or_default(value: object, minimum: int, maximum: int, default: int) -> int:
-    try:
-        number = int(value)
-    except (TypeError, ValueError, OverflowError):
-        return default
-    return number if minimum <= number <= maximum else default
+from .models import SupervisionConfig
 
 
 class SupervisionController:

--- a/plugin/plugins/study_companion/surfaces/daily_goal_editor.tsx
+++ b/plugin/plugins/study_companion/surfaces/daily_goal_editor.tsx
@@ -1,36 +1,7 @@
 import { useEffect, useState } from '@neko/plugin-ui';
 import type { PluginSurfaceProps } from '@neko/plugin-ui';
 
-async function readJsonResponse(response: Response, label: string) {
-  if (!response.ok) throw new Error(`${label} failed: HTTP ${response.status}`);
-  return await response.json();
-}
-
-async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
-  const created = await readJsonResponse(await fetch('/runs', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
-  }), 'Run create');
-  const runId = created.run_id || created.id;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
-    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
-    if (run.status === 'succeeded') {
-      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
-      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
-      if (!item) throw new Error('Run export missing JSON result');
-      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
-      return item.json.data || {};
-    }
-  }
-  throw new Error('Plugin call timed out');
-}
-
-function text(props: PluginSurfaceProps, key: string, fallback: string) {
-  const value = props.t?.(key);
-  return value && value !== key ? value : fallback;
-}
+import { callPlugin, formatError, text } from './study_surface_utils';
 
 export default function DailyGoalEditor(props: PluginSurfaceProps) {
   const [goals, setGoals] = useState<any[]>([]);
@@ -49,7 +20,7 @@ export default function DailyGoalEditor(props: PluginSurfaceProps) {
   }
 
   useEffect(() => {
-    refresh().catch((err) => setError(err instanceof Error ? err.message : String(err)));
+    refresh().catch((err) => setError(formatError(err)));
   }, []);
 
   return (

--- a/plugin/plugins/study_companion/surfaces/daily_goal_editor.tsx
+++ b/plugin/plugins/study_companion/surfaces/daily_goal_editor.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from '@neko/plugin-ui';
+import type { PluginSurfaceProps } from '@neko/plugin-ui';
+
+async function readJsonResponse(response: Response, label: string) {
+  if (!response.ok) throw new Error(`${label} failed: HTTP ${response.status}`);
+  return await response.json();
+}
+
+async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
+  const created = await readJsonResponse(await fetch('/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
+  }), 'Run create');
+  const runId = created.run_id || created.id;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
+    if (run.status === 'succeeded') {
+      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
+      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
+      if (!item) throw new Error('Run export missing JSON result');
+      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
+      return item.json.data || {};
+    }
+  }
+  throw new Error('Plugin call timed out');
+}
+
+function text(props: PluginSurfaceProps, key: string, fallback: string) {
+  const value = props.t?.(key);
+  return value && value !== key ? value : fallback;
+}
+
+export default function DailyGoalEditor(props: PluginSurfaceProps) {
+  const [goals, setGoals] = useState<any[]>([]);
+  const [subject, setSubject] = useState('study');
+  const [targetAmount, setTargetAmount] = useState(25);
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    const payload = await callPlugin('study_goals');
+    setGoals(Array.isArray(payload.goals) ? payload.goals : []);
+  }
+
+  async function createGoal() {
+    await callPlugin('study_goal_create', { target_type: 'subject', subject, target_amount: targetAmount, unit: 'minute' });
+    await refresh();
+  }
+
+  useEffect(() => {
+    refresh().catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, []);
+
+  return (
+    <div className="study-panel">
+      <header className="study-panel__header">
+        <div>
+          <h1>{text(props, 'ui.surface.daily_goal_editor', 'Daily Goals')}</h1>
+          <span>{goals.length}</span>
+        </div>
+      </header>
+      {error ? <pre>{error}</pre> : null}
+      <section className="study-panel__state">
+        <label>
+          <span>{text(props, 'ui.label.subject', 'Subject')}</span>
+          <input value={subject} onChange={(event: any) => setSubject(event.target.value)} />
+        </label>
+        <label>
+          <span>{text(props, 'ui.label.target', 'Target')}</span>
+          <input type="number" min="1" value={targetAmount} onChange={(event: any) => setTargetAmount(Number(event.target.value) || 1)} />
+        </label>
+        <button type="button" onClick={createGoal}>{text(props, 'ui.button.create_goal', 'Create')}</button>
+      </section>
+      <div className="study-panel__actions">
+        {goals.map((goal) => (
+          <button key={goal.id} type="button" onClick={() => callPlugin('study_goal_delete', { goal_id: goal.id }).then(refresh)}>
+            {goal.subject || goal.target_type}: {goal.progress_amount}/{goal.target_amount} {goal.unit}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/plugin/plugins/study_companion/surfaces/daily_goal_editor.tsx
+++ b/plugin/plugins/study_companion/surfaces/daily_goal_editor.tsx
@@ -15,8 +15,23 @@ export default function DailyGoalEditor(props: PluginSurfaceProps) {
   }
 
   async function createGoal() {
-    await callPlugin('study_goal_create', { target_type: 'subject', subject, target_amount: targetAmount, unit: 'minute' });
-    await refresh();
+    try {
+      await callPlugin('study_goal_create', { target_type: 'subject', subject, target_amount: targetAmount, unit: 'minute' });
+      await refresh();
+      setError('');
+    } catch (err) {
+      setError(formatError(err));
+    }
+  }
+
+  async function deleteGoal(goalId: string) {
+    try {
+      await callPlugin('study_goal_delete', { goal_id: goalId });
+      await refresh();
+      setError('');
+    } catch (err) {
+      setError(formatError(err));
+    }
   }
 
   useEffect(() => {
@@ -45,7 +60,7 @@ export default function DailyGoalEditor(props: PluginSurfaceProps) {
       </section>
       <div className="study-panel__actions">
         {goals.map((goal) => (
-          <button key={goal.id} type="button" onClick={() => callPlugin('study_goal_delete', { goal_id: goal.id }).then(refresh)}>
+          <button key={goal.id} type="button" onClick={() => deleteGoal(goal.id)}>
             {goal.subject || goal.target_type}: {goal.progress_amount}/{goal.target_amount} {goal.unit}
           </button>
         ))}

--- a/plugin/plugins/study_companion/surfaces/habit_dashboard.tsx
+++ b/plugin/plugins/study_companion/surfaces/habit_dashboard.tsx
@@ -1,40 +1,7 @@
 import { useEffect, useState } from '@neko/plugin-ui';
 import type { PluginSurfaceProps } from '@neko/plugin-ui';
 
-async function readJsonResponse(response: Response, label: string) {
-  if (!response.ok) {
-    throw new Error(`${label} failed: HTTP ${response.status}`);
-  }
-  return await response.json();
-}
-
-async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
-  const createResp = await fetch('/runs', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
-  });
-  const created = await readJsonResponse(createResp, 'Run create');
-  const runId = created.run_id || created.id;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
-    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
-    if (run.status === 'succeeded') {
-      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
-      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
-      if (!item) throw new Error('Run export missing JSON result');
-      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
-      return item.json.data || {};
-    }
-    if (['failed', 'canceled', 'timeout'].includes(run.status)) throw new Error(run.status);
-  }
-  throw new Error('Plugin call timed out');
-}
-
-function text(props: PluginSurfaceProps, key: string, fallback: string) {
-  const value = props.t?.(key);
-  return value && value !== key ? value : fallback;
-}
+import { callPlugin, formatError, text } from './study_surface_utils';
 
 export default function HabitDashboard(props: PluginSurfaceProps) {
   const [payload, setPayload] = useState<any>({});
@@ -52,8 +19,8 @@ export default function HabitDashboard(props: PluginSurfaceProps) {
   }
 
   useEffect(() => {
-    refresh().catch((err) => setError(err instanceof Error ? err.message : String(err)));
-    const id = window.setInterval(() => refresh().catch(() => undefined), 5000);
+    refresh().catch((err) => setError(formatError(err)));
+    const id = window.setInterval(() => refresh().catch((err) => setError(formatError(err))), 5000);
     return () => window.clearInterval(id);
   }, []);
 

--- a/plugin/plugins/study_companion/surfaces/habit_dashboard.tsx
+++ b/plugin/plugins/study_companion/surfaces/habit_dashboard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from '@neko/plugin-ui';
+import type { PluginSurfaceProps } from '@neko/plugin-ui';
+
+async function readJsonResponse(response: Response, label: string) {
+  if (!response.ok) {
+    throw new Error(`${label} failed: HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
+  const createResp = await fetch('/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
+  });
+  const created = await readJsonResponse(createResp, 'Run create');
+  const runId = created.run_id || created.id;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
+    if (run.status === 'succeeded') {
+      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
+      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
+      if (!item) throw new Error('Run export missing JSON result');
+      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
+      return item.json.data || {};
+    }
+    if (['failed', 'canceled', 'timeout'].includes(run.status)) throw new Error(run.status);
+  }
+  throw new Error('Plugin call timed out');
+}
+
+function text(props: PluginSurfaceProps, key: string, fallback: string) {
+  const value = props.t?.(key);
+  return value && value !== key ? value : fallback;
+}
+
+export default function HabitDashboard(props: PluginSurfaceProps) {
+  const [payload, setPayload] = useState<any>({});
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    const [status, goals, checkin, summary, supervision] = await Promise.all([
+      callPlugin('study_pomodoro_status'),
+      callPlugin('study_goals'),
+      callPlugin('study_checkin_status'),
+      callPlugin('study_session_summary'),
+      callPlugin('study_supervision_status'),
+    ]);
+    setPayload({ status, goals: goals.goals || [], checkin, summary, supervision });
+  }
+
+  useEffect(() => {
+    refresh().catch((err) => setError(err instanceof Error ? err.message : String(err)));
+    const id = window.setInterval(() => refresh().catch(() => undefined), 5000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const goals = Array.isArray(payload.goals) ? payload.goals : [];
+  return (
+    <div className="study-panel">
+      <header className="study-panel__header">
+        <div>
+          <h1>{text(props, 'ui.surface.habit_dashboard', 'Habit Dashboard')}</h1>
+          <span>{payload.status?.state || 'idle'}</span>
+        </div>
+      </header>
+      {error ? <pre>{error}</pre> : null}
+      <section className="study-panel__state">
+        <div><span>{text(props, 'ui.label.streak', 'Streak')}</span><strong>{payload.checkin?.streak_days || 0}</strong></div>
+        <div><span>{text(props, 'ui.label.focus_minutes', 'Focus')}</span><strong>{payload.summary?.total_focus_minutes || 0}</strong></div>
+        <div><span>{text(props, 'ui.label.goals', 'Goals')}</span><strong>{goals.length}</strong></div>
+      </section>
+      <div className="study-panel__actions">
+        <button type="button" onClick={() => callPlugin('study_checkin_manual').then(refresh)}>
+          {text(props, 'ui.button.checkin', 'Check in')}
+        </button>
+        <button type="button" onClick={() => callPlugin('study_supervision_toggle', { enabled: !payload.supervision?.enabled }).then(refresh)}>
+          {payload.supervision?.enabled ? text(props, 'ui.button.quiet', 'Quiet') : text(props, 'ui.button.supervise', 'Supervise')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/plugin/plugins/study_companion/surfaces/habit_dashboard.tsx
+++ b/plugin/plugins/study_companion/surfaces/habit_dashboard.tsx
@@ -18,10 +18,37 @@ export default function HabitDashboard(props: PluginSurfaceProps) {
     setPayload({ status, goals: goals.goals || [], checkin, summary, supervision });
   }
 
+  async function act(entryId: string, args: Record<string, unknown> = {}) {
+    try {
+      await callPlugin(entryId, args);
+      await refresh();
+      setError('');
+    } catch (err) {
+      setError(formatError(err));
+    }
+  }
+
   useEffect(() => {
-    refresh().catch((err) => setError(formatError(err)));
-    const id = window.setInterval(() => refresh().catch((err) => setError(formatError(err))), 5000);
-    return () => window.clearInterval(id);
+    let disposed = false;
+    let inFlight = false;
+    const tick = async () => {
+      if (disposed || inFlight) return;
+      inFlight = true;
+      try {
+        await refresh();
+        if (!disposed) setError('');
+      } catch (err) {
+        if (!disposed) setError(formatError(err));
+      } finally {
+        inFlight = false;
+      }
+    };
+    void tick();
+    const id = window.setInterval(() => void tick(), 5000);
+    return () => {
+      disposed = true;
+      window.clearInterval(id);
+    };
   }, []);
 
   const goals = Array.isArray(payload.goals) ? payload.goals : [];
@@ -40,10 +67,10 @@ export default function HabitDashboard(props: PluginSurfaceProps) {
         <div><span>{text(props, 'ui.label.goals', 'Goals')}</span><strong>{goals.length}</strong></div>
       </section>
       <div className="study-panel__actions">
-        <button type="button" onClick={() => callPlugin('study_checkin_manual').then(refresh)}>
+        <button type="button" onClick={() => act('study_checkin_manual')}>
           {text(props, 'ui.button.checkin', 'Check in')}
         </button>
-        <button type="button" onClick={() => callPlugin('study_supervision_toggle', { enabled: !payload.supervision?.enabled }).then(refresh)}>
+        <button type="button" onClick={() => act('study_supervision_toggle', { enabled: !payload.supervision?.enabled })}>
           {payload.supervision?.enabled ? text(props, 'ui.button.quiet', 'Quiet') : text(props, 'ui.button.supervise', 'Supervise')}
         </button>
       </div>

--- a/plugin/plugins/study_companion/surfaces/pomodoro_panel.tsx
+++ b/plugin/plugins/study_companion/surfaces/pomodoro_panel.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from '@neko/plugin-ui';
+import type { PluginSurfaceProps } from '@neko/plugin-ui';
+
+async function readJsonResponse(response: Response, label: string) {
+  if (!response.ok) throw new Error(`${label} failed: HTTP ${response.status}`);
+  return await response.json();
+}
+
+async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
+  const created = await readJsonResponse(await fetch('/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
+  }), 'Run create');
+  const runId = created.run_id || created.id;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
+    if (run.status === 'succeeded') {
+      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
+      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
+      if (!item) throw new Error('Run export missing JSON result');
+      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
+      return item.json.data || {};
+    }
+  }
+  throw new Error('Plugin call timed out');
+}
+
+function text(props: PluginSurfaceProps, key: string, fallback: string) {
+  const value = props.t?.(key);
+  return value && value !== key ? value : fallback;
+}
+
+function formatSeconds(value: number) {
+  const seconds = Math.max(0, Number(value) || 0);
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, '0')}`;
+}
+
+export default function PomodoroPanel(props: PluginSurfaceProps) {
+  const [status, setStatus] = useState<any>({});
+  const [error, setError] = useState('');
+
+  async function refresh() {
+    setStatus(await callPlugin('study_pomodoro_status'));
+  }
+  async function act(entryId: string) {
+    setStatus(await callPlugin(entryId));
+  }
+
+  useEffect(() => {
+    refresh().catch((err) => setError(err instanceof Error ? err.message : String(err)));
+    const id = window.setInterval(() => refresh().catch(() => undefined), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  return (
+    <div className="study-panel">
+      <header className="study-panel__header">
+        <div>
+          <h1>{text(props, 'ui.surface.pomodoro_panel', 'Pomodoro')}</h1>
+          <span>{status.state || 'idle'}</span>
+        </div>
+      </header>
+      {error ? <pre>{error}</pre> : null}
+      <section className="study-panel__state">
+        <div><span>{text(props, 'ui.label.remaining', 'Remaining')}</span><strong>{formatSeconds(status.remaining_seconds)}</strong></div>
+        <div><span>{text(props, 'ui.label.sessions', 'Sessions')}</span><strong>{status.session_count || 0}</strong></div>
+        <div><span>{text(props, 'ui.label.mode', 'Mode')}</span><strong>{status.mode || 'focus'}</strong></div>
+      </section>
+      <div className="study-panel__actions">
+        <button type="button" onClick={() => act('study_pomodoro_start')}>{text(props, 'ui.button.start', 'Start')}</button>
+        <button type="button" onClick={() => act('study_pomodoro_pause')}>{text(props, 'ui.button.pause', 'Pause')}</button>
+        <button type="button" onClick={() => act('study_pomodoro_resume')}>{text(props, 'ui.button.resume', 'Resume')}</button>
+        <button type="button" onClick={() => act('study_pomodoro_stop')}>{text(props, 'ui.button.stop', 'Stop')}</button>
+        <button type="button" onClick={() => act('study_pomodoro_skip_break')}>{text(props, 'ui.button.skip_break', 'Skip break')}</button>
+      </div>
+    </div>
+  );
+}

--- a/plugin/plugins/study_companion/surfaces/pomodoro_panel.tsx
+++ b/plugin/plugins/study_companion/surfaces/pomodoro_panel.tsx
@@ -17,13 +17,32 @@ export default function PomodoroPanel(props: PluginSurfaceProps) {
     setStatus(await callPlugin('study_pomodoro_status'));
   }
   async function act(entryId: string) {
-    setStatus(await callPlugin(entryId));
+    try {
+      setStatus(await callPlugin(entryId));
+      setError('');
+    } catch (err) {
+      setError(formatError(err));
+    }
   }
 
   useEffect(() => {
-    refresh().catch((err) => setError(formatError(err)));
-    const id = window.setInterval(() => refresh().catch((err) => setError(formatError(err))), 1000);
-    return () => window.clearInterval(id);
+    let disposed = false;
+    let timeoutId = 0;
+    const tick = async () => {
+      try {
+        await refresh();
+        if (!disposed) setError('');
+      } catch (err) {
+        if (!disposed) setError(formatError(err));
+      } finally {
+        if (!disposed) timeoutId = window.setTimeout(() => void tick(), 1000);
+      }
+    };
+    void tick();
+    return () => {
+      disposed = true;
+      window.clearTimeout(timeoutId);
+    };
   }, []);
 
   return (

--- a/plugin/plugins/study_companion/surfaces/pomodoro_panel.tsx
+++ b/plugin/plugins/study_companion/surfaces/pomodoro_panel.tsx
@@ -1,36 +1,7 @@
 import { useEffect, useState } from '@neko/plugin-ui';
 import type { PluginSurfaceProps } from '@neko/plugin-ui';
 
-async function readJsonResponse(response: Response, label: string) {
-  if (!response.ok) throw new Error(`${label} failed: HTTP ${response.status}`);
-  return await response.json();
-}
-
-async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
-  const created = await readJsonResponse(await fetch('/runs', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
-  }), 'Run create');
-  const runId = created.run_id || created.id;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
-    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
-    if (run.status === 'succeeded') {
-      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
-      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
-      if (!item) throw new Error('Run export missing JSON result');
-      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
-      return item.json.data || {};
-    }
-  }
-  throw new Error('Plugin call timed out');
-}
-
-function text(props: PluginSurfaceProps, key: string, fallback: string) {
-  const value = props.t?.(key);
-  return value && value !== key ? value : fallback;
-}
+import { callPlugin, formatError, text } from './study_surface_utils';
 
 function formatSeconds(value: number) {
   const seconds = Math.max(0, Number(value) || 0);
@@ -50,8 +21,8 @@ export default function PomodoroPanel(props: PluginSurfaceProps) {
   }
 
   useEffect(() => {
-    refresh().catch((err) => setError(err instanceof Error ? err.message : String(err)));
-    const id = window.setInterval(() => refresh().catch(() => undefined), 1000);
+    refresh().catch((err) => setError(formatError(err)));
+    const id = window.setInterval(() => refresh().catch((err) => setError(formatError(err))), 1000);
     return () => window.clearInterval(id);
   }, []);
 

--- a/plugin/plugins/study_companion/surfaces/session_summary.tsx
+++ b/plugin/plugins/study_companion/surfaces/session_summary.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from '@neko/plugin-ui';
+import type { PluginSurfaceProps } from '@neko/plugin-ui';
+
+async function readJsonResponse(response: Response, label: string) {
+  if (!response.ok) throw new Error(`${label} failed: HTTP ${response.status}`);
+  return await response.json();
+}
+
+async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
+  const created = await readJsonResponse(await fetch('/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
+  }), 'Run create');
+  const runId = created.run_id || created.id;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
+    if (run.status === 'succeeded') {
+      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
+      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
+      if (!item) throw new Error('Run export missing JSON result');
+      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
+      return item.json.data || {};
+    }
+  }
+  throw new Error('Plugin call timed out');
+}
+
+function text(props: PluginSurfaceProps, key: string, fallback: string) {
+  const value = props.t?.(key);
+  return value && value !== key ? value : fallback;
+}
+
+export default function SessionSummary(props: PluginSurfaceProps) {
+  const [summary, setSummary] = useState<any>({});
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    callPlugin('study_session_summary')
+      .then(setSummary)
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, []);
+
+  const completed = Array.isArray(summary.completed_goals) ? summary.completed_goals : [];
+  const incomplete = Array.isArray(summary.incomplete_goals) ? summary.incomplete_goals : [];
+  return (
+    <div className="study-panel">
+      <header className="study-panel__header">
+        <div>
+          <h1>{text(props, 'ui.surface.session_summary', 'Session Summary')}</h1>
+          <span>{summary.date || ''}</span>
+        </div>
+      </header>
+      {error ? <pre>{error}</pre> : null}
+      <section className="study-panel__state">
+        <div><span>{text(props, 'ui.label.focus_minutes', 'Focus')}</span><strong>{summary.total_focus_minutes || 0}</strong></div>
+        <div><span>{text(props, 'ui.label.completed', 'Completed')}</span><strong>{completed.length}</strong></div>
+        <div><span>{text(props, 'ui.label.incomplete', 'Open')}</span><strong>{incomplete.length}</strong></div>
+      </section>
+      <pre>{[...completed, ...incomplete].map((goal: any) => `${goal.subject || goal.target_type}: ${goal.progress_amount}/${goal.target_amount} ${goal.unit}`).join('\n')}</pre>
+    </div>
+  );
+}

--- a/plugin/plugins/study_companion/surfaces/session_summary.tsx
+++ b/plugin/plugins/study_companion/surfaces/session_summary.tsx
@@ -1,36 +1,7 @@
 import { useEffect, useState } from '@neko/plugin-ui';
 import type { PluginSurfaceProps } from '@neko/plugin-ui';
 
-async function readJsonResponse(response: Response, label: string) {
-  if (!response.ok) throw new Error(`${label} failed: HTTP ${response.status}`);
-  return await response.json();
-}
-
-async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
-  const created = await readJsonResponse(await fetch('/runs', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
-  }), 'Run create');
-  const runId = created.run_id || created.id;
-  for (let attempt = 0; attempt < 30; attempt += 1) {
-    await new Promise((resolve) => window.setTimeout(resolve, 250));
-    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
-    if (run.status === 'succeeded') {
-      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
-      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
-      if (!item) throw new Error('Run export missing JSON result');
-      if (item.json.success === false || item.json.error) throw new Error(item.json.error?.message || 'Plugin call failed');
-      return item.json.data || {};
-    }
-  }
-  throw new Error('Plugin call timed out');
-}
-
-function text(props: PluginSurfaceProps, key: string, fallback: string) {
-  const value = props.t?.(key);
-  return value && value !== key ? value : fallback;
-}
+import { callPlugin, formatError, text } from './study_surface_utils';
 
 export default function SessionSummary(props: PluginSurfaceProps) {
   const [summary, setSummary] = useState<any>({});
@@ -39,7 +10,7 @@ export default function SessionSummary(props: PluginSurfaceProps) {
   useEffect(() => {
     callPlugin('study_session_summary')
       .then(setSummary)
-      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+      .catch((err) => setError(formatError(err)));
   }, []);
 
   const completed = Array.isArray(summary.completed_goals) ? summary.completed_goals : [];

--- a/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
+++ b/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
@@ -31,8 +31,8 @@ export async function callPlugin(entryId: string, args: Record<string, unknown> 
       }
       return item.json.data || {};
     }
-    if (['failed', 'canceled', 'timeout'].includes(run.status)) {
-      throw new Error(run.error?.message || run.message || run.status);
+    if (['failed', 'error', 'canceled', 'cancelled', 'timeout', 'timed_out'].includes(run.status)) {
+      throw new Error(run.error?.message || run.error_message || run.message || run.status);
     }
   }
   throw new Error('Plugin call timed out');

--- a/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
+++ b/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
@@ -7,6 +7,26 @@ export async function readJsonResponse(response: Response, label: string) {
   return await response.json();
 }
 
+function pluginErrorMessage(error: unknown) {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message) {
+      return message;
+    }
+  }
+  if (error !== undefined && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return 'Plugin call failed';
+}
+
 export async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
   const created = await readJsonResponse(await fetch('/runs', {
     method: 'POST',
@@ -27,7 +47,7 @@ export async function callPlugin(entryId: string, args: Record<string, unknown> 
         throw new Error('Run export missing JSON result');
       }
       if (item.json.success === false || item.json.error) {
-        throw new Error(item.json.error?.message || 'Plugin call failed');
+        throw new Error(pluginErrorMessage(item.json.error));
       }
       return item.json.data || {};
     }

--- a/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
+++ b/plugin/plugins/study_companion/surfaces/study_surface_utils.ts
@@ -1,0 +1,48 @@
+import type { PluginSurfaceProps } from '@neko/plugin-ui';
+
+export async function readJsonResponse(response: Response, label: string) {
+  if (!response.ok) {
+    throw new Error(`${label} failed: HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+export async function callPlugin(entryId: string, args: Record<string, unknown> = {}) {
+  const created = await readJsonResponse(await fetch('/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ plugin_id: 'study_companion', entry_id: entryId, args }),
+  }), 'Run create');
+  const runId = created.run_id || created.id;
+  if (!runId) {
+    throw new Error('Run id missing');
+  }
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+    const run = await readJsonResponse(await fetch(`/runs/${runId}`), 'Run poll');
+    if (run.status === 'succeeded') {
+      const exported = await readJsonResponse(await fetch(`/runs/${runId}/export`), 'Run export');
+      const item = (exported.items || []).find((candidate: any) => candidate.type === 'json' && candidate.json);
+      if (!item) {
+        throw new Error('Run export missing JSON result');
+      }
+      if (item.json.success === false || item.json.error) {
+        throw new Error(item.json.error?.message || 'Plugin call failed');
+      }
+      return item.json.data || {};
+    }
+    if (['failed', 'canceled', 'timeout'].includes(run.status)) {
+      throw new Error(run.error?.message || run.message || run.status);
+    }
+  }
+  throw new Error('Plugin call timed out');
+}
+
+export function text(props: PluginSurfaceProps, key: string, fallback: string) {
+  const value = props.t?.(key);
+  return value && value !== key ? value : fallback;
+}
+
+export function formatError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/plugin/plugins/study_companion/ui_api.py
+++ b/plugin/plugins/study_companion/ui_api.py
@@ -58,13 +58,20 @@ def build_knowledge_map_payload(
             prereq_id = _topic_ref_id(prereq)
             if prereq_id:
                 edge = {"from": prereq_id, "to": topic_id, "relation": "prerequisite"}
-                if isinstance(prereq, dict) and prereq.get("required_mastery") is not None:
+                if (
+                    isinstance(prereq, dict)
+                    and prereq.get("required_mastery") is not None
+                ):
                     edge["required_mastery"] = prereq.get("required_mastery")
                 edges.append(edge)
         for related in topic.get("related") or []:
             related_id = _topic_ref_id(related)
             if related_id:
-                relation = str(related.get("relation") or "related") if isinstance(related, dict) else "related"
+                relation = (
+                    str(related.get("relation") or "related")
+                    if isinstance(related, dict)
+                    else "related"
+                )
                 edges.append({"from": topic_id, "to": related_id, "relation": relation})
     return {
         "nodes": nodes,
@@ -81,7 +88,9 @@ def build_knowledge_map_payload(
     }
 
 
-def build_contribution_settings_payload(*, opt_in: bool, preview: dict[str, Any] | None = None) -> dict[str, Any]:
+def build_contribution_settings_payload(
+    *, opt_in: bool, preview: dict[str, Any] | None = None
+) -> dict[str, Any]:
     preview_payload = dict(preview or {})
     preview_payload["opt_in"] = bool(opt_in)
     return {
@@ -89,4 +98,46 @@ def build_contribution_settings_payload(*, opt_in: bool, preview: dict[str, Any]
         "preview": preview_payload,
         "summary": preview_payload.get("summary") or {},
         "queue": preview_payload.get("queue") or [],
+    }
+
+
+def build_pomodoro_status_payload(
+    status: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload = dict(status or {})
+    return {
+        "state": str(payload.get("state") or "idle"),
+        "mode": str(payload.get("mode") or "focus"),
+        "remaining_seconds": max(0, int(payload.get("remaining_seconds") or 0)),
+        "session_count": max(0, int(payload.get("session_count") or 0)),
+        "goal_id": str(payload.get("goal_id") or ""),
+        "date": str(payload.get("date") or ""),
+        "pause_count": max(0, int(payload.get("pause_count") or 0)),
+        "interrupt_count": max(0, int(payload.get("interrupt_count") or 0)),
+        "current_focus_session": dict(payload.get("current_focus_session") or {}),
+        "config": dict(payload.get("config") or {}),
+    }
+
+
+def build_habit_dashboard_payload(
+    *,
+    goals: list[dict[str, Any]] | None = None,
+    checkin: dict[str, Any] | None = None,
+    pomodoro: dict[str, Any] | None = None,
+    summary: dict[str, Any] | None = None,
+    supervision: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    goal_items = list(goals or [])
+    completed = [
+        item for item in goal_items if str(item.get("status") or "") == "completed"
+    ]
+    summary_payload = dict(summary or {})
+    summary_payload.setdefault("completed_goal_count", len(completed))
+    summary_payload.setdefault("goal_count", len(goal_items))
+    return {
+        "goals": goal_items,
+        "checkin": dict(checkin or {}),
+        "pomodoro": build_pomodoro_status_payload(pomodoro or {}),
+        "summary": summary_payload,
+        "supervision": dict(supervision or {}),
     }

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -30,7 +30,9 @@ def _habit_store(tmp_path: Path) -> StudyHabitStore:
     return StudyHabitStore(store)
 
 
-def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_minutes(tmp_path: Path) -> None:
+def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_minutes(
+    tmp_path: Path,
+) -> None:
     habits = _habit_store(tmp_path)
     clock = _Clock()
     timer = PomodoroTimer(
@@ -43,8 +45,15 @@ def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_
         ),
         clock=clock.time,
     )
+    goal = habits.create_goal(
+        date="1970-01-01",
+        target_type="subject",
+        subject="math",
+        target_amount=1,
+        unit="pomodoro",
+    )
 
-    started = timer.start(goal_id="", focus_minutes=1)
+    started = timer.start(goal_id=goal["id"], focus_minutes=1)
     assert started["state"] == "focusing"
     assert started["remaining_seconds"] == 60
 
@@ -68,14 +77,26 @@ def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_
     assert completed["state"] == "completed"
     assert completed["remaining_seconds"] == 0
     assert habits.focus_minutes_for_date(started["date"]) == 1
+    updated_goal = habits.get_goal(goal["id"])
+    assert updated_goal is not None
+    assert updated_goal["progress_amount"] == 1
+    assert updated_goal["status"] == "completed"
+    assert habits.list_checkins(date=started["date"])[0]["source"] == "session_derived"
 
 
-def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(tmp_path: Path) -> None:
+def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(
+    tmp_path: Path,
+) -> None:
     habits = _habit_store(tmp_path)
     clock = _Clock()
     timer = PomodoroTimer(
         habits,
-        config=PomodoroConfig(focus_minutes=1, short_break_minutes=1, long_break_minutes=3, long_break_interval=2),
+        config=PomodoroConfig(
+            focus_minutes=1,
+            short_break_minutes=1,
+            long_break_minutes=3,
+            long_break_interval=2,
+        ),
         clock=clock.time,
     )
 

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -56,8 +56,9 @@ class _FailingHabitStore:
 
 
 class _CheckinFailingHabitStore(_FailingHabitStore):
-    def __init__(self) -> None:
+    def __init__(self, *, failures_remaining: int | None = None) -> None:
         super().__init__(fail_on="record_checkin")
+        self.failures_remaining = failures_remaining
         self.progress_delta = 0.0
 
     def get_goal(self, goal_id: str) -> dict[str, Any] | None:
@@ -67,6 +68,14 @@ class _CheckinFailingHabitStore(_FailingHabitStore):
         del goal_id
         self.progress_delta += float(progress_delta or 0.0)
         return {"progress_amount": self.progress_delta}
+
+    def record_checkin(self, **_: Any) -> dict[str, Any]:
+        if self.failures_remaining is None:
+            raise RuntimeError("checkin failed")
+        if self.failures_remaining > 0:
+            self.failures_remaining -= 1
+            raise RuntimeError("checkin failed")
+        return {"id": "checkin-1"}
 
 
 def _habit_store(tmp_path: Path) -> tuple[StudyStore, StudyHabitStore]:
@@ -170,6 +179,38 @@ def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(
         store.close()
 
 
+def test_pomodoro_stop_completes_expired_focus_before_cancelling(
+    tmp_path: Path,
+) -> None:
+    store, habits = _habit_store(tmp_path)
+    try:
+        clock = _Clock()
+        timer = PomodoroTimer(
+            habits,
+            config=PomodoroConfig(focus_minutes=1, short_break_minutes=1),
+            clock=clock.time,
+        )
+        goal = habits.create_goal(
+            date="1970-01-01",
+            target_type="subject",
+            subject="math",
+            target_amount=1,
+            unit="pomodoro",
+        )
+
+        started = timer.start(goal_id=goal["id"], focus_minutes=1)
+        clock.advance(60)
+        stopped = timer.stop()
+
+        assert stopped["state"] == "short_break"
+        assert stopped["session_count"] == 1
+        assert stopped["current_focus_session"]["status"] == "completed"
+        assert habits.get_goal(goal["id"])["progress_amount"] == 1
+        assert habits.list_checkins(date=started["date"])[0]["source"] == "session_derived"
+    finally:
+        store.close()
+
+
 def test_pomodoro_stop_is_noop_when_timer_is_not_active(tmp_path: Path) -> None:
     store, habits = _habit_store(tmp_path)
     try:
@@ -263,8 +304,8 @@ def test_pomodoro_start_does_not_mutate_state_when_initial_persistence_fails() -
     assert status["current_focus_session"] == {}
 
 
-def test_pomodoro_completion_does_not_duplicate_progress_when_checkin_fails() -> None:
-    habits = _CheckinFailingHabitStore()
+def test_pomodoro_completion_does_not_duplicate_progress_when_checkin_retries() -> None:
+    habits = _CheckinFailingHabitStore(failures_remaining=1)
     clock = _Clock()
     timer = PomodoroTimer(
         habits,  # type: ignore[arg-type]
@@ -281,12 +322,14 @@ def test_pomodoro_completion_does_not_duplicate_progress_when_checkin_fails() ->
     else:  # pragma: no cover - assertion guard
         raise AssertionError("tick should propagate checkin persistence failures")
 
-    assert timer.status()["state"] == "short_break"
-    assert timer.status()["session_count"] == 1
+    assert timer.status()["state"] == "focusing"
+    assert timer.status()["session_count"] == 0
     assert habits.progress_delta == 1.0
 
     timer.tick()
 
+    assert timer.status()["state"] == "short_break"
+    assert timer.status()["session_count"] == 1
     assert habits.progress_delta == 1.0
 
 

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from plugin.plugins.study_companion.pomodoro_timer import PomodoroConfig, PomodoroTimer
+from plugin.plugins.study_companion.study_habit_store import StudyHabitStore
+from plugin.plugins.study_companion.store import StudyStore
+
+
+class _Logger:
+    def warning(self, *args, **kwargs):
+        return None
+
+
+@dataclass
+class _Clock:
+    now: float = 1_000.0
+
+    def time(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _habit_store(tmp_path: Path) -> StudyHabitStore:
+    store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
+    store.open()
+    return StudyHabitStore(store)
+
+
+def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_minutes(tmp_path: Path) -> None:
+    habits = _habit_store(tmp_path)
+    clock = _Clock()
+    timer = PomodoroTimer(
+        habits,
+        config=PomodoroConfig(
+            focus_minutes=1,
+            short_break_minutes=1,
+            long_break_minutes=2,
+            long_break_interval=2,
+        ),
+        clock=clock.time,
+    )
+
+    started = timer.start(goal_id="", focus_minutes=1)
+    assert started["state"] == "focusing"
+    assert started["remaining_seconds"] == 60
+
+    timer.pause()
+    clock.advance(30)
+    paused = timer.status()
+    assert paused["state"] == "paused"
+    assert paused["remaining_seconds"] == 60
+    timer.resume()
+
+    clock.advance(60)
+    transitioned = timer.tick()
+
+    assert transitioned["state"] == "short_break"
+    assert transitioned["session_count"] == 1
+    assert transitioned["current_focus_session"]["actual_minutes"] == 1
+
+    clock.advance(60)
+    completed = timer.tick()
+
+    assert completed["state"] == "completed"
+    assert completed["remaining_seconds"] == 0
+    assert habits.focus_minutes_for_date(started["date"]) == 1
+
+
+def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(tmp_path: Path) -> None:
+    habits = _habit_store(tmp_path)
+    clock = _Clock()
+    timer = PomodoroTimer(
+        habits,
+        config=PomodoroConfig(focus_minutes=1, short_break_minutes=1, long_break_minutes=3, long_break_interval=2),
+        clock=clock.time,
+    )
+
+    timer.start(focus_minutes=1)
+    clock.advance(60)
+    assert timer.tick()["state"] == "short_break"
+    assert timer.skip_break()["state"] == "completed"
+
+    timer.start(focus_minutes=1)
+    clock.advance(60)
+    long_break = timer.tick()
+    assert long_break["state"] == "long_break"
+    assert long_break["remaining_seconds"] == 180
+
+    cancelled = timer.stop()
+
+    assert cancelled["state"] == "cancelled"
+    assert cancelled["current_focus_session"]["status"] == "completed"

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -52,6 +53,20 @@ class _FailingHabitStore:
 
     def get_goal(self, goal_id: str) -> dict[str, Any] | None:
         return None
+
+
+class _CheckinFailingHabitStore(_FailingHabitStore):
+    def __init__(self) -> None:
+        super().__init__(fail_on="record_checkin")
+        self.progress_delta = 0.0
+
+    def get_goal(self, goal_id: str) -> dict[str, Any] | None:
+        return {"id": goal_id, "unit": "pomodoro"}
+
+    def update_goal(self, goal_id: str, *, progress_delta: float = 0.0) -> dict[str, Any]:
+        del goal_id
+        self.progress_delta += float(progress_delta or 0.0)
+        return {"progress_amount": self.progress_delta}
 
 
 def _habit_store(tmp_path: Path) -> tuple[StudyStore, StudyHabitStore]:
@@ -155,6 +170,31 @@ def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(
         store.close()
 
 
+def test_pomodoro_stop_is_noop_when_timer_is_not_active(tmp_path: Path) -> None:
+    store, habits = _habit_store(tmp_path)
+    try:
+        clock = _Clock()
+        timer = PomodoroTimer(
+            habits,
+            config=PomodoroConfig(focus_minutes=1, short_break_minutes=1),
+            clock=clock.time,
+        )
+
+        assert timer.stop()["state"] == "idle"
+
+        timer.start(focus_minutes=1)
+        clock.advance(60)
+        assert timer.tick()["state"] == "short_break"
+        assert timer.skip_break()["state"] == "completed"
+
+        stopped = timer.stop()
+
+        assert stopped["state"] == "completed"
+        assert stopped["current_focus_session"]["status"] == "completed"
+    finally:
+        store.close()
+
+
 def test_pomodoro_timer_respects_disabled_session_derived_checkins(
     tmp_path: Path,
 ) -> None:
@@ -178,6 +218,31 @@ def test_pomodoro_timer_respects_disabled_session_derived_checkins(
         store.close()
 
 
+def test_pomodoro_timer_uses_configured_timezone_for_session_derived_checkins(
+    tmp_path: Path,
+) -> None:
+    store, habits = _habit_store(tmp_path)
+    try:
+        timestamp = datetime(2024, 1, 1, 0, 30, tzinfo=timezone.utc).timestamp()
+        clock = _Clock(timestamp)
+        timer = PomodoroTimer(
+            habits,
+            config=PomodoroConfig(focus_minutes=1, short_break_minutes=1),
+            clock=clock.time,
+            checkin_timezone="America/Los_Angeles",
+        )
+
+        started = timer.start(focus_minutes=1)
+        clock.advance(60)
+        timer.tick()
+
+        assert started["date"] == "2023-12-31"
+        assert habits.list_checkins(date="2023-12-31")
+        assert habits.list_checkins(date="2024-01-01") == []
+    finally:
+        store.close()
+
+
 def test_pomodoro_start_does_not_mutate_state_when_initial_persistence_fails() -> None:
     timer = PomodoroTimer(
         _FailingHabitStore(fail_on="create_focus_session"),  # type: ignore[arg-type]
@@ -196,6 +261,33 @@ def test_pomodoro_start_does_not_mutate_state_when_initial_persistence_fails() -
     assert status["state"] == "idle"
     assert status["remaining_seconds"] == 0
     assert status["current_focus_session"] == {}
+
+
+def test_pomodoro_completion_does_not_duplicate_progress_when_checkin_fails() -> None:
+    habits = _CheckinFailingHabitStore()
+    clock = _Clock()
+    timer = PomodoroTimer(
+        habits,  # type: ignore[arg-type]
+        config=PomodoroConfig(focus_minutes=1, short_break_minutes=1),
+        clock=clock.time,
+    )
+    timer.start(goal_id="goal-1", focus_minutes=1)
+    clock.advance(60)
+
+    try:
+        timer.tick()
+    except RuntimeError as exc:
+        assert str(exc) == "checkin failed"
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("tick should propagate checkin persistence failures")
+
+    assert timer.status()["state"] == "short_break"
+    assert timer.status()["session_count"] == 1
+    assert habits.progress_delta == 1.0
+
+    timer.tick()
+
+    assert habits.progress_delta == 1.0
 
 
 def test_pomodoro_completion_stays_retryable_when_persistence_fails() -> None:

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -113,8 +113,7 @@ def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_
         assert updated_goal["progress_amount"] == 1
         assert updated_goal["status"] == "completed"
         assert (
-            habits.list_checkins(date=started["date"])[0]["source"]
-            == "session_derived"
+            habits.list_checkins(date=started["date"])[0]["source"] == "session_derived"
         )
     finally:
         store.close()

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -54,97 +54,129 @@ class _FailingHabitStore:
         return None
 
 
-def _habit_store(tmp_path: Path) -> StudyHabitStore:
+def _habit_store(tmp_path: Path) -> tuple[StudyStore, StudyHabitStore]:
     store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
     store.open()
-    return StudyHabitStore(store)
+    return store, StudyHabitStore(store)
 
 
 def test_pomodoro_timer_completes_focus_then_short_break_without_counting_break_minutes(
     tmp_path: Path,
 ) -> None:
-    habits = _habit_store(tmp_path)
-    clock = _Clock()
-    timer = PomodoroTimer(
-        habits,
-        config=PomodoroConfig(
-            focus_minutes=1,
-            short_break_minutes=1,
-            long_break_minutes=2,
-            long_break_interval=2,
-        ),
-        clock=clock.time,
-    )
-    goal = habits.create_goal(
-        date="1970-01-01",
-        target_type="subject",
-        subject="math",
-        target_amount=1,
-        unit="pomodoro",
-    )
+    store, habits = _habit_store(tmp_path)
+    try:
+        clock = _Clock()
+        timer = PomodoroTimer(
+            habits,
+            config=PomodoroConfig(
+                focus_minutes=1,
+                short_break_minutes=1,
+                long_break_minutes=2,
+                long_break_interval=2,
+            ),
+            clock=clock.time,
+        )
+        goal = habits.create_goal(
+            date="1970-01-01",
+            target_type="subject",
+            subject="math",
+            target_amount=1,
+            unit="pomodoro",
+        )
 
-    started = timer.start(goal_id=goal["id"], focus_minutes=1)
-    assert started["state"] == "focusing"
-    assert started["remaining_seconds"] == 60
+        started = timer.start(goal_id=goal["id"], focus_minutes=1)
+        assert started["state"] == "focusing"
+        assert started["remaining_seconds"] == 60
 
-    timer.pause()
-    clock.advance(30)
-    paused = timer.status()
-    assert paused["state"] == "paused"
-    assert paused["remaining_seconds"] == 60
-    timer.resume()
+        timer.pause()
+        clock.advance(30)
+        paused = timer.status()
+        assert paused["state"] == "paused"
+        assert paused["remaining_seconds"] == 60
+        timer.resume()
 
-    clock.advance(60)
-    transitioned = timer.tick()
+        clock.advance(60)
+        transitioned = timer.tick()
 
-    assert transitioned["state"] == "short_break"
-    assert transitioned["session_count"] == 1
-    assert transitioned["current_focus_session"]["actual_minutes"] == 1
+        assert transitioned["state"] == "short_break"
+        assert transitioned["session_count"] == 1
+        assert transitioned["current_focus_session"]["actual_minutes"] == 1
 
-    clock.advance(60)
-    completed = timer.tick()
+        clock.advance(60)
+        completed = timer.tick()
 
-    assert completed["state"] == "completed"
-    assert completed["remaining_seconds"] == 0
-    assert habits.focus_minutes_for_date(started["date"]) == 1
-    updated_goal = habits.get_goal(goal["id"])
-    assert updated_goal is not None
-    assert updated_goal["progress_amount"] == 1
-    assert updated_goal["status"] == "completed"
-    assert habits.list_checkins(date=started["date"])[0]["source"] == "session_derived"
+        assert completed["state"] == "completed"
+        assert completed["remaining_seconds"] == 0
+        assert habits.focus_minutes_for_date(started["date"]) == 1
+        updated_goal = habits.get_goal(goal["id"])
+        assert updated_goal is not None
+        assert updated_goal["progress_amount"] == 1
+        assert updated_goal["status"] == "completed"
+        assert (
+            habits.list_checkins(date=started["date"])[0]["source"]
+            == "session_derived"
+        )
+    finally:
+        store.close()
 
 
 def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(
     tmp_path: Path,
 ) -> None:
-    habits = _habit_store(tmp_path)
-    clock = _Clock()
-    timer = PomodoroTimer(
-        habits,
-        config=PomodoroConfig(
-            focus_minutes=1,
-            short_break_minutes=1,
-            long_break_minutes=3,
-            long_break_interval=2,
-        ),
-        clock=clock.time,
-    )
+    store, habits = _habit_store(tmp_path)
+    try:
+        clock = _Clock()
+        timer = PomodoroTimer(
+            habits,
+            config=PomodoroConfig(
+                focus_minutes=1,
+                short_break_minutes=1,
+                long_break_minutes=3,
+                long_break_interval=2,
+            ),
+            clock=clock.time,
+        )
 
-    timer.start(focus_minutes=1)
-    clock.advance(60)
-    assert timer.tick()["state"] == "short_break"
-    assert timer.skip_break()["state"] == "completed"
+        timer.start(focus_minutes=1)
+        clock.advance(60)
+        assert timer.tick()["state"] == "short_break"
+        assert timer.skip_break()["state"] == "completed"
 
-    timer.start(focus_minutes=1)
-    clock.advance(60)
-    long_break = timer.tick()
-    assert long_break["state"] == "long_break"
-    assert long_break["remaining_seconds"] == 180
+        timer.start(focus_minutes=1)
+        clock.advance(60)
+        long_break = timer.tick()
+        assert long_break["state"] == "long_break"
+        assert long_break["remaining_seconds"] == 180
 
-    cancelled = timer.stop()
+        cancelled = timer.stop()
 
-    assert cancelled["state"] == "cancelled"
-    assert cancelled["current_focus_session"]["status"] == "completed"
+        assert cancelled["state"] == "cancelled"
+        assert cancelled["current_focus_session"]["status"] == "completed"
+    finally:
+        store.close()
+
+
+def test_pomodoro_timer_respects_disabled_session_derived_checkins(
+    tmp_path: Path,
+) -> None:
+    store, habits = _habit_store(tmp_path)
+    try:
+        clock = _Clock()
+        timer = PomodoroTimer(
+            habits,
+            config=PomodoroConfig(focus_minutes=1, short_break_minutes=1),
+            clock=clock.time,
+            auto_derive_from_session=False,
+        )
+
+        started = timer.start(focus_minutes=1)
+        clock.advance(60)
+        assert timer.tick()["state"] == "short_break"
+
+        assert habits.focus_minutes_for_date(started["date"]) == 1
+        assert habits.list_checkins(date=started["date"]) == []
+    finally:
+        store.close()
 
 
 def test_pomodoro_start_does_not_mutate_state_when_initial_persistence_fails() -> None:

--- a/plugin/tests/unit/plugins/test_pomodoro_timer.py
+++ b/plugin/tests/unit/plugins/test_pomodoro_timer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from plugin.plugins.study_companion.pomodoro_timer import PomodoroConfig, PomodoroTimer
 from plugin.plugins.study_companion.study_habit_store import StudyHabitStore
@@ -22,6 +23,35 @@ class _Clock:
 
     def advance(self, seconds: float) -> None:
         self.now += seconds
+
+
+class _FailingHabitStore:
+    def __init__(self, *, fail_on: str) -> None:
+        self.fail_on = fail_on
+        self.focus_session = {
+            "id": "focus-1",
+            "date": "1970-01-01",
+            "status": "active",
+        }
+
+    def create_focus_session(self, **_: Any) -> dict[str, Any]:
+        if self.fail_on == "create_focus_session":
+            raise RuntimeError("create failed")
+        return dict(self.focus_session)
+
+    def finish_focus_session(self, *_: Any, **__: Any) -> dict[str, Any]:
+        if self.fail_on == "finish_focus_session":
+            raise RuntimeError("finish failed")
+        self.focus_session = {**self.focus_session, "status": "completed"}
+        return dict(self.focus_session)
+
+    def record_checkin(self, **_: Any) -> dict[str, Any]:
+        if self.fail_on == "record_checkin":
+            raise RuntimeError("checkin failed")
+        return {"id": "checkin-1"}
+
+    def get_goal(self, goal_id: str) -> dict[str, Any] | None:
+        return None
 
 
 def _habit_store(tmp_path: Path) -> StudyHabitStore:
@@ -115,3 +145,46 @@ def test_pomodoro_timer_uses_long_break_interval_and_supports_cancel(
 
     assert cancelled["state"] == "cancelled"
     assert cancelled["current_focus_session"]["status"] == "completed"
+
+
+def test_pomodoro_start_does_not_mutate_state_when_initial_persistence_fails() -> None:
+    timer = PomodoroTimer(
+        _FailingHabitStore(fail_on="create_focus_session"),  # type: ignore[arg-type]
+        config=PomodoroConfig(focus_minutes=1),
+        clock=lambda: 1_000.0,
+    )
+
+    try:
+        timer.start(focus_minutes=1)
+    except RuntimeError as exc:
+        assert str(exc) == "create failed"
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("start should propagate persistence failures")
+
+    status = timer.status()
+    assert status["state"] == "idle"
+    assert status["remaining_seconds"] == 0
+    assert status["current_focus_session"] == {}
+
+
+def test_pomodoro_completion_stays_retryable_when_persistence_fails() -> None:
+    clock = _Clock()
+    timer = PomodoroTimer(
+        _FailingHabitStore(fail_on="finish_focus_session"),  # type: ignore[arg-type]
+        config=PomodoroConfig(focus_minutes=1, short_break_minutes=1),
+        clock=clock.time,
+    )
+    timer.start(focus_minutes=1)
+    clock.advance(60)
+
+    try:
+        timer.tick()
+    except RuntimeError as exc:
+        assert str(exc) == "finish failed"
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("tick should propagate persistence failures")
+
+    status = timer.status()
+    assert status["state"] == "focusing"
+    assert status["session_count"] == 0
+    assert status["remaining_seconds"] == 0

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -2519,7 +2519,9 @@ async def test_study_pomodoro_status_offloads_timer_operations(
 
 
 @pytest.mark.asyncio
-async def test_study_pomodoro_start_does_not_restart_supervision_on_noop() -> None:
+async def test_study_pomodoro_start_does_not_restart_supervision_on_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _Habits:
         def get_goal(self, _goal_id: str) -> dict[str, object]:
             return {"id": "goal-1"}
@@ -2542,6 +2544,13 @@ async def test_study_pomodoro_start_does_not_restart_supervision_on_noop() -> No
         def on_focus_start(self, **_kwargs) -> None:
             self.focus_start_count += 1
 
+    to_thread_calls: list[str] = []
+
+    async def _to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(study_companion_module.asyncio, "to_thread", _to_thread)
     plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
     supervision = _Supervision()
     plugin._cfg = StudyConfig()
@@ -2554,7 +2563,62 @@ async def test_study_pomodoro_start_does_not_restart_supervision_on_noop() -> No
 
     assert isinstance(status, Ok)
     assert status.value["state"] == "focusing"
+    assert to_thread_calls == ["status", "start"]
     assert supervision.focus_start_count == 0
+
+
+@pytest.mark.asyncio
+async def test_study_pomodoro_start_offloads_blocking_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Habits:
+        def get_goal(self, goal_id: str) -> dict[str, object]:
+            return {"id": goal_id, "title": "read"}
+
+    class _Timer:
+        def status(self) -> dict[str, object]:
+            return {"state": "idle", "current_focus_session": {}}
+
+        def start(self, **_kwargs) -> dict[str, object]:
+            return {
+                "state": "focusing",
+                "current_focus_session": {"id": "focus-2"},
+                "config": {"focus_minutes": 30},
+            }
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.goal: dict[str, object] = {}
+            self.planned_minutes = 0.0
+
+        def on_focus_start(
+            self, *, goal: dict[str, object], planned_minutes: float
+        ) -> None:
+            self.goal = goal
+            self.planned_minutes = planned_minutes
+
+    to_thread_calls: list[str] = []
+
+    async def _to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(study_companion_module.asyncio, "to_thread", _to_thread)
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._cfg = StudyConfig()
+    plugin._habit_store = _Habits()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = _Timer()
+    plugin._supervision = supervision
+
+    status = await plugin.study_pomodoro_start(goal_id="goal-1", focus_minutes=30)
+
+    assert isinstance(status, Ok)
+    assert status.value["state"] == "focusing"
+    assert to_thread_calls == ["status", "start", "get_goal"]
+    assert supervision.goal == {"id": "goal-1", "title": "read"}
+    assert supervision.planned_minutes == 30.0
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -2534,36 +2534,37 @@ async def test_study_plugin_starts_and_collects_entries(
     )
     plugin = StudyCompanionPlugin(ctx)
     result = await plugin.startup()
-
-    assert isinstance(result, Ok)
-    entries = plugin.collect_entries()
-    assert "study_status" in entries
-    assert "study_explain_text" in entries
-    assert "study_ocr_snapshot" in entries
-    assert "study_set_mode" in entries
-    assert "study_detect_mode_intent" in entries
-    assert "study_export_notes" not in entries
-    assert "study_knowledge_map" in entries
-    assert "study_set_knowledge_contribution_opt_in" in entries
-    disabled_export = await plugin._study_export_notes_entry(
-        fmt="markdown", preview_only=True, title="Default Notes"
-    )
-    assert isinstance(disabled_export, Err)
-    status = await plugin.study_status()
-    assert isinstance(status, Ok)
-    assert status.value["status"] == "ready"
-    assert status.value["is_first_run"] is True
-    assert status.value["active_mode"] == MODE_COMPANION
-    assert "mode_started_at" in status.value
-    assert "recent_mode_switches" in status.value
-    assert status.value["knowledge_summary"]["topic_count"] >= 120
-    assert "review_queue" in status.value
-    assert "weak_topics" in status.value
-    assert "mastery_overview" in status.value
-    assert (
-        runtime_root / "plugins" / "study_companion" / "data" / "study_companion.db"
-    ).is_file()
-    await plugin.shutdown()
+    try:
+        assert isinstance(result, Ok)
+        entries = plugin.collect_entries()
+        assert "study_status" in entries
+        assert "study_explain_text" in entries
+        assert "study_ocr_snapshot" in entries
+        assert "study_set_mode" in entries
+        assert "study_detect_mode_intent" in entries
+        assert "study_export_notes" not in entries
+        assert "study_knowledge_map" in entries
+        assert "study_set_knowledge_contribution_opt_in" in entries
+        disabled_export = await plugin._study_export_notes_entry(
+            fmt="markdown", preview_only=True, title="Default Notes"
+        )
+        assert isinstance(disabled_export, Err)
+        status = await plugin.study_status()
+        assert isinstance(status, Ok)
+        assert status.value["status"] == "ready"
+        assert status.value["is_first_run"] is True
+        assert status.value["active_mode"] == MODE_COMPANION
+        assert "mode_started_at" in status.value
+        assert "recent_mode_switches" in status.value
+        assert status.value["knowledge_summary"]["topic_count"] >= 120
+        assert "review_queue" in status.value
+        assert "weak_topics" in status.value
+        assert "mastery_overview" in status.value
+        assert (
+            runtime_root / "plugins" / "study_companion" / "data" / "study_companion.db"
+        ).is_file()
+    finally:
+        await plugin.shutdown()
 
 
 @pytest.mark.asyncio
@@ -2583,21 +2584,23 @@ async def test_study_status_degrades_when_habit_payload_fails(
     )
     plugin = StudyCompanionPlugin(ctx)
     result = await plugin.startup()
-    assert isinstance(result, Ok)
+    try:
+        assert isinstance(result, Ok)
 
-    class _BrokenHabitStore:
-        def list_goals(self, **_kwargs):
-            raise RuntimeError("habit db unavailable")
+        class _BrokenHabitStore:
+            def list_goals(self, **_kwargs):
+                raise RuntimeError("habit db unavailable")
 
-    plugin._habit_store = _BrokenHabitStore()  # type: ignore[assignment]
+        plugin._habit_store = _BrokenHabitStore()  # type: ignore[assignment]
 
-    status = await plugin.study_status()
+        status = await plugin.study_status()
 
-    assert isinstance(status, Ok)
-    assert status.value["status"] == "ready"
-    assert status.value["habit"]["available"] is False
-    assert "habit db unavailable" in status.value["habit"]["error"]
-    await plugin.shutdown()
+        assert isinstance(status, Ok)
+        assert status.value["status"] == "ready"
+        assert status.value["habit"]["available"] is False
+        assert "habit db unavailable" in status.value["habit"]["error"]
+    finally:
+        await plugin.shutdown()
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -2277,6 +2277,40 @@ async def test_study_plugin_starts_and_collects_entries(tmp_path: Path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_study_status_degrades_when_habit_payload_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
+    ctx = _Ctx(
+        tmp_path,
+        {
+            "study": {"language": "en"},
+            "ocr_reader": {"enabled": True},
+            "rapidocr": {"lang_type": "ch"},
+        },
+    )
+    plugin = StudyCompanionPlugin(ctx)
+    result = await plugin.startup()
+    assert isinstance(result, Ok)
+
+    class _BrokenHabitStore:
+        def list_goals(self, **_kwargs):
+            raise RuntimeError("habit db unavailable")
+
+    plugin._habit_store = _BrokenHabitStore()  # type: ignore[assignment]
+
+    status = await plugin.study_status()
+
+    assert isinstance(status, Ok)
+    assert status.value["status"] == "ready"
+    assert status.value["habit"]["available"] is False
+    assert "habit db unavailable" in status.value["habit"]["error"]
+    await plugin.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_study_plugin_shutdown_continues_when_dynamic_entry_cleanup_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -11,6 +11,7 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
@@ -39,18 +40,34 @@ from plugin.plugins.study_companion.knowledge_quality import (
     KnowledgeEvidenceType,
     KnowledgeQualityStore,
 )
-from plugin.plugins.study_companion.knowledge_contribution import PublicGraphContributionBuilder
+from plugin.plugins.study_companion.knowledge_contribution import (
+    PublicGraphContributionBuilder,
+)
 from plugin.plugins.study_companion.knowledge_tracker import KnowledgeTracker
-from plugin.plugins.study_companion.models import OcrSnapshot, StudyConfig, TutorReply, build_config
+from plugin.plugins.study_companion.models import (
+    OcrSnapshot,
+    StudyConfig,
+    TutorReply,
+    build_config,
+)
 from plugin.plugins.study_companion.state import build_initial_state
 from plugin.plugins.study_companion.store import StudyStore
-from plugin.plugins.study_companion.study_ocr_pipeline import StudyCaptureProfile, StudyOcrPipeline
+from plugin.plugins.study_companion.study_ocr_pipeline import (
+    StudyCaptureProfile,
+    StudyOcrPipeline,
+)
 from plugin.plugins.study_companion import service as study_service
 from plugin.plugins.study_companion import tesseract_support as study_tesseract_support
-from plugin.plugins.study_companion.screen_classifier import ScreenClassification, classify_screen_from_ocr
+from plugin.plugins.study_companion.screen_classifier import (
+    ScreenClassification,
+    classify_screen_from_ocr,
+)
 from plugin.plugins.study_companion.service import _available_tesseract_languages
 from plugin.plugins.study_companion.tutor_llm_agent import TutorLLMAgent, _JSONCorrector
-from plugin.plugins.study_companion.ui_api import build_knowledge_map_payload, build_open_ui_payload
+from plugin.plugins.study_companion.ui_api import (
+    build_knowledge_map_payload,
+    build_open_ui_payload,
+)
 from plugin.server.application.plugins.ui_query_service import _build_surfaces_sync
 from plugin.sdk.plugin import Err, Ok
 
@@ -85,7 +102,9 @@ class _Ctx:
     def __init__(self, plugin_dir: Path, config: dict[str, object]) -> None:
         self.logger = _Logger()
         self.config_path = plugin_dir / "plugin.toml"
-        self.config_path.write_text("[plugin]\nid='study_companion'\n", encoding="utf-8")
+        self.config_path.write_text(
+            "[plugin]\nid='study_companion'\n", encoding="utf-8"
+        )
         self._config = config
         self._effective_config = {
             "plugin": {"store": {"enabled": True}, "database": {"enabled": False}},
@@ -107,7 +126,9 @@ class _Ctx:
     async def get_own_profile_config(self, profile_name: str, timeout: float = 5.0):
         return {"profile_name": profile_name, "config": self._config}
 
-    async def get_own_effective_config(self, profile_name: str | None = None, timeout: float = 5.0):
+    async def get_own_effective_config(
+        self, profile_name: str | None = None, timeout: float = 5.0
+    ):
         return {"config": self._config}
 
     async def update_own_config(self, updates, timeout: float = 10.0):
@@ -208,7 +229,9 @@ class _FakeTutorAgent:
         mode: str = MODE_COMPANION,
         context: dict[str, object] | None = None,
     ) -> TutorReply:
-        self.evaluations.append((question, answer, expected_answer, dict(context or {}), mode))
+        self.evaluations.append(
+            (question, answer, expected_answer, dict(context or {}), mode)
+        )
         return TutorReply(
             operation="answer_evaluate",
             input_text=answer,
@@ -236,9 +259,15 @@ def test_study_store_round_trip_and_export(tmp_path: Path) -> None:
 
     store.save_config(config)
     store.save_state(state)
-    store.append_interaction(kind="concept_explain", input_text="a", output_text="b", history_limit=2)
-    store.append_interaction(kind="concept_explain", input_text="c", output_text="d", history_limit=2)
-    store.append_interaction(kind="concept_explain", input_text="e", output_text="f", history_limit=2)
+    store.append_interaction(
+        kind="concept_explain", input_text="a", output_text="b", history_limit=2
+    )
+    store.append_interaction(
+        kind="concept_explain", input_text="c", output_text="d", history_limit=2
+    )
+    store.append_interaction(
+        kind="concept_explain", input_text="e", output_text="f", history_limit=2
+    )
     store.ensure_topic(topic_id="photosynthesis_topic", name="Photosynthesis")
     store.ensure_session(session_id="session-1", mode="interactive")
     store.add_qa_record(
@@ -293,13 +322,20 @@ def test_study_store_round_trip_and_export(tmp_path: Path) -> None:
 
     assert store.load_config(StudyConfig()).language == "en"
     assert store.load_state(build_initial_state()).last_ocr_text == "photosynthesis"
-    assert [item["input_text"] for item in store.list_interactions(limit=10)] == ["e", "c"]
+    assert [item["input_text"] for item in store.list_interactions(limit=10)] == [
+        "e",
+        "c",
+    ]
     exported = store.export_json()
     assert exported["config"]["language"] == "en"
     assert exported["sessions"][0]["id"] == "session-1"
-    assert [item["question"]["question"] for item in store.list_qa_records(limit=2)] == ["Recent QA 0", "Recent QA 1"]
+    assert [
+        item["question"]["question"] for item in store.list_qa_records(limit=2)
+    ] == ["Recent QA 0", "Recent QA 1"]
     assert [item["rating"] for item in store.list_review_log(limit=2)] == [1, 2]
-    assert [item["context"].get("index") for item in store.list_knowledge_evidence(limit=2)] == [0, 1]
+    assert [
+        item["context"].get("index") for item in store.list_knowledge_evidence(limit=2)
+    ] == [0, 1]
     assert exported["qa_records"][-1]["question"]["question"] == "Recent QA 1"
     assert exported["review_log"][0]["topic_id"] == "photosynthesis_topic"
     assert exported["knowledge_evidence"][0]["item_id"] == candidate["id"]
@@ -440,8 +476,12 @@ def test_build_tutor_payload_preserves_structured_summary() -> None:
 
 def test_study_mode_manager_intent_switch_rules() -> None:
     assert normalize_mode("concept_explain") == MODE_COMPANION
-    assert "already in" in build_transition_phrase(MODE_COMPANION, language="en-GB", outcome="same")
-    assert "already in" in build_transition_phrase(MODE_COMPANION, language="eng", outcome="same")
+    assert "already in" in build_transition_phrase(
+        MODE_COMPANION, language="en-GB", outcome="same"
+    )
+    assert "already in" in build_transition_phrase(
+        MODE_COMPANION, language="eng", outcome="same"
+    )
     pure = handle_user_intent("教我")
     assert pure["mode"] == MODE_TEACHING
     assert pure["pure_switch"] is True
@@ -471,7 +511,9 @@ def test_study_mode_manager_intent_switch_rules() -> None:
     assert cross_mode["keyword"] == "互动模式"
     assert mode_label(MODE_TEACHING, language="ja") == "指導"
     assert mode_label(MODE_TEACHING, language="pt-BR") == "Ensino"
-    assert "教学" not in build_transition_phrase(MODE_TEACHING, language="ja", outcome="changed")
+    assert "教学" not in build_transition_phrase(
+        MODE_TEACHING, language="ja", outcome="changed"
+    )
 
     manager = ModeManager(current_mode=MODE_COMPANION)
     first = manager.switch_to(MODE_INTERACTIVE, "unit", now=1000.0)
@@ -508,7 +550,9 @@ def test_study_config_and_state_legacy_mode_migration(tmp_path: Path) -> None:
 
     llm_timeout = build_config({"llm": {"call_timeout_seconds": 42}})
     assert llm_timeout.llm_call_timeout_seconds == 42
-    fsrs_config = build_config({"fsrs": {"retention_target": 0.88, "auto_optimize_interval_days": 14}})
+    fsrs_config = build_config(
+        {"fsrs": {"retention_target": 0.88, "auto_optimize_interval_days": 14}}
+    )
     assert fsrs_config.fsrs_retention_target == 0.88
     assert fsrs_config.fsrs_auto_optimize_interval_days == 14
     llm_section_legacy_timeout = build_config({"llm": {"llm_call_timeout_seconds": 84}})
@@ -530,7 +574,14 @@ def test_study_config_and_state_legacy_mode_migration(tmp_path: Path) -> None:
     store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
     store.open()
     try:
-        store.set_raw("state", {"status": "ready", "active_mode": "concept_explain", "last_ocr_text": "legacy"})
+        store.set_raw(
+            "state",
+            {
+                "status": "ready",
+                "active_mode": "concept_explain",
+                "last_ocr_text": "legacy",
+            },
+        )
         loaded = store.load_state(build_initial_state())
         assert loaded.active_mode == MODE_COMPANION
         assert loaded.last_ocr_text == "legacy"
@@ -541,7 +592,9 @@ def test_study_config_and_state_legacy_mode_migration(tmp_path: Path) -> None:
         store.close()
 
 
-def test_trusted_knowledge_candidate_is_deprecated_after_conflict(tmp_path: Path) -> None:
+def test_trusted_knowledge_candidate_is_deprecated_after_conflict(
+    tmp_path: Path,
+) -> None:
     store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
     store.open()
     quality = KnowledgeQualityStore(store, trusted_negative_threshold=1)
@@ -579,27 +632,41 @@ def test_trusted_knowledge_candidate_is_deprecated_after_conflict(tmp_path: Path
 
 
 def test_study_screen_classifier_routes_summary_keywords_to_summary() -> None:
-    english = classify_screen_from_ocr("## Summary\n\nThe learner reviewed photosynthesis.")
+    english = classify_screen_from_ocr(
+        "## Summary\n\nThe learner reviewed photosynthesis."
+    )
     assert english.screen_type == "summary"
     assert "summary" in english.signals.get("summary_hits", [])
 
-    chinese = classify_screen_from_ocr("本节总结\n光合作用的主要过程包括光反应和暗反应。")
+    chinese = classify_screen_from_ocr(
+        "本节总结\n光合作用的主要过程包括光反应和暗反应。"
+    )
     assert chinese.screen_type == "summary"
     assert "总结" in chinese.signals.get("summary_hits", [])
 
 
 def test_study_screen_classifier_covers_core_screen_types_and_smoothing() -> None:
-    assert classify_screen_from_ocr("", window_title="").to_payload()["screen_type"] == "idle"
+    assert (
+        classify_screen_from_ocr("", window_title="").to_payload()["screen_type"]
+        == "idle"
+    )
 
-    question = classify_screen_from_ocr("Problem 1: What is the derivative?", window_title="Quiz exercise")
+    question = classify_screen_from_ocr(
+        "Problem 1: What is the derivative?", window_title="Quiz exercise"
+    )
     assert question.screen_type == "question"
     assert question.confidence > 0.0
 
-    answering = classify_screen_from_ocr("Answer submitted\nScore: incorrect\nFeedback: retry", window_title="Answer review")
+    answering = classify_screen_from_ocr(
+        "Answer submitted\nScore: incorrect\nFeedback: retry",
+        window_title="Answer review",
+    )
     assert answering.screen_type in {"answering", "review"}
     assert answering.signals["answer_hits"]
 
-    notes = classify_screen_from_ocr("Notes\nmemo outline for photosynthesis", window_title="Study note")
+    notes = classify_screen_from_ocr(
+        "Notes\nmemo outline for photosynthesis", window_title="Study note"
+    )
     assert notes.screen_type == "notes"
 
     reading = classify_screen_from_ocr(
@@ -622,12 +689,16 @@ def test_study_screen_classifier_covers_core_screen_types_and_smoothing() -> Non
 def test_compact_prompt_value_stops_at_max_depth() -> None:
     nested = {"a": {"b": {"c": {"d": "bottom"}}}}
 
-    compacted = _compact_prompt_value(nested, list_limit=5, string_limit=50, max_depth=2)
+    compacted = _compact_prompt_value(
+        nested, list_limit=5, string_limit=50, max_depth=2
+    )
 
     assert compacted == {"a": {"b": "...[max depth reached]"}}
 
 
-def test_study_prompt_builder_compacts_large_context_and_rejects_unknown_operation() -> None:
+def test_study_prompt_builder_compacts_large_context_and_rejects_unknown_operation() -> (
+    None
+):
     context = {
         "text": "x" * 20000,
         "language": "en",
@@ -657,7 +728,9 @@ def test_study_knowledge_map_payload_uses_topic_ids_for_object_edges() -> None:
             {
                 "id": "number_axis",
                 "name": "Number Axis",
-                "prerequisites": [{"id": "real_number_concept", "required_mastery": 0.55}],
+                "prerequisites": [
+                    {"id": "real_number_concept", "required_mastery": 0.55}
+                ],
                 "related": [{"id": "absolute_value", "relation": "next"}],
             },
             {"id": "real_number_concept", "name": "Real Numbers"},
@@ -665,8 +738,17 @@ def test_study_knowledge_map_payload_uses_topic_ids_for_object_edges() -> None:
         ]
     )
 
-    assert {"from": "real_number_concept", "to": "number_axis", "relation": "prerequisite", "required_mastery": 0.55} in payload["edges"]
-    assert {"from": "number_axis", "to": "absolute_value", "relation": "next"} in payload["edges"]
+    assert {
+        "from": "real_number_concept",
+        "to": "number_axis",
+        "relation": "prerequisite",
+        "required_mastery": 0.55,
+    } in payload["edges"]
+    assert {
+        "from": "number_axis",
+        "to": "absolute_value",
+        "relation": "next",
+    } in payload["edges"]
     assert all(not edge["from"].startswith("{") for edge in payload["edges"])
 
 
@@ -736,14 +818,19 @@ def test_study_companion_i18n_bundles_are_present() -> None:
         assert "entries.set_knowledge_contribution_opt_in.name" in bundle
         assert "entries.export_notes.name" in bundle
 
-    en_bundle = json.loads((plugin_dir / "i18n" / "en.json").read_text(encoding="utf-8"))
+    en_bundle = json.loads(
+        (plugin_dir / "i18n" / "en.json").read_text(encoding="utf-8")
+    )
     for locale in locales:
         assert set(bundles[locale]) == set(en_bundle)
     for locale in [item for item in locales if item != "en"]:
         bundle = bundles[locale]
         assert any(bundle[key] != en_bundle[key] for key in phase3_keys)
     assert bundles["ja"]["entries.open_ui.name"] != en_bundle["entries.open_ui.name"]
-    assert bundles["ja"]["entries.download_rapidocr_models.description"] != en_bundle["entries.download_rapidocr_models.description"]
+    assert (
+        bundles["ja"]["entries.download_rapidocr_models.description"]
+        != en_bundle["entries.download_rapidocr_models.description"]
+    )
 
     with (plugin_dir / "plugin.toml").open("rb") as handle:
         config = tomllib.load(handle)
@@ -757,16 +844,32 @@ def test_study_companion_i18n_bundles_are_present() -> None:
     }
     surfaces, warnings = _build_surfaces_sync("study_companion", meta)
     assert warnings == []
-    assert any(surface["id"] == "study-panel" and surface["available"] is True for surface in surfaces)
-    assert any(surface["id"] == "knowledge-map" and surface["available"] is True for surface in surfaces)
-    assert any(surface["id"] == "knowledge-contribution-settings" and surface["available"] is True for surface in surfaces)
-    assert any(surface["id"] == "note-exporter" and surface["available"] is True for surface in surfaces)
-    assert any(surface["id"] == "quickstart" and surface["available"] is True for surface in surfaces)
+    assert any(
+        surface["id"] == "study-panel" and surface["available"] is True
+        for surface in surfaces
+    )
+    assert any(
+        surface["id"] == "knowledge-map" and surface["available"] is True
+        for surface in surfaces
+    )
+    assert any(
+        surface["id"] == "knowledge-contribution-settings"
+        and surface["available"] is True
+        for surface in surfaces
+    )
+    assert any(
+        surface["id"] == "note-exporter" and surface["available"] is True
+        for surface in surfaces
+    )
+    assert any(
+        surface["id"] == "quickstart" and surface["available"] is True
+        for surface in surfaces
+    )
 
     index_html = (plugin_dir / "static" / "index.html").read_text(encoding="utf-8")
     main_js = (plugin_dir / "static" / "main.js").read_text(encoding="utf-8")
     assert "./i18n.js" in index_html
-    assert "data-i18n=\"ui.title\"" in index_html
+    assert 'data-i18n="ui.title"' in index_html
     assert "I18n.init" in main_js
 
 
@@ -774,9 +877,13 @@ def test_study_companion_static_ui_smoke_with_mocked_runs() -> None:
     plugin_dir = Path(__file__).resolve().parents[3] / "plugins" / "study_companion"
     frontend_dir = Path(__file__).resolve().parents[4] / "frontend" / "plugin-manager"
     if shutil.which("node") is None:
-        pytest.skip("node is not installed; frontend/plugin-manager happy-dom smoke test requires node")
+        pytest.skip(
+            "node is not installed; frontend/plugin-manager happy-dom smoke test requires node"
+        )
     if not (frontend_dir / "node_modules" / "happy-dom").is_dir():
-        pytest.skip("frontend/plugin-manager node_modules with happy-dom is not installed")
+        pytest.skip(
+            "frontend/plugin-manager node_modules with happy-dom is not installed"
+        )
 
     script = r"""
 import { Window } from 'happy-dom';
@@ -913,7 +1020,10 @@ def test_study_companion_hosted_panel_uses_long_running_entry_poll_budget() -> N
     assert "study_explain_text: 60000" in source
     assert "const deadline = Date.now() + timeoutForEntry(entryId);" in source
     assert "for (let i = 0; i < 40; i += 1)" not in source
-    assert "async function refresh(signal?: AbortSignal, options: { updateReply?: boolean } = {})" in source
+    assert (
+        "async function refresh(signal?: AbortSignal, options: { updateReply?: boolean } = {})"
+        in source
+    )
     assert "await refresh(controller.signal, { updateReply: false });" in source
     assert "const appliedMode = String(" in source
     assert "setStatus((prev) => ({" in source
@@ -932,7 +1042,9 @@ def test_study_companion_note_exporter_uses_backend_export_poll_budget() -> None
     assert "POLL_TIMEOUT_BUFFER_MS = 5_000" in source
     assert "const timeoutSeconds = Number(entry?.timeout);" in source
     assert "return timeoutSeconds * 1000 + POLL_TIMEOUT_BUFFER_MS;" in source
-    assert "const deadline = Date.now() + Math.max(timeoutMs, POLL_INTERVAL_MS);" in source
+    assert (
+        "const deadline = Date.now() + Math.max(timeoutMs, POLL_INTERVAL_MS);" in source
+    )
     assert "while (Date.now() < deadline)" in source
     assert "pollTimeoutMs = getEntryTimeoutMs(exportEntry)" in source
     assert "}, pollTimeoutMs);" in source
@@ -942,12 +1054,17 @@ def test_study_companion_note_exporter_uses_backend_export_poll_budget() -> None
 
 def test_study_companion_ui_export_failures_are_not_silent_successes() -> None:
     plugin_dir = Path(__file__).resolve().parents[3] / "plugins" / "study_companion"
-    hosted_source = (plugin_dir / "surfaces" / "study_panel.tsx").read_text(encoding="utf-8")
+    hosted_source = (plugin_dir / "surfaces" / "study_panel.tsx").read_text(
+        encoding="utf-8"
+    )
     static_source = (plugin_dir / "static" / "main.js").read_text(encoding="utf-8")
 
     assert "RUN_EXPORT_RETRY_COUNT = 3" in hosted_source
     assert "throw new Error(`Run export failed: HTTP ${lastStatus}`);" in hosted_source
-    assert "const exported = exportResp.ok ? await exportResp.json() : {};" not in hosted_source
+    assert (
+        "const exported = exportResp.ok ? await exportResp.json() : {};"
+        not in hosted_source
+    )
     assert "return item?.json?.data || {};" not in hosted_source
     assert "study_set_mode" in hosted_source
 
@@ -975,7 +1092,9 @@ def test_study_companion_static_mode_switch_uses_applied_mode() -> None:
     assert "answerInput.value = '';" not in static_source
 
 
-def test_study_companion_static_panel_keeps_mode_highlight_when_status_refresh_fails() -> None:
+def test_study_companion_static_panel_keeps_mode_highlight_when_status_refresh_fails() -> (
+    None
+):
     if shutil.which("node") is None:
         pytest.skip("node is not installed")
 
@@ -1244,7 +1363,9 @@ def test_study_companion_does_not_import_galgame_ocr_reader_directly() -> None:
 
 def test_ocr_pipeline_handles_empty_text_repeats_and_errors() -> None:
     cfg = StudyConfig()
-    empty = StudyOcrPipeline(logger=_Logger(), config=cfg, ocr_backend=_FakeOcrBackend(""))
+    empty = StudyOcrPipeline(
+        logger=_Logger(), config=cfg, ocr_backend=_FakeOcrBackend("")
+    )
     assert empty.snapshot_from_image(object()).status == "empty"
     assert empty.snapshot_from_image(None).diagnostic == "no image supplied"
 
@@ -1292,19 +1413,28 @@ def test_ocr_pipeline_normalizes_box_objects_and_capture_failures() -> None:
     assert snapshot.status == "ok"
     assert snapshot.backend == "fake"
     assert snapshot.text == "Box text Dict text Tail"
-    assert snapshot.boxes == [{"text": "Box text", "x": 1}, {"text": "Dict text", "x": 2}]
+    assert snapshot.boxes == [
+        {"text": "Box text", "x": 1},
+        {"text": "Dict text", "x": 2},
+    ]
 
-    broken = StudyOcrPipeline(logger=_Logger(), config=StudyConfig(), capture_backend=_BrokenCapture())
+    broken = StudyOcrPipeline(
+        logger=_Logger(), config=StudyConfig(), capture_backend=_BrokenCapture()
+    )
     failed = broken.capture_snapshot(target=object())
     assert failed.status == "capture_failed"
     assert "target capture boom" in failed.diagnostic
 
 
-def test_ocr_pipeline_reports_fullscreen_capture_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_ocr_pipeline_reports_fullscreen_capture_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def _capture_boom():
         raise RuntimeError("capture boom")
 
-    monkeypatch.setattr(StudyOcrPipeline, "_capture_fullscreen", staticmethod(_capture_boom))
+    monkeypatch.setattr(
+        StudyOcrPipeline, "_capture_fullscreen", staticmethod(_capture_boom)
+    )
     pipeline = StudyOcrPipeline(logger=_Logger(), config=StudyConfig())
 
     snapshot = pipeline.capture_snapshot()
@@ -1323,7 +1453,9 @@ def test_available_tesseract_languages_logs_timeout_and_falls_back(
     (tessdata / "eng.traineddata").write_text("stub", encoding="utf-8")
 
     def _timeout(*_args, **_kwargs):
-        raise subprocess.TimeoutExpired(cmd=[str(detected), "--list-langs"], timeout=5.0)
+        raise subprocess.TimeoutExpired(
+            cmd=[str(detected), "--list-langs"], timeout=5.0
+        )
 
     monkeypatch.setattr(subprocess, "run", _timeout)
     with caplog.at_level("WARNING", logger=study_service._LOGGER.name):
@@ -1359,9 +1491,14 @@ async def test_study_install_tesseract_uses_local_support(
             )
             if hasattr(maybe_awaitable, "__await__"):
                 await maybe_awaitable
-        return {"summary": "Tesseract is ready", "detected_path": "C:/Tesseract/tesseract.exe"}
+        return {
+            "summary": "Tesseract is ready",
+            "detected_path": "C:/Tesseract/tesseract.exe",
+        }
 
-    monkeypatch.setattr(study_tesseract_support, "install_tesseract", _fake_install_tesseract)
+    monkeypatch.setattr(
+        study_tesseract_support, "install_tesseract", _fake_install_tesseract
+    )
     ctx = _Ctx(
         tmp_path,
         {
@@ -1379,7 +1516,9 @@ async def test_study_install_tesseract_uses_local_support(
     assert isinstance(result, Ok)
 
     try:
-        install_result = await plugin.study_install_tesseract(force=True, _ctx={"run_id": "run-study-install"})
+        install_result = await plugin.study_install_tesseract(
+            force=True, _ctx={"run_id": "run-study-install"}
+        )
 
         assert isinstance(install_result, Ok)
         assert install_result.value["summary"] == "Tesseract is ready"
@@ -1393,14 +1532,18 @@ async def test_study_install_tesseract_uses_local_support(
         await plugin.shutdown()
 
 
-def test_study_ocr_pipeline_uses_local_tesseract_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_study_ocr_pipeline_uses_local_tesseract_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     created: list[dict[str, object]] = []
 
     class _FakeTesseractBackend:
         def __init__(self, **kwargs) -> None:
             created.append(dict(kwargs))
 
-    monkeypatch.setattr(study_tesseract_support, "TesseractOcrBackend", _FakeTesseractBackend)
+    monkeypatch.setattr(
+        study_tesseract_support, "TesseractOcrBackend", _FakeTesseractBackend
+    )
     pipeline = StudyOcrPipeline(
         logger=_Logger(),
         config=StudyConfig(
@@ -1438,7 +1581,9 @@ def test_study_tesseract_backend_restores_global_tesseract_cmd(
 
     fake_pytesseract.image_to_string = image_to_string
     monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
-    monkeypatch.setattr(study_tesseract_support, "_prepare_ocr_image", lambda image: "prepared-image")
+    monkeypatch.setattr(
+        study_tesseract_support, "_prepare_ocr_image", lambda image: "prepared-image"
+    )
 
     backend = study_tesseract_support.TesseractOcrBackend(
         tesseract_path=str(executable),
@@ -1582,7 +1727,10 @@ async def test_study_explain_text_detects_mode_intent_and_continues_when_content
         assert isinstance(explained, Ok)
         assert explained.value["intent"]["mode"] == MODE_TEACHING
         assert explained.value["mode_switch"]["changed"] is True
-        assert explained.value["reply"] == f'explained[teaching]: {explained.value["input_text"]}'
+        assert (
+            explained.value["reply"]
+            == f"explained[teaching]: {explained.value['input_text']}"
+        )
         assert plugin._agent.inputs[-1][0] == explained.value["input_text"]
         assert plugin._agent.inputs[-1][2] == MODE_TEACHING
         assert plugin._agent.inputs[-1][1]["source"] == "manual"
@@ -1592,8 +1740,13 @@ async def test_study_explain_text_detects_mode_intent_and_continues_when_content
 
         short_explained = await plugin.study_explain_text("??????")
         assert isinstance(short_explained, Ok)
-        assert short_explained.value.get("intent", {}).get("pure_switch", False) is False
-        assert short_explained.value["reply"] == f'explained[teaching]: {short_explained.value["input_text"]}'
+        assert (
+            short_explained.value.get("intent", {}).get("pure_switch", False) is False
+        )
+        assert (
+            short_explained.value["reply"]
+            == f"explained[teaching]: {short_explained.value['input_text']}"
+        )
         assert plugin._agent.inputs[-1][0] == short_explained.value["input_text"]
         assert plugin._agent.inputs[-1][2] == MODE_TEACHING
         assert plugin._agent.inputs[-1][1]["source"] == "manual"
@@ -1699,7 +1852,9 @@ async def test_learning_context_builds_question_params_off_event_loop(
             self.calls: list[tuple[str, bool]] = []
 
         def get_next_question_params(self, topic_id: str = "") -> dict[str, object]:
-            self.calls.append((topic_id, threading.get_ident() != self.event_loop_thread_id))
+            self.calls.append(
+                (topic_id, threading.get_ident() != self.event_loop_thread_id)
+            )
             return {"target_topic_id": topic_id, "threaded": self.calls[-1][1]}
 
     runtime_root = tmp_path / "runtime"
@@ -1725,7 +1880,10 @@ async def test_learning_context_builds_question_params_off_event_loop(
             extra={"topic_hint": "quadratic_vertex_form"},
         )
 
-        assert context["knowledge_question_params"]["target_topic_id"] == "quadratic_vertex_form"
+        assert (
+            context["knowledge_question_params"]["target_topic_id"]
+            == "quadratic_vertex_form"
+        )
         assert tracker.calls == [("quadratic_vertex_form", True)]
     finally:
         await plugin.shutdown()
@@ -1764,7 +1922,9 @@ async def test_study_evaluate_answer_does_not_reuse_old_expected_answer_for_cust
         )
 
         assert isinstance(evaluated, Ok)
-        assert fake_agent.evaluations[-1][0] == "What organelle stores genetic material?"
+        assert (
+            fake_agent.evaluations[-1][0] == "What organelle stores genetic material?"
+        )
         assert fake_agent.evaluations[-1][2] == ""
         assert fake_agent.evaluations[-1][3]["expected_answer"] == ""
     finally:
@@ -1785,7 +1945,9 @@ async def test_study_evaluate_answer_custom_question_does_not_reuse_old_topic(
             mode: str = MODE_COMPANION,
             context: dict[str, object] | None = None,
         ) -> TutorReply:
-            self.evaluations.append((question, answer, expected_answer, dict(context or {}), mode))
+            self.evaluations.append(
+                (question, answer, expected_answer, dict(context or {}), mode)
+            )
             return TutorReply(
                 operation="answer_evaluate",
                 input_text=answer,
@@ -1836,7 +1998,9 @@ async def test_study_evaluate_answer_custom_question_does_not_reuse_old_topic(
     plugin._agent = _TrackingTutorAgent()
 
     try:
-        plugin._store.ensure_topic(topic_id="photosynthesis_topic", name="Photosynthesis")
+        plugin._store.ensure_topic(
+            topic_id="photosynthesis_topic", name="Photosynthesis"
+        )
         plugin._store.ensure_topic(topic_id="cell_nucleus", name="Cell nucleus")
         with plugin._lock:
             plugin._state.current_question = {
@@ -1881,7 +2045,9 @@ async def test_study_evaluate_answer_persists_knowledge_tracking(
             mode: str = MODE_COMPANION,
             context: dict[str, object] | None = None,
         ) -> TutorReply:
-            self.evaluations.append((question, answer, expected_answer, dict(context or {}), mode))
+            self.evaluations.append(
+                (question, answer, expected_answer, dict(context or {}), mode)
+            )
             return TutorReply(
                 operation="answer_evaluate",
                 input_text=answer,
@@ -1940,7 +2106,9 @@ async def test_study_evaluate_answer_persists_knowledge_tracking(
                 "difficulty": 3,
             }
 
-        evaluated = await plugin.study_evaluate_answer(answer="(-h,k)", _ctx={"run_id": "answer-run-1"})
+        evaluated = await plugin.study_evaluate_answer(
+            answer="(-h,k)", _ctx={"run_id": "answer-run-1"}
+        )
         assert isinstance(evaluated, Ok)
         assert evaluated.value["verdict"] == "wrong"
 
@@ -1949,7 +2117,11 @@ async def test_study_evaluate_answer_persists_knowledge_tracking(
         assert mastery["level"] in {"薄弱", "进行中", "未接触"}
         assert plugin._store.get_fsrs_card("quadratic_vertex_form") is not None
         assert plugin._store.list_wrong_questions(topic_id="quadratic_vertex_form")
-        session = next(item for item in plugin._store.list_sessions() if item["id"] == "answer-run-1")
+        session = next(
+            item
+            for item in plugin._store.list_sessions()
+            if item["id"] == "answer-run-1"
+        )
         assert session["question_count"] == 1
         assert session["topics_touched"] == ["quadratic_vertex_form"]
 
@@ -1965,7 +2137,9 @@ async def test_study_evaluate_answer_persists_knowledge_tracking(
 
 
 @pytest.mark.asyncio
-async def test_tutor_agent_prompt_and_reply_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_tutor_agent_prompt_and_reply_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     messages = build_concept_explain_messages(
         text="A derivative measures instantaneous rate of change.",
         language="en",
@@ -1990,9 +2164,13 @@ async def test_tutor_agent_prompt_and_reply_contract(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
-async def test_tutor_agent_teaching_prefix_is_applied_once(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_tutor_agent_teaching_prefix_is_applied_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     agent = TutorLLMAgent(logger=_Logger(), config=StudyConfig(language="en"))
-    teaching_prefix = build_transition_phrase(MODE_TEACHING, language="en", outcome="changed")
+    teaching_prefix = build_transition_phrase(
+        MODE_TEACHING, language="en", outcome="changed"
+    )
 
     async def _fake_call_model(_messages):
         return f"{teaching_prefix}\n\nA derivative is the slope at one point."
@@ -2050,12 +2228,16 @@ def test_json_corrector_parses_plain_json() -> None:
 
 def test_json_corrector_parses_code_fenced_json() -> None:
     corrector = _JSONCorrector(logger=_Logger())
-    assert corrector.parse_json_object('```json\n{"question": "What is it?"}\n```') == {"question": "What is it?"}
+    assert corrector.parse_json_object('```json\n{"question": "What is it?"}\n```') == {
+        "question": "What is it?"
+    }
 
 
 def test_json_corrector_recovers_json_from_surrounding_text() -> None:
     corrector = _JSONCorrector(logger=_Logger())
-    assert corrector.parse_json_object('noise before {"topic": "biology", "score": 90} noise after') == {
+    assert corrector.parse_json_object(
+        'noise before {"topic": "biology", "score": 90} noise after'
+    ) == {
         "topic": "biology",
         "score": 90,
     }
@@ -2067,7 +2249,11 @@ def test_json_corrector_recovers_json_from_surrounding_text() -> None:
     [
         (
             "question_generate",
-            {"text": "Photosynthesis converts light to chemical energy.", "mode": MODE_INTERACTIVE, "context": {"screen_classification": {"screen_type": "reading"}}},
+            {
+                "text": "Photosynthesis converts light to chemical energy.",
+                "mode": MODE_INTERACTIVE,
+                "context": {"screen_classification": {"screen_type": "reading"}},
+            },
             {
                 "question": "What process converts light to chemical energy?",
                 "answer": "Photosynthesis",
@@ -2101,7 +2287,13 @@ def test_json_corrector_recovers_json_from_surrounding_text() -> None:
         ),
         (
             "knowledge_track",
-            {"mode": MODE_COMPANION, "context": {"screen_classification": {"screen_type": "review"}, "session_summary_seed": {"weak_points": ["definition"]}}},
+            {
+                "mode": MODE_COMPANION,
+                "context": {
+                    "screen_classification": {"screen_type": "review"},
+                    "session_summary_seed": {"weak_points": ["definition"]},
+                },
+            },
             {
                 "topic": "photosynthesis",
                 "mastery_delta": 0.1,
@@ -2117,7 +2309,12 @@ def test_json_corrector_recovers_json_from_surrounding_text() -> None:
         (
             "summarize_session",
             {
-                "history": [{"kind": "question_generate", "output_text": "What process converts light to chemical energy?"}],
+                "history": [
+                    {
+                        "kind": "question_generate",
+                        "output_text": "What process converts light to chemical energy?",
+                    }
+                ],
                 "mode": MODE_TEACHING,
                 "context": {"screen_classification": {"screen_type": "summary"}},
             },
@@ -2160,10 +2357,38 @@ async def test_tutor_agent_structured_operations_normal_path(
 @pytest.mark.parametrize(
     "operation_name, kwargs",
     [
-        ("question_generate", {"text": "Photosynthesis converts light to chemical energy.", "context": {"screen_classification": {"screen_type": "reading"}}}),
-        ("answer_evaluate", {"question": "What process converts light to chemical energy?", "answer": "It is photosynthesis.", "expected_answer": "Photosynthesis", "context": {"screen_classification": {"screen_type": "answering"}}}),
-        ("knowledge_track", {"context": {"screen_classification": {"screen_type": "review"}}}),
-        ("summarize_session", {"history": [{"kind": "question_generate", "output_text": "What process converts light to chemical energy?"}], "context": {"screen_classification": {"screen_type": "summary"}}}),
+        (
+            "question_generate",
+            {
+                "text": "Photosynthesis converts light to chemical energy.",
+                "context": {"screen_classification": {"screen_type": "reading"}},
+            },
+        ),
+        (
+            "answer_evaluate",
+            {
+                "question": "What process converts light to chemical energy?",
+                "answer": "It is photosynthesis.",
+                "expected_answer": "Photosynthesis",
+                "context": {"screen_classification": {"screen_type": "answering"}},
+            },
+        ),
+        (
+            "knowledge_track",
+            {"context": {"screen_classification": {"screen_type": "review"}}},
+        ),
+        (
+            "summarize_session",
+            {
+                "history": [
+                    {
+                        "kind": "question_generate",
+                        "output_text": "What process converts light to chemical energy?",
+                    }
+                ],
+                "context": {"screen_classification": {"screen_type": "summary"}},
+            },
+        ),
     ],
 )
 async def test_tutor_agent_structured_operations_degrade_with_generic_diagnostics(
@@ -2186,7 +2411,9 @@ async def test_tutor_agent_structured_operations_degrade_with_generic_diagnostic
 
 
 @pytest.mark.asyncio
-async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from utils import config_manager, llm_client
 
     class _ConfigManager:
@@ -2235,7 +2462,9 @@ async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(monkeypatch:
 
 
 @pytest.mark.asyncio
-async def test_study_plugin_starts_and_collects_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_study_plugin_starts_and_collects_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     runtime_root = tmp_path / "runtime"
     monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
     ctx = _Ctx(
@@ -2259,7 +2488,9 @@ async def test_study_plugin_starts_and_collects_entries(tmp_path: Path, monkeypa
     assert "study_export_notes" not in entries
     assert "study_knowledge_map" in entries
     assert "study_set_knowledge_contribution_opt_in" in entries
-    disabled_export = await plugin._study_export_notes_entry(fmt="markdown", preview_only=True, title="Default Notes")
+    disabled_export = await plugin._study_export_notes_entry(
+        fmt="markdown", preview_only=True, title="Default Notes"
+    )
     assert isinstance(disabled_export, Err)
     status = await plugin.study_status()
     assert isinstance(status, Ok)
@@ -2272,7 +2503,9 @@ async def test_study_plugin_starts_and_collects_entries(tmp_path: Path, monkeypa
     assert "review_queue" in status.value
     assert "weak_topics" in status.value
     assert "mastery_overview" in status.value
-    assert (runtime_root / "plugins" / "study_companion" / "data" / "study_companion.db").is_file()
+    assert (
+        runtime_root / "plugins" / "study_companion" / "data" / "study_companion.db"
+    ).is_file()
     await plugin.shutdown()
 
 
@@ -2347,7 +2580,10 @@ async def test_study_plugin_shutdown_continues_when_dynamic_entry_cleanup_fails(
 
     assert isinstance(shutdown_result, Ok)
     assert shutdown_called is True
-    assert any("dynamic entry cleanup failed" in str(args[0]) for args, _kwargs in ctx.logger.warnings)
+    assert any(
+        "dynamic entry cleanup failed" in str(args[0])
+        for args, _kwargs in ctx.logger.warnings
+    )
 
 
 @pytest.mark.asyncio
@@ -2363,7 +2599,11 @@ async def test_study_plugin_doc_export_dynamic_entry_and_knowledge_settings(
             "study": {"language": "en"},
             "ocr_reader": {"enabled": True},
             "rapidocr": {"lang_type": "ch"},
-            "doc_export": {"enabled": True, "default_style": "compact", "xmind_enabled": False},
+            "doc_export": {
+                "enabled": True,
+                "default_style": "compact",
+                "xmind_enabled": False,
+            },
         },
     )
     plugin = StudyCompanionPlugin(ctx)
@@ -2388,7 +2628,9 @@ async def test_study_plugin_doc_export_dynamic_entry_and_knowledge_settings(
             history_limit=10,
         )
 
-        exported = await entries["study_export_notes"].handler(fmt="markdown", preview_only=False, title="Unit Notes")
+        exported = await entries["study_export_notes"].handler(
+            fmt="markdown", preview_only=False, title="Unit Notes"
+        )
         assert isinstance(exported, Ok)
         assert exported.value["filename"] == "unit-notes.md"
         assert exported.value["format"] == "markdown"
@@ -2417,7 +2659,10 @@ async def test_study_plugin_doc_export_dynamic_entry_and_knowledge_settings(
         preview = await plugin.study_anonymous_knowledge_preview(limit=10)
         assert isinstance(preview, Ok)
         assert preview.value["opt_in"] is True
-        assert plugin._store.load_config(StudyConfig()).knowledge_contribution_opt_in is True
+        assert (
+            plugin._store.load_config(StudyConfig()).knowledge_contribution_opt_in
+            is True
+        )
     finally:
         await plugin.shutdown()
 
@@ -2443,7 +2688,10 @@ async def test_study_knowledge_contribution_opt_in_preview_failure_is_atomic(
         result = await plugin.study_set_knowledge_contribution_opt_in(opt_in=True)
         assert isinstance(result, Err)
         assert plugin._cfg.knowledge_contribution_opt_in is False
-        assert plugin._store.load_config(StudyConfig()).knowledge_contribution_opt_in is False
+        assert (
+            plugin._store.load_config(StudyConfig()).knowledge_contribution_opt_in
+            is False
+        )
     finally:
         await plugin.shutdown()
 
@@ -2470,7 +2718,9 @@ async def test_study_plugin_doc_export_schema_includes_xmind_only_when_enabled(
 
     try:
         entries = plugin.collect_entries()
-        export_formats = entries["study_export_notes"].meta.input_schema["properties"]["fmt"]["enum"]
+        export_formats = entries["study_export_notes"].meta.input_schema["properties"][
+            "fmt"
+        ]["enum"]
         assert export_formats == ["markdown", "pdf", "docx", "xmind"]
     finally:
         await plugin.shutdown()
@@ -2494,7 +2744,9 @@ async def test_study_plugin_startup_restores_runtime_mode_without_overwriting_de
     state = build_initial_state(mode=MODE_TEACHING)
     plugin._store.open()
     try:
-        plugin._store.save_config(StudyConfig(mode=MODE_COMPANION, default_mode=MODE_COMPANION, language="en"))
+        plugin._store.save_config(
+            StudyConfig(mode=MODE_COMPANION, default_mode=MODE_COMPANION, language="en")
+        )
         plugin._store.save_state(state)
     finally:
         plugin._store.close()
@@ -2512,7 +2764,9 @@ async def test_study_plugin_startup_restores_runtime_mode_without_overwriting_de
 
 
 @pytest.mark.asyncio
-async def test_study_plugin_startup_failure_cleans_partial_resources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_study_plugin_startup_failure_cleans_partial_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     runtime_root = tmp_path / "runtime"
     monkeypatch.setenv("NEKO_STORAGE_SELECTED_ROOT", str(runtime_root))
 

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -1673,6 +1673,57 @@ async def test_study_ocr_snapshot_preserves_last_text_when_capture_fails(
 
 
 @pytest.mark.asyncio
+async def test_study_ocr_snapshot_feeds_supervision_activity() -> None:
+    class _Supervision:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def observe_activity(
+            self, *, ocr_text: str, sensor_available: bool
+        ) -> dict[str, object]:
+            self.calls.append(
+                {"ocr_text": ocr_text, "sensor_available": sensor_available}
+            )
+            return {
+                "sensor_available": sensor_available,
+                "inactivity_detected": False,
+            }
+
+    persisted: list[bool] = []
+
+    async def _persist_state() -> None:
+        persisted.append(True)
+
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._ocr_pipeline = _FakeStudyOcrPipeline(
+        OcrSnapshot(
+            text="photosynthesis note",
+            status="ok",
+            captured_at="2026-05-11T00:00:00Z",
+        )
+    )
+    plugin._supervision = supervision
+    plugin._lock = threading.RLock()
+    plugin._state = build_initial_state()
+    plugin._persist_state = _persist_state
+    plugin._update_screen_classification = lambda text, update_empty=False: {
+        "screen_type": "reading",
+        "text": text,
+        "update_empty": update_empty,
+    }
+
+    result = await plugin.study_ocr_snapshot()
+
+    assert isinstance(result, Ok)
+    assert result.value["supervision"]["sensor_available"] is True
+    assert supervision.calls == [
+        {"ocr_text": "photosynthesis note", "sensor_available": True}
+    ]
+    assert persisted == [True]
+
+
+@pytest.mark.asyncio
 async def test_study_explain_text_detects_mode_intent_and_continues_when_content_exists(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2516,6 +2567,41 @@ async def test_study_pomodoro_status_offloads_timer_operations(
     assert status.value["state"] == "short_break"
     assert to_thread_calls == ["status", "tick"]
     assert supervision.focus_end_count == 1
+
+
+@pytest.mark.asyncio
+async def test_study_pomodoro_status_drives_supervision_reminders() -> None:
+    class _Timer:
+        def status(self) -> dict[str, object]:
+            return {"state": "focusing", "remaining_seconds": 120}
+
+        def tick(self) -> dict[str, object]:
+            return {"state": "focusing", "remaining_seconds": 119}
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.reminder_count = 0
+
+        def due_reminder(self) -> dict[str, object]:
+            self.reminder_count += 1
+            return {"due": True, "reminder_level": "low_frequency"}
+
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._habit_store = object()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = _Timer()
+    plugin._supervision = supervision
+
+    status = await plugin.study_pomodoro_status()
+
+    assert isinstance(status, Ok)
+    assert status.value["state"] == "focusing"
+    assert status.value["supervision_reminder"] == {
+        "due": True,
+        "reminder_level": "low_frequency",
+    }
+    assert supervision.reminder_count == 1
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -2605,6 +2605,46 @@ async def test_study_pomodoro_status_drives_supervision_reminders() -> None:
 
 
 @pytest.mark.asyncio
+async def test_study_pomodoro_stop_offloads_timer_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Timer:
+        def stop(self) -> dict[str, object]:
+            return {
+                "state": "cancelled",
+                "current_focus_session": {"id": "focus-1", "status": "cancelled"},
+            }
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.focus_end_count = 0
+
+        def on_focus_end(self) -> None:
+            self.focus_end_count += 1
+
+    to_thread_calls: list[str] = []
+
+    async def _to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(study_companion_module.asyncio, "to_thread", _to_thread)
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._habit_store = object()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = _Timer()
+    plugin._supervision = supervision
+
+    status = await plugin.study_pomodoro_stop()
+
+    assert isinstance(status, Ok)
+    assert status.value["state"] == "cancelled"
+    assert to_thread_calls == ["stop"]
+    assert supervision.focus_end_count == 1
+
+
+@pytest.mark.asyncio
 async def test_study_pomodoro_start_does_not_restart_supervision_on_noop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -2519,6 +2519,71 @@ async def test_study_pomodoro_status_offloads_timer_operations(
 
 
 @pytest.mark.asyncio
+async def test_study_pomodoro_start_does_not_restart_supervision_on_noop() -> None:
+    class _Habits:
+        def get_goal(self, _goal_id: str) -> dict[str, object]:
+            return {"id": "goal-1"}
+
+    class _Timer:
+        def status(self) -> dict[str, object]:
+            return {
+                "state": "focusing",
+                "current_focus_session": {"id": "focus-1"},
+                "config": {"focus_minutes": 25},
+            }
+
+        def start(self, **_kwargs) -> dict[str, object]:
+            return self.status()
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.focus_start_count = 0
+
+        def on_focus_start(self, **_kwargs) -> None:
+            self.focus_start_count += 1
+
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._cfg = StudyConfig()
+    plugin._habit_store = _Habits()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = _Timer()
+    plugin._supervision = supervision
+
+    status = await plugin.study_pomodoro_start(goal_id="goal-1")
+
+    assert isinstance(status, Ok)
+    assert status.value["state"] == "focusing"
+    assert supervision.focus_start_count == 0
+
+
+@pytest.mark.asyncio
+async def test_study_supervision_toggle_respects_disable_guard() -> None:
+    class _Supervision:
+        def __init__(self) -> None:
+            self.calls: list[bool] = []
+
+        def set_enabled(self, enabled: bool) -> dict[str, object]:
+            self.calls.append(enabled)
+            return {"enabled": enabled}
+
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._cfg = StudyConfig()
+    plugin._cfg.supervision.allow_disable_by_chat = False
+    plugin._habit_store = object()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = object()
+    plugin._supervision = supervision
+
+    result = await plugin.study_supervision_toggle(enabled=False)
+
+    assert isinstance(result, Err)
+    assert "blocked by config" in str(result.error)
+    assert supervision.calls == []
+
+
+@pytest.mark.asyncio
 async def test_study_plugin_starts_and_collects_entries(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -18,6 +18,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
     import tomli as tomllib  # type: ignore[no-redef]
 
 from plugin.core.ui_manifest import normalize_plugin_ui_manifest
+from plugin.plugins import study_companion as study_companion_module
 from plugin.plugins.study_companion import StudyCompanionPlugin
 from plugin.plugins.study_companion.llm_prompts import (
     _compact_prompt_value,
@@ -1100,6 +1101,10 @@ def test_study_companion_static_panel_keeps_mode_highlight_when_status_refresh_f
 
     plugin_dir = Path(__file__).resolve().parents[3] / "plugins" / "study_companion"
     frontend_dir = Path(__file__).resolve().parents[4] / "frontend" / "plugin-manager"
+    if not (frontend_dir / "node_modules" / "happy-dom").is_dir():
+        pytest.skip(
+            "frontend/plugin-manager node_modules with happy-dom is not installed"
+        )
 
     script = r"""
 import { Window } from 'happy-dom';
@@ -1223,6 +1228,18 @@ if (document.querySelector('[data-mode="interactive"]').getAttribute('aria-press
         check=False,
     )
     assert completed.returncode == 0, completed.stderr or completed.stdout
+
+
+def test_study_surface_utils_preserves_nonstandard_backend_error_details() -> None:
+    plugin_dir = Path(__file__).resolve().parents[3] / "plugins" / "study_companion"
+    source = (plugin_dir / "surfaces" / "study_surface_utils.ts").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function pluginErrorMessage" in source
+    assert "typeof error === 'string'" in source
+    assert "JSON.stringify(error)" in source
+    assert "throw new Error(pluginErrorMessage(item.json.error))" in source
 
 
 def test_study_companion_i18n_prefers_traditional_chinese_bundle() -> None:
@@ -2459,6 +2476,46 @@ async def test_tutor_agent_llm_cache_distinguishes_rotated_api_keys(
     assert all("max_completion_tokens" not in item for item in create_kwargs)
     assert "old-key" not in repr(agent._client_cache._cache)
     assert "new-key" not in repr(agent._client_cache._cache)
+
+
+@pytest.mark.asyncio
+async def test_study_pomodoro_status_offloads_timer_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Timer:
+        def status(self) -> dict[str, object]:
+            return {"state": "focusing", "remaining_seconds": 1}
+
+        def tick(self) -> dict[str, object]:
+            return {"state": "short_break", "remaining_seconds": 300}
+
+    class _Supervision:
+        def __init__(self) -> None:
+            self.focus_end_count = 0
+
+        def on_focus_end(self) -> None:
+            self.focus_end_count += 1
+
+    to_thread_calls: list[str] = []
+
+    async def _to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(study_companion_module.asyncio, "to_thread", _to_thread)
+    plugin = StudyCompanionPlugin.__new__(StudyCompanionPlugin)
+    supervision = _Supervision()
+    plugin._habit_store = object()
+    plugin._checkin_manager = object()
+    plugin._pomodoro_timer = _Timer()
+    plugin._supervision = supervision
+
+    status = await plugin.study_pomodoro_status()
+
+    assert isinstance(status, Ok)
+    assert status.value["state"] == "short_break"
+    assert to_thread_calls == ["status", "tick"]
+    assert supervision.focus_end_count == 1
 
 
 @pytest.mark.asyncio

--- a/plugin/tests/unit/plugins/test_study_companion_phase6_ui.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase6_ui.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from plugin.core.ui_manifest import normalize_plugin_ui_manifest
+from plugin.plugins.study_companion.models import build_config
+from plugin.plugins.study_companion.ui_api import (
+    build_habit_dashboard_payload,
+    build_pomodoro_status_payload,
+)
+from plugin.server.application.plugins.ui_query_service import _build_surfaces_sync
+
+
+def test_phase6_config_parses_habit_defaults_and_clamps_ranges() -> None:
+    config = build_config(
+        {
+            "study": {
+                "pomodoro": {
+                    "focus_minutes": 500,
+                    "short_break_minutes": -1,
+                    "long_break_minutes": 99,
+                    "long_break_interval": 50,
+                    "allow_skip_break": False,
+                },
+                "supervision": {
+                    "enabled": True,
+                    "remind_interval_minutes": 0,
+                    "inactivity_timeout_minutes": 99,
+                    "allow_disable_by_chat": False,
+                },
+                "checkin": {
+                    "streak_timezone": "Asia/Shanghai",
+                    "makeup_window_days": 99,
+                    "auto_derive_from_session": False,
+                },
+            }
+        }
+    )
+
+    assert config.pomodoro.focus_minutes == 25
+    assert config.pomodoro.short_break_minutes == 5
+    assert config.pomodoro.long_break_minutes == 15
+    assert config.pomodoro.long_break_interval == 4
+    assert config.pomodoro.allow_skip_break is False
+    assert config.supervision.remind_interval_minutes == 10
+    assert config.supervision.inactivity_timeout_minutes == 5
+    assert config.supervision.allow_disable_by_chat is False
+    assert config.checkin.streak_timezone == "Asia/Shanghai"
+    assert config.checkin.makeup_window_days == 3
+    assert config.checkin.auto_derive_from_session is False
+
+
+def test_phase6_ui_guides_are_registered() -> None:
+    plugin_dir = Path(__file__).resolve().parents[3] / "plugins" / "study_companion"
+    with (plugin_dir / "plugin.toml").open("rb") as handle:
+        config = tomllib.load(handle)
+    plugin_ui = normalize_plugin_ui_manifest(config, plugin_id="study_companion")
+    assert plugin_ui is not None
+    surfaces, warnings = _build_surfaces_sync(
+        "study_companion",
+        {
+            "id": "study_companion",
+            "config_path": str(plugin_dir / "plugin.toml"),
+            "plugin_ui": plugin_ui,
+            "i18n": config["plugin"]["i18n"],
+        },
+    )
+
+    assert warnings == []
+    surface_ids = {surface["id"] for surface in surfaces if surface["available"]}
+    assert {"habit-dashboard", "pomodoro-panel", "daily-goal-editor", "session-summary"}.issubset(surface_ids)
+
+
+def test_phase6_ui_payload_builders_shape_dashboard_and_pomodoro_status() -> None:
+    pomodoro = build_pomodoro_status_payload(
+        {"state": "focusing", "remaining_seconds": 1200, "session_count": 2},
+    )
+    dashboard = build_habit_dashboard_payload(
+        goals=[{"id": "g1", "status": "completed", "target_amount": 1, "progress_amount": 1}],
+        checkin={"checked_in": True, "streak_days": 5},
+        pomodoro=pomodoro,
+        summary={"total_focus_minutes": 50},
+        supervision={"enabled": True, "sensor_available": False},
+    )
+
+    assert pomodoro["state"] == "focusing"
+    assert pomodoro["remaining_seconds"] == 1200
+    assert dashboard["summary"]["completed_goal_count"] == 1
+    assert dashboard["checkin"]["streak_days"] == 5
+    assert dashboard["supervision"]["sensor_available"] is False

--- a/plugin/tests/unit/plugins/test_study_companion_phase6_ui.py
+++ b/plugin/tests/unit/plugins/test_study_companion_phase6_ui.py
@@ -73,7 +73,12 @@ def test_phase6_ui_guides_are_registered() -> None:
 
     assert warnings == []
     surface_ids = {surface["id"] for surface in surfaces if surface["available"]}
-    assert {"habit-dashboard", "pomodoro-panel", "daily-goal-editor", "session-summary"}.issubset(surface_ids)
+    assert {
+        "habit-dashboard",
+        "pomodoro-panel",
+        "daily-goal-editor",
+        "session-summary",
+    }.issubset(surface_ids)
 
 
 def test_phase6_ui_payload_builders_shape_dashboard_and_pomodoro_status() -> None:
@@ -81,7 +86,14 @@ def test_phase6_ui_payload_builders_shape_dashboard_and_pomodoro_status() -> Non
         {"state": "focusing", "remaining_seconds": 1200, "session_count": 2},
     )
     dashboard = build_habit_dashboard_payload(
-        goals=[{"id": "g1", "status": "completed", "target_amount": 1, "progress_amount": 1}],
+        goals=[
+            {
+                "id": "g1",
+                "status": "completed",
+                "target_amount": 1,
+                "progress_amount": 1,
+            }
+        ],
         checkin={"checked_in": True, "streak_days": 5},
         pomodoro=pomodoro,
         summary={"total_focus_minutes": 50},

--- a/plugin/tests/unit/plugins/test_study_habit_store.py
+++ b/plugin/tests/unit/plugins/test_study_habit_store.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugin.plugins.study_companion.checkin_manager import CheckinManager
+from plugin.plugins.study_companion.study_habit_store import StudyHabitStore
+from plugin.plugins.study_companion.store import StudyStore
+
+
+class _Logger:
+    def warning(self, *args, **kwargs):
+        return None
+
+
+def _study_store(tmp_path: Path) -> StudyStore:
+    store = StudyStore(tmp_path / "study.db", tmp_path / "seed.json", _Logger())
+    store.open()
+    return store
+
+
+def test_habit_store_creates_goals_and_cascades_focus_sessions(tmp_path: Path) -> None:
+    store = _study_store(tmp_path)
+    try:
+        habits = StudyHabitStore(store)
+        goal = habits.create_goal(
+            date="2026-05-22",
+            target_type="subject",
+            subject="math",
+            target_amount=2,
+            unit="pomodoro",
+        )
+        focus = habits.create_focus_session(
+            goal_id=goal["id"],
+            mode="focus",
+            planned_minutes=25,
+            started_at="2026-05-22T23:50:00+08:00",
+        )
+        habits.finish_focus_session(
+            focus["id"],
+            ended_at="2026-05-23T00:15:00+08:00",
+            actual_minutes=25,
+            status="completed",
+        )
+
+        assert habits.list_goals(date="2026-05-22")[0]["progress_amount"] == 0
+        assert habits.list_focus_sessions(date="2026-05-22")[0]["actual_minutes"] == 25
+        assert habits.list_focus_sessions(date="2026-05-23") == []
+
+        habits.delete_goal(goal["id"])
+
+        assert habits.list_goals(date="2026-05-22") == []
+        assert habits.list_focus_sessions(date="2026-05-22") == []
+    finally:
+        store.close()
+
+
+def test_checkin_manager_tracks_streaks_makeups_and_session_derived_progress(tmp_path: Path) -> None:
+    store = _study_store(tmp_path)
+    try:
+        habits = StudyHabitStore(store)
+        manager = CheckinManager(habits, makeup_window_days=3)
+        goal = manager.create_goal(
+            date="2026-05-20",
+            target_type="subject",
+            subject="math",
+            target_amount=30,
+            unit="minute",
+        )
+
+        manager.apply_session_progress(
+            date="2026-05-20",
+            duration_minutes=20,
+            question_count=3,
+            subject="math",
+        )
+        manager.manual_checkin(date="2026-05-21", today="2026-05-22", note="复习错题")
+        manager.manual_checkin(date="2026-05-22", today="2026-05-22")
+        manager.apply_session_progress(
+            date="2026-05-20",
+            duration_minutes=10,
+            question_count=0,
+            subject="math",
+        )
+
+        updated = habits.get_goal(goal["id"])
+        status = manager.checkin_status(date="2026-05-22", today="2026-05-22")
+        summary = manager.daily_summary(date="2026-05-20")
+
+        assert updated is not None
+        assert updated["progress_amount"] == 30
+        assert updated["status"] == "completed"
+        assert status["checked_in"] is True
+        assert status["streak_days"] == 3
+        assert status["makeup_window_days"] == 3
+        assert summary["total_focus_minutes"] == 30
+        assert summary["completed_goal_count"] == 1
+        assert summary["weak_points"] == []
+    finally:
+        store.close()
+
+
+def test_habit_data_stays_out_of_public_knowledge_export(tmp_path: Path) -> None:
+    store = _study_store(tmp_path)
+    try:
+        habits = StudyHabitStore(store)
+        habits.create_goal(
+            date="2026-05-22",
+            target_type="custom",
+            subject="private",
+            target_amount=1,
+            unit="task",
+            target_id="personal-plan",
+        )
+
+        exported = store.export_json()
+
+        assert "daily_goals" not in exported
+        assert "checkins" not in exported
+        assert "focus_sessions" not in exported
+        assert "personal-plan" not in str(exported)
+    finally:
+        store.close()

--- a/plugin/tests/unit/plugins/test_study_habit_store.py
+++ b/plugin/tests/unit/plugins/test_study_habit_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
 from pathlib import Path
 
 from plugin.plugins.study_companion.checkin_manager import CheckinManager
@@ -121,5 +122,27 @@ def test_habit_data_stays_out_of_public_knowledge_export(tmp_path: Path) -> None
         assert "checkins" not in exported
         assert "focus_sessions" not in exported
         assert "personal-plan" not in str(exported)
+    finally:
+        store.close()
+
+
+def test_checkin_streak_is_not_truncated_at_default_checked_dates_limit(
+    tmp_path: Path,
+) -> None:
+    store = _study_store(tmp_path)
+    try:
+        habits = StudyHabitStore(store)
+        manager = CheckinManager(habits, makeup_window_days=3)
+        start = date(2025, 1, 1)
+        for offset in range(405):
+            habits.record_checkin(
+                date=(start + timedelta(days=offset)).isoformat(),
+                status="checked_in",
+                source="manual",
+            )
+
+        status = manager.checkin_status(date="2026-02-09", today="2026-02-09")
+
+        assert status["streak_days"] == 405
     finally:
         store.close()

--- a/plugin/tests/unit/plugins/test_study_habit_store.py
+++ b/plugin/tests/unit/plugins/test_study_habit_store.py
@@ -50,6 +50,7 @@ def test_habit_store_creates_goals_and_cascades_focus_sessions(tmp_path: Path) -
 
         assert habits.list_goals(date="2026-05-22") == []
         assert habits.list_focus_sessions(date="2026-05-22") == []
+        assert habits.delete_goal("missing-goal") is False
     finally:
         store.close()
 

--- a/plugin/tests/unit/plugins/test_study_habit_store.py
+++ b/plugin/tests/unit/plugins/test_study_habit_store.py
@@ -54,7 +54,9 @@ def test_habit_store_creates_goals_and_cascades_focus_sessions(tmp_path: Path) -
         store.close()
 
 
-def test_checkin_manager_tracks_streaks_makeups_and_session_derived_progress(tmp_path: Path) -> None:
+def test_checkin_manager_tracks_streaks_makeups_and_session_derived_progress(
+    tmp_path: Path,
+) -> None:
     store = _study_store(tmp_path)
     try:
         habits = StudyHabitStore(store)

--- a/plugin/tests/unit/plugins/test_supervision.py
+++ b/plugin/tests/unit/plugins/test_supervision.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from plugin.plugins.study_companion.supervision import SupervisionConfig, SupervisionController
+
+
+def test_supervision_reminders_are_low_frequency_and_can_be_disabled() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(enabled=True, remind_interval_minutes=10, inactivity_timeout_minutes=5),
+        clock=lambda: 0.0,
+    )
+
+    start = controller.on_focus_start(goal={"subject": "math"}, planned_minutes=25, now=0.0)
+    assert start["reminder_level"] == "start"
+    assert start["enabled"] is True
+
+    assert controller.due_reminder(now=9 * 60)["due"] is False
+    assert controller.due_reminder(now=10 * 60)["due"] is True
+    assert controller.due_reminder(now=11 * 60)["due"] is False
+
+    disabled = controller.set_enabled(False)
+
+    assert disabled["enabled"] is False
+    assert controller.due_reminder(now=30 * 60)["due"] is False
+
+
+def test_supervision_inactivity_degrades_when_sensor_unavailable() -> None:
+    controller = SupervisionController(
+        SupervisionConfig(enabled=True, remind_interval_minutes=10, inactivity_timeout_minutes=5),
+        clock=lambda: 0.0,
+    )
+    controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
+
+    unavailable = controller.observe_activity(ocr_text="", sensor_available=False, now=60.0)
+    first = controller.observe_activity(ocr_text="same text", sensor_available=True, now=120.0)
+    inactive = controller.observe_activity(ocr_text="same text", sensor_available=True, now=421.0)
+    changed = controller.observe_activity(ocr_text="new text", sensor_available=True, now=430.0)
+
+    assert unavailable["sensor_available"] is False
+    assert unavailable["inactivity_detected"] is False
+    assert first["inactivity_detected"] is False
+    assert inactive["inactivity_detected"] is True
+    assert inactive["suggested_action"] == "pause_or_switch"
+    assert changed["inactivity_detected"] is False

--- a/plugin/tests/unit/plugins/test_supervision.py
+++ b/plugin/tests/unit/plugins/test_supervision.py
@@ -63,3 +63,4 @@ def test_supervision_inactivity_degrades_when_sensor_unavailable() -> None:
     assert inactive["inactivity_detected"] is True
     assert inactive["suggested_action"] == "pause_or_switch"
     assert changed["inactivity_detected"] is False
+    assert changed["reminder_level"] != "inactivity"

--- a/plugin/tests/unit/plugins/test_supervision.py
+++ b/plugin/tests/unit/plugins/test_supervision.py
@@ -29,6 +29,11 @@ def test_supervision_reminders_are_low_frequency_and_can_be_disabled() -> None:
     assert disabled["enabled"] is False
     assert controller.due_reminder(now=30 * 60)["due"] is False
 
+    ended = controller.on_focus_end(now=31 * 60)
+
+    assert ended["focus_active"] is False
+    assert ended["reminder_level"] == "end"
+
 
 def test_supervision_inactivity_degrades_when_sensor_unavailable() -> None:
     controller = SupervisionController(

--- a/plugin/tests/unit/plugins/test_supervision.py
+++ b/plugin/tests/unit/plugins/test_supervision.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
-from plugin.plugins.study_companion.supervision import SupervisionConfig, SupervisionController
+from plugin.plugins.study_companion.supervision import (
+    SupervisionConfig,
+    SupervisionController,
+)
 
 
 def test_supervision_reminders_are_low_frequency_and_can_be_disabled() -> None:
     controller = SupervisionController(
-        SupervisionConfig(enabled=True, remind_interval_minutes=10, inactivity_timeout_minutes=5),
+        SupervisionConfig(
+            enabled=True, remind_interval_minutes=10, inactivity_timeout_minutes=5
+        ),
         clock=lambda: 0.0,
     )
 
-    start = controller.on_focus_start(goal={"subject": "math"}, planned_minutes=25, now=0.0)
+    start = controller.on_focus_start(
+        goal={"subject": "math"}, planned_minutes=25, now=0.0
+    )
     assert start["reminder_level"] == "start"
     assert start["enabled"] is True
 
@@ -25,15 +32,25 @@ def test_supervision_reminders_are_low_frequency_and_can_be_disabled() -> None:
 
 def test_supervision_inactivity_degrades_when_sensor_unavailable() -> None:
     controller = SupervisionController(
-        SupervisionConfig(enabled=True, remind_interval_minutes=10, inactivity_timeout_minutes=5),
+        SupervisionConfig(
+            enabled=True, remind_interval_minutes=10, inactivity_timeout_minutes=5
+        ),
         clock=lambda: 0.0,
     )
     controller.on_focus_start(goal={}, planned_minutes=25, now=0.0)
 
-    unavailable = controller.observe_activity(ocr_text="", sensor_available=False, now=60.0)
-    first = controller.observe_activity(ocr_text="same text", sensor_available=True, now=120.0)
-    inactive = controller.observe_activity(ocr_text="same text", sensor_available=True, now=421.0)
-    changed = controller.observe_activity(ocr_text="new text", sensor_available=True, now=430.0)
+    unavailable = controller.observe_activity(
+        ocr_text="", sensor_available=False, now=60.0
+    )
+    first = controller.observe_activity(
+        ocr_text="same text", sensor_available=True, now=120.0
+    )
+    inactive = controller.observe_activity(
+        ocr_text="same text", sensor_available=True, now=421.0
+    )
+    changed = controller.observe_activity(
+        ocr_text="new text", sensor_available=True, now=430.0
+    )
 
     assert unavailable["sensor_available"] is False
     assert unavailable["inactivity_detected"] is False


### PR DESCRIPTION
## Summary

实现伴学插件 Phase 6 学习习惯系统，补齐"长期陪伴"和"学习执行"能力。

- 新增 `study_habit_store.py` — daily_goals / checkins / focus_sessions 三表 SQLite 持久化
- 新增 `pomodoro_timer.py` — asyncio 非阻塞番茄钟状态机（idle → focusing ↔ paused → short_break/long_break → completed/cancelled）
- 新增 `checkin_manager.py` — 每日目标 CRUD + 打卡/补签 + StudySession.close() 自动汇总
- 新增 `supervision.py` — 四阶段监督策略（专注开始/中/无活动检测/结束），OCR 不可用时降级
- 新增前端 4 面板：habit_dashboard / pomodoro_panel / daily_goal_editor / session_summary
- 新增 `ui_api.py` 15 个 API 端点
- 新增 `plugin.toml` 配置段：`[study.pomodoro]` / `[study.supervision]` / `[study.checkin]`

## Test plan

- [x] `test_pomodoro_timer.py` — 番茄钟状态机全部转换路径
- [x] `test_study_habit_store.py` — 打卡连续天数 + 汇总 + 数据隔离
- [x] `test_supervision.py` — 专注中模式切换 + 提醒频率
- [x] `test_study_companion_phase6_ui.py` — UI 面板基础渲染
- [ ] 实机验收：番茄钟完整状态流转 / 打卡连续天数 / 监督降级 / 习惯数据本地隔离

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 完整习惯体系：日目标 CRUD、手动/补签、会话派生打卡与每日汇总
  * 番茄钟：启动/暂停/恢复/停止/跳过、可自定义时长、会话计数与时区感知的派生打卡
  * 专注监督：无活动检测、到期提醒、启用/禁用控制
  * 前端表面与工具：习惯仪表板、番茄面板、目标编辑器、会话摘要与前端调用/错误格式化工具

* **改进**
  * 状态/负载结构化更一致，学习追踪与屏幕识别更稳健
  * 时间与时区处理更健壮，启动/失败清理与错误信息更友好
  * 导出更安全，习惯数据不出现在公开导出

* **测试**
  * 大量单元测试覆盖习惯存储、打卡、番茄计时、监督与 UI 构建

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->