### PR TITLE
refactor(study-companion): 解耦 galgame 命名空间依赖

### DIFF
--- a/plugin/plugins/_shared/__init__.py
+++ b/plugin/plugins/_shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared plugin helpers that are not owned by a single user plugin."""

--- a/plugin/plugins/_shared/rapidocr/__init__.py
+++ b/plugin/plugins/_shared/rapidocr/__init__.py
@@ -1,0 +1,25 @@
+"""Shared RapidOCR runtime, model download, and OCR backend helpers."""
+
+from .ocr_backends import RapidOcrBackend
+from .rapidocr_support import (
+    DEFAULT_RAPIDOCR_ENGINE_TYPE,
+    DEFAULT_RAPIDOCR_LANG_TYPE,
+    DEFAULT_RAPIDOCR_MODEL_TYPE,
+    DEFAULT_RAPIDOCR_OCR_VERSION,
+    RAPIDOCR_PACKAGE_NAME,
+    download_rapidocr_models,
+    inspect_rapidocr_installation,
+    load_rapidocr_runtime,
+)
+
+__all__ = [
+    "DEFAULT_RAPIDOCR_ENGINE_TYPE",
+    "DEFAULT_RAPIDOCR_LANG_TYPE",
+    "DEFAULT_RAPIDOCR_MODEL_TYPE",
+    "DEFAULT_RAPIDOCR_OCR_VERSION",
+    "RAPIDOCR_PACKAGE_NAME",
+    "RapidOcrBackend",
+    "download_rapidocr_models",
+    "inspect_rapidocr_installation",
+    "load_rapidocr_runtime",
+]

--- a/plugin/plugins/_shared/rapidocr/_inspect_download.py
+++ b/plugin/plugins/_shared/rapidocr/_inspect_download.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.util
+import inspect
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+from ._model_registry import (
+    DEFAULT_RAPIDOCR_ENGINE_TYPE,
+    DEFAULT_RAPIDOCR_LANG_TYPE,
+    DEFAULT_RAPIDOCR_MODEL_TYPE,
+    DEFAULT_RAPIDOCR_OCR_VERSION,
+    RAPIDOCR_PACKAGE_NAME,
+    _RAPIDOCR_MODELSCOPE_BASE,
+    missing_rapidocr_model_files,
+    rapidocr_selected_model_name,
+    required_rapidocr_model_files,
+)
+from ._paths import (
+    _rapidocr_install_state_path,
+    is_windows_platform,
+    resolve_rapidocr_install_target,
+    resolve_rapidocr_model_cache_dir,
+    resolve_rapidocr_runtime_dir,
+    resolve_rapidocr_site_packages_dir,
+)
+from . import _runtime
+
+
+def inspect_rapidocr_installation(
+    *,
+    install_target_dir_raw: str,
+    engine_type: str = DEFAULT_RAPIDOCR_ENGINE_TYPE,
+    lang_type: str = DEFAULT_RAPIDOCR_LANG_TYPE,
+    model_type: str = DEFAULT_RAPIDOCR_MODEL_TYPE,
+    ocr_version: str = DEFAULT_RAPIDOCR_OCR_VERSION,
+    platform_fn: Callable[[], bool] | None = None,
+) -> dict[str, Any]:
+    checker = platform_fn or is_windows_platform
+    supported = bool(checker())
+    target_dir = resolve_rapidocr_install_target(install_target_dir_raw)
+    runtime_dir = resolve_rapidocr_runtime_dir(install_target_dir_raw)
+    site_packages_dir = resolve_rapidocr_site_packages_dir(install_target_dir_raw)
+    model_cache_dir = resolve_rapidocr_model_cache_dir(install_target_dir_raw)
+    package_dir = _runtime._rapidocr_package_dir(install_target_dir_raw)
+    install_state_path = _rapidocr_install_state_path(install_target_dir_raw)
+    selected_model = rapidocr_selected_model_name(
+        ocr_version=ocr_version,
+        lang_type=lang_type,
+        model_type=model_type,
+    )
+    detail = "missing"
+    detected_path = str(package_dir) if package_dir.exists() else ""
+    install_state: dict[str, Any] = {}
+    runtime_error = ""
+
+    # Legacy install_state.json holds metadata about which model variant the
+    # plugin-isolated install picked. Read it as a hint for callers; the bundled
+    # path (post-refactor) never writes it, so absence is fine.
+    if supported and install_state_path.is_file():
+        try:
+            install_state_payload = json.loads(install_state_path.read_text(encoding="utf-8"))
+            if isinstance(install_state_payload, dict):
+                install_state = install_state_payload
+        except (OSError, ValueError, TypeError):
+            install_state = {}
+
+    # rapidocr-onnxruntime is now bundled into the main program. Treat either source as
+    # "package present": main interpreter import OR legacy plugin-isolated dir.
+    bundled_spec = None
+    try:
+        bundled_spec = importlib.util.find_spec(RAPIDOCR_PACKAGE_NAME)
+    except (ImportError, ValueError):
+        bundled_spec = None
+
+    if not supported:
+        detail = "unsupported_platform"
+    elif bundled_spec is not None:
+        # Bundled main-program path: trust find_spec instead of constructing a
+        # full RapidOCR runtime (which inits an ONNX session) on every status
+        # probe. inspect_*_installation gets called from the bridge poll on a
+        # short cache TTL — running ORT init repeatedly would hammer CPU even
+        # when OCR is disabled. Real OCR errors will still surface from
+        # OcrReaderManager when capture/recognition is actually attempted.
+        detail = "installed"
+        spec_origin = getattr(bundled_spec, "origin", None) or ""
+        if spec_origin:
+            detected_path = str(Path(spec_origin).resolve().parent)
+        # Non-bundled (ocr_version, lang_type) combos require additional
+        # ONNX files that the wheel doesn't ship. Surface that as its own
+        # state so the UI can offer an explicit, opt-in download instead
+        # of "installed but silently broken at first capture".
+        missing = missing_rapidocr_model_files(
+            install_target_dir_raw=install_target_dir_raw,
+            ocr_version=ocr_version,
+            lang_type=lang_type,
+            model_type=model_type,
+        )
+        if missing:
+            detail = "missing_model_files"
+    elif not package_dir.exists():
+        detail = "missing"
+    else:
+        # Legacy plugin-isolated install: still validated by full runtime load
+        # since this path is for upgrade users with potentially-stale installs
+        # that may legitimately be broken. Frequency is low (only when bundled
+        # path is unavailable AND legacy dir exists).
+        try:
+            _rapidocr_runtime, runtime_meta = _runtime.load_rapidocr_runtime(
+                install_target_dir_raw=install_target_dir_raw,
+                engine_type=engine_type,
+                lang_type=lang_type,
+                model_type=model_type,
+                ocr_version=ocr_version,
+            )
+            detected_path = str(runtime_meta.get("detected_path") or detected_path)
+            detail = "installed"
+            # Same missing-models check as the bundled branch above. Without
+            # this, an upgrade user on a legacy plugin-isolated install with
+            # explicit `lang_type=japan` would land on `installed` even when
+            # `japan_PP-OCRv4_rec_mobile.onnx` is absent — `can_download_models`
+            # would stay False and OCR would silently fall back to the
+            # bundled ch model with no UI affordance to fix it.
+            legacy_missing = missing_rapidocr_model_files(
+                install_target_dir_raw=install_target_dir_raw,
+                ocr_version=ocr_version,
+                lang_type=lang_type,
+                model_type=model_type,
+            )
+            if legacy_missing:
+                detail = "missing_model_files"
+        except Exception as exc:
+            detail = "broken_runtime"
+            runtime_error = str(exc)
+
+    installed = detail == "installed"
+    missing_files = missing_rapidocr_model_files(
+        install_target_dir_raw=install_target_dir_raw,
+        ocr_version=ocr_version,
+        lang_type=lang_type,
+        model_type=model_type,
+    )
+    total_size_estimate = sum(int(f.get("size") or 0) for f in missing_files)
+    return {
+        "install_supported": supported,
+        "installed": installed,
+        # rapidocr-onnxruntime is now bundled into the main program. When it's not importable
+        # the user is on a source install without the optional OCR dependency group —
+        # no in-app install action exists anymore (HTTP routes removed in this
+        # refactor), so `can_install` stays False to keep the UI button hidden.
+        "can_install": False,
+        # `can_download_models` is True only when the package is present but
+        # the user-selected language pack isn't on disk yet — that's the only
+        # condition under which the download UX is meaningful.
+        "can_download_models": detail == "missing_model_files",
+        "detected_path": detected_path,
+        "target_dir": str(target_dir) if target_dir else "",
+        "runtime_dir": str(runtime_dir) if runtime_dir else "",
+        "site_packages_dir": str(site_packages_dir) if site_packages_dir else "",
+        "model_cache_dir": str(model_cache_dir) if model_cache_dir else "",
+        "selected_model": selected_model,
+        "engine_type": engine_type,
+        "lang_type": lang_type,
+        "model_type": model_type,
+        "ocr_version": ocr_version,
+        "detail": detail,
+        "runtime_error": runtime_error,
+        "missing_model_files": missing_files,
+        "missing_model_total_size": total_size_estimate,
+        "model_download_source": _RAPIDOCR_MODELSCOPE_BASE,
+    }
+
+
+# ====== Model download ======
+
+ProgressCallback = Callable[[dict[str, Any]], Awaitable[None] | None]
+InstallStateUpdater = Callable[..., dict[str, object]]
+
+
+def _noop_install_state_updater(*_args: Any, **_kwargs: Any) -> dict[str, object]:
+    return {}
+
+
+async def _emit_model_progress(
+    progress_callback: ProgressCallback | None,
+    payload: dict[str, Any],
+) -> None:
+    if progress_callback is None:
+        return
+    maybe = progress_callback(dict(payload))
+    if inspect.isawaitable(maybe):
+        await maybe
+
+
+def _verify_model_sha256(path: Path, expected_sha256: str) -> None:
+    expected = (expected_sha256 or "").strip().lower()
+    if not expected:
+        return
+    hasher = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    actual = hasher.hexdigest()
+    if actual != expected:
+        path.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"downloaded model checksum mismatch for {path.name}: expected {expected}, got {actual}"
+        )
+
+async def download_rapidocr_models(
+    *,
+    logger,
+    install_target_dir_raw: str,
+    ocr_version: str,
+    lang_type: str,
+    model_type: str = DEFAULT_RAPIDOCR_MODEL_TYPE,
+    timeout_seconds: float = 180.0,
+    force: bool = False,
+    task_id: str | None = None,
+    plugin_id: str = "study_companion",
+    progress_callback: ProgressCallback | None = None,
+    before_completed_callback: Callable[[], Awaitable[None] | None] | None = None,
+    install_state_updater: InstallStateUpdater | None = None,
+) -> dict[str, Any]:
+    """Download all model files required for the (ocr_version, lang_type) selection.
+
+    Bundled (PP-OCRv4 + ch) is a no-op. Otherwise downloads each missing file
+    from the original ModelScope URL in the model registry.
+    Files are written into model_cache_dir, verified with SHA256, and reported
+    through progress events.
+    Failures preserve specific error text (HTTP status, timeout, network) so
+    the UI can show actionable copy.
+    """
+    update_install_task_state = install_state_updater or _noop_install_state_updater
+
+    async def _before_completed() -> None:
+        if before_completed_callback is None:
+            return
+        result = before_completed_callback()
+        if inspect.isawaitable(result):
+            await result
+
+    async def _before_completed_safely() -> None:
+        try:
+            await _before_completed()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning("failed to run rapidocr_models completion callback", exc_info=True)
+
+    cache_dir = resolve_rapidocr_model_cache_dir(install_target_dir_raw)
+    if not cache_dir:
+        raise RuntimeError("missing RapidOCR model cache directory")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    required = required_rapidocr_model_files(
+        install_target_dir_raw=install_target_dir_raw,
+        ocr_version=ocr_version,
+        lang_type=lang_type,
+        model_type=model_type,
+    )
+    if not required:
+        await _before_completed_safely()
+        if task_id:
+            update_install_task_state(
+                task_id,
+                kind="rapidocr_models",
+                plugin_id=plugin_id,
+                status="completed",
+                phase="completed",
+                message="No download needed for bundled ch + PP-OCRv4 models",
+                progress=1.0,
+                target_dir=str(cache_dir),
+            )
+        await _emit_model_progress(
+            progress_callback,
+            {
+                "status": "completed",
+                "phase": "completed",
+                "message": "No download needed for bundled ch + PP-OCRv4 models",
+                "progress": 1.0,
+                "downloaded_bytes": 0,
+                "total_bytes": 0,
+                "target_dir": str(cache_dir),
+            },
+        )
+        return {"downloaded": [], "skipped_bundled": True, "target_dir": str(cache_dir)}
+
+    pending = required if force else [
+        spec for spec in required
+        if not (spec["target_path"] and Path(spec["target_path"]).is_file())
+    ]
+    total_bytes = sum(int(spec.get("size") or 0) for spec in pending)
+
+    if not pending:
+        already_present_message = "All required RapidOCR models already on disk"
+        await _before_completed_safely()
+        if task_id:
+            update_install_task_state(
+                task_id,
+                kind="rapidocr_models",
+                plugin_id=plugin_id,
+                status="completed",
+                phase="completed",
+                message=already_present_message,
+                progress=1.0,
+                target_dir=str(cache_dir),
+            )
+        # Emit a streaming completion event too — the bundled-no-op branch
+        # above does this; the cache-hit branch was missing it, so SSE
+        # subscribers stayed in `running` until timeout when a re-trigger
+        # found everything already on disk.
+        await _emit_model_progress(
+            progress_callback,
+            {
+                "status": "completed",
+                "phase": "completed",
+                "message": already_present_message,
+                "progress": 1.0,
+                "downloaded_bytes": 0,
+                "total_bytes": 0,
+                "target_dir": str(cache_dir),
+            },
+        )
+        return {"downloaded": [], "already_present": True, "target_dir": str(cache_dir)}
+
+    downloaded_bytes = 0
+    downloaded: list[str] = []
+    downloaded_sources: dict[str, str] = {}
+    async with httpx.AsyncClient(
+        timeout=timeout_seconds,
+        trust_env=True,
+        follow_redirects=True,
+    ) as client:
+        for index, spec in enumerate(pending):
+            asset_name = spec["name"]
+            destination = Path(spec["target_path"])
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = destination.with_suffix(destination.suffix + ".part")
+            source = "modelscope"
+            url = str(spec["url"])
+            headers = {
+                "Accept": "application/octet-stream",
+                "User-Agent": "N.E.K.O/study_companion",
+            }
+            source_label = "ModelScope"
+            running_message = (
+                f"Downloading {asset_name} from {source_label} "
+                f"({index + 1}/{len(pending)})"
+            )
+            if task_id:
+                update_install_task_state(
+                    task_id,
+                    kind="rapidocr_models",
+                    plugin_id=plugin_id,
+                    status="running",
+                    phase="downloading",
+                    message=running_message,
+                    progress=(downloaded_bytes / total_bytes) if total_bytes else 0.0,
+                    downloaded_bytes=downloaded_bytes,
+                    total_bytes=total_bytes,
+                    target_dir=str(cache_dir),
+                    asset_name=asset_name,
+                    source=source,
+                )
+            await _emit_model_progress(
+                progress_callback,
+                {
+                    "status": "running",
+                    "phase": "downloading",
+                    "message": running_message,
+                    "progress": (downloaded_bytes / total_bytes) if total_bytes else 0.0,
+                    "downloaded_bytes": downloaded_bytes,
+                    "total_bytes": total_bytes,
+                    "target_dir": str(cache_dir),
+                    "asset_name": asset_name,
+                    "source": source,
+                },
+            )
+
+            tmp_path.unlink(missing_ok=True)
+            try:
+                async with client.stream("GET", url, headers=headers) as response:
+                    response.raise_for_status()
+                    asset_total = int(response.headers.get("Content-Length") or spec.get("size") or 0)
+                    asset_downloaded = 0
+                    last_emit = 0.0
+                    with tmp_path.open("wb") as fh:
+                        async for chunk in response.aiter_bytes(chunk_size=64 * 1024):
+                            if not chunk:
+                                continue
+                            fh.write(chunk)
+                            asset_downloaded += len(chunk)
+                            now = downloaded_bytes + asset_downloaded
+                            # Throttle progress emission to ~1% steps to keep
+                            # the SSE stream cheap.
+                            if total_bytes and (now - last_emit) > max(64 * 1024, total_bytes // 100):
+                                last_emit = float(now)
+                                if task_id:
+                                    update_install_task_state(
+                                        task_id,
+                                        kind="rapidocr_models",
+                                        plugin_id=plugin_id,
+                                        status="running",
+                                        phase="downloading",
+                                        message=running_message,
+                                        progress=(now / total_bytes) if total_bytes else 0.0,
+                                        downloaded_bytes=now,
+                                        total_bytes=total_bytes,
+                                        target_dir=str(cache_dir),
+                                        asset_name=asset_name,
+                                        source=source,
+                                    )
+                                await _emit_model_progress(
+                                    progress_callback,
+                                    {
+                                        "status": "running",
+                                        "phase": "downloading",
+                                        "message": running_message,
+                                        "progress": (now / total_bytes) if total_bytes else 0.0,
+                                        "downloaded_bytes": now,
+                                        "total_bytes": total_bytes,
+                                        "target_dir": str(cache_dir),
+                                        "asset_name": asset_name,
+                                        "source": source,
+                                    },
+                                )
+                _verify_model_sha256(tmp_path, str(spec.get("sha256") or ""))
+                # Path.replace = os.replace, unconditionally overwrites the
+                # destination atomically on both POSIX and Windows (Python
+                # 3.3+). The previous explicit unlink-then-replace created a
+                # race window where the destination briefly didn't exist
+                # — load_rapidocr_runtime / inspect_rapidocr_installation
+                # could observe the file as missing during force=True
+                # re-downloads. The atomic replace covers both new-file and
+                # overwrite cases.
+                tmp_path.replace(destination)
+                downloaded_bytes += int(spec.get("size") or asset_downloaded)
+                downloaded.append(asset_name)
+                downloaded_sources[asset_name] = source
+            except Exception as exc:  # noqa: BLE001 - report the configured source
+                tmp_path.unlink(missing_ok=True)
+                logger.warning(
+                    "failed to download RapidOCR model %s from %s",
+                    asset_name,
+                    source_label,
+                    exc_info=True,
+                )
+                err_message = (
+                    f"failed to download {asset_name} from {source_label}: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                # Without these, the SSE stream and persisted task state stay in
+                # `running` until the client times out; the user sees a download
+                # that "never finishes" instead of an explicit failure.
+                if task_id:
+                    try:
+                        update_install_task_state(
+                            task_id,
+                            kind="rapidocr_models",
+                            plugin_id=plugin_id,
+                            status="failed",
+                            phase="failed",
+                            message=err_message,
+                            progress=(downloaded_bytes / total_bytes) if total_bytes else 0.0,
+                            downloaded_bytes=downloaded_bytes,
+                            total_bytes=total_bytes,
+                            target_dir=str(cache_dir),
+                            asset_name=asset_name,
+                            error=err_message,
+                        )
+                    except Exception:
+                        logger.warning("failed to persist rapidocr_models failure state", exc_info=True)
+                try:
+                    await _emit_model_progress(
+                        progress_callback,
+                        {
+                            "status": "failed",
+                            "phase": "failed",
+                            "message": err_message,
+                            "error": err_message,
+                            "progress": (downloaded_bytes / total_bytes) if total_bytes else 0.0,
+                            "downloaded_bytes": downloaded_bytes,
+                            "total_bytes": total_bytes,
+                            "target_dir": str(cache_dir),
+                            "asset_name": asset_name,
+                        },
+                    )
+                except Exception:
+                    logger.warning("failed to emit rapidocr_models failure progress", exc_info=True)
+                raise RuntimeError(err_message) from exc
+
+    await _before_completed_safely()
+
+    if task_id:
+        update_install_task_state(
+            task_id,
+            kind="rapidocr_models",
+            plugin_id=plugin_id,
+            status="completed",
+            phase="completed",
+            message=f"Downloaded {len(downloaded)} model file(s)",
+            progress=1.0,
+            downloaded_bytes=total_bytes,
+            total_bytes=total_bytes,
+            target_dir=str(cache_dir),
+        )
+    await _emit_model_progress(
+        progress_callback,
+        {
+            "status": "completed",
+            "phase": "completed",
+            "message": f"Downloaded {len(downloaded)} model file(s)",
+            "progress": 1.0,
+            "downloaded_bytes": total_bytes,
+            "total_bytes": total_bytes,
+            "target_dir": str(cache_dir),
+        },
+    )
+    result: dict[str, Any] = {
+        "downloaded": downloaded,
+        "target_dir": str(cache_dir),
+        "sources": downloaded_sources,
+    }
+    unique_sources = set(downloaded_sources.values())
+    if len(unique_sources) == 1:
+        result["source"] = next(iter(unique_sources))
+    return result

--- a/plugin/plugins/_shared/rapidocr/_inspect_download.py
+++ b/plugin/plugins/_shared/rapidocr/_inspect_download.py
@@ -170,6 +170,7 @@ def inspect_rapidocr_installation(
         "ocr_version": ocr_version,
         "detail": detail,
         "runtime_error": runtime_error,
+        "install_state": install_state,
         "missing_model_files": missing_files,
         "missing_model_total_size": total_size_estimate,
         "model_download_source": _RAPIDOCR_MODELSCOPE_BASE,
@@ -332,8 +333,14 @@ async def download_rapidocr_models(
     downloaded_bytes = 0
     downloaded: list[str] = []
     downloaded_sources: dict[str, str] = {}
+    http_timeout = httpx.Timeout(
+        connect=min(max(float(timeout_seconds), 1.0), 30.0),
+        read=None,
+        write=max(float(timeout_seconds), 1.0),
+        pool=min(max(float(timeout_seconds), 1.0), 30.0),
+    )
     async with httpx.AsyncClient(
-        timeout=timeout_seconds,
+        timeout=http_timeout,
         trust_env=True,
         follow_redirects=True,
     ) as client:

--- a/plugin/plugins/_shared/rapidocr/_model_registry.py
+++ b/plugin/plugins/_shared/rapidocr/_model_registry.py
@@ -209,6 +209,16 @@ def _registry_lookup(ocr_version: str, lang_type: str) -> dict[str, dict[str, An
     return _RAPIDOCR_MODEL_REGISTRY.get(_normalize_model_key(ocr_version, lang_type))
 
 
+def rapidocr_selection_requires_downloaded_models(
+    *,
+    ocr_version: str,
+    lang_type: str,
+) -> bool:
+    """Return True when the local registry expects explicit downloaded model files."""
+    key = _normalize_model_key(ocr_version, lang_type)
+    return key != _BUNDLED_KEY and key in _RAPIDOCR_MODEL_REGISTRY
+
+
 def _registry_spec_for_model_type(
     spec: dict[str, Any],
     *,

--- a/plugin/plugins/_shared/rapidocr/_model_registry.py
+++ b/plugin/plugins/_shared/rapidocr/_model_registry.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+from ._paths import _BUNDLED_KEY, resolve_rapidocr_model_cache_dir
+
+
+RAPIDOCR_PACKAGE_NAME = "rapidocr_onnxruntime"
+DEFAULT_RAPIDOCR_ENGINE_TYPE = "onnxruntime"
+# Default to the bundled Chinese PP-OCRv4 model so minimal/older configs take
+# the no-download path. Japanese games can still opt into `japan` explicitly.
+DEFAULT_RAPIDOCR_LANG_TYPE = "ch"
+DEFAULT_RAPIDOCR_MODEL_TYPE = "mobile"
+# PP-OCRv4 keeps the bundled-no-download path working for ch+v4. v5 has
+# better quality but requires a download for everything (no bundled v5).
+DEFAULT_RAPIDOCR_OCR_VERSION = "PP-OCRv4"
+
+# Models hosted on RapidAI's ModelScope mirror. URL pattern stable as of
+# RapidOCR v3.8.0 (the registry source). Each entry's `name` is the on-disk
+# filename (also forms the URL leaf) and is what we pass to RapidOCR via
+# det_model_path / rec_model_path / cls_model_path. SHA256 is from the
+# upstream default_models.yaml — used for integrity checks after download.
+_RAPIDOCR_MODELSCOPE_BASE = (
+    "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.8.0/onnx"
+)
+
+
+def _ms_url(version: str, kind: str, name: str) -> str:
+    return f"{_RAPIDOCR_MODELSCOPE_BASE}/{version}/{kind}/{name}"
+
+# (ocr_version, lang_type) -> {det/rec/cls: {name, url, sha256, size}}.
+# `det` is largely language-agnostic (we use ch det for all langs); `cls` is
+# orientation-only. Only `rec` truly varies by lang. PP-OCRv5 has no japan
+# rec model upstream, so we fall back to the v4 japan rec — det/cls stay v5.
+_RAPIDOCR_MODEL_REGISTRY: dict[tuple[str, str], dict[str, dict[str, Any]]] = {
+    ("PP-OCRv4", "ch"): {
+        "det": {"name": "ch_PP-OCRv4_det_mobile.onnx", "url": _ms_url("PP-OCRv4", "det", "ch_PP-OCRv4_det_mobile.onnx"), "sha256": "d2a7720d45a54257208b1e13e36a8479894cb74155a5efe29462512d42f49da9", "size": 4_700_000},
+        "rec": {"name": "ch_PP-OCRv4_rec_mobile.onnx", "url": _ms_url("PP-OCRv4", "rec", "ch_PP-OCRv4_rec_mobile.onnx"), "sha256": "48fc40f24f6d2a207a2b1091d3437eb3cc3eb6b676dc3ef9c37384005483683b", "size": 10_700_000},
+        "cls": {"name": "ch_ppocr_mobile_v2.0_cls_mobile.onnx", "url": _ms_url("PP-OCRv4", "cls", "ch_ppocr_mobile_v2.0_cls_mobile.onnx"), "sha256": "e47acedf663230f8863ff1ab0e64dd2d82b838fceb5957146dab185a89d6215c", "size": 580_000},
+    },
+    ("PP-OCRv4", "japan"): {
+        "det": {"name": "ch_PP-OCRv4_det_mobile.onnx", "url": _ms_url("PP-OCRv4", "det", "ch_PP-OCRv4_det_mobile.onnx"), "sha256": "d2a7720d45a54257208b1e13e36a8479894cb74155a5efe29462512d42f49da9", "size": 4_700_000},
+        "rec": {"name": "japan_PP-OCRv4_rec_mobile.onnx", "url": _ms_url("PP-OCRv4", "rec", "japan_PP-OCRv4_rec_mobile.onnx"), "sha256": "e1075a67dba758ecfc7ebc78a10ae61c95ac8fb66a9c86fab5541e33f085cb7a", "size": 9_753_335},
+        "cls": {"name": "ch_ppocr_mobile_v2.0_cls_mobile.onnx", "url": _ms_url("PP-OCRv4", "cls", "ch_ppocr_mobile_v2.0_cls_mobile.onnx"), "sha256": "e47acedf663230f8863ff1ab0e64dd2d82b838fceb5957146dab185a89d6215c", "size": 580_000},
+    },
+    ("PP-OCRv4", "korean"): {
+        "det": {"name": "ch_PP-OCRv4_det_mobile.onnx", "url": _ms_url("PP-OCRv4", "det", "ch_PP-OCRv4_det_mobile.onnx"), "sha256": "d2a7720d45a54257208b1e13e36a8479894cb74155a5efe29462512d42f49da9", "size": 4_700_000},
+        "rec": {"name": "korean_PP-OCRv4_rec_mobile.onnx", "url": _ms_url("PP-OCRv4", "rec", "korean_PP-OCRv4_rec_mobile.onnx"), "sha256": "ab151ba9065eccd98f884cf4d927db091be86137276392072edd4f9d43ad7426", "size": 9_500_000},
+        "cls": {"name": "ch_ppocr_mobile_v2.0_cls_mobile.onnx", "url": _ms_url("PP-OCRv4", "cls", "ch_ppocr_mobile_v2.0_cls_mobile.onnx"), "sha256": "e47acedf663230f8863ff1ab0e64dd2d82b838fceb5957146dab185a89d6215c", "size": 580_000},
+    },
+    ("PP-OCRv4", "en"): {
+        "det": {"name": "ch_PP-OCRv4_det_mobile.onnx", "url": _ms_url("PP-OCRv4", "det", "ch_PP-OCRv4_det_mobile.onnx"), "sha256": "d2a7720d45a54257208b1e13e36a8479894cb74155a5efe29462512d42f49da9", "size": 4_700_000},
+        "rec": {"name": "en_PP-OCRv4_rec_mobile.onnx", "url": _ms_url("PP-OCRv4", "rec", "en_PP-OCRv4_rec_mobile.onnx"), "sha256": "e8770c967605983d1570cdf5352041dfb68fa0c21664f49f47b155abd3e0e318", "size": 9_500_000},
+        "cls": {"name": "ch_ppocr_mobile_v2.0_cls_mobile.onnx", "url": _ms_url("PP-OCRv4", "cls", "ch_ppocr_mobile_v2.0_cls_mobile.onnx"), "sha256": "e47acedf663230f8863ff1ab0e64dd2d82b838fceb5957146dab185a89d6215c", "size": 580_000},
+    },
+    ("PP-OCRv5", "ch"): {
+        "det": {"name": "ch_PP-OCRv5_det_mobile.onnx", "url": _ms_url("PP-OCRv5", "det", "ch_PP-OCRv5_det_mobile.onnx"), "sha256": "4d97c44a20d30a81aad087d6a396b08f786c4635742afc391f6621f5c6ae78ae", "size": 5_000_000},
+        "rec": {"name": "ch_PP-OCRv5_rec_mobile.onnx", "url": _ms_url("PP-OCRv5", "rec", "ch_PP-OCRv5_rec_mobile.onnx"), "sha256": "5825fc7ebf84ae7a412be049820b4d86d77620f204a041697b0494669b1742c5", "size": 11_500_000},
+        "cls": {"name": "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx", "url": _ms_url("PP-OCRv5", "cls", "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx"), "sha256": "54379ae5174d026780215fc748a7f31910dee36818e63d49e17dc598ecc82df7", "size": 600_000},
+    },
+    # PP-OCRv5 has no `japan` rec model upstream — fall back to v4 japan rec.
+    # Det + cls stay on v5; mixing release lines is supported by RapidOCR's
+    # per-stage model_path config.
+    ("PP-OCRv5", "japan"): {
+        "det": {"name": "ch_PP-OCRv5_det_mobile.onnx", "url": _ms_url("PP-OCRv5", "det", "ch_PP-OCRv5_det_mobile.onnx"), "sha256": "4d97c44a20d30a81aad087d6a396b08f786c4635742afc391f6621f5c6ae78ae", "size": 5_000_000},
+        "rec": {"name": "japan_PP-OCRv4_rec_mobile.onnx", "url": _ms_url("PP-OCRv4", "rec", "japan_PP-OCRv4_rec_mobile.onnx"), "sha256": "e1075a67dba758ecfc7ebc78a10ae61c95ac8fb66a9c86fab5541e33f085cb7a", "size": 9_753_335},
+        "cls": {"name": "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx", "url": _ms_url("PP-OCRv5", "cls", "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx"), "sha256": "54379ae5174d026780215fc748a7f31910dee36818e63d49e17dc598ecc82df7", "size": 600_000},
+    },
+    ("PP-OCRv5", "korean"): {
+        "det": {"name": "ch_PP-OCRv5_det_mobile.onnx", "url": _ms_url("PP-OCRv5", "det", "ch_PP-OCRv5_det_mobile.onnx"), "sha256": "4d97c44a20d30a81aad087d6a396b08f786c4635742afc391f6621f5c6ae78ae", "size": 5_000_000},
+        "rec": {"name": "korean_PP-OCRv5_rec_mobile.onnx", "url": _ms_url("PP-OCRv5", "rec", "korean_PP-OCRv5_rec_mobile.onnx"), "sha256": "cd6e2ea50f6943ca7271eb8c56a877a5a90720b7047fe9c41a2e541a25773c9b", "size": 10_000_000},
+        "cls": {"name": "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx", "url": _ms_url("PP-OCRv5", "cls", "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx"), "sha256": "54379ae5174d026780215fc748a7f31910dee36818e63d49e17dc598ecc82df7", "size": 600_000},
+    },
+    ("PP-OCRv5", "en"): {
+        "det": {"name": "ch_PP-OCRv5_det_mobile.onnx", "url": _ms_url("PP-OCRv5", "det", "ch_PP-OCRv5_det_mobile.onnx"), "sha256": "4d97c44a20d30a81aad087d6a396b08f786c4635742afc391f6621f5c6ae78ae", "size": 5_000_000},
+        "rec": {"name": "en_PP-OCRv5_rec_mobile.onnx", "url": _ms_url("PP-OCRv5", "rec", "en_PP-OCRv5_rec_mobile.onnx"), "sha256": "c3461add59bb4323ecba96a492ab75e06dda42467c9e3d0c18db5d1d21924be8", "size": 10_000_000},
+        "cls": {"name": "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx", "url": _ms_url("PP-OCRv5", "cls", "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx"), "sha256": "54379ae5174d026780215fc748a7f31910dee36818e63d49e17dc598ecc82df7", "size": 600_000},
+    },
+}
+
+def rapidocr_selected_model_name(
+    *,
+    ocr_version: str,
+    lang_type: str,
+    model_type: str,
+) -> str:
+    return "/".join(
+        [
+            str(ocr_version or DEFAULT_RAPIDOCR_OCR_VERSION).strip() or DEFAULT_RAPIDOCR_OCR_VERSION,
+            str(lang_type or DEFAULT_RAPIDOCR_LANG_TYPE).strip() or DEFAULT_RAPIDOCR_LANG_TYPE,
+            str(model_type or DEFAULT_RAPIDOCR_MODEL_TYPE).strip() or DEFAULT_RAPIDOCR_MODEL_TYPE,
+        ]
+    )
+
+
+def _resolve_rapidocr_model_paths(
+    *,
+    model_cache_dir: Path,
+    package_models_dir: Path | None,
+    lang_type: str,
+    ocr_version: str,
+    model_type: str,
+) -> tuple[str | None, str | None, str | None]:
+    """Find det/cls/rec ONNX files on disk for a given (lang, version, type).
+
+    Two filename conventions in the wild:
+      - PaddleOCR / wheel-bundled: f"{lang}_{version}_{stage}{_server?}_infer.onnx"
+        e.g. ch_PP-OCRv4_det_infer.onnx, ch_PP-OCRv4_det_server_infer.onnx
+      - RapidAI ModelScope releases (v3.x): f"{lang}_{version}_{stage}_{type}.onnx"
+        e.g. ch_PP-OCRv4_det_mobile.onnx, ch_PP-OCRv4_det_server.onnx
+        (no `_infer` suffix; type is `_mobile` or `_server`)
+
+    Both conventions are checked per location to support either source. The
+    `_infer` form is preferred (matches both bundled wheels and the
+        existing RapidOCR support fixtures that came in with PR #1194).
+    """
+    lang = str(lang_type or DEFAULT_RAPIDOCR_LANG_TYPE).strip() or DEFAULT_RAPIDOCR_LANG_TYPE
+    version = str(ocr_version or DEFAULT_RAPIDOCR_OCR_VERSION).strip() or DEFAULT_RAPIDOCR_OCR_VERSION
+    mt = (str(model_type or DEFAULT_RAPIDOCR_MODEL_TYPE).strip() or DEFAULT_RAPIDOCR_MODEL_TYPE).lower()
+    server_infix = "_server" if mt == "server" else ""
+    type_suffix = "_server" if mt == "server" else "_mobile"
+
+    # Consult the registry FIRST so cross-version fallbacks resolve correctly.
+    # Example: ("PP-OCRv5", "japan") rec actually downloads as
+    # `japan_PP-OCRv4_rec_mobile.onnx` (no v5 japan rec exists upstream); the
+    # synthesized `f"{lang}_{version}_rec_*"` names below would never match.
+    # The registry's `name` is the on-disk filename our downloader writes.
+    registry = _registry_lookup(version, lang) or {}
+
+    def _names(*items: str) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in items:
+            if item and item not in seen:
+                seen.add(item)
+                out.append(item)
+        return out
+
+    def _alt_infer(name: str) -> str:
+        """Wheel/Paddle pattern: same prefix but `_infer.onnx` instead of
+        `_mobile.onnx` / `_server.onnx`. Lets us pick up wheel-bundled
+        files even when the registry lists the modelscope `_mobile` name.
+        Example: `ch_PP-OCRv4_det_mobile.onnx` ↔ `ch_PP-OCRv4_det_infer.onnx`.
+        """
+        for suf in ("_mobile.onnx", "_server.onnx"):
+            if name.endswith(suf):
+                return name[: -len(suf)] + "_infer.onnx"
+        return ""
+
+    reg_det = str((registry.get("det") or {}).get("name") or "")
+    reg_rec = str((registry.get("rec") or {}).get("name") or "")
+    reg_cls = str((registry.get("cls") or {}).get("name") or "")
+
+    det_names = _names(
+        reg_det,
+        _alt_infer(reg_det),
+        f"{lang}_{version}_det{server_infix}_infer.onnx",  # paddle / wheel
+        f"{lang}_{version}_det{type_suffix}.onnx",          # modelscope v3.x
+    )
+    rec_names = _names(
+        reg_rec,
+        _alt_infer(reg_rec),
+        f"{lang}_{version}_rec{server_infix}_infer.onnx",
+        f"{lang}_{version}_rec{type_suffix}.onnx",
+    )
+    # Cls is shared across mobile/server variants. PaddleOCR ships the
+    # legacy v2.0 mobile cls; PP-OCRv5 introduces a new textline-orientation
+    # cls. Consult the registry first, then list the known generics.
+    cls_names = _names(
+        reg_cls,
+        _alt_infer(reg_cls),
+        "ch_ppocr_mobile_v2.0_cls_infer.onnx",
+        "ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+        "ch_PP-LCNet_x0_25_textline_ori_cls_mobile.onnx",
+    )
+
+    def _find_first(search_dir: Path, names: list[str]) -> str | None:
+        for name in names:
+            candidate = search_dir / name
+            if candidate.is_file():
+                return str(candidate)
+        return None
+
+    det_path: str | None = None
+    cls_path: str | None = None
+    rec_path: str | None = None
+    for search_dir in (model_cache_dir, package_models_dir):
+        if not search_dir or not search_dir.is_dir():
+            continue
+        if det_path is None:
+            det_path = _find_first(search_dir, det_names)
+        if cls_path is None:
+            cls_path = _find_first(search_dir, cls_names)
+        if rec_path is None:
+            rec_path = _find_first(search_dir, rec_names)
+    return det_path, cls_path, rec_path
+
+def _normalize_model_key(ocr_version: str, lang_type: str) -> tuple[str, str]:
+    return (
+        str(ocr_version or DEFAULT_RAPIDOCR_OCR_VERSION).strip() or DEFAULT_RAPIDOCR_OCR_VERSION,
+        str(lang_type or DEFAULT_RAPIDOCR_LANG_TYPE).strip() or DEFAULT_RAPIDOCR_LANG_TYPE,
+    )
+
+
+def _registry_lookup(ocr_version: str, lang_type: str) -> dict[str, dict[str, Any]] | None:
+    """Return the (det, rec, cls) entries for a given selection, or None if not catalogued."""
+    return _RAPIDOCR_MODEL_REGISTRY.get(_normalize_model_key(ocr_version, lang_type))
+
+
+def _registry_spec_for_model_type(
+    spec: dict[str, Any],
+    *,
+    kind: str,
+    model_type: str,
+) -> dict[str, Any]:
+    model_kind = (str(model_type or DEFAULT_RAPIDOCR_MODEL_TYPE).strip() or DEFAULT_RAPIDOCR_MODEL_TYPE).lower()
+    if model_kind != "server" or kind == "cls":
+        return dict(spec)
+    name = str(spec.get("name") or "")
+    url = str(spec.get("url") or "")
+    if name.endswith("_mobile.onnx"):
+        name = name[: -len("_mobile.onnx")] + "_server.onnx"
+    if url.endswith("_mobile.onnx"):
+        url = url[: -len("_mobile.onnx")] + "_server.onnx"
+    return {
+        **spec,
+        "name": name,
+        "url": url,
+        "sha256": "",
+    }
+
+
+def required_rapidocr_model_files(
+    *,
+    install_target_dir_raw: str,
+    ocr_version: str,
+    lang_type: str,
+    model_type: str = DEFAULT_RAPIDOCR_MODEL_TYPE,
+) -> list[dict[str, Any]]:
+    """Files that must exist on disk for a given selection. Empty for the bundled combo."""
+    key = _normalize_model_key(ocr_version, lang_type)
+    if key == _BUNDLED_KEY:
+        return []
+    registry = _RAPIDOCR_MODEL_REGISTRY.get(key)
+    if not registry:
+        return []
+    cache_dir = resolve_rapidocr_model_cache_dir(install_target_dir_raw)
+    files: list[dict[str, Any]] = []
+    for kind in ("det", "rec", "cls"):
+        spec = registry.get(kind)
+        if not spec:
+            continue
+        spec = _registry_spec_for_model_type(spec, kind=kind, model_type=model_type)
+        files.append({
+            "kind": kind,
+            "name": str(spec["name"]),
+            "url": str(spec["url"]),
+            "sha256": str(spec.get("sha256") or ""),
+            "size": int(spec.get("size") or 0),
+            "target_path": str(cache_dir / spec["name"]) if cache_dir else "",
+        })
+    return files
+
+
+def missing_rapidocr_model_files(
+    *,
+    install_target_dir_raw: str,
+    ocr_version: str,
+    lang_type: str,
+    model_type: str = DEFAULT_RAPIDOCR_MODEL_TYPE,
+) -> list[dict[str, Any]]:
+    """Required files that the resolver can't locate on disk.
+
+    Delegates to `_resolve_rapidocr_model_paths` so we accept the same files
+    RapidOCR will actually load: both filename conventions (`_infer.onnx` for
+    the wheel/PaddleOCR pattern, `_mobile.onnx`/`_server.onnx` for ModelScope
+    v3.x) and both locations (model_cache_dir + the imported package's
+    bundled `models/` dir). Marking a stage missing only because the
+    registry's preferred filename isn't at the exact target_path would have
+    caused inspect_rapidocr_installation to keep returning
+    `detail="missing_model_files"` even when RapidOCR could already serve
+    OCR successfully from a wheel-bundled file or a manually-dropped
+    alternate-name file — locking the user into a perpetual download banner.
+    """
+    required = required_rapidocr_model_files(
+        install_target_dir_raw=install_target_dir_raw,
+        ocr_version=ocr_version,
+        lang_type=lang_type,
+        model_type=model_type,
+    )
+    if not required:
+        return []
+
+    cache_dir = resolve_rapidocr_model_cache_dir(install_target_dir_raw)
+    # Two possible `<package>/models/` dirs to scan:
+    # 1. The bundled-import path's models dir (find_spec → wheel models).
+    # 2. The legacy plugin-isolated install's package dir, which sits at
+    #    `<install_target>/runtime/site-packages/rapidocr_onnxruntime/models`
+    #    and is loaded via `_rapidocr_import_context` rather than the normal
+    #    Python import machinery — so `find_spec` returns None for it even
+    #    when load_rapidocr_runtime can use it. Without this fallback,
+    #    legacy-install users see a perpetual "missing models" banner even
+    #    though their files are reachable.
+    candidate_package_dirs: list[Path | None] = []
+    try:
+        spec = importlib.util.find_spec(RAPIDOCR_PACKAGE_NAME)
+        if spec is not None and spec.origin:
+            candidate_package_dirs.append(Path(spec.origin).resolve().parent / "models")
+    except (ImportError, ValueError):
+        pass
+    from ._runtime import _rapidocr_package_dir
+    legacy_pkg = _rapidocr_package_dir(install_target_dir_raw)
+    if legacy_pkg and legacy_pkg.exists():
+        candidate_package_dirs.append(legacy_pkg / "models")
+    if not candidate_package_dirs:
+        candidate_package_dirs.append(None)
+
+    # "Any candidate dir resolves a stage" → that stage isn't missing.
+    found_by_kind: dict[str, str | None] = {"det": None, "cls": None, "rec": None}
+    for pkg_dir in candidate_package_dirs:
+        det_path, cls_path, rec_path = _resolve_rapidocr_model_paths(
+            model_cache_dir=cache_dir,
+            package_models_dir=pkg_dir,
+            lang_type=lang_type,
+            ocr_version=ocr_version,
+            model_type=model_type,
+        )
+        found_by_kind["det"] = found_by_kind["det"] or det_path
+        found_by_kind["cls"] = found_by_kind["cls"] or cls_path
+        found_by_kind["rec"] = found_by_kind["rec"] or rec_path
+        if all(found_by_kind.values()):
+            break
+    return [
+        item for item in required
+        if not found_by_kind.get(item["kind"])
+    ]

--- a/plugin/plugins/_shared/rapidocr/_paths.py
+++ b/plugin/plugins/_shared/rapidocr/_paths.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from utils.config_manager import get_config_manager
+
+
+_BUNDLED_KEY: tuple[str, str] = ("PP-OCRv4", "ch")
+_INSTALL_STATE_NAME = "install_state.json"
+
+
+def _expand_candidate_path(raw_path: str) -> Path:
+    return Path(os.path.expanduser(os.path.expandvars(raw_path)))
+
+
+def is_windows_platform() -> bool:
+    return sys.platform == "win32"
+
+
+def _app_runtimes_root() -> Path:
+    return get_config_manager().app_docs_dir / "runtimes" / "study_companion"
+
+
+def _legacy_galgame_rapidocr_target() -> Path:
+    return get_config_manager().app_docs_dir / "runtimes" / "galgame_plugin" / "RapidOCR"
+
+
+def _rapidocr_target_has_assets(target: Path, package_name: str) -> bool:
+    package_dir = target / "runtime" / "site-packages" / package_name
+    if package_dir.exists():
+        return True
+    models_dir = target / "models"
+    return models_dir.is_dir() and any(models_dir.iterdir())
+
+
+def default_rapidocr_install_target_raw() -> str:
+    if is_windows_platform():
+        return str(_app_runtimes_root() / "RapidOCR")
+    return ""
+
+
+def default_rapidocr_install_target_raw_legacy() -> str:
+    if is_windows_platform():
+        return "%LOCALAPPDATA%/Programs/N.E.K.O/RapidOCR"
+    return ""
+
+
+def resolve_rapidocr_install_target(raw_target_dir: str) -> Path:
+    from ._model_registry import RAPIDOCR_PACKAGE_NAME
+
+    normalized = str(raw_target_dir or "").strip()
+    if normalized:
+        return _expand_candidate_path(normalized)
+
+    target = _app_runtimes_root() / "RapidOCR"
+    if not target.exists():
+        galgame_target = _legacy_galgame_rapidocr_target()
+        if _rapidocr_target_has_assets(galgame_target, RAPIDOCR_PACKAGE_NAME):
+            return galgame_target
+        legacy_raw = default_rapidocr_install_target_raw_legacy()
+        if legacy_raw:
+            legacy_target = _expand_candidate_path(legacy_raw)
+            legacy_package_dir = (
+                legacy_target / "runtime" / "site-packages" / RAPIDOCR_PACKAGE_NAME
+            )
+            if legacy_package_dir.exists():
+                return legacy_target
+    return target
+
+
+def resolve_rapidocr_runtime_dir(raw_target_dir: str) -> Path:
+    target_dir = resolve_rapidocr_install_target(raw_target_dir)
+    return target_dir / "runtime" if target_dir else Path()
+
+
+def resolve_rapidocr_site_packages_dir(raw_target_dir: str) -> Path:
+    runtime_dir = resolve_rapidocr_runtime_dir(raw_target_dir)
+    return runtime_dir / "site-packages" if runtime_dir else Path()
+
+
+def resolve_rapidocr_model_cache_dir(raw_target_dir: str) -> Path:
+    target_dir = resolve_rapidocr_install_target(raw_target_dir)
+    return target_dir / "models" if target_dir else Path()
+
+
+def _rapidocr_install_state_path(raw_target_dir: str) -> Path:
+    target_dir = resolve_rapidocr_install_target(raw_target_dir)
+    return target_dir / _INSTALL_STATE_NAME if target_dir else Path()

--- a/plugin/plugins/_shared/rapidocr/_paths.py
+++ b/plugin/plugins/_shared/rapidocr/_paths.py
@@ -55,18 +55,18 @@ def resolve_rapidocr_install_target(raw_target_dir: str) -> Path:
         return _expand_candidate_path(normalized)
 
     target = _app_runtimes_root() / "RapidOCR"
-    if not target.exists():
-        galgame_target = _legacy_galgame_rapidocr_target()
-        if _rapidocr_target_has_assets(galgame_target, RAPIDOCR_PACKAGE_NAME):
-            return galgame_target
-        legacy_raw = default_rapidocr_install_target_raw_legacy()
-        if legacy_raw:
-            legacy_target = _expand_candidate_path(legacy_raw)
-            legacy_package_dir = (
-                legacy_target / "runtime" / "site-packages" / RAPIDOCR_PACKAGE_NAME
-            )
-            if legacy_package_dir.exists():
-                return legacy_target
+    if _rapidocr_target_has_assets(target, RAPIDOCR_PACKAGE_NAME):
+        return target
+
+    galgame_target = _legacy_galgame_rapidocr_target()
+    if _rapidocr_target_has_assets(galgame_target, RAPIDOCR_PACKAGE_NAME):
+        return galgame_target
+
+    legacy_raw = default_rapidocr_install_target_raw_legacy()
+    if legacy_raw:
+        legacy_target = _expand_candidate_path(legacy_raw)
+        if _rapidocr_target_has_assets(legacy_target, RAPIDOCR_PACKAGE_NAME):
+            return legacy_target
     return target
 
 

--- a/plugin/plugins/_shared/rapidocr/_runtime.py
+++ b/plugin/plugins/_shared/rapidocr/_runtime.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from ._model_registry import (
+    RAPIDOCR_PACKAGE_NAME,
+    _resolve_rapidocr_model_paths,
+    rapidocr_selected_model_name,
+)
+from ._paths import (
+    resolve_rapidocr_model_cache_dir,
+    resolve_rapidocr_site_packages_dir,
+)
+
+
+# Leave one core free for the OS / interactive use; floor at 2 so 1-2 core hosts still parallelise.
+_RAPIDOCR_INFERENCE_THREAD_LIMIT = max(2, (os.cpu_count() or 2) - 1)
+
+_RAPIDOCR_IMPORT_CONTEXT_LOCK = threading.RLock()
+
+
+@contextmanager
+def _rapidocr_import_context(
+    *,
+    site_packages_dir: Path,
+    model_cache_dir: Path,
+) -> Iterator[None]:
+    with _RAPIDOCR_IMPORT_CONTEXT_LOCK:
+        inserted = False
+        old_model_dir = os.environ.get("RAPIDOCR_MODEL_DIR")
+        old_model_home = os.environ.get("RAPIDOCR_MODEL_HOME")
+        dll_handles: list[Any] = []
+        # Legacy plugin-isolated install layout: only injected as a fallback
+        # when the bundled main-program rapidocr_onnxruntime is NOT importable.
+        # Otherwise sys.path order would let a stale legacy install shadow the
+        # bundled (likely newer) version, breaking upgrades for users who
+        # haven't manually cleaned %LOCALAPPDATA%/.../RapidOCR/runtime.
+        bundled_available = importlib.util.find_spec(RAPIDOCR_PACKAGE_NAME) is not None
+        use_legacy_layout = (
+            site_packages_dir
+            and site_packages_dir.is_dir()
+            and not bundled_available
+        )
+        if use_legacy_layout:
+            site_path = str(site_packages_dir)
+            if site_path not in sys.path:
+                sys.path.insert(0, site_path)
+                inserted = True
+            if hasattr(os, "add_dll_directory"):
+                for candidate in (
+                    site_packages_dir,
+                    site_packages_dir / "onnxruntime",
+                    site_packages_dir / "onnxruntime" / "capi",
+                ):
+                    if candidate.is_dir():
+                        try:
+                            dll_handles.append(os.add_dll_directory(str(candidate)))
+                        except OSError:
+                            continue
+        if model_cache_dir:
+            model_cache_dir.mkdir(parents=True, exist_ok=True)
+            os.environ["RAPIDOCR_MODEL_DIR"] = str(model_cache_dir)
+            os.environ["RAPIDOCR_MODEL_HOME"] = str(model_cache_dir)
+        try:
+            yield
+        finally:
+            for handle in dll_handles:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+            if old_model_dir is None:
+                os.environ.pop("RAPIDOCR_MODEL_DIR", None)
+            else:
+                os.environ["RAPIDOCR_MODEL_DIR"] = old_model_dir
+            if old_model_home is None:
+                os.environ.pop("RAPIDOCR_MODEL_HOME", None)
+            else:
+                os.environ["RAPIDOCR_MODEL_HOME"] = old_model_home
+            if inserted:
+                try:
+                    sys.path.remove(str(site_packages_dir))
+                except ValueError:
+                    pass
+
+
+def _rapidocr_package_dir(raw_target_dir: str) -> Path:
+    site_packages_dir = resolve_rapidocr_site_packages_dir(raw_target_dir)
+    return site_packages_dir / RAPIDOCR_PACKAGE_NAME if site_packages_dir else Path()
+
+def _build_runtime_constructor_kwargs(
+    runtime_class: type[Any],
+    *,
+    engine_type: str,
+    lang_type: str,
+    model_type: str,
+    ocr_version: str,
+    model_cache_dir: Path,
+    package_models_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Build kwargs passed to RapidOCR(...).
+
+    Bug history: the previous implementation only kept keys whose name
+    appeared in `inspect.signature(RapidOCR).parameters`. RapidOCR's signature
+    is `(config_path: Optional[str] = None, **kwargs)`, so `'engine_type' in
+    parameters` etc. were always False — every direct_value was silently
+    dropped, and `lang_type` / `ocr_version` never reached the runtime.
+    Real routing happens inside `UpdateParameters.__call__` (rapidocr's
+    `parse_parameters.py`), which dispatches kwargs by *name prefix*
+    (`det_*` / `cls_*` / `rec_*` / global). When a class accepts **kwargs,
+    we passthrough the model paths directly so RapidOCR can route them.
+    """
+    try:
+        parameters = inspect.signature(runtime_class).parameters
+    except (TypeError, ValueError):
+        return {}
+
+    has_var_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+    # Passthrough mode (RapidOCR's actual signature path): the runtime accepts
+    # **kwargs and routes by name prefix in `UpdateParameters.__call__`. We
+    # resolve det/cls/rec paths from disk and hand them through. The resolver
+    # checks two filename conventions per location — `_infer.onnx` (PaddleOCR
+    # / wheel-bundled) and `_mobile.onnx` (RapidAI ModelScope downloads via
+    # `download_rapidocr_models`). Only emit a model_path key when the file
+    # actually exists; passing a non-existent path makes RapidOCR silently
+    # fall back to its bundled config (wrong model, no error).
+    if has_var_kwargs:
+        det_path, cls_path, rec_path = _resolve_rapidocr_model_paths(
+            model_cache_dir=model_cache_dir,
+            package_models_dir=package_models_dir,
+            lang_type=lang_type,
+            ocr_version=ocr_version,
+            model_type=model_type,
+        )
+        kwargs: dict[str, Any] = {}
+        if det_path and rec_path:
+            kwargs["det_model_path"] = det_path
+            kwargs["rec_model_path"] = rec_path
+            if cls_path:
+                kwargs["cls_model_path"] = cls_path
+                cls_image_shape = _rapidocr_cls_image_shape_for_model(cls_path)
+                if cls_image_shape is not None:
+                    kwargs["cls_image_shape"] = cls_image_shape
+        if engine_type:
+            kwargs["engine_type"] = engine_type
+        return kwargs
+
+    kwargs: dict[str, Any] = {}
+
+    # Legacy / explicit-arg mode: older RapidOCR builds may take some of
+    # these as named parameters. inspect-by-name only catches them if they
+    # actually exist in the signature (the original intent).
+    direct_values = {
+        "engine_type": engine_type,
+        "lang_type": lang_type,
+        "model_type": model_type,
+        "ocr_version": ocr_version,
+        "det_model_type": model_type,
+        "cls_model_type": model_type,
+        "rec_model_type": model_type,
+        "cache_dir": str(model_cache_dir),
+        "model_dir": str(model_cache_dir),
+        "models_dir": str(model_cache_dir),
+        "model_root": str(model_cache_dir),
+    }
+    for key, value in direct_values.items():
+        if key in parameters:
+            kwargs[key] = value
+    return kwargs
+
+
+def _rapidocr_cls_image_shape_for_model(cls_path: str | None) -> list[int] | None:
+    if not cls_path:
+        return None
+    name = Path(cls_path).name.lower()
+    if "pp-lcnet" in name or "textline_ori_cls" in name:
+        return [3, 80, 160]
+    return None
+
+
+_SESSION_OPTIONS_PATCH_TLS = threading.local()
+_SESSION_OPTIONS_PATCH_LOCK = threading.Lock()
+_SESSION_OPTIONS_PATCH_INSTALLED = False
+
+
+def _ensure_session_options_patch_installed() -> None:
+    """Patch ort.SessionOptions.__init__ once; the patch only acts on threads that opted in."""
+    global _SESSION_OPTIONS_PATCH_INSTALLED
+    if _SESSION_OPTIONS_PATCH_INSTALLED:
+        return
+    with _SESSION_OPTIONS_PATCH_LOCK:
+        if _SESSION_OPTIONS_PATCH_INSTALLED:
+            return
+        try:
+            import onnxruntime as _ort
+        except Exception:
+            return
+        options_cls = getattr(_ort, "SessionOptions", None)
+        if options_cls is None:
+            return
+        orig_init = options_cls.__init__
+
+        def _patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+            orig_init(self, *args, **kwargs)
+            intra = getattr(_SESSION_OPTIONS_PATCH_TLS, "intra", None)
+            if intra is None:
+                return
+            if getattr(self, "intra_op_num_threads", 0) == 0:
+                self.intra_op_num_threads = intra
+
+        options_cls.__init__ = _patched_init
+        _SESSION_OPTIONS_PATCH_INSTALLED = True
+
+
+@contextmanager
+def _onnxruntime_intra_op_thread_cap(limit: int) -> Iterator[None]:
+    """Clamp SessionOptions.intra_op_num_threads on the calling thread only."""
+    _ensure_session_options_patch_installed()
+    prev = getattr(_SESSION_OPTIONS_PATCH_TLS, "intra", None)
+    _SESSION_OPTIONS_PATCH_TLS.intra = limit
+    try:
+        yield
+    finally:
+        if prev is None:
+            try:
+                del _SESSION_OPTIONS_PATCH_TLS.intra
+            except AttributeError:
+                pass
+        else:
+            _SESSION_OPTIONS_PATCH_TLS.intra = prev
+
+
+def load_rapidocr_runtime(
+    *,
+    install_target_dir_raw: str,
+    engine_type: str,
+    lang_type: str,
+    model_type: str,
+    ocr_version: str,
+) -> tuple[Any, dict[str, str]]:
+    site_packages_dir = resolve_rapidocr_site_packages_dir(install_target_dir_raw)
+    model_cache_dir = resolve_rapidocr_model_cache_dir(install_target_dir_raw)
+    with _rapidocr_import_context(
+        site_packages_dir=site_packages_dir,
+        model_cache_dir=model_cache_dir,
+    ):
+        importlib.invalidate_caches()
+        module = importlib.import_module(RAPIDOCR_PACKAGE_NAME)
+        runtime_class = getattr(module, "RapidOCR", None)
+        if runtime_class is None:
+            raise RuntimeError("RapidOCR runtime class not found")
+        module_file = getattr(module, "__file__", "") or ""
+        # Sentinel must be None (not Path()) — Path() resolves to CWD and would
+        # let _resolve_rapidocr_model_paths inadvertently scan the working
+        # directory if `__file__` were ever missing.
+        package_models_dir: Path | None = (
+            Path(module_file).resolve().parent / "models" if module_file else None
+        )
+        with _onnxruntime_intra_op_thread_cap(_RAPIDOCR_INFERENCE_THREAD_LIMIT):
+            runtime = runtime_class(
+                **_build_runtime_constructor_kwargs(
+                    runtime_class,
+                    engine_type=engine_type,
+                    lang_type=lang_type,
+                    model_type=model_type,
+                    ocr_version=ocr_version,
+                    model_cache_dir=model_cache_dir,
+                    package_models_dir=package_models_dir,
+                )
+            )
+    metadata = {
+        "detected_path": str(Path(getattr(module, "__file__", "")).resolve().parent),
+        "model_cache_dir": str(model_cache_dir),
+        "selected_model": rapidocr_selected_model_name(
+            ocr_version=ocr_version,
+            lang_type=lang_type,
+            model_type=model_type,
+        ),
+    }
+    return runtime, metadata

--- a/plugin/plugins/_shared/rapidocr/_runtime.py
+++ b/plugin/plugins/_shared/rapidocr/_runtime.py
@@ -13,6 +13,7 @@ from typing import Any, Iterator
 from ._model_registry import (
     RAPIDOCR_PACKAGE_NAME,
     _resolve_rapidocr_model_paths,
+    rapidocr_selection_requires_downloaded_models,
     rapidocr_selected_model_name,
 )
 from ._paths import (
@@ -144,20 +145,25 @@ def _build_runtime_constructor_kwargs(
             model_type=model_type,
         )
         kwargs: dict[str, Any] = {}
-        if not det_path or not rec_path:
+        requires_downloaded_models = rapidocr_selection_requires_downloaded_models(
+            ocr_version=ocr_version,
+            lang_type=lang_type,
+        )
+        if requires_downloaded_models and (not det_path or not rec_path):
             selected_model = rapidocr_selected_model_name(
                 ocr_version=ocr_version,
                 lang_type=lang_type,
                 model_type=model_type,
             )
             raise RuntimeError(f"RapidOCR model files are incomplete for {selected_model}")
-        kwargs["det_model_path"] = det_path
-        kwargs["rec_model_path"] = rec_path
-        if cls_path:
-            kwargs["cls_model_path"] = cls_path
-            cls_image_shape = _rapidocr_cls_image_shape_for_model(cls_path)
-            if cls_image_shape is not None:
-                kwargs["cls_image_shape"] = cls_image_shape
+        if det_path and rec_path:
+            kwargs["det_model_path"] = det_path
+            kwargs["rec_model_path"] = rec_path
+            if cls_path:
+                kwargs["cls_model_path"] = cls_path
+                cls_image_shape = _rapidocr_cls_image_shape_for_model(cls_path)
+                if cls_image_shape is not None:
+                    kwargs["cls_image_shape"] = cls_image_shape
         if engine_type:
             kwargs["engine_type"] = engine_type
         return kwargs

--- a/plugin/plugins/_shared/rapidocr/_runtime.py
+++ b/plugin/plugins/_shared/rapidocr/_runtime.py
@@ -144,14 +144,20 @@ def _build_runtime_constructor_kwargs(
             model_type=model_type,
         )
         kwargs: dict[str, Any] = {}
-        if det_path and rec_path:
-            kwargs["det_model_path"] = det_path
-            kwargs["rec_model_path"] = rec_path
-            if cls_path:
-                kwargs["cls_model_path"] = cls_path
-                cls_image_shape = _rapidocr_cls_image_shape_for_model(cls_path)
-                if cls_image_shape is not None:
-                    kwargs["cls_image_shape"] = cls_image_shape
+        if not det_path or not rec_path:
+            selected_model = rapidocr_selected_model_name(
+                ocr_version=ocr_version,
+                lang_type=lang_type,
+                model_type=model_type,
+            )
+            raise RuntimeError(f"RapidOCR model files are incomplete for {selected_model}")
+        kwargs["det_model_path"] = det_path
+        kwargs["rec_model_path"] = rec_path
+        if cls_path:
+            kwargs["cls_model_path"] = cls_path
+            cls_image_shape = _rapidocr_cls_image_shape_for_model(cls_path)
+            if cls_image_shape is not None:
+                kwargs["cls_image_shape"] = cls_image_shape
         if engine_type:
             kwargs["engine_type"] = engine_type
         return kwargs

--- a/plugin/plugins/_shared/rapidocr/ocr_backends.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_backends.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .ocr_rapidocr_backend import RapidOcrBackend
+from .ocr_runtime_types import (
+    OcrTextBox,
+    _CJK_CHAR_RE,
+    _KANA_CHAR_RE,
+    _LOCAL_RAPIDOCR_INFERENCE_LOCK,
+    _OCR_PREPARE_MAX_LONG_EDGE,
+    _OCR_PREPARE_TARGET_LONG_EDGE,
+    _OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE,
+    _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS,
+    _RapidOcrToken,
+    _join_ocr_segments,
+    _prepare_ocr_image,
+    _rapidocr_lines_from_output,
+    _rapidocr_points,
+    _rapidocr_runtime_cache_key,
+    _rapidocr_text_from_output,
+    _rapidocr_tokens_from_output,
+    _score_ocr_text,
+    _should_insert_ascii_space,
+    _significant_char_count,
+)
+
+
+class OcrBackend(Protocol):
+    def is_available(self) -> bool: ...
+
+    def extract_text(self, image: Any) -> str: ...
+
+
+def _shared_rapidocr_runtime(
+    _key: tuple[str, str, str, str, str],
+    *,
+    now: float,
+) -> Any | None:
+    from .ocr_runtime_types import _get_rapidocr_runtime_cache
+
+    return _get_rapidocr_runtime_cache(_key, now=now)
+
+
+def _store_shared_rapidocr_runtime(
+    _key: tuple[str, str, str, str, str],
+    runtime: Any,
+    *,
+    now: float,
+) -> None:
+    from .ocr_runtime_types import _store_rapidocr_runtime_cache
+
+    _store_rapidocr_runtime_cache(_key, runtime, now=now)
+
+
+def _rapidocr_inference_lock() -> Any:
+    from .ocr_runtime_types import _RAPIDOCR_INFERENCE_LOCK
+
+    return _RAPIDOCR_INFERENCE_LOCK
+
+
+__all__ = [
+    "OcrBackend",
+    "OcrTextBox",
+    "RapidOcrBackend",
+    "_CJK_CHAR_RE",
+    "_KANA_CHAR_RE",
+    "_LOCAL_RAPIDOCR_INFERENCE_LOCK",
+    "_OCR_PREPARE_MAX_LONG_EDGE",
+    "_OCR_PREPARE_TARGET_LONG_EDGE",
+    "_OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE",
+    "_RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS",
+    "_RapidOcrToken",
+    "_join_ocr_segments",
+    "_prepare_ocr_image",
+    "_rapidocr_inference_lock",
+    "_rapidocr_lines_from_output",
+    "_rapidocr_points",
+    "_rapidocr_runtime_cache_key",
+    "_rapidocr_text_from_output",
+    "_rapidocr_tokens_from_output",
+    "_score_ocr_text",
+    "_shared_rapidocr_runtime",
+    "_should_insert_ascii_space",
+    "_significant_char_count",
+    "_store_shared_rapidocr_runtime",
+]

--- a/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from .ocr_runtime_types import (
+    OcrTextBox,
+    _RAPIDOCR_INFERENCE_LOCK,
+    _RAPIDOCR_RUNTIME_CACHE_LOCK,
+    _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS,
+    _get_rapidocr_runtime_cache,
+    _prepare_ocr_image,
+    _rapidocr_lines_from_output,
+    _rapidocr_runtime_cache_key,
+    _rapidocr_text_from_output,
+    _store_rapidocr_runtime_cache,
+)
+from .rapidocr_support import (
+    inspect_rapidocr_installation,
+    load_rapidocr_runtime,
+)
+
+__all__ = ["RapidOcrBackend"]
+
+class RapidOcrBackend:
+    def __init__(
+        self,
+        *,
+        install_target_dir_raw: str,
+        engine_type: str,
+        lang_type: str,
+        model_type: str,
+        ocr_version: str,
+    ) -> None:
+        self._install_target_dir_raw = install_target_dir_raw
+        self._engine_type = engine_type
+        self._lang_type = lang_type
+        self._model_type = model_type
+        self._ocr_version = ocr_version
+        self._runtime = None
+        self._runtime_lock = threading.Lock()
+        self._runtime_cache_key: tuple[str, str, str, str, str] | None = None
+        self._runtime_last_used_at = 0.0
+        self._warmup_started = False
+        self._warmup_completed = False
+        self._warmup_error = ""
+
+    def is_available(self) -> bool:
+        inspection = inspect_rapidocr_installation(
+            install_target_dir_raw=self._install_target_dir_raw,
+            engine_type=self._engine_type,
+            lang_type=self._lang_type,
+            model_type=self._model_type,
+            ocr_version=self._ocr_version,
+        )
+        return bool(inspection.get("installed"))
+
+    def _ensure_runtime(self) -> Any:
+        now = time.monotonic()
+        key = _rapidocr_runtime_cache_key(
+            install_target_dir_raw=self._install_target_dir_raw,
+            engine_type=self._engine_type,
+            lang_type=self._lang_type,
+            model_type=self._model_type,
+            ocr_version=self._ocr_version,
+        )
+        with self._runtime_lock:
+            if (
+                self._runtime is not None
+                and self._runtime_cache_key == key
+                and now - float(self._runtime_last_used_at or 0.0) < _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+            ):
+                self._runtime_last_used_at = now
+                with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+                    _store_rapidocr_runtime_cache(key, self._runtime, now=now)
+                return self._runtime
+
+            self._runtime = None
+            self._runtime_cache_key = key
+            with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+                runtime = _get_rapidocr_runtime_cache(key, now=now)
+                if runtime is None:
+                    runtime, _metadata = load_rapidocr_runtime(
+                        install_target_dir_raw=self._install_target_dir_raw,
+                        engine_type=self._engine_type,
+                        lang_type=self._lang_type,
+                        model_type=self._model_type,
+                        ocr_version=self._ocr_version,
+                    )
+                    _store_rapidocr_runtime_cache(key, runtime, now=now)
+            self._runtime = runtime
+            self._runtime_last_used_at = now
+            return runtime
+
+    def warmup_async(self, logger: Any | None = None) -> None:
+        if self._warmup_started or self._warmup_completed:
+            return
+        self._warmup_started = True
+
+        def _warmup() -> None:
+            try:
+                import numpy as np
+                from PIL import Image
+
+                runtime = self._ensure_runtime()
+                with _RAPIDOCR_INFERENCE_LOCK:
+                    runtime(np.asarray(Image.new("RGB", (640, 360), "white")))
+                self._warmup_completed = True
+            except Exception as exc:
+                self._warmup_error = str(exc)
+                if logger is not None:
+                    try:
+                        logger.debug("ocr_reader RapidOCR warmup skipped/failed: {}", exc)
+                    except Exception:
+                        pass
+
+        threading.Thread(target=_warmup, name="shared-rapidocr-warmup", daemon=True).start()
+
+    def extract_text(self, image: Any) -> str:
+        import numpy as np
+
+        runtime = self._ensure_runtime()
+        prepared = _prepare_ocr_image(image, apply_filters=False).convert("RGB")
+        with _RAPIDOCR_INFERENCE_LOCK:
+            output = runtime(np.asarray(prepared))
+        return _rapidocr_text_from_output(output)
+
+    def extract_text_with_boxes(self, image: Any) -> tuple[str, list[OcrTextBox]]:
+        import numpy as np
+
+        runtime = self._ensure_runtime()
+        prepared = _prepare_ocr_image(image, apply_filters=False).convert("RGB")
+        with _RAPIDOCR_INFERENCE_LOCK:
+            output = runtime(np.asarray(prepared))
+        lines = _rapidocr_lines_from_output(output)
+        if not lines:
+            return "", []
+        scale_x = prepared.width / max(float(getattr(image, "width", prepared.width)), 1.0)
+        scale_y = prepared.height / max(float(getattr(image, "height", prepared.height)), 1.0)
+        boxes = [
+            OcrTextBox(
+                text=box.text,
+                left=box.left / scale_x,
+                top=box.top / scale_y,
+                right=box.right / scale_x,
+                bottom=box.bottom / scale_y,
+                score=float(score),
+            )
+            for _text, _score, box in lines
+            for score in (_score,)
+        ]
+        return "\n".join(text for text, _score, _box in lines), boxes

--- a/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_rapidocr_backend.py
@@ -147,7 +147,6 @@ class RapidOcrBackend:
                 bottom=box.bottom / scale_y,
                 score=float(score),
             )
-            for _text, _score, box in lines
-            for score in (_score,)
+            for _text, score, box in lines
         ]
         return "\n".join(text for text, _score, _box in lines), boxes

--- a/plugin/plugins/_shared/rapidocr/ocr_runtime_types.py
+++ b/plugin/plugins/_shared/rapidocr/ocr_runtime_types.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+
+_LOGGER = logging.getLogger(__name__)
+
+_RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS = 300.0
+_RAPIDOCR_RUNTIME_CACHE_LOCK = threading.RLock()
+_RAPIDOCR_RUNTIME_CACHE: dict[tuple[str, str, str, str, str], tuple[Any, float]] = {}
+_RAPIDOCR_INFERENCE_LOCK = threading.Lock()
+
+_OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE = 900
+_OCR_PREPARE_TARGET_LONG_EDGE = 1400
+_OCR_PREPARE_MAX_LONG_EDGE = 1600
+
+_CJK_CHAR_RE = re.compile(r"[\u3400-\u9fff]")
+_KANA_CHAR_RE = re.compile(r"[\u3040-\u30ff]")
+_HANGUL_RE = re.compile(r"[\uac00-\ud7af]")
+_SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_text(value: str) -> str:
+    return _SPACE_RE.sub(" ", str(value or "").replace("\u3000", " ")).strip()
+
+
+def _significant_char_count(text: str) -> int:
+    return sum(1 for ch in str(text or "") if ch.isalnum() or _CJK_CHAR_RE.match(ch) or _KANA_CHAR_RE.match(ch) or _HANGUL_RE.match(ch))
+
+
+def _score_ocr_text(text: str) -> int:
+    return _significant_char_count(normalize_text(text))
+
+
+def _should_insert_ascii_space(previous_text: str, next_text: str) -> bool:
+    if not previous_text or not next_text:
+        return False
+    left = previous_text[-1]
+    right = next_text[0]
+    return left.isascii() and right.isascii() and left.isalnum() and right.isalnum()
+
+
+def _join_ocr_segments(parts: list[str]) -> str:
+    rendered = ""
+    for part in parts:
+        normalized = normalize_text(str(part or "")).replace("\n", " ").strip()
+        if not normalized:
+            continue
+        if not rendered:
+            rendered = normalized
+            continue
+        if _should_insert_ascii_space(rendered, normalized):
+            rendered += " "
+        rendered += normalized
+    return rendered
+
+
+def _ocr_score_weight(text: str) -> int:
+    return max(_significant_char_count(text), 1)
+
+
+def _weighted_ocr_score(scores: Any) -> float:
+    total_weight = 0
+    weighted_sum = 0.0
+    for score, weight in scores:
+        normalized_weight = max(int(weight or 0), 1)
+        weighted_sum += float(score) * normalized_weight
+        total_weight += normalized_weight
+    if total_weight <= 0:
+        return 0.0
+    return max(0.0, min(1.0, weighted_sum / total_weight))
+
+
+def _rapidocr_runtime_cache_key(
+    *,
+    install_target_dir_raw: str,
+    engine_type: str,
+    lang_type: str,
+    model_type: str,
+    ocr_version: str,
+) -> tuple[str, str, str, str, str]:
+    return (
+        str(install_target_dir_raw or "").strip(),
+        str(engine_type or "").strip().lower(),
+        str(lang_type or "").strip().lower(),
+        str(model_type or "").strip().lower(),
+        str(ocr_version or "").strip(),
+    )
+
+
+def _prune_rapidocr_runtime_cache(now: float) -> None:
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        stale_keys = [
+            key
+            for key, (_runtime, last_used_at) in _RAPIDOCR_RUNTIME_CACHE.items()
+            if now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS
+        ]
+        for key in stale_keys:
+            _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+
+
+def _get_rapidocr_runtime_cache(
+    key: tuple[str, str, str, str, str],
+    *,
+    now: float,
+) -> Any | None:
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        cached = _RAPIDOCR_RUNTIME_CACHE.get(key)
+        if cached is None:
+            return None
+        runtime, last_used_at = cached
+        if now - float(last_used_at or 0.0) >= _RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS:
+            _RAPIDOCR_RUNTIME_CACHE.pop(key, None)
+            return None
+        _RAPIDOCR_RUNTIME_CACHE[key] = (runtime, now)
+        return runtime
+
+
+def _store_rapidocr_runtime_cache(
+    key: tuple[str, str, str, str, str],
+    runtime: Any,
+    *,
+    now: float,
+) -> None:
+    with _RAPIDOCR_RUNTIME_CACHE_LOCK:
+        _prune_rapidocr_runtime_cache(now)
+        _RAPIDOCR_RUNTIME_CACHE[key] = (runtime, now)
+
+
+def _prepare_ocr_image(image: Any, *, apply_filters: bool = True) -> Any:
+    from PIL import Image, ImageFilter, ImageOps
+
+    resampling = getattr(Image, "Resampling", Image)
+    prepared = image.convert("L")
+    prepared = ImageOps.autocontrast(prepared)
+    long_edge = max(prepared.width, prepared.height, 1)
+    scale = 1.0
+    if long_edge < _OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE:
+        scale = min(2.0, _OCR_PREPARE_TARGET_LONG_EDGE / float(long_edge))
+    elif long_edge > _OCR_PREPARE_MAX_LONG_EDGE:
+        scale = _OCR_PREPARE_MAX_LONG_EDGE / float(long_edge)
+    if abs(scale - 1.0) > 0.01:
+        prepared = prepared.resize(
+            (
+                max(int(round(prepared.width * scale)), 1),
+                max(int(round(prepared.height * scale)), 1),
+            ),
+            resampling.LANCZOS,
+        )
+        if apply_filters:
+            prepared = prepared.filter(ImageFilter.SHARPEN)
+    return prepared
+
+
+def _rapidocr_points(box: Any) -> list[tuple[float, float]]:
+    if hasattr(box, "tolist"):
+        box = box.tolist()
+    if not isinstance(box, (list, tuple)):
+        return []
+    points: list[tuple[float, float]] = []
+    for point in box:
+        if hasattr(point, "tolist"):
+            point = point.tolist()
+        if not isinstance(point, (list, tuple)) or len(point) < 2:
+            continue
+        try:
+            points.append((float(point[0]), float(point[1])))
+        except (TypeError, ValueError):
+            continue
+    return points
+
+
+@dataclass(slots=True)
+class _RapidOcrToken:
+    text: str
+    score: float
+    left: float
+    right: float
+    top: float
+    bottom: float
+    height: float
+
+
+@dataclass(slots=True)
+class OcrTextBox:
+    text: str
+    left: float
+    top: float
+    right: float
+    bottom: float
+    score: float = 0.0
+
+    def to_dict(self) -> dict[str, float | str]:
+        return {
+            "text": self.text,
+            "left": self.left,
+            "top": self.top,
+            "right": self.right,
+            "bottom": self.bottom,
+            "score": self.score,
+        }
+
+
+def _rapidocr_tokens_from_output(raw_output: Any) -> list[_RapidOcrToken]:
+    payload = raw_output[0] if isinstance(raw_output, tuple) and raw_output else raw_output
+    if not isinstance(payload, list):
+        return []
+    tokens: list[_RapidOcrToken] = []
+    low_confidence_count = 0
+    for item in payload:
+        if not isinstance(item, (list, tuple)) or len(item) < 3:
+            continue
+        box, text, score = item[0], item[1], item[2]
+        normalized = normalize_text(str(text or "")).strip()
+        if not normalized:
+            continue
+        try:
+            score_value = float(score)
+        except (TypeError, ValueError):
+            score_value = 0.0
+        if score_value < 0.30:
+            low_confidence_count += 1
+            continue
+        points = _rapidocr_points(box)
+        if not points:
+            continue
+        xs = [point[0] for point in points]
+        ys = [point[1] for point in points]
+        top = min(ys)
+        bottom = max(ys)
+        tokens.append(
+            _RapidOcrToken(
+                text=normalized,
+                score=score_value,
+                left=min(xs),
+                right=max(xs),
+                top=top,
+                bottom=bottom,
+                height=max(bottom - top, 1.0),
+            )
+        )
+    if low_confidence_count:
+        _LOGGER.debug("rapidocr discarded %d low-confidence token(s)", low_confidence_count)
+    return tokens
+
+
+def _rapidocr_lines_from_output(raw_output: Any) -> list[tuple[str, float, OcrTextBox]]:
+    tokens = _rapidocr_tokens_from_output(raw_output)
+    if not tokens:
+        return []
+    tokens.sort(key=lambda token: (token.top, token.left))
+    token_heights = sorted(max(1.0, float(token.height or 1.0)) for token in tokens)
+    median_height = token_heights[len(token_heights) // 2]
+    bucket_size = max(1.0, median_height * 0.75)
+    line_entries: list[dict[str, Any]] = []
+    line_buckets: dict[int, list[dict[str, Any]]] = {}
+
+    def _bucket_key(center: float) -> int:
+        return int(center // bucket_size)
+
+    def _add_line_bucket(entry: dict[str, Any]) -> None:
+        line_buckets.setdefault(int(entry["bucket"]), []).append(entry)
+
+    def _remove_line_bucket(entry: dict[str, Any]) -> None:
+        bucket = line_buckets.get(int(entry["bucket"]))
+        if bucket is None:
+            return
+        for index, item in enumerate(bucket):
+            if item is entry:
+                del bucket[index]
+                break
+        else:
+            return
+        if not bucket:
+            line_buckets.pop(int(entry["bucket"]), None)
+
+    def _refresh_line_entry(entry: dict[str, Any], *, top: float, bottom: float) -> float:
+        center = (top + bottom) / 2.0
+        new_bucket = _bucket_key(center)
+        if new_bucket != int(entry["bucket"]):
+            _remove_line_bucket(entry)
+            entry["bucket"] = new_bucket
+            _add_line_bucket(entry)
+        entry["top"] = top
+        entry["bottom"] = bottom
+        entry["center"] = center
+        return max(1.0, bottom - top)
+
+    max_line_height = max(1.0, tokens[0].height)
+    for token in tokens:
+        token_center = (token.top + token.bottom) / 2.0
+        best_entry: dict[str, Any] | None = None
+        best_distance = float("inf")
+        search_radius = max(2, int(max(max_line_height, token.height) / bucket_size) + 2)
+        candidate_entries: list[dict[str, Any]] = []
+        token_bucket = _bucket_key(token_center)
+        for bucket_key in range(token_bucket - search_radius, token_bucket + search_radius + 1):
+            candidate_entries.extend(line_buckets.get(bucket_key, ()))
+        for entry in candidate_entries:
+            line_top = float(entry["top"])
+            line_bottom = float(entry["bottom"])
+            line_center = float(entry["center"])
+            threshold = max((line_bottom - line_top) * 0.6, token.height * 0.6, token.height * 0.3)
+            distance = abs(token_center - line_center)
+            if distance <= threshold and distance < best_distance:
+                best_entry = entry
+                best_distance = distance
+        if best_entry is not None:
+            best_entry["tokens"].append(token)
+            line_height = _refresh_line_entry(
+                best_entry,
+                top=min(float(best_entry["top"]), token.top),
+                bottom=max(float(best_entry["bottom"]), token.bottom),
+            )
+            max_line_height = max(max_line_height, line_height)
+        else:
+            entry = {
+                "tokens": [token],
+                "top": token.top,
+                "bottom": token.bottom,
+                "center": token_center,
+                "bucket": _bucket_key(token_center),
+            }
+            line_entries.append(entry)
+            _add_line_bucket(entry)
+            max_line_height = max(max_line_height, token.height)
+
+    rendered_lines: list[str] = []
+    line_results: list[tuple[str, float, OcrTextBox]] = []
+    lines = [list(entry["tokens"]) for entry in line_entries]
+    lines.sort(key=lambda line: (min(item.top for item in line), min(item.left for item in line)))
+    for line in lines:
+        line.sort(key=lambda item: item.left)
+        text = _join_ocr_segments([item.text for item in line])
+        if not text:
+            continue
+        line_score = _weighted_ocr_score(
+            (item.score, _ocr_score_weight(item.text)) for item in line
+        )
+        rendered_lines.append(text)
+        line_results.append(
+            (
+                text,
+                line_score,
+                OcrTextBox(
+                    text=text,
+                    left=min(item.left for item in line),
+                    top=min(item.top for item in line),
+                    right=max(item.right for item in line),
+                    bottom=max(item.bottom for item in line),
+                    score=line_score,
+                ),
+            )
+        )
+    text = "\n".join(line for line in rendered_lines if line)
+    normalized = normalize_text(text)
+    if not normalized:
+        return []
+    average_score = _weighted_ocr_score(
+        (score, _ocr_score_weight(text)) for text, score, _box in line_results
+    )
+    if _significant_char_count(normalized) < 4 and average_score < 0.55:
+        return []
+    return line_results
+
+
+def _rapidocr_text_from_output(raw_output: Any) -> str:
+    lines = _rapidocr_lines_from_output(raw_output)
+    if not lines:
+        return ""
+    return "\n".join(text for text, _score, _box in lines)
+
+
+__all__ = [
+    "OcrTextBox",
+    "_CJK_CHAR_RE",
+    "_KANA_CHAR_RE",
+    "_LOCAL_RAPIDOCR_INFERENCE_LOCK",
+    "_OCR_PREPARE_MAX_LONG_EDGE",
+    "_OCR_PREPARE_TARGET_LONG_EDGE",
+    "_OCR_PREPARE_UPSCALE_SOURCE_LONG_EDGE",
+    "_RAPIDOCR_INFERENCE_LOCK",
+    "_RAPIDOCR_RUNTIME_CACHE_LOCK",
+    "_RAPIDOCR_RUNTIME_IDLE_TTL_SECONDS",
+    "_RapidOcrToken",
+    "_get_rapidocr_runtime_cache",
+    "_join_ocr_segments",
+    "_prepare_ocr_image",
+    "_rapidocr_lines_from_output",
+    "_rapidocr_points",
+    "_rapidocr_runtime_cache_key",
+    "_rapidocr_text_from_output",
+    "_rapidocr_tokens_from_output",
+    "_score_ocr_text",
+    "_should_insert_ascii_space",
+    "_significant_char_count",
+    "_store_rapidocr_runtime_cache",
+]
+
+_LOCAL_RAPIDOCR_INFERENCE_LOCK = _RAPIDOCR_INFERENCE_LOCK

--- a/plugin/plugins/_shared/rapidocr/rapidocr_support.py
+++ b/plugin/plugins/_shared/rapidocr/rapidocr_support.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+import types as _types
+from typing import Any
+
+from utils.config_manager import get_config_manager
+
+from ._model_registry import (
+    DEFAULT_RAPIDOCR_ENGINE_TYPE,
+    DEFAULT_RAPIDOCR_LANG_TYPE,
+    DEFAULT_RAPIDOCR_MODEL_TYPE,
+    DEFAULT_RAPIDOCR_OCR_VERSION,
+    RAPIDOCR_PACKAGE_NAME,
+    missing_rapidocr_model_files,
+    rapidocr_selected_model_name,
+    required_rapidocr_model_files,
+)
+from ._paths import (
+    default_rapidocr_install_target_raw,
+    default_rapidocr_install_target_raw_legacy,
+    is_windows_platform,
+    resolve_rapidocr_install_target,
+    resolve_rapidocr_model_cache_dir,
+    resolve_rapidocr_runtime_dir,
+    resolve_rapidocr_site_packages_dir,
+)
+from ._runtime import (
+    load_rapidocr_runtime,
+    _build_runtime_constructor_kwargs,
+    _onnxruntime_intra_op_thread_cap,
+)
+from ._inspect_download import (
+    ProgressCallback,
+    download_rapidocr_models,
+    inspect_rapidocr_installation,
+    _verify_model_sha256,
+)
+
+
+# Pre-split, all rapidocr names lived in this one module. After the split, tests
+# that monkeypatch ``rapidocr_support.<name>`` must keep affecting the call sites
+# in the submodules where the names now actually live (``download_rapidocr_models``,
+# ``load_rapidocr_runtime``, ``inspect_rapidocr_installation`` resolve their
+# helpers in their own module globals). This proxy reroutes the writes so the
+# old test-time semantics survive the split unchanged.
+_PROXY_TO_INSPECT_DOWNLOAD = frozenset(
+    {
+        "_verify_model_sha256",
+        "required_rapidocr_model_files",
+        "missing_rapidocr_model_files",
+    }
+)
+_PROXY_TO_RUNTIME = frozenset(
+    {
+        "_onnxruntime_intra_op_thread_cap",
+        "_build_runtime_constructor_kwargs",
+        "load_rapidocr_runtime",
+    }
+)
+_PROXY_TO_PATHS = frozenset(
+    {
+        "get_config_manager",
+        "is_windows_platform",
+    }
+)
+
+
+class _ShimModule(_types.ModuleType):
+    def __setattr__(self, name: str, value: Any) -> None:
+        super().__setattr__(name, value)
+        if name in _PROXY_TO_INSPECT_DOWNLOAD:
+            from . import _inspect_download
+
+            setattr(_inspect_download, name, value)
+        if name in _PROXY_TO_RUNTIME:
+            from . import _runtime
+
+            setattr(_runtime, name, value)
+        if name in _PROXY_TO_PATHS:
+            from . import _paths
+
+            setattr(_paths, name, value)
+
+
+sys.modules[__name__].__class__ = _ShimModule

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2681,6 +2681,7 @@ class StudyCompanionPlugin(NekoPluginBase):
                 install_target_dir_raw=self._cfg.rapidocr_install_target_dir,
                 ocr_version=self._cfg.rapidocr_ocr_version,
                 lang_type=self._cfg.rapidocr_lang_type,
+                model_type=self._cfg.rapidocr_model_type,
                 timeout_seconds=float(self._cfg.ocr_install_timeout_seconds or 180.0),
                 force=bool(force),
                 task_id=run_id or None,

--- a/plugin/plugins/study_companion/__init__.py
+++ b/plugin/plugins/study_companion/__init__.py
@@ -2672,7 +2672,7 @@ class StudyCompanionPlugin(NekoPluginBase):
             self._rapidocr_models_in_progress = True
         run_id = self._resolve_current_run_id(kwargs)
         try:
-            from plugin.plugins.galgame_plugin.rapidocr_support import (
+            from plugin.plugins._shared.rapidocr.rapidocr_support import (
                 download_rapidocr_models,
             )
 

--- a/plugin/plugins/study_companion/service.py
+++ b/plugin/plugins/study_companion/service.py
@@ -92,24 +92,17 @@ def build_dependency_status(config: StudyConfig) -> dict[str, Any]:
 
 
 def _inspect_rapidocr(config: StudyConfig) -> dict[str, Any]:
-    spec = importlib.util.find_spec("rapidocr_onnxruntime")
-    origin = str(getattr(spec, "origin", "") or "") if spec is not None else ""
-    installed = bool(spec)
-    return {
-        "install_supported": sys.platform == "win32",
-        "installed": installed,
-        "can_install": False,
-        "can_download_models": installed
-        and (config.rapidocr_lang_type, config.rapidocr_ocr_version)
-        != ("ch", "PP-OCRv4"),
-        "detected_path": str(Path(origin).resolve().parent) if origin else "",
-        "target_dir": config.rapidocr_install_target_dir,
-        "engine_type": config.rapidocr_engine_type,
-        "lang_type": config.rapidocr_lang_type,
-        "model_type": config.rapidocr_model_type,
-        "ocr_version": config.rapidocr_ocr_version,
-        "detail": "installed" if installed else "missing",
-    }
+    from plugin.plugins._shared.rapidocr.rapidocr_support import (
+        inspect_rapidocr_installation,
+    )
+
+    return inspect_rapidocr_installation(
+        install_target_dir_raw=config.rapidocr_install_target_dir,
+        engine_type=config.rapidocr_engine_type,
+        lang_type=config.rapidocr_lang_type,
+        model_type=config.rapidocr_model_type,
+        ocr_version=config.rapidocr_ocr_version,
+    )
 
 
 def _inspect_tesseract(config: StudyConfig) -> dict[str, Any]:

--- a/plugin/plugins/study_companion/study_capture_backends.py
+++ b/plugin/plugins/study_companion/study_capture_backends.py
@@ -215,7 +215,16 @@ class PrintWindowCaptureBackend(_BaseCaptureBackend):
     kind = CAPTURE_BACKEND_PRINTWINDOW
 
     def is_available(self) -> bool:
-        return sys.platform == "win32"
+        if sys.platform != "win32":
+            return False
+        try:
+            import win32con
+            import win32gui
+            import win32ui
+
+            return bool(win32con and win32gui and win32ui)
+        except ImportError:
+            return False
 
     def capture_frame(self, target: Any, profile: Any) -> Any:
         _require_visible_capture_target(target, backend_kind=self.kind)
@@ -243,13 +252,14 @@ class PrintWindowCaptureBackend(_BaseCaptureBackend):
         bmp = None
         mem_dc = None
         hdc_mem = None
+        previous_bitmap = None
         try:
             hdc_mem = win32ui.CreateDCFromHandle(hdc)
             mem_dc = hdc_mem.CreateCompatibleDC()
 
             bmp = win32ui.CreateBitmap()
             bmp.CreateCompatibleBitmap(hdc_mem, width, height)
-            mem_dc.SelectObject(bmp)
+            previous_bitmap = mem_dc.SelectObject(bmp)
 
             success = False
             try:
@@ -280,9 +290,12 @@ class PrintWindowCaptureBackend(_BaseCaptureBackend):
             )
         finally:
             if mem_dc is not None:
+                if previous_bitmap is not None:
+                    try:
+                        mem_dc.SelectObject(previous_bitmap)
+                    except Exception:
+                        pass
                 mem_dc.DeleteDC()
-            if hdc_mem is not None:
-                hdc_mem.DeleteDC()
             if bmp is not None:
                 win32gui.DeleteObject(bmp.GetHandle())
             win32gui.ReleaseDC(hwnd, hdc)
@@ -317,7 +330,8 @@ class DxcamCaptureBackend(_BaseCaptureBackend):
 
         _require_visible_capture_target(target, backend_kind=self.kind)
         rect = _target_window_rect(target)
-        frame = self._camera_instance().grab(region=rect)
+        with self._camera_lock:
+            frame = self._camera_instance().grab(region=rect)
         if frame is None:
             raise RuntimeError("dxcam returned no frame")
         image = Image.fromarray(frame)

--- a/plugin/plugins/study_companion/study_capture_backends.py
+++ b/plugin/plugins/study_companion/study_capture_backends.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import ctypes
+import sys
+import threading
+from collections.abc import Callable
+from typing import Any
+
+
+CAPTURE_BACKEND_DXCAM = "dxcam"
+CAPTURE_BACKEND_MSS = "mss"
+CAPTURE_BACKEND_PRINTWINDOW = "printwindow"
+CAPTURE_BACKEND_PYAUTOGUI = "pyautogui"
+
+
+def _target_value(target: Any, name: str, default: Any = 0) -> Any:
+    if isinstance(target, dict):
+        return target.get(name, default)
+    return getattr(target, name, default)
+
+
+def _target_window_rect(target: Any) -> tuple[int, int, int, int]:
+    hwnd = int(_target_value(target, "hwnd", 0) or 0)
+    if hwnd and sys.platform == "win32":
+        try:
+            import win32gui
+
+            def _read_rect() -> tuple[int, int, int, int]:
+                left, top, right, bottom = win32gui.GetWindowRect(hwnd)
+                return int(left), int(top), int(right), int(bottom)
+
+            return _run_with_thread_dpi_awareness(_read_rect)
+        except Exception:
+            pass
+
+    left = int(_target_value(target, "left", _target_value(target, "x", 0)) or 0)
+    top = int(_target_value(target, "top", _target_value(target, "y", 0)) or 0)
+    right = _target_value(target, "right", None)
+    bottom = _target_value(target, "bottom", None)
+    width = int(_target_value(target, "width", 0) or 0)
+    height = int(_target_value(target, "height", 0) or 0)
+    if right is None:
+        right = left + width
+    if bottom is None:
+        bottom = top + height
+    rect = (left, top, int(right or 0), int(bottom or 0))
+    if rect[2] <= rect[0] or rect[3] <= rect[1]:
+        raise RuntimeError("study OCR target has no usable screen rectangle")
+    return rect
+
+
+def _run_with_thread_dpi_awareness(
+    fn: Callable[[], tuple[int, int, int, int]],
+) -> tuple[int, int, int, int]:
+    windll = getattr(ctypes, "windll", None)
+    user32 = getattr(windll, "user32", None) if windll is not None else None
+    set_context = (
+        getattr(user32, "SetThreadDpiAwarenessContext", None)
+        if user32 is not None
+        else None
+    )
+    if not callable(set_context):
+        return fn()
+    try:
+        set_context.restype = ctypes.c_void_p
+        set_context.argtypes = [ctypes.c_void_p]
+    except Exception:
+        pass
+    old_context = None
+    try:
+        old_context = set_context(ctypes.c_void_p(-4))
+    except Exception:
+        old_context = None
+    try:
+        return fn()
+    finally:
+        if old_context is not None:
+            try:
+                set_context(old_context)
+            except Exception:
+                pass
+
+
+def _target_hwnd(target: Any, *, backend_kind: str) -> int:
+    hwnd = int(_target_value(target, "hwnd", 0) or 0)
+    if hwnd <= 0:
+        raise RuntimeError(f"{backend_kind} capture requires target hwnd")
+    return hwnd
+
+
+def _require_visible_capture_target(target: Any, *, backend_kind: str) -> None:
+    if target is None:
+        raise RuntimeError(f"{backend_kind} capture requires a target window")
+    if bool(_target_value(target, "is_minimized", False)):
+        raise RuntimeError(f"{backend_kind} capture target is minimized")
+    if bool(_target_value(target, "eligible", True)) is False:
+        reason = str(_target_value(target, "exclude_reason", "") or "ineligible")
+        raise RuntimeError(f"{backend_kind} capture target is not eligible: {reason}")
+
+
+def _crop_image_to_profile(image: Any, profile: Any) -> Any:
+    width = max(int(getattr(image, "width", 0) or 0), 1)
+    height = max(int(getattr(image, "height", 0) or 0), 1)
+    left = int(width * max(0.0, min(float(getattr(profile, "left_inset_ratio", 0.0) or 0.0), 1.0)))
+    right = width - int(width * max(0.0, min(float(getattr(profile, "right_inset_ratio", 0.0) or 0.0), 1.0)))
+    top = int(height * max(0.0, min(float(getattr(profile, "top_ratio", 0.0) or 0.0), 1.0)))
+    bottom = height - int(height * max(0.0, min(float(getattr(profile, "bottom_inset_ratio", 0.0) or 0.0), 1.0)))
+    if right <= left or bottom <= top:
+        return image
+    return image.crop((left, top, right, bottom))
+
+
+def _is_window_on_primary_monitor(rect: tuple[int, int, int, int]) -> tuple[bool, str]:
+    import pyautogui
+
+    left, top, right, bottom = rect
+    primary_w, primary_h = pyautogui.size()
+    if left >= primary_w:
+        return False, "window_entirely_in_right_secondary_monitor"
+    if right <= 0:
+        return False, "window_entirely_in_left_secondary_monitor"
+    if top >= primary_h:
+        return False, "window_entirely_in_bottom_secondary_monitor"
+    if bottom <= 0:
+        return False, "window_entirely_in_top_secondary_monitor"
+    if left < 0 or top < 0 or right > primary_w or bottom > primary_h:
+        return False, "window_spans_across_primary_and_secondary_monitor"
+    return True, ""
+
+
+class _BaseCaptureBackend:
+    kind = ""
+
+    def describe_target(self, target: Any) -> str:
+        process = str(_target_value(target, "process_name", "") or "")
+        pid = int(_target_value(target, "pid", 0) or 0)
+        title = str(_target_value(target, "title", "") or "")
+        return f"{process}({pid}) {title}".strip()
+
+
+class MssCaptureBackend(_BaseCaptureBackend):
+    kind = CAPTURE_BACKEND_MSS
+
+    def __init__(self) -> None:
+        self._sct = None
+        self._sct_lock = threading.RLock()
+
+    def is_available(self) -> bool:
+        try:
+            import mss
+
+            return bool(mss)
+        except ImportError:
+            return False
+
+    def _sct_instance(self) -> Any:
+        with self._sct_lock:
+            if self._sct is not None:
+                return self._sct
+            import mss
+
+            self._sct = mss.mss()
+            return self._sct
+
+    def capture_frame(self, target: Any, profile: Any) -> Any:
+        from PIL import Image
+
+        _require_visible_capture_target(target, backend_kind=self.kind)
+        left, top, right, bottom = _target_window_rect(target)
+        monitor = {
+            "left": int(left),
+            "top": int(top),
+            "width": int(right - left),
+            "height": int(bottom - top),
+        }
+        with self._sct_lock:
+            shot = self._sct_instance().grab(monitor)
+        image = Image.frombytes("RGB", shot.size, shot.rgb)
+        return _crop_image_to_profile(image, profile)
+
+
+class PyAutoGuiCaptureBackend(_BaseCaptureBackend):
+    kind = CAPTURE_BACKEND_PYAUTOGUI
+
+    def is_available(self) -> bool:
+        try:
+            import pyautogui
+
+            return bool(pyautogui)
+        except ImportError:
+            return False
+
+    def capture_frame(self, target: Any, profile: Any) -> Any:
+        import pyautogui
+
+        _require_visible_capture_target(target, backend_kind=self.kind)
+        left, top, right, bottom = _target_window_rect(target)
+        if sys.platform == "win32":
+            on_primary, reason = _is_window_on_primary_monitor((left, top, right, bottom))
+            if not on_primary:
+                primary_w, primary_h = pyautogui.size()
+                raise RuntimeError(
+                    f"pyautogui: {reason}"
+                    f" rect=({left},{top},{right},{bottom})"
+                    f" primary=({primary_w},{primary_h})"
+                    " -- switch to dxcam or mss backend for multi-monitor support"
+                )
+        image = pyautogui.screenshot(region=(left, top, right - left, bottom - top))
+        if getattr(image, "mode", "RGB") != "RGB":
+            image = image.convert("RGB")
+        return _crop_image_to_profile(image, profile)
+
+
+class PrintWindowCaptureBackend(_BaseCaptureBackend):
+    kind = CAPTURE_BACKEND_PRINTWINDOW
+
+    def is_available(self) -> bool:
+        return sys.platform == "win32"
+
+    def capture_frame(self, target: Any, profile: Any) -> Any:
+        _require_visible_capture_target(target, backend_kind=self.kind)
+        hwnd = _target_hwnd(target, backend_kind=self.kind)
+        rect = _target_window_rect(target)
+        image = self._capture_full_window(hwnd, rect)
+        return _crop_image_to_profile(image, profile)
+
+    @staticmethod
+    def _capture_full_window(hwnd: int, rect: tuple[int, int, int, int]) -> Any:
+        import win32con
+        import win32gui
+        import win32ui
+        from PIL import Image
+
+        width = int(rect[2] - rect[0])
+        height = int(rect[3] - rect[1])
+        if width <= 0 or height <= 0:
+            raise RuntimeError(f"Invalid window dimensions: {width}x{height}")
+
+        hdc = win32gui.GetWindowDC(hwnd)
+        if not hdc:
+            raise RuntimeError("Failed to get window DC")
+
+        bmp = None
+        mem_dc = None
+        hdc_mem = None
+        try:
+            hdc_mem = win32ui.CreateDCFromHandle(hdc)
+            mem_dc = hdc_mem.CreateCompatibleDC()
+
+            bmp = win32ui.CreateBitmap()
+            bmp.CreateCompatibleBitmap(hdc_mem, width, height)
+            mem_dc.SelectObject(bmp)
+
+            success = False
+            try:
+                version = sys.getwindowsversion()
+                if version.major > 6 or (version.major == 6 and version.minor >= 3):
+                    success = bool(
+                        ctypes.windll.user32.PrintWindow(
+                            hwnd,
+                            mem_dc.GetSafeHdc(),
+                            3,
+                        )
+                    )
+            except Exception:
+                success = False
+            if not success:
+                mem_dc.BitBlt((0, 0), (width, height), hdc_mem, (0, 0), win32con.SRCCOPY)
+
+            bmp_info = bmp.GetInfo()
+            bmp_str = bmp.GetBitmapBits(True)
+            return Image.frombuffer(
+                "RGB",
+                (bmp_info["bmWidth"], bmp_info["bmHeight"]),
+                bmp_str,
+                "raw",
+                "BGRX",
+                0,
+                1,
+            )
+        finally:
+            if mem_dc is not None:
+                mem_dc.DeleteDC()
+            if hdc_mem is not None:
+                hdc_mem.DeleteDC()
+            if bmp is not None:
+                win32gui.DeleteObject(bmp.GetHandle())
+            win32gui.ReleaseDC(hwnd, hdc)
+
+
+class DxcamCaptureBackend(_BaseCaptureBackend):
+    kind = CAPTURE_BACKEND_DXCAM
+
+    def __init__(self) -> None:
+        self._camera = None
+        self._camera_lock = threading.RLock()
+
+    def is_available(self) -> bool:
+        try:
+            import dxcam
+
+            return bool(dxcam)
+        except ImportError:
+            return False
+
+    def _camera_instance(self) -> Any:
+        with self._camera_lock:
+            if self._camera is not None:
+                return self._camera
+            import dxcam
+
+            self._camera = dxcam.create(output_color="RGB")
+            return self._camera
+
+    def capture_frame(self, target: Any, profile: Any) -> Any:
+        from PIL import Image
+
+        _require_visible_capture_target(target, backend_kind=self.kind)
+        rect = _target_window_rect(target)
+        frame = self._camera_instance().grab(region=rect)
+        if frame is None:
+            raise RuntimeError("dxcam returned no frame")
+        image = Image.fromarray(frame)
+        return _crop_image_to_profile(image, profile)
+
+
+__all__ = [
+    "CAPTURE_BACKEND_DXCAM",
+    "CAPTURE_BACKEND_MSS",
+    "CAPTURE_BACKEND_PRINTWINDOW",
+    "CAPTURE_BACKEND_PYAUTOGUI",
+    "DxcamCaptureBackend",
+    "MssCaptureBackend",
+    "PrintWindowCaptureBackend",
+    "PyAutoGuiCaptureBackend",
+]

--- a/plugin/plugins/study_companion/study_ocr_pipeline.py
+++ b/plugin/plugins/study_companion/study_ocr_pipeline.py
@@ -137,7 +137,7 @@ class StudyOcrPipeline:
     @staticmethod
     def _join_segments(parts: list[str]) -> str:
         try:
-            from plugin.plugins.galgame_plugin.ocr_backends import _join_ocr_segments
+            from plugin.plugins._shared.rapidocr.ocr_backends import _join_ocr_segments
 
             return _join_ocr_segments(parts)
         except Exception:
@@ -164,7 +164,7 @@ class StudyOcrPipeline:
                 languages=self._config.ocr_languages,
             )
         else:
-            from plugin.plugins.galgame_plugin.ocr_backends import RapidOcrBackend
+            from plugin.plugins._shared.rapidocr.ocr_backends import RapidOcrBackend
 
             self._ocr_backend = RapidOcrBackend(
                 install_target_dir_raw=self._config.rapidocr_install_target_dir,
@@ -178,7 +178,7 @@ class StudyOcrPipeline:
     def _resolve_capture_backend(self) -> Any:
         if self._capture_backend is not None:
             return self._capture_backend
-        from plugin.plugins.galgame_plugin.ocr_capture import (
+        from .study_capture_backends import (
             DxcamCaptureBackend,
             MssCaptureBackend,
             PrintWindowCaptureBackend,

--- a/plugin/server/http_app.py
+++ b/plugin/server/http_app.py
@@ -48,21 +48,31 @@ def _can_register_faulthandler_signal() -> bool:
     return hasattr(faulthandler, "register") and hasattr(signal, "SIGUSR1")
 
 
-def _include_optional_router(app: FastAPI, module_name: str, description: str) -> None:
+def _include_optional_router(
+    app: FastAPI,
+    *,
+    module_name: str,
+    router_name: str = "router",
+    label: str,
+) -> None:
     try:
         module = importlib.import_module(module_name)
     except ImportError as exc:
         logger.warning(
             "{} unavailable, endpoints will be 404: err_type={}, err={}",
-            description,
+            label,
             type(exc).__name__,
             str(exc),
         )
         return
 
-    router = getattr(module, "router", None)
+    router = getattr(module, router_name, None)
     if router is None:
-        logger.warning("{} unavailable, endpoints will be 404: missing router", description)
+        logger.error(
+            "{} unavailable, endpoints will be 404: missing {}",
+            label,
+            router_name,
+        )
         return
 
     app.include_router(router)
@@ -195,13 +205,13 @@ def build_plugin_server_app(title: str = "N.E.K.O User Plugin Server") -> FastAP
     # import-time failures must not prevent the base plugin server from starting.
     _include_optional_router(
         app,
-        "plugin.plugins.galgame_plugin.install_routes",
-        "galgame install routes",
+        module_name="plugin.plugins.galgame_plugin.install_routes",
+        label="galgame install routes",
     )
     _include_optional_router(
         app,
-        "plugin.plugins.bilibili_danmaku.i18n_routes",
-        "bilibili i18n routes",
+        module_name="plugin.plugins.bilibili_danmaku.i18n_routes",
+        label="bilibili i18n routes",
     )
     app.include_router(plugin_cli_router)
     app.include_router(llm_tools_router)

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import os
 import shutil
@@ -57,6 +58,7 @@ from plugin.plugins.study_companion.state import build_initial_state
 from plugin.plugins.study_companion.store import StudyStore
 from plugin.plugins.study_companion import study_capture_backends as study_capture_backends_module
 from plugin.plugins.study_companion.study_capture_backends import (
+    DxcamCaptureBackend,
     PrintWindowCaptureBackend,
     PyAutoGuiCaptureBackend,
 )
@@ -1436,6 +1438,106 @@ def test_printwindow_capture_requires_hwnd() -> None:
         PrintWindowCaptureBackend().capture_frame(target, StudyCaptureProfile())
 
 
+def test_printwindow_capture_unavailable_when_pywin32_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"win32con", "win32gui", "win32ui"}:
+            raise ImportError(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(study_capture_backends_module.sys, "platform", "win32")
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    assert PrintWindowCaptureBackend().is_available() is False
+
+
+def test_printwindow_capture_releases_window_dc_without_deleting_wrapped_hdc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    previous_bitmap = object()
+
+    class _Bitmap:
+        def CreateCompatibleBitmap(self, _source_dc, width: int, height: int) -> None:
+            calls.append(f"create_bitmap:{width}x{height}")
+
+        def GetInfo(self) -> dict[str, int]:
+            return {"bmWidth": 2, "bmHeight": 2}
+
+        def GetBitmapBits(self, _as_bytes: bool) -> bytes:
+            return b"\x00" * 16
+
+        def GetHandle(self) -> int:
+            return 123
+
+    bitmap = _Bitmap()
+
+    class _MemDc:
+        def SelectObject(self, obj):
+            calls.append("restore_bitmap" if obj is previous_bitmap else "select_bitmap")
+            return previous_bitmap
+
+        def GetSafeHdc(self) -> int:
+            return 456
+
+        def BitBlt(self, *_args) -> None:
+            calls.append("bitblt")
+
+        def DeleteDC(self) -> None:
+            calls.append("mem_delete")
+
+    mem_dc = _MemDc()
+
+    class _SourceDc:
+        def CreateCompatibleDC(self):
+            return mem_dc
+
+        def DeleteDC(self) -> None:
+            calls.append("source_delete")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "win32gui",
+        SimpleNamespace(
+            GetWindowDC=lambda _hwnd: 789,
+            DeleteObject=lambda _handle: calls.append("delete_object"),
+            ReleaseDC=lambda _hwnd, _hdc: calls.append("release_dc"),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "win32ui",
+        SimpleNamespace(
+            CreateDCFromHandle=lambda _hdc: _SourceDc(),
+            CreateBitmap=lambda: bitmap,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "win32con", SimpleNamespace(SRCCOPY=1))
+    monkeypatch.setattr(
+        study_capture_backends_module.ctypes,
+        "windll",
+        SimpleNamespace(user32=SimpleNamespace(PrintWindow=lambda *_args: 0)),
+        raising=False,
+    )
+
+    image = PrintWindowCaptureBackend._capture_full_window(1234, (0, 0, 2, 2))
+
+    assert image.size == (2, 2)
+    assert calls == [
+        "create_bitmap:2x2",
+        "select_bitmap",
+        "bitblt",
+        "restore_bitmap",
+        "mem_delete",
+        "delete_object",
+        "release_dc",
+    ]
+    assert "source_delete" not in calls
+
+
 def test_win32_target_window_rect_reads_under_dpi_aware_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1500,6 +1602,52 @@ def test_pyautogui_capture_rejects_secondary_monitor_target(
     with pytest.raises(RuntimeError, match="secondary_monitor|spans_across"):
         PyAutoGuiCaptureBackend().capture_frame(target, StudyCaptureProfile())
     assert screenshot_calls == 0
+
+
+def test_dxcam_capture_serializes_grab_with_camera_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from PIL import Image
+
+    calls: list[str] = []
+
+    class _Lock:
+        def __enter__(self):
+            calls.append("lock_enter")
+
+        def __exit__(self, *_exc):
+            calls.append("lock_exit")
+
+    class _Camera:
+        def grab(self, *, region):
+            calls.append(f"grab:{region}")
+            return object()
+
+    backend = DxcamCaptureBackend()
+    backend._camera = _Camera()
+    backend._camera_lock = _Lock()
+    monkeypatch.setattr(
+        study_capture_backends_module,
+        "_target_window_rect",
+        lambda _target: (1, 2, 3, 4),
+    )
+    monkeypatch.setattr(
+        study_capture_backends_module,
+        "_require_visible_capture_target",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(Image, "fromarray", lambda _frame: Image.new("RGB", (2, 2)))
+
+    image = backend.capture_frame(object(), StudyCaptureProfile())
+
+    assert image.size == (2, 2)
+    assert calls == [
+        "lock_enter",
+        "lock_enter",
+        "lock_exit",
+        "grab:(1, 2, 3, 4)",
+        "lock_exit",
+    ]
 
 
 def test_ocr_pipeline_handles_empty_text_repeats_and_errors() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion.py
+++ b/plugin/tests/unit/plugins/test_study_companion.py
@@ -55,6 +55,11 @@ from plugin.plugins.study_companion.models import (
 )
 from plugin.plugins.study_companion.state import build_initial_state
 from plugin.plugins.study_companion.store import StudyStore
+from plugin.plugins.study_companion import study_capture_backends as study_capture_backends_module
+from plugin.plugins.study_companion.study_capture_backends import (
+    PrintWindowCaptureBackend,
+    PyAutoGuiCaptureBackend,
+)
 from plugin.plugins.study_companion.study_ocr_pipeline import (
     StudyCaptureProfile,
     StudyOcrPipeline,
@@ -1376,11 +1381,125 @@ def test_study_ocr_pipeline_uses_local_capture_profile() -> None:
     assert profile.bottom_inset_ratio == 0.14
 
 
-def test_study_companion_does_not_import_galgame_ocr_reader_directly() -> None:
+def test_study_companion_does_not_import_galgame_namespace_directly() -> None:
     plugin_dir = Path(__file__).resolve().parents[3] / "plugins" / "study_companion"
-    for path in plugin_dir.glob("*.py"):
+    for path in plugin_dir.rglob("*.py"):
         source = path.read_text(encoding="utf-8")
-        assert "plugin.plugins.galgame_plugin.ocr_reader" not in source
+        assert "plugin.plugins.galgame_plugin" not in source
+
+
+def test_printwindow_capture_uses_hwnd_capture_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from PIL import Image
+
+    calls: list[tuple[int, tuple[int, int, int, int]]] = []
+
+    def _capture_full_window(hwnd: int, rect: tuple[int, int, int, int]):
+        calls.append((hwnd, rect))
+        return Image.new("RGB", (rect[2] - rect[0], rect[3] - rect[1]))
+
+    monkeypatch.setattr(
+        PrintWindowCaptureBackend,
+        "_capture_full_window",
+        staticmethod(_capture_full_window),
+    )
+    target = SimpleNamespace(
+        hwnd=1234,
+        left=10,
+        top=20,
+        width=100,
+        height=80,
+        is_minimized=False,
+        eligible=True,
+    )
+
+    image = PrintWindowCaptureBackend().capture_frame(
+        target,
+        StudyCaptureProfile(left_inset_ratio=0.0, right_inset_ratio=0.0),
+    )
+
+    assert image.size == (100, 80)
+    assert calls == [(1234, (10, 20, 110, 100))]
+
+
+def test_printwindow_capture_requires_hwnd() -> None:
+    target = SimpleNamespace(
+        hwnd=0,
+        left=10,
+        top=20,
+        width=100,
+        height=80,
+        is_minimized=False,
+        eligible=True,
+    )
+
+    with pytest.raises(RuntimeError, match="target hwnd"):
+        PrintWindowCaptureBackend().capture_frame(target, StudyCaptureProfile())
+
+
+def test_win32_target_window_rect_reads_under_dpi_aware_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[object] = []
+
+    class _User32:
+        def SetThreadDpiAwarenessContext(self, context):
+            value = getattr(context, "value", context)
+            calls.append(value)
+            return 99
+
+    monkeypatch.setattr(study_capture_backends_module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        study_capture_backends_module.ctypes,
+        "windll",
+        SimpleNamespace(user32=_User32()),
+        raising=False,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "win32gui",
+        SimpleNamespace(
+            GetWindowRect=lambda _hwnd: calls.append("get_window_rect")
+            or (10, 20, 110, 100)
+        ),
+    )
+
+    rect = study_capture_backends_module._target_window_rect(
+        SimpleNamespace(hwnd=1234)
+    )
+
+    assert rect == (10, 20, 110, 100)
+    per_monitor_v2 = study_capture_backends_module.ctypes.c_void_p(-4).value
+    assert calls == [per_monitor_v2, "get_window_rect", 99]
+
+
+def test_pyautogui_capture_rejects_secondary_monitor_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screenshot_calls = 0
+
+    def _screenshot(**_kwargs):
+        nonlocal screenshot_calls
+        screenshot_calls += 1
+
+    monkeypatch.setitem(
+        sys.modules,
+        "pyautogui",
+        SimpleNamespace(size=lambda: (1920, 1080), screenshot=_screenshot),
+    )
+    monkeypatch.setattr(study_capture_backends_module.sys, "platform", "win32")
+    target = SimpleNamespace(
+        hwnd=0,
+        left=2000,
+        top=100,
+        width=400,
+        height=300,
+        is_minimized=False,
+        eligible=True,
+    )
+
+    with pytest.raises(RuntimeError, match="secondary_monitor|spans_across"):
+        PyAutoGuiCaptureBackend().capture_frame(target, StudyCaptureProfile())
+    assert screenshot_calls == 0
 
 
 def test_ocr_pipeline_handles_empty_text_repeats_and_errors() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
+++ b/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
@@ -184,6 +184,28 @@ def test_shared_rapidocr_kwargs_fail_when_configured_model_is_missing(
         )
 
 
+def test_shared_rapidocr_kwargs_allows_unregistered_model_fallback(
+    tmp_path: Path,
+) -> None:
+    model_cache_dir = tmp_path / "RapidOCR" / "models"
+    package_models_dir = tmp_path / "package" / "models"
+    package_models_dir.mkdir(parents=True)
+    (package_models_dir / "ch_PP-OCRv4_det_infer.onnx").write_text("", encoding="utf-8")
+    (package_models_dir / "ch_PP-OCRv4_rec_infer.onnx").write_text("", encoding="utf-8")
+
+    kwargs = shared_rapidocr_runtime._build_runtime_constructor_kwargs(
+        _RapidOcrWithKwargs,
+        engine_type="onnxruntime",
+        lang_type="multi",
+        model_type="mobile",
+        ocr_version="PP-OCRv4",
+        model_cache_dir=model_cache_dir,
+        package_models_dir=package_models_dir,
+    )
+
+    assert kwargs == {"engine_type": "onnxruntime"}
+
+
 def test_shared_rapidocr_inspection_returns_install_state(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
+++ b/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from plugin.plugins._shared.rapidocr import rapidocr_support as shared_rapidocr_support
 from plugin.plugins.study_companion.models import OcrSnapshot, StudyConfig, TutorReply
 from plugin.plugins.study_companion.service import (
     _available_tesseract_languages,
@@ -83,6 +84,35 @@ def test_dependency_status_uses_installability_and_tesseract_language_fallbacks(
 
     assert status["missing_installable"] == ["rapidocr", "dxcam"]
     assert languages == {"eng"}
+
+
+def test_study_rapidocr_resolve_uses_galgame_runtime_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app_docs_dir = tmp_path / "AppDocs"
+    galgame_target = app_docs_dir / "runtimes" / "galgame_plugin" / "RapidOCR"
+    (galgame_target / "models").mkdir(parents=True)
+    (galgame_target / "models" / "japan_PP-OCRv4_rec_infer.onnx").write_bytes(
+        b"model"
+    )
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "EmptyLocalAppData"))
+    monkeypatch.setattr(shared_rapidocr_support, "is_windows_platform", lambda: True)
+    monkeypatch.setattr(
+        shared_rapidocr_support,
+        "get_config_manager",
+        lambda: SimpleNamespace(app_docs_dir=app_docs_dir),
+    )
+
+    raw_target = shared_rapidocr_support.default_rapidocr_install_target_raw()
+    resolved = shared_rapidocr_support.resolve_rapidocr_install_target("")
+
+    assert raw_target == str(
+        app_docs_dir / "runtimes" / "study_companion" / "RapidOCR"
+    )
+    assert resolved == galgame_target
+    assert shared_rapidocr_support.resolve_rapidocr_model_cache_dir("") == (
+        galgame_target / "models"
+    )
 
 
 def test_ui_api_payloads_cover_open_map_and_contribution_shapes() -> None:

--- a/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
+++ b/plugin/tests/unit/plugins/test_study_companion_service_ui_api.py
@@ -5,6 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from plugin.plugins._shared.rapidocr import _inspect_download as shared_rapidocr_inspect
+from plugin.plugins._shared.rapidocr import _runtime as shared_rapidocr_runtime
 from plugin.plugins._shared.rapidocr import rapidocr_support as shared_rapidocr_support
 from plugin.plugins.study_companion.models import OcrSnapshot, StudyConfig, TutorReply
 from plugin.plugins.study_companion.service import (
@@ -23,6 +25,11 @@ from plugin.plugins.study_companion.ui_api import (
 )
 
 pytestmark = pytest.mark.unit
+
+
+class _RapidOcrWithKwargs:
+    def __init__(self, config_path=None, **kwargs) -> None:
+        del config_path, kwargs
 
 
 def test_service_payload_builders_preserve_nested_state_and_reply_payloads() -> None:
@@ -113,6 +120,96 @@ def test_study_rapidocr_resolve_uses_galgame_runtime_fallback(
     assert shared_rapidocr_support.resolve_rapidocr_model_cache_dir("") == (
         galgame_target / "models"
     )
+
+
+def test_study_rapidocr_resolve_uses_galgame_fallback_when_new_target_is_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app_docs_dir = tmp_path / "AppDocs"
+    study_target = app_docs_dir / "runtimes" / "study_companion" / "RapidOCR"
+    galgame_target = app_docs_dir / "runtimes" / "galgame_plugin" / "RapidOCR"
+    study_target.mkdir(parents=True)
+    (galgame_target / "models").mkdir(parents=True)
+    (galgame_target / "models" / "japan_PP-OCRv4_rec_infer.onnx").write_bytes(
+        b"model"
+    )
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "EmptyLocalAppData"))
+    monkeypatch.setattr(shared_rapidocr_support, "is_windows_platform", lambda: True)
+    monkeypatch.setattr(
+        shared_rapidocr_support,
+        "get_config_manager",
+        lambda: SimpleNamespace(app_docs_dir=app_docs_dir),
+    )
+
+    assert shared_rapidocr_support.resolve_rapidocr_install_target("") == galgame_target
+
+
+def test_study_rapidocr_resolve_uses_legacy_models_only_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app_docs_dir = tmp_path / "AppDocs"
+    legacy_root = tmp_path / "LegacyLocalAppData"
+    legacy_target = legacy_root / "Programs" / "N.E.K.O" / "RapidOCR"
+    (legacy_target / "models").mkdir(parents=True)
+    (legacy_target / "models" / "en_PP-OCRv4_rec_infer.onnx").write_bytes(b"model")
+    monkeypatch.setenv("LOCALAPPDATA", str(legacy_root))
+    monkeypatch.setattr(shared_rapidocr_support, "is_windows_platform", lambda: True)
+    monkeypatch.setattr(
+        shared_rapidocr_support,
+        "get_config_manager",
+        lambda: SimpleNamespace(app_docs_dir=app_docs_dir),
+    )
+
+    assert shared_rapidocr_support.resolve_rapidocr_install_target("") == legacy_target
+
+
+def test_shared_rapidocr_kwargs_fail_when_configured_model_is_missing(
+    tmp_path: Path,
+) -> None:
+    model_cache_dir = tmp_path / "RapidOCR" / "models"
+    package_models_dir = tmp_path / "package" / "models"
+    package_models_dir.mkdir(parents=True)
+    (package_models_dir / "ch_PP-OCRv4_det_infer.onnx").write_text("", encoding="utf-8")
+    (package_models_dir / "ch_PP-OCRv4_rec_infer.onnx").write_text("", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="PP-OCRv5/ch/mobile"):
+        shared_rapidocr_runtime._build_runtime_constructor_kwargs(
+            _RapidOcrWithKwargs,
+            engine_type="onnxruntime",
+            lang_type="ch",
+            model_type="mobile",
+            ocr_version="PP-OCRv5",
+            model_cache_dir=model_cache_dir,
+            package_models_dir=package_models_dir,
+        )
+
+
+def test_shared_rapidocr_inspection_returns_install_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_target = tmp_path / "RapidOCR"
+    install_target.mkdir()
+    (install_target / "install_state.json").write_text(
+        '{"selected_model": "PP-OCRv4/japan/mobile"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        shared_rapidocr_inspect.importlib.util,
+        "find_spec",
+        lambda _name: SimpleNamespace(
+            origin=str(tmp_path / "rapidocr_onnxruntime" / "__init__.py")
+        ),
+    )
+
+    status = shared_rapidocr_inspect.inspect_rapidocr_installation(
+        install_target_dir_raw=str(install_target),
+        lang_type="ch",
+        ocr_version="PP-OCRv4",
+        platform_fn=lambda: True,
+    )
+
+    assert status["install_state"] == {"selected_model": "PP-OCRv4/japan/mobile"}
 
 
 def test_ui_api_payloads_cover_open_map_and_contribution_shapes() -> None:

--- a/plugin/tests/unit/server/test_http_app.py
+++ b/plugin/tests/unit/server/test_http_app.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from plugin.server import http_app
+
+
+pytestmark = pytest.mark.unit
+
+
+class _App:
+    def __init__(self) -> None:
+        self.routers: list[object] = []
+
+    def include_router(self, router: object) -> None:
+        self.routers.append(router)
+
+
+def test_optional_router_does_not_swallow_import_attribute_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _App()
+
+    def _import_module(_module_name: str) -> object:
+        raise AttributeError("inner module bug")
+
+    monkeypatch.setattr(http_app.importlib, "import_module", _import_module)
+
+    with pytest.raises(AttributeError, match="inner module bug"):
+        http_app._include_optional_router(
+            app,
+            module_name="plugin.plugins.optional_routes",
+            label="optional routes",
+        )
+
+    assert app.routers == []


### PR DESCRIPTION
## 变更内容

- 新增 `plugin.plugins._shared.rapidocr`，承载 RapidOCR runtime、模型下载、OCR backend 等共享能力
- 将 `study_companion` 的 RapidOCR 下载、依赖检测、OCR backend 从 `galgame_plugin` 命名空间迁移到 shared helper
- 为 `study_companion` 增加独立的轻量捕获后端，避免继续依赖 `galgame_plugin.ocr_capture`
- 将 `plugin/server/http_app.py` 的可选插件路由注册改为动态导入 helper，避免基础 plugin server 静态 direct import 插件模块
- 加严测试，确保 `study_companion` 源码不再直接 import `plugin.plugins.galgame_plugin`

## 背景

此前猫娘伴学复用了 galgame 插件里的 RapidOCR / capture helper，形成了跨插件命名空间直接依赖。  
这会让可选插件模块的 import-time 问题影响插件服务器整体打包和启动隔离。

本 PR 将可复用 OCR 能力迁移到中立 shared namespace，`galgame_plugin` 与 `study_companion` 不再通过插件命名空间互相耦合。

## 验证

- `uv run python -m pytest plugin/tests/unit/plugins/test_study_companion.py`
- `uv run python -m pytest plugin/tests/unit/server/test_plugin_query_status.py`
- `uv run python -m pytest plugin/tests/integration/test_galgame_bridge_ui_routes.py::test_study_companion_install_routes_map_to_study_entries plugin/tests/integration/test_galgame_bridge_ui_routes.py::test_install_latest_routes_are_namespaced_by_plugin_id`
- `python -c "from plugin.server.http_app import build_plugin_server_app; app=build_plugin_server_app(); print(type(app).__name__)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加多种截图后端（Dxcam、MSS、PrintWindow、PyAutoGui），改善截取兼容性与稳定性。
  * 丰富 RapidOCR 支持：安装检测、模型注册与缺失判断、模型下载与完整性校验、运行时动态加载与预热、行级文本解析与坐标输出。

* **重构**
  * 将 OCR 与截图逻辑提取为共享模块，统一路径解析、运行时管理与兼容适配。

* **修复/增强**
  * 可选路由加载改进，统一异常与日志处理，避免静默失败。

* **测试**
  * 补充并调整单元测试，覆盖捕获后端、模型安装回退与可选路由异常场景。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->