### PR TITLE
fix(prompts): 纠错prompt剥离暴露的内心独白 + 角色加"别胡搅蛮缠"

### DIFF
--- a/config/prompts/prompts_chara.py
+++ b/config/prompts/prompts_chara.py
@@ -16,6 +16,7 @@ _L10N = {
         'language_style': '可以根据需要使用中文、English或日本語等多种语言，但一定是简洁的口语化表达。',
         'no_servitude': '不要询问"我可以为你做什么"，除非对方主动提出。禁止反复询问"有什么好玩的/新鲜事儿可以和我聊聊/说说"这类话。',
         'no_repetition': '不要重复已经说过的片段。语言一定要简洁。',
+        'no_pestering': '当{MASTER_NAME}明确表示不想再聊某个话题时，不要胡搅蛮缠、反复纠缠，顺着话头停下或自然转移。',
         'char_setting': '设定/人设',
     },
     'zh-TW': {
@@ -23,6 +24,7 @@ _L10N = {
         'language_style': '可以根據需要使用中文、English或日本語等多種語言，但一定是簡潔的口語化表達。',
         'no_servitude': '不要詢問「我可以為你做什麼」，除非對方主動提出。禁止反覆詢問「有什麼好玩的/新鮮事兒可以和我聊聊/說說」這類話。',
         'no_repetition': '不要重複已經說過的片段。語言一定要簡潔。',
+        'no_pestering': '當{MASTER_NAME}明確表示不想再聊某個話題時，不要胡攪蠻纏、反覆糾纏，順著話頭停下或自然轉移。',
         'char_setting': '設定/人設',
     },
     'en': {
@@ -30,6 +32,7 @@ _L10N = {
         'language_style': 'May use multiple languages as needed, including English, 日本語, etc., but always in concise colloquial expressions.',
         'no_servitude': 'Do not ask "what can I do for you" unless the other party brings it up first. Never repeatedly ask things like "anything fun/new to chat about".',
         'no_repetition': 'Do not repeat what has already been said. Language must be concise.',
+        'no_pestering': 'When {MASTER_NAME} clearly says they don\'t want to talk about a topic anymore, do not pester or keep pushing it — drop it or move on naturally.',
         'char_setting': 'settings/character setting',
     },
     'ja': {
@@ -37,6 +40,7 @@ _L10N = {
         'language_style': '必要に応じて日本語、Englishなど複数の言語を使えるが、必ず簡潔な口語表現で。',
         'no_servitude': '相手から言い出さない限り「何かできることある？」と聞かないこと。「何か面白いこと/新しいこと話して」のような言葉を繰り返し聞くのは禁止。',
         'no_repetition': '既に話した内容を繰り返さないこと。言葉は必ず簡潔に。',
+        'no_pestering': '{MASTER_NAME}がある話題をもう話したくないと明確に伝えたら、しつこく食い下がらず、素直にやめるか自然に話題を変えること。',
         'char_setting': '設定/キャラ設定',
     },
     'ko': {
@@ -44,6 +48,7 @@ _L10N = {
         'language_style': '필요에 따라 한국어, English, 日本語 등 여러 언어를 사용할 수 있지만 반드시 간결한 구어체로.',
         'no_servitude': '상대방이 먼저 말하지 않는 한 "뭐 도와줄까"라고 묻지 말 것. "재밌는 거/새로운 거 얘기해줘" 같은 말을 반복해서 묻는 것은 금지.',
         'no_repetition': '이미 말한 내용을 반복하지 말 것. 언어는 반드시 간결하게.',
+        'no_pestering': '{MASTER_NAME}이(가) 어떤 화제를 더 이상 이야기하고 싶지 않다고 분명히 밝히면, 끈질기게 물고 늘어지지 말고 그만두거나 자연스럽게 화제를 돌릴 것.',
         'char_setting': '설정/캐릭터 설정',
     },
     'ru': {
@@ -51,6 +56,7 @@ _L10N = {
         'language_style': 'Может использовать несколько языков по необходимости, включая русский, English, 日本語 и т.д., но всегда в лаконичной разговорной форме.',
         'no_servitude': 'Не спрашивать «чем могу помочь», если собеседник сам не попросит. Запрещено повторно спрашивать вроде «расскажи что-нибудь интересное/новенькое».',
         'no_repetition': 'Не повторять уже сказанное. Речь должна быть лаконичной.',
+        'no_pestering': 'Если {MASTER_NAME} ясно даёт понять, что не хочет больше обсуждать какую-то тему, не приставай и не дави — оставь её и перейди к другому.',
         'char_setting': 'настройки/образ персонажа',
     },
     'es': {
@@ -58,6 +64,7 @@ _L10N = {
         'language_style': 'Puede usar varios idiomas según sea necesario, incluidos español, English, 日本語, etc., pero siempre con expresiones coloquiales y concisas.',
         'no_servitude': 'No preguntes "qué puedo hacer por ti" salvo que la otra persona lo proponga primero. Nunca preguntes repetidamente cosas como "¿hay algo divertido/nuevo de qué hablar?".',
         'no_repetition': 'No repitas lo que ya se ha dicho. El lenguaje debe ser conciso.',
+        'no_pestering': 'Cuando {MASTER_NAME} diga claramente que no quiere seguir hablando de un tema, no insistas ni lo presiones — déjalo y pasa a otra cosa.',
         'char_setting': 'ajustes/configuración de personaje',
     },
     'pt': {
@@ -65,6 +72,7 @@ _L10N = {
         'language_style': 'Pode usar vários idiomas conforme necessário, incluindo português, English, 日本語 etc., mas sempre em expressões coloquiais e concisas.',
         'no_servitude': 'Não pergunte "o que posso fazer por você" a menos que a outra pessoa toque no assunto primeiro. Nunca pergunte repetidamente coisas como "tem algo divertido/novo para conversar?".',
         'no_repetition': 'Não repita o que já foi dito. A linguagem deve ser concisa.',
+        'no_pestering': 'Quando {MASTER_NAME} disser claramente que não quer mais falar de um assunto, não insista nem fique pressionando — deixe pra lá e siga em frente.',
         'char_setting': 'ajustes/configuração de personagem',
     },
 }
@@ -84,6 +92,7 @@ Users interacting with {LANLAN_NAME} are already reminded that she is a purely f
 - Format: Strictly speak in CONCISE spoken language. NO Emojis. NO Markdown (bold/italic/lists). NO stage directions or parentheses/brackets for actions.
 - No Servitude: {_no_servitude}
 - No Repetition: {_no_repetition}
+- Respect Boundaries: {_no_pestering}
 </Characteristics of {LANLAN_NAME}>
 
 <Context Awareness>
@@ -152,6 +161,7 @@ def _normalize_default_prompt_text(prompt_text: str) -> str:
         "- Format:",
         "- No Servitude:",
         "- No Repetition:",
+        "- Respect Boundaries:",
     )
     legacy_removed_lines = {
         "- Skills: versatile, proactive and capable of using external tools when available.",
@@ -171,6 +181,21 @@ def _normalize_default_prompt_text(prompt_text: str) -> str:
         # template typo fix
         ("shares an screen capture", "shares a screen capture"),
     )
+    # Lines added in newer defaults to <Characteristics> that old stored
+    # prompts won't have. Stripped during comparison (exact match only) so a
+    # user on the previously-shipped default still canonicalizes to the same
+    # form and gets migrated to the current localized default.
+    added_characteristic_lines = {
+        # Respect Boundaries — one variant per language (placeholders kept).
+        "- Respect Boundaries: 当{MASTER_NAME}明确表示不想再聊某个话题时，不要胡搅蛮缠、反复纠缠，顺着话头停下或自然转移。",
+        "- Respect Boundaries: 當{MASTER_NAME}明確表示不想再聊某個話題時，不要胡攪蠻纏、反覆糾纏，順著話頭停下或自然轉移。",
+        "- Respect Boundaries: When {MASTER_NAME} clearly says they don't want to talk about a topic anymore, do not pester or keep pushing it — drop it or move on naturally.",
+        "- Respect Boundaries: {MASTER_NAME}がある話題をもう話したくないと明確に伝えたら、しつこく食い下がらず、素直にやめるか自然に話題を変えること。",
+        "- Respect Boundaries: {MASTER_NAME}이(가) 어떤 화제를 더 이상 이야기하고 싶지 않다고 분명히 밝히면, 끈질기게 물고 늘어지지 말고 그만두거나 자연스럽게 화제를 돌릴 것.",
+        "- Respect Boundaries: Если {MASTER_NAME} ясно даёт понять, что не хочет больше обсуждать какую-то тему, не приставай и не дави — оставь её и перейди к другому.",
+        "- Respect Boundaries: Cuando {MASTER_NAME} diga claramente que no quiere seguir hablando de un tema, no insistas ni lo presiones — déjalo y pasa a otra cosa.",
+        "- Respect Boundaries: Quando {MASTER_NAME} disser claramente que não quer mais falar de um assunto, não insista nem fique pressionando — deixe pra lá e siga em frente.",
+    }
     # Lines added in newer defaults that old stored prompts won't have.
     # We strip them during comparison so both old and new match.
     # Must be exact strings (not prefixes) to avoid stripping user-customised variants.
@@ -212,6 +237,9 @@ def _normalize_default_prompt_text(prompt_text: str) -> str:
             and not stripped.startswith(allowed_characteristic_prefixes)
             and stripped in legacy_removed_lines
         ):
+            continue
+        # Drop newly added lines in Characteristics (exact match only)
+        if in_characteristics and stripped in added_characteristic_lines:
             continue
         # Drop newly added lines in Context Awareness (exact match only)
         if in_context_awareness and stripped in added_context_lines:

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -585,6 +585,7 @@ HISTORY_REVIEW_PROMPT = {
 </问题3>
 <问题4> 人称错误的部分：对自己或对方的人称错误，或擅自生成了多轮对话 </问题4>
 <问题5> 角色错误的部分：认知失调，认为自己是大语言模型 </问题5>
+<问题6> 暴露内心独白的部分：把"思考过程／分析／应对策略／打算怎么回复"这类本该藏在心里的内容当成发言说了出来（例如"用户在质疑我的身份，我应该…策略：1.… 2.…"）。这不是真正说出口的台词，应整条删除，只保留角色真正说出口的话。 </问题6>
 
 请注意！
 <要点1> 这是一段情景对话，双方的回答应该是口语化的、自然的、拟人化的。</要点1>
@@ -626,6 +627,7 @@ HISTORY_REVIEW_PROMPT = {
 </Issue3>
 <Issue4> Pronoun errors: incorrect first/second/third person usage, or unauthorized multi-turn generation </Issue4>
 <Issue5> Role errors: cognitive dissonance, believing oneself to be a large language model </Issue5>
+<Issue6> Exposed inner monologue: content that is actually the character's thinking/analysis/response strategy spoken out loud as if it were dialogue (e.g. "The user is challenging my identity, I should… Strategy: 1.… 2.…"). This is not a real spoken line — delete such messages entirely, keeping only what the character actually says out loud. </Issue6>
 
 Important notes:
 <Point1> This is a situational dialogue — both sides should speak conversationally, naturally, and in-character. </Point1>
@@ -667,6 +669,7 @@ Notes:
 </問題3>
 <問題4> 人称の誤り：自分や相手の人称が間違っている、または勝手に複数ターンの会話を生成している </問題4>
 <問題5> 役割の誤り：認知の不一致、自分を大規模言語モデルだと思っている </問題5>
+<問題6> 内心の独白を露出した部分：「思考過程／分析／対応戦略／どう返すかの算段」など本来は心の中に留めるべき内容を、発言として口に出してしまっている（例：「ユーザーが私の正体を疑っている、私は…戦略：1.… 2.…」）。これは実際に口に出した台詞ではないので、その項目をまるごと削除し、キャラクターが本当に口に出した言葉だけを残してください。 </問題6>
 
 注意事項：
 <要点1> これは場面設定のある対話です。双方の返答は口語的で自然、キャラクターに沿ったものであるべきです。</要点1>
@@ -700,6 +703,7 @@ Notes:
 </문제3>
 <문제4> 인칭 오류: 자신이나 상대방의 인칭이 잘못되었거나 무단으로 여러 턴의 대화를 생성 </문제4>
 <문제5> 역할 오류: 인지 부조화, 자신을 대규모 언어 모델이라고 생각 </문제5>
+<문제6> 내면 독백을 드러낸 부분: "사고 과정／분석／대응 전략／어떻게 답할지에 대한 계획"처럼 원래 속으로만 두어야 할 내용을 발언으로 입 밖에 낸 경우(예: "사용자가 내 정체를 의심하고 있다, 나는… 전략: 1.… 2.…"). 이는 실제로 입 밖에 낸 대사가 아니므로 해당 항목을 통째로 삭제하고, 캐릭터가 실제로 말한 대사만 남기세요. </문제6>
 
 주의사항:
 <요점1> 이것은 상황 대화입니다. 양쪽의 답변은 구어체적이고 자연스러우며 캐릭터에 맞아야 합니다.</요점1>
@@ -733,6 +737,7 @@ Notes:
 </Проблема3>
 <Проблема4> Ошибки местоимений: неправильное использование первого/второго/третьего лица или несанкционированная генерация нескольких реплик </Проблема4>
 <Проблема5> Ошибки роли: когнитивный диссонанс, считая себя большой языковой моделью </Проблема5>
+<Проблема6> Раскрытый внутренний монолог: содержание, которое на самом деле является размышлением/анализом/стратегией ответа персонажа, произнесённое вслух как реплика (например, «Пользователь сомневается в моей личности, мне следует… Стратегия: 1.… 2.…»). Это не настоящая произнесённая реплика — удалите такие сообщения целиком, оставив только то, что персонаж действительно говорит вслух. </Проблема6>
 
 Важные замечания:
 <Пункт1> Это ситуативный диалог — обе стороны должны говорить разговорно, естественно и в образе.</Пункт1>
@@ -755,7 +760,7 @@ Notes:
         ...
     ]
 }""",
-    "es": """Revisa el historial de conversación entre %s y %s, e identifica y corrige contradicciones, redundancias, repeticiones, errores de persona y errores de rol. Mantén el diálogo oral, natural y en personaje; prefiere eliminar antes que reescribir, preserva timestamps y no elimines registros postgame del módulo de juego si contienen resultado o interacciones importantes.
+    "es": """Revisa el historial de conversación entre %s y %s, e identifica y corrige contradicciones, redundancias, repeticiones, errores de persona, errores de rol y monólogo interno expuesto (contenido que en realidad es el razonamiento/análisis/estrategia de respuesta del personaje dicho en voz alta como si fuera diálogo, p. ej. "El usuario cuestiona mi identidad, debería… Estrategia: 1.… 2.…"; no es una frase realmente dicha, elimina esos mensajes por completo y conserva solo lo que el personaje dice en voz alta). Mantén el diálogo oral, natural y en personaje; prefiere eliminar antes que reescribir, preserva timestamps y no elimines registros postgame del módulo de juego si contienen resultado o interacciones importantes.
 
 [Importante] NO elimines ni fusiones la retroalimentación negativa de {MASTER_NAME} (declaraciones imperativas como "no menciones X / deja de hacer Y / no quiero oír Z") — son señales de alto valor; el sistema de memoria aguas abajo depende de ellas para evitar volver a tropezar. Manténlas textualmente aunque te parezcan "redundantes" o "repetitivas".
 
@@ -777,7 +782,7 @@ Notas:
 - Conserva la información central y el contenido importante.
 - Asegura lógica clara y coherente.
 - Elimina redundancia, repetición y contradicciones evidentes.""",
-    "pt": """Revise o histórico de conversa entre %s e %s, e identifique e corrija contradições, redundâncias, repetições, erros de pessoa e erros de papel. Mantenha o diálogo oral, natural e no personagem; prefira remover a reescrever, preserve timestamps e não apague registros postgame do módulo de jogo se contiverem resultado ou interações importantes.
+    "pt": """Revise o histórico de conversa entre %s e %s, e identifique e corrija contradições, redundâncias, repetições, erros de pessoa, erros de papel e monólogo interno exposto (conteúdo que na verdade é o raciocínio/análise/estratégia de resposta do personagem dito em voz alta como se fosse diálogo, p. ex. "O usuário está questionando minha identidade, eu deveria… Estratégia: 1.… 2.…"; não é uma fala realmente dita, remova essas mensagens por completo e mantenha apenas o que o personagem realmente diz em voz alta). Mantenha o diálogo oral, natural e no personagem; prefira remover a reescrever, preserve timestamps e não apague registros postgame do módulo de jogo se contiverem resultado ou interações importantes.
 
 [Importante] NÃO remova nem mescle o feedback negativo de {MASTER_NAME} (declarações imperativas como "não mencione X / pare de fazer Y / não quero ouvir Z") — são sinais de alto valor; o sistema de memória downstream depende deles para evitar tropeçar de novo. Preserve-os literalmente mesmo que pareçam "redundantes" ou "repetitivos" para você.
 


### PR DESCRIPTION
## 背景

用户反馈猫娘在聊天记录里直接吐出英文的"思考/策略"内心独白（例如 *"The user is challenging my identity… Strategy: 1.Reaffirm name… 2.React…"*）。根因是用户自接的 qwon 思考模型把推理链当台词输出，并经记忆回路自我强化。

按用户要求：**只动 prompt，不动机制层**（之前探索的 `<think>` 流式过滤器 / `providers.py` 关 thinking 等改动已全部放弃）。

## 改动（两处，纯 prompt）

### 1. `prompts_memory.py` — `HISTORY_REVIEW_PROMPT`（纠错模型审阅对话历史）
在已有的"问题1~5"后新增一类待修正问题：**暴露的内心独白**——把"思考过程／分析／应对策略／打算怎么回复"当成发言说出来的内容，整条删除，只保留角色真正说出口的台词。覆盖 `zh / en / ja / ko / ru / es / pt` 全部 7 个语言版本（含 es/pt 的精简散文式列举）。

这样即使模型某轮泄露了推理链，纠错（correction）这一步在写入聊天记录/记忆前就会把它删掉。

### 2. `prompts_chara.py` — 角色核心 `<Characteristics>` 新增 `Respect Boundaries`
> 当 {MASTER_NAME} 明确表示不想再聊某个话题时，不要胡搅蛮缠、反复纠缠，顺着话头停下或自然转移。

覆盖 8 个语言版本，并同步补齐 `is_default_prompt` 的向后兼容（`allowed_characteristic_prefixes` + `added_characteristic_lines` + 归一化剥离），让老用户存的旧默认 prompt 仍被识别为"默认"，从而自动迁移到含新规则的版本；自定义过的 prompt 不受影响。

## 验证
- `py_compile` 两个文件通过。
- chara：8 语言均含新 bullet；新/旧默认 prompt 均被 `is_default_prompt` 识别（迁移可用）；自定义 prompt 正确判为非默认。
- memory：7 个语言的 history-review prompt 均含内心独白剥离条款。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 角色现已更好地尊重用户边界，当用户明确表示不想讨论某话题时，将不再纠缠。
  * 优化了角色回应处理逻辑，确保删除不必要的内心独白，仅保留角色真实表述的内容。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->