### PR TITLE
fix(ui): 锁图标半透明与角色形象淡化状态完全同步

### DIFF
--- a/static/live2d-ui-buttons.js
+++ b/static/live2d-ui-buttons.js
@@ -187,7 +187,10 @@ Live2DManager.prototype.setupHTMLLockIcon = function(model) {
                     }
                 });
             }
-            lockIcon.style.opacity = isOverlapped ? '0.3' : '';
+            // 与角色形象半透明状态完全同步：容器加了 locked-hover-fade 类(opacity 0.12)时，锁图标也淡到同一透明度
+            const live2dFadeContainer = document.getElementById('live2d-container');
+            const lockShouldFade = live2dFadeContainer && live2dFadeContainer.classList.contains('locked-hover-fade');
+            lockIcon.style.opacity = lockShouldFade ? '0.12' : (isOverlapped ? '0.3' : '');
         } catch (_) {}
     };
     this._lockIconTicker = tick;

--- a/static/mmd-ui-buttons.js
+++ b/static/mmd-ui-buttons.js
@@ -815,7 +815,12 @@ MMDManager.prototype._startUIUpdateLoop = function() {
                                 }
                             }
                         });
-                        lockIcon.style.opacity = isLockOverlapped ? '0.3' : '';
+                        // 与角色形象半透明状态完全同步：容器淡化(opacity<1)时锁图标镜像同一透明度
+                        const mmdFadeContainer = document.getElementById('mmd-container');
+                        const mmdFadeOpacity = mmdFadeContainer ? parseFloat(mmdFadeContainer.style.opacity) : NaN;
+                        lockIcon.style.opacity = (Number.isFinite(mmdFadeOpacity) && mmdFadeOpacity < 1)
+                            ? String(mmdFadeOpacity)
+                            : (isLockOverlapped ? '0.3' : '');
                     }
                 }
                 buttonsContainer.style.transform = `scale(${scale})`;

--- a/static/vrm-ui-buttons.js
+++ b/static/vrm-ui-buttons.js
@@ -704,7 +704,12 @@ VRMManager.prototype._startUIUpdateLoop = function() {
                                 }
                             }
                         });
-                        lockIcon.style.opacity = isLockOverlapped ? '0.3' : '';
+                        // 与角色形象半透明状态完全同步：容器淡化(opacity<1)时锁图标镜像同一透明度
+                        const vrmFadeContainer = document.getElementById('vrm-container');
+                        const vrmFadeOpacity = vrmFadeContainer ? parseFloat(vrmFadeContainer.style.opacity) : NaN;
+                        lockIcon.style.opacity = (Number.isFinite(vrmFadeOpacity) && vrmFadeOpacity < 1)
+                            ? String(vrmFadeOpacity)
+                            : (isLockOverlapped ? '0.3' : '');
                     }
                 }
                 buttonsContainer.style.transform = `scale(${scale})`;


### PR DESCRIPTION
## 改动

让 lock（锁）图标的半透明化与角色形象的淡化状态（`locked-hover-fade`）**完全同步**，覆盖 Live2D / VRM / MMD 三种模型。

### 背景
角色形象在 **按住 Ctrl** 或 **鼠标在模型范围内静止 1 秒** 时会淡到 `opacity: 0.12`（受全局开关 `window.lockedHoverFadeEnabled` 控制）。但锁图标是 `document.body` 的直接子节点、不在角色容器内，不继承容器透明度，原本只在被弹窗/侧面板遮挡时降到 `0.3`，角色淡出时锁图标仍是全不透明。

### 实现
让三种模型各自的 lock icon ticker **每帧读取角色容器当前的 fade 状态作为唯一真相**，镜像同一透明度：

- `static/live2d-ui-buttons.js` — 检测 `#live2d-container` 是否含 `locked-hover-fade` 类，有则锁图标设 `0.12`
- `static/vrm-ui-buttons.js` — 读 `#vrm-container` 内联 opacity，`<1` 时镜像该值
- `static/mmd-ui-buttons.js` — 读 `#mmd-container` 内联 opacity，`<1` 时镜像该值

未淡化时保留原有「遮挡 → 0.3 / 否则正常」逻辑。

### 为什么读容器状态而非另设标志位
fade 可由 Ctrl、静止、设置开关多条路径触发/取消（`setLocked` 解锁时甚至直接 `classList.remove` 绕过 applyFade）。读容器实际状态保证锁图标永不失同步。锁图标自带 `transition: opacity 0.3s ease`，淡入淡出与角色平滑一致；tutorial /「请她离开」等用 `!important` 强制隐藏的状态不受影响。

## 测试
- [x] 三个文件 `node --check` 通过
- [ ] 真实 app 内加载模型，按住 Ctrl / 静止 1 秒触发淡化，确认锁图标与角色同步淡出
- [ ] 切换 VRM / MMD 模型验证同样生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了锁定图标的透明度显示，使其能与角色的透明度状态保持同步。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->