### PR TITLE
fix(screenshot): 手动截图原分辨率裁剪、入列前压720p，字节上限降到1MB

### DIFF
--- a/brain/computer_use.py
+++ b/brain/computer_use.py
@@ -1031,7 +1031,9 @@ class ComputerUseAdapter:
 
                 t0 = time.monotonic()
                 shot = pyautogui.screenshot()
-                jpg_bytes = compress_screenshot(shot)
+                # CUA 自己抓屏做 agent 控制，需要更高分辨率读清小字 UI；不随 vision 分析
+                # 一起降到 720p，显式锁定在 1080p（quality 仍走默认）。
+                jpg_bytes = compress_screenshot(shot, target_h=1080)
                 t_capture = time.monotonic() - t0
 
                 t1 = time.monotonic()

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2530,6 +2530,10 @@
                     }
                     if (acquiredStream) {
                         var mframe = await window.captureFrameFromStream(acquiredStream, 0.8, true);
+                        if (!mframe) {
+                            // 全分辨率编码失败（超大画面等）时，用同一条流退回 720p 再试
+                            mframe = await window.captureFrameFromStream(acquiredStream, 0.8, false);
+                        }
                         if (mframe) {
                             dataUrl = mframe.dataUrl;
                             width = mframe.width;
@@ -2600,6 +2604,11 @@
                         if (acquiredStream) {
                             isCachedStream = (acquiredStream === S.screenCaptureStream);
                             var frame = await window.captureFrameFromStream(acquiredStream, 0.8, true);
+                            if (!frame) {
+                                // 全分辨率编码可能在超大/虚拟显示器上失败；用同一条流退回 720p 再试，
+                                // 保住正确的窗口内容（优于后端 pyautogui 抓整屏的兜底）。
+                                frame = await window.captureFrameFromStream(acquiredStream, 0.8, false);
+                            }
                             if (frame) {
                                 dataUrl = frame.dataUrl;
                                 width = frame.width;

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -259,6 +259,11 @@
             }
         }
         // 720p 下极少触达这里；兜底返回最低质量结果，不再硬抛错以免阻塞发送。
+        // 真触达说明这张图异常难压，加条 warn 记录尺寸，方便事后发现"列表混入超 1MB"的个例。
+        console.warn(
+            '[截图] 720p 最低质量仍超出 1MB 上限（' +
+            Math.round(getDataUrlEncodedBytes(bestDataUrl) / 1024) + 'KB），仍按兜底入列'
+        );
         return bestDataUrl;
     };
 

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2736,11 +2736,18 @@
                 // holding only the compressed copy (low memory) and lets send pass it through
                 // without re-encoding.
                 var avatarPos = result.dataUrl === result.originalDataUrl ? result.avatarPos : null;
-                var compactDataUrl = result.dataUrl;
+                var compactDataUrl;
                 try {
                     compactDataUrl = await mod.compressScreenshotDataUrlTo720p(result.dataUrl);
                 } catch (compressErr) {
-                    console.warn('[\u622A\u56FE] 720p \u538B\u7F29\u5931\u8D25\uFF0C\u4F7F\u7528\u539F\u56FE\u5165\u5217:', compressErr);
+                    // Compression only throws when the image can't be decoded/encoded (the 720p
+                    // canvas is small enough that size limits never apply). Don't fall back to the
+                    // full-res original -- that would break the "list holds only compressed <=1MB"
+                    // invariant and pin a huge dataUrl in memory, and a broken image would fail at
+                    // send anyway. Abort queueing and surface an error toast instead.
+                    console.warn('[\u622A\u56FE] 720p \u538B\u7F29\u5931\u8D25\uFF0C\u53D6\u6D88\u5165\u5217:', compressErr);
+                    window.showStatusToast(window.t ? window.t('app.screenshotFailed') : '\u622A\u56FE\u5931\u8D25', 4000);
+                    return false;
                 }
 
                 mod.addScreenshotToList(compactDataUrl, avatarPos);

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -12,9 +12,16 @@
     const S = window.appState;
     const C = window.appConst;
     const U = window.appUtils;
-    const PENDING_IMAGE_MAX_ENCODED_BYTES = 10 * 1024 * 1024;
+    // 待发送图片编码后的字节上限：1MB。720p 截图通常 150~400KB，普通上传图压到
+    // 长边 1920 后也基本在此之下；超标才逐步降采样/降质。
+    const PENDING_IMAGE_MAX_ENCODED_BYTES = 1 * 1024 * 1024;
     const PENDING_IMAGE_MIN_LONG_SIDE = 320;
+    // 手动上传图首次超出字节上限时，一步到位把长边压到 ≤1920px，再走后续逐步降采样。
+    const PENDING_IMAGE_FIRST_STEP_LONG_SIDE = 1920;
     const PENDING_IMAGE_JPEG_QUALITIES = [0.92, 0.86, 0.78, 0.7, 0.62, 0.52, 0.42, 0.32];
+    // 手动截图入列前压缩用的质量阶梯：主质量 0.8（与屏幕分享、后端 vision 分析一致），
+    // 720p 下若仍超 1MB 再逐步降质兜底。
+    const SCREENSHOT_JPEG_QUALITIES = [0.8, 0.72, 0.64, 0.56, 0.48];
 
     function isHomeTutorialInteractionLocked() {
         try {
@@ -138,6 +145,7 @@
         var width = natural.width;
         var height = natural.height;
         var bestDataUrl = '';
+        var firstStepApplied = false;
 
         for (var pass = 0; pass < 6; pass += 1) {
             for (var i = 0; i < PENDING_IMAGE_JPEG_QUALITIES.length; i += 1) {
@@ -145,6 +153,18 @@
                 bestDataUrl = dataUrl;
                 if (getDataUrlEncodedBytes(dataUrl) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
                     return dataUrl;
+                }
+            }
+
+            // 首次超标：先一步到位把长边压到 ≤1920px，再继续后续的逐步降采样。
+            if (!firstStepApplied) {
+                firstStepApplied = true;
+                var curLongSide = Math.max(width, height);
+                if (curLongSide > PENDING_IMAGE_FIRST_STEP_LONG_SIDE) {
+                    var firstScale = PENDING_IMAGE_FIRST_STEP_LONG_SIDE / curLongSide;
+                    width = Math.max(1, Math.floor(width * firstScale));
+                    height = Math.max(1, Math.floor(height * firstScale));
+                    continue;
                 }
             }
 
@@ -210,6 +230,38 @@
         return compressLoadedImageToPendingDataUrl(image);
     };
 
+    // 手动截图入列前的压缩：捕获/裁剪叠层保留全分辨率（清晰），裁剪结束后调用这里统一
+    // 压成 720p / 0.8 JPEG，并保证编码字节 ≤ 1MB（与屏幕分享、后端 vision 分析口径一致）。
+    mod.compressScreenshotDataUrlTo720p = async function compressScreenshotDataUrlTo720p(dataUrl) {
+        var src = String(dataUrl || '');
+        if (!/^data:image\//i.test(src)) {
+            throw new Error('INVALID_IMAGE_DATA_URL');
+        }
+
+        var image = await loadImageFromSource(src);
+        var natural = getImageNaturalSize(image);
+        if (!natural.width || !natural.height) {
+            throw new Error('INVALID_IMAGE_SIZE');
+        }
+
+        var maxW = (C && C.MAX_SCREENSHOT_WIDTH) || 1280;
+        var maxH = (C && C.MAX_SCREENSHOT_HEIGHT) || 720;
+        var scale = Math.min(1, maxW / natural.width, maxH / natural.height);
+        var width = Math.max(1, Math.round(natural.width * scale));
+        var height = Math.max(1, Math.round(natural.height * scale));
+
+        var bestDataUrl = '';
+        for (var i = 0; i < SCREENSHOT_JPEG_QUALITIES.length; i += 1) {
+            var encoded = drawImageToJpegDataUrl(image, width, height, SCREENSHOT_JPEG_QUALITIES[i]);
+            bestDataUrl = encoded;
+            if (getDataUrlEncodedBytes(encoded) <= PENDING_IMAGE_MAX_ENCODED_BYTES) {
+                return encoded;
+            }
+        }
+        // 720p 下极少触达这里；兜底返回最低质量结果，不再硬抛错以免阻塞发送。
+        return bestDataUrl;
+    };
+
     mod.normalizePendingAttachmentItem = async function normalizePendingAttachmentItem(item) {
         if (!item || !item.querySelector) {
             throw new Error('INVALID_ATTACHMENT_ITEM');
@@ -220,6 +272,7 @@
             throw new Error('INVALID_ATTACHMENT_IMAGE');
         }
 
+        // 截图入列前已压到 720p JPEG（≤1MB），这里会原样透传；上传图按字节上限压缩。
         var normalized = await mod.normalizeImageDataUrlForPendingList(img.src);
         if (normalized && normalized !== img.src) {
             img.src = normalized;
@@ -2190,41 +2243,9 @@
             }
         });
 
-        // 工具：将 dataUrl 图片降采样到 720p 上限并重新编码为 JPEG 0.8，保持与既有流水线一致。
-        // 如果图片本身已经在 720p 以内，直接返回原 dataUrl，避免无谓的解码/再编码。
-        // 返回 { dataUrl, width, height }：width/height 始终是"返回的这张图"的实际尺寸，
-        // 避免调用方把源尺寸误当成最终尺寸写进日志/UI。
-        async function downscaleDataUrlTo720p(srcDataUrl) {
-            if (!srcDataUrl) return { dataUrl: null, width: 0, height: 0 };
-            var maxW = (window.appConst && window.appConst.MAX_SCREENSHOT_WIDTH) || 1280;
-            var maxH = (window.appConst && window.appConst.MAX_SCREENSHOT_HEIGHT) || 720;
-            return await new Promise(function (resolve) {
-                var img = new Image();
-                img.onload = function () {
-                    var w = img.naturalWidth, h = img.naturalHeight;
-                    if (!w || !h) { resolve({ dataUrl: srcDataUrl, width: 0, height: 0 }); return; }
-                    if (w <= maxW && h <= maxH) { resolve({ dataUrl: srcDataUrl, width: w, height: h }); return; }
-                    var scale = Math.min(maxW / w, maxH / h);
-                    var tw = Math.max(1, Math.round(w * scale));
-                    var th = Math.max(1, Math.round(h * scale));
-                    try {
-                        var cv = document.createElement('canvas');
-                        cv.width = tw; cv.height = th;
-                        var cx = cv.getContext('2d');
-                        cx.drawImage(img, 0, 0, tw, th);
-                        resolve({ dataUrl: cv.toDataURL('image/jpeg', 0.8), width: tw, height: th });
-                    } catch (e) {
-                        console.warn('[截图] 降采样失败，使用原图:', e);
-                        resolve({ dataUrl: srcDataUrl, width: w, height: h });
-                    }
-                };
-                img.onerror = function (e) {
-                    console.warn('[截图] 图片加载失败，使用原图:', e);
-                    resolve({ dataUrl: srcDataUrl, width: 0, height: 0 });
-                };
-                img.src = srcDataUrl;
-            });
-        }
+        // 手动截图链路在捕获/裁剪阶段一律保留原始分辨率，不再实时压缩，让裁剪在全分辨率上
+        // 进行、保住细节；720p / 0.8 JPEG 的压缩在裁剪结束、入待发送列表前统一做
+        // （captureScreenshotToPendingList → compressScreenshotDataUrlTo720p）。
 
         // ----------------------------------------------------------------
         // Hide NEKO UI, recapture screen, then restore
@@ -2359,15 +2380,14 @@
                 throw new Error(normalized.error || 'DESKTOP_REGION_CAPTURE_FAILED');
             }
 
-            var scaled = await downscaleDataUrlTo720p(normalized.dataUrl);
-            console.log('[截图] 桌面框选捕获成功:', regionMethod.name, (scaled.width || normalized.width || 0) + 'x' + (scaled.height || normalized.height || 0));
+            console.log('[截图] 桌面框选捕获成功:', regionMethod.name, (normalized.width || 0) + 'x' + (normalized.height || 0));
             return {
-                dataUrl: scaled.dataUrl,
+                dataUrl: normalized.dataUrl,
                 originalDataUrl: normalized.originalDataUrl || normalized.dataUrl,
                 avatarPos: normalized.avatarPos || null,
                 captureType: normalized.captureType || 'desktop-region',
-                width: scaled.width || normalized.width || 0,
-                height: scaled.height || normalized.height || 0
+                width: normalized.width || 0,
+                height: normalized.height || 0
             };
         }
 
@@ -2382,8 +2402,7 @@
                 try {
                     var atomic = await window.electronDesktopCapturer.captureSourceWithoutNeko(selectedSourceId);
                     if (atomic && atomic.success && atomic.dataUrl) {
-                        var atomicScaled = await downscaleDataUrlTo720p(atomic.dataUrl);
-                        if (atomicScaled && atomicScaled.dataUrl) return atomicScaled.dataUrl;
+                        return atomic.dataUrl;
                     } else if (atomic && atomic.error) {
                         console.warn('[隐藏NEKO] 主进程原子化路径失败:', atomic.error);
                         if (typeof window.maybeClearSourceOnNotFound === 'function') {
@@ -2425,8 +2444,7 @@
                     try {
                         var direct = await window.electronDesktopCapturer.captureSourceAsDataUrl(currentSourceId);
                         if (direct && direct.success && direct.dataUrl) {
-                            var scaled = await downscaleDataUrlTo720p(direct.dataUrl);
-                            if (scaled && scaled.dataUrl) return scaled.dataUrl;
+                            return direct.dataUrl;
                         } else if (typeof window.maybeClearSourceOnNotFound === 'function') {
                             window.maybeClearSourceOnNotFound(direct, 'recaptureWithoutNeko Priority 1 Source not found');
                         }
@@ -2440,7 +2458,7 @@
                         if (acqStream) {
                             var isCached = (acqStream === S.screenCaptureStream);
                             try {
-                                var frame = await window.captureFrameFromStream(acqStream, 0.8);
+                                var frame = await window.captureFrameFromStream(acqStream, 0.8, true);
                                 if (frame && frame.dataUrl) return frame.dataUrl;
                             } finally {
                                 if (!isCached && acqStream instanceof MediaStream) {
@@ -2454,7 +2472,7 @@
                         if (S.screenCaptureStream && S.screenCaptureStream.active) {
                             var tracks = S.screenCaptureStream.getVideoTracks();
                             if (tracks.length > 0 && tracks.some(function (t) { return t.readyState === 'live'; })) {
-                                var cachedFrame = await window.captureFrameFromStream(S.screenCaptureStream, 0.8);
+                                var cachedFrame = await window.captureFrameFromStream(S.screenCaptureStream, 0.8, true);
                                 if (cachedFrame && cachedFrame.dataUrl) return cachedFrame.dataUrl;
                             }
                         }
@@ -2464,8 +2482,7 @@
                 // Priority 3: backend pyautogui
                 var result = await window.fetchBackendScreenshot();
                 if (result && result.dataUrl) {
-                    var beScaled = await downscaleDataUrlTo720p(result.dataUrl);
-                    return (beScaled && beScaled.dataUrl) || null;
+                    return result.dataUrl || null;
                 }
                 return null;
             } finally {
@@ -2512,7 +2529,7 @@
                         throw mobileErr;
                     }
                     if (acquiredStream) {
-                        var mframe = await window.captureFrameFromStream(acquiredStream, 0.8);
+                        var mframe = await window.captureFrameFromStream(acquiredStream, 0.8, true);
                         if (mframe) {
                             dataUrl = mframe.dataUrl;
                             width = mframe.width;
@@ -2527,9 +2544,8 @@
                             return null;
                         }
                         if (interactiveBackendResult && interactiveBackendResult.dataUrl) {
-                            var interactiveScaled = await downscaleDataUrlTo720p(interactiveBackendResult.dataUrl);
                             return {
-                                dataUrl: (interactiveScaled && interactiveScaled.dataUrl) || interactiveBackendResult.dataUrl,
+                                dataUrl: interactiveBackendResult.dataUrl,
                                 originalDataUrl: interactiveBackendResult.dataUrl,
                                 avatarPos: null
                             };
@@ -2554,10 +2570,9 @@
                         try {
                             var direct = await window.electronDesktopCapturer.captureSourceAsDataUrl(selectedSourceId);
                             if (direct && direct.success && direct.dataUrl) {
-                                var scaled = await downscaleDataUrlTo720p(direct.dataUrl);
-                                dataUrl = scaled.dataUrl;
-                                width = scaled.width || direct.width || 0;
-                                height = scaled.height || direct.height || 0;
+                                dataUrl = direct.dataUrl;
+                                width = direct.width || 0;
+                                height = direct.height || 0;
                                 captureType = window.detectScreenshotCaptureType
                                     ? window.detectScreenshotCaptureType(null, selectedSourceId)
                                     : null;
@@ -2584,7 +2599,7 @@
 
                         if (acquiredStream) {
                             isCachedStream = (acquiredStream === S.screenCaptureStream);
-                            var frame = await window.captureFrameFromStream(acquiredStream, 0.8);
+                            var frame = await window.captureFrameFromStream(acquiredStream, 0.8, true);
                             if (frame) {
                                 dataUrl = frame.dataUrl;
                                 width = frame.width;
@@ -2604,10 +2619,9 @@
                         try {
                             var backendResult = await window.fetchBackendScreenshot();
                             if (backendResult && backendResult.dataUrl) {
-                                var beScaled = await downscaleDataUrlTo720p(backendResult.dataUrl);
-                                dataUrl = beScaled.dataUrl;
-                                width = beScaled.width || 0;
-                                height = beScaled.height || 0;
+                                dataUrl = backendResult.dataUrl;
+                                width = 0;
+                                height = 0;
                             }
                         } catch (beErr) {
                             console.warn('[截图] 后端兜底失败:', beErr);
@@ -2699,7 +2713,19 @@
                     return;
                 }
 
-                mod.addScreenshotToList(result.dataUrl, result.dataUrl === result.originalDataUrl ? result.avatarPos : null);
+                // Capture/crop overlay keeps full resolution (crisp); cropping is done here,
+                // so compress to 720p / 0.8 right before queueing. This keeps the pending list
+                // holding only the compressed copy (low memory) and lets send pass it through
+                // without re-encoding.
+                var avatarPos = result.dataUrl === result.originalDataUrl ? result.avatarPos : null;
+                var compactDataUrl = result.dataUrl;
+                try {
+                    compactDataUrl = await mod.compressScreenshotDataUrlTo720p(result.dataUrl);
+                } catch (compressErr) {
+                    console.warn('[\u622A\u56FE] 720p \u538B\u7F29\u5931\u8D25\uFF0C\u4F7F\u7528\u539F\u56FE\u5165\u5217:', compressErr);
+                }
+
+                mod.addScreenshotToList(compactDataUrl, avatarPos);
                 window.showStatusToast(window.t ? window.t('app.screenshotAdded') : '\u622A\u56FE\u5DF2\u6DFB\u52A0\uFF0C\u70B9\u51FB\u53D1\u9001\u4E00\u8D77\u53D1\u9001', 3000);
             } catch (err) {
                 console.error(window.t('console.screenshotFailed'), err);

--- a/static/app-buttons.js
+++ b/static/app-buttons.js
@@ -2459,6 +2459,11 @@
                             var isCached = (acqStream === S.screenCaptureStream);
                             try {
                                 var frame = await window.captureFrameFromStream(acqStream, 0.8, true);
+                                if (!frame) {
+                                    // 全分辨率编码可能在超大/虚拟显示器上失败；用同一条流退回 720p 再试，
+                                    // 保住正确的窗口内容（优于后端 pyautogui 抓整屏）。
+                                    frame = await window.captureFrameFromStream(acqStream, 0.8, false);
+                                }
                                 if (frame && frame.dataUrl) return frame.dataUrl;
                             } finally {
                                 if (!isCached && acqStream instanceof MediaStream) {
@@ -2473,6 +2478,10 @@
                             var tracks = S.screenCaptureStream.getVideoTracks();
                             if (tracks.length > 0 && tracks.some(function (t) { return t.readyState === 'live'; })) {
                                 var cachedFrame = await window.captureFrameFromStream(S.screenCaptureStream, 0.8, true);
+                                if (!cachedFrame) {
+                                    // 同上：全分辨率失败时用同一条流退回 720p，保住正确窗口内容
+                                    cachedFrame = await window.captureFrameFromStream(S.screenCaptureStream, 0.8, false);
+                                }
                                 if (cachedFrame && cachedFrame.dataUrl) return cachedFrame.dataUrl;
                             }
                         }

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -223,7 +223,7 @@
      * @param {boolean} detectBlack - 是否检测纯黑帧（窗口最小化等），默认false
      * @returns {{dataUrl: string, width: number, height: number}|null}
      */
-    function captureCanvasFrame(video, jpegQuality, detectBlack) {
+    function captureCanvasFrame(video, jpegQuality, detectBlack, fullResolution) {
         if (jpegQuality === undefined) jpegQuality = 0.8;
 
         // 流无效时 videoWidth/videoHeight 为 0，直接返回 null 避免生成空图
@@ -234,11 +234,13 @@
         var canvas = document.createElement('canvas');
         var ctx = canvas.getContext('2d');
 
-        // 计算缩放后的尺寸（保持宽高比，限制到720p）
+        // 计算缩放后的尺寸（保持宽高比，限制到720p）。
+        // fullResolution=true 时保留原生分辨率不缩放 —— 手动截图走这条路，让裁剪在全
+        // 分辨率上进行，720p 压缩在裁剪后入列前统一做（见 compressScreenshotDataUrlTo720p）。
         var targetWidth = video.videoWidth;
         var targetHeight = video.videoHeight;
 
-        if (targetWidth > C.MAX_SCREENSHOT_WIDTH || targetHeight > C.MAX_SCREENSHOT_HEIGHT) {
+        if (!fullResolution && (targetWidth > C.MAX_SCREENSHOT_WIDTH || targetHeight > C.MAX_SCREENSHOT_HEIGHT)) {
             var widthRatio = C.MAX_SCREENSHOT_WIDTH / targetWidth;
             var heightRatio = C.MAX_SCREENSHOT_HEIGHT / targetHeight;
             var scale = Math.min(widthRatio, heightRatio);
@@ -279,9 +281,10 @@
      * 从MediaStream提取单帧截图（创建临时video元素，用后即销毁）
      * @param {MediaStream} stream - 媒体流
      * @param {number} jpegQuality - JPEG压缩质量 (0-1)
+     * @param {boolean} [fullResolution] - true 时保留原生分辨率（手动截图用），不缩放到720p
      * @returns {Promise<{dataUrl: string, width: number, height: number}|null>}
      */
-    async function captureFrameFromStream(stream, jpegQuality) {
+    async function captureFrameFromStream(stream, jpegQuality, fullResolution) {
         if (!stream || !stream.active) return null;
         var video = document.createElement('video');
         video.srcObject = stream;
@@ -293,7 +296,7 @@
                 video.addEventListener('loadeddata', resolve, { once: true });
             });
         }
-        var frame = captureCanvasFrame(video, jpegQuality, true); // detectBlack=true
+        var frame = captureCanvasFrame(video, jpegQuality, true, fullResolution); // detectBlack=true
         video.srcObject = null;
         video.remove();
         return frame; // {dataUrl, width, height} or null

--- a/static/app-screen.js
+++ b/static/app-screen.js
@@ -221,7 +221,9 @@
      * @param {HTMLVideoElement} video - 视频源元素
      * @param {number} jpegQuality - JPEG压缩质量 (0-1)，默认0.8
      * @param {boolean} detectBlack - 是否检测纯黑帧（窗口最小化等），默认false
+     * @param {boolean} [fullResolution] - true 时保留原生分辨率不缩放（手动截图用）
      * @returns {{dataUrl: string, width: number, height: number}|null}
+     *   canvas 绘制/编码失败（如超大虚拟显示器超出 canvas 上限）时返回 null，由调用方兜底
      */
     function captureCanvasFrame(video, jpegQuality, detectBlack, fullResolution) {
         if (jpegQuality === undefined) jpegQuality = 0.8;
@@ -251,26 +253,41 @@
         canvas.width = targetWidth;
         canvas.height = targetHeight;
 
-        // 绘制视频帧到canvas（缩放绘制）并转换为JPEG
-        ctx.drawImage(video, 0, 0, targetWidth, targetHeight);
+        // 绘制 + 黑帧检测 + 编码整段做防御：fullResolution 下 canvas 尺寸不再受 720p 约束，
+        // 超大/虚拟显示器可能超出浏览器 canvas 上限，导致 drawImage/getImageData/toDataURL
+        // 抛错或返回空。这里捕获后返回 null，让调用方走兜底（同流退 720p / 后端抓屏），
+        // 而不是把可恢复的失败变成硬失败。
+        var dataUrl;
+        try {
+            ctx.drawImage(video, 0, 0, targetWidth, targetHeight);
 
-        // 黑帧检测：采样中心16x16区域，全黑则返回null（窗口最小化等场景）
-        if (detectBlack) {
-            var sw = Math.min(16, targetWidth), sh = Math.min(16, targetHeight);
-            var sx = Math.floor((targetWidth - sw) / 2);
-            var sy = Math.floor((targetHeight - sh) / 2);
-            var sample = ctx.getImageData(sx, sy, sw, sh);
-            var allBlack = true;
-            for (var i = 0; i < sample.data.length; i += 4) {
-                if (sample.data[i] > 2 || sample.data[i + 1] > 2 || sample.data[i + 2] > 2) {
-                    allBlack = false;
-                    break;
+            // 黑帧检测：采样中心16x16区域，全黑则返回null（窗口最小化等场景）
+            if (detectBlack) {
+                var sw = Math.min(16, targetWidth), sh = Math.min(16, targetHeight);
+                var sx = Math.floor((targetWidth - sw) / 2);
+                var sy = Math.floor((targetHeight - sh) / 2);
+                var sample = ctx.getImageData(sx, sy, sw, sh);
+                var allBlack = true;
+                for (var i = 0; i < sample.data.length; i += 4) {
+                    if (sample.data[i] > 2 || sample.data[i + 1] > 2 || sample.data[i + 2] > 2) {
+                        allBlack = false;
+                        break;
+                    }
                 }
+                if (allBlack) return null;
             }
-            if (allBlack) return null;
+
+            dataUrl = canvas.toDataURL('image/jpeg', jpegQuality);
+        } catch (e) {
+            console.warn('[截图] canvas 绘制/编码失败（可能分辨率超出上限），返回 null 交由调用方兜底:', e);
+            return null;
         }
 
-        var dataUrl = canvas.toDataURL('image/jpeg', jpegQuality);
+        // toDataURL 在部分实现下对超限 canvas 不抛错而返回 'data:,' 空串，这里一并视为失败
+        if (!dataUrl || dataUrl.length < 'data:image/jpeg;base64,'.length) {
+            console.warn('[截图] canvas 编码返回空结果（可能分辨率超出上限），返回 null 交由调用方兜底');
+            return null;
+        }
 
         return { dataUrl: dataUrl, width: targetWidth, height: targetHeight };
     }

--- a/utils/screenshot_utils.py
+++ b/utils/screenshot_utils.py
@@ -18,9 +18,11 @@ logger = get_module_logger(__name__)
 MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024
 MAX_BASE64_SIZE = MAX_IMAGE_SIZE_BYTES * 4 // 3 + 100
 
-# 截图压缩默认参数（供 computer_use 等模块复用）
-COMPRESS_TARGET_HEIGHT = 1080
-COMPRESS_JPEG_QUALITY = 75
+# 截图压缩默认参数：与前端手动截图 / 屏幕分享口径对齐（720p, JPEG quality 80）。
+# 前端已统一把发给后端的画面压到 720p，这里的 vision 分析、后端 pyautogui 兜底
+# 等再压也保持同一档位，避免一边 720 一边 1080 的不一致。
+COMPRESS_TARGET_HEIGHT = 720
+COMPRESS_JPEG_QUALITY = 80
 _LANCZOS = getattr(Image, 'LANCZOS', getattr(Image, 'ANTIALIAS', 1))
 
 LOCAL_MAX_PIXELS = 100_000_000


### PR DESCRIPTION
## 背景

之前手动截图一按截图键，画面会立刻被压成 720p 才进入裁剪叠层，框选时画面很糊；同时待发送图片的字节上限是 10MB——对纯靠 vision 描述的场景太大，高分辨率图直接喂模型容易 token 爆炸。

## 改动

### 1. 手动截图：原分辨率裁剪，720p 压缩挪到入列前
- 捕获 + 裁剪叠层全程保留原始分辨率（**修复按下截图键画面立刻糊成 720p**），让框选在清晰画面上进行。
- 720p / 0.8 JPEG 压缩在裁剪结束、加入待发送列表前统一做（`captureScreenshotToPendingList → compressScreenshotDataUrlTo720p`）。
- 待发送列表 / 缩略图只存压缩版，不再把几十 MB 的 4K dataURL 挂在内存里；发送时直接透传，不二次编码。
- `captureCanvasFrame` / `captureFrameFromStream` 新增 `fullResolution` 参数，**仅手动截图传 `true`**；屏幕分享、主动视觉等流式路径不受影响，仍走 720p。

### 2. 字节上限 10MB → 1MB
- 720p 截图通常 150~400KB，远低于 1MB（实测 1920×1920 典型照片 q80 仅 ~266KB）。

### 3. 手动上传图：1MB 上限 + 首超标一步到位 1920
- 满质量阶梯仍超 1MB 时，**第一步直接把长边压到 ≤1920px**，再走原有逐步降采样；不靠质量单挑，保证收敛。

### 4. vision 分析口径与前端对齐
- `COMPRESS_TARGET_HEIGHT` 1080→720、`COMPRESS_JPEG_QUALITY` 75→80，级联到 vision 分析 / `/api/screenshot` 后端兜底 / `request_fresh_screenshot` 等所有「截图喂 LLM」路径。
- **例外**：`computer_use`（CUA agent 自抓屏做电脑控制，需读清小字 UI）显式锁定 1080p，不属于前端→vision 管线，不跟着降。

## 性能说明
- 主力 Electron 主进程截图路径：解码/编码次数不变，只是把「压 720p」从裁剪前挪到裁剪后，性能基本持平。
- 流式兜底路径：多一轮编解码（全分辨率裁剪的固有代价），但属 fallback。
- 内存：待发送列表仍只存 720p，与改动前一致。

## Test plan
- [ ] Electron：按截图键 → 框选叠层画面清晰（非 720p 糊图）
- [ ] 截图发送后落到后端的图为 720p、≤1MB
- [ ] 粘贴/导入一张 4K 图 → 压到 ≤1MB（长边先到 1920）
- [ ] 屏幕分享 / 主动视觉仍为 720p，行为不变
- [ ] computer_use 截屏仍为 1080p
- [x] `node --check` 通过；`tests/unit/test_system_screenshot_router.py`、`test_capture_router.py`、`test_capture_bridge.py` 全绿（64 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 增加保留全分辨率截图链路，裁剪后统一压缩为 720p JPEG 再加入发送队列。

* **Bug Fixes / Improvements**
  * 默认截图压缩口径调整为 720p，默认 JPEG 质量提高以改善小字识别。
  * 上传图片大小上限降至 1MB，并新增先按长边缩放再迭代压缩的流程以提高成功率。
  * 抓取/绘制/编码流程增加防护与重试；压缩失败时阻止入列并提示“截图失败”。
  * 在逐步执行场景下保留更高纵向分辨率以提升小字读取效果。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->