### PR TITLE
ci(health-check): 移除 lanlan.tech (China, old) 监听

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -35,30 +35,6 @@ jobs:
             echo "healthy=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── 检查 lanlan.tech (China, old) ──
-      - name: Check lanlan.tech (old)
-        id: check_tech
-        run: |
-          HTTP_CODE=$(curl -s -o /tmp/resp_tech.json -w "%{http_code}" \
-            --max-time 30 --connect-timeout 10 \
-            -X POST "https://lanlan.tech/text/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer free-access" \
-            -d '{"model":"free-mini-model","messages":[{"role":"user","content":"sends some useful information"}],"max_completion_tokens":5}' \
-            2>/dev/null || echo "000")
-          BODY=$(cat /tmp/resp_tech.json 2>/dev/null || echo "{}")
-          echo "http_code=$HTTP_CODE" >> "$GITHUB_OUTPUT"
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            if echo "$BODY" | jq -e '(.choices | type) == "array" and (.choices | length) > 0 and (.choices[0].message | type) == "object" and .choices[0].message.role == "assistant" and (.choices[0].message | has("content"))' >/dev/null 2>&1; then
-              echo "healthy=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "healthy=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "healthy=false" >> "$GITHUB_OUTPUT"
-          fi
-
       # ── 检查 www.lanlan.app (US, new) ──
       - name: Check www.lanlan.app (new)
         id: check_api_app
@@ -116,9 +92,7 @@ jobs:
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           APP_HEALTHY="${{ steps.check_app.outputs.healthy }}"
-          TECH_HEALTHY="${{ steps.check_tech.outputs.healthy }}"
           APP_CODE="${{ steps.check_app.outputs.http_code }}"
-          TECH_CODE="${{ steps.check_tech.outputs.http_code }}"
 
           API_APP_HEALTHY="${{ steps.check_api_app.outputs.healthy }}"
           API_TECH_HEALTHY="${{ steps.check_api_tech.outputs.healthy }}"
@@ -127,7 +101,7 @@ jobs:
 
           ALL_HEALTHY="true"
           ANY_DOWN="false"
-          for h in "$APP_HEALTHY" "$TECH_HEALTHY" "$API_APP_HEALTHY" "$API_TECH_HEALTHY"; do
+          for h in "$APP_HEALTHY" "$API_APP_HEALTHY" "$API_TECH_HEALTHY"; do
             if [ "$h" = "false" ]; then
               ALL_HEALTHY="false"
               ANY_DOWN="true"
@@ -137,7 +111,7 @@ jobs:
           if [ "$ALL_HEALTHY" = "true" ]; then
             COLOR=3066993  # green
             TITLE="All Servers Healthy"
-          elif [ "$APP_HEALTHY" = "false" ] && [ "$TECH_HEALTHY" = "false" ] && [ "$API_APP_HEALTHY" = "false" ] && [ "$API_TECH_HEALTHY" = "false" ]; then
+          elif [ "$APP_HEALTHY" = "false" ] && [ "$API_APP_HEALTHY" = "false" ] && [ "$API_TECH_HEALTHY" = "false" ]; then
             COLOR=15158332 # red
             TITLE="All Servers Down"
           else
@@ -149,12 +123,6 @@ jobs:
             APP_STATUS=":white_check_mark: OK (HTTP $APP_CODE)"
           else
             APP_STATUS=":x: DOWN (HTTP $APP_CODE)"
-          fi
-
-          if [ "$TECH_HEALTHY" = "true" ]; then
-            TECH_STATUS=":white_check_mark: OK (HTTP $TECH_CODE)"
-          else
-            TECH_STATUS=":x: DOWN (HTTP $TECH_CODE)"
           fi
 
           if [ "$API_APP_HEALTHY" = "true" ]; then
@@ -180,7 +148,6 @@ jobs:
             --arg title "$TITLE" \
             --argjson color "$COLOR" \
             --arg app_status "$APP_STATUS" \
-            --arg tech_status "$TECH_STATUS" \
             --arg api_app_status "$API_APP_STATUS" \
             --arg api_tech_status "$API_TECH_STATUS" \
             --arg timestamp "$TIMESTAMP" \
@@ -191,7 +158,6 @@ jobs:
                 color: $color,
                 fields: [
                   {name: "lanlan.app (US, old)", value: $app_status, inline: true},
-                  {name: "lanlan.tech (China, old)", value: $tech_status, inline: true},
                   {name: "\u200b", value: "\u200b", inline: false},
                   {name: "www.lanlan.app (US, new)", value: $api_app_status, inline: true},
                   {name: "www.lanlan.tech (China, new)", value: $api_tech_status, inline: true}


### PR DESCRIPTION
## Summary
- 从 Server Health Check workflow 移除对 `lanlan.tech (China, old)` 的探活步骤
- 清理 Discord 通知里相关的 `TECH_HEALTHY`/`TECH_CODE`/`TECH_STATUS` 引用及 embed 字段
- 保留 lanlan.app (US, old)、www.lanlan.app (US, new)、www.lanlan.tech (China, new) 三个端点

## Test plan
- [ ] workflow YAML 语法有效，手动 `workflow_dispatch` 触发后 Discord 通知正常渲染（不再含 China old 字段）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了API健康检查工作流，扩展监控范围至新域名，并调整了健康状态通知的展示内容。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->