### PR TITLE
fix(telemetry): install_hooks 加单次安装守卫，修合并单进程模式下计数翻倍

### DIFF
--- a/tests/unit/test_token_tracker_install_hooks_idempotent.py
+++ b/tests/unit/test_token_tracker_install_hooks_idempotent.py
@@ -1,0 +1,90 @@
+"""回归：``install_hooks()`` 必须幂等，不能叠加 monkey-patch。
+
+合并单进程模式（打包 / Steam 版，见 launcher 的 _run_merged）把 main / memory /
+agent 三个 uvicorn app 跑在同一进程，三个 app 的 startup 各调一次
+``install_hooks()``，打在同一个进程级 ``Completions.create`` 上。没有幂等守卫时
+wrapper 会逐层叠加 —— 每个 chat.completions 调用被 record 多次，conversation /
+emotion / proactive / galgame_options 等走 hook 的 call_type 在遥测里精确翻 N 倍
+（线上 Steam 版三 app 实测 ×3）。
+
+本测试钉住：连调多次 ``install_hooks()`` 后，一次 create 调用只 record 一次。
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import utils.token_tracker as tt
+
+
+@pytest.fixture
+def restore_openai_create():
+    """隔离全局副作用：测试结束后把被 patch 的 SDK 方法还原。"""
+    from openai.resources.chat.completions import AsyncCompletions, Completions
+
+    orig_sync = Completions.create
+    orig_async = AsyncCompletions.create
+    try:
+        yield Completions, AsyncCompletions
+    finally:
+        Completions.create = orig_sync
+        AsyncCompletions.create = orig_async
+
+
+def _fake_usage_response():
+    usage = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        prompt_tokens_details=None,
+    )
+    return SimpleNamespace(usage=usage, model="fake-model")
+
+
+def test_install_hooks_idempotent_no_stacking(restore_openai_create):
+    Completions, _AsyncCompletions = restore_openai_create
+
+    # 用不打网络的假 create 当"原始" SDK 方法（未带我们的 hook 标记）
+    def fake_create(self, *args, **kwargs):
+        return _fake_usage_response()
+
+    Completions.create = fake_create
+
+    rec = MagicMock()
+    fake_tracker = SimpleNamespace(record=rec)
+
+    with patch.object(tt.TokenTracker, "get_instance", return_value=fake_tracker):
+        # 模拟合并模式：main / memory / agent 三个 startup 各装一次
+        tt.install_hooks()
+        installed_once = Completions.create
+        tt.install_hooks()
+        tt.install_hooks()
+
+        # 守卫生效：第 2、3 次安装是 no-op，函数对象不变（没有重新包一层）
+        assert Completions.create is installed_once
+        assert getattr(Completions.create, "_neko_token_tracker_hooked", False) is True
+
+        # 一次非流式调用
+        Completions.create(SimpleNamespace(), model="fake-model", stream=False)
+
+    # 关键不变量：record 恰好一次，而不是三次（叠层会是 3）
+    assert rec.call_count == 1, f"expected 1 record, got {rec.call_count}（wrapper 叠层）"
+
+
+def test_install_hooks_records_once_after_single_install(restore_openai_create):
+    """单次安装的基线：一次调用记一次（与叠层场景形成对照）。"""
+    Completions, _AsyncCompletions = restore_openai_create
+
+    def fake_create(self, *args, **kwargs):
+        return _fake_usage_response()
+
+    Completions.create = fake_create
+    rec = MagicMock()
+
+    with patch.object(
+        tt.TokenTracker, "get_instance", return_value=SimpleNamespace(record=rec)
+    ):
+        tt.install_hooks()
+        Completions.create(SimpleNamespace(), model="fake-model", stream=False)
+
+    assert rec.call_count == 1

--- a/tests/unit/test_token_tracker_install_hooks_idempotent.py
+++ b/tests/unit/test_token_tracker_install_hooks_idempotent.py
@@ -88,3 +88,31 @@ def test_install_hooks_records_once_after_single_install(restore_openai_create):
         Completions.create(SimpleNamespace(), model="fake-model", stream=False)
 
     assert rec.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_install_hooks_idempotent_async_path(restore_openai_create):
+    """异步路径同样不叠层。
+
+    生产里 conversation 走 LangChain astream → AsyncCompletions.create，异步分支
+    才是主路径；它与同步分支共用 _neko_token_tracker_hooked 守卫，但单独钉一遍，
+    避免将来有人只改其中一条分支时静默漏掉。
+    """
+    _Completions, AsyncCompletions = restore_openai_create
+
+    async def fake_async_create(self, *args, **kwargs):
+        return _fake_usage_response()
+
+    AsyncCompletions.create = fake_async_create
+    rec = MagicMock()
+
+    with patch.object(
+        tt.TokenTracker, "get_instance", return_value=SimpleNamespace(record=rec)
+    ):
+        # 合并模式：main / memory / agent 三个 startup 各装一次
+        tt.install_hooks()
+        tt.install_hooks()
+        tt.install_hooks()
+        await AsyncCompletions.create(SimpleNamespace(), model="fake-model", stream=False)
+
+    assert rec.call_count == 1, f"expected 1 record, got {rec.call_count}（async wrapper 叠层）"

--- a/tests/unit/test_token_tracker_install_hooks_idempotent.py
+++ b/tests/unit/test_token_tracker_install_hooks_idempotent.py
@@ -111,8 +111,16 @@ async def test_install_hooks_idempotent_async_path(restore_openai_create):
     ):
         # 合并模式：main / memory / agent 三个 startup 各装一次
         tt.install_hooks()
+        installed_once = AsyncCompletions.create
         tt.install_hooks()
         tt.install_hooks()
+
+        # 与同步测试对称：第 2、3 次安装是 no-op，异步函数对象不变（没有重新包一层），
+        # 且守卫标记已设。缺这两个断言时，若将来异步分支的守卫被误删而 wrapper 恰好
+        # 还能跑一次，仅 record 计数无法发现。
+        assert AsyncCompletions.create is installed_once
+        assert getattr(AsyncCompletions.create, "_neko_token_tracker_hooked", False) is True
+
         await AsyncCompletions.create(SimpleNamespace(), model="fake-model", stream=False)
 
     assert rec.call_count == 1, f"expected 1 record, got {rec.call_count}（async wrapper 叠层）"

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -1651,6 +1651,9 @@ class TokenTracker:
 _stream_options_blocklist: set = set()
 _blocklist_lock = threading.Lock()
 
+# install_hooks() 单次安装守卫（见 install_hooks 文档）
+_hooks_install_lock = threading.Lock()
+
 
 def _get_base_url(self_obj) -> str:
     """从 OpenAI client 实例提取 base_url。"""
@@ -1880,6 +1883,15 @@ def install_hooks():
     同时覆盖 LangChain 底层调用（因为 LangChain ChatOpenAI 底层调用 OpenAI SDK）。
 
     顺便：装 sys.excepthook 抓 unhandled exception 打 crash 事件。
+
+    幂等：合并单进程模式（打包 / Steam 版，见 launcher 的 _run_merged）把
+    main / memory / agent 三个 uvicorn app 跑在同一进程，三个 app 的 startup
+    都会调本函数，打在同一个进程级 ``Completions.create`` 上。没有守卫时 wrapper
+    会逐层叠加 —— 每个 chat.completions 调用被 record 多次，conversation /
+    emotion / proactive / galgame_options 等走 hook 的 call_type 在遥测里精确翻
+    N 倍（线上 Steam 版三 app 实测 ×3）。走 ``TokenTracker.record()`` 直接记账的
+    tts / conversation_realtime / agent_cua 绕开 hook 不受影响；app_start 由
+    ``_has_recorded_app_start`` 单例锁兜住 —— 本守卫是它在 hook 侧的对偶。
     """
     # crash hook 跟 openai 库无关，独立装；幂等。
     _install_crash_excepthook()
@@ -1888,6 +1900,10 @@ def install_hooks():
         from openai.resources.chat.completions import Completions, AsyncCompletions
     except ImportError:
         logger.warning("Token tracker: openai package not found, hooks not installed")
+        return
+
+    # 已装则直接返回（cheap path），避免叠加 wrapper。真正的安装走下面的双检锁。
+    if getattr(Completions.create, "_neko_token_tracker_hooked", False):
         return
 
     _original_create = Completions.create
@@ -1933,8 +1949,19 @@ def install_hooks():
             )
             raise
 
-    Completions.create = patched_create
-    AsyncCompletions.create = patched_async_create
+    # 标记 wrapper，供幂等守卫识别"已装"。functools.wraps 不会复制这个自定义属性，
+    # 所以原始 SDK 方法上不会有它，只有我们包过的才有。
+    patched_create._neko_token_tracker_hooked = True
+    patched_async_create._neko_token_tracker_hooked = True
+
+    # 双检锁：合并模式下三个 startup 协程在同一 event loop 串行跑，cheap path 已能
+    # 挡住；锁是为多线程初始化路径（agent / memory watchdog 线程）兜底，确保
+    # "检测已装 → 赋值"这段不被并发穿插成叠加安装。
+    with _hooks_install_lock:
+        if getattr(Completions.create, "_neko_token_tracker_hooked", False):
+            return
+        Completions.create = patched_create
+        AsyncCompletions.create = patched_async_create
     logger.info("Token tracker: OpenAI SDK hooks installed")
 
 


### PR DESCRIPTION
## 背景：线上遥测计数翻倍

Steam（打包）版的核心 call_type 计数被系统性放大：`conversation / emotion / proactive / galgame_options` 等线上恒为 3 的倍数，而 `tts / conversation_realtime / agent_cua / app_start` 不是。

## 根因

打包 / Steam 版走 `launcher.py` 的合并单进程模式（`_should_use_merged_mode()` 在 frozen 且无 `NEKO_MERGED` override 时为真 → `run_merged_servers()`），把 `main_server.app / memory_server.app / agent_server.app` 三个 uvicorn app 用 `asyncio.create_task(s.serve())` 跑在**同一个进程**。

三个 app 的 `startup` 各调一次 `install_hooks()`，而它无条件 monkey-patch 进程级的 `openai...Completions.create`：

- **走 hook 的**（`chat.completions.create`：conversation / emotion / proactive / galgame_options 等）→ wrapper 叠 3 层 → 每次调用被 `record()` 3 次 → **×3**。
- **直接 `TokenTracker.record()` 记账的**（tts / conversation_realtime / agent_cua）→ 绕开 hook → ×1。
- **app_start** → 进程内 `_has_recorded_app_start` 单例锁兜住 → ×1。

开发机源码版是多进程，每进程装一次 → ×1，所以本地复现不出来，只有线上 Steam 版有。

已对 Electron 端（lanlan_frd）核实出货路径：`backend-runtime.js` spawn 打包 exe `bin/projectneko_server.exe`（`sys.frozen=True`）、无参数、全仓无 `NEKO_MERGED` → 确定走合并模式。

## 修复

给 `install_hooks()` 加单次安装守卫（标记已包装的 wrapper `_neko_token_tracker_hooked` + 双检锁），幂等。一处把所有 hooked call_type 从 ×N 收回 ×1，对未来新增 server / 调用次数都鲁棒。这是 `record_app_start` 进程内单例锁在 hook 侧缺失的对偶。

同类排查：`record_app_start`（单例锁）、`start_periodic_save`（`_save_task` 判空）、`_install_runtime_bindings`（`_INSTALLED` 守卫）三个 startup 各调一次的全局初始化里，只有 `install_hooks` 漏了，其余都已有守卫。

## 数据影响（非本 PR 改动，分析时需知）

修复 rollout 之前，合并模式下 hooked call_type 的线上绝对计数是真 ×3。看板里这段时期这些类型需除以 3；hooked 类型之间比例不受影响，但与非 hooked 类型对比偏 3 倍。

## 测试

新增 `tests/unit/test_token_tracker_install_hooks_idempotent.py`：连调多次 `install_hooks()` 后一次调用只 `record` 一次（叠层会是 3）。

- [x] `pytest tests/unit/test_token_tracker_install_hooks_idempotent.py` → 2 passed
- [x] 相关现有测试 94 passed（唯一 1 个失败 `test_main_server_manual_startup_...` 在 base 基线 stash 后单独跑同样失败，预存在、与本改动无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复 Token Tracker 在重复安装钩子时的叠加与重复记录问题，确保多次安装幂等，提升并发场景下的稳定性与一致性。

* **测试**
  * 新增单元测试覆盖同步与异步路径，验证安装流程幂等性：重复安装不改变行为且每次调用仅产生一次记录。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->