### PR TITLE
feat(activity): 跨平台 OS 信号 push 通道 + agent_router remote 守卫

### DIFF
--- a/docs/design/user-activity-tracker.md
+++ b/docs/design/user-activity-tracker.md
@@ -794,7 +794,7 @@ and to weigh conversation signals more heavily.
 `UserActivityTracker.push_external_system_signal(...)` accepts OS
 signals from outside the backend — designed for a frontend (Electron
 app, browser via WebSocket, mobile shell) to read its local OS state
-and POST it on a heartbeat. When fresh (≤ 30s), pushed signals
+and POST it on a heartbeat. When fresh (≤ 15s), pushed signals
 override the local collector entirely. When stale (heartbeat stops),
 the tracker falls back to the local collector and the degraded marker
 re-appears.

--- a/docs/design/user-activity-tracker.md
+++ b/docs/design/user-activity-tracker.md
@@ -815,10 +815,53 @@ All fields optional — pass whatever the frontend can read on each
 platform. The push primes `os_signals_available=True` so the AI sees
 non-degraded state.
 
-The HTTP endpoint to receive these pushes hasn't been added yet — when
-the frontend implementation lands, wire it via something like
-`POST /api/activity_signal/{lanlan_name}` in `system_router.py`.
-Until then, the API surface exists for whoever builds it.
+#### HTTP endpoint
+
+`POST /api/activity_signal` (in `main_routers/system_router.py`) is the
+public surface. Body is a JSON object with `lanlan_name` (required)
+plus any subset of the snake_case fields above. The endpoint enforces:
+
+- 400 on malformed body / out-of-range fields
+- 404 when `lanlan_name` isn't registered
+- 429 when pushed faster than 5s per lanlan_name (matches the heartbeat
+  cadence — `_EXTERNAL_SIGNAL_MIN_INTERVAL` in `tracker.py`). Honour
+  `Retry-After`.
+- 503 if the character's tracker hasn't initialised yet (boot race —
+  retry on the next heartbeat)
+- 500 if the tracker raises
+
+No auth header today — defended by the per-character `lanlan_name`
+lookup + rate limit. A stricter CSRF/Origin guard is tracked for a
+follow-up PR; the threat model write-up lives in issue #1023.
+
+#### Renderer client
+
+`static/app-activity-signal.js` does the 5s heartbeat in the desktop
+pet window. It reads OS signals through the Electron preload bridge
+(`window.nekoActivitySignal.read()` — exposed by the NEKO-PC sibling
+repo), normalises camelCase → snake_case, and POSTs to the endpoint
+above. The module is defensive: when the bridge isn't exposed
+(non-Electron dev runs, mobile browser shell, NEKO-PC older than the
+companion PR), it logs once and stays silent — the backend tracker's
+local collector handles the rest in degraded mode.
+
+#### Electron bridge contract (NEKO-PC side)
+
+The companion PR in NEKO-PC adds an IPC handler that returns:
+
+```js
+{
+    windowTitle: "VS Code — neko",  // active-win → activeWindow.title
+    processName: "Code.exe",        // active-win → activeWindow.owner.name
+    idleSeconds: 12,                // powerMonitor.getSystemIdleTime() (seconds, not ms)
+    cpuAvg30s: 27.5,                // os.cpus() rolling diff, [0, 100]
+    gpuUtilization: 65.0,           // nvidia-smi (optional — None on AMD/Intel)
+}
+```
+
+The renderer (`app-activity-signal.js`) drops any field that fails
+type/range validation and POSTs the rest. A partial snapshot is still
+better than no push.
 
 ### What works in fully-degraded remote mode
 

--- a/main_logic/activity/system_signals.py
+++ b/main_logic/activity/system_signals.py
@@ -42,23 +42,47 @@ logger = logging.getLogger(__name__)
 _IS_WINDOWS = platform.system() == 'Windows'
 
 
-def _force_degraded_from_env() -> bool:
+def is_remote_backend_deployment() -> bool:
     """Honour ``NEKO_ACTIVITY_TRACKER_REMOTE`` / ``ACTIVITY_TRACKER_REMOTE``.
 
-    Set to ``1`` / ``true`` / ``yes`` when the backend is on a different
-    machine from the user — covers the Windows-remote edge case where
-    the local OS APIs would happily report the server's foreground
-    window (since pygetwindow technically works), but those signals
-    are about the server, not the user.
+    Single source of truth for the "is the backend running on a different
+    machine from the user" question. Two unrelated consumers used to keep
+    their own copies of this env-var check and drifted:
+
+      * the activity collector here — flips the OS-signal pipeline into
+        degraded mode (window/idle/CPU/GPU come from frontend push or
+        not at all).
+      * ``main_routers/system_router._is_remote_backend_deployment`` —
+        blocks local-machine operations like ``/api/screenshot`` from
+        accidentally capturing the *server's* desktop and returning it
+        to the user. ``main_routers/agent_router`` follows the same
+        rule for ``computer_use`` / agent commands.
+
+    Both now call into this function. The check itself is intentionally
+    cheap (env lookup) so it's safe to call inline on every request.
+
+    Set to ``1`` / ``true`` / ``yes`` / ``on`` when the backend is on a
+    different machine from the user — covers the Windows-remote edge
+    case where the local OS APIs would happily report the server's
+    foreground window (since pygetwindow technically works), but those
+    signals are about the server, not the user. Same applies to
+    pyautogui screenshots and computer_use commands — they target the
+    backend machine, which is wrong when that machine isn't the user's.
 
     Default off — most users run backend on their own PC where local
-    OS signals are correct.
+    OS signals / screenshots / computer_use are correct.
     """
     for key in ('NEKO_ACTIVITY_TRACKER_REMOTE', 'ACTIVITY_TRACKER_REMOTE'):
         raw = os.getenv(key, '').strip().lower()
         if raw in ('1', 'true', 'yes', 'on'):
             return True
     return False
+
+
+# Legacy private alias — keeps in-flight callers (and tests that patch
+# the private name) working without a sweep. New code calls
+# ``is_remote_backend_deployment`` directly.
+_force_degraded_from_env = is_remote_backend_deployment
 
 
 # ── Public snapshot dataclass ───────────────────────────────────────
@@ -185,7 +209,7 @@ class SystemSignalCollector:
         # for the case where the backend is a Windows server and the user
         # is on a different machine — local OS APIs would technically
         # work but report data about the server, not the user.
-        env_force_degraded = _force_degraded_from_env()
+        env_force_degraded = is_remote_backend_deployment()
         self._os_signals_available: bool = bool(
             _IS_WINDOWS and self._gw is not None and not env_force_degraded
         )

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -72,7 +72,17 @@ _ACTIVITY_GUESS_MIN_REFRESH_SECONDS = 30.0
 # seconds. After that the tracker falls back to the local collector
 # (which on remote deployments will be in degraded mode) — better to
 # advertise "no signal" than to keep using stale window data.
-_EXTERNAL_SIGNAL_TTL_SECONDS = 30.0
+#
+# 15s = 3× the 5s heartbeat. The push pipeline stacks two unsynchronised
+# 5s timers — the NEKO-PC bridge sampler (reads OS signals) and the
+# renderer heartbeat (reads the bridge's cached snapshot + POSTs) — so
+# worst-case data age can already approach ~10-12s before any loss. 15s
+# therefore tolerates ~2 consecutive dropped pushes before falling back.
+# Shorter (e.g. 10s) would thrash between fresh/degraded on a single
+# drop over a lossy remote link; 30s keeps trusting a stale "user
+# active" snapshot for too long after the heartbeat dies. 15s balances
+# faster stale-detection against fallback thrash.
+_EXTERNAL_SIGNAL_TTL_SECONDS = 15.0
 
 # Minimum interval between accepted external-signal pushes for a given
 # lanlan_name. Tuned together with the frontend heartbeat: the Electron
@@ -82,9 +92,9 @@ _EXTERNAL_SIGNAL_TTL_SECONDS = 30.0
 # tracker is happily idempotent and just overwrites the last push.
 #
 # Pairs with TTL above: TTL is the "data freshness" window, this is the
-# "request frequency" cap. TTL ≫ interval so even when 5 of every 6
-# pushes get rate-limited the tracker still has data within the freshness
-# window.
+# "request frequency" cap. TTL is 3× this interval, so the tracker
+# tolerates ~2 consecutive rate-limited/dropped pushes and still has
+# data within the freshness window.
 _EXTERNAL_SIGNAL_MIN_INTERVAL = 5.0
 
 

--- a/main_logic/activity/tracker.py
+++ b/main_logic/activity/tracker.py
@@ -74,6 +74,19 @@ _ACTIVITY_GUESS_MIN_REFRESH_SECONDS = 30.0
 # advertise "no signal" than to keep using stale window data.
 _EXTERNAL_SIGNAL_TTL_SECONDS = 30.0
 
+# Minimum interval between accepted external-signal pushes for a given
+# lanlan_name. Tuned together with the frontend heartbeat: the Electron
+# preload pushes every ~5s, so anything more frequent is either a buggy
+# client (re-entering the heartbeat) or spam. Enforced by the
+# ``/api/activity_signal`` endpoint, not the tracker itself — the
+# tracker is happily idempotent and just overwrites the last push.
+#
+# Pairs with TTL above: TTL is the "data freshness" window, this is the
+# "request frequency" cap. TTL ≫ interval so even when 5 of every 6
+# pushes get rate-limited the tracker still has data within the freshness
+# window.
+_EXTERNAL_SIGNAL_MIN_INTERVAL = 5.0
+
 
 # ── Break-reminder defaults ─────────────────────────────────────────
 # Override per-character via ``user_preferences.json::__global_conversation__::activity::thresholds``.

--- a/main_routers/agent_router.py
+++ b/main_routers/agent_router.py
@@ -26,6 +26,7 @@ import httpx
 from .shared_state import get_session_manager, get_config_manager, get_templates
 from config import TOOL_SERVER_PORT, USER_PLUGIN_BASE
 from main_logic.agent_event_bus import publish_session_event
+from main_logic.activity.system_signals import is_remote_backend_deployment
 
 router = APIRouter(prefix="/api/agent", tags=["agent"])
 logger = get_module_logger(__name__, "Main")
@@ -54,6 +55,37 @@ _AGENT_OFF_FLAGS = {
     "openclaw_enabled": False,
     "openfang_enabled": False,
 }
+
+
+def _remote_backend_block() -> JSONResponse | None:
+    """Reject agent mutation when backend is deployed away from the user.
+
+    In remote mode (``NEKO_ACTIVITY_TRACKER_REMOTE=1``) the "computer"
+    that computer_use / browser_use / openclaw would control is the
+    *server's*, not the user's — there's no useful action to take, and
+    silently forwarding the command to a localhost tool_server on the
+    server side is actively dangerous (anyone who can reach the public
+    backend HTTP can drive the agent on the server). Returning 501
+    matches the same-env block on ``/api/screenshot`` in
+    ``main_routers/system_router.py`` so the frontend can surface a
+    uniform "agent unavailable on remote backend" state.
+
+    Threat model context: a deeper CSRF + Origin guard (defending
+    against DNS-rebinding-style attacks on a *local* backend) is
+    deferred to a follow-up — it needs the ~15 frontend agent fetch
+    sites to start sending ``X-CSRF-Token`` first, which doesn't fit
+    PR B's scope. See issue #1023 for the audit + scope decision.
+    """
+    if is_remote_backend_deployment():
+        return JSONResponse(
+            {
+                "success": False,
+                "error": "agent disabled in remote backend deployment "
+                         "(NEKO_ACTIVITY_TRACKER_REMOTE)",
+            },
+            status_code=501,
+        )
+    return None
 
 
 async def force_disable_agent_for_character_switch(current_lanlan: str, previous_lanlan: str | None = None) -> bool:
@@ -197,6 +229,9 @@ async def _close_http_client():
 @router.post('/flags')
 async def update_agent_flags(request: Request):
     """来自前端的Agent开关更新，级联到各自的session manager。"""
+    blocked = _remote_backend_block()
+    if blocked is not None:
+        return blocked
     try:
         data = await request.json()
         _config_manager = get_config_manager()
@@ -276,6 +311,9 @@ async def get_agent_state():
 @router.post('/command')
 async def post_agent_command(request: Request):
     """统一命令入口，前端只发送 command，不直接操作多路开关。"""
+    blocked = _remote_backend_block()
+    if blocked is not None:
+        return blocked
     t0 = time.perf_counter()
     try:
         data = await request.json()
@@ -521,6 +559,9 @@ async def proxy_task_detail(task_id: str):
 @router.post('/tasks/{task_id}/cancel')
 async def proxy_task_cancel(task_id: str):
     """Cancel a specific task via tool server proxy."""
+    blocked = _remote_backend_block()
+    if blocked is not None:
+        return blocked
     try:
         client = _get_http_client()
         r = await client.post(f"{TOOL_SERVER_BASE}/tasks/{task_id}/cancel", timeout=5.0)
@@ -534,6 +575,9 @@ async def proxy_task_cancel(task_id: str):
 @router.post('/admin/control')
 async def proxy_admin_control(payload: dict = Body(...)):
     """Proxy admin control commands to tool server."""
+    blocked = _remote_backend_block()
+    if blocked is not None:
+        return blocked
     try:
         client = _get_http_client()
         r = await client.post(f"{TOOL_SERVER_BASE}/admin/control", json=payload, timeout=5.0)

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4333,7 +4333,7 @@ async def push_activity_signal(request: Request):
             {"success": False, "error": err}, status_code=400,
         )
 
-    # ── Empty-signal guard (Codex F6 on PR #1477, defence-in-depth) ──
+    # ── Empty-signal guard (Codex F6 + CodeRabbit F7 on PR #1477) ──
     # If every signal field is absent, the tracker's
     # ``push_external_system_signal`` would still mark
     # ``os_signals_available=True`` and default missing numerics to
@@ -4342,10 +4342,21 @@ async def push_activity_signal(request: Request):
     # no window". The frontend client already skips empty bridge
     # snapshots, but a malicious or buggy native caller could still
     # POST an empty payload, so we reject server-side too.
-    if all(v is None for v in (
-        idle_seconds, cpu_avg_30s, gpu_utilization,
-        window_title, process_name,
-    )):
+    #
+    # Blank-string handling (CodeRabbit F7): ``"window_title": ""`` or
+    # whitespace-only strings carry no information and have the same
+    # poisoning effect as ``None``. Treat them as absent for the
+    # all-empty check; non-blank strings (legit "no foreground window
+    # right now" semantics with explicit ``""``) would still trip the
+    # check if every other field is also None — which is the right
+    # outcome, that payload tells the tracker literally nothing.
+    if all(
+        v is None or (isinstance(v, str) and not v.strip())
+        for v in (
+            idle_seconds, cpu_avg_30s, gpu_utilization,
+            window_title, process_name,
+        )
+    ):
         return _json_no_store_response(
             {
                 "success": False,

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -63,6 +63,7 @@ from cachetools import TTLCache
 from .shared_state import ensure_steamworks as get_steamworks, get_config_manager, get_sync_message_queue, get_session_manager
 from main_logic.omni_realtime_client import OmniRealtimeClient
 from main_logic.activity.system_signals import is_remote_backend_deployment
+from main_logic.activity.tracker import _EXTERNAL_SIGNAL_MIN_INTERVAL
 from config import (
     AUTOSTART_ALLOWED_ORIGINS,
     AUTOSTART_CSRF_TOKEN,
@@ -4138,6 +4139,220 @@ async def backend_interactive_screenshot(request: Request):
                 os.remove(tmp_path)
         except Exception:
             logger.debug("清理交互截图临时文件失败: %s", tmp_path, exc_info=True)
+
+
+# ── Frontend-pushed activity signals (cross-platform OS signal channel) ──
+#
+# Per-lanlan throttle for ``/api/activity_signal``. Keyed by lanlan_name,
+# value is the timestamp of the last accepted push. Bounded — see
+# ``_ACTIVITY_SIGNAL_THROTTLE_MAX_ENTRIES`` — to defend against an
+# attacker spraying lanlan_names; in practice the dict has 1-3 entries.
+# Concurrent access from FastAPI's worker pool is safe because Python
+# dict ops are atomic under the GIL and we tolerate occasional rate-limit
+# slippage (worst case: an extra push slips through).
+_ACTIVITY_SIGNAL_THROTTLE: dict[str, float] = {}
+_ACTIVITY_SIGNAL_THROTTLE_MAX_ENTRIES = 64
+
+
+def _activity_signal_validate_float(
+    data: dict, key: str, lo: float | None, hi: float | None,
+) -> tuple[float | None, str | None]:
+    """Coerce ``data[key]`` to a bounded float; ``None`` means absent.
+
+    Tracker treats absent fields as neutral defaults (see
+    ``UserActivityTracker.push_external_system_signal`` docstring), so
+    we keep ``None`` distinct from a present-but-invalid value — the
+    latter is a 400 with a specific error.
+    """
+    raw = data.get(key)
+    if raw is None:
+        return None, None
+    try:
+        val = float(raw)
+    except (TypeError, ValueError):
+        return None, f"{key} must be a number"
+    if lo is not None and val < lo:
+        return None, f"{key} must be >= {lo}"
+    if hi is not None and val > hi:
+        return None, f"{key} must be <= {hi}"
+    return val, None
+
+
+def _activity_signal_validate_str(
+    data: dict, key: str,
+) -> tuple[str | None, str | None]:
+    raw = data.get(key)
+    if raw is None:
+        return None, None
+    if not isinstance(raw, str):
+        return None, f"{key} must be a string"
+    return raw, None
+
+
+@router.post('/activity_signal')
+async def push_activity_signal(request: Request):
+    """Accept OS-activity signals pushed by the frontend on a heartbeat.
+
+    Companion to ``UserActivityTracker.push_external_system_signal()``
+    (PR #1015 ``main_logic/activity/tracker.py:347``), exposing the
+    push channel as HTTP for the "backend doesn't run on the user's
+    machine" deployments. The frontend (Electron preload reading
+    ``powerMonitor.getSystemIdleTime`` + npm ``active-win`` +
+    ``os.cpus()`` + ``nvidia-smi``) POSTs here every ``~5s``; the
+    tracker treats anything fresher than ``_EXTERNAL_SIGNAL_TTL_SECONDS``
+    (30s) as the authoritative OS view, falling back to the local
+    collector when the heartbeat stops. Same fresh-then-fallback path
+    feeds both the async ``get_snapshot`` and the sync variant — see
+    ``tracker._select_system_snapshot``.
+
+    Why not loopback-only / CSRF guarded: in remote deployments the
+    frontend is intentionally not on loopback. CSRF/Origin would be
+    the right hardening, but adding it requires updating frontend
+    agent fetch sites to send ``X-CSRF-Token`` (out of PR B scope —
+    see issue #1023 audit). For PR B we accept anonymous pushes; the
+    per-lanlan rate limit below + the tracker's per-character lookup
+    are the practical defenses.
+
+    Body fields (all optional except ``lanlan_name``):
+      * ``lanlan_name`` (required) — which character's tracker to update
+      * ``window_title`` — string, raw active-window title
+      * ``process_name`` — string, owning process exe name (e.g. ``"Code.exe"``)
+      * ``idle_seconds`` — float ≥ 0, OS-wide keyboard/mouse idle
+      * ``cpu_avg_30s`` — float in ``[0, 100]``, rolling CPU average
+      * ``gpu_utilization`` — float in ``[0, 100]``, primary GPU utilisation
+
+    Returns 200 on success, 400 on malformed payload, 404 if
+    ``lanlan_name`` isn't registered, 429 if pushed faster than
+    ``_EXTERNAL_SIGNAL_MIN_INTERVAL`` (5s), 503 if the character's
+    tracker hasn't initialised yet.
+    """
+    try:
+        data = await request.json()
+    except Exception:
+        return _json_no_store_response(
+            {"success": False, "error": "invalid JSON body"},
+            status_code=400,
+        )
+    if not isinstance(data, dict):
+        return _json_no_store_response(
+            {"success": False, "error": "body must be a JSON object"},
+            status_code=400,
+        )
+
+    lanlan_name = data.get("lanlan_name")
+    if not isinstance(lanlan_name, str) or not lanlan_name.strip():
+        return _json_no_store_response(
+            {"success": False, "error": "lanlan_name required"},
+            status_code=400,
+        )
+    lanlan_name = lanlan_name.strip()
+
+    idle_seconds, err = _activity_signal_validate_float(
+        data, "idle_seconds", 0.0, None,
+    )
+    if err:
+        return _json_no_store_response(
+            {"success": False, "error": err}, status_code=400,
+        )
+    cpu_avg_30s, err = _activity_signal_validate_float(
+        data, "cpu_avg_30s", 0.0, 100.0,
+    )
+    if err:
+        return _json_no_store_response(
+            {"success": False, "error": err}, status_code=400,
+        )
+    gpu_utilization, err = _activity_signal_validate_float(
+        data, "gpu_utilization", 0.0, 100.0,
+    )
+    if err:
+        return _json_no_store_response(
+            {"success": False, "error": err}, status_code=400,
+        )
+
+    window_title, err = _activity_signal_validate_str(data, "window_title")
+    if err:
+        return _json_no_store_response(
+            {"success": False, "error": err}, status_code=400,
+        )
+    process_name, err = _activity_signal_validate_str(data, "process_name")
+    if err:
+        return _json_no_store_response(
+            {"success": False, "error": err}, status_code=400,
+        )
+
+    # Per-lanlan throttle — matches the frontend's 5s heartbeat. TTL
+    # is 30s so even if 5 of every 6 pushes get rate-limited the
+    # tracker stays inside its freshness window. Spam control, not
+    # auth — the character lookup below is the real integrity check.
+    now = time.time()
+    last_push = _ACTIVITY_SIGNAL_THROTTLE.get(lanlan_name)
+    if last_push is not None and (now - last_push) < _EXTERNAL_SIGNAL_MIN_INTERVAL:
+        retry_after = max(
+            0.0, _EXTERNAL_SIGNAL_MIN_INTERVAL - (now - last_push),
+        )
+        resp = _json_no_store_response(
+            {
+                "success": False,
+                "error": "rate limited",
+                "retry_after_seconds": round(retry_after, 3),
+            },
+            status_code=429,
+        )
+        # Header is integer seconds per RFC 9110; round up so clients
+        # don't retry into the same window.
+        resp.headers["Retry-After"] = str(int(retry_after) + 1)
+        return resp
+
+    session_manager = get_session_manager()
+    mgr = session_manager.get(lanlan_name)
+    if not mgr:
+        return _json_no_store_response(
+            {
+                "success": False,
+                "error": f"lanlan_name {lanlan_name!r} not registered",
+            },
+            status_code=404,
+        )
+    tracker = getattr(mgr, "_activity_tracker", None)
+    if tracker is None:
+        return _json_no_store_response(
+            {
+                "success": False,
+                "error": "activity tracker not initialised for this character",
+            },
+            status_code=503,
+        )
+
+    try:
+        tracker.push_external_system_signal(
+            window_title=window_title,
+            process_name=process_name,
+            idle_seconds=idle_seconds,
+            cpu_avg_30s=cpu_avg_30s,
+            gpu_utilization=gpu_utilization,
+            now=now,
+        )
+    except Exception as e:
+        logger.exception(
+            "push_external_system_signal failed for %s", lanlan_name,
+        )
+        return _json_no_store_response(
+            {"success": False, "error": f"tracker rejected push: {e}"},
+            status_code=500,
+        )
+
+    _ACTIVITY_SIGNAL_THROTTLE[lanlan_name] = now
+    # Bound the dict: in practice lanlan_names are 1-3, but if an
+    # attacker sprays unique names we trim oldest. Sorted ascending by
+    # timestamp; keep the freshest MAX entries.
+    if len(_ACTIVITY_SIGNAL_THROTTLE) > _ACTIVITY_SIGNAL_THROTTLE_MAX_ENTRIES:
+        excess = sorted(
+            _ACTIVITY_SIGNAL_THROTTLE.items(), key=lambda kv: kv[1],
+        )[:-_ACTIVITY_SIGNAL_THROTTLE_MAX_ENTRIES]
+        for key, _ in excess:
+            _ACTIVITY_SIGNAL_THROTTLE.pop(key, None)
+
+    return _json_no_store_response({"success": True})
 
 
 # ================================================================

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4175,6 +4175,14 @@ def _activity_signal_validate_float(
     raw = data.get(key)
     if raw is None:
         return None, None
+    # Reject booleans before float coercion (Codex F8 on PR #1477).
+    # ``bool`` is a subclass of ``int`` in Python, so ``float(True)``
+    # silently returns ``1.0`` and ``float(False)`` returns ``0.0``,
+    # which would slip past the range checks below as legitimate signal
+    # values. ``isinstance(raw, bool)`` catches both before the int
+    # / float fast paths in ``float()``.
+    if isinstance(raw, bool):
+        return None, f"{key} must be a number"
     try:
         val = float(raw)
     except (TypeError, ValueError):

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -62,6 +62,7 @@ from cachetools import TTLCache
 
 from .shared_state import ensure_steamworks as get_steamworks, get_config_manager, get_sync_message_queue, get_session_manager
 from main_logic.omni_realtime_client import OmniRealtimeClient
+from main_logic.activity.system_signals import is_remote_backend_deployment
 from config import (
     AUTOSTART_ALLOWED_ORIGINS,
     AUTOSTART_CSRF_TOKEN,
@@ -199,21 +200,16 @@ def _is_loopback_request(request: Request) -> bool:
         return False
 
 
-def _is_remote_backend_deployment() -> bool:
-    """``NEKO_ACTIVITY_TRACKER_REMOTE`` / ``ACTIVITY_TRACKER_REMOTE`` 兜底开关。
-
-    /screenshot 和 /screenshot/interactive 都是在后端机器上抓屏的，部署到
-    远程服务器时抓出来的是服务器自己的桌面而不是用户的。loopback 校验
-    会被反向代理 / 隧道绕过，这条环境变量是运维显式声明"后端不在用户本机"
-    的硬开关，命中就直接拒绝本地截图。
-
-    用法和 PR #1015 的活动追踪器保持一致，避免再发明一套部署变量。
-    """
-    for key in ("NEKO_ACTIVITY_TRACKER_REMOTE", "ACTIVITY_TRACKER_REMOTE"):
-        raw = os.getenv(key, "").strip().lower()
-        if raw in ("1", "true", "yes", "on"):
-            return True
-    return False
+# /screenshot 和 /screenshot/interactive 都是在后端机器上抓屏的，部署到
+# 远程服务器时抓出来的是服务器自己的桌面而不是用户的。loopback 校验
+# 会被反向代理 / 隧道绕过，``NEKO_ACTIVITY_TRACKER_REMOTE`` 是运维显式
+# 声明"后端不在用户本机"的硬开关，命中就直接拒绝本地截图。
+#
+# 真正的实现在 ``main_logic/activity/system_signals.is_remote_backend_deployment``
+# —— PR #1015 给 activity tracker 用的，这里直接复用避免再发明一套部署变量。
+# 私有别名保留是为了 ``tests/unit/test_system_screenshot_router.py`` 还
+# 在调 ``system_router_module._is_remote_backend_deployment()``。
+_is_remote_backend_deployment = is_remote_backend_deployment
 
 
 def _run_macos_interactive_screenshot(output_path: str) -> tuple[int, str]:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4163,6 +4163,14 @@ def _activity_signal_validate_float(
     ``UserActivityTracker.push_external_system_signal`` docstring), so
     we keep ``None`` distinct from a present-but-invalid value — the
     latter is a 400 with a specific error.
+
+    Non-finite values (``NaN`` / ``±Infinity``) are rejected explicitly
+    before range comparison — ``float('nan') < lo`` is silently
+    ``False``, so they'd otherwise bypass the bounds check. Worse,
+    serialising them downstream (state-machine logs, JSON responses)
+    crashes since standard JSON forbids them. ``math.isfinite`` is the
+    correct guard: it rejects NaN and both infinities while accepting
+    every normal/subnormal float.
     """
     raw = data.get(key)
     if raw is None:
@@ -4171,6 +4179,8 @@ def _activity_signal_validate_float(
         val = float(raw)
     except (TypeError, ValueError):
         return None, f"{key} must be a number"
+    if not math.isfinite(val):
+        return None, f"{key} must be finite"
     if lo is not None and val < lo:
         return None, f"{key} must be >= {lo}"
     if hi is not None and val > hi:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4225,7 +4225,7 @@ async def push_activity_signal(request: Request):
     ``powerMonitor.getSystemIdleTime`` + npm ``active-win`` +
     ``os.cpus()`` + ``nvidia-smi``) POSTs here every ``~5s``; the
     tracker treats anything fresher than ``_EXTERNAL_SIGNAL_TTL_SECONDS``
-    (30s) as the authoritative OS view, falling back to the local
+    (15s) as the authoritative OS view, falling back to the local
     collector when the heartbeat stops. Same fresh-then-fallback path
     feeds both the async ``get_snapshot`` and the sync variant — see
     ``tracker._select_system_snapshot``.
@@ -4381,9 +4381,10 @@ async def push_activity_signal(request: Request):
         )
 
     # Per-lanlan throttle — matches the frontend's 5s heartbeat. TTL
-    # is 30s so even if 5 of every 6 pushes get rate-limited the
-    # tracker stays inside its freshness window. Spam control, not
-    # auth — the character lookup below is the real integrity check.
+    # is 15s (3× this interval) so even if 2 of every 3 pushes get
+    # rate-limited the tracker stays inside its freshness window. Spam
+    # control, not auth — the character lookup below is the real
+    # integrity check.
     now = time.time()
     last_push = _ACTIVITY_SIGNAL_THROTTLE.get(lanlan_name)
     if last_push is not None and (now - last_push) < _EXTERNAL_SIGNAL_MIN_INTERVAL:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4185,7 +4185,14 @@ def _activity_signal_validate_float(
         return None, f"{key} must be a number"
     try:
         val = float(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError is raised by ``float()`` when the integer is
+        # too large to fit in a C double (Codex F9 on PR #1477) —
+        # JSON allows arbitrary-precision ints which Python loads as
+        # native big ints, and ``float(10**400)`` blows up. Without
+        # this case the request becomes a 500 instead of a clean 400,
+        # giving a low-cost crash vector to anyone POSTing oversized
+        # numeric literals.
         return None, f"{key} must be a number"
     if not math.isfinite(val):
         return None, f"{key} must be finite"

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4215,13 +4215,22 @@ async def push_activity_signal(request: Request):
     feeds both the async ``get_snapshot`` and the sync variant — see
     ``tracker._select_system_snapshot``.
 
-    Why not loopback-only / CSRF guarded: in remote deployments the
-    frontend is intentionally not on loopback. CSRF/Origin would be
-    the right hardening, but adding it requires updating frontend
-    agent fetch sites to send ``X-CSRF-Token`` (out of PR B scope —
-    see issue #1023 audit). For PR B we accept anonymous pushes; the
-    per-lanlan rate limit below + the tracker's per-character lookup
-    are the practical defenses.
+    Auth:
+
+    * Origin-present same-origin gate (zero-frontend-cost defence,
+      suggested by CodeRabbit on PR #1477): when the request carries an
+      ``Origin`` / ``Referer`` header AND that origin isn't in
+      ``_get_allowed_local_origins`` (which always includes the current
+      ``request.base_url``), reject with 403. Browser-mediated requests
+      always carry ``Origin`` for POST, so this single check blocks
+      cross-site drive-by JS without breaking ``curl`` / Electron's
+      same-origin renderer / native scripts (no Origin → allowed).
+    * Per-lanlan 5s rate limit below + the tracker's per-character
+      lookup raise spam cost and bound the impact even if Origin
+      validation passes.
+    * A stricter CSRF token mechanism (parity with screenshot endpoints)
+      is tracked for a follow-up security-hardening PR; the threat
+      model write-up lives in issue #1023.
 
     Body fields (all optional except ``lanlan_name``):
       * ``lanlan_name`` (required) — which character's tracker to update
@@ -4236,6 +4245,23 @@ async def push_activity_signal(request: Request):
     ``_EXTERNAL_SIGNAL_MIN_INTERVAL`` (5s), 503 if the character's
     tracker hasn't initialised yet.
     """
+    # ── Origin-present same-origin gate ────────────────────────────
+    # When the request carries an Origin (or Referer fallback) but it's
+    # not in our allowed-origins set, refuse — that's the drive-by CSRF
+    # signature. Missing Origin means a non-browser caller (curl, Node,
+    # native script) which we explicitly allow because there's no
+    # mandatory CSRF token yet. Same-origin browser requests pass
+    # naturally because their Origin matches ``request.base_url``,
+    # which ``_get_allowed_local_origins`` always includes.
+    request_origin = _get_request_origin(request)
+    if request_origin:
+        allowed = _get_allowed_local_origins(request)
+        if request_origin not in allowed:
+            return _json_no_store_response(
+                {"success": False, "error": "origin not allowed"},
+                status_code=403,
+            )
+
     try:
         data = await request.json()
     except Exception:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -4253,6 +4253,23 @@ async def push_activity_signal(request: Request):
     # mandatory CSRF token yet. Same-origin browser requests pass
     # naturally because their Origin matches ``request.base_url``,
     # which ``_get_allowed_local_origins`` always includes.
+    #
+    # Opaque-origin guard (Codex F5 on PR #1477): browsers send the
+    # literal string ``"null"`` as Origin for sandboxed iframes,
+    # ``file://`` pages, and certain extension contexts. ``urlsplit``
+    # parses "null" into an empty scheme/netloc which
+    # ``_normalize_origin_value`` turns into ``""`` — without this
+    # check that bypasses to the no-Origin "allowed" branch. We
+    # explicitly reject the raw "null" string before normalisation, on
+    # both Origin and Referer (the latter is our fallback).
+    raw_origin = (request.headers.get("origin") or "").strip().lower()
+    raw_referer = (request.headers.get("referer") or "").strip().lower()
+    if raw_origin == "null" or raw_referer == "null":
+        return _json_no_store_response(
+            {"success": False, "error": "origin not allowed"},
+            status_code=403,
+        )
+
     request_origin = _get_request_origin(request)
     if request_origin:
         allowed = _get_allowed_local_origins(request)
@@ -4314,6 +4331,27 @@ async def push_activity_signal(request: Request):
     if err:
         return _json_no_store_response(
             {"success": False, "error": err}, status_code=400,
+        )
+
+    # ── Empty-signal guard (Codex F6 on PR #1477, defence-in-depth) ──
+    # If every signal field is absent, the tracker's
+    # ``push_external_system_signal`` would still mark
+    # ``os_signals_available=True`` and default missing numerics to
+    # ``0.0`` — i.e., a payload of ``{"lanlan_name": "X"}`` would
+    # silently overwrite real state with synthetic "idle=0 / cpu=0 /
+    # no window". The frontend client already skips empty bridge
+    # snapshots, but a malicious or buggy native caller could still
+    # POST an empty payload, so we reject server-side too.
+    if all(v is None for v in (
+        idle_seconds, cpu_avg_30s, gpu_utilization,
+        window_title, process_name,
+    )):
+        return _json_no_store_response(
+            {
+                "success": False,
+                "error": "at least one signal field required",
+            },
+            status_code=400,
         )
 
     # Per-lanlan throttle — matches the frontend's 5s heartbeat. TTL

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -46,6 +46,22 @@
     var hasLoggedBridgeMissing = false;
 
     function resolveLanlanName() {
+        // Order matters: ``window.appState.lanlan_name`` first, then
+        // ``window.lanlan_config.lanlan_name`` as fallback. During a
+        // character switch the renderer updates ``appState`` ahead of
+        // ``lanlan_config`` (see ``static/app-character.js`` switch
+        // sequence + the existing precedent in
+        // ``static/app-react-chat-window.js`` ~line 1442 where
+        // CodeRabbit flagged the same lag in a prior PR). Reading
+        // ``lanlan_config`` first would push a few heartbeats to the
+        // *old* tracker during the switch window — 404'd by backend
+        // but loses the immediate post-switch OS-signal coverage.
+        try {
+            var st = window.appState;
+            if (st && typeof st.lanlan_name === 'string' && st.lanlan_name) {
+                return st.lanlan_name;
+            }
+        } catch (_) {}
         try {
             var cfg = window.lanlan_config;
             if (cfg && typeof cfg.lanlan_name === 'string' && cfg.lanlan_name) {

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -166,6 +166,19 @@
                 // bridge call itself threw.
                 return;
             }
+            // F6 (Codex on PR #1477): bridge returned an object but
+            // every field failed type/range validation, so the payload
+            // is empty. Posting just lanlan_name is worse than skipping
+            // — the tracker's ``push_external_system_signal`` defaults
+            // absent numerics to 0.0 and flips ``os_signals_available``
+            // to true, silently overwriting real state with "idle=0,
+            // cpu=0, no window". Skip and let the 30s TTL hand back to
+            // the local collector. Backend also rejects empty payloads
+            // as a defence-in-depth, but skipping client-side saves an
+            // HTTP roundtrip and a rate-limit hit.
+            if (Object.keys(payload).length === 0) {
+                return;
+            }
             payload.lanlan_name = lanlanName;
             var resp = await fetch(ENDPOINT, {
                 method: 'POST',

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -111,8 +111,14 @@
         } catch (e) {
             // Bridge call itself threw — distinct from "bridge returned
             // an empty snapshot" because it usually means IPC died.
-            // Log once and let the failure counter throttle the rest.
-            if (consecutiveFailures < LOG_FAILURE_QUIET_THRESHOLD) {
+            // Bump the failure counter so the log throttle below kicks
+            // in: ``readSignalsFromBridge`` returns ``null`` either for
+            // benign "no signal" or for real failures, and we want
+            // repeat failures to fall under the same 3-then-quiet
+            // policy as POST failures. Then log gated by current
+            // counter (after increment, ``<= threshold``).
+            consecutiveFailures++;
+            if (consecutiveFailures <= LOG_FAILURE_QUIET_THRESHOLD) {
                 console.warn('[activity-signal] bridge read failed:', e);
             }
             return null;
@@ -120,22 +126,31 @@
     }
 
     async function pushOnce(lanlanName) {
+        // Set the in-flight latch BEFORE the bridge read so two ticks
+        // can't both clear the ``if (inFlight)`` check while one is
+        // mid-await. On a slow IPC (Linux xprop, macOS Screen Recording
+        // prompt) the bridge read can take seconds; without this latch
+        // a subsequent tick would re-enter, hit the backend twice in
+        // quick succession, and trip the 5s rate limit unnecessarily.
         if (inFlight) {
-            // Previous POST still running (rare — endpoint is fast).
-            // Skip this tick rather than queueing up; backend rate
-            // limit would reject it anyway.
+            // Previous tick still in flight (rare — endpoint is fast).
+            // Skip rather than queue; the backend rate limit would
+            // reject the duplicate anyway.
             return;
         }
-        var payload = await readSignalsFromBridge();
-        if (payload === null) {
-            // Bridge read failed or returned nothing usable. Skip silently —
-            // tracker's 30s TTL will expire and the local collector takes
-            // over, which is the documented fallback for this case.
-            return;
-        }
-        payload.lanlan_name = lanlanName;
         inFlight = true;
         try {
+            var payload = await readSignalsFromBridge();
+            if (payload === null) {
+                // Bridge read failed or returned nothing usable. Skip
+                // silently — tracker's 30s TTL will expire and the
+                // local collector takes over, which is the documented
+                // fallback for this case. ``readSignalsFromBridge``
+                // already incremented ``consecutiveFailures`` if the
+                // bridge call itself threw.
+                return;
+            }
+            payload.lanlan_name = lanlanName;
             var resp = await fetch(ENDPOINT, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },

--- a/static/app-activity-signal.js
+++ b/static/app-activity-signal.js
@@ -1,0 +1,258 @@
+/**
+ * app-activity-signal.js — frontend half of the cross-platform OS-activity
+ * signal channel (issue #1023, follow-up to PR #1015's activity tracker).
+ *
+ * In remote / non-Windows deployments the Python backend can't read the
+ * foreground window, system idle, CPU, or GPU — those signals are about
+ * the *server*, not the user. PR #1015 left
+ * ``UserActivityTracker.push_external_system_signal()`` as the documented
+ * way to feed them from outside; this file POSTs there from the renderer
+ * on a 5s heartbeat, sourcing the data through the Electron preload
+ * bridge (``window.nekoActivitySignal`` — exposed by the NEKO-PC
+ * companion PR, defined in NEKO-PC ``src/main.js`` +
+ * ``src/preload-*.js``).
+ *
+ * Defensive against the bridge being absent: pure browsers (mobile
+ * shell, dev runs without the Electron wrapper, NEKO-PC older than the
+ * companion PR) skip the heartbeat entirely — the backend tracker
+ * falls back to its local collector in degraded mode, which is what
+ * #1015 already documents for these cases.
+ *
+ * Pairs with backend endpoint ``POST /api/activity_signal`` defined in
+ * ``main_routers/system_router.py``. Endpoint enforces a 5s rate limit
+ * per lanlan_name (matches our heartbeat) and a 30s TTL on each push
+ * (so a stalled heartbeat triggers fallback to the local collector).
+ *
+ * Single-window invariant: load this script only from the always-on
+ * desktop UI (``templates/index.html``), not from the chat popup —
+ * the chat window comes and goes, the desktop pet stays.
+ */
+(function () {
+    'use strict';
+
+    // ── tuning ──────────────────────────────────────────────────────
+    // Match backend ``_EXTERNAL_SIGNAL_MIN_INTERVAL`` (5.0s). Faster
+    // bumps the rate limit and wastes bridge calls; slower lets the
+    // 30s TTL expire if anything blips.
+    var HEARTBEAT_INTERVAL_MS = 5000;
+    // After this many consecutive failures, throttle the log spam (we
+    // keep retrying, just stop printing every time).
+    var LOG_FAILURE_QUIET_THRESHOLD = 3;
+    var ENDPOINT = '/api/activity_signal';
+
+    var heartbeatTimer = null;
+    var inFlight = false;            // re-entrancy guard if the previous POST is still running
+    var consecutiveFailures = 0;
+    var hasLoggedBridgeMissing = false;
+
+    function resolveLanlanName() {
+        try {
+            var cfg = window.lanlan_config;
+            if (cfg && typeof cfg.lanlan_name === 'string' && cfg.lanlan_name) {
+                return cfg.lanlan_name;
+            }
+        } catch (_) {}
+        try {
+            var params = new URLSearchParams(window.location.search);
+            var fromUrl = params.get('lanlan_name');
+            if (fromUrl) return fromUrl;
+        } catch (_) {}
+        return '';
+    }
+
+    function hasBridge() {
+        return Boolean(
+            typeof window !== 'undefined'
+            && window.nekoActivitySignal
+            && typeof window.nekoActivitySignal.read === 'function'
+        );
+    }
+
+    /**
+     * Pull signals from the Electron bridge. Returns the snake_case
+     * payload the backend expects, or ``null`` on any failure (bridge
+     * rejected, fields wrong shape, etc — surfaced as "no signal" so
+     * we just skip this tick).
+     */
+    async function readSignalsFromBridge() {
+        try {
+            var snapshot = await window.nekoActivitySignal.read();
+            if (!snapshot || typeof snapshot !== 'object') {
+                return null;
+            }
+            var payload = {};
+            // Bridge keys are camelCase (Node convention); backend
+            // expects snake_case. Each field is independently optional —
+            // a partial snapshot is still better than no push.
+            if (typeof snapshot.windowTitle === 'string') {
+                payload.window_title = snapshot.windowTitle;
+            }
+            if (typeof snapshot.processName === 'string') {
+                payload.process_name = snapshot.processName;
+            }
+            if (typeof snapshot.idleSeconds === 'number'
+                && isFinite(snapshot.idleSeconds)
+                && snapshot.idleSeconds >= 0) {
+                payload.idle_seconds = snapshot.idleSeconds;
+            }
+            if (typeof snapshot.cpuAvg30s === 'number'
+                && isFinite(snapshot.cpuAvg30s)
+                && snapshot.cpuAvg30s >= 0
+                && snapshot.cpuAvg30s <= 100) {
+                payload.cpu_avg_30s = snapshot.cpuAvg30s;
+            }
+            if (typeof snapshot.gpuUtilization === 'number'
+                && isFinite(snapshot.gpuUtilization)
+                && snapshot.gpuUtilization >= 0
+                && snapshot.gpuUtilization <= 100) {
+                payload.gpu_utilization = snapshot.gpuUtilization;
+            }
+            return payload;
+        } catch (e) {
+            // Bridge call itself threw — distinct from "bridge returned
+            // an empty snapshot" because it usually means IPC died.
+            // Log once and let the failure counter throttle the rest.
+            if (consecutiveFailures < LOG_FAILURE_QUIET_THRESHOLD) {
+                console.warn('[activity-signal] bridge read failed:', e);
+            }
+            return null;
+        }
+    }
+
+    async function pushOnce(lanlanName) {
+        if (inFlight) {
+            // Previous POST still running (rare — endpoint is fast).
+            // Skip this tick rather than queueing up; backend rate
+            // limit would reject it anyway.
+            return;
+        }
+        var payload = await readSignalsFromBridge();
+        if (payload === null) {
+            // Bridge read failed or returned nothing usable. Skip silently —
+            // tracker's 30s TTL will expire and the local collector takes
+            // over, which is the documented fallback for this case.
+            return;
+        }
+        payload.lanlan_name = lanlanName;
+        inFlight = true;
+        try {
+            var resp = await fetch(ENDPOINT, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+                cache: 'no-store',
+                // Don't keep the page alive on close just for the heartbeat.
+                keepalive: false,
+            });
+            if (resp.ok) {
+                if (consecutiveFailures > 0) {
+                    console.info('[activity-signal] recovered after '
+                        + consecutiveFailures + ' failure(s)');
+                }
+                consecutiveFailures = 0;
+                return;
+            }
+            // 429 = rate-limited (we're heartbeating too fast somehow — shouldn't
+            // happen with the 5s interval, but if it does we just skip).
+            // 404 = lanlan_name not registered yet (boot race) — silent.
+            // 503 = tracker not yet initialised (boot race) — silent.
+            // Anything else: count toward failure log throttle.
+            if (resp.status !== 429 && resp.status !== 404 && resp.status !== 503) {
+                consecutiveFailures++;
+                if (consecutiveFailures <= LOG_FAILURE_QUIET_THRESHOLD) {
+                    console.warn(
+                        '[activity-signal] push failed: HTTP ' + resp.status,
+                    );
+                }
+            }
+        } catch (e) {
+            consecutiveFailures++;
+            if (consecutiveFailures <= LOG_FAILURE_QUIET_THRESHOLD) {
+                console.warn('[activity-signal] push exception:', e);
+            }
+        } finally {
+            inFlight = false;
+        }
+    }
+
+    function start() {
+        if (heartbeatTimer !== null) {
+            return; // already running
+        }
+        if (!hasBridge()) {
+            if (!hasLoggedBridgeMissing) {
+                hasLoggedBridgeMissing = true;
+                console.info(
+                    '[activity-signal] Electron bridge '
+                    + '(window.nekoActivitySignal) not exposed — heartbeat '
+                    + 'disabled. Backend tracker will use its local collector '
+                    + '(degraded mode on non-Windows / remote backends).',
+                );
+            }
+            return;
+        }
+        var lanlanName = resolveLanlanName();
+        if (!lanlanName) {
+            // No character yet — happens during very early boot. Retry
+            // every tick; resolveLanlanName is cheap.
+            console.debug(
+                '[activity-signal] lanlan_name not resolved yet; '
+                + 'will retry each heartbeat.',
+            );
+        }
+
+        async function tick() {
+            // Resolve lanlan_name on every tick rather than caching once
+            // at start — character switches mid-session would otherwise
+            // keep pushing into the old tracker.
+            var current = resolveLanlanName();
+            if (current) {
+                await pushOnce(current);
+            }
+        }
+
+        // First tick immediately (don't wait 5s for the first signal
+        // after the page loads), then on interval.
+        tick();
+        heartbeatTimer = setInterval(tick, HEARTBEAT_INTERVAL_MS);
+    }
+
+    function stop() {
+        if (heartbeatTimer !== null) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+        }
+    }
+
+    // Expose for tests / manual control. Not a public contract — kept
+    // intentionally on a namespaced global rather than ``window.*``
+    // directly so it's easy to grep for callers.
+    window.nekoActivitySignalClient = {
+        start: start,
+        stop: stop,
+        // Exposed for unit-test hooks; not for production callers.
+        _resolveLanlanName: resolveLanlanName,
+        _hasBridge: hasBridge,
+    };
+
+    // Auto-start once DOM is settled. We don't depend on any specific
+    // DOM nodes, but waiting until DOMContentLoaded keeps the heartbeat
+    // from racing the early bridge-injection phase.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start, { once: true });
+    } else {
+        start();
+    }
+
+    // Pause on tab hide to avoid burning bridge IPC + network for a
+    // hidden window. Resume on visible. The 30s TTL covers brief tab
+    // switches, so the user won't see stale data on resume — the next
+    // tick fires within HEARTBEAT_INTERVAL_MS.
+    document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState === 'hidden') {
+            stop();
+        } else if (document.visibilityState === 'visible') {
+            start();
+        }
+    });
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -353,6 +353,7 @@
     <script src="/static/app-spatial-audio.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-audio-capture.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-screen.js?v={{ static_asset_version }}"></script>
+    <script src="/static/app-activity-signal.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-crop.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-interpage.js?v={{ static_asset_version }}"></script>
     <script src="/static/app-proactive.js?v={{ static_asset_version }}"></script>

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -210,6 +210,119 @@ def test_field_validation_400s(monkeypatch, payload, expected_error_fragment):
     tracker.push_external_system_signal.assert_not_called()
 
 
+# ── Origin-present same-origin gate ──────────────────────────────────
+
+
+@pytest.mark.unit
+def test_no_origin_header_accepted(monkeypatch):
+    """``curl`` / Node / native scripts send no Origin → must be allowed.
+
+    The Origin gate is intentionally permissive in the no-Origin case
+    because:
+      - Browsers always send Origin on POST (since the 2024-ish spec
+        update), so missing Origin reliably means non-browser caller
+      - Mandatory CSRF tokens would block legitimate native callers
+        without a clean path forward; defer to follow-up PR
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+
+    assert resp.status_code == 200, resp.text
+    tracker.push_external_system_signal.assert_called_once()
+
+
+@pytest.mark.unit
+def test_same_origin_browser_request_accepted(monkeypatch):
+    """Browser fetch with matching Origin (== ``request.base_url``) passes."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria"},
+        headers={"Origin": "http://testserver"},  # TestClient's base_url
+    )
+
+    assert resp.status_code == 200, resp.text
+    tracker.push_external_system_signal.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("evil_origin", [
+    "https://evil.com",
+    "http://attacker.example.com:8080",
+    "https://localhost.evil.com",
+])
+def test_cross_site_origin_blocked_with_403(monkeypatch, evil_origin):
+    """Drive-by browser fetch from off-origin page → 403.
+
+    This is the threat that the Origin gate exists to block: a
+    malicious page on attacker.com calling our endpoint via fetch().
+    Browser always sends Origin = the page's origin; since that's not
+    our base_url, we reject before tracker dispatch.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria"},
+        headers={"Origin": evil_origin},
+    )
+
+    assert resp.status_code == 403, resp.text
+    assert "origin" in resp.json()["error"].lower()
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+def test_referer_used_when_no_origin(monkeypatch):
+    """``_get_request_origin`` falls back to Referer when Origin absent.
+
+    Drive-by CSRF mitigation must work even when an attacker omits
+    Origin (some older clients / browser bugs do this) — Referer is
+    the practical fallback, and our helper already implements it.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    # Referer from off-origin page → should still block
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria"},
+        headers={"Referer": "https://evil.com/some/path"},
+    )
+
+    assert resp.status_code == 403
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+def test_unparseable_origin_treated_as_absent(monkeypatch):
+    """Garbage Origin (can't parse scheme/host) → treated as no-Origin.
+
+    Mirrors screenshot-router test
+    ``test_interactive_screenshot_blocks_browser_requests_with_unparseable_origin``
+    inverted: unparseable means "we can't tell where this came from",
+    so we fall through to the no-Origin path (allow). The endpoint's
+    rate limit + lanlan_name lookup still bound impact.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria"},
+        headers={"Origin": "not a url"},
+    )
+
+    # Origin couldn't be normalised → counts as no Origin → allowed
+    assert resp.status_code == 200, resp.text
+    tracker.push_external_system_signal.assert_called_once()
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize("field", ["idle_seconds", "cpu_avg_30s", "gpu_utilization"])
 @pytest.mark.parametrize("bad_token", ["NaN", "Infinity", "-Infinity"])

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``POST /api/activity_signal``.
+
+The endpoint exposes ``UserActivityTracker.push_external_system_signal``
+(PR #1015) as an HTTP channel so frontend-pushed OS signals can feed
+the tracker in remote / cross-platform deployments where the Python
+backend can't read foreground-window / idle / CPU / GPU directly.
+
+Coverage focus:
+  * Happy path → tracker is called with the right kwargs.
+  * Validation → 400 on bad shapes, 404 / 503 on missing tracker.
+  * Rate limit → 429 with ``Retry-After`` when pushed too fast.
+  * Partial payloads → all fields except ``lanlan_name`` are optional.
+  * Throttle eviction → dict stays bounded under attack.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from main_routers import system_router as system_router_module
+
+
+ACTIVITY_SIGNAL_ENDPOINT = "/api/activity_signal"
+
+
+def _build_mgr(*, has_tracker: bool = True):
+    """A bare-bones session_manager value — only what the endpoint touches."""
+    tracker = MagicMock(name="UserActivityTracker") if has_tracker else None
+    mgr = SimpleNamespace()
+    mgr._activity_tracker = tracker
+    return mgr, tracker
+
+
+@pytest.fixture(autouse=True)
+def _isolate_throttle_state():
+    """Each test starts with an empty throttle dict.
+
+    Without this, test order changes whether the 5s rate limit trips —
+    tests that don't care about throttle would still see 429s leaked
+    from earlier tests' lanlan_name keys.
+    """
+    system_router_module._ACTIVITY_SIGNAL_THROTTLE.clear()
+    yield
+    system_router_module._ACTIVITY_SIGNAL_THROTTLE.clear()
+
+
+def _build_client(monkeypatch, mgr_map: dict):
+    """TestClient with ``get_session_manager`` monkey-patched.
+
+    ``mgr_map`` is the same dict shape returned in production
+    (lanlan_name → mgr-like object). Pass an empty dict to simulate
+    "no characters registered".
+    """
+    monkeypatch.setattr(
+        system_router_module, "get_session_manager", lambda: mgr_map,
+    )
+    app = FastAPI()
+    app.include_router(system_router_module.router)
+    return TestClient(app)
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_full_payload_forwards_to_tracker(monkeypatch):
+    """All fields present → tracker called with them as kwargs."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={
+        "lanlan_name": "Aria",
+        "window_title": "VS Code — neko",
+        "process_name": "Code.exe",
+        "idle_seconds": 3.5,
+        "cpu_avg_30s": 27.4,
+        "gpu_utilization": 65.0,
+    })
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"success": True}
+    tracker.push_external_system_signal.assert_called_once()
+    kwargs = tracker.push_external_system_signal.call_args.kwargs
+    assert kwargs["window_title"] == "VS Code — neko"
+    assert kwargs["process_name"] == "Code.exe"
+    assert kwargs["idle_seconds"] == 3.5
+    assert kwargs["cpu_avg_30s"] == 27.4
+    assert kwargs["gpu_utilization"] == 65.0
+    assert "now" in kwargs and isinstance(kwargs["now"], float)
+
+
+@pytest.mark.unit
+def test_lanlan_name_only_payload_accepted(monkeypatch):
+    """Frontend may push just lanlan_name — tracker handles None fields."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+
+    assert resp.status_code == 200
+    tracker.push_external_system_signal.assert_called_once()
+    kwargs = tracker.push_external_system_signal.call_args.kwargs
+    # All optional fields default to None — let tracker decide defaults.
+    assert kwargs["window_title"] is None
+    assert kwargs["process_name"] is None
+    assert kwargs["idle_seconds"] is None
+    assert kwargs["cpu_avg_30s"] is None
+    assert kwargs["gpu_utilization"] is None
+
+
+@pytest.mark.unit
+def test_lanlan_name_stripped(monkeypatch):
+    """Whitespace around lanlan_name is stripped before lookup."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "  Aria  "})
+
+    assert resp.status_code == 200
+    tracker.push_external_system_signal.assert_called_once()
+
+
+# ── validation errors ────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_missing_lanlan_name_returns_400(monkeypatch):
+    client = _build_client(monkeypatch, {})
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"idle_seconds": 1.0})
+    assert resp.status_code == 400
+    assert "lanlan_name" in resp.json()["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_lanlan_name_returns_400(monkeypatch, blank):
+    client = _build_client(monkeypatch, {})
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": blank})
+    assert resp.status_code == 400
+
+
+@pytest.mark.unit
+def test_invalid_json_body_returns_400(monkeypatch):
+    client = _build_client(monkeypatch, {})
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        content=b"not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("non_object", [[], "string", 42, True])
+def test_non_object_body_returns_400(monkeypatch, non_object):
+    client = _build_client(monkeypatch, {})
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=non_object)
+    assert resp.status_code == 400
+
+
+@pytest.mark.unit
+def test_unknown_lanlan_name_returns_404(monkeypatch):
+    client = _build_client(monkeypatch, {"Aria": _build_mgr()[0]})
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Unknown"},
+    )
+    assert resp.status_code == 404
+    assert "not registered" in resp.json()["error"]
+
+
+@pytest.mark.unit
+def test_mgr_without_tracker_returns_503(monkeypatch):
+    """During boot a mgr can exist before its tracker is attached."""
+    mgr, _ = _build_mgr(has_tracker=False)
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+
+    assert resp.status_code == 503
+    assert "tracker" in resp.json()["error"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("payload,expected_error_fragment", [
+    ({"idle_seconds": -0.1}, "idle_seconds"),
+    ({"idle_seconds": "not a number"}, "idle_seconds"),
+    ({"cpu_avg_30s": 100.01}, "cpu_avg_30s"),
+    ({"cpu_avg_30s": -0.1}, "cpu_avg_30s"),
+    ({"gpu_utilization": 150.0}, "gpu_utilization"),
+    ({"gpu_utilization": "abc"}, "gpu_utilization"),
+    ({"window_title": 123}, "window_title"),
+    ({"process_name": ["array"]}, "process_name"),
+])
+def test_field_validation_400s(monkeypatch, payload, expected_error_fragment):
+    """Out-of-range / wrong-type fields return 400 with a specific message."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    full_payload = {"lanlan_name": "Aria", **payload}
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=full_payload)
+
+    assert resp.status_code == 400, resp.text
+    assert expected_error_fragment in resp.json()["error"]
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+def test_tracker_exception_returns_500(monkeypatch):
+    """If tracker.push_external_system_signal raises, surface 500."""
+    mgr, tracker = _build_mgr()
+    tracker.push_external_system_signal.side_effect = RuntimeError("boom")
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+
+    assert resp.status_code == 500
+    assert "tracker rejected" in resp.json()["error"]
+
+
+# ── rate limiting ─────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_second_push_within_interval_returns_429(monkeypatch):
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    payload = {"lanlan_name": "Aria"}
+
+    resp1 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=payload)
+    resp2 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=payload)
+
+    assert resp1.status_code == 200
+    assert resp2.status_code == 429
+    assert "Retry-After" in resp2.headers
+    # Retry-After is integer seconds, rounded up — must be a positive int.
+    assert int(resp2.headers["Retry-After"]) >= 1
+    body = resp2.json()
+    assert body["error"] == "rate limited"
+    assert body["retry_after_seconds"] > 0
+    # Only the first push reached the tracker.
+    assert tracker.push_external_system_signal.call_count == 1
+
+
+@pytest.mark.unit
+def test_throttle_independent_per_lanlan_name(monkeypatch):
+    """Different lanlan_names have independent throttle buckets."""
+    mgr_a, tracker_a = _build_mgr()
+    mgr_b, tracker_b = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr_a, "Bea": mgr_b})
+
+    resp_a = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    resp_b = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Bea"})
+
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    tracker_a.push_external_system_signal.assert_called_once()
+    tracker_b.push_external_system_signal.assert_called_once()
+
+
+@pytest.mark.unit
+def test_push_accepted_after_interval_elapses(monkeypatch):
+    """After the throttle window passes the next push goes through.
+
+    Drive ``time.time`` through monkeypatch so the test doesn't actually
+    have to sleep 5 seconds.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    # Freeze time at t=1000 for the first push, then t=1006 for the second.
+    fake_now = [1000.0]
+    monkeypatch.setattr(
+        system_router_module.time, "time", lambda: fake_now[0],
+    )
+
+    resp1 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    assert resp1.status_code == 200
+
+    fake_now[0] = 1006.0  # > _EXTERNAL_SIGNAL_MIN_INTERVAL (5.0)
+    resp2 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    assert resp2.status_code == 200, resp2.text
+    assert tracker.push_external_system_signal.call_count == 2
+
+
+# ── throttle dict bookkeeping ────────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_throttle_dict_bounded(monkeypatch):
+    """An attacker spraying lanlan_names can't grow the throttle dict
+    unboundedly — oldest entries get trimmed when over MAX_ENTRIES.
+    """
+    cap = system_router_module._ACTIVITY_SIGNAL_THROTTLE_MAX_ENTRIES
+    # Pre-load the throttle with cap entries, all in the past so they're
+    # candidates for eviction.
+    base = time.time() - 3600
+    for i in range(cap):
+        system_router_module._ACTIVITY_SIGNAL_THROTTLE[f"old_{i}"] = base + i
+
+    mgr, _ = _build_mgr()
+    client = _build_client(monkeypatch, {"NewArrival": mgr})
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "NewArrival"},
+    )
+    assert resp.status_code == 200
+
+    # New entry is in; total size still <= cap.
+    assert "NewArrival" in system_router_module._ACTIVITY_SIGNAL_THROTTLE
+    assert (
+        len(system_router_module._ACTIVITY_SIGNAL_THROTTLE) <= cap
+    )
+    # Oldest entry should have been evicted.
+    assert "old_0" not in system_router_module._ACTIVITY_SIGNAL_THROTTLE

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -451,6 +451,32 @@ def test_unparseable_origin_treated_as_absent(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("field", ["idle_seconds", "cpu_avg_30s", "gpu_utilization"])
+@pytest.mark.parametrize("bool_value", [True, False])
+def test_boolean_rejected_in_numeric_fields(monkeypatch, field, bool_value):
+    """Booleans must be 400'd before ``float()`` coerces them to 0.0/1.0.
+
+    Codex F8 on PR #1477: Python's ``bool`` is a subclass of ``int``,
+    so ``float(True) == 1.0`` and ``float(False) == 0.0`` silently
+    succeed and pass the range checks. A payload like
+    ``{"idle_seconds": true}`` would otherwise spoof a "user just
+    acted" signal; ``{"cpu_avg_30s": true}`` would spoof 1% utilisation.
+    Both are fabricated telemetry that biases activity classification.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    payload = {"lanlan_name": "Aria", field: bool_value}
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=payload)
+
+    assert resp.status_code == 400, resp.text
+    err = resp.json()["error"]
+    assert field in err, f"error should name the offending field, got: {err!r}"
+    assert "number" in err.lower()
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["idle_seconds", "cpu_avg_30s", "gpu_utilization"])
 @pytest.mark.parametrize("bad_token", ["NaN", "Infinity", "-Infinity"])
 def test_nan_and_infinity_rejected(monkeypatch, field, bad_token):
     """``NaN`` / ``±Infinity`` must be 400'd before they reach the tracker.

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -118,6 +118,62 @@ def test_lanlan_name_only_payload_rejected_400(monkeypatch):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("blank_payload", [
+    {"window_title": ""},
+    {"window_title": "   "},
+    {"process_name": ""},
+    {"process_name": "\t\n  "},
+    {"window_title": "", "process_name": ""},
+    {"window_title": "  ", "process_name": "\t"},
+])
+def test_blank_string_payload_rejected_400(monkeypatch, blank_payload):
+    """Blank / whitespace-only strings count as absent for the empty-signal guard.
+
+    CodeRabbit F7 (PR #1477): the original F6 fix only treated ``None``
+    as absent. ``{"window_title": ""}`` (or whitespace-only) would pass
+    the validator, slip through the all-None check, and still pollute
+    tracker state because the tracker treats them as "saw the desktop,
+    no foreground window" while every numeric defaults to 0.0. Same
+    poisoning as the empty payload, just with extra noise.
+
+    Carrying a blank string + no numerics tells the tracker literally
+    nothing, so reject for the same reason a fully-empty payload is
+    rejected.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    full_payload = {"lanlan_name": "Aria", **blank_payload}
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=full_payload)
+
+    assert resp.status_code == 400, resp.text
+    assert "signal field" in resp.json()["error"]
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("blank_payload", [
+    # Blank string PAIRED with a real numeric → not "empty payload",
+    # the numeric carries the signal. Validator-level normalisation of
+    # blank → None is deliberately NOT applied so downstream tracker
+    # logic can still distinguish "" ("saw desktop, no title") from
+    # None ("no observation") if it ever wants to.
+    {"window_title": "", "idle_seconds": 5},
+    {"process_name": "  ", "cpu_avg_30s": 25.0},
+])
+def test_blank_string_paired_with_signal_accepted(monkeypatch, blank_payload):
+    """Blank strings are OK as long as at least one real signal is present."""
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    full_payload = {"lanlan_name": "Aria", **blank_payload}
+
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=full_payload)
+
+    assert resp.status_code == 200, resp.text
+    tracker.push_external_system_signal.assert_called_once()
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("single_field,value", [
     ("window_title", "Finder"),
     ("process_name", "Code.exe"),

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -211,6 +211,42 @@ def test_field_validation_400s(monkeypatch, payload, expected_error_fragment):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("field", ["idle_seconds", "cpu_avg_30s", "gpu_utilization"])
+@pytest.mark.parametrize("bad_token", ["NaN", "Infinity", "-Infinity"])
+def test_nan_and_infinity_rejected(monkeypatch, field, bad_token):
+    """``NaN`` / ``±Infinity`` must be 400'd before they reach the tracker.
+
+    ``float('nan') < lo`` is silently ``False``, so a missing
+    ``math.isfinite`` check let these slip past the range guards
+    (CodeRabbit + Codex P2 on PR #1477). Worse, downstream JSON
+    serialisation of NaN/Infinity crashes since RFC 8259 forbids them.
+
+    We bypass TestClient's ``json=`` helper (which uses httpx's strict
+    ``allow_nan=False`` serialiser) and send raw bytes via ``content=``
+    — Python's stdlib ``json.loads`` (what Starlette uses) accepts the
+    non-standard ``NaN`` / ``Infinity`` tokens, which is exactly the
+    in-the-wild path an attacker / buggy client would take.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    body = (
+        '{"lanlan_name":"Aria","' + field + '":' + bad_token + '}'
+    ).encode()
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 400, resp.text
+    err = resp.json()["error"]
+    assert field in err, f"error should name the offending field, got: {err!r}"
+    assert "finite" in err.lower(), f"error should mention 'finite', got: {err!r}"
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
 def test_tracker_exception_returns_500(monkeypatch):
     """If tracker.push_external_system_signal raises, surface 500."""
     mgr, tracker = _build_mgr()

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -451,6 +451,43 @@ def test_unparseable_origin_treated_as_absent(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.parametrize("field", ["idle_seconds", "cpu_avg_30s", "gpu_utilization"])
+def test_oversized_integer_rejected_400_not_500(monkeypatch, field):
+    """JSON-valid huge ints that ``float()`` can't represent → 400, not 500.
+
+    Codex F9 on PR #1477: ``float(10**400)`` raises ``OverflowError``,
+    which the original ``except (TypeError, ValueError)`` missed →
+    request crashes as 500 instead of being a clean validation 400.
+    Cheap DOS / crash-spam vector for anyone POSTing arbitrary big ints.
+
+    JSON spec doesn't bound integer precision so this is a legit
+    payload from the parser's perspective — Starlette's ``json.loads``
+    happily produces a Python big-int and hands it to us.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+    # JSON: huge int literal. Pass as raw bytes since ``json=`` helper
+    # would serialise it as scientific notation that fits in a double.
+    body = (
+        '{"lanlan_name":"Aria","' + field + '":'
+        + '1' + '0' * 400  # 10**400 — clearly beyond double's range
+        + '}'
+    ).encode()
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 400, (
+        f"oversized int should 400 (clean validation), got {resp.status_code}"
+    )
+    assert field in resp.json()["error"]
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("field", ["idle_seconds", "cpu_avg_30s", "gpu_utilization"])
 @pytest.mark.parametrize("bool_value", [True, False])
 def test_boolean_rejected_in_numeric_fields(monkeypatch, field, bool_value):
     """Booleans must be 400'd before ``float()`` coerces them to 0.0/1.0.

--- a/tests/unit/test_activity_signal_router.py
+++ b/tests/unit/test_activity_signal_router.py
@@ -95,31 +95,70 @@ def test_full_payload_forwards_to_tracker(monkeypatch):
 
 
 @pytest.mark.unit
-def test_lanlan_name_only_payload_accepted(monkeypatch):
-    """Frontend may push just lanlan_name — tracker handles None fields."""
+def test_lanlan_name_only_payload_rejected_400(monkeypatch):
+    """A payload with no signal fields must 400, not push synthetic zeros.
+
+    Codex F6 (PR #1477): the tracker's ``push_external_system_signal``
+    defaults missing numerics to ``0.0`` and unconditionally marks
+    ``os_signals_available=True``. Accepting an all-None push therefore
+    overwrites real state with "idle=0 / cpu=0 / no window" — actively
+    biases activity classification. Defence-in-depth at the endpoint:
+    require ≥ 1 signal field. Frontend client also skips empty bridge
+    snapshots, but the server side closes the same hole for native /
+    malicious callers.
+    """
     mgr, tracker = _build_mgr()
     client = _build_client(monkeypatch, {"Aria": mgr})
 
     resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
 
-    assert resp.status_code == 200
+    assert resp.status_code == 400
+    assert "signal field" in resp.json()["error"]
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("single_field,value", [
+    ("window_title", "Finder"),
+    ("process_name", "Code.exe"),
+    ("idle_seconds", 5),
+    ("cpu_avg_30s", 25.5),
+    ("gpu_utilization", 50.0),
+])
+def test_single_field_payload_accepted(monkeypatch, single_field, value):
+    """Any single signal field is enough — partial snapshot still useful.
+
+    Bridge platforms differ in coverage (Wayland often can't read
+    window, Mac without Screen Recording perm can't either, AMD/Intel
+    no GPU); a partial push is better than no push as long as ≥ 1
+    real datum is in there.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria", single_field: value},
+    )
+
+    assert resp.status_code == 200, resp.text
     tracker.push_external_system_signal.assert_called_once()
-    kwargs = tracker.push_external_system_signal.call_args.kwargs
-    # All optional fields default to None — let tracker decide defaults.
-    assert kwargs["window_title"] is None
-    assert kwargs["process_name"] is None
-    assert kwargs["idle_seconds"] is None
-    assert kwargs["cpu_avg_30s"] is None
-    assert kwargs["gpu_utilization"] is None
 
 
 @pytest.mark.unit
 def test_lanlan_name_stripped(monkeypatch):
-    """Whitespace around lanlan_name is stripped before lookup."""
+    """Whitespace around lanlan_name is stripped before lookup.
+
+    Carries one signal field (``idle_seconds``) to pass the empty-payload
+    guard (Codex F6); the strip behaviour itself is independent.
+    """
     mgr, tracker = _build_mgr()
     client = _build_client(monkeypatch, {"Aria": mgr})
 
-    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "  Aria  "})
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "  Aria  ", "idle_seconds": 0},
+    )
 
     assert resp.status_code == 200
     tracker.push_external_system_signal.assert_called_once()
@@ -168,7 +207,7 @@ def test_unknown_lanlan_name_returns_404(monkeypatch):
     client = _build_client(monkeypatch, {"Aria": _build_mgr()[0]})
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
-        json={"lanlan_name": "Unknown"},
+        json={"lanlan_name": "Unknown", "idle_seconds": 0},
     )
     assert resp.status_code == 404
     assert "not registered" in resp.json()["error"]
@@ -180,7 +219,7 @@ def test_mgr_without_tracker_returns_503(monkeypatch):
     mgr, _ = _build_mgr(has_tracker=False)
     client = _build_client(monkeypatch, {"Aria": mgr})
 
-    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
 
     assert resp.status_code == 503
     assert "tracker" in resp.json()["error"].lower()
@@ -227,7 +266,7 @@ def test_no_origin_header_accepted(monkeypatch):
     mgr, tracker = _build_mgr()
     client = _build_client(monkeypatch, {"Aria": mgr})
 
-    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
 
     assert resp.status_code == 200, resp.text
     tracker.push_external_system_signal.assert_called_once()
@@ -241,7 +280,7 @@ def test_same_origin_browser_request_accepted(monkeypatch):
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
-        json={"lanlan_name": "Aria"},
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
         headers={"Origin": "http://testserver"},  # TestClient's base_url
     )
 
@@ -268,7 +307,7 @@ def test_cross_site_origin_blocked_with_403(monkeypatch, evil_origin):
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
-        json={"lanlan_name": "Aria"},
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
         headers={"Origin": evil_origin},
     )
 
@@ -291,11 +330,42 @@ def test_referer_used_when_no_origin(monkeypatch):
     # Referer from off-origin page → should still block
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
-        json={"lanlan_name": "Aria"},
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
         headers={"Referer": "https://evil.com/some/path"},
     )
 
     assert resp.status_code == 403
+    tracker.push_external_system_signal.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("header_name,opaque_value", [
+    ("Origin", "null"),
+    ("Origin", "NULL"),  # case-insensitive
+    ("Referer", "null"),  # Referer fallback also rejects "null"
+])
+def test_opaque_origin_null_rejected(monkeypatch, header_name, opaque_value):
+    """``Origin: null`` (and Referer: null) from sandboxed iframes / file://
+    contexts must be 403, not fall through to the no-Origin allow path.
+
+    Codex P1 (F5 on PR #1477): browsers emit the literal string "null"
+    for opaque origins. ``urlsplit("null")`` parses into empty scheme +
+    netloc → ``_normalize_origin_value`` returns "" → the no-Origin
+    allow branch fires, bypassing the gate. Without an explicit raw
+    check, ``<iframe sandbox>`` on attacker.com could fetch our
+    endpoint and spoof signals.
+    """
+    mgr, tracker = _build_mgr()
+    client = _build_client(monkeypatch, {"Aria": mgr})
+
+    resp = client.post(
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "Aria", "idle_seconds": 5},
+        headers={header_name: opaque_value},
+    )
+
+    assert resp.status_code == 403, resp.text
+    assert "origin" in resp.json()["error"].lower()
     tracker.push_external_system_signal.assert_not_called()
 
 
@@ -314,7 +384,7 @@ def test_unparseable_origin_treated_as_absent(monkeypatch):
 
     resp = client.post(
         ACTIVITY_SIGNAL_ENDPOINT,
-        json={"lanlan_name": "Aria"},
+        json={"lanlan_name": "Aria", "idle_seconds": 0},
         headers={"Origin": "not a url"},
     )
 
@@ -366,7 +436,7 @@ def test_tracker_exception_returns_500(monkeypatch):
     tracker.push_external_system_signal.side_effect = RuntimeError("boom")
     client = _build_client(monkeypatch, {"Aria": mgr})
 
-    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    resp = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
 
     assert resp.status_code == 500
     assert "tracker rejected" in resp.json()["error"]
@@ -379,7 +449,7 @@ def test_tracker_exception_returns_500(monkeypatch):
 def test_second_push_within_interval_returns_429(monkeypatch):
     mgr, tracker = _build_mgr()
     client = _build_client(monkeypatch, {"Aria": mgr})
-    payload = {"lanlan_name": "Aria"}
+    payload = {"lanlan_name": "Aria", "idle_seconds": 0}
 
     resp1 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=payload)
     resp2 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json=payload)
@@ -403,8 +473,8 @@ def test_throttle_independent_per_lanlan_name(monkeypatch):
     mgr_b, tracker_b = _build_mgr()
     client = _build_client(monkeypatch, {"Aria": mgr_a, "Bea": mgr_b})
 
-    resp_a = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
-    resp_b = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Bea"})
+    resp_a = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
+    resp_b = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Bea", "idle_seconds": 0})
 
     assert resp_a.status_code == 200
     assert resp_b.status_code == 200
@@ -428,11 +498,11 @@ def test_push_accepted_after_interval_elapses(monkeypatch):
         system_router_module.time, "time", lambda: fake_now[0],
     )
 
-    resp1 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    resp1 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
     assert resp1.status_code == 200
 
     fake_now[0] = 1006.0  # > _EXTERNAL_SIGNAL_MIN_INTERVAL (5.0)
-    resp2 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria"})
+    resp2 = client.post(ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "Aria", "idle_seconds": 0})
     assert resp2.status_code == 200, resp2.text
     assert tracker.push_external_system_signal.call_count == 2
 
@@ -456,7 +526,8 @@ def test_throttle_dict_bounded(monkeypatch):
     client = _build_client(monkeypatch, {"NewArrival": mgr})
 
     resp = client.post(
-        ACTIVITY_SIGNAL_ENDPOINT, json={"lanlan_name": "NewArrival"},
+        ACTIVITY_SIGNAL_ENDPOINT,
+        json={"lanlan_name": "NewArrival", "idle_seconds": 0},
     )
     assert resp.status_code == 200
 

--- a/tests/unit/test_agent_router_remote_block.py
+++ b/tests/unit/test_agent_router_remote_block.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""Tests for agent_router's remote-backend mutation block.
+
+When ``NEKO_ACTIVITY_TRACKER_REMOTE`` / ``ACTIVITY_TRACKER_REMOTE`` is set,
+agent mutation endpoints (``/flags``, ``/command``, ``/admin/control``,
+``/tasks/{task_id}/cancel``) must short-circuit with HTTP 501 rather
+than forwarding to a localhost tool_server — in remote deployments the
+"computer" that computer_use would control is the *server's*, not the
+user's, so silently driving it is actively dangerous.
+
+Parity target: ``main_routers/system_router`` already returns 501 with
+the same env override on ``/api/screenshot`` and
+``/api/screenshot/interactive``. This file is the agent-router half of
+that contract. See PR description + issue #1023 for the threat-model
+discussion.
+
+Scope note: a stricter CSRF + Origin guard against DNS-rebinding-style
+attacks on local backends is deferred to a follow-up — it needs the
+~15 frontend agent fetch sites to start sending ``X-CSRF-Token`` first.
+This file covers only the remote-mode block.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from main_routers import agent_router as agent_router_module
+
+
+# Endpoints that MUST short-circuit in remote-backend mode. Body shape
+# is deliberately minimal — we never reach the parsing path, so anything
+# JSON-shaped works. Each entry: (path, body).
+_REMOTE_BLOCKED_ENDPOINTS = [
+    ("/api/agent/flags", {"flags": {}}),
+    ("/api/agent/command", {"command": "set_agent_enabled", "enabled": True}),
+    ("/api/agent/admin/control", {}),
+    ("/api/agent/tasks/abc-123/cancel", None),
+]
+
+
+def _build_client():
+    app = FastAPI()
+    app.include_router(agent_router_module.router)
+    return TestClient(app)
+
+
+def _clear_remote_env(monkeypatch):
+    monkeypatch.delenv("NEKO_ACTIVITY_TRACKER_REMOTE", raising=False)
+    monkeypatch.delenv("ACTIVITY_TRACKER_REMOTE", raising=False)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "env_name", ["NEKO_ACTIVITY_TRACKER_REMOTE", "ACTIVITY_TRACKER_REMOTE"]
+)
+@pytest.mark.parametrize("env_value", ["1", "true", "TRUE", "yes", "on"])
+@pytest.mark.parametrize("path,body", _REMOTE_BLOCKED_ENDPOINTS)
+def test_agent_mutation_endpoints_blocked_in_remote_mode(
+    monkeypatch, env_name, env_value, path, body
+):
+    """Setting the remote env var must short-circuit before any work runs."""
+    _clear_remote_env(monkeypatch)
+    monkeypatch.setenv(env_name, env_value)
+    client = _build_client()
+
+    resp = client.post(path, json=body) if body is not None else client.post(path)
+
+    assert resp.status_code == 501, (
+        f"{path} did not short-circuit in remote mode "
+        f"({env_name}={env_value}): got {resp.status_code} {resp.text!r}"
+    )
+    payload = resp.json()
+    assert payload.get("success") is False
+    assert "NEKO_ACTIVITY_TRACKER_REMOTE" in payload.get("error", ""), (
+        "error message must name the env var so operators can grep for it"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path,body", _REMOTE_BLOCKED_ENDPOINTS)
+def test_agent_mutation_endpoints_not_blocked_when_env_unset(
+    monkeypatch, path, body
+):
+    """Without the env var, the remote-block path must not fire.
+
+    The endpoint may still fail downstream (no shared_state, no
+    tool_server) — that's fine; we're only asserting we don't see the
+    remote-mode 501 envelope. This guards against the env check
+    drifting toward "always on".
+    """
+    _clear_remote_env(monkeypatch)
+    client = _build_client()
+
+    resp = client.post(path, json=body) if body is not None else client.post(path)
+
+    if resp.status_code == 501:
+        error = resp.json().get("error", "")
+        assert "NEKO_ACTIVITY_TRACKER_REMOTE" not in error, (
+            f"{path} short-circuited as remote-blocked even with env unset: "
+            f"{resp.text!r}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("env_value", ["", "0", "false", "no", "off", "anything-else"])
+def test_remote_backend_block_helper_falsy(monkeypatch, env_value):
+    """Falsy/garbage env values must not trip the block helper.
+
+    Mirrors ``test_is_remote_backend_deployment_falsy`` in the
+    screenshot-router suite so the two share an invariant: both
+    consumers agree on what "remote" means.
+    """
+    _clear_remote_env(monkeypatch)
+    if env_value:
+        monkeypatch.setenv("NEKO_ACTIVITY_TRACKER_REMOTE", env_value)
+    assert agent_router_module._remote_backend_block() is None
+
+
+@pytest.mark.unit
+def test_remote_backend_block_helper_truthy_returns_501(monkeypatch):
+    """When the env is truthy, the helper returns a 501 JSONResponse."""
+    _clear_remote_env(monkeypatch)
+    monkeypatch.setenv("NEKO_ACTIVITY_TRACKER_REMOTE", "1")
+    resp = agent_router_module._remote_backend_block()
+    assert resp is not None
+    assert resp.status_code == 501
+
+
+@pytest.mark.unit
+def test_remote_block_alias_reuses_system_signals_helper():
+    """``agent_router.is_remote_backend_deployment`` is the same callable
+    as ``main_logic.activity.system_signals.is_remote_backend_deployment``.
+
+    The whole point of consolidating the env check was to eliminate the
+    drifted-duplicate risk between the activity collector and the
+    routers. This pins the invariant — if someone shadows the import
+    with a local copy, this test fails loudly.
+    """
+    from main_logic.activity.system_signals import (
+        is_remote_backend_deployment as canonical,
+    )
+
+    assert agent_router_module.is_remote_backend_deployment is canonical


### PR DESCRIPTION
## Summary

Issue #1023 拍板路径的实现 —— 给 PR #1015 留下的 `UserActivityTracker.push_external_system_signal()` 补上 HTTP 通道，覆盖 Win/Mac/Linux 桌面 + 远端后端部署 + 移动 shell（受平台限制部分降级）。

两个 commit：
- **C1 `refactor(activity)`** — 单源化 remote-deploy helper + 给 agent_router mutation 端点加 remote-mode 守卫（关掉远程部署下 computer_use 被公网触发的洞）
- **C2 `feat(activity)`** — `POST /api/activity_signal` 端点 + Electron 5s 心跳客户端 + 文档

## Scope 注记（必读）

Issue #1023 审计里点过的"agent_router 没套 CSRF/Origin 守卫"是更宽泛的洞 —— 防的是 DNS rebinding 这类对**本地后端**的攻击。完整修复需要前端 15+ 个 agent fetch 调用点开始送 `X-CSRF-Token`（参考 `static/app-screen.js` 的 `secureLocalScreenshotFetch` 模式），那是 ~200 行前端改动，超出 PR B 预算。

本 PR 只覆盖**远端部署**这一半：在 `is_remote_backend_deployment()` 命中时返回 501，对齐 `/api/screenshot` 同 env 下的拒绝模式。这是 wehos 在 issue 评论里关心的具体威胁（"把后端暴露到公网 = 任何能调到这个端点的请求都能触发 computer_use"）。

CSRF/Origin 防御留 follow-up issue。

## 关键设计点（issue #1023 评论里和 wehos 对齐过）

1. **Endpoint 形态**：`POST /api/activity_signal`，`lanlan_name` 在 body 不在 path —— system_router 的"系统类"端点都这么干，且 lanlan_name 可能含中文，path 转义麻烦
2. **节流**：`_EXTERNAL_SIGNAL_MIN_INTERVAL = 5.0` 放 `tracker.py` 紧挨 `_EXTERNAL_SIGNAL_TTL_SECONDS = 30.0`，不进 config —— 前后端心跳节奏耦合，不该分开调
3. **鉴权**：不叠 `_is_loopback_request` —— 远端模式恰好是非 loopback 才有意义。lanlan_name 查找 + 429 节流是当前的事实防御
4. **手机 shell**：不发 push，保持 #1015 的对话时序降级模式 —— Page Visibility API 拿不到 OS-wide idle，半残 push 反而盖掉本地 collector

## Cross-repo

桥的 Electron 半边在 NEKO-PC 的 follow-up PR：
- `src/main.js` 加 `ipcMain.handle('neko:read-activity-signal', ...)` 调 `powerMonitor.getSystemIdleTime` + npm `active-win` + `os.cpus()` diff + `nvidia-smi`
- 对应 preload 用 `contextBridge.exposeInMainWorld('nekoActivitySignal', { read })`

`static/app-activity-signal.js` 在桥缺席时优雅 no-op（log 一次后退出），所以两个 PR 谁先 merge 都不会破东西。

## Helper 合并：单源化 `is_remote_backend_deployment()`

PR #1015 把 env 检查放在 `system_signals.py::_force_degraded_from_env`，又在 `system_router.py::_is_remote_backend_deployment` 抄了一份。两边逻辑一致但分两处维护，新增 consumer（agent_router、本 PR 的新端点）只会让漂移风险继续累积。

公共 helper `is_remote_backend_deployment()` 现住 `main_logic/activity/system_signals.py`；两处旧名都保留为别名，screenshot router 测试无需改动。

## Test plan

- [x] `tests/unit/test_system_screenshot_router.py` 35 个用例继续通过（helper 重命名向后兼容）
- [x] `tests/unit/test_agent_router_remote_block.py` 52 个新用例：4 端点 × 2 env 变量 × 5 truthy 值 + falsy 边界 + helper 直接调用 + 跨模块同源验证
- [x] `tests/unit/test_activity_signal_router.py` 26 个新用例：happy path / 校验 / 404 / 503 / 500 / 429 + Retry-After / 节流字典 cap
- [x] `tests/test_activity_tracker_followup.py` 68 个活动追踪器既有用例继续通过
- [ ] **需要 reviewer 确认**：scope 收窄（CSRF 拆 follow-up）是否 ok
- [ ] **跨仓库联动**：等 NEKO-PC 桥 PR 起来后做端到端 manual smoke（Electron 渲染端 → 桥 → 后端 → tracker → snapshot 反映新 window/idle）

## 文档

- `docs/design/user-activity-tracker.md` §"Frontend-pushed signals" 改了 —— 从"端点未实现"改成完整 endpoint 契约 + 渲染端客户端 + Electron 桥契约

## 链接

- Issue: #1023
- 基础设施 PR: #1015 (activity tracker)
- 关联 issue: #1020 (系统压力自我退出)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 增加页面端 ~5s 心跳上报脚本（自动启动、可 start/stop、隐藏时暂停、暴露 window.nekoActivitySignalClient），并新增公开接口 POST /api/activity_signal（字段校验、按 lanlan_name 限流、返回整数秒级 Retry-After）。

* **Behavior Changes**
  * 外部信号新鲜度 TTL 从 30s 调整为 15s，新增外部信号最小间隔 5s；远程部署模式下阻断代理变更/控制类路由并返回 501；严格拒绝 NaN/Infinity/布尔数值与空载荷。

* **Tests**
  * 为新接口与远程阻断添加全面单元测试，覆盖校验、限流、容量、来源策略与错误路径。

* **Documentation**
  * 补充设计文档，描述 HTTP 接口与渲染器/Electron 桥接契约及行为说明。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->