### PR TITLE
fix(memory): 后台 LLM 任务持续失败必须退避，杜绝挂机无脑重烧

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -2600,8 +2600,12 @@ async def _amaybe_trigger_negative_keyword_hook(
 async def _run_persona_refine_for_character(character: str) -> None:
     """单角色 persona refine pass。embedding 不可用 / cluster_hash 全
     skip / 候选不足 → 整 pass no-op。"""
-    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from config import (
+        MEMORY_LIVENESS_MAX_ATTEMPTS,
+        MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+    )
     from memory.facts import safe_int_field
+    from memory.temporal import cooldown_elapsed
     from memory.refine import (
         MemoryRefineEngine,
         REFINE_ENTITY_KEY,
@@ -2619,14 +2623,22 @@ async def _run_persona_refine_for_character(character: str) -> None:
         # entry 不再进 cluster gather。Site 4 dead-letter——同 entry 在多
         # cluster 反复 LLM 失败后被 frozen，避免持续占用 starvation-first
         # ordering 名额空跑 LLM。recovery 路径：apply_refine_actions 在
-        # stamp 成功时会清回 0；或人工编辑 persona.json。
+        # stamp 成功时会清回 0；或人工编辑 persona.json；或时间自愈——
+        # 冻结后过 MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS 放行一次 probe，让
+        # 一次性 correction 模型宕机恢复后自愈（不再永久冻死无辜 entry）。
         entries = [
             annotate_entry(e, type_='persona', entity=entity)
             for e in section
             if isinstance(e, dict)
             and not e.get('protected')
             and e.get('id')
-            and safe_int_field(e, 'refine_attempts') < MEMORY_LIVENESS_MAX_ATTEMPTS
+            and (
+                safe_int_field(e, 'refine_attempts') < MEMORY_LIVENESS_MAX_ATTEMPTS
+                or cooldown_elapsed(
+                    e.get('last_refine_attempt_at'),
+                    MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+                )
+            )
         ]
         if entries:
             candidates_by_entity[entity] = entries
@@ -2693,8 +2705,12 @@ async def _run_reflection_refine_for_character(character: str) -> None:
     """单角色 reflection refine pass。cluster 内可混入同 entity 的
     absorbed fact 作只读信息源（fact 不可被 split/discard/modify，apply
     层代码兜底）。"""
-    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from config import (
+        MEMORY_LIVENESS_MAX_ATTEMPTS,
+        MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+    )
     from memory.facts import safe_int_field
+    from memory.temporal import cooldown_elapsed
     from memory.refine import (
         MemoryRefineEngine,
         REFINE_ENTITY_KEY,
@@ -2718,14 +2734,21 @@ async def _run_reflection_refine_for_character(character: str) -> None:
         # Liveness 过滤：refine_attempts ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 的
         # reflection 不再进 cluster gather（同 persona refine）。fact 不算
         # ——fact 是 readonly 信息源，不会被 refine 改，自然不会 bump
-        # attempts。
+        # attempts。时间自愈：冻结后过 MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS
+        # 放行一次 probe，让一次性宕机恢复后自愈。
         entity_refls = [
             annotate_entry(r, type_='reflection', entity=entity)
             for r in refls
             if isinstance(r, dict)
             and r.get('entity') == entity
             and r.get('id')
-            and safe_int_field(r, 'refine_attempts') < MEMORY_LIVENESS_MAX_ATTEMPTS
+            and (
+                safe_int_field(r, 'refine_attempts') < MEMORY_LIVENESS_MAX_ATTEMPTS
+                or cooldown_elapsed(
+                    r.get('last_refine_attempt_at'),
+                    MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+                )
+            )
         ]
         entity_facts = [
             annotate_entry(f, type_='fact', entity=entity)

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3373,8 +3373,14 @@ async def _run_review_in_background(
             # 本次失败的输入 fingerprint，供 Gate 6 在输入不变时 dead-letter，避免
             # correction 模型一直超时 + 长挂机 bypass 续命导致整夜空烧（用户审计 #1）。
             from memory.recent import build_review_fingerprint
+            cur_fp = build_review_fingerprint(snapshot)
+            # 输入已变（与上次失败记下的 fingerprint 不同）→ 这是新输入的第一次
+            # 失败，预算从 0 重新计起。否则不同 history tail 的失败会跨输入累积，
+            # 把只失败过一次的新对话提前 dead-letter（Codex P2）。
+            if state.get('review_fail_fp') != cur_fp:
+                state['review_fail_attempts'] = 0
             state['review_fail_attempts'] = (state.get('review_fail_attempts', 0) or 0) + 1
-            state['review_fail_fp'] = build_review_fingerprint(snapshot)
+            state['review_fail_fp'] = cur_fp
             logger.info(
                 f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败），"
                 f"失败退避计数 → {state['review_fail_attempts']}"

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3306,6 +3306,24 @@ async def maybe_spawn_review(name: str) -> None:
         correction_tasks[name] = task
 
 
+async def _record_review_failure(lanlan_name: str, snapshot: list) -> int:
+    """记一次 review 失败到失败退避计数（Gate 6 用），返回累计次数。
+
+    输入 fingerprint 与上次失败记录不同 → 先把预算归零再 +1，让每段
+    history tail 各享独立的 N 次预算，不跨输入累积（Codex P2）。'failed'
+    返回分支和 except 异常分支共用本函数，避免两处逻辑漂移。
+    """
+    from memory.recent import build_review_fingerprint
+    state = _maint_state.setdefault(lanlan_name, {})
+    cur_fp = build_review_fingerprint(snapshot)
+    if state.get('review_fail_fp') != cur_fp:
+        state['review_fail_attempts'] = 0
+    state['review_fail_attempts'] = (state.get('review_fail_attempts', 0) or 0) + 1
+    state['review_fail_fp'] = cur_fp
+    await _asave_maint_state()
+    return state['review_fail_attempts']
+
+
 async def _run_review_in_background(
     lanlan_name: str, snapshot: list, cancel_event: asyncio.Event,
 ):
@@ -3372,24 +3390,27 @@ async def _run_review_in_background(
             # 'failed'：LLM 持续失败 / 超时 / 格式错误。bump 失败退避计数 + 记下
             # 本次失败的输入 fingerprint，供 Gate 6 在输入不变时 dead-letter，避免
             # correction 模型一直超时 + 长挂机 bypass 续命导致整夜空烧（用户审计 #1）。
-            from memory.recent import build_review_fingerprint
-            cur_fp = build_review_fingerprint(snapshot)
-            # 输入已变（与上次失败记下的 fingerprint 不同）→ 这是新输入的第一次
-            # 失败，预算从 0 重新计起。否则不同 history tail 的失败会跨输入累积，
-            # 把只失败过一次的新对话提前 dead-letter（Codex P2）。
-            if state.get('review_fail_fp') != cur_fp:
-                state['review_fail_attempts'] = 0
-            state['review_fail_attempts'] = (state.get('review_fail_attempts', 0) or 0) + 1
-            state['review_fail_fp'] = cur_fp
+            attempts = await _record_review_failure(lanlan_name, snapshot)
             logger.info(
                 f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败），"
-                f"失败退避计数 → {state['review_fail_attempts']}"
+                f"失败退避计数 → {attempts}"
             )
-            await _asave_maint_state()
     except asyncio.CancelledError:
         logger.info(f"⚠️ {lanlan_name} 的记忆整理任务被取消")
     except Exception as e:
-        logger.error(f"❌ {lanlan_name} 的记忆整理任务出错: {e}")
+        # review_history 正常会把内部异常收口成 ('failed', None)；但万一它直接
+        # 抛（try 外的初始化 / SDK 内部 / 未来重构），这里也要把失败计入退避，
+        # 否则 Gate 6 永远拿不到预算、持续重烧仍会发生（CodeRabbit Major）。
+        # 落盘失败本身不应再掀翻 finally 的清理。
+        try:
+            attempts = await _record_review_failure(lanlan_name, snapshot)
+            logger.error(
+                f"❌ {lanlan_name} 的记忆整理任务出错（失败退避计数 → {attempts}）: {e}"
+            )
+        except Exception as se:
+            logger.error(
+                f"❌ {lanlan_name} 的记忆整理任务出错: {e}（退避计数落盘失败: {se}）"
+            )
     finally:
         # 按 task/event 身份比对再清理：如果并发的新 spawn 已经写入了新 task /
         # 新 event，本 task 不应该把它们清掉。

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3374,9 +3374,20 @@ async def _run_review_in_background(
       race，但身份检查是廉价的防御。
     """
     try:
-        result = await recent_history_manager.review_history(
-            lanlan_name, snapshot, cancel_event=cancel_event,
-        )
+        # 只把 review_history 调用本身包进内层 try：它抛异常才算"review 失败"，
+        # 收口成 ('failed', None) 走下面统一的失败分支记一次退避。成功后的 result
+        # 处理 / state 落盘异常**不**能被当成 review 失败（否则 patched/white 的
+        # save 抖动会误判成失败、误触 Gate 6 dead-letter；'failed' 分支自己 save
+        # 抛异常也会被重复记一次）——那类异常交给外层 except 纯兜底、不 bump。
+        # 注：asyncio.CancelledError 是 BaseException，不被 except Exception 捕获，
+        # 会正常冒泡到外层 CancelledError 分支。
+        try:
+            result = await recent_history_manager.review_history(
+                lanlan_name, snapshot, cancel_event=cancel_event,
+            )
+        except Exception as e:
+            logger.error(f"❌ {lanlan_name} 的 review_history 抛异常，按失败处理: {e}")
+            result = ('failed', None)
         # 兼容意外的返回类型，统一解包
         if isinstance(result, tuple) and len(result) == 2:
             status, fingerprint = result
@@ -3421,19 +3432,11 @@ async def _run_review_in_background(
     except asyncio.CancelledError:
         logger.info(f"⚠️ {lanlan_name} 的记忆整理任务被取消")
     except Exception as e:
-        # review_history 正常会把内部异常收口成 ('failed', None)；但万一它直接
-        # 抛（try 外的初始化 / SDK 内部 / 未来重构），这里也要把失败计入退避，
-        # 否则 Gate 6 永远拿不到预算、持续重烧仍会发生（CodeRabbit Major）。
-        # 落盘失败本身不应再掀翻 finally 的清理。
-        try:
-            attempts = await _record_review_failure(lanlan_name, snapshot)
-            logger.error(
-                f"❌ {lanlan_name} 的记忆整理任务出错（失败退避计数 → {attempts}）: {e}"
-            )
-        except Exception as se:
-            logger.error(
-                f"❌ {lanlan_name} 的记忆整理任务出错: {e}（退避计数落盘失败: {se}）"
-            )
+        # 纯兜底：能到这里的只剩 result 处理 / state 持久化等"非 review 失败"
+        # 的异常（review_history 自身抛已在内层收口成 'failed'）。这类异常**不**
+        # 计入失败退避——否则成功 review 的 save 抖动会被误判成失败、误触
+        # Gate 6 dead-letter 压住后续 review（Codex P2）。
+        logger.error(f"❌ {lanlan_name} 的记忆整理后处理出错（不计入失败退避）: {e}")
     finally:
         # 按 task/event 身份比对再清理：如果并发的新 spawn 已经写入了新 task /
         # 新 event，本 task 不应该把它们清掉。

--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -3271,6 +3271,30 @@ async def maybe_spawn_review(name: str) -> None:
                 f"[Review/spawn] {name}: 长挂机 bypass MIN_NEW_MSGS_FOR_REVIEW "
                 f"(new_msgs={new_msg_count}, idle={idle_secs:.0f}s)"
             )
+        # Gate 6: 失败退避（dead-letter）。review 连续失败 ≥
+        # MEMORY_LIVENESS_MAX_ATTEMPTS 次且**输入未变**（当前 history 末尾 K 条
+        # fingerprint == 上次失败时记下的）→ 跳过本次 spawn，不再每轮空烧
+        # 3×110s 超时。输入一变（master 发了新消息，尾部 fingerprint 变）→ 视为
+        # 新输入，清掉失败计数放行重试。
+        # 必须放在 Gate 5 之后：长挂机 bypass 在 correction 模型持续超时时会
+        # 主动给死循环续命，本闸门要能压过它（用户审计 #1：实锤的整夜无限重烧）。
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        from memory.recent import build_review_fingerprint
+        state = _maint_state.setdefault(name, {})
+        fail_attempts = state.get('review_fail_attempts', 0) or 0
+        if fail_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+            cur_fp = build_review_fingerprint(history)
+            if state.get('review_fail_fp') == cur_fp:
+                logger.debug(
+                    f"[Review/spawn] {name}: 失败退避 dead-letter "
+                    f"(连续失败 {fail_attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS} "
+                    f"且输入未变)，跳过本轮"
+                )
+                return
+            # 输入已变 → 旧失败计数过期，复位后放行重试
+            state['review_fail_attempts'] = 0
+            state['review_fail_fp'] = None
+            await _asave_maint_state()
         # 全过 → spawn
         logger.info(f"[Review/spawn] {name}: 触发 review (history_len={len(history)})")
         cancel_event = asyncio.Event()
@@ -3324,6 +3348,9 @@ async def _run_review_in_background(
             state['review_clean'] = True
             state['last_review_ts'] = datetime.now().isoformat()
             state['last_reviewed_cutoff_tail'] = fingerprint
+            # 成功 → 清掉失败退避计数（Gate 6）
+            state['review_fail_attempts'] = 0
+            state['review_fail_fp'] = None
             await _asave_maint_state()
         elif status == 'white':
             logger.info(
@@ -3332,9 +3359,27 @@ async def _run_review_in_background(
             state['last_reviewed_cutoff_tail'] = None
             # 故意不更新 last_review_ts：让下轮 gate 4 用旧 ts（通常已过 30/60s）
             # 直接放行，配合 fingerprint=None 触发 gate 5 的 ∞ 通行 → 立即重 review。
+            # 白 review 是 cutoff 失配（输入实际已变）而非失败，清退避计数允许立即重建锚点。
+            state['review_fail_attempts'] = 0
+            state['review_fail_fp'] = None
             await _asave_maint_state()
+        elif cancel_event.is_set():
+            # review_history 在 cancel_event 置位时也返回 ('failed', None)，但这是
+            # 主动取消（cancel_correction：记忆编辑后立即生效）而非失败，不能计入
+            # 失败退避——否则用户频繁编辑记忆会被误判成 poison。
+            logger.info(f"ℹ️ {lanlan_name} 的记忆整理被取消（不计入失败退避）")
         else:
-            logger.info(f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败）")
+            # 'failed'：LLM 持续失败 / 超时 / 格式错误。bump 失败退避计数 + 记下
+            # 本次失败的输入 fingerprint，供 Gate 6 在输入不变时 dead-letter，避免
+            # correction 模型一直超时 + 长挂机 bypass 续命导致整夜空烧（用户审计 #1）。
+            from memory.recent import build_review_fingerprint
+            state['review_fail_attempts'] = (state.get('review_fail_attempts', 0) or 0) + 1
+            state['review_fail_fp'] = build_review_fingerprint(snapshot)
+            logger.info(
+                f"ℹ️ {lanlan_name} 的记忆整理未执行（被跳过或失败），"
+                f"失败退避计数 → {state['review_fail_attempts']}"
+            )
+            await _asave_maint_state()
     except asyncio.CancelledError:
         logger.info(f"⚠️ {lanlan_name} 的记忆整理任务被取消")
     except Exception as e:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1185,6 +1185,22 @@ MEMORY_LIVENESS_MAX_ATTEMPTS = 5
 - 5 跟 `MEMORY_RECHECK_MAX_ATTEMPTS` 同口径——按 40s 一轮算 3 分钟级窗口，
   跨过偶发 transient failure 够用；再多就属于真正 poison。"""
 
+MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS = 5 * 60 * 60
+"""dead-letter 的时间冷却自愈窗口（秒）。
+
+- 问题：达 `MEMORY_LIVENESS_MAX_ATTEMPTS` 被冻结的 entry（reflection synth /
+  schema recheck / refine cluster）只在"成功"或"输入变化"时才解冻。但当失败
+  其实是**一次性持续故障**（correction 模型快照下线一直超时 / cloudsave 卡
+  维护态 / FS 只读）时，故障期间会把一批无辜 entry 一路 bump 到 MAX 永久冻死，
+  故障恢复后也不会自愈（内容没变、又进不了候选）。
+- 治理：给这些 dead-letter 加时间冷却——冻结后每过本窗口放行**一次** probe。
+  probe 成功 → 计数清零彻底恢复；probe 失败 → 重新计时、再等一个窗口。这样
+  一次性故障 5h 后自愈，真正 poison 仍被压到"每 5h 一次"不空烧。
+- **不适用 memory_review**：它的恢复机制是"对话尾部 fingerprint 变化即复位"
+  （master 一发新消息就重试），不需要也不应该有时间自愈——挂机期间就该一直停。
+- 5h：refine cron 30min 一轮 → 一次 >2.5h 的模型宕机会把 entry 顶到 MAX；
+  5h 冷却确保宕机恢复后下一轮就能 probe，又远大于偶发抖动窗口。"""
+
 # ---- Memory: followup picker (memory/reflection.py) ─
 REFLECTION_FOLLOWUP_WEIGHTED = True
 """主动搭话 followup 候选采样是否按 evidence_score 加权随机。
@@ -2005,6 +2021,7 @@ __all__ = [
     'PERSONA_CORRECTION_BATCH_LIMIT',
     'PERSONA_VERSION_HISTORY_MAX',
     'MEMORY_LLM_HARD_TIMEOUT_SECONDS',
+    'MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS',
     'MEMORY_REFINE_COSINE_THRESHOLD',
     'MEMORY_REFINE_TOPK_PER_ENTRY',
     'MEMORY_REFINE_CLUSTER_SIZE_MAX',

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1410,6 +1410,12 @@ class FactStore:
             ok = await asyncio.to_thread(_apply_update)
         except Exception as e:
             logger.warning(f"[Recheck-Fact] {name} {fid}: save 失败: {e}")
+            # 落盘失败也计入 recheck_attempts：否则 cloudsave 维护态 / 只读 FS /
+            # 权限导致的持续写盘失败会让同一条 fact 每 30s 原样重判、熔断永不
+            # 触发（对齐上面 LLM 失败路径的 bump）。
+            await asyncio.to_thread(
+                self._bump_fact_recheck_attempts, name, fid, f"save failed: {e}",
+            )
             return False
         if ok:
             logger.info(

--- a/memory/facts.py
+++ b/memory/facts.py
@@ -1273,6 +1273,8 @@ class FactStore:
             for f in current:
                 if f.get('id') == fid:
                     f['recheck_attempts'] = (f.get('recheck_attempts') or 0) + 1
+                    # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed）
+                    f['last_recheck_attempt_at'] = datetime.now().isoformat()
                     self.save_facts(name)
                     logger.debug(
                         f"[Recheck-Fact] {name} {fid}: "
@@ -1292,11 +1294,15 @@ class FactStore:
 
         Returns: True 表示成功处理了一条；False 表示没找到候选或失败。
         """
-        from config import MEMORY_RECHECK_MAX_ATTEMPTS
+        from config import (
+            MEMORY_RECHECK_MAX_ATTEMPTS,
+            MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+        )
         from config.prompts.prompts_memory import MEMORY_RECHECK_FACT_PROMPT
         from memory.temporal import (
             normalize_event_when as _norm_when,
             compute_event_timestamps as _compute_ts,
+            cooldown_elapsed,
         )
 
         facts = await self.aload_facts(name)
@@ -1304,8 +1310,16 @@ class FactStore:
             f for f in facts
             if (f.get('schema_version') or 1) < MEMORY_SCHEMA_VERSION_CURRENT
             # 重试预算：LLM 持续失败的 entry 累计达上限后不再阻塞队列
-            # (Codex review on PR #1316 P2，对齐 reflection 同样写法)
-            and (f.get('recheck_attempts') or 0) < MEMORY_RECHECK_MAX_ATTEMPTS
+            # (Codex review on PR #1316 P2，对齐 reflection 同样写法)。
+            # 时间自愈：达上限的 entry 过 MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS
+            # 后放行一次 probe，让一次性写盘/网络故障恢复后自愈。
+            and (
+                (f.get('recheck_attempts') or 0) < MEMORY_RECHECK_MAX_ATTEMPTS
+                or cooldown_elapsed(
+                    f.get('last_recheck_attempt_at'),
+                    MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+                )
+            )
         ]
         if not candidates:
             return False

--- a/memory/persona.py
+++ b/memory/persona.py
@@ -2239,6 +2239,10 @@ class PersonaManager:
                         continue
                     new_attempts = safe_int_field(e, 'refine_attempts') + 1
                     e['refine_attempts'] = new_attempts
+                    # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed）：
+                    # 一次性 correction 模型宕机把 entry 顶到 MAX 后，过 5h 冷却
+                    # 重新进候选 probe，避免宕机恢复后仍永久冻结。
+                    e['last_refine_attempt_at'] = datetime.now().isoformat()
                     modified = True
                     if new_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS:
                         logger.warning(

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -141,15 +141,19 @@ class MemoryRefineEngine:
 
         Embedding 不可用 → 返回零计数，no-op。
 
-        ``failure_fn``: 可选回调，**仅在** ``_resolve_cluster`` 返 False（LLM
-        输出空 / parse 失败 / 非 list 等 LLM-decision 持续性问题）时调用，
-        传入 ``(cluster, cluster_hash)``。Exception 路径按 transient 不调
-        回调——apply_fn 持久化失败 (cloudsave / IO / 锁) + LLM 网络瞬态
-        都属于跟 cluster 内容无关的瞬时故障，不该让 entry refine_attempts
-        被冤枉计数 (Codex P1 round-3 on PR #1412)。Manager 在回调里 bump
-        ``refine_attempts`` 字段做 liveness 兜底——同 cluster 反复 LLM 失败
-        N 次后 manager 在下次候选 gather 时把成员过滤掉，避免毒 cluster
-        持续占用 starvation-first ordering 第一名空跑 LLM。
+        ``failure_fn``: 可选回调，在 ``_resolve_cluster`` 返 False（LLM 输出
+        空 / parse 失败 / 非 list）**或** 抛异常（LLM 超时 / apply_fn 持久化
+        失败等）时都调用，传入 ``(cluster, cluster_hash)``。Manager 在回调里
+        bump ``refine_attempts``，达 N 次后下次候选 gather 把成员过滤掉。
+
+        为什么异常路径也计数（修正先前 Codex P1 round-3 on PR #1412 的设计）：
+        原本把异常按"瞬态、不计数"处理，怕单次网络/IO 抖动冤枉具体 entry。
+        但当"瞬态"其实是**持续性**的——correction 模型快照下线一直超时、
+        cloudsave 卡维护态、FS 只读——这条不计数路径就变成无限重试风暴，
+        每 30min 把同一个毒 cluster 原样重打 LLM 永不放弃。N=
+        ``MEMORY_LIVENESS_MAX_ATTEMPTS`` 的预算足够跨过偶发抖动（要连续
+        失败才 dead-letter），且 cluster 内容一变 hash 就变、attempts 随
+        新成员天然复位，所以持续故障收敛、偶发抖动无损。
         """
         zero = {
             'clusters_seen': 0,
@@ -196,14 +200,11 @@ class MemoryRefineEngine:
         resolved = 0
         failed = 0
         for entity, cluster, cluster_hash in to_process:
-            # 只在 ``_resolve_cluster`` 返 False 时 bump refine_attempts
-            # （= LLM 输出空 / parse 失败 / 非 list 等持续性问题，跟 cluster
-            # 内容相关）。raise 路径不 bump（Codex P1）——抓不到的异常来源
-            # 不确定，可能是 ``apply_fn`` 的 manager 端持久化 transient
-            # （cloudsave 维护态 / atomic_write IO / 锁竞争）或 LLM 网络
-            # transient，把这类错算到 cluster 成员的 refine_attempts 上会
-            # 让磁盘 / 锁瞬态错误冤枉具体 entry，触发非必要 dead-letter。
-            llm_decision_failed = False
+            # _resolve_cluster 返 False（LLM 输出空 / parse 失败 / 非 list）
+            # 或抛异常（LLM 超时 / apply_fn 持久化失败）都 bump refine_attempts。
+            # 持续性故障必须计入预算才能 dead-letter（见函数 docstring）；偶发
+            # 抖动靠 N 次预算 + cluster 内容变即复位兜住，不会冤枉。
+            cluster_failed = False
             try:
                 ok = await self._resolve_cluster(
                     entity, cluster, cluster_hash, apply_fn,
@@ -212,14 +213,15 @@ class MemoryRefineEngine:
                     resolved += 1
                 else:
                     failed += 1
-                    llm_decision_failed = True
+                    cluster_failed = True
             except Exception as e:  # noqa: BLE001 — refine is best-effort
                 failed += 1
+                cluster_failed = True
                 logger.warning(
                     f"[Refine] {scope_label} cluster {cluster_hash} 异常"
-                    f"（按 transient 不计 refine_attempts）: {e}"
+                    f"（计入 refine_attempts）: {e}"
                 )
-            if llm_decision_failed and failure_fn is not None:
+            if cluster_failed and failure_fn is not None:
                 try:
                     await failure_fn(cluster, cluster_hash)
                 except Exception as fe:  # noqa: BLE001 — failure_fn 是兜底，自己再失败也不该挂主路径

--- a/memory/refine.py
+++ b/memory/refine.py
@@ -103,11 +103,10 @@ ApplyFn = Callable[[list[dict], list[dict], str], Awaitable[set[str]]]
 
 # Manager-supplied failure callback signature.
 # Args: cluster (annotated entries), cluster_hash.
-# Triggered ONLY when ``_resolve_cluster`` returns False (LLM 输出空 /
-# parse 失败 / 非 list 等 LLM-decision 持续性问题)。**Exception 路径不调**
-# ——`_resolve_cluster` 内部 `await apply_fn(...)` 的 manager 端持久化异常
-# （cloudsave 维护态 / atomic_write IO / 锁竞争）+ LLM 网络 transient
-# 都按 transient 处理，不触发该回调（Codex P1 round-3 on PR #1412）。
+# Triggered when ``_resolve_cluster`` returns False（LLM 输出空 / parse 失败 /
+# 非 list）**或**抛异常（LLM 超时 / apply_fn 持久化异常等）。先前只在 False
+# 时调、异常按 transient 不计（Codex P1 round-3 on PR #1412），但持续性故障
+# （模型快照下线一直超时）那样会变成每 30min 无限重打；现在异常也计入预算。
 # Manager bumps ``refine_attempts`` on each non-fact cluster member (and
 # saves persona/reflection file), so the next refine pass can filter
 # out entries that have repeatedly failed (Site 4 liveness 兜底)。

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -311,7 +311,8 @@ class ReflectionEngine:
         )
 
     async def _aload_synth_backoff(self, name: str) -> dict:
-        """读 {rid: attempts(int)} map；缺文件 / 损坏 → 空 dict。"""
+        """读 {key: {"n": attempts(int), "at": last_fail_iso|None}} map；
+        缺文件 / 损坏 → 空 dict。兼容旧格式 {key: int}（at 补 None）。"""
         path = self._synth_backoff_path(name)
         if not await asyncio.to_thread(os.path.exists, path):
             return {}
@@ -321,12 +322,19 @@ class ReflectionEngine:
             return {}
         if not isinstance(data, dict):
             return {}
-        out: dict[str, int] = {}
+        out: dict[str, dict] = {}
         for k, v in data.items():
-            try:
-                out[str(k)] = int(v)
-            except (TypeError, ValueError):
-                continue
+            if isinstance(v, dict):
+                try:
+                    out[str(k)] = {"n": int(v.get("n", 0)), "at": v.get("at")}
+                except (TypeError, ValueError):
+                    continue
+            else:
+                # 旧格式 {key: int}
+                try:
+                    out[str(k)] = {"n": int(v), "at": None}
+                except (TypeError, ValueError):
+                    continue
         return out
 
     async def _asave_synth_backoff(self, name: str, backoff: dict) -> None:
@@ -340,30 +348,34 @@ class ReflectionEngine:
         except Exception as e:
             logger.debug(f"[Reflection] {name}: synth_backoff 写盘失败: {e}")
 
-    async def _abump_synth_backoff(self, name: str, rid: str, reason: str) -> int:
-        """记 rid 一次合成失败，返回累计次数。caller 不持锁（失败分支都在
-        post-LLM 锁之外），这里自取 _get_alock 做 read-modify-write。"""
+    async def _abump_synth_backoff(self, name: str, key: str, reason: str) -> int:
+        """记 key 一次合成失败，返回累计次数并戳上失败时刻（供时间自愈）。
+        caller 不持锁（失败分支都在 post-LLM 锁之外），这里自取 _get_alock
+        做 read-modify-write。"""
         async with self._get_alock(name):
             backoff = await self._aload_synth_backoff(name)
-            attempts = backoff.get(rid, 0) + 1
-            backoff[rid] = attempts
-            # 防失败 rid 长期累积：超阈值时只留 attempts 最高的若干条
-            # （dead-letter 候选优先保活，被丢的低分 rid 下次失败重新计起）。
+            attempts = backoff.get(key, {}).get("n", 0) + 1
+            entry = {"n": attempts, "at": datetime.now().isoformat()}
+            backoff[key] = entry
+            # 防失败 key 长期累积：超阈值时只留 attempts 最高的若干条
+            # （dead-letter 候选优先保活，被丢的低分 key 下次失败重新计起）。
             if len(backoff) > 64:
-                backoff = dict(sorted(backoff.items(), key=lambda kv: -kv[1])[:64])
-                backoff[rid] = attempts
+                backoff = dict(
+                    sorted(backoff.items(), key=lambda kv: -kv[1].get("n", 0))[:64]
+                )
+                backoff[key] = entry  # 确保当前 key 不被裁掉
             await self._asave_synth_backoff(name, backoff)
         logger.debug(
-            f"[Reflection] {name}: rid {rid} 合成失败退避 → {attempts} ({reason})"
+            f"[Reflection] {name}: key {key} 合成失败退避 → {attempts} ({reason})"
         )
         return attempts
 
-    async def _aclear_synth_backoff(self, name: str, rid: str) -> None:
-        """rid 成功落盘后清掉其失败记录。caller 不持锁。"""
+    async def _aclear_synth_backoff(self, name: str, key: str) -> None:
+        """key 成功落盘后清掉其失败记录。caller 不持锁。"""
         async with self._get_alock(name):
             backoff = await self._aload_synth_backoff(name)
-            if rid in backoff:
-                del backoff[rid]
+            if key in backoff:
+                del backoff[key]
                 await self._asave_synth_backoff(name, backoff)
 
     # ── persistence ──────────────────────────────────────────────────
@@ -780,12 +792,22 @@ class ReflectionEngine:
         # 失败退避（dead-letter）：同一批 unabsorbed facts(backoff_key) 合成已连续
         # 失败 ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 次 → 不再每 180s 原样重抽空跑 LLM。
         # 任一 unabsorbed fact 增减 → backoff_key 变、计数天然复位（用户审计 #2）。
-        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
-        synth_attempts = (await self._aload_synth_backoff(lanlan_name)).get(backoff_key, 0)
-        if synth_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+        # 时间自愈：池子不变（挂机）时，每过 MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS
+        # 放行一次 probe，让一次性模型宕机恢复后自愈，poison 批仍被压到每 5h 一次。
+        from config import (
+            MEMORY_LIVENESS_MAX_ATTEMPTS,
+            MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+        )
+        from memory.temporal import cooldown_elapsed
+        synth_entry = (await self._aload_synth_backoff(lanlan_name)).get(backoff_key, {})
+        synth_attempts = synth_entry.get("n", 0)
+        if synth_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS and not cooldown_elapsed(
+            synth_entry.get("at"), MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS,
+        ):
             logger.debug(
                 f"[Reflection] {lanlan_name}: backoff_key {backoff_key} 合成连续失败 "
                 f"{synth_attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，dead-letter 跳过"
+                f"（未到 {MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS}s 自愈窗口）"
             )
             return []
 
@@ -1403,6 +1425,9 @@ class ReflectionEngine:
                     continue
                 new_attempts = safe_int_field(r, 'refine_attempts') + 1
                 r['refine_attempts'] = new_attempts
+                # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed），对偶
+                # persona 侧——一次性宕机顶到 MAX 后过 5h 冷却重新 probe。
+                r['last_refine_attempt_at'] = datetime.now().isoformat()
                 modified = True
                 if new_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS:
                     logger.warning(
@@ -2570,6 +2595,8 @@ class ReflectionEngine:
                 for r in current:
                     if r.get('id') == rid:
                         r['recheck_attempts'] = (r.get('recheck_attempts') or 0) + 1
+                        # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed）
+                        r['last_recheck_attempt_at'] = datetime.now().isoformat()
                         await self.asave_reflections(lanlan_name, current)
                         logger.debug(
                             f"[Recheck-Reflection] {lanlan_name} {rid}: "
@@ -2600,6 +2627,7 @@ class ReflectionEngine:
         from config import (
             MEMORY_SCHEMA_VERSION_CURRENT as _SCHEMA_V,
             MEMORY_RECHECK_MAX_ATTEMPTS as _MAX_ATTEMPTS,
+            MEMORY_DEAD_LETTER_SELF_HEAL_SECONDS as _SELF_HEAL,
         )
         from config.prompts.prompts_memory import (
             MEMORY_RECHECK_REFLECTION_PROMPT,
@@ -2607,6 +2635,7 @@ class ReflectionEngine:
         from memory.temporal import (
             normalize_event_when as _norm_when,
             compute_event_timestamps as _compute_ts,
+            cooldown_elapsed,
             ACTIVE_TEMPORAL_SCOPES,
         )
 
@@ -2617,8 +2646,12 @@ class ReflectionEngine:
             if (r.get('schema_version') or 1) < _SCHEMA_V
             and r.get('status') not in REFLECTION_TERMINAL_STATUSES
             # 重试预算：LLM 持续给出无效 temporal_scope 或抛异常的 entry
-            # 累计达上限后不再阻塞队列（Codex review on PR #1316 P2 catch）
-            and (r.get('recheck_attempts') or 0) < _MAX_ATTEMPTS
+            # 累计达上限后不再阻塞队列（Codex review on PR #1316 P2 catch）。
+            # 时间自愈：达上限的 entry 过 _SELF_HEAL 后放行一次 probe。
+            and (
+                (r.get('recheck_attempts') or 0) < _MAX_ATTEMPTS
+                or cooldown_elapsed(r.get('last_recheck_attempt_at'), _SELF_HEAL)
+            )
         ]
         if not candidates:
             return False

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -735,6 +735,14 @@ class ReflectionEngine:
         if len(unabsorbed) < MIN_FACTS_FOR_REFLECTION:
             return []
 
+        # 失败退避 key 必须覆盖**全部** unabsorbed facts，所以在 cap 之前先取。
+        # 不能用 rid（下面那个 capped top-N 子集的 hash）当退避 key：否则一个
+        # poison 的 top-N 批次 dead-letter 后，新到的低 importance facts 进不了
+        # top-N → rid 不变 → 合成被永久跳过，把整个 unabsorbed 池饿死（Codex P2）。
+        # 用全集 key 时任何新 fact 都会改 key → 预算复位 → 重试一次。
+        all_unabsorbed_ids = sorted(f['id'] for f in unabsorbed)
+        backoff_key = _reflection_id_from_facts(all_unabsorbed_ids)
+
         # Cap unabsorbed facts entering this synthesis call. 上游
         # aget_unabsorbed_facts 没有 limit 参数，长期不上线时可能堆几百
         # 条；按 importance(desc) → 创建时间(asc) 排序后取前 N 条，避免
@@ -769,14 +777,14 @@ class ReflectionEngine:
             )
             return []
 
-        # 失败退避（dead-letter）：同批 facts(rid) 合成已连续失败 ≥
-        # MEMORY_LIVENESS_MAX_ATTEMPTS 次 → 不再每 180s 原样重抽空跑 LLM。
-        # facts 一变 rid 就变、计数天然复位（用户审计 #2）。
+        # 失败退避（dead-letter）：同一批 unabsorbed facts(backoff_key) 合成已连续
+        # 失败 ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 次 → 不再每 180s 原样重抽空跑 LLM。
+        # 任一 unabsorbed fact 增减 → backoff_key 变、计数天然复位（用户审计 #2）。
         from config import MEMORY_LIVENESS_MAX_ATTEMPTS
-        synth_attempts = (await self._aload_synth_backoff(lanlan_name)).get(rid, 0)
+        synth_attempts = (await self._aload_synth_backoff(lanlan_name)).get(backoff_key, 0)
         if synth_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
             logger.debug(
-                f"[Reflection] {lanlan_name}: rid {rid} 合成连续失败 "
+                f"[Reflection] {lanlan_name}: backoff_key {backoff_key} 合成连续失败 "
                 f"{synth_attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，dead-letter 跳过"
             )
             return []
@@ -820,12 +828,12 @@ class ReflectionEngine:
             result = robust_json_loads(raw)
             if not isinstance(result, dict):
                 logger.warning(f"[Reflection] LLM 返回非 dict: {type(result)}")
-                await self._abump_synth_backoff(lanlan_name, rid, "non-dict response")
+                await self._abump_synth_backoff(lanlan_name, backoff_key, "non-dict response")
                 return []
             reflection_text = result.get('reflection', '')
             if not isinstance(reflection_text, str):
                 logger.warning(f"[Reflection] reflection 字段非 str: {type(reflection_text)}")
-                await self._abump_synth_backoff(lanlan_name, rid, "reflection field non-str")
+                await self._abump_synth_backoff(lanlan_name, backoff_key, "reflection field non-str")
                 return []
             reflection_text = reflection_text.strip()
             reflection_entity = result.get('entity', 'relationship')
@@ -868,11 +876,11 @@ class ReflectionEngine:
                 subject = None
         except Exception as e:
             logger.warning(f"[Reflection] 合成失败: {e}")
-            await self._abump_synth_backoff(lanlan_name, rid, f"LLM/parse exception: {e}")
+            await self._abump_synth_backoff(lanlan_name, backoff_key, f"LLM/parse exception: {e}")
             return []
 
         if not reflection_text:
-            await self._abump_synth_backoff(lanlan_name, rid, "empty reflection text")
+            await self._abump_synth_backoff(lanlan_name, backoff_key, "empty reflection text")
             return []
 
         # Create pending reflection — id 已在函数开头由 source_fact_ids 决定
@@ -945,9 +953,10 @@ class ReflectionEngine:
                 await self.asave_reflections(lanlan_name, reflections)
                 created = True
 
-        # rid 已落盘（本次 append 或并发对方先写），清掉其失败退避记录——
-        # 锁外调用（_aclear_synth_backoff 自取锁，避免 reentrant 死锁）。
-        await self._aclear_synth_backoff(lanlan_name, rid)
+        # reflection 已落盘（本次 append 或并发对方先写），清掉本次 unabsorbed
+        # 全集的失败退避记录——锁外调用（_aclear_synth_backoff 自取锁，避免
+        # reentrant 死锁）。
+        await self._aclear_synth_backoff(lanlan_name, backoff_key)
 
         # 无条件 mark_absorbed：幂等，且覆盖 save 成功后但在此崩溃的补跑情况
         # （fact_store 自己有锁，不需要在 reflection 锁内）

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -295,6 +295,77 @@ class ReflectionEngine:
         from memory import ensure_character_dir
         return os.path.join(ensure_character_dir(self._config_manager.memory_dir, name), 'surfaced.json')
 
+    def _synth_backoff_path(self, name: str) -> str:
+        """Per-character sidecar tracking per-rid synthesis 失败次数。
+
+        synthesize_reflections 在 LLM 失败时没有任何可挂 attempts 的实体
+        （reflection 还没建），所以失败计数落在这个 ``{rid: attempts}`` map
+        里。rid 由 source_fact_ids 决定（确定性）——facts 一变 rid 就变、
+        attempts 天然复位，所以持续失败的同批 facts 会被 dead-letter，新
+        输入立即重试。
+        """
+        from memory import ensure_character_dir
+        return os.path.join(
+            ensure_character_dir(self._config_manager.memory_dir, name),
+            'synth_backoff.json',
+        )
+
+    async def _aload_synth_backoff(self, name: str) -> dict:
+        """读 {rid: attempts(int)} map；缺文件 / 损坏 → 空 dict。"""
+        path = self._synth_backoff_path(name)
+        if not await asyncio.to_thread(os.path.exists, path):
+            return {}
+        try:
+            data = await read_json_async(path)
+        except Exception:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        out: dict[str, int] = {}
+        for k, v in data.items():
+            try:
+                out[str(k)] = int(v)
+            except (TypeError, ValueError):
+                continue
+        return out
+
+    async def _asave_synth_backoff(self, name: str, backoff: dict) -> None:
+        """best-effort 落盘——维护态 / 只读 FS 写失败不抛（这条只是熔断辅助，
+        丢了下次重算，不影响主数据）。"""
+        try:
+            await atomic_write_json_async(
+                self._synth_backoff_path(name), backoff,
+                indent=2, ensure_ascii=False,
+            )
+        except Exception as e:
+            logger.debug(f"[Reflection] {name}: synth_backoff 写盘失败: {e}")
+
+    async def _abump_synth_backoff(self, name: str, rid: str, reason: str) -> int:
+        """记 rid 一次合成失败，返回累计次数。caller 不持锁（失败分支都在
+        post-LLM 锁之外），这里自取 _get_alock 做 read-modify-write。"""
+        async with self._get_alock(name):
+            backoff = await self._aload_synth_backoff(name)
+            attempts = backoff.get(rid, 0) + 1
+            backoff[rid] = attempts
+            # 防失败 rid 长期累积：超阈值时只留 attempts 最高的若干条
+            # （dead-letter 候选优先保活，被丢的低分 rid 下次失败重新计起）。
+            if len(backoff) > 64:
+                backoff = dict(sorted(backoff.items(), key=lambda kv: -kv[1])[:64])
+                backoff[rid] = attempts
+            await self._asave_synth_backoff(name, backoff)
+        logger.debug(
+            f"[Reflection] {name}: rid {rid} 合成失败退避 → {attempts} ({reason})"
+        )
+        return attempts
+
+    async def _aclear_synth_backoff(self, name: str, rid: str) -> None:
+        """rid 成功落盘后清掉其失败记录。caller 不持锁。"""
+        async with self._get_alock(name):
+            backoff = await self._aload_synth_backoff(name)
+            if rid in backoff:
+                del backoff[rid]
+                await self._asave_synth_backoff(name, backoff)
+
     # ── persistence ──────────────────────────────────────────────────
 
     @staticmethod
@@ -698,6 +769,18 @@ class ReflectionEngine:
             )
             return []
 
+        # 失败退避（dead-letter）：同批 facts(rid) 合成已连续失败 ≥
+        # MEMORY_LIVENESS_MAX_ATTEMPTS 次 → 不再每 180s 原样重抽空跑 LLM。
+        # facts 一变 rid 就变、计数天然复位（用户审计 #2）。
+        from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+        synth_attempts = (await self._aload_synth_backoff(lanlan_name)).get(rid, 0)
+        if synth_attempts >= MEMORY_LIVENESS_MAX_ATTEMPTS:
+            logger.debug(
+                f"[Reflection] {lanlan_name}: rid {rid} 合成连续失败 "
+                f"{synth_attempts} 次 ≥ {MEMORY_LIVENESS_MAX_ATTEMPTS}，dead-letter 跳过"
+            )
+            return []
+
         _, _, _, _, name_mapping, _, _, _, _ = await self._config_manager.aget_character_data()
         master_name = name_mapping.get('human', '主人')
 
@@ -737,10 +820,12 @@ class ReflectionEngine:
             result = robust_json_loads(raw)
             if not isinstance(result, dict):
                 logger.warning(f"[Reflection] LLM 返回非 dict: {type(result)}")
+                await self._abump_synth_backoff(lanlan_name, rid, "non-dict response")
                 return []
             reflection_text = result.get('reflection', '')
             if not isinstance(reflection_text, str):
                 logger.warning(f"[Reflection] reflection 字段非 str: {type(reflection_text)}")
+                await self._abump_synth_backoff(lanlan_name, rid, "reflection field non-str")
                 return []
             reflection_text = reflection_text.strip()
             reflection_entity = result.get('entity', 'relationship')
@@ -783,9 +868,11 @@ class ReflectionEngine:
                 subject = None
         except Exception as e:
             logger.warning(f"[Reflection] 合成失败: {e}")
+            await self._abump_synth_backoff(lanlan_name, rid, f"LLM/parse exception: {e}")
             return []
 
         if not reflection_text:
+            await self._abump_synth_backoff(lanlan_name, rid, "empty reflection text")
             return []
 
         # Create pending reflection — id 已在函数开头由 source_fact_ids 决定
@@ -857,6 +944,10 @@ class ReflectionEngine:
                 reflections.append(reflection)
                 await self.asave_reflections(lanlan_name, reflections)
                 created = True
+
+        # rid 已落盘（本次 append 或并发对方先写），清掉其失败退避记录——
+        # 锁外调用（_aclear_synth_backoff 自取锁，避免 reentrant 死锁）。
+        await self._aclear_synth_backoff(lanlan_name, rid)
 
         # 无条件 mark_absorbed：幂等，且覆盖 save 成功后但在此崩溃的补跑情况
         # （fact_store 自己有锁，不需要在 reflection 锁内）
@@ -2622,6 +2713,7 @@ class ReflectionEngine:
         )
 
         # ── 锁内：reload + 找同 id + 更新字段 + save ──────────────
+        save_failed_reason: str | None = None
         async with self._get_alock(lanlan_name):
             current = await self._aload_reflections_full(lanlan_name)
             found = None
@@ -2640,7 +2732,23 @@ class ReflectionEngine:
             found['event_start_at'] = event_start_at
             found['event_end_at'] = event_end_at
             found['schema_version'] = _SCHEMA_V
-            await self.asave_reflections(lanlan_name, current)
+            try:
+                await self.asave_reflections(lanlan_name, current)
+            except Exception as e:
+                # 落盘失败也要计入 recheck_attempts：否则 cloudsave 维护态 /
+                # 只读 FS / 权限导致的持续写盘失败会让同一条 reflection 每 30s
+                # 原样重判、熔断永不触发（对齐上面 LLM 失败路径的 bump）。
+                # bump helper 自取锁，asyncio.Lock 不可重入，必须退出本锁后再调。
+                save_failed_reason = f"save failed: {e}"
+
+        if save_failed_reason is not None:
+            logger.warning(
+                f"[Recheck-Reflection] {lanlan_name} {rid}: {save_failed_reason}"
+            )
+            await self._abump_reflection_recheck_attempts(
+                lanlan_name, rid, save_failed_reason,
+            )
+            return False
 
         logger.info(
             f"[Recheck-Reflection] {lanlan_name} {rid}: v1→v{_SCHEMA_V} "

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -238,6 +238,11 @@ class ReflectionEngine:
         # threading.Lock guards the dict itself (reads/writes of _alocks are
         # pure Python, no await inside this critical section).
         self._alocks_guard = threading.Lock()
+        # synth 失败退避的进程内镜像 {name: {key: {"n", "at"}}}。它是 session 内
+        # 的权威工作副本，磁盘只是持久化 + 重启恢复。这样即使 synth_backoff.json
+        # 写盘失败（只读 FS / 权限），失败计数也不会丢、dead-letter 闸门照常生效
+        # （Codex P2）。对齐 review 的 _maint_state 进程内持久语义。
+        self._synth_backoff_mem: dict[str, dict] = {}
 
     def _get_alock(self, name: str) -> asyncio.Lock:
         """Get (or lazily create) the per-character asyncio.Lock.
@@ -310,8 +315,8 @@ class ReflectionEngine:
             'synth_backoff.json',
         )
 
-    async def _aload_synth_backoff(self, name: str) -> dict:
-        """读 {key: {"n": attempts(int), "at": last_fail_iso|None}} map；
+    async def _aload_synth_backoff_from_disk(self, name: str) -> dict:
+        """从磁盘读 {key: {"n": attempts(int), "at": last_fail_iso|None}} map；
         缺文件 / 损坏 → 空 dict。兼容旧格式 {key: int}（at 补 None）。"""
         path = self._synth_backoff_path(name)
         if not await asyncio.to_thread(os.path.exists, path):
@@ -337,23 +342,40 @@ class ReflectionEngine:
                     continue
         return out
 
+    async def _aload_synth_backoff(self, name: str) -> dict:
+        """返回失败退避 map。优先用进程内镜像（最新工作副本，即使上次写盘
+        失败也不丢计数）；首次访问该角色时从磁盘加载并缓存。"""
+        cached = self._synth_backoff_mem.get(name)
+        if cached is not None:
+            return cached
+        loaded = await self._aload_synth_backoff_from_disk(name)
+        self._synth_backoff_mem[name] = loaded
+        return loaded
+
     async def _asave_synth_backoff(self, name: str, backoff: dict) -> None:
-        """best-effort 落盘——维护态 / 只读 FS 写失败不抛（这条只是熔断辅助，
-        丢了下次重算，不影响主数据）。"""
+        """先更新进程内镜像（session 内权威，保证写盘失败也不丢 throttle），
+        再 best-effort 落盘。写盘失败 WARN 但不抛——镜像已生效，dead-letter
+        闸门照常工作；重启才会从磁盘读，那时已是另一种恢复语境（Codex P2）。"""
+        self._synth_backoff_mem[name] = backoff
         try:
             await atomic_write_json_async(
                 self._synth_backoff_path(name), backoff,
                 indent=2, ensure_ascii=False,
             )
         except Exception as e:
-            logger.debug(f"[Reflection] {name}: synth_backoff 写盘失败: {e}")
+            logger.warning(
+                f"[Reflection] {name}: synth_backoff 写盘失败（进程内镜像仍生效，"
+                f"throttle 不受影响）: {e}"
+            )
 
     async def _abump_synth_backoff(self, name: str, key: str, reason: str) -> int:
         """记 key 一次合成失败，返回累计次数并戳上失败时刻（供时间自愈）。
         caller 不持锁（失败分支都在 post-LLM 锁之外），这里自取 _get_alock
         做 read-modify-write。"""
         async with self._get_alock(name):
-            backoff = await self._aload_synth_backoff(name)
+            # 拷贝一份再改：_aload_synth_backoff 返回的是进程内镜像引用，
+            # 由 _asave_synth_backoff 统一回写，避免半改状态被并发读看到。
+            backoff = dict(await self._aload_synth_backoff(name))
             attempts = backoff.get(key, {}).get("n", 0) + 1
             entry = {"n": attempts, "at": datetime.now().isoformat()}
             backoff[key] = entry
@@ -373,7 +395,7 @@ class ReflectionEngine:
     async def _aclear_synth_backoff(self, name: str, key: str) -> None:
         """key 成功落盘后清掉其失败记录。caller 不持锁。"""
         async with self._get_alock(name):
-            backoff = await self._aload_synth_backoff(name)
+            backoff = dict(await self._aload_synth_backoff(name))
             if key in backoff:
                 del backoff[key]
                 await self._asave_synth_backoff(name, backoff)

--- a/memory/reflection.py
+++ b/memory/reflection.py
@@ -2619,7 +2619,14 @@ class ReflectionEngine:
                         r['recheck_attempts'] = (r.get('recheck_attempts') or 0) + 1
                         # 戳失败时刻供 dead-letter 时间自愈（cooldown_elapsed）
                         r['last_recheck_attempt_at'] = datetime.now().isoformat()
-                        await self.asave_reflections(lanlan_name, current)
+                        # 传 active-only：对齐 _abump_refine_attempts / arecord_mentions
+                        # 的 save 约定，让 promoted/denied 等 terminal 条目正常归档，
+                        # 不被多留一个周期（CodeRabbit 一致性 nitpick）。
+                        active = [
+                            x for x in current
+                            if x.get('status') not in REFLECTION_TERMINAL_STATUSES
+                        ]
+                        await self.asave_reflections(lanlan_name, active)
                         logger.debug(
                             f"[Recheck-Reflection] {lanlan_name} {rid}: "
                             f"recheck_attempts → {r['recheck_attempts']} ({reason})"

--- a/memory/temporal.py
+++ b/memory/temporal.py
@@ -82,6 +82,11 @@ def cooldown_elapsed(
         return True
     if now is None:
         now = datetime.now()
+    # aware/naive 归一：写入路径都用 datetime.now()（naive），但迁移 / import
+    # 数据可能塞进 +00:00 / Z 的 aware ISO，直接和 naive now 相减会抛
+    # TypeError 中断冷却判定。复用全项目 tz 归一口径 to_naive_local（保瞬时）。
+    last = to_naive_local(last)
+    now = to_naive_local(now)
     return (now - last).total_seconds() >= cooldown_seconds
 
 

--- a/memory/temporal.py
+++ b/memory/temporal.py
@@ -56,6 +56,35 @@ ALL_TEMPORAL_SCOPES = (
 )
 
 
+def cooldown_elapsed(
+    last_at_iso: str | None,
+    cooldown_seconds: float,
+    now: datetime | None = None,
+) -> bool:
+    """dead-letter 时间冷却自愈判定：距上次失败是否已过 ``cooldown_seconds``。
+
+    用于 reflection synth / schema recheck / refine 这些"达 N 次冻结"的
+    dead-letter——冻结后每过冷却窗口放行一次 probe，让一次性持续故障
+    （模型宕机 / 维护态 / 只读 FS）恢复后自愈。memory_review **不**用本机制
+    （它靠 fingerprint 变化复位，挂机期间应一直停）。
+
+    返回 True = 冷却已过 / 无时间基准，可放行 probe。
+
+    ``last_at_iso`` 为空或无法解析 → 返回 True：没有时间戳通常是旧数据或
+    首次冻结前的遗留，给一次 probe 比永久冻死更安全（probe 失败会写回
+    时间戳，下次就按正常冷却计时）。
+    """
+    if not last_at_iso:
+        return True
+    try:
+        last = datetime.fromisoformat(last_at_iso)
+    except (ValueError, TypeError):
+        return True
+    if now is None:
+        now = datetime.now()
+    return (now - last).total_seconds() >= cooldown_seconds
+
+
 # ── offset spec 解析 ──────────────────────────────────────────────────
 
 def _validate_offset_spec(spec: object) -> dict | None:

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -523,6 +523,10 @@ async def test_persona_abump_refine_attempts_at_threshold_warns():
 
     # 最终 refine_attempts == MEMORY_LIVENESS_MAX_ATTEMPTS
     assert persona['master']['facts'][0]['refine_attempts'] == MEMORY_LIVENESS_MAX_ATTEMPTS
+    # 每次 bump 都戳失败时刻，供 dead-letter 时间自愈（cooldown_elapsed）
+    assert persona['master']['facts'][0].get('last_refine_attempt_at'), (
+        "bump 必须戳 last_refine_attempt_at，否则 dead-letter 无法时间自愈"
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_memory_liveness_dead_letter.py
+++ b/tests/unit/test_memory_liveness_dead_letter.py
@@ -427,13 +427,14 @@ async def test_refine_pass_failure_fn_invoked_on_resolve_false():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_refine_pass_exception_does_not_invoke_failure_fn():
-    """Codex P1 regression：``_resolve_cluster`` 抛异常时**不**调 failure_fn。
+async def test_refine_pass_exception_invokes_failure_fn():
+    """``_resolve_cluster`` 抛异常时**也**调 failure_fn（计入 refine_attempts）。
 
-    抛异常的可能源是 apply_fn 持久化 transient（cloudsave 维护态 / atomic
-    write IO / 锁竞争）或 LLM 网络 transient。把这类错算到 cluster 成员的
-    ``refine_attempts`` 上会冤枉具体 entry 触发非必要 dead-letter。只在
-    ``_resolve_cluster`` 明确返 False（LLM/parse 持续性问题）时 bump。
+    先前设计（Codex P1 on PR #1412）把异常按"瞬态、不计数"处理，怕单次抖动
+    冤枉 entry。但持续性故障（correction 模型快照下线一直超时、cloudsave 卡
+    维护态、FS 只读）会让同一个毒 cluster 每 30min 原样重打 LLM 永不放弃。
+    现在异常也计入预算：N=MEMORY_LIVENESS_MAX_ATTEMPTS 跨过偶发抖动，cluster
+    内容一变 hash 即变、attempts 随新成员复位，所以持续故障收敛、偶发无损。
     """
     from memory.refine import (
         MemoryRefineEngine,
@@ -472,10 +473,13 @@ async def test_refine_pass_exception_does_not_invoke_failure_fn():
         )
 
     assert result['clusters_failed'] == 1, "exception 仍记 clusters_failed"
-    assert captured_failures == [], (
-        f"exception 不该触发 failure_fn（apply_fn / LLM transient 不算 cluster "
-        f"liveness failure）, 实际触发 {len(captured_failures)} 次"
+    assert len(captured_failures) == 1, (
+        f"exception 应触发 failure_fn 一次（持续性故障必须计入 refine_attempts "
+        f"才能 dead-letter）, 实际触发 {len(captured_failures)} 次"
     )
+    cluster_arg, hash_arg = captured_failures[0]
+    assert cluster_arg == candidates['master']
+    assert isinstance(hash_arg, str) and len(hash_arg) > 0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_memory_review_backoff.py
+++ b/tests/unit/test_memory_review_backoff.py
@@ -104,6 +104,56 @@ async def test_run_review_patched_clears_backoff():
     memory_server._maint_state.pop(name, None)
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_review_patched_save_failure_does_not_bump():
+    """成功 review（patched）的 state 落盘抖动不得被误判成失败 bump（Codex P2）。"""
+    from app import memory_server
+
+    name = "测试角色保存抖动"
+    snapshot = _history(10)
+    memory_server._maint_state.pop(name, None)
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("patched", [{"type": "ai", "content": "x"}]))
+    cancel_event = asyncio.Event()
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state",
+                      AsyncMock(side_effect=RuntimeError("disk full"))):
+        await memory_server._run_review_in_background(name, snapshot, cancel_event)
+
+    state = memory_server._maint_state.get(name, {})
+    assert state.get("review_fail_attempts", 0) == 0, (
+        "成功 review 的 save 失败被外层 except 当成 review 失败 bump 了"
+    )
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_review_failed_save_failure_counts_once():
+    """'failed' 分支 save 抛异常时只记一次，不被外层 except 重复 bump（Codex P2）。"""
+    from app import memory_server
+
+    name = "测试角色失败保存"
+    snapshot = _history(10)
+    memory_server._maint_state.pop(name, None)
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("failed", None))
+    cancel_event = asyncio.Event()
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state",
+                      AsyncMock(side_effect=RuntimeError("disk full"))):
+        await memory_server._run_review_in_background(name, snapshot, cancel_event)
+
+    # _record_review_failure 在落盘前已把内存计数 +1；外层 except 不再重复 bump
+    assert memory_server._maint_state.get(name, {}).get("review_fail_attempts", 0) == 1, (
+        "save 失败导致 _record_review_failure 抛出后被外层 except 重复计数了"
+    )
+    memory_server._maint_state.pop(name, None)
+
+
 async def _drive_spawn(memory_server, name, history):
     """跑 maybe_spawn_review，gate 1-5 全开（patch 掉），只测 Gate 6。"""
     fake_mgr = MagicMock()

--- a/tests/unit/test_memory_review_backoff.py
+++ b/tests/unit/test_memory_review_backoff.py
@@ -170,6 +170,53 @@ async def test_gate6_resets_and_spawns_when_input_changed():
     try:
         await task
     except asyncio.CancelledError:
+        # 预期内：上面刚 task.cancel()，await 必然抛 CancelledError，吞掉即可
         pass
     memory_server._maint_state.pop(name, None)
     memory_server.correction_tasks.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_failed_resets_budget_on_input_change():
+    """不同 history tail 各失败一次不应跨输入累积（Codex P2）：每次输入变都从 1 计起。"""
+    from app import memory_server
+    from memory.recent import build_review_fingerprint
+
+    name = "测试角色累积"
+    memory_server._maint_state.pop(name, None)
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("failed", None))
+    cancel_event = asyncio.Event()
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        for n in (8, 10, 12):  # 三段 tail fingerprint 互不相同的输入
+            await memory_server._run_review_in_background(name, _history(n), cancel_event)
+
+    state = memory_server._maint_state[name]
+    assert state["review_fail_attempts"] == 1, "输入每次都变应复位，不该累积到 3"
+    assert state["review_fail_fp"] == build_review_fingerprint(_history(12))
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_failed_same_input_accumulates_budget():
+    """同一输入连续失败才累积预算（与跨输入复位对偶）。"""
+    from app import memory_server
+
+    name = "测试角色累积2"
+    memory_server._maint_state.pop(name, None)
+    same = _history(10)
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("failed", None))
+    cancel_event = asyncio.Event()
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        for _ in range(3):
+            await memory_server._run_review_in_background(name, same, cancel_event)
+
+    assert memory_server._maint_state[name]["review_fail_attempts"] == 3
+    memory_server._maint_state.pop(name, None)

--- a/tests/unit/test_memory_review_backoff.py
+++ b/tests/unit/test_memory_review_backoff.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+"""用户审计 #1 回归：memory_review 失败退避（dead-letter）。
+
+日志实锤：correction 模型持续超时 → review 每轮 3×110s 超时后 'failed' →
+既不刷 ts 也不退避，配合长挂机 bypass 主动续命 → 整夜每 ~6min 无限重烧。
+
+修复：'failed' 时 bump review_fail_attempts + 记下失败输入的 tail fingerprint；
+maybe_spawn_review 的 Gate 6 在 attempts ≥ MEMORY_LIVENESS_MAX_ATTEMPTS 且输入
+未变时跳过 spawn。输入一变（master 发新消息，fingerprint 变）→ 复位重试。
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from utils.llm_client import AIMessage, HumanMessage
+
+
+def _history(n: int):
+    """造 n 条交替 user/ai 消息（长度 ≥ REVIEW_SKIP_HISTORY_LEN=8）。"""
+    out = []
+    for i in range(n):
+        if i % 2 == 0:
+            out.append(HumanMessage(content=f"u{i}"))
+        else:
+            out.append(AIMessage(content=f"a{i}"))
+    return out
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_review_failed_bumps_backoff():
+    """review_history 返回 ('failed', None) → bump review_fail_attempts + 记 fp。"""
+    from app import memory_server
+    from memory.recent import build_review_fingerprint
+
+    name = "测试角色"
+    snapshot = _history(10)
+    memory_server._maint_state.pop(name, None)
+
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("failed", None))
+    cancel_event = asyncio.Event()  # 未置位 → 真失败
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._run_review_in_background(name, snapshot, cancel_event)
+
+    state = memory_server._maint_state[name]
+    assert state["review_fail_attempts"] == 1
+    assert state["review_fail_fp"] == build_review_fingerprint(snapshot)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_review_cancelled_does_not_bump():
+    """cancel_event 置位时返回 ('failed', None) 是主动取消，不计入失败退避。"""
+    from app import memory_server
+
+    name = "测试角色"
+    snapshot = _history(10)
+    memory_server._maint_state.pop(name, None)
+
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("failed", None))
+    cancel_event = asyncio.Event()
+    cancel_event.set()  # 模拟 cancel_correction 已置位
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._run_review_in_background(name, snapshot, cancel_event)
+
+    state = memory_server._maint_state.get(name, {})
+    assert state.get("review_fail_attempts", 0) == 0
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_review_patched_clears_backoff():
+    """成功 patch → 清掉失败退避计数 + fp。"""
+    from app import memory_server
+
+    name = "测试角色"
+    snapshot = _history(10)
+    memory_server._maint_state[name] = {
+        "review_fail_attempts": 3,
+        "review_fail_fp": [{"type": "human", "content": "stale"}],
+    }
+
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(return_value=("patched", [{"type": "ai", "content": "x"}]))
+    cancel_event = asyncio.Event()
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._run_review_in_background(name, snapshot, cancel_event)
+
+    state = memory_server._maint_state[name]
+    assert state["review_fail_attempts"] == 0
+    assert state["review_fail_fp"] is None
+    memory_server._maint_state.pop(name, None)
+
+
+async def _drive_spawn(memory_server, name, history):
+    """跑 maybe_spawn_review，gate 1-5 全开（patch 掉），只测 Gate 6。"""
+    fake_mgr = MagicMock()
+    fake_mgr.aget_recent_history = AsyncMock(return_value=history)
+    # 被 spawn 的后台 task 真跑起来时会调 review_history——给个安全返回
+    fake_mgr.review_history = AsyncMock(return_value=("white", None))
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_ais_review_enabled", AsyncMock(return_value=True)), \
+         patch.object(memory_server, "_count_new_user_msgs_since_last_review", return_value=999), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server.maybe_spawn_review(name)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate6_skips_when_dead_lettered_and_input_unchanged():
+    """attempts ≥ MAX 且当前 history tail fingerprint == 失败时记下的 → 不 spawn。"""
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+    from memory.recent import build_review_fingerprint
+
+    name = "测试角色G6"
+    history = _history(12)
+    memory_server.correction_tasks.pop(name, None)
+    memory_server._maint_state[name] = {
+        "review_fail_attempts": MEMORY_LIVENESS_MAX_ATTEMPTS,
+        "review_fail_fp": build_review_fingerprint(history),
+    }
+
+    await _drive_spawn(memory_server, name, history)
+
+    assert name not in memory_server.correction_tasks or memory_server.correction_tasks[name] is None, \
+        "dead-letter + 输入未变时不应 spawn 新 review"
+    memory_server._maint_state.pop(name, None)
+    memory_server.correction_tasks.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate6_resets_and_spawns_when_input_changed():
+    """attempts ≥ MAX 但当前 fingerprint 与失败记录不同（新消息）→ 复位并 spawn。"""
+    from app import memory_server
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    name = "测试角色G6b"
+    history = _history(12)
+    memory_server.correction_tasks.pop(name, None)
+    # 失败 fp 是另一段输入（与当前 history tail 不同）
+    memory_server._maint_state[name] = {
+        "review_fail_attempts": MEMORY_LIVENESS_MAX_ATTEMPTS,
+        "review_fail_fp": [{"type": "human", "content": "完全不同的旧输入"}],
+    }
+
+    await _drive_spawn(memory_server, name, history)
+
+    # 输入已变 → 复位计数
+    assert memory_server._maint_state[name]["review_fail_attempts"] == 0
+    # 并且确实 spawn 了（correction_tasks 落了一个 task）
+    task = memory_server.correction_tasks.get(name)
+    assert task is not None
+    # 清理后台 task
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    memory_server._maint_state.pop(name, None)
+    memory_server.correction_tasks.pop(name, None)

--- a/tests/unit/test_memory_review_backoff.py
+++ b/tests/unit/test_memory_review_backoff.py
@@ -202,6 +202,31 @@ async def test_failed_resets_budget_on_input_change():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_run_review_exception_bumps_backoff():
+    """review_history 直接抛异常（而非返回 ('failed', None)）也要计入失败退避，
+    否则 Gate 6 拿不到预算、持续重烧仍会发生（CodeRabbit Major）。"""
+    from app import memory_server
+    from memory.recent import build_review_fingerprint
+
+    name = "测试角色异常"
+    snapshot = _history(10)
+    memory_server._maint_state.pop(name, None)
+    fake_mgr = MagicMock()
+    fake_mgr.review_history = AsyncMock(side_effect=RuntimeError("boom"))
+    cancel_event = asyncio.Event()
+
+    with patch.object(memory_server, "recent_history_manager", fake_mgr), \
+         patch.object(memory_server, "_asave_maint_state", AsyncMock()):
+        await memory_server._run_review_in_background(name, snapshot, cancel_event)
+
+    state = memory_server._maint_state[name]
+    assert state["review_fail_attempts"] == 1
+    assert state["review_fail_fp"] == build_review_fingerprint(snapshot)
+    memory_server._maint_state.pop(name, None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_failed_same_input_accumulates_budget():
     """同一输入连续失败才累积预算（与跨输入复位对偶）。"""
     from app import memory_server

--- a/tests/unit/test_memory_temporal.py
+++ b/tests/unit/test_memory_temporal.py
@@ -52,6 +52,17 @@ def test_cooldown_elapsed_respects_now_arg():
     assert cooldown_elapsed(last, 3 * 3600, now=base) is True
 
 
+def test_cooldown_elapsed_handles_aware_timestamp():
+    """aware ISO（+00:00 / Z）不应让相减抛 TypeError（迁移/import 数据防御，
+    CodeRabbit）。aware 与 naive now 经 to_naive_local 归一后正常比较。"""
+    from datetime import timezone
+    from memory.temporal import cooldown_elapsed
+    last_aware_old = (datetime.now(timezone.utc) - timedelta(hours=6)).isoformat()
+    assert cooldown_elapsed(last_aware_old, 5 * 3600) is True
+    last_aware_recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    assert cooldown_elapsed(last_aware_recent, 5 * 3600) is False
+
+
 # ── memory.temporal helpers ─────────────────────────────────────────
 
 

--- a/tests/unit/test_memory_temporal.py
+++ b/tests/unit/test_memory_temporal.py
@@ -19,6 +19,39 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+# ── cooldown_elapsed (dead-letter 时间自愈) ──────────────────────────
+
+
+def test_cooldown_elapsed_true_after_window():
+    from memory.temporal import cooldown_elapsed
+    last = (datetime.now() - timedelta(hours=6)).isoformat()
+    assert cooldown_elapsed(last, 5 * 3600) is True
+
+
+def test_cooldown_elapsed_false_within_window():
+    from memory.temporal import cooldown_elapsed
+    last = (datetime.now() - timedelta(hours=1)).isoformat()
+    assert cooldown_elapsed(last, 5 * 3600) is False
+
+
+def test_cooldown_elapsed_missing_or_garbage_is_eligible():
+    """无时间戳 / 无法解析 → True（给一次 probe，比永久冻死安全）。"""
+    from memory.temporal import cooldown_elapsed
+    assert cooldown_elapsed(None, 5 * 3600) is True
+    assert cooldown_elapsed("", 5 * 3600) is True
+    assert cooldown_elapsed("not-a-date", 5 * 3600) is True
+
+
+def test_cooldown_elapsed_respects_now_arg():
+    from memory.temporal import cooldown_elapsed
+    base = datetime(2026, 5, 24, 12, 0, 0)
+    last = (base - timedelta(hours=4)).isoformat()
+    # 4h < 5h 窗口
+    assert cooldown_elapsed(last, 5 * 3600, now=base) is False
+    # 同一时间戳，6h 窗口外
+    assert cooldown_elapsed(last, 3 * 3600, now=base) is True
+
+
 # ── memory.temporal helpers ─────────────────────────────────────────
 
 

--- a/tests/unit/test_reflection_idempotent.py
+++ b/tests/unit/test_reflection_idempotent.py
@@ -413,3 +413,86 @@ async def test_synth_success_clears_backoff(tmp_path):
         assert rid not in (await re._aload_synth_backoff("小天")), (
             "成功合成后应清掉该 rid 的失败退避记录"
         )
+
+
+def _write_facts_with_importance(tmpdir: str, character: str, specs: list[tuple[str, int]]):
+    """写 facts.json，每条带显式 importance，用于构造 top-N cap 场景。"""
+    import json
+
+    char_dir = os.path.join(tmpdir, character)
+    os.makedirs(char_dir, exist_ok=True)
+    facts = [
+        {"id": fid, "text": f"fact text {fid}", "entity": "master",
+         "importance": imp, "absorbed": False}
+        for fid, imp in specs
+    ]
+    with open(os.path.join(char_dir, "facts.json"), "w", encoding="utf-8") as f:
+        json.dump(facts, f, ensure_ascii=False)
+
+
+@pytest.mark.asyncio
+async def test_synth_dead_letter_resets_when_full_input_changes(tmp_path):
+    """Codex P2：退避 key 必须覆盖全部 unabsorbed，而非 capped top-N(rid)。
+
+    poison 的 top-20 dead-letter 后，新到的 fact（importance≥5 进得了
+    unabsorbed 池，但低于 top-20 那批、进不了 cap）不会改 rid——若按 rid 退避
+    会永久跳过、饿死整池。按全集 key 退避则新 fact 改 key → 预算复位 → 重试。
+
+    注：aget_unabsorbed_facts 有 min_importance=5 闸门，importance<5 的 fact
+    根本不进池，所以构造新 fact 用 importance=5（poison 批用 9 占满 top-20）。
+    """
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS, REFLECTION_SYNTHESIS_FACTS_MAX
+
+    mock_cm = _build_mock_cm(str(tmp_path))
+    # 20 条高 importance（=top-N poison 批次）
+    poison = [(f"p{i:02d}", 9) for i in range(REFLECTION_SYNTHESIS_FACTS_MAX)]
+    _write_facts_with_importance(str(tmp_path), "小天", poison)
+
+    with patch("memory.reflection.get_config_manager", return_value=mock_cm), \
+         patch("memory.facts.get_config_manager", return_value=mock_cm):
+        from memory.facts import FactStore
+        from memory.persona import PersonaManager
+        from memory.reflection import ReflectionEngine
+
+        fs = FactStore()
+        fs._config_manager = mock_cm
+        pm = PersonaManager()
+        pm._config_manager = mock_cm
+        re = ReflectionEngine(fs, pm)
+        re._config_manager = mock_cm
+
+        llm_calls = {"n": 0}
+
+        async def _fail_ainvoke(self, prompt):
+            llm_calls["n"] += 1
+            resp = MagicMock()
+            resp.content = "not json"  # 触发失败分支
+            return resp
+
+        class _FakeLLM:
+            def __init__(self, *a, **kw): pass
+            ainvoke = _fail_ainvoke
+
+            async def aclose(self):
+                return None
+
+        with patch("utils.llm_client.create_chat_llm", _FakeLLM), \
+             patch("config.prompts.prompts_memory.get_reflection_prompt", lambda lang: "{FACTS}|{LANLAN_NAME}|{MASTER_NAME}"), \
+             patch("utils.language_utils.get_global_language", return_value="zh"):
+            # 跑到 dead-letter：MAX 次真打 LLM，之后跳过
+            for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS + 2):
+                assert await re.synthesize_reflections("小天") == []
+            assert llm_calls["n"] == MEMORY_LIVENESS_MAX_ATTEMPTS
+
+            # 加一条 importance=5 的 fact：进得了 unabsorbed 池（≥min_importance），
+            # 但低于 poison 批的 9、挤不进 top-20，rid 不变，但全集 key 变
+            new_facts = poison + [("low0", 5)]
+            _write_facts_with_importance(str(tmp_path), "小天", new_facts)
+            fs._facts.pop("小天", None)
+
+            calls_before = llm_calls["n"]
+            await re.synthesize_reflections("小天")
+            assert llm_calls["n"] == calls_before + 1, (
+                "新 fact 改变 unabsorbed 全集 → 退避 key 变 → 应复位重试，"
+                "而不是按旧 rid 永久跳过"
+            )

--- a/tests/unit/test_reflection_idempotent.py
+++ b/tests/unit/test_reflection_idempotent.py
@@ -360,11 +360,12 @@ async def test_synth_failure_bumps_backoff_and_dead_letters(tmp_path):
             f"dead-letter 后不应再调 LLM；实际调了 {llm_call_count['n']} 次"
         )
 
-        # backoff 文件落了该 rid 的计数
+        # backoff 文件落了该 rid 的计数（新格式 {key: {"n", "at"}}）
         from memory.reflection import _reflection_id_from_facts
         rid = _reflection_id_from_facts(sorted(f"f{i}" for i in range(6)))
         backoff = await re._aload_synth_backoff("小天")
-        assert backoff.get(rid) == MEMORY_LIVENESS_MAX_ATTEMPTS
+        assert backoff.get(rid, {}).get("n") == MEMORY_LIVENESS_MAX_ATTEMPTS
+        assert backoff.get(rid, {}).get("at"), "失败应戳上时间戳供自愈"
 
 
 @pytest.mark.asyncio
@@ -390,7 +391,7 @@ async def test_synth_success_clears_backoff(tmp_path):
         rid = _reflection_id_from_facts(sorted(fact_ids))
         # 预置一条失败退避记录
         await re._abump_synth_backoff("小天", rid, "seed failure")
-        assert (await re._aload_synth_backoff("小天")).get(rid) == 1
+        assert (await re._aload_synth_backoff("小天")).get(rid, {}).get("n") == 1
 
         async def _fake_ainvoke(self, prompt):
             resp = MagicMock()
@@ -495,4 +496,69 @@ async def test_synth_dead_letter_resets_when_full_input_changes(tmp_path):
             assert llm_calls["n"] == calls_before + 1, (
                 "新 fact 改变 unabsorbed 全集 → 退避 key 变 → 应复位重试，"
                 "而不是按旧 rid 永久跳过"
+            )
+
+
+@pytest.mark.asyncio
+async def test_synth_dead_letter_self_heals_after_cooldown(tmp_path):
+    """池子不变（挂机）时，dead-letter 过 5h 冷却后应放行一次 probe。
+
+    模拟方式：把失败记录的时间戳手动改成 6h 前，再调 synthesize，断言 LLM
+    被重新调用（cooldown_elapsed → 不再跳过）。
+    """
+    import json
+    from datetime import datetime, timedelta
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    mock_cm = _build_mock_cm(str(tmp_path))
+    _write_unabsorbed_facts(str(tmp_path), "小天", [f"f{i}" for i in range(6)])
+
+    with patch("memory.reflection.get_config_manager", return_value=mock_cm), \
+         patch("memory.facts.get_config_manager", return_value=mock_cm):
+        from memory.facts import FactStore
+        from memory.persona import PersonaManager
+        from memory.reflection import ReflectionEngine, _reflection_id_from_facts
+
+        fs = FactStore()
+        fs._config_manager = mock_cm
+        pm = PersonaManager()
+        pm._config_manager = mock_cm
+        re = ReflectionEngine(fs, pm)
+        re._config_manager = mock_cm
+
+        llm_calls = {"n": 0}
+
+        async def _fail_ainvoke(self, prompt):
+            llm_calls["n"] += 1
+            resp = MagicMock()
+            resp.content = "not json"
+            return resp
+
+        class _FakeLLM:
+            def __init__(self, *a, **kw): pass
+            ainvoke = _fail_ainvoke
+
+            async def aclose(self):
+                return None
+
+        with patch("utils.llm_client.create_chat_llm", _FakeLLM), \
+             patch("config.prompts.prompts_memory.get_reflection_prompt", lambda lang: "{FACTS}|{LANLAN_NAME}|{MASTER_NAME}"), \
+             patch("utils.language_utils.get_global_language", return_value="zh"):
+            for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS + 2):
+                assert await re.synthesize_reflections("小天") == []
+            assert llm_calls["n"] == MEMORY_LIVENESS_MAX_ATTEMPTS  # 已 dead-letter
+
+            # 把失败时间戳改到 6h 前（池子完全不变）
+            key = _reflection_id_from_facts(sorted(f"f{i}" for i in range(6)))
+            bpath = re._synth_backoff_path("小天")
+            with open(bpath, encoding="utf-8") as f:
+                backoff = json.load(f)
+            backoff[key]["at"] = (datetime.now() - timedelta(hours=6)).isoformat()
+            with open(bpath, "w", encoding="utf-8") as f:
+                json.dump(backoff, f, ensure_ascii=False)
+
+            calls_before = llm_calls["n"]
+            await re.synthesize_reflections("小天")
+            assert llm_calls["n"] == calls_before + 1, (
+                "冷却期已过应放行一次 probe（时间自愈），即使池子没变"
             )

--- a/tests/unit/test_reflection_idempotent.py
+++ b/tests/unit/test_reflection_idempotent.py
@@ -305,3 +305,111 @@ async def test_synth_concurrent_dedup_returns_empty(tmp_path):
         )
         # 我们这次没真正 save（dedup 命中跳过 append+save）
         assert save_called["n"] == 0
+
+
+# ── synth 失败退避 / dead-letter（用户审计 #2）────────────────────
+
+
+@pytest.mark.asyncio
+async def test_synth_failure_bumps_backoff_and_dead_letters(tmp_path):
+    """LLM 持续失败 → 每次 bump synth_backoff，达 MEMORY_LIVENESS_MAX_ATTEMPTS
+    后 synthesize 不再调 LLM（dead-letter），不再每 180s 原样空烧。"""
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    mock_cm = _build_mock_cm(str(tmp_path))
+    _write_unabsorbed_facts(str(tmp_path), "小天", [f"f{i}" for i in range(6)])
+
+    with patch("memory.reflection.get_config_manager", return_value=mock_cm), \
+         patch("memory.facts.get_config_manager", return_value=mock_cm):
+        from memory.facts import FactStore
+        from memory.persona import PersonaManager
+        from memory.reflection import ReflectionEngine
+
+        fs = FactStore()
+        fs._config_manager = mock_cm
+        pm = PersonaManager()
+        pm._config_manager = mock_cm
+        re = ReflectionEngine(fs, pm)
+        re._config_manager = mock_cm
+
+        llm_call_count = {"n": 0}
+
+        async def _fake_ainvoke(self, prompt):
+            llm_call_count["n"] += 1
+            resp = MagicMock()
+            # 非 dict → 触发失败分支（non-dict response）
+            resp.content = "not a json object at all"
+            return resp
+
+        class _FakeLLM:
+            def __init__(self, *a, **kw): pass
+            ainvoke = _fake_ainvoke
+
+            async def aclose(self):
+                return None
+
+        with patch("utils.llm_client.create_chat_llm", _FakeLLM), \
+             patch("config.prompts.prompts_memory.get_reflection_prompt", lambda lang: "{FACTS}|{LANLAN_NAME}|{MASTER_NAME}"), \
+             patch("utils.language_utils.get_global_language", return_value="zh"):
+            # 调用 MAX + 3 次：前 MAX 次真正打 LLM 并 bump，之后 dead-letter 跳过
+            for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS + 3):
+                out = await re.synthesize_reflections("小天")
+                assert out == []
+
+        assert llm_call_count["n"] == MEMORY_LIVENESS_MAX_ATTEMPTS, (
+            f"dead-letter 后不应再调 LLM；实际调了 {llm_call_count['n']} 次"
+        )
+
+        # backoff 文件落了该 rid 的计数
+        from memory.reflection import _reflection_id_from_facts
+        rid = _reflection_id_from_facts(sorted(f"f{i}" for i in range(6)))
+        backoff = await re._aload_synth_backoff("小天")
+        assert backoff.get(rid) == MEMORY_LIVENESS_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_synth_success_clears_backoff(tmp_path):
+    """一次成功合成必须清掉该 rid 的失败退避记录（输入恢复正常即复活）。"""
+    mock_cm = _build_mock_cm(str(tmp_path))
+    fact_ids = [f"f{i}" for i in range(6)]
+    _write_unabsorbed_facts(str(tmp_path), "小天", fact_ids)
+
+    with patch("memory.reflection.get_config_manager", return_value=mock_cm), \
+         patch("memory.facts.get_config_manager", return_value=mock_cm):
+        from memory.facts import FactStore
+        from memory.persona import PersonaManager
+        from memory.reflection import ReflectionEngine, _reflection_id_from_facts
+
+        fs = FactStore()
+        fs._config_manager = mock_cm
+        pm = PersonaManager()
+        pm._config_manager = mock_cm
+        re = ReflectionEngine(fs, pm)
+        re._config_manager = mock_cm
+
+        rid = _reflection_id_from_facts(sorted(fact_ids))
+        # 预置一条失败退避记录
+        await re._abump_synth_backoff("小天", rid, "seed failure")
+        assert (await re._aload_synth_backoff("小天")).get(rid) == 1
+
+        async def _fake_ainvoke(self, prompt):
+            resp = MagicMock()
+            resp.content = '{"reflection": "主人 likes tea", "entity": "master"}'
+            return resp
+
+        class _FakeLLM:
+            def __init__(self, *a, **kw): pass
+            ainvoke = _fake_ainvoke
+
+            async def aclose(self):
+                return None
+
+        with patch("utils.llm_client.create_chat_llm", _FakeLLM), \
+             patch("config.prompts.prompts_memory.get_reflection_prompt", lambda lang: "{FACTS}|{LANLAN_NAME}|{MASTER_NAME}"), \
+             patch("utils.language_utils.get_global_language", return_value="zh"):
+            out = await re.synthesize_reflections("小天")
+            assert len(out) == 1
+
+        assert rid not in (await re._aload_synth_backoff("小天")), (
+            "成功合成后应清掉该 rid 的失败退避记录"
+        )

--- a/tests/unit/test_reflection_idempotent.py
+++ b/tests/unit/test_reflection_idempotent.py
@@ -506,7 +506,6 @@ async def test_synth_dead_letter_self_heals_after_cooldown(tmp_path):
     模拟方式：把失败记录的时间戳手动改成 6h 前，再调 synthesize，断言 LLM
     被重新调用（cooldown_elapsed → 不再跳过）。
     """
-    import json
     from datetime import datetime, timedelta
     from config import MEMORY_LIVENESS_MAX_ATTEMPTS
 
@@ -548,17 +547,67 @@ async def test_synth_dead_letter_self_heals_after_cooldown(tmp_path):
                 assert await re.synthesize_reflections("小天") == []
             assert llm_calls["n"] == MEMORY_LIVENESS_MAX_ATTEMPTS  # 已 dead-letter
 
-            # 把失败时间戳改到 6h 前（池子完全不变）
+            # 把失败时间戳改到 6h 前（池子完全不变）。退避现在以进程内镜像为准，
+            # 改镜像而非磁盘文件。
             key = _reflection_id_from_facts(sorted(f"f{i}" for i in range(6)))
-            bpath = re._synth_backoff_path("小天")
-            with open(bpath, encoding="utf-8") as f:
-                backoff = json.load(f)
-            backoff[key]["at"] = (datetime.now() - timedelta(hours=6)).isoformat()
-            with open(bpath, "w", encoding="utf-8") as f:
-                json.dump(backoff, f, ensure_ascii=False)
+            re._synth_backoff_mem["小天"][key]["at"] = (
+                datetime.now() - timedelta(hours=6)
+            ).isoformat()
 
             calls_before = llm_calls["n"]
             await re.synthesize_reflections("小天")
             assert llm_calls["n"] == calls_before + 1, (
                 "冷却期已过应放行一次 probe（时间自愈），即使池子没变"
             )
+
+
+@pytest.mark.asyncio
+async def test_synth_backoff_survives_disk_write_failure(tmp_path):
+    """synth_backoff 写盘一直失败（只读 FS / 权限）时，进程内镜像仍累计失败
+    计数 → dead-letter 照常在 MAX 次后生效，不会每 180s 重打 LLM（Codex P2）。"""
+    from unittest.mock import AsyncMock
+    from config import MEMORY_LIVENESS_MAX_ATTEMPTS
+
+    mock_cm = _build_mock_cm(str(tmp_path))
+    _write_unabsorbed_facts(str(tmp_path), "小天", [f"f{i}" for i in range(6)])
+
+    with patch("memory.reflection.get_config_manager", return_value=mock_cm), \
+         patch("memory.facts.get_config_manager", return_value=mock_cm):
+        from memory.facts import FactStore
+        from memory.persona import PersonaManager
+        from memory.reflection import ReflectionEngine
+
+        fs = FactStore()
+        fs._config_manager = mock_cm
+        pm = PersonaManager()
+        pm._config_manager = mock_cm
+        re = ReflectionEngine(fs, pm)
+        re._config_manager = mock_cm
+
+        llm_calls = {"n": 0}
+
+        async def _fail_ainvoke(self, prompt):
+            llm_calls["n"] += 1
+            resp = MagicMock()
+            resp.content = "not json"
+            return resp
+
+        class _FakeLLM:
+            def __init__(self, *a, **kw): pass
+            ainvoke = _fail_ainvoke
+
+            async def aclose(self):
+                return None
+
+        with patch("utils.llm_client.create_chat_llm", _FakeLLM), \
+             patch("config.prompts.prompts_memory.get_reflection_prompt", lambda lang: "{FACTS}|{LANLAN_NAME}|{MASTER_NAME}"), \
+             patch("utils.language_utils.get_global_language", return_value="zh"), \
+             patch("memory.reflection.atomic_write_json_async",
+                   AsyncMock(side_effect=OSError("read-only fs"))):
+            for _ in range(MEMORY_LIVENESS_MAX_ATTEMPTS + 3):
+                assert await re.synthesize_reflections("小天") == []
+
+        assert llm_calls["n"] == MEMORY_LIVENESS_MAX_ATTEMPTS, (
+            f"写盘失败不应丢失失败计数；dead-letter 应在 MAX 次后生效，"
+            f"实际调了 {llm_calls['n']} 次 LLM"
+        )


### PR DESCRIPTION
## 背景

四处后台记忆任务在"瞬态失败其实是持续性故障"时**没有放弃/退避标记**，靠周期 loop 无脑重试。判据：in-place 重试耗尽后有没有持久化一个跳过标记让下一轮周期 tick 跳过它——没有的就危险（挂机无脑重烧）。

最严重的 `memory_review` 已被日志实锤：`correction` 模型持续超时 → review 每轮 3×110s 超时后返回 `'failed'`，既不刷 `last_review_ts` 也不退避，配合长挂机 bypass（idle≥30min 主动绕过新消息门）主动给死循环续命 → 整夜每 ~6min 无限空烧。

## 统一修复原则

任何失败（尤其超时）连试 N 次后都落一个**持久化**的退避/放弃标记，下一轮周期跳过、直到输入内容有变化才复位；**瞬态失败也计入预算**（不能永不计）。N 复用既有的 `MEMORY_LIVENESS_MAX_ATTEMPTS`。

## 改动

- **#1 `memory_review`**（`app/memory_server.py`）：`_run_review_in_background` 的 `'failed'` 分支 bump `review_fail_attempts` + 记下失败输入的 tail fingerprint（持久化到 `idle_maintenance_state.json`）；`'patched'`/`'white'` 清空。新增 **Gate 6**：`attempts ≥ MAX` 且当前 history tail fingerprint == 失败记录时跳过 spawn——放在长挂机 bypass **之后**以压过它。输入一变（master 发新消息）→ 复位重试。`cancel_correction` 触发的取消不计入失败。
- **#2 reflection 合成**（`memory/reflection.py`）：新增 `synth_backoff.json` 按 `rid` 计数；dead-letter 后不再每 180s 原样空跑 LLM。`rid` 由 `source_fact_ids` 决定，facts 一变 rid 即变、计数天然复位。
- **#3 recheck**（`memory/facts.py` + `memory/reflection.py`）：fact / reflection 的 **save 落盘失败**路径也 bump `recheck_attempts`，否则 cloudsave 维护态 / 只读 FS / 权限导致的持续写盘失败让熔断永不触发、每 30s 重判。
- **#4 refine**（`memory/refine.py`）：异常路径也走 `failure_fn` 计入 `refine_attempts`。修正先前 Codex P1 "异常按 transient 不计" 的设计——当"瞬态"其实是持续性的（模型快照下线一直超时），不计数就变成每 30min 重打的无限风暴。N 次预算足够跨过偶发抖动，cluster 内容变即复位。

## 测试

- 新增 `tests/unit/test_memory_review_backoff.py`：Gate 6 跳过 / 输入变化复位并 spawn、`'failed'` bump、cancel 不计、`'patched'` 清空。
- `tests/unit/test_reflection_idempotent.py` 追加两条：synth 连续失败 dead-letter 后停调 LLM、成功合成清退避。
- 翻转 `tests/unit/test_memory_liveness_dead_letter.py` 中固化旧 "异常不调 failure_fn" 行为的回归用例。
- memory 相关 139 条全过。

## 已知边界（不修，flag 一下）

#3 的"FS 全局只读"退化场景：写盘普遍失败时 bump 出来的计数本身也存不下，理论上仍无法 dead-letter。但本 PR 覆盖的主场景（LLM 挂、磁盘正常，即截图里的情况）完全收敛。要不要再加一层内存兜底可另议。

## Test plan

- [x] `uv run pytest tests/unit/test_memory_review_backoff.py tests/unit/test_reflection_idempotent.py tests/unit/test_memory_liveness_dead_letter.py tests/unit/test_refine_engine.py tests/unit/test_persona_refine_apply.py tests/unit/test_reflection_refine_apply.py tests/unit/test_reflection_synthesis_loop.py tests/unit/test_review_history_memo_preservation.py tests/unit/test_memory_temporal.py tests/unit/test_memory_server_cache_settle.py`（139 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 引入“死信冷却自愈”机制：达到失败上限后会在配置的冷却窗口允许一次探测重试，并提供冷却判定工具与配置常量。

* **Bug Fixes**
  * 统一并强化失败退避/死信策略：异常或保存失败会计入退避；相同输入重复失败会暂时跳过，输入变化或冷却期后可重试；成功或白审清除退避状态，取消不计入失败预算；失败计数与时间戳将持久化支持自愈。

* **Tests**
  * 新增/更新大量单元测试，覆盖退避、死信、自愈、指纹变更、取消与异常场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->