### PR TITLE
fix(livestream): free 路 livestream 走原生视觉，不再绕分析通道

### DIFF
--- a/main_logic/omni_realtime_client.py
+++ b/main_logic/omni_realtime_client.py
@@ -416,12 +416,21 @@ class OmniRealtimeClient:
             and not bool(livestream_mode)
         )
 
+        # free 经 Gemini 代理（OpenAI-realtime 协议，发图走 input_image_buffer.append、
+        # 服务端 VAD 由代理吞掉）：lanlan.app 海外节点，或 livestream 主播自建 server_prefix。
+        # 二者上游同为 Gemini 系，原生视觉与发图协议一致；lanlan.tech free 上游是
+        # StepFun（无原生视觉，走 VISION_MODEL 分析通道），不在此列。
+        self._is_free_proxy = 'free' in self._model_lower and (
+            'lanlan.app' in (base_url or '')
+            or bool(livestream_mode)
+        )
+
         # Whether this client supports native image input
-        # qwen/glm/gpt/gemini have native vision; lanlan.app replacement server (free, non-mainland) also does
+        # qwen/glm/gpt/gemini have native vision; free Gemini-proxy (lanlan.app / livestream) also does
         self._supports_native_image = (
             any(m in self._model_lower for m in ['qwen', 'glm', 'gpt'])
             or self._is_gemini
-            or ('lanlan.app' in (base_url or '') and 'free' in self._model_lower)
+            or self._is_free_proxy
         )
         self._gemini_client = None  # genai.Client instance
         self._gemini_session = None  # Live session from SDK
@@ -1372,7 +1381,7 @@ class OmniRealtimeClient:
                             self._fatal_error_occurred = True
                 return
 
-            if ('lanlan.app' in self.base_url and 'free' in self._model_lower):
+            if self._is_free_proxy:
                 append_event = {
                     "type": "input_image_buffer.append" ,
                     "image": image_b64
@@ -1787,7 +1796,7 @@ class OmniRealtimeClient:
                                 }],
                             },
                         })
-                    elif "qwen" in self._model_lower or ("lanlan.app" in self.base_url and "free" in self._model_lower):
+                    elif "qwen" in self._model_lower or self._is_free_proxy:
                         await self.send_event({
                             "type": "input_image_buffer.append",
                             "image": snapshot_image_b64,

--- a/tests/unit/test_video_session.py
+++ b/tests/unit/test_video_session.py
@@ -136,14 +136,64 @@ async def test_non_native_vision_fallback():
     client = _make_client("step-realtime", supports_native_image=False)
     # Mark the image description as "analyzing" to trigger the vision model path
     client._image_description = "实时屏幕截图或相机画面正在分析中"
-    
+
     # Mock the _analyze_image_with_vision_model method
     client._analyze_image_with_vision_model = AsyncMock()
-    
+
     await client.stream_image(DUMMY_IMAGE_B64)
-    
+
     # Should have called vision model fallback
     assert client._analyze_image_with_vision_model.called
     assert client._analyze_image_with_vision_model.call_args[0][0] == DUMMY_IMAGE_B64
-    
+
+    await client.close()
+
+
+@pytest.mark.unit
+def test_livestream_free_supports_native_vision():
+    """Livestream 主播自建 server_prefix 上游同为 Gemini 系，free 路应被判定为原生视觉，
+    哪怕 base_url 既不含 lanlan.app 也不含 lanlan.tech（已被派生为自建地址）。"""
+    client = OmniRealtimeClient(
+        base_url="ws://streamer.example:8080/tok/core",
+        api_key="test-key",
+        model="free-model",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="free",
+        livestream_mode=True,
+    )
+    assert client._is_free_proxy is True
+    assert client._supports_native_image is True
+    # livestream 自建上游是 Gemini 系，不应被当成有 server VAD 的 StepFun proxy
+    assert client._has_server_vad is False
+
+
+@pytest.mark.unit
+async def test_livestream_free_image_streaming():
+    """Livestream free 发图应走 input_image_buffer.append（Gemini 代理协议），
+    不落入 VISION_MODEL 分析通道。"""
+    client = OmniRealtimeClient(
+        base_url="ws://streamer.example:8080/tok/core",
+        api_key="test-key",
+        model="free-model",
+        turn_detection_mode=TurnDetectionMode.SERVER_VAD,
+        api_type="free",
+        livestream_mode=True,
+    )
+    client.ws = AsyncMock()
+    client._audio_in_buffer = True
+    client._last_native_image_time = 0
+    client._analyze_image_with_vision_model = AsyncMock()
+
+    await client.stream_image(DUMMY_IMAGE_B64)
+
+    assert not client._analyze_image_with_vision_model.called, (
+        "Livestream free 不应走分析通道"
+    )
+    image_event_found = False
+    for call_args in client.ws.send.call_args_list:
+        msg = json.loads(call_args[0][0])
+        if msg.get("type") == "input_image_buffer.append":
+            image_event_found = True
+            assert msg["image"] == DUMMY_IMAGE_B64
+    assert image_event_found, "Expected input_image_buffer.append event for livestream free"
     await client.close()


### PR DESCRIPTION
## 背景
livestream 模式下 free 走主播自建 `server_prefix`，base_url 被 `_derive_livestream_url` 派生成自建地址（既不含 `lanlan.app` 也不含 `lanlan.tech`）。但 `OmniRealtimeClient` 判定原生视觉时只认 `lanlan.app + free`，于是 livestream free 被当成"无原生视觉" → 每帧都丢进 `VISION_MODEL` 分析通道转文字描述，多一次额外模型调用、画面延迟、且文字描述不如原生看图准。

实际上 livestream 上游同为 Gemini 系（`_has_server_vad` 那段注释早已确认"主播自建 server_prefix 上游同样是 Gemini 系，不发 OpenAI 协议的 VAD 帧"），原生视觉 + 发图协议（`input_image_buffer.append`）与 `lanlan.app+free` 完全一致。

## 改动
- 抽出共享谓词 `self._is_free_proxy`（free 经 Gemini 代理：`lanlan.app` 海外节点 **或** livestream 自建），替换三处原先散落的 `'lanlan.app' in base_url and 'free'` 字面判断：
  - `_supports_native_image`
  - `stream_image` 实时发图分支
  - `prompt_ephemeral` 主动注入截图分支
- `lanlan.tech free`（上游 StepFun，无原生视觉）不在此列，仍走分析通道，行为不变。
- `_has_server_vad` 未改（它本就已单独 OR 了 livestream）。

## Test plan
- [x] `tests/unit/test_video_session.py` — 新增 livestream free 原生视觉判定 + 发图路径回归（7 passed）
- [x] `tests/unit/test_voice_session.py` — VAD 矩阵回归未受影响（25 passed, 3 skipped）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **错误修复**
  * 改进了免费代理模式和直播模式下的识别逻辑，确保正确判断原生视觉输入能力。
  * 优化了图像流处理路径，使其在特定场景下的行为更加一致。

* **测试**
  * 新增单元测试，验证直播免费模式下的视觉能力识别与图像流传输功能。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->