### PR TITLE
fix(plugin-server): tolerate optional built-in route import failures

### DIFF
--- a/plugin/server/http_app.py
+++ b/plugin/server/http_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import faulthandler
+import importlib
 import os
 import signal
 import threading
@@ -45,6 +46,21 @@ else:
 
 def _can_register_faulthandler_signal() -> bool:
     return hasattr(faulthandler, "register") and hasattr(signal, "SIGUSR1")
+
+
+def _include_optional_router(app: FastAPI, module_name: str, description: str) -> None:
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        logger.warning(
+            "{} unavailable, endpoints will be 404: err_type={}, err={}",
+            description,
+            type(exc).__name__,
+            str(exc),
+        )
+        return
+
+    app.include_router(module.router)
 
 
 @asynccontextmanager
@@ -168,33 +184,20 @@ def build_plugin_server_app(title: str = "N.E.K.O User Plugin Server") -> FastAP
     app.include_router(frontend_router)
     app.include_router(websocket_router)
     app.include_router(plugin_ui_router)
-    # galgame_plugin install routes 是可选模块：plugin import-time 副作用
-    # （缺 dxcam / tesseract / textractor 等可选依赖、非 Windows 运行时等）不应让
-    # 整个 plugin server 启动失败；失败时只让 install 端点返回 404。
-    try:
-        from plugin.plugins.galgame_plugin.install_routes import (
-            router as galgame_install_router,
-        )
-        app.include_router(galgame_install_router)
-    except ImportError as exc:
-        logger.warning(
-            "galgame install routes unavailable, install endpoints will be 404: "
-            "err_type={}, err={}",
-            type(exc).__name__,
-            str(exc),
-        )
-    # bilibili_danmaku 插件 i18n / 测试接口
-    try:
-        from plugin.plugins.bilibili_danmaku.i18n_routes import (
-            router as bilibili_i18n_router,
-        )
-        app.include_router(bilibili_i18n_router)
-    except ModuleNotFoundError as exc:
-        logger.warning(
-            "bilibili i18n routes unavailable: err_type={}, err={}",
-            type(exc).__name__,
-            str(exc),
-        )
+
+    # Built-in plugin routes are optional. In AppImage/Nuitka builds,
+    # ``plugin.plugins`` can be intentionally excluded, and optional plugin
+    # import-time failures must not prevent the base plugin server from starting.
+    _include_optional_router(
+        app,
+        "plugin.plugins.galgame_plugin.install_routes",
+        "galgame install routes",
+    )
+    _include_optional_router(
+        app,
+        "plugin.plugins.bilibili_danmaku.i18n_routes",
+        "bilibili i18n routes",
+    )
     app.include_router(plugin_cli_router)
     app.include_router(llm_tools_router)
     return app

--- a/plugin/server/http_app.py
+++ b/plugin/server/http_app.py
@@ -60,7 +60,12 @@ def _include_optional_router(app: FastAPI, module_name: str, description: str) -
         )
         return
 
-    app.include_router(module.router)
+    router = getattr(module, "router", None)
+    if router is None:
+        logger.warning("{} unavailable, endpoints will be 404: missing router", description)
+        return
+
+    app.include_router(router)
 
 
 @asynccontextmanager


### PR DESCRIPTION
## Summary
- prevent optional built-in plugin route import failures from aborting plugin server app creation
- treat galgame and bilibili UI routes as optional when dependencies or packaged plugin modules are unavailable

## Context
Linux AppImage/Nuitka builds exclude `plugin.plugins` from static following. If `plugin.server.http_app` imports built-in plugin route modules during startup, the embedded user plugin server can fail before core plugin APIs come up.

This is a stopgap to keep the plugin server alive and let those optional endpoints degrade to 404. The longer-term architectural fix should remove hard-coded plugin route mounts from `plugin/server/**` entirely.

## Validation
- `python -m py_compile plugin/server/http_app.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 统一并改进可选插件路由加载：缺失或加载失败的可选路由现在会记录统一警告并跳过注册（相关端点返回 404），不会阻止服务启动，提升稳定性与行为一致性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->