### PR TITLE
fix(tests): 对齐 tests/unit 12 个 pre-existing 失败到当前代码

### DIFF
--- a/tests/unit/test_api_config_manager.py
+++ b/tests/unit/test_api_config_manager.py
@@ -204,25 +204,6 @@ class TestCustomApiToggle:
         assert cfg['CONVERSATION_MODEL_API_KEY'] == 'sk-custom-conv'
 
     @pytest.mark.unit
-    def test_model_vision_override_marks_custom_model_capability(self, config_manager):
-        """Explicit modelVisionOverrides should win before model-name sniffing."""
-        _write_core_config(config_manager, {
-            'coreApiKey': 'sk-core',
-            'coreApi': 'qwen',
-            'assistApi': 'qwen',
-            'enableCustomApi': True,
-            'conversationModelUrl': 'https://custom.example.com/v1',
-            'conversationModelId': 'local-multimodal',
-            'conversationModelApiKey': 'sk-custom-conv',
-            'modelVisionOverrides': {'local-multimodal': True},
-        })
-
-        cfg = config_manager.get_model_api_config('conversation')
-
-        assert cfg['model'] == 'local-multimodal'
-        assert cfg['supports_vision'] is True
-
-    @pytest.mark.unit
     def test_on_applies_all_model_types(self, config_manager):
         """enableCustomApi=true → all 8 model types can be overridden."""
         model_types = [
@@ -374,7 +355,9 @@ class TestProviderExclusion:
         from utils.api_config_loader import get_core_api_profiles
         core_profiles = get_core_api_profiles()
 
-        expected_core = {'free', 'qwen', 'qwen_intl', 'openai', 'step', 'gemini', 'glm'}
+        # grok joined core as a realtime voice provider (Grok Voice, wss
+        # endpoint) in PR #1306 — it has a core_url, so it belongs here.
+        expected_core = {'free', 'qwen', 'qwen_intl', 'openai', 'step', 'gemini', 'glm', 'grok'}
         actual_core = set(core_profiles.keys())
 
         assert actual_core == expected_core, (
@@ -399,9 +382,12 @@ class TestProviderExclusion:
         from utils.api_config_loader import get_core_api_profiles
         core_profiles = get_core_api_profiles()
 
+        # grok has a realtime voice endpoint (Grok Voice, PR #1306) so it is
+        # intentionally also a core provider — only truly text-only providers
+        # are listed here.
         must_not_be_core = [
             'deepseek', 'doubao', 'minimax', 'minimax_intl',
-            'kimi', 'grok', 'silicon',
+            'kimi', 'silicon',
         ]
         for provider in must_not_be_core:
             assert provider not in core_profiles, (

--- a/tests/unit/test_cloudsave_lifecycle_flow.py
+++ b/tests/unit/test_cloudsave_lifecycle_flow.py
@@ -5,7 +5,7 @@ import asyncio
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, call, patch
 
 from fastapi.testclient import TestClient
 
@@ -385,13 +385,17 @@ async def test_main_server_manual_startup_performs_fallback_import_and_continues
         mock_sync_reload.assert_awaited_once_with(fake_import_result)
         mock_set_root_mode.assert_called_once()
         mock_init_steam.assert_called_once_with()
-        mock_set_steamworks.assert_called_once_with(None)
+        # set_steamworks is wired twice on startup: init_shared_state seeds the
+        # shared registry with the current (None) handle, then runtime init
+        # publishes the freshly initialized handle. Under this mock
+        # initialize_steamworks returns None, so both calls carry None.
+        assert mock_set_steamworks.call_args_list == [call(None), call(None)]
         mock_default_steam_info.assert_called_once_with()
         bridge_start.assert_awaited_once_with()
         mock_set_main_bridge.assert_called_once()
         mock_mount_workshop.assert_awaited_once_with()
         fake_tracker.start_periodic_save.assert_called_once_with()
-        fake_tracker.record_app_start.assert_called_once_with()
+        fake_tracker.record_app_start.assert_called_once_with(process="main_server")
         assert main_server._preload_task is not None
 
 

--- a/tests/unit/test_galgame_router.py
+++ b/tests/unit/test_galgame_router.py
@@ -399,7 +399,19 @@ async def test_galgame_unparseable_output_returns_fallback(monkeypatch, caplog):
     monkeypatch.setattr(galgame_router, "get_config_manager", lambda: config_manager)
     monkeypatch.setattr(galgame_router, "create_chat_llm", lambda *a, **kw: GarbageLLM())
 
-    with caplog.at_level(logging.INFO, logger=galgame_router.logger.name):
+    # galgame_router.logger is a get_module_logger child whose N.E.K.O ancestor
+    # gets configured with propagate=False once any service initializes logging
+    # (e.g. the Memory logger during a full-suite import). caplog installs its
+    # handler on root, so the INFO record never reaches it. Attach caplog's
+    # handler directly to the emitting logger and silence propagation during the
+    # call so the record is captured exactly once regardless of global state.
+    galgame_logger = galgame_router.logger
+    prev_propagate = galgame_logger.propagate
+    prev_level = galgame_logger.level
+    galgame_logger.addHandler(caplog.handler)
+    galgame_logger.propagate = False
+    galgame_logger.setLevel(logging.INFO)
+    try:
         response = await galgame_router.generate_galgame_options(
             FakeRequest(
                 {
@@ -408,6 +420,10 @@ async def test_galgame_unparseable_output_returns_fallback(monkeypatch, caplog):
                 }
             )
         )
+    finally:
+        galgame_logger.removeHandler(caplog.handler)
+        galgame_logger.propagate = prev_propagate
+        galgame_logger.setLevel(prev_level)
 
     data = _decode_response(response)
     assert data["success"] is True

--- a/tests/unit/test_game_llm_static_contracts.py
+++ b/tests/unit/test_game_llm_static_contracts.py
@@ -35,7 +35,8 @@ def test_soccer_game_prompts_follow_user_language():
     assert "Output only the spoken line" in en_prompt
     assert en_prompt != zh_prompt
     assert ja_prompt != en_prompt
-    assert es_prompt == en_prompt  # es falls back to en until its own i18n is added
+    assert es_prompt != en_prompt  # es now ships its own Spanish localization
+    assert es_prompt.startswith("Eres Lan")
 
 
 @pytest.mark.unit

--- a/tests/unit/test_gemini_realtime_voice_routing.py
+++ b/tests/unit/test_gemini_realtime_voice_routing.py
@@ -175,11 +175,11 @@ def test_step_native_preview_provider_respects_custom_voice_collision():
     colliding_mgr = _FakeCharactersRouterConfigManager(
         "free",
         "wss://lanlan.tech/realtime",
-        stored_voice_ids={"linjiameimei"},
+        stored_voice_ids={"qingchunshaonv"},
     )
 
     assert characters_router._get_active_native_preview_provider(native_mgr, "中文女") == "free"
-    assert characters_router._get_active_native_preview_provider(colliding_mgr, "linjiameimei") is None
+    assert characters_router._get_active_native_preview_provider(colliding_mgr, "qingchunshaonv") is None
     assert characters_router._get_active_native_preview_provider(colliding_mgr, "中文女") is None
 
 

--- a/tests/unit/test_reflection_related_context.py
+++ b/tests/unit/test_reflection_related_context.py
@@ -91,7 +91,7 @@ async def test_happy_path_renders_watermarked_block():
         {"id": "f1", "text": "absorbed fact text", "absorbed": True, "importance": 7},
     ])
     mock_reranker = MagicMock()
-    mock_reranker.aretrieve_candidates = AsyncMock(return_value=[
+    mock_reranker.aretrieve_per_query_topk = AsyncMock(return_value=[
         {"id": "f1", "text": "absorbed fact text", "importance": 7},
     ])
     with patch("memory.embeddings.get_embedding_service", return_value=_enabled_service()), \

--- a/tests/unit/test_stepfun_tts_voices.py
+++ b/tests/unit/test_stepfun_tts_voices.py
@@ -24,12 +24,12 @@ from utils.stepfun_tts_voices import (
 
 
 def test_stepfun_and_free_catalogs_are_registered():
-    assert STEPFUN_TTS_DEFAULT_VOICE == "linjiameimei"
+    assert STEPFUN_TTS_DEFAULT_VOICE == "qingchunshaonv"
     assert FALLBACK_STEPFUN_TTS_DEFAULT_VOICE == "linjiameimei"
-    assert STEPFUN_TTS_DEFAULT_MALE_VOICE == "cixingnansheng"
+    assert STEPFUN_TTS_DEFAULT_MALE_VOICE == "wenrounansheng"
     assert is_native_voice(STEPFUN_TTS_DEFAULT_VOICE, provider_key="step") is True
     assert is_native_voice(STEPFUN_TTS_DEFAULT_VOICE, provider_key="free") is True
-    assert is_native_voice("清纯少女", provider_key="step") is True
+    assert is_native_voice("青春少女", provider_key="step") is True
     assert is_native_voice("中文男", provider_key="free") is True
 
 
@@ -82,9 +82,9 @@ def test_stepfun_ui_catalog_exposes_provider_label():
     assert STEPFUN_TTS_DEFAULT_VOICE in catalog
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider"] == "step"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider_label"] == "StepFun"
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "邻家妹妹"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "青春少女"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["gender"] == ""
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "邻家妹妹"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "青春少女"
 
 
 def test_free_ui_catalog_uses_voice_label_without_provider_prefix():
@@ -92,17 +92,17 @@ def test_free_ui_catalog_uses_voice_label_without_provider_prefix():
     assert catalog is not None
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider"] == "free"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["provider_label"] == "免费 API"
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "邻家妹妹"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["display_name"] == "青春少女"
     assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["gender"] == ""
-    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "邻家妹妹"
-    assert catalog[STEPFUN_TTS_DEFAULT_MALE_VOICE]["prefix"] == "磁性男声"
+    assert catalog[STEPFUN_TTS_DEFAULT_VOICE]["prefix"] == "青春少女"
+    assert catalog[STEPFUN_TTS_DEFAULT_MALE_VOICE]["prefix"] == "温柔男声"
 
 
 def test_stepfun_catalog_is_loaded_from_api_providers_config():
     step_cfg = get_native_tts_voice_provider_config("step")
     free_cfg = get_native_tts_voice_provider_config("free")
 
-    assert step_cfg["voices"][STEPFUN_TTS_DEFAULT_VOICE] == "邻家妹妹"
+    assert step_cfg["voices"][STEPFUN_TTS_DEFAULT_VOICE] == "青春少女"
     assert step_cfg["default_voice"] == STEPFUN_TTS_DEFAULT_VOICE
     assert step_cfg["default_male_voice"] == STEPFUN_TTS_DEFAULT_MALE_VOICE
     assert free_cfg["voices"] == step_cfg["voices"]


### PR DESCRIPTION
## Summary

`tests/unit` 全量跑出的 12 个失败，在干净 HEAD 上同样存在（与 startup-perf 工作无关，已核实）。逐个 root-cause 后**全部判定为"代码有意演进、测试陈旧"或测试自身脆弱，没有一个是生产回归**——修改只落在测试文件，未触碰任何 startup / lazy-import 生产代码。

| 失败 | Root cause | 修法 |
|---|---|---|
| grok 不该在 core (×2) | PR #1306 让 grok 成为 realtime voice provider（含 `wss://api.x.ai/v1/realtime`） | 更新 core 期望集合 |
| `supports_vision` KeyError | PR #1373 撤销了 `modelVisionOverrides→supports_vision`（"留待单独 PR"，从未落地），前后端均无人读写该字段 | 删除孤儿测试 |
| stepfun/free voice (×4) | PR #1385 默认音色改 `qingchunshaonv`/青春少女 + `wenrounansheng`/温柔男声 | 对齐断言（保留仍为 `linjiameimei` 的 `FALLBACK_*` 常量断言） |
| native preview collision | "中文女"现解析到 `qingchunshaonv`，旧 `linjiameimei` fixture 不再撞名 | 换 stored voice id |
| soccer prompt 语言 | soccer prompt 新增 es/pt 本地化，es 不再回退 en | `es != en` + 西语内容校验 |
| reflection watermark 空 | reranker 在 PR #1401 改名 `aretrieve_per_query_topk`，旧 mock 名导致 await 到裸 MagicMock | 更新 mock 方法名 |
| set_steamworks 调 2 次 | `init_shared_state` 播种 + runtime init 发布各一次；`record_app_start` 新增 `process=`（PR #1486） | 更新两处断言（仅测试侧） |
| galgame caplog 漏捕 | `N.E.K.O` 祖先 logger 全量跑时被置 `propagate=False`，INFO record 到不了 caplog 的 root handler（单跑通过、全量挂） | caplog handler 直挂发射 logger，capture 期间抑制 propagate |

## Test plan

- [x] 12 个目标用例逐个单跑通过
- [x] 全量 `tests/unit -p no:cacheprovider`：**2825 passed, 14 skipped**，无新增失败
- [ ] CI 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 更新了自定义 API 配置测试，确保支持全部 8 种模型类型的覆盖。
  * 调整了 Grok 提供商分类识别的测试期望。
  * 更新了语音相关测试用例的期望值。
  * 改进了日志捕获与 Mock 断言的测试方法。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->