### PR TITLE
fix(llm): thinking 模型多轮工具调用回填 reasoning_content

### DIFF
--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -635,6 +635,7 @@ class OmniOfflineClient:
         messages,
         calls,
         assistant_text: str = "",
+        assistant_reasoning: str = "",
     ) -> None:
         """Run each tool call through ``on_tool_call`` and mutate
         ``messages`` in place: append one assistant turn announcing all
@@ -647,6 +648,12 @@ class OmniOfflineClient:
         某些 OpenAI-compat provider 会"先吐文字再进 tool_calls"。和 Gemini
         路径的 streamed_text_buffer 一样，这条 text 必须一起写进历史，否则
         下一轮上下文丢前缀，模型重复 / 改口。
+
+        ``assistant_reasoning`` 是 thinking 模型本轮的推理链（``reasoning_content``）。
+        DeepSeek-R / Qwen / GLM thinking 等端点在多轮 tool calling 时要求把发起
+        tool_calls 那条 assistant 消息的 ``reasoning_content`` 原样回填，否则下一轮
+        报 400 "The `reasoning_content` in the thinking mode must be passed back to
+        the API."。非 thinking 端点恒为空，此时不写该字段以免污染普通会话。
         """
         # 防御性过滤：``ChatOpenAI.collect_tool_calls`` 已会丢弃空 name 槽位，
         # 但万一调用方直接构造（或上游聚合实现替换），这里再兜一层 ——
@@ -655,7 +662,7 @@ class OmniOfflineClient:
         calls = [c for c in calls if (getattr(c, "name", "") or "").strip()]
         if not calls:
             return
-        messages.append({
+        assistant_turn = {
             "role": "assistant",
             "content": assistant_text or "",
             "tool_calls": [
@@ -669,7 +676,10 @@ class OmniOfflineClient:
                 }
                 for i, c in enumerate(calls)
             ],
-        })
+        }
+        if assistant_reasoning:
+            assistant_turn["reasoning_content"] = assistant_reasoning
+        messages.append(assistant_turn)
         for i, c in enumerate(calls):
             tool_call = ToolCall(
                 name=c.name,
@@ -778,9 +788,15 @@ class OmniOfflineClient:
             # 一 turn 既有 content 又有 tool_calls；某些兼容 provider 真会
             # 先吐文字再进 tool_calls。和 Gemini 路径完全对偶。
             streamed_text_buffer = ""
+            # Thinking 模型本轮的推理链：finish_reason=tool_calls 时必须随
+            # assistant tool_calls turn 一起回填，否则部分 provider 下一轮报
+            # 400（reasoning_content must be passed back）。普通端点恒为空。
+            streamed_reasoning_buffer = ""
             async for chunk in self.llm.astream(messages, **overrides):
                 if getattr(chunk, "content", None):
                     streamed_text_buffer += chunk.content
+                if getattr(chunk, "reasoning_content", None):
+                    streamed_reasoning_buffer += chunk.reasoning_content
                 if chunk.tool_call_deltas:
                     deltas_per_chunk.append(chunk.tool_call_deltas)
                 if chunk.finish_reason:
@@ -828,7 +844,9 @@ class OmniOfflineClient:
                 from utils.llm_client import LLMStreamChunk as _LLMStreamChunk
                 calls = _ChatOpenAI.collect_tool_calls(deltas_per_chunk)
                 await self._execute_and_append_openai_tool_calls(
-                    messages, calls, assistant_text=streamed_text_buffer,
+                    messages, calls,
+                    assistant_text=streamed_text_buffer,
+                    assistant_reasoning=streamed_reasoning_buffer,
                 )
                 # 通知上游 ``stream_text``：本轮的 pre-tool text + tool_calls
                 # 已经写进 history（assistant turn）。stream_text 据此清空

--- a/main_logic/omni_offline_client.py
+++ b/main_logic/omni_offline_client.py
@@ -808,6 +808,18 @@ class OmniOfflineClient:
                     pt = chunk.usage_metadata.get("prompt_tokens")
                     if pt:
                         self._last_prompt_tokens = pt
+                # 纯 reasoning chunk（thinking 模型先吐推理链，content 为空、无
+                # tool delta / finish / usage）只在上面累积进 buffer，不向下游
+                # 转发：``stream_text`` 在首个 yield 的 chunk 上记 TTFT，放行
+                # reasoning-only 会把"首推理 token"误当首 token，拉低延迟埋点。
+                if (
+                    getattr(chunk, "reasoning_content", None)
+                    and not getattr(chunk, "content", None)
+                    and not chunk.tool_call_deltas
+                    and not chunk.finish_reason
+                    and not chunk.usage_metadata
+                ):
+                    continue
                 # 永远 yield 文本 chunk —— 即便是 tool-only turn 也可能在
                 # finish_reason=tool_calls 之前 emit usage chunk 和空 content。
                 yield chunk

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -373,12 +373,15 @@ async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
         "thinking 模型发起 tool_calls 那轮的 reasoning_content 必须累积并回填进历史，"
         "否则部分 provider 下一轮报 400"
     )
-    # 第二轮请求确实带上了含 reasoning_content 的历史
+    # 第二轮请求确实带上了含 reasoning_content 的历史，且值与本轮累积的推理链
+    # 完全一致（不只验存在——中间路径若截断/改写 reasoning_content 也要抓到）。
     second_call_messages = fake_llm.calls[1][0]
-    assert any(
-        isinstance(m, dict) and m.get("reasoning_content")
+    replayed = next(
+        m.get("reasoning_content")
         for m in second_call_messages
+        if isinstance(m, dict) and m.get("reasoning_content")
     )
+    assert replayed == "用户问起以前的事，我得查一下记忆。"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -296,6 +296,134 @@ async def test_offline_openai_path_runs_tool_then_text():
 
 
 @pytest.mark.asyncio
+async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
+    """Thinking 模型（DeepSeek-R / Qwen / GLM thinking 等 OpenAI-compat 端点）
+    在多轮 tool calling 时，发起 tool_calls 的那条 assistant 消息必须把本轮流出的
+    ``reasoning_content`` 原样回填，否则下一轮报 400 "The `reasoning_content` in the
+    thinking mode must be passed back to the API."（触发 memory_recall 时复现过）。
+
+    本测试 script 一个带 reasoning_content 的 tool-call 轮，断言写回历史的
+    assistant tool_calls 消息里 reasoning_content 被保留。"""
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+
+    tool_def = ToolDefinition(
+        name="memory_recall",
+        description="recall",
+        parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+        handler=lambda args: {"hits": []},
+    )
+
+    # 第一轮：先流推理链，再流 tool_call，finish_reason=tool_calls。
+    chunks_call_1 = [
+        LLMStreamChunk(content="", reasoning_content="用户问起以前的事，"),
+        LLMStreamChunk(content="", reasoning_content="我得查一下记忆。"),
+        LLMStreamChunk(
+            content="",
+            tool_call_deltas=[{
+                "index": 0,
+                "id": "call_m",
+                "type": "function",
+                "function": {"name": "memory_recall", "arguments": '{"q":"生日"}'},
+            }],
+            finish_reason=None,
+        ),
+        LLMStreamChunk(content="", tool_call_deltas=None, finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [
+        LLMStreamChunk(content="我记得是夏天。", finish_reason="stop"),
+    ]
+
+    fake_llm = _FakeLLM([chunks_call_1, chunks_call_2])
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.llm = fake_llm
+    client._tool_definitions = [tool_def]
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={"hits": []})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "我生日是什么时候？"}]
+    async for _ in client._astream_with_tools(messages):
+        pass
+
+    assistant_with_tool_calls = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert assistant_with_tool_calls.get("reasoning_content") == "用户问起以前的事，我得查一下记忆。", (
+        "thinking 模型发起 tool_calls 那轮的 reasoning_content 必须累积并回填进历史，"
+        "否则部分 provider 下一轮报 400"
+    )
+    # 第二轮请求确实带上了含 reasoning_content 的历史
+    second_call_messages = fake_llm.calls[1][0]
+    assert any(
+        isinstance(m, dict) and m.get("reasoning_content")
+        for m in second_call_messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_offline_openai_path_omits_reasoning_when_absent():
+    """非 thinking 端点（delta 不带 reasoning_content）时，assistant tool_calls
+    消息不应凭空塞入 reasoning_content 字段，免得污染普通会话 / 触发某些 provider
+    对 reasoning_content 的反向校验。"""
+    from utils.llm_client import LLMStreamChunk
+    from main_logic.omni_offline_client import OmniOfflineClient
+    from main_logic.tool_calling import ToolCall, ToolDefinition, ToolResult
+
+    tool_def = ToolDefinition(
+        name="memory_recall",
+        description="recall",
+        parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+        handler=lambda args: {"hits": []},
+    )
+    chunks_call_1 = [
+        LLMStreamChunk(
+            content="",
+            tool_call_deltas=[{
+                "index": 0,
+                "id": "call_m",
+                "type": "function",
+                "function": {"name": "memory_recall", "arguments": "{}"},
+            }],
+            finish_reason=None,
+        ),
+        LLMStreamChunk(content="", tool_call_deltas=None, finish_reason="tool_calls"),
+    ]
+    chunks_call_2 = [LLMStreamChunk(content="好的喵。", finish_reason="stop")]
+    fake_llm = _FakeLLM([chunks_call_1, chunks_call_2])
+
+    client = OmniOfflineClient.__new__(OmniOfflineClient)
+    client.llm = fake_llm
+    client._tool_definitions = [tool_def]
+    client.max_tool_iterations = 4
+    client._use_genai_sdk = False
+    client._genai_tools_unsupported = False
+
+    async def handler(call: ToolCall) -> ToolResult:
+        return ToolResult(call_id=call.call_id, name=call.name, output={"hits": []})
+
+    client.on_tool_call = handler
+
+    messages = [{"role": "user", "content": "hi"}]
+    async for _ in client._astream_with_tools(messages):
+        pass
+
+    assistant_with_tool_calls = next(
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
+    )
+    assert "reasoning_content" not in assistant_with_tool_calls
+
+
+@pytest.mark.asyncio
 async def test_offline_switch_model_recomputes_genai_routing(monkeypatch):
     """switch_model 切到不同 endpoint 后必须重新计算 _use_genai_sdk，
     并清空 _genai_client，否则会沿用旧 conversation 的路由判断。

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -350,8 +350,20 @@ async def test_offline_openai_path_persists_reasoning_content_with_tool_call():
     client.on_tool_call = handler
 
     messages = [{"role": "user", "content": "我生日是什么时候？"}]
-    async for _ in client._astream_with_tools(messages):
-        pass
+    out_chunks = []
+    async for ch in client._astream_with_tools(messages):
+        out_chunks.append(ch)
+
+    # 纯 reasoning chunk（content 空 + 无 tool/finish/usage）不得向下游转发，
+    # 否则 stream_text 会把首个推理 chunk 误记成 TTFT 首 token（Codex P2）。
+    assert not any(
+        getattr(ch, "reasoning_content", None)
+        and not getattr(ch, "content", None)
+        and not ch.tool_call_deltas
+        and not ch.finish_reason
+        and not ch.usage_metadata
+        for ch in out_chunks
+    ), "reasoning-only chunk 不应 surface 给通用流式消费者（TTFT 会被拉低）"
 
     assistant_with_tool_calls = next(
         m for m in messages

--- a/utils/llm_client.py
+++ b/utils/llm_client.py
@@ -224,6 +224,13 @@ class LLMStreamChunk:
     # ``"tool_calls"`` / ``"content_filter"`` / None. ``"tool_calls"`` signals
     # the caller should run the tool then continue the conversation.
     finish_reason: str | None = None
+    # Thinking-mode 模型（DeepSeek-R 系 / Qwen / GLM thinking 等 OpenAI-compat
+    # 端点）在 ``delta`` 里单独流出的推理链文本。普通对话用不到，但 **多轮
+    # tool calling** 时这些 provider 要求把发起 tool_calls 那条 assistant 消息的
+    # ``reasoning_content`` 原样回填，否则下一轮报 400 "The `reasoning_content`
+    # in the thinking mode must be passed back to the API."。tool 循环靠累积此
+    # 字段把它写回 assistant 历史。
+    reasoning_content: str | None = None
     # ``OmniOfflineClient`` tool-loop sentinel：``_astream_*_with_tools`` 在
     # 把当前 tool 轮（assistant tool_calls + tool result）inline 写进 history
     # 后会 yield 一个 ``LLMStreamChunk(content="", tool_round_persisted=True)``。
@@ -542,12 +549,19 @@ class ChatOpenAI:
                                 "arguments": getattr(fn, "arguments", "") if fn else "",
                             },
                         })
+            # Thinking 模型把推理链放在非标准的 ``delta.reasoning_content``
+            # 字段（openai-python 的 BaseModel extra=allow，未知字段照样可
+            # getattr）。普通端点没有这个字段，getattr 返回 None。
+            reasoning_content = (
+                getattr(delta, "reasoning_content", None) if delta else None
+            )
             finish_reason = getattr(choice, "finish_reason", None) if choice else None
-            if content or tool_call_deltas or finish_reason:
+            if content or tool_call_deltas or finish_reason or reasoning_content:
                 yield LLMStreamChunk(
                     content=content,
                     tool_call_deltas=tool_call_deltas,
                     finish_reason=finish_reason,
+                    reasoning_content=reasoning_content,
                 )
             # Terminal chunk with usage info (stream_options={"include_usage": True})
             if chunk.usage is not None:


### PR DESCRIPTION
## 背景

触发 `memory_recall` 工具时报错：

```
BadRequestError: Error code: 400
{'error': {'message': 'The `reasoning_content` in the thinking mode must be passed back to the API.', ...}}
```

## 原因

思考模式（thinking mode）模型走 OpenAI 兼容接口时，把推理链单独流在非标准的 `delta.reasoning_content` 字段。当模型发起工具调用（如 `memory_recall`）时，工具循环要重建那条 assistant 消息并把整段对话发回去续聊——但原来重建只带了 `content` + `tool_calls`，**丢了 `reasoning_content`**。Qwen / GLM 这类思考端点在下一轮就拒绝请求，报上面的 400。

（DeepSeek-reasoner 是反向要求——发回去反而 400，但它不支持工具调用、走不到这条路径，故不受影响。）

## 改动

- `utils/llm_client.py`
  - `LLMStreamChunk` 新增 `reasoning_content` 字段
  - `ChatOpenAI.astream` 用 `getattr` 抓取 `delta.reasoning_content`（非标准字段）并透传到 chunk
- `main_logic/omni_offline_client.py`
  - `_astream_openai_with_tools` 新增 `streamed_reasoning_buffer`，与现有文本 buffer 对偶地累积本轮推理链
  - `_execute_and_append_openai_tool_calls` 接收并**仅在非空时**把 `reasoning_content` 写回 assistant 历史——普通端点不流该字段，消息保持干净

## 测试

`tests/unit/test_tool_calling.py` 新增两个回归测试：
- 思考模式工具往返时，确认累积的 `reasoning_content` 被保留并随下一轮请求发回
- 非思考模式时，确认 assistant 消息不会凭空多出 `reasoning_content` 键

## Test plan

- [x] `uv run pytest tests/unit/test_tool_calling.py -q` → 56 passed
- [ ] 真机：用思考模式端点触发 `memory_recall`，确认不再 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持“思考”模型在流式输出中的推理链累积与回填，使多轮工具调用时历史能保留并回放推理内容，提升上下文连续性与工具执行准确性。

* **Tests**
  * 新增端到端测试覆盖思考模式与非思考场景，验证推理链累积/回填行为及仅含推理片段不被下游透传。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->