### PR TITLE
fix(ci): GHCR 清理换用 manifest-aware action 修复每周 404 失败

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -33,7 +33,9 @@ jobs:
       # "Package not found" 且不吞，每周稳定删到一半挂掉。dataaxiom 删父 manifest
       # 会连带处理子镜像、不会对级联删除的 digest 二次删。
       - name: Delete old container versions
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        # 第三方社区 action + GHCR 删除权限/token，固定到 commit SHA 防 tag 被改写。
+        # 下方 SHA 对应 v1.2.0；升级时一并更新 SHA 和行尾版本注释。
+        uses: dataaxiom/ghcr-cleanup-action@374e2028c8fb93b7219f3771cd405fab95d3dec4 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: project-n-e-k-o

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       min_versions_to_keep:
-        description: '保留最近 N 个版本（按上传时间），其他不在 ignore-versions 里的版本会被删'
+        description: '保留最近 N 个标签版本（按创建时间），其他不在 exclude-tags 里的会被删'
         required: false
         default: '30'
 
@@ -26,26 +26,36 @@ jobs:
     if: github.repository == 'Project-N-E-K-O/N.E.K.O'
     runs-on: ubuntu-latest
     steps:
+      # 换用 manifest-aware 的 dataaxiom/ghcr-cleanup-action：
+      # 旧的 actions/delete-package-versions@v5 不懂 multi-arch manifest list ↔
+      # per-arch 子 manifest 的引用关系——删父 manifest 触发 GHCR 级联回收子 digest
+      # 后，它仍按开跑前拉到的陈旧列表去删那个已消失的 digest，API 返回 404
+      # "Package not found" 且不吞，每周稳定删到一半挂掉。dataaxiom 删父 manifest
+      # 会连带处理子镜像、不会对级联删除的 digest 二次删。
       - name: Delete old container versions
-        uses: actions/delete-package-versions@v5
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           owner: project-n-e-k-o
-          package-name: 'n.e.k.o'
-          package-type: 'container'
-          min-versions-to-keep: ${{ github.event.inputs.min_versions_to_keep || 30 }}
-          # 保护：浮动别名 + release 版本号 + standard/full 主版本族，
-          # 以及它们的 per-arch 子 manifest（`-linux-{amd64,arm64}` 后缀）。
-          # 匹配 version 的任一 tag 命中即保留整个 version。
+          packages: 'n.e.k.o'
+          # 保留最近 N 个非 exclude 的标签版本（按创建时间），其余删除。
+          keep-n-tagged: ${{ github.event.inputs.min_versions_to_keep || 30 }}
+          # 清理无引用的孤儿 untagged 镜像，以及子 manifest 全缺失的悬空 manifest list。
+          delete-untagged: true
+          delete-ghost-images: true
+          use-regex: true
+          # 保护（exclude-tags 优先级最高，被命中的 tag 完全不参与删除）：
+          # 浮动别名 + release 版本号 + standard/full 主版本族，以及它们的 per-arch
+          # 子 manifest（`-linux-{amd64,arm64}` 后缀）。
           #
-          # 关键点：multi-arch manifest list（如 `latest-standard`、`0.8.0-full`、
-          # `ci-standard`）通过 digest 引用 per-arch 子 manifest（如
-          # `0.8.0-standard-linux-amd64`）。如果只保护 manifest list 而让
-          # 子 manifest 被回收，list 会指向不存在的 digest，pull 会挂在某个架构上。
-          # 所以下面的正则结尾允许可选的 `-linux-(amd64|arm64)` 后缀。
+          # 子 manifest 在本仓库各自带独立 tag（如 `latest-standard-linux-amd64`），
+          # 虽然 dataaxiom 已是 manifest 感知，但仍显式保护后缀，确保被排除的
+          # manifest list 的子镜像绝不被回收、list 不会指向不存在的 digest。
+          # 正则与旧 action 的 ignore-versions 完全一致。
           #
           # 覆盖（含 per-arch 变体）：
           #   latest, latest-standard, latest-full
           #   v1.2.3 / 1.2.3 / 1.2.3-standard / 1.2.3-full
           #   ci-standard, ci-full
           #   pr-ci-standard, pr-ci-full（PR 触发若未来恢复时仍会浮动）
-          ignore-versions: '^(latest(-(standard|full))?|v?\d+\.\d+\.\d+(-(standard|full))?|(pr-)?ci-(standard|full))(-linux-(amd64|arm64))?$'
+          exclude-tags: '^(latest(-(standard|full))?|v?\d+\.\d+\.\d+(-(standard|full))?|(pr-)?ci-(standard|full))(-linux-(amd64|arm64))?$'

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -17,6 +17,14 @@ on:
         required: false
         default: '30'
 
+# 串行化：list-then-delete 式清理并发跑同一 package 会互相基于陈旧列表删，
+# 导致 404 / 误删——正是本 workflow 要修的那类竞态。schedule + 手动 dispatch
+# 可能重叠，加锁让多次运行排队而非并行。cancel-in-progress=false：不打断
+# 进行中的删除，让它跑完再排下一个。
+concurrency:
+  group: ghcr-cleanup
+  cancel-in-progress: false
+
 permissions:
   packages: write
   contents: read


### PR DESCRIPTION
## 问题
定时的 **Docker Image Cleanup** workflow（每周日 03:00 UTC）连续两周 schedule run 都失败（[run 5/24](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/26354199504)、5/17），每次删到 ~100 个版本后报 `delete version API failed. Package not found.` 退出非零。

## Root cause
`actions/delete-package-versions@v5` 不是 manifest-list 感知的。GHCR 上 multi-arch 镜像是 manifest list（如 `0.8.0-standard`）通过 digest 引用 per-arch 子 manifest（`...-linux-amd64/arm64`）。当 action 删掉一个 manifest list / 子 manifest 时，GHCR **级联回收**被引用的、已无 tag 的子 digest。但 action 在开跑前已把整页版本列表拉到本地——轮到去删那个被级联删掉的 digest 时，API 返回 404，action 不吞 404 直接 fail。每次稳定删到一半挂。

## 修复（方案 A：换 action）
换成 manifest 感知的 **`dataaxiom/ghcr-cleanup-action@v1`**：删父 manifest 会连带处理子镜像、不会对级联删除的 digest 二次删。
- `exclude-tags` 正则与旧 `ignore-versions` **完全一致**（浮动别名 + release + standard/full 族 + `-linux-{amd64,arm64}` per-arch 后缀），保护语义不变。
- `keep-n-tagged` 沿用原 `min_versions_to_keep`（默认 30），dispatch 输入名不变。
- `delete-untagged` + `delete-ghost-images` 清孤儿 untagged 和悬空 manifest list。

## 注意
- 首次 run 会做一次**较大的补偿性清理**（之前每周都半途而废，积压了不少旧 `ci-{hash}-*` 版本），属预期行为——浮动别名 / release / 最近 30 个标签版本受 `exclude-tags` + `keep-n-tagged` 保护。
- 与 PR #1495（embedding 模型）相互独立，不冲突。

## Test plan
- [ ] 合并后 Actions 页面手动 `workflow_dispatch` 跑一次，确认绿且无 404
- [ ] 确认 `latest` / `latest-standard` / `latest-full` / `ci-standard` / `ci-full` / 最近 release tag 及其 `-linux-amd64/arm64` 子 manifest 仍在
- [ ] 确认 `docker pull ghcr.io/project-n-e-k-o/n.e.k.o:latest` 两个架构都能拉

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了容器镜像清理工作流：替换并锁定清理动作并调整输入参数，统一重命名保留/排除规则，启用对未标记镜像与孤立镜像的自动删除，增强并行控制以序列化清理任务，强化对浮动别名、release/standard/full 版本族及其按架构后缀变体的保护，避免误删导致引用中断。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->