### PR TITLE
fix(proactive): Phase 2 无合法来源标签时 drop，杜绝脚手架泄漏

### DIFF
--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -566,6 +566,74 @@ def render_regen_avoid_instruction(terms: List[str], lang: str, master_name: str
     )
 
 
+# ---------------------------------------------------------------------------
+# Proactive 格式纠正指令 — 初稿没按格式输出时自救用
+# ---------------------------------------------------------------------------
+# 初稿没解析到合法来源标签时（弱化模型常把人设 Format/约束块当正文吐出来，
+# 如 "No Markdown: Yes."），system_router 注入这段再生成一次，把模型拽回
+# "第一行写来源标签、其后正文" 的格式；与 BEGIN 触发句一起放进 Human turn
+# （末尾仍是中性触发句）。占位符：{master_name} 搭话对象。
+
+PROACTIVE_FORMAT_FIX_INSTRUCTION = {
+    'zh': (
+        "【格式纠正】上一次的输出没有按规定格式，把格式要求当成正文吐了出来。"
+        "请重写：第一行只写一个来源标签（[CHAT]、[MUSIC] 或 [MEME] 之一），"
+        "第二行起只写要对{master_name}说的话本身；没什么新鲜的可说就只输出 [PASS]。"
+        "不要复述或解释任何规则，不要输出清单或思考过程，标签和正文以外的内容一律不要输出。"
+    ),
+    'en': (
+        "[Format fix] Your last output didn't follow the required format — it spat out the "
+        "rules as if they were the message. Rewrite it: the first line is a single source tag "
+        "(one of [CHAT], [MUSIC], or [MEME]), then from the next line write only the actual "
+        "words you'd say to {master_name}; if you have nothing fresh to say, output only [PASS]. "
+        "Do NOT restate or explain any rule, do NOT output lists or reasoning, and output "
+        "nothing other than the tag and the message."
+    ),
+    'ja': (
+        "【書式修正】前回の出力は指定の書式に従わず、ルールをそのまま本文として出してしまいました。"
+        "書き直してください：1行目に来源タグを1つだけ（[CHAT]・[MUSIC]・[MEME] のいずれか）、"
+        "2行目以降は{master_name}に実際に言う言葉だけ。新しく言うことがなければ [PASS] だけを出力。"
+        "ルールを復唱・説明せず、リストや思考過程を出さず、タグと本文以外は何も出力しないこと。"
+    ),
+    'ko': (
+        "【형식 교정】지난 출력이 규정된 형식을 따르지 않고 규칙을 본문처럼 뱉어냈습니다. "
+        "다시 쓰세요: 첫 줄에는 출처 태그 하나만([CHAT]·[MUSIC]·[MEME] 중 하나), 이후 줄부터는 "
+        "{master_name}에게 실제로 할 말만. 새로 할 말이 없으면 [PASS]만 출력. 규칙을 되풀이하거나 "
+        "설명하지 말고, 목록·사고 과정을 출력하지 말며, 태그와 본문 외에는 아무것도 출력하지 마세요."
+    ),
+    'ru': (
+        "[Исправь формат] Прошлый вывод не соответствовал формату — ты выдал правила, как "
+        "будто это сообщение. Перепиши: первая строка — один тег источника (один из [CHAT], "
+        "[MUSIC] или [MEME]), далее со следующей строки — только сами слова, которые ты скажешь "
+        "{master_name}; если нового сказать нечего, выведи только [PASS]. Не пересказывай и не "
+        "объясняй правила, не выводи списки или рассуждения и не выводи ничего, кроме тега и сообщения."
+    ),
+    'es': (
+        "[Corrige el formato] Tu última salida no siguió el formato requerido: soltó las reglas "
+        "como si fueran el mensaje. Reescríbela: la primera línea es una sola etiqueta de fuente "
+        "(una de [CHAT], [MUSIC] o [MEME]), luego desde la línea siguiente escribe solo lo que le "
+        "dirías a {master_name}; si no tienes nada nuevo que decir, responde solo [PASS]. No "
+        "repitas ni expliques ninguna regla, no muestres listas ni razonamientos, y no muestres "
+        "nada más que la etiqueta y el mensaje."
+    ),
+    'pt': (
+        "[Corrija o formato] Sua última saída não seguiu o formato exigido — cuspiu as regras "
+        "como se fossem a mensagem. Reescreva: a primeira linha é uma única etiqueta de fonte "
+        "(uma de [CHAT], [MUSIC] ou [MEME]), depois, a partir da linha seguinte, escreva apenas o "
+        "que você diria a {master_name}; se não tiver nada novo a dizer, responda apenas [PASS]. "
+        "Não repita nem explique nenhuma regra, não exiba listas ou raciocínio, e não exiba nada "
+        "além da etiqueta e da mensagem."
+    ),
+}
+
+
+def render_format_fix_instruction(lang: str, master_name: str = "") -> str:
+    """渲染"格式纠正"自救指令。``master_name`` 缺省退化为中性占位符。"""
+    short = _norm_lang(lang)
+    template = PROACTIVE_FORMAT_FIX_INSTRUCTION.get(short) or PROACTIVE_FORMAT_FIX_INSTRUCTION['en']
+    return template.format(master_name=master_name or _DEFAULT_ADDRESSEE.get(short, "them"))
+
+
 # =====================================================================
 # ======= Negative-keyword target check (RFC §3.4.5 Layer 2) ==========
 # =====================================================================

--- a/config/prompts/prompts_directives.py
+++ b/config/prompts/prompts_directives.py
@@ -577,41 +577,47 @@ def render_regen_avoid_instruction(terms: List[str], lang: str, master_name: str
 PROACTIVE_FORMAT_FIX_INSTRUCTION = {
     'zh': (
         "【格式纠正】上一次的输出没有按规定格式，把格式要求当成正文吐了出来。"
-        "请重写：第一行只写一个来源标签（[CHAT]、[MUSIC] 或 [MEME] 之一），"
-        "第二行起只写要对{master_name}说的话本身；没什么新鲜的可说就只输出 [PASS]。"
+        "请重写：第一行只写一个来源标签（按上面输出格式段列出的来源标签选，"
+        "如 [CHAT]、[WEB]、[MUSIC]、[MEME]），第二行起只写要对{master_name}说的话本身；"
+        "没什么新鲜的可说就只输出 [PASS]。"
         "不要复述或解释任何规则，不要输出清单或思考过程，标签和正文以外的内容一律不要输出。"
     ),
     'en': (
         "[Format fix] Your last output didn't follow the required format — it spat out the "
         "rules as if they were the message. Rewrite it: the first line is a single source tag "
-        "(one of [CHAT], [MUSIC], or [MEME]), then from the next line write only the actual "
-        "words you'd say to {master_name}; if you have nothing fresh to say, output only [PASS]. "
-        "Do NOT restate or explain any rule, do NOT output lists or reasoning, and output "
-        "nothing other than the tag and the message."
+        "(choose from the source tags listed in the output-format section above, e.g. [CHAT], "
+        "[WEB], [MUSIC], [MEME]), then from the next line write only the actual words you'd say "
+        "to {master_name}; if you have nothing fresh to say, output only [PASS]. Do NOT restate "
+        "or explain any rule, do NOT output lists or reasoning, and output nothing other than "
+        "the tag and the message."
     ),
     'ja': (
         "【書式修正】前回の出力は指定の書式に従わず、ルールをそのまま本文として出してしまいました。"
-        "書き直してください：1行目に来源タグを1つだけ（[CHAT]・[MUSIC]・[MEME] のいずれか）、"
-        "2行目以降は{master_name}に実際に言う言葉だけ。新しく言うことがなければ [PASS] だけを出力。"
+        "書き直してください：1行目に来源タグを1つだけ（上の出力形式に挙げられたタグから選ぶ。"
+        "例：[CHAT]・[WEB]・[MUSIC]・[MEME]）、2行目以降は{master_name}に実際に言う言葉だけ。"
+        "新しく言うことがなければ [PASS] だけを出力。"
         "ルールを復唱・説明せず、リストや思考過程を出さず、タグと本文以外は何も出力しないこと。"
     ),
     'ko': (
         "【형식 교정】지난 출력이 규정된 형식을 따르지 않고 규칙을 본문처럼 뱉어냈습니다. "
-        "다시 쓰세요: 첫 줄에는 출처 태그 하나만([CHAT]·[MUSIC]·[MEME] 중 하나), 이후 줄부터는 "
-        "{master_name}에게 실제로 할 말만. 새로 할 말이 없으면 [PASS]만 출력. 규칙을 되풀이하거나 "
-        "설명하지 말고, 목록·사고 과정을 출력하지 말며, 태그와 본문 외에는 아무것도 출력하지 마세요."
+        "다시 쓰세요: 첫 줄에는 출처 태그 하나만(위 출력 형식에 나열된 태그 중 선택, 예: [CHAT]·"
+        "[WEB]·[MUSIC]·[MEME]), 이후 줄부터는 {master_name}에게 실제로 할 말만. 새로 할 말이 "
+        "없으면 [PASS]만 출력. 규칙을 되풀이하거나 설명하지 말고, 목록·사고 과정을 출력하지 "
+        "말며, 태그와 본문 외에는 아무것도 출력하지 마세요."
     ),
     'ru': (
         "[Исправь формат] Прошлый вывод не соответствовал формату — ты выдал правила, как "
-        "будто это сообщение. Перепиши: первая строка — один тег источника (один из [CHAT], "
-        "[MUSIC] или [MEME]), далее со следующей строки — только сами слова, которые ты скажешь "
-        "{master_name}; если нового сказать нечего, выведи только [PASS]. Не пересказывай и не "
-        "объясняй правила, не выводи списки или рассуждения и не выводи ничего, кроме тега и сообщения."
+        "будто это сообщение. Перепиши: первая строка — один тег источника (выбери из тегов, "
+        "перечисленных в разделе формата вывода выше, напр. [CHAT], [WEB], [MUSIC], [MEME]), "
+        "далее со следующей строки — только сами слова, которые ты скажешь {master_name}; если "
+        "нового сказать нечего, выведи только [PASS]. Не пересказывай и не объясняй правила, не "
+        "выводи списки или рассуждения и не выводи ничего, кроме тега и сообщения."
     ),
     'es': (
         "[Corrige el formato] Tu última salida no siguió el formato requerido: soltó las reglas "
         "como si fueran el mensaje. Reescríbela: la primera línea es una sola etiqueta de fuente "
-        "(una de [CHAT], [MUSIC] o [MEME]), luego desde la línea siguiente escribe solo lo que le "
+        "(elige entre las etiquetas listadas en la sección de formato de salida de arriba, p. ej. "
+        "[CHAT], [WEB], [MUSIC], [MEME]), luego desde la línea siguiente escribe solo lo que le "
         "dirías a {master_name}; si no tienes nada nuevo que decir, responde solo [PASS]. No "
         "repitas ni expliques ninguna regla, no muestres listas ni razonamientos, y no muestres "
         "nada más que la etiqueta y el mensaje."
@@ -619,9 +625,10 @@ PROACTIVE_FORMAT_FIX_INSTRUCTION = {
     'pt': (
         "[Corrija o formato] Sua última saída não seguiu o formato exigido — cuspiu as regras "
         "como se fossem a mensagem. Reescreva: a primeira linha é uma única etiqueta de fonte "
-        "(uma de [CHAT], [MUSIC] ou [MEME]), depois, a partir da linha seguinte, escreva apenas o "
-        "que você diria a {master_name}; se não tiver nada novo a dizer, responda apenas [PASS]. "
-        "Não repita nem explique nenhuma regra, não exiba listas ou raciocínio, e não exiba nada "
+        "(escolha entre as etiquetas listadas na seção de formato de saída acima, p. ex. [CHAT], "
+        "[WEB], [MUSIC], [MEME]), depois, a partir da linha seguinte, escreva apenas o que você "
+        "diria a {master_name}; se não tiver nada novo a dizer, responda apenas [PASS]. Não "
+        "repita nem explique nenhuma regra, não exiba listas ou raciocínio, e não exiba nada "
         "além da etiqueta e da mensagem."
     ),
 }

--- a/config/prompts/prompts_memory.py
+++ b/config/prompts/prompts_memory.py
@@ -842,13 +842,13 @@ emotion_analysis_prompt = EMOTION_ANALYSIS_PROMPT["zh"]
 
 # ---------- Inner thoughts block header ----------
 INNER_THOUGHTS_HEADER = {
-    "zh": "\n======以下是{name}的内心活动======\n",
-    "en": "\n======{name}'s Inner Thoughts======\n",
-    "ja": "\n======{name}の心の声======\n",
-    "ko": "\n======{name}의 내면 활동======\n",
-    "ru": "\n======Внутренние мысли {name}======\n",
-    "es": "\n======Pensamientos internos de {name}======\n",
-    "pt": "\n======Pensamentos internos de {name}======\n",
+    "zh": "\n\n======以下是{name}的内心活动======\n",
+    "en": "\n\n======{name}'s Inner Thoughts======\n",
+    "ja": "\n\n======{name}の心の声======\n",
+    "ko": "\n\n======{name}의 내면 활동======\n",
+    "ru": "\n\n======Внутренние мысли {name}======\n",
+    "es": "\n\n======Pensamientos internos de {name}======\n",
+    "pt": "\n\n======Pensamentos internos de {name}======\n",
 }
 
 INNER_THOUGHTS_BODY = {

--- a/config/prompts/prompts_proactive.py
+++ b/config/prompts/prompts_proactive.py
@@ -2919,13 +2919,13 @@ def get_proactive_format_sections(
     }
 
     _of_header = {
-        "zh": "输出格式（严格遵守）：\n- 放弃搭话 → 只输出 [PASS]\n- 否则第一行写来源标签，第二行起写你要说的话：",
-        "en": "Output format (strict):\n- To skip → reply only [PASS]\n- Otherwise, first line = source tag, then your message on the next line(s):",
-        "ja": "出力形式（厳守）：\n- パス → [PASS] のみ\n- それ以外 → 1行目にソースタグ、2行目以降にメッセージ：",
-        "ko": "출력 형식 (엄격 준수):\n- 패스 → [PASS]만\n- 그 외 → 첫 줄에 소스 태그, 다음 줄부터 메시지:",
-        "ru": "Формат ответа (строго):\n- Пропустить → ответьте только [PASS]\n- Иначе первая строка = тег источника, далее со следующей строки ваше сообщение:",
-        "es": "Formato de salida (estricto):\n- Para omitir → responde solo [PASS]\n- Si no, primera línea = tag de fuente, luego tu mensaje en la(s) línea(s) siguiente(s):",
-        "pt": "Formato de saída (estrito):\n- Para pular → responda apenas [PASS]\n- Caso contrário, primeira linha = tag de fonte, depois sua mensagem na(s) linha(s) seguinte(s):",
+        "zh": "最终输出格式（严格遵守）：\n- 放弃搭话 → 只输出 [PASS]\n- 否则第一行写来源标签，第二行起写你要说的话：",
+        "en": "Final output format (strict):\n- To skip → reply only [PASS]\n- Otherwise, first line = source tag, then your message on the next line(s):",
+        "ja": "最終出力形式（厳守）：\n- パス → [PASS] のみ\n- それ以外 → 1行目にソースタグ、2行目以降にメッセージ：",
+        "ko": "최종 출력 형식 (엄격 준수):\n- 패스 → [PASS]만\n- 그 외 → 첫 줄에 소스 태그, 다음 줄부터 메시지:",
+        "ru": "Окончательный формат ответа (строго):\n- Пропустить → ответьте только [PASS]\n- Иначе первая строка = тег источника, далее со следующей строки ваше сообщение:",
+        "es": "Formato de salida final (estricto):\n- Para omitir → responde solo [PASS]\n- Si no, primera línea = tag de fuente, luego tu mensaje en la(s) línea(s) siguiente(s):",
+        "pt": "Formato de saída final (estrito):\n- Para pular → responda apenas [PASS]\n- Caso contrário, primeira linha = tag de fonte, depois sua mensagem na(s) linha(s) seguinte(s):",
     }
 
     _of_example = {

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -110,7 +110,7 @@ from config.prompts.prompts_emotion import (
     get_emotion_label_aliases_flat,
 )
 from config.prompts.prompts_memory import PROACTIVE_FOLLOWUP_HEADER
-from config.prompts.prompts_directives import render_regen_avoid_instruction
+from config.prompts.prompts_directives import render_regen_avoid_instruction, render_format_fix_instruction
 from config.prompts.prompts_proactive import (
     get_proactive_screen_prompt, get_proactive_generate_prompt,
     get_proactive_music_playing_hint,
@@ -5416,27 +5416,31 @@ async def proactive_chat(request: Request):
             return await _end_proactive(JSONResponse(_proactive_preempted_json("phase1_post_reflect")))
 
         # ========== 4. 获取 LLM 配置 ==========
+        # 主动搭话全链路（Phase1 筛选 / Phase2 生成 / regen）用 conversation tier
+        # 而非 correction tier：correction（纠错）模型在不开思考时较难稳定遵循
+        # "第一行写来源标签" 的格式，容易把人设约束块当正文吐出来；conversation
+        # 是主对话主力模型，格式遵循更稳。仍保持 disable_thinking（vision+思考必超时）。
         try:
-            correction_config = _config_manager.get_model_api_config('correction')
-            correction_model = correction_config.get('model')
-            correction_base_url = correction_config.get('base_url')
-            correction_api_key = correction_config.get('api_key')
-            
-            if not correction_model or not correction_api_key:
-                logger.error("纠错模型配置缺失: model或api_key未设置")
+            conversation_config = _config_manager.get_model_api_config('conversation')
+            conversation_model = conversation_config.get('model')
+            conversation_base_url = conversation_config.get('base_url')
+            conversation_api_key = conversation_config.get('api_key')
+
+            if not conversation_model or not conversation_api_key:
+                logger.error("对话模型配置缺失: model或api_key未设置")
                 return await _end_proactive(JSONResponse({
                     "success": False,
-                    "error": "纠错模型配置缺失",
-                    "detail": "请在设置中配置纠错模型的model和api_key"
+                    "error": "对话模型配置缺失",
+                    "detail": "请在设置中配置对话模型的model和api_key"
                 }, status_code=500))
-            
+
             vision_config = _config_manager.get_model_api_config('vision')
             vision_model_name = vision_config.get('model', '')
             vision_base_url = vision_config.get('base_url', '')
             vision_api_key = vision_config.get('api_key', '')
             has_vision_model = bool(vision_model_name and vision_api_key)
             if not has_vision_model:
-                logger.info("Vision 模型未配置，Phase 2 将退回使用 correction 模型")
+                logger.info("Vision 模型未配置，Phase 2 将退回使用对话模型")
         except Exception as e:
             logger.error(f"获取模型配置失败: {e}")
             return await _end_proactive(JSONResponse({
@@ -5454,7 +5458,7 @@ async def proactive_chat(request: Request):
             if use_vision and has_vision_model:
                 m, bu, ak = vision_model_name, vision_base_url, vision_api_key
             else:
-                m, bu, ak = correction_model, correction_base_url, correction_api_key
+                m, bu, ak = conversation_model, conversation_base_url, conversation_api_key
             kw: dict = dict(
                 temperature=temperature,
                 max_completion_tokens=max_completion_tokens,
@@ -5477,7 +5481,7 @@ async def proactive_chat(request: Request):
             带重试的 LLM 调用。image_b64 非空时以多模态方式发送截图。
             dynamic_context: 动态上下文，注入到 HumanMessage 中使 SystemMessage 可被缓存。
             """
-            actual_model = (vision_model_name if use_vision and has_vision_model else correction_model)
+            actual_model = (vision_model_name if use_vision and has_vision_model else conversation_model)
             begin_text = _loc(BEGIN_GENERATE, proactive_lang)
             human_text = f"{dynamic_context}\n\n{begin_text}" if dynamic_context else begin_text
             if image_b64:
@@ -6228,7 +6232,7 @@ async def proactive_chat(request: Request):
             human_content = human_text
         messages = [SystemMessage(content=generate_prompt), HumanMessage(content=human_content)]
 
-        actual_model = (vision_model_name if phase2_use_vision else correction_model)
+        actual_model = (vision_model_name if phase2_use_vision else conversation_model)
         print(f"\n{'='*60}\n[PROACTIVE-DEBUG] Phase 2 STREAM: model={actual_model} | vision={phase2_use_vision} | img={'yes' if phase2_use_vision else 'no'}\n{'='*60}\n{generate_prompt}\n{'='*60}\n")
 
         # --- 流式调用 + 在线拦截 ---
@@ -6373,8 +6377,56 @@ async def proactive_chat(request: Request):
         # 这类脚手架泄漏。合法搭话必然以 tag 起头，缺 tag 即判格式泄漏，drop 整轮，
         # 不要把脚手架念给博士听。（TTS 在本函数后段才真正投递，此处 abort 安全。）
         if not aborted and full_text.strip() and not source_tag:
-            print(f"[{lanlan_name}] Phase 2 输出无合法来源标签，判为格式泄漏，drop")
-            aborted = True
+            # 没解析到合法来源标签——多半是模型把人设 Format/约束块当正文吐了出来。
+            # 不直接 drop，先给一次"格式纠正"regen 自救：重建 Human turn（fix 指令 +
+            # 原 human_text，末尾仍是 BEGIN 触发句），ainvoke 重跑一次再解析 tag。
+            # 解析到合法非 PASS tag → 用自救结果接回主流程（下游 is_duplicate / BM25
+            # 照常生效）；仍无 tag / [PASS] / 空 → 才判格式泄漏 drop。preempt 时放弃。
+            print(f"[{lanlan_name}] Phase 2 输出无合法来源标签，尝试格式自救 regen")
+            if mgr.state.is_proactive_preempted(proactive_sid):
+                aborted = True
+            else:
+                _fix_human_text = f"{render_format_fix_instruction(proactive_lang, master_name_current)}\n\n{human_text}"
+                if phase2_use_vision:
+                    _fix_human_content = [
+                        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{screenshot_b64_for_phase2}"}},
+                        {"type": "text", "text": _fix_human_text},
+                    ]
+                else:
+                    _fix_human_content = _fix_human_text
+                _fix_text = ""
+                try:
+                    async with asyncio.timeout(20.0):
+                        async with _make_llm(
+                            temperature=1.0,
+                            max_completion_tokens=PROACTIVE_PHASE2_GENERATE_MAX_TOKENS,
+                            use_vision=phase2_use_vision,
+                            disable_thinking=True,
+                        ) as _fix_llm:
+                            _fix_resp = await _fix_llm.ainvoke(
+                                [messages[0], HumanMessage(content=_fix_human_content)]
+                            )
+                            _fix_text = (_fix_resp.content if hasattr(_fix_resp, "content") else "") or ""
+                except Exception as _fix_exc:
+                    logger.warning("[%s] Phase 2 格式自救 regen 失败: %s", lanlan_name, _fix_exc)
+                    _fix_text = ""
+                _fc = (_fix_text or "").strip()
+                _fm = re.search(r"主动搭话\s*\n", _fc)
+                if _fm:
+                    _fc = _fc[_fm.end():]
+                _fc = _fc.lstrip()
+                _fix_tag = ""
+                _ftm = re.match(r"^\[(CHAT|WEB|PASS|MUSIC|MEME)\]\s*", _fc, re.IGNORECASE)
+                if _ftm:
+                    _fix_tag = _ftm.group(1).upper()
+                    _fc = _fc[_ftm.end():]
+                if _fix_tag and _fix_tag != "PASS" and _fc.strip() and "[PASS]" not in _fc.upper():
+                    source_tag = _fix_tag
+                    full_text = _fc.strip()
+                    print(f"[{lanlan_name}] Phase 2 格式自救成功 tag={source_tag}")
+                else:
+                    print(f"[{lanlan_name}] Phase 2 格式自救仍无合法 tag，drop")
+                    aborted = True
 
         # --- 结果处理 ---
         # buffer 是流前 ~80 字符的原始累积（含 [TAG]\n 前缀和正文头部），

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6121,6 +6121,12 @@ async def proactive_chat(request: Request):
             has_meme=bool(meme_section),
             lang=proactive_lang,
         )
+        # 本轮是否启用"来源标签系统"：有 web/music/meme 副作用通道时，
+        # get_proactive_format_sections 用 _of_header（要求第一行写 [TAG]）；三者全无
+        # 时用 _of_none（明确要求纯文本、无 tag，下游靠 source_tag='CHAT' 兜底投递）。
+        # 无 tag gate 只在前者生效，否则会把 _of_none 模式的合法纯文本搭话误判为
+        # 格式泄漏 drop（Codex P1）。
+        _expects_source_tag = bool(external_section) or bool(music_section) or bool(meme_section)
         music_playing_hint = ""
         if is_playing_music and current_track:
             track_name = current_track.get('name') or get_proactive_music_unknown_track_name(proactive_lang)
@@ -6380,8 +6386,10 @@ async def proactive_chat(request: Request):
         # "No Markdown: Yes."、"* No stage directions/parentheses"、"完全不同的角度或主题"
         # 这类脚手架泄漏。合法搭话必然以 tag 起头，缺 tag 即判格式泄漏，drop 整轮，
         # 不要把脚手架念给博士听。（TTS 在本函数后段才真正投递，此处 abort 安全。）
-        if not aborted and full_text.strip() and not source_tag:
+        if not aborted and full_text.strip() and not source_tag and _expects_source_tag:
             # 没解析到合法来源标签——多半是模型把人设 Format/约束块当正文吐了出来。
+            # （仅在本轮启用 tag 系统时才判泄漏；_of_none 纯文本模式无 tag 是合法的，
+            #  不进此分支，留给后面的 source_tag='CHAT' 兜底正常投递。）
             # 不直接 drop，先给一次"格式纠正"regen 自救：重建 Human turn（fix 指令 +
             # 原 human_text，末尾仍是 BEGIN 触发句），ainvoke 重跑一次再解析 tag。
             # 解析到合法非 PASS tag → 用自救结果接回主流程（下游 is_duplicate / BM25

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -5481,7 +5481,6 @@ async def proactive_chat(request: Request):
             带重试的 LLM 调用。image_b64 非空时以多模态方式发送截图。
             dynamic_context: 动态上下文，注入到 HumanMessage 中使 SystemMessage 可被缓存。
             """
-            actual_model = (vision_model_name if use_vision and has_vision_model else conversation_model)
             begin_text = _loc(BEGIN_GENERATE, proactive_lang)
             human_text = f"{dynamic_context}\n\n{begin_text}" if dynamic_context else begin_text
             if image_b64:

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6602,10 +6602,17 @@ async def proactive_chat(request: Request):
                 regen_source_tag = _tag_m.group(1).upper()
                 _cleaned = _cleaned[_tag_m.end():]
             # regen 输出 [PASS] / 空 → 等价于"模型放弃了"，drop 而不是退回原文。
-            # 显式把 ``regen_source_tag == 'PASS'`` 也算 drop——前面剥过 [TAG]
-            # 前缀，剩下的 _cleaned 已经不含 "[PASS]" 字面量，但 regen_source_tag
-            # 已经记下这是 PASS，与"内嵌 [PASS]"等价拦掉（CodeRabbit Minor）。
-            if regen_source_tag in ("", "PASS") or not _cleaned.strip() or "[PASS]" in _cleaned.upper():
+            # 显式把 ``regen_source_tag == 'PASS'`` 也算 drop（前面剥过 [TAG] 前缀，
+            # _cleaned 已不含字面 "[PASS]"，但 regen_source_tag 记下了是 PASS）。
+            # 无 tag 是否算 drop 与初稿 gate 同款守卫：仅当本轮启用 tag 系统
+            # (_expects_source_tag) 时，无 tag 才判格式泄漏 drop；_of_none 纯文本模式
+            # 无 tag 是合法的，留空交给下游 source_tag='CHAT' 兜底（Codex P2）。
+            if (
+                regen_source_tag == "PASS"
+                or (_expects_source_tag and not regen_source_tag)
+                or not _cleaned.strip()
+                or "[PASS]" in _cleaned.upper()
+            ):
                 logger.info("[%s] proactive BM25 regen returned empty/PASS/untagged, drop", lanlan_name)
                 if not mgr.state.is_proactive_preempted(proactive_sid):
                     await mgr.handle_new_message()
@@ -6654,7 +6661,8 @@ async def proactive_chat(request: Request):
                     "similarity": _regen_sim,
                     "threshold": _PROACTIVE_SIMILARITY_THRESHOLD,
                 }))
-            # 走到这里 regen_source_tag 必为合法非 PASS tag（无 tag 已在上面 drop）。
+            # _expects_source_tag 时 regen_source_tag 必为合法非 PASS tag；_of_none
+            # 模式可能为空（合法无 tag），留空交给下游 source_tag='CHAT' 兜底。
             source_tag = regen_source_tag
             # regen 后只要最终不是 MUSIC，就清掉本轮 music 候选。
             # 之前的版本只在 _initial_source_tag == "MUSIC" 时清，但 tagless

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6367,6 +6367,15 @@ async def proactive_chat(request: Request):
             elif cleaned.strip():
                 await _emit_safe(cleaned)
         
+        # 没有解析到合法来源标签（[CHAT]/[WEB]/[MUSIC]/[MEME]）→ 输出不符合格式。
+        # 弱模型（free-model）常把人设里的 Format / 约束块当正文吐出来——线上见过
+        # "No Markdown: Yes."、"* No stage directions/parentheses"、"完全不同的角度或主题"
+        # 这类脚手架泄漏。合法搭话必然以 tag 起头，缺 tag 即判格式泄漏，drop 整轮，
+        # 不要把脚手架念给博士听。（TTS 在本函数后段才真正投递，此处 abort 安全。）
+        if not aborted and full_text.strip() and not source_tag:
+            print(f"[{lanlan_name}] Phase 2 输出无合法来源标签，判为格式泄漏，drop")
+            aborted = True
+
         # --- 结果处理 ---
         # buffer 是流前 ~80 字符的原始累积（含 [TAG]\n 前缀和正文头部），
         # full_text 是去标签后真正投递给 TTS / send_lanlan_response 的内容。
@@ -6515,7 +6524,8 @@ async def proactive_chat(request: Request):
             # 让下面的 "MUSIC→非MUSIC clear" 不触发、music 候选继续注入 → 复读
             # 又出去（CodeRabbit Major）。规则：
             #   regen 解析出 tag → 用该 tag
-            #   regen 非空但没 tag → 当成 CHAT（model 偏离格式但产出有效正文）
+            #   regen 非空但没 tag → drop（与初稿同款格式泄漏防护：弱模型常把人设
+            #     Format/约束块当正文吐出来，缺 tag 一律判泄漏，不再当成 CHAT 投递）
             #   regen 空 / [PASS] → 上面 drop 分支拦掉
             _cleaned = (regen_text or "").strip()
             regen_source_tag = ""
@@ -6532,8 +6542,8 @@ async def proactive_chat(request: Request):
             # 显式把 ``regen_source_tag == 'PASS'`` 也算 drop——前面剥过 [TAG]
             # 前缀，剩下的 _cleaned 已经不含 "[PASS]" 字面量，但 regen_source_tag
             # 已经记下这是 PASS，与"内嵌 [PASS]"等价拦掉（CodeRabbit Minor）。
-            if regen_source_tag == "PASS" or not _cleaned.strip() or "[PASS]" in _cleaned.upper():
-                logger.info("[%s] proactive BM25 regen returned empty/PASS, drop", lanlan_name)
+            if regen_source_tag in ("", "PASS") or not _cleaned.strip() or "[PASS]" in _cleaned.upper():
+                logger.info("[%s] proactive BM25 regen returned empty/PASS/untagged, drop", lanlan_name)
                 if not mgr.state.is_proactive_preempted(proactive_sid):
                     await mgr.handle_new_message()
                 return await _end_proactive(JSONResponse({
@@ -6581,10 +6591,8 @@ async def proactive_chat(request: Request):
                     "similarity": _regen_sim,
                     "threshold": _PROACTIVE_SIMILARITY_THRESHOLD,
                 }))
-            # regen 非空 + 没 tag → 视为 CHAT。沿用初稿 tag 会让初稿 [MUSIC]
-            # 但 regen 偏离格式产出纯文本时仍走音乐通道——既不是 user-visible
-            # bug，但与 regen 的语义"换话题"相违（CodeRabbit Major）。
-            source_tag = regen_source_tag or "CHAT"
+            # 走到这里 regen_source_tag 必为合法非 PASS tag（无 tag 已在上面 drop）。
+            source_tag = regen_source_tag
             # regen 后只要最终不是 MUSIC，就清掉本轮 music 候选。
             # 之前的版本只在 _initial_source_tag == "MUSIC" 时清，但 tagless
             # 初稿（_initial 为空）+ phase1 只有 music topic 的场景下，

--- a/main_routers/system_router.py
+++ b/main_routers/system_router.py
@@ -6307,6 +6307,9 @@ async def proactive_chat(request: Request):
                             if m:
                                 cleaned = cleaned[m.end():]
                             # 解析 [PASS] / [CHAT] / [WEB] / [MUSIC] / [MEME]
+                            # 先 lstrip：模型偶尔先吐换行/空格再吐 [CHAT]，不去前导空白
+                            # 会让 ^\[ 匹配失败、source_tag 误留空被当成无 tag（Codex P2）。
+                            cleaned = cleaned.lstrip()
                             tag_match = re.match(r'^\[(CHAT|WEB|PASS|MUSIC|MEME)\]\s*', cleaned, re.IGNORECASE)
                             if tag_match:
                                 source_tag = tag_match.group(1).upper()
@@ -6362,6 +6365,7 @@ async def proactive_chat(request: Request):
             m = re.search(r'主动搭话\s*\n', cleaned)
             if m:
                 cleaned = cleaned[m.end():]
+            cleaned = cleaned.lstrip()  # 同上：去前导空白再匹配 tag（Codex P2）
             tag_match = re.match(r'^\[(CHAT|WEB|PASS|MUSIC|MEME)\]\s*', cleaned, re.IGNORECASE)
             if tag_match:
                 source_tag = tag_match.group(1).upper()


### PR DESCRIPTION
## 背景
紧接 #1510（已合并）。线上又复现一例搭话吐出 prompt 脚手架的奇怪回复：

```
No Markdown: Yes.
*   No stage directions/parentheses
```

## 根因
和 #1510 修的 regen 泄漏是**同一类、但不同路径**：这次是 **Phase 2 初稿生成**直接把人设里的 `Format:` 约束块当正文吐了出来（`free-model` 弱模型）。日志里 `Phase 2 STREAM output (aborted=False, tag=)` —— **tag 解析为空**。问题在于 tag 解析未命中时 `source_tag` 留空，但下游照样把正文 emit 出去投递（text_len=57）。

## 改动（`main_routers/system_router.py`）
- **初稿**：结果处理前加一道闸——非 abort、有正文、但 `source_tag` 为空（未解析到 `[CHAT]/[WEB]/[MUSIC]/[MEME]`）即判格式泄漏，drop 整轮。合法搭话必以 tag 起头，缺 tag 一律不投递。`_emit_safe` 在流式阶段只累计 `full_text`、不喂 TTS（真正投递在本函数后段），所以此处 abort 安全、不会有半句已念出去。
- **regen**：同款防护——regen 产出无 tag 不再默认当 `CHAT` 投递，并入 empty/PASS 的 drop 分支（`regen_source_tag in ("", "PASS")`）。

这道结构化闸（要求合法 tag）比按脚手架字面匹配更稳，能覆盖 "No Markdown..."、"完全不同的角度或主题" 等各种泄漏变体。

## 测试
- `test_proactive_phase1_pass` / `test_passthrough_to_chat_bubble` / `test_music_played_through_reset` / `test_anti_repeat`：75 passed —— 合法 tag 的正常投递路径不受影响，只有无 tag 的会被拦。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加多语言“格式纠正”再生成指令与触发流程，异常时尝试重写并恢复合法来源标签；视觉场景支持附带截图的重建。

* **Bug 修复**
  * 加固流式与再生的来源标签解析（去除前导空白、统一无效标签直接中止）；BM25 再生成规则严格化，再生成功后采纳再生标签；非视觉分支优先使用对话类模型以提升一致性并减少误判。

* **文案调整**
  * 为“内心活动/Inner Thoughts”标题增加额外换行；“输出格式”表述改为“最终输出格式（严格遵守）”。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->