### PR TITLE
fix(chat): 主动消息 / agent_callback 轮也触发情感分析

### DIFF
--- a/static/app-websocket.js
+++ b/static/app-websocket.js
@@ -812,6 +812,102 @@
         );
     }
 
+    // 一轮 AI 文本说完后的统一收尾：音乐指令（可选）+ 情感分析 + 字幕翻译。
+    // 'turn end'（用户发起）与 'turn end agent_callback'（主动消息 / 热切换回调）
+    // 两条路径共用，避免 emotion / 字幕逻辑再像以前那样在两个分支间悄悄走样
+    // ——旧版 agent_callback 分支漏掉了 emotion 分析，导致主动消息时头像表情僵住，
+    // 且这类用户在 telemetry 上表现为「有 galgame_options 调用却从无 emotion 调用」。
+    // 唯一保留的分支差异：
+    //   - music commands：proactive 轮默认关闭（主动消息自动放歌过于侵入）；
+    //   - proactive 调度：仅 'turn end' 分支 reschedule，agent_callback 不排，
+    //     防止 proactive 自己触发下一条 proactive。
+    // emotion 本身是只读的（仅向头像推一条表情，不触发对话 / 记忆 / 再投递），
+    // 没有自触发风险，因此 proactive 轮也应当照常触发。
+    function finalizeAssistantTurn(assistantTurnId, options) {
+        options = options || {};
+        var enableMusic = options.enableMusic !== false;
+
+        var bufferedFullText = typeof window._geminiTurnFullText === 'string'
+            ? window._geminiTurnFullText
+            : '';
+        var fallbackFromBubble = (window.currentGeminiMessage &&
+            window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
+            window.currentGeminiMessage.isConnected &&
+            typeof window.currentGeminiMessage.textContent === 'string')
+            ? window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /, '')
+            : '';
+
+        var fullText = (bufferedFullText && bufferedFullText.trim()) ? bufferedFullText : fallbackFromBubble;
+
+        // Trigger music bubble generation
+        if (enableMusic && typeof window.processMusicCommands === 'function' && fullText) {
+            window.processMusicCommands(fullText);
+        }
+
+        // Strip music commands before emotion analysis / subtitle translation
+        fullText = fullText.replace(/\[play_music:[^\]]*(\]|$)/g, '').trim();
+
+        if (!fullText || !fullText.trim()) {
+            return;
+        }
+
+        // Emotion analysis (5s timeout)
+        setTimeout(async function () {
+            try {
+                var emotionPromise = (typeof window.analyzeEmotion === 'function')
+                    ? window.analyzeEmotion(fullText)
+                    : Promise.resolve(null);
+                var timeoutPromise = new Promise(function (_, reject2) {
+                    setTimeout(function () { reject2(new Error('情感分析超时')); }, 5000);
+                });
+                var emotionResult = await Promise.race([emotionPromise, timeoutPromise]);
+                if (emotionResult && emotionResult.emotion) {
+                    console.log(window.t('console.emotionAnalysisComplete'), emotionResult);
+                    if (typeof window.applyEmotion === 'function') window.applyEmotion(emotionResult.emotion);
+                    if (assistantTurnId) {
+                        emitAssistantLifecycleEvent('neko-assistant-emotion-ready', {
+                            turnId: assistantTurnId,
+                            emotion: emotionResult.emotion,
+                            source: 'emotion_analysis'
+                        });
+                    }
+                }
+            } catch (emotionError) {
+                if (emotionError.message === '情感分析超时') {
+                    console.warn(window.t('console.emotionAnalysisTimeout'));
+                } else {
+                    console.warn(window.t('console.emotionAnalysisFailed'), emotionError);
+                }
+            }
+        }, 100);
+
+        // Frontend subtitle finalization: subtitle.js 内部根据开关决定是否
+        // 真正发请求；不需要的语言会保留流式累积的原文，不会清空字幕。
+        // 结构化 turn 收尾为 [markdown] 占位，跳过翻译链路。
+        if (window._turnIsStructured) {
+            if (typeof window.finalizeSubtitleAsStructured === 'function') {
+                try { window.finalizeSubtitleAsStructured(); } catch (_) {}
+            }
+            return;
+        }
+        (async function () {
+            try {
+                if (typeof window.translateAndShowSubtitle === 'function') {
+                    await window.translateAndShowSubtitle(fullText);
+                }
+            } catch (transError) {
+                console.error(window.t('console.translationProcessFailed'), {
+                    error: transError.message,
+                    stack: transError.stack,
+                    fullText: fullText.substring(0, 50) + '...'
+                });
+                if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+                    console.warn(window.t('console.translationUnavailable'));
+                }
+            }
+        })();
+    }
+
     function ensureAssistantTurnStarted(source, serverTurnId) {
         if (S.assistantTurnId) {
             clearPendingAssistantTurnStart();
@@ -2354,37 +2450,10 @@
                     clearPendingAssistantTurnStart();
 
                     // 主动消息 / 热切换回调也产生了 AI 文本（来自 send_lanlan_response），
-                    // 同样需要为字幕翻译。情感分析 / proactive backoff 维持原行为不动。
-                    (function () {
-                        var bufferedFullText = typeof window._geminiTurnFullText === 'string'
-                            ? window._geminiTurnFullText
-                            : '';
-                        var fallbackFromBubble = (window.currentGeminiMessage &&
-                            window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
-                            window.currentGeminiMessage.isConnected &&
-                            typeof window.currentGeminiMessage.textContent === 'string')
-                            ? window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /, '')
-                            : '';
-                        var fullText = (bufferedFullText && bufferedFullText.trim()) ? bufferedFullText : fallbackFromBubble;
-                        fullText = fullText.replace(/\[play_music:[^\]]*(\]|$)/g, '').trim();
-                        if (!fullText) return;
-                        // 结构化 turn（markdown/code/table/latex）→ 字幕收尾为 [markdown] 占位，不翻译
-                        if (window._turnIsStructured) {
-                            if (typeof window.finalizeSubtitleAsStructured === 'function') {
-                                try { window.finalizeSubtitleAsStructured(); } catch (_) {}
-                            }
-                            return;
-                        }
-                        (async function () {
-                            try {
-                                if (typeof window.translateAndShowSubtitle === 'function') {
-                                    await window.translateAndShowSubtitle(fullText);
-                                }
-                            } catch (transError) {
-                                console.error('[Subtitle] agent_callback translate failed:', transError);
-                            }
-                        })();
-                    })();
+                    // 与正常 'turn end' 走同一套收尾（emotion + 字幕）。music 关闭——
+                    // 主动消息不自动放歌；也不在此调 scheduleProactiveChat（见上方
+                    // "skipping proactive chat schedule"），防 proactive 自触发。
+                    finalizeAssistantTurn(agentCallbackTurnId, { enableMusic: false });
 
                 // -------- system turn end --------
                 } else if (response.type === 'system' && response.data === 'turn end') {
@@ -2420,88 +2489,9 @@
                     }
                     clearPendingAssistantTurnStart();
 
-                    // Emotion analysis & translation on turn completion
-                    (function () {
-                        var bufferedFullText = typeof window._geminiTurnFullText === 'string'
-                            ? window._geminiTurnFullText
-                            : '';
-                        var fallbackFromBubble = (window.currentGeminiMessage &&
-                            window.currentGeminiMessage.nodeType === Node.ELEMENT_NODE &&
-                            window.currentGeminiMessage.isConnected &&
-                            typeof window.currentGeminiMessage.textContent === 'string')
-                            ? window.currentGeminiMessage.textContent.replace(/^\[\d{2}:\d{2}:\d{2}\] \u{1F380} /, '')
-                            : '';
-
-                        var fullText = (bufferedFullText && bufferedFullText.trim()) ? bufferedFullText : fallbackFromBubble;
-
-                        // Trigger music bubble generation
-                        if (typeof window.processMusicCommands === 'function' && fullText) {
-                            window.processMusicCommands(fullText);
-                        }
-
-                        // Strip music commands before emotion analysis / subtitle translation
-                        fullText = fullText.replace(/\[play_music:[^\]]*(\]|$)/g, '').trim();
-
-                        if (!fullText || !fullText.trim()) {
-                            return;
-                        }
-
-                        // Emotion analysis (5s timeout)
-                        setTimeout(async function () {
-                            try {
-                                var emotionPromise = (typeof window.analyzeEmotion === 'function')
-                                    ? window.analyzeEmotion(fullText)
-                                    : Promise.resolve(null);
-                                var timeoutPromise = new Promise(function (_, reject2) {
-                                    setTimeout(function () { reject2(new Error('情感分析超时')); }, 5000);
-                                });
-                                var emotionResult = await Promise.race([emotionPromise, timeoutPromise]);
-                                if (emotionResult && emotionResult.emotion) {
-                                    console.log(window.t('console.emotionAnalysisComplete'), emotionResult);
-                                    if (typeof window.applyEmotion === 'function') window.applyEmotion(emotionResult.emotion);
-                                    if (assistantTurnId) {
-                                        emitAssistantLifecycleEvent('neko-assistant-emotion-ready', {
-                                            turnId: assistantTurnId,
-                                            emotion: emotionResult.emotion,
-                                            source: 'emotion_analysis'
-                                        });
-                                    }
-                                }
-                            } catch (emotionError) {
-                                if (emotionError.message === '情感分析超时') {
-                                    console.warn(window.t('console.emotionAnalysisTimeout'));
-                                } else {
-                                    console.warn(window.t('console.emotionAnalysisFailed'), emotionError);
-                                }
-                            }
-                        }, 100);
-
-                        // Frontend subtitle finalization: subtitle.js 内部根据开关决定是否
-                        // 真正发请求；不需要的语言会保留流式累积的原文，不会清空字幕。
-                        // 结构化 turn 收尾为 [markdown] 占位，跳过翻译链路。
-                        if (window._turnIsStructured) {
-                            if (typeof window.finalizeSubtitleAsStructured === 'function') {
-                                try { window.finalizeSubtitleAsStructured(); } catch (_) {}
-                            }
-                            return;
-                        }
-                        (async function () {
-                            try {
-                                if (typeof window.translateAndShowSubtitle === 'function') {
-                                    await window.translateAndShowSubtitle(fullText);
-                                }
-                            } catch (transError) {
-                                console.error(window.t('console.translationProcessFailed'), {
-                                    error: transError.message,
-                                    stack: transError.stack,
-                                    fullText: fullText.substring(0, 50) + '...'
-                                });
-                                if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-                                    console.warn(window.t('console.translationUnavailable'));
-                                }
-                            }
-                        })();
-                    })();
+                    // Emotion analysis & subtitle on turn completion —— 与
+                    // agent_callback 路径共用 finalizeAssistantTurn；正常轮启用 music。
+                    finalizeAssistantTurn(assistantTurnId);
 
                     // AI turn_end 后只 reschedule，不 reset backoff。
                     // 理由：turn_end 无法区分"用户发话引发的 turn"和"proactive 自己引发的 turn"，


### PR DESCRIPTION
## 背景 / 现象

telemetry 发现约 10% 用户**有 `galgame_options` 调用，却从来没产生过一次 `emotion` 调用**。

## Root cause

后端有两条 turn-end 完成回调，对应前端 `app-websocket.js` 两个分支：

| 后端回调 | 前端消息 | 触发场景 | 旧行为 |
|---|---|---|---|
| `handle_response_complete` → `_emit_turn_end` | `'turn end'` | 正常回复用户 | 字幕 + **情感分析** ✓ |
| `handle_proactive_complete` | `'turn end agent_callback'` | 主动消息 / 热切换回调 | 只做字幕，**漏了情感分析** ✗ |

两个分支**都**发 `neko-assistant-turn-end` 事件（galgame 选项监听它，所以照常拉取），但情感分析那段只写在 `'turn end'` 分支里。任何交互以主动消息 / agent_callback 为主的用户，galgame_options 会有调用、emotion 永远不会——头像表情也因此僵在原地。

旧分支的注释「情感分析 / proactive backoff 维持原行为不动」把两件不同性质的东西捆在了一起：proactive 调度（确实是防自触发的防线，该排除）和情感分析（只读、无副作用，被顺手一起漏掉了）。

## 改动

把两条路径的「音乐 + 情感 + 字幕」收尾抽成共用的 `finalizeAssistantTurn(assistantTurnId, options)`，两个分支都调用它，避免逻辑再在分支间走样。

刻意保留的分支差异仅两处（用参数 / 调用位置表达，不再靠复制粘贴维持）：
- **music commands**：proactive 轮 `{ enableMusic: false }`（主动消息自动放歌过于侵入）；
- **proactive 调度**：仅 `'turn end'` 分支 reschedule，`agent_callback` 不调 `scheduleProactiveChat`，防 proactive 自排下一条。

emotion 是只读的——仅向头像推一条表情，不触发对话 / 记忆分析 / agent 再投递，没有自触发风险，所以 proactive 轮也应当照常触发。

## Test plan

- [x] `node --check static/app-websocket.js` 语法通过
- [x] 正常 `'turn end'` 分支行为逐字保留（music + emotion + 字幕 + proactive 调度尾部不变）
- [ ] 主动消息 / 热切换场景：开 galgame 模式，让 AI 主动说话，确认头像表情随之变化（旧版僵住）
- [ ] telemetry：复查目标 cohort 在上线后是否开始产生 emotion 调用
- [ ] 三上下文回归（index.html 宽屏 / 窄宽手机 / chat.html Electron）——本改动为 WS handler 内部逻辑抽取，三处共用同一份，无渲染差异

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 优化了助手回合完成后的逻辑处理流程，统一了音乐、字幕和情感分析的执行方式，提高了代码的可维护性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->