### PR TITLE
fix(proactive): 修复搭话 prompt 四处问题 + i18n 补漏

### DIFF
--- a/app/memory_server.py
+++ b/app/memory_server.py
@@ -65,6 +65,7 @@ from config.prompts.prompts_memory import (
     CHAT_HOLIDAY_CONTEXT,
     MEMORY_RECALL_HEADER, MEMORY_RESULTS_HEADER,
     PERSONA_HEADER, INNER_THOUGHTS_DYNAMIC,
+    RECENT_HISTORY_INTRO, NO_RECENT_HISTORY,
 )
 # Negative-intent prompts/scanner 已迁到 ``prompts_directives``（与 ban-topic
 # regex 同源——同是"用户负面 / 回避指令"的语义层）。``prompts_memory`` 保留
@@ -3924,21 +3925,22 @@ async def settle_conversation(request: HistoryRequest, lanlan_name: str):
 @app.get("/get_recent_history/{lanlan_name}")
 async def get_recent_history(lanlan_name: str):
     lanlan_name = validate_lanlan_name(lanlan_name)
+    _lang = get_global_language()
     # 检查角色是否存在于配置中
     try:
         character_data = await _config_manager.aload_characters()
         catgirl_names = list(character_data.get('猫娘', {}).keys())
         if lanlan_name not in catgirl_names:
             logger.warning(f"角色 '{lanlan_name}' 不在配置中，返回空历史记录")
-            return "开始聊天前，没有历史记录。\n"
+            return _loc(NO_RECENT_HISTORY, _lang)
     except Exception as e:
         logger.error(f"检查角色配置失败: {e}")
-        return "开始聊天前，没有历史记录。\n"
+        return _loc(NO_RECENT_HISTORY, _lang)
 
     history = await recent_history_manager.aget_recent_history(lanlan_name)
     _, _, _, _, name_mapping, _, _, _, _ = await _config_manager.aget_character_data()
     name_mapping['ai'] = lanlan_name
-    result = f"开始聊天前，{lanlan_name}又在脑海内整理了近期发生的事情。\n"
+    result = _loc(RECENT_HISTORY_INTRO, _lang).format(name=lanlan_name)
     for i in history:
         if i.type == 'system':
             result += i.content + "\n"

--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -466,55 +466,104 @@ def render_recent_topics_block(terms: List[str], lang: str) -> str:
 # Proactive regen 指令 — 给重 sample 用
 # ---------------------------------------------------------------------------
 # 当 BM25 总分超 REGEN_THRESHOLD 时，``main_routers/system_router`` 在第二次
-# Phase 2 LLM 调用前把这段塞到 messages 末尾，告诉 LLM 哪些 term 必须避开。
+# Phase 2 LLM 调用前注入这段，告诉 LLM 哪些 term 必须避开。
+#
+# ⚠️ 措辞刻意做成"结构化指令 + 显式反复述约束"：早期版本是一句散文式祈使
+# （"换一个完全不同的角度或主题"），弱模型在超长上下文末尾收到后，容易把指令
+# 原文/规划脚手架当成正文吐出来（线上见过 "完全不同的角度或主题"、"括号、Emoji"
+# 这类泄漏）。现在每条都：(1) 用方括号小标题标明这是改写要求而非对话；(2) 末尾
+# 明确"不要复述/解释本要求、不要输出标签化回复以外的任何东西"。注入侧还会把
+# BEGIN 触发句放在最后（见 system_router），使指令本身不是模型看到的最后一句。
+# 占位符：{terms} 要避开的词；{master_name} 搭话对象。
 
 PROACTIVE_REGEN_AVOID_INSTRUCTION = {
     'zh': (
-        "你上一次输出过于贴近最近重复说过的话题（{terms}）。"
-        "请重新生成一次，刻意避开这些词与话题，换一个完全不同的角度或主题。"
+        "【改写要求】这些词和话题最近已经聊得太多，本次必须避开：{terms}。"
+        "换个角度或换个话题，直接写一句全新的搭话。"
+        "输出严格遵守上面的格式：第一行写来源标签，第二行起只写要对{master_name}说的原话；"
+        "如果想不出新角度，就只输出 [PASS]。"
+        "不要复述或解释本要求，不要输出任何思考过程、清单或标签化回复以外的内容。"
     ),
     'en': (
-        "Your previous draft circled back to topics you've already covered "
-        "recently ({terms}). Please regenerate, deliberately avoiding these "
-        "terms and topics, and pick a completely different angle or subject."
+        "[Rewrite] These words and topics have been used too much recently and MUST be "
+        "avoided: {terms}. Pick a different angle or topic and write one brand-new line. "
+        "Keep strictly to the format above: the first line is the source tag, then write "
+        "only the actual words you'd say to {master_name}; if you have no fresh angle, output "
+        "only [PASS]. Do NOT restate or explain this instruction, and do NOT output any "
+        "reasoning, lists, or anything other than the tagged reply."
     ),
     'ja': (
-        "先ほどの出力は最近繰り返している話題（{terms}）に近すぎました。"
-        "これらの語と話題を意図的に避けて、まったく違う切り口や主題で"
-        "もう一度生成してください。"
+        "【書き直し】次の語と話題は最近使いすぎているので必ず避けてください：{terms}。"
+        "切り口か話題を変えて、新しい一言を書いてください。"
+        "出力は上の形式を厳守：1行目に来源タグ、その後は{master_name}に実際に言う言葉だけ。"
+        "新しい切り口が思いつかなければ [PASS] だけを出力。"
+        "この指示を復唱・説明せず、思考過程やリスト、タグ付き発言以外のものを出力しないこと。"
     ),
     'ko': (
-        "방금 생성한 응답이 최근에 반복된 화제（{terms}）와 너무 가깝습니다。"
-        "이 단어와 주제를 의도적으로 피해 완전히 다른 관점이나 주제로 "
-        "다시 생성해 주세요."
+        "【다시 쓰기】다음 단어와 화제는 최근에 너무 많이 다뤘으니 반드시 피하세요: {terms}. "
+        "관점이나 화제를 바꿔 완전히 새로운 한마디를 쓰세요. "
+        "출력은 위 형식을 엄격히 따르세요: 첫 줄은 출처 태그, 이후에는 {master_name}에게 실제로 "
+        "할 말만 쓰세요; 새 관점이 없으면 [PASS]만 출력하세요. 이 지시를 되풀이하거나 설명하지 "
+        "말고, 사고 과정·목록·태그 외의 어떤 것도 출력하지 마세요."
     ),
     'ru': (
-        "Ваш предыдущий черновик слишком близок к темам, которые недавно "
-        "повторялись ({terms}). Сгенерируйте ещё раз, намеренно избегая этих "
-        "слов и тем, выберите совершенно другой ракурс или предмет."
+        "[Перепиши] Эти слова и темы в последнее время используются слишком часто, их "
+        "обязательно нужно избегать: {terms}. Выбери другой угол или тему и напиши одну "
+        "совершенно новую реплику. Строго соблюдай формат выше: первая строка — тег источника, "
+        "далее — только сами слова, которые ты скажешь {master_name}; если нового угла нет, "
+        "выведи только [PASS]. Не пересказывай и не объясняй эту инструкцию, не выводи "
+        "рассуждения, списки или что-либо кроме реплики с тегом."
     ),
     'es': (
-        "Tu borrador anterior se acercó demasiado a temas ya repetidos "
-        "({terms}). Regenera evitando deliberadamente esos términos y temas, "
-        "y elige un ángulo o asunto completamente distinto."
+        "[Reescribe] Estas palabras y temas se han usado demasiado últimamente y DEBES "
+        "evitarlos: {terms}. Elige otro ángulo o tema y escribe una frase totalmente nueva. "
+        "Respeta estrictamente el formato de arriba: la primera línea es la etiqueta de "
+        "fuente, luego escribe solo lo que le dirías a {master_name}; si no tienes un ángulo "
+        "nuevo, responde solo [PASS]. No repitas ni expliques esta instrucción, y no muestres "
+        "razonamientos, listas ni nada que no sea la respuesta con etiqueta."
     ),
     'pt': (
-        "Seu rascunho anterior se aproximou demais de tópicos já repetidos "
-        "({terms}). Regenere evitando deliberadamente esses termos e tópicos, "
-        "e escolha um ângulo ou assunto completamente diferente."
+        "[Reescreva] Estas palavras e temas foram usados demais recentemente e você DEVE "
+        "evitá-los: {terms}. Escolha outro ângulo ou tema e escreva uma fala totalmente nova. "
+        "Siga estritamente o formato acima: a primeira linha é a etiqueta de fonte, depois "
+        "escreva apenas o que você diria a {master_name}; se não tiver um ângulo novo, "
+        "responda apenas [PASS]. Não repita nem explique esta instrução, e não exiba "
+        "raciocínio, listas ou qualquer coisa além da resposta com etiqueta."
     ),
 }
 
 
-def render_regen_avoid_instruction(terms: List[str], lang: str) -> str:
-    """把 regen 用的 "避开 X / Y" 指令渲染成单行文本。空列表 → ""。"""
+# render_regen_avoid_instruction 缺省称呼（master_name 未传时的中性占位）。
+# 不用"主人/master"等物化称呼（见项目约定）。
+_DEFAULT_ADDRESSEE = {
+    "zh": "对方",
+    "en": "them",
+    "ja": "相手",
+    "ko": "상대",
+    "ru": "собеседника",
+    "es": "la otra persona",
+    "pt": "a outra pessoa",
+}
+
+
+def render_regen_avoid_instruction(terms: List[str], lang: str, master_name: str = "") -> str:
+    """把 regen 用的"避开 X / Y"指令渲染成文本。空列表 → ""。
+
+    ``master_name`` 用于把"对谁说"写进指令；缺省退化为中性占位符，避免 KeyError。
+    """
     if not terms:
         return ""
     short = _norm_lang(lang)
     template = PROACTIVE_REGEN_AVOID_INSTRUCTION.get(short) or PROACTIVE_REGEN_AVOID_INSTRUCTION['en']
-    # 用各 locale 的"、/、/ , / etc" 列表分隔符
+    # 每个词单独括起来，让模型清楚哪些是要避开的离散词（CJK 用「」，其余用双引号），
+    # 再用各 locale 的列表分隔符拼接。
+    lq, rq = ("「", "」") if short in ("zh", "ja") else ('"', '"')
     sep = "、" if short in ("zh", "ja") else ", "
-    return template.format(terms=sep.join(terms))
+    quoted_terms = sep.join(f"{lq}{t}{rq}" for t in terms)
+    return template.format(
+        terms=quoted_terms,
+        master_name=master_name or _DEFAULT_ADDRESSEE.get(short, "them"),
+    )
 
 
 # =====================================================================

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -8,6 +8,8 @@ inner-thoughts injection fragments, and chat-gap notices.
 
 from __future__ import annotations
 
+import re
+
 from config.prompts.prompts_sys import _loc
 
 # =====================================================================
@@ -869,6 +871,66 @@ INNER_THOUGHTS_DYNAMIC = {
     "es": "La hora actual es {time}. Antes de iniciar la conversación, {name} repasa mentalmente los acontecimientos recientes.\n",
     "pt": "A hora atual é {time}. Antes de iniciar a conversa, {name} revisa mentalmente os acontecimentos recentes.\n",
 }
+
+# ---------- /get_recent_history 端点文案（game/galgame 流程消费，须 i18n） ----------
+# 这两条历史上硬编码成中文，非中文用户的游戏流程会读到中文引导句。
+RECENT_HISTORY_INTRO = {
+    "zh": "开始聊天前，{name}又在脑海内整理了近期发生的事情。\n",
+    "en": "Before the chat begins, {name} mentally reviews recent events.\n",
+    "ja": "会話を始める前に、{name}は最近の出来事を頭の中で整理しています。\n",
+    "ko": "대화를 시작하기 전에 {name}은 최근 있었던 일들을 마음속으로 정리하고 있습니다.\n",
+    "ru": "Перед началом разговора {name} мысленно перебирает последние события.\n",
+    "es": "Antes de iniciar la conversación, {name} repasa mentalmente los acontecimientos recientes.\n",
+    "pt": "Antes de iniciar a conversa, {name} revisa mentalmente os acontecimentos recentes.\n",
+}
+
+NO_RECENT_HISTORY = {
+    "zh": "开始聊天前，没有历史记录。\n",
+    "en": "Before the chat begins, there is no history.\n",
+    "ja": "会話を始める前、履歴はありません。\n",
+    "ko": "대화를 시작하기 전, 기록이 없습니다.\n",
+    "ru": "Перед началом разговора истории нет.\n",
+    "es": "Antes de iniciar la conversación, no hay historial.\n",
+    "pt": "Antes de iniciar a conversa, não há histórico.\n",
+}
+
+
+# ---------- Locale-independent /new_dialog splitter ----------
+# new_dialog 的文本结构固定为三段拼接：
+#   [PERSONA_HEADER + 长期记忆] + [INNER_THOUGHTS_HEADER + INNER_THOUGHTS_DYNAMIC] + [对话历史]
+# 下游（proactive Phase 2）需要把"内心活动"与"对话历史"切开。历史实现硬编码
+# 单一中文哨兵 "整理了近期发生的事情" 来 split，但该句来自上面的多语言
+# INNER_THOUGHTS_DYNAMIC，非中文渲染时哨兵不存在 → 切分静默失效（内心活动恒空，
+# 整段被当历史）。这里改成：用所有 locale 的 DYNAMIC 模板各编一条正则（{time}/
+# {name} 占位转成通配），命中即在该句**结尾**切开——locale 无关、不删句、不留断标点。
+def _build_inner_thoughts_dynamic_patterns() -> list[re.Pattern[str]]:
+    patterns: list[re.Pattern[str]] = []
+    for template in INNER_THOUGHTS_DYNAMIC.values():
+        escaped = re.escape(template.strip())
+        escaped = escaped.replace(re.escape("{time}"), ".+?")
+        escaped = escaped.replace(re.escape("{name}"), ".+?")
+        patterns.append(re.compile(escaped, re.DOTALL))
+    return patterns
+
+
+_INNER_THOUGHTS_DYNAMIC_PATTERNS = _build_inner_thoughts_dynamic_patterns()
+
+
+def split_inner_thoughts_and_history(text: str) -> tuple[str, str] | None:
+    """把 /new_dialog 文本切成 ``(inner_thoughts, history)``。
+
+    在 INNER_THOUGHTS_DYNAMIC 那句话（任一支持的 locale）**结尾处**切开：
+    其前（含长期记忆 + 内心活动引语）归 inner_thoughts，其后（对话历史）归 history。
+    任何 locale 都找不到该句 → 返回 ``None``，由调用方决定兜底并打日志（不要静默错位）。
+    """
+    if not text:
+        return None
+    for pattern in _INNER_THOUGHTS_DYNAMIC_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return text[: match.end()].strip(), text[match.end():].strip()
+    return None
+
 
 # =====================================================================
 # ======= Chat gap notices ===========================================

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -3222,9 +3222,11 @@ MEME_TOPIC_NO_KEYWORD = {
 
 def get_meme_topic_line(lang: str, *, keyword: str, title: str, source: str) -> str:
     """组装表情包话题行；keyword 非空时带上它（描述梗内容），否则退回通用措辞。"""
-    if keyword:
+    # 先归一化空白：纯空白关键词（"   "）应视为无关键词，否则会误走带关键词模板。
+    normalized_keyword = " ".join((keyword or "").split())
+    if normalized_keyword:
         return _loc(MEME_TOPIC_WITH_KEYWORD, lang).format(
-            keyword=keyword, title=title, source=source
+            keyword=normalized_keyword, title=title, source=source
         )
     return _loc(MEME_TOPIC_NO_KEYWORD, lang).format(title=title, source=source)
 

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -3194,6 +3194,40 @@ MEME_SECTION_FOOTER = {
     "pt": "======Acima está o material de meme======",
 }
 
+# ---------- 表情包话题描述 ----------
+# 抓取源（尤其国内站）常常没返回有意义的标题，title 退化成占位符 "表情包_N"，
+# 模型完全不知道这张图是关于什么的梗。LLM 当初搜图用的 keyword（如"开心猫咪"）
+# 才是对图片内容/情绪的描述，必须带进话题里，模型才能"利用图片情绪表达"。
+# keyword 为空（fallback 随机热词，无法对应具体描述）时退回不带 keyword 的措辞。
+MEME_TOPIC_WITH_KEYWORD = {
+    "zh": "发现一个关于「{keyword}」的[表情包]：'{title}'（来自 {source}）",
+    "en": "Found a [meme] about \"{keyword}\": '{title}' (from {source})",
+    "ja": "「{keyword}」に関する[ミーム]を見つけた：'{title}'（{source} より）",
+    "ko": "'{keyword}'에 관한 [밈]을 발견했어: '{title}' ({source} 출처)",
+    "ru": "Нашла [мем] про «{keyword}»: '{title}' (из {source})",
+    "es": "Encontré un [meme] sobre «{keyword}»: '{title}' (de {source})",
+    "pt": "Encontrei um [meme] sobre «{keyword}»: '{title}' (de {source})",
+}
+
+MEME_TOPIC_NO_KEYWORD = {
+    "zh": "发现一个很有意思的[表情包]：'{title}'（来自 {source}）",
+    "en": "Found an interesting [meme]: '{title}' (from {source})",
+    "ja": "面白い[ミーム]を見つけた：'{title}'（{source} より）",
+    "ko": "재미있는 [밈]을 발견했어: '{title}' ({source} 출처)",
+    "ru": "Нашла интересный [мем]: '{title}' (из {source})",
+    "es": "Encontré un [meme] interesante: '{title}' (de {source})",
+    "pt": "Encontrei um [meme] interessante: '{title}' (de {source})",
+}
+
+
+def get_meme_topic_line(lang: str, *, keyword: str, title: str, source: str) -> str:
+    """组装表情包话题行；keyword 非空时带上它（描述梗内容），否则退回通用措辞。"""
+    if keyword:
+        return _loc(MEME_TOPIC_WITH_KEYWORD, lang).format(
+            keyword=keyword, title=title, source=source
+        )
+    return _loc(MEME_TOPIC_NO_KEYWORD, lang).format(title=title, source=source)
+
 # ---------- 主动搭话信息源标签 ----------
 PROACTIVE_SOURCE_LABELS = {
     "zh": {

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6461,10 +6461,12 @@ async def proactive_chat(request: Request):
             )
             # 不再把 avoid 指令作为独立的最后一条 HumanMessage 追加在 12.5k 末尾
             # （弱模型容易把这条 meta 指令的原文/脚手架当正文吐出来）。改为**重建
-            # 同一个 Human turn**：avoid 约束在前、BEGIN 触发句在最后，让模型看到的
-            # 最后一句是中性的"请开始"而非可照抄的指令文本。System 段（generate_prompt）
-            # 原样复用；vision 图保留。
-            regen_human_text = f"{avoid_msg}\n\n{begin_text}"
+            # 同一个 Human turn**：avoid 约束在前，后接原始 human_text。human_text 本身
+            # = dynamic_context_for_phase2 + BEGIN 触发句，所以一来保留了音乐 tag、
+            # 模糊匹配披露、"正在放歌时禁止再推歌"等运行时约束（否则 regen 可能回出被
+            # 禁止的内容，Codex P1 / CodeRabbit），二来它仍以 BEGIN 句结尾，模型看到的
+            # 最后一句还是中性的"请开始"而非可照抄的指令文本。System 段原样复用；vision 图保留。
+            regen_human_text = f"{avoid_msg}\n\n{human_text}"
             if phase2_use_vision:
                 regen_human_content = [
                     {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{screenshot_b64_for_phase2}"}},

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -126,6 +126,7 @@ from config.prompts.prompts_proactive import (
     EXTERNAL_TOPIC_HEADER, EXTERNAL_TOPIC_FOOTER,
     MUSIC_SECTION_HEADER, MUSIC_SECTION_FOOTER,
     MEME_SECTION_HEADER, MEME_SECTION_FOOTER,
+    get_meme_topic_line,
     PROACTIVE_SOURCE_LABELS,
     PROACTIVE_MUSIC_TAG_INSTRUCTIONS,
     MUSIC_SEARCH_RESULT_TEXTS,
@@ -5322,28 +5323,24 @@ async def proactive_chat(request: Request):
         except Exception as e:
             logger.warning(f"[{lanlan_name}] 获取记忆上下文失败，使用空上下文: {e}")
         
-        # 解析 new_dialog 响应
+        # 解析 new_dialog 响应：把"内心活动"与"对话历史"切开。
+        # 切分逻辑（locale 无关）集中在 prompts_memory.split_inner_thoughts_and_history，
+        # 以 INNER_THOUGHTS_DYNAMIC 的多语言模板为准；任一 locale 都匹配不到时返回
+        # None，这里兜底为"全部当历史、内心活动留空"并打 warning（不再静默错位）。
         def _parse_new_dialog(text: str) -> tuple[str, str]:
-            """
-            解析 new_dialog 的文本响应，尝试分离内心活动和对话历史。
-             - 如果包含分割线 "整理了近期发生的事情"，则将其前部分作为内心活动，后部分作为对话历史。
-             - 该函数的目的是为了在 Phase 1 后能够清晰地获取到内心活动和对话历史，以便在 Phase 2 中更好地生成搭话内容。
-             - 内心活动通常包含角色的当前状态、情绪、想法等信息，而对话历史则是与用户的过去交流记录。
-             - 通过这种方式，我们可以在 Phase 1 中分析内心活动来选择搭话话题，在 Phase 2 中结合对话历史生成更符合上下文的搭话内容。
-            """
             if not text:
                 return "", ""
-            # 尝试找到分割线 "整理了近期发生的事情"
-            split_keyword = "整理了近期发生的事情"
-            if split_keyword in text:
-                parts = text.split(split_keyword, 1)
-                # part[0] 是内心活动+时间，part[1] 是对话历史
-                # 提取内心活动 (去除首尾空白)
-                inner_thoughts_part = parts[0].strip()
-                # 提取对话历史 (去除首尾空白)
-                history_part = parts[1].strip()
-                return history_part, inner_thoughts_part
-            return text, ""
+            from config.prompts.prompts_memory import split_inner_thoughts_and_history
+            split = split_inner_thoughts_and_history(text)
+            if split is None:
+                logger.warning(
+                    "[%s] new_dialog 未匹配到内心活动分隔句（任一 locale），"
+                    "整段归入对话历史，当前内心留空",
+                    lanlan_name,
+                )
+                return text, ""
+            inner_thoughts_part, history_part = split
+            return history_part, inner_thoughts_part
 
         memory_context, inner_thoughts = _parse_new_dialog(raw_memory_context)
 
@@ -5827,22 +5824,31 @@ async def proactive_chat(request: Request):
                 return None
 
         async def _fetch_meme_with_fallback(kw: str):
-            """用 LLM 关键词搜索表情包，失败则随机热词"""
+            """用 LLM 关键词搜索表情包，失败则随机热词。
+
+            ``effective_keyword`` 标注本次实际生效的搜索词：关键词命中时即 kw
+            （描述了梗内容，下游话题会带上它）；走随机热词兜底时置空，避免谎报
+            "这是关于 X 的图"。
+            """
             try:
                 raw = await asyncio.wait_for(
                     fetch_meme_content(keyword=kw, limit=_PHASE1_FETCH_PER_SOURCE),
                     timeout=12.0
                 )
                 if raw and raw.get('success'):
+                    raw['effective_keyword'] = kw
                     return raw
             except Exception as e:
                 logger.warning(f"[{lanlan_name}] 表情包关键词 '{kw}' 搜索异常: {e}")
             logger.warning(f"[{lanlan_name}] 表情包关键词 '{kw}' 搜索失败，尝试随机热词")
             try:
-                return await asyncio.wait_for(
+                raw = await asyncio.wait_for(
                     fetch_meme_content(keyword="", limit=_PHASE1_FETCH_PER_SOURCE),
                     timeout=12.0
                 )
+                if raw:
+                    raw['effective_keyword'] = ""
+                return raw
             except Exception:
                 return None
 
@@ -5883,6 +5889,7 @@ async def proactive_chat(request: Request):
                         'data': result_p1.get('data', []),
                         'raw_data': result_p1,
                         'source': result_p1.get('source', '表情包'),
+                        'keyword': result_p1.get('effective_keyword', ''),
                     }
                     print(f"[{lanlan_name}] 成功获取 {len(result_p1.get('data', []))} 个表情包 (来源: {result_p1.get('source', '?')})")
 
@@ -5965,7 +5972,12 @@ async def proactive_chat(request: Request):
                     if meme_topic_key and _should_skip_source(meme_topic_key):
                         logger.debug(f"[{lanlan_name}]- Phase 1 表情包候选去重命中，跳过: {meme_title[:30]}")
                         continue
-                    single_meme_topic = f"发现一个很有意思的[表情包]：'{meme_title}' (来自 {meme_source})"
+                    single_meme_topic = get_meme_topic_line(
+                        proactive_lang,
+                        keyword=meme_content.get('keyword', ''),
+                        title=meme_title,
+                        source=meme_source,
+                    )
                     logger.debug(f"[{lanlan_name}]- Phase 1 表情包话题已添加 (限额1张): {single_meme_topic}")
                     phase1_topics.append(('meme', single_meme_topic))
                     selected_meme_link = {
@@ -6444,8 +6456,23 @@ async def proactive_chat(request: Request):
                 f"[{lanlan_name}] 主动搭话 BM25 触发 regen "
                 f"(score={_bm25_total:.2f} >= {ANTI_REPEAT_REGEN_THRESHOLD}, 避开={avoid_terms})"
             )
-            avoid_msg = render_regen_avoid_instruction(avoid_terms, proactive_lang)
-            regen_messages = list(messages) + [HumanMessage(content=avoid_msg)]
+            avoid_msg = render_regen_avoid_instruction(
+                avoid_terms, proactive_lang, master_name_current,
+            )
+            # 不再把 avoid 指令作为独立的最后一条 HumanMessage 追加在 12.5k 末尾
+            # （弱模型容易把这条 meta 指令的原文/脚手架当正文吐出来）。改为**重建
+            # 同一个 Human turn**：avoid 约束在前、BEGIN 触发句在最后，让模型看到的
+            # 最后一句是中性的"请开始"而非可照抄的指令文本。System 段（generate_prompt）
+            # 原样复用；vision 图保留。
+            regen_human_text = f"{avoid_msg}\n\n{begin_text}"
+            if phase2_use_vision:
+                regen_human_content = [
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{screenshot_b64_for_phase2}"}},
+                    {"type": "text", "text": regen_human_text},
+                ]
+            else:
+                regen_human_content = regen_human_text
+            regen_messages = [messages[0], HumanMessage(content=regen_human_content)]
             regen_text = ""
             # 进入 regen 前再读一次 sticky preempt：与上方流式循环 / Phase1 各
             # 长 await 入口保持一致——用户在初稿出来到这里之间接管的话，免去

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -316,6 +316,7 @@ def _append_persona_guidance_to_prompt(prompt_text: str, character_payload: dict
         return prompt_text
 
     guidance = ""
+    from_preset = False
     preset_id = str(override.get("preset_id") or "").strip()
     if preset_id:
         # 运行时按当前全局语言重新解析，使 persona prompt 与基础 LANLAN prompt
@@ -323,6 +324,7 @@ def _append_persona_guidance_to_prompt(prompt_text: str, character_payload: dict
         try:
             from utils.persona_presets import get_persona_prompt_guidance
             guidance = (get_persona_prompt_guidance(preset_id) or "").strip()
+            from_preset = bool(guidance)
         except Exception:
             guidance = ""
 
@@ -331,6 +333,15 @@ def _append_persona_guidance_to_prompt(prompt_text: str, character_payload: dict
 
     if not guidance:
         return prompt_text
+
+    # preset 的 guidance 是一份**完整独立**的人设 prompt，骨架（fictional-character
+    # 前言 + <Context Awareness> + <WARNING> + <IMPORTANT>）与默认 base 逐字相同。
+    # 直接 append 会让整套骨架重复一遍（~1500 字），且这段经 lanlan_prompt_map 流向
+    # 主对话 system prompt、proactive、break reminder、各插件等**所有**消费点。
+    # 当 base 仍是默认 prompt 时，preset 本身就是完整人设 → 用它替换 base，避免重复；
+    # 仅当用户写过自定义 system_prompt（非默认）时才退回 append 以保留其自定义内容。
+    if from_preset and is_default_prompt(prompt_text):
+        return guidance
 
     return f"{prompt_text}\n\nAdditional role guidance: {guidance}"
 

--- a/utils/persona_presets.py
+++ b/utils/persona_presets.py
@@ -91,6 +91,7 @@ Users interacting with {LANLAN_NAME} are already reminded that she is a purely f
 - No Servitude: {_persona_no_servitude}
 - {_persona_extra_label_en}: {_persona_extra_text}
 - No Repetition: {_no_repetition}
+- Respect Boundaries: {_no_pestering}
 </Characteristics of {LANLAN_NAME}>
 
 <Context Awareness>


### PR DESCRIPTION
## 背景
排查一次"搭话吐出奇怪回复"（把 prompt 指令原文当正文）的日志，顺藤摸瓜修了搭话 prompt 链路上的 4 个问题，外加 2 处顺带的 i18n 补漏。

## 改动

**1. 表情包不知道是什么梗**
抓取源（斗图啦等）常不返回标题，`meme_title` 退化成占位符 `表情包_N`，模型完全不知道图是关于什么的。现在把 LLM 当初搜图的关键词（如「开心猫咪」）带进话题；走随机热词兜底时置空，不谎报。新增 `MEME_TOPIC_*` i18n 模板 + `get_meme_topic_line`。

**2. persona override 重复整套骨架**
preset guidance 本就是完整人设 prompt，骨架（fictional-character 前言 + `<Context Awareness>` + `<WARNING>` + `<IMPORTANT>`）与默认 base 逐字相同，`_append_persona_guidance_to_prompt` 整段 append 导致骨架重复 ~1500 字，且经 `lanlan_prompt_map` 流向**主对话 system prompt、proactive、break reminder、各插件**等所有消费点。改为 base 是默认时直接用 preset 替换；并给 preset 模板补上 base 独有的 `Respect Boundaries` 行使替换无损。

**3. `_parse_new_dialog` 脆弱切分**
原本用硬编码中文哨兵「整理了近期发生的事情」切"内心活动/对话历史"，但该句来自多语言模板，非中文渲染时切分静默失效（当前内心恒空、整段当历史）。改用 `prompts_memory.split_inner_thoughts_and_history`：按所有 locale 的 `INNER_THOUGHTS_DYNAMIC` 编正则在句尾切，miss 时打 warning 不静默错位。（全库 split 审计确认这是唯一此类高危点。）

**4. regen avoid 指令植入方式**
原本作为最后一条 `HumanMessage` 追加在 12.5k 末尾，弱模型容易把这条 meta 指令原文/脚手架当正文吐出来（线上见过 `完全不同的角度或主题`、`括号、Emoji` 泄漏）。改为重建同一 Human turn、avoid 约束在前、`======请开始======` 垫底；措辞改成结构化「改写要求」+ 显式反复述约束，去掉模型看不到的「上一稿」提法，要避开的词逐个加引号。

**顺带**
- `get_recent_history` 端点 3 处硬编码中文搬进 i18n（`RECENT_HISTORY_INTRO` / `NO_RECENT_HISTORY`，game 流程消费）。
- 修正 `INNER_THOUGHTS_DYNAMIC` pt 拼写 `acontecimientos`→`acontecimentos`。

i18n：所有新增/改写文案 7 locale 全覆盖。

## 测试
- `tests/unit/test_anti_repeat.py` / `test_persona_presets.py` / `test_character_persona_router.py` / `test_evidence_render_budget.py` / `test_proactive_text_does_not_dehumanize.py`：全绿。
- 直接渲染验证：split（zh/en/无标记）、meme topic（带/不带 keyword）、persona 去重（preamble×1、保留 Personality + Respect Boundaries）、regen 指令渲染。

## 注
未改 memory_server 的 locale 解析（persona zh 配 en 内心活动最可能是"中文角色 + 英文全局 UI"的合理配置，非 bug；split 修复已兜住）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 表情包话题智能生成：支持带关键词与通用描述两种模式
  * 多语言近期历史与“无历史”提示本地化输出

* **改进**
  * 优化对话记忆解析，提升多语言兼容性与健壮性
  * 强化生成指令结构与约束，减少多余解释与格式偏离
  * 增强表情包抓取稳定性与关键词标注
  * 完善人格预设指导加载与替换逻辑

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->