### PR TITLE
fix(config): agent URL 按线路路由（国内 lanlan.app / 国际 www.lanlan.app）

### DIFF
--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -656,11 +656,26 @@ class TestAgentUrlRegionRouting:
 
     @pytest.mark.unit
     @pytest.mark.parametrize('non_mainland', [True, False, None])
-    def test_normalize_agent_url_custom_url_untouched(self, config_manager, non_mainland):
-        """不含 lanlan 域的自定义 URL 原样返回，不受线路影响。"""
+    @pytest.mark.parametrize('custom', [
+        'https://api.openai.com/v1',
+        # 自定义代理把 lanlan 域写进 path/query：只按 host 判定，不得被改写
+        'https://myproxy.example.com/v1?upstream=www.lanlan.app',
+        'https://myproxy.example.com/lanlan.tech/v1',
+        # host 仅以 lanlan.app 结尾但并非该域，不应命中
+        'https://evil-lanlan.app/v1',
+    ])
+    def test_normalize_agent_url_custom_url_untouched(self, config_manager, non_mainland, custom):
+        """host 非 lanlan 域时原样返回，不受线路影响，也不做字符串级 replace。"""
         config_manager._check_non_mainland = lambda: non_mainland
-        custom = 'https://api.openai.com/v1'
         assert config_manager._normalize_agent_url(custom) == custom
+
+    @pytest.mark.unit
+    def test_normalize_agent_url_preserves_port(self, config_manager):
+        """改写 host 时保留端口。"""
+        config_manager._check_non_mainland = lambda: False
+        assert config_manager._normalize_agent_url(
+            'https://www.lanlan.tech:8443/text/v1'
+        ) == 'https://lanlan.app:8443/text/v1'
 
     @pytest.mark.unit
     def test_normalize_agent_url_non_string_passthrough(self, config_manager):

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -626,6 +626,45 @@ class TestGetModelApiConfig:
 
 
 # ---------------------------------------------------------------------------
+# 7b. Agent URL region routing: 国内 lanlan.app / 国际 www.lanlan.app
+# ---------------------------------------------------------------------------
+class TestAgentUrlRegionRouting:
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ('non_mainland', 'url_in', 'expected'),
+        [
+            # 国际：保留 www 前缀
+            (True, 'https://www.lanlan.tech/text/v1', 'https://www.lanlan.app/text/v1'),
+            # 国内：剥掉 www
+            (False, 'https://www.lanlan.tech/text/v1', 'https://lanlan.app/text/v1'),
+            # GeoIP 不确定（按国内处理）：同样剥 www
+            (None, 'https://www.lanlan.tech/text/v1', 'https://lanlan.app/text/v1'),
+            # 已经是 www.lanlan.app 的国内输入：仍剥 www（幂等）
+            (False, 'https://www.lanlan.app/text/v1', 'https://lanlan.app/text/v1'),
+            # 国际下 www.lanlan.app 保持不变
+            (True, 'https://www.lanlan.app/text/v1', 'https://www.lanlan.app/text/v1'),
+        ],
+    )
+    def test_normalize_agent_url_by_region(self, config_manager, non_mainland, url_in, expected):
+        config_manager._check_non_mainland = lambda: non_mainland
+        assert config_manager._normalize_agent_url(url_in) == expected
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('non_mainland', [True, False, None])
+    def test_normalize_agent_url_custom_url_untouched(self, config_manager, non_mainland):
+        """不含 lanlan 域的自定义 URL 原样返回，不受线路影响。"""
+        config_manager._check_non_mainland = lambda: non_mainland
+        custom = 'https://api.openai.com/v1'
+        assert config_manager._normalize_agent_url(custom) == custom
+
+    @pytest.mark.unit
+    def test_normalize_agent_url_non_string_passthrough(self, config_manager):
+        config_manager._check_non_mainland = lambda: True
+        assert config_manager._normalize_agent_url(None) is None
+
+
+# ---------------------------------------------------------------------------
 # 8. MiniMax / Qwen voice clone key resolution
 # ---------------------------------------------------------------------------
 class TestVoiceCloneKeyResolution:

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -678,6 +678,14 @@ class TestAgentUrlRegionRouting:
         ) == 'https://lanlan.app:8443/text/v1'
 
     @pytest.mark.unit
+    def test_normalize_agent_url_preserves_explicit_zero_port(self, config_manager):
+        """显式 :0 合法但 falsy，须保留（is not None），不被默认端口吞掉。"""
+        config_manager._check_non_mainland = lambda: False
+        assert config_manager._normalize_agent_url(
+            'https://www.lanlan.tech:0/text/v1'
+        ) == 'https://lanlan.app:0/text/v1'
+
+    @pytest.mark.unit
     @pytest.mark.parametrize('bad_url', [
         'https://www.lanlan.tech:abc/text/v1',   # 端口非数字
         'https://www.lanlan.tech:99999/text/v1',  # 端口越界

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -696,6 +696,22 @@ class TestAgentUrlRegionRouting:
         ) == 'https://www.lanlan.tech:secret@www.lanlan.app:8443/text/v1'
 
     @pytest.mark.unit
+    @pytest.mark.parametrize('url_in,expected', [
+        # 空用户名 + token 密码（bearer 式代理）：保留 :token@
+        ('https://:token@www.lanlan.tech/text/v1',
+         'https://:token@www.lanlan.app/text/v1'),
+        # 用户名 + 空密码：保留 user:@
+        ('https://user:@www.lanlan.tech/text/v1',
+         'https://user:@www.lanlan.app/text/v1'),
+    ])
+    def test_normalize_agent_url_preserves_empty_userinfo_components(
+        self, config_manager, url_in, expected
+    ):
+        """空但存在的 userinfo 分量（is not None）须保留，不被截断式 if 丢掉。"""
+        config_manager._check_non_mainland = lambda: True
+        assert config_manager._normalize_agent_url(url_in) == expected
+
+    @pytest.mark.unit
     def test_normalize_agent_url_non_string_passthrough(self, config_manager):
         config_manager._check_non_mainland = lambda: True
         assert config_manager._normalize_agent_url(None) is None

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -678,6 +678,14 @@ class TestAgentUrlRegionRouting:
         ) == 'https://lanlan.app:8443/text/v1'
 
     @pytest.mark.unit
+    def test_normalize_agent_url_preserves_userinfo(self, config_manager):
+        """netloc 含 user:pass@ 时只改 host，不动凭证（即便凭证里含 host 同名串）。"""
+        config_manager._check_non_mainland = lambda: True
+        assert config_manager._normalize_agent_url(
+            'https://www.lanlan.tech:secret@www.lanlan.tech:8443/text/v1'
+        ) == 'https://www.lanlan.tech:secret@www.lanlan.app:8443/text/v1'
+
+    @pytest.mark.unit
     def test_normalize_agent_url_non_string_passthrough(self, config_manager):
         config_manager._check_non_mainland = lambda: True
         assert config_manager._normalize_agent_url(None) is None

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -644,6 +644,10 @@ class TestAgentUrlRegionRouting:
             (False, 'https://www.lanlan.app/text/v1', 'https://lanlan.app/text/v1'),
             # 国际下 www.lanlan.app 保持不变
             (True, 'https://www.lanlan.app/text/v1', 'https://www.lanlan.app/text/v1'),
+            # bare host 输入（无 www，仅可能来自自定义 URL）：尊重原样，不补 www，
+            # 两区都落到 bare lanlan.app（仅做 tech→app）
+            (True, 'https://lanlan.tech/text/v1', 'https://lanlan.app/text/v1'),
+            (False, 'https://lanlan.tech/text/v1', 'https://lanlan.app/text/v1'),
         ],
     )
     def test_normalize_agent_url_by_region(self, config_manager, non_mainland, url_in, expected):

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -678,6 +678,16 @@ class TestAgentUrlRegionRouting:
         ) == 'https://lanlan.app:8443/text/v1'
 
     @pytest.mark.unit
+    @pytest.mark.parametrize('bad_url', [
+        'https://www.lanlan.tech:abc/text/v1',   # 端口非数字
+        'https://www.lanlan.tech:99999/text/v1',  # 端口越界
+    ])
+    def test_normalize_agent_url_invalid_port_passthrough(self, config_manager, bad_url):
+        """端口非法（.port 抛 ValueError）时原样返回，不拖垮 config 加载。"""
+        config_manager._check_non_mainland = lambda: False
+        assert config_manager._normalize_agent_url(bad_url) == bad_url
+
+    @pytest.mark.unit
     def test_normalize_agent_url_preserves_userinfo(self, config_manager):
         """netloc 含 user:pass@ 时只改 host，不动凭证（即便凭证里含 host 同名串）。"""
         config_manager._check_non_mainland = lambda: True

--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -656,68 +656,11 @@ class TestAgentUrlRegionRouting:
 
     @pytest.mark.unit
     @pytest.mark.parametrize('non_mainland', [True, False, None])
-    @pytest.mark.parametrize('custom', [
-        'https://api.openai.com/v1',
-        # 自定义代理把 lanlan 域写进 path/query：只按 host 判定，不得被改写
-        'https://myproxy.example.com/v1?upstream=www.lanlan.app',
-        'https://myproxy.example.com/lanlan.tech/v1',
-        # host 仅以 lanlan.app 结尾但并非该域，不应命中
-        'https://evil-lanlan.app/v1',
-    ])
-    def test_normalize_agent_url_custom_url_untouched(self, config_manager, non_mainland, custom):
-        """host 非 lanlan 域时原样返回，不受线路影响，也不做字符串级 replace。"""
+    def test_normalize_agent_url_custom_url_untouched(self, config_manager, non_mainland):
+        """不含 lanlan 域的自定义 URL 原样返回，不受线路影响。"""
         config_manager._check_non_mainland = lambda: non_mainland
+        custom = 'https://api.openai.com/v1'
         assert config_manager._normalize_agent_url(custom) == custom
-
-    @pytest.mark.unit
-    def test_normalize_agent_url_preserves_port(self, config_manager):
-        """改写 host 时保留端口。"""
-        config_manager._check_non_mainland = lambda: False
-        assert config_manager._normalize_agent_url(
-            'https://www.lanlan.tech:8443/text/v1'
-        ) == 'https://lanlan.app:8443/text/v1'
-
-    @pytest.mark.unit
-    def test_normalize_agent_url_preserves_explicit_zero_port(self, config_manager):
-        """显式 :0 合法但 falsy，须保留（is not None），不被默认端口吞掉。"""
-        config_manager._check_non_mainland = lambda: False
-        assert config_manager._normalize_agent_url(
-            'https://www.lanlan.tech:0/text/v1'
-        ) == 'https://lanlan.app:0/text/v1'
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize('bad_url', [
-        'https://www.lanlan.tech:abc/text/v1',   # 端口非数字
-        'https://www.lanlan.tech:99999/text/v1',  # 端口越界
-    ])
-    def test_normalize_agent_url_invalid_port_passthrough(self, config_manager, bad_url):
-        """端口非法（.port 抛 ValueError）时原样返回，不拖垮 config 加载。"""
-        config_manager._check_non_mainland = lambda: False
-        assert config_manager._normalize_agent_url(bad_url) == bad_url
-
-    @pytest.mark.unit
-    def test_normalize_agent_url_preserves_userinfo(self, config_manager):
-        """netloc 含 user:pass@ 时只改 host，不动凭证（即便凭证里含 host 同名串）。"""
-        config_manager._check_non_mainland = lambda: True
-        assert config_manager._normalize_agent_url(
-            'https://www.lanlan.tech:secret@www.lanlan.tech:8443/text/v1'
-        ) == 'https://www.lanlan.tech:secret@www.lanlan.app:8443/text/v1'
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize('url_in,expected', [
-        # 空用户名 + token 密码（bearer 式代理）：保留 :token@
-        ('https://:token@www.lanlan.tech/text/v1',
-         'https://:token@www.lanlan.app/text/v1'),
-        # 用户名 + 空密码：保留 user:@
-        ('https://user:@www.lanlan.tech/text/v1',
-         'https://user:@www.lanlan.app/text/v1'),
-    ])
-    def test_normalize_agent_url_preserves_empty_userinfo_components(
-        self, config_manager, url_in, expected
-    ):
-        """空但存在的 userinfo 分量（is not None）须保留，不被截断式 if 丢掉。"""
-        config_manager._check_non_mainland = lambda: True
-        assert config_manager._normalize_agent_url(url_in) == expected
 
     @pytest.mark.unit
     def test_normalize_agent_url_non_string_passthrough(self, config_manager):

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2971,6 +2971,26 @@ class ConfigManager:
 
         return url
 
+    def _normalize_agent_url(self, url: str) -> str:
+        """Agent 模型始终走 lanlan.app（国际 API），不分线路。
+
+        - 统一把 lanlan.tech 域改写为 lanlan.app。
+        - 国际线路保留 www 前缀（www.lanlan.app）；国内线路剥掉 www
+          （lanlan.app），按各自就近节点路由。
+        - 不含 lanlan 域的自定义 URL 原样返回。
+        - GeoIP 不确定时按国内处理（剥 www），与 _adjust_free_api_url
+          “未确认非大陆即视为大陆”的口径保持一致。
+        """
+        if not isinstance(url, str):
+            return url
+        url = url.replace('lanlan.tech', 'lanlan.app')
+        try:
+            if not self._check_non_mainland():
+                url = url.replace('www.lanlan.app', 'lanlan.app')
+        except Exception:
+            pass
+        return url
+
     @staticmethod
     def _derive_livestream_url(original_url: str, prefix: str) -> str:
         """从 livestream server_prefix 派生 lanlan.tech URL 的等价地址。
@@ -3280,7 +3300,7 @@ class ConfigManager:
         # agent api 默认跟随辅助 API 的 agent_model，缺失时回退到 VISION_MODEL
         config['AGENT_MODEL'] = config.get('AGENT_MODEL') or config.get('VISION_MODEL', '')
         config['AGENT_MODEL_URL'] = config.get('AGENT_MODEL_URL') or config.get('VISION_MODEL_URL', '') or config.get('OPENROUTER_URL', '')
-        config['AGENT_MODEL_URL'] = config['AGENT_MODEL_URL'].replace('lanlan.tech', 'lanlan.app') # TODO: 先放这里
+        config['AGENT_MODEL_URL'] = self._normalize_agent_url(config['AGENT_MODEL_URL'])
 
         key_field = assist_api_key_fields.get(assist_api_value)
         derived_key = ''
@@ -3463,7 +3483,7 @@ class ConfigManager:
 
         # Agent model always uses international API regardless of region
         if isinstance(config.get('AGENT_MODEL_URL'), str):
-            config['AGENT_MODEL_URL'] = config['AGENT_MODEL_URL'].replace('lanlan.tech', 'lanlan.app')
+            config['AGENT_MODEL_URL'] = self._normalize_agent_url(config['AGENT_MODEL_URL'])
 
         return config
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3015,7 +3015,12 @@ class ConfigManager:
             if parsed.password:
                 userinfo += f':{parsed.password}'
             userinfo += '@'
-        port = f':{parsed.port}' if parsed.port else ''
+        try:
+            port = f':{parsed.port}' if parsed.port else ''
+        except ValueError:
+            # 端口非法（如 :abc / 越界）。urlparse 不校验，.port 才抛 ValueError；
+            # 不让一个 typo 端口拖垮整个 config 加载，原样返回交给下游处理。
+            return url
         return urlunparse(parsed._replace(netloc=f'{userinfo}{new_host}{port}'))
 
     @staticmethod

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2986,6 +2986,8 @@ class ConfigManager:
             if not self._check_non_mainland():
                 url = url.replace('www.lanlan.app', 'lanlan.app')
         except Exception:
+            # 仅 _check_non_mainland 可能抛（GeoIP 探测）。探测失败时不剥 www，
+            # 保留国际形态作安全默认；线路探测不该阻断 URL 推导。
             pass
         return url
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3007,10 +3007,16 @@ class ConfigManager:
         if not non_mainland and new_host.startswith('www.'):
             new_host = new_host[len('www.'):]
 
-        # 仅替换 netloc 里的 host，保留可能存在的端口/用户信息
-        netloc = parsed.netloc.replace(parsed.hostname, new_host, 1) \
-            if parsed.hostname else new_host
-        return urlunparse(parsed._replace(netloc=netloc))
+        # 按组件重建 netloc，只换 host；保留 userinfo/port，避免 host 字串
+        # 恰好出现在 user:pass@ 段里被误改（如 user=www.lanlan.tech 的情形）。
+        userinfo = ''
+        if parsed.username:
+            userinfo = parsed.username
+            if parsed.password:
+                userinfo += f':{parsed.password}'
+            userinfo += '@'
+        port = f':{parsed.port}' if parsed.port else ''
+        return urlunparse(parsed._replace(netloc=f'{userinfo}{new_host}{port}'))
 
     @staticmethod
     def _derive_livestream_url(original_url: str, prefix: str) -> str:

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2971,61 +2971,23 @@ class ConfigManager:
 
         return url
 
-    # 只对这些 lanlan host 做改写，其余域（含自定义代理）一律原样透传
-    _AGENT_LANLAN_HOSTS = frozenset({
-        'lanlan.tech', 'www.lanlan.tech', 'lanlan.app', 'www.lanlan.app',
-    })
-
     def _normalize_agent_url(self, url: str) -> str:
-        """Agent 模型始终走 lanlan.app（国际 API），不分线路。
+        """Agent 模型始终走 lanlan.app（国际 API），统一 lanlan.tech → lanlan.app；
+        国际保留 www（www.lanlan.app），国内剥掉 www（lanlan.app）走就近节点。
 
-        - 仅当 URL 的 host 恰为 lanlan.tech / www.lanlan.tech / lanlan.app /
-          www.lanlan.app 时改写；其余域（含 path/query 里碰巧出现 lanlan
-          字样的自定义代理 URL）一律原样透传，不做字符串级 replace。
-        - 统一把 host 里的 lanlan.tech 改写为 lanlan.app。
-        - 国际线路保留 www 前缀（www.lanlan.app）；国内线路剥掉 www
-          （lanlan.app），按各自就近节点路由。
-        - bare host 输入不补 www，尊重用户写的 host。
-        - GeoIP 探测异常时按国际处理（保留 www）作为安全默认，等价于本次
-          改动前行为；线路探测不该阻断 URL 推导。
+        lanlan.tech / lanlan.app 是项目自有域名，AGENT_MODEL_URL 要么是写死的
+        free 默认（https://www.lanlan.tech/text/v1），要么是用户自填的其它服务
+        URL（不含这两个域，replace 自然 no-op），所以直接字符串替换即可。
         """
-        if not isinstance(url, str) or not url:
+        if not isinstance(url, str):
             return url
+        url = url.replace('lanlan.tech', 'lanlan.app')
         try:
-            parsed = urlparse(url)
+            if not self._check_non_mainland():
+                url = url.replace('www.lanlan.app', 'lanlan.app')
         except Exception:
-            return url
-        host = (parsed.hostname or '').lower()
-        if host not in self._AGENT_LANLAN_HOSTS:
-            return url
-
-        new_host = host.replace('lanlan.tech', 'lanlan.app')
-        try:
-            non_mainland = self._check_non_mainland()
-        except Exception:
-            non_mainland = True  # 探测失败 → 国际安全默认
-        if not non_mainland and new_host.startswith('www.'):
-            new_host = new_host[len('www.'):]
-
-        # 按组件重建 netloc，只换 host；保留 userinfo/port，避免 host 字串
-        # 恰好出现在 user:pass@ 段里被误改（如 user=www.lanlan.tech 的情形）。
-        # 用 is not None 区分「分量为空但存在」与「分量不存在」：urlparse 对
-        # https://:token@host 给出 username='' / password='token'，截断式 if 会
-        # 丢掉整个 :token@，改坏认证语义；只有 username 为 None 才是真没有 userinfo。
-        userinfo = ''
-        if parsed.username is not None:
-            userinfo = parsed.username
-            if parsed.password is not None:
-                userinfo += f':{parsed.password}'
-            userinfo += '@'
-        try:
-            # is not None：端口 0 合法但 falsy，截断式 if 会把显式 :0 丢掉。
-            port = f':{parsed.port}' if parsed.port is not None else ''
-        except ValueError:
-            # 端口非法（如 :abc / 越界）。urlparse 不校验，.port 才抛 ValueError；
-            # 不让一个 typo 端口拖垮整个 config 加载，原样返回交给下游处理。
-            return url
-        return urlunparse(parsed._replace(netloc=f'{userinfo}{new_host}{port}'))
+            pass
+        return url
 
     @staticmethod
     def _derive_livestream_url(original_url: str, prefix: str) -> str:

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2988,6 +2988,8 @@ class ConfigManager:
             if not self._check_non_mainland():
                 url = url.replace('www.lanlan.app', 'lanlan.app')
         except Exception:
+            # GeoIP 探测异常时不剥 www，保留国际形态（www.lanlan.app）作为安全
+            # 默认，等价于本次改动前的行为；线路探测不该阻断 URL 推导。
             pass
         return url
 

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3019,7 +3019,8 @@ class ConfigManager:
                 userinfo += f':{parsed.password}'
             userinfo += '@'
         try:
-            port = f':{parsed.port}' if parsed.port else ''
+            # is not None：端口 0 合法但 falsy，截断式 if 会把显式 :0 丢掉。
+            port = f':{parsed.port}' if parsed.port is not None else ''
         except ValueError:
             # 端口非法（如 :abc / 越界）。urlparse 不校验，.port 才抛 ValueError；
             # 不让一个 typo 端口拖垮整个 config 加载，原样返回交给下游处理。

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -3009,10 +3009,13 @@ class ConfigManager:
 
         # 按组件重建 netloc，只换 host；保留 userinfo/port，避免 host 字串
         # 恰好出现在 user:pass@ 段里被误改（如 user=www.lanlan.tech 的情形）。
+        # 用 is not None 区分「分量为空但存在」与「分量不存在」：urlparse 对
+        # https://:token@host 给出 username='' / password='token'，截断式 if 会
+        # 丢掉整个 :token@，改坏认证语义；只有 username 为 None 才是真没有 userinfo。
         userinfo = ''
-        if parsed.username:
+        if parsed.username is not None:
             userinfo = parsed.username
-            if parsed.password:
+            if parsed.password is not None:
                 userinfo += f':{parsed.password}'
             userinfo += '@'
         try:

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -2971,27 +2971,46 @@ class ConfigManager:
 
         return url
 
+    # 只对这些 lanlan host 做改写，其余域（含自定义代理）一律原样透传
+    _AGENT_LANLAN_HOSTS = frozenset({
+        'lanlan.tech', 'www.lanlan.tech', 'lanlan.app', 'www.lanlan.app',
+    })
+
     def _normalize_agent_url(self, url: str) -> str:
         """Agent 模型始终走 lanlan.app（国际 API），不分线路。
 
-        - 统一把 lanlan.tech 域改写为 lanlan.app。
+        - 仅当 URL 的 host 恰为 lanlan.tech / www.lanlan.tech / lanlan.app /
+          www.lanlan.app 时改写；其余域（含 path/query 里碰巧出现 lanlan
+          字样的自定义代理 URL）一律原样透传，不做字符串级 replace。
+        - 统一把 host 里的 lanlan.tech 改写为 lanlan.app。
         - 国际线路保留 www 前缀（www.lanlan.app）；国内线路剥掉 www
           （lanlan.app），按各自就近节点路由。
-        - 不含 lanlan 域的自定义 URL 原样返回。
-        - GeoIP 不确定时按国内处理（剥 www），与 _adjust_free_api_url
-          “未确认非大陆即视为大陆”的口径保持一致。
+        - bare host 输入不补 www，尊重用户写的 host。
+        - GeoIP 探测异常时按国际处理（保留 www）作为安全默认，等价于本次
+          改动前行为；线路探测不该阻断 URL 推导。
         """
-        if not isinstance(url, str):
+        if not isinstance(url, str) or not url:
             return url
-        url = url.replace('lanlan.tech', 'lanlan.app')
         try:
-            if not self._check_non_mainland():
-                url = url.replace('www.lanlan.app', 'lanlan.app')
+            parsed = urlparse(url)
         except Exception:
-            # GeoIP 探测异常时不剥 www，保留国际形态（www.lanlan.app）作为安全
-            # 默认，等价于本次改动前的行为；线路探测不该阻断 URL 推导。
-            pass
-        return url
+            return url
+        host = (parsed.hostname or '').lower()
+        if host not in self._AGENT_LANLAN_HOSTS:
+            return url
+
+        new_host = host.replace('lanlan.tech', 'lanlan.app')
+        try:
+            non_mainland = self._check_non_mainland()
+        except Exception:
+            non_mainland = True  # 探测失败 → 国际安全默认
+        if not non_mainland and new_host.startswith('www.'):
+            new_host = new_host[len('www.'):]
+
+        # 仅替换 netloc 里的 host，保留可能存在的端口/用户信息
+        netloc = parsed.netloc.replace(parsed.hostname, new_host, 1) \
+            if parsed.hostname else new_host
+        return urlunparse(parsed._replace(netloc=netloc))
 
     @staticmethod
     def _derive_livestream_url(original_url: str, prefix: str) -> str:


### PR DESCRIPTION
## 背景

Agent 模型 URL 原本**无条件**把 `lanlan.tech` 改写为 `lanlan.app`（`config_manager.py` 两处 replace），默认 free 的 `https://www.lanlan.tech/text/v1` 对**所有线路**都落到 `https://www.lanlan.app/text/v1`，不分国内外。

## 改动

抽出 `_normalize_agent_url(url)`，让 agent URL 推导 region-aware：

- 统一把 `lanlan.tech` → `lanlan.app`
- **国际线路**保留 `www` 前缀 → `www.lanlan.app`（维持现状）
- **国内线路**剥掉 `www` → `lanlan.app`，走就近节点
- GeoIP 不确定时按国内处理（剥 www），与 `_adjust_free_api_url`「未确认非大陆即视为大陆」口径一致
- 不含 lanlan 域的自定义 URL 原样返回

原先的两处 inline replace（`get_core_config` 流程 + 角色 config builder）改为调用同一 helper，避免逻辑漂移。下游 agent 代理端点直接吃 `get_model_api_config('agent')` 的 base_url，不按 host 字符串判定，无需改动。

## 测试

新增 `TestAgentUrlRegionRouting`：参数化覆盖国内/国际/不确定三态、`www.lanlan.app` 幂等、自定义 URL 不动、非字符串 passthrough。

\`\`\`
uv run pytest tests/unit/test_api_config_manager.py -k AgentUrlRegion -q
# 10 passed
\`\`\`

> 注：`tests/unit/test_api_config_manager.py` 里 `TestProviderExclusion` / `test_model_vision_override_marks_custom_model_capability` 这 3 个失败是**基线已有**（grok 进 core providers 的陈旧断言），与本 PR 无关。

## 待确认（非代码）

`lanlan.app`（无 www，health-check 标 "US, old" 的节点）需确认从大陆可连通且就是国内 agent 端点 —— 这是 infra 假设，代码只负责按线路把 URL 派生对。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增测试**
  * 增加针对 Agent 服务地址按地区路由与归一化的单元测试，覆盖将旧域名改写为新域名、在国内环境去除 www 的幂等性、自定义非 lanlan 域不改写以及非字符串输入的透传场景。

* **功能改进**
  * 统一将旧域名归一为新域名，并根据地域判断决定是否去除 www，同时在相关分支保证模型调用使用国际地址以提升跨区域一致性与稳健性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->