### PR TITLE
feat(telemetry): 下线隐私默认值实验 v1，上线反向实验 v2

### DIFF
--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -17,8 +17,11 @@
     let _syncTimerId = null;
     // 同步间隔（毫秒）：60秒
     const SYNC_INTERVAL_MS = 60000;
-    // 隐私模式 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）
-    const _PRIVACY_OFF_BRANCH = 'privacy_default_off_v1';
+    // 隐私模式 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）。
+    // v2 实验组把隐私默认「打开」（vision=false）：国外用户控制组本就隐私开，对其是
+    // no-op；国内用户控制组默认隐私关，实验组翻成隐私开——即国外恒隐私开、A/B 差异只
+    // 体现在国内。命名方向中性，避免 v1/v2 反向后再次过时
+    const _PRIVACY_AB_BRANCH = 'privacy_default_off_v2';
     // 「首启等 branch 决议」专属 marker：只有 localStorage 走过本 PR 的首启分支才会写
     // 「1」，branch 决议后清掉。用 marker 在不在判断「应不应该套 A/B 覆写」，避免拿
     // 「没见过 branch 」当首启代名——升级用户也都没见过 branch，那个口径会误伤他们的
@@ -452,7 +455,7 @@
                 });
             } else {
                 // 首次启动：默认按 A/B 控制组行为——隐私模式按用户地区分流（仅中国
-                // 地区默认关闭）。实验组（privacy_default_off_v1）的「一律默认关闭」
+                // 地区默认关闭）。实验组（privacy_default_off_v2）的「国内默认打开隐私」
                 // 由 loadSettingsFromServer 拿到 telemetryBranch 后追加覆写，见下方
                 // 异步合并块。
                 if (_isUserRegionChina()) {
@@ -523,10 +526,12 @@
                 // A/B test 覆写：必须是本 PR 之后真·首启（_FIRST_LAUNCH_PENDING_KEY 存在）+
                 // 分支 = 实验组 + 服务器没有云端 vision 偏好 + 用户没在 fetch 间隙
                 // 手动切 toggle + 本地 vision 值仍等于控制组默认（即用户也没在之前的
-                // offline session 里改过），才把隐私模式默认关掉。升级用户没有 pending
-                // marker 不会被误覆写；offline 首启把 marker 留在 localStorage，下次
-                // 在线启动再补；offline 期间用户改过 toggle 时本地值跟控制组默认会拉
-                // 开差距，保留用户选择
+                // offline session 里改过），才套实验组默认。v2 实验组把隐私默认「打开」
+                // （vision=false）：对国内用户（控制组默认隐私关 vision=true）是真翻转，
+                // 对国外用户（控制组默认本就隐私开 vision=false）是 no-op——即国外恒隐
+                // 私开、国内做 A/B。升级用户没有 pending marker 不会被误覆写；offline
+                // 首启把 marker 留在 localStorage，下次在线启动再补；offline 期间用户改
+                // 过 toggle 时本地值跟控制组默认会拉开差距，保留用户选择
                 const noServerVisionPref = !serverSettings ||
                     serverSettings.proactiveVisionEnabled === undefined;
                 const userToggledDuringFetch = S.proactiveVisionEnabled !== _visionAtFetchStart;
@@ -534,14 +539,14 @@
                 const localVisionMatchesControlDefault =
                     S.proactiveVisionEnabled === controlGroupDefaultVision;
                 if (_firstLaunchPending
-                        && telemetryBranch === _PRIVACY_OFF_BRANCH
+                        && telemetryBranch === _PRIVACY_AB_BRANCH
                         && noServerVisionPref
                         && !userToggledDuringFetch
                         && localVisionMatchesControlDefault) {
-                    if (S.proactiveVisionEnabled !== true) {
-                        S.proactiveVisionEnabled = true;
+                    if (S.proactiveVisionEnabled !== false) {
+                        S.proactiveVisionEnabled = false;
                         hasUpdate = true;
-                        console.log('[app-settings] A/B 实验组', telemetryBranch, '：隐私模式默认关闭');
+                        console.log('[app-settings] A/B 实验组', telemetryBranch, '：隐私模式默认开启');
                     }
                 }
                 // 只要 server 给了 branch，本次决议就算完成（不管控制组还是实验组、

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -366,17 +366,30 @@ def _get_anonymous_device_id() -> str:
 #
 # 三者都是描述「这台机器/这个用户当前是谁」的副字段：
 #   - branch：首次启动时随机抽签后落盘，后续启动只读不改，保证同一设备稳定。
-#             当前 _TELEMETRY_BRANCHES 只有一个值，将来扩展元组即可触发 split；
-#             已经落盘的老用户继续读到旧分支，新用户随机进新池。
+#             扩展 _TELEMETRY_BRANCHES 元组即可触发 split，新用户随机进新池。注意：
+#             从池里移除某分支会让落盘旧值被严格校验判非法、按当前池重抽迁组（见
+#             privacy_default_off_v1 退役说明），这是退役实验的有意行为，不是
+#             append-only 扩展场景。
 #   - locale / timezone：每次上报时取当下值；同一设备换语言/换时区都视为同
 #             一个 device_id，server 端按 "latest seen" 覆写即可。
 # ---------------------------------------------------------------------------
 
 _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
-# A/B 池：
+# A/B 池（只决定「首启默认值」实验分组；首启后用户行为已落盘、不再响应覆写，其分组
+# 归因对默认值实验无意义，分析端按真·首启样本过滤即可）：
 #   - "main"：控制组，沿用历史默认（隐私模式按用户地区分流，仅中国地区默认关闭）
-#   - "privacy_default_off_v1"：实验组，隐私模式一律默认关闭
-_TELEMETRY_BRANCHES: tuple = ("main", "privacy_default_off_v1")
+#   - "privacy_default_off_v2"：实验组，与已退役的 v1 方向相反——
+#       v1 对「国外用户」试隐私默认关（国内本就默认关，对国内 no-op）；
+#       v2 对「国内用户」试隐私默认开（国外本就默认开，对国外 no-op）。
+#       即：国外用户恒隐私开，国内用户在 main / v2 间分流。抽签全地区随机，国外用户
+#       也会落 v2 但首启覆写是 no-op；分析国内 A/B 时按 locale 过滤即可。
+#
+# 已退役实验：
+#   - "privacy_default_off_v1"（试国外隐私默认关）：前期数据效果差，已下线、移出池。
+#     老 v1 落盘用户的旧值被 _read 严格校验判非法 → 下次启动按当前池随机重抽（落
+#     main 或 v2）。这些都是已过首启的用户，重抽只改 telemetry 标签、不动已落盘的
+#     vision 偏好，对「默认值」实验无影响，故不为其单独做确定性迁移。
+_TELEMETRY_BRANCHES: tuple = ("main", "privacy_default_off_v2")
 
 # 进程级缓存：keyed by str(config_dir)。写盘失败的环境下（只读 FS / 权限拒绝），
 # 不缓存就每次 secrets.choice 重抽，导致同一 install 的 TokenTracker 上报和
@@ -411,8 +424,10 @@ def _get_telemetry_branch(config_dir: Path) -> str:
         # 让 OSError 透出，让 `/conversation-settings` 的 except 把 telemetryBranch
         # 返 None，前端保留 pending marker，下次启动 fast path 读到合法值收敛。
         #
-        # 严格校验：append-only 池下迁移期老分支也该保留在 _TELEMETRY_BRANCHES
-        # 里，所以这里不会误杀历史值。
+        # 严格校验：活跃分支都在 _TELEMETRY_BRANCHES 里，所以正常情况下不会误杀。
+        # 唯一例外是退役实验（如 privacy_default_off_v1）——它被有意移出池，落盘旧值
+        # 在这里判非法、触发按当前池重抽（见上方退役说明），正是「让老实验群退出原
+        # 分支」的预期路径。
         if not p.exists():
             return None
         value = p.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Summary
- **下线 `privacy_default_off_v1`**：前期数据显示效果差，整组移出 A/B 池。老 v1 落盘用户旧值会被 `_read` 严格校验判非法 → 下次启动按当前池随机重抽（这些都已过首启、行为已落盘，重抽只改 telemetry 标签，不影响"默认值"实验）。
- **上线 `privacy_default_off_v2`**：与 v1 方向**相反**。
  - v1：对**国外用户**试隐私默认关（国内本就默认关，对国内 no-op）
  - v2：对**国内用户**试隐私默认开（国外本就默认开，对国外 no-op）
  - 即 **国外用户恒隐私开，A/B 差异只体现在国内**。

## 行为矩阵（vision=false 即隐私开）
| | 控制组 main | 实验组 v2 |
|---|---|---|
| 国外（非CN） | 隐私开（初始默认） | 覆写 false → 仍隐私开，**no-op** |
| 国内（CN） | 隐私关（首启设 true） | 覆写翻成 false → **隐私开** |

抽签仍全地区随机，国外也会落 v2 cohort 但首启覆写是 no-op；分析国内 A/B 时按 locale 过滤。

## 改动
- `utils/token_tracker.py`：`_TELEMETRY_BRANCHES` → `("main", "privacy_default_off_v2")`，更新池/退役/重抽相关注释
- `static/app-settings.js`：实验组覆写 `vision=true`（隐私关）→ `vision=false`（隐私开）；常量 `_PRIVACY_OFF_BRANCH` → 方向中性的 `_PRIVACY_AB_BRANCH`

## Test plan
- [x] 后端 import + 池值（`('main', 'privacy_default_off_v2')`）
- [x] 前端 `node --check static/app-settings.js`
- [x] 无残留旧常量名 `_PRIVACY_OFF_BRANCH`
- [ ] 首启分流为随机抽签 + 地区检测路径，未在浏览器确定性实跑（reviewer 可清 localStorage + mock telemetryBranch 验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes（错误修复）**
  * 更新了隐私功能的测试版本配置，调整了隐私设置的默认行为以改进用户体验。
  * 同步更新了相关的遥测配置以保持版本一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->