### PR TITLE
fix(avatar): 桌宠/Electron 边缘回弹与网页端统一为可见面积阈值

### DIFF
--- a/static/live2d-interaction.js
+++ b/static/live2d-interaction.js
@@ -97,9 +97,6 @@ Live2DManager.prototype._checkSnapRequired = async function (model, options = {}
 
         const threshold = customThreshold ?? SNAP_CONFIG.threshold;
         const margin = SNAP_CONFIG.margin;
-        const isDesktopPetWindow = Boolean(
-            window.electronScreen && typeof window.electronScreen.getCurrentDisplay === 'function'
-        );
 
         // 计算模型在屏幕内剩余的像素数
         const visibleLeft = Math.max(modelLeft, screenLeft);
@@ -109,8 +106,10 @@ Live2DManager.prototype._checkSnapRequired = async function (model, options = {}
         const visibleBottom = Math.min(modelBottom, screenBottom);
         const visibleHeight = Math.max(0, visibleBottom - visibleTop);
 
+        // 桌宠窗口与网页端统一按可见面积阈值吸附：只有模型绝大部分出屏才回弹，
+        // 贴边摆放不会被过度纠正。多屏切换后仍强制按安全边距吸回当前窗口。
         let needsSnapLeft, needsSnapRight, needsSnapTop, needsSnapBottom;
-        if (afterDisplaySwitch || isDesktopPetWindow) {
+        if (afterDisplaySwitch) {
             needsSnapLeft = overflowLeft > margin;
             needsSnapRight = overflowRight > margin;
             needsSnapTop = overflowTop > margin;

--- a/static/mmd-interaction.js
+++ b/static/mmd-interaction.js
@@ -330,21 +330,14 @@ class MMDInteraction {
                     : false;
 
                 if (!displaySwitched) {
-                    const isDesktopPetWindow = Boolean(
-                        window.electronScreen && typeof window.electronScreen.getCurrentDisplay === 'function'
-                    );
-                    if (isDesktopPetWindow) {
-                        // 桌宠窗口需要边缘回弹，避免模型被拖出透明窗口后找不回来。
-                        const snapped = await this._snapModelIntoScreen({ animate: true });
-                        if (!snapped) {
-                            this._savePositionAfterInteraction();
-                        } else if (window.NekoAvatarMultiScreenDragHint &&
-                            typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
-                            window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('mmd');
-                        }
-                    } else {
-                        // 网页端保留普通保存，不做贴边回弹。
+                    // 桌宠窗口与网页端统一：clampModelPosition 已按可见像素(200px)判定，
+                    // 只有模型绝大部分出屏才回弹，贴边摆放不会被过度纠正。
+                    const snapped = await this._snapModelIntoScreen({ animate: true });
+                    if (!snapped) {
                         this._savePositionAfterInteraction();
+                    } else if (window.NekoAvatarMultiScreenDragHint &&
+                        typeof window.NekoAvatarMultiScreenDragHint.recordEdgeBounce === 'function') {
+                        window.NekoAvatarMultiScreenDragHint.recordEdgeBounce('mmd');
                     }
                 }
             }

--- a/tests/unit/test_live2d_interaction_static_contracts.py
+++ b/tests/unit/test_live2d_interaction_static_contracts.py
@@ -8,10 +8,11 @@ def _live2d_source() -> str:
     return (PROJECT_ROOT / "static/live2d-interaction.js").read_text(encoding="utf-8")
 
 
-def test_live2d_web_drag_snap_keeps_visible_area_threshold():
+def test_live2d_drag_snap_keeps_visible_area_threshold_on_all_platforms():
     source = _live2d_source()
 
-    assert "const isDesktopPetWindow = Boolean(" in source
+    # 桌宠窗口不再单独走 margin 回弹，与网页端统一用可见面积阈值。
+    assert "const isDesktopPetWindow = Boolean(" not in source
     assert "const visibleWidth = Math.max(0, visibleRight - visibleLeft);" in source
     assert "const visibleHeight = Math.max(0, visibleBottom - visibleTop);" in source
     assert "const needsSnapHorizontal = visibleWidth < threshold && (overflowLeft > 0 || overflowRight > 0);" in source
@@ -19,10 +20,11 @@ def test_live2d_web_drag_snap_keeps_visible_area_threshold():
     assert "needsSnapBottom = overflowBottom > 0 && needsSnapVertical;" in source
 
 
-def test_live2d_desktop_drag_snap_uses_edge_margin():
+def test_live2d_only_display_switch_uses_edge_margin():
     source = _live2d_source()
 
-    assert "if (afterDisplaySwitch || isDesktopPetWindow) {" in source
+    assert "if (afterDisplaySwitch) {" in source
+    assert "if (afterDisplaySwitch || isDesktopPetWindow) {" not in source
     assert "needsSnapLeft = overflowLeft > margin;" in source
     assert "needsSnapRight = overflowRight > margin;" in source
     assert "needsSnapTop = overflowTop > margin;" in source

--- a/tests/unit/test_mmd_interaction_static_contracts.py
+++ b/tests/unit/test_mmd_interaction_static_contracts.py
@@ -8,22 +8,16 @@ def _mmd_source() -> str:
     return (PROJECT_ROOT / "static/mmd-interaction.js").read_text(encoding="utf-8")
 
 
-def test_mmd_web_pan_drag_preserves_existing_save_without_forced_snap():
+def test_mmd_pan_drag_snaps_on_all_platforms_before_saving_position():
     source = _mmd_source()
     pan_drag_section = source.split("if (!displaySwitched) {", 1)[1].split("// 鼠标离开", 1)[0]
 
-    assert "const isDesktopPetWindow = Boolean(" in source
-    assert "this._savePositionAfterInteraction();" in pan_drag_section
-
-
-def test_mmd_desktop_pan_drag_snaps_before_saving_position():
-    source = _mmd_source()
-    pan_drag_section = source.split("if (!displaySwitched) {", 1)[1].split("// 鼠标离开", 1)[0]
-
-    assert "if (isDesktopPetWindow) {" in pan_drag_section
+    # 桌宠窗口与网页端统一走 clampModelPosition(可见像素阈值)，不再按运行环境分叉。
+    assert "if (isDesktopPetWindow) {" not in pan_drag_section
     assert "const snapped = await this._snapModelIntoScreen({ animate: true });" in pan_drag_section
     assert "if (!snapped) {" in pan_drag_section
     assert "this._savePositionAfterInteraction();" in pan_drag_section
+    assert "recordEdgeBounce('mmd')" in pan_drag_section
 
 
 def test_mmd_display_switch_snaps_to_target_screen_before_saving_position():


### PR DESCRIPTION
## 改动内容

#1460 为 PC/Electron 桌宠窗口单独保留了 `overflow > margin(5px)` 的强制回弹（理由：避免模型被拖出透明窗口后找不回来）。但这条对桌宠生效后，模型一贴屏幕边缘就立刻被吸回，桌宠根本没法摆到边缘——基本不可用。

本 PR 让 Electron 与网页端统一行为：

- **Live2D**：`_checkSnapRequired` 去掉 `isDesktopPetWindow` 分叉。普通拖拽 web/Electron 统一按**可见面积阈值（200px）**回弹——只有模型绝大部分出屏才吸回，贴边摆放不会被过度纠正。`afterDisplaySwitch`（多屏切换后）仍按安全 margin 强制吸回当前窗口，保持不变。
- **MMD**：拖拽结束去掉 `isDesktopPetWindow` 分叉，两端统一走 `_snapModelIntoScreen`。其 `clampModelPosition` 本就是 200px 可见像素判定，所以从来没有"贴边即回弹"问题——PR #1460 对 MMD 的拆分其实是多余的。改后与**未改动的 VRM 行为完全一致**。
- **安全网不丢失**：可见像素 < 200px 时仍会吸回，模型不会被拖出屏幕彻底找不回。

改完 Live2D / MMD / VRM 三者统一为「web 与 Electron 都用可见面积 200px 阈值，仅多屏切换时按 margin 强制吸回」。

## 背景

#1442 引入多屏拖拽提示后，普通拖拽吸附从"可见面积不足才吸回"变成"超 margin 就吸回"。#1460 修复了网页端，却把回弹保护用 `isDesktopPetWindow` 留给了 Electron，结果桌宠继承了那条不可用的激进回弹。

## 验证

- `node --check static/live2d-interaction.js && node --check static/mmd-interaction.js`
- `uv run python -m pytest tests/unit/test_avatar_multiscreen_drag_hint_static_contracts.py tests/unit/test_live2d_interaction_static_contracts.py tests/unit/test_mmd_interaction_static_contracts.py`

结果：14 passed

> 注：拖拽吸附是实机交互行为，静态契约测试只能锁住分支逻辑，真机桌宠（Electron）边缘摆放需手动确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化了拖拽时的窗口吸附逻辑，使桌宠窗口与网页端的行为保持一致，基于可见面积阈值而非特殊的边距判定
* 调整了边缘回弹机制，统一应用于所有平台，提升拖拽体验的稳定性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->