### PR TITLE
fix(docker): uv run 加 --no-sync 杜绝跨平台 wheel 误下载 + 镜像 fallback

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,10 @@ ARG HTTPS_PROXY
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
-ENV UV_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
+# Per-request HTTP timeout for uv downloads (default 30s). Bumped because the
+# build runs on US Azure runners while the package mirror is in China, so large
+# wheels are slow to transfer; 30s caused spurious "operation timed out" failures.
+ENV UV_HTTP_TIMEOUT=120
 
 # Set working directory
 WORKDIR /app
@@ -101,11 +104,20 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /usr/local/bin/uv
 RUN chmod +x /usr/local/bin/uv && \
     echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bashrc
 
-# 5. Configure uv to use Aliyun mirror
+# 5. Configure uv mirrors + fallback.
+# Two China mirrors are tried in order (aliyun -> tsinghua); neither is marked
+# default, so the implicit default (pypi.org) stays as the final fallback -- which
+# is actually fastest on the US runner. If any mirror is missing a package or
+# stalls, uv walks down the list instead of single-pointing at aliyun.
 RUN mkdir -p /root/.config/uv && \
-    echo '[[index]]' > /root/.config/uv/uv.toml && \
-    echo 'url = "https://mirrors.aliyun.com/pypi/simple/"' >> /root/.config/uv/uv.toml && \
-    echo 'default = true' >> /root/.config/uv/uv.toml
+    printf '%s\n' \
+      '[[index]]' \
+      'name = "aliyun"' \
+      'url = "https://mirrors.aliyun.com/pypi/simple/"' \
+      '[[index]]' \
+      'name = "tsinghua"' \
+      'url = "https://pypi.tuna.tsinghua.edu.cn/simple/"' \
+      > /root/.config/uv/uv.toml
 
 # 6. Copy N.E.K.O. project from local build context (with correct ownership)
 COPY --chown=neko:neko . /app
@@ -142,7 +154,7 @@ ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
 RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    uv run python scripts/prepare_embedding_model.py \
+    uv run --no-sync python scripts/prepare_embedding_model.py \
         --repo "$EMBEDDING_MODEL_REPO" \
         --revision "$EMBEDDING_MODEL_REVISION" \
         --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -43,7 +43,10 @@ ARG HTTPS_PROXY
 # 设置环境变量
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
-ENV UV_INDEX_URL=https://mirrors.aliyun.com/pypi/simple/
+# Per-request HTTP timeout for uv downloads (default 30s). Bumped because the
+# build runs on US Azure runners while the package mirror is in China, so large
+# wheels are slow to transfer; 30s caused spurious "operation timed out" failures.
+ENV UV_HTTP_TIMEOUT=120
 
 # 设置工作目录
 WORKDIR /app
@@ -173,11 +176,19 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.17 /uv /usr/local/bin/uv
 RUN chmod +x /usr/local/bin/uv && \
     echo 'export PATH="/usr/local/bin:$PATH"' >> /root/.bashrc
 
-# 5. 配置 uv 使用阿里云镜像
+# 5. 配置 uv 镜像 + fallback。
+# 两个国内镜像按顺序优先（aliyun → tsinghua），均未标 default，所以官方
+# pypi.org 作为隐式 default 留作最后兜底——US runner 上反而最快。任一镜像缺包/
+# 抽风时 uv 会顺着列表往下走，不再单点依赖 aliyun。
 RUN mkdir -p /root/.config/uv && \
-    echo '[[index]]' > /root/.config/uv/uv.toml && \
-    echo 'url = "https://mirrors.aliyun.com/pypi/simple/"' >> /root/.config/uv/uv.toml && \
-    echo 'default = true' >> /root/.config/uv/uv.toml
+    printf '%s\n' \
+      '[[index]]' \
+      'name = "aliyun"' \
+      'url = "https://mirrors.aliyun.com/pypi/simple/"' \
+      '[[index]]' \
+      'name = "tsinghua"' \
+      'url = "https://pypi.tuna.tsinghua.edu.cn/simple/"' \
+      > /root/.config/uv/uv.toml
 
 # 6. Copy N.E.K.O. project from local build context (with correct ownership)
 COPY --chown=neko:neko . /app
@@ -215,7 +226,7 @@ ARG EMBEDDING_MODEL_PROFILE_ID=local-text-retrieval-v1
 RUN cd /app && \
     if [ -n "$HTTP_PROXY" ]; then export http_proxy=$HTTP_PROXY; fi; \
     if [ -n "$HTTPS_PROXY" ]; then export https_proxy=$HTTPS_PROXY; fi; \
-    uv run python scripts/prepare_embedding_model.py \
+    uv run --no-sync python scripts/prepare_embedding_model.py \
         --repo "$EMBEDDING_MODEL_REPO" \
         --revision "$EMBEDDING_MODEL_REVISION" \
         --profile-id "$EMBEDDING_MODEL_PROFILE_ID" \
@@ -231,7 +242,7 @@ RUN chown -R neko:neko /app
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
 # 10. Install Playwright Chromium browser during build (FULL version includes this)
-RUN uv run python -m playwright install chromium --with-deps && \
+RUN uv run --no-sync python -m playwright install chromium --with-deps && \
     chown -R neko:neko /opt/ms-playwright && \
     chmod -R 755 /opt/ms-playwright
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -886,7 +886,7 @@ setup_dependencies() {
     else
         echo "📦 Playwright Chromium not found, installing..."
         # 尝试安装 Chromium，失败时不中断启动
-        if uv run python -m playwright install chromium --with-deps 2>&1; then
+        if uv run --no-sync python -m playwright install chromium --with-deps 2>&1; then
             echo "✅ Playwright Chromium installed successfully"
         else
             echo "⚠️ Playwright Chromium installation failed (will retry on next start)"


### PR DESCRIPTION
## 背景
`build-full (linux/arm64)` 在 embedding-model 步骤失败（[run 26383698314](https://github.com/Project-N-E-K-O/N.E.K.O/actions/runs/26383698314/job/77657804061)），报错是从 aliyun 镜像拉 `fonttools-4.61.0-...-macosx_10_9_universal2.whl` 超时。

## Root cause
`scripts/prepare_embedding_model.py` 是纯 stdlib（只 urllib 下 HF 权重，零 PyPI 依赖），但 Dockerfile 用 `uv run python ...` **没带 `--frozen`/`--no-sync`**。于是 `uv run` 先校验 universal lockfile → 拉取**全平台** wheel 元数据，含 macOS 的 fonttools universal2 wheel。该 wheel 在 aliyun 上无 PEP 658 sidecar，被**整包下载**仅为读 METADATA。aliyun（中国）在 **US Azure runner** 上慢且抖，3 次重试后超时，build 挂掉。

`uv sync --frozen`（前一步）在 arm64 上只装 manylinux aarch64 wheel，所以那步没事——问题完全出在后续未冻结的 `uv run` 触发的再解析。

## 改动（`docker/Dockerfile` + `docker/Dockerfile.full`）
- **`--no-sync`（根因修复）**：所有 post-sync 的 `uv run` 统一加 `--no-sync`，直接复用已 frozen 的 venv，零再解析零网络。覆盖 model-prep、playwright 构建期安装，以及运行时 `docker/entrypoint.sh` 的 playwright 安装。
- **镜像 fallback**：单一 aliyun 索引 → 有序 `aliyun → tsinghua`，均不标 `default`，pypi.org 作隐式最终兜底（US runner 上反而最快）。任一镜像缺包/抽风 uv 顺列表往下走。移除冗余 `UV_INDEX_URL`。
- **更高容忍度**：`ENV UV_HTTP_TIMEOUT=120`（默认 30s），让正常 `uv sync` 扛得住跨洲慢传输。（uv 0.6.17 无 `UV_HTTP_RETRIES`，故只调 timeout。）

刻意**没有**把 `tool.uv.environments` 收窄到 linux：deps 带 darwin/win32 marker，universal lock 必须保持多平台（本地 Windows/macOS 开发要用）。

## Test plan
- [ ] 重跑 `build-full (linux/arm64)` 与 `build (linux/arm64)`，确认不再下载 macOS wheel、embedding-model 步骤通过
- [ ] 确认 `uv sync --frozen` 仍正常（索引改动后无 hash mismatch）
- [ ] 标准镜像首启时 entrypoint 的 playwright 安装正常（`--no-sync` 不破坏运行时安装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 改进Docker构建流程的稳定性：增加依赖下载超时时间至120秒
  * 优化Python包源配置：支持多个镜像源自动回退，提高包下载可靠性
  * 优化构建步骤执行效率，避免不必要的依赖同步操作

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-N-E-K-O/N.E.K.O/pull/1516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->