### PR TITLE
feat(proactive): 海外专属 A/B 测主动搭话间隔默认 20s

### DIFF
--- a/static/app-settings.js
+++ b/static/app-settings.js
@@ -22,6 +22,16 @@
     // 关；隐私模式默认值不动（仍按地区分流）。屏幕分享来源只在隐私关（vision 开）时才
     // 有意义，海外默认隐私开 → 对该实验天然 no-op，A/B 差异主要体现在国内。
     const _VISION_CHAT_AB_BRANCH = 'vision_chat_default_off';
+    // 海外专属 A/B 实验组分支名（与 utils/token_tracker.py 的 _TELEMETRY_BRANCHES 对齐）。
+    // 把主动搭话间隔（proactiveChatInterval）首启默认从控制组的 15s 拉长到 20s，看更慢的
+    // 搭话节奏对海外用户的影响；不动隐私 / 屏幕分享来源默认值，也没有弹窗。方向与
+    // vision_chat_default_off 相反——只在海外（_isUserRegionChina() 为 false）才覆写，
+    // 国内落到本组天然 no-op。两组抽签互斥（同设备只落一个 branch），但目标地区不重叠
+    // （vision 差异在国内、本组只影响海外），可同时在线。
+    const _PROACTIVE_INTERVAL_AB_BRANCH = 'proactive_interval_20s';
+    // 实验组的主动搭话间隔默认值（秒）。控制组默认见 app-state.js 的
+    // DEFAULT_PROACTIVE_CHAT_INTERVAL（15s）。
+    const _PROACTIVE_INTERVAL_AB_VALUE = 20;
     // 「首启等 branch 决议」专属 marker：只有 localStorage 走过本 PR 的首启分支才会写
     // 「1」，branch 决议后清掉。用 marker 在不在判断「应不应该套 A/B 覆写」，避免拿
     // 「没见过 branch 」当首启代名——升级用户也都没见过 branch，那个口径会误伤他们的
@@ -513,6 +523,7 @@
         // 捕获 fetch 发起时的屏幕分享来源值：若用户在 fetch 返回前手动切了 toggle，
         // 后续 A/B 覆写就跳过，避免把用户的显式选择刷掉
         const _visionChatAtFetchStart = S.proactiveVisionChatEnabled;
+        const _proactiveIntervalAtFetchStart = S.proactiveChatInterval;
         const _firstLaunchPending = (() => {
             try { return localStorage.getItem(_FIRST_LAUNCH_PENDING_KEY) === '1'; } catch (_) { return false; }
         })();
@@ -547,6 +558,31 @@
                         S.proactiveVisionChatEnabled = false;
                         hasUpdate = true;
                         console.log('[app-settings] A/B 实验组', telemetryBranch, '：屏幕分享来源默认关闭');
+                    }
+                }
+                // A/B test 覆写（海外专属）：与上方 vision 实验对称，但目标地区相反——只在
+                // 海外（!_isUserRegionChina()）真·首启时，把主动搭话间隔默认值从控制组的
+                // DEFAULT_PROACTIVE_CHAT_INTERVAL（15s）拉长到 _PROACTIVE_INTERVAL_AB_VALUE
+                // （20s）。守卫与 vision 同款：服务器无云端间隔偏好 + 用户没在 fetch 间隙手
+                // 动改 + 本地值仍等于控制组默认（即也没在之前 offline session 里改过）。国内
+                // 落到本组天然 no-op；与 vision_chat_default_off（差异在国内）目标地区不重
+                // 叠，可同时在线。本组只改默认值、无弹窗。
+                const noServerIntervalPref = !serverSettings ||
+                    serverSettings.proactiveChatInterval === undefined;
+                const userChangedIntervalDuringFetch =
+                    S.proactiveChatInterval !== _proactiveIntervalAtFetchStart;
+                const localIntervalMatchesControlDefault =
+                    S.proactiveChatInterval === C.DEFAULT_PROACTIVE_CHAT_INTERVAL;
+                if (_firstLaunchPending
+                        && telemetryBranch === _PROACTIVE_INTERVAL_AB_BRANCH
+                        && !_isUserRegionChina()
+                        && noServerIntervalPref
+                        && !userChangedIntervalDuringFetch
+                        && localIntervalMatchesControlDefault) {
+                    if (S.proactiveChatInterval !== _PROACTIVE_INTERVAL_AB_VALUE) {
+                        S.proactiveChatInterval = _PROACTIVE_INTERVAL_AB_VALUE;
+                        hasUpdate = true;
+                        console.log('[app-settings] A/B 实验组', telemetryBranch, '：主动搭话间隔默认', _PROACTIVE_INTERVAL_AB_VALUE, '秒（海外）');
                     }
                 }
                 // 只要 server 给了 branch，本次决议就算完成（不管控制组还是实验组、

--- a/utils/token_tracker.py
+++ b/utils/token_tracker.py
@@ -394,13 +394,21 @@ _TELEMETRY_BRANCH_FILE = ".telemetry_branch"
 #       地区分流（仅中国地区默认隐私关），海外默认隐私开 → 对本实验天然 no-op。抽签
 #       全地区随机，海外也会落实验组但首启覆写 / 弹窗都不生效；分析时按 locale 过滤，
 #       A/B 差异主要体现在国内。
+#   - "proactive_interval_20s"：海外专属实验组，把「主动搭话间隔」
+#     （proactiveChatInterval）首启默认从控制组 15s 拉长到 20s，看更慢的搭话节奏对
+#     海外用户的影响。**不动**隐私模式 / 屏幕分享来源默认值，也没有弹窗。
+#       地区交互：与 vision_chat_default_off 方向相反——只在海外（前端
+#       _isUserRegionChina() 为 false）才覆写间隔默认值；国内落到本组天然 no-op。抽签
+#       全地区随机、三组互斥（同设备只落一个 branch），但 vision 实验差异在国内、本组
+#       只影响海外，目标地区不重叠，可同时在线观测。注意 _bucket_proactive_interval
+#       把 15s / 20s 都归进「10-30s」桶，所以 cohort 命中靠 branch 维度区分，不靠间隔桶。
 #
 # 已退役实验（老落盘值被 _read 严格校验判非法 → 下次启动按当前池随机重抽，落 main 或
 # vision_chat_default_off。都是已过首启的用户，重抽只改 telemetry 标签、不动已落盘的
 # 用户偏好，对「默认值」实验无影响，故不为其单独做确定性迁移）：
 #   - "privacy_default_off_v1"（试国外隐私默认关）：前期数据效果差，已下线。
 #   - "privacy_default_off_v2"（试国内隐私默认开）：改方向去测屏幕分享来源，已下线。
-_TELEMETRY_BRANCHES: tuple = ("main", "vision_chat_default_off")
+_TELEMETRY_BRANCHES: tuple = ("main", "vision_chat_default_off", "proactive_interval_20s")
 
 # 进程级缓存：keyed by str(config_dir)。写盘失败的环境下（只读 FS / 权限拒绝），
 # 不缓存就每次 secrets.choice 重抽，导致同一 install 的 TokenTracker 上报和


### PR DESCRIPTION
## Summary
- 新增 telemetry 分支 `proactive_interval_20s`（`_TELEMETRY_BRANCHES`），**海外专属**实验组：真·首启时把主动搭话间隔默认值从控制组 15s 拉长到 20s
- 覆写仅在 `!_isUserRegionChina()` 时生效，国内落到本组天然 no-op（仍 15s）；守卫与 `vision_chat_default_off` 同款（真·首启 marker + 服务器无云端偏好 + 用户没在 fetch 间隙改 + 本地仍等于控制组默认）
- 与 `vision_chat_default_off`（#1513，差异主要在国内）抽签互斥但**目标地区不重叠**，可同时在线观测
- 本组只改默认值、**无弹窗**，不动隐私 / 屏幕分享来源默认值

## 结果
| 分组 | 海外用户 | 国内用户 |
|------|---------|---------|
| `main` | 15s | 15s |
| `proactive_interval_20s` | **20s** | 15s (no-op) |

## 注意
- **方向更正**：当前 main 默认值是 15s（git 历史 30→15，从无 20s）。经确认，main 保持 15s、海外实验组测更长的 20s。
- **telemetry bucket**：`_bucket_proactive_interval` 把 15s / 20s 都归进 `10-30s` 同一桶，cohort 命中验证靠 `branch` 维度，不靠间隔桶；未改 bucket 边界以保现有实验数据连续性。

## Test plan
- [ ] 海外首启 + 抽到 `proactive_interval_20s` → 间隔默认 20s，调度器按 20s 重排
- [ ] 国内首启 + 抽到 `proactive_interval_20s` → 间隔仍 15s（no-op）
- [ ] 升级用户（无 first-launch marker）不被覆写
- [ ] 服务器已有 `proactiveChatInterval` 偏好 / 用户 fetch 间隙手改 → 跳过覆写
- [ ] 同时跑 `vision_chat_default_off` 国内组互不干扰

🤖 Generated with [Claude Code](https://claude.com/claude-code)